### PR TITLE
fix(tga): rules YAML accepts singular pattern: field + schema docs (#259 #260)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -9835,6 +9835,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "strsim 0.11.1",
+ "tempfile",
  "tera",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "1.2.0"
+version = "1.2.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for
@@ -110,6 +110,8 @@ wiremock = "0.6"
 criterion = { workspace = true }
 # Capture tracing events in tests (used by ticket_regex warn-log assertions)
 tracing-test = "0.2"
+# Temporary files for rule-loader tests
+tempfile = { workspace = true }
 
 [[bench]]
 name = "tga_bench"

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -503,11 +503,12 @@ Commits that match no rule are assigned category `uncategorized` with confidence
 
 ### Custom Rules File
 
-Supply your own rules alongside the defaults:
+Supply your own rules as a YAML (or JSON) file:
 
 ```yaml
 # my-rules.yaml
 version: "1.0"
+extend_defaults: false   # true = merge with built-ins; false = standalone (default)
 rules:
   - id: my-deploy
     category: deployment
@@ -526,6 +527,41 @@ tga classify --rules ./my-rules.yaml
 # classification:
 #   rules_file: ./my-rules.yaml
 ```
+
+### Rules YAML schema
+
+Each entry under `rules:` is a **Rule** with these fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | string | **required** | Unique rule identifier (used in logs and `tga rules test`) |
+| `category` | string | **required** | The classification label written to the database |
+| `subcategory` | string | `null` | Optional leaf label (e.g. `"sql-injection"` under `category: "security"`) |
+| `keywords` | list of strings | `[]` | Exact substrings, matched case-insensitively via Aho-Corasick |
+| `pattern` / `patterns` | string or list | `[]` | Regex patterns (see note below) |
+| `priority` | integer | `110` | Higher = checked first. Custom-rule default (110) beats built-ins (peak 115 for `cc-revert`, 100 for `cc-feat`/`cc-fix`) |
+| `confidence` | float 0–1 | `0.85` | Score attached to the verdict; only accepted if ≥ `confidence_threshold` |
+
+**`pattern:` vs `patterns:`** — both key names are accepted:
+
+```yaml
+# Singular string (most natural for a single regex)
+pattern: "(?i)^feat[:(]"
+
+# Plural list (multiple alternates for one rule)
+patterns:
+  - "(?i)^feat[:(]"
+  - "(?i)^feature[:(]"
+```
+
+Using `pattern:` with a single string is exactly equivalent to `patterns:` with a single-element list. Both forms were silently mishandled in versions ≤ 1.2.0 (issue #259); if you had rules that never fired, this was the cause.
+
+The top-level `RuleSet` also has two optional fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `version` | string | `null` | Schema version tag (informational) |
+| `extend_defaults` | bool | `false` | When `true`, custom rules are merged with the built-in set; same-`id` entries override the built-in |
 
 ### Rule Priority and extend_defaults (issue #259)
 
@@ -553,18 +589,34 @@ rules:
     confidence: 0.92
 ```
 
+**Diagnosing rules that never fire**: if your custom categories never appear in reports, run:
+
+```bash
+tga rules list --rules ./my-rules.yaml   # shows all loaded rules with their matchers
+tga rules test "feat: add login" --rules ./my-rules.yaml   # dry-run a message
+tga classify -vv --rules ./my-rules.yaml   # verbose mode shows per-rule decisions
+```
+
+A `WARN rule has no keywords or patterns` in the log output means a rule's YAML key was silently dropped — the most common cause is writing `pattern:` (singular) in a version before 1.2.1. Upgrade to 1.2.1+ and both `pattern:` and `patterns:` are accepted.
+
+See also: [Multi-source classification](#multi-source-classification-issue-260) for external ticket system integration.
+
 ### Multi-source classification (issue #260)
 
 `tga classify` can consult external ticket systems — JIRA Cloud/Server and
 GitHub Issues — as high-confidence classification signals **before** the
 commit-message rule tiers run.
 
+External sources fire as **Tier 0.5** — after manual overrides, before
+commit-message rules — with a fixed confidence of `0.92`. They are enabled
+by default when configured; use `--no-external` to opt out for a run.
+
 **Priority model** (highest to lowest):
 
-1. Manual overrides (`tga override add`)
+1. Manual overrides (`tga override add`, confidence 1.0)
 2. External sources — JIRA issue type / GitHub Issues labels (confidence 0.92)
-3. Custom regex rules (default priority 110)
-4. Built-in TGA rules (priority 100)
+3. Custom commit-message rules (default priority 110)
+4. Built-in TGA commit-message rules (priority 100)
 5. LLM fallback (when `use_llm: true`)
 
 **Configuration** — add a `sources:` list to `config.yaml` under
@@ -572,49 +624,65 @@ commit-message rule tiers run.
 
 ```yaml
 classification:
+  no_external: false    # opt-out flag; sources fire by default once configured
   sources:
-    # JIRA source
+
+    # --- JIRA source ---
     - type: jira
       base_url: "https://yourco.atlassian.net"
-      token_env: JIRA_API_TOKEN      # env var carrying the API token
-      username: "you@yourco.com"     # omit for Bearer-only tokens
-      project_keys: ["PROJ", "ENG"]  # empty = all projects
+      token_env: JIRA_API_TOKEN      # name of the env var holding your API token
+      email_env: JIRA_USER_EMAIL     # optional — only needed for JIRA Cloud Basic auth
+      project_keys: ["PROJ", "ENG"]  # empty list = match all projects
       field_mappings:
+        # Maps JIRA issue type → tga category. Case-sensitive on the JIRA side.
         issue_type:
           Bug: bug_fix
           Story: new_feature
           Task: tech_debt_refactoring
+          Sub-task: tech_debt_refactoring
           Epic: new_feature
+        # Maps JIRA labels → tga category. Labels are case-sensitive.
         labels:
           ktlo: tech_debt_refactoring
           security: security
+        # Maps JIRA components → tga category.
         components:
+          "CI/CD": devops
           Platform: platform_infrastructure
 
-    # GitHub Issues source
+    # --- GitHub Issues source ---
     - type: github_issues
-      repo: "acme/widgets"
-      token_env: GITHUB_TOKEN
+      repo: "acme/widgets"           # "owner/repo" slug
+      token_env: GITHUB_TOKEN        # name of the env var holding your PAT
       label_mappings:
         bug: bug_fix
         enhancement: new_feature
         dependencies: tech_debt_refactoring
         documentation: documentation
+        security: security
 ```
 
-Credentials are read from the **named environment variables** at runtime —
-never store tokens directly in config files:
+**Field-mapping precedence within a JIRA source** (highest to lowest):
+`issue_type` → `labels` → `components`. The first mapping that matches wins.
+
+**Credential handling**: tokens are read from the **named environment
+variables** at runtime — never store them directly in config files:
 
 ```bash
 export JIRA_API_TOKEN="your-jira-api-token"
+export JIRA_USER_EMAIL="you@yourco.com"   # JIRA Cloud only
 export GITHUB_TOKEN="your-github-pat"
 tga classify --config config.yaml
 ```
 
+**Failure mode**: a missing token, HTTP 401/404, or network error causes the
+source to be skipped with a `WARN` log and the pipeline falls through to
+commit-message rules for affected commits. Classification never panics on
+source failures.
+
 **Caching**: each unique ticket is fetched at most once per `tga classify`
-run (in-memory cache, never persisted to disk). On HTTP failure or missing
-token, the source is skipped with a warning and the pipeline falls through
-to commit-message rules.
+run (in-memory dedup, never persisted to disk). A 15 000-commit run against
+a project with 500 unique JIRA tickets makes 500 API calls, not 15 000.
 
 **Disabling external sources**: use `--no-external` to skip all sources for
 a run (useful in CI or offline environments):
@@ -628,6 +696,8 @@ for a fully annotated example.
 
 **Deferred sources** (planned for a future release): Linear, Shortcut,
 Confluence, Datadog.
+
+See also: [Rules YAML schema](#rules-yaml-schema) for commit-message rule authoring.
 
 ## Output Formats
 

--- a/crates/trusty-git-analytics/src/classify/rules/loader.rs
+++ b/crates/trusty-git-analytics/src/classify/rules/loader.rs
@@ -39,6 +39,24 @@ pub fn load_rules(path: &Path) -> Result<RuleSet> {
             path.display()
         )));
     }
+
+    // Warn about rules that will never match — a common symptom of the singular
+    // `pattern:` vs plural `patterns:` naming confusion (issue #259). After the
+    // fix the deserializer handles both forms, but this guard catches other cases
+    // (e.g. a rule with neither keywords nor patterns) and gives a clear diagnostic
+    // so users don't spend time debugging silent "all uncategorized" results.
+    for rule in &set.rules {
+        if rule.keywords.is_empty() && rule.patterns.is_empty() {
+            tracing::warn!(
+                rule_id = %rule.id,
+                category = %rule.category,
+                "rule has no keywords or patterns and will never match — \
+                 check YAML field names (use `pattern:` for a single regex or \
+                 `patterns:` for a list; both are accepted)"
+            );
+        }
+    }
+
     Ok(set)
 }
 
@@ -1521,5 +1539,176 @@ fn catch_all_rule() -> Rule {
         patterns: vec![r"(?s).+".into()],
         priority: 1,
         confidence: 0.3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write a temporary YAML file and load it, returning the parsed RuleSet.
+    ///
+    /// Why: `load_rules` requires a real file path; this helper avoids
+    /// duplicating the tempfile boilerplate in every test.
+    /// What: writes `content` to a `.yaml` temp file and calls `load_rules`.
+    /// Test: only used as an internal helper — the callers are the real tests.
+    fn load_yaml(content: &str) -> crate::classify::errors::Result<RuleSet> {
+        let mut f = tempfile::NamedTempFile::with_suffix(".yaml").expect("create temp file");
+        f.write_all(content.as_bytes()).expect("write yaml");
+        load_rules(f.path())
+    }
+
+    /// A rule file using singular `pattern:` key loads successfully and
+    /// produces the correct `patterns` vec — the core #259 regression test.
+    ///
+    /// Why: load_rules must handle the full file-parse path (not just the
+    /// struct-level serde deserialization) for the singular alias to be
+    /// observable end-to-end.
+    /// What: writes a two-rule YAML (one with `pattern:`, one with
+    /// `patterns:`) to a temp file, calls `load_rules`, and asserts that
+    /// both rules have non-empty `patterns`.
+    /// Test: passes when the `#[serde(alias = "pattern")]` and
+    /// `deserialize_with` are in place; fails on the old unaliased field.
+    #[test]
+    fn load_rules_singular_pattern_key_accepted() {
+        let yaml = r#"
+rules:
+  - id: singular-test
+    category: new_feature
+    pattern: "(?i)^feat[:(]"
+  - id: plural-test
+    category: bugfix
+    patterns:
+      - "(?i)^fix[:(]"
+      - "(?i)^bug[:(]"
+"#;
+        let set = load_yaml(yaml).expect("load");
+        let singular = set.rules.iter().find(|r| r.id == "singular-test").unwrap();
+        assert_eq!(
+            singular.patterns,
+            vec!["(?i)^feat[:(]".to_string()],
+            "singular `pattern:` must load as a single-element vec"
+        );
+        let plural = set.rules.iter().find(|r| r.id == "plural-test").unwrap();
+        assert_eq!(plural.patterns.len(), 2);
+    }
+
+    /// A rule with no keywords AND no patterns emits a tracing WARN.
+    ///
+    /// Why: silent "all uncategorized" results are the hardest bugs to
+    /// diagnose; the warn gives users a direct pointer to the issue (#259).
+    /// What: loads a rule file containing one zero-matcher rule and one
+    /// valid rule, then uses `tracing_test` to assert the warn is emitted
+    /// exactly for the zero-matcher rule's id.
+    /// Test: `logs_contain` checks the warn message text; the valid rule
+    /// must NOT produce a warn.
+    #[test]
+    #[tracing_test::traced_test]
+    fn load_rules_warns_on_empty_matchers() {
+        let yaml = r#"
+rules:
+  - id: no-matchers
+    category: custom_category
+  - id: has-keyword
+    category: bugfix
+    keywords:
+      - "fix:"
+"#;
+        let set = load_yaml(yaml).expect("load");
+        assert_eq!(set.rules.len(), 2);
+        // The warn must mention the rule id of the empty-matcher rule.
+        assert!(
+            logs_contain("no-matchers"),
+            "expected warn log containing the rule id `no-matchers`"
+        );
+        // The rule with keywords must NOT trigger the warn.
+        assert!(
+            !logs_contain("has-keyword"),
+            "rule `has-keyword` should not warn — it has a keyword"
+        );
+    }
+
+    /// End-to-end: load a singular-`pattern:` rule file and classify a
+    /// commit that should match it, asserting the custom category appears.
+    ///
+    /// Why: verifies that the fix propagates through the full classification
+    /// pipeline — load_rules → ClassificationEngine → ClassificationResult.
+    /// If patterns were still silently dropped, the rule would never fire
+    /// and the result would fall through to the catch-all.
+    /// What: builds a ClassificationEngine from a user rules file with
+    /// `pattern:` (singular), classifies `"feat: add login"`, and asserts
+    /// `category == "new_feature"` (the custom name, not the built-in
+    /// `"feature"` from the default ruleset).
+    /// Test: this is the closest equivalent of the QA repro documented in
+    /// #259 — standalone rules file, singular pattern, custom category name.
+    #[test]
+    fn end_to_end_singular_pattern_rule_fires() {
+        use crate::classify::classifier::{ClassificationEngine, ClassificationEngineConfig};
+
+        let yaml = r#"
+extend_defaults: false
+rules:
+  - id: custom-feat
+    category: new_feature
+    pattern: "(?i)^feat[:(]"
+"#;
+        let set = load_yaml(yaml).expect("load");
+        let engine = ClassificationEngine::new(
+            set,
+            ClassificationEngineConfig {
+                use_llm: false,
+                ..Default::default()
+            },
+        )
+        .expect("engine");
+
+        let result = engine
+            .classify_sync("feat: add login flow", false)
+            .expect("classified");
+
+        assert_eq!(
+            result.category, "new_feature",
+            "singular `pattern:` rule must fire and produce custom category"
+        );
+    }
+
+    /// A rule file with `patterns:` (plural list) also works end-to-end.
+    ///
+    /// Why: regression guard — the custom deserializer must not break the
+    /// existing plural form that all prior users had.
+    /// What: same as `end_to_end_singular_pattern_rule_fires` but uses
+    /// `patterns:` with two entries.
+    /// Test: asserts the engine returns the custom category for both patterns.
+    #[test]
+    fn end_to_end_plural_patterns_rule_fires() {
+        use crate::classify::classifier::{ClassificationEngine, ClassificationEngineConfig};
+
+        let yaml = r#"
+extend_defaults: false
+rules:
+  - id: custom-feat
+    category: new_feature
+    patterns:
+      - "(?i)^feat[:(]"
+      - "(?i)^feature[:(]"
+"#;
+        let set = load_yaml(yaml).expect("load");
+        let engine = ClassificationEngine::new(
+            set,
+            ClassificationEngineConfig {
+                use_llm: false,
+                ..Default::default()
+            },
+        )
+        .expect("engine");
+
+        for msg in ["feat: add login", "feature: dark mode"] {
+            let result = engine.classify_sync(msg, false).expect("classified");
+            assert_eq!(
+                result.category, "new_feature",
+                "plural `patterns:` rule must fire for `{msg}`"
+            );
+        }
     }
 }

--- a/crates/trusty-git-analytics/src/classify/rules/types.rs
+++ b/crates/trusty-git-analytics/src/classify/rules/types.rs
@@ -1,6 +1,44 @@
 //! Rule and rule-set data structures.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Deserialize the `patterns` / `pattern` field from a YAML rule entry.
+///
+/// Why: user-authored rules YAMLs naturally write `pattern: "(?i)^feat"` (singular
+/// string) while the struct field is `Vec<String>`. Without this deserializer
+/// `serde_yaml` rejects the scalar value when the target type is a sequence, and
+/// because the field is `#[serde(default)]` the error is silently swallowed,
+/// leaving `patterns = []`. That is the root cause of issue #259 — rules with an
+/// empty pattern list never fire, causing 100% "uncategorized" results. This
+/// function handles three cases so neither existing nor new YAML files break:
+///
+/// - Absent key (field omitted) → `vec![]`
+/// - Single string (`pattern: "foo"`) → `vec!["foo"]`
+/// - Sequence (`patterns: ["foo", "bar"]`) → `vec!["foo", "bar"]`
+///
+/// What: deserializes via an `#[serde(untagged)]` enum that matches all three
+/// shapes, then maps each variant to the appropriate `Vec<String>`.
+/// Test: covered by `rule_singular_pattern_deserializes`,
+/// `rule_plural_patterns_deserializes`, and `rule_missing_patterns_field_gives_empty_vec`
+/// in `classify::rules::types::tests`, and by the end-to-end tests in
+/// `classify::rules::loader::tests`.
+fn deserialize_patterns_field<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVecOrNull {
+        Single(String),
+        Many(Vec<String>),
+        Null,
+    }
+    match StringOrVecOrNull::deserialize(deserializer)? {
+        StringOrVecOrNull::Single(s) => Ok(vec![s]),
+        StringOrVecOrNull::Many(v) => Ok(v),
+        StringOrVecOrNull::Null => Ok(vec![]),
+    }
+}
 
 /// A single classification rule.
 ///
