### PR TITLE
chore(tga): bump to 2.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.3.1"
+version = "2.4.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for


### PR DESCRIPTION
Releases the #445 epic (batches A/B/C, all merged).

Minor bump reflects new features:
- Ticketed fix
- AI flags
- top_level_category
- effort_tshirt
- quality persistence
- complexity surfacing
- rule files
- percentile binning

🤖 Generated with [Claude Code](https://claude.com/claude-code)