### PR TITLE
feat(trusty-analyze): expose trusty-review LLM review as MCP tools (tr_review_pr/diff/health, optional `review` feature)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -22,7 +22,7 @@ crates/trusty-analyze/src/lang/adapters/swift.rs	531
 crates/trusty-analyze/src/lang/adapters/typescript.rs	680
 crates/trusty-analyze/src/lang/detection.rs	616
 crates/trusty-analyze/src/main.rs	846
-crates/trusty-analyze/src/mcp/mod.rs	1252
+crates/trusty-analyze/src/mcp/mod.rs	1178
 crates/trusty-analyze/src/service/mod.rs	2163
 crates/trusty-analyze/tests/stdio_harness.rs	639
 crates/trusty-common/src/bm25_client.rs	503

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10741,6 +10741,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "trusty-common",
+ "trusty-review",
  "which 6.0.3",
  "xxhash-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ tga = { path = "crates/trusty-git-analytics", version = "2.5.0" }
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
 trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
+# trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
+# (behind the optional `review` feature) so the analyze MCP server can expose
+# the trusty-review pipeline as `tr_review_*` tools (#630).
+trusty-review = { path = "crates/trusty-review", version = "0.1.0" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -91,6 +91,11 @@ hex                = { workspace = true }
 fastembed  = { workspace = true, features = ["hf-hub-rustls-tls"], optional = true }
 ort        = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
+# Why (#630): trusty-review provides the reusable LLM review pipeline + MCP tool
+#      surface. Optional and OFF by default so `cargo install trusty-analyze`
+#      and the crates.io publish are unaffected (trusty-review need not be
+#      published). The `review` feature pulls it in with its `mcp` feature.
+trusty-review = { workspace = true, optional = true }
 
 [features]
 # Why (issue #249): mirrors the `trusty-common` / `trusty-memory` rule that
@@ -126,6 +131,13 @@ load-dynamic = ["dep:fastembed", "fastembed/ort-load-dynamic"]
 # Always pair with --no-default-features so bundled-ort is dropped.
 cuda         = ["dep:fastembed", "fastembed/cuda", "fastembed/ort-load-dynamic"]
 ner     = ["dep:ort", "dep:tokenizers"]
+# Why (#630): exposes the trusty-review LLM review pipeline as MCP tools
+#      (`tr_review_pr`, `tr_review_diff`, `tr_review_health`). OFF by default so
+#      the standard `cargo install` / crates.io publish do not require
+#      trusty-review to be published. Pulls in trusty-review with its `mcp`
+#      feature so the reusable tool surface (`tools::call_tool`, `AppState`,
+#      `build_review_state`) is reachable.
+review  = ["dep:trusty-review", "trusty-review/mcp"]
 
 [dev-dependencies]
 tempfile       = { workspace = true }

--- a/crates/trusty-analyze/src/mcp/descriptors.rs
+++ b/crates/trusty-analyze/src/mcp/descriptors.rs
@@ -1,0 +1,234 @@
+//! Base MCP tool descriptors for the trusty-analyze dispatcher.
+//!
+//! Why: the `tools/list` JSON-Schema payload is large (~200 lines) and was
+//! inflating `mcp/mod.rs` past the #610 shrink-only line-cap budget. Extracting
+//! it into its own module both keeps `mod.rs` under its frozen budget and gives
+//! the descriptor list a single, easy-to-locate home. The optional `review`
+//! feature (#630) appends its three `tr_review_*` descriptors on top of these.
+//!
+//! What: `base_tool_descriptors()` returns the descriptor array for every tool
+//! the dispatcher serves unconditionally (i.e. excluding feature-gated ones).
+//!
+//! Test: `crates/trusty-analyze/src/mcp/mod.rs` `tools_list_contains_full_surface`
+//! asserts the names this list produces are all present in the `tools/list`
+//! response.
+
+use serde_json::Value;
+
+/// Return the descriptor array for the always-compiled analyzer tools.
+///
+/// Why: callers (`mod.rs::tool_descriptors`) assemble the final `tools/list`
+/// payload from this base set plus any feature-gated additions; keeping the
+/// base set here is what lets `mod.rs` stay within its line-cap budget.
+/// What: returns a `serde_json::Value` array, one object per tool, each with a
+/// `name`, `description`, and JSON-Schema `inputSchema`.
+/// Test: name coverage asserted by `mod.rs::tools_list_contains_full_surface`.
+pub fn base_tool_descriptors() -> Value {
+    serde_json::json!([
+        {
+            "name": "complexity_hotspots",
+            "description": "Top-N chunks ranked by cyclomatic complexity",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index": { "type": "string" },
+                    "index_id": { "type": "string" },
+                    "top_n": { "type": "number" }
+                }
+            }
+        },
+        {
+            "name": "find_smells",
+            "description": "Chunks with at least one detected code smell",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index": { "type": "string" },
+                    "index_id": { "type": "string" }
+                }
+            }
+        },
+        {
+            "name": "analyze_quality",
+            "description": "Aggregate quality stats: avg cyclomatic, %A, smell count",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index": { "type": "string" },
+                    "index_id": { "type": "string" }
+                }
+            }
+        },
+        {
+            "name": "run_diagnostics",
+            "description": "Run available external static-analysis tools (clippy, ruff, biome, staticcheck, pmd, rubocop, phpstan, swiftlint, detekt, clang-tidy) across the index corpus on demand. Tools are auto-discovered: only installed binaries run. Returns normalized diagnostics with file, line, severity, rule code, and message.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index":    { "type": "string" },
+                    "index_id": { "type": "string" },
+                    "language": { "type": "string", "description": "Optional: restrict to one language tag (rust, python, typescript, go, java, ruby, php, swift, kotlin, cpp)" },
+                    "tools":    { "type": "string", "description": "Optional: comma-separated list of tool names to run; defaults to all available" }
+                }
+            }
+        },
+        {
+            "name": "list_facts",
+            "description": "List canonical facts, optionally filtered by subject/predicate/object",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "subject":   { "type": "string" },
+                    "predicate": { "type": "string" },
+                    "object":    { "type": "string" }
+                }
+            }
+        },
+        {
+            "name": "upsert_fact",
+            "description": "Insert or update a canonical fact triple",
+            "inputSchema": {
+                "type": "object",
+                "required": ["subject", "predicate", "object", "index_id"],
+                "properties": {
+                    "subject":    { "type": "string" },
+                    "predicate":  { "type": "string" },
+                    "object":     { "type": "string" },
+                    "index_id":   { "type": "string" },
+                    "confidence": { "type": "number" },
+                    "provenance": { "type": "array", "items": { "type": "string" } }
+                }
+            }
+        },
+        {
+            "name": "delete_fact",
+            "description": "Delete a fact by its u64 id",
+            "inputSchema": {
+                "type": "object",
+                "required": ["id"],
+                "properties": { "id": { "type": "number" } }
+            }
+        },
+        {
+            "name": "analyzer_health",
+            "description": "Probe analyzer daemon liveness and version",
+            "inputSchema": { "type": "object", "properties": {} }
+        },
+        {
+            "name": "extract_graph",
+            "description": "Build the multi-language knowledge graph (nodes + edges) for an index",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index":    { "type": "string" },
+                    "index_id": { "type": "string" },
+                    "language": { "type": "string" }
+                }
+            }
+        },
+        {
+            "name": "cluster_concepts",
+            "description": "Group chunks into concept clusters using k-means over embeddings (BOW or neural)",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index":    { "type": "string" },
+                    "index_id": { "type": "string" },
+                    "k":        { "type": "number" },
+                    "method":   { "type": "string", "description": "Embedding method: 'bow' (default, fast) or 'neural' (semantic, requires fastembed model)" }
+                }
+            }
+        },
+        {
+            "name": "ingest_scip",
+            "description": "Ingest a SCIP (Scalable and Precise Index for Code) protobuf index for a given index_id, enriching the knowledge graph with fully-resolved symbols and cross-file relationships. The SCIP bytes must be base64-encoded.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["scip_base64"],
+                "properties": {
+                    "index":        { "type": "string" },
+                    "index_id":     { "type": "string" },
+                    "scip_base64":  { "type": "string", "description": "Base64-encoded SCIP Index protobuf payload" }
+                }
+            }
+        },
+        {
+            "name": "extract_ner",
+            "description": "Extract named entities from doc comments for a code index using NER",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index":    { "type": "string" },
+                    "index_id": { "type": "string", "description": "Index ID" },
+                    "top_k":    { "type": "integer", "description": "Max entities to return", "default": 50 }
+                }
+            }
+        },
+        {
+            "name": "suggest_refactors",
+            "description": "Suggest concrete refactoring actions (extract method, reduce nesting, ...) ranked by severity, derived from complexity metrics and code smells",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index":        { "type": "string" },
+                    "index_id":     { "type": "string" },
+                    "file":         { "type": "string", "description": "Optional path filter — restrict suggestions to one file" },
+                    "min_severity": { "type": "string", "description": "Minimum severity: 'low' (default), 'medium', 'high', 'critical'" },
+                    "top_k":        { "type": "number", "description": "Cap on suggestions returned (default 20)" }
+                }
+            }
+        },
+        {
+            "name": "review_diff",
+            "description": "Review a unified git diff and return a structured quality report (per-file complexity, code smells, grade A-F, recommendations). Cross-references the diff against the trusty-search index corpus, so trusty-search must be running. Deterministic and LLM-free — use the deep_analysis tool for LLM-augmented narrative.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["diff", "index_id"],
+                "properties": {
+                    "diff":     { "type": "string", "description": "Unified git diff text to review" },
+                    "index_id": { "type": "string", "description": "Index ID to cross-reference the diff against in trusty-search" }
+                }
+            }
+        },
+        {
+            "name": "deep_analysis",
+            "description": "Run an LLM-augmented deep analysis pass over an index: synthesises a deterministic review report from the indexed corpus, looks up detected frameworks, and asks an OpenRouter model for a prose narrative plus framework-aware recommendations. Requires OPENROUTER_API_KEY configured on the daemon.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["index_id"],
+                "properties": {
+                    "index_id": { "type": "string", "description": "trusty-search index ID to analyse" },
+                    "model":    { "type": "string", "description": "Optional OpenRouter model id (e.g. 'openai/gpt-4o-mini'); falls back to TRUSTY_LLM_MODEL on the daemon" }
+                }
+            }
+        },
+        {
+            "name": "review_github_pr",
+            "description": "Fetch a GitHub pull request's unified diff and run a structured quality review against a trusty-search index. Requires GITHUB_TOKEN set on the daemon. Optionally posts the review back as a PR comment.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["owner", "repo", "pr", "index_id"],
+                "properties": {
+                    "owner":        { "type": "string", "description": "Repository owner (user or org)" },
+                    "repo":         { "type": "string", "description": "Repository name" },
+                    "pr":           { "type": "integer", "description": "Pull request number" },
+                    "index_id":     { "type": "string", "description": "trusty-search index ID to cross-reference" },
+                    "post_comment": { "type": "boolean", "description": "Post the review back as a PR comment (default false)", "default": false }
+                }
+            }
+        },
+        {
+            "name": "list_entities",
+            "description": "List symbol-level entities (functions, classes, ...) for an index",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index":    { "type": "string" },
+                    "index_id": { "type": "string" },
+                    "kind":     { "type": "string" },
+                    "language": { "type": "string" }
+                }
+            }
+        }
+    ])
+}

