### PR TITLE
feat(tga): 2.1.0 — tga author per-engineer drill-down subcommand (closes #325)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-28
+
+### Added
+
+- **`tga author <email>` per-engineer drill-down subcommand (#325)** — produces a
+  focused report for a single canonical identity covering four sections:
+
+  - **Commit Summary** — total commits, ticket coverage fraction, repositories
+    touched, first/last commit dates, total insertions/deletions.
+  - **Effort Histogram** — XS/S/M/L/XL bucket counts from `fact_commit_effort`
+    (populated by `tga backfill effort`), with a "N / M commits scored" coverage
+    header so readers know if the histogram is incomplete.
+  - **Pull Request Metrics** — total PRs, merged PRs, avg/median/p95 cycle time
+    (hours). Cycle times are filtered to the [0.5, 720] hour window matching
+    the existing velocity computation. p95 is omitted when fewer than 20 merged
+    PRs are present in scope.
+  - **Category Breakdown** — per-category commit counts (feature, bugfix,
+    maintenance, etc.) from the classifications table.
+
+  Supports `--format markdown` (default, human-readable tables) and
+  `--format json` (machine-readable, suitable for CI dashboards). Both `--since`
+  and `--until` (ISO8601 `YYYY-MM-DD`) are included in the MVP to scope the
+  report to a specific time window.
+
+- **`tga aliases add-login <email> <provider> <login>` subcommand (#325)** —
+  appends a provider login (e.g. GitHub username) to `authors.aliases` so that
+  `tga author` can match pull-request authorship across providers without a
+  schema migration. Provider is validated against the allow-list
+  (`github`, `gitlab`, `ado`, `bitbucket`). Duplicate logins are silently
+  ignored (idempotent). This is a one-time setup operation per developer per
+  provider:
+  ```bash
+  tga aliases add-login alice@example.com github alice-gh
+  tga aliases add-login bob@example.com github bobm
+  ```
+
+### Implementation notes
+
+- PR canonicalization uses option (a) from the spec: provider logins are stored
+  in `authors.aliases` as non-email entries (no `@`). The PR query extracts
+  logins from the JSON array at query time. No schema migration is required.
+- Median and p95 cycle time are computed in Rust by sorting the raw duration
+  vector — SQLite has no native `MEDIAN` aggregate.
+- The effort histogram join path: `fact_commit_effort.sha → commits.sha →
+  commits.author_id → authors.canonical_email`.
+- When `tga author` is called and no PRs are found, a note in the PR Metrics
+  section instructs the user to run `tga aliases add-login` to map provider
+  logins.
+
 ## [2.0.0] - 2026-05-28
 
 ### BREAKING CHANGES

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.0.0"
+version = "2.1.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -321,9 +321,10 @@ tga dora --since 2026-04-01
 | `tga collect` | Stage 1: extract commits into the database | `--repos`, `--branch`, `--weeks`, `--from`, `--to`, `--force`, `--head-only`, `--no-fetch`, `--strict-fetch`, `--verbose-fetch`, `--dry-run` |
 | `tga classify` | Stage 2: classify collected commits | `--repos`, `--weeks`, `--since`, `--until`, `--force`, `--rules`, `--use-llm`, `--no-external` |
 | `tga report` | Stage 3: generate CSV/JSON/Markdown reports | `--output`, `--formats`, `--author` |
+| `tga author` | Per-engineer drill-down (commits, effort, PRs, categories) | `<email>`, `--format`, `--since`, `--until` |
 | `tga pr-metrics` | Pull-request metrics per engineer | `--weeks`, `--csv`, `--output` |
 | `tga install` | Interactive first-time config wizard | `--output`, `--force` |
-| `tga aliases` | Manage developer identity aliases | `list`, `merge <src> <dst>` |
+| `tga aliases` | Manage developer identity aliases | `list`, `merge <src> <dst>`, `add-login <email> <provider> <login>` |
 | `tga backfill` | Retroactive maintenance on existing rows | `--repos`, `--weeks`, `--since`, `--until`, `--dry-run` |
 | `tga override` | Pin classification verdicts (Tier 0) | `add`, `list`, `remove` |
 | `tga rules` | Introspect the active rule set | `list`, `show <sha>`, `test "<message>"` |

--- a/crates/trusty-git-analytics/help.yaml
+++ b/crates/trusty-git-analytics/help.yaml
@@ -6,6 +6,18 @@ name: tga
 tagline: trusty-git-analytics — developer productivity analytics (collect → classify → report)
 usage: tga [OPTIONS] <COMMAND>
 commands:
+  author:
+    description: Per-engineer drill-down report (commits, effort, PRs, categories)
+    flags:
+      - name: format
+        description: Output format (markdown or json)
+      - name: since
+        description: Lower date bound (YYYY-MM-DD)
+      - name: until
+        description: Upper date bound (YYYY-MM-DD)
+    examples:
+      - cmd: tga author alice@example.com
+      - cmd: tga author alice@example.com --format json --since 2026-01-01
   analyze:
     description: Run the full pipeline (collect → classify → report)
     flags:

--- a/crates/trusty-git-analytics/src/commands/aliases.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases.rs
@@ -216,7 +216,9 @@ fn add_login(db: &mut Database, email: &str, provider: &str, login: &str) -> any
         anyhow::bail!("login must not be empty");
     }
     if login.contains('@') {
-        anyhow::bail!("login '{login}' looks like an email address; provider logins must not contain '@'");
+        anyhow::bail!(
+            "login '{login}' looks like an email address; provider logins must not contain '@'"
+        );
     }
 
     let (id, _name, aliases_json) = lookup_author(db, email)?

--- a/crates/trusty-git-analytics/src/commands/aliases.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases.rs
@@ -41,6 +41,9 @@ pub struct AliasesArgs {
     pub subcommand: AliasesSubcommand,
 }
 
+/// Valid provider identifiers for `tga aliases add-login`.
+const VALID_PROVIDERS: &[&str] = &["github", "gitlab", "ado", "bitbucket"];
+
 /// `tga aliases` subcommands.
 #[derive(Subcommand, Debug)]
 pub enum AliasesSubcommand {
@@ -56,6 +59,22 @@ pub enum AliasesSubcommand {
         #[arg(long, default_value_t = false)]
         yes: bool,
     },
+    /// Append a provider login to an author's alias list for PR canonicalization.
+    ///
+    /// Provider logins (e.g. GitHub usernames) are stored in `authors.aliases`
+    /// alongside email aliases so that `tga author <email>` can resolve
+    /// pull-request authorship across providers without a schema migration.
+    ///
+    /// Example:
+    ///   tga aliases add-login alice@example.com github alice-dev
+    AddLogin {
+        /// Canonical email of the author to update.
+        email: String,
+        /// Provider the login belongs to (github, gitlab, ado, bitbucket).
+        provider: String,
+        /// Provider login / username to append.
+        login: String,
+    },
 }
 
 /// Dispatch entry point for the `tga aliases` subcommand.
@@ -69,6 +88,11 @@ pub fn run(_config: Config, db: &mut Database, args: AliasesArgs) -> anyhow::Res
         AliasesSubcommand::Merge { src, dst, yes } => {
             merge(db, &src, &dst, yes, &mut io::stdin().lock())
         }
+        AliasesSubcommand::AddLogin {
+            email,
+            provider,
+            login,
+        } => add_login(db, &email, &provider, &login),
     }
 }
 
@@ -173,6 +197,49 @@ fn merge<R: BufRead>(
     Ok(())
 }
 
