### PR TITLE
ci(trusty-analyze): gate Amazon Linux 2023 load-dynamic build (refs #605)

### DIFF
--- a/.github/workflows/al2023-build.yml
+++ b/.github/workflows/al2023-build.yml
@@ -121,10 +121,17 @@ jobs:
       #    Note: tar and gzip are already installed in step 0 above;
       #    listing them here again is harmless (dnf is idempotent) and
       #    keeps this step self-documenting.
+      #
+      #    --allowerasing: amazonlinux:2023 ships curl-minimal; installing
+      #    the full `curl` package conflicts unless dnf is allowed to
+      #    replace (erase) curl-minimal first.  This flag is safe here
+      #    because curl-minimal and curl are mutually exclusive providers
+      #    of the same capability — we want the full curl for its richer
+      #    CLI options used in the ORT download step below.
       # ------------------------------------------------------------------
       - name: Install build prerequisites (dnf)
         run: |
-          dnf install -y \
+          dnf install -y --allowerasing \
             gcc \
             gcc-c++ \
             make \

--- a/.github/workflows/al2023-build.yml
+++ b/.github/workflows/al2023-build.yml
@@ -92,6 +92,19 @@ jobs:
 
     steps:
       # ------------------------------------------------------------------
+      # 0. Install tar/gzip BEFORE actions/checkout.
+      #
+      #    Why: amazonlinux:2023 ships without tar and gzip.  GitHub's
+      #    actions/checkout action uses tar to extract the repo archive from
+      #    the runner's local cache — it fails immediately with
+      #    "Unable to locate executable file: tar" if tar is absent.
+      #    This step must run before ANY action that touches the workspace.
+      #    It intentionally does not depend on repo contents.
+      # ------------------------------------------------------------------
+      - name: Install tar/gzip (required by actions/checkout)
+        run: dnf install -y tar gzip
+
+      # ------------------------------------------------------------------
       # 1. Checkout the repo inside the container.
       # ------------------------------------------------------------------
       - name: Checkout repository
@@ -105,6 +118,9 @@ jobs:
       #    - openssl-devel / perl for the openssl-sys crate's build.rs
       #    - curl / tar for the ORT tarball download below
       #    - pkg-config for pkg-config-using crates
+      #    Note: tar and gzip are already installed in step 0 above;
+      #    listing them here again is harmless (dnf is idempotent) and
+      #    keeps this step self-documenting.
       # ------------------------------------------------------------------
       - name: Install build prerequisites (dnf)
         run: |
@@ -116,6 +132,7 @@ jobs:
             perl \
             curl \
             tar \
+            gzip \
             pkg-config \
             findutils
 

--- a/.github/workflows/al2023-build.yml
+++ b/.github/workflows/al2023-build.yml
@@ -1,0 +1,206 @@
+# Amazon Linux 2023 / glibc 2.34 build gate for trusty-analyze (issue #605).
+#
+# WHY this job exists:
+#   The default `bundled-ort` feature of trusty-analyze downloads a prebuilt
+#   ONNX Runtime binary (ORT 1.24.2 as of fastembed 5.x) that was compiled
+#   against glibc 2.38. Amazon Linux 2023 ships glibc 2.34, which is lower —
+#   so the prebuilt ORT binary references `__isoc23_strtol`, a glibc 2.38
+#   symbol, causing a link failure on AL2023.
+#
+#   The fix is to build with `--no-default-features --features http-server,
+#   load-dynamic`, which tells the `ort` crate to dlopen a system-installed
+#   `libonnxruntime.so` at runtime instead of linking the bundled static libs.
+#   That system library just needs to satisfy the glibc present on the host.
+#
+#   This job proves the load-dynamic build path compiles AND links (not just
+#   `cargo check`) on a real AL2023 container — so the regression cannot
+#   return silently (refs #605).
+#
+# WHAT it does:
+#   1. Runs in an `amazonlinux:2023` container (glibc 2.34 — the exact platform
+#      that triggered #605).
+#   2. Installs Rust 1.91 (workspace MSRV) via rustup inside the container.
+#   3. Downloads the official ORT 1.20.1 linux-x64 tarball (built on Ubuntu
+#      20.04 / glibc 2.31 — compatible with AL2023's glibc 2.34) and exports
+#      ORT_DYLIB_PATH pointing at the extracted libonnxruntime.so.
+#   4. Runs `cargo build -p trusty-analyze --no-default-features
+#      --features http-server,load-dynamic` — full link step, not just check.
+#
+# ORT version choice (1.20.1):
+#   The workspace Cargo.lock resolves `ort` to 2.0.0-rc.12, which downloads ORT
+#   1.20.1 at build time when `ort-download-binaries` is active.  The load-dynamic
+#   feature bypasses that download and instead dlopens whatever is at
+#   ORT_DYLIB_PATH at runtime.  We supply 1.20.1 here to keep ABI-level parity
+#   with what ort-sys rc.12 expects.  The official ORT 1.20.1 linux-x64 release
+#   was compiled on Ubuntu 20.04 (glibc 2.31), so it loads cleanly on any host
+#   with glibc >= 2.31 — including AL2023 (glibc 2.34).
+#
+# TRIGGERS:
+#   - push / PR touching crates/trusty-analyze/** or this workflow file.
+#   - workflow_dispatch (manual re-run from the Actions UI).
+#   Deliberately NOT on every push to main — the container build is slow (~5 min)
+#   and only trusty-analyze changes can affect the load-dynamic build path.
+
+name: AL2023 load-dynamic build gate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/trusty-analyze/**"
+      - ".github/workflows/al2023-build.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/trusty-analyze/**"
+      - ".github/workflows/al2023-build.yml"
+  workflow_dispatch:
+    # Allow manual trigger from the Actions UI for ad-hoc validation.
+
+# Cancel superseded runs for the same ref (matches ci.yml convention).
+concurrency:
+  group: al2023-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Suppress ort/fastembed download progress bars in build output.
+  RUST_LOG: "warn"
+  CARGO_TERM_COLOR: always
+  # Skip Svelte UI build (same as ci.yml — committed ui-dist/ is sufficient).
+  SKIP_UI_BUILD: "1"
+  # Pin the ORT release used for the system libonnxruntime.so.
+  # 1.20.1 was built on Ubuntu 20.04 (glibc 2.31) — compatible with AL2023 (glibc 2.34).
+  # Bump this when the workspace's ort-sys version moves to a new ORT major.
+  ORT_VERSION: "1.20.1"
+
+jobs:
+  # --------------------------------------------------------------------------
+  # al2023-load-dynamic: prove `cargo build -p trusty-analyze
+  # --no-default-features --features http-server,load-dynamic` compiles AND
+  # links on Amazon Linux 2023 (glibc 2.34).
+  #
+  # Container note: amazonlinux:2023 is an official Amazon image published to
+  # Docker Hub. It ships with dnf and glibc 2.34 — the exact combination that
+  # exposed the __isoc23_strtol linker error in issue #605.
+  # --------------------------------------------------------------------------
+  al2023-load-dynamic:
+    name: AL2023 load-dynamic (glibc 2.34)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: amazonlinux:2023
+
+    steps:
+      # ------------------------------------------------------------------
+      # 1. Checkout the repo inside the container.
+      # ------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------
+      # 2. Install build prerequisites via dnf.
+      #    AL2023 uses dnf (not apt-get).  We need:
+      #    - gcc / gcc-c++ for the C/C++ linker and tree-sitter compilation
+      #    - make for build scripts
+      #    - openssl-devel / perl for the openssl-sys crate's build.rs
+      #    - curl / tar for the ORT tarball download below
+      #    - pkg-config for pkg-config-using crates
+      # ------------------------------------------------------------------
+      - name: Install build prerequisites (dnf)
+        run: |
+          dnf install -y \
+            gcc \
+            gcc-c++ \
+            make \
+            openssl-devel \
+            perl \
+            curl \
+            tar \
+            pkg-config \
+            findutils
+
+      # ------------------------------------------------------------------
+      # 3. Install Rust 1.91 (workspace MSRV) via rustup inside the container.
+      #    The dtolnay/rust-toolchain action requires the host runner's Node.js,
+      #    which isn't available inside the AL2023 container — use rustup directly.
+      # ------------------------------------------------------------------
+      - name: Install Rust 1.91 (MSRV) via rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain 1.91
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          # Make cargo/rustc available in the same step for subsequent steps
+          # via GITHUB_PATH (GitHub Actions resolves PATH additions across steps).
+
+      # ------------------------------------------------------------------
+      # 4. Cache cargo registry + build artefacts.
+      #    Key includes the toolchain and the Cargo.lock hash so cache
+      #    invalidates when either changes.  The container OS is included in
+      #    the key to avoid cross-OS cache poisoning.
+      # ------------------------------------------------------------------
+      - name: Cache cargo registry and build artefacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: al2023-1.91-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            al2023-1.91-
+
+      # ------------------------------------------------------------------
+      # 5. Download the official ORT 1.20.1 linux-x64 tarball and export
+      #    ORT_DYLIB_PATH so the `ort` crate's load-dynamic path can find it.
+      #
+      #    Why 1.20.1?  See file-level comment.  The tarball contains
+      #    lib/libonnxruntime.so.<version> plus a lib/libonnxruntime.so symlink.
+      #    We point ORT_DYLIB_PATH at the versioned file so ort can dlopen it
+      #    even if symlink resolution is imperfect inside the container.
+      # ------------------------------------------------------------------
+      - name: Download ONNX Runtime ${{ env.ORT_VERSION }} (glibc 2.31 build)
+        run: |
+          ORT_DIR="/opt/onnxruntime-${ORT_VERSION}"
+          ORT_TARBALL="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+          ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_TARBALL}"
+
+          echo "Downloading ORT ${ORT_VERSION} from ${ORT_URL}"
+          curl -fsSL --retry 3 --retry-delay 5 -o "/tmp/${ORT_TARBALL}" "${ORT_URL}"
+
+          mkdir -p "${ORT_DIR}"
+          tar -xzf "/tmp/${ORT_TARBALL}" -C "${ORT_DIR}" --strip-components=1
+          rm "/tmp/${ORT_TARBALL}"
+
+          # Locate libonnxruntime.so — prefer the versioned shared object.
+          DYLIB_PATH=$(find "${ORT_DIR}/lib" -name "libonnxruntime.so.${ORT_VERSION}" | head -1)
+          if [ -z "${DYLIB_PATH}" ]; then
+            # Fall back to the unversioned symlink if present.
+            DYLIB_PATH=$(find "${ORT_DIR}/lib" -name "libonnxruntime.so" | head -1)
+          fi
+          if [ -z "${DYLIB_PATH}" ]; then
+            echo "ERROR: libonnxruntime.so not found in ${ORT_DIR}/lib after extraction."
+            find "${ORT_DIR}" -name "*.so*" || true
+            exit 1
+          fi
+
+          echo "ORT_DYLIB_PATH=${DYLIB_PATH}" >> "$GITHUB_ENV"
+          echo "Found libonnxruntime.so at: ${DYLIB_PATH}"
+          # Sanity-check: ldd the library to confirm it is a valid ELF shared object.
+          ldd "${DYLIB_PATH}" | head -5 || true
+
+      # ------------------------------------------------------------------
+      # 6. Build trusty-analyze with load-dynamic, no bundled-ort.
+      #
+      #    This is the critical step: it runs the full LINK phase (not just
+      #    cargo check), so any __isoc23_strtol or other glibc-2.38 symbol
+      #    references in the bundled ORT static libs would surface here.
+      #    With load-dynamic, the bundled libs are NOT linked — ort is told
+      #    to dlopen at runtime — so the build must succeed on glibc 2.34.
+      # ------------------------------------------------------------------
+      - name: Build trusty-analyze (load-dynamic, no bundled-ort)
+        run: |
+          echo "ORT_DYLIB_PATH=${ORT_DYLIB_PATH}"
+          cargo build -p trusty-analyze \
+            --no-default-features \
+            --features http-server,load-dynamic


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/al2023-build.yml` — a regression gate that proves `cargo build -p trusty-analyze --no-default-features --features http-server,load-dynamic` compiles **and links** on Amazon Linux 2023 (glibc 2.34).
- This gate prevents issue #605 from silently returning: the default `bundled-ort` feature downloads ORT 1.24.2 (compiled against glibc 2.38), which fails to link on AL2023 with `undefined symbol: __isoc23_strtol`. The load-dynamic path bypasses the bundled static libs entirely.
- The first real validation of this job is the CI run on this PR itself (the `amazonlinux:2023` container cannot run on the macOS dev host).

## What the job does

1. Runs in an `amazonlinux:2023` container (glibc 2.34 — the exact platform that triggered #605).
2. Installs build prerequisites via `dnf` (gcc, openssl-devel, etc.).
3. Installs Rust 1.91 (workspace MSRV) via `rustup` directly — the `dtolnay/rust-toolchain` action requires host runner Node.js, which is not present inside the AL2023 container.
4. Downloads ORT 1.20.1 linux-x64 (built on Ubuntu 20.04 / glibc 2.31 — compatible with AL2023's glibc 2.34) and sets `ORT_DYLIB_PATH`.
5. Runs `cargo build -p trusty-analyze --no-default-features --features http-server,load-dynamic` — full link step, not just `check`.

## ORT version pinned

**1.20.1** — built on Ubuntu 20.04 (glibc 2.31). Works on any host with glibc >= 2.31 including AL2023 (glibc 2.34). Matches the ORT version that `ort-sys 2.0.0-rc.12` (current workspace lock) downloads when `ort-download-binaries` is active, keeping ABI-level parity. Bump this pin when the workspace's `ort-sys` version moves to a new ORT major.

## Trigger / path filter

Triggers on push and PR for `crates/trusty-analyze/**` and `.github/workflows/al2023-build.yml`, plus manual `workflow_dispatch`. Does **not** run on every push to main — the container build is slow and only trusty-analyze changes can affect this path.

## YAML validation

Validated locally with `python3 -c 'import yaml,sys; yaml.safe_load(open(...))'` — parse succeeded. Pre-commit `check yaml` hook also passed on commit. The Docker AL2023 build itself can only be validated by this PR's CI run.

## Test plan

- [ ] CI run on this PR shows the `AL2023 load-dynamic (glibc 2.34)` job passes
- [ ] Verify the job correctly fails if someone re-introduces a `bundled-ort` dependency (manual check — test by temporarily changing the cargo features in the workflow and confirming failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)