### PR TITLE
docs(trusty-memory): canonical spec set

### DIFF
--- a/docs/trusty-memory/README.md
+++ b/docs/trusty-memory/README.md
@@ -2,6 +2,23 @@
 
 Memory palace storage daemon + MCP server frontend (`crates/trusty-memory-core` + `crates/trusty-memory`).
 
+## Canonical specification
+
+The authoritative product + engineering specification lives in
+[`spec/`](spec/) — start here for *what trusty-memory is, what it does today, and
+what gaps remain*:
+
+| Document | Covers |
+|---|---|
+| [`spec/README.md`](spec/README.md) | Index, one-paragraph summary, status legend, reading order. |
+| [`spec/PRD.md`](spec/PRD.md) | Vision/mission, goals/non-goals, personas, the full status-tagged functional-requirement catalog, success criteria, roadmap. |
+| [`spec/ARCHITECTURE.md`](spec/ARCHITECTURE.md) | The frontend/core split, multi-transport model, BM25 sidecar bundling, fire-and-forget remember path, storage model, L0–L3 retrieval, source-module map. |
+| [`spec/COMPONENTS.md`](spec/COMPONENTS.md) | Per-subsystem specs (MCP server, HTTP API, palace store, BM25 sidecar, retrieval, KG/dream, UI, `note` CLI, migration) with `src/` citations. |
+
+Architectural decision records live in [`decisions/`](decisions/):
+
+- [ADR-0001 — Frontend/core split: trusty-memory ⇄ trusty-common `memory_core`](decisions/0001-frontend-core-split.md)
+
 ## Layout
 
 This directory follows the standard three-subdir layout used across all
@@ -9,15 +26,17 @@ published trusty-* crates:
 
 | Subdir | Contents |
 |--------|----------|
+| [`spec/`](spec/) | Canonical product + engineering specification (PRD / ARCHITECTURE / COMPONENTS). |
+| [`decisions/`](decisions/) | Architectural decision records (Nygard format). |
 | [`regression-testing/`](regression-testing/) | Versioned performance/quality snapshots, baseline measurements, alternate-corpus baselines. |
 | [`research/`](research/) | Investigation docs, audits, decision documents. |
 | [`sessions/`](sessions/) | Engineering-session summaries — narrative + reasoning. |
 
 ## Status
 
-No `trusty-memory` documentation has been authored yet in this layout. As work
-on trusty-memory produces benchmarks, decisions, or session summaries, add files
-under the appropriate subdir and update its README index.
+The canonical [`spec/`](spec/) set has been authored from a code/docs/tickets
+audit (2026-05-29). As work on trusty-memory produces benchmarks or session
+summaries, add files under the appropriate subdir and update its README index.
 
 See [`docs/trusty-search/`](../trusty-search/) for a worked example of the
 populated layout.

