### PR TITLE
fix(trusty-search): per-const Rust chunking + SCREAMING_SNAKE classifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11134,7 +11134,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,7 +7,7 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
-## [Unreleased]
+## [0.11.1] — 2026-05-26
 
 ### Added
 

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,7 +9,28 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ## [Unreleased]
 
-_(no unreleased changes)_
+### Added
+
+- **#143** `ChunkType::Constant` chunks per `pub const` / `pub static` Rust declaration.
+  The Rust tree-sitter chunker now emits one `Constant` chunk per top-level public
+  constant/static, with `function_name = Some(<identifier>)` (e.g. `BRUSILOV_EPOCH`).
+  Previously a file containing only `pub const` declarations produced a single whole-file
+  `Code` chunk with null `function_name`, making every constant invisible to symbol-name
+  queries and the Definition-intent boost. Phase 1 covers Rust only; Python /
+  TypeScript / Go / Java follow-up noted via TODO comment in the chunker.
+- **#142** SCREAMING_SNAKE_CASE pattern in `QueryClassifier` — queries that are a
+  single ALL_CAPS_WITH_UNDERSCORES identifier (e.g. `MAX_BATCH_SIZE`, `BRUSILOV_EPOCH`,
+  `KIKUCHI_MAX_DEPTH`) now classify as `Intent::Definition` instead of `Unknown`.
+  This was a gap in the priority chain: `SNAKE_IDENT_RE` matched lowercase snake_case
+  but not SCREAMING_SNAKE; `ACRONYM_HINT_RE` fired on ALL_CAPS tokens *inside*
+  multi-word queries but not on a whole-query constant name.
+
+### Fixed
+
+- **#142 + #143** Together these two fixes unblock the Definition-intent boost (#122)
+  for constant lookups: the classifier correctly recognises SCREAMING_SNAKE queries,
+  and the corpus now has per-constant chunks with non-null `function_name` for the
+  structural lane to surface.
 
 ---
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/core/chunker/classify.rs
+++ b/crates/trusty-search/src/core/chunker/classify.rs
@@ -52,6 +52,18 @@ pub(super) fn classify_node(lang: &str, node: Node<'_>) -> Option<ChunkType> {
         ("rust", "trait_item") => ChunkType::Trait,
         ("rust", "enum_item") => ChunkType::Enum,
         ("rust", "mod_item") => ChunkType::Module,
+        // `pub const NAME: TYPE = VALUE;` and `pub static NAME: TYPE = VALUE;`
+        // (Phase 1: Rust only — see TODO below for other languages).
+        // Only public declarations get their own Constant chunk; private consts
+        // stay in the surrounding scope chunk so the chunk count doesn't
+        // explode for internal implementation details.
+        //
+        // TODO: extend per-const chunking to Python (UPPERCASE module-level
+        // assignments), TypeScript (`export const X = …`), Go (`const` /
+        // `const ( … )` blocks), and Java (`public static final` fields) in
+        // follow-up tickets once the Rust phase is validated.
+        ("rust", "const_item") if rust_item_is_pub(node) => ChunkType::Constant,
+        ("rust", "static_item") if rust_item_is_pub(node) => ChunkType::Constant,
 
         ("python", "function_definition") => {
             if ancestor_kind(node, "class_definition").is_some() {
@@ -237,6 +249,26 @@ pub(super) fn scala_enclosing_class_name(node: Node<'_>, src: &[u8]) -> Option<S
             .unwrap_or("")
             .to_string(),
     )
+}
+
+/// Return `true` when a Rust `const_item` or `static_item` node has a
+/// `visibility_modifier` child (i.e. is `pub`, `pub(crate)`, etc.).
+///
+/// Why: Phase 1 per-const chunking is scoped to public declarations only.
+/// Private constants stay in whatever surrounding scope chunk would otherwise
+/// claim them, avoiding an explosion of trivial implementation-detail chunks.
+/// What: walks the direct children of `node` looking for a
+/// `visibility_modifier` node; returns `true` on first hit, `false` otherwise.
+/// Test: `test_rust_pub_const_chunking` verifies that `pub const` items get
+/// Constant chunks and private `const` items do not.
+pub(super) fn rust_item_is_pub(node: Node<'_>) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "visibility_modifier" {
+            return true;
+        }
+    }
+    false
 }
 
 /// For PHP methods (issue #49): walk up to the enclosing

