### PR TITLE
fix(trusty-analyze): make ORT backend feature-selectable for glibc<2.38 / system ORT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,7 +485,7 @@ These abbreviations apply everywhere: ticket descriptions, build commands, refer
 | `TRUSTY_MAX_BATCH_SIZE` | `trusty-search` | ONNX embedding batch size. Auto-tuned; set if OOM during reindex. |
 | `TRUSTY_EMBEDDING_CACHE` | `trusty-search` | LRU embedding cache capacity (entries). |
 | `TRUSTY_COREML_TRIPWIRE_MB` | `trusty-search` (Apple Silicon) | RSS-delta ceiling per CoreML batch (default 4 GB). If exceeded, batch size is halved automatically. Override for hosts with different memory pressure characteristics. |
-| `ORT_DYLIB_PATH` | `trusty-search` (CUDA, glibc < 2.38) | Path to `libonnxruntime.so` on hosts with glibc < 2.38 and CUDA builds. |
+| `ORT_DYLIB_PATH` | `trusty-search` (CUDA, glibc < 2.38); `trusty-analyze` (`load-dynamic`, `cuda` features) | Path to `libonnxruntime.so` on hosts with glibc < 2.38 and CUDA builds. For trusty-analyze, install with `--no-default-features --features http-server,load-dynamic` and set this var to the system libonnxruntime path. |
 | `SKIP_UI_BUILD` | `trusty-search` `build.rs` | Set to `1` to skip the Svelte UI build step (CI publish flows). |
 | `TRUSTY_NO_KG` | `trusty-search` daemon | Machine-wide default for `skip_kg`. When set to `1`, `true`, or `yes`, every new index created via `POST /indexes` (or `trusty-search index`) has `skip_kg=true` applied automatically unless the caller explicitly sets `skip_kg: false`. Useful for CI machines or resource-constrained hosts where KG is never needed. |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10686,7 +10686,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors.workspace    = true
@@ -83,7 +83,12 @@ base64             = { workspace = true }
 hmac               = { workspace = true }
 sha2               = { workspace = true }
 hex                = { workspace = true }
-fastembed          = { workspace = true, features = ["hf-hub-rustls-tls", "ort-download-binaries"] }
+# Why (issue #536): fastembed is now optional so callers can select the ORT
+#      backend via Cargo features instead of having ort-download-binaries
+#      hardcoded.  The base features list only includes the TLS stack needed
+#      to fetch the ONNX model; the ORT backend feature is added by one of
+#      the bundled-ort / load-dynamic / cuda sub-features below.
+fastembed  = { workspace = true, features = ["hf-hub-rustls-tls"], optional = true }
 ort        = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
 
@@ -94,11 +99,32 @@ tokenizers = { workspace = true, optional = true }
 #      trusty-analyze` / `cargo test -p trusty-analyze` flows — keep building
 #      exactly as before. Library consumers that only want the dispatcher /
 #      CLI types override with `default-features = false`.
-default = ["http-server"]
+#
+# Why (issue #536): `bundled-ort` is now part of the default set so existing
+#      installs (`cargo install trusty-analyze`) keep the same behaviour (static
+#      ORT libs bundled, glibc ≥ 2.38 hosts).  To install on glibc < 2.38
+#      (e.g. Amazon Linux 2023 / glibc 2.34) use:
+#        cargo install trusty-analyze \
+#          --no-default-features --features http-server,load-dynamic
+#      and set ORT_DYLIB_PATH to the system libonnxruntime.so path at runtime.
+default = ["http-server", "bundled-ort"]
 # Enables the axum HTTP daemon surface (the `service` module and the
 # `mcp::sse` HTTP/SSE transport). Pulls in `axum`, `tower-http`, and the
 # matching `trusty-common/axum-server` feature flag.
 http-server = ["dep:axum", "dep:tower-http", "trusty-common/axum-server"]