--- a/docs/trusty-memory/decisions/0001-frontend-core-split.md
+++ b/docs/trusty-memory/decisions/0001-frontend-core-split.md
@@ -1,0 +1,69 @@
+# 0001. Frontend/core split: trusty-memory ⇄ trusty-common `memory_core`
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Scope:** Crates `trusty-memory` and `trusty-common`
+- **Supersedes / Superseded by:** Absorbs the former `trusty-memory-core` crate (issue #5)
+
+## Context
+
+The Memory Palace has two distinct concerns: (1) the **storage and retrieval
+engine** — the palace data model, the redb/HNSW vector store, the temporal
+knowledge graph, the dream/consolidation loop, and the embedder — and (2) the
+**frontend** that exposes that engine to the world over MCP, HTTP/SSE, a Unix
+domain socket, an embedded Svelte dashboard, and a CLI.
+
+Originally the engine lived in a separate published crate, `trusty-memory-core`,
+imported by `trusty-memory`. That created a published-crate boundary and an extra
+member to version and release. Meanwhile, two very different consumers needed the
+engine:
+
+- The **standalone daemon** (`trusty-memory serve`) needs the full HTTP/axum
+  surface, the UI, and the BM25 sidecar.
+- **open-mpm** links the engine **in-process** as an rlib only to register
+  `MemoryMcpService` for a merged `rpc.discover` document — it never binds an HTTP
+  socket, so dragging axum + tower-http into its dependency tree was pure cost
+  (issue #226).
+
+The engine also pulls heavy storage dependencies (`redb`, an HNSW implementation,
+`tiktoken-rs`, `git2`) that not every `trusty-common` consumer wants.
+
+## Decision
+
+1. **Absorb `trusty-memory-core` into `trusty-common`** as the `memory_core`
+   module, gated behind the **`memory-core` feature** (issue #5, phase 2d). The
+   trusty-* toolchain then links one internal library and ships one fewer
+   published crate. The former crate's submodules (`palace`, `registry`,
+   `retrieval`, `store/*`, `dream`, `semantic_consolidation`, `filter`, `decay`,
+   `community`, `analytics`, `git`, `embed`) move under
+   `trusty-common/src/memory_core/` unchanged, keeping their tests.
+
+2. **Keep `trusty-memory` as a thin frontend** over that core: the MCP tool
+   surface (`tools.rs`), the HTTP/SSE + REST + `/rpc` server (`web.rs`,
+   `transport/`), the embedded UI, the CLI (`commands/*`), and the BM25 sidecar
+   supervisor. The frontend depends on
+   `trusty-common = { features = ["mcp", "memory-core", …] }`.
+
+3. **Gate the HTTP surface behind `axum-server`** (default on) so open-mpm can
+   link `trusty-memory` with `default-features = false` and get `MemoryMcpService`
+   *without* axum/tower-http (issue #226). The standalone binaries keep the default.
+
+## Consequences
+
+- **Positive — one engine, two consumption modes:** the same storage/retrieval
+  code is either a standalone daemon *or* an in-process library, selected purely by
+  Cargo features, with no code fork.
+- **Positive — fewer published crates:** `trusty-memory-core` is gone; only
+  `trusty-common` (engine) and `trusty-memory` (frontend) are versioned/released.
+- **Positive — lean embedding:** open-mpm's dependency tree drops axum + tower-http
+  and (via `memory-core` gating) only pulls the storage deps it actually links.
+- **Positive — clean transport boundary:** because the engine knows nothing about
+  HTTP/MCP, the frontend can add transports (UDS, `/rpc`, future gRPC) without
+  touching the core.
+- **Known doc drift:** the workspace-root `CLAUDE.md` still lists
+  `crates/trusty-memory-core/` as a shim crate, but the directory no longer exists
+  on disk — the engine lives entirely in `trusty-common::memory_core`. Treat
+  `memory_core/mod.rs` and this ADR as authoritative.
+- **Neutral — feature discipline required:** consumers must remember to enable the
+  `memory-core` feature (and `axum-server` for the daemon path); a missing feature
+  surfaces as link errors rather than a clear message.

--- a/docs/trusty-memory/spec/ARCHITECTURE.md
+++ b/docs/trusty-memory/spec/ARCHITECTURE.md
@@ -1,0 +1,333 @@
+# trusty-memory — System Architecture
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+This document describes how trusty-memory fits together: the **frontend/core
+split**, the multi-transport model, the bundled BM25 sidecar, the fire-and-forget
+remember path, the storage model, the progressive-retrieval layering, and the
+source-module map.
+
+Module paths under `memory_core/` refer to
+`crates/trusty-common/src/memory_core/`; all other paths refer to
+`crates/trusty-memory/src/`.
+
+---
+
+## 1. Frontend / Core Split (the defining structural fact)
+
+trusty-memory is split into a **frontend** (this crate) and a **storage core**
+(absorbed into `trusty-common`). This is the single most important thing to
+understand about the codebase — see [ADR-0001](../decisions/0001-frontend-core-split.md).
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  trusty-memory  (this crate — the FRONTEND)                            │
+│  ─────────────────────────────────────────────────────────────────    │
+│  • MCP tool surface          tools.rs, mcp_service.rs, openrpc.rs      │
+│  • HTTP/SSE + REST + /rpc     web.rs, chat.rs, transport/rpc.rs        │
+│  • UDS transport              transport/uds.rs                          │
+│  • Embedded Svelte UI         web.rs (rust-embed of ui/dist/)          │
+│  • CLI commands               main.rs, commands/*                       │
+│  • BM25 sidecar supervisor    bm25_supervisor.rs                        │
+│  • KG auto-extract / bootstrap kg_extract.rs, bootstrap.rs, discovery.rs│
+│  • Messaging / activity / logs messaging.rs, activity.rs, prompt_log.rs │
+└───────────────────────────────┬────────────────────────────────────────┘
+                                 │  calls (memory-core feature)
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  trusty-common :: memory_core   (the CORE — storage + retrieval)       │
+│  ─────────────────────────────────────────────────────────────────    │
+│  • Palace data model          palace.rs (Palace→Wing→Room→Closet→Drawer)│
+│  • Concurrent registry         registry.rs (DashMap<PalaceId, Arc<…>>)  │
+│  • 4-layer retrieval (L0–L3)   retrieval.rs (PalaceHandle)              │
+│  • Vector store (HNSW/redb)    store/hnsw_store.rs, store/vector.rs     │
+│  • Temporal KG (redb)          store/kg.rs, kg_redb.rs (+ kg_sqlite)    │
+│  • Dream + semantic consolid.  dream.rs, semantic_consolidation.rs      │
+│  • Filter / decay / community  filter.rs, decay.rs, community.rs        │
+│  • Embeddings (re-export)      embed.rs → trusty-common::embedder       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- **The historical `trusty-memory-core` crate no longer exists.** It was fully
+  **absorbed into `trusty-common`** as the `memory_core` module (issue #5, phase
+  2d) so the toolchain links one internal library and ships one fewer published
+  crate. The module-level doc says so explicitly (`memory_core/mod.rs`). ✅
+  > Note: the *workspace-root* `CLAUDE.md` still lists `crates/trusty-memory-core/`
+  > as a shim crate; that is stale — the worktree's `CLAUDE.md` correctly says
+  > "re-export shim — absorbed into trusty-common's memory-core feature," and the
+  > directory is gone from disk.
+- **The core is feature-gated.** `memory_core` is compiled only with
+  `trusty-common`'s `memory-core` feature, which pulls in the heavy storage deps
+  (`redb`, HNSW, `tiktoken-rs`, `git2`); consumers that don't need storage skip it.
+- **This crate enables it** via
+  `trusty-common = { …, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help"] }`.
+- **Two consumption modes.** open-mpm links this crate as an **rlib** with
+  `default-features = false` to get `MemoryMcpService` *without* the axum/HTTP
+  surface (#226); the standalone daemon keeps `axum-server` on (the default). See
+  `docs/trusty-memory/research/axum-feature-flag-decision-2026-05-26.md`.
+
+---
+
+## 2. Process & Transport Model
+
+trusty-memory runs as **one long-lived daemon per host** that owns the redb write
+locks. Clients reach it over three transports, all converging on the same
+`AppState` (shared `PalaceRegistry` + data root + lazily-initialized embedder).
+
+```
+Claude Code (stdio MCP)                  curl / browser / open-mpm-HTTP
+        │                                          │
+        ▼                                          ▼
+trusty-memory-mcp-bridge          ┌──────────── HTTP/SSE (axum) ────────────┐
+  (src/bin/mcp_bridge.rs)         │  /api/v1/*  •  /sse  •  /rpc  •  /health │
+  tokio::io::copy_bidirectional   │  + embedded Svelte UI (rust-embed)       │
+        │  (byte pipe, NO redb)   └──────────────────────────────────────────┘
+        ▼                                          │
+   Unix domain socket  ─────────────────────────►  │
+   transport/uds.rs                                ▼
+                                          ┌──────────────────────┐
+                                          │   AppState            │
+                                          │   PalaceRegistry      │
+                                          │   data_root           │
+                                          │   embedder (lazy)     │
+                                          │   Bm25Supervisor      │
+                                          │   ActivityLog         │
+                                          └──────────┬───────────┘
+                                                     ▼
+                                       trusty-common :: memory_core
+                                       (redb + HNSW + KG + dream)
+```
+
+### Key properties
+
+- **One daemon, three transports.** The same process serves: (a) MCP JSON-RPC over
+  a Unix domain socket (`transport/uds.rs`), (b) the full HTTP/SSE + REST surface
+  plus the embedded UI (`web.rs`), and (c) a `POST /rpc` JSON-RPC dispatch
+  (`transport/rpc.rs`). The dispatch layer (`transport::dispatch`) is
+  transport-agnostic so future transports (gRPC, named pipes) can be added without
+  touching the core. ✅
+- **The MCP bridge owns no database.** Claude Code launches MCP servers as stdio
+  child processes, but the daemon owns the redb locks and must not be re-spawned
+  per session. `trusty-memory-mcp-bridge` (PR #149) is a ~40-line byte pipe
+  (`tokio::io::copy_bidirectional`) between Claude Code's stdio and the daemon's
+  UDS — it has **zero database knowledge**. ✅
+- **`serve --stdio` was removed.** The legacy in-process stdio path deadlocked on
+  redb's exclusive write lock whenever a daemon was already running; it was deleted
+  in #150. The canonical stdio integration is now the bridge. ✅
+- **Logs to stderr, never stdout.** MCP/UDS framing reserves stdout; the daemon
+  logs to stderr (workspace-wide rule). ✅
+- **Dynamic port discovery.** `serve` self-spawns a detached `serve --foreground`,
+  binds HTTP on `7070..=7079` (OS fallback), and writes the resolved address to a
+  discovery file read by `trusty_common::read_daemon_addr` (`commands/start.rs`). ✅
+- **Multi-process concurrent reads.** redb takes an exclusive `flock` per file. To
+  let a second process *read* a palace the daemon owns, `concurrent_open.rs` (#59)
+  copies the database to a process-local snapshot when an exclusive open hits
+  `DatabaseAlreadyOpen`. Writers always go through the daemon. ✅
+
+### 2.1 Socket & data-dir resolution (`transport/uds.rs`)
+
+The UDS path is deliberately kept **short** (≤104 bytes, the macOS `sun_path`
+limit) by living under the runtime dir, not under `~/Library/Application Support`:
+
+- `socket_path()` → `<runtime-dir>/trusty-memory.sock`
+  (`$XDG_RUNTIME_DIR` when set, else `$TMPDIR` / `/var/folders/...` on macOS).
+- `socket_path_for(data_root)` → `<runtime>/trusty-memory-<16-hex-hash>.sock`,
+  hashing the data root so multiple data dirs get distinct sockets.
+- `UDS_ADDR_FILE` (`uds_addr`) under the data root records the bound address.
+- Orphaned `.sock` files are cleaned up on exit (#153).
+
+Palace data persists under the OS-standard data dir
+(`trusty_common::resolve_data_dir("trusty-memory")`):
+- **macOS:** `~/Library/Application Support/trusty-memory/<palace-id>/`
+- **Linux:** `~/.local/share/trusty-memory/<palace-id>/`
+
+Per-palace files: `drawers.db` / payload sidecar, `vectors` HNSW redb,
+`kg.redb` (or legacy `kg.db`), `chat_sessions` redb, `l1_cache.json`,
+`palace.json` (metadata + `identity.txt`). `TRUSTY_DATA_DIR_OVERRIDE` redirects
+the root (intended for tests).
+
+---
+
+## 3. Fire-and-Forget Remember Path
+
+Sub-agents spawned via Claude Code's Agent tool inherit **no MCP connection**, so
+`mcp__trusty-memory__memory_remember` is unreachable to them — but they can run
+shell commands. The `note` path closes that gap with a **detached** write:
+
+```
+trusty-memory note "fact" --palace p --tag t
+        │
+        ├─ read_daemon_addr("trusty-memory")        # discovery file
+        ├─ POST /api/v1/remember  { palace, text, tags }   (short timeout)
+        │        │
+        │        └─ handler: tokio::spawn(write)     # returns 202 immediately
+        │                       │
+        │                       └─ filter → dedup → store → KG auto-extract
+        └─ print "Queued."  •  exit 0  (even if daemon unreachable)
+```
+
+- The CLI **never blocks** on the redb write or the content gates; the endpoint
+  queues the dispatch on a `tokio::spawn` (`commands/note.rs`, `web.rs`). ✅
+- Failure is **swallowed**: a missing/slow daemon yields `exit 0` with no error,
+  because a failure that arrives after the agent has already exited is useless. ✅
+- The same detached-spawn discipline backs the **hook emit** path
+  (`hook_emit.rs`): the `prompt-context` / `inbox-check` hook subprocesses POST to
+  `/api/v1/activity/hook` so the activity feed isn't empty in a normal Claude Code
+  session, again best-effort with exit 0 on failure. ✅
+
+---
+
+## 4. Storage Model (`memory_core/store/`)
+
+All storage is **pure-Rust embedded** on the default path. The redb migration
+sweep (#43–#56) removed the rusqlite/r2d2 and C++ usearch chains.
+
+| Concern | Backend | Module | Notes |
+|---|---|---|---|
+| Vector index | **redb-backed HNSW** (`hnsw_rs` 0.3) | `store/hnsw_store.rs`, `store/vector.rs` | Type name `UsearchStore` preserved for back-compat (#50/#51); vectors postcard-encoded in a redb table; HNSW graph rebuilt on open; async ops on `spawn_blocking`. |
+| Knowledge graph | **redb** (`KgStoreRedb`) | `store/kg.rs`, `kg_redb.rs`, `kg_store.rs`, `kg_writer.rs` | Temporal triples with `valid_from`/`valid_to`; composite-key + postcard codecs (#44). |
+| Legacy KG | **SQLite** (feature-gated) | `store/kg_sqlite.rs` | `#[cfg(feature = "sqlite-kg")]`, for #45 migration; #47 will remove. 🟡 |
+| Palace metadata | JSON | `store/palace_store.rs` | `palace.json` + `identity.txt` (L0 baseline), atomic writes. |
+| L1 cache | JSON snapshot | `store/l1_cache.json` (`l1_cache.rs`) | Top-N essential drawers; hydrated on open, refreshed lazily. |
+| External payloads | **redb** | `store/payload_store.rs` | Durable string-id↔uuid↔JSON map for open-mpm's `TrustyBackedMemoryStore` (#46/#52). |
+| Chat sessions | **redb** | `store/chat_sessions.rs` | Web-UI chat resume (#56). |
+| Recall analytics | **redb** | `memory_core/analytics.rs` | Hit/miss `RecallLog` (#57); one-shot SQLite→redb migration on first open. |
+| Multi-process reads | redb snapshot copy | `store/concurrent_open.rs` | Falls back to a tmp snapshot on `DatabaseAlreadyOpen` (#59). |
+| kuzu import | KuzuDB reader | `store/kuzu.rs` | Import-only; `kuzu` feature swaps the stub for real Cypher reads (#277). |
+
+### Embeddings
+
+`memory_core/embed.rs` is now a **re-export shim** for the unified `Embedder` /
+`FastEmbedder` (`AllMiniLML6V2Q`, **384-dim**, `EMBED_DIM`) that moved to the
+shared embedder surface in `trusty-common` so trusty-memory and trusty-search ship
+the same code. The model cache (~22 MB) downloads on first run (~100 MB disk).
+
+---
+
+## 5. Progressive Retrieval (L0–L3) — `memory_core/retrieval.rs`
+
+LLM context is precious, so recall is **layered and paid lazily**. The
+`PalaceHandle` owns the per-palace storage handles plus the pre-cached L0/L1.
+
+| Layer | Name | Cost | What it returns |
+|---|---|---|---|
+| **L0** | Identity | Always (cached) | Palace identity / baseline context (`identity.txt`). |
+| **L1** | Essential | Always (cached) | Top-N drawers by importance (`l1_cache.json`); ~900 tokens combined with L0. |
+| **L2** | On-demand vector | Paid per query | HNSW vector similarity + BM25 (bundled daemon) hybrid hits. |
+| **L3** | Deep | `memory_recall_deep` | Slower, higher-recall search for what L0–L2 miss. |
+
+- `memory_recall` → L0 + L1 + L2. `memory_recall_deep` → L3. `memory_recall_all`
+  fans out across every palace.
+- **Hybrid ranking** combines lexical (BM25 from the sidecar) and dense (HNSW)
+  scores; temporal **decay** (`decay.rs`, 90-day half-life) de-weights stale
+  drawers; the **filter** (`filter.rs`) keeps noise out of the store in the first
+  place; **recall analytics** (`analytics.rs`) close the loop on which drawers are
+  actually useful.
+
+---
+
+## 6. BM25 Sidecar — bundling & supervision
+
+trusty-memory does not implement BM25 in-process; it drives the bundled
+**`trusty-bm25-daemon`** (also bundled by trusty-search via #156/#190).
+
+```
+cargo install trusty-memory  ⇒  trusty-memory
+                                 trusty-memory-mcp-bridge
+                                 trusty-bm25-daemon     ← bundled [[bin]] shim
+```
+
+- **Single-install:** the third `[[bin]]` (`src/bin/bm25_daemon.rs`) is a thin
+  shim that calls `trusty_bm25_daemon::run()`; declaring the daemon as a Cargo
+  dependency makes `cargo install trusty-memory` build and install all three
+  binaries in one command. This closes the "set `TRUSTY_BM25_DAEMON=1` but never
+  installed the daemon → silently degraded lexical recall" footgun. ✅
+- **Per-palace spawn supervision:** `Bm25Supervisor` (`bm25_supervisor.rs`, #193)
+  keyed by palace id, with a `Mutex<HashMap<String, ChildHandle>>` preventing
+  double-spawn. `ensure_running` discovers the binary, spawns a child with
+  `--palace`/`--data-dir`, polls the socket, and owns the `tokio::process::Child`
+  for the daemon's life. `TRUSTY_BM25_EXTERNAL=1` opts out (operator-managed
+  daemon); shutdown SIGTERMs (via `libc::kill`) then SIGKILLs each child and
+  cleans up its socket. Unix-only (UDS protocol). ✅
+
+---
+
+## 7. Embedded UI Build
+
+The Svelte admin dashboard (`ui/`) is compiled at build time and embedded into the
+binary via `rust-embed`; `web.rs` serves `ui/dist/` with an asset fallback. No Node
+or separate web server is needed at runtime — deployment is "drop the binary on a
+host." The UI consumes the same `/api/v1/*` surface as `curl` plus the `/sse` event
+stream, so anything trusty-memory can do via Claude Code is reachable from the
+browser. ✅
+
+---
+
+## 8. Source Module Map
+
+### 8.1 Frontend — `crates/trusty-memory/src/`
+
+| Module | Responsibility |
+|---|---|
+| `lib.rs` | Crate root: `run_http*` (axum HTTP/SSE/REST/UI), `AppState`, re-exports. |
+| `main.rs` | `clap` CLI shim; dispatches to `commands::*`. |
+| `tools.rs` | MCP tool surface: `MemoryMcpServer`, `tool_definitions[_with]` (the **23-tool** `tools/list` payload), in-process dispatcher. |
+| `mcp_service.rs` | `MemoryMcpService` — `trusty_mcp_core::ServiceDescriptor` impl for in-process hosts (open-mpm). |
+| `openrpc.rs` | OpenRPC 1.3.2 `rpc.discover` builder + `scopes_for_tool` (read/write/knowledge.write). |
+| `web.rs` | All `/api/v1/*` handlers, `/sse`, `/rpc`, `/health`, embedded-UI fallback. |
+| `service.rs` | `MemoryService` — pure business-logic facade over `AppState` (extracted from `web.rs`, #151) reused by HTTP + chat dispatch. |
+| `chat.rs` | OpenRouter/Ollama SSE chat, tool dispatch loop, chat-session CRUD, `/api/v1/messages*`. |
+| `transport/` | `rpc.rs` (transport-agnostic JSON-RPC dispatch), `uds.rs` (Unix-socket listener + path resolution). |
+| `bm25_supervisor.rs` | Per-palace `trusty-bm25-daemon` spawn supervisor (#193). |
+| `kg_extract.rs` | Deterministic KG triple extraction on write (#97). |
+| `bootstrap.rs` | KG bootstrap from project files after `palace_create` (#60). |
+| `discovery.rs` | Automatic project-alias discovery → `is_alias_for` triples. |
+| `prompt_facts.rs` | Hot-predicate prompt-context surface (`get_prompt_context`). |
+| `messaging.rs` | Inter-project messaging via `msg:*`-tagged drawers (#99). |
+| `activity.rs` | Persistent redb-backed activity log, FIFO-capped, source-tagged (#96). |
+| `prompt_log.rs` | Enriched-prompt JSONL logger with rotation/retention (#105). |
+| `attribution.rs` | `creator:*` tag namespace attached to every write (#202). |
+| `hook_emit.rs` | Cross-process hook activity emit (`POST /api/v1/activity/hook`). |
+| `project_root.rs` | Project-root detection + palace-slug derivation (#88). |
+| `commands/` | Subcommand handlers: `serve`/`start`/`stop`, `setup`, `service` (launchd), `migrate`/`kuzu_migrate`/`migrations`, `monitor`, `note`, `send_message`, `inbox_check`, `doctor`, `kg_rebuild`, `prompt_context`. |
+| `bin/mcp_bridge.rs` | `trusty-memory-mcp-bridge` — stdio↔UDS byte pipe (PR #149). |
+| `bin/bm25_daemon.rs` | Bundled `trusty-bm25-daemon` binary shim. |
+
+### 8.2 Core — `crates/trusty-common/src/memory_core/`
+
+| Module | Responsibility |
+|---|---|
+| `mod.rs` | Re-exports the palace hierarchy, registry, retrieval handle, consolidation types. Gated behind the `memory-core` feature. |
+| `palace.rs` | Data model: `PalaceId`, `Palace` → `Wing` → `Room` → Closet → `Drawer`. |
+| `registry.rs` | `PalaceRegistry` — concurrent `DashMap<PalaceId, Arc<PalaceHandle>>`. |
+| `retrieval.rs` | 4-layer (L0–L3) progressive retrieval; the canonical `PalaceHandle`. |
+| `dream.rs` | `Dreamer` / `dream_cycle` — idle consolidation (prune/dedup/compact/closet) + optional semantic phase. |
+| `semantic_consolidation.rs` | `Inference` trait + `OpenRouter`/`Ollama`/`Mock` impls + `SemanticConsolidator` (#87). |
+| `filter.rs` | Signal/noise ingest filter (#61). |
+| `decay.rs` | Temporal importance/confidence decay (90-day half-life). |
+| `community.rs` | Louvain community detection → knowledge gaps (#52). |
+| `analytics.rs` | redb-backed `RecallLog` hit/miss tracking (#57). |
+| `git.rs` | Git-history fact extractor (rule-based NLP, zero LLM). |
+| `embed.rs` | Re-export shim for the unified `Embedder`/`FastEmbedder`. |
+| `store/` | All storage backends (see §4): `hnsw_store`, `vector`, `kg`/`kg_redb`/`kg_store`/`kg_writer`/`kg_sqlite`, `palace_store`, `l1_cache`, `payload_store`, `chat_sessions`, `kuzu`, `concurrent_open`. |
+
+---
+
+## 9. RPC / Tool Dispatch Surface
+
+The transport-agnostic `transport::dispatch` (`transport/rpc.rs`) handles JSON-RPC
+methods over both UDS and `POST /rpc`:
+
+- **Lifecycle:** `initialize`, `tools/list`, `tools/call`, `rpc.discover`.
+- **Direct tool methods** (also callable by name): the memory/palace/KG tools
+  enumerated in PRD §4.3 — e.g. `memory_remember`, `memory_recall`,
+  `memory_recall_deep`, `memory_recall_all`, `memory_list`, `memory_forget`,
+  `palace_create/list/info/compact`, plus helper resolvers `palace_id` /
+  `palace_name`, and `memory_note` / `memory_send_message`.
+- **Scopes** are advertised per method via OpenRPC `x-scopes` (`openrpc.rs`):
+  `memory.read` for queries, `memory.write` for mutations, `knowledge.write` for
+  `kg_bootstrap`. Advertised, not locally enforced (PRD §2 Non-Goals).

--- a/docs/trusty-memory/spec/COMPONENTS.md
+++ b/docs/trusty-memory/spec/COMPONENTS.md
@@ -1,0 +1,318 @@
+# trusty-memory — Component Specifications
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+One section per major subsystem. Each states **Responsibility**, **Key
+types/modules** (with `src/` paths), **Current state**, and **Known gaps**, framed
+Vision / Current / Gap. For the frontend/core split and transport model see
+[ARCHITECTURE.md](./ARCHITECTURE.md); for product framing see [PRD.md](./PRD.md).
+
+Paths under `memory_core/` are in `crates/trusty-common/src/memory_core/`; all
+others are in `crates/trusty-memory/src/`.
+
+---
+
+## 1. MCP Server / Tool Surface — `tools.rs`, `mcp_service.rs`, `openrpc.rs`
+
+**Responsibility.** Expose memory + palace + KG operations as a stable MCP tool
+contract, kept in sync across the `tools/list` payload, the in-process dispatcher,
+and the OpenRPC `rpc.discover` manifest; let in-process hosts (open-mpm) register
+the same tools without spawning a child.
+
+**Key types/modules.**
+- `tools.rs` — `MemoryMcpServer`, `tool_definitions()` / `tool_definitions_with(has_default)` (the **23-tool** payload), in-process dispatcher wired to the real `PalaceRegistry` + retrieval/KG APIs.
+- `mcp_service.rs` — `MemoryMcpService`, a zero-sized `trusty_mcp_core::ServiceDescriptor` impl delegating to `tool_definitions_with` + `scopes_for_tool`.
+- `openrpc.rs` — `scopes_for_tool` (read/write/knowledge.write split) + `build_discover_response` (OpenRPC 1.3.2 with `x-scopes`).
+
+**Current state.** ✅ 23 tools: the five memory ops, six palace ops, four KG/alias
+ops, three prompt-facts ops, `memory_note`, `memory_send_message`, and
+`memory_recall_all`. `--palace <name>` makes the `palace` argument optional in
+every tool (`tool_definitions_with(has_default)`). `MemoryMcpService` lets open-mpm
+merge these into a unified `rpc.discover` with no glue code.
+
+**Known gaps.**
+- 🟡 **Tool-count doc drift:** the wire surface is **23** (per the
+  `tool_definitions_lists_all_tools` test), but the crate `README.md` shows a
+  12-tool curated table and `mcp_service.rs` comments cite 23/11 inconsistently.
+  The authoritative source is `tool_definitions()`.
+- 🔗 Broken README link to `trusty-memory-mcp` path (#398).
+
+---
+
+## 2. HTTP API & Transport — `web.rs`, `service.rs`, `chat.rs`, `transport/`
+
+**Responsibility.** Serve the full REST/SSE surface and the embedded UI over axum,
+the JSON-RPC `POST /rpc` and UDS transports, and a chat/tool-calling loop — all on
+top of one `AppState`, with HTTP handlers staying thin.
+
+**Key types/modules.**
+- `web.rs` — every `/api/v1/*` handler (status, palaces, drawers, recall, KG
+  subjects/graph/triples/gaps/aliases, config, activity, dream, messages, logs),
+  `/sse`, `/health` round-trip probe (dedicated probe palace, #185), `/rpc`, and
+  the embedded-asset fallback.
+- `service.rs` — `MemoryService`, a pure-logic facade over `AppState` returning
+  `anyhow::Result<Value>` (extracted from `web.rs`, #151; no behaviour change) so
+  HTTP handlers and chat dispatch share the same code paths.
+- `chat.rs` — OpenRouter/Ollama SSE chat, the tool dispatcher, chat-session CRUD,
+  and `/api/v1/messages*`.
+- `transport/rpc.rs` — transport-agnostic JSON-RPC `dispatch` (`initialize`,
+  `tools/list`, `tools/call`, `rpc.discover`, direct tool methods).
+- `transport/uds.rs` — UDS listener + short-path socket resolution (≤104 bytes),
+  `UDS_ADDR_FILE`, orphan cleanup (#153).
+
+**Current state.** ✅ One daemon, three transports converging on `AppState`. axum
+is gated behind the `axum-server` feature (default on; off for open-mpm rlib use,
+#226). Dynamic port `7070..=7079` with discovery file. Multi-process concurrent
+reads via snapshot copy (#59).
+
+**Known gaps.** None material.
+
+---
+
+## 3. Palace Store & Data Model — `memory_core/palace.rs`, `registry.rs`, `store/`, `project_root.rs`
+
+**Responsibility.** Own the spatial memory data model (Palace → Wing → Room →
+Closet → Drawer), the concurrent multi-palace registry, durable per-palace storage,
+and the project-anchored naming rules.
+
+**Key types/modules.**
+- `memory_core/palace.rs` — `PalaceId`, `Palace`, `Wing`, `RoomType`, `Room`, `Drawer`, `DrawerType`.
+- `memory_core/registry.rs` — `PalaceRegistry` (`DashMap<PalaceId, Arc<PalaceHandle>>`).
+- `memory_core/store/palace_store.rs` — `palace.json` + `identity.txt` atomic persistence.
+- `memory_core/store/l1_cache.rs` — L1 essential-drawer snapshot.
+- `memory_core/store/payload_store.rs`, `chat_sessions.rs` — redb sidecars (#46/#52/#56).
+- `project_root.rs` — `project_slug()` + `personal` sentinel (#88).
+- `attribution.rs` — `creator:*` tag namespace on every write (#202).
+
+**Current state.** ✅ Full CRUD (`palace_create/list/info/update/delete/compact`);
+`palace_delete` backs `DELETE /api/v1/palaces/{id}` (#180). Palace-as-project
+enforcement on **new** palace creation; existing palaces grandfathered.
+
+**Known gaps.**
+- 🔵 **Orphaned-palace remediation is advisory only** — `doctor --fix-palaces` /
+  `doctor --fix` print rename suggestions but never mutate the filesystem; actual
+  merge of orphans into `personal` is unbuilt (PRD FR-2.2/FR-10.4).
+
+---
+
+## 4. Retrieval & Ranking — `memory_core/retrieval.rs`, `filter.rs`, `decay.rs`, `analytics.rs`
+
+**Responsibility.** Return the most relevant drawers cheaply via 4-layer
+progressive retrieval, keep noise out at ingest, de-weight stale memories, and
+close the feedback loop on recall usefulness.
+
+**Key types/modules.**
+- `memory_core/retrieval.rs` — L0 (identity), L1 (essential, cached ~900 tokens),
+  L2 (on-demand vector + BM25), L3 (deep); the canonical `PalaceHandle`.
+- `memory_core/filter.rs` — `FilterConfig` / `classify` / `apply` (#61) + rolling
+  Jaro-Winkler dedup window (#220).
+- `memory_core/decay.rs` — `effective_importance` (90-day half-life, access boost).
+- `memory_core/analytics.rs` — redb-backed `RecallLog` (#57).
+
+**Current state.** ✅ `memory_recall` (L0+L1+L2), `memory_recall_deep` (L3),
+`memory_recall_all` (cross-palace). Hybrid lexical (BM25 sidecar) + dense (HNSW)
+ranking with temporal decay. Ingest filter + dedup reject noise before storage.
+
+**Known gaps.** None material at this time.
+
+---
+
+## 5. BM25 Sidecar Integration — `bm25_supervisor.rs`, `bin/bm25_daemon.rs`
+
+**Responsibility.** Provide lexical (BM25) recall by bundling and auto-supervising
+the external `trusty-bm25-daemon` so it works out of the box, one process per
+palace.
+
+**Key types/modules.**
+- `bin/bm25_daemon.rs` — bundled `[[bin]]` shim delegating to `trusty_bm25_daemon::run()`.
+- `bm25_supervisor.rs` — `Bm25Supervisor` keyed by palace id; `ensure_running` /
+  `shutdown`; `Mutex<HashMap<String, ChildHandle>>` anti-double-spawn; SIGTERM→SIGKILL
+  via `libc::kill`.
+
+**Current state.** ✅ Single-install (`cargo install trusty-memory` → three
+binaries, mirrors #190). On first BM25 use for a palace, the supervisor discovers
+the binary, spawns a child with `--palace`/`--data-dir`, polls the socket, and owns
+the child. `TRUSTY_BM25_EXTERNAL=1` opts out for operator-managed daemons.
+
+**Known gaps.**
+- 🟡 **Unix-only** — the spawn supervisor and daemon protocol are UDS, so there is
+  no Windows path.
+
+---
+
+## 6. Knowledge Graph & Facts — `kg_extract.rs`, `bootstrap.rs`, `discovery.rs`, `prompt_facts.rs`, `memory_core/store/kg*.rs`, `community.rs`
+
+**Responsibility.** Maintain a temporal triple store, populate it automatically on
+write and at palace creation, surface hot facts into the model's working context,
+and detect knowledge gaps.
+
+**Key types/modules.**
+- `memory_core/store/kg.rs` + `kg_redb.rs` + `kg_store.rs` + `kg_writer.rs` —
+  redb-backed `KnowledgeGraph` / `Triple` with `valid_from`/`valid_to` (#44).
+- `memory_core/store/kg_sqlite.rs` — legacy SQLite KG (`sqlite-kg` feature, #45).
+- `kg_extract.rs` — deterministic `extract_triples` on write (#97).
+- `bootstrap.rs` — `bootstrap_palace` / `scan_project` from project files (#60).
+- `discovery.rs` — alias discovery → `is_alias_for` triples.
+- `prompt_facts.rs` — `HOT_PREDICATES`, `PromptFactsCache`, `get_prompt_context`.
+- `memory_core/community.rs` — Louvain community detection → knowledge gaps (#52).
+
+**Current state.** ✅ `kg_assert`/`kg_query`/`kg_gaps`/`kg_bootstrap`/`add_alias`/
+`discover_aliases` and the prompt-facts tools. Auto-extraction on every write keeps
+graphs non-empty; bootstrap seeds from manifests; gap detection drives
+consolidation. `memory_forget` cascade-deletes derived triples; surgical triple
+delete via `DELETE /api/v1/palaces/{id}/kg/triples/{triple_id}` (#278).
+
+**Known gaps.**
+- 🟡 **Legacy SQLite KG lingers** behind `sqlite-kg` pending #47 retirement.
+- 🔵 **Louvain-only** community detection — Leiden phase-2 refinement deferred.
+- Auto-extraction is **heuristic-only** (tag/room/hashtag + a small pattern table);
+  semantic extraction is left to the dream LLM pass.
+
+---
+
+## 7. Dream / Consolidation — `memory_core/dream.rs`, `semantic_consolidation.rs`
+
+**Responsibility.** Keep a palace healthy as it grows: prune low-value/stale
+drawers, dedup near-duplicates, compact storage, refresh closet indexes, and
+(optionally) collapse paraphrases/aliases with an LLM.
+
+**Key types/modules.**
+- `memory_core/dream.rs` — `DreamConfig`, `DreamStats`, `Dreamer` (idle clock +
+  `dream_cycle`: content-prune #222, dedup, prune, compaction, closet refresh).
+- `memory_core/semantic_consolidation.rs` — `Inference` trait;
+  `OpenRouterInference` / `OllamaInference` / `MockInference`; `SemanticConsolidator`
+  (Alias / Merge / Flag actions, additive `superseded_by` lineage, SHA-256 response
+  cache, per-cycle call budget) (#87).
+
+**Current state.** ✅ Idle background dreaming + on-demand `memory_dream` /
+`POST /api/v1/dream/run`. Semantic phase enabled when an inference backend is
+available (OpenRouter > Ollama > disabled no-op); default model
+`anthropic/claude-haiku-4-5`. `MockInference` keeps `cargo test` offline; live tests
+are `#[ignore]`-gated.
+
+**Known gaps.** None material.
+
+---
+
+## 8. Inter-Project Messaging — `messaging.rs`, `commands/send_message.rs`, `commands/inbox_check.rs`
+
+**Responsibility.** Let one project deliver a message to another project's palace
+inbox and surface unread messages at the recipient's next Claude Code session —
+with no new schema and no IPC.
+
+**Key types/modules.**
+- `messaging.rs` — `msg:*` tag envelope (`v1`/`from`/`to`/`purpose`/`sent_at`/`read`),
+  `slugify_for_palace` addressing (#99).
+- `commands/send_message.rs` — `send-message` CLI → `POST /api/v1/messages`.
+- `commands/inbox_check.rs` — `inbox-check` (installed as a `SessionStart` hook by
+  `setup`): fetch unread → print as Markdown (Claude injects stdout) → atomically
+  mark read.
+
+**Current state.** ✅ A message is just a drawer with a tag envelope (no schema
+change). Atomic compare-and-swap on the read flag prevents double-delivery under
+concurrent sessions. Every `inbox-check` failure path exits 0 with empty stdout so
+a missing/slow daemon never blocks session start. Replaces claude-mpm's Python
+`/mpm-message` skill.
+
+**Known gaps.**
+- No central registry — sender and receiver agree on the repo slug **out of band**
+  (a deliberate design choice, not a gap).
+
+---
+
+## 9. Embedded UI & Activity — `web.rs`, `activity.rs`, `prompt_log.rs`, `hook_emit.rs`
+
+**Responsibility.** Give humans a browser dashboard (palace overview, live event
+stream, manual dream, memory browsing, KG graph) with no Node at runtime, and a
+persistent, source-tagged activity record across all write origins.
+
+**Key types/modules.**
+- `web.rs` — `rust-embed` of `ui/dist/`, `/sse` event stream, asset fallback.
+- `activity.rs` — `ActivityLog` (redb, FIFO-capped at `MAX_ENTRIES`,
+  `ActivitySource` = HTTP/MCP/Hook) (#96); paged drawer list w/ creator info (#184).
+- `hook_emit.rs` — best-effort `POST /api/v1/activity/hook` from hook subprocesses.
+- `prompt_log.rs` — enriched-prompt JSONL logger (daily + size-cap rotation,
+  retention pruning, optional prompt hashing) (#105).
+
+**Current state.** ✅ Svelte UI compiled at build time and embedded; the feed shows
+historical entries on mount (not just live SSE) and captures writes from HTTP, MCP,
+*and* hook origins — closing the "empty feed in a normal Claude Code session"
+complaint, since hooks now emit via `hook_emit.rs`.
+
+**Known gaps.**
+- 🟡 The embedded UI requires `pnpm` at **build** time (or `SKIP_UI_BUILD`-style
+  bypass for CI publish flows); runtime needs nothing.
+
+---
+
+## 10. `note` CLI & Hooks — `commands/note.rs`, `commands/prompt_context.rs`, `commands/inbox_check.rs`
+
+**Responsibility.** Provide MCP-free write/read entry points for sub-agents and
+Claude Code hooks, all best-effort and non-blocking.
+
+**Key types/modules.**
+- `commands/note.rs` — `trusty-memory note` → `POST /api/v1/remember` (detached
+  `tokio::spawn`); prints `Queued.`, exits 0 even if the daemon is down.
+- `commands/prompt_context.rs` — `UserPromptSubmit` hook: inject hot KG context.
+- `commands/inbox_check.rs` — `SessionStart` hook: deliver unread messages (see §8).
+
+**Current state.** ✅ Sub-agents (which inherit no MCP connection) get a writable
+handle that needs no MCP plumbing; the endpoint queues the write so the CLI never
+waits on redb or the content gates. Hook subprocesses populate the activity feed via
+`hook_emit.rs`.
+
+**Known gaps.** None material.
+
+---
+
+## 11. Setup, Service & Migration — `commands/setup.rs`, `service.rs` (launchd), `migrate.rs`, `kuzu_migrate.rs`, `doctor.rs`, `kg_rebuild.rs`
+
+**Responsibility.** First-time install, OS service management, migration off the
+legacy kuzu-memory server, and operational diagnostics.
+
+**Key types/modules.**
+- `commands/setup.rs` — launchd LaunchAgent install (macOS), embedder pre-warm,
+  Claude settings patch (MCP entry + `prompt-context`/`inbox-check` hooks) (#86).
+- `commands/service.rs` — macOS launchd lifecycle.
+- `commands/migrate.rs` — `migrate kuzu-memory` (rewrite Claude MCP config, #278).
+- `commands/kuzu_migrate.rs` — `migrate kuzu-data` (import `store.redb`; idempotent
+  via SHA-256-derived UUIDs, #277).
+- `commands/migrations.rs` — startup data migrations.
+- `commands/doctor.rs` — palace/orphan audit + `--fix-palaces`.
+- `commands/kg_rebuild.rs` — rebuild the KG from drawers.
+- `commands/{start,stop,monitor}.rs` — unified start/serve/stop (#83), monitor TUI.
+
+**Current state.** ✅ Idempotent setup with service-owned hooks; unified
+start/serve/stop matching trusty-search; kuzu config + data migration; diagnostics.
+
+**Known gaps.**
+- 🔵 `doctor --fix` is advisory only — no actual orphan remediation (see §3).
+- 🟡 launchd path is macOS-specific; Linux relies on systemd/manual supervision.
+
+---
+
+## 12. Storage Backends (shared core) — `memory_core/store/`
+
+**Responsibility.** Pure-Rust embedded persistence for every palace concern, with
+no rusqlite/usearch native chain on the default path (the redb sweep, #43–#56).
+
+**Key types/modules.**
+- Vector: `hnsw_store.rs` (redb-backed `hnsw_rs`), `vector.rs` (`VectorStore` trait,
+  `UsearchStore` name preserved for back-compat) (#50/#51).
+- KG: `kg.rs` / `kg_redb.rs` / `kg_store.rs` / `kg_writer.rs` (redb, #44);
+  `kg_sqlite.rs` (legacy, `sqlite-kg`).
+- Metadata/cache: `palace_store.rs`, `l1_cache.rs`.
+- Sidecars: `payload_store.rs` (#46/#52), `chat_sessions.rs` (#56).
+- Concurrency: `concurrent_open.rs` (snapshot-on-lock, #59).
+- Import: `kuzu.rs` (read-only; `kuzu` feature for real Cypher).
+- Embeddings: `embed.rs` (re-export of unified `FastEmbedder`, 384-dim).
+
+**Current state.** ✅ All default-path storage is redb + HNSW + JSON snapshots.
+Async ops run on `spawn_blocking` so the reactor isn't stalled.
+
+**Known gaps.**
+- 🟡 SQLite KG code retained behind `sqlite-kg` pending #47 removal.

--- a/docs/trusty-memory/spec/PRD.md
+++ b/docs/trusty-memory/spec/PRD.md
@@ -1,0 +1,353 @@
+# trusty-memory — Product Requirements Document
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+Each requirement is framed **Vision / Current / Gap**.
+
+---
+
+## 1. Vision & Mission
+
+### North-star vision
+
+> **trusty-memory is a persistent memory palace for AI agents and humans** — a
+> local, embedded daemon that lets any MCP-aware client *remember* natural-language
+> facts and *recall* them later via hybrid BM25 + vector retrieval, organized into
+> per-project namespaces ("palaces"), with an optional knowledge-graph layer for
+> structured facts — **with no external services, no cloud, and no Python/Node in
+> the core**.
+
+Where Claude Code's session memory evaporates at the end of a conversation,
+trusty-memory is **durable long-term memory** that survives sessions, agents, and
+machines reboots. It is the cross-session, cross-agent, cross-project knowledge
+substrate of the trusty-* ecosystem: open-mpm links it as an in-process library,
+Claude Code talks to it over a thin stdio→UDS bridge, sub-agents fire notes at it
+over HTTP, and a human can browse the same data in an embedded web dashboard.
+
+The product is deliberately **single-install**: `cargo install trusty-memory`
+produces three binaries (`trusty-memory`, `trusty-memory-mcp-bridge`, and the
+bundled `trusty-bm25-daemon`) so an operator never has to hand-assemble a sidecar
+fleet.
+
+### Mission
+
+Give every agent — and every human working alongside one — a memory that is
+**always available, always local, and organized by the project it belongs to**,
+reachable through whatever surface the caller already speaks (MCP tool, HTTP REST,
+SSE, Unix socket, or a one-line shell command), without standing up a database or
+a service mesh.
+
+### Why this is novel
+
+trusty-memory unifies four capabilities that are usually separate products into a
+single embedded binary: (1) a **vector recall** store, (2) a **temporal
+knowledge-graph**, (3) an **inter-project message bus**, and (4) an **idle-time
+LLM consolidation** ("dream") loop — all behind one MCP tool surface, all pure
+Rust, all licensed MIT. The frontend/core split (this crate ⇄ `trusty-common`'s
+`memory_core`) lets the same storage engine be embedded in-process by open-mpm or
+served as a standalone daemon, with no code change.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+| # | Goal | Status |
+|---|---|---|
+| G1 | **Remember / recall over MCP** — store natural-language drawers and recall them by hybrid BM25 + vector retrieval, exposed as MCP tools. | ✅ |
+| G2 | **Palace namespacing anchored to projects** — one palace per project (slug-derived), plus a `personal` escape hatch. | ✅ |
+| G3 | **Multi-transport single daemon** — one long-lived daemon serving MCP (via the stdio→UDS bridge), HTTP/SSE REST, and a `POST /rpc` JSON-RPC surface. | ✅ |
+| G4 | **Fire-and-forget writes for sub-agents** — a `note` CLI + `POST /api/v1/remember` that returns immediately (detached spawn) for agents with no MCP connection. | ✅ |
+| G5 | **Bundled BM25 sidecar** — ship and auto-spawn `trusty-bm25-daemon` so lexical recall works out of the box (single-install convention). | ✅ |
+| G6 | **Temporal knowledge graph** — assert/query time-bounded triples; auto-extraction on write; visual graph in the UI. | ✅ |
+| G7 | **Idle-time consolidation ("dream")** — NLP dedup/prune/compact + optional LLM-backed semantic consolidation. | ✅ |
+| G8 | **Embedded admin UI** — Svelte dashboard compiled into the binary (no Node at runtime). | ✅ |
+| G9 | **Inter-project messaging** — deliver messages to another palace's inbox; surfaced at Claude Code session start. | ✅ |
+| G10 | **Import / migration** — migrate from kuzu-memory (MCP config + data) into palaces. | ✅ |
+| G11 | **Pure-Rust, service-free storage** — redb + in-process HNSW + fastembed ONNX; no rusqlite/usearch native chain on the default path. | ✅ |
+| G12 | **In-process embeddability** — open-mpm links `MemoryMcpService` as an rlib without the axum/HTTP surface. | ✅ |
+
+### Non-Goals
+
+| Non-Goal | Rationale |
+|---|---|
+| Central server / cloud-hosted memory | trusty-memory is a single-binary **local** daemon. |
+| Multi-tenant auth / RBAC enforcement | Scopes (`memory.read` / `memory.write`) are *advertised* via OpenRPC for orchestrators to enforce; the daemon itself trusts its local caller. |
+| Embedding-model training or fine-tuning | Uses the fixed `AllMiniLML6V2Q` 384-dim model; not a model lab. |
+| Cross-machine replication / sync | Each host owns its palaces on local disk; no built-in replication. |
+| Node.js at runtime | Node is used only to *build* the embedded Svelte UI; the runtime is the single Rust binary. |
+| A general graph database | The KG is a purpose-built temporal triple store, not a Cypher/Gremlin engine (the kuzu reader is import-only). |
+
+---
+
+## 3. Target Users / Personas
+
+| Persona | Who | Primary need | Surface |
+|---|---|---|---|
+| **MCP agent (Claude Code)** | An interactive coding agent in a session | Remember/recall facts per-turn; pull hot project context (aliases, conventions) without blind searching | MCP tools via `trusty-memory-mcp-bridge` (stdio→UDS) |
+| **Embedded host (open-mpm)** | A Rust orchestrator linking memory in-process | Register `MemoryMcpService` into a merged `rpc.discover`; call tools without spawning a child | rlib (`default-features = false`, no axum) |
+| **Sub-agent / shell script** | A spawned agent with **no** MCP connection | Save a fact and move on, never blocking on the write | `trusty-memory note` → `POST /api/v1/remember` (detached) |
+| **Human operator** | A developer auditing/curating memory | Browse palaces, watch the live activity feed, trigger a dream, inspect the KG | Embedded Svelte dashboard + REST |
+| **Cross-project automation** | One project messaging another | Drop a message into another palace's inbox; have it surface at the recipient's next session | `send-message` / `inbox-check` (SessionStart hook) |
+
+**Unifying need across all surfaces:** a durable, project-scoped memory that is
+reachable through whatever protocol the caller already speaks, with no service to
+provision.
+
+---
+
+## 4. Functional Requirements
+
+Grouped by capability area. Each requirement carries Vision / Current / Gap and
+an inline status tag. Source paths are cited where known. Module paths under
+`memory_core/` refer to `crates/trusty-common/src/memory_core/`; all others refer
+to `crates/trusty-memory/src/`.
+
+### 4.1 Remember / Recall (`tools.rs`, `memory_core/retrieval.rs`)
+
+**FR-1.1 — Store a memory (`memory_remember` / `memory_note`)** ✅
+- *Vision:* A caller stores a natural-language fact in a palace and gets back a stable `drawer_id`; tags, room, and creator attribution are attached automatically.
+- *Current:* Implemented (`tools.rs`, `attribution.rs`). Writes pass a **signal/noise filter** (`memory_core/filter.rs`, #61) and a **rolling Jaro-Winkler dedup window** (#220) before storage; creator tags (`creator:*`, #202) tag every write path (HTTP/MCP/CLI/hook). Auto-KG extraction (`kg_extract.rs`, #97) populates the graph on write.
+- *Gap:* None material.
+
+**FR-1.2 — Hybrid recall (`memory_recall`)** ✅
+- *Vision:* A query returns the most relevant drawers using BM25 *and* vector similarity, cheaply.
+- *Current:* Implemented over the **4-layer progressive retrieval** (`memory_core/retrieval.rs`): L0 (palace identity) + L1 (top-N essential, persisted as `l1_cache.json`) are always loaded (~900 tokens); L2 (on-demand vector) is paid only when the query needs it. BM25 comes from the bundled `trusty-bm25-daemon`; vectors from the in-process HNSW index.
+- *Gap:* None material.
+
+**FR-1.3 — Deep recall (`memory_recall_deep`)** ✅
+- *Vision:* A slower, higher-recall path (L3 deep search) for queries the fast layers miss.
+- *Current:* Implemented (L3 layer in `memory_core/retrieval.rs`).
+- *Gap:* None material.
+
+**FR-1.4 — Cross-palace recall (`memory_recall_all`)** ✅
+- *Vision:* Recall across every palace at once, not just the bound one.
+- *Current:* Implemented (`tools.rs`, HTTP `GET /api/v1/recall`).
+- *Gap:* None material.
+
+**FR-1.5 — List / forget (`memory_list`, `memory_forget`)** ✅
+- *Vision:* Enumerate stored drawers (optionally filtered by room/tag) and delete a specific drawer by id, cascading its derived KG triples.
+- *Current:* Implemented; `memory_forget` cascade-deletes auto-derived triples (#278).
+- *Gap:* None material.
+
+### 4.2 Palace Management (`tools.rs`, `project_root.rs`, `memory_core/palace.rs`, `registry.rs`)
+
+**FR-2.1 — Palace CRUD (`palace_create/list/info/update/delete`)** ✅
+- *Vision:* Create, list, inspect, update, and delete palace namespaces; deletion removes on-disk state.
+- *Current:* All five implemented (`tools.rs`); `palace_delete` backs `DELETE /api/v1/palaces/{id}` (#180). The `PalaceRegistry` is a concurrent `DashMap<PalaceId, Arc<PalaceHandle>>` (`memory_core/registry.rs`).
+- *Gap:* None material.
+
+**FR-2.2 — Palace-as-project enforcement** ✅
+- *Vision:* New palace names must match a slug derived from the project root (`.git`/`Cargo.toml`/`pyproject.toml`/`package.json` walk); `personal` is the only allowed name outside any project. Existing palaces are grandfathered.
+- *Current:* Implemented (`project_root.rs`, #88). `doctor --fix-palaces` audits orphans (advisory only).
+- *Gap:* Actual rename/merge of orphaned palaces into `personal` is **not implemented** — `doctor --fix` only prints suggestions. 🔵
+
+**FR-2.3 — Palace compaction (`palace_compact`)** ✅
+- *Vision:* Compact a palace's on-disk storage on demand.
+- *Current:* Implemented (`tools.rs` → store compaction).
+- *Gap:* None material.
+
+### 4.3 MCP Tool Surface (`tools.rs`, `mcp_service.rs`, `openrpc.rs`)
+
+**FR-3.1 — Full MCP tool set (23 tools)** ✅
+- *Vision:* One auditable file defines every tool the server exposes, kept in sync with the MCP `tools/list` payload and the OpenRPC `rpc.discover` manifest.
+- *Current:* **23 tools** in `tool_definitions()` (`tools.rs`): `memory_remember`, `memory_note`, `memory_recall`, `memory_recall_deep`, `memory_recall_all`, `memory_list`, `memory_forget`, `palace_create`, `palace_delete`, `palace_update`, `palace_list`, `palace_info`, `palace_compact`, `kg_assert`, `kg_query`, `kg_gaps`, `kg_bootstrap`, `add_alias`, `discover_aliases`, `list_prompt_facts`, `remove_prompt_fact`, `get_prompt_context`, `memory_send_message`. (The README's "12 tools" table is a curated subset; the wire surface is 23.)
+- *Gap:* Doc drift — the crate `README.md` and `mcp_service.rs` comments cite varying counts (11/12/23). The authoritative count is the `tool_definitions_lists_all_tools` test: **23**.
+
+**FR-3.2 — Per-tool scopes via OpenRPC** ✅
+- *Vision:* Each tool advertises a logical scope (`memory.read` / `memory.write` / `knowledge.write`) so orchestrators can authorize without bespoke adapters.
+- *Current:* Implemented (`openrpc.rs` `scopes_for_tool`); `build_discover_response` emits OpenRPC 1.3.2 with `x-scopes`.
+- *Gap:* Scopes are *advertised* only; the daemon does not itself enforce them (see §2 Non-Goals).
+
+**FR-3.3 — `ServiceDescriptor` for in-process hosts** ✅
+- *Vision:* open-mpm links the crate and merges its tools into a single `rpc.discover` document with no glue.
+- *Current:* `MemoryMcpService` implements `trusty_mcp_core::ServiceDescriptor` (`mcp_service.rs`).
+- *Gap:* None material.
+
+**FR-3.4 — Optional default palace** ✅
+- *Vision:* When the daemon is started with `--palace <name>`, the `palace` argument becomes optional in every tool call (`tool_definitions_with(has_default)`).
+- *Current:* Implemented (`tools.rs`).
+- *Gap:* None material.
+
+### 4.4 HTTP Remember Endpoint & `note` CLI (`commands/note.rs`, `web.rs`, `hook_emit.rs`)
+
+**FR-4.1 — Fire-and-forget remember (`POST /api/v1/remember`)** ✅
+- *Vision:* An agent with no MCP connection saves a fact with a one-line shell command that returns immediately, never blocking on the redb write or the content gates.
+- *Current:* `trusty-memory note "…" --palace <p> [--tag …]` resolves the daemon address via `trusty_common::read_daemon_addr`, POSTs to `/api/v1/remember`, prints `Queued.`, and exits 0 even when the daemon is unreachable (`commands/note.rs`). The endpoint queues the dispatch on a `tokio::spawn` so the caller never waits (`web.rs`).
+- *Gap:* None material.
+
+**FR-4.2 — REST mirror of the tool surface** ✅
+- *Vision:* Anything trusty-memory can do over MCP can also be done via `curl`.
+- *Current:* `/api/v1/*` covers status, palaces, drawers, recall, KG (subjects/graph/triples/gaps/aliases), chat, config, activity, dream, messages, and logs (`web.rs`).
+- *Gap:* None material.
+
+### 4.5 BM25 Sidecar (`bm25_supervisor.rs`, `src/bin/bm25_daemon.rs`)
+
+**FR-5.1 — Bundled single-install daemon** ✅
+- *Vision:* `cargo install trusty-memory` produces the `trusty-bm25-daemon` binary too, so lexical recall works without a separate install.
+- *Current:* The `[[bin]]` shim (`src/bin/bm25_daemon.rs`) delegates to `trusty_bm25_daemon::run()`; the daemon crate is a Cargo dependency so it builds and installs alongside (mirrors #190 for trusty-embedderd).
+- *Gap:* None material.
+
+**FR-5.2 — Per-palace spawn supervision** ✅
+- *Vision:* On first BM25 use for a palace, auto-spawn a child with the right `--palace`/`--data-dir`, poll its socket, and own the process for the daemon's life — so operators never hand-`launchctl bootstrap` one daemon per palace.
+- *Current:* `Bm25Supervisor` (`bm25_supervisor.rs`, #193) keyed by palace id, with a `tokio::sync::Mutex<HashMap<…>>` guarding against double-spawn. Graceful SIGTERM → SIGKILL shutdown via `libc::kill`. `TRUSTY_BM25_EXTERNAL=1` opts out (operator runs their own daemon).
+- *Gap:* Unix-only (the daemon protocol is UDS).
+
+### 4.6 Knowledge Graph & Facts (`kg_extract.rs`, `bootstrap.rs`, `discovery.rs`, `prompt_facts.rs`, `memory_core/store/kg*.rs`)
+
+**FR-6.1 — Temporal triple store (`kg_assert`, `kg_query`)** ✅
+- *Vision:* Assert and query time-bounded triples (`valid_from`/`valid_to`); back the store with pure-Rust embedded storage.
+- *Current:* `KnowledgeGraph` over **redb** (`memory_core/store/kg.rs`, `kg_redb.rs`, #44); the legacy SQLite path is preserved behind the `sqlite-kg` feature for migration (#45) and slated for removal (#47).
+- *Gap:* SQLite KG code still present pending #47 cleanup. 🟡
+
+**FR-6.2 — Auto-extraction on write** ✅
+- *Vision:* Every `memory_remember` populates the KG so palaces always have a non-empty graph, offline and fast.
+- *Current:* Deterministic `extract_triples` (`kg_extract.rs`, #97) — tag/room/hashtag→drawer plus a small is-a/has-a/works-at pattern table; skips `test`/`fixture`/`cross-project-qa` tags.
+- *Gap:* Heuristic-only; richer extraction is left to the dream cycle's LLM pass.
+
+**FR-6.3 — KG bootstrap (`kg_bootstrap`)** ✅
+- *Vision:* After `palace_create`, seed the KG from project files so it is never empty.
+- *Current:* `bootstrap.rs` (#60) scans `Cargo.toml`/`package.json`/`pyproject.toml`/`CLAUDE.md`/`.git/config`/`go.mod` and seeds structured + temporal triples; missing files are non-errors.
+- *Gap:* None material.
+
+**FR-6.4 — Alias discovery (`add_alias`, `discover_aliases`)** ✅
+- *Vision:* Surface implicit shorthand (`tga` → `trusty-git-analytics`) automatically as `is_alias_for` triples.
+- *Current:* `discovery.rs` scans Cargo/git/abbreviation signals; the tool dedupes against active triples and rebuilds the prompt cache.
+- *Gap:* None material.
+
+**FR-6.5 — Prompt-facts surface (`get_prompt_context`, `list_prompt_facts`, `remove_prompt_fact`)** ✅
+- *Vision:* Hot KG predicates (aliases, conventions, ambient facts) injected into the model's working context per-turn, query-filterable.
+- *Current:* `prompt_facts.rs` defines `HOT_PREDICATES`, the formatter, and a cached `PromptFactsCache`. The `get_prompt_context` tool is invoked per-turn (replacing the session-init MCP-prompts approach that hosts read only once).
+- *Gap:* None material. (The workspace CLAUDE.md references `get_prompt_context()` auto-resolution; this is the implementing tool.)
+
+**FR-6.6 — Knowledge gaps (`kg_gaps`)** ✅
+- *Vision:* Detect sparse "knowledge gap" communities in the KG to drive consolidation.
+- *Current:* In-tree Louvain community detection (`memory_core/community.rs`, #52); a community is a gap when internal density < 0.2.
+- *Gap:* Leiden phase-2 refinement deferred (Louvain only). 🔵
+
+### 4.7 Dream / Consolidation (`memory_core/dream.rs`, `semantic_consolidation.rs`, `decay.rs`)
+
+**FR-7.1 — Idle-time NLP consolidation** ✅
+- *Vision:* A background idle clock periodically dedups, prunes low-value/stale drawers, refreshes closet indexes, and compacts storage.
+- *Current:* `Dreamer` + `dream_cycle` (`memory_core/dream.rs`) with content-prune (#222), dedup, prune, compaction, closet refresh. Temporal decay (`memory_core/decay.rs`) de-weights old drawers (90-day half-life). Triggerable via `memory_dream` / `POST /api/v1/dream/run`.
+- *Gap:* None material.
+
+**FR-7.2 — LLM-backed semantic consolidation** ✅
+- *Vision:* When an inference backend is available, an extra phase canonicalizes paraphrases and aliases the NLP passes miss (Alias / Merge / Flag actions), additively (originals preserved; `superseded_by` triples link lineage), with a per-cycle call budget and SHA-256 response caching.
+- *Current:* `SemanticConsolidator` (`memory_core/semantic_consolidation.rs`, #87). Backend priority: OpenRouter (`OPENROUTER_API_KEY`) > Ollama (`local_model.enabled`) > disabled no-op. Default model `anthropic/claude-haiku-4-5`. `MockInference` keeps `cargo test` offline.
+- *Gap:* None material.
+
+### 4.8 Inter-Project Messaging (`messaging.rs`, `commands/send_message.rs`, `commands/inbox_check.rs`)
+
+**FR-8.1 — Message delivery (`memory_send_message`, `send-message`)** ✅
+- *Vision:* Deliver a message to another palace's inbox with no new schema — encode it as a drawer with a `msg:*` tag envelope.
+- *Current:* `messaging.rs` (#99) defines the `msg:v1`/`msg:from`/`msg:to`/`msg:purpose`/`msg:sent_at`/`msg:read` envelope; addressing is by repo slug. CLI `send-message` and `POST /api/v1/messages`.
+- *Gap:* No central registry — sender/receiver agree on the slug out of band (by design).
+
+**FR-8.2 — Inbox surfacing at session start (`inbox-check`)** ✅
+- *Vision:* Unread messages for the cwd-derived palace are injected into Claude Code session context, then atomically marked read.
+- *Current:* `commands/inbox_check.rs`; installed as a `SessionStart` hook by `setup`. Atomic compare-and-swap on the read flag prevents double-delivery under concurrency. Every failure path exits 0 with empty stdout.
+- *Gap:* None material.
+
+### 4.9 Embedded UI & Activity (`web.rs`, `activity.rs`, `prompt_log.rs`)
+
+**FR-9.1 — Embedded Svelte dashboard** ✅
+- *Vision:* A browser admin panel served from the daemon with no Node at runtime: palace overview, live event stream, manual dream trigger, memory browsing, KG graph view.
+- *Current:* Svelte build compiled via `rust-embed` and served by `web.rs`; SSE at `/sse`.
+- *Gap:* None material.
+
+**FR-9.2 — Persistent activity feed** ✅
+- *Vision:* The activity feed shows historical entries on mount (not just live SSE) and captures writes from *every* origin (HTTP / MCP / Hook).
+- *Current:* `ActivityLog` (`activity.rs`, #96) — redb-backed, FIFO-capped at `MAX_ENTRIES`, source-tagged. Hook subprocesses emit via `hook_emit.rs` → `POST /api/v1/activity/hook`.
+- *Gap:* None material.
+
+**FR-9.3 — Enriched-prompt logging** ✅
+- *Vision:* Record what each `prompt-context` / `inbox-check` hook injected, for effectiveness analysis.
+- *Current:* `prompt_log.rs` (#105) — rolling JSONL under `<data_root>/logs/`, daily + size-cap rotation, retention pruning, optional prompt hashing.
+- *Gap:* None material.
+
+### 4.10 Setup, Service & Migration (`commands/setup.rs`, `service.rs`, `migrate.rs`, `kuzu_migrate.rs`, `doctor.rs`)
+
+**FR-10.1 — One-shot setup (`setup`)** ✅
+- *Vision:* `trusty-memory setup` installs the launchd LaunchAgent (macOS), pre-warms the embedder cache, and patches every Claude settings file with the MCP entry + the `prompt-context`/`inbox-check` hooks.
+- *Current:* Implemented (`commands/setup.rs`, #86); idempotent, service-owned hooks.
+- *Gap:* None material.
+
+**FR-10.2 — Unified start/serve/stop** ✅
+- *Vision:* `start`/`serve`/`stop` match trusty-search semantics — `serve` self-spawns a detached `serve --foreground`; a second `start` is a no-op when healthy.
+- *Current:* `commands/{start,stop}.rs` (#83). Dynamic port `7070..=7079` with OS fallback; address written to the discovery file.
+- *Gap:* None material.
+
+**FR-10.3 — kuzu-memory migration (`migrate kuzu-memory`, `migrate kuzu-data`)** ✅
+- *Vision:* Rewrite Claude MCP config from the legacy kuzu-memory server, and import its `store.redb` data into palaces (idempotent).
+- *Current:* `commands/migrate.rs` (#278) + `kuzu_migrate.rs` (#277); each entity → drawer, each relation → triple; SHA-256-derived UUIDs make re-import idempotent.
+- *Gap:* None material.
+
+**FR-10.4 — Diagnostics & KG rebuild (`doctor`, `kg_rebuild`)** ✅
+- *Vision:* Audit palaces/orphans and rebuild the KG from drawers.
+- *Current:* `commands/doctor.rs` and `kg_rebuild.rs`.
+- *Gap:* `doctor --fix` is advisory only (see FR-2.2). 🔵
+
+---
+
+## 5. Success Criteria / Differentiators
+
+A release meets the bar when:
+
+1. **Remember/recall is real and frictionless** — an agent stores a fact via MCP
+   (or a one-line `note`) and recalls it accurately later via hybrid BM25 +
+   vector retrieval, with L0/L1 grounding always present. ✅
+2. **Single-install holds** — `cargo install trusty-memory` yields a working
+   daemon *and* its bundled BM25 sidecar, auto-spawned per palace, with no manual
+   service assembly. ✅
+3. **One daemon, many transports** — the same long-lived process serves MCP (via
+   the bridge), HTTP/SSE REST, and JSON-RPC, never re-spawning per session and
+   never deadlocking on the redb write lock (the reason `serve --stdio` was
+   removed, #150). ✅
+4. **Project-scoped and predictable** — palace names map deterministically to the
+   project on disk; "which palace am I in?" is answerable from cwd alone. ✅
+5. **Service-free and embeddable** — no cloud, no Python, no native SQLite/usearch
+   chain on the default path; open-mpm can link the core in-process without axum. ✅
+6. **Memory stays healthy over time** — the dream cycle dedups, prunes, and
+   (optionally) semantically consolidates so recall quality does not degrade as a
+   palace grows. ✅
+
+**Core differentiator (restated):** trusty-memory is a single embedded MIT-licensed
+Rust binary that unifies vector recall, a temporal knowledge graph, an
+inter-project message bus, and idle-time LLM consolidation behind one MCP tool
+surface — with a frontend/core split that lets the same engine be a standalone
+daemon *or* an in-process library.
+
+---
+
+## 6. Open Questions & Roadmap
+
+### Open questions
+
+- **Tool-count doc drift:** the wire surface is 23 tools, but the README table
+  shows 12 and `mcp_service.rs` comments say 23/11 inconsistently. Should the
+  README be regenerated from `tool_definitions()` to stay authoritative? 🟡
+- **Orphaned-palace remediation:** `doctor --fix-palaces` is advisory only.
+  Should it actually merge orphans into `personal` (FR-2.2)? 🔵
+- **SQLite KG retirement (#47):** the legacy `sqlite-kg` path lingers for
+  migration. When can it be removed entirely? 🟡
+- **Leiden refinement:** community detection is Louvain-only; is phase-2
+  refinement worth adding to reduce false-positive knowledge gaps (FR-6.6)? 🔵
+- **Scope enforcement:** scopes are advertised, not enforced. Should the daemon
+  ever enforce `memory.read`/`memory.write` locally, or is that always the
+  orchestrator's job (§2 Non-Goals)? ⚪
+- **Cross-machine sync:** explicitly a non-goal today — revisit if multi-host
+  agent fleets need shared memory. ⚪
+
+### Roadmap (phased, from current gaps)
+
+| Phase | Theme | Highlights |
+|---|---|---|
+| **Now** | Doc hygiene | Reconcile the tool-count drift (README ↔ `tool_definitions()` ↔ `mcp_service.rs`); fix the broken README link (#398). |
+| **Phase 2** | Storage cleanup | Retire the legacy `sqlite-kg` path (#47) once migration tooling is no longer needed. |
+| **Phase 3** | Palace lifecycle | Implement actual orphaned-palace merge into `personal` behind `doctor --fix` (FR-2.2/FR-10.4). |
+| **Later** | Retrieval/graph depth | Leiden phase-2 refinement for knowledge gaps (FR-6.6); richer KG auto-extraction beyond the heuristic table (FR-6.2). |

--- a/docs/trusty-memory/spec/README.md
+++ b/docs/trusty-memory/spec/README.md
@@ -1,0 +1,74 @@
+# trusty-memory — Specification Set
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+This directory holds the canonical product and engineering specification for the
+`trusty-memory` crate (`crates/trusty-memory/`) and the storage core it sits on
+top of (`trusty-common`'s `memory_core` feature). It is the single authoritative
+reference for *what trusty-memory is meant to be*, *what it is today*, and *what
+gaps remain*.
+
+## What is trusty-memory?
+
+`trusty-memory` is a **local, embedded "memory palace" for AI agents and humans**:
+a long-running daemon that lets an MCP-aware client (Claude Code, open-mpm, or a
+plain `curl`) **remember** natural-language facts and **recall** them later via
+hybrid BM25 + vector retrieval, organized into per-project namespaces called
+**palaces**. It bundles an optional knowledge-graph layer for structured triples,
+an embedded Svelte admin dashboard, and a background "dream" consolidation cycle.
+It is licensed **MIT** (most of the workspace is Elastic-2.0) and runs with **no
+external services** — storage is pure-Rust redb + an in-process HNSW vector index
++ `fastembed` ONNX embeddings.
+
+The defining structural fact is a **frontend/core split**: this crate is the
+*MCP-server + HTTP + UI frontend*; all the storage, retrieval, knowledge-graph,
+and dream logic lives in **`trusty-common`'s `memory_core` module** (gated behind
+the `memory-core` feature). The historical `trusty-memory-core` crate has been
+**fully absorbed** into `trusty-common` (issue #5); it no longer exists as a
+separate workspace member. See [ARCHITECTURE.md §1](./ARCHITECTURE.md) and
+[ADR-0001](../decisions/0001-frontend-core-split.md).
+
+## Documents in this set
+
+| Document | Read it when you want to know… |
+|---|---|
+| **[PRD.md](./PRD.md)** | The product: vision & mission, goals/non-goals, personas (agents + humans across projects), the full functional-requirement catalog (tagged by implementation status), success criteria, and the open-question roadmap. Start here for *why* and *what*. |
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | The system shape: the **frontend/core split**, the multi-transport model (MCP-stdio bridge ⇄ UDS ⇄ HTTP/SSE), the bundled `trusty-bm25-daemon` sidecar (one-install convention), the fire-and-forget `POST /api/v1/remember` path for sub-agents, the storage model (redb + HNSW + SQLite-legacy KG), the 4-layer (L0–L3) progressive retrieval, and the embedded-UI build. Includes the source-module map with `src/` citations. Start here for *how it fits together*. |
+| **[COMPONENTS.md](./COMPONENTS.md)** | Per-subsystem specs: MCP server / tool surface, HTTP API, palace store, BM25 sidecar integration, retrieval & ranking, knowledge-graph + dream, the embedded UI, the `note` CLI, and import/export/migration. Each component states responsibility, key types/modules (with `src/` paths), current state, and known gaps. Start here for *the detail of one subsystem*. |
+
+## Reading order
+
+1. **New to trusty-memory?** PRD → ARCHITECTURE → COMPONENTS.
+2. **Implementing a feature?** Jump to the relevant COMPONENTS section, then
+   cross-check the transport/storage model in ARCHITECTURE.
+3. **Evaluating product direction?** PRD vision + success criteria, then the
+   gap callouts throughout COMPONENTS.
+
+## Status legend (used throughout this set)
+
+Every requirement and component is framed as **Vision / Current / Gap** and
+tagged inline with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, or plan) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+## Provenance & maintenance
+
+These documents are derived from a direct audit of the `crates/trusty-memory/src/`
+tree, the `trusty-common/src/memory_core/` storage core, the crate `README.md`,
+the existing `docs/trusty-memory/` research/sessions, and the closed-issue backlog
+(notably the redb migration sweep #43–#56, the BM25/embed sidecar work #155/#156/
+#193, the multi-transport refactor #149/#150, inter-project messaging #99, and the
+palace-as-project enforcement #88). When the code changes materially, update the
+relevant document and bump the *Last reviewed* date. Source-path citations reflect
+the layout at the time of review.
+
+## Related decisions
+
+- [ADR-0001 — Frontend/core split: trusty-memory ⇄ trusty-common `memory_core`](../decisions/0001-frontend-core-split.md)


### PR DESCRIPTION
Adds the canonical spec set (PRD/ARCHITECTURE/COMPONENTS + README index) under docs/trusty-memory/spec/ in the open-mpm style, plus an ADR documenting the frontend/core split (trusty-memory frontend ⇄ trusty-common memory_core; the old trusty-memory-core crate is absorbed/gone). cargo check -p trusty-memory passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)