### PR TITLE
fix(trusty-search): include help.yaml in publish tarball (0.12.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -14,6 +14,7 @@ include = [
     "src/**/*",
     "build.rs",
     "ui-dist/**/*",
+    "help.yaml",
     "Cargo.toml",
     "README.md",
     "LICENSE",


### PR DESCRIPTION
## Problem
Publishing trusty-search 0.12.2 (the RAM-bypass hotfix) fails verification:

```
error: couldn't read `src/../help.yaml`: No such file or directory (os error 2)
  --> src/main.rs:767:40
```

The `include` array in `Cargo.toml` was never updated when #219 added `help.yaml` and the `include_str!("../help.yaml")` call in `main.rs`. `cargo publish` packages the crate but the verification compile fails because the file is missing from the tarball.

## Fix
Add `help.yaml` to the `include` list and bump to 0.12.3 so the 0.12.2 RAM-bypass fix can ship.

## Test plan
- [x] `cargo package --no-verify` confirms `help.yaml` is in the tarball
- [x] `cargo check -p trusty-search` passes
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` clean

Generated with Claude Code