### PR TITLE
docs: reconcile stale crate inventory + MCP tool counts (closes #430)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ dance for cross-crate development. The authoritative crate list is the
 Key consumers of the shared libraries:
 - **open-mpm** — MPM orchestration platform (lives in `crates/open-mpm`)
 - **trusty-search** — hybrid code search daemon + MCP server
-- **trusty-memory-core / trusty-memory** — memory palace storage + MCP frontend
+- **trusty-memory** — MCP frontend over the memory palace (storage lives in
+  `trusty-common`'s `memory-core` feature)
 - **trusty-analyze** — code analysis daemon (complexity, smells, quality metrics)
 
 Work touching a shared crate (e.g. `trusty-common`, `trusty-embedderd`) may
@@ -125,18 +126,16 @@ Always verify the `name` field in the crate's `Cargo.toml` if you get a "package
 trusty-tools/               # workspace root
 ├── Cargo.toml              # workspace manifest — glob members = ["crates/*"]
 ├── Cargo.lock
-├── crates/
-│   ├── trusty-common/       # shared utilities, tracing, OpenRouter chat, memory-core feature
+├── crates/                 # 16 members (matches `ls crates/`)
+│   ├── trusty-common/       # shared utilities, tracing, OpenRouter chat; hosts the
+│   │                        # consolidated mcp/rpc/embedder/symgraph/memory-core/
+│   │                        # tickets/monitor-tui modules behind feature flags
 │   ├── trusty-embedderd/    # fastembed wrapper — sidecar daemon for trusty-search
 │   ├── trusty-bm25-daemon/  # BM25 index daemon — sidecar for trusty-memory
-│   ├── trusty-symgraph/     # symbol graph engine (tree-sitter parser)
-│   ├── trusty-rpc/          # RPC helpers and service descriptors
-│   ├── trusty-tickets/      # GitHub Issues ticketing integration
 │   ├── trusty-gworkspace/   # Google Workspace client (Calendar, Tasks, Drive)
 │   ├── trusty-cto-db/       # SQLite CTO database (rusqlite-backed)
 │   ├── tc-services/         # service-layer adapters: CTO DB, Granola, GWorkspace
 │   ├── trusty-search/       # hybrid BM25 + vector + KG search daemon + MCP server
-│   ├── trusty-memory-core/  # re-export shim — absorbed into trusty-common's memory-core feature
 │   ├── trusty-memory/       # MCP server frontend for memory (includes Svelte UI)
 │   ├── trusty-analyze/      # code analysis daemon + MCP server
 │   ├── trusty-mpm/          # unified MPM platform: CLI (tm/trusty-mpm), daemon, MCP, TUI, Telegram
@@ -148,6 +147,13 @@ trusty-tools/               # workspace root
 │   └── open-mpm-local/      # open-mpm local execution (publish=false)
 └── .gitignore
 ```
+
+> **Consolidation note:** the formerly separate `trusty-symgraph`, `trusty-rpc`,
+> `trusty-tickets`, `trusty-mcp-core`, `trusty-embedder`, `trusty-memory-core`,
+> and `trusty-monitor-tui` crates no longer exist as standalone directories —
+> they were absorbed into `trusty-common` behind the `symgraph`, `rpc`,
+> `tickets`, `mcp`, `embedder`, `memory-core`, and `monitor-tui` feature flags
+> respectively. Enable the relevant feature to pull in the corresponding module.
 
 For the source layout of any crate, read its `README.md` or browse
 `crates/<name>/src/`. Each crate owns its own `README.md` covering purpose,
@@ -393,9 +399,9 @@ refs, never working trees.
 Detailed implementation information for each crate lives in its own documentation:
 
 - **trusty-common** — see `crates/trusty-common/README.md` and `docs/trusty-common/`
-- **trusty-embedderd** — see `crates/trusty-embedderd/README.md` (fastembed sidecar daemon)
-- **trusty-bm25-daemon** — see `crates/trusty-bm25-daemon/README.md` (BM25 index sidecar)
-- **trusty-memory / trusty-memory-core** — see `crates/trusty-memory/README.md` and `docs/trusty-memory/` (licensed MIT, not Elastic-2.0)
+- **trusty-embedderd** — see `crates/trusty-embedderd/README.md` and `docs/trusty-embedderd/` (fastembed sidecar daemon)
+- **trusty-bm25-daemon** — see `crates/trusty-bm25-daemon/README.md` and `docs/trusty-bm25-daemon/` (BM25 index sidecar)
+- **trusty-memory** — see `crates/trusty-memory/README.md` and `docs/trusty-memory/` (licensed MIT, not Elastic-2.0; storage engine lives in `trusty-common`'s `memory-core` feature)
 - **trusty-search** — see `crates/trusty-search/README.md` and **`docs/trusty-search/`** (primary worked example with regression testing, research, sessions)
 - **trusty-analyze** — see `crates/trusty-analyze/README.md` and `docs/trusty-analyze/` (licensed MIT, not Elastic-2.0)
 - **trusty-mpm** — see `crates/trusty-mpm/README.md` and `docs/trusty-mpm/` (unified platform: CLI binaries `tm`/`trusty-mpm`, daemon, MCP server, TUI, Telegram)
@@ -521,8 +527,8 @@ behind the `axum-server` feature flag, matching the pattern in `trusty-common`.
 Otherwise every library consumer pulls in the full axum + tower stack.
 
 🟡 **Editing a shared crate without propagating changes** — modifying
-`trusty-common`, `trusty-embedderd`, `trusty-bm25-daemon`, or `trusty-symgraph`
-can silently break dependents. Always run `cargo check` (workspace-wide) and
+`trusty-common` (or its consolidated `symgraph` / `embedder` / `mcp` modules),
+`trusty-embedderd`, or `trusty-bm25-daemon` can silently break dependents. Always run `cargo check` (workspace-wide) and
 `cargo test -p <consumer>` for every crate that imports the edited library.
 
 🟡 **Forgetting the Why/What/Test doc pattern on new public items** — clippy
@@ -560,7 +566,7 @@ PRs, issues, or commit messages that reference the former repo names.
 |---|---|
 | `bobmatnyc/trusty-common` | `crates/trusty-common` + 8 library crates |
 | `bobmatnyc/trusty-search` | `crates/trusty-search` |
-| `bobmatnyc/trusty-memory` | `crates/trusty-common` (`memory-core` feature) + `crates/trusty-memory-core` (shim) + `crates/trusty-memory` (MCP frontend) |
+| `bobmatnyc/trusty-memory` | `crates/trusty-common` (`memory-core` feature — storage engine) + `crates/trusty-memory` (MCP frontend) |
 | `bobmatnyc/trusty-analyze` | `crates/trusty-analyze` |
 | `bobmatnyc/trusty-git-analytics` | `crates/trusty-git-analytics` |
 | `bobmatnyc/trusty-mpm` | `crates/trusty-mpm/` (unified crate) + `crates/trusty-mpm-gui/` |

--- a/crates/trusty-analyze/CLAUDE.md
+++ b/crates/trusty-analyze/CLAUDE.md
@@ -40,7 +40,8 @@ certain design decisions were made.
 
 - Sidecar to trusty-search: fetches chunk corpus via `GET /indexes/:id/chunks`,
   runs analysis, serves results on port 7879
-- trusty-common shared type crate lives here and is path-depended on by both projects
+- Shared types come from the `trusty-common` sibling crate in the `trusty-tools`
+  workspace (path dep), which is also consumed by trusty-search
 - Planned Phase 2: dynamic analysis (runtime call graphs, test coverage,
   mutation testing scores)
 
@@ -262,20 +263,21 @@ C, C++
 
 ```
 trusty-search daemon (port 7878)          trusty-analyze daemon (port 7879)
-  GET /indexes/:id/chunks  ─────────────► trusty-analyze-core
+  GET /indexes/:id/chunks  ─────────────► src/core/  (analysis engines)
   (bulk corpus export)                      complexity.rs   — cyclomatic/cognitive
                                             blame.rs        — git temporal decay
                                             quality.rs      — grade aggregation
                                             facts.rs        — FactStore (redb)
                                             client.rs       — HTTP client to trusty-search
-                                          trusty-analyze-service (axum HTTP API)
-                                          trusty-analyze-mcp   (MCP stdio + SSE)
+                                          src/service/  (axum HTTP API)
+                                          src/mcp/      (MCP stdio + SSE)
 ```
 
 ### trusty-common — Shared Type Crate
 
-Lives at `crates/trusty-common`. Path-depended on by both trusty-analyze and
-trusty-search (once trusty-search migrates its internal types to the shared crate).
+Lives at `crates/trusty-common` (a sibling crate in the same `trusty-tools`
+workspace). Referenced as a path dep (`trusty-common = { workspace = true }`)
+by both trusty-analyze and trusty-search.
 
 Key types:
 
@@ -323,45 +325,41 @@ pub struct FactRecord { subject, predicate, object, provenance, ... }
 
 ---
 
-## Workspace Layout
+## Crate Layout
+
+`trusty-analyze` is a **single crate** (one `Cargo.toml`, lib + bin targets)
+within the `trusty-tools` workspace. There is no nested
+`crates/trusty-analyze/crates/*` workspace — the analysis engines, language
+adapters, embedder, MCP server, and service layer are all sibling modules under
+`src/`. Shared types come from the in-workspace `trusty-common` path dep.
 
 ```
-trusty-analyze/
-├── Cargo.toml                          workspace + bin manifest
+crates/trusty-analyze/
+├── Cargo.toml                          single-crate manifest (lib + bin)
 ├── CLAUDE.md                           this file
 ├── README.md
 ├── src/
-│   └── main.rs                         CLI: trusty-analyze serve/analyze/facts/health
-├── crates/
-│   ├── trusty-common/                  shared types (also used by trusty-search)
-│   │   └── src/
-│   │       ├── lib.rs
-│   │       ├── chunk.rs                CodeChunk
-│   │       ├── complexity.rs           ComplexityMetrics, CodeSmell, ComplexityGrade
-│   │       ├── blame.rs                ChunkBlame
-│   │       ├── entity.rs               EntityType, EdgeKind, RawEntity
-│   │       └── facts.rs                FactRecord
-│   ├── trusty-analyze-core/           analysis engines
-│   │   └── src/
-│   │       ├── lib.rs
-│   │       ├── complexity.rs           cyclomatic + cognitive analysis
-│   │       ├── blame.rs                git log parser + temporal decay
-│   │       ├── quality.rs              grade aggregation
-│   │       ├── facts.rs                FactStore (redb persistence)
-│   │       └── client.rs               HTTP client to trusty-search daemon
-│   ├── trusty-analyze-service/        axum HTTP sidecar (port 7879)
-│   │   └── src/
-│   │       └── lib.rs
-│   ├── trusty-embedder/                 FastEmbedder wrapper (dir name differs from
-│   │   └── src/                         package name: `trusty-analyze-embedder`)
-│   │       └── lib.rs
-│   └── trusty-analyze-mcp/            MCP stdio + SSE server
-│       └── src/
-│           └── lib.rs
+│   ├── lib.rs                          re-publishes modules below
+│   ├── main.rs                         CLI: serve / analyze / facts / health
+│   ├── types/                          CodeChunk, ComplexityMetrics, CodeSmell,
+│   │                                   ComplexityGrade, ChunkBlame, EntityType,
+│   │                                   EdgeKind, FactRecord, graph types
+│   ├── core/                           analysis engines — complexity(.rs/_ts.rs),
+│   │                                   blame, quality, facts (redb FactStore),
+│   │                                   client (HTTP → trusty-search), concept_cluster,
+│   │                                   explain, github, linker
+│   ├── lang/                           LanguageAnalyzer trait, detection, and
+│   │   └── adapters/                   tree-sitter adapters (15: rust, python, java,
+│   │                                   go, typescript, javascript, c, cpp, csharp,
+│   │                                   kotlin, php, ruby, scala, swift)
+│   ├── embedder/                       BoW + neural concept-clustering embedders
+│   ├── service/                        axum HTTP API (port 7879) + embedded UI
+│   ├── mcp/                            MCP server: stdio + HTTP/SSE transports
+│   └── commands/                       per-subcommand handlers (daemon/service/setup)
 ```
 
 Documentation lives at the workspace top level under
-`docs/trusty-analyze/` (research, sessions, regression-testing), not in-crate.
+`docs/trusty-analyze/`, not in-crate.
 
 ---
 
@@ -407,19 +405,14 @@ GET  /indexes/:id/clusters?k=N&method=bow|neural
 
 ## MCP Tools
 
-Parity rule: every HTTP endpoint has an MCP tool equivalent.
+Parity rule: every HTTP endpoint has an MCP tool equivalent. The MCP server
+registers **17 tools** (authoritative source: `src/mcp/mod.rs`
+`tool_definitions`):
 
-| Tool | Equivalent endpoint |
-|------|---------------------|
-| `analyzer_health` | `GET /health` |
-| `complexity_hotspots` | `GET /indexes/:id/complexity_hotspots` |
-| `find_smells` | `GET /indexes/:id/smells` |
-| `analyze_quality` | `GET /indexes/:id/quality` |
-| `list_facts` | `GET /facts` |
-| `upsert_fact` | `POST /facts` |
-| `delete_fact` | `DELETE /facts/:id` |
-| `ingest_scip` | `POST /indexes/:id/scip` |
-| `cluster_concepts` | `GET /indexes/:id/clusters` |
+`complexity_hotspots`, `find_smells`, `analyze_quality`, `run_diagnostics`,
+`list_facts`, `upsert_fact`, `delete_fact`, `analyzer_health`, `extract_graph`,
+`cluster_concepts`, `ingest_scip`, `extract_ner`, `suggest_refactors`,
+`review_diff`, `deep_analysis`, `review_github_pr`, `list_entities`.
 
 ### Transports
 
@@ -549,62 +542,23 @@ RUST_LOG=debug                             # enable debug tracing
 
 ## Publishing
 
-Publishing is **fully automated via CI/CD** — never run `cargo publish` manually.
-Trigger paths:
-
-1. **Tag push**: pushing a `v*` tag (e.g. `v0.1.1`) runs
-   `.github/workflows/publish.yml` and uploads to crates.io.
-2. **Manual dispatch**: GitHub Actions UI → *Publish* → *Run workflow*
-   (with optional `dry_run`).
-3. **Cross-repo dispatch**: trusty-common's publish workflow fires a
-   `repository_dispatch` of type `publish` after `trusty-contracts` is on
-   crates.io, ensuring downstream resolution succeeds.
-
-### Workspace publishability map
-
-| Crate | Published to crates.io? | Why |
-|-------|------------------------|-----|
-| `trusty-analyze-types` | ✅ Yes | Pure types, no internal deps |
-| `trusty-analyze-lang`  | ✅ Yes | Tree-sitter adapters; depends on `-types` |
-| `trusty-analyze-core`  | ✅ Yes | Analysis primitives; depends on `-types` + `-lang` |
-| `trusty-analyze-mcp`   | ✅ Yes | MCP server; depends on `-types` + `-core` |
-| `trusty-analyze-embedder` | ✅ Yes | Renamed from `trusty-embedder` (commit 0abfdaf); name free on crates.io |
-| `trusty-analyze-service`  | ✅ Yes | Depends on `trusty-analyze-embedder` |
-| `trusty-analyze` (bin)    | ✅ Yes | `cargo install trusty-analyze` works from crates.io |
-
-> **`trusty-analyze-embedder` rename:** the crate was originally named
-> `trusty-embedder`, which collided with an unrelated published crate. It was
-> renamed to `trusty-analyze-embedder` in commit `0abfdaf`, resolving the
-> collision. All seven workspace crates are now publishable to crates.io.
-
-### Pre-publish validation
-
-Before tagging a release, validate that publishable crates are still
-publish-clean:
+`trusty-analyze` is a single crate published independently with the workspace's
+per-crate tag convention `trusty-analyze-v<version>` (the version comes from
+this crate's `Cargo.toml`). There is no nested multi-crate workspace and no
+separate `trusty-analyze-types` / `-lang` / `-core` / `-mcp` / `-service` /
+`-embedder` packages — those were sibling modules under `src/`, not crates.
 
 ```bash
-# Dry-run each publishable crate (no upload). Run in dependency order.
-cargo publish -p trusty-analyze-types     --dry-run
-cargo publish -p trusty-analyze-lang      --dry-run
-cargo publish -p trusty-analyze-core      --dry-run
-cargo publish -p trusty-analyze-mcp       --dry-run
-cargo publish -p trusty-analyze-embedder  --dry-run
-cargo publish -p trusty-analyze-service   --dry-run
-cargo publish -p trusty-analyze           --dry-run
+# Dry-run before tagging (no upload)
+cargo publish -p trusty-analyze --dry-run
+
+# Then follow the workspace release workflow (see the root CLAUDE.md):
+#   bump version → cargo test -p trusty-analyze → tag trusty-analyze-v<version>
+#   → push tag → cargo publish -p trusty-analyze → cargo install --path .
 ```
 
-Note: dry-runs require dependencies to already be published on crates.io at
-the same version, otherwise the index lookup fails. For first-time publishing
-of a new crate, run the GitHub Actions workflow with `dry_run = true` so the
-local `[patch.crates-io]` overrides don't shadow the lookup.
-
-### Dependency-bump cadence
-
-`.github/dependabot.yml` opens grouped weekly PRs:
-
-- Minor/patch cargo bumps rolled into one PR per week
-- tree-sitter grammar crates grouped together (they version in lockstep)
-- GitHub Actions versions grouped weekly
+Dependency bumps follow the workspace `[workspace.dependencies]` table; do not
+pin tree-sitter or other shared crates locally if they already live there.
 
 ---
 
@@ -615,23 +569,26 @@ MCP server, SCIP ingest, neural/BoW concept clustering, and language-specific
 tree-sitter adapters are all functional.
 
 **Working:**
-- Workspace builds and all 107 tests pass (`cargo test --workspace`)
-- trusty-common type definitions (chunk, complexity, blame, entity, facts)
-- trusty-analyze-core fully wired: `client.rs`, `complexity.rs`, `blame.rs`,
-  `quality.rs`, `facts.rs`
-- axum HTTP sidecar (`trusty-analyze-service`) — 8 endpoints live on port 7879
-- MCP stdio server (`trusty-analyze-mcp`) — 9 tools (HTTP parity maintained)
+- Crate builds and tests pass (`cargo test -p trusty-analyze`)
+- `trusty-common` type definitions (chunk, complexity, blame, entity, facts)
+- `src/core/` fully wired: `client.rs`, `complexity.rs`, `complexity_ts.rs`,
+  `blame.rs`, `quality.rs`, `facts.rs`, `concept_cluster.rs`, `linker.rs`,
+  `explain.rs`, `github.rs`
+- axum HTTP sidecar (`src/service/`) on port 7879
+- MCP stdio + HTTP/SSE server (`src/mcp/`) — 17 tools (authoritative source:
+  `src/mcp/mod.rs` `tool_definitions`)
 - CLI subcommands: `serve`, `analyze`, `facts list/upsert`, `health`
 - Daemon PID lockfile (fs4), graceful shutdown, `--search-url` flag
-- `LanguageAnalyzer` trait + tree-sitter adapters for Python, Java, Go (complete);
-  Rust / TypeScript / C / C++ scaffolded
-- CALLS edges from Rust adapter + cross-chunk entity linker (`#47` complete)
+- `LanguageAnalyzer` trait + 15 tree-sitter adapters, all implemented:
+  rust, python, java, go, typescript, javascript, c, cpp, csharp, kotlin,
+  php, ruby, scala, swift (see `src/lang/adapters/`)
+- CALLS edges + cross-chunk entity linker (`#47` complete)
 - k-means concept clustering (BoW / neural) + `/indexes/:id/clusters` endpoint
 - SCIP protobuf ingest → knowledge graph (`#47` complete)
 - Integration self-analysis suite
 
 **Remaining / next steps:**
-- Phase 2 adapters: complete Rust, TypeScript, C, C++ tree-sitter adapters
+- Phase 2 semantic enrichment: deepen adapters beyond the tree-sitter baseline
 - Phase 3: Dockerized runtime execution (sandboxed profiler jobs)
 - Phase 4: Runtime-to-graph mapping (normalize profiler output → graph nodes)
 - Phase 5: Advanced unified scoring (text + embed + graph + runtime layers)

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -74,17 +74,28 @@ unreachable.
 
 ## MCP Tools
 
+The MCP server registers **17 tools** (authoritative source: `src/mcp/mod.rs`
+`tool_definitions`):
+
 | Tool | HTTP equivalent |
 |------|-----------------|
 | `analyzer_health` | `GET /health` |
 | `complexity_hotspots` | `GET /indexes/:id/complexity_hotspots` |
 | `find_smells` | `GET /indexes/:id/smells` |
 | `analyze_quality` | `GET /indexes/:id/quality` |
+| `run_diagnostics` | (composite diagnostics run) |
 | `list_facts` | `GET /facts` |
 | `upsert_fact` | `POST /facts` |
 | `delete_fact` | `DELETE /facts/:id` |
 | `ingest_scip` | `POST /indexes/:id/scip` |
 | `cluster_concepts` | `GET /indexes/:id/clusters` |
+| `extract_graph` | knowledge-graph extraction |
+| `extract_ner` | named-entity extraction (optional ONNX) |
+| `list_entities` | enumerate extracted entities |
+| `suggest_refactors` | refactor suggestions |
+| `review_diff` | review a unified diff |
+| `review_github_pr` | review a GitHub pull request |
+| `deep_analysis` | combined deep-analysis pass |
 
 ## HTTP API
 

--- a/crates/trusty-common/README.md
+++ b/crates/trusty-common/README.md
@@ -4,9 +4,12 @@
 [![License: Elastic-2.0](https://img.shields.io/badge/License-Elastic--2.0-blue.svg)](https://www.elastic.co/licensing/elastic-license)
 
 Shared utility surface for the `trusty-*` AI tooling ecosystem. This crate is
-the result of consolidating several formerly separate crates into one:
-`trusty-mcp-core`, `trusty-rpc`, `trusty-embedder`, and `trusty-symgraph` have
-all been absorbed here.
+the result of consolidating several formerly separate crates into one. The
+following have all been absorbed here behind feature flags: `trusty-mcp-core`
+(`mcp`), `trusty-rpc` (`rpc`), `trusty-embedder` (`embedder`),
+`trusty-embedder-client` (`embedder-client`), `trusty-symgraph` (`symgraph` /
+`symgraph-parser`), `trusty-memory-core` (`memory-core`), `trusty-tickets`
+(`tickets`), and `trusty-monitor-tui` (`monitor-tui`).
 
 Each subsystem is feature-gated so consumers only pay for what they use.
 
@@ -14,13 +17,13 @@ Each subsystem is feature-gated so consumers only pay for what they use.
 
 ```toml
 [dependencies]
-trusty-common = "0.3"
+trusty-common = "0.8"
 ```
 
 With optional features:
 
 ```toml
-trusty-common = { version = "0.3", features = ["axum-server", "mcp", "rpc", "embedder"] }
+trusty-common = { version = "0.8", features = ["axum-server", "mcp", "rpc", "embedder"] }
 ```
 
 ## Feature Flags
@@ -35,9 +38,20 @@ trusty-common = { version = "0.3", features = ["axum-server", "mcp", "rpc", "emb
 | `embedder-cuda` | GPU-accelerated embedding via CUDA execution provider |
 | `embedder-load-dynamic` | Dynamic ORT loading for AL2023 / glibc < 2.38 builds |
 | `embedder-test-support` | Expose `MockEmbedder` outside `cfg(test)` for downstream tests |
+| `embedder-coreml` | CoreML execution provider on Apple Silicon (no-op alias on other platforms) |
+| `embedder-candle` | Candle Metal embedding backend |
+| `embedder-client` | UDS JSON-RPC client for the `trusty-embedderd` sidecar (formerly `trusty-embedder-client`) |
 | `symgraph` | Contracts surface only: `EntityType`, `RawEntity`, `EdgeKind` — no tree-sitter |
 | `symgraph-parser` | Full symbol graph: tree-sitter grammars, `SymbolGraph`, emitter, editor |
 | `symgraph-server` | HTTP server frontend for the symbol graph (implies `symgraph-parser`) |
+| `bm25` | Zero-dependency BM25 lexical index + code-aware tokenizer (issue #156) |
+| `bm25-client` | UDS JSON-RPC client for the per-palace `trusty-bm25-daemon` subprocess |
+| `memory-core` | Memory Palace storage engine — HNSW (usearch), SQLite metadata + KG, dream cycle (formerly `trusty-memory-core`) |
+| `memory-core-kuzu` | Read-only Kùzu graph-DB integration on top of `memory-core` |
+| `usearch-migrate` | One-shot usearch index migration helper (implies `memory-core`) |
+| `tickets` | Unified ticketing MCP server (GitHub / JIRA / Linear backends; formerly `trusty-tickets`) |
+| `monitor-tui` | ratatui + crossterm dashboard TUI for the trusty-search/trusty-memory daemons (formerly `trusty-monitor-tui`) |
+| `cli-help` | Declarative help-config parsing (serde_yaml + strsim + indexmap) |
 | `migrations` | Reusable schema-migration kernel: `SchemaVersion`, `Migration`, `MigrationRunner`, file-stamp helpers |
 
 By default the crate is dependency-light: `tokio`, `serde`, `reqwest`, and

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -96,10 +96,16 @@ running (started either by `trusty-memory setup`'s LaunchAgent or by
 
 ## Available MCP Tools
 
-All 12 tools are exposed via both the MCP protocol (over the
-`trusty-memory-mcp-bridge` → UDS path) and the HTTP API (`/api/v1/`). The
-`palace` argument is required unless the server was started with
-`--palace <name>`.
+The MCP server registers **23 tools** (authoritative source:
+`src/tools.rs` `tool_definitions`, asserted by the
+`tool_definitions_lists_all_tools` test). All are exposed via both the MCP
+protocol (over the `trusty-memory-mcp-bridge` → UDS path) and the HTTP API
+(`/api/v1/`). The `palace` argument is required unless the server was started
+with `--palace <name>`. The tables below cover the primary surface; the full
+roster also includes `memory_note`, `memory_recall_all`, `palace_delete`,
+`palace_update`, `palace_compact`, `kg_gaps`, `kg_bootstrap`, `add_alias`,
+`discover_aliases`, `list_prompt_facts`, `remove_prompt_fact`, and
+`get_prompt_context`.
 
 ### Memory tools
 
@@ -406,17 +412,17 @@ Each palace directory contains:
 ## Architecture
 
 ```
-trusty-memory (this crate)          trusty-memory-core
+trusty-memory (this crate)          trusty-common `memory-core` feature
   axum HTTP/SSE server     ──────►  PalaceRegistry
   Unix domain socket       ──────►  usearch vector index
   embedded Svelte UI               SQLite metadata + KG
-  12 MCP tools                     fastembed (AllMiniLML6V2Q)
+  23 MCP tools                     fastembed (AllMiniLML6V2Q)
 
 trusty-memory-mcp-bridge (separate binary, PR #149)
   Claude Code stdio  ◄──pipe──►  trusty-memory UDS
 ```
 
-`trusty-memory-core` owns the storage engine: `usearch` for approximate
+The `memory-core` feature of `trusty-common` owns the storage engine: `usearch` for approximate
 nearest-neighbor search, SQLite for metadata and knowledge-graph triples, and
 `fastembed` for 384-dim text embeddings. The MCP server (`trusty-memory`) is a
 thin protocol layer on top.
@@ -502,7 +508,8 @@ cargo run -p trusty-memory -- serve --foreground --http 127.0.0.1:7880
 
 # Tests
 cargo test -p trusty-memory
-cargo test -p trusty-memory-core
+# Storage-engine tests live in trusty-common behind the memory-core feature:
+cargo test -p trusty-common --features memory-core
 
 # Check only (faster)
 cargo check -p trusty-memory

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -396,16 +396,26 @@ Serves the embedded Svelte admin UI. Not part of the integration contract.
 
 ### MCP Tools
 
-- `search_code` — hybrid search query
+The MCP server registers **18 tools** (authoritative source:
+`src/mcp/tools.rs` `tool_definitions`):
+
+- `search` — hybrid search (BM25 + vector + KG, RRF-fused)
+- `search_lexical` — BM25-only lexical search
+- `search_semantic` — vector-only semantic search
+- `search_kg` — knowledge-graph expansion search
+- `search_all` — fan-out across every registered index
+- `search_similar` — code-to-code similarity from a seed file/function
 - `index_file` — add/update one file
 - `remove_file` — remove one file
 - `list_indexes` — enumerate registered indexes
 - `create_index` — register a new index
-- `search_health` — daemon liveness
 - `delete_index` — delete an index
 - `reindex` — trigger full reindex
 - `index_status` — per-index stats
+- `search_health` — daemon liveness
 - `list_chunks` — paginated enumeration of an index's chunks
+- `get_call_chain` — KG caller/callee chain for a symbol
+- `grep` — literal/regex grep fallback over the corpus
 - `chat` — OpenRouter conversational Q&A
 
 ## Stack
@@ -599,17 +609,6 @@ trusty-search init [path]                            # alias for index
 trusty-search reindex [path]                         # alias for index --force
 ```
 
-## The ONE Seam from open-mpm
-
-When integrating into open-mpm, only one cut is needed:
-
-- `src/search/indexer.rs` imports `crate::context::bm25::Bm25Index` →
-  re-export from `trusty-search-core/src/bm25.rs`
-- `crate::context::indexer::tokenize` → re-export from
-  `trusty-search-core/src/bm25.rs` (lives in the same module)
-
-Everything else (the orchestrator, agent runners, REPL, ctrl) stays in open-mpm.
-
 ## Crate Layout
 
 As of v0.3.0, `trusty-search` is a **single crate** with both `[lib]` and
@@ -642,16 +641,19 @@ trusty-search/
     └── benchmark_harness.rs         MRR@5 / Recall@10 quality bench
 ```
 
-### Shared Crates (external, `../trusty-common`)
+### Shared Library (`trusty-common`, in-workspace path dep)
 
-Three crates extracted from this repo and published at
-`github.com/bobmatnyc/trusty-common` (pinned via git tags in `Cargo.toml`):
+`trusty-search` depends on the in-workspace `trusty-common` crate
+(`trusty-common = { workspace = true }`). The formerly separate
+`trusty-mcp-core` and `trusty-embedder` crates were consolidated into
+`trusty-common` modules behind feature flags (`mcp` and `embedder`); enable
+them via the crate's `Cargo.toml` features. Key surfaces consumed here:
 
-| Crate | Contents |
-|-------|----------|
-| `trusty-mcp-core` | `McpRequest`/`McpResponse`/`JsonRpcError`, `run_stdio_loop`, CORS/Trace axum helpers |
-| `trusty-embedder` | `Embedder` trait, `FastEmbedder` (LRU + persistent model cache), `MockEmbedder` |
-| `trusty-common` | `bind_with_auto_port`, `resolve_data_dir`/`cache_dir`, `ConcurrentRegistry`, `init_tracing`, `daemon_http_client` |
+| Feature / module | Contents |
+|------------------|----------|
+| `mcp` (`trusty_common::mcp`) | `McpRequest`/`McpResponse`/`JsonRpcError`, `run_stdio_loop`, CORS/Trace axum helpers (formerly `trusty-mcp-core`) |
+| `embedder` (`trusty_common::embedder`) | `Embedder` trait, `FastEmbedder` (LRU + persistent model cache), `MockEmbedder` (formerly `trusty-embedder`) |
+| core (always available) | `bind_with_auto_port`, `resolve_data_dir`/`cache_dir`, `ConcurrentRegistry`, `init_tracing`, `daemon_http_client` |
 
 ## Development
 
@@ -827,7 +829,7 @@ via `cargo install trusty-search`.
 - `EntityExtractor` Phase A structural entities (functions, classes, imports)
 - `SymbolGraph` KG expansion (callers_of / callees_of, 1–2 hop, EdgeKind multipliers)
 - `FileWatcher` with notify-debouncer-mini, 500ms debounce
-- MCP server: full JSON-RPC 2.0 stdio + HTTP/SSE transport, 10 tools
+- MCP server: full JSON-RPC 2.0 stdio + HTTP/SSE transport, 18 tools (per `src/mcp/tools.rs`)
 - Daemon: auto-port, fs4 PID lockfile, graceful shutdown, persistent model cache
 - Svelte 5 admin UI embedded in binary via `include_dir`
 - OpenRouter chat proxy with search context injection

--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -146,7 +146,7 @@ trusty-search serve --http 127.0.0.1:7879
 
 Then add `http://127.0.0.1:7879/sse` as an SSE MCP endpoint in your Claude Code config.
 
-Once connected, Claude Code can call `search_code`, `index_file`, `list_indexes`, and 9 other tools directly. The daemon must be running independently (`trusty-search start`) before Claude Code connects.
+Once connected, Claude Code can call `search`, `index_file`, `list_indexes`, and 15 other tools directly (18 total). The daemon must be running independently (`trusty-search start`) before Claude Code connects.
 
 ## Features
 
@@ -178,7 +178,7 @@ Once connected, Claude Code can call `search_code`, `index_file`, `list_indexes`
   LRU embedding cache (256+ entries) skips re-embedding on repeat queries
 - **Native multi-request** — `Arc<SearchAppState>`, reader-priority `RwLock`,
   axum HTTP/2 — many concurrent searches against the same index never block
-- **MCP server** — stdio + HTTP/SSE transports, 11 tools, drop-in for Claude Code
+- **MCP server** — stdio + HTTP/SSE transports, 18 tools (per `src/mcp/tools.rs`), drop-in for Claude Code
 - **Embedded Svelte 5 admin UI** — Collections, Search, Chat, Admin panels
   compiled into the binary via `include_dir!`; open with `trusty-search ui`
 - **Migration path** — `trusty-search convert` reads `mcp-vector-search`
@@ -351,12 +351,16 @@ trusty-search reindex [path]                         # alias for index --force
 
 ## MCP tools
 
+The MCP server registers **18 tools** (authoritative source: `src/mcp/tools.rs`
+`tool_definitions`):
+
 | Tool            | Description                                          |
 |-----------------|------------------------------------------------------|
-| `search_code`   | Hybrid search (BM25 + HNSW + KG, RRF-fused)          |
+| `search`        | Hybrid search (BM25 + HNSW + KG, RRF-fused)          |
 | `search_kg`     | KG-first graph-walk search; accepts optional `refine_query` (see below) |
 | `search_semantic` | Vector-only semantic search lane                   |
 | `search_lexical`| BM25/token lexical search lane                       |
+| `search_all`    | Fan-out search across every registered index         |
 | `search_similar`| Code-to-code similarity from a seed file/function    |
 | `index_file`    | Add or replace a single file in the index            |
 | `remove_file`   | Remove a file and all its chunks                     |
@@ -366,6 +370,8 @@ trusty-search reindex [path]                         # alias for index --force
 | `reindex`       | Fire-and-forget full reindex (SSE progress)          |
 | `index_status`  | Per-index stats including walk diagnostics (see below) |
 | `list_chunks`   | Paginated enumeration of chunks `(file, start_line)` |
+| `get_call_chain`| KG caller/callee chain for a symbol                  |
+| `grep`          | Literal/regex grep fallback over the corpus          |
 | `search_health` | Daemon liveness probe                                |
 | `chat`          | OpenRouter Q&A with auto-injected search context     |
 


### PR DESCRIPTION
Fixes documentation drift (closes #430), with extra drift found during spec authoring.

- Workspace CLAUDE.md: crate inventory corrected to the actual 16 crates; removed trusty-symgraph/rpc/tickets/memory-core (consolidated into trusty-common behind feature flags); Per-Crate Reference + Former Repos updated.
- In-crate CLAUDE.md: trusty-search (removed trusty-search-core/embedder/mcp-core refs → current module layout); trusty-analyze (replaced fictional nested-workspace layout with real single-crate modules; corrected 15 implemented language adapters).
- README tool counts reconciled to verified authoritative sources: trusty-memory 23 (per tool_definitions_lists_all_tools test), trusty-analyze 17, trusty-search 18; trusty-common README version 0.3→0.8 + missing feature flags.

cargo check passes; docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)