@@ -40,7 +78,24 @@ pub struct Rule {
     pub keywords: Vec<String>,
 
     /// Regex patterns to match against the commit message.
-    #[serde(default)]
+    ///
+    /// Accepts both the singular YAML key `pattern:` (a string or a list of strings)
+    /// and the plural key `patterns:` (a list of strings). User-authored rule files
+    /// naturally reach for `pattern: "(?i)^feat"` which, without this alias, would be
+    /// silently dropped by serde because the target type is `Vec<String>`. The
+    /// `deserialize_with` helper coerces a scalar string to a single-element vec.
+    ///
+    /// **Either form is accepted:**
+    ///
+    /// ```yaml
+    /// pattern: "(?i)^feat[:(]"            # singular string → vec!["(?i)^feat[:(]"]
+    /// patterns: ["(?i)^feat", "(?i)^feature"]  # plural list  → vec as-is
+    /// ```
+    #[serde(
+        default,
+        alias = "pattern",
+        deserialize_with = "deserialize_patterns_field"
+    )]
     pub patterns: Vec<String>,
 
     /// Priority (higher = checked first).
@@ -121,5 +176,104 @@ impl RuleSet {
         let mut refs: Vec<&Rule> = self.rules.iter().collect();
         refs.sort_by_key(|r| std::cmp::Reverse(r.priority));
         refs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Singular `pattern:` key with a string value deserializes into a
+    /// single-element `patterns` vec.
+    ///
+    /// Why: this is the primary regression guarded by issue #259. User YAMLs
+    /// (and the issue body itself) write `pattern: "..."` (natural English
+    /// singular). Before the fix serde silently dropped the unknown key,
+    /// giving `patterns = []` — so rules never fired.
+    /// What: parses a minimal YAML rule with `pattern:` (singular string) and
+    /// asserts that `rule.patterns` has exactly one element matching the input.
+    /// Test: this test IS the regression test — watch it fail against the old
+    /// `patterns: Vec<String>` field (no alias, no custom deserializer).
+    #[test]
+    fn rule_singular_pattern_deserializes() {
+        let yaml = r#"
+id: test-1
+category: new_feature
+pattern: "(?i)^feat"
+"#;
+        let rule: Rule = serde_yaml::from_str(yaml).expect("deserialize");
+        assert_eq!(
+            rule.patterns,
+            vec!["(?i)^feat".to_string()],
+            "singular `pattern:` must be coerced to a single-element vec"
+        );
+    }
+
+    /// Plural `patterns:` key with a YAML list deserializes unchanged.
+    ///
+    /// Why: existing rule files that already use `patterns:` (plural) must
+    /// continue to work after adding the singular alias and custom deserializer.
+    /// What: parses a minimal YAML rule with `patterns:` as a two-element list
+    /// and asserts both elements are preserved in order.
+    /// Test: verify the happy path was not broken by the alias addition.
+    #[test]
+    fn rule_plural_patterns_deserializes() {
+        let yaml = r#"
+id: test-2
+category: new_feature
+patterns:
+  - "(?i)^feat"
+  - "(?i)^feature"
+"#;
+        let rule: Rule = serde_yaml::from_str(yaml).expect("deserialize");
+        assert_eq!(rule.patterns.len(), 2);
+        assert_eq!(rule.patterns[0], "(?i)^feat");
+        assert_eq!(rule.patterns[1], "(?i)^feature");
+    }
+
+    /// A rule with neither `pattern:` nor `patterns:` gives an empty vec
+    /// (not a parse error).
+    ///
+    /// Why: rules that match only on keywords have no patterns field at all;
+    /// this must remain valid and produce `patterns = []`.
+    /// What: parses a rule with only `keywords:` and asserts `patterns` is
+    /// empty and the parse succeeds.
+    /// Test: ensures the `#[serde(default)]` fallback still works alongside
+    /// the custom deserializer.
+    #[test]
+    fn rule_missing_patterns_field_gives_empty_vec() {
+        let yaml = r#"
+id: test-3
+category: bugfix
+keywords:
+  - "fix:"
+"#;
+        let rule: Rule = serde_yaml::from_str(yaml).expect("deserialize");
+        assert!(rule.patterns.is_empty());
+        assert_eq!(rule.keywords, vec!["fix:".to_string()]);
+    }
+
+    /// A singular `pattern:` value still compiles as a valid regex that
+    /// matches the intended commit message, exercising the full round-trip.
+    ///
+    /// Why: end-to-end check that the coerced string is not mangled — a
+    /// deserialization that produces `patterns = [""]` would pass the
+    /// structural check above but still silently mismatch everything.
+    /// What: deserializes a rule, compiles its single pattern with the
+    /// `regex` crate, and asserts it matches an expected commit message.
+    /// Test: confirms the regex is intact after string→vec coercion.
+    #[test]
+    fn rule_singular_pattern_regex_compiles_and_matches() {
+        let yaml = r#"
+id: test-4
+category: new_feature
+pattern: "(?i)^feat[:(]"
+"#;
+        let rule: Rule = serde_yaml::from_str(yaml).expect("deserialize");
+        assert_eq!(rule.patterns.len(), 1);
+        let re = regex::Regex::new(&rule.patterns[0]).expect("compile");
+        assert!(re.is_match("feat: add login flow"));
+        assert!(re.is_match("feat(api): new endpoint"));
+        assert!(!re.is_match("fix: null deref"));
     }
 }


