### PR TITLE
chore(trusty-embedderd,trusty-bm25-daemon): set publish=false — sidecars are bundled into main crates

### DIFF
--- a/crates/trusty-bm25-daemon/Cargo.toml
+++ b/crates/trusty-bm25-daemon/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "trusty-bm25-daemon"
 version = "0.1.0"
+publish = false
 edition = "2021"
 rust-version = "1.88"
 description = "Per-palace BM25 lexical-index subprocess for the trusty-* ecosystem (issue #156)"

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "trusty-embedderd"
 version = "0.3.0"
+publish = false
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/bobmatnyc/trusty-tools"


### PR DESCRIPTION
## Summary

- Add `publish = false` to `crates/trusty-embedderd/Cargo.toml` — this daemon is now a bundled sidecar inside `trusty-search` (single-install surface, PR #190) and must never be published separately to crates.io.
- Add `publish = false` to `crates/trusty-bm25-daemon/Cargo.toml` — same rationale; bundled inside `trusty-memory` (PR #191).
- Placement follows the existing project convention: after `version`, before `edition` (matches `open-mpm/Cargo.toml` line 4).

## Test plan

- [x] `cargo check -p trusty-embedderd` passes
- [x] `cargo check -p trusty-bm25-daemon` passes
- [x] `cargo fmt --check` passes (no formatting drift)
- [x] Pre-commit hooks pass

LOC Delta: +2 lines, 0 removed — minimal targeted change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)