### PR TITLE
chore(trusty-common): bump to 0.6.1 — expose cli-help feature for tga publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 
 [workspace.dependencies]
 # ── Internal crates (path deps so the monorepo builds without publish cycles) ──
-trusty-common = { path = "crates/trusty-common", version = "0.6.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.6.1" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.0" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "1.0.16"
+version = "1.0.17"
 publish = true
 edition = "2021"
 # Required for `std::sync::LazyLock` used by the shared CLI help wiring


### PR DESCRIPTION
Publishes `trusty-common v0.6.1` with the `cli-help` feature that was added
in-tree but missing from the v0.6.0 crates.io release. Required so
`tga v1.0.17` can resolve its `cli-help` dependency from the registry.

- Bumps `trusty-common` from `0.6.0` → `0.6.1` in `crates/trusty-common/Cargo.toml`
- Updates workspace `[workspace.dependencies]` entry to match