### PR TITLE
docs(mdbook): consolidate SUMMARY nav across all crate specs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Decisions](./open-mpm/decisions/README.md)
   - [0001 — NDJSON subprocess IPC](./open-mpm/decisions/0001-ndjson-subprocess-ipc.md)
   - [0002 — Model-agnostic credential routing](./open-mpm/decisions/0002-model-agnostic-credential-routing.md)
+  - [0003 — Daemon process model](./open-mpm/decisions/0003-daemon-process-model.md)
 - [Design](./open-mpm/design/README.md)
   - [Goals](./open-mpm/design/goals.md)
   - [Workflow Engine](./open-mpm/design/workflow-engine.md)
@@ -46,33 +47,120 @@
 - [Research](./open-mpm/research/README.md)
 - [Archive](./open-mpm/_archive/README.md)
 
+# trusty-mpm
+
+- [Overview](./trusty-mpm/README.md)
+- [Specification](./trusty-mpm/spec/README.md)
+  - [PRD](./trusty-mpm/spec/PRD.md)
+  - [Architecture](./trusty-mpm/spec/ARCHITECTURE.md)
+  - [Components](./trusty-mpm/spec/COMPONENTS.md)
+- [Decisions](./trusty-mpm/decisions/README.md)
+  - [0001 — Single-install multi-binary bundling](./trusty-mpm/decisions/0001-single-install-multi-binary-bundling.md)
+- [Research](./trusty-mpm/research/README.md)
+  - [PRD (2026-05-29)](./trusty-mpm/research/prd-2026-05-29.md)
+  - [Architecture Spec (2026-05-29)](./trusty-mpm/research/architecture-spec-2026-05-29.md)
+  - [tm Services Discovery Spec (2026-05-28)](./trusty-mpm/research/tm-services-discovery-spec-2026-05-28.md)
+- [Sessions](./trusty-mpm/sessions/README.md)
+  - [2026-05-26 — TUI Color Fix](./trusty-mpm/sessions/SESSION-2026-05-26-tui-color-fix.md)
+
 # trusty-search
 
 - [Overview](./trusty-search/README.md)
+- [Specification](./trusty-search/spec/README.md)
+  - [PRD](./trusty-search/spec/PRD.md)
+  - [Architecture](./trusty-search/spec/ARCHITECTURE.md)
+  - [Components](./trusty-search/spec/COMPONENTS.md)
+- [Decisions](./trusty-search/decisions/README.md)
+  - [0001 — Bundled embedder sidecar](./trusty-search/decisions/0001-bundled-embedder-sidecar.md)
 - [Research](./trusty-search/research/README.md)
 - [Regression Testing](./trusty-search/regression-testing/README.md)
 - [Sessions](./trusty-search/sessions/README.md)
 
-# trusty-git-analytics
-
-- [Overview](./trusty-git-analytics/README.md)
-- [Requirements](./trusty-git-analytics/requirements/index.md)
-- [Decisions](./trusty-git-analytics/decisions/README.md)
-- [Regression Testing](./trusty-git-analytics/regression-testing/README.md)
-
 # trusty-memory
 
 - [Overview](./trusty-memory/README.md)
-
-# trusty-common
-
-- [Overview](./trusty-common/README.md)
+- [Specification](./trusty-memory/spec/README.md)
+  - [PRD](./trusty-memory/spec/PRD.md)
+  - [Architecture](./trusty-memory/spec/ARCHITECTURE.md)
+  - [Components](./trusty-memory/spec/COMPONENTS.md)
+- [Decisions](./trusty-memory/decisions/README.md)
+  - [0001 — Frontend/Core Split](./trusty-memory/decisions/0001-frontend-core-split.md)
+- [Research](./trusty-memory/research/README.md)
+  - [axum Feature-Flag Decision (2026-05-26)](./trusty-memory/research/axum-feature-flag-decision-2026-05-26.md)
+- [Sessions](./trusty-memory/sessions/README.md)
+  - [2026-05-26 — Code Analysis & Fixes](./trusty-memory/sessions/SESSION-2026-05-26-code-analysis-and-fixes.md)
 
 # trusty-analyze
 
 - [Overview](./trusty-analyze/README.md)
+- [Specification](./trusty-analyze/spec/README.md)
+  - [PRD](./trusty-analyze/spec/PRD.md)
+  - [Architecture](./trusty-analyze/spec/ARCHITECTURE.md)
+  - [Components](./trusty-analyze/spec/COMPONENTS.md)
+- [Decisions](./trusty-analyze/decisions/README.md)
+  - [0001 — Gate axum Behind http-server Feature (2026-05-26)](./trusty-analyze/decisions/0001-gate-axum-behind-http-server-feature-2026-05-26.md)
+- [Research](./trusty-analyze/research/README.md)
+  - [Code Analysis Summary](./trusty-analyze/research/trustee_search_code_analysis_summary.md)
 
