### PR TITLE
fix(tga): 2.1.1 — enable TLS for https remote fetch (closes #337)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-05-28
+
+### Fixed
+
+- **HTTPS remote fetch support** (#337). Enable `git2` `https` and `vendored-openssl`
+  features so `tga collect` can fetch from `https://` remotes without an external
+  system `git` pre-fetch. The always-fetch behavior shipped in 2.0.0 now works for
+  the common case of GitHub/GitLab https remotes:
+  - macOS: uses the native Security framework (no openssl runtime dependency)
+  - Linux: vendors openssl statically (portable binaries, no system libssl)
+  - Windows: uses Schannel (no openssl runtime dependency)
+- The pre-2.1.1 workaround (pre-fetch with system git, then `tga collect --no-fetch`)
+  is no longer necessary for https remotes.
+
 ## [2.1.0] - 2026-05-28
 
 ### Added

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.1.0"
+version = "2.1.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for
@@ -55,9 +55,14 @@ rusqlite = { workspace = true, features = ["chrono"] }
 # Git
 # Local pin retained: the workspace `git2` entry turns on default ssh+https
 # features and `vendored-openssl`; tga explicitly disables defaults to drop
-# the OpenSSL/libssh2 system dependency for cross-compiled musl builds.
-# Switching to `workspace = true` would change the linked TLS stack.
-git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2"] }
+# the libssh2 system dependency. The `https` and `vendored-openssl` features
+# are added here (#337) so `tga collect` can fetch from https:// remotes
+# without an external system git:
+#   - macOS: uses the native Security framework (no openssl runtime dep)
+#   - Linux: vendors openssl statically (portable binaries, no system libssl)
+#   - Windows: uses Schannel (no openssl runtime dep)
+# SSH transport remains disabled (out of scope for this fix).
+git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2", "https", "vendored-openssl"] }
 # HTTP client — workspace entry already declares
 # `default-features = false, features = ["json", "stream", "rustls-tls"]`
 # which is a superset of what tga needs. The `stream` extra is harmless

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -238,6 +238,11 @@ tga collect --repos my-service --branch main
 
 ### Monitor fetch health across many repos
 
+`tga` fetches via libgit2 with full TLS support — `https://` remotes (GitHub,
+GitLab, Bitbucket, etc.) work out of the box without a system `git` pre-fetch.
+On macOS the native Security framework is used; on Linux openssl is vendored
+statically; on Windows Schannel is used.
+
 By default `tga collect` always fetches each repo before walking and prints an
 end-of-run summary:
 


### PR DESCRIPTION
## Summary

Hotfix for #337: tga's bundled libgit2 was built without TLS, causing fetch failures on every `https://` remote. The always-fetch behavior shipped in 2.0.0 (#334) correctly surfaced these failures via the per-repo fetch summary, but the underlying TLS gap meant the common case (GitHub/GitLab https remotes) was unfetchable without an external `git` pre-fetch.

This PR enables the `git2` crate's `https` feature, restoring native fetch for https remotes.

## Platform behavior

- **macOS** — uses Security framework (no openssl runtime dep). Verified locally with bare clone of `octocat/Hello-World`: fetch succeeds, no transport errors.
- **Linux** — uses statically vendored openssl (`vendored-openssl` feature). Portable binaries.
- **Windows** — uses Schannel.

## Workspace audit

Confirmed tga is the only workspace crate that performs git fetches via libgit2:
- `open-mpm` uses git2 for local repo reads (commits, tree walking) — no remote fetch.
- `trusty-common` uses git2 optionally under `memory-core` for git history — local only.

Only `crates/trusty-git-analytics/Cargo.toml` needed the feature change.

## Pre-fix workaround (no longer needed after 2.1.1)

\`\`\`bash
# Old workaround: pre-fetch with system git, then collect with --no-fetch
for repo in */; do git -C "$repo" fetch --all 2>/dev/null || true; done
tga collect --no-fetch
\`\`\`

After 2.1.1: \`tga collect\` works directly against https remotes.

## Build time impact

Clean build of tga with \`https + vendored-openssl\`: 41.5s (openssl-src compilation is the bulk; cached on incremental rebuilds).

## Test plan

- [x] \`cargo build -p tga --release\` — clean (41.5s clean build)
- [x] \`cargo test -p tga\` — 582/584 pass (2 ignored, same as 2.1.0 baseline)
- [x] \`cargo clippy -p tga --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] Manual https fetch: bare clone of \`octocat/Hello-World\` via tga collect — "Fetch summary: 1 / 1 repos updated (0 failures, 0 skipped)"
- [ ] Post-merge: real-world verification against Duetto CTO repo (118 repos, ~all https remotes)

## Out of scope

- SSH transport (separate libgit2 feature, separate ticket if needed)
- Credential storage / SSH key management
- Workspace root Cargo.toml git2 declaration (tga pins locally per existing comment about disabling libssh2; root entry left alone since no other crate needs https)

Closes #337