### PR TITLE
docs(trusty-search): document RAM-check bypass (#291)

### DIFF
--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -10,7 +10,7 @@ one always-on daemon, unlimited named indexes.
 ## System requirements
 
 - **Rust 1.75+** (for source builds)
-- **16 GB RAM minimum** — hard-checked at daemon startup; the daemon will not start on under-spec machines
+- **16 GB RAM minimum (default)** — hard-checked at daemon startup. The daemon exits with an actionable error message on under-spec hosts. Set `TRUSTY_SKIP_RAM_CHECK=1` in the daemon environment to bypass this check for small workloads where peak RAM is known to stay well under the memory limit. Bypass at your own risk on large corpora — the default exists because realistic indexing OOMs without it.
 - **macOS 12+ or Linux** (Windows: not yet supported)
 - **~2 GB disk** for model cache (downloaded on first run to `~/Library/Caches/trusty-search/` on macOS or `$XDG_DATA_HOME/trusty-search/` on Linux)
 
@@ -291,7 +291,7 @@ trusty-search reindex [path]                         # alias for index --force
 Run `trusty-search doctor` for a 6-check diagnostic. Common causes:
 - Another daemon already running: `trusty-search stop` then `trusty-search start`
 - Stale PID lockfile: `trusty-search doctor --fix` removes it automatically
-- Less than 16 GB RAM: the daemon performs a hard RAM check and exits with an error
+- Less than 16 GB RAM: the daemon performs a hard RAM check and exits with an actionable error. Set `TRUSTY_SKIP_RAM_CHECK=1` in the daemon environment to bypass for small workloads; not recommended on large corpora (risk of OOM during indexing)
 
 **Embedder stuck on "initializing"**
 


### PR DESCRIPTION
## Summary

- Fixes `crates/trusty-search/README.md` to accurately reflect that the 16 GB RAM check has a `TRUSTY_SKIP_RAM_CHECK=1` bypass (re-added in PR #237 but never documented)
- Closes #291 (RAM-check doc accuracy)
- Closes #292 (crates.io yank — handled out-of-band via `cargo yank`, detailed below)

## README changes

Two spots updated:

**System requirements bullet (line 13):** Changed from the absolute "the daemon will not start on under-spec machines" to:
> 16 GB RAM minimum (default) — hard-checked at daemon startup. The daemon exits with an actionable error message on under-spec hosts. Set `TRUSTY_SKIP_RAM_CHECK=1` in the daemon environment to bypass this check for small workloads where peak RAM is known to stay well under the memory limit. Bypass at your own risk on large corpora — the default exists because realistic indexing OOMs without it.

**Troubleshooting section (line 294):** Changed from "hard RAM check and exits with an error" to also document the bypass and OOM risk.

## crates.io yank (out-of-band, closes #292)

Three crates marked `publish = false` locally had stale versions on crates.io. All three have been yanked. Results verified via the crates.io API:

| Crate | Version yanked | crates.io `yanked` field |
|---|---|---|
| `open-mpm` | 0.38.3 | `true` (was already yanked prior to this PR) |
| `open-mpm-agent-api` | 0.1.0 | `true` (yanked during this workflow) |
| `trusty-gworkspace` | 0.1.0 | `true` (was already yanked prior to this PR) |

Note: the issue draft referenced `open-mpm@0.0.0` and `trusty-gworkspace@0.0.0` as the versions to yank, but those versions do not exist on crates.io. The actual published versions (0.38.3 and 0.1.0 respectively) were already yanked. `open-mpm-agent-api@0.1.0` was the one live un-yanked version and was successfully yanked by this workflow.

Yanking is non-destructive — crate pages remain visible, but Cargo will refuse to resolve to a yanked version and users see a "yanked" tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)