### PR TITLE
docs(trusty-git-analytics): canonical spec set reconciled from requirements

### DIFF
--- a/docs/trusty-git-analytics/README.md
+++ b/docs/trusty-git-analytics/README.md
@@ -14,7 +14,8 @@ design, requirements, research, and user/developer documentation. The crate
 
 | Subdir | What's here |
 |--------|-------------|
-| [`requirements/`](requirements/) | Canonical specification set ported from the Python predecessor: overview, configuration schema, database schema, CLI commands, classification cascade, collection, reporting, and Rust architecture. Start at [`requirements/index.md`](requirements/index.md). |
+| [`spec/`](spec/) | **Canonical, authoritative specification set** — the *what / why / gap* layer reconciled against the live code and ticket backlog: [`PRD.md`](spec/PRD.md), [`ARCHITECTURE.md`](spec/ARCHITECTURE.md), [`COMPONENTS.md`](spec/COMPONENTS.md). **Start here.** It sits *above* `requirements/` and supersedes it where they disagree. |
+| [`requirements/`](requirements/) | Detailed source specification ported from the Python predecessor: overview, configuration schema, database schema, CLI commands, classification cascade, collection, reporting, and Rust architecture. The field-by-field reference the `spec/` set links into. Some sections have drifted from the code (taxonomy, DB migration list, CLI surface, DORA/effort/quality additions) — where `spec/` and `requirements/` disagree, **`spec/` is authoritative**. Start at [`requirements/index.md`](requirements/index.md). |
 | [`developer/`](developer/) | Contributor docs: [architecture](developer/architecture.md), [developer guide](developer/developer-guide.md), [configuration reference](developer/configuration-reference.md), [migration from Python](developer/migration-from-python.md), [publishing](developer/publishing.md). |
 | [`user/`](user/) | End-user docs: [user guide](user/user-guide.md). |
 | [`decisions/`](decisions/) | **Crate-specific ADRs** (Nygard format): SQLite tuning, performance hotspots, Bitbucket PR provider. Workspace-wide ADRs live in [`docs/adr/`](../adr/). |
@@ -24,7 +25,7 @@ design, requirements, research, and user/developer documentation. The crate
 
 ## Where to start
 
-- **Understanding the system?** [`requirements/overview.md`](requirements/overview.md) → [`requirements/index.md`](requirements/index.md).
+- **Understanding the system?** [`spec/README.md`](spec/README.md) → [`spec/PRD.md`](spec/PRD.md) → [`spec/ARCHITECTURE.md`](spec/ARCHITECTURE.md) (canonical), then [`requirements/`](requirements/) for field-level detail.
 - **Using the CLI?** [`user/user-guide.md`](user/user-guide.md).
 - **Contributing?** [`developer/developer-guide.md`](developer/developer-guide.md) and [`developer/architecture.md`](developer/architecture.md).
 - **Understanding a past decision?** [`decisions/`](decisions/) (crate-specific) or [`docs/adr/`](../adr/) (workspace-wide).
@@ -32,6 +33,9 @@ design, requirements, research, and user/developer documentation. The crate
 ## Conventions
 
 Subdirs follow the workspace documentation conventions described in the root
