### PR TITLE
feat(tga): #445 batch A — fix ticketed bug, AI flags, top_level_category, effort_tshirt

### DIFF
--- a/crates/trusty-git-analytics/src/classify/pipeline.rs
+++ b/crates/trusty-git-analytics/src/classify/pipeline.rs
@@ -1153,8 +1153,9 @@ fn write_results_chunk(
         let mut insert_classification = tx
             .prepare(
                 "INSERT INTO classifications \
-                    (category, subcategory, ticket_id, confidence, method, complexity) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    (category, subcategory, ticket_id, confidence, method, complexity, \
+                     top_level_category) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             )
             .map_err(crate::core::TgaError::from)?;
         // Issue #205: when `--force` reclassifies a commit that already
@@ -1165,8 +1166,9 @@ fn write_results_chunk(
             .prepare(
                 "UPDATE classifications \
                  SET category = ?1, subcategory = ?2, ticket_id = ?3, \
-                     confidence = ?4, method = ?5, complexity = ?6 \
-                 WHERE id = ?7",
+                     confidence = ?4, method = ?5, complexity = ?6, \
+                     top_level_category = ?7 \
+                 WHERE id = ?8",
             )
             .map_err(crate::core::TgaError::from)?;
         // The UPDATE also sets `is_revert` so the column stays in sync with
@@ -1183,6 +1185,11 @@ fn write_results_chunk(
             .map_err(crate::core::TgaError::from)?;
 
         for (commit, result) in commits.iter().zip(results.iter()) {
+            // Issue #445: derive top_level_category from the verdict's top_level
+            // field so the column is populated at classification write time
+            // without requiring a separate backfill pass.
+            let top_level_str = result.top_level.map(|t| t.as_str_snake());
+
             let classification_id = if let Some(existing) = commit.existing_classification_id {
                 update_existing_classification
                     .execute(params![
@@ -1192,6 +1199,7 @@ fn write_results_chunk(
                         result.confidence,
                         result.method.as_str(),
                         result.complexity.map(|v| v as i64),
+                        top_level_str,
                         existing,
                     ])
                     .map_err(crate::core::TgaError::from)?;
@@ -1205,6 +1213,7 @@ fn write_results_chunk(
                         result.confidence,
                         result.method.as_str(),
                         result.complexity.map(|v| v as i64),
+                        top_level_str,
                     ])
                     .map_err(crate::core::TgaError::from)?;
                 tx.last_insert_rowid()

--- a/crates/trusty-git-analytics/src/classify/taxonomy.rs
+++ b/crates/trusty-git-analytics/src/classify/taxonomy.rs
@@ -74,6 +74,41 @@ impl TopLevelCategory {
         }
     }
 
+    /// Stable snake_case string identifier for DB persistence.
+    ///
+    /// Why: `classifications.top_level_category` stores a stable ASCII string
+    /// so SQL GROUP BY and downstream BI tools work without decoding enum
+    /// integers or display names. Using snake_case keeps the value predictable
+    /// across language/locale boundaries and matches the serde `rename_all`
+    /// attribute.
+    /// What: returns a `&'static str` in snake_case for each variant. These
+    /// strings are stable — do not rename them once rows have been written to
+    /// the database.
+    /// Test: `taxonomy::tests::as_str_snake_stable_identifiers`.
+    ///
+    /// | Variant        | Returned string   |
+    /// |----------------|-------------------|
+    /// | Feature        | `"feature"`       |
+    /// | Bugfix         | `"bugfix"`        |
+    /// | Ktlo           | `"ktlo"`          |
+    /// | Integrations   | `"integrations"`  |
+    /// | PlatformWork   | `"platform_work"` |
+    /// | Content        | `"content"`       |
+    /// | Maintenance    | `"maintenance"`   |
+    /// | Unknown        | `"unknown"`       |
+    pub fn as_str_snake(&self) -> &'static str {
+        match self {
+            TopLevelCategory::Feature => "feature",
+            TopLevelCategory::Bugfix => "bugfix",
+            TopLevelCategory::Ktlo => "ktlo",
+            TopLevelCategory::Integrations => "integrations",
+            TopLevelCategory::PlatformWork => "platform_work",
+            TopLevelCategory::Content => "content",
+            TopLevelCategory::Maintenance => "maintenance",
+            TopLevelCategory::Unknown => "unknown",
+        }
+    }
+
     /// All canonical variants in the recommended display order.
     ///
     /// Why: report iteration order must be stable so output stays diffable
@@ -470,6 +505,28 @@ mod tests {
             assert_ne!(*top, TopLevelCategory::Unknown);
         }
         assert_eq!(TopLevelCategory::all().len(), 7);
+    }
+
+    /// Why: `top_level_category` is stored in SQLite as a snake_case string;
+    /// the mapping must be stable across releases (migration v17, issue #445).
+    /// What: asserts every variant returns its canonical snake_case identifier.
+    /// Test: this test itself.
+    #[test]
+    fn as_str_snake_stable_identifiers() {
+        assert_eq!(TopLevelCategory::Feature.as_str_snake(), "feature");
+        assert_eq!(TopLevelCategory::Bugfix.as_str_snake(), "bugfix");
+        assert_eq!(TopLevelCategory::Ktlo.as_str_snake(), "ktlo");
+        assert_eq!(
+            TopLevelCategory::Integrations.as_str_snake(),
+            "integrations"
+        );
+        assert_eq!(
+            TopLevelCategory::PlatformWork.as_str_snake(),
+            "platform_work"
+        );
+        assert_eq!(TopLevelCategory::Content.as_str_snake(), "content");
+        assert_eq!(TopLevelCategory::Maintenance.as_str_snake(), "maintenance");
+        assert_eq!(TopLevelCategory::Unknown.as_str_snake(), "unknown");
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/collect/ai_attribution.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_attribution.rs
@@ -1,0 +1,199 @@
+//! AI co-authorship attribution from commit message trailers.
+//!
+//! Why: engineering teams are increasingly using AI coding assistants
+//! (Claude, GitHub Copilot, Cursor) whose contributions appear in commits
+//! via `Co-Authored-By:` trailers. Detecting these at collection time lets
+//! reports measure AI adoption without requiring human annotation.
+//!
+//! What: a single pure function [`detect_ai_tool`] that scans commit message
+//! trailers (case-insensitive `Co-Authored-By:` / `Co-authored-by:`) for
+//! well-known AI tool signatures and returns a stable `&'static str`
+//! identifier.
+//!
+//! Test: unit tests in [`tests`] at the bottom of this file. The function is
+//! also covered by the extractor path (`collect::git::extractor`) which calls
+//! it at INSERT time for every new commit.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// Compiled AI-tool detection patterns.
+struct AiPatterns {
+    /// Matches the full `Co-Authored-By:` or `Co-authored-by:` trailer line.
+    trailer_line: Regex,
+    /// Matches "claude" (Anthropic Claude assistant).
+    claude: Regex,
+    /// Matches "github copilot" (GitHub Copilot assistant).
+    copilot: Regex,
+    /// Matches "cursor" (Cursor AI assistant).
+    cursor: Regex,
+}
+
+/// Global, lazily-initialized pattern set.
+///
+/// Why: `OnceLock` gives thread-safe one-time initialisation without a
+/// global mutex on every call.
+/// What: compiles the regexes once and reuses them for the lifetime of the
+/// process.
+/// Test: `tests::ai_patterns_compile` forces initialisation.
+fn ai_patterns() -> &'static AiPatterns {
+    static PATTERNS: OnceLock<AiPatterns> = OnceLock::new();
+    PATTERNS.get_or_init(|| AiPatterns {
+        // Capture the content after the trailer key (case-insensitive key).
+        trailer_line: Regex::new(r"(?im)^[Cc]o-[Aa]uthored-[Bb]y:\s*(.+)$")
+            .expect("trailer_line pattern compiles"),
+        claude: Regex::new(r"(?i)\bclaude\b").expect("claude pattern compiles"),
+        copilot: Regex::new(r"(?i)\bcopilot\b|GitHub\s+Copilot").expect("copilot pattern compiles"),
+        cursor: Regex::new(r"(?i)\bcursor\b").expect("cursor pattern compiles"),
+    })
+}
+
+/// Detect the AI tool that co-authored a commit from its message.
+///
+/// Why: `commits.ai_tool` and `commits.is_ai_assisted` must be populated at
+/// collection time (issue #445). This function provides the detection logic
+/// shared between the initial `tga collect` INSERT and the retroactive
+/// `tga backfill ai-detection-commits` path.
+/// What: scans all `Co-Authored-By:` / `Co-authored-by:` trailer lines in
+/// `message` for the signatures of known AI tools. Returns the first match
+/// as a stable `&'static str` identifier, or `None` if no known AI trailer
+/// is present. Priority order: Claude → Copilot → Cursor.
+/// Test: `tests::detect_ai_tool_*` below.
+///
+/// # Stable identifiers
+///
+/// | Detected tool     | Returned string |
+/// |-------------------|-----------------|
+/// | Anthropic Claude  | `"claude"`      |
+/// | GitHub Copilot    | `"copilot"`     |
+/// | Cursor            | `"cursor"`      |
+///
+/// # Examples
+///
+/// ```
+/// use tga::collect::ai_attribution::detect_ai_tool;
+///
+/// let msg = "feat: add auth\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>";
+/// assert_eq!(detect_ai_tool(msg), Some("claude"));
+///
+/// let human = "feat: add auth\n\nCo-Authored-By: Alice <alice@example.com>";
+/// assert_eq!(detect_ai_tool(human), None);
+/// ```
+pub fn detect_ai_tool(message: &str) -> Option<&'static str> {
+    let p = ai_patterns();
+
+    for caps in p.trailer_line.captures_iter(message) {
+        let trailer_value = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+
+        if p.claude.is_match(trailer_value) {
+            return Some("claude");
+        }
+        if p.copilot.is_match(trailer_value) {
+            return Some("copilot");
+        }
+        if p.cursor.is_match(trailer_value) {
+            return Some("cursor");
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ai_patterns_compile() {
+        // Force lazy init; any bad pattern literal panics here, not at runtime.
+        let _ = ai_patterns();
+    }
+
+    /// Why: Claude is the primary AI tool in this codebase; must be detected.
+    /// What: message with a Claude co-author trailer returns `"claude"`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_detects_claude() {
+        let msg =
+            "feat: add auth\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>";
+        assert_eq!(detect_ai_tool(msg), Some("claude"));
+    }
+
+    /// Why: case-insensitive trailer key must be accepted.
+    /// What: lowercase `co-authored-by:` is recognised.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_case_insensitive_key() {
+        let msg = "fix: bug\n\nco-authored-by: Claude Sonnet 4 <noreply@anthropic.com>";
+        assert_eq!(detect_ai_tool(msg), Some("claude"));
+    }
+
+    /// Why: Copilot must be detected by keyword.
+    /// What: `"GitHub Copilot"` in trailer value returns `"copilot"`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_detects_copilot() {
+        let msg = "feat: autocomplete\n\nCo-Authored-By: GitHub Copilot <copilot@github.com>";
+        assert_eq!(detect_ai_tool(msg), Some("copilot"));
+    }
+
+    /// Why: Copilot detection must also match just "copilot" (bare keyword).
+    /// What: `"copilot"` anywhere in the trailer value returns `"copilot"`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_detects_copilot_bare() {
+        let msg = "fix: npe\n\nCo-Authored-By: copilot <noreply@github.com>";
+        assert_eq!(detect_ai_tool(msg), Some("copilot"));
+    }
+
+    /// Why: Cursor must be detected by keyword.
+    /// What: `"Cursor"` in trailer value returns `"cursor"`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_detects_cursor() {
+        let msg = "chore: refactor\n\nCo-Authored-By: Cursor <noreply@cursor.sh>";
+        assert_eq!(detect_ai_tool(msg), Some("cursor"));
+    }
+
+    /// Why: human co-authors must not be detected as AI.
+    /// What: ordinary `Co-Authored-By:` with a human name returns `None`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_returns_none_for_human() {
+        let msg = "feat: auth\n\nCo-Authored-By: Alice Smith <alice@example.com>";
+        assert_eq!(detect_ai_tool(msg), None);
+    }
+
+    /// Why: commits without any trailer must return `None`.
+    /// What: plain commit message with no `Co-Authored-By:` returns `None`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_returns_none_for_no_trailer() {
+        assert_eq!(detect_ai_tool("feat: add feature"), None);
+        assert_eq!(detect_ai_tool(""), None);
+    }
+
+    /// Why: multiple trailers — Claude takes priority over Copilot in the
+    /// priority order (Claude → Copilot → Cursor).
+    /// What: message with both Claude and Copilot trailers returns `"claude"`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_priority_claude_before_copilot() {
+        let msg = "pair session\n\n\
+                   Co-Authored-By: Claude Opus <noreply@anthropic.com>\n\
+                   Co-Authored-By: GitHub Copilot <copilot@github.com>";
+        assert_eq!(detect_ai_tool(msg), Some("claude"));
+    }
+
+    /// Why: priority order — Copilot before Cursor when both present.
+    /// What: Copilot trailer appears before Cursor; returns `"copilot"`.
+    /// Test: this test itself.
+    #[test]
+    fn detect_ai_tool_priority_copilot_before_cursor() {
+        let msg = "pair session\n\n\
+                   Co-Authored-By: GitHub Copilot <copilot@github.com>\n\
+                   Co-Authored-By: Cursor <noreply@cursor.sh>";
+        assert_eq!(detect_ai_tool(msg), Some("copilot"));
+    }
+}

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -12,6 +12,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use rusqlite::params;
 use tracing::{debug, info, warn};
 
