### PR TITLE
docs(trusty-analyze): canonical spec set

### DIFF
--- a/docs/trusty-analyze/README.md
+++ b/docs/trusty-analyze/README.md
@@ -15,6 +15,8 @@ published trusty-* crates:
 
 | Subdir | Contents |
 |--------|----------|
+| [`spec/`](spec/) | **Canonical specification set** — the single source of truth for *what trusty-analyze is meant to be, is today, and is missing*: [README](spec/README.md) (index + status legend), [PRD](spec/PRD.md), [ARCHITECTURE](spec/ARCHITECTURE.md), [COMPONENTS](spec/COMPONENTS.md). |
+| [`decisions/`](decisions/) | Evidenced design-decision records (ADR-style). |
 | [`research/`](research/) | Investigation docs and audits: [trustee/search code-analysis summary](research/trustee_search_code_analysis_summary.md), plus the source `code_search_analysis.docx`. |
 | [`regression-testing/`](regression-testing/) | Versioned performance/quality snapshots, baseline measurements. (None authored yet.) |
 | [`sessions/`](sessions/) | Engineering-session summaries — narrative + reasoning. (None authored yet.) |

--- a/docs/trusty-analyze/decisions/0001-gate-axum-behind-http-server-feature-2026-05-26.md
+++ b/docs/trusty-analyze/decisions/0001-gate-axum-behind-http-server-feature-2026-05-26.md
@@ -1,0 +1,51 @@
+# 0001 — Gate axum/tower-http behind an `http-server` cargo feature
+
+> **Status:** Accepted
+> **Date:** 2026-05-26
+> **Decided in:** issue [#249](https://github.com/bobmatnyc/trusty-tools/issues/249), PR [#262](https://github.com/bobmatnyc/trusty-tools/pull/262)
+> **Last reviewed:** 2026-05-29
+
+## Context
+
+`trusty-analyze` ships a single crate that is simultaneously a binary (HTTP
+daemon + MCP HTTP/SSE), a stdio MCP server, and a library of analysis
+primitives. axum + tower-http are heavyweight HTTP-server-only dependencies. A
+downstream consumer that only wants the analysis core, the wire types, or the
+pure JSON-RPC dispatcher should not be forced to compile the entire axum + tower
+stack — the same concern already solved in `trusty-common` (`axum-server`
+feature) and `trusty-memory`.
+
+## Decision
+
+Introduce an `http-server` cargo feature (default-on) that gates:
+
+- `dep:axum` and `dep:tower-http`,
+- the `trusty-common/axum-server` feature,
+- the `service` module (axum HTTP daemon), and
+- the `mcp::sse` HTTP/SSE transport.
+
+The `trusty-analyze` binary declares `required-features = ["http-server"]`. The
+stdio MCP transport (`mcp::stdio`) stays **unconditional**, since Claude Code and
+similar clients spawn the dispatcher as a subprocess and only need stdio.
+Library consumers opt out of the HTTP stack with `--no-default-features`.
+
+## Consequences
+
+- **Positive:** `cargo install trusty-analyze`, `cargo test -p trusty-analyze`,
+  and the default daemon build are unchanged (feature is default-on). Library
+  consumers can drop axum entirely. The rule is consistent across the workspace
+  (`trusty-common`, `trusty-memory`, `trusty-analyze`).
+- **Negative:** module visibility now depends on a feature flag — `service` and
+  `mcp::sse` only exist under `http-server`, so any code referencing them must be
+  similarly gated (see the `#[cfg(feature = "http-server")]` annotations in
+  `src/lib.rs` and `src/mcp/mod.rs`).
+
+## Evidence
+
+- `crates/trusty-analyze/Cargo.toml` — `[features]` block with the
+  `http-server` definition and the `[[bin]]` `required-features` entry, both
+  carrying `# Why (issue #249)` comments.
+- `crates/trusty-analyze/src/lib.rs` — `#[cfg(feature = "http-server")] pub mod service;`.
+- `crates/trusty-analyze/src/mcp/mod.rs` — `#[cfg(feature = "http-server")] pub mod sse;`.
+- Commit `48545cc` "fix(trusty-analyze,trusty-embedderd): gate axum behind
+  feature flags (closes #249 #250) (#262)".

--- a/docs/trusty-analyze/spec/ARCHITECTURE.md
+++ b/docs/trusty-analyze/spec/ARCHITECTURE.md
@@ -1,0 +1,244 @@
+# trusty-analyze — Architecture
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+This document describes *how trusty-analyze fits together*. Components are framed
+**Vision / Current / Gap** and tagged ✅ / 🟡 / 🔵 / ⚪ (see
+[README](./README.md#status-legend-used-throughout-this-set)).
+
+---
+
+## 1. System Topology
+
+trusty-analyze is a **sidecar daemon**. It owns no corpus; it fetches chunks
+from `trusty-search` over HTTP and computes analysis in-process.
+
+```
+┌──────────────────────────┐        HTTP/2 (loopback)        ┌────────────────────────────┐
+│   trusty-search (7878)    │   GET /indexes/:id/chunks       │   trusty-analyze (7879)      │
+│   - BM25 + vector + KG    │ ◄────────── paged corpus ────── │   core/   analysis engines   │
+│   - authoritative corpus  │   GET /indexes                  │   lang/   tree-sitter adapters│
+│   - GET /health           │ ◄────────── proxied ──────────  │   service/ axum HTTP API      │
+└──────────────────────────┘                                 │   mcp/    stdio + HTTP/SSE    │
+        ▲  hard dependency                                    │   embedder/ BoW | neural     │
+        │  (startup health check)                             │   redb facts store (owned)   │
+        └─────────────────────────────────────────────────── │   /ui embedded dashboard     │
+                                                              └────────────────────────────┘
+```
+
+### Hard runtime dependency (✅)
+
+**Vision:** the analyzer is meaningless without a corpus to analyze.
+**Current:** every corpus-touching command (`serve`, `review`, `review-pr`)
+performs a single `GET <search-url>/health` probe before binding a port or
+opening redb; failure prints a clear message and exits 1 (`main.rs`). There is
+no offline mode.
+**Gap:** none — this is intentional (`CLAUDE.md` "Hard Runtime Dependency").
+
+### Dependency direction (✅)
+
+```
+trusty-search  ──►  trusty-common  (shared wire types)
+trusty-analyze ──►  trusty-common  (shared wire types; features = symgraph, cli-help, axum-server)
+trusty-analyze ──HTTP──►  trusty-search  (chunk corpus at runtime)
+```
+
+`trusty-common` must never depend on either daemon. Note: the crate-local
+`CLAUDE.md` describes `trusty-common` as living *inside* the analyze workspace;
+post-consolidation it is a sibling workspace crate (`crates/trusty-common/`).
+
+---
+
+## 2. Single-Crate Module Layout
+
+The crate was collapsed from a nested multi-crate workspace into **one
+publishable crate** (`lib.rs` docstring; issue #5). Each former crate is now a
+top-level module re-exporting its old public API.
+
+| Module | Responsibility | Key paths |
+|---|---|---|
+| `core/` | Analysis engines + the trusty-search HTTP client | `core/mod.rs` |
+| `lang/` | `LanguageAnalyzer` trait, detection, 14 tree-sitter adapters | `lang/mod.rs`, `lang/adapters/` |
+| `embedder/` | BoW + neural embedding backends | `embedder/mod.rs` |
+| `mcp/` | MCP server: dispatcher + stdio + HTTP/SSE transports | `mcp/mod.rs` |
+| `service/` | axum HTTP daemon + embedded UI (feature-gated) | `service/mod.rs`, `service/ui.rs` |
+| `types/` | serde wire-format types shared across the HTTP/MCP boundary | `types/mod.rs` |
+| `commands/` | CLI subcommand handlers (daemon lifecycle, service, setup) | `commands/` |
+
+### `core/` submodule map
+
+| Submodule | Role |
+|---|---|
+| `client.rs` | HTTP/2 client to trusty-search; paged chunk fetch |
+| `complexity.rs` | Text-heuristic complexity + `compute_complexity_for` dispatcher |
+| `complexity_ts.rs` | tree-sitter AST complexity for Rust / TS / JS |
+| `quality.rs` | Corpus aggregation: `QualityReport`, hotspots, smelly chunks |
+| `blame.rs` | Temporal-decay scoring over `ChunkBlame` (pure, no `git` shell-out) |
+| `concept_cluster.rs` | k-means + BoW embedding helper |
+| `facts.rs` | redb `FactStore`, stable `xxh3` fact hash |
+| `linker.rs` | Cross-chunk KgNode deduplication |
+| `scip.rs` | SCIP protobuf → `KgGraph` |
+| `registry.rs` | `AnalyzerRegistry` dispatching chunks to language adapters |
+| `tools.rs` / `tool_registry.rs` / `tool_impls/` | External-linter plugin trait, discovery, 10 adapters |
+| `refactor.rs` | Rule-engine refactor suggestions |
+| `review.rs` | Unified-diff review + index cross-reference |
+| `explain.rs` | LLM deep-analysis (`DeepAnalysisReport`) |
+| `github.rs` | PR diff fetch, comment post, markdown render, webhook HMAC |
+| `ner.rs` | Optional ONNX NER over doc comments |
+
+---
+
+## 3. Analysis Pipeline
+
+```
+1. Fetch     GET /indexes/:id/chunks  ─► Vec<CodeChunk>      (core/client.rs)
+2. Complexity compute_complexity_for(content, lang)          (core/complexity*.rs)
+               ├─ rust/ts/js → tree-sitter AST walk
+               └─ else / parse-fail → text heuristic (fallback)
+3. Smells     threshold rules (LongFunction/DeepNesting/…)   (types/complexity.rs)
+4. Grade      A–F per chunk → QualityReport per index         (core/quality.rs)
+5. Graph      registry.analyze(&chunks) → per-lang KgGraph    (core/registry.rs, lang/)
+6. Link       merge duplicate nodes across windows            (core/linker.rs)
+7. Cluster    k-means over BoW/neural embeddings              (core/concept_cluster.rs)
+8. Refactor   complexity+smells → suggestions                 (core/refactor.rs)
+9. Review     parse diff, cross-ref corpus → ReviewReport     (core/review.rs)
+10. Serve     axum HTTP + MCP (stdio/SSE) → JSON              (service/, mcp/)
+```
+
+### AST substrate + fallback (✅)
+
+**Vision:** accurate, line-anchored complexity, not substring counting.
+**Current:** `compute_complexity_for` dispatches on language: Rust/TS/JS get a
+tree-sitter AST walk (`complexity_ts.rs`) that counts each branching node once
+(cyclomatic) and weights by nesting depth (cognitive); all other languages or
+any parse failure fall back to the dependency-free text heuristic
+(`complexity.rs`). The 14 structural adapters in `lang/adapters/` each own their
+grammar walk for graph extraction.
+**Gap:** AST-accurate complexity is Rust/TS/JS-only; other languages use the
+heuristic for the *complexity number* even though they have full structural
+adapters for the *graph*.
+
+### Knowledge-graph schema + linker (✅)
+
+`types/graph.rs` defines a language-neutral `KgGraph`. Because trusty-search
+chunks are overlapping ~40-line windows, the same symbol appears in several
+chunks; `core/linker.rs::link` collapses duplicates by
+`(language, kind, qualified_name)`, keeps the widest line range, rewires edges to
+the canonical id, and drops resulting self-loops. SCIP ingest (`core/scip.rs`)
+produces the same `KgGraph` shape from precise indexer output, complementing the
+heuristic adapters with resolved cross-file references.
+
+---
+
+## 4. Surfaces & Framing
+
+### MCP framing (✅) — stdout reserved
+
+**Vision:** an MCP client gets the same capability surface as a curl user.
+**Current:** `mcp/mod.rs` holds the JSON-RPC dispatcher (18 tools). Two
+transports share it:
+- **stdio** (`mcp/stdio.rs`): line-delimited JSON-RPC over stdin/stdout; one
+  object per line; notifications suppressed; parse errors returned with `id=null`.
+- **HTTP/SSE** (`mcp/sse.rs`, feature-gated): `POST /mcp` synchronous JSON-RPC +
+  `GET /mcp/sse` long-lived stream with a `ready` event and 15s keep-alive pings.
+
+`main.rs` installs `trusty_common::init_tracing(1)`, routing **all logs to
+stderr** so stdout carries only JSON-RPC framing. This fixed the #66 corruption
+where a `TraceLayer` error wrote to stdout. **Gap:** none.
+
+### HTTP daemon (✅)
+
+`service/mod.rs` builds an axum router (~20 routes) on port 7879 (auto-increments
+if busy). Endpoint groups: health/index proxy, complexity/smells/quality,
+diagnostics/graph/entities/clusters/ner, SCIP ingest, review/deep/webhook, facts
+CRUD, and the embedded UI (`/ui`, rust-embed via `service/ui.rs`). Strict
+**parity** with the 18 MCP tools.
+
+### `http-server` feature gate (✅)
+
+**Vision:** library consumers shouldn't pull in axum + tower-http just to use
+the dispatcher or CLI types.
+**Current (#249):** the `http-server` feature (default-on) gates `dep:axum`,
+`dep:tower-http`, `trusty-common/axum-server`, the `service` module, and
+`mcp::sse`. The `trusty-analyze` binary lists it as a `required-feature`; stdio
+MCP stays unconditional. `--no-default-features` drops the HTTP stack.
+**Gap:** none — mirrors the `trusty-common` / `trusty-memory` rule.
+
+---
+
+## 5. Persistence & State
+
+- **Facts store (✅):** the *only* state the analyzer owns. redb table
+  `fact_id(u64) → JSON(FactRecord)`; `fact_id` is a length-prefixed `xxh3` hash
+  of the triple — stable across toolchains (replaced `DefaultHasher`, issue #64).
+  Path is `--facts-path` (default `trusty-analyze.facts.redb`,
+  env `TRUSTY_ANALYZER_FACTS`). #67 fixed a read-lock contention spike in
+  `list_facts`.
+- **No corpus state (✅):** chunks, blame, and call chains are fetched live from
+  trusty-search; the analyzer never opens trusty-search's redb files.
+- **PID file (✅):** `start`/`stop`/`status` use a PID file under
+  `~/.trusty-analyze/` (`commands/daemon.rs`).
+- **Embedding model cache (🟡):** neural embedder loads fastembed from
+  `--fastembed-cache` (default `.fastembed_cache`, env `TRUSTY_FASTEMBED_CACHE`);
+  load failure is non-fatal and degrades to BoW.
+
+---
+
+## 6. Configuration
+
+| Variable / flag | Default | Purpose |
+|---|---|---|
+| `--search-url` / `TRUSTY_SEARCH_URL` | `http://127.0.0.1:7878` | trusty-search daemon address |
+| `--port` / `TRUSTY_ANALYZER_PORT` | `7879` | Analyzer listen port (auto-increments if busy) |
+| `--facts-path` / `TRUSTY_ANALYZER_FACTS` | `trusty-analyze.facts.redb` | redb facts file |
+| `--fastembed-cache` / `TRUSTY_FASTEMBED_CACHE` | `.fastembed_cache` | Neural model cache dir |
+| `--mcp` | off | Run MCP stdio loop in the `serve` process |
+| `--mcp-port` | off | Run MCP HTTP/SSE on a separate port |
+| `OPENROUTER_API_KEY` | — | Deep-analysis LLM key (daemon-side; 400 without) |
+| `TRUSTY_LLM_MODEL` / `--model` | — | OpenRouter model for `deep` |
+| `GITHUB_TOKEN` | — | PR diff fetch + comment post for `review-pr` |
+| `RUST_LOG` | `info` (via `init_tracing(1)`) | Tracing filter (stderr only) |
+
+Cargo features: `default = ["http-server"]`; `http-server` (axum stack);
+`ner` (`dep:ort` + `dep:tokenizers`).
+
+---
+
+## 7. CLI Command Map
+
+`serve` · `analyze` · `review` · `deep` · `review-pr` · `facts {list,add,delete}`
+· `health` · `mcp` · `dashboard`/`dash` · `start` · `stop` · `status`/`st` ·
+`doctor` · `completions` · `service {install,uninstall,status,logs}` ·
+`setup {claude-code,cursor,claude-mpm,daemon,all}`. *(`main.rs`,
+`commands/`)*. Unknown subcommands trigger the shared
+`trusty_common::help::suggest` "did you mean?" hint loaded from a bundled
+`help.yaml` (issue #216).
+
+---
+
+## 8. Phased Roadmap (design substrate)
+
+The schema already reserves runtime hooks: `KgNodeKind`/`KgEdgeKind` include
+`GeneratedFrom` and `RuntimeObservationFor` for Phase 3/4 runtime mapping (🔵),
+and the `LanguageAnalyzer` trait in `CLAUDE.md` sketches a
+`detect → parse_static → enrich_semantics → prepare_runtime → run_runtime`
+lifecycle. The shipping trait (`lang/lang.rs`) currently exposes only the static
+path (`analyze_chunks`); the runtime methods are design-only.
+
+---
+
+## 9. Stale-Doc Reconciliation Notes
+
+The audited tree differs materially from the in-crate `CLAUDE.md` / `README.md`:
+
+- **Layout:** single crate (`src/{core,lang,mcp,service,embedder,types,commands}`),
+  not the nested `crates/trusty-analyze-*` workspace the CLAUDE.md describes.
+- **MCP tools:** 18, not 9.
+- **HTTP routes:** ~20 (incl. diagnostics/graph/entities/ner/review/deep/webhook),
+  not 8.
+- **Adapters:** 14 fully implemented, not "Python/Java/Go stubbed".
+
+Tracked in [#430](https://github.com/bobmatnyc/trusty-tools/issues/430). This
+spec reflects the code, not the stale prose.

--- a/docs/trusty-analyze/spec/COMPONENTS.md
+++ b/docs/trusty-analyze/spec/COMPONENTS.md
@@ -1,0 +1,250 @@
+# trusty-analyze — Components
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+Per-subsystem specs. Each states **responsibility**, **key types/modules** (with
+`src/` paths), **current state**, and **gaps**, tagged ✅ / 🟡 / 🔵 / ⚪ (see
+[README](./README.md#status-legend-used-throughout-this-set)).
+
+---
+
+## 1. trusty-search HTTP Client — `core/client.rs`
+
+- **Responsibility:** the analyzer's only window onto the corpus — fetch chunks
+  and index summaries from trusty-search.
+- **Key types:** `TrustySearchClient` (clone-cheap `reqwest::Client` wrapper),
+  `IndexSummary`. Constants `CHUNK_PAGE_LIMIT = 1000`, `CHUNK_PAGE_CONCURRENCY = 4`.
+- **Current (✅):** HTTP/2 prior-knowledge (loopback, no TLS) for low-latency
+  multiplexed paging; `get_chunks` pages with `FuturesOrdered` at concurrency 4;
+  `health()` powers the hard-dependency probe.
+- **Gaps:** no retry/backoff; a mid-paging failure aborts the whole fetch.
+
+---
+
+## 2. Complexity — `core/complexity.rs`, `core/complexity_ts.rs`
+
+- **Responsibility:** cyclomatic + cognitive complexity, A–F grade, smell list
+  per chunk.
+- **Key types/fns:** `compute_complexity_for(content, language)` dispatcher;
+  `compute_complexity` (text heuristic); `compute_complexity_rust` /
+  `compute_complexity_ts` (AST); thresholds `LONG_FUNCTION_THRESHOLD = 50`,
+  `DEEP_NESTING_THRESHOLD = 4`, `TOO_MANY_PARAMS_THRESHOLD = 5`.
+- **Current (✅/🟡):** Rust/TS/JS use a tree-sitter walk (accurate, line-anchored,
+  no false `if ` matches inside strings); everything else falls back to the
+  language-agnostic text heuristic, also used on any parse failure as a safety
+  net.
+- **Gaps:** AST-accurate complexity is Rust/TS/JS-only despite 14 structural
+  adapters existing. Thresholds are compile-time constants (FR-3.3 / OQ-1).
+
+---
+
+## 3. Quality Aggregation — `core/quality.rs`
+
+- **Responsibility:** one-shot corpus summaries for the `quality` endpoint/tool
+  and the `analyze` CLI.
+- **Key types/fns:** `QualityReport { avg_cyclomatic, pct_grade_a, smell_count,
+  chunk_count }`; `complexity_hotspots(chunks, n)`; `smelly_chunks(chunks)`.
+- **Current (✅):** pure functions; re-score chunks on demand from `content` when
+  a pre-computed `complexity` field is absent, so trusty-search need not populate
+  it.
+- **Gaps:** grade-rollup weights are fixed; no per-file (vs per-index) report at
+  the HTTP layer despite the README mentioning per-file grades.
+
+---
+
+## 4. Code Smells — `types/complexity.rs`
+
+- **Responsibility:** define the smell taxonomy and grade enum (wire types live
+  in this crate's `types/`, mirroring the old `trusty-common` types).
+- **Key types:** `CodeSmell::{LongFunction{lines}, DeepNesting{max_depth},
+  TooManyParams{count}, MissingDocstring}`; `ComplexityGrade::{A,B,C,D,F}`;
+  `ComplexityMetrics`.
+- **Current (✅):** detection runs in both the text and AST paths; the AST path
+  produces line-accurate smell positions.
+- **Gaps:** four smell categories only; no duplication/dead-code/coupling smells.
+
+---
+
+## 5. Language Adapters & Registry — `lang/`, `core/registry.rs`
+
+- **Responsibility:** parse chunk content per language into a `KgGraph`; route
+  chunks to the right adapter; detect languages/build-systems/frameworks.
+- **Key types:** `LanguageAnalyzer` trait (`analyze_chunks`,
+  `supported_extensions`) + `StaticAnalysisResult`; `LanguageDetector` /
+  `DetectionResult` / `detect_frameworks`; `AnalyzerRegistry::default_registry`.
+- **Current (✅):** 14 adapters registered — Rust, TypeScript, JavaScript,
+  Python, Java, Go, C, C++, C#, Kotlin, PHP, Ruby, Scala, Swift — each emitting
+  File/Function/Method/Class/Interface/Module/Import nodes plus Contains/Imports/
+  Implements/Calls edges (and TestCase where the grammar allows).
+- **Gaps:** `lang/mod.rs` module doc falsely claims Python/Java/Go are "stubbed
+  for Phase 2b" — a doc gap (FR-4.4 / OQ-2). The trait exposes only the static
+  path; the `enrich_semantics`/`prepare_runtime`/`run_runtime` lifecycle from
+  `CLAUDE.md` is design-only (🔵).
+
+---
+
+## 6. Knowledge Graph, Linker & SCIP — `types/graph.rs`, `core/linker.rs`, `core/scip.rs`
+
+- **Responsibility:** a language-neutral symbol graph, deduplicated across
+  overlapping chunk windows, optionally enriched by precise SCIP indexes.
+- **Key types:** `KgGraph`, `KgNode`, `KgEdge`, `KgNodeKind` (14 kinds incl.
+  Repository/Package/Module/File/Class/Interface/Function/Method/Field/Import/
+  Export/CallExpression/TestCase/Dependency), `KgEdgeKind` (11 kinds incl.
+  GeneratedFrom/RuntimeObservationFor); `linker::link`; `scip::extract_kg_from_scip`
+  + `ScipIngestSummary`.
+- **Current (✅):** `link` collapses `(language, kind, qualified_name)` duplicates,
+  keeps the widest range, rewires edges, drops self-loops. SCIP ingest decodes
+  the protobuf `Index`, emitting definitions as nodes, `is_implementation` as
+  Implements edges, occurrences as References edges.
+- **Gaps:** `GeneratedFrom` / `RuntimeObservationFor` have no producer (await
+  Phase 3/4, 🔵). No graph persistence — graphs are recomputed per request.
+
+---
+
+## 7. Concept Clustering & Embedders — `core/concept_cluster.rs`, `embedder/`
+
+- **Responsibility:** group semantically related chunks into labelled concept
+  clusters.
+- **Key types:** `cluster()` (Lloyd k-means + k-means++ seeding),
+  `ConceptCluster { id, label, members, cohesion }`, `ClusterResult`;
+  `bow_embedding`; `Embedder` trait with `BowEmbedder` + `NeuralEmbedder`
+  (`EmbedderKind::{Bow,Neural}`).
+- **Current (✅):** BoW is deterministic and dependency-free; neural is fastembed
+  all-MiniLM-L6-v2 (384-dim). Neural load failure at `serve` startup degrades
+  gracefully to BoW (`main.rs`).
+- **Gaps:** `k` is caller-supplied (no auto-k); neural requires a pre-cached
+  model (shares trusty-search's cache).
+
+---
+
+## 8. Refactor, Review, Deep Analysis & GitHub — `core/refactor.rs`, `core/review.rs`, `core/explain.rs`, `core/github.rs`
+
+- **Responsibility:** turn metrics into actionable guidance and PR-time review.
+- **Key types:** `RefactorSuggestion` / `RefactorType` / `Severity`;
+  `DiffParser` / `FileDiff` / `ReviewReport` / `analyze_diff_with_client` /
+  `render_review_text`; `DeepAnalysisReport { narrative, frameworks,
+  recommendations, model_used }` / `explain_report` / `deep_analysis`;
+  `fetch_pr_diff` / `post_pr_comment` / `format_review_as_markdown` /
+  `verify_webhook_signature`.
+- **Current (✅/🟡):** refactor + review are deterministic pure pipelines —
+  review cross-references the index corpus (stored complexity for indexed files,
+  local tree-sitter for new files). Deep analysis layers an LLM narrative via a
+  `trusty_common::chat::ChatProvider`, kept *out* of the deterministic
+  `ReviewReport` so reproducibility is preserved; needs `OPENROUTER_API_KEY`
+  (returns 400 otherwise). GitHub helpers fetch a PR diff, run review, post a
+  comment, and verify webhook HMAC (SHA-256).
+- **Gaps:** deep analysis is non-deterministic and model-dependent (🟡); GitHub
+  integration relies on `GITHUB_TOKEN` being present in the daemon env.
+
+---
+
+## 9. Facts Store — `core/facts.rs`, `types/facts.rs`
+
+- **Responsibility:** the only persistent state — a canonical
+  `(subject, predicate, object)` triple store with provenance.
+- **Key types:** `FactStore` (redb `facts` table), `FactRecord`, `new_fact`,
+  `fact_hash` (length-prefixed `xxh3`).
+- **Current (✅):** the triple *is* the identity; re-asserting merges provenance.
+  `xxh3` hashing is stable across toolchains (replaced `DefaultHasher`, #64).
+  #67 removed a read-lock contention p99 spike in `list_facts`.
+- **Gaps:** `#64` notes pre-switch redb rows are invalidated with no migration
+  (facts are re-derivable on next run, so accepted).
+
+---
+
+## 10. External Static Tools — `core/tools.rs`, `core/tool_registry.rs`, `core/tool_impls/`
+
+- **Responsibility:** complement the tree-sitter baseline with real linters.
+- **Key types:** `StaticTool` trait (`name`/`language`/`is_available`/`run`),
+  `ToolDiagnostic`, `Severity::{Error,Warning,Info,Hint}`; `ToolRegistry`
+  (`discover`, `tools_for`, `run_all`) + process-wide `global_registry()`;
+  `TOOL_TIMEOUT = 30s`.
+- **Current (✅):** 10 adapters — `ClippyTool`, `RuffTool`, `BiomeTool`,
+  `RubocopTool`, `PhpstanTool`, `DetektTool`, `PmdTool`, `StaticcheckTool`,
+  `ClangtidyTool`, `SwiftlintTool` — discovered lazily via `which`, indexed by
+  language, each parsing native output into `ToolDiagnostic` under a hard timeout.
+  Surfaced at `/indexes/:id/diagnostics` + MCP `run_diagnostics`.
+- **Gaps:** availability depends on the host having each binary installed;
+  tool-specific config (rulesets) is not yet plumbed.
+
+---
+
+## 11. NER — `core/ner.rs`
+
+- **Responsibility:** extract natural-language phrases from doc comments as
+  `RawEntity`s for downstream BM25/KG lookup.
+- **Key types:** `NerExtractor` (`try_load`, `extract`), `extract_doc_comments`.
+- **Current (🟡):** double-gated — requires `--features ner` (pulls `ort` +
+  `tokenizers`) **and** a model at `~/.trusty-analyzer/models/ner.onnx`.
+  Always constructible; `extract()` is a no-op when disabled, so the single
+  binary ships without ONNX yet can light up if a user drops the model in.
+  Surfaced at `/indexes/:id/ner` + MCP `extract_ner`.
+- **Gaps:** off by default; no bundled model; structural extractor remains the
+  primary entity source.
+
+---
+
+## 12. MCP Server — `mcp/mod.rs`, `mcp/stdio.rs`, `mcp/sse.rs`
+
+- **Responsibility:** expose the full HTTP surface as MCP tools (strict parity).
+- **Key types:** `AnalyzerMcpServer::dispatch` (JSON-RPC→HTTP translator),
+  `Request`/`Response`/`JsonRpcError`, `error_codes`; `stdio::run`;
+  `sse::router`.
+- **Current (✅):** 18 tools — `complexity_hotspots`, `find_smells`,
+  `analyze_quality`, `run_diagnostics`, `list_facts`, `upsert_fact`,
+  `delete_fact`, `extract_graph`, `list_entities`, `cluster_concepts`,
+  `analyzer_health`, `ingest_scip`, `extract_ner`, `suggest_refactors`,
+  `review_diff`, `review_github_pr`, `deep_analysis` (plus the resource/index
+  listing in `tools/list`). Two transports share one dispatcher; the dispatcher
+  owns only a `reqwest::Client` + base URL.
+- **Gaps:** the README/CLAUDE.md still list 9 tools (OQ-2). The dispatcher is
+  stateless — it cannot serve when the analyzer daemon it points at is down.
+
+---
+
+## 13. HTTP Daemon & Embedded UI — `service/mod.rs`, `service/ui.rs`
+
+- **Responsibility:** the axum REST surface (port 7879) + dashboard.
+- **Key types:** `AnalyzerAppState` (`new`, `with_embedder`), `serve`,
+  `DEFAULT_PORT`; route handlers; `WebAssets` (rust-embed) + `ui_index_handler` /
+  `ui_asset_handler`.
+- **Current (✅):** ~20 routes — health, index proxy, complexity/smells/quality,
+  diagnostics/graph/entities/clusters/ner, scip ingest, review/github-pr/deep,
+  github webhook, facts CRUD, `/ui` SPA (with index.html fallback for client-side
+  routing). Gated behind the `http-server` feature (#249); `serve` can also fork
+  an MCP stdio loop (`--mcp`) and/or an MCP HTTP/SSE server (`--mcp-port`).
+- **Gaps:** UI assets come from `ui/dist/` built by `build.rs` via pnpm; the
+  build warns (non-fatal) when pnpm is unavailable, shipping an empty dashboard.
+
+---
+
+## 14. CLI & Daemon Lifecycle — `main.rs`, `commands/`
+
+- **Responsibility:** the user-facing command surface and process management.
+- **Key modules:** `commands/daemon.rs` (`start`/`stop`/`status`/`doctor` +
+  PID file under `~/.trusty-analyze/`); `commands/service.rs` (macOS launchd
+  install/uninstall/status/logs); `commands/setup.rs` (`SetupTarget`:
+  ClaudeCode/Cursor/ClaudeMpm/Daemon/All).
+- **Current (✅):** full lifecycle parity with trusty-search/trusty-memory;
+  shell completions via `clap_complete`; shared "did you mean?" help (#216);
+  `dashboard`/`dash` opens the UI after a TCP probe.
+- **Gaps:** launchd `service` is macOS-only (exits 1 on Linux/Windows with a
+  clear message).
+
+---
+
+## 15. Wire Types — `types/`
+
+- **Responsibility:** serde wire-format types crossing the HTTP/MCP boundary,
+  forward-compatible with trusty-search additions.
+- **Key types:** `CodeChunk` (id, file, line range, content, function_name,
+  score, snippet, match_reason — no complexity/blame carrier, removed in #71),
+  `ComplexityMetrics`/`CodeSmell`/`ComplexityGrade`, `ChunkBlame`, `RawEntity`/
+  `EntityType`/`EdgeKind`, `FactRecord`, `KgGraph`/`KgNode`/`KgEdge`.
+- **Current (✅):** every struct uses `#[serde(default)]` on optional fields and
+  tolerant unknown-field handling so trusty-search can evolve independently.
+- **Gaps:** these duplicate the old `trusty-common` types (the crate now carries
+  its own `types/` rather than depending on `trusty-common` for chunk types);
+  drift between the two is a maintenance risk.

--- a/docs/trusty-analyze/spec/PRD.md
+++ b/docs/trusty-analyze/spec/PRD.md
@@ -1,0 +1,300 @@
+# trusty-analyze — Product Requirements Document (PRD)
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+This PRD defines *what trusty-analyze is meant to be*, *what it is today*, and
+*what gaps remain*. Every requirement is framed **Vision / Current / Gap** and
+tagged with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, RFC, or plan) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+---
+
+## 1. Vision & Mission
+
+### Vision
+
+A **local code-intelligence layer** that turns a searchable code corpus into
+actionable quality signal — complexity, smells, structural graph, refactor
+guidance, and reviews — surfaced uniformly to LLM agents (via MCP), humans (via
+CLI/dashboard), and CI (via HTTP), with no cloud round-trip and no per-project
+install.
+
+### Mission
+
+Be the **analysis sidecar** to `trusty-search`: reuse the search daemon's
+already-chunked, already-indexed corpus rather than re-walking the filesystem,
+and compute every quality metric in-process so a single `cargo install
+trusty-analyze` adds a complete static-analysis surface to any machine that
+already runs trusty-search.
+
+### Product north star (⚪/🔵)
+
+The crate's `CLAUDE.md` lays out a five-phase roadmap that grows the tool from a
+"complexity reporter" into a full **code-intelligence engine**: Phase 1 static
+analysis (now), Phase 2 language-specific semantic enrichment (largely now via
+tree-sitter adapters + SCIP), Phase 3 Dockerized sandboxed runtime execution
+(🔵), Phase 4 runtime-to-graph mapping (🔵), and Phase 5 unified
+text+embed+graph+runtime scoring (⚪). Phases 3–5 are documented design, not
+shipped code.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- **G1 (✅)** Compute complexity, smells, and quality grades over a fetched chunk
+  corpus, with no direct filesystem or database access.
+- **G2 (✅)** Build a language-neutral knowledge graph from tree-sitter parses
+  across many languages, deduplicated across overlapping chunk windows.
+- **G3 (✅)** Maintain strict **HTTP↔MCP parity** — every endpoint has a tool and
+  vice versa.
+- **G4 (✅)** Treat trusty-search as a hard runtime dependency; fail fast and
+  loudly when it is unreachable.
+- **G5 (✅)** Ship a single self-contained binary (CLI + daemon + MCP + embedded
+  UI), installable with `cargo install trusty-analyze`.
+- **G6 (✅)** Keep stdout clean for MCP JSON-RPC framing; all logs to stderr.
+- **G7 (🟡)** Provide LLM-augmented deep analysis on top of deterministic
+  metrics, opt-in and isolated from the reproducible path.
+- **G8 (🔵)** Add sandboxed runtime execution + runtime-to-graph mapping
+  (Phases 3–4).
+
+### Non-Goals
+
+- **NG1** Not a search engine — it never re-implements BM25/vector/KG *search*;
+  it consumes trusty-search's corpus.
+- **NG2** Not a corpus owner — it does **not** read trusty-search's redb files
+  directly; the only state it owns is its own facts store.
+- **NG3** Not an offline tool — there is deliberately no standalone mode.
+- **NG4** Not a name resolver by itself — precise cross-file symbol resolution
+  is delegated to SCIP indexers; tree-sitter stays structural/heuristic.
+- **NG5** `trusty-common` (the shared type crate) must never depend on
+  trusty-search or trusty-analyze.
+
+---
+
+## 3. Personas
+
+| Persona | Needs | Primary surface |
+|---|---|---|
+| **LLM coding agent** (Claude Code, Cursor) | "Where is the gnarly code? What should I refactor? Review this diff." Structured, machine-readable answers. | MCP tools (stdio) |
+| **Developer at the CLI** | One-shot complexity report, diff review before pushing, a dashboard to browse hotspots. | `trusty-analyze` CLI + `/ui` dashboard |
+| **CI / automation** | Quality gate on a PR diff; fetch a GitHub PR diff and post a review comment. | HTTP API + `review-pr` |
+| **Platform integrator** | Wire the analyzer into an MCP host or a remote service. | MCP HTTP/SSE transport, `setup` |
+
+---
+
+## 4. Functional Requirements
+
+### 4.1 Analysis Engine & Corpus Access
+
+- **FR-1.1 (✅)** Fetch a named index's full chunk corpus from trusty-search via
+  paged `GET /indexes/:id/chunks` (HTTP/2 prior-knowledge, 1000/page, 4
+  concurrent pages). *(`core/client.rs`)*
+- **FR-1.2 (✅)** Operate purely on `CodeChunk` wire-format types with
+  forward-compatible serde (`#[serde(default)]`), so trusty-search can add fields
+  without breaking the analyzer. *(`types/`)*
+- **FR-1.3 (✅)** Hard startup health check against trusty-search `/health`;
+  exit code 1 with a clear message if unreachable. Applies to `serve`, `review`,
+  and `review-pr`. *(`main.rs`)*
+- **FR-1.4 (✅)** `analyze` one-shot CLI report: quality summary + per-language
+  node/edge rollup + top-N complexity hotspots. *(`main.rs::Cmd::Analyze`)*
+
+### 4.2 Complexity Metrics
+
+- **FR-2.1 (✅)** Cyclomatic + cognitive complexity per chunk; A–F letter grade.
+  *(`types/complexity.rs::ComplexityMetrics`, `ComplexityGrade`)*
+- **FR-2.2 (✅)** Language-aware dispatch: tree-sitter AST walk for Rust /
+  TypeScript / JavaScript (accurate, line-anchored), with a graceful fallback to
+  a language-agnostic text heuristic for everything else or on parse failure.
+  *(`core/complexity.rs::compute_complexity_for`, `core/complexity_ts.rs`)*
+- **FR-2.3 (✅)** Aggregate quality report over a corpus: avg cyclomatic,
+  %grade-A, smell count, chunk count. *(`core/quality.rs::QualityReport`)*
+- **FR-2.4 (✅)** Complexity hotspots: top-N chunks by descending cyclomatic
+  complexity. *(`core/quality.rs::complexity_hotspots`)*
+
+### 4.3 Code Smell Detection
+
+- **FR-3.1 (✅)** Threshold-based smells: `LongFunction`, `DeepNesting`,
+  `TooManyParams`, `MissingDocstring`. *(`types/complexity.rs::CodeSmell`)*
+- **FR-3.2 (✅)** Smell listing endpoint/tool, optionally filtered by category.
+  *(`service/mod.rs` `/indexes/:id/smells`, MCP `find_smells`)*
+- **FR-3.3 (🟡)** Thresholds are compile-time constants (`LONG_FUNCTION_THRESHOLD`
+  = 50, `DEEP_NESTING_THRESHOLD` = 4, `TOO_MANY_PARAMS_THRESHOLD` = 5). The
+  README advertises "configurable thresholds"; runtime configuration is **not**
+  yet wired. *Gap.*
+
+### 4.4 Language & AST Support
+
+- **FR-4.1 (✅)** `LanguageAnalyzer` plugin trait + extension-based detection.
+  *(`lang/lang.rs`, `lang/detection.rs`)*
+- **FR-4.2 (✅)** 14 registered tree-sitter adapters — Rust, TypeScript,
+  JavaScript, Python, Java, Go, C, C++, C#, Kotlin, PHP, Ruby, Scala, Swift —
+  each emitting File/Function/Method/Class/Interface/Module/Import nodes,
+  `Contains`/`Imports`/`Implements`/`Calls` edges, and TestCase nodes where
+  applicable. *(`lang/adapters/`, `core/registry.rs::default_registry`)*
+- **FR-4.3 (✅)** Build-system + framework detection from manifest files (Cargo,
+  npm, Maven/Gradle, pip, go-mod; Next.js, Django, Rails, …).
+  *(`lang/detection.rs::detect_frameworks`)*
+- **FR-4.4 (🟡)** The `lang/mod.rs` module doc still claims Python/Java/Go are
+  "stubbed for Phase 2b". In fact all 14 adapters are fully implemented and
+  registered. *Doc gap, not a code gap.*
+
+### 4.5 Knowledge Graph
+
+- **FR-5.1 (✅)** Language-neutral `KgGraph` of `KgNode`/`KgEdge` with node kinds
+  (Repository, Package, Module, File, Class, Interface, Function, Method, Field,
+  Import, Export, CallExpression, TestCase, Dependency) and edge kinds (Contains,
+  Imports, Exports, Calls, Implements, Extends, References, Tests, DependsOn,
+  GeneratedFrom, RuntimeObservationFor). *(`types/graph.rs`)*
+- **FR-5.2 (✅)** Cross-chunk linker: merges duplicate nodes (same
+  language+kind+qualified_name) emitted by overlapping chunk windows, rewires
+  edges, drops self-loops. *(`core/linker.rs`)*
+- **FR-5.3 (✅)** SCIP protobuf ingest → KgGraph (definitions → nodes,
+  `is_implementation` → Implements edges, occurrences → References edges).
+  *(`core/scip.rs`)*
+- **FR-5.4 (✅)** Graph + entity endpoints/tools. *(`/indexes/:id/graph`,
+  `/indexes/:id/entities`, MCP `extract_graph`, `list_entities`)*
+- **FR-5.5 (🔵)** `GeneratedFrom` / `RuntimeObservationFor` edge kinds exist in
+  the schema but have no producer — they await Phase 3/4 runtime execution.
+
+### 4.6 Concept Clustering & Embeddings
+
+- **FR-6.1 (✅)** k-means (Lloyd + k-means++) concept clustering over chunk
+  embeddings; returns labelled clusters with cohesion. *(`core/concept_cluster.rs`)*
+- **FR-6.2 (✅)** Two embedder backends: BoW hashed (always available,
+  deterministic) and neural (fastembed all-MiniLM-L6-v2, 384-dim). Neural load
+  failure degrades gracefully to BoW. *(`embedder/`, `main.rs` serve path)*
+- **FR-6.3 (✅)** Clusters endpoint/tool with `k` and `method=bow|neural`.
+  *(`/indexes/:id/clusters`, MCP `cluster_concepts`)*
+
+### 4.7 Refactor, Review & LLM Deep Analysis
+
+- **FR-7.1 (✅)** Rule-engine refactor suggestions derived from complexity +
+  smells (ExtractMethod, ReduceNesting, …), severity mirroring the grade with a
+  bump at 3+ smells. *(`core/refactor.rs`, MCP `suggest_refactors`)*
+- **FR-7.2 (✅)** Unified-diff review: parse a git diff, cross-reference the
+  index corpus, report per-file grades + recommendations; indexed files use
+  stored complexity, new files fall back to local tree-sitter analysis.
+  *(`core/review.rs`, CLI `review`, `/review`, MCP `review_diff`)*
+- **FR-7.3 (✅)** GitHub PR review: fetch a PR diff via the REST API, run the
+  review pipeline, optionally post the report back as a comment; HMAC webhook
+  signature verification. *(`core/github.rs`, CLI `review-pr`, `/review/github-pr`,
+  `/webhooks/github`, MCP `review_github_pr`)*
+- **FR-7.4 (🟡)** LLM-augmented deep analysis: a `DeepAnalysisReport`
+  (narrative + frameworks + recommendations + model) layered on top of the
+  deterministic `ReviewReport` via a `ChatProvider`. Requires an
+  `OPENROUTER_API_KEY` on the daemon side; returns 400 without one. Working but
+  non-deterministic and opt-in. *(`core/explain.rs`, CLI `deep`, `/analyze/deep`,
+  MCP `deep_analysis`)*
+
+### 4.8 External Static-Tool Integration
+
+- **FR-8.1 (✅)** `StaticTool` plugin trait + lazily-discovered `ToolRegistry`
+  that probes installed linters once and indexes them by language.
+  *(`core/tools.rs`, `core/tool_registry.rs`)*
+- **FR-8.2 (✅)** 10 tool adapters: clippy (Rust), ruff (Python), biome (TS/JS),
+  rubocop (Ruby), phpstan (PHP), detekt (Kotlin), pmd (Java), staticcheck (Go),
+  clang-tidy (C/C++), swiftlint (Swift). Each has a 30s hard timeout and parses
+  native output into `ToolDiagnostic`. *(`core/tool_impls/`)*
+- **FR-8.3 (✅)** Diagnostics endpoint/tool runs available tools for an index's
+  languages. *(`/indexes/:id/diagnostics`, MCP `run_diagnostics`)*
+
+### 4.9 Facts Store
+
+- **FR-9.1 (✅)** redb-backed `(subject, predicate, object)` triple store; the
+  triple *is* the identity (re-asserting merges provenance). *(`core/facts.rs`)*
+- **FR-9.2 (✅)** Stable `xxh3` fact hash (replaced the non-stable
+  `DefaultHasher` to survive toolchain bumps). *(`core/facts.rs::fact_hash`,
+  issue #64)*
+- **FR-9.3 (✅)** List/upsert/delete via CLI, HTTP, and MCP. *(`/facts`,
+  `/facts/:id`, MCP `list_facts`/`upsert_fact`/`delete_fact`)*
+
+### 4.10 NER (optional)
+
+- **FR-10.1 (🟡)** Optional ONNX NER over doc comments, double-gated: requires
+  both `--features ner` *and* a model present at `~/.trusty-analyzer/models/ner.onnx`.
+  Disabled by default; `extract()` is a no-op when off. *(`core/ner.rs`,
+  `/indexes/:id/ner`, MCP `extract_ner`)*
+
+### 4.11 MCP Surface
+
+- **FR-11.1 (✅)** 18 MCP tools (a superset of the 9 in the README): the
+  9 originals plus `run_diagnostics`, `extract_graph`, `list_entities`,
+  `extract_ner`, `suggest_refactors`, `review_diff`, `review_github_pr`,
+  `deep_analysis`. *(`mcp/mod.rs` dispatcher)*
+- **FR-11.2 (✅)** Two transports sharing one dispatcher: stdio (subprocess) and
+  HTTP/SSE (`POST /mcp`, `GET /mcp/sse`, 15s keep-alive). *(`mcp/stdio.rs`,
+  `mcp/sse.rs`)*
+- **FR-11.3 (✅)** MCP dispatcher is a pure JSON-RPC→HTTP translator owning only a
+  `reqwest::Client` + base URL — no analysis state. *(`mcp/mod.rs`)*
+
+### 4.12 HTTP / Daemon Surface
+
+- **FR-12.1 (✅)** axum HTTP daemon on port 7879 (auto-detect upward if busy);
+  ~20 routes including `/health`, `/indexes`, complexity/smells/quality/
+  diagnostics/graph/entities/clusters/ner, scip ingest, review endpoints, facts,
+  and the embedded UI. *(`service/mod.rs`)*
+- **FR-12.2 (✅)** `http-server` cargo feature gates axum + tower-http + the
+  `service` and `mcp::sse` modules; library consumers can drop the HTTP stack
+  with `--no-default-features`. *(`Cargo.toml`, issue #249)*
+- **FR-12.3 (✅)** Daemon lifecycle: `serve`, `start` (detached + PID file under
+  `~/.trusty-analyze/`), `stop` (SIGTERM + port poll), `status`, `doctor`,
+  plus macOS launchd `service install/uninstall/status/logs`.
+  *(`commands/daemon.rs`, `commands/service.rs`)*
+- **FR-12.4 (✅)** `setup` integrations for Claude Code, Cursor, claude-mpm, and
+  the daemon, via `trusty_common::claude_config`. *(`commands/setup.rs`)*
+- **FR-12.5 (✅)** Embedded Svelte dashboard served from `/ui` (rust-embed),
+  `dashboard`/`dash` opens it; `completions` emits shell scripts.
+  *(`service/ui.rs`, `main.rs`)*
+
+### 4.13 Output & Reporting
+
+- **FR-13.1 (✅)** All HTTP responses are JSON; reports serialize cleanly for
+  machine consumption.
+- **FR-13.2 (✅)** Review and deep-analysis reports render as both JSON and
+  human-readable text. *(`render_review_text`, `render_deep_analysis_text`)*
+- **FR-13.3 (✅)** Review-as-markdown rendering for GitHub PR comments.
+  *(`core/github.rs::format_review_as_markdown`)*
+
+---
+
+## 5. Success Criteria
+
+| # | Criterion | Status |
+|---|---|---|
+| SC-1 | `cargo install trusty-analyze` yields a working CLI + daemon + MCP server + dashboard. | ✅ |
+| SC-2 | Every HTTP endpoint has an MCP tool and vice versa (parity rule). | ✅ (now 18 tools / ~20 routes) |
+| SC-3 | Daemon refuses to start without trusty-search, with a clear error. | ✅ |
+| SC-4 | No MCP framing corruption — stdout carries only JSON-RPC. | ✅ (fixed in #66) |
+| SC-5 | Complexity numbers for Rust/TS/JS match a real AST walk, not substring counting. | ✅ |
+| SC-6 | Analysis spans ≥10 languages structurally. | ✅ (14 adapters) |
+| SC-7 | Diff/PR review usable as a CI quality gate. | ✅ |
+| SC-8 | Workspace test suite green (`cargo test -p trusty-analyze`). | ✅ |
+| SC-9 | Runtime execution (Phase 3) maps profiler data onto graph nodes. | 🔵 |
+
+---
+
+## 6. Open Questions & Roadmap
+
+- **OQ-1 (🟡)** Make smell thresholds runtime-configurable (README already
+  advertises this). Today they are compile-time constants.
+- **OQ-2 (🟡)** Reconcile stale docs: `lang/mod.rs` adapter-status comment, the
+  crate `CLAUDE.md` nested-workspace layout, and the README's 9-tool / 8-endpoint
+  tables vs. the actual 18-tool / ~20-route surface (issue #430).
+- **OQ-3 (🔵)** Phase 3 — Dockerized sandboxed runtime execution (per-language
+  profiler images, non-root, network-isolated, resource-capped).
+- **OQ-4 (🔵)** Phase 4 — normalize profiler output to the runtime-result schema
+  and attach to graph nodes via `RuntimeObservationFor` / `GeneratedFrom` edges.
+- **OQ-5 (⚪)** Phase 5 — unified scoring blending text + embedding + graph
+  centrality + static complexity + runtime cost + error/coverage/dependency-risk.
+- **OQ-6 (⚪)** Performance/quality regression baselines (the
+  `regression-testing/` subdir is empty).

--- a/docs/trusty-analyze/spec/README.md
+++ b/docs/trusty-analyze/spec/README.md
@@ -1,0 +1,97 @@
+# trusty-analyze — Specification Set
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+This directory holds the canonical product and engineering specification for the
+`trusty-analyze` crate (`crates/trusty-analyze/`). It is the single authoritative
+reference for *what trusty-analyze is meant to be*, *what it is today*, and *what
+gaps remain*.
+
+## What is trusty-analyze?
+
+`trusty-analyze` is a **local code-quality analysis sidecar**: a daemon + MCP
+server that fetches a project's chunk corpus from the [`trusty-search`](../../trusty-search/)
+daemon over HTTP and computes **complexity, code smells, quality grades, a
+language-neutral knowledge graph, concept clusters, refactor suggestions, and
+diff/PR reviews** — every result reachable both as an HTTP endpoint and as an
+MCP tool (strict parity). Structural analysis is built on **tree-sitter** (14
+language adapters) with optional **external-linter** integration (clippy, ruff,
+biome, …, 10 tools) and **SCIP** ingest for LSP-grade symbol resolution.
+Persistence is a single embedded **redb** facts store; everything is local,
+service-free, and MIT-licensed. trusty-search is a **hard runtime dependency** —
+there is no offline mode; the daemon refuses to start if the search daemon is
+unreachable.
+
+## Documents in this set
+
+| Document | Read it when you want to know… |
+|---|---|
+| **[PRD.md](./PRD.md)** | The product: vision & mission, goals/non-goals, personas (LLM agents, devs, CI), the full functional-requirement catalog grouped by capability (analysis engine, complexity metrics, smell detection, language/AST support, knowledge graph, clustering, review/LLM, MCP, HTTP/daemon, output/reporting) and tagged by implementation status, success criteria, and the open-question roadmap. Start here for *why* and *what*. |
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | The system shape: the sidecar topology and hard runtime dependency on trusty-search, the chunk-fetch → analyze → serve pipeline, the tree-sitter AST substrate and text-heuristic fallback, the knowledge-graph schema and cross-chunk linker, MCP stdio + HTTP/SSE framing (stdout reserved for JSON-RPC, logs to stderr), the `http-server` feature gate, and the daemon lifecycle. Includes the source-module map with `src/` citations. Start here for *how it fits together*. |
+| **[COMPONENTS.md](./COMPONENTS.md)** | Per-subsystem specs: HTTP client, complexity (text + tree-sitter), smells/quality, the language-adapter registry, the knowledge graph + linker + SCIP, concept clustering + embedders, refactor/review/deep-analysis/GitHub, the facts store, the external-tool registry, NER, the MCP server, the HTTP daemon + embedded UI, and the CLI/daemon lifecycle. Each states responsibility, key types/modules (with `src/` paths), current state, and known gaps. Start here for *the detail of one subsystem*. |
+
+## Reading order
+
+1. **New to trusty-analyze?** PRD → ARCHITECTURE → COMPONENTS.
+2. **Implementing a feature?** Jump to the relevant COMPONENTS section, then
+   cross-check the analysis pipeline in ARCHITECTURE.
+3. **Evaluating product direction?** PRD vision + success criteria, then the gap
+   callouts throughout COMPONENTS.
+
+## Status legend (used throughout this set)
+
+Every requirement and component is framed as **Vision / Current / Gap** and
+tagged inline with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, RFC, or plan) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+## Related documentation
+
+This `spec/` set is the *what/why/gap* layer. The point-in-time and operational
+docs live alongside it:
+
+- **[../research/](../research/)** — dated investigations and audits (the
+  trustee/search code-analysis summary and source `.docx`).
+- **[../regression-testing/](../regression-testing/)** — versioned
+  performance/quality snapshots (none authored yet).
+- **[../sessions/](../sessions/)** — engineering-session narratives (none
+  authored yet).
+- **[../decisions/](../decisions/)** — evidenced design-decision records.
+- **[crates/trusty-analyze/README.md](../../../crates/trusty-analyze/README.md)**
+  and **[crates/trusty-analyze/CLAUDE.md](../../../crates/trusty-analyze/CLAUDE.md)**
+  — in-crate quick-start, HTTP/MCP catalogue, and project history.
+
+## Provenance & maintenance
+
+These documents are derived from an audit of the `crates/trusty-analyze/src/`
+tree (the single-crate `commands` / `core` / `embedder` / `lang` / `mcp` /
+`service` / `types` module layout as of v0.1.10), the crate `README.md` /
+`CLAUDE.md`, and the open/closed issue backlog (notably the axum feature-gate
+[#249](https://github.com/bobmatnyc/trusty-tools/issues/249), the MCP
+stdout-framing fix [#66](https://github.com/bobmatnyc/trusty-tools/issues/66),
+the `list_facts` read-lock contention fix
+[#67](https://github.com/bobmatnyc/trusty-tools/issues/67), the LLM-narrative /
+framework analysis feature [#4](https://github.com/bobmatnyc/trusty-tools/issues/4),
+the micro-crate consolidation [#5](https://github.com/bobmatnyc/trusty-tools/issues/5),
+and the crate-inventory reconciliation
+[#430](https://github.com/bobmatnyc/trusty-tools/issues/430)). When the code
+changes materially, update the relevant document and bump the *Last reviewed*
+date. Source-path citations reflect the layout at the time of review.
+
+> **Note on in-crate `CLAUDE.md` drift:** the crate-local
+> `crates/trusty-analyze/CLAUDE.md` predates the workspace consolidation and
+> still describes a *nested* multi-crate workspace
+> (`crates/trusty-analyze/crates/trusty-analyze-{types,lang,core,mcp,service,embedder}`),
+> a 9-tool MCP surface, and an 8-endpoint HTTP surface. The authoritative layout
+> is the **single `trusty-analyze` crate** with `core` / `lang` / `mcp` /
+> `service` / `embedder` / `types` modules, an **18-tool MCP surface**, and a
+> ~20-route HTTP surface. This spec set reflects the audited tree, not the stale
+> CLAUDE.md; the reconciliation is tracked in
+> [#430](https://github.com/bobmatnyc/trusty-tools/issues/430).


### PR DESCRIPTION
Canonical spec set under docs/trusty-analyze/spec/, open-mpm style. ADR for the http-server feature gate (#249). Documents the single-crate layout post-#5, 18 MCP tools, 14 language adapters. cargo check -p trusty-analyze passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)