### PR TITLE
chore: release version bumps — trusty-common 0.8.1, trusty-search 0.20.0, trusty-memory 0.10.0, trusty-analyze 0.2.0, tga 2.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -10649,7 +10649,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10725,7 +10725,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10848,7 +10848,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10946,7 +10946,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 
 [workspace.dependencies]
 # ── Internal crates (path deps so the monorepo builds without publish cycles) ──
-trusty-common = { path = "crates/trusty-common", version = "0.8.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.8.1" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.1" }

--- a/crates/open-mpm/Cargo.toml
+++ b/crates/open-mpm/Cargo.toml
@@ -43,8 +43,8 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      `default-features = false` drops the `axum-server` feature so we don't
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
-trusty-memory = { path = "../trusty-memory", version = "0.9.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.19.0" }
+trusty-memory = { path = "../trusty-memory", version = "0.10.0", default-features = false }
+trusty-search = { path = "../trusty-search", version = "0.20.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.1.10"
+version     = "0.2.0"
 edition     = "2021"
 license     = "MIT"
 authors.workspace    = true

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/src/update/tests.rs
+++ b/crates/trusty-common/src/update/tests.rs
@@ -227,7 +227,10 @@ async fn live_crates_io_with_old_version_returns_some() {
     // Verify the notice string renders correctly
     let n = notice(&info);
     println!("Notice: {n}");
-    assert!(n.contains("cargo install trusty-search --locked"), "notice missing install cmd: {n}");
+    assert!(
+        n.contains("cargo install trusty-search --locked"),
+        "notice missing install cmd: {n}"
+    );
     assert!(n.contains(&info.latest), "notice missing latest version");
     assert!(n.contains("0.0.1"), "notice missing current version");
 }

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.4.0"
+version = "2.5.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.88) per #254. Required for

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -14,7 +14,7 @@ name = "gworkspace-mcp"
 path = "src/bin/gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.8.0", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.8.1", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license = "MIT"
@@ -69,7 +69,7 @@ path = "src/bin/bm25_daemon.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.8.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check"] }
+trusty-common = { path = "../trusty-common", version = "0.8.1", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check"] }
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
 #      trusty-memory — one install command, three binaries. The shim at

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -48,7 +48,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.8.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification
+trusty-common = { version = "0.8.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification
 
 # ── Bundled sidecar ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
Release version bumps for 5 published crates. All crates are already published to crates.io with release tags pushed.

## Published Crates
- trusty-common 0.8.1
- trusty-search 0.20.0
- trusty-memory 0.10.0
- trusty-analyze 0.2.0
- tga 2.5.0

## Changes in This PR
- Bumped version fields in `Cargo.toml` for all 5 published crates
- Updated workspace dependency pins in root `Cargo.toml` to reference the new versions
- Updated version pins in `publish=false` consumer crates (open-mpm, trusty-gworkspace, trusty-mpm) to maintain workspace buildability
- Minor rustfmt fix in trusty-common tests

## Tags
All 5 release tags (e.g. `trusty-common-v0.8.1`, `trusty-search-v0.20.0`, etc.) point to commit e110c15 and will be fast-forwarded to main via this merge.

## Merge Strategy
This PR uses merge-commit to preserve the tag anchor point (e110c15). Squashing would orphan the release tags from main's history.