+use crate::collect::ai_attribution::detect_ai_tool;
 use crate::collect::collector::{FetchOutcome, PerRepoFetch};
 use crate::collect::errors::{CollectError, Result};
 use crate::collect::git::diff::{compute_commit_diff, CommitDiff};
@@ -512,12 +513,16 @@ impl GitCollector {
             // `commits.ticket_id` is populated without a separate
             // `tga backfill ticket-ids` run.
             let ticket_id = extract_ticket_id(&message);
+            // Issue #445: detect AI co-authorship from `Co-Authored-By:` trailers.
+            let ai_tool = detect_ai_tool(&message);
+            let is_ai_assisted = ai_tool.is_some();
 
             let inserted = tx.execute(
                 "INSERT OR IGNORE INTO commits \
                  (sha, author_name, author_email, timestamp, message, repository, \
-                  files_changed, insertions, deletions, is_merge, ticketed, ticket_id) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                  files_changed, insertions, deletions, is_merge, ticketed, ticket_id, \
+                  is_ai_assisted, ai_tool) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 params![
                     sha_str,
                     author_name,
@@ -531,6 +536,8 @@ impl GitCollector {
                     is_merge as i64,
                     ticketed as i64,
                     ticket_id,
+                    is_ai_assisted as i64,
+                    ai_tool,
                 ],
             )?;
 

--- a/crates/trusty-git-analytics/src/collect/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/mod.rs
@@ -17,6 +17,7 @@
 //! - [`collector`] — end-to-end pipeline orchestrator
 //! - [`errors`] — module-level error type ([`CollectError`])
 
+pub mod ai_attribution;
 pub mod azdo;
 pub mod bitbucket;
 pub mod collector;

--- a/crates/trusty-git-analytics/src/collect/ticket.rs
+++ b/crates/trusty-git-analytics/src/collect/ticket.rs
@@ -8,12 +8,15 @@
 //!   (`ENG-123`, `FE-456`) is a subset of this pattern.
 //! - **GitHub action-keyword refs**: `fixes #123`, `closes #45`,
 //!   `resolves #7` (case-insensitive, also matches `fix`/`close`/`resolve`).
-//! - **GitHub bare issue refs**: `#123` preceded by start-of-string or
-//!   whitespace, so we don't false-positive on things like a hex color
-//!   `#abc123` inside another token.
-//! - **Azure DevOps work-item refs**: `AB#123`. Bare `#N` is intentionally
-//!   excluded from the ADO pattern because it collides with GitHub PR/issue
-//!   numbers (the existing GitHub bare-`#N` rule above still applies).
+//! - **Azure DevOps work-item refs**: `AB#123`.
+//!
+//! **Note on bare `#N` refs (issue #445):** A bare `#N` preceded by
+//! whitespace (the `gh_bare` pattern) is explicitly *excluded* from
+//! [`is_ticketed`]. It fires on almost any multi-line commit body and was
+//! inflating the ticketed rate to ~100%. The `gh_bare` pattern is still
+//! used by [`extract_ticket_id`] to populate `commits.ticket_id` as a
+//! last-resort identifier, so the data is not lost — it just no longer
+//! counts as "ticketed" for quality-metric purposes.
 //!
 //! Patterns are compiled exactly once on first use via [`OnceLock`].
 
@@ -22,10 +25,14 @@ use std::sync::OnceLock;
 use regex::Regex;
 
 /// Compiled regexes used by [`is_ticketed`].
+///
+/// Note: `gh_bare` is intentionally excluded from this struct (issue #445).
+/// A bare `#N` reference no longer qualifies a commit as "ticketed" — only
+/// JIRA/Linear, GitHub action-keyword refs, and Azure DevOps refs do.
+/// The bare pattern still lives in [`ExtractPatterns`] for `ticket_id` population.
 struct TicketPatterns {
     jira: Regex,
     gh_action: Regex,
-    gh_bare: Regex,
     azdo: Regex,
 }
 
@@ -44,8 +51,6 @@ fn patterns() -> &'static TicketPatterns {
             // GitHub action keyword: fix(es|ed)?|close(s|d)?|resolve(s|d)?  #123
             gh_action: Regex::new(r"(?i)\b(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#\d+\b")
                 .expect("gh_action pattern compiles"),
-            // Bare `#123` preceded by start-of-line or whitespace.
-            gh_bare: Regex::new(r"(?m)(?:^|\s)#\d+\b").expect("gh_bare pattern compiles"),
             // Azure DevOps work-item reference: AB#123.
             // Bare #N intentionally excluded — collides with GitHub PR/issue numbers.
             azdo: Regex::new(r"\bAB#\d+\b").expect("azdo pattern compiles"),
@@ -80,9 +85,20 @@ fn extract_patterns() -> &'static ExtractPatterns {
 
 /// Return `true` if `message` contains any recognized ticket reference.
 ///
-/// The check is performed against the full message (subject + body); a
-/// reference anywhere in the text — including later lines of a multi-line
-/// commit body — flags the commit as ticketed.
+/// Why: downstream metrics (ticketed-commit rate, quality score) must only
+/// count commits that are genuinely linked to a tracked work item. A bare
+/// `#N` reference (e.g. `#42` from a release note) is too noisy — it fires
+/// on nearly every multi-line commit body and inflates the ticketed rate to
+/// ~100% (issue #445). The `gh_bare` pattern is intentionally **excluded**
+/// from this OR-chain; it is still used by [`extract_ticket_id`] to populate
+/// `commits.ticket_id` as a last-resort identifier.
+/// What: returns `true` for JIRA/Linear identifiers (`PROJ-N`), GitHub
+/// action-keyword refs (`closes #N`, `fixes #N`), and Azure DevOps refs
+/// (`AB#N`). A bare `#N` with no action keyword does NOT make a commit
+/// ticketed.
+/// Test: `tests::ticketed_*` below; the critical regression cases are
+/// `bare_hash_alone_is_NOT_ticketed`, `closes_hash_IS_ticketed`,
+/// `jira_IS_ticketed`, and `azdo_IS_ticketed`.
 ///
 /// # Examples
 ///
@@ -92,13 +108,11 @@ fn extract_patterns() -> &'static ExtractPatterns {
 /// assert!(is_ticketed("ENG-123: add feature"));
 /// assert!(is_ticketed("Fix login (closes #42)"));
 /// assert!(!is_ticketed("misc cleanup"));
+/// assert!(!is_ticketed("some note about #42"));
 /// ```
 pub fn is_ticketed(message: &str) -> bool {
     let p = patterns();
-    p.jira.is_match(message)
-        || p.gh_action.is_match(message)
-        || p.gh_bare.is_match(message)
-        || p.azdo.is_match(message)
+    p.jira.is_match(message) || p.gh_action.is_match(message) || p.azdo.is_match(message)
 }
 
 /// Extract the first recognizable ticket identifier from a commit message.
@@ -262,10 +276,45 @@ mod tests {
         assert!(is_ticketed("CLOSED #99")); // case-insensitive
     }
 
+    /// Why: regression guard for issue #445. Bare `#N` refs no longer make a
+    /// commit "ticketed" — only JIRA/Linear, GitHub action keywords, and ADO
+    /// refs do. This test confirms bare refs are NOT ticketed while confirming
+    /// they still produce a `ticket_id` via `extract_ticket_id`.
+    /// What: asserts `is_ticketed` returns false for bare `#N`, and that
+    /// action keywords and JIRA refs still return true.
+    /// Test: this test itself.
     #[test]
-    fn github_bare_hash_ref_is_ticketed() {
-        assert!(is_ticketed("Bug from #123 still present"));
-        assert!(is_ticketed("#42 follow-up"));
+    fn bare_hash_alone_is_not_ticketed() {
+        // Bare #N with no action keyword is NOT ticketed (issue #445 fix).
+        assert!(!is_ticketed("Bug from #123 still present"));
+        assert!(!is_ticketed("#42 follow-up"));
+        assert!(!is_ticketed("some note about #42"));
+        // But the ticket_id is still extractable.
+        assert_eq!(extract_ticket_id("#42 follow-up"), Some("#42".to_string()));
+        assert_eq!(
+            extract_ticket_id("Bug from #123 still present"),
+            Some("#123".to_string())
+        );
+    }
+
+    #[test]
+    fn closes_hash_is_ticketed() {
+        // Action keyword + bare ref IS ticketed.
+        assert!(is_ticketed("closes #42"));
+        assert!(is_ticketed("fixes #123"));
+        assert!(is_ticketed("resolves #7"));
+    }
+
+    #[test]
+    fn jira_is_ticketed() {
+        assert!(is_ticketed("ENG-123: add feature"));
+        assert!(is_ticketed("PROJ-1 initial commit"));
+    }
+
+    #[test]
+    fn azdo_is_ticketed() {
+        assert!(is_ticketed("AB#1234 implement new feature"));
+        assert!(is_ticketed("Refactor module (AB#42)"));
     }
 
     #[test]
@@ -282,11 +331,16 @@ mod tests {
 
     #[test]
     fn multiline_body_with_ticket_is_ticketed() {
+        // JIRA ref anywhere in body → ticketed.
         let msg = "Refactor module structure\n\nMoves things around.\nRelates to PROJ-789.\n";
         assert!(is_ticketed(msg));
 
-        let msg2 = "First line no ticket\n\nSecond paragraph mentions #321 explicitly.";
-        assert!(is_ticketed(msg2));
+        // Bare #N in body is NOT ticketed (issue #445 fix); action keyword is.
+        let msg2 = "First line no ticket\n\nSee #321 for context.";
+        assert!(!is_ticketed(msg2));
+
+        let msg3 = "First line no ticket\n\nCloses #321.";
+        assert!(is_ticketed(msg3));
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/commands/backfill.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill.rs
@@ -14,12 +14,14 @@
 use clap::{Args, Subcommand};
 use git2::{Repository, Sort};
 use rusqlite::{params, Connection};
+use tga::classify::taxonomy::TaxonomyRegistry;
 use tga::classify::ClassificationPipeline;
+use tga::collect::ai_attribution::detect_ai_tool;
 use tga::collect::git::scan_and_persist;
 use tga::collect::ticket::{extract_ticket_id, is_ticketed};
 use tga::core::config::{expand_path, Config};
 use tga::core::db::{CheckpointMode, Database};
-use tga::core::effort::{compute_effort, FORMULA_VERSION};
+use tga::core::effort::{compute_effort, effort_tshirt_from_size, FORMULA_VERSION};
 
 /// Arguments for `tga backfill`.
 #[derive(Args, Debug)]
@@ -132,6 +134,38 @@ pub enum BackfillSubcommand {
     /// --repos/--since/--until/--weeks do not scope this operation: all NULL
     /// rows are processed.
     Complexity(ComplexityBackfillArgs),
+    /// Recompute `commits.ticketed` using the fixed regex rules (issue #445).
+    ///
+    /// Bare `#N` refs no longer mark a commit as ticketed; only JIRA/Linear
+    /// (`PROJ-N`), GitHub action keywords (`closes/fixes/resolves #N`), and
+    /// Azure DevOps (`AB#N`) do. This subcommand re-evaluates every stored
+    /// `commits.message` with the corrected [`is_ticketed`] and updates rows
+    /// that differ from the stored value. No LLM required — pure regex.
+    ///
+    /// Use --repos/--since/--until to limit scope on large databases.
+    Ticketed,
+    /// Scan existing `commits.message` for AI co-authorship trailers (issue #445).
+    ///
+    /// Detects `Co-Authored-By:` trailers for Claude, GitHub Copilot, and
+    /// Cursor; sets `commits.is_ai_assisted` and `commits.ai_tool`.
+    /// No LLM required — pure string matching.
+    ///
+    /// Use --repos/--since/--until to limit scope.
+    AiDetectionCommits,
+    /// Fill in `classifications.top_level_category` from existing subcategory
+    /// values using the built-in taxonomy (issue #445).
+    ///
+    /// The top_level_category column was added in migration v17 and is
+    /// populated for new classifications at write time. This subcommand
+    /// retroactively fills existing rows by resolving each subcategory through
+    /// the taxonomy registry. No LLM required.
+    TopLevel,
+    /// Fill in `fact_commit_effort.effort_tshirt` from existing `size` values
+    /// (issue #445).
+    ///
+    /// Maps the text size label (XS/S/M/L/XL) to the numeric T-shirt integer
+    /// (1–5) for existing rows that pre-date migration v17.
+    EffortTshirt,
 }
 
 /// Arguments for `tga backfill complexity`.
@@ -236,6 +270,18 @@ pub async fn run(config: Config, db: &mut Database, args: BackfillArgs) -> anyho
         BackfillSubcommand::Complexity(complexity_args) => {
             backfill_complexity(config, db, complexity_args, args.dry_run).await
         }
+        BackfillSubcommand::Ticketed => {
+            backfill_ticketed(db, args.dry_run, &repos, since.as_deref(), until.as_deref())
+        }
+        BackfillSubcommand::AiDetectionCommits => backfill_ai_detection_commits(
+            db,
+            args.dry_run,
+            &repos,
+            since.as_deref(),
+            until.as_deref(),
+        ),
+        BackfillSubcommand::TopLevel => backfill_top_level(db, args.dry_run),
+        BackfillSubcommand::EffortTshirt => backfill_effort_tshirt(db, args.dry_run),
     }
 }
 
@@ -558,6 +604,7 @@ fn process_one_repo_db(
             tests_factor: effort.tests_factor,
             formula_version: FORMULA_VERSION.to_string(),
             computed_at,
+            effort_tshirt: effort_tshirt_from_size(effort.size_label()),
         });
         if records.len().is_multiple_of(1000) {
             tracing::info!(
@@ -842,6 +889,7 @@ fn process_one_repo_git(
             tests_factor: effort.tests_factor,
             formula_version: FORMULA_VERSION.to_string(),
             computed_at,
+            effort_tshirt: effort_tshirt_from_size(effort.size_label()),
         });
 
         // Log progress every 1000 commits.
@@ -890,6 +938,8 @@ struct EffortRow {
     tests_factor: f64,
     formula_version: String,
     computed_at: i64,
+    /// Numeric T-shirt size: XS=1, S=2, M=3, L=4, XL=5 (issue #445 migration v17).
+    effort_tshirt: i64,
 }
 
 /// Persist effort rows in batches of 1000 using UPSERT semantics.
@@ -908,8 +958,8 @@ fn persist_effort_rows(db: &mut Database, rows: &[EffortRow]) -> anyhow::Result<
             let mut stmt = tx.prepare(
                 "INSERT OR REPLACE INTO fact_commit_effort \
                  (sha, repository, size, score, loc, files, test_loc, tests_factor, \
-                  formula_version, computed_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                  formula_version, computed_at, effort_tshirt) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             )?;
             for row in chunk {
                 stmt.execute(params![
@@ -923,6 +973,7 @@ fn persist_effort_rows(db: &mut Database, rows: &[EffortRow]) -> anyhow::Result<
                     row.tests_factor,
                     row.formula_version,
                     row.computed_at,
+                    row.effort_tshirt,
                 ])?;
             }
         }
@@ -1316,6 +1367,295 @@ fn is_revert(message: &str) -> bool {
     tga::core::revert::is_revert(message)
 }
 
+// ── backfill ticketed (issue #445) ───────────────────────────────────────────
+
+/// Recompute `commits.ticketed` using the corrected `is_ticketed` logic.
+///
+/// Why: before issue #445 the `gh_bare` pattern (`#N` preceded by whitespace)
+/// was included in [`is_ticketed`], inflating the ticketed rate to ~100%.
+/// After the fix, bare `#N` no longer marks a commit as ticketed. This
+/// backfill lets operators correct existing rows without re-collecting.
+/// What: loads every commit (filtered by repos/since/until), recomputes
+/// `ticketed` from `commits.message` using the fixed `is_ticketed`, and
+/// updates rows whose stored value differs. No LLM required — pure regex.
+/// Test: `tests::backfill_ticketed_corrects_bare_hash_rows`.
+///
+/// # Errors
+///
+/// Propagates database errors from the underlying queries.
+fn backfill_ticketed(
+    db: &mut Database,
+    dry_run: bool,
+    repos_filter: &[String],
+    since: Option<&str>,
+    until: Option<&str>,
+) -> anyhow::Result<()> {
+    let mut to_update: Vec<(i64, i64)> = Vec::new();
+    {
+        let conn = db.connection();
+        let (sql, params) = build_commits_filter_sql(
+            "SELECT id, message, ticketed FROM commits",
+            repos_filter,
+            since,
+            until,
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })?;
+        for r in rows {
+            let (id, message, current) = r?;
+            let new_val = if is_ticketed(&message) { 1 } else { 0 };
+            if new_val != current {
+                to_update.push((id, new_val));
+            }
+        }
+    }
+
+    let now_ticketed = to_update.iter().filter(|(_, v)| *v == 1).count();
+    let now_unticketed = to_update.iter().filter(|(_, v)| *v == 0).count();
+
+    if dry_run {
+        println!(
+            "Dry run — would update {} commits \
+             ({} newly ticketed, {} newly unticketed). No changes written.",
+            to_update.len(),
+            now_ticketed,
+            now_unticketed,
+        );
+        return Ok(());
+    }
+
+    let conn = db.connection_mut();
+    let tx = conn.transaction()?;
+    {
+        let mut up = tx.prepare("UPDATE commits SET ticketed = ?1 WHERE id = ?2")?;
+        for (id, val) in &to_update {
+            up.execute(params![val, id])?;
+        }
+    }
+    tx.commit()?;
+    println!(
+        "Updated ticketed on {} commits \
+         ({} newly ticketed, {} newly unticketed).",
+        to_update.len(),
+        now_ticketed,
+        now_unticketed,
+    );
+    Ok(())
+}
+
+// ── backfill ai-detection-commits (issue #445) ────────────────────────────────
+
+/// Scan existing `commits.message` for AI co-authorship trailers.
+///
+/// Why: `is_ai_assisted` and `ai_tool` columns were added in migration v17;
+/// existing rows have `is_ai_assisted = 0` and `ai_tool = NULL` regardless of
+/// their actual history. This backfill retroactively detects Claude,
+/// GitHub Copilot, and Cursor via `Co-Authored-By:` trailers.
+/// What: loads every commit (filtered by repos/since/until), runs
+/// [`detect_ai_tool`] on the message, and updates rows where `ai_tool`
+/// differs from the stored value. No LLM required — pure string matching.
+/// Test: `tests::backfill_ai_detection_commits_detects_claude`.
+///
+/// # Errors
+///
+/// Propagates database errors from the underlying queries.
+fn backfill_ai_detection_commits(
+    db: &mut Database,
+    dry_run: bool,
+    repos_filter: &[String],
+    since: Option<&str>,
+    until: Option<&str>,
+) -> anyhow::Result<()> {
+    let mut to_update: Vec<(i64, i64, Option<&'static str>)> = Vec::new();
+    {
+        let conn = db.connection();
+        let (sql, params) = build_commits_filter_sql(
+            "SELECT id, message, ai_tool FROM commits",
+            repos_filter,
+            since,
+            until,
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows: Vec<(i64, String, Option<String>)> = stmt
+            .query_map(rusqlite::params_from_iter(params.iter()), |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })?
+            .collect::<Result<_, _>>()?;
+
+        for (id, message, current_tool) in rows {
+            let detected = detect_ai_tool(&message);
+            let current_str = current_tool.as_deref();
+            if detected != current_str {
+                let is_ai = if detected.is_some() { 1_i64 } else { 0_i64 };
+                to_update.push((id, is_ai, detected));
+            }
+        }
+    }
+
+    let with_tool = to_update.iter().filter(|(_, _, t)| t.is_some()).count();
+
+    if dry_run {
+        println!(
+            "Dry run — would update {} commits ({} with AI tool detected). No changes written.",
+            to_update.len(),
+            with_tool,
+        );
+        return Ok(());
+    }
+
+    let conn = db.connection_mut();
+    let tx = conn.transaction()?;
+    {
+        let mut up =
+            tx.prepare("UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2 WHERE id = ?3")?;
+        for (id, is_ai, tool) in &to_update {
+            up.execute(params![is_ai, tool, id])?;
+        }
+    }
+    tx.commit()?;
+    println!(
+        "Updated {} commits ({} AI-assisted, {} cleared).",
+        to_update.len(),
+        with_tool,
+        to_update.len() - with_tool,
+    );
+    Ok(())
+}
+
+// ── backfill top-level (issue #445) ──────────────────────────────────────────
+
+/// Fill in `classifications.top_level_category` for existing rows.
+///
+/// Why: `top_level_category` was added in migration v17. New classifications
+/// written by `write_results_chunk` will have it populated automatically;
+/// this backfill handles the pre-existing rows where the column is NULL.
+/// What: resolves each stored `subcategory` through the built-in
+/// [`TaxonomyRegistry`] and sets `top_level_category` to the snake_case
+/// string for the resolved variant. Rows with an unrecognized subcategory
+/// (or NULL subcategory) are left as NULL. No LLM required.
+/// Test: `tests::backfill_top_level_fills_known_subcategories`.
+///
+/// # Errors
+///
+/// Propagates database errors from the underlying queries.
+fn backfill_top_level(db: &mut Database, dry_run: bool) -> anyhow::Result<()> {
+    let registry = TaxonomyRegistry::with_builtins();
+
+    let mut to_update: Vec<(i64, String)> = Vec::new();
+    {
+        let conn = db.connection();
+        let mut stmt = conn.prepare(
+            "SELECT id, subcategory FROM classifications WHERE top_level_category IS NULL",
+        )?;
+        let rows: Vec<(i64, Option<String>)> = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?))
+            })?
+            .collect::<Result<_, _>>()?;
+
+        for (id, subcategory) in rows {
+            if let Some(sub) = subcategory {
+                if let Some(top) = registry.resolve(&sub) {
+                    to_update.push((id, top.as_str_snake().to_string()));
+                }
+            }
+        }
+    }
+
+    if dry_run {
+        println!(
+            "Dry run — would update top_level_category for {} classification(s). \
+             No changes written.",
+            to_update.len(),
+        );
+        return Ok(());
+    }
+
+    let conn = db.connection_mut();
+    let tx = conn.transaction()?;
+    {
+        let mut up =
+            tx.prepare("UPDATE classifications SET top_level_category = ?1 WHERE id = ?2")?;
+        for (id, top) in &to_update {
+            up.execute(params![top, id])?;
+        }
+    }
+    tx.commit()?;
+    println!(
+        "Updated top_level_category for {} classification(s).",
+        to_update.len()
+    );
+    Ok(())
+}
+
+// ── backfill effort-tshirt (issue #445) ──────────────────────────────────────
+
+/// Fill in `fact_commit_effort.effort_tshirt` from existing `size` text values.
+///
+/// Why: the `effort_tshirt` integer column (1=XS, 2=S, 3=M, 4=L, 5=XL) was
+/// added in migration v17. Existing rows retain a valid `size` TEXT value
+/// but have `effort_tshirt = NULL`. This backfill derives the integer from
+/// the existing text without re-computing the effort formula.
+/// What: selects all rows where `effort_tshirt IS NULL`, maps `size` to an
+/// integer via [`effort_tshirt_from_size`], and updates in place.
+/// Test: `tests::backfill_effort_tshirt_fills_from_size`.
+///
+/// # Errors
+///
+/// Propagates database errors from the underlying queries.
+fn backfill_effort_tshirt(db: &mut Database, dry_run: bool) -> anyhow::Result<()> {
+    let mut to_update: Vec<(i64, i64)> = Vec::new();
+    {
+        let conn = db.connection();
+        let mut stmt =
+            conn.prepare("SELECT rowid, size FROM fact_commit_effort WHERE effort_tshirt IS NULL")?;
+        let rows: Vec<(i64, String)> = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<_, _>>()?;
+
+        for (rowid, size) in rows {
+            let tshirt = effort_tshirt_from_size(&size);
+            to_update.push((rowid, tshirt));
+        }
+    }
+
+    if dry_run {
+        println!(
+            "Dry run — would update effort_tshirt for {} row(s). No changes written.",
+            to_update.len(),
+        );
+        return Ok(());
+    }
+
+    let conn = db.connection_mut();
+    let tx = conn.transaction()?;
+    {
+        let mut up =
+            tx.prepare("UPDATE fact_commit_effort SET effort_tshirt = ?1 WHERE rowid = ?2")?;
+        for (rowid, tshirt) in &to_update {
+            up.execute(params![tshirt, rowid])?;
+        }
+    }
+    tx.commit()?;
+    println!(
+        "Updated effort_tshirt for {} effort row(s).",
+        to_update.len()
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1475,6 +1815,7 @@ mod tests {
             tests_factor: 1.0,
             formula_version: FORMULA_VERSION.to_string(),
             computed_at: 1_000_000,
+            effort_tshirt: 3,
         }];
 
         persist_effort_rows(&mut db, &rows).expect("persist");
@@ -1516,6 +1857,7 @@ mod tests {
             tests_factor: 1.0,
             formula_version: FORMULA_VERSION.to_string(),
             computed_at: 1_000_000,
+            effort_tshirt: 1,
         }];
         persist_effort_rows(&mut db, &first).expect("first persist");
 
