### PR TITLE
docs(trusty-common): canonical spec set

### DIFF
--- a/docs/trusty-common/README.md
+++ b/docs/trusty-common/README.md
@@ -1,23 +1,40 @@
 # trusty-common — documentation
 
-Shared utilities: tracing, OpenRouter chat helpers, port-walking, daemon address resolution. Library crate consumed by every other trusty-* component.
+The **foundational shared library** of the trusty-* workspace — the one internal
+crate every other trusty-* tool links. Started as a bag of utilities (tracing,
+OpenRouter chat, port-walking, daemon address resolution) and absorbed seven
+formerly standalone micro-crates (MCP/RPC primitives, the embedder, the symbol
+graph, the memory-palace engine, ticketing, monitor TUIs) behind opt-in feature
+flags (issue #5).
+
+## Canonical specification
+
+The authoritative *what / why / gap* reference lives in
+[**`spec/`**](spec/) — start there:
+
+| Document | Purpose |
+|--------|---------|
+| [`spec/README.md`](spec/README.md) | Index, summary, status legend, reading order. |
+| [`spec/PRD.md`](spec/PRD.md) | Vision, goals/non-goals, personas (the other crates), functional requirements by subsystem. |
+| [`spec/ARCHITECTURE.md`](spec/ARCHITECTURE.md) | The feature-flag model, cross-crate consumption, design conventions, module map. |
+| [`spec/COMPONENTS.md`](spec/COMPONENTS.md) | Per-subsystem specs with `src/` citations. |
+
+Architecture Decision Records (Nygard format) live in
+[**`decisions/`**](decisions/) — see
+[`0001-consolidate-library-micro-crates.md`](decisions/0001-consolidate-library-micro-crates.md).
 
 ## Layout
 
-This directory follows the standard three-subdir layout used across all
-published trusty-* crates:
+This directory follows the standard layout used across all published trusty-*
+crates:
 
 | Subdir | Contents |
 |--------|----------|
+| [`spec/`](spec/) | Canonical PRD / Architecture / Components specification set. |
+| [`decisions/`](decisions/) | Architecture Decision Records (Nygard format). |
 | [`regression-testing/`](regression-testing/) | Versioned performance/quality snapshots, baseline measurements, alternate-corpus baselines. |
 | [`research/`](research/) | Investigation docs, audits, decision documents. |
 | [`sessions/`](sessions/) | Engineering-session summaries — narrative + reasoning. |
-
-## Status
-
-No `trusty-common` documentation has been authored yet in this layout. As work
-on trusty-common produces benchmarks, decisions, or session summaries, add files
-under the appropriate subdir and update its README index.
 
 See [`docs/trusty-search/`](../trusty-search/) for a worked example of the
 populated layout.

--- a/docs/trusty-common/decisions/0001-consolidate-library-micro-crates.md
+++ b/docs/trusty-common/decisions/0001-consolidate-library-micro-crates.md
@@ -1,0 +1,95 @@
+# 0001. Consolidate library micro-crates into one feature-gated crate
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Scope:** Crate `trusty-common`
+- **Supersedes / Superseded by:** —
+
+## Context
+
+The trusty-* ecosystem grew as a constellation of small published crates:
+`trusty-mcp-core` (JSON-RPC/MCP envelopes), `trusty-rpc` (a JSON-RPC client),
+`trusty-embedder` (the fastembed/ONNX abstraction), `trusty-symgraph` (the
+tree-sitter symbol graph), `trusty-memory-core` (the Memory-Palace storage
+engine), `trusty-tickets` (the GitHub/JIRA/Linear MCP server), and
+`trusty-monitor-tui` (the ratatui dashboards) — on top of a base `trusty-common`
+utilities crate.
+
+This factoring caused three recurring problems:
+
+1. **Drift.** The *same* `Request`/`Response` MCP envelope, the *same* `Embedder`
+   trait, and the *same* launchd plist generator were copy-pasted across
+   trusty-memory and trusty-search and diverged subtly — cache vs no-cache
+   embedders, drifting JSON-RPC error-code types, three different ways to read the
+   user's UID. A bug fixed in one copy stayed unfixed in the others.
+2. **Release friction.** Each crate carried its own version, and cross-crate
+   development required a `[patch.crates-io]` dance to test an unreleased change
+   in a downstream crate.
+3. **Coordination cost.** Seven version numbers to reason about, seven changelogs,
+   seven `cargo publish` invocations for what was logically one shared library.
+
+The naive fix — merge everything into one crate — has an obvious failure mode:
+forcing every consumer to compile every dependency. A chat-only CLI must not pull
+in ONNX Runtime; a `lexical_only` search index must not compile tree-sitter
+grammars; a tool that never serves HTTP must not link axum + tower (the recurring
+mistake later corrected in #226 and #249 for downstream crates).
+
+This work spans the consolidation tracker
+[#5](https://github.com/bobmatnyc/trusty-tools/issues/5) (phases 2c symgraph, 2d
+memory-core), plus the absorption of ticketing
+([#216](https://github.com/bobmatnyc/trusty-tools/issues/216) is the help-system
+companion), the monitor TUIs
+([#31](https://github.com/bobmatnyc/trusty-tools/issues/31),
+[#34](https://github.com/bobmatnyc/trusty-tools/issues/34),
+[#32](https://github.com/bobmatnyc/trusty-tools/issues/32)), the embedder-client
+unification ([#110](https://github.com/bobmatnyc/trusty-tools/issues/110),
+[#164](https://github.com/bobmatnyc/trusty-tools/issues/164)), and the migration
+kernel ([#179](https://github.com/bobmatnyc/trusty-tools/issues/179)).
+
+## Decision
+
+We will consolidate the seven library micro-crates into **one crate,
+`trusty-common`**, where **every absorbed subsystem sits behind an opt-in feature
+flag** and **`default = []`**.
+
+- The default build compiles only the always-on core (port-walk, data-dir,
+  daemon-addr, tracing, chat, setup helpers) and its light dependencies
+  (`tokio`, `serde`, `reqwest`, `tracing`, `sysinfo`, `dirs`, `colored`).
+- Each heavy subsystem is reachable **only** through its feature: `mcp`, `rpc`,
+  `embedder` (+ ORT/candle variants), `embedder-client`, `bm25`, `bm25-client`,
+  `migrations`, `symgraph` / `symgraph-parser` / `symgraph-server`, `memory-core`
+  (+ `-kuzu` / `usearch-migrate` / `sqlite-kg`), `tickets`, `cli-help`,
+  `monitor-tui`, and `axum-server`.
+- The symbol-graph engine is split so the **pure-data contracts** (`EntityType`,
+  `RawEntity`, `EdgeKind`) ship under `symgraph` without tree-sitter, while the
+  full parser lives behind `symgraph-parser` — which alone claims the
+  `links = "tree-sitter"` native slot, enabled in at most one crate per build.
+- Crates that previously published a separate name (e.g. `trusty-memory-core`) are
+  reduced to thin re-export shims so existing import paths still resolve.
+- The crate keeps a single `version` field (currently `0.8.0`) and remains
+  publishable to crates.io under Elastic-2.0, so external consumers can adopt a
+  single subsystem by enabling just its feature.
+
+## Consequences
+
+- **Positive:** one source of truth per shared primitive — a bug fixed in the
+  `Embedder` trait or the MCP envelope is fixed everywhere at once; behavioural
+  drift between the daemons is eliminated.
+- **Positive:** cross-crate development no longer needs `[patch.crates-io]`; Cargo
+  resolves the in-tree path automatically and workspace builds are atomic.
+- **Positive:** the `default = []` gate means consolidation does **not** tax
+  consumers — a chat-only consumer never compiles ONNX, tree-sitter, redb, or
+  axum; the dependency surface each crate carries shrank rather than grew.
+- **Positive:** one version to bump for shared code, one changelog, one publish.
+- **Negative / trade-off:** `Cargo.toml` carries a large, intricate `[features]`
+  table with non-obvious implications (ORT variants are mutually exclusive at the
+  `ort-sys` level; `memory-core` auto-enables `embedder` + `embedder-bundled-ort`;
+  `symgraph-parser` monopolises the tree-sitter `links` slot). The feature matrix
+  is now itself a thing to maintain and document (see ARCHITECTURE §2).
+- **Negative / trade-off:** a few transitional features (`sqlite-kg`,
+  `usearch-migrate`) exist only to read legacy stores during one-shot upgrades and
+  must be remembered for later removal (#47, #51).
+- **Neutral:** documentation drift risk — the in-crate `README.md` lagged the
+  `Cargo.toml` (still showing v0.3 without `memory-core`/`monitor-tui`/
+  `embedder-client`/`tickets`/`cli-help`); this spec set reflects the audited tree
+  and #430 tracks the broader inventory reconciliation.

--- a/docs/trusty-common/decisions/README.md
+++ b/docs/trusty-common/decisions/README.md
@@ -1,0 +1,16 @@
+# trusty-common — Architecture Decision Records
+
+**Crate-specific** ADRs for trusty-common, in the Nygard format. These cover
+decisions local to the trusty-common crate; **workspace-wide** decisions live in
+[`docs/adr/`](../../adr/). This directory maintains its own independent numbering
+sequence.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](./0001-consolidate-library-micro-crates.md) | Consolidate library micro-crates into one feature-gated crate | Accepted |
+
+---
+
+[← Back to trusty-common docs index](../README.md)

--- a/docs/trusty-common/spec/ARCHITECTURE.md
+++ b/docs/trusty-common/spec/ARCHITECTURE.md
@@ -1,0 +1,264 @@
+# trusty-common — Architecture
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+This document describes *how trusty-common fits together*: the feature-flag model
+that is its defining architectural decision, the cross-crate consumption
+relationships, the design conventions every subsystem obeys, and the
+source-module map. For product framing see [PRD.md](./PRD.md); for per-subsystem
+detail see [COMPONENTS.md](./COMPONENTS.md).
+
+---
+
+## 1. The shape of the crate
+
+trusty-common is a **single `rlib`** (`crate-type = ["rlib"]`, `src/lib.rs`)
+plus two **feature-gated binary shims**:
+
+- `tickets-mcp` (`src/bin/tickets_mcp.rs`, `required-features = ["tickets"]`)
+- `candle_metal_bench` (`src/bin/candle_metal_bench.rs`, `required-features = ["embedder-candle"]`)
+
+The library surface is a set of **independent, feature-gated subsystems**. The
+crate root (`src/lib.rs`) carries only the always-on core (port-walk, data-dir,
+daemon-addr, tracing, chat re-exports, misc helpers); every heavier subsystem is a
+`#[cfg(feature = "…")] pub mod …`. There is **no global state** beyond the
+idempotent tracing subscriber and the process-wide shared `FastEmbedder`
+`OnceCell` inside `memory-core` (#57).
+
+```
+                       trusty-common (rlib, edition 2021, ELv2)
+ ┌──────────────────────────────────────────────────────────────────────────┐
+ │  ALWAYS-ON CORE (default = [])                                            │
+ │   lib.rs        bind_with_auto_port · resolve_data_dir · daemon-addr ·    │
+ │                 check_already_running · init_tracing · chat re-exports    │
+ │   chat.rs       ChatProvider · OpenRouter · Ollama · tool-use             │
+ │   log_buffer.rs · sys_metrics.rs · claude_config.rs · project_discovery   │
+ │   launchd.rs (#[cfg(macos)])                                              │
+ ├──────────────────────────────────────────────────────────────────────────┤
+ │  OPT-IN SUBSYSTEMS (each behind one or more feature flags)                │
+ │   axum-server → server.rs                                                 │
+ │   mcp         → mcp/        rpc → rpc/        bm25 → bm25.rs               │
+ │   embedder    → embedder/   embedder-client → embedder_client/            │
+ │   bm25-client → bm25_client.rs        migrations → migrations/            │
+ │   symgraph(-parser/-server) → symgraph/                                   │
+ │   memory-core(-kuzu) / usearch-migrate / sqlite-kg → memory_core/         │
+ │   tickets → tickets/        cli-help → help.rs    monitor-tui → monitor/  │
+ └──────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. The feature-flag model (the load-bearing decision)
+
+The crate's central architectural choice: **`default = []`**. A bare
+`trusty-common` dependency compiles only the always-on core plus its light deps
+(`tokio`, `serde`, `serde_json`, `reqwest`, `tracing`, `tracing-subscriber`,
+`sysinfo`, `dirs`, `colored`, `futures-util`, `async-trait`, `anyhow`). Every
+heavy transitive dependency — ONNX Runtime, tree-sitter grammars, redb, usearch,
+git2, axum, ratatui, candle — is reachable **only** through an explicit feature.
+
+This is what made the issue-[#5](https://github.com/bobmatnyc/trusty-tools/issues/5)
+consolidation of seven micro-crates safe: absorbing `trusty-embedder` into
+trusty-common does not force a chat-only consumer to compile ONNX, because the
+ONNX deps sit behind `embedder`. See
+[decisions/0001-consolidate-library-micro-crates.md](../decisions/0001-consolidate-library-micro-crates.md).
+
+### Feature → module → dependency matrix
+
+| Feature | Enables module | Pulls in (key deps) | Implies | Former crate |
+|---|---|---|---|---|
+| *(default)* | core, `chat`, `log_buffer`, `sys_metrics`, `claude_config`, `project_discovery`, `launchd`(macOS) | tokio, serde, reqwest, tracing, sysinfo, dirs, colored | — | base `trusty-common` |
+| `axum-server` | `server` | axum, tower-http | — | — |
+| `mcp` | `mcp` | *(none beyond serde/tokio)* | — | `trusty-mcp-core` |
+| `rpc` | `rpc` | uuid | — | `trusty-rpc` (lib half) |
+| `embedder` | `embedder` | fastembed, lru, parking_lot, ort | — | `trusty-embedder` |
+| `embedder-bundled-ort` | — | fastembed bundled ORT | `embedder` | — |
+| `embedder-cuda` | — | ort/cuda, fastembed/cuda (load-dynamic) | `embedder` | — |
+| `embedder-load-dynamic` | — | ort/load-dynamic | `embedder` | — |
+| `embedder-coreml` | — | *(deprecated no-op alias)* | `embedder` | — |
+| `embedder-test-support` | `MockEmbedder` (outside `cfg(test)`) | — | `embedder` | — |
+| `embedder-candle` | `embedder::candle_embedder` | candle-core/-nn/-transformers, hf-hub, tokenizers | `embedder` | — (#54) |
+| `embedder-client` | `embedder_client` | thiserror | `embedder` | `trusty-embedder-client` + `embed_client` |
+| `bm25` | `bm25` | *(pure std)* | — | (from open-mpm) |
+| `bm25-client` | `bm25_client` | *(pure tokio/serde)* | — | — (#156) |
+| `migrations` | `migrations` | *(pure serde/anyhow)* | — | (from trusty-search, #179) |
+| `symgraph` | `symgraph::contracts` | thiserror, sha2 | — | `trusty-symgraph` (contracts) |
+| `symgraph-parser` | `symgraph` parser/emitter/editor | tree-sitter + 8 grammars, syn, petgraph, indexmap, similar, walkdir, genco | `symgraph` | `trusty-symgraph` (full) |
+| `symgraph-server` | `symgraph::server` | (axum stack) | `symgraph-parser`, `axum-server` | — |
+| `memory-core` | `memory_core` | hnsw_rs, redb, postcard, git2, dashmap, chrono, regex, petgraph, sha2, hex | `embedder`, `embedder-bundled-ort` | `trusty-memory-core` (#5 phase 2d) |
+| `memory-core-kuzu` | kuzu read path | kuzu | `memory-core` | — |
+| `usearch-migrate` | `.usearch` drain | usearch (FFI) | `memory-core` | — (#51) |
+| `sqlite-kg` | legacy SQLite KG read | rusqlite, r2d2, r2d2_sqlite | `memory-core` | — (#47) |
+| `monitor-tui` | `monitor` | ratatui, crossterm, chrono | — | `trusty-monitor-tui` (#31/#34) |
+| `tickets` | `tickets` | chrono, uuid, base64, thiserror, toml | `mcp` | `trusty-tickets` |
+| `cli-help` | `help` | serde_yaml, strsim, indexmap, thiserror | — | — (#216) |
+
+### Mutual-exclusion & single-slot constraints
+
+- **ORT linking variants are mutually exclusive at the `ort-sys` level.**
+  `embedder-bundled-ort` (static, macOS/glibc ≥ 2.38) vs `embedder-cuda` /
+  `embedder-load-dynamic` (dynamic, operator-supplied `libonnxruntime.so` via
+  `ORT_DYLIB_PATH`). Pick one.
+- **`symgraph-parser` claims `links = "tree-sitter"`.** A `links` slot is
+  unique per build graph, so enable the parser in **at most one crate** per
+  build (typically open-mpm). Other crates enable `symgraph` (contracts only) and
+  resolve symbol types without the grammar slot.
+- **`memory-core` auto-enables `embedder` + `embedder-bundled-ort`** so a palace
+  always has a working `FastEmbedder`; a consumer can switch ORT variants by
+  additionally enabling `embedder-load-dynamic` / `embedder-cuda` explicitly.
+
+---
+
+## 3. Cross-crate consumption
+
+trusty-common is consumed via the workspace path dependency
+(`trusty-common = { workspace = true }`); the workspace manifest declares the
+path so every member resolves the in-tree source. The most architecturally
+significant relationship is **`memory-core` ⇄ `trusty-memory`**:
+
+```
+ trusty-memory (MCP frontend, MIT) ── enables ──▶ trusty-common[memory-core]
+   ├─ owns the MCP server, HTTP API, Svelte UI, BM25-daemon supervision
+   └─ delegates ALL palace storage/retrieval/dream/decay to
+      trusty_common::memory_core::{Palace, PalaceRegistry, PalaceHandle, store::*}
+
+ trusty-memory-core (shim crate) ── re-exports ──▶ trusty-common[memory-core]
+   (kept as a thin re-export so old import paths still resolve)
+```
+
+The memory-palace engine **lives in trusty-common**; `trusty-memory` is a frontend
+over it, and the standalone `trusty-memory-core` crate is now a re-export shim
+(issue #5 phase 2d). The same pattern holds for the other absorbed crates:
+`trusty-search` consumes `embedder-client` + `symgraph` (contracts) + `mcp` +
+`bm25` + `migrations`; `open-mpm` is the single holder of `symgraph-parser`
+(the tree-sitter `links` slot); `trusty-embedderd` consumes `embedder` +
+`embedder-client`.
+
+---
+
+## 4. Design conventions every subsystem obeys
+
+These are enforced by the root `CLAUDE.md` and visible throughout the source:
+
+1. **No unconditional axum.** The HTTP server stack (`server.rs`,
+   `symgraph::server`) is reachable only through `axum-server`. A library
+   consumer that does not serve HTTP must not transitively pull in axum + tower
+   (cf. #226, #249 where downstream crates had to gate their own axum).
+
+2. **API keys passed in, never read from env in the library.**
+   `OpenRouterProvider::new(api_key, model)` takes the key as an argument
+   (`src/chat.rs`, `src/lib.rs`). The library defines `OPENROUTER_URL` /
+   `HTTP_REFERER` / `X_TITLE` constants and timeouts but reads **no** secret from
+   the process environment — that is the binary's responsibility. The only env
+   vars the library itself reads are operational, non-secret tunables:
+   `RUST_LOG` / `RUST_LOG_BUFFER` (tracing), `NO_COLOR` / `TERM` (colour), and the
+   **test-only** `TRUSTY_DATA_DIR_OVERRIDE`.
+
+3. **Logs to stderr.** `init_tracing` / `init_tracing_with_buffer` install a
+   stderr `fmt` layer with `try_init` (idempotent). stdout is reserved for MCP
+   JSON-RPC framing — a stray `println!` would corrupt the protocol.
+
+4. **`thiserror` for library errors, `anyhow` for binary glue.** Subsystems that
+   are imported as a library API define structured error enums
+   (`embedder_client::EmbedderError`, the symgraph error types). `anyhow::Result`
+   appears in the binary shims (`tickets-mcp`, `candle_metal_bench`) and in the
+   handful of daemon-glue free functions in `lib.rs` (`bind_with_auto_port`,
+   `resolve_data_dir`, `write_daemon_addr`) where the caller is always a binary.
+
+5. **No global state.** Free functions and small structs. The only permitted
+   `OnceCell`/`Lazy` are the idempotent tracing subscriber and the process-wide
+   shared `FastEmbedder` in `memory_core::retrieval` (#57), which exists
+   specifically to *avoid* forking dozens of ~90 MB ONNX sessions.
+
+6. **500-line file cap.** Subsystems that grow past the cap are split into a thin
+   `mod.rs` + sibling files (e.g. `memory_core/store/` is 14 files;
+   `embedder_client/` is 7; `tickets/api/backends/` is one file per backend).
+
+---
+
+## 5. Source-module map
+
+| Path | Feature | Responsibility |
+|---|---|---|
+| `src/lib.rs` | default | Core utilities: port-walk, data-dir, daemon-addr, already-running guard, tracing init, colour, `ChatMessage`, deprecated OpenRouter free fns. |
+| `src/chat.rs` | default | `ChatProvider` trait, OpenRouter + Ollama providers, tool-use types, local auto-detect. |
+| `src/log_buffer.rs` | default | `LogBuffer` ring + `LogBufferLayer` tracing layer for `/logs/tail`. |
+| `src/sys_metrics.rs` | default | `SysMetrics` RSS/CPU sampler + `dir_size_bytes`. |
+| `src/claude_config.rs` | default | Claude Code settings discovery + idempotent MCP-server/hook upsert. |
+| `src/project_discovery.rs` | default | `ClaudeProject` + `discover_claude_projects` walk. |
+| `src/launchd.rs` | default (macOS) | `LaunchdConfig` plist generation + `launchctl` lifecycle. |
+| `src/server.rs` | `axum-server` | `with_standard_middleware` (CORS/Trace/gzip) + `daemon_http_client`. |
+| `src/mcp/` | `mcp` | JSON-RPC 2.0 envelopes, error codes, `initialize`, stdio loop, OpenRPC discover, `ServiceDescriptor`. |
+| `src/rpc/` | `rpc` | `RpcClient`, `Transport` + stdio/HTTP transports, pretty-printers. |
+| `src/embedder/` | `embedder`(+variants) | `Embedder` trait, `FastEmbedder`, `MockEmbedder`, Candle backend, RSS helper. |
+| `src/embedder_client/` | `embedder-client` | `EmbedderClient` trait + InProcess/HTTP/UDS/stdio clients + `EmbedderSupervisor`. |
+| `src/bm25.rs` | `bm25` | Code-aware tokenizer + incremental `BM25Index`. |
+| `src/bm25_client.rs` | `bm25-client` | UDS JSON-RPC client for `trusty-bm25-daemon`. |
+| `src/migrations/` | `migrations` | `SchemaVersion`, `Migration<S>`, `MigrationRunner`, `file_stamp`, `redb_stamp` (doc-only). |
+| `src/symgraph/` | `symgraph`/`-parser`/`-server` | Contracts surface; tree-sitter parser → registry → emit; editor; HTTP server. |
+| `src/memory_core/` | `memory-core`(+sub) | Palace hierarchy, registry, retrieval, stores (HNSW/redb-KG/payload/chat/L1), dream/decay/analytics/community/consolidation/git. |
+| `src/tickets/` | `tickets` | `api::*` (config/models/Backend/GitHub/JIRA/Linear), MCP `server`, `tools` schema. |
+| `src/help.rs` | `cli-help` | `HelpConfig` YAML model, `render_help`, Jaro-Winkler `suggest`. |
+| `src/monitor/` | `monitor-tui` | `search_tui`/`memory_tui` ratatui apps + typed HTTP clients + shared dashboard/utils. |
+| `src/bin/tickets_mcp.rs` | `tickets` | Binary shim → `tickets::server::run_stdio`. |
+| `src/bin/candle_metal_bench.rs` | `embedder-candle` | Candle Metal RSS validation harness. |
+
+---
+
+## 6. Memory-core internal topology (`src/memory_core/`)
+
+The heaviest subsystem warrants its own sub-map. The palace engine is a layered
+store stack behind a single `PalaceHandle`:
+
+```
+ PalaceRegistry (registry.rs) ──owns──▶ many PalaceHandle (retrieval.rs)
+   PalaceHandle = progressive retrieval (L0 identity → L1 essential →
+                  L2 on-demand vector → L3 deep search)
+     ├─ store/palace_store.rs  durable palace/wing/room/drawer rows (redb)
+     ├─ store/vector.rs        VectorStore trait + UsearchStore (HNSW, hnsw_rs)
+     ├─ store/hnsw_store.rs    pure-Rust HNSW graph
+     ├─ store/kg*.rs           KnowledgeGraph: kg_redb (current) / kg_sqlite
+     │                         (legacy read, sqlite-kg) / kg_writer / kg_store
+     ├─ store/payload_store.rs large-payload sidecar (postcard)
+     ├─ store/chat_sessions.rs chat-session log (redb, #56)
+     ├─ store/l1_cache.rs      pre-cached L0/L1 layer
+     ├─ store/kuzu.rs          optional kuzu read path (memory-core-kuzu)
+     └─ store/concurrent_open.rs  multi-process open coordination
+   Analytics surfaces (operate over the stores):
+     analytics.rs (RecallLog, redb #57) · decay.rs · dream.rs ·
+     community.rs (Louvain on petgraph, #52) · semantic_consolidation.rs
+     (inference-backed dedup via Mock/Ollama/OpenRouter, #87) · git.rs
+     (git2 history extraction) · embed.rs (palace-local Embedder shim) ·
+     filter.rs (content-quality gate, #222)
+```
+
+All stores migrated from SQLite/rusqlite to **redb** (#43–#47, #56, #57); the
+`sqlite-kg` and `usearch-migrate` features exist only to read legacy stores
+during the one-shot upgrade and are slated for removal.
+
+---
+
+## 7. Build & verification
+
+```bash
+# Default (dependency-light) build — what a bare consumer gets
+cargo check -p trusty-common
+
+# A representative multi-feature build
+cargo test -p trusty-common --features axum-server,mcp,rpc,symgraph
+
+# Embedder (ONNX-backed tests are #[ignore] by default)
+cargo test -p trusty-common --features embedder -- --include-ignored
+
+# Memory-palace engine
+cargo test -p trusty-common --features memory-core
+```
+
+Because every consumer build is atomic in the workspace, a change to a
+trusty-common subsystem must be validated with `cargo check` (workspace-wide) and
+`cargo test -p <consumer>` for each dependent crate before commit (root
+`CLAUDE.md` cross-crate workflow).

--- a/docs/trusty-common/spec/COMPONENTS.md
+++ b/docs/trusty-common/spec/COMPONENTS.md
@@ -1,0 +1,350 @@
+# trusty-common — Component Specifications
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+One section per subsystem. Each states **Responsibility**, **Key types/modules**
+(with `src/` paths), **Current state**, and **Known gaps**, framed Vision /
+Current / Gap. For the feature-flag matrix see
+[ARCHITECTURE.md §2](./ARCHITECTURE.md#2-the-feature-flag-model-the-load-bearing-decision);
+for product framing see [PRD.md](./PRD.md).
+
+---
+
+## 1. Core utilities — `src/lib.rs` *(default)*
+
+**Responsibility.** The always-on daemon-lifecycle primitives every trusty-*
+binary shares: bind a port, find a data directory, record/discover the daemon
+address, refuse to start a duplicate, initialise tracing, control colour.
+
+**Key types/modules.**
+- `bind_with_auto_port(addr, max_attempts)` — `src/lib.rs:283`.
+- `resolve_data_dir(app_name)` + `DATA_DIR_OVERRIDE_ENV` — `src/lib.rs:323`, `:352`.
+- `write_daemon_addr` / `read_daemon_addr` — `src/lib.rs:390`, `:406`.
+- `probe_health` / `check_already_running` — `src/lib.rs:433`, `:470`.
+- `maybe_disable_color`, `is_dir` — `src/lib.rs:589`, `:809`.
+- `ChatMessage` + deprecated `openrouter_chat` / `openrouter_chat_stream` — `src/lib.rs:621`, `:665`, `:721`.
+
+**Current state.** ✅ All functions implemented and unit-tested
+(`auto_port_walks_forward`, `resolve_data_dir_creates_directory`,
+`daemon_addr_round_trips`, `check_already_running_*`). Logs nothing to stdout;
+returns `anyhow::Result` because every caller is a binary.
+
+**Known gaps.**
+- 🟡 `openrouter_chat` / `openrouter_chat_stream` are deprecated (0.3.1) — use
+  `OpenRouterProvider` (§4). Retained for back-compat.
+- ⚪ Windows data-dir paths are unverified in CI.
+
+---
+
+## 2. Tracing & log buffer — `src/lib.rs`, `src/log_buffer.rs` *(default)*
+
+**Responsibility.** One verbosity ladder + `RUST_LOG` override for every binary,
+always to stderr, plus an in-memory ring so daemons can serve `GET /logs/tail`.
+
+**Key types/modules.**
+- `init_tracing(verbose_count)` — `src/lib.rs:504` (`0→warn,1→info,2→debug,3+→trace`).
+- `init_tracing_with_buffer(verbose, capacity)` — `src/lib.rs:538` (dual-layer registry).
+- `LogBuffer` (capped `VecDeque<String>`) + `LogBufferLayer` — `src/log_buffer.rs`.
+
+**Current state.** ✅ `try_init` makes both idempotent across test binaries. The
+buffer layer filters via `RUST_LOG_BUFFER` (default `info`) independently of the
+stderr filter, so lifecycle events reach `/logs/tail` even when stderr is at
+`warn`.
+
+**Known gaps.** None material.
+
+---
+
+## 3. System metrics — `src/sys_metrics.rs` *(default)*
+
+**Responsibility.** Per-process RSS + CPU sampling for `/health`; directory byte
+sizing.
+
+**Key types/modules.** `SysMetrics` (wraps `sysinfo::System` scoped to current
+PID), `SysMetrics::sample() -> (rss_mb, cpu_pct)`, `dir_size_bytes`.
+
+**Current state.** ✅ CPU is delta-based, so the first sample reports `0.0` and
+subsequent samples reflect usage since the prior call — designed for a ~2 s
+`/health` poll without a background task. Tests: `sample_does_not_panic`,
+`rss_is_plausible`.
+
+**Known gaps.** None material.
+
+---
+
+## 4. Chat / providers — `src/chat.rs` *(default)*
+
+**Responsibility.** Provider-agnostic streaming chat with OpenAI-style tool-use,
+across cloud (OpenRouter) and local (Ollama/LM Studio) backends.
+
+**Key types/modules.**
+- `ChatProvider` trait (`chat_stream`).
+- `OpenRouterProvider` / `OllamaProvider` — both speak OpenAI-compatible
+  `/v1/chat/completions` SSE, including streamed `tool_calls`.
+- `ChatEvent` (`Delta`/`Done`/`ToolCall`), `ToolDef`, `ToolCall`, `LocalModelConfig`.
+- `auto_detect_local_provider` — probes `{base_url}/v1/models`, 1 s timeout.
+
+**Current state.** ✅ Re-exported from the crate root (`src/lib.rs:259`). **API
+key is a constructor argument** (`OpenRouterProvider::new(api_key, model)`) — the
+library never reads `OPENROUTER_API_KEY`. Tests cover default config, the
+unreachable-server path, SSE delta streaming, and tool-call fragment
+accumulation.
+
+**Known gaps.** None material; the deprecated free-function path lives in
+`lib.rs` (§1).
+
+---
+
+## 5. MCP / JSON-RPC primitives — `src/mcp/` *(`mcp`)*
+
+**Responsibility.** The shared JSON-RPC 2.0 / MCP envelope surface so every MCP
+server in the workspace imports identical types.
+
+**Key types/modules.** `Request`, `Response`, `JsonRpcError`, `error_codes`
+(spec i32 constants), `initialize_response`, `run_stdio_loop` (accepts any
+`Fn(Request) -> Future<Output=Response>`); `openrpc.rs` (`rpc.discover`),
+`service.rs` (`ServiceDescriptor`). Formerly `trusty-mcp-core`.
+
+**Current state.** ✅ Adds no deps beyond `serde`/`tokio`. Tests cover envelope
+round-trips, error-code values, and the stdio loop with an in-memory dispatcher.
+
+**Known gaps.** None material.
+
+---
+
+## 6. RPC client + transports — `src/rpc/` *(`rpc`)*
+
+**Responsibility.** A general-purpose JSON-RPC 2.0 client with stdio-subprocess
+and HTTP transports + pretty-printers (the library half of `trusty-rpc`).
+
+**Key types/modules.** `RpcClient`, `new_id` (UUID-v4), `extract_result`;
+`Transport` trait + `StdioTransport` + `HttpTransport`; `print_json`,
+`print_server_info`, `print_tool_result`, `print_tools_list`.
+
+**Current state.** ✅ Requires `uuid`; HTTP transport reuses workspace `reqwest`.
+Per-submodule unit tests; integration tests live in the `trusty-rpc` crate.
+
+**Known gaps.** None material.
+
+---
+
+## 7. Embedder — `src/embedder/` *(`embedder` + variants)*
+
+**Responsibility.** One shared embedding abstraction so trusty-memory and
+trusty-search stop shipping divergent `Embedder`/`FastEmbedder` copies.
+
+**Key types/modules.**
+- `Embedder` async trait (`embed_batch` primitive; single-text embed is a helper).
+- `FastEmbedder` — fastembed-rs, all-MiniLM-L6-v2 (INT8, 384-d) with LRU cache +
+  ORT warmup; fallback to full-precision when quantized unavailable.
+- `MockEmbedder` (`embedder-test-support`) — deterministic test double.
+- `candle_embedder::CandleEmbedder` (`embedder-candle`, #54) — Metal/CPU BERT.
+- `rss.rs` — portable RSS measurement for the validation harness.
+
+**Current state.** ✅ ORT linking variants: `embedder-bundled-ort` (static),
+`embedder-cuda`, `embedder-load-dynamic`; `embedder-coreml` is a deprecated
+no-op (CoreML auto-detected on Apple Silicon). CoreML safety hardened to require
+a double opt-in (#85).
+
+**Known gaps.**
+- 🟡 ONNX-backed tests are `#[ignore]` (CI-fast); run with `--include-ignored`.
+- ⚠️ ORT variants are mutually exclusive at the `ort-sys` level — pick one.
+
+---
+
+## 8. Embedder client — `src/embedder_client/` *(`embedder-client`)*
+
+**Responsibility.** One client trait over every `trusty-embedderd` deployment
+mode, so call sites are transport-agnostic (#110, #164).
+
+**Key types/modules.** `EmbedderClient` trait; `InProcessEmbedderClient` (wraps
+`FastEmbedder`), `RemoteEmbedderClient` (HTTP `POST /embed`), `UdsEmbedderClient`
+(newline-framed JSON-RPC over UDS), `StdioEmbedderClient` (piped child process),
+`EmbedderSupervisor` (auto-spawn lifecycle); `EmbedRequest`/`EmbedResponse` wire
+types, `EmbedderError` (`thiserror`). Files: `mod.rs`, `in_process.rs`,
+`remote.rs`, `uds.rs`, `stdio.rs`, `supervisor.rs`, `types.rs`, `error.rs`.
+
+**Current state.** ✅ Consolidated the former `trusty-embedder-client` (HTTP, PR
+#163) and `embed_client` (UDS, PR #157) into one module; the `embed-client`
+feature/module are retired (#164). The `embedder` feature is **not** implied so
+HTTP/UDS-only callers skip fastembed/ORT.
+
+**Known gaps.** 🟡 Residual `embed_client`↔`embedder_client` naming reconciliation
+(#164).
+
+---
+
+## 9. BM25 lexical index + client — `src/bm25.rs` *(`bm25`)*, `src/bm25_client.rs` *(`bm25-client`)*
+
+**Responsibility.** A shared, zero-dependency BM25 index + code-aware tokenizer,
+and a UDS client for the per-palace `trusty-bm25-daemon`.
+
+**Key types/modules.** `tokenize` (camelCase/PascalCase/alpha↔digit splits),
+`BM25Index` (incremental insert/update/remove, corpus cap); `Bm25Client`
+(`index`/`search`/`delete` over a fresh `UnixStream` per call).
+
+**Current state.** ✅ `bm25` is pure `std`+`tracing`, ported from open-mpm
+(#156). `bm25_client` is pure tokio/serde; end-to-end coverage lives in
+`trusty-bm25-daemon/tests/`. `rebuild` is intentionally not exposed on the
+client (the dream subprocess calls it directly).
+
+**Known gaps.** None material.
+
+---
+
+## 10. Memory-palace engine — `src/memory_core/` *(`memory-core` + sub-features)*
+
+**Responsibility.** The complete Memory-Palace storage engine consumed by
+`trusty-memory` — data model, layered stores, progressive retrieval, and the
+dream/decay/analytics surfaces. Absorbed from `trusty-memory-core` (#5 phase 2d).
+
+**Key types/modules.**
+- **Model:** `Palace`/`Wing`/`Room`/`Drawer` + `PalaceId` (`palace.rs`),
+  `PalaceRegistry` (`registry.rs`).
+- **Retrieval:** `PalaceHandle` — 4-layer progressive retrieval L0→L3
+  (`retrieval.rs`); process-wide shared `FastEmbedder` `OnceCell` (#57).
+- **Stores (`store/`):** `palace_store` (redb rows), `vector`/`hnsw_store`
+  (HNSW via hnsw_rs), `kg_redb`/`kg_store`/`kg_writer`/`kg` (KnowledgeGraph),
+  `kg_sqlite` (legacy read, `sqlite-kg`), `payload_store` (postcard),
+  `chat_sessions` (redb, #56), `l1_cache`, `kuzu` (`memory-core-kuzu`),
+  `concurrent_open`.
+- **Analytics:** `analytics` (RecallLog, redb #57), `decay`, `dream`,
+  `community` (Louvain on petgraph, #52), `semantic_consolidation`
+  (Mock/Ollama/OpenRouter inference, #87/#222), `git` (git2 history),
+  `embed`, `filter` (content-quality gate, #222).
+
+**Current state.** ✅ All stores migrated SQLite→redb (#43–#47, #56, #57). Auto-
+enables `embedder` + `embedder-bundled-ort`.
+
+**Known gaps.**
+- 🟡 `sqlite-kg` (legacy SQLite read) and `usearch-migrate` (one-shot `.usearch`
+  drain, #51) are transitional, slated for removal once all production palaces
+  upgrade (#47).
+- 🟡 The in-crate `palace.rs`/`retrieval.rs` doc comments still reference
+  `cargo test -p trusty-memory-core` test paths (pre-absorption).
+
+---
+
+## 11. Symbol graph — `src/symgraph/` *(`symgraph` / `-parser` / `-server`)*
+
+**Responsibility.** A tree-sitter symbol-graph engine with a pure-data contracts
+surface separable from the parser (absorbed from `trusty-symgraph`, #5 phase 2c).
+
+**Key types/modules.**
+- **Contracts (`symgraph`):** `EntityType`, `RawEntity`, `EdgeKind`,
+  `fact_hash_str`, tables — pure data, `thiserror`+`sha2`, **no** tree-sitter
+  (`contracts.rs`).
+- **Parser (`symgraph-parser`):** `SymbolGraph`, `SymbolRegistry`, parse →
+  registry → emit + editor primitives, tree-sitter grammars for Rust/Python/JS/
+  TS/Go/Java/C/C++ (`parser.rs`, `registry.rs`, `graph.rs`, `emitter.rs`,
+  `editor.rs`, `symbol.rs`, `strategy.rs`, `locality.rs`).
+- **Server (`symgraph-server`):** HTTP frontend (`server.rs`, implies `axum-server`).
+
+**Current state.** ✅ The contracts/parser split lets non-parser consumers
+(trusty-search, trusty-analyze) take `EntityType`/`RawEntity`/`EdgeKind` without
+the tree-sitter `links` slot.
+
+**Known gaps.** ⚠️ `symgraph-parser` claims `links = "tree-sitter"` — enable in
+**at most one** crate per build graph (typically open-mpm).
+
+---
+
+## 12. Migration kernel — `src/migrations/` *(`migrations`)*
+
+**Responsibility.** One ordered schema-migration runner replacing ad-hoc
+"if schema_version < N" branches (#179).
+
+**Key types/modules.** `SchemaVersion` (u32 newtype, `UNVERSIONED = 0`),
+`Migration<S>` trait (`from_version`/`label`/`apply`), `MigrationRunner` (applies
+pending steps in order, stamps after each); `file_stamp` (atomic JSON sidecar
+`{ "schema_version": N }`), `redb_stamp` (documentation-only recipe so the
+feature adds zero deps).
+
+**Current state.** ✅ Pure `serde`/`anyhow`/`tracing` — no new deps. Tests cover
+runner ordering, crash resumption, write-stamp failure propagation, and the
+file-stamp round-trip.
+
+**Known gaps.** None material; redb-backed stores follow the doc-only recipe
+rather than a shared helper.
+
+---
+
+## 13. Ticketing MCP server — `src/tickets/` *(`tickets`)*
+
+**Responsibility.** One MCP surface over GitHub Issues / JIRA / Linear (absorbed
+from `trusty-tickets`).
+
+**Key types/modules.** `api::config`, `api::models`, `api::client`, the
+`Backend` trait + `backends::{github,jira,linear}`; `server` (MCP dispatch +
+`run_stdio`); `tools` (tool-list schema). Driven by the `tickets-mcp` binary shim
+(`src/bin/tickets_mcp.rs`). Requires `mcp`.
+
+**Current state.** ✅ Module unit tests cover dispatch, tool-list counts, config
+parsing, and serde round-trips.
+
+**Known gaps.** 🟡 Live-backend tests require env-var credentials (not run in CI).
+
+---
+
+## 14. CLI help — `src/help.rs` *(`cli-help`)*
+
+**Responsibility.** One declarative help model + renderer + "did you mean?" so
+all six standalone binaries share a user-facing voice (#216).
+
+**Key types/modules.** `HelpConfig`/`CommandDef`/`FlagDef`/`Example` (parsed from a
+per-binary `help.yaml`, typically `include_str!`-bundled), `load_help`,
+`render_help` (top-level + subcommand), `suggest` (Jaro-Winkler threshold). All
+pure functions — no global state, no I/O. Deps: serde_yaml, strsim, indexmap.
+
+**Current state.** ✅ Tests cover YAML parsing, top-level vs subcommand rendering,
+and the suggester's positive-match / below-threshold-rejection behaviour.
+
+**Known gaps.** None material.
+
+---
+
+## 15. Monitor TUIs — `src/monitor/` *(`monitor-tui`)*
+
+**Responsibility.** Service-specific ratatui dashboards for trusty-search and
+trusty-memory, exposed as a CLI subcommand (not a standalone binary).
+
+**Key types/modules.** `search_tui::run` / `memory_tui::run` (the two ratatui
+apps), `search_client` / `memory_client` (typed HTTP transports), `dashboard`
+(shared wire structs + number formatters), `tui_common`, `utils` (activity log,
+status enum, formatters). Deps: ratatui, crossterm, chrono.
+
+**Current state.** ✅ Began as a unified two-panel dashboard (#31), split into two
+dedicated TUIs for per-index/per-palace depth (#34), and re-homed as the
+`monitor tui` subcommand of each daemon rather than a published binary (#32).
+Tests cover the pure state, rendering, and client pieces.
+
+**Known gaps.** None material.
+
+---
+
+## 16. Setup helpers — `src/claude_config.rs`, `src/project_discovery.rs`, `src/launchd.rs` *(default; launchd macOS-only)*
+
+**Responsibility.** Shared "make this tool installable" plumbing: Claude Code
+config patching, project discovery, and macOS launchd integration (#1, #2, #3,
+#86, #132).
+
+**Key types/modules.**
+- `claude_config.rs` — scan `$HOME` for `.claude/settings*.json`
+  (`SCAN_SKIP_DIRS`), idempotent MCP-server upsert (`mcp_server_entry`), atomic
+  write + backup, `merge_hook_entries`.
+- `project_discovery.rs` — `ClaudeProject` + `discover_claude_projects`
+  (`.claude/`/`CLAUDE.md` markers, depth-3 default).
+- `launchd.rs` — `LaunchdConfig` plist XML rendering, install under
+  `~/Library/LaunchAgents`, `launchctl` bootstrap/bootout; `#[cfg(target_os =
+  "macos")]`.
+
+**Current state.** ✅ Replaced three divergent copies across the daemons. `#132`
+fixed the launchd `serve`-forks-and-exits supervision bug. Filesystem-touching
+tests are `#[ignore]`; pure logic (entry shape, hook idempotency, plist string,
+skip-dir behaviour) is unit-tested.
+
+**Known gaps.** ⚪ macOS-only — no Windows service integration.

--- a/docs/trusty-common/spec/PRD.md
+++ b/docs/trusty-common/spec/PRD.md
@@ -1,0 +1,353 @@
+# trusty-common — Product Requirements Document
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+Each requirement is framed **Vision / Current / Gap**.
+
+---
+
+## 1. Vision & Mission
+
+### North-star vision
+
+> **trusty-common is the single foundational library of the trusty-\* workspace.**
+> Every other trusty-* tool links exactly one internal crate for its shared
+> primitives — protocol envelopes, embeddings, the memory-palace engine, the
+> symbol graph, chat, CLI help, monitoring — and pays **only** for the
+> subsystems it opts into via feature flags. The default build is
+> dependency-light; the heavy subsystems are invisible until enabled.
+
+Where the trusty-* ecosystem once shipped eight separate published micro-crates
+(`trusty-mcp-core`, `trusty-rpc`, `trusty-embedder`, `trusty-symgraph`,
+`trusty-memory-core`, `trusty-tickets`, `trusty-monitor-tui`, plus the base
+utilities), each with its own version, its own `[patch.crates-io]` dance, and its
+own slow drift, trusty-common collapses them into **one heavily feature-gated
+crate** (issue [#5](https://github.com/bobmatnyc/trusty-tools/issues/5)). The
+defining properties are: **a single internal link target** (one `cargo` graph,
+one version to bump for shared code), **pay-for-what-you-use feature gating** (a
+`lexical_only` consumer never compiles ONNX; a chat-only consumer never compiles
+tree-sitter), and **strict library discipline** — pure functions, no global
+state, `thiserror` errors, logs to stderr.
+
+### Mission
+
+Give every trusty-* binary one import surface for the primitives they share, with
+no behavioural drift between consumers, no duplicated bug fixes, and no
+dependency a consumer did not ask for. Keep the crate publishable to crates.io
+(Elastic-2.0) so external consumers can adopt individual subsystems.
+
+### Why this matters
+
+The pre-consolidation world had the *same* `Request`/`Response` MCP envelope, the
+*same* `Embedder` trait, and the *same* launchd plist generator copy-pasted
+across trusty-memory and trusty-search with subtle divergence (cache vs no-cache
+embedders, drifting JSON-RPC error-code types, three different ways to read the
+user's UID). Centralising fixes one bug in one place. Feature-gating keeps the
+centralisation from forcing every consumer to carry every dependency — the design
+tension that originally justified separate crates.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+| # | Goal | Status |
+|---|---|---|
+| G1 | **Single internal shared library** — one crate every trusty-* tool links, replacing seven standalone micro-crates (#5). | ✅ |
+| G2 | **Pay-for-what-you-use feature gating** — every heavy subsystem behind an opt-in feature; default build is `tokio`/`serde`/`reqwest`/`tracing`/`sysinfo`/`dirs` only. | ✅ |
+| G3 | **Shared daemon-lifecycle primitives** — port auto-walk, data-dir resolution, daemon addr file, already-running guard, tracing init. | ✅ |
+| G4 | **Provider-agnostic streaming chat** — `ChatProvider` trait + OpenRouter + Ollama + local auto-detect + tool-use. | ✅ |
+| G5 | **Shared MCP / JSON-RPC primitives** — `Request`/`Response`/error codes/`initialize`/stdio loop/OpenRPC discover (`mcp` feature). | ✅ |
+| G6 | **Shared embedding abstraction** — `Embedder` trait + `FastEmbedder` (all-MiniLM-L6-v2, 384-d) + `MockEmbedder` + Candle backend (`embedder` features). | ✅ |
+| G7 | **Memory-palace storage engine** — palace hierarchy + HNSW vector store + redb KG + retrieval + dream/decay/analytics, consumed by `trusty-memory` (`memory-core`). | ✅ |
+| G8 | **Symbol-graph engine** — tree-sitter parse → registry → emit, with a pure-data contracts surface separable from the parser (`symgraph` / `symgraph-parser`). | ✅ |
+| G9 | **Reusable schema-migration kernel** — `SchemaVersion`/`Migration`/`MigrationRunner` + file-stamp helpers (#179, `migrations`). | ✅ |
+| G10 | **Unified ticketing MCP server** — GitHub/JIRA/Linear backends behind one MCP surface (`tickets`). | ✅ |
+| G11 | **Declarative CLI help system** — YAML-driven `HelpConfig` + canonical renderer + Jaro-Winkler "did you mean?" (#216, `cli-help`). | ✅ |
+| G12 | **Service-specific monitor TUIs** — ratatui dashboards for trusty-search and trusty-memory (#31/#34, `monitor-tui`). | ✅ |
+| G13 | **Unified embedder-client surface** — one `EmbedderClient` trait over in-process / HTTP / UDS / stdio transports for `trusty-embedderd` (#110/#164, `embedder-client`). | ✅ |
+| G14 | **Shared setup helpers** — Claude-config discovery/patching, project discovery, macOS launchd plist generation (#1/#2/#3/#86). | ✅ |
+| G15 | **Publishable to crates.io** — external consumers can adopt individual subsystems via features. | ✅ |
+
+### Non-Goals
+
+| Non-Goal | Rationale |
+|---|---|
+| **Unconditional `axum` / `tower-http` dependency** | The HTTP server stack is gated behind the `axum-server` feature. A library consumer that does not serve HTTP must not pull in the full axum + tower stack (root `CLAUDE.md` hard rule; cf. #226, #249 where downstream crates had to gate axum). |
+| **Reading secrets from the environment inside the library** | Chat helpers (`OpenRouterProvider`) take the API key as an argument; the library **never** reads `OPENROUTER_API_KEY` itself. Env-reading is the binary's job. |
+| **Global mutable state** | All helpers are free functions or small structs. The only `Lazy`/`OnceCell` permitted is the idempotent tracing subscriber (`try_init`) and the process-wide shared `FastEmbedder` `OnceCell` inside `memory-core` (#57). |
+| **`anyhow` in library-facing error surfaces** | Library subsystems define `thiserror` enums (`EmbedderError`, symgraph errors, etc.). `anyhow::Result` is used only in the binary shims (`tickets-mcp`, `candle_metal_bench`) and the few daemon-glue free functions. |
+| **A binary deliverable** | trusty-common is a library (`crate-type = ["rlib"]`). The two `[[bin]]` targets (`tickets-mcp`, `candle_metal_bench`) are feature-gated thin shims, not the product. |
+| **Multiple tree-sitter `links` slots** | `symgraph-parser` claims the `links = "tree-sitter"` native slot; enable it in at most **one** crate per build graph. |
+| **Windows-specific daemon integration** | `launchd` is macOS-only (`#[cfg(target_os = "macos")]`); Windows service integration is not provided. |
+
+---
+
+## 3. Target Users / Personas
+
+trusty-common's users are **other crates**, not end users. Its API surface is
+designed for the consuming binaries below.
+
+| Persona (consumer crate) | What it links | Features it enables |
+|---|---|---|
+| **trusty-search** | embedder-client, symgraph contracts, MCP, RPC, BM25, migrations, server, monitor, setup helpers | `mcp`, `rpc`, `embedder-client`, `bm25`, `symgraph`, `migrations`, `axum-server`, `monitor-tui`, `cli-help` |
+| **trusty-memory** | the entire memory-palace engine, BM25-client, embedder, monitor, setup helpers | `memory-core`, `bm25-client`, `mcp`, `axum-server`, `monitor-tui`, `cli-help` |
+| **open-mpm** | the full symbol-graph parser, chat, MCP | `symgraph-parser`, `mcp` (the single tree-sitter `links` holder) |
+| **trusty-analyze** | symgraph contracts, MCP, setup helpers | `symgraph`, `mcp`, `cli-help`, `axum-server` |
+| **trusty-embedderd** | the embedder + embedder-client wire types | `embedder`, `embedder-client` + an ORT variant |
+| **trusty-mpm / tga / cto-assistant** | chat, MCP, CLI help, utilities | `mcp`, `cli-help`, chat (default) |
+| **External crates.io consumer** | any single subsystem | whatever subset they opt into |
+
+**Unifying need across all consumers:** import the shared primitive, get the
+same behaviour every other consumer gets, and compile **only** the dependencies
+that primitive actually needs.
+
+---
+
+## 4. Functional Requirements
+
+Grouped by subsystem. Each requirement carries Vision / Current / Gap and an
+inline status tag. Source paths are cited where known. Feature flags are noted in
+parentheses.
+
+### 4.1 Core utilities (default features — `src/lib.rs`)
+
+**FR-CORE-1 — Port auto-walk** ✅
+- *Vision:* daemon restarts and concurrent instances should not fail noisily on a
+  busy port.
+- *Current:* `bind_with_auto_port(addr, max_attempts)` walks forward through
+  ports on `AddrInUse`, returning the first listener that binds
+  (`src/lib.rs:283`). `max_attempts == 0` tries the requested port exactly once.
+- *Gap:* none material.
+
+**FR-CORE-2 — OS-standard data directory** ✅
+- *Vision:* one per-app, per-machine data dir resolved identically across tools
+  and platforms.
+- *Current:* `resolve_data_dir(app_name)` resolves `~/Library/Application
+  Support/<app>` (macOS), `~/.local/share/<app>` (Linux), with a `~/.<app>`
+  fallback, creating the directory (`src/lib.rs:352`). The
+  `TRUSTY_DATA_DIR_OVERRIDE` env var is a documented **test-only** escape hatch,
+  needed because macOS's `dirs::data_dir()` bypasses `HOME`/`XDG_DATA_HOME` via
+  `NSFileManager`.
+- *Gap:* Windows paths are unverified in CI.
+
+**FR-CORE-3 — Daemon address file + already-running guard** ✅
+- *Vision:* MCP clients and follow-up CLI calls must discover where an
+  auto-port-walked daemon landed, and a second `start` must refuse to spawn a
+  duplicate.
+- *Current:* `write_daemon_addr` / `read_daemon_addr` persist `host:port` to
+  `<data_dir>/http_addr`; `probe_health` + `check_already_running` probe the
+  recorded address for a 2xx `/health` within ~1.5 s and best-effort delete a
+  stale file (`src/lib.rs:390`–`490`).
+- *Gap:* none material.
+
+**FR-CORE-4 — Colour control + dir shim** ✅
+- *Current:* `maybe_disable_color` honours `NO_COLOR`/`TERM=dumb`/`--no-color`;
+  `is_dir` is a clarity shim (`src/lib.rs:589`, `:809`).
+
+### 4.2 Tracing & logging (default — `src/lib.rs`, `src/log_buffer.rs`)
+
+**FR-LOG-1 — Verbosity-laddered tracing to stderr** ✅
+- *Vision:* every binary shares one verbosity ladder and `RUST_LOG` override, and
+  logs **never** corrupt MCP stdout framing.
+- *Current:* `init_tracing(verbose_count)` maps `0→warn,1→info,2→debug,3+→trace`,
+  honours `RUST_LOG`, writes to stderr, and uses `try_init` so it is idempotent
+  across test binaries (`src/lib.rs:504`).
+- *Gap:* none.
+
+**FR-LOG-2 — In-memory log ring for `/logs/tail`** ✅
+- *Current:* `init_tracing_with_buffer` adds a `LogBufferLayer` feeding a capped
+  `LogBuffer` (`VecDeque<String>`), filtered independently via `RUST_LOG_BUFFER`
+  (default `info`) so lifecycle events reach the buffer even at stderr `warn`
+  (`src/lib.rs:538`, `src/log_buffer.rs`).
+
+**FR-LOG-3 — Process RSS/CPU sampling** ✅
+- *Current:* `SysMetrics` (sysinfo, scoped to current PID) returns `(rss_mb,
+  cpu_pct)` for `/health`; first sample reports `0.0` CPU (delta-based)
+  (`src/sys_metrics.rs`).
+
+### 4.3 Chat / OpenRouter (default — `src/chat.rs`, `src/lib.rs`)
+
+**FR-CHAT-1 — Provider-agnostic streaming chat with tool-use** ✅
+- *Vision:* support cloud (OpenRouter) and local (Ollama/LM Studio) LLMs behind
+  one trait, including OpenAI-style function calling.
+- *Current:* `ChatProvider` trait + `OpenRouterProvider` + `OllamaProvider` (both
+  speak OpenAI-compatible `/v1/chat/completions` SSE), `ChatEvent` /
+  `ToolDef` / `ToolCall` tool-use types, and `auto_detect_local_provider`
+  (probes `/v1/models` with a 1 s timeout) (`src/chat.rs`).
+- *API-key contract:* the key is passed to `OpenRouterProvider::new`; the library
+  never reads it from the environment.
+- *Gap:* the legacy free functions `openrouter_chat` / `openrouter_chat_stream`
+  are **deprecated** (since 0.3.1) in favour of `OpenRouterProvider::chat_stream`
+  (`src/lib.rs:664`, `:720`) — 🟡 retained for back-compat.
+
+### 4.4 MCP / JSON-RPC primitives (`mcp` — `src/mcp/`)
+
+**FR-MCP-1 — Shared JSON-RPC 2.0 / MCP envelopes** ✅
+- *Current:* `Request` / `Response` / `JsonRpcError` envelopes, `error_codes`
+  (spec-canonical i32 constants), `initialize_response`, an async
+  `run_stdio_loop`, and OpenRPC `rpc.discover` helpers (`src/mcp/mod.rs`,
+  `openrpc.rs`, `service.rs`). Pulls in no deps beyond `serde`/`tokio`.
+
+### 4.5 RPC client (`rpc` — `src/rpc/`)
+
+**FR-RPC-1 — General-purpose JSON-RPC client + transports** ✅
+- *Current:* `RpcClient` + `Transport` trait + `StdioTransport` (subprocess) +
+  `HttpTransport`, `new_id` (UUID-v4), `extract_result`, and pretty-printers
+  (`print_json`, `print_tools_list`, …) (`src/rpc/`). Requires `uuid`.
+
+### 4.6 Embedder (`embedder` + variants — `src/embedder/`)
+
+**FR-EMB-1 — Shared embedding abstraction** ✅
+- *Vision:* one `Embedder` trait + production `FastEmbedder` so trusty-memory and
+  trusty-search stop shipping divergent copies.
+- *Current:* async `Embedder` trait (`embed_batch` primitive), `FastEmbedder`
+  (fastembed-rs, all-MiniLM-L6-v2 INT8, 384-d) with LRU cache + ORT warmup,
+  `MockEmbedder` (`embedder-test-support`), and a Candle Metal/CPU backend
+  (`embedder-candle`, #54) (`src/embedder/mod.rs`, `candle_embedder.rs`,
+  `rss.rs`).
+- *ORT variants:* `embedder-bundled-ort` (macOS/modern Linux),
+  `embedder-cuda`, `embedder-load-dynamic` (AL2023/glibc < 2.38);
+  `embedder-coreml` is a deprecated no-op (CoreML is auto-detected).
+- *Gap:* ONNX-backed tests are `#[ignore]` (CI-fast); CoreML safety required a
+  double opt-in hardening (#85).
+
+**FR-EMB-2 — Unified embedder-client transports** ✅
+- *Vision:* one client trait over every `trusty-embedderd` deployment mode.
+- *Current:* `embedder-client` exposes `EmbedderClient` + `InProcessEmbedderClient`,
+  `RemoteEmbedderClient` (HTTP), `UdsEmbedderClient` (UDS), `StdioEmbedderClient`,
+  and `EmbedderSupervisor` (auto-spawn lifecycle) (`src/embedder_client/`).
+  Consolidated the former `trusty-embedder-client` + `embed_client` (#110, #164).
+
+### 4.7 BM25 lexical (`bm25` / `bm25-client` — `src/bm25.rs`, `src/bm25_client.rs`)
+
+**FR-BM25-1 — Zero-dependency BM25 index + code-aware tokenizer** ✅
+- *Current:* `tokenize` (camelCase/PascalCase/alpha↔digit splits) + incremental
+  `BM25Index` keyed by opaque string ids, pure `std`+`tracing`, ported from
+  open-mpm (#156) (`src/bm25.rs`).
+
+**FR-BM25-2 — UDS client for per-palace BM25 daemon** ✅
+- *Current:* `Bm25Client` opens a fresh `UnixStream` per call, newline-framed
+  JSON-RPC (`index`/`search`/`delete`); end-to-end coverage in
+  `trusty-bm25-daemon` (`src/bm25_client.rs`).
+
+### 4.8 Memory-palace engine (`memory-core` — `src/memory_core/`)
+
+**FR-MEM-1 — Palace data model + storage + retrieval** ✅
+- *Vision:* the entire Memory-Palace storage engine, consumed by `trusty-memory`,
+  living behind one feature so chat/MCP-only consumers pay nothing (#5 phase 2d).
+- *Current:* the 5-level hierarchy (`Palace`/`Wing`/`Room`/`Drawer`,
+  `src/memory_core/palace.rs`), `PalaceRegistry`, `PalaceHandle` 4-layer
+  progressive retrieval (L0 identity → L1 essential → L2 vector → L3 deep,
+  `retrieval.rs`), the storage backends (HNSW vector store, redb KG, payload
+  store, chat-session store, L1 cache — `store/`), and dream/decay/analytics/
+  community/semantic-consolidation/git-history surfaces. Storage migrated off
+  SQLite to redb (#43–#47, #56, #57); a process-wide shared `FastEmbedder`
+  `OnceCell` (#57) avoids forking model instances.
+- *Sub-features:* `memory-core-kuzu` (read-only kuzu graph), `usearch-migrate`
+  (one-shot `.usearch` drain, #51), `sqlite-kg` (legacy SQLite read path for
+  migration, #47).
+- *Gap:* `sqlite-kg` / `usearch-migrate` are 🟡 transitional and slated for
+  removal once all production palaces are upgraded.
+
+### 4.9 Symbol graph (`symgraph` / `symgraph-parser` / `symgraph-server` — `src/symgraph/`)
+
+**FR-SYM-1 — Pure-data contracts surface** ✅
+- *Current:* `symgraph` exposes only `EntityType`/`RawEntity`/`EdgeKind`/
+  `fact_hash_str`/tables — no tree-sitter, no `links` conflict
+  (`src/symgraph/contracts.rs`).
+
+**FR-SYM-2 — Full tree-sitter parser + emitter + editor** ✅
+- *Current:* `symgraph-parser` adds `SymbolGraph`/`SymbolRegistry`/parse → registry
+  → emit + editor primitives, tree-sitter grammars for Rust/Python/JS/TS/Go/
+  Java/C/C++; `symgraph-server` adds the HTTP frontend (implies `axum-server`).
+- *Constraint:* claims `links = "tree-sitter"` — enable in at most one crate per
+  build graph (typically open-mpm).
+
+### 4.10 Migrations (`migrations` — `src/migrations/`)
+
+**FR-MIG-1 — Reusable schema-migration kernel** ✅
+- *Vision:* replace the ad-hoc "if schema_version < N" branches across
+  trusty-search/trusty-memory with one ordered runner (#179).
+- *Current:* `SchemaVersion` (u32, `UNVERSIONED = 0`), `Migration<S>` trait,
+  `MigrationRunner` (applies pending steps in order, stamps after each),
+  `file_stamp` (atomic JSON sidecar), and `redb_stamp` (documentation-only recipe
+  so the feature adds zero deps) (`src/migrations/`).
+
+### 4.11 Tickets (`tickets` — `src/tickets/`)
+
+**FR-TKT-1 — Unified ticketing MCP server** ✅
+- *Current:* `tickets::api::*` (config, models, `Backend` trait + GitHub/JIRA/
+  Linear backends), `tickets::server` (MCP dispatch + `run_stdio`),
+  `tickets::tools` (tool-list schema); the `tickets-mcp` binary shim drives it
+  (requires `mcp`) (`src/tickets/`, `src/bin/tickets_mcp.rs`).
+- *Gap:* live-backend tests require env-var credentials.
+
+### 4.12 CLI help (`cli-help` — `src/help.rs`)
+
+**FR-HELP-1 — Declarative help + "did you mean?"** ✅
+- *Current:* `HelpConfig`/`CommandDef`/`FlagDef`/`Example` parsed from a per-binary
+  `help.yaml` (typically `include_str!`-bundled), `render_help`, and a
+  Jaro-Winkler `suggest` for mistyped subcommands; all pure functions (#216)
+  (`src/help.rs`).
+
+### 4.13 Monitor TUI (`monitor-tui` — `src/monitor/`)
+
+**FR-MON-1 — Service-specific TUIs** ✅
+- *Current:* `search_tui` + `memory_tui` (ratatui apps), `search_client` +
+  `memory_client` (typed HTTP transports), shared `dashboard`/`utils`. Began as a
+  unified dashboard (#31), split into two dedicated TUIs (#34), exposed as a CLI
+  subcommand rather than a standalone binary (#32) (`src/monitor/`).
+
+### 4.14 Setup helpers (default + macOS — `src/claude_config.rs`, `src/project_discovery.rs`, `src/launchd.rs`)
+
+**FR-SETUP-1 — Claude-config discovery + idempotent patching** ✅
+- *Current:* scan `$HOME` for `.claude/settings*.json`, idempotent MCP-server
+  upsert, atomic write + backup, hook merging (#1, #2, #3, #86)
+  (`src/claude_config.rs`).
+
+**FR-SETUP-2 — Claude project discovery** ✅
+- *Current:* `ClaudeProject` + `discover_claude_projects` walk
+  (`.claude/`/`CLAUDE.md` markers, depth-3 default) (`src/project_discovery.rs`).
+
+**FR-SETUP-3 — macOS launchd LaunchAgent** ✅
+- *Current:* `LaunchdConfig` renders plist XML, installs under
+  `~/Library/LaunchAgents`, bootstraps/bootouts via `launchctl`; `#[cfg(macos)]`
+  only (#132 fixed the `serve`-forks-and-exits supervision bug)
+  (`src/launchd.rs`).
+
+---
+
+## 5. Success Criteria & Differentiators
+
+| Criterion | Target | Status |
+|---|---|---|
+| **Default build is dependency-light** | Only `tokio`/`serde`/`reqwest`/`tracing`/`sysinfo`/`dirs`/`colored`/`futures-util` on `default = []`. | ✅ |
+| **No unconditional axum** | `cargo tree -p trusty-common` (default) shows no `axum`. | ✅ |
+| **One version to bump for shared code** | Single `version` field (0.8.0); consumers update one pin. | ✅ |
+| **Behavioural parity across consumers** | Both daemons share one `Embedder`, one MCP envelope, one launchd generator. | ✅ |
+| **Feature isolation compiles** | `cargo check -p trusty-common` (default) passes; each feature builds independently. | ✅ |
+| **Publishable** | Released to crates.io under Elastic-2.0; external single-subsystem adoption supported. | ✅ |
+
+**Differentiators vs. a generic "utils" crate:** trusty-common is not a grab-bag —
+it is a *consolidation* of formerly-published crates behind a disciplined
+feature-flag matrix, so the consolidation never forces a consumer to carry an
+unwanted dependency. The same crate ships a chat client, an ONNX embedder, a
+tree-sitter symbol graph, a redb memory engine, and a ratatui TUI without any one
+consumer paying for all of them.
+
+---
+
+## 6. Open Questions / Roadmap
+
+| # | Question | Notes |
+|---|---|---|
+| OQ-1 | When can `sqlite-kg` / `usearch-migrate` be removed? | Once all production palaces have drained legacy SQLite/`.usearch` files (#47, #51). 🟡 |
+| OQ-2 | Reconcile `embed_client` vs `embedder_client` naming fully? | #164 retired `embed-client`; residual naming reconciliation tracked there. 🟡 |
+| OQ-3 | Stale crate README / version pins | `crates/trusty-common/README.md` still says v0.3 and omits five features; #430 tracks the broader inventory reconciliation. 🟡 |
+| OQ-4 | Windows daemon support | `launchd` is macOS-only; no Windows service path. ⚪ |
+| OQ-5 | Remove deprecated `openrouter_chat*` free functions | Deprecated since 0.3.1 in favour of `OpenRouterProvider`; a future major can drop them. 🔵 |

--- a/docs/trusty-common/spec/README.md
+++ b/docs/trusty-common/spec/README.md
@@ -1,0 +1,98 @@
+# trusty-common — Specification Set
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+This directory holds the canonical product and engineering specification for the
+`trusty-common` crate (`crates/trusty-common/`). It is the single authoritative
+reference for *what trusty-common is meant to be*, *what it is today*, and *what
+gaps remain*.
+
+## What is trusty-common?
+
+`trusty-common` is the **foundational shared library of the trusty-\* workspace**:
+the one internal crate every other trusty-* tool links. It started as a thin bag
+of utilities (port-walking, data-dir resolution, tracing init, an OpenRouter chat
+helper) and, under the workspace-consolidation effort (issue
+[#5](https://github.com/bobmatnyc/trusty-tools/issues/5)), **absorbed seven
+formerly standalone micro-crates** — `trusty-mcp-core`, `trusty-rpc`,
+`trusty-embedder`, `trusty-symgraph`, `trusty-memory-core`, `trusty-tickets`, and
+`trusty-monitor-tui` — into one heavily **feature-gated** crate. The headline
+guarantee: **the default build is dependency-light** (`tokio`, `serde`,
+`reqwest`, `tracing`, `sysinfo`, `dirs`), and every heavy subsystem (ONNX
+embedder, tree-sitter symbol graph, redb/HNSW memory engine, axum HTTP stack,
+ratatui TUI) is gated behind an opt-in feature so a consumer pays only for what it
+imports.
+
+Everything here is a **library**: pure free functions and small helper structs,
+**no global state** except the idempotent tracing subscriber, `thiserror` error
+enums (not `anyhow`) for the library-facing surfaces, and logs always to
+**stderr** so stdout stays clean for MCP JSON-RPC framing. It is edition 2021,
+licensed Elastic-2.0, and currently at version **0.8.0**.
+
+## Documents in this set
+
+| Document | Read it when you want to know… |
+|---|---|
+| **[PRD.md](./PRD.md)** | The product: vision & mission (the shared foundation + the consolidation of seven micro-crates), goals/non-goals (no unconditional axum dep, pure functions, no global state, API keys passed in not read from env), the personas (the *other* crates are the users), the full functional-requirement catalog grouped by subsystem (core utilities, tracing/logging, chat/OpenRouter, MCP, RPC, embedder, embedder-client, BM25, memory-core, symgraph, migrations, tickets, help, monitor, setup/launchd) and tagged by status, success criteria, and open questions. Start here for *why* and *what*. |
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | The system shape: the **feature-flag model** (the full dependency-gating matrix), how `memory-core` is consumed by `trusty-memory`, the chat-helper design (API key passed in, never read from env in lib), tracing-to-stderr, the `thiserror`-vs-`anyhow` error convention, and the single tree-sitter `links =` slot constraint. Includes the source-module map with `src/` citations. Start here for *how it fits together*. |
+| **[COMPONENTS.md](./COMPONENTS.md)** | Per-module specs: every subsystem (utilities, tracing/log-buffer, sys-metrics, chat, MCP, RPC, embedder, embedder-client, BM25, BM25-client, memory-core, symgraph, migrations, tickets, help, monitor, setup helpers). Each states responsibility, key types (with `src/` paths), current state, and known gaps. Start here for *the detail of one subsystem*. |
+
+## Reading order
+
+1. **New to trusty-common?** PRD → ARCHITECTURE → COMPONENTS.
+2. **Adding a feature to one subsystem?** Jump to the relevant COMPONENTS
+   section, then cross-check the feature-flag matrix in ARCHITECTURE.
+3. **Deciding whether to add a dependency?** ARCHITECTURE feature-flag model +
+   the Non-Goals in PRD §2.
+
+## Status legend (used throughout this set)
+
+Every requirement and component is framed as **Vision / Current / Gap** and
+tagged inline with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, RFC, or plan) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+## Related documentation
+
+This `spec/` set is the *what/why/gap* layer. The point-in-time and operational
+docs live alongside it:
+
+- **[../decisions/](../decisions/)** — Architecture Decision Records (Nygard
+  format). [`0001-consolidate-library-micro-crates.md`](../decisions/0001-consolidate-library-micro-crates.md)
+  captures the issue-#5 absorption of seven standalone crates behind feature
+  flags.
+- **[../research/](../research/)** — dated investigations and decision documents.
+- **[../regression-testing/](../regression-testing/)** — versioned performance
+  snapshots.
+- **[../sessions/](../sessions/)** — engineering-session narratives.
+- **[crates/trusty-common/README.md](../../../crates/trusty-common/README.md)** —
+  in-crate quick-start, feature-flag table, and usage snippets.
+
+## Provenance & maintenance
+
+These documents are derived from an audit of the `crates/trusty-common/src/`
+tree (93 source files across 17 feature-gated subsystems as of v0.8.0), the crate
+`README.md` and `Cargo.toml` `[features]` table, the root `CLAUDE.md`
+conventions, and the open/closed issue backlog — notably the consolidation
+tracker [#5](https://github.com/bobmatnyc/trusty-tools/issues/5), the migration
+kernel [#179](https://github.com/bobmatnyc/trusty-tools/issues/179), the CLI-help
+system [#216](https://github.com/bobmatnyc/trusty-tools/issues/216), the
+embedder-process split [#110](https://github.com/bobmatnyc/trusty-tools/issues/110),
+and the monitor-TUI consolidation [#31](https://github.com/bobmatnyc/trusty-tools/issues/31)
+/ [#34](https://github.com/bobmatnyc/trusty-tools/issues/34). When the code
+changes materially, update the relevant document and bump the *Last reviewed*
+date. Source-path citations reflect the layout at the time of review.
+
+> **Note on in-crate `README.md` drift:** the crate-local
+> `crates/trusty-common/README.md` predates several absorptions — it documents the
+> crate at version `0.3` and omits the `memory-core`, `monitor-tui`,
+> `embedder-client`, `tickets`, and `cli-help` features that the audited
+> `Cargo.toml` (v0.8.0) actually ships. This spec set reflects the audited tree,
+> not the stale README header.


### PR DESCRIPTION
Canonical spec set (PRD/ARCHITECTURE/COMPONENTS + README) under docs/trusty-common/spec/, open-mpm style (Vision/Current/Gap, ✅/🟡/🔵/⚪). ADR documents the issue-#5 consolidation of 7 former micro-crates (trusty-mcp-core/rpc/embedder/symgraph/memory-core/tickets/monitor-tui) behind feature flags (default=[]). cargo check -p trusty-common passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)