### PR TITLE
feat(trusty-review): pluggable context sources + live JIRA/Confluence/GitHub-Issues enrichment (Phase 6 PR-A, refs #550)

### DIFF
--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -112,7 +112,9 @@ default     = ["http-server"]
 http-server = ["dep:axum", "dep:tower", "dep:tower-http", "dep:tempfile", "trusty-common/axum-server"]
 
 [dev-dependencies]
-tokio        = { workspace = true }
+# test-util enables tokio's paused-clock (`tokio::time::pause`) used by the
+# context-orchestrator timeout fail-open test (#550).
+tokio        = { workspace = true, features = ["test-util"] }
 tempfile     = { workspace = true }
 tower        = { workspace = true }
 axum         = { workspace = true }

--- a/crates/trusty-review/src/config/context.rs
+++ b/crates/trusty-review/src/config/context.rs
@@ -19,6 +19,8 @@
 use serde::Deserialize;
 use tracing::warn;
 
+use crate::integrations::context::ContextSourcesFileConfig;
+
 /// Environment variable that toggles whether trusty-search is a hard requirement.
 ///
 /// Why: operators need a discoverable single switch to opt into a degraded run
@@ -107,6 +109,11 @@ pub struct ContextFileConfig {
     /// `[context] require_analyze = false` opts into a degraded run when analyze
     /// is unavailable.
     pub require_analyze: Option<bool>,
+    /// `[context.sources.*]` — per-source enable/mode for the external context
+    /// sources (JIRA / Confluence / GitHub Issues; APEX in PR-B).  Defaults to an
+    /// all-default (auto-disable-without-creds) configuration when absent.
+    #[serde(default)]
+    pub sources: ContextSourcesFileConfig,
 }
 
 /// Parse a boolean env var with lenient truthiness, or `None` if unset/empty.
@@ -177,6 +184,7 @@ mod tests {
         let file = ContextFileConfig {
             require_search: None,
             require_analyze: Some(false),
+            ..Default::default()
         };
         let cfg = ContextConfig::from_env_and_file(Some(&file));
         assert!(cfg.require_search, "search stays required by default");
@@ -198,6 +206,7 @@ mod tests {
         let file = ContextFileConfig {
             require_search: Some(false),
             require_analyze: None,
+            ..Default::default()
         };
         let cfg = ContextConfig::from_env_and_file(Some(&file));
         assert!(cfg.require_search, "env true must override file false");
@@ -214,6 +223,7 @@ mod tests {
         let file = ContextFileConfig {
             require_search: None,
             require_analyze: Some(false),
+            ..Default::default()
         };
         let cfg = ContextConfig::from_env_and_file(Some(&file));
         assert!(

--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -167,6 +167,14 @@ pub struct ReviewConfig {
     /// Both default to `true`: a missing dependency skips the review rather than
     /// degrading to a context-free verdict.
     pub context: ContextConfig,
+
+    // ── External context sources (Phase 6, #550) ───────────────────────────
+    /// Resolved per-source settings for the external enrichment sources
+    /// (JIRA / Confluence / GitHub Issues; APEX in PR-B).  Each source defaults
+    /// to disabled unless its credentials are present (auto-enable) — so the
+    /// crate works out of the box with no Atlassian/GitHub-context config.  These
+    /// sources are best-effort / fail-open, distinct from the REQUIRED gate above.
+    pub context_sources: crate::integrations::context::ContextSourcesConfig,
 }
 
 impl ReviewConfig {
@@ -195,6 +203,9 @@ impl ReviewConfig {
         let role_models = RoleModels::resolve(cli_overrides, &env, file_models.as_ref());
         let verification = VerificationConfig::from_env_and_file(file_verification.as_ref());
         let context = ContextConfig::from_env_and_file(file_context.as_ref());
+        let context_sources = crate::integrations::context::ContextSourcesConfig::from_env_and_file(
+            file_context.as_ref().map(|c| &c.sources),
+        );
 
         let dry_run = std::env::var("PR_INTELLIGENCE_DRY_RUN")
             .map(|v| v.to_lowercase() != "false")
@@ -242,6 +253,7 @@ impl ReviewConfig {
             live_review_requesters: load_live_review_requesters(),
             verification,
             context,
+            context_sources,
         }
     }
 

--- a/crates/trusty-review/src/integrations/context/atlassian.rs
+++ b/crates/trusty-review/src/integrations/context/atlassian.rs
@@ -1,0 +1,288 @@
+//! Shared Atlassian credentials for the JIRA + Confluence live sources (#550).
+//!
+//! Why: JIRA and Confluence are both Atlassian Cloud products that share one
+//! credential set (email + API token + site base URL).  Resolving them once,
+//! here, keeps the two sources DRY and — critically — matches the env-var names
+//! code-intelligence already uses so an existing deployment migrates drop-in
+//! (RESOLVED decision on #550: reuse `ATLASSIAN_API_TOKEN` et al.).
+//!
+//! ## Env-var contract (matched to code-intelligence / Duetto cto reference)
+//!
+//! Token  (any of, first non-empty wins):
+//!   - `ATLASSIAN_API_TOKEN`   (canonical; what extract_confluence_authors.py reads)
+//!   - `ATLASSIAN_PAT`         (alias used in the cto `.env.local.example`)
+//!   - per-product `JIRA_API_TOKEN` / `CONFLUENCE_API_TOKEN` (product override)
+//!
+//! Email  (any of):
+//!   - `ATLASSIAN_EMAIL`       (canonical)
+//!   - per-product `JIRA_EMAIL` / `CONFLUENCE_EMAIL`
+//!
+//! Base URL (any of):
+//!   - `ATLASSIAN_URL`         (canonical site root, e.g. https://acme.atlassian.net)
+//!   - per-product `JIRA_BASE_URL` / `JIRA_URL` / `CONFLUENCE_BASE_URL` / `CONFLUENCE_URL`
+//!
+//! Auth is HTTP Basic (email:token), exactly as the reference Python uses
+//! `HTTPBasicAuth(ATLASSIAN_EMAIL, ATLASSIAN_API_TOKEN)`.  JIRA REST lives at
+//! `{base}/rest/api/3/...`; Confluence REST at `{base}/wiki/rest/api/...`.
+//!
+//! No secret values are read from any file — only env-var *names* were matched
+//! against the cto reference; values come from the process environment.
+//!
+//! What: `AtlassianCreds::from_env` (canonical-only) and
+//! `AtlassianCreds::from_env_for` (canonical + product fallbacks) resolve the
+//! three pieces and expose `basic_auth_header` for the `Authorization` header.
+//!
+//! Test: `creds_resolve_from_canonical`, `creds_product_fallback`,
+//! `creds_missing_when_no_token`, `basic_auth_header_encodes` in this module.
+
+use base64::Engine;
+
+/// Which Atlassian product a credential lookup is for (selects fallback env vars).
+///
+/// Why: JIRA and Confluence allow product-specific env overrides (`JIRA_*` /
+/// `CONFLUENCE_*`) layered under the shared `ATLASSIAN_*` canon; the product tag
+/// selects the right fallback names.
+/// What: a two-variant enum used only by `from_env_for`.
+/// Test: `creds_product_fallback`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtlassianProduct {
+    /// JIRA — fallback env prefix `JIRA_`.
+    Jira,
+    /// Confluence — fallback env prefix `CONFLUENCE_`.
+    Confluence,
+}
+
+/// Resolved Atlassian credentials (email + token + base URL).
+///
+/// Why: both sources need the same triple to build the basic-auth header and
+/// the REST base; bundling them keeps the source code small and makes the
+/// "missing creds → skip" decision a single `Option` check.
+/// What: all three fields are non-empty by construction (`from_env*` returns
+/// `None` if any is missing).  `base_url` has its trailing slash trimmed.
+/// Test: `creds_resolve_from_canonical`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AtlassianCreds {
+    /// Account email (basic-auth username).
+    pub email: String,
+    /// API token (basic-auth password).
+    pub token: String,
+    /// Site base URL, e.g. `https://acme.atlassian.net` (no trailing slash).
+    pub base_url: String,
+}
+
+impl AtlassianCreds {
+    /// Resolve from the canonical `ATLASSIAN_*` env vars only.
+    ///
+    /// Why: a convenience used by tests and any caller that does not need the
+    /// product-specific fallbacks.
+    /// What: reads `ATLASSIAN_EMAIL`, `ATLASSIAN_API_TOKEN` (or `ATLASSIAN_PAT`),
+    /// and `ATLASSIAN_URL`; returns `None` if any is missing/empty.
+    /// Test: `creds_resolve_from_canonical`, `creds_missing_when_no_token`.
+    pub fn from_env() -> Option<Self> {
+        Self::build(
+            first_env(&["ATLASSIAN_EMAIL"]),
+            first_env(&["ATLASSIAN_API_TOKEN", "ATLASSIAN_PAT"]),
+            first_env(&["ATLASSIAN_URL"]),
+        )
+    }
+
+    /// Resolve for a specific product with canonical + product-specific fallbacks.
+    ///
+    /// Why: matches code-intelligence, where some deployments set only the
+    /// product-scoped vars (`JIRA_BASE_URL`, `CONFLUENCE_EMAIL`, …).  Canonical
+    /// `ATLASSIAN_*` wins; the product vars fill any gap.
+    /// What: builds the lookup order from the product tag, then resolves each of
+    /// email/token/base from the first non-empty env var in its chain.
+    /// Test: `creds_product_fallback`.
+    pub fn from_env_for(product: AtlassianProduct) -> Option<Self> {
+        let (email_keys, token_keys, base_keys): (&[&str], &[&str], &[&str]) = match product {
+            AtlassianProduct::Jira => (
+                &["ATLASSIAN_EMAIL", "JIRA_EMAIL"],
+                &["ATLASSIAN_API_TOKEN", "ATLASSIAN_PAT", "JIRA_API_TOKEN"],
+                &["ATLASSIAN_URL", "JIRA_BASE_URL", "JIRA_URL"],
+            ),
+            AtlassianProduct::Confluence => (
+                &["ATLASSIAN_EMAIL", "CONFLUENCE_EMAIL"],
+                &[
+                    "ATLASSIAN_API_TOKEN",
+                    "ATLASSIAN_PAT",
+                    "CONFLUENCE_API_TOKEN",
+                ],
+                &["ATLASSIAN_URL", "CONFLUENCE_BASE_URL", "CONFLUENCE_URL"],
+            ),
+        };
+        Self::build(
+            first_env(email_keys),
+            first_env(token_keys),
+            first_env(base_keys),
+        )
+    }
+
+    /// Build from three optional values; `None` if any is missing.
+    ///
+    /// Why: shared construction for both `from_env` variants, including the
+    /// trailing-slash trim so callers can always `format!("{base}/...")`.
+    /// What: returns `Some` only when all three are present and non-empty.
+    /// Test: covered by `creds_resolve_from_canonical`, `creds_missing_when_no_token`.
+    fn build(email: Option<String>, token: Option<String>, base: Option<String>) -> Option<Self> {
+        let email = email?;
+        let token = token?;
+        let base = base?;
+        Some(Self {
+            email,
+            token,
+            base_url: base.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// Produce the HTTP `Authorization: Basic …` header value.
+    ///
+    /// Why: Atlassian Cloud REST authenticates with HTTP Basic over
+    /// `email:api_token` (NOT a bearer token); centralising the encoding avoids
+    /// per-source mistakes.
+    /// What: base64-encodes `"{email}:{token}"` and prefixes `Basic `.
+    /// Test: `basic_auth_header_encodes`.
+    pub fn basic_auth_header(&self) -> String {
+        let raw = format!("{}:{}", self.email, self.token);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(raw.as_bytes());
+        format!("Basic {encoded}")
+    }
+}
+
+/// Return the value of the first env var in `keys` that is set and non-empty.
+///
+/// Why: the canonical-then-fallback resolution order is the same for email,
+/// token, and base URL; one helper keeps it consistent.
+/// What: iterates `keys`, returns the first non-empty trimmed value, else `None`.
+/// Test: covered by `creds_product_fallback`.
+fn first_env(keys: &[&str]) -> Option<String> {
+    for k in keys {
+        if let Ok(v) = std::env::var(k) {
+            let v = v.trim();
+            if !v.is_empty() {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear() {
+        unsafe {
+            for k in [
+                "ATLASSIAN_EMAIL",
+                "ATLASSIAN_API_TOKEN",
+                "ATLASSIAN_PAT",
+                "ATLASSIAN_URL",
+                "JIRA_EMAIL",
+                "JIRA_API_TOKEN",
+                "JIRA_BASE_URL",
+                "JIRA_URL",
+                "CONFLUENCE_EMAIL",
+                "CONFLUENCE_API_TOKEN",
+                "CONFLUENCE_BASE_URL",
+                "CONFLUENCE_URL",
+            ] {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn creds_resolve_from_canonical() {
+        clear();
+        unsafe {
+            std::env::set_var("ATLASSIAN_EMAIL", "bob@acme.com");
+            std::env::set_var("ATLASSIAN_API_TOKEN", "tok123"); // pragma: allowlist secret
+            std::env::set_var("ATLASSIAN_URL", "https://acme.atlassian.net/");
+        }
+        let creds = AtlassianCreds::from_env().expect("creds present");
+        assert_eq!(creds.email, "bob@acme.com");
+        assert_eq!(creds.token, "tok123");
+        // Trailing slash trimmed.
+        assert_eq!(creds.base_url, "https://acme.atlassian.net");
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn creds_pat_alias_resolves_token() {
+        clear();
+        unsafe {
+            std::env::set_var("ATLASSIAN_EMAIL", "bob@acme.com");
+            std::env::set_var("ATLASSIAN_PAT", "pat999"); // pragma: allowlist secret
+            std::env::set_var("ATLASSIAN_URL", "https://acme.atlassian.net");
+        }
+        let creds = AtlassianCreds::from_env().expect("creds present via PAT alias");
+        assert_eq!(creds.token, "pat999");
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn creds_product_fallback() {
+        clear();
+        // No canonical email/base; only JIRA-scoped vars present.
+        unsafe {
+            std::env::set_var("JIRA_EMAIL", "jira@acme.com");
+            std::env::set_var("ATLASSIAN_API_TOKEN", "tok"); // pragma: allowlist secret
+            std::env::set_var("JIRA_BASE_URL", "https://acme.atlassian.net");
+        }
+        let creds = AtlassianCreds::from_env_for(AtlassianProduct::Jira).expect("jira creds");
+        assert_eq!(creds.email, "jira@acme.com");
+        assert_eq!(creds.base_url, "https://acme.atlassian.net");
+        // Canonical-only resolution would fail (no ATLASSIAN_EMAIL/URL).
+        assert!(AtlassianCreds::from_env().is_none());
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn creds_canonical_beats_product() {
+        clear();
+        unsafe {
+            std::env::set_var("ATLASSIAN_URL", "https://canon.atlassian.net");
+            std::env::set_var("CONFLUENCE_URL", "https://product.atlassian.net");
+            std::env::set_var("ATLASSIAN_EMAIL", "bob@acme.com");
+            std::env::set_var("ATLASSIAN_API_TOKEN", "t"); // pragma: allowlist secret
+        }
+        let creds =
+            AtlassianCreds::from_env_for(AtlassianProduct::Confluence).expect("creds present");
+        assert_eq!(creds.base_url, "https://canon.atlassian.net");
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn creds_missing_when_no_token() {
+        clear();
+        unsafe {
+            std::env::set_var("ATLASSIAN_EMAIL", "bob@acme.com");
+            std::env::set_var("ATLASSIAN_URL", "https://acme.atlassian.net");
+            // No token set.
+        }
+        assert!(AtlassianCreds::from_env().is_none());
+        clear();
+    }
+
+    #[test]
+    fn basic_auth_header_encodes() {
+        let creds = AtlassianCreds {
+            email: "user@x.com".to_string(),
+            token: "secret".to_string(), // pragma: allowlist secret
+            base_url: "https://x.atlassian.net".to_string(),
+        };
+        let header = creds.basic_auth_header();
+        assert!(header.starts_with("Basic "));
+        // "user@x.com:secret" base64 == "dXNlckB4LmNvbTpzZWNyZXQ="
+        assert_eq!(header, "Basic dXNlckB4LmNvbTpzZWNyZXQ=");
+    }
+}

--- a/crates/trusty-review/src/integrations/context/config.rs
+++ b/crates/trusty-review/src/integrations/context/config.rs
@@ -1,0 +1,350 @@
+//! Per-source context configuration (Phase 6, #550).
+//!
+//! Why: each external context source (JIRA / Confluence / GitHub Issues, and
+//! later APEX) needs an independent enable flag and a retrieval mode, resolved
+//! with the same env-over-TOML-over-default precedence as the rest of the
+//! config module.  Critically, every source defaults to **disabled** and only
+//! turns on when its credentials/base URLs are actually present — so the crate
+//! works out of the box with zero Atlassian/GitHub context config, and a source
+//! with no creds is simply skipped (logged once by the orchestrator) rather than
+//! erroring on every review.
+//!
+//! What: exposes `ContextSourcesConfig` (the resolved, owned per-source
+//! settings) and its TOML mirrors (`ContextSourcesFileConfig`, `SourceFileConfig`).
+//! `from_env_and_file` resolves the `[context.sources.*]` tables layered under
+//! env overrides.  The actual credential resolution (Atlassian creds, GitHub
+//! auth) is NOT done here — that lives in the sources themselves; this struct
+//! only carries the *intent* (enabled / mode) and the auto-disable signal.
+//!
+//! Precedence for `enabled`:
+//!   1. explicit env `TRUSTY_REVIEW_CONTEXT_<SOURCE>_ENABLED` (true/false)  — wins
+//!   2. explicit TOML `[context.sources.<source>] enabled = <bool>`
+//!   3. default: `false` UNLESS the source's credentials are present, in which
+//!      case the source auto-enables (computed by the source, not here).
+//!
+//! Test: `source_defaults_disabled`, `env_enables_source`,
+//! `file_sets_mode`, `env_beats_file`, `mode_parses` in this module.
+
+use serde::Deserialize;
+use tracing::warn;
+
+use super::RetrievalMode;
+
+/// Resolved configuration for a single context source.
+///
+/// Why: the source constructor reads this to decide whether to run and in which
+/// mode; keeping it a small owned struct makes the source trivially testable
+/// (construct it directly) and free of scattered env lookups.
+/// What: `enabled` is the *explicit* operator intent (`Some(true/false)`) or
+/// `None` (defer to credential-presence auto-enable); `mode` is the retrieval
+/// backend (default `Live`).
+/// Test: `source_defaults_disabled`, `file_sets_mode`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SourceConfig {
+    /// Explicit enable intent.  `None` → auto-decide from credential presence
+    /// (default disabled when creds absent).  `Some(true/false)` → operator
+    /// override, honoured even against credential presence.
+    pub enabled: Option<bool>,
+    /// Retrieval backend for this source (default `Live`).
+    pub mode: RetrievalMode,
+}
+
+impl SourceConfig {
+    /// Resolve the *effective* enabled flag given whether credentials are present.
+    ///
+    /// Why: the final "should this source run?" decision combines the explicit
+    /// operator intent with credential presence.  Centralising it keeps every
+    /// source consistent: an explicit `true`/`false` always wins; absent an
+    /// explicit flag, the source runs only when its creds are present.
+    /// What: returns `self.enabled` if set; otherwise returns `creds_present`.
+    /// Test: `effective_enabled_honours_explicit`, `effective_enabled_auto`.
+    pub fn effective_enabled(&self, creds_present: bool) -> bool {
+        self.enabled.unwrap_or(creds_present)
+    }
+}
+
+/// Resolved per-source context configuration for all external sources.
+///
+/// Why: the runner constructs the source set from one owned struct instead of
+/// re-reading env vars per source; this mirrors `ContextConfig` (#590) and keeps
+/// the precedence logic in one place.
+/// What: one `SourceConfig` per external source.  PR-B will add an `apex` field
+/// (or a generic knowledgebase map) without disturbing these three.
+/// Test: `from_env_and_file_layers_correctly`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ContextSourcesConfig {
+    /// JIRA live source.
+    pub jira: SourceConfig,
+    /// Confluence live source.
+    pub confluence: SourceConfig,
+    /// GitHub Issues live source.
+    pub github_issues: SourceConfig,
+}
+
+impl ContextSourcesConfig {
+    /// Resolve from env vars layered over an optional `[context.sources]` table.
+    ///
+    /// Why: gives operators one mental model (env beats TOML beats default)
+    /// across every source, matching the rest of `config`.
+    /// What: starts from the file values (or defaults), then applies the
+    /// `TRUSTY_REVIEW_CONTEXT_<SOURCE>_ENABLED` and
+    /// `TRUSTY_REVIEW_CONTEXT_<SOURCE>_MODE` env overrides per source.
+    /// Test: `env_enables_source`, `env_beats_file`, `file_sets_mode`.
+    pub fn from_env_and_file(file: Option<&ContextSourcesFileConfig>) -> Self {
+        Self {
+            jira: resolve_source("JIRA", file.map(|f| &f.jira)),
+            confluence: resolve_source("CONFLUENCE", file.map(|f| &f.confluence)),
+            github_issues: resolve_source("GITHUB_ISSUES", file.map(|f| &f.github_issues)),
+        }
+    }
+}
+
+/// Resolve one source's `SourceConfig` from its file table + env overrides.
+///
+/// Why: the three sources resolve identically; factoring the per-source logic
+/// avoids triplicated env-var plumbing.
+/// What: reads `[context.sources.<source>]` (file) for the base values, then
+/// overrides `enabled` from `TRUSTY_REVIEW_CONTEXT_<KEY>_ENABLED` and `mode`
+/// from `TRUSTY_REVIEW_CONTEXT_<KEY>_MODE`.
+/// Test: covered by `env_enables_source`, `env_beats_file`, `file_sets_mode`.
+fn resolve_source(env_key: &str, file: Option<&SourceFileConfig>) -> SourceConfig {
+    let mut cfg = SourceConfig {
+        enabled: file.and_then(|f| f.enabled),
+        mode: file.and_then(|f| f.mode).unwrap_or_default(),
+    };
+    if let Some(v) = parse_bool_env(&format!("TRUSTY_REVIEW_CONTEXT_{env_key}_ENABLED")) {
+        cfg.enabled = Some(v);
+    }
+    if let Some(m) = parse_mode_env(&format!("TRUSTY_REVIEW_CONTEXT_{env_key}_MODE")) {
+        cfg.mode = m;
+    }
+    cfg
+}
+
+// ─── TOML mirrors ───────────────────────────────────────────────────────────
+
+/// TOML-deserialisable `[context.sources]` table.
+///
+/// Why: lets a config file set per-source enable/mode without env vars; nested
+/// under the existing `[context]` table so all context knobs live together.
+/// What: one optional `SourceFileConfig` per source; absent keys fall through to
+/// the env / default layer.
+/// Test: covered by `from_env_and_file` tests via injected `ContextSourcesFileConfig`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ContextSourcesFileConfig {
+    /// `[context.sources.jira]`.
+    #[serde(default)]
+    pub jira: SourceFileConfig,
+    /// `[context.sources.confluence]`.
+    #[serde(default)]
+    pub confluence: SourceFileConfig,
+    /// `[context.sources.github_issues]`.
+    #[serde(default)]
+    pub github_issues: SourceFileConfig,
+}
+
+/// TOML-deserialisable single-source table (all fields optional).
+///
+/// Why: a source's file table may set neither, either, or both knobs; optional
+/// fields let an absent key fall through to env / default.
+/// What: `enabled` and `mode`, both optional.
+/// Test: `file_sets_mode`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SourceFileConfig {
+    /// `enabled = true|false`.
+    pub enabled: Option<bool>,
+    /// `mode = "live"|"semantic"`.
+    pub mode: Option<RetrievalMode>,
+}
+
+// ─── Env parsing helpers ────────────────────────────────────────────────────
+
+/// Parse a boolean env var with lenient truthiness, or `None` if unset/empty.
+///
+/// Why: env booleans come in many spellings; centralising the parse keeps every
+/// source's enable flag consistent.
+/// What: `Some(true)` for true/1/yes/on; `Some(false)` for false/0/no/off;
+/// `None` for unset/empty; `None` (with a warning) for anything unrecognised.
+/// Test: covered by `env_enables_source`.
+fn parse_bool_env(var: &str) -> Option<bool> {
+    let raw = std::env::var(var).ok()?;
+    let v = raw.trim().to_lowercase();
+    if v.is_empty() {
+        return None;
+    }
+    match v.as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        other => {
+            warn!("unrecognised boolean for {var}: {other:?} — ignoring");
+            None
+        }
+    }
+}
+
+/// Parse a retrieval-mode env var, or `None` if unset/empty/invalid.
+///
+/// Why: operators can flip a source to `semantic` via env once PR-B lands; the
+/// parse must be lenient and never panic.
+/// What: `Some(Live)` for `live`; `Some(Semantic)` for `semantic`/`indexed`;
+/// `None` otherwise (warn on unrecognised non-empty values).
+/// Test: `mode_parses`.
+fn parse_mode_env(var: &str) -> Option<RetrievalMode> {
+    let raw = std::env::var(var).ok()?;
+    let v = raw.trim().to_lowercase();
+    if v.is_empty() {
+        return None;
+    }
+    match v.as_str() {
+        "live" => Some(RetrievalMode::Live),
+        "semantic" | "indexed" => Some(RetrievalMode::Semantic),
+        other => {
+            warn!("unrecognised retrieval mode for {var}: {other:?} — ignoring");
+            None
+        }
+    }
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear_env() {
+        unsafe {
+            for k in [
+                "TRUSTY_REVIEW_CONTEXT_JIRA_ENABLED",
+                "TRUSTY_REVIEW_CONTEXT_JIRA_MODE",
+                "TRUSTY_REVIEW_CONTEXT_CONFLUENCE_ENABLED",
+                "TRUSTY_REVIEW_CONTEXT_CONFLUENCE_MODE",
+                "TRUSTY_REVIEW_CONTEXT_GITHUB_ISSUES_ENABLED",
+                "TRUSTY_REVIEW_CONTEXT_GITHUB_ISSUES_MODE",
+            ] {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    #[test]
+    fn source_defaults_disabled_without_creds() {
+        let cfg = SourceConfig::default();
+        // No explicit flag, no creds → disabled.
+        assert!(!cfg.effective_enabled(false));
+        // No explicit flag, creds present → auto-enabled.
+        assert!(cfg.effective_enabled(true));
+        assert_eq!(cfg.mode, RetrievalMode::Live);
+    }
+
+    #[test]
+    fn effective_enabled_honours_explicit_false_even_with_creds() {
+        let cfg = SourceConfig {
+            enabled: Some(false),
+            mode: RetrievalMode::Live,
+        };
+        // Explicit false wins even when creds are present.
+        assert!(!cfg.effective_enabled(true));
+    }
+
+    #[test]
+    fn effective_enabled_honours_explicit_true_without_creds() {
+        let cfg = SourceConfig {
+            enabled: Some(true),
+            mode: RetrievalMode::Live,
+        };
+        // Explicit true is honoured; the source will still skip later if it has
+        // no creds, but the *intent* is enabled.
+        assert!(cfg.effective_enabled(false));
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_and_file_defaults_disabled() {
+        clear_env();
+        let cfg = ContextSourcesConfig::from_env_and_file(None);
+        assert_eq!(cfg.jira.enabled, None);
+        assert_eq!(cfg.confluence.enabled, None);
+        assert_eq!(cfg.github_issues.enabled, None);
+        assert_eq!(cfg.jira.mode, RetrievalMode::Live);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn env_enables_source() {
+        clear_env();
+        unsafe {
+            std::env::set_var("TRUSTY_REVIEW_CONTEXT_JIRA_ENABLED", "true");
+        }
+        let cfg = ContextSourcesConfig::from_env_and_file(None);
+        assert_eq!(cfg.jira.enabled, Some(true));
+        assert_eq!(cfg.confluence.enabled, None);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn file_sets_mode() {
+        clear_env();
+        let file = ContextSourcesFileConfig {
+            jira: SourceFileConfig {
+                enabled: Some(true),
+                mode: Some(RetrievalMode::Semantic),
+            },
+            ..Default::default()
+        };
+        let cfg = ContextSourcesConfig::from_env_and_file(Some(&file));
+        assert_eq!(cfg.jira.enabled, Some(true));
+        assert_eq!(cfg.jira.mode, RetrievalMode::Semantic);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn env_beats_file() {
+        clear_env();
+        unsafe {
+            std::env::set_var("TRUSTY_REVIEW_CONTEXT_JIRA_ENABLED", "false");
+            std::env::set_var("TRUSTY_REVIEW_CONTEXT_JIRA_MODE", "live");
+        }
+        let file = ContextSourcesFileConfig {
+            jira: SourceFileConfig {
+                enabled: Some(true),
+                mode: Some(RetrievalMode::Semantic),
+            },
+            ..Default::default()
+        };
+        let cfg = ContextSourcesConfig::from_env_and_file(Some(&file));
+        // Env false + live override the file's true + semantic.
+        assert_eq!(cfg.jira.enabled, Some(false));
+        assert_eq!(cfg.jira.mode, RetrievalMode::Live);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn mode_parses() {
+        clear_env();
+        unsafe {
+            std::env::set_var("TRUSTY_REVIEW_CONTEXT_GITHUB_ISSUES_MODE", "semantic");
+        }
+        let cfg = ContextSourcesConfig::from_env_and_file(None);
+        assert_eq!(cfg.github_issues.mode, RetrievalMode::Semantic);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn unrecognised_env_falls_through() {
+        clear_env();
+        unsafe {
+            std::env::set_var("TRUSTY_REVIEW_CONTEXT_JIRA_ENABLED", "maybe");
+            std::env::set_var("TRUSTY_REVIEW_CONTEXT_JIRA_MODE", "fuzzy");
+        }
+        let cfg = ContextSourcesConfig::from_env_and_file(None);
+        assert_eq!(cfg.jira.enabled, None, "garbage enabled ignored");
+        assert_eq!(cfg.jira.mode, RetrievalMode::Live, "garbage mode ignored");
+        clear_env();
+    }
+}

--- a/crates/trusty-review/src/integrations/context/confluence.rs
+++ b/crates/trusty-review/src/integrations/context/confluence.rs
@@ -1,0 +1,451 @@
+//! LIVE Confluence context source (Phase 6, #550).
+//!
+//! Why: product/architecture/decision docs in Confluence often constrain how a
+//! change *should* be made.  Surfacing the matching pages lets the reviewer
+//! check the diff against documented design intent — the same Stage-5 retrieval
+//! code-intelligence does.  Confluence is LIVE (RESOLVED on #550), querying the
+//! API at review time rather than pre-indexing.
+//!
+//! What: `ConfluenceSource` implements `ContextSource` in `Live` mode by issuing
+//! a CQL `text ~ "<keywords>"` search against `{base}/wiki/rest/api/content/search`
+//! using the shared `AtlassianCreds` basic-auth header (same site root as JIRA,
+//! with the `/wiki` REST prefix), then mapping each page to a
+//! `## Related Confluence docs` bullet (title, space, web link).  The HTTP call
+//! goes through an injectable `ConfluenceTransport` for network-free testing.
+//!
+//! Fail-open: missing creds → `NotConfigured` (skip, logged once); transport /
+//! API / parse error → orchestrator logs and drops the section.  Never blocks
+//! the review.
+//!
+//! Test: `query_builds_cql`, `parse_pages_to_section`, `disabled_when_no_creds`,
+//! `semantic_mode_errors`, `gather_with_fake_transport` in this module.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::atlassian::{AtlassianCreds, AtlassianProduct};
+use super::{
+    ContextSection, ContextSnippet, ContextSource, ContextSourceError, RetrievalMode,
+    ReviewSubject, TransportErr,
+};
+
+/// Source identifier used in logs, config keys, and error messages.
+const SOURCE_NAME: &str = "confluence";
+
+/// Max Confluence pages to embed in the section.
+const MAX_RESULTS: u32 = 5;
+
+/// Max diff identifiers folded into the keyword query.
+const MAX_QUERY_IDENTIFIERS: usize = 6;
+
+// ─── Transport seam ─────────────────────────────────────────────────────────
+
+/// Injectable HTTP transport for the Confluence CQL search call.
+///
+/// Why: same rationale as `JiraTransport` — the query + parse logic must be
+/// testable without a live Confluence.
+/// What: one async method performing the CQL search, returning the raw JSON body
+/// (or a typed failure).
+/// Test: implemented by `ReqwestConfluenceTransport` (prod) and a fake in tests.
+#[async_trait]
+pub trait ConfluenceTransport: Send + Sync {
+    /// GET a CQL search and return the raw response body on 2xx.
+    async fn search_cql(
+        &self,
+        creds: &AtlassianCreds,
+        cql: &str,
+        limit: u32,
+    ) -> Result<String, ContextSourceError>;
+}
+
+/// Production `ConfluenceTransport` over reqwest.
+///
+/// Why: the default transport for real reviews.
+/// What: GETs `{base}/wiki/rest/api/content/search?cql=...&limit=...` with basic
+/// auth, mapping non-2xx to `Api` and transport failures to `Transport`.
+/// Test: exercised via the fake in `gather_with_fake_transport`.
+pub struct ReqwestConfluenceTransport {
+    http: reqwest::Client,
+}
+
+impl ReqwestConfluenceTransport {
+    /// Construct with a default 15s-timeout client.
+    ///
+    /// Why: bound the worst-case latency of an enrichment call.
+    /// What: builds a reqwest client; panics only on TLS-backend init failure.
+    /// Test: covered transitively by `ConfluenceSource::from_config`.
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .expect("reqwest::Client::build failed — TLS backend unavailable");
+        Self { http }
+    }
+}
+
+impl Default for ReqwestConfluenceTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ConfluenceTransport for ReqwestConfluenceTransport {
+    async fn search_cql(
+        &self,
+        creds: &AtlassianCreds,
+        cql: &str,
+        limit: u32,
+    ) -> Result<String, ContextSourceError> {
+        let url = format!("{}/wiki/rest/api/content/search", creds.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("cql", cql), ("limit", &limit.to_string())])
+            .header("Authorization", creds.basic_auth_header())
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("GET {url}: {e}")),
+            })?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("read body of {url}: {e}")),
+            })?;
+        if !status.is_success() {
+            return Err(ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: status.as_u16(),
+                body: text,
+            });
+        }
+        Ok(text)
+    }
+}
+
+// ─── JSON shapes ────────────────────────────────────────────────────────────
+
+/// Top-level Confluence content-search response.
+#[derive(Debug, Deserialize)]
+struct ConfluenceSearchResponse {
+    #[serde(default)]
+    results: Vec<ConfluencePage>,
+}
+
+/// One Confluence page (content) result.
+#[derive(Debug, Deserialize)]
+struct ConfluencePage {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    space: Option<ConfluenceSpace>,
+    #[serde(default, rename = "_links")]
+    links: Option<ConfluenceLinks>,
+}
+
+/// The page's space (we render its name/key).
+#[derive(Debug, Deserialize)]
+struct ConfluenceSpace {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    key: Option<String>,
+}
+
+/// The page's `_links` block (we use `webui` to build the canonical URL).
+#[derive(Debug, Deserialize)]
+struct ConfluenceLinks {
+    #[serde(default)]
+    webui: Option<String>,
+}
+
+// ─── The source ─────────────────────────────────────────────────────────────
+
+/// LIVE Confluence context source.
+///
+/// Why: implements the `ContextSource` seam for Confluence; constructed by the
+/// runner when enabled (config + Atlassian creds present).
+/// What: holds `enabled`, `mode`, optional `AtlassianCreds`, and the injected
+/// transport.  Auto-disabled when creds are absent.
+/// Test: `disabled_when_no_creds`, `gather_with_fake_transport`.
+pub struct ConfluenceSource {
+    enabled: bool,
+    mode: RetrievalMode,
+    creds: Option<AtlassianCreds>,
+    transport: Box<dyn ConfluenceTransport>,
+}
+
+impl ConfluenceSource {
+    /// Build from resolved config using canonical + Confluence-scoped env creds.
+    ///
+    /// Why: the runner wires the source without knowing credential mechanics.
+    /// What: resolves `AtlassianCreds::from_env_for(Confluence)`, computes
+    /// `effective_enabled`, and attaches the production transport.
+    /// Test: `disabled_when_no_creds`.
+    pub fn from_config(cfg: &super::SourceConfig) -> Self {
+        let creds = AtlassianCreds::from_env_for(AtlassianProduct::Confluence);
+        let enabled = cfg.effective_enabled(creds.is_some());
+        Self {
+            enabled,
+            mode: cfg.mode,
+            creds,
+            transport: Box::new(ReqwestConfluenceTransport::new()),
+        }
+    }
+
+    /// Construct directly (tests inject a fake transport / creds).
+    ///
+    /// Why: drive `gather` without env or network.
+    /// What: stores the provided fields verbatim.
+    /// Test: `gather_with_fake_transport`, `semantic_mode_errors`.
+    pub fn new(
+        enabled: bool,
+        mode: RetrievalMode,
+        creds: Option<AtlassianCreds>,
+        transport: Box<dyn ConfluenceTransport>,
+    ) -> Self {
+        Self {
+            enabled,
+            mode,
+            creds,
+            transport,
+        }
+    }
+
+    /// Build the CQL string from the subject's keyword query.
+    ///
+    /// Why: Confluence full-text search uses `text ~ "..."`; one builder keeps
+    /// quoting consistent and testable, and scopes results to pages.
+    /// What: returns `type=page AND text ~ "<keywords>" ORDER BY lastmodified DESC`
+    /// (double-quotes stripped from keywords).  `None` when no keyword signal.
+    /// Test: `query_builds_cql`.
+    fn build_cql(subject: &ReviewSubject) -> Option<String> {
+        let keywords = subject.keyword_query(MAX_QUERY_IDENTIFIERS);
+        let keywords = keywords.replace('"', " ");
+        let keywords = keywords.trim();
+        if keywords.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "type=page AND text ~ \"{keywords}\" ORDER BY lastmodified DESC"
+        ))
+    }
+
+    /// Parse a Confluence search body into a `ContextSection`.
+    ///
+    /// Why: separate parsing from the network call for unit-testability.
+    /// What: maps each page to a `ContextSnippet` (title, subtitle = space name
+    /// or key, link = `{base}/wiki{webui}`), wrapped in a `Related Confluence
+    /// docs` section.
+    /// Test: `parse_pages_to_section`.
+    fn parse_section(body: &str, base_url: &str) -> Result<ContextSection, ContextSourceError> {
+        let resp: ConfluenceSearchResponse =
+            serde_json::from_str(body).map_err(|e| ContextSourceError::Parse {
+                src: SOURCE_NAME,
+                detail: e.to_string(),
+            })?;
+        let snippets = resp
+            .results
+            .into_iter()
+            .map(|page| {
+                let subtitle = page
+                    .space
+                    .and_then(|s| s.name.or(s.key))
+                    .map(|s| format!("space: {s}"));
+                let link = page
+                    .links
+                    .and_then(|l| l.webui)
+                    .map(|webui| format!("{base_url}/wiki{webui}"));
+                ContextSnippet {
+                    title: page.title,
+                    subtitle,
+                    body: None,
+                    link,
+                }
+            })
+            .collect();
+        Ok(ContextSection {
+            heading: "Related Confluence docs".to_string(),
+            snippets,
+        })
+    }
+}
+
+#[async_trait]
+impl ContextSource for ConfluenceSource {
+    fn name(&self) -> &'static str {
+        SOURCE_NAME
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn mode(&self) -> RetrievalMode {
+        self.mode
+    }
+
+    async fn gather(&self, subject: &ReviewSubject) -> Result<ContextSection, ContextSourceError> {
+        if self.mode == RetrievalMode::Semantic {
+            return Err(ContextSourceError::SemanticNotImplemented { src: SOURCE_NAME });
+        }
+        let creds = self
+            .creds
+            .as_ref()
+            .ok_or(ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: "ATLASSIAN_API_TOKEN / ATLASSIAN_EMAIL / ATLASSIAN_URL not set".to_string(),
+            })?;
+        let Some(cql) = Self::build_cql(subject) else {
+            return Ok(ContextSection {
+                heading: "Related Confluence docs".to_string(),
+                snippets: Vec::new(),
+            });
+        };
+        let body = self.transport.search_cql(creds, &cql, MAX_RESULTS).await?;
+        Self::parse_section(&body, &creds.base_url)
+    }
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn creds() -> AtlassianCreds {
+        AtlassianCreds {
+            email: "bob@acme.com".to_string(),
+            token: "tok".to_string(), // pragma: allowlist secret
+            base_url: "https://acme.atlassian.net".to_string(),
+        }
+    }
+
+    struct FakeConfluence {
+        body: Result<String, ()>,
+    }
+
+    #[async_trait]
+    impl ConfluenceTransport for FakeConfluence {
+        async fn search_cql(
+            &self,
+            _creds: &AtlassianCreds,
+            _cql: &str,
+            _limit: u32,
+        ) -> Result<String, ContextSourceError> {
+            self.body.clone().map_err(|_| ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: 502,
+                body: "down".to_string(),
+            })
+        }
+    }
+
+    fn subject() -> ReviewSubject {
+        ReviewSubject {
+            owner: "acme".to_string(),
+            repo: "backend".to_string(),
+            title: "Auth design".to_string(),
+            identifiers: vec!["Session".to_string()],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn query_builds_cql() {
+        let cql = ConfluenceSource::build_cql(&subject()).expect("has signal");
+        assert!(cql.contains("type=page"));
+        assert!(cql.contains("text ~ \"Auth design Session\""));
+        assert!(cql.contains("ORDER BY lastmodified DESC"));
+    }
+
+    #[test]
+    fn query_none_without_signal() {
+        assert!(ConfluenceSource::build_cql(&ReviewSubject::default()).is_none());
+    }
+
+    #[test]
+    fn parse_pages_to_section() {
+        let body = r#"{
+            "results": [
+                {"title": "Auth Architecture", "space": {"name": "Engineering"},
+                 "_links": {"webui": "/spaces/ENG/pages/123/Auth"}},
+                {"title": "Sessions", "space": {"key": "ENG"}}
+            ]
+        }"#;
+        let section = ConfluenceSource::parse_section(body, "https://acme.atlassian.net").unwrap();
+        assert_eq!(section.heading, "Related Confluence docs");
+        assert_eq!(section.snippets.len(), 2);
+        assert_eq!(section.snippets[0].title, "Auth Architecture");
+        assert_eq!(
+            section.snippets[0].subtitle.as_deref(),
+            Some("space: Engineering")
+        );
+        assert_eq!(
+            section.snippets[0].link.as_deref(),
+            Some("https://acme.atlassian.net/wiki/spaces/ENG/pages/123/Auth")
+        );
+        // Second page has only a space key and no link.
+        assert_eq!(section.snippets[1].subtitle.as_deref(), Some("space: ENG"));
+        assert!(section.snippets[1].link.is_none());
+    }
+
+    #[test]
+    fn parse_error_on_garbage() {
+        let r = ConfluenceSource::parse_section("xx", "https://acme.atlassian.net");
+        assert!(matches!(r, Err(ContextSourceError::Parse { .. })));
+    }
+
+    #[tokio::test]
+    async fn disabled_when_no_creds() {
+        let src = ConfluenceSource::new(
+            true,
+            RetrievalMode::Live,
+            None,
+            Box::new(FakeConfluence {
+                body: Ok("{}".into()),
+            }),
+        );
+        let r = src.gather(&subject()).await;
+        assert!(matches!(r, Err(ContextSourceError::NotConfigured { .. })));
+    }
+
+    #[tokio::test]
+    async fn semantic_mode_errors() {
+        let src = ConfluenceSource::new(
+            true,
+            RetrievalMode::Semantic,
+            Some(creds()),
+            Box::new(FakeConfluence {
+                body: Ok("{}".into()),
+            }),
+        );
+        let r = src.gather(&subject()).await;
+        assert!(matches!(
+            r,
+            Err(ContextSourceError::SemanticNotImplemented { src: "confluence" })
+        ));
+    }
+
+    #[tokio::test]
+    async fn gather_with_fake_transport() {
+        let body = r#"{"results":[{"title":"Design Doc","space":{"name":"Eng"}}]}"#;
+        let src = ConfluenceSource::new(
+            true,
+            RetrievalMode::Live,
+            Some(creds()),
+            Box::new(FakeConfluence {
+                body: Ok(body.to_string()),
+            }),
+        );
+        let section = src.gather(&subject()).await.expect("ok");
+        assert_eq!(section.snippets.len(), 1);
+        assert_eq!(section.snippets[0].title, "Design Doc");
+    }
+}

--- a/crates/trusty-review/src/integrations/context/github_issues.rs
+++ b/crates/trusty-review/src/integrations/context/github_issues.rs
@@ -1,0 +1,382 @@
+//! LIVE GitHub Issues context source (Phase 6, #550).
+//!
+//! Why: the reviewed repo's own issues frequently capture the bug a PR fixes or
+//! the feature it implements.  Surfacing related issues lets the reviewer judge
+//! whether the diff actually closes them.  This is the fourth Stage-5 retrieval
+//! source code-intelligence performs.
+//!
+//! What: `GithubIssuesSource` implements `ContextSource` in `Live` mode by
+//! issuing a GitHub Search-API query (`GET /search/issues`) scoped to the repo
+//! (`repo:{owner}/{repo} is:issue <keywords>`), then mapping each hit to a
+//! `## Related GitHub issues` bullet (number, title, state, html link).
+//!
+//! ## Auth reuse (NO new auth)
+//! GitHub auth is the Phase-1 dual-mode abstraction (#582): the token is
+//! resolved by an injected `IssueTokenResolver` that, in production, delegates to
+//! `AuthStrategy::select(run_mode).resolve_token(...)` — CLI → PAT/`gh`, serve →
+//! App.  This source adds NO new credential mechanism; it threads the existing
+//! one through a small resolver trait so the search query + parse logic stays
+//! network-/auth-free for tests.
+//!
+//! Fail-open: token resolution failure → `NotConfigured` (skip, logged once);
+//! transport / API / parse error → orchestrator logs and drops the section.
+//! Never blocks the review.
+//!
+//! Test: `query_builds_search`, `parse_issues_to_section`,
+//! `disabled_without_token`, `semantic_mode_errors`, `gather_with_fakes`.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::{
+    ContextSection, ContextSnippet, ContextSource, ContextSourceError, RetrievalMode,
+    ReviewSubject, TransportErr,
+};
+use crate::config::ReviewConfig;
+use crate::integrations::github::{AuthStrategy, GithubClient, RunMode};
+
+/// Source identifier used in logs, config keys, and error messages.
+const SOURCE_NAME: &str = "github_issues";
+
+/// Max issues to embed in the section.
+const MAX_RESULTS: u32 = 5;
+
+/// Max diff identifiers folded into the keyword query.
+const MAX_QUERY_IDENTIFIERS: usize = 4;
+
+// ─── Auth seam (reuses #582 dual-mode auth) ─────────────────────────────────
+
+/// Resolves a GitHub bearer token for the issue-search call.
+///
+/// Why: this is the seam that REUSES the Phase-1 dual-mode auth (#582) without
+/// the source knowing whether it is PAT- or App-backed, and lets tests inject a
+/// fixed token (or a failure) so the query/parse logic is testable without
+/// `gh`/network.
+/// What: one async method returning a token for `owner`, or a `ContextSourceError`
+/// (mapped to `NotConfigured` so the orchestrator skips fail-open).
+/// Test: implemented by `DualModeTokenResolver` (prod) and a fake in tests.
+#[async_trait]
+pub trait IssueTokenResolver: Send + Sync {
+    /// Resolve a GitHub token for `owner`, or an error (treated as skip).
+    async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError>;
+}
+
+/// Production resolver delegating to the #582 `AuthStrategy`.
+///
+/// Why: keeps the single dual-mode auth funnel — no second credential path.
+/// What: holds the resolved run mode + a cloned `ReviewConfig`; on `resolve`,
+/// selects the strategy (CLI→PAT/`gh`, Serve→App) and resolves a token, mapping
+/// any `GithubError` to `NotConfigured` (skip).
+/// Test: not unit-tested directly (requires real auth); the seam is exercised
+/// via the fake in `gather_with_fakes`.
+pub struct DualModeTokenResolver {
+    run_mode: RunMode,
+    config: ReviewConfig,
+}
+
+impl DualModeTokenResolver {
+    /// Construct from the run mode and a config snapshot.
+    ///
+    /// Why: the resolver needs the same config the rest of the GitHub path uses
+    /// (App id/key, PAT) to mint a token.
+    /// What: stores `run_mode` and a clone of `config`.
+    /// Test: covered transitively by `GithubIssuesSource::from_config`.
+    pub fn new(run_mode: RunMode, config: ReviewConfig) -> Self {
+        Self { run_mode, config }
+    }
+}
+
+#[async_trait]
+impl IssueTokenResolver for DualModeTokenResolver {
+    async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError> {
+        let client = GithubClient::new();
+        AuthStrategy::select(self.run_mode, None)
+            .resolve_token(&client, &self.config, owner)
+            .await
+            .map_err(|e| ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: format!("GitHub token unavailable: {e}"),
+            })
+    }
+}
+
+// ─── Search transport seam ──────────────────────────────────────────────────
+
+/// Injectable transport for the GitHub issue-search call.
+///
+/// Why: isolate the only network call so query construction + parsing are
+/// tested against canned JSON.
+/// What: one async method performing `GET /search/issues?q=...` with the bearer
+/// token, returning the raw JSON body (or a typed failure).
+/// Test: implemented by `ReqwestIssueSearch` (prod) and a fake in tests.
+#[async_trait]
+pub trait IssueSearchTransport: Send + Sync {
+    /// Run the issue search and return the raw response body on 2xx.
+    async fn search(
+        &self,
+        token: &str,
+        query: &str,
+        per_page: u32,
+    ) -> Result<String, ContextSourceError>;
+}
+
+/// Production `IssueSearchTransport` over reqwest + the GitHub Search API.
+///
+/// Why: the default transport for real reviews.
+/// What: GETs `https://api.github.com/search/issues` with the bearer token and
+/// the GitHub `User-Agent`, mapping non-2xx to `Api` and transport failures to
+/// `Transport`.
+/// Test: exercised via the fake in `gather_with_fakes`.
+pub struct ReqwestIssueSearch {
+    http: reqwest::Client,
+}
+
+impl ReqwestIssueSearch {
+    /// Construct with a default 15s-timeout client.
+    ///
+    /// Why: bound the worst-case latency of an enrichment call.
+    /// What: builds a reqwest client; panics only on TLS-backend init failure.
+    /// Test: covered transitively by `GithubIssuesSource::from_config`.
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .expect("reqwest::Client::build failed — TLS backend unavailable");
+        Self { http }
+    }
+}
+
+impl Default for ReqwestIssueSearch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl IssueSearchTransport for ReqwestIssueSearch {
+    async fn search(
+        &self,
+        token: &str,
+        query: &str,
+        per_page: u32,
+    ) -> Result<String, ContextSourceError> {
+        let url = "https://api.github.com/search/issues";
+        let resp = self
+            .http
+            .get(url)
+            .query(&[
+                ("q", query),
+                ("per_page", &per_page.to_string()),
+                ("sort", "updated"),
+            ])
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "trusty-review")
+            .send()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("GET {url}: {e}")),
+            })?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("read body of {url}: {e}")),
+            })?;
+        if !status.is_success() {
+            return Err(ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: status.as_u16(),
+                body: text,
+            });
+        }
+        Ok(text)
+    }
+}
+
+// ─── JSON shapes ────────────────────────────────────────────────────────────
+
+/// GitHub `search/issues` response (only the fields we render).
+#[derive(Debug, Deserialize)]
+struct IssueSearchResponse {
+    #[serde(default)]
+    items: Vec<IssueItem>,
+}
+
+/// One issue search hit.
+#[derive(Debug, Deserialize)]
+struct IssueItem {
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    html_url: String,
+    /// Present on PRs (not plain issues); used to filter PRs out.
+    #[serde(default)]
+    pull_request: Option<serde_json::Value>,
+}
+
+// ─── The source ─────────────────────────────────────────────────────────────
+
+/// LIVE GitHub Issues context source.
+///
+/// Why: implements the `ContextSource` seam for GitHub Issues, reusing the #582
+/// dual-mode auth via the injected `IssueTokenResolver`.
+/// What: holds `enabled`, `mode`, the token resolver, and the search transport.
+/// Unlike the Atlassian sources, "creds present" is decided at gather time (the
+/// token resolver may fail), so `enabled` here reflects only config intent
+/// (default disabled unless explicitly enabled — see `from_config`).
+/// Test: `disabled_without_token`, `gather_with_fakes`.
+pub struct GithubIssuesSource {
+    enabled: bool,
+    mode: RetrievalMode,
+    token: Box<dyn IssueTokenResolver>,
+    transport: Box<dyn IssueSearchTransport>,
+}
+
+impl GithubIssuesSource {
+    /// Build from resolved config + run mode, wiring the dual-mode resolver.
+    ///
+    /// Why: the runner enables GitHub Issues when configured; because the token
+    /// is resolved lazily at gather time (and may legitimately be present via
+    /// `gh`), we treat "creds present" as true for the auto-enable decision and
+    /// let the resolver fail-open at gather time if no token is actually
+    /// available.  An explicit `enabled = false` still wins.
+    /// What: computes `effective_enabled(true)` (auto-enable when not explicitly
+    /// disabled), and attaches the `DualModeTokenResolver` + prod transport.
+    /// Test: `from_config_respects_explicit_disable`.
+    pub fn from_config(cfg: &super::SourceConfig, run_mode: RunMode, config: ReviewConfig) -> Self {
+        // GitHub credentials may come from `gh` even with no env token, so we
+        // cannot cheaply pre-detect them; treat as available and fail-open later.
+        let enabled = cfg.effective_enabled(true);
+        Self {
+            enabled,
+            mode: cfg.mode,
+            token: Box::new(DualModeTokenResolver::new(run_mode, config)),
+            transport: Box::new(ReqwestIssueSearch::new()),
+        }
+    }
+
+    /// Construct directly (tests inject fakes).
+    ///
+    /// Why: drive `gather` without auth or network.
+    /// What: stores the provided fields verbatim.
+    /// Test: `gather_with_fakes`, `semantic_mode_errors`.
+    pub fn new(
+        enabled: bool,
+        mode: RetrievalMode,
+        token: Box<dyn IssueTokenResolver>,
+        transport: Box<dyn IssueSearchTransport>,
+    ) -> Self {
+        Self {
+            enabled,
+            mode,
+            token,
+            transport,
+        }
+    }
+
+    /// Build the GitHub search query string for the subject.
+    ///
+    /// Why: GitHub's issue search scopes by `repo:` and `is:issue`; centralising
+    /// the construction keeps the qualifier set consistent and testable.
+    /// What: returns `repo:{owner}/{repo} is:issue <keywords>`.  `None` when
+    /// there is no keyword signal or no owner/repo (local-diff mode).
+    /// Test: `query_builds_search`.
+    fn build_query(subject: &ReviewSubject) -> Option<String> {
+        if subject.owner.is_empty() || subject.repo.is_empty() {
+            return None;
+        }
+        let keywords = subject.keyword_query(MAX_QUERY_IDENTIFIERS);
+        let keywords = keywords.trim();
+        if keywords.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "repo:{}/{} is:issue {keywords}",
+            subject.owner, subject.repo
+        ))
+    }
+
+    /// Parse a GitHub issue-search body into a `ContextSection`.
+    ///
+    /// Why: separate parsing from the network call for unit-testability, and
+    /// filter out PR hits (the search API returns PRs as issues).
+    /// What: drops any item with a `pull_request` field, then maps each issue to
+    /// a `ContextSnippet` (`#N — title`, subtitle = state, link = html_url),
+    /// wrapped in a `Related GitHub issues` section.
+    /// Test: `parse_issues_to_section`, `parse_filters_pull_requests`.
+    fn parse_section(body: &str) -> Result<ContextSection, ContextSourceError> {
+        let resp: IssueSearchResponse =
+            serde_json::from_str(body).map_err(|e| ContextSourceError::Parse {
+                src: SOURCE_NAME,
+                detail: e.to_string(),
+            })?;
+        let snippets = resp
+            .items
+            .into_iter()
+            .filter(|i| i.pull_request.is_none())
+            .map(|i| {
+                let title = if i.title.is_empty() {
+                    format!("#{}", i.number)
+                } else {
+                    format!("#{} — {}", i.number, i.title)
+                };
+                ContextSnippet {
+                    title,
+                    subtitle: (!i.state.is_empty()).then(|| i.state.clone()),
+                    body: None,
+                    link: (!i.html_url.is_empty()).then(|| i.html_url.clone()),
+                }
+            })
+            .collect();
+        Ok(ContextSection {
+            heading: "Related GitHub issues".to_string(),
+            snippets,
+        })
+    }
+}
+
+#[async_trait]
+impl ContextSource for GithubIssuesSource {
+    fn name(&self) -> &'static str {
+        SOURCE_NAME
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn mode(&self) -> RetrievalMode {
+        self.mode
+    }
+
+    async fn gather(&self, subject: &ReviewSubject) -> Result<ContextSection, ContextSourceError> {
+        if self.mode == RetrievalMode::Semantic {
+            return Err(ContextSourceError::SemanticNotImplemented { src: SOURCE_NAME });
+        }
+        let Some(query) = Self::build_query(subject) else {
+            // No repo/keyword signal (e.g. local-diff) — empty section, not error.
+            return Ok(ContextSection {
+                heading: "Related GitHub issues".to_string(),
+                snippets: Vec::new(),
+            });
+        };
+        // Resolve a token via the reused dual-mode auth; failure → skip fail-open.
+        let token = self.token.resolve(&subject.owner).await?;
+        let body = self.transport.search(&token, &query, MAX_RESULTS).await?;
+        Self::parse_section(&body)
+    }
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+// Extracted to github_issues_tests.rs to keep this file under the 500-line cap.
+
+#[cfg(test)]
+#[path = "github_issues_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/integrations/context/github_issues_tests.rs
+++ b/crates/trusty-review/src/integrations/context/github_issues_tests.rs
@@ -1,0 +1,158 @@
+//! Tests for the GitHub Issues context source.
+//!
+//! Why: extracted from `github_issues.rs` to keep that file under the 500-line
+//! cap while preserving full coverage (query construction, parse + PR filtering,
+//! the semantic-mode error path, and the fail-open token/transport seams).
+//! What: query/parse unit tests plus fake-driven `gather` tests (no network).
+//! Test: included as `#[cfg(test)] mod tests` from `github_issues.rs`.
+
+use super::*;
+
+struct FakeToken(Result<String, ()>);
+#[async_trait]
+impl IssueTokenResolver for FakeToken {
+    async fn resolve(&self, _owner: &str) -> Result<String, ContextSourceError> {
+        self.0
+            .clone()
+            .map_err(|_| ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: "no token".to_string(),
+            })
+    }
+}
+
+struct FakeSearch(Result<String, ()>);
+#[async_trait]
+impl IssueSearchTransport for FakeSearch {
+    async fn search(&self, _t: &str, _q: &str, _n: u32) -> Result<String, ContextSourceError> {
+        self.0.clone().map_err(|_| ContextSourceError::Api {
+            src: SOURCE_NAME,
+            status: 403,
+            body: "rate limited".to_string(),
+        })
+    }
+}
+
+fn subject() -> ReviewSubject {
+    ReviewSubject {
+        owner: "acme".to_string(),
+        repo: "backend".to_string(),
+        title: "Fix login".to_string(),
+        identifiers: vec!["login".to_string()],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn query_builds_search() {
+    let q = GithubIssuesSource::build_query(&subject()).expect("signal");
+    assert!(q.starts_with("repo:acme/backend is:issue "));
+    assert!(q.contains("Fix login"));
+}
+
+#[test]
+fn query_none_for_local_diff() {
+    let subj = ReviewSubject {
+        owner: "local".to_string(),
+        repo: String::new(),
+        title: "x".to_string(),
+        ..Default::default()
+    };
+    assert!(GithubIssuesSource::build_query(&subj).is_none());
+}
+
+#[test]
+fn parse_issues_to_section() {
+    let body = r#"{
+        "items": [
+            {"number": 42, "title": "Login broken", "state": "open",
+             "html_url": "https://github.com/acme/backend/issues/42"}
+        ]
+    }"#;
+    let section = GithubIssuesSource::parse_section(body).unwrap();
+    assert_eq!(section.heading, "Related GitHub issues");
+    assert_eq!(section.snippets.len(), 1);
+    assert_eq!(section.snippets[0].title, "#42 — Login broken");
+    assert_eq!(section.snippets[0].subtitle.as_deref(), Some("open"));
+    assert_eq!(
+        section.snippets[0].link.as_deref(),
+        Some("https://github.com/acme/backend/issues/42")
+    );
+}
+
+#[test]
+fn parse_filters_pull_requests() {
+    let body = r#"{
+        "items": [
+            {"number": 1, "title": "real issue", "state": "open", "html_url": "u1"},
+            {"number": 2, "title": "a PR", "state": "open", "html_url": "u2",
+             "pull_request": {"url": "x"}}
+        ]
+    }"#;
+    let section = GithubIssuesSource::parse_section(body).unwrap();
+    // The PR item is dropped.
+    assert_eq!(section.snippets.len(), 1);
+    assert_eq!(section.snippets[0].title, "#1 — real issue");
+}
+
+#[test]
+fn parse_error_on_garbage() {
+    assert!(matches!(
+        GithubIssuesSource::parse_section("nope"),
+        Err(ContextSourceError::Parse { .. })
+    ));
+}
+
+#[test]
+fn from_config_respects_explicit_disable() {
+    let cfg = super::super::SourceConfig {
+        enabled: Some(false),
+        mode: RetrievalMode::Live,
+    };
+    let src = GithubIssuesSource::from_config(&cfg, RunMode::Cli, ReviewConfig::load(None));
+    assert!(!src.is_enabled());
+}
+
+#[tokio::test]
+async fn disabled_without_token() {
+    let src = GithubIssuesSource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Err(()))),
+        Box::new(FakeSearch(Ok("{}".into()))),
+    );
+    let r = src.gather(&subject()).await;
+    assert!(matches!(r, Err(ContextSourceError::NotConfigured { .. })));
+}
+
+#[tokio::test]
+async fn semantic_mode_errors() {
+    let src = GithubIssuesSource::new(
+        true,
+        RetrievalMode::Semantic,
+        Box::new(FakeToken(Ok("t".into()))),
+        Box::new(FakeSearch(Ok("{}".into()))),
+    );
+    let r = src.gather(&subject()).await;
+    assert!(matches!(
+        r,
+        Err(ContextSourceError::SemanticNotImplemented {
+            src: "github_issues"
+        })
+    ));
+}
+
+#[tokio::test]
+async fn gather_with_fakes() {
+    let body = r#"{"items":[{"number":7,"title":"bug","state":"closed","html_url":"u"}]}"#;
+    let src = GithubIssuesSource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Ok("tok".into()))),
+        Box::new(FakeSearch(Ok(body.to_string()))),
+    );
+    let section = src.gather(&subject()).await.expect("ok");
+    assert_eq!(section.snippets.len(), 1);
+    assert_eq!(section.snippets[0].title, "#7 — bug");
+    assert_eq!(section.snippets[0].subtitle.as_deref(), Some("closed"));
+}

