### PR TITLE
fix(tga): JIRA Cloud Basic auth + fuzzy tier gating + strict schema (#286)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "1.2.1"
+version = "1.2.2"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -569,6 +569,8 @@ Custom rules default to **priority 110** — one step above the highest built-in
 
 Custom rule files also default to **standalone** mode (`extend_defaults: false`): only the rules in the file are applied. Opt in to merging with the built-in defaults by adding `extend_defaults: true`.
 
+**Fuzzy-tier gating (1.2.2)**: the fuzzy heuristic tier (which emits the built-in category strings `merge`, `feature`, `chore`) is also suppressed when `extend_defaults: false`. This aligns with the principle that `extend_defaults: false` means "no built-in classification of any kind." If you see `method=fuzzy_match` rows for a config with `extend_defaults: false`, upgrade to 1.2.2.
+
 ```yaml
 # my-rules.yaml — standalone by default (no built-in rules loaded)
 extend_defaults: false   # optional: explicitly document the default

--- a/crates/trusty-git-analytics/examples/multi-source-config.yaml
+++ b/crates/trusty-git-analytics/examples/multi-source-config.yaml
@@ -42,9 +42,17 @@ classification:
       # Set it as:  export JIRA_API_TOKEN="your-token"
       token_env: JIRA_API_TOKEN
 
-      # JIRA Cloud requires Basic auth: "email:token" base64-encoded.
-      # Set username here; omit for pure Bearer token (JIRA Server).
-      username: "you@yourco.com"
+      # JIRA Cloud requires Basic auth: email + token base64-encoded.
+      #
+      # Recommended: use `email_env:` so the email address is read from the
+      # environment at request time and never stored in the config file.
+      #   export JIRA_EMAIL="you@yourco.com"
+      email_env: JIRA_EMAIL
+      #
+      # Alternative (backward compat): set the literal email here.
+      # Only one of `email_env` or `username` is needed; `username` wins if
+      # both are present.
+      # username: "you@yourco.com"
 
       # Limit JIRA lookups to these project keys.
       # An empty list (or omitting the key) means "query any project key

--- a/crates/trusty-git-analytics/src/classify/classifier.rs
+++ b/crates/trusty-git-analytics/src/classify/classifier.rs
@@ -66,6 +66,11 @@ impl Default for ClassificationEngineConfig {
 /// so callers don't reimplement the precedence rules.
 /// What: holds one classifier per tier plus the shared taxonomy and
 /// config. `classify` walks the tiers in order; first non-`None` wins.
+/// The fuzzy tier is gated by `extend_defaults`: when `false`, the fuzzy
+/// tier is suppressed because it emits hardcoded built-in category strings
+/// (`"merge"`, `"feature"`, `"chore"`) that conflict with user-defined
+/// taxonomies, violating the principle that `extend_defaults: false` means
+/// "no built-in classification of any kind".
 /// Test: covered by `classify::tests::engine_classify_batch_does_not_panic`
 /// and the cascade-coverage `corpus_uncategorized_below_1_percent` test.
 pub struct ClassificationEngine {
@@ -74,7 +79,13 @@ pub struct ClassificationEngine {
     issue_type: IssueTypeTier,
     regex: RegexMatcher,
     jira_project: JiraProjectTier,
-    fuzzy: FuzzyClassifier,
+    /// `None` when `extend_defaults == false` in the loaded ruleset.
+    ///
+    /// Why: the fuzzy tier is built-in by definition — it emits hardcoded
+    /// category strings (`"merge"`, `"feature"`, `"chore"`) regardless of
+    /// user taxonomy. Gating it behind `extend_defaults` ensures it never
+    /// fires when the user has elected a fully custom taxonomy.
+    fuzzy: Option<FuzzyClassifier>,
     llm: Option<LlmClassifier>,
     taxonomy: TaxonomyRegistry,
     config: ClassificationEngineConfig,
@@ -178,7 +189,16 @@ impl ClassificationEngine {
     ) -> Result<Self> {
         let exact = ExactMatcher::new(&ruleset.rules)?;
         let regex = RegexMatcher::new(&ruleset.rules)?;
-        let fuzzy = FuzzyClassifier;
+        // Gate the fuzzy tier on extend_defaults. The fuzzy tier is built-in
+        // by definition: it emits hardcoded category strings ("merge",
+        // "feature", "chore") that conflict with user-defined taxonomies.
+        // When extend_defaults is false the user has elected a fully custom
+        // taxonomy, so the fuzzy tier must be suppressed entirely.
+        let fuzzy = if ruleset.extend_defaults {
+            Some(FuzzyClassifier)
+        } else {
+            None
+        };
         let llm = if config.use_llm {
             match LlmClassifier::from_provider(
                 &config.llm_provider,
@@ -336,17 +356,22 @@ impl ClassificationEngine {
             });
         }
 
-        // Tier 3.5: fuzzy heuristics
-        if let Some(mut result) = self.fuzzy.classify(message, is_merge) {
-            if result.ticket_id.is_none() {
-                result.ticket_id = RegexMatcher::extract_ticket_id(message);
+        // Tier 3.5: fuzzy heuristics (only when extend_defaults is true).
+        // The fuzzy tier emits hardcoded built-in category strings ("merge",
+        // "feature", "chore"). When the user's ruleset has extend_defaults:
+        // false the fuzzy field is None, and this block is skipped entirely.
+        if let Some(fuzzy) = &self.fuzzy {
+            if let Some(mut result) = fuzzy.classify(message, is_merge) {
+                if result.ticket_id.is_none() {
+                    result.ticket_id = RegexMatcher::extract_ticket_id(message);
+                }
+                // Re-resolve top_level via the engine's registry in case user
+                // overrides changed the parent for the fuzzy verdict's category.
+                if let Some(top) = self.taxonomy.resolve(&result.category) {
+                    result.top_level = Some(top);
+                }
+                return Some(result);
             }
-            // Re-resolve top_level via the engine's registry in case user
-            // overrides changed the parent for the fuzzy verdict's category.
-            if let Some(top) = self.taxonomy.resolve(&result.category) {
-                result.top_level = Some(top);
-            }
-            return Some(result);
         }
 
         None
@@ -472,6 +497,69 @@ mod tests {
             .classify_sync("INFRA-7 patch", false)
             .expect("verdict");
         assert!((v.confidence - 0.5).abs() < 1e-6);
+    }
+
+    /// Why: the fuzzy tier emits hardcoded built-in category strings
+    /// ("merge", "feature", "chore") that conflict with user-defined
+    /// taxonomies. It must be suppressed when `extend_defaults: false` so
+    /// the user's fully-custom ruleset is respected end-to-end.
+    /// What: build an engine from a minimal `extend_defaults: false` ruleset,
+    /// classify a bare merge commit message, and assert no verdict from the
+    /// fuzzy tier ("merge") is produced.
+    /// Test: pure cascade exercise, no DB or HTTP.
+    #[test]
+    fn fuzzy_tier_suppressed_when_extend_defaults_false() {
+        use crate::classify::rules::{Rule, RuleSet};
+        let ruleset = RuleSet {
+            version: None,
+            extend_defaults: false, // user has a custom-only taxonomy
+            rules: vec![Rule {
+                id: "my-deploy".to_string(),
+                category: "deployment".to_string(),
+                subcategory: None,
+                keywords: vec!["deploy:".to_string()],
+                patterns: vec![],
+                priority: 110,
+                confidence: 0.9,
+            }],
+        };
+        let engine = ClassificationEngine::new(ruleset, ClassificationEngineConfig::default())
+            .expect("engine builds");
+
+        // A merge-commit message that would normally fire the fuzzy tier.
+        let result = engine.classify_sync("Merge pull request #42 from main", true);
+        // With extend_defaults: false the fuzzy tier is suppressed — no
+        // verdict should be produced for this message since our custom
+        // ruleset has no rule that matches "Merge pull request".
+        assert!(
+            result.is_none(),
+            "fuzzy tier must not fire when extend_defaults is false; got: {result:?}"
+        );
+    }
+
+    /// Why: the fuzzy tier must still fire when `extend_defaults: true`
+    /// to preserve backward-compatible behaviour for users who opt in to
+    /// the built-in ruleset.
+    /// What: build an engine from the default ruleset (extend_defaults: true)
+    /// and classify a merge commit; assert the fuzzy tier fires.
+    /// Test: pure cascade exercise.
+    #[test]
+    fn fuzzy_tier_active_when_extend_defaults_true() {
+        let ruleset = {
+            let mut rs = default_rules();
+            rs.extend_defaults = true;
+            rs
+        };
+        let engine = ClassificationEngine::new(ruleset, ClassificationEngineConfig::default())
+            .expect("engine builds");
+
+        let result = engine.classify_sync("Merge pull request #42 from main", true);
+        assert!(
+            result.is_some(),
+            "fuzzy tier must fire for merge commits when extend_defaults is true"
+        );
+        let r = result.unwrap();
+        assert_eq!(r.category, "merge");
     }
 
     /// Why: exact-keyword conventional-commit prefixes (`fix:`, `feat:`)

--- a/crates/trusty-git-analytics/src/classify/rules/types.rs
+++ b/crates/trusty-git-analytics/src/classify/rules/types.rs
@@ -49,13 +49,20 @@ where
 /// the produced `category` / `subcategory`, a `priority` for tie-breaking,
 /// and a `confidence` (0.0–1.0).
 /// Test: covered by `classify::tests::exact_matcher_classifies_*` and
-/// `regex_matcher_*` test cases.
+/// `regex_matcher_*` test cases; unknown-field rejection covered by
+/// `tests::rule_unknown_field_is_rejected`.
 ///
 /// A rule matches when **any** of its `keywords` is present in the commit
 /// message (Tier 1) or **any** of its `patterns` matches (Tier 2). The
 /// resulting verdict carries the rule's `category`, `subcategory`, and
 /// `confidence`.
+///
+/// `deny_unknown_fields` closes the class of silent-drop bugs seen in
+/// issues #259 (`pattern:` vs `patterns:`) and #286 (`email_env:`). Any
+/// YAML key that is not a recognised field name (or alias) causes a loud
+/// parse error at load time rather than being silently ignored.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Rule {
     /// Unique rule identifier (used in logs and overrides).
     pub id: String,
@@ -137,8 +144,12 @@ fn default_rule_priority() -> i32 {
 /// composition explicit at the file level.
 /// What: holds the loaded version tag, the extend-defaults flag, and the
 /// vector of [`Rule`]s. Rules are not pre-sorted — use [`Self::by_priority`].
-/// Test: covered by `load_rules` round-trip in `classify::tests`.
+/// Test: covered by `load_rules` round-trip in `classify::tests`;
+/// unknown-field rejection covered by `tests::rule_set_unknown_field_is_rejected`.
+///
+/// `deny_unknown_fields` prevents silent YAML typos from going unnoticed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RuleSet {
     /// Optional schema version for forward compatibility.
     #[serde(default)]
@@ -275,5 +286,48 @@ pattern: "(?i)^feat[:(]"
         assert!(re.is_match("feat: add login flow"));
         assert!(re.is_match("feat(api): new endpoint"));
         assert!(!re.is_match("fix: null deref"));
+    }
+
+    /// Why: `deny_unknown_fields` on `Rule` must turn a field typo (e.g.
+    /// `method: regex_rule` — user's incidental bug from QA repro #286) into
+    /// a loud parse error at load time instead of silently being ignored.
+    /// What: attempt to deserialize a rule with `method: regex_rule` and
+    /// assert the result is `Err`.
+    /// Test: pure deserialization regression guard.
+    #[test]
+    fn rule_unknown_field_is_rejected() {
+        let yaml = r#"
+id: test-5
+category: bug_fix
+keywords: ["bugfix:"]
+method: regex_rule
+"#;
+        let result: Result<Rule, _> = serde_yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "Rule with unknown `method:` field must be rejected at parse time"
+        );
+    }
+
+    /// Why: `deny_unknown_fields` on `RuleSet` must reject a YAML typo in
+    /// the outer envelope (e.g. `extends_defaults:` instead of
+    /// `extend_defaults:`).
+    /// What: attempt to deserialize a rule set with a misspelled top-level
+    /// key and assert the result is `Err`.
+    /// Test: pure deserialization regression guard.
+    #[test]
+    fn rule_set_unknown_field_is_rejected() {
+        let yaml = r#"
+extends_defaults: false
+rules:
+  - id: my-rule
+    category: bug_fix
+    keywords: ["bugfix:"]
+"#;
+        let result: Result<RuleSet, _> = serde_yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "RuleSet with unknown `extends_defaults:` (typo) must be rejected"
+        );
     }
 }

--- a/crates/trusty-git-analytics/src/classify/sources/jira.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/jira.rs
@@ -159,9 +159,18 @@ pub fn classify_issue(issue: &JiraIssue, config: &JiraSourceConfig) -> Option<Ex
 ///
 /// Why: the HTTP call must be isolated here so the resolver can inject a
 /// mock client via its trait seam for testing.
+///
 /// What: issues `GET {base_url}/rest/api/3/issue/{key}?fields=issuetype,labels,components`
-/// with Basic auth (email + token) or Bearer auth (token-only). Returns
-/// `None` on any HTTP error or when the token env var is unset.
+/// with the auth mode determined by the config:
+///
+/// 1. `username` set (literal) → Basic auth with that literal email + token.
+/// 2. `email_env` set → Basic auth with `std::env::var(email_env)` + token
+///    (resolved at request time, not config-load time).
+/// 3. Neither set → Bearer auth (token-only; rare for Atlassian Cloud which
+///    requires Basic auth — a `warn!` is emitted).
+///
+/// Returns `None` on any HTTP error or when the token env var is unset.
+///
 /// Test: integration-tested via the resolver with wiremock in
 /// `resolver::tests`.
 ///
@@ -181,7 +190,9 @@ pub async fn fetch_issue(
         _ => {
             warn!(
                 token_env = %config.token_env,
-                "JIRA token env var is unset or empty; skipping external lookup"
+                "JIRA token env var `{}` is not set in the tga process environment — \
+                 did you `export {}` before running tga?",
+                config.token_env, config.token_env,
             );
             return None;
         }
@@ -192,10 +203,33 @@ pub async fn fetch_issue(
 
     let mut req = client.get(&url);
 
-    // Basic auth (email + token) if username is configured; otherwise Bearer.
+    // Auth priority:
+    //   1. username (literal email) — backward compat.
+    //   2. email_env (env-var indirection) — recommended for Atlassian Cloud.
+    //   3. Bearer token-only — unusual for Cloud; emit a warning.
     if let Some(username) = &config.username {
         req = req.basic_auth(username, Some(&token));
+    } else if let Some(env_name) = &config.email_env {
+        match std::env::var(env_name) {
+            Ok(email) if !email.is_empty() => {
+                req = req.basic_auth(email, Some(&token));
+            }
+            _ => {
+                warn!(
+                    email_env = %env_name,
+                    "JIRA email env var `{env_name}` is not set in the tga process \
+                     environment — did you `export {env_name}` before running tga? \
+                     Falling back to Bearer auth (may return 403 on Atlassian Cloud).",
+                );
+                req = req.bearer_auth(&token);
+            }
+        }
     } else {
+        warn!(
+            "No JIRA email configured (neither `username` nor `email_env` is set). \
+             Using Bearer auth — this typically returns HTTP 403 on Atlassian Cloud. \
+             Add `email_env: JIRA_EMAIL` to your source config.",
+        );
         req = req.bearer_auth(&token);
     }
 
@@ -312,6 +346,7 @@ mod tests {
             base_url: "https://acme.atlassian.net".to_string(),
             token_env: "JIRA_API_TOKEN".to_string(),
             username: None,
+            email_env: None,
             project_keys: vec![],
             field_mappings: Default::default(),
         };
@@ -353,6 +388,7 @@ mod tests {
             base_url: "https://acme.atlassian.net".to_string(),
             token_env: "JIRA_API_TOKEN".to_string(),
             username: None,
+            email_env: None,
             project_keys: vec![],
             field_mappings: Default::default(),
         };
@@ -386,9 +422,56 @@ mod tests {
             base_url: "https://acme.atlassian.net".to_string(),
             token_env: "JIRA_API_TOKEN".to_string(),
             username: None,
+            email_env: None,
             project_keys: vec![],
             field_mappings: Default::default(),
         };
         assert!(classify_issue(&issue, &config).is_none());
+    }
+
+    /// Why: `email_env` round-trips through YAML deserialization so users who
+    /// write `email_env: JIRA_EMAIL` in their config get the field populated
+    /// rather than a silent unknown-field error.
+    /// What: deserialize a JIRA source config with `email_env:` and assert the
+    /// field is `Some("JIRA_EMAIL")`.
+    /// Test: pure deserialization; no HTTP.
+    #[test]
+    fn jira_config_email_env_deserializes() {
+        use super::super::SourceConfig;
+        let yaml = r#"
+type: jira
+base_url: "https://acme.atlassian.net"
+token_env: JIRA_API_TOKEN
+email_env: JIRA_EMAIL
+project_keys: ["PROJ"]
+"#;
+        let cfg: SourceConfig = serde_yaml::from_str(yaml).expect("deserialize");
+        match cfg {
+            SourceConfig::Jira(j) => {
+                assert_eq!(j.email_env.as_deref(), Some("JIRA_EMAIL"));
+                assert_eq!(j.username, None);
+            }
+            other => panic!("expected Jira variant, got {other:?}"),
+        }
+    }
+
+    /// Why: `deny_unknown_fields` on `JiraSourceConfig` must turn a YAML typo
+    /// (e.g. `emial_env:`) into a loud parse error instead of silently
+    /// dropping the field.
+    /// What: attempt to deserialize a config with an unknown field and assert
+    /// the result is `Err`.
+    /// Test: pure deserialization; no HTTP.
+    #[test]
+    fn jira_config_unknown_field_is_rejected() {
+        let yaml = r#"
+type: jira
+base_url: "https://acme.atlassian.net"
+token_env: JIRA_API_TOKEN
+emial_env: JIRA_EMAIL
+"#;
+        // The SourceConfig tagged enum peels off `type:` before forwarding to
+        // JiraSourceConfig, so this error surfaces via the inner struct.
+        let result: Result<super::super::SourceConfig, _> = serde_yaml::from_str(yaml);
+        assert!(result.is_err(), "unknown field must be rejected");
     }
 }

--- a/crates/trusty-git-analytics/src/classify/sources/mod.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/mod.rs
@@ -50,8 +50,10 @@ pub enum SourceConfig {
 /// What: holds the JIRA base URL, the environment-variable name carrying the
 /// API token, the project keys to scope queries to, and field mappings that
 /// convert JIRA issue_type/labels/components to TGA category strings.
-/// Test: see `tests::jira_config_deserializes` in this module.
+/// Test: see `tests::jira_source_config_deserializes` and
+/// `tests::jira_source_config_email_env_deserializes` in this module.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct JiraSourceConfig {
     /// JIRA Cloud / Server base URL (e.g. `https://yourco.atlassian.net`).
     pub base_url: String,
@@ -64,10 +66,37 @@ pub struct JiraSourceConfig {
     #[serde(default = "default_jira_token_env")]
     pub token_env: String,
 
-    /// Optional JIRA username (email) for Basic-auth token requests.
-    /// If omitted, the token is passed as a Bearer token.
+    /// Optional JIRA username (literal email) for Basic-auth requests.
+    ///
+    /// If set, this literal string is used as the Basic-auth username
+    /// together with the token from `token_env`. Kept for backward
+    /// compatibility. Prefer `email_env` for new configurations so the
+    /// email address is not stored in the config file.
+    ///
+    /// If both `username` and `email_env` are present, `username` wins.
+    /// If neither is set, the token is sent as a Bearer token (uncommon
+    /// for Atlassian Cloud, which requires Basic auth).
     #[serde(default)]
     pub username: Option<String>,
+
+    /// Name of the environment variable carrying the JIRA user email.
+    ///
+    /// Mirrors `token_env` for the email half of Atlassian Cloud Basic
+    /// auth. The env var is resolved at request time (not at config-load)
+    /// so `export JIRA_EMAIL=you@co.com` before running `tga` is
+    /// sufficient even if the config file was loaded before the export.
+    ///
+    /// Example YAML:
+    /// ```yaml
+    /// type: jira
+    /// base_url: "https://yourco.atlassian.net"
+    /// token_env: JIRA_API_TOKEN
+    /// email_env: JIRA_EMAIL          # <-- recommended for Atlassian Cloud
+    /// ```
+    ///
+    /// Ignored when `username` is also set (literal wins).
+    #[serde(default)]
+    pub email_env: Option<String>,
 
     /// Limit queries to issues under these project keys.
     /// Empty list means no project filter (query any project found in commits).
@@ -98,6 +127,7 @@ fn default_jira_token_env() -> String {
 /// What: three sub-maps — `issue_type`, `labels`, and `components`.
 /// Test: covered by `jira::tests::field_mapping_resolves_issue_type`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct JiraFieldMappings {
     /// Maps JIRA issue-type names (e.g. `"Story"`, `"Bug"`) to TGA categories.
     #[serde(default)]
@@ -121,6 +151,7 @@ pub struct JiraFieldMappings {
 /// label-to-category mapping.
 /// Test: see `tests::github_issues_config_deserializes`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct GithubIssuesSourceConfig {
     /// Repository slug in `owner/name` form, e.g. `"acme/widgets"`.
     ///
@@ -221,6 +252,37 @@ field_mappings:
                     j.field_mappings.labels.get("ktlo"),
                     Some(&"tech_debt_refactoring".to_string())
                 );
+            }
+            other => panic!("expected Jira variant, got {other:?}"),
+        }
+    }
+
+    /// Why: `email_env:` is the recommended way for Atlassian Cloud users to
+    /// supply the Basic-auth email address without storing it in config files.
+    /// Before this fix the field didn't exist, so YAML configs with `email_env:`
+    /// would have the field silently dropped (serde default = None), causing
+    /// Bearer auth and HTTP 403 on every JIRA call.
+    /// What: deserialize a Jira source config with `email_env: JIRA_EMAIL` and
+    /// assert the field is populated; `username` should remain `None`.
+    /// Test: pure deserialization; no HTTP.
+    #[test]
+    fn jira_source_config_email_env_deserializes() {
+        let yaml = r#"
+type: jira
+base_url: "https://duettoresearch.atlassian.net"
+token_env: JIRA_API_TOKEN
+email_env: JIRA_EMAIL
+project_keys: ["DUE"]
+"#;
+        let cfg: SourceConfig = serde_yaml::from_str(yaml).expect("deserialize");
+        match cfg {
+            SourceConfig::Jira(j) => {
+                assert_eq!(j.email_env.as_deref(), Some("JIRA_EMAIL"));
+                assert_eq!(
+                    j.username, None,
+                    "username must remain None when only email_env is set"
+                );
+                assert_eq!(j.token_env, "JIRA_API_TOKEN");
             }
             other => panic!("expected Jira variant, got {other:?}"),
         }

--- a/crates/trusty-git-analytics/src/classify/sources/resolver.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/resolver.rs
@@ -309,6 +309,7 @@ mod tests {
             base_url: "https://acme.atlassian.net".to_string(),
             token_env: "JIRA_API_TOKEN".to_string(),
             username: None,
+            email_env: None,
             project_keys: vec!["PROJ".to_string()],
             field_mappings: JiraFieldMappings::default(),
         };
@@ -351,6 +352,7 @@ mod tests {
             base_url: server.uri(),
             token_env: "JIRA_API_TOKEN_TEST_BUG".to_string(),
             username: None,
+            email_env: None,
             project_keys: vec![],
             field_mappings: JiraFieldMappings {
                 issue_type: issue_type_map,
@@ -407,6 +409,7 @@ mod tests {
             base_url: server.uri(),
             token_env: "JIRA_API_TOKEN_CACHE_TEST".to_string(),
             username: None,
+            email_env: None,
             project_keys: vec![],
             field_mappings: JiraFieldMappings {
                 issue_type: issue_type_map,
@@ -443,6 +446,7 @@ mod tests {
             base_url: "https://acme.atlassian.net".to_string(),
             token_env: "JIRA_TOKEN_DEFINITELY_NOT_SET_XYZ".to_string(),
             username: None,
+            email_env: None,
             project_keys: vec![],
             field_mappings: JiraFieldMappings::default(),
         };

--- a/crates/trusty-git-analytics/src/core/config/mod.rs
+++ b/crates/trusty-git-analytics/src/core/config/mod.rs
@@ -267,7 +267,12 @@ pub struct OutputConfig {
 }
 
 /// Classification cascade configuration.
+///
+/// `deny_unknown_fields` closes the class of silent-drop bugs seen in
+/// issues #259 and #286. Any YAML key under `classification:` that is not
+/// a recognised field is rejected at load time with a clear error message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ClassificationConfig {
     /// Path to user-supplied rules YAML/JSON.
     #[serde(default)]
@@ -1019,6 +1024,24 @@ mod tests {
         assert!(
             msg.contains("ticket_regex"),
             "error should name the field: {msg}"
+        );
+    }
+
+    /// Why: `deny_unknown_fields` on `ClassificationConfig` closes the
+    /// silent-drop bug class. An unknown key under `classification:` (e.g. a
+    /// YAML typo) must be rejected loudly at parse time.
+    /// What: deserialize a `ClassificationConfig` fragment containing an
+    /// unknown field and assert the result is `Err`.
+    /// Test: pure deserialization regression guard.
+    #[test]
+    fn classification_config_unknown_field_is_rejected() {
+        // `rules_path:` is a plausible typo for `rules_file:`.
+        let yaml = "rules_path: ./my-rules.yaml\nuse_llm: false\n";
+        let result: std::result::Result<ClassificationConfig, serde_yaml::Error> =
+            serde_yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "ClassificationConfig with unknown `rules_path:` must be rejected"
         );
     }
 }


### PR DESCRIPTION
## Summary

Four QA-confirmed fixes bundled as tga 1.2.2 (closes #286).

### Fix 1: `email_env` field on `JiraSourceConfig` (root cause of #286)

**Bug**: `JiraSourceConfig` had only `username: Option<String>` (literal email). User configs use `email_env: JIRA_EMAIL` (env-var indirection, mirroring `token_env`). serde silently dropped `email_env:` (no `deny_unknown_fields`), `username=None`, code fell back to Bearer auth, Atlassian Cloud returned 403 on every call.

**Fix**: Added `email_env: Option<String>` field. `fetch_issue()` auth priority: (1) `username` literal → Basic, (2) `email_env` env-var → Basic, (3) neither → Bearer (with warning). Env var resolved at request time so `export JIRA_EMAIL=...` after process start works.

### Fix 2: `JIRA token env var unset` intermittent warning (secondary symptom)

**Finding**: Not a code bug. Env vars are resolved at request time in `fetch_issue()` — there's no eager caching at config-load. The intermittent warning was caused by the user's shell sessions having inconsistent exports. Added a more descriptive warning message that names the env var and prompts the user to check their export.

### Fix 3: Fuzzy tier respects `extend_defaults: false`

**Bug**: `FuzzyClassifier` ran unconditionally, emitting hardcoded built-in category strings (`merge`, `feature`, `chore`). `extend_defaults: false` didn't gate it.

**Fix**: `ClassificationEngine.fuzzy` is now `Option<FuzzyClassifier>`. Set to `None` when `extend_defaults: false` in the loaded ruleset. The principle is: `extend_defaults: false` means "no built-in classification of any kind."

### Fix 4: `#[serde(deny_unknown_fields)]` on classify config types

Three same-class silent-drop bugs in one release cycle (`pattern:` vs `patterns:`, `email_env:`, `method:` on rules). Strict schema applied to:
- `JiraSourceConfig`, `GithubIssuesSourceConfig`, `JiraFieldMappings` (sources/mod.rs)
- `ClassificationConfig` (core/config/mod.rs)
- `Rule`, `RuleSet` (classify/rules/types.rs)

Note: `SourceConfig` (tagged enum) was intentionally excluded — `deny_unknown_fields` + internally-tagged enums have known serde compatibility issues.

**User's rules file (`tga-classification-rules.yaml`)**: now rejects at parse time because every rule has `method: "regex_rule"` (the incidental bug from QA). User must remove `method:` from their rules. This is the correct behavior — the field never had any effect.

---

## End-to-End SQL Verification (tga 1.2.2 binary, `~/Duetto/cto`, `duettoresearch.atlassian.net`)

Test run: April 2026 window (3,013+ commits), patched rules file (method fields stripped):

```
Classified 3691/4472 commits (82.5% coverage)
By method:
  fuzzy_match: 781
  external_source: 834
  regex_rule: 2857
```

```sql
SELECT c.method, COUNT(*) FROM classifications c JOIN commits cm ON cm.classification_id = c.id WHERE cm.timestamp >= '2026-04-01' GROUP BY c.method;
-- external_source|834
-- fuzzy_match|781
-- regex_rule|2857

SELECT c.category, COUNT(*) FROM classifications c JOIN commits cm ON cm.classification_id = c.id WHERE cm.timestamp >= '2026-04-01' AND c.method = 'fuzzy_match' GROUP BY c.category;
-- uncategorized|781
```

**Results confirm**:
- `external_source: 834` — JIRA Basic auth via `email_env` is firing (was 0 before, 391+ × HTTP 403)
- `fuzzy_match` rows are exclusively `uncategorized` (the unclassified fallback) — zero built-in categories (`merge`, `feature`, `chore`) leaking from the fuzzy tier
- No "JIRA token env var unset" or 403 warnings in logs

---

## Test Plan

- [x] `cargo clippy -p tga --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt -p tga -- --check` — clean
- [x] `cargo test -p tga` — 445 tests pass (8 new tests added)
- [x] New tests: `fuzzy_tier_suppressed_when_extend_defaults_false`, `fuzzy_tier_active_when_extend_defaults_true`, `jira_source_config_email_env_deserializes`, `jira_config_email_env_deserializes`, `jira_config_unknown_field_is_rejected`, `rule_unknown_field_is_rejected`, `rule_set_unknown_field_is_rejected`, `classification_config_unknown_field_is_rejected`
- [x] E2E against `~/Duetto/cto` with worktree binary — `external_source: 834`, zero fuzzy built-in categories
- [x] `cargo check --workspace` — clean

## Note for users upgrading from 1.2.1

If your rules YAML has `method:` on any rule entry, update to remove it — the field was never used but is now rejected with a clear error message listing valid fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)