+# Bundle the static ORT libs downloaded by fastembed (glibc ≥ 2.38 hosts,
+# macOS). This is the default ORT backend. Mutually exclusive with
+# load-dynamic and cuda at the ort-sys level.
+bundled-ort  = ["dep:fastembed", "fastembed/ort-download-binaries"]
+# Dynamic ORT loading — no bundled static libs. Use on glibc < 2.38 hosts
+# (e.g. Amazon Linux 2023) with a system ONNX Runtime installation.
+# Build: cargo install trusty-analyze --no-default-features \
+#                                     --features http-server,load-dynamic
+# Runtime: export ORT_DYLIB_PATH=/path/to/libonnxruntime.so
+load-dynamic = ["dep:fastembed", "fastembed/ort-load-dynamic"]
+# GPU-accelerated embedding via the ONNX Runtime CUDA execution provider.
+# Always pair with --no-default-features so bundled-ort is dropped.
+cuda         = ["dep:fastembed", "fastembed/cuda", "fastembed/ort-load-dynamic"]
 ner     = ["dep:ort", "dep:tokenizers"]
 
 [dev-dependencies]

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -18,8 +18,38 @@ This README and the rustdoc stay in-crate; everything else lives under `docs/`.
 
 ## Installation
 
+### Standard install (macOS / modern Linux, glibc ≥ 2.38)
+
 ```bash
 cargo install trusty-analyze
+```
+
+The default build bundles a prebuilt ONNX Runtime (via `fastembed/ort-download-binaries`)
+for the neural concept-clustering embedder. This is the correct choice for macOS and
+any Linux host with glibc 2.38 or later.
+
+### Amazon Linux 2023 / glibc < 2.38 (system ORT)
+
+The bundled ORT static library requires glibc 2.38+. On AL2023 (glibc 2.34) or any
+other host with an older glibc, install with the `load-dynamic` feature and point the
+binary at the system ONNX Runtime at runtime:
+
+```bash
+cargo install trusty-analyze --no-default-features --features http-server,load-dynamic
+```
+
+Then set `ORT_DYLIB_PATH` to the system `libonnxruntime.so` before starting the daemon:
+
+```bash
+export ORT_DYLIB_PATH=/usr/local/lib/libonnxruntime.so.1.24.2
+trusty-analyze serve --search-url http://127.0.0.1:7878
+```
+
+If no system ORT is available, install without any ORT backend. The daemon will still
+run with the deterministic BoW embedder (no semantic clustering):
+
+```bash
+cargo install trusty-analyze --no-default-features --features http-server
 ```
 
 The installed binary is named `trusty-analyze`. The crate name on crates.io is
@@ -168,11 +198,24 @@ accumulation, recommendations extraction) is identical.
 | `TRUSTY_ANALYZER_PORT` | `7879` | Analyzer listen port |
 | `RUST_LOG` | `warn` | Tracing filter |
 
-## Features Flag
+## Feature Flags
 
 | Flag | Description |
 |---|---|
-| `ner` | Optional ONNX-backed named entity recognition |
+| `http-server` | Axum HTTP daemon (enabled by default). Required for the `trusty-analyze` binary. |
+| `bundled-ort` | **Default.** Bundle the static ONNX Runtime libs via fastembed. Requires glibc ≥ 2.38. |
+| `load-dynamic` | Load ONNX Runtime dynamically from `ORT_DYLIB_PATH`. Use on glibc < 2.38 (AL2023). Mutually exclusive with `bundled-ort`. |
+| `cuda` | GPU-accelerated embedding via ONNX Runtime CUDA EP. Always pair with `--no-default-features`. |
+| `ner` | Optional ONNX-backed named entity recognition (separate model file required). |
+
+### ORT backend selection summary
+
+| Host | Recommended install command |
+|---|---|
+| macOS, Linux glibc ≥ 2.38 | `cargo install trusty-analyze` (default, bundled ORT) |
+| Amazon Linux 2023 / glibc 2.34 | `cargo install trusty-analyze --no-default-features --features http-server,load-dynamic` + `ORT_DYLIB_PATH` |
+| No ONNX Runtime available | `cargo install trusty-analyze --no-default-features --features http-server` (BoW fallback) |
+| CUDA GPU | `cargo install trusty-analyze --no-default-features --features http-server,cuda` + `ORT_DYLIB_PATH` |
 
 ## Architecture
 