--- a/crates/trusty-search/src/core/chunker/mod.rs
+++ b/crates/trusty-search/src/core/chunker/mod.rs
@@ -1641,6 +1641,199 @@ class Foo {
         );
     }
 
+    // ----- Per-pub-const Rust chunking (issue #143) -------------------------
+
+    /// Why: a file containing only `pub const` declarations used to produce a
+    /// single whole-file `Code` chunk with null `function_name`, making every
+    /// constant invisible to symbol-name queries and the Definition-intent boost.
+    /// What: each `pub const` / `pub static` in a `.rs` file must produce its own
+    /// `Constant` chunk with a non-null `function_name`.
+    /// Test: this is the test.
+    #[test]
+    fn test_rust_pub_const_chunking_produces_n_constant_chunks() {
+        let src = r#"
+pub const ALPHA: u32 = 1;
+pub const BRUSILOV_EPOCH: u64 = 1_000_000;
+pub const MAX_BATCH_SIZE: usize = 256;
+pub const KIKUCHI_MAX_DEPTH: usize = 8;
+pub const HNSW_EF_CONSTRUCTION: usize = 200;
+pub const DEFAULT_TOP_K: usize = 10;
+pub const BM25_K1: f32 = 1.5;
+pub const BM25_B: f32 = 0.75;
+"#;
+        let (chunks, _) = chunk_ast("constants.rs", src);
+        let const_chunks: Vec<&RawChunk> = chunks
+            .iter()
+            .filter(|c| c.chunk_type == ChunkType::Constant)
+            .collect();
+        assert_eq!(
+            const_chunks.len(),
+            8,
+            "expected 8 Constant chunks (one per pub const), got {}: {:#?}",
+            const_chunks.len(),
+            chunks
+        );
+        // Every constant chunk must have a non-null function_name.
+        for c in &const_chunks {
+            assert!(
+                c.function_name.is_some(),
+                "expected non-null function_name for constant chunk {c:#?}"
+            );
+        }
+        // Spot-check a few names.
+        let names: Vec<_> = const_chunks
+            .iter()
+            .filter_map(|c| c.function_name.as_deref())
+            .collect();
+        assert!(
+            names.contains(&"BRUSILOV_EPOCH"),
+            "expected BRUSILOV_EPOCH in names: {names:?}"
+        );
+        assert!(
+            names.contains(&"MAX_BATCH_SIZE"),
+            "expected MAX_BATCH_SIZE in names: {names:?}"
+        );
+    }
+
+    /// Why: validates that a mixed Rust file — constants + functions — emits
+    /// the correct chunk type for each item and does not absorb function chunks
+    /// into constant chunks or vice-versa.
+    /// What: a file with one `pub const`, one `pub fn`, and one more `pub const`
+    /// must produce 3 chunks in the expected types.
+    /// Test: this is the test.
+    #[test]
+    fn test_rust_mixed_const_and_fn_chunking() {
+        let src = r#"
+pub const FOO: u32 = 42;
+
+pub fn do_something() -> u32 {
+    FOO + 1
+}
+
+pub const BAR: &str = "hello";
+"#;
+        let (chunks, _) = chunk_ast("mixed.rs", src);
+
+        let const_chunks: Vec<&RawChunk> = chunks
+            .iter()
+            .filter(|c| c.chunk_type == ChunkType::Constant)
+            .collect();
+        assert_eq!(
+            const_chunks.len(),
+            2,
+            "expected 2 Constant chunks, got {const_chunks:#?}"
+        );
+        let const_names: Vec<_> = const_chunks
+            .iter()
+            .filter_map(|c| c.function_name.as_deref())
+            .collect();
+        assert!(
+            const_names.contains(&"FOO"),
+            "expected FOO: {const_names:?}"
+        );
+        assert!(
+            const_names.contains(&"BAR"),
+            "expected BAR: {const_names:?}"
+        );
+
+        let fn_chunks: Vec<&RawChunk> = chunks
+            .iter()
+            .filter(|c| c.chunk_type == ChunkType::Function)
+            .collect();
+        assert_eq!(
+            fn_chunks.len(),
+            1,
+            "expected 1 Function chunk, got {fn_chunks:#?}"
+        );
+        assert_eq!(
+            fn_chunks[0].function_name.as_deref(),
+            Some("do_something"),
+            "fn chunk name mismatch"
+        );
+    }
+
+    /// Why: `pub static` is semantically equivalent to `pub const` for the
+    /// purpose of symbol lookup; both must emit Constant chunks.
+    /// What: `pub static X: &str = "…"` produces a Constant chunk with the
+    /// identifier as `function_name`.
+    /// Test: this is the test.
+    #[test]
+    fn test_rust_pub_static_treated_as_constant() {
+        let src = r#"
+pub static GREETING: &str = "hello";
+pub static MAX_RETRIES: u32 = 3;
+"#;
+        let (chunks, _) = chunk_ast("statics.rs", src);
+        let const_chunks: Vec<&RawChunk> = chunks
+            .iter()
+            .filter(|c| c.chunk_type == ChunkType::Constant)
+            .collect();
+        assert_eq!(
+            const_chunks.len(),
+            2,
+            "expected 2 Constant chunks for pub static, got {const_chunks:#?}"
+        );
+        let names: Vec<_> = const_chunks
+            .iter()
+            .filter_map(|c| c.function_name.as_deref())
+            .collect();
+        assert!(names.contains(&"GREETING"), "expected GREETING: {names:?}");
+        assert!(
+            names.contains(&"MAX_RETRIES"),
+            "expected MAX_RETRIES: {names:?}"
+        );
+    }
+
+    /// Why: Phase 1 scopes per-const chunking to public declarations only;
+    /// private constants stay in whatever surrounding chunk applies.
+    /// What: a file with private `const` (no `pub`) must NOT produce any
+    /// `Constant` chunks — the private const stays unclaimed / falls through
+    /// to the whole-file fallback.
+    /// Test: this is the test.
+    #[test]
+    fn test_rust_private_const_does_not_get_constant_chunk() {
+        let src = r#"
+const INTERNAL_LIMIT: usize = 100;
+const PRIVATE_KEY: &str = "secret";
+"#;
+        let (chunks, _) = chunk_ast("private.rs", src);
+        let const_chunks: Vec<&RawChunk> = chunks
+            .iter()
+            .filter(|c| c.chunk_type == ChunkType::Constant)
+            .collect();
+        assert!(
+            const_chunks.is_empty(),
+            "expected no Constant chunks for private consts, got {const_chunks:#?}"
+        );
+    }
+
+    /// Why: regression guard — existing function/struct/impl/trait/enum
+    /// chunking must not be disturbed by the new const/static rules.
+    /// What: a Rust file without any `pub const` / `pub static` still produces
+    /// correct Function, Struct, Impl chunks as before.
+    /// Test: this is the test.
+    #[test]
+    fn test_rust_no_const_regression_on_function_chunks() {
+        // Uses the same content as test_rust_function_chunking to ensure parity.
+        let src = r#"
+fn alpha() {}
+
+fn beta() -> i32 { 1 }
+
+fn gamma(x: i32) -> i32 { x + 1 }
+"#;
+        let (chunks, _) = chunk_ast("no_const.rs", src);
+        let fns: Vec<&RawChunk> = chunks
+            .iter()
+            .filter(|c| c.chunk_type == ChunkType::Function)
+            .collect();
+        assert_eq!(fns.len(), 3, "expected 3 Function chunks, got {fns:#?}");
+        assert!(
+            chunks.iter().all(|c| c.chunk_type != ChunkType::Constant),
+            "unexpected Constant chunk in function-only file: {chunks:#?}"
+        );
+    }
+
     /// Issue #90: end-to-end check that a small Rust snippet — parsed by
     /// `chunk_ast`, fed into `SymbolGraph::build_from_chunks` — produces
     /// non-zero symbols and a usable caller→callee edge. This is the

