### PR TITLE
feat(trusty-search): storage hygiene — prune-orphans + moved-project relocation (v0.20.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10986,7 +10986,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10986,7 +10986,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.20.2"
+version = "0.20.3"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/commands/mod.rs
+++ b/crates/trusty-search/src/commands/mod.rs
@@ -44,6 +44,7 @@ pub mod list;
 pub mod migrate;
 pub mod migrate_storage;
 pub mod monitor;
+pub mod prune_orphans;
 pub mod query;
 pub mod reindex;
 pub mod remove;

--- a/crates/trusty-search/src/commands/prune_orphans.rs
+++ b/crates/trusty-search/src/commands/prune_orphans.rs
@@ -1,0 +1,288 @@
+//! Handler for `trusty-search prune-orphans` (issue #489).
+//!
+//! Why: over time, the `indexes.toml` registry accumulates entries whose
+//! `root_path` no longer exists — projects deleted from disk, wiped volumes
+//! (e.g. `/Volumes/Kemono`), or `/tmp` test indexes. These orphaned entries
+//! clutter startup logs ("no durable corpus"), waste registry space, and
+//! are never reachable by a reindex. A dedicated offline command lets operators
+//! batch-remove them without needing the daemon to be running.
+//!
+//! What: loads `indexes.toml`, identifies entries whose `root_path` does not
+//! exist on disk, prints the list, and (unless `--dry-run`) asks for
+//! confirmation before removing them via the existing atomic save path.
+//! `--dry-run` previews the list and exits with no mutations.
+//! Works entirely OFFLINE — no daemon connection required.
+//!
+//! Test: `prune_orphans_removes_dead_root_entries`,
+//! `prune_orphans_preserves_live_root_entries`,
+//! `prune_orphans_dry_run_mutates_nothing`.
+
+use anyhow::Result;
+use colored::Colorize;
+use std::io::{BufRead, Write};
+
+use crate::service::persistence::{
+    indexes_toml_path, load_index_registry_at, save_index_registry_at, PersistedIndex,
+};
+
+/// Why: a small record per orphaned entry keeps the display and removal
+/// logic independent of the full `PersistedIndex` shape.
+/// What: holds the id and the dead root path (for display only).
+/// Test: covered transitively by `handle_prune_orphans`.
+struct OrphanEntry {
+    id: String,
+    root_path: String,
+}
+
+/// Handle `trusty-search prune-orphans [--dry-run] [--yes]`.
+///
+/// Why: extracted so `main()` stays thin and this function is independently
+/// testable with path-injectable helpers.
+/// What: loads the registry, filters to entries whose `root_path` does not
+/// exist, prints the table, prompts for confirmation (unless `--yes` or
+/// `--dry-run`), then removes the orphans from disk via `save_index_registry_at`.
+/// `--dry-run` overrides `--yes` — it never mutates the registry.
+/// Test: `cargo run -p trusty-search -- prune-orphans --dry-run` prints the
+/// table and exits 0 without modifying `indexes.toml`.
+pub fn handle_prune_orphans(dry_run: bool, yes: bool) -> Result<()> {
+    let toml_path = indexes_toml_path()?;
+    handle_prune_orphans_at(&toml_path, dry_run, yes, /*interactive=*/ true)
+}
+
+/// Path-injectable variant of [`handle_prune_orphans`].
+///
+/// Why: tests need to drive this against a tempfile registry without touching
+/// the user's real `~/Library/Application Support/trusty-search/indexes.toml`.
+/// What: same logic as `handle_prune_orphans`, but reads from and writes to
+/// `toml_path` instead of the platform default. `interactive` must be `false`
+/// in tests so the stdin-prompt branch is never hit.
+/// Test: all `prune_orphans_*` unit tests call this variant.
+pub(crate) fn handle_prune_orphans_at(
+    toml_path: &std::path::Path,
+    dry_run: bool,
+    yes: bool,
+    interactive: bool,
+) -> Result<()> {
+    // 1. Load the registry.
+    let entries = load_index_registry_at(toml_path)?;
+
+    if entries.is_empty() {
+        println!("Registry is empty — nothing to prune.");
+        return Ok(());
+    }
+
+    // 2. Classify: orphaned (root_path missing) vs. live.
+    let (orphans, live): (Vec<PersistedIndex>, Vec<PersistedIndex>) =
+        entries.into_iter().partition(|e| !e.root_path.exists());
+
+    if orphans.is_empty() {
+        println!(
+            "{} All {} registered index(es) have live root paths — nothing to prune.",
+            "✓".green(),
+            live.len()
+        );
+        return Ok(());
+    }
+
+    let orphan_records: Vec<OrphanEntry> = orphans
+        .iter()
+        .map(|e| OrphanEntry {
+            id: e.id.clone(),
+            root_path: e.root_path.display().to_string(),
+        })
+        .collect();
+
+    // 3. Print the table.
+    let count = orphan_records.len();
+    println!(
+        "{} {} orphaned index registration(s) (root_path missing):",
+        "Found".bold(),
+        count.to_string().bold()
+    );
+    let name_width = orphan_records
+        .iter()
+        .map(|e| e.id.len())
+        .max()
+        .unwrap_or(0)
+        .max(4);
+    for e in &orphan_records {
+        println!(
+            "  {:<width$}  {}",
+            e.id.bold(),
+            e.root_path.dimmed(),
+            width = name_width
+        );
+    }
+
+    // 4. Dry-run: stop here, no mutations.
+    if dry_run {
+        println!(
+            "{} dry-run: {} registration(s) would be removed. Re-run without --dry-run to apply.",
+            "ℹ".cyan(),
+            count
+        );
+        return Ok(());
+    }
+
+    // 5. Prompt unless --yes or non-interactive.
+    if !yes {
+        if !interactive {
+            // Non-interactive (tests): treat as cancelled.
+            println!("Aborted (non-interactive mode).");
+            return Ok(());
+        }
+        if !confirm(&format!(
+            "Remove {} orphaned registration(s) from indexes.toml?",
+            count
+        ))? {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // 6. Write the pruned registry (live entries only).
+    save_index_registry_at(toml_path, &live)?;
+
+    println!(
+        "{} Removed {} orphaned registration(s) from indexes.toml. {} registration(s) remain.",
+        "✓".green(),
+        count.to_string().bold(),
+        live.len()
+    );
+
+    Ok(())
+}
+
+/// Why: keep the y/N prompt isolated so tests bypass it via `interactive=false`.
+/// What: prints `<prompt> [y/N] ` to stdout, reads one line from stdin, returns
+/// `true` when the trimmed reply starts with `y` or `Y`. Empty input → false.
+/// Test: side-effect-only; exercised manually.
+fn confirm(prompt: &str) -> Result<bool> {
+    print!("{} [y/N] ", prompt);
+    std::io::stdout().flush().ok();
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+    let answer = line.trim();
+    Ok(matches!(answer.chars().next(), Some('y') | Some('Y')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::persistence::{save_index_registry_at, PersistedIndex};
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn entry(id: &str, root: &str) -> PersistedIndex {
+        PersistedIndex {
+            id: id.to_string(),
+            root_path: PathBuf::from(root),
+            ..Default::default()
+        }
+    }
+
+    /// Why: the core contract — an entry whose root_path does not exist must be
+    /// removed from indexes.toml by prune-orphans.
+    /// What: write a registry with one dead-root entry, run prune_orphans, reload
+    /// the registry, assert the dead entry is gone.
+    /// Test: this test.
+    #[test]
+    fn prune_orphans_removes_dead_root_entries() {
+        let tmp = tempdir().unwrap();
+        let toml_path = tmp.path().join("indexes.toml");
+
+        // Dead root (non-existent path).
+        let dead = entry("ghost", "/tmp/trusty-prune-orphans-dead-root-xyz9999");
+        // Live root (the tempdir itself exists).
+        let live_root = tmp.path().to_path_buf();
+        let live = PersistedIndex {
+            id: "live".into(),
+            root_path: live_root.clone(),
+            ..Default::default()
+        };
+
+        save_index_registry_at(&toml_path, &[dead, live]).unwrap();
+        assert_eq!(
+            load_index_registry_at(&toml_path).unwrap().len(),
+            2,
+            "setup: both entries must be in the registry"
+        );
+
+        // Run prune-orphans (non-interactive, no dry-run).
+        handle_prune_orphans_at(
+            &toml_path, /*dry_run=*/ false, /*yes=*/ true, /*interactive=*/ false,
+        )
+        .unwrap();
+
+        let remaining = load_index_registry_at(&toml_path).unwrap();
+        assert_eq!(remaining.len(), 1, "dead-root entry must be removed");
+        assert_eq!(remaining[0].id, "live", "live entry must be preserved");
+    }
+
+    /// Why: prune-orphans must NEVER remove entries whose root_path exists.
+    /// What: write a registry with only live-root entries, run prune, assert
+    /// the registry is unchanged.
+    /// Test: this test.
+    #[test]
+    fn prune_orphans_preserves_live_root_entries() {
+        let tmp = tempdir().unwrap();
+        let toml_path = tmp.path().join("indexes.toml");
+
+        let live = PersistedIndex {
+            id: "myproject".into(),
+            root_path: tmp.path().to_path_buf(),
+            ..Default::default()
+        };
+        save_index_registry_at(&toml_path, &[live]).unwrap();
+
+        handle_prune_orphans_at(&toml_path, false, true, false).unwrap();
+
+        let remaining = load_index_registry_at(&toml_path).unwrap();
+        assert_eq!(remaining.len(), 1, "live entry must not be removed");
+        assert_eq!(remaining[0].id, "myproject");
+    }
+
+    /// Why: --dry-run must preview orphans without mutating indexes.toml.
+    /// What: write a registry with one dead entry, run with dry_run=true, reload
+    /// and assert the entry is still there.
+    /// Test: this test.
+    #[test]
+    fn prune_orphans_dry_run_mutates_nothing() {
+        let tmp = tempdir().unwrap();
+        let toml_path = tmp.path().join("indexes.toml");
+
+        let dead = entry("ghost", "/tmp/trusty-dry-run-dead-xyz8888");
+        save_index_registry_at(&toml_path, &[dead]).unwrap();
+
+        // dry_run=true — must not write to toml_path.
+        handle_prune_orphans_at(
+            &toml_path, /*dry_run=*/ true, /*yes=*/ true, /*interactive=*/ false,
+        )
+        .unwrap();
+
+        let after = load_index_registry_at(&toml_path).unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "dry-run must not modify indexes.toml: found {} entries",
+            after.len()
+        );
+        assert_eq!(
+            after[0].id, "ghost",
+            "dry-run must leave the orphan in place"
+        );
+    }
+
+    /// Why: an empty registry must be handled gracefully (no panic, no error).
+    /// What: call handle_prune_orphans_at on an empty file, assert it returns Ok.
+    /// Test: this test.
+    #[test]
+    fn prune_orphans_empty_registry_is_noop() {
+        let tmp = tempdir().unwrap();
+        let toml_path = tmp.path().join("indexes.toml");
+        // Don't create the file — load_index_registry_at treats missing as empty.
+        let result = handle_prune_orphans_at(&toml_path, false, true, false);
+        assert!(result.is_ok(), "empty registry must not error");
+    }
+}

--- a/crates/trusty-search/src/commands/start.rs
+++ b/crates/trusty-search/src/commands/start.rs
@@ -250,24 +250,174 @@ fn collect_all_index_entries() -> Vec<PersistedIndex> {
     all
 }
 
+/// Attempt to locate a moved project root for a colocated index (issue #484).
+///
+/// Why: when a project is moved (e.g. `mv projA projA-moved`), the daemon
+/// restarts with a stale `root_path` in `indexes.toml`. Without relocation
+/// detection, `build_indexer_from_entry` calls `colocated_storage_dir` which
+/// calls `create_dir_all` on the non-existent old path, silently producing an
+/// empty ghost directory and a 0-chunk index. This function intercepts that
+/// case before any disk mutation.
+///
+/// What: scans all tracked roots for `.trusty-search/` directories containing
+/// a populated `index.redb`. Filters out roots already claimed by another live
+/// entry in `indexes.toml`. Returns the new root path ONLY when exactly one
+/// candidate exists (ambiguous = skip, zero = skip). If a unique candidate is
+/// found, updates `indexes.toml` atomically so subsequent restarts are instant.
+///
+/// Test: `restore_moved_colocated_index_relinks_unique_candidate`,
+/// `restore_missing_root_with_no_candidate_skips`,
+/// `restore_missing_root_with_ambiguous_candidates_skips`.
+pub(crate) fn try_locate_moved_root(
+    entry: &PersistedIndex,
+    all_entries: &[PersistedIndex],
+) -> Option<std::path::PathBuf> {
+    use crate::service::colocated_storage::COLOCATED_DIR_NAME;
+    use crate::service::fs_discovery::{scan_roots_for_colocated_indexes, DEFAULT_SCAN_DEPTH};
+    use crate::service::roots_registry::load_roots;
+
+    // Only attempt relocation for colocated indexes with a missing root.
+    if !entry.colocated || entry.root_path.exists() {
+        return None;
+    }
+
+    // Collect root paths that are already claimed by other live entries so
+    // we don't accidentally steal their `.trusty-search/` directory.
+    let claimed: std::collections::HashSet<std::path::PathBuf> = all_entries
+        .iter()
+        .filter(|e| e.id != entry.id && e.root_path.exists())
+        .map(|e| e.root_path.clone())
+        .collect();
+
+    // Scan tracked roots for colocated index directories.
+    let tracked_roots: Vec<std::path::PathBuf> = match load_roots() {
+        Ok(r) => r.into_iter().map(|r| r.path).collect(),
+        Err(_) => return None,
+    };
+    if tracked_roots.is_empty() {
+        return None;
+    }
+
+    let discovered = scan_roots_for_colocated_indexes(&tracked_roots, DEFAULT_SCAN_DEPTH);
+
+    // A candidate must:
+    //   1. Have a populated index.redb (not just an empty .trusty-search/ dir).
+    //   2. Not be already claimed by another entry.
+    let candidates: Vec<std::path::PathBuf> = discovered
+        .into_iter()
+        .filter(|c| {
+            if claimed.contains(&c.root_path) {
+                return false;
+            }
+            let redb = c.root_path.join(COLOCATED_DIR_NAME).join("index.redb");
+            // Require a non-empty redb file so we don't relink to a ghost dir.
+            std::fs::metadata(&redb)
+                .map(|m| m.is_file() && m.len() > 0)
+                .unwrap_or(false)
+        })
+        .map(|c| c.root_path)
+        .collect();
+
+    match candidates.len() {
+        1 => {
+            let new_root = candidates.into_iter().next().expect("len==1");
+            tracing::info!(
+                "warm-boot: index '{}' root_path moved: {} → {} (auto-relink, issue #484)",
+                entry.id,
+                entry.root_path.display(),
+                new_root.display(),
+            );
+            // Persist the new root_path so subsequent restarts skip the scan.
+            let updated = PersistedIndex {
+                root_path: new_root.clone(),
+                ..entry.clone()
+            };
+            if let Err(e) = crate::service::persistence::upsert_index_registry_entry(updated) {
+                tracing::warn!(
+                    "warm-boot: could not persist relocated root_path for '{}': {e}",
+                    entry.id
+                );
+            }
+            Some(new_root)
+        }
+        0 => {
+            tracing::warn!(
+                "warm-boot: skipping index '{}' — root_path {} no longer exists and no \
+                 unique candidate found in tracked roots",
+                entry.id,
+                entry.root_path.display(),
+            );
+            None
+        }
+        n => {
+            tracing::warn!(
+                "warm-boot: skipping index '{}' — root_path {} no longer exists and {} \
+                 ambiguous candidates found (manual `trusty-search index <path>` required)",
+                entry.id,
+                entry.root_path.display(),
+                n,
+            );
+            None
+        }
+    }
+}
+
 /// Register one index entry into the in-memory registry, restoring HNSW + corpus.
 ///
 /// Why: extracted so the loop in `restore_indexes` remains readable and so
 /// colocated-index integration tests can drive this path directly.
-/// What: skips entries already in the in-memory registry (idempotent), builds
-/// the indexer via `build_indexer_from_entry` (which routes to colocated or
-/// legacy storage), and registers the resulting `IndexHandle`.
-/// Test: covered by the warm-boot integration tests.
+/// What: checks `root_path.exists()` before building — when the path is missing
+/// for a colocated index, attempts relocation via `try_locate_moved_root` (issue
+/// #484); for non-colocated or unresolvable entries, logs WARN and skips.
+/// Skips entries already in the in-memory registry (idempotent), builds the
+/// indexer via `build_indexer_from_entry`, and registers the resulting
+/// `IndexHandle`.
+/// Test: covered by the warm-boot integration tests and the
+/// `restore_moved_colocated_index_*` unit tests in this module.
 async fn restore_one_index(
     state: &SearchAppState,
     embedder: &Arc<dyn crate::core::Embedder>,
-    entry: PersistedIndex,
+    mut entry: PersistedIndex,
 ) {
     let id = IndexId::new(entry.id.clone());
     if state.registry.get(&id).is_some() {
         // A live create_index handler beat us to it — skip.
         return;
     }
+
+    // Issue #484: guard against missing root_path before any disk mutation.
+    // `build_indexer_from_entry` → `corpus_redb_path_for_entry` → `colocated_storage_dir`
+    // calls `create_dir_all` on the (now-dead) path, silently creating an empty
+    // ghost dir and loading 0 chunks. Block that here.
+    if !entry.root_path.exists() {
+        // For colocated indexes: attempt relocation scan.
+        if entry.colocated {
+            // Collect all current registry entries so the scan can exclude
+            // already-claimed roots.  Best-effort: an empty vec is safe —
+            // it just disables the claimed-root filter.
+            let all_entries =
+                crate::service::persistence::load_index_registry().unwrap_or_default();
+            match try_locate_moved_root(&entry, &all_entries) {
+                Some(new_root) => {
+                    entry.root_path = new_root;
+                }
+                None => {
+                    // Warn already emitted by try_locate_moved_root.
+                    return;
+                }
+            }
+        } else {
+            tracing::warn!(
+                "warm-boot: skipping index '{}' — root_path {} no longer exists \
+                 (run `trusty-search prune-orphans` to clean up or \
+                 `trusty-search index <path>` to re-register at the new location)",
+                entry.id,
+                entry.root_path.display(),
+            );
+            return;
+        }
+    }
+
     let mut indexer = build_indexer_from_entry(&entry, embedder).await;
     // Restore per-index filters and domain vocabulary from indexes.toml.
     // Resolve `include_paths` to absolute under `root_path` so the reindex
@@ -1585,6 +1735,135 @@ mod tests {
         assert!(
             !should_skip_discovery(false, Some("")),
             "empty env value must not suppress scan"
+        );
+    }
+
+    // ── Issue #484: moved-project relocation tests ─────────────────────────────
+
+    use crate::service::colocated_storage::COLOCATED_DIR_NAME;
+    use crate::service::persistence::PersistedIndex;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    /// Create a populated `.trusty-search/index.redb` under `root`.
+    fn make_populated_ts(root: &std::path::Path) {
+        let ts_dir = root.join(COLOCATED_DIR_NAME);
+        std::fs::create_dir_all(&ts_dir).unwrap();
+        std::fs::write(ts_dir.join("index.redb"), b"notempty").unwrap();
+    }
+
+    /// Why: the core relocation contract — a colocated index with a dead root_path
+    /// and exactly one candidate tracked root containing a populated .trusty-search/
+    /// must be relinked to that candidate.
+    /// What: set up a dead root entry and one candidate tracked root with a
+    /// populated redb; call `try_locate_moved_root` and assert it returns the
+    /// candidate path.
+    /// Test: this test.
+    #[test]
+    #[serial]
+    fn restore_moved_colocated_index_relinks_unique_candidate() {
+        let data_tmp = tempdir().unwrap();
+        let new_root = tempdir().unwrap();
+        make_populated_ts(new_root.path());
+
+        // Point TRUSTY_DATA_DIR at our tempdir so roots.toml is isolated.
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_tmp.path()) };
+
+        // Register new_root as a tracked root.
+        crate::service::roots_registry::upsert_root(new_root.path().to_path_buf()).unwrap();
+
+        // Entry whose root_path no longer exists.
+        let dead_root = std::path::PathBuf::from("/tmp/trusty-484-dead-root-xyz9999");
+        let entry = PersistedIndex {
+            id: "moved-project".to_string(),
+            root_path: dead_root.clone(),
+            colocated: true,
+            ..Default::default()
+        };
+
+        let result = try_locate_moved_root(&entry, &[]);
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+
+        let new_path = result.expect("must find the unique candidate");
+        assert_eq!(
+            new_path.canonicalize().unwrap(),
+            new_root.path().canonicalize().unwrap(),
+            "must relink to the tracked root containing .trusty-search/"
+        );
+    }
+
+    /// Why: when the root_path is missing and NO tracked root has a populated
+    /// .trusty-search/, `try_locate_moved_root` must return None and must NOT
+    /// create any ghost directory.
+    /// What: register a tracked root with NO .trusty-search/, call the function,
+    /// assert None is returned and no ghost dir was created.
+    /// Test: this test.
+    #[test]
+    #[serial]
+    fn restore_missing_root_with_no_candidate_returns_none() {
+        let data_tmp = tempdir().unwrap();
+        let empty_root = tempdir().unwrap();
+        // No .trusty-search/ here.
+
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_tmp.path()) };
+        crate::service::roots_registry::upsert_root(empty_root.path().to_path_buf()).unwrap();
+
+        let dead_root = std::path::PathBuf::from("/tmp/trusty-484-no-candidate-xyz9999");
+        let entry = PersistedIndex {
+            id: "no-candidate".to_string(),
+            root_path: dead_root.clone(),
+            colocated: true,
+            ..Default::default()
+        };
+
+        let result = try_locate_moved_root(&entry, &[]);
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+
+        assert!(
+            result.is_none(),
+            "must return None when no candidate has a populated .trusty-search/"
+        );
+        // Verify no ghost directory was created under the dead root.
+        let ghost = dead_root.join(COLOCATED_DIR_NAME);
+        assert!(
+            !ghost.exists(),
+            "must not create a ghost .trusty-search/ under the missing root"
+        );
+    }
+
+    /// Why: when multiple tracked roots have a populated .trusty-search/ and none
+    /// is claimed by another entry, `try_locate_moved_root` must return None
+    /// (ambiguous — cannot auto-pick).
+    /// What: register two tracked roots both with populated .trusty-search/; call
+    /// the function and assert it returns None.
+    /// Test: this test.
+    #[test]
+    #[serial]
+    fn restore_missing_root_with_ambiguous_candidates_returns_none() {
+        let data_tmp = tempdir().unwrap();
+        let root_a = tempdir().unwrap();
+        let root_b = tempdir().unwrap();
+        make_populated_ts(root_a.path());
+        make_populated_ts(root_b.path());
+
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_tmp.path()) };
+        crate::service::roots_registry::upsert_root(root_a.path().to_path_buf()).unwrap();
+        crate::service::roots_registry::upsert_root(root_b.path().to_path_buf()).unwrap();
+
+        let dead_root = std::path::PathBuf::from("/tmp/trusty-484-ambiguous-xyz9999");
+        let entry = PersistedIndex {
+            id: "ambiguous".to_string(),
+            root_path: dead_root,
+            colocated: true,
+            ..Default::default()
+        };
+
+        let result = try_locate_moved_root(&entry, &[]);
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+
+        assert!(
+            result.is_none(),
+            "must return None when multiple candidates exist (ambiguous)"
         );
     }
 }

