### PR TITLE
chore: commit trusty-memory palace pin + gitignore .obsidian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ tga.db
 
 # mdBook build output
 /docs/book/
+
+# Obsidian editor config (personal)
+.obsidian/

--- a/.trusty-tools/trusty-memory.yaml
+++ b/.trusty-tools/trusty-memory.yaml
@@ -5,4 +5,4 @@
 
 schema_version: 1
 palace: trusty-tools
-note: pinned before drive reorg
+note: 'Pinned 2026-05-30: canonical checkout /Volumes/SSD1/Projects/trusty-tools (moved off /Volumes/Kemono)'


### PR DESCRIPTION
Pins the project's memory palace to slug `trusty-tools` so the linkage survives the /Volumes/Kemono → /Volumes/SSD1 move and is shared across checkouts.

Also ignores personal Obsidian editor configuration files.

## Files
- `.trusty-tools/trusty-memory.yaml` — palace slug pin
- `.gitignore` — add `.obsidian/`