--- a/crates/trusty-search/src/core/classifier.rs
+++ b/crates/trusty-search/src/core/classifier.rs
@@ -59,6 +59,20 @@ static ACRONYM_HINT_RE: OnceLock<Regex> = OnceLock::new();
 // existing 6-word `LONG_NL_RE` so 3-5 word concept queries also classify
 // as Conceptual instead of Unknown.
 static MULTI_NOUN_RE: OnceLock<Regex> = OnceLock::new();
+// SCREAMING_SNAKE_CASE single-identifier pattern (issue #142): the WHOLE
+// query is an ALL_CAPS identifier with underscores, e.g. `BRUSILOV_EPOCH`,
+// `MAX_BATCH_SIZE`, `HNSW_EF_CONSTRUCTION`. These are Rust / Java / Python
+// constants — first-class symbol names that belong in the Definition lane.
+//
+// Distinct from `ACRONYM_HINT_RE` which fires when an ALL_CAPS token appears
+// *inside* a multi-word query. `SCREAM_IDENT_RE` requires the entire trimmed
+// query to be a single constant identifier (no whitespace allowed).
+//
+// Pattern: starts with an uppercase letter, followed by uppercase letters,
+// digits, or underscores, contains at least one underscore (to distinguish
+// from pure acronyms like `HNSW` that are already handled by
+// `ACRONYM_HINT_RE`), and is at least 2 characters total.
+static SCREAM_IDENT_RE: OnceLock<Regex> = OnceLock::new();
 
 impl QueryClassifier {
     /// Classify a query string into a `QueryIntent` for routing weight selection.
@@ -221,6 +235,26 @@ impl QueryClassifier {
             Regex::new(r"^[a-z][a-z0-9_]*_[a-z0-9_]+$").expect("static regex pattern must compile")
         });
         if snake_ident_re.is_match(trimmed) {
+            return QueryIntent::Definition;
+        }
+
+        // SCREAMING_SNAKE_CASE single identifier (issue #142): the entire
+        // query is an ALL_CAPS constant name like `BRUSILOV_EPOCH` or
+        // `MAX_BATCH_SIZE`. These are first-class symbol names in Rust, Java,
+        // and Python; routing to Definition engages the BM25-heavy lane so
+        // the file containing the constant declaration outranks usage sites.
+        //
+        // Checked after `snake_ident_re` (disjoint patterns — no overlap)
+        // and before `acronym_hint_re` (which handles ALL_CAPS tokens *inside*
+        // multi-word queries rather than whole-query identifiers).
+        let scream_ident_re = SCREAM_IDENT_RE.get_or_init(|| {
+            // Whole query: one or more uppercase letters/digits, must contain
+            // at least one underscore, no lowercase letters, no whitespace.
+            // Minimum two chars. Does NOT match single lowercase segments.
+            Regex::new(r"^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$")
+                .expect("static regex pattern must compile")
+        });
+        if scream_ident_re.is_match(trimmed) {
             return QueryIntent::Definition;
         }
 
