### PR TITLE
chore(release): trusty-common 0.12.0 / trusty-search 0.23.0 / trusty-memory 0.15.0 / trusty-analyze 0.5.0 / trusty-review 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10686,7 +10686,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10774,7 +10774,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10900,7 +10900,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11002,7 +11002,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11043,7 +11043,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.22.4"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 
 [workspace.dependencies]
 # ── Internal crates (path deps so the monorepo builds without publish cycles) ──
-trusty-common = { path = "crates/trusty-common", version = "0.11.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.12.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.1" }
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.1.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.2.0" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/open-mpm/Cargo.toml
+++ b/crates/open-mpm/Cargo.toml
@@ -43,8 +43,8 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      `default-features = false` drops the `axum-server` feature so we don't
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
-trusty-memory = { path = "../trusty-memory", version = "0.14.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.22.0" }
+trusty-memory = { path = "../trusty-memory", version = "0.15.0", default-features = false }
+trusty-search = { path = "../trusty-search", version = "0.23.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -7,7 +7,29 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
-## [Unreleased]
+## [0.5.0] — 2026-06-03
+
+### Added
+
+- **redb 4.x + facts store recovery** (#702) — facts store upgraded to redb 4.x
+  with graceful incompatible-file recovery: existing redb 2.x `facts.redb` is
+  backed up to `facts.redb.v2-incompatible` and recreated on first start.
+
+- **Optional `review` feature exposing trusty-review MCP tools** (#630/#631) —
+  a new `review` Cargo feature wires trusty-review's MCP tool surface into the
+  trusty-analyze daemon, enabling PR-review tools without a separate process.
+
+- **On-demand SubprocessAnalyzeClient + facts store** (#632) — the analysis
+  client now supports on-demand subprocess invocation for environments where a
+  persistent daemon is not running.
+
+- **Dashboard auto-start** (#684) — the web UI dashboard auto-starts on first
+  daemon launch without requiring a manual invocation.
+
+> **OPERATOR NOTE:** Existing `facts.redb` is backed up to
+> `facts.redb.v2-incompatible` and recreated empty on first start after upgrade.
+> No analysis history is stored in the facts store; only user-authored facts are
+> affected.
 
 ---
 

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.4.2"
+version     = "0.5.0"
 edition     = "2021"
 license     = "MIT"
 authors.workspace    = true

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — trusty-common
 
+## [0.12.0] — 2026-06-03
+
+### Changed
+
+- **redb 2.6 → 4.1 upgrade** (#702) — all stores upgraded to redb 4.x API.
+  Graceful old-format recovery at every store open: existing `.redb` files
+  written by redb 2.x are detected as incompatible, backed up to
+  `*.v2-incompatible`, and recreated automatically. No manual intervention
+  required.
+
+- **Memory recall ranked by similarity score** (#633) — recall results are
+  now sorted by embedding similarity score (descending) rather than insertion
+  order, surfacing the most relevant memories first.
+
+> **OPERATOR NOTE:** Existing palace `.redb` files are detected as incompatible
+> on first open, backed up to `*.v2-incompatible`, and recreated empty.
+> Re-populating palace data requires re-importing or re-creating memories.
+
 ## [0.11.1] — 2026-06-02
 
 ### Fixed

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.11.1"
+version = "0.12.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -14,7 +14,7 @@ name = "gworkspace-mcp"
 path = "src/bin/gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.11.0", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.12.0", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -1,15 +1,32 @@
 # Changelog — trusty-memory
 
-## [Unreleased]
+## [0.15.0] — 2026-06-03
 
 ### Added
+
+- **redb 4.x + graceful recovery for activity/store** (#702) — all embedded redb
+  stores upgraded to redb 4.x. Existing redb 2.x activity and memory stores are
+  detected as incompatible, backed up to `*.v2-incompatible`, and recreated on
+  first start.
+
+- **Dashboard auto-start** (#687) — the web UI dashboard auto-starts on first
+  daemon launch without requiring a manual invocation.
+
+- **add_alias/discover_aliases optional palace param** (#664) — the
+  `add_alias` and `discover_aliases` MCP tools now accept an optional `palace`
+  parameter to scope alias operations to a specific palace.
+
 - Bundled `trusty-bm25-daemon` as a second binary target. One
   `cargo install trusty-memory` now produces three binaries:
   `trusty-memory`, `trusty-memory-mcp-bridge`, and `trusty-bm25-daemon`.
   Users who set `TRUSTY_BM25_DAEMON=1` no longer need a separate
   `cargo install trusty-bm25-daemon` step.
+
 - `locate_bm25_daemon_binary()` in `trusty-common::bm25_client` (behind
   the `bm25-client` feature flag). Discovery order: `TRUSTY_BM25_DAEMON_BIN`
   env var, sibling of `current_exe()` (bundled-install path), then PATH.
   The `current_exe().parent()` fallback ensures the bundled-install case
   works without `~/.cargo/bin` on PATH globally.
+
+> **OPERATOR NOTE:** Existing redb stores are backed up to `*.v2-incompatible`
+> and recreated empty on first start after upgrade.

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license = "MIT"
@@ -69,7 +69,7 @@ path = "src/bin/bm25_daemon.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.11.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture"] }
+trusty-common = { path = "../trusty-common", version = "0.12.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog — trusty-review
+
+All notable changes to trusty-review are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [0.2.0] — 2026-06-03
+
+### Added
+
+- **Map-reduce review Phase 1: config + selector** (#690) — structured
+  map-reduce review pipeline with per-file configuration and selector logic
+  to route files to the appropriate review strategy.
+
+- **Map-reduce review Phase 2: per-file diff splitter** (#698) — per-file
+  diff splitter that partitions large diffs into reviewable chunks, enabling
+  reviews on PRs that exceed the single-pass diff cap.
+
+- **Auto-derive search index from repo root** (#661) — the reviewer now
+  auto-detects the trusty-search index ID from the repository root path,
+  eliminating manual index configuration for standard installations.
+
+- **Daemon http_addr discovery + auto-detect** (#665/#676) — the review
+  daemon discovers the trusty-search HTTP address automatically via the
+  port-lock file; manual `--search-url` override still supported.
+
+- **list_indexes envelope parse + resolve_index wiring** (#672/#670) —
+  MCP tool `list_indexes` correctly parses the response envelope and
+  `resolve_index` is wired into the review pipeline.
+
+- **GitHub Issues query cap 256 chars** (#675) — GitHub Issues search
+  queries are now capped at 256 characters to stay within API limits.
+
+- **BrokenPipe on stdin treated non-fatal** (#702) — a broken pipe on
+  the MCP stdio transport is treated as a clean client disconnect rather
+  than a crash, improving robustness in CI and pipe-based invocations.
+
+- **redb 4.x dedup store recovery** (#702) — the dedup claim store is
+  upgraded to redb 4.x with graceful incompatible-file recovery: existing
+  redb 2.x `dedup.redb` is backed up and recreated automatically.
+
+> **OPERATOR NOTE:** Existing `dedup.redb` is backed up to
+> `dedup.redb.v2-incompatible` and recreated on first start after upgrade.
+> The dedup store only tracks posted reviews (SHA-keyed claim locks), not
+> review history or results — no review content is lost.
+
+---
+
+## [0.1.0] — 2026-05-28
+
+### Added
+
+- Initial release: LLM-backed PR-review service with GitHub App auth,
+  MCP stdio JSON-RPC service, diff analysis with noise filtering,
+  context orchestration, and dedup claim store.

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.1.0"
+version     = "0.2.0"
 edition     = "2024"
 rust-version.workspace = true
 license-file           = "LICENSE"

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,49 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.23.0] — 2026-06-03
+
+### Changed
+
+- **redb 4.x + incompatible-corpus backup/rebuild on open** (#702) — index.redb
+  and kg.redb are upgraded to redb 4.x. Existing redb 2.x files are detected as
+  incompatible, backed up to `*.v2-incompatible`, and rebuilt (reindex triggered
+  automatically). Possible multi-minute reindex window on first start after upgrade.
+
+- **TRUSTY_HNSW_MMAP_SERVE (default on)** (#709) — warm-booted HNSW snapshots
+  are now served directly from the mmap page cache, significantly reducing RSS.
+  Promotion to a heap-resident copy is deferred until the first write. Disable with
+  `TRUSTY_HNSW_MMAP_SERVE=0` on NFS/EFS-backed storage where cold page-fault
+  latency matters more than RSS.
+
+- **TRUSTY_VECTOR_QUANT (f16/i8)** (#712) — optional vector quantization for new
+  HNSW indexes: `f16` (≈2× smaller, small recall cost) or `i8` (≈4× smaller,
+  larger recall cost). Requires a forced reindex to take effect on existing indexes.
+
+- **Persistent reindex hash cache** (#662) — content-hash cache for incremental
+  reindex is now stored on disk and survives daemon restarts, avoiding unnecessary
+  re-embedding on startup.
+
+- **Dashboard auto-start** (#686) — the web UI dashboard auto-starts on first
+  daemon launch without requiring a manual `trusty-search ui` invocation.
+
+- **Bulk select/delete/reindex + Documents=0 fix** (#683) — UI and API support
+  bulk operations; fixed a regression where new indexes incorrectly reported 0
+  documents.
+
+- **GET /indexes?details=true root_path** (#661) — the index list endpoint now
+  accepts `details=true` to include `root_path` for each index.
+
+- **Portable-paths fix + migration M004 schema 3→4** (#674) — index paths are
+  now stored in a platform-portable form; M004 migration runs automatically on
+  first start (non-destructive and idempotent).
+
+> **OPERATOR NOTES:**
+> 1. Existing `index.redb` and `kg.redb` files are redb 2.x and will be backed up
+>    to `*.v2-incompatible` and rebuilt (reindex) on first start after upgrade.
+>    Expect a multi-minute reindex window for large indexes.
+> 2. Migration M004 runs automatically, is non-destructive, and is idempotent.
+
 ## [0.22.3] - 2026-06-02
 
 ### Fixed

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.22.4"
+version = "0.23.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -48,7 +48,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.11.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
+trusty-common = { version = "0.12.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 
 # ── Bundled sidecar ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue

--- a/crates/trusty-search/ui/pnpm-workspace.yaml
+++ b/crates/trusty-search/ui/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true


### PR DESCRIPTION
## Summary

Coordinated version-bump + CHANGELOG PR for the redb 4.x + feature release wave. **Publish in checkpoint 2** after this merges.

### Version bumps

| Crate | Old | New |
|---|---|---|
| trusty-common | 0.11.1 | 0.12.0 |
| trusty-search | 0.22.4 | 0.23.0 |
| trusty-memory | 0.14.0 | 0.15.0 |
| trusty-analyze | 0.4.2 | 0.5.0 |
| trusty-review | 0.1.0 | 0.2.0 |

Also updated internal dep pins: workspace `[workspace.dependencies]` trusty-common→0.12.0 and trusty-review→0.2.0; trusty-gworkspace, trusty-search, trusty-memory explicit pins; open-mpm correctness pins.

### Changelog highlights

**trusty-common 0.12.0** — redb 2.6→4.1 upgrade + graceful old-format recovery at every store open (incompatible files backed up to `*.v2-incompatible` and recreated) (#702); memory recall ranks by similarity score (#633).

> OPERATOR NOTE: Existing palace `.redb` files are detected incompatible, backed up, and recreated.

**trusty-search 0.23.0** — redb 4.x + incompatible-corpus backup/rebuild on open (#702); `TRUSTY_HNSW_MMAP_SERVE` (default on) — serve HNSW from mmap page cache, lower RSS (#709); `TRUSTY_VECTOR_QUANT` (f16/i8) optional vector quantization (#712); persistent reindex hash cache (#662); dashboard auto-start (#686); bulk select/delete/reindex + Documents=0 fix (#683); `GET /indexes?details=true` root_path (#661); portable-paths fix + migration M004 schema 3→4 (#674).

> OPERATOR NOTES: (1) Existing `index.redb`/`kg.redb` are redb 2.x and will be backed up to `*.v2-incompatible` and rebuilt (reindex) on first start — possible multi-minute reindex window; (2) M004 runs automatically, non-destructive/idempotent.

**trusty-memory 0.15.0** — redb 4.x + graceful recovery for activity/store (#702); dashboard auto-start (#687); add_alias/discover_aliases optional palace param (#664).

> OPERATOR NOTE: Existing redb stores backed up + recreated on first start.

**trusty-analyze 0.5.0** — redb 4.x + facts store recovery (#702); optional `review` feature exposing trusty-review MCP tools (#630/#631); on-demand SubprocessAnalyzeClient + facts store (#632); dashboard auto-start (#684).

> OPERATOR NOTE: Existing `facts.redb` backed up + recreated on first start.

**trusty-review 0.2.0** — map-reduce review Phase 1 config+selector (#690) and Phase 2 per-file splitter (#698); auto-derive search index from repo root (#661); daemon http_addr discovery + auto-detect (#665/#676); list_indexes envelope parse + resolve_index wiring (#672/#670); GitHub Issues query cap 256 chars (#675); BrokenPipe-on-stdin treated non-fatal (#702); redb 4.x dedup store recovery (#702).

> OPERATOR NOTE: Existing `dedup.redb` backed up + recreated (only tracks posted reviews; no review history lost).

### UI prep

- trusty-search ui-dist rebuilt (pnpm esbuild approved in pnpm-workspace.yaml).

## Test plan

- [ ] `cargo fmt --check` — passed
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — passed (0 errors, pre-existing tga MSRV warning only)
- [ ] `cargo test -p trusty-common -p trusty-search -p trusty-memory -p trusty-analyze -p trusty-review` — 591+339+13+6 passed; pre-existing trusty-memory project_slug failures (environment-specific: tempdir inside worktree finds Cargo.toml parent; pass in CI)
- [ ] `bash scripts/check_line_cap.sh` — passed (172 allowlisted, 0 violations)
- [ ] `cargo build --workspace` — passed (Finished dev profile)
- [ ] `cargo publish --dry-run --allow-dirty -p trusty-common` — packaged 117 files, 2.2MiB, verified compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)