### PR TITLE
feat(tga): --author <email> filter on report subcommand (closes #324)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2026-05-28
+
+### Added
+
+- **`--author <email>` filter on `tga report` (#324)** — Scope any report run
+  to a single canonical identity by passing `--author <canonical_email>`.  The
+  filter matches case-insensitively against the `canonical_email` field in the
+  `authors` table, so `ALICE@EXAMPLE.COM` and `alice@example.com` are
+  equivalent.  All formatters (CSV, JSON, Markdown) receive the single-engineer
+  `ReportData` unchanged — no formatter logic was modified.  When the supplied
+  email does not match any canonical identity, `tga report` exits non-zero with
+  a helpful message directing the user to `tga aliases list`.
+  Omitting `--author` preserves the existing full-team aggregate behaviour.
+
 ## [1.5.3] - 2026-05-27
 
 ### Fixed

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "1.5.3"
+version = "1.5.4"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -268,16 +268,28 @@ Stage 3: generate reports from classified commits.
 ```bash
 tga report [--config <PATH>] [--database <PATH>]
            [--output <DIR>] [--formats <FMT,...>]
+           [--author <EMAIL>]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--output <DIR>` | Override `output.directory` from config |
 | `--formats <FMT,...>` | Comma-separated: `csv`, `json`, `markdown` |
+| `--author <EMAIL>` | Scope report to one canonical identity (matches `canonical_email` case-insensitively) |
 
 ```bash
+# Full team report
 tga report --output ./q1-reports --formats csv,json
+
+# Single-engineer report
+tga report --author alice@example.com --output ./alice-q1
+
+# List available canonical identities
+tga aliases list
 ```
+
+If `--author` is supplied but the email is not in the `authors` table, `tga report`
+exits non-zero with a suggestion to run `tga aliases list`.
 
 ### tga pr-metrics
 

--- a/crates/trusty-git-analytics/src/commands/report.rs
+++ b/crates/trusty-git-analytics/src/commands/report.rs
@@ -8,8 +8,14 @@ use crate::ReportArgs;
 
 /// Generate reports from the classified commits stored in `db`.
 ///
-/// Applies `--output` and `--formats` CLI overrides on top of the
-/// [`OutputConfig`] in the loaded YAML config.
+/// Why: provides a focused entry point for stage-3 report generation so the
+/// binary can apply CLI overrides (output directory, formats, author filter)
+/// without polluting the pipeline or aggregator with argument-parsing logic.
+/// What: materialises an `OutputConfig` if none exists yet, applies
+/// `--output` / `--formats` / `--author` overrides, then delegates to
+/// [`ReportPipeline::run`].
+/// Test: covered indirectly via `report::tests::pipeline_runs_all_formats_when_unspecified`;
+/// the `--author` path is unit-tested in `report::tests::aggregator_author_filter_*`.
 pub fn run(config: Config, db: &Database, args: ReportArgs) -> anyhow::Result<()> {
     let mut cfg = config;
 
@@ -27,7 +33,7 @@ pub fn run(config: Config, db: &Database, args: ReportArgs) -> anyhow::Result<()
     }
 
     let pipeline = ReportPipeline::new(cfg);
-    let stats = pipeline.run(db)?;
+    let stats = pipeline.run_with_filter(db, args.author.as_deref())?;
 
     println!(
         "Generated {} report file(s) ({} commits, {} authors)",

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -336,6 +336,13 @@ pub struct ReportArgs {
     /// Output formats (csv, json, markdown — comma-separated).
     #[arg(long, value_delimiter = ',')]
     pub formats: Vec<String>,
+    /// Scope the report to a single canonical identity.
+    ///
+    /// Must match the `canonical_email` field in the `authors` table
+    /// (case-insensitive). If the email is not found, `tga report`
+    /// exits non-zero and suggests `tga aliases list`.
+    #[arg(long, value_name = "EMAIL")]
+    pub author: Option<String>,
 }
 
 /// Run config validation and decide whether the caller should exit.

--- a/crates/trusty-git-analytics/src/report/aggregator.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator.rs
@@ -13,7 +13,7 @@ use tracing::{debug, warn};
 
 use crate::core::config::Config;
 use crate::core::db::Database;
-use crate::report::errors::Result;
+use crate::report::errors::{ReportError, Result};
 use crate::report::models::{
     ActivityWeights, AuthorSummary, DeveloperActivitySummary, DoraMetrics, QualitySummary,
     ReportData, ReportSummary, RepositorySummary, UntrackedCommit, VelocitySummary, WeeklyActivity,
@@ -141,9 +141,48 @@ impl Aggregator {
     ///
     /// Returns [`crate::report::ReportError::Core`] if the underlying queries fail.
     pub fn build(db: &Database, config: &Config) -> Result<ReportData> {
-        let rows = Self::load_rows(db)?;
+        Self::build_filtered(db, config, None)
+    }
+
+    /// Build a [`ReportData`] optionally scoped to one canonical identity.
+    ///
+    /// Why: `tga report --author <email>` lets users drill into a single
+    /// engineer's contribution without generating a full team report.
+    /// What: when `author_email` is `Some`, validates that the email exists
+    /// in the `authors` table (case-insensitive) before filtering the commit
+    /// rows to that identity; when `None`, behaves identically to
+    /// [`Self::build`].
+    /// Test: see `report::tests::aggregator_author_filter_returns_single_author`
+    /// and `aggregator_author_filter_unknown_email_errors`.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`ReportError::Report`] (exit-non-zero) when `author_email`
+    ///   is provided but does not match any `canonical_email` in the
+    ///   `authors` table.
+    /// - Returns [`crate::report::ReportError::Core`] if underlying queries fail.
+    pub fn build_filtered(
+        db: &Database,
+        config: &Config,
+        author_email: Option<&str>,
+    ) -> Result<ReportData> {
+        // Validate and canonicalize the author filter before loading rows.
+        let canonical_email: Option<String> = if let Some(email) = author_email {
+            let resolved = Self::resolve_canonical_email(db, email)?;
+            Some(resolved)
+        } else {
+            None
+        };
+
+        let rows = Self::load_rows_filtered(db, canonical_email.as_deref())?;
         let prs = Self::load_prs(db).unwrap_or_default();
-        let unresolved_db = Self::count_unresolved_author_commits(db).unwrap_or(0);
+        let unresolved_db = if canonical_email.is_none() {
+            Self::count_unresolved_author_commits(db).unwrap_or(0)
+        } else {
+            // When scoped to one author, the "unresolved" count is not
+            // meaningful for the per-author view — suppress it.
+            0
+        };
         let mut data = Self::aggregate(rows, prs);
 
         // Issue #68 / #67: surface coverage and unresolved-identity counts
@@ -242,7 +281,48 @@ impl Aggregator {
         Ok(out)
     }
 
-    fn load_rows(db: &Database) -> Result<Vec<CommitRow>> {
+    /// Resolve an author email filter to the stored `canonical_email`.
+    ///
+    /// Why: `canonical_email` values in the DB may differ in case from what
+    /// the user typed; resolving once up-front ensures the SQL `WHERE` clause
+    /// uses the exact stored value and produces consistent results across
+    /// collation settings.
+    /// What: queries `authors` with a case-insensitive match on
+    /// `LOWER(canonical_email)`; returns the stored value on success, or a
+    /// helpful `ReportError::Report` that names the `tga aliases list`
+    /// remedy when no match exists.
+    /// Test: see `report::tests::aggregator_author_filter_unknown_email_errors`.
+    fn resolve_canonical_email(db: &Database, email: &str) -> Result<String> {
+        let conn = db.connection();
+        let lower = email.to_lowercase();
+        let result: rusqlite::Result<String> = conn.query_row(
+            "SELECT canonical_email FROM authors WHERE LOWER(canonical_email) = LOWER(?1) LIMIT 1",
+            rusqlite::params![lower],
+            |row| row.get(0),
+        );
+        match result {
+            Ok(stored) => Ok(stored),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Err(ReportError::Report(format!(
+                "no canonical identity with canonical_email '{email}' found in authors table.\n\
+                 Run `tga aliases list` to see all canonical identities, or \
+                 `tga aliases merge` to consolidate duplicate identities."
+            ))),
+            Err(e) => Err(ReportError::Core(crate::core::TgaError::from(e))),
+        }
+    }
+
+    /// Load commit rows, optionally filtered to a single canonical email.
+    ///
+    /// Why: separating row loading from the `build_filtered` orchestration
+    /// keeps the SQL in one place and makes the filter opt-in without
+    /// duplicating the large query string.
+    /// What: when `author_email` is `Some`, appends
+    /// `WHERE LOWER(a.canonical_email) = LOWER(?)` to the base JOIN query;
+    /// when `None`, returns all rows.
+    /// Test: covered by `aggregator_author_filter_returns_single_author`
+    /// (filters to alice's rows) and `aggregator_builds_report_data`
+    /// (no filter, returns all rows).
+    fn load_rows_filtered(db: &Database, author_email: Option<&str>) -> Result<Vec<CommitRow>> {
         let conn = db.connection();
         // Prefer the canonical identity from the `authors` table when the
         // commit has been linked (i.e. `author_id IS NOT NULL`). This ensures
@@ -254,9 +334,13 @@ impl Aggregator {
         // Falls back to the raw commit fields when no `author_id` is set
         // (which can happen for commits inserted before
         // `upsert_observed_authors` ran).
-        let mut stmt = conn
-            .prepare(
-                "SELECT c.sha, \
+        //
+        // The optional `author_email` filter restricts to rows whose resolved
+        // canonical email matches case-insensitively.  We use
+        // `LOWER(COALESCE(...)) = LOWER(?)` so that the filter still works
+        // for commits that pre-date `upsert_observed_authors` and fall back
+        // to the raw `c.author_email` field.
+        let sql_base = "SELECT c.sha, \
                         COALESCE(a.canonical_name,  c.author_name)  AS author_name, \
                         COALESCE(NULLIF(a.canonical_email, ''), c.author_email) AS author_email, \
                         c.timestamp, c.repository, \
@@ -264,37 +348,55 @@ impl Aggregator {
                         c.message, c.ticketed \
                  FROM commits c \
                  LEFT JOIN authors a ON a.id = c.author_id \
-                 LEFT JOIN classifications cl ON cl.id = c.classification_id",
-            )
-            .map_err(crate::core::TgaError::from)?;
+                 LEFT JOIN classifications cl ON cl.id = c.classification_id";
 
-        let rows = stmt
-            .query_map([], |row| {
-                let ts_str: String = row.get(3)?;
-                let timestamp = DateTime::parse_from_rfc3339(&ts_str)
-                    .map(|dt| dt.with_timezone(&Utc))
-                    .unwrap_or_else(|_| Utc::now());
-                let ticketed: i64 = row.get(10).unwrap_or(0);
-                Ok(CommitRow {
-                    sha: row.get(0)?,
-                    author_name: row.get(1)?,
-                    author_email: row.get(2)?,
-                    timestamp,
-                    repository: row.get(4)?,
-                    insertions: row.get(5)?,
-                    deletions: row.get(6)?,
-                    files_changed: row.get(7)?,
-                    category: row.get(8)?,
-                    message: row.get(9)?,
-                    ticketed: ticketed != 0,
-                })
+        let row_mapper = |row: &rusqlite::Row<'_>| -> rusqlite::Result<CommitRow> {
+            let ts_str: String = row.get(3)?;
+            let timestamp = DateTime::parse_from_rfc3339(&ts_str)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now());
+            let ticketed: i64 = row.get(10).unwrap_or(0);
+            Ok(CommitRow {
+                sha: row.get(0)?,
+                author_name: row.get(1)?,
+                author_email: row.get(2)?,
+                timestamp,
+                repository: row.get(4)?,
+                insertions: row.get(5)?,
+                deletions: row.get(6)?,
+                files_changed: row.get(7)?,
+                category: row.get(8)?,
+                message: row.get(9)?,
+                ticketed: ticketed != 0,
             })
-            .map_err(crate::core::TgaError::from)?;
+        };
 
-        let mut out = Vec::new();
-        for r in rows {
-            out.push(r.map_err(crate::core::TgaError::from)?);
+        let mut out: Vec<CommitRow> = Vec::new();
+
+        if let Some(email) = author_email {
+            let sql = format!(
+                "{sql_base} \
+                 WHERE LOWER(COALESCE(NULLIF(a.canonical_email, ''), c.author_email)) = LOWER(?1)"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(crate::core::TgaError::from)?;
+            let rows = stmt
+                .query_map(rusqlite::params![email], row_mapper)
+                .map_err(crate::core::TgaError::from)?;
+            for r in rows {
+                out.push(r.map_err(crate::core::TgaError::from)?);
+            }
+        } else {
+            let mut stmt = conn
+                .prepare(sql_base)
+                .map_err(crate::core::TgaError::from)?;
+            let rows = stmt
+                .query_map([], row_mapper)
+                .map_err(crate::core::TgaError::from)?;
+            for r in rows {
+                out.push(r.map_err(crate::core::TgaError::from)?);
+            }
         }
+
         debug!(count = out.len(), "loaded commit rows for aggregation");
         Ok(out)
     }

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -350,4 +350,169 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    // =========================================================================
+    // Author filter tests (issue #324)
+    // =========================================================================
+
+    /// Seed a DB with two authors linked to the `authors` table (canonical
+    /// identity rows) so that `resolve_canonical_email` / `load_rows_filtered`
+    /// paths are fully exercised.
+    fn seed_db_with_authors() -> Database {
+        let db = Database::open_in_memory().expect("open db");
+        let conn = db.connection();
+
+        // Insert canonical author rows.
+        conn.execute(
+            "INSERT INTO authors (id, canonical_name, canonical_email, aliases) \
+             VALUES (1, 'Alice Smith', 'alice@example.com', '[]')",
+            [],
+        )
+        .expect("insert author alice");
+        conn.execute(
+            "INSERT INTO authors (id, canonical_name, canonical_email, aliases) \
+             VALUES (2, 'Bob Jones', 'bob@example.com', '[]')",
+            [],
+        )
+        .expect("insert author bob");
+
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository, \
+                 files_changed, insertions, deletions, is_merge, author_id) \
+             VALUES ('aaa111', 'Alice Smith', 'alice@example.com', '2024-01-15T10:00:00+00:00', \
+                 'feat: add login', 'repo-a', 3, 50, 5, 0, 1)",
+            [],
+        )
+        .expect("insert alice commit 1");
+
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository, \
+                 files_changed, insertions, deletions, is_merge, author_id) \
+             VALUES ('aaa222', 'Alice Smith', 'alice@example.com', '2024-01-16T10:00:00+00:00', \
+                 'feat: add logout', 'repo-a', 2, 20, 3, 0, 1)",
+            [],
+        )
+        .expect("insert alice commit 2");
+
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository, \
+                 files_changed, insertions, deletions, is_merge, author_id) \
+             VALUES ('bbb111', 'Bob Jones', 'bob@example.com', '2024-01-22T11:00:00+00:00', \
+                 'fix: edge case', 'repo-a', 1, 10, 2, 0, 2)",
+            [],
+        )
+        .expect("insert bob commit");
+
+        db
+    }
+
+    #[test]
+    fn aggregator_author_filter_returns_single_author() {
+        // Why: validates that `build_filtered` with a known email returns only
+        // that author's commits and excludes all others.
+        let db = seed_db_with_authors();
+        let cfg = baseline_config();
+
+        let data = Aggregator::build_filtered(&db, &cfg, Some("alice@example.com"))
+            .expect("build filtered");
+
+        assert_eq!(
+            data.total_commits, 2,
+            "should contain only alice's 2 commits, got {}",
+            data.total_commits
+        );
+        assert_eq!(
+            data.total_authors, 1,
+            "should contain only 1 author (alice), got {}",
+            data.total_authors
+        );
+        assert_eq!(
+            data.authors[0].email, "alice@example.com",
+            "the sole author should be alice"
+        );
+    }
+
+    #[test]
+    fn aggregator_author_filter_case_insensitive() {
+        // Why: git emails in the wild mix case; the filter must be
+        // case-insensitive so `ALICE@EXAMPLE.COM` resolves the same as
+        // `alice@example.com`.
+        let db = seed_db_with_authors();
+        let cfg = baseline_config();
+
+        let data = Aggregator::build_filtered(&db, &cfg, Some("ALICE@EXAMPLE.COM"))
+            .expect("case-insensitive filter");
+
+        assert_eq!(data.total_commits, 2);
+        assert_eq!(data.total_authors, 1);
+    }
+
+    #[test]
+    fn aggregator_author_filter_unknown_email_errors() {
+        // Why: a typo in the email should fail loudly with a suggestion, not
+        // silently produce an empty report.
+        let db = seed_db_with_authors();
+        let cfg = baseline_config();
+
+        let result = Aggregator::build_filtered(&db, &cfg, Some("nobody@example.com"));
+
+        assert!(
+            result.is_err(),
+            "expected an error for unknown email, got Ok"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("nobody@example.com"),
+            "error should contain the supplied email; got: {msg}"
+        );
+        assert!(
+            msg.contains("tga aliases list"),
+            "error should suggest `tga aliases list`; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn aggregator_author_filter_none_returns_all() {
+        // Why: omitting `--author` must behave identically to the pre-existing
+        // `Aggregator::build` path — backwards compatibility is not regressed.
+        let db = seed_db_with_authors();
+        let cfg = baseline_config();
+
+        let unfiltered = Aggregator::build(&db, &cfg).expect("unfiltered");
+        let filtered_none = Aggregator::build_filtered(&db, &cfg, None).expect("filtered none");
+
+        assert_eq!(unfiltered.total_commits, filtered_none.total_commits);
+        assert_eq!(unfiltered.total_authors, filtered_none.total_authors);
+    }
+
+    #[test]
+    fn pipeline_author_filter_single_author() {
+        // Why: validates the full pipeline path (`run_with_filter`) so that
+        // all formatters receive the scoped data without crashing.
+        let db = seed_db_with_authors();
+        let dir = tmp_dir("pipeline-author");
+        let cfg = Config {
+            repositories: vec![RepositoryConfig {
+                path: PathBuf::from("/tmp/repo-a"),
+                name: Some("repo-a".into()),
+                ..Default::default()
+            }],
+            output: Some(OutputConfig {
+                directory: Some(dir.clone()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pipeline = ReportPipeline::new(cfg);
+        let stats = pipeline
+            .run_with_filter(&db, Some("alice@example.com"))
+            .expect("run with filter");
+
+        assert_eq!(stats.total_commits, 2, "filtered report: 2 alice commits");
+        assert_eq!(stats.total_authors, 1, "filtered report: 1 author");
+        // 14 files still written (formatters are unchanged).
+        assert_eq!(stats.files_written.len(), 14);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/trusty-git-analytics/src/report/pipeline.rs
+++ b/crates/trusty-git-analytics/src/report/pipeline.rs
@@ -68,7 +68,25 @@ impl ReportPipeline {
     ///
     /// Propagates any aggregator, formatter, or I/O failure.
     pub fn run(&self, db: &Database) -> Result<ReportStats> {
-        let data = Aggregator::build(db, &self.config)?;
+        self.run_with_filter(db, None)
+    }
+
+    /// Aggregate the database, optionally scoped to one canonical identity,
+    /// and write all configured report formats.
+    ///
+    /// Why: `tga report --author <email>` needs to scope the report to a
+    /// single canonical identity; this method threads the filter through to
+    /// the aggregator without duplicating the full run logic.
+    /// What: delegates to [`Aggregator::build_filtered`] when `author_email`
+    /// is `Some`; falls back to the full aggregate when `None`.  All
+    /// formatters receive the (possibly filtered) [`ReportData`] unchanged.
+    /// Test: covered by `report::tests::pipeline_author_filter_single_author`.
+    pub fn run_with_filter(
+        &self,
+        db: &Database,
+        author_email: Option<&str>,
+    ) -> Result<ReportStats> {
+        let data = Aggregator::build_filtered(db, &self.config, author_email)?;
         let output_dir = self.resolve_output_dir();
         std::fs::create_dir_all(&output_dir)?;
         info!(dir = %output_dir.display(), "writing reports");


### PR DESCRIPTION
## Summary
Adds `--author <email>` filter to `tga report` so a single canonical engineer's data can be exported without post-processing `authors.csv`. Scopes the aggregator's SQL query to one canonical identity.

Closes #324.

## Motivation
TGA already canonicalizes author identities via the `authors` table (`tga aliases merge` consolidates duplicate emails for one engineer). What was missing: a way to scope `tga report` to one engineer for individual performance views. This flag plugs that gap with no new schema.

## Changes
- `tga report --author <EMAIL>` optional flag
- Aggregator query gains a `WHERE LOWER(canonical_email) = LOWER(?)` filter when set
- Case-insensitive match across `canonical_email` and the fallback `c.author_email` (covers commits that pre-date identity resolution)
- Helpful error if the email doesn't resolve to a canonical identity, suggesting `tga aliases list`
- All existing formatters (csv, json, markdown) emit single-engineer output unchanged
- 5 new unit tests covering: filter behavior, case-insensitivity, unknown-email error path, no-filter parity, pipeline integration
- README `tga report` section updated; CHANGELOG `[1.5.4]` entry added
- Version: 1.5.3 → 1.5.4 (patch — additive, backward compatible)

## Test plan
- [x] `cargo build -p tga` (clean)
- [x] `cargo test -p tga` (547 tests pass, 0 fail)
- [x] `cargo clippy -p tga --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

## Follow-up
This is the prerequisite ticket for #325 (`tga author <email>` drill-down subcommand with effort histogram + PR metrics canonicalization). #325 will reuse the canonical-email lookup logic established here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)