### PR TITLE
fix(trusty-search): re-add TRUSTY_SKIP_RAM_CHECK bypass (0.12.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6305,7 +6305,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9873,7 +9873,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -10806,7 +10806,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/commands/start.rs
+++ b/crates/trusty-search/src/commands/start.rs
@@ -740,11 +740,14 @@ pub async fn handle_start(port: u16, foreground: bool, device: &str, verbose: bo
     // under realistic workloads. Exit before binding any port or loading
     // the embedder so the operator gets a clear, actionable error.
     const MIN_RAM_MB: u64 = 16 * 1024;
-    if policy.total_ram_mb < MIN_RAM_MB {
+    if policy.total_ram_mb < MIN_RAM_MB
+        && std::env::var("TRUSTY_SKIP_RAM_CHECK").as_deref() != Ok("1")
+    {
         anyhow::bail!(
             "trusty-search requires at least 16 GB of RAM.\n\
              Detected: {} MB ({:.1} GB)\n\
-             Indexing large codebases on machines with less memory is not supported.",
+             Indexing large codebases on machines with less memory is not supported.\n\
+             To bypass on this host set TRUSTY_SKIP_RAM_CHECK=1 in the daemon environment.",
             policy.total_ram_mb,
             policy.total_ram_mb as f64 / 1024.0
         );


### PR DESCRIPTION
## Problem
The hard 16 GB RAM minimum check at daemon startup removed the `TRUSTY_SKIP_RAM_CHECK=1` env-var escape hatch. Hosts with 15-16 GB RAM (just under the limit) cannot start the service even when the systemd unit sets the bypass var.

## Fix
Re-add the env-var guard: `if policy.total_ram_mb < MIN_RAM_MB && std::env::var("TRUSTY_SKIP_RAM_CHECK").as_deref() != Ok("1")`.

## Test plan
- [ ] `cargo test -p trusty-search` passes
- [ ] `cargo clippy -p trusty-search --all-targets -- -D warnings` clean
- [ ] Service starts on 15.4 GB host with `TRUSTY_SKIP_RAM_CHECK=1`

Generated with Claude Code