### PR TITLE
feat(trusty-review): per-finding verification round + verifier-model liveness gate (Phase 2, closes #583)

### DIFF
--- a/crates/trusty-review/src/cli_verify.rs
+++ b/crates/trusty-review/src/cli_verify.rs
@@ -1,0 +1,70 @@
+//! Verifier-provider construction for the CLI / daemon entry points (Phase 2, #583).
+//!
+//! Why: both the one-shot CLI (`run` / `compare`) and the long-lived `serve`
+//! daemon must build the verifier-role provider, but with different
+//! failure-handling: the CLI degrades to no-verification on a build error, while
+//! the daemon treats a build failure as fatal (the liveness gate exists to catch
+//! exactly that misconfiguration).  Keeping both builders here keeps `main.rs`
+//! focused on argument parsing and dispatch.
+//!
+//! What: `build_verifier_opt` (non-fatal, returns `Option`) and
+//! `build_verifier_for_serve` (fatal, returns `Result<Option<_>>`).
+//!
+//! Test: the network build path is not unit-tested; the gating logic these feed
+//! (`enforce_verifier_liveness`) is covered in `pipeline::verify_liveness::tests`.
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use trusty_review::{config::ReviewConfig, llm::LlmProvider, llm::build_provider};
+
+/// Build the verifier provider when verification is enabled, else `None`
+/// (non-fatal).
+///
+/// Why: the verifier role is a separate model (Haiku by default) resolved
+/// independently of the reviewer.  The one-shot CLI must not abort a review just
+/// because the verifier could not be built — it degrades to no-verification.
+/// What: returns `Some(provider)` when `config.verification.enabled` and the
+/// build succeeds; `None` when verification is disabled or the build fails
+/// (logged).
+/// Test: build path is network-bound; covered transitively by the verification
+/// runner tests with injected fakes.
+pub async fn build_verifier_opt(config: &ReviewConfig) -> Option<Arc<dyn LlmProvider>> {
+    if !config.verification.enabled {
+        return None;
+    }
+    let role = &config.role_models.verifier;
+    match build_provider(&role.model, &role.provider, &config.openrouter_api_key).await {
+        Ok(p) => Some(p),
+        Err(e) => {
+            warn!("failed to build verifier provider (continuing without verification): {e}");
+            None
+        }
+    }
+}
+
+/// Build the verifier provider for the `serve` daemon (fatal on failure).
+///
+/// Why: unlike the one-shot CLI, the long-lived daemon must not silently degrade
+/// to no-verification on a verifier-build failure — that failure is exactly the
+/// kind of misconfiguration the liveness gate exists to catch.  When verification
+/// is enabled a build error is fatal; when disabled we return `None`.
+/// What: returns `Ok(Some(provider))` when enabled and the build succeeds,
+/// `Ok(None)` when verification is disabled, and `Err` when enabled but the build
+/// fails.
+/// Test: build path is network-bound; the decision branch is covered by the
+/// liveness-gate unit tests via `enforce_verifier_liveness`.
+#[cfg(feature = "http-server")]
+pub async fn build_verifier_for_serve(
+    config: &ReviewConfig,
+) -> anyhow::Result<Option<Arc<dyn LlmProvider>>> {
+    if !config.verification.enabled {
+        return Ok(None);
+    }
+    let role = &config.role_models.verifier;
+    let p = build_provider(&role.model, &role.provider, &config.openrouter_api_key)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to build verifier provider: {e}"))?;
+    Ok(Some(p))
+}

--- a/crates/trusty-review/src/config/constants.rs
+++ b/crates/trusty-review/src/config/constants.rs
@@ -33,8 +33,11 @@ pub const BLOCK_VERDICT_MIN_CONFIDENCE: f32 = 0.90;
 /// PR comment.
 ///
 /// Why: the PR comment can distinguish "FYI" from "definitely fix this".
-/// What: corresponds to `pr_threshold` in per-repo config.
-pub const VERIFY_CANDIDATE_MIN_CONFIDENCE: f32 = 0.95;
+/// What: corresponds to `pr_threshold` in per-repo config.  Renamed from the
+/// former `VERIFY_CANDIDATE_MIN_CONFIDENCE` (Phase 2, #583) — that name is now
+/// the verification candidate-selection floor (0.50); this constant always
+/// meant the PR high-confidence flag (`pr_threshold`), never the verify gate.
+pub const PR_HIGH_CONFIDENCE_THRESHOLD: f32 = 0.95;
 
 /// Minimum confidence to include a finding in the verification round.
 ///
@@ -43,6 +46,34 @@ pub const VERIFY_CANDIDATE_MIN_CONFIDENCE: f32 = 0.95;
 /// What: findings below this are skipped by the verifier and treated as
 /// unverified.
 pub const VERIFICATION_MIN_CONFIDENCE: f32 = 0.65;
+
+/// Minimum confidence for a finding to be a verification *candidate* when the
+/// primary verdict is REQUEST_CHANGES / BLOCK (Phase 2, #583).
+///
+/// Why: when the reviewer already wants to block the merge, the verification
+/// round must cast a wide net — even moderate-confidence findings can be the
+/// sole reason the verdict escalated, so they must be confirmed or refuted
+/// before they are allowed to drive a blocking verdict.  This is distinct from
+/// (and deliberately lower than) `VERIFICATION_MIN_CONFIDENCE`, which gates the
+/// *advisory* path; on a blocking verdict we widen the candidate set down to
+/// this floor so a false-positive blocking finding cannot slip past unverified.
+/// What: on a REQUEST_CHANGES / BLOCK primary verdict, every finding with
+/// `confidence >= VERIFY_CANDIDATE_MIN_CONFIDENCE` is sent to the verifier.
+/// Default 0.50 (matches the Phase 2 ticket #583 work item (b)).
+pub const VERIFY_CANDIDATE_MIN_CONFIDENCE: f32 = 0.50;
+
+/// Demoted confidence assigned to a finding the verifier REFUTED (Phase 2, #583).
+///
+/// Why: a refuted finding must not surface or drive a verdict, but the spec
+/// (REV-606) requires we keep it on the result for transparency rather than
+/// silently dropping it.  Demoting its confidence below every advisory / block
+/// gate makes `derive_verdict` treat it as noise while the `verified` field
+/// records *why* it was demoted.
+/// What: set below `FIX_ISSUE_MIN_CONFIDENCE` (0.60), `VERIFICATION_MIN_CONFIDENCE`
+/// (0.65), and `LOW_CONFIDENCE_THRESHOLD` (0.65 in grade.rs) so a refuted
+/// finding is always treated as advisory-only noise and collapses the floor.
+/// Test: `refuted_finding_is_demoted_below_advisory_tier` in `verify_tests.rs`.
+pub const VERIFY_REFUTED_CONFIDENCE: f32 = 0.10;
 
 // ─── Suppression (spec §06 REV-530) ──────────────────────────────────────────
 
@@ -114,10 +145,12 @@ mod tests {
             ("FIX_ISSUE_MIN_CONFIDENCE", FIX_ISSUE_MIN_CONFIDENCE),
             ("BLOCK_ISSUE_MIN_CONFIDENCE", BLOCK_ISSUE_MIN_CONFIDENCE),
             ("BLOCK_VERDICT_MIN_CONFIDENCE", BLOCK_VERDICT_MIN_CONFIDENCE),
+            ("PR_HIGH_CONFIDENCE_THRESHOLD", PR_HIGH_CONFIDENCE_THRESHOLD),
             (
                 "VERIFY_CANDIDATE_MIN_CONFIDENCE",
                 VERIFY_CANDIDATE_MIN_CONFIDENCE,
             ),
+            ("VERIFY_REFUTED_CONFIDENCE", VERIFY_REFUTED_CONFIDENCE),
             ("VERIFICATION_MIN_CONFIDENCE", VERIFICATION_MIN_CONFIDENCE),
             ("SUPPRESS_OVERLAP_THRESHOLD", SUPPRESS_OVERLAP_THRESHOLD),
             ("FINDING_SIMILARITY_THRESHOLD", FINDING_SIMILARITY_THRESHOLD),
@@ -138,8 +171,20 @@ mod tests {
         );
         // Block threshold must be <= pr_threshold.
         const _: () = assert!(
-            BLOCK_VERDICT_MIN_CONFIDENCE <= VERIFY_CANDIDATE_MIN_CONFIDENCE,
-            "block_verdict must be <= verify_candidate"
+            BLOCK_VERDICT_MIN_CONFIDENCE <= PR_HIGH_CONFIDENCE_THRESHOLD,
+            "block_verdict must be <= pr_high_confidence_threshold"
+        );
+        // The verification candidate floor (REQUEST_CHANGES/BLOCK path) must sit
+        // below the advisory verification gate — it deliberately widens the net.
+        const _: () = assert!(
+            VERIFY_CANDIDATE_MIN_CONFIDENCE <= VERIFICATION_MIN_CONFIDENCE,
+            "verify_candidate floor must be <= advisory verification gate"
+        );
+        // A refuted finding must be demoted strictly below the include-in-review
+        // gate so it can never resurface or drive a verdict.
+        const _: () = assert!(
+            VERIFY_REFUTED_CONFIDENCE < FIX_ISSUE_MIN_CONFIDENCE,
+            "refuted confidence must be below the review-include gate"
         );
     }
 

--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -15,10 +15,12 @@
 
 pub mod constants;
 pub mod role_models;
+pub mod verification;
 
 pub use role_models::{
     FileModels, RoleCliOverrides, RoleConfig, RoleConfigOverride, RoleEnv, RoleModels,
 };
+pub use verification::{VerificationConfig, VerificationFileConfig};
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -75,6 +77,8 @@ impl std::str::FromStr for Provider {
 struct TomlFile {
     #[serde(default)]
     models: FileModels,
+    #[serde(default)]
+    verification: VerificationFileConfig,
 }
 
 /// Global service configuration for trusty-review.
@@ -149,6 +153,10 @@ pub struct ReviewConfig {
     // ── Role models (fully resolved) ───────────────────────────────────────
     /// Resolved per-role model configurations.
     pub role_models: RoleModels,
+
+    // ── Verification round (Phase 2, #583) ─────────────────────────────────
+    /// Resolved verification-round settings (`enabled`, `liveness_check`).
+    pub verification: VerificationConfig,
 }
 
 impl ReviewConfig {
@@ -165,11 +173,16 @@ impl ReviewConfig {
         config_path: Option<&std::path::Path>,
         cli_overrides: Option<&RoleCliOverrides>,
     ) -> Self {
-        // Try to load the config file; silently fall back to defaults.
-        let file_models = load_file_models(config_path);
+        // Try to load the config file; silently fall back to defaults.  Parse
+        // it once so both the `[models]` and `[verification]` tables come from
+        // the same read.
+        let toml_file = load_toml_file(config_path);
+        let file_models = toml_file.as_ref().map(|f| f.models.clone());
+        let file_verification = toml_file.as_ref().map(|f| f.verification.clone());
 
         let env = RoleEnv::from_env();
         let role_models = RoleModels::resolve(cli_overrides, &env, file_models.as_ref());
+        let verification = VerificationConfig::from_env_and_file(file_verification.as_ref());
 
         let dry_run = std::env::var("PR_INTELLIGENCE_DRY_RUN")
             .map(|v| v.to_lowercase() != "false")
@@ -215,6 +228,7 @@ impl ReviewConfig {
                 .filter(|s| !s.trim().is_empty())
                 .unwrap_or_else(|| "trusty-review[bot]".to_string()),
             live_review_requesters: load_live_review_requesters(),
+            verification,
         }
     }
 
@@ -278,20 +292,22 @@ fn load_live_review_requesters() -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Try to load `[models]` from a TOML config file; return `None` on any
-/// error (fail-open per spec REV-511).
+/// Try to parse the whole TOML config file; return `None` on any error
+/// (fail-open per spec REV-511).
 ///
-/// Why: config file absence or parse errors must never block a review.
-/// What: reads the file as a string, deserialises as `TomlFile`, returns
-/// the `models` table.  Any I/O or TOML error logs a warning and returns
-/// `None`.
+/// Why: config-file absence or parse errors must never block a review.  Parsing
+/// once and returning the whole `TomlFile` lets the caller pull both the
+/// `[models]` and `[verification]` tables from a single read instead of opening
+/// the file twice.
+/// What: reads the file as a string and deserialises as `TomlFile`.  Any I/O or
+/// TOML error logs a warning and returns `None`.
 /// Test: covered indirectly by `ReviewConfig` unit tests.
-fn load_file_models(path: Option<&std::path::Path>) -> Option<FileModels> {
+fn load_toml_file(path: Option<&std::path::Path>) -> Option<TomlFile> {
     let path = path?;
     match std::fs::read_to_string(path) {
         Err(_) => None,
         Ok(s) => match toml::from_str::<TomlFile>(&s) {
-            Ok(f) => Some(f.models),
+            Ok(f) => Some(f),
             Err(e) => {
                 warn!(?path, "failed to parse config file: {e}");
                 None

--- a/crates/trusty-review/src/config/verification.rs
+++ b/crates/trusty-review/src/config/verification.rs
@@ -1,0 +1,219 @@
+//! Verification-round configuration (Phase 2, #583).
+//!
+//! Why: the per-finding verification pass (the second LLM pass that confirms or
+//! refutes findings) must be switchable off in environments where the verifier
+//! model is unavailable or the extra latency/cost is unwanted, and its startup
+//! liveness gate must be independently toggleable for tests and offline runs.
+//! Centralising these two knobs here keeps `config/mod.rs` under the 500-line
+//! cap and gives the `[verification]` TOML table a single typed home.
+//!
+//! What: exposes `VerificationConfig` (`enabled`, `liveness_check`) and its
+//! TOML-deserialisable mirror `VerificationFileConfig`.  `from_env_and_file`
+//! resolves the two-layer precedence (env var over config file over default),
+//! matching the rest of the config module.
+//!
+//! Test: `verification_defaults_enabled`, `verification_env_disables`,
+//! `verification_file_disables`, `verification_env_beats_file` in this module.
+
+use serde::Deserialize;
+use tracing::warn;
+
+/// Environment variable that toggles the whole verification round.
+///
+/// Why: operators need a single, discoverable switch to disable verification
+/// without editing a TOML file (e.g. when the verifier model is being migrated).
+/// What: any of `false`/`0`/`no`/`off` (case-insensitive) disables it; anything
+/// else (or unset) leaves the config-file / default value in force.
+const ENV_VERIFICATION_ENABLED: &str = "TRUSTY_REVIEW_VERIFICATION_ENABLED";
+
+/// Environment variable that toggles only the startup verifier-model liveness gate.
+///
+/// Why: the liveness probe makes a real (cheap) network call to the verifier
+/// model; offline/CI runs need to disable just that probe while keeping the
+/// verification logic itself testable with injected fakes.
+/// What: same truthiness parsing as `ENV_VERIFICATION_ENABLED`.
+const ENV_LIVENESS_CHECK: &str = "TRUSTY_REVIEW_VERIFIER_LIVENESS_CHECK";
+
+/// Resolved configuration for the verification round.
+///
+/// Why: the runner and the `serve` startup path both read these flags; a single
+/// owned struct keeps the decision logic free of scattered env lookups and makes
+/// the behaviour trivially testable (construct the struct directly).
+/// What: `enabled` gates whether the verification pass runs at all; `liveness_check`
+/// gates whether `serve`/`run --live` refuse to start when the verifier model is
+/// unavailable.  Both default to `true` (safe-by-default: verify, and refuse to
+/// run live against a dead verifier).
+/// Test: `verification_defaults_enabled`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationConfig {
+    /// When `true` (default), the per-finding verification round runs between
+    /// verdict parse and finalisation.
+    pub enabled: bool,
+    /// When `true` (default), live mode refuses to start if the startup
+    /// verifier-model liveness probe fails with a config/lifecycle error.
+    pub liveness_check: bool,
+}
+
+impl Default for VerificationConfig {
+    /// Why: the safe default is "verification on, liveness gate on" so a
+    /// mis-deployed verifier model fails loudly instead of silently
+    /// auto-refuting every finding (the code-intelligence incident).
+    /// What: both flags `true`.
+    /// Test: `verification_defaults_enabled`.
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            liveness_check: true,
+        }
+    }
+}
+
+impl VerificationConfig {
+    /// Resolve from env vars layered over an optional `[verification]` TOML table.
+    ///
+    /// Why: matches the rest of the config module's env-over-file-over-default
+    /// precedence so operators have one mental model for every knob.
+    /// What: starts from the file value (or default), then applies env overrides.
+    /// Unrecognised env values are ignored with a warning (fail-open: keep the
+    /// stricter file/default value rather than silently flipping a safety gate).
+    /// Test: `verification_env_disables`, `verification_file_disables`,
+    /// `verification_env_beats_file`.
+    pub fn from_env_and_file(file: Option<&VerificationFileConfig>) -> Self {
+        let mut cfg = VerificationConfig {
+            enabled: file.and_then(|f| f.enabled).unwrap_or(true),
+            liveness_check: file.and_then(|f| f.liveness_check).unwrap_or(true),
+        };
+        if let Some(v) = parse_bool_env(ENV_VERIFICATION_ENABLED) {
+            cfg.enabled = v;
+        }
+        if let Some(v) = parse_bool_env(ENV_LIVENESS_CHECK) {
+            cfg.liveness_check = v;
+        }
+        cfg
+    }
+}
+
+/// TOML-deserialisable `[verification]` table (all fields optional).
+///
+/// Why: the config file may set neither, either, or both flags; optional fields
+/// let an absent key fall through to the env / default layer.
+/// What: an optional-field mirror of `VerificationConfig` used only during
+/// config-file parsing.
+/// Test: covered by `verification_file_disables` via `from_env_and_file`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct VerificationFileConfig {
+    /// `[verification] enabled = false` disables the whole round.
+    pub enabled: Option<bool>,
+    /// `[verification] liveness_check = false` disables only the startup gate.
+    pub liveness_check: Option<bool>,
+}
+
+/// Parse a boolean env var with lenient truthiness, or `None` if unset/empty.
+///
+/// Why: env-var booleans come in many spellings; centralising the parse keeps
+/// the two flags consistent and avoids silently treating `"false"` as truthy.
+/// What: returns `Some(false)` for `false`/`0`/`no`/`off`, `Some(true)` for
+/// `true`/`1`/`yes`/`on`, `None` for unset/empty, and `None` (with a warning)
+/// for anything unrecognised.
+/// Test: covered indirectly by `verification_env_disables` /
+/// `verification_env_beats_file`.
+fn parse_bool_env(var: &str) -> Option<bool> {
+    let raw = std::env::var(var).ok()?;
+    let v = raw.trim().to_lowercase();
+    if v.is_empty() {
+        return None;
+    }
+    match v.as_str() {
+        "false" | "0" | "no" | "off" => Some(false),
+        "true" | "1" | "yes" | "on" => Some(true),
+        other => {
+            warn!("unrecognised boolean for {var}: {other:?} — ignoring");
+            None
+        }
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear_env() {
+        unsafe {
+            std::env::remove_var(ENV_VERIFICATION_ENABLED);
+            std::env::remove_var(ENV_LIVENESS_CHECK);
+        }
+    }
+
+    #[test]
+    fn verification_defaults_enabled() {
+        let cfg = VerificationConfig::default();
+        assert!(cfg.enabled, "verification must default ON");
+        assert!(cfg.liveness_check, "liveness gate must default ON");
+    }
+
+    #[test]
+    #[serial]
+    fn verification_env_disables() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_VERIFICATION_ENABLED, "false");
+        }
+        let cfg = VerificationConfig::from_env_and_file(None);
+        assert!(!cfg.enabled, "env false must disable verification");
+        assert!(cfg.liveness_check, "liveness untouched by enabled var");
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn verification_file_disables() {
+        clear_env();
+        let file = VerificationFileConfig {
+            enabled: Some(false),
+            liveness_check: Some(false),
+        };
+        let cfg = VerificationConfig::from_env_and_file(Some(&file));
+        assert!(!cfg.enabled, "file false must disable verification");
+        assert!(!cfg.liveness_check, "file false must disable liveness gate");
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn verification_env_beats_file() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_VERIFICATION_ENABLED, "true");
+        }
+        // File says disabled, env says enabled → env wins.
+        let file = VerificationFileConfig {
+            enabled: Some(false),
+            liveness_check: None,
+        };
+        let cfg = VerificationConfig::from_env_and_file(Some(&file));
+        assert!(cfg.enabled, "env true must override file false");
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn verification_unrecognised_env_keeps_file_value() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_VERIFICATION_ENABLED, "maybe");
+        }
+        let file = VerificationFileConfig {
+            enabled: Some(false),
+            liveness_check: None,
+        };
+        let cfg = VerificationConfig::from_env_and_file(Some(&file));
+        assert!(
+            !cfg.enabled,
+            "unrecognised env must fall through to file value"
+        );
+        clear_env();
+    }
+}

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -14,6 +14,7 @@
 //! `service::webhook`; the `profile` subcommand is tested in `cli_profile`.
 
 mod cli_profile;
