### PR TITLE
docs(trusty-mpm): foundational PRD + architecture spec

### DIFF
--- a/docs/trusty-mpm/README.md
+++ b/docs/trusty-mpm/README.md
@@ -15,8 +15,13 @@ published trusty-* crates:
 
 ## Status
 
-No `trusty-mpm` documentation has been authored yet in this layout. As work
-on trusty-mpm produces benchmarks, decisions, or session summaries, add files
+Foundational design docs live under [`research/`](research/):
+
+- [Product Requirements Document (reconstructed)](research/prd-2026-05-29.md)
+- [Architecture & technical specification (reconstructed)](research/architecture-spec-2026-05-29.md)
+- [`tm services` discovery spec](research/tm-services-discovery-spec-2026-05-28.md)
+
+As work on trusty-mpm produces benchmarks, decisions, or session summaries, add files
 under the appropriate subdir and update its README index.
 
 See [`docs/trusty-search/`](../trusty-search/) for a worked example of the

--- a/docs/trusty-mpm/research/README.md
+++ b/docs/trusty-mpm/research/README.md
@@ -1,0 +1,28 @@
+# trusty-mpm — research
+
+Investigation docs, audits, decision documents, and reconstructed design docs for the
+`trusty-mpm` crate.
+
+## Naming convention
+
+`{topic}-{YYYY-MM-DD}.md` or `{topic}-decision-{YYYY-MM-DD}.md`.
+
+## Contents
+
+- **[prd-2026-05-29.md](./prd-2026-05-29.md)** — Reconstructed Product Requirements
+  Document. Recovers the original product intent (single-daemon-per-machine coordinating
+  multiple Claude Code processes; Rust successor to `claude-mpm`) and annotates each
+  functional/non-functional requirement with current implementation status.
+- **[architecture-spec-2026-05-29.md](./architecture-spec-2026-05-29.md)** — Reconstructed
+  technical specification. Covers the process/coordination model, module breakdown, data
+  model, instruction assembly, agent/skill deployment, HTTP API + MCP surfaces, filesystem
+  layout, configuration, distribution, and a prioritized gaps-and-deviations list. Marks
+  INTENDED design vs CURRENT IMPLEMENTATION wherever they differ.
+- **[tm-services-discovery-spec-2026-05-28.md](./tm-services-discovery-spec-2026-05-28.md)** —
+  Engineering spec for the `tm services` canonical service-discovery CLI (manifest schema,
+  discovery engine, CLI subcommands, phased implementation plan).
+
+## Related
+
+- [Parent index](../README.md)
+- [crate README](../../../crates/trusty-mpm/README.md)