@@ -822,6 +856,82 @@ mod tests {
         assert_eq!(
             QueryClassifier::classify("Louvain community detection modularity"),
             QueryIntent::Conceptual
+        );
+    }
+
+    // ── SCREAMING_SNAKE_CASE identifier tests (issue #142) ─────────────────
+
+    #[test]
+    fn test_screaming_snake_brusilov_epoch_is_definition() {
+        // Reproduces the exact failing query from the #142 bug report.
+        assert_eq!(
+            QueryClassifier::classify("BRUSILOV_EPOCH"),
+            QueryIntent::Definition
+        );
+    }
+
+    #[test]
+    fn test_screaming_snake_max_batch_size_is_definition() {
+        assert_eq!(
+            QueryClassifier::classify("MAX_BATCH_SIZE"),
+            QueryIntent::Definition
+        );
+    }
+
+    #[test]
+    fn test_screaming_snake_foo_bar_baz_is_definition() {
+        assert_eq!(
+            QueryClassifier::classify("FOO_BAR_BAZ"),
+            QueryIntent::Definition
+        );
+    }
+
+    #[test]
+    fn test_screaming_snake_is_default_doc_excluded_is_definition() {
+        // Acceptance criterion from #142: all-caps version of a known identifier.
+        assert_eq!(
+            QueryClassifier::classify("IS_DEFAULT_DOC_EXCLUDED"),
+            QueryIntent::Definition
+        );
+    }
+
+    #[test]
+    fn test_screaming_snake_does_not_change_multiword_query() {
+        // "HNSW vector similarity" contains an ALL_CAPS token but is NOT a
+        // whole-query SCREAMING_SNAKE identifier (it has whitespace + mixed
+        // case). The existing ACRONYM_HINT path handles it — verify no
+        // regression.
+        assert_eq!(
+            QueryClassifier::classify("HNSW vector similarity"),
+            QueryIntent::Definition
+        );
+    }
+
+    #[test]
+    fn test_regular_snake_case_unaffected_by_scream_rule() {
+        // `authenticate_user` must still be Definition via the snake_ident path.
+        assert_eq!(
+            QueryClassifier::classify("authenticate_user"),
+            QueryIntent::Definition
+        );
+    }
+
+    #[test]
+    fn test_fn_authenticate_unaffected_by_scream_rule() {
+        // `fn authenticate` should remain Definition via `def_re`.
+        assert_eq!(
+            QueryClassifier::classify("fn authenticate"),
+            QueryIntent::Definition
+        );
+    }
+
+    #[test]
+    fn test_lowercase_mixed_words_unaffected_by_scream_rule() {
+        // A plain multi-word lowercase query must not be affected.
+        // It would stay Unknown (3 words, no identifiers).
+        assert_eq!(
+            QueryClassifier::classify("reservation booking flow"),
+            QueryIntent::Unknown
         );
     }
 


