### PR TITLE
docs: session notes, changelog, README feature flags for trusty-memory analysis pass + TUI color fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to trusty-tools are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Crate versions are tagged independently (`<crate-name>-v<version>`); this file
+records changes in chronological order grouped by release date.
+
+## [Unreleased] — 2026-05-26
+
+### Fixed
+- **trusty-memory**: `open_activity_log_with_fallback` no longer panics on restricted filesystems — returns a `Discard` no-op log variant (#225)
+- **trusty-memory**: `AppState::emit` no longer blocks the tokio runtime — activity log writes offloaded to `spawn_blocking` (#232)
+- **trusty-memory**: `prompt_context_cache` uses `tokio::sync::RwLock` — KG cache rebuilds no longer stall async worker threads (#229)
+- **trusty-memory**: Per-palace write mutex eliminates TOCTOU race in `dedup_gate` — concurrent identical writes now correctly deduplicate (#230)
+- **trusty-mpm-tui**: Drawer detail pane and help overlay text now visible on light terminal themes — replaced `Color::White` with `Color::Reset` (#244)
+
+### Changed
+- **trusty-memory**: `axum` and `tower-http` gated behind `axum-server` feature flag — consumers can link the rlib without the HTTP stack (`default-features = false`) (#226)
+- **trusty-memory**: `dispatch_tool` refactored from 957-line monolith to 28-line router + 23 per-tool handler functions (#227)
+- **trusty-memory**: Write hot path no longer triggers O(N) palace disk walks — palace name lookup uses in-memory cache; status aggregation moved to 30s background ticker (#228)
+- **trusty-memory**: BM25 indexing uses bounded `mpsc::channel(256)` — burst writes no longer accumulate unbounded background tasks; queue-full events are logged and skipped (#231)
+
+### Internal
+- **trusty-memory**: `run_serve` startup hydration deduplicated into `spawn_startup_tasks` helper (#233)
+- **trusty-memory**: Test helper `test_state()` returns `(AppState, TempDir)` — eliminates `mem::forget` temp directory leaks across 262 tests (#234)

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -285,6 +285,20 @@ thin protocol layer on top.
 The embedded Svelte UI is compiled at build time and served via `rust-embed` —
 no separate web server or Node.js installation is needed at runtime.
 
+## Feature Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `axum-server` | **enabled** | Compiles the HTTP server, SSE endpoint, and axum-based REST API. Disable with `default-features = false` when embedding only the in-process MCP tools (e.g. from `open-mpm`). |
+
+```toml
+# Full daemon build — no change needed (axum-server is on by default)
+trusty-memory = { workspace = true }
+
+# rlib consumer — omit the HTTP stack
+trusty-memory = { workspace = true, default-features = false }
+```
+
 ## Development
 
 ```bash

--- a/docs/trusty-memory/research/axum-feature-flag-decision-2026-05-26.md
+++ b/docs/trusty-memory/research/axum-feature-flag-decision-2026-05-26.md
@@ -1,0 +1,67 @@
+# Decision: axum-server Feature Flag for trusty-memory
+
+**Date**: 2026-05-26
+**PR**: #240 (`ab8ebbc`)
+**Issue**: #226
+
+## Why
+
+The trusty-tools workspace rule (CLAUDE.md, "Feature flags" convention) requires
+that `axum` and `tower-http` be gated behind an `axum-server` feature in any
+crate that is also consumed as an rlib. The motivation: pulling in axum
+unconditionally forces every downstream consumer to compile the full axum +
+tower + hyper stack even when that consumer only needs the in-process logic.
+
+The immediate trigger was `open-mpm`, which links `trusty-memory` as an rlib
+to access the in-process MCP tool dispatch layer. Before this change, `open-mpm`
+had to carry axum and tower-http in its dependency tree despite never binding
+an HTTP socket — increasing compile times and binary size for no benefit.
+
+The workspace already established this pattern in `trusty-common`, which has
+gated its own axum helpers behind `axum-server` since the initial workspace
+consolidation.
+
+## What Was Changed
+
+`axum`, `tower-http`, and the SSE/REST handler modules in `trusty-memory` are
+now compiled only when the `axum-server` feature is enabled. The feature is
+**default-enabled**, so existing binary builds (`cargo build -p trusty-memory`,
+`cargo install trusty-memory`) require no changes.
+
+The `[features]` table in `crates/trusty-memory/Cargo.toml` now reads:
+
+```toml
+[features]
+default = ["axum-server"]
+axum-server = ["dep:axum", "dep:tower-http"]
+```
+
+## How to Use
+
+**Binary / full daemon** (default — no change needed):
+```toml
+trusty-memory = { workspace = true }
+```
+
+**rlib consumer — no HTTP stack** (e.g. `open-mpm`, test harnesses):
+```toml
+trusty-memory = { workspace = true, default-features = false }
+```
+
+With `default-features = false`, the crate compiles the storage engine, MCP
+tool dispatch, and knowledge-graph layer but omits the axum router, SSE
+endpoint, and REST API handlers.
+
+## Trade-offs
+
+The default-enabled arrangement means the common case (building or installing
+the daemon binary) works without any `Cargo.toml` changes. The trade-off is
+that a developer who forgets `default-features = false` when writing a
+lightweight consumer will silently pull in axum — but this is the same
+behaviour as before the change, so it is not a regression. The feature flag
+makes the opt-out explicit and documented rather than impossible.
+
+Any code gated on `#[cfg(feature = "axum-server")]` is not reachable from
+consumers that disable the feature; the compiler will reject attempts to call
+into axum-gated functions from `default-features = false` dependents, providing
+a clear build-time error rather than a silent footgun.

--- a/docs/trusty-memory/sessions/SESSION-2026-05-26-code-analysis-and-fixes.md
+++ b/docs/trusty-memory/sessions/SESSION-2026-05-26-code-analysis-and-fixes.md
@@ -1,0 +1,105 @@
+# SESSION-2026-05-26 — trusty-memory Code Analysis and Fixes
+
+## Overview
+
+A systematic code analysis pass over `crates/trusty-memory/` identified 10
+correctness, safety, and performance issues. Each was filed as a GitHub issue
+(#225–#234), implemented in five focused PRs (#239–#243), and merged to main
+on 2026-05-26.
+
+The pass covered async correctness (blocking calls on the tokio runtime), race
+conditions in the write deduplication gate, O(N) disk walks in the write hot
+path, unbounded background task accumulation, and test infrastructure leaks.
+
+---
+
+## Issues Found and Resolved
+
+| # | Title | Severity | Fix Summary |
+|---|---|---|---|
+| #225 | `ActivityLog` panics on restricted filesystems | High | Converted `ActivityLog` to an enum with `Redb` and `Discard` variants; `open_activity_log_with_fallback` returns `Discard` when the storage path is unwritable |
+| #226 | `axum` unconditional dep breaks rlib consumers | Medium | Gated `axum` and `tower-http` behind `axum-server` feature flag (default enabled); `open-mpm` now links without the HTTP stack |
+| #227 | `dispatch_tool` is a 957-line monolith | Medium | Decomposed into 28-line router + 23 per-tool `handle_*` functions; shared write pipeline unified in `write_drawer(state, WriteDrawerParams)` |
+| #228 | Palace name lookup does an O(N) disk walk per write | High | Replaced filesystem walk with an in-memory `DashMap` cache populated at startup; `aggregate_status_event` removed from the write path, replaced by 30-second background ticker |
+| #229 | `prompt_context_cache` uses `std::sync::RwLock` | Medium | Replaced with `tokio::sync::RwLock` — KG cache rebuilds no longer stall async worker threads |
+| #230 | TOCTOU race in `dedup_gate` under concurrent writes | High | Added per-palace write mutex; concurrent identical writes now correctly deduplicate instead of both passing the gate |
+| #231 | BM25 indexing spawns unbounded background tasks | Medium | Replaced unbounded per-write spawns with bounded `mpsc::channel(256)` + single background worker; queue-full events log a warning and skip (best-effort) |
+| #232 | `AppState::emit` blocks the tokio runtime | High | Offloaded redb activity log write to `spawn_blocking` |
+| #233 | Duplicated startup hydration in `run_serve` | Low | Extracted into `spawn_startup_tasks` helper |
+| #234 | `test_state()` leaks TempDir via `mem::forget` | Low | `test_state()` now returns `(AppState, TempDir)` — caller holds the guard, which drops correctly at end of test scope |
+
+---
+
+## Architecture Changes
+
+### axum Feature Flag (#226)
+
+`axum` and `tower-http` are now optional, gated behind the `axum-server`
+feature (default enabled). This aligns `trusty-memory` with the workspace
+rule requiring HTTP stacks to be feature-flagged in rlib crates. `open-mpm`
+can now link `trusty-memory` without pulling in axum.
+
+See `docs/trusty-memory/research/axum-feature-flag-decision-2026-05-26.md`
+for the full decision record.
+
+### dispatch_tool Decomposition (#227)
+
+The original `dispatch_tool` function had grown to 957 lines through
+incremental feature additions, making it difficult to test individual tool
+handlers in isolation. The refactor introduces a 28-line routing match
+statement that delegates to 23 per-tool `handle_*` functions. The shared
+write pipeline (`memory_remember` + `memory_note`) is unified in a single
+`write_drawer(state, WriteDrawerParams)` call, eliminating the duplicated
+validation and deduplication logic that existed in each branch.
+
+### Write Hot-Path Performance (#228, #231)
+
+Two independent optimisations targeted the write path:
+
+1. **Palace name resolution**: The previous implementation walked the
+   filesystem on every write to map a palace ID to its display name. This
+   has been replaced by a `DashMap` populated during daemon startup.
+   `aggregate_status_event` was also removed from the synchronous write
+   path and replaced by a 30-second background ticker.
+
+2. **BM25 indexing backpressure**: Each write previously spawned an
+   independent tokio task to update the BM25 index, which meant burst
+   writes could accumulate an unbounded queue of background work. A bounded
+   `mpsc::channel(256)` now feeds a single background worker. When the
+   channel is full, the write completes but the BM25 update is skipped with
+   a `WARN`-level log entry (best-effort semantics; vector recall is
+   unaffected).
+
+---
+
+## Test Coverage
+
+New tests added as part of this pass:
+
+- **Discard fallback** (#225): test that `open_activity_log_with_fallback`
+  returns `Discard` when given an unwritable path, and that `Discard` writes
+  silently succeed without panicking
+- **TOCTOU race regression** (#230): concurrent-write test that submits 50
+  identical texts from 50 parallel tasks and asserts exactly one drawer is
+  created (verifies per-palace mutex holds)
+- **BM25 queue-drop under load** (#231): flood test that sends 512 writes
+  over a `channel(256)` and asserts the process does not panic and the
+  warning counter increments
+- **Palace name cache** (#228): test that `lookup_palace_name` returns
+  correct results after cache population and that a cache miss falls back
+  correctly
+
+The `test_state()` change (#234) fixed latent TempDir leaks across the
+existing 262-test suite; no tests were deleted.
+
+---
+
+## Commits
+
+| PR | Commit | Description |
+|---|---|---|
+| #239 | `c0dfc9d` | safety + async correctness: ActivityLog enum, spawn_blocking, tokio RwLock, per-palace mutex |
+| #240 | `ab8ebbc` | axum feature flag: gate axum/tower-http behind axum-server feature |
+| #241 | `ce11eaa` | dispatch_tool refactor: 957-line monolith → 28-line router + 23 handlers |
+| #242 | `41411a1` | write hot-path perf: DashMap palace cache, background ticker, bounded BM25 channel |
+| #243 | `feb5a79` | cleanup: spawn_startup_tasks helper, test_state returns TempDir |

--- a/docs/trusty-mpm/sessions/SESSION-2026-05-26-tui-color-fix.md
+++ b/docs/trusty-mpm/sessions/SESSION-2026-05-26-tui-color-fix.md
@@ -1,0 +1,38 @@
+# SESSION-2026-05-26 — trusty-mpm-tui: Drawer Detail Pane Color Fix
+
+## Summary
+
+Fixed invisible text in the drawer detail pane and help overlay on light
+terminal themes. Merged as PR #245 (closes issue #244).
+
+## Bug
+
+The drawer detail pane and help overlay in the MPM TUI rendered invisible
+text on terminals configured with a light background (e.g. the macOS default
+Terminal profile, iTerm2 Solarized Light, VS Code integrated terminal in
+light mode).
+
+Root cause: the rendering code set `fg(Color::White)` without a contrasting
+background. On dark themes this renders as white text on a dark background
+(readable). On light themes — where the terminal's default background is
+white or near-white — it renders as white text on a white background,
+producing no visible output at all.
+
+## Fix
+
+Replaced `Color::White` with `Color::Reset` in the affected render paths.
+`Color::Reset` instructs the terminal emulator to revert to its native
+foreground colour, which is chosen by the user's theme to contrast against
+the terminal's background. This produces readable text on both dark and light
+themes without hard-coding any colour value.
+
+## Files Changed
+
+- `crates/trusty-mpm-tui/src/tui/dashboard.rs` — drawer detail pane and help
+  overlay render functions: `fg(Color::White)` replaced with `fg(Color::Reset)`
+
+## References
+
+- Issue: #244
+- PR: #245
+- Commit: `b32cc16` (HEAD of main at time of merge)


### PR DESCRIPTION
## Summary
- `CHANGELOG.md` created (Keep-a-Changelog format) with entries for all 10 trusty-memory fixes (#225–#234) and TUI color fix (#244)
- `docs/trusty-memory/sessions/SESSION-2026-05-26-code-analysis-and-fixes.md` — full session narrative
- `docs/trusty-memory/research/axum-feature-flag-decision-2026-05-26.md` — decision doc for the axum feature flag
- `docs/trusty-mpm/sessions/SESSION-2026-05-26-tui-color-fix.md` — TUI bug session note
- `crates/trusty-memory/README.md` — Feature Flags section added documenting `axum-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)