### PR TITLE
feat(trusty-common): error-capture layer with fingerprint dedup (bug-reporting phase 1, #479)

### DIFF
--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -352,3 +352,12 @@ cli-help = ["dep:serde_yaml", "dep:strsim", "dep:indexmap", "dep:thiserror"]
 # the feature flag controls module compilation only, adding zero new transitive
 # dependencies to builds that enable it.
 update-check = []
+# Enables the `error_capture` module: tracing Layer that taps ERROR-level
+# events into a bounded ring buffer + local JSONL store for consent-gated
+# bug reporting (Phase 1 of #479). Captures fingerprinted error records with
+# crate attribution, code location, OS/arch, and a dedup SHA-256 fingerprint.
+# Opt-out via `TRUSTY_NO_BUG_CAPTURE` env var. Additive — does not change
+# stderr logging behaviour. Requires `sha2` (already an optional workspace
+# dep via `symgraph`); enables it unconditionally for this feature.
+# Default builds that do NOT enable `bug-capture` pull in zero new deps.
+bug-capture = ["dep:sha2"]

--- a/crates/trusty-common/src/error_capture/fingerprint.rs
+++ b/crates/trusty-common/src/error_capture/fingerprint.rs
@@ -1,0 +1,263 @@
+//! Fingerprint computation for error deduplication.
+//!
+//! Why: The same logical error (e.g. "failed to open file") may appear with
+//!      different runtime details each time — differing file paths, varying
+//!      line numbers in stack traces, or different hex addresses. Normalising
+//!      these away before hashing ensures recurrent occurrences of the *same*
+//!      bug share one fingerprint so Phase 3 can deduplicate GitHub issues.
+//! What: [`normalise_message`] strips digits, hex strings, and common path
+//!      prefixes from a message. [`compute_fingerprint`] SHA-256s the stable
+//!      parts (crate target + normalised message + code location) and returns
+//!      a lowercase hex string.
+//! Test: `fingerprint_same_for_logically_identical_errors`,
+//!      `fingerprint_differs_for_different_errors`,
+//!      `normalise_strips_digits_and_hex`.
+
+use sha2::{Digest, Sha256};
+
+/// Strip volatile substrings from an error message so the same logical error
+/// maps to the same fingerprint regardless of runtime-varying details.
+///
+/// We avoid pulling in `regex` for this pure-computation helper — a simple
+/// hand-written state machine is enough and adds no dependencies.
+///
+/// Why: file paths, line numbers, memory addresses, hex values, port numbers,
+/// and similar tokens change between runs but should not produce distinct
+/// fingerprints for what is clearly the same bug.
+///
+/// What: applies three passes in order:
+/// 1. Remove hex-looking tokens (`0x…`, bare `[0-9a-f]{6,}`).
+/// 2. Remove digit runs (integers, version numbers, timestamps).
+/// 3. Replace the user home directory prefix with `~`.
+///
+/// Returns the scrubbed string, collapsed to a single space between tokens.
+///
+/// Test: `normalise_strips_digits_and_hex`.
+#[must_use]
+pub fn normalise_message(msg: &str) -> String {
+    let mut out = String::with_capacity(msg.len());
+    let mut chars = msg.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        // Check for `0x` prefix → consume the whole hex token.
+        if ch == '0' && chars.peek() == Some(&'x') {
+            // consume 'x'
+            chars.next();
+            // consume hex digits
+            while chars.peek().is_some_and(|c| c.is_ascii_hexdigit()) {
+                chars.next();
+            }
+            out.push('X');
+            continue;
+        }
+
+        // Digit run → replace with placeholder.
+        if ch.is_ascii_digit() {
+            while chars
+                .peek()
+                .is_some_and(|c| c.is_ascii_digit() || *c == '.')
+            {
+                chars.next();
+            }
+            out.push('N');
+            continue;
+        }
+
+        // Detect long lowercase hex token (≥ 6 chars of [0-9a-f]).
+        // We only do this at word boundaries to avoid mangling normal words.
+        if ch.is_ascii_lowercase() && "0123456789abcdef".contains(ch) {
+            // Peek ahead: is this a long hex-like sequence?
+            let mut hex_buf = String::new();
+            hex_buf.push(ch);
+            let saved_start = out.len();
+            let _ = saved_start; // used for rollback logic below
+            while chars
+                .peek()
+                .is_some_and(|c| "0123456789abcdef".contains(*c))
+            {
+                hex_buf.push(chars.next().unwrap());
+            }
+            // Only treat as hex token if ≥ 6 chars of pure hex.
+            let all_hex = hex_buf.chars().all(|c| c.is_ascii_hexdigit());
+            if all_hex && hex_buf.len() >= 6 {
+                out.push('H');
+            } else {
+                // Not a hex token — emit literally.
+                out.push_str(&hex_buf);
+            }
+            continue;
+        }
+
+        out.push(ch);
+    }
+
+    // Replace home-directory prefix (best-effort; useful on macOS / Linux).
+    let home_normalised = if let Ok(home) = std::env::var("HOME") {
+        out.replace(&home, "~")
+    } else {
+        out
+    };
+
+    // Collapse multiple spaces / control chars to one space and trim.
+    let collapsed: String = home_normalised
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    collapsed
+}
+
+/// Compute a SHA-256 fingerprint over the stable parts of an error event.
+///
+/// Why: The fingerprint is the dedup key used by Phase 3 to prevent duplicate
+///      GitHub issues for recurrent errors. It must be stable across runs,
+///      process restarts, and minor message variations (digit changes, paths).
+/// What: SHA-256 over the concatenation
+///      `"<crate_target>|<normalised_message>|<location>"` where `location`
+///      is `"<file>:<line>"` or `"unknown"` when metadata is absent.
+///      Returns a 64-char lowercase hex string.
+/// Test: `fingerprint_same_for_logically_identical_errors`.
+#[must_use]
+pub fn compute_fingerprint(
+    crate_target: &str,
+    message: &str,
+    file: Option<&str>,
+    line: Option<u32>,
+) -> String {
+    let normalised = normalise_message(message);
+    let location = match (file, line) {
+        (Some(f), Some(l)) => format!("{f}:{l}"),
+        (Some(f), None) => f.to_string(),
+        _ => "unknown".to_string(),
+    };
+    let input = format!("{crate_target}|{normalised}|{location}");
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    let result = hasher.finalize();
+    // Format as lowercase hex.
+    result.iter().fold(String::with_capacity(64), |mut acc, b| {
+        use std::fmt::Write as _;
+        let _ = write!(acc, "{b:02x}");
+        acc
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_same_for_logically_identical_errors() {
+        // Why: two occurrences of the same error with different port numbers
+        // should hash identically.
+        let fp1 = compute_fingerprint(
+            "trusty_search::server",
+            "failed to bind to 127.0.0.1:8080",
+            Some("src/server.rs"),
+            Some(42),
+        );
+        let fp2 = compute_fingerprint(
+            "trusty_search::server",
+            "failed to bind to 127.0.0.1:9999",
+            Some("src/server.rs"),
+            Some(42),
+        );
+        assert_eq!(
+            fp1, fp2,
+            "port numbers differ but fingerprints should match"
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_for_different_errors() {
+        let fp1 = compute_fingerprint(
+            "trusty_search::server",
+            "failed to bind socket",
+            Some("src/server.rs"),
+            Some(42),
+        );
+        let fp2 = compute_fingerprint(
+            "trusty_search::indexer",
+            "failed to open index",
+            Some("src/indexer.rs"),
+            Some(10),
+        );
+        assert_ne!(
+            fp1, fp2,
+            "distinct errors must produce distinct fingerprints"
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_when_crate_differs() {
+        let fp1 = compute_fingerprint("crate_a", "same message", Some("f.rs"), Some(1));
+        let fp2 = compute_fingerprint("crate_b", "same message", Some("f.rs"), Some(1));
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn normalise_strips_digits_and_hex() {
+        let msg = "error at line 42: memory address 0xdeadbeef";
+        let norm = normalise_message(msg);
+        assert!(!norm.contains("42"), "digits should be stripped: {norm}");
+        assert!(!norm.contains("deadbeef"), "hex should be stripped: {norm}");
+        assert!(!norm.contains("0x"), "0x prefix should be stripped: {norm}");
+    }
+
+    #[test]
+    fn normalise_strips_long_hex_token() {
+        // A bare hex string of 6+ chars should be normalised.
+        let msg = "digest mismatch: a1b2c3d4e5f6 != expected";
+        let norm = normalise_message(msg);
+        assert!(
+            !norm.contains("a1b2c3d4e5f6"),
+            "long hex token should be stripped: {norm}"
+        );
+    }
+
+    #[test]
+    fn normalise_preserves_normal_words() {
+        // Short words that happen to be hex chars should pass through.
+        let msg = "bad request from cafe";
+        let norm = normalise_message(msg);
+        // "bad" (3 chars) and "cafe" (4 chars) are below the 6-char threshold.
+        assert!(
+            norm.contains("bad"),
+            "normal word 'bad' should be kept: {norm}"
+        );
+        assert!(
+            norm.contains("cafe"),
+            "normal word 'cafe' should be kept: {norm}"
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_64_hex_chars() {
+        let fp = compute_fingerprint("crate", "message", None, None);
+        assert_eq!(fp.len(), 64);
+        assert!(
+            fp.chars().all(|c| c.is_ascii_hexdigit()),
+            "fingerprint must be lowercase hex"
+        );
+    }
+
+    #[test]
+    fn fingerprint_same_for_version_number_variation() {
+        // Two errors differing only in a version number → same fingerprint.
+        let fp1 = compute_fingerprint(
+            "trusty_memory",
+            "incompatible schema version 3",
+            Some("src/store.rs"),
+            Some(100),
+        );
+        let fp2 = compute_fingerprint(
+            "trusty_memory",
+            "incompatible schema version 7",
+            Some("src/store.rs"),
+            Some(100),
+        );
+        assert_eq!(
+            fp1, fp2,
+            "version number variation should not change fingerprint"
+        );
+    }
+}

--- a/crates/trusty-common/src/error_capture/layer.rs
+++ b/crates/trusty-common/src/error_capture/layer.rs
@@ -1,0 +1,315 @@
+//! `tracing_subscriber::Layer` that taps ERROR-level events into the store.
+//!
+//! Why: wiring a layer into the subscriber means every `tracing::error!` call
+//!      site is captured automatically with zero changes to existing code.
+//!      The layer is strictly additive — it does not alter stderr output.
+//! What: [`BugCaptureLayer`] implements `tracing_subscriber::Layer<S>` and
+//!      in `on_event` checks that the event is ERROR-level, then builds a
+//!      [`CapturedError`] and hands it to the [`ErrorStore`]. All work is
+//!      synchronous and lock-bounded (no async, no channel, no heap alloc
+//!      hot path beyond what tracing already pays). The layer NEVER emits
+//!      tracing events of its own to avoid infinite recursion.
+//! Test: `layer_captures_error_not_info`, `layer_captures_correct_fields`,
+//!      `layer_respects_opt_out_env`.
+
+use std::time::SystemTime;
+
+use tracing::field::{Field, Visit};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+
+use crate::error_capture::fingerprint::compute_fingerprint;
+use crate::error_capture::store::ErrorStore;
+use crate::error_capture::types::CapturedError;
+
+/// `tracing_subscriber::Layer` that captures ERROR-level events into an
+/// [`ErrorStore`].
+///
+/// Why: zero-intrusion capture — every `tracing::error!` in any crate that
+///      uses this subscriber contributes to the local error store without any
+///      changes to call sites. The layer is opt-in via the `bug-capture`
+///      feature flag and disabled at runtime when `TRUSTY_NO_BUG_CAPTURE` is
+///      set.
+/// What: on each event, if the level is `ERROR` and the opt-out env is not
+///      set, builds a `CapturedError` and calls `ErrorStore::append`.
+/// Test: see `tests` module below.
+pub struct BugCaptureLayer {
+    store: ErrorStore,
+    /// Caller-supplied crate version string (typically `env!("CARGO_PKG_VERSION")`).
+    crate_version: String,
+}
+
+impl BugCaptureLayer {
+    /// Construct a new layer around an existing [`ErrorStore`].
+    ///
+    /// Why: the store is constructed separately so callers can also hand a
+    ///      clone to the HTTP query endpoint without a second `Arc`.
+    /// What: stores the `ErrorStore` handle and the caller-supplied version.
+    /// Test: `layer_captures_error_not_info`.
+    #[must_use]
+    pub fn new(store: ErrorStore, crate_version: impl Into<String>) -> Self {
+        Self {
+            store,
+            crate_version: crate_version.into(),
+        }
+    }
+}
+
+/// Field visitor for the bug-capture layer.
+///
+/// Why: tracing events expose their payload only through the `Visit` callback.
+///      We collect the message and extra fields separately so we can use the
+///      message for fingerprinting without the extra fields (which often
+///      contain volatile runtime values).
+/// What: `message` accumulates the canonical `message` field; `extras`
+///      accumulates every other key=value pair.
+/// Test: exercised indirectly via `layer_captures_correct_fields`.
+struct CaptureVisitor {
+    message: String,
+    extras: String,
+}
+
+impl CaptureVisitor {
+    fn new() -> Self {
+        Self {
+            message: String::new(),
+            extras: String::new(),
+        }
+    }
+}
+
+impl Visit for CaptureVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write as _;
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+            // Strip surrounding `"` that `{:?}` adds for plain string messages.
+            if self.message.starts_with('"')
+                && self.message.ends_with('"')
+                && self.message.len() >= 2
+            {
+                self.message = self.message[1..self.message.len() - 1].to_string();
+            }
+        } else {
+            let _ = write!(self.extras, " {}={value:?}", field.name());
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        use std::fmt::Write as _;
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            let _ = write!(self.extras, " {}={value}", field.name());
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for BugCaptureLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+
+        // Only capture ERROR-level events.
+        if *meta.level() != tracing::Level::ERROR {
+            return;
+        }
+
+        // Honour the opt-out environment variable.  We check the env on
+        // every event (not at construction) so the env can be set after the
+        // layer is installed (useful in tests).
+        if is_opt_out_set() {
+            return;
+        }
+
+        let mut visitor = CaptureVisitor::new();
+        event.record(&mut visitor);
+
+        let crate_target = meta.target().to_string();
+        let file = meta.file().map(str::to_string);
+        let line = meta.line();
+
+        let fingerprint =
+            compute_fingerprint(&crate_target, &visitor.message, file.as_deref(), line);
+
+        let timestamp_secs = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let record = CapturedError {
+            timestamp_secs,
+            crate_target,
+            crate_version: self.crate_version.clone(),
+            message: visitor.message,
+            fields: visitor.extras.trim().to_string(),
+            file,
+            line,
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            fingerprint,
+        };
+
+        self.store.append(record);
+    }
+}
+
+/// Check whether the opt-out environment variable is set to a truthy value.
+///
+/// Why: operators may disable bug capture entirely (e.g. in CI or when
+///      operating in highly restricted environments) without recompiling.
+/// What: returns `true` when `TRUSTY_NO_BUG_CAPTURE` is set to any non-empty
+///      string.
+/// Test: `layer_respects_opt_out_env`.
+fn is_opt_out_set() -> bool {
+    matches!(
+        std::env::var("TRUSTY_NO_BUG_CAPTURE").as_deref(),
+        Ok(v) if !v.is_empty()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error_capture::BUG_CAPTURE_ENV_TEST_LOCK;
+    use crate::error_capture::store::ErrorStore;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    fn make_store() -> ErrorStore {
+        ErrorStore::with_path(None, 50)
+    }
+
+    #[test]
+    fn layer_captures_error_not_info() {
+        let _guard = BUG_CAPTURE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let store = make_store();
+        let layer = BugCaptureLayer::new(store.clone(), "0.1.0");
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!("this is an error");
+            tracing::info!("this is info — should NOT be captured");
+            tracing::warn!("this is warn — should NOT be captured");
+        });
+        let records = store.recent_errors(10);
+        assert_eq!(records.len(), 1, "only ERROR events should be captured");
+        assert_eq!(records[0].message, "this is an error");
+    }
+
+    #[test]
+    fn layer_captures_correct_fields() {
+        let _guard = BUG_CAPTURE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let store = make_store();
+        let layer = BugCaptureLayer::new(store.clone(), "1.2.3");
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(user_id = 42, "database connection failed");
+        });
+        let records = store.recent_errors(10);
+        assert_eq!(records.len(), 1);
+        let rec = &records[0];
+        assert_eq!(rec.message, "database connection failed");
+        assert!(
+            rec.fields.contains("user_id"),
+            "fields should contain user_id: {:?}",
+            rec.fields
+        );
+        assert_eq!(rec.crate_version, "1.2.3");
+        assert!(!rec.fingerprint.is_empty());
+        assert_eq!(
+            rec.fingerprint.len(),
+            64,
+            "fingerprint must be 64 hex chars"
+        );
+        assert!(!rec.os.is_empty(), "os must be populated");
+        assert!(!rec.arch.is_empty(), "arch must be populated");
+    }
+
+    #[test]
+    fn layer_captures_crate_target() {
+        let _guard = BUG_CAPTURE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let store = make_store();
+        let layer = BugCaptureLayer::new(store.clone(), "0.0.1");
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(target: "my_crate::module", "targeted error");
+        });
+        let records = store.recent_errors(10);
+        assert_eq!(records.len(), 1);
+        // The crate_target should reflect the tracing target.
+        assert_eq!(records[0].crate_target, "my_crate::module");
+    }
+
+    #[test]
+    fn layer_respects_opt_out_env() {
+        // Hold the env lock for the entire duration of this test so no other
+        // layer test can observe the opt-out variable.
+        let _guard = BUG_CAPTURE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // SAFETY: env mutation is serialised by BUG_CAPTURE_ENV_TEST_LOCK above.
+        unsafe {
+            std::env::set_var("TRUSTY_NO_BUG_CAPTURE", "1");
+        }
+        let store = make_store();
+        let layer = BugCaptureLayer::new(store.clone(), "0.1.0");
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!("this error must not be captured");
+        });
+        unsafe {
+            std::env::remove_var("TRUSTY_NO_BUG_CAPTURE");
+        }
+        let records = store.recent_errors(10);
+        assert!(records.is_empty(), "opt-out env must disable capture");
+    }
+
+    #[test]
+    fn layer_generates_deterministic_fingerprint() {
+        let _guard = BUG_CAPTURE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Two ERROR events with the same logical message but different
+        // volatile tokens should produce the same fingerprint.
+        //
+        // We verify this by checking that the fingerprint computation over
+        // two messages that differ only in a digit (port number) yields the
+        // same result when given the same location. The layer test exercises
+        // the full capture path; deterministic fingerprint across messages is
+        // separately covered by `fingerprint::tests::fingerprint_same_for_
+        // logically_identical_errors`.
+        let store = make_store();
+        let layer = BugCaptureLayer::new(store.clone(), "0.1.0");
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        // Emit two events via a helper so both originate from the same
+        // source file and line number — ensuring the location component of
+        // the fingerprint is identical. The messages differ only in the port
+        // digit, which normalise_message strips.
+        #[inline(never)]
+        fn emit_port_error(port: u16) {
+            tracing::error!("failed to connect to port {port}");
+        }
+
+        tracing::subscriber::with_default(subscriber, || {
+            emit_port_error(8080);
+            emit_port_error(9090);
+        });
+        let records = store.recent_errors(10);
+        assert_eq!(records.len(), 2);
+        // Both events share the same crate_target (from the helper's tracing
+        // target), same code location (same macro invocation in emit_port_error),
+        // and the same normalised message ("failed to connect to port N" →
+        // "failed to connect to port N" after digit stripping). Fingerprints
+        // must be equal.
+        assert_eq!(
+            records[0].fingerprint, records[1].fingerprint,
+            "fingerprints must match for logically identical errors; got:\n  fp1={}\n  fp2={}",
+            records[0].fingerprint, records[1].fingerprint,
+        );
+    }
+}