### PR DESCRIPTION
## Summary

Two paired fixes that together unblock the #122 Definition-intent boost for constant lookups:

- **#142 (classifier)**: Adds `SCREAMING_SNAKE_CASE` pattern to `QueryClassifier`. Queries like `BRUSILOV_EPOCH`, `MAX_BATCH_SIZE`, `FOO_BAR_BAZ` now classify as `Intent::Definition` instead of `Unknown`. Regex `^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$` requires at least one underscore (so it doesn't overlap with the existing `ACRONYM_HINT_RE` path that handles `HNSW`, `BM25`, etc.).
- **#143 (chunker)**: Rust tree-sitter chunker now emits one chunk per `pub const` / `pub static` declaration instead of a single whole-file chunk. Each chunk carries `chunk_type=Constant`, non-null `function_name=<identifier>`, and the full declaration text. Phase 1 is Rust-only; Python/TypeScript/Go/Java follow in separate tickets.

Together: queries like `MAX_BATCH_SIZE` now (a) classify correctly as Definition and (b) hit a properly-named constant chunk, so the #122 Definition boost fires on the right chunks and pulls the constant definition to rank ≤ 2.

## Notable findings

- **`ChunkType::Constant` already existed** in the enum but the Rust grammar path never emitted it. No new enum variant — zero semver impact on the type system.
- **Visibility check is direct-child only**: tree-sitter-rust attaches `visibility_modifier` as a direct child of `const_item`/`static_item`. Handles `pub`, `pub(crate)`, `pub(super)` uniformly. Private constants stay folded into surrounding chunks (intentional — Phase 1 ships pub-only).

## Test plan

- [x] `cargo test -p trusty-search` — 548 tests pass (+13 new), 0 fail
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] 13 new unit tests covering: SCREAMING_SNAKE classification (5 positive, 3 no-regression), per-pub-const Rust chunking (4), private-const exclusion (1)
- [ ] Post-merge: reindex a representative repo, run query `MAX_BATCH_SIZE` against `trusty-tools` and confirm a Rust `pub const MAX_BATCH_SIZE` chunk lands at rank ≤ 2 (the #122 acceptance gate)
- [ ] Post-merge: regression snapshot to confirm no Hit@1 drop on the v0.10.0 benchmark suite

## Versioning

This branch deliberately does NOT bump the version. After PR #160 (v0.11.0 BREAKING) merges, this branch will be rebased and bumped to **v0.11.1** (two patch-level bug fixes).

Closes #142. Closes #143. Unblocks #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)