+mod cli_verify;
 
 use std::sync::Arc;
 
@@ -391,6 +392,17 @@ async fn cmd_serve(config: ReviewConfig, args: ServeArgs) -> Result<()> {
     .await
     .map_err(|e| anyhow::anyhow!("failed to build LLM provider: {e}"))?;
 
+    // ── Verifier provider + startup liveness gate (Phase 2, #583) ──────────
+    // In LIVE mode (not dry-run) a dead verifier model would silently neuter
+    // every review (the code-intelligence incident), so we probe the verifier
+    // model and REFUSE to start when it is unavailable.  In dry-run mode the
+    // probe is informational only.  The gate itself is independently skippable
+    // via TRUSTY_REVIEW_VERIFIER_LIVENESS_CHECK=false.
+    let verifier = cli_verify::build_verifier_for_serve(&config).await?;
+    trusty_review::pipeline::enforce_verifier_liveness(&config, verifier.as_ref())
+        .await
+        .map_err(|reason| anyhow::anyhow!(reason))?;
+
     let search = HttpSearchClient::from_config(&config);
     let analyze = HttpAnalyzeClient::from_config(&config);
 
@@ -409,9 +421,10 @@ async fn cmd_serve(config: ReviewConfig, args: ServeArgs) -> Result<()> {
         }
     };
 