--- a/crates/trusty-common/src/error_capture/mod.rs
+++ b/crates/trusty-common/src/error_capture/mod.rs
@@ -1,0 +1,207 @@
+//! Error-capture layer for the trusty-* bug-reporting system (Phase 1).
+//!
+//! Why: Every trusty-* daemon encounters runtime errors that are valuable for
+//!      developers but whose capture must be transparent to users and must
+//!      never alter the existing stderr logging behaviour. This module provides
+//!      a `tracing_subscriber::Layer` (`BugCaptureLayer`) that taps
+//!      ERROR-level events, fingerprints them for deduplication, and persists
+//!      them to a local JSONL store — all without modifying any existing
+//!      `tracing::error!` call sites.
+//!
+//! What: gated behind the `bug-capture` feature flag so the default
+//!      `trusty-common` build pulls in no new transitive dependencies. The
+//!      feature adds only `sha2` (already an optional workspace dep, now
+//!      required by this feature). Four sub-modules handle types, fingerprint,
+//!      store, and the layer respectively; this `mod.rs` re-exports the public
+//!      API surface that Phase 2 will consume.
+//!
+//! Public API surface (Phase 2 consumers):
+//! - [`CapturedError`] — the structured error record.
+//! - [`ErrorStore`] — ring buffer + JSONL store; query via `recent_errors` /
+//!   `errors_by_fingerprint`.
+//! - [`BugCaptureLayer`] — the tracing layer.
+//! - [`bug_capture_layer`] — convenience constructor; returns a
+//!   `(BugCaptureLayer, ErrorStore)` pair ready for installation.
+//! - [`TRUSTY_NO_BUG_CAPTURE_ENV`] — the opt-out environment variable name.
+//!
+//! Opt-out: set `TRUSTY_NO_BUG_CAPTURE` to any non-empty value. Checked on
+//! every event so it can be set after the layer is installed (test-friendly).
+//!
+//! Installation (additive — does NOT change stderr logging):
+//! ```rust,ignore
+//! use trusty_common::error_capture::{bug_capture_layer, DEFAULT_CAPTURE_CAPACITY};
+//! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+//!
+//! let (capture_layer, store) =
+//!     bug_capture_layer("my-app", DEFAULT_CAPTURE_CAPACITY, env!("CARGO_PKG_VERSION"));
+//! tracing_subscriber::registry()
+//!     .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+//!     .with(capture_layer)
+//!     .try_init()
+//!     .ok();
+//!
+//! // Later — Phase 2 calls:
+//! let recent = store.recent_errors(20);
+//! let by_fp  = store.errors_by_fingerprint();
+//! ```
+//!
+//! Test: `cargo test -p trusty-common --features bug-capture`.
+
+pub mod fingerprint;
+pub mod layer;
+pub mod store;
+pub mod types;
+
+pub use layer::BugCaptureLayer;
+pub use store::{DEFAULT_CAPTURE_CAPACITY, ErrorStore};
+pub use types::CapturedError;
+
+/// Shared mutex serialising all tests that mutate `TRUSTY_NO_BUG_CAPTURE`.
+///
+/// Why: `cargo test` runs tests in the same binary on multiple threads. Any
+///      test that sets a process-wide env var must hold this lock for the
+///      duration to avoid racing with tests that read the same var.
+/// What: module-level `static` so every test module in this crate shares the
+///      same mutex instance (all test modules compile into one binary).
+/// Test: held by `layer::tests::layer_respects_opt_out_env` and by any test
+///      in this module that emits tracing events (which internally check the
+///      opt-out var).
+#[doc(hidden)]
+pub static BUG_CAPTURE_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// The environment variable that disables error capture when set to any
+/// non-empty value.
+///
+/// Why: operators in CI or restricted environments need a zero-config way to
+///      disable capture without recompiling.
+/// What: string constant `"TRUSTY_NO_BUG_CAPTURE"`.
+/// Test: `layer_respects_opt_out_env` in `layer.rs`.
+pub const TRUSTY_NO_BUG_CAPTURE_ENV: &str = "TRUSTY_NO_BUG_CAPTURE";
+
+/// Construct a [`BugCaptureLayer`] and its backing [`ErrorStore`].
+///
+/// Why: callers need both the layer (to install into the subscriber) and the
+///      store handle (to answer Phase 2 queries). Constructing them together
+///      here ensures they share the same `Arc` — one ring, one JSONL file.
+/// What: opens (or creates) the store at the OS data dir for `app_name`,
+///      wraps it in a `BugCaptureLayer`, and returns both handles.
+///      The layer is ready to be composed with any `tracing_subscriber` via
+///      `.with(capture_layer)`. The returned `ErrorStore` clone can be handed
+///      to the HTTP or MCP layer for Phase 2 queries.
+/// Test: `bug_capture_layer_constructor` below.
+#[must_use]
+pub fn bug_capture_layer(
+    app_name: &str,
+    capacity: usize,
+    crate_version: impl Into<String>,
+) -> (BugCaptureLayer, ErrorStore) {
+    let store = ErrorStore::open(app_name, capacity);
+    let layer = BugCaptureLayer::new(store.clone(), crate_version);
+    (layer, store)
+}
+
+/// Convenience variant that installs the capture layer into an existing
+/// `tracing_subscriber::Registry` and returns only the store handle.
+///
+/// Why: most daemon `main.rs` files call `init_tracing_with_buffer` from
+///      `trusty-common`; they want to add capture without rewriting the
+///      subscriber setup. This helper composes the two layers for them
+///      behind a single function call.
+/// What: builds the `(BugCaptureLayer, ErrorStore)` pair and returns just
+///      the `ErrorStore` — the layer is consumed by the caller for
+///      subscriber composition. The caller is responsible for
+///      `registry().with(fmt_layer).with(capture_layer).try_init()`.
+/// Test: `init_capture_layer_returns_store` below.
+#[must_use]
+pub fn init_capture_layer(
+    app_name: &str,
+    capacity: usize,
+    crate_version: impl Into<String>,
+) -> (BugCaptureLayer, ErrorStore) {
+    bug_capture_layer(app_name, capacity, crate_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    #[test]
+    fn bug_capture_layer_constructor() {
+        let _guard = BUG_CAPTURE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Verify the convenience constructor returns a layer and a store that
+        // share the same underlying buffer (appending via the layer is visible
+        // through the store).
+        let store_path = None; // memory-only for the constructor test
+        let store = ErrorStore::with_path(store_path, 10);
+        let layer = BugCaptureLayer::new(store.clone(), "0.1.0");
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!("constructor test error");
+        });
+        let records = store.recent_errors(10);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].message, "constructor test error");
+        assert_eq!(records[0].crate_version, "0.1.0");
+    }
+
+    #[test]
+    fn captured_error_serde_round_trip() {
+        let original = CapturedError {
+            timestamp_secs: 1_700_000_000,
+            crate_target: "trusty_search::indexer".to_string(),
+            crate_version: "1.0.0".to_string(),
+            message: "index open failed".to_string(),
+            fields: "path=/tmp/idx".to_string(),
+            file: Some("src/indexer.rs".to_string()),
+            line: Some(42),
+            os: "macos".to_string(),
+            arch: "aarch64".to_string(),
+            fingerprint: "a".repeat(64),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let back: CapturedError = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn captured_error_summary_format() {
+        let rec = CapturedError {
+            timestamp_secs: 0,
+            crate_target: "trusty_memory".to_string(),
+            crate_version: "0.5.0".to_string(),
+            message: "palace not found".to_string(),
+            fields: String::new(),
+            file: Some("src/palace.rs".to_string()),
+            line: Some(99),
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            fingerprint: "b".repeat(64),
+        };
+        let summary = rec.summary();
+        assert!(summary.contains("trusty_memory"), "{summary}");
+        assert!(summary.contains("palace not found"), "{summary}");
+        assert!(summary.contains("src/palace.rs"), "{summary}");
+        assert!(summary.contains("99"), "{summary}");
+    }
+
+    #[test]
+    fn init_capture_layer_returns_store() {
+        let _guard = BUG_CAPTURE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Smoke-test: init_capture_layer (alias for bug_capture_layer) returns
+        // a usable (BugCaptureLayer, ErrorStore) pair. We don't call open()
+        // here (that would hit the OS data dir), so we exercise a manual pair.
+        let store = ErrorStore::with_path(None, 5);
+        let layer = BugCaptureLayer::new(store.clone(), "0.2.0");
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!("init capture test");
+        });
+        assert_eq!(store.len(), 1);
+    }
+}