--- a/crates/trusty-analyze/src/embedder/mod.rs
+++ b/crates/trusty-analyze/src/embedder/mod.rs
@@ -6,14 +6,19 @@
 //!
 //! What: `Embedder` trait with two implementations — `BowEmbedder` (wraps
 //! `crate::core::bow_embedding`) and `NeuralEmbedder` (fastembed
-//! `all-MiniLM-L6-v2`). `EmbedderKind` selects which to use.
+//! `all-MiniLM-L6-v2`, only compiled when an ORT backend feature is active).
+//! `EmbedderKind` selects which to use.
 //!
 //! Test: both embedders produce normalized vectors of the correct dimension.
+//! `NeuralEmbedder` tests are skipped at compile time when no ORT backend
+//! feature is enabled.
 
 pub mod bow;
+#[cfg(any(feature = "bundled-ort", feature = "load-dynamic", feature = "cuda"))]
 pub mod neural;
 
 pub use bow::BowEmbedder;
+#[cfg(any(feature = "bundled-ort", feature = "load-dynamic", feature = "cuda"))]
 pub use neural::NeuralEmbedder;
 
 /// Which embedding backend to use.

--- a/crates/trusty-analyze/src/main.rs
+++ b/crates/trusty-analyze/src/main.rs
@@ -13,7 +13,9 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use trusty_analyze::core::{facts::new_fact, AnalyzerRegistry, FactStore, TrustySearchClient};
-use trusty_analyze::embedder::{BowEmbedder, Embedder, NeuralEmbedder};
+#[cfg(any(feature = "bundled-ort", feature = "load-dynamic", feature = "cuda"))]
+use trusty_analyze::embedder::NeuralEmbedder;
+use trusty_analyze::embedder::{BowEmbedder, Embedder};
 use trusty_analyze::mcp::AnalyzerMcpServer;
 use trusty_analyze::service::{serve, AnalyzerAppState, DEFAULT_PORT};
 
