### PR TITLE
feat(trusty-memory): fire-and-forget memory note — POST /api/v1/remember + trusty-memory note CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,15 @@ cargo run -p trusty-mpm-cli -- --help
 # trusty-memory (MCP server + embedded Svelte UI)
 RUST_LOG=info cargo run -p trusty-memory
 
+# Fire-and-forget memory note from any agent (no MCP tool needed):
+# Sub-agents spawned via Claude Code's Agent tool do not inherit MCP
+# connections, so they cannot call `mcp__trusty-memory__memory_remember`
+# directly. The `note` subcommand POSTs to the daemon's HTTP endpoint
+# (`POST /api/v1/remember`) and returns immediately — the dispatch runs
+# on a detached `tokio::spawn`. Failures degrade to stderr + zero exit.
+trusty-memory note "key fact here" --palace my-project
+trusty-memory note "another fact" --palace my-project --tag style --tag preferences
+
 # Build a specific binary in release mode
 cargo build --release -p trusty-search
 ./target/release/trusty-search start

--- a/crates/trusty-memory/src/commands/mod.rs
+++ b/crates/trusty-memory/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod kuzu_migrate;
 pub mod migrate;
 pub mod migrations;
 pub mod monitor;
+pub mod note;
 pub mod prompt_context;
 pub mod send_message;
 pub mod service;