-    let state = AppState::with_dedup(
+    let state = AppState::with_verifier_and_dedup(
         config.clone(),
         llm,
+        verifier,
         Arc::new(search),
         Some(Arc::new(analyze)),
         dedup,
@@ -589,11 +602,18 @@ async fn build_deps_async(
         .await
         .map_err(|e| anyhow::anyhow!("failed to build LLM provider: {e}"))?;
 
+    // Build the verifier provider only when the verification round is enabled
+    // (Phase 2, #583).  A verifier-build failure is non-fatal for the CLI path:
+    // we log and fall back to running without verification rather than aborting
+    // a one-shot review.
+    let verifier = cli_verify::build_verifier_opt(config).await;
+
     let search = HttpSearchClient::from_config(config);
     let analyze = HttpAnalyzeClient::from_config(config);
 
     Ok(ReviewDeps {
         llm,
+        verifier,
         search: Arc::new(search),
         analyze: Some(Arc::new(analyze)),
         // CLI runs do not use the durable dedup store (one-shot, no retries).

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -7,14 +7,16 @@
 //! `ReviewInput`, `ReviewDeps`, `DiffSource`) and the compare aggregator.
 //!
 //! Submodules:
-//!  - `diff`    — diff source, loading, truncation, identifier extraction.
-//!  - `grade`   — severity-anchored deterministic grade derivation (floor logic).
-//!  - `prompt`  — prompt construction for the reviewer role.
-//!  - `parser`  — verdict + findings parsing from LLM responses.
-//!  - `output`  — log file writing and STDOUT rendering.
-//!  - `post`    — post-or-log finalisation decision (Phase 1, #582).
-//!  - `runner`  — top-level orchestration loop (`run_review`).
-//!  - `trigger` — live vs dry-run trigger classification (REV-703).
+//!  - `diff`         — diff source, loading, truncation, identifier extraction.
+//!  - `grade`        — severity-anchored deterministic grade derivation (floor logic).
+//!  - `prompt`       — prompt construction for the reviewer role.
+//!  - `parser`       — verdict + findings parsing from LLM responses.
+//!  - `output`       — log file writing and STDOUT rendering.
+//!  - `post`         — post-or-log finalisation decision (Phase 1, #582).
+//!  - `verify_prompt`— verifier-pass prompt + forced-output schema (Phase 2, #583).
+//!  - `verify`       — per-finding verification round + liveness gate (Phase 2, #583).
+//!  - `runner`       — top-level orchestration loop (`run_review`).
+//!  - `trigger`      — live vs dry-run trigger classification (REV-703).
 //!
 //! Test: each submodule carries its own unit tests.
 
@@ -25,7 +27,11 @@ pub mod parser;
 pub mod post;
 pub mod prompt;
 pub mod runner;
+pub mod runner_context;
 pub mod trigger;
+pub mod verify;
+pub mod verify_liveness;
+pub mod verify_prompt;
 
 pub use diff::DiffSource;
 pub use grade::derive_verdict;
@@ -35,3 +41,5 @@ pub use post::{FinalizeAction, PostContext, decide_action, finalize_review};
 pub use prompt::{ReviewContext, ReviewPrMeta, build_review_prompt, reviewer_system_prompt};
 pub use runner::{ReviewDeps, ReviewInput, run_review};
 pub use trigger::{TriggerDecision, classify_review_request, effective_dry_run};
+pub use verify::{maybe_verify, run_verification_round, select_candidates};
+pub use verify_liveness::{LivenessDecision, enforce_verifier_liveness, probe_verifier_liveness};

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -10,8 +10,11 @@
 //! gated by the trigger decision and the SHA-keyed dedup store.  Returns a
 //! `ReviewResult` even on pipeline errors (fail-safe APPROVE/UNKNOWN).
 //!
+//! Phase 2 (#583) adds the per-finding verification round between verdict parse
+//! and finalisation: candidate findings are confirmed/refuted by the verifier
+//! model and the verdict is re-derived so refuted blocking findings relax it.
+//!
 //! Deferred to later phases (stubs/comments intact):
-//!  - Verification round (Phase 2 / #583)
 //!  - Suppression filtering + per-repo `.github/code-intelligence.yml` (Phase 3 / #584)
 //!  - Tracker-issue upsert (Phase 4 / #585)
 //!  - JIRA/Confluence/APEX/GH-Issues context (Phase 6 / #550)
@@ -41,8 +44,10 @@ use crate::{
         output::{print_review_result, write_review_log},
         parser::parse_review_response,
         post::{PostContext, finalize_review},
-        prompt::{ReviewContext, ReviewPrMeta, build_review_prompt},
+        prompt::{ReviewPrMeta, build_review_prompt},
+        runner_context::gather_context,
         trigger::TriggerDecision,
+        verify::maybe_verify,
     },
     store::{ClaimOutcome, DedupStore},
 };
@@ -95,6 +100,10 @@ pub struct ReviewInput {
 pub struct ReviewDeps {
     /// LLM provider for the reviewer role.
     pub llm: Arc<dyn LlmProvider>,
+    /// LLM provider for the verifier role (Phase 2, #583).  `None` disables the
+    /// verification round (e.g. tests that don't exercise it, or when
+    /// `config.verification.enabled` is false the caller passes `None`).
+    pub verifier: Option<Arc<dyn LlmProvider>>,
     /// Code search client (required; gracefully degrades on error).
     pub search: Arc<dyn SearchClient>,
     /// Static analysis client (optional; None skips the analyze step).
@@ -280,8 +289,23 @@ pub async fn run_review(
         "final verdict after severity-anchored floor"
     );
 
-    result.verdict = final_verdict;
-    result.findings = parsed.findings;
+    let mut findings = parsed.findings;
+
+    // ── Step 7c: per-finding verification round (Phase 2, #583) ────────────
+    // Confirm or refute candidate findings with the verifier model; refuted
+    // findings are demoted below the advisory tier and the verdict is re-derived
+    // so a BLOCK whose only blocking finding was refuted relaxes.  `maybe_verify`
+    // applies the enabled / verifier-wired gating and returns the verdict
+    // unchanged when the round is skipped.
+    result.verdict = maybe_verify(
+        config,
+        deps.verifier.as_ref(),
+        &diff,
+        final_verdict,
+        &mut findings,
+    )
+    .await;
+    result.findings = findings;
 
     finalize_run(result, config, &input, deps.dedup.as_ref()).await
 }
@@ -318,96 +342,6 @@ async fn fetch_github_pr_meta(
         },
         head_sha,
     ))
-}
-
-/// Gather code context from trusty-search and (optionally) trusty-analyze.
-///
-/// Why: context retrieval is the most latency-sensitive step; running search
-/// and analyze in parallel reduces wall-clock time.
-/// What: runs the search query (identifier names + PR title) and the analyze
-/// probe concurrently; both degrade gracefully on error (empty context).
-/// Test: `gather_context_degrades_gracefully_on_search_failure`.
-async fn gather_context(
-    config: &ReviewConfig,
-    deps: &ReviewDeps,
-    identifiers: &[String],
-    changed_files: &[String],
-    pr_title: &str,
-) -> ReviewContext {
-    // Build a search query from identifiers + changed files.
-    let query_parts: Vec<&str> = {
-        let mut parts: Vec<&str> = identifiers.iter().map(|s| s.as_str()).collect();
-        if !pr_title.is_empty() {
-            parts.push(pr_title);
-        }
-        // Limit to 5 terms to avoid query bloat.
-        parts.truncate(5);
-        parts
-    };
-    let query = query_parts.join(" ");
-
-    let search_fut = async {
-        if query.is_empty() {
-            return Vec::new();
-        }
-        match deps
-            .search
-            .search(&config.search_index, &query, Some(8))
-            .await
-        {
-            Ok(results) => {
-                debug!(count = results.len(), "search context retrieved");
-                results
-            }
-            Err(e) => {
-                warn!("trusty-search unavailable (proceeding with no context): {e}");
-                Vec::new()
-            }
-        }
-    };
-
-    let analyze_fut = async {
-        let Some(ref analyze) = deps.analyze else {
-            return (Vec::new(), Vec::new());
-        };
-        if !analyze.has_analysis(&config.search_index).await {
-            debug!("trusty-analyze not available or has no index — skipping");
-            return (Vec::new(), Vec::new());
-        }
-        // Filter hotspots to changed files only.
-        let hotspots = match analyze
-            .complexity_hotspots(&config.search_index, Some(10))
-            .await
-        {
-            Ok(h) => h
-                .into_iter()
-                .filter(|h| changed_files.iter().any(|f| f == &h.file))
-                .collect(),
-            Err(e) => {
-                debug!("complexity_hotspots failed (optional): {e}");
-                Vec::new()
-            }
-        };
-        let smells = match analyze.smells(&config.search_index).await {
-            Ok(s) => s
-                .into_iter()
-                .filter(|s| changed_files.iter().any(|f| f == &s.file))
-                .collect(),
-            Err(e) => {
-                debug!("smells failed (optional): {e}");
-                Vec::new()
-            }
-        };
-        (hotspots, smells)
-    };
-
-    let (search_results, (complexity_hotspots, smells)) = tokio::join!(search_fut, analyze_fut);
-
-    ReviewContext {
-        search_results,
-        complexity_hotspots,
-        smells,
-    }
 }
 
 /// Finalise an *aborted* review as dry-run only, releasing the dedup claim.

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -1,0 +1,104 @@
+//! Context retrieval for the review pipeline.
+//!
+//! Why: gathering code context from trusty-search and trusty-analyze is a
+//! self-contained, latency-sensitive concern; extracting it from `runner.rs`
+//! keeps that file under the 500-line cap and lets the retrieval logic be read
+//! and tested in isolation.
+//! What: exposes `gather_context`, which runs the search query and the analyze
+//! probe concurrently and folds both (each degrading gracefully on error) into a
+//! `ReviewContext`.
+//! Test: `gather_context_degrades_gracefully_on_search_failure` (runner tests).
+
+use tracing::{debug, warn};
+
+use crate::{config::ReviewConfig, pipeline::prompt::ReviewContext, pipeline::runner::ReviewDeps};
+
+/// Gather code context from trusty-search and (optionally) trusty-analyze.
+///
+/// Why: context retrieval is the most latency-sensitive step; running search
+/// and analyze in parallel reduces wall-clock time.
+/// What: runs the search query (identifier names + PR title) and the analyze
+/// probe concurrently; both degrade gracefully on error (empty context).
+/// Test: `gather_context_degrades_gracefully_on_search_failure`.
+pub(crate) async fn gather_context(
+    config: &ReviewConfig,
+    deps: &ReviewDeps,
+    identifiers: &[String],
+    changed_files: &[String],
+    pr_title: &str,
+) -> ReviewContext {
+    // Build a search query from identifiers + changed files.
+    let query_parts: Vec<&str> = {
+        let mut parts: Vec<&str> = identifiers.iter().map(|s| s.as_str()).collect();
+        if !pr_title.is_empty() {
+            parts.push(pr_title);
+        }
+        // Limit to 5 terms to avoid query bloat.
+        parts.truncate(5);
+        parts
+    };
+    let query = query_parts.join(" ");
+
+    let search_fut = async {
+        if query.is_empty() {
+            return Vec::new();
+        }
+        match deps
+            .search
+            .search(&config.search_index, &query, Some(8))
+            .await
+        {
+            Ok(results) => {
+                debug!(count = results.len(), "search context retrieved");
+                results
+            }
+            Err(e) => {
+                warn!("trusty-search unavailable (proceeding with no context): {e}");
+                Vec::new()
+            }
+        }
+    };
+
+    let analyze_fut = async {
+        let Some(ref analyze) = deps.analyze else {
+            return (Vec::new(), Vec::new());
+        };
+        if !analyze.has_analysis(&config.search_index).await {
+            debug!("trusty-analyze not available or has no index — skipping");
+            return (Vec::new(), Vec::new());
+        }
+        // Filter hotspots to changed files only.
+        let hotspots = match analyze
+            .complexity_hotspots(&config.search_index, Some(10))
+            .await
+        {
+            Ok(h) => h
+                .into_iter()
+                .filter(|h| changed_files.iter().any(|f| f == &h.file))
+                .collect(),
+            Err(e) => {
+                debug!("complexity_hotspots failed (optional): {e}");
+                Vec::new()
+            }
+        };
+        let smells = match analyze.smells(&config.search_index).await {
+            Ok(s) => s
+                .into_iter()
+                .filter(|s| changed_files.iter().any(|f| f == &s.file))
+                .collect(),
+            Err(e) => {
+                debug!("smells failed (optional): {e}");
+                Vec::new()
+            }
+        };
+        (hotspots, smells)
+    };
+
+    let (search_results, (complexity_hotspots, smells)) = tokio::join!(search_fut, analyze_fut);
+
+    ReviewContext {
+        search_results,
+        complexity_hotspots,
+        smells,
+    }
+}

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -82,6 +82,31 @@ impl LlmProvider for FakeLlm {
     }
 }
 
+// ── Fake verifier provider (Phase 2, #583) ────────────────────────────────
+// Returns a fixed CONFIRMED / REFUTED judgment so the runner-level wiring of
+// the verification round can be asserted deterministically.
+
+struct FakeVerifier {
+    judgment: &'static str,
+}
+
+#[async_trait]
+impl LlmProvider for FakeVerifier {
+    fn name(&self) -> &str {
+        "fake-verifier"
+    }
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Ok(LlmResponse {
+            text: format!(r#"{{"judgment":"{}","reason":"test"}}"#, self.judgment),
+            model: req.model.clone(),
+            input_tokens: 5,
+            output_tokens: 3,
+            latency_ms: 1,
+            cost_usd: 0.0,
+        })
+    }
+}
+
 // ── Fake search client ────────────────────────────────────────────────
 
 struct FakeSearch;
@@ -202,6 +227,7 @@ async fn run_review_with_fake_provider_approves() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::approves()),
+        verifier: None,
         search: Arc::new(FakeSearch),
         analyze: None,
         dedup: None,
@@ -235,6 +261,7 @@ async fn run_review_request_changes_parsed_correctly() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::request_changes()),
+        verifier: None,
         search: Arc::new(FakeSearch),
         analyze: None,
         dedup: None,
@@ -261,6 +288,7 @@ async fn run_review_fail_safe_on_llm_error() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::errors("simulated transport error")),
+        verifier: None,
         search: Arc::new(FakeSearch),
         analyze: None,
         dedup: None,
@@ -294,6 +322,7 @@ async fn run_review_search_failure_does_not_block() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::approves()),
+        verifier: None,
         search: Arc::new(FailingSearch), // search is down
         analyze: None,
         dedup: None,
@@ -326,6 +355,7 @@ async fn run_review_local_diff_skips_github() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::approves()),
+        verifier: None,
         search: Arc::new(FakeSearch),
         analyze: None,
         dedup: None,
@@ -352,6 +382,7 @@ async fn run_review_missing_diff_file_sets_error() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::approves()),
+        verifier: None,
         search: Arc::new(FakeSearch),
         analyze: None,
         dedup: None,
@@ -385,6 +416,7 @@ async fn run_review_local_diff_is_dry_run_and_not_posted() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::approves()),
+        verifier: None,
         search: Arc::new(FakeSearch),
         analyze: None,
         dedup: None,
@@ -417,6 +449,7 @@ async fn run_review_writes_dry_run_log_on_log_only_path() {
     };
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::approves()),
+        verifier: None,
         search: Arc::new(FakeSearch),
         analyze: None,
         dedup: None,
