### PR TITLE
chore(release): trusty-analyze 0.4.2 (AL2023 load-dynamic docs #605)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10686,7 +10686,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ## [Unreleased]
 
+---
+
+## [0.4.2] — 2026-06-02
+
 ### Fixed
 - **Amazon Linux 2023 / glibc < 2.38 build failure** (closes #605): the
   prebuilt ONNX Runtime bundled via `fastembed/ort-download-binaries` (ORT

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.4.1"
+version     = "0.4.2"
 edition     = "2021"
 license     = "MIT"
 authors.workspace    = true


### PR DESCRIPTION
## Summary

- Bumps `trusty-analyze` version 0.4.1 → 0.4.2 (PATCH release)
- Promotes the `[Unreleased]` CHANGELOG entry to `[0.4.2] — 2026-06-02`
- Adds a fresh empty `[Unreleased]` section above it
- No code changes — this release captures the AL2023 / glibc < 2.38 build-fix docs already merged via PR #614 (commit 5f883a6, closes #605)

## What's in this release

**Fixed**: Amazon Linux 2023 / glibc < 2.38 build failure (#605). The `load-dynamic` Cargo feature (introduced in #536) bypasses the static ORT bundle and allows `ort` to dlopen a system-installed `libonnxruntime.so` at runtime. README now documents the full three-step AL2023 installation procedure.

## Test plan

- [x] `cargo fmt --check` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed
- [x] `cargo test -p trusty-analyze` — 12 passed, 1 ignored (daemon integration, requires running services)
- [x] `cargo check --workspace` — passed
- [x] `cargo publish --dry-run -p trusty-analyze` — to be verified after merge/tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)