### PR DESCRIPTION
## What was actually wrong

The 1.1.0 and 1.1.1 releases addressed real problems (priority defaults, `extend_defaults` behavior, taxonomy aliases) but not the primary failure mode. The actual bug:

- `Rule.patterns` is declared as `Vec<String>` (plural field name)
- User YAMLs, including the issue #259 body itself, write `pattern: "..."` (singular — natural English)
- `serde_yaml` sees an unknown key `pattern:` and silently drops it because `patterns` has `#[serde(default)]`
- Rules load with `patterns = []` — the regex tier never fires — all commits fall through to the catch-all or built-in rules

Result: 100% uncategorized (with `extend_defaults: false`) or 100% built-in categories (with `extend_defaults: true`). The user's custom category names never appear.

## How this fix differs from 1.1.0/1.1.1

1.1.x patched the _priority_ and _extend_defaults_ layers. This patch fixes the _deserialization_ layer — the earlier layer that must work before anything else matters.

## Changes

### Fix 1 — `#[serde(alias = "pattern")]` + custom deserializer (`types.rs`)

`#[serde(alias = "pattern")]` alone is insufficient — serde would try to deserialize a YAML scalar string into `Vec<String>` and fail. We need a `deserialize_with` function that accepts three shapes:

- `pattern: "regex"` (scalar string → `vec!["regex"]`)
- `patterns: ["a", "b"]` (sequence → unchanged)
- absent key → `vec![]` (via `#[serde(default)]` combined)