--- a/crates/trusty-analyze/src/mcp/mod.rs
+++ b/crates/trusty-analyze/src/mcp/mod.rs
@@ -27,6 +27,19 @@
 pub mod sse;
 pub mod stdio;
 
+// Why (#610): the `tools/list` JSON-Schema payload was extracted into its own
+// module to keep this file under its frozen line-cap budget while the `review`
+// feature (#630) adds new tools. `descriptors::base_tool_descriptors()` is the
+// always-compiled base set.
+pub mod descriptors;
+
+// Why (#630): the `tr_review_*` LLM tools that embed the trusty-review pipeline
+// live behind the optional `review` feature so the default build / crates.io
+// publish are unaffected. When off, the module is not compiled and the names
+// fall through to `UnknownTool`.
+#[cfg(feature = "review")]
+pub mod review;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -321,6 +334,13 @@ impl AnalyzerMcpServer {
             "review_diff" => self.handle_review_diff(args).await,
             "review_github_pr" => self.handle_review_github_pr(args).await,
             "deep_analysis" => self.handle_deep_analysis(args).await,
+            // Why (#630): the `tr_review_*` LLM tools delegate into the embedded
+            // trusty-review pipeline. Gated behind the `review` feature; when
+            // off these names fall through to the `_ => UnknownTool` arm.
+            #[cfg(feature = "review")]
+            "tr_review_pr" | "tr_review_diff" | "tr_review_health" => {
+                review::handle_tr_review(tool, args).await
+            }
             _ => Err(DispatchError::UnknownTool),
         }
     }
