### PR TITLE
fix(trusty-memory): per-palace write mutex + create_dir_all guard on L1 snapshot (#154)

### DIFF
--- a/crates/trusty-common/src/memory_core/retrieval.rs
+++ b/crates/trusty-common/src/memory_core/retrieval.rs
@@ -152,6 +152,27 @@ pub struct PalaceHandle {
     /// `dream_cycle` and cleared on drop.
     /// Test: `dream::tests::dream_cycle_toggles_is_compacting`.
     pub is_compacting: Arc<AtomicBool>,
+    /// Serialises mutating ops (`remember_with_options`, `forget`) on this
+    /// palace so concurrent writers don't race on the L1 snapshot rename,
+    /// the vector store upsert, the KG SQLite row insert, or the in-memory
+    /// drawer table.
+    ///
+    /// Why: Issue #154 — under 20 concurrent HTTP `memory_remember` calls,
+    /// 30–60 % failed with "save L1 snapshot: io error … No such file or
+    /// directory". The root cause was multiple writers racing on the same
+    /// `l1_cache.json.tmp` file (fixed defensively in `L1Cache`), but the
+    /// broader hazard is that the `remember_with_options` pipeline
+    /// (embed → vector upsert → KG upsert → in-memory push → L1 snapshot)
+    /// has no per-palace ordering guarantee. A per-palace mutex serialises
+    /// those steps so the L1 snapshot always reflects a consistent
+    /// drawer-table state, without blocking reads or cross-palace writes.
+    /// What: `Arc<tokio::sync::Mutex<()>>`. Held only by the mutating
+    /// methods; readers (`recall`, `recall_deep`, `list_drawers`) never
+    /// touch it. Per-palace, not global, so distinct palaces still write
+    /// in parallel. Held across `.await` points, so we use the tokio mutex
+    /// rather than `parking_lot::Mutex` (which would deadlock the runtime).
+    /// Test: `remember_concurrent_does_not_lose_writes` in this module.
+    pub write_mutex: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// Options for `PalaceHandle::remember_with_options` (issue #61).
@@ -268,6 +289,7 @@ impl PalaceHandle {
             recall_log: None,
             closets: Arc::new(RwLock::new(HashMap::new())),
             is_compacting: Arc::new(AtomicBool::new(false)),
+            write_mutex: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -392,6 +414,7 @@ impl PalaceHandle {
             recall_log,
             closets: Arc::new(RwLock::new(HashMap::new())),
             is_compacting: Arc::new(AtomicBool::new(false)),
+            write_mutex: Arc::new(tokio::sync::Mutex::new(())),
         };
         Ok(Arc::new(handle))
     }
@@ -522,6 +545,14 @@ impl PalaceHandle {
             ));
         }
 
+        // Issue #154: serialise mutating ops on this palace so concurrent
+        // writers don't race on the L1 snapshot rename, vector upsert, KG
+        // row insert, or in-memory drawer push. Held across the full
+        // pipeline below. Other palaces' writes proceed in parallel.
+        // Reads (`recall`, `list_drawers`, etc.) never acquire this lock,
+        // so the write mutex doesn't impact read throughput.
+        let _write_guard = self.write_mutex.lock().await;
+
         // Issue #61: signal/noise gate. `force == true` bypasses entirely.
         // `enforce_min_tokens` lets `memory_note` keep the noise patterns
         // while permitting short curated facts ("User prefers snake_case").
@@ -638,6 +669,14 @@ impl PalaceHandle {
                 self.id
             ));
         }