@@ -429,6 +462,120 @@ async fn run_review_writes_dry_run_log_on_log_only_path() {
         .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
         .count();
     assert_eq!(json_count, 1, "a dry-run JSON log must be written");
+}
+
+/// The verification round, when wired in, REFUTES the only blocking finding and
+/// the runner's final verdict relaxes from REQUEST_CHANGES to APPROVE.
+///
+/// Why: end-to-end proof that the runner threads the verification round between
+/// parse/grade and finalisation and that a refuted finding correctly relaxes the
+/// verdict (Phase 2, #583 deliverable 2/3).
+#[tokio::test]
+async fn run_review_verification_refutes_and_relaxes_verdict() {
+    let (source, _tmp) = local_diff_source("+fn bad() {}\n");
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ReviewDeps {
+        llm: Arc::new(FakeLlm::request_changes()), // 1 medium finding → REQUEST_CHANGES
+        verifier: Some(Arc::new(FakeVerifier {
+            judgment: "REFUTED",
+        })),
+        search: Arc::new(FakeSearch),
+        analyze: None,
+        dedup: None,
+    };
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(
+        result.verdict,
+        Verdict::Approve,
+        "refuting the sole finding must relax REQUEST_CHANGES to APPROVE"
+    );
+    assert_eq!(
+        result.findings.len(),
+        1,
+        "the finding is demoted, not dropped"
+    );
+}
+
+/// The verification round, when wired in, CONFIRMS the finding and the verdict
+/// is preserved.
+#[tokio::test]
+async fn run_review_verification_confirms_and_preserves_verdict() {
+    let (source, _tmp) = local_diff_source("+fn bad() {}\n");
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ReviewDeps {
+        llm: Arc::new(FakeLlm::request_changes()),
+        verifier: Some(Arc::new(FakeVerifier {
+            judgment: "CONFIRMED",
+        })),
+        search: Arc::new(FakeSearch),
+        analyze: None,
+        dedup: None,
+    };
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(
+        result.verdict,
+        Verdict::RequestChanges,
+        "a confirmed finding must preserve the REQUEST_CHANGES verdict"
+    );
+}
+
+/// When verification is disabled by config, the verifier is never consulted and
+/// the verdict is the un-verified grade.
+#[tokio::test]
+async fn run_review_verification_disabled_skips_round() {
+    let (source, _tmp) = local_diff_source("+fn bad() {}\n");
+    let mut config = default_config();
+    config.verification.enabled = false; // disable the round
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ReviewDeps {
+        llm: Arc::new(FakeLlm::request_changes()),
+        // A REFUTED verifier is wired in but must NOT be consulted when disabled.
+        verifier: Some(Arc::new(FakeVerifier {
+            judgment: "REFUTED",
+        })),
+        search: Arc::new(FakeSearch),
+        analyze: None,
+        dedup: None,
+    };
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(
+        result.verdict,
+        Verdict::RequestChanges,
+        "with verification disabled the verdict must remain REQUEST_CHANGES"
+    );
+    assert!(
+        result.findings[0].verified.is_none(),
+        "disabled verification must not mark any finding"
+    );
 }
 
 /// Live post + dedup-skip end-to-end requires a real PR + GitHub creds, so

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -1,0 +1,466 @@
+//! Per-finding verification round (Phase 2, #583).
+//!
+//! Why: the reviewer LLM over-fires — calibration showed REQUEST_CHANGES/BLOCK
+//! verdicts driven by speculative findings that do not survive scrutiny.  A
+//! second, cheaper LLM pass that confirms or refutes each candidate finding
+//! cuts those false-positive blocking verdicts before they are posted.  This is
+//! the trusty-review port of the code-intelligence verifier protocol.
+//!
+//! What: `run_verification_round` selects candidate findings (per the primary
+//! verdict), verifies each concurrently against the verifier model with a strict
+//! CONFIRMED / REFUTED judgment, demotes REFUTED findings below the advisory
+//! tier (without dropping them — the outcome is recorded on the finding), and
+//! re-derives the final verdict so a BLOCK whose only blocking finding was
+//! refuted relaxes correctly.  `probe_verifier_liveness` is the startup gate that
+//! refuses live mode when the verifier model is unavailable.
+//!
+//! ## Why the liveness gate exists (incident rationale)
+//! code-intelligence suffered a production incident where a **stale verifier
+//! model** (an inference profile that had been deactivated) caused every
+//! verification call to fail with `ResourceNotFoundException`.  Those errors were
+//! swallowed as REFUTED, so EVERY finding was silently auto-refuted and EVERY
+//! review collapsed to APPROVE — the reviewer was effectively neutered with no
+//! visible signal.  The startup liveness probe (`probe_verifier_liveness`) exists
+//! specifically to make that failure mode loud: in live mode we refuse to start
+//! when the verifier model is dead, rather than running a defanged reviewer.
+//!
+//! Test: see `verify_tests.rs` — candidate selection per verdict, CONFIRMED
+//! keeps / REFUTED demotes, verdict re-derivation after demotion, and the
+//! liveness-gate decision logic with an injected model-unavailable provider.
+
+use std::sync::Arc;
+
+use futures_util::stream::{self, StreamExt};
+use serde::Deserialize;
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    config::ReviewConfig,
+    config::constants::{
+        BLOCK_VERDICT_MIN_CONFIDENCE, VERIFY_CANDIDATE_MIN_CONFIDENCE, VERIFY_REFUTED_CONFIDENCE,
+    },
+    llm::{LlmError, LlmProvider},
+    models::{Finding, Verdict, VerifyOutcome},
+    pipeline::{grade::derive_verdict, verify_prompt::build_verify_request},
+};
+
+/// Maximum number of verifier calls to run concurrently.
+///
+/// Why: verifications are independent per finding, so running them concurrently
+/// cuts wall-clock latency; the bound caps provider concurrency so a PR with
+/// many findings does not burst the verifier model's rate limit.
+/// What: `buffer_unordered(VERIFY_CONCURRENCY)` over the candidate stream.
+const VERIFY_CONCURRENCY: usize = 4;
+
+// ─── Runner seam ──────────────────────────────────────────────────────────────
+
+/// Run the verification round if enabled and a verifier is wired, else return
+/// the verdict unchanged.
+///
+/// Why: this is the single gating seam the runner calls so the enabled /
+/// verifier-wired checks live with the rest of the verification logic instead of
+/// cluttering the orchestration loop.  Keeping it here also keeps `runner.rs`
+/// under the 500-line cap.
+/// What: when `config.verification.enabled` and a `verifier` provider is present,
+/// delegates to `run_verification_round` with the resolved verifier role config;
+/// otherwise logs why it was skipped and returns `verdict` unchanged (findings
+/// untouched).
+/// Test: runner-level `run_review_verification_*` tests; the disabled path is
+/// `run_review_verification_disabled_skips_round`.
+pub async fn maybe_verify(
+    config: &ReviewConfig,
+    verifier: Option<&Arc<dyn LlmProvider>>,
+    diff: &str,
+    verdict: Verdict,
+    findings: &mut [Finding],
+) -> Verdict {
+    if !config.verification.enabled {
+        debug!("verification disabled by config — skipping round");
+        return verdict;
+    }
+    let Some(verifier) = verifier else {
+        debug!("verification enabled but no verifier provider wired — skipping");
+        return verdict;
+    };
+    let role = &config.role_models.verifier;
+    run_verification_round(
+        verifier,
+        &role.model,
+        diff,
+        verdict,
+        findings,
+        Some(role.temperature),
+        Some(role.max_tokens),
+    )
+    .await
+}
+
+// ─── Public entry point ──────────────────────────────────────────────────────
+
+/// Run the per-finding verification round and return the re-derived verdict.
+///
+/// Why: this is the single seam the runner calls between verdict parse and
+/// finalisation.  It mutates `findings` in place (recording each outcome and
+/// demoting refuted findings) and returns the verdict re-derived from the
+/// post-verification confidence distribution, so a blocking verdict whose only
+/// blocking finding was refuted correctly relaxes.
+/// What: selects candidates via `select_candidates`, verifies each concurrently
+/// (bounded), applies the outcome (CONFIRMED keeps confidence, REFUTED demotes
+/// below the advisory tier), then returns `derive_verdict(primary, findings)`.
+/// When there are no candidates the findings are left untouched and the primary
+/// verdict is re-derived unchanged.
+/// Test: `verify_confirmed_keeps_and_block_holds`,
+/// `verify_refuted_demotes_and_block_relaxes`,
+/// `verify_no_candidates_is_noop`.
+pub async fn run_verification_round(
+    verifier: &Arc<dyn LlmProvider>,
+    verifier_model: &str,
+    diff: &str,
+    primary_verdict: Verdict,
+    findings: &mut [Finding],
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+) -> Verdict {
+    // UNKNOWN is terminal — the diff was unassessable, so there is nothing to
+    // verify and no verdict to re-derive.
+    if primary_verdict == Verdict::Unknown {
+        return Verdict::Unknown;
+    }
+
+    let candidate_idxs = select_candidates(primary_verdict.clone(), findings);
+    if candidate_idxs.is_empty() {
+        // Nothing was verified — leave findings and verdict exactly as graded.
+        debug!("verification: no candidate findings — verdict unchanged");
+        return primary_verdict;
+    }
+
+    info!(
+        candidates = candidate_idxs.len(),
+        total = findings.len(),
+        primary = %primary_verdict,
+        "verification round: verifying candidate findings"
+    );
+
+    // Verify candidates concurrently (bounded).  Each task borrows the finding
+    // immutably to build its request; the outcome is applied afterwards so we
+    // never hold a mutable borrow across the await points.
+    let outcomes: Vec<(usize, VerifyOutcome)> = stream::iter(candidate_idxs)
+        .map(|idx| {
+            let req = build_verify_request(
+                verifier_model,
+                diff,
+                &findings[idx],
+                temperature,
+                max_tokens,
+            );
+            async move {
+                let outcome = verify_one(verifier, req).await;
+                (idx, outcome)
+            }
+        })
+        .buffer_unordered(VERIFY_CONCURRENCY)
+        .collect()
+        .await;
+
+    // Apply outcomes: record on the finding and demote refuted ones.  Track
+    // whether ANY candidate was confirmed — that decides whether the model's
+    // original escalation is still grounded (see `rederive_verdict`).
+    let mut any_confirmed = false;
+    for (idx, outcome) in outcomes {
+        if matches!(outcome, VerifyOutcome::Confirmed) {
+            any_confirmed = true;
+        }
+        apply_outcome(&mut findings[idx], outcome);
+    }
+
+    // Re-derive the verdict from the SURVIVING findings (refuted ones excluded).
+    let final_verdict = rederive_verdict(primary_verdict.clone(), any_confirmed, findings);
+    info!(
+        primary = %primary_verdict,
+        final = %final_verdict,
+        any_confirmed,
+        "verification round complete — verdict re-derived"
+    );
+    final_verdict
+}
+
+/// Re-derive the final verdict from the surviving (non-refuted) findings.
+///
+/// Why: after verification, the *surviving* findings are the ground truth — a
+/// refuted finding can no longer justify a blocking verdict.  Two facts make a
+/// naive `derive_verdict` call insufficient:
+///   1. the severity floor is keyed on a finding's `Effort`, so a refuted
+///      High-effort finding would still force a BLOCK floor on its tier alone;
+///   2. `derive_verdict` also treats its `model_proposed` argument as a lower
+///      bound, so always passing the original BLOCK would pin the result at
+///      BLOCK even when every blocking finding was refuted.
+///
+/// The rule, designed to satisfy the ticket's example ("a BLOCK whose only
+/// blocking finding was REFUTED should fall back") without throwing away
+/// legitimate model escalation on *confirmed* findings:
+///   - Always exclude refuted findings from the floor computation.
+///   - If at least one candidate was CONFIRMED, the model's escalation is still
+///     grounded, so use the original `primary_verdict` as the lower bound:
+///     `max(primary_verdict, survivor_floor)` (preserves e.g. a model
+///     REQUEST_CHANGES backed by a confirmed Medium finding).
+///   - If NO candidate was confirmed (all refuted), the escalation rested on
+///     refuted evidence, so drop the lower bound to a neutral `APPROVE` baseline
+///     and let the surviving findings alone decide — relaxing the verdict.
+///
+/// `UNKNOWN` is handled by the caller and never reaches here.
+/// What: filters out refutation-variant findings, picks the baseline per the
+/// rule above, then calls `derive_verdict(baseline, survivors)`.
+/// Test: `rederive_excludes_refuted_relaxes`, `rederive_keeps_confirmed_block`,
+/// `rederive_mixed_keeps_only_surviving_floor`, and the end-to-end
+/// `verify_refuted_demotes_and_block_relaxes` /
+/// `run_review_verification_confirms_and_preserves_verdict`.
+fn rederive_verdict(
+    primary_verdict: Verdict,
+    any_confirmed: bool,
+    findings: &[Finding],
+) -> Verdict {
+    let survivors: Vec<Finding> = findings
+        .iter()
+        .filter(|f| {
+            !matches!(
+                f.verified,
+                Some(VerifyOutcome::Refuted)
+                    | Some(VerifyOutcome::ErrorRefuted { .. })
+                    | Some(VerifyOutcome::TruncationRefuted)
+            )
+        })
+        .cloned()
+        .collect();
+    // Confirmed evidence keeps the model's escalation as a lower bound; an
+    // all-refuted candidate set drops to a neutral baseline so the verdict relaxes.
+    let baseline = if any_confirmed {
+        primary_verdict
+    } else {
+        Verdict::Approve
+    };
+    derive_verdict(baseline, &survivors)
+}
+
+// ─── Candidate selection ─────────────────────────────────────────────────────
+
+/// Select the indices of findings to send to the verifier for a given verdict.
+///
+/// Why: verifying every finding is wasteful; the candidate set depends on the
+/// primary verdict (#583 work item (b)).  On a blocking verdict we cast a wide
+/// net — any finding ≥ `VERIFY_CANDIDATE_MIN_CONFIDENCE` could be the sole reason
+/// the verdict escalated, so each must be confirmed before it is allowed to
+/// drive a block.  On an approving verdict only the blocking-tier findings (the
+/// ones that could *escalate* if confirmed) are worth the verifier's time.
+/// What: returns indices into `findings`.  For REQUEST_CHANGES / BLOCK: every
+/// finding with `confidence >= VERIFY_CANDIDATE_MIN_CONFIDENCE` (0.50).  For
+/// APPROVE / APPROVE*: only findings with `confidence >= BLOCK_VERDICT_MIN_CONFIDENCE`
+/// (0.90).  UNKNOWN never reaches here (handled by the caller).
+/// Test: `select_candidates_block_uses_wide_net`,
+/// `select_candidates_approve_uses_block_tier_only`.
+pub fn select_candidates(primary_verdict: Verdict, findings: &[Finding]) -> Vec<usize> {
+    let floor = match primary_verdict {
+        Verdict::RequestChanges | Verdict::Block => VERIFY_CANDIDATE_MIN_CONFIDENCE,
+        Verdict::Approve | Verdict::ApproveWithReservations => BLOCK_VERDICT_MIN_CONFIDENCE,
+        // UNKNOWN is filtered before this is called; treat defensively as "no
+        // candidates" so a stray UNKNOWN never triggers verifier calls.
+        Verdict::Unknown => return Vec::new(),
+    };
+    findings
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.confidence >= floor)
+        .map(|(i, _)| i)
+        .collect()
+}
+
+// ─── Single-finding verification ─────────────────────────────────────────────
+
+/// Verifier JSON output (forced via `response_schema`).
+///
+/// Why: the verifier is forced to emit `{judgment, reason}`; parsing it into a
+/// typed struct lets the outcome mapping be exhaustive instead of string-sniffing.
+/// What: `judgment` is `"CONFIRMED"` / `"REFUTED"`; `reason` is advisory.
+/// Test: covered by `verify_one` behaviour in `verify_tests.rs`.
+#[derive(Debug, Deserialize)]
+struct VerifyJudgment {
+    judgment: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    reason: String,
+}
+
+/// Verify one finding and map the provider result to a `VerifyOutcome`.
+///
+/// Why: this is where the safety-critical error handling lives.  A config/
+/// lifecycle error (`is_alarm`) from the verifier model must NOT be silently
+/// swallowed as a plain refutation — that is exactly the incident this phase
+/// guards against.  Such errors map to `ErrorRefuted { error_class }` AND emit
+/// the `verification_model_error` signal; only a clean CONFIRMED/REFUTED judgment
+/// (or a transient error, which is conservatively treated as unverifiable) maps
+/// to the ordinary outcomes.
+/// What: calls the verifier, parses the forced JSON judgment, and returns
+/// `Confirmed` / `Refuted` accordingly.  On an alarm-class `LlmError`, emits the
+/// signal and returns `ErrorRefuted`.  On a transient error or unparseable
+/// output, returns `Refuted` (conservative: an unverifiable finding must not be
+/// allowed to block) without raising the alarm.
+/// Test: `verify_one_confirmed`, `verify_one_refuted`,
+/// `verify_one_model_unavailable_emits_signal`.
+async fn verify_one(verifier: &Arc<dyn LlmProvider>, req: crate::llm::LlmRequest) -> VerifyOutcome {
+    let model = req.model.clone();
+    match verifier.complete(req).await {
+        Ok(resp) => match parse_judgment(&resp.text) {
+            Some(true) => VerifyOutcome::Confirmed,
+            Some(false) => VerifyOutcome::Refuted,
+            None => {
+                warn!(
+                    text = %truncate(&resp.text, 120),
+                    "verifier returned unparseable judgment — treating as REFUTED (conservative)"
+                );
+                VerifyOutcome::Refuted
+            }
+        },
+        Err(e) if e.is_alarm() => {
+            // Config/lifecycle failure: the verifier model is broken.  This is
+            // the incident path — make it loud, do not pretend the finding was
+            // refuted on its merits.
+            let error_class = error_class(&e);
+            emit_verification_model_error(&model, &error_class, &e);
+            VerifyOutcome::ErrorRefuted { error_class }
+        }
+        Err(e) => {
+            // Transient failure: we could not verify this finding, but the
+            // deployment is not broken.  Conservatively refuse to let an
+            // unverified finding drive a block.
+            warn!("verifier transient error (treating as REFUTED): {e}");
+            VerifyOutcome::Refuted
+        }
+    }
+}
+
+/// Apply a verification outcome to a finding: record it and demote if refuted.
+///
+/// Why: the spec (REV-606) forbids silently dropping a refuted finding — its
+/// outcome must stay on the result for transparency.  Demoting the confidence
+/// (rather than deleting the finding) makes `derive_verdict` treat it as noise
+/// while the `verified` field records *why*.
+/// What: sets `finding.verified`; for any refutation variant
+/// (`Refuted` / `ErrorRefuted` / `TruncationRefuted`) also clamps the confidence
+/// down to `VERIFY_REFUTED_CONFIDENCE` (0.10), below every advisory / block gate.
+/// `Confirmed` and `Skipped` leave the confidence untouched.
+/// Test: `verify_confirmed_keeps_and_block_holds`,
+/// `verify_refuted_demotes_and_block_relaxes`.
+pub fn apply_outcome(finding: &mut Finding, outcome: VerifyOutcome) {
+    let is_refutation = matches!(
+        outcome,
+        VerifyOutcome::Refuted
+            | VerifyOutcome::ErrorRefuted { .. }
+            | VerifyOutcome::TruncationRefuted
+    );
+    if is_refutation {
+        finding.confidence = VERIFY_REFUTED_CONFIDENCE;
+    }
+    finding.verified = Some(outcome);
+}
+
+/// Parse the verifier's forced JSON judgment into `Some(true)`=CONFIRMED,
+/// `Some(false)`=REFUTED, or `None` if unparseable.
+///
+/// Why: the verifier output is forced JSON `{judgment, reason}`; a robust parse
+/// (with a keyword fallback for non-structured providers) keeps the outcome
+/// deterministic.
+/// What: tries direct JSON deserialisation first; falls back to a case-insensitive
+/// keyword scan (CONFIRMED before REFUTED) so a provider that ignored the schema
+/// still produces a decision.  Returns `None` only when neither token appears.
+/// Test: `parse_judgment_confirmed`, `parse_judgment_refuted`,
+/// `parse_judgment_unparseable`.
+fn parse_judgment(text: &str) -> Option<bool> {
+    let trimmed = text.trim();
+    if let Ok(j) = serde_json::from_str::<VerifyJudgment>(trimmed) {
+        return match j.judgment.trim().to_uppercase().as_str() {
+            "CONFIRMED" => Some(true),
+            "REFUTED" => Some(false),
+            _ => None,
+        };
+    }
+    // Fallback keyword scan for providers that ignored the forced schema.
+    let upper = trimmed.to_uppercase();
+    if upper.contains("CONFIRMED") {
+        return Some(true);
+    }
+    if upper.contains("REFUTED") {
+        return Some(false);
+    }
+    None
+}
+
+// The startup liveness gate (`LivenessDecision`, `probe_verifier_liveness`)
+// lives in the sibling `verify_liveness` module to keep this file under the
+// 500-line cap.  Re-export here so callers and the verify test module reach the
+// whole verification API through one path.
+pub use crate::pipeline::verify_liveness::{LivenessDecision, probe_verifier_liveness};
+
+// ─── Signal emission (alarm hook) ────────────────────────────────────────────
+
+/// Emit the `verification_model_error` signal.
+///
+/// Why: a broken verifier model is an operational incident that must be visible.
+/// The signal is the stable, queryable event the alarm/metrics backend will key
+/// off in Phase 7.
+/// What: emits a structured `tracing::error!` with a stable `event` field and
+/// the error class/model.  This is the *only* sink today.
+///
+/// TODO(#554, Phase 7): wire this to the real metrics/alarm backend (counter +
+/// alarm). Do NOT build that backend here — this phase ships only the structured
+/// log signal. Until #554 lands, operators alarm on the `event="verification_model_error"`
+/// log line.
+/// Test: `verify_one_model_unavailable_emits_signal` (asserts the outcome, which
+/// is the observable side effect; the log line itself is side-effect-only).
+pub(crate) fn emit_verification_model_error(model: &str, error_class: &str, err: &LlmError) {
+    error!(
+        event = "verification_model_error",
+        model = %model,
+        error_class = %error_class,
+        error = %err,
+        "verifier model error — verification integrity compromised (see #554 for alarm backend)"
+    );
+}
+
+/// Map an `LlmError` to a short, stable error-class string for the signal.
+///
+/// Why: the `VerifyOutcome::ErrorRefuted` variant and the signal both carry an
+/// error class; deriving it in one place keeps them consistent.
+/// What: returns a stable PascalCase token per alarm-class variant.
+/// Test: `error_class_maps_alarm_variants`.
+pub(crate) fn error_class(err: &LlmError) -> String {
+    match err {
+        LlmError::ModelNotFound(_) => "ModelNotFound",
+        LlmError::ModelNotReady(_) => "ModelNotReady",
+        LlmError::Validation(_) => "Validation",
+        LlmError::AccessDenied(_) => "AccessDenied",
+        LlmError::Transport(_) => "Transport",
+        LlmError::RateLimited => "RateLimited",
+        LlmError::Upstream { .. } => "Upstream",
+    }
+    .to_string()
+}
+
+/// Truncate a string to `max` chars for safe logging.
+///
+/// Why: verifier output is short, but a misbehaving provider could return a wall
+/// of text; we cap it before it reaches a log line.
+/// What: returns up to `max` chars, appending `…` when truncated.
+/// Test: side-effect-only logging helper; covered transitively.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let prefix: String = s.chars().take(max).collect();
+        format!("{prefix}…")
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "verify_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/verify_liveness.rs
+++ b/crates/trusty-review/src/pipeline/verify_liveness.rs
@@ -1,0 +1,290 @@
+//! Startup verifier-model liveness gate (Phase 2, #583).
+//!
+//! Why: see the incident rationale in `pipeline::verify` — a stale verifier
+//! model that auto-refutes every finding must stop a live deployment from
+//! starting, not silently neuter every review.  This gate is split into its own
+//! module to keep `verify.rs` under the 500-line cap and to isolate the startup
+//! decision logic from the per-finding round.
+//!
+//! What: exposes `LivenessDecision` and `probe_verifier_liveness`, a cheap single
+//! verifier call whose outcome decides whether live mode may start.  Alarm-class
+//! errors (`ModelNotFound` / `ModelNotReady` / `Validation` / `AccessDenied`)
+//! refuse the start and emit the `verification_model_error` signal; transient
+//! errors and successful responses allow it.
+//!
+//! Test: `liveness_alive_allows_start`, `liveness_model_unavailable_refuses`,
+//! `liveness_access_denied_refuses`, `liveness_transient_allows_start`,
+//! `liveness_rate_limited_allows_start` in `verify_tests.rs`.
+
+use std::sync::Arc;
+
+use tracing::{debug, info, warn};
+
+use crate::{
+    config::ReviewConfig,
+    llm::LlmProvider,
+    models::{Effort, Finding},
+    pipeline::verify::{emit_verification_model_error, error_class},
+    pipeline::verify_prompt::build_verify_request,
+};
+
+/// Decision returned by `probe_verifier_liveness`.
+///
+/// Why: the caller (the `serve` / `run --live` startup path) needs a typed
+/// answer it can act on — proceed, or refuse to start with a reason — without
+/// re-classifying the raw `LlmError`.
+/// What: `Ok` means the verifier model is alive (or the probe was disabled);
+/// `Refuse` carries the human-readable reason and the error class for the signal.
+/// Test: `liveness_alive_allows_start`, `liveness_model_unavailable_refuses`,
+/// `liveness_transient_allows_start`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LivenessDecision {
+    /// The verifier model responded (or the probe was skipped) — start is allowed.
+    Ok,
+    /// The verifier model is unavailable — live mode must refuse to start.
+    Refuse {
+        /// Human-readable reason (used in the startup error message).
+        reason: String,
+        /// Error class for the `verification_model_error` signal.
+        error_class: String,
+    },
+}
+
+/// Probe the verifier model with a tiny stub call and decide whether live mode
+/// may start.
+///
+/// Why: see the `verify` module-level incident rationale — a stale verifier model
+/// must stop a live deployment from starting, not silently neuter every review.
+/// The probe is a cheap single call; the cost is negligible next to the safety it
+/// buys.
+/// What: issues a minimal verify request against a throwaway finding.  A
+/// successful response (any text) or a *transient* error (`is_retryable`) returns
+/// `Ok` — a transient blip must not block startup, the reviewer will retry per
+/// finding at run time.  Only an *alarm-class* error (`ModelNotFound` /
+/// `ModelNotReady` / `Validation` / `AccessDenied`) returns `Refuse`, after
+/// emitting the `verification_model_error` signal.
+/// Test: `liveness_alive_allows_start`, `liveness_model_unavailable_refuses`,
+/// `liveness_transient_allows_start`.
+pub async fn probe_verifier_liveness(
+    verifier: &Arc<dyn LlmProvider>,
+    verifier_model: &str,
+) -> LivenessDecision {
+    let probe_finding = stub_probe_finding();
+    // Empty diff is intentional: we only care whether the MODEL responds, not
+    // about the judgment.  The verifier will likely REFUTE (finding not in
+    // diff) — that is a perfectly healthy response and means the model is alive.
+    let req = build_verify_request(verifier_model, "", &probe_finding, None, Some(16));
+
+    match verifier.complete(req).await {
+        Ok(_) => {
+            debug!(model = %verifier_model, "verifier liveness probe: model responded — OK");
+            LivenessDecision::Ok
+        }
+        Err(e) if e.is_alarm() => {
+            let error_class = error_class(&e);
+            emit_verification_model_error(verifier_model, &error_class, &e);
+            LivenessDecision::Refuse {
+                reason: format!(
+                    "verifier model '{verifier_model}' is unavailable ({error_class}: {e}); \
+                     refusing to start in live mode. Fix the verifier model id / lifecycle \
+                     state, or disable the gate with TRUSTY_REVIEW_VERIFIER_LIVENESS_CHECK=false \
+                     (only if you accept running without verification)."
+                ),
+                error_class,
+            }
+        }
+        Err(e) => {
+            // Transient error during the probe — do not block startup; per-finding
+            // verification will retry at run time.
+            warn!(
+                model = %verifier_model,
+                "verifier liveness probe hit a transient error (allowing start): {e}"
+            );
+            LivenessDecision::Ok
+        }
+    }
+}
+
+/// Build a throwaway finding used only as the liveness-probe payload.
+///
+/// Why: the probe needs a well-formed finding to build a valid request; its
+/// content is irrelevant because we only inspect whether the model responds.
+/// What: a fixed, obviously-synthetic finding referencing a file that cannot be
+/// in any diff.
+/// Test: covered transitively by the liveness tests.
+fn stub_probe_finding() -> Finding {
+    Finding::new(
+        "__liveness_probe__",
+        "liveness",
+        "startup verifier liveness probe — not a real finding",
+        "",
+        0.5,
+        Effort::Low,
+    )
+}
+
+/// Enforce the startup verifier-model liveness gate (Phase 2, #583).
+///
+/// Why: the code-intelligence incident — a stale verifier model auto-refuting
+/// every finding — must be impossible in a live deployment.  This gate probes the
+/// verifier model at startup and refuses to start live mode when it is dead.
+/// Keeping the decision logic in the library (rather than the binary) makes it
+/// directly unit-testable with injected fake providers.
+/// What: a no-op (`Ok`) when verification or the liveness check is disabled.
+/// In live (non-dry-run) mode a missing verifier or an alarm-class probe failure
+/// returns `Err(reason)` so the daemon aborts startup; in dry-run mode the same
+/// conditions only warn and return `Ok` (a dry-run daemon never posts, so a dead
+/// verifier weakens the dry-run output but cannot corrupt a live review).
+/// Test: `enforce_disabled_is_ok`, `enforce_live_missing_verifier_refuses`,
+/// `enforce_live_model_unavailable_refuses`, `enforce_live_alive_ok`,
+/// `enforce_dry_run_model_unavailable_allows`.
+pub async fn enforce_verifier_liveness(
+    config: &ReviewConfig,
+    verifier: Option<&Arc<dyn LlmProvider>>,
+) -> Result<(), String> {
+    // Gate only applies when verification + the liveness check are both on.
+    if !config.verification.enabled || !config.verification.liveness_check {
+        return Ok(());
+    }
+    if config.dry_run {
+        info!("dry-run mode — verifier liveness gate is informational only");
+    }
+
+    let Some(verifier) = verifier else {
+        // Verification enabled but no verifier built: in live mode this is a
+        // misconfiguration; refuse.  In dry-run, warn and continue.
+        if config.dry_run {
+            warn!("no verifier provider available — dry-run continues without verification");
+            return Ok(());
+        }
+        return Err(
+            "verification is enabled but no verifier provider could be built; \
+             refusing to start in live mode"
+                .to_string(),
+        );
+    };
+
+    let model = &config.role_models.verifier.model;
+    match probe_verifier_liveness(verifier, model).await {
+        LivenessDecision::Ok => Ok(()),
+        LivenessDecision::Refuse { reason, .. } => {
+            if config.dry_run {
+                // Dry-run: surface the problem but do not block startup.
+                warn!("verifier liveness probe failed in dry-run (continuing): {reason}");
+                Ok(())
+            } else {
+                Err(reason)
+            }
+        }
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::llm::{LlmError, LlmRequest, LlmResponse};
+
+    /// A verifier that always returns a fixed result/error for gate tests.
+    struct StubVerifier {
+        err: Option<fn() -> LlmError>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for StubVerifier {
+        fn name(&self) -> &str {
+            "stub"
+        }
+        async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+            if let Some(make) = self.err {
+                return Err(make());
+            }
+            Ok(LlmResponse {
+                text: r#"{"judgment":"REFUTED"}"#.to_string(),
+                model: req.model,
+                input_tokens: 1,
+                output_tokens: 1,
+                latency_ms: 1,
+                cost_usd: 0.0,
+            })
+        }
+    }
+
+    fn alive() -> Arc<dyn LlmProvider> {
+        Arc::new(StubVerifier { err: None })
+    }
+    fn dead() -> Arc<dyn LlmProvider> {
+        Arc::new(StubVerifier {
+            err: Some(|| LlmError::ModelNotFound("stale".into())),
+        })
+    }
+
+    /// Build a config with the verification flags + dry_run set as given.
+    fn cfg(enabled: bool, liveness: bool, dry_run: bool) -> ReviewConfig {
+        let mut c = ReviewConfig::load(None);
+        c.verification.enabled = enabled;
+        c.verification.liveness_check = liveness;
+        c.dry_run = dry_run;
+        c
+    }
+
+    #[tokio::test]
+    async fn enforce_disabled_is_ok() {
+        // Verification disabled → gate is a no-op even with a dead verifier.
+        let c = cfg(false, true, false);
+        assert!(enforce_verifier_liveness(&c, Some(&dead())).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn enforce_liveness_check_off_is_ok() {
+        let c = cfg(true, false, false);
+        assert!(enforce_verifier_liveness(&c, Some(&dead())).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn enforce_live_missing_verifier_refuses() {
+        // Live mode, verification on, no verifier → refuse.
+        let c = cfg(true, true, false);
+        assert!(enforce_verifier_liveness(&c, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn enforce_live_model_unavailable_refuses() {
+        // Live mode + dead verifier model → refuse (the incident path).
+        let c = cfg(true, true, false);
+        let res = enforce_verifier_liveness(&c, Some(&dead())).await;
+        assert!(res.is_err(), "live mode must refuse a dead verifier");
+        assert!(
+            res.unwrap_err().contains("refusing to start"),
+            "error must state the refusal"
+        );
+    }
+
+    #[tokio::test]
+    async fn enforce_live_alive_ok() {
+        let c = cfg(true, true, false);
+        assert!(
+            enforce_verifier_liveness(&c, Some(&alive())).await.is_ok(),
+            "a live verifier must allow start"
+        );
+    }
+
+    #[tokio::test]
+    async fn enforce_dry_run_model_unavailable_allows() {
+        // Dry-run never posts, so a dead verifier only warns — start is allowed.
+        let c = cfg(true, true, true);
+        assert!(
+            enforce_verifier_liveness(&c, Some(&dead())).await.is_ok(),
+            "dry-run must not block startup on a dead verifier"
+        );
+    }
+
+    #[tokio::test]
+    async fn enforce_dry_run_missing_verifier_allows() {
+        let c = cfg(true, true, true);
+        assert!(enforce_verifier_liveness(&c, None).await.is_ok());
+    }
+}

--- a/crates/trusty-review/src/pipeline/verify_prompt.rs
+++ b/crates/trusty-review/src/pipeline/verify_prompt.rs
@@ -1,0 +1,185 @@
+//! Verification-round prompt construction (Phase 2, #583).
+//!
+//! Why: the per-finding verification pass needs a strict, single-purpose prompt
+//! that asks the verifier LLM for a binary CONFIRMED / REFUTED judgment on one
+//! finding at a time, mirroring the code-intelligence verifier protocol.  Keeping
+//! the prompt text and its forced-output schema in their own module keeps
+//! `verify.rs` focused on orchestration and keeps every file under the 500-line
+//! cap.
+//!
+//! What: exposes `build_verify_request` (assembles the `LlmRequest` for one
+//! finding, forcing structured `{judgment, reason}` output via the same
+//! `response_schema` mechanism the reviewer pass uses) and `VERIFY_SCHEMA_NAME`.
+//! The system prompt encodes the truncation/hallucination guard: if the finding
+//! references a file or line absent from the diff/context, the verifier MUST
+//! answer REFUTED.
+//!
+//! Test: `verify_request_contains_finding`, `verify_request_forces_schema`,
+//! `verify_schema_enumerates_judgments` in `verify_prompt_tests.rs`.
+
+use crate::{
+    llm::{ChatMessage, LlmRequest, ResponseSchema, strip_provider_prefix},
+    models::Finding,
+};
+
+// ─── Constants ──────────────────────────────────────────────────────────────────
+
+/// Temperature for the verifier role.
+///
+/// Why: the verifier must be decisive but not pinned to a single deterministic
+/// token across paraphrases; the role default (spec REV-310) is 1.0.  The
+/// caller passes the resolved role temperature, so this is only the fallback.
+/// What: matches the verifier `RoleConfig` default temperature (1.0).
+const VERIFY_TEMPERATURE: f32 = 1.0;
+
+/// Maximum output tokens for a verification call.
+///
+/// Why: the response is a single judgment plus a short reason; a tight cap keeps
+/// latency and cost low (verifier calls are high-volume).
+/// What: 64 tokens is ample for `{"judgment":"REFUTED","reason":"..."}`.
+const VERIFY_MAX_TOKENS: u32 = 64;
+
+/// Name used for the verifier's forced-output tool / json_schema.
+///
+/// Why: the Bedrock tool-use and OpenRouter json_schema paths both key off this
+/// identifier; it must be a valid identifier and stable across calls.
+/// What: a fixed snake_case string distinct from the reviewer's `review_output`.
+pub const VERIFY_SCHEMA_NAME: &str = "verification_judgment";
+
+// ─── System prompt ──────────────────────────────────────────────────────────────
+
+/// Return the verifier system prompt.
+///
+/// Why: the verifier is a *fact-checker*, not a re-reviewer — its sole job is to
+/// confirm or refute the specific finding it is handed.  Encoding the
+/// truncation/hallucination guard here (REFUTE anything that references a
+/// file/line not present in the provided diff) is the key false-positive defence
+/// borrowed from the code-intelligence verifier protocol.
+/// What: returns a static string instructing the model to emit exactly one of
+/// CONFIRMED / REFUTED with a one-line reason, and to default to REFUTED when the
+/// finding cannot be grounded in the supplied diff.
+/// Test: `verify_system_prompt_mentions_refuted_guard`.
+pub fn verifier_system_prompt() -> &'static str {
+    r#"You are a strict code-review fact-checker. You are given the unified diff of a
+pull request and ONE finding another reviewer raised about that diff. Your only
+job is to decide whether the finding is a real, defensible issue grounded in the
+diff shown.
+
+## Judgment (MANDATORY — pick exactly one)
+- CONFIRMED — the finding is real: the cited problem is actually present in the
+  diff, the failure path is plausible, and a reasonable engineer would agree it
+  needs attention.
+- REFUTED — the finding is NOT defensible: it is speculative, incorrect,
+  contradicted by the diff, or cannot be located in the diff at all.
+
+## Hard rule (truncation / hallucination guard)
+If the finding references a file or line that does NOT appear in the diff shown
+below, you MUST answer REFUTED. Do not assume context you cannot see. A finding
+about code that is not in the diff is, by definition, not verifiable and must be
+refuted. This rule is absolute — it overrides any plausibility you might infer.
+
+## Burden of proof
+The default answer is REFUTED. Answer CONFIRMED only when the diff clearly shows
+the problem the finding describes. When in doubt, REFUTE.
+
+Populate the structured response fields: `judgment` (CONFIRMED or REFUTED) and
+`reason` (one short sentence)."#
+}
+
+// ─── Output schema ───────────────────────────────────────────────────────────────
+
+/// Build the forced-output schema for a verification call.
+///
+/// Why: forcing structured output eliminates the "model answered in prose and we
+/// guessed" failure mode — the provider guarantees `LlmResponse.text` is a clean
+/// JSON object with a `judgment` enum, so a parse can never silently default.
+/// What: returns a `ResponseSchema` whose object requires `judgment` ∈
+/// {CONFIRMED, REFUTED} plus an optional one-line `reason`.
+/// Test: `verify_schema_enumerates_judgments`.
+pub fn verify_response_schema() -> ResponseSchema {
+    ResponseSchema {
+        name: VERIFY_SCHEMA_NAME.to_string(),
+        schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "judgment": {
+                    "type": "string",
+                    "enum": ["CONFIRMED", "REFUTED"],
+                    "description": "Binary verification judgment for the finding"
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "One short sentence justifying the judgment"
+                }
+            },
+            "required": ["judgment"]
+        }),
+    }
+}
+
+// ─── Request builder ─────────────────────────────────────────────────────────────
+
+/// Build the `LlmRequest` to verify a single finding against the diff.
+///
+/// Why: each finding is verified independently so a refutation of one cannot
+/// taint another; the request bundles the diff and the one finding with the
+/// forced-output schema so the verifier returns a clean judgment.
+/// What: assembles a system + user message (diff block + the finding's
+/// file/line/kind/description) and sets `response_schema` to force the binary
+/// judgment.  `verifier_model` may carry a `bedrock/`/`openrouter/` routing
+/// prefix; it is stripped before being set as the bare API model id.  The
+/// resolved role `temperature` / `max_tokens` are passed through so config
+/// overrides apply; `None` falls back to the role defaults.
+/// Test: `verify_request_contains_finding`, `verify_request_forces_schema`.
+pub fn build_verify_request(
+    verifier_model: &str,
+    diff: &str,
+    finding: &Finding,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+) -> LlmRequest {
+    let line = finding
+        .line
+        .map(|l| l.to_string())
+        .unwrap_or_else(|| "(unspecified)".to_string());
+
+    let user_message = format!(
+        "## Unified diff\n\n```diff\n{diff}\n```\n\n\
+         ## Finding to verify\n\
+         - file: `{file}`\n\
+         - line: {line}\n\
+         - kind: {kind}\n\
+         - description: {description}\n\
+         - proposed fix: {suggestion}\n\n\
+         Decide CONFIRMED or REFUTED per the rules in the system prompt. \
+         If `{file}` or line {line} does not appear in the diff above, answer REFUTED.",
+        diff = diff,
+        file = finding.file,
+        line = line,
+        kind = finding.kind,
+        description = finding.description,
+        suggestion = if finding.suggestion.is_empty() {
+            "(none)"
+        } else {
+            &finding.suggestion
+        },
+    );
+
+    LlmRequest {
+        model: strip_provider_prefix(verifier_model).to_string(),
+        system: verifier_system_prompt().to_string(),
+        messages: vec![ChatMessage {
+            role: "user".to_string(),
+            content: user_message,
+        }],
+        temperature: temperature.unwrap_or(VERIFY_TEMPERATURE),
+        max_tokens: max_tokens.unwrap_or(VERIFY_MAX_TOKENS),
+        response_schema: Some(verify_response_schema()),
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "verify_prompt_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/verify_prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_prompt_tests.rs
@@ -1,0 +1,126 @@
+//! Unit tests for `pipeline::verify_prompt`.
+//!
+//! Why: split from `verify_prompt.rs` to keep that file under the 500-line cap
+//! while fully covering the prompt assembly and forced-output schema.
+//! What: asserts the verifier request carries the finding, forces the schema,
+//! strips routing prefixes, and that the schema enumerates both judgments.
+//! Test: this is the test module.
+
+use super::*;
+use crate::models::{Effort, Finding};
+
+fn sample_finding() -> Finding {
+    let mut f = Finding::new(
+        "src/auth.rs",
+        "logic-error",
+        "off-by-one in loop bound",
+        "use <= instead of <",
+        0.8,
+        Effort::Medium,
+    );
+    f.line = Some(42);
+    f
+}
+
+#[test]
+fn verify_request_contains_finding() {
+    let diff = "+fn authenticate() {}\n";
+    let req = build_verify_request(
+        "us.anthropic.claude-haiku-4-5",
+        diff,
+        &sample_finding(),
+        None,
+        None,
+    );
+    let user = &req.messages[0].content;
+    assert!(
+        user.contains("src/auth.rs"),
+        "must mention the finding file"
+    );
+    assert!(user.contains("42"), "must mention the finding line");
+    assert!(
+        user.contains("off-by-one in loop bound"),
+        "must mention the finding description"
+    );
+    assert!(user.contains("```diff"), "must embed the diff block");
+}
+
+#[test]
+fn verify_request_forces_schema() {
+    let req = build_verify_request(
+        "us.anthropic.claude-haiku-4-5",
+        "diff",
+        &sample_finding(),
+        None,
+        None,
+    );
+    let schema = req
+        .response_schema
+        .as_ref()
+        .expect("verifier request must force structured output");
+    assert_eq!(schema.name, VERIFY_SCHEMA_NAME);
+}
+
+#[test]
+fn verify_request_strips_provider_prefix() {
+    let req = build_verify_request(
+        "bedrock/us.anthropic.claude-haiku-4-5",
+        "diff",
+        &sample_finding(),
+        None,
+        None,
+    );
+    assert_eq!(
+        req.model, "us.anthropic.claude-haiku-4-5",
+        "routing prefix must be stripped before reaching the provider"
+    );
+}
+
+#[test]
+fn verify_request_uses_role_overrides() {
+    let req = build_verify_request("m", "diff", &sample_finding(), Some(0.2), Some(128));
+    assert!((req.temperature - 0.2).abs() < f32::EPSILON);
+    assert_eq!(req.max_tokens, 128);
+}
+
+#[test]
+fn verify_request_defaults_when_no_overrides() {
+    let req = build_verify_request("m", "diff", &sample_finding(), None, None);
+    // Role defaults: temperature 1.0, tight token cap.
+    assert!((req.temperature - 1.0).abs() < f32::EPSILON);
+    assert!(req.max_tokens <= 128, "verifier output cap must stay tight");
+}
+
+#[test]
+fn verify_schema_enumerates_judgments() {
+    let schema = verify_response_schema();
+    let enum_vals = &schema.schema["properties"]["judgment"]["enum"];
+    assert_eq!(enum_vals[0], "CONFIRMED");
+    assert_eq!(enum_vals[1], "REFUTED");
+}
+
+#[test]
+fn verify_system_prompt_mentions_refuted_guard() {
+    let sys = verifier_system_prompt();
+    assert!(sys.contains("REFUTED"), "must define the REFUTED judgment");
+    assert!(
+        sys.contains("CONFIRMED"),
+        "must define the CONFIRMED judgment"
+    );
+    assert!(
+        sys.to_lowercase().contains("does not appear in the diff")
+            || sys.to_lowercase().contains("not appear in the diff"),
+        "must encode the truncation/hallucination guard"
+    );
+}
+
+#[test]
+fn verify_request_handles_missing_line() {
+    let mut f = sample_finding();
+    f.line = None;
+    let req = build_verify_request("m", "diff", &f, None, None);
+    assert!(
+        req.messages[0].content.contains("(unspecified)"),
+        "missing line must render a stable placeholder"
+    );
+}

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -1,0 +1,450 @@
+//! Unit tests for `pipeline::verify` (Phase 2, #583).
+//!
+//! Why: split from `verify.rs` to keep that file under the 500-line cap while
+//! fully covering the verification round: candidate selection per primary
+//! verdict, CONFIRMED-keeps / REFUTED-demotes outcome handling, verdict
+//! re-derivation after demotion, and the liveness-gate decision logic with an
+//! injected model-unavailable provider.
+//! What: drives the public verify API with deterministic fake providers.
+//! Test: this is the test module; each function is a self-contained unit test.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::{
+    config::constants::VERIFY_REFUTED_CONFIDENCE,
+    llm::{LlmError, LlmProvider, LlmRequest, LlmResponse},
+    models::{Effort, Finding, Verdict, VerifyOutcome},
+};
+
+// ── Deterministic fake verifier providers ─────────────────────────────────────
+
+/// A verifier that always returns the same fixed judgment text.
+struct FixedVerifier {
+    text: String,
+}
+
+impl FixedVerifier {
+    fn confirmed() -> Self {
+        Self {
+            text: r#"{"judgment":"CONFIRMED","reason":"present in diff"}"#.to_string(),
+        }
+    }
+    fn refuted() -> Self {
+        Self {
+            text: r#"{"judgment":"REFUTED","reason":"not in diff"}"#.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for FixedVerifier {
+    fn name(&self) -> &str {
+        "fixed-verifier"
+    }
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Ok(LlmResponse {
+            text: self.text.clone(),
+            model: req.model.clone(),
+            input_tokens: 10,
+            output_tokens: 5,
+            latency_ms: 1,
+            cost_usd: 0.0,
+        })
+    }
+}
+
+/// A verifier that always fails with a configurable `LlmError`.
+struct FailingVerifier {
+    make_err: fn() -> LlmError,
+}
+
+#[async_trait]
+impl LlmProvider for FailingVerifier {
+    fn name(&self) -> &str {
+        "failing-verifier"
+    }
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Err((self.make_err)())
+    }
+}
+
+fn finding(effort: Effort, confidence: f32) -> Finding {
+    let mut f = Finding::new("src/a.rs", "logic", "a bug", "fix it", confidence, effort);
+    f.line = Some(10);
+    f
+}
+
+fn confirmed_provider() -> Arc<dyn LlmProvider> {
+    Arc::new(FixedVerifier::confirmed())
+}
+fn refuted_provider() -> Arc<dyn LlmProvider> {
+    Arc::new(FixedVerifier::refuted())
+}
+
+// ── Candidate selection ───────────────────────────────────────────────────────
+
+#[test]
+fn select_candidates_block_uses_wide_net() {
+    // On a BLOCK verdict every finding ≥ 0.50 is a candidate.
+    let findings = vec![
+        finding(Effort::High, 0.95),   // candidate
+        finding(Effort::Medium, 0.55), // candidate (>= 0.50)
+        finding(Effort::Low, 0.30),    // NOT a candidate (< 0.50)
+    ];
+    let idxs = select_candidates(Verdict::Block, &findings);
+    assert_eq!(
+        idxs,
+        vec![0, 1],
+        "block verdict casts a wide net down to 0.50"
+    );
+}
+
+#[test]
+fn select_candidates_request_changes_uses_wide_net() {
+    let findings = vec![finding(Effort::Medium, 0.50), finding(Effort::Low, 0.49)];
+    let idxs = select_candidates(Verdict::RequestChanges, &findings);
+    assert_eq!(idxs, vec![0], "0.50 is included; 0.49 is excluded");
+}
+
+#[test]
+fn select_candidates_approve_uses_block_tier_only() {
+    // On an APPROVE* verdict only blocking-tier (>= 0.90) findings are verified.
+    let findings = vec![
+        finding(Effort::High, 0.92),   // candidate (>= 0.90)
+        finding(Effort::Medium, 0.80), // NOT a candidate
+        finding(Effort::Medium, 0.55), // NOT a candidate
+    ];
+    let idxs = select_candidates(Verdict::ApproveWithReservations, &findings);
+    assert_eq!(
+        idxs,
+        vec![0],
+        "approve verdict only verifies block-tier findings"
+    );
+
+    let idxs_plain = select_candidates(Verdict::Approve, &findings);
+    assert_eq!(idxs_plain, vec![0], "plain APPROVE behaves the same");
+}
+
+#[test]
+fn select_candidates_unknown_is_empty() {
+    let findings = vec![finding(Effort::High, 0.99)];
+    assert!(select_candidates(Verdict::Unknown, &findings).is_empty());
+}
+
+// ── Outcome application ───────────────────────────────────────────────────────
+
+#[test]
+fn apply_outcome_confirmed_keeps_confidence() {
+    let mut f = finding(Effort::High, 0.95);
+    apply_outcome(&mut f, VerifyOutcome::Confirmed);
+    assert!(
+        (f.confidence - 0.95).abs() < f32::EPSILON,
+        "CONFIRMED keeps confidence"
+    );
+    assert!(matches!(f.verified, Some(VerifyOutcome::Confirmed)));
+}
+
+#[test]
+fn apply_outcome_refuted_demotes_below_advisory() {
+    let mut f = finding(Effort::High, 0.95);
+    apply_outcome(&mut f, VerifyOutcome::Refuted);
+    assert!(
+        (f.confidence - VERIFY_REFUTED_CONFIDENCE).abs() < f32::EPSILON,
+        "REFUTED demotes confidence below the advisory tier"
+    );
+    assert!(matches!(f.verified, Some(VerifyOutcome::Refuted)));
+}
+
+#[test]
+fn apply_outcome_error_refuted_also_demotes() {
+    let mut f = finding(Effort::High, 0.95);
+    apply_outcome(
+        &mut f,
+        VerifyOutcome::ErrorRefuted {
+            error_class: "ModelNotFound".to_string(),
+        },
+    );
+    assert!((f.confidence - VERIFY_REFUTED_CONFIDENCE).abs() < f32::EPSILON);
+    assert!(matches!(
+        f.verified,
+        Some(VerifyOutcome::ErrorRefuted { .. })
+    ));
+}
+
+// ── Verdict re-derivation (refuted exclusion) ─────────────────────────────────
+
+#[test]
+fn rederive_excludes_refuted_relaxes() {
+    // One High finding, refuted, NO candidate confirmed → excluded + neutral
+    // baseline → APPROVE.
+    let mut f = finding(Effort::High, 0.95);
+    apply_outcome(&mut f, VerifyOutcome::Refuted);
+    let verdict = rederive_verdict(Verdict::Block, false, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "a refuted-only candidate set must not contribute a BLOCK floor"
+    );
+}
+
+#[test]
+fn rederive_keeps_confirmed_block() {
+    // One High finding, confirmed → survives → BLOCK floor.
+    let mut f = finding(Effort::High, 0.95);
+    apply_outcome(&mut f, VerifyOutcome::Confirmed);
+    let verdict = rederive_verdict(Verdict::Block, true, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a confirmed High finding must keep the BLOCK floor"
+    );
+}
+
+#[test]
+fn rederive_confirmed_preserves_model_escalation() {
+    // Model escalated to REQUEST_CHANGES on a single confirmed Medium finding.
+    // Because a candidate was confirmed, the model's escalation is preserved
+    // even though the lone-Medium floor alone is only APPROVE*.
+    let mut med = finding(Effort::Medium, 0.85);
+    apply_outcome(&mut med, VerifyOutcome::Confirmed);
+    let verdict = rederive_verdict(Verdict::RequestChanges, true, &[med]);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "confirmed evidence keeps the model's escalation as a lower bound"
+    );
+}
+
+#[test]
+fn rederive_mixed_keeps_only_surviving_floor() {
+    // High refuted + one surviving confirmed Medium, model said BLOCK.
+    // any_confirmed=true → baseline is the model BLOCK, but the BLOCK was driven
+    // by the now-refuted High... this asserts the documented trade-off: with a
+    // confirmed candidate the model's BLOCK is preserved as a lower bound.
+    let mut high = finding(Effort::High, 0.95);
+    apply_outcome(&mut high, VerifyOutcome::Refuted);
+    let mut med = finding(Effort::Medium, 0.85);
+    apply_outcome(&mut med, VerifyOutcome::Confirmed);
+    let verdict = rederive_verdict(Verdict::ApproveWithReservations, true, &[high, med]);
+    assert_eq!(
+        verdict,
+        Verdict::ApproveWithReservations,
+        "surviving single Medium floors to APPROVE*; refuted High is excluded"
+    );
+}
+
+// ── End-to-end verification round ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn verify_confirmed_keeps_and_block_holds() {
+    // A single High-effort, high-confidence finding that the verifier CONFIRMS:
+    // confidence is kept and the BLOCK verdict holds.
+    let verifier = confirmed_provider();
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round(
+        &verifier,
+        "us.anthropic.claude-haiku-4-5",
+        "+ some diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "confirmed High finding must hold BLOCK"
+    );
+    assert!(matches!(
+        findings[0].verified,
+        Some(VerifyOutcome::Confirmed)
+    ));
+    assert!((findings[0].confidence - 0.95).abs() < f32::EPSILON);
+}
+
+#[tokio::test]
+async fn verify_refuted_demotes_and_block_relaxes() {
+    // The ONLY blocking finding is REFUTED → demoted → derive_verdict relaxes
+    // from BLOCK down to APPROVE (no substantive findings remain).
+    let verifier = refuted_provider();
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round(
+        &verifier,
+        "us.anthropic.claude-haiku-4-5",
+        "+ some diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "refuting the only blocking finding must relax BLOCK to APPROVE"
+    );
+    assert!(matches!(findings[0].verified, Some(VerifyOutcome::Refuted)));
+    assert!(
+        (findings[0].confidence - VERIFY_REFUTED_CONFIDENCE).abs() < f32::EPSILON,
+        "refuted finding is demoted, not dropped"
+    );
+}
+
+#[tokio::test]
+async fn verify_no_candidates_is_noop() {
+    // APPROVE verdict with only sub-block-tier findings → no candidates → the
+    // findings are untouched and the verdict re-derives unchanged.
+    let verifier = refuted_provider(); // would refute, but is never called
+    let mut findings = vec![finding(Effort::Low, 0.40)];
+    let verdict = run_verification_round(
+        &verifier,
+        "m",
+        "diff",
+        Verdict::Approve,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(verdict, Verdict::Approve);
+    assert!(
+        findings[0].verified.is_none(),
+        "no candidate must stay unverified"
+    );
+    assert!((findings[0].confidence - 0.40).abs() < f32::EPSILON);
+}
+
+#[tokio::test]
+async fn verify_unknown_is_passthrough() {
+    let verifier = refuted_provider();
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round(
+        &verifier,
+        "m",
+        "diff",
+        Verdict::Unknown,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(
+        verdict,
+        Verdict::Unknown,
+        "UNKNOWN passes through untouched"
+    );
+    assert!(findings[0].verified.is_none(), "UNKNOWN must not verify");
+}
+
+#[tokio::test]
+async fn verify_model_unavailable_marks_error_refuted_and_relaxes() {
+    // The verifier model is unavailable (ModelNotFound). The finding must be
+    // ErrorRefuted (NOT silently confirmed), demoted, and the verdict relaxes.
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
+        make_err: || LlmError::ModelNotFound("stale-verifier".to_string()),
+    });
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round(
+        &verifier,
+        "stale-verifier",
+        "+ diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        matches!(
+            findings[0].verified,
+            Some(VerifyOutcome::ErrorRefuted { .. })
+        ),
+        "a model error must record ErrorRefuted, not a plain refutation/confirmation"
+    );
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "an unverifiable (model-down) finding must not be allowed to keep blocking"
+    );
+}
+
+// ── Liveness gate decision logic ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn liveness_alive_allows_start() {
+    // The verifier responds (any text) → Ok.
+    let verifier = confirmed_provider();
+    let decision = probe_verifier_liveness(&verifier, "us.anthropic.claude-haiku-4-5").await;
+    assert_eq!(
+        decision,
+        LivenessDecision::Ok,
+        "a responding model allows start"
+    );
+}
+
+#[tokio::test]
+async fn liveness_model_unavailable_refuses() {
+    // ModelNotFound is an alarm-class error → Refuse (the incident path).
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
+        make_err: || LlmError::ModelNotFound("no-such-profile".to_string()),
+    });
+    let decision = probe_verifier_liveness(&verifier, "no-such-profile").await;
+    match decision {
+        LivenessDecision::Refuse {
+            error_class,
+            reason,
+        } => {
+            assert_eq!(error_class, "ModelNotFound");
+            assert!(reason.contains("no-such-profile"), "reason names the model");
+            assert!(
+                reason.contains("refusing to start"),
+                "reason must state the refusal"
+            );
+        }
+        LivenessDecision::Ok => panic!("an unavailable verifier model must refuse start"),
+    }
+}
+
+#[tokio::test]
+async fn liveness_access_denied_refuses() {
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
+        make_err: || LlmError::AccessDenied("bad iam".to_string()),
+    });
+    let decision = probe_verifier_liveness(&verifier, "m").await;
+    assert!(
+        matches!(decision, LivenessDecision::Refuse { .. }),
+        "AccessDenied is alarm-class and must refuse start"
+    );
+}
+
+#[tokio::test]
+async fn liveness_transient_allows_start() {
+    // A transient error during the probe must NOT block startup — per-finding
+    // verification will retry at run time.
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
+        make_err: || LlmError::Transport("connection reset".to_string()),
+    });
+    let decision = probe_verifier_liveness(&verifier, "m").await;
+    assert_eq!(
+        decision,
+        LivenessDecision::Ok,
+        "a transient probe error must not block startup"
+    );
+}
+
+#[tokio::test]
+async fn liveness_rate_limited_allows_start() {
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
+        make_err: || LlmError::RateLimited,
+    });
+    let decision = probe_verifier_liveness(&verifier, "m").await;
+    assert_eq!(
+        decision,
+        LivenessDecision::Ok,
+        "rate-limit during probe is transient"
+    );
+}

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -43,6 +43,9 @@ pub struct AppState {
     pub config: ReviewConfig,
     /// LLM provider (reviewer role).
     pub llm: Arc<dyn LlmProvider>,
+    /// LLM provider (verifier role, Phase 2 #583).  `None` disables the
+    /// verification round for service-path reviews.
+    pub verifier: Option<Arc<dyn LlmProvider>>,
     /// Code search client.
     pub search: Arc<dyn SearchClient>,
     /// Static analysis client (optional — `None` skips the analyze step).
@@ -90,9 +93,30 @@ impl AppState {
         analyze: Option<Arc<dyn AnalyzeClient>>,
         dedup: Option<Arc<DedupStore>>,
     ) -> Self {
+        Self::with_verifier_and_dedup(config, llm, None, search, analyze, dedup)
+    }
+
+    /// Construct `AppState` with an explicit verifier provider and dedup store.
+    ///
+    /// Why: the deployed `serve` daemon builds a verifier provider (Phase 2,
+    /// #583) so the verification round runs on webhook-driven reviews; this
+    /// constructor threads it in alongside the dedup store.  The simpler `new` /
+    /// `with_dedup` constructors keep `verifier = None` for tests and callers
+    /// that do not exercise verification.
+    /// What: like `with_dedup`, but takes the verifier provider explicitly.
+    /// Test: exercised by the `serve` path; unit tests use `new` (verifier None).
+    pub fn with_verifier_and_dedup(
+        config: ReviewConfig,
+        llm: Arc<dyn LlmProvider>,
+        verifier: Option<Arc<dyn LlmProvider>>,
+        search: Arc<dyn SearchClient>,
+        analyze: Option<Arc<dyn AnalyzeClient>>,
+        dedup: Option<Arc<DedupStore>>,
+    ) -> Self {
         Self {
             config,
             llm,
+            verifier,
             search,
             analyze,
             in_flight: Arc::new(AtomicU64::new(0)),
@@ -286,6 +310,7 @@ pub async fn handle_review(
 
     let deps = ReviewDeps {
         llm: Arc::clone(&state.llm),
+        verifier: state.verifier.clone(),
         search: Arc::clone(&state.search),
         analyze: state.analyze.clone(),
         // POST /review is a synchronous inspection endpoint — no dedup needed.

--- a/crates/trusty-review/src/service/webhook.rs
+++ b/crates/trusty-review/src/service/webhook.rs
@@ -258,6 +258,7 @@ pub async fn handle_github_webhook(
 
         let deps = ReviewDeps {
             llm: Arc::clone(&state_clone.llm),
+            verifier: state_clone.verifier.clone(),
             search: Arc::clone(&state_clone.search),
             analyze: state_clone.analyze.clone(),
             dedup: state_clone.dedup.clone(),


### PR DESCRIPTION
## Phase 2 of the trusty-review build-out (closes #583)

Adds a per-finding **verification round** — a cheaper second LLM pass that confirms or refutes each candidate finding before posting — to cut false-positive `REQUEST_CHANGES`/`BLOCK` verdicts. Builds directly on Phase 1 (#582).

### Verification flow (`pipeline/verify.rs`)
1. After the reviewer pass + severity-anchored grade, candidate findings are selected (see below).
2. Each candidate is verified **concurrently (bounded, 4-way)** against the **verifier role** model (Haiku by default, already config-selectable via `TRUSTY_REVIEW_VERIFIER_MODEL` / `[models.verifier]`), using forced structured `CONFIRMED`/`REFUTED` output (same Bedrock tool-use / OpenRouter `json_schema` mechanism the reviewer pass uses).
3. Outcome handling:
   - **CONFIRMED** → keep the finding's confidence.
   - **REFUTED** → demote confidence to `0.10` (below every advisory/block gate) and record `VerifyOutcome::Refuted` on the finding — **never silently dropped**.
   - Verifier **config/lifecycle error** (`ModelNotFound`/`ModelNotReady`/`Validation`/`AccessDenied`) → `VerifyOutcome::ErrorRefuted { error_class }` **and** emits the `verification_model_error` signal (not swallowed as a plain refutation).
   - Transient verifier error → conservatively `Refuted` (an unverifiable finding must not keep blocking), no alarm.
4. **Truncation/hallucination guard:** the verifier prompt (`verify_prompt.rs`) instructs the model to `REFUTED` any finding referencing a file/line absent from the diff (mirrors code-intelligence).
5. **Verdict re-derivation:** the final verdict is re-derived from the *surviving (non-refuted)* findings via `grade.rs::derive_verdict`, so a `BLOCK` whose only blocking finding was `REFUTED` falls back to `APPROVE`; if a candidate was confirmed, the model's escalation is preserved as a lower bound.

Wired into `runner.rs` **between verdict parse and `post::finalize_review`**. Skippable via `[verification] enabled = true/false` (default true; env `TRUSTY_REVIEW_VERIFICATION_ENABLED`).

### Candidate selection (`select_candidates`)
- Primary verdict **REQUEST_CHANGES / BLOCK** → verify every finding `≥ VERIFY_CANDIDATE_MIN_CONFIDENCE` (0.50) — wide net, since a moderate-confidence finding could be the sole reason for the block.
- Primary verdict **APPROVE / APPROVE\*** → verify only blocking-tier findings (`≥ BLOCK_VERDICT_MIN_CONFIDENCE`, 0.90).

### Startup verifier-model liveness gate (`pipeline/verify_liveness.rs`)
On `serve` startup in **live** mode, a cheap verifier-model probe runs. If the model is unavailable (alarm-class error), the daemon **refuses to start** with a clear error and emits `verification_model_error`. In dry-run mode the probe is informational only. Independently toggleable via `TRUSTY_REVIEW_VERIFIER_LIVENESS_CHECK`.

**Incident rationale (in a doc comment):** code-intelligence had a production incident where a **stale verifier model** caused every verification call to fail → every finding was silently auto-`REFUTED` → every review collapsed to `APPROVE`, neutering the reviewer with no visible signal. This gate exists specifically to make that failure mode loud.

`verification_model_error` is a structured `tracing::error!` signal **only**; the real metrics/alarm backend is left as a clearly-marked `TODO(#554, Phase 7)` hook — not built here.

### Test evidence
```
test result: ok. 369 passed; 0 failed; 1 ignored   (lib)
test result: ok.   8 passed; 0 failed; 0 ignored   (bin)
clippy -p trusty-review --all-targets -- -D warnings : clean
cargo fmt --check : clean
cargo check --no-default-features : ok
cargo check --features http-server : ok
```
New coverage: candidate selection per primary verdict; CONFIRMED-keeps / REFUTED-demotes; verdict re-derivation after demotion; model-unavailable → `ErrorRefuted` + verdict relaxes; and the liveness-gate decision logic (fake provider returns model-unavailable → live mode refused; dry-run allowed; transient/rate-limit allowed).

### File splits (500-line cap)
New focused modules: `pipeline/verify.rs`, `verify_liveness.rs`, `verify_tests.rs`, `runner_context.rs` (extracted `gather_context`), `config/verification.rs`, `cli_verify.rs`. All new files < 500 lines.

> Caveat: `crates/trusty-review/src/main.rs` is 718 lines — it was already a pre-existing >500 violation at the branch base (698 lines); this PR added ~20 net lines after extracting the verifier builders into `cli_verify.rs`. Recommend a separate refactor ticket to split `main.rs` (subcommand handlers).

### Deferred (out of scope; stubs re-pointed to the right phase)
- Suppression / per-repo `.github/code-intelligence.yml` — Phase 3 (#584)
- Review-disposition sink refactor — Phase 4 (#585)
- JIRA/Confluence/APEX/GH-Issues context — Phase 6 (#550)
- Real metrics/alarm backend — Phase 7 (#554) — only the structured-log signal + TODO hook here

🤖 Generated with [Claude Code](https://claude.com/claude-code)