--- a/crates/trusty-review/src/integrations/context/jira.rs
+++ b/crates/trusty-review/src/integrations/context/jira.rs
@@ -1,0 +1,492 @@
+//! LIVE JIRA context source (Phase 6, #550).
+//!
+//! Why: when a PR implements a JIRA ticket, surfacing that ticket's summary +
+//! status in the reviewer prompt gives the model the *intent* behind the change
+//! — turning "is this code correct?" into "does this code do what the ticket
+//! asked?".  This is the same Stage-5 retrieval code-intelligence performs.
+//!
+//! What: `JiraSource` implements `ContextSource` in `Live` mode by issuing a JQL
+//! `text ~ "<keywords>"` search against `{base}/rest/api/3/search/jql` using the
+//! shared `AtlassianCreds` basic-auth header, then mapping each issue to a
+//! `## Related JIRA tickets` bullet (key, summary, status, browse link).  The
+//! HTTP call goes through an injectable `JiraTransport` trait so the query +
+//! parse logic is unit-tested against canned JSON with no network.
+//!
+//! Fail-open: missing creds → `NotConfigured` (skip, logged once); any transport
+//! / API / parse error → the orchestrator logs and drops the section.  A JIRA
+//! outage NEVER blocks the review (#550 supplementary-vs-required distinction).
+//!
+//! Test: `query_builds_jql`, `parse_issues_to_section`, `disabled_when_no_creds`,
+//! `semantic_mode_errors`, `gather_with_fake_transport` in this module.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::atlassian::{AtlassianCreds, AtlassianProduct};
+use super::{
+    ContextSection, ContextSnippet, ContextSource, ContextSourceError, RetrievalMode,
+    ReviewSubject, TransportErr,
+};
+
+/// Source identifier used in logs, config keys, and error messages.
+const SOURCE_NAME: &str = "jira";
+
+/// Max JIRA issues to embed in the section (keeps the prompt bounded).
+const MAX_RESULTS: u32 = 5;
+
+/// Max diff identifiers folded into the keyword query.
+const MAX_QUERY_IDENTIFIERS: usize = 6;
+
+// ─── Transport seam ─────────────────────────────────────────────────────────
+
+/// Injectable HTTP transport for the JIRA search call.
+///
+/// Why: the source's value is its query-construction + response-parsing logic,
+/// which must be unit-testable without a live JIRA.  Hiding the single network
+/// call behind this trait lets tests inject canned JSON.
+/// What: one async method that performs the JQL search and returns the raw JSON
+/// body (or a `TransportErr`/`Api` failure).  The real impl uses reqwest.
+/// Test: implemented by `ReqwestJiraTransport` (prod) and fakes in tests.
+#[async_trait]
+pub trait JiraTransport: Send + Sync {
+    /// POST a JQL search and return the raw response body on 2xx.
+    async fn search_jql(
+        &self,
+        creds: &AtlassianCreds,
+        jql: &str,
+        max_results: u32,
+    ) -> Result<String, ContextSourceError>;
+}
+
+/// Production `JiraTransport` over reqwest.
+///
+/// Why: the default transport for real reviews; isolates the only network call.
+/// What: POSTs `{base}/rest/api/3/search/jql` with basic auth and a JSON body
+/// `{ jql, maxResults, fields }`, mapping non-2xx to `Api` and transport
+/// failures to `Transport`.
+/// Test: not unit-tested (requires network); exercised via the fake in
+/// `gather_with_fake_transport`.
+pub struct ReqwestJiraTransport {
+    /// Shared reqwest client (connection pool reuse).
+    http: reqwest::Client,
+}
+
+impl ReqwestJiraTransport {
+    /// Construct with a default 15s-timeout client.
+    ///
+    /// Why: external enrichment must not hang a review; a tight timeout bounds
+    /// the worst case (the orchestrator also wraps each source in a timeout).
+    /// What: builds a reqwest client; panics only on TLS-backend init failure
+    /// (a programmer/environment error, never a runtime condition).
+    /// Test: covered transitively by `JiraSource::with_default_transport`.
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .expect("reqwest::Client::build failed — TLS backend unavailable");
+        Self { http }
+    }
+}
+
+impl Default for ReqwestJiraTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl JiraTransport for ReqwestJiraTransport {
+    async fn search_jql(
+        &self,
+        creds: &AtlassianCreds,
+        jql: &str,
+        max_results: u32,
+    ) -> Result<String, ContextSourceError> {
+        let url = format!("{}/rest/api/3/search/jql", creds.base_url);
+        let body = serde_json::json!({
+            "jql": jql,
+            "maxResults": max_results,
+            "fields": ["summary", "status"],
+        });
+        let resp = self
+            .http
+            .post(&url)
+            .header("Authorization", creds.basic_auth_header())
+            .header("Accept", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("POST {url}: {e}")),
+            })?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("read body of {url}: {e}")),
+            })?;
+        if !status.is_success() {
+            return Err(ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: status.as_u16(),
+                body: text,
+            });
+        }
+        Ok(text)
+    }
+}
+
+// ─── JSON shapes ────────────────────────────────────────────────────────────
+
+/// Top-level JIRA `search/jql` response (only the fields we render).
+#[derive(Debug, Deserialize)]
+struct JiraSearchResponse {
+    #[serde(default)]
+    issues: Vec<JiraIssue>,
+}
+
+/// One JIRA issue from the search response.
+#[derive(Debug, Deserialize)]
+struct JiraIssue {
+    key: String,
+    #[serde(default)]
+    fields: JiraFields,
+}
+
+/// The subset of issue fields we requested.
+#[derive(Debug, Default, Deserialize)]
+struct JiraFields {
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    status: Option<JiraStatus>,
+}
+
+/// Issue status object (we only need its display name).
+#[derive(Debug, Deserialize)]
+struct JiraStatus {
+    name: String,
+}
+
+// ─── The source ─────────────────────────────────────────────────────────────
+
+/// LIVE JIRA context source.
+///
+/// Why: implements the `ContextSource` seam for JIRA; constructed by the runner
+/// when the JIRA source is enabled (config + Atlassian creds present).
+/// What: holds the resolved `enabled` flag, the retrieval `mode`, the optional
+/// `AtlassianCreds`, and the injected transport.  `enabled` is false when creds
+/// are absent (auto-disable), so `gather` returns `NotConfigured` only if forced
+/// on without creds.
+/// Test: `disabled_when_no_creds`, `gather_with_fake_transport`.
+pub struct JiraSource {
+    enabled: bool,
+    mode: RetrievalMode,
+    creds: Option<AtlassianCreds>,
+    transport: Box<dyn JiraTransport>,
+}
+
+impl JiraSource {
+    /// Build from resolved config using the canonical + JIRA-scoped env creds.
+    ///
+    /// Why: the runner wires the source from `ContextSourcesConfig` without
+    /// knowing the credential mechanics; this resolves them and computes the
+    /// auto-disable (no creds → disabled unless explicitly enabled).
+    /// What: resolves `AtlassianCreds::from_env_for(Jira)`, computes
+    /// `effective_enabled(creds_present)`, and attaches the production transport.
+    /// Test: `disabled_when_no_creds`.
+    pub fn from_config(cfg: &super::SourceConfig) -> Self {
+        let creds = AtlassianCreds::from_env_for(AtlassianProduct::Jira);
+        let enabled = cfg.effective_enabled(creds.is_some());
+        Self {
+            enabled,
+            mode: cfg.mode,
+            creds,
+            transport: Box::new(ReqwestJiraTransport::new()),
+        }
+    }
+
+    /// Construct directly (used by tests to inject a fake transport / creds).
+    ///
+    /// Why: tests need to drive `gather` without env vars or a network.
+    /// What: stores the provided enabled/mode/creds/transport verbatim.
+    /// Test: used by `gather_with_fake_transport`, `semantic_mode_errors`.
+    pub fn new(
+        enabled: bool,
+        mode: RetrievalMode,
+        creds: Option<AtlassianCreds>,
+        transport: Box<dyn JiraTransport>,
+    ) -> Self {
+        Self {
+            enabled,
+            mode,
+            creds,
+            transport,
+        }
+    }
+
+    /// Build the JQL string from the review subject's keyword query.
+    ///
+    /// Why: JIRA's full-text search uses `text ~ "..."`; building the JQL in one
+    /// place keeps quoting/escaping consistent and testable.
+    /// What: returns `text ~ "<keywords>" ORDER BY updated DESC`, with embedded
+    /// double-quotes stripped from the keyword string to avoid breaking the JQL.
+    /// Returns `None` when there is no keyword signal (caller skips the call).
+    /// Test: `query_builds_jql`.
+    fn build_jql(subject: &ReviewSubject) -> Option<String> {
+        let keywords = subject.keyword_query(MAX_QUERY_IDENTIFIERS);
+        let keywords = keywords.replace('"', " ");
+        let keywords = keywords.trim();
+        if keywords.is_empty() {
+            return None;
+        }
+        Some(format!("text ~ \"{keywords}\" ORDER BY updated DESC"))
+    }
+
+    /// Parse a JIRA search response body into a `ContextSection`.
+    ///
+    /// Why: separating parsing from the network call makes the mapping
+    /// (issue → bullet) unit-testable against canned JSON.
+    /// What: deserialises the body, maps each issue to a `ContextSnippet`
+    /// (`KEY — summary`, subtitle = status, link = `{base}/browse/KEY`), and
+    /// wraps them in a `Related JIRA tickets` section.
+    /// Test: `parse_issues_to_section`.
+    fn parse_section(body: &str, base_url: &str) -> Result<ContextSection, ContextSourceError> {
+        let resp: JiraSearchResponse =
+            serde_json::from_str(body).map_err(|e| ContextSourceError::Parse {
+                src: SOURCE_NAME,
+                detail: e.to_string(),
+            })?;
+        let snippets = resp
+            .issues
+            .into_iter()
+            .map(|issue| {
+                let summary = issue.fields.summary.unwrap_or_default();
+                let title = if summary.is_empty() {
+                    issue.key.clone()
+                } else {
+                    format!("{} — {summary}", issue.key)
+                };
+                ContextSnippet {
+                    title,
+                    subtitle: issue.fields.status.map(|s| s.name),
+                    body: None,
+                    link: Some(format!("{base_url}/browse/{}", issue.key)),
+                }
+            })
+            .collect();
+        Ok(ContextSection {
+            heading: "Related JIRA tickets".to_string(),
+            snippets,
+        })
+    }
+}
+
+#[async_trait]
+impl ContextSource for JiraSource {
+    fn name(&self) -> &'static str {
+        SOURCE_NAME
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn mode(&self) -> RetrievalMode {
+        self.mode
+    }
+
+    async fn gather(&self, subject: &ReviewSubject) -> Result<ContextSection, ContextSourceError> {
+        // PR-A implements only the Live backend.
+        if self.mode == RetrievalMode::Semantic {
+            return Err(ContextSourceError::SemanticNotImplemented { src: SOURCE_NAME });
+        }
+        let creds = self
+            .creds
+            .as_ref()
+            .ok_or(ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: "ATLASSIAN_API_TOKEN / ATLASSIAN_EMAIL / ATLASSIAN_URL not set".to_string(),
+            })?;
+        let Some(jql) = Self::build_jql(subject) else {
+            // No keyword signal (e.g. local-diff with empty title) — nothing to
+            // search.  Empty section, not an error.
+            return Ok(ContextSection {
+                heading: "Related JIRA tickets".to_string(),
+                snippets: Vec::new(),
+            });
+        };
+        let body = self.transport.search_jql(creds, &jql, MAX_RESULTS).await?;
+        Self::parse_section(&body, &creds.base_url)
+    }
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn creds() -> AtlassianCreds {
+        AtlassianCreds {
+            email: "bob@acme.com".to_string(),
+            token: "tok".to_string(), // pragma: allowlist secret
+            base_url: "https://acme.atlassian.net".to_string(),
+        }
+    }
+
+    /// A `JiraTransport` returning a fixed body (or error) without network.
+    struct FakeJira {
+        body: Result<String, ()>,
+    }
+
+    #[async_trait]
+    impl JiraTransport for FakeJira {
+        async fn search_jql(
+            &self,
+            _creds: &AtlassianCreds,
+            _jql: &str,
+            _max: u32,
+        ) -> Result<String, ContextSourceError> {
+            self.body.clone().map_err(|_| ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: 500,
+                body: "boom".to_string(),
+            })
+        }
+    }
+
+    fn subject() -> ReviewSubject {
+        ReviewSubject {
+            owner: "acme".to_string(),
+            repo: "backend".to_string(),
+            title: "Add token refresh".to_string(),
+            identifiers: vec!["TokenStore".to_string()],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn query_builds_jql() {
+        let jql = JiraSource::build_jql(&subject()).expect("has signal");
+        assert!(jql.contains("text ~ \"Add token refresh TokenStore\""));
+        assert!(jql.contains("ORDER BY updated DESC"));
+    }
+
+    #[test]
+    fn query_strips_quotes() {
+        let subj = ReviewSubject {
+            title: "Add \"quoted\" thing".to_string(),
+            ..Default::default()
+        };
+        let jql = JiraSource::build_jql(&subj).unwrap();
+        // No raw double-quotes inside the keyword payload would break the JQL.
+        assert!(!jql.contains("\"quoted\""));
+    }
+
+    #[test]
+    fn query_none_without_signal() {
+        let subj = ReviewSubject::default();
+        assert!(JiraSource::build_jql(&subj).is_none());
+    }
+
+    #[test]
+    fn parse_issues_to_section() {
+        let body = r#"{
+            "issues": [
+                {"key": "PROJ-1", "fields": {"summary": "Add auth", "status": {"name": "In Progress"}}},
+                {"key": "PROJ-2", "fields": {"summary": "Refresh tokens", "status": {"name": "Done"}}}
+            ]
+        }"#;
+        let section = JiraSource::parse_section(body, "https://acme.atlassian.net").unwrap();
+        assert_eq!(section.heading, "Related JIRA tickets");
+        assert_eq!(section.snippets.len(), 2);
+        assert_eq!(section.snippets[0].title, "PROJ-1 — Add auth");
+        assert_eq!(section.snippets[0].subtitle.as_deref(), Some("In Progress"));
+        assert_eq!(
+            section.snippets[0].link.as_deref(),
+            Some("https://acme.atlassian.net/browse/PROJ-1")
+        );
+    }
+
+    #[test]
+    fn parse_handles_missing_fields() {
+        let body = r#"{"issues":[{"key":"X-9","fields":{}}]}"#;
+        let section = JiraSource::parse_section(body, "https://acme.atlassian.net").unwrap();
+        assert_eq!(section.snippets[0].title, "X-9");
+        assert!(section.snippets[0].subtitle.is_none());
+    }
+
+    #[test]
+    fn parse_error_on_garbage() {
+        let r = JiraSource::parse_section("not json", "https://acme.atlassian.net");
+        assert!(matches!(r, Err(ContextSourceError::Parse { .. })));
+    }
+
+    #[tokio::test]
+    async fn disabled_when_no_creds() {
+        // Forced-on but no creds → NotConfigured (fail-open at orchestrator).
+        let src = JiraSource::new(
+            true,
+            RetrievalMode::Live,
+            None,
+            Box::new(FakeJira {
+                body: Ok("{}".into()),
+            }),
+        );
+        let r = src.gather(&subject()).await;
+        assert!(matches!(r, Err(ContextSourceError::NotConfigured { .. })));
+    }
+
+    #[tokio::test]
+    async fn semantic_mode_errors() {
+        let src = JiraSource::new(
+            true,
+            RetrievalMode::Semantic,
+            Some(creds()),
+            Box::new(FakeJira {
+                body: Ok("{}".into()),
+            }),
+        );
+        let r = src.gather(&subject()).await;
+        assert!(matches!(
+            r,
+            Err(ContextSourceError::SemanticNotImplemented { src: "jira" })
+        ));
+    }
+
+    #[tokio::test]
+    async fn gather_with_fake_transport() {
+        let body =
+            r#"{"issues":[{"key":"PROJ-7","fields":{"summary":"Fix","status":{"name":"Open"}}}]}"#;
+        let src = JiraSource::new(
+            true,
+            RetrievalMode::Live,
+            Some(creds()),
+            Box::new(FakeJira {
+                body: Ok(body.to_string()),
+            }),
+        );
+        let section = src.gather(&subject()).await.expect("ok");
+        assert_eq!(section.snippets.len(), 1);
+        assert_eq!(section.snippets[0].title, "PROJ-7 — Fix");
+    }
+
+    #[tokio::test]
+    async fn gather_propagates_api_error_for_logging() {
+        let src = JiraSource::new(
+            true,
+            RetrievalMode::Live,
+            Some(creds()),
+            Box::new(FakeJira { body: Err(()) }),
+        );
+        let r = src.gather(&subject()).await;
+        assert!(matches!(
+            r,
+            Err(ContextSourceError::Api { status: 500, .. })
+        ));
+    }
+}

