### PR TITLE
fix(tga): IssueType+JiraProject tiers now report ExternalSource method (closes #321)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2026-05-27
+
+### Fixed
+
+- **`JiraProjectTier` (Tier 1.6) and `IssueTypeTier` (Tier 1.5) misreport classification method (#319)** — Commits classified via `jira.jira_project_mappings` (Tier 1.6) were persisted with `method = 'regex_rule'` instead of `'external_source'`, causing JIRA project-key-driven verdicts to be attributed to the regex bucket in analytics dashboards. Similarly, PM issue-type-driven verdicts (Tier 1.5, e.g. JIRA `"Bug"` → `bugfix`, Linear `"Story"` → `feature`) were misreported as `'exact_rule'`. Both tiers now correctly emit `ClassificationMethod::ExternalSource` since classification is driven by external ticket-system metadata, not commit-message text patterns. The regression became observable after the 1.5.2 fix to inline `commits.ticket_id` population (#316) — once users could see which commits had JIRA ticket IDs, the misattributed method in `classifications.method` was detectable. No schema migration required; re-running `tga classify` on affected date ranges will repopulate the correct method values.
+
 ## [1.5.2] - 2026-05-27
 
 ### Fixed

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "1.5.2"
+version = "1.5.3"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for

--- a/crates/trusty-git-analytics/src/classify/classifier.rs
+++ b/crates/trusty-git-analytics/src/classify/classifier.rs
@@ -623,9 +623,12 @@ mod tests {
 
     /// Why: exact-keyword conventional-commit prefixes (`fix:`, `feat:`)
     /// must still beat the JIRA mapping — they encode developer intent
-    /// at much higher confidence than the project key.
+    /// at much higher confidence than the project key. The cascade runs
+    /// Tier 1 (ExactRule) before Tier 1.6 (JiraProjectTier), so the
+    /// cc-fix ExactRule verdict is returned before the JIRA tier is
+    /// consulted.
     /// What: classify a `fix: TQL-1 ...` message with a TQL mapping
-    /// configured; assert the cc-fix rule wins.
+    /// configured; assert the cc-fix rule wins and reports ExactRule.
     /// Test: pure cascade exercise.
     #[test]
     fn exact_rule_still_beats_jira_project_mapping() {
@@ -644,5 +647,39 @@ mod tests {
             .expect("verdict");
         assert_eq!(v.category, "bugfix");
         assert_eq!(v.method, ClassificationMethod::ExactRule);
+    }
+
+    /// Why: the JIRA project-key tier (Tier 1.6) must report
+    /// `ExternalSource` rather than `RegexRule` so that analytics
+    /// dashboards correctly attribute JIRA-project-driven verdicts to the
+    /// external-source bucket. Before tga 1.5.3 the wrong method caused
+    /// JIRA contribution to appear as ~1% (`regex_rule`) when it should
+    /// have been 5–10% (`external_source`) (issue #319).
+    /// What: classify a bare JIRA-key message with a project mapping and
+    /// assert the verdict's method is `ExternalSource`.
+    /// Test: pure cascade exercise, no DB.
+    #[test]
+    fn jira_project_tier_reports_external_source_method() {
+        let mut mappings = HashMap::new();
+        mappings.insert("TQL".to_string(), "bug_fix".to_string());
+        let engine = ClassificationEngine::with_taxonomy_and_mappings(
+            default_rules(),
+            ClassificationEngineConfig::default(),
+            Vec::new(),
+            mappings,
+            None,
+        )
+        .expect("engine builds");
+        // No conventional-commit prefix: the JIRA project tier fires (not ExactRule).
+        let v = engine
+            .classify_sync("TQL-1234 fix null pointer", false)
+            .expect("verdict");
+        assert_eq!(
+            v.method,
+            ClassificationMethod::ExternalSource,
+            "JIRA project-key mapping must report ExternalSource, not RegexRule"
+        );
+        assert_eq!(v.category, "bug_fix");
+        assert_eq!(v.ticket_id.as_deref(), Some("TQL-1234"));
     }
 }

--- a/crates/trusty-git-analytics/src/classify/tiers/issue_type_tier.rs
+++ b/crates/trusty-git-analytics/src/classify/tiers/issue_type_tier.rs
@@ -91,7 +91,16 @@ impl IssueTypeTier {
             subcategory: None,
             top_level: Some(top_level),
             confidence: ISSUE_TYPE_CONFIDENCE,
-            method: ClassificationMethod::ExactRule,
+            // Why: the verdict is derived from a PM-system issue type field
+            // (e.g. JIRA `"Bug"`, Linear `"Story"`) — an external ticket-system
+            // signal, not a commit-message heuristic. Using `ExactRule` here
+            // caused PM-issue-type-classified commits to report as `exact_rule`
+            // in analytics, conflating rule-file keyword matches with PM
+            // metadata signals. `ExternalSource` is the correct label — it
+            // covers all paths where classification is driven by external
+            // ticket-system metadata rather than message-text patterns.
+            // Fixed in tga 1.5.3 (issue #319).
+            method: ClassificationMethod::ExternalSource,
             ticket_id: None,
             complexity: None,
         })

--- a/crates/trusty-git-analytics/src/classify/tiers/jira_project_tier.rs
+++ b/crates/trusty-git-analytics/src/classify/tiers/jira_project_tier.rs
@@ -131,7 +131,16 @@ impl JiraProjectTier {
             subcategory: None,
             top_level: Some(top_level),
             confidence: self.confidence,
-            method: ClassificationMethod::RegexRule,
+            // Why: the verdict comes from an external JIRA project-key mapping
+            // (operator-supplied semantic context), not from a regex pattern
+            // in the commit message. Labelling it `RegexRule` caused all
+            // JIRA-project-mapped commits to appear as `regex_rule` in the
+            // `classifications.method` column, hiding the JIRA contribution
+            // from analytics dashboards (issue #319 / tga 1.5.3 regression
+            // fix). `ExternalSource` is the correct label — it covers all
+            // paths where classification is driven by external ticket-system
+            // metadata rather than message-text heuristics.
+            method: ClassificationMethod::ExternalSource,
             ticket_id,
             complexity: None,
         })


### PR DESCRIPTION
## Summary

Two cascade tiers (`IssueTypeTier`, `JiraProjectTier`) were emitting the wrong `ClassificationMethod` variant — `ExactRule` and `RegexRule` respectively, when both should have reported `ExternalSource`. This caused JIRA-driven verdicts to be misattributed in analytics buckets and held `external_source`'s visible share near ~1% instead of the expected ~5-10%.

**Closes #321.** Version bump: tga 1.5.2 → 1.5.3 (patch).

## Why this was invisible until 1.5.2

PR #318 (1.5.2, closes #316) fixed `commits.ticket_id` being NULL during `tga collect`. Before that, no commits even had `ticket_id` to look up — so the misnamed method on JIRA-attributed rows was invisible. The user spotted it the moment ticket_ids started appearing on commit rows.

## Root cause

Both tiers classify based on **external ticket-system metadata** (PM issue type fields, JIRA project-key mappings), NOT commit-message text patterns. `ExternalSource` is the semantically correct provenance label.

| Tier | File | Before | After |
|------|------|--------|-------|
| 1.5 `IssueTypeTier` | `classify/tiers/issue_type_tier.rs` | `ExactRule` | `ExternalSource` |
| 1.6 `JiraProjectTier` | `classify/tiers/jira_project_tier.rs` | `RegexRule` | `ExternalSource` |

The tiers were firing and winning correctly — they just reported the wrong provenance to downstream analytics, which swallowed their contribution into the `regex_rule` / `exact_rule` buckets.

## Fix

Two single-line method-label changes (one per tier), each accompanied by a Why-comment explaining the semantic justification. No structural change to the cascade.

## Regression test

Added `jira_project_tier_reports_external_source_method` in `classifier.rs` — pins the contract so a future copy-paste can't reintroduce the mismatch.

## Migration

Existing `tga.db` files have wrong `classification_method` on JIRA-eligible commits. Users should **re-run `tga classify`** on affected date ranges to overwrite `regex_rule` / `exact_rule` rows with `external_source`. No schema change, no new `backfill` subcommand needed — the existing classify pipeline will produce correct labels on re-run.

## Test plan

- [x] `cargo test -p tga`: 66 lib + 1 integration + 3 doc tests passing, 0 failed
- [x] `cargo clippy -p tga --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] New regression test pins the contract
- [x] All pre-existing tier tests still pass (no other downstream method-label assertions broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)