### PR TITLE
fix(trusty-analyze): raise MCP deep_analysis timeout above OpenRouter 120s + clarify missing-API-key UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10686,7 +10686,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.2.1"
+version     = "0.2.2"
 edition     = "2021"
 license     = "MIT"
 authors.workspace    = true

--- a/crates/trusty-analyze/src/main.rs
+++ b/crates/trusty-analyze/src/main.rs
@@ -432,6 +432,22 @@ async fn main() -> Result<()> {
             };
             let state = AnalyzerAppState::new(search, facts).with_embedder(embedder);
 
+            // Warn at startup when OPENROUTER_API_KEY is absent so operators
+            // notice the gap before any deep-analysis call returns a 400.
+            // Why: the key is read once at startup (stored in state.api_key);
+            // setting it after the daemon is running has no effect until the
+            // next restart. A clear startup warning surfaces this constraint
+            // early (issue #528).
+            // What: logs a WARN to stderr when the resolved api_key is None.
+            // Test: side-effect-only — verified by running the daemon without
+            // the env var and observing the log line.
+            if state.api_key.is_none() {
+                tracing::warn!(
+                    "OPENROUTER_API_KEY is not set; deep (LLM) analysis will be \
+                     unavailable until the daemon is restarted with it set"
+                );
+            }
+
             // Optionally start the MCP HTTP/SSE server on a separate port.
             // Why: some MCP clients (and remote integrations) prefer HTTP/SSE
             // over stdio. Spawned independently of the analyzer's own HTTP

--- a/crates/trusty-analyze/src/mcp/mod.rs
+++ b/crates/trusty-analyze/src/mcp/mod.rs
@@ -102,6 +102,19 @@ impl Response {
     }
 }
 