-# trusty-mpm
+# trusty-common
 
-- [Overview](./trusty-mpm/README.md)
-- [Research](./trusty-mpm/research/README.md)
+- [Overview](./trusty-common/README.md)
+- [Specification](./trusty-common/spec/README.md)
+  - [PRD](./trusty-common/spec/PRD.md)
+  - [Architecture](./trusty-common/spec/ARCHITECTURE.md)
+  - [Components](./trusty-common/spec/COMPONENTS.md)
+- [Decisions](./trusty-common/decisions/README.md)
+  - [0001 — Consolidate library micro-crates](./trusty-common/decisions/0001-consolidate-library-micro-crates.md)
+
+# trusty-git-analytics
+
+- [Overview](./trusty-git-analytics/README.md)
+- [Specification](./trusty-git-analytics/spec/README.md)
+  - [PRD](./trusty-git-analytics/spec/PRD.md)
+  - [Architecture](./trusty-git-analytics/spec/ARCHITECTURE.md)
+  - [Components](./trusty-git-analytics/spec/COMPONENTS.md)
+- [Decisions](./trusty-git-analytics/decisions/README.md)
+  - [0001 — SQLite Tuning](./trusty-git-analytics/decisions/0001-sqlite-tuning.md)
+  - [0002 — Performance Hotspots](./trusty-git-analytics/decisions/0002-performance-hotspots.md)
+  - [0003 — Bitbucket PR Provider](./trusty-git-analytics/decisions/0003-bitbucket-pr-provider.md)
+- [Requirements](./trusty-git-analytics/requirements/README.md)
+  - [Index](./trusty-git-analytics/requirements/index.md)
+  - [Overview](./trusty-git-analytics/requirements/overview.md)
+  - [CLI Commands](./trusty-git-analytics/requirements/cli-commands.md)
+  - [Collection](./trusty-git-analytics/requirements/collection.md)
+  - [Classification](./trusty-git-analytics/requirements/classification.md)
+  - [Reporting](./trusty-git-analytics/requirements/reporting.md)
+  - [Configuration](./trusty-git-analytics/requirements/configuration.md)
+  - [Database Schema](./trusty-git-analytics/requirements/database-schema.md)
+  - [Rust Architecture](./trusty-git-analytics/requirements/rust-architecture.md)
+- [User Guide](./trusty-git-analytics/user/README.md)
+  - [User Guide](./trusty-git-analytics/user/user-guide.md)
+- [Developer Guide](./trusty-git-analytics/developer/README.md)
+  - [Architecture](./trusty-git-analytics/developer/architecture.md)
+  - [Developer Guide](./trusty-git-analytics/developer/developer-guide.md)
+  - [Configuration Reference](./trusty-git-analytics/developer/configuration-reference.md)
+  - [Migration from Python](./trusty-git-analytics/developer/migration-from-python.md)
+  - [Publishing](./trusty-git-analytics/developer/publishing.md)
+- [Research](./trusty-git-analytics/research/README.md)
+  - [Commit Effort Spec (2026-05-27)](./trusty-git-analytics/research/commit-effort-spec-2026-05-27.md)
+  - [Per-Engineer Drill-down (2026-05-28)](./trusty-git-analytics/research/per-engineer-drilldown-2026-05-28.md)
+- [Regression Testing](./trusty-git-analytics/regression-testing/README.md)
+  - [Comparison](./trusty-git-analytics/regression-testing/comparison.md)
+  - [v1.3.0 (2026-05-27)](./trusty-git-analytics/regression-testing/v1.3.0-2026-05-27.md)
+
+# Libraries & Sidecars
+
+- [trusty-embedderd](./trusty-embedderd/README.md)
+  - [Spec](./trusty-embedderd/SPEC.md)
+- [trusty-bm25-daemon](./trusty-bm25-daemon/README.md)
+  - [Spec](./trusty-bm25-daemon/SPEC.md)
+- [trusty-gworkspace](./trusty-gworkspace/README.md)
+  - [Spec](./trusty-gworkspace/SPEC.md)
+- [trusty-cto-db](./trusty-cto-db/README.md)
+  - [Spec](./trusty-cto-db/SPEC.md)
+- [tc-services](./tc-services/README.md)
+  - [Spec](./tc-services/SPEC.md)
+- [open-mpm-agent-api](./open-mpm-agent-api/README.md)
+  - [Spec](./open-mpm-agent-api/SPEC.md)
+- [open-mpm-local](./open-mpm-local/README.md)
+  - [Spec](./open-mpm-local/SPEC.md)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,7 +14,14 @@ This book is built from the `docs/` tree. Documentation is organized **by crate*
 - **Architecture Decisions** — workspace-wide ADRs (Nygard format). The bar for
   writing one is *architecturally significant **and** costly to reverse*.
 - **Per-crate sections** — each crate's specification, design, research, user,
