### PR TITLE
docs(trusty-search): canonical spec set + fix stale doc links

### DIFF
--- a/docs/trusty-search/README.md
+++ b/docs/trusty-search/README.md
@@ -14,13 +14,16 @@ regression testing, and engineering-session documentation. The crate
 
 | Subdir | What's here |
 |--------|-------------|
+| [`spec/`](spec/) | **Canonical specification set** — the authoritative *what/why/gap* reference: [`PRD.md`](spec/PRD.md) (vision, goals, functional requirements tagged by status), [`ARCHITECTURE.md`](spec/ARCHITECTURE.md) (process model, staged pipeline, embedder sidecar, storage, query dispatch, module map), and [`COMPONENTS.md`](spec/COMPONENTS.md) (per-subsystem specs). Indexed in [`spec/README.md`](spec/README.md). |
 | [`research/`](research/) | Investigation, audit, and decision documents — BM25 memory, Candle/Metal validation, the nested-index fan-out RFC, NLP/ER/KG indexing, the staged-pipeline (stage-1 minimal, stage-3 KG, phase-3 async symbol-graph) decisions, and the trusty-search vs. mcp-vector-search comparison. Indexed in [`research/README.md`](research/README.md). |
 | [`regression-testing/`](regression-testing/) | Versioned performance snapshots (`v{VERSION}-{DATE}.md`) plus alternate-corpus baselines (synthetic, open-mpm) and certification runs. [`current.md`](regression-testing/current.md) symlinks the latest snapshot. Methodology in [`regression-testing/README.md`](regression-testing/README.md). |
+| [`decisions/`](decisions/) | Crate-specific Architecture Decision Records (Nygard format). Indexed in [`decisions/README.md`](decisions/README.md). |
 | [`sessions/`](sessions/) | Engineering-session narratives (`SESSION-{DATE}-{topic}.md`). Indexed in [`sessions/README.md`](sessions/README.md). |
 | [`examples/`](examples/) | Reference configurations: [`trusty-search.yaml`](examples/trusty-search.yaml) — multi-index per-repo config consumed by `trusty-search index`. |
 
 ## Where to start
 
+- **What is trusty-search / what's built vs. planned?** [`spec/README.md`](spec/README.md) → [`spec/PRD.md`](spec/PRD.md).
 - **Performance / benchmarks?** [`regression-testing/README.md`](regression-testing/README.md) → [`regression-testing/current.md`](regression-testing/current.md).
 - **Why a feature works the way it does?** [`research/README.md`](research/README.md).
 - **Configuring multi-index repos?** [`examples/trusty-search.yaml`](examples/trusty-search.yaml).

