### PR TITLE
chore(tui): show "Loading…" in all panels while daemon is connecting

### DIFF
--- a/crates/trusty-common/src/monitor/memory_tui.rs
+++ b/crates/trusty-common/src/monitor/memory_tui.rs
@@ -1272,8 +1272,17 @@ pub fn palace_lines_at(
     });
 
     if state.palaces.is_empty() {
+        // While the first daemon poll is still in flight we don't yet know
+        // whether the palace list is genuinely empty or just unfetched — show
+        // a "Loading…" placeholder so the left panel doesn't look broken on
+        // startup. Once the poll resolves we fall through to "(no palaces)".
+        let text = if state.daemon_status == DaemonStatus::Connecting {
+            "  Loading…".to_string()
+        } else {
+            "  (no palaces)".to_string()
+        };
         rows.push(PalaceListRow {
-            text: "  (no palaces)".to_string(),
+            text,
             selected: false,
             is_all: false,
             is_header: false,
@@ -1358,13 +1367,19 @@ pub fn palace_lines_at(
 /// Why: the bottom-right panel shows counts and sizes for whichever palace is
 /// selected, or aggregate totals plus a per-palace breakdown when "All" is
 /// selected; isolating the builder makes the content testable without a
-/// terminal.
+/// terminal. While the daemon is still being polled for the first time we
+/// surface a "Loading…" placeholder so the panel does not flash zeroes that
+/// are indistinguishable from a genuinely empty daemon.
 /// What: for a single palace, returns its name, vector count, and id. For the
 /// "All" selection, returns the palace count and the daemon's aggregate
 /// vector / drawer / KG-triple totals, plus one `· <name>: <vectors>`
-/// breakdown line per palace.
-/// Test: `test_stats_lines`.
+/// breakdown line per palace. Returns `["Loading…"]` while the daemon status
+/// is [`DaemonStatus::Connecting`].
+/// Test: `test_stats_lines`, `test_stats_lines_connecting_shows_loading`.
 pub fn stats_lines(state: &MemoryTuiState) -> Vec<String> {
+    if state.daemon_status == DaemonStatus::Connecting {
+        return vec!["Loading…".to_string()];
+    }
     if state.is_all_selected() {
         let stats = state.status.clone().unwrap_or_default();
         let mut lines = vec![
@@ -1630,6 +1645,10 @@ pub fn render(frame: &mut Frame, state: &mut MemoryTuiState) {
             .tail_scoped(scope, activity_height.max(1))
             .map(|line| ListItem::new(line.as_str()))
             .collect()
+    } else if state.daemon_status == DaemonStatus::Connecting {
+        // Distinguish "first poll has not completed" from "genuinely no activity"
+        // so the panel doesn't look broken on startup.
+        vec![ListItem::new("Loading…")]
     } else {
         vec![ListItem::new("(no activity yet)")]
     };
@@ -1838,6 +1857,18 @@ mod tests {
     }
 
     #[test]
+    fn test_stats_lines_connecting_shows_loading() {
+        // While the daemon is still in the Connecting state the STATISTICS
+        // panel should surface a single "Loading…" line — never a half-formed
+        // zero-valued snapshot that would be indistinguishable from a real
+        // empty daemon.
+        let state = MemoryTuiState::new("http://x");
+        assert!(matches!(state.daemon_status, DaemonStatus::Connecting));
+        let lines = stats_lines(&state);
+        assert_eq!(lines, vec!["Loading…".to_string()]);
+    }
+
+    #[test]
     fn test_palace_row_display() {
         // The selection highlight is now applied by the List widget via
         // `highlight_symbol`, so the row text itself begins with a space-
@@ -1894,11 +1925,31 @@ mod tests {
         assert!(rows[2].text.contains("work"));
 
         // An empty palace list still shows the "All" row plus a placeholder.
-        let empty = MemoryTuiState::new("http://x");
+        // The placeholder text depends on daemon status: "Loading…" while the
+        // first poll is in flight, "(no palaces)" once the daemon is reachable
+        // but has no palaces registered.
+        let mut empty = MemoryTuiState::new("http://x");
+        empty.daemon_status = DaemonStatus::Online {
+            version: "0.1.54".into(),
+            uptime_secs: 0,
+        };
         let rows = palace_lines(&empty);
         assert_eq!(rows.len(), 2);
         assert!(rows[0].is_all);
         assert!(rows[1].text.contains("no palaces"));
+
+        // Before the first daemon poll completes the placeholder switches to
+        // "Loading…" so the panel doesn't look broken on startup.
+        let connecting = MemoryTuiState::new("http://x");
+        assert!(matches!(connecting.daemon_status, DaemonStatus::Connecting));
+        let rows = palace_lines(&connecting);
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].is_all);
+        assert!(
+            rows[1].text.contains("Loading…"),
+            "connecting state must show Loading…, got: {:?}",
+            rows[1].text
+        );
     }
 
     #[test]
@@ -2621,6 +2672,12 @@ mod tests {
     fn test_stats_graph_section() {
         use chrono::{TimeZone, Utc};
         let mut state = MemoryTuiState::new("http://x");
+        // Drop out of the Connecting → "Loading…" early return so the full
+        // graph section is rendered.
+        state.daemon_status = DaemonStatus::Online {
+            version: "0.1.54".into(),
+            uptime_secs: 0,
+        };
         state.palaces = vec![PalaceRow {
             id: "p1".into(),
             name: "p1".into(),

--- a/crates/trusty-common/src/monitor/search_tui.rs
+++ b/crates/trusty-common/src/monitor/search_tui.rs
@@ -959,8 +959,18 @@ pub fn index_lines(state: &SearchTuiState) -> Vec<IndexListRow> {
     });
 
     if state.indexes.is_empty() {
+        // While the first daemon poll is still in flight we don't yet know
+        // whether the index list is genuinely empty or just unfetched — show
+        // a "Loading…" placeholder so the left panel doesn't look broken on
+        // startup. Once the poll resolves we fall through to
+        // "(no indexes registered)".
+        let text = if state.daemon_status == DaemonStatus::Connecting {
+            "  Loading…".to_string()
+        } else {
+            "  (no indexes registered)".to_string()
+        };
         rows.push(IndexListRow {
-            text: "  (no indexes registered)".to_string(),
+            text,
             selected: false,
             is_all: false,
             is_header: false,
@@ -1037,12 +1047,18 @@ pub fn index_lines(state: &SearchTuiState) -> Vec<IndexListRow> {
 /// Why: the bottom-right panel shows counts and sizes for whichever index is
 /// selected, or aggregate totals plus a per-index breakdown when "All" is
 /// selected; isolating the builder makes the content testable without a
-/// terminal.
+/// terminal. While the daemon is still being polled for the first time we
+/// surface a "Loading…" placeholder so the panel does not flash zeroes that
+/// are indistinguishable from a genuinely empty daemon.
 /// What: for a single index, returns its id, chunk count, and indexed root
 /// path. For the "All" selection, returns the index count, the summed chunk
-/// count, and one `· <id>: <chunks>` breakdown line per index.
-/// Test: `test_stats_lines`.
+/// count, and one `· <id>: <chunks>` breakdown line per index. Returns
+/// `["Loading…"]` while the daemon status is [`DaemonStatus::Connecting`].
+/// Test: `test_stats_lines`, `test_stats_lines_connecting_shows_loading`.
 pub fn stats_lines(state: &SearchTuiState) -> Vec<String> {
+    if state.daemon_status == DaemonStatus::Connecting {
+        return vec!["Loading…".to_string()];
+    }
     if state.is_all_selected() {
         let total: u64 = state.indexes.iter().map(|i| i.chunk_count).sum();
         let total_nodes: u64 = state.indexes.iter().map(|i| i.node_count).sum();
@@ -1349,6 +1365,10 @@ pub fn render(frame: &mut Frame, state: &mut SearchTuiState) {
             .tail_scoped(scope, activity_height.max(1))
             .map(|line| ListItem::new(line.as_str()))
             .collect()
+    } else if state.daemon_status == DaemonStatus::Connecting {
+        // Distinguish "first poll has not completed" from "genuinely no activity"
+        // so the panel doesn't look broken on startup.
+        vec![ListItem::new("Loading…")]
     } else {
         vec![ListItem::new("(no activity yet)")]
     };
@@ -1748,11 +1768,43 @@ mod tests {
         assert!(rows[3].text.contains("19.0k"));
 
         // An empty index list still shows the "All" row plus a placeholder.
-        let empty = SearchTuiState::new("http://x");
+        // The placeholder text depends on daemon status: "Loading…" while the
+        // first poll is in flight, "(no indexes registered)" once the daemon
+        // is reachable but has no indexes registered.
+        let mut empty = SearchTuiState::new("http://x");
+        empty.daemon_status = DaemonStatus::Online {
+            version: "0.3.65".into(),
+            uptime_secs: 0,
+        };
         let rows = index_lines(&empty);
         assert_eq!(rows.len(), 2);
         assert!(rows[0].is_all);
         assert!(rows[1].text.contains("no indexes"));
+
+        // Before the first daemon poll completes the placeholder switches to
+        // "Loading…" so the panel doesn't look broken on startup.
+        let connecting = SearchTuiState::new("http://x");
+        assert!(matches!(connecting.daemon_status, DaemonStatus::Connecting));
+        let rows = index_lines(&connecting);
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].is_all);
+        assert!(
+            rows[1].text.contains("Loading…"),
+            "connecting state must show Loading…, got: {:?}",
+            rows[1].text
+        );
+    }
+
+    #[test]
+    fn test_stats_lines_connecting_shows_loading() {
+        // While the daemon is still in the Connecting state the STATISTICS
+        // panel should surface a single "Loading…" line — never a half-formed
+        // zero-valued snapshot that would be indistinguishable from a real
+        // empty daemon.
+        let state = SearchTuiState::new("http://x");
+        assert!(matches!(state.daemon_status, DaemonStatus::Connecting));
+        let lines = stats_lines(&state);
+        assert_eq!(lines, vec!["Loading…".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The memory and search TUIs start in `DaemonStatus::Connecting` and only transition to `Online`/`Offline` after the first poll. Three panels per TUI were content-less placeholders during that window:

- **ACTIVITY**: showed `"(no activity yet)"` — indistinguishable from a real empty log on startup.
- **STATISTICS**: rendered zero-valued aggregate snapshots — looked like a daemon with no data.
- **Index / palace list**: only the synthetic "All" header row, leaving the left panel visually broken on startup.

Now each panel surfaces a `"Loading…"` placeholder while `daemon_status == DaemonStatus::Connecting`, then falls through to the existing empty / zero rendering once the first poll resolves. `Offline` rendering is untouched (it already has its own error display).

### Changes

- `memory_tui.rs`:
  - Activity panel: branch on `Connecting` in the empty-log path.
  - `stats_lines()`: early-return `vec!["Loading…"]` while `Connecting`.
  - `palace_lines_at()`: show `"  Loading…"` row when `palaces.is_empty() && Connecting`.
- `search_tui.rs`: same three changes applied to the search TUI.
- Tests: updated `test_palace_lines` / `test_index_lines` / `test_stats_graph_section` to opt out of `Connecting` (they were using fresh `*::new()` states that now hit the Loading path). Added explicit `test_stats_lines_connecting_shows_loading` coverage on both TUIs and asserted the Connecting placeholder is rendered by the list builders.

## Test plan

- [x] `cargo check -p trusty-common --features monitor-tui`
- [x] `cargo clippy -p trusty-common --features monitor-tui --all-targets -- -D warnings`
- [x] `cargo test -p trusty-common --features monitor-tui` — 183 passed, 0 failed, 6 ignored
- [ ] Spot-check on a live daemon: launch `trusty-memory` / `trusty-search` TUI before the daemon is reachable, confirm all three panels render `Loading…` until the first poll, then transition cleanly to data or `(no …)` placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)