### PR TITLE
feat(trusty-common): migrations feature + trusty-search consumer (closes #179)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10957,72 +10957,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "trusty-mpm-cli"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "clap",
- "colored 2.2.0",
- "dirs 5.0.1",
- "libc",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sysinfo",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "trusty-common",
- "trusty-mpm-client",
- "trusty-mpm-core",
- "trusty-mpm-daemon",
- "trusty-mpm-telegram",
- "trusty-mpm-tui",
-]
-
-[[package]]
-name = "trusty-mpm-client"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "axum 0.8.9",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
- "tracing",
- "trusty-mpm-core",
- "trusty-mpm-daemon",
- "uuid",
-]
-
-[[package]]
-name = "trusty-mpm-core"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "chrono",
- "dirs 5.0.1",
- "gray_matter",
- "libc",
- "nix 0.29.0",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2 0.10.9",
- "tempfile",
- "thiserror 1.0.69",
- "toml 0.8.23",
- "tracing",
- "utoipa",
- "uuid",
- "walkdir",
-]
-
-[[package]]
-name = "trusty-mpm-daemon"
+name = "trusty-mpm"
 version = "0.4.0"
 dependencies = [
  "anyhow",
@@ -11030,19 +10965,30 @@ dependencies = [
  "axum 0.8.9",
  "chrono",
  "clap",
+ "colored 2.2.0",
+ "crossterm",
  "dashmap 6.2.1",
  "dirs 5.0.1",
  "futures",
+ "gray_matter",
  "http-body-util",
+ "libc",
+ "nix 0.29.0",
  "notify 6.1.1",
  "parking_lot",
+ "ratatui",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "sha2 0.10.9",
+ "sysinfo",
+ "teloxide 0.13.0",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 0.8.23",
  "tower",
  "tower-http 0.6.11",
@@ -11050,8 +10996,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "trusty-common",
- "trusty-mpm-core",
- "trusty-mpm-mcp",
+ "trusty-mpm-gui",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -11069,63 +11014,6 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tokio",
-]
-
-[[package]]
-name = "trusty-mpm-mcp"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "trusty-common",
- "trusty-mpm-core",
- "uuid",
-]
-
-[[package]]
-name = "trusty-mpm-telegram"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "axum 0.8.9",
- "clap",
- "reqwest 0.12.28",
- "serde_json",
- "teloxide 0.13.0",
- "tempfile",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "trusty-mpm-client",
- "trusty-mpm-core",
- "trusty-mpm-daemon",
-]
-
-[[package]]
-name = "trusty-mpm-tui"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "crossterm",
- "ratatui",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "trusty-mpm-client",
- "trusty-mpm-core",
- "uuid",
 ]
 
 [[package]]

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -175,6 +175,11 @@ embedder = ["dep:fastembed", "dep:lru", "dep:parking_lot", "dep:ort"]
 # Enables the `bm25` module: zero-dependency BM25 lexical index +
 # code-aware tokenizer (issue #156). Pure `std` + `tracing` — no new deps.
 bm25 = []
+# Enables the `migrations` module: reusable schema-migration kernel
+# (`SchemaVersion`, `Migration`, `MigrationRunner`, file-stamp helpers).
+# Issue #179. Pure user of existing `serde` / `serde_json` / `anyhow` /
+# `tracing` workspace deps — adds no new dependencies.
+migrations = []
 # Enables the `bm25_client` module: a UDS JSON-RPC client for the per-palace
 # `trusty-bm25-daemon` subprocess (issue #156). Pure user of existing
 # `tokio` / `serde_json` / `anyhow` workspace deps — adds no new deps.

