### PR TITLE
fix(trusty-review): require trusty-search + trusty-analyze context; skip/fail loudly instead of context-free review (closes #590)

### DIFF
--- a/crates/trusty-review/src/config/context.rs
+++ b/crates/trusty-review/src/config/context.rs
@@ -1,0 +1,225 @@
+//! Context-dependency requirement configuration (#590).
+//!
+//! Why: trusty-review's entire value is the context it injects from
+//! trusty-search (code context) and trusty-analyze (static analysis).  A review
+//! produced WITHOUT that context is actively harmful — it gives false confidence
+//! from a verdict that never saw the project.  So both dependencies are REQUIRED
+//! by default; if either is unreachable the review must skip/fail loudly rather
+//! than silently degrade.  This struct holds the two opt-out knobs an operator
+//! can flip (to `false`) to explicitly allow a clearly-labelled degraded run.
+//!
+//! What: exposes `ContextConfig` (`require_search`, `require_analyze`, both
+//! defaulting to `true`) and its TOML-deserialisable mirror
+//! `ContextFileConfig`.  `from_env_and_file` resolves env-over-file-over-default
+//! precedence, matching the rest of the config module.
+//!
+//! Test: `context_defaults_required`, `context_env_relaxes_search`,
+//! `context_file_relaxes_analyze`, `context_env_beats_file` in this module.
+
+use serde::Deserialize;
+use tracing::warn;
+
+/// Environment variable that toggles whether trusty-search is a hard requirement.
+///
+/// Why: operators need a discoverable single switch to opt into a degraded run
+/// (e.g. an air-gapped CI box with no search daemon) without editing TOML.
+/// What: any of `false`/`0`/`no`/`off` (case-insensitive) relaxes the
+/// requirement; anything else (or unset) leaves the file / default value (true).
+const ENV_REQUIRE_SEARCH: &str = "TRUSTY_REVIEW_REQUIRE_SEARCH";
+
+/// Environment variable that toggles whether trusty-analyze is a hard requirement.
+///
+/// Why: same opt-out as `ENV_REQUIRE_SEARCH`, scoped to the analyze sidecar.
+/// What: same truthiness parsing as `ENV_REQUIRE_SEARCH`.
+const ENV_REQUIRE_ANALYZE: &str = "TRUSTY_REVIEW_REQUIRE_ANALYZE";
+
+/// Resolved configuration for the required-context gate.
+///
+/// Why: the runner reads these flags before gathering context to decide whether
+/// a missing dependency aborts the review (required) or merely tags it degraded
+/// (opted out).  A single owned struct keeps the decision logic free of scattered
+/// env lookups and makes the behaviour trivially testable (construct it directly).
+/// What: `require_search` / `require_analyze` each gate one dependency.  Both
+/// default to `true` (safe-by-default: refuse to review without context).
+/// Test: `context_defaults_required`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextConfig {
+    /// When `true` (default), an unreachable/unhealthy trusty-search skips the
+    /// review instead of proceeding with no code context.
+    pub require_search: bool,
+    /// When `true` (default), an unreachable/unhealthy trusty-analyze skips the
+    /// review instead of proceeding with no static-analysis context.
+    pub require_analyze: bool,
+}
+
+impl Default for ContextConfig {
+    /// Why: the safe default is "both required" so a missing dependency fails
+    /// loudly rather than silently producing a context-free, false-confidence
+    /// verdict (#590 binding premise).
+    /// What: both flags `true`.
+    /// Test: `context_defaults_required`.
+    fn default() -> Self {
+        Self {
+            require_search: true,
+            require_analyze: true,
+        }
+    }
+}
+
+impl ContextConfig {
+    /// Resolve from env vars layered over an optional `[context]` TOML table.
+    ///
+    /// Why: matches the rest of the config module's env-over-file-over-default
+    /// precedence so operators have one mental model for every knob.
+    /// What: starts from the file value (or default `true`), then applies env
+    /// overrides.  Unrecognised env values are ignored with a warning (fail
+    /// closed: keep the stricter file/default value rather than silently
+    /// relaxing a safety gate).
+    /// Test: `context_env_relaxes_search`, `context_file_relaxes_analyze`,
+    /// `context_env_beats_file`.
+    pub fn from_env_and_file(file: Option<&ContextFileConfig>) -> Self {
+        let mut cfg = ContextConfig {
+            require_search: file.and_then(|f| f.require_search).unwrap_or(true),
+            require_analyze: file.and_then(|f| f.require_analyze).unwrap_or(true),
+        };
+        if let Some(v) = parse_bool_env(ENV_REQUIRE_SEARCH) {
+            cfg.require_search = v;
+        }
+        if let Some(v) = parse_bool_env(ENV_REQUIRE_ANALYZE) {
+            cfg.require_analyze = v;
+        }
+        cfg
+    }
+}
+
+/// TOML-deserialisable `[context]` table (all fields optional).
+///
+/// Why: the config file may set neither, either, or both flags; optional fields
+/// let an absent key fall through to the env / default layer.
+/// What: an optional-field mirror of `ContextConfig` used only during config-file
+/// parsing.
+/// Test: covered by `context_file_relaxes_analyze` via `from_env_and_file`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ContextFileConfig {
+    /// `[context] require_search = false` opts into a degraded run when search
+    /// is unavailable.
+    pub require_search: Option<bool>,
+    /// `[context] require_analyze = false` opts into a degraded run when analyze
+    /// is unavailable.
+    pub require_analyze: Option<bool>,
+}
+
+/// Parse a boolean env var with lenient truthiness, or `None` if unset/empty.
+///
+/// Why: env-var booleans come in many spellings; centralising the parse keeps
+/// the two flags consistent and avoids silently treating `"false"` as truthy.
+/// What: returns `Some(false)` for `false`/`0`/`no`/`off`, `Some(true)` for
+/// `true`/`1`/`yes`/`on`, `None` for unset/empty, and `None` (with a warning)
+/// for anything unrecognised.
+/// Test: covered indirectly by `context_env_relaxes_search`.
+fn parse_bool_env(var: &str) -> Option<bool> {
+    let raw = std::env::var(var).ok()?;
+    let v = raw.trim().to_lowercase();
+    if v.is_empty() {
+        return None;
+    }
+    match v.as_str() {
+        "false" | "0" | "no" | "off" => Some(false),
+        "true" | "1" | "yes" | "on" => Some(true),
+        other => {
+            warn!("unrecognised boolean for {var}: {other:?} — ignoring");
+            None
+        }
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear_env() {
+        unsafe {
+            std::env::remove_var(ENV_REQUIRE_SEARCH);
+            std::env::remove_var(ENV_REQUIRE_ANALYZE);
+        }
+    }
+
+    #[test]
+    fn context_defaults_required() {
+        let cfg = ContextConfig::default();
+        assert!(cfg.require_search, "search must default to REQUIRED");
+        assert!(cfg.require_analyze, "analyze must default to REQUIRED");
+    }
+
+    #[test]
+    #[serial]
+    fn context_env_relaxes_search() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_REQUIRE_SEARCH, "false");
+        }
+        let cfg = ContextConfig::from_env_and_file(None);
+        assert!(
+            !cfg.require_search,
+            "env false must relax search requirement"
+        );
+        assert!(cfg.require_analyze, "analyze untouched by search var");
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn context_file_relaxes_analyze() {
+        clear_env();
+        let file = ContextFileConfig {
+            require_search: None,
+            require_analyze: Some(false),
+        };
+        let cfg = ContextConfig::from_env_and_file(Some(&file));
+        assert!(cfg.require_search, "search stays required by default");
+        assert!(
+            !cfg.require_analyze,
+            "file false must relax analyze requirement"
+        );
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn context_env_beats_file() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_REQUIRE_SEARCH, "true");
+        }
+        // File says relaxed, env says required → env wins (fail closed).
+        let file = ContextFileConfig {
+            require_search: Some(false),
+            require_analyze: None,
+        };
+        let cfg = ContextConfig::from_env_and_file(Some(&file));
+        assert!(cfg.require_search, "env true must override file false");
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn context_unrecognised_env_keeps_file_value() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_REQUIRE_ANALYZE, "maybe");
+        }
+        let file = ContextFileConfig {
+            require_search: None,
+            require_analyze: Some(false),
+        };
+        let cfg = ContextConfig::from_env_and_file(Some(&file));
+        assert!(
+            !cfg.require_analyze,
+            "unrecognised env must fall through to file value"
+        );
+        clear_env();
+    }
+}

--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -14,9 +14,11 @@
 //! module; `ReviewConfig` env-loading is covered by `test_config_from_env`.
 
 pub mod constants;
+pub mod context;
 pub mod role_models;
 pub mod verification;
 
+pub use context::{ContextConfig, ContextFileConfig};
 pub use role_models::{
     FileModels, RoleCliOverrides, RoleConfig, RoleConfigOverride, RoleEnv, RoleModels,
 };
