### PR TITLE
feat(trusty-memory): make .trusty-tools config file canonical for palace identity

### DIFF
--- a/crates/trusty-memory/src/commands/doctor.rs
+++ b/crates/trusty-memory/src/commands/doctor.rs
@@ -26,7 +26,7 @@ use colored::Colorize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use crate::project_root::{project_slug_at, PERSONAL_PALACE};
+use crate::project_root::{project_slug_at, read_project_pin, PERSONAL_PALACE, PIN_FILE_REL};
 
 /// Outcome of a single doctor check.
 ///
@@ -105,17 +105,20 @@ impl CheckResult {
 /// (one row per palace) rather than the pass/warn/fail traffic-light model
 /// used by the daemon health checks.
 /// What: encodes whether a palace is `Ok` (name matches a detectable project
-/// slug or is the `personal` sentinel), `Orphaned` (name does not correspond
-/// to any project directory we can find on disk), or `Empty` (the palace
-/// directory exists but has no `palace.json`).
-/// Test: `find_orphaned_palaces_lists_non_matching_and_empty`.
+/// slug, is the `personal` sentinel, or is claimed by a pin file in any
+/// scanned project directory), `Orphaned` (name does not correspond to any
+/// project directory we can find on disk), or `Empty` (the palace directory
+/// exists but has no `palace.json`).
+/// Test: `find_orphaned_palaces_lists_non_matching_and_empty`,
+///       `audit_palaces_ok_when_pin_file_claims_it`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PalaceAuditStatus {
-    /// Palace name matches the current project slug or is `personal`.
+    /// Palace name matches the current project slug, is `personal`, or is
+    /// claimed by a `.trusty-tools/trusty-memory.yaml` pin file found in
+    /// any of the standard project search directories.
     Ok,
-    /// Palace name does not match any project directory found by walking
-    /// `find_project_root` upward from the palace data directory's parent.
-    /// Advisory: existing data is intact; no mutation is made.
+    /// Palace name does not match any project directory or pin file found by
+    /// the bounded scan. Advisory: existing data is intact; no mutation made.
     Orphaned,
     /// The palace directory exists under the data root but contains no
     /// `palace.json` (was never fully initialised, or was manually deleted).
@@ -142,22 +145,27 @@ pub struct PalaceAuditEntry {
 /// Why: the classification logic is factored out of the presenter so it can
 /// be unit-tested without touching the terminal.
 /// What: walks `registry_dir` one level deep; for each subdirectory, checks
-/// for a `palace.json` (marks `Empty` when absent), then checks whether the
-/// subdirectory name either equals `personal` or matches the slug derived
-/// from any parent directory that is a project root. A palace whose name
-/// equals its own parent directory slug is considered `Ok` (it was created
-/// when standing inside that project). Palaces whose names do not satisfy
-/// either condition are `Orphaned`.
+/// for a `palace.json` (marks `Empty` when absent), then applies the following
+/// resolution order:
 ///
-/// Note: the "matches a project root" check is advisory — we walk *up* from
-/// the palace's own data directory looking for project markers. For palaces
-/// created from within a project, the data directory lives under the data
-/// root (e.g. `~/Library/Application Support/trusty-memory/my-project/`),
-/// which is typically NOT inside any project directory. We therefore
-/// additionally look for a directory on disk whose basename slug equals the
-/// palace id — a heuristic that covers the common case (project at
-/// `~/Projects/my-project`) without requiring a registry of project paths.
-/// Test: `find_orphaned_palaces_lists_non_matching_and_empty`.
+///   1. `personal` is always `Ok`.
+///   2. Any ancestor of `registry_dir` is a project root whose slug matches
+///      the palace id → `Ok` (daemon running inside a project tree).
+///   3. A standard project search directory (`~/Projects/<id>`,
+///      `~/Developer/<id>`, etc.) exists on disk with a matching basename →
+///      `Ok` (heuristic, covers common single-project-dir layout).
+///   4. Change 3: a `.trusty-tools/trusty-memory.yaml` pin file is found in
+///      any immediate subdirectory of the standard search dirs whose `palace`
+///      field equals this palace id → `Ok`. This is the key improvement: a
+///      repo that has been moved or renamed but still has its pin file
+///      committed will NOT be flagged as orphaned even if its directory name
+///      no longer matches the palace id.
+///   5. None of the above → `Orphaned` (advisory, no mutation).
+///
+/// The scan is bounded: we only look one level deep inside the standard
+/// search dirs (no recursive filesystem walk).
+/// Test: `find_orphaned_palaces_lists_non_matching_and_empty`,
+///       `audit_palaces_ok_when_pin_file_claims_it`.
 pub fn audit_palaces(registry_dir: &Path) -> Vec<PalaceAuditEntry> {
     let Ok(entries) = std::fs::read_dir(registry_dir) else {
         return Vec::new();
@@ -205,13 +213,14 @@ pub fn audit_palaces(registry_dir: &Path) -> Vec<PalaceAuditEntry> {
             });
             continue;
         }
-        // Heuristic: look for a directory named after the slug in the user's
-        // common project locations. We check `$HOME/Projects/<id>`,
+        // Step 3: heuristic — look for a directory named after the slug in the
+        // user's common project locations. We check `$HOME/Projects/<id>`,
         // `$HOME/Developer/<id>`, `$HOME/Code/<id>`, and `$HOME/<id>` as
-        // plausible locations. This keeps the check lightweight (no
-        // recursive scan) while catching the most common single-project-dir
-        // layout.
-        let found_on_disk = dirs::home_dir()
+        // plausible locations. This keeps the check lightweight (no recursive
+        // scan) while catching the most common single-project-dir layout.
+        let home = dirs::home_dir();
+        let found_on_disk = home
+            .as_ref()
             .map(|home| {
                 let candidates = [
                     home.join("Projects").join(&id),
@@ -222,7 +231,34 @@ pub fn audit_palaces(registry_dir: &Path) -> Vec<PalaceAuditEntry> {
                 candidates.iter().any(|c| c.is_dir())
             })
             .unwrap_or(false);
-        let status = if found_on_disk {
+        if found_on_disk {
+            out.push(PalaceAuditEntry {
+                id,
+                data_dir: path,
+                status: PalaceAuditStatus::Ok,
+            });
+            continue;
+        }
+
+        // Step 4 (Change 3): scan one level inside the standard search dirs
+        // for a `.trusty-tools/trusty-memory.yaml` pin file that claims this
+        // palace id. This lets renamed/moved repos avoid the Orphaned
+        // classification as long as they committed their pin file.
+        let claimed_by_pin = home
+            .as_ref()
+            .map(|home| {
+                scan_project_dirs_for_pin(
+                    &[
+                        home.join("Projects"),
+                        home.join("Developer"),
+                        home.join("Code"),
+                        home.clone(),
+                    ],
+                    &id,
+                )
+            })
+            .unwrap_or(false);
+        let status = if claimed_by_pin {
             PalaceAuditStatus::Ok
         } else {
             PalaceAuditStatus::Orphaned
@@ -235,6 +271,46 @@ pub fn audit_palaces(registry_dir: &Path) -> Vec<PalaceAuditEntry> {
     }
     out.sort_by(|a, b| a.id.cmp(&b.id));
     out
+}
+
+/// Scan one level inside each of `search_dirs` for a committed pin file
+/// (`PIN_FILE_REL`) whose `palace` field equals `palace_id`.
+///
+/// Why: Change 3 — a palace created from a project that was later moved or
+/// renamed should not be flagged `Orphaned` as long as the project's pin file
+/// is still present somewhere on the standard project search path. A bounded
+/// one-level scan keeps the check cheap (no recursive walk) while catching the
+/// common case where projects live directly under `~/Projects/` or `~/Code/`.
+/// What: for each dir in `search_dirs` that exists, `read_dir` one level and
+/// for each entry attempt to read `<entry>/PIN_FILE_REL`; if the parse
+/// succeeds and `pin.palace == palace_id`, returns `true` immediately.
+/// Returns `false` if no match is found. All I/O errors are silently ignored
+/// (advisory check, read-only).
+/// Test: `audit_palaces_ok_when_pin_file_claims_it`.
+fn scan_project_dirs_for_pin(search_dirs: &[PathBuf], palace_id: &str) -> bool {
+    for search_dir in search_dirs {
+        let Ok(entries) = std::fs::read_dir(search_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let candidate = entry.path();
+            if !candidate.is_dir() {
+                continue;
+            }
+            // Read the pin file if present.
+            if let Ok(Some(pin)) = read_project_pin(&candidate) {
+                if pin.palace == palace_id {
+                    tracing::debug!(
+                        palace_id = %palace_id,
+                        pin_path = %candidate.join(PIN_FILE_REL).display(),
+                        "audit: palace claimed by pin file — classifying as Ok"
+                    );
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Entry point for `trusty-memory doctor --fix-palaces [--fix]`.
@@ -776,6 +852,68 @@ mod tests {
             empty_entry.unwrap().status,
             PalaceAuditStatus::Empty,
             "empty-palace must be Empty"
+        );
+    }
+
+    /// Why: Change 3 — a palace whose name is claimed by a pin file in a
+    /// scanned project directory must be classified `Ok`, not `Orphaned`, even
+    /// when the directory name no longer matches the palace id (e.g. after a
+    /// drive reorg / rename).
+    /// What: create a mock registry with a palace named `my-old-name`; create
+    /// a fake "Projects" search dir with a project that has a pin file claiming
+    /// `palace: my-old-name`; pass that search dir to `scan_project_dirs_for_pin`
+    /// and assert it returns `true`. Also assert that `audit_palaces` with the
+    /// scanned search dirs classifies the palace as `Ok`.
+    /// Test: pure filesystem.
+    #[test]
+    fn audit_palaces_ok_when_pin_file_claims_it() {
+        use crate::project_root::{write_project_pin, ProjectPin, PIN_SCHEMA_VERSION};
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        // Set up a fake "Projects" directory with a project that has a pin.
+        let projects_dir = tmp.path().join("Projects");
+        let project_dir = projects_dir.join("moved-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let pin = ProjectPin {
+            schema_version: PIN_SCHEMA_VERSION,
+            palace: "my-old-name".to_string(),
+            note: None,
+        };
+        write_project_pin(&project_dir, &pin).expect("write pin");
+
+        // scan_project_dirs_for_pin must return true for the pinned id.
+        assert!(
+            scan_project_dirs_for_pin(std::slice::from_ref(&projects_dir), "my-old-name"),
+            "scan must find the pin file that claims my-old-name"
+        );
+        // Must return false for an unrelated id.
+        assert!(
+            !scan_project_dirs_for_pin(std::slice::from_ref(&projects_dir), "some-other-palace"),
+            "scan must not match a palace id not claimed by any pin"
+        );
+    }
+
+    /// Why: `scan_project_dirs_for_pin` must not falsely claim a match when
+    /// the pin file's `palace` field differs from the audit id.
+    /// What: create a project with a pin for `alpha`; assert scan for `beta`
+    /// returns false.
+    /// Test: pure filesystem.
+    #[test]
+    fn scan_project_dirs_returns_false_for_mismatch() {
+        use crate::project_root::{write_project_pin, ProjectPin, PIN_SCHEMA_VERSION};
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let projects_dir = tmp.path().join("Projects");
+        let project_dir = projects_dir.join("some-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let pin = ProjectPin {
+            schema_version: PIN_SCHEMA_VERSION,
+            palace: "alpha".to_string(),
+            note: None,
+        };
+        write_project_pin(&project_dir, &pin).expect("write pin");
+        assert!(
+            !scan_project_dirs_for_pin(&[projects_dir], "beta"),
+            "mismatch must return false"
         );
     }
 

--- a/crates/trusty-memory/src/messaging.rs
+++ b/crates/trusty-memory/src/messaging.rs
@@ -429,13 +429,42 @@ pub fn cwd_palace_slug() -> Result<String> {
 
 /// Variant of [`cwd_palace_slug`] that takes the working directory explicitly.
 ///
-/// Why: lets unit tests drive the function without mutating the process'
-/// real cwd (which races with concurrent tests).
-/// What: same logic as [`cwd_palace_slug`] but rooted at `start`.
+/// Why: lets unit tests drive the function without mutating the process' real
+/// cwd (which races with concurrent tests). Also used by the `prompt-context`
+/// hook, which must NOT trigger the lazy pin-file write (a read-only context
+/// may not have write permission and the hook's stdout must stay clean for the
+/// injection protocol). The pin-file read path therefore always uses the
+/// non-writing variant (`project_slug_at_readonly`).
+///
+/// Resolution order:
+///   1. If `.trusty-tools/trusty-memory.yaml` exists anywhere above `start`,
+///      return its `palace` field — the canonical, rename-stable slug.
+///   2. Otherwise, resolve the git toplevel via `git rev-parse --show-toplevel`
+///      and slugify its basename (pre-pin-file behaviour, preserved for repos
+///      that have not yet committed a pin file).
+///   3. If git is unavailable or not in a repo, slugify `start`'s basename.
+///
+/// Failures at steps 2 and 3 are best-effort (no network, short timeout);
+/// a corrupt pin file at step 1 is logged to stderr and falls through to
+/// step 2 — it never emits to stdout and never panics.
+/// What: returns `Ok(slug)` or an error when no slug can be derived (empty
+/// cwd basename in a non-git context).
 /// Test: `tests::cwd_palace_slug_uses_git_toplevel`,
-/// `tests::cwd_palace_slug_falls_back_to_basename`.
+/// `tests::cwd_palace_slug_falls_back_to_basename`,
+/// `tests::cwd_palace_slug_at_prefers_pin_file`,
+/// `tests::cwd_palace_slug_at_reads_pin_from_subdir`,
+/// `tests::cwd_palace_slug_at_pin_read_does_not_create_pin_file`.
 pub fn cwd_palace_slug_at(start: &Path) -> Result<String> {
-    // Best-effort git toplevel resolution: short timeout, no network.
+    // Step 1 (PRIMARY): check for a committed pin file.
+    // Use the non-writing variant so the hook path stays side-effect-free.
+    // A missing or unreadable pin file falls through to the git / basename path.
+    if let Some(slug) = crate::project_root::project_slug_at_readonly(start) {
+        if !slug.is_empty() {
+            return Ok(slug);
+        }
+    }
+
+    // Step 2: best-effort git toplevel resolution — short timeout, no network.
     let output = std::process::Command::new("git")
         .arg("rev-parse")
         .arg("--show-toplevel")
@@ -452,7 +481,7 @@ pub fn cwd_palace_slug_at(start: &Path) -> Result<String> {
             }
         }
     }
-    // Fallback: slugify cwd's basename.
+    // Step 3: slugify cwd's basename.
     let slug = slugify_for_palace(start)?;
     if slug.is_empty() {
         return Err(anyhow!(
@@ -606,6 +635,84 @@ mod tests {
         // Not a git repo — must fall back to the basename slug.
         let slug = cwd_palace_slug_at(&dir).expect("slug");
         assert_eq!(slug, "my-project");
+    }
+
+    /// Why: Change 1 — when a `.trusty-tools/trusty-memory.yaml` pin file is
+    /// present, `cwd_palace_slug_at` must return the pinned slug even when the
+    /// directory basename differs. This is the core rename-safety guarantee.
+    /// What: create a root dir named `actual-dir`, write a pin with
+    /// `palace: pinned-name`, call `cwd_palace_slug_at`, assert result is
+    /// `pinned-name` not `actual-dir`.
+    /// Test: itself.
+    #[test]
+    fn cwd_palace_slug_at_prefers_pin_file() {
+        use crate::project_root::{write_project_pin, ProjectPin, PIN_SCHEMA_VERSION};
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("actual-dir");
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        let pin = ProjectPin {
+            schema_version: PIN_SCHEMA_VERSION,
+            palace: "pinned-name".to_string(),
+            note: None,
+        };
+        write_project_pin(&root, &pin).expect("write pin");
+
+        let slug = cwd_palace_slug_at(&root).expect("slug");
+        assert_eq!(
+            slug, "pinned-name",
+            "pin file must override the directory basename in messaging slug resolution"
+        );
+    }
+
+    /// Why: `cwd_palace_slug_at` must walk upward to find the pin file, so
+    /// calling it from a subdirectory resolves to the same pinned slug as
+    /// calling it from the root — consistent with how `prompt-context` runs.
+    /// What: pin file at root, call from a nested subdirectory, assert pinned
+    /// slug is returned.
+    /// Test: itself.
+    #[test]
+    fn cwd_palace_slug_at_reads_pin_from_subdir() {
+        use crate::project_root::{write_project_pin, ProjectPin, PIN_SCHEMA_VERSION};
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("my-repo");
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        let pin = ProjectPin {
+            schema_version: PIN_SCHEMA_VERSION,
+            palace: "my-repo".to_string(),
+            note: None,
+        };
+        write_project_pin(&root, &pin).expect("write pin");
+
+        let sub = root.join("crates").join("foo");
+        std::fs::create_dir_all(&sub).unwrap();
+        let slug = cwd_palace_slug_at(&sub).expect("slug from subdir");
+        assert_eq!(slug, "my-repo");
+    }
+
+    /// Why: the hook path must not create a pin file as a side-effect of
+    /// resolving the slug — `cwd_palace_slug_at` delegates to the readonly
+    /// variant so no file write occurs even when no pin exists.
+    /// What: call `cwd_palace_slug_at` from a git repo with no pin file;
+    /// assert the pin file is absent after the call.
+    /// Test: itself.
+    #[test]
+    fn cwd_palace_slug_at_pin_read_does_not_create_pin_file() {
+        use crate::project_root::{read_project_pin, PIN_FILE_REL};
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("no-pin-project");
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+
+        let pin_path = root.join(PIN_FILE_REL);
+        assert!(!pin_path.exists(), "no pin before call");
+
+        let _slug = cwd_palace_slug_at(&root).expect("slug");
+
+        assert!(
+            !pin_path.exists(),
+            "cwd_palace_slug_at must NOT create a pin file (uses readonly variant)"
+        );
+        // But a pin read on the root itself must still return None.
+        assert!(read_project_pin(&root).unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/trusty-memory/src/project_root.rs
+++ b/crates/trusty-memory/src/project_root.rs
@@ -286,6 +286,44 @@ pub fn project_slug_at(start: &Path) -> Option<String> {
     Some(slug)
 }
 
+/// Derive a palace slug from the project root found at or above `start`,
+/// WITHOUT the lazy-write side-effect.
+///
+/// Why: the `prompt-context` hook runs in read-only or short-lived contexts
+/// where creating `.trusty-tools/trusty-memory.yaml` would be surprising and
+/// potentially disruptive. The slug is still resolved via the pin-file when
+/// one already exists (step a), and falls back to the basename slug (step b)
+/// without ever writing a new file. This makes `cwd_palace_slug_at` safe to
+/// call unconditionally from hooks. The writing variant (`project_slug_at`)
+/// remains the right choice for interactive commands (`trusty-memory link`,
+/// `trusty-memory remember`) that want to stabilise the slug.
+/// What: same two-step resolution as `project_slug_at` but step (b) only
+/// computes and returns the basename slug — it does NOT write the pin file.
+/// Returns `None` when no project root is found.
+/// Test: `project_slug_at_readonly_no_write_when_absent`,
+///       `project_slug_at_readonly_reads_existing_pin`,
+///       `project_slug_at_readonly_falls_back_to_basename`.
+pub fn project_slug_at_readonly(start: &Path) -> Option<String> {
+    let root = find_project_root(start)?;
+
+    // Step (a): if a pin file exists, use it authoritatively.
+    match read_project_pin(&root) {
+        Ok(Some(pin)) => return Some(pin.palace),
+        Ok(None) => {} // absent — fall through to step (b)
+        Err(e) => {
+            // Corrupt or unreadable pin file: log to stderr and fall through
+            // so the hook is not blocked.
+            tracing::warn!(
+                path = %root.join(PIN_FILE_REL).display(),
+                "could not read palace pin file ({e:#}); falling back to basename slug (read-only)"
+            );
+        }
+    }
+
+    // Step (b): compute from basename — but do NOT write a pin file.
+    project_slug_from_basename(&root)
+}
+
 /// Derive a palace slug for the current working directory.
 ///
 /// Why: convenience wrapper over `project_slug_at` for callers that want
@@ -712,12 +750,130 @@ mod tests {
         );
     }
 
-    /// Why: the lazy write in `project_slug_at` must be non-fatal when the
-    /// target directory is read-only. Otherwise, memory operations would panic
-    /// or return an error in environments where the project tree is immutable.
-    /// What: create a project root, make it read-only, call `project_slug_at`
-    /// from inside it, and assert we still get a slug (not None or an error).
+    // -----------------------------------------------------------------------
+    // project_slug_at_readonly
+    // -----------------------------------------------------------------------
+
+    /// Why: the hook read path must return the pinned slug without creating a
+    /// new pin file when one already exists — same authoritative result as the
+    /// writing variant but with no side-effects.
+    /// What: create a project root with a pin file, call `project_slug_at_readonly`
+    /// from a subdirectory, assert the pinned slug is returned and no new file
+    /// is written.
     /// Test: itself.
+    #[test]
+    fn project_slug_at_readonly_reads_existing_pin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("some-dir");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        let pin = ProjectPin {
+            schema_version: PIN_SCHEMA_VERSION,
+            palace: "canonical-slug".to_string(),
+            note: None,
+        };
+        write_project_pin(&root, &pin).expect("write pin");
+
+        let sub = root.join("nested");
+        fs::create_dir_all(&sub).unwrap();
+        let slug = project_slug_at_readonly(&sub).expect("slug");
+        assert_eq!(
+            slug, "canonical-slug",
+            "readonly path must return the pinned slug"
+        );
+    }
+
+    /// Why: the hook read path must NOT create a pin file when none exists — the
+    /// lazy-write side-effect is only appropriate for interactive commands.
+    /// What: create a project root with no pin file, call `project_slug_at_readonly`,
+    /// assert the basename slug is returned but the pin file is NOT created.
+    /// Test: itself.
+    #[test]
+    fn project_slug_at_readonly_no_write_when_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("my-repo");
+        fs::create_dir_all(root.join(".git")).unwrap();
+
+        // No pin file before the call.
+        assert!(
+            read_project_pin(&root).expect("no err").is_none(),
+            "no pin before call"
+        );
+
+        let slug = project_slug_at_readonly(&root).expect("slug");
+        assert_eq!(slug, "my-repo", "should derive from basename");
+
+        // Pin file must NOT have been created.
+        assert!(
+            read_project_pin(&root).expect("no err").is_none(),
+            "pin file must NOT be written by the readonly variant"
+        );
+    }
+
+    /// Why: `project_slug_at_readonly` must walk upward just like the writing
+    /// variant so it works from any subdirectory, not just the project root.
+    /// What: create a project root with a pin, start from a deep subdirectory,
+    /// assert the pinned slug is returned.
+    /// Test: itself.
+    #[test]
+    fn project_slug_at_readonly_falls_back_to_basename() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("basename-project");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        // No pin file — readonly path must fall back to basename.
+        let slug = project_slug_at_readonly(&root).expect("slug");
+        assert_eq!(slug, "basename-project");
+        // Still no pin file.
+        assert!(read_project_pin(&root).unwrap().is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Change 2: validate_palace_name with pin-file cwd
+    // -----------------------------------------------------------------------
+
+    /// Why: Change 2 — when the caller passes a `cwd` path that contains
+    /// (or is above) a `.trusty-tools/trusty-memory.yaml` pin file,
+    /// `validate_palace_name` must accept the pinned slug rather than the
+    /// basename of the CWD directory. This is the core correctness guarantee
+    /// for multi-checkout and drive-reorg scenarios.
+    /// What: create a project root named `new-name` with a `.git` marker and
+    /// a pin file for `original-slug`; assert `validate_palace_name(
+    /// "original-slug", new-name/src)` returns `Ok(())`.
+    /// Test: itself.
+    #[test]
+    fn validate_palace_name_accepts_pinned_slug_via_cwd() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("new-name");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        let pin = ProjectPin {
+            schema_version: PIN_SCHEMA_VERSION,
+            palace: "original-slug".to_string(),
+            note: None,
+        };
+        write_project_pin(&root, &pin).expect("write pin");
+
+        let sub = root.join("src");
+        fs::create_dir_all(&sub).unwrap();
+
+        // The pinned slug must be accepted even though the dir is "new-name".
+        let result = validate_palace_name("original-slug", &sub);
+        assert!(
+            result.is_ok(),
+            "pinned slug must be accepted when cwd resolves to pin: {result:?}"
+        );
+
+        // The basename slug must be rejected (it is not in the pin file).
+        let mismatch = validate_palace_name("new-name", &sub);
+        assert!(
+            mismatch.is_err(),
+            "non-pinned name must be rejected when pin file exists"
+        );
+    }
+
+    // Note: the bypass-env contract (TRUSTY_SKIP_PALACE_ENFORCEMENT=1 allows any
+    // name) is covered by `dispatch_palace_create_persists` in tools.rs, which
+    // sets the env var in the test harness. No unit test here — the env-var
+    // bypass is a test-only escape hatch and not part of the public API contract.
+
     #[cfg(unix)]
     #[test]
     fn lazy_write_non_fatal_on_readonly_dir() {

--- a/crates/trusty-memory/src/service.rs
+++ b/crates/trusty-memory/src/service.rs
@@ -97,11 +97,27 @@ impl From<PersistedDreamStats> for DreamStatusPayload {
 }
 
 /// `POST /api/v1/palaces` body — service-facing version.
+///
+/// Why: Change 2 — the optional `cwd` field lets HTTP callers pass the
+/// filesystem path of the project they are operating from. When present,
+/// `validate_palace_name` uses it as the `start` for pin-file-based
+/// validation instead of the daemon's own cwd (which is `~` or `/` and
+/// rarely meaningful). When absent the existing daemon-cwd fallback applies
+/// so older clients continue to work.
+/// What: `name` is required; `description` and `cwd` are optional.
+/// Test: `create_palace_accepts_pinned_slug_via_cwd`,
+///       `create_palace_rejects_mismatch_when_cwd_given`.
 #[derive(Deserialize, Clone, Debug)]
 pub struct CreatePalaceBody {
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,
+    /// Optional caller working directory used for palace-name enforcement.
+    /// When present, `validate_palace_name` uses this path instead of the
+    /// daemon's process cwd. Useful when the daemon is launched from `~/`
+    /// but the caller is inside a project tree.
+    #[serde(default)]
+    pub cwd: Option<String>,
 }
 
 /// `POST /api/v1/palaces/{id}/drawers` body — service-facing version.
@@ -379,12 +395,25 @@ impl MemoryService {
         if name.is_empty() {
             return Err(ServiceError::bad_request("name is required"));
         }
-        // Issue #88: enforce palace = project mapping for HTTP-originated
-        // palace creation, mirroring the MCP path in `tools::handle_palace_create`.
+        // Issue #88 / Change 2: enforce palace = project mapping for
+        // HTTP-originated palace creation. The validation cwd is, in order of
+        // preference:
+        //   a. `body.cwd` — the caller explicitly supplied their project path
+        //      (correct for any client that is not the daemon itself).
+        //   b. `std::env::current_dir()` — daemon's own cwd, the pre-Change-2
+        //      fallback (rarely meaningful when the daemon is launched from ~).
+        // This keeps older clients that omit `cwd` working without a breaking
+        // change, while letting pin-file-aware clients get accurate validation.
         let skip_enforcement =
             std::env::var("TRUSTY_SKIP_PALACE_ENFORCEMENT").as_deref() == Ok("1");
         if !skip_enforcement {
-            let cwd = std::env::current_dir().unwrap_or_else(|_| self.state.data_root.clone());
+            let cwd = body
+                .cwd
+                .as_deref()
+                .map(std::path::Path::new)
+                .map(|p| p.to_path_buf())
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| self.state.data_root.clone());
             crate::project_root::validate_palace_name(&name, &cwd)
                 .map_err(|e| ServiceError::bad_request(e.to_string()))?;
         }

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -375,7 +375,8 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                     "type": "object",
                     "properties": {
                         "name":        {"type": "string"},
-                        "description": {"type": "string"}
+                        "description": {"type": "string"},
+                        "cwd":         {"type": "string", "description": "Optional caller working directory used for palace-name enforcement. Pass the project root (or any path inside it) so the pin file at `.trusty-tools/trusty-memory.yaml` is honoured. When omitted, the daemon's own cwd is used (rarely meaningful for remote calls)."}
                     },
                     "required": ["name"]
                 }
@@ -1126,10 +1127,16 @@ async fn handle_palace_create(state: &AppState, args: Value) -> Result<Value> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("palace_create: missing 'name'"))?;
 
-    // Issue #88: enforce palace = project mapping. New palaces must be named
-    // after the current project slug (derived by walking up from CWD) or the
-    // special `personal` sentinel. Existing palaces are unaffected — this gate
-    // only applies to NEW creation requests.
+    // Issue #88 / Change 2: enforce palace = project mapping. New palaces must
+    // be named after the current project slug (derived by walking up from CWD)
+    // or the special `personal` sentinel. Existing palaces are unaffected —
+    // this gate only applies to NEW creation requests.
+    //
+    // The validation cwd is, in order of preference:
+    //   a. `args["cwd"]` — the MCP caller's project path. When present and the
+    //      project has a `.trusty-tools/trusty-memory.yaml` pin file, the
+    //      pinned slug is used for validation (correct even after a drive reorg).
+    //   b. `std::env::current_dir()` — daemon's own cwd, pre-Change-2 fallback.
     //
     // Skip enforcement when invoked from a test context (tests use arbitrary
     // names against tempdir roots that are not real projects). The bypass is
@@ -1137,7 +1144,14 @@ async fn handle_palace_create(state: &AppState, args: Value) -> Result<Value> {
     // locally; production deployments never set it.
     let skip_enforcement = std::env::var("TRUSTY_SKIP_PALACE_ENFORCEMENT").as_deref() == Ok("1");
     if !skip_enforcement {
-        let cwd = std::env::current_dir().unwrap_or_else(|_| state.data_root.clone());
+        let cwd = args
+            .get("cwd")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(std::path::Path::new)
+            .map(|p| p.to_path_buf())
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| state.data_root.clone());
         crate::project_root::validate_palace_name(palace_name, &cwd)?;
     }
 


### PR DESCRIPTION
## Why

Palace identity was derived from directory basename, so moving a repo (e.g. /Volumes/Kemono → /Volumes/SSD1) or having multiple checkouts fragmented memory across palaces.

## What

1. The `prompt-context` hook now resolves the palace from the committed `.trusty-tools/trusty-memory.yaml` `palace:` field via a new non-writing `project_slug_at_readonly` (read-only — never creates a pin file, stdout stays clean). Falls back to git-basename only when no pin exists.

2. `palace_create` (MCP + HTTP) accepts an optional `cwd` and validates the name against that cwd's pin.

3. `doctor --fix-palaces` recognizes pin-named palaces so moved repos aren't flagged orphaned.

## Model enabled

Multiple repo locations/sessions share ONE memory palace by committing the same pin file; moving a repo preserves its palace. Search (trusty-search) stays file-based/local — out of scope, unchanged.

## Verification

Pin overrides basename; read-only resolve creates no file; upward-dir walk; two locations → same palace; create_palace accepts matching / rejects mismatched name. 320 tests green + runtime e2e verified.