### PR TITLE
feat(trusty-memory): inject creator tags on MCP writes + show memory snippet in drawer rows (closes #202)

### DIFF
--- a/crates/trusty-common/src/bm25_client.rs
+++ b/crates/trusty-common/src/bm25_client.rs
@@ -304,9 +304,7 @@ pub fn locate_bm25_daemon_binary() -> anyhow::Result<std::path::PathBuf> {
         if p.is_file() {
             return Ok(p);
         }
-        anyhow::bail!(
-            "TRUSTY_BM25_DAEMON_BIN={explicit:?} does not point to an existing file"
-        );
+        anyhow::bail!("TRUSTY_BM25_DAEMON_BIN={explicit:?} does not point to an existing file");
     }
 
     // 2. Sibling of the currently-running executable — works for both

--- a/crates/trusty-common/src/monitor/memory_client.rs
+++ b/crates/trusty-common/src/monitor/memory_client.rs
@@ -590,8 +590,11 @@ pub fn parse_palaces(raw: &serde_json::Value) -> Vec<PalaceRow> {
 /// Keeping a typed projection out of the renderer means the parsing /
 /// creator-tag extraction logic is unit-testable without a live daemon.
 /// What: a stable id, a created_at timestamp (UTC), the resolved creator
-/// label (`"—"` when no creator tag was found), and the drawer's tag list
-/// surfaced so future panels can present richer detail without re-fetching.
+/// label (`"—"` when no creator tag was found), the drawer's tag list
+/// surfaced so future panels can present richer detail without
+/// re-fetching, and an optional content snippet for inline display
+/// (issue #202; `None` when the body was empty or the daemon predates
+/// the snippet field).
 /// Test: `parse_drawers_projects_fields`, `creator_label_picks_first_match`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DrawerInfo {
@@ -604,6 +607,13 @@ pub struct DrawerInfo {
     pub creator: String,
     /// All tags as carried on the wire (for downstream filtering / display).
     pub tags: Vec<String>,
+    /// Short whitespace-collapsed snippet of the drawer body (issue #202).
+    ///
+    /// Populated by the daemon's `/api/v1/palaces/{id}/drawers` endpoint
+    /// (truncated to ~60 chars with `…`). The client falls back to
+    /// truncating the full `content` field when the daemon predates the
+    /// `snippet` wire field; `None` when neither is available.
+    pub snippet: Option<String>,
 }
 
 /// Fallback creator label rendered when no recognised creator tag is found.
@@ -615,6 +625,17 @@ pub struct DrawerInfo {
 /// Test: `creator_label_picks_first_match`.
 pub const NO_CREATOR_LABEL: &str = "—";
 
+/// Maximum characters retained when the client falls back to truncating
+/// `content` because the daemon didn't return a `snippet` (issue #202).
+///
+/// Why: the activity panel must show a usable snippet against older
+/// daemons that predate the wire field. Matching the server's
+/// `DRAWER_SNIPPET_MAX_CHARS` keeps the rendered width consistent across
+/// daemon versions.
+/// What: 60 characters; matches `trusty_memory::service::DRAWER_SNIPPET_MAX_CHARS`.
+/// Test: `parse_drawers_projects_fields`.
+const DRAWER_SNIPPET_FALLBACK_MAX: usize = 60;
+
 /// Project a `…/drawers` JSON payload into [`DrawerInfo`]s.
 ///
 /// Why: the endpoint may return either a bare JSON array (the
@@ -624,7 +645,10 @@ pub const NO_CREATOR_LABEL: &str = "—";
 /// drop the whole page.
 /// What: accepts a JSON array (or object with `drawers`); for each entry
 /// reads `id` (UUID string), `created_at` (RFC 3339), and `tags`, then
-/// resolves the creator label via [`creator_label`].
+/// resolves the creator label via [`creator_label`]. The optional
+/// `snippet` field is preferred; when absent the client falls back to
+/// truncating `content` to [`DRAWER_SNIPPET_FALLBACK_MAX`] chars so older
+/// daemons still surface a usable snippet (issue #202).
 /// Test: `parse_drawers_projects_fields`.
 pub fn parse_drawers(raw: &serde_json::Value) -> Vec<DrawerInfo> {
     let array: Vec<serde_json::Value> = match raw {
@@ -658,14 +682,55 @@ pub fn parse_drawers(raw: &serde_json::Value) -> Vec<DrawerInfo> {
                 })
                 .unwrap_or_default();
             let creator = creator_label(&tags);
+            // Issue #202: prefer the daemon-supplied `snippet` field
+            // (already truncated and whitespace-collapsed). Fall back
+            // to a client-side truncation of `content` for daemons that
+            // predate the field. `null` / empty / whitespace-only
+            // values yield `None` so the renderer can omit the column.
+            let snippet = item
+                .get("snippet")
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .or_else(|| {
+                    item.get("content")
+                        .and_then(|v| v.as_str())
+                        .map(client_snippet)
+                        .filter(|s| !s.is_empty())
+                });
             DrawerInfo {
                 id,
                 created_at,
                 creator,
                 tags,
+                snippet,
             }
         })
         .collect()
+}
+
+/// Client-side fallback snippet builder for daemons that predate the
+/// `snippet` wire field (issue #202).
+///
+/// Why: keep the activity panel useful across daemon versions; the
+/// projection should still surface a glanceable summary even when the
+/// daemon returns only the raw `content`.
+/// What: whitespace-collapses, trims, and truncates to
+/// [`DRAWER_SNIPPET_FALLBACK_MAX`] with a trailing `…` when cut. Empty
+/// / whitespace-only inputs yield the empty string so the caller can
+/// drop the snippet via `filter(|s| !s.is_empty())`.
+/// Test: covered by `parse_drawers_projects_fields` via the fallback path.
+fn client_snippet(content: &str) -> String {
+    let normalised: String = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalised.chars().count() <= DRAWER_SNIPPET_FALLBACK_MAX {
+        normalised
+    } else {
+        let kept: String = normalised
+            .chars()
+            .take(DRAWER_SNIPPET_FALLBACK_MAX.saturating_sub(1))
+            .collect();
+        format!("{kept}…")
+    }
 }
 
 /// Pick the first recognised creator tag from a drawer's tag list.
@@ -854,18 +919,22 @@ mod tests {
 
     #[test]
     fn parse_drawers_projects_fields() {
-        // Bare array shape — the daemon's current response.
+        // Bare array shape — the daemon's current response. Row 0
+        // carries an explicit `snippet`; row 1 only has `content` (the
+        // fallback path); row 2 carries neither.
         let raw = serde_json::json!([
             {
                 "id": "11111111-1111-1111-1111-111111111111",
                 "created_at": "2026-05-20T12:34:56Z",
                 "tags": ["msg:from=cto", "user-tag"],
-                "content": "ignored by projection",
+                "content": "ignored when snippet is present",
+                "snippet": "JWT middleware added",
             },
             {
                 "id": "22222222-2222-2222-2222-222222222222",
                 "created_at": "2026-05-19T08:00:00Z",
                 "tags": ["creator:client=mpm", "creator:source=http"],
+                "content": "Plain content for the legacy fallback path",
             },
             {
                 "id": "33333333-3333-3333-3333-333333333333",
@@ -879,12 +948,21 @@ mod tests {
         assert_eq!(drawers[0].creator, "msg:from=cto");
         assert_eq!(drawers[0].tags.len(), 2);
         assert!(drawers[0].created_at.is_some());
+        // Issue #202: explicit snippet wins over content.
+        assert_eq!(drawers[0].snippet.as_deref(), Some("JWT middleware added"));
 
         assert_eq!(drawers[1].creator, "creator:client=mpm");
+        // Issue #202: fall back to truncating `content` when snippet is absent.
+        assert_eq!(
+            drawers[1].snippet.as_deref(),
+            Some("Plain content for the legacy fallback path"),
+        );
 
-        // Malformed timestamp drops to None; missing creator tag → em-dash.
+        // Malformed timestamp drops to None; missing creator tag → em-dash;
+        // no snippet and no content → snippet is None.
         assert!(drawers[2].created_at.is_none());
         assert_eq!(drawers[2].creator, NO_CREATOR_LABEL);
+        assert!(drawers[2].snippet.is_none());
 
         // Object-wrapped shape.
         let obj = serde_json::json!({
@@ -896,6 +974,32 @@ mod tests {
 
         // Unexpected shape yields an empty list.
         assert!(parse_drawers(&serde_json::json!("nope")).is_empty());
+
+        // An explicit `null` snippet (daemon returned `Value::Null`) also
+        // yields `None` — neither the snippet nor the absent content
+        // fields fill it in.
+        let null_snippet = serde_json::json!([{
+            "id": "44444444-4444-4444-4444-444444444444",
+            "snippet": serde_json::Value::Null,
+            "tags": [],
+        }]);
+        let drawers = parse_drawers(&null_snippet);
+        assert!(drawers[0].snippet.is_none());
+
+        // Long content gets truncated by the client fallback.
+        let long_content = "x".repeat(200);
+        let long = serde_json::json!([{
+            "id": "55555555-5555-5555-5555-555555555555",
+            "content": long_content,
+            "tags": [],
+        }]);
+        let drawers = parse_drawers(&long);
+        let snippet = drawers[0].snippet.as_deref().expect("fallback snippet");
+        assert_eq!(snippet.chars().count(), DRAWER_SNIPPET_FALLBACK_MAX);
+        assert!(
+            snippet.ends_with('…'),
+            "long fallback snippet must be truncated with ellipsis",
+        );
     }
 
     #[test]

--- a/crates/trusty-common/src/monitor/memory_tui.rs
+++ b/crates/trusty-common/src/monitor/memory_tui.rs
@@ -1039,15 +1039,30 @@ pub fn drawer_panel_lines(state: &MemoryTuiState, total_drawer_count: u64) -> Ve
     lines
 }
 
+/// Maximum characters retained for the trailing snippet column.
+///
+/// Why: issue #202 — the activity panel row layout is `<id> <ts>
+/// <creator>  <snippet>`. The snippet column adds new width to an
+/// already narrow panel; capping it keeps rows from wrapping on
+/// reasonable terminal widths.
+/// What: 60 characters with a trailing `…` from the truncate helper
+/// when cut. Matches the server's `DRAWER_SNIPPET_MAX_CHARS`.
+/// Test: `drawer_row_includes_snippet`.
+const DRAWER_SNIPPET_WIDTH: usize = 60;
+
 /// Format one drawer as a single compact activity-panel row.
 ///
 /// Why: the panel is narrow; a fixed `<id> <ts> <creator>` column layout
-/// keeps the rendered list scannable.
+/// keeps the rendered list scannable. Issue #202 appends an optional
+/// snippet column when the daemon supplied one, giving the operator a
+/// glance at the drawer body without opening it.
 /// What: `<truncated-id> <MM-DD HH:MM>  <creator>` — id truncated to 8
 /// chars (the leading UUID block), timestamp rendered in UTC, creator
 /// truncated to [`DRAWER_CREATOR_WIDTH`] chars via the shared truncate
-/// helper. A drawer with no timestamp shows `--`.
-/// Test: `drawer_row_layout`.
+/// helper. When `drawer.snippet` is `Some` and non-empty, a `  <snippet>`
+/// suffix is appended (truncated to [`DRAWER_SNIPPET_WIDTH`]). A drawer
+/// with no timestamp shows `--`.
+/// Test: `drawer_row_layout`, `drawer_row_includes_snippet`.
 pub fn format_drawer_row(drawer: &DrawerInfo) -> String {
     let id = truncate(&drawer.id, 8);
     let ts = match drawer.created_at {
@@ -1055,7 +1070,16 @@ pub fn format_drawer_row(drawer: &DrawerInfo) -> String {
         None => "--         ".to_string(),
     };
     let creator = truncate(&drawer.creator, DRAWER_CREATOR_WIDTH);
-    format!("{id} {ts}  {creator}")
+    let base = format!("{id} {ts}  {creator}");
+    match drawer
+        .snippet
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(snippet) => format!("{base}  {}", truncate(snippet, DRAWER_SNIPPET_WIDTH)),
+        None => base,
+    }
 }
 
 /// The memory TUI event loop: poll, render, handle input, drain SSE events.
@@ -3121,7 +3145,15 @@ mod tests {
                 &tags.iter().map(|s| (*s).to_string()).collect::<Vec<_>>(),
             ),
             tags: tags.iter().map(|s| (*s).to_string()).collect(),
+            snippet: None,
         }
+    }
+
+    /// Build a [`DrawerInfo`] for tests with an explicit snippet (issue #202).
+    fn sample_drawer_with_snippet(idx: usize, tags: &[&str], snippet: &str) -> DrawerInfo {
+        let mut d = sample_drawer(idx, tags);
+        d.snippet = Some(snippet.to_string());
+        d
     }
 
     #[test]
@@ -3222,6 +3254,57 @@ mod tests {
         undated.created_at = None;
         let row = format_drawer_row(&undated);
         assert!(row.contains("--"), "missing `--` for undated row: {row}");
+    }
+
+    /// Why (issue #202): when the daemon returns a `snippet`, the row
+    /// must append it after the creator column so the operator sees a
+    /// glanceable preview of the drawer body without opening it. When
+    /// the snippet is absent the row must collapse back to the legacy
+    /// layout — no trailing separator, no padding artefact.
+    /// What: builds drawers with and without snippets and asserts both
+    /// the appended-snippet and absent-snippet shapes.
+    /// Test: itself.
+    #[test]
+    fn drawer_row_includes_snippet() {
+        // Snippet is appended inline after the creator column.
+        let with_snippet =
+            sample_drawer_with_snippet(3, &["msg:from=cto"], "JWT middleware added to auth flow");
+        let row = format_drawer_row(&with_snippet);
+        assert!(
+            row.contains("msg:from=cto"),
+            "creator must still appear before snippet: {row}",
+        );
+        assert!(
+            row.contains("JWT middleware added to auth flow"),
+            "snippet must be appended: {row}",
+        );
+
+        // No snippet → row falls back to the legacy `<id> <ts> <creator>`
+        // shape with no trailing whitespace.
+        let bare = sample_drawer(4, &["msg:from=cto"]);
+        let row = format_drawer_row(&bare);
+        assert!(
+            !row.ends_with("  "),
+            "no-snippet row must not have trailing whitespace: {row:?}",
+        );
+
+        // Empty / whitespace-only snippet is treated as absent so the
+        // row stays at the legacy width.
+        let empty = sample_drawer_with_snippet(5, &["msg:from=cto"], "   ");
+        let row = format_drawer_row(&empty);
+        assert!(
+            !row.ends_with("  "),
+            "whitespace-only snippet must be elided: {row:?}",
+        );
+
+        // A long snippet is truncated to fit the column.
+        let long = "x".repeat(200);
+        let big = sample_drawer_with_snippet(6, &["msg:from=cto"], &long);
+        let row = format_drawer_row(&big);
+        assert!(
+            row.contains('…'),
+            "long snippet must be truncated with `…`: {row}",
+        );
     }
 
     #[test]

--- a/crates/trusty-memory/src/attribution.rs
+++ b/crates/trusty-memory/src/attribution.rs
@@ -65,6 +65,18 @@ pub const CREATOR_SOURCE_PREFIX: &str = "creator:source=";
 /// Test: `creator_info_omits_cwd_when_absent`.
 pub const CREATOR_CWD_PREFIX: &str = "creator:cwd=";
 
+/// Tag prefix carrying the short session id of the writer (issue #202).
+///
+/// Why: when a session UUID is already attached as a bare tag, the TUI
+/// activity panel cannot easily pick it out of the tag list. Emitting a
+/// dedicated `creator:session=<first-8>` tag puts the session shorthand
+/// in the same reserved namespace as the rest of the attribution data so
+/// the dashboard / TUI can render it without bespoke parsing.
+/// What: prefix string; the suffix is the first 8 hex characters of the
+/// originating UUID.
+/// Test: `session_tag_from_tags_returns_first_uuid_short`.
+pub const CREATOR_SESSION_PREFIX: &str = "creator:session=";
+
 /// HTTP request header carrying the writing client's short name.
 ///
 /// Why: lets remote HTTP callers self-identify so the recipient daemon
@@ -238,6 +250,43 @@ pub fn is_creator_tag(tag: &str) -> bool {
     tag.starts_with("creator:")
 }
 
+/// Build a `creator:session=<first-8-chars>` tag from the first bare UUID
+/// found in `tags`, if any (issue #202).
+///
+/// Why: MCP writers (claude-mpm hooks, in particular) already pass the
+/// session UUID as a free-form tag in the `tags` array. Turning that into
+/// an explicit `creator:session=...` tag puts the session id alongside
+/// the rest of the attribution data so the dashboard / TUI can surface
+/// it without inspecting every tag for UUID-shaped strings.
+/// What: scans the slice in order, parses each entry with
+/// `uuid::Uuid::parse_str`, and on the first success returns
+/// `Some("creator:session=<first-8-hex>")`. Returns `None` when no entry
+/// parses as a UUID, or when the matching tag is itself already a
+/// `creator:*` tag (so dashboard-supplied creator tags don't get
+/// re-projected).
+/// Test: `session_tag_from_tags_returns_first_uuid_short`,
+/// `session_tag_from_tags_skips_non_uuid_entries`.
+pub fn session_tag_from_tags(tags: &[String]) -> Option<String> {
+    for tag in tags {
+        // Skip the reserved-namespace tags so a stray
+        // `creator:cwd=<uuid-shaped-path>` can never be misinterpreted
+        // as a session id. We only consider free-form bare tags.
+        if is_creator_tag(tag) {
+            continue;
+        }
+        if let Ok(uuid) = uuid::Uuid::parse_str(tag) {
+            // `uuid.simple()` renders as 32 lowercase hex chars; the
+            // first 8 are the same characters that appear before the
+            // first dash in the hyphenated form. Both forms parse to the
+            // same `Uuid`, so we render canonically here for stability.
+            let simple = uuid.simple().to_string();
+            let short: String = simple.chars().take(8).collect();
+            return Some(format!("{CREATOR_SESSION_PREFIX}{short}"));
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -345,6 +394,62 @@ mod tests {
         assert!(!is_creator_tag("user-tag"));
         assert!(!is_creator_tag("msg:v1"));
         assert!(!is_creator_tag("creatorx"));
+    }
+
+    /// Why: issue #202 — MCP writers (claude-mpm hooks) commonly pass
+    /// the session UUID as a bare tag in the `tags` array. The helper
+    /// must pick out the first parseable UUID and emit the short form
+    /// in the reserved `creator:session=` namespace so the TUI activity
+    /// panel renders it without bespoke parsing.
+    /// What: feeds a mixed tag list and asserts the first 8 hex chars
+    /// of the UUID round-trip into the returned tag.
+    /// Test: itself.
+    #[test]
+    fn session_tag_from_tags_returns_first_uuid_short() {
+        let tags = vec![
+            "user-tag".to_string(),
+            "01919e90-8a2e-7c1d-9f8b-1234567890ab".to_string(),
+            "ignored-second-uuid:11111111-2222-3333-4444-555555555555".to_string(),
+        ];
+        let session = session_tag_from_tags(&tags).expect("session tag");
+        assert_eq!(session, "creator:session=01919e90");
+    }
+
+    /// Why: non-UUID entries (free-form tags, scoped tags like `idx:0`)
+    /// must not be misinterpreted as session ids — the helper has to
+    /// return `None` when no entry parses as a UUID.
+    /// What: feeds a tag list with no UUIDs and asserts `None`.
+    /// Test: itself.
+    #[test]
+    fn session_tag_from_tags_skips_non_uuid_entries() {
+        let tags = vec![
+            "user-tag".to_string(),
+            "idx:0".to_string(),
+            "session-prefix-not-a-uuid".to_string(),
+        ];
+        assert!(session_tag_from_tags(&tags).is_none());
+
+        // Empty list returns `None`.
+        assert!(session_tag_from_tags(&[]).is_none());
+    }
+
+    /// Why: a tag in the reserved `creator:*` namespace must never be
+    /// re-projected as a session id, even if its value parses as a UUID.
+    /// `creator:cwd=` carrying a UUID-shaped temporary path is the
+    /// motivating example.
+    /// What: feeds a `creator:` tag whose value parses as a UUID and a
+    /// real bare UUID later in the list, then asserts the real one wins.
+    /// Test: itself.
+    #[test]
+    fn session_tag_from_tags_skips_reserved_namespace() {
+        let tags = vec![
+            // Reserved namespace tag with a UUID-shaped value — must be skipped.
+            "creator:cwd=11111111-1111-1111-1111-111111111111".to_string(),
+            // The real session tag — must win.
+            "22222222-2222-2222-2222-222222222222".to_string(),
+        ];
+        let session = session_tag_from_tags(&tags).expect("session tag");
+        assert_eq!(session, "creator:session=22222222");
     }
 
     /// Why: the `From<ActivitySource>` impl lets the HTTP path build a

--- a/crates/trusty-memory/src/service.rs
+++ b/crates/trusty-memory/src/service.rs
@@ -609,7 +609,32 @@ impl MemoryService {
             drawers.sort_by_key(|d| std::cmp::Reverse(d.created_at));
         }
         let page: Vec<_> = drawers.into_iter().skip(offset).take(limit).collect();
-        Ok(serde_json::to_value(page).unwrap_or(json!([])))
+        // Issue #202: enrich every row with a short `snippet` derived from
+        // the drawer's content so the TUI activity panel can render a
+        // glanceable summary without re-parsing the full body. The
+        // snippet is whitespace-collapsed and bounded at
+        // `DRAWER_SNIPPET_MAX_CHARS` (60) — shorter than the SSE preview
+        // because the activity panel renders it on a single narrow row.
+        let payload: Vec<Value> = page
+            .into_iter()
+            .map(|drawer| {
+                let snippet = drawer_snippet(&drawer.content);
+                let mut value = serde_json::to_value(&drawer).unwrap_or_else(|_| json!({}));
+                if let Value::Object(ref mut map) = value {
+                    // `null` when the drawer has no usable content so
+                    // clients can distinguish "no body" from "empty body
+                    // after whitespace collapse".
+                    let snippet_value = if snippet.is_empty() {
+                        Value::Null
+                    } else {
+                        Value::String(snippet)
+                    };
+                    map.insert("snippet".to_string(), snippet_value);
+                }
+                value
+            })
+            .collect();
+        Ok(Value::Array(payload))
     }
 
     /// Store a new drawer and emit the matching activity events.
@@ -636,6 +661,13 @@ impl MemoryService {
         let importance = body.importance.unwrap_or(0.5);
         let content_preview = drawer_content_preview(&body.content);
         let mut tags_with_creator = body.tags;
+        // Issue #202: project a bare-UUID session tag (when the caller
+        // passed one in the request body) into the reserved
+        // `creator:session=<first-8>` slot so the activity panel can
+        // surface session attribution without bespoke parsing.
+        if let Some(session_tag) = crate::attribution::session_tag_from_tags(&tags_with_creator) {
+            tags_with_creator.push(session_tag);
+        }
         creator.merge_into(&mut tags_with_creator);
         let content_for_kg = body.content.clone();
         let tags_for_kg = tags_with_creator.clone();
@@ -1001,6 +1033,17 @@ impl MemoryService {
 /// Maximum characters retained in a drawer's content preview.
 pub const DRAWER_PREVIEW_MAX_CHARS: usize = 80;
 
+/// Maximum characters retained in a drawer-row snippet (issue #202).
+///
+/// Why: the TUI activity panel renders the snippet inline at the end of a
+/// narrow row (`<id> <ts> <creator>  <snippet>`); 60 chars is short
+/// enough to keep the row readable while still showing the key phrase
+/// of most drawers.
+/// What: 60 characters; the trailing `…` from [`drawer_snippet`] counts
+/// against this budget.
+/// Test: `drawer_snippet_truncates_long_content`.
+pub const DRAWER_SNIPPET_MAX_CHARS: usize = 60;
+
 /// Build a single-line preview of drawer content for SSE events.
 ///
 /// Why: the activity feed should show *what* was just stored; multiline /
@@ -1016,6 +1059,33 @@ pub fn drawer_content_preview(content: &str) -> String {
         let kept: String = normalised
             .chars()
             .take(DRAWER_PREVIEW_MAX_CHARS.saturating_sub(1))
+            .collect();
+        format!("{kept}…")
+    }
+}
+
+/// Build a short snippet from a drawer's content for the TUI activity panel
+/// row (issue #202).
+///
+/// Why: the activity panel renders one row per drawer at narrow column
+/// width; a 60-char whitespace-collapsed snippet is long enough to convey
+/// the gist but short enough to fit inline with the id / timestamp /
+/// creator columns. Re-using the preview's whitespace-collapse rule keeps
+/// SSE and `/drawers` snippets visually consistent.
+/// What: collapses whitespace, trims, truncates to
+/// [`DRAWER_SNIPPET_MAX_CHARS`] (60) with a trailing `…` when cut.
+/// Returns the empty string for empty / whitespace-only content so the
+/// caller can omit the `snippet` field entirely.
+/// Test: `drawer_snippet_truncates_long_content`,
+/// `drawer_snippet_handles_empty_content`.
+pub fn drawer_snippet(content: &str) -> String {
+    let normalised: String = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalised.chars().count() <= DRAWER_SNIPPET_MAX_CHARS {
+        normalised
+    } else {
+        let kept: String = normalised
+            .chars()
+            .take(DRAWER_SNIPPET_MAX_CHARS.saturating_sub(1))
             .collect();
         format!("{kept}…")
     }
@@ -1441,5 +1511,62 @@ mod tests {
             Some("drawer-1"),
             "importance default should surface drawer with importance 0.9 first",
         );
+
+        // Issue #202: every row carries an enriched `snippet` field
+        // derived from the drawer body so the TUI activity panel can
+        // render a glanceable summary without re-parsing.
+        assert_eq!(
+            arr[0]["snippet"].as_str(),
+            Some("drawer-1"),
+            "snippet must be populated for non-empty drawer content",
+        );
+    }
+
+    /// Why: issue #202 — the snippet helper must collapse whitespace,
+    /// trim, and cap at [`DRAWER_SNIPPET_MAX_CHARS`] with a trailing `…`
+    /// when the body overflows, matching the SSE preview's shape but at
+    /// a tighter width.
+    /// What: feeds a multiline / whitespace-heavy body and asserts both
+    /// the truncation and the collapse rule.
+    /// Test: itself.
+    #[test]
+    fn drawer_snippet_truncates_long_content() {
+        // Short content round-trips verbatim.
+        assert_eq!(drawer_snippet("hello world"), "hello world");
+
+        // Whitespace is collapsed.
+        assert_eq!(
+            drawer_snippet("first line\n\nsecond\tline   third"),
+            "first line second line third",
+        );
+
+        // Padding is trimmed.
+        assert_eq!(drawer_snippet("   padded   "), "padded");
+
+        // A body longer than the cap is truncated and ends with `…`.
+        let long = "a".repeat(200);
+        let snippet = drawer_snippet(&long);
+        assert_eq!(snippet.chars().count(), DRAWER_SNIPPET_MAX_CHARS);
+        assert!(
+            snippet.ends_with('…'),
+            "long body must be truncated with ellipsis",
+        );
+
+        // A body sized exactly at the cap is preserved verbatim.
+        let exact = "a".repeat(DRAWER_SNIPPET_MAX_CHARS);
+        assert_eq!(drawer_snippet(&exact), exact);
+    }
+
+    /// Why: empty / whitespace-only bodies must produce an empty
+    /// snippet so the `list_drawers` shaper can omit the `snippet`
+    /// field (rendered as `null` on the wire) instead of an empty
+    /// string. The TUI relies on this distinction to skip the snippet
+    /// column entirely when the body has no usable preview.
+    /// What: feeds empty and whitespace-only strings.
+    /// Test: itself.
+    #[test]
+    fn drawer_snippet_handles_empty_content() {
+        assert_eq!(drawer_snippet(""), "");
+        assert_eq!(drawer_snippet("   \n\t  "), "");
     }
 }

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -19,7 +19,7 @@
 //! - `kg_assert(palace, subject, predicate, object, confidence?, provenance?)` -> ()
 //! - `kg_query(palace, subject)`                    -> Vec<Triple>
 
-use crate::attribution::{CreatorInfo, CreatorSource, MCP_CLIENT_NAME};
+use crate::attribution::{session_tag_from_tags, CreatorInfo, CreatorSource, MCP_CLIENT_NAME};
 use crate::kg_extract::{extract_triples, ExtractInput};
 use crate::{ActivitySource, AppState, DaemonEvent};
 use anyhow::{anyhow, Context, Result};
@@ -585,7 +585,13 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
             // Submission-logging Part B: attach `creator:*` attribution so
             // every MCP-origin drawer carries the writer identity (client
             // = `trusty-memory-mcp`, source = `mcp`, version + cwd of the
-            // MCP server process).
+            // MCP server process). Issue #202: also project a bare-UUID
+            // session tag (when present in the caller's tags) into the
+            // reserved `creator:session=<first-8>` slot so the activity
+            // panel can surface it without inspecting every tag.
+            if let Some(session_tag) = session_tag_from_tags(&tags) {
+                tags.push(session_tag);
+            }
             CreatorInfo::new_self(MCP_CLIENT_NAME, CreatorSource::Mcp).merge_into(&mut tags);
 
             let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
@@ -662,6 +668,11 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
                 })
                 .unwrap_or_default();
             // Submission-logging Part B: same attribution as memory_remember.
+            // Issue #202: project a bare-UUID session tag (when present)
+            // into the reserved `creator:session=<first-8>` slot.
+            if let Some(session_tag) = session_tag_from_tags(&tags) {
+                tags.push(session_tag);
+            }
             CreatorInfo::new_self(MCP_CLIENT_NAME, CreatorSource::Mcp).merge_into(&mut tags);
             let handle = open_palace_handle(state, palace)?;
             // Issue #97: mirror memory_remember — keep originals so the KG

--- a/crates/trusty-memory/src/transport/rpc.rs
+++ b/crates/trusty-memory/src/transport/rpc.rs
@@ -467,7 +467,11 @@ mod tests {
             })),
         };
         let resp = dispatch(&state, req).await;
-        assert!(resp.error.is_none(), "initialize must not error: {:?}", resp.error);
+        assert!(
+            resp.error.is_none(),
+            "initialize must not error: {:?}",
+            resp.error
+        );
         let result = resp.result.expect("result");
         assert_eq!(
             result["protocolVersion"], "2024-11-05",


### PR DESCRIPTION
## Summary

Two related TUI activity panel improvements for the trusty-memory drawer display (issue #202).

### Part 1 — Project session UUID into the creator namespace
- `attribution::session_tag_from_tags()` (new helper) detects the first parseable bare UUID in a tag list, skipping anything already in the reserved `creator:*` namespace, and returns a formatted `creator:session=<first-8-hex>` tag.
- Wired into both MCP write paths (`memory_remember`, `memory_note`) and the HTTP `create_drawer` service method so dashboard / TUI surfaces can show session attribution without UUID-shape sniffing.
- Verified the HTTP path's existing `creator:source=http` injection (via `creator_info_from_http`) is consistent.

### Part 2 — Drawer content snippet
- Server: new `drawer_snippet()` helper + `DRAWER_SNIPPET_MAX_CHARS = 60`; `service::list_drawers` now injects a `snippet` field into every drawer entry. Whitespace-collapsed, trimmed, capped with `…`, `null` when empty.
- Client (`memory_client::DrawerInfo`): new `snippet: Option<String>` field. Parses the daemon-supplied snippet; falls back to a 60-char client-side truncation of `content` for older daemons.
- TUI (`memory_tui::format_drawer_row`): appends `  <snippet>` (truncated to 60 chars) after the creator column when present. Empty / whitespace-only snippets are elided so the legacy layout is preserved.

### Tests (raw output below)
- `cargo test -p trusty-memory` → 244 passed, 0 failed, 4 ignored.
- `cargo test -p trusty-common --features monitor-tui` → 194 passed, 0 failed, 6 ignored.
- New tests:
  - `attribution::tests::session_tag_from_tags_returns_first_uuid_short`
  - `attribution::tests::session_tag_from_tags_skips_non_uuid_entries`
  - `attribution::tests::session_tag_from_tags_skips_reserved_namespace`
  - `service::tests::drawer_snippet_truncates_long_content`
  - `service::tests::drawer_snippet_handles_empty_content`
  - `service::tests::list_drawers_creates_desc_paginates` (extended)
  - `monitor::memory_client::tests::parse_drawers_projects_fields` (extended with snippet / fallback / null / long-truncate cases)
  - `monitor::memory_tui::tests::drawer_row_includes_snippet`

### Drive-by
`cargo fmt` cleaned up two pre-existing whitespace drifts in `bm25_client.rs` and `transport/rpc.rs`.

## Test plan

- [x] `cargo check -p trusty-memory -p trusty-common`
- [x] `cargo clippy -p trusty-memory -p trusty-common --all-targets -- -D warnings`
- [x] `cargo clippy -p trusty-common --features monitor-tui --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p trusty-memory`
- [x] `cargo test -p trusty-common --features monitor-tui`
- [ ] Launch `trusty-memory monitor tui` against a populated palace and confirm drawer rows now show the inline snippet column and that recent MCP-origin drawers carry the `creator:session=<short>` tag.