### PR TITLE
feat(trusty-review): DiffAnalyzer noise filter + raise diff cap 60k→160k (closes #624)

### DIFF
--- a/crates/trusty-review/src/config/constants.rs
+++ b/crates/trusty-review/src/config/constants.rs
@@ -101,9 +101,14 @@ pub const DEDUP_STALE_SECS: u64 = 7200; // 2 hours.
 
 /// Maximum length of the full diff text (characters) fed to the LLM.
 ///
-/// Why: very large diffs cause token budget overruns and poor review quality.
-/// What: the diff summarizer truncates after this many characters.
-pub const MAX_DIFF_CHARS: usize = 60_000;
+/// Why: the reviewer model (Bedrock Claude Sonnet 4.6) has a 200 K-token context
+/// window; the old 60 K-char cap (~15 K tokens) was overly conservative and
+/// caused real PRs with large fixture churn to drop substantive code changes.
+/// Raised to 160 K chars (≈40 K tokens) — still ~5× under the 200 K window —
+/// to give the DiffAnalyzer noise filter enough headroom to work.
+/// What: `truncate_diff` and `DiffAnalyzer::render_for_prompt` both use this cap
+/// as their final safety net.  Closes: #624.
+pub const MAX_DIFF_CHARS: usize = 160_000;
 
 /// Maximum number of context files retrieved from trusty-search per review.
 pub const MAX_CONTEXT_FILES: usize = 20;
@@ -222,6 +227,52 @@ mod tests {
         assert!(
             REVIEW_VERSION.starts_with("tr-"),
             "REVIEW_VERSION must start with 'tr-'"
+        );
+    }
+
+    /// Regression guard: `MAX_DIFF_CHARS` must be 160_000 (the cap raised from
+    /// 60_000 in #624 to give the DiffAnalyzer noise filter enough headroom).
+    ///
+    /// Why: a silent regression to the old 60 K cap would make the DiffAnalyzer
+    /// pointless — noise-filtered diffs would still be truncated at ~15 K tokens.
+    /// What: asserts the exact numeric value; changing it must fail this test so
+    /// the change is explicit and intentional.
+    /// Test: this test itself.
+    #[test]
+    fn max_diff_chars_is_160k() {
+        assert_eq!(
+            MAX_DIFF_CHARS,
+            160_000,
+            "MAX_DIFF_CHARS must be 160_000 (raised from 60_000 in #624)"
+        );
+        // Also assert it comfortably fits below the reviewer model's context window.
+        // 200 K tokens × ~4 chars/token ≈ 800 K chars → 160 K is well within range.
+        assert!(
+            MAX_DIFF_CHARS < 400_000,
+            "MAX_DIFF_CHARS must remain well below the 200 K-token context window"
+        );
+    }
+
+    /// Regression guard: `truncate_diff` must cut at a hunk boundary and not
+    /// exceed the cap significantly (covers the new 160 K value end-to-end).
+    ///
+    /// Why: ensures the `truncate_diff` implementation respects the updated cap.
+    /// What: builds a diff longer than MAX_DIFF_CHARS, asserts the truncation
+    /// marker appears and the result does not greatly exceed MAX_DIFF_CHARS.
+    /// Test: this test itself.
+    #[test]
+    fn max_diff_chars_truncation_consistent() {
+        use crate::pipeline::diff::truncate_diff;
+        let over = "a".repeat(MAX_DIFF_CHARS + 5_000);
+        let result = truncate_diff(&over);
+        assert!(
+            result.contains("[DIFF TRUNCATED"),
+            "truncated diff must contain the marker"
+        );
+        assert!(
+            result.len() <= MAX_DIFF_CHARS + 300,
+            "truncated result must not greatly exceed the cap: len={}",
+            result.len()
         );
     }
 }

