### PR TITLE
chore(trusty-memory): cleanup test helpers and hydration logic

### DIFF
--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -1582,17 +1582,22 @@ pub(crate) async fn sse_handler(
 mod tests {
     use super::*;
 
-    fn test_state() -> AppState {
+    /// Why: Issue #234 — previously we `mem::forget`ed the `TempDir` so tests
+    /// could keep using `AppState` without juggling the directory handle, but
+    /// that leaked one temp directory per test (262+ accumulated each run).
+    /// What: Returns the `TempDir` alongside the `AppState` so the caller can
+    /// bind it (`let (state, _tmp) = ...;`) and let drop semantics clean up
+    /// when the test scope ends.
+    /// Test: Every test in this module that constructs state.
+    fn test_state() -> (AppState, tempfile::TempDir) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().to_path_buf();
-        // Leak the tempdir so it lives for the test process; tests are short.
-        std::mem::forget(tmp);
-        AppState::new(root)
+        (AppState::new(root), tmp)
     }
 
     #[tokio::test]
     async fn initialize_returns_protocol_version_and_capabilities() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let req = json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -1613,7 +1618,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialized_notification_returns_null() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let req = json!({
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
@@ -1625,7 +1630,7 @@ mod tests {
 
     #[tokio::test]
     async fn tools_list_returns_all_tools() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let req = json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"});
         let resp = handle_message(&state, req).await;
         let tools = resp["result"]["tools"].as_array().expect("tools array");
@@ -1637,7 +1642,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_method_returns_error() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let req = json!({"jsonrpc": "2.0", "id": 4, "method": "wat"});
         let resp = handle_message(&state, req).await;
         assert_eq!(resp["error"]["code"], -32601);
@@ -1645,7 +1650,7 @@ mod tests {
 
     #[tokio::test]
     async fn ping_returns_empty_result() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let req = json!({"jsonrpc": "2.0", "id": 5, "method": "ping"});
         let resp = handle_message(&state, req).await;
         assert!(resp["result"].is_object());
@@ -1653,7 +1658,7 @@ mod tests {
 
     #[tokio::test]
     async fn app_state_default_constructs() {
-        let s = test_state();
+        let (s, _tmp) = test_state();
         assert!(!s.version.is_empty());
         assert!(s.registry.is_empty());
         assert!(s.default_palace.is_none());
@@ -1831,7 +1836,7 @@ mod tests {
     /// without a `palace` argument should error helpfully rather than panic.
     #[tokio::test]
     async fn missing_palace_without_default_errors() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let resp = handle_message(
             &state,
             json!({
@@ -1994,7 +1999,7 @@ mod tests {
     /// brand-new install has nothing to hydrate and should report zero.
     #[tokio::test]
     async fn load_palaces_from_disk_empty_root_returns_zero() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let count = state
             .load_palaces_from_disk()
             .await
@@ -2064,7 +2069,7 @@ mod tests {
     async fn palace_name_cache_updates_on_create() {
         use serde_json::json;
 
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = tools::dispatch_tool(&state, "palace_create", json!({"name": "gamma"}))
             .await
             .expect("palace_create");
@@ -2080,7 +2085,7 @@ mod tests {
     /// from `serverInfo` so clients can detect the unbound mode.
     #[tokio::test]
     async fn initialize_without_default_palace_omits_field() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let init = handle_message(
             &state,
             json!({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
@@ -2159,7 +2164,7 @@ mod tests {
     /// found" path.
     #[tokio::test]
     async fn initialize_does_not_advertise_prompts_capability() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let init = handle_message(
             &state,
             json!({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
@@ -2191,7 +2196,7 @@ mod tests {
     /// `tokio::spawn`, which requires an active runtime.
     #[tokio::test]
     async fn app_state_starts_with_empty_bound_addr() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         assert!(state.bound_addr.get().is_none());
     }
 
@@ -2371,7 +2376,7 @@ mod tests {
     /// Test: this test.
     #[tokio::test]
     async fn emit_persists_mutations_but_skips_status_changed() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         state.emit(DaemonEvent::PalaceCreated {
             id: "p".into(),
             name: "p".into(),
@@ -2416,7 +2421,8 @@ mod tests {
         unsafe {
             std::env::remove_var("TRUSTY_BM25_DAEMON");
         }
-        let state = test_state().with_bm25_client_from_env();
+        let (state, _tmp) = test_state();
+        let state = state.with_bm25_client_from_env();
         assert!(
             state.bm25_client.is_none(),
             "bm25_client must be None when TRUSTY_BM25_DAEMON is unset"
@@ -2448,7 +2454,8 @@ mod tests {
         unsafe {
             std::env::set_var("TRUSTY_BM25_DAEMON", "1");
         }
-        let state = test_state().with_bm25_client_from_env();
+        let (state, _tmp) = test_state();
+        let state = state.with_bm25_client_from_env();
         assert!(
             state.bm25_client.is_some(),
             "bm25_client must be Some when TRUSTY_BM25_DAEMON=1"

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -443,47 +443,7 @@ async fn run_serve(
             // a no-op when the env var is unset so existing deployments
             // see no behavioural change.
             .with_bm25_client_from_env();
-        // Why: previously, `load_palaces_from_disk` was awaited synchronously
-        // before binding the HTTP listener. A single broken `kg.db` (stale
-        // WAL sidecar, corrupt file, permissions) could stall hydration for
-        // seconds per palace, deferring `/health` becoming reachable until
-        // every palace had been visited. The dashboard, MCP clients, and
-        // `launchctl` health-probes all interpret that as "the daemon is
-        // dead", so the launchd job thrashes and operators see no useful
-        // output. Spawning hydration as a background task lets the HTTP
-        // server bind immediately; palaces appear in `palace_list` and the
-        // dashboard as each one finishes opening. Per-palace failures are
-        // already logged and skipped inside `load_palaces_from_disk` so a
-        // single bad `kg.db` can never abort the daemon.
-        // What: `AppState` derives `Clone` (its internals are `Arc`-wrapped),
-        // so the background task gets a cheap clone that shares the same
-        // registry the serving state writes into. We log start, summary, and
-        // total elapsed time so operators can see the warmup completing in
-        // the daemon log.
-        let bg_state = state.clone();
-        tokio::spawn(async move {
-            let started = std::time::Instant::now();
-            tracing::info!("starting background palace hydration");
-            match bg_state.load_palaces_from_disk().await {
-                Ok(count) => tracing::info!(
-                    elapsed_ms = started.elapsed().as_millis() as u64,
-                    "background palace hydration complete: {count} palaces loaded"
-                ),
-                Err(e) => tracing::error!(
-                    elapsed_ms = started.elapsed().as_millis() as u64,
-                    "background palace hydration failed: {e:#}"
-                ),
-            }
-            // Issue #42: once palaces are live, kick off auto-discovery
-            // against cwd targeting the default palace (if configured).
-            // Without a default palace there's no obvious destination, so
-            // skip — explicit MCP `discover_aliases` calls still work.
-            if let Some(palace) = bg_state.default_palace.clone() {
-                if let Ok(cwd) = std::env::current_dir() {
-                    bg_state.spawn_alias_discovery(palace, cwd);
-                }
-            }
-        });
+        spawn_startup_tasks(&state);
         run_http(state, addr).await
     } else {
         // Default: dynamic-port HTTP daemon. Mirrors the explicit `--http`
@@ -498,30 +458,57 @@ async fn run_serve(
             // a no-op when the env var is unset so existing deployments
             // see no behavioural change.
             .with_bm25_client_from_env();
-        let bg_state = state.clone();
-        tokio::spawn(async move {
-            let started = std::time::Instant::now();
-            tracing::info!("starting background palace hydration");
-            match bg_state.load_palaces_from_disk().await {
-                Ok(count) => tracing::info!(
-                    elapsed_ms = started.elapsed().as_millis() as u64,
-                    "background palace hydration complete: {count} palaces loaded"
-                ),
-                Err(e) => tracing::error!(
-                    elapsed_ms = started.elapsed().as_millis() as u64,
-                    "background palace hydration failed: {e:#}"
-                ),
-            }
-            // Issue #42: once palaces are live, kick off auto-discovery
-            // against cwd targeting the default palace (if configured).
-            // Without a default palace there's no obvious destination, so
-            // skip — explicit MCP `discover_aliases` calls still work.
-            if let Some(palace) = bg_state.default_palace.clone() {
-                if let Ok(cwd) = std::env::current_dir() {
-                    bg_state.spawn_alias_discovery(palace, cwd);
-                }
-            }
-        });
+        spawn_startup_tasks(&state);
         run_http_dynamic(state).await
     }
+}
+
+/// Why: startup tasks (palace hydration, alias discovery) are the same
+///      regardless of whether HTTP binds to a fixed or dynamic port; keeping
+///      the logic in a single helper means a new startup task only has to be
+///      added in one place. Previously, `load_palaces_from_disk` was awaited
+///      synchronously before binding the HTTP listener — a single broken
+///      `kg.db` (stale WAL sidecar, corrupt file, permissions) could stall
+///      hydration for seconds per palace, deferring `/health` becoming
+///      reachable until every palace had been visited. The dashboard, MCP
+///      clients, and `launchctl` health-probes all interpret that as "the
+///      daemon is dead", so the launchd job thrashes and operators see no
+///      useful output. Spawning hydration as a background task lets the HTTP
+///      server bind immediately; palaces appear in `palace_list` and the
+///      dashboard as each one finishes opening. Per-palace failures are
+///      already logged and skipped inside `load_palaces_from_disk` so a
+///      single bad `kg.db` can never abort the daemon.
+/// What: clones `state` (cheap — `AppState` derives `Clone` with `Arc`-wrapped
+///       internals) and spawns a background task that (1) hydrates persisted
+///       palaces from disk with timing logs, and (2) once palaces are live,
+///       kicks off issue-#42 alias auto-discovery against the cwd targeting
+///       the default palace (if configured). Returns immediately — the
+///       spawned task runs concurrently with the HTTP listener bind.
+/// Test: indirectly covered by `run_serve` integration tests; no direct unit
+///       test (process-level entry point, fire-and-forget spawn).
+fn spawn_startup_tasks(state: &AppState) {
+    let bg_state = state.clone();
+    tokio::spawn(async move {
+        let started = std::time::Instant::now();
+        tracing::info!("starting background palace hydration");
+        match bg_state.load_palaces_from_disk().await {
+            Ok(count) => tracing::info!(
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "background palace hydration complete: {count} palaces loaded"
+            ),
+            Err(e) => tracing::error!(
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "background palace hydration failed: {e:#}"
+            ),
+        }
+        // Issue #42: once palaces are live, kick off auto-discovery against
+        // cwd targeting the default palace (if configured). Without a default
+        // palace there's no obvious destination, so skip — explicit MCP
+        // `discover_aliases` calls still work.
+        if let Some(palace) = bg_state.default_palace.clone() {
+            if let Ok(cwd) = std::env::current_dir() {
+                bg_state.spawn_alias_discovery(palace, cwd);
+            }
+        }
+    });
 }

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -2161,11 +2161,17 @@ mod tests {
     use super::*;
     use crate::AppState;
 
-    fn test_state() -> AppState {
+    /// Why: Issue #234 — previously we `mem::forget`ed the `TempDir` so tests
+    /// could keep using `AppState` without juggling the directory handle, but
+    /// that leaked one temp directory per test (262+ accumulated each run).
+    /// What: Returns the `TempDir` alongside the `AppState` so the caller can
+    /// bind it (`let (state, _tmp) = ...;`) and let drop semantics clean up
+    /// when the test scope ends.
+    /// Test: Every test in this module that constructs state.
+    fn test_state() -> (AppState, tempfile::TempDir) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().to_path_buf();
-        std::mem::forget(tmp);
-        AppState::new(root)
+        (AppState::new(root), tmp)
     }
 
     /// Why: Issue #26 — when the server is started with `--palace`, the
@@ -2251,7 +2257,7 @@ mod tests {
     /// configured data root and `palace_list` then sees it.
     #[tokio::test]
     async fn dispatch_palace_create_persists() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let created = dispatch_tool(&state, "palace_create", json!({"name": "alpha"}))
             .await
             .expect("palace_create");
@@ -2268,7 +2274,7 @@ mod tests {
     /// through the MCP tool surface using the real embedder + retrieval path.
     #[tokio::test]
     async fn dispatch_remember_then_recall() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "beta"}))
             .await
             .expect("palace_create");
@@ -2313,7 +2319,7 @@ mod tests {
     /// Test: This test.
     #[tokio::test]
     async fn auto_kg_extraction_hooks_into_memory_remember() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "kgauto"}))
             .await
             .expect("palace_create");
@@ -2378,7 +2384,7 @@ mod tests {
     /// Test: This test.
     #[tokio::test]
     async fn auto_kg_extraction_no_op_does_not_fail_remember() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "kgnoop"}))
             .await
             .expect("palace_create");
@@ -2402,7 +2408,7 @@ mod tests {
     /// through the MCP tool surface.
     #[tokio::test]
     async fn dispatch_kg_assert_then_query() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "gamma"}))
             .await
             .expect("palace_create");
@@ -2446,7 +2452,7 @@ mod tests {
     async fn dispatch_kg_gaps_returns_cached() {
         use trusty_common::memory_core::community::KnowledgeGap;
 
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "delta"}))
             .await
             .expect("palace_create");
@@ -2487,9 +2493,10 @@ mod tests {
     /// `remove_prompt_fact`.
     #[tokio::test]
     async fn add_alias_round_trip_through_prompt_cache() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let root = tmp.path().to_path_buf();
-        std::mem::forget(tmp);
+        // Issue #234: bind `_tmp` so the directory is cleaned up on drop at
+        // end of scope (previously we leaked via `std::mem::forget`).
+        let _tmp = tempfile::tempdir().expect("tempdir");
+        let root = _tmp.path().to_path_buf();
         let state = AppState::new(root).with_default_palace(Some("ctx".to_string()));
 
         // Pre-create the default palace.
@@ -2589,7 +2596,7 @@ mod tests {
     /// and (c) filter by `query` against subject/object case-insensitively.
     #[tokio::test]
     async fn get_prompt_context_serves_cache_and_filters() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
 
         // (a) empty cache -> "No prompt facts stored yet."
         let resp = dispatch_tool(&state, "get_prompt_context", json!({}))
@@ -2677,9 +2684,10 @@ mod tests {
     /// Test: this test itself.
     #[tokio::test]
     async fn dispatch_discover_aliases_inserts_new_and_dedupes() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let root = tmp.path().to_path_buf();
-        std::mem::forget(tmp);
+        // Issue #234: bind `_tmp` so the directory is cleaned up on drop at
+        // end of scope (previously we leaked via `std::mem::forget`).
+        let _tmp = tempfile::tempdir().expect("tempdir");
+        let root = _tmp.path().to_path_buf();
         let state = AppState::new(root).with_default_palace(Some("disc".to_string()));
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "disc"}))
             .await
@@ -2747,7 +2755,7 @@ mod tests {
     /// and confirm the temporal triples are present.
     #[tokio::test]
     async fn palace_create_auto_seeds_temporal_metadata() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let created = dispatch_tool(&state, "palace_create", json!({"name": "auto"}))
             .await
             .expect("palace_create");
@@ -2790,7 +2798,7 @@ mod tests {
     /// arrays with no breadcrumb back to the seeding tools.
     #[tokio::test]
     async fn kg_query_emits_hint_when_palace_empty() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "hinted"}))
             .await
             .expect("palace_create");
@@ -2813,7 +2821,7 @@ mod tests {
     /// origin URL, then make them queryable through `kg_query`.
     #[tokio::test]
     async fn kg_bootstrap_seeds_workspace_facts() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "ws"}))
             .await
             .expect("palace_create");
@@ -2954,7 +2962,7 @@ mod tests {
     /// Test: itself.
     #[tokio::test]
     async fn dispatch_remember_skips_short_no_context() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "gate"}))
             .await
             .expect("palace_create");
@@ -2995,7 +3003,7 @@ mod tests {
     /// Test: itself.
     #[tokio::test]
     async fn dispatch_remember_with_context_writes_combined() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "ctxgate"}))
             .await
             .expect("palace_create");
@@ -3037,7 +3045,7 @@ mod tests {
     /// Test: itself.
     #[tokio::test]
     async fn dispatch_note_skips_short_no_context() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "noteg"}))
             .await
             .expect("palace_create");
@@ -3062,7 +3070,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_unknown_tool_errors() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let err = dispatch_tool(&state, "does_not_exist", json!({}))
             .await
             .expect_err("should error");
@@ -3131,7 +3139,7 @@ mod tests {
     /// Test: itself.
     #[tokio::test]
     async fn dedup_skips_near_duplicate() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "dedup1"}))
             .await
             .expect("palace_create");
@@ -3177,7 +3185,7 @@ mod tests {
     /// Test: itself.
     #[tokio::test]
     async fn dedup_allows_different_content() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "dedup2"}))
             .await
             .expect("palace_create");
@@ -3223,7 +3231,8 @@ mod tests {
     /// Test: itself — fail-then-pass on this commit.
     #[tokio::test]
     async fn dedup_gate_blocks_concurrent_duplicate_writes() {
-        let state = std::sync::Arc::new(test_state());
+        let (state, _tmp) = test_state();
+        let state = std::sync::Arc::new(state);
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "dedup_race"}))
             .await
             .expect("palace_create");
@@ -3306,7 +3315,7 @@ mod tests {
     /// Test: itself.
     #[tokio::test]
     async fn dispatch_remember_blocks_blocklist_pattern() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let _ = dispatch_tool(&state, "palace_create", json!({"name": "blk"}))
             .await
             .expect("palace_create");
@@ -3352,7 +3361,7 @@ mod tests {
         // Build a normal AppState, then swap in a fresh bounded channel
         // *without* spawning a drain worker so we can deterministically
         // observe overflow at `try_send`.
-        let mut state = test_state();
+        let (mut state, _tmp) = test_state();
         let (tx, _rx_held) =
             tokio::sync::mpsc::channel::<Bm25IndexRequest>(BM25_INDEX_QUEUE_CAPACITY);
         state.bm25_index_tx = tx;


### PR DESCRIPTION
## Summary
- fix(trusty-memory): return `TempDir` from test helpers instead of leaking via `mem::forget` (closes #234)
- refactor(trusty-memory): extract duplicated startup hydration into `spawn_startup_tasks` helper (closes #233)

## Test plan
- [x] Both changes are covered by existing tests in the trusty-memory test suite
- [x] `cargo test -p trusty-memory` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)