### PR TITLE
fix: point pre-commit mypy --config-file at crates/open-mpm/mypy.ini (#414)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-PyYAML, types-requests]
-        args: ['--config-file=mypy.ini']
+        args: ['--config-file=crates/open-mpm/mypy.ini']
         exclude: ^(venv/|\.venv/|env/|\.env/|build/|dist/|\.git/|tests/.*\.py|scripts/.*\.py)
 
   # Security scanning with bandit


### PR DESCRIPTION
Follow-up to #509. The Task-2 edit (#414) was lost before that commit, so the mypy hook still pointed at a nonexistent root `mypy.ini`. This applies the fix on its own.

## #414 — pre-commit mypy config path
Investigation:
- No `mypy.ini` at the repo root.
- No `[tool.mypy]` section in any `pyproject.toml` (none of the Python-adjacent crates carry one).
- The only real mypy config is **`crates/open-mpm/mypy.ini`**.

Fix: point the hook arg at the existing config — `--config-file=crates/open-mpm/mypy.ini` — rather than dropping the arg (which would silently change type-check behavior) or inventing a new root file. The hook already excludes `scripts/.*\.py` and `tests/.*\.py`, so it effectively targets the open-mpm Python helpers this config was written for.

Verified `pre-commit run check-yaml` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)