--- a/crates/trusty-review/src/config/constants.rs
+++ b/crates/trusty-review/src/config/constants.rs
@@ -241,16 +241,17 @@ mod tests {
     #[test]
     fn max_diff_chars_is_160k() {
         assert_eq!(
-            MAX_DIFF_CHARS,
-            160_000,
+            MAX_DIFF_CHARS, 160_000,
             "MAX_DIFF_CHARS must be 160_000 (raised from 60_000 in #624)"
         );
         // Also assert it comfortably fits below the reviewer model's context window.
         // 200 K tokens × ~4 chars/token ≈ 800 K chars → 160 K is well within range.
-        assert!(
-            MAX_DIFF_CHARS < 400_000,
-            "MAX_DIFF_CHARS must remain well below the 200 K-token context window"
-        );
+        const {
+            assert!(
+                MAX_DIFF_CHARS < 400_000,
+                "MAX_DIFF_CHARS must remain well below the 200 K-token context window"
+            )
+        };
     }
 
     /// Regression guard: `truncate_diff` must cut at a hunk boundary and not

--- a/crates/trusty-review/src/pipeline/diff.rs
+++ b/crates/trusty-review/src/pipeline/diff.rs
@@ -83,7 +83,7 @@ pub async fn load_diff(source: &DiffSource) -> Result<String, GithubError> {
 /// Truncate a diff to at most `MAX_DIFF_CHARS` characters.
 ///
 /// Why: very large diffs cause LLM token budget overruns and degraded review
-/// quality.  The cap is defined in `constants::MAX_DIFF_CHARS` (60 000 chars).
+/// quality.  The cap is defined in `constants::MAX_DIFF_CHARS` (160 000 chars).
 /// What: if the diff exceeds the cap, it is cut at the nearest hunk boundary
 /// before the cap, or at the raw char limit if no hunk boundary is found.  A
 /// `[DIFF TRUNCATED — ...]` marker is appended so the LLM can see the diff is

--- a/crates/trusty-review/src/pipeline/diff_analyzer/file_filter.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/file_filter.rs
@@ -1,0 +1,423 @@
+//! Stage A: file-level deterministic noise filter (spec REV-201–202).
+//!
+//! Why: lockfiles, snapshots, generated code, and pure renames consume large
+//! portions of the LLM context budget without contributing review signal.
+//! Dropping or summarising them before Stage B increases effective signal
+//! density and protects the reviewer from the §12.12 fixture-churn problem.
+//!
+//! What: `FileFilter::apply` classifies each file from a parsed diff as
+//! `Kept`, `Dropped`, or `SummaryOnly`.  Decisions are ordered:
+//! 1. Preserve (security paths, credential filenames) — highest priority.
+//! 2. Drop (lockfiles, snapshots, generated code).
+//! 3. SummaryOnly (fixture/i18n files > `fixture_summary_min_lines`).
+//! 4. Kept — default.
+//!
+//! Test: `lockfile_is_dropped`, `security_file_is_preserved`,
+//! `fixture_file_is_summarised`, `plain_rust_file_is_kept`.
+
+use super::models::{DroppedFile, FileDisposition, FilteredFile, FilteredHunk};
+
+// ─── Built-in pattern lists ───────────────────────────────────────────────────
+
+static LOCKFILE_SUFFIXES: &[&str] = &[
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.lock",
+    "uv.lock",
+    "poetry.lock",
+    "Pipfile.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "go.sum",
+];
+
+static SNAPSHOT_SUFFIXES: &[&str] = &[".snap", ".snapshot."];
+
+static SNAPSHOT_SEGMENTS: &[&str] = &["__snapshots__/", "__fixtures__/"];
+
+static GENERATED_SUFFIXES: &[&str] = &[
+    "_pb2.py",
+    "_pb2_grpc.py",
+    ".pb.go",
+    ".generated.",
+    ".gen.go",
+];
+
+static GENERATED_SEGMENTS: &[&str] = &["dist/", "build/", ".next/", "__generated__/"];
+
+/// Pattern: `generated/<lang-ext>` file.
+fn is_generated_lang(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    lower.contains("generated/")
+        && (lower.ends_with(".java") || lower.ends_with(".ts") || lower.ends_with(".js"))
+}
+
+static FIXTURE_SUFFIXES: &[&str] = &[".tsv", ".csv"];
+
+static FIXTURE_SEGMENTS: &[&str] = &[
+    "nls/",
+    "messages/",
+    "labels/",
+    "fixtures/",
+    "test_fixtures/",
+    "__generated__/",
+    "generated/",
+];
+
+fn is_fixture_json_xml_sql(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    (lower.contains("fixture") || lower.contains("test_fixture"))
+        && (lower.ends_with(".json") || lower.ends_with(".xml") || lower.ends_with(".sql"))
+}
+
+// ─── Preserve rules ───────────────────────────────────────────────────────────
+
+static PRESERVE_PATH_SEGMENTS: &[&str] = &["security/", ".env", "secrets/"];
+
+static CREDENTIAL_FILENAME_SUBSTRINGS: &[&str] =
+    &["secret", "token", "password", "key", "dsn", "credential"];
+
+/// Regex for credential URLs embedded in diff content.
+static CREDENTIAL_URL_PATTERN: &str = r"https?://[^@ ]+@";
+
+/// Returns `true` if the path or patch likely contains credentials (spec REV-207).
+///
+/// Why: force-preserving credential-bearing files prevents the filter from
+/// accidentally stripping security-sensitive changes.
+/// What: checks path segments, filename substrings, and content for credential
+/// URL patterns.
+/// Test: `credential_path_is_preserved`, `credential_url_in_patch_is_preserved`.
+pub fn should_preserve(path: &str, patch: &str) -> bool {
+    let lower = path.to_lowercase();
+
+    for seg in PRESERVE_PATH_SEGMENTS {
+        if lower.contains(seg) {
+            return true;
+        }
+    }
+    // Filename (last component) check for credential substrings.
+    let filename = path.rsplit('/').next().unwrap_or(path).to_lowercase();
+    for sub in CREDENTIAL_FILENAME_SUBSTRINGS {
+        if filename.contains(sub) {
+            return true;
+        }
+    }
+    // Content-level credential URL check.
+    if !patch.is_empty()
+        && patch.contains("://")
+        && patch.contains('@')
+        && regex::Regex::new(CREDENTIAL_URL_PATTERN)
+            .map(|re| re.is_match(patch))
+            .unwrap_or(false)
+    {
+        return true;
+    }
+    false
+}
+
+// ─── Classification helpers ───────────────────────────────────────────────────
+
+fn is_lockfile(path: &str) -> bool {
+    for suffix in LOCKFILE_SUFFIXES {
+        if path == *suffix || path.ends_with(&format!("/{suffix}")) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_snapshot(path: &str) -> bool {
+    for suffix in SNAPSHOT_SUFFIXES {
+        if path.ends_with(suffix) {
+            return true;
+        }
+    }
+    for seg in SNAPSHOT_SEGMENTS {
+        if path.contains(seg) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_generated(path: &str) -> bool {
+    for suffix in GENERATED_SUFFIXES {
+        if path.ends_with(suffix) {
+            return true;
+        }
+    }
+    for seg in GENERATED_SEGMENTS {
+        if path.contains(seg) {
+            return true;
+        }
+    }
+    is_generated_lang(path)
+}
+
+fn is_fixture(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    for suffix in FIXTURE_SUFFIXES {
+        if lower.ends_with(suffix) {
+            return true;
+        }
+    }
+    for seg in FIXTURE_SEGMENTS {
+        if lower.contains(seg) {
+            return true;
+        }
+    }
+    is_fixture_json_xml_sql(&lower)
+}
+
+fn count_patch_lines(patch: &str) -> usize {
+    patch.lines().count()
+}
+
+// ─── Diff parsing helper ──────────────────────────────────────────────────────
+
+/// Split a unified-diff patch string into (header, lines) pairs.
+///
+/// Why: Stage A needs per-hunk structure to populate `FilteredFile.hunks` for
+/// Stage B.  If the patch has no `@@` headers (e.g., opaque blobs), the entire
+/// patch is treated as a single hunk.
+/// What: scans for `@@` lines; each found line starts a new hunk.
+/// Test: `split_patch_into_hunks_basic`.
+pub fn split_patch_into_hunks(patch: &str) -> Vec<(String, Vec<String>)> {
+    let mut hunks: Vec<(String, Vec<String>)> = Vec::new();
+    let mut current_header: Option<String> = None;
+    let mut current_lines: Vec<String> = Vec::new();
+
+    for line in patch.lines() {
+        if line.starts_with("@@") {
+            if let Some(h) = current_header.take() {
+                hunks.push((h, std::mem::take(&mut current_lines)));
+            }
+            current_header = Some(line.to_string());
+        } else if let Some(ref _h) = current_header {
+            current_lines.push(line.to_string());
+        }
+    }
+    if let Some(h) = current_header {
+        hunks.push((h, current_lines));
+    }
+
+    // Opaque blob: no @@ headers found but patch has content.
+    if hunks.is_empty() && !patch.trim().is_empty() {
+        hunks.push((
+            "@@ (opaque) @@".to_string(),
+            patch.lines().map(|l| l.to_string()).collect(),
+        ));
+    }
+
+    hunks
+}
+
+// ─── FileFilter ───────────────────────────────────────────────────────────────
+
+/// Configures the Stage A file-level noise filter.
+///
+/// Why: all filter knobs are passed explicitly (spec REV-262 "no global state").
+/// What: `preserve_patterns` are additional regex patterns that force-keep files;
+/// `suppress_patterns` are additional drop patterns; `fixture_summary_min_lines`
+/// controls when fixture files are summarised vs dropped.
+/// Test: used directly by `FileFilter` and `DiffAnalyzer`.
+#[derive(Debug, Clone)]
+pub struct FilterConfig {
+    /// Extra preserve patterns (beyond built-ins); regex strings.
+    pub preserve_patterns: Vec<String>,
+    /// Extra suppress/drop patterns; regex strings.
+    pub suppress_patterns: Vec<String>,
+    /// Min diff lines for a fixture/i18n file to be summarised (default 30).
+    pub fixture_summary_min_lines: usize,
+    /// When true, Stage B drops whitespace-only hunks.
+    pub ignore_whitespace: bool,
+    /// When true, Stage B drops import-only hunks.
+    pub ignore_imports: bool,
+    /// When true, Stage B drops comment-only hunks.
+    pub ignore_comments: bool,
+    /// When true, Stage C (LLM classifier) is disabled.
+    pub disable_classifier: bool,
+    /// Mechanical confidence threshold above which Stage C drops a hunk.
+    pub drop_confidence_threshold: f32,
+    /// Haiku batch size for Stage C.
+    pub classifier_batch_size: usize,
+}
+
+impl Default for FilterConfig {
+    fn default() -> Self {
+        Self {
+            preserve_patterns: Vec::new(),
+            suppress_patterns: Vec::new(),
+            fixture_summary_min_lines: 30,
+            ignore_whitespace: true,
+            ignore_imports: true,
+            ignore_comments: true,
+            disable_classifier: true,
+            drop_confidence_threshold: 0.7,
+            classifier_batch_size: 10,
+        }
+    }
+}
+
+/// Stage A file-level noise filter (spec REV-201–202).
+///
+/// Why: fast, deterministic pre-filter that eliminates the most egregious
+/// noise classes before hunk-level analysis.  Zero external dependencies.
+/// What: `apply` iterates parsed diff files and classifies each; returns
+/// surviving `FilteredFile` stubs (hunk content is raw text for Stage B to
+/// re-classify) and a list of `DroppedFile` records.
+/// Test: `lockfile_is_dropped`, `security_file_is_preserved`,
+/// `fixture_file_is_summarised`, `plain_rust_file_is_kept`.
+pub struct FileFilter {
+    config: FilterConfig,
+    user_preserve: Vec<regex::Regex>,
+    user_suppress: Vec<regex::Regex>,
+}
+
+impl FileFilter {
+    /// Build a `FileFilter` from the given `FilterConfig`.
+    ///
+    /// Why: pattern compilation is expensive; doing it once at construction
+    /// avoids redundant work across many `apply` calls.
+    /// What: compiles user-supplied preserve and suppress regex patterns;
+    /// silently ignores patterns that fail to compile (non-fatal, logged).
+    /// Test: `filefilter_user_preserve_keeps_file`.
+    pub fn new(config: FilterConfig) -> Self {
+        let user_preserve = config
+            .preserve_patterns
+            .iter()
+            .filter_map(|p| regex::Regex::new(p).ok())
+            .collect();
+        let user_suppress = config
+            .suppress_patterns
+            .iter()
+            .filter_map(|p| regex::Regex::new(p).ok())
+            .collect();
+        Self {
+            config,
+            user_preserve,
+            user_suppress,
+        }
+    }
+
+    /// Classify each file in `parsed_files` and return (kept, dropped).
+    ///
+    /// Why: centralises Stage A logic so tests can run it without the full
+    /// pipeline; the `DiffAnalyzer` calls this once per review.
+    /// What: for each `(path, status, patch)`, calls `classify` and builds the
+    /// appropriate `FilteredFile` or `DroppedFile`.
+    /// Test: `lockfile_is_dropped`, `plain_rust_file_is_kept`.
+    pub fn apply(
+        &self,
+        parsed_files: &[(String, String, String)], // (path, status, patch)
+    ) -> (Vec<FilteredFile>, Vec<DroppedFile>) {
+        let mut kept = Vec::new();
+        let mut dropped = Vec::new();
+
+        for (path, status, patch) in parsed_files {
+            let (disposition, reason) = self.classify(path, patch);
+            match disposition {
+                FileDisposition::Dropped => {
+                    dropped.push(DroppedFile {
+                        path: path.clone(),
+                        reason: reason.unwrap_or_else(|| "noise".to_string()),
+                    });
+                }
+                FileDisposition::SummaryOnly => {
+                    kept.push(FilteredFile {
+                        filename: path.clone(),
+                        status: status.clone(),
+                        disposition: FileDisposition::SummaryOnly,
+                        hunks: Vec::new(),
+                        dropped_hunks: Vec::new(),
+                        summary_line: Some(self.summarize(path, patch)),
+                    });
+                }
+                FileDisposition::Kept => {
+                    let raw_hunks = split_patch_into_hunks(patch);
+                    kept.push(FilteredFile {
+                        filename: path.clone(),
+                        status: status.clone(),
+                        disposition: FileDisposition::Kept,
+                        hunks: raw_hunks
+                            .into_iter()
+                            .map(|(header, lines)| FilteredHunk {
+                                header,
+                                lines,
+                                substantive_confidence: 1.0,
+                                reason_kept: "stage-a-pass".to_string(),
+                            })
+                            .collect(),
+                        dropped_hunks: Vec::new(),
+                        summary_line: None,
+                    });
+                }
+            }
+        }
+        (kept, dropped)
+    }
+
+    /// Classify a single file as `Kept`, `Dropped`, or `SummaryOnly`.
+    ///
+    /// Why: isolated for per-file unit testing without constructing full input.
+    /// What: applies rules in priority order (preserve > drop > summarize > keep).
+    /// Returns `(disposition, Option<drop_reason>)`.
+    /// Test: `classify_lockfile`, `classify_security_file`.
+    pub fn classify(&self, path: &str, patch: &str) -> (FileDisposition, Option<String>) {
+        // 1. Preserve (highest priority — overrides all drops).
+        if should_preserve(path, patch) {
+            return (FileDisposition::Kept, None);
+        }
+        for re in &self.user_preserve {
+            if re.is_match(path) {
+                return (FileDisposition::Kept, None);
+            }
+        }
+
+        // 2. User suppress patterns (optional extra drops before built-ins).
+        for re in &self.user_suppress {
+            if re.is_match(path) {
+                return (
+                    FileDisposition::Dropped,
+                    Some("suppress-pattern".to_string()),
+                );
+            }
+        }
+
+        // 3. Built-in drop patterns.
+        if is_lockfile(path) {
+            return (FileDisposition::Dropped, Some("lockfile".to_string()));
+        }
+        if is_snapshot(path) {
+            return (FileDisposition::Dropped, Some("snapshot".to_string()));
+        }
+        if is_generated(path) {
+            return (FileDisposition::Dropped, Some("generated".to_string()));
+        }
+
+        // 4. SummaryOnly: fixture/i18n with enough lines.
+        if is_fixture(path) && count_patch_lines(patch) > self.config.fixture_summary_min_lines {
+            return (FileDisposition::SummaryOnly, None);
+        }
+
+        // 5. Default: Kept.
+        (FileDisposition::Kept, None)
+    }
+
+    fn summarize(&self, path: &str, patch: &str) -> String {
+        let n_lines = count_patch_lines(patch);
+        format!("[fixture/i18n: {n_lines} diff lines omitted — {path}]")
+    }
+
+    /// Expose the parsed config for use by the DiffAnalyzer / HunkFilter.
+    pub fn config(&self) -> &FilterConfig {
+        &self.config
+    }
+}
+
+// ─── Unit tests (extracted to keep file under 500-line cap) ──────────────────
+
+#[cfg(test)]
+#[path = "file_filter_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/diff_analyzer/file_filter_tests.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/file_filter_tests.rs
@@ -1,0 +1,167 @@
+//! Unit tests for Stage A FileFilter (spec REV-201–202).
+
+use super::{FileFilter, FilterConfig, split_patch_into_hunks};
+use crate::pipeline::diff_analyzer::models::FileDisposition;
+
+fn filter() -> FileFilter {
+    FileFilter::new(FilterConfig::default())
+}
+
+fn files(list: &[(&str, &str, &str)]) -> Vec<(String, String, String)> {
+    list.iter()
+        .map(|(p, s, pa)| (p.to_string(), s.to_string(), pa.to_string()))
+        .collect()
+}
+
+#[test]
+fn lockfile_is_dropped() {
+    let ff = filter();
+    let (kept, dropped) = ff.apply(&files(&[("Cargo.lock", "modified", "+foo\n")]));
+    assert!(kept.is_empty(), "lockfile must not be kept");
+    assert_eq!(dropped.len(), 1);
+    assert_eq!(dropped[0].reason, "lockfile");
+}
+
+#[test]
+fn yarn_lock_is_dropped() {
+    let ff = filter();
+    let (kept, dropped) = ff.apply(&files(&[("yarn.lock", "modified", "+x\n")]));
+    assert!(kept.is_empty());
+    assert_eq!(dropped[0].reason, "lockfile");
+}
+
+#[test]
+fn snapshot_is_dropped() {
+    let ff = filter();
+    let (kept, dropped) = ff.apply(&files(&[(
+        "tests/__snapshots__/foo.snap",
+        "modified",
+        "+x\n",
+    )]));
+    assert!(kept.is_empty());
+    assert_eq!(dropped[0].reason, "snapshot");
+}
+
+#[test]
+fn generated_file_is_dropped() {
+    let ff = filter();
+    let (kept, dropped) = ff.apply(&files(&[(
+        "src/gen/api_pb2.py",
+        "added",
+        "+class X: pass\n",
+    )]));
+    assert!(kept.is_empty());
+    assert!(
+        dropped[0].reason.contains("generated"),
+        "expected generated, got: {}",
+        dropped[0].reason
+    );
+}
+
+#[test]
+fn plain_rust_file_is_kept() {
+    let ff = filter();
+    let patch = "@@ -1,1 +1,1 @@\n-fn foo() {}\n+fn bar() {}\n";
+    let (kept, dropped) = ff.apply(&files(&[("src/auth.rs", "modified", patch)]));
+    assert!(dropped.is_empty());
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].disposition, FileDisposition::Kept);
+    assert_eq!(kept[0].filename, "src/auth.rs");
+}
+
+#[test]
+fn security_file_is_preserved() {
+    let ff = filter();
+    // A file in a security/ path should be force-kept even if it looks like a lockfile.
+    let (kept, dropped) = ff.apply(&files(&[("security/Cargo.lock", "modified", "+x\n")]));
+    assert!(dropped.is_empty(), "security file must be force-kept");
+    assert_eq!(kept.len(), 1);
+}
+
+#[test]
+fn credential_filename_preserved() {
+    let ff = filter();
+    // "token" in the filename triggers preserve.
+    let (kept, dropped) = ff.apply(&files(&[("config/api_token.json", "modified", "+x\n")]));
+    assert!(dropped.is_empty());
+    assert_eq!(kept[0].disposition, FileDisposition::Kept);
+}
+
+#[test]
+fn env_file_is_preserved() {
+    let ff = filter();
+    let (kept, dropped) = ff.apply(&files(&[(".env", "modified", "+SECRET=xxx\n")]));
+    assert!(dropped.is_empty(), ".env must be force-kept");
+    assert_eq!(kept[0].disposition, FileDisposition::Kept);
+}
+
+#[test]
+fn fixture_file_is_summarised_when_large() {
+    let ff = filter();
+    let big_patch = "+row\n".repeat(50);
+    let (kept, dropped) = ff.apply(&files(&[(
+        "tests/fixtures/data.json",
+        "modified",
+        &big_patch,
+    )]));
+    assert!(dropped.is_empty());
+    assert_eq!(kept[0].disposition, FileDisposition::SummaryOnly);
+    assert!(kept[0].summary_line.is_some());
+}
+
+#[test]
+fn fixture_file_kept_when_small() {
+    let ff = filter();
+    let small_patch = "@@ -1,2 +1,2 @@\n+row1\n+row2\n";
+    let (kept, dropped) = ff.apply(&files(&[(
+        "tests/fixtures/data.json",
+        "modified",
+        small_patch,
+    )]));
+    assert!(dropped.is_empty());
+    assert_eq!(kept[0].disposition, FileDisposition::Kept);
+}
+
+#[test]
+fn split_patch_into_hunks_basic() {
+    let patch = "@@ -1,2 +1,2 @@\n-old\n+new\n@@ -10,1 +10,1 @@\n-x\n+y\n";
+    let hunks = split_patch_into_hunks(patch);
+    assert_eq!(hunks.len(), 2);
+    assert_eq!(hunks[0].0, "@@ -1,2 +1,2 @@");
+    assert_eq!(hunks[1].0, "@@ -10,1 +10,1 @@");
+}
+
+#[test]
+fn split_opaque_patch_treated_as_single_hunk() {
+    let patch = "-old line\n+new line\n";
+    let hunks = split_patch_into_hunks(patch);
+    assert_eq!(hunks.len(), 1);
+    assert_eq!(hunks[0].0, "@@ (opaque) @@");
+}
+
+#[test]
+fn filefilter_user_preserve_keeps_file() {
+    let config = FilterConfig {
+        preserve_patterns: vec![r"vendor/.*\.lock$".to_string()],
+        ..Default::default()
+    };
+    let ff = FileFilter::new(config);
+    let (kept, dropped) = ff.apply(&files(&[("vendor/foo.lock", "modified", "+x\n")]));
+    assert!(dropped.is_empty(), "user preserve must override drop");
+    assert_eq!(kept.len(), 1);
+}
+
+#[test]
+fn multiple_files_classified_correctly() {
+    let ff = filter();
+    let patch = "@@ -1,1 +1,1 @@\n+fn foo() {}\n";
+    let input = files(&[
+        ("Cargo.lock", "modified", "+x\n"),
+        ("src/main.rs", "modified", patch),
+        ("yarn.lock", "modified", "+y\n"),
+    ]);
+    let (kept, dropped) = ff.apply(&input);
+    assert_eq!(dropped.len(), 2, "both lockfiles must be dropped");
+    assert_eq!(kept.len(), 1, "only main.rs should be kept");
+    assert_eq!(kept[0].filename, "src/main.rs");
+}

--- a/crates/trusty-review/src/pipeline/diff_analyzer/hunk_classifier.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/hunk_classifier.rs
@@ -1,0 +1,463 @@
+//! Stage C: LLM-based per-hunk substantive-ness classifier (spec REV-205–208).
+//!
+//! Why: regex hunk filtering (Stage B) only handles homogeneous-noise hunks.
+//! Real PRs interleave noise and substance within the same hunk.  A cheap
+//! Haiku classifier recovers budget by dropping mixed hunks that are
+//! predominantly mechanical, but NEVER at the cost of missing real changes.
+//!
+//! What: `HunkClassifier::classify_batch` groups surviving hunks into batches
+//! of `batch_size`, calls the injected `LlmProvider` once per batch at
+//! temperature 0.0, parses the JSON array response, and returns
+//! `HunkClassification` results.  Any error causes the whole batch to be
+//! treated as `uncertain` (kept) — spec REV-208 fail-safe.
+//!
+//! Note: the classifier is optional and disabled by default (`disable_classifier`
+//! = true in `FilterConfig`).  The `DiffAnalyzer` checks this flag before calling
+//! this module.  When Stage C is enabled, it uses the same `LlmProvider` trait
+//! that the reviewer/verifier use.  Issue #596 plans consolidation onto
+//! `trusty_common::chat::ChatProvider`; for now we use the in-crate provider.
+//!
+//! Test: `classify_batch_all_uncertain_on_parse_error`,
+//! `classify_batch_drops_mechanical_hunk`,
+//! `parse_classification_array_valid`, `parse_classification_array_partial`.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+use crate::{
+    llm::{ChatMessage, LlmProvider, LlmRequest},
+    pipeline::diff_analyzer::models::{FilteredHunk, HunkDropReason},
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Maximum number of hunks per LLM batch call (spec REV-205).
+pub const DEFAULT_BATCH_SIZE: usize = 10;
+
+/// Maximum characters from a single hunk sent to the classifier.
+pub const MAX_HUNK_CHARS: usize = 4_000;
+
+/// Mechanical confidence threshold above which a hunk is dropped (spec REV-206).
+pub const DROP_CONFIDENCE_THRESHOLD: f64 = 0.7;
+
+/// Haiku model id used for classification (can be overridden via config).
+pub const DEFAULT_CLASSIFIER_MODEL: &str = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+// ─── System prompt ────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT: &str = "\
+You are a code review assistant. Below are N code diff hunks from a pull request.\n\
+For each hunk, classify it as exactly one of:\n\
+  - \"substantive\": the hunk contains a meaningful change — logic change, schema\n\
+    change, API surface change, security-relevant change, control-flow change,\n\
+    new function/method body, bug fix, or any change that a reviewer must evaluate.\n\
+  - \"mechanical\": the hunk is boilerplate or noise — pure formatting, whitespace\n\
+    changes, import reordering, license/copyright header, generated code, fixture\n\
+    data, JavaDoc-only additions with no logic, getter/setter stubs, pure rename.\n\
+  - \"uncertain\": cannot determine substantiveness without more context.\n\
+\n\
+Return a JSON array with exactly one entry per hunk in order, each with:\n\
+  {\"hunk_id\": \"<id>\", \"classification\": \"<substantive|mechanical|uncertain>\",\n\
+   \"confidence\": <0.0-1.0>, \"reason\": \"<one sentence>\"}\n\
+\n\
+Do not include any text outside the JSON array. Do not wrap in markdown fences.";
+
+// ─── Classification result ────────────────────────────────────────────────────
+
+/// The LLM classification for a single hunk (spec REV-206).
+///
+/// Why: carries the full classifier verdict alongside hunk identity so the
+/// orchestrator can make drop/keep decisions and record telemetry.
+/// What: `is_mechanical` = true only when `classification == "mechanical"` AND
+/// `confidence > DROP_CONFIDENCE_THRESHOLD`.  `uncertain` or low-confidence
+/// mechanical results are fail-open (kept).
+/// Test: `hunk_classification_mechanical_high_confidence_droppable`.
+#[derive(Debug, Clone)]
+pub struct HunkClassification {
+    /// The hunk index within the batch (0-based).
+    pub hunk_index: usize,
+    /// Raw classification string from the LLM.
+    pub classification: String,
+    /// Confidence score 0.0–1.0.
+    pub confidence: f64,
+    /// One-sentence reason from the classifier.
+    pub reason: String,
+}
+
+impl HunkClassification {
+    /// Returns `true` if this hunk should be dropped (spec REV-206).
+    ///
+    /// Why: encapsulates the drop decision so callers do not inline the threshold.
+    /// What: `mechanical` AND `confidence > DROP_CONFIDENCE_THRESHOLD` → drop.
+    /// `uncertain`, `substantive`, or low-confidence mechanical → keep.
+    /// Test: `hunk_classification_mechanical_high_confidence_droppable`.
+    pub fn should_drop(&self) -> bool {
+        self.classification == "mechanical" && self.confidence > DROP_CONFIDENCE_THRESHOLD
+    }
+
+    /// Returns the `HunkDropReason` for a dropped hunk.
+    ///
+    /// Why: the `FilteredDiff.drop_hunk_counts` map needs the reason enum.
+    /// What: always returns `MechanicalHaiku` (the only Stage C drop reason).
+    /// Test: covered transitively.
+    pub fn drop_reason(&self) -> HunkDropReason {
+        HunkDropReason::MechanicalHaiku
+    }
+}
+
+// ─── JSON response shape ──────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ClassificationEntry {
+    #[allow(dead_code)] // populated by serde from JSON; carried for debuggability
+    hunk_id: String,
+    classification: String,
+    confidence: f64,
+    #[serde(default)]
+    reason: String,
+}
+
+// ─── HunkClassifier ───────────────────────────────────────────────────────────
+
+/// Stage C Haiku-based per-hunk substantive-ness classifier (spec REV-205–208).
+///
+/// Why: deterministic Stages A+B cannot classify mixed-content hunks; this stage
+/// recovers context budget by dropping high-confidence mechanical hunks while
+/// maintaining the fail-open guarantee.
+/// What: groups hunks into batches, builds a prompt, calls the LLM provider, and
+/// parses the JSON response.  On ANY error the whole batch is kept (spec REV-208).
+/// Test: `classify_batch_all_uncertain_on_parse_error`,
+/// `classify_batch_drops_mechanical_hunk`.
+pub struct HunkClassifier {
+    provider: Arc<dyn LlmProvider>,
+    model: String,
+    batch_size: usize,
+    /// Configurable drop confidence threshold; overrides DROP_CONFIDENCE_THRESHOLD.
+    /// Stored for future per-caller configuration; `should_drop` uses the const default.
+    #[allow(dead_code)]
+    drop_threshold: f64,
+}
+
+impl HunkClassifier {
+    /// Construct a `HunkClassifier` with the given provider and config.
+    ///
+    /// Why: provider is injected for testability (spec REV-261); the model can
+    /// be configured independently of the reviewer/verifier models.
+    /// What: stores the provider and config knobs; no external calls at construction.
+    /// Test: construct with a `MockLlmProvider`; see classify_batch tests.
+    pub fn new(
+        provider: Arc<dyn LlmProvider>,
+        model: impl Into<String>,
+        batch_size: usize,
+        drop_threshold: f64,
+    ) -> Self {
+        Self {
+            provider,
+            model: model.into(),
+            batch_size,
+            drop_threshold,
+        }
+    }
+
+    /// Classify `hunks` in batches; return per-hunk `HunkClassification` results.
+    ///
+    /// Why: batching amortises LLM call overhead while staying within context
+    /// limits (spec REV-205).
+    /// What: splits hunks into slices of `batch_size`, calls `classify_batch_slice`
+    /// for each, collects results.  On error each batch returns `uncertain` for
+    /// all hunks in that batch (spec REV-208).
+    /// Test: `classify_batch_all_uncertain_on_parse_error`.
+    pub async fn classify(&self, hunks: &[FilteredHunk]) -> Vec<HunkClassification> {
+        let mut results = Vec::with_capacity(hunks.len());
+        for (base_idx, batch) in hunks.chunks(self.batch_size).enumerate() {
+            let batch_results = self.classify_batch_slice(batch, base_idx).await;
+            results.extend(batch_results);
+        }
+        results
+    }
+
+    async fn classify_batch_slice(
+        &self,
+        batch: &[FilteredHunk],
+        base_idx: usize,
+    ) -> Vec<HunkClassification> {
+        let user_content = self.build_batch_prompt(batch, base_idx);
+        let req = LlmRequest {
+            model: self.model.clone(),
+            system: SYSTEM_PROMPT.to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: user_content,
+            }],
+            temperature: 0.0,
+            max_tokens: 1024,
+            response_schema: None,
+        };
+
+        match self.provider.complete(req).await {
+            Ok(resp) => match parse_classification_array(&resp.text, batch.len(), base_idx) {
+                Ok(classifications) => {
+                    debug!(
+                        batch_start = base_idx,
+                        count = classifications.len(),
+                        "Stage C classified batch"
+                    );
+                    classifications
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        batch_start = base_idx,
+                        batch_size = batch.len(),
+                        "Stage C parse failed — keeping all hunks (fail-open)"
+                    );
+                    uncertain_batch(batch, base_idx)
+                }
+            },
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    batch_start = base_idx,
+                    batch_size = batch.len(),
+                    "Stage C LLM error — keeping all hunks (fail-open, spec REV-208)"
+                );
+                uncertain_batch(batch, base_idx)
+            }
+        }
+    }
+
+    fn build_batch_prompt(&self, batch: &[FilteredHunk], base_idx: usize) -> String {
+        let mut out = format!("Classify the following {} hunks:\n\n", batch.len());
+        for (i, hunk) in batch.iter().enumerate() {
+            let hunk_id = base_idx + i;
+            let body = hunk.render();
+            let truncated = if body.len() > MAX_HUNK_CHARS {
+                &body[..MAX_HUNK_CHARS]
+            } else {
+                &body
+            };
+            out.push_str(&format!("--- HUNK {hunk_id} ---\n{truncated}\n\n"));
+        }
+        out
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Parse the LLM's JSON array response into `HunkClassification` entries.
+///
+/// Why: isolated for unit testing with mock response strings (no LLM needed).
+/// What: strips markdown fences if present, deserialises the JSON array,
+/// maps `hunk_id` strings to indices, and fills `expected_count` slots.
+/// Test: `parse_classification_array_valid`, `parse_classification_array_partial`.
+pub fn parse_classification_array(
+    text: &str,
+    expected_count: usize,
+    base_idx: usize,
+) -> Result<Vec<HunkClassification>, String> {
+    // Strip markdown fences if the model added them despite instructions.
+    let cleaned = text
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+
+    let entries: Vec<ClassificationEntry> =
+        serde_json::from_str(cleaned).map_err(|e| format!("JSON parse error: {e}"))?;
+
+    if entries.len() != expected_count {
+        return Err(format!(
+            "expected {expected_count} entries, got {}",
+            entries.len()
+        ));
+    }
+
+    let mut results = Vec::with_capacity(entries.len());
+    for (i, entry) in entries.into_iter().enumerate() {
+        results.push(HunkClassification {
+            hunk_index: base_idx + i,
+            classification: entry.classification,
+            confidence: entry.confidence.clamp(0.0, 1.0),
+            reason: entry.reason,
+        });
+    }
+    Ok(results)
+}
+
+/// Build `uncertain` (kept) results for all hunks in a batch (fail-open).
+///
+/// Why: any LLM or parse error must result in all hunks being kept (spec REV-208).
+/// What: creates one `uncertain` `HunkClassification` per hunk in the batch.
+/// Test: used in `classify_batch_all_uncertain_on_parse_error`.
+fn uncertain_batch(batch: &[FilteredHunk], base_idx: usize) -> Vec<HunkClassification> {
+    batch
+        .iter()
+        .enumerate()
+        .map(|(i, _)| HunkClassification {
+            hunk_index: base_idx + i,
+            classification: "uncertain".to_string(),
+            confidence: 0.0,
+            reason: "fail-open: LLM error or parse failure".to_string(),
+        })
+        .collect()
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hunk_classification_mechanical_high_confidence_droppable() {
+        let c = HunkClassification {
+            hunk_index: 0,
+            classification: "mechanical".to_string(),
+            confidence: 0.85,
+            reason: "pure import reorder".to_string(),
+        };
+        assert!(c.should_drop());
+    }
+
+    #[test]
+    fn hunk_classification_mechanical_low_confidence_kept() {
+        let c = HunkClassification {
+            hunk_index: 0,
+            classification: "mechanical".to_string(),
+            confidence: 0.5,
+            reason: "unsure".to_string(),
+        };
+        assert!(!c.should_drop());
+    }
+
+    #[test]
+    fn hunk_classification_substantive_not_dropped() {
+        let c = HunkClassification {
+            hunk_index: 0,
+            classification: "substantive".to_string(),
+            confidence: 0.99,
+            reason: "logic change".to_string(),
+        };
+        assert!(!c.should_drop());
+    }
+
+    #[test]
+    fn hunk_classification_uncertain_not_dropped() {
+        let c = HunkClassification {
+            hunk_index: 0,
+            classification: "uncertain".to_string(),
+            confidence: 0.9,
+            reason: "need context".to_string(),
+        };
+        assert!(!c.should_drop());
+    }
+
+    #[test]
+    fn parse_classification_array_valid() {
+        let json = r#"[
+            {"hunk_id": "0", "classification": "substantive", "confidence": 0.9, "reason": "logic change"},
+            {"hunk_id": "1", "classification": "mechanical", "confidence": 0.8, "reason": "import reorder"}
+        ]"#;
+        let results = parse_classification_array(json, 2, 0).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].classification, "substantive");
+        assert!(!results[0].should_drop());
+        assert_eq!(results[1].classification, "mechanical");
+        assert!(results[1].should_drop());
+    }
+
+    #[test]
+    fn parse_classification_array_strips_markdown_fence() {
+        let json = "```json\n[{\"hunk_id\": \"0\", \"classification\": \"uncertain\", \"confidence\": 0.5, \"reason\": \"x\"}]\n```";
+        let results = parse_classification_array(json, 1, 0).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].classification, "uncertain");
+    }
+
+    #[test]
+    fn parse_classification_array_wrong_count_returns_error() {
+        let json = r#"[{"hunk_id": "0", "classification": "substantive", "confidence": 0.9, "reason": "x"}]"#;
+        let err = parse_classification_array(json, 2, 0).unwrap_err();
+        assert!(err.contains("expected 2"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_classification_array_invalid_json_returns_error() {
+        let err = parse_classification_array("not json", 1, 0).unwrap_err();
+        assert!(err.contains("JSON parse error"));
+    }
+
+    #[test]
+    fn uncertain_batch_has_correct_length() {
+        let hunks: Vec<FilteredHunk> = (0..3)
+            .map(|i| FilteredHunk {
+                header: format!("@@ -{i},1 +{i},1 @@"),
+                lines: vec![format!("+line {i}")],
+                substantive_confidence: 1.0,
+                reason_kept: "test".to_string(),
+            })
+            .collect();
+        let results = uncertain_batch(&hunks, 5);
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].hunk_index, 5);
+        assert_eq!(results[2].hunk_index, 7);
+        for r in &results {
+            assert!(!r.should_drop(), "uncertain results must not be dropped");
+        }
+    }
+
+    /// Live Bedrock test — requires real AWS credentials and is `#[ignore]`d in CI.
+    ///
+    /// Why: verifies the full Stage C round-trip with a real Haiku model call.
+    /// What: constructs a real `BedrockProvider`, classifies two synthetic hunks
+    /// (one import-only, one logic change), asserts mechanical is classified
+    /// mechanical and substantive is not dropped.
+    /// Test: `cargo test -p trusty-review -- stage_c_live_bedrock --include-ignored`
+    #[tokio::test]
+    #[ignore]
+    async fn stage_c_live_bedrock() {
+        use crate::llm::BedrockProvider;
+        let provider = BedrockProvider::new(DEFAULT_CLASSIFIER_MODEL.to_string(), None)
+            .await
+            .expect("BedrockProvider must build");
+        let classifier = HunkClassifier::new(
+            Arc::new(provider),
+            DEFAULT_CLASSIFIER_MODEL,
+            10,
+            DROP_CONFIDENCE_THRESHOLD,
+        );
+        let hunks = vec![
+            FilteredHunk {
+                header: "@@ -1,1 +1,1 @@".to_string(),
+                lines: vec![
+                    "-use std::io;".to_string(),
+                    "+use std::io::{Read, Write};".to_string(),
+                ],
+                substantive_confidence: 1.0,
+                reason_kept: "test".to_string(),
+            },
+            FilteredHunk {
+                header: "@@ -10,3 +10,5 @@".to_string(),
+                lines: vec![
+                    "-fn process(data: &[u8]) -> Result<(), Error> {".to_string(),
+                    "+fn process(data: &[u8], config: &Config) -> Result<(), Error> {".to_string(),
+                    "+    let timeout = config.timeout();".to_string(),
+                    "+    validate_input(data, timeout)?;".to_string(),
+                ],
+                substantive_confidence: 1.0,
+                reason_kept: "test".to_string(),
+            },
+        ];
+        let results = classifier.classify(&hunks).await;
+        assert_eq!(results.len(), 2);
+        // The logic change (second hunk) must NOT be dropped.
+        assert!(
+            !results[1].should_drop(),
+            "substantive hunk must not be dropped: {:?}",
+            results[1]
+        );
+    }
+}