--- a/docs/trusty-search/decisions/0001-bundled-embedder-sidecar.md
+++ b/docs/trusty-search/decisions/0001-bundled-embedder-sidecar.md
@@ -1,0 +1,75 @@
+# 0001. Bundled, supervised `trusty-embedderd` embedder sidecar
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Scope:** Crate `trusty-search`
+- **Supersedes / Superseded by:** —
+
+## Context
+
+trusty-search embeds code chunks with all-MiniLM-L6-v2 (INT8, 384-dim) via the
+ONNX Runtime (and CoreML on Apple Silicon). The ONNX execution-provider arena is
+the daemon's **largest and spikiest** memory consumer: a reindex issues hundreds
+of `embed_batch` calls, and ORT allocates working memory proportional to batch
+size *during* each call, producing RSS spikes the between-batch poller cannot
+catch (see [research/bm25-memory](../research/bm25-memory-2026-05-28.md) and
+issue #95). Running embedding *in-process* meant the search daemon's address
+space inherited that volatility, raising OOM and (on macOS) jetsam-kill risk and
+inflating steady-state RSS.
+
+Industry ML-serving practice (Triton, vLLM, TEI, ollama) separates the model
+server from its callers. The supervisor module records this rationale directly:
+*"This aligns with industry-standard ML serving topology … and reduces
+trusty-search daemon RSS substantially by moving the ONNX arena out of the search
+process"* (`crates/trusty-search/src/service/embedder_supervisor.rs`). The work
+spans issues #110 (split the embedder into a dedicated process), #181 (#110
+Phase 2: auto-spawn + manage as a core subprocess), #187 (bundle as a second
+binary), #164 (consolidate the embed/BM25 daemons), and #315 (lazy spawn + idle
+shutdown). Peak-RSS was measured sidecar-vs-in-process under #282.
+
+A naive sidecar would force operators to install and launch a second binary by
+hand — unacceptable for a tool whose product promise is *one install, one
+daemon*.
+
+## Decision
+
+We will run embedding in a **separate, supervised subprocess** named
+`trusty-embedderd`, and bundle it so a single `cargo install trusty-search`
+installs **both** binaries:
+
+- `trusty-embedderd` is a workspace crate (`crates/trusty-embedderd/`) declared
+  in trusty-search's manifest **both** as a Cargo dependency **and** as a second
+  `[[bin]]` whose shim (`src/bin/trusty-embedderd.rs`) calls
+  `trusty_embedderd::run()`. One install command, two binaries, zero logic
+  divergence.
+- The search daemon owns the sidecar's lifecycle through an
+  `EmbedderSupervisor` (`src/service/embedder_supervisor.rs`) that re-exports the
+  shared `trusty_common::embedder_client` supervisor types, with startup-timeout,
+  restart-backoff, and max-restart limits.
+- Spawn is **lazy** (`LazyEmbedderHandle`, #315): binary discovery runs at boot
+  and fails fast with an actionable install hint, but the process is started on
+  the **first embed request**, and may be idle-shut-down
+  (`TRUSTY_EMBEDDERD_IDLE_SHUTDOWN_SECS`) and re-spawned.
+- The transport is configurable via `TRUSTY_EMBEDDER`: `auto`/`stdio` (default,
+  supervised stdio subprocess), `in-process` (an explicit, never-silent escape
+  hatch for tests/constrained hosts), `http://…`, `unix:/…`, or `candle`.
+- A priority `embed_pool` (`src/service/embed_pool.rs`, #41) sits in front of the
+  sidecar so interactive search embeddings drain before background reindex work.
+
+## Consequences
+
+- **Positive:** the search daemon's address space no longer carries the ONNX
+  arena, cutting steady-state RSS and removing the in-process jetsam/OOM-kill
+  risk during large reindexes.
+- **Positive:** the product promise holds — operators still run one install and
+  one `trusty-search start`; the sidecar is invisible unless it fails to install.
+- **Positive:** lazy spawn means `lexical_only` deployments (daemonized ripgrep)
+  never pay the ONNX init cost at all.
+- **Positive:** crash isolation — a wedged embedder is restarted by the
+  supervisor (within backoff/restart limits) without taking down search.
+- **Negative / trade-off:** an extra IPC hop (stdio/UDS) per embed batch, and a
+  second supervised process to reason about; mitigated by request batching
+  (`batch_queue.rs`) and the priority pool.
+- **Neutral:** the in-process path remains available behind an explicit
+  `TRUSTY_EMBEDDER=in-process` for tests and hosts where the sidecar cannot be
+  installed; it is never selected silently.

--- a/docs/trusty-search/decisions/README.md
+++ b/docs/trusty-search/decisions/README.md
@@ -1,0 +1,17 @@
+# trusty-search — Architecture Decision Records
+
+**Crate-specific** ADRs for trusty-search, in the Nygard format. These cover
+decisions local to the trusty-search crate; **workspace-wide** decisions live in
+[`docs/adr/`](../../adr/). The ADR process, numbering, and status lifecycle are
+documented in the [workspace ADR README](../../adr/README.md). This directory
+maintains its own independent numbering sequence.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](./0001-bundled-embedder-sidecar.md) | Bundled, supervised `trusty-embedderd` embedder sidecar | Accepted |
+
+---
+
+[← Back to trusty-search docs index](../README.md)

--- a/docs/trusty-search/regression-testing/open-mpm-baseline-2026-05-25.md
+++ b/docs/trusty-search/regression-testing/open-mpm-baseline-2026-05-25.md
@@ -198,8 +198,8 @@ The absolute numbers are **reasonable**: 67% Hit@1 / 72% Hit@5 on naturally-phra
 - [#123](https://github.com/bobmatnyc/trusty-tools/issues/123) — _BM25 circular bias_ — this baseline complements the synthetic-corpus measurement on the organic axis
 - [synthetic-corpus-baseline-2026-05-25.md](synthetic-corpus-baseline-2026-05-25.md) — synthetic peer to this organic baseline
 - [v0.10.0-2026-05-25.md](v0.10.0-2026-05-25.md) — current.md target; the version snapshot this baseline is parallel to
-- [benchmark_open_mpm.rs](../../crates/trusty-search/tests/benchmark_open_mpm.rs) — harness source
-- [benchmark_open_mpm_ground_truth.json](../../crates/trusty-search/tests/benchmark_open_mpm_ground_truth.json) — 20-query ground truth
+- [benchmark_open_mpm.rs](../../../crates/trusty-search/tests/benchmark_open_mpm.rs) — harness source
+- [benchmark_open_mpm_ground_truth.json](../../../crates/trusty-search/tests/benchmark_open_mpm_ground_truth.json) — 20-query ground truth
 
 ## Raw measurements
 

--- a/docs/trusty-search/regression-testing/synthetic-corpus-baseline-2026-05-25.md
+++ b/docs/trusty-search/regression-testing/synthetic-corpus-baseline-2026-05-25.md
@@ -354,5 +354,5 @@ The improvement over v1 on Q01–Q14 is entirely attributable to mode-hint forwa
 
 - [#123](https://github.com/bobmatnyc/trusty-tools/issues/123) — v2 of this work
 - [v1 of this doc](#three-mode-results-run-2026-05-25-daemon-v091) — same file, section above
-- [benchmark_synthetic.rs](../../crates/trusty-search/tests/benchmark_synthetic.rs) — harness source (v0.2.0)
-- [GROUND_TRUTH.json](../../crates/trusty-search/tests/benchmark_corpus/synthetic/GROUND_TRUTH.json) — v0.2.0, 19 queries
+- [benchmark_synthetic.rs](../../../crates/trusty-search/tests/benchmark_synthetic.rs) — harness source (v0.2.0)
+- [GROUND_TRUTH.json](../../../crates/trusty-search/tests/benchmark_corpus/synthetic/GROUND_TRUTH.json) — v0.2.0, 19 queries

--- a/docs/trusty-search/research/stage-3-kg-decision-2026-05-25.md
+++ b/docs/trusty-search/research/stage-3-kg-decision-2026-05-25.md
@@ -25,8 +25,8 @@
 - **Two-stage pattern**: each KG query first issued a stage-1 `search_lexical` with `top_k=1` to anchor the seed chunk_id (logged for forensics), then stage-2 fired the chosen lane with `expand_graph` set per the lane semantics. The `seed_chunk_id` was included in the request body for forensic clarity even though the daemon's current `SearchQuery` struct ignores the field — KG expansion in production is intent-driven and seeded from top-K results, not from an explicit chunk_id.
 - **Daemon**: same persistent daemon instance used for all #5 / #128 / #138 measurements (continuous uptime); embedder running on CPU (provider reported as `CPU` in /health — CoreML EP was NOT active for this run, see Caveats).
 - **Index reuse**: harness checks `GET /indexes/open-mpm-benchmark/status` first and skips reindex when all three stages are `ready` with a matching root_path. This run was a fresh index (the prior #5 cleanup deleted it); subsequent #145 re-runs will skip reindex.
-- **Harness**: [`crates/trusty-search/tests/benchmark_open_mpm_kg.rs`](../../crates/trusty-search/tests/benchmark_open_mpm_kg.rs).
-- **Ground truth**: [`crates/trusty-search/tests/benchmark_open_mpm_kg_ground_truth.json`](../../crates/trusty-search/tests/benchmark_open_mpm_kg_ground_truth.json) — each query carries an explicit list of files that a graph-aware tool should be able to surface.
+- **Harness**: [`crates/trusty-search/tests/benchmark_open_mpm_kg.rs`](../../../crates/trusty-search/tests/benchmark_open_mpm_kg.rs).
+- **Ground truth**: [`crates/trusty-search/tests/benchmark_open_mpm_kg_ground_truth.json`](../../../crates/trusty-search/tests/benchmark_open_mpm_kg_ground_truth.json) — each query carries an explicit list of files that a graph-aware tool should be able to surface.
 
 ## Results — per-class breakdown
 
@@ -123,8 +123,8 @@ The #109 ticket itself should be rescoped from "async-split Stage 3" to "async-s
 - [#138](https://github.com/bobmatnyc/trusty-tools/issues/138) — per-lane MCP tool surface (stays as-is)
 - [#147](https://github.com/bobmatnyc/trusty-tools/issues/147) — search_kg refining query (re-evaluate after rescope)
 - [open-mpm-baseline-2026-05-25.md](../regression-testing/open-mpm-baseline-2026-05-25.md) — the mixed-intent peer baseline
-- [benchmark_open_mpm_kg.rs](../../crates/trusty-search/tests/benchmark_open_mpm_kg.rs) — harness source
-- [benchmark_open_mpm_kg_ground_truth.json](../../crates/trusty-search/tests/benchmark_open_mpm_kg_ground_truth.json) — 18-query KG-targeted ground truth
+- [benchmark_open_mpm_kg.rs](../../../crates/trusty-search/tests/benchmark_open_mpm_kg.rs) — harness source
+- [benchmark_open_mpm_kg_ground_truth.json](../../../crates/trusty-search/tests/benchmark_open_mpm_kg_ground_truth.json) — 18-query KG-targeted ground truth
 
 ## Re-run instructions
 

--- a/docs/trusty-search/spec/ARCHITECTURE.md
+++ b/docs/trusty-search/spec/ARCHITECTURE.md
@@ -1,0 +1,416 @@
+# trusty-search — System Architecture
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+This document describes how trusty-search fits together: the daemon/registry
+process model, the staged indexing pipeline, the bundled embedder sidecar, the
+storage layer, the query-dispatch pipeline, the MCP/HTTP framing rules, the
+memory auto-tuning knobs, and the execution-provider paths. It closes with the
+source-module map.
+
+---
+
+## 1. Process Model
+
+trusty-search is a **single Rust crate** (`crates/trusty-search/`) producing two
+binaries plus a library:
+
+- **`trusty-search`** (`src/main.rs`) — the CLI + daemon + MCP server.
+- **`trusty-embedderd`** (`src/bin/trusty-embedderd.rs`) — a thin shim calling
+  `trusty_embedderd::run()`; the actual sidecar logic lives in the
+  `crates/trusty-embedderd/` library crate. Declaring it as both a Cargo
+  dependency *and* a `[[bin]]` is what makes `cargo install trusty-search`
+  install **both** binaries in one command (Cargo.toml `[[bin]]` + dep, #187).
+- **`trusty_search`** (`src/lib.rs`) — an rlib re-publishing `core`, `service`,
+  and `mcp` so integration tests and host crates (open-mpm) can `use
+  trusty_search::SearchMcpService` directly (#115).
+
+```
+cargo install trusty-search
+        │  installs two binaries
+        ├─ trusty-search        (CLI / daemon / MCP)
+        └─ trusty-embedderd     (ONNX/CoreML embedder sidecar)
+
+trusty-search start  ──►  HTTP daemon (singleton, loopback)
+    │
+    ├─ IndexRegistry: DashMap<IndexId, Arc<IndexHandle>>     ← many projects, one process
+    │     └─ IndexHandle
+    │           ├─ CodeIndexer: Arc<RwLock<…>>  (usearch HNSW + redb corpus)
+    │           ├─ Bm25Index   (per-query, built from corpus)
+    │           ├─ SymbolGraph: Arc<…>  (petgraph, tree-sitter derived)
+    │           ├─ FileWatcher (notify, 500 ms debounce)
+    │           └─ QueryCache  (LruCache<QueryHash, Vec<f32>>)
+    │
+    ├─ axum router (HTTP/2, CORS/trace/gzip)  ← REST + SSE + /metrics + /ui
+    ├─ EmbedPool (priority lanes)  ──►  EmbedderSupervisor
+    │                                       └─ spawns trusty-embedderd (lazy)
+    └─ MCP server (when `serve`): stdio loop or HTTP/SSE router → proxies to daemon
+```
+
+### Key properties
+
+- **Singleton daemon per machine.** An OS advisory exclusive lock on a PID
+  lockfile in the user data dir enforces it; a second `start` exits with
+  `DaemonError::AlreadyRunning` (`src/service/daemon.rs`). ✅
+- **Auto-port + discoverable.** The daemon binds from a requested port walking
+  forward to the first free one, then writes `port.lock`
+  (`~/Library/Application Support/trusty-search/port.lock` on macOS,
+  `$XDG_DATA_HOME/trusty-search/port.lock` on Linux). The CLI and MCP server
+  resolve the live port from that file. ✅
+- **Loopback-only, no auth.** The daemon binds `127.0.0.1` and trusts every
+  caller by design — **never** bind a non-loopback interface (PRD non-goal). ✅
+- **Concurrent multi-index reads.** `DashMap` shard-locks per index (different
+  indexes never contend); `Arc<RwLock<CodeIndexer>>` is reader-priority so many
+  searches against one index never block. Indexing uses a `tokio::Semaphore` to
+  avoid thread-pool starvation. ✅
+- **MCP is a thin proxy.** `serve` does **not** re-implement search; the
+  `McpServer` dispatcher proxies each tool call to the running daemon over HTTP
+  (`src/mcp/`). The daemon must already be running. ✅
+
+---
+
+## 2. Indexing Pipeline (staged)
+
+A reindex walks the project root, chunks each file, embeds the chunks, commits
+them durably, and builds the symbol graph. The pipeline is **staged** so each
+stage can be independently skipped:
+
+```
+walk_source_files(root)            # ignore-crate gitignore-aware, SOURCE_EXTS filter, size/minify guards
+   │   (src/service/walker.rs)
+   ▼
+Stage 1 — chunk + BM25             # chunk_ast() tree-sitter → RawChunk[] + RawEntity[]
+   │   (src/core/chunker/)          # BM25 index built from the chunk corpus
+   │                                # `lexical_only` stops here (daemonized ripgrep)
+   ▼
+Stage 2 — embed (vector)           # parse_and_embed_files() OUTSIDE the write lock
+   │   (src/core/indexer/ingest.rs) # batched ONNX embed via the embedder sidecar
+   │                                # `skip_kg`/`lexical_only` independence (orthogonal)
+   ▼
+commit_parsed_batch()              # holds the write lock ONLY for the redb + HNSW commit
+   │   (atomic per-batch; O(batch) not O(corpus))
+   ▼
+Stage 3 — knowledge graph          # SymbolGraph rebuilt from corpus (CALLS/IMPORTS/…)
+       (src/core/symbol_graph.rs)   # skipped when skip_kg / lexical_only / Stage-1-minimal
+```
+
+- **Split-lock design.** Parsing and embedding (the slow part) run outside the
+  `RwLock`; only the redb+HNSW commit takes the write lock, keeping searches
+  responsive during a reindex. ✅
+- **Incremental skip.** sha2 content fingerprints skip unchanged files across
+  daemon restarts; `--force` clears the per-index hash cache. ✅
+- **Memory-bounded.** The reindex orchestrator polls RSS via `memguard`; on a
+  `TRUSTY_MEMORY_LIMIT_MB` breach it skips remaining batches (already-committed
+  chunks stay searchable) and reports `memory_limit_hit: true`. ✅
+- **Progress.** SSE events (`start`/`progress`/`complete`/`error`) on a
+  `tokio::broadcast` channel with a 500-event replay buffer so late subscribers
+  still see `start` (`src/service/reindex.rs`). ✅
+- **Walk diagnostics.** `last_walk_started_at`/`files_seen`/`files_skipped`/
+  `error` are recorded per reindex so a zero-chunk outcome is explainable (#280). ✅
+
+### Stage-skipping modes
+
+| Mode | Stage 1 (BM25) | Stage 2 (vector) | Stage 3 (KG) | Trigger |
+|---|---|---|---|---|
+| Full hybrid | ✅ | ✅ | ✅ | default |
+| `skip_kg` | ✅ | ✅ | — | `--no-kg` / YAML / HTTP / `TRUSTY_NO_KG=1` (#313) |
+| `lexical_only` | ✅ | — | — | `--lexical-only` / `lexical_only: true` (#111) |
+| Stage-1-minimal | ✅ | — | — | lexical_only + symbol-graph skip (#312) |
+
+`skip_kg` and `lexical_only` are **orthogonal**: setting both leaves only BM25.
+
+---
+
+## 3. Embedder Sidecar (`trusty-embedderd`)
+
+The ONNX/CoreML embedding arena is the daemon's largest, spikiest memory
+consumer. trusty-search moves it into a **separate supervised subprocess**
+(`crates/trusty-embedderd/`), mirroring industry ML-serving topology (Triton,
+vLLM, TEI, ollama) and substantially reducing the search daemon's RSS (#110).
+
+```
+trusty-search daemon
+   │
+   ├─ EmbedPool (interactive/background priority lanes, src/service/embed_pool.rs)
+   │
+   └─ EmbedderSupervisor (src/service/embedder_supervisor.rs)
+         │  re-exports trusty_common::embedder_client supervisor types
+         │  + trusty-search defaults, default_socket_path(), locate_embedderd_binary()
+         │
+         └─ LazyEmbedderHandle  ──spawn on first embed request──►  trusty-embedderd
+                                                                      (--stdio | --socket | http)
+```
+
+- **Single install, two binaries.** See §1: the `[[bin]]` + Cargo-dep trick. ✅
+- **Lazy spawn (#315).** Binary discovery runs at boot (fails fast with an
+  install hint if missing), but the sidecar process is spawned on the **first
+  embed request** (reindex, hybrid search, or `context_inference`), not at
+  startup. `TRUSTY_EMBEDDERD_IDLE_SHUTDOWN_SECS` kills it after idle and resets
+  the spawn gate. ✅
+- **Transport selection (`TRUSTY_EMBEDDER`).** `auto`/`stdio` (default,
+  supervised stdio subprocess), `in-process` (explicit ONNX in the daemon — never
+  silent), `http://…`, `unix:/…`, or `candle` (Metal via `--features candle`). ✅
+- **Supervisor tuning.** `TRUSTY_EMBEDDERD_BIN`,
+  `*_STARTUP_TIMEOUT_SECS` (30), `*_RESTART_BACKOFF_MAX_SECS` (60),
+  `*_MAX_RESTARTS` (5), `*_IDLE_SHUTDOWN_SECS` (0 = off),
+  `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (60). ✅
+- **Sidecar internals.** `crates/trusty-embedderd/src/`: `protocol.rs`
+  (JSON-RPC embed protocol), `batch_queue.rs` (request batching),
+  `stdio_server.rs`, `uds_server.rs`, and an optional `http-server` feature
+  (axum, #250). Both the standalone binary and the bundled shim call
+  `trusty_embedderd::run()` — zero divergence.
+
+---
+
+## 4. Storage Layer
+
+Three storage substrates, all local and embedded:
+
+| Substrate | Backend | Holds | Module |
+|---|---|---|---|
+| **Chunk corpus** | redb 2.6 | `chunk_id → RawChunk`, `file → RawEntity[]`, `_meta.schema_version` | `src/core/corpus.rs`, `src/core/store.rs` |
+| **Vector index** | usearch 2.25 (HNSW, in-memory) | 384-dim INT8 vectors + `chunk_id ↔ u64 key` sidecar | `src/core/store.rs` |
+| **Symbol graph** | petgraph 0.6 (in-memory) | `DiGraph<SymbolNode,()>` keyed by symbol name | `src/core/symbol_graph.rs` |
+
+- **Why redb (#28).** The prior `chunks.json` full-rewrite-per-batch caused a
+  memory explosion (~400 MB blob on a 200k corpus). redb gives crash-safe atomic
+  **per-batch** commits (O(batch)), incremental writes, and streamed startup
+  reads without holding two copies in RAM. ✅
+- **HNSW persistence.** usearch persists vectors + graph keyed by `u64`; a
+  JSON sidecar maps `chunk_id → u64 key` (and `next_key`) so a restored index
+  can translate HNSW matches back to chunk ids. The graph is **pinned hot**
+  (`Duration::MAX` cool-after) for zero cold-start. ✅
+- **Warm-boot persistence (#85).** A registry TOML (`<data_dir>/indexes.toml`,
+  `IndexId → root_path`) plus per-index dirs (`<data_dir>/indexes/<id>/` with
+  `hnsw.usearch` + the redb corpus) survive restarts; `restore_indexes` reloads
+  them on startup (`src/service/persistence.rs`, `persistence_loader.rs`). ✅
+- **Idle eviction.** The in-memory `RawChunk` map for durably-backed indexes is
+  evicted after `TRUSTY_CHUNKS_IDLE_EVICT_SECS` (300 s default); readers
+  rehydrate from redb; BM25 + symbol graph stay hot. ✅
+
+### Schema migrations
+
+A forward-only, idempotent migration framework evolves the redb schema without
+manual reindexing (`src/core/migration/`, shared kernel from `trusty-common`,
+#179). The `_meta` table stores a `u32 schema_version` (legacy DBs = 0). On
+startup `run_migrations` computes the chain `source_version >= current`, applies
+each in sequence, and writes the new version **after** each successful (idempotent)
+`apply`, in a background `tokio::spawn` so queries keep serving.
+`TRUSTY_DISABLE_MIGRATIONS=1` skips it. Registered: `m001` (re-chunk Rust
+`pub const`/`static`, #143), `m002`.
+
+---
+
+## 5. Query-Dispatch Pipeline
+
+Every hybrid search runs the same five-step pipeline (`src/core/indexer/search.rs`):
+
+```
+1. Classify intent      QueryClassifier (sub-ms regex)  → Definition|Usage|Conceptual|BugDebt|Unknown
+   (src/core/classifier.rs)
+2. Route weights        intent → (α vector, β BM25, use_kg_first)
+3. Search lanes         4×top_k HNSW candidates  +  per-query BM25 over the corpus
+4. Fuse                 rrf_fuse(): Σ weight·1/(k+rank), k=60, rank-only   (src/core/search/rrf.rs)
+5. KG expand            (Usage only) 1–2 hop callers_of/callees_of @ 0.7× trigger RRF score
+   + MMR rerank         mmr_rerank() cosine-diversity                       (src/core/mmr.rs)
+   + branch boost       branch_files / branch → ×branch_boost (default 1.5) (#122)
+   + docs penalty       down-rank .md/changelog on code intent             (#72/#77)
+   → return CodeChunk[] with per-result match_reason ("hybrid","hybrid+kg","bm25","vector","fallback:ripgrep")
+```
+
+### Intent → routing weights
+
+| Intent | α (vector) | β (BM25) | KG-first |
+|---|---|---|---|
+| Definition | 0.3 | 0.7 | false |
+| Usage | 0.5 | 0.5 | **true** |
+| Conceptual | 0.8 | 0.2 | false |
+| BugDebt | 0.1 | 0.9 | false |
+| Unknown | 0.6 | 0.4 | false |
+
+The classifier is a sub-ms regex over the query text; KG expansion is gated to
+**Usage** intent only.
+
+### `CodeChunk` (result shape)
+
+`{ id ("{path}:{start}:{end}"), file, start_line, end_line, content,
+function_name?, score, compact_snippet? (7-line, token-efficient),
+match_reason }`. Complexity/blame fields were removed when code-quality moved to
+**trusty-analyze** (#71).
+
+---
+
+## 6. MCP / HTTP Framing
+
+🔴 **stdout is reserved.** When running as an MCP stdio server, stdout carries
+line-delimited JSON-RPC 2.0 frames; a stray `println!` corrupts the protocol.
+All logging goes to **stderr** via `tracing` (`init_tracing`). This is a hard
+project rule.
+
+### MCP server (`src/mcp/`)
+
+- `McpServer` — pure dispatcher: takes a JSON-RPC `Request`, proxies the named
+  tool to the daemon over HTTP, returns a `Response`.
+- `stdio` — line-delimited JSON-RPC loop on stdin/stdout (default `serve`).
+- `sse` — axum router exposing `POST /mcp` and `GET /mcp/sse` (`serve --http`).
+- `tools` — the 17-tool catalogue + JSON-RPC error codes (`src/mcp/tools.rs`).
+- `openrpc` — an OpenRPC service descriptor.
+
+### HTTP API (`src/service/server.rs`)
+
+axum 0.8 + tower-http (CORS permissive `*`, trace, gzip), HTTP/2. All bodies are
+`application/json` except SSE (`text/event-stream`). Errors return
+`{ "error": "<message>" }` with standard codes (404 unknown index, 503 subsystem
+disabled, 500 internal).
+
+| Route | Purpose |
+|---|---|
+| `GET /health` | liveness/readiness (`{status, version, indexes}`) |
+| `GET /indexes`, `POST /indexes`, `DELETE /indexes/{id}` | registry management |
+| `GET /indexes/{id}/status` | chunk count + walk diagnostics (#280) |
+| `POST /indexes/{id}/search` | hybrid search (+ branch boost) |
+| `POST /indexes/{id}/search_similar` | code-to-code similarity |
+| `POST /indexes/{id}/index-file`, `/remove-file` | single-file add/remove |
+| `POST /indexes/{id}/reindex`, `GET …/reindex/stream` | fire-and-forget + SSE |
+| `GET /indexes/{id}/chunks` | paginated chunk enumeration |
+| `GET /indexes/{id}/call_chain` | annotated call tree (503 if skip_kg, #313) |
+| `GET /indexes/{id}/graph`, `…/graph/stats` | symbol-graph export |
+| `POST /indexes/{id}/grep`, `POST /grep` | per-index / cross-index grep |
+| `POST /search` | cross-index fan-out (context-inference weighted, #112) |
+| `GET /metrics` | Prometheus text (#41) |
+| `GET /status/stream`, `GET /logs/tail` | live status / log tail |
+| `POST /chat`, `GET /api/chat/providers` | OpenRouter chat proxy |
+| `GET /ui`, `/ui/`, `/ui/{*path}` | embedded Svelte admin UI |
+
+---
+
+## 7. Memory Auto-Tuning
+
+`MemoryPolicy::detect()` reads total RAM (`hw.memsize` on macOS, `/proc/meminfo`
+on Linux) at startup, classifies into a tier, sets default caps, overrides any
+field whose env var is set, and writes resolved values back into the process env
+so module-level readers pick them up (`src/core/memory_policy.rs`). Precedence:
+**shell env > `daemon.env` > tier default**. The resolved tier is logged at boot.
+
+| Tier | RAM | MAX_CHUNKS | EMBEDDING_CACHE | MAX_BATCH_SIZE | BM25_CORPUS_CAP | MAX_KG_NODES |
+|---|---|---|---|---|---|---|
+| Tiny | < 8 GB | 50 000 | 500 | 64 | 20 000 | 30 000 |
+| Small | 8–15 GB | 100 000 | 1 000 | 128 | 50 000 | 75 000 |
+| Medium | 16–31 GB | 200 000 | 5 000 | 256 | 100 000 | 150 000 |
+| Large | 32–63 GB | 400 000 | 10 000 | 512 | 200 000 | 300 000 |
+| XLarge | ≥ 64 GB | 800 000 | 20 000 | 512 | 400 000 | 500 000 |
+
+`MEMORY_LIMIT_MB` is `clamp(RAM × 25%, 1 GB, 64 GB)`. `MAX_BATCH_SIZE` is
+auto-derived as `floor(limit_mb × 0.75 / 55)` clamped `[32, 512]` (55 MB =
+empirical ORT arena cost per batch slot, #95).
+
+> **Caveat (PRD Q8):** `start` hard-checks a 16 GB minimum (#291), so the Tiny/
+> Small tiers are effectively gated off at runtime even though the policy code
+> still defines five tiers. README and CLAUDE.md describe this inconsistently.
+
+**Env knobs:** `TRUSTY_MAX_CHUNKS`, `TRUSTY_EMBEDDING_CACHE`,
+`TRUSTY_MAX_BATCH_SIZE`, `TRUSTY_BM25_CORPUS_CAP`, `TRUSTY_MAX_KG_NODES`,
+`TRUSTY_MEMORY_LIMIT_MB`, `TRUSTY_CHUNKS_IDLE_EVICT_SECS`,
+`TRUSTY_COREML_BATCH_SIZE`, `TRUSTY_COREML_TRIPWIRE_MB`, `TRUSTY_SKIP_RAM_CHECK`.
+
+`memguard` (`src/core/memguard.rs`) polls RSS during reindex (per-PID, including
+the sidecar) and enforces the soft ceiling; non-fatal probe failures return 0
+and disable the tripwire gracefully rather than crashing.
+
+---
+
+## 8. Execution-Provider Paths (ONNX / CoreML / CUDA / Candle)
+
+The embedder runs all-MiniLM-L6-v2 (INT8, 384-dim) through one of several
+execution providers, resolved at sidecar startup and reported in the log
+(`embedder initialized: model=AllMiniLML6V2(Q) dim=384 provider=…`):
+
+| Provider | Activation | Notes |
+|---|---|---|
+| **CPU** (default) | always available | `bundled-ort` static ORT (glibc ≥ 2.38 / macOS) |
+| **CoreML** (Metal GPU / ANE) | auto on `aarch64`-macOS since v0.3.13 | no feature flag; `coreml` feature is a no-op alias; batch 32 ANE-optimal + tripwire |
+| **CUDA** | `--features cuda` (+ `--no-default-features`) | activates `ort/cuda` + `ort/load-dynamic`; auto-bumps batch to 512; `--device gpu` fails fast if absent |
+| **Candle (Metal)** | `--features candle` + `TRUSTY_EMBEDDER=candle` | bypasses ONNX jetsam-kill risk on Apple Silicon (`src/service/candle_embedder.rs`, #41 phase 4) |
+
+`--device cpu|gpu|auto` (persisted to `daemon.env`) forces/relaxes provider
+selection at runtime. On glibc < 2.38 + CUDA, set `ORT_DYLIB_PATH` to a host
+`libonnxruntime.so` (the load-dynamic path; #114). Feature chain:
+`trusty-search/cuda → trusty-common/embedder-cuda → {fastembed/cuda,
+fastembed/ort-load-dynamic, ort/cuda, ort/load-dynamic}` — `ort/cuda` is the
+load-bearing GPU link.
+
+---
+
+## 9. Source Module Map
+
+Single crate; three module trees (`core`, `service`, `mcp`) plus `commands`,
+`bin`, and top-level files. Paths under `crates/trusty-search/`.
+
+| Module | Responsibility |
+|---|---|
+| `src/main.rs` | CLI entry: clap parsing → `commands::*` dispatch; friendly error/exit handling (#104). |
+| `src/lib.rs` | Re-publishes `core` / `service` / `mcp`; surfaces `SearchMcpService` (#115). |
+| `src/bin/trusty-embedderd.rs` | Shim → `trusty_embedderd::run()` (bundled sidecar). |
+| `src/config.rs`, `src/detect.rs`, `src/doctor.rs` | User config, project auto-detection, diagnostics. |
+| **`src/core/`** | Search engine internals (no I/O server code). |
+| `core/chunker/` | tree-sitter AST chunker (`mod.rs`), `classify.rs`, `inherits.rs`, `walk.rs`. |
+| `core/indexer/` | `CodeIndexer` orchestrator: `mod.rs`, `ingest.rs`, `persist.rs`, `files.rs`, `search.rs`, `docs_penalty.rs`, `archive.rs`, `migrations.rs`, `tests.rs`. |
+| `core/search/rrf.rs` | Reciprocal Rank Fusion (k = 60). |
+| `core/classifier.rs` | `QueryClassifier` / `QueryIntent` + lane weights. |
+| `core/bm25.rs` | Re-export of `trusty_common::bm25` (`Bm25Index`, `tokenize`, #156). |
+| `core/store.rs` | `VectorStore` / usearch HNSW wrapper + key sidecar. |
+| `core/corpus.rs` | redb-backed durable `CorpusStore` (#28). |
+| `core/symbol_graph.rs` | petgraph `SymbolGraph` (callers_of / callees_of). |
+| `core/mmr.rs` | MMR diversity rerank + cosine similarity. |
+| `core/memory_policy.rs` | RAM detection + tier caps (`MemoryPolicy`/`MemoryTier`). |
+| `core/memguard.rs` | RSS polling + soft memory ceiling. |
+| `core/migration/` | Forward-only schema migrations (`mod.rs`, `m001`, `m002`). |
+| `core/entity.rs`, `ner.rs`, `concept_cluster.rs` | Entity extraction; optional ONNX NER; optional k-means concept clusters (`clustering` feature). |
+| `core/registry.rs` | `IndexRegistry`, `IndexHandle`, `IndexId`, `WalkDiagnostics`. |
+| `core/repo_config.rs`, `project_config.rs` | `trusty-search.yaml` multi-index config. |
+| `core/scip_ingest.rs` | SCIP entity ingest trait (`from_refs` ✅, protobuf 🔵 #105). |
+| `core/git.rs`, `output.rs`, `embed.rs` | git diff helpers, result formatting, `Embedder` trait/`FastEmbedder`. |
+| **`src/service/`** | The HTTP daemon and all server-side machinery. |
+| `service/server.rs` | axum router + `SearchAppState` (all HTTP handlers). |
+| `service/daemon.rs` | PID lockfile, auto-port, graceful shutdown, `daemon.env`. |
+| `service/reindex.rs` | Reindex orchestration + SSE progress/replay. |
+| `service/walker.rs` | gitignore-aware source walk (`ignore` crate, #100). |
+| `service/embedder_supervisor.rs` | Sidecar supervisor + `LazyEmbedderHandle` (#315). |
+| `service/embed_pool.rs` | Priority embed worker pool (#41). |
+| `service/context_inference.rs` | Per-index relevance summary for fan-out (#112). |
+| `service/grep.rs` | grep-parity regex matcher (#111). |
+| `service/call_chain.rs` | Annotated call-tree renderer (#76). |
+| `service/persistence.rs`, `persistence_loader.rs` | Registry/index (de)serialization + restore. |
+| `service/watcher.rs`, `watch_loop.rs` | File watching (notify, 500 ms debounce). |
+| `service/metrics.rs` | Prometheus `/metrics` (#41). |
+| `service/candle_embedder.rs` | Candle/Metal embedder (`candle` feature). |
+| `service/concurrency.rs`, `config.rs`, `constants.rs`, `client.rs`, `indexed_files.rs`, `mcp_descriptor.rs`, `ui.rs` | Concurrency limits, user config, defaults, daemon HTTP client, indexed-file set, `SearchMcpService`, embedded UI serving. |
+| **`src/mcp/`** | MCP server: `mod.rs`, `tools.rs` (17 tools), `stdio.rs`, `sse.rs`, `openrpc.rs`. |
+| **`src/commands/`** | One handler per CLI subcommand + shared helpers (`daemon_utils`, `format`, `index_resolve`, `reindex_engine`, `doctor_*`, …). |
+
+Supporting trees: `ui/` (Svelte 5 sources), `ui-dist/` (compiled bundle embedded
+via `include_dir!`), `build.rs` (UI build wrapper, `SKIP_UI_BUILD=1` to skip),
+`tests/` (integration + benchmark harnesses).
+
+---
+
+## 10. Multi-Index Topology (current vs. designed)
+
+**Current (✅/🟡).** Every index is a **flat peer** in the `DashMap`. Cross-index
+fan-out exists (`POST /search`, `POST /grep`) and `context_inference` scrapes
+each project's metadata to weight relevance — but there is no parent/child
+relationship and no dedup, so a file covered by two overlapping indexes appears
+twice with different chunk ids.
+
+**Designed-not-built (🔵).** The
+[nested-index fan-out RFC](../research/nested-index-fanout-rfc-2026-05-29.md)
+([#404](https://github.com/bobmatnyc/trusty-tools/issues/404)) proposes a
+directed-acyclic **nested-index graph**: sub-indexes declared as children of a
+parent, fan-out prioritising subtree results with the parent as a backstop, and
+dedup of overlapping coverage. It depends on co-located `.trusty-search/` storage
++ filesystem discovery ([#403](https://github.com/bobmatnyc/trusty-tools/issues/403))
+and relative chunk paths (#402).

--- a/docs/trusty-search/spec/COMPONENTS.md
+++ b/docs/trusty-search/spec/COMPONENTS.md
@@ -1,0 +1,307 @@
+# trusty-search — Component Specifications
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+One section per major subsystem. Each states **Responsibility**, **Key
+types/modules** (with `src/` paths), **Current state**, and **Known gaps**,
+framed Vision / Current / Gap. For the cross-cutting query pipeline see
+[ARCHITECTURE.md §5](./ARCHITECTURE.md); for product framing see [PRD.md](./PRD.md).
+All paths are under `crates/trusty-search/`.
+
+---
+
+## 1. Indexer / Pipeline — `src/core/indexer/`, `src/core/chunker/`, `src/service/reindex.rs`, `src/service/walker.rs`
+
+**Responsibility.** Turn a project directory into a searchable index: walk files,
+chunk them AST-aware, embed, commit durably, and build the symbol graph — staged
+so any stage can be skipped, incrementally and crash-safely.
+
+**Key types/modules.**
+- `CodeIndexer` (`src/core/indexer/mod.rs`) — the orchestrator holding an
+  `Embedder`, a `VectorStore`, and the in-memory chunk corpus; `search()` runs
+  both lanes and fuses.
+- `ingest.rs` — `parse_and_embed_files()` (outside the write lock) +
+  `commit_parsed_batch()` (write lock only for the redb+HNSW commit); `ParsedBatch`,
+  `CommitTimings`.
+- `persist.rs` — snapshot/restore + background incremental persist.
+- `files.rs` — remove/lookup/entity-exact-match.
+- `search.rs` — the hybrid query pipeline (HNSW + BM25 + RRF + KG + MMR).
+- `docs_penalty.rs` — down-rank docs/changelog on code intent (#72/#77).
+- `chunk_ast()` / `chunk_text()` (`src/core/chunker/`) — tree-sitter AST chunker
+  (15 grammars) with oversized-chunk splitting + format-aware doc fallback.
+- `walk_source_files()` (`src/service/walker.rs`) — gitignore-aware walk.
+- `spawn_reindex` + `ReindexProgress` (`src/service/reindex.rs`) — SSE progress.
+
+**Current state.** ✅ Full staged pipeline with split-lock concurrency, sha2
+incremental skip, atomic redb per-batch commits, gitignore-honouring walk (#100),
+walk diagnostics (#280), and memory-bounded reindex with a soft RSS ceiling.
+
+**Known gaps.**
+- 🟡 Build-file grammars (`.gradle`, `.groovy`) fall back to sliding-window.
+- 🔵 SCIP-quality cross-file entities (FR-KG-5 / #105).
+
+---
+
+## 2. Lexical Search — BM25 + grep — `src/core/bm25.rs`, `src/service/grep.rs`
+
+**Responsibility.** Provide both ranked lexical retrieval (BM25) and exact,
+deterministic regex matching (grep parity) with code-aware tokenization.
+
+**Key types/modules.**
+- `Bm25Index` / `tokenize` (`src/core/bm25.rs`, re-exported from
+  `trusty_common::bm25`, #156) — zero-dep BM25 with camelCase/snake_case
+  splitting; per-query index built from the corpus, capped by
+  `TRUSTY_BM25_CORPUS_CAP`.
+- `CompiledGrep` + `grep_file_content` (`src/service/grep.rs`) — pure, I/O-free
+  matcher (regex, `-i`, `-A`/`-B`/`-C`, `--include` globs, multiline) driven by
+  the HTTP handler over already-chunked files; never re-embeds.
+
+**Current state.** ✅ BM25 lane in every hybrid query; `/grep` certified at
+ripgrep parity (P50 8 ms vs 9 ms, #111). `lexical_only` mode is a daemonized
+ripgrep (~63× faster reindex, ~700 MB daemon).
+
+**Known gaps.**
+- 🟡 Deferred BM25 in-memory footprint optimizations (streaming sort-merge, B.1/
+  B.3/B.5) — [#340](https://github.com/bobmatnyc/trusty-tools/issues/340).
+
+---
+
+## 3. Vector / Semantic Search — `src/core/store.rs`, `src/core/embed.rs`
+
+**Responsibility.** Approximate-nearest-neighbour semantic recall over code-chunk
+embeddings, hot from daemon start, with repeat queries free.
+
+**Key types/modules.**
+- `VectorStore` / usearch HNSW wrapper (`src/core/store.rs`) in `Arc<RwLock<>>`
+  for concurrent reads; `chunk_id ↔ u64 key` JSON sidecar for restore.
+- `Embedder` trait + `FastEmbedder` (`src/core/embed.rs`) — fastembed/ONNX
+  all-MiniLM-L6-v2 INT8 (384-dim).
+- `QueryCache` — `LruCache<QueryHash, Vec<f32>>` (`TRUSTY_EMBEDDING_CACHE`).
+
+**Current state.** ✅ HNSW pinned hot (`Duration::MAX` cool-after); 4× top_k
+candidates feed RRF; LRU embedding cache skips re-embed on repeat;
+`search_semantic` (vector-only lane) and `search_similar` (code-to-code from a
+seed file/function) both implemented.
+
+**Known gaps.** None material; embedding itself runs in the sidecar (§10).
+
+---
+
+## 4. Knowledge Graph — `src/core/symbol_graph.rs`, `src/service/call_chain.rs`
+
+**Responsibility.** Answer structural questions ("who calls / what does X call")
+and expand search around a hit with adjacent code at a discounted score.
+
+**Key types/modules.**
+- `SymbolGraph` / `SymbolNode` (`src/core/symbol_graph.rs`) — petgraph
+  `DiGraph<SymbolNode,()>` keyed by (qualified) symbol name, rebuilt cheaply from
+  the corpus, held in `Arc<SymbolGraph>`; `callers_of` / `callees_of` 1–2-hop;
+  `EdgeKind` (CALLS/IMPORTS/INHERITS/CONTAINS) multipliers; capped by
+  `TRUSTY_MAX_KG_NODES`.
+- `get_call_chain` renderer (`src/service/call_chain.rs`, #76) — plain-text
+  depth-1 caller/callee tree with `Why:`/`What:` doc annotations; resolves by
+  exact/fuzzy/`file:line`, picking the most-connected candidate.
+- `search_kg` `refine_query` filter (#147) — embeds the refinement, discards KG
+  neighbours below cosine 0.4, re-ranks survivors.
+
+**Current state.** ✅ KG expansion gated to Usage intent, scored at 0.7× the
+trigger chunk's RRF score. `get_call_chain` and `search_kg` work. skip-KG mode
+(`--no-kg` / `TRUSTY_NO_KG`) suppresses Stage 3 entirely and returns a structured
+503 (`kg_unavailable`) from `call_chain` (#313).
+
+**Known gaps.**
+- 🔵 KG Phase B: cross-file IMPORTS/INHERITS edge propagation.
+- 🔵 SCIP protobuf decode (`src/core/scip_ingest.rs`, #105).
+
+---
+
+## 5. Ranker — RRF + intent routing + MMR — `src/core/search/rrf.rs`, `src/core/classifier.rs`, `src/core/mmr.rs`
+
+**Responsibility.** Fuse heterogeneous ranked lists without per-query tuning,
+reweighted by classified intent, with diversity and branch/docs adjustments.
+
+**Key types/modules.**
+- `rrf_fuse()` + `RRF_K = 60` (`src/core/search/rrf.rs`) — rank-only fusion,
+  `Σ weight·1/(k+rank)`.
+- `QueryClassifier` / `QueryIntent` (`src/core/classifier.rs`) — sub-ms regex →
+  `(α, β, use_kg_first)` per intent (see ARCHITECTURE §5).
+- `mmr_rerank` / `cosine_similarity` (`src/core/mmr.rs`).
+- Branch boost (`branch_files`/`branch` → ×`branch_boost`, default 1.5, #122);
+  docs penalty (`src/core/indexer/docs_penalty.rs`).
+
+**Current state.** ✅ All five ingredients (RRF, intent routing, MMR, branch
+boost, docs penalty) implemented and wired into `search.rs`. Each result carries
+a `match_reason` and `on_branch`.
+
+**Known gaps.** None material.
+
+---
+
+## 6. MCP Server — `src/mcp/`
+
+**Responsibility.** Adapt the daemon's REST API into MCP JSON-RPC 2.0 tool calls
+over stdio and HTTP/SSE so an LLM client (Claude Code) can drive code search.
+
+**Key types/modules.**
+- `McpServer` (`src/mcp/tools.rs`) — pure dispatcher proxying tools to the daemon
+  over HTTP; `Request`/`Response`/`JsonRpcError`/`error_codes`/`tool_descriptors`.
+- `stdio` (`src/mcp/stdio.rs`) — line-delimited JSON-RPC loop.
+- `sse` (`src/mcp/sse.rs`) — axum `POST /mcp` + `GET /mcp/sse`.
+- `openrpc` (`src/mcp/openrpc.rs`) — OpenRPC descriptor.
+
+**Current state.** ✅ 17 tools: `search_code`, `search_kg`, `search_semantic`,
+`search_lexical`, `search_similar`, `grep`, `get_call_chain`, `index_file`,
+`remove_file`, `list_indexes`, `create_index`, `delete_index`, `reindex`,
+`index_status`, `list_chunks`, `search_health`, `chat`. stdout reserved for
+JSON-RPC; logs to stderr.
+
+**Known gaps.**
+- 🟡 The crate `README.md` advertises an older 11–15-tool subset; `src/mcp/tools.rs`
+  is authoritative.
+
+---
+
+## 7. HTTP API — `src/service/server.rs`
+
+**Responsibility.** Serve the search pipeline + index management as a
+loopback-only REST API (axum) for integrators and the UI, plus cross-index
+fan-out and observability.
+
+**Key types/modules.**
+- `SearchAppState` (`Arc`-shared) over the `IndexRegistry`.
+- Per-index handlers (search, search_similar, index-file, remove-file, reindex +
+  SSE, chunks, status, call_chain, graph, grep).
+- Global handlers: `global_search_handler` / `global_grep_handler` (fan-out),
+  `/health`, `/indexes`, `/metrics`, `/status/stream`, `/logs/tail`, `/chat`,
+  `/api/chat/providers`, `/ui/*`.
+- `MetricsState` (`src/service/metrics.rs`), `context_inference`
+  (`src/service/context_inference.rs`).
+
+**Current state.** ✅ Full per-index API + global fan-out; HTTP/2; CORS/trace/gzip;
+`{ "error": … }` error envelope with standard codes; Prometheus `/metrics` (#41).
+
+**Known gaps.**
+- 🟡 Cross-index fan-out has no dedup of overlapping indexes (FR-NEST-1, #404).
+- Facts store (`/facts`) optional — 503 when unconfigured.
+
+---
+
+## 8. CLI — `src/main.rs`, `src/commands/`
+
+**Responsibility.** Zero-to-search from the terminal plus daemon lifecycle and
+diagnostics; testable handlers split out of `main()`.
+
+**Key types/modules.**
+- `src/main.rs` — clap parsing → `commands::*`; central friendly-error/exit (#104).
+- Per-subcommand handlers (`src/commands/`): `start`, `stop`, `index`, `query`,
+  `status`, `doctor`, `ui`, `convert`, `serve`, plus `init`/`reindex` aliases,
+  `discover`, `monitor`, `dashboard`, `setup`, `integrate`, `cleanup`, `migrate`.
+- Shared helpers: `daemon_utils`, `format`, `index_resolve`, `reindex_engine`,
+  `doctor_checks`, `doctor_pipeline`, `log_rotation`.
+
+**Current state.** ✅ `index` auto-detects `./trusty-search.yaml`; `doctor --fix`
+is a 6-check diagnostic with auto-repair; `convert` migrates from
+`mcp-vector-search`; `--data-dir` enables isolated daemon instances;
+`--no-auto-discover` skips the startup scan.
+
+**Known gaps.** None material.
+
+---
+
+## 9. Daemon Lifecycle — `src/service/daemon.rs`, `src/service/persistence*.rs`, `src/commands/start.rs`
+
+**Responsibility.** One discoverable singleton daemon per machine that warm-boots
+its registered indexes and degrades safely under memory pressure.
+
+**Key types/modules.**
+- `run_daemon` / `DaemonHandle` / `DaemonError` (`src/service/daemon.rs`) — PID
+  lockfile (OS advisory exclusive lock), auto-port + `port.lock`, graceful
+  shutdown, `daemon.env` (`save_daemon_env` / `PERSISTED_ENV_VARS`).
+- `load_index_registry` / `save_index_registry` / `index_data_dir`
+  (`src/service/persistence.rs`) + `persistence_loader.rs` (`restore_indexes`).
+- `MigrationRegistry` / `run_migrations` (`src/core/migration/`) — background,
+  forward-only, idempotent (#179).
+- Hard 16 GB RAM check (`src/commands/start.rs`, #291).
+
+**Current state.** ✅ Singleton enforcement, auto-port discovery, warm-boot
+persistence (HNSW + redb survive restarts, #85), background schema migrations,
+device-flag persistence.
+
+**Known gaps.**
+- 🔵 Co-located `.trusty-search/` storage + filesystem discovery
+  ([#403](https://github.com/bobmatnyc/trusty-tools/issues/403)) — today data
+  lives under a central daemon data dir.
+
+---
+
+## 10. Embedder Integration — `crates/trusty-embedderd`, `src/service/embedder_supervisor.rs`, `src/service/embed_pool.rs`
+
+**Responsibility.** Keep the ONNX/CoreML arena out of the search daemon's address
+space, install transparently, spawn lazily, and never starve interactive search.
+
+**Key types/modules.**
+- `EmbedderSupervisor` + `LazyEmbedderHandle` (`src/service/embedder_supervisor.rs`,
+  re-exporting `trusty_common::embedder_client` supervisor types) — config from
+  env, `default_socket_path()`, `locate_embedderd_binary()` (actionable install
+  hint), deferred spawn (#315).
+- `embed_pool` (`src/service/embed_pool.rs`) — fixed worker pool, interactive lane
+  drained before background via biased `select!`, worker count autotuned from RAM
+  (#41).
+- `crates/trusty-embedderd/src/`: `protocol.rs`, `batch_queue.rs`,
+  `stdio_server.rs`, `uds_server.rs`, optional `http-server` feature (#250); both
+  the standalone binary and trusty-search's bundled shim call
+  `trusty_embedderd::run()`.
+
+**Current state.** ✅ One `cargo install` installs both binaries; sidecar spawned
+on first embed request, supervised with backoff/restart limits, idle-shutdownable;
+`TRUSTY_EMBEDDER` selects stdio (default) / in-process / http / uds / candle.
+
+**Known gaps.** None material.
+
+---
+
+## 11. Embedded UI — `src/service/ui.rs`, `ui/`, `ui-dist/`
+
+**Responsibility.** Browser-based search, index management, and chat served by the
+daemon itself, with no separate frontend deploy.
+
+**Key types/modules.**
+- `src/service/ui.rs` — serves the bundle at `GET /ui`, `/ui/`, `/ui/{*path}`.
+- `ui/` (Svelte 5 sources) → `ui-dist/` (compiled bundle embedded via
+  `include_dir!`); built by `build.rs` (`SKIP_UI_BUILD=1` skips).
+- `POST /chat` + `GET /api/chat/providers` — OpenRouter chat with search-context
+  injection (503 without `OPENROUTER_API_KEY`).
+
+**Current state.** ✅ Collections, Search, Chat, Admin panels compiled into the
+binary; opened with `trusty-search ui`. CI fails if `ui-dist/` is stale
+(`ui-dist-check`); `make release-prep` rebuilds + mirrors before publish.
+
+**Known gaps.** None material; the UI is not part of the integration contract.
+
+---
+
+## 12. Cross-cutting: Memory Auto-Tuning — `src/core/memory_policy.rs`, `src/core/memguard.rs`
+
+**Responsibility.** Bound RAM on long-running deployments: defaults sized to the
+host, a soft RSS ceiling that degrades to a usable partial index, and an
+Apple-Silicon batch tripwire.
+
+**Key types/modules.**
+- `MemoryPolicy` / `MemoryTier` (`src/core/memory_policy.rs`) — RAM detection,
+  tier selection, env-override, write-back into process env;
+  `resolve_coreml_batch_size`, `resolve_coreml_tripwire_mb`.
+- `memguard` (`src/core/memguard.rs`) — `current_rss_mb` (per-PID, incl. sidecar),
+  `index_memory_limit_mb`, soft-ceiling enforcement.
+
+**Current state.** ✅ Five tiers (Tiny→XLarge); `MEMORY_LIMIT_MB =
+clamp(RAM×25%, 1–64 GB)`; `MAX_BATCH_SIZE` auto-derived (#95); soft ceiling skips
+remaining batches with `memory_limit_hit: true` (#75); CoreML tripwire halves
+batch on > 4 GB RSS jumps; idle chunk-map eviction (300 s).
+
+**Known gaps.**
+- 🟡 README/CLAUDE.md describe the Tiny/Small tiers inconsistently vs. the 16 GB
+  hard check at `start` (PRD Q8); the policy code still defines all five tiers.

--- a/docs/trusty-search/spec/PRD.md
+++ b/docs/trusty-search/spec/PRD.md
@@ -1,0 +1,503 @@
+# trusty-search — Product Requirements Document
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+Each requirement is framed **Vision / Current / Gap**.
+
+---
+
+## 1. Vision & Mission
+
+### North-star vision
+
+> **trusty-search is a machine-wide hybrid code-search service** — one install,
+> one always-on daemon, unlimited named indexes — that fuses **lexical (BM25),
+> semantic (HNSW vector), and structural (knowledge-graph) search** behind a
+> single, parameter-free ranker, and serves that pipeline identically over
+> **MCP, HTTP, and CLI**. It is **local, embedded, and service-free**: no cloud,
+> no database server, no Python or Node runtime in the search path.
+
+Where a developer today juggles `grep`/`ripgrep` for literals, an ad-hoc vector
+tool for "what does this concept look like," and nothing at all for "who calls
+this function," trusty-search collapses all three into one query whose intent it
+classifies and routes automatically. The defining properties are: **hybrid
+ranking that needs no per-query tuning** (RRF, k = 60), **zero cold-start**
+(the HNSW graph is pinned hot and embeddings are LRU-cached), and a
+**single-binary install that bundles its own embedder sidecar** so
+`cargo install trusty-search` is genuinely all an operator runs.
+
+### Mission
+
+Deliver a single machine-wide daemon that any tool — a human at a CLI, an LLM
+agent over MCP, or a host process like open-mpm over HTTP — can ask code
+questions of, in lexical / semantic / structural terms, and get back ranked,
+token-efficient code chunks in single-digit milliseconds, without standing up
+any external service.
+
+### Why this is novel
+
+The closest prior art is `mcp-vector-search` (a Python vector-only MCP tool;
+see [research/trusty-search-vs-mcp-vector-search](../research/trusty-search-vs-mcp-vector-search-2026-05-12.md)).
+trusty-search's differentiator is the **three-lane hybrid** (lexical + vector +
+KG) fused with RRF, the **intent classifier** that reweights lanes per query,
+the **machine-wide multi-index daemon** model (one process, many projects), and
+the **Rust single-binary + bundled sidecar** deployment that removes the runtime
+and service dependencies vector-only tools carry. A `lexical_only` index further
+makes trusty-search a *daemonized ripgrep* — BM25 + grep-parity matching with no
+ONNX, no GPU, no model download (issue [#111](https://github.com/bobmatnyc/trusty-tools/issues/111)).
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+| # | Goal | Status |
+|---|---|---|
+| G1 | **Machine-wide multi-index daemon** — single install, one process, unlimited named indexes via `DashMap<IndexId, Arc<IndexHandle>>`. | ✅ |
+| G2 | **Hybrid three-lane search** — BM25 + HNSW vector + KG expansion fused via RRF (k = 60, parameter-free). | ✅ |
+| G3 | **Query-intent routing** — sub-ms regex classifier into 5 intents, per-intent α/β lane weights and KG gating. | ✅ |
+| G4 | **MCP server** — JSON-RPC 2.0 over stdio + HTTP/SSE, drop-in for Claude Code. | ✅ |
+| G5 | **REST HTTP API** — loopback-only axum daemon for integrators (e.g. open-mpm). | ✅ |
+| G6 | **Single-binary install with bundled embedder** — `cargo install trusty-search` installs both `trusty-search` and the `trusty-embedderd` sidecar. | ✅ |
+| G7 | **Zero cold-start queries** — HNSW pinned hot (`Duration::MAX` cool-after) + LRU embedding cache. | ✅ |
+| G8 | **Auto-tuned memory footprint** — caps computed from detected RAM at startup; every cap env-overridable. | ✅ |
+| G9 | **Incremental, crash-safe persistence** — redb corpus with per-batch atomic commits + sha2 content-fingerprint skip across restarts. | ✅ |
+| G10 | **Embedded admin UI** — Svelte 5 UI compiled into the binary via `include_dir!`. | ✅ |
+| G11 | **Lexical-only / skip-KG modes** — `daemonized ripgrep` (BM25, no embedder) and KG-suppressed indexes for resource-constrained or generated-code subtrees. | ✅ |
+| G12 | **Cross-index fan-out search** — one query across all registered indexes (`POST /search`, `POST /grep`). | 🟡 |
+| G13 | **Nested-index hierarchy & sub-index prioritization** — parent/child index graph with dedup and subtree-first fan-out ranking. | 🔵 |
+| G14 | **Co-located per-project storage + filesystem discovery** — index data in `.trusty-search/` next to the project, auto-discovered on walk. | 🔵 |
+| G15 | **Cross-release performance regression CI gate** — MRR@5 / Recall@10 tracked across versions. | 🟡 |
+
+### Non-Goals
+
+| Non-Goal | Rationale |
+|---|---|
+| Cloud-hosted / multi-tenant search service | trusty-search is a **local, loopback-only** daemon; the ELv2 license explicitly forbids offering it as a hosted service. |
+| Network-exposed daemon | The daemon binds `127.0.0.1` only and trusts every caller — **do not** bind a non-loopback interface; there is no auth layer by design. |
+| Python or Node runtime in the search path | Rust single binary; Node is used only to *build* the embedded Svelte UI. |
+| Code-quality metrics (complexity / smells / grades) | Moved to **trusty-analyze** (issue #71). `CodeChunk` no longer carries complexity/blame; those HTTP endpoints are not served here as of v0.2.0. |
+| Windows daemon support | macOS 12+ / Linux only today; Windows paths in `trusty-common` are a future item. |
+| Full LSP/compiler-grade symbol resolution | tree-sitter extraction is the baseline; SCIP ingest is a designed-not-built upgrade path (#105). |
+
+---
+
+## 3. Target Users / Personas
+
+| Persona | Who | Primary need | Surface |
+|---|---|---|---|
+| **LLM coding agent** | Claude Code (and other MCP clients) | Token-efficient hybrid code search + call-chain navigation as a tool | **MCP** (stdio / HTTP-SSE) |
+| **Host orchestrator** | open-mpm and other Rust processes embedding the daemon | A liveness-probable REST API + the `SearchMcpService` rlib surface | **HTTP API** / `rlib` |
+| **Terminal developer** | Engineers who want a faster, semantic `grep` | Index a repo, run a query, see ranked chunks; manage the daemon | **CLI** |
+| **Daemon operator** | Whoever runs the box | One install, predictable RAM, diagnostics, GPU/CPU control | **CLI** (`status` / `doctor` / `start`) + **admin UI** |
+
+**Unifying need across all four:** ask a code question in whatever terms fit
+(literal, conceptual, or "who calls/who is called by") and get ranked, accurate,
+token-cheap results back fast, from a service that is already running.
+
+---
+
+## 4. Functional Requirements
+
+Grouped by capability area. Each requirement carries Vision / Current / Gap and
+an inline status tag. Source paths are cited where known.
+
+### 4.1 Indexing pipeline (`src/core/chunker/`, `src/core/indexer/`, `src/service/reindex.rs`, `src/service/walker.rs`)
+
+**FR-IDX-1 — AST-aware chunking** ✅
+- *Vision:* One chunk per top-level declaration (not sliding windows), so
+  `function_name`, `chunk_type`, and `calls` are accurate enough to drive both
+  semantic search and KG CALLS edges.
+- *Current:* `chunk_ast()` parses with tree-sitter (15 grammars: rust, python,
+  js, ts, go, java, c, cpp, ruby, php, scala, c-sharp, kotlin, swift) and walks
+  top-level declarations into chunks, splitting oversized ones into stable
+  parent-ID sub-chunks (`src/core/chunker/mod.rs`). Unknown extensions and
+  structured docs (md/yaml/toml/json) fall back to format-aware text chunkers.
+- *Gap:* Build-file grammars (`.gradle`, `.groovy`) use the sliding-window
+  fallback.
+
+**FR-IDX-2 — Source-tree walk honouring `.gitignore`** ✅
+- *Vision:* Enumerate indexable files while skipping VCS/build/dependency dirs
+  and binary noise; never silently partial-index because of ignore rules.
+- *Current:* `walk_source_files()` uses the `ignore` crate (ripgrep's engine) to
+  honour `.gitignore`/`.ignore`/global gitignore, filters by `SOURCE_EXTS`, and
+  applies minification/size guards at read time (`src/service/walker.rs`, #100).
+  Walk diagnostics (`last_walk_files_seen/skipped/error`) are recorded per
+  reindex to explain zero-chunk outcomes (#280).
+- *Gap:* None material.
+
+**FR-IDX-3 — Incremental, crash-safe reindex** ✅
+- *Vision:* Re-running an index skips unchanged files; a crash mid-reindex never
+  corrupts the corpus; large repos reindex in minutes, not tens of minutes.
+- *Current:* sha2 content fingerprints skip unchanged files across restarts;
+  `--force` clears the per-index hash cache. The redb `CorpusStore` commits each
+  batch atomically (O(batch), not O(corpus)) (`src/core/corpus.rs`, #28). Parse +
+  embed run outside the write lock; only the redb+HNSW commit holds it. SSE
+  progress with a 500-event replay buffer (`src/service/reindex.rs`).
+- *Gap:* None material.
+
+**FR-IDX-4 — File watching** ✅
+- *Vision:* Edits on disk update the index without a manual reindex.
+- *Current:* `notify` + `notify-debouncer-mini` (500 ms debounce) drive a watch
+  loop per index (`src/service/watcher.rs`, `watch_loop.rs`).
+- *Gap:* None material.
+
+### 4.2 Lexical search — BM25 (`src/core/bm25.rs` → `trusty_common::bm25`, `src/service/grep.rs`)
+
+**FR-LEX-1 — BM25 ranked lexical lane** ✅
+- *Vision:* A zero-dependency BM25 scorer with code-aware tokenization
+  (camelCase / snake_case splitting) shared across trusty tooling.
+- *Current:* BM25 moved into `trusty-common` (#156) and is re-exported here as
+  `Bm25Index`; the per-query index is built from the chunk corpus and capped by
+  `TRUSTY_BM25_CORPUS_CAP`.
+- *Gap:* Deferred memory optimizations (streaming sort-merge, etc.) tracked in
+  [#340](https://github.com/bobmatnyc/trusty-tools/issues/340). 🟡
+
+**FR-LEX-2 — grep-parity regex search (`/grep`)** ✅
+- *Vision:* Exact, deterministic, line-accurate matching with ripgrep ergonomics
+  (regex, `-i`, `-A`/`-B`/`-C`, `--include` globs, multiline) — without
+  re-embedding.
+- *Current:* `CompiledGrep` + `grep_file_content` is a pure matcher driven by the
+  HTTP handler over the files the index already knows (`src/service/grep.rs`).
+  Certified at grep parity: P50 8 ms vs ripgrep 9 ms on a 1,155-file workspace
+  (#111, [v0.14.0 stage-1 cert](../regression-testing/v0.14.0-stage1-cert-2026-05-27.md)).
+- *Gap:* None material.
+
+**FR-LEX-3 — Lexical-only mode (daemonized ripgrep)** ✅
+- *Vision:* An index that skips embedding entirely — BM25 + grep speed via a
+  persistent HTTP/MCP daemon, no ONNX, no GPU, no model download.
+- *Current:* `lexical_only: true` on index create. ~63× faster reindex; daemon
+  fits in ~700 MB. Stage-1-minimal also skips symbol-graph construction
+  ([#312](https://github.com/bobmatnyc/trusty-tools/issues/312)).
+- *Gap:* None material.
+
+### 4.3 Semantic search — HNSW vector (`src/core/store.rs`, `src/core/embed.rs`, `src/service/embedder_supervisor.rs`)
+
+**FR-VEC-1 — HNSW vector lane** ✅
+- *Vision:* Fast approximate-nearest-neighbour semantic recall over code-chunk
+  embeddings, hot from daemon start.
+- *Current:* usearch 2.25 HNSW wrapped in `Arc<RwLock<>>` for concurrent reads;
+  pinned hot (`Duration::MAX` cool-after); INT8-quantized all-MiniLM-L6-v2
+  (384-dim) via fastembed/ONNX. 4× top_k candidates feed RRF
+  (`src/core/store.rs`, `src/core/indexer/search.rs`).
+- *Gap:* None material.
+
+**FR-VEC-2 — Embedding cache (zero re-embed on repeat)** ✅
+- *Vision:* Repeated queries never re-pay the embedder cost.
+- *Current:* LRU cache (`TRUSTY_EMBEDDING_CACHE`, 500–20 000 by tier) on query
+  embeddings; cache miss falls back gracefully.
+- *Gap:* None material.
+
+**FR-VEC-3 — `search_semantic` / `search_similar` lanes** ✅
+- *Vision:* A vector-only lane and code-to-code similarity from a seed
+  file/function.
+- *Current:* `search_semantic` MCP tool + `POST /indexes/:id/search_similar`
+  (seed = named function or first chunk of a file).
+- *Gap:* None material.
+
+### 4.4 Knowledge-graph search (`src/core/symbol_graph.rs`, `src/service/call_chain.rs`)
+
+**FR-KG-1 — Symbol graph & KG expansion** ✅
+- *Vision:* Answer "who calls X / what does X call" and expand search around a
+  hit with adjacent code at a discounted score.
+- *Current:* petgraph `DiGraph<SymbolNode,()>` keyed by (qualified) symbol name,
+  rebuilt cheaply from the corpus and held in `Arc<SymbolGraph>`; 1–2-hop
+  `callers_of`/`callees_of` expansion scored at 70% of the trigger chunk's RRF
+  score, **gated to Usage intent only**. `EdgeKind` (CALLS/IMPORTS/INHERITS/
+  CONTAINS) multipliers. Node count capped by `TRUSTY_MAX_KG_NODES`.
+- *Gap:* KG Phase B (cross-file IMPORTS/INHERITS propagation) not built.
+
+**FR-KG-2 — `get_call_chain` annotated call tree** ✅
+- *Vision:* A depth-1 caller/callee tree with `Why:`/`What:` doc annotations to
+  improve multi-function edit quality.
+- *Current:* `get_call_chain` MCP tool + `GET /indexes/:id/call_chain` render a
+  plain-text tree resolved by exact/fuzzy/`file:line` symbol lookup
+  (`src/service/call_chain.rs`, #76).
+- *Gap:* None material.
+
+**FR-KG-3 — `search_kg` with `refine_query`** ✅
+- *Vision:* KG-first graph-walk search that does not compound a weak seed's error.
+- *Current:* `search_kg` accepts optional `refine_query`; the daemon embeds it
+  and discards KG neighbours below cosine 0.4, re-ranking survivors (#147).
+- *Gap:* None material.
+
+**FR-KG-4 — skip-KG mode** ✅
+- *Vision:* Run BM25 + vector but skip the Phase-3 KG rebuild for
+  documentation-heavy / generated-code subtrees.
+- *Current:* `skip_kg: true` (CLI `--no-kg`, YAML, HTTP, or `TRUSTY_NO_KG=1`).
+  Saves ~50–100 MB heap + ~400 ms/reindex. `call_chain` returns a structured 503
+  (`kg_unavailable`) when skipped (#313).
+- *Gap:* None material.
+
+**FR-KG-5 — SCIP ingest for LSP-quality entities** 🔵
+- *Vision:* Consume CI-produced SCIP indexes for cross-file symbol fidelity
+  beyond tree-sitter.
+- *Current:* `CodeEntityIndex` trait + `ScipIndex::from_refs` testable path
+  exist; native protobuf decode is a TODO (`src/core/scip_ingest.rs`, #105).
+- *Gap:* `ScipIndex::from_scip` (protobuf parse) not wired.
+
+### 4.5 Hybrid ranking (`src/core/search/rrf.rs`, `src/core/classifier.rs`, `src/core/mmr.rs`)
+
+**FR-RANK-1 — RRF fusion** ✅
+- *Vision:* Combine heterogeneous ranked lists without per-query tuning.
+- *Current:* `rrf_fuse()` sums `weight · 1/(k+rank)` per lane, k = 60 (Cormack et
+  al.), rank-only (scores ignored) (`src/core/search/rrf.rs`).
+- *Gap:* None material.
+
+**FR-RANK-2 — Intent classification & lane routing** ✅
+- *Vision:* Reweight lexical/vector lanes and gate KG per query, sub-ms.
+- *Current:* `QueryClassifier` regex → `Definition | Usage | Conceptual |
+  BugDebt | Unknown`, each mapping to `(α, β, use_kg_first)`
+  (`src/core/classifier.rs`). Usage gates KG expansion on.
+- *Gap:* None material.
+
+**FR-RANK-3 — MMR diversity re-ranking** ✅
+- *Vision:* Avoid near-duplicate top results.
+- *Current:* `mmr_rerank` with cosine similarity (`src/core/mmr.rs`).
+- *Gap:* None material.
+
+**FR-RANK-4 — Branch-aware boosting** ✅
+- *Vision:* Surface work on the current git branch first.
+- *Current:* `branch_files`/`branch` on `POST .../search` boost matching chunks
+  (default 1.5×, clamped [1.0, 3.0]); each result carries `on_branch` (#122).
+  When only `branch` is given the daemon derives the file list via
+  `git merge-base` + `git diff --name-only` (non-fatal on failure).
+- *Gap:* None material.
+
+**FR-RANK-5 — Documentation down-ranking** ✅
+- *Vision:* Code queries should not be dominated by `.md`/changelog chunks.
+- *Current:* `src/core/indexer/docs_penalty.rs` down-ranks doc/changelog chunks
+  in code-intent queries (#72, #77).
+- *Gap:* None material.
+
+### 4.6 MCP server (`src/mcp/`)
+
+**FR-MCP-1 — JSON-RPC 2.0 server over stdio + HTTP/SSE** ✅
+- *Vision:* A drop-in MCP server Claude Code can wire with two lines of config.
+- *Current:* `McpServer` dispatcher proxies tool calls to the daemon over HTTP;
+  `stdio` line-delimited loop and `sse` axum router (`POST /mcp`, `GET /mcp/sse`)
+  (`src/mcp/mod.rs`). Stdout reserved for JSON-RPC; logs to stderr.
+- *Gap:* None material.
+
+**FR-MCP-2 — Tool catalogue** ✅
+- *Vision:* Expose every search lane + index management as MCP tools.
+- *Current:* `search_code`, `search_kg`, `search_semantic`, `search_lexical`,
+  `search_similar`, `grep`, `get_call_chain`, `index_file`, `remove_file`,
+  `list_indexes`, `create_index`, `delete_index`, `reindex`, `index_status`,
+  `list_chunks`, `search_health`, `chat` (`src/mcp/tools.rs`).
+- *Gap:* The crate README lists an older subset; the code is authoritative.
+
+### 4.7 HTTP API (`src/service/server.rs`)
+
+**FR-HTTP-1 — Loopback REST API** ✅
+- *Vision:* A liveness-probable REST surface for integrators; localhost-only, no
+  auth.
+- *Current:* axum 0.8 + tower-http (CORS, trace, gzip), HTTP/2; per-index search,
+  search_similar, index-file, remove-file, reindex (+ SSE stream), chunks,
+  status, call_chain, graph (+ stats), grep; plus global `/health`, `/indexes`,
+  `/search`, `/grep`, `/metrics`, `/status/stream`, `/logs/tail`,
+  `/api/chat/providers`, `/chat`, `/ui/*` (`src/service/server.rs`).
+- *Gap:* Facts store endpoints (`/facts`) are optional/may return 503 when
+  unconfigured.
+
+**FR-HTTP-2 — Cross-index fan-out** 🟡
+- *Vision:* One query across all indexes, weighted/skipped by per-project
+  relevance.
+- *Current:* `POST /search` and `POST /grep` fan out across the registry;
+  `context_inference` scrapes project metadata (README/CLAUDE.md/manifests) to
+  build a per-index relevance summary (`src/service/context_inference.rs`, #112).
+- *Gap:* No dedup of overlapping indexes; no subtree prioritization — see
+  FR-NEST-1.
+
+**FR-HTTP-3 — Prometheus metrics** ✅
+- *Vision:* Production observability for multi-user deployments.
+- *Current:* `/metrics` (request counters, latency histograms, queue/pool gauges)
+  when the recorder is wired (`src/service/metrics.rs`, #41 Phase 1).
+- *Gap:* None material.
+
+### 4.8 CLI (`src/main.rs`, `src/commands/`)
+
+**FR-CLI-1 — Index + query + manage from the terminal** ✅
+- *Vision:* Zero-to-search in five commands; daemon lifecycle and diagnostics.
+- *Current:* `start`/`stop`/`index`/`query`/`status`/`doctor`/`ui`/`convert`/
+  `serve` + aliases (`init`, `reindex`). `index` auto-detects
+  `./trusty-search.yaml`. `doctor --fix` runs a 6-check diagnostic with
+  auto-repair. `convert` migrates from `mcp-vector-search` (`src/commands/`).
+- *Gap:* None material.
+
+### 4.9 Daemon lifecycle (`src/service/daemon.rs`, `src/commands/start.rs`)
+
+**FR-DMN-1 — Singleton, auto-port, graceful shutdown** ✅
+- *Vision:* One daemon per machine, discoverable port, clean SIGTERM/SIGINT exit.
+- *Current:* OS advisory lock on a PID lockfile enforces singleton; binds from a
+  requested port walking forward to a free one and writes `port.lock`; graceful
+  shutdown via axum `with_graceful_shutdown` (`src/service/daemon.rs`).
+- *Gap:* None material.
+
+**FR-DMN-2 — Warm-boot persistence** ✅
+- *Vision:* Registered indexes (with HNSW graph + chunk corpus) survive restarts;
+  no full re-index on every boot.
+- *Current:* Registry TOML + per-index data dir (`hnsw.usearch` + redb corpus);
+  `restore_indexes` on startup; forward-only idempotent schema migrations
+  (`_meta.schema_version`) run in background (`src/service/persistence.rs`,
+  `src/core/migration/`, #85).
+- *Gap:* None material.
+
+**FR-DMN-3 — Hard RAM check** ✅
+- *Vision:* Fail fast on under-spec hosts rather than OOM mid-reindex.
+- *Current:* 16 GB minimum hard-checked at `start` with an actionable error;
+  `TRUSTY_SKIP_RAM_CHECK=1` bypass (`src/commands/start.rs`, #291).
+- *Gap:* None material.
+
+**FR-DMN-4 — GPU/CPU device control** ✅
+- *Vision:* CoreML auto on Apple Silicon; CUDA opt-in; force-CPU/GPU at runtime.
+- *Current:* CoreML EP auto-registered on aarch64-macOS (no feature flag since
+  v0.3.13); CUDA via `--features cuda` (+ `--no-default-features` and
+  `ORT_DYLIB_PATH` on glibc < 2.38); `--device cpu|gpu|auto` persisted to
+  `daemon.env`.
+- *Gap:* None material.
+
+### 4.10 Embedder sidecar (`crates/trusty-embedderd`, `src/service/embedder_supervisor.rs`)
+
+**FR-EMB-1 — Bundled single-install sidecar** ✅
+- *Vision:* `cargo install trusty-search` installs both binaries; the operator
+  manages one daemon.
+- *Current:* `trusty-embedderd` is a workspace crate declared both as a Cargo dep
+  and a second `[[bin]]` in trusty-search's manifest; the shim calls
+  `trusty_embedderd::run()`. The supervisor spawns/supervises it
+  (`src/service/embedder_supervisor.rs`, #110 Phase 2 / #187).
+- *Gap:* None material.
+
+**FR-EMB-2 — Lazy spawn + idle shutdown** ✅
+- *Vision:* Don't pay the ONNX init cost until the first embed; reclaim it when
+  idle (useful for lexical-only deployments).
+- *Current:* `LazyEmbedderHandle` defers the spawn until the first embed request;
+  binary discovery still runs at boot and fails fast with an install hint.
+  `TRUSTY_EMBEDDERD_IDLE_SHUTDOWN_SECS` kills + resets the spawn gate (#315).
+- *Gap:* None material.
+
+**FR-EMB-3 — Pluggable embedder transports** ✅
+- *Vision:* The sidecar is the default, but in-process / HTTP / UDS / Candle
+  paths exist for tests and special hosts.
+- *Current:* `TRUSTY_EMBEDDER` selects `auto/stdio` (default sidecar),
+  `in-process`, `http://…`, `unix:/…`, or `candle` (with `--features candle`).
+- *Gap:* None material.
+
+**FR-EMB-4 — Priority embed pool** ✅
+- *Vision:* Interactive search embeddings must not starve behind a long reindex.
+- *Current:* `embed_pool` drains interactive before background via biased
+  `select!`; worker count autotuned from RAM (`src/service/embed_pool.rs`, #41).
+- *Gap:* None material.
+
+### 4.11 Memory & auto-tuning (`src/core/memory_policy.rs`, `src/core/memguard.rs`)
+
+**FR-MEM-1 — Tiered auto-tuned caps** ✅
+- *Vision:* Defaults that fit the host: safe on a laptop, generous on a
+  workstation, all overridable.
+- *Current:* `MemoryPolicy::detect()` reads RAM (`hw.memsize` / `/proc/meminfo`),
+  selects a tier (Tiny→XLarge), sets `MAX_CHUNKS`, `EMBEDDING_CACHE`,
+  `MAX_BATCH_SIZE`, `BM25_CORPUS_CAP`, `MAX_KG_NODES`, and `MEMORY_LIMIT_MB`
+  (= clamp(RAM×25%, 1–64 GB)); env vars override (precedence: shell >
+  `daemon.env` > tier). Resolved tier logged at startup.
+- *Gap:* README and CLAUDE.md disagree on whether Tiny/Small tiers are removed
+  vs. retained — the code retains five tiers but `start` hard-checks 16 GB. 🟡
+
+**FR-MEM-2 — Soft RSS ceiling during reindex** ✅
+- *Vision:* Never OOM; degrade to a usable partial index instead.
+- *Current:* `memguard` polls RSS; on `TRUSTY_MEMORY_LIMIT_MB` breach the reindex
+  skips remaining batches (already-committed chunks stay searchable) and emits
+  `memory_limit_hit: true` (`src/core/memguard.rs`, #75/#95).
+- *Gap:* Between-batch poller cannot catch intra-call ORT spikes; mitigated by
+  the batch-size formula and CoreML tripwire.
+
+**FR-MEM-3 — CoreML batch tripwire** ✅
+- *Vision:* Bound Apple-Silicon unified-memory spikes per embed batch.
+- *Current:* `TRUSTY_COREML_TRIPWIRE_MB` (4 GB default) halves batch size on a
+  > 4 GB RSS jump; default CoreML batch 32 (ANE-optimal).
+- *Gap:* None material.
+
+**FR-MEM-4 — Idle chunk-map eviction** ✅
+- *Vision:* A quiet daemon should shrink to its durable baseline.
+- *Current:* `TRUSTY_CHUNKS_IDLE_EVICT_SECS` (300 s) evicts the in-memory
+  `RawChunk` map for durably-backed indexes; readers rehydrate from redb;
+  BM25 + symbol graph stay hot.
+- *Gap:* None material.
+
+### 4.12 UI (`src/service/ui.rs`, `ui/`, `ui-dist/`)
+
+**FR-UI-1 — Embedded Svelte admin UI** ✅
+- *Vision:* Search, index management, and chat from a browser, served by the
+  daemon itself.
+- *Current:* Svelte 5 UI compiled into the binary via `include_dir!`; Collections,
+  Search, Chat, Admin panels; opened with `trusty-search ui`; built by `build.rs`
+  (`SKIP_UI_BUILD=1` to skip) (`src/service/ui.rs`).
+- *Gap:* None material.
+
+**FR-UI-2 — OpenRouter chat with auto-injected search context** ✅
+- *Vision:* Ask natural-language questions answered with retrieved code context.
+- *Current:* `POST /chat` (+ `chat` MCP tool) forwards to OpenRouter with
+  search-context injection; requires `OPENROUTER_API_KEY` (503 otherwise).
+- *Gap:* None material.
+
+### 4.13 Multi-index topology & storage (roadmap)
+
+**FR-NEST-1 — Nested-index hierarchy & sub-index prioritization** 🔵
+- *Vision:* A DAG of indexes where sub-indexes are children of a parent; fan-out
+  returns subtree results first, dedups overlapping coverage, and uses the parent
+  as a backstop.
+- *Current:* All indexes are flat `DashMap` peers; overlapping indexes return
+  duplicates in fan-out. RFC drafted
+  ([nested-index-fanout-rfc](../research/nested-index-fanout-rfc-2026-05-29.md),
+  [#404](https://github.com/bobmatnyc/trusty-tools/issues/404)).
+- *Gap:* Entire feature designed-not-built; depends on FR-STORE-1 and #402
+  (relative chunk paths).
+
+**FR-STORE-1 — Co-located `.trusty-search/` storage + filesystem discovery** 🔵
+- *Vision:* Index data lives in a `.trusty-search/` dir next to the project;
+  the walker discovers existing indexes on the filesystem.
+- *Current:* Index data lives under the central daemon data dir.
+- *Gap:* Designed-not-built ([#403](https://github.com/bobmatnyc/trusty-tools/issues/403)).
+
+---
+
+## 5. Success Criteria & Differentiators
+
+| Criterion | Target | Status |
+|---|---|---|
+| Warm p50 query latency | < 10 ms on a 100k-chunk index | ✅ (8 ms `/grep` P50 certified on 1,155 files) |
+| `/grep` vs ripgrep | parity | ✅ (8 ms vs 9 ms) |
+| Full hybrid reindex | ~2–3 min for a 14k-file repo | ✅ |
+| Lexical-only reindex | ~63× faster than hybrid; daemon ≤ ~700 MB | ✅ |
+| Cold start | zero (HNSW hot + LRU embed cache) | ✅ |
+| Install footprint | one command installs both binaries | ✅ |
+| Retrieval quality | MRR@5 / Recall@10 tracked across releases | 🟡 (benchmarks exist; CI gate pending) |
+
+**Differentiators vs. `mcp-vector-search` and bare ripgrep:** three-lane hybrid
+(lexical + vector + KG) with parameter-free RRF and per-query intent routing;
+machine-wide multi-index daemon (one process, many projects); Rust single-binary
++ bundled sidecar (no Python/Node runtime); zero cold-start; and a `lexical_only`
+mode that is a daemonized ripgrep with MCP/HTTP integration.
+
+---
+
+## 6. Open Questions & Roadmap
+
+| # | Question / item | Tracking |
+|---|---|---|
+| Q1 | Should fan-out dedup overlapping indexes before or after RRF? | RFC #404 |
+| Q2 | Co-located `.trusty-search/` storage layout & relative chunk paths | #403, #402 |
+| Q3 | Nested parent/child index graph + subtree-first ranking | #404 |
+| Q4 | Wire a benchmark regression CI gate (MRR@5 / Recall@10) | #129 |
+| Q5 | SCIP protobuf decode for LSP-quality entities | #105 |
+| Q6 | KG Phase B: cross-file IMPORTS/INHERITS edge propagation | — |
+| Q7 | Further BM25 / redb in-memory footprint reductions | #340 |
+| Q8 | Reconcile the README/CLAUDE.md memory-tier description (Tiny/Small retained vs removed) | docs |
+| Q9 | Windows daemon path support (via `trusty-common`) | — |
+
+For **cross-release performance tracking**, see
+[#129](https://github.com/bobmatnyc/trusty-tools/issues/129), which accumulates
+benchmark deltas across all measured versions.

--- a/docs/trusty-search/spec/README.md
+++ b/docs/trusty-search/spec/README.md
@@ -1,0 +1,95 @@
+# trusty-search — Specification Set
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+This directory holds the canonical product and engineering specification for the
+`trusty-search` crate (`crates/trusty-search/`). It is the single authoritative
+reference for *what trusty-search is meant to be*, *what it is today*, and *what
+gaps remain*.
+
+## What is trusty-search?
+
+`trusty-search` is a **machine-wide hybrid code-search service**: one install per
+machine (`cargo install trusty-search`), one always-on HTTP daemon, and an
+unlimited number of named per-project indexes managed concurrently from a single
+`DashMap<IndexId, Arc<IndexHandle>>`. Each query is classified by intent (a
+sub-millisecond regex classifier) and then run across **three search lanes —
+BM25 lexical, HNSW vector-semantic, and a tree-sitter-derived knowledge graph
+(KG)** — whose ranked outputs are fused, parameter-free, via Reciprocal Rank
+Fusion (RRF, k = 60). The daemon exposes the same pipeline over **three
+surfaces**: a REST HTTP API (axum, loopback-only), an MCP server (JSON-RPC 2.0
+over stdio + HTTP/SSE, for Claude Code), and a `clap`-based CLI. Embedding runs
+in a **bundled sidecar process** (`trusty-embedderd`) that `cargo install
+trusty-search` installs alongside the main binary, keeping the ONNX/CoreML arena
+out of the search daemon's address space. Everything is local, embedded, and
+service-free: redb for the durable chunk corpus, usearch for the in-memory HNSW
+graph, fastembed/ONNX (all-MiniLM-L6-v2 INT8, 384-dim) for embeddings, petgraph
+for the symbol graph.
+
+## Documents in this set
+
+| Document | Read it when you want to know… |
+|---|---|
+| **[PRD.md](./PRD.md)** | The product: vision & mission, goals/non-goals, personas, the full functional-requirement catalog grouped by capability (indexing, lexical, semantic, KG, hybrid ranking, MCP, HTTP, CLI, daemon lifecycle, memory/auto-tuning, UI) and tagged by implementation status, success criteria & differentiators, and the open-question roadmap. Start here for *why* and *what*. |
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | The system shape: daemon/registry topology, the staged indexing pipeline, the `trusty-embedderd` sidecar bundling + single-install relationship, storage (redb corpus + usearch HNSW + petgraph KG), the query-dispatch pipeline (classify → route → search → fuse → expand), MCP/HTTP framing (stdout reserved for JSON-RPC, logs to stderr), the memory auto-tuning `TRUSTY_*` env knobs, and the CoreML/ONNX/CUDA execution-provider paths. Includes the source-module map with `src/` citations. Start here for *how it fits together*. |
+| **[COMPONENTS.md](./COMPONENTS.md)** | Per-subsystem specs: indexer/pipeline, lexical (BM25), vector (HNSW + embedder), KG (symbol graph), ranker (RRF + MMR + intent routing), MCP server, HTTP API, CLI, daemon lifecycle, embedder-sidecar integration, and the embedded Svelte UI. Each states responsibility, key types/modules (with `src/` paths), current state, and known gaps. Start here for *the detail of one subsystem*. |
+
+## Reading order
+
+1. **New to trusty-search?** PRD → ARCHITECTURE → COMPONENTS.
+2. **Implementing a feature?** Jump to the relevant COMPONENTS section, then
+   cross-check the dispatch pipeline in ARCHITECTURE.
+3. **Evaluating product direction?** PRD vision + success criteria, then the gap
+   callouts throughout COMPONENTS.
+
+## Status legend (used throughout this set)
+
+Every requirement and component is framed as **Vision / Current / Gap** and
+tagged inline with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, RFC, or plan) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+## Related documentation
+
+This `spec/` set is the *what/why/gap* layer. The point-in-time and operational
+docs live alongside it:
+
+- **[../research/](../research/)** — dated investigations and decision documents
+  (BM25 memory, Candle/Metal validation, the nested-index fan-out RFC #404, the
+  staged-pipeline decisions, the trusty-search vs. mcp-vector-search comparison).
+- **[../regression-testing/](../regression-testing/)** — versioned performance
+  snapshots and alternate-corpus baselines; [`current.md`](../regression-testing/current.md)
+  symlinks the latest.
+- **[../sessions/](../sessions/)** — engineering-session narratives.
+- **[../examples/trusty-search.yaml](../examples/trusty-search.yaml)** —
+  multi-index per-repo config.
+- **[crates/trusty-search/README.md](../../../crates/trusty-search/README.md)**
+  and **[crates/trusty-search/CLAUDE.md](../../../crates/trusty-search/CLAUDE.md)**
+  — in-crate quick-start, HTTP endpoint catalogue, and release process.
+
+## Provenance & maintenance
+
+These documents are derived from an audit of the `crates/trusty-search/src/`
+tree (the single-crate `core` / `service` / `mcp` module layout as of v0.18.0),
+the crate `README.md` / `CLAUDE.md`, and the open/closed issue backlog (notably
+the cross-release performance tracker [#129](https://github.com/bobmatnyc/trusty-tools/issues/129),
+the `.trusty-search/` co-located-storage work [#403](https://github.com/bobmatnyc/trusty-tools/issues/403),
+and the nested-index fan-out RFC [#404](https://github.com/bobmatnyc/trusty-tools/issues/404)).
+When the code changes materially, update the relevant document and bump the
+*Last reviewed* date. Source-path citations reflect the layout at the time of
+review.
+
+> **Note on in-crate `CLAUDE.md` drift:** the crate-local
+> `crates/trusty-search/CLAUDE.md` predates the workspace consolidation and
+> still references the pre-monorepo crate names (`trusty-search-core`,
+> `trusty-embedder`, `trusty-mcp-core`) and per-crate test paths. The authoritative
+> layout is the single `trusty-search` crate with `core` / `service` / `mcp`
+> modules plus the bundled `trusty-embedderd` sidecar — this spec set reflects
+> the audited tree, not the stale CLAUDE.md.


### PR DESCRIPTION
Adds the canonical spec set (PRD/ARCHITECTURE/COMPONENTS + README index) under docs/trusty-search/spec/ in the open-mpm style (Vision/Current/Gap, ✅/🟡/🔵/⚪), an ADR for the bundled-embedder sidecar split, and fixes 8 pre-existing broken `../../crates/` links in older trusty-search docs. cargo check -p trusty-search passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)