### PR TITLE
docs(trusty-mpm): canonical spec set

### DIFF
--- a/docs/trusty-mpm/README.md
+++ b/docs/trusty-mpm/README.md
@@ -1,6 +1,24 @@
 # trusty-mpm — documentation
 
-MPM platform — 8 binary crates: `trusty-mpm-core`, `-mcp`, `-daemon`, `-client`, `-cli`, `-tui`, `-telegram`, `-gui`. Docs covering any of the eight live here.
+Unified MPM platform — one crate (`crates/trusty-mpm`) with feature-gated
+`[[bin]]` targets: the CLI (`tm` / `trusty-mpm`), the daemon (`trusty-mpmd`), an
+in-session MCP server, a TUI (`trusty-mpm-tui`), and a Telegram bot
+(`trusty-mpm-telegram`); the Tauri GUI lives in the sibling `trusty-mpm-gui`
+crate and is wrapped via the optional `gui` feature. Docs covering any surface
+live here.
+
+## Canonical specification
+
+The authoritative product + engineering spec for trusty-mpm lives in
+[**`spec/`**](spec/):
+
+- [spec/README.md](spec/README.md) — index, status legend, reading order, and the
+  open-mpm relationship.
+- [spec/PRD.md](spec/PRD.md) — vision, personas, status-tagged functional
+  requirements grouped by surface.
+- [spec/ARCHITECTURE.md](spec/ARCHITECTURE.md) — multi-binary topology,
+  single-daemon coordination, MCP framing, HTTP API, filesystem layout.
+- [spec/COMPONENTS.md](spec/COMPONENTS.md) — per-binary and per-subsystem specs.
 
 ## Layout
 