--- a/crates/trusty-review/src/pipeline/diff_analyzer/hunk_filter.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/hunk_filter.rs
@@ -1,0 +1,258 @@
+//! Stage B: hunk-level deterministic noise filter (spec REV-203–204).
+//!
+//! Why: even after Stage A removes noisy files, many surviving hunks contain
+//! only whitespace changes, import reorderings, or comment-only edits that
+//! consume LLM context without contributing actionable review signal.
+//!
+//! What: `HunkFilter::apply` iterates each `KEPT` `FilteredFile`, checks
+//! every hunk against language-specific regex rules, and moves purely-noise
+//! hunks to `dropped_hunks`.  Stage B is purely deterministic — no LLM.
+//!
+//! Test: `whitespace_only_hunk_dropped`, `import_only_hunk_dropped`,
+//! `mixed_hunk_kept`, `comment_only_hunk_dropped`.
+
+use std::collections::HashMap;
+
+use super::file_filter::FilterConfig;
+use super::models::{DroppedHunk, FileDisposition, FilteredFile, HunkDropReason};
+
+// ─── Language detection ───────────────────────────────────────────────────────
+
+fn ext(filename: &str) -> &str {
+    filename.rfind('.').map(|i| &filename[i..]).unwrap_or("")
+}
+
+fn is_python(f: &str) -> bool {
+    matches!(ext(f), ".py" | ".pyi")
+}
+
+fn is_js_ts(f: &str) -> bool {
+    matches!(ext(f), ".js" | ".jsx" | ".ts" | ".tsx" | ".mjs" | ".cjs")
+}
+
+fn is_java(f: &str) -> bool {
+    ext(f) == ".java"
+}
+
+fn is_go(f: &str) -> bool {
+    ext(f) == ".go"
+}
+
+fn is_rust(f: &str) -> bool {
+    ext(f) == ".rs"
+}
+
+fn is_c_like(f: &str) -> bool {
+    matches!(ext(f), ".c" | ".cpp" | ".cc" | ".cxx" | ".h" | ".hpp")
+}
+
+// ─── Import patterns ─────────────────────────────────────────────────────────
+
+/// Return the import-line regex for `filename`, or `None` for unknown languages.
+///
+/// Why: import detection is language-specific; returning `None` means "no
+/// import filtering" rather than a silent miss.
+/// What: returns a compiled `Regex` whose full-line match indicates an import
+/// statement.  A hunk is import-only if ALL changed lines match.
+/// Test: tested via `HunkFilter` import tests.
+fn import_pattern_for(filename: &str) -> Option<regex::Regex> {
+    let pat = if is_python(filename) {
+        // Matches: "import x", "import x, y, z", "from x import y", "from x import (y, z)"
+        r"^(import\s+[\w.,\s]+|from\s+[\w.]+\s+import\s+.+)$"
+    } else if is_js_ts(filename) {
+        r#"^(import\s+.*\s+from\s+['"].+['"]|import\s+['"].+['"]|require\s*\(|export\s+\{.*\}\s+from\s+['"].+['"]);?\s*$"#
+    } else if is_java(filename) {
+        r"^import\s+(static\s+)?[\w.]+(\.\*)?\s*;\s*$"
+    } else if is_go(filename) {
+        r#"^(import\s+("[\w./]+"|\()|"[\w./]+")\s*$"#
+    } else if is_rust(filename) {
+        // Matches: "use std::io;", "use std::io::{Read, Write};", "use x as y;"
+        r"^(use\s+[\w::{},\s*]+(\s+as\s+\w+)?;|extern\s+crate\s+\w+;)\s*$"
+    } else if is_c_like(filename) {
+        r#"^#\s*include\s*[<"].+[>"]"#
+    } else {
+        return None;
+    };
+    regex::Regex::new(pat).ok()
+}
+
+// ─── Comment patterns ─────────────────────────────────────────────────────────
+
+/// Return the comment-line regex for `filename`, or `None`.
+///
+/// Why: comment-only diffs add no logic signal and are safe to omit from the
+/// reviewer context.
+/// What: matches lines that are entirely a comment (no code on the same line).
+/// Test: tested via `HunkFilter` comment tests.
+fn comment_pattern_for(filename: &str) -> Option<regex::Regex> {
+    let pat = if is_python(filename) || is_c_like(filename) {
+        r"^(#.*|/\*.*\*/|//.*)$"
+    } else if is_js_ts(filename) || is_java(filename) || is_go(filename) || is_rust(filename) {
+        r"^(/\*.*\*/|//.*|\s*\*\s?.*)$"
+    } else {
+        return None;
+    };
+    regex::Regex::new(pat).ok()
+}
+
+// ─── Hunk analysis ────────────────────────────────────────────────────────────
+
+/// Extract changed lines (lines starting with `+` or `-`, excluding `+++`/`---`).
+///
+/// Why: context lines must not influence classification — only actually-changed
+/// lines determine whether a hunk is "import-only" or "comment-only".
+/// What: strips the `+`/`-` prefix and trims; skips `+++`/`---` headers.
+/// Test: covered transitively by hunk classification tests.
+fn extract_changed_lines(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .filter(|l| {
+            (l.starts_with('+') || l.starts_with('-'))
+                && !l.starts_with("+++")
+                && !l.starts_with("---")
+        })
+        .map(|l| l[1..].trim().to_string())
+        .collect()
+}
+
+fn is_whitespace_only(lines: &[String]) -> bool {
+    lines.iter().all(|l| l.trim().is_empty())
+}
+
+fn all_match(lines: &[String], re: &regex::Regex) -> bool {
+    !lines.is_empty() && lines.iter().all(|l| re.is_match(l))
+}
+
+// ─── HunkFilter ───────────────────────────────────────────────────────────────
+
+/// Stage B: deterministic hunk-level noise filter (spec REV-203–204).
+///
+/// Why: applies three config-gated rules (whitespace, import, comment) to
+/// each surviving hunk in `KEPT` files; moves noise hunks to `dropped_hunks`
+/// for telemetry; leaves `SUMMARY_ONLY` files untouched.
+/// What: `apply` mutates `FilteredFile.hunks` and `FilteredFile.dropped_hunks`
+/// in place and returns aggregate `HunkDropReason` counts.
+/// Test: `whitespace_only_hunk_dropped`, `import_only_hunk_dropped`,
+/// `mixed_hunk_kept`, `comment_only_hunk_dropped`.
+pub struct HunkFilter {
+    ignore_whitespace: bool,
+    ignore_imports: bool,
+    ignore_comments: bool,
+}
+
+impl HunkFilter {
+    /// Build a `HunkFilter` from the crate's shared `FilterConfig`.
+    ///
+    /// Why: all three gates come from the same config so the caller only needs
+    /// one config object (spec REV-262 "no global state").
+    /// What: copies the three `ignore_*` booleans.
+    /// Test: `hunk_filter_gates_respect_config`.
+    pub fn new(config: &FilterConfig) -> Self {
+        Self {
+            ignore_whitespace: config.ignore_whitespace,
+            ignore_imports: config.ignore_imports,
+            ignore_comments: config.ignore_comments,
+        }
+    }
+
+    /// Apply Stage B to all `KEPT` files; return aggregate drop counts.
+    ///
+    /// Why: the `DiffAnalyzer` needs to merge Stage B counts into the
+    /// `FilteredDiff.drop_hunk_counts` map.
+    /// What: calls `filter_file` for each `KEPT` file; accumulates counts.
+    /// Test: `apply_returns_aggregate_counts`.
+    pub fn apply(&self, files: &mut [FilteredFile]) -> HashMap<HunkDropReason, u32> {
+        let mut totals: HashMap<HunkDropReason, u32> = HashMap::new();
+        for file in files.iter_mut() {
+            if file.disposition != FileDisposition::Kept {
+                continue;
+            }
+            let counts = self.filter_file(file);
+            for (reason, n) in counts {
+                *totals.entry(reason).or_insert(0) += n;
+            }
+        }
+        totals
+    }
+
+    /// Apply Stage B to a single file; returns per-reason drop counts.
+    ///
+    /// Why: isolated for per-file unit testing without constructing a Vec.
+    /// What: checks each hunk via `classify_hunk`; surviving hunks replace
+    /// `file.hunks`; dropped hunks go to `file.dropped_hunks`.
+    /// Test: used in all per-language hunk tests.
+    pub fn filter_file(&self, file: &mut FilteredFile) -> HashMap<HunkDropReason, u32> {
+        let import_rx = import_pattern_for(&file.filename);
+        let comment_rx = comment_pattern_for(&file.filename);
+
+        let mut surviving = Vec::new();
+        let mut counts: HashMap<HunkDropReason, u32> = HashMap::new();
+
+        let hunks = std::mem::take(&mut file.hunks);
+        for hunk in hunks {
+            match self.classify_hunk(&hunk.lines, &import_rx, &comment_rx) {
+                Some(reason) => {
+                    *counts.entry(reason.clone()).or_insert(0) += 1;
+                    file.dropped_hunks.push(DroppedHunk {
+                        reason,
+                        lines_count: hunk.lines.len(),
+                        header: hunk.header.clone(),
+                    });
+                }
+                None => surviving.push(hunk),
+            }
+        }
+        file.hunks = surviving;
+        counts
+    }
+
+    /// Classify a single hunk's lines; returns the drop reason or `None` to keep.
+    ///
+    /// Why: isolated for direct unit testing of classification edge cases.
+    /// What: extracts changed lines; applies whitespace/import/comment checks
+    /// in priority order.  Returns the first matching drop reason or `None`.
+    /// Test: `classify_whitespace_hunk`, `classify_import_hunk`.
+    pub fn classify_hunk(
+        &self,
+        lines: &[String],
+        import_rx: &Option<regex::Regex>,
+        comment_rx: &Option<regex::Regex>,
+    ) -> Option<HunkDropReason> {
+        let changed = extract_changed_lines(lines);
+
+        if changed.is_empty() {
+            // Context-only hunk: keep if there is any non-empty content.
+            let has_content = lines.iter().any(|l| !l.trim().is_empty());
+            return if has_content {
+                None
+            } else {
+                if self.ignore_whitespace {
+                    Some(HunkDropReason::WhitespaceOnly)
+                } else {
+                    None
+                }
+            };
+        }
+
+        if self.ignore_whitespace && is_whitespace_only(&changed) {
+            return Some(HunkDropReason::WhitespaceOnly);
+        }
+        if self.ignore_imports && import_rx.as_ref().is_some_and(|re| all_match(&changed, re)) {
+            return Some(HunkDropReason::ImportOnly);
+        }
+        if self.ignore_comments
+            && comment_rx
+                .as_ref()
+                .is_some_and(|re| all_match(&changed, re))
+        {
+            return Some(HunkDropReason::CommentOnly);
+        }
+        None
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "hunk_filter_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/diff_analyzer/hunk_filter_tests.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/hunk_filter_tests.rs
@@ -1,0 +1,189 @@
+//! Unit tests for Stage B HunkFilter (spec REV-203–204).
+
+use super::HunkFilter;
+use crate::pipeline::diff_analyzer::{
+    file_filter::FilterConfig,
+    models::{FileDisposition, FilteredFile, FilteredHunk, HunkDropReason},
+};
+
+fn default_filter() -> HunkFilter {
+    HunkFilter::new(&FilterConfig::default())
+}
+
+fn make_file(name: &str, hunk_lines: Vec<Vec<String>>) -> FilteredFile {
+    FilteredFile {
+        filename: name.to_string(),
+        status: "modified".to_string(),
+        disposition: FileDisposition::Kept,
+        hunks: hunk_lines
+            .into_iter()
+            .enumerate()
+            .map(|(i, lines)| FilteredHunk {
+                header: format!("@@ -{i},1 +{i},1 @@"),
+                lines,
+                substantive_confidence: 1.0,
+                reason_kept: "stage-a-pass".to_string(),
+            })
+            .collect(),
+        dropped_hunks: vec![],
+        summary_line: None,
+    }
+}
+
+fn lines(raw: &[&str]) -> Vec<String> {
+    raw.iter().map(|s| s.to_string()).collect()
+}
+
+// ─── Whitespace-only ─────────────────────────────────────────────────────────
+
+#[test]
+fn whitespace_only_hunk_dropped() {
+    let f = &mut make_file("src/a.rs", vec![lines(&["-   ", "+  "])]);
+    let filter = default_filter();
+    let counts = filter.filter_file(f);
+    assert!(f.hunks.is_empty(), "whitespace hunk must be dropped");
+    assert_eq!(f.dropped_hunks.len(), 1);
+    assert_eq!(f.dropped_hunks[0].reason, HunkDropReason::WhitespaceOnly);
+    assert_eq!(*counts.get(&HunkDropReason::WhitespaceOnly).unwrap(), 1);
+}
+
+#[test]
+fn whitespace_gate_disabled_keeps_hunk() {
+    let config = FilterConfig {
+        ignore_whitespace: false,
+        ..Default::default()
+    };
+    let filter = HunkFilter::new(&config);
+    let f = &mut make_file("src/a.rs", vec![lines(&["-   ", "+  "])]);
+    filter.filter_file(f);
+    assert_eq!(
+        f.hunks.len(),
+        1,
+        "whitespace hunk must be kept when gate disabled"
+    );
+    assert!(f.dropped_hunks.is_empty());
+}
+
+// ─── Import-only ──────────────────────────────────────────────────────────────
+
+#[test]
+fn rust_import_only_hunk_dropped() {
+    let f = &mut make_file(
+        "src/lib.rs",
+        vec![lines(&["-use std::io;", "+use std::io::{Read, Write};"])],
+    );
+    let filter = default_filter();
+    filter.filter_file(f);
+    assert!(f.hunks.is_empty(), "import-only Rust hunk must be dropped");
+    assert_eq!(f.dropped_hunks[0].reason, HunkDropReason::ImportOnly);
+}
+
+#[test]
+fn python_import_only_hunk_dropped() {
+    let f = &mut make_file(
+        "service.py",
+        vec![lines(&["-import os", "+import os, sys"])],
+    );
+    let filter = default_filter();
+    filter.filter_file(f);
+    assert!(
+        f.hunks.is_empty(),
+        "import-only Python hunk must be dropped"
+    );
+    assert_eq!(f.dropped_hunks[0].reason, HunkDropReason::ImportOnly);
+}
+
+#[test]
+fn java_import_only_hunk_dropped() {
+    let f = &mut make_file(
+        "Foo.java",
+        vec![lines(&[
+            "-import java.util.List;",
+            "+import java.util.List;",
+            "+import java.util.Map;",
+        ])],
+    );
+    let filter = default_filter();
+    filter.filter_file(f);
+    assert!(f.hunks.is_empty(), "import-only Java hunk must be dropped");
+    assert_eq!(f.dropped_hunks[0].reason, HunkDropReason::ImportOnly);
+}
+
+#[test]
+fn ts_import_only_hunk_dropped() {
+    let f = &mut make_file(
+        "index.ts",
+        vec![lines(&[
+            r#"-import { foo } from './foo';"#,
+            r#"+import { foo, bar } from './foo';"#,
+        ])],
+    );
+    let filter = default_filter();
+    filter.filter_file(f);
+    assert!(f.hunks.is_empty(), "import-only TS hunk must be dropped");
+    assert_eq!(f.dropped_hunks[0].reason, HunkDropReason::ImportOnly);
+}
+
+#[test]
+fn mixed_hunk_kept() {
+    // Import line + logic line → must NOT be dropped (spec REV-203).
+    let f = &mut make_file(
+        "src/lib.rs",
+        vec![lines(&["+use std::io;", "+fn process() {}"])],
+    );
+    let filter = default_filter();
+    filter.filter_file(f);
+    assert_eq!(f.hunks.len(), 1, "mixed hunk must be kept");
+    assert!(f.dropped_hunks.is_empty());
+}
+
+// ─── Comment-only ─────────────────────────────────────────────────────────────
+
+#[test]
+fn comment_only_hunk_dropped() {
+    let f = &mut make_file(
+        "src/lib.rs",
+        vec![lines(&["-// old comment", "+// new comment"])],
+    );
+    let filter = default_filter();
+    filter.filter_file(f);
+    assert!(f.hunks.is_empty(), "comment-only hunk must be dropped");
+    assert_eq!(f.dropped_hunks[0].reason, HunkDropReason::CommentOnly);
+}
+
+// ─── Aggregate counts ─────────────────────────────────────────────────────────
+
+#[test]
+fn apply_returns_aggregate_counts() {
+    let filter = default_filter();
+    let mut files = vec![
+        make_file("src/a.rs", vec![lines(&["-use foo;", "+use bar;"])]),
+        make_file("src/b.rs", vec![lines(&["-  ", "+   "])]),
+    ];
+    let counts = filter.apply(&mut files);
+    assert_eq!(*counts.get(&HunkDropReason::ImportOnly).unwrap_or(&0), 1);
+    assert_eq!(
+        *counts.get(&HunkDropReason::WhitespaceOnly).unwrap_or(&0),
+        1
+    );
+}
+
+// ─── Summary-only files skipped ───────────────────────────────────────────────
+
+#[test]
+fn summary_only_files_skipped_by_stage_b() {
+    let filter = default_filter();
+    let mut files = vec![FilteredFile {
+        filename: "tests/fixtures/data.tsv".to_string(),
+        status: "modified".to_string(),
+        disposition: FileDisposition::SummaryOnly,
+        hunks: vec![],
+        dropped_hunks: vec![],
+        summary_line: Some("[fixture: 50 lines omitted]".to_string()),
+    }];
+    let counts = filter.apply(&mut files);
+    assert!(
+        counts.is_empty(),
+        "SummaryOnly files must be skipped by Stage B"
+    );
+}

--- a/crates/trusty-review/src/pipeline/diff_analyzer/mod.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/mod.rs
@@ -1,0 +1,310 @@
+//! DiffAnalyzer — three-stage diff noise filter (spec REV-200–262).
+//!
+//! Why: PR diffs frequently contain lockfiles, snapshots, whitespace-only hunks,
+//! import reorderings, and comment-only changes that consume LLM context budget
+//! without contributing review signal.  The DiffAnalyzer strips these before the
+//! reviewer LLM sees the diff, maximising the fraction of the context window that
+//! carries real signal (lesson §12.12 — the PR #9545 fixture-churn problem).
+//!
+//! What: implements the three-stage pipeline from spec REV-200:
+//!  - Stage A (`file_filter`) — deterministic file-level classification.
+//!  - Stage B (`hunk_filter`) — deterministic hunk-level classification.
+//!  - Stage C (`hunk_classifier`) — optional Haiku LLM hunk classification.
+//!
+//! Standalone usage (spec REV-260): the module is usable without the review
+//! pipeline.  Stages A+B are always deterministic (no LLM needed).  Stage C
+//! requires an injected `LlmProvider` and is disabled by default
+//! (`FilterConfig::disable_classifier = true`).
+//!
+//! Test: `diff_analyzer_stages_a_b_integration`, `diff_analyzer_drops_lockfile`.
+
+pub mod file_filter;
+pub mod hunk_classifier;
+pub mod hunk_filter;
+pub mod models;
+
+pub use file_filter::{FileFilter, FilterConfig};
+pub use hunk_classifier::HunkClassifier;
+pub use hunk_filter::HunkFilter;
+pub use models::{DroppedFile, FilteredDiff, FilteredFile, FilteredHunk};
+
+use std::sync::Arc;
+
+use tracing::{debug, info};
+
+use crate::llm::LlmProvider;
+
+/// Top-level DiffAnalyzer — orchestrates Stages A, B, and optionally C.
+///
+/// Why: single entry point so the pipeline has a minimal, stable integration
+/// surface (spec REV-260).  The orchestrator computes byte-size telemetry and
+/// logs filter results without requiring the caller to know Stage internals.
+/// What: `analyze` accepts a raw unified diff string plus an optional file-status
+/// map, runs the three stages, and returns a `FilteredDiff`.
+/// Test: `diff_analyzer_stages_a_b_integration`, `diff_analyzer_drops_lockfile`.
+pub struct DiffAnalyzer {
+    config: FilterConfig,
+    classifier_provider: Option<Arc<dyn LlmProvider>>,
+}
+
+impl Default for DiffAnalyzer {
+    /// Default DiffAnalyzer: default FilterConfig, no Stage C provider.
+    ///
+    /// Why: most callers want Stages A+B only (deterministic, no LLM required).
+    /// What: equivalent to `DiffAnalyzer::new(FilterConfig::default(), None)`.
+    /// Test: used in pipeline integration tests and runner.rs.
+    fn default() -> Self {
+        Self::new(FilterConfig::default(), None)
+    }
+}
+
+impl DiffAnalyzer {
+    /// Build a `DiffAnalyzer` with the given config and optional Stage C provider.
+    ///
+    /// Why: provider is injected for testability (spec REV-261); passing `None`
+    /// runs Stages A+B only (fully deterministic, no LLM).
+    /// What: stores config and provider; no I/O at construction.
+    /// Test: `diff_analyzer_stages_a_b_integration`.
+    pub fn new(config: FilterConfig, classifier_provider: Option<Arc<dyn LlmProvider>>) -> Self {
+        Self {
+            config,
+            classifier_provider,
+        }
+    }
+
+    /// Analyze a unified diff string; return a `FilteredDiff`.
+    ///
+    /// Why: wraps parse → Stage A → Stage B → Stage C → telemetry in one call
+    /// so the pipeline just calls `analyze(&raw_diff).render_for_prompt(cap)`.
+    /// What: parses the raw diff into `(path, status, patch)` triples, runs
+    /// `FileFilter.apply`, then `HunkFilter.apply`, then (if enabled and a
+    /// provider is available) `HunkClassifier.classify`.  Computes byte-size
+    /// telemetry.  Returns a `FilteredDiff` ready for `render_for_prompt`.
+    /// Test: `diff_analyzer_stages_a_b_integration`, `diff_analyzer_drops_lockfile`.
+    pub async fn analyze(&self, raw_diff: &str) -> FilteredDiff {
+        let original_byte_size = raw_diff.len();
+
+        // Parse the raw diff into (path, status, patch) triples.
+        let parsed = parse_diff_files(raw_diff);
+        debug!(file_count = parsed.len(), "parsed diff into files");
+
+        // Stage A: file-level filter.
+        let file_filter = FileFilter::new(self.config.clone());
+        let (mut kept_files, dropped_files) = file_filter.apply(&parsed);
+        info!(
+            kept = kept_files.len(),
+            dropped = dropped_files.len(),
+            "Stage A complete"
+        );
+
+        // Stage B: hunk-level filter.
+        let hunk_filter = HunkFilter::new(&self.config);
+        let mut drop_hunk_counts = hunk_filter.apply(&mut kept_files);
+        let stage_b_total: u32 = drop_hunk_counts.values().sum();
+        info!(dropped_hunks = stage_b_total, "Stage B complete");
+
+        // Stage C: LLM classifier (optional — disabled by default).
+        if !self.config.disable_classifier
+            && let Some(ref provider) = self.classifier_provider
+        {
+            use crate::pipeline::diff_analyzer::hunk_classifier::{
+                DEFAULT_CLASSIFIER_MODEL, DROP_CONFIDENCE_THRESHOLD, HunkClassifier,
+            };
+            use models::{DroppedHunk, HunkDropReason};
+
+            let classifier = HunkClassifier::new(
+                Arc::clone(provider),
+                DEFAULT_CLASSIFIER_MODEL,
+                self.config.classifier_batch_size,
+                DROP_CONFIDENCE_THRESHOLD,
+            );
+            for file in kept_files.iter_mut() {
+                if file.disposition != models::FileDisposition::Kept {
+                    continue;
+                }
+                let classifications = classifier.classify(&file.hunks).await;
+                let mut surviving = Vec::new();
+                for (hunk, cls) in file.hunks.drain(..).zip(classifications.iter()) {
+                    if cls.should_drop() {
+                        *drop_hunk_counts
+                            .entry(HunkDropReason::MechanicalHaiku)
+                            .or_insert(0) += 1;
+                        file.dropped_hunks.push(DroppedHunk {
+                            reason: cls.drop_reason(),
+                            lines_count: hunk.lines.len(),
+                            header: hunk.header.clone(),
+                        });
+                    } else {
+                        surviving.push(hunk);
+                    }
+                }
+                file.hunks = surviving;
+            }
+            let stage_c_total: u32 = drop_hunk_counts
+                .get(&models::HunkDropReason::MechanicalHaiku)
+                .copied()
+                .unwrap_or(0);
+            info!(dropped_hunks = stage_c_total, "Stage C complete");
+        }
+
+        // Compute filtered byte size (approximate; based on rendered content).
+        let filtered_byte_size = kept_files
+            .iter()
+            .flat_map(|f| f.hunks.iter().flat_map(|h| h.lines.iter().map(|l| l.len())))
+            .sum::<usize>();
+
+        FilteredDiff {
+            files: kept_files,
+            dropped_files,
+            drop_hunk_counts,
+            original_byte_size,
+            filtered_byte_size,
+        }
+    }
+}
+
+// ─── Diff parser ──────────────────────────────────────────────────────────────
+
+/// Parse a unified diff string into `(path, status, patch)` triples.
+///
+/// Why: Stage A needs per-file structured data; the raw diff is a flat string.
+/// What: scans for `diff --git` lines to split files; reads `+++`/`---` headers
+/// for paths; treats the remainder as the patch string.
+/// Test: `parse_diff_files_basic`, `parse_diff_files_new_file`.
+pub fn parse_diff_files(diff: &str) -> Vec<(String, String, String)> {
+    let mut files = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_status = "modified".to_string();
+    let mut current_patch = String::new();
+
+    for line in diff.lines() {
+        if line.starts_with("diff --git ") {
+            // Flush previous file.
+            if let Some(path) = current_path.take() {
+                files.push((path, current_status.clone(), current_patch.clone()));
+                current_patch.clear();
+            }
+            current_status = "modified".to_string();
+        } else if let Some(rest) = line.strip_prefix("+++ b/") {
+            let path = rest.trim().to_string();
+            if path != "/dev/null" && !path.is_empty() {
+                current_path = Some(path);
+            }
+        } else if line.starts_with("+++ /dev/null") {
+            // Deleted file — path already captured from --- line; status = removed.
+            current_status = "removed".to_string();
+        } else if line.starts_with("--- /dev/null") || line.starts_with("new file mode") {
+            current_status = "added".to_string();
+        } else if line.starts_with("deleted file mode") {
+            current_status = "removed".to_string();
+        } else if line.starts_with("rename to ") {
+            current_status = "renamed".to_string();
+        } else if current_path.is_some() {
+            current_patch.push_str(line);
+            current_patch.push('\n');
+        }
+    }
+    // Flush last file.
+    if let Some(path) = current_path {
+        files.push((path, current_status, current_patch));
+    }
+    files
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_DIFF: &str = r#"diff --git a/Cargo.lock b/Cargo.lock
+index abc..def 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1,3 +1,3 @@
+-serde = "1.0.100"
++serde = "1.0.200"
+diff --git a/src/auth.rs b/src/auth.rs
+index abc..def 100644
+--- a/src/auth.rs
++++ b/src/auth.rs
+@@ -1,3 +1,5 @@
+-pub fn authenticate(user: &str) -> Result<Token, Error> {
++pub fn authenticate(user: &str, config: &Config) -> Result<Token, Error> {
++    validate(user)?;
+     Ok(Token::new(user))
+ }
+"#;
+
+    #[tokio::test]
+    async fn diff_analyzer_drops_lockfile() {
+        let analyzer = DiffAnalyzer::default();
+        let result = analyzer.analyze(SAMPLE_DIFF).await;
+        assert_eq!(result.dropped_files.len(), 1);
+        assert_eq!(result.dropped_files[0].path, "Cargo.lock");
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.files[0].filename, "src/auth.rs");
+    }
+
+    #[tokio::test]
+    async fn diff_analyzer_stages_a_b_integration() {
+        // A diff where one file is a lockfile (dropped) and another has an
+        // import-only hunk alongside a logic hunk.
+        let diff = "\
+diff --git a/package-lock.json b/package-lock.json\n\
+--- a/package-lock.json\n\
++++ b/package-lock.json\n\
+@@ -1,1 +1,1 @@\n\
+-\"version\": \"1\"\n\
++\"version\": \"2\"\n\
+diff --git a/src/api.rs b/src/api.rs\n\
+--- a/src/api.rs\n\
++++ b/src/api.rs\n\
+@@ -1,1 +1,1 @@\n\
+-use std::io;\n\
++use std::io::{Read, Write};\n\
+@@ -10,3 +10,4 @@\n\
+-pub fn handle(req: Request) -> Response {\n\
++pub fn handle(req: Request, cfg: &Config) -> Response {\n\
++    cfg.validate()?;\n\
+     Ok(Response::ok())\n\
+ }\n\
+";
+        let analyzer = DiffAnalyzer::default();
+        let result = analyzer.analyze(diff).await;
+
+        assert_eq!(result.dropped_files.len(), 1, "lockfile must be dropped");
+        assert_eq!(result.files.len(), 1, "only src/api.rs should survive");
+
+        let api_file = &result.files[0];
+        // Stage B should have dropped the import-only hunk.
+        assert!(
+            !api_file.dropped_hunks.is_empty() || api_file.hunks.len() < 2,
+            "import-only hunk should be dropped by Stage B"
+        );
+
+        let rendered = result.render_for_prompt(100_000);
+        assert!(
+            rendered.contains("handle"),
+            "logic hunk must appear in rendered diff"
+        );
+    }
+
+    #[test]
+    fn parse_diff_files_basic() {
+        let files = parse_diff_files(SAMPLE_DIFF);
+        assert_eq!(files.len(), 2);
+        let paths: Vec<&str> = files.iter().map(|(p, _, _)| p.as_str()).collect();
+        assert!(paths.contains(&"Cargo.lock"));
+        assert!(paths.contains(&"src/auth.rs"));
+    }
+
+    #[test]
+    fn parse_diff_files_new_file() {
+        let diff = "diff --git a/new.rs b/new.rs\nnew file mode 100644\n--- /dev/null\n+++ b/new.rs\n@@ -0,0 +1 @@\n+fn new() {}\n";
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "new.rs");
+        assert_eq!(files[0].1, "added");
+    }
+}

--- a/crates/trusty-review/src/pipeline/diff_analyzer/models.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/models.rs
@@ -1,0 +1,432 @@
+//! Data models for the DiffAnalyzer pipeline (spec REV-200–262, §4).
+//!
+//! Why: typed output lets each stage produce structured metadata rather than
+//! opaque strings, enabling per-hunk telemetry, stage isolation in tests,
+//! and a clean audit trail of what was dropped and why (lesson §12.12).
+//! What: `FilteredDiff` is the top-level result; `render_for_prompt` produces
+//! the noise-filtered diff text bounded to `max_chars`.  The manifest is
+//! telemetry-only — never injected into the LLM prompt (spec REV-209).
+//! Test: `filtered_diff_render_for_prompt_contains_surviving_content`,
+//! `filtered_diff_render_respects_max_chars`,
+//! `filtered_diff_drop_summary_emitted`.
+
+use std::collections::HashMap;
+
+// ─── Disposition / drop reason enums ─────────────────────────────────────────
+
+/// Stage A file-level filtering outcome (spec REV-201).
+///
+/// Why: structured enum prevents the "KEPT vs kept" string mismatch bugs that
+/// plagued the Python predecessor's early iterations.
+/// What: three variants covering the three Stage A outcomes.
+/// Test: used directly in `FileFilter` and `DiffAnalyzer` tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileDisposition {
+    /// File survives in full; hunks are passed to Stage B.
+    Kept,
+    /// File is a noise class (lockfile, snapshot, generated); excluded entirely.
+    Dropped,
+    /// File is a fixture/i18n artefact; content collapsed to one summary line.
+    SummaryOnly,
+}
+
+/// Reason a hunk was dropped in Stage B or Stage C (spec REV-203, REV-206).
+///
+/// Why: explicit reason enum enables per-reason telemetry counters and lets the
+/// noise-summary line tell the reviewer exactly what was filtered.
+/// What: four variants — three deterministic (Stage B) and one LLM (Stage C).
+/// Test: used in `HunkFilter` and `HunkClassifier` tests.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum HunkDropReason {
+    /// Hunk only changes whitespace (spaces/tabs/blank lines).
+    WhitespaceOnly,
+    /// Hunk only changes import/use statements.
+    ImportOnly,
+    /// Hunk only changes comments.
+    CommentOnly,
+    /// Stage C Haiku classifier marked this hunk `mechanical` with high confidence.
+    MechanicalHaiku,
+}
+
+impl HunkDropReason {
+    /// Human-readable label used in the noise summary injected into the prompt.
+    ///
+    /// Why: the summary must be legible to humans and the LLM; snake_case keys
+    /// are not user-friendly.
+    /// What: returns a static English phrase for each variant.
+    /// Test: `hunk_drop_reason_label`.
+    pub fn label(&self) -> &'static str {
+        match self {
+            HunkDropReason::WhitespaceOnly => "whitespace-only",
+            HunkDropReason::ImportOnly => "import-only",
+            HunkDropReason::CommentOnly => "comment-only",
+            HunkDropReason::MechanicalHaiku => "mechanical (Haiku)",
+        }
+    }
+}
+
+// ─── Hunk types ───────────────────────────────────────────────────────────────
+
+/// A single hunk that survived Stage B / Stage C filtering (spec §4).
+///
+/// Why: retains header and lines so `render_for_prompt` can reconstruct a valid
+/// unified diff section verbatim.
+/// What: `header` is the `@@` line; `lines` are the raw diff lines (including
+/// `+`, `-`, and context lines); `substantive_confidence` is 1.0 for
+/// deterministic survivors and the Haiku score for Stage C survivors.
+/// Test: used in `HunkFilter` and integration tests.
+#[derive(Debug, Clone)]
+pub struct FilteredHunk {
+    /// The `@@ -a,b +c,d @@ context` header line.
+    pub header: String,
+    /// Raw diff lines (context, `+`, `-`).
+    pub lines: Vec<String>,
+    /// Haiku-assigned substantive confidence (default 1.0 for det. survivors).
+    pub substantive_confidence: f32,
+    /// Human-readable reason this hunk was kept.
+    pub reason_kept: String,
+}
+
+impl FilteredHunk {
+    /// Reconstruct this hunk as a unified diff string segment.
+    ///
+    /// Why: `render_for_prompt` needs to reconstruct the diff body from
+    /// individual hunks without re-parsing the original text.
+    /// What: joins header and lines with `\n`.
+    /// Test: `filtered_hunk_render_roundtrip`.
+    pub fn render(&self) -> String {
+        let mut out = self.header.clone();
+        for line in &self.lines {
+            out.push('\n');
+            out.push_str(line);
+        }
+        out
+    }
+}
+
+/// A hunk that was dropped in Stage B or Stage C (spec §4).
+///
+/// Why: preserves drop metadata for the noise-summary and telemetry manifest.
+/// What: `reason` is the `HunkDropReason`; `lines_count` is the raw diff-line
+/// count of the dropped hunk; `header` is the `@@` line for reference.
+/// Test: used in `HunkFilter` tests.
+#[derive(Debug, Clone)]
+pub struct DroppedHunk {
+    /// Why this hunk was dropped.
+    pub reason: HunkDropReason,
+    /// Number of diff lines in the dropped hunk (for telemetry).
+    pub lines_count: usize,
+    /// The `@@` header line of the dropped hunk.
+    pub header: String,
+}
+
+// ─── File types ───────────────────────────────────────────────────────────────
+
+/// A file that survived Stage A, with its Stage B-filtered hunk list (spec §4).
+///
+/// Why: per-file structure lets the pipeline track per-file drop counts and
+/// re-render individual files for the prompt without rebuilding from the raw diff.
+/// What: `disposition` is always `Kept` or `SummaryOnly` for files in this list
+/// (`Dropped` files go to `DroppedFile`); `summary_line` is set for `SummaryOnly`
+/// files; `hunks` contains the surviving Stage B hunks.
+/// Test: used in `FileFilter`, `HunkFilter`, and integration tests.
+#[derive(Debug, Clone)]
+pub struct FilteredFile {
+    /// File path (from the `+++ b/` header).
+    pub filename: String,
+    /// Git status: `"added"`, `"modified"`, `"renamed"`, `"removed"`.
+    pub status: String,
+    /// Stage A outcome (`Kept` or `SummaryOnly`; never `Dropped` here).
+    pub disposition: FileDisposition,
+    /// Stage B survivors. Empty for `SummaryOnly` files.
+    pub hunks: Vec<FilteredHunk>,
+    /// Stage B drops (retained for telemetry only; not rendered).
+    pub dropped_hunks: Vec<DroppedHunk>,
+    /// One-line summary for `SummaryOnly` files.
+    pub summary_line: Option<String>,
+}
+
+/// A file that was dropped entirely in Stage A (spec §4).
+///
+/// Why: retained separately from `FilteredFile` so the noise summary can say
+/// "N files dropped: lockfiles, snapshots, …" without scanning all files.
+/// What: `path` is the file name; `reason` is a human label for the drop rule
+/// that fired.
+/// Test: used in `FileFilter` tests.
+#[derive(Debug, Clone)]
+pub struct DroppedFile {
+    /// File path.
+    pub path: String,
+    /// Human-readable drop reason (e.g. `"lockfile"`, `"snapshot"`).
+    pub reason: String,
+}
+
+// ─── FilteredDiff — top-level result ─────────────────────────────────────────
+
+/// Top-level result from `DiffAnalyzer::analyze` (spec REV-200, §4).
+///
+/// Why: encapsulates the full analysis result — surviving files/hunks plus all
+/// telemetry — so the pipeline can call `render_for_prompt` without knowing the
+/// internals of the filter stages.
+/// What: `files` are the surviving files (with their filtered hunks);
+/// `dropped_files` are Stage A exclusions; `drop_hunk_counts` aggregates Stage B
+/// drops by reason; `render_for_prompt` produces the bounded diff text.
+/// Test: `filtered_diff_render_for_prompt_contains_surviving_content`,
+/// `filtered_diff_render_respects_max_chars`.
+#[derive(Debug, Clone)]
+pub struct FilteredDiff {
+    /// Files that survived Stage A (disposition Kept or SummaryOnly).
+    pub files: Vec<FilteredFile>,
+    /// Files dropped entirely in Stage A.
+    pub dropped_files: Vec<DroppedFile>,
+    /// Aggregate hunk-drop counts by reason (Stage B + Stage C).
+    pub drop_hunk_counts: HashMap<HunkDropReason, u32>,
+    /// Character length of the raw diff before filtering.
+    pub original_byte_size: usize,
+    /// Character length of the filtered diff text (after render).
+    pub filtered_byte_size: usize,
+}
+
+impl FilteredDiff {
+    /// Render the filtered diff as a bounded string for the LLM prompt.
+    ///
+    /// Why: the prompt builder needs a diff string bounded to `max_chars`; this
+    /// method encapsulates the rendering logic so the pipeline has one call site.
+    /// What: iterates `files`, renders each surviving hunk, appends the noise
+    /// summary, and stops before exceeding `max_chars`.  Does NOT inject a
+    /// manifest header (spec REV-209 — framing-regression guard).
+    /// Test: `filtered_diff_render_for_prompt_contains_surviving_content`,
+    /// `filtered_diff_render_respects_max_chars`.
+    pub fn render_for_prompt(&self, max_chars: usize) -> String {
+        let mut out = String::with_capacity(max_chars.min(64 * 1024));
+        let suffix = self.build_noise_summary();
+
+        for file in &self.files {
+            match file.disposition {
+                FileDisposition::SummaryOnly => {
+                    if let Some(ref summary) = file.summary_line {
+                        let line = format!("# {}: {}\n", file.filename, summary);
+                        if out.len() + line.len() + suffix.len() > max_chars {
+                            break;
+                        }
+                        out.push_str(&line);
+                    }
+                }
+                FileDisposition::Kept => {
+                    // Build the file header.
+                    let file_header = format!("--- a/{0}\n+++ b/{0}\n", file.filename);
+                    if out.len() + file_header.len() + suffix.len() > max_chars {
+                        break;
+                    }
+                    out.push_str(&file_header);
+
+                    for hunk in &file.hunks {
+                        let rendered = hunk.render();
+                        if out.len() + rendered.len() + suffix.len() + 1 > max_chars {
+                            break;
+                        }
+                        out.push_str(&rendered);
+                        out.push('\n');
+                    }
+                }
+                FileDisposition::Dropped => {
+                    // Dropped files are never rendered in the prompt.
+                }
+            }
+        }
+
+        if !suffix.is_empty() {
+            out.push_str(&suffix);
+        }
+
+        out
+    }
+
+    /// Build the noise-summary line appended to the prompt (spec REV-209).
+    ///
+    /// Why: the reviewer model must know that filtering happened so it does not
+    /// assume it is seeing the complete diff (spec REV-209).
+    /// What: produces a one-line summary of what was omitted, or an empty string
+    /// if nothing was dropped.  Never exceeds one paragraph.
+    /// Test: `filtered_diff_drop_summary_emitted`.
+    pub fn build_noise_summary(&self) -> String {
+        let dropped_files = self.dropped_files.len();
+        let dropped_hunks: u32 = self.drop_hunk_counts.values().sum();
+
+        if dropped_files == 0 && dropped_hunks == 0 {
+            return String::new();
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+        if dropped_files > 0 {
+            // Collect up to 3 unique drop reasons for the file summary.
+            let mut reasons: Vec<String> = self
+                .dropped_files
+                .iter()
+                .map(|f| f.reason.clone())
+                .collect::<std::collections::HashSet<_>>()
+                .into_iter()
+                .take(3)
+                .collect();
+            reasons.sort();
+            let reason_str = if reasons.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", reasons.join(", "))
+            };
+            parts.push(format!("{dropped_files} file(s) omitted{reason_str}"));
+        }
+        if dropped_hunks > 0 {
+            let mut labels: Vec<&str> = self
+                .drop_hunk_counts
+                .keys()
+                .map(|r| r.label())
+                .collect::<std::collections::HashSet<_>>()
+                .into_iter()
+                .collect();
+            labels.sort();
+            let label_str = if labels.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", labels.join(", "))
+            };
+            parts.push(format!("{dropped_hunks} hunk(s) omitted{label_str}"));
+        }
+
+        format!(
+            "\n[DiffAnalyzer filtered {} — noise removed before review]\n",
+            parts.join("; ")
+        )
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_kept_file(name: &str, hunk_content: &str) -> FilteredFile {
+        FilteredFile {
+            filename: name.to_string(),
+            status: "modified".to_string(),
+            disposition: FileDisposition::Kept,
+            hunks: vec![FilteredHunk {
+                header: "@@ -1,3 +1,3 @@".to_string(),
+                lines: vec![hunk_content.to_string()],
+                substantive_confidence: 1.0,
+                reason_kept: "deterministic-pass".to_string(),
+            }],
+            dropped_hunks: vec![],
+            summary_line: None,
+        }
+    }
+
+    #[test]
+    fn filtered_hunk_render_roundtrip() {
+        let h = FilteredHunk {
+            header: "@@ -1,2 +1,2 @@".to_string(),
+            lines: vec!["-old line".to_string(), "+new line".to_string()],
+            substantive_confidence: 1.0,
+            reason_kept: "test".to_string(),
+        };
+        let rendered = h.render();
+        assert!(rendered.contains("@@ -1,2 +1,2 @@"));
+        assert!(rendered.contains("-old line"));
+        assert!(rendered.contains("+new line"));
+    }
+
+    #[test]
+    fn hunk_drop_reason_label() {
+        assert_eq!(HunkDropReason::WhitespaceOnly.label(), "whitespace-only");
+        assert_eq!(HunkDropReason::ImportOnly.label(), "import-only");
+        assert_eq!(HunkDropReason::CommentOnly.label(), "comment-only");
+        assert_eq!(
+            HunkDropReason::MechanicalHaiku.label(),
+            "mechanical (Haiku)"
+        );
+    }
+
+    #[test]
+    fn filtered_diff_render_for_prompt_contains_surviving_content() {
+        let diff = FilteredDiff {
+            files: vec![make_kept_file("src/auth.rs", "+pub fn authenticate() {}")],
+            dropped_files: vec![],
+            drop_hunk_counts: HashMap::new(),
+            original_byte_size: 500,
+            filtered_byte_size: 100,
+        };
+        let rendered = diff.render_for_prompt(10_000);
+        assert!(rendered.contains("src/auth.rs"), "file path must appear");
+        assert!(
+            rendered.contains("authenticate"),
+            "hunk content must appear"
+        );
+    }
+
+    #[test]
+    fn filtered_diff_render_respects_max_chars() {
+        // Create a large number of files — rendering should stop before max_chars.
+        let files: Vec<FilteredFile> = (0..100)
+            .map(|i| make_kept_file(&format!("src/file{i}.rs"), &"+fn foo() {}".repeat(50)))
+            .collect();
+        let diff = FilteredDiff {
+            files,
+            dropped_files: vec![],
+            drop_hunk_counts: HashMap::new(),
+            original_byte_size: 100_000,
+            filtered_byte_size: 50_000,
+        };
+        let rendered = diff.render_for_prompt(2_000);
+        assert!(
+            rendered.len() <= 2_000 + 200,
+            "rendered output must not greatly exceed max_chars: len={}",
+            rendered.len()
+        );
+    }
+
+    #[test]
+    fn filtered_diff_drop_summary_emitted() {
+        let mut drop_counts = HashMap::new();
+        drop_counts.insert(HunkDropReason::ImportOnly, 3u32);
+        drop_counts.insert(HunkDropReason::WhitespaceOnly, 1u32);
+
+        let diff = FilteredDiff {
+            files: vec![make_kept_file("src/main.rs", "+fn main() {}")],
+            dropped_files: vec![DroppedFile {
+                path: "Cargo.lock".to_string(),
+                reason: "lockfile".to_string(),
+            }],
+            drop_hunk_counts: drop_counts,
+            original_byte_size: 5_000,
+            filtered_byte_size: 200,
+        };
+
+        let rendered = diff.render_for_prompt(100_000);
+        assert!(
+            rendered.contains("DiffAnalyzer filtered"),
+            "noise summary must appear: {rendered}"
+        );
+        assert!(
+            rendered.contains("file(s) omitted"),
+            "file drop count must appear: {rendered}"
+        );
+        assert!(
+            rendered.contains("hunk(s) omitted"),
+            "hunk drop count must appear: {rendered}"
+        );
+    }
+
+    #[test]
+    fn no_summary_when_nothing_dropped() {
+        let diff = FilteredDiff {
+            files: vec![make_kept_file("src/lib.rs", "+pub fn new() {}")],
+            dropped_files: vec![],
+            drop_hunk_counts: HashMap::new(),
+            original_byte_size: 100,
+            filtered_byte_size: 100,
+        };
+        let summary = diff.build_noise_summary();
+        assert!(summary.is_empty(), "empty summary when nothing was dropped");
+    }
+}

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -7,21 +7,23 @@
 //! `ReviewInput`, `ReviewDeps`, `DiffSource`) and the compare aggregator.
 //!
 //! Submodules:
