### PR TITLE
fix(trusty-search): token-count guard on ACRONYM_HINT_RE — multi-word acronym queries route to Conceptual

### DIFF
--- a/crates/trusty-search/src/core/classifier.rs
+++ b/crates/trusty-search/src/core/classifier.rs
@@ -268,11 +268,29 @@ impl QueryClassifier {
         // Word-boundary anchored so a query containing the acronym as a
         // substring of a larger word (`URLParser` — already matched by
         // `pascal_ident_re` above) doesn't re-fire here.
+        //
+        // Token-count guard (issue #197): only fire when the query is short
+        // (≤2 tokens) OR has no natural-language (lowercase-leading) tokens.
+        // Multi-word queries with both an ALL_CAPS acronym AND lowercase NL
+        // words (e.g. "HNSW vector similarity search") read as concept
+        // questions, not symbol lookups — they should fall through to the
+        // multi-noun branch and classify as Conceptual so the semantic lane
+        // can surface the canonical struct file (`store.rs`) over docs that
+        // merely mention the acronym (regression from PR #162 dense docs in
+        // `classifier.rs`).
         let acronym_hint_re = ACRONYM_HINT_RE.get_or_init(|| {
             Regex::new(r"\b[A-Z]{2,}[0-9]*\b").expect("static regex pattern must compile")
         });
         if acronym_hint_re.is_match(trimmed) {
-            return QueryIntent::Definition;
+            let token_count = trimmed.split_whitespace().count();
+            let has_nl_words = trimmed
+                .split_whitespace()
+                .any(|t| t.chars().next().is_some_and(|c| c.is_lowercase()));
+            if token_count <= 2 || !has_nl_words {
+                return QueryIntent::Definition;
+            }
+            // fall through — multi-word acronym phrase with NL words → let
+            // the multi-noun branch route this to Conceptual.
         }
 
         // Multi-noun query with no identifier tokens (issue #119): ≥4
@@ -818,15 +836,15 @@ mod tests {
 
     #[test]
     fn test_acronym_struct_hint_is_definition() {
-        // The four canonical struct-name acronyms in the trusty-search
-        // codebase: HNSW (HnswStore), BM25 (Bm25Index), RRF (rrf_fuse),
-        // ORT (ONNX Runtime types). All four were `Unknown` on v0.8.1.
+        // Short acronym queries (≤2 tokens) still route to Definition.
+        // Acronyms in 2-token phrases stay Definition because they read as
+        // symbol lookups (e.g. "BM25 index" / "RRF fusion" / "ORT").
+        // Issue #197 added a token-count guard so longer multi-word queries
+        // with NL words (e.g. "HNSW vector similarity search") fall through
+        // to the multi-noun / Conceptual path — see
+        // `test_multi_word_acronym_with_nl_words_is_conceptual` below.
         assert_eq!(
-            QueryClassifier::classify("HNSW vector similarity search"),
-            QueryIntent::Definition
-        );
-        assert_eq!(
-            QueryClassifier::classify("BM25 inverted index"),
+            QueryClassifier::classify("BM25 index"),
             QueryIntent::Definition
         );
         assert_eq!(
@@ -834,6 +852,35 @@ mod tests {
             QueryIntent::Definition
         );
         assert_eq!(QueryClassifier::classify("ORT"), QueryIntent::Definition);
+        assert_eq!(QueryClassifier::classify("HNSW"), QueryIntent::Definition);
+    }
+
+    #[test]
+    fn test_multi_word_acronym_with_nl_words_is_conceptual() {
+        // Regression for issue #197: multi-word queries that combine an
+        // ALL_CAPS acronym with natural-language tokens (≥3 tokens AND ≥1
+        // lowercase-leading token) read as concept questions, not symbol
+        // lookups. Routing them to Definition with beta=0.7 BM25 caused
+        // dense-doc files (e.g. `classifier.rs` after PR #162's verbose
+        // docs) to outrank the canonical struct file (`store.rs`) for
+        // queries like "HNSW vector similarity search".
+        //
+        // After the token-count guard, ACRONYM_HINT_RE falls through for
+        // these queries, letting the multi-noun branch classify them as
+        // Conceptual (alpha=0.8 semantic). The semantic lane surfaces the
+        // canonical struct file over docs that merely mention the acronym.
+        assert_eq!(
+            QueryClassifier::classify("HNSW vector similarity search"),
+            QueryIntent::Conceptual
+        );
+        // Note: `BM25` (acronym + digits) matches `pascal_ident_re` before
+        // reaching the acronym branch, so multi-word BM25 queries still
+        // classify as Definition via the PascalCase fallback. The guard
+        // only affects pure ALL_CAPS acronyms like HNSW, RRF, ORT, BFS.
+        assert_eq!(
+            QueryClassifier::classify("RRF fusion algorithm explanation"),
+            QueryIntent::Conceptual
+        );
     }
 
     // ── Multi-noun conceptual tests (issue #119) ────────────────────────────
@@ -899,11 +946,18 @@ mod tests {
     fn test_screaming_snake_does_not_change_multiword_query() {
         // "HNSW vector similarity" contains an ALL_CAPS token but is NOT a
         // whole-query SCREAMING_SNAKE identifier (it has whitespace + mixed
-        // case). The existing ACRONYM_HINT path handles it — verify no
-        // regression.
+        // case). The SCREAM_IDENT path therefore must not fire on it.
+        //
+        // Updated for issue #197: this query is 3 tokens with NL words
+        // ("vector", "similarity"), so the ACRONYM_HINT token-count guard
+        // suppresses the Definition route. The multi-noun branch needs ≥4
+        // tokens, so this falls through to Unknown — which is the expected
+        // outcome. (The corresponding 4-word variant
+        // "HNSW vector similarity search" classifies as Conceptual; see
+        // `test_multi_word_acronym_with_nl_words_is_conceptual`.)
         assert_eq!(
             QueryClassifier::classify("HNSW vector similarity"),
-            QueryIntent::Definition
+            QueryIntent::Unknown
         );
     }
 

--- a/crates/trusty-search/src/core/indexer/tests.rs
+++ b/crates/trusty-search/src/core/indexer/tests.rs
@@ -1016,29 +1016,33 @@ async fn test_struct_definition_boost_surfaces_struct_over_usage() {
     // behind `retrieval.rs` and `mmr.rs`.
     //
     // Combined fix:
-    //   1. #119 classifies the query as Definition (via the new ALL-CAPS
-    //      acronym hint).
+    //   1. #119 classifies short acronym queries (≤2 tokens) as Definition
+    //      via the ALL-CAPS acronym hint.
     //   2. The structural boost in `apply_score_adjustments` multiplies
     //      the score of any Struct/Enum/Class/Trait chunk whose
     //      `function_name` matches a query token by `STRUCT_DEFINITION_BOOST`.
     //
-    // What: build a corpus with one declaration chunk (Struct, name
-    // `HnswStore`, in `hnsw_store.rs`) plus three usage chunks
-    // (`retrieval.rs`, `mmr.rs`, `search.rs`) that mention `HNSW` heavily
-    // but are typed as plain `Code` chunks. Run the canonical benchmark
-    // query and assert the declaration ranks in the top 3 (acceptance
-    // criterion from the ticket).
+    // Updated for issue #197: the original `HNSW vector similarity search`
+    // query no longer routes to Definition (the token-count guard suppresses
+    // ACRONYM_HINT_RE for multi-word NL-heavy queries) — it now reads as a
+    // Conceptual query, which is the correct semantic intent. The
+    // Definition structural-boost path is still exercised here by the
+    // shorter 2-token acronym query `HNSW lookup`, which preserves the
+    // #117 acceptance criterion: `hnsw_store.rs` (canonical struct decl)
+    // must outrank usage sites for a Definition-intent acronym query.
     // Test: this test.
     use crate::core::chunker::ChunkType;
     use crate::core::classifier::{QueryClassifier, QueryIntent};
 
-    // Sanity: the query must classify as Definition. The acronym-hint rule
-    // from #119 is what makes this true; if it ever regresses, the test
-    // should fail loudly here rather than in the ranking assertion below.
+    // Sanity: the (short, 2-token) query must classify as Definition. The
+    // acronym-hint rule from #119, gated by the #197 token-count guard,
+    // is what makes this true; if it regresses, the test should fail loudly
+    // here rather than in the ranking assertion below.
     assert_eq!(
-        QueryClassifier::classify("HNSW vector similarity search"),
+        QueryClassifier::classify("HNSW lookup"),
         QueryIntent::Definition,
-        "test pre-condition: ALL-CAPS acronym must classify as Definition (#119)"
+        "test pre-condition: short ALL-CAPS acronym query must classify as \
+         Definition (#119 + #197 short-query carve-out)"
     );
 
     let idx = make_indexer();
@@ -1055,36 +1059,36 @@ async fn test_struct_definition_boost_surfaces_struct_over_usage() {
     .await
     .unwrap();
     // 2-4) Three usage chunks in plausible-looking files. They mention
-    //      `HNSW` and the other query tokens enough to dominate BM25 if
-    //      left unboosted (and on v0.8.1 they did exactly that).
+    //      `HNSW` heavily so the BM25 lane would otherwise rank them
+    //      above the declaration (the #117 failure mode).
     idx.add_chunk(raw(
         "use:1",
         "src/retrieval.rs",
-        "// HNSW vector similarity search\n\
-         // Uses HNSW to retrieve top-k vectors with cosine similarity.\n\
-         // HNSW lookup HNSW lookup HNSW search HNSW search HNSW HNSW vector vector similarity similarity",
+        "// HNSW lookup path.\n\
+         // Uses HNSW to retrieve top-k vectors.\n\
+         // HNSW lookup HNSW lookup HNSW HNSW HNSW HNSW HNSW HNSW HNSW HNSW",
     ))
     .await
     .unwrap();
     idx.add_chunk(raw(
         "use:2",
         "src/mmr.rs",
-        "// MMR diversity reranker over HNSW vector similarity search results.\n\
-         // HNSW HNSW HNSW vector similarity similarity search search lambda lambda",
+        "// MMR diversity reranker over HNSW lookup results.\n\
+         // HNSW HNSW HNSW lookup lookup lookup HNSW HNSW HNSW",
     ))
     .await
     .unwrap();
     idx.add_chunk(raw(
         "use:3",
         "src/search.rs",
-        "// Top-level hybrid search: BM25 lane + HNSW vector similarity search lane.\n\
-         // HNSW HNSW vector vector similarity similarity search search RRF fuse fuse",
+        "// Top-level hybrid search: BM25 lane + HNSW lookup lane.\n\
+         // HNSW HNSW HNSW lookup lookup HNSW HNSW lookup HNSW",
     ))
     .await
     .unwrap();
 
     let q = SearchQuery {
-        text: "HNSW vector similarity search".to_string(),
+        text: "HNSW lookup".to_string(),
         top_k: 10,
         expand_graph: false,
         compact: false,
@@ -1096,7 +1100,8 @@ async fn test_struct_definition_boost_surfaces_struct_over_usage() {
     assert!(
         top3_files.contains(&"src/hnsw_store.rs"),
         "issue #117 acceptance: hnsw_store.rs must rank in top-3 for \
-         the canonical query; got top-3 files = {top3_files:?}, full ranking = {:?}",
+         the canonical acronym query; got top-3 files = {top3_files:?}, \
+         full ranking = {:?}",
         results
             .iter()
             .map(|c| (c.file.as_str(), c.score))


### PR DESCRIPTION
## Summary

Closes #197.

PR #162 added dense doc strings to `classifier.rs` containing the tokens `{HNSW, vector, similarity, search}`, making `classifier.rs` BM25-competitive for the query `"HNSW vector similarity search"`. Combined with `ACRONYM_HINT_RE` firing on ANY query containing an ALL_CAPS token, the query routed to `Intent::Definition` (β=0.7 BM25). After RRF fusion `classifier.rs` outranked `store.rs` (where `UsearchStore::search` lives), pushing the expected result from rank 1–3 to rank 5.

### Fix

Gate `ACRONYM_HINT_RE` on token count. The Definition route now only fires when:
- the query is **≤2 tokens**, OR
- the query has **no natural-language** (lowercase-leading) tokens.

Queries with ≥3 tokens AND lowercase NL words (e.g. `"HNSW vector similarity search"`) fall through to the multi-noun branch and classify as `Intent::Conceptual` (α=0.8 semantic), letting the vector lane surface the canonical struct file over docs that merely mention the acronym.

Short acronym queries (`HNSW`, `BM25 index`, `RRF fusion`, `ORT`) continue to route to Definition unchanged — the #117 acceptance criterion is preserved via the 2-token `"HNSW lookup"` query in the updated structural-boost test.

### Files

- `crates/trusty-search/src/core/classifier.rs` — token-count guard on ACRONYM_HINT_RE; updated 2 tests; added 1 new test
- `crates/trusty-search/src/core/indexer/tests.rs` — switched the `test_struct_definition_boost_surfaces_struct_over_usage` regression test to a 2-token query so the Definition + structural-boost path is still exercised

LOC delta: +96 / −37 (net +59, mostly new comments and the new conceptual test)

## Test plan

- [x] `cargo test -p trusty-search` — 545 lib + 100 + 4 tests pass, 0 failures
- [x] `cargo clippy -p trusty-search -- -D warnings` — clean
- [x] `cargo fmt -p trusty-search --check` — clean
- [x] New `test_multi_word_acronym_with_nl_words_is_conceptual` asserts `"HNSW vector similarity search"` → `Conceptual`
- [x] Updated `test_acronym_struct_hint_is_definition` confirms short queries (`HNSW`, `BM25 index`, `RRF fusion`, `ORT`) still → `Definition`
- [x] Updated `test_screaming_snake_does_not_change_multiword_query` reflects that 3-token NL acronym phrases now classify as `Unknown` (multi-noun threshold is ≥4 tokens)
- [x] Updated `test_struct_definition_boost_surfaces_struct_over_usage` uses 2-token `"HNSW lookup"` to preserve #117 acceptance
- [ ] Post-merge: re-run search regression baseline to confirm `store.rs` returns to rank 1–3 for `"HNSW vector similarity search"`