### PR TITLE
chore(trusty-search): bump to 0.19.0

### DIFF
--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
Release bump for #401 (4 sequential progress bars + KG SSE events) and #402 (relative chunk-path storage + M002 migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)