### PR TITLE
fix(trusty-memory): accept optional palace param on add_alias + discover_aliases

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -107,7 +107,7 @@ crates/trusty-memory/src/messaging.rs	843
 crates/trusty-memory/src/project_root.rs	980
 crates/trusty-memory/src/prompt_log.rs	851
 crates/trusty-memory/src/service.rs	1704
-crates/trusty-memory/src/tools.rs	3575
+crates/trusty-memory/src/tools.rs	3629
 crates/trusty-memory/src/transport/rpc.rs	571
 crates/trusty-memory/src/web.rs	5396
 crates/trusty-memory/tests/concurrent_perf.rs	1163

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -309,6 +309,15 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
     } else {
         vec!["palace", "content"]
     };
+    // Issue #664: add_alias and discover_aliases both call resolve_palace() but
+    // previously omitted `palace` from their schemas, making them uncallable
+    // without a server-side default. Now follow the memory_remember pattern.
+    let add_alias_required: Vec<&str> = if has_default {
+        vec!["short", "full"]
+    } else {
+        vec!["palace", "short", "full"]
+    };
+    let discover_aliases_required: Vec<&str> = if has_default { vec![] } else { vec!["palace"] };
 
     json!({
         "tools": [
@@ -492,11 +501,12 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                 "inputSchema": {
                     "type": "object",
                     "properties": {
+                        "palace": {"type": "string", "description": "Palace ID (optional if server started with --palace)"},
                         "short": {"type": "string", "description": "Short name / alias (subject)"},
                         "full":  {"type": "string", "description": "Full / canonical name (object)"},
                         "extra": {"type": "string", "description": "Optional extra context appended to the full name"}
                     },
-                    "required": ["short", "full"],
+                    "required": add_alias_required,
                 }
             },
             {
@@ -535,8 +545,10 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                 "inputSchema": {
                     "type": "object",
                     "properties": {
+                        "palace": {"type": "string", "description": "Palace ID (optional if server started with --palace)"},
                         "project_root": {"type": "string", "description": "Optional filesystem path to scan. Defaults to the process cwd."}
-                    }
+                    },
+                    "required": discover_aliases_required,
                 }
             },
             {
@@ -2355,6 +2367,10 @@ mod tests {
             ("palace_compact", true),
             ("kg_assert", true),
             ("kg_query", true),
+            // Issue #664: add_alias and discover_aliases now include `palace`
+            // in their schema and follow the same conditional-required pattern.
+            ("add_alias", true),
+            ("discover_aliases", true),
         ] {
             for (defs, has_default) in [(&with_default, true), (&without_default, false)] {
                 let tools = defs["tools"].as_array().unwrap();
@@ -2752,6 +2768,43 @@ mod tests {
         .await
         .expect("remove_prompt_fact missing");
         assert_eq!(missing["removed"], false);
+    }
+
+    /// Why (issue #664): `add_alias` must accept an explicit `palace` arg when
+    /// the server has no `--palace` default, and reject with a clear error when
+    /// both are absent.
+    /// What: (a) explicit palace succeeds and refreshes the cache; (b) no
+    /// palace + no default returns an error mentioning both `palace` and
+    /// `add_alias`.
+    /// Test: this function.
+    #[tokio::test]
+    async fn add_alias_palace_arg_required_without_server_default() {
+        // (a) explicit palace succeeds — use test_state() so palace-name
+        // enforcement is bypassed (sets TRUSTY_SKIP_PALACE_ENFORCEMENT=1).
+        let (state, _tmp) = test_state();
+        dispatch_tool(&state, "palace_create", json!({"name": "p"}))
+            .await
+            .expect("palace_create");
+        let added = dispatch_tool(
+            &state,
+            "add_alias",
+            json!({"palace": "p", "short": "tga", "full": "trusty-git-analytics"}),
+        )
+        .await
+        .expect("add_alias with explicit palace");
+        assert_eq!(added["asserted"], true);
+        let guard = state.prompt_context_cache.read().await;
+        assert!(guard.formatted.contains("tga → trusty-git-analytics"));
+
+        // (b) no palace + no default → clear error (state2 has no default_palace).
+        drop(guard);
+        let (state2, _tmp2) = test_state();
+        let err = dispatch_tool(&state2, "add_alias", json!({"short": "x", "full": "y"}))
+            .await
+            .expect_err("should fail without palace");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("palace"), "error must mention 'palace': {msg}");
+        assert!(msg.contains("add_alias"), "error must name tool: {msg}");
     }
 
     /// Why (issue #42): `get_prompt_context` is the per-message replacement


### PR DESCRIPTION
## Summary

- **Root cause**: `add_alias` and `discover_aliases` both call `resolve_palace()` in their handlers but their MCP input schemas omitted `palace` from `inputSchema.properties` entirely — making both tools uncallable when the server has no `--palace` default configured. Callers had no way to pass a palace even though the handler required one.
- **Fix**: Add `palace` to both schemas and follow the established `memory_remember` pattern — conditional `required` via `add_alias_required` / `discover_aliases_required` vectors in `tool_definitions_with()`: required when `has_default=false`, absent when `has_default=true`.
- **Audit**: `list_prompt_facts`, `remove_prompt_fact`, and `get_prompt_context` are NOT affected — they operate across all palaces or from the server-side prompt cache with no per-call palace resolution.

Closes #664.

## Changes

`crates/trusty-memory/src/tools.rs` (`tools::tool_definitions_with`, line ~306):
- Added `add_alias_required` conditional vector (palace required when no server default)
- Added `discover_aliases_required` conditional vector (palace required when no server default)
- Added `"palace"` property to `add_alias` inputSchema
- Added `"palace"` property to `discover_aliases` inputSchema (with `required` field)
- Extended `tool_definitions_drops_palace_required_when_default_set` test to cover `add_alias` and `discover_aliases`
- Added `add_alias_palace_arg_required_without_server_default` test covering: (a) explicit palace succeeds; (b) no palace + no default → clear error

`.line-cap-allowlist.tsv`: bumped `crates/trusty-memory/src/tools.rs` budget 3575 → 3629 (intentional growth for fix + test).

## Test plan

- [x] `cargo test -p trusty-memory` — 342 pass, 7 pre-existing failures (unchanged, unrelated to this PR: `project_slug`, `inbox_check`, `messaging`, `prompt_context` features)
- [x] New test `add_alias_palace_arg_required_without_server_default` passes: explicit palace works; missing palace+no default returns clear error
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p trusty-memory` — no formatting drift
- [x] `bash scripts/check_line_cap.sh` — 172 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)