@@ -79,6 +81,8 @@ struct TomlFile {
     models: FileModels,
     #[serde(default)]
     verification: VerificationFileConfig,
+    #[serde(default)]
+    context: ContextFileConfig,
 }
 
 /// Global service configuration for trusty-review.
@@ -157,6 +161,12 @@ pub struct ReviewConfig {
     // ── Verification round (Phase 2, #583) ─────────────────────────────────
     /// Resolved verification-round settings (`enabled`, `liveness_check`).
     pub verification: VerificationConfig,
+
+    // ── Required-context gate (#590) ───────────────────────────────────────
+    /// Resolved required-context settings (`require_search`, `require_analyze`).
+    /// Both default to `true`: a missing dependency skips the review rather than
+    /// degrading to a context-free verdict.
+    pub context: ContextConfig,
 }
 
 impl ReviewConfig {
@@ -179,10 +189,12 @@ impl ReviewConfig {
         let toml_file = load_toml_file(config_path);
         let file_models = toml_file.as_ref().map(|f| f.models.clone());
         let file_verification = toml_file.as_ref().map(|f| f.verification.clone());
+        let file_context = toml_file.as_ref().map(|f| f.context.clone());
 
         let env = RoleEnv::from_env();
         let role_models = RoleModels::resolve(cli_overrides, &env, file_models.as_ref());
         let verification = VerificationConfig::from_env_and_file(file_verification.as_ref());
+        let context = ContextConfig::from_env_and_file(file_context.as_ref());
 
         let dry_run = std::env::var("PR_INTELLIGENCE_DRY_RUN")
             .map(|v| v.to_lowercase() != "false")
@@ -229,6 +241,7 @@ impl ReviewConfig {
                 .unwrap_or_else(|| "trusty-review[bot]".to_string()),
             live_review_requesters: load_live_review_requesters(),
             verification,
+            context,
         }
     }
 

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -292,6 +292,19 @@ async fn cmd_run(config: ReviewConfig, args: RunArgs) -> Result<()> {
         eprintln!("\nLog written to: {}", log_path.display());
     }
 
+    // Required-context gate (#590): a skipped review produced NO real verdict
+    // because trusty-search / trusty-analyze was unavailable.  Exit non-zero with
+    // the actionable reason so callers (and CI) never mistake a skip for a pass.
+    if result.status.is_skipped() {
+        anyhow::bail!(
+            "review skipped — {}",
+            result
+                .error
+                .as_deref()
+                .unwrap_or("required code-context dependency unavailable")
+        );
+    }
+
     Ok(())
 }
 

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -11,6 +11,9 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod status;
+pub use status::ReviewStatus;
+
 use crate::config::constants::REVIEW_VERSION;
 
 // ─── Verdict ──────────────────────────────────────────────────────────────────