-[`CLAUDE.md`](../../CLAUDE.md). The `requirements/` set mirrors the API contract
-of the [gitflow-analytics](https://github.com/bobmatnyc/gitflow-analytics)
-Python predecessor; `research/` files are dated point-in-time investigations.
+[`CLAUDE.md`](../../CLAUDE.md). The `spec/` set is the canonical *what/why/gap*
+layer, reconciled against the live `crates/trusty-git-analytics/src/` tree; the
+`requirements/` set is the detailed field-level source that originally mirrored
+the API contract of the [gitflow-analytics](https://github.com/bobmatnyc/gitflow-analytics)
+Python predecessor and now serves as reference beneath `spec/`. `research/`
+files are dated point-in-time investigations.

--- a/docs/trusty-git-analytics/spec/ARCHITECTURE.md
+++ b/docs/trusty-git-analytics/spec/ARCHITECTURE.md
@@ -1,0 +1,271 @@
+# trusty-git-analytics (`tga`) — Architecture
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** existing `requirements/` docs + code/tickets reconciliation
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+This document describes the system shape: the processing pipeline, the SQLite
+schema, the LLM configuration layer, and the CLI surface. Field-level detail
+lives in [`../requirements/`](../requirements/); per-subsystem detail lives in
+[COMPONENTS.md](./COMPONENTS.md).
+
+---
+
+## 1. Crate shape
+
+`tga` is a **single crate** (`crates/trusty-git-analytics/`, package name `tga`,
+edition 2021, MSRV 1.88, license Elastic-2.0) consolidated from an earlier
+5-crate workspace. The library (`src/lib.rs`) and the binary (`src/main.rs`,
+`[[bin]] name = "tga"`) are both built from it. The `bedrock` Cargo feature gates
+the AWS Bedrock LLM provider; everything else is in the default build.
+
+```
+src/
+├── lib.rs                 # public library surface: core / collect / classify / report
+├── main.rs                # clap CLI; wires commands into the library
+├── core/                  # shared foundation (config, db, models, errors, effort, quality, revert)
+├── collect/               # Stage 1: git walk + external PR/ticket fetch + identity
+├── classify/              # Stage 2: multi-tier cascade + external sources + taxonomy
+├── report/                # Stage 3: aggregation + CSV/JSON/Markdown formatters + drill-down
+└── commands/              # binary-private clap subcommand handlers
+```
+
+Module dependency order: `core` ← {`collect`, `classify`, `report`} ← `commands`
+← `main.rs`. `tga` depends on `trusty-common` only for the shared `cli-help`
+feature (declarative `help.yaml` + Jaro-Winkler "did you mean?" suggester,
+#216); it is otherwise independent of the rest of the workspace.
+
+---
+
+## 2. Processing pipeline
+
+The pipeline is **`collect → classify → score → aggregate → report`**, all stages
+reading from and writing to one SQLite file. `tga analyze` runs them in sequence;
+each stage is also independently invocable. SQLite WAL mode lets a later stage
+read while an earlier one is still writing.
+
+```
+┌──────────────┐   ┌───────────────┐   ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
+│  collect     │──▶│  classify     │──▶│  score       │──▶│  aggregate   │──▶│  report      │
+│ (Stage 1)    │   │ (Stage 2)     │   │ (effort/     │   │ (DB → in-mem │   │ (CSV/JSON/MD │
+│              │   │               │   │  quality)    │   │  ReportData) │   │  + drilldown)│
+│ git2 revwalk │   │ override →    │   │ fact_commit_ │   │ single scan, │   │ Tera         │
+│ + rayon      │   │ ext-source →  │   │ effort;      │   │ in-mem group │   │ templates,   │
+│ PR/ticket    │   │ jira-key →    │   │ revert/      │   │ DORA views   │   │ csv::Writer, │
+│ fetch        │   │ exact/regex/  │   │ bugfix/      │   │              │   │ serde_json   │
+│ identity res │   │ fuzzy → LLM   │   │ ticket rates │   │              │   │              │
+└──────┬───────┘   └──────┬────────┘   └──────┬───────┘   └──────┬───────┘   └──────┬───────┘
+       │                  │                   │                  │                  │
+       ▼                  ▼                   ▼                  ▼                  ▼
+  ┌──────────────────────────────────────────────────────────────────────────────────┐
+  │   tga.db  (single SQLite file, WAL; synchronous=NORMAL; foreign_keys=ON)           │
+  └──────────────────────────────────────────────────────────────────────────────────┘
+```
+
+> **Reconciliation note.** `requirements/overview.md` describes a 3-stage
+> pipeline (collect → classify → report) over two DB files (`gitflow_cache.db` +
+> `identities.db`). The code uses **one** SQLite file (`tga.db`) and inserts an
+> explicit **score** step (effort + quality) and an **aggregate** step (the
+> `report::Aggregator`) inside what the requirements lump into "report". This
+> spec uses the 5-phase framing because it matches the modules.
+
+### 2.1 Stage 1 — collect (`src/collect/`)
+
+- **Git walk** (`collect/git/`): `git2` revwalk over each repo, in-process diff
+  (`diff.rs`), branch selection (`extractor.rs`), HTTPS fetch (`fetch.rs`,
+  vendored-TLS libgit2 #337), tag/release-branch reachability (`reachability.rs`,
+  #279). Parallel across repos/branches with rayon.
+- **External fetch**: GitHub (`collect/github/`), Bitbucket Cloud
+  (`collect/bitbucket/`, ADR-0003), Azure DevOps (`collect/azdo/`, WIQL +
+  `workitemsbatch`), JIRA (`collect/jira/`), Linear (`collect/linear/`) — all
+  behind the `PrProvider` (`pr_provider.rs`) and `PmAdapter` (`pm_adapter.rs`)
+  traits, dispatched concurrently from `tokio::JoinSet`.
+- **Identity** (`collect/identity/`): manual → exact-email → GitHub-login →
+  `strsim::jaro_winkler` fuzzy → new canonical UUID.
+- **Bookkeeping**: `collector.rs` writes `collection_runs` per (repo, ISO-week);
+  per-repo errors are isolated (#334).
+
+### 2.2 Stage 2 — classify (`src/classify/`)
+
+The cascade (`pipeline.rs` → `classifier.rs`) runs, first-match-wins:
+
+1. **Manual override** (`tiers/override_tier.rs`) — `classification_overrides`.
+2. **External source / issue type** (`sources/` + `tiers/issue_type_tier.rs`) —
+   resolves the ticket behind the commit (JIRA / GitHub Issues / Linear /
+   Shortcut / Confluence / Datadog) via `ExternalSourceResolver` (per-run cache)
+   and maps issue type → category.
+3. **JIRA project key** (`tiers/jira_project_tier.rs`) — `jira_project_mappings`.
+4. **Exact** (`tiers/exact.rs`) — Aho-Corasick multi-keyword FSM.
+5. **Regex** (`tiers/regex_tier.rs`) — pre-compiled patterns.
+6. **Fuzzy** (`tiers/fuzzy.rs`) — structural heuristics (merge/revert/ticket).
+7. **LLM** (`tiers/llm.rs`, `tiers/bedrock.rs`) — async, batched, circuit-broken,
+   confidence-gated fallback. `tiers/weighted_sum.rs` blends multi-signal scores.
+
+Tiers 4–6 run in parallel across commits via rayon; the LLM tier is async/serial.
+Every verdict carries a `ClassificationResult { top_level, category, subcategory,
+confidence, method, ticket_id, complexity }`. WAL is checkpointed at exit (#298).
+
+### 2.3 Stage 3 — score, aggregate, report (`src/report/`, `src/core/`)
+
+- **Score**: `core/effort.rs` (deterministic v1 formula → `fact_commit_effort`,
+  via `tga backfill effort`); `core/quality.rs` (per-engineer-per-week 1–5);
+  `core/revert.rs` (shared revert detector — single source of truth for
+  `is_revert` and report-time revert rate).
+- **Aggregate**: `report/aggregator.rs` does a **single** scan of `commits`
+  left-joined to `classifications`, grouping in memory into `ReportData`
+  (`report/models.rs`). DORA arithmetic reads the SQL views.
+- **Report**: `report/formatters/{csv,json,markdown}.rs` + Tera templates
+  (`report/templates/`); `report/drilldown.rs` powers `tga author`;
+  `report/ticketed_stats.rs` computes ticket-linkage stats.
+
+---
+
+## 3. Database schema
+
+Detailed table-by-table source: [`../requirements/database-schema.md`](../requirements/database-schema.md)
+(note: that doc lists migrations `0001`–`0013`; the **on-disk** migration set
+runs to `0016`). Every `Database::open()` applies:
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous  = NORMAL;
+PRAGMA foreign_keys = ON;
+```
+
+Migrations live in `src/core/db/sql/0001_*.sql … 0016_*.sql`, tracked in
+`schema_migrations` and applied idempotently by `src/core/db/migrations.rs`.
+
+### 3.1 Table families
+
+| Family | Tables | Source |
+|---|---|---|
+| **Commits & identity** | `authors`, `commits`, `files`, `classifications`, `classification_overrides` | `0001`, `0003`, `0006`, `0013` |
+| **External work items** | `work_items`, `commit_work_items`, `linear_issues`, `azdo_iterations` | `0002`, `0005`, `0008` |
+| **Pull requests** | `pull_requests` (+ `provider`, `repository`), `pr_reviewers` | `0007`, `0010`, `0011`, `0012` |
+| **Run bookkeeping** | `collection_runs` (+ `repo_count`), `repository_analysis_status` | `0004`, `0009` |
+| **DORA facts** (#207/#208/#212/#213) | `fact_deployments`, `fact_incidents`, `deployment_failures` + views `v_deployment_frequency`, `v_lead_time`, `v_mttr`, `v_change_failure_rate` | `0014` |
+| **Reachability** (#279) | `fact_commit_reachability` (default-branch / tag / release-branch) | `0015` |
+| **Effort** (PR #308) | `fact_commit_effort` (XS–XL size, score, LoC, files, test_loc, `formula_version`) | `0016` |
+
+The `fact_*` convention: each row is an immutable observation keyed by a stable
+upstream id (e.g. `deploy_id`, `(sha, repository)`), so re-ingest is idempotent
+and the fact tables can be re-built independently of commit collection. Most
+`fact_*` tables intentionally carry **no** FK to `commits` so a backfill can run
+before or independently of the collection walk.
+
+> **Reconciliation note.** The requirements DB schema uses the predecessor names
+> `cached_commits` / `weekly_fetch_status`; the live schema uses `commits` /
+> `collection_runs`. The five `fact_*` tables and the DORA views do not appear in
+> the requirements doc at all. Treat the on-disk SQL under `src/core/db/sql/` as
+> authoritative.
+
+---
+
+## 4. LLM configuration layer
+
+The LLM fallback tier reaches a provider through the top-level `llm:` config
+section (`core/config/`, #407) — the single source of truth, superseding the
+legacy `classification.llm_provider` / `classification.openrouter_api_key`
+fields (which emit a deprecation `tracing::warn!`).
+
+```yaml
+llm:
+  source: openrouter            # openrouter | bedrock | anthropic-api
+  api_key_env: OPENROUTER_API_KEY   # NAME of the env var — never the secret itself
+  region: us-east-1             # Bedrock only; falls back to AWS SDK resolution
+  model: gpt-4o-mini            # provider-appropriate default if omitted
+```
+
+| Source | Auth | Default model | Availability |
+|---|---|---|---|
+| `openrouter` (default) | key from `api_key_env` (OpenAI-compatible schema) | `gpt-4o-mini` | default build |
+| `bedrock` | AWS IAM credential chain (no stored secret) | `anthropic.claude-3-haiku-20240307-v1:0` | requires `--features bedrock` |
+| `anthropic-api` | `x-api-key` from `api_key_env`, `anthropic-version: 2023-06-01` | `claude-3-5-haiku-latest` | default build |
+
+Behavioral rules (#405/#407):
+
+- **Self-enabling**: a present `llm:` section enables the LLM tier automatically
+  (no `classification.use_llm: true` needed). Precedence: `llm:` → legacy
+  `use_llm` → disabled.
+- **Hard-fail on missing key**: when LLM is enabled but the named env var is
+  unset/empty, `tga classify` exits non-zero with an actionable message naming
+  the variable, **before** any DB write (no silent short-circuit — the bug #405
+  was reported against).
+- **Bedrock without the feature**: returns a configuration error explaining the
+  build flag.
+- **Security**: only the env-var *name* is ever stored; the secret is read at
+  runtime.
+
+All providers share one `SYSTEM_PROMPT` and the `LlmVerdict` JSON shape
+(`category`, `subcategory`, `confidence`, `complexity`). The DB path resolves
+`--database` > `database:` config (#406) > hardcoded `tga.db`.
+
+---
+
+## 5. CLI surface
+
+Binary `tga` (clap v4 derive, `src/main.rs`). Global flags: `--config`/`-c`,
+`--database`/`-d`, `-v`/`--log` (with `RUST_LOG` taking precedence). ISO-week
+targeting via mutually-exclusive `--weeks` / `--week` / `--from`+`--to`.
+
+| Subcommand | Stage / role | Source |
+|---|---|---|
+| `analyze` | Full pipeline (`--skip-collect`, `--skip-classify`, `--force`). | `commands/analyze.rs` |
+| `collect` | Stage 1 — git walk + external fetch (`--repo`/`--branch`/`--week`, #332). | `commands/collect.rs` |
+| `classify` | Stage 2 — cascade (`--reclassify`, `--validate-coverage`, `--show-jira-signals`). | `commands/classify.rs` |
+| `report` | Stage 3 — reports (`--author <email>` #324, `--anonymize`). | `commands/report.rs` |
+| `author` | Per-engineer drill-down (effort + PRs + commits, #325). | `commands/author.rs` |
+| `pr-metrics` | Weekly PR-metrics aggregation. | `commands/pr_metrics.rs` |
+| `aliases` | Identity CRUD + LLM-assisted `suggest` (#347/#348). | `commands/aliases/` |
+| `backfill` | Retroactive `ticket-id` / `effort` / `reachability` re-runs (`--dry-run`). | `commands/backfill.rs` |
+| `override` | Manual Tier-0 classification overrides. | `commands/override_cmd.rs` |
+| `rules` | Inspect/validate the active rule set (#209/#259). | `commands/rules.rs` |
+| `install` | Interactive config wizard. | `commands/install.rs` |
+| `deployments collect` | Ingest deploy events → `fact_deployments` (#212). | `commands/deployments.rs` |
+| `incidents collect` | Ingest incidents → `fact_incidents` (#213). | `commands/incidents.rs` |
+| `dora` | Compute & display the four DORA metrics. | `commands/dora.rs` |
+
+> **Reconciliation note.** `requirements/cli-commands.md` documents `fetch` and
+> `identities list/merge` as standalone subcommands and omits `author`,
+> `backfill`, `rules`, `deployments`, `incidents`, and `dora`. The live CLI
+> folds fetch into `collect` and identity management into `aliases`, and adds the
+> six newer commands. The table above reflects the audited `main.rs`.
+
+---
+
+## 6. Key technology choices
+
+Detailed rationale: [`../requirements/rust-architecture.md`](../requirements/rust-architecture.md)
+and [`../decisions/`](../decisions/).
+
+| Concern | Choice | Why (short) |
+|---|---|---|
+| Git | `git2` (vendored libgit2, https + vendored-openssl, no SSH) | mature diff/revwalk; self-contained TLS (#337) |
+| Database | `rusqlite` (bundled + `chrono`) | sync API maps to per-thread rayon workers; workspace version pin (#257) |
+| Async | `tokio` + `reqwest` (rustls-tls) | HTTP fetch for PR/ticket APIs |
+| CPU parallelism | `rayon` | per-repo / per-branch / per-commit-batch parallelism |
+| Pattern match | `aho-corasick` | one FSM pass for all classification keywords |
+| Fuzzy match | `strsim` (Jaro-Winkler) | identity resolution |
+| Config | `serde` + `serde_yaml` + `shellexpand` | typed YAML, `~` + `${VAR}` expansion |
+| Dates | `chrono` | ISO-week support matching Python `isocalendar()` |
+| Reports | `csv`, `serde_json`, `tera` | buffered/streamed output |
+| Hashing | `blake3` | config-drift hash (`repository_analysis_status.config_hash`) |
+| LLM (Bedrock) | `aws-config` + `aws-sdk-bedrockruntime` (feature `bedrock`) | IAM-auth provider |
+| Errors | `thiserror` (library) / `anyhow` (binary) | structured per-module enums; no `unwrap()` in lib |
+
+---
+
+## 7. Cross-cutting conventions
+
+- **No `unwrap()` in library code**; `thiserror` enums per module
+  (`CollectError`, `ClassifyError`, `ReportError`, `TgaError`), `anyhow` in
+  `commands/` and `main.rs`.
+- **Logs to stderr** (tracing); stdout reserved for human-readable report text.
+- **Forward-compatible config**: unknown YAML keys are ignored so newer configs
+  load on older binaries.
+- **Determinism**: effort scores carry a `formula_version`; identical output is
+  guaranteed between the Rust path and `scripts/compute-effort.sh`.
+- **Idempotent ingest**: `fact_*` tables keyed by stable upstream ids; migrations
+  idempotent and never edited after release (additive `0014`–`0016` only).

--- a/docs/trusty-git-analytics/spec/COMPONENTS.md
+++ b/docs/trusty-git-analytics/spec/COMPONENTS.md
@@ -1,0 +1,307 @@
+# trusty-git-analytics (`tga`) — Components
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** existing `requirements/` docs + code/tickets reconciliation
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+
+Per-subsystem specs. Each states **responsibility**, **key types** (with `src/`
+paths), **current state**, and **gaps**. System framing is in
+[ARCHITECTURE.md](./ARCHITECTURE.md); field-level detail is in
+[`../requirements/`](../requirements/).
+
+---
+
+## 1. Collector (`src/collect/`)
+
+**Responsibility.** Stage 1: extract commits from local git repos and enrich
+them with PR / ticket / identity data, persisting to SQLite.
+
+**Key types & modules.**
+- `collect/collector.rs` — top-level orchestrator; per-(repo, ISO-week)
+  `collection_runs` bookkeeping; per-repo error isolation (#334).
+- `collect/git/{extractor,diff,fetch,reachability}.rs` — `git2` revwalk, in-process
+  diff stats, HTTPS fetch (vendored TLS, #337), tag/release-branch reachability
+  (`reachability.rs`, #279/#290/#303).
+- `collect/pr_provider.rs` (`PrProvider` trait) + `collect/{github,bitbucket,azdo}/`
+  — concurrent PR collection (GitHub, Bitbucket Cloud, Azure DevOps).
+- `collect/pm_adapter.rs` (`PmAdapter`/`PmTicket`/`PmSource`) — normalized ticket
+  enrichment across JIRA / GitHub / Linear / Azure DevOps.
+- `collect/{jira,linear}/client.rs` — ticket fetch clients.
+- `collect/identity/resolver.rs` — manual → email → login → Jaro-Winkler → new
+  canonical UUID.
+- `collect/ticket.rs` — `extract_ticket_id` / `is_ticketed` regex extraction
+  (per-provider `ticket_regex` override, #75/#285/#316).
+- `collect/weeks.rs` — ISO-week range resolution.
+
+**Current state.** ✅ All four PR providers, all PM adapters, identity cascade,
+reachability, and per-repo error isolation are implemented. Branch coverage bug
+(#331, -56% on multi-repo orgs) and always-fetch-before-collect (#334) are fixed.
+
+**Gaps.** GitLab PR collection 🔵 (parity gap, `collection.md` §PR). Bitbucket
+`merged_at` is approximated by `updated_on` (one-directional bias, ADR-0003 §6)
+🟡. SSH transport disabled by design ✅/non-goal.
+
+---
+
+## 2. Classifier — cascade + tiers (`src/classify/`)
+
+**Responsibility.** Stage 2: assign each commit a two-level work category with
+provenance, via a first-match-wins multi-tier cascade.
+
+**Key types & modules.**
+- `classify/pipeline.rs` (`ClassificationPipeline`, `ClassificationStats`) —
+  read DB → classify → write back; coverage stats per tier/category/repo; WAL
+  checkpoint at exit (#298).
+- `classify/classifier.rs` (`ClassificationEngine`, `ClassificationEngineConfig`)
+  — cascade orchestrator.
+- `classify/tiers/` — `override_tier.rs`, `issue_type_tier.rs`,
+  `jira_project_tier.rs`, `exact.rs` (Aho-Corasick), `regex_tier.rs`, `fuzzy.rs`,
+  `llm.rs`, `bedrock.rs`, `weighted_sum.rs`. Shared `ClassificationResult`
+  (`top_level`, `category`, `subcategory`, `confidence`, `method`, `ticket_id`,
+  optional LLM `complexity`).
+- `classify/rules/` (`Rule`, `RuleSet`, `loader.rs`) — built-in + user YAML rules
+  with working priority (#259); inspectable via `tga rules` (#209/#269).
+
+**Current state.** ✅ Full cascade with the seven tiers above. Rule priority,
+coverage gating, and crash-safe checkpointing are implemented.
+
+**Gaps.** 🟡 `external_source` method not appearing in `classifications` despite
+cache hits on some 1.5.2 paths (#320 open; related #321/#316 fixed).
+
+---
+
+## 3. Taxonomy (`src/classify/taxonomy.rs`)
+
+**Responsibility.** Provide a stable, closed set of **top-level** work categories
+plus an extensible registry of **subcategories** that roll up to them.
+
+**Key types.**
+- `TopLevelCategory` — closed enum: `Feature`, `Bugfix`, `Ktlo`, `Integrations`,
+  `PlatformWork`, `Content`, `Maintenance`, + `Unknown`. Users **cannot** add to
+  this list.
+- `TaxonomyRegistry` (`with_builtins()`, `resolve()`) — subcategory-name →
+  top-level lookup, seeded with built-ins and merged with user-defined
+  `SubcategoryDef` entries from rules/config.
+- `SubcategoryDef` — a user-declarable subcategory with its top-level parent.
+
+**Current state.** ✅ Two-level taxonomy implemented; `bug_fix`/`bugfix`
+collision fixed (#271).
+
+**Gaps.** **Documentation drift** 🟡: `requirements/classification.md` still
+describes a flat 19-value `ChangeType` enum and its fallthrough set
+(`maintenance`/`ktlo`/`other`/`unknown`). The 19 names now live as *subcategories*
+under the seven top-levels. The requirements doc should be refreshed or demoted
+to "predecessor reference."
+
+---
+
+## 4. External classification sources (`src/classify/sources/`)
+
+**Responsibility.** Use external ticket/alert systems as high-confidence
+classification signals *ahead of* commit-message tiers — because a bare
+`PROJ-1234 update handler` carries no semantic content but the ticket behind it
+has an explicit issue type.
+
+**Key types & modules.**
+- `sources/mod.rs` (`SourceConfig`, `ExternalSignal`) — YAML-deserializable
+  per-source config.
+- `sources/resolver.rs` (`ExternalSourceResolver`) — per-run in-memory cache +
+  dispatcher; extracts ticket keys, fetches only misses, returns the
+  highest-priority signal across sources.
+- Per-source clients: `jira.rs`, `github_issues.rs`, `linear.rs` (#272),
+  `shortcut.rs` (#273), `confluence.rs` (#274), `datadog.rs` (#275).
+
+**Current state.** ✅ Six sources implemented; confidence varies by signal
+quality (#270); JIRA 403 (#286) and greedy-regex (#285) bugs fixed.
+
+**Gaps.** `requirements/collection.md` documents only JIRA/GitHub/Linear/ADO
+adapters; Shortcut / Confluence / Datadog are code-only additions 🟡 (doc drift).
+
+---
+
+## 5. Effort scorer (`src/core/effort.rs`)
+
+**Responsibility.** Assign each commit a deterministic empirical effort T-shirt
+size, persisted for per-engineer effort histograms.
+
+**Key types.**
+- `FORMULA_VERSION` (`"v1"`), `compute_effort(...)` → `EffortRecord` (size, score,
+  loc, files, test_loc, tests_factor).
+- Formula: `score = α·log₂(LoC+1) + β·log₂(files+1) + δ·tests_factor`, with
+  α=1.0, β=1.5, γ=0.0 (deferred), δ=1.0; `tests_factor = 1 − 0.3·min(test_LoC/LoC, 1)`.
+- T-shirt bands (calibrated against 99 trusty-tools commits, PR #308):
+  XS ≤ 6, S (6,10], M (10,14], L (14,18], XL > 18.
+- Persisted to `fact_commit_effort` (`PRIMARY KEY (sha, repository)`,
+  `formula_version`, unix `computed_at`).
+
+**Current state.** ✅ v1 implemented; output identical between Rust
+(`tga backfill effort`) and `scripts/compute-effort.sh`.
+
+**Gaps.** 🔵 v2 formula with cyclomatic-complexity γ term (re-run inserts new rows
+alongside v1 for score-evolution tracking). Not in `requirements/` — code-only.
+
+---
+
+## 6. Quality scorer (`src/core/quality.rs`) & revert detector (`src/core/revert.rs`)
+
+**Responsibility.** Per-engineer-per-week quality score (1–5) and the single
+shared revert-detection heuristic feeding both `commits.is_revert` and the
+report-time revert rate.
+
+**Key types.**
+- `core/quality.rs` — `quality = 0.35·(1−revert_rate) + 0.40·(1−bugfix_rate) +
+  0.25·ticket_linkage_rate` (negative signals inverted so higher = better);
+  bucketed into integer 1–5 with even 0.20 bands (#377).
+- `core/revert.rs` — compiled `^revert` / `^fix.*revert` / `Revert "…"` /
+  `revert(scope):` patterns anchored to the subject's first line; the single
+  source of truth both the backfill and aggregator paths now call (resolves the
+  ~87% disagreement that motivated #210/#377).
+
+**Current state.** ✅ Both implemented and unified.
+
+**Gaps.** Not in `requirements/` — code-only additions (doc drift). No persisted
+`fact_quality` table; quality is computed at report time.
+
+---
+
+## 7. DORA subsystem (`src/commands/{deployments,incidents,dora}.rs`, migration `0014`)
+
+**Responsibility.** Ingest deployment and incident events and compute the four
+DORA delivery metrics with performance-level banding.
+
+**Key types & tables.**
+- `fact_deployments` (`deploy_id` PK, repo, environment, triggered/completed,
+  status, git_sha, git_tag, source) — #212.
+- `fact_incidents` (`incident_id` PK, source, detected/resolved, denormalised
+  `mttr_hours`, severity, triggering_deploy, repo) — #213.
+- `deployment_failures` (derived failure↔recovery commit join) — #208.
+- SQL views: `v_deployment_frequency`, `v_lead_time`, `v_mttr`,
+  `v_change_failure_rate`.
+- Commands: `deployments collect` (`DeploymentsCollectArgs`), `incidents collect`
+  (`IncidentsCollectArgs`), `dora` (`DoraArgs`).
+
+**Current state.** ✅ Ingest + views + `tga dora` compute (lead time, deploy
+frequency, MTTR, CFR) with Elite/High/Medium/Low banding. Datadog incident
+extraction feeds MTTR (#213).
+
+**Gaps.** `requirements/reporting.md` describes DORA as report-time arithmetic
+only; the entire `fact_*` ingestion subsystem and the three commands are
+code-only 🟡 (doc drift — the most significant gap between docs and code).
+
+---
+
+## 8. Reporter — aggregator, formatters, drill-down (`src/report/`)
+
+**Responsibility.** Stage 3: turn classified/scored DB rows into CSV / JSON /
+Markdown artifacts and per-engineer drill-downs.
+
+**Key types & modules.**
+- `report/aggregator.rs` (`Aggregator::build`) — single scan of `commits`
+  ⨝ `classifications`, in-memory grouping into `ReportData`.
+- `report/models.rs` — `ReportData`, `AuthorSummary`, `RepositorySummary`,
+  `WeeklyMetrics`, `WeeklyVelocity`, `WeeklyCategorization`, `DoraMetrics`,
+  `QualitySummary`, `VelocitySummary`, `DeveloperActivitySummary`,
+  `UntrackedCommit`, plus the scope/health integers `repository_coverage`,
+  `unresolved_authors`, `unresolved_author_commits` (#67/#68).
+- `report/formatters/{csv,json,markdown}.rs` + `report/templates/` (Tera).
+- `report/drilldown.rs` (`AuthorDrilldownData`, `EffortHistogram`,
+  `format_markdown`/`format_json`) — powers `tga author` (#325).
+- `report/ticketed_stats.rs` (`compute_ticketed_stats`, `TicketedStats`).
+- `report/pipeline.rs` (`ReportPipeline`, `ReportStats`) — orchestrator.
+
+**Current state.** ✅ All CSV/JSON/Markdown outputs, velocity, weighted activity
+scoring, boilerplate filter, anonymization, `--author` filter (#324), and the
+`tga author` drill-down (#325) are implemented.
+
+**Gaps.** Activity-scoring weights, boilerplate thresholds match
+`requirements/reporting.md` ✅. Markdown narrative templates documented as
+shipping in `tga-report/templates/` in the requirements doc; they actually live
+in `src/report/templates/` (single-crate consolidation) 🟡 (minor doc drift).
+
+---
+
+## 9. Database & migrations (`src/core/db/`)
+
+**Responsibility.** Own the single SQLite file, its pragmas, the typed query
+wrappers, and the versioned migration runner.
+
+**Key types & modules.**
+- `core/db/mod.rs` (`Database`, `Database::open`/`open_in_memory`,
+  `CheckpointMode`) — WAL + `synchronous=NORMAL` + `foreign_keys=ON`.
+- `core/db/migrations.rs` — idempotent runner over `sql/0001_*.sql … 0016_*.sql`,
+  tracked in `schema_migrations`.
+- Per-table wrappers: `collection_runs.rs`, `work_items.rs`,
+  `azdo_iterations.rs` (no raw SQL at call sites).
+
+**Current state.** ✅ Migrations `0001`–`0016`; WAL checkpointing on exit (#298);
+rusqlite version aligned to workspace (#257).
+
+**Gaps.** 🟡 `requirements/database-schema.md` is stale: it lists migrations only
+through `0013`, uses predecessor table names (`cached_commits`,
+`weekly_fetch_status`), and omits the `fact_*` family and DORA views. The on-disk
+`src/core/db/sql/` set is authoritative.
+
+---
+
+## 10. CLI & commands (`src/main.rs`, `src/commands/`)
+
+**Responsibility.** Parse the clap CLI, open the DB, and dispatch to one `run`
+function per subcommand.
+
+**Key types & modules.**
+- `main.rs` — `Cli` parser, global flags, `Commands` enum, ISO-week selectors,
+  `LogLevel`; `RUST_LOG` precedence; shared `cli-help` (#216).
+- `commands/` — `analyze.rs`, `collect.rs`, `classify.rs`, `report.rs`,
+  `author.rs`, `pr_metrics.rs`, `aliases/` (crud + suggest), `backfill.rs`,
+  `override_cmd.rs`, `rules.rs`, `install.rs`, `deployments.rs`, `incidents.rs`,
+  `dora.rs`, plus shared `date_range.rs`.
+
+**Current state.** ✅ Fifteen subcommands; uniform `--repo`/`--branch`/`--week`
+filters (#332); per-subcommand `--help` audit (#333).
+
+**Gaps.** 🟡 `requirements/cli-commands.md` documents `fetch` and `identities
+list/merge` as standalone subcommands (folded into `collect` / `aliases`) and
+omits `author`/`backfill`/`rules`/`deployments`/`incidents`/`dora`. ARCHITECTURE
+§5 has the reconciled table.
+
+---
+
+## 11. Configuration & LLM config (`src/core/config/`)
+
+**Responsibility.** Load and validate the YAML config; own the `llm:` provider
+layer and DB-path precedence.
+
+**Key types & modules.**
+- `core/config/mod.rs` (`Config`, `Config::load`, `expand_path`) — serde YAML,
+  `~` + `${VAR}` expansion, unknown-key tolerance.
+- `core/config/validator.rs` (`ConfigValidator`) — cross-field checks (activity
+  weights sum to 1.0, etc.).
+- `core/config/azdo.rs` — Azure DevOps config section.
+- `core/config/aliases.rs` — identity-alias config.
+- Top-level `database:` (#406) and `llm:` (`source`/`api_key_env`/`region`/`model`,
+  #407) sections; self-enabling LLM; hard-fail on missing key env var (#405).
+
+**Current state.** ✅ All sections in `requirements/configuration.md` plus the
+three #405/#406/#407 additions implemented; secret values never persisted.
+
+**Gaps.** None material; `requirements/configuration.md` was already updated for
+`database:` and `llm:` and is the authoritative field reference. ✅
+
+---
+
+## 12. Errors (`src/{core,collect,classify,report}/errors.rs`)
+
+**Responsibility.** Structured library errors (`thiserror`) and an `anyhow`
+binary boundary.
+
+**Key types.** `TgaError`/`Result` (core), `CollectError`, `ClassifyError`,
+`ReportError` — each with `#[from]` conversions for upstream `git2` / `rusqlite`
+/ `reqwest` errors. `commands/` and `main.rs` use `anyhow::Result`.
+
+**Current state.** ✅ Per-module enums; no `unwrap()` in library code (the
+cascade fallback uses a documented `expect()` invariant that rule-based always
+returns `Some`).
+
+**Gaps.** None material.

--- a/docs/trusty-git-analytics/spec/PRD.md
+++ b/docs/trusty-git-analytics/spec/PRD.md
@@ -1,0 +1,263 @@
+# trusty-git-analytics (`tga`) — Product Requirements Document
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** existing `requirements/` docs + code/tickets reconciliation
+
+**Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
+Each requirement is framed **Vision / Current / Gap**.
+
+---
+
+## 1. Vision & Mission
+
+### North-star vision
+
+> **tga turns raw git history into trustworthy engineering analytics** — who did
+> what kind of work, how much effort it took, how well it shipped, and how the
+> team delivers against DORA — from a single local binary over an embedded SQLite
+> database, with **no daemon, no cloud, and no Python or Node runtime in the
+> hot path.**
+
+Where a manager today stitches together GitHub insights, a JIRA velocity board,
+a hand-rolled spreadsheet of "lines changed," and nothing at all for "what *kind*
+of work was this," tga collapses all of that into one reproducible pipeline. The
+defining properties are: **work classification that does not depend on commit
+messages alone** (it reaches through to the JIRA/Linear/GitHub-Issues ticket
+behind the commit), **empirical effort and quality scores** that survive
+re-runs deterministically, and a **single-file SQLite output** any downstream
+warehouse (e.g. a CTO analytics DuckDB) can read directly.
+
+### Mission
+
+Deliver a CLI any engineering leader or IC can point at a set of repositories
+and get back, in seconds, per-author / per-week / per-category / DORA / velocity
+reports — reproducibly, offline, and without standing up any service.
+
+### Lineage & divergence
+
+tga began as a Rust port of the Python `gitflow-analytics` tool with the goal of
+config/schema/CLI parity. It has since **diverged upward**: a two-level work
+taxonomy, multi-source classification (six external systems), per-commit effort
+scoring, per-engineer quality scoring, a full DORA fact-table subsystem, tag /
+release-branch reachability, and a per-engineer drill-down command are all tga
+capabilities the predecessor never had. Parity with the Python tool is therefore
+a **historical motivation, not a current constraint** — where the code exceeds
+the predecessor, the code wins.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+| # | Goal | Status |
+|---|---|---|
+| G1 | **Three-stage pipeline** — `collect → classify → report`, runnable end-to-end (`tga analyze`) or stage-by-stage. | ✅ |
+| G2 | **Parallel git extraction** — libgit2 (`git2`) revwalk with rayon across repos/branches; smart branch selection. | ✅ |
+| G3 | **Multi-provider PR collection** — GitHub, Bitbucket Cloud, and Azure DevOps PRs + reviewer data behind one `PrProvider`/`PmAdapter` abstraction. | ✅ |
+| G4 | **Multi-source classification** — JIRA, GitHub Issues, Linear, Shortcut, Confluence, Datadog as high-confidence signals ahead of commit-message tiers. | ✅ |
+| G5 | **Multi-tier classification cascade** — override → external-source/issue-type → jira-project → exact/regex/fuzzy rules → LLM, with a rule-based result guaranteed for every commit. | ✅ |
+| G6 | **Two-level work taxonomy** — closed 7-variant `TopLevelCategory` + extensible subcategory registry; user-overridable via rules/config. | ✅ |
+| G7 | **LLM fallback tier** — OpenRouter (default), AWS Bedrock (feature-gated), and direct Anthropic API; self-enabling `llm:` config section that never stores the key. | ✅ |
+| G8 | **Empirical per-commit effort scoring** — deterministic XS–XL T-shirt sizes persisted in `fact_commit_effort`, identical between the Rust path and the parallel bash script. | ✅ |
+| G9 | **Per-engineer-per-week quality scoring** — 1–5 score from revert / bugfix / ticket-linkage rates (#377). | ✅ |
+| G10 | **DORA delivery metrics** — deployment-frequency, lead-time, change-failure-rate, MTTR from ingested `fact_deployments` / `fact_incidents` and SQL views. | ✅ |
+| G11 | **Velocity & activity reporting** — PR cycle time, throughput, revision rate, story points, weighted activity score per engineer per ISO week. | ✅ |
+| G12 | **Per-engineer drill-down** — `tga author <email>` assembling effort histogram + PR metrics + commit summary. | ✅ |
+| G13 | **Identity resolution** — manual mappings → exact email → GitHub login → Jaro-Winkler fuzzy match → canonical record; CRUD + LLM-assisted alias suggestion. | ✅ |
+| G14 | **Reproducible offline output** — single SQLite file (WAL), CSV/JSON/Markdown reports, optional anonymization. | ✅ |
+| G15 | **Tag / release-branch reachability** — distinguish deployed-via-release commits from abandoned WIP (`fact_commit_reachability`, #279). | ✅ |
+| G16 | **Config/CLI compatibility with `gitflow-analytics`** — same YAML keys and subcommand layout where they still apply. | 🟡 |
+| G17 | **Performance regression tracking** — Rust-vs-Python and version-over-version snapshots in `regression-testing/`. | 🟡 |
+| G18 | **In-process LLM** — feature-flag `candle`/`llama.cpp` to classify without HTTP. | ⚪ |
+| G19 | **Parquet / DuckDB export** — first-class columnar export for analytics pipelines. | ⚪ |
+
+### Non-Goals
+
+| Non-Goal | Rationale |
+|---|---|
+| Always-on daemon or MCP server | tga is a **batch CLI**; there is no long-running process. Downstream tools read the SQLite file directly. |
+| Hosted / multi-tenant SaaS | ELv2-licensed; intended to run on a developer or CI host against local clones. |
+| Real-time / streaming analytics | Analysis is run on demand over an ISO-week window; not event-streamed. |
+| Code-quality static analysis (complexity, smells) | That is **trusty-analyze**'s job. tga's `complexity` column is an LLM-assigned 1–5 hint, not a static metric. |
+| Bitbucket Server / Data Center | Only Bitbucket **Cloud** is supported (ADR-0003). |
+| GitLab PR collection | Not implemented — a known parity gap with the Python predecessor. |
+| Storing secrets in config | API keys are read from env vars named by config (`api_key_env`), never persisted. |
+
+---
+
+## 3. Target Users / Personas
+
+| Persona | Needs | tga answer |
+|---|---|---|
+| **Engineering manager** | Weekly per-engineer breakdown of work type, velocity, and effort without nagging the team for status. | `tga analyze --weeks 4` → weekly CSVs + per-author summary + effort histogram. |
+| **Individual contributor / tech lead** | A defensible picture of their own contribution mix (feature vs. KTLO vs. maintenance) for reviews. | `tga author <email>` drill-down: effort histogram + PR metrics + commit summary. |
+| **CTO / director** | Org-level DORA posture and quality trend to report upward; portfolio coverage confidence. | `tga dora` + `repository_coverage` / `unresolved_authors` fields guard against undercounting. |
+| **Platform / data engineer** | A clean, reproducible SQLite/CSV feed into a warehouse (e.g. CTO analytics DuckDB). | Single `tga.db` file + `comprehensive_export_{date}.json`; deterministic effort scores. |
+
+---
+
+## 4. Functional Requirements
+
+### 4.1 Collection (git walk + external fetch) — `tga collect`
+
+Detailed source: [`../requirements/collection.md`](../requirements/collection.md).
+
+| # | Requirement | Status |
+|---|---|---|
+| C1 | Extract commits via `git2` revwalk (OID traversal, in-process diff); parallel across repos/branches with rayon. | ✅ |
+| C2 | Smart branch selection (`smart` / `all` / `main_only`), with `branch_commit_limit`, `max_branches`, `active_days` limits (#331). | ✅ |
+| C3 | Per-commit fields: hash, author, timestamp, ISO week, message, files/insertions/deletions, merge flag, `ticketed` / `ticket_id`, `is_revert`. | ✅ |
+| C4 | Path-exclusion globs filter diff stats. | ✅ |
+| C5 | HTTPS remote fetch with bundled libgit2 TLS (macOS Security / vendored OpenSSL / Schannel); SSH disabled (#337). | ✅ |
+| C6 | Ticket-reference extraction (JIRA `[A-Z]{2,10}-\d+` w/ CVE/CWE exclusion, GitHub `#\d+`, ADO `AB#\d+`, Linear); per-provider `ticket_regex` override (#75). | ✅ |
+| C7 | GitHub PR + review collection (incremental, open-PR TTL refresh) (#11/#211). | ✅ |
+| C8 | Bitbucket Cloud PR collection via `PrProvider` (ADR-0003). | ✅ |
+| C9 | Azure DevOps work-item + PR + reviewer collection via WIQL + `workitemsbatch` (#84). | ✅ |
+| C10 | JIRA ticket fetch (JQL, story-point field discovery). | ✅ |
+| C11 | Identity resolution cascade + canonical records. | ✅ |
+| C12 | Tag / release-branch reachability into `fact_commit_reachability` (#279/#290/#303). | ✅ |
+| C13 | Per-(repo, ISO-week) collection bookkeeping in `collection_runs`; `--force` re-collects. | ✅ |
+| C14 | Always-fetch-before-collect with per-repo error isolation and visible reporting (#334). | ✅ |
+| C15 | GitLab PR collection. | 🔵 |
+
+### 4.2 Classification — `tga classify`
+
+Detailed source: [`../requirements/classification.md`](../requirements/classification.md).
+
+| # | Requirement | Status |
+|---|---|---|
+| L1 | Multi-tier cascade: manual override → external-source/issue-type → jira-project-key → exact (Aho-Corasick) → regex → fuzzy → LLM; rule-based result guaranteed. | ✅ |
+| L2 | Two-level taxonomy: closed `TopLevelCategory` (Feature, Bugfix, Ktlo, Integrations, PlatformWork, Content, Maintenance, +Unknown) + extensible subcategory registry. | ✅ |
+| L3 | Multi-source signals: JIRA, GitHub Issues, Linear, Shortcut, Confluence, Datadog, resolved + cached per run; confidence varies by signal quality (#270). | ✅ |
+| L4 | Per-run external-source cache (in-memory) to avoid duplicate API fetches. | ✅ |
+| L5 | LLM tier: batched, circuit-broken, response-cached (90d), confidence-gated; `llm_fallback_threshold` / `llm_fallback_concurrency` (#78/#83). | ✅ |
+| L6 | External-source verdicts persist as `external_source` method on the commit (#321/#316). | ✅ |
+| L7 | Custom rules from YAML with working priority (#259); `tga rules list/show` to inspect (#209). | ✅ |
+| L8 | Coverage metrics + `--validate-coverage` / `--coverage-threshold` gating. | ✅ |
+| L9 | WAL checkpoint at exit so a crash mid-classify does not lose work (#298). | ✅ |
+| L10 | `external_source` method missing from `classifications` table despite cache hits in some 1.5.2 paths. | 🟡 (#320 open) |
+
+### 4.3 Effort scoring — `tga backfill effort`
+
+Detailed source: [`../research/commit-effort-spec-2026-05-27.md`](../research/commit-effort-spec-2026-05-27.md).
+
+| # | Requirement | Status |
+|---|---|---|
+| E1 | Deterministic v1 formula `score = α·log₂(LoC+1) + β·log₂(files+1) + δ·tests_factor` (α=1.0, β=1.5, δ=1.0). | ✅ |
+| E2 | XS–XL T-shirt bucketing (calibrated against 99 trusty-tools commits, PR #308). | ✅ |
+| E3 | Test-LoC detection by path globs; `tests_factor` discount. | ✅ |
+| E4 | Persisted to `fact_commit_effort` with `formula_version` for score-evolution tracking. | ✅ |
+| E5 | Identical output between the Rust path and the parallel `scripts/compute-effort.sh`. | ✅ |
+| E6 | v2 formula adding cyclomatic complexity (γ term). | 🔵 |
+
+### 4.4 Quality scoring — `tga` report path (#377)
+
+| # | Requirement | Status |
+|---|---|---|
+| Q1 | Per-engineer-per-week 1–5 quality score from `0.35·(1−revert_rate) + 0.40·(1−bugfix_rate) + 0.25·ticket_linkage_rate`. | ✅ |
+| Q2 | Negative signals inverted so higher = better, matching the effort scale. | ✅ |
+| Q3 | Even 0.20-wide bucketing into integer 1–5. | ✅ |
+| Q4 | Shared revert detector (`core/revert.rs`) is the single source of truth for `is_revert` and report-time revert rate (#210/#377). | ✅ |
+
+### 4.5 DORA metrics — `tga deployments` / `tga incidents` / `tga dora`
+
+| # | Requirement | Status |
+|---|---|---|
+| D1 | Ingest deployment events into `fact_deployments` (idempotent on upstream `deploy_id`) (#212). | ✅ |
+| D2 | Ingest incidents into `fact_incidents` with denormalised `mttr_hours` (Datadog/PagerDuty/JIRA SRE) (#213). | ✅ |
+| D3 | Derived `deployment_failures` join (failure + recovery commit) (#208). | ✅ |
+| D4 | SQL views `v_deployment_frequency`, `v_lead_time`, `v_mttr`, `v_change_failure_rate`. | ✅ |
+| D5 | `tga dora` computes & displays the four metrics with Elite/High/Medium/Low performance levels. | ✅ |
+| D6 | Datadog deployment-event source feeds classification + DORA (#275/#213). | ✅ |
+
+### 4.6 Reporting — `tga report`
+
+Detailed source: [`../requirements/reporting.md`](../requirements/reporting.md).
+
+| # | Requirement | Status |
+|---|---|---|
+| R1 | CSV reports (weekly metrics, developer activity, categorization, velocity, DORA, untracked commits, developers). | ✅ |
+| R2 | JSON exports (velocity / weekly / quality summaries, comprehensive export). | ✅ |
+| R3 | Markdown narrative + qualitative reports via Tera templates. | ✅ |
+| R4 | Velocity metrics (cycle time w/ outlier filter, throughput, revision rate, story points/week). | ✅ |
+| R5 | Weighted activity scoring (weights sum to 1.0, min-max normalized). | ✅ |
+| R6 | Boilerplate / auto-generated-code filter (`flag` / `exclude_from_averages` / `exclude`). | ✅ |
+| R7 | Scope/identity-health fields: `repository_coverage`, `unresolved_authors`, `unresolved_author_commits` (#67/#68). | ✅ |
+| R8 | Anonymization (`dev_NNN` ids + mapping file). | ✅ |
+| R9 | `--author <email>` filter on `tga report` (#324). | ✅ |
+| R10 | Per-domain drill-down (`tga author`, #325) — effort histogram + PR metrics + commit summary. | ✅ |
+
+### 4.7 CLI
+
+Detailed source: [`../requirements/cli-commands.md`](../requirements/cli-commands.md).
+**Note:** the live command set exceeds that doc — see ARCHITECTURE §CLI surface.
+
+| # | Requirement | Status |
+|---|---|---|
+| CLI1 | Core stage commands: `analyze`, `collect`, `classify`, `report`. | ✅ |
+| CLI2 | Identity: `aliases` (list/add/remove/show/suggest, #347/#348). | ✅ |
+| CLI3 | `pr-metrics`, `override`, `install`, `rules`, `backfill`, `author`. | ✅ |
+| CLI4 | DORA: `deployments collect`, `incidents collect`, `dora`. | ✅ |
+| CLI5 | Uniform `--repo` / `--branch` / `--week` filters across collect/classify/backfill (#332). | ✅ |
+| CLI6 | Global `--config`, `--database`, `-v/--log`; `RUST_LOG` precedence. | ✅ |
+| CLI7 | Per-subcommand `--help` / examples audit (#333). | ✅ |
+| CLI8 | `fetch` and `identities list/merge` standalone subcommands as drafted in `requirements/cli-commands.md`. | 🟡 (folded into `collect` / `aliases`) |
+
+### 4.8 Configuration
+
+Detailed source: [`../requirements/configuration.md`](../requirements/configuration.md).
+
+| # | Requirement | Status |
+|---|---|---|
+| CFG1 | YAML via serde; `~` expansion; `${VAR}` secret expansion; unknown keys ignored (forward-compatible). | ✅ |
+| CFG2 | Top-level `database:` path with `--database > config > tga.db` precedence (#406). | ✅ |
+| CFG3 | Top-level `llm:` section (`source` ∈ openrouter/bedrock/anthropic-api, `api_key_env`, `region`, `model`); self-enabling; supersedes legacy `classification.*` fields with deprecation warning (#407/#405). | ✅ |
+| CFG4 | Repository / GitHub / Bitbucket / Azure-DevOps / JIRA / Linear / analysis / output / cache / velocity / activity_scoring / boilerplate_filter / quality_report / taxonomy_mapping / teams sections. | ✅ |
+| CFG5 | `validate()` cross-field checks (e.g. activity weights sum to 1.0). | ✅ |
+| CFG6 | Hard error (non-zero, before any DB write) when LLM is enabled but the named key env var is unset/empty (#405). | ✅ |
+
+### 4.9 Database
+
+Detailed source: [`../requirements/database-schema.md`](../requirements/database-schema.md).
+
+| # | Requirement | Status |
+|---|---|---|
+| DB1 | Single SQLite file, WAL + `synchronous=NORMAL` + `foreign_keys=ON`; versioned, idempotent migrations (`schema_migrations`). | ✅ |
+| DB2 | Core tables: `authors`, `commits`, `classifications`, `files`, `pull_requests`, `pr_reviewers`, `work_items`, `commit_work_items`, `linear_issues`, `classification_overrides`, `collection_runs`, `repository_analysis_status`, `azdo_iterations`. | ✅ |
+| DB3 | `fact_*` family: `fact_deployments`, `fact_incidents`, `deployment_failures`, `fact_commit_reachability`, `fact_commit_effort` + DORA views. | ✅ |
+| DB4 | Migrations `0001`–`0016` (requirements doc stops at `0013`). | ✅ |
+| DB5 | `requirements/database-schema.md` migration list (`0001`–`0013`) is stale vs. on-disk SQL (`0001`–`0016`). | 🟡 (doc drift — see COMPONENTS §Database) |
+
+---
+
+## 5. Success Criteria & Differentiators
+
+- **Reproducibility.** Re-running `tga analyze` over the same window and config
+  yields byte-identical effort scores and stable classifications (modulo LLM
+  cache expiry). ✅
+- **Coverage honesty.** `repository_coverage` and `unresolved_authors` surface
+  undercounting and phantom developers instead of silently inflating totals. ✅
+- **Work-type accuracy without good commit messages.** Multi-source
+  classification reaches through to the ticket behind a commit, so a bare
+  `PROJ-1234 update` still classifies correctly. ✅
+- **Single-binary, offline.** No daemon, no service, no Python/Node in the hot
+  path; one SQLite file is the whole output surface. ✅
+- **Speed.** Aspirational 5–10× git-extraction and 4–8× overall-pipeline speedup
+  vs. the Python predecessor (`rust-architecture.md`). 🟡 (targets set; tracked in
+  `regression-testing/`).
+
+---
+
+## 6. Open Questions / Roadmap
+
+| # | Question | Pointer |
+|---|---|---|
+| OQ1 | Persist `external_source` method reliably across all 1.5.x cache paths. | #320 (open) |
+| OQ2 | v2 effort formula with cyclomatic complexity (γ term). | E6 / `core/effort.rs` header |
+| OQ3 | GitLab PR collection for full predecessor parity. | C15 |
+| OQ4 | In-process LLM via `candle`/`llama.cpp` (no HTTP). | `rust-architecture.md` Future Improvements |
+| OQ5 | Parquet / DuckDB columnar export. | `rust-architecture.md` Future Improvements |
+| OQ6 | Reconcile / refresh the `requirements/` docs (taxonomy, DB migration list, tier naming) to match the spec, or formally demote them to "predecessor parity" reference. | DB5 / this PRD |
+| OQ7 | gitoxide migration once its diff API stabilizes. | ADR backlog |

--- a/docs/trusty-git-analytics/spec/README.md
+++ b/docs/trusty-git-analytics/spec/README.md
@@ -1,0 +1,117 @@
+# trusty-git-analytics (`tga`) — Specification Set
+
+> **Status:** Canonical · Living Document
+> **Last reviewed:** 2026-05-29
+> **Derived from:** existing `requirements/` docs + code/tickets reconciliation
+
+This directory holds the canonical product and engineering specification for the
+`tga` crate (package name `tga`, directory `crates/trusty-git-analytics/`,
+version `2.3.0`). It is the single authoritative reference for *what tga is meant
+to be*, *what it is today*, and *what gaps remain*.
+
+## What is trusty-git-analytics?
+
+`tga` is a **developer-productivity analytics CLI and embedded SQLite database**.
+It walks local git repositories, correlates each commit with external systems
+(GitHub / Bitbucket / Azure DevOps PRs; JIRA / Linear / Shortcut / GitHub-Issues
+tickets), classifies every commit into a two-level work taxonomy via a
+multi-tier cascade, scores per-commit *effort* and per-engineer *quality*, tracks
+DORA delivery metrics from ingested deployment and incident events, and emits
+per-author / per-week / velocity / DORA / quality reports as CSV, JSON, and
+Markdown. It originated as a Rust port of the Python `gitflow-analytics` tool but
+has since grown capabilities (effort scoring, DORA fact tables, a two-level
+taxonomy, per-engineer drill-downs) that the predecessor never had. Everything is
+local: a single `tga` binary, one SQLite file (`tga.db`, WAL mode), no daemon and
+no service dependency.
+
+## Documents in this set
+
+| Document | Read it when you want to know… |
+|---|---|
+| **[PRD.md](./PRD.md)** | The product: vision & mission, goals/non-goals, personas (eng managers, ICs, CTO), and the full functional-requirement catalogue grouped by capability (collection, classification, effort scoring, quality scoring, DORA, reporting, CLI, configuration, database) tagged by implementation status. Start here for *why* and *what*. |
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | The system shape: the `collect → classify → score → aggregate → report` pipeline, the single SQLite schema (with the `fact_*` family that the requirements docs predate), the LLM config layer (`llm:` section, OpenRouter / Bedrock / Anthropic per #405/#406/#407), and the CLI surface. Includes the source-module map with `src/` citations. Start here for *how it fits together*. |
+| **[COMPONENTS.md](./COMPONENTS.md)** | Per-subsystem specs: collector, classifier (tiers + sources), effort scorer, quality scorer, reporter/aggregator + drill-down, database/migrations, CLI, and config/LLM. Each states responsibility, key types (with `src/` paths), current state, and known gaps. Start here for *the detail of one subsystem*. |
+
+## Reading order
+
+1. **New to tga?** PRD → ARCHITECTURE → COMPONENTS.
+2. **Implementing a feature?** Jump to the relevant COMPONENTS section, then
+   cross-check the pipeline in ARCHITECTURE.
+3. **Evaluating product direction?** PRD vision + success criteria, then the gap
+   callouts throughout COMPONENTS.
+
+## Status legend (used throughout this set)
+
+Every requirement and component is framed as **Vision / Current / Gap** and
+tagged inline with one of:
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Built and working today. |
+| 🟡 **Partial** | Partly built; usable but incomplete or with known caveats. |
+| 🔵 **Designed-not-built** | Design exists (types, scaffolding, or plan) but no working path. |
+| ⚪ **Aspirational** | North-star intent; no design committed yet. |
+
+## Relationship to the `requirements/` docs
+
+This `spec/` set **supersedes and sits above** the nine detailed documents in
+[`../requirements/`](../requirements/) (`overview.md`, `collection.md`,
+`classification.md`, `reporting.md`, `cli-commands.md`, `configuration.md`,
+`database-schema.md`, `rust-architecture.md`, `index.md`). Those remain as the
+**detailed source material** — the field-by-field config schema, the full
+migration list, the rule-tier tables — and are linked from the relevant spec
+sections. Where the two disagree, **this spec set is authoritative** because it
+was reconciled against the `crates/trusty-git-analytics/src/` tree and the issue
+backlog as of the review date. The most material reconciliations:
+
+- **Taxonomy.** `requirements/classification.md` describes a flat 19-value
+  `ChangeType` enum. The code implements a **two-level taxonomy** — a closed
+  7-variant `TopLevelCategory` (+ `Unknown`) plus an extensible subcategory
+  registry (`TaxonomyRegistry`). The 19 names survive as *subcategories* that
+  roll up to the seven top-levels. See COMPONENTS §Classifier.
+- **DORA.** The requirements treat DORA purely as report-time arithmetic. The
+  code ships a **full DORA subsystem**: `fact_deployments`, `fact_incidents`,
+  `deployment_failures`, four SQL views, and `tga deployments` / `tga incidents`
+  / `tga dora` commands (migration `0014`, issues #207/#208/#212/#213).
+- **Effort & quality scoring.** Neither appears in the requirements. The code has
+  `core/effort.rs` + `fact_commit_effort` (`tga backfill effort`, PR #308) and
+  `core/quality.rs` (#377).
+- **Reachability.** `fact_commit_reachability` (migration `0015`, #279) tracks
+  tag/release-branch reachability — absent from the requirements.
+- **Tier naming.** The classify cascade modules are named `exact / regex / fuzzy
+  / llm` with `override / issue_type / jira_project / weighted_sum / bedrock`
+  helpers — not the `Tier 0 / 1.5 / 3` numbering used in
+  `requirements/classification.md`.
+- **DB table names.** Live tables are `commits` / `collection_runs`, not the
+  predecessor's `cached_commits` / `weekly_fetch_status`. Migrations run to
+  `0016`, past the `0013` ceiling documented in `requirements/database-schema.md`.
+
+## Related documentation
+
+This `spec/` set is the *what/why/gap* layer. The point-in-time and operational
+docs live alongside it:
+
+- **[../requirements/](../requirements/)** — the detailed source specification
+  (config schema, DB schema, CLI flags, classification cascade).
+- **[../decisions/](../decisions/)** — crate-specific ADRs (SQLite tuning,
+  performance hotspots, Bitbucket PR provider).
+- **[../developer/](../developer/)** — contributor architecture, developer guide,
+  configuration reference, migration-from-Python.
+- **[../user/](../user/)** — the end-user CLI guide.
+- **[../research/](../research/)** — dated investigations (commit-effort spec,
+  per-engineer drill-down).
+- **[../regression-testing/](../regression-testing/)** — versioned performance
+  snapshots and the Rust-vs-Python comparison.
+- **[crates/trusty-git-analytics/README.md](../../../crates/trusty-git-analytics/README.md)**
+  — in-crate quick-start and CLI catalogue.
+
+## Provenance & maintenance
+
+These documents were derived by reconciling the existing `requirements/` set
+against an audit of the `crates/trusty-git-analytics/src/` tree (the single `tga`
+crate with `core` / `collect` / `classify` / `report` / `commands` modules as of
+v2.3.0), the crate `Cargo.toml`, and the open/closed issue backlog (notably the
+DORA work #207/#208/#212/#213, the effort spec PR #308, the quality metric #377,
+the reachability work #279, and the LLM-config trio #405/#406/#407). When the
+code changes materially, update the relevant document and bump the *Last
+reviewed* date. Source-path citations reflect the layout at the time of review.


### PR DESCRIPTION
Canonical spec set under docs/trusty-git-analytics/spec/, reconciled from the existing requirements/ docs against code (now v2.3.0). Captures drift: two-level taxonomy, full DORA ingestion subsystem, effort/quality scoring, migrations to 0016. No new ADR (existing decisions cover it). cargo check -p tga passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)