### PR TITLE
feat(tga): #445 batch B — persist fact_weekly_quality + surface complexity

### DIFF
--- a/crates/trusty-git-analytics/src/commands/backfill.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill.rs
@@ -22,6 +22,7 @@ use tga::collect::ticket::{extract_ticket_id, is_ticketed};
 use tga::core::config::{expand_path, Config};
 use tga::core::db::{CheckpointMode, Database};
 use tga::core::effort::{compute_effort, effort_tshirt_from_size, FORMULA_VERSION};
+use tga::report::aggregator::Aggregator;
 
 /// Arguments for `tga backfill`.
 #[derive(Args, Debug)]
@@ -166,6 +167,18 @@ pub enum BackfillSubcommand {
     /// Maps the text size label (XS/S/M/L/XL) to the numeric T-shirt integer
     /// (1–5) for existing rows that pre-date migration v17.
     EffortTshirt,
+    /// Recompute and persist per-engineer-per-week quality scores to
+    /// `fact_weekly_quality` for all historical data (issue #445 batch B).
+    ///
+    /// Reads the full `commits` table (left-joined against `classifications`
+    /// and `authors`), re-runs the aggregator's weekly bucketing logic, and
+    /// UPSERTs every (author, week, repo) grain into `fact_weekly_quality`.
+    /// Idempotent — running twice produces the same result. Supports --dry-run
+    /// to report the row count without writing.
+    ///
+    /// No LLM required — quality scoring is a pure formula applied to
+    /// per-bucket counts of reverts, bugfixes, and ticketed commits.
+    Quality,
 }
 
 /// Arguments for `tga backfill complexity`.
@@ -282,6 +295,7 @@ pub async fn run(config: Config, db: &mut Database, args: BackfillArgs) -> anyho
         ),
         BackfillSubcommand::TopLevel => backfill_top_level(db, args.dry_run),
         BackfillSubcommand::EffortTshirt => backfill_effort_tshirt(db, args.dry_run),
+        BackfillSubcommand::Quality => backfill_quality(db, args.dry_run),
     }
 }
 
@@ -1656,6 +1670,76 @@ fn backfill_effort_tshirt(db: &mut Database, dry_run: bool) -> anyhow::Result<()
     Ok(())
 }
 
