### PR TITLE
chore: bump trusty-search dep to 0.19.0 in dependents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10945,7 +10945,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/open-mpm/Cargo.toml
+++ b/crates/open-mpm/Cargo.toml
@@ -44,7 +44,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.8.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.18.0" }
+trusty-search = { path = "../trusty-search", version = "0.19.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Bumps the trusty-search path+version dependency in open-mpm from 0.18.0 to 0.19.0 so cargo publish -p trusty-search resolves. Unblocks the trusty-search 0.19.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)