--- a/crates/trusty-common/README.md
+++ b/crates/trusty-common/README.md
@@ -38,6 +38,7 @@ trusty-common = { version = "0.3", features = ["axum-server", "mcp", "rpc", "emb
 | `symgraph` | Contracts surface only: `EntityType`, `RawEntity`, `EdgeKind` — no tree-sitter |
 | `symgraph-parser` | Full symbol graph: tree-sitter grammars, `SymbolGraph`, emitter, editor |
 | `symgraph-server` | HTTP server frontend for the symbol graph (implies `symgraph-parser`) |
+| `migrations` | Reusable schema-migration kernel: `SchemaVersion`, `Migration`, `MigrationRunner`, file-stamp helpers |
 
 By default the crate is dependency-light: `tokio`, `serde`, `reqwest`, and
 `tracing`. Pull in only the features you need.
@@ -203,6 +204,40 @@ let graph = SymbolGraph::parse_file("src/main.rs")?;
 library slot. Enable it in at most one crate per build graph (typically
 `open-mpm`). Downstream crates that only need the data types enable `symgraph`
 (contracts only) and stop there.
+
+## Migrations (`migrations` feature)
+
+Shared schema-migration kernel (issue #179) for long-lived trusty-* stores.
+Replaces the ad-hoc "if schema_version < N { … }" branches in trusty-search
+and trusty-memory with one ordered runner that stamps a `SchemaVersion`
+after each successful step.
+
+```rust
+use trusty_common::migrations::{
+    Migration, MigrationRunner, SchemaVersion,
+    file_stamp::{read_version_from_file, write_version_to_file},
+};
+use anyhow::Result;
+use std::path::Path;
+
+struct DropLegacyTables;
+impl Migration<MyStore> for DropLegacyTables {
+    fn from_version(&self) -> SchemaVersion { SchemaVersion::UNVERSIONED }
+    fn label(&self) -> &'static str { "drop legacy tables" }
+    fn apply(&self, store: &MyStore) -> Result<()> { /* … */ Ok(()) }
+}
+
+let runner = MigrationRunner::new(vec![Box::new(DropLegacyTables)]);
+let stamp_path = Path::new("/var/lib/my-store/schema_version.json");
+let current = read_version_from_file(stamp_path)?;
+runner.run(&store, current, |v| write_version_to_file(stamp_path, v))?;
+```
+
+The `file_stamp` module owns the JSON-sidecar stamp format
+(`{ "schema_version": <u32> }`, written atomically via temp + rename). Stores
+that already depend on redb should use the recipe documented in the
+`migrations::redb_stamp` module (kept doc-only here so this feature adds
+zero new dependencies).
 
 ## Development
 

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -139,6 +139,24 @@ pub mod embedder_client;
 #[cfg(feature = "bm25")]
 pub mod bm25;
 
+/// Reusable schema-migration kernel (issue #179).
+///
+/// Why: trusty-search, trusty-memory, and other long-lived stores have grown
+/// ad-hoc schema-migration loops that drift apart. Centralising the
+/// `SchemaVersion` newtype, the `Migration<S>` trait, and a `MigrationRunner`
+/// that applies pending steps in order (writing a stamp after each) collapses
+/// those into one shared kernel. The `file_stamp` helper covers the common
+/// "JSON sidecar in the store's data dir" stamp format; redb-stamp users get
+/// a documented recipe instead of a heavyweight dep.
+/// What: gated behind the `migrations` feature flag. Adds no new
+/// dependencies — pure `serde` + `serde_json` + `anyhow` + `tracing` which
+/// the crate already requires.
+/// Test: `cargo test -p trusty-common --features migrations` covers the
+/// runner ordering, crash resumption, write-stamp failure propagation, and
+/// the file-stamp round-trip / atomic-write behaviour.
+#[cfg(feature = "migrations")]
+pub mod migrations;
+
 /// UDS JSON-RPC client for the per-palace `trusty-bm25-daemon` subprocess
 /// (issue #156).
 ///

--- a/crates/trusty-common/src/migrations/file_stamp.rs
+++ b/crates/trusty-common/src/migrations/file_stamp.rs
@@ -1,0 +1,205 @@
+//! File-based schema-version stamp (JSON sidecar).
+//!
+//! Why: many trusty-* stores already keep their durable state next to a
+//! per-store directory (`index.redb`, `palace/kg.redb`, …). The simplest stamp
+//! storage is a tiny JSON sidecar in that same directory — easy to inspect,
+//! easy to write atomically, no extra schema to migrate. This module is the
+//! one place that owns the on-disk file layout so every store that opts into
+//! it stays compatible.
+//!
+//! What: two free functions — `read_version_from_file` and
+//! `write_version_to_file` — both operating on a JSON object of the form
+//! `{ "schema_version": <u32> }`. The write path uses temp-file + rename for
+//! atomicity so a crash mid-write cannot truncate the stamp.
+//!
+//! Test: `file_stamp_roundtrip`, `read_returns_unversioned_when_missing`,
+//! `read_returns_unversioned_on_corrupt_payload`,
+//! `write_is_atomic_via_tmp_rename`.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::SchemaVersion;
+
+/// On-disk shape of the stamp sidecar.
+///
+/// Why: keeping the wire format in a dedicated struct (rather than serialising
+/// a bare `u32`) leaves room for future additions (timestamps, migration
+/// labels) without breaking existing files — every new field would be optional
+/// and `#[serde(default)]`-friendly.
+/// What: a single `schema_version` field. Serialised as `{ "schema_version":
+/// N }`.
+/// Test: covered by the round-trip test in this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct StampFile {
+    schema_version: u32,
+}
+
+/// Read the [`SchemaVersion`] from a JSON sidecar at `path`.
+///
+/// Why: callers need a single line to answer "what version is the store on?"
+/// without writing the same `match fs::read → from_slice → unwrap_or` ladder
+/// every time. The behaviour is defensive by design — a missing file or a
+/// malformed payload are *not* errors, they map to
+/// [`SchemaVersion::UNVERSIONED`] so the [`super::MigrationRunner`] runs every
+/// step from scratch (which is the correct behaviour for a fresh store *or*
+/// for one whose stamp was lost / hand-edited).
+/// What: reads `path`, parses it as `{ "schema_version": <u32> }`, and
+/// returns the resulting [`SchemaVersion`]. `Ok(UNVERSIONED)` when the file
+/// is absent or unparseable; an `Err` is only returned for I/O errors other
+/// than `NotFound` (permission denied, etc.).
+/// Test: `file_stamp_roundtrip`, `read_returns_unversioned_when_missing`,
+/// `read_returns_unversioned_on_corrupt_payload`.
+pub fn read_version_from_file(path: &Path) -> Result<SchemaVersion> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(SchemaVersion::UNVERSIONED);
+        }
+        Err(e) => {
+            return Err(e).with_context(|| format!("read schema stamp at {}", path.display()));
+        }
+    };
+    match serde_json::from_slice::<StampFile>(&bytes) {
+        Ok(stamp) => Ok(SchemaVersion(stamp.schema_version)),
+        Err(e) => {
+            tracing::warn!(
+                "schema stamp at {} is malformed ({e}) — treating as UNVERSIONED",
+                path.display()
+            );
+            Ok(SchemaVersion::UNVERSIONED)
+        }
+    }
+}
+
+/// Write a [`SchemaVersion`] to a JSON sidecar at `path`, atomically.
+///
+/// Why: the [`super::MigrationRunner`] invokes this after every successful
+/// migration step. A crash mid-write must never leave a truncated stamp on
+/// disk — the next boot would mis-identify the schema. Temp-file plus
+/// rename is the standard cross-platform atomic-write pattern; on POSIX the
+/// rename itself is guaranteed atomic, and on Windows it falls back to a
+/// best-effort replace which is still safer than a direct write.
+/// What: serialises `{ "schema_version": version.0 }` into a sibling
+/// `<path>.tmp` file, then renames it over `path`. Creates any missing
+/// parent directory components first.
+/// Test: `file_stamp_roundtrip`, `write_is_atomic_via_tmp_rename`.
+pub fn write_version_to_file(path: &Path, version: SchemaVersion) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create parent of schema stamp {}", path.display()))?;
+    }
+    let stamp = StampFile {
+        schema_version: version.0,
+    };
+    let bytes = serde_json::to_vec(&stamp).context("serialize schema stamp")?;
+    // Use a `.tmp` sibling instead of `path.with_extension("tmp")` so we don't
+    // clobber a stamp whose filename happens to lack an extension (e.g.
+    // `schema_version`).
+    let tmp = {
+        let mut t = path.as_os_str().to_owned();
+        t.push(".tmp");
+        std::path::PathBuf::from(t)
+    };
+    std::fs::write(&tmp, &bytes)
+        .with_context(|| format!("write temp schema stamp {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("rename schema stamp into place at {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> std::path::PathBuf {
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let p = std::env::temp_dir().join(format!("trusty-common-stamp-test-{pid}-{nanos}"));
+        std::fs::create_dir_all(&p).expect("create scratch dir");
+        p
+    }
+
+    #[test]
+    fn file_stamp_roundtrip() {
+        // Why: baseline — write a version, read it back, expect equality.
+        let dir = tempdir();
+        let path = dir.join("schema_version.json");
+        write_version_to_file(&path, SchemaVersion(7)).expect("write succeeds");
+        let got = read_version_from_file(&path).expect("read succeeds");
+        assert_eq!(got, SchemaVersion(7));
+    }
+
+    #[test]
+    fn read_returns_unversioned_when_missing() {
+        // Why: a brand-new store has no stamp on disk yet. The reader must
+        // map that to UNVERSIONED so the runner applies every step.
+        let dir = tempdir();
+        let path = dir.join("missing.json");
+        let got = read_version_from_file(&path).expect("missing file is not an error");
+        assert_eq!(got, SchemaVersion::UNVERSIONED);
+    }
+
+    #[test]
+    fn read_returns_unversioned_on_corrupt_payload() {
+        // Why: a hand-edited / truncated stamp must not crash the daemon.
+        let dir = tempdir();
+        let path = dir.join("schema_version.json");
+        std::fs::write(&path, b"this is not json").expect("write garbage");
+        let got = read_version_from_file(&path).expect("corrupt file is not an error");
+        assert_eq!(got, SchemaVersion::UNVERSIONED);
+    }
+
+    #[test]
+    fn write_is_atomic_via_tmp_rename() {
+        // Why: confirm the documented atomicity pattern (`.tmp` sibling +
+        // rename) is what actually happens. Catches a future refactor that
+        // accidentally switches to a direct write.
+        let dir = tempdir();
+        let path = dir.join("schema_version.json");
+        write_version_to_file(&path, SchemaVersion(3)).expect("write");
+        // The `.tmp` file must not linger after a successful write.
+        let tmp = {
+            let mut t = path.as_os_str().to_owned();
+            t.push(".tmp");
+            std::path::PathBuf::from(t)
+        };
+        assert!(
+            !tmp.exists(),
+            "temp file should be renamed away, but {} still exists",
+            tmp.display()
+        );
+        assert!(path.exists(), "final stamp file must exist after write");
+    }
+
+    #[test]
+    fn write_creates_missing_parent_directories() {
+        // Why: callers often pass a path under a not-yet-created data dir.
+        // The writer must materialise the parent before writing.
+        let dir = tempdir();
+        let nested = dir.join("a").join("b").join("c");
+        let path = nested.join("schema_version.json");
+        write_version_to_file(&path, SchemaVersion(1))
+            .expect("nested write creates intermediate dirs");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn overwrite_replaces_existing_stamp() {
+        // Why: every successful migration step overwrites the stamp. Confirm
+        // the second write replaces the first cleanly (no append, no error).
+        let dir = tempdir();
+        let path = dir.join("schema_version.json");
+        write_version_to_file(&path, SchemaVersion(1)).expect("first write");
+        write_version_to_file(&path, SchemaVersion(2)).expect("second write");
+        assert_eq!(
+            read_version_from_file(&path).expect("read"),
+            SchemaVersion(2)
+        );
+    }
+}

--- a/crates/trusty-common/src/migrations/mod.rs
+++ b/crates/trusty-common/src/migrations/mod.rs
@@ -1,0 +1,456 @@
+//! Reusable schema-migration kernel for the trusty-* ecosystem (issue #179).
+//!
+//! Why: every long-lived trusty-* store ships its own ad-hoc "is this schema
+//! version N or N-1?" branch. `trusty-search` migrated `chunks.json → redb`,
+//! `trusty-memory` lazy-upgrades legacy drawer rows, the vector-store lane
+//! drains `.usearch` files behind a `usearch-migrate` feature, and the palace
+//! store stamps a `schema_version` field that nothing ever reads. The code is
+//! correct in isolation but drifts subtly across crates and the next migration
+//! starts from scratch every time. This module is the single shared kernel:
+//! a `SchemaVersion` stamp, a `Migration` trait, and a `MigrationRunner` that
+//! applies pending steps in order and writes the stamp after each.
+//!
+//! What: pure-data API gated behind the `migrations` feature flag. No new
+//! crate-level dependencies — uses `anyhow` and `serde` which the workspace
+//! already requires. Helper modules cover the two common stamp formats
+//! (`file_stamp` for a JSON sidecar; `redb_stamp` is documentation-only
+//! because redb is not a trusty-common dependency).
+//!
+//! Test: `cargo test -p trusty-common --features migrations` exercises the
+//! runner ordering, crash-resumption semantics, and the file-stamp round-trip.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+pub mod file_stamp;
+pub mod redb_stamp;
+
+/// A u32 schema version stamp.
+///
+/// Why: every persisted store needs an unambiguous "what schema is this on?"
+/// answer that survives a process restart. A monotonically-increasing `u32` is
+/// the smallest workable representation — it round-trips through JSON,
+/// postcard, and redb without surprises, and the explicit `UNVERSIONED` zero
+/// sentinel lets a brand-new store self-identify as "pre-migration" without
+/// requiring callers to special-case `None`.
+/// What: a newtype around `u32`. `0` is reserved as [`Self::UNVERSIONED`] —
+/// every real schema starts at version 1. Comparison is the underlying
+/// integer order, so a `MigrationRunner` can ask "is the on-disk version
+/// strictly less than the target?" with the natural `<` operator.
+/// Test: `schema_version_ordering` confirms `UNVERSIONED < SchemaVersion(1)
+/// < SchemaVersion(2)`; round-trip through serde is covered by the
+/// `file_stamp_roundtrip` test in `file_stamp::tests`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
+#[serde(transparent)]
+pub struct SchemaVersion(pub u32);
+
+impl SchemaVersion {
+    /// Sentinel for stores that have never recorded a schema version — they
+    /// were created before the migration kernel existed (or were just
+    /// initialised and haven't run their first migration yet).
+    ///
+    /// Why: callers want to distinguish "fresh store, run every migration"
+    /// from "version 1, only run migrations 2 onwards" without resorting to
+    /// `Option<SchemaVersion>`. Reserving 0 as a sentinel keeps the type
+    /// `Copy` and makes the "no stamp on disk → default to UNVERSIONED"
+    /// fallback trivial.
+    /// What: `SchemaVersion(0)`. By convention, no [`Migration`] should
+    /// declare `from_version() == UNVERSIONED.next()` of itself — the very
+    /// first migration step in any store runs from `UNVERSIONED` to
+    /// `SchemaVersion(1)`.
+    /// Test: `schema_version_ordering` plus `runner_applies_pending_steps`
+    /// (which starts at `UNVERSIONED` and walks through two steps).
+    pub const UNVERSIONED: Self = Self(0);
+
+    /// Return the version that immediately follows this one.
+    ///
+    /// Why: the [`MigrationRunner`] writes the stamp as
+    /// `step.from_version().next()` after each successful migration. Lifting
+    /// the `+ 1` into a named method keeps that hot path readable and the
+    /// invariant ("each step advances exactly one major version") visible in
+    /// the type's API.
+    /// What: returns `SchemaVersion(self.0 + 1)`. Saturates at `u32::MAX`
+    /// (`saturating_add(1)`) so a malformed schema version on disk can never
+    /// trigger arithmetic-overflow undefined behaviour or panic — instead the
+    /// next runner pass observes `current >= target` and exits cleanly.
+    /// Test: covered by the runner tests, which assert the stamp written
+    /// after step `n` equals `SchemaVersion(n + 1)`.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+impl std::fmt::Display for SchemaVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "v{}", self.0)
+    }
+}
+
+/// A single ordered migration step that moves a store from `from_version`
+/// to `from_version.next()`.
+///
+/// Why: every migration the trusty-* ecosystem has shipped fits the same
+/// shape — "given a store that is currently on version N, do the work to
+/// make it version N+1." Encoding that shape as a trait gives the
+/// [`MigrationRunner`] one composable abstraction to register and dispatch
+/// against, and forces new migrations to declare their starting version
+/// explicitly (no more "this one runs first" comments). The generic `S`
+/// parameter is whatever store handle the migration body operates on
+/// (a `CodeIndexer`, a `PalaceStore`, a `redb::Database`, …) so the kernel
+/// is store-agnostic.
+/// What: three methods. `from_version` is the version this step expects to
+/// see on disk before it runs (the runner skips a step whose
+/// `from_version` is `< current`). `label` is a short human-readable
+/// identifier for logs (`"chunks.json → index.redb"`, `"drop legacy
+/// drawers table"`). `apply` performs the actual migration — it owns the
+/// store reference and returns `Result<()>` so failures surface to the
+/// runner, which then leaves the stamp at the previous version so a retry
+/// can resume.
+/// Test: covered by `runner_applies_pending_steps`,
+/// `runner_skips_already_applied`, and `runner_is_incremental_on_crash`
+/// in this module's tests.
+pub trait Migration<S>: Send + Sync {
+    /// Schema version this step expects on disk before it runs.
+    ///
+    /// Why: the runner uses this as the dispatch key. A step whose
+    /// `from_version()` is strictly less than the current on-disk version
+    /// is treated as already-applied and skipped; otherwise the runner
+    /// fires `apply(store)` and writes the stamp at `from_version.next()`.
+    /// What: a [`SchemaVersion`]. The very first migration of any store
+    /// returns [`SchemaVersion::UNVERSIONED`].
+    ///
+    /// `clippy::wrong_self_convention` would prefer `from_*` to take no
+    /// `&self`, but this method is the trait's central accessor — it asks
+    /// "what version does *this* step expect?" so taking `&self` is the
+    /// correct shape for a `Box<dyn Migration<S>>` dispatch table.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_version(&self) -> SchemaVersion;
+
+    /// Short human-readable label used in `tracing` logs.
+    ///
+    /// Why: operators reading daemon logs need to see *what* the runner is
+    /// doing without grepping source. A static `&'static str` keeps the
+    /// trait object-safe without forcing the migration body to materialise
+    /// a `String` on every call.
+    /// What: a `&'static str`. Should be terse — "JSON corpus → redb",
+    /// "drop community tables".
+    fn label(&self) -> &'static str;
+
+    /// Apply the migration to `store`.
+    ///
+    /// Why: this is where the actual data movement / schema rewrite
+    /// happens. The runner guarantees `apply` is called exactly once per
+    /// step per `run()` invocation, in increasing version order, and only
+    /// when the on-disk version permits it (so the migration body never
+    /// has to defend against "am I already applied?" itself).
+    /// What: receives `&S` (the store handle is shared by reference so the
+    /// caller can keep using the store afterwards). Returns
+    /// `Result<()>` — an `Err` aborts the runner, leaving the on-disk
+    /// stamp at the previous version so a later `run()` resumes from the
+    /// same step.
+    fn apply(&self, store: &S) -> Result<()>;
+}
+
+/// Applies pending [`Migration`] steps in order, writing a [`SchemaVersion`]
+/// stamp after each successful application.
+///
+/// Why: the trusty-* ecosystem has at least four open-coded migration loops
+/// today, each subtly different (some forget to stamp after success, some
+/// stamp before running so a crash mid-step appears completed). Centralising
+/// the loop into a runner that owns the ordering, the skip-if-already-applied
+/// logic, and the stamp-after-success contract removes that drift entirely.
+/// The closure-based `write_stamp` callback keeps the runner storage-agnostic
+/// — JSON sidecar, redb metadata table, in-memory test stub all share one
+/// runner.
+/// What: holds the registered steps as `Vec<Box<dyn Migration<S>>>` so each
+/// runner instance can mix migrations against the same store type. `run()`
+/// sorts by `from_version`, dispatches each pending step (one whose
+/// `from_version >= current`), calls `write_stamp(step.from_version.next())`
+/// after a successful `apply`, and returns the final reached version. A
+/// failing step short-circuits the loop without rewriting the stamp.
+/// Test: see the module-level `tests` block.
+pub struct MigrationRunner<S> {
+    steps: Vec<Box<dyn Migration<S>>>,
+}
+
+impl<S> MigrationRunner<S> {
+    /// Build a runner from a list of migration steps.
+    ///
+    /// Why: the call site already owns the migration registry (it is the
+    /// only place that knows which migrations exist for that particular
+    /// store), so constructing the runner with the registry inline keeps
+    /// the configuration co-located with the dispatch.
+    /// What: stores the steps verbatim, sorted by `from_version` so the
+    /// dispatch loop can walk them in order without re-sorting per call.
+    /// Duplicate `from_version` values are permitted but the second is
+    /// effectively dead code (the first applies, advances the stamp, the
+    /// second's `from_version < current` and is skipped).
+    /// Test: ordering is asserted by `runner_applies_pending_steps`.
+    pub fn new(mut steps: Vec<Box<dyn Migration<S>>>) -> Self {
+        steps.sort_by_key(|s| s.from_version());
+        Self { steps }
+    }
+
+    /// The schema version this runner advances the store to when every
+    /// registered step has been applied.
+    ///
+    /// Why: callers want to know "is this store fully up to date?" without
+    /// having to peek into the step list. Exposing the target version as a
+    /// method also makes the runner's intent self-documenting in logs:
+    /// `"migrations: target=vN, current=vM"`.
+    /// What: returns the last step's `from_version.next()`, or
+    /// [`SchemaVersion::UNVERSIONED`] if no steps are registered (which is
+    /// not a typical configuration — a runner with zero steps is a no-op).
+    /// Test: covered by `runner_target_version_matches_last_step`.
+    pub fn target_version(&self) -> SchemaVersion {
+        self.steps
+            .last()
+            .map(|s| s.from_version().next())
+            .unwrap_or(SchemaVersion::UNVERSIONED)
+    }
+
+    /// Run all pending migrations, returning the final reached version.
+    ///
+    /// Why: the runner contract is "advance the store from `current` to
+    /// `target_version()`, stamping after each successful step so a crash
+    /// is recoverable." Returning the reached version lets the caller log
+    /// (and assert in tests) where the migration ended up — equal to
+    /// `target_version()` on full success, equal to a step's
+    /// `from_version()` if that step failed.
+    /// What: walks the (already sorted) step list, skipping any step whose
+    /// `from_version()` is strictly less than `current`. For each
+    /// applicable step, calls `apply(store)`; on success calls
+    /// `write_stamp(step.from_version().next())`; on failure returns the
+    /// error without rewriting the stamp. A `write_stamp` failure is
+    /// treated as a migration failure (the data was migrated but we can no
+    /// longer record that it was migrated, which would invite a re-run on
+    /// the next boot — explicit failure is safer than silent inconsistency).
+    /// Test: `runner_applies_pending_steps`, `runner_skips_already_applied`,
+    /// `runner_is_incremental_on_crash`, and
+    /// `runner_propagates_write_stamp_failure`.
+    pub fn run(
+        &self,
+        store: &S,
+        current: SchemaVersion,
+        write_stamp: impl Fn(SchemaVersion) -> Result<()>,
+    ) -> Result<SchemaVersion> {
+        let mut reached = current;
+        for step in &self.steps {
+            if step.from_version() < reached {
+                tracing::debug!(
+                    "migrations: skipping '{}' ({} < {})",
+                    step.label(),
+                    step.from_version(),
+                    reached
+                );
+                continue;
+            }
+            tracing::info!(
+                "migrations: applying '{}' ({} → {})",
+                step.label(),
+                step.from_version(),
+                step.from_version().next()
+            );
+            step.apply(store)?;
+            let next = step.from_version().next();
+            write_stamp(next)?;
+            reached = next;
+        }
+        Ok(reached)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+    /// In-memory test store: tracks which steps fired and the last stamp
+    /// the runner wrote.
+    #[derive(Default)]
+    struct TestStore {
+        step_0_ran: AtomicBool,
+        step_1_ran: AtomicBool,
+        step_2_ran: AtomicBool,
+        last_stamp: AtomicU32,
+    }
+
+    impl TestStore {
+        fn stamp(&self) -> SchemaVersion {
+            SchemaVersion(self.last_stamp.load(Ordering::SeqCst))
+        }
+        fn write_stamp(&self) -> impl Fn(SchemaVersion) -> Result<()> + '_ {
+            move |v: SchemaVersion| {
+                self.last_stamp.store(v.0, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+    }
+
+    struct Step0;
+    impl Migration<TestStore> for Step0 {
+        fn from_version(&self) -> SchemaVersion {
+            SchemaVersion::UNVERSIONED
+        }
+        fn label(&self) -> &'static str {
+            "step 0 → 1"
+        }
+        fn apply(&self, store: &TestStore) -> Result<()> {
+            store.step_0_ran.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct Step1;
+    impl Migration<TestStore> for Step1 {
+        fn from_version(&self) -> SchemaVersion {
+            SchemaVersion(1)
+        }
+        fn label(&self) -> &'static str {
+            "step 1 → 2"
+        }
+        fn apply(&self, store: &TestStore) -> Result<()> {
+            store.step_1_ran.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// A step that always fails — exercises the crash-resumption invariant.
+    struct FailingStep2;
+    impl Migration<TestStore> for FailingStep2 {
+        fn from_version(&self) -> SchemaVersion {
+            SchemaVersion(2)
+        }
+        fn label(&self) -> &'static str {
+            "step 2 → 3 (failing)"
+        }
+        fn apply(&self, store: &TestStore) -> Result<()> {
+            store.step_2_ran.store(true, Ordering::SeqCst);
+            Err(anyhow::anyhow!("simulated migration failure"))
+        }
+    }
+
+    #[test]
+    fn schema_version_ordering() {
+        // Why: the runner relies on `<` to decide which steps are pending.
+        // What: confirm UNVERSIONED is strictly less than v1, v1 < v2, and
+        // equality round-trips.
+        assert!(SchemaVersion::UNVERSIONED < SchemaVersion(1));
+        assert!(SchemaVersion(1) < SchemaVersion(2));
+        assert_eq!(SchemaVersion::UNVERSIONED, SchemaVersion(0));
+        assert_eq!(SchemaVersion(5).next(), SchemaVersion(6));
+        // `next()` saturates so a corrupted-on-disk MAX never panics.
+        assert_eq!(SchemaVersion(u32::MAX).next(), SchemaVersion(u32::MAX));
+    }
+
+    #[test]
+    fn runner_applies_pending_steps() {
+        // Why: baseline correctness — start at UNVERSIONED, two steps, both
+        // should fire in order and the final stamp should equal the target.
+        let store = TestStore::default();
+        let runner: MigrationRunner<TestStore> =
+            MigrationRunner::new(vec![Box::new(Step0), Box::new(Step1)]);
+        let reached = runner
+            .run(&store, SchemaVersion::UNVERSIONED, store.write_stamp())
+            .expect("two-step migration succeeds");
+
+        assert!(store.step_0_ran.load(Ordering::SeqCst));
+        assert!(store.step_1_ran.load(Ordering::SeqCst));
+        assert_eq!(reached, SchemaVersion(2));
+        assert_eq!(store.stamp(), SchemaVersion(2));
+        assert_eq!(runner.target_version(), SchemaVersion(2));
+    }
+
+    #[test]
+    fn runner_skips_already_applied() {
+        // Why: starting at v1 means step 0 → 1 is already applied; only step
+        // 1 → 2 should fire.
+        let store = TestStore::default();
+        let runner: MigrationRunner<TestStore> =
+            MigrationRunner::new(vec![Box::new(Step0), Box::new(Step1)]);
+        let reached = runner
+            .run(&store, SchemaVersion(1), store.write_stamp())
+            .expect("resume-from-v1 succeeds");
+
+        assert!(
+            !store.step_0_ran.load(Ordering::SeqCst),
+            "step 0 should be skipped when current >= v1"
+        );
+        assert!(store.step_1_ran.load(Ordering::SeqCst));
+        assert_eq!(reached, SchemaVersion(2));
+        assert_eq!(store.stamp(), SchemaVersion(2));
+    }
+
+    #[test]
+    fn runner_is_incremental_on_crash() {
+        // Why: the central crash-safety invariant — if step 2 → 3 fails, the
+        // stamp written for step 1 → 2 must persist (so a retry resumes at v2,
+        // not at the beginning).
+        let store = TestStore::default();
+        let runner: MigrationRunner<TestStore> = MigrationRunner::new(vec![
+            Box::new(Step0),
+            Box::new(Step1),
+            Box::new(FailingStep2),
+        ]);
+        let err = runner
+            .run(&store, SchemaVersion::UNVERSIONED, store.write_stamp())
+            .expect_err("FailingStep2 should fail");
+        assert!(
+            err.to_string().contains("simulated migration failure"),
+            "unexpected error message: {err}"
+        );
+        assert!(store.step_0_ran.load(Ordering::SeqCst));
+        assert!(store.step_1_ran.load(Ordering::SeqCst));
+        assert!(store.step_2_ran.load(Ordering::SeqCst));
+        // Stamp is at v2 because step 1 → 2 ran and stamped, then step 2 → 3
+        // fired but errored *after* writing nothing.
+        assert_eq!(store.stamp(), SchemaVersion(2));
+    }
+
+    #[test]
+    fn runner_propagates_write_stamp_failure() {
+        // Why: a write_stamp failure must surface to the caller — silently
+        // proceeding would leave an unrecorded migration.
+        let store = TestStore::default();
+        let runner: MigrationRunner<TestStore> = MigrationRunner::new(vec![Box::new(Step0)]);
+        let err = runner
+            .run(&store, SchemaVersion::UNVERSIONED, |_v| {
+                Err(anyhow::anyhow!("stamp write failed"))
+            })
+            .expect_err("write_stamp failure should propagate");
+        assert!(err.to_string().contains("stamp write failed"));
+        // The migration body ran, but the runner correctly reported failure.
+        assert!(store.step_0_ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn runner_target_version_matches_last_step() {
+        // Why: documented contract — target_version() is the stamp the runner
+        // writes after the final step.
+        let runner_empty: MigrationRunner<TestStore> = MigrationRunner::new(vec![]);
+        assert_eq!(runner_empty.target_version(), SchemaVersion::UNVERSIONED);
+
+        let runner_two: MigrationRunner<TestStore> =
+            MigrationRunner::new(vec![Box::new(Step0), Box::new(Step1)]);
+        assert_eq!(runner_two.target_version(), SchemaVersion(2));
+    }
+
+    #[test]
+    fn runner_handles_out_of_order_step_registration() {
+        // Why: the constructor must sort the steps so callers can register
+        // them in any order — useful when many small migration modules each
+        // contribute one step to a shared `Vec`.
+        let store = TestStore::default();
+        let runner: MigrationRunner<TestStore> =
+            MigrationRunner::new(vec![Box::new(Step1), Box::new(Step0)]);
+        runner
+            .run(&store, SchemaVersion::UNVERSIONED, store.write_stamp())
+            .expect("out-of-order registration runs in version order");
+        assert!(store.step_0_ran.load(Ordering::SeqCst));
+        assert!(store.step_1_ran.load(Ordering::SeqCst));
+        assert_eq!(store.stamp(), SchemaVersion(2));
+    }
+}

--- a/crates/trusty-common/src/migrations/redb_stamp.rs
+++ b/crates/trusty-common/src/migrations/redb_stamp.rs
@@ -1,0 +1,55 @@
+//! Documentation-only stub for storing schema-version stamps inside redb.
+//!
+//! Why: redb is not a direct dependency of `trusty-common` — it lives behind
+//! the heavyweight `memory-core` feature flag — so this crate cannot offer
+//! a generic redb-stamp helper without dragging redb into every consumer's
+//! build graph. Crates that already depend on redb (`trusty-search`,
+//! `trusty-memory`) can implement the equivalent five-line helper locally
+//! using the recipe below.
+//!
+//! What: this module is intentionally empty of types. It exists so callers
+//! grepping for "redb_stamp" find the convention documented in one place.
+//!
+//! Test: none — the recipe is exercised by the crate that adopts it.
+//!
+//! # Recipe
+//!
+//! ```text
+//! // Local to the consumer crate, alongside its existing `redb::Database`:
+//!
+//! use redb::{Database, TableDefinition};
+//! use trusty_common::migrations::SchemaVersion;
+//! use anyhow::Result;
+//!
+//! const META_TABLE: TableDefinition<&'static str, u32> = TableDefinition::new("meta");
+//! const STAMP_KEY: &str = "schema_version";
+//!
+//! pub fn read_redb_stamp(db: &Database) -> Result<SchemaVersion> {
+//!     let txn = db.begin_read()?;
+//!     let table = match txn.open_table(META_TABLE) {
+//!         Ok(t) => t,
+//!         // Table missing means the store predates the migration kernel.
+//!         Err(redb::TableError::TableDoesNotExist(_)) => {
+//!             return Ok(SchemaVersion::UNVERSIONED);
+//!         }
+//!         Err(e) => return Err(e.into()),
+//!     };
+//!     match table.get(STAMP_KEY)? {
+//!         Some(v) => Ok(SchemaVersion(v.value())),
+//!         None => Ok(SchemaVersion::UNVERSIONED),
+//!     }
+//! }
+//!
+//! pub fn write_redb_stamp(db: &Database, v: SchemaVersion) -> Result<()> {
+//!     let txn = db.begin_write()?;
+//!     {
+//!         let mut table = txn.open_table(META_TABLE)?;
+//!         table.insert(STAMP_KEY, v.0)?;
+//!     }
+//!     txn.commit()?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Pass `write_redb_stamp` as the `write_stamp` closure to
+//! [`super::MigrationRunner::run`].

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/main.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.6.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156)
+trusty-common = { version = "0.6.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179)
 
 # ── Async runtime / HTTP ───────────────────────────────────────────────────
 tokio = { version = "1", features = ["full"] }

--- a/crates/trusty-search/src/core/indexer/migrations.rs
+++ b/crates/trusty-search/src/core/indexer/migrations.rs
@@ -1,0 +1,170 @@
+//! `trusty-search` migration steps, registered against the shared
+//! [`trusty_common::migrations`] kernel (issue #179).
+//!
+//! Why: historically the warm-boot path in `service::persistence_loader`
+//! open-coded a "try redb; if empty, read JSON; if non-empty, migrate JSON →
+//! redb" cascade. The branching was correct but it was the *only* migration
+//! the workspace had, drifting away from any reusable shape. Now that
+//! `trusty-common` exposes `Migration` / `MigrationRunner`, this module is
+//! the dispatch table — every new schema migration for trusty-search adds a
+//! step here, and the runner orchestrates the order + stamps the schema
+//! version file.
+//!
+//! What: defines [`JsonCorpusToRedbMigration`] (UNVERSIONED → v1), which is
+//! the canonical entry point for the legacy `chunks.json` → `index.redb`
+//! transfer. The migration body is a thin sync wrapper around the existing
+//! async [`crate::core::indexer::CodeIndexer::load_chunks_from_disk`] and
+//! [`crate::core::indexer::CodeIndexer::migrate_corpus_to_redb`] helpers —
+//! the imperative logic is unchanged; only the orchestration moves under the
+//! runner.
+//!
+//! Test: covered indirectly by the existing `service::persistence_loader`
+//! integration tests; the runner contract itself is unit-tested in
+//! `trusty-common::migrations`.
+
+use anyhow::Result;
+
+use trusty_common::migrations::{Migration, SchemaVersion};
+
+use crate::core::indexer::CodeIndexer;
+use crate::service::persistence;
+
+/// Target schema version once every registered trusty-search migration has
+/// been applied.
+///
+/// Why: lets the persistence loader log "current vs. target" and lets tests
+/// assert the on-disk stamp converged to the expected value. Bump this
+/// whenever a new migration step is added.
+/// What: an alias for `SchemaVersion(1)` — Phase 1 introduces exactly one
+/// step (JSON → redb).
+/// Test: covered by the runner-target assertions in
+/// `trusty-common::migrations::tests` (any new migration here should add an
+/// equivalent assertion in `core::indexer::tests`).
+pub const TRUSTY_SEARCH_SCHEMA_TARGET: SchemaVersion = SchemaVersion(1);
+
+/// One-time migration that copies a legacy `chunks.json` snapshot into the
+/// redb corpus store (issue #28, registered with the kernel under #179).
+///
+/// Why: daemons that booted on a pre-#28 build accumulated a `chunks.json`
+/// snapshot next to an empty `index.redb`. The runner makes this the first
+/// (and currently only) registered migration — a fresh install lands on the
+/// "empty redb" branch directly and stamps schema v1 without doing any work,
+/// whereas an upgraded install lands on the "load JSON → seed redb" branch.
+/// What: a unit struct whose `apply` body bridges the sync runner into the
+/// existing async migration helpers via `tokio::task::block_in_place` +
+/// `Handle::current().block_on` — the trusty-search daemon always runs on
+/// the multi-threaded tokio runtime (`#[tokio::main]` default) so the
+/// bridge is safe. Reads the JSON snapshot through
+/// [`CodeIndexer::load_chunks_from_disk`] (which restores BM25 + symbol
+/// graph as a side effect) and then seeds redb via
+/// [`CodeIndexer::migrate_corpus_to_redb`]. A missing or empty JSON file is
+/// the genuine first-boot case and yields `Ok(())` — the stamp still moves
+/// to v1 so subsequent boots skip this step entirely.
+/// Test: end-to-end coverage lives in
+/// `service::persistence_loader`-driven integration tests; the runner-skip
+/// semantics are unit-tested in `trusty-common::migrations`.
+pub struct JsonCorpusToRedbMigration;
+
+impl Migration<CodeIndexer> for JsonCorpusToRedbMigration {
+    fn from_version(&self) -> SchemaVersion {
+        SchemaVersion::UNVERSIONED
+    }
+
+    fn label(&self) -> &'static str {
+        "chunks.json → index.redb"
+    }
+
+    fn apply(&self, indexer: &CodeIndexer) -> Result<()> {
+        let index_id = indexer.index_id.clone();
+        let chunks_path = match persistence::chunks_path(&index_id) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    "migrations: cannot resolve chunks.json path for '{index_id}' ({e}) — \
+                     skipping legacy JSON load"
+                );
+                return Ok(());
+            }
+        };
+
+        // Bridge the sync runner into the existing async migration helpers.
+        // The production daemon runs under the multi-threaded tokio runtime
+        // (`#[tokio::main]` default), so `block_in_place` is permitted. Some
+        // unit tests, however, spin up a current-thread runtime — for those
+        // we spawn a fresh worker thread that hosts its own block_on call so
+        // we never deadlock the calling runtime.
+        let handle = tokio::runtime::Handle::current();
+        match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::CurrentThread => {
+                // We can't `block_in_place` on a current-thread runtime; the
+                // safe pattern is to hand the async work off to a fresh
+                // single-thread runtime hosted on a worker thread, so the
+                // calling runtime stays free to drive other futures.
+                run_migration_off_thread(indexer, &chunks_path)
+            }
+            _ => tokio::task::block_in_place(|| {
+                handle.block_on(run_migration_async(indexer, &chunks_path))
+            }),
+        }
+    }
+}
+
+/// Core async migration body: load JSON snapshot, then seed redb.
+///
+/// Why: extracted into its own function so the two runtime-flavour bridges
+/// (`block_in_place` for the multi-threaded path, off-thread runtime for
+/// the current-thread path) can share one implementation.
+/// What: returns `Ok(())` on success (including the "no JSON file" fresh
+/// install case) and propagates `Err` from the underlying chunk loader.
+/// Test: covered indirectly via the persistence_loader integration tests.
+async fn run_migration_async(indexer: &CodeIndexer, chunks_path: &std::path::Path) -> Result<()> {
+    // Step 1: read the JSON snapshot into memory (best-effort).
+    // `load_chunks_from_disk` returns 0 (and `Ok`) for missing / corrupt
+    // files — both are the fresh-install case.
+    let restored = indexer.load_chunks_from_disk(chunks_path).await?;
+    if restored == 0 {
+        return Ok(());
+    }
+    tracing::info!(
+        "migrations: '{}' loaded {restored} chunks from legacy {} — seeding redb",
+        indexer.index_id,
+        chunks_path.display()
+    );
+    // Step 2: seed redb from the now-live in-memory corpus.
+    indexer.migrate_corpus_to_redb().await;
+    Ok(())
+}
+
+/// Run the async migration body on a fresh single-thread runtime hosted on
+/// a brand-new worker thread.
+///
+/// Why: when the caller is a current-thread tokio runtime,
+/// `block_in_place` panics. Spawning a dedicated thread with its own
+/// runtime lets the migration run synchronously from the caller's
+/// perspective without nesting runtimes. The caller's runtime stays free
+/// to drive other futures while this thread blocks.
+/// What: spawns an OS thread, builds a `current_thread` runtime inside it,
+/// drives [`run_migration_async`] to completion, and joins the thread.
+/// Any error from the migration body or the thread join is returned to
+/// the caller.
+/// Test: exercised by the trusty-search lib tests that build the
+/// persistence loader on a current-thread runtime
+/// (`create_index_accepts_valid_absolute_root_path` et al.).
+fn run_migration_off_thread(indexer: &CodeIndexer, chunks_path: &std::path::Path) -> Result<()> {
+    // The migration body needs `&CodeIndexer` and `&Path` — both Send +
+    // Sync. We can borrow across the thread boundary via `std::thread::scope`
+    // so no `'static` clones are required.
+    std::thread::scope(|s| {
+        let handle = s.spawn(|| -> Result<()> {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(anyhow::Error::from)?;
+            rt.block_on(run_migration_async(indexer, chunks_path))
+        });
+        match handle.join() {
+            Ok(res) => res,
+            Err(_) => Err(anyhow::anyhow!("migration worker thread panicked")),
+        }
+    })
+}

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod archive;
 pub(crate) mod docs_penalty;
 mod files;
 mod ingest;
+pub(crate) mod migrations;
 mod persist;
 mod search;
 

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -241,6 +241,21 @@ pub fn corpus_redb_path(index_id: &str) -> Result<PathBuf> {
     Ok(index_data_dir(index_id)?.join("index.redb"))
 }
 
+/// Path to the per-index schema-version stamp file (issue #179).
+///
+/// Why: the `trusty-common::migrations` runner persists the applied
+/// `SchemaVersion` next to the index data so warm-boot can decide whether
+/// the JSON → redb migration has already run. Centralising the layout here
+/// keeps the stamp adjacent to `index.redb` / `chunks.json` and ensures the
+/// persistence loader and the migration registry agree on one path.
+/// What: returns `<data_dir>/indexes/<id>/schema_version.json`.
+/// Test: covered indirectly by `persistence_loader` integration tests; the
+/// file-stamp round-trip itself is unit-tested in
+/// `trusty_common::migrations::file_stamp`.
+pub fn schema_version_path(index_id: &str) -> Result<PathBuf> {
+    Ok(index_data_dir(index_id)?.join("schema_version.json"))
+}
+
 /// Path to the staging redb corpus written during a `--force` reindex
 /// (issue #28, Phase 4).
 ///

--- a/crates/trusty-search/src/service/persistence_loader.rs
+++ b/crates/trusty-search/src/service/persistence_loader.rs
@@ -17,10 +17,15 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use trusty_common::migrations::{
+    file_stamp::{read_version_from_file, write_version_to_file},
+    MigrationRunner, SchemaVersion,
+};
+
 use crate::core::{
     corpus::CorpusStore,
     embed::Embedder,
-    indexer::CodeIndexer,
+    indexer::{migrations::JsonCorpusToRedbMigration, CodeIndexer},
     store::{UsearchStore, VectorStore},
 };
 
@@ -66,48 +71,116 @@ pub async fn build_indexer_with_persisted_state(
 }
 
 /// Restore the chunk corpus for `indexer`, preferring the redb store and
-/// falling back to the legacy `chunks.json` snapshot (issue #28).
+/// falling back to the legacy `chunks.json` snapshot via the shared
+/// `trusty-common::migrations` runner (issues #28, #179).
 ///
 /// Why: redb is the new source of truth, but daemons upgraded in place have a
-/// populated `chunks.json` and an empty `index.redb`. This function tries redb
-/// first; on an empty redb corpus it reads the JSON snapshot and then seeds
-/// redb from it so every subsequent restart uses the fast path.
-/// What: `load_chunks_from_redb` → (if 0 chunks) `load_chunks_from_disk` +
-/// `migrate_corpus_to_redb`. Either restore path rebuilds BM25 + the symbol
-/// graph as a side effect.
-/// Test: covered by the corpus roundtrip + migration integration tests.
+/// populated `chunks.json` and an empty `index.redb`. The migration kernel
+/// owns the ordering — we always try redb first (the fast path) and only run
+/// the legacy-JSON step when redb is empty *and* the on-disk schema stamp
+/// hasn't already recorded that the migration ran. The stamp is written
+/// after every successful migration step so subsequent boots skip the JSON
+/// probe entirely.
+/// What: tries `load_chunks_from_redb` first; on a populated redb corpus
+/// stamps the schema (so legacy `chunks.json` becomes inert) and returns.
+/// On an empty redb the [`MigrationRunner`] dispatches
+/// [`JsonCorpusToRedbMigration`], which reads the JSON snapshot and seeds
+/// redb. The runner writes the schema stamp after each successful step.
+/// Test: covered by the corpus roundtrip + migration integration tests; the
+/// runner itself is unit-tested in `trusty-common::migrations`.
 async fn restore_corpus(indexer: &mut CodeIndexer, index_id: &str) {
     // Primary path: redb durable corpus.
     match indexer.load_chunks_from_redb().await {
         Ok(n) if n > 0 => {
             tracing::info!("warm-boot: restored {n} chunks for index '{index_id}' from redb");
+            // Ensure the schema stamp is bumped past the JSON → redb step so
+            // a stray `chunks.json` left over from the legacy build is never
+            // re-read on the next boot.
+            stamp_if_unversioned(index_id);
             return;
         }
-        Ok(_) => {} // empty redb — fall through to the JSON migration branch
+        Ok(_) => {} // empty redb — fall through to the migration runner.
         Err(e) => tracing::warn!(
             "warm-boot: redb corpus load failed for '{index_id}' ({e}) — \
-             trying legacy chunks.json"
+             trying registered migrations"
         ),
     }
 
-    // Fallback / migration path: legacy chunks.json snapshot.
-    match persistence::chunks_path(index_id) {
-        Ok(path) => match indexer.load_chunks_from_disk(&path).await {
-            Ok(n) if n > 0 => {
-                tracing::info!(
-                    "warm-boot: restored {n} chunks for index '{index_id}' from legacy {} — \
-                     migrating to redb",
-                    path.display()
-                );
-                // Seed redb so the next restart uses the fast path.
-                indexer.migrate_corpus_to_redb().await;
-            }
-            Ok(_) => {} // empty / missing — genuine first-run case
-            Err(e) => tracing::warn!(
-                "warm-boot: could not load chunks for '{index_id}' ({e}) — starting empty"
-            ),
-        },
-        Err(e) => tracing::warn!("cannot resolve chunks path for '{index_id}': {e}"),
+    // Migration runner path (issue #179): dispatches the legacy JSON →
+    // redb migration when the on-disk schema stamp says it hasn't yet run.
+    run_migrations(indexer, index_id);
+}
+
+/// Dispatch the trusty-search migration runner for one index.
+///
+/// Why: lifted into its own function so the redb-empty branch in
+/// [`restore_corpus`] and any future "force re-migrate" admin command can
+/// share one entry point. Keeps the runner's stamp file path resolution
+/// and error logging in one place.
+/// What: reads the current stamp via `read_version_from_file`, instantiates
+/// the runner with [`JsonCorpusToRedbMigration`], and runs it against the
+/// indexer. Failures are logged but never propagated — a missing
+/// `chunks.json` is the genuine first-boot case and yields an empty corpus.
+/// Test: covered by the existing migration integration tests.
+fn run_migrations(indexer: &mut CodeIndexer, index_id: &str) {
+    let stamp_path = match persistence::schema_version_path(index_id) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("cannot resolve schema version path for '{index_id}': {e}");
+            return;
+        }
+    };
+    let current = match read_version_from_file(&stamp_path) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "warm-boot: failed to read schema stamp at {} ({e}) — \
+                 treating as UNVERSIONED",
+                stamp_path.display()
+            );
+            SchemaVersion::UNVERSIONED
+        }
+    };
+    let runner = MigrationRunner::new(vec![Box::new(JsonCorpusToRedbMigration)]);
+    if let Err(e) = runner.run(indexer, current, |v| write_version_to_file(&stamp_path, v)) {
+        tracing::warn!(
+            "warm-boot: migration runner failed for '{index_id}' ({e}) — \
+             starting with whatever state was restored"
+        );
+    }
+}
+
+/// Stamp the schema as fully migrated if the on-disk stamp is currently
+/// UNVERSIONED.
+///
+/// Why: the redb-populated branch in [`restore_corpus`] short-circuits
+/// without invoking the runner. We still want the stamp to advance so a
+/// future migration with a higher `from_version` runs cleanly, and so a
+/// stray legacy `chunks.json` is never reprocessed. Writing only when the
+/// stamp is missing/UNVERSIONED preserves any version that a previous
+/// runner write recorded.
+/// What: best-effort — read the stamp, and if it is UNVERSIONED, write the
+/// current `TRUSTY_SEARCH_SCHEMA_TARGET`. A failure is logged at WARN.
+/// Test: covered indirectly via the corpus roundtrip integration tests.
+fn stamp_if_unversioned(index_id: &str) {
+    use crate::core::indexer::migrations::TRUSTY_SEARCH_SCHEMA_TARGET;
+
+    let stamp_path = match persistence::schema_version_path(index_id) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("cannot resolve schema version path for '{index_id}': {e}");
+            return;
+        }
+    };
+    let current = read_version_from_file(&stamp_path).unwrap_or(SchemaVersion::UNVERSIONED);
+    if current >= TRUSTY_SEARCH_SCHEMA_TARGET {
+        return;
+    }
+    if let Err(e) = write_version_to_file(&stamp_path, TRUSTY_SEARCH_SCHEMA_TARGET) {
+        tracing::warn!(
+            "warm-boot: failed to bump schema stamp for '{index_id}' at {} ({e})",
+            stamp_path.display()
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Implements `trusty-common::migrations` — a shared schema-versioning framework extracted from the ad-hoc patterns scattered across trusty-search and trusty-memory
- Updates trusty-search to consume the shared framework for its `chunks.json → redb` corpus migration

## Changes

### trusty-common — new `migrations` feature flag

- `SchemaVersion(u32)` — newtype for schema version stamps; `UNVERSIONED` = 0 sentinel
- `Migration<S>` trait — `from_version()`, `label()`, `apply(&S)`
- `MigrationRunner<S>` — applies pending steps in order, writes version stamp after each (crash-safe)
- `migrations::file_stamp` — atomic JSON sidecar helpers (`read_version_from_file`, `write_version_to_file`)
- `migrations::redb_stamp` — doc-only recipe for redb users (no extra dep)
- README `## Migrations` section with example

### trusty-search — consume shared framework

- `JsonCorpusToRedbMigration` struct implementing `Migration<CodeIndexer>`
- Replaces ad-hoc try-redb → try-JSON cascade in `persistence_loader.rs` with `MigrationRunner` dispatch
- `schema_version.json` sidecar written alongside `index.redb` for durable version stamp

## Tests

- 13 new unit tests in `trusty-common::migrations` (runner ordering, crash-safety, file stamp roundtrip)
- All 628 trusty-search tests pass (including 2 server tests that hit the current-thread runtime bridge)
- Clippy clean on both crates

## Next adopters

trusty-memory and trusty-bm25-daemon can now add `trusty-common = { workspace = true, features = ["migrations"] }` and implement `Migration<T>` for their schema evolution steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)