+// ── backfill quality (issue #445 batch B) ─────────────────────────────────────
+
+/// Recompute and persist per-engineer-per-week quality scores for all historical
+/// data into `fact_weekly_quality`.
+///
+/// Why: `fact_weekly_quality` (migration v18) is populated automatically when a
+/// `tga report` run calls `Aggregator::persist_weekly_quality`. For databases
+/// collected before batch B was deployed, or for databases where quality rows
+/// need to be corrected after `tga backfill ticketed` changed the `ticketed`
+/// values, this subcommand recomputes the full table from scratch.
+/// What: delegates to `Aggregator::build` (which re-aggregates the commits
+/// table) and then calls `Aggregator::persist_weekly_quality`. The aggregator
+/// shares the same bucketing logic used at report time, so the stored values
+/// are guaranteed to match what a fresh `tga report` would produce. In
+/// `--dry-run` mode it counts the weekly-activity rows and prints the estimate
+/// without writing anything.
+/// Test: `tests::backfill_quality_populates_and_is_idempotent`.
+///
+/// # Errors
+///
+/// Propagates aggregator / database errors. The aggregator itself is non-fatal
+/// on empty databases (returns an empty `ReportData`).
+fn backfill_quality(db: &mut Database, dry_run: bool) -> anyhow::Result<()> {
+    // Build report data without writing CSV/JSON — we only need the
+    // weekly_activity slice to feed `persist_weekly_quality`.
+    let config = tga::core::config::Config::default();
+    // Use `build` instead of `build_filtered` to get all historical rows.
+    // Note: `Aggregator::build` also calls `persist_weekly_quality` internally,
+    // so we just let it do the work and report the final count.
+    if dry_run {
+        // Estimate: count distinct (author_email, iso_year, iso_week, repository)
+        // tuples that would be written by running the aggregator.
+        let candidate: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM ( \
+                     SELECT DISTINCT \
+                         COALESCE(NULLIF(a.canonical_email, ''), c.author_email) AS ae, \
+                         CAST(strftime('%Y', c.timestamp) AS INTEGER) AS yr, \
+                         CAST(strftime('%W', c.timestamp) AS INTEGER) AS wk, \
+                         c.repository \
+                     FROM commits c \
+                     LEFT JOIN authors a ON a.id = c.author_id \
+                 )",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        println!(
+            "Dry run — would write approximately {candidate} quality row(s) \
+             to fact_weekly_quality. No changes written."
+        );
+        return Ok(());
+    }
+
+    let data =
+        Aggregator::build(db, &config).map_err(|e| anyhow::anyhow!("aggregation failed: {e}"))?;
+
+    let written = Aggregator::persist_weekly_quality(db, &data)
+        .map_err(|e| anyhow::anyhow!("quality persist failed: {e}"))?;
+
+    println!("Backfilled fact_weekly_quality: {written} row(s) written (UPSERT semantics).");
+
+    // Flush the WAL so the new rows are durable in the main DB file.
+    if let Err(e) = db.wal_checkpoint(tga::core::db::CheckpointMode::Truncate) {
+        tracing::warn!(error = %e, "WAL TRUNCATE checkpoint failed after quality backfill");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2501,5 +2585,109 @@ mod tests {
             )
             .expect("read effort_tshirt");
         assert_eq!(tshirt, Some(4), "L size must map to effort_tshirt=4");
+    }
+
+    /// Why: regression guard for issue #445 batch B. `backfill_quality` must
+    /// populate `fact_weekly_quality` for all historical weeks, and running it
+    /// twice must produce the same result (idempotent UPSERT).
+    /// What: seeds two commits by the same author in the same ISO week with known
+    /// quality signals (one revert, one ticketed feature). Runs `backfill_quality`
+    /// once and checks the written row; runs it again and checks the row count
+    /// is still 1 (UPSERT did not duplicate).
+    /// Test: this test itself.
+    #[test]
+    fn backfill_quality_populates_and_is_idempotent() {
+        let mut db = Database::open_in_memory().expect("open");
+        // Seed: one revert + one ticketed feature by Alice in 2024-W03.
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                     repository, files_changed, insertions, deletions, is_merge, ticketed) \
+                 VALUES ('q1', 'Alice', 'alice@example.com', '2024-01-15T10:00:00+00:00', \
+                     'ENG-1 feature', 'repo-a', 1, 5, 1, 0, 1)",
+                [],
+            )
+            .expect("seed ticketed feature");
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                     repository, files_changed, insertions, deletions, is_merge, ticketed) \
+                 VALUES ('q2', 'Alice', 'alice@example.com', '2024-01-16T10:00:00+00:00', \
+                     'Revert \"ENG-1 feature\"', 'repo-a', 1, 2, 5, 0, 0)",
+                [],
+            )
+            .expect("seed revert");
+
+        // First backfill — should write 1 row.
+        backfill_quality(&mut db, false).expect("first backfill");
+        let count: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM fact_weekly_quality WHERE author_email = 'alice@example.com'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count after first backfill");
+        assert_eq!(count, 1, "first backfill must write exactly 1 row");
+
+        // Second backfill — idempotent: still 1 row.
+        backfill_quality(&mut db, false).expect("second backfill (idempotency)");
+        let count2: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM fact_weekly_quality WHERE author_email = 'alice@example.com'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count after second backfill");
+        assert_eq!(
+            count2, 1,
+            "second backfill must not add duplicate rows (UPSERT semantics)"
+        );
+
+        // Verify the quality_score is plausible (1 revert, 1 ticketed, 2 commits,
+        // 0 bugfixes): 0.35*(1-0.5) + 0.40*(1-0) + 0.25*0.5 = 0.175+0.40+0.125 = 0.7.
+        let score: f64 = db
+            .connection()
+            .query_row(
+                "SELECT quality_score FROM fact_weekly_quality WHERE author_email = 'alice@example.com'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read quality_score");
+        assert!(
+            (score - 0.700).abs() < 0.001,
+            "quality_score must be ~0.70 for this fixture, got {score:.6}"
+        );
+    }
+
+    /// Why: regression guard for issue #445 batch B. `backfill_quality --dry-run`
+    /// must estimate the row count without writing to `fact_weekly_quality`.
+    /// What: seed two commits; run dry-run backfill; assert `fact_weekly_quality`
+    /// is still empty and the exit code is Ok.
+    /// Test: this test itself.
+    #[test]
+    fn backfill_quality_dry_run_does_not_write() {
+        let mut db = Database::open_in_memory().expect("open");
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                     repository, files_changed, insertions, deletions, is_merge) \
+                 VALUES ('dq1', 'Bob', 'bob@example.com', '2024-02-05T10:00:00+00:00', \
+                     'feat: x', 'repo-b', 1, 3, 1, 0)",
+                [],
+            )
+            .expect("seed commit");
+
+        backfill_quality(&mut db, true).expect("dry-run quality backfill must not error");
+
+        let count: i64 = db
+            .connection()
+            .query_row("SELECT COUNT(*) FROM fact_weekly_quality", [], |r| r.get(0))
+            .expect("count after dry-run");
+        assert_eq!(
+            count, 0,
+            "dry-run must not write any rows to fact_weekly_quality"
+        );
     }
 }

--- a/crates/trusty-git-analytics/src/core/db/migrations.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations.rs
@@ -111,6 +111,11 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "pushdown_445",
         sql: include_str!("sql/0017_pushdown_445.sql"),
     },
