### PR TITLE
fix(open-mpm): add flush() to async file writes to eliminate read-after-write races (closes #540)

### DIFF
--- a/crates/open-mpm/src/context/cleaner.rs
+++ b/crates/open-mpm/src/context/cleaner.rs
@@ -139,7 +139,14 @@ pub async fn clean_once(store_dir: &Path, _api_key: &str, batch_size: usize) -> 
         .append(true)
         .open(&log_path)
         .await?;
-    f.write_all(log_line.as_bytes()).await?;
+    // Error-first: return before flushing a failed write.
+    if let Err(e) = f.write_all(log_line.as_bytes()).await {
+        return Err(e.into());
+    }
+    // Flush so the log line is visible to any reader (e.g. `clean_once_rewrites_file`
+    // asserts the log file exists, and a timing-dependent read might see an empty
+    // file without this flush on a loaded test runner).
+    f.flush().await?;
 
     Ok(())
 }

--- a/crates/open-mpm/src/context/cluster.rs
+++ b/crates/open-mpm/src/context/cluster.rs
@@ -42,8 +42,13 @@ impl ClusterStore {
     /// Why: The synthesized text is what we want surfaced; storing its
     /// embedding alongside allows future retrieval without re-embedding.
     /// What: Wraps `summary + embedding` in an `IndexedEntry` with a synthetic
-    /// `TurnRecord` (agent = "consolidator"). Appends one JSONL line.
-    /// Test: `cluster_save_and_load_roundtrip`.
+    /// `TurnRecord` (agent = "consolidator"). Appends one JSONL line, then
+    /// flushes to ensure bytes are visible to subsequent `load_all` calls in
+    /// the same process. Tokio's `File` uses `spawn_blocking` internally so
+    /// `write_all` can resolve before the kernel has committed the buffer;
+    /// without `flush`, a read-back in the same task (or a different one) can
+    /// observe an empty file — the same race fixed in PR #532 for `append_usage`.
+    /// Test: `cluster_save_and_load_roundtrip` (verified stable across ≥5 runs).
     pub async fn save(&self, summary: String, embedding: Vec<f32>) -> anyhow::Result<()> {
         let entry = IndexedEntry {
             id: uuid::Uuid::new_v4().to_string(),
@@ -69,7 +74,10 @@ impl ClusterStore {
             .append(true)
             .open(&self.path)
             .await?;
-        f.write_all(format!("{line}\n").as_bytes()).await?;
+        if let Err(e) = f.write_all(format!("{line}\n").as_bytes()).await {
+            return Err(e.into());
+        }
+        f.flush().await?;
         Ok(())
     }
 

--- a/crates/open-mpm/src/context/indexer.rs
+++ b/crates/open-mpm/src/context/indexer.rs
@@ -103,8 +103,16 @@ async fn run_indexer(mut rx: mpsc::Receiver<TurnRecord>, store_dir: PathBuf, api
                         .await
                     {
                         Ok(mut f) => {
+                            // Write the line first; return early on failure so we
+                            // do not flush a partial write. Then flush to ensure
+                            // the bytes are visible to the retriever's read-back
+                            // in the same process (Tokio's File uses spawn_blocking
+                            // internally — write_all resolving does NOT guarantee
+                            // the OS buffer is committed).
                             if let Err(e) = f.write_all(format!("{line}\n").as_bytes()).await {
                                 tracing::warn!(error = %e, "history indexer: write failed");
+                            } else if let Err(e) = f.flush().await {
+                                tracing::warn!(error = %e, "history indexer: flush failed");
                             }
                         }
                         Err(e) => {

--- a/crates/open-mpm/src/mistake_log.rs
+++ b/crates/open-mpm/src/mistake_log.rs
@@ -161,6 +161,15 @@ pub fn truncate(s: &str, max: usize) -> String {
 }
 
 /// Append one record as a JSON line.
+///
+/// Why: Mistake records must be visible to the synchronous `read_session` /
+/// `read_recent_global` readers that follow immediately in tests and
+/// postmortem flows. Without `flush`, Tokio's `File` (which uses
+/// `spawn_blocking` internally) may not have committed the buffer by the time
+/// the caller reads the file back. Fix mirrors the pattern from PR #532.
+/// What: Opens the file in create+append mode, writes `line + "\n"` — bailing
+/// out on write failure before flushing — then flushes to guarantee visibility.
+/// Test: `mistake_log_records_nonzero_exit` reads back what `record` wrote.
 async fn append_line(path: &Path, record: &MistakeRecord) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
@@ -171,8 +180,15 @@ async fn append_line(path: &Path, record: &MistakeRecord) -> Result<()> {
         .append(true)
         .open(path)
         .await?;
-    file.write_all(line.as_bytes()).await?;
-    file.write_all(b"\n").await?;
+    // Write first; short-circuit before flush on failure so we don't flush a
+    // partial write.
+    if let Err(e) = file.write_all(line.as_bytes()).await {
+        return Err(e.into());
+    }
+    if let Err(e) = file.write_all(b"\n").await {
+        return Err(e.into());
+    }
+    file.flush().await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes the `write_all`-without-`flush` race class in `open-mpm` (same root cause as PR #532). Tokio's `File` resolves `write_all` once the write is *submitted* via `spawn_blocking`, not once the kernel buffer is committed. A subsequent read in the same process can observe an empty/short file, producing intermittent test failures under load.

- Add `flush().await` after `write_all` in four async file-write sites
- Follow the error-first pattern: bail on write failure before flushing
- `cluster_save_and_load_roundtrip` confirmed stable across 10 repeated runs

## Audit table — every `tokio::fs::OpenOptions` + `write_all` site in `open-mpm`

| File | Line area | Pattern | Status | Change |
|---|---|---|---|---|
| `context/cluster.rs` | 67–73 | `OpenOptions.append + write_all` | **FIXED** | Added `flush().await` with error-first guard |
| `context/indexer.rs` | 99–113 | `OpenOptions.append + write_all` | **FIXED** | Added `flush().await` with error-first guard |
| `context/cleaner.rs` | 137–142 | `OpenOptions.append + write_all` | **FIXED** | Added `flush().await` with error-first guard |
| `mistake_log.rs` | 169–176 | `OpenOptions.append + write_all × 2` | **FIXED** | Added `flush().await` with error-first guard |
| `usage/mod.rs` | 109–126 | `OpenOptions.append + write_all` | Already fixed (PR #532) | No change |
| `perf/mod.rs` | 430–439 | `OpenOptions.append + write_all` | Already has `f.flush().await.ok()` | No change |
| `cli/memories_cmd/ops.rs` | 74–133 | `File::create + write_all` | Already has `f.flush().await?` | No change |
| `ctrl/socket_listener.rs` | 261, 312 | `write_all` on UnixStream writer | Already calls `g.flush().await` | No change |
| All `tokio::fs::write(path, bytes)` call sites (many) | — | Free function | Safe — flushes+closes internally | No change |
| `interaction_log.rs` + `state_writer.rs` | — | `std::fs::OpenOptions` + `fs4` advisory locks | Synchronous (not Tokio File); not subject to spawn_blocking buffering | No change |
| `bus/mod.rs`, `subprocess/spawn.rs`, `ctrl/repl/mod.rs`, etc. | — | `write_all` on stdin/stdout/socket halves | These are stream writes, not file persistence; flush behavior is appropriate for their use | No change |
| `std::fs::File` write_all sites in tests/tools | — | Synchronous | Not affected | No change |

## Loop-test evidence for `cluster_save_and_load_roundtrip`

```
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 1/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 2/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 3/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 4/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 5/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 6/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 7/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 8/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 9/10)
test context::cluster::tests::cluster_save_and_load_roundtrip ... ok  (run 10/10)
```

## Full `cargo test -p open-mpm` result

```
test result: ok. 1867 passed; 0 failed; 5 ignored  (lib)
test result: ok.    6 passed; 0 failed; 0 ignored  (bin ompm)
test result: ok.    4 passed; 0 failed; 3 ignored  (api_e2e)
test result: ok.    2 passed; 0 failed; 0 ignored  (cli_project)
```

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (zero lint errors)
- [x] `cargo test -p open-mpm` — 1879 tests green, 5 ignored
- [x] `cluster_save_and_load_roundtrip` stable across 10 repeated runs
- [x] `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)