### PR TITLE
chore: release trusty-search 0.20.1 (#457 + #458 reliability fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10946,7 +10946,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/open-mpm/Cargo.toml
+++ b/crates/open-mpm/Cargo.toml
@@ -44,7 +44,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.10.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.20.0" }
+trusty-search = { path = "../trusty-search", version = "0.20.1" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
# trusty-search 0.20.1

trusty-search 0.20.1 is now live on crates.io, tagged as `trusty-search-v0.20.1` at commit 3a82f3e.

This PR syncs `main` with the release branch, updating:
- `crates/trusty-search/Cargo.toml`: 0.20.0 → 0.20.1
- `crates/open-mpm/Cargo.toml`: inline trusty-search pin → 0.20.1
- `Cargo.lock`: dependencies updated

## Changes in 0.20.1

### #457: Serve self-exits on stdin EOF
- MCP server now detects EOF on stdin and exits gracefully
- Prevents orphaned MCP worker processes when clients disconnect
- Improves daemon lifecycle management in Claude Code

### #458: Reindex-storm priority + dead-root skip
- User indexing operations now prioritized over startup reindex storms
- Skips processing of dead roots (repos deleted or inaccessible)
- Reduces memory thrashing and improves responsiveness during large index initialization

Both fixes improve reliability and stability under high load and during initialization.