--- a/crates/trusty-memory/src/commands/note.rs
+++ b/crates/trusty-memory/src/commands/note.rs
@@ -1,0 +1,180 @@
+//! Handler for `trusty-memory note` — fire-and-forget memory save from a shell.
+//!
+//! Why: sub-agents spawned via Claude Code's Agent tool inherit no MCP
+//! connections, so the `mcp__trusty-memory__memory_remember` tool is
+//! unreachable to them. They *can* run shell commands. This subcommand
+//! gives them a writable handle that needs no MCP plumbing — it POSTs to
+//! the running daemon's `POST /api/v1/remember` endpoint and returns
+//! immediately. The endpoint queues the dispatch on a `tokio::spawn`, so
+//! the CLI does not wait for the redb write or any of the content gates.
+//!
+//! What: resolves the daemon's HTTP address via
+//! `trusty_common::read_daemon_addr`, builds the JSON body, fires a short-
+//! timeout POST, prints `"Queued."` on success, and exits zero even when
+//! the daemon is unreachable (the contract is fire-and-forget — the caller
+//! has no use for a failure that arrives after the agent already exited).
+//!
+//! Test: `note_builds_expected_body` covers the request payload shape;
+//! end-to-end coverage of the endpoint itself lives in
+//! `crate::web::tests::remember_async_*`.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::time::Duration;
+
+/// Default HTTP timeout for the note call.
+///
+/// Why: the daemon's response path is "parse body, spawn task, return 202",
+/// which should never take more than a few hundred milliseconds. A two-
+/// second ceiling leaves room for a paged-out cache while still letting the
+/// CLI return promptly when the daemon is unreachable.
+/// What: const `Duration` reused for both `timeout` and `connect_timeout`
+/// on the `reqwest::Client`.
+/// Test: implicitly exercised by the integration tests that drive the
+/// endpoint through the router.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Build the JSON body for `POST /api/v1/remember` from CLI inputs.
+///
+/// Why: pulled out so the body shape can be asserted from a unit test
+/// without spinning up a daemon. The body shape is the public contract
+/// between the CLI and the HTTP endpoint — drift here is a silent break.
+/// What: returns a `serde_json::Value` object with `content` always set,
+/// `palace` and `tags` set only when non-empty (so the endpoint can fall
+/// back to its `--palace` default and tag-less store, respectively).
+/// Test: `note_builds_expected_body` (in this module).
+fn build_request_body(content: &str, palace: Option<&str>, tags: &[String]) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("content".to_string(), Value::String(content.to_string()));
+    if let Some(p) = palace {
+        obj.insert("palace".to_string(), Value::String(p.to_string()));
+    }
+    if !tags.is_empty() {
+        obj.insert(
+            "tags".to_string(),
+            Value::Array(tags.iter().cloned().map(Value::String).collect()),
+        );
+    }
+    Value::Object(obj)
+}
+
+/// Entry point for `trusty-memory note <content> [--palace <name>] [--tag <tag>]...`.
+///
+/// Why: the CLI face of the fire-and-forget save path. Sub-agents call
+/// this from `Bash` to land a memory without inheriting an MCP connection.
+/// Every failure mode — daemon not running, transport error, non-2xx —
+/// degrades to a stderr warning and a zero exit so the agent's task is
+/// never blocked by an unreliable memory write.
+/// What: discovers the daemon via `trusty_common::read_daemon_addr`,
+/// fires a `POST /api/v1/remember` with `{content, palace?, tags?}`, and
+/// prints `"Queued."` on 2xx. Daemon-missing prints a warning to stderr
+/// and still exits zero (the contract is one-way).
+/// Test: covered manually via `trusty-memory start && trusty-memory note
+/// "hello"`; the HTTP endpoint itself is covered by
+/// `crate::web::tests::remember_async_returns_202_and_persists`.
+pub async fn handle_note(content: String, palace: Option<String>, tags: Vec<String>) -> Result<()> {
+    // Validate locally so the CLI does not even bother contacting the
+    // daemon when the caller passed an empty string. The endpoint would
+    // reject it with 400, but failing fast here keeps the failure mode
+    // visible (instead of "queued and silently dropped").
+    if content.trim().is_empty() {
+        eprintln!("trusty-memory note: 'content' must not be empty");
+        std::process::exit(2);
+    }
+
+    // Discover the running daemon. When no daemon is running we degrade
+    // to a warning + zero exit so the agent's parent shell does not break
+    // on a missing memory write — the contract is fire-and-forget.
+    let addr = match trusty_common::read_daemon_addr("trusty-memory") {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            eprintln!(
+                "trusty-memory note: daemon not running — memory write \
+                 dropped. Start it with `trusty-memory start`."
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            eprintln!("trusty-memory note: could not read daemon address: {e:#}");
+            return Ok(());
+        }
+    };
+    let base = if addr.starts_with("http://") || addr.starts_with("https://") {
+        addr
+    } else {
+        format!("http://{addr}")
+    };
+    let url = format!("{base}/api/v1/remember");
+
+    let body = build_request_body(&content, palace.as_deref(), &tags);
+
+    let client = match reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .connect_timeout(HTTP_TIMEOUT)
+        .build()
+        .context("build http client")
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("trusty-memory note: could not build http client: {e:#}");
+            return Ok(());
+        }
+    };
+
+    match client.post(&url).json(&body).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            println!("Queued.");
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            eprintln!(
+                "trusty-memory note: daemon returned {status}: {text} (memory write dropped)"
+            );
+        }
+        Err(e) => {
+            eprintln!("trusty-memory note: POST {url} failed: {e:#} (memory write dropped)");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `build_request_body` emits exactly the fields the HTTP endpoint
+    /// expects, omitting `palace` and `tags` when the caller does not set
+    /// them.
+    ///
+    /// Why: drift between the CLI body shape and the endpoint's
+    /// `RememberAsyncBody` deserialiser would silently break the agent
+    /// workflow. Pin every field name and the omission rules.
+    /// What: builds the body with and without optional fields and asserts
+    /// the resulting JSON layout.
+    /// Test: this test.
+    #[test]
+    fn note_builds_expected_body() {
+        // Minimal: only content.
+        let b = build_request_body("hello", None, &[]);
+        assert_eq!(b["content"], "hello");
+        assert!(
+            b.get("palace").is_none(),
+            "palace must be omitted when None"
+        );
+        assert!(b.get("tags").is_none(), "tags must be omitted when empty");
+
+        // Full: content + palace + tags.
+        let b = build_request_body(
+            "facts about quokkas",
+            Some("wildlife"),
+            &["marsupials".to_string(), "australia".to_string()],
+        );
+        assert_eq!(b["content"], "facts about quokkas");
+        assert_eq!(b["palace"], "wildlife");
+        let tags = b["tags"].as_array().expect("tags array");
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0], "marsupials");
+        assert_eq!(tags[1], "australia");
+    }
+}

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -21,6 +21,7 @@ use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
 use trusty_memory::commands::inbox_check::handle_inbox_check;
 use trusty_memory::commands::migrate::{handle_migrate, MigrateTarget};
