### PR TITLE
fix(tga): classify finalization hang, db-lock race, complexity population (2.2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-05-29
+
+### Fixed
+
+- **`tga classify` no longer hangs ~120s at exit with external sources enabled
+  (#397, bug 1)** — `tga` used the default multi-threaded Tokio runtime via
+  `#[tokio::main]`. On return the runtime drop blocks until every background
+  task finishes, including `reqwest`'s keep-alive connection-pool reaper, whose
+  idle sockets against a live server (e.g. JIRA/Atlassian) linger up to the
+  ~90s pool idle timeout. The process therefore completed all work, printed its
+  summary, then hung before terminating. `main` now builds the runtime
+  explicitly and calls `Runtime::shutdown_timeout(0)` after the async body
+  completes, dropping idle connection tasks immediately so the process exits
+  promptly. All real work is awaited before shutdown, so nothing is discarded.
+
+- **`tga classify` no longer fails with "database is locked" immediately after
+  `tga collect` (#397, bug 3)** — connections were opened without a
+  `busy_timeout`, so a `classify` that opened while a just-finished `collect`
+  was still flushing/checkpointing its WAL hit `SQLITE_BUSY` and failed
+  instantly. Every connection now sets `PRAGMA busy_timeout = 5000`, so a
+  transient checkpoint lock is waited out (up to 5s) instead of erroring.
+
+- **`classifications.complexity` (1–5) is now populatable via a discoverable
+  command (#397, bug 2)** — the complexity scoring logic shipped in 2.2.0
+  (the LLM tier produces scores; the pipeline persists them) but was only
+  reachable via the non-obvious `tga classify --backfill-complexity` flag. The
+  normal `tga classify` run only consults the LLM for low-confidence commits,
+  so rule-/JIRA-resolved commits keep `complexity = NULL`. A new
+  `tga backfill complexity` subcommand exposes the existing
+  `ClassificationPipeline::backfill_complexity` operation where operators look
+  for it. It fills every `complexity IS NULL` (non-`exact_rule`) row via the
+  LLM, supports `--dry-run` and `--use-llm`, and leaves
+  category/confidence/method untouched. (No new scoring feature was built; this
+  is a wiring/discoverability fix.)
+
 ## [2.2.0] - 2026-05-29
 
 ### Added

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.2.0"
+version = "2.2.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for

--- a/crates/trusty-git-analytics/src/commands/backfill.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill.rs
@@ -14,10 +14,11 @@
 use clap::{Args, Subcommand};
 use git2::{Repository, Sort};
 use rusqlite::{params, Connection};
+use tga::classify::ClassificationPipeline;
 use tga::collect::git::scan_and_persist;
 use tga::collect::ticket::{extract_ticket_id, is_ticketed};
 use tga::core::config::{expand_path, Config};
-use tga::core::db::Database;
+use tga::core::db::{CheckpointMode, Database};
 use tga::core::effort::{compute_effort, FORMULA_VERSION};
 
 /// Arguments for `tga backfill`.
@@ -116,6 +117,34 @@ pub enum BackfillSubcommand {
     ///
     /// --branch is collect-only and not applicable here.
     Effort(EffortBackfillArgs),
+    /// Fill in missing `complexity` scores (1–5) for already-classified commits.
+    ///
+    /// The `complexity` column is only ever populated by the LLM tier, which
+    /// the normal `tga classify` run consults solely for low-confidence
+    /// commits. Commits resolved by rules or external sources (JIRA/GitHub)
+    /// therefore keep `complexity = NULL`. This subcommand asks the LLM for a
+    /// 1–5 complexity score for every classification with `complexity IS NULL`
+    /// and a non-`exact_rule` method, leaving category/confidence/method
+    /// untouched. Requires `use_llm: true` (or `--use-llm`) and an LLM API key.
+    ///
+    /// Equivalent to `tga classify --backfill-complexity`; exposed here so the
+    /// operation is discoverable under `tga backfill` (issue #397, bug 2).
+    /// --repos/--since/--until/--weeks do not scope this operation: all NULL
+    /// rows are processed.
+    Complexity(ComplexityBackfillArgs),
+}
+
+/// Arguments for `tga backfill complexity`.
+#[derive(Args, Debug)]
+pub struct ComplexityBackfillArgs {
+    /// Enable the LLM tier for this run even if `config.classification.use_llm`
+    /// is `false`.
+    ///
+    /// Complexity scoring is LLM-only, so the LLM tier must be on. Pass this
+    /// flag (or set `use_llm: true` in config) along with an API key
+    /// (`OPENAI_API_KEY` / `OPENROUTER_API_KEY`).
+    #[arg(long, default_value_t = false)]
+    pub use_llm: bool,
 }
 
 /// Arguments for `tga backfill effort`.
@@ -183,7 +212,7 @@ fn resolve_backfill_date_range(
 /// # Errors
 ///
 /// Propagates database errors from the underlying queries.
-pub fn run(config: Config, db: &mut Database, args: BackfillArgs) -> anyhow::Result<()> {
+pub async fn run(config: Config, db: &mut Database, args: BackfillArgs) -> anyhow::Result<()> {
     let (since, until) = resolve_backfill_date_range(&args)?;
     let repos = args.repos.clone();
     match args.subcommand {
@@ -204,7 +233,79 @@ pub fn run(config: Config, db: &mut Database, args: BackfillArgs) -> anyhow::Res
             until.as_deref(),
             args.dry_run,
         ),
+        BackfillSubcommand::Complexity(complexity_args) => {
+            backfill_complexity(config, db, complexity_args, args.dry_run).await
+        }
     }
+}
+
+// ── backfill complexity ────────────────────────────────────────────────────────
+
+/// Fill in missing `complexity` scores for already-classified commits.
+///
+/// Why: the `complexity` column added in 2.2.0 is only ever written by the LLM
+/// tier, and the normal `tga classify` run consults the LLM solely for
+/// low-confidence commits. On a corpus where most commits are resolved by
+/// rules or external sources (JIRA/GitHub), `complexity` stays `NULL` for
+/// nearly every row. The population logic already exists
+/// ([`ClassificationPipeline::backfill_complexity`]) and was reachable via
+/// `tga classify --backfill-complexity`, but operators looked for it under
+/// `tga backfill` and found nothing — so it appeared the feature was never
+/// shipped (issue #397, bug 2). This makes the operation discoverable here.
+/// What: builds a [`ClassificationPipeline`] from config (forcing `use_llm` on
+/// when `--use-llm` is passed), invokes `backfill_complexity`, and checkpoints
+/// the WAL on completion. In `--dry-run` it reports the candidate count without
+/// calling the LLM or writing.
+/// Test: `tests::backfill_complexity_dry_run_reports_candidates` (dry-run path)
+/// and the library-level `pipeline::tests::backfill_complexity_updates_only_null_rows`
+/// (population path, mock LLM).
+///
+/// # Errors
+///
+/// Returns an error if pipeline construction, the LLM calls, or DB access fail.
+async fn backfill_complexity(
+    config: Config,
+    db: &mut Database,
+    args: ComplexityBackfillArgs,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    if dry_run {
+        // Count candidate rows without invoking the LLM or writing anything.
+        let candidates: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM classifications \
+                 WHERE complexity IS NULL AND method != 'exact_rule'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        println!(
+            "Dry run — would request complexity scores for {candidates} classification(s) \
+             (complexity IS NULL, method != 'exact_rule'). No changes written."
+        );
+        return Ok(());
+    }
+
+    // Force the LLM tier on when requested; complexity scoring is LLM-only.
+    let mut cfg = config;
+    if args.use_llm {
+        let classification = cfg
+            .classification
+            .get_or_insert_with(tga::core::config::ClassificationConfig::default);
+        classification.use_llm = true;
+    }
+
+    let pipeline = ClassificationPipeline::new(cfg);
+    let updated = pipeline.backfill_complexity(db).await?;
+    println!("Backfilled complexity for {updated} commit(s)");
+
+    // Flush the WAL after the backfill so the scores are durable in the main
+    // DB file (mirrors the post-classify checkpoint, issue #298).
+    if let Err(e) = db.wal_checkpoint(CheckpointMode::Truncate) {
+        tracing::warn!(error = %e, "WAL TRUNCATE checkpoint failed after complexity backfill");
+    }
+    Ok(())
 }
 
 // ── backfill effort ──────────────────────────────────────────────────────────
@@ -1305,6 +1406,53 @@ mod tests {
             )
             .expect("q");
         assert_eq!(reverts, 0);
+    }
+
+    /// Why: regression guard for issue #397 bug 2. `tga backfill complexity`
+    /// must be wired and its dry-run path must report the count of NULL-complexity
+    /// candidates without invoking the LLM (so it works offline) and without
+    /// mutating any row.
+    /// What: seed one classification with `complexity IS NULL` (regex_rule,
+    /// eligible) and one already-scored row (must not be counted); run the
+    /// dry-run backfill; assert no LLM is needed and nothing is written.
+    /// Test: in-memory DB; dry_run=true short-circuits before any LLM call.
+    #[tokio::test]
+    async fn backfill_complexity_dry_run_reports_candidates_without_writing() {
+        let mut db = Database::open_in_memory().expect("open");
+
+        // Candidate: NULL complexity, non-exact method.
+        db.connection()
+            .execute(
+                "INSERT INTO classifications (category, confidence, method, complexity) \
+                 VALUES ('feature', 0.5, 'regex_rule', NULL)",
+                [],
+            )
+            .expect("insert null-complexity row");
+        // Not a candidate: already scored.
+        db.connection()
+            .execute(
+                "INSERT INTO classifications (category, confidence, method, complexity) \
+                 VALUES ('bugfix', 0.8, 'regex_rule', 3)",
+                [],
+            )
+            .expect("insert scored row");
+
+        let args = ComplexityBackfillArgs { use_llm: false };
+        // dry_run=true must not hit the network; Config::default() has no LLM key.
+        backfill_complexity(Config::default(), &mut db, args, true)
+            .await
+            .expect("dry-run complexity backfill");
+
+        // Nothing changed: the NULL row is still NULL, the scored row still 3.
+        let null_count: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM classifications WHERE complexity IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count null");
+        assert_eq!(null_count, 1, "dry-run must not write complexity scores");
     }
 
     // ── effort backfill tests ─────────────────────────────────────────────────

--- a/crates/trusty-git-analytics/src/core/db/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/mod.rs
@@ -4,6 +4,7 @@
 //! pragmas on every connection open (see `Database::apply_pragmas`):
 //!
 //! - `journal_mode = WAL` — concurrent reads during write-heavy collection
+//! - `busy_timeout = 5000` — wait up to 5 s for a lock before erroring
 //! - `synchronous = NORMAL` — durability with reasonable performance
 //! - `foreign_keys = ON` — enforce FK constraints
 //! - `cache_size = -65536` — 64 MB page cache (negative = KB)
@@ -91,11 +92,22 @@ impl Database {
     ///
     /// Pragmas applied (see module-level docs for rationale):
     /// - `journal_mode = WAL`
+    /// - `busy_timeout = 5000`
     /// - `synchronous = NORMAL`
     /// - `foreign_keys = ON`
     /// - `cache_size = -65536` (64 MB)
     /// - `temp_store = MEMORY`
     /// - `mmap_size = 268435456` (256 MB)
+    ///
+    /// Why the `busy_timeout`: in WAL mode a brief exclusive lock is taken
+    /// during checkpointing and at the tail of a write transaction. If
+    /// `tga classify` opens the DB while a just-finished `tga collect` is
+    /// still flushing/checkpointing its WAL, SQLite returns `SQLITE_BUSY`
+    /// ("database is locked") *immediately* with no retry — surfacing as a
+    /// hard failure to the operator (issue #397, bug 3). Setting
+    /// `busy_timeout` makes SQLite block and retry for up to 5 s, which is
+    /// far longer than any transient checkpoint lock, so the second command
+    /// waits the lock out instead of erroring.
     fn apply_pragmas(conn: &Connection) -> Result<()> {
         // `journal_mode` is a query-style pragma; use query_row to honor it.
         let mode: String = conn
@@ -103,15 +115,20 @@ impl Database {
             .map_err(TgaError::from)?;
         debug!(journal_mode = %mode, "applied WAL pragma");
         // Bundle the remaining pragmas in a single batch — none of them
-        // return rows so `execute_batch` is appropriate.
+        // return rows so `execute_batch` is appropriate. `busy_timeout` is
+        // first so a transient lock from a concurrent writer is waited out
+        // rather than failing the rest of the batch.
         conn.execute_batch(
-            "PRAGMA synchronous = NORMAL; \
+            "PRAGMA busy_timeout = 5000; \
+             PRAGMA synchronous = NORMAL; \
              PRAGMA foreign_keys = ON; \
              PRAGMA cache_size = -65536; \
              PRAGMA temp_store = MEMORY; \
              PRAGMA mmap_size = 268435456;",
         )?;
-        debug!("applied SQLite tuning pragmas (cache=64MB, mmap=256MB, temp=memory)");
+        debug!(
+            "applied SQLite tuning pragmas (busy_timeout=5s, cache=64MB, mmap=256MB, temp=memory)"
+        );
         Ok(())
     }
 
@@ -244,6 +261,61 @@ mod tests {
             .expect("passive checkpoint must not fail");
         db.wal_checkpoint(CheckpointMode::Truncate)
             .expect("truncate checkpoint must not fail");
+    }
+
+    /// Why: regression guard for issue #397 bug 3. Every connection must set a
+    /// non-zero `busy_timeout` so that a `classify` opened immediately after a
+    /// `collect` waits out the brief WAL checkpoint lock instead of failing
+    /// with "database is locked". Without the pragma, `busy_timeout` is 0 and
+    /// any contended lock errors instantly.
+    /// What: open a DB and read back `PRAGMA busy_timeout`; assert it is 5000ms.
+    /// Test: pure pragma read; works on in-memory and file DBs identically.
+    #[test]
+    fn busy_timeout_is_set_to_5000ms() {
+        let db = Database::open_in_memory().expect("open");
+        let timeout: i64 = db
+            .connection()
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .expect("query busy_timeout");
+        assert_eq!(
+            timeout, 5000,
+            "busy_timeout must be 5000ms so contended opens wait rather than erroring"
+        );
+    }
+
+    /// Why: a second connection opened against the same file-backed WAL
+    /// database (the `collect` → `classify` sequence) must succeed even while
+    /// the first connection holds an open write transaction for a moment;
+    /// `busy_timeout` makes the second connection wait rather than fail with
+    /// "database is locked" (issue #397 bug 3). This asserts the second open
+    /// applies its pragmas (including `busy_timeout`) without erroring while
+    /// the first connection is live.
+    /// What: open a file DB, keep it open, open a *second* `Database` on the
+    /// same path, and assert both report a 5000ms `busy_timeout`.
+    /// Test: uses a real temp-file DB so WAL locking semantics apply.
+    #[test]
+    fn second_open_on_same_file_succeeds_with_busy_timeout() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let db_path = tmp.path().to_path_buf();
+        tmp.keep().expect("keep tempfile");
+
+        let db1 = Database::open(&db_path).expect("first open");
+        assert_eq!(db1.journal_mode().expect("journal_mode"), "wal");
+
+        // A second connection (mimicking `tga classify` after `tga collect`)
+        // must open cleanly and also carry the busy_timeout pragma.
+        let db2 = Database::open(&db_path).expect("second open must not fail");
+        let timeout: i64 = db2
+            .connection()
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .expect("query busy_timeout");
+        assert_eq!(timeout, 5000);
+
+        drop(db1);
+        drop(db2);
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+        let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
     }
 
     /// Why: the checkpoint must succeed and the WAL file must be small (or

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -566,8 +566,45 @@ static HELP: std::sync::LazyLock<trusty_common::help::HelpConfig> =
             .expect("tga help.yaml is bundled and valid")
     });
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+/// Process entry point.
+///
+/// Why: a plain `#[tokio::main]` builds a multi-threaded runtime and, on
+/// return, drops it — which blocks until every background task the runtime
+/// spawned has finished. `reqwest`'s default `Client` keeps idle HTTP
+/// keep-alive connections in a pool whose reaper runs as such a background
+/// task; against a live server (e.g. JIRA/Atlassian) those sockets linger up
+/// to the pool idle timeout (~90s). The result is that `tga classify` with
+/// external sources enabled finishes all work, prints its summary, then hangs
+/// ~120s at exit waiting on the runtime drop before the process finally
+/// terminates (issue #397, bug 1).
+/// What: builds the multi-threaded runtime explicitly, runs the async body to
+/// completion, then calls [`tokio::runtime::Runtime::shutdown_timeout`] with a
+/// zero deadline so any still-idle connection-pool tasks are dropped
+/// immediately instead of blocking the process exit. All real work is already
+/// awaited inside `run`, so nothing useful is discarded.
+/// Test: `cargo test -p tga` (the existing suite) plus the manual repro in the
+/// issue; clean-exit timing is host-dependent so it is not unit-asserted.
+fn main() -> anyhow::Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let result = runtime.block_on(run());
+    // Drop idle background tasks (e.g. reqwest's keep-alive connection pool)
+    // immediately rather than waiting on the runtime's default drop, which
+    // would block until those tasks wind down on their own.
+    runtime.shutdown_timeout(std::time::Duration::from_secs(0));
+    result
+}
+
+/// Async program body, invoked by [`main`] on an explicit runtime.
+///
+/// Why: split out from `main` so the runtime can be shut down with a bounded
+/// timeout after the body completes (see [`main`]).
+/// What: parses CLI args, initializes tracing/config, opens the DB, and
+/// dispatches the chosen subcommand.
+/// Test: exercised end-to-end by every CLI invocation; per-command behavior is
+/// covered by each command module's tests.
+async fn run() -> anyhow::Result<()> {
     // Why: parse via `try_parse` so we can attach the workspace-shared
     // "did you mean?" suggestion (issue #216) before exiting on a clap error.
     let argv: Vec<String> = std::env::args().collect();
@@ -645,7 +682,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Report(args) => commands::report::run(config, &db, args)?,
         Commands::PrMetrics(args) => commands::pr_metrics::run(config, &db, args)?,
         Commands::Aliases(args) => commands::aliases::run(config, &mut db, args)?,
-        Commands::Backfill(args) => commands::backfill::run(config, &mut db, args)?,
+        Commands::Backfill(args) => commands::backfill::run(config, &mut db, args).await?,
         Commands::Override(args) => commands::override_cmd::run(config, &mut db, args)?,
         Commands::Rules(args) => commands::rules::run(config, &db, args)?,
         Commands::Deployments(args) => match args.subcommand {


### PR DESCRIPTION
Closes #397.

Fixes the three bugs reported against tga 2.2.0. Version bumped 2.2.0 → 2.2.1 (patch; bug fixes only). CHANGELOG updated.

## Bug 1 — `tga classify` hangs ~120s at finalization with external sources (JIRA) enabled

**Root cause:** `tga` used `#[tokio::main]`, which builds a multi-threaded runtime and, on return, drops it. Dropping a multi-thread runtime blocks until every background task it spawned has finished — and `reqwest`'s default `Client` keeps idle HTTP keep-alive connections in a pool whose reaper runs as a background task. Against a live server (JIRA/Atlassian) those sockets linger up to the ~90s pool idle timeout. The command therefore finished all work, printed its summary, then hung ~120s before the process exited. It is *not* a WAL checkpoint hang and not a deadlock on 404s (legacy ticket 404s are handled fine during processing).

**Fix:** `main` now builds the multi-threaded runtime explicitly, runs the async body to completion, then calls `Runtime::shutdown_timeout(Duration::ZERO)`. All real work is awaited inside the body before shutdown, so nothing useful is discarded; the only thing dropped is the idle connection-pool task that was keeping the process alive. The process now exits promptly.

## Bug 2 — `classifications.complexity` (1–5) never populated — BOUNDED INVESTIGATION → wiring/discoverability fix (no new feature)

**Finding:** the complexity *computation* logic shipped in 2.2.0 and works end-to-end:
- The LLM tier prompts for and parses a 1–5 `complexity` (`classify/tiers/llm.rs`).
- The pipeline persists it on INSERT/UPDATE (`classify/pipeline.rs`, `classifications.complexity`).
- `ClassificationPipeline::backfill_complexity` exists and is covered by a passing mock-LLM test.

The reason production rows are all NULL: complexity is **only** produced by the LLM tier, and the normal `tga classify` run consults the LLM **only for low-confidence commits**. On a corpus where most commits are resolved by rules or external sources (JIRA/GitHub), the LLM tier never runs, so `complexity` stays NULL by design. The intended population path — the `tga classify --backfill-complexity` flag — existed but was undiscoverable; operators looked under `tga backfill` and found nothing, so it looked unimplemented.

**Per the bounded rule, no new scoring feature was built.** Instead, the existing `backfill_complexity` operation is now exposed as a discoverable `tga backfill complexity` subcommand (supports `--dry-run` and `--use-llm`). It fills every `complexity IS NULL` (non-`exact_rule`) row via the LLM and leaves category/confidence/method untouched. The non-obvious `tga classify --backfill-complexity` flag still works.

## Bug 3 — "database is locked" when `tga classify` runs immediately after `tga collect`

**Root cause:** connections were opened with WAL mode but no `busy_timeout`. A `classify` that opened while a just-finished `collect` was still flushing/checkpointing its WAL hit `SQLITE_BUSY` and failed **instantly** with no retry.

**Fix:** every connection now sets `PRAGMA busy_timeout = 5000` in the central `apply_pragmas` path, so a transient checkpoint lock is waited out (up to 5s) instead of erroring. Cheap and broadly correct.

## Files changed
- `crates/trusty-git-analytics/src/main.rs` — explicit runtime + `shutdown_timeout(0)`; async `backfill::run` dispatch (bug 1).
- `crates/trusty-git-analytics/src/core/db/mod.rs` — `PRAGMA busy_timeout = 5000` + 2 regression tests (bug 3).
- `crates/trusty-git-analytics/src/commands/backfill.rs` — `tga backfill complexity` subcommand wiring to existing `backfill_complexity` + dry-run regression test (bug 2).
- `crates/trusty-git-analytics/Cargo.toml` — version 2.2.0 → 2.2.1.
- `crates/trusty-git-analytics/CHANGELOG.md` — `[2.2.1]` entry.

## Tests
- `core::db::tests::busy_timeout_is_set_to_5000ms`
- `core::db::tests::second_open_on_same_file_succeeds_with_busy_timeout`
- `commands::backfill::tests::backfill_complexity_dry_run_reports_candidates_without_writing`
- Existing `backfill_complexity_updates_only_null_rows` / `pipeline_writes_complexity_to_db` still pass.

Full suite: `cargo test -p tga` → 530 + 103 + 1 + 1 + 3 doctests passing, 0 failed. `cargo clippy -p tga --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)