@@ -1531,6 +1873,7 @@ mod tests {
             tests_factor: 1.0,
             formula_version: FORMULA_VERSION.to_string(),
             computed_at: 2_000_000,
+            effort_tshirt: 5,
         }];
         persist_effort_rows(&mut db, &second).expect("second persist");
 
@@ -1580,6 +1923,7 @@ mod tests {
                 tests_factor: 1.0,
                 formula_version: FORMULA_VERSION.to_string(),
                 computed_at: 1_000_000,
+                effort_tshirt: 2, // S=2
             },
             EffortRow {
                 sha: "cafebabe".to_string(),
@@ -1592,6 +1936,7 @@ mod tests {
                 tests_factor: 1.0,
                 formula_version: FORMULA_VERSION.to_string(),
                 computed_at: 1_000_000,
+                effort_tshirt: 3, // M=3
             },
         ];
 
@@ -1759,6 +2104,7 @@ mod tests {
             tests_factor: 1.0,
             formula_version: FORMULA_VERSION.to_string(),
             computed_at: 0,
+            effort_tshirt: 1, // XS=1
         }];
         persist_effort_rows(&mut db, &pre).expect("pre-persist");
 
@@ -1807,6 +2153,7 @@ mod tests {
             tests_factor: 1.0,
             formula_version: "v0".to_string(),
             computed_at: 0,
+            effort_tshirt: 1, // XS=1
         }];
         persist_effort_rows(&mut db, &stale).expect("stale persist");
 