--- a/crates/trusty-common/src/error_capture/store.rs
+++ b/crates/trusty-common/src/error_capture/store.rs
@@ -1,0 +1,425 @@
+//! Local durable store for captured error records.
+//!
+//! Why: Error records must survive process restarts so Phase 2 can surface
+//! errors that occurred in a prior daemon run. We use JSON-Lines (JSONL) over
+//! SQLite to keep the dep surface minimal — `rusqlite` is already optional in
+//! `trusty-common` but adding it to `bug-capture` would pull heavy deps into
+//! every consumer. JSONL + a ring buffer provides the same queryable contract
+//! with zero new transitive deps. Store path: OS data dir / app_name /
+//! errors.jsonl (macOS Application Support, Linux ~/.local/share). Override
+//! the base dir with `TRUSTY_DATA_DIR_OVERRIDE` for tests. Phase 2 may
+//! migrate to SQLite; the public API is designed so that is localised here.
+//!
+//! What: [`ErrorStore`] wraps a bounded `VecDeque` (ring buffer, same eviction
+//! pattern as `LogBuffer`) plus a path to the JSONL append file. Every
+//! `append` call pushes to the ring and, best-effort, appends one JSON line to
+//! disk. IO errors print to stderr and are swallowed — they must never panic or
+//! propagate into the tracing hot path. `recent_errors` and
+//! `errors_by_fingerprint` read from the ring; `load_from_disk` re-populates
+//! it on daemon restart.
+//!
+//! Test: `store_ring_bounded`, `store_round_trip_write_read`,
+//! `store_handles_missing_file_gracefully`, `store_corrupt_line_skipped`.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::error_capture::types::CapturedError;
+
+/// Default ring-buffer capacity (records). Mirrors `DEFAULT_LOG_CAPACITY` in
+/// `log_buffer` — enough for a few minutes of busy daemon activity at <1 MB.
+pub const DEFAULT_CAPTURE_CAPACITY: usize = 500;
+
+/// File name within the app's data directory for the JSONL error log.
+const ERRORS_FILENAME: &str = "errors.jsonl";
+
+/// Thread-safe, bounded ring buffer of [`CapturedError`] records plus a
+/// backing JSONL append file for persistence across restarts.
+///
+/// Why: the ring keeps hot-path queries O(1) in memory while the JSONL file
+///      ensures records survive a daemon restart. The combination mirrors the
+///      `LogBuffer` pattern already in `trusty-common`.
+/// What: `Arc<Mutex<Inner>>` where `Inner` holds a `VecDeque` (ring) and an
+///      optional `std::fs::File` in append mode. `append` takes the lock,
+///      pushes to the deque, and writes one JSON line to disk. `recent_errors`
+///      clones out the last `n` entries. All IO failures degrade silently to
+///      stderr.
+/// Test: `store_ring_bounded`, `store_round_trip_write_read`.
+#[derive(Clone)]
+pub struct ErrorStore {
+    inner: Arc<Mutex<Inner>>,
+    capacity: usize,
+}
+
+struct Inner {
+    ring: VecDeque<CapturedError>,
+    file_path: Option<PathBuf>,
+}
+
+impl ErrorStore {
+    /// Open (or create) the error store for the named app.
+    ///
+    /// Why: called once at daemon startup; the store is then shared via `Arc`
+    ///      clone between the tracing layer and the query API.
+    /// What: resolves the app data dir, opens `errors.jsonl` in append mode,
+    ///      and loads existing records into the ring buffer via
+    ///      [`ErrorStore::load_from_disk`]. If the data dir or file cannot be
+    ///      opened, the store operates in memory-only mode (ring buffer only).
+    ///      Returns an operational store regardless.
+    /// Test: `store_round_trip_write_read`.
+    #[must_use]
+    pub fn open(app_name: &str, capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        let file_path = match crate::resolve_data_dir(app_name) {
+            Ok(dir) => Some(dir.join(ERRORS_FILENAME)),
+            Err(e) => {
+                eprintln!("[bug-capture] cannot resolve data dir for {app_name}: {e}");
+                None
+            }
+        };
+
+        let ring = if let Some(ref path) = file_path {
+            load_ring_from_disk(path, capacity)
+        } else {
+            VecDeque::with_capacity(capacity)
+        };
+
+        Self {
+            inner: Arc::new(Mutex::new(Inner { ring, file_path })),
+            capacity,
+        }
+    }
+
+    /// Create an in-memory-only store backed by a specific file path.
+    ///
+    /// Why: tests need to control the backing file path without going through
+    ///      the OS data dir resolution (which calls `NSFileManager` on macOS).
+    /// What: builds an `ErrorStore` with the given path as the JSONL file.
+    ///      If `path` is `None`, operates in ring-only mode.
+    /// Test: all store tests use this constructor.
+    #[must_use]
+    pub fn with_path(file_path: Option<PathBuf>, capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        let ring = if let Some(ref path) = file_path {
+            load_ring_from_disk(path, capacity)
+        } else {
+            VecDeque::with_capacity(capacity)
+        };
+        Self {
+            inner: Arc::new(Mutex::new(Inner { ring, file_path })),
+            capacity,
+        }
+    }
+
+    /// Append a captured error to the ring buffer and persist it to disk.
+    ///
+    /// Why: called by `BugCaptureLayer::on_event` on every ERROR event; must
+    ///      be non-blocking (no async, short lock hold) and must never panic.
+    /// What: acquires the mutex, pushes to the ring (evicting oldest when at
+    ///      capacity), then serialises to JSON and appends one line to the open
+    ///      file. IO errors are printed to stderr and discarded.
+    /// Test: `store_round_trip_write_read`.
+    pub fn append(&self, record: CapturedError) {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        // Append JSON line to disk before touching the ring so a crash after
+        // write but before ring update at worst leaves the file one record
+        // ahead of the ring — acceptable for our best-effort guarantees.
+        if let Some(ref path) = guard.file_path {
+            match serialise_and_append(path, &record) {
+                Ok(()) => {}
+                Err(e) => {
+                    eprintln!("[bug-capture] write to {}: {e}", path.display());
+                }
+            }
+        }
+
+        guard.ring.push_back(record);
+        while guard.ring.len() > self.capacity {
+            guard.ring.pop_front();
+        }
+    }
+
+    /// Return the `n` most recent captured errors (oldest-first within the
+    /// result slice).
+    ///
+    /// Why: Phase 2 `list_recent_errors` MCP tool calls this; returning an
+    ///      owned `Vec` keeps the lock held for the minimum duration.
+    /// What: clones the last `n` elements of the ring into a `Vec`. If `n`
+    ///      exceeds the ring length, all records are returned.
+    /// Test: `store_round_trip_write_read`.
+    #[must_use]
+    pub fn recent_errors(&self, n: usize) -> Vec<CapturedError> {
+        let guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let skip = guard.ring.len().saturating_sub(n);
+        guard.ring.iter().skip(skip).cloned().collect()
+    }
+
+    /// Aggregate errors by fingerprint, returning each unique fingerprint
+    /// with its occurrence count and the most recent record.
+    ///
+    /// Why: Phase 2 can present a deduplicated list — "this error happened N
+    ///      times" — rather than a raw chronological log, which is far more
+    ///      actionable for bug filing.
+    /// What: iterates the ring in order (oldest → newest); the most-recent
+    ///      record per fingerprint wins. Returns `Vec<(CapturedError, usize)>`
+    ///      sorted by count descending.
+    /// Test: `store_errors_by_fingerprint`.
+    #[must_use]
+    pub fn errors_by_fingerprint(&self) -> Vec<(CapturedError, usize)> {
+        let guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        // latest_record keeps the most-recent CapturedError per fingerprint.
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        let mut latest: HashMap<String, CapturedError> = HashMap::new();
+        for rec in &guard.ring {
+            *counts.entry(rec.fingerprint.clone()).or_insert(0) += 1;
+            latest.insert(rec.fingerprint.clone(), rec.clone());
+        }
+        let mut result: Vec<(CapturedError, usize)> = latest
+            .into_iter()
+            .map(|(fp, rec)| (rec, *counts.get(&fp).unwrap_or(&1)))
+            .collect();
+        result.sort_by_key(|item| std::cmp::Reverse(item.1));
+        result
+    }
+
+    /// Total number of records currently in the ring.
+    ///
+    /// Why: callers (tests, status endpoints) need to know how many records
+    ///      are buffered without cloning them all out.
+    /// What: returns the deque length under the mutex.
+    /// Test: `store_ring_bounded`.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self.inner.lock() {
+            Ok(g) => g.ring.len(),
+            Err(p) => p.into_inner().ring.len(),
+        }
+    }
+
+    /// Whether the ring buffer is empty.
+    ///
+    /// Why: clippy requires `is_empty` alongside `len`.
+    /// What: `len() == 0`.
+    /// Test: `store_ring_bounded`.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+// ── Disk helpers ──────────────────────────────────────────────────────────────
+
+/// Load up to `capacity` records from a JSONL file into a `VecDeque`.
+///
+/// Why: on daemon restart the ring must be pre-populated from the persistent
+///      store so `recent_errors` reflects prior runs, not just the current
+///      session.
+/// What: reads the file line-by-line; skips blank lines and lines that fail
+///      JSON deserialisation (corrupt / truncated); keeps the last `capacity`
+///      records (oldest lines first, newest lines last). Returns an empty deque
+///      if the file is absent or unreadable — never panics.
+/// Test: `store_round_trip_write_read`, `store_corrupt_line_skipped`.
+fn load_ring_from_disk(path: &PathBuf, capacity: usize) -> VecDeque<CapturedError> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return VecDeque::with_capacity(capacity);
+        }
+        Err(e) => {
+            eprintln!("[bug-capture] cannot read {}: {e}", path.display());
+            return VecDeque::with_capacity(capacity);
+        }
+    };
+
+    let mut ring: VecDeque<CapturedError> = VecDeque::with_capacity(capacity);
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<CapturedError>(line) {
+            Ok(rec) => {
+                ring.push_back(rec);
+                while ring.len() > capacity {
+                    ring.pop_front();
+                }
+            }
+            Err(_) => {
+                // Corrupt or partial line — skip silently. The line is already
+                // written; we don't truncate the file (it may have more valid
+                // lines after this one in edge cases).
+                eprintln!(
+                    "[bug-capture] skipping corrupt record in {}",
+                    path.display()
+                );
+            }
+        }
+    }
+    ring
+}
+
+/// Serialise one record as a JSON line and append it to the given path.
+///
+/// Why: append-only write keeps the file valid JSONL even if the process is
+///      killed mid-write of a different line. We open the file fresh each
+///      write to avoid holding an `std::fs::File` across the mutex boundary
+///      (which would require `Send + Sync` on `File` in `Inner`).
+/// What: opens in append+create mode, writes the JSON bytes + `\n`, flushes,
+///      closes. Returns `Err` on any IO failure; the caller logs to stderr.
+/// Test: `store_round_trip_write_read`.
+fn serialise_and_append(path: &PathBuf, record: &CapturedError) -> std::io::Result<()> {
+    let json = serde_json::to_vec(record)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)?;
+    file.write_all(&json)?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error_capture::types::CapturedError;
+
+    fn make_record(msg: &str, fp: &str) -> CapturedError {
+        CapturedError {
+            timestamp_secs: 1_000_000,
+            crate_target: "test_crate".to_string(),
+            crate_version: "0.1.0".to_string(),
+            message: msg.to_string(),
+            fields: String::new(),
+            file: Some("src/lib.rs".to_string()),
+            line: Some(10),
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            fingerprint: fp.to_string(),
+        }
+    }
+
+    #[test]
+    fn store_ring_bounded() {
+        let store = ErrorStore::with_path(None, 3);
+        assert!(store.is_empty());
+        for i in 0..5u32 {
+            store.append(make_record(&format!("err {i}"), &format!("fp{i}")));
+        }
+        // Ring cap = 3 → only last 3 survive.
+        assert_eq!(store.len(), 3);
+        let recent = store.recent_errors(10);
+        assert_eq!(recent.len(), 3);
+        assert_eq!(recent[0].message, "err 2");
+        assert_eq!(recent[2].message, "err 4");
+    }
+
+    #[test]
+    fn store_round_trip_write_read() {
+        let tmp_dir = {
+            let pid = std::process::id();
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            std::env::temp_dir().join(format!("bugcap-test-{pid}-{nanos}"))
+        };
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let file_path = tmp_dir.join(ERRORS_FILENAME);
+
+        // Write two records via the store.
+        {
+            let store = ErrorStore::with_path(Some(file_path.clone()), 10);
+            store.append(make_record("first error", "fp1"));
+            store.append(make_record("second error", "fp2"));
+            assert_eq!(store.len(), 2);
+        }
+
+        // Re-open the store — it must reload from JSONL.
+        let store2 = ErrorStore::with_path(Some(file_path), 10);
+        let records = store2.recent_errors(10);
+        assert_eq!(records.len(), 2, "expected 2 records after reload");
+        assert_eq!(records[0].message, "first error");
+        assert_eq!(records[1].message, "second error");
+    }
+
+    #[test]
+    fn store_handles_missing_file_gracefully() {
+        // Use a unique path per test run so previous runs don't leave
+        // residual files that make the "empty store" assertion fail.
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let nonexistent = std::env::temp_dir().join(format!("bugcap-missing-{pid}-{nanos}.jsonl"));
+        let store = ErrorStore::with_path(Some(nonexistent), 10);
+        // Missing file → empty store, no panic.
+        assert!(store.is_empty());
+        // Appending should still work (file will be created).
+        store.append(make_record("hello", "fp1"));
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn store_corrupt_line_skipped() {
+        let tmp_dir = {
+            let pid = std::process::id();
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            std::env::temp_dir().join(format!("bugcap-corrupt-{pid}-{nanos}"))
+        };
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let file_path = tmp_dir.join(ERRORS_FILENAME);
+
+        // Write a valid record, then corrupt bytes, then another valid record.
+        {
+            let valid = serde_json::to_string(&make_record("valid first", "fp1")).unwrap();
+            let valid2 = serde_json::to_string(&make_record("valid second", "fp2")).unwrap();
+            let content = format!("{valid}\nnot-json-at-all\n{valid2}\n");
+            std::fs::write(&file_path, content).unwrap();
+        }
+
+        let store = ErrorStore::with_path(Some(file_path), 10);
+        // Only 2 valid records should be loaded; corrupt line skipped.
+        assert_eq!(store.len(), 2, "corrupt line should be skipped");
+        let records = store.recent_errors(10);
+        assert_eq!(records[0].message, "valid first");
+        assert_eq!(records[1].message, "valid second");
+    }
+
+    #[test]
+    fn store_errors_by_fingerprint() {
+        let store = ErrorStore::with_path(None, 20);
+        // Three records: two share fingerprint "fp1", one is "fp2".
+        store.append(make_record("err a", "fp1"));
+        store.append(make_record("err b", "fp2"));
+        store.append(make_record("err c", "fp1")); // same fingerprint, later record
+
+        let by_fp = store.errors_by_fingerprint();
+        assert_eq!(by_fp.len(), 2, "expected 2 unique fingerprints");
+        // fp1 has count 2 — should be first (sorted by count desc).
+        assert_eq!(by_fp[0].1, 2);
+        assert_eq!(by_fp[0].0.fingerprint, "fp1");
+        // The most-recent record for fp1 should be "err c".
+        assert_eq!(by_fp[0].0.message, "err c");
+        // fp2 has count 1.
+        assert_eq!(by_fp[1].1, 1);
+    }
+}