The new `deserialize_patterns_field` function handles all three via `#[serde(untagged)]`.

**Decision note**: `#[serde(alias = "pattern", deserialize_with = "deserialize_patterns_field")]` is the only approach that handles the scalar-vs-sequence type mismatch. A simple alias without `deserialize_with` would still reject the scalar shape for `Vec<String>`.

### Fix 2 — warn at load time on empty matchers (`loader.rs`)

After deserialization, scan every loaded rule. If both `keywords` and `patterns` are empty, emit:

```
WARN rule has no keywords or patterns and will never match — check YAML field names
     (use `pattern:` for a single regex or `patterns:` for a list; both are accepted)
```

This gives future users a direct pointer to the issue even if they encounter it before upgrading.

### Fix 3 — README schema documentation (closes #260 doc gap)

- New **"Rules YAML schema"** section with a full field table, the `pattern:` / `patterns:` note, `RuleSet` top-level fields, and a "diagnosing rules that never fire" guide
- Updated **"Multi-source classification"** section: added `email_env` field, field-mapping precedence, failure mode, caching details, and cross-link to the rules section
- Cross-links between both sections

### Fix 4 — version bump to 1.2.1 + `tempfile` dev-dep

## Test plan

8 new tests all pass (378 lib tests + 55 doc/integration tests total, 0 failures):