-//!  - `diff`         — diff source, loading, truncation, identifier extraction.
-//!  - `grade`        — severity-anchored deterministic grade derivation (floor logic).
-//!  - `prompt`       — prompt construction for the reviewer role.
-//!  - `parser`       — verdict + findings parsing from LLM responses.
-//!  - `output`       — log file writing and STDOUT rendering.
-//!  - `post`         — post-or-log finalisation decision (Phase 1, #582).
-//!  - `verify_prompt`— verifier-pass prompt + forced-output schema (Phase 2, #583).
-//!  - `verify`       — per-finding verification round + liveness gate (Phase 2, #583).
-//!  - `runner`       — top-level orchestration loop (`run_review`).
-//!  - `trigger`      — live vs dry-run trigger classification (REV-703).
+//!  - `diff`          — diff source, loading, truncation, identifier extraction.
+//!  - `diff_analyzer` — DiffAnalyzer noise filter: Stages A/B/C (spec REV-200–262).
+//!  - `grade`         — severity-anchored deterministic grade derivation (floor logic).
+//!  - `prompt`        — prompt construction for the reviewer role.
+//!  - `parser`        — verdict + findings parsing from LLM responses.
+//!  - `output`        — log file writing and STDOUT rendering.
+//!  - `post`          — post-or-log finalisation decision (Phase 1, #582).
+//!  - `verify_prompt` — verifier-pass prompt + forced-output schema (Phase 2, #583).
+//!  - `verify`        — per-finding verification round + liveness gate (Phase 2, #583).
+//!  - `runner`        — top-level orchestration loop (`run_review`).
+//!  - `trigger`       — live vs dry-run trigger classification (REV-703).
 //!
 //! Test: each submodule carries its own unit tests.
 
 pub mod context_gate;
 pub mod diff;
