### PR TITLE
ops(trusty-search): production systemd unit with graceful-stop tuning (mitigates #694)

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,146 @@
+# trusty-search systemd unit
+
+Production systemd unit for the `trusty-search` HTTP daemon on Linux/EC2 (EBS).
+
+## Why this unit exists (#694)
+
+On the Duetto EC2/EBS fleet, an abrupt SIGKILL during a shutdown flush
+corrupted `index.redb` (unrecoverable).  Two mitigations were already shipped:
+
+1. **redb 4.x** (trusty-common 0.12+) defaults to `Durability::Immediate` —
+   every commit is fully fsynced before the call returns, so a crash between
+   commits leaves the database in a clean prior state rather than a torn write.
+2. **Graceful SIGTERM drain** (#534) — the daemon finishes all in-flight axum
+   HTTP requests before exiting, so searches and reindex jobs land cleanly.
+
+This unit adds the third layer: `TimeoutStopSec=120` gives the daemon 120
+seconds after SIGTERM before systemd escalates to SIGKILL.  Without a generous
+stop timeout, systemd defaults to 90 s — potentially interrupting a slow EBS
+fsync mid-transaction.
+
+Pair with **EBS snapshots -> S3** for point-in-time volume-level recovery
+(issue #704): graceful stop prevents corruption, but only volume backups
+protect against accidental deletion or volume failure.
+
+## Prerequisites
+
+1. **Binary installed** on the target host (typically via
+   `cargo install trusty-search --locked`), default path `/usr/local/bin/trusty-search`.
+2. **`trusty-embedderd` installed** alongside it:
+   `cargo install trusty-embedderd --locked`.
+3. **Service account** created:
+   ```bash
+   useradd --system --no-create-home --shell /sbin/nologin trusty
+   ```
+4. **EBS data directory** created and owned by the service account:
+   ```bash
+   mkdir -p /data/trusty-search
+   chown trusty:trusty /data/trusty-search
+   ```
+
+## Install
+
+```bash
+# Copy the unit file
+sudo cp deploy/systemd/trusty-search.service /etc/systemd/system/
+
+# Review and adjust placeholders (binary path, User/Group, WorkingDirectory,
+# TRUSTY_DATA_DIR, port) before enabling.
+
+# Reload systemd and enable + start the service
+sudo systemctl daemon-reload
+sudo systemctl enable --now trusty-search
+
+# Verify it is running
+sudo systemctl status trusty-search
+journalctl -u trusty-search -f
+```
+
+## Graceful restart (the safe way)
+
+```bash
+sudo systemctl restart trusty-search
+```
+
+`systemctl restart` sends SIGTERM and waits up to `TimeoutStopSec=120` for the
+daemon to shut down cleanly before starting the new process.  This is safe to
+run at any time, including during an active reindex — the daemon will complete
+the current redb transaction and fsync before exiting.
+
+For a zero-downtime rolling upgrade, stop the old daemon first, install the new
+binary, then start:
+
+```bash
+sudo systemctl stop trusty-search    # waits for graceful shutdown (up to 120 s)
+cargo install trusty-search --locked # or copy the new binary to /usr/local/bin/
+sudo systemctl start trusty-search
+```
+
+## Stop and verify clean shutdown
+
+```bash
+sudo systemctl stop trusty-search
+# systemd sends SIGTERM and waits up to TimeoutStopSec=120 before SIGKILL.
+# A clean shutdown logs: "graceful shutdown complete" at INFO level.
+journalctl -u trusty-search --since "1 minute ago"
+```
+
+## Key directives and rationale
+
+| Directive | Value | Rationale |
+|---|---|---|
+| `KillSignal` | `SIGTERM` | Explicit graceful-stop signal; daemon's SIGTERM handler (#534) drains requests then exits. |
+| `TimeoutStopSec` | `120` | **#694 mitigation**: 120 s budget for in-flight HTTP drain + redb Immediate fsync on EBS before SIGKILL escalation. |
+| `Type` | `simple` | Daemon stays in foreground via `--foreground`; does not use sd_notify. |
+| `Restart` | `on-failure` | Automatic restart on crashes; no restart on clean `systemctl stop`. |
+| `LimitNOFILE` | `65536` | Raised for mmap-heavy redb files + HNSW snapshots + HTTP keep-alive sockets. |
+
+## Foreground invocation
+
+systemd requires the supervised process to remain in the foreground.
+`trusty-search start` (without flags) self-forks a detached background child
+and returns immediately — that mode is **wrong** for systemd.
+
+The `--foreground` flag (added alongside issue #534) keeps the daemon in the
+foreground:
+
+```
+ExecStart=/usr/local/bin/trusty-search start --foreground --no-auto-discover --port 7878
+```
+
+## Environment variables
+
+Edit the `Environment=` lines in the unit file to match your deployment:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `RUST_LOG` | recommended | Log level (`info` for production, `debug` for bring-up). |
+| `TRUSTY_DATA_DIR` | **required on EC2** | Absolute path to the EBS data directory (indexes.toml, redb files, HNSW snapshots). |
+| `TRUSTY_EMBEDDERD_BIN` | if not on PATH | Absolute path to the `trusty-embedderd` sidecar binary. |
+| `TRUSTY_DEVICE` | optional | `auto` (default), `cpu`, or `gpu`. |
+| `TRUSTY_NO_KG` | optional | Set `1` to disable the Knowledge Graph on all indexes. |
+| `TRUSTY_MEMORY_LIMIT_MB` | optional | Override auto-tuned RSS ceiling (MiB). |
+| `TRUSTY_GPU_MEM_LIMIT_BYTES` | CUDA hosts | VRAM ceiling in bytes; default 12 GiB (safe for 16 GB T4). |
+| `ORT_DYLIB_PATH` | Amazon Linux 2023 + CUDA | Path to `libonnxruntime.so` (required when glibc < 2.38). |
+
+## Troubleshooting
+
+```bash
+# Live log stream
+journalctl -u trusty-search -f
+
+# Check daemon health via CLI (from any shell on the same host)
+trusty-search status
+
+# Check listening port
+trusty-search port
+
+# Verify health endpoint
+curl http://127.0.0.1:$(trusty-search port)/health
+```
+
+If the daemon exits immediately with a non-zero code, check:
+- Binary path in `ExecStart` exists and is executable.
+- `TRUSTY_DATA_DIR` directory exists and is writable by `User=trusty`.
+- `trusty-embedderd` is on PATH or `TRUSTY_EMBEDDERD_BIN` is set.
+- System has at least 16 GB RAM (enforced at daemon startup).

--- a/deploy/systemd/trusty-search.service
+++ b/deploy/systemd/trusty-search.service
@@ -1,0 +1,165 @@
+# trusty-search.service — production systemd unit for the trusty-search HTTP daemon
+#
+# ISSUE CONTEXT
+# -------------
+# Issue #694: an abrupt SIGKILL during shutdown while redb was mid-flush
+# truncated index.redb, leaving the index unrecoverable on Duetto EC2/EBS.
+# Root mitigations already shipped:
+#   - redb 4.x (trusty-common 0.12+) defaults to Durability::Immediate (fsync
+#     after every commit), so partial writes are far less likely to corrupt.
+#   - Graceful SIGTERM drain was added in #534: the daemon finishes in-flight
+#     axum requests before exiting.
+# THIS UNIT seals the gap: TimeoutStopSec gives the daemon enough wall-clock
+# time to drain HTTP requests AND let redb's fsync complete before systemd
+# escalates to SIGKILL.  Without a generous timeout, systemd would SIGKILL
+# after its default 90 s — potentially mid-fsync on a busy EBS volume.
+#
+# Issue #704 (EBS durability): this unit handles graceful stop.  Pair it with
+# scheduled EBS snapshots → S3 for point-in-time recovery.  Graceful stop is
+# necessary but not sufficient — volume-level backups are the durability layer.
+#
+# INSTALLATION
+# ------------
+# See README.md in this directory for the full install + restart workflow.
+#
+# FOREGROUND MODE
+# ---------------
+# `trusty-search start` (no flags) self-forks a detached background child and
+# returns immediately — wrong for systemd, which requires the supervised
+# process to stay in the foreground.  Use `trusty-search start --foreground`
+# (added alongside issue #534).  systemd manages the lifecycle; the daemon
+# must not fork itself.
+
+[Unit]
+Description=trusty-search hybrid code-search daemon (BM25 + vector + KG)
+# Wait for the network stack to be fully up before starting.
+# Why: the daemon binds a TCP port and connects to trusty-embedderd over a
+# UDS socket; starting before the loopback interface is ready is harmless
+# but logs spurious bind-retry noise.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# ── Process type ─────────────────────────────────────────────────────────────
+# Type=simple: systemd considers the service started as soon as ExecStart
+# forks.  The daemon does NOT call sd_notify(), so Type=notify is incorrect.
+# Type=forking is also wrong: --foreground keeps the daemon in the foreground
+# rather than double-forking.
+Type=simple
+
+# ── Identity ─────────────────────────────────────────────────────────────────
+# Run as a dedicated non-root user.  Create this user before enabling the unit:
+#   useradd --system --no-create-home --shell /sbin/nologin trusty
+# Adjust Group= if your deployment uses a shared data group for the EBS mount.
+User=trusty
+Group=trusty
+
+# ── Binary ───────────────────────────────────────────────────────────────────
+# Adjust the path to match where `cargo install trusty-search` placed the
+# binary on this host (typically /usr/local/bin or ~/.cargo/bin for the trusty
+# user).  Use an absolute path; systemd does not search PATH for ExecStart.
+#
+# --foreground: required — keeps the process in the foreground so systemd owns
+#               its lifecycle.  Without this flag, the daemon self-forks and
+#               systemd loses track of the PID.
+# --no-auto-discover: suppresses the startup scan that walks scan_paths and
+#               indexes every git repo it finds.  On EC2, auto-discovery should
+#               be off by default; register indexes explicitly with
+#               `trusty-search index <path>`.
+# --port 7878: explicit port; change to match your deployment or omit to use
+#               the compiled-in default (7878).
+ExecStart=/usr/local/bin/trusty-search start \
+    --foreground \
+    --no-auto-discover \
+    --port 7878
+
+# ── Graceful shutdown (#694 mitigation) ──────────────────────────────────────
+# KillSignal=SIGTERM: instruct systemd to send SIGTERM first (graceful).  This
+# is systemd's default, but stated explicitly so the intent is unambiguous.
+# The daemon's SIGTERM handler (issue #534) drains in-flight HTTP requests and
+# waits for redb to finish its current fsync before exiting.
+KillSignal=SIGTERM
+
+# TimeoutStopSec=120: THIS IS THE PRIMARY #694 MITIGATION.
+# After SIGTERM, systemd waits this many seconds before escalating to SIGKILL.
+# 120 s gives the daemon time to:
+#   1. Finish all in-flight HTTP search/reindex requests (drain phase, #534).
+#   2. Let redb complete its Durability::Immediate fsync to the EBS volume.
+#      EBS throughput can be low under concurrent I/O; a 120 s budget is
+#      generous for any realistic redb write set.  If a reindex is mid-flight
+#      when the stop arrives, the pipeline will either complete its current
+#      batch or be aborted cleanly by the shutdown signal — either way redb
+#      commits only full, fsynced transactions.
+# Without this timeout, systemd defaults to 90 s — tight for a heavily loaded
+# EBS volume.  Increase further (e.g. 300 s) if reindexing very large
+# codebases simultaneously with a stop is expected.
+TimeoutStopSec=120
+
+# ── Restart policy ───────────────────────────────────────────────────────────
+# Restart on abnormal exits (crash, OOM) but not on clean exit (systemctl stop).
+Restart=on-failure
+# Wait 5 s before restarting to avoid thundering-herd on a broken embedder or
+# OOM condition.  Increase if the daemon is crashlooping due to a transient
+# resource spike.
+RestartSec=5
+
+# ── Working directory ─────────────────────────────────────────────────────────
+# Set to the EBS mount point that holds the index data (redb files, HNSW
+# snapshots, indexes.toml).  The daemon resolves TRUSTY_DATA_DIR relative to
+# this directory when the env var is set to a relative path.  Using an absolute
+# path in TRUSTY_DATA_DIR (recommended) makes WorkingDirectory advisory only,
+# but it is good practice to set it to the data volume nonetheless.
+WorkingDirectory=/data/trusty-search
+
+# ── Environment ──────────────────────────────────────────────────────────────
+# Core logging level.  Use debug for initial bring-up; info for steady state.
+Environment=RUST_LOG=info
+
+# TRUSTY_DATA_DIR: root for all daemon-owned data (indexes.toml, per-index
+# redb/HNSW data, lockfile, port discovery file).  Point this at the EBS
+# mount so index data survives instance replacement.
+# REQUIRED on EC2/EBS — do not leave as /tmp or the daemon's XDG default.
+Environment=TRUSTY_DATA_DIR=/data/trusty-search
+
+# TRUSTY_EMBEDDER: embedding back-end.  Default ("auto"/"stdio") spawns
+# trusty-embedderd as a stdio sidecar on the first embed request.  That binary
+# must be on PATH (or set TRUSTY_EMBEDDERD_BIN to its absolute path).
+# On GPU-equipped instances, set TRUSTY_DEVICE=gpu or leave as "auto".
+# Environment=TRUSTY_EMBEDDER=auto
+
+# TRUSTY_EMBEDDERD_BIN: absolute path to trusty-embedderd if not on PATH.
+# Environment=TRUSTY_EMBEDDERD_BIN=/usr/local/bin/trusty-embedderd
+
+# TRUSTY_DEVICE: embedding device.  "auto" (default) uses CUDA if available,
+# then CoreML on Apple Silicon, then CPU.  Set "cpu" to force CPU-only.
+# Environment=TRUSTY_DEVICE=auto
+
+# TRUSTY_NO_KG: set to "1" to disable the Knowledge Graph on every new index.
+# Saves memory and indexing time on hosts where KG is not needed.
+# Environment=TRUSTY_NO_KG=1
+
+# TRUSTY_MEMORY_LIMIT_MB: soft RSS ceiling for the indexing pipeline (MiB).
+# Auto-tuned from system RAM by default.  Override on constrained instances.
+# Environment=TRUSTY_MEMORY_LIMIT_MB=4096
+
+# TRUSTY_GPU_MEM_LIMIT_BYTES: CUDA VRAM ceiling in bytes (issue #600).
+# Default 12 GiB (12884901888), safe for a 16 GB Tesla T4.
+# Reduce for smaller cards: TRUSTY_GPU_MEM_LIMIT_MB=6144 for 8 GB.
+# Environment=TRUSTY_GPU_MEM_LIMIT_BYTES=12884901888
+
+# ORT_DYLIB_PATH: required on Amazon Linux 2023 (glibc < 2.38) with CUDA
+# builds.  Point to the system libonnxruntime.so installed from an ORT GPU
+# release tarball.  Not needed for CPU-only or default bundled-ORT builds.
+# Environment=ORT_DYLIB_PATH=/opt/onnxruntime/lib/libonnxruntime.so
+
+# ── File descriptor limit ─────────────────────────────────────────────────────
+# Raise the open-file limit.  The daemon holds mmap'd redb files (one per
+# index) plus HNSW snapshot files plus HTTP keep-alive sockets.  On a machine
+# with many indexes, the default system limit (1024) is easily exhausted.
+# 65536 is a common safe ceiling for daemons that use mmap-intensive workloads.
+LimitNOFILE=65536
+
+[Install]
+# Start this service when the system reaches multi-user (non-graphical) mode —
+# the standard target for daemon services on EC2 and other headless Linux hosts.
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `deploy/systemd/trusty-search.service`: a well-commented systemd unit for the trusty-search HTTP daemon on Linux/EC2 (EBS), tuned to prevent the redb truncation described in issue #694.
- Adds `deploy/systemd/README.md`: install guide, graceful-restart workflow, directive rationale, and environment variable reference.

## #694 Mitigation — how this unit prevents redb corruption

Issue #694: an abrupt SIGKILL mid-flush truncated `index.redb` on EBS (unrecoverable). Two prior mitigations shipped in trusty-common 0.12 / trusty-search 0.23:
1. **redb 4.x `Durability::Immediate`** — every commit is fully fsynced before returning; a crash between commits leaves the DB in a clean prior state.
2. **Graceful SIGTERM drain (#534)** — the daemon finishes in-flight axum requests before exiting.

This unit adds the third layer:
- `KillSignal=SIGTERM` — explicit; systemd sends SIGTERM first so the drain handler fires.
- `TimeoutStopSec=120` — 120 s between SIGTERM and the SIGKILL escalation; generous enough for in-flight HTTP drain + redb fsync on a loaded EBS volume. Without this, systemd's 90 s default could fire mid-fsync.

## Foreground invocation

`trusty-search start` (no flags) self-forks a background child — wrong for systemd. The `--foreground` flag (added alongside #534) keeps the process in the foreground, as confirmed by reading `src/commands/start.rs`.

`ExecStart` used:
```
/usr/local/bin/trusty-search start --foreground --no-auto-discover --port 7878
```

`--no-auto-discover` suppresses the startup scan that walks `scan_paths`; on EC2, index registration should be explicit.

## EBS durability note (#704)

This unit ensures graceful stop. Pair with scheduled EBS snapshots -> S3 for point-in-time volume recovery — noted in both the unit file and README.

## Test plan

- [ ] Copy unit to `/etc/systemd/system/`, `systemctl daemon-reload`, `systemctl enable --now trusty-search` — daemon starts and `systemctl status` shows `active (running)`.
- [ ] `systemctl stop trusty-search` — daemon exits cleanly within `TimeoutStopSec`; no SIGKILL in journal.
- [ ] `systemctl restart trusty-search` while a reindex is in progress — daemon completes current redb transaction, exits, restarts; `index.redb` intact.
- [ ] Verify `journalctl -u trusty-search` shows `INFO` log lines (no stdout pollution from `--foreground`).

Closes #694

Generated with Claude Code