### PR TITLE
fix(trusty-analyze,trusty-embedderd): gate axum behind http-server feature flag (closes #249 #250)

### DIFF
--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -15,6 +15,13 @@ build       = "build.rs"
 [[bin]]
 name = "trusty-analyze"
 path = "src/main.rs"
+# Why (issue #249): the `trusty-analyze` binary boots the axum HTTP daemon and
+# the axum-backed MCP HTTP/SSE transport, so it needs the `http-server` feature
+# compiled in. Listing it here keeps `--no-default-features` library builds
+# (e.g. consumers that only want the CLI types or the pure dispatcher) from
+# accidentally trying to build this binary without axum and failing to link
+# the `service` and `mcp::sse` modules.
+required-features = ["http-server"]
 
 [lib]
 name = "trusty_analyze"
@@ -22,8 +29,12 @@ path = "src/lib.rs"
 
 [dependencies]
 tokio              = { workspace = true }
-axum               = { workspace = true }
-tower-http         = { workspace = true }
+# Why (issue #249): axum + tower-http are HTTP-server only. Gating them behind
+#      the `http-server` feature mirrors the rule already enforced in
+#      `trusty-common` (`axum-server`) and `trusty-memory` so downstream library
+#      consumers can drop the HTTP stack entirely with `default-features = false`.
+axum               = { workspace = true, optional = true }
+tower-http         = { workspace = true, optional = true }
 reqwest            = { workspace = true, features = ["http2"] }
 futures-util       = { workspace = true }
 futures            = { workspace = true }
@@ -47,7 +58,7 @@ redb               = { workspace = true }
 dashmap            = { workspace = true }
 rust-embed         = { workspace = true }
 mime_guess         = { workspace = true }
-trusty-common      = { workspace = true, features = ["axum-server", "symgraph", "cli-help"] }
+trusty-common      = { workspace = true, features = ["symgraph", "cli-help"] }
 tree-sitter            = { workspace = true }
 tree-sitter-rust       = { workspace = true }
 tree-sitter-typescript = { workspace = true }
@@ -76,7 +87,17 @@ ort        = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
 
 [features]
-default = []
+# Why (issue #249): mirrors the `trusty-common` / `trusty-memory` rule that
+#      axum + tower-http are HTTP-server-only deps. Defaults to `http-server`
+#      so the `trusty-analyze` binary — and the standard `cargo install
+#      trusty-analyze` / `cargo test -p trusty-analyze` flows — keep building
+#      exactly as before. Library consumers that only want the dispatcher /
+#      CLI types override with `default-features = false`.
+default = ["http-server"]
+# Enables the axum HTTP daemon surface (the `service` module and the
+# `mcp::sse` HTTP/SSE transport). Pulls in `axum`, `tower-http`, and the
+# matching `trusty-common/axum-server` feature flag.
+http-server = ["dep:axum", "dep:tower-http", "trusty-common/axum-server"]
 ner     = ["dep:ort", "dep:tokenizers"]
 
 [dev-dependencies]

--- a/crates/trusty-analyze/src/lib.rs
+++ b/crates/trusty-analyze/src/lib.rs
@@ -9,5 +9,10 @@ pub mod core;
 pub mod embedder;
 pub mod lang;
 pub mod mcp;
+// Why (issue #249): the `service` module is the axum HTTP daemon surface and
+// only compiles when the `http-server` feature is enabled. Gating it keeps
+// library consumers that only need the analysis core / dispatcher free of the
+// axum + tower-http stack.
+#[cfg(feature = "http-server")]
 pub mod service;
 pub mod types;

--- a/crates/trusty-analyze/src/mcp/mod.rs
+++ b/crates/trusty-analyze/src/mcp/mod.rs
@@ -19,6 +19,11 @@
 //! | `ingest_scip`         | `POST /indexes/:id/scip`                     |
 //! | `analyzer_health`     | `GET /health`                                |
 
+// Why (issue #249): the `sse` submodule is the axum HTTP/SSE transport and
+// only compiles when the `http-server` feature is enabled. The `stdio`
+// transport stays unconditional — MCP clients (Claude Code) that spawn the
+// dispatcher as a subprocess only need stdio, never axum.
+#[cfg(feature = "http-server")]
 pub mod sse;
 pub mod stdio;
 

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -21,6 +21,14 @@ crate-type = ["rlib"]
 [[bin]]
 name = "trusty-embedderd"
 path = "src/main.rs"
+# Why (issue #250): the `trusty-embedderd` binary boots the axum HTTP daemon
+# (and the stdio / UDS transports that share its `AppState`), so it needs the
+# `http-server` feature compiled in. Listing it here keeps
+# `--no-default-features` library builds (e.g. consumers that only want the
+# `protocol` / `batch_queue` modules) from accidentally trying to build this
+# binary without axum and failing to link `run` / `run_with_args` /
+# `health_handler` / `embed_handler`.
+required-features = ["http-server"]
 
 [dependencies]
 # Shared client / wire types — now provided by trusty-common's `embedder-client` feature.
@@ -30,9 +38,13 @@ trusty-common = { workspace = true, features = ["embedder", "embedder-bundled-or
 # CLI argument parsing.
 clap = { workspace = true }
 
-# HTTP server.
-axum = { workspace = true }
-tower-http = { workspace = true }
+# Why (issue #250): axum + tower-http are HTTP-server only. Gating them behind
+# the `http-server` feature mirrors the rule already enforced in
+# `trusty-common` (`axum-server`) and `trusty-memory` so the daemon's logic
+# (BatchQueue, protocol, stdio/UDS transports) can be consumed by a library
+# user with `default-features = false` without dragging the HTTP stack in.
+axum = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true }
 
 # Async runtime.
 tokio = { workspace = true }
@@ -60,8 +72,19 @@ reqwest = { workspace = true }
 trusty-common = { workspace = true, features = ["embedder", "embedder-bundled-ort", "embedder-client", "embedder-test-support"] }
 
 [features]
+# Why (issue #250): mirrors the `trusty-common` / `trusty-memory` rule that
+#      axum + tower-http are HTTP-server-only deps. Defaults to `http-server`
+#      so the `trusty-embedderd` binary — and the `trusty-search`-bundled
+#      shim binary that calls `trusty_embedderd::run()` — keep building
+#      exactly as before. Library consumers that only need the wire
+#      protocol / batch queue override with `default-features = false`.
+default = ["http-server"]
+# Enables the axum HTTP daemon surface (`Args`, `AppState`, `run`,
+# `run_with_args`, `health_handler`, `embed_handler`). Pulls in `axum` and
+# `tower-http`. The stdio + UDS transports do not require this feature; they
+# are exposed via the always-on `stdio_server` and `uds_server` modules.
+http-server = ["dep:axum", "dep:tower-http"]
 # Forward ORT feature flags so the binary can be compiled with cuda/coreml.
-default = []
 bundled-ort = ["trusty-common/embedder-bundled-ort"]
 cuda = ["trusty-common/embedder-cuda"]
 load-dynamic = ["trusty-common/embedder-load-dynamic"]

--- a/crates/trusty-embedderd/src/lib.rs
+++ b/crates/trusty-embedderd/src/lib.rs
@@ -22,25 +22,44 @@ pub mod protocol;
 pub mod stdio_server;
 pub mod uds_server;
 
+// Why (issue #250): the daemon's HTTP startup sequence (`run`, `run_with_args`,
+// `AppState`, `health_handler`, `embed_handler`, and the `Args` clap struct
+// that drives them) only compiles under the `http-server` feature, mirroring
+// the `trusty-common` / `trusty-memory` rule that axum + tower-http are
+// HTTP-server-only deps. The `protocol`, `batch_queue`, `stdio_server`, and
+// `uds_server` modules stay unconditional — they have no axum surface.
+#[cfg(feature = "http-server")]
 use std::sync::Arc;
+#[cfg(feature = "http-server")]
 use std::time::Duration;
 
+#[cfg(feature = "http-server")]
 use anyhow::{bail, Context, Result};
+#[cfg(feature = "http-server")]
 use axum::{
     extract::State,
     http::StatusCode,
     routing::{get, post},
     Json, Router,
 };
+#[cfg(feature = "http-server")]
 use clap::Parser;
+#[cfg(feature = "http-server")]
 use serde_json::json;
+#[cfg(feature = "http-server")]
 use tokio::net::TcpListener;
+#[cfg(feature = "http-server")]
 use tokio::signal::unix::{signal, SignalKind};
+#[cfg(feature = "http-server")]
 use tower_http::trace::TraceLayer;
+#[cfg(feature = "http-server")]
 use tracing::info;
+#[cfg(feature = "http-server")]
 use trusty_common::embedder::{Embedder as _, FastEmbedder};
+#[cfg(feature = "http-server")]
 use trusty_common::embedder_client::{EmbedRequest, EmbedResponse};
 
+#[cfg(feature = "http-server")]
 use batch_queue::{BatchConfig, BatchQueue};
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
@@ -54,6 +73,7 @@ use batch_queue::{BatchConfig, BatchQueue};
 /// `--batch-size` and `--batch-window-ms` configure the `BatchQueue`
 /// coalescing window.
 /// Test: `clap::Parser::try_parse_from` in unit tests.
+#[cfg(feature = "http-server")]
 #[derive(Parser, Debug)]
 #[command(
     name = "trusty-embedderd",
@@ -122,6 +142,7 @@ pub struct Args {
 /// What: holds the `BatchQueue` handle so every HTTP request is served through
 /// the shared batching worker rather than calling the ONNX session directly.
 /// Test: constructed in `run` after model load; exercised by handler tests.
+#[cfg(feature = "http-server")]
 #[derive(Clone)]
 pub struct AppState {
     pub queue: Arc<BatchQueue>,
@@ -149,6 +170,7 @@ pub struct AppState {
 /// `curl http://127.0.0.1:7890/health`. For stdio mode:
 /// `cargo run -p trusty-embedderd -- --stdio` (parent drives via pipes).
 /// Covered indirectly by `embedder_supervisor_e2e` in `trusty-search`.
+#[cfg(feature = "http-server")]
 pub async fn run() -> Result<()> {
     let args = Args::parse();
     run_with_args(args).await
@@ -161,6 +183,7 @@ pub async fn run() -> Result<()> {
 /// What: performs the full daemon startup sequence using the provided args.
 /// Test: the public `run()` is tested indirectly via the supervisor e2e tests;
 /// `run_with_args` can be unit-tested with controlled `Args` values.
+#[cfg(feature = "http-server")]
 pub async fn run_with_args(args: Args) -> Result<()> {
     // Init tracing to stderr — never stdout (MCP policy; stdout is used for
     // JSON-RPC frames in --stdio mode).
@@ -321,6 +344,7 @@ pub async fn run_with_args(args: Args) -> Result<()> {
 /// serving requests before sending embedding work.
 /// What: returns a static JSON body with `status`, `model`, and `dim` fields.
 /// Test: `curl http://127.0.0.1:7890/health` returns HTTP 200.
+#[cfg(feature = "http-server")]
 pub async fn health_handler() -> Json<serde_json::Value> {
     Json(json!({
         "status": "ok",
@@ -336,6 +360,7 @@ pub async fn health_handler() -> Json<serde_json::Value> {
 /// What: deserialises `EmbedRequest`, enqueues via `BatchQueue::embed_many`,
 /// and returns `EmbedResponse`. On error returns HTTP 500 with a JSON body.
 /// Test: `cargo test -p trusty-embedderd --test bit_identical -- --include-ignored`
+#[cfg(feature = "http-server")]
 pub async fn embed_handler(
     State(state): State<AppState>,
     Json(req): Json<EmbedRequest>,


### PR DESCRIPTION
## Summary
- **#249** `trusty-analyze`: `axum` + `tower-http` made optional behind `http-server` feature (default enabled). `src/service/` and `src/mcp/sse.rs` gated; `src/mcp/stdio.rs` stays unconditional. `[[bin]]` gets `required-features = ["http-server"]`.
- **#250** `trusty-embedderd`: same pattern — `run`, `AppState`, HTTP handlers gated behind `http-server`; wire-protocol + batch-queue modules stay unconditional so the embedder shim in `trusty-search` works without the HTTP stack.

Both follow the `axum-server` pattern established in `trusty-common` and `trusty-memory` (PR #240).

## Test plan
- [ ] `cargo build -p trusty-analyze` and `--no-default-features` both pass
- [ ] `cargo build -p trusty-embedderd` and `--no-default-features` both pass
- [ ] `cargo build -p open-mpm` passes
- [ ] 346 trusty-analyze tests + 16 trusty-embedderd tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)