### PR TITLE
docs: fix README crate refs (#398), pre-commit mypy path (#414), CLAUDE.md drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,10 +222,20 @@ concept, a thin `mod.rs` that re-exports, and sibling files with clear single
 responsibilities. File a refactor ticket for any existing file that already exceeds
 500 lines rather than continuing to grow it.
 
-Current known violations (file refactor tickets open):
-- `crates/open-mpm/src/ctrl/mod.rs` (~5,730 lines) → #170
-- `crates/open-mpm/src/runtime.rs` (~5,148 lines) → #171
-- `crates/open-mpm/src/workflow/engine.rs` (~4,965 lines) → #172
+Past violations (refactor tickets #170/#171/#172 are CLOSED and the splits have
+landed — all three former monoliths are now under the 500-line cap):
+- `crates/open-mpm/src/ctrl/mod.rs` — RESOLVED (#170). Split into focused
+  submodules under `crates/open-mpm/src/ctrl/` (`state`, `config`, `repl`,
+  `handlers`, `pm_task`, …); `mod.rs` is now a ~50-line re-export facade.
+- `crates/open-mpm/src/runtime/` — RESOLVED (#171). The original `runtime.rs`
+  was split into a `runtime/` module; every submodule is now under the cap.
+- `crates/open-mpm/src/workflow/engine/` — RESOLVED (#172). The original
+  `engine.rs` was split into an `engine/` module; every submodule is now under
+  the cap (largest is `engine/executor/run.rs` at ~485 lines).
+
+The largest remaining files in `open-mpm` (none tied to an open ticket) are
+`tools/memory/tests.rs` (~605) and `tm/manager.rs` (~570) — file a fresh refactor
+ticket before growing those further.
 
 🔴 **`thiserror` for libraries, `anyhow` for binaries** — library crates
 (`trusty-common`, `trusty-embedderd`, `trusty-bm25-daemon`, etc.) define structured error enums with
@@ -546,8 +556,9 @@ them. All patches must live in the root `Cargo.toml`.
 🔴 **Growing a file past 500 lines instead of splitting** — the compiler does not
 stop you, but continued feature additions to a 1,000+ line file make the module
 harder to review, reason about, and test. Split proactively. The open-mpm `ctrl/`,
-`runtime.rs`, and `workflow/engine.rs` files (#170, #171, #172) are the canonical
-bad examples of what happens when this rule isn't enforced.
+`runtime/`, and `workflow/engine/` modules (#170, #171, #172) were the canonical
+examples of files that grew past the cap; all three have since been split into
+focused submodules and now serve as the worked examples of a clean split.
 
 🟢 **MSRV drift** — the workspace pins `rust-version = "1.88"`. Running
 `rustup update` and picking up a new nightly may introduce syntax that

--- a/README.md
+++ b/README.md
@@ -47,18 +47,18 @@ Long-term memory storage with semantic search, persistent embedding index, and e
 
 **Quick start:**
 ```bash
-cargo run -p trusty-memory-mcp -- serve
+cargo run -p trusty-memory -- serve
 # Or via MCP stdio:
 # Add to ~/.claude/claude_desktop_config.json:
 # "trusty-memory": {
 #   "command": "cargo",
-#   "args": ["run", "-p", "trusty-memory-mcp", "--", "serve"]
+#   "args": ["run", "-p", "trusty-memory", "--", "serve"]
 # }
 ```
 
 **MCP tools:** `store_memory`, `search_memories`, `update_memory`, `list_collections`, `create_collection`, `get_memory`, `delete_memory`
 
-See [crates/trusty-memory-mcp/README.md](crates/trusty-memory-mcp/README.md) for full documentation.
+See [crates/trusty-memory/README.md](crates/trusty-memory/README.md) for full documentation.
 
 ---
 
@@ -111,8 +111,7 @@ documentation.
 | Crate | Description | License |
 |---|---|---|
 | `trusty-search` | Hybrid code search (BM25 + vector + KG) + MCP server | Elastic-2.0 |
-| `trusty-memory-core` | Memory storage engine (usearch + SQLite + embeddings) | MIT |
-| `trusty-memory-mcp` | Memory palace UI + MCP frontend | MIT |
+| `trusty-memory` | Memory palace UI + MCP frontend (storage engine lives in `trusty-common`'s `memory-core` feature) | MIT |
 | `trusty-analyze` | Code-analysis sidecar daemon (complexity, smells, facts) + MCP server | MIT |
 
 ### Shared Libraries
@@ -212,10 +211,10 @@ cargo fmt
 
 **MSRV:** Rust 1.88+ (required for `let-chains` used by `trusty-mpm-*` and `open-mpm` in edition 2024)
 
-**License:** Elastic License 2.0 (most crates), MIT (trusty-memory-core, trusty-memory-mcp, trusty-gworkspace). See each crate's `Cargo.toml` for the authoritative license field.
+**License:** Elastic License 2.0 (most crates), MIT (trusty-memory, trusty-analyze). See each crate's `Cargo.toml` for the authoritative license field.
 
 **Where to start:**
 - **I want to search code:** Read [crates/trusty-search/README.md](crates/trusty-search/README.md)
-- **I want persistent memory:** Read [crates/trusty-memory-mcp/README.md](crates/trusty-memory-mcp/README.md)
+- **I want persistent memory:** Read [crates/trusty-memory/README.md](crates/trusty-memory/README.md)
 - **I want the full platform:** Read [crates/open-mpm/README.md](crates/open-mpm/README.md)
 


### PR DESCRIPTION
Batched documentation/config quick-wins. No Rust source changes.

## Task 1 — #398: README references to removed `trusty-memory-mcp` crate
The `trusty-memory-mcp` and `trusty-memory-core` crates no longer exist (consolidated into `trusty-memory`; storage engine moved to `trusty-common`s `memory-core` feature). Fixed in `README.md`:
- `cargo run -p trusty-memory-mcp -- serve` -> `-p trusty-memory` (quick-start + commented MCP stdio config).
- Dead links `crates/trusty-memory-mcp/README.md` -> `crates/trusty-memory/README.md` (two places).
- Crate-table: collapsed the two stale rows into one `trusty-memory` row (MIT), noting the storage engine lives behind `trusty-common`s `memory-core` feature.
- License line: corrected to `MIT (trusty-memory, trusty-analyze)`. Verified per-crate `Cargo.toml`: trusty-memory=MIT, trusty-analyze=MIT, **trusty-gworkspace=Elastic-2.0** (the task hint that gworkspace is MIT was wrong; reflected reality).
- Left `trusty-memory-mcp-bridge` untouched (not present in README; that binary name is real).

## Task 2 — #414: pre-commit mypy config path
No `mypy.ini` at repo root and no `[tool.mypy]` in any `pyproject.toml`. The only real mypy config is `crates/open-mpm/mypy.ini`. Fixed the hook arg to `--config-file=crates/open-mpm/mypy.ini` (least-surprising: keeps type-checking configured against the existing config rather than dropping it or inventing a new root file).

## Task 5 — CLAUDE.md drift (#170/#171/#172)
All three refactor tickets are **CLOSED** and the splits have **landed**: `ctrl/`, `runtime/`, and `workflow/engine/` are now modules whose submodules are all under the 500-line cap (verified by recursive `wc -l`; largest is `workflow/engine/executor/run.rs` ~485). Updated the "Current known violations" list and the "canonical bad examples" wording to stop claiming open tickets / oversized files, and noted the two largest unrelated files (`tools/memory/tests.rs` ~605, `tm/manager.rs` ~570) for a future ticket.

## Verify-close tasks (handled separately on the issues)
- **#473** (split discover.rs): NOT met — `trusty-search/src/commands/discover.rs` is still 559 lines. Left open; no refactor in this PR.
- **#407** (tga `llm:` config): resolved by merged #416 (LlmConfig/LlmSource implemented + consumed by classification pipeline). Closed referencing #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)