+use trusty_memory::commands::note::handle_note;
 use trusty_memory::commands::prompt_context::handle_prompt_context;
 use trusty_memory::commands::send_message::handle_send_message;
 use trusty_memory::commands::service::{handle_service, ServiceAction};
@@ -261,6 +262,33 @@ enum Command {
         palace: Option<String>,
     },
 
+    /// Fire-and-forget save of a memory note to the running daemon.
+    ///
+    /// Why: sub-agents spawned via Claude Code's Agent tool do not inherit
+    /// any MCP connections, so the `mcp__trusty-memory__memory_remember`
+    /// tool is unreachable to them. They can still execute shell commands,
+    /// so this subcommand POSTs to `POST /api/v1/remember` and returns
+    /// immediately — the daemon dispatches `memory_remember` on a detached
+    /// task. Errors degrade to stderr warnings + zero exit because the
+    /// agent has already left the room by the time the write completes.
+    ///
+    /// Example: `trusty-memory note "User prefers tabs" --palace my-project \
+    ///           --tag style --tag preferences`.
+    Note {
+        /// Drawer body. Required.
+        #[arg(value_name = "CONTENT")]
+        content: String,
+
+        /// Target palace (defaults to the daemon's `--palace` default when
+        /// omitted; required when the daemon was started without one).
+        #[arg(long, value_name = "NAME")]
+        palace: Option<String>,
+
+        /// Tag to attach to the drawer. Repeatable.
+        #[arg(long = "tag", value_name = "TAG")]
+        tags: Vec<String>,
+    },
+
     /// Re-run auto-KG extraction across every drawer in a palace.
     ///
     /// Why: Issue #97 — `memory_remember` now extracts triples on write,
@@ -398,6 +426,11 @@ async fn main() -> Result<()> {
             from,
         } => handle_send_message(to, purpose, content, from).await,
         Command::InboxCheck { palace } => handle_inbox_check(palace).await,
+        Command::Note {
+            content,
+            palace,
+            tags,
+        } => handle_note(content, palace, tags).await,
         Command::KgRebuild { palace } => {
             trusty_memory::commands::kg_rebuild::handle_kg_rebuild(palace).await
         }

--- a/crates/trusty-memory/src/web.rs
+++ b/crates/trusty-memory/src/web.rs
@@ -155,6 +155,15 @@ pub fn router() -> Router<AppState> {
         .route("/api/v1/activity", get(activity_handler))
         .route("/api/v1/activity/hook", post(hook_activity_handler))
         .route("/api/v1/admin/stop", post(admin_stop))
+        // Issue: fire-and-forget memory save for callers that cannot speak
+        // MCP. Sub-agents spawned via Claude Code's Agent tool inherit no
+        // MCP connections, so `memory_remember` is unreachable to them.
+        // This endpoint lets the agent shell out to `trusty-memory note`
+        // (which in turn POSTs here) and the request returns 202 the moment
+        // the body is parsed — the actual `memory_remember` dispatch runs
+        // on a detached `tokio::spawn`. Failures are logged at warn but
+        // never surface to the caller because the contract is one-way.
+        .route("/api/v1/remember", post(remember_async))
         // Multi-transport refactor: a single JSON-RPC 2.0 endpoint that
         // accepts the same envelopes the UDS transport speaks. Lets
         // browser clients, curl, and the stdio bridge fallback hit the
@@ -528,6 +537,99 @@ async fn admin_stop(State(_state): State<AppState>) -> Json<Value> {
         std::process::exit(0);
     });
     Json(serde_json::json!({ "ok": true, "message": "shutting down" }))