+/// Per-request timeout for the MCP→daemon HTTP client (in seconds).
+///
+/// Why: the `deep_analysis` tool calls `POST /analyze/deep`, which in turn
+/// calls OpenRouter with up to 120 s allowed (matching `OPENROUTER_REQUEST_TIMEOUT_SECS`
+/// in `trusty-common/src/chat.rs`). Adding 30 s of headroom for report synthesis
+/// and network round-trips gives 150 s total — safely above the 120 s
+/// OpenRouter ceiling so slow or large-context models are not systematically
+/// killed at the MCP transport layer before the daemon's own timeout fires.
+/// What: sets the per-request timeout passed to `reqwest::ClientBuilder`.
+/// Test: `mcp_client_timeout_exceeds_openrouter_ceiling` asserts this value
+/// is strictly greater than 120 (the OpenRouter maximum).
+const DEEP_ANALYSIS_MCP_TIMEOUT_SECS: u64 = 150;
+
 /// MCP dispatcher backed by an HTTP client targeting the analyzer daemon.
 #[derive(Clone)]
 pub struct AnalyzerMcpServer {
@@ -111,15 +124,22 @@ pub struct AnalyzerMcpServer {
 
 impl AnalyzerMcpServer {
     /// Why: without timeouts MCP tool calls hang forever if the analyze daemon
-    /// is slow or unresponsive, blocking the entire stdio dispatch loop.
-    /// What: builds a `reqwest::Client` with a 30 s per-request timeout and a
-    /// 5 s TCP connect timeout — mirroring the pattern in
-    /// `crates/trusty-analyze/src/core/client.rs`.
+    /// is slow or unresponsive, blocking the entire stdio dispatch loop. The
+    /// per-request timeout is set to [`DEEP_ANALYSIS_MCP_TIMEOUT_SECS`] (150 s)
+    /// so LLM-backed tools like `deep_analysis` — which can take up to the
+    /// OpenRouter 120 s ceiling plus synthesis headroom — complete without
+    /// being aborted at the transport layer.
+    /// What: builds a `reqwest::Client` with a 150 s per-request timeout and a
+    /// 5 s TCP connect timeout. The connect timeout is kept short because the
+    /// daemon is always local; the long request timeout is required only for
+    /// the LLM call path.
     /// Test: `cargo test -p trusty-analyze -- mcp` exercises dispatch paths;
-    /// the timeout prevents indefinite hangs in production usage.
+    /// `mcp_client_timeout_exceeds_openrouter_ceiling` asserts the const value.
     pub fn new(base_url: impl Into<String>) -> Self {
         let http = reqwest::ClientBuilder::new()
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(std::time::Duration::from_secs(
+                DEEP_ANALYSIS_MCP_TIMEOUT_SECS,
+            ))
             .connect_timeout(std::time::Duration::from_secs(5))
             .build()
             .expect("reqwest ClientBuilder is infallible with valid config");
@@ -1194,6 +1214,26 @@ mod tests {
         assert!(q.contains("subject=fn%20auth"), "got {q}");
         assert!(q.contains("object=JWT"), "got {q}");
         assert!(!q.contains("predicate"), "got {q}");
+    }
+
+    /// Verify at compile time that the MCP client timeout is strictly greater
+    /// than OpenRouter's 120 s maximum so deep_analysis calls are never aborted
+    /// at the MCP transport layer before the daemon's own timeout fires.
+    ///
+    /// Why: issue #528 — a 30 s MCP timeout silently killed any LLM response
+    /// taking more than 30 s, even when the daemon and API key were correct.
+    /// What: compile-time assertion that `DEEP_ANALYSIS_MCP_TIMEOUT_SECS > 120`.
+    /// Test: this is the test — it fails to compile if the const regresses.
+    #[test]
+    fn mcp_client_timeout_exceeds_openrouter_ceiling() {
+        // The OpenRouter request timeout in trusty-common/src/chat.rs is 120 s.
+        // Our MCP client must allow more than that. Use const assertion so
+        // clippy does not flag `assertions_on_constants`.
+        const OPENROUTER_CEILING_SECS: u64 = 120;
+        const _: () = assert!(
+            DEEP_ANALYSIS_MCP_TIMEOUT_SECS > OPENROUTER_CEILING_SECS,
+            "DEEP_ANALYSIS_MCP_TIMEOUT_SECS must be > OpenRouter ceiling (120 s)"
+        );
     }
 
     #[tokio::test]

--- a/crates/trusty-analyze/src/service/mod.rs
+++ b/crates/trusty-analyze/src/service/mod.rs
@@ -1148,7 +1148,9 @@ async fn deep_analyze_handler(
     let api_key = state.api_key.as_deref().filter(|s| !s.is_empty());
     if api_key.is_none() {
         return Err(ApiError::bad_request(
-            "OPENROUTER_API_KEY is not configured on the daemon; cannot run deep analysis",
+            "OPENROUTER_API_KEY is not configured on the daemon; \
+             set OPENROUTER_API_KEY in the environment and restart the daemon, \
+             then retry deep analysis",
         ));
     }
 


### PR DESCRIPTION
## Summary

Fixes two latent bugs in `trusty-analyze`'s deep (LLM) analysis path (issue #528).

- **Fix 1 (functional):** MCP→daemon `reqwest::Client` had a 30 s per-request timeout while the daemon's OpenRouter call is allowed up to 120 s. Any LLM response taking >30 s was silently killed at the MCP transport layer. Raised to `DEEP_ANALYSIS_MCP_TIMEOUT_SECS = 150` (120 s OpenRouter ceiling + 30 s synthesis headroom). Added a compile-time `const` assertion that the value stays strictly greater than 120.
- **Fix 2 (UX):** `OPENROUTER_API_KEY` is read once at daemon startup. Users who set the env var after the daemon starts got the same 400 with no indication of why retrying wouldn't help. Added a `tracing::warn!` at serve startup when the key is absent, and extended the 400 body to explicitly say "restart the daemon with `OPENROUTER_API_KEY` set".
- **Version bump:** `trusty-analyze` 0.2.1 → 0.2.2 (patch, bug fix).

## Files changed

| File | Change |
|---|---|
| `crates/trusty-analyze/src/mcp/mod.rs` | Add `DEEP_ANALYSIS_MCP_TIMEOUT_SECS = 150` const; raise client timeout; update doc; add const-assert test |
| `crates/trusty-analyze/src/service/mod.rs` | Extend 400 message to include restart instruction |
| `crates/trusty-analyze/src/main.rs` | Add `tracing::warn!` at serve startup when API key is absent |
| `crates/trusty-analyze/Cargo.toml` | Bump version 0.2.1 → 0.2.2 |
| `Cargo.lock` | Reflect version bump |

## Timeout derivation

`DEEP_ANALYSIS_MCP_TIMEOUT_SECS = 150`:
- Source: `OPENROUTER_REQUEST_TIMEOUT_SECS = 120` in `trusty-common/src/chat.rs` (private const)
- Headroom: +30 s for report synthesis and network round-trip before/after the LLM call
- Rationale for local const over making the trusty-common const pub: making it pub would widen trusty-common's API surface; the linkage is documented in the Why/What/Test comment on the const and enforced by the compile-time assertion

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p trusty-analyze` — 347 tests pass (335 lib + 10 bin + 2 integration)
- [x] `cargo check` workspace-wide — clean
- [x] New test `mcp_client_timeout_exceeds_openrouter_ceiling` — compile-time const assertion that `DEEP_ANALYSIS_MCP_TIMEOUT_SECS > 120`

Closes #528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)