@@ -1981,5 +2328,178 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM fact_commit_effort", [], |r| r.get(0))
             .expect("count");
         assert_eq!(count, 0, "dry_run must not write to fact_commit_effort");
+    }
+
+    // ── issue #445 backfill tests ─────────────────────────────────────────────
+
+    /// Why: regression guard for issue #445. `backfill_ticketed` must correct
+    /// rows where a bare `#N` was (incorrectly) stored as `ticketed=1` under the
+    /// old logic, setting them to `ticketed=0`. Rows with JIRA refs must stay 1.
+    /// What: seeds two commits (one bare-hash, one JIRA), runs the ticketed
+    /// backfill with dry_run=false, asserts the bare-hash row is now 0 and the
+    /// JIRA row remains 1.
+    /// Test: this test itself.
+    #[test]
+    fn backfill_ticketed_corrects_bare_hash_rows() {
+        let mut db = Database::open_in_memory().expect("open");
+
+        // Force-insert with ticketed=1 to simulate the pre-#445 incorrect state.
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, ticketed) VALUES ('bare1', 'n', 'e', '2024-01-01T00:00:00Z', \
+                 'some note about #42', 'repo', 1)",
+                [],
+            )
+            .expect("insert bare-hash commit");
+        // JIRA ref — was and should remain ticketed.
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, ticketed) VALUES ('jira1', 'n', 'e', '2024-01-02T00:00:00Z', \
+                 'ENG-7: add feature', 'repo', 1)",
+                [],
+            )
+            .expect("insert JIRA commit");
+        // Plain message — was and should remain 0.
+        seed(&db, "plain1", "no ticket here");
+
+        backfill_ticketed(&mut db, false, &[], None, None).expect("backfill ticketed");
+
+        let bare_val: i64 = db
+            .connection()
+            .query_row(
+                "SELECT ticketed FROM commits WHERE sha = 'bare1'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read bare");
+        assert_eq!(bare_val, 0, "bare #N must be unticketed after backfill");
+
+        let jira_val: i64 = db
+            .connection()
+            .query_row(
+                "SELECT ticketed FROM commits WHERE sha = 'jira1'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read jira");
+        assert_eq!(jira_val, 1, "JIRA ref must remain ticketed");
+    }
+
+    /// Why: verify `backfill_ai_detection_commits` detects Claude in an existing
+    /// commit message and sets `is_ai_assisted=1` / `ai_tool='claude'`.
+    /// What: seeds one Claude-co-authored commit and one plain human commit;
+    /// runs the backfill; asserts is_ai_assisted and ai_tool are set correctly.
+    /// Test: this test itself.
+    #[test]
+    fn backfill_ai_detection_commits_detects_claude() {
+        let mut db = Database::open_in_memory().expect("open");
+
+        // AI-assisted commit (Claude trailer).
+        let ai_msg = "feat: add auth\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>";
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository) VALUES ('ai1', 'n', 'e', '2024-01-01T00:00:00Z', ?1, 'repo')",
+                params![ai_msg],
+            )
+            .expect("insert AI commit");
+        // Human-only commit.
+        seed(&db, "human1", "fix: bug without AI help");
+
+        backfill_ai_detection_commits(&mut db, false, &[], None, None)
+            .expect("backfill ai-detection");
+
+        let (is_ai, tool): (i64, Option<String>) = db
+            .connection()
+            .query_row(
+                "SELECT is_ai_assisted, ai_tool FROM commits WHERE sha = 'ai1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("read ai1");
+        assert_eq!(is_ai, 1, "AI-assisted commit must have is_ai_assisted=1");
+        assert_eq!(tool, Some("claude".to_string()), "ai_tool must be 'claude'");
+
+        let (human_ai, human_tool): (i64, Option<String>) = db
+            .connection()
+            .query_row(
+                "SELECT is_ai_assisted, ai_tool FROM commits WHERE sha = 'human1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("read human1");
+        assert_eq!(human_ai, 0, "human commit must have is_ai_assisted=0");
+        assert!(human_tool.is_none(), "human commit must have ai_tool=NULL");
+    }
+
+    /// Why: `backfill_top_level` must fill `top_level_category` for existing
+    /// classifications where it is NULL, using the built-in taxonomy.
+    /// What: seeds a classification with subcategory='bugfix' and
+    /// top_level_category=NULL; runs the backfill; asserts top_level_category
+    /// is now 'bugfix'.
+    /// Test: this test itself.
+    #[test]
+    fn backfill_top_level_fills_known_subcategories() {
+        let mut db = Database::open_in_memory().expect("open");
+
+        db.connection()
+            .execute(
+                "INSERT INTO classifications (category, subcategory, confidence, method) \
+                 VALUES ('bugfix', 'bugfix', 0.9, 'exact_rule')",
+                [],
+            )
+            .expect("insert classification");
+
+        backfill_top_level(&mut db, false).expect("backfill top-level");
+
+        let top: Option<String> = db
+            .connection()
+            .query_row(
+                "SELECT top_level_category FROM classifications WHERE subcategory = 'bugfix' \
+                 ORDER BY id DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read top");
+        assert_eq!(
+            top,
+            Some("bugfix".to_string()),
+            "bugfix subcategory must resolve to 'bugfix' top-level"
+        );
+    }
+
+    /// Why: `backfill_effort_tshirt` must populate `effort_tshirt` from the
+    /// existing `size` TEXT column for rows where the integer is NULL.
+    /// What: inserts an effort row with size='L' and effort_tshirt=NULL; runs
+    /// the backfill; asserts effort_tshirt is now 4 (L=4).
+    /// Test: this test itself.
+    #[test]
+    fn backfill_effort_tshirt_fills_from_size() {
+        let mut db = Database::open_in_memory().expect("open");
+
+        // Insert a row with size='L' but no effort_tshirt (simulating pre-v17 row).
+        db.connection()
+            .execute(
+                "INSERT INTO fact_commit_effort \
+                 (sha, repository, size, score, loc, files, test_loc, tests_factor, \
+                  formula_version, computed_at) \
+                 VALUES ('tshirt_test', 'repo', 'L', 15.5, 200, 5, 0, 1.0, 'v1', 1000000)",
+                [],
+            )
+            .expect("insert effort row without tshirt");
+
+        backfill_effort_tshirt(&mut db, false).expect("backfill effort-tshirt");
+
+        let tshirt: Option<i64> = db
+            .connection()
+            .query_row(
+                "SELECT effort_tshirt FROM fact_commit_effort WHERE sha = 'tshirt_test'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read effort_tshirt");
+        assert_eq!(tshirt, Some(4), "L size must map to effort_tshirt=4");
     }
 }

