### PR TITLE
chore: remove Communities display from all TUI and web UIs

### DIFF
--- a/crates/trusty-common/src/monitor/memory_tui.rs
+++ b/crates/trusty-common/src/monitor/memory_tui.rs
@@ -1411,7 +1411,6 @@ pub fn stats_lines(state: &MemoryTuiState) -> Vec<String> {
                 "Knowledge Graph".to_string(),
                 format!("  Nodes:        {}", format_count(palace.node_count)),
                 format!("  Edges:        {}", format_count(palace.edge_count)),
-                format!("  Communities:  {}", format_count(palace.community_count)),
                 format!("  Triples:      {}", format_count(palace.kg_triple_count)),
                 String::new(),
             ];
@@ -2640,7 +2639,6 @@ mod tests {
         assert!(joined.contains("4,321"));
         assert!(joined.contains("Edges:"));
         assert!(joined.contains("12.3k"));
-        assert!(joined.contains("Communities:"));
         assert!(joined.contains("Triples:"));
         assert!(joined.contains("567"));
         assert!(joined.contains("Last write:"));

--- a/crates/trusty-common/src/monitor/search_tui.rs
+++ b/crates/trusty-common/src/monitor/search_tui.rs
@@ -1099,8 +1099,7 @@ pub fn stats_lines(state: &SearchTuiState) -> Vec<String> {
             // Graph stats section — always shown so users know whether the
             // daemon has built a symbol graph for this index. When
             // `node_count == 0` we surface a hint to reindex; otherwise we
-            // emit the full nodes/edges breakdown, edge-kind bars, and (if
-            // present) the communities subsection.
+            // emit the full nodes/edges breakdown and edge-kind bars.
             lines.push(String::new());
             lines.push("Graph:".to_string());
             if idx.node_count == 0 {
@@ -1127,14 +1126,6 @@ pub fn stats_lines(state: &SearchTuiState) -> Vec<String> {
                             bar,
                         ));
                     }
-                }
-                if idx.community_count > 0 {
-                    lines.push(String::new());
-                    lines.push("Communities:".to_string());
-                    lines.push(format!(
-                        "  Count: {}  Modularity: {:.3}",
-                        idx.community_count, idx.modularity,
-                    ));
                 }
             }
             lines
@@ -1554,8 +1545,8 @@ mod tests {
     #[test]
     fn test_stats_lines_graph_section() {
         // An index with non-zero node_count should produce a Graph section
-        // including the nodes/edges line and a Communities section when
-        // community_count is positive.
+        // including the nodes/edges line and edge-kind bars. The Communities
+        // display was retired; the underlying fields stay on the data model.
         let mut state = sample_state();
         state.indexes[0].node_count = 4_821;
         state.indexes[0].edge_count = 12_034;
@@ -1575,11 +1566,9 @@ mod tests {
                 .any(|l| l.contains("Nodes:") && l.contains("4,821") && l.contains("Edges:"))
         );
         assert!(lines.iter().any(|l| l.contains("CallsFunction")));
-        assert!(lines.iter().any(|l| l == "Communities:"));
         assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("Count: 47") && l.contains("Modularity: 0.712"))
+            !lines.iter().any(|l| l.contains("Communities")),
+            "Communities display must not surface in the stats panel"
         );
     }
 
