### PR TITLE
feat(trusty-mpm): implement project-level instruction override loading

### DIFF
--- a/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
+++ b/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
@@ -14,13 +14,21 @@ No cost-saving, "trivial change", or "documented command" exceptions.
 
 ## Customizing PM Behavior
 
+Override files live in the project's `.trusty-mpm/` directory and are read at
+session start. Relative to the project root:
+
 | User wants | File | Effect |
 |-----------|------|--------|
-| Project rules | `.trusty-mpm/INSTRUCTIONS.md` | Appended to PM prompt |
-| Agent routing | `.trusty-mpm/AGENT_DELEGATION.md` | Replaces routing table |
-| Workflow phases | `.trusty-mpm/WORKFLOW.md` | Replaces default workflow |
-| Memory behavior | `.trusty-mpm/MEMORY.md` | Replaces memory section |
-| Full PM replacement | `.trusty-mpm/PM_INSTRUCTIONS_DEPLOYED.md` | Replaces entire PM prompt |
+| Project rules | `.trusty-mpm/INSTRUCTIONS.md` | Appended (additive) to the PM prompt |
+| Agent routing | `.trusty-mpm/AGENT_DELEGATION.md` | Replaces the agent-delegation section |
+| Workflow phases | `.trusty-mpm/WORKFLOW.md` | Replaces the workflow section |
+| Memory behavior | `.trusty-mpm/MEMORY.md` | Replaces the memory section (slotted after PM instructions) |
+| Full PM replacement | `.trusty-mpm/PM_INSTRUCTIONS_DEPLOYED.md` | Replaces the entire PM body — **except** the BASE_PM floor below, which is always kept |
+
+**The BASE_PM floor is never overridable.** Even `PM_INSTRUCTIONS_DEPLOYED.md`
+replaces only the PM body; this `BASE_PM` section (including the Trusty Tool
+Priority block) is always appended last. Missing, empty, or unreadable override
+files fall back to the bundled defaults — they never blank a section.
 
 Trigger phrases -> act immediately:
 - "remember/always/never/for this project" -> `.trusty-mpm/INSTRUCTIONS.md`
@@ -30,7 +38,8 @@ Trigger phrases -> act immediately:
 
 After writing: confirm file path, note "takes effect at next session startup."
 Inspect: `ls .trusty-mpm/*.md 2>/dev/null`
-Full docs: `docs/customization/pm-override-system.md`
+Verify the resolved prompt: `tm session instructions` (or read
+`.trusty-mpm/last-instructions.md`).
 
 ## Trusty Tool Priority (Non-Overridable)
 

--- a/crates/trusty-mpm/src/bin/tm.rs
+++ b/crates/trusty-mpm/src/bin/tm.rs
@@ -1902,26 +1902,26 @@ async fn launch(client: &reqwest::Client, url: &str, dir: Option<String>) -> any
         }
     };
 
