### PR TITLE
docs(trusty-review): add design spec for AI-assisted PR review pipeline

### DIFF
--- a/docs/trusty-review/spec/01-architecture.md
+++ b/docs/trusty-review/spec/01-architecture.md
@@ -1,0 +1,220 @@
+# 01 — Architecture
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [02-pipeline](02-pr-review-pipeline.md) · [04-llm-providers](04-llm-providers.md) · [05-integrations](05-integrations.md) · [09-deployment](09-deployment-operations.md)
+**Factual basis:** source-analysis §11 (workspace conventions), §6 (adapters), §13 (delta table).
+
+---
+
+## 1. System context
+
+trusty-review is the third member of the `trusty-tools` PR-review triad. It orchestrates; it does not index or analyze on its own.
+
+```mermaid
+flowchart LR
+    subgraph clients["Triggers"]
+      GH["GitHub webhook\n(review_requested)"]
+      CLI["CLI one-shot\n(run / local diff)"]
+    end
+
+    subgraph review["trusty-review (NEW)"]
+      ROUTER["axum router\n(http-server feature)"]
+      PIPE["Review pipeline\n(stages 1–16)"]
+      PROV["LlmProvider trait\n(Bedrock | OpenRouter)"]
+      DIFF["Diff summarizer\n(Stage A/B/C)"]
+    end
+
+    subgraph deps["Workspace deps"]
+      SEARCH["trusty-search :7878\n(REQUIRED)"]
+      ANALYZE["trusty-analyze :7879\n(OPTIONAL)"]
+    end
+
+    subgraph external["External services"]
+      BEDROCK["AWS Bedrock"]
+      OPENROUTER["OpenRouter"]
+      GHAPI["GitHub REST/GraphQL"]
+      JIRA["JIRA REST"]
+      SLACK["Slack"]
+    end
+
+    GH --> ROUTER --> PIPE
+    CLI --> PIPE
+    PIPE --> DIFF
+    PIPE --> PROV
+    DIFF --> PROV
+    PROV --> BEDROCK
+    PROV --> OPENROUTER
+    PIPE --> SEARCH
+    PIPE -.optional.-> ANALYZE
+    PIPE --> GHAPI
+    PIPE --> JIRA
+    PIPE -.notify.-> SLACK
+```
+
+---
+
+## 2. Crate layout within the workspace
+
+**REV-001** — trusty-review SHALL be added as `crates/trusty-review/` and picked up automatically by the workspace glob `members = ["crates/*"]` (source-analysis §11.1). It SHALL NOT modify the workspace root manifest except to add shared dependencies under `[workspace.dependencies]`.
+
+**REV-002** — The crate SHALL ship a library (`src/lib.rs`, `[lib] name = "trusty_review"`) and a binary (`src/main.rs`, `[[bin]] name = "trusty-review"`), mirroring trusty-analyze (source-analysis §11.1, §11.3).
+
+**REV-003** — The crate SHALL set `edition = "2024"`, `rust-version = "1.88"` (workspace MSRV), matching the current workspace package settings. (NOTE: source-analysis §11.2 records edition 2021 as the old convention; the live workspace `[workspace.package]` is now edition 2024 — the implementer SHALL follow the live workspace value.)
+
+**REV-004** — axum + tower-http SHALL be **optional** dependencies gated behind a `http-server` feature, defaulting on, exactly as trusty-analyze does (source-analysis §11.2). Library consumers building `--no-default-features` MUST be able to use the pipeline, diff summarizer, and provider trait without pulling the HTTP stack. The webhook server (`service` module) SHALL be compiled only under `http-server`.
+
+**REV-005** — Errors in library modules SHALL use `thiserror` enums; the binary SHALL use `anyhow`. No `unwrap()` in library code (use `?` or `expect()` only for true invariants). No global state / no `lazy_static!`. Logs go to **stderr** only. (source-analysis §11.2)
+
+**REV-006** — Every public item SHALL carry Why / What / Test doc comments; no source file SHALL exceed 500 lines (split proactively). (source-analysis §11.2)
+
+### 2.1 Proposed module map (normative shape, not code)
+
+```
+crates/trusty-review/
+├── Cargo.toml
+└── src/
+    ├── lib.rs                  # re-exports; crate-level docs
+    ├── main.rs                 # binary: clap dispatch → CLI or `serve`
+    ├── config/                 # global config + per-repo config model (doc 06)
+    │   ├── mod.rs
+    │   ├── global.rs           # env + file → ReviewConfig
+    │   └── repo.rs             # .github/code-intelligence.yml model
+    ├── pipeline/               # the review pipeline (doc 02)
+    │   ├── mod.rs              # ReviewPipeline orchestrator
+    │   ├── eligibility.rs
+    │   ├── dedup.rs            # in-flight + persistent claim
+    │   ├── context.rs          # parallel retrieval (search/jira/apex/xref)
+    │   ├── verdict.rs          # grade extraction + normalization
+    │   ├── verify.rs           # per-finding verification round
+    │   └── suppression.rs      # suppression + relevance gate
+    ├── diff/                   # diff summarizer (doc 03)
+    │   ├── mod.rs              # DiffAnalyzer (Stage A/B/C)
+    │   ├── file_filter.rs      # Stage A
+    │   ├── hunk_filter.rs      # Stage B (deterministic)
+    │   ├── hunk_classifier.rs  # Stage C (LLM)
+    │   └── models.rs           # FilteredDiff et al.
+    ├── llm/                    # provider abstraction (doc 04)
+    │   ├── mod.rs              # LlmProvider trait + RoleModels
+    │   ├── openrouter.rs       # wraps trusty_common::chat::OpenRouterProvider
+    │   └── bedrock.rs          # Bedrock Converse provider
+    ├── integrations/           # external clients (doc 05)
+    │   ├── github/             # auth, PR ops, tracker issues, webhook verify
+    │   ├── jira.rs
+    │   ├── search_client.rs    # trusty-search HTTP client (:7878)
+    │   ├── analyze_client.rs   # trusty-analyze HTTP client (:7879)
+    │   └── slack.rs
+    ├── store/                  # persistence (doc 07): dedup claims + review log
+    │   ├── mod.rs
+    │   ├── dedup.rs            # redb cross-process claim
+    │   └── log.rs              # filesystem JSON/MD review log
+    ├── service/                # axum webhook server (http-server feature, doc 08)
+    │   └── mod.rs              # build_router(state) -> Router
+    └── cli/                    # CLI subcommands (doc 08)
+        └── mod.rs
+```
+
+Files approaching 500 lines (e.g. `pipeline/mod.rs`, `service/mod.rs`) SHALL be split further during implementation.
+
+---
+
+## 3. Consuming trusty-search and trusty-analyze: in-process vs HTTP
+
+The product owner asked us to *prefer in-process library calls where the workspace allows, else HTTP, and recommend*.
+
+### 3.1 Analysis
+
+| Dependency | In-process feasible? | Notes |
+|------------|----------------------|-------|
+| **trusty-search** | Partially. `trusty-search` is a lib + binary; its types could be linked. **But** the production index lives in a *separately deployed* daemon (`:7878`) with its own redb store, embedder pool, and GPU/CPU lifecycle. The serving model is: one long-lived daemon, many clients. (source-analysis §6.1, CLAUDE.md architecture). |
+| **trusty-analyze** | Partially. Same shape — already a daemon at `:7879`, already exposes `/review/github-pr` and `/webhooks/github` axum routes (verified in `crates/trusty-analyze/src/service/mod.rs`). |
+
+### 3.2 Recommendation
+
+**REV-007 (RECOMMENDED, NORMATIVE DEFAULT)** — trusty-review SHALL consume both trusty-search and trusty-analyze **over HTTP** (`:7878`, `:7879`) as its default and production transport, mirroring the Python adapters (source-analysis §6, §11.5). Rationale:
+
+1. The daemons own a heavyweight, separately-managed runtime (embedder pool, GPU on the indexing instance, redb stores synced from S3). Linking them in-process would duplicate that lifecycle inside the review process and defeat the "restart the daemon without downtime" isolation property (CLAUDE.md "Why trusty-search is a separate process").
+2. The Python production deployment already proved the HTTP boundary, including its graceful-degradation and readiness-probe semantics. Reusing the contract de-risks the port.
+3. It keeps trusty-review a thin orchestrator, satisfying NG2.
+
+**REV-008 (OPTIONAL EXTENSION)** — The crate MAY expose an `in-process-search` cargo feature that, when enabled, satisfies the same internal `SearchClient`/`AnalyzeClient` traits (REV-410, REV-430 in doc 05) by calling `trusty_search` / `trusty_analyze` library entry points directly — for the local-CLI single-binary use case where no daemon is running. The trait boundary (below) makes this swappable without touching the pipeline.
+
+**REV-009** — All trusty-search/trusty-analyze access SHALL go through a Rust trait (`SearchClient`, `AnalyzeClient`) so the transport (HTTP vs in-process) is an implementation detail invisible to the pipeline. This is the same indirection the Python code achieved with its adapter classes (source-analysis §6).
+
+```mermaid
+flowchart TB
+    PIPE[ReviewPipeline] --> SC{{SearchClient trait}}
+    PIPE --> AC{{AnalyzeClient trait}}
+    SC -->|default| HTTPSEARCH[HttpSearchClient → :7878]
+    SC -.feature in-process-search.-> LIBSEARCH[InProcessSearchClient]
+    AC -->|default| HTTPANALYZE[HttpAnalyzeClient → :7879]
+    AC -.feature in-process-search.-> LIBANALYZE[InProcessAnalyzeClient]
+```
+
+---
+
+## 4. Component responsibilities
+
+| Component | Responsibility | Doc |
+|-----------|----------------|-----|
+| `service::build_router(state) -> Router` | axum 0.8 webhook + health/status surface; matches trusty-analyze pattern. | 08 |
+| `cli` | `run`, `run --local-diff`, `list`, `stats`, `compare`, `eval`. | 08 |
+| `ReviewPipeline` | Owns the 16-stage ordered pipeline; pure orchestration over the trait-boundary clients. | 02 |
+| `DiffAnalyzer` | Stage A/B/C diff filtering; usable standalone. | 03 |
+| `LlmProvider` impls | Bedrock + OpenRouter behind one trait; per-role model selection. | 04 |
+| `integrations::*` | GitHub (App+PAT), JIRA, trusty-search/analyze clients, Slack. | 05 |
+| `store` | dedup claim (redb) + review log (filesystem). | 07 |
+| `config` | global (env+file) + per-repo YAML. | 06 |
+
+---
+
+## 5. Local vs server topology
+
+**REV-010** — The same binary SHALL support both modes; mode is selected by subcommand, not a build flag (binding decision #4). `trusty-review serve` starts the webhook daemon; `trusty-review run …` performs a one-shot review and exits.
+
+### 5.1 Server mode (production)
+
+```mermaid
+flowchart LR
+    GH[GitHub] -->|webhook HMAC| RS[trusty-review serve\n:PORT]
+    RS --> SEARCH[trusty-search :7878]
+    RS -.->|optional| ANALYZE[trusty-analyze :7879]
+    RS --> LLM[Bedrock / OpenRouter]
+    RS --> REDB[(redb dedup claim)]
+    RS --> FS[(filesystem review log)]
+    RS -->|live: comment + tracker issue| GH
+    RS -.->|notify| SLACK[Slack]
+```
+
+- Long-lived; multi-worker safe via the redb cross-process claim (REV-110, doc 02 / doc 07).
+- Default `dry_run = true` (source-analysis §12.8). Only `review_requested` events dispatch (source-analysis §1.2, §12.4).
+
+### 5.2 Local / one-shot mode (developer)
+
+```mermaid
+flowchart LR
+    DEV[Developer CLI] --> R1[trusty-review run owner repo 42]
+    DEV --> R2[trusty-review run --local-diff ./my.diff]
+    R1 -->|reads live PR| GHAPI[GitHub API]
+    R1 --> SEARCH2[trusty-search :7878\nvia tunnel or in-process]
+    R2 -->|no GitHub fetch| SEARCH2
+    R1 --> LLM2[Bedrock / OpenRouter]
+    R2 --> LLM2
+    R1 --> OUT[stdout review + JSON log]
+    R2 --> OUT
+```
+
+- `run` honors `dry_run` (defaults true → never posts). `--local-diff` reviews a diff file with no GitHub fetch and no posting (always dry).
+- May target a tunneled production trusty-search (`make tunnel` analog) or an `in-process-search` build (REV-008).
+
+---
+
+## 6. Graceful-degradation posture (summary; detailed in doc 05/09)
+
+**REV-011** — Required dependencies: **trusty-search** and the **selected LLM provider**. If either is unavailable, the review SHALL be skipped (not silently approved) and a Slack service-failure notification SHALL be sent. (source-analysis §9, §12.10)
+
+**REV-012** — Optional dependency: **trusty-analyze**. If it is unavailable, the pipeline SHALL proceed with an empty static-analysis context. Its absence MUST NOT raise the "service unavailable" path. (source-analysis §12.10)
+
+**REV-013** — Readiness for trusty-analyze SHALL be the **two-step cheap probe** (`GET /health` + `GET /indexes`), never the O(corpus) `/quality` endpoint. (source-analysis §12.3 — see doc 05 REV-431 and doc 10 §L3.)
+
+**REV-014** — JIRA, Confluence, APEX, Slack, and suppression lookups are all **fail-open**: any error degrades to "no extra context" / "no suppression" and never blocks the review. (source-analysis §12.9)

--- a/docs/trusty-review/spec/02-pr-review-pipeline.md
+++ b/docs/trusty-review/spec/02-pr-review-pipeline.md
@@ -1,0 +1,174 @@
+# 02 — PR Review Pipeline
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [01-architecture](01-architecture.md) · [03-diff-summarizer](03-diff-summarizer.md) · [04-llm-providers](04-llm-providers.md) · [05-integrations](05-integrations.md) · [07-data-models](07-data-models.md) · [10-lessons](10-lessons-and-rationale.md)
+**Factual basis:** source-analysis §1 (pipeline), §2 (verdict + verification), §5 (log/dedup), §12 (lessons).
+
+This document specifies the core review pipeline: the ordered stages, the fail-safe verdict policy, and the per-finding verification round.
+
+---
+
+## 1. Pipeline stage sequence
+
+The pipeline is a direct, ordered re-specification of the Python `review_pr → _review_pr_inner → _run_review_pipeline → _run_review_pipeline_inner` chain (source-analysis §1.3). It runs identically in server and CLI modes; the only differences are the *trigger* (doc 08) and the *output side-effects* (dry vs live).
+
+```mermaid
+flowchart TD
+    S1[1. Eligibility] --> S2[2. Dedup: in-flight + claim]
+    S2 --> S3[3. Diff fetch + MAX_DIFF_CHARS]
+    S3 --> S4[4. Repo-config load]
+    S4 -->|skip:true| STOP1[return None]
+    S4 --> S5[5. Existing bot-review detection]
+    S5 --> S6[6. Head-SHA dedup]
+    S6 -->|same head_sha| STOP2[return cached]
+    S6 --> S7[7. Parallel context retrieval]
+    S7 -->|require_search_context && empty| STOP3[skip review]
+    S7 --> S8[8. Iterative enrichment ≤5 rounds]
+    S8 --> S9[9. Static analysis - optional]
+    S9 --> S10[10. LLM review generation - reviewer role]
+    S10 --> S11[11. Grade extraction]
+    S11 --> S12[12. Fix-suggestion parsing]
+    S12 --> S13[13. Verification round - verifier role]
+    S13 --> S14[14. Suppression filtering]
+    S14 --> S15[15. Relevance gate]
+    S15 --> S16{16. Output}
+    S16 -->|dry-run| DRY[log + calibration issue + Slack]
+    S16 -->|live| LIVE[PR comment + tracker issue + log + Slack]
+```
+
+### Stage-by-stage requirements
+
+**REV-100 — Stage 1: Eligibility.** Check the repo against the enabled/excluded allow/deny lists (`PR_INTELLIGENCE_ENABLED_REPOS` / `EXCLUDED_REPOS`, doc 06). `*` = all; `org/*` = org wildcard; deny list always overrides allow list. Not enabled → return early, no LLM call. (source-analysis §1.3 step 1, §10.1)
+
+**REV-101 — Stage 2: Deduplication (three layers).** (source-analysis §1.3 step 2, §5.3, §12.4)
+- (a) In-process per-`(owner,repo,pr_number)` guard, claimed at request receipt **before** the head SHA is known.
+- (b) In-process per-`(owner,repo,pr_number,head_sha)` guard once the SHA is known.
+- (c) Cross-process atomic claim in the persistent store (redb; doc 07 REV-620) keyed on `(owner,repo,pr_number,head_sha)`. The claim SHALL be an atomic insert-or-fail; stale claims (> `DEDUP_STALE_SECS` = 7200) SHALL be purged on each claim attempt; the claim SHALL be released in a `finally`/`Drop`-equivalent guard to avoid leaks.
+  > **Rationale (lesson learned §12.4):** Concurrent webhook delivery fires multiple events per push; all three layers are required, and the cross-process claim is critical for multi-worker server deployments.
+
+**REV-102 — Stage 3: Diff fetch + truncation.** Fetch PR metadata, file list, and unified diff (doc 05 GitHub client). Collapse noisy fixture/i18n files to a 1-line summary (`NOISY_FILE_PATTERNS`, `NOISY_DIFF_MIN_LINES` = 30). Build the prompt diff text and **truncate to `MAX_DIFF_CHARS` = 16384** (≈ 4k tokens). Use the diff summarizer (doc 03) when available; fall back to raw truncated diff otherwise. (source-analysis §1.3 step 3, §3.4)
+
+**REV-103 — Stage 4: Repo config load.** Fetch `.github/code-intelligence.yml` from the reviewed repo's default branch via the GitHub Contents API. On any error, fall back to the default config (**fail-open**). If `skip: true`, return immediately with no review. (source-analysis §1.3 step 4, §8, §12.9)
+
+**REV-104 — Stage 5: Existing bot-review detection.** Fetch prior bot/Copilot PR reviews and classify a "copilot mode" ∈ {`full`, `supplement`, `duetto_only`} that conditions the reviewer prompt. (source-analysis §1.3 step 5)
+
+**REV-105 — Stage 6: Head-SHA dedup (cache).** Look up any existing logged review for this PR. If its `head_sha` equals the current head SHA and `skip_dedup` is false, return the cached result without re-running. `eval` mode sets `skip_dedup = true`. (source-analysis §1.3 step 6, §1.1)
+
+**REV-106 — Stage 7: Parallel context retrieval.** Run concurrently (source-analysis §1.3 step 7):
+- **Code context** — trusty-search `POST /indexes/{index}/search`; query = PR title + changed file paths; up to `MAX_CONTEXT_FILES` = 6 chunks.
+- **JIRA/ticket context** — doc 05 fallback chain.
+- **APEX context** — queried as a repo within the same index (binding decision #3; doc 05 REV-420).
+- **Confluence context**, **GitHub-issues context**.
+- **Cross-reference blast-radius search** (REV-108).
+
+  **REV-107 — require_search_context relevance gate (input side).** If `require_search_context = true` and code-context search returns **zero** results, the review SHALL be skipped entirely (no LLM call). (source-analysis §1.3 step 7)
+
+**REV-108 — Cross-reference blast-radius search.** Extract enum constants (`ALL_CAPS_WITH_UNDERSCORE`) and method calls (`camelCase(`) from **deleted** diff lines; search trusty-search for *other, unchanged* files referencing them; prioritize producer-keyword hits (`enqueue`, `schedule`, `produce`, …).
+  > **Rationale (lesson learned §12.13):** a PR that deletes a permission check leaves an orphaned producer in an untouched file; diff-only similarity never surfaces it.
+
+**REV-109 — Stage 8: Iterative enrichment (≤ `MAX_ENRICHMENT_ROUNDS` = 5).** Extract identifiers (class/method/const names) from the diff; run targeted vector searches per identifier; add only newly-found chunks. Record `enrichment_rounds` and `enrichment_queries` for audit (doc 07). (source-analysis §1.3 step 8)
+
+**REV-110 — Stage 9: Static analysis (optional).** Probe trusty-analyze readiness with the **two-step cheap probe** (REV-431); if ready, fetch complexity hotspots and smells for changed files; otherwise proceed with an empty analysis. Never raise on trusty-analyze failure. (source-analysis §1.3 step 9, §12.3, §12.10)
+
+**REV-111 — Stage 10: LLM review generation (reviewer role).** Assemble all context into a structured prompt and call the **reviewer-role** provider (doc 04). The system prompt SHALL encode the fail-safe verdict policy (§2 below). Capture input/output token counts. Reviewer temperature default 0.3 (tighter than chat, for determinism). (source-analysis §1.3 step 10, §6.3)
+
+**REV-112 — Stage 11: Grade extraction.** Scan the last 20% of the review body against the grade patterns; support both verdict tokens and letter grades A–F; normalize to one of `APPROVE` / `APPROVE*` / `REQUEST_CHANGES` / `BLOCK` / `N/A`. (source-analysis §2.1)
+
+**REV-113 — Stage 12: Fix-suggestion parsing.** Parse structured ```fix_suggestions``` JSON blocks from the review body into `FixSuggestion` records (doc 07 REV-601). (source-analysis §1.3 step 12, §5.2)
+
+**REV-114 — Stage 13: Verification round.** Per §3 below. (source-analysis §2.2)
+
+**REV-115 — Stage 14: Suppression filtering.** Merge label-driven (`bot-suppress` closed issues) and repo-config (`suppress`) patterns; drop findings matching by case-insensitive substring OR ≥70% Jaccard word overlap; all lookups **fail-open**. (source-analysis §4.4, §8.2, §12.9; doc 05 REV-405, doc 06 REV-530)
+
+**REV-116 — Stage 15: Relevance gate (output side).** (source-analysis §1.3 step 15)
+- `min_findings` check — skip posting if surviving eligible findings < repo `min_findings` (or `PR_INTELLIGENCE_MIN_FINDINGS_TO_POST`).
+- `suppress_advisory` check — if verdict ∈ {APPROVE, APPROVE\*} and there are no required-change findings, skip posting when `suppress_advisory` is set.
+
+**REV-117 — Stage 16: Output.** (source-analysis §1.3 step 16)
+- **Dry-run path:** write the review log (`review.json` + `review.md`), file/update a calibration GitHub issue (`code-intelligence-review` label), send Slack completion notice. Post nothing to the PR.
+- **Live path:** post the PR review comment, upsert the single tracker issue for the PR, write the review log, send Slack completion notice.
+
+**REV-118 — review_version.** Each result SHALL carry a `review_version` pipeline string (the Python baseline is `"v1.4"`). trusty-review SHALL stamp its own version (e.g. `"tr-0.1"`) so logs and tracker issues are attributable to a pipeline revision. (source-analysis §5.1)
+
+---
+
+## 2. Fail-safe verdict policy
+
+**REV-130 — Default verdict is APPROVE; the bot bears the burden of proof.** The reviewer system prompt SHALL state this verbatim in intent. (source-analysis §2.1)
+
+**REV-131 — REQUEST_CHANGES gate.** A `REQUEST_CHANGES` verdict SHALL require ALL THREE, evidenced from the **visible diff**: (a) a specific wrong line cited, (b) a traceable failure path, (c) a concrete fix. (source-analysis §2.1)
+
+**REV-132 — BLOCK gate.** `BLOCK` is reserved for undisputed evidence of a serious flaw introduced by this PR (data loss, auth bypass, irreversible production breakage). (source-analysis §2.1)
+
+### 2.1 Verdict taxonomy
+
+| Verdict | Meaning | Findings precondition |
+|---------|---------|------------------------|
+| `APPROVE` | Merge as-is. | No findings, or only advisory. |
+| `APPROVE*` | Merge, minor issues noted. | No surviving required-change findings. Also the **effective** outcome when all blocking findings are refuted (REV-141). |
+| `REQUEST_CHANGES` | Must fix before merge. | ≥1 surviving finding meeting REV-131. |
+| `BLOCK` | Serious undisputed flaw. | ≥1 surviving finding meeting REV-132. |
+| `N/A` | Could not determine a grade. | Treated as APPROVE-tier for verification candidate selection (§3.1). |
+
+**REV-133 — Letter-grade mapping.** When the reviewer emits a letter grade A–F instead of a verdict token, it SHALL be normalized: A/B → APPROVE-tier, C → APPROVE\*, D → REQUEST_CHANGES, F → BLOCK (implementer MAY refine the mapping but SHALL document it). A `display_grade` and `display_grade_is_fallback` flag SHALL be recorded (doc 07). (source-analysis §2.1, §5.1)
+
+**REV-134 — Grade-divergence handling.** When the narrative verdict and the extracted grade diverge (e.g. narrative says "request changes" but the supporting finding's confidence is sub-threshold), the **verification round** (§3) is the arbiter. The reviewer's narrative is NOT trusted to set the final verdict on its own; surviving verified findings determine the effective outcome.
+  > **Rationale (lesson learned §12.5):** the LLM wrote REQUEST_CHANGES while assigning the finding confidence < 0.90, so the finding was never verified and the verdict silently became APPROVE\*. Candidate selection (§3.1) is widened precisely to close this gap.
+
+---
+
+## 3. Per-finding verification round
+
+Re-specifies Python `_verify_blocking_findings()` (source-analysis §2.2). Runs after fix-suggestion parsing (Stage 12), before suppression (Stage 14). Uses the **verifier role** provider (doc 04, Haiku-tier).
+
+### 3.1 Candidate selection
+
+**REV-135** — Candidate selection depends on the primary verdict (source-analysis §2.2 table; lesson §12.5):
+
+| Primary verdict | Candidates sent to verifier |
+|-----------------|------------------------------|
+| `REQUEST_CHANGES` or `BLOCK` | ALL findings with `confidence ≥ VERIFY_CANDIDATE_MIN_CONFIDENCE` (0.50), sorted descending, capped at `FIX_ISSUE_MAX_PER_PR` (5). |
+| `APPROVE`, `APPROVE*`, `N/A` | Only findings with `confidence ≥ block_threshold` (default 0.90). |
+
+### 3.2 Per-finding decision
+
+**REV-136** — For each candidate, call the verifier provider with the `VERIFICATION_SYSTEM_PROMPT`, which demands **exactly one word**: `CONFIRMED` if a specific wrong line is quotable and the failure path is traceable entirely within the visible code; `REFUTED` otherwise (absent evidence, requires assumptions outside the diff, or the diff appears truncated). (source-analysis §2.2)
+
+| Verifier response | Action |
+|-------------------|--------|
+| `CONFIRMED` | Promote confidence to `max(current, block_threshold)`. |
+| `REFUTED` | Set confidence to `FIX_ISSUE_MIN_CONFIDENCE - 0.01` (drops below both tiers). |
+| Any error / exception | Same as REFUTED — **fail toward APPROVE**. |
+| Truncation shortcut | Auto-REFUTE **without** an LLM call only when the diff is truncated AND **both** the finding's `file` AND its `line` marker are absent from the **full** diff text. |
+
+**REV-137 — Verifier model must be ACTIVE.** The verifier provider/model SHALL default to a Bedrock foundation-lifecycle-`ACTIVE` Haiku-tier model (or its OpenRouter equivalent). Model-config errors (model-not-found, validation, access-denied, not-ready) SHALL be classified distinctly from transient network errors and emitted as a `verification_model_error` event at ERROR level with an alarm (doc 04 REV-340, doc 09 REV-810).
+  > **Rationale (lesson learned §12.1):** a hardcoded LEGACY Haiku ID threw `ResourceNotFoundException` on every verification call → every finding auto-refuted → every PR silently became APPROVE. An inactive verifier model MUST produce an observable alarm, never a silent all-approve.
+
+**REV-138 — Full-diff verification window.** The diff handed to the verifier (`diff_for_verify`) SHALL be the **full** `diff_text` already bounded to `MAX_DIFF_CHARS` by the caller — NOT a smaller sub-slice. The truncation shortcut (REV-136) SHALL test the full diff.
+  > **Rationale (lesson learned §12.6):** checking only a 4k-char verification window auto-refuted real findings whose location appeared at char 4001–16384. Only genuinely hallucinated locations (absent from the full diff) may be auto-refuted.
+
+### 3.3 Downgrade logic
+
+**REV-139** — After verification, surviving blocking findings = candidates returned `CONFIRMED`. (source-analysis §2.2)
+
+**REV-140** — If the primary verdict was `REQUEST_CHANGES`/`BLOCK` and NO blocking findings survive, the review body is **not** rewritten, but the filed-findings list is empty.
+
+**REV-141** — With an empty filed-findings list, the **effective** outcome is `APPROVE*`. (source-analysis §2.2)
+
+### 3.4 Confidence tiers
+
+**REV-142** — (source-analysis §2.3)
+
+| Tier / constant | Value | Behavior |
+|-----------------|-------|----------|
+| `FIX_ISSUE_MIN_CONFIDENCE` (advisory) | 0.70 | Summarized in the review comment. |
+| `BLOCK_ISSUE_MIN_CONFIDENCE` (blocking) | 0.90 | Eligible to be filed as a tracker issue. |
+| `VERIFY_CANDIDATE_MIN_CONFIDENCE` | 0.50 | Lower bound for verification candidacy when verdict is REQUEST_CHANGES/BLOCK. |
+| `FIX_ISSUE_MAX_PER_PR` | 5 | Runaway safety cap on filed issues / verification candidates. |
+| `FIX_ISSUE_ALLOWED_EFFORTS` | `("low","medium")` | Only these effort levels may file issues. |
+| `issue_threshold` (repo) | 0.75 | Per-repo override of issue-filing threshold. |
+| `block_threshold` (repo) | 0.90 | Per-repo override of BLOCK tier. |
+| `pr_threshold` (repo) | 0.95 | High-confidence flag threshold. |
+
+These constants SHALL be defined once (config/constants) and reused by both the pipeline and the diff summarizer (mirroring the Python shared-constant discipline that avoids drift; source-analysis §2.2 note on `HAIKU_MODEL_ID`).

--- a/docs/trusty-review/spec/03-diff-summarizer.md
+++ b/docs/trusty-review/spec/03-diff-summarizer.md
@@ -1,0 +1,123 @@
+# 03 — Diff Summarizer (DiffAnalyzer)
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [02-pipeline](02-pr-review-pipeline.md) · [04-llm-providers](04-llm-providers.md) · [07-data-models](07-data-models.md) · [10-lessons](10-lessons-and-rationale.md)
+**Factual basis:** source-analysis §3 (DiffAnalyzer pipeline), §12.12 (noisy fixture problem).
+
+This is the standalone specification for the diff summarizer/analyzer. It re-specifies the Python `services/diff_analyzer/` subpackage as the `crates/trusty-review/src/diff/` module. It is usable **independently** of the full review pipeline (REV-260).
+
+---
+
+## 1. Purpose
+
+A PR diff is the LLM's single most expensive and most easily-poisoned input. The summarizer's job is to hand the reviewer a **token-budgeted, noise-stripped, anti-regression-protected** view of the diff while *never* dropping a security- or logic-relevant change.
+
+> **Rationale (lesson learned §12.12):** PR #9545 buried a real code change under i18n/fixture churn; the bot spent its context budget on noise and missed the change. The summarizer exists to prevent that class of failure.
+
+**REV-200** — The summarizer SHALL be a deterministic-first, LLM-last, three-stage pipeline. Stages A and B are pure/deterministic; only Stage C calls an LLM. (source-analysis §3.1)
+
+---
+
+## 2. Stage architecture
+
+Re-specifies `DiffAnalyzer.analyze(files, diff_text, config)` (source-analysis §3.1).
+
+```mermaid
+flowchart TD
+    IN[unified diff + file list + config] --> A[Stage A: FileFilter\n deterministic file-level]
+    A --> B[Stage B: HunkFilter\n deterministic hunk-level]
+    B --> C[Stage C: HunkClassifier\n LLM substantive scoring]
+    C --> OUT[FilteredDiff.render_for_prompt]
+    A -. preserve override .-> KEEP[(force-keep set)]
+    KEEP --> OUT
+```
+
+### 2.1 Stage A — FileFilter (deterministic, file-level)
+
+**REV-201** — Stage A SHALL classify each file into a `FileDisposition` ∈ {`KEPT`, `DROPPED`, `SUMMARY_ONLY`} using ordered rules (source-analysis §3.1):
+
+1. **Preserve-first (highest priority, overrides all drops):**
+   - Built-in preserve patterns: `security/`, `.env`, `secrets/`, config files.
+   - Credential-filename substrings: `secret`, `token`, `password`, `key`, `dsn`, `credential`.
+   - Content-level credential-URL regex match.
+   - User `diff_filter.preserve_patterns` (doc 06).
+2. **Drop:** lockfiles, snapshots, generated code, pure renames.
+3. **Summary-only:** fixture/i18n files exceeding `fixture_summary_min_lines` (default 30) → collapsed to a `summary_line`.
+4. Otherwise → `KEPT`.
+
+**REV-202** — Preserve rules SHALL take precedence over every drop/summarize rule. A file matching a credential pattern is ALWAYS `KEPT` in full. (source-analysis §3.1)
+
+### 2.2 Stage B — HunkFilter (deterministic, hunk-level)
+
+**REV-203** — For each surviving (`KEPT`) file, Stage B SHALL drop hunks by regex/language rule, recording a `HunkDropReason` (source-analysis §3.1):
+
+| Rule (config-gated) | Drop reason | Default gate |
+|---------------------|-------------|--------------|
+| Whitespace-only hunk | `WHITESPACE_ONLY` | `diff_filter.ignore_whitespace` = true |
+| Import-only hunk (language-specific) | `IMPORT_ONLY` | `diff_filter.ignore_imports` = true |
+| Comment-only hunk | `COMMENT_ONLY` | `diff_filter.ignore_comments` = true |
+
+**REV-204** — Stage B SHALL be purely deterministic (no LLM). Disabling a gate (doc 06) SHALL keep the corresponding hunk class.
+
+### 2.3 Stage C — HunkClassifier (LLM, per-hunk substantive scoring)
+
+**REV-205** — Stage C SHALL batch surviving hunks (`BATCH_SIZE` = 10 per call) and call the **summarizer-role** provider (doc 04 — model selectable independently of reviewer/verifier) at **temperature 0.0**, requesting a JSON array of `{hunk_id, classification, confidence, reason}`. (source-analysis §3.1, §3.2)
+
+**REV-206 — Classification taxonomy.** (source-analysis §3.2)
+
+| Classification | Meaning | Droppable |
+|----------------|---------|-----------|
+| `substantive` | Logic, schema, API, security, control-flow change. | No |
+| `mechanical` | Formatting, whitespace, import reorder, generated, getters/setters. | Yes, **only if** `confidence > DROP_CONFIDENCE_THRESHOLD` (0.7). |
+| `uncertain` | Cannot determine without more context. | No (kept). |
+
+**REV-207 — Credential force-preserve.** A hunk containing a credential URL SHALL be force-preserved even if classified `mechanical` with high confidence. (source-analysis §3.1)
+
+**REV-208 — Fail-safe on classifier error.** ANY LLM error during a batch SHALL cause ALL hunks in that batch to be treated as `uncertain` (kept). The summarizer never drops a hunk because the classifier failed. (source-analysis §3.1)
+  > **Rationale:** mirrors the pipeline's fail-toward-APPROVE posture — when uncertain, show the reviewer more, not less.
+
+---
+
+## 3. Output / rendering
+
+**REV-209** — Output type is `FilteredDiff`. Its `render_for_prompt(max_chars)` SHALL emit the kept files/hunks bounded to `max_chars` (default 12000), and SHALL **NOT** emit a manifest header in the rendered prompt text.
+  > **Rationale (source-analysis §3.1, forecasting#120):** a manifest header in the rendered diff caused a framing-effect regression. The manifest is telemetry-only.
+
+**REV-210 — Manifest telemetry.** A separate `build_manifest_telemetry()`-equivalent SHALL produce the drop/keep manifest for logging/metrics only — never injected into the LLM prompt. (source-analysis §3.1)
+
+---
+
+## 4. Data models
+
+Re-specifies `diff_analyzer/models.py` (source-analysis §3.3). Full field tables live in [doc 07 §3](07-data-models.md); summarized here for self-containment.
+
+| Type | Key fields |
+|------|------------|
+| `FilteredDiff` | `files: Vec<FilteredFile>`, `dropped_files: Vec<DroppedFile>`, `drop_hunk_counts: Map<String,u32>`, `original_byte_size`, `filtered_byte_size`, `phase2_telemetry` |
+| `FilteredFile` | `filename`, `status` (added/modified/renamed/removed), `disposition: FileDisposition`, `hunks: Vec<FilteredHunk>`, `dropped_hunks: Vec<DroppedHunk>`, `summary_line: Option<String>` |
+| `FilteredHunk` | `header` (`@@` line), `lines: Vec<String>`, `substantive_confidence: f32`, `reason_kept: String` |
+| `DroppedHunk` | `reason: HunkDropReason`, `lines_count`, `header` |
+| `DroppedFile` | `path`, `reason` |
+| `FileDisposition` (enum) | `KEPT` / `DROPPED` / `SUMMARY_ONLY` |
+| `HunkDropReason` (enum) | `WHITESPACE_ONLY` / `IMPORT_ONLY` / `COMMENT_ONLY` / `MECHANICAL_HAIKU` |
+
+---
+
+## 5. Noisy-file collapse (pipeline-side, separate from Stages A–C)
+
+**REV-211** — Independently of the A/B/C pipeline, the review pipeline's diff-fetch stage (doc 02 REV-102) SHALL collapse large fixture/i18n diffs to a 1-line summary using `NOISY_FILE_PATTERNS` when a file's diff exceeds `NOISY_DIFF_MIN_LINES` (30). Patterns (source-analysis §3.4): `.tsv`, `.csv`, `nls/**/*.{properties,json}`, `messages/**`, `labels/**`, `fixtures/**/*.{json,xml,sql}`, `test*fixtures*/**`, `__generated__/**`, `generated/**/*.{java,ts,js}`.
+
+This is belt-and-suspenders with Stage A (which also summary-collapses fixtures) and protects the raw-diff fallback path when the summarizer is unavailable.
+
+---
+
+## 6. Standalone usage
+
+**REV-260** — The `diff` module SHALL be usable without the review pipeline. Inputs: a unified diff string (+ optional file-status list) + a `DiffFilterConfig`. Output: a `FilteredDiff`. This enables:
+- The CLI `run --local-diff <file>` flow (doc 08 REV-720) to filter a local diff with no GitHub/trusty-search dependency.
+- Unit testing of Stages A/B in isolation with no LLM (Stage C mocked or skipped via a `classify: false` flag).
+
+**REV-261** — Stage C SHALL accept an injected `summarizer` provider (`Box<dyn LlmProvider>` / role handle, doc 04). When no provider is supplied, the summarizer SHALL run Stages A and B only and mark all surviving hunks `uncertain` (kept) — a fully deterministic, LLM-free mode.
+
+**REV-262** — The summarizer SHALL NOT read configuration from global state; all knobs (`fixture_summary_min_lines`, `ignore_*`, `preserve_patterns`, `suppress_patterns`, `DROP_CONFIDENCE_THRESHOLD`, `BATCH_SIZE`) are passed in via a `DiffFilterConfig` value (source-analysis §11.2 "no global state").

--- a/docs/trusty-review/spec/04-llm-providers.md
+++ b/docs/trusty-review/spec/04-llm-providers.md
@@ -1,0 +1,142 @@
+# 04 — LLM Providers
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [02-pipeline](02-pr-review-pipeline.md) · [03-diff-summarizer](03-diff-summarizer.md) · [06-configuration](06-configuration.md) · [09-deployment](09-deployment-operations.md) · [10-lessons](10-lessons-and-rationale.md)
+**Factual basis:** source-analysis §6.3 (Bedrock adapter), §11.4 (trusty-common chat client), §12.1 (inactive verifier), §12.2 (inference profile prefix), §13 (delta).
+**Workspace grounding:** `crates/trusty-common/src/chat.rs` already defines a `ChatProvider` trait + `OpenRouterProvider` + `OllamaProvider` (verified).
+
+This document specifies the pluggable LLM provider abstraction. **Binding decision #2:** co-equal Bedrock + OpenRouter behind one trait; models selectable **per run AND per role**.
+
+---
+
+## 1. Provider abstraction
+
+**REV-300 — Single trait, two co-equal backends.** trusty-review SHALL define one `LlmProvider` trait with at least two concrete implementations — `BedrockProvider` and `OpenRouterProvider` — neither privileged. The provider in use is selected at **runtime** (env/config), not compile-time. (binding decision #2; source-analysis §11.4, §13)
+
+**REV-301 — Reuse trusty-common.** The OpenRouter implementation SHALL reuse / wrap the existing `trusty_common::chat::OpenRouterProvider` (OpenAI-compatible `/v1/chat/completions`, `OPENROUTER_API_KEY`, default model `anthropic/claude-haiku-4.5`) rather than re-implementing the OpenRouter wire protocol. The Bedrock provider is net-new. (source-analysis §11.4)
+
+**REV-302 — Trait shape (non-code sketch).** The trait SHALL expose a non-streaming, awaitable completion call sufficient for review/verify/summarize, returning text plus token usage. (The existing `trusty_common::chat::ChatProvider` is *streaming*; trusty-review MAY wrap it to accumulate a full response, or define its own `LlmProvider` that the OpenRouter impl satisfies by draining the stream.)
+
+```text
+trait LlmProvider (Send + Sync):
+    async fn complete(req: LlmRequest) -> Result<LlmResponse, LlmError>
+    fn name() -> &str            // "bedrock" | "openrouter"
+
+LlmRequest:
+    model: String               // resolved model ID for this call
+    system: String
+    messages: Vec<ChatMessage>
+    temperature: f32
+    max_tokens: u32
+
+LlmResponse:
+    text: String
+    input_tokens: u32
+    output_tokens: u32
+    model: String               // echo of model actually used
+
+LlmError (thiserror):
+    ModelNotFound       // model/profile does not exist or is not ACTIVE  → ALARM
+    ModelNotReady       // provisioning/lifecycle not ready                → ALARM
+    Validation(String)  // malformed request (e.g. missing us. prefix)     → ALARM
+    AccessDenied        // auth/permission                                  → ALARM
+    Transport(String)   // DNS/connect/timeout — transient
+    RateLimited
+    Upstream { status, body }
+```
+
+**REV-303 — No global provider state.** Providers are constructed from config values and passed into the pipeline / summarizer as handles (`Box<dyn LlmProvider>` or `Arc<dyn LlmProvider>`); no `lazy_static!`/global singletons. (source-analysis §11.2)
+
+---
+
+## 2. Per-run AND per-role model selection
+
+**REV-310 — Three roles.** The pipeline uses three LLM call-types, each independently model-selectable (binding decision #2):
+
+| Role | Used by | Tier (today's baseline) | Temperature |
+|------|---------|-------------------------|-------------|
+| **reviewer** | Pipeline Stage 10 (doc 02 REV-111) | Sonnet-tier (`us.anthropic.claude-sonnet-4-6`) | 0.3 |
+| **verifier** | Verification round (doc 02 REV-136) | Haiku-tier (ACTIVE) (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) | 1.0 (single-word) |
+| **summarizer** | Diff Stage C (doc 03 REV-205) | Haiku-tier | 0.0 |
+
+**REV-311 — RoleModels config object.** A `RoleModels` value SHALL resolve, for each role: (provider backend, model ID, temperature, max_tokens). Each role MAY use a *different provider* (e.g. reviewer on Bedrock, summarizer on OpenRouter). (binding decision #2)
+
+**REV-312 — Per-run override.** Every role's provider+model SHALL be overridable per run via CLI flags (doc 08: `--reviewer-model`, `--verifier-model`, `--summarizer-model`, `--provider`) and, for `eval`, by a list of reviewer models to compare. Run-level overrides take precedence over config-file and env defaults. (source-analysis §1.1 eval/compare; binding decision #2)
+
+**REV-313 — Resolution precedence.** For each role: CLI flag → per-role env var → role default in config file → built-in default. (doc 06 REV-540)
+
+```mermaid
+flowchart LR
+    subgraph RoleModels
+      RV[reviewer →\nprovider+model+temp]
+      VF[verifier →\nprovider+model+temp]
+      SM[summarizer →\nprovider+model+temp]
+    end
+    RV --> PB1{provider}
+    VF --> PB2{provider}
+    SM --> PB3{provider}
+    PB1 --> BED[BedrockProvider]
+    PB1 --> ORP[OpenRouterProvider]
+    PB2 --> BED
+    PB2 --> ORP
+    PB3 --> BED
+    PB3 --> ORP
+```
+
+---
+
+## 3. Model IDs & Bedrock inference profiles
+
+**REV-320 — Bedrock inference-profile prefix.** The `BedrockProvider` SHALL require model IDs that carry the cross-region inference-profile prefix `us.` (e.g. `us.anthropic.claude-sonnet-4-6`). On a config value lacking the prefix it SHALL either (a) reject at config-validation time with a clear error, or (b) be configured with an explicit `require_us_prefix = true` guard — implementer's choice, but the failure MUST be surfaced at startup, not at first review.
+  > **Rationale (lesson learned §12.2):** bare model IDs (`anthropic.claude-3-5-sonnet-...`) fail Bedrock cross-region invocation with `ValidationException`/`ResourceNotFoundException`.
+
+**REV-321 — Bedrock Converse API.** `BedrockProvider` SHALL use the Bedrock Converse API (`converse` / `converse_stream`) which normalizes request/response across model families. Region from `AWS_REGION` (doc 06). boto3-equivalent adaptive retry: `max_attempts = 3`, read timeout 120s. (source-analysis §6.3)
+
+**REV-322 — OpenRouter model slugs.** `OpenRouterProvider` SHALL use OpenRouter model slugs (e.g. `anthropic/claude-haiku-4.5`, `anthropic/claude-sonnet-4.5`). OpenRouter does NOT need the `us.` prefix; the prefix rule (REV-320) is Bedrock-only. (source-analysis §12.2, §13)
+
+**REV-323 — Model-ID config table.** Config SHALL accept, per role, a `{ provider, model }` pair so an operator can write e.g. `reviewer = { provider = "bedrock", model = "us.anthropic.claude-sonnet-4-6" }` or `reviewer = { provider = "openrouter", model = "anthropic/claude-sonnet-4.5" }`. (doc 06 §model-selection)
+
+---
+
+## 4. Token & cost tracking
+
+**REV-330 — Usage capture.** Each `complete()` SHALL return `input_tokens` / `output_tokens`. The pipeline SHALL record final reviewer-call tokens on the result (`input_tokens`, `output_tokens`) plus a `cost_estimate_usd` (doc 07 REV-600). (source-analysis §5.1, §6.3)
+
+**REV-331 — Multi-pass / per-role accounting.** When multiple LLM calls occur (summarizer batches, verifier per-finding, optional multi-pass), the implementation SHOULD aggregate per-role token totals for observability (analogous to Python `pass1_tokens`/`pass2_tokens`). (source-analysis §5.1)
+
+**REV-332 — Metrics emission.** Token counts SHALL be emitted as metrics tagged by review type and role (Python emitted `LLMInputTokens`/`LLMOutputTokens` tagged `ReviewType=PRReview` to CloudWatch). Backend is deployment-specific (doc 09). (source-analysis §6.3)
+
+---
+
+## 5. Retry / timeout
+
+**REV-333 — Timeouts.** Default per-call read timeout 120s (both providers). Connect timeout 10s (matches `trusty_common::chat` OpenRouter constants). (source-analysis §6.3, §11.4)
+
+**REV-334 — Retries.** Transient errors (`Transport`, `RateLimited`, `Upstream 5xx`) SHALL be retried with bounded backoff (≤ 3 attempts). **Config/lifecycle errors (`ModelNotFound`, `ModelNotReady`, `Validation`, `AccessDenied`) SHALL NOT be retried** — they are deterministic and must alarm immediately. (source-analysis §12.1)
+
+---
+
+## 6. Active-model requirement & `verification_model_error` alarm
+
+**REV-340 — Active-model requirement (BINDING).** The verifier model SHALL be a foundation-lifecycle-`ACTIVE` model. The provider SHALL classify model-config errors distinctly from transient failures (the `LlmError` variants in REV-302). When a *verification* call fails with a config/lifecycle error, the pipeline SHALL:
+1. Emit a `verification_model_error` event at **ERROR** level with the model ID, provider, and error class.
+2. Trigger the operational alarm (doc 09 REV-810).
+3. Treat the finding as REFUTED for that call (fail toward APPROVE) — but the alarm guarantees the degradation is **observable**, never silent.
+
+  > **Rationale (lesson learned §12.1):** the single most damaging production failure was a LEGACY verifier model ID that silently auto-refuted every finding, turning every review into APPROVE. This requirement makes that failure loud.
+
+**REV-341 — Startup model probe (RECOMMENDED).** On server start and at the top of a CLI run, the binary SHOULD perform a cheap liveness/identity check of each configured role's provider+model (e.g. a tiny `complete()` or a provider list-models call) and refuse to start / warn loudly if a configured model is not ACTIVE/available. This converts §12.1 from a runtime surprise into a startup failure. (source-analysis §12.1; doc 09 REV-811)
+
+---
+
+## 7. Provider matrix (summary)
+
+| Concern | BedrockProvider | OpenRouterProvider |
+|---------|-----------------|--------------------|
+| Auth | AWS creds / IAM role; `AWS_REGION` | `OPENROUTER_API_KEY` |
+| Wire | Bedrock Converse API | OpenAI `/v1/chat/completions` (via `trusty_common::chat`) |
+| Model ID form | `us.`-prefixed inference profile (REV-320) | OpenRouter slug (REV-322) |
+| Reuse | net-new module | wraps `trusty_common::chat::OpenRouterProvider` |
+| Primary deployment | production Duetto | local / standalone |
+| Privilege | **co-equal** | **co-equal** |

--- a/docs/trusty-review/spec/05-integrations.md
+++ b/docs/trusty-review/spec/05-integrations.md
@@ -1,0 +1,153 @@
+# 05 — Integrations
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [01-architecture](01-architecture.md) · [02-pipeline](02-pr-review-pipeline.md) · [06-configuration](06-configuration.md) · [08-interfaces](08-interfaces.md) · [10-lessons](10-lessons-and-rationale.md)
+**Factual basis:** source-analysis §4 (GitHub), §6 (adapters), §7 (JIRA/APEX), §9 (Slack), §11.5 (HTTP APIs consumed), §12 (lessons).
+**Workspace grounding:** `crates/trusty-analyze/src/core/github.rs` already implements `fetch_pr_diff`, `post_pr_comment`, `verify_webhook_signature`, typed `GithubError` (verified) — reuse where possible.
+
+---
+
+## 1. GitHub integration
+
+### 1.1 Authentication
+
+**REV-400 — GitHub App preferred, PAT fallback.** trusty-review SHALL prefer GitHub App authentication and fall back to a PAT. (source-analysis §4.1)
+
+| Input | Purpose |
+|-------|---------|
+| `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID` | App identity |
+| `GITHUB_APP_PRIVATE_KEY` (RSA PEM, `\n`-escaped) | Signs the App JWT |
+| `GITHUB_INSTALLATION_ID_DUETTORESEARCH` | duettoresearch org installation |
+| `GITHUB_INSTALLATION_ID_HOTSTATS` | hotstats org installation |
+| `GITHUB_TOKEN` | PAT fallback |
+
+**REV-401 — App JWT in Rust.** The crate SHALL mint the GitHub App JWT in Rust (`jsonwebtoken` is already a workspace dependency) and exchange it for a short-lived installation token. (source-analysis §13 "GitHub auth")
+
+**REV-402 — Multi-org token selection.** A `resolve_token(owner)` SHALL select the installation token by case-insensitive `owner` match (duettoresearch vs hotstats), falling back to PAT when App auth is not configured. (source-analysis §4.1)
+
+### 1.2 Push firewall (BINDING)
+
+**REV-403 — Read + comment only; hard-coded push firewall.** A `GH_ALLOW_PUSH = false` constant SHALL be hard-coded and NOT configurable by env or per-repo config. Any attempt to invoke a git-write operation (branch create, file commit, PR create, force-push) SHALL panic/error via an `assert_no_push_operation()` guard.
+  > **Rationale (lesson learned §12.11):** the bot was caught force-pushing to an infra repo. The firewall is intentionally non-configurable. (binding non-goal NG1)
+
+### 1.3 Permitted GitHub operations
+
+**REV-404** — The bot is restricted to (source-analysis §4.2):
+- POST PR review comment.
+- GET PR diff, file list, metadata.
+- GET/POST/PATCH issues (tracker + calibration).
+- GET/POST labels; POST issue type (REST numeric `TASK_ISSUE_TYPE_NUMERIC_ID = 203410`).
+- POST GraphQL for GitHub Project v2 add.
+- GET `.github/code-intelligence.yml`.
+- GET existing PR reviews (Copilot/bot detection).
+
+### 1.4 Tracker-issue-per-PR semantics
+
+**REV-405 — One tracker issue per PR (upsert).** A single GitHub issue per PR SHALL be created on first review and **updated in place** on every re-review. (source-analysis §4.3, §12.7)
+
+| Property | Value |
+|----------|-------|
+| Labels | `["code-review", "code-intelligence"]` |
+| Issue type | "Task" (GraphQL node `IT_kwDOABbzg84AAxqS`) |
+| Project discovery label | `code-intelligence` (for Project #16 filter) |
+| Title pattern | `[PR Review] {owner}/{repo}#{pr_number} — {VERDICT}` |
+| Suppression prefix length | first 60 chars after the marker (`SUPPRESS_PATTERN_PREFIX_LEN`) |
+
+**REV-406 — Upsert algorithm.** Search existing `code-review`-labeled issues for a matching title prefix; if found, PATCH body + title; else create. (source-analysis §4.3)
+  > **Rationale (lesson learned §12.7):** without upsert, each re-push created a new tracker issue (8+ duplicates per active PR).
+
+**REV-407 — Calibration issues (dry-run).** In dry-run, file a calibration issue with label `code-intelligence-review`, added to a `PR Review Calibration` GitHub Project (created if missing); body includes trigger, grade, PR link, full review text. (source-analysis §4.3)
+
+**REV-408 — Fix-suggestion issues.** When live and a finding is issue-eligible (confidence ≥ `issue_threshold`, effort ∈ `("low","medium")`, cap `FIX_ISSUE_MAX_PER_PR` = 5), the finding contributes to the tracker issue body. v0.1 SHALL NOT open separate auto-fix PRs (NG5; firewall REV-403). (source-analysis §2.3, §4.3)
+
+### 1.5 Dismissal / suppression control flow (developer-facing)
+
+**REV-409 — Tracker control semantics.** Re-specify the developer controls (CLAUDE.md "Handling Incorrect Bot Findings"):
+- Close the tracker issue → bot does not re-open or re-file for the same PR.
+- Close + `bot-suppress` label → extract a pattern from the issue title and suppress similar findings in all future PRs for that repo.
+- `wontfix` label → same effect as closing for that PR.
+
+---
+
+## 2. Suppression integration (GitHub side)
+
+**REV-405S → see REV-115/REV-530.** Two suppression sources, merged at review time, both **fail-open** (source-analysis §4.4, §8.2, §12.9):
+1. `fetch_suppressed_patterns()` — repo issues with `bot-suppress` label + closed state → extract pattern from title.
+2. `fetch_repo_suppress_config()` — `suppress` list from `.github/code-intelligence.yml`.
+
+Matching: case-insensitive substring OR Jaccard word overlap ≥ 0.70 (`SUPPRESS_OVERLAP_THRESHOLD`). (doc 06 REV-530)
+
+---
+
+## 3. JIRA / ticket context
+
+**REV-410 — Ticket-ID extraction.** Extract ticket IDs matching `\b([A-Z][A-Z0-9]+-\d+)\b` from PR title + description. (source-analysis §7.1)
+
+**REV-411 — Fallback chain.** (source-analysis §7.1)
+1. If `ATLASSIAN_EMAIL` + `ATLASSIAN_API_TOKEN` + `ATLASSIAN_URL` configured AND ticket IDs found → `GET /rest/api/3/issue/{id}` per ticket (up to `MAX_KNOWLEDGE_RESULTS` = 3).
+2. If REST returns nothing → per-ticket keyword vector search against the knowledge index.
+3. If no credentials → vector search fallback.
+4. Final fallback → semantic search on PR title + description.
+
+**REV-412 — Fail-open.** Any JIRA error → empty ticket context; never blocks the review. (source-analysis §12.9)
+
+---
+
+## 4. APEX-as-repo (BINDING decision #3)
+
+**REV-420 — APEX is a repo, not a separate index.** trusty-review SHALL treat APEX product specs as a repository **indexed alongside code in trusty-search** and query it through the **same** index query used for code context — NOT via a bespoke separate adapter instance.
+  > **Rationale (source-analysis §7.2, §13):** today APEX is a separate `apex_search` VectorSearchAdapter. The NEW design folds APEX into the primary index so a single search returns apex spec chunks alongside code chunks.
+
+**REV-421 — Implementation options (spec both; recommend).**
+- **(A, RECOMMENDED)** Single primary index containing code + APEX repo; one `POST /indexes/{index}/search` returns both. trusty-review filters/labels APEX chunks by path prefix for citation.
+- **(B, fallback)** A configurable secondary index URL/name (`TRUSTY_SEARCH_APEX_INDEX`) queried with the same cross-query, for deployments that keep APEX in its own index. The pipeline merges results.
+
+**REV-422 — Citation format.** APEX hits SHALL be cited in the review as ``[apex: `path/to/spec.md:15` — "brief excerpt"]``, capped at `MAX_APEX_RESULTS` = 2. (source-analysis §7.2)
+
+---
+
+## 5. trusty-search client (`:7878`) — REQUIRED dependency
+
+**REV-430 — Client contract.** A `SearchClient` (HTTP default, doc 01 REV-009) over `TRUSTY_SEARCH_URL` (default `http://localhost:7878`), index from `TRUSTY_SEARCH_INDEX` (default `main`). (source-analysis §6.1, §11.5)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/health` | GET | Liveness; `embedder` status, `search_reachable` |
+| `/indexes` | GET | List registered indexes |
+| `/indexes/{id}/status` | GET | Chunk count + root path |
+| `/indexes/{id}/search` | POST | Hybrid BM25 + vector search |
+
+**REV-431 — REQUIRED dependency.** If trusty-search is unreachable, the review SHALL be **skipped** (not approved) and a Slack service-failure notice sent (REV-450). (source-analysis §9, §12.10; doc 01 REV-011)
+
+---
+
+## 6. trusty-analyze client (`:7879`) — OPTIONAL dependency
+
+**REV-440 — Client contract.** An `AnalyzeClient` over `PR_INTELLIGENCE_ANALYZER_URL` (default `http://localhost:7879`), index from `TRUSTY_SEARCH_INDEX`. (source-analysis §6.2, §11.5)
+
+| Method | Endpoint | Timeout | Notes |
+|--------|----------|---------|-------|
+| `health()` | `GET /health` | 5s | liveness + `search_reachable` |
+| `is_available()` | `GET /health` | 5s | cache 60s TTL |
+| `has_analysis()` | `GET /health` **+** `GET /indexes` | 5s each | **cheap two-step readiness probe** |
+| `complexity_hotspots()` | `GET /indexes/{id}/complexity_hotspots` | 180s | hotspot list |
+| `smells()` | `GET /indexes/{id}/smells` | 180s | smell list |
+| `quality()` | `GET /indexes/{id}/quality` | 180s | O(corpus) — **NEVER a readiness probe** |
+
+**REV-441 — Two-step readiness probe (BINDING).** `has_analysis()` SHALL use ONLY `GET /health` (O(1)) + `GET /indexes` (O(n_indexes)). It SHALL NEVER call `/quality`.
+  > **Rationale (lesson learned §12.3):** probing the O(corpus) `/quality` endpoint with a 5s timeout always timed out (it streams ~396k chunks, 11–103s), making the sidecar look perpetually unavailable. The `/health` response carries a `search_reachable` boolean — check it explicitly.
+
+**REV-442 — Graceful degradation.** All `AnalyzeClient` methods SHALL catch connect/timeout/HTTP errors and return an empty default. trusty-analyze failure SHALL NOT raise the service-unavailable path; the review proceeds with empty static-analysis context. (source-analysis §6.2, §12.10; doc 01 REV-012)
+
+---
+
+## 7. Slack notifications
+
+**REV-450 — Two notification types** (source-analysis §9):
+- `notify_pr_review_complete()` — single-line mrkdwn: dry-run/live label, linked `owner/repo#PR`, verdict, findings count, optional calibration/tracker issue link. **Never raises** (a Slack outage cannot break a review).
+- `notify_pr_review_service_failure()` — Block Kit warning when a **required** service (trusty-search or LLM) is unavailable; includes service name, PR URL, truncated error (≤500 chars).
+
+**REV-451 — Dispatch precedence.** Prefer `SLACK_NOTIFICATION_CHANNEL` + `SLACK_BOT_TOKEN` (`chat.postMessage`); fall back to `SLACK_NOTIFICATION_WEBHOOK`. (source-analysis §9)
+
+**REV-452 — Failure trigger.** The service-failure notice fires on the "required service unavailable" condition (trusty-search / LLM), mirroring the Python `PRReviewServiceUnavailable` path; trusty-analyze unavailability does NOT trigger it (REV-442). (source-analysis §9, §12.10)

--- a/docs/trusty-review/spec/06-configuration.md
+++ b/docs/trusty-review/spec/06-configuration.md
@@ -1,0 +1,179 @@
+# 06 — Configuration
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [02-pipeline](02-pr-review-pipeline.md) · [04-llm-providers](04-llm-providers.md) · [05-integrations](05-integrations.md) · [10-lessons](10-lessons-and-rationale.md)
+**Factual basis:** source-analysis §8 (per-repo config), §10 (env vars), §11.2 (no global state), §12 (lessons).
+
+Two configuration layers: (1) **global** service config (config file + env), and (2) **per-repo** `.github/code-intelligence.yml` fetched from each reviewed repo.
+
+---
+
+## 1. Global configuration model
+
+**REV-500 — Config sources & precedence.** trusty-review SHALL resolve config from, in increasing precedence: built-in defaults → config file (TOML; `toml` is a workspace dep) → environment variables → CLI flags. The resolved `ReviewConfig` is an owned value passed into the pipeline (no global state). (source-analysis §11.2)
+
+**REV-501 — Config file location.** A `--config <path>` flag and a default path (e.g. `$XDG_CONFIG_HOME/trusty-review/config.toml`, resolved via the `dirs` crate). Absence of a config file is not an error; env + defaults suffice. (consistency with workspace daemons)
+
+### 1.1 Env-var mapping (today → trusty-review)
+
+The Rust service SHALL read the same env-var names as the Python service so existing deployments need no relabeling. (source-analysis §10)
+
+#### PR Intelligence settings (source-analysis §10.1)
+
+| Env Var | Default | Effect |
+|---------|---------|--------|
+| `PR_INTELLIGENCE_DRY_RUN` | `true` | `true` = log only; `false` = post to GitHub. **Default ON.** |
+| `PR_INTELLIGENCE_ENABLED_REPOS` | `*` | Comma-sep allow-list; `*` = all; `org/*` = org wildcard |
+| `PR_INTELLIGENCE_EXCLUDED_REPOS` | `""` | Comma-sep deny-list; **always overrides** allow-list |
+| `PR_INTELLIGENCE_EXCLUDED_AUTHORS` | `""` | Bot logins to skip (e.g. `duetto-snyk-svc`) |
+| `PR_REVIEW_BOT_USERNAME` | `""` | App login; triggers manual/live when requested as reviewer |
+| `PR_INTELLIGENCE_LOG_DIR` | `/data/app/data/pr-reviews` | Review-log + dedup-store directory |
+| `PR_INTELLIGENCE_ANALYZER_URL` | `http://localhost:7879` | trusty-analyze sidecar URL |
+| `PR_INTELLIGENCE_EVAL_MODEL` | (varies) | Secondary model for `eval`/`compare` (dry-run only) |
+| `PR_INTELLIGENCE_MIN_FINDINGS_TO_POST` | `1` | Global min-findings gate (per-repo overrideable) |
+| `PR_INTELLIGENCE_SUPPRESS_ADVISORY_REVIEWS` | `false` | Global `suppress_advisory` |
+| `PR_INTELLIGENCE_FILE_ISSUES_ON_MERGE_ONLY` | `false` | Global `file_issues_on_merge_only` |
+
+#### GitHub App settings (source-analysis §10.2)
+
+| Env Var | Effect |
+|---------|--------|
+| `GITHUB_APP_ID` | Numeric app ID |
+| `GITHUB_APP_CLIENT_ID` | App OAuth client ID |
+| `GITHUB_APP_PRIVATE_KEY` | RSA PEM (newlines `\n`) |
+| `GITHUB_INSTALLATION_ID_DUETTORESEARCH` | duettoresearch installation |
+| `GITHUB_INSTALLATION_ID_HOTSTATS` | hotstats installation |
+| `GITHUB_WEBHOOK_SECRET` | HMAC secret for `X-Hub-Signature-256` |
+| `GITHUB_TOKEN` | PAT fallback |
+
+#### LLM, search, JIRA, Slack (source-analysis §10.3; doc 04)
+
+| Env Var | Default | Effect |
+|---------|---------|--------|
+| `TRUSTY_REVIEW_PROVIDER` | `bedrock` | Default provider when a role does not specify one (`bedrock`\|`openrouter`) |
+| `TRUSTY_REVIEW_REVIEWER_MODEL` | `us.anthropic.claude-sonnet-4-6` | reviewer-role model |
+| `TRUSTY_REVIEW_VERIFIER_MODEL` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | verifier-role model (must be ACTIVE) |
+| `TRUSTY_REVIEW_SUMMARIZER_MODEL` | (= verifier default) | diff Stage-C model |
+| `BEDROCK_MODEL_ID` | `us.anthropic.claude-sonnet-4-6` | Back-compat alias for reviewer model when on Bedrock |
+| `OPENROUTER_API_KEY` | `""` | OpenRouter auth (doc 04) |
+| `AWS_REGION` | `us-west-2` | Bedrock region |
+| `TRUSTY_SEARCH_URL` | `http://localhost:7878` | trusty-search endpoint (REQUIRED dep) |
+| `TRUSTY_SEARCH_INDEX` | `main` | Index name (search + analyze) |
+| `TRUSTY_SEARCH_APEX_INDEX` | `""` | Optional secondary APEX index (doc 05 REV-421 option B) |
+| `ATLASSIAN_URL` / `ATLASSIAN_EMAIL` / `ATLASSIAN_API_TOKEN` | `""` | JIRA/Confluence |
+| `SLACK_NOTIFICATION_CHANNEL` / `SLACK_BOT_TOKEN` | `""` | Preferred Slack dispatch |
+| `SLACK_NOTIFICATION_WEBHOOK` | `""` | Slack fallback |
+
+**REV-502 — Pipeline tuning constants** (`MAX_DIFF_CHARS`, `MAX_CONTEXT_FILES`, `MAX_ENRICHMENT_ROUNDS`, `FIX_ISSUE_MAX_PER_PR`, confidence thresholds, `DEDUP_STALE_SECS`, etc.) SHALL have the source-analysis defaults (doc 02 §3.4) and MAY be overridable via config file but NOT required as env vars.
+
+---
+
+## 2. Per-repo config: `.github/code-intelligence.yml`
+
+Fetched from the reviewed repo's default branch (doc 02 REV-103). **Fails open** to defaults on any fetch/parse error. (source-analysis §8.1)
+
+### 2.1 Full schema
+
+**REV-510** — (source-analysis §8.1)
+
+| Key | Type | Default | Behavior |
+|-----|------|---------|----------|
+| `skip` | bool | `false` | Disable all reviews for this repo |
+| `issue_threshold` | float | `0.75` | Min confidence to file tracker issue |
+| `block_threshold` | float | `0.90` | Min confidence for BLOCK tier |
+| `pr_threshold` | float | `0.95` | Min confidence for high-confidence flag |
+| `suppress` | list[str] | `[]` | Substring/word-overlap suppression patterns |
+| `min_findings` | int | `1` | Min eligible findings to post |
+| `suppress_advisory` | bool | `false` | Skip posting APPROVE/APPROVE\* with no required-change findings |
+| `file_issues_on_merge_only` | bool | `false` | Defer tracker issue creation until merge |
+| `diff_filter.suppress_patterns` | list[str] | `[]` | Extra file patterns to drop from diff (Stage A) |
+| `diff_filter.preserve_patterns` | list[str] | `[]` | Force-keep patterns (override built-in drops) |
+| `diff_filter.ignore_whitespace` | bool | `true` | Drop whitespace-only hunks (Stage B) |
+| `diff_filter.ignore_imports` | bool | `true` | Drop import-only hunks (Stage B) |
+| `diff_filter.ignore_comments` | bool | `true` | Drop comment-only hunks (Stage B) |
+| `diff_filter.fixture_summary_min_lines` | int | `30` | Fixture summarization threshold (Stage A) |
+
+### 2.2 Validation
+
+**REV-511** — `issue_threshold`, `block_threshold`, `pr_threshold` MUST be in `[0.0, 1.0]`, and `pr_threshold >= issue_threshold`. On violation, **all three** revert to defaults. Unknown keys are ignored. Parse/fetch errors → full default config (**fail-open**). (source-analysis §8.1)
+  > **Rationale (lesson learned §12.9):** suppression and config lookups must never block a review.
+
+### 2.3 Annotated example
+
+```yaml
+# .github/code-intelligence.yml  (in the REVIEWED repo, not trusty-review)
+skip: false
+issue_threshold: 0.80      # stricter than the 0.75 default
+block_threshold: 0.92
+pr_threshold: 0.95         # must be >= issue_threshold
+min_findings: 1
+suppress_advisory: true    # don't post APPROVE/APPROVE* with no required changes
+suppress:
+  - "missing docstring"    # substring or >=70% word overlap → dropped
+  - "consider adding a test"
+diff_filter:
+  ignore_whitespace: true
+  ignore_imports: true
+  ignore_comments: true
+  fixture_summary_min_lines: 30
+  preserve_patterns:
+    - "src/security/**"     # always shown in full, even if it looks generated
+  suppress_patterns:
+    - "**/*.snap"           # never show snapshot files in the diff
+```
+
+---
+
+## 3. Suppression matching
+
+**REV-530 — Matching algorithm.** `is_finding_suppressed(finding_desc, patterns)` (source-analysis §8.2, §4.4):
+- Case-insensitive.
+- Match if EITHER: (a) pattern is a substring of `finding_desc`, OR (b) `texts_similar(finding_desc, pattern)` — normalized word sets, Jaccard overlap ≥ `SUPPRESS_OVERLAP_THRESHOLD` (0.70).
+- (Note: source-analysis also references a separate `FINDING_SIMILARITY_THRESHOLD` = 0.6 used by a related helper; the suppression path uses 0.70. The implementer SHALL keep both constants distinct and documented.)
+
+**REV-531 — Merged pattern sources.** The active pattern list = `bot-suppress`-labeled-closed-issue patterns (doc 05 REV-409) ∪ repo `suppress` list. (source-analysis §4.4)
+
+**REV-532 — Fail-open.** Any error retrieving labels or repo config → treat as no suppression rules. (source-analysis §12.9)
+
+---
+
+## 4. Dry-run, enabled/excluded repos & authors
+
+**REV-540 — Dry-run default ON.** `PR_INTELLIGENCE_DRY_RUN` defaults `true`. Flip to live only by setting it `false` OR by the per-run `--live` flag (doc 08). The webhook handler further gates dispatch to `review_requested` events regardless of dry-run (doc 08 REV-700).
+  > **Rationale (lesson learned §12.8):** dry-run rollout discipline prevents posting un-validated reviews.
+
+**REV-541 — Effective dry-run formula.** `effective_dry_run = (config.dry_run OR force_dry_run) AND NOT force_live`, where `force_live` / `force_dry_run` are determined by the trigger classification (doc 08 REV-701). (source-analysis §1.2)
+
+**REV-542 — Repo gating.** Enabled = match `PR_INTELLIGENCE_ENABLED_REPOS` (`*`, `org/*`, or exact). Excluded = match `PR_INTELLIGENCE_EXCLUDED_REPOS` (always wins). Author exclusion = login in `PR_INTELLIGENCE_EXCLUDED_AUTHORS` → silently skip before dispatch. (source-analysis §1.2, §10.1)
+
+---
+
+## 5. Model-selection config (per-run + per-role)
+
+**REV-550 — RoleModels in config.** The config file SHALL accept a `[models]` table mapping each role to `{ provider, model, temperature?, max_tokens? }`. (doc 04 REV-311/REV-323)
+
+```toml
+[provider]
+default = "bedrock"          # used when a role omits `provider`
+
+[models.reviewer]
+provider = "bedrock"
+model = "us.anthropic.claude-sonnet-4-6"   # us. prefix required for Bedrock
+temperature = 0.3
+
+[models.verifier]
+provider = "bedrock"
+model = "us.anthropic.claude-haiku-4-5-20251001-v1:0"   # MUST be foundation-lifecycle ACTIVE
+temperature = 1.0
+
+[models.summarizer]
+provider = "openrouter"      # roles may mix providers
+model = "anthropic/claude-haiku-4.5"        # OpenRouter slug — no us. prefix
+temperature = 0.0
+```
+
+**REV-551 — Per-run override.** CLI flags `--provider`, `--reviewer-model`, `--verifier-model`, `--summarizer-model` (doc 08) override the `[models]` table for that run. `eval` accepts a list of reviewer models to compare. (doc 04 REV-312)
+
+**REV-552 — Bedrock prefix validation at config time.** When a role's provider is `bedrock`, the model SHALL be validated for the `us.` prefix at config-resolution time (doc 04 REV-320), failing loudly before any review runs.
+  > **Rationale (lesson learned §12.2):** surface inference-profile errors at startup, not mid-review.

--- a/docs/trusty-review/spec/07-data-models.md
+++ b/docs/trusty-review/spec/07-data-models.md
@@ -1,0 +1,128 @@
+# 07 — Data Models & Persistence
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [02-pipeline](02-pr-review-pipeline.md) · [03-diff-summarizer](03-diff-summarizer.md) · [05-integrations](05-integrations.md) · [08-interfaces](08-interfaces.md)
+**Factual basis:** source-analysis §5 (PRReviewResult, FixSuggestion, dedup), §3.3 (diff models), §13 (storage delta).
+
+All models SHALL be `serde`-(de)serializable so the JSON log schema (§5) is the canonical wire shape. Enums use lowercase string serialization unless noted.
+
+---
+
+## 1. ReviewResult
+
+**REV-600 — ReviewResult fields.** Direct port of the Python `PRReviewResult` field set (source-analysis §5.1). Field names SHALL be preserved on the JSON wire so existing log tooling keeps working.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `owner`, `repo` | String | GitHub org/repo |
+| `pr_number` | u64 | |
+| `pr_title`, `pr_url` | String | |
+| `review_body` | String | Full LLM markdown output |
+| `analysis` | Object | `grade`, `display_grade`, `display_grade_is_fallback`, `hotspots_in_pr`, `smells_in_pr`, `copilot_mode`, `bot_review_count` |
+| `context_files` | Vec\<String\> | Filenames from vector-search context |
+| `input_tokens`, `output_tokens` | u32 | Final reviewer call only |
+| `cost_estimate_usd` | f64 | |
+| `dry_run`, `posted` | bool | |
+| `timestamp` | String | ISO-8601 |
+| `error` | Option\<String\> | Non-None on pipeline error |
+| `fix_suggestions` | Vec\<FixSuggestion\> | §2 |
+| `filed_issue_numbers` | Vec\<u64\> | GitHub issues filed |
+| `review_mode` | String | `full` \| `no_context` |
+| `head_sha` | String | dedup key; empty on pre-field records |
+| `tracker_issue_number` | Option\<u64\> | |
+| `tracker_issue_url` | Option\<String\> | |
+| `diff` | Option\<String\> | Stored diff for eval replay |
+| `apex_context` | Vec\<Object\> | slim metadata (bodies stripped) |
+| `jira_context` | Vec\<Object\> | slim |
+| `confluence_context` | Vec\<Object\> | slim |
+| `github_issues_context` | Vec\<Object\> | slim |
+| `cross_ref_context` | Vec\<Object\> | slim (blast-radius hits) |
+| `copilot_mode` | String | `full` \| `supplement` \| `duetto_only` |
+| `bot_review_count` | u32 | |
+| `multipass` | bool | |
+| `pass1_tokens`, `pass2_tokens` | u32 | multi-pass cost breakdown |
+| `trigger` | String | `manual` \| `auto` |
+| `grade` | String | top-level mirror of `analysis.grade` |
+| `enrichment_rounds` | u32 | |
+| `enrichment_queries` | Vec\<String\> | |
+| `skip_reason` | Option\<String\> | short token on pipeline skip |
+| `review_version` | String | pipeline version (e.g. `tr-0.1`; doc 02 REV-118) |
+
+**REV-601 — Context slimming.** The `*_context` vectors SHALL store **slim** metadata (paths, line refs, short excerpts) with full bodies stripped, mirroring Python `_slim_context()`. This bounds log size. (source-analysis §5.1)
+
+---
+
+## 2. FixSuggestion
+
+**REV-602 — FixSuggestion fields.** (source-analysis §5.2)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `file` | String | Changed file path |
+| `line` | Option\<u32\> | Optional line number |
+| `kind` | String | Finding type |
+| `description` | String | Human-readable finding |
+| `suggestion` | String | Proposed fix |
+| `confidence` | f32 | 0.0–1.0 |
+| `effort` | String (enum) | `low` \| `medium` \| `high` |
+
+**REV-603 — Issue eligibility derived fields (transient).** During the pipeline, each finding carries transient flags not necessarily persisted: `verified` (CONFIRMED/REFUTED/skipped), `issue_eligible` (confidence ≥ `issue_threshold` AND effort ∈ `("low","medium")`). These drive Stage 13–15 (doc 02). (source-analysis §2.2, §2.3)
+
+---
+
+## 3. Verdict & confidence enums
+
+**REV-604 — Verdict enum.** `Verdict ∈ { Approve, ApproveStar, RequestChanges, Block, NotApplicable }` serialized as `APPROVE` / `APPROVE*` / `REQUEST_CHANGES` / `BLOCK` / `N/A`. (source-analysis §2.1; doc 02 §2.1)
+
+**REV-605 — Effort enum.** `Effort ∈ { Low, Medium, High }`. Only `Low`/`Medium` are issue-eligible (`FIX_ISSUE_ALLOWED_EFFORTS`). (source-analysis §2.3)
+
+**REV-606 — Verification outcome enum.** `VerifyOutcome ∈ { Confirmed, Refuted, ErrorRefuted, TruncationRefuted, Skipped }` for telemetry. `ErrorRefuted` carries the `LlmError` class so config/lifecycle failures are distinguishable in logs (doc 04 REV-340). (source-analysis §2.2, §12.1)
+
+**REV-607 — Confidence is `f32` in `[0.0, 1.0]`.** Constructors SHALL clamp out-of-range values rather than error (defensive against malformed LLM JSON).
+
+---
+
+## 4. Diff-summarizer models
+
+**REV-608** — As specified in [doc 03 §4](03-diff-summarizer.md) (source-analysis §3.3): `FilteredDiff`, `FilteredFile`, `FilteredHunk`, `DroppedHunk`, `DroppedFile`, `FileDisposition` (`KEPT`/`DROPPED`/`SUMMARY_ONLY`), `HunkDropReason` (`WHITESPACE_ONLY`/`IMPORT_ONLY`/`COMMENT_ONLY`/`MECHANICAL_HAIKU`). These live in `src/diff/models.rs`.
+
+---
+
+## 5. Dry-run JSON log schema
+
+**REV-610 — On-disk layout.** `{PR_INTELLIGENCE_LOG_DIR}/{owner}/{repo}/{pr_number}/review.{json,md}` (source-analysis §5.3):
+- `review.json` — serialized `ReviewResult` (§1). This IS the canonical schema.
+- `review.md` — the human-readable `review_body` plus a header (verdict, grade, links).
+
+**REV-611 — Schema stability.** The JSON SHALL be additively versioned via `review_version`. New fields are added with serde defaults; existing field names are not renamed (back-compat with Python logs where feasible). (source-analysis §5.1)
+
+---
+
+## 6. Persistence: dedup store & review log
+
+### 6.1 Persistence choice — RECOMMENDATION
+
+**REV-620 — Use redb for the cross-process dedup claim.** The Python service used SQLite (`dedup.db`); trusty-review SHALL use **redb** for the dedup claim store.
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| **redb (RECOMMENDED)** | Already the workspace standard (`redb` is a workspace dep; trusty-analyze/trusty-search use it; `trusty-analyze.facts.redb` exists). Pure-Rust, embedded, ACID, no external process. Aligns deps. | Need an atomic insert-or-fail pattern over a key table. | **CHOSEN** |
+| SQLite (`rusqlite`) | Direct parity with Python; familiar `INSERT OR FAIL`. | Adds a non-standard dep (sqlite native lib) the workspace otherwise avoids. | Rejected for dep hygiene. |
+
+  > **Rationale (source-analysis §13 storage delta):** the delta table explicitly leaves dedup storage "redb … or SQLite; TBD in spec." We choose redb to match the workspace and avoid a native SQLite dependency.
+
+**REV-621 — Dedup claim semantics.** A redb table keyed on `(owner, repo, pr_number, head_sha)` SHALL implement an atomic **claim** (write within a transaction that fails if the key exists and is not stale) and a **release** (delete on completion). Stale claims older than `DEDUP_STALE_SECS` (7200) SHALL be purged on each claim attempt. Release SHALL run in a guard (`Drop` or explicit `finally`-equivalent) to prevent leaked claims. (source-analysis §5.3, §12.4; doc 02 REV-101c)
+
+### 6.2 Review log backend
+
+**REV-622 — Filesystem JSON/MD by default.** The review log SHALL default to the filesystem layout (REV-610), matching today's schema. The store module SHALL expose a `ReviewLog` trait so an alternative backend (e.g. redb or object storage) can be plugged later without pipeline changes. (source-analysis §5.3, §13)
+
+---
+
+## 7. Calibration tracker (upsert-per-PR)
+
+**REV-630 — Calibration record.** In dry-run, a calibration record SHALL be upserted **per PR** (not per push): keyed by `(owner, repo, pr_number)`, updated in place on re-review. It mirrors the tracker-issue upsert discipline. (source-analysis §4.3, §12.7)
+  > **Rationale (lesson learned §12.7):** per-push records accumulated duplicate calibration issues; upsert-per-PR fixes it.
+
+**REV-631 — Calibration fields.** `owner`, `repo`, `pr_number`, `trigger`, `grade`/`verdict`, `pr_url`, `review_excerpt`, `head_sha`, `timestamp`, `calibration_issue_number`. Persisted alongside (or within) the review log. (source-analysis §4.3)

--- a/docs/trusty-review/spec/08-interfaces.md
+++ b/docs/trusty-review/spec/08-interfaces.md
@@ -1,0 +1,118 @@
+# 08 — Interfaces (HTTP API + CLI)
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [01-architecture](01-architecture.md) · [02-pipeline](02-pr-review-pipeline.md) · [04-llm-providers](04-llm-providers.md) · [09-deployment](09-deployment-operations.md)
+**Factual basis:** source-analysis §1.1–1.2 (entry points, webhook filtering), §11.3 (axum router pattern), §12.4/§12.8 (dedup, dry-run).
+**Workspace grounding:** `crates/trusty-analyze/src/service/mod.rs` `build_router(state) -> Router` (axum 0.8); `core/github.rs::verify_webhook_signature` — reuse.
+
+Two surfaces, one binary (doc 01 REV-010): a **webhook server** (`serve`) and a **CLI** (one-shot). Both drive the identical pipeline (doc 02).
+
+---
+
+## 1. HTTP API (server mode)
+
+**REV-700 — axum router.** Under the `http-server` feature, `service::build_router(state) -> Router` SHALL expose the routes below, following the trusty-analyze pattern (source-analysis §11.3). The binary resolves config, builds state, and binds with `axum::serve()`.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/health` | GET | Liveness; reports version, dry-run flag, dependency reachability (trusty-search REQUIRED, trusty-analyze OPTIONAL), configured role models. |
+| `/status` | GET | Richer status: in-flight review count, recent verdict distribution, last `verification_model_error` (if any). |
+| `/pr/github/webhook` | POST | GitHub PR webhook; HMAC-validated; event-filtered. |
+
+> The HTTP surface is intentionally minimal (NG3): trusty-review is a webhook consumer, not a general API. Search/chat/ontology endpoints are out of scope (those belong to the host app / trusty-search).
+
+### 1.1 Webhook contract
+
+**REV-701 — HMAC validation.** The webhook SHALL validate `X-Hub-Signature-256` against `GITHUB_WEBHOOK_SECRET` using a constant-time comparison (reuse `trusty_analyze::core::github::verify_webhook_signature` semantics). Invalid signature → 401, no dispatch. (source-analysis §1.2, §4.x; workspace grounding)
+
+**REV-702 — Event filtering: only `review_requested` dispatches.** (source-analysis §1.2, §12.4, §12.8)
+
+| `pull_request` action | Behavior |
+|-----------------------|----------|
+| `review_requested` | Classify trigger (REV-703) → dispatch pipeline. |
+| `opened`, `synchronize`, `reopened` | 200 OK, **no dispatch**. |
+| `closed` | 200 OK, short-circuit, no dispatch. |
+| (other event types) | 200 OK, ignored. |
+
+  > **Rationale (lesson learned §12.4, §12.8):** dispatching on every event caused duplicate reviews; restricting to `review_requested` is both a dedup layer and the dry-run rollout gate.
+
+**REV-703 — Trigger classification** (from request context, not env; source-analysis §1.2):
+
+| Condition | trigger | dry-run override |
+|-----------|---------|------------------|
+| `requested_reviewer.login == PR_REVIEW_BOT_USERNAME` | `manual` | `force_live = true` (posts live regardless of `PR_INTELLIGENCE_DRY_RUN`) |
+| `requested_reviewer.login` ∈ `live_review_requesters` | `manual` | `force_live = true` |
+| any other `review_requested` | `auto` | `force_dry_run = true` (files calibration issue) |
+
+`effective_dry_run = (config.dry_run OR force_dry_run) AND NOT force_live` (doc 06 REV-541).
+
+**REV-704 — Author exclusion.** PRs from logins in `PR_INTELLIGENCE_EXCLUDED_AUTHORS` SHALL be skipped before dispatch. (source-analysis §1.2)
+
+**REV-705 — Async dispatch + ack.** The handler SHALL acknowledge the webhook quickly (200) and run the pipeline as a spawned task (`tokio::spawn`), matching the Python `asyncio.create_task` model. The in-process pre-SHA dedup guard (doc 02 REV-101a) SHALL be claimed before spawning. (source-analysis §1.2, §12.4)
+
+**REV-706 — Health response shape (sketch).**
+
+```json
+{
+  "status": "ok",
+  "version": "tr-0.1",
+  "dry_run": true,
+  "deps": {
+    "trusty_search": { "required": true, "reachable": true },
+    "trusty_analyze": { "required": false, "reachable": false },
+    "llm": { "provider": "bedrock", "reviewer_model_ok": true, "verifier_model_ok": true }
+  }
+}
+```
+
+`/health` SHALL return 200 when all REQUIRED deps are reachable; degraded (200 with a warning flag, or 503 — implementer's choice but documented) when a required dep is down. The verifier-model check ties to doc 04 REV-341.
+
+---
+
+## 2. CLI surface (local / one-shot mode)
+
+**REV-710 — clap dispatch.** The binary SHALL use `clap` (workspace dep, derive + env) with these subcommands. All review subcommands honor `PR_INTELLIGENCE_DRY_RUN` unless `--live` is passed; `--local-diff` is always dry. (source-analysis §1.1)
+
+| Subcommand | Purpose | Key flags |
+|------------|---------|-----------|
+| `serve` | Start the webhook daemon. | `--port`, `--config` |
+| `run <owner> <repo> <pr>` | One-shot review of a live PR (honors dry-run). | `--no-context`, `--live`, `--multipass`, role-model flags |
+| `run --local-diff <path>` | Review a local unified-diff file; no GitHub fetch, no posting (always dry). | role-model flags, `--repo-config <path>` |
+| `list` | List logged reviews. | `--owner`, `--repo` |
+| `stats` | Aggregate stats (verdict distribution, token totals, dedup skips). | `--since` |
+| `show <owner> <repo> <pr>` | Show one logged review. | |
+| `compare <owner> <repo> <pr>` | Full vs `--no-context` side-by-side (dry-run). | role-model flags |
+| `eval <owner> <repo> <pr>` | Multi-model eval; `skip_dedup = true`. | `--models <slug,slug,...>` |
+
+**REV-711 — `--no-context`.** Runs the pipeline with code/JIRA/APEX/analysis context retrieval disabled (LLM-only review). Sets `review_mode = "no_context"` on the result. (source-analysis §1.1, §5.1)
+
+**REV-712 — `--multipass`.** Enables the optional two-pass pipeline; records `multipass`, `pass1_tokens`, `pass2_tokens` (doc 07). (source-analysis §1.1, §5.1)
+
+**REV-713 — `eval` semantics.** `eval` SHALL set `skip_dedup = true` (so the same head SHA can be re-reviewed across models) and run the reviewer role once per model in `--models`, producing a comparison report. It is **dry-run only** — never posts. (source-analysis §1.1)
+
+**REV-714 — `compare` semantics.** Runs the pipeline twice — full context and `--no-context` — and emits a side-by-side diff of verdicts/findings. Dry-run only. (source-analysis §1.1)
+
+**REV-715 — Per-run model flags.** `--provider`, `--reviewer-model`, `--verifier-model`, `--summarizer-model` override config for that run (doc 04 REV-312, doc 06 REV-551). For Bedrock providers, the `us.` prefix is validated before the run starts (doc 04 REV-320).
+
+**REV-720 — `--local-diff` independence.** `run --local-diff` SHALL function with NO GitHub credentials and NO live PR: it reads a diff file, runs the diff summarizer (doc 03 REV-260) + reviewer + verifier, and prints the review + writes a local JSON log. It MAY still query trusty-search for context if `TRUSTY_SEARCH_URL` is reachable; otherwise it degrades to `--no-context` behavior. This satisfies the "review a local diff" requirement in binding decision #4.
+
+**REV-721 — Push firewall applies to all CLI paths.** No CLI flag can enable any write to a reviewed repo beyond posting a review comment / tracker issue in `--live` mode (doc 05 REV-403).
+
+**REV-722 — Output.** CLI review commands print the review body + verdict to stdout and write the JSON/MD log (doc 07 REV-610). All diagnostic logging goes to **stderr** (source-analysis §11.2), keeping stdout clean for piping.
+
+---
+
+## 3. Interface ↔ pipeline mapping
+
+```mermaid
+flowchart LR
+    WH["/pr/github/webhook"] -->|review_requested only| DISPATCH
+    CLIRUN["run owner repo pr"] --> DISPATCH
+    CLILOCAL["run --local-diff"] --> DISPATCH
+    CLICMP["compare"] --> DISPATCH
+    CLIEVAL["eval (skip_dedup)"] --> DISPATCH
+    DISPATCH[ReviewPipeline doc 02] --> OUT{effective_dry_run?}
+    OUT -->|dry| LOGS[log + calibration + Slack]
+    OUT -->|live| POST[PR comment + tracker issue + Slack]
+```

--- a/docs/trusty-review/spec/09-deployment-operations.md
+++ b/docs/trusty-review/spec/09-deployment-operations.md
@@ -1,0 +1,110 @@
+# 09 — Deployment & Operations
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** [01-architecture](01-architecture.md) · [04-llm-providers](04-llm-providers.md) · [05-integrations](05-integrations.md) · [08-interfaces](08-interfaces.md) · [10-lessons](10-lessons-and-rationale.md)
+**Factual basis:** source-analysis §6 (adapters/probes), §9 (Slack), §12 (lessons); CLAUDE.md systemd/deploy patterns; workspace `trusty_common::launchd` (used by trusty-analyze `commands/service.rs`).
+
+---
+
+## 1. Two run modes (one binary)
+
+**REV-800 — Mode parity.** The same `trusty-review` binary SHALL run as a one-shot CLI or a long-lived server, selected by subcommand (`run`/`compare`/`eval`/`list`/`stats` vs `serve`). (binding decision #4; doc 01 REV-010, doc 08)
+
+| | Local / one-shot | Server / webhook |
+|---|------------------|------------------|
+| Entry | `trusty-review run …` | `trusty-review serve --port P` |
+| Lifecycle | exits after one review | long-lived daemon |
+| Trigger | CLI args | GitHub `review_requested` webhook |
+| Dedup | in-process; `eval` sets skip_dedup | all 3 layers incl. redb cross-process |
+| Posting | dry unless `--live`; `--local-diff` always dry | `effective_dry_run` (doc 06 REV-541) |
+| Deps | trusty-search optional-degrade for `--local-diff`; required otherwise | trusty-search required; analyze optional |
+
+---
+
+## 2. Service installation (server mode)
+
+**REV-801 — systemd unit (Linux production).** A systemd unit SHALL run `trusty-review serve`, modeled on the trusty-search unit in CLAUDE.md (Restart=on-failure, env file for secrets). Sketch:
+
+```ini
+[Unit]
+Description=trusty-review PR Review Daemon
+After=network.target trusty-search.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ec2-user
+EnvironmentFile=/data/app/.env.trusty-review
+ExecStart=/usr/local/bin/trusty-review serve --port 7880
+Restart=on-failure
+RestartSec=5
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**REV-802 — launchd (macOS dev).** On macOS the crate MAY reuse `trusty_common::launchd::LaunchdConfig` (as trusty-analyze's `commands/service.rs` does) to install/bootstrap a dev agent. (workspace grounding)
+
+**REV-803 — Port.** Default server port SHOULD be distinct from the sibling daemons (`:7878` search, `:7879` analyze) — e.g. `:7880`. Configurable via `--port`. (consistency with workspace)
+
+**REV-804 — Secrets.** GitHub App private key, webhook secret, OpenRouter key, AWS creds SHALL come from the environment/EnvironmentFile (never config-file plaintext in the repo). (source-analysis §10; workspace security posture)
+
+---
+
+## 3. Startup / readiness checks
+
+**REV-805 — Dependency startup checks.** On `serve` start (and at the top of a CLI run), the binary SHALL probe (source-analysis §12.3, §12.10; doc 05):
+1. **trusty-search** (`GET /health`) — REQUIRED. If unreachable at startup, log loudly; reviews will skip + Slack-notify until it returns (do not crash-loop the daemon).
+2. **trusty-analyze** via the **two-step cheap probe** (`/health` + `/indexes`) — OPTIONAL; record reachability for `/health` output. NEVER probe `/quality`.
+3. **LLM provider/model identity** per role — see REV-811.
+
+  > **Rationale (lesson learned §12.3):** never use the O(corpus) `/quality` endpoint as a readiness probe.
+
+**REV-811 — Verifier model startup probe (RECOMMENDED).** At startup, perform a cheap identity/liveness check of each configured role's model (doc 04 REV-341). If the **verifier** model is not ACTIVE/available, the daemon SHALL refuse to start in live mode (or start with a prominent `verification_model_error` alarm if dry-run), converting §12.1 into a startup failure rather than a silent all-approve.
+  > **Rationale (lesson learned §12.1):** the worst production incident was a silently-inactive verifier model.
+
+---
+
+## 4. Observability & metrics
+
+**REV-810 — Required alarms / events.** The service SHALL emit, at minimum (source-analysis §6.3, §12.1):
+
+| Event / metric | Level / type | Trigger |
+|----------------|--------------|---------|
+| `verification_model_error` | ERROR + **alarm** | verifier LLM call fails with a config/lifecycle error class (doc 04 REV-340). **Must page/alert** — distinguishes model misconfig from transient. |
+| `pr_review_service_unavailable` | ERROR + Slack | required dep (trusty-search / LLM) down (doc 05 REV-452). |
+| `dedup_skip` | counter | a review skipped due to in-flight/claim/head-SHA dedup (doc 02 REV-101/REV-105). |
+| `verdict_distribution` | counter by verdict | every completed review, tagged `APPROVE`/`APPROVE*`/`REQUEST_CHANGES`/`BLOCK`/`N/A`. |
+| `LLMInputTokens` / `LLMOutputTokens` | gauge/counter | per LLM call, tagged `ReviewType=PRReview`, role (doc 04 REV-332). |
+| `analyze_degraded` | counter | trusty-analyze unavailable → static analysis skipped (doc 05 REV-442). |
+
+**REV-812 — Metric backend.** Backend is deployment-specific (CloudWatch in production per source-analysis §6.3; stderr-structured logs locally). The crate SHALL emit through a thin metrics abstraction so the backend is swappable. Logs to **stderr** only (source-analysis §11.2).
+
+**REV-813 — Verdict-distribution monitoring (calibration).** Operators SHALL monitor `verdict_distribution`. A sudden spike to ~100% APPROVE is the *symptom* of the §12.1 failure mode; pairing this dashboard with the `verification_model_error` alarm gives two independent signals of the same regression.
+
+---
+
+## 5. Dry-run rollout discipline
+
+**REV-820 — Dry-run default + staged rollout.** (source-analysis §12.8; doc 06 REV-540)
+1. Deploy with `PR_INTELLIGENCE_DRY_RUN=true` (default). Pipeline runs fully; posts nothing; files calibration issues; logs locally.
+2. Validate review quality against the calibration log / verdict distribution.
+3. Opt-in repos via `PR_INTELLIGENCE_ENABLED_REPOS` while still dry, then flip `PR_INTELLIGENCE_DRY_RUN=false` per readiness.
+4. The `review_requested`-only webhook gate (doc 08 REV-702) holds throughout, independent of dry-run.
+
+  > **Rationale (lesson learned §12.8):** prevents premature live posting before quality is validated.
+
+---
+
+## 6. Operational runbook (sketch)
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| Every PR is APPROVE; `verification_model_error` firing | inactive verifier model (§12.1) | Fix `TRUSTY_REVIEW_VERIFIER_MODEL` to an ACTIVE model; restart. |
+| Reviews skipped + Slack "service unavailable" | trusty-search down or LLM auth/region wrong | Check `:7878 /health`; check AWS creds/region or `OPENROUTER_API_KEY`. |
+| `analysis.available: false` but analyze is up | regression to O(corpus) probe (§12.3) | Verify `has_analysis()` uses `/health`+`/indexes`, not `/quality`. |
+| Duplicate tracker/calibration issues | upsert broken (§12.7) | Verify tracker upsert searches by `code-review` label + title prefix. |
+| Bedrock `ValidationException` on every call | missing `us.` prefix (§12.2) | Add the inference-profile prefix; config-time validation (doc 06 REV-552). |
+| Duplicate concurrent reviews | dedup layer missing (§12.4) | Verify in-process + redb claim + `review_requested`-only gate. |

--- a/docs/trusty-review/spec/10-lessons-and-rationale.md
+++ b/docs/trusty-review/spec/10-lessons-and-rationale.md
@@ -1,0 +1,160 @@
+# 10 — Lessons & Rationale (Binding Requirements Ledger)
+
+**Status:** DRAFT
+**Part of:** [trusty-review spec](README.md)
+**Cross-refs:** every other spec doc.
+**Factual basis:** source-analysis §12 (13 hard-won lessons), §13 (NEW-vs-today delta).
+
+This document distills the 13 hard-won lessons from the Python production system into binding, testable requirements, each as **symptom → fix → requirement**. It is the cross-cutting requirements ledger that the other docs trace back to. The NEW-vs-today delta table closes the document.
+
+---
+
+## 1. Lessons → binding requirements
+
+### L1 — Inactive verifier model → silent all-approve (source-analysis §12.1)
+
+- **Symptom:** Every blocking finding auto-refuted; every PR effectively APPROVE regardless of content.
+- **Root cause:** `_VERIFICATION_MODEL_ID` hardcoded to a `LEGACY`-lifecycle Haiku ID; every verification call threw `ResourceNotFoundException`; the handler set `confirmed = false` → REFUTED for all → downgrade to APPROVE.
+- **Fix (today):** Source the verifier model from the ACTIVE-lifecycle constant; classify the error at ERROR level as `pr_review_verification_model_error`.
+- **Binding requirement:** **REV-340** (provider classifies config/lifecycle errors distinctly + emits `verification_model_error` + alarms), **REV-341 / REV-811** (startup model probe; refuse to start live if verifier inactive), **REV-810** (alarm), **REV-813** (verdict-distribution monitoring as a second signal), **REV-334** (do not retry config/lifecycle errors).
+
+### L2 — Bedrock inference-profile prefix (source-analysis §12.2)
+
+- **Symptom:** Bedrock calls fail with `ValidationException`/`ResourceNotFoundException` on bare model IDs.
+- **Root cause:** Cross-region inference profiles require the `us.` prefix.
+- **Fix (today):** All production model IDs use `us.`.
+- **Binding requirement:** **REV-320** (Bedrock provider requires/validates `us.` prefix), **REV-552** (config-time validation, fail loudly at startup), **REV-322** (OpenRouter is exempt — uses slugs).
+
+### L3 — Analyzer readiness false `corpus_not_ready` (source-analysis §12.3)
+
+- **Symptom:** Every review logged trusty-analyze unavailable even when it was healthy.
+- **Root cause:** `has_analysis()` probed the O(corpus) `/quality` endpoint (11–103s) with a 5s timeout → always timed out.
+- **Fix (today):** Two cheap checks — `GET /health` + `GET /indexes`; never `/quality`.
+- **Binding requirement:** **REV-441 / REV-013 / REV-805.2** (two-step cheap probe; never probe O(corpus); check `search_reachable`).
+
+### L4 — Concurrent webhook delivery → duplicate reviews (source-analysis §12.4)
+
+- **Symptom:** Multiple webhook events per push ran the pipeline twice → duplicate calibration issues.
+- **Fix (today):** Three-layer dedup (webhook event filter + in-process guard + cross-process SQLite claim).
+- **Binding requirement:** **REV-702** (only `review_requested` dispatches), **REV-101** (three dedup layers), **REV-621** (redb atomic claim + stale purge + release guard), **REV-705** (claim pre-SHA guard before spawn).
+
+### L5 — Verifier candidate selection bug (sub-0.90 never verified) (source-analysis §12.5)
+
+- **Symptom:** Real defects at confidence 0.65–0.82 never reached the verifier; narrative said REQUEST_CHANGES but findings sat below the 0.90 verify gate → downgrade to APPROVE\*.
+- **Root cause:** Candidate selection used only `confidence ≥ block_threshold` (0.90) regardless of verdict.
+- **Fix (2026-05-30):** When verdict ∈ {REQUEST_CHANGES, BLOCK}, verify ALL findings with `confidence ≥ 0.50`, sorted desc, capped at 5.
+- **Binding requirement:** **REV-135** (verdict-conditioned candidate selection), **REV-134** (grade-divergence resolved by verification), **REV-142** (`VERIFY_CANDIDATE_MIN_CONFIDENCE = 0.50`).
+
+### L6 — Verifier truncation shortcut over-eagerness (source-analysis §12.6)
+
+- **Symptom:** Real findings at char 4001–16384 auto-refuted without an LLM call.
+- **Root cause:** The truncation shortcut checked a 4k-char verification slice, not the full diff.
+- **Fix (today):** `diff_for_verify` is the full `diff_text` (bounded to `MAX_DIFF_CHARS`); auto-refute only when BOTH file path AND line marker are absent from the FULL diff.
+- **Binding requirement:** **REV-138** (full-diff verification window), **REV-136** (truncation-shortcut precondition).
+
+### L7 — Calibration tracker upsert-per-PR (source-analysis §12.7)
+
+- **Symptom:** Each re-push created a new tracker issue (8+ duplicates per PR).
+- **Fix (today):** Search existing `code-review`-labeled issue by title prefix; update in place; create only if absent.
+- **Binding requirement:** **REV-405 / REV-406** (one tracker issue per PR, upsert), **REV-630** (calibration record upsert-per-PR).
+
+### L8 — Dry-run rollout discipline (source-analysis §12.8)
+
+- **Symptom (risk):** Premature switch to live before quality validated.
+- **Fix (today):** Dry-run default ON; pipeline runs fully but posts nothing; only `review_requested` dispatches.
+- **Binding requirement:** **REV-540** (dry-run default ON), **REV-820** (staged rollout), **REV-702** (event gate independent of dry-run), **REV-117** (dry vs live output paths).
+
+### L9 — Suppression fail-open (source-analysis §12.9)
+
+- **Symptom (design principle):** A GitHub API error during suppression must never block a review.
+- **Fix (today):** Every suppression/config lookup wraps errors and returns empty.
+- **Binding requirement:** **REV-115 / REV-405S / REV-511 / REV-532 / REV-014** (all suppression + config lookups fail-open).
+
+### L10 — Graceful degradation when trusty-analyze is down (source-analysis §12.10)
+
+- **Symptom (design):** Optional sidecar down should not block the review.
+- **Fix (today):** `has_analysis()` returns false → empty analysis; `PRReviewServiceUnavailable` raised only for trusty-search + LLM.
+- **Binding requirement:** **REV-011 / REV-012 / REV-442** (required vs optional dependency distinction; analyze degrades silently), **REV-452** (failure notice only for required deps).
+
+### L11 — Push firewall (source-analysis §12.11)
+
+- **Symptom:** Bot caught force-pushing to an infra repo.
+- **Fix (today):** `GH_ALLOW_PUSH = False` hard-coded; `_assert_no_push_operation()` raises on any write.
+- **Binding requirement:** **REV-403** (hard-coded, non-configurable push firewall), **REV-721** (applies to all CLI paths), **NG1** (read + comment only).
+
+### L12 — Noisy fixture/generated file diff (source-analysis §12.12)
+
+- **Symptom:** i18n/fixture churn buried real changes; bot burned context budget on noise (PR #9545).
+- **Fix (today):** `NOISY_FILE_PATTERNS` 1-line collapse + DiffAnalyzer Stage A/B/C drops.
+- **Binding requirement:** **REV-211** (noisy-file collapse), **REV-201–REV-208** (Stage A/B/C), **REV-102** (truncation + summarizer in diff fetch).
+
+### L13 — Cross-reference blast-radius gap (source-analysis §12.13)
+
+- **Symptom:** PR #9545 deleted a permission check; the orphaned producer lived in an untouched file; diff-only similarity missed it.
+- **Fix (today):** `_search_cross_references()` extracts enum constants / method calls from deleted lines, searches unchanged files, prioritizes producer keywords.
+- **Binding requirement:** **REV-108** (cross-reference blast-radius search in parallel context retrieval).
+
+---
+
+## 2. Lesson → requirement traceability matrix
+
+| Lesson | Primary requirements | Doc(s) |
+|--------|----------------------|--------|
+| L1 inactive verifier | REV-340, REV-341, REV-811, REV-810, REV-813, REV-334 | 04, 09 |
+| L2 Bedrock prefix | REV-320, REV-552, REV-322 | 04, 06 |
+| L3 analyzer probe | REV-441, REV-013, REV-805 | 01, 05, 09 |
+| L4 concurrent webhooks | REV-702, REV-101, REV-621, REV-705 | 02, 07, 08 |
+| L5 candidate selection | REV-135, REV-134, REV-142 | 02 |
+| L6 truncation window | REV-138, REV-136 | 02 |
+| L7 tracker upsert | REV-405, REV-406, REV-630 | 05, 07 |
+| L8 dry-run discipline | REV-540, REV-820, REV-702, REV-117 | 02, 06, 08, 09 |
+| L9 suppression fail-open | REV-115, REV-511, REV-532, REV-014 | 02, 06, 01 |
+| L10 graceful degradation | REV-011, REV-012, REV-442, REV-452 | 01, 05 |
+| L11 push firewall | REV-403, REV-721, NG1 | 05, 08, README |
+| L12 noisy diffs | REV-211, REV-201–208, REV-102 | 02, 03 |
+| L13 blast radius | REV-108 | 02 |
+
+---
+
+## 3. NEW vs Today — delta table
+
+Reproduced from source-analysis §13, annotated with the spec requirements that realize each delta.
+
+| Dimension | Today (Python) | NEW (trusty-review Rust) | Realized by |
+|-----------|----------------|--------------------------|-------------|
+| Language | Python 3.11+, FastAPI | Rust, axum 0.8 | REV-001..006, REV-700 |
+| LLM provider | AWS Bedrock only (Converse) | **Co-equal** Bedrock + OpenRouter behind a trait | REV-300, REV-301 |
+| Model selection | Fixed by env var | Selectable **per run AND per role** (reviewer/verifier/summarizer) | REV-310, REV-311, REV-312 |
+| JIRA context | ATLASSIAN_* REST + vector fallback | Same logic; configurable JIRA REST client | REV-410, REV-411 |
+| APEX context | Separate VectorSearchAdapter instance | **APEX as a repo** in trusty-search; same index query | REV-420, REV-421 |
+| Deployment | FastAPI app embedded in code-intelligence | **Standalone** Rust service; server OR CLI, one binary | REV-010, REV-800 |
+| Dedup storage | SQLite (`dedup.db`) | **redb** (workspace standard) | REV-620, REV-621 |
+| Log storage | Filesystem JSON/MD | Filesystem JSON/MD (same schema); pluggable `ReviewLog` trait | REV-610, REV-622 |
+| GitHub auth | PyGithub + httpx + GithubIntegration | reqwest/octocrab + App JWT in Rust (`jsonwebtoken`) | REV-400, REV-401 |
+| Suppression matching | Python regex + word overlap | Same algorithm in Rust | REV-530 |
+| Diff analyzer | Python + Haiku LLM | Rust deterministic Stages A/B + LLM Stage C via provider trait | REV-200..208 |
+| Webhook server | FastAPI route | axum route (trusty-analyze/search pattern) | REV-700, REV-701 |
+| Multi-org | INSTALLATION_ID_* per org | Same; config-driven | REV-402 |
+
+---
+
+## 4. Acceptance checklist (spec → implementation gate)
+
+An implementation is spec-conformant only when ALL of the following hold:
+
+- [ ] Verifier-model misconfig produces a `verification_model_error` alarm and (live) refuses to start — never a silent all-approve. (L1)
+- [ ] Bedrock model IDs validated for `us.` prefix at config time. (L2)
+- [ ] trusty-analyze readiness uses `/health`+`/indexes` only. (L3)
+- [ ] Three dedup layers present; redb claim atomic + released. (L4)
+- [ ] Verification candidate selection is verdict-conditioned (≥0.50 when REQUEST_CHANGES/BLOCK). (L5)
+- [ ] Verification uses the full diff window. (L6)
+- [ ] One tracker issue per PR, upserted. (L7)
+- [ ] Dry-run default ON; only `review_requested` dispatches. (L8)
+- [ ] All suppression/config lookups fail-open. (L9)
+- [ ] trusty-search + LLM required; trusty-analyze optional/degrades. (L10)
+- [ ] Push firewall hard-coded, non-configurable. (L11)
+- [ ] Noisy fixtures collapsed; Stage A/B/C diff filtering present. (L12)
+- [ ] Cross-reference blast-radius search present. (L13)
+- [ ] LLM provider trait with co-equal Bedrock + OpenRouter, per-run/per-role model selection. (binding decision #2)
+- [ ] APEX treated as a repo in the primary index. (binding decision #3)
+- [ ] Runs as both CLI one-shot and webhook server from one binary. (binding decision #4)

--- a/docs/trusty-review/spec/README.md
+++ b/docs/trusty-review/spec/README.md
@@ -1,0 +1,99 @@
+# trusty-review — Specification Index
+
+**Status:** DRAFT
+**Spec version:** 0.1 (2026-05-31)
+**Owner:** Bob Matsuoka
+**Factual basis:** [`research/source-analysis.md`](research/source-analysis.md) (the grounded analysis of the existing Python PR-review system). Every non-obvious requirement in these docs cites a section of that analysis.
+
+> ⚠️ **This is a specification only.** No implementation code (no `.rs` files, no Cargo crates) is produced or implied to exist by these documents. All requirement IDs (`REV-NNN`) are normative for a future implementation.
+
+---
+
+## One-paragraph overview
+
+**trusty-review** is a new Rust crate (or small family of crates) in the existing `trusty-tools` Cargo workspace that performs AI-assisted GitHub pull-request review. It is a ground-up Rust reimplementation — **not** a Python port — of the Python `PRReviewService` documented in the source analysis. It consumes the two sibling daemons already in the workspace, **trusty-search** (`:7878`, semantic code/context retrieval) and **trusty-analyze** (`:7879`, static-analysis sidecar), and drives an LLM through a single pluggable provider abstraction with **co-equal Bedrock and OpenRouter** backends whose models are selectable **per run and per role** (reviewer / verifier / diff-summarizer). It runs in two deployment modes from the same binary: a **local one-shot CLI** (review a live PR or a local diff) and a **long-lived webhook server** (axum, matching the trusty-search/trusty-analyze pattern). Its review philosophy is **fail-safe**: the default verdict is APPROVE and the bot carries the burden of proof, enforced by a per-finding LLM verification round.
+
+---
+
+## Goals
+
+| # | Goal |
+|---|------|
+| G1 | Reproduce the proven review *quality behaviors* of the Python service: fail-safe APPROVE default, per-finding verification round, deterministic diff filtering, cross-reference blast-radius search, suppression, dry-run discipline. (source-analysis §2, §3, §12) |
+| G2 | Be a first-class `trusty-tools` workspace citizen: lib + binary, axum behind `http-server` feature, `thiserror` errors, Why/What/Test doc comments, ≤500-line modules, no global state. (source-analysis §11.2) |
+| G3 | Treat the LLM as a runtime-pluggable resource: **co-equal** Bedrock + OpenRouter behind one trait, models chosen **per run and per role**. (binding decision #2; source-analysis §11.4, §12.1, §12.2) |
+| G4 | Run **locally (CLI / one-shot)** or **as a server (webhook)** from one binary. (binding decision #4) |
+| G5 | Consume trusty-search + trusty-analyze with correct readiness probes and graceful degradation; never use an O(corpus) endpoint as a probe. (source-analysis §6, §12.3, §12.10) |
+| G6 | Treat **APEX as a repo** (indexed alongside code in trusty-search), not as a bespoke separate index. (binding decision #3; source-analysis §7.2, §13) |
+| G7 | Encode all 13 hard-won lessons as binding, testable requirements with explicit alarms (esp. `verification_model_error`). (source-analysis §12) |
+
+## Non-goals
+
+| # | Non-goal |
+|---|----------|
+| NG1 | **No write access to reviewed repos.** No branch creation, file commits, or PR creation. Read + comment only, enforced by a hard-coded push firewall. (source-analysis §4.2, §12.11) |
+| NG2 | Not a code indexer or static analyzer. trusty-review *consumes* trusty-search/trusty-analyze; it does not embed, index, or parse trees itself. |
+| NG3 | Not a drop-in API clone of the Python FastAPI routes. The HTTP surface is re-specified for axum; only the webhook contract (HMAC, event filtering) is preserved verbatim. |
+| NG4 | Not responsible for building/owning the trusty-search index. APEX-as-repo indexing is an upstream (trusty-search) configuration concern; trusty-review only queries it. |
+| NG5 | No auto-fix PR generation in v0.1 (the Python `auto_fix_prs` config key is reserved but unimplemented; the push firewall forbids it regardless). |
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Verdict** | The merge recommendation: `APPROVE`, `APPROVE*`, `REQUEST_CHANGES`, or `BLOCK`. (source-analysis §2.1) |
+| **APPROVE\*** | "Approve with minor notes" — no required-change findings survive. Also the *effective* outcome when all blocking findings are refuted by verification. (source-analysis §2.2) |
+| **Finding / FixSuggestion** | A single discrete issue the reviewer raises, with file/line/confidence/effort. (source-analysis §5.2) |
+| **Verification round** | A per-finding second-opinion LLM pass (Haiku-tier) that must CONFIRM a blocking finding or it is dropped. (source-analysis §2.2) |
+| **Fail-safe / burden of proof** | Default is APPROVE; the bot must prove a problem, not the engineer prove its absence. (source-analysis §2.1) |
+| **Reviewer / Verifier / Summarizer roles** | The three LLM call-types, each independently model-selectable. (binding decision #2) |
+| **Dry-run** | Pipeline runs fully but posts nothing to GitHub; writes a log + calibration issue. Default ON. (source-analysis §10.1, §12.8) |
+| **Tracker issue** | One GitHub issue per PR, upserted on each re-review, carrying the verdict in its title. (source-analysis §4.3, §12.7) |
+| **Suppression** | Mechanism to silence findings by pattern (label-driven or repo-config). Fail-open. (source-analysis §4.4, §8.2, §12.9) |
+| **Blast radius / cross-reference** | Searching unchanged files that reference symbols a PR deleted/modified. (source-analysis §12.13) |
+| **APEX-as-repo** | APEX product specs indexed alongside code repos in trusty-search and queried via the same index, not a separate adapter. (source-analysis §7.2, §13) |
+| **trusty-search** | Sibling daemon, `:7878`, hybrid BM25+vector search. **Required** dependency. |
+| **trusty-analyze** | Sibling daemon, `:7879`, static analysis (hotspots, smells). **Optional** dependency (graceful degradation). |
+
+---
+
+## How the documents fit together
+
+```
+README.md  ......................  you are here (index, goals, glossary)
+01-architecture.md  .............  crate layout, dependency topology, local vs server
+02-pr-review-pipeline.md  .......  the ordered review stages + verdict/verification policy
+03-diff-summarizer.md  ..........  standalone diff analyzer (Stage A/B/C) spec
+04-llm-providers.md  ............  provider trait, Bedrock+OpenRouter, per-role models
+05-integrations.md  .............  GitHub / JIRA / APEX / trusty-search / trusty-analyze / Slack
+06-configuration.md  ............  global config + env + per-repo .github/code-intelligence.yml
+07-data-models.md  ..............  review result, fix-suggestion, enums, persistence choice
+08-interfaces.md  ...............  HTTP API (webhook) + CLI surface
+09-deployment-operations.md  ....  local vs server runtime, systemd, health, observability
+10-lessons-and-rationale.md  ....  13 lessons → binding requirements + NEW-vs-today delta
+```
+
+Reading order for an implementer: `01` → `04` → `02` → `03` → `05` → `06`/`07` → `08` → `09`, with `10` as the cross-cutting requirements ledger to satisfy throughout. Each document is independently navigable and cross-links to the others.
+
+---
+
+## Requirement ID scheme
+
+Requirements use the prefix `REV-` followed by a zero-padded number. The hundreds digit groups by document:
+
+| Range | Document |
+|-------|----------|
+| REV-0xx | Architecture (01) |
+| REV-1xx | Pipeline (02) |
+| REV-2xx | Diff summarizer (03) |
+| REV-3xx | LLM providers (04) |
+| REV-4xx | Integrations (05) |
+| REV-5xx | Configuration (06) |
+| REV-6xx | Data models (07) |
+| REV-7xx | Interfaces (08) |
+| REV-8xx | Deployment/operations (09) |
+| REV-9xx | Lessons/rationale (10) |
+
+"**Rationale (lesson learned)**" callouts trace a requirement back to a numbered lesson in source-analysis §12.

--- a/docs/trusty-review/spec/research/source-analysis.md
+++ b/docs/trusty-review/spec/research/source-analysis.md
@@ -1,0 +1,730 @@
+# trusty-review Source Analysis
+
+**Purpose**: Grounded analysis of the existing Python PR auto-review system for use by a spec author writing the trusty-review Rust crate specification.
+
+**Sources analyzed**:
+- `/Volumes/SSD1/Duetto/repos/code-intelligence/src/code_intelligence/services/pr_review_service.py` (6,990 lines, REVIEW_VERSION = "v1.4")
+- `diff_analyzer/` subpackage (analyzer.py, file_filter.py, hunk_classifier.py, hunk_filter.py, models.py)
+- `pr_review_github.py`, `pr_review_log.py`, `slack_notify.py`
+- `adapters/analyzer_adapter.py`, `adapters/vector_search.py`, `adapters/bedrock_llm.py`
+- `web/routes/pr_review.py`, `cli/pr_review.py`
+- `docs/repo-config.md`, repo root `CLAUDE.md`
+- `/Users/masa/Projects/trusty-tools/` — Cargo workspace (16 crates), `CLAUDE.md`, trusty-analyze and trusty-search crate layouts
+
+---
+
+## 1. End-to-End Review Pipeline
+
+### 1.1 Entry Points
+
+| Entry | Location | Key parameters |
+|---|---|---|
+| GitHub webhook | `web/routes/pr_review.py` `POST /pr/github/webhook` | HMAC-verified, fires `review_pr` as `asyncio.create_task` |
+| CLI manual run | `cli/pr_review.py` `pr-review run` | `--no-context` flag, `--multipass` flag |
+| CLI eval | `cli/pr_review.py` `pr-review eval` | `skip_dedup=True`, multi-model |
+| CLI compare | `cli/pr_review.py` `pr-review compare` | full vs no-context side-by-side |
+
+### 1.2 Webhook Event Filtering (`web/routes/pr_review.py`)
+
+Only `review_requested` triggers a review. All other `pull_request` actions (`opened`, `synchronize`, `reopened`) are accepted with 200 OK but **not dispatched**. `closed` is also short-circuited with no dispatch.
+
+**Trigger classification** (determined entirely from request context, not env vars):
+- `requested_reviewer.login == PR_REVIEW_BOT_USERNAME` → `trigger="manual"`, `force_live=True` (posts live regardless of `PR_INTELLIGENCE_DRY_RUN`)
+- `requested_reviewer.login` in `live_review_requesters` set → `trigger="manual"`, `force_live=True`
+- Any other `review_requested` → `trigger="auto"`, `force_dry_run=True` (forced dry-run, files calibration issue)
+
+`effective_dry_run = (settings.pr_intelligence.dry_run OR force_dry_run) AND NOT force_live`
+
+**Author exclusion**: PRs from logins in `PR_INTELLIGENCE_EXCLUDED_AUTHORS` are silently skipped before dispatch.
+
+HMAC verification uses `X-Hub-Signature-256` header, `hmac.compare_digest` for constant-time comparison.
+
+### 1.3 Pipeline Stage Sequence (`PRReviewService.review_pr` → `_review_pr_inner` → `_run_review_pipeline` → `_run_review_pipeline_inner`)
+
+```
+1. Eligibility check
+   ├── _is_repo_enabled(): checks PR_INTELLIGENCE_ENABLED_REPOS / EXCLUDED_REPOS
+   └── Returns early if not enabled
+
+2. Deduplication (two layers)
+   ├── _PR_IN_FLIGHT set: per-(owner,repo,pr_number) in-process guard (pre-SHA)
+   ├── _IN_FLIGHT set: per-(owner,repo,pr_number,head_sha) in-process guard
+   └── PRReviewLog.claim_review(): SQLite INSERT on composite PK (cross-process)
+
+3. Diff fetch (_fetch_pr_diff)
+   ├── PyGithub: PR metadata, file list, unified diff
+   ├── _summarize_noisy_diff_files(): collapse large fixture/i18n diffs to 1-line
+   └── _build_diff_text(): truncate to MAX_DIFF_CHARS (16,384 chars ≈ 4k tokens)
+       Uses DiffAnalyzer if available; falls back to raw diff
+
+4. Repo config fetch (_fetch_repo_config)
+   ├── GET .github/code-intelligence.yml via GitHub Contents API
+   ├── Falls back to DEFAULT_REPO_CONFIG on any error (fail-open)
+   └── If skip:true → return None immediately
+
+5. Existing bot-review detection (_fetch_existing_bot_reviews)
+   ├── Fetch prior Copilot/bot PR reviews
+   └── _determine_copilot_mode() → "full" | "supplement" | "duetto_only"
+
+6. Head-SHA dedup
+   ├── PRReviewLog.show() to check existing review for this PR
+   └── If existing.head_sha == current head_sha AND NOT skip_dedup → return cached
+
+7. Parallel context retrieval
+   ├── _search_context(): trusty-search POST /indexes/main/search (vector search)
+   │   Query = PR title + changed file paths
+   │   Up to MAX_CONTEXT_FILES=6 chunks
+   │   If require_search_context=True and zero results → skip review entirely
+   ├── _fetch_jira_context(): JIRA tickets (REST API or vector fallback)
+   ├── _fetch_confluence_context(): Confluence pages (vector search)
+   ├── apex search: product specs from apex_search VectorSearchAdapter
+   ├── github_search: GitHub issues context
+   └── _search_cross_references(): cross-repo blast-radius search
+
+8. Iterative enrichment (_run_enrichment_rounds, up to MAX_ENRICHMENT_ROUNDS=5)
+   ├── Extracts identifiers from diff (class/method/const names)
+   └── Runs targeted vector searches per identifier (if new chunks found)
+
+9. Static analysis (_analyze_changed_files)
+   ├── AnalyzerAdapter.has_analysis(): cheap readiness probe (GET /health + GET /indexes)
+   ├── AnalyzerAdapter.complexity_hotspots(): GET /indexes/{id}/hotspots
+   ├── AnalyzerAdapter.smells(): GET /indexes/{id}/smells
+   └── Graceful degradation if unavailable
+
+10. LLM review generation (_generate_review)
+    ├── _build_user_message(): assembles all context into structured markdown prompt
+    ├── BedrockClient.chat() → Claude Sonnet (us.anthropic.claude-sonnet-4-6)
+    └── Returns (review_body, input_tokens, output_tokens)
+
+11. Grade extraction (_extract_review_grade)
+    └── Regex scan of last 20% of review_body against _GRADE_PATTERNS
+
+12. Fix-suggestion parsing (_parse_fix_suggestions)
+    └── Parses structured ```fix_suggestions JSON blocks from review body
+
+13. Verification round (_verify_blocking_findings)
+    ├── Candidate selection (see §2.2)
+    ├── Per-finding: BedrockClient with HAIKU_MODEL_ID → "CONFIRMED" or "REFUTED"
+    ├── CONFIRMED → promote confidence to max(current, block_threshold)
+    └── REFUTED / error → set confidence to FIX_ISSUE_MIN_CONFIDENCE - 0.01
+
+14. Suppression filtering
+    ├── _fetch_suppressed_patterns(): bot-suppress-labeled closed issues
+    ├── _fetch_repo_suppress_config(): .github/code-intelligence.yml suppress list
+    └── _is_finding_suppressed(): substring OR ≥70% word overlap
+
+15. Relevance gate (_relevance_gate_blocks)
+    ├── min_findings check (repo config or PR_INTELLIGENCE_MIN_FINDINGS_TO_POST)
+    └── suppress_advisory check (skip if APPROVE/APPROVE* with no required-change findings)
+
+16. Output
+    ├── DRY-RUN path:
+    │   ├── PRReviewLog.write() → {owner}/{repo}/{pr_number}/review.{json,md}
+    │   ├── _file_dry_run_calibration_issue() → GitHub issue with CALIBRATION_LABEL
+    │   └── notify_pr_review_complete() → Slack
+    └── LIVE path:
+        ├── _post_review() → GitHub PR review comment
+        ├── _file_or_update_tracker_issue() → upsert one tracker issue per PR
+        ├── PRReviewLog.write()
+        └── notify_pr_review_complete() → Slack
+```
+
+---
+
+## 2. Verdict Policy and Verification Round
+
+### 2.1 Fail-Safe Verdict Policy
+
+**Default verdict is APPROVE. The bot bears the burden of proof, not the engineer.**
+
+From the system prompt (`PR_REVIEW_SYSTEM_PROMPT`, lines ~960–980):
+
+> REQUEST_CHANGES requires ALL THREE of the following from evidence in the visible diff:
+> (a) a specific wrong line cited, (b) a traceable failure path, (c) a concrete fix.
+>
+> BLOCK = reserved for undisputed evidence of a serious flaw introduced by this PR.
+>
+> Default verdict is APPROVE. The bot bears the burden of proof, not the engineer.
+
+Verdict taxonomy:
+- `APPROVE` — merge as-is
+- `APPROVE*` — merge, minor issues noted (no required-change findings)
+- `REQUEST_CHANGES` — must fix before merge (real bug, contract violation, or safety risk demonstrated from visible diff)
+- `BLOCK` — undisputed serious flaw (data loss, auth bypass, irreversible production breakage)
+
+Grade patterns extracted by `_extract_review_grade()` from last 20% of review body using `_GRADE_PATTERNS` (list of compiled regexes). Letter grades A–F also supported (parsed by `None`-label entries in `_GRADE_PATTERNS`).
+
+`_normalize_review_verdict()` normalizes raw extracted grade to one of: `APPROVE`, `APPROVE*`, `REQUEST_CHANGES`, `BLOCK`, or `N/A`.
+
+### 2.2 Per-Finding Haiku Verification Round
+
+**Function**: `_verify_blocking_findings()` (lines 4385–4615)
+
+**When called**: After `_parse_fix_suggestions()`, before suppression filtering.
+
+**Candidate selection** (changed 2026-05-30 — see Hard-won Lessons §7.1):
+
+| Primary verdict | Candidates sent to verifier |
+|---|---|
+| `REQUEST_CHANGES` or `BLOCK` | ALL fix_suggestions with `confidence >= _VERIFY_CANDIDATE_MIN_CONFIDENCE` (0.50), sorted desc, capped at `FIX_ISSUE_MAX_PER_PR` (5) |
+| `APPROVE`, `APPROVE*`, `N/A` | Only findings with `confidence >= block_threshold` (default 0.90) |
+
+**Per-finding decision table**:
+
+| Verifier response | Action |
+|---|---|
+| `CONFIRMED` | Promote confidence to `max(current, block_threshold)` |
+| `REFUTED` | Set confidence to `FIX_ISSUE_MIN_CONFIDENCE - 0.01` (drops below both tiers) |
+| Exception (any) | Same as REFUTED (fail toward APPROVE) |
+| Truncation shortcut | Auto-REFUTE WITHOUT LLM call when diff is truncated AND both `finding.file` AND `finding.line` marker are absent from full diff text |
+
+**Verifier model**: `HAIKU_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"` (imported from `diff_analyzer/hunk_classifier.py`; shared constant to avoid drift).
+
+**Verification system prompt** (`_VERIFICATION_SYSTEM_PROMPT`): Requests exactly one word: `CONFIRMED` if specific wrong line is quotable and failure path is traceable entirely within visible code; `REFUTED` otherwise (absent evidence, requires assumptions outside diff, or diff appears truncated).
+
+**Exception handling in verifier**: Bedrock errors classified by marker strings (`ResourceNotFoundException`, `ValidationException`, `AccessDeniedException`, `ModelNotReadyException`) → log `pr_review_verification_model_error` at ERROR level (distinguishes model-config errors from transient network errors). Both result in `confirmed = False`.
+
+**Downgrade logic**: After verification, if primary verdict was `REQUEST_CHANGES`/`BLOCK` and NO surviving blocking findings remain (all refuted), the verdict in the review body is NOT rewritten (review body is returned unchanged) — but the filed findings list is empty, which means `APPROVE*` is the effective outcome.
+
+### 2.3 Confidence Tiers
+
+| Tier | Threshold | Behavior |
+|---|---|---|
+| Advisory | `FIX_ISSUE_MIN_CONFIDENCE` (0.70) | Summarized in review comment |
+| Blocking / issue-eligible | `BLOCK_ISSUE_MIN_CONFIDENCE` (0.90) | Filed as tracker issue |
+| `FIX_ISSUE_MAX_PER_PR` | 5 | Runaway safety cap on filed issues |
+| `FIX_ISSUE_ALLOWED_EFFORTS` | `("low", "medium")` | Only these effort levels file issues |
+| Repo-configurable `issue_threshold` | default 0.75 | Per-repo override |
+| Repo-configurable `block_threshold` | default 0.90 | Per-repo override |
+| Repo-configurable `pr_threshold` | default 0.95 | High-confidence flag threshold |
+
+---
+
+## 3. Diff Summarizer / DiffAnalyzer Pipeline
+
+### 3.1 Stage Architecture (`services/diff_analyzer/`)
+
+```
+DiffAnalyzer.analyze(files, diff_text, config)
+  ├── Stage A: FileFilter.apply() — deterministic file-level filter
+  │   ├── Preserve-first: builtin preserve patterns (security/, .env, secrets/,
+  │   │   config), credential-filename substrings (secret, token, password, key,
+  │   │   dsn, credential), content-level credential URL regex, user preserve_patterns
+  │   ├── Drop: lockfiles, snapshots, generated code, pure renames
+  │   └── Summary-only: fixture/i18n files > fixture_summary_min_lines (30)
+  │
+  ├── Stage B: HunkFilter.apply() — regex hunk-level filter per surviving file
+  │   ├── Whitespace-only hunks → WHITESPACE_ONLY
+  │   ├── Import-only hunks (language-specific) → IMPORT_ONLY
+  │   └── Comment-only hunks → COMMENT_ONLY
+  │
+  └── Stage C: HunkClassifier.classify() — Haiku per-hunk substantive scoring
+      ├── Batches of BATCH_SIZE=10 hunks per Haiku call
+      ├── mechanical + confidence > DROP_CONFIDENCE_THRESHOLD (0.7) → dropped
+      │   UNLESS hunk contains credential URL (force-preserve)
+      ├── substantive | uncertain → kept
+      └── ANY Haiku error → ALL hunks in batch treated as "uncertain" (kept)
+```
+
+**Output**: `FilteredDiff.render_for_prompt(max_chars=12_000)` — no manifest header in output (framing-effect regression fix from forecasting#120; manifest is telemetry-only via `build_manifest_telemetry()`).
+
+### 3.2 Hunk Classification Taxonomy
+
+| Classification | Meaning | `is_droppable` |
+|---|---|---|
+| `substantive` | Logic, schema, API, security, control-flow change | False |
+| `mechanical` | Formatting, whitespace, import reorder, generated, getters/setters | True if confidence > 0.7 |
+| `uncertain` | Cannot determine without more context | False |
+
+Haiku model: same `HAIKU_MODEL_ID` constant. Batch prompt requests JSON array with `{hunk_id, classification, confidence, reason}` per hunk. Temperature 0.0.
+
+### 3.3 File/Hunk Data Models (`diff_analyzer/models.py`)
+
+| Type | Key fields |
+|---|---|
+| `FilteredDiff` | `files: list[FilteredFile]`, `dropped_files: list[DroppedFile]`, `drop_hunk_counts: dict[str,int]`, `original_byte_size`, `filtered_byte_size`, `phase2_telemetry` |
+| `FilteredFile` | `filename`, `status` (added/modified/renamed/removed), `disposition: FileDisposition`, `hunks: list[FilteredHunk]`, `dropped_hunks: list[DroppedHunk]`, `summary_line` |
+| `FilteredHunk` | `header` (@@ line), `lines: list[str]`, `substantive_confidence`, `reason_kept` |
+| `DroppedHunk` | `reason: HunkDropReason`, `lines_count`, `header` |
+| `DroppedFile` | `path`, `reason` |
+| `FileDisposition` | `KEPT`, `DROPPED`, `SUMMARY_ONLY` |
+| `HunkDropReason` | `WHITESPACE_ONLY`, `IMPORT_ONLY`, `COMMENT_ONLY`, `MECHANICAL_HAIKU` |
+
+### 3.4 Noisy File Patterns (in `pr_review_service.py`)
+
+For PR diff display (separate from DiffAnalyzer), `NOISY_FILE_PATTERNS` and `NOISY_DIFF_MIN_LINES=30` suppress large fixture/i18n diffs: `.tsv`, `.csv`, `nls/**/*.{properties,json}`, `messages/**`, `labels/**`, `fixtures/**/*.{json,xml,sql}`, `test*fixtures*/**`, `__generated__/**`, `generated/**/*.{java,ts,js}`.
+
+---
+
+## 4. GitHub Integration (`pr_review_github.py`, `pr_review_service.py`)
+
+### 4.1 Authentication
+
+**GitHub App auth** (preferred over PAT):
+- `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_PRIVATE_KEY` (RSA)
+- `GITHUB_INSTALLATION_ID_DUETTORESEARCH`, `GITHUB_INSTALLATION_ID_HOTSTATS`
+- `_resolve_github_token(owner)` → selects installation token by org name
+- Falls back to `GITHUB_TOKEN` (PAT) if App auth not configured
+
+**Multi-org**: Two separate installation IDs for `duettoresearch` and `hotstats` orgs. Token selection is by `owner.lower()` match.
+
+### 4.2 GitHub Operations Performed by the Bot
+
+The bot is restricted to read + comment operations. `GH_ALLOW_PUSH = False` (hard-coded, not configurable). `_assert_no_push_operation()` raises `RuntimeError` if any of `_FORBIDDEN_PUSH_OPERATIONS` is called.
+
+Permitted operations:
+- POST PR review comment (`_post_review`)
+- GET PR diff, file list, metadata
+- GET/POST/PATCH issues (tracker + calibration issues)
+- GET/POST labels
+- POST issue type (REST numeric ID: `TASK_ISSUE_TYPE_NUMERIC_ID = 203410`)
+- POST GraphQL for GitHub Project v2 add
+- GET `.github/code-intelligence.yml`
+- GET existing PR reviews (for Copilot detection)
+
+### 4.3 Tracker Issue Semantics
+
+One GitHub issue per PR (the "tracker"), updated in place on every re-review.
+
+- Labels: `["code-review", "code-intelligence"]` (`TRACKER_ISSUE_LABELS`)
+- Issue type: "Task" (`TASK_ISSUE_TYPE_ID = "IT_kwDOABbzg84AAxqS"` GraphQL node ID)
+- Discovery label for Project #16 filter: `code-intelligence`
+- Title pattern: `[PR Review] {owner}/{repo}#{pr_number} — {VERDICT}`
+- Suppression pattern extracted from title: first 60 chars after marker (`SUPPRESS_PATTERN_PREFIX_LEN`)
+
+**`_file_or_update_tracker_issue()`**: Searches existing `code-review`-labeled issues on the repo for a matching title prefix; updates body + title if found (upsert), creates if not found.
+
+**Calibration issues** (dry-run): Filed with `CALIBRATION_ISSUE_LABEL = "code-intelligence-review"`, added to `PR Review Calibration` GitHub Project (created if missing). Body includes trigger, grade, PR link, and full review text.
+
+### 4.4 Suppression Flow
+
+1. `_fetch_suppressed_patterns()`: search repo issues for `bot-suppress` label + closed state → extract pattern from issue title via `_suppress_pattern_from_title()`
+2. `_fetch_repo_suppress_config()`: fetch `.github/code-intelligence.yml`, return `suppress` list
+3. Lists merged at review time
+4. `_is_finding_suppressed(finding_desc, patterns)`: case-insensitive substring OR `_texts_similar()` (Jaccard word overlap >= `SUPPRESS_OVERLAP_THRESHOLD=0.7`)
+5. ALL lookups fail-open (GitHub API error never blocks review)
+
+---
+
+## 5. Log and Calibration Tracker (`pr_review_log.py`)
+
+### 5.1 `PRReviewResult` Data Model (full field list)
+
+| Field | Type | Notes |
+|---|---|---|
+| `owner`, `repo` | str | GitHub org/repo |
+| `pr_number` | int | PR number |
+| `pr_title`, `pr_url` | str | |
+| `review_body` | str | Full LLM markdown output |
+| `analysis` | dict | Contains `grade`, `display_grade`, `display_grade_is_fallback`, `hotspots_in_pr`, `smells_in_pr`, `copilot_mode`, `bot_review_count` |
+| `context_files` | list[str] | Filenames from vector search context |
+| `input_tokens`, `output_tokens` | int | Final LLM call only |
+| `cost_estimate_usd` | float | Estimated cost |
+| `dry_run`, `posted` | bool | |
+| `timestamp` | str | ISO timestamp |
+| `error` | str\|None | Non-None on pipeline error |
+| `fix_suggestions` | list[FixSuggestion] | |
+| `filed_issue_numbers` | list[int] | GitHub issue numbers filed |
+| `review_mode` | str | `"full"` or `"no_context"` |
+| `head_sha` | str | For dedup; empty on pre-field records |
+| `tracker_issue_number`, `tracker_issue_url` | int\|None, str\|None | |
+| `diff` | str\|None | Stored diff for eval replay |
+| `apex_context`, `jira_context`, `confluence_context`, `github_issues_context`, `cross_ref_context` | list[dict] | Slim metadata (bodies stripped via `_slim_context()`) |
+| `copilot_mode` | str | `"full"` / `"supplement"` / `"duetto_only"` |
+| `bot_review_count` | int | |
+| `multipass` | bool | Two-pass pipeline flag |
+| `pass1_tokens`, `pass2_tokens` | int | Multi-pass cost breakdown |
+| `trigger` | str | `"manual"` or `"auto"` |
+| `grade` | str | Top-level mirror of `analysis["grade"]` |
+| `enrichment_rounds`, `enrichment_queries` | int, list[str] | Context enrichment audit |
+| `skip_reason` | str\|None | Short token on pipeline skip |
+| `review_version` | str | Pipeline version string (currently `"v1.4"`) |
+
+### 5.2 `FixSuggestion` Data Model
+
+| Field | Type | Notes |
+|---|---|---|
+| `file` | str | Changed file path |
+| `line` | int\|None | Line number (optional) |
+| `kind` | str | Finding type |
+| `description` | str | Human-readable finding |
+| `suggestion` | str | Proposed fix |
+| `confidence` | float | 0.0–1.0 |
+| `effort` | str | `"low"` / `"medium"` / `"high"` |
+
+### 5.3 Directory Layout and Cross-Process Dedup
+
+On-disk: `{PR_INTELLIGENCE_LOG_DIR}/{owner}/{repo}/{pr_number}/review.{json,md}`
+
+Cross-process dedup: `{PR_INTELLIGENCE_LOG_DIR}/dedup.db` — SQLite with `in_flight_reviews` table (composite PK: `owner, repo, pr_number, head_sha`). `claim_review()` does atomic `INSERT OR FAIL`; stale claims (>2 hours) purged on each claim attempt. `release_review()` called in `finally` to free the claim.
+
+---
+
+## 6. Adapters
+
+### 6.1 trusty-search Adapter (`adapters/vector_search.py`)
+
+HTTP client for `TRUSTY_SEARCH_URL` (default `http://localhost:7878`). Index name from `TRUSTY_SEARCH_INDEX` (default `"main"`).
+
+Key calls used by PR review:
+- `POST /indexes/{index}/search` — semantic similarity search; query from PR title + changed file paths
+- `GET /health` — liveness
+- `GET /indexes/{index}/status` — file count / health
+
+Multiple named `VectorSearchAdapter` instances used for different index targets:
+- `vector_search` — main code index
+- `knowledge_search` — JIRA/Confluence knowledge index (74K+ chunks)
+- `apex_search` — APEX product spec index
+- `github_search` — GitHub issues index
+
+### 6.2 trusty-analyze Adapter (`adapters/analyzer_adapter.py`)
+
+HTTP client for `PR_INTELLIGENCE_ANALYZER_URL` (default `http://localhost:7879`). Index from `TRUSTY_SEARCH_INDEX`.
+
+| Method | Endpoint | Timeout | Notes |
+|---|---|---|---|
+| `health()` | `GET /health` | 5s (`_health_timeout`) | Liveness + `search_reachable` flag |
+| `is_available()` | `GET /health` | 5s | Cached 60s TTL |
+| `has_analysis()` | `GET /health` + `GET /indexes` | 5s each | Cheap readiness probe (see §8.2) |
+| `complexity_hotspots()` | `GET /indexes/{id}/hotspots` | 180s | Returns list of hotspot dicts |
+| `smells()` | `GET /indexes/{id}/smells` | 180s | Returns list of smell dicts |
+| `quality_grade()` | `GET /indexes/{id}/quality` | 180s | O(corpus) — do NOT use as readiness probe |
+
+All methods catch `httpx.ConnectError`, `TimeoutException`, `HTTPError` and return empty default. Non-2xx logged at WARNING (404 on known-optional paths at DEBUG).
+
+### 6.3 Bedrock LLM Adapter (`adapters/bedrock_llm.py`)
+
+Uses **Bedrock Converse API** (`bedrock-runtime.converse` / `converse_stream`). The Converse API normalizes request/response shape across model families.
+
+| Setting | Value | Notes |
+|---|---|---|
+| Main review model | `us.anthropic.claude-sonnet-4-6` (from `BEDROCK_MODEL_ID`) | `us.` inference profile prefix required |
+| Verifier/classifier model | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Must be `foundation_lifecycle=ACTIVE` |
+| Region | `AWS_REGION` (default `us-east-1`) | |
+| max_tokens | `bedrock.max_tokens` from settings | |
+| temperature for review | 0.3 (webhook route) | Tighter than chat for determinism |
+| temperature for verification | 1.0 default | Single-word response |
+| Retry | `max_attempts=3, mode="adaptive"` | boto3 adaptive retry |
+| Read timeout | 120s | |
+| Token tracking | `_last_usage: dict[str, int]` | Set after each call; read by `_generate_review` |
+
+Token metrics emitted to CloudWatch: `LLMInputTokens`, `LLMOutputTokens` tagged `ReviewType=PRReview`.
+
+---
+
+## 7. JIRA / Ticket Context Mechanism
+
+### 7.1 `_fetch_jira_context()` (lines 4015–4085)
+
+1. Extract ticket IDs matching `_JIRA_TICKET_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")` from PR title + description
+2. If ATLASSIAN credentials configured (`ATLASSIAN_EMAIL`, `ATLASSIAN_API_TOKEN`, `ATLASSIAN_URL`) and ticket IDs found → `_fetch_jira_tickets()`: `GET /rest/api/3/issue/{id}` per ticket (up to `MAX_KNOWLEDGE_RESULTS=3`)
+3. If REST API returns nothing → `_vector_search_for_tickets()`: per-ticket keyword search against 74K+ JIRA/Confluence vector index
+4. If no credentials → same vector search fallback
+5. Final fallback: semantic search on PR title + description
+
+### 7.2 APEX Context
+
+APEX is treated as a separate vector index (`apex_search` adapter, queried via `SearchService`). The query is the same cross-query used for code context (PR title + changed filenames). Results up to `MAX_APEX_RESULTS=2`. Cited in review as `[apex: \`path/to/spec.md:15\` — "brief excerpt"]`.
+
+**NEW vs today**: For trusty-review, apex must be treated as a repo (indexed alongside code repos in trusty-search) rather than a separate index. The spec author should design a single-index query that returns apex spec chunks alongside code chunks, or a configurable secondary index URL.
+
+---
+
+## 8. Per-Repo Config (`.github/code-intelligence.yml`)
+
+### 8.1 Full Schema
+
+| Key | Type | Default | Behavior |
+|---|---|---|---|
+| `skip` | bool | `false` | Disable all reviews for this repo |
+| `issue_threshold` | float | `0.75` | Min confidence to file tracker issue |
+| `block_threshold` | float | `0.90` | Min confidence for BLOCK tier |
+| `pr_threshold` | float | `0.95` | Min confidence for high-confidence flag |
+| `suppress` | list[str] | `[]` | Substring/word-overlap suppression patterns |
+| `min_findings` | int | `1` | Min eligible findings to post to GitHub |
+| `suppress_advisory` | bool | `false` | Skip posting APPROVE/APPROVE* with no required-change findings |
+| `file_issues_on_merge_only` | bool | `false` | Defer tracker issue creation until PR merge |
+| `diff_filter.suppress_patterns` | list[str] | `[]` | Additional file patterns to drop from diff |
+| `diff_filter.preserve_patterns` | list[str] | `[]` | Force-keep patterns (override built-in drops) |
+| `diff_filter.ignore_whitespace` | bool | `true` | Drop whitespace-only hunks |
+| `diff_filter.ignore_imports` | bool | `true` | Drop import-only hunks |
+| `diff_filter.ignore_comments` | bool | `true` | Drop comment-only hunks |
+| `diff_filter.fixture_summary_min_lines` | int | `30` | Threshold for fixture file summarization |
+
+**Validation**: `issue_threshold`, `block_threshold`, `pr_threshold` must be in `[0.0, 1.0]`; `pr_threshold >= issue_threshold`. Violations revert both to defaults. Unknown keys ignored. Config fails open (fetch/parse errors → defaults).
+
+### 8.2 Suppression Matching
+
+`_is_finding_suppressed(finding_desc, patterns)`:
+- Case-insensitive
+- OR condition: (a) pattern is substring of `finding_desc`, OR (b) `_texts_similar()` returns True
+- `_texts_similar(a, b, threshold=FINDING_SIMILARITY_THRESHOLD=0.6)`: normalized word sets, Jaccard overlap >= threshold
+- Suppression lookups always fail-open
+
+---
+
+## 9. Slack Notifications (`services/slack_notify.py`)
+
+Two notification types relevant to PR review:
+
+**`notify_pr_review_complete()`**: Single-line mrkdwn message with dry-run/live label, linked `owner/repo#PR`, verdict, findings count, optional calibration/tracker issue link. Never raises (Slack outage cannot break review).
+
+**`notify_pr_review_service_failure()`**: Block Kit warning message when a required service (trusty-search, trusty-analyze, Bedrock) is unavailable. Includes service name, PR URL, truncated error (500 chars). Triggered by `PRReviewServiceUnavailable` exception caught in `_run_review_pipeline`.
+
+Dispatch: prefers `SLACK_NOTIFICATION_CHANNEL` + `SLACK_BOT_TOKEN` (chat.postMessage); falls back to `SLACK_NOTIFICATION_WEBHOOK`.
+
+---
+
+## 10. Environment Variables / Configuration Reference
+
+### 10.1 PR Intelligence Settings
+
+| Env Var | Default | Effect |
+|---|---|---|
+| `PR_INTELLIGENCE_DRY_RUN` | `"true"` | `true` = log to disk; `false` = post to GitHub |
+| `PR_INTELLIGENCE_ENABLED_REPOS` | `"*"` | Comma-sep allow-list; `"*"` = all; `"org/*"` = org wildcard |
+| `PR_INTELLIGENCE_EXCLUDED_REPOS` | `""` | Comma-sep deny-list; always overrides allow-list |
+| `PR_INTELLIGENCE_EXCLUDED_AUTHORS` | `""` | Bot logins to skip (e.g. `duetto-snyk-svc`) |
+| `PR_REVIEW_BOT_USERNAME` | `""` | GitHub App login; triggers manual/live mode when requested as reviewer |
+| `PR_INTELLIGENCE_LOG_DIR` | `/data/app/data/pr-reviews` | Dry-run log directory |
+| `PR_INTELLIGENCE_ANALYZER_URL` | `http://localhost:7879` | trusty-analyze sidecar URL |
+| `PR_INTELLIGENCE_EVAL_MODEL` | (varies) | Secondary model for eval comparisons (dry-run only) |
+| `PR_INTELLIGENCE_MIN_FINDINGS_TO_POST` | `1` | Global min findings gate (overrideable per-repo) |
+| `PR_INTELLIGENCE_SUPPRESS_ADVISORY_REVIEWS` | `false` | Global suppress_advisory flag |
+| `PR_INTELLIGENCE_FILE_ISSUES_ON_MERGE_ONLY` | `false` | Global file_issues_on_merge_only flag |
+
+### 10.2 GitHub App Settings
+
+| Env Var | Effect |
+|---|---|
+| `GITHUB_APP_ID` | Numeric app ID |
+| `GITHUB_APP_CLIENT_ID` | App OAuth client ID |
+| `GITHUB_APP_PRIVATE_KEY` | RSA private key (PEM, newlines as `\n`) |
+| `GITHUB_INSTALLATION_ID_DUETTORESEARCH` | Installation ID for duettoresearch org |
+| `GITHUB_INSTALLATION_ID_HOTSTATS` | Installation ID for hotstats org |
+| `GITHUB_WEBHOOK_SECRET` | HMAC secret for webhook signature verification |
+| `GITHUB_TOKEN` | PAT fallback when App auth not configured |
+
+### 10.3 LLM and Infrastructure
+
+| Env Var | Default | Effect |
+|---|---|---|
+| `BEDROCK_MODEL_ID` | `us.anthropic.claude-sonnet-4-6` | Main review LLM |
+| `AWS_REGION` | `us-west-2` | Bedrock region |
+| `TRUSTY_SEARCH_URL` | `http://localhost:7878` | trusty-search HTTP endpoint |
+| `TRUSTY_SEARCH_INDEX` | `"main"` | Index name for both trusty-search and trusty-analyze |
+| `ATLASSIAN_URL` | `""` | Jira/Confluence base URL |
+| `ATLASSIAN_EMAIL` | `""` | API auth email |
+| `ATLASSIAN_API_TOKEN` | `""` | API token |
+| `SLACK_NOTIFICATION_WEBHOOK` | `""` | Slack webhook for notifications |
+| `SLACK_NOTIFICATION_CHANNEL` | `""` | Slack channel (preferred over webhook) |
+| `SLACK_BOT_TOKEN` | `""` | Bot token for channel posting |
+
+---
+
+## 11. trusty-tools Workspace Conventions for trusty-review
+
+### 11.1 Workspace Structure
+
+```
+trusty-tools/
+├── Cargo.toml          # workspace root; glob members = ["crates/*"]
+├── crates/
+│   ├── trusty-common/  # shared libs (chat, MCP, embedder, memory-core, etc.)
+│   ├── trusty-search/  # HTTP daemon :7878; lib + binary
+│   └── trusty-analyze/ # HTTP daemon :7879; lib + binary
+```
+
+The new `trusty-review` crate should follow the same pattern: `crates/trusty-review/` with a `lib.rs` and a `main.rs` (`[[bin]]`).
+
+### 11.2 Crate Conventions (from `CLAUDE.md`)
+
+| Rule | Detail |
+|---|---|
+| Why/What/Test doc comments | Every public item must have all three sections |
+| 500-line file cap | Split files proactively; no file > 500 lines |
+| `thiserror` for libraries | Structured error enums; `anyhow` for binary crates |
+| No `unwrap()` in library code | Use `?` or `expect()` for true invariants only |
+| No global state | Free functions or small structs; no `lazy_static!` |
+| Logs to stderr | Never stdout (MCP JSON-RPC framing uses stdout) |
+| `axum` behind `http-server` feature | Gate axum/tower-http so library consumers don't pull in HTTP stack |
+| Edition 2021 | (2024 only for `trusty-mpm`, `open-mpm` family) |
+| Workspace dependencies | All shared deps declared once in root `[workspace.dependencies]` |
+| MSRV 1.88 | Required for let-chains |
+
+### 11.3 HTTP Server Pattern (trusty-analyze as reference)
+
+`trusty-analyze/src/service/mod.rs` exposes `build_router(state: AnalyzerAppState) -> Router` returning an axum 0.8 router. Routes follow the pattern:
+
+```rust
+Router::new()
+    .route("/health", get(health))
+    .route("/indexes", get(list_indexes))
+    .route("/indexes/{id}/complexity_hotspots", get(complexity_hotspots))
+    // ...
+```
+
+The binary (`main.rs`) resolves config, creates state, calls `build_router()`, and binds with `axum::serve()`.
+
+### 11.4 LLM Client in trusty-tools
+
+`trusty-common` provides `OpenRouterProvider` (via `chat` module) using the OpenRouter API (`OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"`). The `OPENROUTER_API_KEY` env var provides auth. Default model: `anthropic/claude-haiku-4.5`.
+
+**NEW vs today**: trusty-review should implement a `LlmProvider` trait with at minimum two concrete backends:
+1. `OpenRouterProvider` (via `trusty-common::chat`) — for local/standalone use
+2. `BedrockProvider` — for production Duetto deployment
+
+The provider must be selectable at runtime (env var or config), not compile-time. The verifier (Haiku-tier) and main review (Sonnet-tier) should each accept a `Box<dyn LlmProvider>` or equivalent.
+
+### 11.5 trusty-search and trusty-analyze HTTP APIs (consumed by trusty-review)
+
+**trusty-search (:7878)**:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/health` | GET | Liveness; returns `embedder` status, `search_reachable` |
+| `/indexes` | GET | List registered indexes |
+| `/indexes/:id/status` | GET | Chunk count + root path |
+| `/indexes/:id/search` | POST | Hybrid BM25+vector search |
+| `/indexes/:id/reindex` | POST | Fire-and-forget reindex |
+
+**trusty-analyze (:7879)**:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/health` | GET | Liveness + `search_reachable` flag |
+| `/indexes` | GET | List indexes (cheap readiness probe step 2) |
+| `/indexes/{id}/complexity_hotspots` | GET | Top-N complexity hotspots |
+| `/indexes/{id}/smells` | GET | Code smell findings |
+| `/indexes/{id}/quality` | GET | Aggregate quality report (O(corpus) — do NOT use as probe) |
+
+Both are consumed over HTTP (not in-process). trusty-review should have its own HTTP client modules for each, analogous to the Python adapters, with the same graceful degradation semantics.
+
+---
+
+## 12. Hard-Won Lessons / Failure Modes
+
+### 12.1 Inactive Verifier Model → Silent All-Approve Degradation
+
+**Symptom**: All blocking findings were being auto-refuted silently; every PR review effectively became APPROVE regardless of the diff content.
+
+**Root cause**: `_VERIFICATION_MODEL_ID` was hardcoded to `"us.anthropic.claude-3-5-haiku-20241022-v1:0"` which had `foundation_lifecycle=LEGACY` on the Duetto Bedrock account. Every verification call threw `ResourceNotFoundException`. The exception handler set `confirmed = False`, which meant REFUTED for every finding. With all findings refuted, the downgrade logic produced APPROVE.
+
+**Fix**: The constant is now sourced from `hunk_classifier.HAIKU_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"` — the only Haiku tier with `foundation_lifecycle=ACTIVE`. The error is now classified at ERROR level (`pr_review_verification_model_error` log event) to distinguish model-config failure from transient network errors.
+
+**NEW vs today implication**: trusty-review must alarm on `verification_model_error` events. An inactive model ID must produce an observable alert, not a silent degradation. The LLM provider abstraction must distinguish "model not found" errors from transient failures.
+
+### 12.2 Bedrock Inference Profile ID Requirement
+
+**Symptom**: Bedrock calls fail with `ValidationException` or `ResourceNotFoundException` when using bare model IDs like `anthropic.claude-3-5-sonnet-20241022-v2:0`.
+
+**Root cause**: Cross-region inference profiles require the `us.` prefix (e.g., `us.anthropic.claude-sonnet-4-6`). Without the prefix, Bedrock rejects the model ID for cross-region invocation.
+
+**Fix**: All model IDs in production configuration use the `us.` inference profile prefix.
+
+**NEW vs today implication**: trusty-review's OpenRouter provider avoids this — OpenRouter uses model slugs like `anthropic/claude-haiku-4.5`. If a Bedrock provider is implemented, it must enforce the `us.` prefix or accept it as a required configuration input.
+
+### 12.3 Analyzer Readiness Probe False "corpus_not_ready"
+
+**Symptom**: Every PR review logged `analysis.available: False, reason: trusty_analyze_corpus_not_ready` even when trusty-analyze was running correctly.
+
+**Root cause**: `has_analysis()` was probing `GET /indexes/{id}/quality` with a 5-second timeout. The `/quality` endpoint is O(corpus) — it streams all ~396k chunks from trusty-search and can take 11–103 seconds. Every probe timed out, making the sidecar appear unavailable.
+
+**Fix**: `has_analysis()` now uses two cheap checks: (1) `GET /health` (O(1), liveness + `search_reachable`), (2) `GET /indexes` (O(n_indexes), typically 1–3 indexes). Both use `_health_timeout=5s`. The `/quality` endpoint is never called as a readiness probe.
+
+**NEW vs today implication**: trusty-review must replicate this two-step probe. Never use an O(corpus) endpoint as a readiness check. The trusty-analyze daemon's `/health` response includes a `search_reachable` boolean flag — check it explicitly.
+
+### 12.4 Concurrent Webhook Delivery → Duplicate Reviews
+
+**Symptom**: GitHub fires several distinct webhook events for one PR push (e.g., `synchronize` + `review_requested` within seconds). Without guards, both events ran the full LLM pipeline and produced duplicate calibration issues.
+
+**Fix**: Three-layer dedup:
+1. Webhook-level filter: only `review_requested` triggers dispatch (non-`review_requested` actions return 200 OK but no dispatch)
+2. `_PR_IN_FLIGHT` set: in-process per-(owner,repo,pr_number) guard active from request receipt (before SHA is known)
+3. `_IN_FLIGHT` set + SQLite `claim_review()`: per-(owner,repo,pr_number,head_sha) cross-process atomic claim
+
+**NEW vs today implication**: trusty-review needs all three layers. The SQLite cross-process claim is critical for multi-worker deployments. The `claim_review/release_review` in-`finally` pattern must be preserved to avoid leaked claims.
+
+### 12.5 Verifier Candidate Selection Bug (Sub-0.90 Findings Never Verified)
+
+**Symptom**: Real defects with confidence 0.65–0.82 were never reaching the verifier. The LLM would write `REQUEST_CHANGES` in its narrative but assign the supporting finding a confidence below 0.90. Those findings were excluded from the verify-only-blocking-tier path. After verification (which had no candidates), the downgrade logic fired and produced APPROVE*.
+
+**Root cause**: The original candidate selection for the verifier only included findings with `confidence >= block_threshold` (0.90). Sub-threshold findings were never verified even when the primary verdict was REQUEST_CHANGES.
+
+**Fix** (2026-05-30): When primary verdict ∈ {REQUEST_CHANGES, BLOCK}, verify ALL findings with `confidence >= _VERIFY_CANDIDATE_MIN_CONFIDENCE` (0.50), sorted desc, capped at 5. Only APPROVE/APPROVE*/N/A verdicts still use the old blocking-only selection.
+
+### 12.6 Verifier Truncation Shortcut Over-Eagerness
+
+**Symptom**: Real findings at line ~5000 chars in the diff were being auto-refuted without an LLM call. The truncation shortcut checked whether the finding's location was present in a 4k-char window, not the full diff.
+
+**Root cause**: The truncation shortcut was checking the 4k-char verification slice (not the full diff). A finding whose line appeared at char 4001–16384 was marked "absent from diff" and auto-refuted.
+
+**Fix**: `diff_for_verify` is now the full `diff_text` (already bounded to `MAX_DIFF_CHARS` by the caller), not a smaller sub-slice. The truncation shortcut only fires when BOTH the file path AND the line marker are absent from the FULL diff — genuinely hallucinated locations.
+
+### 12.7 Calibration Tracker Upsert-Per-PR
+
+**Symptom**: Each re-push to a PR created a new tracker issue instead of updating the existing one, accumulating 8+ duplicate issues per active PR.
+
+**Fix**: `_file_or_update_tracker_issue()` searches for an existing issue with the stable `code-review` label and matching title prefix before creating a new one. First-push creates; subsequent pushes update body + title in place.
+
+### 12.8 Dry-Run Rollout Discipline
+
+**Symptom** (operational risk): Premature switch to live mode before the review quality was validated.
+
+**Design**: `PR_INTELLIGENCE_DRY_RUN=true` is the default. In dry-run mode, the pipeline runs fully (diff fetch, context retrieval, LLM review, verification) but posts nothing to GitHub — writes only to disk and files a calibration GitHub issue. The webhook handler further enforces that only `review_requested` events (not `opened`/`synchronize`) trigger dispatch, regardless of `PR_INTELLIGENCE_DRY_RUN`.
+
+**NEW vs today implication**: trusty-review should implement the same dry-run default. Flip to live only when `--live` or `dry_run=false` is explicitly set.
+
+### 12.9 Suppression Fail-Open
+
+**Design principle**: Every suppression lookup (GitHub API for `bot-suppress` labels, `.github/code-intelligence.yml` fetch) wraps in try/except and returns an empty list on error. A GitHub API error during suppression never blocks the review from running with unsuppressed findings.
+
+**NEW vs today implication**: trusty-review must implement the same fail-open contract. HTTP errors fetching config/labels → treat as no suppression rules.
+
+### 12.10 Graceful Degradation When trusty-analyze Is Down
+
+**Design**: `AnalyzerAdapter.has_analysis()` returns `False` when the sidecar is down. `_analyze_changed_files()` checks this and returns an empty analysis dict. The review proceeds with no static analysis context — the LLM still runs on diff + vector search context.
+
+`PRReviewServiceUnavailable` is raised only for the three required services: trusty-search, AWS Bedrock. trusty-analyze failure is NOT raised as `PRReviewServiceUnavailable` — it degrades silently.
+
+**NEW vs today implication**: trusty-review must distinguish optional (trusty-analyze) from required (trusty-search, LLM) dependencies. Optional service failures degrade gracefully; required service failures skip the review entirely and Slack-notify.
+
+### 12.11 Push Firewall (Learned from Production Incident)
+
+**Symptom**: The bot was caught force-pushing to an infrastructure repo.
+
+**Fix**: `GH_ALLOW_PUSH = False` is hard-coded. `_assert_no_push_operation()` raises `RuntimeError` on any attempted git-write operation. The constant is intentionally not configurable via env vars or per-repo settings.
+
+**NEW vs today implication**: trusty-review must implement an equivalent firewall. The bot is read + comment only. No branch creation, file commits, or PR creation against reviewed repos.
+
+### 12.12 Noisy Fixture/Generated File Diff Problem
+
+**Symptom**: PRs touching large i18n label files or generated sources buried the meaningful code change in column-noise. The bot saw the fixture churn, burned most of its context budget on it, and missed the real change (demonstrated with PR #9545).
+
+**Fix**: `NOISY_FILE_PATTERNS` collapses large diffs of fixture/i18n files to a 1-line summary. The DiffAnalyzer Stage A/B/C pipeline additionally drops lockfiles, snapshots, generated code, whitespace/import/comment-only hunks.
+
+### 12.13 Cross-Reference Blast-Radius Gap
+
+**Symptom**: PR #9545 deleted a permission check. The value it gated was still enqueued by a producer in another file the PR never touched. A similarity search keyed on the diff alone never surfaced the orphaned producer.
+
+**Fix**: `_search_cross_references()` extracts enum constants (`ALL_CAPS_WITH_UNDERSCORE`) and method calls (`camelCase(`) from deleted lines, searches for other files that reference them but were NOT changed, and prioritizes producer-keyword hits (`enqueue`, `schedule`, `produce`, etc.).
+
+---
+
+## 13. NEW vs Today — Delta Flags for Spec Author
+
+| Dimension | Today (Python) | NEW (trusty-review Rust) |
+|---|---|---|
+| Language | Python 3.11+, FastAPI | Rust, axum 0.8 |
+| LLM provider | AWS Bedrock only (Converse API) | Co-equal Bedrock + OpenRouter; provider abstracted via trait |
+| Model selection | Fixed by env var | Configurable per call-type (main vs verifier) |
+| JIRA context | ATLASSIAN_* REST API + vector search fallback | Same logic; configurable JIRA REST client |
+| APEX context | Separate VectorSearchAdapter instance | Apex treated as a repo; indexed alongside code in trusty-search; same index query |
+| Deployment | FastAPI app (embedded in code-intelligence) | Standalone Rust service; can run as server or CLI |
+| Dedup storage | SQLite (`dedup.db`) | Redb (aligns with trusty-analyze/trusty-search) or SQLite; TBD in spec |
+| Log storage | Filesystem JSON/MD | Filesystem JSON/MD (same schema); or pluggable backend |
+| GitHub auth | PyGithub + httpx + GithubIntegration | reqwest + octocrab or raw HTTP; GitHub App JWT generation in Rust |
+| Suppression matching | Python regex + word overlap | Same algorithm in Rust |
+| Diff analyzer | Python + Haiku LLM | Rust deterministic stages + LLM stage via provider trait |
+| Webhook server | FastAPI route | axum route (matches trusty-analyze/trusty-search pattern) |
+| Multi-org | INSTALLATION_ID_* per org | Same; config-driven |


### PR DESCRIPTION
Adds the 12-file trusty-review design spec (architecture, PR-review pipeline, diff summarizer, LLM providers, integrations, configuration, data models, interfaces, deployment, lessons, source-analysis). This is the canonical reference for the trusty-review epic and its child implementation issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)