+    Migration {
+        version: 18,
+        name: "fact_weekly_quality",
+        sql: include_str!("sql/0018_fact_weekly_quality.sql"),
+    },
 ];
 
 /// Ensure the `schema_migrations` bookkeeping table exists.
@@ -268,6 +273,124 @@ mod tests {
             top,
             Some("feature".to_string()),
             "top_level_category must be 'feature'"
+        );
+    }
+
+    /// Why: regression guard for issue #445 batch B. Migration v18 creates
+    /// `fact_weekly_quality` with all required columns and a PRIMARY KEY on
+    /// (author_email, iso_year, iso_week, repository).
+    /// What: opens an in-memory DB (which runs all migrations up to v18),
+    /// UPSERTs a quality row, reads it back, verifies all columns, and
+    /// confirms that re-inserting the same grain key overwrites rather than
+    /// duplicating (UPSERT semantics).
+    /// Test: this test itself.
+    #[test]
+    fn migration_v18_creates_fact_weekly_quality() {
+        let db = Database::open_in_memory().expect("open db");
+        let conn = db.connection();
+
+        // Insert a quality row.
+        conn.execute(
+            "INSERT OR REPLACE INTO fact_weekly_quality \
+             (author_email, iso_year, iso_week, repository, quality_score, quality_tshirt, \
+              revert_count, bugfix_count, ticketed_count, commit_count, formula_version, \
+              computed_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                "alice@example.com",
+                2026_i64,
+                5_i64,
+                "testrepo",
+                0.6875_f64,
+                4_i64,
+                1_i64,
+                1_i64,
+                2_i64,
+                4_i64,
+                "v1",
+                1_000_000_i64,
+            ],
+        )
+        .expect("insert quality row");
+
+        // Read it back and verify columns.
+        let (score, tshirt, reverts, bugfixes, ticketed, commits): (f64, i64, i64, i64, i64, i64) =
+            conn.query_row(
+                "SELECT quality_score, quality_tshirt, revert_count, bugfix_count, \
+                 ticketed_count, commit_count \
+                 FROM fact_weekly_quality \
+                 WHERE author_email = 'alice@example.com' AND iso_year = 2026 \
+                   AND iso_week = 5 AND repository = 'testrepo'",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                    ))
+                },
+            )
+            .expect("read back");
+        assert!(
+            (score - 0.6875).abs() < 1e-9,
+            "quality_score must be 0.6875, got {score}"
+        );
+        assert_eq!(tshirt, 4, "quality_tshirt must be 4");
+        assert_eq!(reverts, 1);
+        assert_eq!(bugfixes, 1);
+        assert_eq!(ticketed, 2);
+        assert_eq!(commits, 4);
+
+        // Verify UPSERT: second insert with updated score must overwrite (not duplicate).
+        conn.execute(
+            "INSERT OR REPLACE INTO fact_weekly_quality \
+             (author_email, iso_year, iso_week, repository, quality_score, quality_tshirt, \
+              revert_count, bugfix_count, ticketed_count, commit_count, formula_version, \
+              computed_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                "alice@example.com",
+                2026_i64,
+                5_i64,
+                "testrepo",
+                1.0_f64, // updated score
+                5_i64,
+                0_i64,
+                0_i64,
+                4_i64,
+                4_i64,
+                "v1",
+                2_000_000_i64,
+            ],
+        )
+        .expect("upsert quality row");
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM fact_weekly_quality \
+                 WHERE author_email = 'alice@example.com' AND iso_year = 2026 \
+                   AND iso_week = 5 AND repository = 'testrepo'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count");
+        assert_eq!(count, 1, "UPSERT must not duplicate the grain row");
+
+        let new_score: f64 = conn
+            .query_row(
+                "SELECT quality_score FROM fact_weekly_quality \
+                 WHERE author_email = 'alice@example.com' AND iso_year = 2026 \
+                   AND iso_week = 5 AND repository = 'testrepo'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("new score");
+        assert!(
+            (new_score - 1.0).abs() < 1e-9,
+            "UPSERT must overwrite the score with 1.0, got {new_score}"
         );
     }
 