@@ -417,6 +419,13 @@ async fn main() -> Result<()> {
             // Why: keeping the daemon resilient when the ONNX model is
             // missing (CI, fresh machines, offline) is more valuable than
             // hard-failing on startup.
+            //
+            // Why (issue #536): when no ORT backend feature is compiled in
+            // (e.g. --no-default-features --features http-server with no
+            // bundled-ort / load-dynamic / cuda), NeuralEmbedder is not
+            // available at all. The cfg block below falls through to BOW
+            // without requiring any runtime check.
+            #[cfg(any(feature = "bundled-ort", feature = "load-dynamic", feature = "cuda"))]
             let embedder: Arc<dyn Embedder> = match NeuralEmbedder::new(Some(&fastembed_cache)) {
                 Ok(e) => {
                     tracing::info!("neural embedder loaded from {}", fastembed_cache.display());
@@ -429,6 +438,20 @@ async fn main() -> Result<()> {
                     );
                     Arc::new(BowEmbedder::default())
                 }
+            };
+            // When no ORT backend feature is compiled in, always use BOW.
+            // The fastembed_cache path is unused in this build variant; the
+            // let _ suppresses the dead-variable lint without removing the
+            // CLI argument (operators still pass --fastembed-cache even if it
+            // has no effect, so we keep the option for forward compatibility).
+            #[cfg(not(any(feature = "bundled-ort", feature = "load-dynamic", feature = "cuda")))]
+            let embedder: Arc<dyn Embedder> = {
+                let _ = &fastembed_cache;
+                tracing::info!(
+                    "no ORT backend compiled in; using BOW embedder \
+                     (build with bundled-ort, load-dynamic, or cuda for neural embeddings)"
+                );
+                Arc::new(BowEmbedder::default())
             };
             let state = AnalyzerAppState::new(search, facts).with_embedder(embedder);
 


### PR DESCRIPTION
## Summary

Closes #536.

`trusty-analyze 0.4.0` hardcoded `fastembed = { features = ["ort-download-binaries"] }` as a non-optional dependency, making it impossible to install on Amazon Linux 2023 (glibc 2.34) without a manual `Cargo.toml` patch. This PR makes the ORT backend fully feature-selectable, matching the existing trusty-search pattern.

### Root cause

`crates/trusty-analyze/Cargo.toml` line ~86 declared:
```toml
fastembed = { workspace = true, features = ["hf-hub-rustls-tls", "ort-download-binaries"] }
```
Non-optional, hardcoded ORT backend — `--no-default-features` had no effect on the glibc requirement.

### Changes

**`crates/trusty-analyze/Cargo.toml`** (version bump 0.4.0 → 0.4.1):
- Make `fastembed` optional (no ORT backend hardcoded in the dep declaration)
- Add `bundled-ort`, `load-dynamic`, `cuda` features mirroring trusty-search
- `default = ["http-server", "bundled-ort"]` — existing installs unchanged
- `load-dynamic = ["dep:fastembed", "fastembed/ort-load-dynamic"]` — the fix

**`src/embedder/mod.rs`**:
- Gate `pub mod neural` and `pub use neural::NeuralEmbedder` behind `#[cfg(any(feature = "bundled-ort", feature = "load-dynamic", feature = "cuda"))]`

**`src/main.rs`**:
- Gate `NeuralEmbedder` import and construction behind the same cfg
- Compile-time BowEmbedder fallback when no ORT backend feature is active

**`README.md`**: document the three install variants (bundled-ort, load-dynamic, no-ORT)

**`CLAUDE.md`**: add `ORT_DYLIB_PATH` note for trusty-analyze alongside trusty-search

### cargo-tree evidence (load-dynamic build — the fix)

```
$ cargo tree -p trusty-analyze --no-default-features --features http-server,load-dynamic -e features -i ort-sys
ort-sys v2.0.0-rc.12
└── ort v2.0.0-rc.12
    ├── ort feature "load-dynamic"          ← dynamic loading active
    │   └── fastembed feature "ort-load-dynamic"  ← no bundled ORT
    └── fastembed v5.13.4
        └── trusty-analyze feature "load-dynamic" (command-line)
```

`ort-download-binaries` / `ort feature "download-binaries"` / `ort-sys feature "download-binaries"` are **completely absent** from the load-dynamic dependency tree. `libloading` (the dynamic-link library) is present instead.

### Contrast: default build (bundled-ort, unchanged)

```
$ cargo tree -p trusty-analyze -e features -i ort-sys | grep -i "download\|load.dynamic"
    ├── fastembed feature "ort-download-binaries"
    └── fastembed feature "ort-download-binaries-native-tls"
    ├── ort feature "download-binaries"
    └── ort-sys feature "download-binaries"
```

Default installs are unaffected.

### Install commands after this fix

```bash
# Standard (macOS, Linux glibc ≥ 2.38) — unchanged
cargo install trusty-analyze

# Amazon Linux 2023 / glibc 2.34 — THE FIX
cargo install trusty-analyze --no-default-features --features http-server,load-dynamic
export ORT_DYLIB_PATH=/usr/local/lib/libonnxruntime.so.1.24.2

# No ONNX Runtime available — BoW embedder fallback
cargo install trusty-analyze --no-default-features --features http-server
```

## Test plan

- [x] Default build `cargo build -p trusty-analyze` compiles (bundled-ort, no regression)
- [x] Fix path `cargo build -p trusty-analyze --no-default-features --features http-server,load-dynamic` compiles
- [x] No-ORT fallback `cargo build -p trusty-analyze --no-default-features --features http-server` compiles
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (default features)
- [x] `cargo clippy -p trusty-analyze --no-default-features --features http-server,load-dynamic -- -D warnings` clean
- [x] `cargo test -p trusty-analyze` — 12 passed, 0 failed (default features)
- [x] `cargo check --workspace` passes
- [x] `cargo fmt --check` clean
- [x] cargo-tree confirms `ort-download-binaries` absent in load-dynamic build
- [ ] Runtime verification on AL2023 glibc 2.34 — not verifiable on macOS (glibc linking), but feature-resolution evidence confirms the correct ORT strategy is selected

Note: parallel PR #537 touches trusty-common/memory/search, not trusty-analyze. No overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)