### PR TITLE
chore(trusty-search): bump 0.13.1 -> 0.13.2 (docs marker)

### DIFF
--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Patch-bumps trusty-search 0.13.1 → 0.13.2 with no source changes. Marks the next published release that captures the v0.13.1 regression-testing snapshot and Phase 3 async-symbol-graph RFC landed in this session's docs commits.

## Why
Aligns the crates.io version history with the v0.13.1-2026-05-27 snapshot doc so consumers querying `cargo info trusty-search` see the freshest version corresponding to the documented baseline.

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -p trusty-search --all-targets -- -D warnings
- [x] cargo test -p trusty-search
- [x] cargo publish --dry-run -p trusty-search

🤖 Generated with [Claude Code](https://claude.com/claude-code)