### PR TITLE
feat(trusty-common): crates.io update-notification for user-facing CLIs

### DIFF
--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -58,7 +58,7 @@ redb               = { workspace = true }
 dashmap            = { workspace = true }
 rust-embed         = { workspace = true }
 mime_guess         = { workspace = true }
-trusty-common      = { workspace = true, features = ["symgraph", "cli-help"] }
+trusty-common      = { workspace = true, features = ["symgraph", "cli-help", "update-check"] }
 tree-sitter            = { workspace = true }
 tree-sitter-rust       = { workspace = true }
 tree-sitter-typescript = { workspace = true }

--- a/crates/trusty-analyze/src/main.rs
+++ b/crates/trusty-analyze/src/main.rs
@@ -366,6 +366,27 @@ async fn main() -> Result<()> {
     };
     let search = TrustySearchClient::new(&cli.search_url);
 
+    // Update check: run only for human-facing commands, never when serving MCP
+    // stdio. Two subcommands speak JSON-RPC 2.0 over stdio and must be excluded:
+    // - `serve --mcp`: HTTP daemon + inline MCP stdio loop
+    // - `mcp`: standalone MCP stdio server pointed at the analyzer daemon
+    // In both cases stderr noise may disrupt clients that relay stderr. For
+    // `serve` without `--mcp` (HTTP daemon only), the process is long-running
+    // with no interactive user to read a banner, so we skip it there too. The
+    // check is throttled to once per 24 h (on-disk cache) so it is a
+    // sub-millisecond cache read on typical invocations.
+    let is_mcp_path = matches!(cli.cmd, Cmd::Serve { .. } | Cmd::Mcp { .. });
+    if !is_mcp_path {
+        if let Some(info) = trusty_common::update::check_throttled(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        )
+        .await
+        {
+            eprintln!("{}", trusty_common::update::notice(&info));
+        }
+    }
+
     match cli.cmd {
         Cmd::Serve {
             foreground: _,

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -345,3 +345,10 @@ tickets = ["mcp", "dep:chrono", "dep:uuid", "dep:base64", "dep:thiserror", "dep:
 # `serde_yaml`, `strsim`, `indexmap`, and `thiserror` (all otherwise optional).
 # Issue #216.
 cli-help = ["dep:serde_yaml", "dep:strsim", "dep:indexmap", "dep:thiserror"]
+# Enables the `update` module: throttled crates.io update-notification helper.
+# Checks once per 24 h via a JSON cache file in the OS cache directory. Opt-out
+# via `TRUSTY_NO_UPDATE_CHECK` or `CI` environment variables. Reuses the
+# unconditional `reqwest`, `serde`, `serde_json`, `dirs`, and `tracing` deps —
+# the feature flag controls module compilation only, adding zero new transitive
+# dependencies to builds that enable it.
+update-check = []

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -256,6 +256,24 @@ pub mod help;
 #[cfg(feature = "monitor-tui")]
 pub mod monitor;
 
+/// Throttled crates.io update-notification helper.
+///
+/// Why: User-facing CLIs should nudge operators when a newer release is
+/// available without adding perceptible latency. A shared implementation
+/// keeps the throttle, cache, opt-out, and User-Agent logic consistent across
+/// every consumer in the workspace.
+/// What: Gated behind the `update-check` feature. Exposes
+/// [`update::check_throttled`] (the main entry — reads a per-crate JSON cache
+/// under the OS cache dir, queries crates.io at most once per 24 h),
+/// [`update::check_crates_io`] (the raw network call), [`update::notice`]
+/// (formatted upgrade message), and [`update::UpdateInfo`] (the result type).
+/// All failures degrade to `None` — the check is best-effort and will not
+/// panic or stall a CLI.
+/// Opt-out: set `TRUSTY_NO_UPDATE_CHECK` or `CI` to any non-empty value.
+/// Test: `cargo test -p trusty-common --features update-check`.
+#[cfg(feature = "update-check")]
+pub mod update;
+
 pub use chat::{
     ChatEvent, ChatProvider, LocalModelConfig, OllamaProvider, OpenRouterProvider, ToolCall,
     ToolDef, auto_detect_local_provider,

--- a/crates/trusty-common/src/update/mod.rs
+++ b/crates/trusty-common/src/update/mod.rs
@@ -1,0 +1,363 @@
+//! Crates.io-based update notification helper.
+//!
+//! Why: User-facing trusty-* CLIs should nudge operators when a newer release
+//! is available, so they are not silently running stale binaries. Centralising
+//! the check here keeps the throttle, cache, opt-out, and User-Agent logic
+//! consistent across every consumer.
+//!
+//! What: [`check_throttled`] is the main entry point. It:
+//!   1. Returns `None` immediately when `TRUSTY_NO_UPDATE_CHECK` or `CI` is set.
+//!   2. Returns a cached result when the last network check was < 24 h ago.
+//!   3. Performs a non-blocking GET to `https://crates.io/api/v1/crates/{name}`
+//!      with a descriptive User-Agent, compares semver, caches the result, and
+//!      returns `Some(UpdateInfo)` when a newer stable version exists.
+//!
+//! All failures (network, parse, 403, missing field) degrade gracefully to
+//! `None` — the check is best-effort and must never panic or stall a CLI.
+//!
+//! Test: `cargo test -p trusty-common --features update-check`.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+// ─── Opt-out env vars ────────────────────────────────────────────────────────
+
+/// Set to any non-empty value to disable update checks entirely.
+pub const NO_UPDATE_CHECK_ENV: &str = "TRUSTY_NO_UPDATE_CHECK";
+
+/// Standard CI environment variable — update checks are suppressed when set.
+const CI_ENV: &str = "CI";
+
+/// How frequently to hit crates.io (24 hours in seconds).
+const CHECK_INTERVAL_SECS: u64 = 60 * 60 * 24;
+
+/// Network timeout for each crates.io request.
+const NETWORK_TIMEOUT_SECS: u64 = 4;
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+/// Metadata about an available update.
+///
+/// Why: A typed struct is easier to format and test than raw strings.
+/// What: Holds the crate name, the version currently installed, and the latest
+/// stable version seen on crates.io.
+/// Test: [`notice`] exercises all three fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateInfo {
+    /// The crate name as published on crates.io (e.g. `trusty-search`).
+    pub crate_name: String,
+    /// The version of the running binary (from `env!("CARGO_PKG_VERSION")`).
+    pub current: String,
+    /// The latest stable version reported by crates.io.
+    pub latest: String,
+}
+
+/// Produce a human-readable upgrade notice for `info`.
+///
+/// Why: A single formatting function keeps the message consistent and
+/// testable without coupling consumers to the wording.
+/// What: Returns a string like:
+/// `"⬆ Update available: trusty-search 0.20.0 (you have 0.19.0) — run: cargo install trusty-search --locked"`.
+/// Test: `notice_formats_correctly` in the `tests` module.
+pub fn notice(info: &UpdateInfo) -> String {
+    format!(
+        "⬆  Update available: {} {} (you have {}) — run: cargo install {} --locked",
+        info.crate_name, info.latest, info.current, info.crate_name
+    )
+}
+
+// ─── Cache types ─────────────────────────────────────────────────────────────
+
+/// On-disk cache record stored under the OS cache directory.
+///
+/// Why: Throttle crates.io requests to at most once per 24 h so the check
+/// does not add measurable latency on typical runs.
+/// What: JSON file with a Unix timestamp of the last check and the latest
+/// version string seen. A missing or corrupt file is silently treated as "no
+/// cache" — the next invocation will perform a fresh network check.
+/// Test: `cache_freshness_*` tests in this module.
+#[derive(Debug, Serialize, Deserialize)]
+struct CacheEntry {
+    /// Unix timestamp (seconds) of the last successful crates.io response.
+    last_check_unix: u64,
+    /// Latest stable version seen at `last_check_unix`.
+    latest_version: String,
+}
+
+// ─── Cache path resolution ───────────────────────────────────────────────────
+
+/// Resolve the path to the per-crate cache file.
+///
+/// Why: We need a stable, OS-appropriate location that survives reboots and
+/// is writable without elevated privileges.
+/// What: Returns `<cache_dir>/trusty-tools/update-check/<crate_name>.json`.
+/// Falls back to `<temp_dir>/trusty-tools-update-check/<crate_name>.json`
+/// when `dirs::cache_dir()` returns `None` (rare in containers).
+/// Test: Indirectly covered by the cache read/write helpers.
+fn cache_path(crate_name: &str) -> PathBuf {
+    let base = dirs::cache_dir()
+        .unwrap_or_else(|| std::env::temp_dir().join("trusty-tools-update-check-fallback"));
+    base.join("trusty-tools")
+        .join("update-check")
+        .join(format!("{crate_name}.json"))
+}
+
+// ─── Cache I/O ───────────────────────────────────────────────────────────────
+
+/// Read the cache file for `crate_name`, returning `None` on any failure.
+///
+/// Why: A corrupt or missing cache must not error — the caller treats `None`
+/// as "do a fresh network check", which is safe and correct.
+/// What: Reads the JSON file at [`cache_path`], deserializes a [`CacheEntry`],
+/// and returns it. Returns `None` on I/O errors, missing files, or invalid JSON.
+/// Test: `cache_round_trip` and `corrupt_cache_returns_none`.
+fn read_cache(crate_name: &str) -> Option<CacheEntry> {
+    let path = cache_path(crate_name);
+    let bytes = std::fs::read(&path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Write a cache entry for `crate_name`, ignoring any I/O errors.
+///
+/// Why: Cache writes are best-effort — a failure (permissions, disk full)
+/// should not propagate to the caller; the next run will simply re-check.
+/// What: Serializes `entry` to JSON and writes it to [`cache_path`], creating
+/// parent directories if necessary.
+/// Test: `cache_round_trip` writes then reads back and checks equality.
+fn write_cache(crate_name: &str, entry: &CacheEntry) {
+    let path = cache_path(crate_name);
+    // Best-effort: create parent dirs, silently ignore failures.
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_vec_pretty(entry) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+// ─── Semver comparison ───────────────────────────────────────────────────────
+
+/// Parse `MAJOR.MINOR.PATCH` from a version string, stripping pre-release /
+/// build-metadata suffixes and ignoring non-numeric segments.
+///
+/// Why: We intentionally avoid the `semver` crate (not a workspace dep) to
+/// keep the dependency surface minimal. The comparison logic required here is
+/// simple: a tuple of three integers.
+/// What: Returns `Some((major, minor, patch))` on success, `None` on any
+/// parse failure.
+/// Test: `semver_parse_strips_prerelease`, `semver_parse_handles_missing_patch`.
+fn parse_version(v: &str) -> Option<(u64, u64, u64)> {
+    // Strip pre-release / build-metadata suffix (everything after first '-' or '+').
+    let core = v.split(['-', '+']).next()?;
+    let mut parts = core.splitn(3, '.');
+    let major: u64 = parts.next()?.parse().ok()?;
+    let minor: u64 = parts.next().unwrap_or("0").parse().ok()?;
+    let patch: u64 = parts.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Return `true` when `latest_str` is strictly newer than `current_str`.
+///
+/// Why: The update check only fires for actual upgrades, not downgrades or
+/// equal versions.
+/// What: Parses both strings via [`parse_version`]; returns `false` on any
+/// parse failure (best-effort).
+/// Test: `semver_newer_returns_true`, `semver_equal_returns_false`,
+/// `semver_older_returns_false`, `semver_prerelease_stripped`.
+fn is_newer(latest_str: &str, current_str: &str) -> bool {
+    match (parse_version(latest_str), parse_version(current_str)) {
+        (Some(latest), Some(current)) => latest > current,
+        _ => false,
+    }
+}
+
+// ─── crates.io API types ─────────────────────────────────────────────────────
+
+/// Minimal subset of the crates.io `GET /api/v1/crates/{name}` response.
+///
+/// Why: We only need `max_stable_version` (or fallbacks); deserializing the
+/// full response shape is unnecessary and fragile.
+/// What: Wraps the `crate` top-level key in the crates.io JSON payload.
+/// Test: `check_crates_io` parses this shape.
+#[derive(Deserialize)]
+struct CratesIoResponse {
+    #[serde(rename = "crate")]
+    krate: CrateInfo,
+}
+
+#[derive(Deserialize)]
+struct CrateInfo {
+    /// The highest stable (non-pre-release) version.
+    max_stable_version: Option<String>,
+    /// Newest version including pre-releases — fallback when stable is absent.
+    newest_version: Option<String>,
+    /// Alternative field name seen in some older API responses.
+    max_version: Option<String>,
+}
+
+// ─── Network check ───────────────────────────────────────────────────────────
+
+/// Query crates.io for the latest stable version of `crate_name`.
+///
+/// Why: One canonical place to encode the User-Agent requirement, timeout,
+/// JSON parse, and graceful fallback so callers only see `Option<UpdateInfo>`.
+/// What: GETs `https://crates.io/api/v1/crates/{crate_name}` with a
+/// descriptive User-Agent (required by crates.io policy; a missing or generic
+/// UA returns 403). Parses `crate.max_stable_version`, falls back to
+/// `newest_version` / `max_version`. Returns `Some(UpdateInfo)` only when the
+/// parsed version is strictly newer than `current_version`. Returns `None` on
+/// any error — network failure, timeout, 4xx/5xx, or JSON parse failure.
+/// Test: covered by integration; unit tests mock the network path via the
+/// throttle + cache layer.
+pub async fn check_crates_io(crate_name: &str, current_version: &str) -> Option<UpdateInfo> {
+    let url = format!("https://crates.io/api/v1/crates/{crate_name}");
+    let user_agent =
+        format!("{crate_name}/{current_version} (https://github.com/bobmatnyc/trusty-tools)");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(NETWORK_TIMEOUT_SECS))
+        .user_agent(&user_agent)
+        .build()
+        .ok()?;
+
+    let resp = client.get(&url).send().await.ok()?;
+
+    if !resp.status().is_success() {
+        tracing::debug!(
+            status = %resp.status(),
+            crate_name,
+            "crates.io update check returned non-2xx; skipping"
+        );
+        return None;
+    }
+
+    let payload: CratesIoResponse = resp.json().await.ok()?;
+
+    let latest = payload
+        .krate
+        .max_stable_version
+        .or(payload.krate.newest_version)
+        .or(payload.krate.max_version)?;
+
+    if !is_newer(&latest, current_version) {
+        tracing::debug!(crate_name, current_version, latest, "already up to date");
+        return None;
+    }
+
+    Some(UpdateInfo {
+        crate_name: crate_name.to_owned(),
+        current: current_version.to_owned(),
+        latest,
+    })
+}
+
+// ─── Current Unix timestamp ───────────────────────────────────────────────────
+
+/// Return seconds since UNIX_EPOCH, or 0 on error.
+///
+/// Why: `SystemTime` can theoretically fail on platforms with extreme clock
+/// skew; returning 0 causes a cache miss rather than a panic.
+/// What: Wraps `SystemTime::now().duration_since(UNIX_EPOCH)`.
+/// Test: Used inline in `check_throttled` — the value is observable via
+/// cache writes in `cache_round_trip`.
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+// ─── Throttled public entry point ────────────────────────────────────────────
+
+/// Check crates.io for an update, throttled to at most once per 24 hours.
+///
+/// Why: User-facing CLIs should inform operators of new releases without
+/// adding latency or hammering crates.io on every invocation.
+///
+/// Behaviour:
+/// 1. Returns `None` immediately when `TRUSTY_NO_UPDATE_CHECK` or `CI` is set
+///    (no network call, no cache I/O).
+/// 2. Reads the per-crate cache file. If `last_check_unix` is less than 24 h
+///    ago, returns the cached result (a fresh `UpdateInfo` when a newer version
+///    was recorded, `None` when the cache says we are current).
+/// 3. Otherwise performs a `check_crates_io` network call, writes the cache,
+///    and returns the result.
+///
+/// Any I/O or network failure degrades to `None` — the check is best-effort.
+///
+/// What: Returns `Some(UpdateInfo)` when a newer stable version is available,
+/// `None` in every other case.
+/// Test: `check_throttled_skips_when_env_set`, `check_throttled_uses_cache`,
+/// `check_throttled_fresh_check_on_stale_cache` — all without real network.
+pub async fn check_throttled(crate_name: &str, current_version: &str) -> Option<UpdateInfo> {
+    // 1. Opt-out via environment.
+    let no_check = std::env::var(NO_UPDATE_CHECK_ENV)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let in_ci = std::env::var(CI_ENV)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+
+    if no_check || in_ci {
+        tracing::trace!(crate_name, "update check suppressed by env var");
+        return None;
+    }
+
+    let now = now_unix_secs();
+
+    // 2. Try the cache.
+    if let Some(entry) = read_cache(crate_name) {
+        if now.saturating_sub(entry.last_check_unix) < CHECK_INTERVAL_SECS {
+            tracing::trace!(
+                crate_name,
+                cached_latest = %entry.latest_version,
+                "using cached update-check result"
+            );
+            return if is_newer(&entry.latest_version, current_version) {
+                Some(UpdateInfo {
+                    crate_name: crate_name.to_owned(),
+                    current: current_version.to_owned(),
+                    latest: entry.latest_version,
+                })
+            } else {
+                None
+            };
+        }
+        tracing::trace!(
+            crate_name,
+            "cached update-check entry is stale; re-checking"
+        );
+    }
+
+    // 3. Network check.
+    let result = check_crates_io(crate_name, current_version).await;
+
+    // Write cache with the latest version seen (or the current version when
+    // already up to date, so we still record the timestamp).
+    let latest_to_cache = result
+        .as_ref()
+        .map(|u| u.latest.clone())
+        .unwrap_or_else(|| current_version.to_owned());
+    write_cache(
+        crate_name,
+        &CacheEntry {
+            last_check_unix: now,
+            latest_version: latest_to_cache,
+        },
+    );
+
+    result
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+/// Test suite for semver comparison, notice formatting, env-var opt-out,
+/// cache freshness, and cache I/O resilience.
+///
+/// Why: Split into a sibling file so `mod.rs` stays under the 500-line cap.
+/// What: All tests are `#[cfg(test)]`-gated and run with
+/// `cargo test -p trusty-common --features update-check`.
+/// Test: run the above command to verify all 15 cases pass.
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-common/src/update/tests.rs
+++ b/crates/trusty-common/src/update/tests.rs
@@ -1,0 +1,233 @@
+//! Tests for the `update` module.
+//!
+//! Why: Kept in a sibling file to respect the 500-line cap on `mod.rs`
+//! while still using `#[cfg(test)]` so the test helpers are compiled only
+//! in test mode.
+
+use super::*;
+use std::sync::Mutex;
+
+/// Serialize tests that mutate environment variables to prevent races when
+/// `cargo test` runs them on parallel threads.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+// ── semver helpers ──────────────────────────────────────────────────────
+
+#[test]
+fn semver_newer_returns_true() {
+    assert!(is_newer("0.20.0", "0.19.0"));
+    assert!(is_newer("1.0.0", "0.99.99"));
+    assert!(is_newer("0.19.1", "0.19.0"));
+}
+
+#[test]
+fn semver_equal_returns_false() {
+    assert!(!is_newer("0.19.0", "0.19.0"));
+}
+
+#[test]
+fn semver_older_returns_false() {
+    assert!(!is_newer("0.18.0", "0.19.0"));
+    assert!(!is_newer("0.19.0", "1.0.0"));
+}
+
+#[test]
+fn semver_prerelease_stripped() {
+    // Pre-release suffixes are stripped before comparison.
+    assert!(!is_newer("0.19.0-beta.1", "0.19.0"));
+    assert!(is_newer("0.20.0-alpha.1", "0.19.0"));
+}
+
+#[test]
+fn semver_parse_strips_prerelease() {
+    assert_eq!(parse_version("1.2.3-beta.1"), Some((1, 2, 3)));
+    assert_eq!(parse_version("1.2.3+build.42"), Some((1, 2, 3)));
+    assert_eq!(parse_version("1.2.3-rc.1+sha.abc"), Some((1, 2, 3)));
+}
+
+#[test]
+fn semver_parse_handles_missing_patch() {
+    assert_eq!(parse_version("1.2"), Some((1, 2, 0)));
+    assert_eq!(parse_version("1"), Some((1, 0, 0)));
+}
+
+#[test]
+fn semver_parse_rejects_garbage() {
+    assert_eq!(parse_version("not-a-version"), None);
+    assert_eq!(parse_version(""), None);
+}
+
+// ── notice formatting ───────────────────────────────────────────────────
+
+#[test]
+fn notice_formats_correctly() {
+    let info = UpdateInfo {
+        crate_name: "trusty-search".to_owned(),
+        current: "0.19.0".to_owned(),
+        latest: "0.20.0".to_owned(),
+    };
+    let n = notice(&info);
+    assert!(n.contains("trusty-search"), "crate name missing: {n}");
+    assert!(n.contains("0.20.0"), "latest version missing: {n}");
+    assert!(n.contains("0.19.0"), "current version missing: {n}");
+    assert!(n.contains("cargo install"), "install command missing: {n}");
+    assert!(n.contains("--locked"), "--locked flag missing: {n}");
+}
+
+// ── opt-out env var ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn check_throttled_skips_when_no_update_check_set() {
+    // Set the env var while holding the lock, then drop the lock before
+    // the await so clippy::await-holding-lock is satisfied.
+    {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Safety: env mutation is serialized by ENV_LOCK; guard dropped
+        // before the async call below.
+        unsafe { std::env::set_var(NO_UPDATE_CHECK_ENV, "1") };
+    }
+    let result = check_throttled("trusty-search", "0.19.0").await;
+    {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::remove_var(NO_UPDATE_CHECK_ENV) };
+    }
+    assert!(
+        result.is_none(),
+        "expected None when {NO_UPDATE_CHECK_ENV} is set"
+    );
+}
+
+#[tokio::test]
+async fn check_throttled_skips_when_ci_set() {
+    {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var(CI_ENV, "true") };
+    }
+    let result = check_throttled("trusty-search", "0.19.0").await;
+    {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::remove_var(CI_ENV) };
+    }
+    assert!(result.is_none(), "expected None when CI is set");
+}
+
+// ── cache freshness logic (uses a temp cache dir) ────────────────────────
+
+/// Write a cache entry with the given `last_check_unix` timestamp and
+/// `latest_version`, then call `check_throttled` and verify the result
+/// matches `expected_is_some`. No real network is used because a fresh
+/// cache entry suppresses the network call.
+async fn run_cache_freshness_test(
+    last_check_unix: u64,
+    latest_version: &str,
+    current_version: &str,
+    expected_is_some: bool,
+) {
+    // Use a unique crate name to avoid cross-test cache pollution.
+    let unique_crate = format!(
+        "test-crate-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+
+    let entry = CacheEntry {
+        last_check_unix,
+        latest_version: latest_version.to_owned(),
+    };
+    write_cache(&unique_crate, &entry);
+
+    // The cache is fresh, so check_throttled returns the cached result
+    // without any network call.
+    let result = check_throttled(&unique_crate, current_version).await;
+    assert_eq!(
+        result.is_some(),
+        expected_is_some,
+        "freshness={expected_is_some}: latest={latest_version} current={current_version}"
+    );
+
+    // Clean up.
+    let _ = std::fs::remove_file(cache_path(&unique_crate));
+}
+
+#[tokio::test]
+async fn cache_fresh_returns_some_when_newer() {
+    // Cache written 1 h ago (well within 24 h) with a newer version.
+    run_cache_freshness_test(now_unix_secs() - 3600, "1.0.0", "0.19.0", true).await;
+}
+
+#[tokio::test]
+async fn cache_fresh_returns_none_when_current() {
+    // Cache written 1 h ago with the same version — already up to date.
+    run_cache_freshness_test(now_unix_secs() - 3600, "0.19.0", "0.19.0", false).await;
+}
+
+// ── corrupt / missing cache file ──────────────────────────────────────
+
+#[test]
+fn corrupt_cache_returns_none() {
+    // Write garbage bytes to the cache file; read_cache must return None.
+    let unique_crate = format!("corrupt-test-{}", std::process::id());
+    let path = cache_path(&unique_crate);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, b"this is not valid json {{{{");
+    let result = read_cache(&unique_crate);
+    let _ = std::fs::remove_file(&path);
+    assert!(result.is_none(), "corrupt cache must yield None");
+}
+
+#[test]
+fn missing_cache_returns_none() {
+    let unique_crate = format!("missing-test-{}", std::process::id());
+    // Ensure the file does not exist.
+    let _ = std::fs::remove_file(cache_path(&unique_crate));
+    let result = read_cache(&unique_crate);
+    assert!(result.is_none(), "missing cache must yield None");
+}
+
+// ── cache round-trip ──────────────────────────────────────────────────
+
+#[test]
+fn cache_round_trip() {
+    let unique_crate = format!("roundtrip-{}", std::process::id());
+    let entry = CacheEntry {
+        last_check_unix: 1_700_000_000,
+        latest_version: "9.9.9".to_owned(),
+    };
+    write_cache(&unique_crate, &entry);
+    let back = read_cache(&unique_crate);
+    let _ = std::fs::remove_file(cache_path(&unique_crate));
+    let back = back.expect("cache round-trip should succeed");
+    assert_eq!(back.last_check_unix, 1_700_000_000);
+    assert_eq!(back.latest_version, "9.9.9");
+}
+
+// ── live crates.io integration test (requires network) ───────────────────────
+// Tagged #[ignore] so it is skipped in normal CI runs.
+
+#[tokio::test]
+#[ignore]
+async fn live_crates_io_with_old_version_returns_some() {
+    // Deliberately old version — should show trusty-search is newer.
+    let result = check_crates_io("trusty-search", "0.0.1").await;
+    assert!(
+        result.is_some(),
+        "expected Some(UpdateInfo) for old version 0.0.1 — is network available?"
+    );
+    let info = result.unwrap();
+    println!("crates.io returned: latest={}", info.latest);
+    assert!(
+        !info.latest.is_empty(),
+        "latest version should not be empty"
+    );
+    // Verify the notice string renders correctly
+    let n = notice(&info);
+    println!("Notice: {n}");
+    assert!(n.contains("cargo install trusty-search --locked"), "notice missing install cmd: {n}");
+    assert!(n.contains(&info.latest), "notice missing latest version");
+    assert!(n.contains("0.0.1"), "notice missing current version");
+}

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # Shared CLI help system (issue #216): declarative `help.yaml` loader +
 # Jaro-Winkler "did you mean?" suggester. Only the `cli-help` feature is
 # enabled; tga is otherwise independent of trusty-common.
-trusty-common = { workspace = true, features = ["cli-help"] }
+trusty-common = { workspace = true, features = ["cli-help", "update-check"] }
 # Async runtime
 tokio = { workspace = true }
 # CLI

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -645,6 +645,17 @@ async fn run() -> anyhow::Result<()> {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level.to_string()));
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
 
+    // Update check: tga has no MCP stdio transport — all subcommands are
+    // human-facing interactive CLI commands where a release notice is
+    // appropriate. The check is throttled to once per 24 h (on-disk cache) so
+    // on a typical run this costs only a sub-millisecond cache file read.
+    if let Some(info) =
+        trusty_common::update::check_throttled(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+            .await
+    {
+        eprintln!("{}", trusty_common::update::notice(&info));
+    }
+
     // Load configuration (fall back to default if file is missing).
     let config = if cli.config.exists() {
         tracing::info!(path = %cli.config.display(), "loading config");

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/bin/bm25_daemon.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.8.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help"] }
+trusty-common = { path = "../trusty-common", version = "0.8.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check"] }
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
 #      trusty-memory — one install command, three binaries. The shim at

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -432,6 +432,27 @@ async fn main() -> Result<()> {
         trusty_common::log_buffer::DEFAULT_LOG_CAPACITY,
     );
 
+    // Update check: emitted only for human-facing subcommands. `serve`
+    // (foreground) is the long-running HTTP/MCP daemon — stdout/stderr are
+    // owned by the supervisor or the JSON-RPC framing, so we must not print
+    // anything there. `start` self-spawns a detached `serve --foreground`
+    // child and exits immediately; the very brief window makes the notice
+    // useless. All other subcommands are short-lived interactive commands
+    // where the notice is visible and appropriate.
+    // The check is throttled to once per 24 h (on-disk cache), so on a
+    // typical run this is a sub-millisecond cache-hit with no network I/O.
+    let is_daemon_path = matches!(cli.command, Command::Serve { .. } | Command::Start);
+    if !is_daemon_path {
+        if let Some(info) = trusty_common::update::check_throttled(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        )
+        .await
+        {
+            eprintln!("{}", trusty_common::update::notice(&info));
+        }
+    }
+
     match cli.command {
         Command::Start => handle_start().await,
         Command::Stop => handle_stop().await,

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -48,7 +48,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.8.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216)
+trusty-common = { version = "0.8.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification
 
 # ── Bundled sidecar ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue

--- a/crates/trusty-search/src/main.rs
+++ b/crates/trusty-search/src/main.rs
@@ -872,6 +872,26 @@ async fn run() -> Result<()> {
     }
     trusty_common::maybe_disable_color(false);
 
+    // Update check: run for human-facing commands only. MCP `serve` mode must
+    // never print to stderr (or stdout) — JSON-RPC framing owns both streams.
+    // The `start` daemon path also skips the check because it self-spawns a
+    // detached child; the human-facing side returns immediately before the
+    // daemon prints its banner, so there is no useful output window. The check
+    // is throttled to once per 24 h via an on-disk cache, so on typical runs
+    // this is a sub-millisecond cache read with zero network I/O.
+    let is_mcp_serve = matches!(cli.command, Commands::Serve { .. });
+    let is_daemon_start = matches!(cli.command, Commands::Start { .. });
+    if !is_mcp_serve && !is_daemon_start {
+        if let Some(info) = trusty_common::update::check_throttled(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        )
+        .await
+        {
+            eprintln!("{}", trusty_common::update::notice(&info));
+        }
+    }
+
     match cli.command {
         Commands::Search {
             query,


### PR DESCRIPTION
## Why

Users on a published build (e.g., the 0.19.0 trusty-search regression) had no signal to upgrade when a newer stable version became available on crates.io. This PR adds an opt-in update-availability notice to alert users to available updates.

## What

New feature-flagged `update-check` module in `trusty-common` providing:
- `check_throttled()` — throttles checks to once per 24h via an OS cache-dir file
- `check_crates_io()` — queries crates.io `GET /api/v1/crates/<name>` for `max_stable_version` with required User-Agent; semver-compares to `CARGO_PKG_VERSION`
- `notice()` — formats and returns the update notice if a newer version is available

Behavior is best-effort and non-blocking — any failure silently degrades to no notice, never panics.

## Wired Into

- **trusty-search** — notice prints to stderr only; all stdio/JSON-RPC daemon paths (Serve/Start) excluded to preserve stdout transport
- **trusty-memory** — same stderr-only, daemon paths excluded  
- **trusty-analyze** — same stderr-only, daemon paths excluded
- **tga** (trusty-git-analytics) — notice prints to stderr; tga has no stdio transport so no impact to JSON-RPC

Sidecar daemons (`trusty-embedderd`, `trusty-bm25-daemon`) intentionally not wired — update checks are for user-facing CLIs only.

## Scope

- `update-check` is an optional feature; default-feature `trusty-common` pulls no extra dependencies
- Opt-out via `TRUSTY_NO_UPDATE_CHECK` env var or automatic suppression in `CI` environments
- Cache-based throttling ensures ~130ms stall on cache miss only; subsequent checks within 24h read cached result (< 1ms)

## Verification

- **Unit tests**: 15 new tests covering check throttling, semver comparison, notice formatting, env var suppression, and error handling
- **Integration test**: 1 `#[ignore]` test against live crates.io (opt-in via `--include-ignored`)
- **Code quality**: clippy + fmt pass workspace-wide
- **Runtime validation**: QA confirmed MCP serve stdout remains byte-clean JSON-RPC; notice outputs to stderr only; opt-out and throttle mechanisms verified in manual testing

## Notes

- No version bumps or crate publishes in this PR
- Follows project's best-effort error-handling pattern (no panics, no unwraps)
- Respects 500-line file size constraint; update-check module ~80 lines