--- a/docs/trusty-mpm/research/architecture-spec-2026-05-29.md
+++ b/docs/trusty-mpm/research/architecture-spec-2026-05-29.md
@@ -1,0 +1,484 @@
+# trusty-mpm — Architecture & Technical Specification (Reconstructed)
+
+**Date**: 2026-05-29
+**Status**: Reconstructed — Draft for review
+**Crate**: `crates/trusty-mpm` (version `0.5.0`, edition 2024, `publish = false`)
+**Companion PRD**: [prd-2026-05-29.md](prd-2026-05-29.md)
+**Sources**: reconstructed from source code, embedded heritage assets, and a 2026-05-29 core-feature code review.
+
+> **Convention.** Throughout, **INTENDED (original product design)** marks design surface
+> that the heritage assets / docs describe, and **CURRENT IMPLEMENTATION** marks what the
+> Rust source actually does. File references use `path:line` against the worktree at the
+> documented date.
+
+---
+
+## 1. Architecture Overview
+
+trusty-mpm is one Cargo crate with feature-gated binaries and library modules. A single
+resident daemon (`trusty-mpmd`) is the coordination hub; the CLI, TUI, Telegram bot, GUI,
+and the in-session MCP server are all clients of that daemon. Coordinated Claude Code
+session processes connect to the daemon over HTTP (hook relay) and are launched as stock
+`claude` processes shaped by deployed framework artifacts.
+
+```
+                          ┌──────────────────────────────────────────────┐
+                          │   ONE MACHINE  (single-instance enforced)      │
+                          │                                                │
+  operator ── tm CLI ─────┼────────────┐                                   │
+  operator ── tm tui ─────┼──────────┐ │   HTTP (loopback :7880)           │
+  phone ───── Telegram ───┼────────┐ │ │   + SSE event feed                │
+  desktop ─── GUI ────────┼──────┐ │ │ │                                   │
+                          │      ▼ ▼ ▼ ▼                                   │
+                          │   ┌───────────────────────────────────────┐   │
+                          │   │   trusty-mpmd  (resident daemon)        │   │
+                          │   │   ┌─────────────────────────────────┐  │   │
+                          │   │   │ Arc<DaemonState> (single source) │  │   │
+                          │   │   │  sessions · delegations ·        │  │   │
+                          │   │   │  breakers · memory · hook ring · │  │   │
+                          │   │   │  projects · overseer · pairing   │  │   │
+                          │   │   └─────────────────────────────────┘  │   │
+                          │   │   axum router · hook relay · watcher ·  │   │
+                          │   │   reaper · discovery · MCP backend       │   │
+                          │   └───────▲───────────────▲─────────────────┘   │
+                          │           │ POST /hooks   │ spawn / send-keys    │
+                          │     hook forwarder        │ (tmux)               │
+                          │   (`tm hook`)             ▼                      │
+                          │   ┌──────────────────────────────────────────┐  │
+                          │   │  coordinated Claude Code session processes │  │
+                          │   │  (stock `claude`, hosted in tmux panes or  │  │
+                          │   │   native Terminal.app windows)             │  │
+                          │   │  ── each shaped by deployed agents/skills, │  │
+                          │   │     project CLAUDE.md, appended system     │  │
+                          │   │     prompt, and injected trusty-* MCP      │  │
+                          │   │  ── each can call the in-session MCP       │  │
+                          │   │     server's 6 orchestration tools         │  │
+                          │   └──────────────────────────────────────────┘  │
+                          │                                                │
+                          │   framework install: ~/.trusty-mpm/...          │
+                          │   deploy targets:     ~/.claude/{agents,skills} │
+                          └──────────────────────────────────────────────┘
+```
+
+Lock file: `~/.trusty-mpm/daemon.lock` records the bound address + PID so clients resolve
+the live daemon and a second `trusty-mpmd` start is refused.
+
+---
+
+## 2. Process & Coordination Model (the core)
+
+> This is the heart of the product: **one daemon per machine coordinating multiple
+> Claude Code session processes.**
+
+### 2.1 Single-instance enforcement
+
+**CURRENT IMPLEMENTATION** (`crates/trusty-mpm/src/bin/tm.rs:3139-3171`):
+
+1. On `tm daemon` (HTTP mode), the daemon first calls `resolve_daemon_url(None)` to read
+   the lock file's recorded address. `resolve_daemon_url` validates the recorded PID is
+   alive and clears stale lock files (`core/connect.rs`).
+2. If the recorded URL is not the default *and* `probe_health(url, "/health")` succeeds,
+   the daemon prints `trusty-mpm daemon is already running at <url>` and exits cleanly —
+   refusing to start a duplicate.
+3. Otherwise it binds the configured address (`127.0.0.1:7880` default,
+   `TRUSTY_MPM_ADDR` override). On `AddrInUse` it falls back to an ephemeral port
+   (`127.0.0.1:0`). The health-probe guard above prevents the ephemeral fallback from
+   silently spawning a traffic-splitting second daemon.
+4. After bind, `lock::write_lock(base_url, tailscale_url)` writes
+   `~/.trusty-mpm/daemon.lock` (TOML: `pid`, `addr`, optional `tailscale_addr`,
+   `started_at`) — `daemon/lock.rs:18-35`.
+5. A shutdown task traps SIGINT **and** SIGTERM and calls `lock::remove_lock()` so a
+   `tm restart` (pkill → SIGTERM) never leaks a stale lock (`tm.rs:3209-3218`).
+
+So the single-instance guarantee is enforced by **three layers**: lock-file PID validation,
+`/health` probe, and the OS port bind.
+
+### 2.2 Spawning and tracking session processes
+
+A "session" is a Claude Code process. Sessions enter the registry by **three paths**:
+
+| Path | Trigger | Code |
+|---|---|---|
+| **Spawn** | `POST /sessions` with a `workdir` (e.g. GUI "New Session") → daemon creates the tmux host and starts `claude` via `TmuxService::spawn_claude` *before* registering (a 422/500 leaves the registry untouched). | `api.rs:303-354` |
+| **Register-only** | `POST /sessions` without `workdir` (CLI launch, `tm connect` → `POST /api/v1/sessions/connect`) — pure bookkeeping; the CLI/client owns the tmux + deployment work. | `api.rs:272-381` |
+| **Connection-driven** | `POST /hooks` with a `SessionStart` event for an unknown id → the daemon auto-registers the session from the incoming UUID. This is how a session "announces itself". | `api.rs:929-945` |
+
+After spawn/register, the daemon discovers the real `claude` PID inside the tmux pane in
+the background (`spawn_pid_capture`) so the reaper can monitor process liveness
+(`api.rs:344-348`). The CLI/daemon also reports the PID back via `PATCH /sessions/{id}/pid`.
+
+**Auto-discovery**: at boot and on `POST /sessions/discover`, `discovery::discover_all`
+scans tmux panes *and* native Terminal.app `ps` processes running Claude Code and adopts
+them, so externally-started sessions appear in the dashboard without a manual adopt
+(`daemon/mod.rs:84-92`, `api.rs:505-528`).
+
+### 2.3 Session registry (the single source of truth)
+
+`Arc<DaemonState>` holds the coordinated picture of the world
+(`crates/trusty-mpm/src/daemon/state.rs:72-162`):
+
+- `sessions: DashMap<SessionId, Session>` — every managed session.
+- `delegations: DashMap<Uuid, Delegation>` — active delegation trees.
+- `breakers: DashMap<String, CircuitBreaker>` — per-agent circuit-breaker state.
+- `memory: DashMap<SessionId, MemoryUsage>` — latest token-usage snapshot per session.
+- `hook_history: Mutex<VecDeque<HookEventRecord>>` — bounded ring buffer (`HOOK_HISTORY_LIMIT = 1024`).
+- `projects: RwLock<HashMap<PathBuf, ProjectInfo>>` — registered project dirs.
+- `overseer: Arc<dyn Overseer>` + optional `llm` — hook evaluation + chat.
+- `event_tx: broadcast::Sender<Value>` — SSE fan-out (`EVENT_CHANNEL_CAPACITY = 1024`).
+- `paired_chat_id` / `pair_code` / `framework_root` — Telegram pairing (persisted).
+
+One `Arc<DaemonState>` is injected into every axum handler and into the MCP `StateBackend`,
+so HTTP clients and in-session MCP tools observe the same state.
+
+### 2.4 Hook relay & enforcement
+
+The hook forwarder (`tm hook`) is the Rust replacement for claude-mpm's per-fire Python
+process. It reads minimal context from Claude Code env vars, posts `hook_event` to the
+daemon, exits 0, and short-circuits when `CLAUDE_MPM_SUB_AGENT=1` (so nested sub-agents
+don't generate hook traffic).
+
+`POST /hooks` (`api.rs:904-953`) is the enforcement point:
+
+1. Parse session id (malformed → 400; unknown event name → 400 at deserialization).
+2. On `SessionStart` for an unknown session → auto-register (connection-driven path).
+3. Run `HookService::process` → consult the overseer on tool-use events; a `Block`
+   decision returns **403** before the tool runs. Every decision is audited (JSONL).
+4. Compress `PostToolUse` output per the optimizer policy.
+5. Append a `HookEventRecord` to the ring buffer and broadcast a JSON copy to all SSE
+   subscribers.
+
+### 2.5 Event streaming
+
+- `GET /events` / `GET /sessions/{id}/events` — live SSE streams (per-session filtering by
+  UUID substring), 15s keep-alive ping (`api.rs:192-218,559-593`).
+- `GET /events/poll` / `GET /sessions/{id}/events/poll` — synchronous ring-buffer snapshots
+  for non-SSE clients.
+
+### 2.6 Reaping
+
+A 60s `reap_loop` (`daemon/mod.rs:128-152`) and `DELETE /sessions/dead` call
+`reap_dead_sessions` → `reap_against` (`state.rs:564-634`): tmux session gone → remove
+the entry; tmux alive but tracked `claude` PID dead → mark `Stopped` in place; native
+(non-tmux) sessions are never tmux-reaped.
+
+---
+
+## 3. Module Breakdown
+
+```
+crates/trusty-mpm/src/
+├── lib.rs            # re-exports: services, core, client (always); mcp/daemon/tui/telegram (gated)
+├── services/         # ALWAYS-ON: tm services discovery (manifest + discoverer)
+├── core/             # ALWAYS-ON: domain types, deploy pipeline, instruction assembly, IPC
+├── client/           # ALWAYS-ON: DaemonClient (HTTP), TrustyCommand, CommandExecutor
+├── mcp/              # feature: mcp  — OrchestratorBackend trait, tool catalog, dispatch
+├── daemon/           # feature: daemon — axum API, DaemonState, hook relay, watcher, lock
+├── tui/              # feature: tui  — ratatui dashboard
+├── telegram/         # feature: telegram — teloxide bot
+└── bin/              # tm, trusty-mpmd, trusty-mpm-tui, trusty-mpm-telegram, trusty-mpm-gui
+```
+
+| Module | Responsibility | Key files |
+|---|---|---|
+| `core` | Domain model + the launch machinery: sessions, agents, hooks, circuit breakers, memory, overseer, **agent inheritance/deploy**, **skill deploy**, **instruction pipeline**, **session launch prep**, `FrameworkPaths`, lock-file path, daemon-URL resolution. | `agent_builder.rs`, `agent_deployer.rs`, `agent_manifest.rs`, `skill_deployer.rs`, `skill_manifest.rs`, `instruction_pipeline.rs`, `session_launch.rs`, `paths.rs`, `circuit.rs`, `memory.rs`, `delegation_authority.rs`, `connect.rs`, `bundle.rs` |
+| `client` | One shared HTTP transport + command model used by TUI, Telegram, CLI. | `http_client.rs`, `command.rs`, `executor.rs`, `result.rs` |
+| `mcp` | Six orchestration tools + `OrchestratorBackend` trait + `dispatch`. | `mcp/mod.rs`, `mcp/tools.rs` |
+| `daemon` | HTTP API + shared state + hook relay + file watcher + reaper + discovery + lock + MCP backend + overseer composition + pairing store. | `daemon/api.rs`, `daemon/state.rs`, `daemon/lock.rs`, `daemon/watcher.rs`, `daemon/discover.rs`, `daemon/discovery.rs`, `daemon/mcp_backend.rs`, `daemon/services/*` |
+| `tui` | ratatui dashboard polling the daemon. | `tui/dashboard.rs`, `tui/client.rs`, `tui/health.rs` |
+| `telegram` | teloxide adapter → `CommandExecutor`, formatter, push-alert loop. | `telegram/commands.rs`, `telegram/alerts.rs`, `telegram/formatter.rs` |
+| `services` | `tm services` manifest + discovery engine. | `services/manifest.rs`, `services/discoverer.rs` |
+
+---
+
+## 4. Data Model
+
+| Type | Purpose | Persistence |
+|---|---|---|
+| `Session` (`core/session.rs`) | id (UUID), project, `workdir`, `tmux_name`, `pid`, `status` (Starting/Active/Paused/Stopped), `origin` (Tmux/Native), `control_model`, `project_path`, pause fields. | In-memory `DashMap`; pause records persisted via `session_store`. |
+| `Delegation` (`core/agent.rs`) | id, session, target agent, task — delegation tree. | In-memory `DashMap`. |
+| `CircuitBreaker` (`core/circuit.rs`) | per-agent `consecutive_failures`, `allows_delegation()`, `CircuitConfig` (default 3-strike). | In-memory `DashMap`. |
+| `MemoryUsage` / `MemoryPressure` (`core/memory.rs`) | `used_tokens`/`window_tokens`; pressure = ok/warn/alert/compact via `MemoryConfig`. | In-memory `DashMap`. |
+| `HookEventRecord` (`core/hook.rs`) | session, `HookEvent` variant, payload, timestamp. | Bounded ring buffer (1024) + SSE broadcast. |
+| `ProjectInfo` (`core/project.rs`) | path-keyed registered project. | In-memory `RwLock<HashMap>`. |
+| `AgentManifest` / `ManifestEntry` (`core/agent_manifest.rs`) | `filename → {source_chain, sha256 checksum, deployed_at, origin}`; `Origin` ∈ {Bundled, Registry, User}. | `~/.claude/agents/.trusty-mpm-manifest.json`. |
+| `SkillManifest` / entry (`core/skill_manifest.rs`) | same ownership model for skills. | `~/.claude/skills/` manifest. |
+| `ServicesManifest` / `ServiceDecl` / `ServiceStatus` (`services/`) | declared services + live probe results. | `~/.claude-mpm/services.yaml` (or embedded default). |
+| Pairing record (`daemon/pairing_store.rs`) | Telegram `chat_id`. | `~/.trusty-mpm/pairing.json`. |
+| `OptimizerConfig` / `OverseerConfig` | compression + oversight policy. | `~/.trusty-mpm/framework/hooks/optimizer.toml` / `overseer.toml`. |
+
+`SessionId` is a single-field UUID newtype serialized as a bare string.
+
+---
+
+## 5. Instruction Assembly Pipeline
+
+### 5.1 CURRENT IMPLEMENTATION — compile-time concat + runtime merge
+
+Two layers operate today:
+
+**(a) System-prompt assembly** (`instruction_pipeline.rs:31-72`):
+```
+PM_INSTRUCTIONS  →  WORKFLOW  →  AGENT_DELEGATION  →  BASE_PM
+```
+All four are `include_str!`'d at compile time and joined with `\n\n---\n\n`. `BASE_PM` is
+appended **last** as the non-overridable floor (carries the Trusty tool-priority block).
+`install_system_prompt()` writes the result to
+`~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`; `build_system_prompt()` reads it
+back (regenerating on first run) and passes it to `claude --append-system-prompt-file`
+(`session_launch.rs:541-579`).
+
+**(b) Runtime merge pipeline** (`build_instructions`, `instruction_pipeline.rs:163-204`),
+sections **3 → 4 → 5**:
+1. **Framework** — the on-disk `INSTRUCTIONS.md` (missing ⇒ empty, non-fatal).
+2. **Delegation authority** — generated fresh from the deployed agents in
+   `~/.claude/agents/` via `scan_agents` + `generate_authority`.
+3. **Project `CLAUDE.md`** — loaded, or the stub is seeded once and never overwritten.
+
+The merged text is stashed to `<project>/.trusty-mpm/last-instructions.md` for inspection.
+
+### 5.2 INTENDED (original product design) — project override layering
+
+`BASE_PM.md:17-33` advertises a **5-file project override system** under `.trusty-mpm/`:
+
+| User wants | File | Effect |
+|---|---|---|
+| Project rules | `.trusty-mpm/INSTRUCTIONS.md` | Appended to PM prompt |
+| Agent routing | `.trusty-mpm/AGENT_DELEGATION.md` | Replaces routing table |
+| Workflow phases | `.trusty-mpm/WORKFLOW.md` | Replaces default workflow |
+| Memory behavior | `.trusty-mpm/MEMORY.md` | Replaces memory section |
+| Full PM replacement | `.trusty-mpm/PM_INSTRUCTIONS_DEPLOYED.md` | Replaces entire PM prompt |
+
+…plus trigger phrases ("remember/always/never for this project" → write `INSTRUCTIONS.md`)
+and a `PM_INSTRUCTIONS_VERSION` marker (`PM_INSTRUCTIONS.md:1` = `0014`) for upgrade gating.
+
+> ⚠️ **DIVERGENCE.** No Rust code reads any of these five files, and the version marker is
+> inert. The only project-level input the pipeline consumes is `CLAUDE.md`. This override
+> layer is intended scope, not yet built. (PRD FR-IN-4 / FR-IN-5.)
+
+---
+
+## 6. Agent & Skill Deployment Model
+
+### 6.1 CURRENT IMPLEMENTATION — compose, checksum, manifest
+
+**Composition** (`agent_builder.rs`): `compose_agent` walks the `extends:` chain base-first,
+merges frontmatter child-wins (name/role/description/model), strips intermediate
+frontmatter, emits one self-contained file. Guards: cycle detection and `MAX_DEPTH = 8`.
+Confirmed chain: `engineer → base-engineer → base-agent`.
+
+**Deployment** (`agent_deployer.rs` / `skill_deployer.rs`) into `~/.claude/{agents,skills}/`,
+governed by `AgentManifest`/`SkillManifest` (`agent_manifest.rs`):
+
+| Target state | Action |
+|---|---|
+| Absent from manifest, file exists | user-owned → **skip** |
+| Managed, checksum matches deployed copy, composed == current | **unchanged** |
+| Managed, checksum matches, composed differs | **safe refresh** (rewrite) |
+| Managed, checksum differs from deployed copy | user-edited → **skip** |
+| New trusty-mpm file | **compose + write + record** (`Origin::Bundled`) |
+
+**Source resolution** (`paths.rs:171-208`): prefers the `agents/` git submodule
+(`<root>/agents/{agents,skills}/`) in a source checkout; otherwise the bundled
+`framework/{agents,skills}/`. There is exactly **one source** and **one target**.
+
+### 6.2 INTENDED (original product design) — registry + 3-level precedence
+
+`PM_INSTRUCTIONS.md` "Agent Deployment" describes:
+- **3-level precedence**: project `.claude/agents/` > user `~/.claude-mpm/agents/` >
+  cached remote (`bobmatnyc/claude-mpm-agents`).
+- **Remote registry**: `Origin::Registry`, `FrameworkPaths::registry`
+  (`~/.trusty-mpm/registry`), a `config.toml [agents] sources` table, fetch/TTL/offline
+  caching.
+
+> ⚠️ **DIVERGENCE.** `Origin::Registry` is a forward-compat enum variant only; `registry`
+> is a resolved-but-unused path; there is no fetch, no TTL, no offline cache, no
+> precedence resolution, and no `config.toml [agents]` reader. The model is single-source,
+> single-target. (PRD FR-AG-4 / FR-AG-5.)
+>
+> ⚠️ **GAP.** `tm install` deploys agents but **not** skills — skills deploy only inside
+> `prepare_session` on session start (`session_launch.rs:99-102`). (PRD FR-AG-6 / FR-SK-3.)
+>
+> ⚠️ **DEFECT.** The frontmatter parser splits on the first `:` and truncates values that
+> contain a colon (`agent_builder.rs:123-132`); a second, divergent parser copy exists
+> (gray_matter path); there is no workaround for the Claude Code `model:` frontmatter
+> injection bug. (PRD FR-AG-7.)
+
+---
+
+## 7. Daemon HTTP API Surface
+
+Built in `api::router` (`crates/trusty-mpm/src/daemon/api.rs:72-127`). Default base
+`http://127.0.0.1:7880`. OpenAPI/Swagger served at `/api-docs`.
+
+| Method | Path | Purpose | Status |
+|---|---|---|---|
+| GET | `/health` | Liveness probe (`"ok"`). | Implemented |
+| GET | `/sessions` | List sessions (optional `?project=`). | Implemented |
+| POST | `/sessions` | Register, or spawn when `workdir` present. | Implemented |
+| POST | `/api/v1/sessions/connect` | Register for a connect (no-deploy) launch. | Implemented |
+| DELETE | `/sessions/dead` | Reap dead tmux sessions. | Implemented |
+| POST | `/sessions/discover` | Auto-discover tmux + native sessions. | Implemented |
+| GET/DELETE | `/sessions/{id}` | Fetch / deregister a session. | Implemented |
+| GET | `/sessions/{id}/events` | Live SSE stream (per session). | Implemented |
+| GET | `/sessions/{id}/events/poll` | Snapshot of one session's events. | Implemented |
+| POST | `/sessions/{id}/pause` · `/resume` | Pause/resume with note. | Implemented |
+| POST | `/sessions/{id}/command` | Send a line to the tmux pane, capture output. | Implemented |
+| GET | `/sessions/{id}/output` · `/pane` | Capture pane scrollback (optional compress). | Implemented |
+| PATCH | `/sessions/{id}/pid` | Record the `claude` PID. | Implemented |
+| GET/POST | `/projects`, `/projects/current`, `/projects/discover` | Project registry. | Implemented |
+| GET | `/events` · `/events/poll` | Global SSE / snapshot event feed. | Implemented |
+| POST | `/hooks` | Universal hook relay (overseer enforcement point). | Implemented |
+| GET | `/breakers` | Per-agent circuit-breaker state. | Implemented |
+| GET | `/optimizer` · `/overseer` | Read framework-managed policy. | Implemented |
+| POST | `/llm/chat` | Coordinator LLM chat (503 if no overseer). | Implemented |
+| GET/POST | `/api/v1/coordinator/context` · `/chat` | Cross-session coordinator. | Implemented |
+| GET/POST | `/tmux/sessions`, `/tmux/sessions/{name}/snapshot`, `/tmux/adopt` | Universal tmux management. | Implemented |
+| GET/POST | `/claude-config*` | Claude Code config analyzer + checkpoints/profiles. | Implemented |
+| POST/GET | `/pair/request` · `/confirm` · `/status` · `/reset` | Telegram pairing. | Implemented |
+| GET | `/api/v1/doctor` | Full stack diagnostic. | Implemented |
+| GET | `/api-docs` (+ `/openapi.json`) | Swagger UI. | Implemented |
+
+> **Planned.** Per-session file tracking (issue #94) — surfacing files an agent created so
+> the PM's git-file-tracking protocol can be observed daemon-side — is **not** yet an
+> endpoint; `set_session_pid`'s doc and `trusty_addrs()` carry follow-up markers. (Tag:
+> Not-started / Planned.)
+
+---
+
+## 8. MCP Tool Surface
+
+Stdio JSON-RPC server (`tm daemon --mcp` / `run_mcp`), backed by `StateBackend` over the
+same `Arc<DaemonState>` (`daemon/mod.rs:154-170`). Six tools (`mcp/tools.rs:19-136`):
+
+| Tool | Purpose |
+|---|---|
+| `session_list` | List sessions the daemon manages (status, cwd, delegation count). |
+| `session_status` | Detailed status for one session (uptime, tokens, agent, pressure). |
+| `agent_delegate` | Request a delegation; daemon applies circuit-breaker + depth limits before spawning. |
+| `memory_protect` | Report context-window usage; daemon classifies pressure (ok/warn/alert/compact). |
+| `circuit_breaker_status` | Inspect all or one agent's breaker. |
+| `hook_event` | Forward a Claude Code hook event into the observability pipeline. |
+
+The MCP surface is how an in-session Claude Code process introspects and participates in
+host-wide coordination from inside its own context.
+
+---
+
+## 9. Filesystem Layout
+
+```
+~/.trusty-mpm/                              # framework root (FrameworkPaths::root)
+├── daemon.lock                            # bound addr + PID (single-instance discovery)
+├── pairing.json                           # Telegram chat pairing
+├── logs/                                  # rolling daemon log + overseer audit JSONL
+├── registry/                              # INTENDED remote-agent cache (unused stub)
+└── framework/
+    ├── instructions/INSTRUCTIONS.md       # assembled system prompt (regenerated)
+    ├── instructions/CLAUDE.md             # user-editable stub
+    ├── agents/                            # bundled agent SOURCE (fallback)
+    ├── skills/                            # bundled skill SOURCE (fallback)
+    └── hooks/{optimizer.toml,overseer.toml}  # framework-managed policy
+
+~/.claude/                                  # Claude Code reads these
+├── agents/                                # composed agent deploy target (+ .trusty-mpm-manifest.json)
+├── skills/                                # skill deploy target (+ manifest)
+└── output-styles/trusty-mpm.md            # deployed output style
+
+~/.claude-mpm/                              # heritage / services namespace
+├── services.yaml                          # tm services manifest (or embedded default)
+└── agents/                                # INTENDED user-level agent source (3-level precedence; unread)
+
+<project>/                                  # per-project, written on launch prep
+├── CLAUDE.md                              # seeded once, never overwritten
+├── .claude/settings.json                  # outputStyle + spinner tips + trusty-memory hooks
+├── .mcp.json                              # injected trusty-memory MCP server
+├── .trusty-mpm/last-instructions.md       # merged-instruction stash (inspection)
+└── .trusty-mpm/{INSTRUCTIONS,AGENT_DELEGATION,WORKFLOW,MEMORY,PM_INSTRUCTIONS_DEPLOYED}.md
+                                            #   INTENDED project overrides (unread)
+```
+
+Source-checkout source: `<repo>/agents/{agents,skills}/` (the `agents/` submodule) wins
+over the bundled framework directories when present (`paths.rs:181-208`).
+
+---
+
+## 10. Configuration
+
+| File | Read by | Status |
+|---|---|---|
+| `~/.trusty-mpm/framework/hooks/optimizer.toml` | daemon (`OptimizerConfig`, hot-reloaded by the watcher) | Implemented |
+| `~/.trusty-mpm/framework/hooks/overseer.toml` | daemon (`OverseerConfig`; `[llm]` section gates LLM overseer) | Implemented |
+| `~/.claude-mpm/services.yaml` | `tm services` (`ServicesManifest`; embedded `assets/default-services.yaml` fallback) | Implemented |
+| `~/.trusty-mpm/config.yaml` `models.agents.*` | (intended) per-agent model overrides | **Partial** — referenced in `PM_INSTRUCTIONS.md`, not read by Rust |
+| `config.toml [agents] sources` | (intended) remote registry sources | **Stub** — never read |
+
+Environment: `TRUSTY_MPM_URL` (client base URL), `TRUSTY_MPM_ADDR` (daemon bind),
+`TRUSTY_MPM_TAILSCALE`, `OPENROUTER_API_KEY` (LLM overseer/chat), `RUST_LOG`,
+`CLAUDE_MPM_SUB_AGENT=1` (hook short-circuit), `TELEGRAM_BOT_TOKEN`.
+
+---
+
+## 11. Distribution
+
+Single-binary, single-install convention (`Cargo.toml`):
+
+- **Features**: `default = [cli, daemon]`; `cli → daemon + tui + telegram`;
+  `daemon → mcp` (+ axum/tower/dashmap/notify/…); `tui`, `telegram`, `gui` (separate
+  Tauri crate) opt-in.
+- **`[[bin]]` targets**: `tm` and `trusty-mpm` (both `src/bin/tm.rs`, feature `cli`),
+  `trusty-mpmd` (feature `daemon`), `trusty-mpm-tui`, `trusty-mpm-telegram`,
+  `trusty-mpm-gui` (back-compat shims; prefer `tm tui` / `tm telegram` / `tm gui`).
+- **Library surfaces**: `core` + `client` + `services` always; `mcp`/`daemon`/`tui`/
+  `telegram` gated.
+
+`cargo install trusty-mpm` therefore installs the CLI plus a bundled daemon, MCP server,
+TUI, and Telegram bot — one install target, no external runtime, framework assets compiled
+in (offline-capable).
+
+---
+
+## 12. Gaps & Deviations from Intent
+
+Prioritized; each tagged with status + severity (impact on the product vision).
+
+| # | Item | Status | Severity | Notes |
+|---|---|---|---|---|
+| 1 | **Project override system** (`.trusty-mpm/{INSTRUCTIONS,AGENT_DELEGATION,WORKFLOW,MEMORY,PM_INSTRUCTIONS_DEPLOYED}.md`) advertised in `BASE_PM.md` but unread. | Not-started (divergent) | **High** | Users following the in-prompt instructions write files that have no effect — a correctness/trust issue. Either implement the reader in `build_instructions` or remove the claim from `BASE_PM.md`. |
+| 2 | **3-level agent precedence** (project > user > cached remote) documented but only single-source/single-target exists. | Not-started (divergent) | **High** | Same trust gap as #1; `PM_INSTRUCTIONS.md` "Agent Deployment" overstates capability. |
+| 3 | **Remote agent registry** (`Origin::Registry`, `registry/` path, `config.toml [agents]`, fetch/TTL/offline). | Stub | **Medium** | Forward-compat only. Blocks distributing agents without a source checkout/bundled assets. |
+| 4 | **`tm install` does not deploy skills** (only agents); skills deploy on session start. | Partial / Gap | **Medium** | A user who runs `install` then inspects `~/.claude/skills/` finds it empty until first launch. |
+| 5 | **Frontmatter parser truncates `:`-containing values; two divergent parser copies; no `model:`-injection workaround.** | Partial / Defect | **Medium** | Risks dropping/garbling agent metadata (esp. descriptions). Consolidate on one parser; round-trip test colon values. |
+| 6 | **Model-selection per-agent overrides** (`~/.trusty-mpm/config.yaml models.agents.*`) advertised, not read by Rust. | Partial | **Low–Medium** | Advisory-only today; instruction text implies enforcement. |
+| 7 | **`PM_INSTRUCTIONS_VERSION` marker** present but inert (no upgrade gating). | Stub | **Low** | Needed if/when instruction-version migration is built. |
+| 8 | **Memory routing breadth**: kuzu-memory backend + static `.claude-mpm/memories` fallback described but only trusty-memory MCP/hook wiring exists. | Not-started | **Low** | trusty-memory path works; alternates unbuilt. |
+| 9 | **PM-behaviour circuit breakers (CB#1–#14)** are instruction-driven inside the session; the daemon tracks only a per-agent failure breaker. | Partial | **Low** | Matches claude-mpm (breakers are PM self-discipline), but daemon-side enforcement/audit of CB violations is not implemented. |
+| 10 | **Per-session file tracking** (issue #94) — no daemon endpoint. | Not-started / Planned | **Low** | Would let the daemon observe the PM's git-file-tracking protocol. |
+
+---
+
+## 13. Source Reference Index
+
+| Concern | File:line |
+|---|---|
+| Crate manifest (features, bins) | `crates/trusty-mpm/Cargo.toml` |
+| Library surface (gated modules) | `crates/trusty-mpm/src/lib.rs` |
+| Single-instance enforcement + daemon boot | `crates/trusty-mpm/src/bin/tm.rs:3139-3218` |
+| Lock file | `crates/trusty-mpm/src/daemon/lock.rs` |
+| Daemon boot / discovery / reaper / MCP | `crates/trusty-mpm/src/daemon/mod.rs` |
+| HTTP router + handlers | `crates/trusty-mpm/src/daemon/api.rs:72-1413` |
+| Shared state (single source of truth) | `crates/trusty-mpm/src/daemon/state.rs:72-906` |
+| Session registry / reaping | `crates/trusty-mpm/src/daemon/state.rs:476-634` |
+| Overseer composition (deterministic + LLM) | `crates/trusty-mpm/src/daemon/state.rs:193-274` |
+| MCP tool catalog | `crates/trusty-mpm/src/mcp/tools.rs:19-136` |
+| Instruction assembly (4-asset concat) | `crates/trusty-mpm/src/core/instruction_pipeline.rs:31-72` |
+| Runtime merge pipeline (3→4→5) | `crates/trusty-mpm/src/core/instruction_pipeline.rs:163-204` |
+| Session launch prep (deploy + MCP/hook wiring) | `crates/trusty-mpm/src/core/session_launch.rs:82-579` |
+| Agent inheritance composition | `crates/trusty-mpm/src/core/agent_builder.rs:212-327` |
+| Agent deploy (checksum/manifest) | `crates/trusty-mpm/src/core/agent_deployer.rs:57-134` |
+| Skill deploy | `crates/trusty-mpm/src/core/skill_deployer.rs` |
+| Manifest + `Origin::Registry` stub | `crates/trusty-mpm/src/core/agent_manifest.rs:34-63` |
+| Framework paths + submodule source | `crates/trusty-mpm/src/core/paths.rs:74-232` |
+| Project override claim (unread) | `crates/trusty-mpm/src/assets/instructions/BASE_PM.md:17-33` |
+| PM model (delegation/CB/workflow) | `crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md` |
+| CLI command surface | `crates/trusty-mpm/src/bin/tm.rs:38-197` |
+| `tm services` spec | `docs/trusty-mpm/research/tm-services-discovery-spec-2026-05-28.md` |

--- a/docs/trusty-mpm/research/architecture-spec-2026-05-29.md
+++ b/docs/trusty-mpm/research/architecture-spec-2026-05-29.md
@@ -147,6 +147,13 @@ don't generate hook traffic).
 5. Append a `HookEventRecord` to the ring buffer and broadcast a JSON copy to all SSE
    subscribers.
 
+> **INTENDED (daemon-enforced circuit breakers).** The current overseer consults the LLM
+> overseer policy for Block/Allow decisions. An intended future extension (FR-PM-2b) is for
+> `HookService::process` to also detect CB#1–#14 violations directly from the hook event
+> payload and return 403 as a **hard block** independent of the LLM overseer. The per-agent
+> `CircuitBreaker` in `core/circuit.rs` is the partial foundation. CURRENT: CB#1–#14 are
+> PM self-discipline enforced only through instructions. INTENDED: daemon-side hard enforcement.
+
 ### 2.5 Event streaming
 
 - `GET /events` / `GET /sessions/{id}/events` — live SSE streams (per-session filtering by
@@ -369,6 +376,7 @@ host-wide coordination from inside its own context.
 ```
 ~/.trusty-mpm/                              # framework root (FrameworkPaths::root)
 ├── daemon.lock                            # bound addr + PID (single-instance discovery)
+├── config.toml                            # CANONICAL config (models.agents.*, [agents] sources, …)
 ├── pairing.json                           # Telegram chat pairing
 ├── logs/                                  # rolling daemon log + overseer audit JSONL
 ├── registry/                              # INTENDED remote-agent cache (unused stub)
@@ -404,13 +412,23 @@ over the bundled framework directories when present (`paths.rs:181-208`).
 
 ## 10. Configuration
 
+**Canonical config file: `~/.trusty-mpm/config.toml`** (TOML, matching Rust/Cargo
+conventions). This is the single source of configuration truth for the Rust harness,
+covering `[agents]`, `[skills]`, `models.agents.*`, and any future `[registry]` sources.
+
+> **Stale artifact.** `PM_INSTRUCTIONS.md` references `~/.trusty-mpm/config.yaml` for
+> per-agent model overrides. That path is a documentation artifact from the Python-era
+> `claude-mpm` harness and has never been read by Rust code. It must be corrected to
+> `config.toml` in a future pass over `PM_INSTRUCTIONS.md`. All design and spec references
+> use `config.toml` as canonical.
+
 | File | Read by | Status |
 |---|---|---|
 | `~/.trusty-mpm/framework/hooks/optimizer.toml` | daemon (`OptimizerConfig`, hot-reloaded by the watcher) | Implemented |
 | `~/.trusty-mpm/framework/hooks/overseer.toml` | daemon (`OverseerConfig`; `[llm]` section gates LLM overseer) | Implemented |
 | `~/.claude-mpm/services.yaml` | `tm services` (`ServicesManifest`; embedded `assets/default-services.yaml` fallback) | Implemented |
-| `~/.trusty-mpm/config.yaml` `models.agents.*` | (intended) per-agent model overrides | **Partial** — referenced in `PM_INSTRUCTIONS.md`, not read by Rust |
-| `config.toml [agents] sources` | (intended) remote registry sources | **Stub** — never read |
+| `~/.trusty-mpm/config.toml` `models.agents.*` | (intended) per-agent model overrides | **Partial** — `config.toml` is canonical; the reference in `PM_INSTRUCTIONS.md` to `config.yaml` is a stale documentation artifact to be corrected; no Rust code currently reads model overrides from either path |
+| `~/.trusty-mpm/config.toml` `[agents] sources` | (intended) remote registry sources | **Stub** — never read |
 
 Environment: `TRUSTY_MPM_URL` (client base URL), `TRUSTY_MPM_ADDR` (daemon bind),
 `TRUSTY_MPM_TAILSCALE`, `OPENROUTER_API_KEY` (LLM overseer/chat), `RUST_LOG`,
@@ -448,10 +466,10 @@ Prioritized; each tagged with status + severity (impact on the product vision).
 | 3 | **Remote agent registry** (`Origin::Registry`, `registry/` path, `config.toml [agents]`, fetch/TTL/offline). | Stub | **Medium** | Forward-compat only. Blocks distributing agents without a source checkout/bundled assets. |
 | 4 | **`tm install` does not deploy skills** (only agents); skills deploy on session start. | Partial / Gap | **Medium** | A user who runs `install` then inspects `~/.claude/skills/` finds it empty until first launch. |
 | 5 | **Frontmatter parser truncates `:`-containing values; two divergent parser copies; no `model:`-injection workaround.** | Partial / Defect | **Medium** | Risks dropping/garbling agent metadata (esp. descriptions). Consolidate on one parser; round-trip test colon values. |
-| 6 | **Model-selection per-agent overrides** (`~/.trusty-mpm/config.yaml models.agents.*`) advertised, not read by Rust. | Partial | **Low–Medium** | Advisory-only today; instruction text implies enforcement. |
+| 6 | **Model-selection per-agent overrides** (`~/.trusty-mpm/config.toml models.agents.*`) intended but not read by Rust. The `PM_INSTRUCTIONS.md` reference to `config.yaml` is a stale artifact — `config.toml` is canonical. | Partial | **Low–Medium** | Advisory-only today; instruction text implies enforcement. Correct `PM_INSTRUCTIONS.md` to reference `config.toml`. |
 | 7 | **`PM_INSTRUCTIONS_VERSION` marker** present but inert (no upgrade gating). | Stub | **Low** | Needed if/when instruction-version migration is built. |
-| 8 | **Memory routing breadth**: kuzu-memory backend + static `.claude-mpm/memories` fallback described but only trusty-memory MCP/hook wiring exists. | Not-started | **Low** | trusty-memory path works; alternates unbuilt. |
-| 9 | **PM-behaviour circuit breakers (CB#1–#14)** are instruction-driven inside the session; the daemon tracks only a per-agent failure breaker. | Partial | **Low** | Matches claude-mpm (breakers are PM self-discipline), but daemon-side enforcement/audit of CB violations is not implemented. |
+| 8 | **kuzu-memory / static `.claude-mpm/memories`**: these were Python-era `claude-mpm` concepts. `trusty-memory` (MCP) is the sole intended memory backend. | **Out of scope** | N/A | Not a gap — explicitly excluded. trusty-memory MCP wiring is fully implemented. |
+| 9 | **PM-behaviour circuit breakers (CB#1–#14)** are currently instruction-driven inside the session; the daemon tracks only a per-agent failure breaker. Daemon-side hook-driven hard enforcement is an **intended future requirement** (FR-PM-2b). | Not-started | **Medium** | The per-agent `CircuitBreaker` in `core/circuit.rs` and the `POST /hooks` enforcement point are the partial foundation. Implementing CB#1–#14 detection + 403 return in `HookService::process` would close this gap. |
 | 10 | **Per-session file tracking** (issue #94) — no daemon endpoint. | Not-started / Planned | **Low** | Would let the daemon observe the PM's git-file-tracking protocol. |
 
 ---

--- a/docs/trusty-mpm/research/prd-2026-05-29.md
+++ b/docs/trusty-mpm/research/prd-2026-05-29.md
@@ -112,6 +112,10 @@ Claude Code session running on that host.
   LLM overseer/chat that reuses OpenRouter credentials.
 - **Not a replacement for the user's own `~/.claude/` files.** Deployment is ownership-aware
   and never clobbers user-authored or user-edited files.
+- **kuzu-memory backend and static `.claude-mpm/memories` fallback are out of scope.**
+  These were Python-era `claude-mpm` concepts. The Rust harness uses `trusty-memory` (MCP)
+  as its sole intended memory backend. These alternatives are not requirements — not
+  Not-started, not future work — they are explicitly excluded from scope.
 
 ---
 
@@ -143,11 +147,12 @@ implementation diverges, the divergence is described inline.
 | Req | Intent | Status |
 |---|---|---|
 | FR-PM-1 | PM delegates all work to specialist agents; default = delegate, exception only on explicit "you do it". | **Implemented** (instruction asset; `PM_INSTRUCTIONS.md`). |
-| FR-PM-2 | Circuit breakers (3-strike: WARNING → ESCALATION → FAILURE) block forbidden PM actions (Edit/Write, `curl`/`lsof`/`ps`/`make`, browser tools, `gh`, `sed`/`awk`, etc.). | **Partial** — the *policy* is fully specified in instructions and the daemon tracks a per-agent `CircuitBreaker` with a 3-failure threshold (`core/circuit.rs`, `state.rs:record_outcome`); enforcement of the *PM-behaviour* breakers (CB#1–#14) is instruction-driven inside the session, not daemon-enforced. |
+| FR-PM-2 | Circuit breakers (3-strike: WARNING → ESCALATION → FAILURE) block forbidden PM actions (Edit/Write, `curl`/`lsof`/`ps`/`make`, browser tools, `gh`, `sed`/`awk`, etc.). CURRENT: instruction-driven PM self-discipline. INTENDED: daemon-side hook-driven hard enforcement. | **Partial** — the *policy* is fully specified in instructions and the daemon tracks a per-agent `CircuitBreaker` with a 3-failure threshold (`core/circuit.rs`, `state.rs:record_outcome`); enforcement of the *PM-behaviour* breakers (CB#1–#14) is currently instruction-driven inside the session, not daemon-enforced. Daemon-side enforcement (hook-driven hard blocks) is an intended future requirement — see FR-PM-2b. |
+| FR-PM-2b | **Daemon-enforced circuit breakers**: the daemon detects CB#1–#14 violations from hook events and returns HTTP 403 (hard block) before the forbidden tool runs. The per-agent failure breaker in `core/circuit.rs` is the partial foundation. | **Not-started** — designed as an extension of the existing hook-relay enforcement point (`POST /hooks` / `HookService::process`); per-agent `CircuitBreaker` tracking already in place. |
 | FR-PM-3 | Verification gates: "done" claims require evidence (file paths, commit hash, QA repro/verify, live health). | **Implemented** (instruction asset; `WORKFLOW.md` + `PM_INSTRUCTIONS.md` Verification Gates). |
 | FR-PM-4 | 5-phase workflow (Research → Code Analysis → Implementation → QA → Documentation) with documented skip rules. | **Implemented** (instruction asset). |
 | FR-PM-5 | Autonomous execution — PM runs the full pipeline without nanny-checking; asks the user only below ~90% success probability. | **Implemented** (instruction asset). |
-| FR-PM-6 | Model-selection protocol (haiku/sonnet/opus tiers, per-agent overrides via config). | **Partial** — fully specified in instructions; per-agent overrides reference `~/.trusty-mpm/config.yaml` `models.agents.*`, but no Rust code reads that file (advisory only). |
+| FR-PM-6 | Model-selection protocol (haiku/sonnet/opus tiers, per-agent overrides via `~/.trusty-mpm/config.toml`). | **Partial** — fully specified in instructions; per-agent overrides are intended to be read from `~/.trusty-mpm/config.toml` (`models.agents.*`), but no Rust code currently reads that key. The reference to `config.yaml` in `PM_INSTRUCTIONS.md` is a stale documentation artifact — `config.toml` is the canonical config file (TOML, matching Rust/Cargo conventions). |
 | FR-PM-7 | Optional LLM overseer that evaluates hook events (allow/block/respond/flag) and an interactive coordinator chat. | **Implemented** — `DeterministicOverseer` + optional `CompositeOverseer` (LLM) built from `overseer.toml`; `POST /llm/chat` (`state.rs:202-274`, `api.rs:977-1012`). Disabled by default; opt-in via framework policy + OpenRouter key. |
 
 ### 5.2 Agent System
@@ -184,8 +189,13 @@ implementation diverges, the divergence is described inline.
 
 | Req | Intent | Status |
 |---|---|---|
-| FR-MEM-1 | Recall before research/delegation; remember findings immediately (trusty-memory / kuzu-memory MCP backends + static `.claude-mpm/memories` fallback). | **Partial** — the *policy* is in instructions (`BASE_PM.md` "Trusty Tool Priority"); trusty-mpm *wires* it by injecting the `trusty-memory` MCP server into the project `.mcp.json` and writing `trusty-memory hooks fire …` into project `.claude/settings.json` (`session_launch.rs:286-450`). No kuzu-memory wiring and no static `.claude-mpm/memories` fallback is implemented in Rust. |
+| FR-MEM-1 | Recall before research/delegation; remember findings immediately via the **trusty-memory MCP backend** (sole intended backend for the Rust harness). | **Implemented** — the *policy* is in instructions (`BASE_PM.md` "Trusty Tool Priority"); trusty-mpm *wires* it by injecting the `trusty-memory` MCP server into the project `.mcp.json` and writing `trusty-memory hooks fire …` into project `.claude/settings.json` (`session_launch.rs:286-450`). |
 | FR-MEM-2 | Per-session context-window pressure tracking with warn/alert/compact classification. | **Implemented** — `memory_protect` MCP tool + `DaemonState::record_memory` → `MemoryPressure` (`state.rs:733-741`, `mcp/tools.rs:78-99`). |
+
+> **Non-Goal — kuzu-memory and static `.claude-mpm/memories` fallback.** These were concepts
+> from the Python-era `claude-mpm` harness. They are **explicitly out of scope** for the Rust
+> harness. `trusty-memory` (MCP) is the sole intended memory backend. Do not treat kuzu-memory
+> or static-file fallback as Not-started requirements — they are out-of-scope by design.
 
 ### 5.6 Hook Handling
 
@@ -282,15 +292,16 @@ implementation diverges, the divergence is described inline.
 | CLI / TUI / Telegram / coordinator / GUI | **Implemented** |
 | `tm services` discovery | **Implemented** |
 | Optional LLM overseer + coordinator chat | **Implemented** (opt-in) |
-| PM-behaviour circuit breakers (CB#1–#14) daemon-enforced | **Partial** (instruction-driven; daemon tracks per-agent breakers only) |
-| Model-selection per-agent overrides (`config.yaml`) | **Partial** (advisory; not read by Rust) |
+| PM-behaviour circuit breakers (CB#1–#14) — instruction-driven | **Partial** (policy in instructions; daemon tracks per-agent failure breaker only) |
+| Daemon-enforced circuit breakers (CB#1–#14 hook-driven hard blocks) | **Not-started** (intended future requirement; FR-PM-2b) |
+| Model-selection per-agent overrides (`config.toml`) | **Partial** (advisory; not read by Rust; `config.yaml` reference in PM_INSTRUCTIONS.md is a stale artifact — `config.toml` is canonical) |
 | `tm install` deploys skills (not just agents) | **Partial / Gap** |
 | Project override system (`.trusty-mpm/*.md`, 5 files) | **Not-started (divergent)** — documented in `BASE_PM.md`, unread |
 | 3-level agent precedence | **Not-started (divergent)** — documented, single source/target only |
 | Remote agent registry (fetch/TTL/offline) | **Stub** — `Origin::Registry` + `registry` path only |
 | `PM_INSTRUCTIONS_VERSION` gating | **Stub** — marker inert |
 | Frontmatter parser robustness (`:` truncation, dual parsers, model-bug workaround) | **Partial / Defect** |
-| kuzu-memory backend / static `.claude-mpm/memories` fallback | **Not-started** |
+| kuzu-memory / static `.claude-mpm/memories` | **Out of scope** — Python-era concepts; trusty-memory MCP is the sole intended backend |
 
 See [architecture-spec-2026-05-29.md §12](architecture-spec-2026-05-29.md) for the
 prioritized gaps-and-deviations list with severities.

--- a/docs/trusty-mpm/research/prd-2026-05-29.md
+++ b/docs/trusty-mpm/research/prd-2026-05-29.md
@@ -1,0 +1,296 @@
+# trusty-mpm — Product Requirements Document (Reconstructed)
+
+**Date**: 2026-05-29
+**Status**: Reconstructed — Draft for review
+**Crate**: `crates/trusty-mpm` (version `0.5.0`, edition 2024, `publish = false`)
+**Companion spec**: [architecture-spec-2026-05-29.md](architecture-spec-2026-05-29.md)
+**Sources**: reconstructed from source code, embedded heritage assets, and a 2026-05-29 core-feature code review.
+
+> **How to read this document.** This PRD recovers the *original product intent* for
+> trusty-mpm and annotates each requirement with its *current implementation status*.
+> Where intent and implementation diverge, the divergence is called out explicitly with
+> a status tag (Implemented / Partial / Stub / Not-started). Documented-but-unbuilt
+> capabilities are treated as **intended scope that is not yet built**, not as features
+> to omit — recovering the full design surface is the point.
+
+---
+
+## 1. Vision & Summary
+
+> **North star.** trusty-mpm is a **Rust reimplementation of the `claude-mpm`
+> meta-harness**. It runs as a **single daemon instance per machine** that
+> **coordinates multiple processes** — multiple Claude Code sessions/agents — and
+> ships as a **single binary** (`tm` / `trusty-mpm`) with a bundled daemon, MCP
+> server, TUI, and Telegram bot.
+
+trusty-mpm replaces the Python `claude-mpm` project (a PM-orchestrator harness layered
+on top of Claude Code) with a native Rust platform. Where claude-mpm spawned a fresh
+Python interpreter for every hook invocation and stored its framework in
+`~/.claude-mpm/`, trusty-mpm runs one resident daemon (`trusty-mpmd`) that:
+
+- **enforces single-instance-per-machine** via a lock file + health probe + port bind
+  guard (`crates/trusty-mpm/src/bin/tm.rs:3147-3171`, `crates/trusty-mpm/src/daemon/lock.rs`);
+- **spawns, tracks, and coordinates multiple Claude Code session processes** through an
+  HTTP API + session registry (`crates/trusty-mpm/src/daemon/state.rs:80-162`,
+  `crates/trusty-mpm/src/daemon/api.rs:72-127`);
+- **carries the claude-mpm product model** — a PM orchestrator that delegates all work to
+  specialist agents, gated by circuit breakers, verification gates, a 5-phase workflow,
+  memory routing, and hooks — embedded as compile-time instruction assets
+  (`crates/trusty-mpm/src/assets/instructions/`).
+
+The "trusty-mpm" behaviour is **not** a forked `claude` binary: every session is a plain
+`claude` (Claude Code CLI) process whose PM identity is supplied through deployed agents,
+deployed skills, a project `CLAUDE.md`, and an assembled system prompt passed via
+`claude --append-system-prompt-file` (`crates/trusty-mpm/src/core/session_launch.rs:1-13,541-579`).
+
+---
+
+## 2. Background & Motivation
+
+### 2.1 What `claude-mpm` (Python) is
+
+`claude-mpm` is a meta-harness around Claude Code that turns a single `claude` session
+into a **Project Manager (PM)** orchestrator. The PM never edits code directly; it
+delegates to specialized sub-agents (Engineer, Research, QA, Local Ops, Documentation,
+Version Control, Security, Planner) and enforces discipline through:
+
+- **Circuit breakers** — a 3-strike model (WARNING → ESCALATION → FAILURE) that blocks
+  the PM from doing forbidden work itself (editing files, running `curl`/`lsof`/`make`,
+  using browser tools, etc.).
+- **Verification gates** — claims of "done" require agent-provided evidence (file paths,
+  commit hashes, QA repro/verify, live health checks).
+- **A 5-phase workflow** — Research → Code Analysis → Implementation → QA → Documentation,
+  with explicit skip rules for simple tasks.
+- **Memory routing** — recall before research; remember findings immediately.
+- **Hooks** — Claude Code lifecycle hooks feed an observability + enforcement pipeline.
+- **Skills** — on-demand PM behaviours loaded from `.claude/skills/`.
+- **Agent deployment** — agents distributed from a remote registry, cached locally, and
+  deployed into `~/.claude/agents/` with a documented 3-level precedence.
+
+### 2.2 Why a Rust rewrite
+
+| Driver | claude-mpm (Python) | trusty-mpm (Rust) |
+|---|---|---|
+| **Per-machine coordination** | one PM session, no cross-session view | one resident daemon coordinating *all* sessions on the host |
+| **Process model** | fresh Python process per hook fire | single long-lived daemon; hooks are thin HTTP forwarders |
+| **Distribution** | `pip install` + Python runtime | single `cargo install` binary, no runtime |
+| **Performance** | interpreter startup per hook | resident process, sub-millisecond hook ingest |
+| **Offline operation** | depends on remote registry fetches | bundled framework assets compiled into the binary |
+| **Observability** | per-session logs | host-wide session registry, SSE event feed, TUI, Telegram |
+
+The single-binary, single-daemon, offline-capable design is the throughline: trusty-mpm
+is meant to be the **one process per machine** that knows about and coordinates every
+Claude Code session running on that host.
+
+---
+
+## 3. Goals / Non-Goals
+
+### 3.1 Goals
+
+1. **One daemon per machine** that coordinates multiple Claude Code session processes.
+2. **Single-binary distribution** — `cargo install trusty-mpm` yields `tm`/`trusty-mpm`
+   with the daemon, MCP server, TUI, and Telegram bot bundled behind feature flags.
+3. **Faithful port of the claude-mpm PM product model** — delegation, circuit breakers,
+   verification gates, 5-phase workflow, autonomous execution, memory routing.
+4. **Agent + skill system** with inheritance (`extends:`), idempotent checksum-guarded
+   deployment, and (intended) remote registry distribution.
+5. **Customizable, layered instruction assembly** — framework floor + project overrides.
+6. **Full observability** — host-wide session registry, hook relay, live event stream,
+   circuit-breaker views, TUI dashboard, remote Telegram management.
+7. **Offline-first** — the framework ships embedded in the binary; no network needed to
+   launch a configured session.
+8. **Canonical service discovery** (`tm services`) replacing ad-hoc `lsof`/`curl`/`ps`.
+
+### 3.2 Non-Goals
+
+- **Not a fork of Claude Code.** trusty-mpm always launches the stock `claude` binary;
+  it shapes behaviour through instructions/agents/skills/MCP, never by patching `claude`.
+- **Not a multi-machine orchestrator.** The coordination boundary is one host. (Telegram
+  remote management is operator access, not cross-host coordination.)
+- **Not an LLM provider.** Model selection is advisory (PM instructions) plus an optional
+  LLM overseer/chat that reuses OpenRouter credentials.
+- **Not a replacement for the user's own `~/.claude/` files.** Deployment is ownership-aware
+  and never clobbers user-authored or user-edited files.
+
+---
+
+## 4. Target Users & Use Cases
+
+**Primary user**: a developer (or small team on one workstation) running one or more
+orchestrated Claude Code sessions, who wants PM-driven delegation discipline and a
+single pane of glass over every active session.
+
+| Use case | Flow |
+|---|---|
+| Launch a configured PM session | `tm launch` deploys agents/skills/instructions + MCP config into the project, then starts `claude` as a PM (`tm.rs` `Launch`, `session_launch::prepare_session`). |
+| Attach without re-deploying | `tm connect` / `tm attach` start or attach to a tmux-hosted session with no framework deployment. |
+| See every session on the host | `tm tui` (ratatui dashboard) or `tm status`; the daemon's session registry tracks tmux + native sessions. |
+| Drive a session remotely | `tm telegram` — pair a phone, inspect sessions, send commands, receive push alerts. |
+| Enforce delegation discipline | Embedded PM instructions + circuit breakers + verification gates shape the PM's behaviour; the daemon audits hook events. |
+| Inspect orchestration state from inside a session | MCP tools (`session_list`, `agent_delegate`, `memory_protect`, `circuit_breaker_status`, `hook_event`, `session_status`). |
+| Answer "is service X running, on what port?" | `tm services` reads a YAML manifest and probes daemons. |
+
+---
+
+## 5. Functional Requirements
+
+Each capability area lists the **intended** requirement and a **status** tag. Where
+implementation diverges, the divergence is described inline.
+
+### 5.1 PM Orchestration Model
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-PM-1 | PM delegates all work to specialist agents; default = delegate, exception only on explicit "you do it". | **Implemented** (instruction asset; `PM_INSTRUCTIONS.md`). |
+| FR-PM-2 | Circuit breakers (3-strike: WARNING → ESCALATION → FAILURE) block forbidden PM actions (Edit/Write, `curl`/`lsof`/`ps`/`make`, browser tools, `gh`, `sed`/`awk`, etc.). | **Partial** — the *policy* is fully specified in instructions and the daemon tracks a per-agent `CircuitBreaker` with a 3-failure threshold (`core/circuit.rs`, `state.rs:record_outcome`); enforcement of the *PM-behaviour* breakers (CB#1–#14) is instruction-driven inside the session, not daemon-enforced. |
+| FR-PM-3 | Verification gates: "done" claims require evidence (file paths, commit hash, QA repro/verify, live health). | **Implemented** (instruction asset; `WORKFLOW.md` + `PM_INSTRUCTIONS.md` Verification Gates). |
+| FR-PM-4 | 5-phase workflow (Research → Code Analysis → Implementation → QA → Documentation) with documented skip rules. | **Implemented** (instruction asset). |
+| FR-PM-5 | Autonomous execution — PM runs the full pipeline without nanny-checking; asks the user only below ~90% success probability. | **Implemented** (instruction asset). |
+| FR-PM-6 | Model-selection protocol (haiku/sonnet/opus tiers, per-agent overrides via config). | **Partial** — fully specified in instructions; per-agent overrides reference `~/.trusty-mpm/config.yaml` `models.agents.*`, but no Rust code reads that file (advisory only). |
+| FR-PM-7 | Optional LLM overseer that evaluates hook events (allow/block/respond/flag) and an interactive coordinator chat. | **Implemented** — `DeterministicOverseer` + optional `CompositeOverseer` (LLM) built from `overseer.toml`; `POST /llm/chat` (`state.rs:202-274`, `api.rs:977-1012`). Disabled by default; opt-in via framework policy + OpenRouter key. |
+
+### 5.2 Agent System
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-AG-1 | Agents declare `extends:` frontmatter; chains are flattened at build time into self-contained files (Claude Code has no native inheritance). | **Implemented** — `compose_agent` walks the chain base-first, merges frontmatter child-wins, with cycle + depth(8) guards (`core/agent_builder.rs`). |
+| FR-AG-2 | All agents inherit a `BASE_AGENT` (git workflow, memory routing, output format, handoff, proactive quality). | **Implemented** — `BASE-AGENT.md` + `BASE-ENGINEER.md`/`BASE-OPS.md`/`BASE-QA.md`/`BASE-RESEARCH.md` assets; e.g. `engineer → base-engineer → base-agent`. |
+| FR-AG-3 | Deployment is idempotent, checksum-guarded, manifest-tracked: never clobber user-owned or user-edited files. | **Implemented** — `deploy_agents` + `AgentManifest` (sha256 checksums, origin, source chain) into `~/.claude/agents/` (`core/agent_deployer.rs`, `core/agent_manifest.rs`). |
+| FR-AG-4 | 3-level agent precedence: project `.claude/agents/` > user `~/.claude-mpm/agents/` > cached remote (`bobmatnyc/claude-mpm-agents`). | **Not-started (divergent)** — *intended* per `PM_INSTRUCTIONS.md` "Agent Deployment". Implementation has exactly **one source** (`framework/agents/` or the `agents/` submodule) and **one target** (`~/.claude/agents/`). No precedence resolution exists. |
+| FR-AG-5 | Remote agent registry: pull agents from a registry with fetch/TTL/offline-cache semantics; record `Origin::Registry`. | **Stub** — `Origin::Registry` is a forward-compat enum variant only (`agent_manifest.rs:36-43`); `FrameworkPaths::registry` resolves `~/.trusty-mpm/registry` but nothing fetches into it. No `config.toml [agents] sources`, no TTL, no offline logic. |
+| FR-AG-6 | `tm install` deploys both agents and skills to the framework. | **Partial (gap)** — `tm install` deploys agents; **skills deploy only on session start** (`prepare_session`), not at install time. |
+| FR-AG-7 | Robust agent frontmatter parsing. | **Partial (defect)** — the in-house parser splits on the first `:` and truncates values containing additional colons; two divergent parser copies exist (`agent_builder.rs` and the gray_matter-based path); no workaround for the Claude Code frontmatter `model:` injection bug. |
+
+### 5.3 Skills System
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-SK-1 | Skills are on-demand PM behaviours deployed to `~/.claude/skills/` as plain content (no inheritance). | **Implemented** — `deploy_skills` + `SkillManifest` (`core/skill_deployer.rs`, `core/skill_manifest.rs`). |
+| FR-SK-2 | Skill deployment is manifest-tracked and ownership-aware, identical to agents. | **Implemented**. |
+| FR-SK-3 | Skills deploy at install time alongside agents. | **Partial (gap)** — see FR-AG-6: skills currently deploy only on session start. |
+
+### 5.4 Instruction Assembly & Customization
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-IN-1 | Every launched session receives identical, version-controlled PM instructions. | **Implemented** — compile-time `include_str!` concat of `PM_INSTRUCTIONS → WORKFLOW → AGENT_DELEGATION → BASE_PM` (`instruction_pipeline.rs:31-53`), written to `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md` and passed via `--append-system-prompt-file`. |
+| FR-IN-2 | `BASE_PM` is the non-overridable framework floor, appended last. | **Implemented**. |
+| FR-IN-3 | The runtime merge pipeline composes framework + delegation authority + project `CLAUDE.md` (sections 3→4→5). | **Implemented** — `build_instructions` (`instruction_pipeline.rs:163-204`); delegation authority is generated from the deployed agents at launch. |
+| FR-IN-4 | Project override system: `.trusty-mpm/INSTRUCTIONS.md`, `AGENT_DELEGATION.md`, `WORKFLOW.md`, `MEMORY.md`, `PM_INSTRUCTIONS_DEPLOYED.md` customize/replace PM behaviour. | **Not-started (divergent)** — `BASE_PM.md:17-33` advertises this 5-file override system and trigger phrases, but **no Rust code reads these files**. The only project-level input the pipeline reads is `CLAUDE.md`. |
+| FR-IN-5 | `PM_INSTRUCTIONS_VERSION` marker gates instruction upgrades. | **Stub** — the marker exists (`PM_INSTRUCTIONS.md:1` = `0014`) but is inert; no version comparison or gating logic. |
+
+### 5.5 Memory Routing
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-MEM-1 | Recall before research/delegation; remember findings immediately (trusty-memory / kuzu-memory MCP backends + static `.claude-mpm/memories` fallback). | **Partial** — the *policy* is in instructions (`BASE_PM.md` "Trusty Tool Priority"); trusty-mpm *wires* it by injecting the `trusty-memory` MCP server into the project `.mcp.json` and writing `trusty-memory hooks fire …` into project `.claude/settings.json` (`session_launch.rs:286-450`). No kuzu-memory wiring and no static `.claude-mpm/memories` fallback is implemented in Rust. |
+| FR-MEM-2 | Per-session context-window pressure tracking with warn/alert/compact classification. | **Implemented** — `memory_protect` MCP tool + `DaemonState::record_memory` → `MemoryPressure` (`state.rs:733-741`, `mcp/tools.rs:78-99`). |
+
+### 5.6 Hook Handling
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-HK-1 | A thin hook forwarder posts every Claude Code lifecycle event to the daemon (replacing claude-mpm's per-fire Python process). | **Implemented** — `tm hook` posts a `hook_event` to the daemon and exits 0; degrades silently on daemon-down (`tm.rs` `Hook`; short-circuits when `CLAUDE_MPM_SUB_AGENT=1`). |
+| FR-HK-2 | Universal hook relay endpoint ingests events, drives the overseer, compresses output, and feeds observability. | **Implemented** — `POST /hooks` (`api.rs:904-953`): auto-registers a session on `SessionStart`, runs the overseer on tool-use (Block → 403), compresses `PostToolUse` output, appends to the ring buffer, broadcasts via SSE. |
+| FR-HK-3 | Project-scoped memory hooks (PostToolUse/Stop/UserPromptSubmit) written into project settings; global duplicates removed. | **Implemented** — `write_project_hooks` + `remove_global_trusty_memory_hooks` (`session_launch.rs:286-539`). |
+
+### 5.7 Session / Process Lifecycle
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-SES-1 | Register/spawn a session, track its tmux name + `claude` PID, list/get/remove. | **Implemented** — `POST /sessions` (register or, with `workdir`, spawn), `GET /sessions[/{id}]`, `DELETE /sessions/{id}`, `PATCH /sessions/{id}/pid` (`api.rs:272-503`). |
+| FR-SES-2 | Auto-discover existing Claude Code sessions (tmux panes + native Terminal.app `ps`) without a manual adopt. | **Implemented** — `discovery::discover_all` at boot and via `POST /sessions/discover` (`daemon/mod.rs:86-92`, `api.rs:505-528`). |
+| FR-SES-3 | Pause/resume with a "where I left off" note that survives restart. | **Implemented** — `POST /sessions/{id}/pause|resume` + `session_store` disk persistence (`api.rs:667-726`). |
+| FR-SES-4 | Send commands to a session's tmux pane and capture pane output (with optional compression). | **Implemented** — `POST /sessions/{id}/command`, `GET /sessions/{id}/output|pane` (`api.rs:755-865`). |
+| FR-SES-5 | Reap dead sessions (tmux gone → remove; tmux alive but `claude` PID dead → mark Stopped); keep native sessions. | **Implemented** — periodic `reap_loop` + `DELETE /sessions/dead` + `reap_against` (`daemon/mod.rs:128-152`, `state.rs:564-634`). |
+
+### 5.8 Single-Daemon Coordination
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-CO-1 | Exactly one daemon per machine; a second start is refused. | **Implemented** — lock-file URL + `/health` probe guard, plus `AddrInUse` ephemeral fallback (`tm.rs:3147-3171`). |
+| FR-CO-2 | Clients discover the daemon's actual address via the lock file (`~/.trusty-mpm/daemon.lock`). | **Implemented** — `lock::write_lock`/`remove_lock` + `resolve_daemon_url` (validates recorded PID, clears stale locks) (`daemon/lock.rs`, `core/connect.rs`). |
+| FR-CO-3 | One shared `DaemonState` is the single source of truth for sessions, delegations, breakers, memory, hook history, projects. | **Implemented** — `Arc<DaemonState>` injected into every handler + the MCP backend (`state.rs:72-162`). |
+| FR-CO-4 | Cross-session coordinator: an operator can chat with the daemon (full session context) or route a command at a named session. | **Implemented** — `GET/POST /api/v1/coordinator/*` + `tm coordinator` (`api.rs:98-99`, coordinator routes module). |
+
+### 5.9 Interfaces
+
+| Interface | Intent | Status |
+|---|---|---|
+| CLI (`tm`/`trusty-mpm`) | One unified binary: daemon control, sessions, projects, launch/connect/attach, optimizer/overseer, coordinator, services, install, hook, TUI, Telegram, GUI. | **Implemented** — full `Command` enum (`tm.rs:38-197`). |
+| Daemon HTTP API | Loopback JSON API for CLI/TUI/Telegram/GUI + hook relay + SSE. | **Implemented** — see §7 of the spec. |
+| MCP server (stdio) | Six orchestration tools exposed to a Claude Code session. | **Implemented** — `session_list`, `session_status`, `agent_delegate`, `memory_protect`, `circuit_breaker_status`, `hook_event` (`mcp/tools.rs`). |
+| TUI | ratatui multi-session dashboard polling the daemon. | **Implemented** — `tui` module (feature `tui`). |
+| Telegram | Remote management bot (pair, sessions, commands, push alerts). | **Implemented** — `telegram` module (feature `telegram`). |
+| GUI | Tauri desktop app (separate `trusty-mpm-gui` crate, optional `gui` feature). | **Implemented (out-of-crate)** — wrapped as an optional dependency. |
+
+### 5.10 Service Discovery (`tm services`)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-SVC-1 | A canonical `tm services` CLI (list/status/port/url/health/log/init/restart) backed by a YAML manifest, replacing `lsof`/`curl`/`ps`. | **Implemented** — `services` module + `assets/default-services.yaml`; eight subcommands with `--json` and spec exit codes (`tm.rs:178-196`). See [tm-services-discovery-spec-2026-05-28.md](tm-services-discovery-spec-2026-05-28.md). |
+
+---
+
+## 6. Non-Functional Requirements
+
+| NFR | Requirement | Status |
+|---|---|---|
+| NFR-1 | **Single binary / single install** — `cargo install trusty-mpm` installs everything; feature gates (`cli` → `daemon`+`tui`+`telegram`; `daemon` → `mcp`). | Implemented (`Cargo.toml` `[features]`, `[[bin]]`). |
+| NFR-2 | **MSRV 1.88**, **edition 2024** (let-chains). | Implemented (workspace-shared). |
+| NFR-3 | **No `unwrap()` in library code** — `thiserror` for libs, `anyhow` for binaries. | Implemented (typed errors: `AgentBuildError`, `PrepError`, `PipelineError`, `DaemonError`). |
+| NFR-4 | **stderr-only logging** — stdout reserved for MCP JSON-RPC framing. | Implemented. |
+| NFR-5 | **Idempotent deploys** — re-running install/launch never duplicates or clobbers; checksum-guarded. | Implemented (`prepare_session_is_idempotent`, manifest checks). |
+| NFR-6 | **Single-instance enforcement** per machine. | Implemented (FR-CO-1/2). |
+| NFR-7 | **Offline-capable** — framework assets compiled into the binary; no network required to launch. | Implemented (all instruction/agent/skill assets are `include_str!` / bundled); the remote-registry path that would *add* network is unbuilt (FR-AG-5). |
+| NFR-8 | **500-line file cap** per source file. | Largely held (e.g. `api.rs` test module split into `api_tests.rs`); audit recommended. |
+
+---
+
+## 7. Success Metrics
+
+1. **One daemon, many sessions**: a single `trusty-mpmd` tracks ≥ N concurrent Claude Code
+   sessions (tmux + native) with accurate status and reaping.
+2. **Zero clobber**: deploy runs never overwrite a user-authored/edited agent or skill
+   (manifest tests pass; field reports of lost edits = 0).
+3. **Launch fidelity**: a `tm launch`ed session shows `style:trusty-mpm`, has the
+   trusty-memory MCP server + hooks wired, and receives the full PM system prompt.
+4. **Hook throughput**: hook events ingest without blocking the user's prompt even during
+   a daemon restart (silent degradation verified).
+5. **Single-install**: `cargo install trusty-mpm` produces a working `tm` with daemon + TUI
+   + Telegram, no extra runtime.
+6. **Offline launch**: launching a configured session with no network succeeds.
+
+---
+
+## 8. Implementation Status Snapshot
+
+| Capability | Status |
+|---|---|
+| Single-daemon-per-machine enforcement | **Implemented** |
+| Session registry + spawn/track/reap | **Implemented** |
+| Hook relay + overseer + SSE event feed | **Implemented** |
+| Agent inheritance (`extends:`) composition | **Implemented** |
+| Checksum-guarded, ownership-aware agent deploy | **Implemented** |
+| Checksum-guarded, ownership-aware skill deploy | **Implemented** |
+| Instruction assembly (4-asset compile-time concat) | **Implemented** |
+| Runtime merge pipeline (framework + delegation + CLAUDE.md) | **Implemented** |
+| trusty-memory MCP + hook wiring on launch | **Implemented** |
+| Per-session memory-pressure classification | **Implemented** |
+| MCP orchestration tools (6) | **Implemented** |
+| CLI / TUI / Telegram / coordinator / GUI | **Implemented** |
+| `tm services` discovery | **Implemented** |
+| Optional LLM overseer + coordinator chat | **Implemented** (opt-in) |
+| PM-behaviour circuit breakers (CB#1–#14) daemon-enforced | **Partial** (instruction-driven; daemon tracks per-agent breakers only) |
+| Model-selection per-agent overrides (`config.yaml`) | **Partial** (advisory; not read by Rust) |
+| `tm install` deploys skills (not just agents) | **Partial / Gap** |
+| Project override system (`.trusty-mpm/*.md`, 5 files) | **Not-started (divergent)** — documented in `BASE_PM.md`, unread |
+| 3-level agent precedence | **Not-started (divergent)** — documented, single source/target only |
+| Remote agent registry (fetch/TTL/offline) | **Stub** — `Origin::Registry` + `registry` path only |
+| `PM_INSTRUCTIONS_VERSION` gating | **Stub** — marker inert |
+| Frontmatter parser robustness (`:` truncation, dual parsers, model-bug workaround) | **Partial / Defect** |
+| kuzu-memory backend / static `.claude-mpm/memories` fallback | **Not-started** |
+
+See [architecture-spec-2026-05-29.md §12](architecture-spec-2026-05-29.md) for the
+prioritized gaps-and-deviations list with severities.


### PR DESCRIPTION
## Summary

Reconstructs the foundational **PRD** and **technical specification** for the
`trusty-mpm` crate, grounded in the actual source and embedded heritage assets, and
annotated with current implementation status from a 2026-05-29 core-feature code review.

These docs recover the **original product intent** — trusty-mpm as a Rust reimplementation
of the `claude-mpm` meta-harness that runs as a **single daemon per machine coordinating
multiple Claude Code session processes**, shipped as a single binary — while being honest
about what exists vs. what is intended-but-unbuilt.

### New files (under `docs/trusty-mpm/research/`)

- **`prd-2026-05-29.md`** — Product Requirements Document
  - Vision & summary (single-daemon north star), background/motivation (claude-mpm → Rust),
    goals/non-goals, target users & use cases.
  - Functional requirements by capability area: PM orchestration, agent system, skills,
    instruction assembly + override layering, memory routing, hooks, session/process
    lifecycle, single-daemon coordination, interfaces, service discovery.
  - Non-functional requirements (single-install, MSRV 1.88, edition 2024, no-unwrap,
    stderr logging, idempotent deploys, single-instance, offline).
  - Success metrics + an implementation-status snapshot table.

- **`architecture-spec-2026-05-29.md`** — Technical specification
  - ASCII component diagram; **process & coordination model** (single-instance
    enforcement via lock file + health probe + port bind; spawn/register/connection-driven
    session entry; the Arc<DaemonState> single source of truth; hook relay enforcement;
    SSE streaming; reaping).
  - Module breakdown, data model, instruction-assembly pipeline (4-asset concat + runtime
    3->4->5 merge vs. the intended .trusty-mpm/*.md override layer), agent/skill deployment
    (manifest/checksum vs. intended registry + 3-level precedence).
  - Full HTTP API table, MCP tool surface, filesystem layout, configuration, distribution
    (feature gates + [[bin]] targets), and a **prioritized gaps & deviations** list with
    Implemented/Partial/Stub/Not-started + severity.

- **`research/README.md`** index + parent `README.md` status update.

### Style
Matches `tm-services-discovery-spec-2026-05-28.md`: path:line source references and an
explicit **INTENDED vs CURRENT IMPLEMENTATION** distinction throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)