--- a/crates/trusty-review/src/integrations/context/mod.rs
+++ b/crates/trusty-review/src/integrations/context/mod.rs
@@ -1,0 +1,371 @@
+//! Pluggable context-source layer (Phase 6, #550).
+//!
+//! Why: a review is sharper when the LLM also sees *external* context — the
+//! JIRA ticket the PR implements, the Confluence design doc it follows, the
+//! GitHub issue it closes.  Rather than hard-wiring each integration into the
+//! prompt builder, this module defines a single `ContextSource` trait so every
+//! enrichment source (JIRA / Confluence / GitHub Issues today; an indexed APEX
+//! knowledgebase in PR-B) plugs into the same orchestrator and renders into the
+//! same `## Related <source>` section of the reviewer user message.
+//!
+//! What: this `mod.rs` is a thin facade.  It defines the shared value types
+//! (`ReviewSubject`, `ContextSnippet`, `ContextSection`, `RetrievalMode`,
+//! `ContextSourceError`) and the `ContextSource` trait, then re-exports the
+//! concrete sources and the orchestrator from sibling modules.
+//!
+//! ## Fail-open contract (CRITICAL — read before adding a source)
+//!
+//! These context sources are **supplementary / best-effort enrichment**.  A
+//! source that errors, times out, or has no credentials MUST log to stderr and
+//! return zero snippets — it MUST NOT block, skip, or fail the review.  This is
+//! deliberately DIFFERENT from the trusty-search / trusty-analyze required gate
+//! (#590): those two are the *core value* of trusty-review and their absence
+//! skips the review; these external sources are nice-to-have and degrade
+//! silently to "no extra context".  Every `ContextSource::gather`
+//! implementation therefore returns `Result` only so the orchestrator can log
+//! the failure — the orchestrator NEVER propagates a source error upward.
+//!
+//! Test: trait object-safety and the value types are unit-tested in this module;
+//! each source carries its own parse/query tests; the orchestrator's fail-open
+//! and section-assembly behaviour is tested in `orchestrator`.
+
+pub mod atlassian;
+pub mod config;
+pub mod confluence;
+pub mod github_issues;
+pub mod jira;
+pub mod orchestrator;
+
+pub use config::{ContextSourcesConfig, ContextSourcesFileConfig, SourceConfig, SourceFileConfig};
+pub use confluence::ConfluenceSource;
+pub use github_issues::GithubIssuesSource;
+pub use jira::JiraSource;
+pub use orchestrator::{gather_external_context, render_sections};
+
+use async_trait::async_trait;
+
+// ─── Retrieval mode ─────────────────────────────────────────────────────────
+
+/// How a context source obtains its snippets.
+///
+/// Why: #550 makes retrieval mode a per-source config knob.  A `Live` source
+/// queries its own API at review time; a `Semantic` source queries the
+/// trusty-search daemon against a pre-built index (APEX / any knowledgebase).
+/// PR-A implements only the `Live` backend for the three external sources; a
+/// source configured `Semantic` here returns a clear "not yet implemented"
+/// error (logged, fail-open) until PR-B lands the indexed backend.
+/// What: a two-variant enum, deserialised lowercase (`"live"` / `"semantic"`).
+/// Test: `retrieval_mode_serde_roundtrip`, and the orchestrator's
+/// `semantic_mode_not_yet_implemented` path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum RetrievalMode {
+    /// Query the source's own API directly at review time (no pre-indexing).
+    #[default]
+    Live,
+    /// Retrieve from a trusty-search index by vector/hybrid search (PR-B).
+    Semantic,
+}
+
+impl std::fmt::Display for RetrievalMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RetrievalMode::Live => write!(f, "live"),
+            RetrievalMode::Semantic => write!(f, "semantic"),
+        }
+    }
+}
+
+// ─── Review subject ─────────────────────────────────────────────────────────
+
+/// The review subject handed to every context source.
+///
+/// Why: each source searches its backend by the same signal set — the PR title
+/// keywords and the identifiers extracted from the diff — so bundling them in
+/// one borrow-friendly struct keeps the `ContextSource::gather` signature stable
+/// as new sources are added.
+/// What: holds the owner/repo (needed by the GitHub-Issues source to scope its
+/// search), the PR title, the changed file paths, and the extracted identifiers.
+/// All fields are owned so the subject can be cheaply shared across the
+/// concurrent gather tasks.
+/// Test: constructed by `orchestrator` tests and each source's tests.
+#[derive(Debug, Clone, Default)]
+pub struct ReviewSubject {
+    /// Repository owner / org (GitHub-Issues source scopes its query to this).
+    pub owner: String,
+    /// Repository name.
+    pub repo: String,
+    /// PR title (empty in local-diff mode — sources should skip on empty query).
+    pub title: String,
+    /// Changed file paths from the diff.
+    pub changed_files: Vec<String>,
+    /// Identifiers extracted from the diff (function/type/symbol names).
+    pub identifiers: Vec<String>,
+}
+
+impl ReviewSubject {
+    /// Build the free-text keyword query a live source should search by.
+    ///
+    /// Why: every live source searches by the same signal — PR-title words plus
+    /// a bounded set of diff identifiers — so the query construction lives here
+    /// once instead of being duplicated (and drifting) across three sources.
+    /// What: joins the PR title and up to `max_identifiers` identifiers into a
+    /// single space-separated string, de-duplicating and dropping empties.
+    /// Returns an empty string when there is no usable signal (caller skips).
+    /// Test: `keyword_query_combines_title_and_identifiers`,
+    /// `keyword_query_empty_when_no_signal` in this module.
+    pub fn keyword_query(&self, max_identifiers: usize) -> String {
+        let mut parts: Vec<&str> = Vec::new();
+        let title = self.title.trim();
+        if !title.is_empty() {
+            parts.push(title);
+        }
+        for id in self.identifiers.iter().take(max_identifiers) {
+            let id = id.trim();
+            if !id.is_empty() && !parts.contains(&id) {
+                parts.push(id);
+            }
+        }
+        parts.join(" ")
+    }
+}
+
+// ─── Snippets + sections ────────────────────────────────────────────────────
+
+/// One retrieved context item from a source.
+///
+/// Why: sources differ in their native shape (a JIRA ticket, a Confluence page,
+/// a GitHub issue), but the prompt only needs a uniform title/subtitle/body/link
+/// quad to render a bullet.  Normalising to this struct keeps the section
+/// renderer source-agnostic so PR-B's APEX source slots in unchanged.
+/// What: a short `title` (such as `PROJ-123 — Add auth`), an optional `subtitle`
+/// (status, space, or issue state), an optional `body` snippet, and a `link`.
+/// Test: `render_sections_emits_headings_and_bullets` in `orchestrator`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextSnippet {
+    /// Primary label for the bullet (ticket key + summary, doc title, etc.).
+    pub title: String,
+    /// Optional secondary label (status, space, issue state).
+    pub subtitle: Option<String>,
+    /// Optional body excerpt to embed under the bullet.
+    pub body: Option<String>,
+    /// Optional canonical link to the item.
+    pub link: Option<String>,
+}
+
+/// A rendered `## Related <source>` section produced by one source.
+///
+/// Why: the orchestrator collects one section per source and the prompt builder
+/// concatenates them in a deterministic order; carrying the heading alongside
+/// the snippets keeps assembly trivial and order-stable.
+/// What: `heading` is the markdown H2 text (e.g. `Related JIRA tickets`);
+/// `snippets` are the items to render as bullets.  A section with zero snippets
+/// is dropped by the orchestrator (nothing to show).
+/// Test: `orchestrator` section-ordering and empty-drop tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextSection {
+    /// Markdown H2 heading text (without the leading `## `).
+    pub heading: String,
+    /// Items to render as bullets under the heading.
+    pub snippets: Vec<ContextSnippet>,
+}
+
+// ─── Error type ─────────────────────────────────────────────────────────────
+
+/// Errors a context source may surface to the orchestrator.
+///
+/// Why: the orchestrator needs to *log* a meaningful reason when a source fails,
+/// even though it never propagates the error (fail-open).  Typed variants let
+/// the log line distinguish "missing creds" (skip, expected) from "API error"
+/// (transient) from "semantic mode not implemented yet" (config/PR-B).
+/// What: a `thiserror` enum (library convention) covering the failure classes
+/// every source shares.
+/// Test: `context_source_error_display` in this module.
+///
+/// Note: every variant carries a `src` (the source name) field rather than
+/// `source` — the latter name is special-cased by `thiserror` as a `#[source]`
+/// error chain and would not satisfy `&'static str: Error`.
+#[derive(Debug, thiserror::Error)]
+pub enum ContextSourceError {
+    /// Required credentials / base URL are absent — the source is simply skipped.
+    #[error("{src} skipped: {reason}")]
+    NotConfigured {
+        /// Source name (e.g. `"jira"`).
+        src: &'static str,
+        /// Human-readable reason (which env var is missing).
+        reason: String,
+    },
+
+    /// HTTP transport failure (DNS, connect, TLS, timeout).
+    #[error("{src} transport error: {err}")]
+    Transport {
+        /// Source name.
+        src: &'static str,
+        /// Underlying transport error text.
+        err: TransportErr,
+    },
+
+    /// The backend returned a non-2xx status.
+    #[error("{src} API returned {status}: {body}")]
+    Api {
+        /// Source name.
+        src: &'static str,
+        /// HTTP status code.
+        status: u16,
+        /// Response body (may be truncated).
+        body: String,
+    },
+
+    /// The response could not be parsed.
+    #[error("{src} response parse error: {detail}")]
+    Parse {
+        /// Source name.
+        src: &'static str,
+        /// Parse error text.
+        detail: String,
+    },
+
+    /// The source is configured `mode = semantic`, which PR-A does not implement.
+    #[error("{src}: semantic mode not yet implemented (see PR-B / APEX indexed knowledgebase)")]
+    SemanticNotImplemented {
+        /// Source name.
+        src: &'static str,
+    },
+}
+
+/// Newtype wrapper carrying a transport error message.
+///
+/// Why: reqwest errors are not `Clone` and we want a simple owned string for
+/// testability; a newtype keeps `Transport` self-describing.
+/// What: wraps a message string with a `Display` impl.
+/// Test: covered transitively by `context_source_error_display`.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct TransportErr(pub String);
+
+// ─── The trait ──────────────────────────────────────────────────────────────
+
+/// A pluggable external context source.
+///
+/// Why: this is the seam that lets the orchestrator treat JIRA, Confluence,
+/// GitHub Issues, and (PR-B) an indexed APEX knowledgebase identically.  Each
+/// source declares its name + enabled flag + retrieval mode and knows how to
+/// turn a `ReviewSubject` into a `ContextSection`.
+/// What: `name` is a stable identifier used in logs and the config table;
+/// `is_enabled` lets the orchestrator skip a disabled source cheaply (without a
+/// network round-trip); `mode` is the configured retrieval mode; `gather`
+/// performs the actual retrieval.
+///
+/// Fail-open contract: `gather` returns `Result` ONLY so the orchestrator can
+/// log a reason; the orchestrator treats `Err(_)` exactly like an empty section
+/// and continues.  Implementations should therefore NOT panic and should map
+/// every failure to a `ContextSourceError`.
+/// Test: `context_source_object_safe` (object-safety) in this module; per-source
+/// behaviour in each source's own tests.
+#[async_trait]
+pub trait ContextSource: Send + Sync {
+    /// Stable source identifier (e.g. `"jira"`), used in logs + config keys.
+    fn name(&self) -> &'static str;
+
+    /// Whether this source is enabled (config + credentials present).
+    fn is_enabled(&self) -> bool;
+
+    /// The configured retrieval mode for this source.
+    fn mode(&self) -> RetrievalMode;
+
+    /// Retrieve context for the review subject.
+    ///
+    /// Returns a `ContextSection` (possibly empty) on success.  On any failure
+    /// returns a `ContextSourceError` for the orchestrator to log; the
+    /// orchestrator NEVER propagates this error (fail-open).
+    async fn gather(&self, subject: &ReviewSubject) -> Result<ContextSection, ContextSourceError>;
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retrieval_mode_serde_roundtrip() {
+        let live: RetrievalMode = serde_json::from_str("\"live\"").unwrap();
+        assert_eq!(live, RetrievalMode::Live);
+        let sem: RetrievalMode = serde_json::from_str("\"semantic\"").unwrap();
+        assert_eq!(sem, RetrievalMode::Semantic);
+        assert_eq!(RetrievalMode::default(), RetrievalMode::Live);
+        assert_eq!(
+            serde_json::to_string(&RetrievalMode::Semantic).unwrap(),
+            "\"semantic\""
+        );
+    }
+
+    #[test]
+    fn keyword_query_combines_title_and_identifiers() {
+        let subj = ReviewSubject {
+            title: "Add auth flow".to_string(),
+            identifiers: vec!["authenticate".to_string(), "TokenStore".to_string()],
+            ..Default::default()
+        };
+        let q = subj.keyword_query(8);
+        assert_eq!(q, "Add auth flow authenticate TokenStore");
+    }
+
+    #[test]
+    fn keyword_query_dedupes_and_caps_identifiers() {
+        let subj = ReviewSubject {
+            title: "fix".to_string(),
+            identifiers: vec![
+                "fix".to_string(), // duplicate of title token — dropped
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string(),
+            ],
+            ..Default::default()
+        };
+        // The cap of 2 applies to the identifier iterator BEFORE dedup, so we
+        // consider ["fix", "a"]; "fix" duplicates the title token and is dropped,
+        // leaving just "a". ("b"/"c" are past the cap.)
+        let q = subj.keyword_query(2);
+        assert_eq!(q, "fix a");
+    }
+
+    #[test]
+    fn keyword_query_empty_when_no_signal() {
+        let subj = ReviewSubject {
+            title: "   ".to_string(),
+            identifiers: vec![String::new(), "  ".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(subj.keyword_query(8), "");
+    }
+
+    #[test]
+    fn context_source_error_display() {
+        let e = ContextSourceError::NotConfigured {
+            src: "jira",
+            reason: "ATLASSIAN_API_TOKEN unset".to_string(),
+        };
+        assert!(e.to_string().contains("jira skipped"));
+        assert!(e.to_string().contains("ATLASSIAN_API_TOKEN"));
+
+        let e = ContextSourceError::SemanticNotImplemented { src: "jira" };
+        assert!(e.to_string().contains("semantic mode not yet implemented"));
+        assert!(e.to_string().contains("PR-B"));
+
+        let e = ContextSourceError::Api {
+            src: "confluence",
+            status: 503,
+            body: "overloaded".to_string(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("confluence"));
+        assert!(s.contains("503"));
+    }
+
+    #[test]
+    fn context_source_object_safe() {
+        // Proves `ContextSource` is object-safe (usable as `dyn`).
+        fn _accepts(_s: &dyn ContextSource) {}
+    }
+}

--- a/crates/trusty-review/src/integrations/context/orchestrator.rs
+++ b/crates/trusty-review/src/integrations/context/orchestrator.rs
@@ -1,0 +1,378 @@
+//! Context-source orchestrator (Phase 6, #550).
+//!
+//! Why: the runner should ask "give me all the external context" once and get
+//! back ready-to-embed `## Related <source>` markdown, without knowing how many
+//! sources exist or how each fetches.  This module owns the fan-out (bounded
+//! concurrency), the per-source timeout, the fail-open policy, and the
+//! deterministic section assembly — so adding PR-B's APEX source is a one-line
+//! registration with zero changes to the runner or prompt builder.
+//!
+//! ## Fail-open policy (supplementary, NOT required — contrast #590)
+//! Every source is best-effort.  A disabled source is skipped; an errored,
+//! timed-out, or empty source contributes nothing and the gather continues.  No
+//! source failure ever propagates to the caller.  This is the OPPOSITE of the
+//! trusty-search/trusty-analyze required gate (#590), where a missing dependency
+//! skips the whole review — those are the core value; these are enrichment.
+//!
+//! What: `gather_external_context` runs all enabled sources concurrently
+//! (bounded by `MAX_CONCURRENCY`), each wrapped in a timeout, collects the
+//! non-empty sections in a stable order, and returns them.  `render_sections`
+//! turns the collected sections into the markdown block appended to the reviewer
+//! user message.
+//!
+//! Test: `gathers_enabled_only`, `fail_open_on_source_error`,
+//! `fail_open_on_timeout`, `sections_stable_order`, `render_sections_*` here.
+
+use std::time::Duration;
+
+use futures_util::future::join_all;
+use tracing::{debug, warn};
+
+use super::{ContextSection, ContextSource, ReviewSubject};
+
+/// Max number of context sources to query concurrently.
+///
+/// Why: bound the simultaneous outbound connections so a review never opens an
+/// unbounded fan-out; four sources today fit comfortably under this.
+/// What: a small constant chunk size for the concurrent gather.
+const MAX_CONCURRENCY: usize = 4;
+
+/// Per-source wall-clock timeout.
+///
+/// Why: an enrichment source must never hang the review; a hung source is just
+/// "no extra context".  Each source also sets its own client timeout, but this
+/// is the orchestrator-level backstop honouring the fail-open contract.
+const PER_SOURCE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Gather context from all enabled sources, fail-open, bounded-concurrent.
+///
+/// Why: the single entry the runner calls; encapsulates the concurrency,
+/// timeout, and fail-open policy so the runner stays a thin orchestration loop.
+/// What: filters to `is_enabled()` sources, runs them in concurrency-bounded
+/// chunks (each under `PER_SOURCE_TIMEOUT`), logs and drops any error/timeout,
+/// drops empty sections, and returns the surviving sections in source order.
+/// Test: `gathers_enabled_only`, `fail_open_on_source_error`,
+/// `fail_open_on_timeout`, `sections_stable_order`.
+pub async fn gather_external_context(
+    sources: &[Box<dyn ContextSource>],
+    subject: &ReviewSubject,
+) -> Vec<ContextSection> {
+    // Index-tagged sections so we can restore source (registration) order after
+    // the concurrent gather (which yields in completion order, not input order).
+    let mut collected: Vec<(usize, ContextSection)> = Vec::new();
+
+    // Enabled sources, tagged with their original index.
+    let enabled: Vec<(usize, &Box<dyn ContextSource>)> = sources
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.is_enabled())
+        .collect();
+
+    if enabled.is_empty() {
+        debug!("no enabled external context sources");
+        return Vec::new();
+    }
+
+    for chunk in enabled.chunks(MAX_CONCURRENCY) {
+        let futs = chunk.iter().map(|(idx, source)| async move {
+            let name = source.name();
+            let result = tokio::time::timeout(PER_SOURCE_TIMEOUT, source.gather(subject)).await;
+            (*idx, name, result)
+        });
+        let outcomes = join_all(futs).await;
+        for (idx, name, result) in outcomes {
+            match result {
+                // Completed within the timeout.
+                Ok(Ok(section)) => {
+                    if section.snippets.is_empty() {
+                        debug!(source = name, "context source returned no results");
+                    } else {
+                        debug!(
+                            source = name,
+                            count = section.snippets.len(),
+                            "context source contributed"
+                        );
+                        collected.push((idx, section));
+                    }
+                }
+                // The source errored — log + continue (FAIL-OPEN, supplementary).
+                Ok(Err(e)) => {
+                    warn!(
+                        source = name,
+                        "context source failed (continuing without it): {e}"
+                    );
+                }
+                // The source timed out — log + continue (FAIL-OPEN).
+                Err(_) => {
+                    warn!(
+                        source = name,
+                        timeout_secs = PER_SOURCE_TIMEOUT.as_secs(),
+                        "context source timed out (continuing without it)"
+                    );
+                }
+            }
+        }
+    }
+
+    // Restore stable source order (sort by original index) and strip the tag.
+    collected.sort_by_key(|(idx, _)| *idx);
+    collected.into_iter().map(|(_, section)| section).collect()
+}
+
+/// Render collected sections into the markdown block for the user message.
+///
+/// Why: the prompt builder appends external context as `## Related …` sections;
+/// keeping the rendering here (not in `prompt.rs`) means the prompt builder
+/// stays source-agnostic and the bullet format is tested in one place.
+/// What: for each non-empty section, emits an `## <heading>` block followed by
+/// one bullet per snippet (`- **title** — subtitle ([link](link))\n  body`).
+/// Returns an empty string when there are no sections (caller appends nothing).
+/// Test: `render_sections_emits_headings_and_bullets`, `render_sections_empty`.
+pub fn render_sections(sections: &[ContextSection]) -> String {
+    if sections.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for section in sections {
+        if section.snippets.is_empty() {
+            continue;
+        }
+        out.push_str(&format!("## {}\n\n", section.heading));
+        for snip in &section.snippets {
+            out.push_str("- **");
+            out.push_str(&snip.title);
+            out.push_str("**");
+            if let Some(sub) = &snip.subtitle {
+                out.push_str(&format!(" — {sub}"));
+            }
+            if let Some(link) = &snip.link {
+                out.push_str(&format!(" ([link]({link}))"));
+            }
+            out.push('\n');
+            if let Some(body) = &snip.body {
+                // Indent the body excerpt under the bullet.
+                for line in body.lines() {
+                    out.push_str("  ");
+                    out.push_str(line);
+                    out.push('\n');
+                }
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrations::context::{ContextSnippet, ContextSourceError, RetrievalMode};
+    use async_trait::async_trait;
+    use std::time::Duration;
+
+    /// A scripted source returning a fixed outcome, for orchestrator tests.
+    struct ScriptedSource {
+        name: &'static str,
+        enabled: bool,
+        outcome: Outcome,
+    }
+
+    #[derive(Clone)]
+    enum Outcome {
+        Section(ContextSection),
+        Error,
+        Hang,
+    }
+
+    #[async_trait]
+    impl ContextSource for ScriptedSource {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn is_enabled(&self) -> bool {
+            self.enabled
+        }
+        fn mode(&self) -> RetrievalMode {
+            RetrievalMode::Live
+        }
+        async fn gather(
+            &self,
+            _subject: &ReviewSubject,
+        ) -> Result<ContextSection, ContextSourceError> {
+            match &self.outcome {
+                Outcome::Section(s) => Ok(s.clone()),
+                Outcome::Error => Err(ContextSourceError::Api {
+                    src: self.name,
+                    status: 500,
+                    body: "boom".to_string(),
+                }),
+                Outcome::Hang => {
+                    // Sleep longer than the per-source timeout to exercise the
+                    // timeout fail-open path. Uses tokio's paused-time fast path.
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                    unreachable!("should be cancelled by timeout")
+                }
+            }
+        }
+    }
+
+    fn section(heading: &str, n: usize) -> ContextSection {
+        ContextSection {
+            heading: heading.to_string(),
+            snippets: (0..n)
+                .map(|i| ContextSnippet {
+                    title: format!("item{i}"),
+                    subtitle: None,
+                    body: None,
+                    link: None,
+                })
+                .collect(),
+        }
+    }
+
+    fn boxed(s: ScriptedSource) -> Box<dyn ContextSource> {
+        Box::new(s)
+    }
+
+    #[tokio::test]
+    async fn gathers_enabled_only() {
+        let sources = vec![
+            boxed(ScriptedSource {
+                name: "a",
+                enabled: true,
+                outcome: Outcome::Section(section("A", 2)),
+            }),
+            boxed(ScriptedSource {
+                name: "b",
+                enabled: false, // disabled — must be skipped
+                outcome: Outcome::Section(section("B", 5)),
+            }),
+        ];
+        let out = gather_external_context(&sources, &ReviewSubject::default()).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].heading, "A");
+    }
+
+    #[tokio::test]
+    async fn fail_open_on_source_error() {
+        // One source errors, one succeeds → the error is swallowed, the good
+        // section survives. The review is NOT blocked.
+        let sources = vec![
+            boxed(ScriptedSource {
+                name: "bad",
+                enabled: true,
+                outcome: Outcome::Error,
+            }),
+            boxed(ScriptedSource {
+                name: "good",
+                enabled: true,
+                outcome: Outcome::Section(section("Good", 1)),
+            }),
+        ];
+        let out = gather_external_context(&sources, &ReviewSubject::default()).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].heading, "Good");
+    }
+
+    #[tokio::test]
+    async fn fail_open_on_timeout() {
+        // Pause tokio's clock so the 20s per-source timeout fires instantly when
+        // the orchestrator's `sleep`-based timeout is auto-advanced; the hanging
+        // source must be dropped (timeout), not block the gather.
+        tokio::time::pause();
+        let sources = vec![
+            boxed(ScriptedSource {
+                name: "slow",
+                enabled: true,
+                outcome: Outcome::Hang,
+            }),
+            boxed(ScriptedSource {
+                name: "fast",
+                enabled: true,
+                outcome: Outcome::Section(section("Fast", 1)),
+            }),
+        ];
+        let out = gather_external_context(&sources, &ReviewSubject::default()).await;
+        assert_eq!(out.len(), 1, "hanging source dropped via timeout");
+        assert_eq!(out[0].heading, "Fast");
+    }
+
+    #[tokio::test]
+    async fn empty_sections_dropped() {
+        let sources = vec![boxed(ScriptedSource {
+            name: "empty",
+            enabled: true,
+            outcome: Outcome::Section(section("Empty", 0)),
+        })];
+        let out = gather_external_context(&sources, &ReviewSubject::default()).await;
+        assert!(out.is_empty(), "empty section contributes nothing");
+    }
+
+    #[tokio::test]
+    async fn sections_stable_order() {
+        // Even if the second source were faster, output order follows input
+        // (source registration) order so the prompt is deterministic.
+        let sources = vec![
+            boxed(ScriptedSource {
+                name: "first",
+                enabled: true,
+                outcome: Outcome::Section(section("First", 1)),
+            }),
+            boxed(ScriptedSource {
+                name: "second",
+                enabled: true,
+                outcome: Outcome::Section(section("Second", 1)),
+            }),
+            boxed(ScriptedSource {
+                name: "third",
+                enabled: true,
+                outcome: Outcome::Section(section("Third", 1)),
+            }),
+        ];
+        let out = gather_external_context(&sources, &ReviewSubject::default()).await;
+        let headings: Vec<&str> = out.iter().map(|s| s.heading.as_str()).collect();
+        assert_eq!(headings, vec!["First", "Second", "Third"]);
+    }
+
+    #[test]
+    fn render_sections_empty() {
+        assert_eq!(render_sections(&[]), "");
+        // A section whose snippets are empty renders nothing.
+        assert_eq!(render_sections(&[section("Empty", 0)]), "");
+    }
+
+    #[test]
+    fn render_sections_emits_headings_and_bullets() {
+        let sec = ContextSection {
+            heading: "Related JIRA tickets".to_string(),
+            snippets: vec![ContextSnippet {
+                title: "PROJ-1 — Add auth".to_string(),
+                subtitle: Some("In Progress".to_string()),
+                body: None,
+                link: Some("https://acme.atlassian.net/browse/PROJ-1".to_string()),
+            }],
+        };
+        let md = render_sections(&[sec]);
+        assert!(md.contains("## Related JIRA tickets"));
+        assert!(md.contains("- **PROJ-1 — Add auth** — In Progress"));
+        assert!(md.contains("([link](https://acme.atlassian.net/browse/PROJ-1))"));
+    }
+
+    #[test]
+    fn render_sections_includes_body_indented() {
+        let sec = ContextSection {
+            heading: "Related GitHub issues".to_string(),
+            snippets: vec![ContextSnippet {
+                title: "#42 — Bug".to_string(),
+                subtitle: Some("open".to_string()),
+                body: Some("first line\nsecond line".to_string()),
+                link: None,
+            }],
+        };
+        let md = render_sections(&[sec]);
+        assert!(md.contains("  first line"));
+        assert!(md.contains("  second line"));
+    }
+}

--- a/crates/trusty-review/src/integrations/mod.rs
+++ b/crates/trusty-review/src/integrations/mod.rs
@@ -9,18 +9,27 @@
 //!     webhook HMAC verification.
 //!   - `search_client` — HTTP client over trusty-search `:7878` (REQUIRED).
 //!   - `analyze_client` — HTTP client over trusty-analyze `:7879` (OPTIONAL).
+//!   - `context` — pluggable external context sources (JIRA / Confluence /
+//!     GitHub Issues today; APEX/knowledgebase in PR-B).  Best-effort / fail-open
+//!     enrichment, distinct from the REQUIRED search/analyze gate (#550, #590).
 //!
-//! Deferred to later stages: `jira`, `slack`.
+//! Deferred to later stages: `slack`.
 //!
 //! Test: each submodule carries its own unit tests.
 
 pub mod analyze_client;
+pub mod context;
 pub mod github;
 pub mod search_client;
 
 pub use analyze_client::{
     AnalyzeClient, AnalyzeClientError, AnalyzeHealthResponse, AnalyzeIndexInfo, ComplexityHotspot,
     HttpAnalyzeClient, Smell,
+};
+pub use context::{
+    ConfluenceSource, ContextSection, ContextSnippet, ContextSource, ContextSourceError,
+    ContextSourcesConfig, ContextSourcesFileConfig, GithubIssuesSource, JiraSource, RetrievalMode,
+    ReviewSubject, SourceConfig, gather_external_context, render_sections,
 };
 pub use github::{
     AuthStrategy, GH_ALLOW_PUSH, GithubClient, GithubError, PostedReview, PrMetadata, PrRef,

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -205,9 +205,10 @@ pub fn build_review_prompt(
     pr_meta: &ReviewPrMeta,
     diff: &str,
     context: &ReviewContext,
+    external_context: &str,
     reviewer_model: &str,
 ) -> LlmRequest {
-    let user_message = build_user_message(owner, repo, pr_meta, diff, context);
+    let user_message = build_user_message(owner, repo, pr_meta, diff, context, external_context);
     LlmRequest {
         model: strip_provider_prefix(reviewer_model).to_string(),
         system: reviewer_system_prompt().to_string(),
@@ -260,14 +261,17 @@ impl ReviewPrMeta {
 /// context blocks.  Splitting it from the system prompt makes each independently
 /// tweakable.
 /// What: formats PR metadata as a header, then the diff block, then optional
-/// context sections for code search and static analysis.
-/// Test: `prompt_includes_context_blocks`.
+/// context sections for code search and static analysis, then any external
+/// context (`## Related <source>` markdown already rendered by the context
+/// orchestrator — JIRA / Confluence / GitHub Issues; APEX in PR-B).
+/// Test: `prompt_includes_context_blocks`, `prompt_includes_external_context`.
 fn build_user_message(
     owner: &str,
     repo: &str,
     pr_meta: &ReviewPrMeta,
     diff: &str,
     context: &ReviewContext,
+    external_context: &str,
 ) -> String {
     let mut msg = String::with_capacity(diff.len() + 2048);
 
@@ -336,6 +340,19 @@ fn build_user_message(
                 "- `{}` — {} [{}]{line_part}\n",
                 s.file, s.category, s.severity
             ));
+        }
+        msg.push('\n');
+    }
+
+    // External context block (rendered `## Related <source>` markdown from the
+    // context orchestrator — JIRA / Confluence / GitHub Issues; APEX in PR-B).
+    // It is appended verbatim because the orchestrator already owns the heading
+    // + bullet format, keeping this builder source-agnostic.
+    let external = external_context.trim();
+    if !external.is_empty() {
+        msg.push_str(external);
+        if !external.ends_with('\n') {
+            msg.push('\n');
         }
         msg.push('\n');
     }

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -105,6 +105,7 @@ fn build_review_prompt_strips_bedrock_prefix() {
         &sample_meta(),
         "+fn x() {}",
         &empty_context(),
+        "",
         "bedrock/us.anthropic.claude-sonnet-4-6",
     );
     assert_eq!(
@@ -126,6 +127,7 @@ fn build_review_prompt_strips_openrouter_prefix() {
         &sample_meta(),
         "+fn x() {}",
         &empty_context(),
+        "",
         "openrouter/openai/gpt-5.4-mini-20260317",
     );
     assert_eq!(
@@ -143,6 +145,7 @@ fn build_review_prompt_includes_diff() {
         &sample_meta(),
         diff,
         &empty_context(),
+        "",
         "openai/gpt-5.4-mini-20260317",
     );
     assert_eq!(req.model, "openai/gpt-5.4-mini-20260317");
@@ -195,6 +198,7 @@ fn prompt_includes_context_blocks() {
         &sample_meta(),
         "+fn foo() {}",
         &context,
+        "",
         "openai/gpt-5.4-mini-20260317",
     );
     let content = &req.messages[0].content;
@@ -216,6 +220,69 @@ fn prompt_includes_context_blocks() {
     );
 }
 
+/// Verify external context markdown is embedded into the user message.
+///
+/// Why: the context orchestrator renders `## Related <source>` markdown that the
+/// prompt builder must append verbatim before the structured-output instruction
+/// (Phase 6, #550); a regression here would silently drop JIRA/Confluence/GH
+/// enrichment from the reviewer prompt.
+/// What: passes a non-empty `external_context` block and asserts it appears in
+/// the user message ahead of the closing instruction.
+/// Test: this test; no network.
+#[test]
+fn prompt_includes_external_context() {
+    let external = "## Related JIRA tickets\n\n- **PROJ-1 — Add auth** — In Progress\n";
+    let req = build_review_prompt(
+        "acme",
+        "backend",
+        &sample_meta(),
+        "+fn x() {}",
+        &empty_context(),
+        external,
+        "openai/gpt-5.4-mini-20260317",
+    );
+    let content = &req.messages[0].content;
+    assert!(
+        content.contains("## Related JIRA tickets"),
+        "external context heading must be embedded"
+    );
+    assert!(
+        content.contains("PROJ-1 — Add auth"),
+        "external context bullet must be embedded"
+    );
+    // The closing instruction must come AFTER the external context.
+    let ext_pos = content.find("Related JIRA tickets").unwrap();
+    let instr_pos = content.find("populate the structured response").unwrap();
+    assert!(
+        ext_pos < instr_pos,
+        "external context must precede the closing instruction"
+    );
+}
+
+/// Verify an empty external context block adds nothing.
+///
+/// Why: out of the box (no Atlassian/GitHub creds) the orchestrator returns an
+/// empty string; the prompt must not emit a stray blank section.
+/// What: passes an empty `external_context` and asserts no `## Related ` heading
+/// for an external source appears.
+/// Test: this test; no network.
+#[test]
+fn prompt_empty_external_context_adds_nothing() {
+    let req = build_review_prompt(
+        "o",
+        "r",
+        &sample_meta(),
+        "+fn x() {}",
+        &empty_context(),
+        "   \n",
+        "openai/gpt-5.4-mini-20260317",
+    );
+    let content = &req.messages[0].content;
+    assert!(!content.contains("Related JIRA"));
+    assert!(!content.contains("Related Confluence"));
+    assert!(!content.contains("Related GitHub issues"));
+}
+
 #[test]
 fn prompt_empty_context_omits_sections() {
     let req = build_review_prompt(
@@ -224,6 +291,7 @@ fn prompt_empty_context_omits_sections() {
         &sample_meta(),
         "+fn x() {}",
         &empty_context(),
+        "",
         "openai/gpt-5.4-nano-20260317",
     );
     let content = &req.messages[0].content;
@@ -252,6 +320,7 @@ fn build_review_prompt_includes_response_schema() {
         &sample_meta(),
         "+fn x() {}",
         &empty_context(),
+        "",
         "us.anthropic.claude-sonnet-4-6",
     );
     let schema = req
@@ -304,6 +373,7 @@ fn prompt_local_diff_mode_no_pr_metadata() {
         &meta,
         "+fn local_fn() {}",
         &empty_context(),
+        "",
         "openai/gpt-5.4-mini-20260317",
     );
     let content = &req.messages[0].content;

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -55,7 +55,7 @@ use crate::{
         parser::parse_review_response,
         post::{PostContext, finalize_review},
         prompt::{ReviewPrMeta, build_review_prompt},
-        runner_context::gather_context,
+        runner_context::{gather_context, gather_external_context_md},
         trigger::TriggerDecision,
         verify::maybe_verify,
     },
@@ -272,7 +272,23 @@ pub async fn run_review(
     };
 
     // ── Step 5: gather context in parallel ────────────────────────────────
-    let context = gather_context(config, &deps, &identifiers, &changed_files, &pr_meta.title).await;
+    // Required code/static-analysis context (from trusty-search/trusty-analyze)
+    // and best-effort external enrichment (JIRA/Confluence/GitHub Issues, #550)
+    // are gathered concurrently.  The external sources are FAIL-OPEN: any error
+    // contributes nothing and never blocks the review (distinct from the #590
+    // required gate above).
+    let (context, external_context) = tokio::join!(
+        gather_context(config, &deps, &identifiers, &changed_files, &pr_meta.title),
+        gather_external_context_md(
+            config,
+            &owner,
+            &repo,
+            &identifiers,
+            &changed_files,
+            &pr_meta.title,
+            input.run_mode,
+        ),
+    );
 
     // ── Step 6: build prompt and call LLM ─────────────────────────────────
     let llm_req = build_review_prompt(
@@ -281,6 +297,7 @@ pub async fn run_review(
         &pr_meta,
         &diff,
         &context,
+        &external_context,
         &input.reviewer_model,
     );
     debug!(model = %input.reviewer_model, "calling LLM reviewer");

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -14,7 +14,18 @@
 
 use tracing::{debug, warn};
 
-use crate::{config::ReviewConfig, pipeline::prompt::ReviewContext, pipeline::runner::ReviewDeps};
+use crate::{
+    config::ReviewConfig,
+    integrations::{
+        context::{
+            ConfluenceSource, ContextSource, GithubIssuesSource, JiraSource, ReviewSubject,
+            gather_external_context, render_sections,
+        },
+        github::RunMode,
+    },
+    pipeline::prompt::ReviewContext,
+    pipeline::runner::ReviewDeps,
+};
 
 /// Gather code context from trusty-search and (optionally) trusty-analyze.
 ///
@@ -104,4 +115,57 @@ pub(crate) async fn gather_context(
         complexity_hotspots,
         smells,
     }
+}
+
+/// Gather external enrichment context (JIRA / Confluence / GitHub Issues).
+///
+/// Why: the runner needs the `## Related <source>` markdown to append to the
+/// reviewer prompt, but the source set is best built next to the other context
+/// gathering so the runner stays a thin loop.  These sources are best-effort /
+/// fail-open enrichment — DISTINCT from the REQUIRED trusty-search/trusty-analyze
+/// gate (#590): a source outage logs and contributes nothing, it never blocks
+/// or skips the review (#550).
+/// What: constructs the enabled context sources from `config.context_sources`
+/// (each auto-disabled when its credentials are absent), runs them concurrently
+/// and fail-open via the orchestrator, and renders the surviving sections to a
+/// markdown block.  Returns an empty string when no source contributes.
+/// Test: source construction is covered by each source's `from_config` tests;
+/// the orchestrator fail-open + ordering + rendering is covered in
+/// `integrations::context::orchestrator` tests.
+pub(crate) async fn gather_external_context_md(
+    config: &ReviewConfig,
+    owner: &str,
+    repo: &str,
+    identifiers: &[String],
+    changed_files: &[String],
+    pr_title: &str,
+    run_mode: RunMode,
+) -> String {
+    let cs = &config.context_sources;
+    let sources: Vec<Box<dyn ContextSource>> = vec![
+        Box::new(JiraSource::from_config(&cs.jira)),
+        Box::new(ConfluenceSource::from_config(&cs.confluence)),
+        Box::new(GithubIssuesSource::from_config(
+            &cs.github_issues,
+            run_mode,
+            config.clone(),
+        )),
+    ];
+
+    // Skip the whole fan-out if nothing is enabled (no creds, no explicit opt-in).
+    if !sources.iter().any(|s| s.is_enabled()) {
+        debug!("no external context sources enabled — skipping enrichment");
+        return String::new();
+    }
+
+    let subject = ReviewSubject {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        title: pr_title.to_string(),
+        changed_files: changed_files.to_vec(),
+        identifiers: identifiers.to_vec(),
+    };
+
+    let sections = gather_external_context(&sources, &subject).await;
+    render_sections(&sections)
 }


### PR DESCRIPTION
## Phase 6 — PR-A: live context sources (refs #550)

Adds a **pluggable external-context layer** and the three **LIVE** enrichment
sources, feeding `## Related <source>` sections into the reviewer prompt. The
indexed APEX/knowledgebase (semantic) source is **PR-B** and is NOT built here.

### Context-source abstraction
- **`ContextSource` trait** (`integrations/context/mod.rs`): given a
  `ReviewSubject` (owner/repo, PR title, changed files, extracted identifiers),
  returns a `ContextSection` of `ContextSnippet`s. Each source exposes
  `name()`, `is_enabled()`, `mode()` (`Live` | `Semantic`), and `gather()`.
- **Orchestrator** (`orchestrator.rs`): runs all enabled sources
  bounded-concurrent, each under a per-source timeout, collects non-empty
  sections in **stable (registration) order**, and renders them to markdown.
  `render_sections` owns the heading + bullet format so the prompt builder
  (`prompt.rs` `build_user_message`) stays source-agnostic — PR-B's APEX source
  slots in with zero rework. The runner gathers required + external context
  concurrently (`tokio::join!`).

### Fail-open vs required (the key distinction)
These four context sources are **supplementary / best-effort enrichment**: a
source that errors, times out, or has no creds **logs to stderr and contributes
nothing — it never blocks or skips the review**. This is deliberately the
OPPOSITE of the REQUIRED trusty-search/trusty-analyze gate (#590), where a
missing dependency skips the whole review. The distinction is documented in the
module-level doc comments of `mod.rs` and `orchestrator.rs`.

### The three LIVE sources
- **JIRA** (`jira.rs`) — JQL `text ~ "<keywords>"` against
  `{base}/rest/api/3/search/jql`; renders `## Related JIRA tickets` (key,
  summary, status, browse link).
- **Confluence** (`confluence.rs`) — CQL `type=page AND text ~ "<keywords>"`
  against `{base}/wiki/rest/api/content/search`; renders
  `## Related Confluence docs` (title, space, web link).
- **GitHub Issues** (`github_issues.rs`) — `GET /search/issues` scoped
  `repo:{owner}/{repo} is:issue <keywords>` (PRs filtered out); renders
  `## Related GitHub issues` (number, title, state, html link).

### Auth
- **Atlassian (JIRA + Confluence)** share `AtlassianCreds` (`atlassian.rs`),
  HTTP Basic (email:token). Env-var contract matched to code-intelligence /
  the Duetto `cto` reference for **drop-in migration**:
  `ATLASSIAN_API_TOKEN` (canonical) / `ATLASSIAN_PAT` (alias), `ATLASSIAN_EMAIL`,
  `ATLASSIAN_URL`, with per-product fallbacks
  `JIRA_EMAIL`/`JIRA_API_TOKEN`/`JIRA_BASE_URL`/`JIRA_URL` and
  `CONFLUENCE_EMAIL`/`CONFLUENCE_API_TOKEN`/`CONFLUENCE_BASE_URL`/`CONFLUENCE_URL`.
  Canonical wins; product vars fill gaps.
- **GitHub Issues** reuses the **Phase-1 dual-mode auth (#582)** via an injected
  `IssueTokenResolver` → `AuthStrategy::select(run_mode)` (CLI → PAT/`gh`,
  serve → App). **No new credential mechanism.**

### Config & tunability
- Per-source config under `[context.sources.*]` (TOML) + env
  `TRUSTY_REVIEW_CONTEXT_<SOURCE>_ENABLED` / `_MODE`, layered
  **env > TOML > default**, consistent with the existing `[context]` table.
- **Auto-disable-without-creds**: every source defaults to *disabled* and
  auto-enables only when its credentials are present, so the crate works out of
  the box with no Atlassian/GitHub-context config (a creds-less source is simply
  skipped, logged once). An explicit `enabled = false` always wins.
- `mode = semantic` returns a clear "semantic mode not yet implemented
  (see PR-B / APEX)" error (logged, fail-open) — never a silent no-op.

### Deferred to PR-B
Indexed APEX / pluggable-knowledgebase **semantic** retrieval via trusty-search.
No suppression (#584), disposition-sink (#585), metrics (#554), or
commit-review (#589) — those deferrals are untouched.

### Test evidence (all run in-worktree)
- `cargo clippy -p trusty-review --all-targets -- -D warnings` → clean.
- `cargo test -p trusty-review` → **447 passed; 0 failed; 1 ignored**.
- `cargo fmt --check -p trusty-review` → clean.
- `cargo check -p trusty-review --no-default-features` and `--features http-server` → both pass.

New tests cover: orchestrator enabled/disabled filtering, **fail-open on source
error**, **fail-open on timeout** (paused tokio clock), stable section order,
each source's query construction + JSON parsing against mocked HTTP (injectable
transport/resolver traits — no network), Atlassian creds resolution +
fallbacks, config layering (env > TOML > default; auto-disable), and the
`mode=semantic` not-yet-implemented path. All sources also keep an injectable
seam so no test touches the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)