--- a/crates/trusty-search/src/main.rs
+++ b/crates/trusty-search/src/main.rs
@@ -603,6 +603,32 @@ enum Commands {
         dry_run: bool,
     },
 
+    /// Remove orphaned index registrations whose root_path no longer exists (issue #489)
+    ///
+    /// Works OFFLINE — no daemon required. Reads indexes.toml, identifies
+    /// entries whose `root_path` does not exist on disk (deleted projects,
+    /// wiped volumes, /tmp test indexes), and removes them from the registry
+    /// after displaying the list and asking for confirmation.
+    ///
+    /// Only the registry entry is removed — no index data directories are
+    /// deleted. If the project comes back (e.g. volume remounted), you can
+    /// re-register with `trusty-search index <path>`.
+    ///
+    /// Examples:
+    ///   trusty-search prune-orphans --dry-run   # preview without any changes
+    ///   trusty-search prune-orphans             # interactive confirmation
+    ///   trusty-search prune-orphans --yes       # non-interactive (scripted)
+    #[command(display_order = 27, name = "prune-orphans")]
+    PruneOrphans {
+        /// Preview the list of orphaned registrations without removing anything
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Skip the confirmation prompt and remove immediately
+        #[arg(long)]
+        yes: bool,
+    },
+
     /// Wire trusty-search into Claude Code's settings.json files
     ///
     /// Scans `$HOME` for every `.claude/settings*.json` and idempotently