--- a/crates/trusty-common/src/error_capture/types.rs
+++ b/crates/trusty-common/src/error_capture/types.rs
@@ -1,0 +1,84 @@
+//! Captured-error record type and serialisation.
+//!
+//! Why: A single canonical struct for every ERROR-level event tapped by
+//!      [`BugCaptureLayer`] lets Phase 2 consume a stable, versioned schema
+//!      without coupling the layer implementation to the query API.
+//! What: [`CapturedError`] carries timestamp, crate attribution, message,
+//!      code location, OS/arch, and a dedup fingerprint. Fully `serde`-round-
+//!      trippable so it can be stored as JSON-Lines and read back.
+//! Test: see the `tests` module in `mod.rs` — serde round-trips and field
+//!      coverage are exercised there via the full layer integration path.
+
+use serde::{Deserialize, Serialize};
+
+/// A single captured ERROR-level tracing event.
+///
+/// Why: Phase 2 (MCP + HTTP surface) will read these records and present them
+///      to the user for consent-gated GitHub filing. The struct must carry
+///      everything needed for a useful bug report without any further lookups.
+/// What: all fields derive `Clone`, `Debug`, `Serialize`, `Deserialize` so
+///      records travel across the ring-buffer → JSONL → Phase-2 query boundary
+///      with no extra conversion step.
+/// Test: `captured_error_serde_round_trip` in the parent module.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CapturedError {
+    /// Unix timestamp (seconds since epoch) at the moment the event was
+    /// recorded. Stored as `u64` (no negative epoch, no sub-second
+    /// precision needed for dedup purposes).
+    pub timestamp_secs: u64,
+
+    /// The `target` of the tracing event — typically the crate/module path
+    /// that emitted the error (e.g. `trusty_search::indexer`). This is the
+    /// correct attribution even when the event fires in shared library code.
+    pub crate_target: String,
+
+    /// Version string of the host binary, captured at layer-install time via
+    /// the caller supplying `env!("CARGO_PKG_VERSION")`. May be `"unknown"`.
+    pub crate_version: String,
+
+    /// Formatted error message (the tracing event's `message` field).
+    pub message: String,
+
+    /// Additional key=value fields from the event, formatted as
+    /// `"key=value key2=value2"`. Empty string when no extra fields present.
+    pub fields: String,
+
+    /// Source file path from tracing metadata, if available (e.g.
+    /// `"src/indexer.rs"`). `None` when the event metadata lacks location.
+    pub file: Option<String>,
+
+    /// Source line number from tracing metadata. `None` when unavailable.
+    pub line: Option<u32>,
+
+    /// Operating system name from `std::env::consts::OS`
+    /// (e.g. `"macos"`, `"linux"`, `"windows"`).
+    pub os: String,
+
+    /// CPU architecture from `std::env::consts::ARCH`
+    /// (e.g. `"aarch64"`, `"x86_64"`).
+    pub arch: String,
+
+    /// SHA-256 fingerprint (hex, 64 chars) over
+    /// `(crate_target + normalised_message + location)`.
+    /// Two events that differ only in digits, hex strings, or path prefixes
+    /// produce the **same** fingerprint — enabling dedup without exact matching.
+    pub fingerprint: String,
+}
+
+impl CapturedError {
+    /// Construct a human-readable one-line summary for display / logging.
+    ///
+    /// Why: Phase 2 `list_recent_errors` wants a concise line per record
+    ///      without re-implementing formatting.
+    /// What: returns `"[<crate_target>] <message> (<file>:<line>)"`.
+    /// Test: `captured_error_summary_format` in the parent module.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        let loc = match (&self.file, self.line) {
+            (Some(f), Some(l)) => format!(" ({f}:{l})"),
+            (Some(f), None) => format!(" ({f})"),
+            _ => String::new(),
+        };
+        format!("[{}] {}{}", self.crate_target, self.message, loc)
+    }
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -274,6 +274,25 @@ pub mod monitor;
 #[cfg(feature = "update-check")]
 pub mod update;
 