--- a/crates/trusty-git-analytics/src/core/db/sql/0018_fact_weekly_quality.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0018_fact_weekly_quality.sql
@@ -1,0 +1,54 @@
+-- Migration v18: fact_weekly_quality — persist per-engineer-per-week quality
+-- scores to the database so downstream warehouses can join on them without
+-- re-running the aggregator (issue #445, batch B).
+--
+-- Grain: one row per (author_email, iso_year, iso_week, repository).
+-- Quality is recomputed by the aggregator each time a report runs and
+-- UPSERTed here so the table always reflects the corrected ticketed logic
+-- introduced by batch A (migration v17).
+--
+-- All additive — no existing columns are modified, no data is removed.
+
+CREATE TABLE IF NOT EXISTS fact_weekly_quality (
+    -- Author identity key (canonical email, matching commits.author_email /
+    -- authors.canonical_email). Stable across renames.
+    author_email     TEXT    NOT NULL,
+    -- ISO-8601 year component of the week label (YYYY).
+    iso_year         INTEGER NOT NULL,
+    -- ISO-8601 week number (1–53).
+    iso_week         INTEGER NOT NULL,
+    -- Repository scope — matches commits.repository. Included so per-repo
+    -- quality aggregations are possible downstream without a separate join.
+    repository       TEXT    NOT NULL,
+    -- Composite quality score in [0.0, 1.0] (higher is better).
+    -- Formula: 0.35*(1-revert_rate) + 0.40*(1-bugfix_rate) + 0.25*ticket_rate.
+    quality_score    REAL    NOT NULL,
+    -- T-shirt bucket 1–5 derived from quality_score (5 = best).
+    quality_tshirt   INTEGER NOT NULL,
+    -- Raw input counts that feed the formula (auditable by downstream).
+    revert_count     INTEGER NOT NULL DEFAULT 0,
+    bugfix_count     INTEGER NOT NULL DEFAULT 0,
+    ticketed_count   INTEGER NOT NULL DEFAULT 0,
+    commit_count     INTEGER NOT NULL DEFAULT 0,
+    -- Formula version string ("v1") so consumers can detect future changes.
+    formula_version  TEXT    NOT NULL DEFAULT 'v1',
+    -- Unix timestamp (seconds) when this row was last computed.
+    computed_at      INTEGER NOT NULL DEFAULT 0,
+
+    -- Grain uniqueness: one row per (author, year, week, repo).
+    -- ON CONFLICT REPLACE enables UPSERT semantics at the application layer
+    -- via INSERT OR REPLACE.
+    PRIMARY KEY (author_email, iso_year, iso_week, repository)
+);
+
+-- Index to support weekly slices (by week label) for reporting queries.
+CREATE INDEX IF NOT EXISTS idx_fwq_week
+    ON fact_weekly_quality (iso_year, iso_week);
+
+-- Index to support per-author longitudinal queries.
+CREATE INDEX IF NOT EXISTS idx_fwq_author
+    ON fact_weekly_quality (author_email);
+
+-- Index to support per-repo quality filtering.
+CREATE INDEX IF NOT EXISTS idx_fwq_repo
+    ON fact_weekly_quality (repository);

--- a/crates/trusty-git-analytics/src/report/aggregator.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator.rs
@@ -13,6 +13,7 @@ use tracing::{debug, warn};
 
 use crate::core::config::Config;
 use crate::core::db::Database;
+use crate::core::quality::QUALITY_FORMULA_VERSION;
 use crate::report::errors::{ReportError, Result};
 use crate::report::models::{
     ActivityWeights, AuthorSummary, DeveloperActivitySummary, DoraMetrics, QualitySummary,
@@ -47,6 +48,10 @@ struct CommitRow {
     /// True when the commit carries a recognised AI co-authorship trailer
     /// (issue #445: `Co-Authored-By: Claude/Copilot/Cursor`).
     is_ai_assisted: bool,
+    /// LLM-assigned complexity score 1–5 from `classifications.complexity`
+    /// (issue #445 batch B, request #6). `None` for non-LLM classifications
+    /// or commits without a classification row.
+    complexity: Option<i64>,
 }
 
 /// Minimal PR row used by velocity / DORA computations and (issue #377)
@@ -210,6 +215,27 @@ impl Aggregator {
         // would otherwise silently break week-over-week deltas.
         check_weekly_coverage_drift(db, &data.weekly_metrics);
 
+        // Issue #445 batch B: persist per-engineer-per-week quality scores to
+        // `fact_weekly_quality` so downstream warehouses can query without
+        // re-running the aggregator. Non-fatal: a persistence failure is
+        // logged but does not abort report generation (the in-memory data is
+        // still complete and formatters will still write their files).
+        match Self::persist_weekly_quality(db, &data) {
+            Ok(n) => {
+                tracing::debug!(
+                    rows = n,
+                    "persisted weekly quality rows to fact_weekly_quality"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "WARNING: could not persist to fact_weekly_quality; \
+                     run `tga backfill quality` to retry. Report generation continues."
+                );
+            }
+        }
+
         if unresolved_db > 0 {
             tracing::warn!(
                 count = unresolved_db,
@@ -342,12 +368,14 @@ impl Aggregator {
         // `LOWER(COALESCE(...)) = LOWER(?)` so that the filter still works
         // for commits that pre-date `upsert_observed_authors` and fall back
         // to the raw `c.author_email` field.
+        // Issue #445 batch B (request #6): include cl.complexity so the weekly
+        // aggregator can surface avg_complexity without a second DB scan.
         let sql_base = "SELECT c.sha, \
                         COALESCE(a.canonical_name,  c.author_name)  AS author_name, \
                         COALESCE(NULLIF(a.canonical_email, ''), c.author_email) AS author_email, \
                         c.timestamp, c.repository, \
                         c.insertions, c.deletions, c.files_changed, cl.category, \
-                        c.message, c.ticketed, c.is_ai_assisted \
+                        c.message, c.ticketed, c.is_ai_assisted, cl.complexity \
                  FROM commits c \
                  LEFT JOIN authors a ON a.id = c.author_id \
                  LEFT JOIN classifications cl ON cl.id = c.classification_id";
@@ -361,6 +389,9 @@ impl Aggregator {
             // Issue #445: column added in migration v17; default 0 for rows
             // that pre-date the migration (SQLite returns NULL as 0 via unwrap_or).
             let is_ai_assisted: i64 = row.get(11).unwrap_or(0);
+            // Issue #445 batch B (request #6): complexity from classifications.
+            // NULL for non-LLM tiers; pre-migration rows also return NULL.
+            let complexity: Option<i64> = row.get(12).unwrap_or(None);
             Ok(CommitRow {
                 sha: row.get(0)?,
                 author_name: row.get(1)?,
@@ -374,6 +405,7 @@ impl Aggregator {
                 message: row.get(9)?,
                 ticketed: ticketed != 0,
                 is_ai_assisted: is_ai_assisted != 0,
+                complexity,
             })
         };
 
@@ -530,6 +562,141 @@ impl Aggregator {
         let _ = acc.dev_ticketed;
         data
     }
+
+    /// Persist per-engineer-per-week quality scores to `fact_weekly_quality`.
+    ///
+    /// Why: downstream warehouses read `tga.db` directly; storing quality rows
+    /// avoids requiring consumers to re-implement the scoring formula in SQL.
+    /// This is called immediately after the aggregation so the stored values
+    /// always reflect the corrected ticketed logic from batch A (migration v17).
+    /// What: UPSERTs one row per [`WeeklyActivity`] into `fact_weekly_quality`,
+    /// batching in chunks of 500. The grain key (author_email, iso_year,
+    /// iso_week, repository) matches the aggregator's weekly bucket exactly.
+    /// Rows whose ISO week label cannot be parsed are skipped with a warning.
+    /// Test: `report::tests::persist_weekly_quality_upserts_rows` (seed the
+    /// aggregator, call persist, assert rows appear in the table + idempotent).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReportError::Core`] if any SQLite operation fails.
+    pub fn persist_weekly_quality(db: &Database, data: &ReportData) -> Result<usize> {
+        if data.weekly_activity.is_empty() {
+            return Ok(0);
+        }
+        let computed_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        let rows: Vec<_> = data
+            .weekly_activity
+            .iter()
+            .filter_map(|wa| {
+                let (iso_year, iso_week) = match parse_week_label_to_parts(&wa.week) {
+                    Some(p) => p,
+                    None => {
+                        tracing::warn!(
+                            week = %wa.week,
+                            "persist_weekly_quality: cannot parse week label; skipping row"
+                        );
+                        return None;
+                    }
+                };
+                // Derive quality_tshirt integer from the string ("1".."5").
+                let quality_tshirt: i64 = wa.quality_tshirt.parse().unwrap_or(
+                    crate::core::quality::size_for_quality_score(wa.quality_score) as i64,
+                );
+                Some((
+                    wa.author.clone(), // Note: this is the display name; use email below.
+                    iso_year,
+                    iso_week,
+                    wa.repository.clone(),
+                    wa.quality_score,
+                    quality_tshirt,
+                    wa.revert_count as i64,
+                    wa.bugfix_count as i64,
+                    wa.ticketed_count as i64,
+                    wa.commit_count as i64,
+                    computed_at,
+                ))
+            })
+            .collect();
+
+        // We need author email, not display name — rebuild a lookup from
+        // ReportData.authors (email → display_name is available; we need the
+        // reverse). Since author identity in weekly_activity is keyed by email
+        // in the aggregator and resolved to display_name at materialisation,
+        // we persist the display name as the author_email key when emails are
+        // not directly available in WeeklyActivity. For now we use the author
+        // field directly as the stable key because the aggregator resolves
+        // canonical emails to display names. To keep the grain key correct,
+        // use a display_name→email map derived from author_summaries.
+        let name_to_email: std::collections::HashMap<String, String> = data
+            .authors
+            .iter()
+            .map(|a| (a.name.clone(), a.email.clone()))
+            .collect();
+
+        let mut written = 0usize;
+        for chunk in rows.chunks(500) {
+            let conn = db.connection();
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(crate::core::TgaError::from)?;
+            {
+                let mut stmt = tx
+                    .prepare(
+                        "INSERT OR REPLACE INTO fact_weekly_quality \
+                         (author_email, iso_year, iso_week, repository, quality_score, \
+                          quality_tshirt, revert_count, bugfix_count, ticketed_count, \
+                          commit_count, formula_version, computed_at) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                    )
+                    .map_err(crate::core::TgaError::from)?;
+                for (author_display, iso_year, iso_week, repo, qs, qt, rc, bc, tc, cc, ca) in chunk
+                {
+                    // Resolve the canonical email from the display name; fall
+                    // back to the display name itself when no match exists (can
+                    // happen for uncommitted / alias-unresolved identities).
+                    let author_email = name_to_email
+                        .get(author_display)
+                        .cloned()
+                        .unwrap_or_else(|| author_display.clone());
+                    stmt.execute(rusqlite::params![
+                        author_email,
+                        iso_year,
+                        iso_week,
+                        repo,
+                        qs,
+                        qt,
+                        rc,
+                        bc,
+                        tc,
+                        cc,
+                        QUALITY_FORMULA_VERSION,
+                        ca,
+                    ])
+                    .map_err(crate::core::TgaError::from)?;
+                    written += 1;
+                }
+            }
+            tx.commit().map_err(crate::core::TgaError::from)?;
+        }
+        Ok(written)
+    }
+}
+
+/// Parse an ISO week label `"YYYY-Www"` into `(iso_year, iso_week)`.
+///
+/// Why: `fact_weekly_quality` stores year and week as separate INTEGER columns
+/// so warehouse tools can filter by year or week number without string parsing.
+/// What: splits on `-W`, parses both halves as integers.
+/// Test: exercised by `persist_weekly_quality` via the report tests.
+fn parse_week_label_to_parts(label: &str) -> Option<(i64, i64)> {
+    let (y, w) = label.split_once("-W")?;
+    let year: i64 = y.parse().ok()?;
+    let week: i64 = w.parse().ok()?;
+    Some((year, week))
 }
 
 // ===========================================================================
@@ -616,6 +783,12 @@ struct WeekAcc {
     ticketed: usize,
     /// AI-assisted commits in this bucket (issue #445: `is_ai_assisted=1`).
     ai_assisted: usize,
+    /// Running sum of non-null complexity scores for this bucket (issue #445
+    /// batch B, request #6). Used with `complexity_count` to compute the
+    /// mean at materialisation time. Only LLM-classified commits contribute.
+    complexity_sum: i64,
+    /// Number of commits in this bucket with a non-null complexity score.
+    complexity_count: usize,
 }
 
 /// Cross-developer per-week running totals during accumulation.
@@ -740,6 +913,8 @@ fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulators {
             bugfixes: 0,
             ticketed: 0,
             ai_assisted: 0,
+            complexity_sum: 0,
+            complexity_count: 0,
         });
         w.commits += 1;
         w.insertions += row.insertions;
@@ -764,6 +939,13 @@ fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulators {
         // so the weekly activity report can surface AI-adoption rates.
         if row.is_ai_assisted {
             w.ai_assisted += 1;
+        }
+        // Issue #445 batch B (request #6): accumulate complexity sum so
+        // materialize_weekly_activity can compute avg_complexity without a
+        // second pass. Only non-null values (LLM-classified commits) contribute.
+        if let Some(c) = row.complexity {
+            w.complexity_sum += c;
+            w.complexity_count += 1;
         }
 
         // Category totals.
@@ -910,6 +1092,15 @@ fn materialize_weekly_activity(
                 .or_else(|| abandoned_by_week_identity.get(&(week.clone(), email.to_lowercase())))
                 .copied()
                 .unwrap_or(0);
+            // Issue #445 batch B (request #6): compute the mean complexity for
+            // this bucket from the running sum. Returns None when no commit has
+            // a non-null complexity score (all-null → None, not 0.0, so
+            // downstream consumers can distinguish "no data" from "scored 0").
+            let avg_complexity = if w.complexity_count > 0 {
+                Some(w.complexity_sum as f64 / w.complexity_count as f64)
+            } else {
+                None
+            };
             WeeklyActivity {
                 week,
                 author,
@@ -926,6 +1117,7 @@ fn materialize_weekly_activity(
                 abandoned_pr_count,
                 // Issue #445: AI-assisted commits in this (week, engineer, repo) bucket.
                 ai_assisted_count: w.ai_assisted,
+                avg_complexity,
             }
         })
         .collect()

--- a/crates/trusty-git-analytics/src/report/formatters/csv.rs
+++ b/crates/trusty-git-analytics/src/report/formatters/csv.rs
@@ -77,9 +77,16 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
         "abandoned_pr_count",
         // Issue #445: AI-adoption column — commits with a known AI co-author trailer.
         "ai_assisted_count",
+        // Issue #445 batch B (request #6): mean LLM-assigned complexity for
+        // this bucket; empty string when no commit has a complexity score.
+        "avg_complexity",
     ])?;
     for row in &data.weekly_activity {
         let categories = serialize_categories(&row.categories);
+        let avg_complexity_str = match row.avg_complexity {
+            Some(c) => format!("{:.4}", c),
+            None => String::new(),
+        };
         w.write_record([
             row.week.as_str(),
             row.author.as_str(),
@@ -95,6 +102,7 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
             row.quality_tshirt.as_str(),
             &row.abandoned_pr_count.to_string(),
             &row.ai_assisted_count.to_string(),
+            avg_complexity_str.as_str(),
         ])?;
     }
     w.flush()?;

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -662,6 +662,210 @@ mod tests {
         );
     }
 
+    // =========================================================================
+    // fact_weekly_quality persistence tests (issue #445 batch B, task 1)
+    // =========================================================================
+
+    /// Why: `persist_weekly_quality` must UPSERT the same values the aggregator
+    /// computed into `fact_weekly_quality`, and running it twice must not
+    /// duplicate rows (idempotent).
+    /// What: seed the quality DB, build a report (which calls persist internally),
+    /// then call `persist_weekly_quality` again; assert the row count is still 1
+    /// and the values match the aggregator's weekly_activity output.
+    /// Test: this test itself.
+    #[test]
+    fn persist_weekly_quality_upserts_rows_and_is_idempotent() {
+        let db = seed_quality_db();
+        let cfg = baseline_config();
+        let data = Aggregator::build(&db, &cfg).expect("aggregate (first — writes quality rows)");
+
+        // The aggregator's build path already called persist internally.
+        let wa = &data.weekly_activity[0];
+
+        // Read back the persisted row.
+        let (score, tshirt, rc, bc, tc, cc): (f64, i64, i64, i64, i64, i64) = db
+            .connection()
+            .query_row(
+                "SELECT quality_score, quality_tshirt, revert_count, bugfix_count, \
+                 ticketed_count, commit_count FROM fact_weekly_quality \
+                 WHERE author_email = 'carol@example.com'",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                    ))
+                },
+            )
+            .expect("read persisted quality row");
+
+        // Values must match the aggregator's weekly_activity output.
+        assert!(
+            (score - wa.quality_score).abs() < 1e-9,
+            "persisted quality_score {score} must match aggregator score {}",
+            wa.quality_score
+        );
+        assert_eq!(tshirt, wa.quality_tshirt.parse::<i64>().unwrap_or(0));
+        assert_eq!(rc, wa.revert_count as i64);
+        assert_eq!(bc, wa.bugfix_count as i64);
+        assert_eq!(tc, wa.ticketed_count as i64);
+        assert_eq!(cc, wa.commit_count as i64);
+
+        // Idempotency: call persist again; row count must still be 1.
+        Aggregator::persist_weekly_quality(&db, &data).expect("second persist");
+        let count: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM fact_weekly_quality WHERE author_email = 'carol@example.com'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count");
+        assert_eq!(count, 1, "UPSERT must not duplicate the grain row");
+    }
+
+    // =========================================================================
+    // avg_complexity tests (issue #445 batch B, task 2)
+    // =========================================================================
+
+    /// Why: `avg_complexity` must be `None` when no commit in the bucket has a
+    /// non-null `classifications.complexity` value, and `Some(mean)` when at
+    /// least one commit does. This validates both the all-null and mixed cases.
+    /// What: seeds a classification with `complexity = 3`, links it to one
+    /// commit; seeds a second commit with no complexity. Asserts avg = 3.0 (only
+    /// non-null values average) and the all-null baseline returns None.
+    /// Test: this test itself.
+    #[test]
+    fn avg_complexity_is_mean_of_non_null_values() {
+        let db = Database::open_in_memory().expect("open db");
+        let conn = db.connection();
+
+        // Insert a classification with complexity = 3.
+        conn.execute(
+            "INSERT INTO classifications (id, category, subcategory, confidence, method, complexity) \
+             VALUES (10, 'feature', NULL, 0.9, 'llm', 3)",
+            [],
+        )
+        .expect("insert classification with complexity");
+        // Insert a classification with complexity = 5.
+        conn.execute(
+            "INSERT INTO classifications (id, category, subcategory, confidence, method, complexity) \
+             VALUES (11, 'feature', NULL, 0.9, 'llm', 5)",
+            [],
+        )
+        .expect("insert classification complexity=5");
+
+        // Three commits by Eve in 2024-W03: two with complexity, one without.
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, classification_id) \
+             VALUES ('e1', 'Eve', 'eve@complexity.example', '2024-01-15T10:00:00+00:00', \
+                 'feat: x', 'repo-c', 1, 5, 1, 0, 10)",
+            [],
+        )
+        .expect("commit with complexity=3");
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, classification_id) \
+             VALUES ('e2', 'Eve', 'eve@complexity.example', '2024-01-16T10:00:00+00:00', \
+                 'feat: y', 'repo-c', 1, 3, 1, 0, 11)",
+            [],
+        )
+        .expect("commit with complexity=5");
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge) \
+             VALUES ('e3', 'Eve', 'eve@complexity.example', '2024-01-17T10:00:00+00:00', \
+                 'chore: no complexity', 'repo-c', 1, 1, 1, 0)",
+            [],
+        )
+        .expect("commit without complexity");
+
+        let cfg = baseline_config();
+        let data = Aggregator::build(&db, &cfg).expect("aggregate");
+
+        // Find Eve's weekly activity row.
+        let wa = data
+            .weekly_activity
+            .iter()
+            .find(|r| r.author == "Eve" || r.author.contains("eve@complexity"))
+            .expect("Eve's weekly row must exist");
+
+        // Expected: avg of [3, 5] = 4.0 (null-complexity commit is excluded).
+        assert_eq!(
+            wa.avg_complexity,
+            Some(4.0),
+            "avg_complexity must be 4.0 (mean of 3 and 5)"
+        );
+    }
+
+    /// Why: when ALL commits in a bucket have null complexity (e.g. all resolved
+    /// by exact_rule), `avg_complexity` must be `None` — not `Some(0.0)`.
+    /// What: uses `seed_db()` which has no complexity values; asserts None.
+    /// Test: this test itself.
+    #[test]
+    fn avg_complexity_is_none_when_all_null() {
+        let db = seed_db();
+        let cfg = baseline_config();
+        let data = Aggregator::build(&db, &cfg).expect("aggregate");
+
+        for wa in &data.weekly_activity {
+            assert_eq!(
+                wa.avg_complexity, None,
+                "avg_complexity must be None when no classifications carry a complexity score"
+            );
+        }
+    }
+
+    /// Why: the weekly CSV must include the `avg_complexity` column so warehouse
+    /// ingestion picks it up without schema changes.
+    /// What: seeds a classification with complexity, builds report, writes CSV,
+    /// asserts the header contains `avg_complexity` and a data row has a value.
+    /// Test: this test itself.
+    #[test]
+    fn weekly_csv_includes_avg_complexity_column() {
+        let db = Database::open_in_memory().expect("open db");
+        let conn = db.connection();
+        conn.execute(
+            "INSERT INTO classifications (id, category, subcategory, confidence, method, complexity) \
+             VALUES (20, 'feature', NULL, 0.9, 'llm', 4)",
+            [],
+        )
+        .expect("insert classification");
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, classification_id) \
+             VALUES ('cx1', 'Frank', 'frank@example.com', '2024-01-15T10:00:00+00:00', \
+                 'feat: z', 'repo-a', 1, 5, 1, 0, 20)",
+            [],
+        )
+        .expect("insert commit");
+
+        let cfg = baseline_config();
+        let data = Aggregator::build(&db, &cfg).expect("aggregate");
+
+        let dir = tmp_dir("csv-complexity");
+        let path = csv_fmt::write_weekly_csv(&data, &dir).expect("write weekly csv");
+        let text = std::fs::read_to_string(&path).expect("read csv");
+        let header = text.lines().next().expect("header");
+
+        assert!(
+            header.contains("avg_complexity"),
+            "weekly CSV header must contain avg_complexity; got: {header}"
+        );
+        // The data row should have a non-empty avg_complexity (4.0000).
+        assert!(
+            text.contains("4.0000"),
+            "CSV should contain avg_complexity = 4.0000 for Frank's row; got:\n{text}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn aggregator_author_filter_none_returns_all() {
         // Why: omitting `--author` must behave identically to the pre-existing

--- a/crates/trusty-git-analytics/src/report/models.rs
+++ b/crates/trusty-git-analytics/src/report/models.rs
@@ -97,6 +97,13 @@ pub struct WeeklyActivity {
     /// get an org-wide AI-adoption count.
     #[serde(default)]
     pub ai_assisted_count: usize,
+    /// Mean LLM-assigned complexity score (1–5) across commits in this bucket
+    /// that have a non-null `classifications.complexity` value (issue #445
+    /// batch B, request #6). `None` when no commit in the bucket has been
+    /// assigned a complexity score (e.g., all classified by rules/external
+    /// sources or no classification at all).
+    #[serde(default)]
+    pub avg_complexity: Option<f64>,
 }
 
 /// Per-week aggregated metrics across all developers and repositories.


### PR DESCRIPTION
## Summary
Batch B of #445 deliverables: migration v18 adds `fact_weekly_quality` table (per-author × ISO-week × repo: quality_score, quality_tshirt, revert/bugfix/ticketed/commit counts, formula_version), UPSERTed from the aggregator (shares core/quality.rs, non-fatal error handling). `tga backfill quality` CLI command loads historical weeks. Complexity surfaced as `avg_complexity` on WeeklyActivity + weekly CSV (Option A: reads existing classifications.complexity, no commits denormalization).

Second of three batches for #445.

Refs #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)