+pub mod diff_analyzer;
 pub mod grade;
 pub mod output;
 pub mod parser;

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -50,6 +50,7 @@ use crate::{
     pipeline::{
         context_gate::{GateOutcome, degraded_banner, preflight_context},
         diff::{DiffSource, extract_changed_files, extract_identifiers, load_diff, truncate_diff},
+        diff_analyzer::DiffAnalyzer, // noise filter (Stages A+B); #624
         grade::derive_verdict,
         output::{print_review_result, write_review_log},
         parser::parse_review_response,
@@ -227,7 +228,8 @@ pub async fn run_review(
         }
     }
 
-    // ── Step 3: load and truncate diff ────────────────────────────────────
+    // ── Step 3: load, filter (DiffAnalyzer Stages A+B), and truncate diff ─
+    // truncate_diff is the final safety net after noise filtering (REV-209).
     let raw_diff = match load_diff(&input.diff_source).await {
         Ok(d) => d,
         Err(e) => {
@@ -236,17 +238,15 @@ pub async fn run_review(
             return abort_dry(result, config, &input, &deps);
         }
     };
-    let diff = truncate_diff(&raw_diff);
-    debug!(diff_chars = diff.len(), "diff loaded and truncated");
+    let filtered = DiffAnalyzer::default().analyze(&raw_diff).await;
+    let max = crate::config::constants::MAX_DIFF_CHARS;
+    let diff = truncate_diff(&filtered.render_for_prompt(max));
+    debug!(orig = raw_diff.len(), filt = diff.len(), "diff filtered");
 
     // ── Step 4: extract identifiers for context retrieval ─────────────────
     let identifiers = extract_identifiers(&diff, 8);
     let changed_files = extract_changed_files(&diff);
-    debug!(
-        identifiers = ?identifiers,
-        changed_files_count = changed_files.len(),
-        "extracted identifiers from diff"
-    );
+    debug!(ids = ?identifiers, files = changed_files.len(), "extracted identifiers from diff");
 
     // ── Step 4b: required-context gate (#590) ─────────────────────────────
     // trusty-search AND trusty-analyze are REQUIRED by default.  If either is


### PR DESCRIPTION
## Summary

Closes #624. Two stacked improvements to large-diff handling:

**Part S — Cap bump (commit 1, independently revertable):**
- Raises `MAX_DIFF_CHARS` from 60,000 → 160,000 chars (~40K tokens; still ~5× under the 200K Bedrock Sonnet context window)
- Updates the stale "60 000 chars" doc comment in `diff.rs`
- Adds two regression-guard tests: `max_diff_chars_is_160k` and `max_diff_chars_truncation_consistent`

**Part M — DiffAnalyzer noise filter (commit 2, spec REV-200–262):**

New module `crates/trusty-review/src/pipeline/diff_analyzer/` (7 files, all under 500-line cap):

- **Stage A (FileFilter, deterministic):** drops lockfiles, snapshots, generated code; collapses large fixture/i18n files to 1-line summaries. Force-preserves security paths, `.env`, credential-filename substrings, and content-level credential URL patterns — these override ALL drop rules (REV-202).
- **Stage B (HunkFilter, deterministic):** drops whitespace-only, import-only, and comment-only hunks per-language (Rust/Python/JS+TS/Java/Go/C++). All three gates individually configurable.
- **Stage C (HunkClassifier, Bedrock Haiku, optional):** batches surviving hunks (10/call) at temp 0.0. Drops `mechanical` hunks with confidence > 0.7. Fail-open: any LLM/parse error → all hunks in batch kept (REV-208). Disabled by default (`disable_classifier = true`). Note: #596 plans consolidation onto `trusty_common::chat::ChatProvider`; Stage C currently uses the in-crate `LlmProvider` trait.
- **Integration:** `runner.rs` Step 3 now runs `DiffAnalyzer::default().analyze().render_for_prompt(MAX_DIFF_CHARS)`, keeping `truncate_diff` as a safety net. A noise summary appended to the prompt tells the reviewer what was dropped (REV-209 — no silent filtering).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero errors
- [x] `cargo test -p trusty-review` — 537 lib + 8 bin = 545 tests passing, 2 ignored (live Bedrock)
- [x] `cargo check --workspace` — clean
- [x] `scripts/check_line_cap.sh` — 173 allowlisted, 0 violations
- [ ] Live Bedrock Stage C integration: `cargo test -p trusty-review -- stage_c_live_bedrock --include-ignored`

New test names:
- Stage A: `lockfile_is_dropped`, `yarn_lock_is_dropped`, `snapshot_is_dropped`, `generated_file_is_dropped`, `plain_rust_file_is_kept`, `security_file_is_preserved`, `credential_filename_preserved`, `env_file_is_preserved`, `fixture_file_is_summarised_when_large`, `fixture_file_kept_when_small`, `split_patch_into_hunks_basic`, `split_opaque_patch_treated_as_single_hunk`, `filefilter_user_preserve_keeps_file`, `multiple_files_classified_correctly`
- Stage B: `whitespace_only_hunk_dropped`, `whitespace_gate_disabled_keeps_hunk`, `rust_import_only_hunk_dropped`, `python_import_only_hunk_dropped`, `java_import_only_hunk_dropped`, `ts_import_only_hunk_dropped`, `mixed_hunk_kept`, `comment_only_hunk_dropped`, `apply_returns_aggregate_counts`, `summary_only_files_skipped_by_stage_b`
- Stage C: `hunk_classification_mechanical_high_confidence_droppable`, `hunk_classification_mechanical_low_confidence_kept`, `hunk_classification_substantive_not_dropped`, `hunk_classification_uncertain_not_dropped`, `parse_classification_array_valid`, `parse_classification_array_strips_markdown_fence`, `parse_classification_array_wrong_count_returns_error`, `parse_classification_array_invalid_json_returns_error`, `uncertain_batch_has_correct_length`
- Integration: `diff_analyzer_drops_lockfile`, `diff_analyzer_stages_a_b_integration`, `parse_diff_files_basic`, `parse_diff_files_new_file`
- Constants: `max_diff_chars_is_160k`, `max_diff_chars_truncation_consistent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)