### PR TITLE
chore: stale version pins, granola expect, tga MSRV 1.88, gworkspace edition (closes #251 #253 #254 #258)

### DIFF
--- a/crates/open-mpm/Cargo.toml
+++ b/crates/open-mpm/Cargo.toml
@@ -44,7 +44,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.5.1", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.12.0" }
+trusty-search = { path = "../trusty-search", version = "0.12.3" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/tc-services/src/granola.rs
+++ b/crates/tc-services/src/granola.rs
@@ -141,13 +141,22 @@ fn build_request(name: &str, args: &Value) -> anyhow::Result<(reqwest::Method, S
     let url = match name {
         "granola_list" => format!("{GRANOLA_API_BASE}/documents"),
         "granola_get" => {
-            format!("{GRANOLA_API_BASE}/documents/{}", id.unwrap())
+            format!(
+                "{GRANOLA_API_BASE}/documents/{}",
+                id.expect("guaranteed by ep.needs_id == true")
+            )
         }
         "granola_get_transcript" => {
-            format!("{GRANOLA_API_BASE}/documents/{}/transcript", id.unwrap())
+            format!(
+                "{GRANOLA_API_BASE}/documents/{}/transcript",
+                id.expect("guaranteed by ep.needs_id == true")
+            )
         }
         "granola_get_shared_document" => {
-            format!("{GRANOLA_API_BASE}/documents/{}/shared", id.unwrap())
+            format!(
+                "{GRANOLA_API_BASE}/documents/{}/shared",
+                id.expect("guaranteed by ep.needs_id == true")
+            )
         }
         "granola_search" => {
             let query = args

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -3,11 +3,10 @@ name = "tga"
 version = "1.0.17"
 publish = true
 edition = "2021"
-# Required for `std::sync::LazyLock` used by the shared CLI help wiring
-# (issue #216). tga doesn't need let-chains, so the workspace MSRV (1.88)
-# is intentionally not adopted here — bumping further would expose newer
-# clippy lints unrelated to this change.
-rust-version = "1.80"
+# Aligned with the workspace MSRV (1.88) per #254. Required for
+# `std::sync::LazyLock` (CLI help wiring, issue #216). tga does not use
+# let-chains, but aligning with the workspace pin prevents MSRV drift.
+rust-version = "1.88"
 authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 license = "Elastic-2.0"
 repository = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trusty-gworkspace"
 version = "0.1.3"
 publish = false
-edition = "2024"
+edition = "2024" # edition 2024: uses let-chains
 description = "Google Workspace MCP server for the Trusty suite"
 license = "Elastic-2.0"
 
@@ -14,7 +14,7 @@ name = "gworkspace-mcp"
 path = "src/bin/gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.6.0", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.6.1", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/bin/bm25_daemon.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.6.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help"] }
+trusty-common = { path = "../trusty-common", version = "0.6.1", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help"] }
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
 #      trusty-memory — one install command, three binaries. The shim at

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -48,7 +48,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.6.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216)
+trusty-common = { version = "0.6.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216)
 
 # ── Bundled sidecar ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
## Summary
- **#251** Stale version pins updated: `trusty-common` 0.6.0→0.6.1 in trusty-search, trusty-gworkspace, trusty-memory; `trusty-search` 0.12.0→0.12.3 in open-mpm
- **#253** `id.unwrap()` in `tc-services/granola.rs:144,147,150` replaced with `id.expect("guaranteed by ep.needs_id == true")`
- **#254** `trusty-git-analytics` MSRV updated 1.80→1.88 to match workspace
- **#258** `trusty-gworkspace` edition 2024 audited — kept, added comment documenting let-chain usage in client.rs, docs/core.rs, gmail/messages.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)