--- a/crates/trusty-git-analytics/src/core/db/migrations.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations.rs
@@ -106,6 +106,11 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "fact_commit_effort",
         sql: include_str!("sql/0016_fact_commit_effort.sql"),
     },
+    Migration {
+        version: 17,
+        name: "pushdown_445",
+        sql: include_str!("sql/0017_pushdown_445.sql"),
+    },
 ];
 
 /// Ensure the `schema_migrations` bookkeeping table exists.
@@ -168,6 +173,103 @@ pub fn run(conn: &mut Connection) -> Result<()> {
 mod tests {
     use crate::core::db::Database;
     use rusqlite::params;
+
+    /// Why: regression guard for issue #445. Migration v17 adds three additive
+    /// columns (`classifications.top_level_category`,
+    /// `fact_commit_effort.effort_tshirt`, `commits.is_ai_assisted`,
+    /// `commits.ai_tool`) plus three indexes. This test verifies the migration
+    /// applies without error and the new columns are writable/readable.
+    /// What: opens an in-memory DB (which runs all migrations), inserts rows
+    /// that exercise the new columns, and reads them back.
+    /// Test: this test itself.
+    #[test]
+    fn migration_v17_adds_pushdown_columns() {
+        let db = Database::open_in_memory().expect("open db");
+        let conn = db.connection();
+
+        // Verify commits accepts is_ai_assisted and ai_tool.
+        conn.execute(
+            "INSERT INTO commits \
+             (sha, author_name, author_email, timestamp, message, repository, \
+              is_ai_assisted, ai_tool) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                "sha_v17_test",
+                "Alice",
+                "alice@example.com",
+                "2026-01-01T00:00:00Z",
+                "feat: AI-assisted commit\n\nCo-Authored-By: Claude Opus <noreply@anthropic.com>",
+                "testrepo",
+                1_i64,
+                "claude",
+            ],
+        )
+        .expect("insert AI-assisted commit");
+
+        let (ai, tool): (i64, Option<String>) = conn
+            .query_row(
+                "SELECT is_ai_assisted, ai_tool FROM commits WHERE sha = 'sha_v17_test'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("read back");
+        assert_eq!(ai, 1, "is_ai_assisted must be 1");
+        assert_eq!(tool, Some("claude".to_string()), "ai_tool must be 'claude'");
+
+        // Verify fact_commit_effort accepts effort_tshirt.
+        conn.execute(
+            "INSERT INTO fact_commit_effort \
+             (sha, repository, size, score, loc, files, test_loc, tests_factor, \
+              formula_version, computed_at, effort_tshirt) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                "sha_v17_test",
+                "testrepo",
+                "M",
+                9.5,
+                50_i64,
+                2_i64,
+                0_i64,
+                1.0_f64,
+                "v1",
+                1_000_000_i64,
+                3_i64, // M=3
+            ],
+        )
+        .expect("insert effort with tshirt");
+
+        let tshirt: i64 = conn
+            .query_row(
+                "SELECT effort_tshirt FROM fact_commit_effort WHERE sha = 'sha_v17_test'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read effort_tshirt");
+        assert_eq!(tshirt, 3, "effort_tshirt M must be 3");
+
+        // Verify classifications accepts top_level_category.
+        conn.execute(
+            "INSERT INTO classifications \
+             (category, subcategory, confidence, method, top_level_category) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params!["feature", "feature", 0.95_f64, "exact_rule", "feature"],
+        )
+        .expect("insert classification with top_level_category");
+
+        let top: Option<String> = conn
+            .query_row(
+                "SELECT top_level_category FROM classifications WHERE category = 'feature' \
+                 ORDER BY id DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read top_level_category");
+        assert_eq!(
+            top,
+            Some("feature".to_string()),
+            "top_level_category must be 'feature'"
+        );
+    }
 
     /// Why: regression guard for issue #88. Before migration v12, the
     /// UNIQUE(provider, pr_number) index collapsed cross-repo PRs that

--- a/crates/trusty-git-analytics/src/core/db/sql/0017_pushdown_445.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0017_pushdown_445.sql
@@ -1,0 +1,24 @@
+-- Migration v17: push-down columns for issue #445 batch A.
+--
+-- Additive only — no existing columns are modified, no data is removed.
+-- All three tables gain optional columns that the Rust-side backfill
+-- subcommands populate retroactively.
+
+-- classifications: top-level work category derived from subcategory taxonomy.
+-- Populated at classification write time (write_results_chunk) and via
+-- `tga backfill top-level`.
+ALTER TABLE classifications ADD COLUMN top_level_category TEXT;
+CREATE INDEX IF NOT EXISTS idx_classifications_top_level ON classifications(top_level_category);
+
+-- fact_commit_effort: numeric T-shirt size (1–5) alongside the text label.
+-- XS=1, S=2, M=3, L=4, XL=5. Populated at effort persist time and via
+-- `tga backfill effort-tshirt`.
+ALTER TABLE fact_commit_effort ADD COLUMN effort_tshirt INTEGER;
+CREATE INDEX IF NOT EXISTS idx_fact_commit_effort_tshirt ON fact_commit_effort(effort_tshirt);
+
+-- commits: AI-tool co-authorship attribution.
+-- is_ai_assisted is 0/1; ai_tool is a stable string identifier
+-- ("claude", "copilot", "cursor") or NULL.
+ALTER TABLE commits ADD COLUMN is_ai_assisted INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE commits ADD COLUMN ai_tool TEXT;
+CREATE INDEX IF NOT EXISTS idx_commits_is_ai_assisted ON commits(is_ai_assisted);

--- a/crates/trusty-git-analytics/src/core/effort.rs
+++ b/crates/trusty-git-analytics/src/core/effort.rs
@@ -124,6 +124,46 @@ impl EffortResult {
     }
 }
 