@@ -613,7 +639,7 @@ enum Commands {
     ///
     /// Examples:
     ///   trusty-search setup
-    #[command(display_order = 27)]
+    #[command(display_order = 28)]
     Setup,
 
     /// Wire trusty-search into an IDE (Cursor, etc.)
@@ -1043,6 +1069,10 @@ async fn run() -> Result<()> {
 
         Commands::MigrateStorage { dry_run } => {
             commands::migrate_storage::handle_migrate_storage(dry_run)?;
+        }
+
+        Commands::PruneOrphans { dry_run, yes } => {
+            commands::prune_orphans::handle_prune_orphans(dry_run, yes)?;
         }
 
         Commands::Setup => {

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -393,7 +393,7 @@ pub fn load_index_registry() -> Result<Vec<PersistedIndex>> {
 /// Path-injectable variant of [`load_index_registry`]. Exists so the
 /// roundtrip / delete-persistence tests can drive the load/save/upsert/remove
 /// pipeline against a tempfile without monkey-patching `dirs::data_local_dir`.
-pub(crate) fn load_index_registry_at(path: &Path) -> Result<Vec<PersistedIndex>> {
+pub fn load_index_registry_at(path: &Path) -> Result<Vec<PersistedIndex>> {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -418,7 +418,7 @@ pub fn save_index_registry(entries: &[PersistedIndex]) -> Result<()> {
 }
 
 /// Path-injectable variant of [`save_index_registry`].
-pub(crate) fn save_index_registry_at(path: &Path, entries: &[PersistedIndex]) -> Result<()> {
+pub fn save_index_registry_at(path: &Path, entries: &[PersistedIndex]) -> Result<()> {
     let file = IndexRegistryFile {
         indexes: entries.to_vec(),
     };
@@ -443,7 +443,7 @@ pub fn upsert_index_registry_entry(entry: PersistedIndex) -> Result<()> {
 /// Path-injectable variant. Same upsert semantics, but reads/writes the
 /// supplied TOML path. Used by the persistence tests (issue #118) to assert
 /// that re-registering the same id never produces a duplicate `[[index]]`.
-pub(crate) fn upsert_index_registry_entry_at(path: &Path, entry: PersistedIndex) -> Result<()> {
+pub fn upsert_index_registry_entry_at(path: &Path, entry: PersistedIndex) -> Result<()> {
     let mut entries = load_index_registry_at(path)?;
     if let Some(existing) = entries.iter_mut().find(|e| e.id == entry.id) {
         // Overwrite the whole record (not just root_path) so updated
@@ -473,7 +473,7 @@ pub fn remove_index_registry_entry(id: &str) -> Result<()> {
 }
 
 /// Path-injectable variant of [`remove_index_registry_entry`].
-pub(crate) fn remove_index_registry_entry_at(path: &Path, id: &str) -> Result<()> {
+pub fn remove_index_registry_entry_at(path: &Path, id: &str) -> Result<()> {
     let mut entries = load_index_registry_at(path)?;
     let before = entries.len();
     entries.retain(|e| e.id != id);


### PR DESCRIPTION
## Summary

- **#489 (prune-orphans)**: Adds `trusty-search prune-orphans [--dry-run] [--yes]` — an offline command that loads `indexes.toml`, identifies entries whose `root_path` no longer exists, displays the list, and removes them after confirmation. Works without the daemon running. Mirrors the dry-run/confirm UX from `migrate-storage`.
- **#484 (moved-project relocation)**: Guards `restore_one_index` against missing `root_path` before any disk mutation. Adds `try_locate_moved_root` which, for colocated indexes, scans tracked roots for a `.trusty-search/index.redb` candidate that is populated and unclaimed. Auto-relinks when exactly one candidate is found; logs WARN and skips on zero or multiple candidates. Prevents the `create_dir_all`-on-dead-path ghost-directory bug.
- **v0.20.3**: PATCH version bump.

## Changes

### #489 — prune-orphans
- `crates/trusty-search/src/commands/prune_orphans.rs` (new): `handle_prune_orphans` + `handle_prune_orphans_at` (path-injectable) + 4 unit tests
- `crates/trusty-search/src/commands/mod.rs`: registered new `prune_orphans` module
- `crates/trusty-search/src/main.rs`: added `PruneOrphans { dry_run, yes }` variant + dispatch arm
- `crates/trusty-search/src/service/persistence.rs`: widened 4 `pub(crate)` helpers to `pub`

### #484 — moved-project relocation
- `crates/trusty-search/src/commands/start.rs`: added `try_locate_moved_root` helper + `root_path.exists()` guard in `restore_one_index` + 3 `#[serial]` unit tests

### Version
- `crates/trusty-search/Cargo.toml`: `0.20.2` → `0.20.3`

## Test plan
- [ ] `cargo test -p trusty-search` — 775 tests pass, 0 failures
- [ ] `cargo clippy -p trusty-search --all-targets -- -D warnings` — zero warnings
- [ ] `cargo fmt --check -p trusty-search` — no drift
- [ ] `trusty-search prune-orphans --dry-run` on a live machine to confirm orphan count

Closes #489
Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)