### PR TITLE
chore(trusty-bm25-daemon): publish v0.1.0 + add patch.crates-io entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ tree-sitter-scala = "0.24"
 [patch.crates-io]
 trusty-common = { path = "crates/trusty-common" }
 trusty-embedderd = { path = "crates/trusty-embedderd" }
+trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon" }
 
 [profile.dev]
 opt-level = 0

--- a/crates/trusty-bm25-daemon/Cargo.toml
+++ b/crates/trusty-bm25-daemon/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "trusty-bm25-daemon"
 version = "0.1.0"
-publish = false
+publish = true
 edition = "2021"
 rust-version = "1.88"
 description = "Per-palace BM25 lexical-index subprocess for the trusty-* ecosystem (issue #156)"
-license = "Elastic-2.0"
+license-file = "LICENSE"
 authors.workspace = true
 repository.workspace = true
 readme = "README.md"

--- a/crates/trusty-bm25-daemon/LICENSE
+++ b/crates/trusty-bm25-daemon/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+Copyright (c) 2024-2026 Bob Matsuoka
+Contact: bob@matsuoka.com
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of legal
+claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.


### PR DESCRIPTION
## Summary

- Flips `publish = false` → `publish = true` and switches `license = "Elastic-2.0"` to `license-file = "LICENSE"` (mirroring the `trusty-embedderd` pattern required by crates.io)
- Adds `crates/trusty-bm25-daemon/LICENSE` (Elastic-2.0, same text as sibling crates)
- Adds `trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon" }` to the `[patch.crates-io]` block in the workspace root `Cargo.toml` so `trusty-memory` resolves to the in-tree source after the crate is live

`trusty-bm25-daemon v0.1.0` was published to crates.io before this PR was opened — the `Uploaded` + `Published` lines from `cargo publish` confirm it is live.

## Test plan

- [x] `cargo check -p trusty-bm25-daemon` — clean
- [x] `cargo publish -p trusty-bm25-daemon` — uploaded and published successfully
- [x] `cargo check -p trusty-memory` — clean, `trusty-bm25-daemon` resolves to in-tree path via patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)