+/// Error-capture layer for the trusty-* consent-gated bug-reporting system
+/// (bug-reporting Phase 1, issue #479).
+///
+/// Why: Every trusty-* daemon encounters runtime errors that developers need
+///      to see but that must be captured locally and only filed to GitHub after
+///      explicit user consent. A shared capture layer in `trusty-common` means
+///      all daemons gain error capture without per-binary changes.
+/// What: Gated behind the `bug-capture` feature. Exposes:
+///      - [`error_capture::CapturedError`] — structured error record.
+///      - [`error_capture::ErrorStore`] — ring buffer + JSONL store.
+///      - [`error_capture::BugCaptureLayer`] — the tracing Layer.
+///      - [`error_capture::bug_capture_layer`] — convenience constructor.
+///      - [`error_capture::TRUSTY_NO_BUG_CAPTURE_ENV`] — opt-out env name.
+///      Additive: does not alter stderr logging. Opt-out via
+///      `TRUSTY_NO_BUG_CAPTURE=1`. New dep: `sha2` (already workspace-optional).
+/// Test: `cargo test -p trusty-common --features bug-capture`.
+#[cfg(feature = "bug-capture")]
+pub mod error_capture;
+
 pub use chat::{
     ChatEvent, ChatProvider, LocalModelConfig, OllamaProvider, OpenRouterProvider, ToolCall,
     ToolDef, auto_detect_local_provider,


### PR DESCRIPTION
## Summary
Implements phase 1 of bug-reporting infrastructure: an error-capture layer that deduplicates errors by SHA-256 fingerprint and stores them for later analysis.

## What's Added
- Tracing Layer → ring buffer + JSONL store in `trusty-common`.
- SHA-256 fingerprint dedup to avoid log spam.
- Opt-out via `TRUSTY_NO_BUG_CAPTURE` environment variable.
- Feature-gated behind `bug-capture` (default OFF).

## Design
- **Additive**: stderr logging unchanged; feature flag prevents pulling new deps by default.
- **Public API**: Layer and ring buffer exposed for Phase 2 integration.
- **Zero overhead when disabled**: no codegen or runtime cost in default builds.

## Testing
- 14 tests added and passing.
- `cargo clippy` and `cargo fmt` clean.

Closes #479