### PR TITLE
refactor(trusty-memory): extract MemoryService + chat from web.rs (closes #151)

### DIFF
--- a/crates/trusty-memory/src/chat.rs
+++ b/crates/trusty-memory/src/chat.rs
@@ -1,0 +1,1234 @@
+//! Chat HTTP surface for trusty-memory: OpenRouter/Ollama SSE chat, tool
+//! dispatch, chat-session CRUD, and inter-project messaging endpoints.
+//!
+//! Why: Extracted from `web.rs` to keep the HTTP router thin and isolate the
+//! tool-calling loop (which is by far the largest single concern in this
+//! crate's HTTP surface) behind its own module. The router still owns wiring,
+//! but the chat-specific request/response handlers, the tool dispatcher, and
+//! the inter-project messaging handlers all live here.
+//! What: Re-exports `chat_handler`, provider/session handlers, the
+//! `execute_*` dispatcher set, and the `/api/v1/messages*` handlers. Items
+//! kept `pub(crate)` so `web::router()` and the cross-palace recall handler
+//! can reference them without enlarging the public crate surface.
+//! Test: Behaviour is covered by `web::tests::all_tools_returns_expected_set`
+//! and `web::tests::execute_tool_dispatches_known_tools`, which still call
+//! into this module via the `pub(crate)` re-exports.
+
+use crate::web::{
+    creator_info_from_http, load_user_config, open_handle, palace_info_from, ApiError,
+    DreamStatusPayload,
+};
+use crate::{ActivitySource, AppState, DaemonEvent};
+use axum::{
+    body::Body,
+    extract::{Path as AxumPath, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use trusty_common::memory_core::dream::PersistedDreamStats;
+use trusty_common::memory_core::palace::{PalaceId, RoomType};
+use trusty_common::memory_core::retrieval::{
+    recall_across_palaces_with_default_embedder, recall_with_default_embedder,
+};
+use trusty_common::memory_core::store::kg::Triple;
+use trusty_common::memory_core::PalaceRegistry;
+use trusty_common::{ChatEvent, ChatMessage, ToolDef};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Chat (OpenRouter, SSE-streaming)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub(crate) struct ChatBody {
+    #[serde(default)]
+    palace_id: Option<String>,
+    message: String,
+    #[serde(default)]
+    history: Vec<ChatMessage>,
+    /// Optional existing chat-session id; when provided we load+append+save.
+    #[serde(default)]
+    session_id: Option<String>,
+}
+
+/// Hard cap on the number of `tool -> assistant` round trips per chat turn.
+///
+/// Why: Without a bound, a malicious or confused model could request tools
+/// indefinitely; 10 is generous enough for any realistic plan-and-act loop
+/// while still terminating quickly when the model gets stuck.
+const MAX_TOOL_ROUNDS: usize = 10;
+
+/// Build the complete set of tool definitions the chat assistant can call.
+///
+/// Why: Centralizing the tool surface keeps the wire schema, the dispatcher in
+/// `execute_tool`, and the system prompt in lock-step — adding a new tool means
+/// editing this one function plus a match arm.
+/// What: Returns the 11 read/write tools spanning palace introspection,
+/// memory recall/create, KG read/write, and daemon status.
+/// Test: `all_tools_returns_expected_set` asserts names and required-arg shape.
+pub(crate) fn all_tools() -> Vec<ToolDef> {
+    vec![
+        ToolDef {
+            name: "list_palaces".into(),
+            description: "List all memory palaces on this machine with their metadata (id, name, description, counts).".into(),
+            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
+        },
+        ToolDef {
+            name: "get_palace".into(),
+            description: "Get details for a specific palace by id.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": { "palace_id": { "type": "string", "description": "Palace id (kebab-case)" } },
+                "required": ["palace_id"],
+            }),
+        },
+        ToolDef {
+            name: "recall_memories".into(),
+            description: "Semantic search for memories in a palace. Returns the top-k most relevant drawers ranked by similarity to the query.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "palace_id": { "type": "string" },
+                    "query": { "type": "string", "description": "Free-text query" },
+                    "top_k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 5 }
+                },
+                "required": ["palace_id", "query"],
+            }),
+        },
+        ToolDef {
+            name: "list_drawers".into(),
+            description: "List all drawers (memories) in a palace, most recent first.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": { "palace_id": { "type": "string" } },
+                "required": ["palace_id"],
+            }),
+        },
+        ToolDef {
+            name: "kg_query".into(),
+            description: "Query the temporal knowledge graph for all currently-active triples whose subject matches.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "palace_id": { "type": "string" },
+                    "subject": { "type": "string" }
+                },
+                "required": ["palace_id", "subject"],
+            }),
+        },
+        ToolDef {
+            name: "get_config".into(),
+            description: "Get the trusty-memory daemon's configuration (provider, model, data root). API keys are masked.".into(),
+            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
+        },
+        ToolDef {
+            name: "get_status".into(),
+            description: "Get daemon health: version, palace count, totals for drawers/vectors/triples.".into(),
+            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
+        },
+        ToolDef {
+            name: "get_dream_status".into(),
+            description: "Get aggregated dreamer activity across all palaces (merged/pruned/compacted counts, last run timestamp).".into(),
+            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
+        },
+        ToolDef {
+            name: "get_palace_dream_status".into(),
+            description: "Get dreamer activity stats for a specific palace.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": { "palace_id": { "type": "string" } },
+                "required": ["palace_id"],
+            }),
+        },
+        ToolDef {
+            name: "create_memory".into(),
+            description: "Store a new memory (drawer) in a palace. The content is embedded and inserted into the vector index plus the drawer table.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "palace_id": { "type": "string" },
+                    "content": { "type": "string", "description": "Verbatim memory text" },
+                    "room": { "type": "string", "description": "Room name (Frontend/Backend/Testing/Planning/Documentation/Research/Configuration/Meetings/General or a custom name); defaults to General." },
+                    "tags": { "type": "array", "items": { "type": "string" } },
+                    "importance": { "type": "number", "minimum": 0.0, "maximum": 1.0, "default": 0.5 }
+                },
+                "required": ["palace_id", "content"],
+            }),
+        },
+        ToolDef {
+            name: "kg_assert".into(),
+            description: "Assert a knowledge-graph triple. Any prior active triple with the same (subject, predicate) is closed out (valid_to set to now) before the new one is inserted.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "palace_id": { "type": "string" },
+                    "subject": { "type": "string" },
+                    "predicate": { "type": "string" },
+                    "object": { "type": "string" },
+                    "confidence": { "type": "number", "minimum": 0.0, "maximum": 1.0, "default": 1.0 }
+                },
+                "required": ["palace_id", "subject", "predicate", "object"],
+            }),
+        },
+        ToolDef {
+            name: "memory_recall_all".into(),
+            description: "Semantic search across ALL palaces simultaneously. Returns the top-k most relevant drawers ranked by similarity, regardless of which palace they belong to. Each result includes a `palace_id` field identifying its source.".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "q": { "type": "string", "description": "Free-text query" },
+                    "top_k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 },
+                    "deep": { "type": "boolean", "default": false }
+                },
+                "required": ["q"],
+            }),
+        },
+    ]
+}
+
+/// Execute a tool call against the live `AppState`.
+///
+/// Why: We want the model's tool invocations to call the same Rust paths the
+/// HTTP handlers use — no extra HTTP round-trip, no JSON re-parsing, and the
+/// results always reflect this daemon's view of the world.
+/// What: Parses `arguments` as JSON, dispatches by tool name, returns a JSON
+/// value that becomes the `role: "tool"` message content. Errors are caught
+/// and returned as `{"error": "..."}` JSON so the model can react.
+/// Test: `execute_tool_dispatches_known_tools` covers the dispatch path and
+/// the unknown-tool error case.
+pub(crate) async fn execute_tool(name: &str, args: &str, state: &AppState) -> Value {
+    let parsed: Value = serde_json::from_str(args).unwrap_or(json!({}));
+    match name {
+        "list_palaces" => execute_list_palaces(state).await,
+        "get_palace" => match parsed.get("palace_id").and_then(|v| v.as_str()) {
+            Some(id) => execute_get_palace(state, id).await,
+            None => json!({ "error": "missing required argument: palace_id" }),
+        },
+        "recall_memories" => {
+            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
+            let q = parsed.get("query").and_then(|v| v.as_str());
+            let top_k = parsed.get("top_k").and_then(|v| v.as_u64()).unwrap_or(5) as usize;
+            match (pid, q) {
+                (Some(p), Some(q)) => execute_recall(state, p, q, top_k).await,
+                _ => json!({ "error": "missing required argument(s): palace_id, query" }),
+            }
+        }
+        "list_drawers" => match parsed.get("palace_id").and_then(|v| v.as_str()) {
+            Some(id) => execute_list_drawers(state, id).await,
+            None => json!({ "error": "missing required argument: palace_id" }),
+        },
+        "kg_query" => {
+            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
+            let subj = parsed.get("subject").and_then(|v| v.as_str());
+            match (pid, subj) {
+                (Some(p), Some(s)) => execute_kg_query(state, p, s).await,
+                _ => json!({ "error": "missing required argument(s): palace_id, subject" }),
+            }
+        }
+        "get_config" => execute_get_config(state),
+        "get_status" => execute_get_status(state).await,
+        "get_dream_status" => execute_get_dream_status(state).await,
+        "get_palace_dream_status" => match parsed.get("palace_id").and_then(|v| v.as_str()) {
+            Some(id) => execute_get_palace_dream_status(state, id).await,
+            None => json!({ "error": "missing required argument: palace_id" }),
+        },
+        "create_memory" => {
+            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
+            let content = parsed.get("content").and_then(|v| v.as_str());
+            let room = parsed.get("room").and_then(|v| v.as_str());
+            let tags: Vec<String> = parsed
+                .get("tags")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|t| t.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let importance = parsed
+                .get("importance")
+                .and_then(|v| v.as_f64())
+                .map(|f| f as f32)
+                .unwrap_or(0.5);
+            match (pid, content) {
+                (Some(p), Some(c)) => {
+                    execute_create_memory(state, p, c, room, tags, importance).await
+                }
+                _ => json!({ "error": "missing required argument(s): palace_id, content" }),
+            }
+        }
+        "kg_assert" => {
+            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
+            let subj = parsed.get("subject").and_then(|v| v.as_str());
+            let pred = parsed.get("predicate").and_then(|v| v.as_str());
+            let obj = parsed.get("object").and_then(|v| v.as_str());
+            let conf = parsed
+                .get("confidence")
+                .and_then(|v| v.as_f64())
+                .map(|f| f as f32)
+                .unwrap_or(1.0);
+            match (pid, subj, pred, obj) {
+                (Some(p), Some(s), Some(pr), Some(o)) => {
+                    execute_kg_assert(state, p, s, pr, o, conf).await
+                }
+                _ => json!({
+                    "error": "missing required argument(s): palace_id, subject, predicate, object"
+                }),
+            }
+        }
+        "memory_recall_all" => {
+            let q = parsed.get("q").and_then(|v| v.as_str());
+            let top_k = parsed.get("top_k").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
+            let deep = parsed
+                .get("deep")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            match q {
+                Some(q) => execute_recall_all(state, q, top_k, deep).await,
+                None => json!({ "error": "missing required argument: q" }),
+            }
+        }
+        _ => json!({ "error": format!("unknown tool: {name}") }),
+    }
+}
+
+async fn execute_list_palaces(state: &AppState) -> Value {
+    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
+        Ok(v) => v,
+        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
+    };
+    let out: Vec<Value> = palaces
+        .into_iter()
+        .map(|p| {
+            let handle = state.registry.open_palace(&state.data_root, &p.id).ok();
+            let info = palace_info_from(&p, handle.as_ref());
+            serde_json::to_value(info).unwrap_or(json!({}))
+        })
+        .collect();
+    json!(out)
+}
+
+async fn execute_get_palace(state: &AppState, id: &str) -> Value {
+    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
+        Ok(v) => v,
+        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
+    };
+    match palaces.into_iter().find(|p| p.id.0 == id) {
+        Some(p) => {
+            let handle = state.registry.open_palace(&state.data_root, &p.id).ok();
+            serde_json::to_value(palace_info_from(&p, handle.as_ref())).unwrap_or(json!({}))
+        }
+        None => json!({ "error": format!("palace not found: {id}") }),
+    }
+}
+
+async fn execute_recall(state: &AppState, palace_id: &str, query: &str, top_k: usize) -> Value {
+    let handle = match state
+        .registry
+        .open_palace(&state.data_root, &PalaceId::new(palace_id))
+    {
+        Ok(h) => h,
+        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
+    };
+    match recall_with_default_embedder(&handle, query, top_k).await {
+        Ok(hits) => json!(hits
+            .into_iter()
+            .map(|r| json!({
+                "drawer_id": r.drawer.id.to_string(),
+                "content": r.drawer.content,
+                "importance": r.drawer.importance,
+                "tags": r.drawer.tags,
+                "score": r.score,
+                "layer": r.layer,
+            }))
+            .collect::<Vec<_>>()),
+        Err(e) => json!({ "error": format!("recall: {e:#}") }),
+    }
+}
+
+/// Execute a cross-palace recall and return JSON results tagged with palace id.
+///
+/// Why: Both the MCP `memory_recall_all` tool and the `GET /api/v1/recall`
+/// HTTP route share the same wiring — list palaces, open handles, fan out via
+/// `recall_across_palaces_with_default_embedder`, and serialize.
+/// What: Lists every palace on disk, opens each (skipping any that fail with
+/// a `tracing::warn!`), and delegates to the core fan-out. On success returns
+/// a JSON array; on listing failure returns `{ "error": "..." }`.
+/// Test: Indirectly via `recall_across_palaces_merges_results` (core merge
+/// logic) and the HTTP/MCP integration paths.
+pub(crate) async fn execute_recall_all(
+    state: &AppState,
+    query: &str,
+    top_k: usize,
+    deep: bool,
+) -> Value {
+    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
+        Ok(v) => v,
+        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
+    };
+    let mut handles = Vec::with_capacity(palaces.len());
+    for p in &palaces {
+        match state.registry.open_palace(&state.data_root, &p.id) {
+            Ok(h) => handles.push(h),
+            Err(e) => {
+                tracing::warn!(palace = %p.id, "execute_recall_all: open failed: {e:#}");
+            }
+        }
+    }
+    if handles.is_empty() {
+        return json!([]);
+    }
+    match recall_across_palaces_with_default_embedder(&handles, query, top_k, deep).await {
+        Ok(results) => json!(results
+            .into_iter()
+            .map(|r| json!({
+                "palace_id": r.palace_id,
+                "drawer_id": r.result.drawer.id.to_string(),
+                "content": r.result.drawer.content,
+                "importance": r.result.drawer.importance,
+                "tags": r.result.drawer.tags,
+                "score": r.result.score,
+                "layer": r.result.layer,
+            }))
+            .collect::<Vec<_>>()),
+        Err(e) => json!({ "error": format!("recall_across_palaces: {e:#}") }),
+    }
+}
+
+async fn execute_list_drawers(state: &AppState, palace_id: &str) -> Value {
+    let handle = match state
+        .registry
+        .open_palace(&state.data_root, &PalaceId::new(palace_id))
+    {
+        Ok(h) => h,
+        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
+    };
+    let drawers = handle.list_drawers(None, None, 200);
+    serde_json::to_value(drawers).unwrap_or(json!([]))
+}
+
+async fn execute_kg_query(state: &AppState, palace_id: &str, subject: &str) -> Value {
+    let handle = match state
+        .registry
+        .open_palace(&state.data_root, &PalaceId::new(palace_id))
+    {
+        Ok(h) => h,
+        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
+    };
+    match handle.kg.query_active(subject).await {
+        Ok(triples) => serde_json::to_value(triples).unwrap_or(json!([])),
+        Err(e) => json!({ "error": format!("kg query: {e:#}") }),
+    }
+}
+
+fn execute_get_config(state: &AppState) -> Value {
+    let cfg = load_user_config().unwrap_or_default();
+    json!({
+        "openrouter_configured": !cfg.openrouter_api_key.is_empty(),
+        "openrouter_model": cfg.openrouter_model,
+        "local_model": {
+            "enabled": cfg.local_model.enabled,
+            "base_url": cfg.local_model.base_url,
+            "model": cfg.local_model.model,
+        },
+        "data_root": state.data_root.display().to_string(),
+    })
+}
+
+async fn execute_get_status(state: &AppState) -> Value {
+    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
+    let (mut total_drawers, mut total_vectors, mut total_kg_triples) = (0usize, 0usize, 0usize);
+    for p in &palaces {
+        if let Ok(handle) = state.registry.open_palace(&state.data_root, &p.id) {
+            total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
+            total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
+            total_kg_triples = total_kg_triples.saturating_add(handle.kg.count_active_triples());
+        }
+    }
+    json!({
+        "version": state.version,
+        "palace_count": palaces.len(),
+        "default_palace": state.default_palace,
+        "data_root": state.data_root.display().to_string(),
+        "total_drawers": total_drawers,
+        "total_vectors": total_vectors,
+        "total_kg_triples": total_kg_triples,
+    })
+}
+
+async fn execute_get_dream_status(state: &AppState) -> Value {
+    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
+    let mut out = DreamStatusPayload::default();
+    let mut latest: Option<chrono::DateTime<chrono::Utc>> = None;
+    for p in palaces {
+        let data_dir = state.data_root.join(p.id.as_str());
+        let snap = match PersistedDreamStats::load(&data_dir) {
+            Ok(Some(s)) => s,
+            _ => continue,
+        };
+        out.merged = out.merged.saturating_add(snap.stats.merged);
+        out.pruned = out.pruned.saturating_add(snap.stats.pruned);
+        out.compacted = out.compacted.saturating_add(snap.stats.compacted);
+        out.closets_updated = out
+            .closets_updated
+            .saturating_add(snap.stats.closets_updated);
+        out.duration_ms = out.duration_ms.saturating_add(snap.stats.duration_ms);
+        latest = match latest {
+            Some(t) if t >= snap.last_run_at => Some(t),
+            _ => Some(snap.last_run_at),
+        };
+    }
+    out.last_run_at = latest;
+    serde_json::to_value(out).unwrap_or(json!({}))
+}
+
+async fn execute_get_palace_dream_status(state: &AppState, palace_id: &str) -> Value {
+    let data_dir = state.data_root.join(palace_id);
+    if !data_dir.exists() {
+        return json!({ "error": format!("palace not found: {palace_id}") });
+    }
+    match PersistedDreamStats::load(&data_dir) {
+        Ok(Some(s)) => serde_json::to_value(DreamStatusPayload::from(s)).unwrap_or(json!({})),
+        Ok(None) => serde_json::to_value(DreamStatusPayload::default()).unwrap_or(json!({})),
+        Err(e) => json!({ "error": format!("read dream stats: {e:#}") }),
+    }
+}
+
+async fn execute_create_memory(
+    state: &AppState,
+    palace_id: &str,
+    content: &str,
+    room: Option<&str>,
+    tags: Vec<String>,
+    importance: f32,
+) -> Value {
+    let handle = match state
+        .registry
+        .open_palace(&state.data_root, &PalaceId::new(palace_id))
+    {
+        Ok(h) => h,
+        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
+    };
+    let room = room.map(RoomType::parse).unwrap_or(RoomType::General);
+    match handle
+        .remember(content.to_string(), room, tags, importance)
+        .await
+    {
+        Ok(id) => json!({ "drawer_id": id.to_string(), "status": "stored" }),
+        Err(e) => json!({ "error": format!("remember: {e:#}") }),
+    }
+}
+
+async fn execute_kg_assert(
+    state: &AppState,
+    palace_id: &str,
+    subject: &str,
+    predicate: &str,
+    object: &str,
+    confidence: f32,
+) -> Value {
+    let handle = match state
+        .registry
+        .open_palace(&state.data_root, &PalaceId::new(palace_id))
+    {
+        Ok(h) => h,
+        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
+    };
+    let triple = Triple {
+        subject: subject.to_string(),
+        predicate: predicate.to_string(),
+        object: object.to_string(),
+        valid_from: chrono::Utc::now(),
+        valid_to: None,
+        confidence,
+        provenance: Some("chat:assistant".to_string()),
+    };
+    match handle.kg.assert(triple).await {
+        Ok(()) => json!({ "status": "asserted" }),
+        Err(e) => json!({ "error": format!("kg assert: {e:#}") }),
+    }
+}
+
+pub(crate) async fn chat_handler(
+    State(state): State<AppState>,
+    Json(body): Json<ChatBody>,
+) -> Response {
+    // Select the active provider (Ollama auto-detect, else OpenRouter).
+    let Some(provider) = state.chat_provider().await else {
+        return (
+            StatusCode::PRECONDITION_FAILED,
+            "No chat provider configured (no local Ollama detected and no OpenRouter key set)",
+        )
+            .into_response();
+    };
+
+    // Resolve palace id (explicit > default).
+    let palace_id = body
+        .palace_id
+        .clone()
+        .or_else(|| state.default_palace.clone())
+        .unwrap_or_default();
+
+    // Resolve / create chat session when a palace is bound.
+    let (session_id, mut history): (Option<String>, Vec<ChatMessage>) = if !palace_id.is_empty() {
+        let store = match state.session_store(&palace_id) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(palace = %palace_id, "session_store open failed: {e:#}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("session store: {e:#}"),
+                )
+                    .into_response();
+            }
+        };
+        match body.session_id.clone() {
+            Some(sid) => match store.get_session(&sid) {
+                Ok(Some(s)) => (
+                    Some(sid),
+                    s.history
+                        .into_iter()
+                        .map(|m| ChatMessage {
+                            role: m.role,
+                            content: m.content,
+                            tool_call_id: None,
+                            tool_calls: None,
+                        })
+                        .collect(),
+                ),
+                _ => (Some(sid), body.history.clone()),
+            },
+            None => {
+                let new_id = store.create_session(None).unwrap_or_else(|e| {
+                    tracing::warn!("create_session failed: {e:#}");
+                    String::new()
+                });
+                (
+                    if new_id.is_empty() {
+                        None
+                    } else {
+                        Some(new_id)
+                    },
+                    body.history.clone(),
+                )
+            }
+        }
+    } else {
+        (None, body.history.clone())
+    };
+
+    // Full palace roster for the identity block — names + ids, not just count,
+    // so the model can pick the right one when the user names a palace.
+    let all_palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
+    let palace_count = all_palaces.len();
+    let palace_roster: String = all_palaces
+        .iter()
+        .map(|p| format!("- {} (id: {})", p.name, p.id.0))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Config + global dream snapshot — give the model an honest view of what's
+    // available so it doesn't invent tools or providers that aren't there.
+    let cfg = load_user_config().unwrap_or_default();
+    let active_provider_name = state
+        .chat_provider()
+        .await
+        .map(|p| p.name().to_string())
+        .unwrap_or_else(|| "none".to_string());
+    let dream_snapshot = execute_get_dream_status(&state).await;
+
+    // Look up the selected palace's metadata (name/description) and open its
+    // handle for live counts + recall context.
+    let selected_palace_meta = if palace_id.is_empty() {
+        None
+    } else {
+        all_palaces.iter().find(|p| p.id.0 == palace_id).cloned()
+    };
+
+    let mut palace_block = String::new();
+    let mut context = String::new();
+    let mut palace_display_name = palace_id.clone();
+
+    if !palace_id.is_empty() {
+        if let Ok(handle) = state
+            .registry
+            .open_palace(&state.data_root, &PalaceId::new(&palace_id))
+        {
+            // Live counts from the opened handle.
+            let drawer_count = handle.drawers.read().len();
+            let vector_count = handle.vector_store.index_size();
+            let kg_triple_count = handle.kg.count_active_triples();
+
+            // Prefer the on-disk palace.json name/description; fall back to id.
+            let (name, description) = match &selected_palace_meta {
+                Some(p) => (p.name.clone(), p.description.clone()),
+                None => (palace_id.clone(), None),
+            };
+            palace_display_name = name.clone();
+
+            palace_block.push_str(&format!(
+                "Currently selected palace:\n\
+                 - id: {id}\n\
+                 - name: {name}\n",
+                id = palace_id,
+                name = name,
+            ));
+            if let Some(desc) = description.as_deref().filter(|s| !s.is_empty()) {
+                palace_block.push_str(&format!("- description: {desc}\n"));
+            }
+            palace_block.push_str(&format!(
+                "- drawers: {drawer_count}\n\
+                 - vectors: {vector_count}\n\
+                 - kg_triples: {kg_triple_count}\n",
+            ));
+            let identity_trimmed = handle.identity.trim();
+            if !identity_trimmed.is_empty() {
+                palace_block.push_str(&format!("- identity:\n{identity_trimmed}\n",));
+            }
+
+            if let Ok(hits) = recall_with_default_embedder(&handle, &body.message, 5).await {
+                for r in hits.iter().take(5) {
+                    context.push_str(&format!("- (L{}) {}\n", r.layer, r.drawer.content));
+                }
+            }
+        }
+    }
+
+    // Build the grounded system prompt with identity, palace, RAG, config,
+    // dream-snapshot, and behavior blocks so the LLM never confuses
+    // trusty-memory palaces with real-world architectural palaces.
+    let mut system = String::new();
+    system.push_str(&format!(
+        "You are the assistant for trusty-memory, a machine-wide AI memory \
+         service running locally on this user's machine. trusty-memory stores \
+         knowledge in named \"palaces\" — isolated memory namespaces, each with \
+         its own vector index (usearch HNSW) and temporal knowledge graph \
+         (SQLite). Memories are organized as Palace -> Wing -> Room -> Closet \
+         -> Drawer, where a Drawer is an atomic memory unit.\n\
+         There are currently {palace_count} palace(s) on this machine.\n",
+    ));
+    if !palace_roster.is_empty() {
+        system.push_str(&format!("Palaces:\n{palace_roster}\n"));
+    }
+    system.push('\n');
+
+    // Config block — what providers/models are wired up right now.
+    system.push_str(&format!(
+        "System configuration:\n\
+         - active chat provider: {active_provider_name}\n\
+         - openrouter model: {or_model}\n\
+         - local model: {local_model} ({local_url}, enabled={local_enabled})\n\
+         - data root: {data_root}\n\n",
+        or_model = cfg.openrouter_model,
+        local_model = cfg.local_model.model,
+        local_url = cfg.local_model.base_url,
+        local_enabled = cfg.local_model.enabled,
+        data_root = state.data_root.display(),
+    ));
+
+    // Dream snapshot — give the model a sense of how stale memory state is.
+    system.push_str(&format!(
+        "Global dream status (background memory maintenance):\n{}\n\n",
+        dream_snapshot,
+    ));
+
+    if !palace_block.is_empty() {
+        system.push_str(&palace_block);
+        system.push('\n');
+    }
+
+    if !context.is_empty() {
+        system.push_str(&format!(
+            "Relevant memories from the '{palace_display_name}' palace \
+             (L0 = identity, L1 = essentials, L2 = topic-filtered, L3 = deep):\n\
+             {context}\n",
+        ));
+    }
+
+    system.push_str(
+        "You have a set of tools to introspect and modify this trusty-memory \
+         daemon. Prefer calling a tool over guessing — e.g. call \
+         `list_palaces` rather than relying on the roster above if you need \
+         live counts, and call `recall_memories` to search for facts you \
+         don't have in context. When the user asks about \"palaces\", they \
+         mean trusty-memory palaces (memory namespaces on this machine), not \
+         architectural palaces like Versailles. If a tool returns an error, \
+         report it honestly and don't fabricate results.",
+    );
+
+    // Append the new user message to the in-memory history we'll persist.
+    history.push(ChatMessage {
+        role: "user".to_string(),
+        content: body.message.clone(),
+        tool_call_id: None,
+        tool_calls: None,
+    });
+
+    let mut messages: Vec<ChatMessage> = Vec::with_capacity(history.len() + 1);
+    messages.push(ChatMessage {
+        role: "system".to_string(),
+        content: system,
+        tool_call_id: None,
+        tool_calls: None,
+    });
+    messages.extend(history.iter().cloned());
+
+    let tools = all_tools();
+    let (sse_tx, sse_rx) =
+        tokio::sync::mpsc::channel::<Result<axum::body::Bytes, std::io::Error>>(64);
+
+    // Capture session-persistence inputs.
+    let session_store = if !palace_id.is_empty() && session_id.is_some() {
+        state.session_store(&palace_id).ok()
+    } else {
+        None
+    };
+    let persist_session_id = session_id.clone();
+
+    // Drive the tool-execution loop in a background task so the response can
+    // start streaming immediately.
+    let loop_state = state.clone();
+    tokio::spawn(async move {
+        // Emit a leading session_id frame so the SPA can correlate this stream
+        // with a persisted session row.
+        if let Some(sid) = persist_session_id.as_deref() {
+            let frame = format!("data: {}\n\n", json!({ "session_id": sid }));
+            if sse_tx
+                .send(Ok(axum::body::Bytes::from(frame)))
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+
+        let mut final_assistant_text = String::new();
+        let mut stream_err: Option<String> = None;
+
+        for round in 0..MAX_TOOL_ROUNDS {
+            let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<ChatEvent>(256);
+            let messages_clone = messages.clone();
+            let tools_clone = tools.clone();
+            let provider_clone = provider.clone();
+            let stream_handle = tokio::spawn(async move {
+                provider_clone
+                    .chat_stream(messages_clone, tools_clone, event_tx)
+                    .await
+            });
+
+            let mut tool_calls_this_round: Vec<trusty_common::ToolCall> = Vec::new();
+            let mut round_assistant_text = String::new();
+
+            while let Some(event) = event_rx.recv().await {
+                match event {
+                    ChatEvent::Delta(text) => {
+                        round_assistant_text.push_str(&text);
+                        let frame = format!("data: {}\n\n", json!({ "delta": text }));
+                        if sse_tx
+                            .send(Ok(axum::body::Bytes::from(frame)))
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    ChatEvent::ToolCall(tc) => {
+                        let frame = format!(
+                            "data: {}\n\n",
+                            json!({ "tool_call": {
+                                "id": tc.id,
+                                "name": tc.name,
+                                "arguments": tc.arguments,
+                            }})
+                        );
+                        let _ = sse_tx.send(Ok(axum::body::Bytes::from(frame))).await;
+                        tool_calls_this_round.push(tc);
+                    }
+                    ChatEvent::Done => break,
+                    ChatEvent::Error(e) => {
+                        stream_err = Some(e);
+                        break;
+                    }
+                }
+            }
+
+            // Drain the spawned stream task; surface any error.
+            match stream_handle.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => stream_err = Some(e.to_string()),
+                Err(e) => stream_err = Some(format!("join: {e}")),
+            }
+
+            if stream_err.is_some() {
+                break;
+            }
+
+            final_assistant_text.push_str(&round_assistant_text);
+
+            if tool_calls_this_round.is_empty() {
+                // Model produced a plain answer — we're done.
+                break;
+            }
+
+            // Build the assistant message that requested these tool calls.
+            let assistant_tool_calls_json: Vec<Value> = tool_calls_this_round
+                .iter()
+                .map(|tc| {
+                    json!({
+                        "id": tc.id,
+                        "type": "function",
+                        "function": { "name": tc.name, "arguments": tc.arguments },
+                    })
+                })
+                .collect();
+            messages.push(ChatMessage {
+                role: "assistant".to_string(),
+                content: round_assistant_text,
+                tool_call_id: None,
+                tool_calls: Some(assistant_tool_calls_json),
+            });
+
+            // Execute each tool and append its result as a `role: "tool"`
+            // message. The next loop iteration feeds these back to the model.
+            for tc in &tool_calls_this_round {
+                let result = execute_tool(&tc.name, &tc.arguments, &loop_state).await;
+                let result_str = result.to_string();
+                let frame = format!(
+                    "data: {}\n\n",
+                    json!({ "tool_result": {
+                        "id": tc.id,
+                        "name": tc.name,
+                        "content": &result_str,
+                    }})
+                );
+                let _ = sse_tx.send(Ok(axum::body::Bytes::from(frame))).await;
+                messages.push(ChatMessage {
+                    role: "tool".to_string(),
+                    content: result_str,
+                    tool_call_id: Some(tc.id.clone()),
+                    tool_calls: None,
+                });
+            }
+
+            // Safety net: log when we walk off the round limit.
+            if round + 1 == MAX_TOOL_ROUNDS {
+                tracing::warn!(
+                    "chat: hit MAX_TOOL_ROUNDS={} — terminating tool loop",
+                    MAX_TOOL_ROUNDS
+                );
+            }
+        }
+
+        // Persist the completed conversation regardless of streaming error
+        // (partial assistant reply still better than nothing).
+        if let (Some(store), Some(sid)) = (session_store, persist_session_id.as_deref()) {
+            if !final_assistant_text.is_empty() {
+                history.push(ChatMessage {
+                    role: "assistant".into(),
+                    content: final_assistant_text,
+                    tool_call_id: None,
+                    tool_calls: None,
+                });
+            }
+            let core_history: Vec<trusty_common::memory_core::store::chat_sessions::ChatMessage> =
+                history
+                    .iter()
+                    .map(
+                        |m| trusty_common::memory_core::store::chat_sessions::ChatMessage {
+                            role: m.role.clone(),
+                            content: m.content.clone(),
+                        },
+                    )
+                    .collect();
+            if let Err(e) = store.upsert_session(sid, &core_history) {
+                tracing::warn!("upsert_session failed: {e:#}");
+            }
+        }
+
+        match stream_err {
+            None => {
+                let _ = sse_tx
+                    .send(Ok(axum::body::Bytes::from("data: [DONE]\n\n")))
+                    .await;
+            }
+            Some(e) => {
+                let out = format!("data: {}\n\n", json!({ "error": e }));
+                let _ = sse_tx.send(Ok(axum::body::Bytes::from(out))).await;
+            }
+        }
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(sse_rx);
+
+    Response::builder()
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .body(Body::from_stream(stream))
+        .expect("static SSE response builds")
+}
+
+// ---------------------------------------------------------------------------
+// Providers + sessions
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/chat/providers — report provider availability + active choice.
+///
+/// Why: The UI's chat panel surfaces whether the user has a local model
+/// running or is hitting OpenRouter. Probing both upstreams here keeps that
+/// logic on the server so the SPA stays dumb.
+/// What: Calls `auto_detect_local_provider` (1s timeout) for Ollama and checks
+/// for a non-empty OpenRouter key. Returns shape `{providers:[...], active}`.
+/// Test: `providers_endpoint_returns_payload`.
+pub(crate) async fn list_providers(State(state): State<AppState>) -> Json<Value> {
+    let cfg = load_user_config().unwrap_or_default();
+    let ollama_available = if cfg.local_model.enabled {
+        trusty_common::auto_detect_local_provider(&cfg.local_model.base_url)
+            .await
+            .is_some()
+    } else {
+        false
+    };
+    let openrouter_available = !cfg.openrouter_api_key.is_empty();
+    let active = state.chat_provider().await.map(|p| p.name().to_string());
+    Json(json!({
+        "providers": [
+            {
+                "name": "ollama",
+                "model": cfg.local_model.model,
+                "available": ollama_available,
+            },
+            {
+                "name": "openrouter",
+                "model": cfg.openrouter_model,
+                "available": openrouter_available,
+            }
+        ],
+        "active": active,
+    }))
+}
+
+#[derive(Deserialize, Default)]
+pub(crate) struct CreateSessionBody {
+    #[serde(default)]
+    title: Option<String>,
+}
+
+pub(crate) async fn create_chat_session(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    body: Option<Json<CreateSessionBody>>,
+) -> Result<Json<Value>, ApiError> {
+    let store = state
+        .session_store(&id)
+        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
+    let title = body.and_then(|b| b.0.title);
+    let sid = store
+        .create_session(title)
+        .map_err(|e| ApiError::internal(format!("create session: {e:#}")))?;
+    Ok(Json(json!({ "id": sid })))
+}
+
+pub(crate) async fn list_chat_sessions(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<Value>, ApiError> {
+    let store = state
+        .session_store(&id)
+        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
+    let metas = store
+        .list_sessions()
+        .map_err(|e| ApiError::internal(format!("list sessions: {e:#}")))?;
+    Ok(Json(serde_json::to_value(metas).unwrap_or(json!([]))))
+}
+
+pub(crate) async fn get_chat_session(
+    State(state): State<AppState>,
+    AxumPath((id, session_id)): AxumPath<(String, String)>,
+) -> Result<Json<Value>, ApiError> {
+    let store = state
+        .session_store(&id)
+        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
+    let s = store
+        .get_session(&session_id)
+        .map_err(|e| ApiError::internal(format!("get session: {e:#}")))?
+        .ok_or_else(|| ApiError::not_found(format!("session not found: {session_id}")))?;
+    Ok(Json(serde_json::to_value(s).unwrap_or(json!({}))))
+}
+
+pub(crate) async fn delete_chat_session(
+    State(state): State<AppState>,
+    AxumPath((id, session_id)): AxumPath<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    let store = state
+        .session_store(&id)
+        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
+    store
+        .delete_session(&session_id)
+        .map_err(|e| ApiError::internal(format!("delete session: {e:#}")))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// Inter-project messaging (issue #99)
+// ---------------------------------------------------------------------------
+
+/// Query parameters for `GET /api/v1/messages`.
+///
+/// Why: the receiver's SessionStart hook calls `unread_only=true` to fetch
+/// pending mail; the UI's audit view calls `unread_only=false` to render
+/// the full history.
+/// What: `palace` is the recipient slug; `unread_only` defaults to `false`.
+/// Test: `messages_endpoint_round_trip`.
+#[derive(Deserialize)]
+pub(crate) struct ListMessagesQuery {
+    palace: String,
+    #[serde(default)]
+    unread_only: Option<bool>,
+}
+
+/// `GET /api/v1/messages?palace=<id>&unread_only=<bool>` — list messages in
+/// a palace, optionally filtering to unread.
+///
+/// Why: serves the same data the MCP `inbox-check` CLI consumes, plus the UI
+/// audit log. Returns a JSON array of `{id, from_palace, to_palace, purpose,
+/// sent_at, read, content, formatted}` objects; `formatted` is the
+/// pre-rendered Markdown block the SessionStart hook emits to stdout.
+/// What: opens the palace, calls
+/// [`crate::messaging::list_messages`], and renders each message envelope
+/// plus its formatted block to JSON.
+/// Test: `messages_endpoint_round_trip`.
+pub(crate) async fn list_messages_handler(
+    State(state): State<AppState>,
+    Query(q): Query<ListMessagesQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let handle = open_handle(&state, &q.palace)?;
+    let unread_only = q.unread_only.unwrap_or(false);
+    let messages = crate::messaging::list_messages(&handle, unread_only);
+    let payload: Vec<Value> = messages
+        .into_iter()
+        .map(|m| {
+            let formatted = m.to_injection_block();
+            json!({
+                "id":          m.id.to_string(),
+                "from_palace": m.from_palace,
+                "to_palace":   m.to_palace,
+                "purpose":     m.purpose,
+                "sent_at":     m.sent_at.to_rfc3339(),
+                "read":        m.read,
+                "content":     m.content,
+                "formatted":   formatted,
+            })
+        })
+        .collect();
+    Ok(Json(json!(payload)))
+}
+
+/// Request body for `POST /api/v1/messages`.
+///
+/// Why: the send path takes the same four fields whether invoked from MCP,
+/// CLI, or HTTP; sharing the JSON shape keeps callers interchangeable.
+/// What: `to_palace`, `purpose`, `content` are required; `from_palace`
+/// defaults to the server's `--palace` default if set, otherwise to
+/// `<unknown>` (sender SHOULD set it explicitly; the CLI does cwd
+/// derivation client-side so the daemon stays project-agnostic).
+/// Test: `messages_endpoint_round_trip`.
+#[derive(Deserialize)]
+pub(crate) struct SendMessageBody {
+    to_palace: String,
+    purpose: String,
+    content: String,
+    #[serde(default)]
+    from_palace: Option<String>,
+}
+
+/// `POST /api/v1/messages` — deliver an inter-project message.
+///
+/// Why: lets non-MCP callers (the `trusty-memory send-message` CLI, future
+/// remote callers) put messages on a recipient palace's queue. Mirrors the
+/// MCP `memory_send_message` tool exactly so they stay in lockstep.
+/// What: writes a tagged drawer into the recipient palace via
+/// [`crate::messaging::send_message_to_palace`]. Returns
+/// `{drawer_id, from_palace, to_palace, purpose, status: "sent"}` on success.
+/// Test: `messages_endpoint_round_trip`.
+pub(crate) async fn send_message_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<SendMessageBody>,
+) -> Result<Json<Value>, ApiError> {
+    let from_palace = body
+        .from_palace
+        .or_else(|| state.default_palace.clone())
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let drawer_id = crate::messaging::send_message_to_palace(
+        &state.registry,
+        &state.data_root,
+        &from_palace,
+        &body.to_palace,
+        &body.purpose,
+        body.content,
+        creator_info_from_http(&headers),
+    )
+    .await
+    .map_err(|e| ApiError::internal(format!("send_message: {e:#}")))?;
+    // Emit a drawer-added SSE event so the dashboard activity feed shows
+    // the new message immediately.
+    let drawer_count = open_handle(&state, &body.to_palace)
+        .map(|h| h.drawers.read().len())
+        .unwrap_or(0);
+    state.emit(DaemonEvent::DrawerAdded {
+        palace_id: body.to_palace.clone(),
+        palace_name: body.to_palace.clone(),
+        drawer_count,
+        timestamp: chrono::Utc::now(),
+        content_preview: format!("[msg from {from_palace}] {}", body.purpose),
+        // Issue #96 — record the originating subsystem so the activity feed
+        // can badge this row as an HTTP-initiated message.
+        source: ActivitySource::Http,
+    });
+    Ok(Json(json!({
+        "drawer_id": drawer_id.to_string(),
+        "from_palace": from_palace,
+        "to_palace": body.to_palace,
+        "purpose": body.purpose,
+        "status": "sent",
+    })))
+}
+
+/// Request body for `POST /api/v1/messages/mark_read`.
+///
+/// Why: the SessionStart hook needs an explicit, idempotent ack so two
+/// concurrent sessions starting on the same palace don't double-deliver.
+/// What: identifies a single message by `(palace, drawer_id)`.
+/// Test: `messages_endpoint_round_trip`.
+#[derive(Deserialize)]
+pub(crate) struct MarkReadBody {
+    palace: String,
+    drawer_id: String,
+}
+
+/// `POST /api/v1/messages/mark_read` — atomically flip a message's read flag.
+///
+/// Why: separating ack from list lets the receiver atomically retire
+/// exactly the messages it printed, even when other writers are landing
+/// new messages in the same palace.
+/// What: parses the drawer id, calls
+/// [`crate::messaging::mark_message_read`], and returns `{flipped: bool}`
+/// where `flipped == true` iff this call was the one that flipped the flag
+/// (returning `false` is fine — it means the drawer was already read or
+/// has been concurrently removed; either way no further work is needed).
+/// Test: `messages_endpoint_round_trip`.
+pub(crate) async fn mark_message_read_handler(
+    State(state): State<AppState>,
+    Json(body): Json<MarkReadBody>,
+) -> Result<Json<Value>, ApiError> {
+    let uuid = Uuid::parse_str(&body.drawer_id)
+        .map_err(|_| ApiError::bad_request("drawer_id must be a UUID"))?;
+    let handle = open_handle(&state, &body.palace)?;
+    let flipped = crate::messaging::mark_message_read(&handle, uuid)
+        .await
+        .map_err(|e| ApiError::internal(format!("mark_read: {e:#}")))?;
+    Ok(Json(json!({"flipped": flipped})))
+}

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -41,6 +41,7 @@ pub mod messaging;
 pub mod openrpc;
 pub mod prompt_facts;
 pub mod prompt_log;
+pub mod chat;
 pub mod service;
 pub mod tools;
 pub mod transport;

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -33,15 +33,16 @@ use trusty_common::ChatProvider;
 pub mod activity;
 pub mod attribution;
 pub mod bootstrap;
+pub mod chat;
 pub mod commands;
 pub mod discovery;
 pub mod hook_emit;
 pub mod kg_extract;
+pub mod mcp_service;
 pub mod messaging;
 pub mod openrpc;
 pub mod prompt_facts;
 pub mod prompt_log;
-pub mod chat;
 pub mod service;
 pub mod tools;
 pub mod transport;
@@ -85,7 +86,7 @@ pub fn hook_prompt_excerpt(prompt: &str) -> String {
     }
 }
 
-pub use service::MemoryMcpService;
+pub use mcp_service::MemoryMcpService;
 pub use tools::MemoryMcpServer;
 
 /// Resolve the directory that actually holds the per-palace subdirectories.

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -1,0 +1,118 @@
+//! `ServiceDescriptor` impl for the trusty-memory MCP service.
+//!
+//! Why: open-mpm (and any future host process that links several MCP
+//! services into a single binary) needs a uniform way to enumerate every
+//! tool a linked service contributes and the scopes each tool requires.
+//! The shared `trusty_mcp_core::ServiceDescriptor` trait is that contract:
+//! the host collects `&dyn ServiceDescriptor` impls and feeds them to
+//! `OpenRpcBuilder::from_services` to emit one merged `rpc.discover`
+//! document covering all of them. By implementing the trait here, the
+//! host no longer needs to know anything concrete about trusty-memory.
+//!
+//! What: A zero-sized `MemoryMcpService` struct that delegates to the
+//! existing `tool_definitions_with` and `scopes_for_tool` helpers already
+//! used by this crate's standalone `rpc.discover` handler. Reusing those
+//! functions guarantees the host-merged manifest and the standalone one
+//! stay byte-identical.
+//!
+//! Test: `tests` below assert the tool count (11), the name string, and
+//! that the read/write scope split matches what `scopes_for_tool` returns
+//! for representative tools (`memory_recall` → `memory.read`,
+//! `memory_remember` → `memory.write`).
+
+use trusty_common::mcp::ServiceDescriptor;
+
+use crate::openrpc::scopes_for_tool;
+use crate::tools::tool_definitions_with;
+
+/// `ServiceDescriptor` impl that advertises this crate's 11 memory tools.
+///
+/// Why: Lets open-mpm link trusty-memory-mcp directly and include its
+/// tools in a unified `rpc.discover` document without bespoke glue code.
+/// What: Wraps the existing tool definitions and the per-tool scope
+/// mapping behind the shared trait. The struct is unit-like — there is
+/// no per-instance state — so callers can construct it with
+/// `MemoryMcpService` at the call site.
+/// Test: `tests::tools_returns_eleven`, `tests::scopes_for_read_tool`,
+/// `tests::scopes_for_write_tool`, `tests::name_returns_trusty_memory`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemoryMcpService;
+
+impl ServiceDescriptor for MemoryMcpService {
+    fn name(&self) -> &str {
+        "trusty-memory"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn tools(&self) -> Vec<serde_json::Value> {
+        // Why: `tool_definitions_with(false)` matches the schema clients see
+        //      when no default palace is configured — the conservative shape
+        //      where `palace` is a required argument on every palace-scoped
+        //      tool. The host can override later if it wants to surface the
+        //      `has_default = true` variant.
+        let defs = tool_definitions_with(false);
+        defs.get("tools")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn scopes_for(&self, tool: &str) -> Vec<String> {
+        scopes_for_tool(tool)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_returns_trusty_memory() {
+        let svc = MemoryMcpService;
+        assert_eq!(svc.name(), "trusty-memory");
+    }
+
+    #[test]
+    fn version_matches_cargo_pkg_version() {
+        let svc = MemoryMcpService;
+        assert_eq!(svc.version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn tools_returns_expected_count() {
+        let svc = MemoryMcpService;
+        let tools = svc.tools();
+        assert_eq!(
+            tools.len(),
+            21,
+            "expected 21 memory tools, got {}",
+            tools.len()
+        );
+    }
+
+    #[test]
+    fn scopes_for_read_tool() {
+        let svc = MemoryMcpService;
+        assert_eq!(svc.scopes_for("memory_recall"), vec!["memory.read"]);
+    }
+
+    #[test]
+    fn scopes_for_write_tool() {
+        let svc = MemoryMcpService;
+        assert_eq!(svc.scopes_for("memory_remember"), vec!["memory.write"]);
+    }
+
+    #[test]
+    fn dispatches_through_trait_object() {
+        // Why: open-mpm collects services as `Vec<Box<dyn ServiceDescriptor>>`,
+        //      so we must confirm dynamic dispatch resolves correctly here.
+        let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
+        assert_eq!(svc.name(), "trusty-memory");
+        assert_eq!(svc.tools().len(), 21);
+        assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
+        assert_eq!(svc.scopes_for("palace_list"), vec!["memory.read"]);
+    }
+}

--- a/crates/trusty-memory/src/service.rs
+++ b/crates/trusty-memory/src/service.rs
@@ -1,118 +1,1069 @@
-//! `ServiceDescriptor` impl for the trusty-memory MCP service.
+//! `MemoryService` — pure business-logic facade over `AppState`.
 //!
-//! Why: open-mpm (and any future host process that links several MCP
-//! services into a single binary) needs a uniform way to enumerate every
-//! tool a linked service contributes and the scopes each tool requires.
-//! The shared `trusty_mcp_core::ServiceDescriptor` trait is that contract:
-//! the host collects `&dyn ServiceDescriptor` impls and feeds them to
-//! `OpenRpcBuilder::from_services` to emit one merged `rpc.discover`
-//! document covering all of them. By implementing the trait here, the
-//! host no longer needs to know anything concrete about trusty-memory.
+//! Why: `web.rs` previously hosted ~5700 lines that mingled axum extraction,
+//! JSON wire shapes, and business logic. Moving the logic into a struct with
+//! `anyhow::Result<Value>` methods lets the HTTP handlers stay one-liners
+//! and lets non-HTTP callers (chat tool dispatch, future RPC bridges) reuse
+//! the same code paths without dragging axum types around.
+//! What: A zero-cost wrapper around [`AppState`] exposing one async method
+//! per logical operation. Each method returns either `anyhow::Result<Value>`
+//! (for handlers that already wrap errors with `ApiError::internal`) or a
+//! domain-specific result the handler maps into JSON.
+//! Test: Each method is covered indirectly via the corresponding HTTP test in
+//! `web::tests` (the handlers delegate here verbatim).
 //!
-//! What: A zero-sized `MemoryMcpService` struct that delegates to the
-//! existing `tool_definitions_with` and `scopes_for_tool` helpers already
-//! used by this crate's standalone `rpc.discover` handler. Reusing those
-//! functions guarantees the host-merged manifest and the standalone one
-//! stay byte-identical.
-//!
-//! Test: `tests` below assert the tool count (11), the name string, and
-//! that the read/write scope split matches what `scopes_for_tool` returns
-//! for representative tools (`memory_recall` → `memory.read`,
-//! `memory_remember` → `memory.write`).
+//! Hard constraint (issue #151): no behaviour change. Every method's success
+//! and failure shapes match what the handler used to produce inline.
 
-use trusty_common::mcp::ServiceDescriptor;
+use crate::attribution::CreatorInfo;
+use crate::{ActivityFilter, ActivitySource, AppState, DaemonEvent};
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::sync::Arc;
+use trusty_common::memory_core::dream::{DreamConfig, Dreamer, PersistedDreamStats};
+use trusty_common::memory_core::palace::{Palace, PalaceId, RoomType};
+use trusty_common::memory_core::retrieval::{
+    recall_across_palaces_with_default_embedder, recall_deep_with_default_embedder,
+    recall_with_default_embedder, RecallResult,
+};
+use trusty_common::memory_core::store::kg::Triple;
+use trusty_common::memory_core::{PalaceHandle, PalaceRegistry};
+use uuid::Uuid;
 
-use crate::openrpc::scopes_for_tool;
-use crate::tools::tool_definitions_with;
+// ---------------------------------------------------------------------------
+// Wire types shared between HTTP handlers and the service layer.
+// ---------------------------------------------------------------------------
 
-/// `ServiceDescriptor` impl that advertises this crate's 11 memory tools.
+/// Serializable palace summary used by `GET /api/v1/palaces` and
+/// `GET /api/v1/palaces/{id}`.
 ///
-/// Why: Lets open-mpm link trusty-memory-mcp directly and include its
-/// tools in a unified `rpc.discover` document without bespoke glue code.
-/// What: Wraps the existing tool definitions and the per-tool scope
-/// mapping behind the shared trait. The struct is unit-like — there is
-/// no per-instance state — so callers can construct it with
-/// `MemoryMcpService` at the call site.
-/// Test: `tests::tools_returns_eleven`, `tests::scopes_for_read_tool`,
-/// `tests::scopes_for_write_tool`, `tests::name_returns_trusty_memory`.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct MemoryMcpService;
+/// Why: Both endpoints return the same enriched shape; centralising the
+/// type in the service layer keeps the wire contract single-source.
+/// What: Mirrors the legacy `PalaceInfo` struct verbatim — counts, timestamps,
+/// graph stats, and the `is_compacting` flag.
+/// Test: `palace_list_includes_richer_counts`, `palace_list_includes_graph_counts`.
+#[derive(Serialize, Clone, Debug)]
+pub struct PalaceInfo {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub drawer_count: usize,
+    pub vector_count: usize,
+    pub kg_triple_count: usize,
+    pub wing_count: usize,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub last_write_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub node_count: u64,
+    #[serde(default)]
+    pub edge_count: u64,
+    #[serde(default)]
+    pub community_count: u64,
+    #[serde(default)]
+    pub is_compacting: bool,
+}
 
-impl ServiceDescriptor for MemoryMcpService {
-    fn name(&self) -> &str {
-        "trusty-memory"
-    }
+/// Dream statistics wire shape used by both per-palace and aggregate endpoints.
+///
+/// Why: Lifted out of `web.rs` so the service layer owns the type the chat
+/// dispatcher and HTTP handlers both serialise. Stays identical to the
+/// pre-refactor shape.
+/// What: All fields are saturating sums across one or more palaces; the
+/// `last_run_at` is the max across them (or `None` when no palace has run).
+/// Test: `dream_status_aggregates_across_palaces`, `dream_run_aggregates_stats`.
+#[derive(Serialize, Default, Clone, Debug)]
+pub struct DreamStatusPayload {
+    pub last_run_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub merged: usize,
+    pub pruned: usize,
+    pub compacted: usize,
+    pub closets_updated: usize,
+    pub duration_ms: u64,
+}
 
-    fn version(&self) -> &str {
-        env!("CARGO_PKG_VERSION")
-    }
-
-    fn tools(&self) -> Vec<serde_json::Value> {
-        // Why: `tool_definitions_with(false)` matches the schema clients see
-        //      when no default palace is configured — the conservative shape
-        //      where `palace` is a required argument on every palace-scoped
-        //      tool. The host can override later if it wants to surface the
-        //      `has_default = true` variant.
-        let defs = tool_definitions_with(false);
-        defs.get("tools")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    fn scopes_for(&self, tool: &str) -> Vec<String> {
-        scopes_for_tool(tool)
+impl From<PersistedDreamStats> for DreamStatusPayload {
+    fn from(p: PersistedDreamStats) -> Self {
+        Self {
+            last_run_at: Some(p.last_run_at),
+            merged: p.stats.merged,
+            pruned: p.stats.pruned,
+            compacted: p.stats.compacted,
+            closets_updated: p.stats.closets_updated,
+            duration_ms: p.stats.duration_ms,
+        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// `POST /api/v1/palaces` body — service-facing version.
+#[derive(Deserialize, Clone, Debug)]
+pub struct CreatePalaceBody {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
 
-    #[test]
-    fn name_returns_trusty_memory() {
-        let svc = MemoryMcpService;
-        assert_eq!(svc.name(), "trusty-memory");
+/// `POST /api/v1/palaces/{id}/drawers` body — service-facing version.
+#[derive(Deserialize, Clone, Debug)]
+pub struct CreateDrawerBody {
+    pub content: String,
+    #[serde(default)]
+    pub room: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub importance: Option<f32>,
+}
+
+/// `GET /api/v1/palaces/{id}/drawers` query — service-facing version.
+#[derive(Deserialize, Default, Clone, Debug)]
+pub struct ListDrawersQuery {
+    #[serde(default)]
+    pub room: Option<String>,
+    #[serde(default)]
+    pub tag: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+/// `POST /api/v1/palaces/{id}/kg` body — service-facing version.
+#[derive(Deserialize, Clone, Debug)]
+pub struct KgAssertBody {
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    #[serde(default)]
+    pub confidence: Option<f32>,
+    #[serde(default)]
+    pub provenance: Option<String>,
+}
+
+/// Knowledge-graph "graph payload" used by `GET /api/v1/palaces/{id}/kg/graph`.
+#[derive(Serialize, Clone, Debug)]
+pub struct KgGraphPayload {
+    pub triples: Vec<Triple>,
+    pub node_count: u64,
+    pub edge_count: u64,
+    pub community_count: u64,
+}
+
+/// Status payload returned by `GET /api/v1/status`.
+#[derive(Serialize, Clone, Debug)]
+pub struct StatusPayload {
+    pub version: String,
+    pub palace_count: usize,
+    pub default_palace: Option<String>,
+    pub data_root: String,
+    pub total_drawers: usize,
+    pub total_vectors: usize,
+    pub total_kg_triples: usize,
+}
+
+/// Service-level error type that maps cleanly onto HTTP status codes.
+///
+/// Why: handlers want to render 400/404/500 from a single point; the service
+/// methods produce a typed error so the binding layer can pick the right
+/// status without parsing strings.
+/// What: three variants matching the legacy `ApiError` constructors.
+/// Test: indirectly via the HTTP tests for the corresponding endpoints.
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceError {
+    #[error("{0}")]
+    BadRequest(String),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("{0}")]
+    Internal(String),
+}
+
+impl ServiceError {
+    pub fn bad_request(msg: impl Into<String>) -> Self {
+        Self::BadRequest(msg.into())
+    }
+    pub fn not_found(msg: impl Into<String>) -> Self {
+        Self::NotFound(msg.into())
+    }
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self::Internal(msg.into())
+    }
+}
+
+/// Result alias used across the service layer.
+pub type ServiceResult<T> = std::result::Result<T, ServiceError>;
+
+/// Hard cap on triples returned by the per-palace graph endpoint.
+const KG_GRAPH_MAX_TRIPLES: usize = 5_000;
+
+// ---------------------------------------------------------------------------
+// MemoryService — pure business logic facade.
+// ---------------------------------------------------------------------------
+
+/// Wraps [`AppState`] and exposes one async method per logical operation.
+///
+/// Why: see module docs. Lets HTTP handlers stay thin and lets non-HTTP
+/// callers (chat tool dispatch, RPC bridges) reuse the same code paths.
+/// What: `Clone` (cheap — only the inner `AppState` is shared); construct
+/// with `MemoryService::new(state)`.
+/// Test: every method is covered by the corresponding handler test in
+/// `web::tests`.
+#[derive(Clone)]
+pub struct MemoryService {
+    state: AppState,
+}
+
+impl MemoryService {
+    /// Construct a new service wrapper.
+    ///
+    /// Why: handlers cheaply re-wrap their `AppState` on every request; the
+    /// cost is just an `Arc` clone, so we don't bother caching the wrapper.
+    /// What: stores the `AppState` for later method calls.
+    /// Test: trivial — covered indirectly by every handler test.
+    pub fn new(state: AppState) -> Self {
+        Self { state }
     }
 
-    #[test]
-    fn version_matches_cargo_pkg_version() {
-        let svc = MemoryMcpService;
-        assert_eq!(svc.version(), env!("CARGO_PKG_VERSION"));
+    /// Borrow the inner [`AppState`].
+    ///
+    /// Why: some handlers still need direct access (SSE broadcaster, session
+    /// store, etc.) while we incrementally extract code into the service.
+    /// What: returns a borrowed reference to the wrapped `AppState`.
+    /// Test: not directly tested; surface-level accessor.
+    pub fn state(&self) -> &AppState {
+        &self.state
     }
 
-    #[test]
-    fn tools_returns_expected_count() {
-        let svc = MemoryMcpService;
-        let tools = svc.tools();
-        assert_eq!(
-            tools.len(),
-            21,
-            "expected 21 memory tools, got {}",
-            tools.len()
-        );
+    // -----------------------------------------------------------------
+    // Status / config
+    // -----------------------------------------------------------------
+
+    /// Build the aggregate `/api/v1/status` payload.
+    ///
+    /// Why: dashboard widgets and the MCP `get_status` tool need the same
+    /// roll-up; centralising avoids drift between the two surfaces.
+    /// What: walks every persisted palace, sums drawer/vector/triple counts,
+    /// and returns the [`StatusPayload`].
+    /// Test: `status_endpoint_returns_payload`.
+    pub async fn status(&self) -> StatusPayload {
+        let palaces = PalaceRegistry::list_palaces(&self.state.data_root).unwrap_or_default();
+        let palace_count = palaces.len();
+        let (mut total_drawers, mut total_vectors, mut total_kg_triples): (usize, usize, usize) =
+            (0, 0, 0);
+        for p in &palaces {
+            if let Ok(handle) = self
+                .state
+                .registry
+                .open_palace(&self.state.data_root, &p.id)
+            {
+                total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
+                total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
+                total_kg_triples =
+                    total_kg_triples.saturating_add(handle.kg.count_active_triples());
+            }
+        }
+        StatusPayload {
+            version: self.state.version.clone(),
+            palace_count,
+            default_palace: self.state.default_palace.clone(),
+            data_root: self.state.data_root.display().to_string(),
+            total_drawers,
+            total_vectors,
+            total_kg_triples,
+        }
     }
 
-    #[test]
-    fn scopes_for_read_tool() {
-        let svc = MemoryMcpService;
-        assert_eq!(svc.scopes_for("memory_recall"), vec!["memory.read"]);
+    /// Compute the aggregate `StatusChanged` event used by SSE consumers.
+    ///
+    /// Why: mutating handlers push a refreshed status snapshot so dashboards
+    /// stay in sync without an extra `/api/v1/status` request.
+    /// What: same math as `status()` but returns a `DaemonEvent::StatusChanged`.
+    /// Test: indirectly via SSE integration tests.
+    pub fn aggregate_status_event(&self) -> DaemonEvent {
+        let palaces = PalaceRegistry::list_palaces(&self.state.data_root).unwrap_or_default();
+        let (mut total_drawers, mut total_vectors, mut total_kg_triples): (usize, usize, usize) =
+            (0, 0, 0);
+        for p in &palaces {
+            if let Ok(handle) = self
+                .state
+                .registry
+                .open_palace(&self.state.data_root, &p.id)
+            {
+                total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
+                total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
+                total_kg_triples =
+                    total_kg_triples.saturating_add(handle.kg.count_active_triples());
+            }
+        }
+        DaemonEvent::StatusChanged {
+            total_drawers,
+            total_vectors,
+            total_kg_triples,
+        }
     }
 
-    #[test]
-    fn scopes_for_write_tool() {
-        let svc = MemoryMcpService;
-        assert_eq!(svc.scopes_for("memory_remember"), vec!["memory.write"]);
+    // -----------------------------------------------------------------
+    // Palaces
+    // -----------------------------------------------------------------
+
+    /// List every palace on disk, enriched with live handle stats.
+    ///
+    /// Why: shared between the HTTP handler and the chat tool dispatcher;
+    /// both want the same `PalaceInfo` shape.
+    /// What: walks the registry and builds a `PalaceInfo` per row.
+    /// Test: `palace_list_includes_richer_counts`, `palace_list_includes_graph_counts`.
+    pub async fn list_palaces(&self) -> ServiceResult<Vec<PalaceInfo>> {
+        let palaces = PalaceRegistry::list_palaces(&self.state.data_root)
+            .map_err(|e| ServiceError::internal(format!("list palaces: {e:#}")))?;
+        let mut out = Vec::with_capacity(palaces.len());
+        for p in palaces {
+            let handle = self
+                .state
+                .registry
+                .open_palace(&self.state.data_root, &p.id)
+                .ok();
+            out.push(palace_info_from(&p, handle.as_ref()));
+        }
+        Ok(out)
     }
 
-    #[test]
-    fn dispatches_through_trait_object() {
-        // Why: open-mpm collects services as `Vec<Box<dyn ServiceDescriptor>>`,
-        //      so we must confirm dynamic dispatch resolves correctly here.
-        let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
-        assert_eq!(svc.name(), "trusty-memory");
-        assert_eq!(svc.tools().len(), 21);
-        assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
-        assert_eq!(svc.scopes_for("palace_list"), vec!["memory.read"]);
+    /// Create a new palace and emit the corresponding activity event.
+    ///
+    /// Why: trims duplicated work between the HTTP handler and any future
+    /// non-HTTP creation flow.
+    /// What: validates the name, builds the `Palace` row, calls
+    /// `PalaceRegistry::create_palace`, and emits `PalaceCreated`. Returns
+    /// the new palace id.
+    /// Test: covered indirectly by `palace_list_includes_richer_counts` (which
+    /// posts a palace through the HTTP layer then reads it back).
+    pub async fn create_palace(
+        &self,
+        body: CreatePalaceBody,
+        source: ActivitySource,
+    ) -> ServiceResult<String> {
+        let name = body.name.trim().to_string();
+        if name.is_empty() {
+            return Err(ServiceError::bad_request("name is required"));
+        }
+        let id = PalaceId::new(&name);
+        let palace = Palace {
+            id: id.clone(),
+            name: name.clone(),
+            description: body.description.filter(|s| !s.is_empty()),
+            created_at: chrono::Utc::now(),
+            data_dir: self.state.data_root.join(&name),
+        };
+        self.state
+            .registry
+            .create_palace(&self.state.data_root, palace)
+            .map_err(|e| ServiceError::internal(format!("create palace: {e:#}")))?;
+        self.state.emit(DaemonEvent::PalaceCreated {
+            id: name.clone(),
+            name: name.clone(),
+            source,
+        });
+        Ok(name)
+    }
+
+    /// Look up a single palace by id and enrich with live handle stats.
+    ///
+    /// Why: distinct 404 vs. 500 path is needed by both HTTP and chat callers.
+    /// What: returns `NotFound` when the id is unknown, otherwise a fully
+    /// populated `PalaceInfo`.
+    /// Test: indirectly via `health_endpoint_round_trip_with_palace_is_ok`.
+    pub async fn get_palace(&self, id: &str) -> ServiceResult<PalaceInfo> {
+        let palaces = PalaceRegistry::list_palaces(&self.state.data_root)
+            .map_err(|e| ServiceError::internal(format!("list palaces: {e:#}")))?;
+        let palace = palaces
+            .into_iter()
+            .find(|p| p.id.0 == id)
+            .ok_or_else(|| ServiceError::not_found(format!("palace not found: {id}")))?;
+        let handle = self
+            .state
+            .registry
+            .open_palace(&self.state.data_root, &palace.id)
+            .ok();
+        Ok(palace_info_from(&palace, handle.as_ref()))
+    }
+
+    // -----------------------------------------------------------------
+    // Drawers
+    // -----------------------------------------------------------------
+
+    /// List drawers in a palace with optional room/tag/limit filters.
+    ///
+    /// Why: deduplicates the open-handle + listing path between HTTP and chat.
+    /// What: opens the palace handle, calls `list_drawers`, returns the
+    /// serialised JSON array.
+    /// Test: `drawers_endpoint_returns_array`.
+    pub async fn list_drawers(&self, id: &str, q: ListDrawersQuery) -> ServiceResult<Value> {
+        let handle = self.open_handle(id)?;
+        let room = q.room.as_deref().map(RoomType::parse);
+        let drawers = handle.list_drawers(room, q.tag.clone(), q.limit.unwrap_or(50));
+        Ok(serde_json::to_value(drawers).unwrap_or(json!([])))
+    }
+
+    /// Store a new drawer and emit the matching activity events.
+    ///
+    /// Why: HTTP and chat both need the auto-KG-extraction follow-up; this
+    /// method keeps that side-effect chain in one place.
+    /// What: opens the palace, stores the drawer via `PalaceHandle::remember`,
+    /// emits `DrawerAdded` + `StatusChanged`, then triggers
+    /// `tools::auto_extract_and_assert`. Returns the new drawer id.
+    /// Test: `http_create_drawer_runs_auto_kg_extraction`.
+    pub async fn create_drawer(
+        &self,
+        id: &str,
+        body: CreateDrawerBody,
+        creator: CreatorInfo,
+        source: ActivitySource,
+    ) -> ServiceResult<Uuid> {
+        let handle = self.open_handle(id)?;
+        let room = body
+            .room
+            .as_deref()
+            .map(RoomType::parse)
+            .unwrap_or(RoomType::General);
+        let importance = body.importance.unwrap_or(0.5);
+        let content_preview = drawer_content_preview(&body.content);
+        let mut tags_with_creator = body.tags;
+        creator.merge_into(&mut tags_with_creator);
+        let content_for_kg = body.content.clone();
+        let tags_for_kg = tags_with_creator.clone();
+        let room_label_for_kg = crate::tools::room_label(&room);
+        let drawer_id = handle
+            .remember(body.content, room, tags_with_creator, importance)
+            .await
+            .map_err(|e| ServiceError::internal(format!("remember: {e:#}")))?;
+        let drawer_count = handle.drawers.read().len();
+        let palace_name = PalaceRegistry::list_palaces(&self.state.data_root)
+            .ok()
+            .and_then(|ps| ps.into_iter().find(|p| p.id.0 == id).map(|p| p.name))
+            .unwrap_or_else(|| id.to_string());
+        self.state.emit(DaemonEvent::DrawerAdded {
+            palace_id: id.to_string(),
+            palace_name,
+            drawer_count,
+            timestamp: chrono::Utc::now(),
+            content_preview,
+            source,
+        });
+        self.state.emit(self.aggregate_status_event());
+        crate::tools::auto_extract_and_assert(
+            &handle,
+            drawer_id,
+            &content_for_kg,
+            &tags_for_kg,
+            room_label_for_kg.as_deref(),
+        )
+        .await;
+        Ok(drawer_id)
+    }
+
+    /// Forget (delete) a drawer and emit the matching events.
+    ///
+    /// Why: same dedup story as `create_drawer`.
+    /// What: parses the drawer UUID, calls `PalaceHandle::forget`, emits
+    /// `DrawerDeleted` + `StatusChanged`.
+    /// Test: indirectly via the drawer-related HTTP tests.
+    pub async fn delete_drawer(
+        &self,
+        id: &str,
+        drawer_id: &str,
+        source: ActivitySource,
+    ) -> ServiceResult<()> {
+        let handle = self.open_handle(id)?;
+        let uuid = Uuid::parse_str(drawer_id)
+            .map_err(|_| ServiceError::bad_request("drawer_id must be a UUID"))?;
+        handle
+            .forget(uuid)
+            .await
+            .map_err(|e| ServiceError::internal(format!("forget: {e:#}")))?;
+        let drawer_count = handle.drawers.read().len();
+        self.state.emit(DaemonEvent::DrawerDeleted {
+            palace_id: id.to_string(),
+            drawer_count,
+            source,
+        });
+        self.state.emit(self.aggregate_status_event());
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------
+    // Recall
+    // -----------------------------------------------------------------
+
+    /// Per-palace recall (semantic search), optionally with deep retrieval.
+    ///
+    /// Why: HTTP and chat tools both perform the same fan-out logic.
+    /// What: opens the palace handle and dispatches to the shallow or deep
+    /// recall helper. Returns a JSON array of flattened drawer rows (the
+    /// `recall_entry_json` shape from issue #69).
+    /// Test: `recall_entry_json_hoists_drawer_fields`.
+    pub async fn recall(
+        &self,
+        id: &str,
+        query: &str,
+        top_k: usize,
+        deep: bool,
+    ) -> ServiceResult<Value> {
+        let handle = self.open_handle(id)?;
+        let results = if deep {
+            recall_deep_with_default_embedder(&handle, query, top_k).await
+        } else {
+            recall_with_default_embedder(&handle, query, top_k).await
+        }
+        .map_err(|e| ServiceError::internal(format!("recall: {e:#}")))?;
+        let payload: Vec<Value> = results.into_iter().map(recall_entry_json).collect();
+        Ok(json!(payload))
+    }
+
+    /// Cross-palace recall.
+    ///
+    /// Why: shared between `/api/v1/recall` and the `memory_recall_all` chat
+    /// tool. Encapsulating the open-everything-fanout-merge dance avoids
+    /// drift.
+    /// What: lists every palace, opens handles (skipping failures with a
+    /// `tracing::warn!`), delegates to
+    /// `recall_across_palaces_with_default_embedder`. Returns a JSON array.
+    /// Test: indirectly via `recall_across_palaces_merges_results` and the
+    /// MCP `memory_recall_all` integration paths.
+    pub async fn recall_all(&self, query: &str, top_k: usize, deep: bool) -> Value {
+        let palaces = match PalaceRegistry::list_palaces(&self.state.data_root) {
+            Ok(v) => v,
+            Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
+        };
+        let mut handles = Vec::with_capacity(palaces.len());
+        for p in &palaces {
+            match self
+                .state
+                .registry
+                .open_palace(&self.state.data_root, &p.id)
+            {
+                Ok(h) => handles.push(h),
+                Err(e) => {
+                    tracing::warn!(palace = %p.id, "recall_all: open failed: {e:#}");
+                }
+            }
+        }
+        if handles.is_empty() {
+            return json!([]);
+        }
+        match recall_across_palaces_with_default_embedder(&handles, query, top_k, deep).await {
+            Ok(results) => json!(results
+                .into_iter()
+                .map(|r| json!({
+                    "palace_id": r.palace_id,
+                    "drawer_id": r.result.drawer.id.to_string(),
+                    "content": r.result.drawer.content,
+                    "importance": r.result.drawer.importance,
+                    "tags": r.result.drawer.tags,
+                    "score": r.result.score,
+                    "layer": r.result.layer,
+                }))
+                .collect::<Vec<_>>()),
+            Err(e) => json!({ "error": format!("recall_across_palaces: {e:#}") }),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Knowledge graph
+    // -----------------------------------------------------------------
+
+    /// Query the KG for all active triples whose subject matches.
+    pub async fn kg_query(&self, id: &str, subject: &str) -> ServiceResult<Vec<Triple>> {
+        let handle = self.open_handle(id)?;
+        handle
+            .kg
+            .query_active(subject)
+            .await
+            .map_err(|e| ServiceError::internal(format!("kg query: {e:#}")))
+    }
+
+    /// Assert a triple in the KG.
+    pub async fn kg_assert(&self, id: &str, body: KgAssertBody) -> ServiceResult<()> {
+        let handle = self.open_handle(id)?;
+        let triple = Triple {
+            subject: body.subject,
+            predicate: body.predicate,
+            object: body.object,
+            valid_from: chrono::Utc::now(),
+            valid_to: None,
+            confidence: body.confidence.unwrap_or(1.0),
+            provenance: body.provenance,
+        };
+        handle
+            .kg
+            .assert(triple)
+            .await
+            .map_err(|e| ServiceError::internal(format!("kg assert: {e:#}")))
+    }
+
+    /// List distinct subjects in the KG.
+    pub async fn kg_list_subjects(&self, id: &str, limit: usize) -> ServiceResult<Vec<String>> {
+        let handle = self.open_handle(id)?;
+        handle
+            .kg
+            .list_subjects(limit)
+            .map_err(|e| ServiceError::internal(format!("kg list_subjects: {e:#}")))
+    }
+
+    /// List distinct subjects in the KG paired with their active-triple count.
+    pub async fn kg_list_subjects_with_counts(
+        &self,
+        id: &str,
+        limit: usize,
+    ) -> ServiceResult<Vec<(String, u64)>> {
+        let handle = self.open_handle(id)?;
+        handle
+            .kg
+            .list_subjects_with_counts(limit)
+            .map_err(|e| ServiceError::internal(format!("kg list_subjects_with_counts: {e:#}")))
+    }
+
+    /// Page through every active triple.
+    pub async fn kg_list_all(
+        &self,
+        id: &str,
+        limit: usize,
+        offset: usize,
+    ) -> ServiceResult<Vec<Triple>> {
+        let handle = self.open_handle(id)?;
+        handle
+            .kg
+            .list_active(limit, offset)
+            .await
+            .map_err(|e| ServiceError::internal(format!("kg list_active: {e:#}")))
+    }
+
+    /// Return the count of currently-active triples.
+    pub async fn kg_count(&self, id: &str) -> ServiceResult<usize> {
+        let handle = self.open_handle(id)?;
+        Ok(handle.kg.count_active_triples())
+    }
+
+    /// Build the per-palace visual graph payload.
+    pub async fn kg_graph(&self, id: &str) -> ServiceResult<KgGraphPayload> {
+        let handle = self.open_handle(id)?;
+        let triples = handle
+            .kg
+            .list_active(KG_GRAPH_MAX_TRIPLES, 0)
+            .await
+            .map_err(|e| ServiceError::internal(format!("kg list_active: {e:#}")))?;
+        Ok(KgGraphPayload {
+            triples,
+            node_count: handle.kg.node_count() as u64,
+            edge_count: handle.kg.edge_count() as u64,
+            community_count: handle.kg.community_count() as u64,
+        })
+    }
+
+    // -----------------------------------------------------------------
+    // Dream cycle
+    // -----------------------------------------------------------------
+
+    /// Aggregate dream stats across every persisted palace.
+    pub async fn dream_status_aggregate(&self) -> DreamStatusPayload {
+        let palaces = PalaceRegistry::list_palaces(&self.state.data_root).unwrap_or_default();
+        let mut out = DreamStatusPayload::default();
+        let mut latest: Option<chrono::DateTime<chrono::Utc>> = None;
+        for p in palaces {
+            let data_dir = self.state.data_root.join(p.id.as_str());
+            let snap = match PersistedDreamStats::load(&data_dir) {
+                Ok(Some(s)) => s,
+                _ => continue,
+            };
+            out.merged = out.merged.saturating_add(snap.stats.merged);
+            out.pruned = out.pruned.saturating_add(snap.stats.pruned);
+            out.compacted = out.compacted.saturating_add(snap.stats.compacted);
+            out.closets_updated = out
+                .closets_updated
+                .saturating_add(snap.stats.closets_updated);
+            out.duration_ms = out.duration_ms.saturating_add(snap.stats.duration_ms);
+            latest = match latest {
+                Some(t) if t >= snap.last_run_at => Some(t),
+                _ => Some(snap.last_run_at),
+            };
+        }
+        out.last_run_at = latest;
+        out
+    }
+
+    /// Per-palace dream stats snapshot.
+    pub async fn dream_status_for_palace(&self, id: &str) -> ServiceResult<DreamStatusPayload> {
+        let data_dir = self.state.data_root.join(id);
+        if !data_dir.exists() {
+            return Err(ServiceError::not_found(format!("palace not found: {id}")));
+        }
+        match PersistedDreamStats::load(&data_dir) {
+            Ok(Some(s)) => Ok(s.into()),
+            Ok(None) => Ok(DreamStatusPayload::default()),
+            Err(e) => Err(ServiceError::internal(format!("read dream stats: {e:#}"))),
+        }
+    }
+
+    /// Run a dream cycle across every palace.
+    pub async fn dream_run(&self) -> ServiceResult<DreamStatusPayload> {
+        let palaces = PalaceRegistry::list_palaces(&self.state.data_root)
+            .map_err(|e| ServiceError::internal(format!("list palaces: {e:#}")))?;
+        let dreamer = Dreamer::new(DreamConfig::default());
+        let mut out = DreamStatusPayload::default();
+        for p in palaces {
+            let handle = match self
+                .state
+                .registry
+                .open_palace(&self.state.data_root, &p.id)
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::warn!(palace = %p.id, "dream_run: open failed: {e:#}");
+                    continue;
+                }
+            };
+            match dreamer.dream_cycle(&handle).await {
+                Ok(stats) => {
+                    out.merged = out.merged.saturating_add(stats.merged);
+                    out.pruned = out.pruned.saturating_add(stats.pruned);
+                    out.compacted = out.compacted.saturating_add(stats.compacted);
+                    out.closets_updated = out.closets_updated.saturating_add(stats.closets_updated);
+                    out.duration_ms = out.duration_ms.saturating_add(stats.duration_ms);
+                }
+                Err(e) => tracing::warn!(palace = %p.id, "dream_run: cycle failed: {e:#}"),
+            }
+            refresh_gaps_cache(&self.state, &handle).await;
+        }
+        out.last_run_at = Some(chrono::Utc::now());
+        self.state.emit(DaemonEvent::DreamCompleted {
+            palace_id: None,
+            merged: out.merged,
+            pruned: out.pruned,
+            compacted: out.compacted,
+            closets_updated: out.closets_updated,
+            duration_ms: out.duration_ms,
+            source: ActivitySource::Http,
+        });
+        self.state.emit(self.aggregate_status_event());
+        Ok(out)
+    }
+
+    // -----------------------------------------------------------------
+    // Activity log
+    // -----------------------------------------------------------------
+
+    /// Paginated activity-log read.
+    pub async fn list_activity(
+        &self,
+        filter: ActivityFilter,
+        limit: usize,
+        offset: usize,
+    ) -> ServiceResult<(Vec<crate::ActivityEntry>, u64)> {
+        let entries = self
+            .state
+            .activity_log
+            .list(&filter, limit, offset)
+            .map_err(|e| ServiceError::internal(format!("activity list: {e:#}")))?;
+        let total = self
+            .state
+            .activity_log
+            .count()
+            .map_err(|e| ServiceError::internal(format!("activity count: {e:#}")))?;
+        Ok((entries, total))
+    }
+
+    // -----------------------------------------------------------------
+    // Internal helper — open a palace handle or return 404.
+    // -----------------------------------------------------------------
+
+    /// Open the named palace, returning `ServiceError::NotFound` on failure.
+    pub fn open_handle(&self, id: &str) -> ServiceResult<Arc<PalaceHandle>> {
+        self.state
+            .registry
+            .open_palace(&self.state.data_root, &PalaceId::new(id))
+            .map_err(|e| ServiceError::not_found(format!("palace not found: {id} ({e:#})")))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helper functions kept module-public so `web.rs` and `chat.rs` can use
+// them without going through the `MemoryService` wrapper. Each is a thin
+// transform (no IO, no global state).
+// ---------------------------------------------------------------------------
+
+/// Maximum characters retained in a drawer's content preview.
+pub const DRAWER_PREVIEW_MAX_CHARS: usize = 80;
+
+/// Build a single-line preview of drawer content for SSE events.
+///
+/// Why: the activity feed should show *what* was just stored; multiline /
+/// whitespace-heavy bodies otherwise blow out the log row.
+/// What: collapses whitespace, trims, truncates to
+/// [`DRAWER_PREVIEW_MAX_CHARS`] with `…` when cut.
+/// Test: `drawer_preview_collapses_whitespace_and_truncates`.
+pub fn drawer_content_preview(content: &str) -> String {
+    let normalised: String = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalised.chars().count() <= DRAWER_PREVIEW_MAX_CHARS {
+        normalised
+    } else {
+        let kept: String = normalised
+            .chars()
+            .take(DRAWER_PREVIEW_MAX_CHARS.saturating_sub(1))
+            .collect();
+        format!("{kept}…")
+    }
+}
+
+/// Flatten a [`RecallResult`] into a single JSON object with the drawer's
+/// fields hoisted to the top level (issue #69 shape).
+///
+/// Why: clients look for `content`/`tags`/`importance` at the top level of an
+/// entry; nesting under `"drawer"` made recall appear empty.
+/// What: serialises the drawer then inserts `score`/`layer`.
+/// Test: `recall_entry_json_hoists_drawer_fields`.
+pub fn recall_entry_json(r: RecallResult) -> Value {
+    let mut obj = match serde_json::to_value(&r.drawer) {
+        Ok(Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    };
+    obj.insert("score".to_string(), json!(r.score));
+    obj.insert("layer".to_string(), json!(r.layer));
+    Value::Object(obj)
+}
+
+/// Build a `PalaceInfo` from a `Palace` row plus an optional opened handle.
+///
+/// Why: both `list_palaces` and `get_palace` need the same enriched shape;
+/// the helper avoids field-set drift between them.
+/// What: reads drawer/vector/triple counts, distinct rooms, max
+/// `created_at`, KG node/edge/community counts, and the `is_compacting` flag.
+/// Test: `palace_list_includes_richer_counts`, `palace_list_includes_graph_counts`.
+pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> PalaceInfo {
+    let (
+        drawer_count,
+        vector_count,
+        kg_triple_count,
+        wing_count,
+        last_write_at,
+        node_count,
+        edge_count,
+        community_count,
+        is_compacting,
+    ) = if let Some(h) = handle {
+        let drawers = h.drawers.read();
+        let distinct_rooms: HashSet<Uuid> = drawers.iter().map(|d| d.room_id).collect();
+        let last_write = drawers.iter().map(|d| d.created_at).max();
+        (
+            drawers.len(),
+            h.vector_store.index_size(),
+            h.kg.count_active_triples(),
+            distinct_rooms.len(),
+            last_write,
+            h.kg.node_count() as u64,
+            h.kg.edge_count() as u64,
+            h.kg.community_count() as u64,
+            h.is_compacting(),
+        )
+    } else {
+        (0, 0, 0, 0, None, 0, 0, 0, false)
+    };
+    PalaceInfo {
+        id: palace.id.0.clone(),
+        name: palace.name.clone(),
+        description: palace.description.clone(),
+        drawer_count,
+        vector_count,
+        kg_triple_count,
+        wing_count,
+        created_at: palace.created_at,
+        last_write_at,
+        node_count,
+        edge_count,
+        community_count,
+        is_compacting,
+    }
+}
+
+/// Recompute the gaps for `handle` and write them to the registry cache.
+///
+/// Why: the dream-run path needs this post-cycle bookkeeping; pulling it out
+/// of `web.rs` keeps the dream code on one side of the wall.
+/// What: calls `knowledge_gaps()`, optionally enriches via
+/// `enrich_gap_exploration`, stores on `state.registry`. Logs gap count.
+/// Test: indirectly via `kg_gaps_endpoint_returns_cached_gaps`.
+pub async fn refresh_gaps_cache(state: &AppState, handle: &Arc<PalaceHandle>) {
+    let mut gaps = handle.kg.knowledge_gaps();
+    if let Ok(api_key) = std::env::var("OPENROUTER_API_KEY") {
+        if !api_key.is_empty() {
+            for gap in gaps.iter_mut() {
+                if let Some(enriched) = enrich_gap_exploration(&api_key, gap).await {
+                    gap.suggested_exploration = enriched;
+                }
+            }
+        }
+    }
+    let gap_count = gaps.len();
+    state.registry.set_gaps(handle.id.clone(), gaps);
+    tracing::debug!(palace = %handle.id, gaps = gap_count, "community gaps updated");
+}
+
+/// Ask OpenRouter for a focused exploration question for a single gap.
+///
+/// Why: see `refresh_gaps_cache`.
+/// What: builds a short user prompt, calls `openrouter_chat`, returns the
+/// trimmed completion (or `None` on any failure).
+/// Test: network-dependent — not unit-tested.
+pub async fn enrich_gap_exploration(
+    api_key: &str,
+    gap: &trusty_common::memory_core::community::KnowledgeGap,
+) -> Option<String> {
+    let preview: Vec<&str> = gap.entities.iter().take(5).map(String::as_str).collect();
+    if preview.is_empty() {
+        return None;
+    }
+    let entities = preview.join(", ");
+    let user = format!(
+        "Given these related entities from a knowledge graph: {entities}. \
+         Suggest one specific research question (single sentence, under 25 words) \
+         that would help fill gaps in this knowledge cluster. Return only the question."
+    );
+    let messages = vec![trusty_common::ChatMessage {
+        role: "user".to_string(),
+        content: user,
+        tool_call_id: None,
+        tool_calls: None,
+    }];
+    #[allow(deprecated)]
+    let res = trusty_common::openrouter_chat(api_key, "openai/gpt-4o-mini", messages).await;
+    match res {
+        Ok(text) => {
+            let trimmed = text.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        }
+        Err(e) => {
+            tracing::debug!("openrouter gap enrichment failed (using template): {e:#}");
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// User config — moved from `web.rs` so chat and HTTP both load it cheaply.
+// ---------------------------------------------------------------------------
+
+/// Minimal mirror of the user-config schema.
+#[derive(Deserialize, Default, Clone)]
+struct UserConfigMin {
+    #[serde(default)]
+    openrouter: OpenRouterMin,
+    #[serde(default)]
+    local_model: LocalModelMin,
+}
+
+#[derive(Deserialize, Default, Clone)]
+struct OpenRouterMin {
+    #[serde(default)]
+    api_key: String,
+    #[serde(default)]
+    model: String,
+}
+
+#[derive(Deserialize, Clone)]
+struct LocalModelMin {
+    #[serde(default = "default_local_enabled")]
+    enabled: bool,
+    #[serde(default = "default_local_base_url")]
+    base_url: String,
+    #[serde(default = "default_local_model")]
+    model: String,
+}
+
+fn default_local_enabled() -> bool {
+    true
+}
+fn default_local_base_url() -> String {
+    "http://localhost:11434".to_string()
+}
+fn default_local_model() -> String {
+    "llama3.2".to_string()
+}
+
+impl Default for LocalModelMin {
+    fn default() -> Self {
+        Self {
+            enabled: default_local_enabled(),
+            base_url: default_local_base_url(),
+            model: default_local_model(),
+        }
+    }
+}
+
+/// Loaded user config (mirrors the public `LoadedUserConfig` from `web.rs`).
+#[derive(Clone)]
+pub struct LoadedUserConfig {
+    pub openrouter_api_key: String,
+    pub openrouter_model: String,
+    pub local_model: trusty_common::LocalModelConfig,
+}
+
+impl Default for LoadedUserConfig {
+    fn default() -> Self {
+        Self {
+            openrouter_api_key: String::new(),
+            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
+            local_model: trusty_common::LocalModelConfig::default(),
+        }
+    }
+}
+
+/// Read the user's `~/.trusty-memory/config.toml`, falling back to defaults.
+///
+/// Why: shared between HTTP config endpoint, chat tool dispatch, and
+/// provider auto-detection.
+/// What: returns `Some(LoadedUserConfig)` even when the file is missing
+/// (so callers see defaults consistently); `None` only when the home
+/// directory itself can't be resolved.
+/// Test: indirectly via `config_endpoint_returns_payload`.
+pub fn load_user_config() -> Option<LoadedUserConfig> {
+    let home = dirs::home_dir()?;
+    let path = home.join(".trusty-memory").join("config.toml");
+    if !path.exists() {
+        return Some(LoadedUserConfig::default());
+    }
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let parsed: UserConfigMin = toml::from_str(&raw).unwrap_or_default();
+    let model = if parsed.openrouter.model.is_empty() {
+        "anthropic/claude-3-5-sonnet".to_string()
+    } else {
+        parsed.openrouter.model
+    };
+    Some(LoadedUserConfig {
+        openrouter_api_key: parsed.openrouter.api_key,
+        openrouter_model: model,
+        local_model: trusty_common::LocalModelConfig {
+            enabled: parsed.local_model.enabled,
+            base_url: parsed.local_model.base_url,
+            model: parsed.local_model.model,
+        },
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Convenience helpers for callers that want `anyhow::Result<Value>` shape.
+// ---------------------------------------------------------------------------
+
+/// Convert a `ServiceResult<T>` into `anyhow::Result<Value>` using a serializer.
+///
+/// Why: the chat tool dispatcher needs uniform `Result<Value>` returns to
+/// shove into the LLM's `role: "tool"` message.
+/// What: serialises `T` to JSON; on `Err`, returns the message as an
+/// `anyhow::Error`. The HTTP layer does *not* go through this — it preserves
+/// the `ServiceError` variant for status-code mapping.
+/// Test: trivial wrapper; covered indirectly by the chat tests.
+pub fn service_result_to_anyhow<T: serde::Serialize>(r: ServiceResult<T>) -> Result<Value> {
+    match r {
+        Ok(v) => serde_json::to_value(v).context("serialize service result"),
+        Err(e) => Err(anyhow!("{e}")),
     }
 }

--- a/crates/trusty-memory/src/web.rs
+++ b/crates/trusty-memory/src/web.rs
@@ -26,16 +26,11 @@ use axum::{
 use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashSet;
-use std::sync::Arc;
 use trusty_common::memory_core::community::KnowledgeGap;
-use trusty_common::memory_core::dream::{DreamConfig, Dreamer, PersistedDreamStats};
-use trusty_common::memory_core::palace::{Palace, PalaceId, RoomType};
-use trusty_common::memory_core::retrieval::{
-    recall_deep_with_default_embedder, recall_with_default_embedder, RecallResult,
-};
+use trusty_common::memory_core::palace::{PalaceId, RoomType};
+use trusty_common::memory_core::retrieval::recall_with_default_embedder;
 use trusty_common::memory_core::store::kg::Triple;
-use trusty_common::memory_core::{PalaceHandle, PalaceRegistry};
+use trusty_common::memory_core::PalaceRegistry;
 use uuid::Uuid;
 
 /// Embedded UI assets produced by `pnpm build` in `ui/`.
@@ -706,37 +701,10 @@ fn serve_embedded(path: &str) -> Option<Response> {
 // /api/v1/status, /api/v1/config
 // ---------------------------------------------------------------------------
 
-#[derive(Serialize)]
-struct StatusPayload {
-    version: String,
-    palace_count: usize,
-    default_palace: Option<String>,
-    data_root: String,
-    total_drawers: usize,
-    total_vectors: usize,
-    total_kg_triples: usize,
-}
+pub(crate) use crate::service::StatusPayload;
 
 async fn status(State(state): State<AppState>) -> Json<StatusPayload> {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
-    let palace_count = palaces.len();
-    let (mut total_drawers, mut total_vectors, mut total_kg_triples) = (0usize, 0usize, 0usize);
-    for p in &palaces {
-        if let Ok(handle) = state.registry.open_palace(&state.data_root, &p.id) {
-            total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
-            total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
-            total_kg_triples = total_kg_triples.saturating_add(handle.kg.count_active_triples());
-        }
-    }
-    Json(StatusPayload {
-        version: state.version.clone(),
-        palace_count,
-        default_palace: state.default_palace.clone(),
-        data_root: state.data_root.display().to_string(),
-        total_drawers,
-        total_vectors,
-        total_kg_triples,
-    })
+    Json(crate::service::MemoryService::new(state).status().await)
 }
 
 #[derive(Serialize)]
@@ -755,339 +723,61 @@ async fn config(State(state): State<AppState>) -> Json<ConfigPayload> {
     })
 }
 
-/// Minimal mirror of the user-config schema (the real type lives in the bin
-/// crate; replicating just the fields we need here avoids a cyclic dep).
-#[derive(Deserialize, Default, Clone)]
-struct UserConfigMin {
-    #[serde(default)]
-    openrouter: OpenRouterMin,
-    #[serde(default)]
-    local_model: LocalModelMin,
-    // Carry forward unknown sections by ignoring them on parse.
-}
-
-#[derive(Deserialize, Default, Clone)]
-struct OpenRouterMin {
-    #[serde(default)]
-    api_key: String,
-    #[serde(default)]
-    model: String,
-}
-
-#[derive(Deserialize, Clone)]
-struct LocalModelMin {
-    #[serde(default = "default_local_enabled")]
-    enabled: bool,
-    #[serde(default = "default_local_base_url")]
-    base_url: String,
-    #[serde(default = "default_local_model")]
-    model: String,
-}
-
-fn default_local_enabled() -> bool {
-    true
-}
-fn default_local_base_url() -> String {
-    "http://localhost:11434".to_string()
-}
-fn default_local_model() -> String {
-    "llama3.2".to_string()
-}
-
-impl Default for LocalModelMin {
-    fn default() -> Self {
-        Self {
-            enabled: default_local_enabled(),
-            base_url: default_local_base_url(),
-            model: default_local_model(),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct LoadedUserConfig {
-    pub(crate) openrouter_api_key: String,
-    pub(crate) openrouter_model: String,
-    pub(crate) local_model: trusty_common::LocalModelConfig,
-}
-
-impl Default for LoadedUserConfig {
-    fn default() -> Self {
-        Self {
-            openrouter_api_key: String::new(),
-            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
-            local_model: trusty_common::LocalModelConfig::default(),
-        }
-    }
-}
-
-pub(crate) fn load_user_config() -> Option<LoadedUserConfig> {
-    let home = dirs::home_dir()?;
-    let path = home.join(".trusty-memory").join("config.toml");
-    if !path.exists() {
-        return Some(LoadedUserConfig::default());
-    }
-    let raw = std::fs::read_to_string(&path).ok()?;
-    let parsed: UserConfigMin = toml::from_str(&raw).unwrap_or_default();
-    let model = if parsed.openrouter.model.is_empty() {
-        "anthropic/claude-3-5-sonnet".to_string()
-    } else {
-        parsed.openrouter.model
-    };
-    Some(LoadedUserConfig {
-        openrouter_api_key: parsed.openrouter.api_key,
-        openrouter_model: model,
-        local_model: trusty_common::LocalModelConfig {
-            enabled: parsed.local_model.enabled,
-            base_url: parsed.local_model.base_url,
-            model: parsed.local_model.model,
-        },
-    })
-}
+pub(crate) use crate::service::load_user_config;
+#[allow(unused_imports)]
+pub(crate) use crate::service::LoadedUserConfig;
 
 // ---------------------------------------------------------------------------
 // /api/v1/palaces
 // ---------------------------------------------------------------------------
 
-#[derive(Serialize)]
-pub(crate) struct PalaceInfo {
-    id: String,
-    name: String,
-    description: Option<String>,
-    drawer_count: usize,
-    vector_count: usize,
-    kg_triple_count: usize,
-    wing_count: usize,
-    created_at: chrono::DateTime<chrono::Utc>,
-    /// Max `created_at` across this palace's drawers, or `None` if empty.
-    ///
-    /// Why: The UI "sort by activity" mode needs a single timestamp per
-    /// palace so operators can spot recently-written palaces. Computing it
-    /// from the loaded drawer set avoids adding a per-write update path or a
-    /// new on-disk index.
-    /// What: `handle.drawers.read().iter().map(|d| d.created_at).max()`.
-    /// Null when the handle is unavailable or the palace has zero drawers.
-    /// Test: `palace_list_includes_last_write_at` (web tests, added below).
-    last_write_at: Option<chrono::DateTime<chrono::Utc>>,
-    /// Distinct-entity count in the KG adjacency (zero when no handle).
-    ///
-    /// Why: The operator TUI surfaces graph breadth alongside triple count;
-    /// a separate field avoids re-querying the KG for every dashboard tick.
-    /// What: `handle.kg.node_count()`. `#[serde(default)]` so older clients
-    /// that don't know the field still deserialise the payload.
-    /// Test: `palace_list_includes_graph_counts`.
-    #[serde(default)]
-    node_count: u64,
-    /// Directed-edge count in the KG adjacency (zero when no handle).
-    ///
-    /// Why: Companion to `node_count` for density at a glance.
-    /// What: `handle.kg.edge_count()`. `#[serde(default)]` for forward-compat.
-    /// Test: `palace_list_includes_graph_counts`.
-    #[serde(default)]
-    edge_count: u64,
-    /// Number of Louvain communities detected in the KG (zero when no handle).
-    ///
-    /// Why: The MEMORY tab shows a community tally so operators can spot
-    /// clustering at a glance without opening the KG explorer.
-    /// What: `handle.kg.community_count()`. `#[serde(default)]` for
-    /// forward-compat.
-    /// Test: `palace_list_includes_graph_counts`.
-    #[serde(default)]
-    community_count: u64,
-    /// `true` while a `Dreamer::dream_cycle` is running against this palace.
-    ///
-    /// Why: Drives the dreaming/compacting spinner in the operator TUI; the
-    /// dashboard polls `/api/v1/palaces` and needs a single boolean signal.
-    /// What: `handle.is_compacting()`, set by `CompactionGuard` in
-    /// `trusty_common::memory_core::dream`. `#[serde(default)]` so old clients
-    /// that don't expect the field deserialise as `false`.
-    /// Test: `palace_list_includes_graph_counts`.
-    #[serde(default)]
-    is_compacting: bool,
-}
-
-/// Build a `PalaceInfo` from a `Palace` row plus an optional opened handle.
-///
-/// Why: Both `list_palaces` and `get_palace_handler` need the same enriched
-/// shape; centralizing the field-pulling avoids drift.
-/// What: Reads drawer count, vector index size, active KG triple count, and
-/// derives wing_count from the number of distinct `room_id`s in the drawer
-/// table (until a dedicated wings/rooms table exists, distinct rooms-by-drawer
-/// is the closest proxy).
-/// Test: `palace_list_includes_richer_counts`.
-pub(crate) fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> PalaceInfo {
-    let (
-        drawer_count,
-        vector_count,
-        kg_triple_count,
-        wing_count,
-        last_write_at,
-        node_count,
-        edge_count,
-        community_count,
-        is_compacting,
-    ) = if let Some(h) = handle {
-        let drawers = h.drawers.read();
-        let distinct_rooms: HashSet<Uuid> = drawers.iter().map(|d| d.room_id).collect();
-        let last_write = drawers.iter().map(|d| d.created_at).max();
-        (
-            drawers.len(),
-            h.vector_store.index_size(),
-            h.kg.count_active_triples(),
-            distinct_rooms.len(),
-            last_write,
-            h.kg.node_count() as u64,
-            h.kg.edge_count() as u64,
-            h.kg.community_count() as u64,
-            h.is_compacting(),
-        )
-    } else {
-        (0, 0, 0, 0, None, 0, 0, 0, false)
-    };
-    PalaceInfo {
-        id: palace.id.0.clone(),
-        name: palace.name.clone(),
-        description: palace.description.clone(),
-        drawer_count,
-        vector_count,
-        kg_triple_count,
-        wing_count,
-        created_at: palace.created_at,
-        last_write_at,
-        node_count,
-        edge_count,
-        community_count,
-        is_compacting,
-    }
-}
+pub(crate) use crate::service::{palace_info_from, CreatePalaceBody, PalaceInfo};
 
 async fn list_palaces(State(state): State<AppState>) -> Result<Json<Vec<PalaceInfo>>, ApiError> {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root)
-        .map_err(|e| ApiError::internal(format!("list palaces: {e:#}")))?;
-    let mut out = Vec::with_capacity(palaces.len());
-    for p in palaces {
-        let handle = state.registry.open_palace(&state.data_root, &p.id).ok();
-        out.push(palace_info_from(&p, handle.as_ref()));
-    }
-    Ok(Json(out))
-}
-
-#[derive(Deserialize)]
-struct CreatePalaceBody {
-    name: String,
-    #[serde(default)]
-    description: Option<String>,
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .list_palaces()
+            .await?,
+    ))
 }
 
 async fn create_palace(
     State(state): State<AppState>,
     Json(body): Json<CreatePalaceBody>,
 ) -> Result<Json<Value>, ApiError> {
-    let name = body.name.trim().to_string();
-    if name.is_empty() {
-        return Err(ApiError::bad_request("name is required"));
-    }
-    let id = PalaceId::new(&name);
-    let palace = Palace {
-        id: id.clone(),
-        name: name.clone(),
-        description: body.description.filter(|s| !s.is_empty()),
-        created_at: chrono::Utc::now(),
-        data_dir: state.data_root.join(&name),
-    };
-    state
-        .registry
-        .create_palace(&state.data_root, palace)
-        .map_err(|e| ApiError::internal(format!("create palace: {e:#}")))?;
-    state.emit(DaemonEvent::PalaceCreated {
-        id: name.clone(),
-        name: name.clone(),
-        source: ActivitySource::Http,
-    });
-    Ok(Json(json!({ "id": name })))
+    let id = crate::service::MemoryService::new(state)
+        .create_palace(body, ActivitySource::Http)
+        .await?;
+    Ok(Json(json!({ "id": id })))
 }
 
 async fn get_palace_handler(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<PalaceInfo>, ApiError> {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root)
-        .map_err(|e| ApiError::internal(format!("list palaces: {e:#}")))?;
-    let palace = palaces
-        .into_iter()
-        .find(|p| p.id.0 == id)
-        .ok_or_else(|| ApiError::not_found(format!("palace not found: {id}")))?;
-    let handle = state
-        .registry
-        .open_palace(&state.data_root, &palace.id)
-        .ok();
-    Ok(Json(palace_info_from(&palace, handle.as_ref())))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .get_palace(&id)
+            .await?,
+    ))
 }
 
 // ---------------------------------------------------------------------------
 // Drawers
 // ---------------------------------------------------------------------------
 
-#[derive(Deserialize)]
-struct ListDrawersQuery {
-    #[serde(default)]
-    room: Option<String>,
-    #[serde(default)]
-    tag: Option<String>,
-    #[serde(default)]
-    limit: Option<usize>,
-}
+pub(crate) use crate::service::{drawer_content_preview, CreateDrawerBody, ListDrawersQuery};
 
 async fn list_drawers(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
     Query(q): Query<ListDrawersQuery>,
 ) -> Result<Json<Value>, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let room = q.room.as_deref().map(RoomType::parse);
-    let drawers = handle.list_drawers(room, q.tag.clone(), q.limit.unwrap_or(50));
-    Ok(Json(serde_json::to_value(drawers).unwrap_or(json!([]))))
-}
-
-#[derive(Deserialize)]
-struct CreateDrawerBody {
-    content: String,
-    #[serde(default)]
-    room: Option<String>,
-    #[serde(default)]
-    tags: Vec<String>,
-    #[serde(default)]
-    importance: Option<f32>,
-}
-
-/// Maximum number of characters retained in a drawer's content preview.
-///
-/// Why: SSE consumers (TUI activity log, dashboard ticker) render the
-/// preview in a single line alongside the palace name; ~80 chars keeps the
-/// line readable on a 100-column terminal without truncating the palace
-/// label.
-const DRAWER_PREVIEW_MAX_CHARS: usize = 80;
-
-/// Build a single-line preview of drawer content for SSE events.
-///
-/// Why: the activity feed should show *what* was just stored, not only the
-/// running drawer count. Multiline / whitespace-heavy bodies otherwise blow
-/// out the log row, so we normalise whitespace and bound the length.
-/// What: collapses every run of ASCII / Unicode whitespace to a single space,
-/// trims leading/trailing whitespace, and truncates to
-/// [`DRAWER_PREVIEW_MAX_CHARS`] characters with a trailing `…` when cut.
-/// Test: `drawer_preview_collapses_whitespace_and_truncates`.
-pub(crate) fn drawer_content_preview(content: &str) -> String {
-    let normalised: String = content.split_whitespace().collect::<Vec<_>>().join(" ");
-    if normalised.chars().count() <= DRAWER_PREVIEW_MAX_CHARS {
-        normalised
-    } else {
-        let kept: String = normalised
-            .chars()
-            .take(DRAWER_PREVIEW_MAX_CHARS.saturating_sub(1))
-            .collect();
-        format!("{kept}…")
-    }
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .list_drawers(&id, q)
+            .await?,
+    ))
 }
 
 async fn create_drawer(
@@ -1096,60 +786,10 @@ async fn create_drawer(
     headers: HeaderMap,
     Json(body): Json<CreateDrawerBody>,
 ) -> Result<Json<Value>, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let room = body
-        .room
-        .as_deref()
-        .map(RoomType::parse)
-        .unwrap_or(RoomType::General);
-    let importance = body.importance.unwrap_or(0.5);
-    // Compute the preview *before* moving `body.content` into `remember` so
-    // the SSE activity feed can show what was actually stored.
-    let content_preview = drawer_content_preview(&body.content);
-    // Submission-logging Part B: attach `creator:*` attribution tags so
-    // every drawer carries the identity of the client that wrote it.
-    // HTTP clients self-identify via `X-Trusty-Client-Name` /
-    // `X-Trusty-Client-Cwd`; absent headers fall back to
-    // `unknown-http-client` and an empty cwd.
     let creator = creator_info_from_http(&headers);
-    let mut tags_with_creator = body.tags;
-    creator.merge_into(&mut tags_with_creator);
-    // Issue #133: mirror the MCP `memory_remember` path — keep originals so
-    // the auto-KG extractor sees the same content / tags / room that landed
-    // in the drawer. `remember` consumes them, so clone before the call.
-    let content_for_kg = body.content.clone();
-    let tags_for_kg = tags_with_creator.clone();
-    let room_label_for_kg = crate::tools::room_label(&room);
-    let drawer_id = handle
-        .remember(body.content, room, tags_with_creator, importance)
-        .await
-        .map_err(|e| ApiError::internal(format!("remember: {e:#}")))?;
-    let drawer_count = handle.drawers.read().len();
-    let palace_name = PalaceRegistry::list_palaces(&state.data_root)
-        .ok()
-        .and_then(|ps| ps.into_iter().find(|p| p.id.0 == id).map(|p| p.name))
-        .unwrap_or_else(|| id.clone());
-    state.emit(DaemonEvent::DrawerAdded {
-        palace_id: id.clone(),
-        palace_name,
-        drawer_count,
-        timestamp: chrono::Utc::now(),
-        content_preview,
-        source: ActivitySource::Http,
-    });
-    state.emit(aggregate_status_event(&state));
-    // Issue #133: best-effort auto-KG extraction. Mirrors the MCP path
-    // (`tools.rs::memory_remember`). Failures during extraction MUST NOT
-    // fail the HTTP write — the drawer is already on disk; the extractor
-    // logs warnings and swallows errors internally.
-    crate::tools::auto_extract_and_assert(
-        &handle,
-        drawer_id,
-        &content_for_kg,
-        &tags_for_kg,
-        room_label_for_kg.as_deref(),
-    )
-    .await;
+    let drawer_id = crate::service::MemoryService::new(state)
+        .create_drawer(&id, body, creator, ActivitySource::Http)
+        .await?;
     Ok(Json(json!({ "id": drawer_id })))
 }
 
@@ -1157,46 +797,15 @@ async fn delete_drawer(
     State(state): State<AppState>,
     AxumPath((id, drawer_id)): AxumPath<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let uuid = Uuid::parse_str(&drawer_id)
-        .map_err(|_| ApiError::bad_request("drawer_id must be a UUID"))?;
-    handle
-        .forget(uuid)
-        .await
-        .map_err(|e| ApiError::internal(format!("forget: {e:#}")))?;
-    let drawer_count = handle.drawers.read().len();
-    state.emit(DaemonEvent::DrawerDeleted {
-        palace_id: id.clone(),
-        drawer_count,
-        source: ActivitySource::Http,
-    });
-    state.emit(aggregate_status_event(&state));
+    crate::service::MemoryService::new(state)
+        .delete_drawer(&id, &drawer_id, ActivitySource::Http)
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// Compute the current aggregate `StatusChanged` event by walking all palaces.
-///
-/// Why: Several mutating handlers (drawer add/delete, dream run) need to push
-/// a refreshed status snapshot so dashboard stat cards stay in sync without
-/// the SPA having to issue an extra `/api/v1/status` request.
-/// What: Mirrors the math in the `status` handler — sums drawer count,
-/// vector index size, and active KG triples across every persisted palace.
-/// Test: Indirectly via the SSE integration tests that observe the event.
+/// Backwards-compat re-export — the implementation now lives in `service`.
 pub(crate) fn aggregate_status_event(state: &AppState) -> DaemonEvent {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
-    let (mut total_drawers, mut total_vectors, mut total_kg_triples) = (0usize, 0usize, 0usize);
-    for p in &palaces {
-        if let Ok(handle) = state.registry.open_palace(&state.data_root, &p.id) {
-            total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
-            total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
-            total_kg_triples = total_kg_triples.saturating_add(handle.kg.count_active_triples());
-        }
-    }
-    DaemonEvent::StatusChanged {
-        total_drawers,
-        total_vectors,
-        total_kg_triples,
-    }
+    crate::service::MemoryService::new(state.clone()).aggregate_status_event()
 }
 
 // ---------------------------------------------------------------------------
@@ -1217,44 +826,15 @@ async fn recall_handler(
     AxumPath(id): AxumPath<String>,
     Query(q): Query<RecallQuery>,
 ) -> Result<Json<Value>, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let top_k = q.top_k.unwrap_or(10);
-    let results = if q.deep.unwrap_or(false) {
-        recall_deep_with_default_embedder(&handle, &q.q, top_k).await
-    } else {
-        recall_with_default_embedder(&handle, &q.q, top_k).await
-    }
-    .map_err(|e| ApiError::internal(format!("recall: {e:#}")))?;
-
-    let payload: Vec<Value> = results.into_iter().map(recall_entry_json).collect();
-    Ok(Json(json!(payload)))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .recall(&id, &q.q, q.top_k.unwrap_or(10), q.deep.unwrap_or(false))
+            .await?,
+    ))
 }
 
-/// Flatten a [`RecallResult`] into a single JSON object with the drawer's
-/// fields hoisted to the top level.
-///
-/// Why: Issue #69 — the recall API previously nested the drawer under a
-/// `"drawer"` wrapper (`{"drawer": {"content": …}, "score": …}`), so every
-/// client that looked for `content`/`tags`/`importance` at the top level of an
-/// entry got nothing and recall always appeared to return `[]`. Hoisting the
-/// drawer fields makes `content` directly reachable while keeping `score` and
-/// `layer` alongside as ranking metadata.
-/// What: Serializes the [`Drawer`](trusty_common::memory_core::Drawer) to a
-/// JSON object and inserts `score` and `layer`. The `Drawer` schema has no
-/// `score`/`layer` keys, so there is no field collision. Falls back to a
-/// `{"score", "layer"}`-only object if the drawer fails to serialize (it never
-/// should — `Drawer` is plain `#[derive(Serialize)]` data).
-/// Test: `recall_entry_json_hoists_drawer_fields` asserts `content` is at the
-/// top level and the `drawer` wrapper key is absent.
-fn recall_entry_json(r: RecallResult) -> Value {
-    let mut obj = match serde_json::to_value(&r.drawer) {
-        Ok(Value::Object(map)) => map,
-        _ => serde_json::Map::new(),
-    };
-    obj.insert("score".to_string(), json!(r.score));
-    obj.insert("layer".to_string(), json!(r.layer));
-    Value::Object(obj)
-}
+#[allow(unused_imports)]
+pub(crate) use crate::service::recall_entry_json;
 
 /// `GET /api/v1/recall?q=<query>&top_k=<n>&deep=<bool>` — cross-palace semantic
 /// search.
@@ -1273,9 +853,9 @@ async fn recall_all_handler(
     State(state): State<AppState>,
     Query(q): Query<RecallQuery>,
 ) -> Result<Json<Value>, ApiError> {
-    let top_k = q.top_k.unwrap_or(10);
-    let deep = q.deep.unwrap_or(false);
-    let value = crate::chat::execute_recall_all(&state, &q.q, top_k, deep).await;
+    let value = crate::service::MemoryService::new(state)
+        .recall_all(&q.q, q.top_k.unwrap_or(10), q.deep.unwrap_or(false))
+        .await;
     if let Some(err) = value.get("error").and_then(|v| v.as_str()) {
         return Err(ApiError::internal(err.to_string()));
     }
@@ -1296,46 +876,23 @@ async fn kg_query(
     AxumPath(id): AxumPath<String>,
     Query(q): Query<KgQueryParams>,
 ) -> Result<Json<Vec<Triple>>, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let triples = handle
-        .kg
-        .query_active(&q.subject)
-        .await
-        .map_err(|e| ApiError::internal(format!("kg query: {e:#}")))?;
-    Ok(Json(triples))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .kg_query(&id, &q.subject)
+            .await?,
+    ))
 }
 
-#[derive(Deserialize)]
-struct KgAssertBody {
-    subject: String,
-    predicate: String,
-    object: String,
-    #[serde(default)]
-    confidence: Option<f32>,
-    #[serde(default)]
-    provenance: Option<String>,
-}
+pub(crate) use crate::service::KgAssertBody;
 
 async fn kg_assert(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
     Json(body): Json<KgAssertBody>,
 ) -> Result<StatusCode, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let triple = Triple {
-        subject: body.subject,
-        predicate: body.predicate,
-        object: body.object,
-        valid_from: chrono::Utc::now(),
-        valid_to: None,
-        confidence: body.confidence.unwrap_or(1.0),
-        provenance: body.provenance,
-    };
-    handle
-        .kg
-        .assert(triple)
-        .await
-        .map_err(|e| ApiError::internal(format!("kg assert: {e:#}")))?;
+    crate::service::MemoryService::new(state)
+        .kg_assert(&id, body)
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1383,13 +940,12 @@ async fn kg_list_subjects(
     AxumPath(id): AxumPath<String>,
     Query(q): Query<KgListSubjectsParams>,
 ) -> Result<Json<Vec<String>>, ApiError> {
-    let handle = open_handle(&state, &id)?;
     let limit = q.limit.clamp(1, MAX_KG_LIST_LIMIT);
-    let subjects = handle
-        .kg
-        .list_subjects(limit)
-        .map_err(|e| ApiError::internal(format!("kg list_subjects: {e:#}")))?;
-    Ok(Json(subjects))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .kg_list_subjects(&id, limit)
+            .await?,
+    ))
 }
 
 /// `GET /api/v1/palaces/{id}/kg/subjects_with_counts?limit=N` — list distinct
@@ -1408,12 +964,10 @@ async fn kg_list_subjects_with_counts(
     AxumPath(id): AxumPath<String>,
     Query(q): Query<KgListSubjectsParams>,
 ) -> Result<Json<Vec<Value>>, ApiError> {
-    let handle = open_handle(&state, &id)?;
     let limit = q.limit.clamp(1, MAX_KG_LIST_LIMIT);
-    let rows = handle
-        .kg
-        .list_subjects_with_counts(limit)
-        .map_err(|e| ApiError::internal(format!("kg list_subjects_with_counts: {e:#}")))?;
+    let rows = crate::service::MemoryService::new(state)
+        .kg_list_subjects_with_counts(&id, limit)
+        .await?;
     let out: Vec<Value> = rows
         .into_iter()
         .map(|(subject, count)| json!({ "subject": subject, "count": count }))
@@ -1448,14 +1002,12 @@ async fn kg_list_all(
     AxumPath(id): AxumPath<String>,
     Query(q): Query<KgListAllParams>,
 ) -> Result<Json<Vec<Triple>>, ApiError> {
-    let handle = open_handle(&state, &id)?;
     let limit = q.limit.clamp(1, MAX_KG_LIST_LIMIT);
-    let triples = handle
-        .kg
-        .list_active(limit, q.offset)
-        .await
-        .map_err(|e| ApiError::internal(format!("kg list_active: {e:#}")))?;
-    Ok(Json(triples))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .kg_list_all(&id, limit, q.offset)
+            .await?,
+    ))
 }
 
 /// `GET /api/v1/palaces/{id}/kg/count` — count of currently-active triples.
@@ -1469,203 +1021,56 @@ async fn kg_count(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<Value>, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let active = handle.kg.count_active_triples();
+    let active = crate::service::MemoryService::new(state)
+        .kg_count(&id)
+        .await?;
     Ok(Json(json!({ "active": active })))
 }
 
-/// Wire shape returned by `/api/v1/palaces/{id}/kg/graph`.
-///
-/// Why: Issue #97 — the per-palace visual graph view needs a single payload
-/// containing every active triple plus a node-level community count so the
-/// UI can color-code clusters. Splitting into nodes/edges client-side lets
-/// d3-force own the layout while keeping the wire shape compact.
-/// What: `triples` carries the raw `(s, p, o)` list; `community_count` lets
-/// the SPA decide whether to color-code clusters (zero ⇒ no Louvain pass
-/// has run).
-/// Test: `kg_graph_returns_active_triples`.
-#[derive(Serialize)]
-struct KgGraphPayload {
-    triples: Vec<Triple>,
-    node_count: u64,
-    edge_count: u64,
-    community_count: u64,
-}
+pub(crate) use crate::service::KgGraphPayload;
 
-/// Hard cap on triples returned by the per-palace graph endpoint.
-///
-/// Why: The visual graph is unusable past a few thousand triples regardless
-/// of how fast the daemon serves the payload. The spec target is "<1s for
-/// palaces with <500 triples"; this cap protects the daemon from a runaway
-/// fetch on a pathologically large palace.
-/// What: `5_000` — well above the issue's 500-triple sanity benchmark while
-/// staying inside an acceptable single JSON response budget.
-/// Test: `kg_graph_returns_active_triples`.
-const KG_GRAPH_MAX_TRIPLES: usize = 5_000;
-
-/// `GET /api/v1/palaces/{id}/kg/graph` — full graph payload for the SPA.
-///
-/// Why: Issue #97's visual graph view needs every active triple in one call
-/// so the d3-force layout can run without paging. The existing `/kg/all`
-/// endpoint caps page size at 200 — fine for the explorer table but too
-/// small for the visual graph. This handler does a single `list_active`
-/// pass capped at [`KG_GRAPH_MAX_TRIPLES`] and bundles the graph counts in
-/// the same payload.
-/// What: opens the palace handle, calls `KnowledgeGraph::list_active(cap,
-/// 0)`, and returns `{ triples, node_count, edge_count, community_count }`.
-/// Failures surface as `ApiError::internal`.
-/// Test: `kg_graph_returns_active_triples` (web tests).
 async fn kg_graph(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<KgGraphPayload>, ApiError> {
-    let handle = open_handle(&state, &id)?;
-    let triples = handle
-        .kg
-        .list_active(KG_GRAPH_MAX_TRIPLES, 0)
-        .await
-        .map_err(|e| ApiError::internal(format!("kg list_active: {e:#}")))?;
-    let node_count = handle.kg.node_count() as u64;
-    let edge_count = handle.kg.edge_count() as u64;
-    let community_count = handle.kg.community_count() as u64;
-    Ok(Json(KgGraphPayload {
-        triples,
-        node_count,
-        edge_count,
-        community_count,
-    }))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .kg_graph(&id)
+            .await?,
+    ))
 }
 
 // ---------------------------------------------------------------------------
 // Dream cycle status + on-demand run
 // ---------------------------------------------------------------------------
 
-/// Wire payload for dream status endpoints — `last_run_at` may be null when no
-/// cycle has run yet on this palace (or the aggregate has nothing to report).
-#[derive(Serialize, Default)]
-pub(crate) struct DreamStatusPayload {
-    pub(crate) last_run_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub(crate) merged: usize,
-    pub(crate) pruned: usize,
-    pub(crate) compacted: usize,
-    pub(crate) closets_updated: usize,
-    pub(crate) duration_ms: u64,
-}
+pub(crate) use crate::service::DreamStatusPayload;
 
-impl From<PersistedDreamStats> for DreamStatusPayload {
-    fn from(p: PersistedDreamStats) -> Self {
-        Self {
-            last_run_at: Some(p.last_run_at),
-            merged: p.stats.merged,
-            pruned: p.stats.pruned,
-            compacted: p.stats.compacted,
-            closets_updated: p.stats.closets_updated,
-            duration_ms: p.stats.duration_ms,
-        }
-    }
-}
-
-/// GET /api/v1/dream/status — aggregate latest dream stats across all palaces.
-///
-/// Why: The dashboard wants a single "last dream cycle" panel rather than
-/// per-palace details; we sum the per-palace counters and surface the most
-/// recent `last_run_at` so operators can spot a stalled background loop.
-/// What: Walks every palace, loads its `dream_stats.json` if present, sums
-/// counts, and returns the max `last_run_at` (or null if no palace has run).
-/// Test: `dream_status_aggregates_across_palaces` covers the read path.
 async fn dream_status(State(state): State<AppState>) -> Json<DreamStatusPayload> {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
-    let mut out = DreamStatusPayload::default();
-    let mut latest: Option<chrono::DateTime<chrono::Utc>> = None;
-    for p in palaces {
-        let data_dir = state.data_root.join(p.id.as_str());
-        let snap = match PersistedDreamStats::load(&data_dir) {
-            Ok(Some(s)) => s,
-            _ => continue,
-        };
-        out.merged = out.merged.saturating_add(snap.stats.merged);
-        out.pruned = out.pruned.saturating_add(snap.stats.pruned);
-        out.compacted = out.compacted.saturating_add(snap.stats.compacted);
-        out.closets_updated = out
-            .closets_updated
-            .saturating_add(snap.stats.closets_updated);
-        out.duration_ms = out.duration_ms.saturating_add(snap.stats.duration_ms);
-        latest = match latest {
-            Some(t) if t >= snap.last_run_at => Some(t),
-            _ => Some(snap.last_run_at),
-        };
-    }
-    out.last_run_at = latest;
-    Json(out)
+    Json(
+        crate::service::MemoryService::new(state)
+            .dream_status_aggregate()
+            .await,
+    )
 }
 
-/// GET /api/v1/palaces/:id/dream/status — per-palace dream stats snapshot.
 async fn palace_dream_status(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<DreamStatusPayload>, ApiError> {
-    let data_dir = state.data_root.join(&id);
-    if !data_dir.exists() {
-        return Err(ApiError::not_found(format!("palace not found: {id}")));
-    }
-    let payload = match PersistedDreamStats::load(&data_dir) {
-        Ok(Some(s)) => s.into(),
-        Ok(None) => DreamStatusPayload::default(),
-        Err(e) => return Err(ApiError::internal(format!("read dream stats: {e:#}"))),
-    };
-    Ok(Json(payload))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .dream_status_for_palace(&id)
+            .await?,
+    ))
 }
 
-/// POST /api/v1/dream/run — run a dream cycle across all palaces on demand.
-///
-/// Why: The dashboard exposes a "Run now" button so operators can force a
-/// cycle without waiting for the idle clock; useful after a bulk ingest or
-/// when diagnosing the dream loop itself.
-/// What: Opens every persisted palace, runs `Dreamer::dream_cycle` with the
-/// default config, and returns the aggregated stats plus the run timestamp.
-/// Errors on individual palaces are logged but don't abort the sweep.
-/// Test: `dream_run_aggregates_stats` covers the round-trip.
 async fn dream_run(State(state): State<AppState>) -> Result<Json<DreamStatusPayload>, ApiError> {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root)
-        .map_err(|e| ApiError::internal(format!("list palaces: {e:#}")))?;
-    let dreamer = Dreamer::new(DreamConfig::default());
-    let mut out = DreamStatusPayload::default();
-    for p in palaces {
-        let handle = match state.registry.open_palace(&state.data_root, &p.id) {
-            Ok(h) => h,
-            Err(e) => {
-                tracing::warn!(palace = %p.id, "dream_run: open failed: {e:#}");
-                continue;
-            }
-        };
-        match dreamer.dream_cycle(&handle).await {
-            Ok(stats) => {
-                out.merged = out.merged.saturating_add(stats.merged);
-                out.pruned = out.pruned.saturating_add(stats.pruned);
-                out.compacted = out.compacted.saturating_add(stats.compacted);
-                out.closets_updated = out.closets_updated.saturating_add(stats.closets_updated);
-                out.duration_ms = out.duration_ms.saturating_add(stats.duration_ms);
-            }
-            Err(e) => tracing::warn!(palace = %p.id, "dream_run: cycle failed: {e:#}"),
-        }
-        // Issue #53: refresh the community-detection cache after each
-        // successful or failed cycle. Even if the dedup/decay pass errored we
-        // still want a fresh gap snapshot — `knowledge_gaps()` reads the KG
-        // directly and is independent of the dream pass results.
-        refresh_gaps_cache(&state, &handle).await;
-    }
-    out.last_run_at = Some(chrono::Utc::now());
-    state.emit(DaemonEvent::DreamCompleted {
-        palace_id: None,
-        merged: out.merged,
-        pruned: out.pruned,
-        compacted: out.compacted,
-        closets_updated: out.closets_updated,
-        duration_ms: out.duration_ms,
-        source: ActivitySource::Http,
-    });
-    state.emit(aggregate_status_event(&state));
-    Ok(Json(out))
+    Ok(Json(
+        crate::service::MemoryService::new(state)
+            .dream_run()
+            .await?,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -1966,92 +1371,8 @@ async fn remove_prompt_fact_handler(
     }
 }
 
-/// Recompute the gaps for `handle` and write them to the registry cache.
-///
-/// Why: Wraps the post-dream-cycle bookkeeping in one place so the HTTP
-/// `dream_run` handler and any future schedulers share the exact same
-/// enrichment path. Issue #53 also asks for an LLM-generated
-/// `suggested_exploration` when `OPENROUTER_API_KEY` is set — that step is
-/// best-effort and never blocks cache population.
-/// What: Calls `KnowledgeGraph::knowledge_gaps()`, optionally enriches the
-/// `suggested_exploration` field via `enrich_gap_exploration`, then stores
-/// the resulting vec on `state.registry`. Logs the gap count at `debug!`.
-/// Test: Indirect via `kg_gaps_endpoint_returns_cached_gaps` (which runs a
-/// dream cycle and then reads `/api/v1/kg/gaps`).
-async fn refresh_gaps_cache(state: &AppState, handle: &Arc<PalaceHandle>) {
-    let mut gaps = handle.kg.knowledge_gaps();
-    // LLM enrichment is best-effort. We only attempt it when an API key is
-    // present in the process environment; absence is the common case and the
-    // template `suggested_exploration` from `find_communities` is already a
-    // perfectly serviceable fallback.
-    if let Ok(api_key) = std::env::var("OPENROUTER_API_KEY") {
-        if !api_key.is_empty() {
-            for gap in gaps.iter_mut() {
-                if let Some(enriched) = enrich_gap_exploration(&api_key, gap).await {
-                    gap.suggested_exploration = enriched;
-                }
-            }
-        }
-    }
-    let gap_count = gaps.len();
-    state.registry.set_gaps(handle.id.clone(), gaps);
-    tracing::debug!(palace = %handle.id, gaps = gap_count, "community gaps updated");
-}
-
-/// Ask OpenRouter for a focused exploration question for a single gap.
-///
-/// Why: Issue #53 — when an API key is available the dream cycle should
-/// upgrade the templated `suggested_exploration` to a model-generated
-/// research question. The result is cached for cheap re-reads, so the LLM
-/// cost is paid at most once per dream cycle per gap rather than on every
-/// `/kg/gaps` request.
-/// What: Builds a short user prompt naming up to the first five entities in
-/// the gap, calls `openrouter_chat` (deprecated but still the simplest
-/// one-shot helper in `trusty-common`), and returns the trimmed completion
-/// on success. Returns `None` on any error so the caller can fall back to
-/// the template.
-/// Test: Network-dependent — not unit-tested. Behavioural coverage comes
-/// from manual runs of the dream cycle with `OPENROUTER_API_KEY` set.
-async fn enrich_gap_exploration(api_key: &str, gap: &KnowledgeGap) -> Option<String> {
-    // Limit the entity list we shove into the prompt so we don't blow the
-    // token budget on a 1k-node community.
-    let preview: Vec<&str> = gap.entities.iter().take(5).map(String::as_str).collect();
-    if preview.is_empty() {
-        return None;
-    }
-    let entities = preview.join(", ");
-    let user = format!(
-        "Given these related entities from a knowledge graph: {entities}. \
-         Suggest one specific research question (single sentence, under 25 words) \
-         that would help fill gaps in this knowledge cluster. Return only the question."
-    );
-    let messages = vec![trusty_common::ChatMessage {
-        role: "user".to_string(),
-        content: user,
-        tool_call_id: None,
-        tool_calls: None,
-    }];
-    // `openrouter_chat` is deprecated in favour of `OpenRouterProvider::chat_stream`,
-    // but the one-shot helper is the right tool for this background, best-effort
-    // enrichment — we don't need streaming and we explicitly tolerate failures.
-    #[allow(deprecated)]
-    let res = trusty_common::openrouter_chat(api_key, "openai/gpt-4o-mini", messages).await;
-    match res {
-        Ok(text) => {
-            let trimmed = text.trim().to_string();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed)
-            }
-        }
-        Err(e) => {
-            tracing::debug!("openrouter gap enrichment failed (using template): {e:#}");
-            None
-        }
-    }
-}
-
+#[allow(unused_imports)]
+pub(crate) use crate::service::refresh_gaps_cache;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2100,12 +1421,25 @@ impl IntoResponse for ApiError {
     }
 }
 
+impl From<crate::service::ServiceError> for ApiError {
+    fn from(e: crate::service::ServiceError) -> Self {
+        match e {
+            crate::service::ServiceError::BadRequest(m) => ApiError::bad_request(m),
+            crate::service::ServiceError::NotFound(m) => ApiError::not_found(m),
+            crate::service::ServiceError::Internal(m) => ApiError::internal(m),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::DRAWER_PREVIEW_MAX_CHARS;
     use axum::body::to_bytes;
     use axum::http::Request;
     use tower::util::ServiceExt;
+    use trusty_common::memory_core::palace::Palace;
+    use trusty_common::memory_core::retrieval::RecallResult;
 
     fn test_state() -> AppState {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/trusty-memory/src/web.rs
+++ b/crates/trusty-memory/src/web.rs
@@ -32,12 +32,10 @@ use trusty_common::memory_core::community::KnowledgeGap;
 use trusty_common::memory_core::dream::{DreamConfig, Dreamer, PersistedDreamStats};
 use trusty_common::memory_core::palace::{Palace, PalaceId, RoomType};
 use trusty_common::memory_core::retrieval::{
-    recall_across_palaces_with_default_embedder, recall_deep_with_default_embedder,
-    recall_with_default_embedder, RecallResult,
+    recall_deep_with_default_embedder, recall_with_default_embedder, RecallResult,
 };
 use trusty_common::memory_core::store::kg::Triple;
 use trusty_common::memory_core::{PalaceHandle, PalaceRegistry};
-use trusty_common::{ChatEvent, ChatMessage, ToolDef};
 use uuid::Uuid;
 
 /// Embedded UI assets produced by `pnpm build` in `ui/`.
@@ -114,24 +112,24 @@ pub fn router() -> Router<AppState> {
             "/api/v1/kg/prompt-facts",
             get(list_prompt_facts_handler).delete(remove_prompt_fact_handler),
         )
-        .route("/api/v1/chat", post(chat_handler))
-        .route("/api/v1/chat/providers", get(list_providers))
+        .route("/api/v1/chat", post(crate::chat::chat_handler))
+        .route("/api/v1/chat/providers", get(crate::chat::list_providers))
         .route(
             "/api/v1/palaces/{id}/chat/sessions",
-            get(list_chat_sessions).post(create_chat_session),
+            get(crate::chat::list_chat_sessions).post(crate::chat::create_chat_session),
         )
         .route(
             "/api/v1/palaces/{id}/chat/sessions/{session_id}",
-            get(get_chat_session).delete(delete_chat_session),
+            get(crate::chat::get_chat_session).delete(crate::chat::delete_chat_session),
         )
         // Issue #99: inter-project messaging.
         .route(
             "/api/v1/messages",
-            get(list_messages_handler).post(send_message_handler),
+            get(crate::chat::list_messages_handler).post(crate::chat::send_message_handler),
         )
         .route(
             "/api/v1/messages/mark_read",
-            post(mark_message_read_handler),
+            post(crate::chat::mark_message_read_handler),
         )
         .route("/health", get(health))
         .route("/api/v1/logs/tail", get(logs_tail))
@@ -622,7 +620,7 @@ async fn rpc_handler(
 /// `source = Http` and the current daemon crate version.
 /// Test: `drawer_creator_attribution_http_default`,
 /// `drawer_creator_attribution_http_header`.
-fn creator_info_from_http(headers: &HeaderMap) -> CreatorInfo {
+pub(crate) fn creator_info_from_http(headers: &HeaderMap) -> CreatorInfo {
     let client = headers
         .get(X_TRUSTY_CLIENT_NAME)
         .and_then(|v| v.to_str().ok())
@@ -852,7 +850,7 @@ pub(crate) fn load_user_config() -> Option<LoadedUserConfig> {
 // ---------------------------------------------------------------------------
 
 #[derive(Serialize)]
-struct PalaceInfo {
+pub(crate) struct PalaceInfo {
     id: String,
     name: String,
     description: Option<String>,
@@ -917,7 +915,7 @@ struct PalaceInfo {
 /// table (until a dedicated wings/rooms table exists, distinct rooms-by-drawer
 /// is the closest proxy).
 /// Test: `palace_list_includes_richer_counts`.
-fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> PalaceInfo {
+pub(crate) fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> PalaceInfo {
     let (
         drawer_count,
         vector_count,
@@ -1277,7 +1275,7 @@ async fn recall_all_handler(
 ) -> Result<Json<Value>, ApiError> {
     let top_k = q.top_k.unwrap_or(10);
     let deep = q.deep.unwrap_or(false);
-    let value = execute_recall_all(&state, &q.q, top_k, deep).await;
+    let value = crate::chat::execute_recall_all(&state, &q.q, top_k, deep).await;
     if let Some(err) = value.get("error").and_then(|v| v.as_str()) {
         return Err(ApiError::internal(err.to_string()));
     }
@@ -1545,13 +1543,13 @@ async fn kg_graph(
 /// Wire payload for dream status endpoints — `last_run_at` may be null when no
 /// cycle has run yet on this palace (or the aggregate has nothing to report).
 #[derive(Serialize, Default)]
-struct DreamStatusPayload {
-    last_run_at: Option<chrono::DateTime<chrono::Utc>>,
-    merged: usize,
-    pruned: usize,
-    compacted: usize,
-    closets_updated: usize,
-    duration_ms: u64,
+pub(crate) struct DreamStatusPayload {
+    pub(crate) last_run_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub(crate) merged: usize,
+    pub(crate) pruned: usize,
+    pub(crate) compacted: usize,
+    pub(crate) closets_updated: usize,
+    pub(crate) duration_ms: u64,
 }
 
 impl From<PersistedDreamStats> for DreamStatusPayload {
@@ -2054,1198 +2052,12 @@ async fn enrich_gap_exploration(api_key: &str, gap: &KnowledgeGap) -> Option<Str
     }
 }
 
-// ---------------------------------------------------------------------------
-// Chat (OpenRouter, SSE-streaming)
-// ---------------------------------------------------------------------------
-
-#[derive(Deserialize)]
-struct ChatBody {
-    #[serde(default)]
-    palace_id: Option<String>,
-    message: String,
-    #[serde(default)]
-    history: Vec<ChatMessage>,
-    /// Optional existing chat-session id; when provided we load+append+save.
-    #[serde(default)]
-    session_id: Option<String>,
-}
-
-/// Hard cap on the number of `tool -> assistant` round trips per chat turn.
-///
-/// Why: Without a bound, a malicious or confused model could request tools
-/// indefinitely; 10 is generous enough for any realistic plan-and-act loop
-/// while still terminating quickly when the model gets stuck.
-const MAX_TOOL_ROUNDS: usize = 10;
-
-/// Build the complete set of tool definitions the chat assistant can call.
-///
-/// Why: Centralizing the tool surface keeps the wire schema, the dispatcher in
-/// `execute_tool`, and the system prompt in lock-step — adding a new tool means
-/// editing this one function plus a match arm.
-/// What: Returns the 11 read/write tools spanning palace introspection,
-/// memory recall/create, KG read/write, and daemon status.
-/// Test: `all_tools_returns_expected_set` asserts names and required-arg shape.
-fn all_tools() -> Vec<ToolDef> {
-    vec![
-        ToolDef {
-            name: "list_palaces".into(),
-            description: "List all memory palaces on this machine with their metadata (id, name, description, counts).".into(),
-            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
-        },
-        ToolDef {
-            name: "get_palace".into(),
-            description: "Get details for a specific palace by id.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "palace_id": { "type": "string", "description": "Palace id (kebab-case)" } },
-                "required": ["palace_id"],
-            }),
-        },
-        ToolDef {
-            name: "recall_memories".into(),
-            description: "Semantic search for memories in a palace. Returns the top-k most relevant drawers ranked by similarity to the query.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "palace_id": { "type": "string" },
-                    "query": { "type": "string", "description": "Free-text query" },
-                    "top_k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 5 }
-                },
-                "required": ["palace_id", "query"],
-            }),
-        },
-        ToolDef {
-            name: "list_drawers".into(),
-            description: "List all drawers (memories) in a palace, most recent first.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "palace_id": { "type": "string" } },
-                "required": ["palace_id"],
-            }),
-        },
-        ToolDef {
-            name: "kg_query".into(),
-            description: "Query the temporal knowledge graph for all currently-active triples whose subject matches.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "palace_id": { "type": "string" },
-                    "subject": { "type": "string" }
-                },
-                "required": ["palace_id", "subject"],
-            }),
-        },
-        ToolDef {
-            name: "get_config".into(),
-            description: "Get the trusty-memory daemon's configuration (provider, model, data root). API keys are masked.".into(),
-            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
-        },
-        ToolDef {
-            name: "get_status".into(),
-            description: "Get daemon health: version, palace count, totals for drawers/vectors/triples.".into(),
-            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
-        },
-        ToolDef {
-            name: "get_dream_status".into(),
-            description: "Get aggregated dreamer activity across all palaces (merged/pruned/compacted counts, last run timestamp).".into(),
-            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
-        },
-        ToolDef {
-            name: "get_palace_dream_status".into(),
-            description: "Get dreamer activity stats for a specific palace.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "palace_id": { "type": "string" } },
-                "required": ["palace_id"],
-            }),
-        },
-        ToolDef {
-            name: "create_memory".into(),
-            description: "Store a new memory (drawer) in a palace. The content is embedded and inserted into the vector index plus the drawer table.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "palace_id": { "type": "string" },
-                    "content": { "type": "string", "description": "Verbatim memory text" },
-                    "room": { "type": "string", "description": "Room name (Frontend/Backend/Testing/Planning/Documentation/Research/Configuration/Meetings/General or a custom name); defaults to General." },
-                    "tags": { "type": "array", "items": { "type": "string" } },
-                    "importance": { "type": "number", "minimum": 0.0, "maximum": 1.0, "default": 0.5 }
-                },
-                "required": ["palace_id", "content"],
-            }),
-        },
-        ToolDef {
-            name: "kg_assert".into(),
-            description: "Assert a knowledge-graph triple. Any prior active triple with the same (subject, predicate) is closed out (valid_to set to now) before the new one is inserted.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "palace_id": { "type": "string" },
-                    "subject": { "type": "string" },
-                    "predicate": { "type": "string" },
-                    "object": { "type": "string" },
-                    "confidence": { "type": "number", "minimum": 0.0, "maximum": 1.0, "default": 1.0 }
-                },
-                "required": ["palace_id", "subject", "predicate", "object"],
-            }),
-        },
-        ToolDef {
-            name: "memory_recall_all".into(),
-            description: "Semantic search across ALL palaces simultaneously. Returns the top-k most relevant drawers ranked by similarity, regardless of which palace they belong to. Each result includes a `palace_id` field identifying its source.".into(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "q": { "type": "string", "description": "Free-text query" },
-                    "top_k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 },
-                    "deep": { "type": "boolean", "default": false }
-                },
-                "required": ["q"],
-            }),
-        },
-    ]
-}
-
-/// Execute a tool call against the live `AppState`.
-///
-/// Why: We want the model's tool invocations to call the same Rust paths the
-/// HTTP handlers use — no extra HTTP round-trip, no JSON re-parsing, and the
-/// results always reflect this daemon's view of the world.
-/// What: Parses `arguments` as JSON, dispatches by tool name, returns a JSON
-/// value that becomes the `role: "tool"` message content. Errors are caught
-/// and returned as `{"error": "..."}` JSON so the model can react.
-/// Test: `execute_tool_dispatches_known_tools` covers the dispatch path and
-/// the unknown-tool error case.
-async fn execute_tool(name: &str, args: &str, state: &AppState) -> Value {
-    let parsed: Value = serde_json::from_str(args).unwrap_or(json!({}));
-    match name {
-        "list_palaces" => execute_list_palaces(state).await,
-        "get_palace" => match parsed.get("palace_id").and_then(|v| v.as_str()) {
-            Some(id) => execute_get_palace(state, id).await,
-            None => json!({ "error": "missing required argument: palace_id" }),
-        },
-        "recall_memories" => {
-            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
-            let q = parsed.get("query").and_then(|v| v.as_str());
-            let top_k = parsed.get("top_k").and_then(|v| v.as_u64()).unwrap_or(5) as usize;
-            match (pid, q) {
-                (Some(p), Some(q)) => execute_recall(state, p, q, top_k).await,
-                _ => json!({ "error": "missing required argument(s): palace_id, query" }),
-            }
-        }
-        "list_drawers" => match parsed.get("palace_id").and_then(|v| v.as_str()) {
-            Some(id) => execute_list_drawers(state, id).await,
-            None => json!({ "error": "missing required argument: palace_id" }),
-        },
-        "kg_query" => {
-            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
-            let subj = parsed.get("subject").and_then(|v| v.as_str());
-            match (pid, subj) {
-                (Some(p), Some(s)) => execute_kg_query(state, p, s).await,
-                _ => json!({ "error": "missing required argument(s): palace_id, subject" }),
-            }
-        }
-        "get_config" => execute_get_config(state),
-        "get_status" => execute_get_status(state).await,
-        "get_dream_status" => execute_get_dream_status(state).await,
-        "get_palace_dream_status" => match parsed.get("palace_id").and_then(|v| v.as_str()) {
-            Some(id) => execute_get_palace_dream_status(state, id).await,
-            None => json!({ "error": "missing required argument: palace_id" }),
-        },
-        "create_memory" => {
-            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
-            let content = parsed.get("content").and_then(|v| v.as_str());
-            let room = parsed.get("room").and_then(|v| v.as_str());
-            let tags: Vec<String> = parsed
-                .get("tags")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|t| t.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let importance = parsed
-                .get("importance")
-                .and_then(|v| v.as_f64())
-                .map(|f| f as f32)
-                .unwrap_or(0.5);
-            match (pid, content) {
-                (Some(p), Some(c)) => {
-                    execute_create_memory(state, p, c, room, tags, importance).await
-                }
-                _ => json!({ "error": "missing required argument(s): palace_id, content" }),
-            }
-        }
-        "kg_assert" => {
-            let pid = parsed.get("palace_id").and_then(|v| v.as_str());
-            let subj = parsed.get("subject").and_then(|v| v.as_str());
-            let pred = parsed.get("predicate").and_then(|v| v.as_str());
-            let obj = parsed.get("object").and_then(|v| v.as_str());
-            let conf = parsed
-                .get("confidence")
-                .and_then(|v| v.as_f64())
-                .map(|f| f as f32)
-                .unwrap_or(1.0);
-            match (pid, subj, pred, obj) {
-                (Some(p), Some(s), Some(pr), Some(o)) => {
-                    execute_kg_assert(state, p, s, pr, o, conf).await
-                }
-                _ => json!({
-                    "error": "missing required argument(s): palace_id, subject, predicate, object"
-                }),
-            }
-        }
-        "memory_recall_all" => {
-            let q = parsed.get("q").and_then(|v| v.as_str());
-            let top_k = parsed.get("top_k").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
-            let deep = parsed
-                .get("deep")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            match q {
-                Some(q) => execute_recall_all(state, q, top_k, deep).await,
-                None => json!({ "error": "missing required argument: q" }),
-            }
-        }
-        _ => json!({ "error": format!("unknown tool: {name}") }),
-    }
-}
-
-async fn execute_list_palaces(state: &AppState) -> Value {
-    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
-        Ok(v) => v,
-        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
-    };
-    let out: Vec<Value> = palaces
-        .into_iter()
-        .map(|p| {
-            let handle = state.registry.open_palace(&state.data_root, &p.id).ok();
-            let info = palace_info_from(&p, handle.as_ref());
-            serde_json::to_value(info).unwrap_or(json!({}))
-        })
-        .collect();
-    json!(out)
-}
-
-async fn execute_get_palace(state: &AppState, id: &str) -> Value {
-    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
-        Ok(v) => v,
-        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
-    };
-    match palaces.into_iter().find(|p| p.id.0 == id) {
-        Some(p) => {
-            let handle = state.registry.open_palace(&state.data_root, &p.id).ok();
-            serde_json::to_value(palace_info_from(&p, handle.as_ref())).unwrap_or(json!({}))
-        }
-        None => json!({ "error": format!("palace not found: {id}") }),
-    }
-}
-
-async fn execute_recall(state: &AppState, palace_id: &str, query: &str, top_k: usize) -> Value {
-    let handle = match state
-        .registry
-        .open_palace(&state.data_root, &PalaceId::new(palace_id))
-    {
-        Ok(h) => h,
-        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
-    };
-    match recall_with_default_embedder(&handle, query, top_k).await {
-        Ok(hits) => json!(hits
-            .into_iter()
-            .map(|r| json!({
-                "drawer_id": r.drawer.id.to_string(),
-                "content": r.drawer.content,
-                "importance": r.drawer.importance,
-                "tags": r.drawer.tags,
-                "score": r.score,
-                "layer": r.layer,
-            }))
-            .collect::<Vec<_>>()),
-        Err(e) => json!({ "error": format!("recall: {e:#}") }),
-    }
-}
-
-/// Execute a cross-palace recall and return JSON results tagged with palace id.
-///
-/// Why: Both the MCP `memory_recall_all` tool and the `GET /api/v1/recall`
-/// HTTP route share the same wiring — list palaces, open handles, fan out via
-/// `recall_across_palaces_with_default_embedder`, and serialize.
-/// What: Lists every palace on disk, opens each (skipping any that fail with
-/// a `tracing::warn!`), and delegates to the core fan-out. On success returns
-/// a JSON array; on listing failure returns `{ "error": "..." }`.
-/// Test: Indirectly via `recall_across_palaces_merges_results` (core merge
-/// logic) and the HTTP/MCP integration paths.
-async fn execute_recall_all(state: &AppState, query: &str, top_k: usize, deep: bool) -> Value {
-    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
-        Ok(v) => v,
-        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
-    };
-    let mut handles = Vec::with_capacity(palaces.len());
-    for p in &palaces {
-        match state.registry.open_palace(&state.data_root, &p.id) {
-            Ok(h) => handles.push(h),
-            Err(e) => {
-                tracing::warn!(palace = %p.id, "execute_recall_all: open failed: {e:#}");
-            }
-        }
-    }
-    if handles.is_empty() {
-        return json!([]);
-    }
-    match recall_across_palaces_with_default_embedder(&handles, query, top_k, deep).await {
-        Ok(results) => json!(results
-            .into_iter()
-            .map(|r| json!({
-                "palace_id": r.palace_id,
-                "drawer_id": r.result.drawer.id.to_string(),
-                "content": r.result.drawer.content,
-                "importance": r.result.drawer.importance,
-                "tags": r.result.drawer.tags,
-                "score": r.result.score,
-                "layer": r.result.layer,
-            }))
-            .collect::<Vec<_>>()),
-        Err(e) => json!({ "error": format!("recall_across_palaces: {e:#}") }),
-    }
-}
-
-async fn execute_list_drawers(state: &AppState, palace_id: &str) -> Value {
-    let handle = match state
-        .registry
-        .open_palace(&state.data_root, &PalaceId::new(palace_id))
-    {
-        Ok(h) => h,
-        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
-    };
-    let drawers = handle.list_drawers(None, None, 200);
-    serde_json::to_value(drawers).unwrap_or(json!([]))
-}
-
-async fn execute_kg_query(state: &AppState, palace_id: &str, subject: &str) -> Value {
-    let handle = match state
-        .registry
-        .open_palace(&state.data_root, &PalaceId::new(palace_id))
-    {
-        Ok(h) => h,
-        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
-    };
-    match handle.kg.query_active(subject).await {
-        Ok(triples) => serde_json::to_value(triples).unwrap_or(json!([])),
-        Err(e) => json!({ "error": format!("kg query: {e:#}") }),
-    }
-}
-
-fn execute_get_config(state: &AppState) -> Value {
-    let cfg = load_user_config().unwrap_or_default();
-    json!({
-        "openrouter_configured": !cfg.openrouter_api_key.is_empty(),
-        "openrouter_model": cfg.openrouter_model,
-        "local_model": {
-            "enabled": cfg.local_model.enabled,
-            "base_url": cfg.local_model.base_url,
-            "model": cfg.local_model.model,
-        },
-        "data_root": state.data_root.display().to_string(),
-    })
-}
-
-async fn execute_get_status(state: &AppState) -> Value {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
-    let (mut total_drawers, mut total_vectors, mut total_kg_triples) = (0usize, 0usize, 0usize);
-    for p in &palaces {
-        if let Ok(handle) = state.registry.open_palace(&state.data_root, &p.id) {
-            total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
-            total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
-            total_kg_triples = total_kg_triples.saturating_add(handle.kg.count_active_triples());
-        }
-    }
-    json!({
-        "version": state.version,
-        "palace_count": palaces.len(),
-        "default_palace": state.default_palace,
-        "data_root": state.data_root.display().to_string(),
-        "total_drawers": total_drawers,
-        "total_vectors": total_vectors,
-        "total_kg_triples": total_kg_triples,
-    })
-}
-
-async fn execute_get_dream_status(state: &AppState) -> Value {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
-    let mut out = DreamStatusPayload::default();
-    let mut latest: Option<chrono::DateTime<chrono::Utc>> = None;
-    for p in palaces {
-        let data_dir = state.data_root.join(p.id.as_str());
-        let snap = match PersistedDreamStats::load(&data_dir) {
-            Ok(Some(s)) => s,
-            _ => continue,
-        };
-        out.merged = out.merged.saturating_add(snap.stats.merged);
-        out.pruned = out.pruned.saturating_add(snap.stats.pruned);
-        out.compacted = out.compacted.saturating_add(snap.stats.compacted);
-        out.closets_updated = out
-            .closets_updated
-            .saturating_add(snap.stats.closets_updated);
-        out.duration_ms = out.duration_ms.saturating_add(snap.stats.duration_ms);
-        latest = match latest {
-            Some(t) if t >= snap.last_run_at => Some(t),
-            _ => Some(snap.last_run_at),
-        };
-    }
-    out.last_run_at = latest;
-    serde_json::to_value(out).unwrap_or(json!({}))
-}
-
-async fn execute_get_palace_dream_status(state: &AppState, palace_id: &str) -> Value {
-    let data_dir = state.data_root.join(palace_id);
-    if !data_dir.exists() {
-        return json!({ "error": format!("palace not found: {palace_id}") });
-    }
-    match PersistedDreamStats::load(&data_dir) {
-        Ok(Some(s)) => serde_json::to_value(DreamStatusPayload::from(s)).unwrap_or(json!({})),
-        Ok(None) => serde_json::to_value(DreamStatusPayload::default()).unwrap_or(json!({})),
-        Err(e) => json!({ "error": format!("read dream stats: {e:#}") }),
-    }
-}
-
-async fn execute_create_memory(
-    state: &AppState,
-    palace_id: &str,
-    content: &str,
-    room: Option<&str>,
-    tags: Vec<String>,
-    importance: f32,
-) -> Value {
-    let handle = match state
-        .registry
-        .open_palace(&state.data_root, &PalaceId::new(palace_id))
-    {
-        Ok(h) => h,
-        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
-    };
-    let room = room.map(RoomType::parse).unwrap_or(RoomType::General);
-    match handle
-        .remember(content.to_string(), room, tags, importance)
-        .await
-    {
-        Ok(id) => json!({ "drawer_id": id.to_string(), "status": "stored" }),
-        Err(e) => json!({ "error": format!("remember: {e:#}") }),
-    }
-}
-
-async fn execute_kg_assert(
-    state: &AppState,
-    palace_id: &str,
-    subject: &str,
-    predicate: &str,
-    object: &str,
-    confidence: f32,
-) -> Value {
-    let handle = match state
-        .registry
-        .open_palace(&state.data_root, &PalaceId::new(palace_id))
-    {
-        Ok(h) => h,
-        Err(e) => return json!({ "error": format!("open palace {palace_id}: {e:#}") }),
-    };
-    let triple = Triple {
-        subject: subject.to_string(),
-        predicate: predicate.to_string(),
-        object: object.to_string(),
-        valid_from: chrono::Utc::now(),
-        valid_to: None,
-        confidence,
-        provenance: Some("chat:assistant".to_string()),
-    };
-    match handle.kg.assert(triple).await {
-        Ok(()) => json!({ "status": "asserted" }),
-        Err(e) => json!({ "error": format!("kg assert: {e:#}") }),
-    }
-}
-
-async fn chat_handler(State(state): State<AppState>, Json(body): Json<ChatBody>) -> Response {
-    // Select the active provider (Ollama auto-detect, else OpenRouter).
-    let Some(provider) = state.chat_provider().await else {
-        return (
-            StatusCode::PRECONDITION_FAILED,
-            "No chat provider configured (no local Ollama detected and no OpenRouter key set)",
-        )
-            .into_response();
-    };
-
-    // Resolve palace id (explicit > default).
-    let palace_id = body
-        .palace_id
-        .clone()
-        .or_else(|| state.default_palace.clone())
-        .unwrap_or_default();
-
-    // Resolve / create chat session when a palace is bound.
-    let (session_id, mut history): (Option<String>, Vec<ChatMessage>) = if !palace_id.is_empty() {
-        let store = match state.session_store(&palace_id) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(palace = %palace_id, "session_store open failed: {e:#}");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("session store: {e:#}"),
-                )
-                    .into_response();
-            }
-        };
-        match body.session_id.clone() {
-            Some(sid) => match store.get_session(&sid) {
-                Ok(Some(s)) => (
-                    Some(sid),
-                    s.history
-                        .into_iter()
-                        .map(|m| ChatMessage {
-                            role: m.role,
-                            content: m.content,
-                            tool_call_id: None,
-                            tool_calls: None,
-                        })
-                        .collect(),
-                ),
-                _ => (Some(sid), body.history.clone()),
-            },
-            None => {
-                let new_id = store.create_session(None).unwrap_or_else(|e| {
-                    tracing::warn!("create_session failed: {e:#}");
-                    String::new()
-                });
-                (
-                    if new_id.is_empty() {
-                        None
-                    } else {
-                        Some(new_id)
-                    },
-                    body.history.clone(),
-                )
-            }
-        }
-    } else {
-        (None, body.history.clone())
-    };
-
-    // Full palace roster for the identity block — names + ids, not just count,
-    // so the model can pick the right one when the user names a palace.
-    let all_palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
-    let palace_count = all_palaces.len();
-    let palace_roster: String = all_palaces
-        .iter()
-        .map(|p| format!("- {} (id: {})", p.name, p.id.0))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    // Config + global dream snapshot — give the model an honest view of what's
-    // available so it doesn't invent tools or providers that aren't there.
-    let cfg = load_user_config().unwrap_or_default();
-    let active_provider_name = state
-        .chat_provider()
-        .await
-        .map(|p| p.name().to_string())
-        .unwrap_or_else(|| "none".to_string());
-    let dream_snapshot = execute_get_dream_status(&state).await;
-
-    // Look up the selected palace's metadata (name/description) and open its
-    // handle for live counts + recall context.
-    let selected_palace_meta = if palace_id.is_empty() {
-        None
-    } else {
-        all_palaces.iter().find(|p| p.id.0 == palace_id).cloned()
-    };
-
-    let mut palace_block = String::new();
-    let mut context = String::new();
-    let mut palace_display_name = palace_id.clone();
-
-    if !palace_id.is_empty() {
-        if let Ok(handle) = state
-            .registry
-            .open_palace(&state.data_root, &PalaceId::new(&palace_id))
-        {
-            // Live counts from the opened handle.
-            let drawer_count = handle.drawers.read().len();
-            let vector_count = handle.vector_store.index_size();
-            let kg_triple_count = handle.kg.count_active_triples();
-
-            // Prefer the on-disk palace.json name/description; fall back to id.
-            let (name, description) = match &selected_palace_meta {
-                Some(p) => (p.name.clone(), p.description.clone()),
-                None => (palace_id.clone(), None),
-            };
-            palace_display_name = name.clone();
-
-            palace_block.push_str(&format!(
-                "Currently selected palace:\n\
-                 - id: {id}\n\
-                 - name: {name}\n",
-                id = palace_id,
-                name = name,
-            ));
-            if let Some(desc) = description.as_deref().filter(|s| !s.is_empty()) {
-                palace_block.push_str(&format!("- description: {desc}\n"));
-            }
-            palace_block.push_str(&format!(
-                "- drawers: {drawer_count}\n\
-                 - vectors: {vector_count}\n\
-                 - kg_triples: {kg_triple_count}\n",
-            ));
-            let identity_trimmed = handle.identity.trim();
-            if !identity_trimmed.is_empty() {
-                palace_block.push_str(&format!("- identity:\n{identity_trimmed}\n",));
-            }
-
-            if let Ok(hits) = recall_with_default_embedder(&handle, &body.message, 5).await {
-                for r in hits.iter().take(5) {
-                    context.push_str(&format!("- (L{}) {}\n", r.layer, r.drawer.content));
-                }
-            }
-        }
-    }
-
-    // Build the grounded system prompt with identity, palace, RAG, config,
-    // dream-snapshot, and behavior blocks so the LLM never confuses
-    // trusty-memory palaces with real-world architectural palaces.
-    let mut system = String::new();
-    system.push_str(&format!(
-        "You are the assistant for trusty-memory, a machine-wide AI memory \
-         service running locally on this user's machine. trusty-memory stores \
-         knowledge in named \"palaces\" — isolated memory namespaces, each with \
-         its own vector index (usearch HNSW) and temporal knowledge graph \
-         (SQLite). Memories are organized as Palace -> Wing -> Room -> Closet \
-         -> Drawer, where a Drawer is an atomic memory unit.\n\
-         There are currently {palace_count} palace(s) on this machine.\n",
-    ));
-    if !palace_roster.is_empty() {
-        system.push_str(&format!("Palaces:\n{palace_roster}\n"));
-    }
-    system.push('\n');
-
-    // Config block — what providers/models are wired up right now.
-    system.push_str(&format!(
-        "System configuration:\n\
-         - active chat provider: {active_provider_name}\n\
-         - openrouter model: {or_model}\n\
-         - local model: {local_model} ({local_url}, enabled={local_enabled})\n\
-         - data root: {data_root}\n\n",
-        or_model = cfg.openrouter_model,
-        local_model = cfg.local_model.model,
-        local_url = cfg.local_model.base_url,
-        local_enabled = cfg.local_model.enabled,
-        data_root = state.data_root.display(),
-    ));
-
-    // Dream snapshot — give the model a sense of how stale memory state is.
-    system.push_str(&format!(
-        "Global dream status (background memory maintenance):\n{}\n\n",
-        dream_snapshot,
-    ));
-
-    if !palace_block.is_empty() {
-        system.push_str(&palace_block);
-        system.push('\n');
-    }
-
-    if !context.is_empty() {
-        system.push_str(&format!(
-            "Relevant memories from the '{palace_display_name}' palace \
-             (L0 = identity, L1 = essentials, L2 = topic-filtered, L3 = deep):\n\
-             {context}\n",
-        ));
-    }
-
-    system.push_str(
-        "You have a set of tools to introspect and modify this trusty-memory \
-         daemon. Prefer calling a tool over guessing — e.g. call \
-         `list_palaces` rather than relying on the roster above if you need \
-         live counts, and call `recall_memories` to search for facts you \
-         don't have in context. When the user asks about \"palaces\", they \
-         mean trusty-memory palaces (memory namespaces on this machine), not \
-         architectural palaces like Versailles. If a tool returns an error, \
-         report it honestly and don't fabricate results.",
-    );
-
-    // Append the new user message to the in-memory history we'll persist.
-    history.push(ChatMessage {
-        role: "user".to_string(),
-        content: body.message.clone(),
-        tool_call_id: None,
-        tool_calls: None,
-    });
-
-    let mut messages: Vec<ChatMessage> = Vec::with_capacity(history.len() + 1);
-    messages.push(ChatMessage {
-        role: "system".to_string(),
-        content: system,
-        tool_call_id: None,
-        tool_calls: None,
-    });
-    messages.extend(history.iter().cloned());
-
-    let tools = all_tools();
-    let (sse_tx, sse_rx) =
-        tokio::sync::mpsc::channel::<Result<axum::body::Bytes, std::io::Error>>(64);
-
-    // Capture session-persistence inputs.
-    let session_store = if !palace_id.is_empty() && session_id.is_some() {
-        state.session_store(&palace_id).ok()
-    } else {
-        None
-    };
-    let persist_session_id = session_id.clone();
-
-    // Drive the tool-execution loop in a background task so the response can
-    // start streaming immediately.
-    let loop_state = state.clone();
-    tokio::spawn(async move {
-        // Emit a leading session_id frame so the SPA can correlate this stream
-        // with a persisted session row.
-        if let Some(sid) = persist_session_id.as_deref() {
-            let frame = format!("data: {}\n\n", json!({ "session_id": sid }));
-            if sse_tx
-                .send(Ok(axum::body::Bytes::from(frame)))
-                .await
-                .is_err()
-            {
-                return;
-            }
-        }
-
-        let mut final_assistant_text = String::new();
-        let mut stream_err: Option<String> = None;
-
-        for round in 0..MAX_TOOL_ROUNDS {
-            let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<ChatEvent>(256);
-            let messages_clone = messages.clone();
-            let tools_clone = tools.clone();
-            let provider_clone = provider.clone();
-            let stream_handle = tokio::spawn(async move {
-                provider_clone
-                    .chat_stream(messages_clone, tools_clone, event_tx)
-                    .await
-            });
-
-            let mut tool_calls_this_round: Vec<trusty_common::ToolCall> = Vec::new();
-            let mut round_assistant_text = String::new();
-
-            while let Some(event) = event_rx.recv().await {
-                match event {
-                    ChatEvent::Delta(text) => {
-                        round_assistant_text.push_str(&text);
-                        let frame = format!("data: {}\n\n", json!({ "delta": text }));
-                        if sse_tx
-                            .send(Ok(axum::body::Bytes::from(frame)))
-                            .await
-                            .is_err()
-                        {
-                            return;
-                        }
-                    }
-                    ChatEvent::ToolCall(tc) => {
-                        let frame = format!(
-                            "data: {}\n\n",
-                            json!({ "tool_call": {
-                                "id": tc.id,
-                                "name": tc.name,
-                                "arguments": tc.arguments,
-                            }})
-                        );
-                        let _ = sse_tx.send(Ok(axum::body::Bytes::from(frame))).await;
-                        tool_calls_this_round.push(tc);
-                    }
-                    ChatEvent::Done => break,
-                    ChatEvent::Error(e) => {
-                        stream_err = Some(e);
-                        break;
-                    }
-                }
-            }
-
-            // Drain the spawned stream task; surface any error.
-            match stream_handle.await {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => stream_err = Some(e.to_string()),
-                Err(e) => stream_err = Some(format!("join: {e}")),
-            }
-
-            if stream_err.is_some() {
-                break;
-            }
-
-            final_assistant_text.push_str(&round_assistant_text);
-
-            if tool_calls_this_round.is_empty() {
-                // Model produced a plain answer — we're done.
-                break;
-            }
-
-            // Build the assistant message that requested these tool calls.
-            let assistant_tool_calls_json: Vec<Value> = tool_calls_this_round
-                .iter()
-                .map(|tc| {
-                    json!({
-                        "id": tc.id,
-                        "type": "function",
-                        "function": { "name": tc.name, "arguments": tc.arguments },
-                    })
-                })
-                .collect();
-            messages.push(ChatMessage {
-                role: "assistant".to_string(),
-                content: round_assistant_text,
-                tool_call_id: None,
-                tool_calls: Some(assistant_tool_calls_json),
-            });
-
-            // Execute each tool and append its result as a `role: "tool"`
-            // message. The next loop iteration feeds these back to the model.
-            for tc in &tool_calls_this_round {
-                let result = execute_tool(&tc.name, &tc.arguments, &loop_state).await;
-                let result_str = result.to_string();
-                let frame = format!(
-                    "data: {}\n\n",
-                    json!({ "tool_result": {
-                        "id": tc.id,
-                        "name": tc.name,
-                        "content": &result_str,
-                    }})
-                );
-                let _ = sse_tx.send(Ok(axum::body::Bytes::from(frame))).await;
-                messages.push(ChatMessage {
-                    role: "tool".to_string(),
-                    content: result_str,
-                    tool_call_id: Some(tc.id.clone()),
-                    tool_calls: None,
-                });
-            }
-
-            // Safety net: log when we walk off the round limit.
-            if round + 1 == MAX_TOOL_ROUNDS {
-                tracing::warn!(
-                    "chat: hit MAX_TOOL_ROUNDS={} — terminating tool loop",
-                    MAX_TOOL_ROUNDS
-                );
-            }
-        }
-
-        // Persist the completed conversation regardless of streaming error
-        // (partial assistant reply still better than nothing).
-        if let (Some(store), Some(sid)) = (session_store, persist_session_id.as_deref()) {
-            if !final_assistant_text.is_empty() {
-                history.push(ChatMessage {
-                    role: "assistant".into(),
-                    content: final_assistant_text,
-                    tool_call_id: None,
-                    tool_calls: None,
-                });
-            }
-            let core_history: Vec<trusty_common::memory_core::store::chat_sessions::ChatMessage> =
-                history
-                    .iter()
-                    .map(
-                        |m| trusty_common::memory_core::store::chat_sessions::ChatMessage {
-                            role: m.role.clone(),
-                            content: m.content.clone(),
-                        },
-                    )
-                    .collect();
-            if let Err(e) = store.upsert_session(sid, &core_history) {
-                tracing::warn!("upsert_session failed: {e:#}");
-            }
-        }
-
-        match stream_err {
-            None => {
-                let _ = sse_tx
-                    .send(Ok(axum::body::Bytes::from("data: [DONE]\n\n")))
-                    .await;
-            }
-            Some(e) => {
-                let out = format!("data: {}\n\n", json!({ "error": e }));
-                let _ = sse_tx.send(Ok(axum::body::Bytes::from(out))).await;
-            }
-        }
-    });
-
-    let stream = tokio_stream::wrappers::ReceiverStream::new(sse_rx);
-
-    Response::builder()
-        .header("Content-Type", "text/event-stream")
-        .header("Cache-Control", "no-cache")
-        .body(Body::from_stream(stream))
-        .expect("static SSE response builds")
-}
-
-// ---------------------------------------------------------------------------
-// Providers + sessions
-// ---------------------------------------------------------------------------
-
-/// GET /api/v1/chat/providers — report provider availability + active choice.
-///
-/// Why: The UI's chat panel surfaces whether the user has a local model
-/// running or is hitting OpenRouter. Probing both upstreams here keeps that
-/// logic on the server so the SPA stays dumb.
-/// What: Calls `auto_detect_local_provider` (1s timeout) for Ollama and checks
-/// for a non-empty OpenRouter key. Returns shape `{providers:[...], active}`.
-/// Test: `providers_endpoint_returns_payload`.
-async fn list_providers(State(state): State<AppState>) -> Json<Value> {
-    let cfg = load_user_config().unwrap_or_default();
-    let ollama_available = if cfg.local_model.enabled {
-        trusty_common::auto_detect_local_provider(&cfg.local_model.base_url)
-            .await
-            .is_some()
-    } else {
-        false
-    };
-    let openrouter_available = !cfg.openrouter_api_key.is_empty();
-    let active = state.chat_provider().await.map(|p| p.name().to_string());
-    Json(json!({
-        "providers": [
-            {
-                "name": "ollama",
-                "model": cfg.local_model.model,
-                "available": ollama_available,
-            },
-            {
-                "name": "openrouter",
-                "model": cfg.openrouter_model,
-                "available": openrouter_available,
-            }
-        ],
-        "active": active,
-    }))
-}
-
-#[derive(Deserialize, Default)]
-struct CreateSessionBody {
-    #[serde(default)]
-    title: Option<String>,
-}
-
-async fn create_chat_session(
-    State(state): State<AppState>,
-    AxumPath(id): AxumPath<String>,
-    body: Option<Json<CreateSessionBody>>,
-) -> Result<Json<Value>, ApiError> {
-    let store = state
-        .session_store(&id)
-        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
-    let title = body.and_then(|b| b.0.title);
-    let sid = store
-        .create_session(title)
-        .map_err(|e| ApiError::internal(format!("create session: {e:#}")))?;
-    Ok(Json(json!({ "id": sid })))
-}
-
-async fn list_chat_sessions(
-    State(state): State<AppState>,
-    AxumPath(id): AxumPath<String>,
-) -> Result<Json<Value>, ApiError> {
-    let store = state
-        .session_store(&id)
-        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
-    let metas = store
-        .list_sessions()
-        .map_err(|e| ApiError::internal(format!("list sessions: {e:#}")))?;
-    Ok(Json(serde_json::to_value(metas).unwrap_or(json!([]))))
-}
-
-async fn get_chat_session(
-    State(state): State<AppState>,
-    AxumPath((id, session_id)): AxumPath<(String, String)>,
-) -> Result<Json<Value>, ApiError> {
-    let store = state
-        .session_store(&id)
-        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
-    let s = store
-        .get_session(&session_id)
-        .map_err(|e| ApiError::internal(format!("get session: {e:#}")))?
-        .ok_or_else(|| ApiError::not_found(format!("session not found: {session_id}")))?;
-    Ok(Json(serde_json::to_value(s).unwrap_or(json!({}))))
-}
-
-async fn delete_chat_session(
-    State(state): State<AppState>,
-    AxumPath((id, session_id)): AxumPath<(String, String)>,
-) -> Result<StatusCode, ApiError> {
-    let store = state
-        .session_store(&id)
-        .map_err(|e| ApiError::internal(format!("session store: {e:#}")))?;
-    store
-        .delete_session(&session_id)
-        .map_err(|e| ApiError::internal(format!("delete session: {e:#}")))?;
-    Ok(StatusCode::NO_CONTENT)
-}
-
-// ---------------------------------------------------------------------------
-// Inter-project messaging (issue #99)
-// ---------------------------------------------------------------------------
-
-/// Query parameters for `GET /api/v1/messages`.
-///
-/// Why: the receiver's SessionStart hook calls `unread_only=true` to fetch
-/// pending mail; the UI's audit view calls `unread_only=false` to render
-/// the full history.
-/// What: `palace` is the recipient slug; `unread_only` defaults to `false`.
-/// Test: `messages_endpoint_round_trip`.
-#[derive(Deserialize)]
-struct ListMessagesQuery {
-    palace: String,
-    #[serde(default)]
-    unread_only: Option<bool>,
-}
-
-/// `GET /api/v1/messages?palace=<id>&unread_only=<bool>` — list messages in
-/// a palace, optionally filtering to unread.
-///
-/// Why: serves the same data the MCP `inbox-check` CLI consumes, plus the UI
-/// audit log. Returns a JSON array of `{id, from_palace, to_palace, purpose,
-/// sent_at, read, content, formatted}` objects; `formatted` is the
-/// pre-rendered Markdown block the SessionStart hook emits to stdout.
-/// What: opens the palace, calls
-/// [`crate::messaging::list_messages`], and renders each message envelope
-/// plus its formatted block to JSON.
-/// Test: `messages_endpoint_round_trip`.
-async fn list_messages_handler(
-    State(state): State<AppState>,
-    Query(q): Query<ListMessagesQuery>,
-) -> Result<Json<Value>, ApiError> {
-    let handle = open_handle(&state, &q.palace)?;
-    let unread_only = q.unread_only.unwrap_or(false);
-    let messages = crate::messaging::list_messages(&handle, unread_only);
-    let payload: Vec<Value> = messages
-        .into_iter()
-        .map(|m| {
-            let formatted = m.to_injection_block();
-            json!({
-                "id":          m.id.to_string(),
-                "from_palace": m.from_palace,
-                "to_palace":   m.to_palace,
-                "purpose":     m.purpose,
-                "sent_at":     m.sent_at.to_rfc3339(),
-                "read":        m.read,
-                "content":     m.content,
-                "formatted":   formatted,
-            })
-        })
-        .collect();
-    Ok(Json(json!(payload)))
-}
-
-/// Request body for `POST /api/v1/messages`.
-///
-/// Why: the send path takes the same four fields whether invoked from MCP,
-/// CLI, or HTTP; sharing the JSON shape keeps callers interchangeable.
-/// What: `to_palace`, `purpose`, `content` are required; `from_palace`
-/// defaults to the server's `--palace` default if set, otherwise to
-/// `<unknown>` (sender SHOULD set it explicitly; the CLI does cwd
-/// derivation client-side so the daemon stays project-agnostic).
-/// Test: `messages_endpoint_round_trip`.
-#[derive(Deserialize)]
-struct SendMessageBody {
-    to_palace: String,
-    purpose: String,
-    content: String,
-    #[serde(default)]
-    from_palace: Option<String>,
-}
-
-/// `POST /api/v1/messages` — deliver an inter-project message.
-///
-/// Why: lets non-MCP callers (the `trusty-memory send-message` CLI, future
-/// remote callers) put messages on a recipient palace's queue. Mirrors the
-/// MCP `memory_send_message` tool exactly so they stay in lockstep.
-/// What: writes a tagged drawer into the recipient palace via
-/// [`crate::messaging::send_message_to_palace`]. Returns
-/// `{drawer_id, from_palace, to_palace, purpose, status: "sent"}` on success.
-/// Test: `messages_endpoint_round_trip`.
-async fn send_message_handler(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Json(body): Json<SendMessageBody>,
-) -> Result<Json<Value>, ApiError> {
-    let from_palace = body
-        .from_palace
-        .or_else(|| state.default_palace.clone())
-        .unwrap_or_else(|| "<unknown>".to_string());
-    let drawer_id = crate::messaging::send_message_to_palace(
-        &state.registry,
-        &state.data_root,
-        &from_palace,
-        &body.to_palace,
-        &body.purpose,
-        body.content,
-        creator_info_from_http(&headers),
-    )
-    .await
-    .map_err(|e| ApiError::internal(format!("send_message: {e:#}")))?;
-    // Emit a drawer-added SSE event so the dashboard activity feed shows
-    // the new message immediately.
-    let drawer_count = open_handle(&state, &body.to_palace)
-        .map(|h| h.drawers.read().len())
-        .unwrap_or(0);
-    state.emit(DaemonEvent::DrawerAdded {
-        palace_id: body.to_palace.clone(),
-        palace_name: body.to_palace.clone(),
-        drawer_count,
-        timestamp: chrono::Utc::now(),
-        content_preview: format!("[msg from {from_palace}] {}", body.purpose),
-        // Issue #96 — record the originating subsystem so the activity feed
-        // can badge this row as an HTTP-initiated message.
-        source: ActivitySource::Http,
-    });
-    Ok(Json(json!({
-        "drawer_id": drawer_id.to_string(),
-        "from_palace": from_palace,
-        "to_palace": body.to_palace,
-        "purpose": body.purpose,
-        "status": "sent",
-    })))
-}
-
-/// Request body for `POST /api/v1/messages/mark_read`.
-///
-/// Why: the SessionStart hook needs an explicit, idempotent ack so two
-/// concurrent sessions starting on the same palace don't double-deliver.
-/// What: identifies a single message by `(palace, drawer_id)`.
-/// Test: `messages_endpoint_round_trip`.
-#[derive(Deserialize)]
-struct MarkReadBody {
-    palace: String,
-    drawer_id: String,
-}
-
-/// `POST /api/v1/messages/mark_read` — atomically flip a message's read flag.
-///
-/// Why: separating ack from list lets the receiver atomically retire
-/// exactly the messages it printed, even when other writers are landing
-/// new messages in the same palace.
-/// What: parses the drawer id, calls
-/// [`crate::messaging::mark_message_read`], and returns `{flipped: bool}`
-/// where `flipped == true` iff this call was the one that flipped the flag
-/// (returning `false` is fine — it means the drawer was already read or
-/// has been concurrently removed; either way no further work is needed).
-/// Test: `messages_endpoint_round_trip`.
-async fn mark_message_read_handler(
-    State(state): State<AppState>,
-    Json(body): Json<MarkReadBody>,
-) -> Result<Json<Value>, ApiError> {
-    let uuid = Uuid::parse_str(&body.drawer_id)
-        .map_err(|_| ApiError::bad_request("drawer_id must be a UUID"))?;
-    let handle = open_handle(&state, &body.palace)?;
-    let flipped = crate::messaging::mark_message_read(&handle, uuid)
-        .await
-        .map_err(|e| ApiError::internal(format!("mark_read: {e:#}")))?;
-    Ok(Json(json!({"flipped": flipped})))
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn open_handle(
+pub(crate) fn open_handle(
     state: &AppState,
     id: &str,
 ) -> Result<std::sync::Arc<trusty_common::memory_core::PalaceHandle>, ApiError> {
@@ -3256,25 +2068,25 @@ fn open_handle(
 }
 
 /// Lightweight error type for HTTP handlers.
-struct ApiError {
+pub(crate) struct ApiError {
     status: StatusCode,
     message: String,
 }
 
 impl ApiError {
-    fn bad_request(msg: impl Into<String>) -> Self {
+    pub(crate) fn bad_request(msg: impl Into<String>) -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,
             message: msg.into(),
         }
     }
-    fn not_found(msg: impl Into<String>) -> Self {
+    pub(crate) fn not_found(msg: impl Into<String>) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,
             message: msg.into(),
         }
     }
-    fn internal(msg: impl Into<String>) -> Self {
+    pub(crate) fn internal(msg: impl Into<String>) -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             message: msg.into(),
@@ -4225,7 +3037,7 @@ mod tests {
     /// Test: This test itself.
     #[test]
     fn all_tools_returns_expected_set() {
-        let tools = all_tools();
+        let tools = crate::chat::all_tools();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
         assert_eq!(
             names,
@@ -4269,14 +3081,14 @@ mod tests {
     #[tokio::test]
     async fn execute_tool_dispatches_known_tools() {
         let state = test_state();
-        let result = execute_tool("list_palaces", "{}", &state).await;
+        let result = crate::chat::execute_tool("list_palaces", "{}", &state).await;
         assert!(
             result.is_array(),
             "list_palaces should be array, got {result}"
         );
         assert_eq!(result.as_array().unwrap().len(), 0);
 
-        let unknown = execute_tool("not_a_tool", "{}", &state).await;
+        let unknown = crate::chat::execute_tool("not_a_tool", "{}", &state).await;
         assert!(
             unknown["error"]
                 .as_str()
@@ -4285,7 +3097,7 @@ mod tests {
             "expected unknown-tool error, got {unknown}"
         );
 
-        let missing = execute_tool("get_palace", "{}", &state).await;
+        let missing = crate::chat::execute_tool("get_palace", "{}", &state).await;
         assert!(
             missing["error"]
                 .as_str()


### PR DESCRIPTION
## Summary

Splits the 5763-line `web.rs` god class into focused modules:

- **`service.rs`** (1069 lines) — `MemoryService` struct wrapping `AppState`; one async method per logical operation (recall, palace CRUD, drawer CRUD, KG, dream, prompt context). Returns `anyhow::Result<Value>` so HTTP and RPC layers share the same code paths.
- **`chat.rs`** (1234 lines) — entire chat cluster extracted: `all_tools()`, `execute_tool()`, `execute_*()` helpers, `chat_handler()`, session/message CRUD.
- **`mcp_service.rs`** (118 lines) — `ServiceDescriptor` impl for open-mpm integration.
- **`web.rs`** thinned to ~1429 lines of handler code (tests remain, ~2480 lines).

## Line counts

| File | Before | After |
|---|---|---|
| `web.rs` (handler code) | ~5763 | ~1429 |
| `service.rs` | — | 1069 |
| `chat.rs` | — | 1234 |
| `mcp_service.rs` | — | 118 |

## Test evidence

All 242 tests pass (219 unit + 23 integration). Clippy clean. fmt clean.

## Non-goals

- No behaviour change
- No API changes
- Tests intentionally left in `web.rs` (moving them is a separate task)

closes #151