+
+        // Issue #154: serialise with concurrent `remember_with_options`
+        // calls so the L1 snapshot rewritten below sees a consistent
+        // drawer-table state and so the vector / KG / in-memory removals
+        // can't interleave with an append. See `write_mutex` docs on
+        // `PalaceHandle`.
+        let _write_guard = self.write_mutex.lock().await;
+
         // Best-effort vector removal — usearch may legitimately not have the
         // key (e.g. if remember failed mid-flight); we propagate other errors.
         if let Err(e) = self.vector_store.remove(id).await {
@@ -1445,6 +1484,85 @@ mod tests {
         assert!(
             !results.iter().any(|r| r.drawer.id == id),
             "forgotten drawer should not appear in recall results"
+        );
+    }
+
+    /// Regression test for issue #154: concurrent `remember_with_options`
+    /// calls on the same palace must not race on the L1 snapshot write.
+    ///
+    /// Why: Pre-fix, 20 concurrent writers against the same palace produced
+    /// 30–60% "No such file or directory" failures because multiple writers
+    /// would write the same `l1_cache.json.tmp` file and the first
+    /// `rename(tmp -> target)` removed the tmp before the second rename
+    /// could see it. The per-palace write mutex + per-call tmp naming
+    /// together eliminate the race.
+    /// What: Spawns 32 concurrent `remember` tasks on the same handle,
+    /// waits for all of them, and asserts every single one returned `Ok`.
+    /// After the burst the drawer table contains all 32 entries.
+    /// Test: this test.
+    #[tokio::test]
+    async fn remember_concurrent_does_not_lose_writes() {
+        use crate::memory_core::palace::Palace;
+        let dir = tempdir().unwrap();
+        let palace = Palace {
+            id: PalaceId::new("concurrent-test"),
+            name: "Concurrent".into(),
+            description: None,
+            created_at: chrono::Utc::now(),
+            data_dir: dir.path().join("concurrent-test"),
+        };
+        std::fs::create_dir_all(&palace.data_dir).unwrap();
+        let handle = PalaceHandle::open(&palace).unwrap();
+
+        // Spawn 32 concurrent writers. Each writes a distinct payload that
+        // is long enough to pass the default token filter (>=8 tokens).
+        let mut tasks = Vec::with_capacity(32);
+        for i in 0..32u32 {
+            let h = handle.clone();
+            tasks.push(tokio::spawn(async move {
+                h.remember(
+                    format!(
+                        "concurrent write test payload number {i} with enough \
+                         tokens to satisfy the default token filter check"
+                    ),
+                    RoomType::General,
+                    vec!["concurrent".into(), format!("idx-{i}")],
+                    0.5,
+                )
+                .await
+            }));
+        }
+
+        let mut ok = 0usize;
+        let mut errs = Vec::new();
+        for t in tasks {
+            match t.await.expect("task panicked") {
+                Ok(_id) => ok += 1,
+                Err(e) => errs.push(format!("{e:#}")),
+            }
+        }
+        assert_eq!(
+            ok, 32,
+            "expected all 32 concurrent remembers to succeed; failures: {errs:?}"
+        );
+
+        // Every write should be present in the in-memory drawer table.
+        let drawer_count = handle.drawers.read().len();
+        assert_eq!(
+            drawer_count, 32,
+            "expected 32 drawers after concurrent burst, got {drawer_count}"
+        );
+
+        // No leaked tmp files from racing renames.
+        let leaked: Vec<_> = std::fs::read_dir(&palace.data_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("l1_cache.json") && n.contains(".tmp."))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "expected no .tmp.* orphans after concurrent saves; found {leaked:?}"
         );
     }
 

--- a/crates/trusty-common/src/memory_core/store/l1_cache.rs
+++ b/crates/trusty-common/src/memory_core/store/l1_cache.rs
@@ -10,11 +10,26 @@
 
 use crate::memory_core::palace::Drawer;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 use thiserror::Error;
 
 /// Filename for the L1 cache snapshot.
 const L1_CACHE_JSON: &str = "l1_cache.json";
+
+/// Monotonic counter that, combined with the process PID, gives every
+/// concurrent `save_l1_cache` invocation its own tmp filename.
+///
+/// Why: Issue #154 — when two writers in the same process raced on
+/// `l1_cache.json.tmp`, the first `rename(tmp -> target)` succeeded and
+/// removed the tmp, then the second `rename` failed with `ENOENT` because
+/// "its" tmp file no longer existed. The reported error was
+/// `"No such file or directory at .../l1_cache.json"` even though it was
+/// really the tmp source that vanished. Per-invocation tmp names eliminate
+/// the trample entirely — each writer renames its own file.
+/// What: `AtomicU64` bumped once per `save_l1_cache` call.
+/// Test: covered by `concurrent_save_l1_cache_no_enoent` in this module.
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Maximum number of drawers stored in the L1 snapshot (mirrors `retrieval::L1_CAP`).
 pub const L1_SNAPSHOT_CAP: usize = 15;
