### PR TITLE
fix(open-mpm): resolve all clippy warnings

### DIFF
--- a/crates/open-mpm/src/adapters/registry.rs
+++ b/crates/open-mpm/src/adapters/registry.rs
@@ -89,7 +89,7 @@ impl AdapterRegistry {
             let result = adapter.detect(pane_output);
             if result.matched
                 && result.confidence >= 0.7
-                && best.map_or(true, |(_, c)| result.confidence > c)
+                && best.is_none_or(|(_, c)| result.confidence > c)
             {
                 best = Some((id, result.confidence));
             }

--- a/crates/open-mpm/src/agents/mod.rs
+++ b/crates/open-mpm/src/agents/mod.rs
@@ -1244,6 +1244,11 @@ fn agents_dir() -> PathBuf {
     }
 }
 
+// Why: Helper kept available for ad-hoc tooling that needs the flat
+// `<name>.toml` path. No longer invoked by the main loader path which prefers
+// the directory-package layout; retained behind `#[allow(dead_code)]` so
+// future tools can reuse it without re-deriving the join logic.
+#[allow(dead_code)]
 fn agent_config_path(name: &str) -> PathBuf {
     agents_dir().join(format!("{name}.toml"))
 }

--- a/crates/open-mpm/src/api/builder.rs
+++ b/crates/open-mpm/src/api/builder.rs
@@ -132,10 +132,10 @@ fn list_files_in_dir(dir: &Path) -> Vec<String> {
                 .unwrap_or(true)
         });
     for entry in walker.flatten() {
-        if entry.file_type().is_file() {
-            if let Ok(rel) = entry.path().strip_prefix(dir) {
-                out.push(rel.to_string_lossy().replace('\\', "/"));
-            }
+        if entry.file_type().is_file()
+            && let Ok(rel) = entry.path().strip_prefix(dir)
+        {
+            out.push(rel.to_string_lossy().replace('\\', "/"));
         }
     }
     out.sort();

--- a/crates/open-mpm/src/api/server.rs
+++ b/crates/open-mpm/src/api/server.rs
@@ -48,7 +48,7 @@ use crate::ctrl_session::{
     Session as CtrlSession, SessionStatus as CtrlSessionStatus, SessionStore,
 };
 use crate::events::{self, EVENT_LINE_PREFIX, Event};
-use crate::recap::{self, Recap, RecapConfig, RecapPhase, RecapTask, RecapTracker};
+use crate::recap::{self, RecapConfig, RecapPhase, RecapTask, RecapTracker};
 use crate::registry::{ProjectEntry, ProjectRegistry, discover_active_projects};
 use crate::tm::TmManager;
 use crate::tm::project::{AdapterType, TmProject};
@@ -117,7 +117,7 @@ async fn serve_asset(
     let path = path.trim_start_matches('/');
     match UiAssets::get(path) {
         Some(f) => {
-            let mime = mime_guess::from_path(&path).first_or_octet_stream();
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
             // Vite emits content-hashed filenames under `assets/` (e.g.
             // `assets/index-abc123.js`), so the bytes at a given URL never
             // change — safe to cache forever. Other top-level assets (favicon,
@@ -383,11 +383,11 @@ async fn load_persisted_tasks() -> Option<TaskStore> {
 async fn persist_tasks(responses: &HashMap<String, PmResponse>) {
     let path = tasks_persistence_path();
     let tmp = path.with_extension("json.tmp");
-    if let Some(parent) = path.parent() {
-        if let Err(e) = tokio::fs::create_dir_all(parent).await {
-            tracing::warn!(?e, "failed to create state dir for tasks.json");
-            return;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = tokio::fs::create_dir_all(parent).await
+    {
+        tracing::warn!(?e, "failed to create state dir for tasks.json");
+        return;
     }
     let json = match serde_json::to_vec(responses) {
         Ok(j) => j,
@@ -1182,7 +1182,7 @@ async fn list_projects(
             .into_iter()
             .filter(|e| e.is_real_project())
             .collect();
-        v.sort_by(|a, b| b.last_active().cmp(&a.last_active()));
+        v.sort_by_key(|b| std::cmp::Reverse(b.last_active()));
         v
     } else {
         let window = chrono::Duration::days(14);
@@ -1595,20 +1595,19 @@ async fn terminate_ctrl_session_handler(
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let uuid = Uuid::parse_str(&id).map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    if let Some(session) = SessionStore::find(&uuid) {
-        if let Some(wt_path) = &session.worktree_path {
-            if wt_path.exists() {
-                let _ = std::process::Command::new("git")
-                    .args([
-                        "worktree",
-                        "remove",
-                        "--force",
-                        wt_path.to_str().unwrap_or(""),
-                    ])
-                    .current_dir(&session.project_path)
-                    .output();
-            }
-        }
+    if let Some(session) = SessionStore::find(&uuid)
+        && let Some(wt_path) = &session.worktree_path
+        && wt_path.exists()
+    {
+        let _ = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "remove",
+                "--force",
+                wt_path.to_str().unwrap_or(""),
+            ])
+            .current_dir(&session.project_path)
+            .output();
     }
 
     let found = SessionStore::terminate(&uuid).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -2508,6 +2507,14 @@ async fn maybe_emit_recap(state: &AppState, session_id: &str) {
 
 #[cfg(test)]
 mod tests {
+    // Why: These tests use `crate::test_env::HOME_LOCK` (a `std::sync::Mutex`)
+    // to serialize cross-module mutation of `$HOME` while the test body
+    // performs async I/O. Holding a sync mutex across `.await` would be a
+    // bug in production code, but here the lock is held intentionally for
+    // the full test body so two tests don't race on the global env var. The
+    // tokio multi-threaded test runtime keeps the lock from causing deadlock.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};

--- a/crates/open-mpm/src/ast/mod.rs
+++ b/crates/open-mpm/src/ast/mod.rs
@@ -203,7 +203,7 @@ mod tests {
 
         let registry = pre_index_directory(dir.path(), dir.path()).unwrap();
         assert!(
-            registry.len() >= 1,
+            !registry.is_empty(),
             "expected at least one symbol, got {}",
             registry.len()
         );

--- a/crates/open-mpm/src/bus/mod.rs
+++ b/crates/open-mpm/src/bus/mod.rs
@@ -177,10 +177,10 @@ impl MessageBus {
                 continue;
             }
             // Probe liveness with a quick connect attempt.
-            if UnixStream::connect(&path).await.is_ok() {
-                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                    result.push(stem.to_string());
-                }
+            if UnixStream::connect(&path).await.is_ok()
+                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+            {
+                result.push(stem.to_string());
             }
         }
         Ok(result)

--- a/crates/open-mpm/src/cli/memories_cmd.rs
+++ b/crates/open-mpm/src/cli/memories_cmd.rs
@@ -231,10 +231,15 @@ pub async fn run_memories_command(args: &[String]) -> Result<()> {
             input,
             from_committed,
         } => {
+            // Why: Both the `--from-committed` and default branches currently
+            // resolve to the same shared-memories file under `.open-mpm/`.
+            // The flag is kept on the CLI for forward compatibility (e.g. if
+            // we later split the committed vs. local file paths) but it has
+            // no effect today — flatten the branches to satisfy
+            // `clippy::if_same_then_else` without changing behavior.
+            let _ = from_committed;
             let in_path = if let Some(p) = input {
                 p
-            } else if from_committed {
-                cwd.join(".open-mpm").join(SHARED_MEMORIES_FILENAME)
             } else {
                 cwd.join(".open-mpm").join(SHARED_MEMORIES_FILENAME)
             };
@@ -255,10 +260,10 @@ pub async fn run_memories_command(args: &[String]) -> Result<()> {
 /// Resolve the active session_id: prefer the run id env var, fall back to the
 /// most recent registered session, finally "default".
 pub fn current_session_id() -> String {
-    if let Ok(rid) = std::env::var("OPEN_MPM_RUN_ID") {
-        if !rid.is_empty() {
-            return rid;
-        }
+    if let Ok(rid) = std::env::var("OPEN_MPM_RUN_ID")
+        && !rid.is_empty()
+    {
+        return rid;
     }
     "default".to_string()
 }
@@ -423,11 +428,11 @@ pub async fn import_file(project_root: &Path, input: &Path) -> Result<usize> {
     let mut tracker = read_tracker(&tracker_path).await;
 
     let key = input.to_string_lossy().to_string();
-    if let Some(prev) = tracker.files.get(&key) {
-        if prev.hash == hash {
-            // Already imported the exact same contents.
-            return Ok(0);
-        }
+    if let Some(prev) = tracker.files.get(&key)
+        && prev.hash == hash
+    {
+        // Already imported the exact same contents.
+        return Ok(0);
     }
 
     // Imported memories live in their own session dir so they're easy to
@@ -568,21 +573,21 @@ async fn list_sessions(project_root: &Path, scope: &str) -> Result<()> {
                 // Best-effort tally — a session whose dim doesn't match (or
                 // that has no records) just contributes zero to the totals.
                 let path = entry.path();
-                if let Ok(store) = RedbUsearchStore::open(&path, ALL_MINI_LM_L6_V2_DIM) {
-                    if let Ok(recs) = store.list_segment(Segment::AgentMemory).await {
-                        for (id, _vec, payload) in recs {
-                            if is_auxiliary_id(&id) {
-                                continue;
-                            }
-                            let tag = payload
-                                .get("tag")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("(untagged)")
-                                .to_string();
-                            let top = tag.split('/').next().unwrap_or(&tag).to_string();
-                            *top_counts.entry(top).or_insert(0) += 1;
-                            *sub_counts.entry(tag).or_insert(0) += 1;
+                if let Ok(store) = RedbUsearchStore::open(&path, ALL_MINI_LM_L6_V2_DIM)
+                    && let Ok(recs) = store.list_segment(Segment::AgentMemory).await
+                {
+                    for (id, _vec, payload) in recs {
+                        if is_auxiliary_id(&id) {
+                            continue;
                         }
+                        let tag = payload
+                            .get("tag")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("(untagged)")
+                            .to_string();
+                        let top = tag.split('/').next().unwrap_or(&tag).to_string();
+                        *top_counts.entry(top).or_insert(0) += 1;
+                        *sub_counts.entry(tag).or_insert(0) += 1;
                     }
                 }
             }
@@ -600,7 +605,7 @@ async fn list_sessions(project_root: &Path, scope: &str) -> Result<()> {
                             (sub, *c)
                         })
                         .collect();
-                    subs.sort_by(|a, b| b.1.cmp(&a.1));
+                    subs.sort_by_key(|b| std::cmp::Reverse(b.1));
                     if subs.is_empty() {
                         println!("  {top}/    {n} entries");
                     } else {

--- a/crates/open-mpm/src/cli/mod.rs
+++ b/crates/open-mpm/src/cli/mod.rs
@@ -33,7 +33,7 @@ pub fn did_you_mean<'a>(
     let mut best: Option<(&str, usize)> = None;
     for &cand in candidates {
         let d = levenshtein(&input, &cand.to_lowercase());
-        if d <= max_distance && best.map_or(true, |(_, bd)| d < bd) {
+        if d <= max_distance && best.is_none_or(|(_, bd)| d < bd) {
             best = Some((cand, d));
         }
     }

--- a/crates/open-mpm/src/cli/search_cmd.rs
+++ b/crates/open-mpm/src/cli/search_cmd.rs
@@ -373,25 +373,24 @@ async fn run_code_search(
         .and_then(|p| p.parent()) // project root
         .map(Path::to_path_buf);
 
-    if let Some(root) = project_root {
-        if let Some(client) =
+    if let Some(root) = project_root
+        && let Some(client) =
             crate::search::service_client::SearchDaemonClient::connect_if_running(&root).await
-        {
-            // Pull a slightly larger pool when filtering so the post-filter
-            // result count still has a chance of reaching `top_k`.
-            let fetch_k = if lang.is_some() { top_k * 4 } else { top_k };
-            let mut hits = client.search(query, fetch_k).await?;
-            if let Some(lang_filter) = lang {
-                hits.retain(|c| c.language == lang_filter);
-                hits.truncate(top_k);
-            }
-            if hits.is_empty() {
-                println!("No results found.");
-                return Ok(());
-            }
-            println!("{}", format_code_results(&hits, json)?);
+    {
+        // Pull a slightly larger pool when filtering so the post-filter
+        // result count still has a chance of reaching `top_k`.
+        let fetch_k = if lang.is_some() { top_k * 4 } else { top_k };
+        let mut hits = client.search(query, fetch_k).await?;
+        if let Some(lang_filter) = lang {
+            hits.retain(|c| c.language == lang_filter);
+            hits.truncate(top_k);
+        }
+        if hits.is_empty() {
+            println!("No results found.");
             return Ok(());
         }
+        println!("{}", format_code_results(&hits, json)?);
+        return Ok(());
     }
 
     // Daemon not running — open the store directly and run hybrid search

--- a/crates/open-mpm/src/compress/tool_output.rs
+++ b/crates/open-mpm/src/compress/tool_output.rs
@@ -160,7 +160,7 @@ pub fn filter_git_diff(output: &str) -> String {
 
     // Second pass: emit, collapsing context runs.
     let mut out: Vec<String> = Vec::new();
-    let mut hunk_idx: usize = 0;
+    let hunk_idx: usize = 0;
     let mut in_context_run = false;
     let mut had_any_context = false;
     for line in &lines {
@@ -699,9 +699,9 @@ mod tests {
             input.push_str(&format!("commit abc123{i:03}def456789\n"));
             input.push_str("Author: Alice <alice@example.com>\n");
             input.push_str("Date:   Mon Jan 1 12:00:00 2024 +0000\n");
-            input.push_str("\n");
+            input.push('\n');
             input.push_str(&format!("    feat: subject line {i}\n"));
-            input.push_str("\n");
+            input.push('\n');
         }
         // 60 lines total
         let out = compress_tool_output("git_log", &input);
@@ -731,7 +731,7 @@ mod tests {
             input.push_str(&format!("// comment {i}\n"));
         }
         for _ in 0..60 {
-            input.push_str("\n");
+            input.push('\n');
         }
         let out = compress_tool_output("read_file", &input);
         assert!(!out.contains("// comment"));

--- a/crates/open-mpm/src/ctrl/mod.rs
+++ b/crates/open-mpm/src/ctrl/mod.rs
@@ -977,6 +977,11 @@ fn apply_credential_routing(
 ///   `None` so call sites can pass only what they have on hand.
 /// Test: `build_deployment_footer_includes_required_fields`,
 ///   `build_deployment_footer_omits_optional_fields_when_none`.
+// Why: Footer assembly genuinely needs every one of these fields and they
+// are all flat scalars — bundling them into a struct just to satisfy the
+// 7-argument heuristic would obscure the call sites without buying real
+// abstraction. Allow locally.
+#[allow(clippy::too_many_arguments)]
 fn build_deployment_footer(
     agent_name: &str,
     runner_label: &str,
@@ -3974,6 +3979,10 @@ async fn build_tm_context_block(state_dir: &Path) -> String {
 }
 
 /// Build the CTRL tool registry for a single LLM turn.
+// Why: Each Arc<Mutex<…>> here is wired into a distinct CTRL tool; collapsing
+// them into a single context struct would tightly couple unrelated tools and
+// fight the per-tool ownership story. Allow locally.
+#[allow(clippy::too_many_arguments)]
 async fn build_ctrl_registry(
     memory: Arc<Mutex<Vec<String>>>,
     pending_connect: Arc<Mutex<Option<String>>>,
@@ -4570,21 +4579,18 @@ async fn run_ctrl_turn_via_rest(
         ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
         ChatCompletionRequestUserMessageArgs,
     };
-    let mut messages: Vec<ChatCompletionRequestMessage> = Vec::new();
-    messages.push(
+    let messages: Vec<ChatCompletionRequestMessage> = vec![
         ChatCompletionRequestSystemMessageArgs::default()
             .content(system_prompt.to_string())
             .build()
             .context("failed to build ctrl_chat_turn system message")?
             .into(),
-    );
-    messages.push(
         ChatCompletionRequestUserMessageArgs::default()
             .content(user_input)
             .build()
             .context("failed to build ctrl_chat_turn user message")?
             .into(),
-    );
+    ];
     // #319: Local Ollama fast-path. When enabled in `~/.open-mpm/config.toml`
     // and the user's intent qualifies (conversational chat or TM-data
     // query), route this turn to the configured local ollama model

--- a/crates/open-mpm/src/ctrl/supervisor.rs
+++ b/crates/open-mpm/src/ctrl/supervisor.rs
@@ -243,18 +243,18 @@ impl CtrlSupervisor {
             };
 
             // Success short-circuit.
-            if let Some(s) = summary_opt.as_ref() {
-                if s.outcome == WorkflowOutcome::Success {
-                    if let Some(mut sess) = SessionStore::find(&session_id) {
-                        sess.status = SessionStatus::Idle;
-                        let _ = SessionStore::upsert(sess);
-                    }
-                    return Ok(SupervisorOutcome::Success {
-                        summary: s.summary.clone(),
-                        session_id,
-                        attempts: attempt,
-                    });
+            if let Some(s) = summary_opt.as_ref()
+                && s.outcome == WorkflowOutcome::Success
+            {
+                if let Some(mut sess) = SessionStore::find(&session_id) {
+                    sess.status = SessionStatus::Idle;
+                    let _ = SessionStore::upsert(sess);
                 }
+                return Ok(SupervisorOutcome::Success {
+                    summary: s.summary.clone(),
+                    session_id,
+                    attempts: attempt,
+                });
             }
 
             // Classify the partial / fail / crash and ask the policy what to do.
@@ -649,17 +649,17 @@ pub fn should_retry(reason: PartialReason, attempt: u32, max_attempts: u32) -> R
 /// retry / escalate when the report is unparseable.
 /// Test: Covered by both report-parsing tests.
 fn detect_outcome(content: &str) -> WorkflowOutcome {
-    if let Some(verdict) = extract_section(content, "Final Verdict") {
-        if let Some(o) = match_outcome(&verdict) {
-            return o;
-        }
+    if let Some(verdict) = extract_section(content, "Final Verdict")
+        && let Some(o) = match_outcome(&verdict)
+    {
+        return o;
     }
     for line in content.lines() {
         let lower = line.to_ascii_lowercase();
-        if lower.contains("**status**") || lower.starts_with("status:") {
-            if let Some(o) = match_outcome(line) {
-                return o;
-            }
+        if (lower.contains("**status**") || lower.starts_with("status:"))
+            && let Some(o) = match_outcome(line)
+        {
+            return o;
         }
     }
     if let Some(o) = match_outcome(content) {

--- a/crates/open-mpm/src/debugger/tui.rs
+++ b/crates/open-mpm/src/debugger/tui.rs
@@ -240,11 +240,9 @@ fn handle_key(app: &mut DebugApp, tmux: &TmuxAdapter, code: KeyCode, mods: KeyMo
     match (app.focus, code) {
         (_, KeyCode::Tab) => app.cycle_focus(),
         (Focus::Input, KeyCode::Esc) => app.input.clear(),
-        (Focus::Input, KeyCode::Enter) => {
-            if !app.input.is_empty() {
-                let _ = tmux.send_line(&app.session_name, &app.input);
-                app.input.clear();
-            }
+        (Focus::Input, KeyCode::Enter) if !app.input.is_empty() => {
+            let _ = tmux.send_line(&app.session_name, &app.input);
+            app.input.clear();
         }
         (Focus::Input, KeyCode::Backspace) => {
             app.input.pop();

--- a/crates/open-mpm/src/init/mod.rs
+++ b/crates/open-mpm/src/init/mod.rs
@@ -378,14 +378,14 @@ impl ProjectInitializer {
         }
 
         // Persist the updated seed-state so we can skip unchanged docs next run.
-        if let Ok(bytes) = serde_json::to_vec_pretty(&seeded) {
-            if let Err(e) = tokio::fs::write(&seeded_path, &bytes).await {
-                tracing::warn!(
-                    error = %e,
-                    path = %seeded_path.display(),
-                    "seed_documentation: write tracker failed (continuing)"
-                );
-            }
+        if let Ok(bytes) = serde_json::to_vec_pretty(&seeded)
+            && let Err(e) = tokio::fs::write(&seeded_path, &bytes).await
+        {
+            tracing::warn!(
+                error = %e,
+                path = %seeded_path.display(),
+                "seed_documentation: write tracker failed (continuing)"
+            );
         }
 
         // Update the initialized marker with seeded_docs count for inspection.
@@ -1208,6 +1208,13 @@ fn render_mcp_description(
 
 #[cfg(test)]
 mod tests {
+    // Why: These tests hold `HOME_LOCK` (a `std::sync::Mutex`) across async
+    // I/O to serialize global $HOME mutation between tests. The lock is
+    // intentionally held for the full test body; see `crate::test_env` for
+    // the rationale. The tokio multi-threaded test runtime keeps this from
+    // deadlocking.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use tempfile::tempdir;
 

--- a/crates/open-mpm/src/intent/classifier_tests.rs
+++ b/crates/open-mpm/src/intent/classifier_tests.rs
@@ -674,7 +674,7 @@ fn intent_class_debug_display() {
 fn intent_class_clone_and_copy() {
     let a = IntentClass::Research;
     let b = a;
-    let c = a.clone();
+    let c = a;
     assert_eq!(a, b);
     assert_eq!(a, c);
 }

--- a/crates/open-mpm/src/llm/mod.rs
+++ b/crates/open-mpm/src/llm/mod.rs
@@ -817,7 +817,7 @@ pub async fn chat_with_tools(
 /// serde failure the messages vec is left untouched (fail-open).
 /// Test: Covered indirectly via `thinking_classifier` unit tests; behaviour
 /// here is a thin Value-level mutation with no LLM dependency.
-fn maybe_inject_qwen3_think(messages: &mut Vec<ChatCompletionRequestMessage>) {
+fn maybe_inject_qwen3_think(messages: &mut [ChatCompletionRequestMessage]) {
     // Walk in reverse — find the last user message.
     let last_user_idx = messages.iter().enumerate().rev().find_map(|(i, m)| {
         let v = serde_json::to_value(m).ok()?;
@@ -869,11 +869,10 @@ fn maybe_inject_qwen3_think(messages: &mut Vec<ChatCompletionRequestMessage>) {
             if let Some(first_text) = parts
                 .iter_mut()
                 .find(|p| p.get("text").and_then(|t| t.as_str()).is_some())
+                && let Some(t) = first_text.get_mut("text")
             {
-                if let Some(t) = first_text.get_mut("text") {
-                    let s = t.as_str().unwrap_or("").to_string();
-                    *t = serde_json::Value::String(format!("/think\n{s}"));
-                }
+                let s = t.as_str().unwrap_or("").to_string();
+                *t = serde_json::Value::String(format!("/think\n{s}"));
             }
         }
         _ => return,
@@ -884,6 +883,11 @@ fn maybe_inject_qwen3_think(messages: &mut Vec<ChatCompletionRequestMessage>) {
     }
 }
 
+// Why: This is the workhorse function-call loop and every parameter is
+// independently load-bearing (model routing, sampling, gating flags, etc.).
+// A wrapper struct would just punt the documentation problem one layer up
+// without reducing complexity at the call sites.
+#[allow(clippy::too_many_arguments)]
 pub async fn chat_with_tools_gated(
     client: &Client<OpenAIConfig>,
     model: &str,

--- a/crates/open-mpm/src/mcp/config.rs
+++ b/crates/open-mpm/src/mcp/config.rs
@@ -845,6 +845,11 @@ impl GlobalConfig {
 
 #[cfg(test)]
 mod tests {
+    // Why: These tests hold `HOME_LOCK` (a `std::sync::Mutex`) across async
+    // I/O to serialize global $HOME mutation between tests. See
+    // `crate::test_env` for the full rationale.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use crate::test_env::HOME_LOCK;
 

--- a/crates/open-mpm/src/memory/mod.rs
+++ b/crates/open-mpm/src/memory/mod.rs
@@ -178,6 +178,11 @@ pub fn migrate_if_needed(open_mpm_dir: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    // Why: These tests hold `ENV_GUARD` (a `std::sync::Mutex`) across async
+    // I/O to serialize global env-var mutation between tests. See the
+    // ENV_GUARD doc comment below for the full rationale.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use serde_json::json;
     use std::sync::Mutex;

--- a/crates/open-mpm/src/recap/mod.rs
+++ b/crates/open-mpm/src/recap/mod.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::Path;
 
 /// A (phase_name, phase_result) pair for a single completed phase.
 pub type RecapPhase = (String, String);
@@ -109,13 +109,13 @@ pub fn assemble_recap(session_id: &str, recent_tasks: &[RecapTask]) -> Recap {
 
     for (_, narrative, phases) in recent_tasks {
         // Extract commit hash if present
-        if let Some(m) = extract_commit(narrative) {
-            if !rows.iter().any(|r: &RecapRow| r.step == "Commit") {
-                rows.push(RecapRow {
-                    step: "Commit".into(),
-                    result: m,
-                });
-            }
+        if let Some(m) = extract_commit(narrative)
+            && !rows.iter().any(|r: &RecapRow| r.step == "Commit")
+        {
+            rows.push(RecapRow {
+                step: "Commit".into(),
+                result: m,
+            });
         }
         // Add phase rows (deduped by step name)
         for (phase_name, phase_result) in phases {
@@ -187,7 +187,7 @@ fn capitalise(s: &str) -> String {
 /// storage trivial and inspectable.
 /// What: Creates the `recaps/` subdir if missing, then writes pretty JSON.
 /// Test: covered by integration; unit test would require a temp dir.
-pub fn save_recap(state_dir: &PathBuf, recap: &Recap) -> Result<()> {
+pub fn save_recap(state_dir: &Path, recap: &Recap) -> Result<()> {
     let dir = state_dir.join("recaps");
     std::fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{}.json", recap.session_id));
@@ -203,7 +203,7 @@ pub fn save_recap(state_dir: &PathBuf, recap: &Recap) -> Result<()> {
 /// What: Reads `state_dir/recaps/{session_id}.json` and deserialises. Any
 /// error (missing file, malformed JSON) returns None; the API maps that to 404.
 /// Test: covered by integration; round-trip with `save_recap`.
-pub fn load_recap(state_dir: &PathBuf, session_id: &str) -> Option<Recap> {
+pub fn load_recap(state_dir: &Path, session_id: &str) -> Option<Recap> {
     let path = state_dir.join("recaps").join(format!("{session_id}.json"));
     let json = std::fs::read_to_string(path).ok()?;
     serde_json::from_str(&json).ok()

--- a/crates/open-mpm/src/registry/mod.rs
+++ b/crates/open-mpm/src/registry/mod.rs
@@ -135,10 +135,10 @@ impl ProjectEntry {
             return false;
         }
         // Exclude entries whose final component starts with `.tmp`.
-        if let Some(name) = path.file_name() {
-            if name.to_string_lossy().starts_with(".tmp") {
-                return false;
-            }
+        if let Some(name) = path.file_name()
+            && name.to_string_lossy().starts_with(".tmp")
+        {
+            return false;
         }
         true
     }
@@ -159,10 +159,8 @@ pub fn extract_github_repo(origin: &str) -> Option<String> {
         rest
     } else if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
         rest
-    } else if let Some(rest) = trimmed.strip_prefix("ssh://git@github.com/") {
-        rest
     } else {
-        return None;
+        trimmed.strip_prefix("ssh://git@github.com/")?
     };
     let body = body.strip_suffix(".git").unwrap_or(body);
     let body = body.trim_end_matches('/');
@@ -474,7 +472,7 @@ impl ProjectRegistry {
             .into_values()
             .filter(|e| e.status == ProjectStatus::Active)
             .collect();
-        active.sort_by(|a, b| b.last_run.cmp(&a.last_run));
+        active.sort_by_key(|b| std::cmp::Reverse(b.last_run));
         Ok(active)
     }
 
@@ -536,7 +534,7 @@ pub fn discover_active_projects<'a>(
             recent || has_session
         })
         .collect();
-    out.sort_by(|a, b| b.last_active().cmp(&a.last_active()));
+    out.sort_by_key(|b| std::cmp::Reverse(b.last_active()));
     out
 }
 

--- a/crates/open-mpm/src/repl/bridge.rs
+++ b/crates/open-mpm/src/repl/bridge.rs
@@ -72,7 +72,7 @@ impl tui::ReplHandler for ReplBridge {
 
         // Try slash command first.
         if trimmed.starts_with('/') {
-            let cmd = trimmed.splitn(2, char::is_whitespace).next().unwrap_or("");
+            let cmd = trimmed.split(char::is_whitespace).next().unwrap_or("");
             if cmd == "/exit" || cmd == "/quit" || cmd == "/disconnect" {
                 return Ok(false);
             }
@@ -108,13 +108,13 @@ impl tui::ReplHandler for ReplBridge {
             // hardcoded short list of common Anthropic models.
             // Test: Manual via tmux REPL.
             let cmd_only = trimmed
-                .splitn(2, char::is_whitespace)
+                .split(char::is_whitespace)
                 .next()
                 .unwrap_or("")
                 .trim();
             let arg_only = trimmed
-                .splitn(2, char::is_whitespace)
-                .nth(1)
+                .split_once(char::is_whitespace)
+                .map(|x| x.1)
                 .map(str::trim)
                 .unwrap_or("");
             if arg_only.is_empty() && cmd_only == "/switch" {

--- a/crates/open-mpm/src/repl/commands.rs
+++ b/crates/open-mpm/src/repl/commands.rs
@@ -556,7 +556,7 @@ impl OpenMpmRepl {
         let display: Vec<&crate::registry::ProjectEntry> = if show_all {
             let mut all: Vec<&crate::registry::ProjectEntry> =
                 entries.iter().filter(|e| e.is_real_project()).collect();
-            all.sort_by(|a, b| b.last_active().cmp(&a.last_active()));
+            all.sort_by_key(|b| std::cmp::Reverse(b.last_active()));
             all
         } else {
             crate::registry::discover_active_projects(
@@ -1274,10 +1274,10 @@ fn expand_tilde(input: &str) -> PathBuf {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(input));
     }
-    if let Some(rest) = input.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home).join(rest);
-        }
+    if let Some(rest) = input.strip_prefix("~/")
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(rest);
     }
     PathBuf::from(input)
 }

--- a/crates/open-mpm/src/repl/markdown.rs
+++ b/crates/open-mpm/src/repl/markdown.rs
@@ -42,7 +42,6 @@ pub fn render_markdown_ansi(text: &str) -> String {
 
     let mut out = String::with_capacity(text.len() + 64);
     let mut in_fence = false;
-    let mut fence_lang: Option<String> = None;
 
     for (idx, line) in text.split('\n').enumerate() {
         if idx > 0 {
@@ -50,11 +49,13 @@ pub fn render_markdown_ansi(text: &str) -> String {
         }
 
         // Code fence delimiter handling. We toggle state and emit a dim
-        // marker line so the user can still see fence boundaries.
+        // marker line so the user can still see fence boundaries. The
+        // opening fence's language tag is rendered inline; it isn't
+        // carried across iterations because each delimiter line ends with
+        // `continue`, so we compute it locally.
         if let Some(rest) = line.trim_start().strip_prefix("```") {
             if in_fence {
                 in_fence = false;
-                fence_lang = None;
                 out.push_str(DIM);
                 out.push_str("```");
                 out.push_str(RESET);
@@ -62,15 +63,10 @@ pub fn render_markdown_ansi(text: &str) -> String {
             } else {
                 in_fence = true;
                 let lang = rest.trim();
-                fence_lang = if lang.is_empty() {
-                    None
-                } else {
-                    Some(lang.to_string())
-                };
                 out.push_str(DIM);
                 out.push_str("```");
-                if let Some(l) = &fence_lang {
-                    out.push_str(l);
+                if !lang.is_empty() {
+                    out.push_str(lang);
                 }
                 out.push_str(RESET);
                 continue;
@@ -126,7 +122,7 @@ pub fn render_markdown_ansi(text: &str) -> String {
         {
             out.push_str(indent);
             out.push_str(FG_YELLOW);
-            out.push_str("•");
+            out.push('•');
             out.push_str(RESET);
             out.push(' ');
             out.push_str(&render_inline(rest));

--- a/crates/open-mpm/src/repl/mod.rs
+++ b/crates/open-mpm/src/repl/mod.rs
@@ -24,7 +24,17 @@ mod banner;
 mod bridge;
 mod commands;
 mod dispatch;
+// Why: Event renderer staged for the REPL streaming loop but not yet routed
+// through the active rendering path. Keep so the public API stays stable
+// when the streaming integration lands.
+#[allow(dead_code)]
 mod event_display;
+// Why: Lightweight ANSI markdown renderer prepared for use by the REPL chat
+// printer but not yet wired into the active rendering path. Keep the module
+// (with its self-contained tests) so the implementation is ready when the
+// REPL adds markdown rendering. The `dead_code` allow suppresses warnings
+// for the not-yet-invoked public helpers.
+#[allow(dead_code)]
 mod markdown;
 mod ollama;
 pub(crate) mod status_bar;

--- a/crates/open-mpm/src/repl/status_bar.rs
+++ b/crates/open-mpm/src/repl/status_bar.rs
@@ -9,6 +9,14 @@
 //! Test: `status_line_format_includes_segments` verifies the rendered string
 //! shape; visual verification on a TTY confirms placement.
 
+// Why: The status-bar surface is partially wired — `StatusBar::new` is called
+// in the REPL constructor, but the per-segment toggles, token accumulator,
+// `format_line`, `render`, and `format_elapsed` helpers are staged for the
+// streaming integration. Tests below exercise the helpers directly, so they
+// must remain reachable. Suppress dead-code warnings module-wide rather than
+// scattering individual `#[allow]`s.
+#![allow(dead_code)]
+
 use std::io::{IsTerminal, Write};
 use std::time::Instant;
 

--- a/crates/open-mpm/src/repl/tui.rs
+++ b/crates/open-mpm/src/repl/tui.rs
@@ -49,18 +49,13 @@ use super::statusline::{StatuslineConfig, render_statusline};
 ///   yellow/amber label to signal project scope vs. personal scope at a glance.
 /// What: Carried in `ReplApp`; updated via `ReplEvent::AgentScopeChanged`.
 /// Test: `repl_app_agent_scope_default`, `agent_scope_label_color_user`, `agent_scope_label_color_project`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum AgentScope {
     /// User-level agent (ctrl, izzie, cto-assistant). Label color = cyan.
+    #[default]
     User,
     /// PM connected to a specific project. Label color = yellow.
     Project,
-}
-
-impl Default for AgentScope {
-    fn default() -> Self {
-        AgentScope::User
-    }
 }
 
 /// Which slash command opened the picker — drives selection routing on Enter.
@@ -409,6 +404,12 @@ pub enum ReplEvent {
     /// Raw terminal key event from the input thread.
     Key(KeyEvent),
     /// Terminal was resized — repaint will pick up new dims.
+    ///
+    /// Why: The repaint loop only needs the signal that a resize happened to
+    /// refresh terminal dimensions via `crossterm::terminal::size()`; the
+    /// carried width/height are kept for future selective-redraw paths but
+    /// are not currently read at the match site.
+    #[allow(dead_code)]
     Resize(u16, u16),
     /// User submitted a line. Dispatched by the input handler so the outer
     /// task can forward to the LLM. The state update (echoing the user line
@@ -468,10 +469,16 @@ pub enum ReplEvent {
     /// Update the statusline's TM session count (#319). Emitted on startup
     /// after the initial reconcile and by background monitor ticks when the
     /// session count changes.
+    ///
+    /// Why: The constructor sites currently live behind feature-gated monitor
+    /// hooks that may not compile into every build profile; keep the variant
+    /// (and its match arm) so the wiring is ready when the hooks are enabled.
+    #[allow(dead_code)]
     TmSessionCount(usize),
     /// Update the statusline's claude-mpm session count (#331). Emitted at
     /// the same points as `TmSessionCount` — counts only sessions whose
     /// `adapter_type == AdapterType::ClaudeMpm`.
+    #[allow(dead_code)]
     ClaudeMpmSessionCount(usize),
     /// Mouse-wheel scroll delta (#329). Negative = older (up), positive =
     /// newer (down). Forwarded from the key reader thread which sees
@@ -698,6 +705,11 @@ impl ReplApp {
     }
 
     /// Up-arrow history navigation.
+    ///
+    /// Why: Exercised by `repl_app_history_prev_next`; the production key-handler
+    /// currently routes Up directly to the underlying `history` index, but the
+    /// helper is kept (and tested) so the navigation logic stays unit-coverable.
+    #[allow(dead_code)]
     pub fn history_prev(&mut self) {
         if self.history.is_empty() {
             return;
@@ -1095,7 +1107,7 @@ async fn process_event<H: ReplHandler + 'static>(
                 let h = handler.clone();
                 let dtx = tx.clone();
                 let app_for_quit = app.clone();
-                let task_slot = current_task.clone();
+                let _task_slot = current_task.clone();
                 let handle = tokio::spawn(async move {
                     let res = h.handle_input(line, dtx.clone()).await;
                     match res {
@@ -1381,23 +1393,23 @@ fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
                 // mouse selection. Falls through to "cursor to end" when
                 // input is non-empty (preserves the readline End-of-line
                 // muscle memory).
-                if app.input_buf.is_empty() {
-                    if let Some(block) = &app.last_bash_block {
-                        // #323: Only paste the first non-empty line — the
-                        // REPL input is single-line. Multi-line blocks are
-                        // common (sequential commands like `git add -A` then
-                        // `git commit -m "msg"`); pasting the whole block
-                        // would silently truncate at the first `\n` on submit.
-                        let first_line = block
-                            .lines()
-                            .find(|l| !l.trim().is_empty())
-                            .unwrap_or("")
-                            .to_string();
-                        if !first_line.is_empty() {
-                            app.input_buf = first_line;
-                            app.cursor_pos = app.input_buf.len();
-                            return None;
-                        }
+                if app.input_buf.is_empty()
+                    && let Some(block) = &app.last_bash_block
+                {
+                    // #323: Only paste the first non-empty line — the
+                    // REPL input is single-line. Multi-line blocks are
+                    // common (sequential commands like `git add -A` then
+                    // `git commit -m "msg"`); pasting the whole block
+                    // would silently truncate at the first `\n` on submit.
+                    let first_line = block
+                        .lines()
+                        .find(|l| !l.trim().is_empty())
+                        .unwrap_or("")
+                        .to_string();
+                    if !first_line.is_empty() {
+                        app.input_buf = first_line;
+                        app.cursor_pos = app.input_buf.len();
+                        return None;
                     }
                 }
                 app.cursor_pos = app.input_buf.len();
@@ -1517,13 +1529,11 @@ fn handle_picker_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
             }
             picker.selected = (picker.selected + 1) % picker.items.len();
         }
-        KeyCode::Enter => {
-            if !picker.items.is_empty() {
-                let selected = picker.items[picker.selected].clone();
-                let kind = picker.kind.clone();
-                app.picker = None;
-                app.pending_picker_selection = Some((kind, selected));
-            }
+        KeyCode::Enter if !picker.items.is_empty() => {
+            let selected = picker.items[picker.selected].clone();
+            let kind = picker.kind.clone();
+            app.picker = None;
+            app.pending_picker_selection = Some((kind, selected));
         }
         KeyCode::Esc => {
             app.picker = None;
@@ -1765,7 +1775,7 @@ fn strip_vendor_prefix(model: &str) -> String {
 fn is_redundant_thinking_step(step: &str) -> bool {
     let trimmed: String = step
         .trim()
-        .trim_end_matches(|c: char| c == '.' || c == '…')
+        .trim_end_matches(['.', '…'])
         .trim()
         .to_ascii_lowercase();
     matches!(trimmed.as_str(), "" | "thinking" | "working" | "processing")
@@ -2944,11 +2954,8 @@ fn draw_banner(f: &mut ratatui::Frame, app: &ReplApp, area: Rect) {
 /// Test: `code_fence_lang_*` asserts bash/sh/empty/non-fence cases.
 fn code_fence_lang(line: &str) -> Option<String> {
     let t = line.trim();
-    if let Some(rest) = t.strip_prefix("```") {
-        Some(rest.trim().to_ascii_lowercase())
-    } else {
-        None
-    }
+    t.strip_prefix("```")
+        .map(|rest| rest.trim().to_ascii_lowercase())
 }
 
 /// Whether a fenced-code-block language tag denotes an executable shell.
@@ -3367,7 +3374,7 @@ fn build_chat_lines(app: &ReplApp, terminal_width: usize) -> Vec<Line<'static>> 
                         // subsequent rendering. Treat malformed/nested cases
                         // as unclosed: don't consume the line at j.
                         let j_is_closer = j < body_lines.len()
-                            && code_fence_lang(body_lines[j]).map_or(false, |lang| lang.is_empty());
+                            && code_fence_lang(body_lines[j]).is_some_and(|lang| lang.is_empty());
                         if j_is_closer {
                             lines.push(Line::from(vec![
                                 Span::raw("   "),
@@ -3403,7 +3410,11 @@ fn build_chat_lines(app: &ReplApp, terminal_width: usize) -> Vec<Line<'static>> 
                         // Indent under the `⏺ ` glyph (3 spaces) — matches
                         // how non-table continuation lines are indented so
                         // the table aligns with surrounding body text.
-                        let indent = if emitted_first { "   " } else { "   " };
+                        // Both branches currently render the same three-space
+                        // continuation indent; kept as a single constant for
+                        // clarity (and to make future per-branch styling a
+                        // one-line tweak).
+                        let indent = "   ";
                         // Available width: the chat pane width. Subtract a
                         // tiny safety margin for ratatui's wrap behavior.
                         let avail = terminal_width.saturating_sub(1);

--- a/crates/open-mpm/src/runtime.rs
+++ b/crates/open-mpm/src/runtime.rs
@@ -1628,20 +1628,21 @@ mod main_tests {
     }
 }
 
-/// Bundled agent config directory — honors `OPEN_MPM_CONFIG_DIR` with a
-/// CWD-relative `.open-mpm/` fallback (#167).
-///
-/// Why: The registry search-path function wants the "bundled" config root
-/// (it appends `/agents` internally). We honor the same env var as
-/// `agents::mod::agent_config_path` so packaged binaries can point the
-/// loader at a vendored config tree.
-/// What: Returns `${OPEN_MPM_CONFIG_DIR}` as-is if set (so search_paths
-/// appends `/agents`), else `./.open-mpm`. Note: the repo's bundled config
-/// lives at `.open-mpm/` now (formerly `config/`); runtime state is in
-/// `.open-mpm/state/` (gitignored).
-// Why: `default_bundled_config_dir` is defined once in `crate::lib` and
-//      pulled in at the top of this file via `use crate::default_bundled_config_dir;`.
-//      No duplicate definition here.
+// Bundled agent config directory — honors `OPEN_MPM_CONFIG_DIR` with a
+// CWD-relative `.open-mpm/` fallback (#167).
+//
+// Why: The registry search-path function wants the "bundled" config root
+// (it appends `/agents` internally). We honor the same env var as
+// `agents::mod::agent_config_path` so packaged binaries can point the
+// loader at a vendored config tree.
+// What: Returns `${OPEN_MPM_CONFIG_DIR}` as-is if set (so search_paths
+// appends `/agents`), else `./.open-mpm`. Note: the repo's bundled config
+// lives at `.open-mpm/` now (formerly `config/`); runtime state is in
+// `.open-mpm/state/` (gitignored).
+//
+// Note: `default_bundled_config_dir` is defined once in `crate::lib` and
+//       pulled in at the top of this file via `use crate::default_bundled_config_dir;`.
+//       No duplicate definition here.
 
 /// Persist post-run skill effectiveness + usage to `~/.open-mpm/skills/index.json`
 /// (#171, #174).

--- a/crates/open-mpm/src/search/indexer.rs
+++ b/crates/open-mpm/src/search/indexer.rs
@@ -28,7 +28,7 @@ use walkdir::WalkDir;
 use crate::context::bm25::Bm25Index;
 use crate::context::indexer::tokenize;
 use crate::memory::{Embedder, MemoryStore, Segment};
-use crate::search::query_classifier::{ClassifiedQuery, QueryIntent, classify_query};
+use crate::search::query_classifier::{ClassifiedQuery, classify_query};
 
 /// Maximum number of characters kept per chunk text payload.
 ///

--- a/crates/open-mpm/src/service/mod.rs
+++ b/crates/open-mpm/src/service/mod.rs
@@ -139,13 +139,15 @@ pub async fn is_service_running(port: u16) -> bool {
     if read_pid_file().is_none() {
         return false;
     }
-    if let Some(state) = read_pid_file() {
-        if state.port == port && pid_alive(state.pid) && health_ok(port).await {
-            return true;
-        }
-        // Stale pid file detected. We don't remove it here — that's
-        // start_service's job — but we don't claim it's running either.
+    if let Some(state) = read_pid_file()
+        && state.port == port
+        && pid_alive(state.pid)
+        && health_ok(port).await
+    {
+        return true;
     }
+    // Stale pid file detected. We don't remove it here — that's
+    // start_service's job — but we don't claim it's running either.
     // Fallback: a healthy port is enough to count as "running" even
     // without a pid file (externally-launched daemons).
     health_ok(port).await

--- a/crates/open-mpm/src/skills/mod.rs
+++ b/crates/open-mpm/src/skills/mod.rs
@@ -834,14 +834,14 @@ impl SkillsLoader {
         let cache_key = compute_cache_key(task, &skill_index);
 
         // Cache lookup.
-        if let Ok(cache) = llm_skill_cache().lock() {
-            if let Some(hit) = cache.get(&cache_key) {
-                tracing::debug!(
-                    skills = ?hit,
-                    "LLM skill selection cache hit"
-                );
-                return Ok(hit.clone());
-            }
+        if let Ok(cache) = llm_skill_cache().lock()
+            && let Some(hit) = cache.get(&cache_key)
+        {
+            tracing::debug!(
+                skills = ?hit,
+                "LLM skill selection cache hit"
+            );
+            return Ok(hit.clone());
         }
 
         // Need an API key to call OpenRouter.

--- a/crates/open-mpm/src/skills/sources.rs
+++ b/crates/open-mpm/src/skills/sources.rs
@@ -159,7 +159,7 @@ impl SkillSourceRegistry {
         };
 
         // Stable sort: higher priority wins, ties keep config order.
-        sources.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sources.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         // Warn (do not block) on unapproved enabled sources.
         for s in &sources {
@@ -187,7 +187,7 @@ impl SkillSourceRegistry {
     #[cfg(test)]
     pub fn from_sources(project_root: &Path, sources: Vec<SkillSource>) -> Self {
         let mut sources = sources;
-        sources.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sources.sort_by_key(|b| std::cmp::Reverse(b.priority));
         Self {
             sources,
             project_root: project_root.to_path_buf(),

--- a/crates/open-mpm/src/slack/mod.rs
+++ b/crates/open-mpm/src/slack/mod.rs
@@ -822,25 +822,25 @@ async fn handle_command(
                 }
             };
             // RBAC enforcement: persona allow-list. `None` => unrestricted.
-            if let Some(allowed) = &user_cfg.allowed_personas {
-                if !allowed.iter().any(|p| p == &requested) {
-                    info!(
-                        user_id = %user_id,
-                        persona = %requested,
-                        "slack: /slack-switch rejected (persona not in allow-list)"
-                    );
-                    return post_message(
-                        bot_token,
-                        &channel,
-                        &format!(
-                            ":lock: Not authorized to switch to *{}*. Allowed: {}",
-                            requested,
-                            allowed.join(", ")
-                        ),
-                        None,
-                    )
-                    .await;
-                }
+            if let Some(allowed) = &user_cfg.allowed_personas
+                && !allowed.iter().any(|p| p == &requested)
+            {
+                info!(
+                    user_id = %user_id,
+                    persona = %requested,
+                    "slack: /slack-switch rejected (persona not in allow-list)"
+                );
+                return post_message(
+                    bot_token,
+                    &channel,
+                    &format!(
+                        ":lock: Not authorized to switch to *{}*. Allowed: {}",
+                        requested,
+                        allowed.join(", ")
+                    ),
+                    None,
+                )
+                .await;
             }
             {
                 let mut map = sessions.lock().await;

--- a/crates/open-mpm/src/subprocess.rs
+++ b/crates/open-mpm/src/subprocess.rs
@@ -675,6 +675,10 @@ fn record_mistake_fire_and_forget(
 /// Setting it per-`Command` (not via `std::env::set_var`) is safe under tokio.
 /// What: Merges config_dir env injection with the full env + context variant.
 /// Test: Used by `ctrl::run_pm_task`; verify child receives correct TOML path.
+// Why: Thin adapter over `spawn_and_run_inner` — every argument is forwarded
+// 1:1 into the `SpawnConfig` struct below, so collapsing them here just
+// duplicates work that struct already does.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_subagent_with_config_dir(
     agent_name: &str,
     task: &str,

--- a/crates/open-mpm/src/telegram/mod.rs
+++ b/crates/open-mpm/src/telegram/mod.rs
@@ -302,21 +302,20 @@ impl TelegramPidGuard {
         }
 
         // If a PID file exists, decide live vs. stale.
-        if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(existing_pid) = contents.trim().parse::<i32>() {
-                if telegram_pid_alive(existing_pid) {
-                    return Err(anyhow!(
-                        "Telegram daemon already running (PID {existing_pid}). \
+        if let Ok(contents) = std::fs::read_to_string(&path)
+            && let Ok(existing_pid) = contents.trim().parse::<i32>()
+            && telegram_pid_alive(existing_pid)
+        {
+            return Err(anyhow!(
+                "Telegram daemon already running (PID {existing_pid}). \
                          Stop it before starting another, or delete {} if you \
                          are sure it is stale.",
-                        path.display()
-                    ));
-                }
-                // Stale lock: the recorded process is gone. Fall through to
-                // overwrite it.
-            }
-            // Unparseable contents are treated as stale too.
+                path.display()
+            ));
         }
+        // Stale lock: the recorded process is gone. Fall through to
+        // overwrite it.
+        // Unparseable contents are treated as stale too.
 
         let pid = std::process::id();
         std::fs::write(&path, pid.to_string())
@@ -640,6 +639,10 @@ fn verify_pair_attempt(
 }
 
 /// Dispatch a parsed slash command.
+// Why: teloxide's dptree dispatch passes injected state as positional
+// arguments; this function reflects the dispatch signature exactly so a
+// wrapper struct would just have to be unpacked at every call site.
+#[allow(clippy::too_many_arguments)]
 async fn handle_command(
     bot: Bot,
     msg: Message,
@@ -1258,11 +1261,9 @@ fn convert_pairs(input: &str, delim: &str, open: &str, close: &str) -> String {
 /// leak into Telegram messages.
 fn strip_ansi(s: &str) -> String {
     // Reuse the project's existing strip-ansi crate via the `strip_ansi_escapes` dep.
-    match strip_ansi_escapes::strip_str(s) {
-        // strip_str returns String in newer versions; the result here is
-        // already a clean &str / String depending on crate version.
-        v => v,
-    }
+    // `strip_str` returns String in newer versions; the result is a clean
+    // String regardless of crate version, so just pass it through.
+    strip_ansi_escapes::strip_str(s)
 }
 
 /// Last-resort: remove all `<...>` tags and unescape HTML entities so the

--- a/crates/open-mpm/src/ticketing/actions.rs
+++ b/crates/open-mpm/src/ticketing/actions.rs
@@ -410,12 +410,11 @@ pub async fn build_actions_client(
     token: Option<&str>,
     repo: Option<&str>,
 ) -> Option<Arc<dyn ActionsClient>> {
-    if let (Some(t), Some(r)) = (token, repo) {
-        if !t.is_empty() {
-            if let Ok(c) = GitHubActionsClient::new(t, r) {
-                return Some(Arc::new(c));
-            }
-        }
+    if let (Some(t), Some(r)) = (token, repo)
+        && !t.is_empty()
+        && let Ok(c) = GitHubActionsClient::new(t, r)
+    {
+        return Some(Arc::new(c));
     }
     if gh_available().await {
         return Some(Arc::new(GhActionsCliClient::new(repo.map(String::from))));

--- a/crates/open-mpm/src/ticketing/identity.rs
+++ b/crates/open-mpm/src/ticketing/identity.rs
@@ -104,10 +104,10 @@ impl GitHubSection {
         if let Some(n) = name {
             return self.identities.iter().find(|i| i.name == n);
         }
-        if let Some(default_name) = &self.default_identity {
-            if let Some(found) = self.identities.iter().find(|i| &i.name == default_name) {
-                return Some(found);
-            }
+        if let Some(default_name) = &self.default_identity
+            && let Some(found) = self.identities.iter().find(|i| &i.name == default_name)
+        {
+            return Some(found);
         }
         self.identities.first()
     }

--- a/crates/open-mpm/src/tm/project_config.rs
+++ b/crates/open-mpm/src/tm/project_config.rs
@@ -341,12 +341,11 @@ pub fn next_session_name(project: &str, harness: &str, existing_names: &[String]
     let prefix = format!("{}-{}-", project, harness);
     let mut max_serial: u32 = 0;
     for name in existing_names {
-        if let Some(rest) = name.strip_prefix(&prefix) {
-            if let Ok(n) = rest.parse::<u32>() {
-                if n > max_serial {
-                    max_serial = n;
-                }
-            }
+        if let Some(rest) = name.strip_prefix(&prefix)
+            && let Ok(n) = rest.parse::<u32>()
+            && n > max_serial
+        {
+            max_serial = n;
         }
     }
     format!("{}{}", prefix, max_serial + 1)

--- a/crates/open-mpm/src/tools/analysis/analyze_project.rs
+++ b/crates/open-mpm/src/tools/analysis/analyze_project.rs
@@ -145,7 +145,7 @@ impl ToolExecutor for AnalyzeProjectTool {
         }
 
         // Top 10 hotspots by cognitive complexity.
-        all_funcs.sort_by(|a, b| b.1.cognitive_complexity.cmp(&a.1.cognitive_complexity));
+        all_funcs.sort_by_key(|b| std::cmp::Reverse(b.1.cognitive_complexity));
         let hotspots: Vec<Value> = all_funcs
             .iter()
             .take(10)

--- a/crates/open-mpm/src/tools/analysis/hotspots.rs
+++ b/crates/open-mpm/src/tools/analysis/hotspots.rs
@@ -66,7 +66,7 @@ impl ToolExecutor for GetComplexityHotspotsTool {
                 all.push((a.file.clone(), f));
             }
         }
-        all.sort_by(|a, b| b.1.cognitive_complexity.cmp(&a.1.cognitive_complexity));
+        all.sort_by_key(|b| std::cmp::Reverse(b.1.cognitive_complexity));
         let hotspots: Vec<Value> = all
             .into_iter()
             .take(top_n)

--- a/crates/open-mpm/src/tools/analysis/metrics.rs
+++ b/crates/open-mpm/src/tools/analysis/metrics.rs
@@ -84,6 +84,11 @@ impl SmellType {
         }
     }
 
+    // Why: We deliberately return `Option<Self>` here rather than implementing
+    // `std::str::FromStr` (which forces a `Result<Self, Err>` API and an error
+    // type that callers would have to import). Internal call sites chain this
+    // through `and_then`, so `Option` matches the consumer shape exactly.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "LongMethod" => Some(Self::LongMethod),
@@ -121,6 +126,8 @@ impl Severity {
         }
     }
 
+    // Why: Option-returning by design — see SmellType::from_str.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
             "info" => Some(Self::Info),

--- a/crates/open-mpm/src/tools/analysis/trace_flow.rs
+++ b/crates/open-mpm/src/tools/analysis/trace_flow.rs
@@ -7,8 +7,8 @@
 //! callers/callees up to `max_depth`.
 //! Test: `trace_flow_outgoing_smoke`.
 
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::{Path, PathBuf};
+use std::collections::HashSet;
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};

--- a/crates/open-mpm/src/tools/ast_tools.rs
+++ b/crates/open-mpm/src/tools/ast_tools.rs
@@ -664,7 +664,7 @@ mod tests {
         assert!(!r.is_error());
         let v: Value = serde_json::from_str(r.content()).unwrap();
         assert_eq!(v["valid"], false);
-        assert!(v["errors"].as_array().unwrap().len() >= 1);
+        assert!(!v["errors"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/open-mpm/src/tools/git_tools.rs
+++ b/crates/open-mpm/src/tools/git_tools.rs
@@ -10,7 +10,7 @@
 //! Test: See unit tests below — count, schemas, and required-argument
 //! validation.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -55,7 +55,7 @@ fn fn_schema(name: &str, description: &str, params: Value) -> Value {
     })
 }
 
-fn open_repo(root: &PathBuf) -> std::result::Result<GitRepo, String> {
+fn open_repo(root: &Path) -> std::result::Result<GitRepo, String> {
     GitRepo::open(root).map_err(|e| format!("failed to open git repo at {}: {e}", root.display()))
 }
 

--- a/crates/open-mpm/src/tools/mcp_tools.rs
+++ b/crates/open-mpm/src/tools/mcp_tools.rs
@@ -380,6 +380,11 @@ pub fn mcp_tool_executors() -> Vec<Arc<dyn ToolExecutor>> {
 
 #[cfg(test)]
 mod tests {
+    // Why: These tests hold `HOME_LOCK` (a `std::sync::Mutex`) across async
+    // I/O to serialize global $HOME mutation between tests. See
+    // `crate::test_env` for the rationale.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use crate::test_env::HOME_LOCK;
     use std::path::PathBuf;

--- a/crates/open-mpm/src/tools/memory.rs
+++ b/crates/open-mpm/src/tools/memory.rs
@@ -242,7 +242,7 @@ impl ToolExecutor for MemoryRecallTool {
         // over-fetch so a tiny index still works.
         let needs_filter = scope == "session" || scope == "imported" || tag_filter.is_some();
         let search_limit = if needs_filter {
-            (limit * 4).max(20).min(50)
+            (limit * 4).clamp(20, 50)
         } else {
             limit
         };

--- a/crates/open-mpm/src/tools/registry/discovery.rs
+++ b/crates/open-mpm/src/tools/registry/discovery.rs
@@ -17,17 +17,13 @@ use serde::{Deserialize, Serialize};
 /// `side_effects` field — kept as the OpenRPC enum.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum SideEffects {
+    #[default]
     None,
     Read,
     Write,
     External,
-}
-
-impl Default for SideEffects {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/open-mpm/src/tools/registry/mod.rs
+++ b/crates/open-mpm/src/tools/registry/mod.rs
@@ -35,7 +35,7 @@ use self::adapter::RegistryToolExecutor;
 use self::config::{DriverKind, EndpointConfig, ToolRegistryConfig};
 use self::direct::DirectDriver;
 use self::discovery::DiscoveredTool;
-use self::driver::{ArcDriver, RegistryDriver};
+use self::driver::ArcDriver;
 use self::scope::{ScopePattern, filter_by_endpoint_scopes};
 
 /// Public builder. Constructed from a `GlobalConfig`; `build()` consumes it.
@@ -170,7 +170,7 @@ mod tests {
     use serde_json::Value;
 
     use self::discovery::{EndpointCapabilities, EndpointManifest, ServerInfo, SideEffects};
-    use self::driver::{BatchCall, BatchResult};
+    use self::driver::{BatchCall, BatchResult, RegistryDriver};
 
     /// Mock driver returning a fixed manifest. Used to exercise the
     /// scope-filter / adapter wiring without an HTTP server.

--- a/crates/open-mpm/src/tools/timer.rs
+++ b/crates/open-mpm/src/tools/timer.rs
@@ -184,7 +184,7 @@ impl ToolExecutor for PollUntilTool {
             .get("contains_text")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        if condition == "contains" && contains_text.as_ref().map_or(true, |s| s.is_empty()) {
+        if condition == "contains" && contains_text.as_ref().is_none_or(|s| s.is_empty()) {
             return ToolResult::err(
                 "poll_until: 'contains_text' is required when condition=contains",
             );
@@ -198,8 +198,7 @@ impl ToolExecutor for PollUntilTool {
             .get("timeout_ms")
             .and_then(|v| v.as_u64())
             .unwrap_or(POLL_TIMEOUT_DEFAULT_MS)
-            .min(POLL_TIMEOUT_MAX_MS)
-            .max(1_000);
+            .clamp(1_000, POLL_TIMEOUT_MAX_MS);
 
         let is_url = target.starts_with("http://") || target.starts_with("https://");
         let started = Instant::now();

--- a/crates/open-mpm/src/usage/mod.rs
+++ b/crates/open-mpm/src/usage/mod.rs
@@ -132,10 +132,10 @@ pub async fn append_usage(project_dir: &Path, record: &UsageRecord) {
 /// else the empty path (which `append_usage` will treat as cwd).
 /// Test: Indirectly via `append_usage_*` tests passing an explicit tempdir.
 pub fn project_dir() -> std::path::PathBuf {
-    if let Ok(d) = std::env::var("OPEN_MPM_PROJECT_DIR") {
-        if !d.is_empty() {
-            return std::path::PathBuf::from(d);
-        }
+    if let Ok(d) = std::env::var("OPEN_MPM_PROJECT_DIR")
+        && !d.is_empty()
+    {
+        return std::path::PathBuf::from(d);
     }
     std::env::current_dir().unwrap_or_default()
 }
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn task_prefix_does_not_split_multibyte_codepoints() {
         // 70 emoji × 4 UTF-8 bytes each — must take 60 chars, not 60 bytes.
-        let task: String = std::iter::repeat('🦀').take(70).collect();
+        let task: String = std::iter::repeat_n('🦀', 70).collect();
         let r = UsageRecord::new("a", "m", "openrouter", 0, 0, 0, &task);
         assert_eq!(r.task_prefix.chars().count(), 60);
     }

--- a/crates/open-mpm/src/workflow/engine.rs
+++ b/crates/open-mpm/src/workflow/engine.rs
@@ -520,20 +520,17 @@ impl WorkflowEngine {
         // happens *after* the directory exists (std::fs::canonicalize requires
         // the path to exist on disk). If canonicalization fails for any reason,
         // fall back to the original path to avoid breaking the run.
-        let out_dir: Option<PathBuf> = match out_dir {
-            Some(dir) => Some(
-                std::fs::canonicalize(&dir)
-                    .inspect_err(|e| {
-                        tracing::warn!(
-                            out_dir = %dir.display(),
-                            error = %e,
-                            "failed to canonicalize out_dir; using original path"
-                        );
-                    })
-                    .unwrap_or(dir),
-            ),
-            None => None,
-        };
+        let out_dir: Option<PathBuf> = out_dir.map(|dir| {
+            std::fs::canonicalize(&dir)
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        out_dir = %dir.display(),
+                        error = %e,
+                        "failed to canonicalize out_dir; using original path"
+                    );
+                })
+                .unwrap_or(dir)
+        });
 
         // #222: Resolve `code_dir` — the destination for generated source files.
         // When unset, falls back to `out_dir` so legacy callers see no behavior
@@ -670,27 +667,25 @@ impl WorkflowEngine {
         // and the workflow integration suite.
         let any_ast_phase = def.phases.iter().any(|p| p.ast_native == Some(true))
             || crate::ast::is_ast_native_overridden();
-        if any_ast_phase {
-            if let Some(dir) = code_dir.as_ref().filter(|d| d.exists()) {
-                let started = std::time::Instant::now();
-                match crate::ast::pre_index_directory(dir, dir) {
-                    Ok(registry) => {
-                        let symbol_count = registry.len();
-                        crate::ast::set_pre_indexed_registry(registry);
-                        info!(
-                            duration_ms = started.elapsed().as_millis() as u64,
-                            symbols = symbol_count,
-                            path = %dir.display(),
-                            "AST pre-index complete"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            path = %dir.display(),
-                            "AST pre-index failed, continuing with empty registry"
-                        );
-                    }
+        if any_ast_phase && let Some(dir) = code_dir.as_ref().filter(|d| d.exists()) {
+            let started = std::time::Instant::now();
+            match crate::ast::pre_index_directory(dir, dir) {
+                Ok(registry) => {
+                    let symbol_count = registry.len();
+                    crate::ast::set_pre_indexed_registry(registry);
+                    info!(
+                        duration_ms = started.elapsed().as_millis() as u64,
+                        symbols = symbol_count,
+                        path = %dir.display(),
+                        "AST pre-index complete"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %dir.display(),
+                        "AST pre-index failed, continuing with empty registry"
+                    );
                 }
             }
         }
@@ -1502,13 +1497,12 @@ impl WorkflowEngine {
             // from prior runs that were never cleaned up.
             if phase.name == "plan"
                 && let Some(dir) = out_dir.as_deref()
+                && let Err(e) = relocate_plan_outputs_from_project_root(dir).await
             {
-                if let Err(e) = relocate_plan_outputs_from_project_root(dir).await {
-                    tracing::warn!(
-                        error = %e,
-                        "post-plan relocation check failed; continuing"
-                    );
-                }
+                tracing::warn!(
+                    error = %e,
+                    "post-plan relocation check failed; continuing"
+                );
             }
 
             // #123: After the code phase for a claude-code runner, reconcile
@@ -1529,13 +1523,13 @@ impl WorkflowEngine {
                 // (legacy mode), behavior is unchanged.
                 let target = code_dir.as_deref().or(out_dir.as_deref());
                 let assignments_dir = out_dir.as_deref().or(target);
-                if let (Some(target), Some(asg_dir)) = (target, assignments_dir) {
-                    if let Err(e) = reconcile_code_outputs_against(asg_dir, target).await {
-                        tracing::warn!(
-                            error = %e,
-                            "post-code reconciliation check failed; continuing"
-                        );
-                    }
+                if let (Some(target), Some(asg_dir)) = (target, assignments_dir)
+                    && let Err(e) = reconcile_code_outputs_against(asg_dir, target).await
+                {
+                    tracing::warn!(
+                        error = %e,
+                        "post-code reconciliation check failed; continuing"
+                    );
                 }
             }
 

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -1513,6 +1513,7 @@ fn spawn_disk_size_ticker(state: AppState) {
 /// registry walk plus the redb `count_active_triples` per palace) is a
 /// rounding error on the daemon's CPU budget.
 /// Test: covered indirectly — the math has not changed, only the cadence.
+#[allow(dead_code)]
 const STATUS_EVENT_TICK_SECS: u64 = 30;
 
 /// Spawn a background ticker that emits `DaemonEvent::StatusChanged` every
@@ -1533,6 +1534,7 @@ const STATUS_EVENT_TICK_SECS: u64 = 30;
 /// Test: not unit-tested (timing-dependent fire-and-forget); the underlying
 /// `aggregate_status_event` math is exercised by the existing
 /// `status_endpoint_returns_payload` path.
+#[allow(dead_code)]
 fn spawn_status_event_ticker(state: AppState) {
     tokio::spawn(async move {
         let mut interval =


### PR DESCRIPTION
## Summary
- Fixes all 148 clippy + dead_code warnings in `crates/open-mpm/` (closes #173)
- One minor touch to `crates/trusty-memory/src/lib.rs` to silence two dead_code warnings on future-use items (issue #228 background ticker)
- Zero behavior changes — purely mechanical clippy fixes

## Fix categories
- `collapsible_if` → let-chains (64 sites via `cargo clippy --fix`)
- `manual_str_repeat`, `manual_repeat_n`, `manual_split_once` → stdlib idioms
- `sort_by` → `sort_by_key` with `Reverse` (9 sites)
- `.max(min).min(max)` → `.clamp(min, max)` (2 sites)
- `&PathBuf` → `&Path`, `&mut Vec<T>` → `&mut [T]`
- `await_holding_lock` in test modules holding `HOME_LOCK`/`ENV_GUARD` across await (intentional serialization — suppressed with `#![allow]` inside `mod tests`)
- `#[allow(clippy::too_many_arguments)]` on 5 functions with documented Why

## Test plan
- [x] `cargo clippy -p open-mpm --all-targets -- -D warnings` → exit 0
- [x] `cargo test -p open-mpm` → 1868 passed, 0 failed, 8 ignored
- [x] `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)