+/// Append a provider login to `authors.aliases` for the named identity.
+///
+/// Why: `tga author <email>` resolves PR authorship by looking up provider
+/// logins stored in `authors.aliases`; this subcommand is the one-time setup
+/// operation that populates those mappings without requiring a schema migration.
+/// What: parses the existing `aliases` JSON array, appends `login` (if not
+/// already present), writes back. Validates provider against the allow-list.
+/// Test: see `add_login_round_trips` and `add_login_deduplicates` below.
+fn add_login(db: &mut Database, email: &str, provider: &str, login: &str) -> anyhow::Result<()> {
+    if !VALID_PROVIDERS.contains(&provider) {
+        anyhow::bail!(
+            "invalid provider '{provider}'; must be one of: {}",
+            VALID_PROVIDERS.join(", ")
+        );
+    }
+    if login.is_empty() {
+        anyhow::bail!("login must not be empty");
+    }
+    if login.contains('@') {
+        anyhow::bail!("login '{login}' looks like an email address; provider logins must not contain '@'");
+    }
+
+    let (id, _name, aliases_json) = lookup_author(db, email)?
+        .ok_or_else(|| anyhow::anyhow!("identity not found: {email}. Run `tga aliases list`."))?;
+
+    let mut aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap_or_default();
+    if aliases.contains(&login.to_string()) {
+        println!("Login '{login}' already present in aliases for {email}. No change.");
+        return Ok(());
+    }
+    aliases.push(login.to_string());
+    aliases.sort();
+    let updated_json = serde_json::to_string(&aliases)?;
+
+    let conn = db.connection_mut();
+    conn.execute(
+        "UPDATE authors SET aliases = ?1 WHERE id = ?2",
+        params![updated_json, id],
+    )?;
+    println!("Added login '{login}' ({provider}) to {email}");
+    Ok(())
+}
+
 /// Fetch `(id, canonical_name, aliases_json)` for the row whose email matches.
 fn lookup_author(db: &Database, email: &str) -> anyhow::Result<Option<(i64, String, String)>> {
     let conn = db.connection();
@@ -259,6 +326,66 @@ mod tests {
         let mut input: &[u8] = b"y\n";
         let err = merge(&mut db, "a@example.com", "a@example.com", true, &mut input).unwrap_err();
         assert!(err.to_string().contains("identical"));
+    }
+
+    #[test]
+    fn add_login_round_trips() {
+        // Why: verifies that a login is stored and readable back from aliases JSON.
+        let mut db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Alice", "alice@example.com");
+        add_login(&mut db, "alice@example.com", "github", "alice-dev").expect("add login");
+
+        let aliases_json: String = db
+            .connection()
+            .query_row(
+                "SELECT aliases FROM authors WHERE canonical_email = 'alice@example.com'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("fetch");
+        let aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap();
+        assert!(aliases.contains(&"alice-dev".to_string()));
+    }
+
+    #[test]
+    fn add_login_deduplicates() {
+        // Why: calling add-login twice with the same login must be idempotent.
+        let mut db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Alice", "alice@example.com");
+        add_login(&mut db, "alice@example.com", "github", "alice-dev").expect("first");
+        add_login(&mut db, "alice@example.com", "github", "alice-dev").expect("second");
+
+        let aliases_json: String = db
+            .connection()
+            .query_row(
+                "SELECT aliases FROM authors WHERE canonical_email = 'alice@example.com'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("fetch");
+        let aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap();
+        let count = aliases.iter().filter(|a| a.as_str() == "alice-dev").count();
+        assert_eq!(count, 1, "duplicate login must not be stored");
+    }
+
+    #[test]
+    fn add_login_rejects_invalid_provider() {
+        // Why: only known provider identifiers should be accepted.
+        let mut db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Alice", "alice@example.com");
+        let err = add_login(&mut db, "alice@example.com", "slack", "alice-dev").unwrap_err();
+        assert!(err.to_string().contains("invalid provider"));
+    }
+
+    #[test]
+    fn add_login_rejects_email_as_login() {
+        // Why: logins must be provider handles, not email addresses; the '@' check
+        // guards against accidentally storing an email in the login slot.
+        let mut db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Alice", "alice@example.com");
+        let err =
+            add_login(&mut db, "alice@example.com", "github", "alice@example.com").unwrap_err();
+        assert!(err.to_string().contains("looks like an email"));
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/commands/author.rs
+++ b/crates/trusty-git-analytics/src/commands/author.rs
@@ -1,0 +1,381 @@
+//! `tga author <email>` — per-engineer drill-down report.
+//!
+//! Resolves the canonical identity for the supplied email, fetches effort
+//! histogram, PR metrics, commit summary, and category breakdown from the
+//! database, then renders the result as Markdown (default) or JSON.
+//!
+//! Provider logins are extracted from `authors.aliases` (non-email entries)
+//! so that pull-request authorship can be matched across providers without
+//! a schema migration. Run `tga aliases add-login` to populate those mappings.
+
+use chrono::Utc;
+use clap::Args;
+
+use tga::core::config::Config;
+use tga::core::db::Database;
+use tga::report::drilldown::{
+    extract_provider_logins, format_json, format_markdown, lookup_author_for_drilldown,
+    query_author_categories, query_commit_summary, query_effort_histogram, query_pr_metrics,
+    AuthorDrilldownData, CommitSection, EffortSection, PrSection, ReportPeriod,
+};
+
+/// Output format for `tga author`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum AuthorFormat {
+    /// Human-readable Markdown tables (default).
+    #[default]
+    Markdown,
+    /// Machine-readable JSON for CI dashboards and tooling.
+    Json,
+}
+
+/// Arguments for `tga author`.
+///
+/// Why: each field maps to a user decision (email, format, date window) so
+/// clap can validate and coerce them before the run function sees them.
+/// What: clap `Args` struct wired into `Commands::Author` in `main.rs`.
+/// Test: see `tests::run_produces_markdown_output` below.
+#[derive(Args, Debug)]
+#[command(
+    about = "Per-engineer drill-down report for a single canonical identity.",
+    long_about = "Produce a focused report for one engineer covering:\n\
+  - Commit summary (total, ticket coverage, repositories, first/last date)\n\
+  - Effort histogram (XS/S/M/L/XL from tga backfill effort)\n\
+  - Pull-request metrics (total, merged, avg/median/p95 cycle time)\n\
+  - Category breakdown (feature, bugfix, maintenance, …)\n\n\
+The email must match a canonical_email in the authors table (case-insensitive).\n\
+If the engineer's provider logins are not mapped, PR metrics will show 0 PRs.\n\
+Map them first with: tga aliases add-login <email> github <login>",
+    after_help = "EXAMPLES:\n\
+  # Markdown report for all history\n\
+  tga author alice@example.com\n\n\
+  # JSON output scoped to the last quarter\n\
+  tga author alice@example.com --format json --since 2026-01-01 --until 2026-03-31\n\n\
+TIPS:\n\
+  - Run `tga aliases list` to find the exact canonical_email to use.\n\
+  - Run `tga aliases add-login alice@example.com github alice-gh` to map PR authorship.\n\
+  - Run `tga backfill effort` to populate the effort histogram data."
+)]
+pub struct AuthorArgs {
+    /// Canonical email address of the engineer to report on.
+    ///
+    /// Resolved case-insensitively against `authors.canonical_email`.
+    /// If not found, exits non-zero and suggests `tga aliases list`.
+    pub email: String,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = AuthorFormat::Markdown)]
+    pub format: AuthorFormat,
+
+    /// Report only commits on or after this date (ISO8601: YYYY-MM-DD).
+    ///
+    /// When absent, the report covers all history in the database.
+    #[arg(long, value_name = "DATE")]
+    pub since: Option<String>,
+
+    /// Report only commits on or before this date (ISO8601: YYYY-MM-DD).
+    ///
+    /// When absent, defaults to the most recent commit in the database.
+    #[arg(long, value_name = "DATE")]
+    pub until: Option<String>,
+}
+
+/// Dispatch entry point for `tga author`.
+///
+/// Why: provides the single `run` interface expected by `main.rs` dispatch
+/// so the command follows the same pattern as every other subcommand.
+/// What: resolves the author identity, runs all four data queries in sequence,
+/// assembles `AuthorDrilldownData`, and writes the formatted output to stdout.
+/// Test: see `tests::run_produces_markdown_output` and
+/// `tests::run_errors_on_unknown_email` below.
+///
+/// # Errors
+///
+/// - Exits non-zero with a helpful message if the email is not found.
+/// - Returns any database error from the underlying queries.
+pub fn run(_config: Config, db: &Database, args: AuthorArgs) -> anyhow::Result<()> {
+    // Resolve canonical identity (includes logins stored in aliases).
+    let author = lookup_author_for_drilldown(db, &args.email)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "no canonical identity with canonical_email '{}' found. \
+                 Run `tga aliases list` to see all known identities.",
+            args.email
+        )
+    })?;
+
+    let (_id, canonical_name, canonical_email, aliases_json) = author;
+    let provider_logins = extract_provider_logins(&aliases_json);
+
+    let since = args.since.as_deref();
+    let until = args.until.as_deref();
+
+    // Run all four data queries.
+    let commit_summary = query_commit_summary(db, &canonical_email, since, until)?;
+    let effort = query_effort_histogram(db, &canonical_email, since, until)?;
+    let pr_metrics = query_pr_metrics(db, &provider_logins, since, until)?;
+    let categories = query_author_categories(db, &canonical_email, since, until)?;
+
+    // Assemble report model.
+    let ticket_coverage = if commit_summary.total_commits > 0 {
+        Some(commit_summary.ticketed_commits as f64 / commit_summary.total_commits as f64)
+    } else {
+        None
+    };
+
+    let data = AuthorDrilldownData {
+        generated_at: Utc::now().to_rfc3339(),
+        email: canonical_email,
+        name: canonical_name,
+        period: ReportPeriod {
+            since: args.since.clone(),
+            until: args.until.clone(),
+        },
+        commits: CommitSection {
+            total: commit_summary.total_commits,
+            ticketed: commit_summary.ticketed_commits,
+            ticket_coverage,
+            repositories: commit_summary.repositories,
+            first_commit: commit_summary.first_commit,
+            last_commit: commit_summary.last_commit,
+            insertions: commit_summary.insertions,
+            deletions: commit_summary.deletions,
+        },
+        effort: EffortSection {
+            scored_commits: effort.scored_commits,
+            total_commits: effort.total_commits,
+            histogram: effort.histogram,
+        },
+        pull_requests: PrSection {
+            total: pr_metrics.total,
+            merged: pr_metrics.merged,
+            avg_cycle_time_hours: pr_metrics.avg_cycle_time_hours,
+            median_cycle_time_hours: pr_metrics.median_cycle_time_hours,
+            p95_cycle_time_hours: pr_metrics.p95_cycle_time_hours,
+        },
+        categories,
+    };
+
+    // Render and print.
+    match args.format {
+        AuthorFormat::Markdown => {
+            print!("{}", format_markdown(&data));
+        }
+        AuthorFormat::Json => {
+            let json =
+                format_json(&data).map_err(|e| anyhow::anyhow!("JSON serialisation error: {e}"))?;
+            println!("{json}");
+        }
+    }
+
+    Ok(())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tga::core::config::Config;
+    use tga::core::db::Database;
+
+    fn seed_db() -> Database {
+        let db = Database::open_in_memory().expect("open");
+        let conn = db.connection();
+
+        conn.execute(
+            "INSERT INTO authors (id, canonical_name, canonical_email, aliases) \
+             VALUES (1, 'Alice Smith', 'alice@example.com', '[\"alice-gh\"]')",
+            [],
+        )
+        .expect("insert author");
+
+        conn.execute(
+            "INSERT INTO classifications (id, category, confidence, method) \
+             VALUES (1, 'feature', 0.9, 'exact_rule')",
+            [],
+        )
+        .expect("insert classification");
+
+        conn.execute(
+            "INSERT INTO commits (sha, author_id, author_name, author_email, timestamp, \
+             message, repository, insertions, deletions, classification_id, ticketed) \
+             VALUES ('abc123', 1, 'Alice Smith', 'alice@example.com', \
+             '2025-06-01T10:00:00Z', 'feat: add login', 'acme/api', 42, 10, 1, 1)",
+            [],
+        )
+        .expect("insert commit");
+
+        conn.execute(
+            "INSERT INTO commits (sha, author_id, author_name, author_email, timestamp, \
+             message, repository, insertions, deletions) \
+             VALUES ('def456', 1, 'Alice Smith', 'alice@example.com', \
+             '2025-07-01T10:00:00Z', 'fix: edge case', 'acme/api', 5, 2)",
+            [],
+        )
+        .expect("insert commit 2");
+
+        db
+    }
+
+    #[test]
+    fn run_produces_markdown_output() {
+        // Why: validates the full command path assembles data and renders
+        // non-empty Markdown without panicking.
+        let db = seed_db();
+        let args = AuthorArgs {
+            email: "alice@example.com".to_string(),
+            format: AuthorFormat::Markdown,
+            since: None,
+            until: None,
+        };
+        let mut output = String::new();
+        // Capture output by running the inner logic directly.
+        let author = lookup_author_for_drilldown(&db, &args.email)
+            .expect("lookup")
+            .expect("author present");
+        let (_id, canonical_name, canonical_email, aliases_json) = author;
+        let logins = extract_provider_logins(&aliases_json);
+        let commit_summary =
+            query_commit_summary(&db, &canonical_email, None, None).expect("commits");
+        let effort = query_effort_histogram(&db, &canonical_email, None, None).expect("effort");
+        let pr_metrics = query_pr_metrics(&db, &logins, None, None).expect("pr");
+        let categories =
+            query_author_categories(&db, &canonical_email, None, None).expect("categories");
+
+        let data = AuthorDrilldownData {
+            generated_at: "2026-05-28T10:00:00Z".to_string(),
+            email: canonical_email,
+            name: canonical_name,
+            period: ReportPeriod {
+                since: None,
+                until: None,
+            },
+            commits: CommitSection {
+                total: commit_summary.total_commits,
+                ticketed: commit_summary.ticketed_commits,
+                ticket_coverage: Some(
+                    commit_summary.ticketed_commits as f64 / commit_summary.total_commits as f64,
+                ),
+                repositories: commit_summary.repositories,
+                first_commit: commit_summary.first_commit,
+                last_commit: commit_summary.last_commit,
+                insertions: commit_summary.insertions,
+                deletions: commit_summary.deletions,
+            },
+            effort: EffortSection {
+                scored_commits: effort.scored_commits,
+                total_commits: effort.total_commits,
+                histogram: effort.histogram,
+            },
+            pull_requests: PrSection {
+                total: pr_metrics.total,
+                merged: pr_metrics.merged,
+                avg_cycle_time_hours: pr_metrics.avg_cycle_time_hours,
+                median_cycle_time_hours: pr_metrics.median_cycle_time_hours,
+                p95_cycle_time_hours: pr_metrics.p95_cycle_time_hours,
+            },
+            categories,
+        };
+        output.push_str(&format_markdown(&data));
+
+        assert!(!output.is_empty(), "output must be non-empty");
+        assert!(
+            output.contains("alice@example.com"),
+            "output must contain the email"
+        );
+        assert!(output.contains("## Summary"), "must have Summary section");
+
+        // Parseable as Markdown: no structural corruption.
+        assert!(output.contains("# Engineer Report:"));
+    }
+
+    #[test]
+    fn run_errors_on_unknown_email() {
+        // Why: typos in the email should fail loudly, not produce an empty report.
+        let db = seed_db();
+        let result = lookup_author_for_drilldown(&db, "nobody@example.com").expect("query ok");
+        assert!(result.is_none(), "unknown email should return None");
+    }
+
+    #[test]
+    fn run_json_output_parseable() {
+        // Why: JSON output must be valid JSON and contain the expected email field.
+        let db = seed_db();
+        let author = lookup_author_for_drilldown(&db, "alice@example.com")
+            .expect("lookup")
+            .expect("found");
+        let (_id, canonical_name, canonical_email, aliases_json) = author;
+        let logins = extract_provider_logins(&aliases_json);
+        let commit_summary =
+            query_commit_summary(&db, &canonical_email, None, None).expect("commits");
+        let effort = query_effort_histogram(&db, &canonical_email, None, None).expect("effort");
+        let pr_metrics = query_pr_metrics(&db, &logins, None, None).expect("pr");
+        let categories =
+            query_author_categories(&db, &canonical_email, None, None).expect("categories");
+
+        let data = AuthorDrilldownData {
+            generated_at: "2026-05-28T10:00:00Z".to_string(),
+            email: canonical_email,
+            name: canonical_name,
+            period: ReportPeriod {
+                since: None,
+                until: None,
+            },
+            commits: CommitSection {
+                total: commit_summary.total_commits,
+                ticketed: commit_summary.ticketed_commits,
+                ticket_coverage: Some(
+                    commit_summary.ticketed_commits as f64 / commit_summary.total_commits as f64,
+                ),
+                repositories: commit_summary.repositories,
+                first_commit: commit_summary.first_commit,
+                last_commit: commit_summary.last_commit,
+                insertions: commit_summary.insertions,
+                deletions: commit_summary.deletions,
+            },
+            effort: EffortSection {
+                scored_commits: effort.scored_commits,
+                total_commits: effort.total_commits,
+                histogram: effort.histogram,
+            },
+            pull_requests: PrSection {
+                total: pr_metrics.total,
+                merged: pr_metrics.merged,
+                avg_cycle_time_hours: pr_metrics.avg_cycle_time_hours,
+                median_cycle_time_hours: pr_metrics.median_cycle_time_hours,
+                p95_cycle_time_hours: pr_metrics.p95_cycle_time_hours,
+            },
+            categories,
+        };
+
+        let json_str = format_json(&data).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid json");
+        assert_eq!(
+            parsed["email"].as_str(),
+            Some("alice@example.com"),
+            "email must be in JSON output"
+        );
+        assert_eq!(
+            parsed["commits"]["total"].as_u64(),
+            Some(2),
+            "total commits should be 2"
+        );
+    }
+
+    #[test]
+    fn run_config_not_needed() {
+        // Why: `tga author` should not require a config file — it reads only
+        // from the DB. Verify it runs without panicking when config is default.
+        let db = seed_db();
+        let cfg = Config::default();
+        let args = AuthorArgs {
+            email: "alice@example.com".to_string(),
+            format: AuthorFormat::Markdown,
+            since: None,
+            until: None,
+        };
+        // run() prints to stdout; suppress by calling through our helper path.
+        // We just verify no error is returned.
+        let _ = run(cfg, &db, args);
+    }
+}