+/// Map a T-shirt size text label to its numeric integer (1–5).
+///
+/// Why: `fact_commit_effort.effort_tshirt` stores an integer alongside the
+/// `size` TEXT column so SQL range queries (`effort_tshirt <= 3`) and ORDER BY
+/// work without string comparisons (issue #445). The mapping is a static
+/// constant agreed on by all tooling.
+/// What: `"XS"` → 1, `"S"` → 2, `"M"` → 3, `"L"` → 4, `"XL"` → 5.
+/// Any unrecognised label falls back to 0 so callers can detect corrupt data.
+/// Test: `tests::effort_tshirt_mapping`.
+///
+/// | Label | Integer |
+/// |-------|---------|
+/// | `"XS"` | 1 |
+/// | `"S"`  | 2 |
+/// | `"M"`  | 3 |
+/// | `"L"`  | 4 |
+/// | `"XL"` | 5 |
+/// | other  | 0 |
+pub fn effort_tshirt_from_size(size: &str) -> i64 {
+    match size {
+        "XS" => 1,
+        "S" => 2,
+        "M" => 3,
+        "L" => 4,
+        "XL" => 5,
+        _ => 0,
+    }
+}
+
+/// Map an [`EffortSize`] enum variant to its numeric T-shirt integer (1–5).
+///
+/// Why: convenience wrapper over [`effort_tshirt_from_size`] for callers that
+/// already have an [`EffortSize`] value and want the integer without converting
+/// to a label string first.
+/// What: delegates to [`effort_tshirt_from_size`] via the label.
+/// Test: covered by `tests::effort_tshirt_mapping` via the text-label path.
+pub fn effort_tshirt(size: EffortSize) -> i64 {
+    effort_tshirt_from_size(size.label())
+}
+
 /// Classify a continuous score into a T-shirt size bucket.
 ///
 /// Why: the bash script uses the same thresholds; keeping them in one place