| Test | What it verifies |
|------|-----------------|
| `rule_singular_pattern_deserializes` | Core regression — `pattern:` singular string → `vec!["..."]` |
| `rule_plural_patterns_deserializes` | Existing plural form not broken |
| `rule_missing_patterns_field_gives_empty_vec` | Absent key → `[]` (no parse error) |
| `rule_singular_pattern_regex_compiles_and_matches` | Round-trip: coerced string is valid regex |
| `load_rules_singular_pattern_key_accepted` | File-level end-to-end load with both forms |
| `load_rules_warns_on_empty_matchers` | `tracing_test::traced_test` captures WARN message |
| `end_to_end_singular_pattern_rule_fires` | Full engine: custom category produced, not catch-all |
| `end_to_end_plural_patterns_rule_fires` | Same for plural form (regression guard) |

End-to-end QA verification against this repo:

```sql
-- singular `pattern:` rules file, extend_defaults: false, 3 custom categories
SELECT category, COUNT(*) FROM classifications GROUP BY category ORDER BY 2 DESC;
uncategorized|132
new_feature|101
bug_fix|78
housekeeping|16
revert|1
```

`new_feature`, `bug_fix`, and `housekeeping` are the custom category names — they appear in the output, not just built-in names or `uncategorized`. The 132 uncategorized entries are commits that match none of the 3 rules (refactors, chores, etc.) and have no catch-all because `extend_defaults: false` excludes it — correct behavior.

Closes #259
Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)