### PR TITLE
fix(trusty-memory): safety + async correctness fixes (closes #225 #229 #230 #232)

### DIFF
--- a/crates/trusty-memory/src/activity.rs
+++ b/crates/trusty-memory/src/activity.rs
@@ -168,15 +168,37 @@ pub struct ActivityFilter {
 /// Why: held on `AppState` so every emitting handler (HTTP, MCP, Hook) can
 /// record an entry without re-opening the database. redb's `Database`
 /// already supports concurrent access internally; an `Arc` clone is cheap
-/// and lets the type satisfy `AppState: Clone`.
-/// What: holds an `Arc<Database>` plus an `AtomicU64` next-id counter
-/// initialised from the table's current max key. The counter survives clones
-/// because it lives behind the same `Arc`.
-/// Test: `appends_assign_monotonic_ids`.
+/// and lets the type satisfy `AppState: Clone`. The `Discard` variant
+/// (issue #225) keeps the daemon usable when no writable directory is
+/// available (read-only containers, locked-down sandboxes) by silently
+/// dropping every append and returning empty reads — the activity log is
+/// documented as best-effort, so falling back to a no-op is the contract
+/// the rest of the daemon already assumes.
+/// What: an enum with two variants — `Redb` wraps a backing redb database
+/// plus an `AtomicU64` next-id counter initialised from the table's current
+/// max key (the counter survives clones because it lives behind the same
+/// `Arc`); `Discard` is a zero-state variant that drops appends and returns
+/// empty reads / zero counts, used when both the primary data root and the
+/// tempdir fallback are unwritable.
+/// Test: `appends_assign_monotonic_ids` covers `Redb`;
+///       `discard_variant_drops_writes_and_returns_empty_reads` covers `Discard`.
 #[derive(Clone)]
-pub struct ActivityLog {
-    db: Arc<Database>,
-    next_id: Arc<AtomicU64>,
+pub enum ActivityLog {
+    /// redb-backed activity log — the production path.
+    Redb {
+        db: Arc<Database>,
+        next_id: Arc<AtomicU64>,
+    },
+    /// No-op fallback used when no writable directory is available.
+    ///
+    /// Why: callers should never branch on whether the log is functional;
+    /// every method on this variant returns a successful empty result so
+    /// `state.emit` stays best-effort and the dashboard simply shows an
+    /// empty feed.
+    /// What: zero-sized variant — appends are dropped, `count` returns 0,
+    /// `list` returns an empty vec.
+    /// Test: `discard_variant_drops_writes_and_returns_empty_reads`.
+    Discard,
 }
 
 impl ActivityLog {
@@ -188,6 +210,8 @@ impl ActivityLog {
     /// monotonic across daemon restarts.
     /// What: ensures the data dir exists, opens the database, creates the
     /// `activity` table if absent, and seeds `next_id` from `last_key()`.
+    /// Always returns the `Redb` variant on success; use
+    /// `ActivityLog::discard()` to construct the no-op fallback explicitly.
     /// Test: `activity_log_open_creates_db_file`,
     /// `next_id_resumes_from_max_after_reopen`.
     pub fn open(data_root: &Path) -> Result<Self> {
@@ -222,10 +246,35 @@ impl ActivityLog {
             key
         };
 
-        Ok(Self {
+        Ok(Self::Redb {
             db: Arc::new(db),
             next_id: Arc::new(AtomicU64::new(max_key.saturating_add(1))),
         })
+    }
+
+    /// Construct a no-op activity log that drops every write (issue #225).
+    ///
+    /// Why: when neither the primary data root nor the tempdir fallback is
+    /// writable, the daemon must still come up. Returning this variant from
+    /// `open_activity_log_with_fallback` keeps the call sites identical —
+    /// `append`, `count`, and `list` all stay infallible-ish (they return
+    /// `Ok` but do nothing) so callers do not need to branch on whether the
+    /// log is real.
+    /// What: returns `ActivityLog::Discard` — a zero-sized enum variant.
+    /// Test: `discard_variant_drops_writes_and_returns_empty_reads`.
+    pub fn discard() -> Self {
+        Self::Discard
+    }
+
+    /// True when this is the `Discard` (no-op) variant.
+    ///
+    /// Why: exposed for tests and for any future code that wants to surface
+    /// the degraded state in a health endpoint without taking a hard
+    /// dependency on the enum shape.
+    /// What: returns `true` for `ActivityLog::Discard`, `false` otherwise.
+    /// Test: `discard_variant_drops_writes_and_returns_empty_reads`.
+    pub fn is_discard(&self) -> bool {
+        matches!(self, Self::Discard)
     }
 
     /// Append a new entry and return the assigned id.
@@ -233,12 +282,14 @@ impl ActivityLog {
     /// Why: every mutating handler calls this so the feed has a complete
     /// history. Append also triggers FIFO eviction when the row count
     /// exceeds [`MAX_ENTRIES`] so the table footprint stays bounded.
-    /// What: serialises the entry with `serde_json` (small overhead, but
-    /// keeps the schema human-readable for `redb`'s `dump` and our own
-    /// debug tooling), writes it under a freshly-allocated id, and prunes
-    /// the oldest rows past the cap.
+    /// What: on the `Redb` variant, serialises the entry with `serde_json`
+    /// (small overhead, but keeps the schema human-readable for `redb`'s
+    /// `dump` and our own debug tooling), writes it under a freshly-allocated
+    /// id, and prunes the oldest rows past the cap. On the `Discard`
+    /// variant, returns `Ok(0)` without touching any state.
     /// Test: `appends_assign_monotonic_ids`,
-    /// `appends_evict_oldest_when_capped`.
+    /// `appends_evict_oldest_when_capped`,
+    /// `discard_variant_drops_writes_and_returns_empty_reads`.
     pub fn append(
         &self,
         source: ActivitySource,
@@ -246,7 +297,11 @@ impl ActivityLog {
         event_type: impl Into<String>,
         payload: impl Serialize,
     ) -> Result<u64> {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (db, next_id) = match self {
+            Self::Redb { db, next_id } => (db, next_id),
+            Self::Discard => return Ok(0),
+        };
+        let id = next_id.fetch_add(1, Ordering::Relaxed);
         let payload_json = serde_json::to_string(&payload).context("serialize activity payload")?;
         let entry = ActivityEntry {
             id,
@@ -258,7 +313,7 @@ impl ActivityLog {
         };
         let bytes = serde_json::to_vec(&entry).context("serialize activity entry")?;
 
-        let write = self.db.begin_write().context("begin_write activity")?;
+        let write = db.begin_write().context("begin_write activity")?;
         {
             let mut table = write
                 .open_table(ACTIVITY_TABLE)
@@ -278,9 +333,14 @@ impl ActivityLog {
     /// Why: keep the on-disk footprint bounded. Called from `append` so the
     /// cap is enforced on every write; tests can also call it directly.
     /// What: counts rows, computes the overflow, and removes the lowest-id
-    /// rows in batches of [`EVICTION_BATCH`].
+    /// rows in batches of [`EVICTION_BATCH`]. On the `Discard` variant,
+    /// returns immediately — there is nothing to evict.
     /// Test: `appends_evict_oldest_when_capped`.
     pub fn prune(&self) -> Result<()> {
+        let db = match self {
+            Self::Redb { db, .. } => db,
+            Self::Discard => return Ok(()),
+        };
         loop {
             let count = self.count()?;
             if count <= MAX_ENTRIES {
@@ -289,10 +349,7 @@ impl ActivityLog {
             let overflow = count - MAX_ENTRIES;
             let to_drop = overflow.min(EVICTION_BATCH);
 
-            let write = self
-                .db
-                .begin_write()
-                .context("begin_write activity (prune)")?;
+            let write = db.begin_write().context("begin_write activity (prune)")?;
             {
                 let mut table = write
                     .open_table(ACTIVITY_TABLE)
@@ -317,10 +374,16 @@ impl ActivityLog {
     ///
     /// Why: exposed for tests and the prune loop; also handy for the
     /// `GET /api/v1/activity` response so the UI can render a total count.
-    /// What: opens a read transaction and calls redb's `Table::len`.
-    /// Test: `appends_evict_oldest_when_capped`.
+    /// What: opens a read transaction and calls redb's `Table::len` on the
+    /// `Redb` variant; returns `0` for the `Discard` variant.
+    /// Test: `appends_evict_oldest_when_capped`,
+    /// `discard_variant_drops_writes_and_returns_empty_reads`.
     pub fn count(&self) -> Result<u64> {
-        let read = self.db.begin_read().context("begin_read activity count")?;
+        let db = match self {
+            Self::Redb { db, .. } => db,
+            Self::Discard => return Ok(0),
+        };
+        let read = db.begin_read().context("begin_read activity count")?;
         let table = read
             .open_table(ACTIVITY_TABLE)
             .context("open_table activity (count)")?;
@@ -337,15 +400,21 @@ impl ActivityLog {
     /// is the simplest correct strategy), and returns at most `limit` rows
     /// starting at `offset`. `limit` is clamped at the call site by the
     /// handler; this method does not clamp so tests can exercise edge cases.
+    /// On the `Discard` variant, returns an empty vec.
     /// Test: `list_returns_newest_first`,
-    /// `list_filters_by_source_palace_and_time`.
+    /// `list_filters_by_source_palace_and_time`,
+    /// `discard_variant_drops_writes_and_returns_empty_reads`.
     pub fn list(
         &self,
         filter: &ActivityFilter,
         limit: usize,
         offset: usize,
     ) -> Result<Vec<ActivityEntry>> {
-        let read = self.db.begin_read().context("begin_read activity list")?;
+        let db = match self {
+            Self::Redb { db, .. } => db,
+            Self::Discard => return Ok(Vec::new()),
+        };
+        let read = db.begin_read().context("begin_read activity list")?;
         let table = read
             .open_table(ACTIVITY_TABLE)
             .context("open_table activity (list)")?;
@@ -632,6 +701,39 @@ mod tests {
             )
             .unwrap();
         assert_eq!(mcp_alpha.len(), 1);
+    }
+
+    #[test]
+    fn discard_variant_drops_writes_and_returns_empty_reads() {
+        // Why: issue #225 — when the data root and tempdir fallback are
+        // both unwritable, `open_activity_log_with_fallback` returns the
+        // `Discard` variant. Verify every method is infallible and a no-op.
+        let log = ActivityLog::discard();
+        assert!(log.is_discard(), "expected Discard variant");
+
+        // append returns Ok and yields the sentinel id 0 without panicking
+        // or mutating state.
+        let id = log
+            .append(ActivitySource::Http, None, "drawer_added", json!({"x": 1}))
+            .expect("discard append must succeed");
+        assert_eq!(id, 0, "discard always returns id 0");
+
+        // count and list always read as empty.
+        assert_eq!(log.count().expect("discard count"), 0);
+        let listed = log
+            .list(&ActivityFilter::default(), 10, 0)
+            .expect("discard list");
+        assert!(listed.is_empty(), "discard list must be empty");
+
+        // prune is a no-op.
+        log.prune().expect("discard prune");
+
+        // A second append still returns 0 — no state is retained.
+        let id2 = log
+            .append(ActivitySource::Mcp, Some("p".into()), "x", json!({}))
+            .expect("discard append (second)");
+        assert_eq!(id2, 0);
+        assert_eq!(log.count().expect("discard count after writes"), 0);
     }
 
     #[test]

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -540,6 +540,26 @@ pub struct AppState {
     /// Test: covered by `bm25_supervisor_present_when_env_set` and the
     /// `bm25_supervisor::tests` unit tests.
     pub bm25_supervisor: Option<Arc<bm25_supervisor::Bm25Supervisor>>,
+    /// Per-palace write serialisation locks (issue #230).
+    ///
+    /// Why: the dedup gate in `tools.rs` previously read a snapshot of
+    /// existing drawers, checked for near-duplicates via Jaro-Winkler, and
+    /// then issued the write — a classic time-of-check/time-of-use race.
+    /// Two concurrent `memory_remember` calls with the same content could
+    /// both see the pre-write snapshot, both pass the gate, and both land
+    /// duplicate drawers. Serialising the gate-then-write sequence per
+    /// palace closes the window: while one task holds the mutex, any
+    /// concurrent writer for the same palace blocks until the first write
+    /// finishes and is visible to `list_drawers`. The lock is **per
+    /// palace** (not global) so writes to different palaces continue to
+    /// run in parallel.
+    /// What: a `DashMap` keyed by palace id, where each entry is an
+    /// `Arc<tokio::sync::Mutex<()>>`. The mutex is constructed lazily by
+    /// `palace_write_lock` on first access. `Arc` lets callers hold a
+    /// clone of the lock past the lifetime of the `DashMap` entry so the
+    /// map never needs to be held across an `.await`.
+    /// Test: `tools::tests::dedup_gate_blocks_concurrent_duplicate_writes`.
+    pub palace_write_locks: Arc<dashmap::DashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl AppState {
@@ -584,7 +604,36 @@ impl AppState {
             activity_log,
             bm25_client: None,
             bm25_supervisor: None,
+            palace_write_locks: Arc::new(dashmap::DashMap::new()),
         }
+    }
+
+    /// Acquire (lazily, then clone) the per-palace write mutex.
+    ///
+    /// Why (issue #230): the dedup-check + `remember_with_options` write
+    /// sequence in `tools.rs` must be atomic per palace to prevent two
+    /// concurrent identical writes from both passing the dedup gate.
+    /// Callers hold the returned `Arc<Mutex<()>>`'s guard across the gate
+    /// check and the write so the second writer blocks until the first
+    /// write is visible to `list_drawers`. Returning a clone of the `Arc`
+    /// rather than a borrow into the `DashMap` lets the caller `.await`
+    /// while holding the lock without risking a deadlock against any
+    /// future map mutation (DashMap shards are sync mutexes).
+    /// What: looks up the palace id in `palace_write_locks` and returns
+    /// a clone of the existing mutex; on the first call for a palace,
+    /// inserts a freshly-constructed `tokio::sync::Mutex<()>` first. The
+    /// `DashMap::entry().or_insert_with` API guarantees the lazy
+    /// construction is racy-safe — only one mutex is ever inserted per
+    /// palace id.
+    /// Test: `tools::tests::dedup_gate_blocks_concurrent_duplicate_writes`.
+    pub fn palace_write_lock(&self, palace_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+        if let Some(existing) = self.palace_write_locks.get(palace_id) {
+            return existing.clone();
+        }
+        self.palace_write_locks
+            .entry(palace_id.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     /// Builder-style: opt-in to the BM25 lexical lane (issue #156).

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -290,34 +290,47 @@ pub enum DaemonEvent {
 }
 
 /// Open the activity log under `data_root`, falling back to a per-process
-/// tempdir when the primary location is unwritable.
+/// tempdir and finally to a no-op `Discard` variant when no writable
+/// directory is available.
 ///
-/// Why (issue #96): the activity log is a best-effort feature — if the data
-/// root is on a read-only mount, missing, or locked by another process, the
-/// daemon should still come up and serve every other endpoint. Falling back
-/// to a `std::env::temp_dir()`-anchored subdirectory keyed by the daemon's
-/// process id keeps the log available for the lifetime of the daemon while
-/// guaranteeing a unique writable directory.
+/// Why (issues #96, #225): the activity log is a best-effort feature — if
+/// the data root is on a read-only mount, missing, or locked by another
+/// process, the daemon should still come up and serve every other endpoint.
+/// The first fallback is a `std::env::temp_dir()`-anchored subdirectory
+/// keyed by the daemon's process id. Issue #225: a previous version called
+/// `expect()` on the tempdir fallback, which crashed the daemon on hosts
+/// where neither `data_root` nor `std::env::temp_dir()` is writable
+/// (read-only containers, locked-down sandboxes). The contract is
+/// "best-effort", so the final fallback is now `ActivityLog::discard()` —
+/// a no-op variant that drops every append and returns empty reads. The
+/// dashboard's activity feed simply shows up empty in that degraded state.
 /// What: tries `ActivityLog::open(data_root)`; on error logs a warning and
-/// retries against `<temp>/trusty-memory-activity-<pid>/`. The final
-/// fallback `expect` is only reachable when even `temp_dir()` is broken,
-/// which is a programmer-error class invariant.
-/// Test: covered indirectly by `app_state_default_constructs` and every
-/// test that builds an `AppState` against a tempdir.
+/// retries against `<temp>/trusty-memory-activity-<pid>/`. If both fail,
+/// emits a final warning and returns `ActivityLog::discard()`.
+/// Test: `open_activity_log_with_fallback_returns_discard_when_unwritable`
+/// covers the discard branch; existing `AppState` construction tests cover
+/// the happy and tempdir-fallback paths.
 fn open_activity_log_with_fallback(data_root: &Path) -> Arc<ActivityLog> {
     match ActivityLog::open(data_root) {
         Ok(log) => Arc::new(log),
-        Err(e) => {
+        Err(primary_err) => {
             tracing::warn!(
-                "could not open activity log at {}: {e:#}; falling back to per-process tempdir",
+                "could not open activity log at {}: {primary_err:#}; falling back to per-process tempdir",
                 data_root.display()
             );
             let fallback =
                 std::env::temp_dir().join(format!("trusty-memory-activity-{}", std::process::id()));
-            Arc::new(
-                ActivityLog::open(&fallback)
-                    .expect("activity fallback log must open in a fresh tempdir"),
-            )
+            match ActivityLog::open(&fallback) {
+                Ok(log) => Arc::new(log),
+                Err(fallback_err) => {
+                    tracing::warn!(
+                        "activity log tempdir fallback at {} also failed: {fallback_err:#}; \
+                         activity feed disabled for this process (no-op log)",
+                        fallback.display()
+                    );
+                    Arc::new(ActivityLog::discard())
+                }
+            }
         }
     }
 }
@@ -1379,6 +1392,89 @@ mod tests {
         assert!(!s.version.is_empty());
         assert!(s.registry.is_empty());
         assert!(s.default_palace.is_none());
+    }
+
+    /// Why (issue #225): the previous implementation called `.expect()` on the
+    /// tempdir fallback, which panicked the daemon at startup on hosts where
+    /// neither the data root nor `std::env::temp_dir()` is writable
+    /// (read-only Docker overlays, locked-down sandboxes). The activity log
+    /// is documented as best-effort, so the fix returns a no-op `Discard`
+    /// variant instead. This test forces both paths to fail and asserts the
+    /// helper returns the discard variant rather than panicking.
+    ///
+    /// Skipped when running as root because `chmod 000` is a no-op for the
+    /// root user — the kernel grants root access regardless of mode bits.
+    /// CI typically runs as non-root, so coverage is preserved in the
+    /// common case; local root invocations simply skip with a warning.
+    #[test]
+    #[cfg(unix)]
+    fn open_activity_log_with_fallback_returns_discard_when_unwritable() {
+        // Skip when running as root — chmod is ignored.
+        // SAFETY: libc::geteuid is a thread-safe syscall with no preconditions.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!(
+                "skipping open_activity_log_with_fallback_returns_discard_when_unwritable: running as root"
+            );
+            return;
+        }
+
+        use std::os::unix::fs::PermissionsExt;
+
+        // Build two unwritable directories: the primary "data root" and a
+        // shadow "TMPDIR" so the tempdir fallback also fails.
+        let outer = tempfile::tempdir().expect("outer tempdir");
+        let primary = outer.path().join("primary");
+        let tmpdir = outer.path().join("fake-tmp");
+        std::fs::create_dir(&primary).expect("create primary");
+        std::fs::create_dir(&tmpdir).expect("create tmpdir");
+
+        // chmod 000 on both — neither can be opened for write.
+        std::fs::set_permissions(&primary, std::fs::Permissions::from_mode(0o000))
+            .expect("chmod primary");
+        std::fs::set_permissions(&tmpdir, std::fs::Permissions::from_mode(0o000))
+            .expect("chmod tmpdir");
+
+        // Override the tempdir lookup so `open_activity_log_with_fallback`
+        // hits our unwritable fake-tmp instead of the real system temp.
+        // Note: env var mutation is process-global; this test is the only
+        // accessor for `TMPDIR` in this test binary, and we restore the
+        // previous value before returning.
+        let prev_tmpdir = std::env::var_os("TMPDIR");
+        std::env::set_var("TMPDIR", &tmpdir);
+
+        let log = open_activity_log_with_fallback(&primary);
+
+        // Restore TMPDIR ASAP so a panic later in the test doesn't leak it.
+        match prev_tmpdir {
+            Some(v) => std::env::set_var("TMPDIR", v),
+            None => std::env::remove_var("TMPDIR"),
+        }
+
+        // Restore permissions so the outer tempdir can clean up.
+        let _ = std::fs::set_permissions(&primary, std::fs::Permissions::from_mode(0o700));
+        let _ = std::fs::set_permissions(&tmpdir, std::fs::Permissions::from_mode(0o700));
+
+        assert!(
+            log.is_discard(),
+            "expected ActivityLog::Discard when both data root and tempdir are unwritable"
+        );
+
+        // The Discard variant must still satisfy the public contract: no
+        // panic on append/count/list.
+        let id = log
+            .append(
+                ActivitySource::Http,
+                None,
+                "drawer_added",
+                json!({"smoke": true}),
+            )
+            .expect("discard append must succeed");
+        assert_eq!(id, 0);
+        assert_eq!(log.count().expect("discard count"), 0);
+        assert!(log
+            .list(&ActivityFilter::default(), 10, 0)
+            .expect("discard list")
+            .is_empty());
     }
 
     /// Why: Issue #26 — when `serve --palace <name>` is set, the MCP server

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -21,6 +21,7 @@ use anyhow::Result;
 use serde_json::{json, Value};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::{broadcast, OnceCell, RwLock};
 use tracing::info;
@@ -560,6 +561,25 @@ pub struct AppState {
     /// map never needs to be held across an `.await`.
     /// Test: `tools::tests::dedup_gate_blocks_concurrent_duplicate_writes`.
     pub palace_write_locks: Arc<dashmap::DashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Counter of in-flight activity-log writes spawned by `emit`
+    /// (issue #232).
+    ///
+    /// Why: `emit` offloads the synchronous redb append to the tokio blocking
+    /// pool via `spawn_blocking` so the async runtime is never parked waiting
+    /// on fsync. The write is fire-and-forget — `emit` returns immediately
+    /// after spawning. Tests that observe the activity log right after a
+    /// burst of `emit` calls need a deterministic synchronization point;
+    /// holding an in-flight counter lets `flush_activity_writes` poll until
+    /// every spawned append has settled, which keeps the assertions
+    /// race-free without forcing every caller to `.await`.
+    /// What: an `Arc<AtomicUsize>` incremented before each `spawn_blocking`
+    /// and decremented inside the closure (after the append completes, even
+    /// if it errored). The counter is cheap (one atomic add per emit) and
+    /// stays at zero in steady-state production traffic.
+    /// Test: `web::tests::activity_endpoint_lists_recent_emits` and
+    /// `tests::emit_persists_mutations_but_skips_status_changed` call
+    /// `flush_activity_writes` to drain the counter before reading the log.
+    pub pending_activity_writes: Arc<AtomicUsize>,
 }
 
 impl AppState {
@@ -605,6 +625,7 @@ impl AppState {
             bm25_client: None,
             bm25_supervisor: None,
             palace_write_locks: Arc::new(dashmap::DashMap::new()),
+            pending_activity_writes: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -771,24 +792,69 @@ impl AppState {
     /// HTTP / Hook origins are visible to the operator. Persistence is
     /// also best-effort — a write failure is logged but never blocks the
     /// SSE broadcast.
+    ///
+    /// Issue #232: the activity-log append is a synchronous redb write +
+    /// fsync. Calling it directly on the async caller's task parked a tokio
+    /// worker thread on disk I/O for every SSE event. We now offload the
+    /// append to the blocking thread pool via `spawn_blocking` and return
+    /// immediately — `emit` stays synchronous so every existing caller
+    /// (including the sync `dispatch_hook_fired` JSON-RPC handler) keeps
+    /// compiling unchanged. The fire-and-forget pattern matches the
+    /// pre-fix semantics (best-effort, never blocks the SSE broadcast)
+    /// while freeing the async runtime to do real work during the write.
     /// What: serialises the event for the log (skipping `StatusChanged`
-    /// which is a recomputed aggregate, not a mutation), then sends it
-    /// over the broadcast channel.
+    /// which is a recomputed aggregate, not a mutation), spawns the redb
+    /// append on `tokio::task::spawn_blocking` keyed by a clone of the
+    /// `Arc<ActivityLog>` and the cloned event, then sends the event over
+    /// the broadcast channel. A `pending_activity_writes` counter is bumped
+    /// before the spawn and decremented inside the closure so
+    /// [`Self::flush_activity_writes`] can drain in tests.
     /// Test: `web::tests::sse_stream_receives_palace_created` confirms a
     /// subscriber observes the emitted event;
-    /// `activity_endpoint_lists_recent_emits` confirms persistence.
+    /// `activity_endpoint_lists_recent_emits` confirms persistence via
+    /// `flush_activity_writes`.
     pub fn emit(&self, event: DaemonEvent) {
         if let Some(source) = event.source() {
             let event_type = event.type_str();
             let palace_id = event.palace_id().map(|s| s.to_string());
-            if let Err(e) = self
-                .activity_log
-                .append(source, palace_id, event_type, &event)
-            {
-                tracing::warn!("activity_log.append failed for {event_type}: {e:#}");
-            }
+            let log = Arc::clone(&self.activity_log);
+            let event_for_log = event.clone();
+            let pending = Arc::clone(&self.pending_activity_writes);
+            pending.fetch_add(1, Ordering::SeqCst);
+            // Why: the synchronous redb append + fsync must not park an
+            // async worker thread (issue #232). Spawn the write on the
+            // blocking pool; the JoinHandle is intentionally dropped —
+            // the write is best-effort and any failure is logged below.
+            tokio::task::spawn_blocking(move || {
+                let result = log.append(source, palace_id, event_type, &event_for_log);
+                if let Err(e) = result {
+                    tracing::warn!("activity_log.append failed for {event_type}: {e:#}");
+                }
+                pending.fetch_sub(1, Ordering::SeqCst);
+            });
         }
         let _ = self.events.send(event);
+    }
+
+    /// Block (asynchronously) until every in-flight activity-log write
+    /// spawned by [`Self::emit`] has settled.
+    ///
+    /// Why: `emit` offloads its redb append to `tokio::task::spawn_blocking`
+    /// and returns immediately (issue #232). Tests that observe the
+    /// activity log right after a burst of emits would otherwise race the
+    /// blocking-pool worker; this helper gives them a deterministic
+    /// synchronization point. Production code never needs to call this —
+    /// the dashboard reads through `GET /api/v1/activity`, which already
+    /// tolerates writes settling asynchronously.
+    /// What: spins on `pending_activity_writes` with a 1 ms yield until the
+    /// counter is zero. Cheap: tests typically emit a handful of events
+    /// and the loop exits within a single scheduler tick.
+    /// Test: covered indirectly by `emit_persists_mutations_but_skips_status_changed`
+    /// and `web::tests::activity_endpoint_lists_recent_emits`.
+    pub async fn flush_activity_writes(&self) {
+        while self.pending_activity_writes.load(Ordering::SeqCst) > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
     }
 
     /// Open (or return cached) the chat-session store for a palace.
@@ -2096,6 +2162,10 @@ mod tests {
             content_preview: "x".into(),
             source: ActivitySource::Mcp,
         });
+        // Issue #232: `emit` now offloads the redb write to `spawn_blocking`,
+        // so the test must wait for the background pool to drain before
+        // asserting on the persisted count.
+        state.flush_activity_writes().await;
         let count = state.activity_log.count().unwrap();
         assert_eq!(count, 2, "only PalaceCreated + DrawerAdded must persist");
     }

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -21,8 +21,8 @@ use anyhow::Result;
 use serde_json::{json, Value};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock, RwLock};
-use tokio::sync::{broadcast, OnceCell};
+use std::sync::{Arc, OnceLock};
+use tokio::sync::{broadcast, OnceCell, RwLock};
 use tracing::info;
 use trusty_common::bm25_client::Bm25Client;
 use trusty_common::mcp::initialize_response;
@@ -488,10 +488,12 @@ pub struct AppState {
     /// the KG. The cache is rebuilt by
     /// `prompt_facts::rebuild_prompt_cache` after any write that touches a
     /// hot predicate (`kg_assert`, `add_alias`, `remove_prompt_fact`).
-    /// What: An `Arc<RwLock<PromptFactsCache>>` so the hot read path takes
-    /// a brief read lock and clones the cache; rebuilds take a write lock
-    /// for the assignment only. An empty `triples` vec ↔ "no context
-    /// stored yet" (the tool handler renders a hint).
+    /// What: An `Arc<tokio::sync::RwLock<PromptFactsCache>>` so the hot
+    /// read path takes a brief read lock and clones the cache; rebuilds
+    /// take a write lock for the assignment only. The async-aware lock
+    /// (issue #229) yields to the tokio runtime instead of blocking a
+    /// runtime thread for the rebuild duration. An empty `triples` vec ↔
+    /// "no context stored yet" (the tool handler renders a hint).
     /// Test: `get_prompt_context_returns_cached_or_hint`,
     /// `get_prompt_context_filters_by_query`.
     pub prompt_context_cache: Arc<RwLock<prompt_facts::PromptFactsCache>>,

--- a/crates/trusty-memory/src/prompt_facts.rs
+++ b/crates/trusty-memory/src/prompt_facts.rs
@@ -205,21 +205,19 @@ pub async fn gather_hot_triples(state: &AppState) -> Result<Vec<(String, String,
 /// `remove_prompt_fact`) must update the cache so the next
 /// `get_prompt_context` tool call returns the fresh content. Centralising
 /// the refresh here means the dispatch sites only have to call one function.
+/// The lock is `tokio::sync::RwLock` (issue #229) so the rebuild yields to
+/// the runtime instead of blocking a worker thread for the full KG walk.
 /// What: Calls `gather_hot_triples`, formats via `build_prompt_context`,
-/// then takes the cache's write lock and replaces both the raw triples and
-/// the pre-formatted string in a single assignment. The write is
-/// non-blocking from the caller's perspective: the lock is held only for
-/// the assignment, not the gather/format work.
+/// then takes the cache's async write lock and replaces both the raw
+/// triples and the pre-formatted string in a single assignment. The write
+/// is non-blocking from the caller's perspective: the lock is held only
+/// for the assignment, not the gather/format work.
 /// Test: `rebuild_prompt_cache_reflects_writes` (in `tools::tests`).
 pub async fn rebuild_prompt_cache(state: &AppState) -> Result<()> {
     let triples = gather_hot_triples(state).await?;
     let formatted = build_prompt_context(&triples);
     let cache = state.prompt_context_cache.clone();
-    let mut guard = cache.write().map_err(|e| {
-        // RwLock poisoning is recoverable here — the worst case is a stale
-        // cache, which is strictly better than panicking the MCP loop.
-        anyhow::anyhow!("prompt cache lock poisoned: {e}")
-    })?;
+    let mut guard = cache.write().await;
     *guard = PromptFactsCache { triples, formatted };
     Ok(())
 }

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -1487,10 +1487,7 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
                 .filter(|s| !s.is_empty());
 
             let cache_snapshot = {
-                let guard = state
-                    .prompt_context_cache
-                    .read()
-                    .map_err(|e| anyhow!("prompt cache lock poisoned: {e}"))?;
+                let guard = state.prompt_context_cache.read().await;
                 guard.clone()
             };
 
@@ -2254,7 +2251,7 @@ mod tests {
 
         // (c) prompt cache has been refreshed with the formatted block.
         {
-            let guard = state.prompt_context_cache.read().expect("read lock");
+            let guard = state.prompt_context_cache.read().await;
             assert!(
                 guard.formatted.contains("tga → trusty-git-analytics"),
                 "prompt cache should contain alias; got: {}",
@@ -2271,7 +2268,7 @@ mod tests {
         .await
         .expect("add_alias with extra");
         {
-            let guard = state.prompt_context_cache.read().expect("read lock");
+            let guard = state.prompt_context_cache.read().await;
             assert!(
                 guard
                     .formatted
@@ -2291,7 +2288,7 @@ mod tests {
         .expect("remove_prompt_fact");
         assert_eq!(removed["removed"], true);
         {
-            let guard = state.prompt_context_cache.read().expect("read lock");
+            let guard = state.prompt_context_cache.read().await;
             assert!(
                 !guard.formatted.contains("tga → trusty-git-analytics"),
                 "retracted alias still in cache: {}",
@@ -2331,7 +2328,7 @@ mod tests {
 
         // Populate the cache by hand with a known triple set.
         {
-            let mut guard = state.prompt_context_cache.write().expect("write lock");
+            let mut guard = state.prompt_context_cache.write().await;
             let triples = vec![
                 (
                     "tga".to_string(),
@@ -2446,7 +2443,7 @@ mod tests {
 
         // The prompt cache must contain the new alias after discovery.
         {
-            let guard = state.prompt_context_cache.read().expect("read lock");
+            let guard = state.prompt_context_cache.read().await;
             assert!(
                 guard.formatted.contains("tga → trusty-git-analytics"),
                 "prompt cache missing tga alias after discover_aliases; got: {}",

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -780,6 +780,17 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
             let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
 
             let handle = open_palace_handle(state, palace)?;
+            // Issue #230: serialise the dedup-check + write sequence
+            // per-palace so two concurrent identical writes can't both
+            // pass the gate. The lock is scoped to the palace id — writes
+            // to different palaces still run in parallel. The guard is
+            // held until the end of this match arm so the post-write
+            // emits / KG extraction also see a consistent view; the redb
+            // write inside `remember_with_options` is the only operation
+            // that strictly needs the lock, but holding it longer is
+            // cheap and keeps the activity-log ordering coherent.
+            let write_lock = state.palace_write_lock(palace);
+            let _write_guard = write_lock.lock().await;
             // Issue #220: rolling dedup window — skip when a near-duplicate
             // landed in the same palace within the last 5 minutes. The
             // `force=true` operator override bypasses the gate so
@@ -903,6 +914,12 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
             }
             CreatorInfo::new_self(MCP_CLIENT_NAME, CreatorSource::Mcp).merge_into(&mut tags);
             let handle = open_palace_handle(state, palace)?;
+            // Issue #230: per-palace write lock — same rationale as
+            // `memory_remember`. Held across the dedup gate and the
+            // `remember_with_options` write so two concurrent identical
+            // notes can't both pass the gate.
+            let write_lock = state.palace_write_lock(palace);
+            let _write_guard = write_lock.lock().await;
             // Issue #220: rolling dedup window — same gate as
             // `memory_remember`. `memory_note` has no `force` arg, so the
             // gate is unconditional: curated short-fact writes that happen
@@ -2934,6 +2951,96 @@ mod tests {
         // Empty/whitespace content is also a pass — the content gate
         // handles the empty case upstream.
         assert!(!dedup_gate(&handle, "   "));
+    }
+
+    /// Why (issue #230): the dedup gate previously had a TOCTOU race —
+    /// two concurrent `memory_remember` calls with identical content
+    /// both saw the empty pre-write snapshot, both passed the gate, and
+    /// both wrote duplicate drawers. The per-palace write mutex on
+    /// `AppState` now serialises the gate-then-write sequence so the
+    /// second writer observes the first writer's drawer in
+    /// `list_drawers` and bails. This test would have failed before the
+    /// fix and passes after.
+    /// What: spawns two `tokio` tasks that race to write the same long
+    /// content into a fresh palace, joins both, then asserts that
+    /// `memory_list` returns exactly one drawer (the loser's envelope
+    /// carries `status = "skipped"` with a `duplicate within window`
+    /// reason).
+    /// Test: itself — fail-then-pass on this commit.
+    #[tokio::test]
+    async fn dedup_gate_blocks_concurrent_duplicate_writes() {
+        let state = std::sync::Arc::new(test_state());
+        let _ = dispatch_tool(&state, "palace_create", json!({"name": "dedup_race"}))
+            .await
+            .expect("palace_create");
+
+        // Long enough to clear the 8-token MCP filter; identical content
+        // in both racers so the dedup gate is the only thing keeping
+        // them from both landing.
+        let text =
+            "Concurrent identical writes must collapse to a single drawer under the dedup gate";
+
+        let s1 = state.clone();
+        let t1 = tokio::spawn(async move {
+            dispatch_tool(
+                &s1,
+                "memory_remember",
+                json!({"palace": "dedup_race", "text": text}),
+            )
+            .await
+        });
+        let s2 = state.clone();
+        let t2 = tokio::spawn(async move {
+            dispatch_tool(
+                &s2,
+                "memory_remember",
+                json!({"palace": "dedup_race", "text": text}),
+            )
+            .await
+        });
+        let r1 = t1.await.expect("join t1").expect("dispatch t1");
+        let r2 = t2.await.expect("join t2").expect("dispatch t2");
+
+        // Exactly one of the two should be `stored`; the other should be
+        // `skipped` with the documented duplicate-window reason.
+        let statuses = [
+            r1["status"].as_str().unwrap_or(""),
+            r2["status"].as_str().unwrap_or(""),
+        ];
+        let stored = statuses.iter().filter(|s| **s == "stored").count();
+        let skipped = statuses.iter().filter(|s| **s == "skipped").count();
+        assert_eq!(
+            stored, 1,
+            "exactly one concurrent write should be stored; got responses {r1:?} {r2:?}"
+        );
+        assert_eq!(
+            skipped, 1,
+            "exactly one concurrent write should be skipped; got responses {r1:?} {r2:?}"
+        );
+        let skipped_reason = if r1["status"] == "skipped" {
+            r1["reason"].as_str().unwrap_or("")
+        } else {
+            r2["reason"].as_str().unwrap_or("")
+        };
+        assert!(
+            skipped_reason.contains("duplicate within window"),
+            "skipped envelope should cite dedup reason; got {skipped_reason:?}"
+        );
+
+        // Belt-and-braces: confirm the palace contains exactly one drawer.
+        let listed = dispatch_tool(
+            &state,
+            "memory_list",
+            json!({"palace": "dedup_race", "limit": 10}),
+        )
+        .await
+        .expect("memory_list");
+        let drawers = listed["drawers"].as_array().expect("drawers array");
+        assert_eq!(
+            drawers.len(),
+            1,
+            "only one drawer should be persisted after concurrent identical writes; got {drawers:?}"
+        );
     }
 
     /// Why: end-to-end confirmation that the blocklist short-circuits the

--- a/crates/trusty-memory/src/transport/rpc.rs
+++ b/crates/trusty-memory/src/transport/rpc.rs
@@ -546,6 +546,9 @@ mod tests {
         };
         let resp = dispatch(&state, req).await;
         assert!(resp.error.is_none(), "expected ok, got {:?}", resp.error);
+        // Issue #232: `emit` now fire-and-forgets the redb append on the
+        // blocking pool; flush before observing the persisted count.
+        state.flush_activity_writes().await;
         let count = state.activity_log.count().unwrap();
         assert_eq!(count, 1, "hook_fired must persist one activity row");
     }

--- a/crates/trusty-memory/src/web.rs
+++ b/crates/trusty-memory/src/web.rs
@@ -4114,6 +4114,10 @@ mod tests {
             drawer_count: 0,
             source: ActivitySource::Http,
         });
+        // Issue #232: emits now fire-and-forget the redb write on the
+        // blocking pool; wait for the writes to settle before querying the
+        // activity endpoint.
+        state.flush_activity_writes().await;
 
         let app = router().with_state(state);
         let resp = app
@@ -4204,6 +4208,8 @@ mod tests {
             content_preview: "".into(),
             source: ActivitySource::Mcp,
         });
+        // Issue #232: drain the spawn_blocking writes before querying.
+        state.flush_activity_writes().await;
 
         let app = router().with_state(state);
         let resp = app
@@ -4297,6 +4303,8 @@ mod tests {
         // The activity log should now hold ≥ 2 entries (palace_created +
         // drawer_added). Also confirm the HTTP endpoint surfaces them with
         // `mcp` sources.
+        // Issue #232: drain fire-and-forget activity-log writes first.
+        state.flush_activity_writes().await;
         let app = router().with_state(state);
         let resp = app
             .oneshot(
@@ -4359,6 +4367,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        // Issue #232: the hook handler emits via the fire-and-forget
+        // `spawn_blocking` path; wait for the write to settle before
+        // reading the activity history endpoint.
+        state.flush_activity_writes().await;
 
         // Read it back through the activity history endpoint.
         let app = router().with_state(state);

--- a/crates/trusty-memory/src/web.rs
+++ b/crates/trusty-memory/src/web.rs
@@ -1437,10 +1437,7 @@ async fn prompt_context_handler(
     Query(_q): Query<PromptFactsQuery>,
 ) -> Result<Response, ApiError> {
     let cache_snapshot = {
-        let guard = state
-            .prompt_context_cache
-            .read()
-            .map_err(|e| ApiError::internal(format!("prompt cache lock poisoned: {e}")))?;
+        let guard = state.prompt_context_cache.read().await;
         guard.clone()
     };
     let body = if cache_snapshot.formatted.is_empty() {
@@ -3827,7 +3824,7 @@ mod tests {
 
         // Populate the cache and re-fetch.
         {
-            let mut guard = state.prompt_context_cache.write().expect("write lock");
+            let mut guard = state.prompt_context_cache.write().await;
             let triples = vec![(
                 "tga".to_string(),
                 "is_alias_for".to_string(),
@@ -3893,7 +3890,7 @@ mod tests {
         assert_eq!(v["object"], "trusty-memory");
 
         // The prompt cache must reflect the new alias.
-        let guard = state.prompt_context_cache.read().expect("read lock");
+        let guard = state.prompt_context_cache.read().await;
         assert!(
             guard.formatted.contains("tm → trusty-memory"),
             "cache missing alias; got: {}",
@@ -4035,7 +4032,7 @@ mod tests {
 
         // Cache must no longer contain the alias.
         {
-            let guard = state.prompt_context_cache.read().expect("read lock");
+            let guard = state.prompt_context_cache.read().await;
             assert!(
                 !guard.formatted.contains("ta → trusty-analyze"),
                 "alias still in cache after delete: {}",


### PR DESCRIPTION
## Summary
- **#225** `open_activity_log_with_fallback`: replace `expect()` panic with a graceful `Discard` no-op variant when both primary and tmpdir fallback paths are unwritable
- **#229** `prompt_context_cache`: replace `std::sync::RwLock` with `tokio::sync::RwLock` — holding a blocking write lock during KG cache rebuilds stalled the tokio runtime thread
- **#230** `dedup_gate`: add per-palace write mutex to eliminate TOCTOU race — concurrent identical writes could both pass the dedup check before either was committed
- **#232** `AppState::emit`: wrap `activity_log.append` in `spawn_blocking` — synchronous redb write was blocking async handler threads on every event emission

## Test plan
- [ ] `cargo test -p trusty-memory` passes (257 unit + 23 integration)
- [ ] New test for #225: `open_activity_log_with_fallback_returns_discard_when_unwritable`
- [ ] New test for #230: `dedup_gate_blocks_concurrent_duplicate_writes` — verify bug is present without the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)