@@ -66,15 +81,33 @@ impl L1Cache {
     /// Persist the top-by-importance drawers to `<data_dir>/l1_cache.json`.
     ///
     /// Why: Atomic JSON snapshot lets the next palace open hydrate L1 in O(1)
-    /// disk reads instead of re-sorting the full drawer table.
+    /// disk reads instead of re-sorting the full drawer table. Concurrency
+    /// hazards (issue #154): two concurrent writers must not stomp on each
+    /// other's tmp file, and the parent directory must exist at rename time
+    /// even if a prior op transiently removed it (e.g. the dream subprocess).
     /// What: Sorts a clone of `drawers` by importance descending, takes the
-    /// first `L1_SNAPSHOT_CAP`, and writes JSON via tmp+rename.
+    /// first `L1_SNAPSHOT_CAP`, writes JSON to a per-call unique tmp path
+    /// (PID + monotonic counter so concurrent writers don't share the tmp),
+    /// re-asserts `create_dir_all` immediately before the rename so the
+    /// destination directory cannot have vanished between this call's first
+    /// `create_dir_all` and its rename, and renames atomically. On rename
+    /// failure the stray tmp is best-effort removed so disk doesn't fill
+    /// with `.tmp.<pid>.<seq>` orphans.
     /// Test: `l1_cache_roundtrip` saves 20 drawers and verifies only the top
-    /// 15 (by importance) come back.
+    /// 15 (by importance) come back. `concurrent_save_l1_cache_no_enoent`
+    /// stresses 16 parallel writers and asserts none hit ENOENT (covers the
+    /// trample race fixed by per-call tmp naming).
     pub fn save_l1_cache(drawers: &[Drawer], data_dir: &Path) -> Result<()> {
         std::fs::create_dir_all(data_dir).map_err(|e| L1CacheError::io(data_dir, e))?;
         let target = data_dir.join(L1_CACHE_JSON);
-        let tmp = data_dir.join(format!("{L1_CACHE_JSON}.tmp"));
+        // Per-invocation tmp filename: PID + monotonic counter. Two
+        // concurrent writers in the same process get distinct tmp paths, so
+        // writer A's `rename(tmp_A -> target)` cannot remove writer B's
+        // `tmp_B`. Different processes get different PIDs, so cross-process
+        // concurrent writes (rare but possible) are also safe.
+        let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let tmp = data_dir.join(format!("{L1_CACHE_JSON}.tmp.{pid}.{seq}"));
 
         let mut sorted: Vec<Drawer> = drawers.to_vec();
         sorted.sort_by(|a, b| {
@@ -87,7 +120,22 @@ impl L1Cache {
         let bytes = serde_json::to_vec_pretty(&sorted)
             .map_err(|e| L1CacheError::json(target.clone(), e))?;
         std::fs::write(&tmp, &bytes).map_err(|e| L1CacheError::io(tmp.clone(), e))?;
-        std::fs::rename(&tmp, &target).map_err(|e| L1CacheError::io(target.clone(), e))?;
+        // Defensive: re-assert the parent dir exists right before rename.
+        // `create_dir_all` is a cheap idempotent syscall when the dir
+        // already exists, and it eliminates a TOCTOU window in case some
+        // other process or test cleanup removed the directory between the
+        // first `create_dir_all` above and this rename.
+        if let Err(e) = std::fs::create_dir_all(data_dir) {
+            // Best-effort tmp cleanup before bubbling the error.
+            let _ = std::fs::remove_file(&tmp);
+            return Err(L1CacheError::io(data_dir, e));
+        }
+        if let Err(e) = std::fs::rename(&tmp, &target) {
+            // Best-effort tmp cleanup so a failed rename doesn't leak
+            // `.tmp.<pid>.<seq>` files into the palace directory.
+            let _ = std::fs::remove_file(&tmp);
+            return Err(L1CacheError::io(target, e));
+        }
         Ok(())
     }
 
@@ -203,5 +251,57 @@ mod tests {
         let tmp = tempdir().unwrap();
         // No snapshot ever written -> always stale.
         assert!(L1Cache::is_stale(tmp.path(), 999_999).unwrap());
+    }
+
+    /// Regression test for issue #154: concurrent `save_l1_cache` calls
+    /// against the same `data_dir` must not race on a shared tmp filename.
+    ///
+    /// Why: Before the per-call tmp naming fix, two writers would both write
+    /// `l1_cache.json.tmp`, then both `rename(tmp -> target)`; the first
+    /// rename consumed the tmp, the second failed with
+    /// "No such file or directory" at the destination path. Reproducing this
+    /// deterministically is hard, but a 16-thread parallel writer pool
+    /// reliably hit it before the fix.
+    /// What: Spawns 16 OS threads that each call `save_l1_cache` 10 times
+    /// against the same directory and asserts every call returns `Ok`. After
+    /// the burst the directory contains exactly one `l1_cache.json` (the
+    /// last winner) and no `.tmp.*` orphans.
+    /// Test: this test.
+    #[test]
+    fn concurrent_save_l1_cache_no_enoent() {
+        let tmp = tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+
+        let mut handles = Vec::with_capacity(16);
+        for thread_id in 0..16u32 {
+            let dir = data_dir.clone();
+            handles.push(std::thread::spawn(move || {
+                for i in 0..10u32 {
+                    let drawers = vec![drawer_with_importance(
+                        &format!("t{thread_id}-i{i}"),
+                        (thread_id as f32) * 0.01 + (i as f32) * 0.001,
+                    )];
+                    L1Cache::save_l1_cache(&drawers, &dir).unwrap_or_else(|e| {
+                        panic!("save_l1_cache (t={thread_id}, i={i}) failed: {e}")
+                    });
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker thread panicked");
+        }
+
+        // Final state assertions: a real snapshot exists and no .tmp files leak.
+        assert!(data_dir.join(L1_CACHE_JSON).exists());
+        let leaked_tmps: Vec<_> = std::fs::read_dir(&data_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with(L1_CACHE_JSON) && n.contains(".tmp."))
+            .collect();
+        assert!(
+            leaked_tmps.is_empty(),
+            "leaked tmp files after concurrent saves: {leaked_tmps:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the concurrent `memory_remember` write failure rate of 30–60% under concurrent load (surfaced by `tests/concurrent_perf.rs`). Two-part fix in `trusty-common`.

## Root cause

The L1 snapshot writer used a single shared tmp filename (`l1_cache.json.tmp`). Two concurrent writers in the same process both wrote to that path — the first rename consumed it, the second rename failed with `ENOENT`, which appeared as "No such file or directory" on `l1_cache.json`. Additionally, the full write pipeline (embed → vector upsert → KG insert → drawer push → L1 snapshot) had no per-palace ordering guarantee.

## Fix

**Part 1 — `l1_cache.rs`: unique tmp filenames + defensive `create_dir_all`**
- Per-call tmp name: `l1_cache.json.tmp.<pid>.<seq>` (monotonic `AtomicU64`) — two writers can never share a tmp file
- `create_dir_all(data_dir)` immediately before every rename (TOCTOU defence)
- Best-effort cleanup of orphaned `.tmp.*` files on rename failure

**Part 2 — `retrieval.rs`: per-palace `tokio::sync::Mutex` on `PalaceHandle`**
- `write_mutex: Arc<tokio::sync::Mutex<()>>` on `PalaceHandle`, acquired at the top of `remember_with_options` and `forget`
- Held across the full write pipeline — serialises concurrent appends to the same palace
- Readers (`recall`, `recall_deep`, `list_drawers`) do **not** acquire the mutex — read throughput is untouched
- Per-palace (not global) — distinct palaces still write in parallel

## Why both parts

- Part 2 eliminates the race in-process; Part 1 hardens the L1 writer against any future out-of-band concurrent writer (dream subprocess, two daemon instances during restart overlap)
- Together: mutex for ordering correctness; unique tmp + `create_dir_all` for filesystem safety

## Tests added

- `concurrent_save_l1_cache_no_enoent` — 16 OS threads × 10 saves to the same dir; asserts 0 failures and 0 leaked `.tmp.*` files (would have failed pre-fix)
- `remember_concurrent_does_not_lose_writes` — 32 concurrent `tokio::spawn` calls on one palace; asserts all 32 succeed and drawer count == 32

## Test plan

- [x] `cargo test -p trusty-common --features memory-core` — 244 pass, 0 fail
- [x] `cargo test -p trusty-memory` — 242 pass, 0 fail
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `check --workspace` — clean

**Expected improvement:** `test_http_concurrent_rw` write success rate ~42% → ≥95% (assertions in `tests/concurrent_perf.rs` can now be tightened).

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)