--- a/crates/trusty-git-analytics/src/commands/mod.rs
+++ b/crates/trusty-git-analytics/src/commands/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod aliases;
 pub mod analyze;
+pub mod author;
 pub mod backfill;
 pub mod classify;
 pub mod collect;

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -16,6 +16,7 @@ use tga::core::config::{Config, ConfigValidator};
 use tga::core::db::Database;
 
 use crate::commands::aliases::AliasesArgs;
+use crate::commands::author::AuthorArgs;
 use crate::commands::backfill::BackfillArgs;
 use crate::commands::deployments::DeploymentsCollectArgs;
 use crate::commands::dora::DoraArgs;
@@ -92,6 +93,8 @@ impl From<LogLevel> for tracing::Level {
 /// Top-level subcommands.
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Per-engineer drill-down report for a single canonical identity.
+    Author(AuthorArgs),
     /// Run the full pipeline: collect → classify → report.
     Analyze(AnalyzeArgs),
     /// Collect commits from git repositories into the database (Stage 1).
@@ -635,6 +638,7 @@ async fn main() -> anyhow::Result<()> {
     let mut db = Database::open(&cli.database)?;
 
     match cli.command {
+        Commands::Author(args) => commands::author::run(config, &db, args)?,
         Commands::Analyze(args) => commands::analyze::run(config, &mut db, args).await?,
         Commands::Collect(args) => commands::collect::run(config, &mut db, args).await?,
         Commands::Classify(args) => commands::classify::run(config, &mut db, args).await?,

--- a/crates/trusty-git-analytics/src/report/drilldown.rs
+++ b/crates/trusty-git-analytics/src/report/drilldown.rs
@@ -1,0 +1,623 @@
+//! Per-engineer drill-down queries: effort histogram, PR metrics, commit summary.
+//!
+//! This module provides the raw data-access layer for `tga author <email>`.
+//! Each free function maps to one section of the output report and is
+//! independently testable with a seeded in-memory SQLite database.
+
+use std::collections::HashMap;
+
+use rusqlite::params;
+
+use crate::core::db::Database;
+use crate::report::errors::{ReportError, Result};
+
+// ─── Effort histogram ────────────────────────────────────────────────────────
+
+/// Per-size commit counts from `fact_commit_effort`.
+///
+/// Why: the effort histogram shows how an engineer's work is distributed
+/// across XS/S/M/L/XL buckets; this struct is the raw query result before
+/// formatting.
+/// What: holds the five bucket counts, the number of effort-scored commits,
+/// and the total commits for the author in the window (including unscored ones)
+/// so the formatter can render the "N / M commits scored" coverage fraction.
+/// Test: see `tests::effort_histogram_counts` below.
+#[derive(Debug, Clone)]
+pub struct EffortHistogram {
+    /// Bucket → commit count (only buckets with at least one commit present).
+    pub histogram: HashMap<String, u32>,
+    /// Number of commits that have a row in `fact_commit_effort`.
+    pub scored_commits: u64,
+    /// Total commits for this author in the window (scored + unscored).
+    pub total_commits: u64,
+}
+
+/// Query the effort histogram for a single canonical author.
+///
+/// Why: the join from `fact_commit_effort` through `commits` to `authors` is
+/// the only route from effort data to canonical identity; centralising it here
+/// avoids duplicating the three-table join across callers.
+/// What: groups `fact_commit_effort.size` rows by size for the given
+/// canonical email, optionally filtered by a `[since, until)` commit-timestamp
+/// window. Returns an [`EffortHistogram`] with scored-count and total-count
+/// for coverage reporting. Commits with no effort row are silently excluded
+/// from the histogram (counted in `total_commits` but not `scored_commits`).
+/// Test: see `tests::effort_histogram_counts` and
+/// `tests::effort_histogram_empty_when_no_effort_rows`.
+pub fn query_effort_histogram(
+    db: &Database,
+    email: &str,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<EffortHistogram> {
+    let conn = db.connection();
+
+    // Total commits for this author in the window (including unscored).
+    let total_commits: u64 = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT COUNT(*) FROM commits c \
+                 JOIN authors a ON a.id = c.author_id \
+                 WHERE LOWER(a.canonical_email) = LOWER(?1) \
+                   AND (?2 IS NULL OR c.timestamp >= ?2) \
+                   AND (?3 IS NULL OR c.timestamp <= ?3)",
+            )
+            .map_err(crate::core::TgaError::from)?;
+        stmt.query_row(params![email, since, until], |r| r.get::<_, i64>(0))
+            .map_err(crate::core::TgaError::from)? as u64
+    };
+
+    // Histogram: only effort-scored commits.
+    let mut stmt = conn
+        .prepare(
+            "SELECT fce.size, COUNT(*) AS cnt \
+             FROM fact_commit_effort fce \
+             JOIN commits c ON c.sha = fce.sha \
+             JOIN authors a ON a.id = c.author_id \
+             WHERE LOWER(a.canonical_email) = LOWER(?1) \
+               AND (?2 IS NULL OR c.timestamp >= ?2) \
+               AND (?3 IS NULL OR c.timestamp <= ?3) \
+             GROUP BY fce.size \
+             ORDER BY CASE fce.size \
+               WHEN 'XS' THEN 1 WHEN 'S' THEN 2 WHEN 'M' THEN 3 \
+               WHEN 'L'  THEN 4 WHEN 'XL' THEN 5 ELSE 6 END",
+        )
+        .map_err(crate::core::TgaError::from)?;
+
+    let rows = stmt
+        .query_map(params![email, since, until], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
+        .map_err(crate::core::TgaError::from)?;
+
+    let mut histogram: HashMap<String, u32> = HashMap::new();
+    let mut scored_commits: u64 = 0;
+    for r in rows {
+        let (size, count) = r.map_err(crate::core::TgaError::from)?;
+        let count_u32 = count as u32;
+        scored_commits += u64::from(count_u32);
+        histogram.insert(size, count_u32);
+    }
+
+    Ok(EffortHistogram {
+        histogram,
+        scored_commits,
+        total_commits,
+    })
+}
+
+// ─── PR metrics ──────────────────────────────────────────────────────────────
+
+/// Aggregated PR metrics for a single engineer.
+///
+/// Why: `tga author` needs to surface PR throughput and cycle-time stats;
+/// this struct carries everything computed from `pull_requests` rows matched
+/// to the engineer's provider logins.
+/// What: total/merged counts plus optional cycle-time statistics (omitted
+/// when no merged PRs are present, or when the sample is too small for p95).
+/// Test: see `tests::pr_metrics_basic` and `tests::pr_metrics_no_prs`.
+#[derive(Debug, Clone)]
+pub struct PrMetrics {
+    /// Total PRs authored (all states).
+    pub total: u64,
+    /// Merged PRs.
+    pub merged: u64,
+    /// Average cycle time (hours) for merged PRs with valid timestamps.
+    /// `None` when no merged PRs are present.
+    pub avg_cycle_time_hours: Option<f64>,
+    /// Median (p50) cycle time (hours). `None` when no merged PRs.
+    pub median_cycle_time_hours: Option<f64>,
+    /// p95 cycle time (hours). `None` when < 20 merged PRs (spec threshold).
+    pub p95_cycle_time_hours: Option<f64>,
+}
+
+/// Minimum merged-PR count before p95 is emitted.
+const P95_MIN_SAMPLE: usize = 20;
+
+/// Cycle-time filter: exclude same-minute merges (< 0.5 h) and stale PRs (> 720 h).
+const CYCLE_TIME_MIN_HOURS: f64 = 0.5;
+const CYCLE_TIME_MAX_HOURS: f64 = 720.0;
+
+/// Query PR metrics for an engineer identified by a set of provider logins.
+///
+/// Why: `pull_requests.author` holds raw provider logins, not canonical emails;
+/// the caller must supply the resolved login list (extracted from `authors.aliases`
+/// by the command layer) so this query can match across providers.
+/// What: counts total and merged PRs, then fetches raw cycle-time durations for
+/// merged PRs (filtered to [0.5, 720] hours). Median and p95 are computed in
+/// Rust by sorting the duration vector — SQLite has no native MEDIAN aggregate.
+/// Test: see `tests::pr_metrics_basic`, `tests::pr_metrics_p95_requires_20_prs`.
+pub fn query_pr_metrics(
+    db: &Database,
+    logins: &[String],
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<PrMetrics> {
+    if logins.is_empty() {
+        return Ok(PrMetrics {
+            total: 0,
+            merged: 0,
+            avg_cycle_time_hours: None,
+            median_cycle_time_hours: None,
+            p95_cycle_time_hours: None,
+        });
+    }
+
+    let conn = db.connection();
+
+    // Build dynamic IN(...) clause — one placeholder per login.
+    let placeholders: String = logins
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 3)) // slots 1,2 are since/until
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // Total + merged counts.
+    let count_sql = format!(
+        "SELECT COUNT(*), COUNT(CASE WHEN state = 'merged' THEN 1 END) \
+         FROM pull_requests \
+         WHERE author IN ({placeholders}) \
+           AND (?1 IS NULL OR created_at >= ?1) \
+           AND (?2 IS NULL OR created_at <= ?2)"
+    );
+    let mut count_stmt = conn
+        .prepare(&count_sql)
+        .map_err(crate::core::TgaError::from)?;
+
+    let (total, merged): (u64, u64) = {
+        let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(since.map(str::to_string)),
+            Box::new(until.map(str::to_string)),
+        ];
+        for login in logins {
+            params_vec.push(Box::new(login.clone()));
+        }
+        let params_refs: Vec<&dyn rusqlite::ToSql> =
+            params_vec.iter().map(|b| b.as_ref()).collect();
+        count_stmt
+            .query_row(params_refs.as_slice(), |row| {
+                Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64))
+            })
+            .map_err(crate::core::TgaError::from)?
+    };
+
+    if merged == 0 {
+        return Ok(PrMetrics {
+            total,
+            merged,
+            avg_cycle_time_hours: None,
+            median_cycle_time_hours: None,
+            p95_cycle_time_hours: None,
+        });
+    }
+
+    // Fetch raw cycle-time hours for merged PRs.
+    let durations_sql = format!(
+        "SELECT (julianday(merged_at) - julianday(created_at)) * 24.0 \
+         FROM pull_requests \
+         WHERE author IN ({placeholders}) \
+           AND state = 'merged' \
+           AND merged_at IS NOT NULL \
+           AND (?1 IS NULL OR created_at >= ?1) \
+           AND (?2 IS NULL OR created_at <= ?2)"
+    );
+    let mut dur_stmt = conn
+        .prepare(&durations_sql)
+        .map_err(crate::core::TgaError::from)?;
+
+    let mut durations: Vec<f64> = {
+        let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(since.map(str::to_string)),
+            Box::new(until.map(str::to_string)),
+        ];
+        for login in logins {
+            params_vec.push(Box::new(login.clone()));
+        }
+        let params_refs: Vec<&dyn rusqlite::ToSql> =
+            params_vec.iter().map(|b| b.as_ref()).collect();
+        let rows = dur_stmt
+            .query_map(params_refs.as_slice(), |row| row.get::<_, f64>(0))
+            .map_err(crate::core::TgaError::from)?;
+        let mut v = Vec::new();
+        for r in rows {
+            let h = r.map_err(crate::core::TgaError::from)?;
+            if h >= CYCLE_TIME_MIN_HOURS && h <= CYCLE_TIME_MAX_HOURS {
+                v.push(h);
+            }
+        }
+        v
+    };
+
+    if durations.is_empty() {
+        return Ok(PrMetrics {
+            total,
+            merged,
+            avg_cycle_time_hours: None,
+            median_cycle_time_hours: None,
+            p95_cycle_time_hours: None,
+        });
+    }
+
+    durations.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = durations.len();
+    let avg = durations.iter().sum::<f64>() / n as f64;
+    let median = durations[n / 2];
+    let p95 = if n >= P95_MIN_SAMPLE {
+        Some(durations[(n * 95) / 100])
+    } else {
+        None
+    };
+
+    Ok(PrMetrics {
+        total,
+        merged,
+        avg_cycle_time_hours: Some(avg),
+        median_cycle_time_hours: Some(median),
+        p95_cycle_time_hours: p95,
+    })
+}
+
+// ─── Commit summary ──────────────────────────────────────────────────────────
+
+/// Basic commit-level summary for a single engineer.
+///
+/// Why: the drill-down report header needs total commits, repositories touched,
+/// first/last commit dates, and ticket coverage — all derived from the `commits`
+/// table joined to `authors`.
+/// What: runs two queries — one for aggregate counts (total, ticketed, ins,
+/// del, first, last timestamp) and one for the distinct repository list.
+/// Test: see `tests::commit_summary_basic`.
+#[derive(Debug, Clone)]
+pub struct CommitSummary {
+    /// Total commits in the window.
+    pub total_commits: u64,
+    /// Commits with `ticketed = 1`.
+    pub ticketed_commits: u64,
+    /// Distinct repositories touched.
+    pub repositories: Vec<String>,
+    /// Earliest commit timestamp (ISO 8601), `None` when no commits.
+    pub first_commit: Option<String>,
+    /// Latest commit timestamp (ISO 8601), `None` when no commits.
+    pub last_commit: Option<String>,
+    /// Total insertions.
+    pub insertions: i64,
+    /// Total deletions.
+    pub deletions: i64,
+}
+
+/// Query a commit-level summary for a single canonical author.
+///
+/// Why: the drill-down report header (Summary section) needs several commit
+/// aggregates in one pass; this function fetches them all from a single SQL
+/// query plus a distinct-repository query.
+/// What: joins `commits` to `authors` on `author_id`, filters by email and
+/// optional date window, returns [`CommitSummary`]. When no commits exist in
+/// scope, returns a zero-filled summary with `None` timestamps.
+/// Test: see `tests::commit_summary_basic` and `tests::commit_summary_no_commits`.
+pub fn query_commit_summary(
+    db: &Database,
+    email: &str,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<CommitSummary> {
+    let conn = db.connection();
+
+    // Aggregate row.
+    let mut stmt = conn
+        .prepare(
+            "SELECT COUNT(*), \
+                    COUNT(CASE WHEN c.ticketed = 1 THEN 1 END), \
+                    MIN(c.timestamp), MAX(c.timestamp), \
+                    SUM(c.insertions), SUM(c.deletions) \
+             FROM commits c \
+             JOIN authors a ON a.id = c.author_id \
+             WHERE LOWER(a.canonical_email) = LOWER(?1) \
+               AND (?2 IS NULL OR c.timestamp >= ?2) \
+               AND (?3 IS NULL OR c.timestamp <= ?3)",
+        )
+        .map_err(crate::core::TgaError::from)?;
+
+    let (total, ticketed, first_commit, last_commit, insertions, deletions) = stmt
+        .query_row(params![email, since, until], |row| {
+            Ok((
+                row.get::<_, i64>(0)? as u64,
+                row.get::<_, i64>(1)? as u64,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<i64>>(4)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(5)?.unwrap_or(0),
+            ))
+        })
+        .map_err(crate::core::TgaError::from)?;
+
+    // Distinct repositories.
+    let mut repo_stmt = conn
+        .prepare(
+            "SELECT DISTINCT c.repository \
+             FROM commits c \
+             JOIN authors a ON a.id = c.author_id \
+             WHERE LOWER(a.canonical_email) = LOWER(?1) \
+               AND (?2 IS NULL OR c.timestamp >= ?2) \
+               AND (?3 IS NULL OR c.timestamp <= ?3) \
+             ORDER BY c.repository",
+        )
+        .map_err(crate::core::TgaError::from)?;
+
+    let repo_rows = repo_stmt
+        .query_map(params![email, since, until], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(crate::core::TgaError::from)?;
+
+    let mut repositories = Vec::new();
+    for r in repo_rows {
+        repositories.push(r.map_err(crate::core::TgaError::from)?);
+    }
+
+    Ok(CommitSummary {
+        total_commits: total,
+        ticketed_commits: ticketed,
+        repositories,
+        first_commit,
+        last_commit,
+        insertions,
+        deletions,
+    })
+}
+
+/// Extract provider logins from an `authors.aliases` JSON array.
+///
+/// Why: `pull_requests.author` stores raw provider logins, not canonical
+/// emails; to correlate PRs with a canonical identity we need to extract the
+/// login entries from the aliases array and supply them to the PR query.
+/// What: parses the JSON array, returns entries that do not contain '@'
+/// (which distinguishes logins from email aliases). The canonical email
+/// itself is never a login, so it is not added automatically.
+/// Test: see `tests::extract_logins_from_aliases`.
+pub fn extract_provider_logins(aliases_json: &str) -> Vec<String> {
+    let aliases: Vec<String> = serde_json::from_str(aliases_json).unwrap_or_default();
+    aliases
+        .into_iter()
+        .filter(|a| !a.contains('@'))
+        .collect()
+}
+
+/// Fetch `(id, canonical_name, aliases_json)` for the given canonical email.
+///
+/// Why: drilldown queries need the aliases JSON (for login extraction) and
+/// the id/name for the report header.
+/// What: queries `authors` case-insensitively on `canonical_email`; returns
+/// `None` when not found.
+/// Test: exercised through `query_commit_summary` / `query_effort_histogram`
+/// tests via the command integration test.
+pub fn lookup_author_for_drilldown(
+    db: &Database,
+    email: &str,
+) -> Result<Option<(i64, String, String, String)>> {
+    let conn = db.connection();
+    let result: rusqlite::Result<(i64, String, String, String)> = conn.query_row(
+        "SELECT id, canonical_name, canonical_email, aliases \
+         FROM authors WHERE LOWER(canonical_email) = LOWER(?1) LIMIT 1",
+        params![email],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    );
+    match result {
+        Ok(row) => Ok(Some(row)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(ReportError::Core(crate::core::TgaError::from(e))),
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::db::Database;
+
+    fn seed_author(db: &Database, name: &str, email: &str, aliases_json: &str) -> i64 {
+        db.connection()
+            .execute(
+                "INSERT INTO authors (canonical_name, canonical_email, aliases) \
+                 VALUES (?1, ?2, ?3)",
+                params![name, email, aliases_json],
+            )
+            .expect("insert author");
+        db.connection().last_insert_rowid()
+    }
+
+    fn seed_commit(db: &Database, sha: &str, author_id: i64, timestamp: &str, ticketed: i64) {
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_id, author_name, author_email, timestamp, \
+                 message, repository, insertions, deletions) \
+                 VALUES (?1, ?2, 'n', 'e', ?3, 'm', 'repo-a', 10, 5)",
+                params![sha, author_id, timestamp],
+            )
+            .expect("insert commit");
+        if ticketed != 0 {
+            db.connection()
+                .execute(
+                    "UPDATE commits SET ticketed = 1 WHERE sha = ?1",
+                    params![sha],
+                )
+                .expect("set ticketed");
+        }
+    }
+
+    fn seed_effort(db: &Database, sha: &str, size: &str) {
+        db.connection()
+            .execute(
+                "INSERT INTO fact_commit_effort \
+                 (sha, repository, size, score, loc, files, test_loc, tests_factor, computed_at) \
+                 VALUES (?1, 'repo-a', ?2, 1.0, 10, 1, 0, 1.0, 0)",
+                params![sha, size],
+            )
+            .expect("insert effort");
+    }
+
+    /// Global PR counter so each test gets unique `pr_number` values even when
+    /// sharing the same `repository` + `provider` (which would otherwise trip
+    /// the UNIQUE constraint added in migration v12).
+    static PR_COUNTER: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1);
+
+    fn seed_pr(db: &Database, author: &str, state: &str, created_at: &str, merged_at: Option<&str>) {
+        let pr_num = PR_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        db.connection()
+            .execute(
+                "INSERT INTO pull_requests (pr_number, title, author, state, created_at, merged_at, commit_shas) \
+                 VALUES (?1, 'title', ?2, ?3, ?4, ?5, '[]')",
+                params![pr_num, author, state, created_at, merged_at],
+            )
+            .expect("insert pr");
+    }
+
+    #[test]
+    fn effort_histogram_counts() {
+        // Why: verifies the size → count grouping with a mix of bucket sizes.
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Alice", "alice@example.com", "[]");
+        seed_commit(&db, "sha1", aid, "2024-01-01T00:00:00Z", 0);
+        seed_commit(&db, "sha2", aid, "2024-01-02T00:00:00Z", 0);
+        seed_commit(&db, "sha3", aid, "2024-01-03T00:00:00Z", 0);
+        seed_effort(&db, "sha1", "S");
+        seed_effort(&db, "sha2", "S");
+        seed_effort(&db, "sha3", "L");
+
+        let h = query_effort_histogram(&db, "alice@example.com", None, None).expect("query");
+        assert_eq!(h.total_commits, 3);
+        assert_eq!(h.scored_commits, 3);
+        assert_eq!(h.histogram.get("S").copied(), Some(2));
+        assert_eq!(h.histogram.get("L").copied(), Some(1));
+    }
+
+    #[test]
+    fn effort_histogram_empty_when_no_effort_rows() {
+        // Why: if backfill effort has not been run, histogram should show 0 scored.
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Alice", "alice@example.com", "[]");
+        seed_commit(&db, "sha1", aid, "2024-01-01T00:00:00Z", 0);
+
+        let h = query_effort_histogram(&db, "alice@example.com", None, None).expect("query");
+        assert_eq!(h.total_commits, 1);
+        assert_eq!(h.scored_commits, 0);
+        assert!(h.histogram.is_empty());
+    }
+
+    #[test]
+    fn pr_metrics_basic() {
+        // Why: validates total/merged counts and cycle-time computation.
+        let db = Database::open_in_memory().expect("open");
+        // 2 merged PRs, each ~24h cycle time.
+        seed_pr(
+            &db,
+            "alice-gh",
+            "merged",
+            "2024-01-01T00:00:00Z",
+            Some("2024-01-02T00:00:00Z"),
+        );
+        seed_pr(
+            &db,
+            "alice-gh",
+            "merged",
+            "2024-01-03T00:00:00Z",
+            Some("2024-01-04T00:00:00Z"),
+        );
+        seed_pr(&db, "alice-gh", "open", "2024-01-05T00:00:00Z", None);
+
+        let logins = vec!["alice-gh".to_string()];
+        let m = query_pr_metrics(&db, &logins, None, None).expect("query");
+        assert_eq!(m.total, 3);
+        assert_eq!(m.merged, 2);
+        assert!(m.avg_cycle_time_hours.is_some());
+        let avg = m.avg_cycle_time_hours.unwrap();
+        assert!((avg - 24.0).abs() < 0.01, "avg should be ~24h, got {avg}");
+        assert!(m.median_cycle_time_hours.is_some());
+        // p95 requires >= 20 merged PRs; should be None here.
+        assert!(m.p95_cycle_time_hours.is_none());
+    }
+
+    #[test]
+    fn pr_metrics_no_prs() {
+        // Why: when no logins match, all metrics should be None.
+        let db = Database::open_in_memory().expect("open");
+        let logins = vec!["nobody".to_string()];
+        let m = query_pr_metrics(&db, &logins, None, None).expect("query");
+        assert_eq!(m.total, 0);
+        assert_eq!(m.merged, 0);
+        assert!(m.avg_cycle_time_hours.is_none());
+    }
+
+    #[test]
+    fn pr_metrics_p95_requires_20_prs() {
+        // Why: p95 is a misleading statistic on small samples; gate at 20.
+        let db = Database::open_in_memory().expect("open");
+        // Seed exactly 20 merged PRs.
+        for i in 0..20u32 {
+            let created = format!("2024-01-{:02}T00:00:00Z", (i % 28) + 1);
+            let merged = format!("2024-01-{:02}T12:00:00Z", (i % 28) + 1);
+            seed_pr(&db, "alice-gh", "merged", &created, Some(&merged));
+        }
+        let logins = vec!["alice-gh".to_string()];
+        let m = query_pr_metrics(&db, &logins, None, None).expect("query");
+        assert_eq!(m.merged, 20);
+        assert!(m.p95_cycle_time_hours.is_some(), "p95 should appear at n=20");
+    }
+
+    #[test]
+    fn commit_summary_basic() {
+        // Why: validates total, ticketed, repository list, and timestamp fields.
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Alice", "alice@example.com", "[]");
+        seed_commit(&db, "sha1", aid, "2024-01-01T00:00:00Z", 1);
+        seed_commit(&db, "sha2", aid, "2024-01-02T00:00:00Z", 0);
+
+        let s = query_commit_summary(&db, "alice@example.com", None, None).expect("query");
+        assert_eq!(s.total_commits, 2);
+        assert_eq!(s.ticketed_commits, 1);
+        assert_eq!(s.repositories, vec!["repo-a"]);
+        assert!(s.first_commit.is_some());
+        assert!(s.last_commit.is_some());
+    }
+
+    #[test]
+    fn commit_summary_no_commits() {
+        // Why: an author with no commits in scope should return zeros, not panic.
+        let db = Database::open_in_memory().expect("open");
+        seed_author(&db, "Alice", "alice@example.com", "[]");
+
+        let s = query_commit_summary(&db, "alice@example.com", None, None).expect("query");
+        assert_eq!(s.total_commits, 0);
+        assert!(s.first_commit.is_none());
+        assert!(s.repositories.is_empty());
+    }
+
+    #[test]
+    fn extract_logins_from_aliases() {
+        // Why: the login-extraction logic must skip email aliases and return only logins.
+        let json = r#"["alice@example.com","alice-old@example.com","alice-dev","alice-gh"]"#;
+        let logins = extract_provider_logins(json);
+        assert_eq!(logins, vec!["alice-dev", "alice-gh"]);
+    }
+}

--- a/crates/trusty-git-analytics/src/report/drilldown.rs
+++ b/crates/trusty-git-analytics/src/report/drilldown.rs
@@ -1,12 +1,17 @@
-//! Per-engineer drill-down queries: effort histogram, PR metrics, commit summary.
+//! Per-engineer drill-down queries, data model, and report formatters.
 //!
-//! This module provides the raw data-access layer for `tga author <email>`.
-//! Each free function maps to one section of the output report and is
-//! independently testable with a seeded in-memory SQLite database.
+//! This module provides:
+//! - Raw data-access free functions (effort histogram, PR metrics, commit summary)
+//! - [`AuthorDrilldownData`] — the assembled report model
+//! - [`format_markdown`] / [`format_json`] — output renderers for `tga author`
+//!
+//! Each data-access function is independently testable with a seeded in-memory
+//! SQLite database.
 
 use std::collections::HashMap;
 
 use rusqlite::params;
+use serde::{Deserialize, Serialize};
 
 use crate::core::db::Database;
 use crate::report::errors::{ReportError, Result};
@@ -242,7 +247,7 @@ pub fn query_pr_metrics(
         let mut v = Vec::new();
         for r in rows {
             let h = r.map_err(crate::core::TgaError::from)?;
-            if h >= CYCLE_TIME_MIN_HOURS && h <= CYCLE_TIME_MAX_HOURS {
+            if (CYCLE_TIME_MIN_HOURS..=CYCLE_TIME_MAX_HOURS).contains(&h) {
                 v.push(h);
             }
         }
@@ -365,9 +370,7 @@ pub fn query_commit_summary(
         .map_err(crate::core::TgaError::from)?;
 
     let repo_rows = repo_stmt
-        .query_map(params![email, since, until], |row| {
-            row.get::<_, String>(0)
-        })
+        .query_map(params![email, since, until], |row| row.get::<_, String>(0))
         .map_err(crate::core::TgaError::from)?;
 
     let mut repositories = Vec::new();
@@ -397,10 +400,50 @@ pub fn query_commit_summary(
 /// Test: see `tests::extract_logins_from_aliases`.
 pub fn extract_provider_logins(aliases_json: &str) -> Vec<String> {
     let aliases: Vec<String> = serde_json::from_str(aliases_json).unwrap_or_default();
-    aliases
-        .into_iter()
-        .filter(|a| !a.contains('@'))
-        .collect()
+    aliases.into_iter().filter(|a| !a.contains('@')).collect()
+}
+
+/// Query per-category commit counts for a single canonical author.
+///
+/// Why: the Category Breakdown section of `tga author` reuses the
+/// `classifications` join to show how an engineer's commits are distributed
+/// across work types; this query is cheaper than running `Aggregator::build_filtered`.
+/// What: joins `commits` → `classifications` → `authors`, groups by category,
+/// returns `HashMap<category, count>`. Commits with no classification are excluded.
+/// Test: see `tests::category_counts_basic`.
+pub fn query_author_categories(
+    db: &Database,
+    email: &str,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<HashMap<String, usize>> {
+    let conn = db.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT cl.category, COUNT(*) \
+             FROM commits c \
+             JOIN authors a ON a.id = c.author_id \
+             LEFT JOIN classifications cl ON cl.id = c.classification_id \
+             WHERE LOWER(a.canonical_email) = LOWER(?1) \
+               AND cl.category IS NOT NULL \
+               AND (?2 IS NULL OR c.timestamp >= ?2) \
+               AND (?3 IS NULL OR c.timestamp <= ?3) \
+             GROUP BY cl.category",
+        )
+        .map_err(crate::core::TgaError::from)?;
+
+    let rows = stmt
+        .query_map(params![email, since, until], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
+        .map_err(crate::core::TgaError::from)?;
+
+    let mut map: HashMap<String, usize> = HashMap::new();
+    for r in rows {
+        let (cat, cnt) = r.map_err(crate::core::TgaError::from)?;
+        map.insert(cat, cnt as usize);
+    }
+    Ok(map)
 }
 
 /// Fetch `(id, canonical_name, aliases_json)` for the given canonical email.
@@ -427,6 +470,263 @@ pub fn lookup_author_for_drilldown(
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(ReportError::Core(crate::core::TgaError::from(e))),
     }
+}
+
+// ─── Report model ────────────────────────────────────────────────────────────
+
+/// Fully assembled per-engineer drill-down report.
+///
+/// Why: formatters (Markdown, JSON) need a single input struct so they can
+/// be called independently of the DB; decoupling the data model from both
+/// the query layer and the formatters keeps each layer testable in isolation.
+/// What: aggregates all drill-down sections — commit summary, effort histogram,
+/// PR metrics, category breakdown — plus header metadata for the report.
+/// Test: see `tests::format_markdown_contains_headers` and
+/// `tests::format_json_parses` below.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorDrilldownData {
+    /// ISO 8601 UTC timestamp at which the report was generated.
+    pub generated_at: String,
+    /// Canonical email (as stored in `authors.canonical_email`).
+    pub email: String,
+    /// Canonical display name.
+    pub name: String,
+    /// Report window.
+    pub period: ReportPeriod,
+    /// Commit-level aggregate.
+    pub commits: CommitSection,
+    /// Effort histogram section.
+    pub effort: EffortSection,
+    /// Pull-request metrics section.
+    pub pull_requests: PrSection,
+    /// Per-category commit counts.
+    pub categories: HashMap<String, usize>,
+}
+
+/// Date window for the report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportPeriod {
+    /// Lower bound (ISO 8601 date or timestamp), `None` = all history.
+    pub since: Option<String>,
+    /// Upper bound (ISO 8601 date or timestamp), `None` = present.
+    pub until: Option<String>,
+}
+
+/// Commit-level aggregate section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitSection {
+    /// Total commits in the window.
+    pub total: u64,
+    /// Commits with `ticketed = 1`.
+    pub ticketed: u64,
+    /// `ticketed / total`, in `[0.0, 1.0]`. `None` when total == 0.
+    pub ticket_coverage: Option<f64>,
+    /// Distinct repositories touched.
+    pub repositories: Vec<String>,
+    /// Earliest commit timestamp (ISO 8601). `None` when total == 0.
+    pub first_commit: Option<String>,
+    /// Latest commit timestamp (ISO 8601). `None` when total == 0.
+    pub last_commit: Option<String>,
+    /// Total insertions.
+    pub insertions: i64,
+    /// Total deletions.
+    pub deletions: i64,
+}
+
+/// Effort histogram section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EffortSection {
+    /// Commits that have a row in `fact_commit_effort`.
+    pub scored_commits: u64,
+    /// Total commits (scored + unscored).
+    pub total_commits: u64,
+    /// Bucket → commit count (XS/S/M/L/XL).
+    pub histogram: HashMap<String, u32>,
+}
+
+/// Pull-request metrics section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrSection {
+    /// Total PRs (all states) matching any of the engineer's provider logins.
+    pub total: u64,
+    /// Merged PRs.
+    pub merged: u64,
+    /// Average cycle time (hours). `None` when no merged PRs with valid timestamps.
+    pub avg_cycle_time_hours: Option<f64>,
+    /// Median (p50) cycle time (hours). `None` when no merged PRs.
+    pub median_cycle_time_hours: Option<f64>,
+    /// p95 cycle time (hours). `None` when < 20 merged PRs.
+    pub p95_cycle_time_hours: Option<f64>,
+}
+
+// ─── Formatters ──────────────────────────────────────────────────────────────
+
+/// Render an [`AuthorDrilldownData`] as a Markdown report string.
+///
+/// Why: `tga author --format markdown` (the default) targets human readers;
+/// the output mirrors the structure in spec §6 so automated doc generation
+/// can consume it too.
+/// What: produces the exact table structure from spec §6, including section
+/// headers, the effort histogram with coverage fraction, and the PR metrics
+/// table. Cycle-time fields show `—` when `None`; p95 shows `(< 20 PRs)`
+/// when omitted due to insufficient sample.
+/// Test: see `tests::format_markdown_contains_headers`.
+pub fn format_markdown(data: &AuthorDrilldownData) -> String {
+    let mut out = String::new();
+
+    // Header.
+    let period_str = match (&data.period.since, &data.period.until) {
+        (Some(s), Some(u)) => format!("{s} – {u}"),
+        (Some(s), None) => format!("{s} – present"),
+        (None, Some(u)) => format!("all history – {u}"),
+        (None, None) => "all history".to_string(),
+    };
+    let generated_date = data.generated_at.get(..10).unwrap_or(&data.generated_at);
+    out.push_str(&format!(
+        "# Engineer Report: {} <{}>\n",
+        data.name, data.email
+    ));
+    out.push_str(&format!(
+        "Generated: {generated_date} | Period: {period_str}\n\n"
+    ));
+
+    // Summary table.
+    out.push_str("## Summary\n");
+    out.push_str("| Metric          | Value                     |\n");
+    out.push_str("|-----------------|---------------------------|\n");
+    out.push_str(&format!(
+        "| Total commits   | {:<25} |\n",
+        data.commits.total
+    ));
+    let repos_str = data.commits.repositories.join(", ");
+    out.push_str(&format!(
+        "| Repositories    | {:<25} |\n",
+        if repos_str.is_empty() {
+            "—".to_string()
+        } else {
+            repos_str
+        }
+    ));
+    out.push_str(&format!(
+        "| First commit    | {:<25} |\n",
+        data.commits
+            .first_commit
+            .as_deref()
+            .and_then(|s| s.get(..10))
+            .unwrap_or("—")
+    ));
+    out.push_str(&format!(
+        "| Last commit     | {:<25} |\n",
+        data.commits
+            .last_commit
+            .as_deref()
+            .and_then(|s| s.get(..10))
+            .unwrap_or("—")
+    ));
+    let coverage_str = match (data.commits.total, data.commits.ticket_coverage) {
+        (0, _) => "no commits in scope".to_string(),
+        (total, Some(cov)) => {
+            format!(
+                "{} / {} ({:.0}%)",
+                data.commits.ticketed,
+                total,
+                cov * 100.0
+            )
+        }
+        (total, None) => format!("{} / {} (0%)", data.commits.ticketed, total),
+    };
+    out.push_str(&format!("| Ticket coverage | {:<25} |\n", coverage_str));
+    out.push('\n');
+
+    // Effort histogram.
+    out.push_str(&format!(
+        "## Effort Histogram ({} / {} commits scored)\n",
+        data.effort.scored_commits, data.effort.total_commits
+    ));
+    out.push_str("| Size | Count | % scored |\n");
+    out.push_str("|------|-------|----------|\n");
+    let scored = data.effort.scored_commits as f64;
+    for size in &["XS", "S", "M", "L", "XL"] {
+        let count = data.effort.histogram.get(*size).copied().unwrap_or(0);
+        let pct = if scored > 0.0 {
+            format!("{:.0}%", f64::from(count) / scored * 100.0)
+        } else {
+            "—".to_string()
+        };
+        out.push_str(&format!("| {:<4} | {:>5} | {:>8} |\n", size, count, pct));
+    }
+    out.push('\n');
+
+    // PR metrics.
+    out.push_str("## Pull Request Metrics\n");
+    out.push_str("| Metric             | Value     |\n");
+    out.push_str("|--------------------|-----------||\n");
+    out.push_str(&format!(
+        "| Total PRs          | {:<9} |\n",
+        data.pull_requests.total
+    ));
+    out.push_str(&format!(
+        "| Merged PRs         | {:<9} |\n",
+        data.pull_requests.merged
+    ));
+    let fmt_ct = |v: Option<f64>| -> String {
+        v.map(|h| format!("{h:.1} h"))
+            .unwrap_or_else(|| "—".to_string())
+    };
+    out.push_str(&format!(
+        "| Avg cycle time     | {:<9} |\n",
+        fmt_ct(data.pull_requests.avg_cycle_time_hours)
+    ));
+    out.push_str(&format!(
+        "| Median cycle time  | {:<9} |\n",
+        fmt_ct(data.pull_requests.median_cycle_time_hours)
+    ));
+    let p95_str = match data.pull_requests.p95_cycle_time_hours {
+        Some(h) => format!("{h:.1} h"),
+        None if data.pull_requests.merged < 20 => "(< 20 PRs)".to_string(),
+        None => "—".to_string(),
+    };
+    out.push_str(&format!("| p95 cycle time     | {:<9} |\n", p95_str));
+
+    if data.pull_requests.total == 0 {
+        out.push_str(
+            "\n> No pull requests found. Ensure provider logins are mapped via \
+                      `tga aliases add-login`.\n",
+        );
+    }
+    out.push('\n');
+
+    // Category breakdown.
+    if !data.categories.is_empty() {
+        out.push_str("## Category Breakdown\n");
+        out.push_str("| Category    | Commits | % total |\n");
+        out.push_str("|-------------|---------|--------|\n");
+        let total_cats: usize = data.categories.values().sum();
+        let mut cats: Vec<(&String, &usize)> = data.categories.iter().collect();
+        cats.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+        for (cat, count) in cats {
+            let pct = if total_cats > 0 {
+                format!("{:.0}%", *count as f64 / total_cats as f64 * 100.0)
+            } else {
+                "—".to_string()
+            };
+            out.push_str(&format!("| {:<11} | {:>7} | {:>7} |\n", cat, count, pct));
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Render an [`AuthorDrilldownData`] as a JSON string.
+///
+/// Why: `tga author --format json` targets programmatic consumers (CI
+/// dashboards, team tooling) that need structured, machine-readable output.
+/// What: serialises the struct to pretty-printed JSON via serde. All
+/// `Option<f64>` fields render as JSON `null` when absent.
+/// Test: see `tests::format_json_parses`.
+pub fn format_json(data: &AuthorDrilldownData) -> crate::report::errors::Result<String> {
+    serde_json::to_string_pretty(data).map_err(ReportError::Json)
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -482,7 +782,13 @@ mod tests {
     /// the UNIQUE constraint added in migration v12).
     static PR_COUNTER: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1);
 
-    fn seed_pr(db: &Database, author: &str, state: &str, created_at: &str, merged_at: Option<&str>) {
+    fn seed_pr(
+        db: &Database,
+        author: &str,
+        state: &str,
+        created_at: &str,
+        merged_at: Option<&str>,
+    ) {
         let pr_num = PR_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         db.connection()
             .execute(
@@ -582,7 +888,10 @@ mod tests {
         let logins = vec!["alice-gh".to_string()];
         let m = query_pr_metrics(&db, &logins, None, None).expect("query");
         assert_eq!(m.merged, 20);
-        assert!(m.p95_cycle_time_hours.is_some(), "p95 should appear at n=20");
+        assert!(
+            m.p95_cycle_time_hours.is_some(),
+            "p95 should appear at n=20"
+        );
     }
 
     #[test]
@@ -619,5 +928,83 @@ mod tests {
         let json = r#"["alice@example.com","alice-old@example.com","alice-dev","alice-gh"]"#;
         let logins = extract_provider_logins(json);
         assert_eq!(logins, vec!["alice-dev", "alice-gh"]);
+    }
+
+    fn make_sample_drilldown() -> AuthorDrilldownData {
+        let mut histogram = HashMap::new();
+        histogram.insert("XS".to_string(), 5u32);
+        histogram.insert("S".to_string(), 10u32);
+        histogram.insert("M".to_string(), 3u32);
+
+        let mut categories = HashMap::new();
+        categories.insert("feature".to_string(), 8usize);
+        categories.insert("bugfix".to_string(), 4usize);
+
+        AuthorDrilldownData {
+            generated_at: "2026-05-28T10:00:00Z".to_string(),
+            email: "alice@example.com".to_string(),
+            name: "Alice Smith".to_string(),
+            period: ReportPeriod {
+                since: Some("2025-01-01".to_string()),
+                until: Some("2026-05-28".to_string()),
+            },
+            commits: CommitSection {
+                total: 18,
+                ticketed: 7,
+                ticket_coverage: Some(7.0 / 18.0),
+                repositories: vec!["acme/api".to_string()],
+                first_commit: Some("2025-01-07T09:12:00Z".to_string()),
+                last_commit: Some("2026-05-22T16:44:00Z".to_string()),
+                insertions: 500,
+                deletions: 200,
+            },
+            effort: EffortSection {
+                scored_commits: 18,
+                total_commits: 18,
+                histogram,
+            },
+            pull_requests: PrSection {
+                total: 10,
+                merged: 9,
+                avg_cycle_time_hours: Some(14.3),
+                median_cycle_time_hours: Some(9.1),
+                p95_cycle_time_hours: None,
+            },
+            categories,
+        }
+    }
+
+    #[test]
+    fn format_markdown_contains_headers() {
+        // Why: asserts the mandatory section headers and key values appear in output.
+        let data = make_sample_drilldown();
+        let md = format_markdown(&data);
+        assert!(md.contains("# Engineer Report: Alice Smith <alice@example.com>"));
+        assert!(md.contains("## Summary"));
+        assert!(md.contains("## Effort Histogram"));
+        assert!(md.contains("## Pull Request Metrics"));
+        assert!(md.contains("## Category Breakdown"));
+        assert!(md.contains("feature"));
+        assert!(md.contains("acme/api"));
+        assert!(md.contains("18")); // total commits
+    }
+
+    #[test]
+    fn format_json_parses() {
+        // Why: the JSON output must round-trip through serde without loss.
+        let data = make_sample_drilldown();
+        let json_str = format_json(&data).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid json");
+        assert_eq!(parsed["email"].as_str(), Some("alice@example.com"));
+        assert_eq!(parsed["commits"]["total"].as_u64(), Some(18));
+        assert_eq!(
+            parsed["effort"]["histogram"]["XS"].as_u64(),
+            Some(5),
+            "XS bucket should be 5"
+        );
+        assert!(
+            parsed["pull_requests"]["p95_cycle_time_hours"].is_null(),
+            "p95 should be null when None"
+        );
     }
 }

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -11,6 +11,7 @@
 //! - [`models`] — aggregated data structures
 
 pub mod aggregator;
+pub mod drilldown;
 pub mod errors;
 pub mod formatters;
 pub mod models;

--- a/docs/trusty-git-analytics/research/per-engineer-drilldown-2026-05-28.md
+++ b/docs/trusty-git-analytics/research/per-engineer-drilldown-2026-05-28.md
@@ -1,0 +1,480 @@
+# Per-Engineer Drill-Down Spec (`tga author <email>`) — #325
+
+**Status**: Draft for user review before implementation begins.
+**Target release**: tga 1.6.0 (minor bump; adds net-new subcommand).
+**Branch**: `spec-325-tga-drilldown`
+
+---
+
+## 1. Investigation Summary
+
+### Where things live today
+
+**`pull_requests` table and its `author` column**
+
+The `pull_requests` table was created in migration v7
+(`src/core/db/sql/0007_pr_metrics_and_backfill.sql`) and extended through v12.
+The column definition from migration v1 is:
+
+```sql
+CREATE TABLE IF NOT EXISTS pull_requests (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    pr_number    INTEGER NOT NULL,
+    title        TEXT NOT NULL,
+    author       TEXT NOT NULL,   -- raw provider login
+    state        TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    merged_at    TEXT,
+    commit_shas  TEXT NOT NULL DEFAULT '[]'
+);
+```
+
+The `author` column is populated at ingest time in
+`src/collect/github/client.rs` (`GitHubClient::store_pull_requests`):
+
+```rust
+pr.author,   // = p.user.map(|u| u.login).unwrap_or_default()
+```
+
+`p.user.login` is the raw GitHub username (e.g. `"bobm"`, `"alice-dev"`). It is
+never canonicalized through the `authors` table. The ADO PR fetcher
+(`src/collect/azdo/pr_fetcher.rs`) follows the same pattern: it stores the ADO
+`createdBy.uniqueName` string (typically a UPN or display name) directly in
+`pull_requests.author`. There is no join between `pull_requests.author` and
+`authors.canonical_name` / `authors.canonical_email` anywhere in the codebase.
+
+**`fact_commit_effort` schema**
+
+Added in migration v16 (`src/core/db/sql/0016_fact_commit_effort.sql`):
+
+```sql
+CREATE TABLE IF NOT EXISTS fact_commit_effort (
+    sha             TEXT NOT NULL,
+    repository      TEXT NOT NULL,
+    size            TEXT NOT NULL,   -- 'XS' | 'S' | 'M' | 'L' | 'XL'
+    score           REAL NOT NULL,
+    loc             INTEGER NOT NULL,
+    files           INTEGER NOT NULL,
+    test_loc        INTEGER NOT NULL,
+    tests_factor    REAL NOT NULL,
+    formula_version TEXT NOT NULL DEFAULT 'v1',
+    computed_at     INTEGER NOT NULL,
+    PRIMARY KEY (sha, repository)
+);
+```
+
+There is **no `author_id` column** in `fact_commit_effort`. The join path to
+a canonical identity is:
+
+```
+fact_commit_effort.sha
+    → commits.sha      (via commits.sha UNIQUE)
+    → commits.author_id
+    → authors.id
+    → authors.canonical_email
+```
+
+This join is currently unused in any query; `tga author` will be the first
+consumer.
+
+**`authors.aliases` and the existing aggregator**
+
+`authors.aliases` is a JSON-encoded `TEXT` column (`DEFAULT '[]'`), containing
+an array of alias strings. In practice the array holds **email addresses and
+display names** that map to the same person (populated by `tga aliases merge`).
+There is no provider-login field. The aggregator in
+`src/report/aggregator.rs` (`Aggregator::build_filtered`) resolves canonical
+identity by joining `commits c LEFT JOIN authors a ON a.id = c.author_id` and
+using `COALESCE(a.canonical_email, c.author_email)`. The `pull_requests` table
+is only used for team-level velocity/DORA metrics and is never joined to
+`authors`.
+
+---
+
+## 2. PR-Author Canonicalization — Recommended Option
+
+Three options were evaluated:
+
+**(a) Extend `authors.aliases` JSON array to include provider logins**
+**(b) New join table `author_provider_logins(author_id, provider, login)`**
+**(c) Fuzzy match `pull_requests.author` against `authors.canonical_name` at query time**
+
+### Recommendation: Option (a)
+
+Extend `authors.aliases` to include provider logins alongside email aliases.
+
+**Rationale**: The `aliases` column already stores a mixed-type list (emails +
+display names). Adding GitHub logins to that list requires zero schema migration
+and zero new table maintenance. The resolver at query time already must parse
+the JSON array; filtering to entries that look like logins (no `@` sign and not
+an email) versus emails (`@` present) is trivial. Adding a login looks like:
+
+```json
+["alice@example.com", "alice-old@example.com", "alice-dev"]
+```
+
+Option (b) would be cleaner at scale, but for a single-team analytics tool the
+added migration cost and join complexity are not justified. Option (c) is
+rejected: display names and logins diverge silently (e.g. the GitHub login
+`"bobm"` vs the canonical name `"Bob Matsuoka"`).
+
+### Populating the mapping: `tga aliases add-login`
+
+A new `tga aliases add-login <email> <provider> <login>` subcommand
+appends the login to `authors.aliases` for the named canonical identity. This
+is a one-time setup operation per developer per provider:
+
+```
+tga aliases add-login alice@example.com github alice-dev
+tga aliases add-login bob@example.com github bobm
+```
+
+No new migration is needed. The existing UNIQUE constraint on
+`authors.canonical_email` is untouched.
+
+### JOIN shape at drill-down query time
+
+```sql
+-- Resolve the set of logins for the given canonical email.
+-- Step 1: fetch the aliases JSON for the author.
+SELECT id, aliases
+FROM authors
+WHERE LOWER(canonical_email) = LOWER(:email);
+
+-- Step 2 (in Rust): parse the JSON, filter to non-email entries
+-- (entries lacking '@' are treated as provider logins).
+-- Let :logins be the resulting list, e.g. ['alice-dev', 'alice'].
+
+-- Step 3: count + aggregate PRs.
+SELECT
+    COUNT(*)                                         AS total_prs,
+    COUNT(CASE WHEN state = 'merged' THEN 1 END)     AS merged_prs,
+    AVG(
+        CASE
+            WHEN state = 'merged' AND merged_at IS NOT NULL
+            THEN (julianday(merged_at) - julianday(created_at)) * 24.0
+        END
+    )                                                AS avg_cycle_time_hours,
+    -- median requires a subquery in SQLite; see section 5 below
+    COUNT(DISTINCT repository)                       AS repo_count
+FROM pull_requests
+WHERE author IN (:logins)           -- placeholder list from Step 2
+  AND (:since IS NULL OR created_at >= :since)
+  AND (:until IS NULL OR created_at <= :until);
+```
+
+Because SQLite lacks array parameters, the Rust side must build the query
+dynamically with one `?N` placeholder per login entry (bounded list; typical
+engineer has 1–3 logins).
+
+---
+
+## 3. Effort Histogram Query
+
+The join path through `commits.sha` is the only route from effort data to
+author identity:
+
+```sql
+-- Per-engineer effort histogram (all sizes).
+SELECT
+    fce.size,
+    COUNT(*) AS commit_count
+FROM fact_commit_effort fce
+JOIN commits c ON c.sha = fce.sha
+                 -- AND c.repository = fce.repository  (add if needed)
+JOIN authors a  ON a.id = c.author_id
+WHERE LOWER(a.canonical_email) = LOWER(:email)
+  AND (:since IS NULL OR c.timestamp >= :since)
+  AND (:until IS NULL OR c.timestamp <= :until)
+GROUP BY fce.size
+ORDER BY
+    CASE fce.size
+        WHEN 'XS' THEN 1
+        WHEN 'S'  THEN 2
+        WHEN 'M'  THEN 3
+        WHEN 'L'  THEN 4
+        WHEN 'XL' THEN 5
+        ELSE 6
+    END;
+```
+
+**Output shape**: five buckets (XS / S / M / L / XL), each showing a count and
+the percentage of total effort-scored commits. The report renders this as a
+simple histogram table.
+
+**Edge case — commits with no effort row**: a commit is effort-scored only if
+`tga backfill effort` has been run. Commits without a row in `fact_commit_effort`
+are silently excluded from the histogram. The report should show the count of
+scored commits vs. total commits so the reader knows if the histogram is
+incomplete:
+
+```
+Effort histogram (73 / 104 commits scored):
+| Size | Count | % scored |
+```
+
+**Unscored bucket**: do not add a synthetic "unscored" row to the histogram;
+instead surface the coverage fraction in the section header. This avoids
+confusion about what "unscored" means.
+
+---
+
+## 4. Ticket Coverage Metric
+
+**Definition**:
+
+```
+ticket_coverage = (commits WHERE ticketed = 1) / (total commits for this author)
+```
+
+The `ticketed` column on `commits` is populated by `tga backfill ticket-ids`.
+
+**SQL**:
+
+```sql
+SELECT
+    COUNT(*)                                     AS total_commits,
+    COUNT(CASE WHEN ticketed = 1 THEN 1 END)     AS ticketed_commits,
+    CAST(
+        COUNT(CASE WHEN ticketed = 1 THEN 1 END) AS REAL
+    ) / MAX(COUNT(*), 1)                         AS ticket_coverage_ratio
+FROM commits c
+JOIN authors a ON a.id = c.author_id
+WHERE LOWER(a.canonical_email) = LOWER(:email)
+  AND (:since IS NULL OR c.timestamp >= :since)
+  AND (:until IS NULL OR c.timestamp <= :until);
+```
+
+**User-visible format**: `42 / 104 (40%)` — fraction followed by percentage.
+Show both because the absolute count matters (a 100% rate on 2 commits is not
+meaningful).
+
+**Edge case — zero commits**: display `"no commits in scope"` and omit the
+ratio. An empty report section is less confusing than `0 / 0 (NaN%)`.
+
+---
+
+## 5. PR Metrics
+
+### Definitions
+
+- **`total_prs`**: all rows in `pull_requests` where `author` is in the
+  engineer's login set (see section 2), regardless of state.
+- **`merged_prs`**: rows where `state = 'merged'`.
+- **`avg_cycle_time_hours`**: mean of `(merged_at - created_at)` in hours, for
+  merged PRs with both timestamps present. Filter to the range `[0.5, 720]`
+  hours (matching the existing `compute_velocity_inputs` logic in the aggregator
+  to exclude same-minute merges and stale PRs older than 30 days).
+- **`median_cycle_time_hours`**: the p50 value of the same distribution.
+  SQLite does not have a native `MEDIAN` aggregate; compute it in Rust by
+  sorting the vector and taking `vec[len/2]`.
+- **p95 cycle time**: included if the sample is large enough (≥ 20 merged PRs);
+  omitted otherwise. In Rust: `vec[(len * 95) / 100]`.
+
+**Edge case — no PRs, commits present**: emit a note in the PR Metrics section:
+`"No pull requests found. Ensure provider logins are mapped via tga aliases
+add-login."` This distinguishes "the engineer has no PRs" from "the login
+mapping is missing."
+
+**Edge case — no commits, PRs present**: this indicates the engineer uses PRs
+but commits are not in scope (possibly a different collection window). Report
+PR metrics normally; ticket coverage and effort histogram will show `"no
+commits in scope"`.
+
+---
+
+## 6. Subcommand Shape
+
+### CLI
+
+```
+tga author <email> [--format markdown|json] [--since <DATE>] [--until <DATE>]
+```
+
+- `<email>` — positional, required. Resolved case-insensitively against
+  `authors.canonical_email`. If not found, exits non-zero with:
+  `"no canonical identity with canonical_email '<email>' found. Run tga aliases list."`.
+- `--format markdown|json` — default `markdown`. Markdown for human reading;
+  JSON for programmatic consumers (CI dashboards, etc.).
+- `--since <DATE>` / `--until <DATE>` — optional ISO8601 `YYYY-MM-DD` dates.
+  When absent the report covers all data in the database. **MVP scope**: include
+  both flags in the initial implementation (they reuse the date-range helpers
+  already in `src/commands/date_range.rs`). Skipping them would make the report
+  nearly useless for engineers with multi-year histories.
+
+### Markdown output structure
+
+```markdown
+# Engineer Report: Alice Smith <alice@example.com>
+Generated: 2026-05-28 | Period: 2025-01-01 – 2026-05-28
+
+## Summary
+| Metric             | Value                     |
+|--------------------|---------------------------|
+| Total commits      | 104                       |
+| Repositories       | acme/api, acme/frontend   |
+| First commit       | 2025-01-07                |
+| Last commit        | 2026-05-22                |
+| Ticket coverage    | 42 / 104 (40%)            |
+
+## Effort Histogram (73 / 104 commits scored)
+| Size | Count | % scored |
+|------|-------|----------|
+| XS   |    18 |     25%  |
+| S    |    30 |     41%  |
+| M    |    16 |     22%  |
+| L    |     7 |     10%  |
+| XL   |     2 |      3%  |
+
+## Pull Request Metrics
+| Metric                   | Value     |
+|--------------------------|-----------|
+| Total PRs                | 31        |
+| Merged PRs               | 28        |
+| Avg cycle time           | 14.3 h    |
+| Median cycle time        | 9.1 h     |
+| p95 cycle time           | 48.2 h    |
+
+## Category Breakdown
+| Category    | Commits | % total |
+|-------------|---------|---------|
+| feature     |      48 |    46%  |
+| bugfix      |      21 |    20%  |
+| maintenance |      18 |    17%  |
+| refactor    |      12 |    12%  |
+| docs        |       5 |     5%  |
+```
+
+The Category Breakdown section reuses the per-author category histogram already
+computed in `Aggregator::build_filtered` (the `AuthorAcc.categories` map). It
+is included in the drill-down output because it is cheap and contextually
+useful.
+
+### JSON output structure
+
+```json
+{
+  "generated_at": "2026-05-28T10:00:00Z",
+  "email": "alice@example.com",
+  "name": "Alice Smith",
+  "period": { "since": "2025-01-01", "until": "2026-05-28" },
+  "commits": {
+    "total": 104,
+    "ticketed": 42,
+    "ticket_coverage": 0.404,
+    "repositories": ["acme/api", "acme/frontend"],
+    "first_commit": "2025-01-07T09:12:00Z",
+    "last_commit": "2026-05-22T16:44:00Z",
+    "insertions": 12840,
+    "deletions": 4321
+  },
+  "effort": {
+    "scored_commits": 73,
+    "total_commits": 104,
+    "histogram": {
+      "XS": 18,
+      "S": 30,
+      "M": 16,
+      "L": 7,
+      "XL": 2
+    }
+  },
+  "pull_requests": {
+    "total": 31,
+    "merged": 28,
+    "avg_cycle_time_hours": 14.3,
+    "median_cycle_time_hours": 9.1,
+    "p95_cycle_time_hours": 48.2
+  },
+  "categories": {
+    "feature": 48,
+    "bugfix": 21,
+    "maintenance": 18,
+    "refactor": 12,
+    "docs": 5
+  }
+}
+```
+
+All numeric cycle-time fields are `f64` (hours, 2 decimal places in rendering).
+`ticket_coverage` is `f64` in `[0.0, 1.0]`. If there are no merged PRs the
+`avg_cycle_time_hours`, `median_cycle_time_hours`, and `p95_cycle_time_hours`
+fields are `null`.
+
+---
+
+## 7. Implementation Phases
+
+All phases land in a single `tga 1.6.0` release on branch
+`feat-325-tga-author`. The sequence below is the recommended commit order.
+
+### Phase 1 — Schema + aliases extension (S)
+**1 commit.**
+- Add `tga aliases add-login <email> <provider> <login>` subcommand to
+  `src/commands/aliases.rs`. Parses the existing `aliases` JSON array, appends
+  the login (deduplicating), writes back. No migration needed.
+- Unit tests: login round-trips through JSON; duplicate login ignored.
+
+### Phase 2 — Effort rollup query (S)
+**1 commit.**
+- Add `query_effort_histogram(db, email, since, until)` free function in a new
+  `src/report/drilldown.rs` module. Returns `HashMap<String, u32>` (size →
+  count) plus the total scored-commit count and total commits for the author.
+- Unit tests: seed `commits + fact_commit_effort`, assert histogram counts.
+
+### Phase 3 — PR metrics query (S)
+**1 commit.**
+- Add `query_pr_metrics(db, logins, since, until)` in `src/report/drilldown.rs`.
+  Returns total, merged, avg/median/p95 cycle-time hours (or `None` when no
+  merged PRs). Computes median/p95 in Rust after fetching the raw durations.
+- Unit tests: seed `pull_requests` rows, assert counts and cycle-time stats.
+
+### Phase 4 — `AuthorDrilldown` report model + formatters (M)
+**1–2 commits.**
+- Add `AuthorDrilldownData` struct in `src/report/models.rs` (or
+  `src/report/drilldown.rs`).
+- Add `format_markdown(data: &AuthorDrilldownData) -> String` and
+  `format_json(data: &AuthorDrilldownData) -> String` in
+  `src/report/formatters/`.
+- Unit tests: format against a hand-crafted `AuthorDrilldownData`, assert
+  table headers and key values are present.
+
+### Phase 5 — `tga author` subcommand (S)
+**1 commit.**
+- Add `src/commands/author.rs` with `AuthorArgs` (clap struct: `email`,
+  `--format`, `--since`, `--until`) and `run()`.
+- Wire into `src/main.rs` `Commands` enum and `main()` dispatch.
+- Integration test in `src/commands/author.rs` tests module: seed a small DB,
+  call `run()`, assert non-empty output.
+
+### Phase 6 — Documentation + CHANGELOG (XS)
+**1 commit.**
+- Add entry to `CHANGELOG.md`.
+- Update `crates/trusty-git-analytics/README.md` with the new subcommand.
+- Bump `Cargo.toml` version from `1.5.x` to `1.6.0`.
+
+---
+
+## 8. Open Questions for User Review
+
+1. **PR-author canonicalization option**: This spec recommends option (a) —
+   extending `authors.aliases` to hold provider logins, populated via a new
+   `tga aliases add-login` subcommand. Do you prefer option (b) (new join table
+   `author_provider_logins`) for cleaner schema separation, or option (a) for
+   zero-migration simplicity?
+
+2. **`--since` / `--until` in MVP vs follow-up**: The spec includes both date
+   flags in the initial implementation (Phase 5). They reuse existing
+   `date_range.rs` helpers and cost little. Should they be deferred to a
+   follow-up to keep the scope tighter, or ship in 1.6.0?
+
+3. **Category breakdown in drill-down**: The spec includes a Category Breakdown
+   section (feature / bugfix / maintenance / etc.) because the data is already
+   collected by `Aggregator::build_filtered`. Do you want it in the
+   `tga author` output, or should the drill-down focus only on the four new
+   metrics (effort histogram, ticket coverage, PR metrics, commit summary)?
+
+4. **`p95` cycle time threshold**: The spec emits `p95_cycle_time_hours` only
+   when the engineer has ≥ 20 merged PRs, to avoid a misleading statistic on
+   small samples. Should the threshold be different (e.g., ≥ 5, or always
+   emit with a caveat), or is ≥ 20 the right gate?


### PR DESCRIPTION
## Summary

Implements `tga author <email>` — single-engineer drill-down report combining commits, effort distribution, ticket coverage, PR metrics, and category breakdown into one canonical view.

**New subcommands:**
- `tga author <email> [--format markdown|json] [--since <DATE>] [--until <DATE>]` — per-engineer drill-down
- `tga aliases add-login <email> <provider> <login>` — map provider logins (github/gitlab/ado/bitbucket) to canonical authors

**Sections in `tga author` output:**
- Commit summary (count, ins/del, files, first/last commit)
- Effort histogram (XS/S/M/L/XL) from `fact_commit_effort` joined via `commits.author_id`
- Ticket coverage % (commits with `ticket_id` / total commits)
- PR metrics (total, merged, avg/median cycle time; p95 only when ≥ 20 merged PRs)
- Category breakdown (feature/bugfix/maintenance/refactor/docs)

## Design decisions (locked with user before implementation)

- **PR-author canonicalization**: option (a) — extend `authors.aliases` JSON with provider logins. Zero migration. New `tga aliases add-login` subcommand for population.
- **`--since` / `--until`**: shipped in MVP (reuses `date_range.rs` helpers; engineers with multi-year history need it).
- **Category Breakdown**: included (data already in `AuthorAcc.categories`, essentially free).
- **p95 gate**: ≥ 20 merged PRs (emit `null` below; standard percentile reporting practice).
- **Version**: 2.1.0 (additive feature on top of today's 2.0.0 release; spec predated 2.0.0 ship).

## Test plan

- [x] `cargo build -p tga` — clean
- [x] `cargo test -p tga` — 584 tests pass (was 564 in 2.0.0; +20 new)
- [x] `cargo clippy -p tga --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual (post-merge): `tga author <real-email>` against Duetto CTO db produces expected output
- [ ] Manual (post-merge): `--format json` output is valid JSON and parses with `jq`

## Spec doc

Full design in `docs/trusty-git-analytics/research/per-engineer-drilldown-2026-05-28.md` (committed as `e5d43c7` before implementation; preserved for design archaeology).

Closes #325