--- a/docs/trusty-mpm/decisions/0001-single-install-multi-binary-bundling.md
+++ b/docs/trusty-mpm/decisions/0001-single-install-multi-binary-bundling.md
@@ -1,0 +1,75 @@
+# 1. Single-install, multi-binary bundling of the trusty-mpm surfaces
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Deciders:** trusty-mpm maintainers
+- **Format:** [Nygard ADR](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+
+## Context
+
+trusty-mpm originated as eight separately-published sub-crates —
+`trusty-mpm-{core, client, mcp, daemon, cli, tui, telegram, gui}`. Publishing
+them independently required a `[patch.crates-io]` dance for cross-crate
+development, forced users to install and version-coordinate eight packages, and
+meant a simple `cargo install trusty-mpm` did not exist. The eight surfaces also
+duplicated their daemon-client HTTP layers, so each new endpoint had to be wired
+three times and the UIs drifted apart.
+
+The product is inherently multi-surface: a developer wants one CLI, a background
+daemon, an in-session MCP server, a TUI, and (optionally) a Telegram bot and a
+desktop GUI — but most users want only a subset, and they should not pay the
+compile cost of components they do not use.
+
+## Decision
+
+Consolidate the sub-crates into **one Cargo crate** (`crates/trusty-mpm`) that
+exposes its surfaces as **feature-gated `[[bin]]` targets** sharing common
+library modules:
+
+- Library modules `core`, `client`, and `services` are always compiled; `mcp`,
+  `daemon`, `tui`, and `telegram` are `#[cfg(feature = …)]`-gated.
+- Bin targets `tm` / `trusty-mpm` (`cli`), `trusty-mpmd` (`daemon`),
+  `trusty-mpm-tui` (`tui`), `trusty-mpm-telegram` (`telegram`), and
+  `trusty-mpm-gui` (`gui`) are each gated by `required-features`.
+- A feature chain (`cli → daemon + tui + telegram`; `daemon → mcp`) makes
+  `default = ["cli", "daemon"]` install the common toolset, while keeping the
+  cost of each optional component opt-in.
+- All five surfaces call the **same library functions**; the standalone
+  `trusty-mpm-{tui,telegram,gui}` binaries are kept only as backward-compatible
+  shims, with `tm <subcommand>` as the canonical entry point.
+- The Tauri GUI stays in the separate `trusty-mpm-gui` crate (it owns `build.rs`
+  + `tauri.conf.json`, which cannot be merged into a generic crate) and is
+  wrapped as an optional dependency behind the `gui` feature.
+
+`cargo install trusty-mpm` therefore yields one install target with the daemon,
+MCP server, TUI, and Telegram bot bundled, no external runtime, and framework
+assets compiled in (offline-capable).
+
+## Consequences
+
+**Positive**
+
+- One install (`cargo install trusty-mpm`); no eight-package version coordination.
+- No `[patch.crates-io]` dance for cross-crate development.
+- The shared `client` seam means a new daemon endpoint is wired once and the
+  CLI/TUI/Telegram surfaces never drift.
+- Users pay compile cost only for features they enable.
+
+**Negative / trade-offs**
+
+- "Always-on" CLI/binary support deps (`clap`, `tracing-subscriber`, `colored`,
+  `sysinfo`, `libc`) are compiled even for `--no-default-features` library
+  consumers, because the bin targets pull them in.
+- Consolidation concentrates surface area in one crate: `src/bin/tm.rs` has grown
+  to ~4,442 lines, over the workspace 500-line cap (split tracked by #395).
+- The GUI cannot be fully in-crate; the `gui` feature is a thin shim over the
+  separate Tauri crate, so the bundling story has one explicit exception.
+
+## References
+
+- `crates/trusty-mpm/Cargo.toml` (`[features]`, `[[bin]]`)
+- `crates/trusty-mpm/src/lib.rs` (module `Why` rationale)
+- `crates/trusty-mpm/README.md`
+- [spec/ARCHITECTURE.md §2](../spec/ARCHITECTURE.md#2-multi-binary-topology-single-install-bundling)
+- Issue #343 (decouple trusty-mpm-* crates from the shared `[workspace.package]`
+  version)

--- a/docs/trusty-mpm/decisions/README.md
+++ b/docs/trusty-mpm/decisions/README.md
@@ -1,0 +1,12 @@
+# trusty-mpm — Architecture Decision Records
+
+Nygard-format ADRs capturing load-bearing decisions for the `trusty-mpm` crate.
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-single-install-multi-binary-bundling.md) | Single-install, multi-binary bundling of the trusty-mpm surfaces | Accepted |
+
+## Related Documentation
+
+- [Specification set](../spec/README.md)
+- [Crate doc index](../README.md)

--- a/docs/trusty-mpm/spec/ARCHITECTURE.md
+++ b/docs/trusty-mpm/spec/ARCHITECTURE.md
@@ -1,0 +1,402 @@
+# trusty-mpm — System Architecture
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+> **Crate:** `crates/trusty-mpm/` (version `0.5.0`, edition 2024, `publish = false`)
+> **Companion docs:** [PRD.md](./PRD.md) · [COMPONENTS.md](./COMPONENTS.md)
+
+Status tags: ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational.
+
+---
+
+## 1. One crate, five surfaces, one daemon
+
+trusty-mpm is **one Cargo crate** that compiles into **multiple feature-gated
+binaries** sharing a common set of library modules. A single resident daemon
+(`trusty-mpmd`) is the coordination hub; the CLI, TUI, Telegram bot, GUI, and the
+in-session MCP server are all **clients** of that daemon. Coordinated Claude Code
+session processes connect to the daemon over HTTP (the hook relay) and are
+launched as **stock `claude` processes** shaped by deployed framework artifacts —
+trusty-mpm never forks the `claude` binary.
+
+```
+                          ┌──────────────────────────────────────────────┐
+                          │   ONE MACHINE  (single-instance enforced)      │
+                          │                                                │
+  operator ── tm CLI ─────┼────────────┐                                   │
+  operator ── tm tui ─────┼──────────┐ │   HTTP (loopback :7880)           │
+  phone ───── Telegram ───┼────────┐ │ │   + SSE event feed                │
+  desktop ─── GUI ────────┼──────┐ │ │ │                                   │
+                          │      ▼ ▼ ▼ ▼                                   │
+                          │   ┌───────────────────────────────────────┐   │
+                          │   │   trusty-mpmd  (resident daemon)        │   │
+                          │   │   ┌─────────────────────────────────┐  │   │
+                          │   │   │ Arc<DaemonState> (single source) │  │   │
+                          │   │   │  sessions · delegations ·        │  │   │
+                          │   │   │  breakers · memory · hook ring · │  │   │
+                          │   │   │  projects · overseer · pairing   │  │   │
+                          │   │   └─────────────────────────────────┘  │   │
+                          │   │   axum router · hook relay · watcher ·  │   │
+                          │   │   reaper · discovery · MCP backend       │   │
+                          │   └───────▲───────────────▲─────────────────┘   │
+                          │           │ POST /hooks   │ spawn / send-keys    │
+                          │     hook forwarder        │ (tmux)               │
+                          │   (`tm hook`)             ▼                      │
+                          │   ┌──────────────────────────────────────────┐  │
+                          │   │  coordinated Claude Code session processes │  │
+                          │   │  (stock `claude`, in tmux panes or native  │  │
+                          │   │   Terminal.app windows) — each shaped by   │  │
+                          │   │   deployed agents/skills, project CLAUDE.md,│  │
+                          │   │   appended system prompt, injected trusty-* │  │
+                          │   │   MCP; each can call the in-session MCP     │  │
+                          │   │   server's 6 orchestration tools            │  │
+                          │   └──────────────────────────────────────────┘  │
+                          │                                                │
+                          │   framework install: ~/.trusty-mpm/...          │
+                          │   deploy targets:     ~/.claude/{agents,skills} │
+                          └──────────────────────────────────────────────┘
+```
+
+Lock file: `~/.trusty-mpm/daemon.lock` records the bound address + PID so clients
+resolve the live daemon and a second `trusty-mpmd` start is refused.
+
+### Relationship to open-mpm
+
+There is **no Cargo dependency** between trusty-mpm and open-mpm in either
+direction, and neither crate imports the other. The only cross-references are
+doc-comment lineage notes: the tmux helpers in `src/core/tmux.rs:6` and
+`src/daemon/tmux.rs:7` were modelled on open-mpm's `tm` manager module, and
+`src/bin/tm.rs:1318` notes the shared tmux-session naming convention. open-mpm is
+the *orchestration engine* (it dispatches tasks to models itself, in-process);
+trusty-mpm is the *coordinator of external Claude Code processes*. See
+[README §Relationship to open-mpm](./README.md#relationship-to-open-mpm).
+
+---
+
+## 2. Multi-binary topology (single-install bundling)
+
+The crate manifest declares one library and six `[[bin]]` targets, each gated by
+the feature it needs (`crates/trusty-mpm/Cargo.toml`).
+
+### Bin-target table
+
+| Binary | `[[bin]]` path | Required feature | Role | Status |
+|---|---|---|---|---|
+| `tm` | `src/bin/tm.rs` | `cli` | Primary unified CLI: daemon control, sessions, projects, launch/connect/attach, optimizer/overseer, coordinator, services, install, hook, plus `tui`/`telegram`/`gui` subcommands. | ✅ |
+| `trusty-mpm` | `src/bin/tm.rs` (same source) | `cli` | Long-name alias of `tm` — identical entry point. | ✅ |
+| `trusty-mpmd` | `src/bin/trusty-mpmd.rs` | `daemon` | Backward-compatible daemon shim → `daemon::run_http` / `run_mcp`. Prefer `tm daemon`. | ✅ |
+| `trusty-mpm-tui` | `src/bin/trusty-mpm-tui.rs` | `tui` | Backward-compatible TUI shim → `tui::run`. Prefer `tm tui`. | ✅ |
+| `trusty-mpm-telegram` | `src/bin/trusty-mpm-telegram.rs` | `telegram` | Backward-compatible Telegram shim → `telegram::run`. Prefer `tm telegram`. | ✅ |
+| `trusty-mpm-gui` | `src/bin/trusty-mpm-gui.rs` | `gui` | Thin shim → `trusty_mpm_gui::run()` (the Tauri app lives in the separate `trusty-mpm-gui` crate). Prefer `tm gui`. | ✅ (out-of-crate) |
+
+**Single-install convention.** `cargo install trusty-mpm` builds the
+`default = ["cli", "daemon"]` features, producing `tm`/`trusty-mpm` (which embeds
+the daemon, TUI, and Telegram logic via the `cli → daemon + tui + telegram`
+feature chain) plus the `trusty-mpmd` shim. The standalone `trusty-mpm-tui`,
+`trusty-mpm-telegram`, and `trusty-mpm-gui` binaries are kept only as
+backward-compatible shims; the canonical entry points are `tm <subcommand>`. All
+binaries call the **same library functions**, so the five surfaces never drift.
+
+### Feature graph
+
+```
+cli ── enables ──▶ daemon ── enables ──▶ mcp        (async-trait)
+   ├─ enables ──▶ tui                                (ratatui, crossterm)
+   └─ enables ──▶ telegram                           (teloxide, tokio-util)
+
+daemon  pulls ── axum, tower, tower-http, tokio-stream, futures,
+                 dashmap, parking_lot, notify, tracing-appender,
+                 utoipa-swagger-ui
+gui     pulls ── trusty-mpm-gui (separate Tauri crate)   ← opt-in only
+```
+
+Each optional binary is gated so a user pays the compile cost only for the
+components they install. `cargo add trusty-mpm --no-default-features` yields the
+libraries (`core` + `client` + `services`) with no binaries.
+
+---
+
+## 3. Library module map (shared core)
+
+```
+crates/trusty-mpm/src/
+├── lib.rs            # re-exports: services, core, client (always);
+│                     #             mcp/daemon/tui/telegram (feature-gated)
+├── services/         # ALWAYS-ON: `tm services` discovery (manifest + discoverer)
+├── core/             # ALWAYS-ON: domain types, deploy pipeline, instruction
+│                     #            assembly, IPC, paths, lock-file/url resolution
+├── client/           # ALWAYS-ON: DaemonClient (HTTP), TrustyCommand,
+│                     #            CommandExecutor, CommandResult  (the one shared seam)
+├── mcp/              # feature: mcp       — OrchestratorBackend trait, tool catalog, dispatch
+├── daemon/           # feature: daemon    — axum API, DaemonState, hook relay,
+│                     #                       watcher, reaper, discovery, lock, MCP backend
+├── tui/              # feature: tui       — ratatui dashboard
+├── telegram/         # feature: telegram  — teloxide bot
+└── bin/              # the six [[bin]] entry points (thin)
+```
+
+| Module | Responsibility | Key files |
+|---|---|---|
+| `core` | Domain model + launch machinery: sessions, agents, hooks, circuit breakers, memory, overseer, **agent inheritance/deploy**, **skill deploy**, **instruction pipeline**, **session launch prep**, `FrameworkPaths`, lock-file path, daemon-URL resolution. | `agent_builder.rs`, `agent_deployer.rs`, `agent_manifest.rs`, `skill_deployer.rs`, `skill_manifest.rs`, `instruction_pipeline.rs`, `session_launch.rs`, `paths.rs`, `circuit.rs`, `memory.rs`, `delegation_authority.rs`, `connect.rs`, `bundle.rs` |
+| `client` | The **single shared seam**: one HTTP transport (`DaemonClient`) + one command model (`TrustyCommand`) + one dispatcher (`CommandExecutor`) + one UI-agnostic result type (`CommandResult`). CLI, TUI, and Telegram all depend on exactly this layer. | `http_client.rs`, `command.rs`, `executor.rs`, `result.rs` |
+| `mcp` | Six orchestration tools + the `OrchestratorBackend` trait (Dependency-Inversion seam) + `dispatch`. | `mcp/mod.rs`, `mcp/tools.rs` |
+| `daemon` | HTTP API + shared state + hook relay + file watcher + reaper + discovery + lock + MCP backend + overseer composition + pairing store + coordinator/claude-config routes. | `daemon/api.rs` (+ `api/`), `daemon/state.rs`, `daemon/lock.rs`, `daemon/watcher.rs`, `daemon/discovery.rs`, `daemon/mcp_backend.rs`, `daemon/services/*` |
+| `tui` | ratatui coordinator dashboard polling the daemon. | `tui/dashboard.rs`, `tui/client.rs`, `tui/health.rs`, `tui/iterm2.rs` |
+| `telegram` | teloxide adapter → `CommandExecutor`, formatter, push-alert loop, pairing flow. | `telegram/commands.rs`, `telegram/alerts.rs`, `telegram/formatter.rs` |
+| `services` | `tm services` manifest + discovery engine. | `services/manifest.rs`, `services/discoverer.rs` |
+
+---
+
+## 4. Single-daemon coordination model
+
+> The heart of the product: **one daemon per machine coordinating multiple
+> Claude Code session processes.**
+
+### 4.1 Single-instance enforcement (`src/bin/tm.rs:3139-3171`)
+
+Three layers guarantee one daemon per host:
+
+1. **Lock-file PID validation.** `resolve_daemon_url(None)` reads the recorded
+   address from `~/.trusty-mpm/daemon.lock`, validates the recorded PID is alive,
+   and clears stale locks (`core/connect.rs`).
+2. **`/health` probe.** If the recorded URL is non-default *and*
+   `probe_health(url, "/health")` succeeds, the daemon prints "already running"
+   and exits cleanly — refusing a duplicate.
+3. **OS port bind.** Otherwise it binds `127.0.0.1:7880` (`TRUSTY_MPM_ADDR`
+   override). On `AddrInUse` it falls back to an ephemeral port; the health-probe
+   guard prevents that fallback from silently spawning a traffic-splitting second
+   daemon.
+
+After bind, `lock::write_lock` records `pid`/`addr`/optional `tailscale_addr`/
+`started_at`. A shutdown task traps **SIGINT and SIGTERM** and removes the lock so
+a `tm restart` (pkill → SIGTERM) never leaks a stale lock (`tm.rs:3209-3218`).
+
+### 4.2 Session entry paths
+
+A "session" is a Claude Code process. Sessions enter the registry by three paths:
+
+| Path | Trigger | Code |
+|---|---|---|
+| **Spawn** | `POST /sessions` with a `workdir` → daemon creates the tmux host and starts `claude` via `TmuxService::spawn_claude` *before* registering (a 422/500 leaves the registry untouched). | `api.rs:303-354` |
+| **Register-only** | `POST /sessions` without `workdir`, or `POST /api/v1/sessions/connect` — pure bookkeeping; the CLI owns tmux + deployment. | `api.rs:272-381` |
+| **Connection-driven** | `POST /hooks` with a `SessionStart` for an unknown id → the daemon auto-registers from the incoming UUID (the session "announces itself"). | `api.rs:929-945` |
+
+After spawn/register, the daemon discovers the real `claude` PID inside the tmux
+pane in the background (`spawn_pid_capture`) so the reaper can monitor liveness;
+the CLI also reports it via `PATCH /sessions/{id}/pid`. **Auto-discovery** at boot
+and on `POST /sessions/discover` scans tmux panes *and* native Terminal.app `ps`
+processes and adopts them (`daemon/mod.rs:84-92`).
+
+### 4.3 The single source of truth (`daemon/state.rs:72-162`)
+
+`Arc<DaemonState>` is injected into every axum handler **and** the MCP backend, so
+HTTP clients and in-session MCP tools observe the same world:
+
+- `sessions: DashMap<SessionId, Session>`
+- `delegations: DashMap<Uuid, Delegation>`
+- `breakers: DashMap<String, CircuitBreaker>`
+- `memory: DashMap<SessionId, MemoryUsage>`
+- `hook_history: Mutex<VecDeque<HookEventRecord>>` (ring buffer, `HOOK_HISTORY_LIMIT = 1024`)
+- `projects: RwLock<HashMap<PathBuf, ProjectInfo>>`
+- `overseer: Arc<dyn Overseer>` + optional `llm`
+- `event_tx: broadcast::Sender<Value>` (SSE fan-out, `EVENT_CHANNEL_CAPACITY = 1024`)
+- `paired_chat_id` / `pair_code` / `framework_root` (Telegram pairing, persisted)
+
+### 4.4 Hook relay & enforcement point (`POST /hooks`, `api.rs:904-953`)
+
+The hook forwarder (`tm hook`) is the Rust replacement for claude-mpm's per-fire
+Python process: it reads minimal context from Claude Code env vars, posts a
+`hook_event`, exits 0, and short-circuits when `CLAUDE_MPM_SUB_AGENT=1` (so nested
+sub-agents generate no hook traffic). `POST /hooks` is the enforcement point:
+
+1. Parse session id (malformed → 400; unknown event name → 400 at deserialization).
+2. `SessionStart` for an unknown session → auto-register (connection-driven path).
+3. `HookService::process` → consult the overseer on tool-use events; a `Block`
+   decision returns **403** before the tool runs; every decision is audited (JSONL).
+4. Compress `PostToolUse` output per the optimizer policy.
+5. Append a `HookEventRecord` to the ring buffer; broadcast a JSON copy to SSE.
+
+🔵 **Designed-not-built (FR-CB-3, #393).** `HookService::process` is the intended
+hook point for daemon-enforced CB#1–#14 hard blocks; today CB#1–#14 are PM
+self-discipline enforced only through instructions, and the daemon enforces only
+the per-agent failure breaker.
+
+### 4.5 Event streaming & reaping
+
+- `GET /events` / `GET /sessions/{id}/events` — live SSE streams (15s keep-alive
+  ping); `GET .../events/poll` — synchronous ring-buffer snapshots for non-SSE
+  clients (`api.rs:192-218,559-593`).
+- A 60s `reap_loop` + `DELETE /sessions/dead` call `reap_against`
+  (`state.rs:564-634`): tmux gone → remove; tmux alive but `claude` PID dead →
+  mark `Stopped`; native sessions are never tmux-reaped.
+
+---
+
+## 5. MCP stdio framing
+
+The in-session MCP server (`tm daemon --mcp` / `run_mcp`) is a stdio JSON-RPC
+server backed by `StateBackend` over the same `Arc<DaemonState>`
+(`daemon/mod.rs:154-170`). `dispatch` (`mcp/mod.rs`) routes a JSON-RPC `Request`
+to the `OrchestratorBackend` trait; the daemon supplies the concrete impl, keeping
+the `mcp` module free of daemon internals (process spawning, tmux, sockets) and
+thus unit-testable against a `MockBackend`.
+
+🔴 **stdout is reserved for JSON-RPC framing.** All logging goes to **stderr**
+(`init_tracing`). A stray `println!` would corrupt the protocol. This holds across
+every binary, including the daemon's HTTP mode.
+
+The six tools (`mcp/tools.rs:19-136`) are how a Claude Code session introspects and
+participates in host-wide coordination from inside its own context: `session_list`,
+`session_status`, `agent_delegate`, `memory_protect`, `circuit_breaker_status`,
+`hook_event`. Server identity is `SERVER_NAME = "trusty-mpm"`, version =
+`CARGO_PKG_VERSION`.
+
+---
+
+## 6. Daemon HTTP API surface
+
+Built in `api::router` (`daemon/api.rs:72-127`). Default base
+`http://127.0.0.1:7880`. OpenAPI/Swagger at `/api-docs` (+ `/openapi.json`).
+
+| Method | Path | Purpose | Status |
+|---|---|---|---|
+| GET | `/health` | Liveness probe (`"ok"`). | ✅ |
+| GET / POST | `/sessions` | List (optional `?project=`) / register-or-spawn. | ✅ |
+| POST | `/api/v1/sessions/connect` | Register for a connect (no-deploy) launch. | ✅ |
+| DELETE | `/sessions/dead` | Reap dead tmux sessions. | ✅ |
+| POST | `/sessions/discover` | Auto-discover tmux + native sessions. | ✅ |
+| GET / DELETE | `/sessions/{id}` | Fetch / deregister. | ✅ |
+| GET | `/sessions/{id}/events[/poll]` | Live SSE / snapshot for one session. | ✅ |
+| POST | `/sessions/{id}/pause` · `/resume` | Pause/resume with note. | ✅ |
+| POST | `/sessions/{id}/command` | Send a line to the tmux pane, capture output. | ✅ |
+| GET | `/sessions/{id}/output` · `/pane` | Capture pane scrollback (optional compress). | ✅ |
+| PATCH | `/sessions/{id}/pid` | Record the `claude` PID. | ✅ |
+| GET | `/sessions/{id}/files` | Per-session created-file tracking. | 🔵 #94 |
+| GET / POST | `/projects`, `/projects/current`, `/projects/discover` | Project registry. | ✅ |
+| GET | `/events` · `/events/poll` | Global SSE / snapshot feed. | ✅ |
+| POST | `/hooks` | Universal hook relay (overseer enforcement point). | ✅ |
+| GET | `/breakers` | Per-agent circuit-breaker state. | ✅ |
+| GET | `/optimizer` · `/overseer` | Read framework-managed policy. | ✅ |
+| POST | `/llm/chat` | Coordinator LLM chat (503 if no overseer). | ✅ |
+| GET / POST | `/api/v1/coordinator/context` · `/chat` | Cross-session coordinator. | ✅ |
+| GET / POST | `/tmux/sessions`, `/tmux/sessions/{name}/snapshot`, `/tmux/adopt` | Universal tmux management. | ✅ |
+| GET / POST | `/claude-config*` | Claude Code config analyzer + checkpoints/profiles. | ✅ |
+| POST / GET | `/pair/request` · `/confirm` · `/status` · `/reset` | Telegram pairing. | ✅ |
+| GET | `/api/v1/doctor` | Full-stack diagnostic. | ✅ |
+| GET | `/api-docs` (+ `/openapi.json`) | Swagger UI. | ✅ |
+
+---
+
+## 7. Instruction-assembly pipeline
+
+Two layers operate (`core/instruction_pipeline.rs`):
+
+**(a) System-prompt assembly** (`:31-72`) — `include_str!` concat at compile time:
+
+```
+PM_INSTRUCTIONS  →  WORKFLOW  →  AGENT_DELEGATION  →  BASE_PM
+```
+
+joined with `\n\n---\n\n`; `BASE_PM` is appended **last** as the non-overridable
+floor (carries the Trusty tool-priority block). `install_system_prompt()` writes
+the result to `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`;
+`build_system_prompt()` reads it back and passes it to
+`claude --append-system-prompt-file` (`session_launch.rs:541-579`).
+
+**(b) Runtime merge** (`build_instructions`, `:163-204`), sections **3 → 4 → 5**:
+framework `INSTRUCTIONS.md` → delegation authority generated fresh from deployed
+agents (`scan_agents` + `generate_authority`) → project `CLAUDE.md` (seeded once,
+never overwritten). The merged text is stashed to
+`<project>/.trusty-mpm/last-instructions.md`.
+
+🔵 **Designed-not-built (FR-IN-4).** `BASE_PM.md:17-33` advertises a 5-file project
+override system (`.trusty-mpm/{INSTRUCTIONS,AGENT_DELEGATION,WORKFLOW,MEMORY,
+PM_INSTRUCTIONS_DEPLOYED}.md`); no Rust code reads these — only `CLAUDE.md` is
+consumed. 🟡 Defects #382 (stash diverges from actual prompt) and #383 (`tm
+install` overwrites the prompt with a 4-line stub) live here.
+
+---
+
+## 8. Filesystem layout
+
+```
+~/.trusty-mpm/                              # framework root (FrameworkPaths::root)
+├── daemon.lock                            # bound addr + PID (single-instance discovery)
+├── config.toml                            # CANONICAL config (models.agents.*, [agents] sources, …)
+├── pairing.json                           # Telegram chat pairing
+├── logs/                                  # rolling daemon log + overseer audit JSONL
+├── registry/                              # 🔵 INTENDED remote-agent cache (unused stub, #388)
+└── framework/
+    ├── instructions/INSTRUCTIONS.md       # assembled system prompt (regenerated)
+    ├── instructions/CLAUDE.md             # user-editable stub
+    ├── agents/                            # bundled agent SOURCE (fallback)
+    ├── skills/                            # bundled skill SOURCE (fallback)
+    └── hooks/{optimizer.toml,overseer.toml}  # framework-managed policy (watcher hot-reloads)
+
+~/.claude/                                  # Claude Code reads these
+├── agents/                                # composed agent deploy target (+ .trusty-mpm-manifest.json)
+├── skills/                                # skill deploy target (+ manifest)
+└── output-styles/trusty-mpm.md            # deployed output style
+
+~/.claude-mpm/                              # heritage / services namespace
+├── services.yaml                          # tm services manifest (or embedded default)
+└── agents/                                # 🔵 INTENDED user-level agent source (3-level precedence; unread, #387)
+
+<project>/                                  # per-project, written on launch prep
+├── CLAUDE.md                              # seeded once, never overwritten
+├── .claude/settings.json                  # outputStyle + spinner tips + trusty-memory hooks
+├── .mcp.json                              # injected trusty-memory MCP server
+├── .trusty-mpm/last-instructions.md       # merged-instruction stash (inspection)
+└── .trusty-mpm/{INSTRUCTIONS,AGENT_DELEGATION,WORKFLOW,MEMORY,PM_INSTRUCTIONS_DEPLOYED}.md
+                                            #   🔵 INTENDED project overrides (unread, FR-IN-4)
+```
+
+A source-checkout's `agents/` submodule (`<repo>/agents/{agents,skills}/`) wins
+over the bundled framework directories when present (`paths.rs:181-208`).
+
+---
+
+## 9. Configuration & environment
+
+**Canonical config: `~/.trusty-mpm/config.toml`** (TOML, Rust/Cargo conventions).
+The `config.yaml` reference in `PM_INSTRUCTIONS.md` is a stale Python-era artifact
+to be corrected (#385/#394).
+
+| File | Read by | Status |
+|---|---|---|
+| `framework/hooks/optimizer.toml` | daemon `OptimizerConfig` (watcher hot-reloads) | ✅ |
+| `framework/hooks/overseer.toml` | daemon `OverseerConfig` (`[llm]` gates the LLM overseer) | ✅ |
+| `~/.claude-mpm/services.yaml` | `tm services` (`ServicesManifest`; embedded default fallback) | ✅ |
+| `config.toml models.agents.*` | (intended) per-agent model overrides | 🟡 not read (#394) |
+| `config.toml [agents] sources` | (intended) remote registry sources | 🔵 not read (#388) |
+
+Environment: `TRUSTY_MPM_URL` (client base URL), `TRUSTY_MPM_ADDR` (daemon bind),
+`TRUSTY_MPM_TAILSCALE`, `OPENROUTER_API_KEY` (LLM overseer/chat), `RUST_LOG`,
+`CLAUDE_MPM_SUB_AGENT=1` (hook short-circuit), `TELEGRAM_BOT_TOKEN`.
+
+---
+
+## 10. Source reference index
+
+| Concern | File:line |
+|---|---|
+| Crate manifest (features, bins) | `crates/trusty-mpm/Cargo.toml` |
+| Library surface (gated modules) | `src/lib.rs` |
+| Single-instance enforcement + daemon boot | `src/bin/tm.rs:3139-3218` |
+| Lock file | `src/daemon/lock.rs` |
+| Daemon boot / discovery / reaper / MCP wiring | `src/daemon/mod.rs` |
+| HTTP router + handlers | `src/daemon/api.rs:72-1413` |
+| Shared state (single source of truth) | `src/daemon/state.rs:72-906` |
+| Session registry / reaping | `src/daemon/state.rs:476-634` |
+| Overseer composition (deterministic + LLM) | `src/daemon/state.rs:193-274` |
+| MCP tool catalog + dispatch | `src/mcp/mod.rs`, `src/mcp/tools.rs:19-136` |
+| Shared client seam (transport/command/executor) | `src/client/mod.rs` |
+| Instruction assembly (4-asset concat) | `src/core/instruction_pipeline.rs:31-72` |
+| Runtime merge pipeline (3→4→5) | `src/core/instruction_pipeline.rs:163-204` |
+| Session launch prep (deploy + MCP/hook wiring) | `src/core/session_launch.rs:82-579` |
+| Agent inheritance composition | `src/core/agent_builder.rs:212-327` |
+| Agent deploy (checksum/manifest) | `src/core/agent_deployer.rs:57-134` |
+| Framework paths + submodule source | `src/core/paths.rs:74-232` |
+| CLI command surface | `src/bin/tm.rs:38-197` |
+| open-mpm lineage notes (no dep) | `src/core/tmux.rs:6`, `src/daemon/tmux.rs:7`, `src/bin/tm.rs:1318` |

--- a/docs/trusty-mpm/spec/COMPONENTS.md
+++ b/docs/trusty-mpm/spec/COMPONENTS.md
@@ -1,0 +1,259 @@
+# trusty-mpm — Component Specifications
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+> **Crate:** `crates/trusty-mpm/` (version `0.5.0`, edition 2024, `publish = false`)
+> **Companion docs:** [PRD.md](./PRD.md) · [ARCHITECTURE.md](./ARCHITECTURE.md)
+
+Status tags: ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational.
+Each component states **responsibility**, **key types/modules** (with `src/`
+paths), **current state**, and **gaps**.
+
+---
+
+## A. Binaries
+
+### 1. CLI — `tm` / `trusty-mpm` (`src/bin/tm.rs`, feature `cli`)
+
+- **Responsibility.** The primary unified entry point. One `Command` enum
+  (`tm.rs:38-197`) covers daemon control (`start`/`stop`/`restart`/`status`/
+  `daemon`), session ops, project ops, `launch`/`connect`/`attach`, optimizer/
+  overseer, coordinator, `services`, `install`, `hook`, and the `tui`/`telegram`/
+  `gui` subcommands (which call the in-crate library modules directly).
+- **Key types.** `Command` enum; `Launch` → `session_launch::prepare_session`;
+  the daemon-boot + single-instance logic at `tm.rs:3139-3218`; the hook
+  forwarder (`Hook` arm).
+- **Current state.** ✅ Full command surface; both `tm` and `trusty-mpm` map to
+  the same source. `tm tui`/`tm telegram`/`tm gui` are the canonical entry points;
+  the standalone shim binaries are kept only for backward compatibility.
+- **Gaps.** 🟡 `tm.rs` is ~4,442 lines, far over the 500-line cap — split tracked
+  by **#395**. 🟡 `tm install` overwrites the assembled system prompt with a
+  4-line stub (**#383**) and historically deployed agents but not skills
+  (FR-DEP-3, #386).
+
+### 2. Daemon — `trusty-mpmd` (`src/bin/trusty-mpmd.rs` shim; `src/daemon/`, feature `daemon`)
+
+- **Responsibility.** The resident coordination hub: HTTP API + universal hook
+  relay + session registry + file watcher + reaper + discovery + MCP backend +
+  overseer composition + Telegram pairing store. One per machine.
+- **Key types.** `DaemonState` (`daemon/state.rs:72-162`); `api::router`
+  (`daemon/api.rs:72-127`); `run_http` / `run_mcp` (`daemon/mod.rs:154-170`);
+  `Lock` (`daemon/lock.rs`); `watcher` (hot-reload of `optimizer.toml`/
+  `overseer.toml`); `reap_loop` (`daemon/mod.rs:128-152`); service modules
+  (`daemon/services/{hook_service,session_service,tmux_service,pairing_service}.rs`).
+- **Current state.** ✅ All HTTP endpoints in
+  [ARCHITECTURE §6](./ARCHITECTURE.md#6-daemon-http-api-surface) implemented;
+  three-layer single-instance enforcement; SIGINT+SIGTERM-clean lock teardown;
+  Swagger at `/api-docs`.
+- **Gaps.** 🟡 Atomic deploy writes + corrupt-manifest handling (**#392**) live in
+  the deploy services. 🔵 `GET /sessions/{id}/files` per-session file tracking
+  (**#94**).
+
+### 3. MCP server (`src/mcp/`, feature `mcp`; served via `tm daemon --mcp`)
+
+- **Responsibility.** Expose six orchestration tools to an in-session Claude Code
+  process over stdio JSON-RPC, backed by the live `Arc<DaemonState>`.
+- **Key types.** `OrchestratorBackend` trait (`mcp/mod.rs`) — the
+  Dependency-Inversion seam keeping the MCP layer free of daemon internals;
+  `dispatch`; `TOOL_CATALOG`/`tool_catalog` (`mcp/tools.rs:19-136`);
+  `StateBackend` concrete impl (`daemon/mcp_backend.rs`); `SERVER_NAME =
+  "trusty-mpm"`.
+- **Current state.** ✅ Six tools: `session_list`, `session_status`,
+  `agent_delegate`, `memory_protect`, `circuit_breaker_status`, `hook_event`.
+  Unit-tested against a `MockBackend`. stdout reserved for framing; logs to stderr.
+- **Gaps.** None functional; tool count must stay consistent with docs (**#430**).
+
+### 4. TUI — `trusty-mpm-tui` / `tm tui` (`src/tui/`, feature `tui`)
+
+- **Responsibility.** A ratatui app: a coordinator chat with visibility into every
+  active session, beside a dismissable session sidebar and a health panel.
+- **Key types.** `tui::run(url, interval_ms)`; `dashboard` (panes), `client`
+  (HTTP), `health` (combined search+memory health, #37), `iterm2` (terminal
+  integration). Polls the daemon's coordinator-context endpoint on a timer and
+  POSTs to the coordinator-chat endpoint.
+- **Current state.** ✅ Live dashboard; rendering + client unit-tested. Shipped as
+  `tm tui` (canonical) and the `trusty-mpm-tui` shim.
+- **Gaps.** None known.
+
+### 5. Telegram bot — `trusty-mpm-telegram` / `tm telegram` (`src/telegram/`, feature `telegram`)
+
+- **Responsibility.** Remote management from a phone: pair a bot, list/inspect
+  sessions, send commands, approve permission requests, inspect overseer/tmux,
+  and receive push alerts.
+- **Key types.** `run` (boots the teloxide dispatcher); `TelegramCommand` + its
+  `From`/conversion into the shared `TrustyCommand` (`telegram/commands.rs`);
+  `TelegramFormatter` (`telegram/formatter.rs`); the pure alert-decision core
+  `AlertConfig`/`LastSeen` (`telegram/alerts.rs`); `BotOptions`. A *thin adapter*
+  over `client::CommandExecutor` — all daemon I/O lives in the shared client.
+- **Current state.** ✅ Pairing (`/pair/*` + `pairing_store`), command dispatch,
+  formatting, push-alert loop. Token resolved from `--token` / `.env.local` /
+  `.env` / `TELEGRAM_BOT_TOKEN`; `--check` validates without connecting.
+- **Gaps.** None known.
+
+### 6. GUI shim — `trusty-mpm-gui` / `tm gui` (`src/bin/trusty-mpm-gui.rs`, feature `gui`)
+
+- **Responsibility.** Wrap the Tauri desktop app (which lives in the separate
+  `trusty-mpm-gui` crate because Tauri requires its own `build.rs` +
+  `tauri.conf.json`) as a `[[bin]]` target of the unified crate.
+- **Key types.** A ~5-line shim calling `trusty_mpm_gui::run()`; suppresses the
+  console window on Windows release builds.
+- **Current state.** ✅ Out-of-crate; opt-in via the `gui` feature (optional
+  dependency). Requires Tauri prerequisites (`xcode-select`, `rustup`, `pnpm`).
+- **Gaps.** None in this crate; GUI logic is owned by `trusty-mpm-gui`.
+
+---
+
+## B. Shared library subsystems
+
+### 7. Shared client seam — `src/client/`
+
+- **Responsibility.** The single HTTP/command layer that CLI, TUI, and Telegram
+  all share, so a new endpoint is wired once and the UIs never drift.
+- **Key types.** `DaemonClient` (one HTTP transport, `http_client.rs`);
+  `TrustyCommand` (one command model, `command.rs`); `CommandExecutor` (the only
+  command→HTTP translator, `executor.rs`); `CommandResult` (one UI-agnostic result
+  type, `result.rs`); plus the row/outcome DTOs (`SessionRow`, `BreakerRow`,
+  `CoordinatorContext`, `LlmChatOutcome`, …).
+- **Current state.** ✅ URL construction, command model, and executor unit-tested
+  against an in-process test daemon.
+- **Gaps.** None known.
+
+### 8. Session management — `src/core/session*.rs`, `src/daemon/state.rs`
+
+- **Responsibility.** The registry, spawn/register/discover paths, pause/resume
+  persistence, command/pane I/O, and reaping that make "one daemon, many sessions"
+  real.
+- **Key types.** `Session` (`core/session.rs`: id, project, `workdir`, `tmux_name`,
+  `pid`, `status` ∈ Starting/Active/Paused/Stopped, `origin` ∈ Tmux/Native,
+  `control_model`, pause fields); `SessionId` (UUID newtype, bare-string serde);
+  `session_store` (disk persistence of pause records); `session_launch`
+  (deploy + MCP/hook wiring); the three entry paths + `reap_against`
+  (`state.rs:303-381,564-634`).
+- **Current state.** ✅ Register/spawn/get/list/remove/pause/resume/command/pane;
+  boot + on-demand auto-discovery of tmux and native sessions; periodic reaping
+  that preserves native sessions.
+- **Gaps.** 🔵 Per-session created-file tracking (`GET /sessions/{id}/files`, #94).
+
+### 9. Agent delegation — `src/core/agent.rs`, `delegation_authority.rs`, `mcp/tools.rs`
+
+- **Responsibility.** Let a session request a delegation; the daemon applies
+  circuit-breaker + depth limits before spawning, and tracks the delegation tree.
+- **Key types.** `Delegation` (id, session, target agent, task; `core/agent.rs`),
+  stored in `DaemonState.delegations`; `generate_authority` (builds the delegation
+  routing table from deployed agents at launch, `delegation_authority.rs`); the
+  `agent_delegate` MCP tool.
+- **Current state.** ✅ Delegation requests gated by per-agent breaker + depth.
+- **Gaps.** None functional; the delegation *routing table* depends on deployed
+  agents, so deploy gaps (§12) bound it.
+
+### 10. Circuit breakers — `src/core/circuit.rs`, `src/daemon/state.rs`
+
+- **Responsibility.** Two distinct breaker concepts: (a) the **per-agent failure
+  breaker** the daemon enforces, and (b) the **PM-behaviour breakers (CB#1–#14)**
+  defined in instructions.
+- **Key types.** `CircuitBreaker` (`consecutive_failures`, `allows_delegation()`)
+  + `CircuitConfig` (default 3-strike); `DaemonState.record_outcome`; `GET
+  /breakers` + the `circuit_breaker_status` MCP tool.
+- **Current state.** ✅ Per-agent failure breaker tracked and surfaced. 🟡 CB#1–#14
+  (block Edit/Write, `curl`/`lsof`/`ps`/`make`, browser tools, `gh`, `sed`/`awk`,
+  …) are PM self-discipline enforced only through instructions.
+- **Gaps.** 🔵 **Daemon-enforced CB#1–#14** — detect violations at `POST /hooks`
+  (`HookService::process`) and return 403 before the tool runs (FR-CB-3, **#393**).
+
+### 11. Memory protection & routing — `src/core/memory.rs`, `session_launch.rs`
+
+- **Responsibility.** Per-session context-window pressure classification, plus
+  wiring the trusty-memory MCP backend + memory hooks into a launched project.
+- **Key types.** `MemoryUsage` / `MemoryPressure` (`used_tokens`/`window_tokens`;
+  ok/warn/alert/compact via `MemoryConfig`, `core/memory.rs`);
+  `DaemonState.record_memory`; the `memory_protect` MCP tool; `write_project_hooks`
+  + `remove_global_trusty_memory_hooks` (`session_launch.rs:286-539`).
+- **Current state.** ✅ Pressure classification; trusty-memory MCP injected into
+  project `.mcp.json`; `trusty-memory hooks fire …` written into project
+  `.claude/settings.json`; global duplicate hooks removed.
+- **Gaps.** None. (kuzu-memory / static `.claude-mpm/memories` are **out of
+  scope** — Python-era; trusty-memory MCP is the sole intended backend.)
+
+### 12. Agent & skill deployment — `src/core/agent_builder.rs`, `agent_deployer.rs`, `agent_manifest.rs`, `skill_*`
+
+- **Responsibility.** Compose `extends:` agent chains into self-contained files
+  and deploy agents + skills into `~/.claude/` idempotently, never clobbering
+  user-owned/edited files.
+- **Key types.** `compose_agent` (base-first walk, child-wins frontmatter merge,
+  cycle + `MAX_DEPTH = 8` guards, `agent_builder.rs:212-327`); `deploy_agents` /
+  `deploy_skills`; `AgentManifest`/`SkillManifest` (`filename → {source_chain,
+  sha256, deployed_at, origin}`; `Origin` ∈ Bundled/Registry/User); `FrameworkPaths`
+  source resolution (`paths.rs:171-208`: `agents/` submodule wins over bundled
+  framework dirs).
+- **Current state.** ✅ Composition + checksum-guarded ownership-aware deploy
+  (skip user-owned, safe-refresh managed-unchanged-source, skip user-edited,
+  compose+write+record new). Confirmed chain `engineer → base-engineer →
+  base-agent`. One source, one target.
+- **Gaps.** 🟡 Frontmatter parser splits on first `:` and truncates colon-bearing
+  values; two divergent parser copies (**#389**); no Claude Code `model:`-injection
+  workaround (**#390**). 🟡 Non-atomic writes / corrupt-manifest handling
+  (**#392**). 🔵 Stale-file pruning on rename/removal (**#391**). 🔵 3-level
+  precedence (project > user > remote, **#387**). 🔵 Remote registry
+  (`Origin::Registry` + `registry/` are forward-compat stubs only, **#388**).
+
+### 13. Instruction assembly — `src/core/instruction_pipeline.rs`, `assets/instructions/`
+
+- **Responsibility.** Produce the PM system prompt and the per-launch merged
+  instruction text.
+- **Key types.** `install_system_prompt` / `build_system_prompt` (compile-time
+  `include_str!` concat `PM_INSTRUCTIONS → WORKFLOW → AGENT_DELEGATION → BASE_PM`,
+  `:31-72`); `build_instructions` (runtime merge framework → delegation authority
+  → `CLAUDE.md`, `:163-204`). `BASE_PM` is the non-overridable floor.
+- **Current state.** ✅ Compile-time assembly + runtime merge; merged text stashed
+  to `<project>/.trusty-mpm/last-instructions.md`.
+- **Gaps.** 🔵 5-file project override system advertised in `BASE_PM.md:17-33` but
+  unread (FR-IN-4 — only `CLAUDE.md` is consumed); 🔵 `PM_INSTRUCTIONS_VERSION`
+  marker inert (**#384**); 🟡 first-launch stash diverges from the actual prompt
+  (**#382**) and `tm install` overwrites it with a stub (**#383**).
+
+### 14. Overseer & coordinator — `src/core/{overseer,deterministic_overseer,llm_overseer}.rs`, `src/daemon/`
+
+- **Responsibility.** Evaluate hook events (allow/block/respond/flag) and host an
+  optional interactive coordinator chat with full session context.
+- **Key types.** `Overseer` trait + `DeterministicOverseer` (always on) + optional
+  `CompositeOverseer`/`llm_overseer` (built from `overseer.toml [llm]`);
+  `overseer_compose` (`daemon/overseer_compose.rs`); `POST /llm/chat` and the
+  `/api/v1/coordinator/*` routes (`daemon/api/coordinator_routes.rs`); the `tm
+  coordinator` CLI + `tui` coordinator chat.
+- **Current state.** ✅ Deterministic overseer + opt-in LLM overseer (reuses
+  `OPENROUTER_API_KEY`); cross-session coordinator chat. Disabled by default.
+- **Gaps.** None functional (the daemon-enforced CB hard blocks in §10 would also
+  flow through this enforcement point).
+
+### 15. Service discovery — `src/services/`
+
+- **Responsibility.** A canonical, scriptable service-discovery interface (`tm
+  services`) replacing ad-hoc `lsof`/`curl`/`pgrep` hardcoded in prompts.
+- **Key types.** `ServicesManifest` (the stable contract), `Discoverer` (runtime
+  probe engine), `ServiceStatus`/`HealthState`, manifest validation +
+  tilde-expansion helpers (`services/manifest.rs`, `services/discoverer.rs`);
+  `assets/default-services.yaml` embedded fallback.
+- **Current state.** ✅ Eight subcommands (list/status/port/url/health/log/init/
+  restart) with `--json` + spec exit codes (`tm.rs:178-196`). Backed by
+  `~/.claude-mpm/services.yaml` or the embedded default. See the
+  [research spec](../research/tm-services-discovery-spec-2026-05-28.md).
+- **Gaps.** None known.
+
+---
+
+## C. Data model summary
+
+| Type | Purpose | Persistence |
+|---|---|---|
+| `Session` (`core/session.rs`) | id, project, `workdir`, `tmux_name`, `pid`, `status`, `origin`, `control_model`, pause fields. | `DashMap`; pause records via `session_store`. |
+| `Delegation` (`core/agent.rs`) | id, session, target agent, task — delegation tree. | `DashMap`. |
+| `CircuitBreaker` (`core/circuit.rs`) | per-agent `consecutive_failures`; default 3-strike. | `DashMap`. |
+| `MemoryUsage`/`MemoryPressure` (`core/memory.rs`) | token usage; ok/warn/alert/compact. | `DashMap`. |
+| `HookEventRecord` (`core/hook.rs`) | session, `HookEvent` variant, payload, timestamp. | Ring buffer (1024) + SSE. |
+| `ProjectInfo` (`core/project.rs`) | path-keyed registered project. | `RwLock<HashMap>`. |
+| `AgentManifest`/`ManifestEntry` (`core/agent_manifest.rs`) | `filename → {source_chain, sha256, deployed_at, origin}`. | `~/.claude/agents/.trusty-mpm-manifest.json`. |
+| `SkillManifest` (`core/skill_manifest.rs`) | same ownership model for skills. | `~/.claude/skills/` manifest. |
+| `ServicesManifest`/`ServiceStatus` (`services/`) | declared services + probe results. | `~/.claude-mpm/services.yaml` / embedded default. |
+| Pairing record (`daemon/pairing_store.rs`) | Telegram `chat_id`. | `~/.trusty-mpm/pairing.json`. |
+| `OptimizerConfig`/`OverseerConfig` | compression + oversight policy. | `framework/hooks/{optimizer,overseer}.toml`. |

--- a/docs/trusty-mpm/spec/PRD.md
+++ b/docs/trusty-mpm/spec/PRD.md
@@ -1,0 +1,309 @@
+# trusty-mpm — Product Requirements Document
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+> **Crate:** `crates/trusty-mpm/` (version `0.5.0`, edition 2024, `publish = false`)
+> **Companion docs:** [ARCHITECTURE.md](./ARCHITECTURE.md) · [COMPONENTS.md](./COMPONENTS.md)
+
+Status tags: ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational.
+Each requirement is framed **Vision / Current / Gap**: the intended product
+surface, what the code does today, and where they diverge.
+
+---
+
+## 1. Vision & Mission
+
+### North-star vision
+
+> **One install, five surfaces. One daemon, many sessions.**
+
+trusty-mpm is a **Rust reimplementation of the Python `claude-mpm` meta-harness**.
+It runs as **a single daemon instance per machine** that **coordinates every
+Claude Code session process on that host**, and ships as a **single binary**
+(`tm` / `trusty-mpm`) that bundles a background daemon, an in-session MCP server,
+a TUI dashboard, and a Telegram bot behind feature flags. Where the Python
+`claude-mpm` spawned a fresh interpreter per hook fire and stored its framework
+in `~/.claude-mpm/`, trusty-mpm runs one resident daemon (`trusty-mpmd`) that
+enforces single-instance-per-machine, spawns/tracks/reaps Claude Code sessions
+through an HTTP API + session registry, and carries the claude-mpm PM-orchestration
+product model (delegation, circuit breakers, verification gates, a 5-phase
+workflow, memory routing, hooks) as compile-time instruction assets.
+
+### Mission
+
+Give a developer (or a small team on one workstation) **PM-driven delegation
+discipline plus a single pane of glass over every active Claude Code session**,
+delivered as one offline-capable install with no external runtime. The PM
+identity is never a forked `claude` binary — every session is a stock `claude`
+process whose PM behaviour comes from deployed agents, deployed skills, a project
+`CLAUDE.md`, an assembled system prompt passed via
+`claude --append-system-prompt-file`, and injected trusty-* MCP servers.
+
+### Why this is distinct
+
+- **Process coordination, not a model harness.** Unlike `open-mpm` (which
+  dispatches tasks to models itself), trusty-mpm coordinates *external* Claude
+  Code OS processes. The two crates share the `claude-mpm` heritage and
+  vocabulary but have **no Cargo dependency in either direction** (see
+  [README §Relationship to open-mpm](./README.md#relationship-to-open-mpm)).
+- **Single resident daemon.** One `trusty-mpmd` per host knows about and
+  coordinates every session — a host-wide registry, hook relay, and event feed
+  that no per-session harness can offer.
+- **Single-install, offline-first.** `cargo install trusty-mpm` yields a working
+  CLI + daemon + TUI + Telegram with the framework assets compiled into the
+  binary; launching a configured session needs no network.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+1. **One daemon per machine** coordinating multiple Claude Code session processes.
+2. **Single-binary distribution** — `cargo install trusty-mpm` yields `tm` /
+   `trusty-mpm` with the daemon, MCP server, TUI, and Telegram bot bundled behind
+   feature gates.
+3. **Faithful port of the claude-mpm PM product model** — delegation, circuit
+   breakers, verification gates, 5-phase workflow, autonomous execution, memory
+   routing.
+4. **Agent + skill system** with `extends:` inheritance, idempotent
+   checksum-guarded ownership-aware deployment, and (intended) remote registry
+   distribution.
+5. **Customizable, layered instruction assembly** — framework floor + project
+   overrides.
+6. **Full host-wide observability** — session registry, hook relay, live SSE
+   event stream, circuit-breaker views, TUI dashboard, remote Telegram management.
+7. **Offline-first** — framework ships embedded in the binary; no network to
+   launch a configured session.
+8. **Canonical service discovery** (`tm services`) replacing ad-hoc
+   `lsof`/`curl`/`ps` in agent prompts.
+
+### Non-Goals
+
+- **Not a fork of Claude Code.** trusty-mpm always launches stock `claude`; it
+  shapes behaviour through instructions/agents/skills/MCP, never by patching the
+  binary.
+- **Not a multi-machine orchestrator.** The coordination boundary is one host.
+  Telegram remote management is operator access, not cross-host coordination.
+- **Not an LLM provider / model harness.** Model selection is advisory PM
+  instruction plus an optional LLM overseer/chat that reuses OpenRouter
+  credentials. (Dispatching tasks to arbitrary models is `open-mpm`'s job.)
+- **Not a replacement for the user's own `~/.claude/` files.** Deployment is
+  ownership-aware and never clobbers user-authored or user-edited files.
+- **kuzu-memory and static `.claude-mpm/memories` fallback are out of scope** —
+  Python-era concepts. `trusty-memory` (MCP) is the sole intended memory backend.
+
+---
+
+## 3. Target Users / Personas
+
+| Persona | Who | Primary surface | Needs |
+|---|---|---|---|
+| **CLI developer** | Solo dev running orchestrated Claude Code sessions in a terminal. | `tm` / `trusty-mpm` CLI | `tm launch` a configured PM session; `tm connect`/`attach`; `tm status`; `tm services`. |
+| **MCP host integrator** | Building a Claude Code experience that introspects orchestration state from inside a session. | In-session MCP server | `session_list`, `session_status`, `agent_delegate`, `memory_protect`, `circuit_breaker_status`, `hook_event`. |
+| **TUI operator** | Dev wanting one pane of glass over all sessions on the host. | `trusty-mpm-tui` (`tm tui`) | Coordinator chat + session sidebar + health panel polling the daemon. |
+| **Telegram / mobile user** | Operator driving the daemon from a phone, away from the workstation. | `trusty-mpm-telegram` (`tm telegram`) | Pair a bot; list/inspect sessions; send commands; receive push alerts. |
+
+---
+
+## 4. Functional Requirements
+
+Requirements are grouped by **surface** then by **capability**, each tagged with
+a status. Where implementation diverges from intent, the divergence is described
+inline. Detailed source citations live in [COMPONENTS.md](./COMPONENTS.md) and
+[ARCHITECTURE.md](./ARCHITECTURE.md).
+
+### 4.1 CLI surface (`tm` / `trusty-mpm`)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-CLI-1 | One unified binary: daemon control (`start`/`stop`/`restart`/`status`/`daemon`), sessions, projects, `launch`/`connect`/`attach`, optimizer/overseer, coordinator, services, install, hook, and the `tui`/`telegram`/`gui` subcommands. | ✅ — full `Command` enum (`src/bin/tm.rs:38-197`). |
+| FR-CLI-2 | `tm launch` deploys agents/skills/instructions + MCP config into the project, then starts `claude` as a PM. | ✅ — `Launch` → `session_launch::prepare_session`. |
+| FR-CLI-3 | `tm connect`/`attach` start or attach a tmux-hosted session **without** redeploying the framework. | ✅ — `POST /api/v1/sessions/connect` register-only path. |
+| FR-CLI-4 | `tm hook` posts a Claude Code lifecycle event to the daemon and exits 0; silent degradation when the daemon is down. | ✅ — short-circuits when `CLAUDE_MPM_SUB_AGENT=1`. |
+| FR-CLI-5 | `tm install` deploys the framework (agents **and** skills) to `~/.claude/`. | 🟡 — deploys agents; skills deploy only on session start (#386 closed for deploy-on-install; verify). See FR-DEP-3. |
+| FR-CLI-6 | `src/bin/tm.rs` stays under the 500-line cap. | 🟡 — `tm.rs` is ~4,442 lines; split tracked by **#395**. |
+
+### 4.2 Daemon surface (`trusty-mpmd`)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-DMN-1 | Exactly one daemon per machine; a second start is refused (lock-file PID validation + `/health` probe + OS port bind). | ✅ — `src/bin/tm.rs:3139-3171`, `daemon/lock.rs`. |
+| FR-DMN-2 | Clients discover the daemon's live address via `~/.trusty-mpm/daemon.lock`; stale locks (dead PID) are cleared. | ✅ — `lock::write_lock`/`remove_lock` + `resolve_daemon_url`. |
+| FR-DMN-3 | One shared `Arc<DaemonState>` is the single source of truth for sessions, delegations, breakers, memory, hook history, projects. | ✅ — injected into every handler + the MCP backend (`daemon/state.rs:72-162`). |
+| FR-DMN-4 | Loopback JSON HTTP API for CLI/TUI/Telegram/GUI + universal hook relay + SSE event feed; OpenAPI/Swagger at `/api-docs`. | ✅ — `api::router` (`daemon/api.rs:72-127`). See ARCHITECTURE §HTTP API. |
+| FR-DMN-5 | Graceful shutdown traps SIGINT **and** SIGTERM and removes the lock so `tm restart` never leaks a stale lock. | ✅ — `src/bin/tm.rs:3209-3218`. |
+| FR-DMN-6 | A file watcher hot-reloads framework-managed policy (`optimizer.toml`, `overseer.toml`). | ✅ — `daemon/watcher.rs`. |
+
+### 4.3 Session / process lifecycle
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-SES-1 | Register/spawn a session, track tmux name + `claude` PID, list/get/remove. | ✅ — `POST/GET/DELETE /sessions[/{id}]`, `PATCH /sessions/{id}/pid` (`api.rs:272-503`). |
+| FR-SES-2 | Auto-discover existing Claude Code sessions (tmux panes + native Terminal.app `ps`) at boot and on demand — no manual adopt. | ✅ — `discovery::discover_all`, `POST /sessions/discover`. |
+| FR-SES-3 | Pause/resume with a "where I left off" note that survives a daemon restart. | ✅ — `POST /sessions/{id}/pause|resume` + `session_store` disk persistence. |
+| FR-SES-4 | Send a line to a session's tmux pane; capture pane scrollback (optional compression). | ✅ — `POST /sessions/{id}/command`, `GET /sessions/{id}/output|pane`. |
+| FR-SES-5 | Reap dead sessions (tmux gone → remove; tmux alive but `claude` PID dead → mark Stopped); never tmux-reap native sessions. | ✅ — 60s `reap_loop` + `DELETE /sessions/dead` (`state.rs:564-634`). |
+| FR-SES-6 | Surface files an agent created per session so the PM git-file-tracking protocol is observable daemon-side. | 🔵 — designed; no endpoint. Tracked by **#94** (`GET /sessions/{id}/files`). |
+
+### 4.4 MCP tool surface (in-session)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-MCP-1 | Stdio JSON-RPC MCP server exposing six orchestration tools to a Claude Code session, backed by the same `Arc<DaemonState>`. | ✅ — `tm daemon --mcp` / `run_mcp` over `StateBackend` (`mcp/tools.rs:19-136`). |
+| FR-MCP-2 | `session_list` / `session_status` — enumerate sibling sessions and inspect one (uptime, tokens, agent, pressure). | ✅. |
+| FR-MCP-3 | `agent_delegate` — request a delegation; daemon applies circuit-breaker + depth limits before spawning. | ✅. |
+| FR-MCP-4 | `memory_protect` — report context-window usage; daemon classifies pressure (ok/warn/alert/compact). | ✅. |
+| FR-MCP-5 | `circuit_breaker_status` — inspect all or one agent's breaker. | ✅. |
+| FR-MCP-6 | `hook_event` — forward a Claude Code hook into the observability pipeline. | ✅. |
+
+### 4.5 TUI surface (`trusty-mpm-tui` / `tm tui`)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-TUI-1 | A ratatui app: a coordinator chat with visibility into every active session, beside a dismissable session sidebar. | ✅ — `tui` module (feature `tui`); polls the coordinator-context endpoint. |
+| FR-TUI-2 | Secondary health screen showing combined search + memory health. | ✅ — `tui/health.rs` (#37 closed). |
+| FR-TUI-3 | Shipped both as `tm tui` and as the backward-compatible `trusty-mpm-tui` shim. | ✅ — shim delegates to `trusty_mpm::tui::run`. |
+
+### 4.6 Telegram surface (`trusty-mpm-telegram` / `tm telegram`)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-TG-1 | Pair a bot to a daemon (request → confirm code → status/reset), persisted across restarts. | ✅ — `POST/GET /pair/*` + `pairing_store`. |
+| FR-TG-2 | List/inspect sessions and send commands from a phone via the shared `CommandExecutor`. | ✅ — teloxide adapter → `TrustyCommand`. |
+| FR-TG-3 | Push unsolicited alerts (pure alert-decision core) to a paired chat. | ✅ — `telegram/alerts.rs`. |
+| FR-TG-4 | Bot token resolved from `--token` / `.env.local` / `.env` / `TELEGRAM_BOT_TOKEN`; `--check` validates config without connecting. | ✅ — `src/bin/trusty-mpm-telegram.rs`. |
+
+### 4.7 PM orchestration model (instruction-driven)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-PM-1 | PM delegates all work to specialist agents; default = delegate, exception only on explicit "you do it". | ✅ — `PM_INSTRUCTIONS.md` asset. |
+| FR-PM-2 | Verification gates: "done" claims require evidence (file paths, commit hash, QA repro/verify, live health). | ✅ — `WORKFLOW.md` + `PM_INSTRUCTIONS.md`. |
+| FR-PM-3 | 5-phase workflow (Research → Code Analysis → Implementation → QA → Documentation) with skip rules. | ✅ — instruction asset. |
+| FR-PM-4 | Autonomous execution — PM runs the full pipeline; asks the user only below ~90% success probability. | ✅ — instruction asset. |
+| FR-PM-5 | Model-selection protocol (haiku/sonnet/opus tiers, per-agent overrides via `~/.trusty-mpm/config.toml models.agents.*`). | 🟡 — specified in instructions; **no Rust code reads the key**. The `config.yaml` reference in `PM_INSTRUCTIONS.md` is a stale Python-era artifact — `config.toml` is canonical. Tracked by **#394**. |
+| FR-PM-6 | Optional LLM overseer evaluating hook events (allow/block/respond/flag) + interactive coordinator chat. | ✅ — `DeterministicOverseer` + optional `CompositeOverseer` from `overseer.toml`; `POST /llm/chat`. Disabled by default; opt-in. |
+
+### 4.8 Circuit breakers
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-CB-1 | PM-behaviour breakers (CB#1–#14, 3-strike WARNING → ESCALATION → FAILURE) block forbidden PM actions (Edit/Write, `curl`/`lsof`/`ps`/`make`, browser tools, `gh`, `sed`/`awk`, …). | 🟡 — *policy* fully specified in instructions; enforced as PM self-discipline inside the session, **not** daemon-enforced. |
+| FR-CB-2 | Per-agent failure breaker (`consecutive_failures`, default 3-strike) gates delegation. | ✅ — `core/circuit.rs`, `state.rs:record_outcome`, surfaced via `GET /breakers` + `circuit_breaker_status`. |
+| FR-CB-3 | **Daemon-enforced** CB#1–#14: detect violations from hook events at `POST /hooks` and return HTTP 403 (hard block) before the forbidden tool runs. | 🔵 — designed as an extension of the `HookService::process` enforcement point; per-agent breaker is the foundation. Tracked by **#393**. |
+
+### 4.9 Agent & skill deployment
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-DEP-1 | Agents declare `extends:` frontmatter; chains flatten at build time into self-contained files (Claude Code has no native inheritance). All agents inherit a `BASE_AGENT`. | ✅ — `compose_agent` walks base-first, child-wins merge, cycle + depth(8) guards (`core/agent_builder.rs`). |
+| FR-DEP-2 | Deployment is idempotent, checksum-guarded, manifest-tracked: never clobber user-owned or user-edited files. | ✅ — `deploy_agents`/`deploy_skills` + `AgentManifest`/`SkillManifest` (sha256, origin, source chain). |
+| FR-DEP-3 | `tm install` deploys both agents and skills at install time. | 🟡 — historically agents only; skills deployed on session start (`prepare_session`). #386 addressed install-time skill deploy — verify against current `tm install`. |
+| FR-DEP-4 | Robust agent frontmatter parsing (no `:`-truncation; single parser; Claude Code `model:`-injection workaround). | 🟡 — defect: parser splits on first `:` and truncates colon-bearing values; two divergent parser copies. Tracked by **#389** (truncation/dup) and **#390** (model-injection). |
+| FR-DEP-5 | Atomic deploy writes; graceful handling of a corrupt manifest. | 🟡 — tracked by **#392**. |
+| FR-DEP-6 | Prune stale deployed agent/skill files on rename or removal. | 🔵 — tracked by **#391**. |
+| FR-DEP-7 | 3-level agent precedence: project `.claude/agents/` > user `~/.claude-mpm/agents/` > cached remote. | 🔵 — documented in `PM_INSTRUCTIONS.md`; implementation has **one source, one target**. Tracked by **#387**. |
+| FR-DEP-8 | Remote agent registry: fetch agents with TTL/offline-cache; record `Origin::Registry`. | 🔵 — `Origin::Registry` is a forward-compat enum variant; `registry/` path resolves but nothing fetches. Tracked by **#388**. |
+
+### 4.10 Instruction assembly & customization
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-IN-1 | Every launched session receives identical, version-controlled PM instructions (`PM_INSTRUCTIONS → WORKFLOW → AGENT_DELEGATION → BASE_PM`, `BASE_PM` last as the non-overridable floor). | ✅ — compile-time `include_str!` concat (`instruction_pipeline.rs:31-72`), passed via `--append-system-prompt-file`. |
+| FR-IN-2 | Runtime merge composes framework + delegation authority (generated from deployed agents) + project `CLAUDE.md`. | ✅ — `build_instructions` (`instruction_pipeline.rs:163-204`); stash at `.trusty-mpm/last-instructions.md`. |
+| FR-IN-3 | First-launch instruction stash matches the actual system prompt; `tm install` does not overwrite the assembled prompt with a stub. | 🟡 — defects: stash diverges (**#382**), `tm install` overwrites the prompt with a 4-line stub (**#383**). |
+| FR-IN-4 | Project override system: `.trusty-mpm/{INSTRUCTIONS,AGENT_DELEGATION,WORKFLOW,MEMORY,PM_INSTRUCTIONS_DEPLOYED}.md` customize/replace PM behaviour. | 🔵 — advertised in `BASE_PM.md:17-33`; **no Rust code reads these files** (only `CLAUDE.md` is read). Trust gap. |
+| FR-IN-5 | `PM_INSTRUCTIONS_VERSION` marker gates instruction upgrades. | 🔵 — marker present (`= 0014`) but inert. Tracked by **#384**. |
+
+### 4.11 Memory routing & protection
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-MEM-1 | Recall before research; remember findings immediately via the **trusty-memory MCP backend** (sole intended backend). | ✅ — policy in instructions; wired by injecting the `trusty-memory` MCP server into project `.mcp.json` and writing `trusty-memory hooks fire …` into `.claude/settings.json` (`session_launch.rs:286-450`). |
+| FR-MEM-2 | Per-session context-window pressure tracking with warn/alert/compact classification. | ✅ — `memory_protect` tool + `DaemonState::record_memory` → `MemoryPressure`. |
+
+### 4.12 Hook handling
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-HK-1 | A thin hook forwarder (`tm hook`) posts every lifecycle event to the daemon and exits, replacing claude-mpm's per-fire Python process. | ✅. |
+| FR-HK-2 | Universal hook relay endpoint ingests events, drives the overseer (Block → 403), compresses output, appends to a ring buffer, broadcasts via SSE. | ✅ — `POST /hooks` (`api.rs:904-953`). |
+| FR-HK-3 | Project-scoped memory hooks written into project settings; global duplicates removed. | ✅ — `write_project_hooks` + `remove_global_trusty_memory_hooks`. |
+
+### 4.13 Service discovery (`tm services`)
+
+| Req | Intent | Status |
+|---|---|---|
+| FR-SVC-1 | A canonical `tm services` CLI (list/status/port/url/health/log/init/restart) backed by a YAML manifest, replacing `lsof`/`curl`/`ps` in agent prompts; `--json` + spec exit codes. | ✅ — `services` module + `assets/default-services.yaml` (`tm.rs:178-196`). See [research spec](../research/tm-services-discovery-spec-2026-05-28.md). |
+
+---
+
+## 5. Non-Functional Requirements
+
+| NFR | Requirement | Status |
+|---|---|---|
+| NFR-1 | **Single binary / single install** — `cargo install trusty-mpm` installs everything; feature gates (`cli` → `daemon`+`tui`+`telegram`; `daemon` → `mcp`). | ✅ — `Cargo.toml [features]`/`[[bin]]`. |
+| NFR-2 | **MSRV 1.88, edition 2024** (let-chains). | ✅ — workspace-shared. |
+| NFR-3 | **No `unwrap()` in library code** — `thiserror` for libs, `anyhow` for binaries. | ✅ — typed errors (`AgentBuildError`, `PrepError`, `PipelineError`, `DaemonError`). |
+| NFR-4 | **stderr-only logging** — stdout reserved for MCP JSON-RPC framing. | ✅. |
+| NFR-5 | **Idempotent deploys** — re-running install/launch never duplicates or clobbers; checksum-guarded. | ✅ — `prepare_session_is_idempotent`. |
+| NFR-6 | **Single-instance enforcement** per machine. | ✅. |
+| NFR-7 | **Offline-capable** — framework assets compiled in; no network to launch. | ✅ — the unbuilt remote-registry path (FR-DEP-8) is the only thing that *would* add network. |
+| NFR-8 | **500-line file cap** per source file. | 🟡 — `src/bin/tm.rs` (~4,442 lines) exceeds the cap; split tracked by **#395**. |
+
+---
+
+## 6. Success Criteria
+
+1. **One daemon, many sessions** — a single `trusty-mpmd` tracks ≥ N concurrent
+   Claude Code sessions (tmux + native) with accurate status and reaping.
+2. **Zero clobber** — deploy runs never overwrite a user-authored/edited agent or
+   skill (manifest tests pass; field reports of lost edits = 0).
+3. **Launch fidelity** — a `tm launch`ed session shows `style:trusty-mpm`, has the
+   trusty-memory MCP server + hooks wired, and receives the full PM system prompt
+   (closing the stash/stub divergence, #382/#383).
+4. **Hook throughput** — hook events ingest without blocking the user's prompt
+   even during a daemon restart (silent degradation verified).
+5. **Single-install** — `cargo install trusty-mpm` produces a working `tm` with
+   daemon + TUI + Telegram, no extra runtime.
+6. **Offline launch** — launching a configured session with no network succeeds.
+
+---
+
+## 7. Open Questions & Roadmap
+
+Gap-remediation is tracked by epic
+[**#380**](https://github.com/bobmatnyc/trusty-tools/issues/380) and its children.
+
+### High-severity trust gaps (documented capability that does not exist)
+
+- **Project override system unread** (FR-IN-4) — users following `BASE_PM.md`
+  write `.trusty-mpm/*.md` files that have no effect. Either implement the reader
+  in `build_instructions` or remove the claim. (#382/#383 cover the related
+  stash/stub instruction defects.)
+- **3-level agent precedence** (FR-DEP-7, **#387**) — `PM_INSTRUCTIONS.md`
+  overstates capability; only single-source/single-target exists.
+
+### Functional gaps
+
+- **Daemon-enforced circuit breakers** (FR-CB-3, **#393**).
+- **Remote agent registry** (FR-DEP-8, **#388**); **3-level precedence** (#387).
+- **`PM_INSTRUCTIONS_VERSION` gating** (FR-IN-5, **#384**).
+- **Per-agent model overrides + canonical `config.toml` loading** (FR-PM-5, **#394**).
+- **Per-session file tracking** (FR-SES-6, **#94**).
+
+### Defects
+
+- **Frontmatter parser truncation + duplication** (FR-DEP-4, **#389**),
+  **model-injection workaround** (**#390**).
+- **Atomic deploy writes / corrupt-manifest handling** (FR-DEP-5, **#392**).
+- **Stale-file pruning** (FR-DEP-6, **#391**).
+
+### Hygiene
+
+- **Purge stale `~/.claude-mpm` Python-era path references** from embedded assets
+  (**#385**); **canonicalize config to `config.toml`** (**#394**).
+- **Split `src/bin/tm.rs`** below the 500-line cap (**#395**).
+- **Reconcile stale crate inventory + MCP tool counts** across docs (**#430**).

--- a/docs/trusty-mpm/spec/README.md
+++ b/docs/trusty-mpm/spec/README.md
@@ -1,0 +1,89 @@
+# trusty-mpm — Specification Set
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** code/docs/tickets audit
+
+This directory holds the canonical product and engineering specification for the
+`trusty-mpm` crate (`crates/trusty-mpm/`). It is the single authoritative
+reference for *what trusty-mpm is meant to be*, *what it is today*, and *what
+gaps remain*.
+
+## What is trusty-mpm?
+
+`trusty-mpm` is the **unified MPM platform** — a Rust reimplementation of the
+Python `claude-mpm` meta-harness, packaged as **one install with five surfaces**.
+A single resident daemon (`trusty-mpmd`) runs **one instance per machine** and
+**coordinates every Claude Code session process on that host**: it spawns, tracks,
+reaps, and observes sessions through an HTTP API + session registry, relays their
+lifecycle hooks, and shapes their behaviour by deploying a PM-orchestration
+framework (agents, skills, instructions, MCP wiring) into the project and
+`~/.claude/`. The coordinated sessions are always **stock `claude` binaries** —
+trusty-mpm never forks Claude Code; it shapes behaviour through deployed
+artifacts and an appended system prompt.
+
+The crate ships as a **single `cargo install trusty-mpm`** that produces one CLI
+(`tm` / `trusty-mpm`) bundling — behind feature-gated `[[bin]]` targets — the
+daemon (`trusty-mpmd`), an in-session MCP server, a ratatui TUI
+(`trusty-mpm-tui`), and a Telegram bot (`trusty-mpm-telegram`). All five surfaces
+share the `core` + `client` library modules so they never drift apart.
+
+### Relationship to `open-mpm`
+
+`trusty-mpm` and `open-mpm` are **independent crates** — there is no Cargo
+dependency in either direction, and neither imports the other's library. They
+are two distinct products that share a heritage and a vocabulary (PM, agents,
+delegation, circuit breakers), not a codebase:
+
+| | `open-mpm` | `trusty-mpm` |
+|---|---|---|
+| **What it is** | A Rust-native AI agent *orchestration engine* — an original coding harness with model-agnostic dispatch (OpenRouter / Anthropic / Bedrock / `claude` CLI) and an in-process CTRL→PM→sub-agent actor hierarchy over NDJSON IPC. | A *meta-harness around stock Claude Code* — a per-machine daemon that coordinates external `claude` session processes and deploys a PM framework into them. |
+| **Runs the model** | Yes — dispatches tasks to any model via any backend itself. | No — every session is a stock `claude` process; model selection is advisory PM instruction (plus an optional LLM overseer/chat). |
+| **Coordination unit** | In-process actors (sub-agents run in-process or as NDJSON subprocesses). | OS processes — multiple Claude Code sessions hosted in tmux panes / native terminals. |
+| **Code link** | None. | None — only doc-comment lineage notes (the tmux helpers in `src/core/tmux.rs` / `src/daemon/tmux.rs` were modelled on open-mpm's `tm` module). |
+
+In short: **open-mpm is the orchestration engine; trusty-mpm is the unified
+product that wraps and coordinates Claude Code.** Both descend from the
+`claude-mpm` product model but are built and shipped separately.
+
+## Documents in this set
+
+| Document | Read it when you want to know… |
+|---|---|
+| **[PRD.md](./PRD.md)** | The product: vision & mission (one install, five surfaces; one daemon, many sessions), goals/non-goals, the four personas, the full functional-requirement catalog grouped by surface + capability and tagged by implementation status, success criteria, and open questions. Start here for *why* and *what*. |
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | The system shape: the single-install multi-binary topology, how the binaries share the `core`/`client` modules, the single-daemon coordination model, the hook relay + enforcement point, MCP stdio framing (stdout reserved, logs to stderr), the daemon HTTP API surface, feature gating, and the filesystem layout. Start here for *how it fits together*. |
+| **[COMPONENTS.md](./COMPONENTS.md)** | Per-binary and per-subsystem specs: the CLI, daemon, MCP server, TUI, Telegram bot, plus agent delegation, circuit breakers, session management, memory protection, instruction assembly, and agent/skill deployment. Each states responsibility, key types/modules (with `src/` paths), current state, and known gaps. Start here for *the detail of one subsystem*. |
+
+## Reading order
+
+1. **New to trusty-mpm?** PRD → ARCHITECTURE → COMPONENTS.
+2. **Integrating a Claude Code host with the MCP surface?** ARCHITECTURE §MCP →
+   COMPONENTS §MCP server.
+3. **Implementing a gap-remediation ticket?** Jump to the relevant COMPONENTS
+   section, cross-check the gap callout, then the ticket linked from PRD §Open
+   Questions.
+
+## Status legend (used throughout this set)
+
+Every requirement and component is framed as **Vision / Current / Gap** and
+tagged inline with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, or asset) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+## Provenance & maintenance
+
+These documents synthesise the two reconstructed research docs
+([`../research/prd-2026-05-29.md`](../research/prd-2026-05-29.md),
+[`../research/architecture-spec-2026-05-29.md`](../research/architecture-spec-2026-05-29.md),
+[`../research/tm-services-discovery-spec-2026-05-28.md`](../research/tm-services-discovery-spec-2026-05-28.md))
+cross-checked against the `crates/trusty-mpm/src/` tree, the crate manifest, the
+embedded instruction assets, and the open/closed issue backlog — notably the
+gap-remediation epic [#380](https://github.com/bobmatnyc/trusty-tools/issues/380)
+and its children (#382–#395, #94). When the code changes materially, update the
+relevant document and bump the *Last reviewed* date. Source-path citations
+reflect the layout at the time of review.


### PR DESCRIPTION
Canonical spec set under docs/trusty-mpm/spec/, open-mpm style. Documents the six-[[bin]] single-install topology (tm canonical) and the open-mpm relationship (no Cargo dep either way; distinct roles). ADR for single-install multi-binary bundling. cargo check -p trusty-mpm passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)