### PR TITLE
chore(release): trusty-common 0.11.1 + trusty-search 0.22.3 version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10762,7 +10762,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11030,7 +11030,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — trusty-common
 
+## [0.11.1] — 2026-06-02
+
+### Fixed
+
+- **CUDA arena VRAM OOM prevention (issue #600)** — `embedder-cuda` builds now
+  configure ORT's BFCArena with `arena_extend_strategy = kSameAsRequested` and an
+  explicit `gpu_mem_limit` (default 12 GiB, tunable via `TRUSTY_GPU_MEM_LIMIT_BYTES`
+  / `TRUSTY_GPU_MEM_LIMIT_MB`) so the arena no longer grows by `kNextPowerOfTwo`
+  and over-reserves device VRAM. Eliminates the OOM failure on 16 GB Tesla T4 GPUs
+  without requiring the `TRUSTY_MAX_BATCH_SIZE=32` workaround.
+
+- **Accurate `/health` provider reporting (issue #604)** — the `provider` field in
+  `/health` responses now reflects the actual ORT execution provider in use (e.g.
+  `CUDA`, `CoreML`, `CPU`) rather than always reporting `CPU`.
+
 ## [0.5.0] — 2026-05-26
 
 ### Added

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,36 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.22.3] - 2026-06-02
+
+### Fixed
+
+- **CUDA arena VRAM OOM prevention (issue #600)** — via trusty-common 0.11.1:
+  ORT's BFCArena is now configured with `arena_extend_strategy = kSameAsRequested`
+  and an explicit `gpu_mem_limit` (default 12 GiB, tunable via
+  `TRUSTY_GPU_MEM_LIMIT_BYTES` / `TRUSTY_GPU_MEM_LIMIT_MB`). Eliminates VRAM OOM
+  on 16 GB Tesla T4 GPUs without requiring the `TRUSTY_MAX_BATCH_SIZE=32` workaround.
+
+- **Accurate `/health` provider reporting (issue #604)** — the `provider` field in
+  `/health` responses now reports the actual ORT execution provider in use (CUDA,
+  CoreML, CPU) rather than always reporting CPU.
+
+- **Non-destructive reindex with atomic swap (issue #603)** — `POST
+  /indexes/:id/reindex` now builds a new corpus in a temporary database and swaps
+  it atomically on completion, so the existing index stays fully searchable while
+  the rebuild runs. Partial or failed reindex jobs no longer corrupt the live index.
+
+- **Portable data paths and migration (issue #602)** — data-directory paths stored
+  in persisted index metadata are now normalised at restore time so indexes survive
+  machine renames, home-directory changes, and cross-machine copy. A forward
+  migration updates stale absolute paths automatically.
+
+- **Non-empty index validation (issue #601)** — the daemon now rejects a reindex
+  swap if the freshly built corpus contains zero chunks, preventing an accidental
+  wipe of a healthy index caused by a transient file-system or embedder failure.
+
+---
+
 ## [0.18.0] - 2026-05-28
 
 ### Changed

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.22.2"
+version = "0.22.3"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -48,7 +48,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.11.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
+trusty-common = { version = "0.11.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 
 # ── Bundled sidecar ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
Lands version-bump commit (bb8fff1) from `release/search-0.22.3` onto `main`.

Both crates are already published to crates.io:
- `trusty-common-v0.11.1` tag pushed
- `trusty-search-v0.22.3` tag pushed

This PR resynchronizes `main` with the published versions by applying Cargo.toml version bumps, CHANGELOG updates, and Cargo.lock changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)