-    // Build the `--append-system-prompt` text (read from the file installed
-    // above) and write it to a temp file so `claude` reads it at startup.
-    let (claude_cmd, prompt_path) = match trusty_mpm::core::session_launch::build_system_prompt() {
-        Some(prompt) => {
-            let file = std::env::temp_dir().join(format!(
-                "trusty-mpm-system-prompt-{}.txt",
-                trusty_mpm::core::session::SessionId::new().0
-            ));
-            match std::fs::write(&file, &prompt) {
-                Ok(()) => (
-                    format!("claude --append-system-prompt-file {}", file.display()),
-                    Some(file),
-                ),
-                Err(err) => {
-                    eprintln!("warning: failed to write system prompt file: {err}");
-                    ("claude".to_string(), None)
-                }
+    // Build the `--append-system-prompt` text and write it to a temp file so
+    // `claude` reads it at startup. The prompt is resolved *for this project
+    // directory* so any override files under `<project>/.trusty-mpm/` take
+    // effect (issue #381); `build_system_prompt_for` always yields a prompt.
+    let prompt = trusty_mpm::core::session_launch::build_system_prompt_for(&path);
+    let (claude_cmd, prompt_path) = {
+        let file = std::env::temp_dir().join(format!(
+            "trusty-mpm-system-prompt-{}.txt",
+            trusty_mpm::core::session::SessionId::new().0
+        ));
+        match std::fs::write(&file, &prompt) {
+            Ok(()) => (
+                format!("claude --append-system-prompt-file {}", file.display()),
+                Some(file),
+            ),
+            Err(err) => {
+                eprintln!("warning: failed to write system prompt file: {err}");
+                ("claude".to_string(), None)
             }
         }
-        None => ("claude".to_string(), None),
     };
 
     // 5. Print the summary banner. The "Prompt:" line shows the canonical
@@ -2655,10 +2655,16 @@ fn compose_session_instructions(
     };
     let output = build_instructions(&input)?;
 
+    // Stash the *override-resolved* PM prompt — the exact text the launch path
+    // passes to `claude` — so `tm session instructions` shows what is actually
+    // used, including any project-level overrides under
+    // `<project>/.trusty-mpm/` (issue #381). Resolving via the shared
+    // `resolve_pm_prompt` keeps this stash and the live prompt identical.
+    let resolved_prompt = trusty_mpm::core::instruction_overrides::resolve_pm_prompt(project_dir);
     let stash_dir = project_dir.join(".trusty-mpm");
     std::fs::create_dir_all(&stash_dir)?;
     let stash = stash_dir.join("last-instructions.md");
-    std::fs::write(&stash, &output.merged)?;
+    std::fs::write(&stash, &resolved_prompt)?;
 
     Ok((output, stash))
 }

--- a/crates/trusty-mpm/src/client/http_client.rs
+++ b/crates/trusty-mpm/src/client/http_client.rs
@@ -1035,28 +1035,28 @@ impl DaemonClient {
             .await?;
 
         // Build the combined `--append-system-prompt` text (claude-mpm PM
-        // instructions + trusty tool-priority block). When present, write it to
-        // a temp file and pass it via `--append-system-prompt-file` so every
-        // launched `claude` is a properly configured PM instance while
-        // preserving Claude Code's built-in tool use instructions. The temp
-        // file persists because `claude` reads it at startup; it lives in
-        // `/tmp` and is superseded by the next launch — no explicit cleanup is
-        // performed.
-        let claude_cmd = match crate::core::session_launch::build_system_prompt() {
-            Some(prompt) => {
-                let path = std::env::temp_dir().join(format!(
-                    "trusty-mpm-system-prompt-{}.txt",
-                    uuid::Uuid::new_v4()
-                ));
-                match std::fs::write(&path, &prompt) {
-                    Ok(()) => format!("claude --append-system-prompt-file {}", path.display()),
-                    Err(err) => {
-                        tracing::warn!(%err, "failed to write system prompt file; launching bare claude");
-                        "claude".to_string()
-                    }
+        // instructions + trusty tool-priority block), resolved *for this project
+        // directory* so override files under `<workdir>/.trusty-mpm/` take effect
+        // (issue #381). Write it to a temp file and pass it via
+        // `--append-system-prompt-file` so every launched `claude` is a properly
+        // configured PM instance while preserving Claude Code's built-in tool use
+        // instructions. The temp file persists because `claude` reads it at
+        // startup; it lives in `/tmp` and is superseded by the next launch — no
+        // explicit cleanup is performed.
+        let prompt =
+            crate::core::session_launch::build_system_prompt_for(std::path::Path::new(workdir));
+        let claude_cmd = {
+            let path = std::env::temp_dir().join(format!(
+                "trusty-mpm-system-prompt-{}.txt",
+                uuid::Uuid::new_v4()
+            ));
+            match std::fs::write(&path, &prompt) {
+                Ok(()) => format!("claude --append-system-prompt-file {}", path.display()),
+                Err(err) => {
+                    tracing::warn!(%err, "failed to write system prompt file; launching bare claude");
+                    "claude".to_string()
                 }
             }
-            None => "claude".to_string(),
         };
 
         let new_session = std::process::Command::new("tmux")
@@ -1124,24 +1124,25 @@ impl DaemonClient {
             .await?;
 
         // Build the `--append-system-prompt` text so a freshly-started `claude`
-        // is a configured PM. This is prompt composition from bundled assets,
-        // not deployment of agents/skills/hooks into the project — `connect`
-        // only skips the latter (`prepare_session`).
-        let claude_cmd = match crate::core::session_launch::build_system_prompt() {
-            Some(prompt) => {
-                let path = std::env::temp_dir().join(format!(
-                    "trusty-mpm-system-prompt-{}.txt",
-                    uuid::Uuid::new_v4()
-                ));
-                match std::fs::write(&path, &prompt) {
-                    Ok(()) => format!("claude --append-system-prompt-file {}", path.display()),
-                    Err(err) => {
-                        tracing::warn!(%err, "failed to write system prompt file; launching bare claude");
-                        "claude".to_string()
-                    }
+        // is a configured PM, resolved *for this project directory* so override
+        // files under `<workdir>/.trusty-mpm/` take effect (issue #381). This is
+        // prompt composition from bundled assets + project overrides, not
+        // deployment of agents/skills/hooks into the project — `connect` only
+        // skips the latter (`prepare_session`).
+        let prompt =
+            crate::core::session_launch::build_system_prompt_for(std::path::Path::new(workdir));
+        let claude_cmd = {
+            let path = std::env::temp_dir().join(format!(
+                "trusty-mpm-system-prompt-{}.txt",
+                uuid::Uuid::new_v4()
+            ));
+            match std::fs::write(&path, &prompt) {
+                Ok(()) => format!("claude --append-system-prompt-file {}", path.display()),
+                Err(err) => {
+                    tracing::warn!(%err, "failed to write system prompt file; launching bare claude");
+                    "claude".to_string()
                 }
             }
-            None => "claude".to_string(),
         };
 
         // `tmux new-session -A` is idempotent: it attaches to the session when

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -1,0 +1,408 @@
+//! Project-level PM instruction overrides read from `<project>/.trusty-mpm/`.
+//!
+//! Why: `BASE_PM.md` advertises a "Customizing PM Behavior" table telling the PM
+//! it can drop override files into the project's `.trusty-mpm/` directory and
+//! that they take effect on the next session start. Historically *no code read
+//! them* — the system prompt was a fixed compile-time concatenation, so every
+//! advertised override was a silent no-op (issue #381). This module makes the
+//! advertised behaviour real: it resolves the override files at session-prepare
+//! time and layers them onto the bundled PM prompt per the documented
+//! append/replace semantics.
+//! What: [`resolve_pm_prompt`] reads up to five override files from
+//! `<project>/.trusty-mpm/` and produces the effective PM prompt, *always*
+//! appending the non-overridable `BASE_PM.md` floor last. The bundled assets are
+//! the defaults for any section that has no override.
+//! Test: the `tests` module exercises every documented file, the BASE_PM floor
+//! invariant, and the robustness fallbacks (missing/empty/unreadable files).
+
+use std::path::Path;
+
+use crate::core::instruction_pipeline::{
+    AGENT_DELEGATION, BASE_PM, PM_INSTRUCTIONS, SECTION_SEPARATOR, WORKFLOW,
+};
+
+/// Directory under the project root that holds the override files.
+///
+/// Why: the override files live alongside the inspectable instruction stash
+/// (`last-instructions.md`) that `prepare_session` already writes, so they share
+/// the project-local `.trusty-mpm/` directory documented in `BASE_PM.md`.
+/// What: the literal directory name, joined onto the project root.
+/// Test: every `resolve_*` test writes files under `<project>/.trusty-mpm/`.
+pub const OVERRIDE_DIR_NAME: &str = ".trusty-mpm";
+
+/// File name: full replacement of the PM instruction body (short-circuits).
+pub const FILE_PM_DEPLOYED: &str = "PM_INSTRUCTIONS_DEPLOYED.md";
+/// File name: replaces the bundled `AGENT_DELEGATION` section.
+pub const FILE_AGENT_DELEGATION: &str = "AGENT_DELEGATION.md";
+/// File name: replaces the bundled `WORKFLOW` section.
+pub const FILE_WORKFLOW: &str = "WORKFLOW.md";
+/// File name: replaces the memory guidance section.
+pub const FILE_MEMORY: &str = "MEMORY.md";
+/// File name: appended (additive) project rules.
+pub const FILE_INSTRUCTIONS: &str = "INSTRUCTIONS.md";
+
+/// Heading that delimits a `MEMORY.md` override block.
+///
+/// Why: there is no standalone bundled "memory" asset — the memory guidance is
+/// the "Context-First Protocol (MANDATORY)" subsection inside `PM_INSTRUCTIONS`.
+/// Rather than fragile surgical excision of that subsection, a `MEMORY.md`
+/// override is slotted in as a clearly-delimited replacement block placed
+/// immediately after `PM_INSTRUCTIONS` (and before `WORKFLOW`). The heading
+/// makes it unambiguous to a reader — and to the launched PM — that the project
+/// has overridden memory behaviour.
+/// What: the Markdown heading prepended to the `MEMORY.md` body when slotted.
+/// Test: `memory_override_is_slotted_after_pm_instructions`.
+const MEMORY_OVERRIDE_HEADING: &str = "## Memory Behavior (project override)";
+
+/// Read an override file, returning `Some(trimmed_contents)` only when it is
+/// present and non-empty.
+///
+/// Why: the override semantics distinguish three states — absent, present but
+/// empty, and present with content. Absent and empty both fall back to the
+/// bundled default; an unreadable file (e.g. permission denied) also falls back.
+/// Treating an empty file as "no override" (with a warning) avoids silently
+/// blanking a whole section because someone `touch`ed a file. Robustness must
+/// never hard-fail the launch.
+/// What: joins `dir/name`; on a successful read of non-whitespace content
+/// returns the trimmed body; on `NotFound` returns `None` silently; on an empty
+/// file or any other IO error logs a `tracing::warn!` and returns `None`.
+/// Test: `unreadable_override_falls_back`, `empty_override_falls_back`,
+/// `missing_override_dir_uses_bundled`.
+fn read_override(dir: &Path, name: &str) -> Option<String> {
+    let path = dir.join(name);
+    match std::fs::read_to_string(&path) {
+        Ok(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "instruction override file is empty; using bundled default"
+                );
+                None
+            } else {
+                tracing::info!(path = %path.display(), "applying instruction override");
+                Some(trimmed.to_string())
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                %err,
+                "instruction override file unreadable; using bundled default"
+            );
+            None
+        }
+    }
+}
+
+/// Resolve the effective PM prompt for `project_dir`, applying any overrides.
+///
+/// Why: this is the single source of truth #381 requires — both the live prompt
+/// delivered to `claude` (`--append-system-prompt-file`) and the inspectable
+/// stash (`tm session instructions` / `.trusty-mpm/last-instructions.md`) call
+/// it, so the inspectable copy can never diverge from what the PM actually
+/// received (the #382 concern).
+///
+/// What: reads override files from `<project_dir>/.trusty-mpm/` and assembles
+/// the prompt per the `BASE_PM.md` "Customizing PM Behavior" table. Branch (1):
+/// when `PM_INSTRUCTIONS_DEPLOYED.md` is present the body is *its* contents
+/// (full replacement of PM_INSTRUCTIONS + WORKFLOW + AGENT_DELEGATION + MEMORY),
+/// then `INSTRUCTIONS.md` (if present) is appended — **SHORT-CIRCUIT**. Branch
+/// (2): otherwise PM_INSTRUCTIONS (bundled) → optional MEMORY override block →
+/// WORKFLOW (override or bundled) → AGENT_DELEGATION (override or bundled), then
+/// `INSTRUCTIONS.md` (if present) appended. In **both** branches the
+/// non-overridable `BASE_PM.md` floor is appended **last** — it is never
+/// replaceable, preserving the framework-floor guarantee `BASE_PM.md` itself
+/// states. Sections are joined with [`SECTION_SEPARATOR`].
+///
+/// Robustness: a missing `.trusty-mpm/` directory, missing files, empty files,
+/// and unreadable files all fall back to the bundled defaults without failing.
+///
+/// MEMORY.md slotting: there is no standalone bundled memory asset (the memory
+/// guidance lives inside `PM_INSTRUCTIONS`). A `MEMORY.md` override is therefore
+/// slotted as a clearly-delimited [`MEMORY_OVERRIDE_HEADING`] block placed
+/// immediately after `PM_INSTRUCTIONS`, which the launched PM reads as the
+/// authoritative, later-and-more-specific memory instruction.
+///
+/// Test: `no_overrides_uses_bundled`, `instructions_appended`,
+/// `workflow_override_replaces`, `agent_delegation_override_replaces`,
+/// `pm_deployed_replaces_body_but_keeps_base_floor`,
+/// `memory_override_is_slotted_after_pm_instructions`, and the robustness tests.
+pub fn resolve_pm_prompt(project_dir: &Path) -> String {
+    let dir = project_dir.join(OVERRIDE_DIR_NAME);
+
+    // Floor is always appended last and never replaceable.
+    let floor = BASE_PM;
+
+    // Branch 1: full replacement short-circuit. BASE_PM still floors it.
+    if let Some(body) = read_override(&dir, FILE_PM_DEPLOYED) {
+        let mut sections: Vec<String> = vec![body];
+        if let Some(extra) = read_override(&dir, FILE_INSTRUCTIONS) {
+            sections.push(extra);
+        }
+        sections.push(floor.trim().to_string());
+        return join_sections(sections);
+    }
+
+    // Branch 2: section-by-section assembly with per-section overrides.
+    let workflow =
+        read_override(&dir, FILE_WORKFLOW).unwrap_or_else(|| WORKFLOW.trim().to_string());
+    let delegation = read_override(&dir, FILE_AGENT_DELEGATION)
+        .unwrap_or_else(|| AGENT_DELEGATION.trim().to_string());
+
+    let mut sections: Vec<String> = vec![PM_INSTRUCTIONS.trim().to_string()];
+
+    // MEMORY override slots in right after PM_INSTRUCTIONS as a delimited block.
+    if let Some(memory) = read_override(&dir, FILE_MEMORY) {
+        sections.push(format!("{MEMORY_OVERRIDE_HEADING}\n\n{memory}"));
+    }
+
+    sections.push(workflow);
+    sections.push(delegation);
+
+    // Additive project rules.
+    if let Some(extra) = read_override(&dir, FILE_INSTRUCTIONS) {
+        sections.push(extra);
+    }
+
+    // Non-overridable floor, always last.
+    sections.push(floor.trim().to_string());
+
+    join_sections(sections)
+}
+
+/// Join resolved sections with the framework separator, dropping empties.
+///
+/// Why: a defensive filter keeps a stray empty section from producing a dangling
+/// `---` rule; centralizing the join keeps the separator consistent with the
+/// bundled [`crate::core::instruction_pipeline::assemble_system_prompt`].
+/// What: trims each section, drops empties, joins the rest with
+/// [`SECTION_SEPARATOR`].
+/// Test: exercised by every `resolve_*` test via the public entry point.
+fn join_sections(sections: Vec<String>) -> String {
+    sections
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(SECTION_SEPARATOR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Write `<project>/.trusty-mpm/<name>` with `content`, creating dirs.
+    fn write_override(project: &Path, name: &str, content: &str) {
+        let dir = project.join(OVERRIDE_DIR_NAME);
+        fs::create_dir_all(&dir).expect("create .trusty-mpm");
+        fs::write(dir.join(name), content).expect("write override");
+    }
+
+    #[test]
+    fn no_overrides_uses_bundled() {
+        // No `.trusty-mpm/` dir at all → the bundled four sections are present
+        // and BASE_PM is the last section.
+        let tmp = TempDir::new().unwrap();
+        let prompt = resolve_pm_prompt(tmp.path());
+
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(prompt.contains("# PM Workflow Configuration"));
+        assert!(prompt.contains("# Agent Delegation Routing"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+
+        let base = prompt.find("# BASE_PM Framework Floor").expect("base");
+        let delegation = prompt.find("# Agent Delegation Routing").expect("deleg");
+        assert!(base > delegation, "BASE_PM floor must be last");
+    }
+
+    #[test]
+    fn instructions_appended() {
+        // INSTRUCTIONS.md is additive: its content appears, the bundled sections
+        // remain, and BASE_PM is still last.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_INSTRUCTIONS,
+            "# Project Rules\n\nALWAYS_RUN_MAKE_CHECK\n",
+        );
+        let prompt = resolve_pm_prompt(tmp.path());
+
+        assert!(prompt.contains("ALWAYS_RUN_MAKE_CHECK"));
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(prompt.contains("# Agent Delegation Routing"));
+
+        let extra = prompt.find("ALWAYS_RUN_MAKE_CHECK").expect("extra");
+        let base = prompt.find("# BASE_PM Framework Floor").expect("base");
+        assert!(extra < base, "INSTRUCTIONS.md precedes the BASE_PM floor");
+    }
+
+    #[test]
+    fn workflow_override_replaces() {
+        // WORKFLOW.md replaces the bundled workflow section; other sections are
+        // intact and the bundled workflow heading is gone.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_WORKFLOW,
+            "# Custom Workflow\n\nTWO_PHASE_ONLY\n",
+        );
+        let prompt = resolve_pm_prompt(tmp.path());
+
+        assert!(prompt.contains("TWO_PHASE_ONLY"));
+        assert!(
+            !prompt.contains("# PM Workflow Configuration"),
+            "bundled workflow heading must be replaced"
+        );
+        // Other sections intact.
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(prompt.contains("# Agent Delegation Routing"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+    }
+
+    #[test]
+    fn agent_delegation_override_replaces() {
+        // AGENT_DELEGATION.md replaces the bundled delegation section; others
+        // intact.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_AGENT_DELEGATION,
+            "# Custom Routing\n\nROUTE_ALL_TO_ENGINEER\n",
+        );
+        let prompt = resolve_pm_prompt(tmp.path());
+
+        assert!(prompt.contains("ROUTE_ALL_TO_ENGINEER"));
+        assert!(
+            !prompt.contains("# Agent Delegation Routing"),
+            "bundled delegation heading must be replaced"
+        );
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(prompt.contains("# PM Workflow Configuration"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+    }
+
+    #[test]
+    fn memory_override_is_slotted_after_pm_instructions() {
+        // MEMORY.md slots in as a delimited block right after PM_INSTRUCTIONS
+        // and before the workflow section.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_MEMORY,
+            "Recall from the `team` palace before any task.\n",
+        );
+        let prompt = resolve_pm_prompt(tmp.path());
+
+        assert!(prompt.contains(MEMORY_OVERRIDE_HEADING));
+        assert!(prompt.contains("Recall from the `team` palace"));
+
+        let pm = prompt.find("# PM Agent -- Claude MPM").expect("pm");
+        let mem = prompt.find(MEMORY_OVERRIDE_HEADING).expect("mem");
+        let wf = prompt.find("# PM Workflow Configuration").expect("wf");
+        assert!(pm < mem, "memory block follows PM_INSTRUCTIONS");
+        assert!(mem < wf, "memory block precedes the workflow section");
+        // Floor still last.
+        let base = prompt.find("# BASE_PM Framework Floor").expect("base");
+        assert!(wf < base);
+    }
+
+    #[test]
+    fn pm_deployed_replaces_body_but_keeps_base_floor() {
+        // PM_INSTRUCTIONS_DEPLOYED.md fully replaces the body, but the
+        // non-overridable BASE_PM floor is STILL appended last, and the bundled
+        // PM/workflow/delegation sections are gone.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_PM_DEPLOYED,
+            "# Wholly Custom PM\n\nDO_EXACTLY_THIS\n",
+        );
+        let prompt = resolve_pm_prompt(tmp.path());
+
+        assert!(prompt.contains("DO_EXACTLY_THIS"));
+        // The non-overridable floor is preserved.
+        assert!(
+            prompt.contains("# BASE_PM Framework Floor"),
+            "BASE_PM floor must always be appended"
+        );
+        assert!(prompt.contains("## Trusty Tool Priority (Non-Overridable)"));
+        // Bundled body sections are replaced.
+        assert!(!prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(!prompt.contains("# PM Workflow Configuration"));
+        assert!(!prompt.contains("# Agent Delegation Routing"));
+
+        // Floor is last.
+        let body = prompt.find("DO_EXACTLY_THIS").expect("body");
+        let base = prompt.find("# BASE_PM Framework Floor").expect("base");
+        assert!(body < base, "BASE_PM floor must come after the custom body");
+    }
+
+    #[test]
+    fn pm_deployed_still_appends_instructions() {
+        // Even under full replacement, INSTRUCTIONS.md (additive) is appended
+        // between the custom body and the BASE_PM floor.
+        let tmp = TempDir::new().unwrap();
+        write_override(tmp.path(), FILE_PM_DEPLOYED, "CUSTOM_BODY\n");
+        write_override(tmp.path(), FILE_INSTRUCTIONS, "PROJECT_ADDENDUM\n");
+        let prompt = resolve_pm_prompt(tmp.path());
+
+        let body = prompt.find("CUSTOM_BODY").expect("body");
+        let addendum = prompt.find("PROJECT_ADDENDUM").expect("addendum");
+        let base = prompt.find("# BASE_PM Framework Floor").expect("base");
+        assert!(body < addendum && addendum < base);
+        // Bundled sections still absent under full replacement.
+        assert!(!prompt.contains("# PM Workflow Configuration"));
+    }
+
+    #[test]
+    fn missing_override_dir_uses_bundled() {
+        // A `.trusty-mpm/` directory that does not exist is not an error.
+        let tmp = TempDir::new().unwrap();
+        assert!(!tmp.path().join(OVERRIDE_DIR_NAME).exists());
+        let prompt = resolve_pm_prompt(tmp.path());
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+    }
+
+    #[test]
+    fn empty_override_falls_back() {
+        // An empty (whitespace-only) override file is treated as "no override":
+        // the bundled default for that section is used (no silent blanking).
+        let tmp = TempDir::new().unwrap();
+        write_override(tmp.path(), FILE_WORKFLOW, "   \n\t\n");
+        let prompt = resolve_pm_prompt(tmp.path());
+        // Bundled workflow heading survives because the empty override is ignored.
+        assert!(prompt.contains("# PM Workflow Configuration"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+    }
+
+    #[test]
+    fn unreadable_override_falls_back() {
+        // A file that cannot be read (here: a directory in the file's place)
+        // falls back to the bundled default rather than failing the launch.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(OVERRIDE_DIR_NAME);
+        fs::create_dir_all(&dir).unwrap();
+        // Create a *directory* named WORKFLOW.md so read_to_string errors with
+        // something other than NotFound.
+        fs::create_dir(dir.join(FILE_WORKFLOW)).unwrap();
+
+        let prompt = resolve_pm_prompt(tmp.path());
+        // Did not panic; bundled workflow is used.
+        assert!(prompt.contains("# PM Workflow Configuration"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+    }
+
+    #[test]
+    fn separators_are_consistent() {
+        // The resolved prompt uses the same `---` rule the bundled assembler
+        // uses, so the two never visually diverge.
+        let tmp = TempDir::new().unwrap();
+        let prompt = resolve_pm_prompt(tmp.path());
+        assert!(prompt.contains(SECTION_SEPARATOR));
+    }
+}

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -16,8 +16,14 @@ use std::path::PathBuf;
 
 use crate::core::delegation_authority::{generate_authority, scan_agents};
 
-/// Separator placed between the three merged instruction sections.
-const SECTION_SEPARATOR: &str = "\n\n---\n\n";
+/// Separator placed between merged instruction sections.
+///
+/// Why: the override resolver in [`crate::core::instruction_overrides`] must use
+/// the identical rule so the bundled and override-resolved prompts never
+/// visually diverge.
+/// What: the `\n\n---\n\n` Markdown horizontal rule used between every section.
+/// Test: `separators_are_consistent` in `instruction_overrides`.
+pub(crate) const SECTION_SEPARATOR: &str = "\n\n---\n\n";
 
 // ---------------------------------------------------------------------------
 // Bundled system-prompt assembly
@@ -29,14 +35,28 @@ const SECTION_SEPARATOR: &str = "\n\n---\n\n";
 // ---------------------------------------------------------------------------
 
 /// Token-optimized PM orchestration instructions (bundled at compile time).
-const PM_INSTRUCTIONS: &str = include_str!("../assets/instructions/PM_INSTRUCTIONS.md");
+///
+/// `pub(crate)` so the override resolver in
+/// [`crate::core::instruction_overrides`] can use it as the default when no
+/// `PM_INSTRUCTIONS_DEPLOYED.md` override is present.
+pub(crate) const PM_INSTRUCTIONS: &str = include_str!("../assets/instructions/PM_INSTRUCTIONS.md");
 /// 5-phase workflow execution details (bundled at compile time).
-const WORKFLOW: &str = include_str!("../assets/instructions/WORKFLOW.md");
+///
+/// `pub(crate)` so the override resolver can use it when no `WORKFLOW.md`
+/// override is present.
+pub(crate) const WORKFLOW: &str = include_str!("../assets/instructions/WORKFLOW.md");
 /// Agent delegation routing table (bundled at compile time).
-const AGENT_DELEGATION: &str = include_str!("../assets/instructions/AGENT_DELEGATION.md");
+///
+/// `pub(crate)` so the override resolver can use it when no
+/// `AGENT_DELEGATION.md` override is present.
+pub(crate) const AGENT_DELEGATION: &str =
+    include_str!("../assets/instructions/AGENT_DELEGATION.md");
 /// Non-overridable BASE_PM framework floor — includes the Trusty tool-priority
 /// block — bundled at compile time. Placed last so it cannot be overridden.
-const BASE_PM: &str = include_str!("../assets/instructions/BASE_PM.md");
+///
+/// `pub(crate)` so the override resolver can append it as the non-overridable
+/// floor even under full PM replacement.
+pub(crate) const BASE_PM: &str = include_str!("../assets/instructions/BASE_PM.md");
 
 /// Assemble the full system prompt from bundled source components.
 ///

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -27,6 +27,7 @@ pub mod doctor;
 pub mod error;
 pub mod external_session;
 pub mod hook;
+pub mod instruction_overrides;
 pub mod instruction_pipeline;
 pub mod ipc;
 pub mod llm_overseer;

--- a/crates/trusty-mpm/src/core/session_launch.rs
+++ b/crates/trusty-mpm/src/core/session_launch.rs
@@ -88,9 +88,12 @@ pub enum PrepError {
 /// call this before sending `claude` into the tmux pane.
 /// What: deploys composed agents from the framework agent source to
 /// `~/.claude/agents/`, runs [`build_instructions`] for `project_dir` (which
-/// loads or creates the project `CLAUDE.md`), writes the merged text to
-/// `<project_dir>/.trusty-mpm/last-instructions.md`, and returns a [`PrepReport`].
-/// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`.
+/// loads or creates the project `CLAUDE.md`), writes the *override-resolved* PM
+/// prompt (from [`crate::core::instruction_overrides::resolve_pm_prompt`]) to
+/// `<project_dir>/.trusty-mpm/last-instructions.md` so the inspectable stash
+/// matches the live launch prompt, and returns a [`PrepReport`].
+/// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
+/// `prepare_session_stash_reflects_override`.
 pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepReport, PrepError> {
     // Deploy composed agents — Claude Code reads `~/.claude/agents/` at startup.
     let deploy = deploy_agents(&fw.agent_source_dir(), &fw.claude_agents_dir())
@@ -111,14 +114,20 @@ pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepRe
     };
     let instructions = build_instructions(&input)?;
 
-    // Stash the merged instructions where an operator can inspect them.
+    // Stash the *override-resolved* PM prompt — the exact text the launch path
+    // passes to `claude --append-system-prompt-file` — so `tm session
+    // instructions` shows what was actually used, including any project-level
+    // overrides under `<project>/.trusty-mpm/`. Resolving via the single
+    // `resolve_pm_prompt` function keeps the stash and the live prompt from
+    // diverging (issue #381 / the #382 concern).
+    let resolved_prompt = crate::core::instruction_overrides::resolve_pm_prompt(project_dir);
     let stash_dir = project_dir.join(".trusty-mpm");
     std::fs::create_dir_all(&stash_dir).map_err(|source| PrepError::Io {
         path: stash_dir.clone(),
         source,
     })?;
     let stash = stash_dir.join("last-instructions.md");
-    std::fs::write(&stash, &instructions.merged).map_err(|source| PrepError::Io {
+    std::fs::write(&stash, &resolved_prompt).map_err(|source| PrepError::Io {
         path: stash.clone(),
         source,
     })?;
@@ -538,12 +547,14 @@ fn group_is_trusty_memory(group: &serde_json::Value) -> bool {
         })
 }
 
-/// Build the `--append-system-prompt` text for a launched session.
+/// Build the project-agnostic `--append-system-prompt` text (no overrides).
 ///
 /// Why: every `claude` session launched by trusty-mpm must be a configured PM
 /// instance. trusty-mpm owns its PM instructions: they are assembled from
 /// bundled assets into `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`
-/// and passed to `claude --append-system-prompt-file`.
+/// and passed to `claude --append-system-prompt-file`. This variant is kept for
+/// callers that do not know the project directory (e.g. tests); prefer
+/// [`build_system_prompt_for`] at launch sites so project-level overrides apply.
 /// What: reads `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`; if it is
 /// missing or empty (first run) it calls
 /// [`crate::core::instruction_pipeline::install_system_prompt`] to generate it from
@@ -578,6 +589,26 @@ pub fn build_system_prompt() -> Option<String> {
     }
 }
 
+/// Build the `--append-system-prompt` text for `project_dir`, applying any
+/// project-level instruction overrides.
+///
+/// Why: `BASE_PM.md` advertises project-level overrides under
+/// `<project>/.trusty-mpm/` (issue #381). The *live* prompt delivered to
+/// `claude` must reflect them, and it must be resolved with the same
+/// [`crate::core::instruction_overrides::resolve_pm_prompt`] function the
+/// inspectable stash uses so the two never diverge (the #382 concern). This is
+/// the launch-site entry point; it always returns a usable prompt — there is no
+/// home-directory dependency because the prompt is composed from compiled-in
+/// bundled assets plus the project's own override files.
+/// What: delegates to
+/// [`crate::core::instruction_overrides::resolve_pm_prompt`], which layers the
+/// override files onto the bundled PM prompt and always appends the
+/// non-overridable `BASE_PM` floor last.
+/// Test: `build_system_prompt_for_applies_project_override`.
+pub fn build_system_prompt_for(project_dir: &Path) -> String {
+    crate::core::instruction_overrides::resolve_pm_prompt(project_dir)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -595,6 +626,77 @@ mod tests {
         assert!(prompt.contains("mcp__trusty-search__search_code"));
         // The bundled PM instructions are also part of the assembled prompt.
         assert!(prompt.contains("# PM Agent -- Claude MPM"));
+    }
+
+    #[test]
+    fn build_system_prompt_for_applies_project_override() {
+        // Why: the live launch prompt must reflect a project-level override file
+        // under `<project>/.trusty-mpm/` (issue #381), while still appending the
+        // non-overridable BASE_PM floor.
+        let tmp = tempdir().unwrap();
+        let project = tmp.path();
+        let override_dir = project.join(".trusty-mpm");
+        std::fs::create_dir_all(&override_dir).unwrap();
+        std::fs::write(
+            override_dir.join("INSTRUCTIONS.md"),
+            "PROJECT_OVERRIDE_MARKER\n",
+        )
+        .unwrap();
+
+        let prompt = build_system_prompt_for(project);
+        assert!(prompt.contains("PROJECT_OVERRIDE_MARKER"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+        // Bundled PM body is still present (INSTRUCTIONS.md is additive).
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+    }
+
+    #[test]
+    fn build_system_prompt_for_no_override_matches_bundled_sections() {
+        // Why: with no override files the live prompt must still carry all
+        // bundled sections and the BASE_PM floor last.
+        let tmp = tempdir().unwrap();
+        let prompt = build_system_prompt_for(tmp.path());
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(prompt.contains("# Agent Delegation Routing"));
+        let base = prompt.find("# BASE_PM Framework Floor").expect("base");
+        let deleg = prompt.find("# Agent Delegation Routing").expect("deleg");
+        assert!(base > deleg, "BASE_PM floor must be last");
+    }
+
+    #[test]
+    fn prepare_session_stash_reflects_override() {
+        // Why: the inspectable stash (`last-instructions.md`) must reflect the
+        // SAME override-resolved prompt the launch path uses, so `tm session
+        // instructions` shows what was actually delivered (issue #381 / #382).
+        let tmp = tempdir().unwrap();
+        let project = tmp.path();
+        let fw = FrameworkPaths::default();
+
+        let override_dir = project.join(".trusty-mpm");
+        std::fs::create_dir_all(&override_dir).unwrap();
+        std::fs::write(
+            override_dir.join("WORKFLOW.md"),
+            "# Custom Workflow\n\nSTASH_OVERRIDE_MARKER\n",
+        )
+        .unwrap();
+
+        let report = prepare_session(&fw, project).expect("prep succeeds");
+        let stash = std::fs::read_to_string(&report.stash).expect("stash readable");
+
+        assert!(
+            stash.contains("STASH_OVERRIDE_MARKER"),
+            "stash must reflect the WORKFLOW.md override"
+        );
+        assert!(
+            !stash.contains("# PM Workflow Configuration"),
+            "bundled workflow heading must be replaced in the stash"
+        );
+        assert!(
+            stash.contains("# BASE_PM Framework Floor"),
+            "stash must still carry the BASE_PM floor"
+        );
+        // The stash must equal the live prompt for this project.
+        assert_eq!(stash, build_system_prompt_for(project));
     }
 
     #[test]


### PR DESCRIPTION
Closes #381.

## Problem
`BASE_PM.md` advertised a "Customizing PM Behavior" table telling the PM it could drop override files into the project's `.trusty-mpm/` directory (`INSTRUCTIONS.md`, `AGENT_DELEGATION.md`, `WORKFLOW.md`, `MEMORY.md`, `PM_INSTRUCTIONS_DEPLOYED.md`) that would take effect on next startup. **No Rust code read any of them** — the system prompt was a fixed compile-time concatenation, so every advertised override was a silent, actively-misleading no-op.

## Implementation
New `core::instruction_overrides::resolve_pm_prompt(project_dir)` reads the five override files from `<project>/.trusty-mpm/` and assembles the effective PM prompt per the documented semantics:

| File | Semantics |
|------|-----------|
| `PM_INSTRUCTIONS_DEPLOYED.md` | Full replacement of the PM body (PM_INSTRUCTIONS + WORKFLOW + AGENT_DELEGATION + MEMORY). Short-circuits. |
| `AGENT_DELEGATION.md` | Replaces the agent-delegation section. |
| `WORKFLOW.md` | Replaces the workflow section. |
| `MEMORY.md` | Replaces the memory section. There is no standalone bundled memory asset (memory guidance lives in PM_INSTRUCTIONS' "Context-First Protocol"), so a `MEMORY.md` override is slotted as a clearly-delimited `## Memory Behavior (project override)` block immediately after PM_INSTRUCTIONS. |
| `INSTRUCTIONS.md` | Appended (additive) project rules. |

### Critical invariant — BASE_PM is the non-overridable floor
`BASE_PM.md` (including the Trusty Tool Priority block) is **always appended last and is never replaceable** — even when `PM_INSTRUCTIONS_DEPLOYED.md` is present, full replacement replaces everything *except* the BASE_PM floor. This preserves the framework-floor guarantee BASE_PM.md itself states.

## Wiring (positively addresses the #382 stash divergence)
Both code paths now resolve through the **same** `resolve_pm_prompt` function, so they can never diverge:
- **Live prompt** delivered to claude: new `build_system_prompt_for(project_dir)` is called at all three launch sites (`tm launch`, `DaemonClient::launch_session`, `DaemonClient::connect_session`), each of which already knows the project directory.
- **Inspectable stash** (`.trusty-mpm/last-instructions.md`): both `prepare_session` and the `tm session instructions` path (`compose_session_instructions`) now write the override-resolved prompt, so `tm session instructions` shows exactly what the PM received.

## Robustness
- Missing `.trusty-mpm/` dir or missing files → bundled defaults (not an error).
- Unreadable / permission-denied file → `tracing::warn!` and fall back to the bundled default for that section (never hard-fails the launch).
- Empty (whitespace-only) file → treated as "no override" with a `tracing::warn!`, to avoid silently blanking a section.

## Docs
`BASE_PM.md` updated so its promises now match the implementation: correct `.trusty-mpm/` paths, per-file semantics, and an explicit "BASE_PM floor is never overridable" note. Unrelated sections untouched.

## Tests
14 new hermetic, tempdir-based tests: no-override bundled prompt, `INSTRUCTIONS.md` additive, `WORKFLOW.md` / `AGENT_DELEGATION.md` replacement, `PM_INSTRUCTIONS_DEPLOYED.md` full replacement with BASE_PM floor preserved, `MEMORY.md` slotting, empty/unreadable fallback, and stash/live-prompt parity. `cargo test -p trusty-mpm` green (707 lib tests + integration), clippy clean (only the pre-existing `tm.rs found in multiple build targets` warning), fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)