@@ -720,214 +740,27 @@ fn wrap_tool_error(msg: &str) -> Value {
     })
 }
 
+/// Assemble the full `tools/list` descriptor array.
+///
+/// Why: the base descriptor set lives in `descriptors.rs` to keep this file
+/// within its line-cap budget (#610). When the optional `review` feature is on
+/// (#630), the three `tr_review_*` descriptors are appended so `tools/list`
+/// advertises exactly the tools the dispatcher can route.
+/// What: starts from `descriptors::base_tool_descriptors()` and, under
+/// `feature = "review"`, pushes `review::review_tool_descriptors()` onto the
+/// array. Returns a `serde_json::Value` array.
+/// Test: `tools_list_contains_full_surface` (base names) and, feature-gated,
+/// `tools_list_includes_tr_review_tools` (the three `tr_` names).
 pub fn tool_descriptors() -> Value {
-    serde_json::json!([
-        {
-            "name": "complexity_hotspots",
-            "description": "Top-N chunks ranked by cyclomatic complexity",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index": { "type": "string" },
-                    "index_id": { "type": "string" },
-                    "top_n": { "type": "number" }
-                }
-            }
-        },
-        {
-            "name": "find_smells",
-            "description": "Chunks with at least one detected code smell",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index": { "type": "string" },
-                    "index_id": { "type": "string" }
-                }
-            }
-        },
-        {
-            "name": "analyze_quality",
-            "description": "Aggregate quality stats: avg cyclomatic, %A, smell count",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index": { "type": "string" },
-                    "index_id": { "type": "string" }
-                }
-            }
-        },
-        {
-            "name": "run_diagnostics",
-            "description": "Run available external static-analysis tools (clippy, ruff, biome, staticcheck, pmd, rubocop, phpstan, swiftlint, detekt, clang-tidy) across the index corpus on demand. Tools are auto-discovered: only installed binaries run. Returns normalized diagnostics with file, line, severity, rule code, and message.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index":    { "type": "string" },
-                    "index_id": { "type": "string" },
-                    "language": { "type": "string", "description": "Optional: restrict to one language tag (rust, python, typescript, go, java, ruby, php, swift, kotlin, cpp)" },
-                    "tools":    { "type": "string", "description": "Optional: comma-separated list of tool names to run; defaults to all available" }
-                }
-            }
-        },
-        {
-            "name": "list_facts",
-            "description": "List canonical facts, optionally filtered by subject/predicate/object",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "subject":   { "type": "string" },
-                    "predicate": { "type": "string" },
-                    "object":    { "type": "string" }
-                }
-            }
-        },
-        {
-            "name": "upsert_fact",
-            "description": "Insert or update a canonical fact triple",
-            "inputSchema": {
-                "type": "object",
-                "required": ["subject", "predicate", "object", "index_id"],
-                "properties": {
-                    "subject":    { "type": "string" },
-                    "predicate":  { "type": "string" },
-                    "object":     { "type": "string" },
-                    "index_id":   { "type": "string" },
-                    "confidence": { "type": "number" },
-                    "provenance": { "type": "array", "items": { "type": "string" } }
-                }
-            }
-        },
-        {
-            "name": "delete_fact",
-            "description": "Delete a fact by its u64 id",
-            "inputSchema": {
-                "type": "object",
-                "required": ["id"],
-                "properties": { "id": { "type": "number" } }
-            }
-        },
-        {
-            "name": "analyzer_health",
-            "description": "Probe analyzer daemon liveness and version",
-            "inputSchema": { "type": "object", "properties": {} }
-        },
-        {
-            "name": "extract_graph",
-            "description": "Build the multi-language knowledge graph (nodes + edges) for an index",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index":    { "type": "string" },
-                    "index_id": { "type": "string" },
-                    "language": { "type": "string" }
-                }
-            }
-        },
-        {
-            "name": "cluster_concepts",
-            "description": "Group chunks into concept clusters using k-means over embeddings (BOW or neural)",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index":    { "type": "string" },
-                    "index_id": { "type": "string" },
-                    "k":        { "type": "number" },
-                    "method":   { "type": "string", "description": "Embedding method: 'bow' (default, fast) or 'neural' (semantic, requires fastembed model)" }
-                }
-            }
-        },
-        {
-            "name": "ingest_scip",
-            "description": "Ingest a SCIP (Scalable and Precise Index for Code) protobuf index for a given index_id, enriching the knowledge graph with fully-resolved symbols and cross-file relationships. The SCIP bytes must be base64-encoded.",
-            "inputSchema": {
-                "type": "object",
-                "required": ["scip_base64"],
-                "properties": {
-                    "index":        { "type": "string" },
-                    "index_id":     { "type": "string" },
-                    "scip_base64":  { "type": "string", "description": "Base64-encoded SCIP Index protobuf payload" }
-                }
-            }
-        },
-        {
-            "name": "extract_ner",
-            "description": "Extract named entities from doc comments for a code index using NER",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index":    { "type": "string" },
-                    "index_id": { "type": "string", "description": "Index ID" },
-                    "top_k":    { "type": "integer", "description": "Max entities to return", "default": 50 }
-                }
-            }
-        },
-        {
-            "name": "suggest_refactors",
-            "description": "Suggest concrete refactoring actions (extract method, reduce nesting, ...) ranked by severity, derived from complexity metrics and code smells",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index":        { "type": "string" },
-                    "index_id":     { "type": "string" },
-                    "file":         { "type": "string", "description": "Optional path filter — restrict suggestions to one file" },
-                    "min_severity": { "type": "string", "description": "Minimum severity: 'low' (default), 'medium', 'high', 'critical'" },
-                    "top_k":        { "type": "number", "description": "Cap on suggestions returned (default 20)" }
-                }
-            }
-        },
-        {
-            "name": "review_diff",
-            "description": "Review a unified git diff and return a structured quality report (per-file complexity, code smells, grade A-F, recommendations). Cross-references the diff against the trusty-search index corpus, so trusty-search must be running. Deterministic and LLM-free — use the deep_analysis tool for LLM-augmented narrative.",
-            "inputSchema": {
-                "type": "object",
-                "required": ["diff", "index_id"],
-                "properties": {
-                    "diff":     { "type": "string", "description": "Unified git diff text to review" },
-                    "index_id": { "type": "string", "description": "Index ID to cross-reference the diff against in trusty-search" }
-                }
-            }
-        },
-        {
-            "name": "deep_analysis",
-            "description": "Run an LLM-augmented deep analysis pass over an index: synthesises a deterministic review report from the indexed corpus, looks up detected frameworks, and asks an OpenRouter model for a prose narrative plus framework-aware recommendations. Requires OPENROUTER_API_KEY configured on the daemon.",
-            "inputSchema": {
-                "type": "object",
-                "required": ["index_id"],
-                "properties": {
-                    "index_id": { "type": "string", "description": "trusty-search index ID to analyse" },
-                    "model":    { "type": "string", "description": "Optional OpenRouter model id (e.g. 'openai/gpt-4o-mini'); falls back to TRUSTY_LLM_MODEL on the daemon" }
-                }
-            }
-        },
-        {
-            "name": "review_github_pr",
-            "description": "Fetch a GitHub pull request's unified diff and run a structured quality review against a trusty-search index. Requires GITHUB_TOKEN set on the daemon. Optionally posts the review back as a PR comment.",
-            "inputSchema": {
-                "type": "object",
-                "required": ["owner", "repo", "pr", "index_id"],
-                "properties": {
-                    "owner":        { "type": "string", "description": "Repository owner (user or org)" },
-                    "repo":         { "type": "string", "description": "Repository name" },
-                    "pr":           { "type": "integer", "description": "Pull request number" },
-                    "index_id":     { "type": "string", "description": "trusty-search index ID to cross-reference" },
-                    "post_comment": { "type": "boolean", "description": "Post the review back as a PR comment (default false)", "default": false }
-                }
-            }
-        },
-        {
-            "name": "list_entities",
-            "description": "List symbol-level entities (functions, classes, ...) for an index",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "index":    { "type": "string" },
-                    "index_id": { "type": "string" },
-                    "kind":     { "type": "string" },
-                    "language": { "type": "string" }
-                }
-            }
-        }
-    ])
+    // `mut` is only needed when the `review` feature appends descriptors; the
+    // attribute keeps the feature-off build free of an `unused_mut` warning.
+    #[cfg_attr(not(feature = "review"), allow(unused_mut))]
+    let mut tools = descriptors::base_tool_descriptors();
+    #[cfg(feature = "review")]
+    if let Some(arr) = tools.as_array_mut() {
+        arr.extend(review::review_tool_descriptors());
+    }
+    tools
 }
 
 #[cfg(test)]