-  and developer docs, plus its crate-specific decision records.
+  and developer docs, plus its crate-specific decision records. Full spec
+  coverage (PRD + Architecture + Components + Decisions) is complete for all
+  major crates: **open-mpm**, **trusty-mpm**, **trusty-search**,
+  **trusty-memory**, **trusty-analyze**, **trusty-common**, and
+  **trusty-git-analytics**. Lighter-tier library and sidecar crates
+  (**trusty-embedderd**, **trusty-bm25-daemon**, **trusty-gworkspace**,
+  **trusty-cto-db**, **tc-services**, **open-mpm-agent-api**, **open-mpm-local**)
+  each carry an Overview and a `SPEC.md`.
 
 ## Conventions
 

--- a/docs/trusty-analyze/decisions/README.md
+++ b/docs/trusty-analyze/decisions/README.md
@@ -1,0 +1,12 @@
+# trusty-analyze — Decision Records
+
+Crate-scoped Architecture Decision Records for `trusty-analyze`.
+
+## Records
+
+- **[0001 — Gate axum Behind http-server Feature (2026-05-26)](./0001-gate-axum-behind-http-server-feature-2026-05-26.md)** — Decision to put the HTTP server surface behind an optional feature flag so the analysis library remains dependency-light.
+
+## Related
+
+- [Workspace ADRs](../../adr/README.md)
+- [trusty-analyze Overview](../README.md)

--- a/docs/trusty-analyze/research/README.md
+++ b/docs/trusty-analyze/research/README.md
@@ -1,0 +1,12 @@
+# trusty-analyze — Research
+
+Investigation documents for `trusty-analyze`.
+
+## Documents
+
+- **[Code Analysis Summary](./trustee_search_code_analysis_summary.md)** — Survey of the trusty-search codebase as an exemplar for analysis engine integration patterns.
+
+## Related
+
+- [trusty-analyze Overview](../README.md)
+- [trusty-analyze Spec](../spec/README.md)

--- a/docs/trusty-git-analytics/developer/README.md
+++ b/docs/trusty-git-analytics/developer/README.md
@@ -1,0 +1,16 @@
+# trusty-git-analytics — Developer Guide
+
+Contributor and developer documentation for `trusty-git-analytics` (`tga`).
+
+## Contents
+
+- **[Architecture](./architecture.md)** — Internal crate architecture, module breakdown, and data-flow diagrams.
+- **[Developer Guide](./developer-guide.md)** — How to build, test, and contribute to `tga`.
+- **[Configuration Reference](./configuration-reference.md)** — All configuration knobs, env vars, and config-file options.
+- **[Migration from Python](./migration-from-python.md)** — Notes on migrating from the legacy Python prototype.
+- **[Publishing](./publishing.md)** — Crate release and publishing workflow for `tga`.
+
+## Related
+
+- [trusty-git-analytics Overview](../README.md)
+- [Decisions](../decisions/README.md)

--- a/docs/trusty-git-analytics/requirements/README.md
+++ b/docs/trusty-git-analytics/requirements/README.md
@@ -1,0 +1,21 @@
+# trusty-git-analytics — Requirements
+
+Structured requirements documents for `trusty-git-analytics` (`tga`).
+See [requirements index](./index.md) for the master table of contents.
+
+## Contents
+
+- **[Index](./index.md)** — Master requirements index and navigation.
+- **[Overview](./overview.md)** — High-level requirements overview and goals.
+- **[CLI Commands](./cli-commands.md)** — Requirements for all CLI subcommands.
+- **[Collection](./collection.md)** — Data collection and ingestion requirements.
+- **[Classification](./classification.md)** — Commit classification and effort-scoring requirements.
+- **[Reporting](./reporting.md)** — Reporting and output format requirements.
+- **[Configuration](./configuration.md)** — Configuration requirements.
+- **[Database Schema](./database-schema.md)** — SQLite schema requirements.
+- **[Rust Architecture](./rust-architecture.md)** — Rust-specific architectural requirements.
+
+## Related
+
+- [trusty-git-analytics Overview](../README.md)
+- [Specification](../spec/README.md)