@@ -261,6 +301,26 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Why: `effort_tshirt_from_size` drives the v17 migration backfill;
+    /// every label must map to the correct integer (issue #445).
+    /// What: asserts all five valid labels and one invalid label.
+    /// Test: this test itself.
+    #[test]
+    fn effort_tshirt_mapping() {
+        assert_eq!(effort_tshirt_from_size("XS"), 1);
+        assert_eq!(effort_tshirt_from_size("S"), 2);
+        assert_eq!(effort_tshirt_from_size("M"), 3);
+        assert_eq!(effort_tshirt_from_size("L"), 4);
+        assert_eq!(effort_tshirt_from_size("XL"), 5);
+        assert_eq!(
+            effort_tshirt_from_size("??"),
+            0,
+            "unknown label falls back to 0"
+        );
+        // Round-trip: EffortSize → label → tshirt
+        assert_eq!(effort_tshirt(EffortSize::M), 3);
+    }
 
     /// Why: guard that T-shirt labels match the spec and the bash script.
     /// What: asserts every variant returns the canonical string.

--- a/crates/trusty-git-analytics/src/report/aggregator.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator.rs
@@ -44,6 +44,9 @@ struct CommitRow {
     category: Option<String>,
     message: String,
     ticketed: bool,
+    /// True when the commit carries a recognised AI co-authorship trailer
+    /// (issue #445: `Co-Authored-By: Claude/Copilot/Cursor`).
+    is_ai_assisted: bool,
 }
 
 /// Minimal PR row used by velocity / DORA computations and (issue #377)
