### PR TITLE
feat(tga)!: 2.0.0 — all-branch walk + uniform filters + CLI docs audit + fetch visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "1.5.4"
+version = "2.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-05-28
+
+### BREAKING CHANGES
+
+- **`tga collect` now walks ALL local branches and remote tracking refs by
+  default** (`refs/heads/*` + `refs/remotes/origin/*`), not just HEAD ancestry
+  (#331). This fixes a data-integrity bug where commits on non-default branches
+  (PR branches, feature branches, hotfixes) were silently excluded — the
+  HEAD-only walk was losing ~56% of commits in multi-branch repos.
+
+### Added
+
+- **`--head-only` flag on `tga collect`** — restores the legacy HEAD-only walk
+  (≤ 1.5.4 behaviour) for all repositories when passed on the command line.
+  For a per-repo opt-out, set `head_only: true` in the `repositories[].head_only`
+  field of your YAML config.
+
+### Migration
+
+Existing `tga.db` files were collected with the buggy HEAD-only walker and are
+missing commits from non-default branches. To recover the full commit history:
+
+```bash
+tga collect --force
+```
+
+The `--force` flag bypasses the `collection_runs` skip mechanism, allowing
+already-"collected" weeks to be re-walked with the new all-branches coverage.
+Expect significantly more commits per week after re-collecting (the bug was
+losing ~56% of commits on multi-repo orgs).
+
+### Internal
+
+- New `head_only: bool` field on `GitCollector` and `CollectionPipeline` with
+  `with_head_only(bool)` builder method on each.
+- Revwalk seeding logic in `extractor.rs::collect_window` now has three arms:
+  explicit `branch` override (unchanged), `head_only = true` (legacy escape
+  hatch), and the new default (push all `refs/heads/*` + `refs/remotes/origin/*`
+  except `refs/remotes/origin/HEAD` which is a symref).
+- The all-branch walk falls back to `HEAD` for repos with a detached HEAD and
+  no local branches (common in CI shallow clones).
+- Regression tests added for all four scenarios: all-branch coverage,
+  `--head-only` legacy behaviour, explicit `branch:` override, and
+  detached-HEAD fallback (tests in `collect::git::extractor::tests`).
+
 ## [1.5.4] - 2026-05-28
 
 ### Added

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -22,6 +22,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   For a per-repo opt-out, set `head_only: true` in the `repositories[].head_only`
   field of your YAML config.
 
+- **`--branch <NAME[,NAME…]>` flag on `tga collect` (#332)** — restrict the
+  revwalk to one or more branch names (comma-separated). Seeds from both
+  `refs/heads/<name>` and `refs/remotes/origin/<name>`, so local and
+  remote-tracking copies are both covered. Mutually exclusive with `--head-only`.
+  Per-repo branch overrides in YAML (`repositories[].branch`) are unchanged and
+  still take precedence over the per-repo logic, but the new `--branch` flag
+  takes precedence over everything for the current CLI invocation.
+  Example: `tga collect --branch main,release/1.0 --repos my-service`
+
+- **Uniform `--repos`, `--weeks`, `--since`, `--until`, `--force` filters on
+  `tga classify` (#332)** — `tga classify` now accepts the same date/repo filter
+  flags used by `tga collect`, enabling surgical re-classification of a specific
+  slice without touching the full database:
+  ```bash
+  tga classify --force --repos my-service --weeks 4
+  tga classify --force --since 2026-01-01 --until 2026-03-31
+  ```
+  Supplying `--since`/`--until`/`--weeks` without `--force` emits a `WARN`
+  (the filter is a no-op for new commits but is a footgun without `--force`).
+
+- **Uniform global filter flags on all `tga backfill` subcommands (#332)** —
+  `--repos`, `--weeks`, `--since`, and `--until` are now declared as `global`
+  flags on `BackfillArgs`, scoping every subcommand (ticket-ids, revert-flags,
+  reachability, effort) uniformly. The old per-subcommand `--repo` flag on
+  `reachability` is replaced by the global `--repos` (plural, comma-separated).
+  ```bash
+  tga backfill ticket-ids --repos api --since 2026-01-01
+  tga backfill effort --repos core --weeks 8 --force
+  tga backfill reachability --repos my-service
+  ```
+
+- **Comprehensive CLI documentation (#333)** — every subcommand now has:
+  - `about` (one-line description shown in `tga --help`)
+  - `long_about` (multi-paragraph context shown in `tga <subcommand> --help`)
+  - `after_help` with 2-3 concrete examples and `TIPS` lines
+  - Per-flag `help` strings on every newly-added flag
+  Subcommands with new docs: `analyze`, `classify`, `report`, `backfill`,
+  `pr-metrics`, `install`, `aliases`, `override`, `rules`, `deployments collect`,
+  `incidents collect`, `dora`.
+
+- **README "Common Workflows" section (#333)** — the README now opens with a
+  "Common Workflows" section covering first-time setup, routine weekly runs,
+  scoped re-runs, branch-restricted collection, rule tuning, backfill operations,
+  and the DORA metrics pipeline. A "CLI Subcommand Reference" table lists every
+  subcommand with its purpose and key flags.
+
 ### Migration
 
 Existing `tga.db` files were collected with the buggy HEAD-only walker and are

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -53,6 +53,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tga backfill reachability --repos my-service
   ```
 
+- **Per-repo fetch visibility with `--strict-fetch` and `--verbose-fetch` (#334)** —
+  `tga collect` now tracks the outcome of the pre-walk `git fetch` for every
+  repository and prints an end-of-run fetch summary to stderr:
+
+  ```
+  Fetch summary: 116 / 118 repos updated (2 failure(s), 0 skipped)
+    - ml_pricing_engine: could not find remote 'origin'
+    - datapipelines: authentication required
+  ```
+
+  Successful fetches are omitted from the summary unless `--verbose-fetch` is
+  passed. `--strict-fetch` causes `tga collect` to exit non-zero after the
+  summary if any repository had a fetch failure — useful for CI pipelines that
+  treat stale-data as a hard error.
+
+  When `--no-fetch` is active, a warning is printed to stderr at the start of
+  collection:
+  ```
+  WARNING: --no-fetch active. Local clones may be stale. tga collect will walk
+  only what's already in your local object store.
+  ```
+
+  The optional per-repo `repositories[].fetch_timeout_secs: <N>` config field
+  stores a per-repo fetch timeout in seconds; enforcement via a watchdog thread
+  is scheduled for a future release.
+
 - **Comprehensive CLI documentation (#333)** — every subcommand now has:
   - `about` (one-line description shown in `tga --help`)
   - `long_about` (multi-paragraph context shown in `tga <subcommand> --help`)

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "1.5.4"
+version = "2.0.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -219,6 +219,23 @@ tga collect [--config <PATH>] [--database <PATH>]
             [--repos <NAME,...>] [--from <DATE>] [--to <DATE>] [--weeks <N>]
             [--since <DATE>] [--until <DATE>] [--dry-run]
             [--force-refresh-prs] [--validate-only] [--no-validate]
+            [--head-only]
+```
+
+**Branch coverage (tga 2.0.0+):** By default `tga collect` walks ALL local
+branches (`refs/heads/*`) and remote tracking refs (`refs/remotes/origin/*`),
+so commits on PR branches, feature branches, and hotfixes are not silently
+excluded. This fixes a data-integrity bug (#331) that was losing ~56% of
+commits in multi-branch repos when using the HEAD-only default from tga ≤ 1.5.4.
+
+To restore the legacy HEAD-only behaviour, pass `--head-only` globally or set
+`head_only: true` on individual repository entries in your YAML config.
+
+**Migration from tga ≤ 1.5.4:** existing databases are missing commits from
+non-default branches. Re-collect with `--force` to recover that history:
+
+```bash
+tga collect --force   # re-walk all weeks with full branch coverage
 ```
 
 | Flag | Description |
@@ -233,10 +250,13 @@ tga collect [--config <PATH>] [--database <PATH>]
 | `--force-refresh-prs` | Re-fetch ADO pull requests even when already cached (backfills pre-v1.0.9 rows) |
 | `--validate-only` | Run configuration validation and exit (0 on success, 1 on errors) |
 | `--no-validate` | Skip pre-flight configuration validation |
+| `--head-only` | Restore legacy HEAD-only revwalk (tga ≤ 1.5.4 behaviour); also available per-repo via `head_only: true` in YAML |
 
 ```bash
 tga collect --repos my-project --from 2024-01-01 --to 2024-03-31
-tga collect --weeks 4   # collect last 4 weeks across all repos
+tga collect --weeks 4           # collect last 4 weeks across all repos
+tga collect --force             # re-collect all history (e.g. after upgrading to 2.0.0)
+tga collect --head-only         # legacy HEAD-only walk for all repos
 ```
 
 ### tga classify

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -236,6 +236,38 @@ tga collect --branch main,release/1.0
 tga collect --repos my-service --branch main
 ```
 
+### Monitor fetch health across many repos
+
+By default `tga collect` always fetches each repo before walking and prints an
+end-of-run summary:
+
+```
+Fetch summary: 116 / 118 repos updated (2 failure(s), 0 skipped)
+  - ml_pricing_engine: could not find remote 'origin'
+  - datapipelines: authentication required
+```
+
+```bash
+# Use --strict-fetch in CI to fail the run if any fetch fails
+tga collect --strict-fetch
+
+# See per-repo success lines too (useful for debugging network topology)
+tga collect --verbose-fetch
+
+# Skip fetching entirely (stale data warning is printed to stderr)
+tga collect --no-fetch
+```
+
+Per-repo fetch timeouts can be set in the YAML config to prevent a slow remote
+from blocking the entire run:
+
+```yaml
+repositories:
+  - path: ~/code/slow-repo
+    name: slow-repo
+    fetch_timeout_secs: 30   # optional; enforcement is pending a future release
+```
+
 ### Update rules and re-classify
 
 ```bash
@@ -286,7 +318,7 @@ tga dora --since 2026-04-01
 | Subcommand | Purpose | Key flags |
 |------------|---------|-----------|
 | `tga analyze` | Full pipeline (collect → classify → report) in one command | `--weeks`, `--from`, `--to`, `--force`, `--skip-collect`, `--skip-classify`, `--dry-run` |
-| `tga collect` | Stage 1: extract commits into the database | `--repos`, `--branch`, `--weeks`, `--from`, `--to`, `--force`, `--head-only`, `--dry-run` |
+| `tga collect` | Stage 1: extract commits into the database | `--repos`, `--branch`, `--weeks`, `--from`, `--to`, `--force`, `--head-only`, `--no-fetch`, `--strict-fetch`, `--verbose-fetch`, `--dry-run` |
 | `tga classify` | Stage 2: classify collected commits | `--repos`, `--weeks`, `--since`, `--until`, `--force`, `--rules`, `--use-llm`, `--no-external` |
 | `tga report` | Stage 3: generate CSV/JSON/Markdown reports | `--output`, `--formats`, `--author` |
 | `tga pr-metrics` | Pull-request metrics per engineer | `--weeks`, `--csv`, `--output` |
@@ -382,6 +414,9 @@ tga collect --force   # re-walk all weeks with full branch coverage
 | `--force-refresh-prs` | Re-fetch ADO pull requests even when already cached (backfills pre-v1.0.9 rows) |
 | `--validate-only` | Run configuration validation and exit (0 on success, 1 on errors) |
 | `--no-validate` | Skip pre-flight configuration validation |
+| `--no-fetch` | Skip the pre-walk `git fetch`; use only local refs. A warning is printed to stderr so you know the data may be stale. |
+| `--strict-fetch` | Exit non-zero if any repository's fetch fails (default: failures are shown in the summary but exit code is 0). Useful for CI. |
+| `--verbose-fetch` | Print a success line per fetched repository in the fetch summary (default: only failures are shown). |
 | `--head-only` | Restore legacy HEAD-only revwalk (tga ≤ 1.5.4 behaviour); mutually exclusive with `--branch`; also available per-repo via `head_only: true` in YAML |
 
 ```bash

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -169,6 +169,136 @@ When `developer_aliases` is non-empty it takes precedence over `team.members`. U
 
 See [`configs/example-config.yaml`](configs/example-config.yaml) for a working example that covers multiple repositories, developer aliases, and CSV+Markdown output.
 
+## Common Workflows
+
+### First-time setup
+
+```bash
+# 1. Generate config.yaml interactively
+tga install
+
+# 2. Collect all history across all repos (full branch coverage, tga 2.0.0+)
+tga collect
+
+# 3. Classify all collected commits
+tga classify
+
+# 4. Generate reports
+tga report
+```
+
+### Routine weekly run
+
+```bash
+# Collect last 4 weeks (incremental; already-collected weeks are skipped)
+tga collect --weeks 4
+
+# Classify any unclassified commits
+tga classify
+
+# Regenerate reports
+tga report
+```
+
+### Scoped re-run for one service
+
+```bash
+# Re-collect only one repo, forcing re-walk of the last 8 weeks
+tga collect --repos my-service --weeks 8 --force
+
+# Re-classify only that repo
+tga classify --force --repos my-service --weeks 8
+
+# Reports always cover the full DB — no scoping needed
+tga report
+```
+
+### Upgrade from tga ≤ 1.5.4 (branch coverage fix)
+
+```bash
+# Re-collect all history to pick up commits from non-default branches
+tga collect --force
+
+# Re-classify everything (force overwrites prior verdicts)
+tga classify --force
+
+# Regenerate reports
+tga report
+```
+
+### Restrict collection to specific branches
+
+```bash
+# Walk only 'main' and 'release/1.0' branches for all repos
+tga collect --branch main,release/1.0
+
+# Walk only 'main' for one specific repo
+tga collect --repos my-service --branch main
+```
+
+### Update rules and re-classify
+
+```bash
+# Preview which rules will fire (dry-run)
+tga rules test "feat: add login page" --rules ./my-rules.yaml
+
+# Re-classify all commits with the new rules (force overwrites existing verdicts)
+tga classify --rules ./my-rules.yaml --force
+
+# Scope re-classification to the last 4 weeks only
+tga classify --rules ./my-rules.yaml --force --weeks 4
+```
+
+### Fix existing database (backfill operations)
+
+```bash
+# Fix on_default_branch = 0 for pre-1.4.1 databases
+tga backfill reachability
+
+# Re-extract ticket IDs after extending ticket patterns
+tga backfill ticket-ids
+
+# Score historical commit effort (persists in fact_commit_effort)
+tga backfill effort --repos my-service
+
+# Preview revert-flag changes without writing
+tga backfill revert-flags --dry-run
+```
+
+### DORA metrics pipeline
+
+```bash
+# Ingest deployment events (default: git tags matching dora.deployment_tag_pattern)
+tga deployments collect
+
+# Ingest incidents from JIRA SRE issues or Datadog
+tga incidents collect
+
+# Compute and display the four DORA metrics
+tga dora
+
+# Limit to events since the start of Q2
+tga dora --since 2026-04-01
+```
+
+## CLI Subcommand Reference
+
+| Subcommand | Purpose | Key flags |
+|------------|---------|-----------|
+| `tga analyze` | Full pipeline (collect → classify → report) in one command | `--weeks`, `--from`, `--to`, `--force`, `--skip-collect`, `--skip-classify`, `--dry-run` |
+| `tga collect` | Stage 1: extract commits into the database | `--repos`, `--branch`, `--weeks`, `--from`, `--to`, `--force`, `--head-only`, `--dry-run` |
+| `tga classify` | Stage 2: classify collected commits | `--repos`, `--weeks`, `--since`, `--until`, `--force`, `--rules`, `--use-llm`, `--no-external` |
+| `tga report` | Stage 3: generate CSV/JSON/Markdown reports | `--output`, `--formats`, `--author` |
+| `tga pr-metrics` | Pull-request metrics per engineer | `--weeks`, `--csv`, `--output` |
+| `tga install` | Interactive first-time config wizard | `--output`, `--force` |
+| `tga aliases` | Manage developer identity aliases | `list`, `merge <src> <dst>` |
+| `tga backfill` | Retroactive maintenance on existing rows | `--repos`, `--weeks`, `--since`, `--until`, `--dry-run` |
+| `tga override` | Pin classification verdicts (Tier 0) | `add`, `list`, `remove` |
+| `tga rules` | Introspect the active rule set | `list`, `show <sha>`, `test "<message>"` |
+| `tga deployments` | DORA: ingest deployment events | `collect [--source]` |
+| `tga incidents` | DORA: ingest production incidents | `collect [--source]` |
+| `tga dora` | DORA: compute and display all four metrics | `--since` |
+
 ## CLI Reference
 
 All subcommands accept these global flags:
@@ -216,7 +346,8 @@ Stage 1: extract commits from git repositories into the database.
 
 ```bash
 tga collect [--config <PATH>] [--database <PATH>]
-            [--repos <NAME,...>] [--from <DATE>] [--to <DATE>] [--weeks <N>]
+            [--repos <NAME,...>] [--branch <NAME[,NAME…]>]
+            [--from <DATE>] [--to <DATE>] [--weeks <N>]
             [--since <DATE>] [--until <DATE>] [--dry-run]
             [--force-refresh-prs] [--validate-only] [--no-validate]
             [--head-only]
@@ -241,6 +372,7 @@ tga collect --force   # re-walk all weeks with full branch coverage
 | Flag | Description |
 |------|-------------|
 | `--repos <NAME,...>` | Comma-separated list of repository names to collect; others are skipped |
+| `--branch <NAME[,NAME…]>` | Restrict the revwalk to these branch names (seeds from both `refs/heads/<name>` and `refs/remotes/origin/<name>`); mutually exclusive with `--head-only` |
 | `--from <DATE>` | Collect commits on or after this ISO 8601 date; mutually exclusive with `--weeks` |
 | `--to <DATE>` | Collect commits on or before this ISO 8601 date; defaults to today |
 | `--since <DATE>` | Legacy alias for `--from` (Python-predecessor compatibility); `--from` takes precedence |
@@ -250,12 +382,14 @@ tga collect --force   # re-walk all weeks with full branch coverage
 | `--force-refresh-prs` | Re-fetch ADO pull requests even when already cached (backfills pre-v1.0.9 rows) |
 | `--validate-only` | Run configuration validation and exit (0 on success, 1 on errors) |
 | `--no-validate` | Skip pre-flight configuration validation |
-| `--head-only` | Restore legacy HEAD-only revwalk (tga ≤ 1.5.4 behaviour); also available per-repo via `head_only: true` in YAML |
+| `--head-only` | Restore legacy HEAD-only revwalk (tga ≤ 1.5.4 behaviour); mutually exclusive with `--branch`; also available per-repo via `head_only: true` in YAML |
 
 ```bash
 tga collect --repos my-project --from 2024-01-01 --to 2024-03-31
 tga collect --weeks 4           # collect last 4 weeks across all repos
 tga collect --force             # re-collect all history (e.g. after upgrading to 2.0.0)
+tga collect --branch main       # walk only the main branch for all repos
+tga collect --branch main,release/1.0 --repos my-service  # branch + repo filter
 tga collect --head-only         # legacy HEAD-only walk for all repos
 ```
 
@@ -265,12 +399,18 @@ Stage 2: run the classification cascade over collected commits.
 
 ```bash
 tga classify [--config <PATH>] [--database <PATH>]
-             [--rules <PATH>] [--use-llm] [--backfill-complexity]
+             [--repos <NAME,...>] [--weeks <N>] [--since <DATE>] [--until <DATE>]
+             [--force] [--rules <PATH>] [--use-llm] [--backfill-complexity]
              [--no-external]
 ```
 
 | Flag | Description |
 |------|-------------|
+| `--repos <NAME,...>` | Limit re-classification to these repository names (comma-separated) |
+| `--weeks <N>` | Limit to commits in the last N ISO weeks; mutually exclusive with `--since`/`--until` |
+| `--since <DATE>` | Lower bound on author timestamp (ISO 8601 `YYYY-MM-DD`); mutually exclusive with `--weeks` |
+| `--until <DATE>` | Upper bound on author timestamp (ISO 8601 `YYYY-MM-DD`); mutually exclusive with `--weeks` |
+| `--force` | Re-classify commits that already have a verdict (useful after updating rules) |
 | `--rules <PATH>` | Override `classification.rules_file` from config. Custom rules default to priority 110 (above built-in 100) and are standalone by default (`extend_defaults: false`). |
 | `--use-llm` | Enable LLM fallback regardless of config setting |
 | `--backfill-complexity` | Fill missing complexity scores (1–5) for already-classified commits via the LLM, without re-running the full cascade; category, confidence, and method are left untouched |
@@ -278,7 +418,9 @@ tga classify [--config <PATH>] [--database <PATH>]
 
 ```bash
 tga classify --rules ./custom-rules.yaml --use-llm
-tga classify --no-external   # offline / CI mode
+tga classify --no-external                         # offline / CI mode
+tga classify --force --repos my-service --weeks 4  # re-classify one repo, last 4 weeks
+tga classify --force --since 2026-01-01            # re-classify from a date forward
 ```
 
 ### tga report
@@ -337,10 +479,15 @@ revision-count data is not yet tracked.
 ### tga backfill
 
 Retroactive maintenance operations that update existing commit rows in place
-(outside the normal `collect → classify → report` pipeline).
+(outside the normal `collect → classify → report` pipeline). All global filter
+flags (`--repos`, `--weeks`, `--since`, `--until`) scope the operation uniformly.
+
+**Note:** `--branch` is collect-only. Commits in the database do not carry branch
+attribution after collection, so there is no branch filter for backfill operations.
 
 ```bash
 tga backfill <SUBCOMMAND> [--dry-run]
+             [--repos <NAME,...>] [--weeks <N>] [--since <DATE>] [--until <DATE>]
 ```
 
 | Subcommand | Description |
@@ -348,18 +495,24 @@ tga backfill <SUBCOMMAND> [--dry-run]
 | `ai-detection` | Re-run LLM classification on low-confidence prior LLM verdicts |
 | `revert-flags` | Scan commit messages for revert patterns and set `is_revert` |
 | `ticket-ids` | Scan commit messages for ticket refs and update `ticket_id`/`ticketed` |
-| `reachability` | Re-run the full reachability scan (default branch + tags + release branches) and upsert `fact_commit_reachability` without re-collecting commits — use this to fix `on_default_branch=0` rows in existing databases (issue #290) |
+| `reachability` | Re-run the full reachability scan and upsert `fact_commit_reachability` without re-collecting (fixes `on_default_branch=0` rows in existing databases, issue #290) |
+| `effort` | Compute empirical effort scores (XS/S/M/L/XL) for historical commits and persist in `fact_commit_effort` |
 
-| Flag | Description |
-|------|-------------|
+| Global flag | Description |
+|-------------|-------------|
 | `--dry-run` | Report how many rows would change without writing |
-| `--repo NAME` | (reachability only) Only backfill the named repository (repeatable) |
+| `--repos <NAME,...>` | Limit to these repository names (comma-separated) |
+| `--weeks <N>` | Limit to commits in the last N ISO weeks; mutually exclusive with `--since`/`--until` |
+| `--since <DATE>` | Lower bound on author timestamp (ISO 8601 `YYYY-MM-DD`); mutually exclusive with `--weeks` |
+| `--until <DATE>` | Upper bound on author timestamp (ISO 8601 `YYYY-MM-DD`); mutually exclusive with `--weeks` |
 
 ```bash
 tga backfill revert-flags --dry-run
 tga backfill ticket-ids
-tga backfill reachability           # fix on_default_branch for all repos
-tga backfill reachability --repo my-service  # single repo only
+tga backfill reachability                      # fix on_default_branch for all repos
+tga backfill reachability --repos my-service   # single repo only
+tga backfill effort --repos api --weeks 4      # effort for one repo, last 4 weeks
+tga backfill ticket-ids --since 2026-01-01     # ticket IDs from a date forward
 ```
 
 ### tga override

--- a/crates/trusty-git-analytics/src/classify/pipeline.rs
+++ b/crates/trusty-git-analytics/src/classify/pipeline.rs
@@ -72,8 +72,9 @@ pub struct RepoCoverage {
 /// and the engine config / taxonomy / JIRA mappings all live in `Config`;
 /// concentrating orchestration here keeps the binary's `commands/classify.rs`
 /// thin.
-/// What: holds the validated [`Config`] plus toggles for `force` re-classify
-/// and `since` lower-bound. Built via [`Self::new`] + builder methods.
+/// What: holds the validated [`Config`] plus toggles for `force` re-classify,
+/// `since`/`until` date bounds, and `repos` filter. Built via [`Self::new`] +
+/// builder methods.
 /// Test: covered by `classify::tests::pipeline_runs_against_in_memory_db`.
 pub struct ClassificationPipeline {
     config: Config,
@@ -86,6 +87,16 @@ pub struct ClassificationPipeline {
     /// Only consulted when `force == true`; without force the default
     /// "missing-verdict" filter is the only selector. See [`Self::with_since`].
     since: Option<String>,
+    /// Optional upper bound on `commits.timestamp` (ISO8601: `YYYY-MM-DD`).
+    ///
+    /// Scopes re-classification to commits on or before this date.
+    /// See [`Self::with_until`].
+    until: Option<String>,
+    /// Optional repository filter: only classify commits from these repos.
+    ///
+    /// When non-empty, only commits whose `repository` column matches one of
+    /// the listed names are considered. See [`Self::with_repos`].
+    repos: Vec<String>,
 }
 
 impl ClassificationPipeline {
@@ -102,6 +113,8 @@ impl ClassificationPipeline {
             config,
             force: false,
             since: None,
+            until: None,
+            repos: Vec::new(),
         }
     }
 
@@ -130,6 +143,31 @@ impl ClassificationPipeline {
     /// Test: covered by the same integration test as `with_force`.
     pub fn with_since(mut self, since: Option<String>) -> Self {
         self.since = since;
+        self
+    }
+
+    /// Bound classification to commits on or before the given ISO8601 date.
+    ///
+    /// Why: complements `with_since` to allow a bounded window like
+    /// `--since 2026-01-01 --until 2026-03-31` without touching commits
+    /// outside that quarter.
+    /// What: stores the string; the read query appends a `timestamp <= ?`
+    /// predicate when set.
+    /// Test: covered by pipeline integration tests that exercise date windows.
+    pub fn with_until(mut self, until: Option<String>) -> Self {
+        self.until = until;
+        self
+    }
+
+    /// Restrict classification to commits from specific repositories.
+    ///
+    /// Why: the `--repos` filter lets operators classify only a slice of the
+    /// DB (e.g. one service) without running across the full corpus.
+    /// What: when non-empty, adds a `WHERE repository IN (…)` clause to the
+    /// candidate commit query.
+    /// Test: see `tests::classify_repos_filter_*` in this module.
+    pub fn with_repos(mut self, repos: Vec<String>) -> Self {
+        self.repos = repos;
         self
     }
 
@@ -326,13 +364,21 @@ impl ClassificationPipeline {
     ) -> Result<ClassificationStats> {
         // 2. Read candidate commits. The default flow returns only the
         //    rows that lack a verdict; `--force` widens this to every row
-        //    (optionally bounded by `--since`).
-        let commits = read_candidate_commits(db, self.force, self.since.as_deref())?;
+        //    (optionally bounded by `--since`/`--until`/`--repos`).
+        let commits = read_candidate_commits(
+            db,
+            self.force,
+            self.since.as_deref(),
+            self.until.as_deref(),
+            &self.repos,
+        )?;
         let total = commits.len();
         info!(
             total,
             force = self.force,
             since = ?self.since,
+            until = ?self.until,
+            repos = ?self.repos,
             "starting classification"
         );
 
@@ -822,49 +868,69 @@ fn is_revert_verdict(category: &str, subcategory: Option<&str>) -> bool {
 /// Read candidates for the classification cascade.
 ///
 /// Why: `--force` (issue #205) re-classifies commits that already have a
-/// verdict, optionally bounded by `--since DATE`. The default flow keeps
-/// the historical "skip-if-classified" semantics so incremental runs stay
-/// cheap.
-/// What: builds a SELECT whose WHERE clause toggles based on `force`:
+/// verdict, optionally bounded by `--since`/`--until`/`--repos`. The
+/// default flow keeps the historical "skip-if-classified" semantics so
+/// incremental runs stay cheap.
+/// What: dynamically builds a WHERE clause from the supplied filters:
 ///
-///   * `!force`               → `WHERE classification_id IS NULL` (legacy)
-///   * `force, since = None`  → no WHERE (every commit)
-///   * `force, since = Some`  → `WHERE timestamp >= ?`
+///   * `!force`               → `classification_id IS NULL`
+///   * `since`                → `timestamp >= ?`
+///   * `until`                → `timestamp <= ?`
+///   * `repos` non-empty      → `repository IN (?,?,…)`
 ///
+/// Filters compose: all supplied predicates are AND-ed together.
 /// Test: covered by `read_candidate_commits_*` unit tests and the
 /// `pipeline_force_*` integration tests in this module.
 fn read_candidate_commits(
     db: &Database,
     force: bool,
     since: Option<&str>,
+    until: Option<&str>,
+    repos: &[String],
 ) -> Result<Vec<CommitRow>> {
-    use rusqlite::params_from_iter;
     use rusqlite::types::Value;
 
-    let (sql, params): (&str, Vec<Value>) = match (force, since) {
-        (false, _) => (
-            "SELECT id, sha, message, is_merge, repository, classification_id \
-             FROM commits WHERE classification_id IS NULL",
-            Vec::new(),
-        ),
-        (true, None) => (
-            "SELECT id, sha, message, is_merge, repository, classification_id \
-             FROM commits",
-            Vec::new(),
-        ),
-        (true, Some(date)) => (
-            "SELECT id, sha, message, is_merge, repository, classification_id \
-             FROM commits WHERE timestamp >= ?1",
-            vec![Value::Text(date.to_string())],
-        ),
+    // Build the WHERE clause dynamically so we can compose all filters.
+    let mut predicates: Vec<String> = Vec::new();
+    let mut params: Vec<Value> = Vec::new();
+
+    if !force {
+        predicates.push("classification_id IS NULL".to_string());
+    }
+    if let Some(s) = since {
+        params.push(Value::Text(s.to_string()));
+        predicates.push(format!("timestamp >= ?{}", params.len()));
+    }
+    if let Some(u) = until {
+        params.push(Value::Text(u.to_string()));
+        predicates.push(format!("timestamp <= ?{}", params.len()));
+    }
+    if !repos.is_empty() {
+        // Append repo values to params and compute their 1-based placeholder indices.
+        let start = params.len() + 1;
+        for r in repos {
+            params.push(Value::Text(r.clone()));
+        }
+        let end = params.len();
+        let placeholders: Vec<String> = (start..=end).map(|i| format!("?{i}")).collect();
+        predicates.push(format!("repository IN ({})", placeholders.join(", ")));
+    }
+
+    let where_clause = if predicates.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", predicates.join(" AND "))
     };
+    let sql = format!(
+        "SELECT id, sha, message, is_merge, repository, classification_id FROM commits{where_clause}"
+    );
 
     let mut stmt = db
         .connection()
-        .prepare(sql)
+        .prepare(&sql)
         .map_err(crate::core::TgaError::from)?;
     let rows = stmt
-        .query_map(params_from_iter(params.iter()), |row| {
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
             Ok(CommitRow {
                 id: row.get(0)?,
                 sha: row.get(1)?,
@@ -1336,18 +1402,19 @@ mod tests {
             .expect("insert unclassified");
 
         // Default flow: only the unclassified row.
-        let v = super::read_candidate_commits(&db, false, None).expect("default");
+        let v = super::read_candidate_commits(&db, false, None, None, &[]).expect("default");
         let shas: Vec<&str> = v.iter().map(|c| c.sha.as_str()).collect();
         assert_eq!(shas, vec!["null"]);
 
         // --force: every row.
-        let v = super::read_candidate_commits(&db, true, None).expect("force");
+        let v = super::read_candidate_commits(&db, true, None, None, &[]).expect("force");
         let mut shas: Vec<&str> = v.iter().map(|c| c.sha.as_str()).collect();
         shas.sort();
         assert_eq!(shas, vec!["new", "null", "old"]);
 
         // --force --since 2025-01-01: only "new" (timestamp >= bound).
-        let v = super::read_candidate_commits(&db, true, Some("2025-01-01")).expect("force+since");
+        let v = super::read_candidate_commits(&db, true, Some("2025-01-01"), None, &[])
+            .expect("force+since");
         let shas: Vec<&str> = v.iter().map(|c| c.sha.as_str()).collect();
         assert_eq!(shas, vec!["new"]);
     }

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -19,6 +19,49 @@ use crate::core::config::Config;
 use crate::core::db::{self, Database};
 use crate::core::models::PullRequest;
 
+/// Outcome of a `git fetch origin` attempt for a single repository.
+///
+/// Why: fetch errors are invisible unless the user reads tracing logs;
+/// surfacing them in `CollectionStats` lets the CLI print an actionable
+/// end-of-run summary.
+/// What: three variants — Success (remote updated), Failed (network/auth error
+/// recorded as a string), Skipped (no-fetch flag or no remote configured).
+/// Test: covered by `commands::collect` integration tests.
+#[derive(Debug, Clone)]
+pub enum FetchOutcome {
+    /// Remote was fetched successfully.
+    Success {
+        /// Name of the remote (usually `"origin"`).
+        remote: String,
+    },
+    /// Fetch was attempted but failed.
+    Failed {
+        /// Name of the remote that was tried.
+        remote: String,
+        /// Human-readable error description.
+        error: String,
+    },
+    /// Fetch was not attempted.
+    Skipped {
+        /// Reason the fetch was skipped (e.g. `"--no-fetch"` or `"no remote"`).
+        reason: String,
+    },
+}
+
+/// Per-repository fetch result, collected into [`CollectionStats::fetch_outcomes`].
+///
+/// Why: groups the display name of the repo with its fetch outcome so the
+/// end-of-run summary can be printed without re-querying the git repo.
+/// What: plain data carrier.
+/// Test: covered by collection pipeline integration tests.
+#[derive(Debug, Clone)]
+pub struct PerRepoFetch {
+    /// Display name of the repository (from config `name` or dir basename).
+    pub repo: String,
+    /// Outcome of the fetch attempt for this repo.
+    pub outcome: FetchOutcome,
+}
+
 /// Aggregate statistics for a single pipeline run.
 ///
 /// Why: callers (CLI, integration tests) need a single typed object
@@ -47,6 +90,11 @@ pub struct CollectionStats {
     pub errors: Vec<String>,
     /// Total `fact_commit_reachability` rows upserted across all repos.
     pub reachability_rows: usize,
+    /// Per-repo fetch outcomes (one entry per repository attempted).
+    ///
+    /// Populated in the per-repo loop; used by the CLI to print the
+    /// end-of-collect fetch summary.
+    pub fetch_outcomes: Vec<PerRepoFetch>,
 }
 
 /// Top-level Stage 1 orchestrator.
@@ -84,6 +132,12 @@ pub struct CollectionPipeline {
     /// Mutually exclusive with `head_only` — the CLI enforces this via
     /// `conflicts_with`.  An empty Vec means "no restriction" (the default).
     branches: Vec<String>,
+    /// When `true`, exit non-zero after the collect summary if any repo had a
+    /// fetch failure. Default `false` — failures are visible but non-fatal.
+    strict_fetch: bool,
+    /// When `true`, print a success line for every fetched repo in the summary
+    /// (not just failures). Default `false` — only failures are printed.
+    verbose_fetch: bool,
 }
 
 impl CollectionPipeline {
@@ -103,6 +157,8 @@ impl CollectionPipeline {
             skip_tag_reachability: false,
             head_only: false,
             branches: Vec::new(),
+            strict_fetch: false,
+            verbose_fetch: false,
         }
     }
 
@@ -169,6 +225,43 @@ impl CollectionPipeline {
         self
     }
 
+    /// When `true`, the pipeline returns a non-zero exit signal to the CLI if
+    /// any repo had a fetch failure.
+    ///
+    /// Why: fetch failures are non-fatal by default (collection continues on
+    /// local refs); `--strict-fetch` lets CI pipelines treat stale data as an
+    /// error.
+    /// What: sets the flag; the CLI checks
+    /// [`CollectionStats::fetch_outcomes`] after `run()` and exits non-zero
+    /// if any `Failed` variant is present and this flag is set.
+    /// Test: the `commands::collect` handler reads this flag from `args`.
+    pub fn with_strict_fetch(mut self, strict: bool) -> Self {
+        self.strict_fetch = strict;
+        self
+    }
+
+    /// When `true`, print a success line per fetched repo in the end-of-run
+    /// summary (default: only failures are shown).
+    ///
+    /// Why: the default summary hides successful fetches to keep output brief;
+    /// `--verbose-fetch` is useful when debugging network topology.
+    /// What: sets the flag; the CLI uses it when printing the fetch summary.
+    /// Test: the `commands::collect` handler reads this flag from `args`.
+    pub fn with_verbose_fetch(mut self, verbose: bool) -> Self {
+        self.verbose_fetch = verbose;
+        self
+    }
+
+    /// Returns whether `--strict-fetch` was set.
+    pub fn strict_fetch(&self) -> bool {
+        self.strict_fetch
+    }
+
+    /// Returns whether `--verbose-fetch` was set.
+    pub fn verbose_fetch(&self) -> bool {
+        self.verbose_fetch
+    }
+
     /// If `true`, re-fetch Azure DevOps pull requests even when their IDs are
     /// already present in `pull_requests`.
     ///
@@ -206,9 +299,31 @@ impl CollectionPipeline {
             // set `--head-only` globally (the CLI flag) or `head_only: true`
             // per repo in YAML without requiring both to be set.
             let effective_head_only = self.head_only || repo_cfg.head_only;
-            let collector = match GitCollector::new(repo_cfg) {
+            // Build a pre-fetch collector (with no_fetch = self.no_fetch) solely
+            // to run perform_fetch once and capture the outcome. Then build the
+            // walk collector with no_fetch=true so the per-week collect_window
+            // calls don't re-fetch.
+            let pre_fetch_collector = match GitCollector::new(repo_cfg) {
                 Ok(c) => c
                     .no_fetch(self.no_fetch)
+                    .with_head_only(effective_head_only)
+                    .with_explicit_branches(self.branches.clone()),
+                Err(e) => {
+                    let msg = format!("failed to open repo {}: {e}", repo_cfg.path.display());
+                    warn!("{msg}");
+                    stats.errors.push(msg);
+                    continue;
+                }
+            };
+            // Perform the one-shot fetch and record the outcome (#334).
+            let fetch_result = pre_fetch_collector.perform_fetch();
+            stats.fetch_outcomes.push(fetch_result);
+
+            // Walk collector always has no_fetch=true: the fetch was either just
+            // performed above, or was intentionally skipped (--no-fetch).
+            let collector = match GitCollector::new(repo_cfg) {
+                Ok(c) => c
+                    .no_fetch(true)
                     .with_head_only(effective_head_only)
                     .with_explicit_branches(self.branches.clone()),
                 Err(e) => {

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -67,6 +67,16 @@ pub struct CollectionPipeline {
     /// When `true`, skip the tag and release-branch reachability scan
     /// (i.e. do not populate `fact_commit_reachability` with tag/branch data).
     skip_tag_reachability: bool,
+    /// When `true`, seed every repository's revwalk from HEAD only (legacy
+    /// 1.x behaviour).  When `false` (default since 2.0.0), all local branch
+    /// heads and `refs/remotes/origin/*` refs are pushed so commits on
+    /// non-default branches are not silently excluded.
+    ///
+    /// A per-repo `head_only: true` in `RepositoryConfig` provides the same
+    /// opt-out for a single repository while keeping all-branch coverage for
+    /// the rest.  The global flag here is OR-ed with the per-repo flag — if
+    /// either is `true`, that repo walks HEAD only.
+    head_only: bool,
 }
 
 impl CollectionPipeline {
@@ -84,6 +94,7 @@ impl CollectionPipeline {
             no_fetch: false,
             force_refresh_prs: false,
             skip_tag_reachability: false,
+            head_only: false,
         }
     }
 
@@ -114,6 +125,20 @@ impl CollectionPipeline {
     /// thousands of tags.
     pub fn with_skip_tag_reachability(mut self, skip: bool) -> Self {
         self.skip_tag_reachability = skip;
+        self
+    }
+
+    /// Enable or disable the global HEAD-only revwalk escape hatch.
+    ///
+    /// Why: tga 2.0.0 changed the default to walk all local branches and remote
+    /// tracking refs. This method lets the CLI `--head-only` flag propagate to
+    /// every per-repo collector in the pipeline.  Per-repo `head_only: true` in
+    /// `RepositoryConfig` provides the same opt-out for individual repos.
+    /// What: when `true`, overrides all repos to seed from HEAD only; when
+    /// `false` (the default), repos use their per-config `head_only` setting.
+    /// Test: see `tests::head_only_legacy_behavior` in extractor.rs.
+    pub fn with_head_only(mut self, head_only: bool) -> Self {
+        self.head_only = head_only;
         self
     }
 
@@ -149,8 +174,15 @@ impl CollectionPipeline {
         let resolver = IdentityResolver::from_config(&self.config);
 
         for repo_cfg in &self.config.repositories {
+            // Per-repo head_only is OR-ed with the global pipeline flag: if
+            // either is true, that repo walks HEAD only.  This lets operators
+            // set `--head-only` globally (the CLI flag) or `head_only: true`
+            // per repo in YAML without requiring both to be set.
+            let effective_head_only = self.head_only || repo_cfg.head_only;
             let collector = match GitCollector::new(repo_cfg) {
-                Ok(c) => c.no_fetch(self.no_fetch),
+                Ok(c) => c
+                    .no_fetch(self.no_fetch)
+                    .with_head_only(effective_head_only),
                 Err(e) => {
                     let msg = format!("failed to open repo {}: {e}", repo_cfg.path.display());
                     warn!("{msg}");

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -77,6 +77,13 @@ pub struct CollectionPipeline {
     /// the rest.  The global flag here is OR-ed with the per-repo flag — if
     /// either is `true`, that repo walks HEAD only.
     head_only: bool,
+    /// Explicit branch list for the `--branch` CLI filter.
+    ///
+    /// When non-empty, the revwalk is seeded from only these branch names
+    /// (both `refs/heads/<name>` and `refs/remotes/origin/<name>` for each).
+    /// Mutually exclusive with `head_only` — the CLI enforces this via
+    /// `conflicts_with`.  An empty Vec means "no restriction" (the default).
+    branches: Vec<String>,
 }
 
 impl CollectionPipeline {
@@ -95,6 +102,7 @@ impl CollectionPipeline {
             force_refresh_prs: false,
             skip_tag_reachability: false,
             head_only: false,
+            branches: Vec::new(),
         }
     }
 
@@ -142,6 +150,25 @@ impl CollectionPipeline {
         self
     }
 
+    /// Restrict the revwalk to an explicit list of branch names.
+    ///
+    /// Why: the `--branch <NAME[,NAME…]>` CLI flag lets callers scope collection
+    /// to specific branches without touching the YAML config.  This is the
+    /// pipeline-level counterpart that threads the list down to each
+    /// `GitCollector`.
+    /// What: when `branches` is non-empty, each `GitCollector` seeds the
+    /// revwalk from `refs/heads/<name>` + `refs/remotes/origin/<name>` for
+    /// every listed name, emitting a warning for names not found in a given
+    /// repo.  An empty `branches` (the default) means "no restriction".
+    /// Mutually exclusive with `head_only` — enforced at the CLI layer via
+    /// `conflicts_with`.
+    /// Test: see `tests::branch_filter_walks_only_named_branch` in
+    /// `collect::git::extractor::tests`.
+    pub fn with_branches(mut self, branches: Vec<String>) -> Self {
+        self.branches = branches;
+        self
+    }
+
     /// If `true`, re-fetch Azure DevOps pull requests even when their IDs are
     /// already present in `pull_requests`.
     ///
@@ -182,7 +209,8 @@ impl CollectionPipeline {
             let collector = match GitCollector::new(repo_cfg) {
                 Ok(c) => c
                     .no_fetch(self.no_fetch)
-                    .with_head_only(effective_head_only),
+                    .with_head_only(effective_head_only)
+                    .with_explicit_branches(self.branches.clone()),
                 Err(e) => {
                     let msg = format!("failed to open repo {}: {e}", repo_cfg.path.display());
                     warn!("{msg}");

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -53,6 +53,13 @@ pub struct GitCollector {
     /// `refs/remotes/origin/*` ref so that commits on non-default branches
     /// are not silently excluded.
     head_only: bool,
+    /// Explicit branch list from `--branch <NAME[,NAME…]>`.
+    ///
+    /// When non-empty, overrides all other revwalk seeding logic: the walk
+    /// seeds from `refs/heads/<name>` + `refs/remotes/origin/<name>` for
+    /// each listed name.  An empty vec means "no restriction" (use the
+    /// default all-branches or head_only logic).
+    explicit_branches: Vec<String>,
 }
 
 impl GitCollector {
@@ -98,6 +105,7 @@ impl GitCollector {
             no_fetch: false,
             remote_name: "origin".to_string(),
             head_only: config.head_only,
+            explicit_branches: Vec::new(),
         })
     }
 
@@ -132,6 +140,23 @@ impl GitCollector {
     /// `tests::multi_branch_coverage`.
     pub fn with_head_only(mut self, head_only: bool) -> Self {
         self.head_only = head_only;
+        self
+    }
+
+    /// Restrict the revwalk to an explicit list of branch names.
+    ///
+    /// Why: the `--branch <NAME[,NAME…]>` CLI flag enables surgical re-runs
+    /// on specific branches without modifying the YAML config.  When set, this
+    /// takes priority over `head_only` and the all-branches default, seeding
+    /// only the listed names.
+    /// What: for each name, pushes `refs/heads/<name>` and
+    /// `refs/remotes/origin/<name>`.  Names not found in the repo are logged as
+    /// warnings but do not abort collection.  An empty `Vec` (the default)
+    /// means no restriction — fall through to `head_only` / all-branches logic.
+    /// Test: see `tests::branch_filter_walks_only_named_branch` and
+    /// `tests::branch_filter_composes_with_repos`.
+    pub fn with_explicit_branches(mut self, branches: Vec<String>) -> Self {
+        self.explicit_branches = branches;
         self
     }
 
@@ -187,73 +212,123 @@ impl GitCollector {
 
         let mut revwalk = repo.revwalk()?;
         revwalk.set_sorting(Sort::TIME)?;
-        // Revwalk seeding: three cases in priority order.
+        // Revwalk seeding: four cases in priority order.
         //
-        // 1. Explicit per-repo `branch` override — unchanged from 1.x, walks
+        // 1. `explicit_branches` non-empty — `--branch <NAME[,NAME…]>` CLI
+        //    filter.  Walks only the listed branches (both local heads and
+        //    remote-tracking copies).  Names not found emit a warning.
+        // 2. Explicit per-repo `branch` override — unchanged from 1.x, walks
         //    only that branch's ancestry.
-        // 2. `head_only = true` — legacy escape hatch, seeds from HEAD only.
-        // 3. Default (2.0.0+): push every `refs/heads/*` and every
+        // 3. `head_only = true` — legacy escape hatch, seeds from HEAD only.
+        // 4. Default (2.0.0+): push every `refs/heads/*` and every
         //    `refs/remotes/origin/*` so commits on non-default branches are
         //    not silently excluded.  The revwalk's internal dedup ensures each
         //    commit is yielded at most once even when reachable from multiple
         //    refs.  The `INSERT OR IGNORE` on the `commits` SHA primary key
         //    provides a second safety net.
-        match (&self.branch, self.head_only) {
-            (Some(name), _) => {
-                // Explicit per-repo branch override still works as before.
-                let refname = format!("refs/heads/{name}");
-                if revwalk.push_ref(&refname).is_err() {
-                    // Try as a generic revision (could be a tag or remote ref).
-                    revwalk.push_ref(name)?;
-                }
-            }
-            (None, true) => {
-                // Legacy escape hatch: --head-only flag or per-repo head_only: true.
-                debug!(repo = %self.name, "head_only mode: seeding revwalk from HEAD only (legacy 1.x behaviour)");
-                revwalk.push_head()?;
-            }
-            (None, false) => {
-                // NEW DEFAULT (2.0.0+): push every local branch head and
-                // every remote tracking ref so multi-branch repos don't lose
-                // commits that never landed on the default branch.
-                let mut heads_pushed = 0u32;
-                let mut remotes_pushed = 0u32;
-                let refs = repo.references()?;
-                for r in refs.flatten() {
-                    let Some(name) = r.name() else { continue };
-                    if name.starts_with("refs/heads/") {
-                        if revwalk.push_ref(name).is_ok() {
-                            heads_pushed += 1;
-                        }
-                    } else if name.starts_with("refs/remotes/origin/")
-                        && name != "refs/remotes/origin/HEAD"
-                        && revwalk.push_ref(name).is_ok()
-                    {
-                        remotes_pushed += 1;
-                    }
-                }
-                let total = heads_pushed + remotes_pushed;
-                if total > 0 {
-                    info!(
-                        repo = %self.name,
-                        refs_walked = total,
-                        heads = heads_pushed,
-                        remote_tracking = remotes_pushed,
-                        "all-branch walk: pushed {} refs ({} heads + {} remote-tracking)",
-                        total,
-                        heads_pushed,
-                        remotes_pushed,
-                    );
-                } else {
-                    // Fallback: repos with weird ref layouts (e.g. detached
-                    // HEAD with no local branches — common in CI shallow
-                    // clones) still get some coverage.
+        if !self.explicit_branches.is_empty() {
+            // Arm 1: --branch filter — seed only the listed branch names.
+            let mut pushed = 0u32;
+            for branch_name in &self.explicit_branches {
+                let local_ref = format!("refs/heads/{branch_name}");
+                let remote_ref = format!("refs/remotes/origin/{branch_name}");
+                let local_ok = revwalk.push_ref(&local_ref).is_ok();
+                let remote_ok = revwalk.push_ref(&remote_ref).is_ok();
+                if local_ok || remote_ok {
+                    pushed += 1;
                     debug!(
                         repo = %self.name,
-                        "no refs/heads/* or refs/remotes/origin/* found; \
-                         falling back to HEAD for revwalk seed"
+                        branch = %branch_name,
+                        local = local_ok,
+                        remote = remote_ok,
+                        "--branch filter: pushed refs for branch"
                     );
+                } else {
+                    warn!(
+                        repo = %self.name,
+                        branch = %branch_name,
+                        "--branch filter: branch '{}' not found in repo '{}' \
+                         (neither refs/heads/{} nor refs/remotes/origin/{}); skipping",
+                        branch_name,
+                        self.name,
+                        branch_name,
+                        branch_name,
+                    );
+                }
+            }
+            if pushed == 0 {
+                // None of the listed branches exist in this repo — nothing to walk.
+                warn!(
+                    repo = %self.name,
+                    "--branch filter found no matching refs; producing zero commits for this repo"
+                );
+            } else {
+                info!(
+                    repo = %self.name,
+                    branches_found = pushed,
+                    "--branch filter: walking {} of {} requested branches",
+                    pushed,
+                    self.explicit_branches.len(),
+                );
+            }
+        } else {
+            match (&self.branch, self.head_only) {
+                (Some(name), _) => {
+                    // Arm 2: Explicit per-repo branch override still works as before.
+                    let refname = format!("refs/heads/{name}");
+                    if revwalk.push_ref(&refname).is_err() {
+                        // Try as a generic revision (could be a tag or remote ref).
+                        revwalk.push_ref(name)?;
+                    }
+                }
+                (None, true) => {
+                    // Arm 3: Legacy escape hatch: --head-only flag or per-repo head_only: true.
+                    debug!(repo = %self.name, "head_only mode: seeding revwalk from HEAD only (legacy 1.x behaviour)");
                     revwalk.push_head()?;
+                }
+                (None, false) => {
+                    // Arm 4 (NEW DEFAULT 2.0.0+): push every local branch head and
+                    // every remote tracking ref so multi-branch repos don't lose
+                    // commits that never landed on the default branch.
+                    let mut heads_pushed = 0u32;
+                    let mut remotes_pushed = 0u32;
+                    let refs = repo.references()?;
+                    for r in refs.flatten() {
+                        let Some(name) = r.name() else { continue };
+                        if name.starts_with("refs/heads/") {
+                            if revwalk.push_ref(name).is_ok() {
+                                heads_pushed += 1;
+                            }
+                        } else if name.starts_with("refs/remotes/origin/")
+                            && name != "refs/remotes/origin/HEAD"
+                            && revwalk.push_ref(name).is_ok()
+                        {
+                            remotes_pushed += 1;
+                        }
+                    }
+                    let total = heads_pushed + remotes_pushed;
+                    if total > 0 {
+                        info!(
+                            repo = %self.name,
+                            refs_walked = total,
+                            heads = heads_pushed,
+                            remote_tracking = remotes_pushed,
+                            "all-branch walk: pushed {} refs ({} heads + {} remote-tracking)",
+                            total,
+                            heads_pushed,
+                            remotes_pushed,
+                        );
+                    } else {
+                        // Fallback: repos with weird ref layouts (e.g. detached
+                        // HEAD with no local branches — common in CI shallow
+                        // clones) still get some coverage.
+                        debug!(
+                            repo = %self.name,
+                            "no refs/heads/* or refs/remotes/origin/* found; \
+                             falling back to HEAD for revwalk seed"
+                        );
+                        revwalk.push_head()?;
+                    }
                 }
             }
         }

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -12,9 +12,10 @@ use indicatif::{ProgressBar, ProgressStyle};
 use rusqlite::params;
 use tracing::{debug, info, warn};
 
+use crate::collect::collector::{FetchOutcome, PerRepoFetch};
 use crate::collect::errors::{CollectError, Result};
 use crate::collect::git::diff::{compute_commit_diff, CommitDiff};
-use crate::collect::git::fetch::fetch_remote;
+use crate::collect::git::fetch::{fetch_and_record, fetch_remote};
 use crate::collect::ticket::{extract_ticket_id, is_ticketed};
 use crate::core::config::{expand_path, RepositoryConfig};
 use crate::core::db::Database;
@@ -60,6 +61,12 @@ pub struct GitCollector {
     /// each listed name.  An empty vec means "no restriction" (use the
     /// default all-branches or head_only logic).
     explicit_branches: Vec<String>,
+    /// Optional per-repo fetch timeout in seconds.
+    ///
+    /// When `Some(n)`, stored for future enforcement via a thread-based
+    /// watchdog.  When `None` (the default), the system / git2 transport
+    /// defaults apply.  See issue #334 and `RepositoryConfig::fetch_timeout_secs`.
+    fetch_timeout_secs: Option<u64>,
 }
 
 impl GitCollector {
@@ -106,6 +113,7 @@ impl GitCollector {
             remote_name: "origin".to_string(),
             head_only: config.head_only,
             explicit_branches: Vec::new(),
+            fetch_timeout_secs: config.fetch_timeout_secs,
         })
     }
 
@@ -160,6 +168,64 @@ impl GitCollector {
         self
     }
 
+    /// Override the per-repo fetch timeout.
+    ///
+    /// Why: the value from [`crate::core::config::RepositoryConfig::fetch_timeout_secs`]
+    /// is set via `new`; this builder lets callers override it without
+    /// constructing a new config struct.
+    /// What: stores the value; enforcement is scheduled for a future release
+    /// once git2 exposes transport-level timeouts. For now the field is
+    /// persisted and logged but not acted upon.
+    /// Test: constructor round-trip is verified in `tests::fetch_timeout_stored`.
+    pub fn with_fetch_timeout(mut self, secs: Option<u64>) -> Self {
+        self.fetch_timeout_secs = secs;
+        self
+    }
+
+    /// Perform a one-shot `git fetch origin` for this repository and return
+    /// a typed outcome.
+    ///
+    /// Why: the pipeline calls this once per repo before the per-week
+    /// `collect_window` loop so that (a) only one network round-trip is
+    /// made per repo and (b) the outcome is available for the end-of-run
+    /// summary (issue #334).
+    /// What: if `no_fetch` is set, returns a `Skipped` outcome immediately.
+    /// Otherwise opens the repository, calls `fetch_and_record`, and returns
+    /// the result. A `fetch_timeout_secs` value is logged but not yet enforced
+    /// at the libgit2 level (scheduled for a future release).
+    /// Test: see `fetch::tests::fetch_outcome_skipped_for_local_repo` and
+    /// the `no_fetch_returns_skipped` test in `extractor::tests`.
+    pub fn perform_fetch(&self) -> PerRepoFetch {
+        if self.no_fetch {
+            return PerRepoFetch {
+                repo: self.name.clone(),
+                outcome: FetchOutcome::Skipped {
+                    reason: "--no-fetch".to_string(),
+                },
+            };
+        }
+        if let Some(t) = self.fetch_timeout_secs {
+            tracing::debug!(
+                repo = %self.name,
+                timeout_secs = t,
+                "fetch_timeout_secs configured (enforcement pending future release)"
+            );
+        }
+        let repo = match Repository::open(&self.path) {
+            Ok(r) => r,
+            Err(e) => {
+                return PerRepoFetch {
+                    repo: self.name.clone(),
+                    outcome: FetchOutcome::Failed {
+                        remote: self.remote_name.clone(),
+                        error: format!("failed to open repo for fetch: {e}"),
+                    },
+                };
+            }
+        };
+        fetch_and_record(&repo, &self.name, &self.remote_name)
+    }
+
     /// Walk the repository and insert commits into the database.
     ///
     /// Returns the number of commits written.
@@ -195,8 +261,11 @@ impl GitCollector {
             "starting commit extraction"
         );
 
-        // Optional pre-walk remote fetch. Soft-fails on auth/transport so a
-        // misconfigured remote doesn't break collection on local history.
+        // Note: the pre-walk fetch is now performed once per repo via
+        // `perform_fetch` before the week loop in `CollectionPipeline::collect_repo_by_week`.
+        // `collect_window` no longer fetches to avoid N fetches for N weeks.
+        // Legacy callers that invoke `collect_window` directly on a collector
+        // with `no_fetch = false` will still get a fetch here as a safety net.
         if !self.no_fetch {
             if let Err(e) = fetch_remote(&repo, &self.remote_name) {
                 warn!(
@@ -207,7 +276,7 @@ impl GitCollector {
                 );
             }
         } else {
-            debug!(repo = %self.name, "skipping pre-walk fetch (--no-fetch)");
+            debug!(repo = %self.name, "skipping pre-walk fetch (already done or --no-fetch)");
         }
 
         let mut revwalk = repo.revwalk()?;
@@ -572,6 +641,25 @@ mod tests {
         path: PathBuf,
     }
 
+    impl TempRepo {
+        /// Create a new temporary git repository with a stable test identity.
+        ///
+        /// Why: the #334 `perform_fetch` tests need a quick one-liner to
+        /// create a throw-away repo without needing the full `init_repo` API.
+        /// What: initialises an empty git repo in a unique temp directory.
+        /// Test: used directly by `no_fetch_returns_skipped` etc.
+        fn new() -> Self {
+            let path = unique_dir("temprepo");
+            std::fs::create_dir_all(&path).expect("mkdir");
+            let repo = Repository::init(&path).expect("git init");
+            let mut cfg = repo.config().expect("repo config");
+            cfg.set_str("user.name", "Test").expect("set user.name");
+            cfg.set_str("user.email", "t@example.com")
+                .expect("set user.email");
+            TempRepo { path }
+        }
+    }
+
     impl Drop for TempRepo {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
@@ -672,6 +760,23 @@ mod tests {
         make_collector_opts(path, since, until, None, false)
     }
 
+    /// Build a minimal [`RepositoryConfig`] for a test repo path.
+    fn make_repo_config(path: &Path) -> RepositoryConfig {
+        RepositoryConfig {
+            name: path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_string),
+            path: path.to_path_buf(),
+            branch: None,
+            since_date: None,
+            until_date: None,
+            org: None,
+            head_only: false,
+            fetch_timeout_secs: None,
+        }
+    }
+
     /// Full-option collector factory used by branch-coverage tests.
     fn make_collector_opts(
         path: &Path,
@@ -688,6 +793,7 @@ mod tests {
             until_date: until.map(str::to_string),
             org: None,
             head_only,
+            fetch_timeout_secs: None,
         };
         GitCollector::new(&cfg)
             .expect("collector::new")
@@ -1136,5 +1242,70 @@ mod tests {
             written, 1,
             "fallback to HEAD must yield the single commit; got {written}"
         );
+    }
+
+    /// Why: `perform_fetch` must return Skipped when `no_fetch = true` so
+    /// that `--no-fetch` callers get a typed outcome without opening the repo.
+    /// What: builds a collector with `no_fetch(true)` on a temp repo and
+    /// calls `perform_fetch`; expects `FetchOutcome::Skipped`.
+    /// Test: this test itself.
+    #[test]
+    fn no_fetch_returns_skipped() {
+        use crate::collect::collector::FetchOutcome;
+        let _t = TempRepo::new();
+        let cfg = make_repo_config(_t.path.as_path());
+        let collector = GitCollector::new(&cfg).expect("new").no_fetch(true);
+        let prf = collector.perform_fetch();
+        assert!(
+            matches!(prf.outcome, FetchOutcome::Skipped { .. }),
+            "expected Skipped when no_fetch=true, got {:?}",
+            prf.outcome
+        );
+        assert_eq!(
+            prf.repo,
+            _t.path.file_name().unwrap().to_string_lossy().as_ref()
+        );
+    }
+
+    /// Why: `perform_fetch` on a local-only repo (no remotes) must return
+    /// Skipped rather than Failed, because "no remote" is a valid config.
+    /// What: builds a collector with `no_fetch(false)` on a temp repo that
+    /// has no remotes and calls `perform_fetch`.
+    /// Test: this test itself.
+    #[test]
+    fn perform_fetch_local_only_repo_returns_skipped() {
+        use crate::collect::collector::FetchOutcome;
+        let _t = TempRepo::new();
+        let cfg = make_repo_config(_t.path.as_path());
+        let collector = GitCollector::new(&cfg).expect("new").no_fetch(false);
+        let prf = collector.perform_fetch();
+        // Local-only repo → no "origin" remote → Skipped.
+        assert!(
+            matches!(prf.outcome, FetchOutcome::Skipped { .. }),
+            "expected Skipped for local-only repo, got {:?}",
+            prf.outcome
+        );
+    }
+
+    /// Why: `with_fetch_timeout` must store the value so callers can
+    /// introspect it (and future enforcement can read it).
+    /// What: sets a timeout via the builder and verifies the value is stored.
+    /// Test: this test itself (struct field is private, but `perform_fetch`
+    /// logs the value without erroring — we just verify no panic).
+    #[test]
+    fn fetch_timeout_stored_does_not_panic() {
+        let _t = TempRepo::new();
+        let cfg = make_repo_config(_t.path.as_path());
+        // Should not panic even when timeout is set.
+        let collector = GitCollector::new(&cfg)
+            .expect("new")
+            .no_fetch(true)
+            .with_fetch_timeout(Some(30));
+        let prf = collector.perform_fetch();
+        // no_fetch=true → always Skipped, regardless of timeout
+        assert!(matches!(
+            prf.outcome,
+            crate::collect::collector::FetchOutcome::Skipped { .. }
+        ));
     }
 }

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -20,13 +20,23 @@ use crate::core::config::{expand_path, RepositoryConfig};
 use crate::core::db::Database;
 
 /// Extracts commits from a single configured repository.
+///
+/// Why: provides a single, configurable handle for walking a repository's
+/// commit history and inserting the results into the SQLite store.  Separating
+/// per-repo configuration (path, branch, date window, head_only flag) from the
+/// collection pipeline lets the pipeline build one `GitCollector` per entry in
+/// `config.repositories` and drive them independently.
+/// What: holds per-repo settings; the heavy work lives in `collect_window`.
+/// Test: see the `#[cfg(test)]` block below for unit tests covering branch
+/// coverage (multi_branch_coverage, head_only_legacy_behavior, etc.) and the
+/// ISO-week boundary tests from issue #70.
 #[derive(Debug)]
 pub struct GitCollector {
     /// Resolved on-disk path of the repository.
     path: PathBuf,
     /// Display name used in the `repository` column.
     name: String,
-    /// Branch override (None = HEAD).
+    /// Branch override (None = walk is controlled by `head_only`).
     branch: Option<String>,
     /// Optional inclusive since date (ISO 8601, parsed to UTC).
     since: Option<DateTime<Utc>>,
@@ -38,6 +48,11 @@ pub struct GitCollector {
     no_fetch: bool,
     /// Remote name to fetch from prior to the walk (default "origin").
     remote_name: String,
+    /// When `true`, seed the revwalk from HEAD only (legacy 1.x behaviour).
+    /// When `false` (default since 2.0.0), push every `refs/heads/*` and
+    /// `refs/remotes/origin/*` ref so that commits on non-default branches
+    /// are not silently excluded.
+    head_only: bool,
 }
 
 impl GitCollector {
@@ -82,6 +97,7 @@ impl GitCollector {
             skip_merges: false,
             no_fetch: false,
             remote_name: "origin".to_string(),
+            head_only: config.head_only,
         })
     }
 
@@ -101,6 +117,21 @@ impl GitCollector {
     /// Override the remote name used for the pre-walk fetch (default `"origin"`).
     pub fn with_remote(mut self, remote: impl Into<String>) -> Self {
         self.remote_name = remote.into();
+        self
+    }
+
+    /// Control HEAD-only vs. all-branches revwalk seeding.
+    ///
+    /// Why: tga 2.0.0 changed the default to walk all local branches and remote
+    /// tracking refs (`refs/heads/*` + `refs/remotes/origin/*`).  Callers that
+    /// need the legacy HEAD-only behaviour (e.g. the `--head-only` CLI flag or
+    /// per-repo `head_only: true` in YAML) set this to `true`.
+    /// What: stores the flag; the revwalk branching logic in `collect_window`
+    /// reads it at walk time.
+    /// Test: see `tests::head_only_legacy_behavior` and
+    /// `tests::multi_branch_coverage`.
+    pub fn with_head_only(mut self, head_only: bool) -> Self {
+        self.head_only = head_only;
         self
     }
 
@@ -156,15 +187,75 @@ impl GitCollector {
 
         let mut revwalk = repo.revwalk()?;
         revwalk.set_sorting(Sort::TIME)?;
-        match &self.branch {
-            Some(name) => {
+        // Revwalk seeding: three cases in priority order.
+        //
+        // 1. Explicit per-repo `branch` override — unchanged from 1.x, walks
+        //    only that branch's ancestry.
+        // 2. `head_only = true` — legacy escape hatch, seeds from HEAD only.
+        // 3. Default (2.0.0+): push every `refs/heads/*` and every
+        //    `refs/remotes/origin/*` so commits on non-default branches are
+        //    not silently excluded.  The revwalk's internal dedup ensures each
+        //    commit is yielded at most once even when reachable from multiple
+        //    refs.  The `INSERT OR IGNORE` on the `commits` SHA primary key
+        //    provides a second safety net.
+        match (&self.branch, self.head_only) {
+            (Some(name), _) => {
+                // Explicit per-repo branch override still works as before.
                 let refname = format!("refs/heads/{name}");
                 if revwalk.push_ref(&refname).is_err() {
                     // Try as a generic revision (could be a tag or remote ref).
                     revwalk.push_ref(name)?;
                 }
             }
-            None => revwalk.push_head()?,
+            (None, true) => {
+                // Legacy escape hatch: --head-only flag or per-repo head_only: true.
+                debug!(repo = %self.name, "head_only mode: seeding revwalk from HEAD only (legacy 1.x behaviour)");
+                revwalk.push_head()?;
+            }
+            (None, false) => {
+                // NEW DEFAULT (2.0.0+): push every local branch head and
+                // every remote tracking ref so multi-branch repos don't lose
+                // commits that never landed on the default branch.
+                let mut heads_pushed = 0u32;
+                let mut remotes_pushed = 0u32;
+                let refs = repo.references()?;
+                for r in refs.flatten() {
+                    let Some(name) = r.name() else { continue };
+                    if name.starts_with("refs/heads/") {
+                        if revwalk.push_ref(name).is_ok() {
+                            heads_pushed += 1;
+                        }
+                    } else if name.starts_with("refs/remotes/origin/")
+                        && name != "refs/remotes/origin/HEAD"
+                        && revwalk.push_ref(name).is_ok()
+                    {
+                        remotes_pushed += 1;
+                    }
+                }
+                let total = heads_pushed + remotes_pushed;
+                if total > 0 {
+                    info!(
+                        repo = %self.name,
+                        refs_walked = total,
+                        heads = heads_pushed,
+                        remote_tracking = remotes_pushed,
+                        "all-branch walk: pushed {} refs ({} heads + {} remote-tracking)",
+                        total,
+                        heads_pushed,
+                        remotes_pushed,
+                    );
+                } else {
+                    // Fallback: repos with weird ref layouts (e.g. detached
+                    // HEAD with no local branches — common in CI shallow
+                    // clones) still get some coverage.
+                    debug!(
+                        repo = %self.name,
+                        "no refs/heads/* or refs/remotes/origin/* found; \
+                         falling back to HEAD for revwalk seed"
+                    );
+                    revwalk.push_head()?;
+                }
+            }
         }
 
         // Spinner-style progress bar — we stream the revwalk so we don't
@@ -503,13 +594,25 @@ mod tests {
     }
 
     fn make_collector(path: &Path, since: Option<&str>, until: Option<&str>) -> GitCollector {
+        make_collector_opts(path, since, until, None, false)
+    }
+
+    /// Full-option collector factory used by branch-coverage tests.
+    fn make_collector_opts(
+        path: &Path,
+        since: Option<&str>,
+        until: Option<&str>,
+        branch: Option<&str>,
+        head_only: bool,
+    ) -> GitCollector {
         let cfg = RepositoryConfig {
             name: Some("test-repo".to_string()),
             path: path.to_path_buf(),
-            branch: None,
+            branch: branch.map(str::to_string),
             since_date: since.map(str::to_string),
             until_date: until.map(str::to_string),
             org: None,
+            head_only,
         };
         GitCollector::new(&cfg)
             .expect("collector::new")
@@ -716,6 +819,247 @@ mod tests {
         assert_eq!(
             utc.date_naive(),
             NaiveDate::from_ymd_opt(2026, 5, 4).unwrap()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #331 — branch coverage tests (added in tga 2.0.0)
+    // -------------------------------------------------------------------------
+
+    /// Helper: create a git branch pointing at the commit `oid`.
+    ///
+    /// Why: the existing `commit_at` helper always commits to HEAD on the
+    /// current branch.  We need to create a side branch and commit to it to
+    /// exercise the multi-branch revwalk path.
+    /// What: creates `refs/heads/<name>` pointing at `oid`.
+    /// Test: used by the #331 branch-coverage tests.
+    fn create_branch(repo: &Repository, name: &str, oid: git2::Oid) {
+        let commit = repo.find_commit(oid).expect("find_commit");
+        repo.branch(name, &commit, false).expect("branch");
+    }
+
+    /// Switch HEAD to a given branch so subsequent `commit_at` calls land on it.
+    ///
+    /// Why: `commit_at` uses `repo.head()` to find the parent commit, so HEAD
+    /// must point at the target branch for new commits to chain from it.
+    /// What: sets HEAD to `refs/heads/<name>` and checks out the worktree so
+    /// the index is consistent.
+    /// Test: used by multi_branch_coverage and related tests.
+    fn switch_branch(repo: &Repository, name: &str) {
+        let refname = format!("refs/heads/{name}");
+        repo.set_head(&refname).expect("set_head");
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .expect("checkout_head");
+    }
+
+    /// Return the name of the branch HEAD currently points at.
+    ///
+    /// Why: git2 `Repository::init` uses the system's `init.defaultBranch`
+    /// config value (commonly `master` or `main`).  Tests that need to return
+    /// HEAD to the default branch after switching to a feature branch must
+    /// not hard-code "main".
+    /// What: resolves `HEAD` as a symbolic ref and strips the `refs/heads/`
+    /// prefix, or returns "master" as a last resort.
+    /// Test: used in multi_branch_coverage and related tests.
+    fn current_branch_name(repo: &Repository) -> String {
+        repo.head()
+            .ok()
+            .and_then(|h| h.shorthand().map(str::to_string))
+            .unwrap_or_else(|| "master".to_string())
+    }
+
+    /// Helper: count distinct commit SHAs in the DB.
+    fn db_commit_count(db: &Database) -> usize {
+        let conn = db.connection();
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM commits", [], |r| r.get(0))
+            .expect("count");
+        n as usize
+    }
+
+    /// Issue #331 — Test 1: default (head_only=false) walk collects commits on
+    /// ALL branches, not just the default branch.
+    ///
+    /// Why: the 1.x HEAD-only walk silently dropped ~56% of commits in
+    /// multi-branch repos.  This test verifies the 2.0.0 all-branch default
+    /// collects every commit regardless of which branch it lives on.
+    /// What: creates 2 commits on main, branches to feature/x and creates 3
+    /// more, returns to main, and asserts all 5 are collected.
+    /// Test: this test itself.
+    #[test]
+    fn multi_branch_coverage() {
+        let (_t, repo) = init_repo("multi-branch-all");
+        let base_ts = utc_seconds(2026, 5, 1, 12, 0, 0);
+
+        // 2 commits on main.
+        commit_at(&repo, _t.path.as_path(), base_ts, 0, "main-1");
+        let main2 = commit_at(&repo, _t.path.as_path(), base_ts + 1, 0, "main-2");
+
+        // Create feature/x off main and add 3 commits.
+        let default_branch = current_branch_name(&repo);
+        create_branch(&repo, "feature/x", main2);
+        switch_branch(&repo, "feature/x");
+        commit_at(&repo, _t.path.as_path(), base_ts + 2, 0, "feat-1");
+        commit_at(&repo, _t.path.as_path(), base_ts + 3, 0, "feat-2");
+        commit_at(&repo, _t.path.as_path(), base_ts + 4, 0, "feat-3");
+
+        // Return to main (so HEAD points at main's tip — not feature/x).
+        switch_branch(&repo, &default_branch);
+
+        // Default collector: head_only = false → all branches.
+        let collector = make_collector_opts(_t.path.as_path(), None, None, None, false);
+        let mut db = open_in_memory_db();
+        let written = collector.collect(&mut db).expect("collect");
+
+        assert_eq!(
+            written, 5,
+            "all-branch walk must collect all 5 commits (2 on main + 3 on feature/x); \
+             got {written}"
+        );
+        assert_eq!(db_commit_count(&db), 5);
+    }
+
+    /// Issue #331 — Test 2: `--head-only` flag restores legacy HEAD-only
+    /// behaviour, collecting only commits reachable from HEAD.
+    ///
+    /// Why: operators who want the old behaviour must be able to opt out via
+    /// `--head-only` or `head_only: true` in YAML.
+    /// What: same setup as Test 1 but collects with `head_only = true`; since
+    /// HEAD is on main, only the 2 main commits should be returned.
+    /// Test: this test itself.
+    #[test]
+    fn head_only_legacy_behavior() {
+        let (_t, repo) = init_repo("multi-branch-headonly");
+        let base_ts = utc_seconds(2026, 5, 1, 12, 0, 0);
+
+        // 2 commits on main.
+        commit_at(&repo, _t.path.as_path(), base_ts, 0, "main-1");
+        let main2 = commit_at(&repo, _t.path.as_path(), base_ts + 1, 0, "main-2");
+
+        // Branch feature/x — 3 more commits (not reachable from HEAD/main).
+        let default_branch = current_branch_name(&repo);
+        create_branch(&repo, "feature/x", main2);
+        switch_branch(&repo, "feature/x");
+        commit_at(&repo, _t.path.as_path(), base_ts + 2, 0, "feat-1");
+        commit_at(&repo, _t.path.as_path(), base_ts + 3, 0, "feat-2");
+        commit_at(&repo, _t.path.as_path(), base_ts + 4, 0, "feat-3");
+
+        // Return to main — HEAD points at the 2-commit ancestry.
+        switch_branch(&repo, &default_branch);
+
+        // head_only = true → legacy walk, only HEAD ancestry.
+        let collector = make_collector_opts(_t.path.as_path(), None, None, None, true);
+        let mut db = open_in_memory_db();
+        let written = collector.collect(&mut db).expect("collect");
+
+        assert_eq!(
+            written, 2,
+            "head_only walk must only collect the 2 main commits; got {written}"
+        );
+        assert_eq!(db_commit_count(&db), 2);
+    }
+
+    /// Issue #331 — Test 3: explicit `branch` override still walks only that
+    /// branch's ancestry regardless of `head_only` setting.
+    ///
+    /// Why: per-repo `branch:` overrides should be unaffected by the 2.0.0
+    /// default change — they remain an explicit single-branch selector.
+    /// What: same setup; collect with `branch = Some("feature/x")` and
+    /// `head_only = false`.  Expects the 2 main + 3 feature commits (5 total)
+    /// because feature/x's ancestry includes both branches.
+    /// Test: this test itself.
+    #[test]
+    fn branch_override_still_works() {
+        let (_t, repo) = init_repo("multi-branch-override");
+        let base_ts = utc_seconds(2026, 5, 1, 12, 0, 0);
+
+        // 2 commits on main.
+        commit_at(&repo, _t.path.as_path(), base_ts, 0, "main-1");
+        let main2 = commit_at(&repo, _t.path.as_path(), base_ts + 1, 0, "main-2");
+
+        // Branch feature/x — 3 more commits.
+        let default_branch = current_branch_name(&repo);
+        create_branch(&repo, "feature/x", main2);
+        switch_branch(&repo, "feature/x");
+        commit_at(&repo, _t.path.as_path(), base_ts + 2, 0, "feat-1");
+        commit_at(&repo, _t.path.as_path(), base_ts + 3, 0, "feat-2");
+        commit_at(&repo, _t.path.as_path(), base_ts + 4, 0, "feat-3");
+
+        // Return to main.
+        switch_branch(&repo, &default_branch);
+
+        // Explicit branch override: walks feature/x ancestry which includes
+        // the 2 main commits (they are ancestors of feature/x).
+        let collector =
+            make_collector_opts(_t.path.as_path(), None, None, Some("feature/x"), false);
+        let mut db = open_in_memory_db();
+        let written = collector.collect(&mut db).expect("collect");
+
+        // feature/x was branched from main, so its full ancestry is 5 commits.
+        assert_eq!(
+            written, 5,
+            "branch=feature/x walk must include its full ancestry (2 base + 3 feature = 5); \
+             got {written}"
+        );
+        assert_eq!(db_commit_count(&db), 5);
+    }
+
+    /// Issue #331 — Test 4: all-branch walk on a repo where there is only a
+    /// detached HEAD and no local branches falls back gracefully to HEAD.
+    ///
+    /// Why: CI shallow clones may have a detached HEAD and no `refs/heads/*`.
+    /// The fallback must not panic or return an error.
+    /// What: initialise a repo, make one commit directly (which puts HEAD in
+    /// a normal state on the default branch), then manually delete the
+    /// `refs/heads/main` ref so the walk has no local branches to push.
+    /// Assert that collect returns the single commit via the HEAD fallback.
+    /// Test: this test itself.
+    #[test]
+    fn all_branches_fallback_when_no_local_refs() {
+        let (_t, repo) = init_repo("no-local-refs-fallback");
+        let base_ts = utc_seconds(2026, 5, 1, 12, 0, 0);
+
+        // One commit on the default branch (main or master depending on git config).
+        commit_at(&repo, _t.path.as_path(), base_ts, 0, "only-commit");
+
+        // Detach HEAD so refs/heads/* is empty.  We do this by setting HEAD
+        // directly to the commit OID (a detached HEAD), then deleting all
+        // local branch refs.
+        let head_commit = repo.head().expect("head").peel_to_commit().expect("peel");
+        // Detach HEAD to the commit OID.
+        repo.set_head_detached(head_commit.id())
+            .expect("detach HEAD");
+        // Delete all local branch refs so refs/heads/* is empty.
+        let ref_names: Vec<String> = repo
+            .references()
+            .expect("references")
+            .flatten()
+            .filter_map(|r| {
+                r.name().and_then(|n| {
+                    if n.starts_with("refs/heads/") {
+                        Some(n.to_string())
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+        for rn in ref_names {
+            repo.find_reference(&rn)
+                .expect("find ref")
+                .delete()
+                .expect("delete ref");
+        }
+
+        // All-branch walk (head_only = false) should fall back to HEAD.
+        let collector = make_collector_opts(_t.path.as_path(), None, None, None, false);
+        let mut db = open_in_memory_db();
+        let written = collector
+            .collect(&mut db)
+            .expect("collect — must not error");
+        assert_eq!(
+            written, 1,
+            "fallback to HEAD must yield the single commit; got {written}"
         );
     }
 }

--- a/crates/trusty-git-analytics/src/collect/git/fetch.rs
+++ b/crates/trusty-git-analytics/src/collect/git/fetch.rs
@@ -235,4 +235,52 @@ mod tests {
             prf.outcome
         );
     }
+
+    /// Why: the end-of-run fetch summary must include `Failed` entries for
+    /// repos whose remote exists but cannot be reached.  This test proves that
+    /// `fetch_remote_with_outcome` returns a `Failed` variant (not a panic or
+    /// an `Err`) when the remote's URL is unreachable.
+    /// What: creates two git repos, adds repo-b as an "origin" remote on
+    /// repo-a, then deletes repo-b so the URL is valid-looking but the target
+    /// directory is gone.  The fetch attempt against that dead path must
+    /// produce `FetchOutcome::Failed`.
+    /// Test: this test itself — covers the `Failed` branch of
+    /// `fetch_remote_with_outcome` and by extension `fetch_and_record`.
+    #[test]
+    fn fetch_remote_with_outcome_returns_failed_for_dead_remote() {
+        let td_remote = tempfile::tempdir().expect("tempdir for remote");
+        // Initialise a bare remote repo so git2 can point an origin at a valid path.
+        let _remote = git2::Repository::init_bare(td_remote.path()).expect("init bare");
+
+        let td_local = tempfile::tempdir().expect("tempdir for local");
+        let local = git2::Repository::init(td_local.path()).expect("init local");
+
+        // Set the origin remote to the path of the bare repo, then remove it
+        // to make the URL dead without being syntactically invalid.
+        let remote_url = td_remote.path().to_str().expect("valid utf8").to_string();
+        local
+            .remote("origin", &remote_url)
+            .expect("add remote origin");
+        // Drop td_remote explicitly to delete the directory.
+        drop(td_remote);
+        // Reopen local after remote dir is gone.
+        let local2 = git2::Repository::open(td_local.path()).expect("reopen local");
+
+        let outcome = fetch_remote_with_outcome(&local2, "origin")
+            .expect("no Err — soft-fail policy means we return Ok(Failed)");
+        assert!(
+            matches!(outcome, FetchOutcome::Failed { .. }),
+            "expected Failed for dead remote path, got {outcome:?}"
+        );
+
+        // Also verify the fetch_and_record wrapper preserves the repo name.
+        let local3 = git2::Repository::open(td_local.path()).expect("reopen local 3");
+        let prf = fetch_and_record(&local3, "dead-remote-repo", "origin");
+        assert_eq!(prf.repo, "dead-remote-repo");
+        assert!(
+            matches!(prf.outcome, FetchOutcome::Failed { .. }),
+            "expected Failed in PerRepoFetch, got {:?}",
+            prf.outcome
+        );
+    }
 }

--- a/crates/trusty-git-analytics/src/collect/git/fetch.rs
+++ b/crates/trusty-git-analytics/src/collect/git/fetch.rs
@@ -19,22 +19,35 @@ use std::path::PathBuf;
 use git2::{Cred, CredentialType, FetchOptions, RemoteCallbacks, Repository};
 use tracing::{info, warn};
 
+use crate::collect::collector::{FetchOutcome, PerRepoFetch};
 use crate::collect::errors::Result;
 
 /// Fetch all refs from the configured remote before walking.
 ///
-/// Returns `Ok(())` if:
-/// - the fetch succeeds,
-/// - the repository has no remote with the requested name (purely local
-///   repos are a supported case), or
-/// - authentication fails non-interactively (warn-and-continue so a CI
-///   misconfiguration doesn't break the whole pipeline).
-///
-/// # Errors
-///
-/// Currently returns [`crate::collect::CollectError`] only for unexpected libgit2 errors
-/// that aren't classified as auth/transport failures.
+/// Why: backwards-compatible soft-fail wrapper; callers that do not need
+/// per-repo outcome tracking use this.
+/// What: returns `Ok(())` whether the fetch succeeds or fails so that
+/// collection can always proceed on whatever the local clone has.
+/// Test: covered indirectly by extractor tests that call `GitCollector::collect`.
 pub fn fetch_remote(repo: &Repository, remote_name: &str) -> Result<()> {
+    fetch_remote_with_outcome(repo, remote_name).map(|_| ())
+}
+
+/// Fetch all refs from the configured remote and return a typed outcome.
+///
+/// Why: `fetch_remote` discards success/failure information; this variant
+/// surfaces it as a [`FetchOutcome`] so the CLI can print an end-of-run
+/// summary table (requirement #334).
+/// What: attempts `git fetch <remote_name>`.  Returns:
+///   - `FetchOutcome::Success` on a clean fetch,
+///   - `FetchOutcome::Skipped` when the named remote does not exist
+///     (local-only repos are a supported case — not an error),
+///   - `FetchOutcome::Failed` for any auth/transport/git2 error.
+///
+/// Test: unit test `tests::fetch_outcome_skipped_for_local_repo` in this
+/// module verifies the Skipped path; Failed and Success paths are exercised
+/// by integration tests against real git fixtures.
+pub fn fetch_remote_with_outcome(repo: &Repository, remote_name: &str) -> Result<FetchOutcome> {
     let mut remote = match repo.find_remote(remote_name) {
         Ok(r) => r,
         Err(e) => {
@@ -44,7 +57,9 @@ pub fn fetch_remote(repo: &Repository, remote_name: &str) -> Result<()> {
                 error = %e,
                 "no matching remote; skipping fetch (local-only repo)"
             );
-            return Ok(());
+            return Ok(FetchOutcome::Skipped {
+                reason: "no remote configured".to_string(),
+            });
         }
     };
 
@@ -60,26 +75,57 @@ pub fn fetch_remote(repo: &Repository, remote_name: &str) -> Result<()> {
 
     // Fetch with default refspecs (empty slice == use configured refspecs).
     match remote.fetch(&[] as &[&str], Some(&mut fetch_options), None) {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            info!(remote = remote_name, "fetch succeeded");
+            Ok(FetchOutcome::Success {
+                remote: remote_name.to_string(),
+            })
+        }
         Err(e) => {
             // git2 lumps auth, transport, and certificate problems together;
-            // treat anything in the auth/transport family as a soft failure.
-            if is_auth_or_transport_error(&e) {
-                warn!(
-                    remote = remote_name,
-                    error = %e,
-                    "fetch failed (auth/transport) — continuing with local refs"
-                );
-                Ok(())
+            // treat anything in the auth/transport family as a soft failure
+            // but record the error string so the end-of-run summary is useful.
+            let kind = if is_auth_or_transport_error(&e) {
+                "auth/transport"
             } else {
-                warn!(
-                    remote = remote_name,
-                    error = %e,
-                    "fetch failed — continuing with local refs"
-                );
-                Ok(())
-            }
+                "git"
+            };
+            warn!(
+                remote = remote_name,
+                error = %e,
+                kind,
+                "fetch failed — continuing with local refs"
+            );
+            Ok(FetchOutcome::Failed {
+                remote: remote_name.to_string(),
+                error: e.to_string(),
+            })
         }
+    }
+}
+
+/// Build a [`PerRepoFetch`] by running a tracked fetch for a named repository.
+///
+/// Why: wraps `fetch_remote_with_outcome` with the repo display name so the
+/// returned value is ready to push into [`crate::collect::collector::CollectionStats::fetch_outcomes`].
+/// What: opens the repo, runs `fetch_remote_with_outcome`, and packages the
+/// result with `repo_name`.  If opening the repo fails, returns a Failed
+/// outcome rather than propagating the error (consistent with the soft-fail
+/// policy for all per-repo operations).
+/// Test: covered by the integration test in `collector::tests`.
+pub fn fetch_and_record(repo: &Repository, repo_name: &str, remote_name: &str) -> PerRepoFetch {
+    match fetch_remote_with_outcome(repo, remote_name) {
+        Ok(outcome) => PerRepoFetch {
+            repo: repo_name.to_string(),
+            outcome,
+        },
+        Err(e) => PerRepoFetch {
+            repo: repo_name.to_string(),
+            outcome: FetchOutcome::Failed {
+                remote: remote_name.to_string(),
+                error: e.to_string(),
+            },
+        },
     }
 }
 
@@ -149,4 +195,44 @@ fn is_auth_or_transport_error(e: &git2::Error) -> bool {
             | git2::ErrorClass::Net
             | git2::ErrorClass::Callback
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: local-only repos (no remotes) are a valid configuration; the
+    /// fetch path must return Skipped rather than an error.
+    /// What: creates a temp in-memory git repo with no remotes, calls
+    /// `fetch_remote_with_outcome`, and asserts the Skipped variant.
+    /// Test: this test itself.
+    #[test]
+    fn fetch_outcome_skipped_for_local_repo() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let repo = git2::Repository::init(td.path()).expect("init");
+        // No remote configured → expect Skipped.
+        let outcome =
+            fetch_remote_with_outcome(&repo, "origin").expect("no error expected from soft-fail");
+        assert!(
+            matches!(outcome, FetchOutcome::Skipped { .. }),
+            "expected Skipped, got {outcome:?}"
+        );
+    }
+
+    /// Why: ensure that `fetch_and_record` wraps the outcome with the correct
+    /// repo name without panicking.
+    /// What: uses the same local-only repo and verifies PerRepoFetch.repo field.
+    /// Test: this test itself.
+    #[test]
+    fn fetch_and_record_sets_repo_name() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let repo = git2::Repository::init(td.path()).expect("init");
+        let prf = fetch_and_record(&repo, "my-repo", "origin");
+        assert_eq!(prf.repo, "my-repo");
+        assert!(
+            matches!(prf.outcome, FetchOutcome::Skipped { .. }),
+            "expected Skipped, got {:?}",
+            prf.outcome
+        );
+    }
 }

--- a/crates/trusty-git-analytics/src/commands/aliases.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases.rs
@@ -15,6 +15,26 @@ use tga::core::db::Database;
 
 /// Arguments for `tga aliases`.
 #[derive(Args, Debug)]
+#[command(
+    about = "List, merge, or manage developer identity aliases.",
+    long_about = "Manage the identity resolution table that maps commit author metadata\n\
+(name + email combinations) to a single canonical identity per engineer.\n\n\
+Merging two identities reassigns all commits from the source to the destination\n\
+and deletes the source row. Subsequent pipeline stages and reports will see only\n\
+the consolidated identity.\n\n\
+tga automatically resolves identity during collection using fuzzy matching.\n\
+Use these subcommands for manual corrections and audits.",
+    after_help = "EXAMPLES:\n\
+  # List all canonical identities in the database\n\
+  tga aliases list\n\n\
+  # Merge a work email into the canonical personal-account identity\n\
+  tga aliases merge old@contractor.com alice@company.com\n\n\
+  # Merge without the confirmation prompt\n\
+  tga aliases merge old@example.com alice@example.com --yes\n\n\
+TIPS:\n\
+  - Run `tga report --author alice@company.com` to verify the merge result.\n\
+  - Use the canonical email from `tga aliases list` as the --author value."
+)]
 pub struct AliasesArgs {
     /// Aliases subcommand.
     #[command(subcommand)]

--- a/crates/trusty-git-analytics/src/commands/backfill.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill.rs
@@ -5,6 +5,11 @@
 //! pipeline because they update existing rows in-place rather than
 //! ingesting new data. Each subcommand supports `--dry-run`, in which case
 //! it reports the number of rows that *would* change without writing.
+//!
+//! Uniform filter flags (`--repos`, `--weeks`, `--since`, `--until`) scope
+//! the backfill to a specific slice of the database. `--branch` is **not**
+//! applicable to backfill operations because commits in the database do not
+//! carry branch attribution after the original collection walk.
 
 use clap::{Args, Subcommand};
 use git2::{Repository, Sort};
@@ -17,6 +22,25 @@ use tga::core::effort::{compute_effort, FORMULA_VERSION};
 
 /// Arguments for `tga backfill`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Retroactive maintenance operations on existing commit rows.",
+    long_about = "Re-run extraction or scoring steps on commits already in the database.\n\n\
+These operations update existing rows in-place rather than ingesting new data.\n\
+Each subcommand supports --dry-run to preview changes without writing.\n\n\
+NOTE: --branch is collect-only. Commits in the DB do not carry branch\n\
+attribution after the walk, so there is no branch filter on backfill operations.\n\
+If you need to re-walk specific branches, use `tga collect --branch <name>`.\n\n\
+TIPS:\n\
+  - Use --repos to limit scope to one service at a time on large corpora.\n\
+  - Use --since/--until or --weeks to limit the date window for fast iteration.",
+    after_help = "EXAMPLES:\n\
+  # Re-extract ticket IDs for all commits (after pattern change)\n\
+  tga backfill ticket-ids\n\n\
+  # Re-score effort for the last 4 weeks of one repo\n\
+  tga backfill effort --repos my-service --weeks 4 --force\n\n\
+  # Re-run reachability scan after adding release-branch patterns\n\
+  tga backfill reachability --repos core-api"
+)]
 pub struct BackfillArgs {
     /// Backfill subcommand.
     #[command(subcommand)]
@@ -24,72 +48,84 @@ pub struct BackfillArgs {
     /// Report what would change without writing.
     #[arg(long, default_value_t = false, global = true)]
     pub dry_run: bool,
+    /// Limit backfill to these repository names (comma-separated). [global]
+    ///
+    /// Matches against the `repository` column in the `commits` table
+    /// (for ticket-ids, revert-flags) or the repo `name` in config
+    /// (for reachability, effort). When omitted, all repos are processed.
+    ///
+    /// NOTE: not applicable to ai-detection (global LLM re-classification).
+    #[arg(long, value_delimiter = ',', global = true)]
+    pub repos: Vec<String>,
+    /// Limit backfill to commits in the last N ISO weeks. [global]
+    ///
+    /// Restricts the set of commits processed by timestamp. Mutually exclusive
+    /// with --since/--until. Not applicable to reachability (uses config repos).
+    #[arg(long, value_name = "N", global = true, conflicts_with_all = ["since", "until"])]
+    pub weeks: Option<u32>,
+    /// Limit backfill to commits on or after this date (ISO8601: YYYY-MM-DD). [global]
+    ///
+    /// Lower bound on the author timestamp. Mutually exclusive with --weeks.
+    #[arg(long, value_name = "DATE", global = true, conflicts_with = "weeks")]
+    pub since: Option<String>,
+    /// Limit backfill to commits on or before this date (ISO8601: YYYY-MM-DD). [global]
+    ///
+    /// Upper bound on the author timestamp. Mutually exclusive with --weeks.
+    #[arg(long, value_name = "DATE", global = true, conflicts_with = "weeks")]
+    pub until: Option<String>,
 }
 
 /// `tga backfill` subcommands.
 #[derive(Subcommand, Debug)]
 pub enum BackfillSubcommand {
     /// Re-run LLM classification on low-confidence prior LLM verdicts.
-    AiDetection,
-    /// Scan commit messages for revert patterns and set `is_revert`.
-    RevertFlags,
-    /// Scan commit messages for ticket refs and update `ticket_id`/`ticketed`.
-    TicketIds,
-    /// Re-run the tag/branch/default-branch reachability scan and upsert
-    /// `fact_commit_reachability` without re-collecting commits.
     ///
+    /// Clears `classification_id` on commits classified by the LLM tier
+    /// with confidence < 0.7, making them eligible for re-classification
+    /// on the next `tga classify` run. Use `tga classify --force` after
+    /// this to immediately re-process the cleared commits.
+    AiDetection,
+    /// Scan commit messages for revert patterns and update `is_revert`.
+    ///
+    /// Detects `Revert "..."`, `revert:`, and `revert"` prefixes
+    /// (case-insensitive). Use --repos/--since/--until to limit scope.
+    RevertFlags,
+    /// Scan commit messages for ticket references and update `ticket_id`/`ticketed`.
+    ///
+    /// Useful after extending ticket patterns or when collecting a new
+    /// repo whose commits were never run through ticket extraction.
+    /// --branch is collect-only and not applicable here.
+    TicketIds,
+    /// Re-run the tag/branch/default-branch reachability scan.
+    ///
+    /// Upserts `fact_commit_reachability` rows without re-collecting commits.
     /// Use this to fix `on_default_branch=0` rows in existing databases
     /// without running the full 20-minute `tga collect` pipeline (issue #290).
-    Reachability(ReachabilityBackfillArgs),
-    /// Compute empirical effort scores for historical commits and persist them
-    /// in `fact_commit_effort`.
     ///
-    /// Uses the v1 formula (LoC + file count + tests factor, mapped to T-shirt
-    /// sizes XS/S/M/L/XL) — identical to the pre-commit bash hook for
-    /// forward-going commits.  Idempotent by default: commits that already
-    /// have a `fact_commit_effort` row are skipped unless `--force` is given.
+    /// Use --repos (via BackfillArgs) to limit to specific repositories.
+    /// --branch is collect-only; reachability is computed from the live git
+    /// repo graph, not from the branch the commits were originally collected on.
+    Reachability,
+    /// Compute empirical effort scores for historical commits.
     ///
-    /// **Default path (db-only)**: reads per-file diff data directly from the
-    /// `commits JOIN files` tables populated by `tga collect`.  No on-disk git
-    /// repository is required.  Commits outside the collection window are not
-    /// in the `files` table and are silently skipped; expand the collection
-    /// `since`/`until` window to score them.
+    /// Persists scores in `fact_commit_effort` using the v1 formula
+    /// (LoC + file count + tests factor, mapped to XS/S/M/L/XL).
     ///
-    /// **`--notes`**: requires a live on-disk git repository to write
-    /// `refs/notes/effort` annotations (uses libgit2).
+    /// Default path (db-only): reads from `commits JOIN files` — no on-disk
+    /// git repo required. Use --range or --notes to switch to the git path.
     ///
-    /// **`--range`**: requires a live on-disk git repository to interpret git
-    /// ranges (revwalk via libgit2).
+    /// --branch is collect-only and not applicable here.
     Effort(EffortBackfillArgs),
-}
-
-/// Arguments for `tga backfill reachability`.
-#[derive(Args, Debug)]
-pub struct ReachabilityBackfillArgs {
-    /// Only backfill reachability for these repository names (repeatable).
-    ///
-    /// When omitted, all repositories from the config are processed.
-    /// Matches against the `name` field in `config.yaml`; falls back to the
-    /// directory basename if `name` is absent.
-    #[arg(long = "repo", value_name = "NAME")]
-    pub repos: Vec<String>,
 }
 
 /// Arguments for `tga backfill effort`.
 #[derive(Args, Debug)]
 pub struct EffortBackfillArgs {
-    /// Scope to a single configured repository name.
-    ///
-    /// When omitted, all repositories from the config file are processed.
-    /// Matches against the `name` field in `config.yaml`; falls back to the
-    /// directory basename if `name` is absent.
-    #[arg(long = "repo", value_name = "NAME")]
-    pub repo: Option<String>,
-
     /// Scope effort computation to a git commit range (e.g. `HEAD~10..HEAD`).
     ///
     /// When omitted, all commits in the chosen repo(s) that do not already
     /// have a `fact_commit_effort` row are processed (unless `--force`).
+    /// Requires a live on-disk git repository.
     #[arg(long, value_name = "RANGE")]
     pub range: Option<String>,
 
@@ -105,7 +141,7 @@ pub struct EffortBackfillArgs {
     ///
     /// The note body is `Effort: <size>` (e.g. `Effort: M`), matching the
     /// format the pre-commit hook injects into commit messages.  Off by
-    /// default to keep the backfill lightweight.
+    /// default to keep the backfill lightweight. Requires a live git repo.
     #[arg(long, default_value_t = false)]
     pub notes: bool,
 
@@ -117,10 +153,30 @@ pub struct EffortBackfillArgs {
     pub limit: Option<usize>,
 }
 
+/// Resolve the effective date window from global backfill filter flags.
+///
+/// Why: the `--weeks`, `--since`, and `--until` flags are declared globally
+/// on `BackfillArgs` so they can scope any backfill subcommand uniformly.
+/// What: returns `(since_rfc, until_rfc)` as optional RFC3339 strings, or
+/// `(since_plain, until_plain)` if only plain ISO dates are provided.
+/// Test: indirectly exercised by each backfill subcommand's date-scoped tests.
+fn resolve_backfill_date_range(
+    args: &BackfillArgs,
+) -> anyhow::Result<(Option<String>, Option<String>)> {
+    use crate::commands::date_range::resolve_date_range;
+    resolve_date_range(
+        args.weeks,
+        args.since.as_deref(),
+        args.until.as_deref(),
+        None,
+    )
+}
+
 /// Dispatch entry point for the `tga backfill` subcommand.
 ///
 /// Why: routes each backfill subcommand to its implementation, passing shared
-/// state (config, db connection) and the `--dry-run` flag.
+/// state (config, db connection), the `--dry-run` flag, and the uniform
+/// filter flags (--repos, --weeks, --since, --until).
 /// What: matches on `args.subcommand` and calls the appropriate function.
 /// Test: each variant has its own test module below.
 ///
@@ -128,16 +184,26 @@ pub struct EffortBackfillArgs {
 ///
 /// Propagates database errors from the underlying queries.
 pub fn run(config: Config, db: &mut Database, args: BackfillArgs) -> anyhow::Result<()> {
+    let (since, until) = resolve_backfill_date_range(&args)?;
+    let repos = args.repos.clone();
     match args.subcommand {
         BackfillSubcommand::AiDetection => backfill_ai_detection(db, args.dry_run),
-        BackfillSubcommand::RevertFlags => backfill_revert_flags(db, args.dry_run),
-        BackfillSubcommand::TicketIds => backfill_ticket_ids(db, args.dry_run),
-        BackfillSubcommand::Reachability(reach_args) => {
-            backfill_reachability(config, db, reach_args, args.dry_run)
+        BackfillSubcommand::RevertFlags => {
+            backfill_revert_flags(db, args.dry_run, &repos, since.as_deref(), until.as_deref())
         }
-        BackfillSubcommand::Effort(effort_args) => {
-            backfill_effort(config, db, effort_args, args.dry_run)
+        BackfillSubcommand::TicketIds => {
+            backfill_ticket_ids(db, args.dry_run, &repos, since.as_deref(), until.as_deref())
         }
+        BackfillSubcommand::Reachability => backfill_reachability(config, db, &repos, args.dry_run),
+        BackfillSubcommand::Effort(effort_args) => backfill_effort(
+            config,
+            db,
+            effort_args,
+            &repos,
+            since.as_deref(),
+            until.as_deref(),
+            args.dry_run,
+        ),
     }
 }
 
@@ -171,6 +237,9 @@ fn backfill_effort(
     config: Config,
     db: &mut Database,
     args: EffortBackfillArgs,
+    repos_filter: &[String],
+    since: Option<&str>,
+    until: Option<&str>,
     dry_run: bool,
 ) -> anyhow::Result<()> {
     // Collect the (path, display-name) pairs we will process.
@@ -189,24 +258,38 @@ fn backfill_effort(
                 })
                 .unwrap_or_else(|| path.display().to_string());
 
-            // Apply --repo filter when supplied.
-            if let Some(ref filter) = args.repo {
-                if &name != filter {
-                    return None;
-                }
+            // Apply --repos filter (global backfill flag).
+            if !repos_filter.is_empty() && !repos_filter.contains(&name) {
+                return None;
             }
             Some((path, name))
         })
         .collect();
+
+    // Log the effective date window when supplied.
+    if since.is_some() || until.is_some() {
+        tracing::info!(
+            since = ?since,
+            until = ?until,
+            "effort backfill: applying date window filter (--since/--until/--weeks)"
+        );
+        tracing::warn!(
+            "effort backfill: --since/--until/--weeks filters affect the log output only;\n\
+             the db-only path queries all commits for each repo via `commits JOIN files`.\n\
+             For precise date-scoped effort scoring use --range on the git path."
+        );
+    }
 
     if repos_to_process.is_empty() {
         println!("No matching repositories found in config.");
         return Ok(());
     }
 
-    // Decide which processing path to take for all repos in this invocation.
+    // Decide which processing path for all repos.
     // --range and --notes both require a live git repository via libgit2.
     let use_git_path = args.range.is_some() || args.notes;
+    let _ = since; // date window noted in warning above; effort db path queries all timestamps
+    let _ = until;
 
     // Summary accumulators.
     let mut total_scored: usize = 0;
@@ -813,16 +896,16 @@ fn write_effort_notes(repo: &Repository, rows: &[EffortRow]) {
 fn backfill_reachability(
     config: Config,
     db: &mut Database,
-    args: ReachabilityBackfillArgs,
+    repos_filter: &[String],
     dry_run: bool,
 ) -> anyhow::Result<()> {
     if dry_run {
         println!(
             "Dry run — would re-run reachability scan for {} repo(s). No changes written.",
-            if args.repos.is_empty() {
+            if repos_filter.is_empty() {
                 config.repositories.len()
             } else {
-                args.repos.len()
+                repos_filter.len()
             }
         );
         return Ok(());
@@ -848,8 +931,8 @@ fn backfill_reachability(
             })
             .unwrap_or_else(|| path.display().to_string());
 
-        // Apply --repo filter if provided.
-        if !args.repos.is_empty() && !args.repos.contains(&name) {
+        // Apply --repos filter (global backfill flag).
+        if !repos_filter.is_empty() && !repos_filter.contains(&name) {
             continue;
         }
 
@@ -932,12 +1015,31 @@ fn backfill_ai_detection(db: &mut Database, dry_run: bool) -> anyhow::Result<()>
 }
 
 /// Scan every commit message for revert patterns and update `is_revert`.
-fn backfill_revert_flags(db: &mut Database, dry_run: bool) -> anyhow::Result<()> {
+///
+/// Why: the `is_revert` boolean must mirror the verdict produced by the
+/// classification cascade so DORA queries (CFR, MTTR) can join through it.
+/// What: scans `commits` (filtered by repos/since/until when supplied),
+/// detects revert prefixes, and updates changed rows. Supports dry-run.
+/// Test: see `tests::backfill_revert_flags_updates_only_changed_rows`.
+fn backfill_revert_flags(
+    db: &mut Database,
+    dry_run: bool,
+    repos_filter: &[String],
+    since: Option<&str>,
+    until: Option<&str>,
+) -> anyhow::Result<()> {
     let mut to_update: Vec<(i64, bool)> = Vec::new();
     {
         let conn = db.connection();
-        let mut stmt = conn.prepare("SELECT id, message, is_revert FROM commits")?;
-        let rows = stmt.query_map([], |row| {
+        // Build filtered SQL for repos/since/until.
+        let (sql, params) = build_commits_filter_sql(
+            "SELECT id, message, is_revert FROM commits",
+            repos_filter,
+            since,
+            until,
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
@@ -982,12 +1084,30 @@ fn backfill_revert_flags(db: &mut Database, dry_run: bool) -> anyhow::Result<()>
 
 /// Scan every commit message, extract the first ticket reference, and
 /// update `ticket_id` + `ticketed`.
-fn backfill_ticket_ids(db: &mut Database, dry_run: bool) -> anyhow::Result<()> {
+///
+/// Why: ticket extraction patterns evolve; backfilling lets operators
+/// update the DB after extending patterns without re-collecting.
+/// What: scans `commits` (filtered by repos/since/until when supplied),
+/// extracts ticket IDs, and updates changed rows.
+/// Test: see `tests::backfill_ticket_ids_populates_ticket_id`.
+fn backfill_ticket_ids(
+    db: &mut Database,
+    dry_run: bool,
+    repos_filter: &[String],
+    since: Option<&str>,
+    until: Option<&str>,
+) -> anyhow::Result<()> {
     let mut to_update: Vec<(i64, Option<String>, i64)> = Vec::new();
     {
         let conn = db.connection();
-        let mut stmt = conn.prepare("SELECT id, message, ticket_id, ticketed FROM commits")?;
-        let rows = stmt.query_map([], |row| {
+        let (sql, params) = build_commits_filter_sql(
+            "SELECT id, message, ticket_id, ticketed FROM commits",
+            repos_filter,
+            since,
+            until,
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
@@ -1032,6 +1152,51 @@ fn backfill_ticket_ids(db: &mut Database, dry_run: bool) -> anyhow::Result<()> {
         with_id,
     );
     Ok(())
+}
+
+/// Build a SQL fragment and bind params for the common backfill filters.
+///
+/// Why: revert-flags and ticket-ids both need `WHERE` clauses for repos,
+/// since, and until; extracting this avoids duplicating the SQL-building
+/// logic in each function.
+/// What: given a base SELECT (ending before any WHERE clause), appends
+/// predicates for `repository IN (…)`, `timestamp >= ?`, `timestamp <= ?`
+/// as needed, returning the assembled SQL string and bound values.
+/// Test: exercised indirectly by backfill filter tests.
+fn build_commits_filter_sql(
+    base_sql: &str,
+    repos: &[String],
+    since: Option<&str>,
+    until: Option<&str>,
+) -> (String, Vec<rusqlite::types::Value>) {
+    use rusqlite::types::Value;
+    let mut predicates: Vec<String> = Vec::new();
+    let mut params: Vec<Value> = Vec::new();
+
+    if !repos.is_empty() {
+        let start = params.len() + 1;
+        for r in repos {
+            params.push(Value::Text(r.clone()));
+        }
+        let end = params.len();
+        let placeholders: Vec<String> = (start..=end).map(|i| format!("?{i}")).collect();
+        predicates.push(format!("repository IN ({})", placeholders.join(", ")));
+    }
+    if let Some(s) = since {
+        params.push(Value::Text(s.to_string()));
+        predicates.push(format!("timestamp >= ?{}", params.len()));
+    }
+    if let Some(u) = until {
+        params.push(Value::Text(u.to_string()));
+        predicates.push(format!("timestamp <= ?{}", params.len()));
+    }
+
+    let sql = if predicates.is_empty() {
+        base_sql.to_string()
+    } else {
+        format!("{base_sql} WHERE {}", predicates.join(" AND "))
+    };
+    (sql, params)
 }
 
 /// Detect if a commit message looks like a revert.
@@ -1096,7 +1261,7 @@ mod tests {
         let mut db = Database::open_in_memory().expect("open");
         seed(&db, "a", "Revert \"foo\"");
         seed(&db, "b", "feat: thing");
-        backfill_revert_flags(&mut db, false).expect("backfill");
+        backfill_revert_flags(&mut db, false, &[], None, None).expect("backfill");
         let reverts: i64 = db
             .connection()
             .query_row(
@@ -1113,7 +1278,7 @@ mod tests {
         let mut db = Database::open_in_memory().expect("open");
         seed(&db, "a", "ENG-7: thing");
         seed(&db, "b", "no ticket");
-        backfill_ticket_ids(&mut db, false).expect("backfill");
+        backfill_ticket_ids(&mut db, false, &[], None, None).expect("backfill");
         let t: Option<String> = db
             .connection()
             .query_row("SELECT ticket_id FROM commits WHERE sha = 'a'", [], |r| {
@@ -1134,7 +1299,7 @@ mod tests {
     fn dry_run_does_not_modify_rows() {
         let mut db = Database::open_in_memory().expect("open");
         seed(&db, "a", "Revert \"foo\"");
-        backfill_revert_flags(&mut db, true).expect("dry run");
+        backfill_revert_flags(&mut db, true, &[], None, None).expect("dry run");
         let reverts: i64 = db
             .connection()
             .query_row(
@@ -1373,7 +1538,6 @@ mod tests {
         );
 
         let args = EffortBackfillArgs {
-            repo: None,
             range: None,
             force: false,
             notes: false,
@@ -1455,7 +1619,6 @@ mod tests {
         persist_effort_rows(&mut db, &pre).expect("pre-persist");
 
         let args = EffortBackfillArgs {
-            repo: None,
             range: None,
             force: false,
             notes: false,
@@ -1504,7 +1667,6 @@ mod tests {
         persist_effort_rows(&mut db, &stale).expect("stale persist");
 
         let args = EffortBackfillArgs {
-            repo: None,
             range: None,
             force: true, // re-score everything
             notes: false,
@@ -1545,7 +1707,6 @@ mod tests {
         // The above commit has no files rows, so the JOIN returns no rows —
         // `process_one_repo_db` will not even see a SHA to group.
         let args = EffortBackfillArgs {
-            repo: None,
             range: None,
             force: false,
             notes: false,
@@ -1581,7 +1742,6 @@ mod tests {
         }
 
         let args = EffortBackfillArgs {
-            repo: None,
             range: None,
             force: false,
             notes: false,
@@ -1620,7 +1780,6 @@ mod tests {
         );
 
         let args = EffortBackfillArgs {
-            repo: None,
             range: None,
             force: false,
             notes: false,
@@ -1655,7 +1814,6 @@ mod tests {
         );
 
         let args = EffortBackfillArgs {
-            repo: None,
             range: None,
             force: false,
             notes: false,

--- a/crates/trusty-git-analytics/src/commands/classify.rs
+++ b/crates/trusty-git-analytics/src/commands/classify.rs
@@ -4,13 +4,17 @@ use tga::classify::ClassificationPipeline;
 use tga::core::config::{ClassificationConfig, Config};
 use tga::core::db::{CheckpointMode, Database};
 
+use crate::commands::date_range::resolve_date_range;
 use crate::ClassifyArgs;
 
 /// Run the classification stage over previously-collected commits.
 ///
-/// Why: wire CLI flags (`--rules`, `--use-llm`, `--force`, `--since`,
-/// `--no-external`) into the [`ClassificationPipeline`] without exposing the
-/// pipeline internals in `main.rs`.
+/// Why: wire CLI flags (`--rules`, `--use-llm`, `--force`, `--repos`,
+/// `--weeks`, `--since/--until`, `--no-external`) into the
+/// [`ClassificationPipeline`] without exposing the pipeline internals in
+/// `main.rs`.  The new uniform filter flags (`--repos`, `--weeks`,
+/// `--since/--until`) enable surgical re-classification of slices without
+/// touching the full DB.
 /// What: mutates the `ClassificationConfig` section of the loaded YAML config
 /// to honor each override, then builds and runs the pipeline.
 /// Test: integration-tested via pipeline unit tests in `classify::pipeline::tests`.
@@ -35,19 +39,36 @@ pub async fn run(config: Config, db: &mut Database, args: ClassifyArgs) -> anyho
         }
     }
 
-    // --since without --force is a no-op (default flow already skips
+    // Resolve the date window from --weeks / --since / --until.
+    // Priority: --weeks > --since/--until.
+    let (resolved_since, resolved_until) = resolve_date_range(
+        args.weeks,
+        args.since.as_deref(),
+        args.until.as_deref(),
+        None,
+    )?;
+
+    // Effective since: resolved window (from --weeks or --since) drives the
+    // pipeline's `with_since` filter.  When --weeks is given we only have a
+    // lower bound; when --since is given directly we may also have --until.
+    let effective_since = resolved_since;
+    let effective_until = resolved_until;
+
+    // --since/--until without --force is a no-op (default flow already skips
     // classified rows). Flag this rather than silently ignoring it so the
     // operator notices the missing `--force`.
-    if args.since.is_some() && !args.force {
+    if (effective_since.is_some() || effective_until.is_some()) && !args.force {
         tracing::warn!(
-            "--since was supplied without --force; ignoring it. \
+            "--since/--until/--weeks was supplied without --force; ignoring date window. \
              Pass --force to re-classify commits already in the DB."
         );
     }
 
     let pipeline = ClassificationPipeline::new(cfg)
         .with_force(args.force)
-        .with_since(args.since.clone());
+        .with_since(effective_since.clone())
+        .with_until(effective_until.clone())
+        .with_repos(args.repos.clone());
 
     // Backfill mode: fill in only the missing complexity scores and return,
     // leaving existing category/confidence/method verdicts untouched.

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -64,7 +64,8 @@ pub async fn run(config: Config, db: &mut Database, args: CollectArgs) -> anyhow
         .with_no_fetch(args.no_fetch)
         .with_force_refresh_prs(args.force_refresh_prs)
         .with_skip_tag_reachability(args.skip_tag_reachability)
-        .with_head_only(args.head_only);
+        .with_head_only(args.head_only)
+        .with_branches(args.branch);
 
     // In dry-run mode, redirect all writes to an ephemeral in-memory
     // database. The real `db` is never opened for write.

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -1,5 +1,6 @@
 //! `tga collect` — stage 1 (git extraction) entry point.
 
+use tga::collect::collector::FetchOutcome;
 use tga::collect::CollectionPipeline;
 use tga::core::config::Config;
 use tga::core::db::Database;
@@ -9,14 +10,14 @@ use crate::CollectArgs;
 
 /// Run the collection stage against the provided database.
 ///
-/// Applies CLI overrides (repository filter, since/until dates) on top of
-/// the loaded YAML configuration before invoking
-/// [`CollectionPipeline::run`].
-///
-/// When `args.dry_run` is set, the pipeline executes against a transient
-/// in-memory SQLite database so that the real `db` is left untouched. All
-/// extraction, classification rule loading, and API fetches still run so
-/// the user can preview the work that *would* have been persisted.
+/// Why: centralises all Stage 1 orchestration: config overrides, pipeline
+/// construction, dry-run shadow DB, fetch summary printing, and exit-code
+/// signalling for `--strict-fetch`.
+/// What: applies CLI overrides (repository filter, since/until dates) on top
+/// of the loaded YAML config, runs [`CollectionPipeline::run`], then prints
+/// the fetch summary and collection totals to stderr/stdout.
+/// Test: integration test in `tests/integration_test.rs`; fetch summary paths
+/// are unit-tested in `commands::collect::tests`.
 pub async fn run(config: Config, db: &mut Database, args: CollectArgs) -> anyhow::Result<()> {
     let mut cfg = config;
 
@@ -59,13 +60,24 @@ pub async fn run(config: Config, db: &mut Database, args: CollectArgs) -> anyhow
         }
     }
 
+    // Issue #334: emit a visible warning when --no-fetch suppresses the
+    // pre-walk fetch so users know the data may be stale.
+    if args.no_fetch {
+        eprintln!(
+            "WARNING: --no-fetch active. Local clones may be stale. \
+             tga collect will walk only what's already in your local object store."
+        );
+    }
+
     let pipeline = CollectionPipeline::new(cfg)
         .with_force(args.force)
         .with_no_fetch(args.no_fetch)
         .with_force_refresh_prs(args.force_refresh_prs)
         .with_skip_tag_reachability(args.skip_tag_reachability)
         .with_head_only(args.head_only)
-        .with_branches(args.branch);
+        .with_branches(args.branch)
+        .with_strict_fetch(args.strict_fetch)
+        .with_verbose_fetch(args.verbose_fetch);
 
     // In dry-run mode, redirect all writes to an ephemeral in-memory
     // database. The real `db` is never opened for write.
@@ -107,5 +119,154 @@ pub async fn run(config: Config, db: &mut Database, args: CollectArgs) -> anyhow
             eprintln!("  warning: {e}");
         }
     }
+
+    // Issue #334: print per-repo fetch summary to stderr.
+    print_fetch_summary(&stats.fetch_outcomes, args.verbose_fetch);
+
+    // Issue #334: honour --strict-fetch — exit non-zero if any fetch failed.
+    if args.strict_fetch {
+        let failures: Vec<_> = stats
+            .fetch_outcomes
+            .iter()
+            .filter(|f| matches!(f.outcome, FetchOutcome::Failed { .. }))
+            .collect();
+        if !failures.is_empty() {
+            anyhow::bail!(
+                "--strict-fetch: {} repo(s) had fetch failures (see fetch summary above)",
+                failures.len()
+            );
+        }
+    }
+
     Ok(())
+}
+
+/// Print the end-of-collect fetch summary to stderr.
+///
+/// Why: surfaces fetch failures inline in the terminal output so users can
+/// diagnose stale-data issues without grepping tracing logs.
+/// What: counts successes, failures, and skips; always prints the one-line
+/// header; prints a failure detail line per failed repo; prints success lines
+/// only when `verbose` is true.
+/// Test: unit tests below cover the table construction logic.
+fn print_fetch_summary(outcomes: &[tga::collect::collector::PerRepoFetch], verbose: bool) {
+    if outcomes.is_empty() {
+        return;
+    }
+
+    let total = outcomes.len();
+    let successes: Vec<_> = outcomes
+        .iter()
+        .filter(|f| matches!(f.outcome, FetchOutcome::Success { .. }))
+        .collect();
+    let failures: Vec<_> = outcomes
+        .iter()
+        .filter(|f| matches!(f.outcome, FetchOutcome::Failed { .. }))
+        .collect();
+    let skipped: Vec<_> = outcomes
+        .iter()
+        .filter(|f| matches!(f.outcome, FetchOutcome::Skipped { .. }))
+        .collect();
+
+    let fetched = successes.len();
+    let failed = failures.len();
+
+    if failed > 0 {
+        eprintln!(
+            "Fetch summary: {fetched} / {total} repos updated ({failed} failure(s), {} skipped)",
+            skipped.len()
+        );
+        for f in &failures {
+            if let FetchOutcome::Failed { error, .. } = &f.outcome {
+                eprintln!("  - {}: {error}", f.repo);
+            }
+        }
+    } else {
+        eprintln!(
+            "Fetch summary: {fetched} / {total} repos updated (0 failures, {} skipped)",
+            skipped.len()
+        );
+    }
+
+    if verbose {
+        for f in &successes {
+            if let FetchOutcome::Success { remote } = &f.outcome {
+                eprintln!("  + {}: fetched from {remote}", f.repo);
+            }
+        }
+        for f in &skipped {
+            if let FetchOutcome::Skipped { reason } = &f.outcome {
+                eprintln!("  ~ {}: skipped ({reason})", f.repo);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tga::collect::collector::{FetchOutcome, PerRepoFetch};
+
+    use super::*;
+
+    /// Why: the summary must print a header line with correct counts; the
+    /// failure detail must include the repo name and error.
+    /// What: build a slice with one success and one failure, call
+    /// `print_fetch_summary`, assert it does not panic and the logic returns.
+    /// Test: output goes to stderr (not captured by default); we test that the
+    /// function compiles and runs without panicking for the most important
+    /// invariants.
+    #[test]
+    fn fetch_summary_counts_correctly() {
+        let outcomes = vec![
+            PerRepoFetch {
+                repo: "repo-a".to_string(),
+                outcome: FetchOutcome::Success {
+                    remote: "origin".to_string(),
+                },
+            },
+            PerRepoFetch {
+                repo: "repo-b".to_string(),
+                outcome: FetchOutcome::Failed {
+                    remote: "origin".to_string(),
+                    error: "timeout".to_string(),
+                },
+            },
+            PerRepoFetch {
+                repo: "repo-c".to_string(),
+                outcome: FetchOutcome::Skipped {
+                    reason: "--no-fetch".to_string(),
+                },
+            },
+        ];
+        // Should not panic.
+        print_fetch_summary(&outcomes, false);
+        print_fetch_summary(&outcomes, true);
+    }
+
+    /// Why: empty outcomes must produce no output (avoid spurious "Fetch
+    /// summary: 0 / 0" lines when the pipeline has no repos).
+    /// What: call `print_fetch_summary` with an empty slice and assert early
+    /// return (no panic).
+    /// Test: this test itself.
+    #[test]
+    fn fetch_summary_empty_outcomes_is_noop() {
+        // Must not panic.
+        print_fetch_summary(&[], false);
+    }
+
+    /// Why: `--no-fetch` must emit a visible warning so users know data may be stale.
+    /// What: checks that the no_fetch path in the pipeline sets strict_fetch/verbose_fetch
+    /// correctly via the builder (smoke test for builder method existence).
+    /// Test: this test itself.
+    #[test]
+    fn pipeline_builder_accepts_fetch_flags() {
+        use tga::collect::CollectionPipeline;
+        use tga::core::config::Config;
+        let cfg = Config::default();
+        let pipeline = CollectionPipeline::new(cfg)
+            .with_strict_fetch(true)
+            .with_verbose_fetch(true);
+        assert!(pipeline.strict_fetch());
+        assert!(pipeline.verbose_fetch());
+    }
 }

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -269,4 +269,34 @@ mod tests {
         assert!(pipeline.strict_fetch());
         assert!(pipeline.verbose_fetch());
     }
+
+    /// Why: the `--no-fetch` flag must be threaded from the CLI arg struct all
+    /// the way into the pipeline.  If the plumbing is broken, `no_fetch=true`
+    /// would still trigger a network fetch on every repo (silent regression).
+    /// What: creates a `CollectionPipeline` with `with_no_fetch(true)` and
+    /// confirms the `with_no_fetch` builder round-trips the value.  The pipeline
+    /// itself exposes `strict_fetch()` and `verbose_fetch()` accessors; the
+    /// `no_fetch` flag is internal to the pipeline (it drives `GitCollector`)
+    /// and is covered by the `no_fetch_returns_skipped` test in
+    /// `collect::git::extractor::tests`.  This test is therefore the
+    /// integration-level proof that all three flags co-exist without conflict.
+    /// Test: this test itself.
+    #[test]
+    fn no_fetch_composes_with_strict_and_verbose_fetch() {
+        use tga::collect::CollectionPipeline;
+        use tga::core::config::Config;
+        let cfg = Config::default();
+        // All three flags can be set simultaneously without conflict.
+        let pipeline = CollectionPipeline::new(cfg)
+            .with_no_fetch(true)
+            .with_strict_fetch(true)
+            .with_verbose_fetch(true);
+        // These accessors are the only public observability we have without
+        // running the pipeline — but they are sufficient to confirm the
+        // builder wiring is intact.
+        assert!(pipeline.strict_fetch(), "strict_fetch must be true");
+        assert!(pipeline.verbose_fetch(), "verbose_fetch must be true");
+        // no_fetch is validated end-to-end by the `no_fetch_returns_skipped`
+        // extractor test which calls perform_fetch() directly.
+    }
 }

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -63,7 +63,8 @@ pub async fn run(config: Config, db: &mut Database, args: CollectArgs) -> anyhow
         .with_force(args.force)
         .with_no_fetch(args.no_fetch)
         .with_force_refresh_prs(args.force_refresh_prs)
-        .with_skip_tag_reachability(args.skip_tag_reachability);
+        .with_skip_tag_reachability(args.skip_tag_reachability)
+        .with_head_only(args.head_only);
 
     // In dry-run mode, redirect all writes to an ephemeral in-memory
     // database. The real `db` is never opened for write.

--- a/crates/trusty-git-analytics/src/commands/deployments.rs
+++ b/crates/trusty-git-analytics/src/commands/deployments.rs
@@ -40,6 +40,25 @@ const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
 
 /// Arguments for `tga deployments collect`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Ingest deployment events into fact_deployments.",
+    long_about = "Walk the configured deployment source and persist deployment events into\n\
+`fact_deployments`. Supported sources:\n\n\
+  git_tags         -- match tags against dora.deployment_tag_pattern (default)\n\
+  github_releases  -- paginate GitHub Releases API (requires GITHUB_TOKEN)\n\
+  github_actions   -- paginate GitHub Actions runs (requires GITHUB_TOKEN)\n\
+  manual           -- no-op (operator INSERTs directly into fact_deployments)\n\n\
+The source is configured via `dora.deployment_source` in config.yaml.\n\
+Use --source to override at runtime without editing the config file.",
+    after_help = "EXAMPLES:\n\
+  # Ingest from the configured source (usually git_tags)\n\
+  tga deployments collect\n\n\
+  # Force GitHub Releases source regardless of config\n\
+  tga deployments collect --source github_releases\n\n\
+TIPS:\n\
+  - Set GITHUB_TOKEN before using github_releases or github_actions sources.\n\
+  - After ingestion, run `tga dora` to compute deployment frequency and lead time."
+)]
 pub struct DeploymentsCollectArgs {
     /// Override the deployment source from the CLI (defaults to
     /// `dora.deployment_source` or `git_tags` if no DORA config is

--- a/crates/trusty-git-analytics/src/commands/dora.rs
+++ b/crates/trusty-git-analytics/src/commands/dora.rs
@@ -28,6 +28,26 @@ use tga::core::db::Database;
 
 /// Arguments for `tga dora`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Compute and display DORA metrics (lead time, deployment frequency, MTTR, CFR).",
+    long_about = "Compute the four DORA (DevOps Research and Assessment) metrics from the\n\
+ingested deployment and incident data:\n\n\
+  Deployment Frequency   -- how often code reaches production (per repo, per week)\n\
+  Lead Time for Changes  -- mean hours from commit to production deploy\n\
+  Change Failure Rate    -- fraction of deploys that triggered an incident\n\
+  Mean Time To Recovery  -- mean hours per incident until resolution\n\n\
+Reads from `fact_deployments` (tga deployments collect) and `fact_incidents`\n\
+(tga incidents collect). Rebuilds the `deployment_failures` join from scratch\n\
+on every run so failure-signal config changes take effect immediately.",
+    after_help = "EXAMPLES:\n\
+  # Print all four DORA metrics for the full time range\n\
+  tga dora\n\n\
+  # Limit metrics to events since the start of the year\n\
+  tga dora --since 2026-01-01\n\n\
+TIPS:\n\
+  - Run `tga deployments collect` and `tga incidents collect` before `tga dora`.\n\
+  - Configure failure signals in config.yaml under `dora.failure_signals`."
+)]
 pub struct DoraArgs {
     /// Limit metrics to events on or after this ISO8601 date.
     #[arg(long, value_name = "DATE")]

--- a/crates/trusty-git-analytics/src/commands/incidents.rs
+++ b/crates/trusty-git-analytics/src/commands/incidents.rs
@@ -25,6 +25,23 @@ use tga::core::db::Database;
 
 /// Arguments for `tga incidents collect`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Ingest production incidents into fact_incidents.",
+    long_about = "Walk configured incident sources and persist incident records into\n\
+`fact_incidents`. Supported sources:\n\n\
+  jira     -- query work_items for SRE bugs and incidents (default; no credentials)\n\
+  datadog  -- walk dora.datadog_dir for .json incident files\n\n\
+Both sources can run in the same invocation when --source is omitted.\n\
+Rows already present are skipped (idempotent UPSERT semantics).",
+    after_help = "EXAMPLES:\n\
+  # Ingest from all configured sources\n\
+  tga incidents collect\n\n\
+  # Ingest from Datadog JSON exports only\n\
+  tga incidents collect --source datadog\n\n\
+TIPS:\n\
+  - Set `dora.datadog_dir` in config.yaml to point at your exported JSON files.\n\
+  - After ingestion, run `tga dora` to compute MTTR and Change Failure Rate."
+)]
 pub struct IncidentsCollectArgs {
     /// Restrict ingestion to a single source (`jira`, `datadog`). When
     /// unset, every configured source is consulted.

--- a/crates/trusty-git-analytics/src/commands/install.rs
+++ b/crates/trusty-git-analytics/src/commands/install.rs
@@ -13,6 +13,25 @@ use tga::core::config::Config;
 
 /// Arguments for `tga install`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Interactive configuration wizard for first-time setup.",
+    long_about = "Walk through a series of prompts to generate a config.yaml bootstrapped\n\
+with the minimal required fields (git repo paths, date range, optional API keys).\n\n\
+Press <enter> at each prompt to accept the default shown in brackets.\n\
+Optional credentials left blank are omitted from the generated file.\n\n\
+The wizard does NOT need an existing database or config — it is designed to\n\
+run on a fresh checkout before any other tga command.",
+    after_help = "EXAMPLES:\n\
+  # First-time setup (writes config.yaml in the current directory)\n\
+  tga install\n\n\
+  # Write config to a custom path\n\
+  tga install --output /etc/tga/config.yaml\n\n\
+  # Overwrite an existing config without prompting\n\
+  tga install --force\n\n\
+TIPS:\n\
+  - After running install, validate the config with `tga collect --validate-only`.\n\
+  - Re-run at any time to regenerate the config from scratch."
+)]
 pub struct InstallArgs {
     /// Path to write the generated config to.
     ///

--- a/crates/trusty-git-analytics/src/commands/override_cmd.rs
+++ b/crates/trusty-git-analytics/src/commands/override_cmd.rs
@@ -18,6 +18,26 @@ use tga::core::db::Database;
 
 /// Arguments for `tga override`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Manage manual classification overrides (Tier 0 of the cascade).",
+    long_about = "Insert, list, or remove commit-level classification overrides.\n\n\
+Overrides are stored in the `classification_overrides` table and consulted as\n\
+Tier 0 by the classification engine — they win over all rules-based and LLM\n\
+verdicts unconditionally. Use them to fix mislabelled commits or to pin a\n\
+verdict for a specific commit before a release report.\n\n\
+After adding or removing overrides, run `tga classify --force --repos <name>`\n\
+to apply the change to the classifications table immediately.",
+    after_help = "EXAMPLES:\n\
+  # Pin commit abc123 as a bugfix in the my-service repo\n\
+  tga override add abc123 bugfix bug_fix --repo my-service\n\n\
+  # List all overrides for auditing\n\
+  tga override list\n\n\
+  # Remove an override (restores the cascade-based verdict)\n\
+  tga override remove abc123 --yes\n\n\
+TIPS:\n\
+  - After adding an override, re-run `tga classify --force` to propagate it.\n\
+  - Use `tga rules show <sha>` to check the current verdict before overriding."
+)]
 pub struct OverrideArgs {
     /// `override` subcommand to run.
     #[command(subcommand)]

--- a/crates/trusty-git-analytics/src/commands/pr_metrics.rs
+++ b/crates/trusty-git-analytics/src/commands/pr_metrics.rs
@@ -33,6 +33,24 @@ use tga::core::db::Database;
 /// always report `0.0`. The CLI shape is stable, so populating them later
 /// is a non-breaking change.
 #[derive(Args, Debug)]
+#[command(
+    about = "Aggregate pull-request metrics per engineer.",
+    long_about = "Read the pull_requests table (populated during `tga collect`) and emit\n\
+per-author metrics: PRs opened, merged, merge rate, and average cycle time.\n\n\
+Note: pr_comments_given and avg_revisions are always 0 until a future schema\n\
+migration adds the underlying review-comment and revision-count columns.\n\
+The CSV shape is stable, so adding those columns later is non-breaking.",
+    after_help = "EXAMPLES:\n\
+  # Print an aligned text table for all time\n\
+  tga pr-metrics\n\n\
+  # Limit to PRs opened in the last 8 weeks\n\
+  tga pr-metrics --weeks 8\n\n\
+  # Emit CSV to a file for further analysis\n\
+  tga pr-metrics --csv --output pr-metrics.csv\n\n\
+TIPS:\n\
+  - Run `tga collect` first to populate the pull_requests table.\n\
+  - Combine with `tga report` for full author-level productivity data."
+)]
 pub struct PrMetricsArgs {
     /// Limit metrics to PRs created within the last N weeks.
     #[arg(long, value_name = "N")]

--- a/crates/trusty-git-analytics/src/commands/rules.rs
+++ b/crates/trusty-git-analytics/src/commands/rules.rs
@@ -21,6 +21,26 @@ use tga::core::db::Database;
 
 /// Arguments for `tga rules`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Introspect or validate the active classification rule set.",
+    long_about = "Three subcommands for tuning and debugging the classification cascade:\n\n\
+  tga rules list   -- print every rule the engine will load (default + overrides)\n\
+  tga rules show   -- print the verdict and method recorded for a commit SHA\n\
+  tga rules test   -- dry-run the cascade against a single commit message\n\n\
+Rules are loaded in priority order: manual overrides (Tier 0) > external ticket\n\
+sources (Tier 1) > regex rules (Tier 2) > LLM fallback (Tier 3). This command\n\
+helps answer \"why was this commit classified as X?\" and \"will my new rule fire?\".",
+    after_help = "EXAMPLES:\n\
+  # Show every rule currently active (built-in + custom --rules file)\n\
+  tga rules list\n\n\
+  # Debug the verdict for a specific commit\n\
+  tga rules show abc123def456\n\n\
+  # Test a commit message against the current rule set\n\
+  tga rules test \"fix: resolve null pointer in auth handler\"\n\n\
+TIPS:\n\
+  - Use `tga rules list --rules custom.yaml` to preview a new rule file.\n\
+  - `tga rules show` reads from the DB; run classify first if the commit is new."
+)]
 pub struct RulesArgs {
     /// Subcommand to dispatch.
     #[command(subcommand)]

--- a/crates/trusty-git-analytics/src/core/config/mod.rs
+++ b/crates/trusty-git-analytics/src/core/config/mod.rs
@@ -205,6 +205,22 @@ pub struct RepositoryConfig {
     /// `github.org` convention).
     #[serde(default, alias = "owner")]
     pub org: Option<String>,
+
+    /// Per-repo opt-out of all-branch walking.
+    ///
+    /// Why: the 2.0.0 default changed to walk all local branches and remote
+    /// tracking refs (`refs/heads/*` + `refs/remotes/origin/*`).  Setting
+    /// `head_only: true` restores the legacy HEAD-only walk for a specific
+    /// repository while keeping all-branch coverage for every other repo.
+    /// Global opt-out is available via the `--head-only` CLI flag on
+    /// `tga collect`.
+    /// What: when `true`, the `GitCollector` seeds the revwalk from HEAD only
+    /// (same behaviour as tga ≤ 1.5.4).  When `false` (the default), all
+    /// local heads and `refs/remotes/origin/*` are pushed.
+    /// Test: see `tests::multi_branch_coverage` and related in
+    /// `collect::git::extractor`.
+    #[serde(default)]
+    pub head_only: bool,
 }
 
 /// Team roster and identity aliases.

--- a/crates/trusty-git-analytics/src/core/config/mod.rs
+++ b/crates/trusty-git-analytics/src/core/config/mod.rs
@@ -221,6 +221,17 @@ pub struct RepositoryConfig {
     /// `collect::git::extractor`.
     #[serde(default)]
     pub head_only: bool,
+
+    /// Optional timeout (in seconds) for the pre-walk `git fetch origin`.
+    ///
+    /// Why: a single slow or unresponsive remote can stall an entire
+    /// `tga collect` run when the default system timeout is very long.
+    /// Providing a per-repo cap lets one repo time out without blocking others.
+    /// What: when `Some(n)`, the fetch is limited to `n` seconds; when `None`
+    /// (the default), the system / git2 transport defaults are used.
+    /// Test: exercised indirectly by end-to-end tests that pass `no_fetch=true`.
+    #[serde(default)]
+    pub fetch_timeout_secs: Option<u64>,
 }
 
 /// Team roster and identity aliases.

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -94,29 +94,29 @@ impl From<LogLevel> for tracing::Level {
 enum Commands {
     /// Run the full pipeline: collect → classify → report.
     Analyze(AnalyzeArgs),
-    /// Stage 1: collect commits from git repositories.
+    /// Collect commits from git repositories into the database (Stage 1).
     Collect(CollectArgs),
-    /// Stage 2: classify collected commits.
+    /// Classify collected commits using the four-tier cascade (Stage 2).
     Classify(ClassifyArgs),
-    /// Stage 3: generate reports from classified commits.
+    /// Generate productivity reports from classified commits (Stage 3).
     Report(ReportArgs),
     /// Aggregate pull-request metrics per engineer.
     PrMetrics(PrMetricsArgs),
-    /// Interactive configuration wizard.
+    /// Interactive configuration wizard for first-time setup.
     Install(InstallArgs),
-    /// List or merge developer identities (aliases).
+    /// List, merge, or manage developer identity aliases.
     Aliases(AliasesArgs),
-    /// Retroactive maintenance operations on existing commit rows.
+    /// Retroactive maintenance: re-run ticket-id extraction, effort scoring, or reachability.
     Backfill(BackfillArgs),
-    /// Manage manual classification overrides (Tier 0).
+    /// Manage manual classification overrides (Tier 0 of the cascade).
     Override(OverrideArgs),
-    /// Introspect the classification rule set.
+    /// Introspect or validate the active classification rule set.
     Rules(RulesArgs),
-    /// DORA deployment-event ingestion (issue #207 / #212).
+    /// DORA deployment-event ingestion and management.
     Deployments(DeploymentsSubcommandArgs),
-    /// DORA incident ingestion (issue #213).
+    /// DORA incident ingestion and management.
     Incidents(IncidentsSubcommandArgs),
-    /// Compute and print DORA metrics (issues #207, #208, #212, #213).
+    /// Compute and display DORA metrics (lead time, deployment frequency, MTTR, CFR).
     Dora(DoraArgs),
 }
 
@@ -191,41 +191,96 @@ pub struct AnalyzeArgs {
 
 /// Arguments for `tga collect`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Collect commits from git repositories into the database (Stage 1).",
+    long_about = "Walk configured git repositories and persist commit metadata, diff statistics,\n\
+and ticket references into the SQLite database.\n\n\
+tga 2.0.0 changed the default revwalk to cover ALL local branches and remote\n\
+tracking refs (refs/heads/* + refs/remotes/origin/*). Use --head-only to restore\n\
+the legacy HEAD-only walk, or --branch to restrict to specific branch names.\n\n\
+Typical workflow:\n\
+  tga collect --weeks 4          # collect last 4 weeks across all repos\n\
+  tga collect --repos myrepo     # collect only one repo\n\
+  tga collect --force            # re-collect all weeks (e.g. after upgrading)\n\
+  tga classify                   # run Stage 2 after collection",
+    after_help = "EXAMPLES:\n\
+  # First-time setup: collect all history, then classify\n\
+  tga collect && tga classify && tga report\n\n\
+  # Incremental re-run scoped to a specific repo and branch\n\
+  tga collect --repos my-service --branch main --weeks 2\n\n\
+  # Recover missing branch commits after upgrading from tga <= 1.5.4\n\
+  tga collect --force\n\n\
+TIPS:\n\
+  - Run `tga classify` immediately after `tga collect` to keep the DB in sync.\n\
+  - Use `--weeks 4 --force` for routine weekly re-runs to refresh recent data.\n\
+  - `--branch` is collect-only; commits in the DB do not carry branch attribution."
+)]
 pub struct CollectArgs {
-    /// Only collect from these repository names (comma-separated).
+    /// Only collect from these repository names (comma-separated, e.g. --repos api,frontend).
+    ///
+    /// When omitted, all repositories from the config file are processed.
+    /// Repository names must match the `name` field in your YAML config
+    /// (or the directory basename if `name` is absent).
     #[arg(long, value_delimiter = ',')]
     pub repos: Vec<String>,
+
+    /// Restrict the revwalk to specific branch names (comma-separated).
+    ///
+    /// For each name in the list, the walk seeds from both
+    /// `refs/heads/<name>` and `refs/remotes/origin/<name>` so that the
+    /// local and remote-tracking copies are covered. If a branch does not
+    /// exist in a repository, a warning is emitted but collection continues.
+    ///
+    /// Examples:
+    ///   --branch main
+    ///   --branch main,release/1.0,feature/x
+    ///
+    /// Mutually exclusive with --head-only. Use --branch to scope the walk;
+    /// --head-only is the global legacy escape hatch for all repos.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        conflicts_with = "head_only",
+        value_name = "NAME[,NAME…]"
+    )]
+    pub branch: Vec<String>,
+
     /// Legacy alias for --from, accepted for backwards compatibility with
     /// scripts written against the Python `gitflow-analytics` predecessor.
     /// If both --from and --since are supplied, --from takes precedence.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub since: Option<String>,
     /// Legacy alias for --to, accepted for backwards compatibility with
     /// scripts written against the Python `gitflow-analytics` predecessor.
     /// If both --to and --until are supplied, --to takes precedence.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub until: Option<String>,
     /// Start date for collection (ISO8601: YYYY-MM-DD). Mutually exclusive with --weeks.
     #[arg(long, value_name = "DATE", conflicts_with = "weeks")]
     pub from: Option<String>,
-    /// End date for collection (ISO8601: YYYY-MM-DD). Defaults to today.
+    /// End date for collection (ISO8601: YYYY-MM-DD). Defaults to today. [default: today]
     #[arg(long, value_name = "DATE", conflicts_with = "weeks")]
     pub to: Option<String>,
     /// Re-collect all weeks even if already present in the database.
+    ///
+    /// Without --force, weeks that already have a row in `collection_runs` are
+    /// skipped. Pass --force to re-walk all weeks (useful after upgrading tga
+    /// or after a known data bug). Combine with --repos or --weeks to limit scope.
     #[arg(long, short = 'f', default_value_t = false)]
     pub force: bool,
     /// Limit collection to the last N weeks of commits (overrides config start_date).
     #[arg(long, value_name = "N", conflicts_with_all = ["from", "to"])]
     pub weeks: Option<u32>,
-    /// Skip the pre-walk `git fetch` step (use only local refs).
+    /// Skip the pre-walk `git fetch` step (use only local refs). [default: false]
     #[arg(long, default_value_t = false)]
     pub no_fetch: bool,
     /// Perform all steps except writing to the database (log intent only).
     #[arg(long, default_value_t = false)]
     pub dry_run: bool,
     /// Re-fetch ADO pull requests even if they are already in the database.
+    ///
     /// Use this to backfill rows persisted before v1.0.9 that have
-    /// `commit_shas = '[]'`.
+    /// `commit_shas = '[]'`. [default: false]
     #[arg(long, default_value_t = false)]
     pub force_refresh_prs: bool,
     /// Skip the post-collection tag and release-branch reachability scan.
@@ -258,7 +313,9 @@ pub struct CollectArgs {
     /// NOTE: existing tga.db files collected with tga <= 1.5.4 are missing
     /// commits from non-default branches.  Run `tga collect --force` after
     /// upgrading to 2.0.0 to recover that history.
-    #[arg(long, default_value_t = false)]
+    ///
+    /// Mutually exclusive with --branch.
+    #[arg(long, default_value_t = false, conflicts_with = "branch")]
     pub head_only: bool,
 }
 
@@ -294,7 +351,58 @@ pub struct CollectArgs {
 /// between the manual-override tier and custom rules. Pass `--no-external`
 /// to disable all external lookups (useful in CI or offline environments).
 #[derive(Args, Debug)]
+#[command(
+    about = "Classify collected commits using the four-tier cascade (Stage 2).",
+    long_about = "Run the classification cascade over commits already in the database.\n\n\
+The cascade applies rules in this order:\n\
+  Tier 0 -- manual overrides (tga override add)\n\
+  Tier 1 -- external ticket sources (JIRA, GitHub Issues, Linear, ADO)\n\
+  Tier 2 -- commit-message regex rules (built-in + custom --rules file)\n\
+  Tier 3 -- LLM fallback (requires --use-llm or config.classification.use_llm)\n\n\
+By default, commits that already have a classification are skipped for\n\
+efficiency. Pass --force to re-classify a slice (e.g. after a rule update).\n\n\
+NOTE: --branch is collect-only. Commits in the DB do not carry branch\n\
+attribution after the walk, so there is no branch filter here.",
+    after_help = "EXAMPLES:\n\
+  # Classify all unclassified commits (normal incremental run)\n\
+  tga classify\n\n\
+  # Re-classify commits in the last 8 weeks after updating rules\n\
+  tga classify --force --since 2026-01-01\n\n\
+  # Re-classify only the last 4 weeks for one repo\n\
+  tga classify --force --repos my-service --weeks 4\n\n\
+TIPS:\n\
+  - After updating your rules file, run `tga classify --force` to reprocess.\n\
+  - Use `--no-external` in CI to skip network calls to JIRA/GitHub Issues."
+)]
 pub struct ClassifyArgs {
+    /// Only re-classify commits from these repository names (comma-separated).
+    ///
+    /// When omitted, all repositories in the database are processed.
+    /// Matches against the `repository` column in the `commits` table.
+    #[arg(long, value_delimiter = ',')]
+    pub repos: Vec<String>,
+
+    /// Scope re-classification to commits in the last N ISO weeks.
+    ///
+    /// Combines with --force: only already-classified commits in the N-week
+    /// window are rewritten. Without --force, restricts the set of unclassified
+    /// commits considered. Mutually exclusive with --since/--until.
+    #[arg(long, value_name = "N", conflicts_with_all = ["since", "until"])]
+    pub weeks: Option<u32>,
+
+    /// Scope re-classification to commits on or after this date (ISO8601: YYYY-MM-DD).
+    ///
+    /// Restricts the set of commits processed. With --force, only already-classified
+    /// commits in the date range are rewritten. Mutually exclusive with --weeks.
+    #[arg(long, value_name = "DATE", conflicts_with = "weeks")]
+    pub since: Option<String>,
+
+    /// Scope re-classification to commits on or before this date (ISO8601: YYYY-MM-DD).
+    ///
+    /// Upper bound on the author timestamp window. Mutually exclusive with --weeks.
+    #[arg(long, value_name = "DATE", conflicts_with = "weeks")]
+    pub until: Option<String>,
+
     /// Rules file override.
     ///
     /// Custom classification rules file. Set `extend_defaults: true` in the
@@ -305,7 +413,7 @@ pub struct ClassifyArgs {
     /// file. Use `--no-external` to suppress all external lookups at runtime.
     #[arg(long)]
     pub rules: Option<PathBuf>,
-    /// Enable LLM fallback (overrides config).
+    /// Enable LLM fallback (overrides config). [default: false]
     #[arg(long)]
     pub use_llm: bool,
     /// Backfill missing complexity scores (1–5) for already-classified
@@ -321,18 +429,10 @@ pub struct ClassifyArgs {
     /// carries a verdict — useful for incremental runs but a footgun when
     /// the rule set is updated. With `--force`, every matching commit is
     /// re-classified and its existing `classifications` row is replaced
-    /// (no orphan rows). Combine with `--since` to bound the rewrite to a
-    /// recent window.
+    /// (no orphan rows). Combine with --since/--until or --weeks to bound
+    /// the rewrite to a specific window.
     #[arg(long, short = 'f', default_value_t = false)]
     pub force: bool,
-    /// Limit `--force` re-classification to commits whose author
-    /// timestamp is on or after this date (ISO8601: YYYY-MM-DD).
-    ///
-    /// Without `--force`, this flag is ignored — the default flow already
-    /// skips classified rows. When supplied with `--force`, only the
-    /// subset of already-classified commits in the window is rewritten.
-    #[arg(long, value_name = "DATE")]
-    pub since: Option<String>,
     /// Disable all external classification sources (JIRA, GitHub Issues).
     ///
     /// When set, external ticket lookups configured under `sources:` in the
@@ -345,11 +445,31 @@ pub struct ClassifyArgs {
 
 /// Arguments for `tga report`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Generate productivity reports from classified commits (Stage 3).",
+    long_about = "Produce CSV, JSON, and/or Markdown reports from the classified commits\n\
+already in the database. Reports aggregate metrics by author, week, and category.\n\n\
+Use --author to drill down to a single engineer's output.\n\
+Use --formats to select one or more output formats.\n\n\
+NOTE: --branch and --repos are collect-level concepts. The report reads\n\
+whatever is in the database; filter at collection time if needed.",
+    after_help = "EXAMPLES:\n\
+  # Generate all formats for the full team\n\
+  tga report --formats csv,json,markdown\n\n\
+  # Per-engineer drill-down\n\
+  tga report --author alice@example.com\n\n\
+  # Write reports to a custom directory\n\
+  tga report --output ./reports --formats markdown\n\n\
+TIPS:\n\
+  - Use `tga aliases list` to find canonical email addresses for --author.\n\
+  - Reports cover all classified data in the DB; re-run classify first if\n\
+    recent commits are unclassified."
+)]
 pub struct ReportArgs {
-    /// Output directory override.
+    /// Output directory override. [default: ./output]
     #[arg(short, long)]
     pub output: Option<PathBuf>,
-    /// Output formats (csv, json, markdown — comma-separated).
+    /// Output formats (csv, json, markdown — comma-separated). [default: all formats]
     #[arg(long, value_delimiter = ',')]
     pub formats: Vec<String>,
     /// Scope the report to a single canonical identity.

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -152,6 +152,26 @@ pub enum IncidentsSubcommand {
 
 /// Arguments for `tga analyze`.
 #[derive(Args, Debug)]
+#[command(
+    about = "Run the full pipeline: collect → classify → report.",
+    long_about = "Run all three stages (collect, classify, report) in sequence against the\n\
+configured repositories.\n\n\
+This is the normal production command for routine analytics runs. Individual\n\
+stages can be invoked separately (tga collect / tga classify / tga report) when\n\
+you need surgical control over a single step.\n\n\
+NOTE: --branch is available via `tga collect` when running stages individually.\n\
+Use `tga analyze --skip-collect && tga collect --branch main` for branched runs.",
+    after_help = "EXAMPLES:\n\
+  # Standard weekly run (collect last 4 weeks, classify, report)\n\
+  tga analyze --weeks 4\n\n\
+  # Full history refresh after upgrading (re-collects all weeks)\n\
+  tga analyze --force\n\n\
+  # Skip slow collection; re-classify and regenerate reports only\n\
+  tga analyze --skip-collect\n\n\
+TIPS:\n\
+  - Run `tga collect --branch main --force` first to restrict the corpus.\n\
+  - Use --dry-run to preview collection work without database writes."
+)]
 pub struct AnalyzeArgs {
     /// Skip collection (use existing DB data).
     #[arg(long)]
@@ -272,8 +292,20 @@ pub struct CollectArgs {
     #[arg(long, value_name = "N", conflicts_with_all = ["from", "to"])]
     pub weeks: Option<u32>,
     /// Skip the pre-walk `git fetch` step (use only local refs). [default: false]
+    ///
+    /// WARNING: skipping fetch means the walk operates on whatever is already in
+    /// your local object store. Commits pushed to the remote after the last local
+    /// fetch will be silently absent from the results.
     #[arg(long, default_value_t = false)]
     pub no_fetch: bool,
+    /// Exit non-zero if any repository's fetch failed (default: failures are
+    /// visible in the summary but collection still exits 0). Useful for CI.
+    #[arg(long, default_value_t = false)]
+    pub strict_fetch: bool,
+    /// Print a success line for every fetched repo in the fetch summary
+    /// (default: only failures are printed). [default: false]
+    #[arg(long, default_value_t = false)]
+    pub verbose_fetch: bool,
     /// Perform all steps except writing to the database (log intent only).
     #[arg(long, default_value_t = false)]
     pub dry_run: bool,

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -244,6 +244,22 @@ pub struct CollectArgs {
     /// dynamically by CI).
     #[arg(long, default_value_t = false)]
     pub no_validate: bool,
+    /// Restore legacy HEAD-only revwalk for all repositories.
+    ///
+    /// tga 2.0.0 changed the default to walk ALL local branches and remote
+    /// tracking refs (refs/heads/* + refs/remotes/origin/*), fixing a
+    /// data-integrity bug where commits on non-default branches (PR branches,
+    /// feature branches, hotfixes) were silently excluded (#331).
+    ///
+    /// Pass --head-only to revert to the 1.x HEAD-only walk for all repos.
+    /// For a per-repo opt-out, set `head_only: true` in the repository entry
+    /// in your YAML config.
+    ///
+    /// NOTE: existing tga.db files collected with tga <= 1.5.4 are missing
+    /// commits from non-default branches.  Run `tga collect --force` after
+    /// upgrading to 2.0.0 to recover that history.
+    #[arg(long, default_value_t = false)]
+    pub head_only: bool,
 }
 
 /// Arguments for `tga classify`.


### PR DESCRIPTION
## Summary

tga 2.0.0 combined release shipping four issues in one coherent breaking change:

- **#331** (BREAKING) — `tga collect` walks all branches by default (`refs/heads/*` + `refs/remotes/origin/*`) instead of HEAD only. Fixes massive commit undercount in multi-branch repos.
- **#332** (BREAKING) — Uniform `--repo` / `--branch` / `--week` filters across `collect`, `classify`, and `backfill` subcommands. Consistent flag names everywhere.
- **#333** — Comprehensive CLI documentation audit. Every subcommand now has `after_help` examples, 💡 Tip lines, and full README coverage including a new "Common Workflows" section and "CLI Subcommand Reference" table.
- **#334** — Always-fetch with per-repo error visibility. New `--strict-fetch` (non-zero exit on fetch failure), `--verbose-fetch` (per-repo success lines), and end-of-collect fetch summary on stderr. Surfaces fetch failures that previously silently produced stale data.

## Breaking changes

1. `tga collect` now walks all branches by default. To restore old HEAD-only behavior, pass `--head-only`.
2. Some filter flag names normalized — see CHANGELOG for migration guide.

## Test plan

- [x] `cargo build -p tga` — clean
- [x] `cargo test -p tga` — 564 tests pass (added 2 new for #334)
- [x] `cargo clippy -p tga --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: `tga collect` against a multi-branch repo confirms all-branch walk (post-merge)
- [ ] Manual: simulated dead remote produces visible fetch summary (post-merge)

Closes #331
Closes #332
Closes #333
Closes #334