@@ -1248,5 +1081,98 @@ mod tests {
         let resp = server.dispatch(r).await;
         let err = resp.error.expect("expected error");
         assert_eq!(err.code, error_codes::INVALID_REQUEST);
+    }
+
+    // ── #630: trusty-review LLM tools (feature `review`) ─────────────────────
+
+    /// With the `review` feature ON, `tools/list` advertises all three
+    /// `tr_review_*` tools alongside the base analyzer tools.
+    #[cfg(feature = "review")]
+    #[tokio::test]
+    async fn tools_list_includes_tr_review_tools() {
+        let server = AnalyzerMcpServer::new("http://127.0.0.1:1");
+        let resp = server.dispatch(req("tools/list", Value::Null)).await;
+        let result = resp.result.expect("expected result");
+        let tools = result
+            .get("tools")
+            .and_then(Value::as_array)
+            .expect("array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(Value::as_str))
+            .collect();
+        for required in ["tr_review_pr", "tr_review_diff", "tr_review_health"] {
+            assert!(names.contains(&required), "missing {required} in {names:?}");
+        }
+        // The base surface must still be present (no descriptors lost in the
+        // extract-to-descriptors.rs refactor).
+        assert!(names.contains(&"complexity_hotspots"), "got {names:?}");
+        assert!(names.contains(&"deep_analysis"), "got {names:?}");
+    }
+
+    /// With the `review` feature ON, the `tr_review_*` names route into the
+    /// embedded pipeline rather than falling through to `UnknownTool`. We do not
+    /// assert success (the credential-bound build path needs live AWS /
+    /// OpenRouter config); we only assert the dispatcher did NOT return
+    /// METHOD_NOT_FOUND, i.e. the name was recognised and routed.
+    #[cfg(feature = "review")]
+    #[tokio::test]
+    async fn tr_review_health_routes_not_unknown_tool() {
+        let server = AnalyzerMcpServer::new("http://127.0.0.1:1");
+        let resp = server
+            .dispatch(req(
+                "tools/call",
+                serde_json::json!({ "name": "tr_review_health", "arguments": {} }),
+            ))
+            .await;
+        // tools/call form: routed tools return a result (possibly an in-band
+        // isError envelope on build failure); an *unrecognised* name returns a
+        // JSON-RPC METHOD_NOT_FOUND error. Assert we are not in the latter case.
+        if let Some(err) = resp.error {
+            assert_ne!(
+                err.code,
+                error_codes::METHOD_NOT_FOUND,
+                "tr_review_health must route, not be unknown: {err:?}"
+            );
+        }
+    }
+
+    /// With the `review` feature OFF, the `tr_review_*` names are neither
+    /// advertised in `tools/list` nor routable — they return METHOD_NOT_FOUND.
+    #[cfg(not(feature = "review"))]
+    #[tokio::test]
+    async fn tr_review_tools_absent_when_feature_off() {
+        let server = AnalyzerMcpServer::new("http://127.0.0.1:1");
+
+        // Not advertised.
+        let resp = server.dispatch(req("tools/list", Value::Null)).await;
+        let tools = resp
+            .result
+            .expect("result")
+            .get("tools")
+            .and_then(Value::as_array)
+            .expect("array")
+            .clone();
+        let names: Vec<String> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(Value::as_str))
+            .map(str::to_owned)
+            .collect();
+        for absent in ["tr_review_pr", "tr_review_diff", "tr_review_health"] {
+            assert!(
+                !names.iter().any(|n| n == absent),
+                "{absent} must be absent when feature off; got {names:?}"
+            );
+        }
+
+        // Not routable.
+        let resp = server
+            .dispatch(req(
+                "tools/call",
+                serde_json::json!({ "name": "tr_review_health", "arguments": {} }),
+            ))
+            .await;
+        let err = resp.error.expect("expected METHOD_NOT_FOUND error");
+        assert_eq!(err.code, error_codes::METHOD_NOT_FOUND);
     }
 }

