### PR TITLE
docs(open-mpm): canonical PRD + spec set

### DIFF
--- a/docs/open-mpm/spec/ARCHITECTURE.md
+++ b/docs/open-mpm/spec/ARCHITECTURE.md
@@ -303,11 +303,11 @@ on `OpenMpmRepl`. They are injected **after** `AgentConfig::load()` and **before
 `apply_credential_routing()`, so a session override **takes precedence over both
 the TOML `model` and the env-var credential**. ✅
 
-> **Caveat:** the legacy stdin REPL turn `ctrl_chat_turn` (~`src/ctrl/mod.rs:3391`)
+> **Caveat:** the legacy stdin REPL turn `ctrl_chat_turn` (`crates/open-mpm/src/ctrl/ctrl_turn/dispatch.rs:48`)
 > hardcodes `CTRL_MODEL` and calls `llm::chat()` directly *without*
 > `pick_credentials()`, so that one path always routes via OpenRouter regardless
 > of overrides/credentials. The ratatui `run_pm_task_with_history` path routes
-> correctly. (PRD FR-1.4) 🟡
+> correctly. (#408; supersedes pre-refactor `src/ctrl/mod.rs:3391` from #358–#366 cap-sweep module split.) (PRD FR-1.4) 🟡
 
 ### 5.6 Model qualification
 

--- a/docs/open-mpm/spec/ARCHITECTURE.md
+++ b/docs/open-mpm/spec/ARCHITECTURE.md
@@ -1,0 +1,352 @@
+# open-mpm — System Architecture
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** research synthesis + code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+This document describes how open-mpm fits together: the process model, the IPC
+wire formats, the event system, the source-module map, and — at length — the
+**model-agnostic dispatch** subsystem that is the product's core differentiator.
+
+---
+
+## 1. Process Model
+
+open-mpm is a **multi-mode single binary** (`src/main.rs`). One executable
+dispatches to PM, sub-agent, workflow, direct, CTRL, API-server, CLI-search, and
+Telegram modes depending on arguments. The runtime topology:
+
+```
+CLI invocation
+    │
+    ├─ Probe ~/.open-mpm/sockets/<project>.ctrl.sock (50ms timeout)
+    │     ├─ Connected → CLI client mode: write JSON command, stream replies, exit
+    │     └─ Not connected → Controller mode
+    │
+Controller (single long-running process)
+    ├─ ratatui TUI REPL (main task)
+    ├─ Axum HTTP API server (tokio task, port 8080)
+    ├─ CLI socket listener (tokio task)
+    ├─ EventBus (tokio::sync::broadcast<Event>, capacity 1024)
+    ├─ ProcessTracker (PID lifecycle)
+    └─ PmHandle map (one tokio task per connected project)
+          └─ LLM call → tool dispatch
+                └─ DispatchingAgentRunner
+                      ├─ ClaudeCodeAgentRunner (claude CLI subprocess)
+                      ├─ InProcessAgentRunner (tokio task, fast path)
+                      └─ SubprocessAgentRunner (NDJSON IPC subprocess)
+```
+
+### Key properties
+
+- **Controller is long-running.** It hosts the TUI REPL on the main task and
+  spins tokio tasks for the HTTP API (Axum, port 8080), the CLI socket listener,
+  the event bus, the process tracker, and one PM actor per connected project
+  (`PmHandle` map). ✅
+- **PM actors are isolated tokio tasks.** Each connected project gets exactly
+  one PM task; the PM calls the LLM, dispatches tools, and delegates to
+  sub-agents through the `DispatchingAgentRunner`. ✅
+- **Three runner kinds** sit beneath dispatch (see §5): the claude-CLI runner,
+  the in-process runner (fast path, read-only agents), and the subprocess runner
+  (full OS isolation, file/shell agents). ✅
+- **Socket probe → client-or-controller.** A new invocation probes the project's
+  `.ctrl.sock` with a 50 ms timeout. On connect, it acts as a thin CLI client:
+  write a JSON command, stream replies, exit. On no-connect, it becomes the
+  controller. 🟡 — *singleton enforcement is not guaranteed*: two near-simultaneous
+  invocations can race on the socket rather than the second reliably routing to
+  the first (see PRD FR-1.3).
+
+### Process module support
+
+- `ProcessTracker` (`src/process_tracker.rs`) records PID lifecycle to
+  `~/.open-mpm/processes.json`. ✅
+- The CLI socket protocol lives in `src/ctrl/socket.rs` and
+  `src/ctrl/socket_listener.rs`. ✅
+- **Real-time push is incomplete:** the web UI polls every ~2 s; SSE is designed
+  and partly built; token streaming is Phase 4. 🟡
+
+---
+
+## 2. IPC Model (NDJSON)
+
+Sub-agents communicate with their PM over **newline-delimited JSON (NDJSON)** on
+stdin/stdout. The codec lives in `src/ipc/mod.rs` (`IpcMessage`). Each subprocess
+has **stdin piped, stdout piped (one NDJSON line per message), stderr
+inherited**. The PM uses **separate tokio read and write tasks** to prevent
+deadlock. ✅
+
+### Message formats
+
+**PM → sub-agent (task):**
+
+```json
+{
+  "type": "task",
+  "id": "<uuid>",
+  "task": "…",
+  "history": [ … ]
+}
+```
+
+**Sub-agent → PM (success):**
+
+```json
+{
+  "type": "result",
+  "id": "<uuid>",
+  "content": "…",
+  "summary": "…",
+  "usage": { … }
+}
+```
+
+**Sub-agent → PM (failure):**
+
+```json
+{
+  "type": "error",
+  "id": "<uuid>",
+  "error": "…",
+  "status": "error"
+}
+```
+
+The `id` correlates request and response. The sub-agent emits exactly one
+NDJSON result/error line, then exits — giving the subprocess runner its crash
+isolation guarantee (a panicking file/shell agent dies alone; the controller
+reads the closed pipe and surfaces an error). ✅
+
+> **Known gap:** the `summary` field exists in the wire format, but the PM today
+> consumes **full `content`** rather than a compressed summary — there is no
+> Roo-Code-style `attempt_completion` summarization step between sub-agent and
+> PM (see PRD FR-2.4). 🔵
+
+---
+
+## 3. Event Architecture
+
+The controller runs an **`EventBus`** built on `tokio::sync::broadcast<Event>`
+with **capacity 1024**. The `Event` enum lives in `src/events.rs`. ✅
+
+### Event enum
+
+The canonical variants (`src/events.rs`) cover the session, PM, agent, tool,
+phase, and LLM lifecycles. The naming in the originating research used
+`*Completed`; the implemented variants use `*Done`:
+
+| Lifecycle | Variants (as implemented in `src/events.rs`) |
+|---|---|
+| Session | `SessionStarted`, `SessionDone`, `SessionCancelled` |
+| PM | `PmThinking`, `PmDelegating` |
+| Agent | `AgentSpawned`, `AgentStarted`, `AgentMessage`, `AgentDone`, `AgentFailed` |
+| Tool | `ToolCalled`, `ToolResult` |
+| AST | `AstOperation` |
+| Phase | `PhaseStarted`, `PhaseDone`, `PhaseSkipped` |
+| LLM | `LlmRequested`, `LlmResponded` |
+| Reporting | `ReportGenerated`, `RecapGenerated` |
+| Persona | `PersonaDetected` |
+
+> The research also referenced `MemoryPressure` and `SubprocessExited`
+> subscribers; treat the table above as authoritative for variant *names* and
+> verify the exact set in `src/events.rs` before depending on a specific variant.
+
+### Subscribers
+
+A single broadcast feeds many consumers; each subscribes independently: ✅
+
+| Subscriber | Role |
+|---|---|
+| **SSE handler** | Streams events to the web GUI (Phase 2 consumer still partial). |
+| **Audit logger** | Persists an audit trail of session/agent/tool activity. |
+| **Controller monitor** | Drives controller-side state and health. |
+| **Task store updater** | Updates the task/session store as events arrive. |
+| **CTRL REPL printer** | Renders live activity into the ratatui TUI. |
+| **ProcessTracker** | Reacts to subprocess lifecycle to maintain PID state. |
+
+Because broadcast has bounded capacity (1024), slow subscribers can lag; this is
+acceptable for UI/audit consumers but is a consideration for any future
+back-pressure-sensitive consumer.
+
+---
+
+## 4. Source Module Map
+
+Top-level modules under `crates/open-mpm/src/` and their responsibilities. Some
+modules cited in the originating research as single `.rs` files (e.g.
+`ctrl/mod.rs`'s `ctrl_turn`/`pm_task`, `workflow/engine.rs`) have since been
+split into same-named **subdirectories** during the 500-line-cap sweep
+(#358–#366); paths below reflect the reviewed layout.
+
+| Module | Responsibility |
+|---|---|
+| `src/ctrl/` | CTRL actor: `state.rs`, `config.rs`, `ctrl_turn/`, `pm_task/`, `repl/`, `socket.rs`, `socket_listener.rs`, `handlers/`, `claude_cli.rs`, `supervisor/` |
+| `src/agents/` | `AgentConfig` TOML loader (`config.rs`, `loader.rs`), model resolution (`model.rs`), credential routing, persona injection (`persona/`), `in_process_runner.rs`, `claude_code_runner/`, `prompt_builder/`, `registry/`, `harness_protocol.rs`, `context_filter.rs` |
+| `src/workflow/` | `WorkflowEngine` (`engine/`), `WorkflowDef`/`PhaseDef` (`config/`), `WorkflowContext` (`context.rs`), parallel wave (`parallel.rs`), worktree mgmt (`worktree.rs`), ticket tracking (`tickets.rs`), autopush (`autopush.rs`), `resolver.rs` |
+| `src/tools/` | `ToolRegistry` (`registry/`), `ToolExecutor` trait (`traits.rs`), `delegate.rs`, `fs_reader/`, `git_tools/`, `mcp_tools/` + `mcp_service_tools.rs`, `memory/`, `analysis/`, `ast_tools/`, `phase_audit.rs`, `finish_task.rs`, `write_file.rs`, `shell_exec.rs`, `web_search.rs`, `skill_loader/`, `native_*` |
+| `src/llm/` | LLM client (OpenRouter / AnthropicDirect / Bedrock), credential routing (`credentials.rs`), tool loop (`tool_loop/`), `single_turn.rs`, compression (`compress.rs`), `thinking_classifier.rs`, `anthropic_native/`, `bedrock/`, `adapter/`, `http.rs` |
+| `src/compress/` | Deterministic NLP compression (dedup, history sliding-window, tool-output, context, session) |
+| `src/skills/` | `SkillRegistry` (tag index), `SkillsLoader` (lang/framework detection), LLM-backed selection (`llm.rs`), `GlobalSkillsCache` |
+| `src/memory/` | `RedbUsearchStore`, `SessionStore`, `CodeStore`, `FastEmbedder`, `MemoryGraph`, `TrustyBacked` |
+| `src/repl/` | ratatui TUI, `ReplBridge`, slash commands, `agent_commands`, banner, dispatch |
+| `src/ipc/` | NDJSON `IpcMessage` codec |
+| `src/subprocess/` | `SubprocessAgentRunner`, spawn helpers |
+| `src/bus/` | UNIX-socket `MessageBus`, `BusEnvelope` |
+| `src/telegram/` | Telegram bot (handlers, pairing, format, session persistence) |
+| `src/context/` | `ContextManager` (token budget), `ClusterStore` (BM25 + embedding), conversation-history indexing (`retrieval.rs`) |
+| `src/registry/` | `ProjectRegistry` (`~/.open-mpm/projects.json`) |
+| `src/search/` | Code indexer + file watcher (tree-sitter) |
+| `src/tm/` | `TmManager` (tmux session mgmt), `TmProject`, `TmSession`, adapter detection |
+| `src/identity/` | `UserProfile` |
+| `src/init/` | `ProjectInitializer` (`project-index.md` generation, kuzu-memory loading) |
+| `src/mcp/` | MCP server/client integration |
+| `src/ticketing/` | GitHub Issues ticketing |
+| `src/eval/` | Bake-off evaluation harness |
+| `src/ast/` | AST-native substrate flag, tree-sitter tooling |
+| `src/rbac/` | Role-based access control |
+| `src/slack/` | Slack integration |
+| `src/api/` | Axum HTTP API server (split from the 3,360-line `server.rs` via #364) |
+
+Additional modules present in the tree include `src/adapters/`, `src/cli/`,
+`src/debugger/`, `src/git/`, `src/inspection/`, `src/intent/`,
+`src/local_inference/`, `src/logging/`, `src/perf/`, `src/plugins/`,
+`src/recap/`, `src/rpc/`, `src/service/`, `src/tmux/`, `src/update/`,
+`src/usage/`, plus top-level support files (`runtime/`, `session*.rs`,
+`state_writer.rs`, `interaction_log.rs`, `mistake_log.rs`, `progress.rs`).
+
+---
+
+## 5. Model-Agnostic Dispatch (core differentiator)
+
+This is the heart of open-mpm's product claim: **any agent → any model → any
+provider**, configured per-agent in TOML, with no code changes. It has six
+moving parts: credential priority, per-agent TOML, the three runner kinds, the
+four LLM backend paths, session-level override, model qualification, and
+thinking mode.
+
+### 5.1 Credential priority (`src/llm/credentials.rs`)
+
+The `LlmCredentials` enum has three variants. `pick_credentials()` checks env
+vars **in priority order — first match wins** (verified in
+`src/llm/credentials.rs`): ✅
+
+| Priority | Credential | Label | Env var | Effect |
+|---|---|---|---|---|
+| 1 (highest) | `ClaudeCode` | `"claude-code"` | `CLAUDE_CODE_OAUTH_TOKEN` | Routes to `ClaudeCodeAgentRunner` (spawns the `claude` CLI). |
+| 2 | `AnthropicDirect` | `"anthropic-direct"` | `ANTHROPIC_API_KEY` | POSTs to `api.anthropic.com` with `x-api-key`. |
+| 3 | `OpenRouter` | `"openrouter"` | `OPENROUTER_API_KEY` | Routes through `openrouter.ai/api/v1` (500+ models). |
+
+Important nuance from the implementation: `ClaudeCode` is selected **only when
+`runner == Some(RunnerKind::ClaudeCode)` *and* `CLAUDE_CODE_OAUTH_TOKEN` is
+set** — because an OAuth token would 401 against the Anthropic REST API, so it
+must drive the CLI subprocess. Otherwise the function prefers `AnthropicDirect`,
+then `OpenRouter`.
+
+### 5.2 Per-agent TOML
+
+Each agent's behavior — including its model and provider — is declared in TOML
+(`AgentConfig`, `src/agents/config.rs`). Reassigning a role to a different model
+or provider is a two-line edit, no code change: ✅
+
+```toml
+[agent]
+model  = "anthropic/claude-sonnet-4-6"   # OpenRouter format: provider/model-id
+runner = "claude-code"                    # or "subprocess", "in-process"
+
+[llm]
+use_anthropic_direct = true               # bypass OpenRouter, POST api.anthropic.com
+aws_profile          = "prod"             # AWS Bedrock
+aws_region           = "us-east-1"
+model_override       = "gpt-4.1"          # beats [agent].model when set
+elevation_threshold  = 5000               # token count that triggers elevation_model
+elevation_model      = "anthropic/claude-opus-4-5"
+```
+
+### 5.3 Three runner kinds (`RunnerKind`)
+
+Dispatch chooses one of three runners per agent invocation; `DispatchingAgentRunner`
+selects by `RunnerKind`: ✅
+
+1. **`RunnerKind::ClaudeCode`** — `ClaudeCodeAgentRunner` invokes the `claude`
+   CLI as a subprocess. OAuth-token auth (`CLAUDE_CODE_OAUTH_TOKEN`), model via
+   the `--model` flag, supports extended thinking. (`src/agents/claude_code_runner/`,
+   `src/ctrl/claude_cli.rs`)
+2. **`RunnerKind::InProcess`** — `InProcessAgentRunner` runs the tool loop *inside
+   the controller process* over the Anthropic/OpenRouter REST path. Shares
+   `Arc<SkillRegistry>`, `Arc<CodeStore>`, and a singleton `reqwest::Client`.
+   Intended for **read-only agents** (avoids the 2–3 s embedder re-init of a fresh
+   subprocess). (`src/agents/in_process_runner.rs`)
+3. **`RunnerKind::Subprocess`** — `SubprocessAgentRunner` re-invokes the binary
+   as `open-mpm --agent <name>`, giving full OS process isolation over NDJSON.
+   **Required for `ShellExec`/`WriteFile` agents.** (`src/subprocess/`)
+
+### 5.4 Four LLM backend paths (`llm::chat_with_tools_gated`)
+
+Beneath the runners, the actual HTTP/CLI transport resolves to one of four
+backend paths: ✅
+
+1. **Bedrock** (`src/llm/bedrock/`) — AWS Bedrock via `OPEN_MPM_AWS_PROFILE` /
+   `OPEN_MPM_AWS_REGION`.
+2. **AnthropicNative** (`src/llm/anthropic_native/`) — REST to
+   `api.anthropic.com`; supports extended thinking and prompt caching via
+   `cache_control`.
+3. **OpenRouter raw** (`send_raw_completion`) — `reqwest` raw POST for
+   non-standard headers OpenRouter requires.
+4. **async-openai typed** (`client.chat().create()`) — the default,
+   OpenAI-compatible path.
+
+### 5.5 Session-level override
+
+`/model` and `/provider` in the REPL store `model_override` / `provider_override`
+on `OpenMpmRepl`. They are injected **after** `AgentConfig::load()` and **before**
+`apply_credential_routing()`, so a session override **takes precedence over both
+the TOML `model` and the env-var credential**. ✅
+
+> **Caveat:** the legacy stdin REPL turn `ctrl_chat_turn` (~`src/ctrl/mod.rs:3391`)
+> hardcodes `CTRL_MODEL` and calls `llm::chat()` directly *without*
+> `pick_credentials()`, so that one path always routes via OpenRouter regardless
+> of overrides/credentials. The ratatui `run_pm_task_with_history` path routes
+> correctly. (PRD FR-1.4) 🟡
+
+### 5.6 Model qualification
+
+`qualify_openrouter_model(&creds, &model_name)` injects an `"anthropic/"` prefix
+for bare Claude model IDs **when routing via OpenRouter** (the OpenRouter
+`provider/model-id` convention, #268). When `use_anthropic_direct` or
+`claude-code` is in effect, the model name is passed **verbatim**. ✅
+
+### 5.7 Thinking mode
+
+`ThinkingMode` classification (`src/llm/thinking_classifier.rs`) determines
+extended-thinking applicability per model/provider — e.g. Anthropic-native and
+claude-CLI paths support extended thinking; other backends may not. The
+classifier gates whether a thinking budget is requested for a given dispatch. ✅
+
+### 5.8 End-to-end dispatch flow (summary)
+
+```
+AgentConfig::load(<name>)            # [agent].model, [agent].runner, [llm].*
+   │
+   ├─ session override?  →  apply model_override / provider_override
+   │
+   ├─ apply_credential_routing()     # pick_credentials(): ClaudeCode > AnthropicDirect > OpenRouter
+   │
+   ├─ qualify_openrouter_model()     # prefix "anthropic/" only for OpenRouter routing
+   │
+   ├─ ThinkingMode classification    # extended-thinking applicability
+   │
+   └─ DispatchingAgentRunner (RunnerKind)
+         ├─ ClaudeCode   → claude CLI subprocess (--model, OAuth)
+         ├─ InProcess    → tool loop in controller → backend path
+         └─ Subprocess   → open-mpm --agent <name> (NDJSON) → backend path
+                              backend = Bedrock | AnthropicNative | OpenRouter-raw | async-openai
+```
+
+> **Known dispatch gaps:** `llm::create_client()` is called **per request** in
+> `run_pm_task_with_history` / `run_pm_task_with_persona` (no singleton client on
+> those paths — `InProcessAgentRunner` *does* cache correctly); there is **no
+> adaptive system prompt per model family** (Claude vs GPT vs Llama tool-calling
+> differences — a gap vs Cline); and the system prompt is rebuilt per request
+> with **no stabilized cache prefix** (Codex-CLI-style cache-prefix ordering not
+> applied). See PRD §6.

--- a/docs/open-mpm/spec/COMPONENTS.md
+++ b/docs/open-mpm/spec/COMPONENTS.md
@@ -1,0 +1,292 @@
+# open-mpm — Component Specifications
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** research synthesis + code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+One section per major subsystem. Each states **Responsibility**, **Key
+types/modules** (with `src/` paths), **Current state**, and **Known gaps**,
+framed Vision / Current / Gap. For the cross-cutting dispatch model see
+[ARCHITECTURE.md §5](./ARCHITECTURE.md); for product framing see
+[PRD.md](./PRD.md).
+
+---
+
+## 1. PM Orchestration / CTRL — `src/ctrl/`
+
+**Responsibility.** The persistent controller that coordinates everything: it
+owns the per-project PM actors, the event bus, the process tracker, the HTTP
+API, and the CLI socket listener. The PM actor reads input, calls the LLM with a
+`delegate_to_agent` tool, and routes work to sub-agents.
+
+**Key types/modules.**
+- `src/ctrl/state.rs` — controller state.
+- `src/ctrl/config.rs` — controller/CTRL configuration.
+- `src/ctrl/ctrl_turn/` — the CTRL-scope LLM turn (split from `mod.rs`).
+- `src/ctrl/pm_task/` — PM-scope task execution (`run_pm_task_with_history`, `run_pm_task_with_persona`).
+- `src/ctrl/repl/` — REPL glue for the controller.
+- `src/ctrl/socket.rs`, `src/ctrl/socket_listener.rs` — UNIX socket controller protocol.
+- `src/ctrl/handlers/`, `src/ctrl/supervisor/`, `src/ctrl/claude_cli.rs`.
+- `PmHandle` map — one tokio task per connected project.
+- Tool registries: `build_ctrl_registry()` (CTRL) + inline PM registry.
+
+**Current state.** ✅ Multi-project coordination works: `/connect <path>` wires
+the REPL to a project PM, and several projects run concurrently. The UNIX socket
+protocol lets a second invocation act as a CLI client to a running controller.
+The credential-correct PM path is `run_pm_task_with_history`.
+
+**Known gaps.**
+- 🟡 **Credential-routing bug:** `ctrl_chat_turn` (legacy stdin REPL,
+  ~`src/ctrl/mod.rs:3391`) hardcodes `CTRL_MODEL` and calls `llm::chat()` without
+  `pick_credentials()`, so it always routes via OpenRouter (PRD FR-1.4).
+- 🟡 **No singleton enforcement:** two near-simultaneous invocations can race on
+  the socket instead of the second auto-routing (PRD FR-1.3).
+- 🟡 **Oversized file:** `src/ctrl/mod.rs` ~5,730 lines (#170), partially split.
+- 🔵 **User-level cancel unimplemented** (the `SessionCancelled` event exists).
+
+---
+
+## 2. Sub-Agent Subprocess Model — `src/subprocess/`, `src/ipc/`
+
+**Responsibility.** Run delegated agent tasks with the right isolation: file/shell
+agents in isolated OS subprocesses (crash isolation), read-only agents as
+in-process tokio tasks (avoid embedder re-init).
+
+**Key types/modules.**
+- `src/subprocess/` — `SubprocessAgentRunner`, spawn helpers (re-invokes the
+  binary as `open-mpm --agent <name>`).
+- `src/ipc/mod.rs` — `IpcMessage` NDJSON codec.
+- `AgentRunner` trait + `DispatchingAgentRunner` (selects by `RunnerKind`).
+- `InProcessAgentRunner` (`src/agents/in_process_runner.rs`).
+
+**Current state.** ✅ NDJSON IPC over stdin/stdout with stderr inherited and
+separate read/write tokio tasks to avoid deadlock. `{"type":"task"}` →
+`{"type":"result"}` / `{"type":"error"}` then the sub-agent exits. Isolation
+policy enforced: `ShellExec`/`WriteFile` agents are subprocess-isolated;
+read-only agents may run in-process.
+
+**Known gaps.**
+- 🔵 **No result summarization:** full sub-agent `content` is returned to the PM;
+  there is no `attempt_completion`-style summary compression (the `summary` wire
+  field is present but not the path the PM consumes). Inflates PM context
+  (PRD FR-2.4).
+- ⚪ **No OS-native sandbox** (seatbelt/bubblewrap) — explicit non-goal; isolation
+  is process-level only.
+
+---
+
+## 3. Tool-Using Agents — `src/tools/`
+
+**Responsibility.** Give agents a multi-turn LLM tool-call loop over a rich,
+per-agent-gated tool set, with safe filesystem and shell access.
+
+**Key types/modules.**
+- `src/tools/registry/` — `ToolRegistry` (OpenAI-compatible schemas).
+- `src/tools/traits.rs` — `ToolExecutor` trait.
+- `src/tools/delegate.rs` — `delegate_to_agent`.
+- `src/tools/fs_reader/`, `src/tools/write_file.rs` (atomic, `out_dir`-sandboxed),
+  `src/tools/shell_exec.rs` / `shell.rs` / `run_bash.rs`.
+- `src/tools/git_tools/`, `src/tools/mcp_tools/` + `mcp_service_tools.rs`,
+  `src/tools/memory/` + `memory_search.rs`, `src/tools/analysis/`,
+  `src/tools/ast_tools/`, `src/tools/phase_audit.rs`, `src/tools/finish_task.rs`,
+  `src/tools/web_search.rs`, `src/tools/skill_loader/`, `src/tools/native_*`.
+
+**Current state.** ✅ 30+ tools across read/write/shell/web/skills/delegation/
+git/MCP/ticketing/memory. Atomic `write_file` sandboxed to `out_dir`. Per-agent
+allowlists via `dispatch_gated`. Two registries: `build_ctrl_registry()` for
+CTRL and an inline PM registry. AST-native tools (`src/tools/ast_tools/`) reduce
+round-trips and are validated at workflow L1/L2/L3.
+
+**Known gaps.**
+- 🟡 The tag-indexed skill registry is **not threaded** into sub-agent tool
+  registries (see §4). 
+
+---
+
+## 4. Skill Injection — `src/skills/`
+
+**Responsibility.** Discover, select, and compose Markdown skills into agent
+prompts; surface the four coding personas.
+
+**Key types/modules.**
+- `SkillRegistry` (tag index) + `SkillRegistry::auto_inject` (tag scoring).
+- `SkillsLoader` (language/framework detection).
+- `src/skills/llm.rs` — LLM-backed selection.
+- `GlobalSkillsCache`.
+- `PhaseDef.skills: Option<Vec<String>>` (per-phase skills).
+- Personas via `src/agents/persona/`.
+
+**Current state.** 🟡 Five-tier discovery
+(`.open-mpm/skills/` > `.claude/skills/` > `~/.open-mpm/skills/` >
+`~/.claude/skills/` > bundled). Skills are Markdown + YAML frontmatter
+(`name`/`description`/`tags`). Two selection mechanisms plus LLM-backed
+selection. Per-phase skills work. Four personas (engineer/hacker/vibe-coder/
+novice) delivered.
+
+**Known gaps.**
+- 🟡 Skill source paths are **hard-coded** — no operator-configurable skill source
+  URLs.
+- 🟡 **No persistent skill index:** rebuilt each run; `GlobalSkillsCache` exists
+  but is unwired; the tag-indexed `list_skills` path is implemented but
+  `#[allow(dead_code)]` pending wiring; `TagSkillRegistry` is built at startup but
+  not threaded into sub-agent registries.
+- 🔵 No skill-effectiveness scoring / feedback loop.
+
+---
+
+## 5. Workflow Engine — `src/workflow/`
+
+**Responsibility.** Run declarative, multi-phase JSON workflows
+(research → plan → code → QA → observe) with per-phase agent, context template,
+tool set, skill list, AST-substrate flag, and dependencies; in sequential or
+parallel-wave mode.
+
+**Key types/modules.**
+- `src/workflow/config/` — `WorkflowDef` / `PhaseDef`.
+- `src/workflow/engine/` — `WorkflowEngine` (prescriptive mode).
+- `src/workflow/parallel.rs` — wave mode (parallel sub-tasks).
+- `src/workflow/worktree.rs` — git worktree management for waves.
+- `src/workflow/context.rs` — `WorkflowContext` (inter-phase template substitution).
+- `src/workflow/tickets.rs`, `autopush.rs`, `resolver.rs`.
+- Per-phase `ast_native: Option<bool>` with an RAII guard; `PerfCollector` for
+  per-phase timing/cost.
+
+**Current state.** ✅ Both modes implemented: **prescriptive** (sequential) and
+**wave** (parallel sub-tasks with git worktrees). Per-phase AST-native substrate
+toggling validated at L1/L2/L3. Inter-phase outputs flow via template
+substitution. Phase ticket tracking, autopush, and per-phase perf collection
+work.
+
+**Known gaps.**
+- 🟡 **Oversized file:** `src/workflow/engine.rs` ~4,965 lines (#172); being split
+  into `src/workflow/engine/`.
+
+---
+
+## 6. Token Compression — `src/compress/`
+
+**Responsibility.** Keep prompts inside per-model budgets using **deterministic**
+NLP (no LLM calls), preserving the most relevant context.
+
+**Key types/modules.**
+- `CompressConfig` (target/max token budgets).
+- Pipeline stages: tool-output filtering → dedup (`dedup_sections`) →
+  sliding-window (`TokenBudget`) → stop-word removal → TF-IDF.
+- `ContextManager` (trims to a `soft_threshold` fraction).
+- Per-agent `[compress]` TOML.
+- `src/llm/compress.rs` integration.
+
+**Current state.** ✅ Full pipeline implemented. Model-aware context windows:
+Claude 200k, GPT-5.1-codex 400k, unknown 128k.
+
+**Known gaps.** None material at this time.
+
+---
+
+## 7. Memory & Search — `src/memory/`, `src/search/`, `src/context/`, `src/init/`
+
+**Responsibility.** Provide embedded, service-free vector memory; code search;
+project-index generation; and hybrid retrieval for context assembly.
+
+**Key types/modules.**
+- `src/memory/` — `RedbUsearchStore` (redb metadata + usearch HNSW),
+  `SessionStore`, `CodeStore`, `FastEmbedder`, `MemoryGraph`, `TrustyBacked`.
+- `SessionRegistry` (`src/session_registry.rs`).
+- `src/search/` — tree-sitter code indexer + file watcher; trusty-search MCP
+  integration.
+- `src/context/retrieval.rs` — BM25 + embedding hybrid; `ClusterStore` (2× boost).
+- `src/init/` — `ProjectInitializer` (`project-index.md`, 24 h TTL, injected into
+  the PM prompt; kuzu-memory loading).
+
+**Current state.** ✅ Embedded memory with no external services. Per-session
+stores and registry. Code search via in-tree indexer + trusty-search MCP. Hybrid
+BM25+embedding retrieval with cluster boosting. Project index generated and
+injected into PM prompts.
+
+**Known gaps.**
+- 🔵 **No hierarchical `AGENTS.md`-style directory walking** — a single root
+  `CLAUDE.md` is used (gap vs nested-context harnesses).
+
+---
+
+## 8. Global Infrastructure — `src/registry/`, `src/bus/`, `src/process_tracker.rs`
+
+**Responsibility.** Cross-process, cross-project coordination state on the local
+filesystem and over UNIX sockets.
+
+**Key types/modules.**
+- `src/registry/` — `ProjectRegistry` at `~/.open-mpm/projects.json`.
+- `src/bus/` — UNIX-socket `MessageBus` + `BusEnvelope` at
+  `~/.open-mpm/sockets/<id>.sock`.
+- `src/process_tracker.rs` — `ProcessTracker`, PID lifecycle at
+  `~/.open-mpm/processes.json`.
+- Shared skills at `~/.open-mpm/skills/`.
+
+**Current state.** ✅ Project registry, inter-project UNIX-socket message bus,
+process tracker, and shared-skills directory all in place.
+
+**Known gaps.**
+- 🟡 **No `backon` retry** on 429/5xx LLM responses.
+- 🟡 **Hand-rolled CLI arg parsing** — **clap migration is HIGH priority** (the
+  multi-mode `src/main.rs` dispatch is bespoke today).
+
+---
+
+## 9. UI Surfaces — TUI / Web / Telegram
+
+Three surfaces share the controller's event bus and HTTP API. Completeness
+varies: **TUI ~80%, Web ~40%, Telegram ~60%.**
+
+### 9.1 TUI — `src/repl/`
+
+**Responsibility.** Primary surface for power developers: live REPL, slash
+commands, scope-colored output, subagent panel, statusline.
+
+**Key types/modules.** ratatui TUI, `ReplBridge`, slash-command dispatch,
+`agent_commands`, banner. `OpenMpmRepl` holds `model_override` /
+`provider_override`.
+
+**Current state.** ✅/🟡 (~80%). Slash commands implemented:
+`/help /connect /disconnect /model /provider /agent /projects /status /tools
+/workflow /version /quit`. Scope colors: cyan = User/ctrl, yellow = Project/PM.
+Subagent panel and statusline present. `/model` and `/provider` overrides applied
+before credential routing (ARCHITECTURE §5.5). **tmux e2e harness**
+(`scripts/tmux-repl-test.sh`) is required before REPL/CTRL commits.
+
+**Known gaps.** 🔵 Token streaming is Phase 4.
+
+### 9.2 Web GUI — Tauri + Svelte
+
+**Responsibility.** Surface for PMs/team leads: sidebar project status, task
+history, cost tracking, dispatch without CLI.
+
+**Key types/modules.** Tauri + Svelte app; Axum HTTP API (`src/api/`, split from
+the 3,360-line `server.rs` via #364); SSE event consumer.
+
+**Current state.** 🟡 (~40%). The GUI exists; the HTTP API and SSE backend are
+in place.
+
+**Known gaps.** 🔵 **Phase 2** features all outstanding: SSE consumer wiring,
+subagent-activity strip, footer statusline, command palette (Cmd+K), tool-call
+cards, session persistence. Web UI currently **polls every ~2 s** (no real-time
+push); token streaming is Phase 4.
+
+### 9.3 Telegram — `src/telegram/`
+
+**Responsibility.** Mobile/async surface: kick off tasks, monitor progress,
+receive results from a phone (`--telegram`).
+
+**Key types/modules.** `src/telegram/` — handlers, pairing, formatting, session
+persistence.
+
+**Current state.** 🟡 (~60%). Bot runs; pairing, formatting, and basic session
+persistence present; slash commands available.
+
+**Known gaps.** 🔵 **Phase 3** features outstanding: file-based session
+persistence, `/tools`, `/projects`, and `/connect <N>`. Token streaming is
+Phase 4.
+
+> A **Slack** integration also exists (`src/slack/`) as an additional surface
+> beyond the three primary personas' surfaces.

--- a/docs/open-mpm/spec/COMPONENTS.md
+++ b/docs/open-mpm/spec/COMPONENTS.md
@@ -39,8 +39,8 @@ The credential-correct PM path is `run_pm_task_with_history`.
 
 **Known gaps.**
 - 🟡 **Credential-routing bug:** `ctrl_chat_turn` (legacy stdin REPL,
-  ~`src/ctrl/mod.rs:3391`) hardcodes `CTRL_MODEL` and calls `llm::chat()` without
-  `pick_credentials()`, so it always routes via OpenRouter (PRD FR-1.4).
+  `crates/open-mpm/src/ctrl/ctrl_turn/dispatch.rs:48`) hardcodes `CTRL_MODEL` and calls `llm::chat()` without
+  `pick_credentials()`, so it always routes via OpenRouter. (#408; supersedes pre-refactor `src/ctrl/mod.rs:3391` from #358–#366 cap-sweep module split.) (PRD FR-1.4).
 - 🟡 **No singleton enforcement:** two near-simultaneous invocations can race on
   the socket instead of the second auto-routing (PRD FR-1.3).
 - 🟡 **Oversized file:** `src/ctrl/mod.rs` ~5,730 lines (#170), partially split.

--- a/docs/open-mpm/spec/PRD.md
+++ b/docs/open-mpm/spec/PRD.md
@@ -1,0 +1,350 @@
+# open-mpm — Product Requirements Document
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** research synthesis + code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+Each requirement is framed **Vision / Current / Gap**.
+
+---
+
+## 1. Vision & Mission
+
+### North-star vision
+
+> **open-mpm is a superset of Warp and Claude Code** — an *agentic assistant
+> manager* **and** an *original coding harness* whose defining property is that
+> **any model can be used for any agent**: OpenRouter (500+ models), the direct
+> Anthropic API, AWS Bedrock, and the `claude` CLI — assignable per-agent via
+> TOML, with no code changes.
+
+Where Claude Code is locked to the `claude` CLI and Anthropic's runtime, and
+Warp manages sessions for a single model family, open-mpm aspires to be the
+**coordination layer *above* any LLM provider**. Different agents in the *same
+session* can be backed by different providers simultaneously — a cheap fast
+model for read-only triage, a frontier model for the hard coding phase, a
+local/OpenRouter model for bulk work — and switching a role from one provider to
+another is a two-line TOML edit.
+
+open-mpm re-implements the PM-orchestrator-plus-specialized-subagent pattern
+that **claude-mpm** pioneered, in **Rust**, for a single-binary, low-overhead,
+local deployment model — with a radically broader model-choice surface.
+
+### Mission
+
+Deliver a single, self-contained binary that lets a developer (or a team lead,
+or a phone) hand off a high-level task and have it coordinated across multiple
+specialized agents, each running on whichever model makes sense for its role —
+without managing the orchestration by hand, and without a cloud service, a
+Python runtime, or a Node.js dependency in the core.
+
+### Why this is novel
+
+The research corpus positioned open-mpm as: *"no competing Rust harness matches
+claude-mpm's feature set — open-mpm would be novel."* The competitive frame is
+Roo Code, Cline, Kilo.ai, and the OpenAI Codex CLI; the differentiator versus
+all of them is **model-agnostic, per-agent, multi-provider dispatch** combined
+with **process-isolated sub-agents** in a **single Rust binary**.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+| # | Goal | Status |
+|---|---|---|
+| G1 | **PM orchestration** — a long-running CTRL layer coordinating multiple PM sessions across project directories. | ✅ |
+| G2 | **Subprocess delegation with process isolation** — sub-agents spawned as OS subprocesses or tokio tasks over NDJSON IPC; crash isolation for file-writing/shell agents. | ✅ |
+| G3 | **Model-agnostic dispatch** — any agent → any model → any provider; credential routing (ClaudeCode > AnthropicDirect > OpenRouter) plus per-agent TOML. | ✅ 🟡 (one legacy code path bypasses routing — see §4.1 / FR-1.4) |
+| G4 | **Skill injection** — Markdown skills composed into prompts; five-tier discovery; auto-select by tag/language/relevance. | 🟡 |
+| G5 | **Declarative workflow engine** — JSON multi-phase workflows (research → plan → code → QA → observe), per-phase agent assignment, skill injection, AST-native/traditional substrate switching, parallel wave execution. | ✅ |
+| G6 | **Token compression** — deterministic NLP: tool-output filtering, dedup, sliding-window, stop-word removal, TF-IDF. | ✅ |
+| G7 | **Three UI surfaces** — ratatui TUI, Tauri + Svelte GUI, Telegram bot. | 🟡 (TUI ~80%, Web ~40%, Telegram ~60%) |
+| G8 | **Inter-project message bus** — UNIX domain socket. | ✅ |
+| G9 | **Vector memory** — embedded redb + usearch + fastembed; no external services. | ✅ |
+| G10 | **Competitive benchmarking** — ai-coding-bake-off L1–L5. | 🟡 (L1–L3 validated) |
+
+### Non-Goals
+
+| Non-Goal | Rationale |
+|---|---|
+| Central server / cloud-hosted execution | open-mpm is a single-binary **local** tool. |
+| Forcing a single LLM provider or model family | BYOK + model choice is first-class; the opposite of the product. |
+| Python runtime or Node.js dependency for the **core** | Rust-native single binary; Node is only used to build embedded Svelte UIs. |
+| VS Code extension | Possible future surface; out of scope today. |
+| OS-native sandboxing (macOS seatbelt / Linux bubblewrap) | A known gap vs Codex CLI; **not planned**. Isolation is process-level only. |
+
+---
+
+## 3. Target Users / Personas
+
+| Persona | Who | Primary need | Surface |
+|---|---|---|---|
+| **Power developer** | Engineers living in the terminal | Slash commands, keybindings, live status bars, multi-project switching | ratatui **TUI** |
+| **Project manager / team lead** | Coordinators who prefer chat over CLI | Sidebar of project status, task history, cost tracking, dispatch without CLI | Tauri + Svelte **GUI** |
+| **Mobile / async user** | People away from the desk | Kick off tasks from a phone, monitor progress, receive results | **Telegram** bot |
+
+**Unifying need across all three:** delegate a high-level task across multiple
+agents, using whichever models make sense for each role, without managing the
+orchestration manually.
+
+Additionally, four **coding personas** are surfaced *through the skill system*
+(not user accounts): **engineer**, **hacker**, **vibe-coder**, **novice** —
+each shaping prompt style and skill selection (see FR-4).
+
+---
+
+## 4. Functional Requirements
+
+Grouped by capability area. Each requirement carries Vision / Current / Gap and
+an inline status tag. Source paths are cited where known.
+
+### 4.1 PM Orchestration & CTRL (`src/ctrl/`)
+
+**FR-1.1 — Persistent CTRL coordinator** ✅
+- *Vision:* A single long-running controller manages a per-project PM actor (one tokio task per active project), reading input, calling the LLM with a `delegate_to_agent` tool, and routing to sub-agents.
+- *Current:* Implemented in `src/ctrl/` (state, config, `ctrl_turn/`, `pm_task/`, `repl/`, `socket.rs`, `socket_listener.rs`, `handlers/`, `claude_cli.rs`).
+- *Gap:* `ctrl/mod.rs` remains oversized (~5,730 lines, #170) and is being split incrementally.
+
+**FR-1.2 — Multi-project dispatcher** ✅
+- *Vision:* `/connect <path>` wires the REPL to a project PM; multiple projects coordinated simultaneously from one controller.
+- *Current:* Implemented; a `PmHandle` map holds one tokio task per connected project.
+- *Gap:* None material; cancel semantics are weak (see FR-1.5).
+
+**FR-1.3 — Singleton controller via UNIX socket** 🟡
+- *Vision:* A second CLI invocation detects the running CTRL over its UNIX socket and routes the command to it instead of spawning a duplicate (`src/ctrl/socket.rs`, `socket_listener.rs`).
+- *Current:* Socket protocol exists; CLI probes `~/.open-mpm/sockets/<project>.ctrl.sock` (50 ms timeout) and can run as a client.
+- *Gap:* **No singleton enforcement** — two near-simultaneous invocations can race on the socket rather than the second reliably auto-routing.
+
+**FR-1.4 — Credential-correct PM turns** 🟡
+- *Vision:* Every PM/CTRL turn routes through `pick_credentials()` so the configured provider priority is honored.
+- *Current:* The ratatui path (`run_pm_task_with_history`) routes correctly.
+- *Gap:* **Credential-routing bug** — the legacy stdin REPL turn (`ctrl_chat_turn`, ~`src/ctrl/mod.rs:3391`) hardcodes `CTRL_MODEL` and calls `llm::chat()` directly *without* `pick_credentials()`, so it always routes via OpenRouter regardless of configured credentials.
+
+**FR-1.5 — User-level cancellation** 🔵
+- *Vision:* A user can cancel an in-flight PM/agent task from any surface.
+- *Current:* `SessionCancelled` event exists in the bus.
+- *Gap:* Cancel is **unimplemented at the user level** — no surface reliably interrupts a running task.
+
+### 4.2 Sub-Agent Subprocess Model (`src/subprocess/`, `src/ipc/`)
+
+**FR-2.1 — Subprocess sub-agents** ✅
+- *Vision:* Sub-agents spawned via `tokio::process::Command` re-invoking the binary as `open-mpm --agent <name>`, with full OS isolation.
+- *Current:* Implemented; `SubprocessAgentRunner` in `src/subprocess/`.
+- *Gap:* None material.
+
+**FR-2.2 — NDJSON IPC** ✅
+- *Vision:* PM writes `{"type":"task"}`; sub-agent returns `{"type":"result"}` or `{"type":"error"}` then exits (`src/ipc/mod.rs`).
+- *Current:* Implemented; stdin/stdout piped, stderr inherited, separate read/write tokio tasks prevent deadlock.
+- *Gap:* None material.
+
+**FR-2.3 — Isolation policy** ✅
+- *Vision:* File/shell agents **must** be subprocess-isolated; read-only agents may run as tokio tasks to avoid the 2–3 s embedder re-init cost.
+- *Current:* `InProcessAgentRunner` + `SubprocessAgentRunner` implement the `AgentRunner` trait; `DispatchingAgentRunner` selects by `RunnerKind`.
+- *Gap:* None for the policy itself; see FR-2.4 for the result-handling gap.
+
+**FR-2.4 — Result summarization** 🔵
+- *Vision:* Sub-agent results compressed to a PM-facing summary (Roo Code's `attempt_completion` pattern) rather than returning full content.
+- *Current:* **Full** sub-agent content is returned to the PM.
+- *Gap:* No summary-compression step between sub-agent and PM, inflating PM context.
+
+### 4.3 Tool-Using Agents (`src/tools/`)
+
+**FR-3.1 — Multi-turn tool-call loop** ✅
+- *Vision:* Agents run an LLM tool-call loop over a rich tool set: `read_file`, `write_file` (atomic, sandboxed to `out_dir`), `shell_exec`, `web_search`, `load_skill`, `list_skills`, `delegate_to_agent`, git tools, MCP service tools, ticketing, memory.
+- *Current:* 30+ tools implemented with OpenAI-compatible schemas; atomic `write_file` with `out_dir` sandboxing (`src/tools/write_file.rs`, `shell_exec.rs`, `delegate.rs`, `git_tools/`, `mcp_tools/`, `memory/`, …).
+- *Gap:* None material.
+
+**FR-3.2 — Per-agent tool allowlists** ✅
+- *Vision:* Each agent exposes only the tools its role needs (`dispatch_gated`).
+- *Current:* Two registries — `build_ctrl_registry()` for CTRL and an inline PM registry for `run_pm_task_with_history`; per-agent allowlists applied.
+- *Gap:* TagSkillRegistry not threaded into sub-agent registries (see FR-4.4).
+
+**FR-3.3 — AST-native tools** ✅
+- *Vision:* Structural introspection tools (`src/tools/ast_tools/`) reduce LLM round-trips versus text grepping.
+- *Current:* Implemented and validated at workflow levels L1/L2/L3.
+- *Gap:* None material.
+
+### 4.4 Skill Injection (`src/skills/`)
+
+**FR-4.1 — Five-tier skill discovery** 🟡
+- *Vision:* Resolve skills across `.open-mpm/skills/` > `.claude/skills/` > `~/.open-mpm/skills/` > `~/.claude/skills/` > bundled.
+- *Current:* Five-tier discovery implemented; skills are Markdown + YAML frontmatter (`name`/`description`/`tags`).
+- *Gap:* Skill source paths are **hard-coded** — no operator-configurable skill source URLs.
+
+**FR-4.2 — Auto-selection** 🟡
+- *Vision:* Two mechanisms — `SkillsLoader` (language/framework detection) and `SkillRegistry::auto_inject` (tag scoring) — plus LLM-backed selection (`src/skills/llm.rs`).
+- *Current:* Both mechanisms exist; LLM-backed selection implemented.
+- *Gap:* No skill-effectiveness scoring / feedback loop to learn which skills help.
+
+**FR-4.3 — Per-phase skills** ✅
+- *Vision:* A phase declares `Option<Vec<String>>` of skills in its `PhaseDef`.
+- *Current:* Implemented in the workflow config.
+- *Gap:* None material.
+
+**FR-4.4 — Persistent skill index** 🟡
+- *Vision:* A tag-indexed skill registry built once and reused, threaded into all (including sub-agent) tool registries.
+- *Current:* `SkillRegistry` tag index and `GlobalSkillsCache` exist; the tag-indexed `list_skills` path is implemented but currently `#[allow(dead_code)]` pending wiring.
+- *Gap:* Index is rebuilt each run (`GlobalSkillsCache` unwired); TagSkillRegistry built at startup but **not threaded** into sub-agent tool registries.
+
+**FR-4.5 — Coding personas** ✅
+- *Vision:* Four personas (engineer / hacker / vibe-coder / novice) shape prompts and skill selection.
+- *Current:* Delivered via the skill system + `src/agents/persona/`.
+- *Gap:* None material.
+
+### 4.5 Workflow Engine (`src/workflow/`)
+
+**FR-5.1 — Declarative JSON workflows** ✅
+- *Vision:* Named phases, each with agent / context template / tool set / skill list / `ast_native` flag / dependency config (`src/workflow/config/`).
+- *Current:* Implemented.
+- *Gap:* `workflow/engine.rs` oversized (~4,965 lines, #172); being split into `workflow/engine/`.
+
+**FR-5.2 — Execution modes** ✅
+- *Vision:* **Prescriptive** (sequential) and **wave** (parallel sub-tasks with git worktrees) (`src/workflow/engine/`, `parallel.rs`).
+- *Current:* Both implemented; worktree management in `src/workflow/worktree.rs`.
+- *Gap:* None material.
+
+**FR-5.3 — Per-phase AST-native substrate** ✅
+- *Vision:* `ast_native: Option<bool>` per phase, toggled via an RAII guard.
+- *Current:* Implemented and validated at L1/L2/L3.
+- *Gap:* None material.
+
+**FR-5.4 — Inter-phase context passing** ✅
+- *Vision:* `WorkflowContext` passes prior-phase outputs into later phases via template substitution.
+- *Current:* Implemented (`src/workflow/context.rs`).
+- *Gap:* None material.
+
+**FR-5.5 — Ticket tracking, autopush, perf** ✅
+- *Vision:* Per-phase ticket tracking (`tickets.rs`), autopush (`autopush.rs`), per-phase timing/cost via `PerfCollector`.
+- *Current:* Implemented.
+- *Gap:* None material.
+
+### 4.6 Token Compression (`src/compress/`)
+
+**FR-6.1 — Deterministic compression pipeline** ✅
+- *Vision:* `CompressConfig` (target/max token budgets) drives: tool-output filtering → dedup (`dedup_sections`) → sliding-window (`TokenBudget`) → stop-word removal → TF-IDF.
+- *Current:* Pipeline implemented; `ContextManager` trims to a `soft_threshold` fraction.
+- *Gap:* None material.
+
+**FR-6.2 — Model-aware context windows** ✅
+- *Vision:* Window sizing per model — Claude 200k, GPT-5.1-codex 400k, unknown 128k — with per-agent `[compress]` TOML.
+- *Current:* Implemented.
+- *Gap:* None material.
+
+### 4.7 CTRL CLI / Multi-Project UX (`src/repl/`, `src/telegram/`, GUI)
+
+**FR-7.1 — TUI REPL slash commands** ✅
+- *Vision:* `/help /connect /disconnect /model /provider /agent /projects /status /tools /workflow /version /quit`, scope colors (cyan = User/ctrl, yellow = Project/PM).
+- *Current:* Implemented in `src/repl/` (ratatui), incl. subagent panel and statusline (~80% complete).
+- *Gap:* Token streaming pending (Phase 4).
+
+**FR-7.2 — Session model/provider override** ✅
+- *Vision:* `/model` and `/provider` set `model_override` / `provider_override` on `OpenMpmRepl`, applied **before** credential routing and beating TOML + env.
+- *Current:* Implemented.
+- *Gap:* None material (note the unrelated `ctrl_chat_turn` bug, FR-1.4).
+
+**FR-7.3 — Telegram bot** 🟡
+- *Vision:* Slash-command parity from a phone (`--telegram`, `src/telegram/`).
+- *Current:* Bot, handlers, pairing, formatting, session persistence exist (~60%).
+- *Gap:* File-based session persistence, `/tools`, `/projects`, `/connect <N>` are Phase 3.
+
+**FR-7.4 — Tauri + Svelte GUI** 🟡
+- *Vision:* Sidebar project status, command palette (Cmd+K), SSE consumer, tool-call cards, cost tracking.
+- *Current:* GUI exists (~40%).
+- *Gap:* SSE consumer, subagent-activity strip, footer statusline, command palette, tool-call cards, session persistence — all Phase 2.
+
+### 4.8 Memory & Search (`src/memory/`, `src/search/`, `src/context/`, `src/init/`)
+
+**FR-8.1 — Embedded vector memory** ✅
+- *Vision:* `RedbUsearchStore` (redb metadata + usearch HNSW) with `FastEmbedder`; no external services.
+- *Current:* Implemented; per-session `SessionStore` + `SessionRegistry`.
+- *Gap:* None material.
+
+**FR-8.2 — Code search** ✅
+- *Vision:* In-tree code search (`src/search/`, tree-sitter) plus trusty-search MCP integration.
+- *Current:* Implemented (indexer + file watcher).
+- *Gap:* None material.
+
+**FR-8.3 — Project index injection** ✅
+- *Vision:* `ProjectInitializer` generates `project-index.md` (24 h TTL), injected into the PM prompt.
+- *Current:* Implemented (`src/init/`).
+- *Gap:* No hierarchical `AGENTS.md`-style directory walking (single root `CLAUDE.md`) — see §6.
+
+**FR-8.4 — Hybrid retrieval** ✅
+- *Vision:* BM25 + embedding hybrid retrieval (`src/context/retrieval.rs`); `ClusterStore` with a 2× boost.
+- *Current:* Implemented.
+- *Gap:* None material.
+
+### 4.9 Global Infrastructure (`src/registry/`, `src/bus/`, process tracking)
+
+**FR-9.1 — Project registry** ✅ — `~/.open-mpm/projects.json` (`src/registry/`).
+**FR-9.2 — Inter-project message bus** ✅ — UNIX socket `~/.open-mpm/sockets/<id>.sock` (`src/bus/`).
+**FR-9.3 — Process tracker** ✅ — `~/.open-mpm/processes.json` (PID lifecycle).
+**FR-9.4 — Shared skills** ✅ — `~/.open-mpm/skills/`.
+
+### 4.10 Evaluation (`src/eval/`)
+
+**FR-10.1 — Bake-off harness** 🟡
+- *Vision:* ai-coding-bake-off L1–L5 competitive benchmarking.
+- *Current:* Harness implemented; L1–L3 validated.
+- *Gap:* L4–L5 not yet validated.
+
+---
+
+## 5. Success Criteria / Differentiators
+
+A release meets the bar when:
+
+1. **Model-agnostic dispatch is real and frictionless** — any agent can be
+   reassigned from one provider to another (OpenRouter / Anthropic-direct /
+   Bedrock / claude CLI) by editing two TOML lines, and *all* PM/CTRL turns
+   honor the configured credential priority (closing FR-1.4). ✅ 🟡
+2. **Process isolation holds** — a crashing file/shell sub-agent never takes
+   down the controller; read-only agents stay in-process for speed. ✅
+3. **Multi-project coordination from one binary** — several projects driven
+   concurrently from a single CTRL, with the singleton guarantee enforced
+   (closing FR-1.3). 🟡
+4. **Declarative workflows run end-to-end** — research → plan → code → QA →
+   observe, with per-phase models/skills/AST substrate, in both prescriptive and
+   parallel-wave modes. ✅
+5. **Self-contained** — no cloud, no Python, no Node in the core; vector memory
+   and search are embedded. ✅
+6. **Competitive** — measurable performance on ai-coding-bake-off L1–L5 versus
+   Roo Code, Cline, Kilo.ai, and Codex CLI. 🟡
+
+**Core differentiator (restated):** open-mpm is the only single-binary Rust
+harness offering claude-mpm-style PM/sub-agent orchestration with **per-agent,
+multi-provider, model-agnostic dispatch** and **OS-level sub-agent isolation**.
+
+---
+
+## 6. Open Questions & Roadmap
+
+### Open questions
+
+- **Singleton vs. multi-controller:** should a second invocation always route to
+  the running CTRL (FR-1.3), or should explicit multi-controller setups be
+  supported? Current behavior races.
+- **Approval modes:** adopt Codex CLI-style tiered approval (suggest / auto-edit
+  / full-auto)? Currently absent. ⚪
+- **Checkpoint/rollback:** adopt Cline-style shadow-Git checkpoints for safe
+  rollback of agent edits? Currently absent. 🔵
+- **OS-native sandbox:** the research marks seatbelt/bubblewrap as **not
+  planned** — confirm this stays a non-goal versus Codex CLI parity.
+- **Adaptive system prompts per model family:** Claude vs GPT vs Llama have
+  different tool-calling conventions; should the prompt builder specialize per
+  family (gap vs Cline)? ⚪
+- **Prompt-cache stabilization:** Codex CLI-style stable cache-prefix ordering
+  is not applied; the system prompt is rebuilt per request. Worth doing? 🔵
+
+### Roadmap (phased, from current gaps)
+
+| Phase | Theme | Highlights |
+|---|---|---|
+| **Now** | Correctness & hygiene | Fix `ctrl_chat_turn` credential blindness (FR-1.4); finish the 500-line-cap sweep — #170/#171/#172 remain (`ctrl/mod.rs`, `runtime.rs`, `workflow/engine.rs`); #356 systematic 66-file sweep; **clap migration** (CLI arg parsing is hand-rolled — HIGH priority); `backon` retry on 429/5xx. |
+| **Phase 2** | Web GUI | SSE consumer, subagent-activity strip, footer statusline, command palette, tool-call cards, session persistence (Web → from ~40%). |
+| **Phase 3** | Telegram | File-based session persistence, `/tools`, `/projects`, `/connect <N>` (Telegram → from ~60%). |
+| **Phase 4** | Streaming | Token streaming across all surfaces; real-time push (replace 2 s polling with live SSE). |
+| **Later** | Differentiation depth | Sub-agent result summarization (FR-2.4); persistent skill index + effectiveness feedback (FR-4.2/4.4); user-level cancel (FR-1.5); hierarchical `AGENTS.md` walking; adaptive per-family prompts; bake-off L4–L5. |

--- a/docs/open-mpm/spec/PRD.md
+++ b/docs/open-mpm/spec/PRD.md
@@ -121,7 +121,7 @@ an inline status tag. Source paths are cited where known.
 **FR-1.4 — Credential-correct PM turns** 🟡
 - *Vision:* Every PM/CTRL turn routes through `pick_credentials()` so the configured provider priority is honored.
 - *Current:* The ratatui path (`run_pm_task_with_history`) routes correctly.
-- *Gap:* **Credential-routing bug** — the legacy stdin REPL turn (`ctrl_chat_turn`, ~`src/ctrl/mod.rs:3391`) hardcodes `CTRL_MODEL` and calls `llm::chat()` directly *without* `pick_credentials()`, so it always routes via OpenRouter regardless of configured credentials.
+- *Gap:* **Credential-routing bug** — the legacy stdin REPL turn (`ctrl_chat_turn`, `crates/open-mpm/src/ctrl/ctrl_turn/dispatch.rs:48`) hardcodes `CTRL_MODEL` and calls `llm::chat()` directly *without* `pick_credentials()`, so it always routes via OpenRouter regardless of configured credentials. (#408; supersedes pre-refactor `src/ctrl/mod.rs:3391` from #358–#366 cap-sweep module split.)
 
 **FR-1.5 — User-level cancellation** 🔵
 - *Vision:* A user can cancel an in-flight PM/agent task from any surface.

--- a/docs/open-mpm/spec/README.md
+++ b/docs/open-mpm/spec/README.md
@@ -1,0 +1,62 @@
+# open-mpm — Specification Set
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** research synthesis + code/docs/tickets audit
+
+This directory holds the canonical product and engineering specification for the
+`open-mpm` crate (`crates/open-mpm/`). It is the single authoritative reference
+for *what open-mpm is meant to be*, *what it is today*, and *what gaps remain*.
+
+## What is open-mpm?
+
+`open-mpm` is a Rust-native AI agent orchestration harness. Its product north
+star is to be a **superset of both Warp and Claude Code**: a persistent,
+multi-project coordination layer ("agentic assistant manager") *and* an original
+coding harness that can dispatch any task to **any model via any backend**.
+A long-running **CTRL** controller coordinates per-project **PM** (project
+manager) actors; each PM delegates work to specialized **sub-agents** that run
+either in-process (fast, read-only) or as isolated OS subprocesses (file/shell
+agents) communicating over NDJSON IPC. The defining differentiator is
+**model-agnostic dispatch**: any agent role can be backed by OpenRouter (500+
+models), the direct Anthropic API, AWS Bedrock, or the `claude` CLI OAuth path,
+assignable per-agent via a two-line TOML change with no code modifications.
+
+## Documents in this set
+
+| Document | Read it when you want to know… |
+|---|---|
+| **[PRD.md](./PRD.md)** | The product: vision & mission, goals/non-goals, personas, the full functional-requirement catalog (tagged by implementation status), success criteria, and the open-question roadmap. Start here for *why* and *what*. |
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | The system shape: process model + topology diagram, NDJSON IPC message formats, the `Event` enum and its subscribers, the source-module map, and a thorough treatment of **model-agnostic dispatch** (credential priority, per-agent TOML, the three runner kinds, four LLM backend paths, session override, model qualification, thinking mode). Start here for *how it fits together*. |
+| **[COMPONENTS.md](./COMPONENTS.md)** | Per-subsystem specs: PM/CTRL orchestration, the sub-agent subprocess model, tool-using agents, skill injection, the workflow engine, token compression, memory & search, global infrastructure, and the three UI surfaces. Each component states responsibility, key types/modules (with `src/` paths), current state, and known gaps. Start here for *the detail of one subsystem*. |
+
+## Reading order
+
+1. **New to open-mpm?** PRD → ARCHITECTURE → COMPONENTS.
+2. **Implementing a feature?** Jump to the relevant COMPONENTS section, then
+   cross-check the dispatch model in ARCHITECTURE.
+3. **Evaluating product direction?** PRD vision + success criteria, then the
+   gap callouts throughout COMPONENTS.
+
+## Status legend (used throughout this set)
+
+Every requirement and component is framed as **Vision / Current / Gap** and
+tagged inline with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, or plan) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+## Provenance & maintenance
+
+These are derived from a research synthesis cross-checked against the
+`crates/open-mpm/src/` tree, crate docs, and the open/closed issue backlog
+(notably the 500-line-cap refactor sweep, #356 and #358–#366, and the three
+remaining oversized-file tickets #170/#171/#172). When the code changes
+materially, update the relevant document and bump the *Last reviewed* date.
+Source-path citations reflect the layout at the time of review; some files
+cited as single `.rs` modules in the originating research have since been split
+into same-named subdirectories during the cap sweep.


### PR DESCRIPTION
## Summary

Adds comprehensive PRD and specification set under `docs/open-mpm/spec/`:
- **README** — navigation and overview of the spec collection
- **PRD** — Vision/Current/Gap framing; any-model-any-agent north star
- **ARCHITECTURE** — runtime patterns, lifecycle, and data flow
- **COMPONENTS** — service layer, agent registry, workflow engine, controller

Grounds the canonical design intent for the open-mpm orchestration platform and resolves ambiguities referenced in #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)