--- a/docs/trusty-git-analytics/research/README.md
+++ b/docs/trusty-git-analytics/research/README.md
@@ -1,0 +1,13 @@
+# trusty-git-analytics — Research
+
+Investigation and specification documents for `trusty-git-analytics` (`tga`).
+
+## Documents
+
+- **[Commit Effort Spec (2026-05-27)](./commit-effort-spec-2026-05-27.md)** — Specification for commit effort scoring and classification algorithms.
+- **[Per-Engineer Drill-down (2026-05-28)](./per-engineer-drilldown-2026-05-28.md)** — Design for per-engineer productivity drill-down reporting.
+
+## Related
+
+- [trusty-git-analytics Overview](../README.md)
+- [trusty-git-analytics Spec](../spec/README.md)

--- a/docs/trusty-git-analytics/user/README.md
+++ b/docs/trusty-git-analytics/user/README.md
@@ -1,0 +1,13 @@
+# trusty-git-analytics — User Guide
+
+End-user documentation for `trusty-git-analytics` (`tga`), the developer productivity analytics tool.
+
+## Contents
+
+- **[User Guide](./user-guide.md)** — Complete guide to installing, configuring, and using `tga` to analyse developer productivity metrics.
+
+## Related
+
+- [trusty-git-analytics Overview](../README.md)
+- [CLI Commands Reference](../requirements/cli-commands.md)
+- [Configuration Reference](../developer/configuration-reference.md)

--- a/docs/trusty-memory/decisions/README.md
+++ b/docs/trusty-memory/decisions/README.md
@@ -1,0 +1,12 @@
+# trusty-memory — Decision Records
+
+Crate-scoped Architecture Decision Records for `trusty-memory`.
+
+## Records
+
+- **[0001 — Frontend/Core Split](./0001-frontend-core-split.md)** — Rationale for splitting the memory palace implementation into a library core (`trusty-common`'s `memory-core` feature) and a thin MCP frontend crate (`trusty-memory`).
+
+## Related
+
+- [Workspace ADRs](../../adr/README.md)
+- [trusty-memory Overview](../README.md)

--- a/docs/trusty-memory/research/README.md
+++ b/docs/trusty-memory/research/README.md
@@ -1,0 +1,12 @@
+# trusty-memory — Research
+
+Investigation documents and decision analyses for `trusty-memory`.
+
+## Documents
+
+- **[axum Feature-Flag Decision (2026-05-26)](./axum-feature-flag-decision-2026-05-26.md)** — Investigation into gating axum behind the `http-server` feature flag to keep the library tier dependency-light.
+
+## Related
+
+- [trusty-memory Overview](../README.md)
+- [trusty-memory Spec](../spec/README.md)

--- a/docs/trusty-memory/sessions/README.md
+++ b/docs/trusty-memory/sessions/README.md
@@ -1,0 +1,11 @@
+# trusty-memory — Engineering Sessions
+
+Session summaries for significant `trusty-memory` engineering work.
+
+## Sessions
+
+- **[2026-05-26 — Code Analysis & Fixes](./SESSION-2026-05-26-code-analysis-and-fixes.md)** — Analysis of trusty-memory codebase, clippy fixes, and feature-flag refactoring.
+
+## Related
+
+- [trusty-memory Overview](../README.md)

--- a/docs/trusty-mpm/sessions/README.md
+++ b/docs/trusty-mpm/sessions/README.md
@@ -1,0 +1,12 @@
+# trusty-mpm — Engineering Sessions
+
+Session summaries for significant `trusty-mpm` engineering work.
+
+## Sessions
+
+- **[2026-05-26 — TUI Color Fix](./SESSION-2026-05-26-tui-color-fix.md)** — Investigation and fix of TUI color rendering issues in the trusty-mpm terminal interface.
+
+## Related
+
+- [trusty-mpm Overview](../README.md)
+- [trusty-mpm Research](../research/README.md)


### PR DESCRIPTION
Completes the documentation program: rewrites the mdBook SUMMARY.md to navigate all 14 crates' docs — full spec sets (open-mpm, trusty-mpm, trusty-search, trusty-memory, trusty-analyze, trusty-common, trusty-git-analytics) and light SPEC.md tier (trusty-embedderd, trusty-bm25-daemon, trusty-cto-db, tc-services, trusty-gworkspace, open-mpm-agent-api, open-mpm-local), plus the workspace ADRs. 137 links, all verified to resolve on disk; adds 10 subdir index READMEs to back the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)