--- a/crates/trusty-analyze/src/mcp/review.rs
+++ b/crates/trusty-analyze/src/mcp/review.rs
@@ -1,0 +1,133 @@
+//! Feature-gated bridge that exposes the trusty-review LLM pipeline as MCP tools.
+//!
+//! Why (#630): collapses two MCP servers into one. With the optional `review`
+//! cargo feature on, the trusty-analyze MCP dispatcher gains three LLM-backed
+//! review tools (`tr_review_pr`, `tr_review_diff`, `tr_review_health`) that
+//! delegate into the embedded trusty-review pipeline. The `tr_` prefix avoids
+//! colliding with trusty-analyze's existing *deterministic* `review_diff` /
+//! `review_github_pr` tools (which forward to analyze's own `/review` HTTP
+//! endpoints). When the feature is off this module is not compiled and the
+//! `tr_*` names fall through to `UnknownTool`.
+//!
+//! What: holds the three review-tool descriptors, a process-wide lazily-built
+//! `AppState` cache (`OnceCell`) so the expensive AWS-credential / provider
+//! build happens at most once, and async handlers that map trusty-review's
+//! `ToolError` onto the dispatcher's [`DispatchError`].
+//!
+//! Test: `mod.rs` tests `tools_list_includes_tr_review_tools` (feature on) and
+//! `tr_review_health_routes` exercise the descriptor list and routing; the
+//! credential-bound build path is covered by the live smoke test.
+
+use serde_json::Value;
+use tokio::sync::OnceCell;
+
+use super::DispatchError;
+
+/// Process-wide cache of the assembled trusty-review `AppState`.
+///
+/// Why: `trusty_review::mcp::build_review_state()` loads AWS credentials and
+/// builds LLM providers, which is slow and should happen once per process, not
+/// per tool call. A `tokio::sync::OnceCell` gives us async-safe lazy init that
+/// shares a single build across concurrent first calls.
+/// What: stores the built `AppState`; populated on the first review tool call.
+/// Test: indirectly via the live smoke test (a second call reuses the cache).
+static REVIEW_STATE: OnceCell<trusty_review::mcp::ReviewAppState> = OnceCell::const_new();
+
+/// Return the descriptors for the three `tr_review_*` tools.
+///
+/// Why: `mod.rs::tool_descriptors()` appends these to the base descriptor set
+/// only when the `review` feature is on, so `tools/list` advertises the review
+/// tools exactly when they are callable.
+/// What: returns a `Vec<Value>`, one descriptor object per tool, mirroring the
+/// trusty-review tool schemas but with the `tr_` name prefix.
+/// Test: `mod.rs::tools_list_includes_tr_review_tools` asserts all three names
+/// appear in the `tools/list` response.
+pub(super) fn review_tool_descriptors() -> Vec<Value> {
+    vec![
+        serde_json::json!({
+            "name": "tr_review_pr",
+            "description": "LLM-backed review of a GitHub pull request via the embedded trusty-review pipeline. Fetches the PR diff, retrieves code context from trusty-search, augments with this analyzer daemon's static-analysis context (loopback), and returns a structured verdict (APPROVE / APPROVE* / REQUEST_CHANGES / BLOCK / UNKNOWN) with actionable findings. Requires GITHUB_TOKEN and AWS Bedrock credentials (or OPENROUTER_API_KEY). Always dry-run — never posts a GitHub comment.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["owner", "repo", "pr"],
+                "properties": {
+                    "owner": { "type": "string", "description": "GitHub organisation or user that owns the repository" },
+                    "repo":  { "type": "string", "description": "GitHub repository name" },
+                    "pr":    { "type": "integer", "description": "Pull request number" },
+                    "reviewer_model": { "type": "string", "description": "Override the reviewer model slug (e.g. 'bedrock/us.anthropic.claude-sonnet-4-6')" }
+                }
+            }
+        }),
+        serde_json::json!({
+            "name": "tr_review_diff",
+            "description": "LLM-backed review of a raw unified diff string via the embedded trusty-review pipeline. No GitHub credentials required. Useful for reviewing local changes, staged diffs, or patches. Requires AWS Bedrock credentials (or OPENROUTER_API_KEY). trusty-search + this analyzer daemon supply code and static-analysis context.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["diff"],
+                "properties": {
+                    "diff":    { "type": "string", "description": "Unified diff string (output of `git diff` or similar)" },
+                    "context": { "type": "string", "description": "Optional human-readable context (PR title/description, ticket, intent)" },
+                    "reviewer_model": { "type": "string", "description": "Override the reviewer model slug (same format as tr_review_pr)" }
+                }
+            }
+        }),
+        serde_json::json!({
+            "name": "tr_review_health",
+            "description": "Probe the embedded trusty-review pipeline's liveness and configuration (dry_run mode, reviewer model, dependency URLs). Safe to call without any credentials.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+    ]
+}
+
+/// Dispatch a `tr_review_*` tool name into the embedded trusty-review pipeline.
+///
+/// Why: `mod.rs::call_tool` routes the three feature-gated names here so the
+/// bridge owns the lazy `AppState` build, the name mapping (`tr_` → bare), and
+/// the error translation in one place.
+/// What: lazily builds (or reuses) the shared `AppState`, strips the `tr_`
+/// prefix to recover the trusty-review tool name, delegates to
+/// `trusty_review::mcp::call_review_tool`, and maps the result/error onto
+/// `Result<Value, DispatchError>`.
+/// Test: `mod.rs::tr_review_health_routes` checks the routing reaches this
+/// handler; the full pipeline is covered by the live smoke test.
+pub(super) async fn handle_tr_review(tool: &str, args: &Value) -> Result<Value, DispatchError> {
+    // Strip the `tr_` prefix to recover the trusty-review tool name.
+    let inner = tool.strip_prefix("tr_").unwrap_or(tool);
+
+    let state = REVIEW_STATE
+        .get_or_try_init(trusty_review::mcp::build_review_state)
+        .await
+        .map_err(|e| {
+            DispatchError::Transport(format!("failed to build trusty-review state: {e}"))
+        })?;
+
+    match trusty_review::mcp::call_review_tool(inner, args, state).await {
+        Ok(value) => Ok(value),
+        Err(trusty_review::mcp::ReviewToolError::UnknownTool) => Err(DispatchError::UnknownTool),
+        Err(trusty_review::mcp::ReviewToolError::InvalidParams(msg)) => {
+            Err(DispatchError::InvalidParams(msg))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_descriptors_are_tr_prefixed_and_complete() {
+        let descs = review_tool_descriptors();
+        let names: Vec<&str> = descs
+            .iter()
+            .filter_map(|d| d.get("name").and_then(Value::as_str))
+            .collect();
+        assert_eq!(names.len(), 3, "expected 3 tr_ tools, got {names:?}");
+        for required in ["tr_review_pr", "tr_review_diff", "tr_review_health"] {
+            assert!(names.contains(&required), "missing {required} in {names:?}");
+        }
+        // Every tr_ tool carries an inputSchema.
+        for d in &descs {
+            assert!(d.get("inputSchema").is_some(), "missing inputSchema: {d}");
+        }
+    }
+}

--- a/crates/trusty-review/src/mcp/mod.rs
+++ b/crates/trusty-review/src/mcp/mod.rs
@@ -22,12 +22,22 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use serde_json::Value;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 use trusty_common::mcp::{Request, Response, error_codes, initialize_response, run_stdio_loop};
 
+use crate::config::ReviewConfig;
+use crate::integrations::{analyze_client::HttpAnalyzeClient, search_client::HttpSearchClient};
+use crate::llm::build_provider;
 use crate::mcp::tools::{ToolError, call_tool, tool_descriptors, wrap_tool_error};
 use crate::service::AppState;
+
+// Re-export the reusable surface an embedding host (e.g. trusty-analyze, #630)
+// needs to delegate into the trusty-review pipeline without depending on the
+// binary's serve assembly: the tool descriptors, the `tools/call` router, the
+// router's error type, and the shared `AppState`.
+pub use crate::mcp::tools::{ToolError as ReviewToolError, call_tool as call_review_tool};
+pub use crate::service::AppState as ReviewAppState;
 
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
@@ -47,6 +57,76 @@ pub async fn run(state: AppState) -> Result<()> {
         async move { dispatch(req, &state).await }
     })
     .await
+}
+
+/// Build a fully-wired trusty-review [`AppState`] from environment + config file.
+///
+/// Why: an embedding host (e.g. trusty-analyze's MCP server, #630) needs to run
+/// the trusty-review pipeline without copying the binary's `serve` assembly,
+/// which lives behind `crate::cli_verify` in the binary target and is therefore
+/// not reachable from a library consumer. This entry point reproduces that
+/// assembly using only library-public builders so the host can obtain an
+/// `AppState` and delegate `tools/call` to [`tools::call_tool`].
+/// What: loads [`ReviewConfig`] from env + the default XDG config file, builds
+/// the reviewer LLM provider (Bedrock or OpenRouter, per config), optionally
+/// builds the verifier provider (degrading to `None` on failure — embedded use
+/// must not hard-fail a host daemon over a missing verifier model), builds the
+/// HTTP search + analyze clients from config (the analyze client defaults to
+/// `http://localhost:7879`, i.e. loopback to the hosting analyze daemon, so
+/// embedded reviews get authoritative static-analysis context), and returns the
+/// assembled `AppState`. No dedup store is opened — embedded callers do not post
+/// comments (`allow_posting=false` in every tool handler), so cross-process
+/// dedup is unnecessary.
+/// Test: the build path is network/credential-bound (AWS / OpenRouter) and is
+/// therefore exercised by the live smoke test rather than a unit test; the
+/// dispatch/tools surface it feeds is covered by `mcp::tests` and
+/// `tools::tests`.
+pub async fn build_review_state() -> Result<AppState> {
+    let config = ReviewConfig::load(None);
+
+    let reviewer_model = config.role_models.reviewer.model.clone();
+    let default_provider = config.role_models.reviewer.provider.clone();
+    let llm = build_provider(
+        &reviewer_model,
+        &default_provider,
+        &config.openrouter_api_key,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to build reviewer LLM provider: {e}"))?;
+
+    // Verifier is optional in the embedded path: degrade to no-verification
+    // rather than abort the host daemon if the verifier model cannot be built.
+    let verifier = if config.verification.enabled {
+        let role = &config.role_models.verifier;
+        match build_provider(&role.model, &role.provider, &config.openrouter_api_key).await {
+            Ok(p) => Some(p),
+            Err(e) => {
+                warn!("failed to build verifier provider (continuing without verification): {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let search = HttpSearchClient::from_config(&config);
+    let analyze = HttpAnalyzeClient::from_config(&config);
+
+    info!(
+        reviewer_model = %config.role_models.reviewer.model,
+        analyzer_url = %config.analyzer_url,
+        search_url = %config.search_url,
+        "trusty-review embedded AppState built"
+    );
+
+    Ok(AppState::with_verifier_and_dedup(
+        config,
+        llm,
+        verifier,
+        Arc::new(search),
+        Some(Arc::new(analyze)),
+        None,
+    ))
 }
 
 // ─── Dispatcher ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #630.

## What

Embeds the **trusty-review** LLM PR-review pipeline into the **trusty-analyze** MCP server as three new tools, behind an optional `review` cargo feature (OFF by default):

| Tool | Delegates to | Purpose |
|---|---|---|
| `tr_review_pr` | `review_pr` | LLM review of a GitHub PR by owner/repo/number |
| `tr_review_diff` | `review_diff` | LLM review of a raw unified diff string |
| `tr_review_health` | `review_health` | Probe trusty-review liveness/config |

The `tr_` prefix avoids colliding with trusty-analyze's existing *deterministic* `review_diff` / `review_github_pr` tools (which forward to analyze's own `/review` HTTP endpoints).

## Design

- **Optional `review` feature** (`review = ["dep:trusty-review", "trusty-review/mcp"]`) — OFF by default, so `cargo install trusty-analyze` and the crates.io publish are unaffected and trusty-review need not be published.
- **Loopback analyze context**: the embedded `AppState` defaults `PR_INTELLIGENCE_ANALYZER_URL=http://localhost:7879` — the same daemon hosting the MCP server. The review pipeline calls analyze's `/analyze` endpoints (not `/review`), so there is no recursion and embedded reviews get **authoritative** static-analysis context rather than running degraded.
- **Lazy AppState**: a process-wide `tokio::sync::OnceCell` builds the trusty-review `AppState` (AWS-cred / provider load is expensive) at most once, on the first review tool call.
- **Reusable embedding entry**: new `trusty_review::mcp::build_review_state()` assembles the `AppState` from env+config using only library-public builders; `tools::call_tool`, `tools::ToolError`, and `service::AppState` are re-exported as `trusty_review::mcp::*` for the host.
- **Always dry-run**: every embedded review handler runs with `allow_posting=false` — no GitHub comments are ever posted.

## 500-line cap (#610)

`crates/trusty-analyze/src/mcp/mod.rs` is on the shrink-only allowlist. To add the feature while NET-SHRINKING the file, the ~208-line inline `tool_descriptors()` JSON was extracted into a new `descriptors.rs` (`base_tool_descriptors()`):

- `mcp/mod.rs`: **1252 → 1178** lines (net −74, even after adding ~96 lines of new tests + feature wiring). Allowlist budget ratcheted 1252 → 1178.
- `mcp/descriptors.rs`: **234** lines (new).
- `mcp/review.rs`: **133** lines (new, `cfg(feature = "review")`).

`bash scripts/check_line_cap.sh` → `0 violations`.

## Tests

- `tools_list_includes_tr_review_tools` — feature ON: all three `tr_` tools advertised.
- `tr_review_health_routes_not_unknown_tool` — feature ON: `tr_*` names route into the pipeline (not METHOD_NOT_FOUND).
- `tr_review_tools_absent_when_feature_off` — feature OFF: names neither advertised nor routable.
- `review_descriptors_are_tr_prefixed_and_complete` — descriptor shape.

## Pre-flight (all green)

- `cargo build -p trusty-analyze --features review` ✅
- `cargo build -p trusty-analyze` (feature off) ✅
- `cargo fmt --check` ✅
- `cargo clippy -p trusty-analyze --features review --all-targets -- -D warnings` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (exit 0)
- `cargo test -p trusty-analyze --features review` ✅ 340 passed
- `cargo test -p trusty-review --features mcp` ✅ 561 passed
- `cargo check --workspace` ✅
- `bash scripts/check_line_cap.sh` ✅ 0 violations

## Publish impact

None — `review` is off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)