@@ -344,7 +347,7 @@ impl Aggregator {
                         COALESCE(NULLIF(a.canonical_email, ''), c.author_email) AS author_email, \
                         c.timestamp, c.repository, \
                         c.insertions, c.deletions, c.files_changed, cl.category, \
-                        c.message, c.ticketed \
+                        c.message, c.ticketed, c.is_ai_assisted \
                  FROM commits c \
                  LEFT JOIN authors a ON a.id = c.author_id \
                  LEFT JOIN classifications cl ON cl.id = c.classification_id";
@@ -355,6 +358,9 @@ impl Aggregator {
                 .map(|dt| dt.with_timezone(&Utc))
                 .unwrap_or_else(|_| Utc::now());
             let ticketed: i64 = row.get(10).unwrap_or(0);
+            // Issue #445: column added in migration v17; default 0 for rows
+            // that pre-date the migration (SQLite returns NULL as 0 via unwrap_or).
+            let is_ai_assisted: i64 = row.get(11).unwrap_or(0);
             Ok(CommitRow {
                 sha: row.get(0)?,
                 author_name: row.get(1)?,
@@ -367,6 +373,7 @@ impl Aggregator {
                 category: row.get(8)?,
                 message: row.get(9)?,
                 ticketed: ticketed != 0,
+                is_ai_assisted: is_ai_assisted != 0,
             })
         };
 
@@ -607,6 +614,8 @@ struct WeekAcc {
     bugfixes: usize,
     /// Ticketed commits in this bucket (issue #377).
     ticketed: usize,
+    /// AI-assisted commits in this bucket (issue #445: `is_ai_assisted=1`).
+    ai_assisted: usize,
 }
 
 /// Cross-developer per-week running totals during accumulation.
@@ -730,6 +739,7 @@ fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulators {
             reverts: 0,
             bugfixes: 0,
             ticketed: 0,
+            ai_assisted: 0,
         });
         w.commits += 1;
         w.insertions += row.insertions;
@@ -749,6 +759,11 @@ fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulators {
         }
         if row.ticketed {
             w.ticketed += 1;
+        }
+        // Issue #445: count AI-assisted commits per (week, engineer, repo) bucket
+        // so the weekly activity report can surface AI-adoption rates.
+        if row.is_ai_assisted {
+            w.ai_assisted += 1;
         }
 
         // Category totals.
@@ -909,6 +924,8 @@ fn materialize_weekly_activity(
                 quality_score,
                 quality_tshirt,
                 abandoned_pr_count,
+                // Issue #445: AI-assisted commits in this (week, engineer, repo) bucket.
+                ai_assisted_count: w.ai_assisted,
             }
         })
         .collect()

--- a/crates/trusty-git-analytics/src/report/formatters/csv.rs
+++ b/crates/trusty-git-analytics/src/report/formatters/csv.rs
@@ -75,6 +75,8 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
         "quality_score",
         "quality_tshirt",
         "abandoned_pr_count",
+        // Issue #445: AI-adoption column — commits with a known AI co-author trailer.
+        "ai_assisted_count",
     ])?;
     for row in &data.weekly_activity {
         let categories = serialize_categories(&row.categories);
@@ -92,6 +94,7 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
             &format!("{:.4}", row.quality_score),
             row.quality_tshirt.as_str(),
             &row.abandoned_pr_count.to_string(),
+            &row.ai_assisted_count.to_string(),
         ])?;
     }
     w.flush()?;

--- a/crates/trusty-git-analytics/src/report/models.rs
+++ b/crates/trusty-git-analytics/src/report/models.rs
@@ -91,6 +91,12 @@ pub struct WeeklyActivity {
     /// the aggregator note on its limitations.
     #[serde(default)]
     pub abandoned_pr_count: usize,
+    /// Commits in this bucket where `is_ai_assisted = 1` (issue #445).
+    /// Counts commits with a recognised `Co-Authored-By:` AI tool trailer
+    /// (Claude, GitHub Copilot, Cursor). Additive — downstream can sum to
+    /// get an org-wide AI-adoption count.
+    #[serde(default)]
+    pub ai_assisted_count: usize,
 }
 
 /// Per-week aggregated metrics across all developers and repositories.


### PR DESCRIPTION
Migration v17 and feature completions for #445 batch A:

- **Fix ticketed bug**: Removed `gh_bare` from `is_ticketed` predicate (~100% false-positive rate resolved)
- **AI tool detection**: Detect Claude, Copilot, Cursor from Co-Authored-By trailers
- **top_level_category**: Rollup emitted at classify time; new backfill subcommand
- **effort_tshirt**: Numeric 1–5 T-shirt sizing; new backfill subcommand
- **AI assisted count**: Report CSV surface of ai_assisted_count
- **4 new backfill subcommands**: `ticketed`, `ai-detection-commits`, `top-level`, `effort-tshirt`
- **675 tests pass**

Refs #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)