### PR TITLE
chore(trusty-common): bump to 0.6.2 — expose sync KG methods for trusty-memory 0.6.0 publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 
 [workspace.dependencies]
 # ── Internal crates (path deps so the monorepo builds without publish cycles) ──
-trusty-common = { path = "crates/trusty-common", version = "0.6.1" }
+trusty-common = { path = "crates/trusty-common", version = "0.6.2" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.1" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -14,7 +14,7 @@ name = "gworkspace-mcp"
 path = "src/bin/gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.6.1", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.6.2", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/bin/bm25_daemon.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.6.1", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help"] }
+trusty-common = { path = "../trusty-common", version = "0.6.2", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help"] }
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
 #      trusty-memory — one install command, three binaries. The shim at

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -48,7 +48,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.6.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216)
+trusty-common = { version = "0.6.2", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216)
 
 # ── Bundled sidecar ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
## Summary

- Bumps `trusty-common` from `0.6.1` → `0.6.2`
- Propagates the minimum version pin in workspace root, `trusty-memory`, `trusty-search`, `trusty-gworkspace`

## Why

PR #294 added three new public methods to `KnowledgeGraph` in `trusty-common`:
`assert_sync`, `upsert_drawer_sync`, and `store()`. These are required by the
`trusty-memory migrate kuzu-data` command introduced in #294.

The `0.6.1` tag on crates.io predates these methods. When `cargo publish --dry-run`
for `trusty-memory 0.6.0` verifies the tarball, it resolves `trusty-common = "0.6.1"`
from the registry (not the in-tree path), and the build fails because those methods
don't exist in the published version.

## Test plan

- [x] `cargo check` passes workspace-wide
- [x] All five changed files only touch the version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)