### PR TITLE
chore: pin trusty-memory palace before drive reorg

### DIFF
--- a/.trusty-tools/trusty-memory.yaml
+++ b/.trusty-tools/trusty-memory.yaml
@@ -1,0 +1,8 @@
+# .trusty-tools/trusty-memory.yaml
+# This file pins the trusty-memory palace slug for this project.
+# Commit it so the linkage survives directory renames and drive reorgs.
+# Schema: https://github.com/bobmatnyc/trusty-tools (trusty-tools convention)
+
+schema_version: 1
+palace: trusty-tools
+note: pinned before drive reorg


### PR DESCRIPTION
Commits `.trusty-tools/trusty-memory.yaml` pinning `palace=trusty-tools` so the project↔palace link survives the upcoming drive reorg / dir rename.

This implements the first step of the `.trusty-tools/` project convention (RFC 2026-05-29) and leverages the new `link` command (trusty-memory v0.9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)