@@ -1587,8 +1576,8 @@ mod tests {
     fn test_stats_lines_no_graph_section() {
         // An index with node_count == 0 should still produce a Graph section
         // header, but the body collapses to a single hint line — and the
-        // full breakdown (Nodes/Edges, Communities) must remain hidden so
-        // the spurious edge/community counters don't leak into the UI.
+        // Nodes/Edges breakdown must remain hidden so the spurious edge
+        // counters don't leak into the UI.
         let mut state = sample_state();
         state.indexes[0].node_count = 0;
         state.indexes[0].edge_count = 100; // ignored without nodes
@@ -1606,8 +1595,8 @@ mod tests {
             "empty-graph hint should appear when node_count == 0"
         );
         assert!(
-            !lines.iter().any(|l| l == "Communities:"),
-            "Communities section must stay hidden without nodes"
+            !lines.iter().any(|l| l.contains("Communities")),
+            "Communities display was retired and must not surface"
         );
         assert!(
             !lines.iter().any(|l| l.contains("Nodes:")),

--- a/crates/trusty-memory/ui/src/lib/views/PalaceGraph.svelte
+++ b/crates/trusty-memory/ui/src/lib/views/PalaceGraph.svelte
@@ -388,9 +388,6 @@
       {/if}
       <span class="badge badge-muted">{counts.node_count} nodes</span>
       <span class="badge badge-muted">{counts.edge_count} edges</span>
-      {#if counts.community_count > 0}
-        <span class="badge badge-muted">{counts.community_count} communities</span>
-      {/if}
       {#if loadElapsedMs > 0 && !loading}
         <span class="badge badge-muted" title="API + layout time">
           loaded in {loadElapsedMs}ms

--- a/crates/trusty-memory/ui/src/lib/views/Palaces.svelte
+++ b/crates/trusty-memory/ui/src/lib/views/Palaces.svelte
@@ -397,11 +397,6 @@
           <span class="badge badge-graph" title="KG edges">
             {p.edge_count ?? 0} edges
           </span>
-          {#if (p.community_count ?? 0) > 0}
-            <span class="badge badge-graph" title="Louvain communities">
-              {p.community_count} communities
-            </span>
-          {/if}
         </span>
       </button>
       <!-- Sibling of the row button so we don't nest <button> inside

--- a/crates/trusty-mpm/src/tui/health.rs
+++ b/crates/trusty-mpm/src/tui/health.rs
@@ -1968,10 +1968,10 @@ pub fn format_with_commas(n: u64) -> String {
 /// drawers, knowledge-graph triples, and the last-write time — rather than
 /// the search-index stats `index_tab_lines` was originally built for.
 /// What: returns a header section (`Vectors` / `Drawers` / `Wings`), a Graph
-/// section (`Triples` / `Communities` / `Nodes` / `Edges` — the latter two
-/// are best-effort and read from the row's KG-side fields if present), and
-/// a freshness section (`Last write`). Numbers are comma-grouped for
-/// readability; missing data renders as `N/A`.
+/// section (`Triples` / `Nodes` / `Edges` — the latter two are best-effort
+/// and read from the row's KG-side fields if present), and a freshness
+/// section (`Last write`). Numbers are comma-grouped for readability;
+/// missing data renders as `N/A`.
 /// Test: `palace_index_tab_lines_shows_graph_section`,
 /// `palace_index_tab_lines_formats_last_write`.
 pub fn palace_index_tab_lines(row: &CollectionRow) -> Vec<String> {
@@ -2006,12 +2006,6 @@ pub fn palace_index_tab_lines(row: &CollectionRow) -> Vec<String> {
         "Nodes:      {:<12} Edges: {}",
         node_cell, edge_cell,
     ));
-    let community_cell = if row.community_count == 0 {
-        "N/A".to_string()
-    } else {
-        format_with_commas(row.community_count)
-    };
-    lines.push(format!("Communities: {community_cell}"));
     lines.push(String::new());
 
     // Freshness section: last write timestamp + activity state.
@@ -2045,11 +2039,10 @@ pub fn palace_index_tab_lines(row: &CollectionRow) -> Vec<String> {
 /// Why: keeping the body builder pure lets a unit test assert the rendered
 /// content without a terminal backend; the per-row stats live on the
 /// [`CollectionRow`] so the renderer reads directly from the screen.
-/// What: returns a header (`Chunks` / `Disk` / `Last index` / `Context`),
-/// a Graph section (`Nodes` / `Edges` + one bar per edge kind, scaled to the
-/// largest kind with `MAX_BAR_WIDTH` blocks), and a Communities section
-/// (`Count` / `Modularity`). If no collection is selected (or the list is
-/// empty), returns a single placeholder line.
+/// What: returns a header (`Chunks` / `Disk` / `Last index` / `Context`)
+/// and a Graph section (`Nodes` / `Edges` + one bar per edge kind, scaled to
+/// the largest kind with `MAX_BAR_WIDTH` blocks). If no collection is
+/// selected (or the list is empty), returns a single placeholder line.
 /// Test: `index_tab_lines_show_graph_stats`,
 /// `index_tab_lines_show_edge_kind_bars`,
 /// `index_tab_lines_empty_when_no_selection`.
@@ -2121,14 +2114,6 @@ pub fn index_tab_lines(screen: &HealthScreen) -> Vec<String> {
         let bar = ascii_bar(ratio, MAX_BAR_WIDTH);
         lines.push(format!("{:<16} {:>6}  {bar}", name, format_count(*count)));
     }
-    lines.push(String::new());
-
-    // Communities section.
-    lines.push("-- Communities ----------------------------------------".to_string());
-    lines.push(format!(
-        "Count:      {:<10} Modularity: {:.3}",
-        row.community_count, row.modularity,
-    ));
 
     lines
 }
@@ -2953,10 +2938,15 @@ mod tests {
                 .iter()
                 .any(|l| l.contains("Nodes:") && l.contains("Edges:"))
         );
+        // The Communities display (`Count:` / `Modularity:` row) was retired;
+        // the data still flows on the row but must not render in the UI.
         assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("Count:") && l.contains("Modularity") && l.contains("0.712"))
+            !lines.iter().any(|l| l.contains("Modularity")),
+            "Modularity must not appear in the index tab"
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("Communities")),
+            "Communities section must not appear in the index tab"
         );
     }
 
@@ -3245,17 +3235,17 @@ mod tests {
                 .iter()
                 .any(|l| l.contains("Triples:") && l.contains("6,789"))
         );
-        // Without graph nodes/edges/communities on the wire, those slots
-        // render as N/A rather than 0 so the operator knows they were absent.
+        // Without graph nodes/edges on the wire, those slots render as N/A
+        // rather than 0 so the operator knows they were absent.
         assert!(
             lines
                 .iter()
                 .any(|l| l.contains("Nodes:") && l.contains("N/A"))
         );
+        // The Communities display was retired; verify it no longer surfaces.
         assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("Communities:") && l.contains("N/A"))
+            !lines.iter().any(|l| l.contains("Communities")),
+            "Communities display must not appear in palace index tab"
         );
         assert!(lines.iter().any(|l| l.contains("Activity")));
         assert!(lines.iter().any(|l| l.starts_with("State:")));


### PR DESCRIPTION
## Summary

The communities feature is being retired from the operator-facing UIs. This PR removes the rendering paths only — the underlying data model (`community_count` / `modularity` struct fields) and the API fetches stay intact so any downstream consumers still compile.

Display lines removed in:

- **`crates/trusty-common/src/monitor/memory_tui.rs`** — palace stats `Communities:` line
- **`crates/trusty-common/src/monitor/search_tui.rs`** — `Communities:` subsection of the Graph panel
- **`crates/trusty-mpm/src/tui/health.rs`** — `Communities:` row in the palace index tab and the `-- Communities --` section in the search index tab
- **`crates/trusty-memory/ui/src/lib/views/Palaces.svelte`** — Louvain community count badge on the palace list row
- **`crates/trusty-memory/ui/src/lib/views/PalaceGraph.svelte`** — community count badge in the graph header

Tests adjusted to assert the absence of the display (the data fields remain on the rows, but no UI surface should render `Communities` text).

## LOC Delta

- Added: 30 lines
- Removed: 61 lines
- Net Change: -31 lines

## Test plan

- [x] `cargo check --workspace` — passes (with `SKIP_UI_BUILD=1`, no `.svelte` rebuild)
- [x] `cargo clippy -p trusty-common --features monitor-tui --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p trusty-common -p trusty-mpm -p trusty-memory --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-common --features monitor-tui` — 181 passed (incl. updated `test_stats_graph_section`, `test_stats_lines_graph_section`, `test_stats_lines_no_graph_section`)
- [x] `cargo test -p trusty-mpm` — 668 + 82 + 34 + 1 passed (incl. updated `palace_index_tab_lines_shows_graph_section`, `index_tab_lines_show_graph_stats`)
- [x] `cargo test -p trusty-memory` — 229 + 14 + 1 + 6 + 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)