### PR TITLE
ci: add workspace GitHub Actions (fmt, clippy, test, MSRV check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,13 @@ jobs:
           key: test
 
       - name: cargo test --workspace
+        # Unset CI so trusty-common's update::check_throttled runs the
+        # cache-freshness code path. The function returns None immediately
+        # when CI is non-empty; tests like cache_fresh_returns_some_when_newer
+        # expect the cache path (is_some), which requires CI to be unset.
+        # We set CI="" here to shadow the global CI=true injected by the runner.
+        env:
+          CI: ""
         run: cargo test --workspace --exclude trusty-mpm-gui
 
   # --------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # open-mpm's git tests (list_branches_includes_current) assert that the
+      # local branch list includes "main". GitHub Actions PR checkouts only create
+      # a local branch for the PR head; "main" is only a remote ref unless we
+      # explicitly create a local tracking branch for it.
+      - name: Create local main branch for git tests
+        run: git fetch origin main:main || true
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,168 @@
+# CI workflow for the trusty-tools Cargo workspace.
+#
+# Jobs:
+#   fmt    – cargo fmt --all --check (stable)
+#   clippy – cargo clippy --workspace --all-targets -D warnings (stable, SKIP_UI_BUILD=1)
+#   test   – cargo test --workspace (stable, SKIP_UI_BUILD=1)
+#   msrv   – cargo check --workspace (toolchain 1.88, SKIP_UI_BUILD=1)
+#
+# trusty-mpm-gui is excluded from all jobs: it is a Tauri desktop GUI
+# (publish = false) that requires WebKit2GTK on Linux (~100 MB apt chain).
+# It is not a deployable service and cannot be meaningfully validated in a
+# headless CI runner. Exclude it via --exclude trusty-mpm-gui on every
+# cargo invocation.
+#
+# SKIP_UI_BUILD=1 is set globally: the four crates with build.rs Svelte
+# pipelines (trusty-search, trusty-memory, trusty-analyze, open-mpm) skip
+# pnpm when this env var is set. The committed ui-dist/ artefacts embedded
+# via include_dir!/include_str! are sufficient for compilation.
+#
+# The 7 env-sensitive trusty-memory tests (project_slug_returns_none_without_markers,
+# project_slug_at_returns_none_without_markers, cwd_palace_slug_falls_back_to_basename,
+# palace_slug_from_stdin_cwd_uses_stdin_path, resolve_palace_for_log_prefers_stdin_cwd,
+# prompt_context_recall_filters_deny_tags, prompt_context_recalls_palace_drawers) fail
+# on developer machines because tempfile::tempdir() creates dirs under a path that is
+# itself inside the trusty-tools git worktree, causing find_project_root to return a
+# non-None value. On the CI runner /tmp is a clean filesystem with no git ancestor, so
+# these tests are expected to pass. They are NOT excluded here; if they go red in CI
+# that is a real bug and should block the PR.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs for the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# SKIP_UI_BUILD=1 prevents the four build.rs Svelte pipelines from invoking pnpm.
+env:
+  SKIP_UI_BUILD: "1"
+  CARGO_TERM_COLOR: always
+  # Reduce noise from ort/fastembed download progress bars.
+  RUST_LOG: "warn"
+
+jobs:
+  # --------------------------------------------------------------------------
+  # fmt: enforce cargo fmt --all --check (stable toolchain + rustfmt component)
+  # --------------------------------------------------------------------------
+  fmt:
+    name: Format check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain with rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      # Note: rustfmt.toml uses imports_granularity and group_imports which are
+      # nightly-only; stable rustfmt silently ignores them (emits warnings, exit 0).
+      # The format check itself is not affected.
+      - name: cargo fmt --all --check
+        run: cargo fmt --all --check
+
+  # --------------------------------------------------------------------------
+  # clippy: deny warnings across the whole workspace (stable, all targets)
+  # trusty-mpm-gui excluded: Tauri desktop GUI, needs WebKit2GTK on Linux.
+  # --------------------------------------------------------------------------
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain with clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libssl-dev
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Separate cache key per job so fmt/clippy/test/msrv don't fight
+          # over incompatible target directories.
+          key: clippy
+
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings
+
+  # --------------------------------------------------------------------------
+  # test: run all unit + integration tests (stable, no --include-ignored).
+  # ONNX-backed tests are #[ignore]-tagged; they are intentionally skipped here
+  # because they require model downloads and a running embedderd daemon.
+  # trusty-mpm-gui excluded: see clippy note above.
+  # --------------------------------------------------------------------------
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libssl-dev
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: test
+
+      - name: cargo test --workspace
+        run: cargo test --workspace --exclude trusty-mpm-gui
+
+  # --------------------------------------------------------------------------
+  # msrv: verify the workspace compiles on the pinned MSRV (1.88).
+  # cargo check is used (not test) to keep this job fast: the MSRV guarantee
+  # is that the code *compiles* on 1.88, not that tests pass on it.
+  # trusty-mpm-gui excluded: see clippy note above.
+  # --------------------------------------------------------------------------
+  msrv:
+    name: MSRV check (1.88)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.88 toolchain
+        uses: dtolnay/rust-toolchain@1.88
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libssl-dev
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv-1-88
+
+      - name: cargo check --workspace
+        run: cargo check --workspace --exclude trusty-mpm-gui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@
 # Jobs:
 #   fmt    – cargo fmt --all --check (stable)
 #   clippy – cargo clippy --workspace --all-targets -D warnings (stable, SKIP_UI_BUILD=1)
-#   test   – cargo test --workspace (stable, SKIP_UI_BUILD=1)
-#   msrv   – cargo check --workspace (toolchain 1.88, SKIP_UI_BUILD=1)
+#   test   – cargo test --workspace (stable, SKIP_UI_BUILD=1, full clone for git tests)
+#   msrv   – cargo check --workspace (toolchain 1.91, SKIP_UI_BUILD=1)
 #
 # trusty-mpm-gui is excluded from all jobs: it is a Tauri desktop GUI
 # (publish = false) that requires WebKit2GTK on Linux (~100 MB apt chain).
@@ -26,6 +26,17 @@
 # non-None value. On the CI runner /tmp is a clean filesystem with no git ancestor, so
 # these tests are expected to pass. They are NOT excluded here; if they go red in CI
 # that is a real bug and should block the PR.
+#
+# open-mpm git tests (git::branch::tests::list_branches_includes_current,
+# git::log::tests::search_commits_finds_known_keyword) require a full git clone
+# with local branch refs and commit history. The test job uses fetch-depth: 0
+# to ensure a full (non-shallow) clone is present.
+#
+# MSRV NOTE: [workspace.package] rust-version = "1.88" in Cargo.toml is STALE.
+# The current Cargo.lock pulls aws-sdk-* / aws-smithy-* crates at versions that
+# declare rust-version = "1.91.1". The effective MSRV is therefore 1.91, not 1.88.
+# The msrv job below is pinned to 1.91 to reflect reality. The Cargo.toml
+# rust-version field should be updated to "1.91" in a follow-up commit.
 
 name: CI
 
@@ -108,6 +119,8 @@ jobs:
   # ONNX-backed tests are #[ignore]-tagged; they are intentionally skipped here
   # because they require model downloads and a running embedderd daemon.
   # trusty-mpm-gui excluded: see clippy note above.
+  # fetch-depth: 0 (full clone) required for open-mpm git tests that inspect
+  # local branch refs and search commit history.
   # --------------------------------------------------------------------------
   test:
     name: Test
@@ -115,6 +128,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -136,20 +151,27 @@ jobs:
         run: cargo test --workspace --exclude trusty-mpm-gui
 
   # --------------------------------------------------------------------------
-  # msrv: verify the workspace compiles on the pinned MSRV (1.88).
+  # msrv: verify the workspace compiles on the effective MSRV.
   # cargo check is used (not test) to keep this job fast: the MSRV guarantee
-  # is that the code *compiles* on 1.88, not that tests pass on it.
+  # is that the code *compiles* on the minimum toolchain, not that tests pass.
   # trusty-mpm-gui excluded: see clippy note above.
+  #
+  # Toolchain is 1.91 — NOT the 1.88 declared in [workspace.package].rust-version.
+  # The current Cargo.lock pulls aws-sdk-*/aws-smithy-* at versions that require
+  # rustc >= 1.91.1. [workspace.package].rust-version = "1.88" in the root
+  # Cargo.toml is therefore stale and should be updated to "1.91". This CI job
+  # enforces the real minimum; the Cargo.toml value is a known inconsistency
+  # tracked as a follow-up: bump rust-version to 1.91 in Cargo.toml.
   # --------------------------------------------------------------------------
   msrv:
-    name: MSRV check (1.88)
+    name: MSRV check (1.91)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust 1.88 toolchain
-        uses: dtolnay/rust-toolchain@1.88
+      - name: Install Rust 1.91 toolchain
+        uses: dtolnay/rust-toolchain@1.91
 
       - name: Install system dependencies
         run: |
@@ -162,7 +184,7 @@ jobs:
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          key: msrv-1-88
+          key: msrv-1-91
 
       - name: cargo check --workspace
         run: cargo check --workspace --exclude trusty-mpm-gui


### PR DESCRIPTION
## Summary

- Adds the **first CI workflow** for the trusty-tools Cargo workspace, closing the gap that allowed the recent trusty-analyze build break to reach `main` undetected.
- Four jobs on every PR→main and push→main: `fmt`, `clippy`, `test`, `msrv`.
- `concurrency` group cancels superseded runs for the same ref.

## Jobs

| Job | Command | Toolchain | Timeout |
|-----|---------|-----------|---------|
| **fmt** | `cargo fmt --all --check` | stable + rustfmt | 10 min |
| **clippy** | `cargo clippy --workspace --all-targets -- -D warnings` | stable + clippy | 45 min |
| **test** | `cargo test --workspace` | stable | 45 min |
| **msrv** | `cargo check --workspace` | 1.88 (pinned) | 30 min |

## Scoping decisions

- **`trusty-mpm-gui` excluded from all jobs** via `--exclude trusty-mpm-gui`: it is a Tauri desktop GUI (`publish = false`) that requires `libwebkit2gtk-4.1-dev` and ~100 MB of GTK deps on Linux. Not a deployable service; no meaningful headless CI value.
- **`SKIP_UI_BUILD=1` set globally**: bypasses the four `build.rs` Svelte pipelines (trusty-search, trusty-memory, trusty-analyze, open-mpm) that invoke pnpm. The committed `ui-dist/` artefacts are sufficient for compilation.
- **`--include-ignored` NOT passed**: ONNX-backed integration tests require model downloads + running embedderd daemon; correctly skipped in CI.
- **Full `-D warnings` clippy on the whole workspace** (minus mpm-gui): validated locally — the entire workspace passes clean.
- **System deps**: `build-essential pkg-config libssl-dev` — covers `ort-download-binaries-native-tls` (reqwest native-tls on Linux) and any pkg-config probes.
- **`Swatinem/rust-cache@v2`** per job with distinct keys: critical for the heavy ONNX/fastembed artifacts.

## Local validation results (on current main)

All four commands run from the worktree with `SKIP_UI_BUILD=1`:

- `cargo fmt --all --check` → **EXIT 0** (only harmless nightly-option warnings from rustfmt.toml)
- `cargo clippy --workspace --all-targets -- -D warnings` → **EXIT 0** (entire workspace clean)
- `cargo test --workspace` → **EXIT 101** — 7 tests fail in `trusty-memory`, all env-sensitive:
  - `project_slug_returns_none_without_markers`, `project_slug_at_returns_none_without_markers`, `cwd_palace_slug_falls_back_to_basename`, `palace_slug_from_stdin_cwd_uses_stdin_path`, `resolve_palace_for_log_prefers_stdin_cwd`, `prompt_context_recall_filters_deny_tags`, `prompt_context_recalls_palace_drawers`
  - **Root cause**: on the dev machine, `tempfile::tempdir()` creates dirs under a path that is itself inside the `trusty-tools` git worktree, so `find_project_root` returns non-None when the tests expect None.
  - **CI hypothesis**: on the Ubuntu runner, `/tmp` has no git ancestor → `find_project_root` returns None → tests **pass**. These tests are intentionally NOT excluded; a failure in CI would be a real regression.
- `cargo check --workspace` → **EXIT 0**

## Test plan

- [ ] Wait for the PR's own CI run to complete
- [ ] Verify all 4 jobs go green (fmt, clippy, test, msrv)
- [ ] Confirm the 7 env-sensitive trusty-memory tests pass on the clean CI /tmp
- [ ] Squash-merge if green

🤖 Generated with [Claude Code](https://claude.com/claude-code)