@@ -250,6 +253,10 @@ pub struct ReviewResult {
     pub latency_ms: u64,
 
     // ── Pipeline flags ────────────────────────────────────────────────────
+    /// Run status — `Completed` (authoritative), `Skipped` (required context
+    /// dep down; no verdict), or `Degraded` (opted-in context-free, #590).
+    #[serde(default)]
+    pub status: ReviewStatus,
     /// True if this is a dry run (no GitHub comment posted).
     pub dry_run: bool,
     /// True if the review comment was posted to GitHub.
@@ -299,6 +306,7 @@ impl ReviewResult {
             output_tokens: 0,
             cost_estimate_usd: 0.0,
             latency_ms: 0,
+            status: ReviewStatus::Completed,
             dry_run: true,
             posted: false,
             // Simple ISO-8601 without the chrono dep for Stage 1.

--- a/crates/trusty-review/src/models/status.rs
+++ b/crates/trusty-review/src/models/status.rs
@@ -1,0 +1,104 @@
+//! Review run status — distinguishes an authoritative verdict from a skip or a
+//! loudly-labelled degraded run (#590).
+//!
+//! Why: trusty-review's value is the code/static-analysis context it injects.  A
+//! review produced WITHOUT that context is actively harmful (false confidence).
+//! When a REQUIRED dependency (trusty-search / trusty-analyze) is unavailable the
+//! pipeline must NOT emit a normal verdict — it must skip loudly.  And when an
+//! operator explicitly opts into a degraded run, the result must be visibly
+//! non-authoritative.  A typed status field lets every sink (CLI exit code, the
+//! `/review` JSON, the webhook) make that distinction without string-matching the
+//! free-form `error` field.
+//!
+//! What: `ReviewStatus` with `Completed` (authoritative), `Skipped` (a required
+//! dependency was unavailable — no verdict was produced), and `Degraded` (an
+//! opted-in context-free run whose verdict is explicitly non-authoritative).
+//! Serialises `snake_case`.
+//!
+//! Test: `review_status_serde_roundtrip`, `review_status_is_authoritative`.
+
+use serde::{Deserialize, Serialize};
+
+/// Outcome class of a review run.
+///
+/// Why: callers need to branch on whether the verdict is trustworthy: a skipped
+/// run has no real verdict (the CLI should exit non-zero, the service should not
+/// post), and a degraded run carries a verdict that must be flagged as
+/// non-authoritative.  A clean APPROVE and a context-free APPROVE must never be
+/// indistinguishable.
+/// What: three variants; `Completed` is the default so existing call-sites and
+/// deserialised older logs read as authoritative.
+/// Test: `review_status_serde_roundtrip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewStatus {
+    /// The review ran with full required context; the verdict is authoritative.
+    #[default]
+    Completed,
+    /// A REQUIRED context dependency (trusty-search / trusty-analyze) was
+    /// unavailable, so the review was skipped — NO verdict was produced.  This is
+    /// not an APPROVE; the caller must surface the skip (non-zero exit / no post).
+    Skipped,
+    /// The review ran WITHOUT a required context dependency because the operator
+    /// explicitly opted out (`require_search`/`require_analyze = false`).  The
+    /// verdict is present but explicitly NON-AUTHORITATIVE and loudly labelled.
+    Degraded,
+}
+
+impl ReviewStatus {
+    /// Returns `true` only for `Completed` — a verdict produced with full context.
+    ///
+    /// Why: sinks gate posting/exit codes on authoritativeness; centralising the
+    /// check avoids each call-site re-deriving the rule.
+    /// What: `matches!(self, Completed)`.
+    /// Test: `review_status_is_authoritative`.
+    pub fn is_authoritative(&self) -> bool {
+        matches!(self, ReviewStatus::Completed)
+    }
+
+    /// Returns `true` when no real verdict was produced (a required dep was down).
+    ///
+    /// Why: the CLI must exit non-zero and the service must not post a skipped
+    /// review; this is the single predicate both paths consult.
+    /// What: `matches!(self, Skipped)`.
+    /// Test: `review_status_is_authoritative`.
+    pub fn is_skipped(&self) -> bool {
+        matches!(self, ReviewStatus::Skipped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_status_serde_roundtrip() {
+        let cases = [
+            (ReviewStatus::Completed, "\"completed\""),
+            (ReviewStatus::Skipped, "\"skipped\""),
+            (ReviewStatus::Degraded, "\"degraded\""),
+        ];
+        for (status, expected) in cases {
+            let json = serde_json::to_string(&status).expect("serialise");
+            assert_eq!(json, expected, "serialise mismatch for {status:?}");
+            let back: ReviewStatus = serde_json::from_str(&json).expect("deserialise");
+            assert_eq!(back, status);
+        }
+    }
+
+    #[test]
+    fn review_status_default_is_completed() {
+        assert_eq!(ReviewStatus::default(), ReviewStatus::Completed);
+    }
+
+    #[test]
+    fn review_status_is_authoritative() {
+        assert!(ReviewStatus::Completed.is_authoritative());
+        assert!(!ReviewStatus::Skipped.is_authoritative());
+        assert!(!ReviewStatus::Degraded.is_authoritative());
+
+        assert!(ReviewStatus::Skipped.is_skipped());
+        assert!(!ReviewStatus::Completed.is_skipped());
+        assert!(!ReviewStatus::Degraded.is_skipped());
+    }
+}

--- a/crates/trusty-review/src/pipeline/context_gate.rs
+++ b/crates/trusty-review/src/pipeline/context_gate.rs
@@ -1,0 +1,155 @@
+//! Required-context preflight gate (#590).
+//!
+//! Why: trusty-review's entire value is the context it injects from trusty-search
+//! (code context) and trusty-analyze (static analysis).  A review produced
+//! WITHOUT that context is actively harmful — it gives false confidence from a
+//! verdict that never saw the project.  So before any review subject (PR review,
+//! local-diff review, and the forward-compatible commit-review of #589) gathers
+//! context, this gate probes both dependencies.  If a REQUIRED dependency is
+//! unreachable the review is SKIPPED loudly with an actionable error; if an
+//! operator explicitly opted out (`require_*` = false) the run proceeds but is
+//! tagged DEGRADED / non-authoritative.
+//!
+//! What: `preflight_context` probes `SearchClient::health` and
+//! `AnalyzeClient::has_analysis` concurrently and folds the two `require_*` flags
+//! into a single `GateOutcome`: `Proceed`, `Skip(reason)`, or `Degraded(reason)`.
+//! The gate lives here (not inline in the runner) so every subject goes through
+//! the same code path and `runner.rs` stays under the 500-line cap.
+//!
+//! Test: `gate_tests.rs` drives every (require × reachable) combination with
+//! injected fakes; the `#[ignore]`-free unit tests need no network.
+
+use tracing::{info, warn};
+
+use crate::{config::ReviewConfig, pipeline::runner::ReviewDeps};
+
+/// Decision produced by the required-context preflight gate.
+///
+/// Why: the runner needs a single typed verdict to decide whether to abort the
+/// review (skip), proceed with a loud non-authoritative label (degraded), or run
+/// normally — without re-deriving the `require_*` logic at the call-site.
+/// What: `Skip`/`Degraded` carry a human-readable, actionable reason string
+/// (which daemon is down and how to start it).
+/// Test: `gate_tests::*` assert the variant for each input combination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateOutcome {
+    /// All required context dependencies are reachable — run a normal review.
+    Proceed,
+    /// A REQUIRED dependency is unavailable — skip the review (no verdict).  The
+    /// string is an actionable operator-facing message.
+    Skip(String),
+    /// A dependency is unavailable but the operator opted out of requiring it —
+    /// proceed with a DEGRADED, explicitly non-authoritative review.  The string
+    /// names what context is missing.
+    Degraded(String),
+}
+
+/// Probe the required context dependencies and decide whether to proceed.
+///
+/// Why: enforces the #590 contract — both trusty-search and trusty-analyze are
+/// REQUIRED by default; a missing one skips the review rather than silently
+/// degrading to a context-free, false-confidence verdict.  Running this once,
+/// before context gathering, makes the policy apply uniformly to every review
+/// subject.
+/// What: probes search health and analyze readiness concurrently.  For each
+/// dependency that is down: if its `require_*` flag is true → `Skip` with an
+/// actionable message; if false → record a degraded reason.  Search is checked
+/// first so its (more fundamental) outage produces the skip message.  When no
+/// dependency is required-and-down but at least one opted-out dependency is down,
+/// returns `Degraded`; otherwise `Proceed`.  Note: when `deps.analyze` is `None`
+/// (analyze client not wired in at all, e.g. the CLI compare path) the analyze
+/// requirement is treated as unmet exactly as if the daemon were down.
+/// Test: `gate_tests::{skips_when_search_down, degraded_when_search_down_optout,
+/// skips_when_analyze_down, proceeds_when_both_healthy}`.
+pub async fn preflight_context(config: &ReviewConfig, deps: &ReviewDeps) -> GateOutcome {
+    let search_url = &config.search_url;
+    let analyzer_url = &config.analyzer_url;
+    let index = &config.search_index;
+
+    // Probe both dependencies concurrently — context retrieval is latency
+    // sensitive and these are independent network calls.
+    let search_fut = async { deps.search.health().await };
+    let analyze_fut = async {
+        match deps.analyze.as_ref() {
+            Some(a) => a.has_analysis(index).await,
+            // No analyze client wired in at all — treat as "no analysis".
+            None => false,
+        }
+    };
+    let (search_health, analyze_ready) = tokio::join!(search_fut, analyze_fut);
+
+    let search_ok = match &search_health {
+        Ok(h) if h.is_healthy() => true,
+        Ok(h) => {
+            warn!(status = %h.status, "trusty-search health is not 'ok'");
+            false
+        }
+        Err(e) => {
+            warn!("trusty-search health probe failed: {e}");
+            false
+        }
+    };
+
+    // ── trusty-search gate (checked first: it is the more fundamental dep) ──
+    if !search_ok {
+        if config.context.require_search {
+            return GateOutcome::Skip(format!(
+                "trusty-search unreachable at {search_url} — start it (`trusty-search start`); \
+                 refusing to review without code context (set \
+                 TRUSTY_REVIEW_REQUIRE_SEARCH=false or [context] require_search=false to opt \
+                 into a degraded, non-authoritative review)"
+            ));
+        }
+        info!(
+            "trusty-search unavailable but require_search=false — proceeding DEGRADED (non-authoritative)"
+        );
+        return GateOutcome::Degraded(format!(
+            "trusty-search unavailable at {search_url}; review produced WITHOUT code context"
+        ));
+    }
+
+    // ── trusty-analyze gate ────────────────────────────────────────────────
+    if !analyze_ready {
+        if config.context.require_analyze {
+            return GateOutcome::Skip(format!(
+                "trusty-analyze unreachable/not-ready at {analyzer_url} — start it \
+                 (`trusty-analyze serve`) and index `{index}`; refusing to review without \
+                 static-analysis context (set TRUSTY_REVIEW_REQUIRE_ANALYZE=false or \
+                 [context] require_analyze=false to opt into a degraded, non-authoritative review)"
+            ));
+        }
+        info!(
+            "trusty-analyze unavailable but require_analyze=false — proceeding DEGRADED (non-authoritative)"
+        );
+        return GateOutcome::Degraded(format!(
+            "trusty-analyze unavailable at {analyzer_url}; review produced WITHOUT \
+             static-analysis context"
+        ));
+    }
+
+    GateOutcome::Proceed
+}
+
+/// Prominent banner prepended to a degraded review body so the verdict is never
+/// mistaken for an authoritative one.
+///
+/// Why: the #590 premise forbids a degraded review masquerading as a normal
+/// verdict.  Embedding a loud warning in the rendered body (in addition to the
+/// `status` field and the `error` reason) makes the non-authoritativeness visible
+/// to any human reading the review markdown, not just to programmatic consumers.
+/// What: returns a Markdown blockquote warning that names the missing context.
+/// Test: `gate_tests::degraded_banner_contains_warning`.
+pub fn degraded_banner(reason: &str) -> String {
+    format!(
+        "> ⚠️ **DEGRADED REVIEW — NOT AUTHORITATIVE**\n>\n> {reason}.\n> \
+         This review ran WITHOUT required project context and must not be treated \
+         as a trustworthy verdict. Start the missing daemon and re-run for an \
+         authoritative review.\n\n"
+    )
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "context_gate_tests.rs"]
+mod gate_tests;

--- a/crates/trusty-review/src/pipeline/context_gate_tests.rs
+++ b/crates/trusty-review/src/pipeline/context_gate_tests.rs
@@ -1,0 +1,221 @@
+//! Unit tests for the required-context preflight gate (#590).
+//!
+//! Why: split from `context_gate.rs` to keep that file focused while exhaustively
+//! covering every (require × reachable) combination for both dependencies.
+//! What: drives `preflight_context` with injected fake search/analyze clients and
+//! a fake LLM (the gate ignores the LLM but `ReviewDeps` requires one).
+//! Test: this is the test module.
+
+use super::*;
+use crate::{
+    config::ReviewConfig,
+    integrations::{
+        analyze_client::{
+            AnalyzeClient, AnalyzeClientError, AnalyzeHealthResponse, ComplexityHotspot, Smell,
+        },
+        search_client::{HealthResponse, IndexInfo, SearchClient, SearchClientError, SearchResult},
+    },
+    llm::{LlmError, LlmProvider, LlmRequest, LlmResponse},
+    pipeline::runner::ReviewDeps,
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+// ── Fakes ─────────────────────────────────────────────────────────────────────
+
+struct StubLlm;
+
+#[async_trait]
+impl LlmProvider for StubLlm {
+    fn name(&self) -> &str {
+        "stub"
+    }
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Err(LlmError::Transport("unused".to_string()))
+    }
+}
+
+/// Search client whose health is configurable: healthy, unhealthy, or erroring.
+struct StubSearch {
+    /// `Some(true)` → status "ok"; `Some(false)` → status "starting";
+    /// `None` → transport error from `health()`.
+    health: Option<bool>,
+}
+
+#[async_trait]
+impl SearchClient for StubSearch {
+    async fn health(&self) -> Result<HealthResponse, SearchClientError> {
+        match self.health {
+            Some(ok) => Ok(HealthResponse {
+                status: if ok { "ok" } else { "starting" }.to_string(),
+                embedder: ok,
+            }),
+            None => Err(SearchClientError::Unavailable("down".to_string())),
+        }
+    }
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        Ok(vec![])
+    }
+    async fn search(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        Ok(vec![])
+    }
+}
+
+/// Analyze client whose readiness is a fixed boolean.
+struct StubAnalyze {
+    ready: bool,
+}
+
+#[async_trait]
+impl AnalyzeClient for StubAnalyze {
+    async fn health(&self) -> Result<AnalyzeHealthResponse, AnalyzeClientError> {
+        Ok(AnalyzeHealthResponse {
+            status: "ok".to_string(),
+            search_reachable: true,
+        })
+    }
+    async fn has_analysis(&self, _: &str) -> bool {
+        self.ready
+    }
+    async fn complexity_hotspots(
+        &self,
+        _: &str,
+        _: Option<u32>,
+    ) -> Result<Vec<ComplexityHotspot>, AnalyzeClientError> {
+        Ok(vec![])
+    }
+    async fn smells(&self, _: &str) -> Result<Vec<Smell>, AnalyzeClientError> {
+        Ok(vec![])
+    }
+}
+
+fn deps(search_health: Option<bool>, analyze_ready: Option<bool>) -> ReviewDeps {
+    ReviewDeps {
+        llm: Arc::new(StubLlm),
+        verifier: None,
+        search: Arc::new(StubSearch {
+            health: search_health,
+        }),
+        analyze: analyze_ready
+            .map(|r| Arc::new(StubAnalyze { ready: r }) as Arc<dyn AnalyzeClient>),
+        dedup: None,
+    }
+}
+
+fn config() -> ReviewConfig {
+    ReviewConfig::load(None)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn proceeds_when_both_healthy() {
+    let cfg = config(); // defaults: both required
+    let d = deps(Some(true), Some(true));
+    assert_eq!(preflight_context(&cfg, &d).await, GateOutcome::Proceed);
+}
+
+#[tokio::test]
+async fn skips_when_search_down_and_required() {
+    let cfg = config();
+    let d = deps(None, Some(true)); // search errors, analyze ready
+    match preflight_context(&cfg, &d).await {
+        GateOutcome::Skip(msg) => {
+            assert!(msg.contains("trusty-search"), "msg: {msg}");
+            assert!(msg.contains("start"), "msg must be actionable: {msg}");
+        }
+        other => panic!("expected Skip, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn skips_when_search_unhealthy_and_required() {
+    let cfg = config();
+    let d = deps(Some(false), Some(true)); // search status != "ok"
+    assert!(matches!(
+        preflight_context(&cfg, &d).await,
+        GateOutcome::Skip(_)
+    ));
+}
+
+#[tokio::test]
+async fn degraded_when_search_down_and_opted_out() {
+    let mut cfg = config();
+    cfg.context.require_search = false;
+    let d = deps(None, Some(true));
+    match preflight_context(&cfg, &d).await {
+        GateOutcome::Degraded(msg) => assert!(msg.contains("trusty-search"), "msg: {msg}"),
+        other => panic!("expected Degraded, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn skips_when_analyze_down_and_required() {
+    let cfg = config();
+    let d = deps(Some(true), Some(false)); // search ok, analyze not ready
+    match preflight_context(&cfg, &d).await {
+        GateOutcome::Skip(msg) => {
+            assert!(msg.contains("trusty-analyze"), "msg: {msg}");
+            assert!(msg.contains("start"), "msg must be actionable: {msg}");
+        }
+        other => panic!("expected Skip, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn skips_when_analyze_absent_and_required() {
+    let cfg = config();
+    let d = deps(Some(true), None); // no analyze client at all
+    assert!(matches!(
+        preflight_context(&cfg, &d).await,
+        GateOutcome::Skip(_)
+    ));
+}
+
+#[tokio::test]
+async fn degraded_when_analyze_down_and_opted_out() {
+    let mut cfg = config();
+    cfg.context.require_analyze = false;
+    let d = deps(Some(true), Some(false));
+    match preflight_context(&cfg, &d).await {
+        GateOutcome::Degraded(msg) => assert!(msg.contains("trusty-analyze"), "msg: {msg}"),
+        other => panic!("expected Degraded, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn search_down_skip_takes_priority_over_analyze() {
+    // Both down, both required → the search (more fundamental) skip wins.
+    let cfg = config();
+    let d = deps(None, Some(false));
+    match preflight_context(&cfg, &d).await {
+        GateOutcome::Skip(msg) => assert!(msg.contains("trusty-search"), "msg: {msg}"),
+        other => panic!("expected search Skip, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn both_opted_out_and_down_proceeds_degraded() {
+    let mut cfg = config();
+    cfg.context.require_search = false;
+    cfg.context.require_analyze = false;
+    let d = deps(None, Some(false));
+    // Search degraded reason takes priority (checked first).
+    match preflight_context(&cfg, &d).await {
+        GateOutcome::Degraded(msg) => assert!(msg.contains("trusty-search"), "msg: {msg}"),
+        other => panic!("expected Degraded, got {other:?}"),
+    }
+}
+
+#[test]
+fn degraded_banner_contains_warning() {
+    let banner = degraded_banner("trusty-search unavailable at http://x");
+    assert!(banner.contains("DEGRADED"));
+    assert!(banner.contains("NOT AUTHORITATIVE"));
+    assert!(banner.contains("trusty-search unavailable at http://x"));
+}

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -20,6 +20,7 @@
 //!
 //! Test: each submodule carries its own unit tests.
 
+pub mod context_gate;
 pub mod diff;
 pub mod grade;
 pub mod output;
@@ -33,6 +34,7 @@ pub mod verify;
 pub mod verify_liveness;
 pub mod verify_prompt;
 
+pub use context_gate::{GateOutcome, degraded_banner, preflight_context};
 pub use diff::DiffSource;
 pub use grade::derive_verdict;
 pub use output::{log_json_path, print_review_result, write_review_log};

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -5,10 +5,19 @@
 //! into a single `run_review` function that the CLI `run`/`compare` commands and
 //! the webhook service all call.
 //!
-//! What: `run_review` runs the pipeline (diff → context → LLM → parse → grade)
-//! then either posts a GitHub PR review comment (live) or writes a dry-run log,
-//! gated by the trigger decision and the SHA-keyed dedup store.  Returns a
-//! `ReviewResult` even on pipeline errors (fail-safe APPROVE/UNKNOWN).
+//! What: `run_review` runs the pipeline (diff → required-context gate → context
+//! → LLM → parse → grade) then either posts a GitHub PR review comment (live) or
+//! writes a dry-run log, gated by the trigger decision and the SHA-keyed dedup
+//! store.  Returns a `ReviewResult` even on pipeline errors (fail-safe
+//! APPROVE/UNKNOWN).
+//!
+//! Required-context contract (#590): trusty-search AND trusty-analyze are
+//! REQUIRED by default.  Before gathering context, `preflight_context` probes
+//! both; if either is unreachable the review is SKIPPED loudly
+//! (`status = Skipped`, no LLM call, never posted) rather than degrading to a
+//! context-free, false-confidence verdict.  An operator may opt a dependency out
+//! (`config.context.require_*`), in which case the run proceeds but is tagged
+//! `Degraded` and loudly labelled non-authoritative.
 //!
 //! Phase 2 (#583) adds the per-finding verification round between verdict parse
 //! and finalisation: candidate findings are confirmed/refuted by the verifier
@@ -37,8 +46,9 @@ use crate::{
         search_client::SearchClient,
     },
     llm::LlmProvider,
-    models::{ReviewResult, Verdict},
+    models::{ReviewResult, ReviewStatus, Verdict},
     pipeline::{
+        context_gate::{GateOutcome, degraded_banner, preflight_context},
         diff::{DiffSource, extract_changed_files, extract_identifiers, load_diff, truncate_diff},
         grade::derive_verdict,
         output::{print_review_result, write_review_log},
@@ -104,9 +114,14 @@ pub struct ReviewDeps {
     /// verification round (e.g. tests that don't exercise it, or when
     /// `config.verification.enabled` is false the caller passes `None`).
     pub verifier: Option<Arc<dyn LlmProvider>>,
-    /// Code search client (required; gracefully degrades on error).
+    /// Code search client.  REQUIRED by default (#590): the required-context
+    /// gate (`preflight_context`) skips the review when search is unreachable
+    /// unless the operator opted out via `config.context.require_search = false`.
     pub search: Arc<dyn SearchClient>,
-    /// Static analysis client (optional; None skips the analyze step).
+    /// Static analysis client.  REQUIRED by default (#590): the gate skips the
+    /// review when analyze is unreachable/absent unless the operator opted out
+    /// via `config.context.require_analyze = false`.  `None` is treated as
+    /// "analyze unavailable" by the gate (a hard skip when required).
     pub analyze: Option<Arc<dyn AnalyzeClient>>,
     /// SHA-keyed dedup store (Phase 1, #582).  `None` disables dedup (e.g.
     /// `compare`, `--local-diff`, or tests that don't exercise it).  Store
@@ -120,10 +135,14 @@ pub struct ReviewDeps {
 ///
 /// Why: the single entry point used by both the CLI `run` and `compare`
 /// subcommands; ensures both take the same code path.
-/// What: loads the diff, gathers context, builds the prompt, calls the LLM,
-/// parses the response, and writes the log.  Returns a `ReviewResult` even
-/// on pipeline errors (fail-safe: verdict = APPROVE with an `error` field set).
-/// Test: `run_review_with_fake_provider_approves`, `run_review_fail_safe_on_llm_error`.
+/// What: loads the diff, runs the required-context gate (#590), gathers context,
+/// builds the prompt, calls the LLM, parses the response, and writes the log.
+/// When a required context dependency is unavailable the review is SKIPPED (no
+/// LLM call, `status = Skipped`).  Returns a `ReviewResult` even on pipeline
+/// errors (fail-safe: verdict = APPROVE with an `error` field set).
+/// Test: `run_review_with_fake_provider_approves`, `run_review_fail_safe_on_llm_error`,
+/// `run_review_search_down_skips_when_required`,
+/// `run_review_search_down_degraded_when_optout`.
 pub async fn run_review(
     config: &ReviewConfig,
     input: ReviewInput,
@@ -228,6 +247,30 @@ pub async fn run_review(
         "extracted identifiers from diff"
     );
 
+    // ── Step 4b: required-context gate (#590) ─────────────────────────────
+    // trusty-search AND trusty-analyze are REQUIRED by default.  If either is
+    // unreachable, SKIP the review loudly (no LLM call, no post) instead of
+    // producing a context-free, false-confidence verdict.  An operator who
+    // explicitly opted a dependency out gets a DEGRADED, non-authoritative run.
+    let degraded_reason: Option<String> = match preflight_context(config, &deps).await {
+        GateOutcome::Proceed => None,
+        GateOutcome::Skip(reason) => {
+            warn!("required-context gate: skipping review — {reason}");
+            result.status = ReviewStatus::Skipped;
+            result.verdict = Verdict::Unknown;
+            result.error = Some(reason);
+            result.dry_run = true;
+            // Return WITHOUT finalize_review so a skipped review is never posted.
+            // Release any dedup claim so a retry (once the dep recovers) can re-run.
+            return abort_dry(result, config, &input, &deps);
+        }
+        GateOutcome::Degraded(reason) => {
+            warn!("required-context gate: proceeding DEGRADED (non-authoritative) — {reason}");
+            result.status = ReviewStatus::Degraded;
+            Some(reason)
+        }
+    };
+
     // ── Step 5: gather context in parallel ────────────────────────────────
     let context = gather_context(config, &deps, &identifiers, &changed_files, &pr_meta.title).await;
 
@@ -261,6 +304,18 @@ pub async fn run_review(
         "LLM reviewer call complete"
     );
     result.apply_llm_response(&llm_resp);
+
+    // ── Degraded labelling (#590) ─────────────────────────────────────────
+    // When an operator opted out of a required dependency, the review still ran
+    // but MUST be loudly labelled non-authoritative: prepend a banner to the
+    // rendered body and set the `error` reason so no consumer mistakes it for an
+    // authoritative verdict.  `status` was already set to Degraded by the gate.
+    if let Some(reason) = degraded_reason.as_ref() {
+        result.review_body = format!("{}{}", degraded_banner(reason), result.review_body);
+        if result.error.is_none() {
+            result.error = Some(format!("degraded (non-authoritative): {reason}"));
+        }
+    }
 
     // ── Step 7: parse verdict + findings ──────────────────────────────────
     let parsed = parse_review_response(&llm_resp.text);

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -5,9 +5,12 @@
 //! keeps that file under the 500-line cap and lets the retrieval logic be read
 //! and tested in isolation.
 //! What: exposes `gather_context`, which runs the search query and the analyze
-//! probe concurrently and folds both (each degrading gracefully on error) into a
-//! `ReviewContext`.
-//! Test: `gather_context_degrades_gracefully_on_search_failure` (runner tests).
+//! probe concurrently and folds both into a `ReviewContext`.  This runs only
+//! AFTER the required-context gate (`pipeline::context_gate`, #590) has confirmed
+//! the dependencies are reachable (or the operator opted into a degraded run), so
+//! a transient per-query error here degrades gracefully to a partial context
+//! rather than re-deciding the hard require/skip policy.
+//! Test: covered transitively by `runner_tests` (gate + gather paths).
 
 use tracing::{debug, warn};
 

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -12,7 +12,8 @@ use crate::{
         analyze_client::{AnalyzeClientError, AnalyzeHealthResponse, ComplexityHotspot, Smell},
         search_client::{HealthResponse, IndexInfo, SearchClientError, SearchResult},
     },
-    llm::{LlmError, LlmRequest, LlmResponse},
+    llm::{LlmError, LlmProvider, LlmRequest, LlmResponse},
+    models::ReviewStatus,
 };
 use async_trait::async_trait;
 use std::path::PathBuf;
@@ -166,9 +167,12 @@ impl SearchClient for FailingSearch {
     }
 }
 
-// ── Fake analyze client ───────────────────────────────────────────────
+// ── Fake analyze clients ──────────────────────────────────────────────
+// `FakeAnalyze` reports NOT ready (the daemon is down); `ReadyAnalyze` reports
+// ready with empty enrichment.  The required-context gate (#590) treats a
+// not-ready / absent analyze client as "analyze unavailable", so positive tests
+// must inject `ReadyAnalyze` for the gate to pass.
 
-#[allow(dead_code)]
 struct FakeAnalyze;
 
 #[async_trait]
@@ -191,6 +195,46 @@ impl AnalyzeClient for FakeAnalyze {
 
     async fn smells(&self, _: &str) -> Result<Vec<Smell>, AnalyzeClientError> {
         Ok(vec![])
+    }
+}
+
+struct ReadyAnalyze;
+
+#[async_trait]
+impl AnalyzeClient for ReadyAnalyze {
+    async fn health(&self) -> Result<AnalyzeHealthResponse, AnalyzeClientError> {
+        Ok(AnalyzeHealthResponse {
+            status: "ok".to_string(),
+            search_reachable: true,
+        })
+    }
+
+    async fn has_analysis(&self, _: &str) -> bool {
+        true
+    }
+
+    async fn complexity_hotspots(
+        &self,
+        _: &str,
+        _: Option<u32>,
+    ) -> Result<Vec<ComplexityHotspot>, AnalyzeClientError> {
+        Ok(vec![])
+    }
+
+    async fn smells(&self, _: &str) -> Result<Vec<Smell>, AnalyzeClientError> {
+        Ok(vec![])
+    }
+}
+
+/// Build deps with healthy search + ready analyze so the required-context gate
+/// (#590) passes.  Positive tests use this to exercise the post-gate pipeline.
+fn ready_deps(llm: Arc<dyn LlmProvider>, verifier: Option<Arc<dyn LlmProvider>>) -> ReviewDeps {
+    ReviewDeps {
+        llm,
+        verifier,
+        search: Arc::new(FakeSearch),
+        analyze: Some(Arc::new(ReadyAnalyze)),
+        dedup: None,
     }
 }
 
@@ -225,13 +269,7 @@ async fn run_review_with_fake_provider_approves() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::approves()),
-        verifier: None,
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
 
     let result = run_review(&config, input, deps).await;
     assert_eq!(result.verdict, Verdict::Approve);
@@ -239,6 +277,11 @@ async fn run_review_with_fake_provider_approves() {
         result.error.is_none(),
         "no error expected: {:?}",
         result.error
+    );
+    assert_eq!(
+        result.status,
+        ReviewStatus::Completed,
+        "both deps healthy → authoritative Completed status"
     );
     assert!(result.dry_run, "MVP must always be dry-run");
     assert_eq!(result.findings.len(), 0);
@@ -259,13 +302,7 @@ async fn run_review_request_changes_parsed_correctly() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::request_changes()),
-        verifier: None,
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    let deps = ready_deps(Arc::new(FakeLlm::request_changes()), None);
 
     let result = run_review(&config, input, deps).await;
     assert_eq!(result.verdict, Verdict::RequestChanges);
@@ -286,13 +323,7 @@ async fn run_review_fail_safe_on_llm_error() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::errors("simulated transport error")),
-        verifier: None,
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    let deps = ready_deps(Arc::new(FakeLlm::errors("simulated transport error")), None);
 
     let result = run_review(&config, input, deps).await;
     // Fail-safe: verdict must be APPROVE on LLM error (spec REV-130).
@@ -307,10 +338,64 @@ async fn run_review_fail_safe_on_llm_error() {
     );
 }
 
+/// REQUIRED-CONTEXT GATE (#590): when trusty-search is unreachable and required
+/// (the default), the review is SKIPPED loudly — NOT a silent APPROVE.
+///
+/// Why: a review without code context gives false confidence; the old
+/// graceful-degrade behaviour (which this test replaces) was actively harmful.
+/// What: a failing search + default `require_search=true` must yield
+/// `status = Skipped`, an actionable error, and NO LLM-derived APPROVE.
 #[tokio::test]
-async fn run_review_search_failure_does_not_block() {
+async fn run_review_search_down_skips_when_required() {
     let (source, _tmp) = local_diff_source("+fn x() {}\n");
-    let config = default_config();
+    let config = default_config(); // require_search defaults true
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ReviewDeps {
+        llm: Arc::new(FakeLlm::approves()), // would APPROVE if ever consulted
+        verifier: None,
+        search: Arc::new(FailingSearch), // search is down
+        analyze: Some(Arc::new(ReadyAnalyze)),
+        dedup: None,
+    };
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(
+        result.status,
+        ReviewStatus::Skipped,
+        "search down + required must SKIP, not silently APPROVE"
+    );
+    assert!(!result.posted, "a skipped review must never be posted live");
+    assert!(result.dry_run, "a skipped review is dry-run");
+    let err = result.error.expect("skip must set an actionable error");
+    assert!(
+        err.contains("trusty-search"),
+        "error must name the dep: {err}"
+    );
+    assert!(
+        err.contains("start"),
+        "error must be actionable (how to fix): {err}"
+    );
+    assert_ne!(
+        result.verdict,
+        Verdict::Approve,
+        "a skip must not masquerade as APPROVE"
+    );
+}
+
+/// REQUIRED-CONTEXT GATE (#590): trusty-analyze unreachable + required (default)
+/// also SKIPS the review.
+#[tokio::test]
+async fn run_review_analyze_down_skips_when_required() {
+    let (source, _tmp) = local_diff_source("+fn x() {}\n");
+    let config = default_config(); // require_analyze defaults true
     let input = ReviewInput {
         diff_source: source,
         reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
@@ -323,17 +408,98 @@ async fn run_review_search_failure_does_not_block() {
     let deps = ReviewDeps {
         llm: Arc::new(FakeLlm::approves()),
         verifier: None,
-        search: Arc::new(FailingSearch), // search is down
-        analyze: None,
+        search: Arc::new(FakeSearch),         // search healthy
+        analyze: Some(Arc::new(FakeAnalyze)), // analyze not ready
         dedup: None,
     };
 
     let result = run_review(&config, input, deps).await;
-    // Review must still complete even if search is unavailable.
+    assert_eq!(
+        result.status,
+        ReviewStatus::Skipped,
+        "analyze down + required must SKIP"
+    );
+    let err = result.error.expect("skip must set an actionable error");
+    assert!(
+        err.contains("trusty-analyze"),
+        "error must name the dep: {err}"
+    );
+}
+
+/// OPT-IN DEGRADED MODE (#590): with `require_search=false`, a down search no
+/// longer skips — the review proceeds but is tagged DEGRADED / non-authoritative
+/// and the rendered body carries a loud warning banner.
+#[tokio::test]
+async fn run_review_search_down_degraded_when_optout() {
+    let (source, _tmp) = local_diff_source("+fn x() {}\n");
+    let mut config = default_config();
+    config.context.require_search = false; // explicit opt-out
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ReviewDeps {
+        llm: Arc::new(FakeLlm::approves()),
+        verifier: None,
+        search: Arc::new(FailingSearch), // search down, but opted out
+        analyze: Some(Arc::new(ReadyAnalyze)),
+        dedup: None,
+    };
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(
+        result.status,
+        ReviewStatus::Degraded,
+        "opted-out + search down must PROCEED but be tagged Degraded"
+    );
+    assert!(
+        !result.status.is_authoritative(),
+        "a degraded review must not be authoritative"
+    );
+    assert!(
+        result.review_body.contains("NOT AUTHORITATIVE"),
+        "degraded body must carry a loud banner: {:?}",
+        result.review_body
+    );
+    let err = result
+        .error
+        .expect("degraded run must record a non-authoritative reason");
+    assert!(err.contains("degraded"), "reason must say degraded: {err}");
+}
+
+/// REGRESSION GUARD (#590): both deps healthy → a normal, authoritative review.
+#[tokio::test]
+async fn run_review_both_healthy_completes_authoritative() {
+    let (source, _tmp) = local_diff_source("+fn x() {}\n");
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(result.status, ReviewStatus::Completed);
+    assert!(result.status.is_authoritative());
     assert_eq!(result.verdict, Verdict::Approve);
     assert!(
         result.error.is_none(),
-        "search failure must not set error field"
+        "healthy run sets no error: {:?}",
+        result.error
+    );
+    assert!(
+        !result.review_body.contains("NOT AUTHORITATIVE"),
+        "authoritative review must not carry the degraded banner"
     );
 }
 
@@ -353,13 +519,7 @@ async fn run_review_local_diff_skips_github() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::approves()),
-        verifier: None,
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
 
     let result = run_review(&config, input, deps).await;
     assert_eq!(result.owner, "local");
@@ -414,13 +574,7 @@ async fn run_review_local_diff_is_dry_run_and_not_posted() {
         run_mode: RunMode::Serve,
         allow_posting: true,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::approves()),
-        verifier: None,
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
 
     let result = run_review(&config, input, deps).await;
     assert!(
@@ -447,13 +601,7 @@ async fn run_review_writes_dry_run_log_on_log_only_path() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::approves()),
-        verifier: None,
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
 
     let _result = run_review(&config, input, deps).await;
     let json_count = std::fs::read_dir(dir.path())
@@ -483,15 +631,12 @@ async fn run_review_verification_refutes_and_relaxes_verdict() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::request_changes()), // 1 medium finding → REQUEST_CHANGES
-        verifier: Some(Arc::new(FakeVerifier {
+    let deps = ready_deps(
+        Arc::new(FakeLlm::request_changes()), // 1 medium finding → REQUEST_CHANGES
+        Some(Arc::new(FakeVerifier {
             judgment: "REFUTED",
         })),
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    );
 
     let result = run_review(&config, input, deps).await;
     assert_eq!(
@@ -521,15 +666,12 @@ async fn run_review_verification_confirms_and_preserves_verdict() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::request_changes()),
-        verifier: Some(Arc::new(FakeVerifier {
+    let deps = ready_deps(
+        Arc::new(FakeLlm::request_changes()),
+        Some(Arc::new(FakeVerifier {
             judgment: "CONFIRMED",
         })),
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    );
 
     let result = run_review(&config, input, deps).await;
     assert_eq!(
@@ -555,16 +697,13 @@ async fn run_review_verification_disabled_skips_round() {
         run_mode: RunMode::Cli,
         allow_posting: false,
     };
-    let deps = ReviewDeps {
-        llm: Arc::new(FakeLlm::request_changes()),
-        // A REFUTED verifier is wired in but must NOT be consulted when disabled.
-        verifier: Some(Arc::new(FakeVerifier {
+    // A REFUTED verifier is wired in but must NOT be consulted when disabled.
+    let deps = ready_deps(
+        Arc::new(FakeLlm::request_changes()),
+        Some(Arc::new(FakeVerifier {
             judgment: "REFUTED",
         })),
-        search: Arc::new(FakeSearch),
-        analyze: None,
-        dedup: None,
-    };
+    );
 
     let result = run_review(&config, input, deps).await;
     assert_eq!(

--- a/docs/trusty-review/spec/ARCHITECTURE.md
+++ b/docs/trusty-review/spec/ARCHITECTURE.md
@@ -26,9 +26,10 @@ trusty-review (crates/trusty-review/)
   ├── Profile pipeline      — profile:: (longitudinal contributor profiling)
   └── Integrations          — GitHub client, search/analyze HTTP clients
 
-Workspace dependencies (HTTP, required for full reviews)
+Workspace dependencies (HTTP, REQUIRED for a real review — #590)
   ├── trusty-search :7878   — REQUIRED (code context retrieval)
-  └── trusty-analyze :7879  — OPTIONAL (static analysis; graceful degradation)
+  └── trusty-analyze :7879  — REQUIRED (static analysis context)
+      (either unreachable ⇒ review SKIPPED loudly; opt-out ⇒ DEGRADED, labelled)
 
 External services
   ├── AWS Bedrock           — Converse API (default provider)
@@ -120,14 +121,59 @@ crates/trusty-review/
 
 | Dependency | Status | Behavior when absent |
 |------------|--------|----------------------|
-| **trusty-search** (:7878) | **REQUIRED** | Review is skipped; Slack service-failure notice sent |
-| **AWS Bedrock** or **OpenRouter** | **REQUIRED** (one active) | Review is skipped; Slack service-failure notice sent |
-| **trusty-analyze** (:7879) | **OPTIONAL** | Pipeline proceeds with empty static-analysis context |
+| **trusty-search** (:7878) | **REQUIRED** (#590) | Review **SKIPPED** loudly (`status = Skipped`, actionable error, never posted) unless `require_search=false` → **DEGRADED** |
+| **trusty-analyze** (:7879) | **REQUIRED** (#590) | Review **SKIPPED** loudly unless `require_analyze=false` → **DEGRADED** |
+| **AWS Bedrock** or **OpenRouter** | **REQUIRED** (one active) | Fail-safe verdict; review not posted live |
 | **JIRA REST** | optional; fail-open | Empty ticket context |
 | **Slack** | optional; fail-open | Notifications silently dropped |
 | **GitHub App auth** | optional; PAT fallback | PAT used if App not configured |
 
-All optional dependency failures are fail-open and never block a review.
+Optional dependency failures (JIRA, Slack, GitHub App auth) are fail-open and
+never block a review. The two **context** dependencies are the exception: they
+are fail-**closed** by default (see §3.1.1).
+
+#### 3.1.1 Required-context gate (#590)
+
+trusty-review's value proposition IS the context it injects from trusty-search
+(code context) and trusty-analyze (static analysis). A review produced WITHOUT
+that context is actively harmful — it gives false confidence from a verdict that
+never saw the project. **A lower-quality / context-free review is NOT acceptable.**
+
+Therefore, before any review subject (PR review, local-diff review, and the
+forward-compatible commit-review of #589) gathers context, the shared pipeline
+runs a **required-context preflight gate** (`pipeline::context_gate`):
+
+1. It probes `trusty-search` health and `trusty-analyze` readiness concurrently.
+2. If **either** REQUIRED dependency is unreachable/unhealthy:
+   - **CLI/`run` path** → `run_review` returns a `ReviewResult` tagged
+     `status = Skipped` with an **actionable** error
+     (e.g. *"trusty-search unreachable at <url> — start it (`trusty-search
+     start`); refusing to review without code context"*). The CLI then exits
+     **non-zero**. No LLM call is made; the review is **never posted**.
+   - **`serve` / `POST /review` / webhook path** → the same skip `ReviewResult`
+     is returned as the structured response. A skipped review is **never posted**
+     to the PR (it is not an APPROVE).
+3. A skip is a **distinct outcome**, never an APPROVE.
+
+**Opt-in degraded mode.** An operator may explicitly set `require_search=false`
+and/or `require_analyze=false` (config layering below). When a dependency that has
+been opted-out is unavailable, the run **proceeds** but is **loudly labelled
+non-authoritative**: `status = Degraded`, a `> ⚠️ DEGRADED REVIEW — NOT
+AUTHORITATIVE` banner is prepended to the rendered review body, and the `error`
+field records the degraded reason. A degraded review must never silently
+masquerade as an authoritative verdict.
+
+**Configuration layering** (env over TOML over default, matching the rest of the
+config module):
+
+| Knob | Default | CLI/env | TOML |
+|------|---------|---------|------|
+| `require_search` | `true` | `TRUSTY_REVIEW_REQUIRE_SEARCH` | `[context] require_search` |
+| `require_analyze` | `true` | `TRUSTY_REVIEW_REQUIRE_ANALYZE` | `[context] require_analyze` |
+
+For the daemonless CI commit-review case (#589), this means CI must have
+trusty-search **and** trusty-analyze reachable, or the run fails — which is the
+intended contract: the context is the point.
 
 ### 3.2 trusty-search and trusty-analyze: HTTP only
 
@@ -209,8 +255,8 @@ The one alarm that breaks the "always proceed" posture: a `verification_model_er
 ```
 [GitHub] --webhook--> [trusty-review serve :7880]
                              |
-                    [trusty-search :7878]  (REQUIRED)
-                    [trusty-analyze :7879] (OPTIONAL)
+                    [trusty-search :7878]  (REQUIRED — #590)
+                    [trusty-analyze :7879] (REQUIRED — #590)
                     [AWS Bedrock / OpenRouter]
                     [redb dedup claim]
                     [filesystem review log]
@@ -265,7 +311,8 @@ The `review_requested`-only webhook gate holds throughout, independent of dry-ru
 | `dedup_skip` | counter | Review skipped due to dedup (in-flight/claim/head-SHA). |
 | `verdict_distribution` | counter by verdict | Every completed review. A spike to ~100% APPROVE is the symptom of an inactive verifier model (L1). |
 | `LLMInputTokens` / `LLMOutputTokens` | gauge/counter | Per LLM call, tagged by role. |
-| `analyze_degraded` | counter | trusty-analyze unavailable → empty static analysis. |
+| `context_gate_skip` | counter + WARN | A REQUIRED context dep (trusty-search/trusty-analyze) was unavailable → review skipped (#590). |
+| `context_gate_degraded` | counter + WARN | A context dep was unavailable but opted-out → review proceeded DEGRADED (non-authoritative). |
 
 Metric backend is deployment-specific (CloudWatch in production; structured stderr logs locally). The crate emits through a thin abstraction so the backend is swappable.
 
@@ -284,7 +331,7 @@ Metric backend is deployment-specific (CloudWatch in production; structured stde
 | **L7** Calibration tracker created duplicates | Upsert-per-PR: one tracker issue per PR, updated in place |
 | **L8** Premature live posting | Dry-run default ON; staged rollout discipline |
 | **L9** Suppression blocked a review | All suppression and config lookups fail-open |
-| **L10** trusty-analyze down blocked reviews | Optional dependency; degrades silently to empty context |
+| **L10** Context-free reviews give false confidence | **trusty-search AND trusty-analyze are REQUIRED (#590)**; either down ⇒ review skipped loudly (`status = Skipped`, never posted); opt-out ⇒ DEGRADED, loudly labelled non-authoritative. (Supersedes the earlier "analyze is optional; degrade silently" stance.) |
 | **L11** Bot force-pushed to infra repo | Hard-coded non-configurable push firewall (`GH_ALLOW_PUSH = false`) |
 | **L12** Fixture/i18n churn buried real changes | Noisy-file collapse + diff Stage A/B/C filtering |
 | **L13** PR deleted a permission check; orphaned producer missed | Cross-reference blast-radius search in parallel context retrieval |

--- a/docs/trusty-review/spec/COMPONENTS.md
+++ b/docs/trusty-review/spec/COMPONENTS.md
@@ -20,16 +20,38 @@
 | `prompt.rs` | `reviewer_system_prompt()`, `build_review_prompt()`, `ReviewContext`, `ReviewPrMeta` |
 | `parser.rs` | `parse_review_response() -> ParsedReview` — verdict token extraction + `Finding` JSON block parsing from LLM response body |
 | `output.rs` | `write_review_log()` (filesystem JSON + Markdown), `print_review_result()` (stdout), `log_json_path()` |
+| `context_gate.rs` | `preflight_context()`, `GateOutcome`, `degraded_banner()` — required-context gate (#590); see §1.1 |
 | `runner.rs` | `ReviewDeps`, `ReviewInput`, `run_review()` — top-level orchestration loop |
 
 **Pipeline stages (implemented):**
 
 1. Diff fetch or local-file read → truncation to `MAX_DIFF_CHARS`
-2. Prompt assembly (PR meta + diff + context)
-3. Reviewer LLM call (forced structured JSON output via Bedrock tool-use / OpenRouter)
-4. `parse_review_response()` → `ParsedReview` (verdict token + findings)
-5. `derive_verdict()` — severity floor + low-confidence override
-6. Log write + stdout print
+2. **Required-context gate** (`preflight_context()`, §1.1) — skip/degrade decision
+3. Prompt assembly (PR meta + diff + context)
+4. Reviewer LLM call (forced structured JSON output via Bedrock tool-use / OpenRouter)
+5. `parse_review_response()` → `ParsedReview` (verdict token + findings)
+6. `derive_verdict()` — severity floor + low-confidence override
+7. Log write + stdout print
+
+### 1.1 Required-context gate (`context_gate.rs`, #590)
+
+trusty-review's value IS the context it injects from trusty-search (code context)
+and trusty-analyze (static analysis); a context-free review gives false
+confidence and is actively harmful. Both daemons are therefore **REQUIRED by
+default**. Before context is gathered, `preflight_context(config, deps)` probes
+both concurrently and returns a `GateOutcome`:
+
+| `GateOutcome` | Trigger | Effect on `run_review` |
+|---------------|---------|------------------------|
+| `Proceed` | both reachable | normal authoritative review (`status = Completed`) |
+| `Skip(reason)` | a REQUIRED dep is unavailable | `ReviewResult { status: Skipped, verdict: Unknown, error: Some(reason), dry_run: true }`, returned **before** the LLM call and **without** finalize/post. The CLI/`run` path turns this into a non-zero exit (`anyhow::Err`); `serve`/`POST /review`/webhook return it as a structured skip result and never post. |
+| `Degraded(reason)` | a dep is unavailable but opted-out (`require_*=false`) | review proceeds but `status = Degraded`, a `⚠️ DEGRADED REVIEW — NOT AUTHORITATIVE` banner is prepended to `review_body`, and `error` records the reason |
+
+The gate lives in the shared pipeline, so it applies uniformly to PR review,
+local-diff review, and the forward-compatible commit-review (#589). Config knobs:
+`require_search` / `require_analyze` (default `true`), layered
+env (`TRUSTY_REVIEW_REQUIRE_SEARCH` / `TRUSTY_REVIEW_REQUIRE_ANALYZE`) over TOML
+`[context]` over default — see §7.1.
 
 **Pipeline stages (designed, not yet built in v0.1):**
 
@@ -184,11 +206,17 @@ Opus is intentionally excluded (not access-granted in the target account).
 - `confidence: f32` (clamped to [0.0, 1.0] at construction; defensive against malformed LLM JSON)
 - `effort: Effort`, `verified: Option<VerifyOutcome>`, `issue_eligible: bool`
 
+**`ReviewStatus`** (`src/models/status.rs`, #590) — review-run outcome class:
+- `Completed` (default) — ran with full required context; verdict is **authoritative**
+- `Skipped` — a REQUIRED context dep (trusty-search/trusty-analyze) was unavailable; **no real verdict** was produced (CLI exits non-zero; service never posts)
+- `Degraded` — opted-in context-free run; the verdict is present but explicitly **non-authoritative** (loudly labelled in `review_body`)
+- helpers: `is_authoritative()` (only `Completed`), `is_skipped()`
+
 **`ReviewResult`** — complete output of a PR review pass:
 - PR identity: `owner`, `repo`, `pr_number`, `pr_title`, `pr_url`
 - Review output: `review_body`, `verdict`, `findings: Vec<Finding>`
 - Telemetry: `model`, `input_tokens`, `output_tokens`, `cost_estimate_usd`, `latency_ms`
-- Pipeline flags: `dry_run` (default true), `posted` (default false), `timestamp`
+- Pipeline flags: `status: ReviewStatus` (default `Completed`, #590), `dry_run` (default true), `posted` (default false), `timestamp`
 - Dedup: `head_sha`
 - Versioning: `review_version` (currently `"tr-0.1"`)
 
@@ -256,7 +284,12 @@ JSON schema is additively versioned via `review_version`. Existing field names a
 | `/indexes/{id}/status` | GET | Chunk count + root path |
 | `/indexes/{id}/search` | POST | Hybrid BM25 + vector search |
 
-If unreachable, review is skipped (not silently approved) and a Slack service-failure notice is sent.
+**REQUIRED dependency (#590).** trusty-search is gated by the required-context
+preflight (`pipeline::context_gate`, §1.1): if `/health` is unreachable/unhealthy
+and `require_search=true` (default), the review is **skipped** (not silently
+approved) — `ReviewResult.status = Skipped`, an actionable error is set, no LLM
+call is made, and the review is never posted. With `require_search=false` the run
+proceeds **DEGRADED** and is loudly labelled non-authoritative.
 
 ### 6.3 trusty-analyze client (`integrations/analyze_client.rs`)
 
@@ -270,7 +303,17 @@ If unreachable, review is skipped (not silently approved) and a Slack service-fa
 | `complexity_hotspots()` | `GET /indexes/{id}/complexity_hotspots` | 180s | |
 | `smells()` | `GET /indexes/{id}/smells` | 180s | |
 
-All methods fail-open: connect/timeout/HTTP errors return empty defaults. trusty-analyze unavailability does not raise the service-unavailable path.
+**REQUIRED dependency (#590).** As of #590 trusty-analyze is no longer optional:
+the required-context preflight (`pipeline::context_gate`, §1.1) treats a failed
+`has_analysis()` two-step probe (or an absent analyze client) as "analyze
+unavailable". When `require_analyze=true` (default) that **skips** the review
+(`status = Skipped`, actionable error, never posted); when `require_analyze=false`
+the run proceeds **DEGRADED** and is loudly labelled non-authoritative.
+
+*Within* a review that has already passed the gate, the per-call enrichment
+fetches (`complexity_hotspots()`, `smells()`) still fail-soft to empty results so
+a transient per-query error degrades the context partially rather than re-deciding
+the hard require/skip policy.
 
 ### 6.4 JIRA client (designed, not in v0.1)
 
@@ -325,6 +368,16 @@ Config file location: `--config <path>` flag or `$XDG_CONFIG_HOME/trusty-review/
 | `TRUSTY_SEARCH_URL` | `http://localhost:7878` | trusty-search endpoint |
 | `TRUSTY_SEARCH_INDEX` | `main` | Index name |
 
+**Required-context settings (#590):**
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `TRUSTY_REVIEW_REQUIRE_SEARCH` | `true` | When `true`, an unreachable trusty-search **skips** the review; `false` opts into a DEGRADED (non-authoritative) run |
+| `TRUSTY_REVIEW_REQUIRE_ANALYZE` | `true` | When `true`, an unreachable/not-ready trusty-analyze **skips** the review; `false` opts into a DEGRADED run |
+
+Truthiness: `false`/`0`/`no`/`off` relax; `true`/`1`/`yes`/`on` require;
+unrecognised values are ignored (fail-closed — keep the stricter value).
+
 **TOML config file model tables:**
 
 ```toml
@@ -345,6 +398,12 @@ temperature = 1.0
 provider = "openrouter"   # roles may mix providers
 model = "anthropic/claude-haiku-4.5"
 temperature = 0.0
+
+# Required-context gate (#590). Both default to true; set to false ONLY to opt
+# into an explicitly-labelled, non-authoritative DEGRADED review.
+[context]
+require_search = true
+require_analyze = true
 ```
 
 Bedrock model IDs in config are validated for the `us.` prefix at config-resolution time. Failure is surfaced at startup, not mid-review.


### PR DESCRIPTION
## Summary

trusty-review's value IS the context it injects from **trusty-search** (code context) and **trusty-analyze** (static analysis). A review produced WITHOUT that context is actively harmful — it gives false confidence. Previously the runner degraded gracefully when either dependency was down and could still return APPROVE. This PR makes both dependencies **REQUIRED by default** and fails/skips **loudly** instead.

Closes #590.

## The gate (default behaviour)

A new shared-pipeline preflight gate — `pipeline::context_gate::preflight_context` — probes both daemons **before** any review subject (PR review, local-diff, and the forward-compatible commit-review of #589) gathers context. It returns a `GateOutcome`:

| Outcome | Trigger | Effect |
|---|---|---|
| `Proceed` | both reachable | normal authoritative review (`status = Completed`) |
| `Skip(reason)` | a REQUIRED dep unavailable | no LLM call, never posted; see per-path handling below |
| `Degraded(reason)` | dep down but opted-out | proceeds, loudly labelled non-authoritative |

### Skip representation per path
- **CLI / `run`**: `run_review` returns a `ReviewResult` tagged `status = Skipped` with an **actionable** error (e.g. *"trusty-search unreachable at <url> — start it (`trusty-search start`); refusing to review without code context"*). `cmd_run` turns this into a non-zero `anyhow::Err`, so the process **exits non-zero**.
- **serve / `POST /review` / webhook**: the same skip `ReviewResult` is returned as the structured response and is **never posted** to the PR. A skip is a distinct outcome, never an APPROVE. (The skip returns before `finalize_review`, so the post path is unreachable for a skipped review.)

## Config opt-in degraded mode (default = required)

New `[context]` config (`config::context::ContextConfig`):
- `require_search` / `require_analyze` — both default **`true`**.
- Layering: env (`TRUSTY_REVIEW_REQUIRE_SEARCH` / `TRUSTY_REVIEW_REQUIRE_ANALYZE`) → TOML `[context]` → default `true`. Unrecognised env values are ignored (**fail-closed** — keep the stricter value).

When an operator sets a requirement to `false` and that dep is down, the run proceeds but is **loudly labelled non-authoritative**:
- `ReviewResult.status = Degraded`
- a `> ⚠️ DEGRADED REVIEW — NOT AUTHORITATIVE` banner is prepended to `review_body`
- the `error` field records the degraded reason

A degraded review never silently masquerades as an authoritative verdict.

## New model

`models::status::ReviewStatus` (`Completed` / `Skipped` / `Degraded`, with `is_authoritative()` / `is_skipped()`), added as a `status` field on `ReviewResult` (default `Completed`, `#[serde(default)]` so older logs deserialise as authoritative).

## Tests

- **Replaced** `run_review_search_failure_does_not_block` (which asserted the old graceful-degrade APPROVE) with `run_review_search_down_skips_when_required`: search down + default → `Skipped`, actionable reason, NOT a silent APPROVE, not posted.
- **Added**: `run_review_analyze_down_skips_when_required`; `run_review_search_down_degraded_when_optout` (proceeds + Degraded + banner); `run_review_both_healthy_completes_authoritative` (regression guard).
- **Added**: exhaustive `context_gate` unit tests (every require × reachable combination, priority ordering, banner) and `[context]` config layering tests; `ReviewStatus` serde/predicate tests. Network-bound paths use injected mock clients (no real network).

## Spec

- `ARCHITECTURE.md` + `COMPONENTS.md`: both deps now **REQUIRED**; unreachable → skip/error; documented the opt-in degraded mode and its loud labelling; added a `§3.1.1`/`§1.1` required-context-gate section, config knob tables, observability metrics, and updated lesson **L10**.
- Fixed the "gracefully degrades on error" doc comment in `runner.rs` (and `runner_context.rs` / `ReviewDeps` field docs) to reflect the new contract.

## Test evidence

```
cargo fmt -p trusty-review --check        → clean
cargo clippy -p trusty-review --all-targets -- -D warnings → 0 warnings (trusty-review)
cargo test -p trusty-review               → 390 passed; 0 failed; 1 ignored (lib)
                                            8 passed; 0 failed (bin)
cargo check -p trusty-review --no-default-features → Finished
cargo check -p trusty-review --features http-server → Finished
```

## Scope

Touches only `crates/trusty-review/` and `docs/trusty-review/`. The deferred items (#584 suppression, #585 disposition-sink, #550 context-source redesign, #554 metrics backend, #589 commit-review subcommand) are intentionally left in place — the gate lives in the shared pipeline so it applies when #589 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)