+}
+
+// ---------------------------------------------------------------------------
+// Fire-and-forget memory save (`POST /api/v1/remember`)
+// ---------------------------------------------------------------------------
+
+/// Request body for `POST /api/v1/remember`.
+///
+/// Why: agents spawned via Claude Code's Agent tool do not inherit any MCP
+/// connections, so the `memory_remember` MCP tool is unreachable to them.
+/// Exposing a plain HTTP entry point lets those agents shell out via the
+/// `trusty-memory note` CLI (or any `curl` call) without learning MCP.
+/// What: `content` is the drawer body and is required; `palace` falls back
+/// to the daemon's `--palace` default when omitted; `tags` is optional and
+/// passed through verbatim to the underlying handler.
+/// Test: `remember_async_*` tests in this module.
+#[derive(Debug, Deserialize)]
+struct RememberAsyncBody {
+    /// Drawer body. Required.
+    content: String,
+    /// Target palace. When `None`, the daemon's `--palace` default is used;
+    /// callers without a default-palace configured must pass this field or
+    /// the spawned task logs a warning and drops the request.
+    #[serde(default)]
+    palace: Option<String>,
+    /// Optional tag list to attach to the drawer.
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+}
+
+/// `POST /api/v1/remember` — fire-and-forget memory save.
+///
+/// Why: sub-agents spawned via Claude Code's Agent tool have no MCP
+/// connection (MCP servers are not inherited across sub-agent spawns), so
+/// they cannot invoke `mcp__trusty-memory__memory_remember` directly. They
+/// can, however, run shell commands — this endpoint plus the
+/// `trusty-memory note` CLI gives them a writable handle that needs no
+/// MCP plumbing. The contract is one-way: the request is parsed, validated,
+/// and queued on a `tokio::spawn`, then `202 Accepted` is returned
+/// immediately. Failures during the spawned dispatch (palace not found,
+/// content gate skip, redb error) are logged at `warn` but never propagate
+/// back to the caller because the agent has already exited by then.
+/// What: deserialises the body, rejects an empty `content` with 400 (the
+/// only synchronous validation), then maps `{content, palace, tags}` →
+/// `{text, palace, tags}` (the field names `handle_memory_remember`
+/// expects) and dispatches `memory_remember` from a detached task. Returns
+/// `202 Accepted` with `{"status":"queued"}`.
+/// Test: `remember_async_returns_202_and_persists` (happy path) and
+/// `remember_async_rejects_empty_content` (input validation).
+async fn remember_async(
+    State(state): State<AppState>,
+    Json(body): Json<RememberAsyncBody>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    let content = body.content.trim();
+    if content.is_empty() {
+        return Err(ApiError::bad_request(
+            "remember: 'content' must be a non-empty string",
+        ));
+    }
+
+    // Build the MCP-shaped args once on the request thread so deserialisation
+    // errors never end up swallowed by the spawned task. `handle_memory_remember`
+    // expects `text` (not `content`), so translate the field name here.
+    let mut args = serde_json::Map::new();
+    args.insert("text".to_string(), Value::String(content.to_string()));
+    if let Some(p) = body.palace {
+        args.insert("palace".to_string(), Value::String(p));
+    }
+    if let Some(tags) = body.tags {
+        args.insert(
+            "tags".to_string(),
+            Value::Array(tags.into_iter().map(Value::String).collect()),
+        );
+    }
+    let args = Value::Object(args);
+
+    let state_for_task = state.clone();
+    tokio::spawn(async move {
+        match crate::tools::dispatch_tool(&state_for_task, "memory_remember", args).await {
+            Ok(v) => {
+                tracing::debug!(target: "trusty_memory::remember_async", result = %v, "queued remember succeeded");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "trusty_memory::remember_async",
+                    error = %format!("{e:#}"),
+                    "queued remember failed (caller already returned 202)",
+                );
+            }
+        }
+    });
+
+    Ok((StatusCode::ACCEPTED, Json(json!({ "status": "queued" }))))
 }
 
 // ---------------------------------------------------------------------------
@@ -2275,6 +2377,118 @@ mod tests {
         let Json(body) = admin_stop(State(state)).await;
         assert_eq!(body["ok"], Value::Bool(true));
         assert_eq!(body["message"].as_str(), Some("shutting down"));
+    }
+
+    /// `POST /api/v1/remember` returns 202 Accepted with a `queued` envelope
+    /// and the spawned task actually persists a drawer in the target palace.
+    ///
+    /// Why: this is the central contract of the fire-and-forget endpoint —
+    /// the response must come back immediately (no waiting on the redb write)
+    /// and the work must still happen. Without this test the endpoint could
+    /// silently regress to either "returns 202 but never writes" or "blocks
+    /// the caller on the dispatch".
+    /// What: provisions a palace, POSTs `{content, palace, tags}` to the
+    /// endpoint, asserts 202 + `{status:"queued"}`, then polls the palace's
+    /// drawer list (up to ~2 s) until the spawned task lands the write.
+    /// Test: this test.
+    #[tokio::test]
+    async fn remember_async_returns_202_and_persists() {
+        let state = test_state();
+        // Pre-create the target palace so the spawned task does not race
+        // against palace_create — we want to assert only the persist path.
+        let palace = Palace {
+            id: PalaceId::new("remember-async"),
+            name: "remember-async".to_string(),
+            description: None,
+            created_at: chrono::Utc::now(),
+            data_dir: state.data_root.join("remember-async"),
+        };
+        state
+            .registry
+            .create_palace(&state.data_root, palace)
+            .expect("create_palace");
+
+        let app = router().with_state(state.clone());
+        let body = json!({
+            "content": "Trusty-memory note CLI ships a fire-and-forget HTTP endpoint for sub-agents.",
+            "palace": "remember-async",
+            "tags": ["docs", "note-cli"],
+        })
+        .to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/remember")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::ACCEPTED,
+            "remember endpoint must respond 202 immediately"
+        );
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["status"], "queued");
+
+        // Wait for the spawned task to finish. The dedup/blocklist gates run
+        // on the spawn thread, so we cannot synchronously await the write;
+        // poll the registry until the drawer lands or the deadline expires.
+        let handle = state
+            .registry
+            .open_palace(&state.data_root, &PalaceId::new("remember-async"))
+            .expect("open palace");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let count = handle.drawers.read().len();
+            if count >= 1 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("spawned remember task never persisted a drawer (count={count})");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// `POST /api/v1/remember` with empty `content` returns 400 — the only
+    /// synchronous validation the endpoint performs.
+    ///
+    /// Why: empty content is a programming error in the caller (the spawned
+    /// task would just hit the content-gate and silently drop the request),
+    /// so we surface it as a 400 before queueing. Every other failure mode
+    /// (palace not found, blocklist, dedup) is logged on the spawn task and
+    /// still returns 202 because the agent has already exited by then.
+    /// What: POST `{content: ""}` and assert 400. Also covers the trim path —
+    /// whitespace-only content is treated as empty.
+    /// Test: this test.
+    #[tokio::test]
+    async fn remember_async_rejects_empty_content() {
+        let state = test_state();
+        let app = router().with_state(state);
+        for body in [json!({"content": ""}), json!({"content": "   \n  "})] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/remember")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "empty content must be rejected; body={body}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
Sub-agents spawned via Claude Code's `Agent()` tool don't inherit the parent session's MCP connections. `mcp__trusty-memory__memory_remember` is unavailable inside sub-agent contexts even when the daemon is running. There was no out-of-band write path.

## Solution

### `POST /api/v1/remember` (HTTP, fire-and-forget)
Accepts `{ content, palace?, tags? }`, spawns a tokio task, returns 202 immediately.

### `trusty-memory note <content> [--palace <name>] [--tag <tag>]...` (CLI)
POSTs to the running daemon, exits 0 immediately — even if daemon is unreachable.

## Usage
```bash
trusty-memory note "important fact discovered" --palace my-project
```

## Test plan
- [x] `cargo test -p trusty-memory` → 291 passed, 0 failed (3 new tests)
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` → zero warnings
- [x] `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)