### PR TITLE
feat(trusty-search): redb 2.x→4.x corpus migration tool (preserve data, avoid reindex) (#716)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -159,7 +159,7 @@ crates/trusty-search/src/core/repo_config.rs	573
 crates/trusty-search/src/core/search/hierarchy.rs	658
 crates/trusty-search/src/core/store.rs	1275
 crates/trusty-search/src/core/symbol_graph.rs	1667
-crates/trusty-search/src/main.rs	1225
+crates/trusty-search/src/main.rs	1243
 crates/trusty-search/src/mcp/tools.rs	2174
 crates/trusty-search/src/service/call_chain.rs	954
 crates/trusty-search/src/service/daemon.rs	774

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6576,7 +6576,7 @@ dependencies = [
  "petgraph 0.8.3",
  "rand 0.8.6",
  "ratatui",
- "redb",
+ "redb 4.1.0",
  "regex",
  "reqwest 0.12.28",
  "rust-embed",
@@ -7769,6 +7769,15 @@ name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "redb"
@@ -10709,7 +10718,7 @@ dependencies = [
  "open",
  "ort",
  "protobuf",
- "redb",
+ "redb 4.1.0",
  "reqwest 0.12.28",
  "rust-embed",
  "scip",
@@ -10813,7 +10822,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "ratatui",
- "redb",
+ "redb 4.1.0",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
@@ -10915,7 +10924,7 @@ dependencies = [
  "libc",
  "mime_guess",
  "open",
- "redb",
+ "redb 4.1.0",
  "reqwest 0.12.28",
  "rust-embed",
  "serde",
@@ -11021,7 +11030,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "jsonwebtoken",
- "redb",
+ "redb 4.1.0",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
@@ -11083,7 +11092,8 @@ dependencies = [
  "petgraph 0.6.5",
  "rand 0.8.6",
  "rayon",
- "redb",
+ "redb 2.6.3",
+ "redb 4.1.0",
  "regex",
  "reqwest 0.12.28",
  "serde",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -94,6 +94,15 @@ open = "5"
 # ── Storage / vector / KG / chunking ───────────────────────────────────────
 usearch = "2.25"
 redb = { workspace = true }
+# Why: the `migrate-redb` subcommand reads legacy redb 2.x corpora that redb 4.x
+# cannot open (`DatabaseError::UpgradeRequired`) and copies their rows into a new
+# redb 4.x file WITHOUT re-embedding. Pulling redb 2.6 in under the `redb2` alias
+# lets the binary link both the 2.x read engine and the 4.x write engine at once.
+# Not feature-gated: the tool must be present in every default `cargo install
+# trusty-search` so an operator who upgrades into the empty-recreate path can run
+# the data-preserving migration with zero extra build steps (redb is a pure-Rust
+# B-tree — no C deps — so the binary-size cost is small).
+redb2 = { package = "redb", version = "2.6" }
 dashmap = "5"
 petgraph = "0.6"
 lru = "0.12"

--- a/crates/trusty-search/src/commands/migrate_redb.rs
+++ b/crates/trusty-search/src/commands/migrate_redb.rs
@@ -1,0 +1,100 @@
+//! Handler for `trusty-search migrate-redb <path>`.
+//!
+//! Why: upgrading trusty-search to a release built on redb 4.x (#702 / #707)
+//! makes the daemon unable to open any `index.redb` written by the old redb 2.x
+//! build. The default auto-recovery moves the stale file aside and recreates an
+//! empty corpus, which forces a full reindex — and that reindex RE-EMBEDS every
+//! chunk (an ONNX forward pass per chunk), which is the slow part on a large
+//! corpus. This subcommand gives operators an explicit, data-preserving path:
+//! it copies the old 2.x corpus into a new 4.x corpus verbatim, so the index is
+//! preserved and nothing is re-embedded.
+//! What: `handle_migrate_redb` resolves the target `index.redb` path, runs
+//! [`crate::core::redb_migrate::migrate_redb_corpus`], and prints a human
+//! summary (tables copied + row counts, or an already-up-to-date no-op).
+//! Test: `cargo run -- migrate-redb <path>` against a 2.x corpus prints the
+//! per-table copy summary; the underlying copy logic is unit-tested in
+//! `core::redb_migrate::tests`.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::core::redb_migrate::{migrate_redb_corpus, MigrationOutcome};
+
+/// Run the `migrate-redb` subcommand against `path`.
+///
+/// Why: a single entry point the CLI dispatcher calls, keeping clap argument
+/// parsing in `main.rs` and the migration orchestration here.
+/// What: canonicalises the target path for clearer logging (best-effort — a
+/// non-existent canonical parent is tolerated), invokes the copy migration, and
+/// renders the outcome. Returns `Ok(())` on success (including the already-4.x
+/// no-op) and bubbles a contextual error otherwise so the central dispatcher
+/// prints the red-✗ line and picks the exit code.
+/// Test: exercised end-to-end by `cargo run -- migrate-redb <fixture>`; the
+/// migration itself is covered by `core::redb_migrate::tests`.
+pub fn handle_migrate_redb(path: PathBuf) -> Result<()> {
+    if !path.exists() {
+        anyhow::bail!(
+            "no file at {} — pass the path to an index.redb (or its \
+             .v2-incompatible backup)",
+            path.display()
+        );
+    }
+
+    println!(
+        "🔄 Migrating redb corpus at {} (preserving data, no re-embedding)…\n",
+        path.display().to_string().bold()
+    );
+
+    let outcome = migrate_redb_corpus(&path)
+        .with_context(|| format!("migrate redb corpus at {}", path.display()))?;
+
+    match outcome {
+        MigrationOutcome::AlreadyV4 => {
+            println!(
+                "{} {} already opens with redb 4.x — nothing to migrate.",
+                "·".dimmed(),
+                path.display()
+            );
+        }
+        MigrationOutcome::Migrated {
+            per_table,
+            total_rows,
+            backup,
+            schema_version,
+        } => {
+            for (name, rows) in &per_table {
+                let line = format!("  {name:<22} {rows:>10} rows");
+                if *rows > 0 {
+                    println!("{} {}", "✓".green(), line);
+                } else {
+                    println!("{} {}", "·".dimmed(), line.dimmed());
+                }
+            }
+            println!();
+            println!(
+                "{} Migrated {} rows across {} table(s) → redb 4.x.",
+                "✓".green(),
+                total_rows.to_string().bold(),
+                per_table.iter().filter(|(_, r)| *r > 0).count()
+            );
+            println!(
+                "{} Preserved schema_version = {} (in-app migrations M00x will run normally).",
+                "·".dimmed(),
+                schema_version
+            );
+            println!(
+                "{} Original 2.x corpus backed up at {}.",
+                "·".dimmed(),
+                backup.display().to_string().dimmed()
+            );
+            println!(
+                "\n{} Restart the daemon to pick up the migrated index — no reindex needed.",
+                "→".cyan()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/trusty-search/src/commands/mod.rs
+++ b/crates/trusty-search/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub mod init;
 pub mod integrate;
 pub mod list;
 pub mod migrate;
+pub mod migrate_redb;
 pub mod migrate_storage;
 pub mod monitor;
 pub mod port;

--- a/crates/trusty-search/src/core/mod.rs
+++ b/crates/trusty-search/src/core/mod.rs
@@ -15,6 +15,7 @@ pub mod migration;
 pub mod mmr;
 pub mod ner;
 pub mod project_config;
+pub mod redb_migrate;
 pub mod registry;
 pub mod repo_config;
 pub mod scip_ingest;

--- a/crates/trusty-search/src/core/redb_migrate/copy.rs
+++ b/crates/trusty-search/src/core/redb_migrate/copy.rs
@@ -1,0 +1,337 @@
+//! Table-copy engine for the redb 2.x → 4.x corpus migration.
+//!
+//! Why: the actual row-by-row copy (reading with the redb 2.6 engine, writing
+//! with the redb 4.x engine) is the bulk of the migration logic and is split
+//! out here so the orchestration in [`super`] stays focused on detection,
+//! backup, and atomic install (and so each file stays under the 500-line cap).
+//! What: defines the fixed table catalogue ([`CORPUS_TABLES`]) and the
+//! shape-specific copy helpers, plus the post-copy row-count verification and
+//! `_meta` schema-version read. [`copy_all_tables`] is the single entry point
+//! [`super::migrate_redb_corpus`] calls.
+//! Test: covered by the round-trip tests in `super::tests` (which exercise all
+//! three table shapes and the verification path) and the `#[ignore]`d
+//! real-corpus smoke test.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use redb::{ReadableDatabase, ReadableTableMetadata as _};
+use redb2::ReadableTable as _;
+
+// ── Table catalogue ─────────────────────────────────────────────────────────
+
+/// Every redb table the trusty-search corpus persists, paired with its
+/// key/value shape.
+///
+/// Why: redb enforces the stored `TypeName` on `open_table`, so a table cannot
+/// be copied through a generic `&[u8]→&[u8]` view if it was declared `&str→…`.
+/// Enumerating the fixed, known schema lets us open each side with the exact
+/// matching typed `TableDefinition` on both the 2.x read and 4.x write engines.
+/// The three shapes mirror the definitions in `core::corpus` and
+/// `core::migration`: most tables are `&str → &[u8]`; the two legacy community
+/// tables are `u64 → &[u8]` and `&str → u64`.
+/// What: a `Shape` discriminant per table name. `migrate_redb_corpus` copies
+/// every catalogued table that exists in the source; tables absent from the
+/// source are silently skipped (an old corpus need not have every table).
+/// Test: the round-trip test seeds tables of all three shapes and asserts they
+/// all survive.
+#[derive(Clone, Copy)]
+enum Shape {
+    /// `&str → &[u8]` — chunks, entities, kg_nodes, kg_edges, kg_edges_rev,
+    /// file_hashes, _meta.
+    StrBytes,
+    /// `u64 → &[u8]` — kg_communities (legacy, migration-tolerance).
+    U64Bytes,
+    /// `&str → u64` — kg_symbol_community (legacy, migration-tolerance).
+    StrU64,
+}
+
+/// The full set of `(table_name, shape)` pairs to copy, in a stable order.
+///
+/// Why: a single authoritative list keeps the migration in lock-step with the
+/// corpus schema. If a new table is added to `core::corpus`, it must be added
+/// here too or its rows would be silently dropped on upgrade.
+/// What: matches the `TableDefinition::new(...)` names in `core::corpus`
+/// (`chunks`, `entities`, `kg_nodes`, `kg_edges`, `kg_edges_rev`,
+/// `file_hashes`, `kg_communities`, `kg_symbol_community`) plus `_meta` from
+/// `core::migration`.
+/// Test: the round-trip test exercises a representative subset
+/// (`chunks`/`entities`/`kg_nodes`/`kg_edges`/`kg_communities`/
+/// `kg_symbol_community`/`_meta`).
+const CORPUS_TABLES: &[(&str, Shape)] = &[
+    ("chunks", Shape::StrBytes),
+    ("entities", Shape::StrBytes),
+    ("kg_nodes", Shape::StrBytes),
+    ("kg_edges", Shape::StrBytes),
+    ("kg_edges_rev", Shape::StrBytes),
+    ("file_hashes", Shape::StrBytes),
+    ("kg_communities", Shape::U64Bytes),
+    ("kg_symbol_community", Shape::StrU64),
+    ("_meta", Shape::StrBytes),
+];
+
+// ── Copy engine ─────────────────────────────────────────────────────────────
+
+/// Summary returned by [`copy_all_tables`]: `(per_table_counts, total_rows,
+/// schema_version)`.
+///
+/// Why: a named alias keeps the copy entry point's signature readable (and
+/// satisfies clippy's `type_complexity` lint) without leaking a one-off struct.
+/// What: the per-table `(name, rows)` vector, the summed row count, and the
+/// preserved `_meta` `schema_version`.
+/// Test: the round-trip test destructures this triple.
+pub(super) type CopySummary = (Vec<(&'static str, u64)>, u64, u32);
+
+/// Open `source` with redb 2.6 and copy every catalogued table into a fresh
+/// redb 4.x database at `staging`, verifying per-table row counts.
+///
+/// Why: this is the load-bearing data-preservation step. Each table is copied
+/// row-for-row with its exact key/value shape so the new 4.x corpus is byte-
+/// identical at the payload level — no re-embedding, no re-parsing.
+/// What: returns `(per_table_counts, total_rows, schema_version)`. After
+/// copying, re-reads the staging 4.x table and asserts its row count equals the
+/// source's; a mismatch is a hard error (the staging file is left for the
+/// caller to discard). `schema_version` is decoded from the copied `_meta` row
+/// (`0` if absent) so the caller can log/return it.
+/// Test: `tests::round_trip_v2_to_v4` verifies counts and schema version.
+pub(super) fn copy_all_tables(source: &Path, staging: &Path) -> Result<CopySummary> {
+    let mut per_table: Vec<(&'static str, u64)> = Vec::with_capacity(CORPUS_TABLES.len());
+    let mut total_rows = 0u64;
+
+    // Scope the two `Database` handles so both are dropped — releasing redb's
+    // exclusive file locks — before we re-open the staging file for
+    // verification. redb permits only one open handle per file at a time.
+    {
+        let src = redb2::Database::open(source)
+            .with_context(|| format!("open redb 2.x source {}", source.display()))?;
+        let dst = redb::Database::create(staging)
+            .with_context(|| format!("create staging redb 4.x corpus {}", staging.display()))?;
+
+        let read = src
+            .begin_read()
+            .context("begin redb 2.x read transaction")?;
+        let write = dst
+            .begin_write()
+            .context("begin redb 4.x write transaction")?;
+
+        for (name, shape) in CORPUS_TABLES {
+            let copied = match shape {
+                Shape::StrBytes => copy_str_bytes(&read, &write, name)?,
+                Shape::U64Bytes => copy_u64_bytes(&read, &write, name)?,
+                Shape::StrU64 => copy_str_u64(&read, &write, name)?,
+            };
+            if copied > 0 {
+                tracing::debug!(table = name, rows = copied, "copied redb table");
+            }
+            per_table.push((name, copied));
+            total_rows += copied;
+        }
+
+        write
+            .commit()
+            .context("commit redb 4.x write transaction")?;
+    }
+
+    // Verify: re-open the staging 4.x corpus and confirm each table's row count
+    // matches what we copied. This catches a silent partial write before we
+    // touch the original and rename the staging file into place.
+    verify_counts(staging, &per_table)
+        .context("verify migrated staging corpus row counts match the source")?;
+
+    let schema_version = read_schema_version(staging).unwrap_or(0);
+    Ok((per_table, total_rows, schema_version))
+}
+
+/// Copy a `&str → &[u8]` table from the 2.x read txn into the 4.x write txn.
+///
+/// Why: the majority of corpus tables (chunks, entities, KG adjacency, file
+/// hashes, `_meta`) share this shape; one helper avoids duplicating the
+/// open/iterate/insert dance.
+/// What: opens the named table on both engines, streams every `(key, value)`
+/// pair across, and returns the number of rows copied. A source table that does
+/// not exist yields `0` (nothing to copy) rather than an error.
+/// Test: exercised by the round-trip test's chunks/entities/_meta rows.
+fn copy_str_bytes(
+    read: &redb2::ReadTransaction,
+    write: &redb::WriteTransaction,
+    name: &str,
+) -> Result<u64> {
+    let def2: redb2::TableDefinition<&str, &[u8]> = redb2::TableDefinition::new(name);
+    let src = match read.open_table(def2) {
+        Ok(t) => t,
+        Err(redb2::TableError::TableDoesNotExist(_)) => return Ok(0),
+        Err(e) => return Err(anyhow::anyhow!("open 2.x table '{name}': {e}")),
+    };
+    let def4: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new(name);
+    let mut dst = write
+        .open_table(def4)
+        .with_context(|| format!("open 4.x table '{name}'"))?;
+
+    let mut n = 0u64;
+    for entry in src.iter().with_context(|| format!("iterate '{name}'"))? {
+        let (k, v) = entry.with_context(|| format!("read row in '{name}'"))?;
+        dst.insert(k.value(), v.value())
+            .with_context(|| format!("insert row into '{name}'"))?;
+        n += 1;
+    }
+    Ok(n)
+}
+
+/// Copy a `u64 → &[u8]` table (legacy `kg_communities`).
+///
+/// Why: the community-record table is keyed by a `u64` id; its rows must be
+/// preserved verbatim for backward-compat even though the active search path no
+/// longer reads them.
+/// What: same stream-copy as [`copy_str_bytes`] but with the `u64` key type.
+/// Test: the round-trip test seeds a `kg_communities` row and asserts it
+/// survives.
+fn copy_u64_bytes(
+    read: &redb2::ReadTransaction,
+    write: &redb::WriteTransaction,
+    name: &str,
+) -> Result<u64> {
+    let def2: redb2::TableDefinition<u64, &[u8]> = redb2::TableDefinition::new(name);
+    let src = match read.open_table(def2) {
+        Ok(t) => t,
+        Err(redb2::TableError::TableDoesNotExist(_)) => return Ok(0),
+        Err(e) => return Err(anyhow::anyhow!("open 2.x table '{name}': {e}")),
+    };
+    let def4: redb::TableDefinition<u64, &[u8]> = redb::TableDefinition::new(name);
+    let mut dst = write
+        .open_table(def4)
+        .with_context(|| format!("open 4.x table '{name}'"))?;
+
+    let mut n = 0u64;
+    for entry in src.iter().with_context(|| format!("iterate '{name}'"))? {
+        let (k, v) = entry.with_context(|| format!("read row in '{name}'"))?;
+        dst.insert(k.value(), v.value())
+            .with_context(|| format!("insert row into '{name}'"))?;
+        n += 1;
+    }
+    Ok(n)
+}
+
+/// Copy a `&str → u64` table (legacy `kg_symbol_community`).
+///
+/// Why: the symbol→community mapping is keyed by string with a `u64` value; it
+/// must round-trip verbatim for backward-compat.
+/// What: same stream-copy with the `(&str, u64)` shape.
+/// Test: the round-trip test seeds a `kg_symbol_community` row and asserts it
+/// survives.
+fn copy_str_u64(
+    read: &redb2::ReadTransaction,
+    write: &redb::WriteTransaction,
+    name: &str,
+) -> Result<u64> {
+    let def2: redb2::TableDefinition<&str, u64> = redb2::TableDefinition::new(name);
+    let src = match read.open_table(def2) {
+        Ok(t) => t,
+        Err(redb2::TableError::TableDoesNotExist(_)) => return Ok(0),
+        Err(e) => return Err(anyhow::anyhow!("open 2.x table '{name}': {e}")),
+    };
+    let def4: redb::TableDefinition<&str, u64> = redb::TableDefinition::new(name);
+    let mut dst = write
+        .open_table(def4)
+        .with_context(|| format!("open 4.x table '{name}'"))?;
+
+    let mut n = 0u64;
+    for entry in src.iter().with_context(|| format!("iterate '{name}'"))? {
+        let (k, v) = entry.with_context(|| format!("read row in '{name}'"))?;
+        dst.insert(k.value(), v.value())
+            .with_context(|| format!("insert row into '{name}'"))?;
+        n += 1;
+    }
+    Ok(n)
+}
+
+// ── Verification ────────────────────────────────────────────────────────────
+
+/// Re-open the staging 4.x corpus and assert each table's row count matches
+/// what the copy step reported.
+///
+/// Why: a silent partial write (e.g. a disk-full mid-copy that did not surface
+/// as an insert error) must be caught *before* we destroy the original. Re-
+/// reading the committed staging file is the cheapest end-to-end integrity
+/// check.
+/// What: opens `staging` with redb 4.x, reads each catalogued table's `len()`,
+/// and errors on the first mismatch. Tables absent from the source (`expected
+/// == 0`) are skipped because they were never created in the staging file.
+/// Test: covered by the round-trip test (passes) — a mismatch path is a defensive
+/// invariant, not normally reachable.
+fn verify_counts(staging: &Path, per_table: &[(&'static str, u64)]) -> Result<()> {
+    let db = redb::Database::open(staging).with_context(|| {
+        format!(
+            "re-open staging corpus {} for verification",
+            staging.display()
+        )
+    })?;
+    let read = db.begin_read().context("begin verify read txn")?;
+
+    for (name, expected) in per_table {
+        if *expected == 0 {
+            continue;
+        }
+        let actual = verify_table_len(&read, name, expected)?;
+        if actual != *expected {
+            anyhow::bail!(
+                "row-count mismatch after migration: table '{name}' has {actual} rows in the \
+                 migrated corpus but {expected} were copied from the source"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Read one table's row count from the staging 4.x read transaction, trying
+/// each shape until one opens.
+///
+/// Why: `verify_counts` does not track the shape per table, and `len()` is
+/// shape-agnostic; opening with the right typed definition is all that is
+/// needed. Probing the three shapes in turn keeps the verifier table-shape-
+/// agnostic.
+/// What: tries the `&str→&[u8]`, then `u64→&[u8]`, then `&str→u64`
+/// definitions; returns the `len()` of whichever opens. Errors only if none
+/// opens (which would contradict the copy step having written rows).
+/// Test: exercised by `verify_counts` in the round-trip test.
+fn verify_table_len(read: &redb::ReadTransaction, name: &str, expected: &u64) -> Result<u64> {
+    if let Ok(t) = read.open_table::<&str, &[u8]>(redb::TableDefinition::new(name)) {
+        return t.len().with_context(|| format!("len of '{name}'"));
+    }
+    if let Ok(t) = read.open_table::<u64, &[u8]>(redb::TableDefinition::new(name)) {
+        return t.len().with_context(|| format!("len of '{name}'"));
+    }
+    if let Ok(t) = read.open_table::<&str, u64>(redb::TableDefinition::new(name)) {
+        return t.len().with_context(|| format!("len of '{name}'"));
+    }
+    anyhow::bail!(
+        "verification could not open migrated table '{name}' (expected {expected} rows) under any \
+         known shape"
+    )
+}
+
+/// Decode the `schema_version` from a freshly migrated 4.x corpus's `_meta`.
+///
+/// Why: the migration must preserve the source's app-schema version so the
+/// in-app migration chain (M001…) runs from the correct starting point rather
+/// than treating the corpus as brand-new. We read it back here purely to log /
+/// return it for operator confidence.
+/// What: opens `_meta` in the 4.x corpus, reads `schema_version`, decodes the
+/// 4-byte little-endian `u32`. Returns `None` when the table or key is absent
+/// (a legacy pre-migration-framework corpus → treated as version 0 by the
+/// runner).
+/// Test: the round-trip test seeds a `_meta` `schema_version` and asserts it is
+/// preserved.
+fn read_schema_version(staging: &Path) -> Option<u32> {
+    let db = redb::Database::open(staging).ok()?;
+    let read = db.begin_read().ok()?;
+    let table = read
+        .open_table::<&str, &[u8]>(redb::TableDefinition::new("_meta"))
+        .ok()?;
+    let v = table.get("schema_version").ok()??;
+    let bytes = v.value();
+    if bytes.len() == 4 {
+        Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    } else {
+        None
+    }
+}

--- a/crates/trusty-search/src/core/redb_migrate/mod.rs
+++ b/crates/trusty-search/src/core/redb_migrate/mod.rs
@@ -1,0 +1,341 @@
+//! redb 2.x → 4.x corpus migration that PRESERVES data (no re-embedding).
+//!
+//! Why: the redb 2.6 → 4.x upgrade (#702 / #707) changed the on-disk file
+//! format. redb 4.x cannot open a 2.x `index.redb` — the open returns
+//! `DatabaseError::UpgradeRequired(_)`. The auto-recovery path
+//! ([`crate::core::corpus_recovery`]) handles that today by moving the stale
+//! file aside to `*.v2-incompatible` and creating a fresh EMPTY corpus, which
+//! forces a full reindex. On a large corpus that reindex is expensive precisely
+//! because it RE-EMBEDS every chunk (an ONNX forward pass per chunk). The
+//! chunk text, entity lists, knowledge-graph adjacency, file hashes and schema
+//! version are all already in the old file — only the *container format*
+//! changed, not the row payloads. This module copies every row out of the 2.x
+//! file and into a new 4.x file verbatim, so an upgrade preserves the index and
+//! skips re-embedding entirely.
+//!
+//! What: [`migrate_redb_corpus`] opens the source with the redb **2.6** engine
+//! (aliased `redb2` in `Cargo.toml`), iterates every known table, and writes
+//! each row into a staging redb **4.x** database. It preserves the stored
+//! `_meta` `schema_version` byte-for-byte so the normal in-app migration chain
+//! (M001…M00x) still runs afterwards against the correct starting version. The
+//! original file is backed up (numbered, non-clobbering, via the existing
+//! [`crate::core::corpus_recovery`] backup convention) before the verified
+//! staging file is atomically renamed into place. The source is never destroyed
+//! until the new file is fully written and row-count-verified.
+//!
+//! Test: `tests` builds a small redb 2.6 fixture with chunks / entities / KG /
+//! `_meta` rows, migrates it, and asserts the resulting 4.x corpus opens via
+//! [`crate::core::corpus::CorpusStore`] and contains the same rows with the
+//! same schema version. A `#[ignore]`-gated test points at a real
+//! `*.v2-incompatible` file on the developer's machine.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::core::corpus_recovery::{backup_incompatible_corpus, INCOMPATIBLE_CORPUS_SUFFIX};
+
+mod copy;
+#[cfg(test)]
+mod tests;
+
+// ── Outcome ─────────────────────────────────────────────────────────────────
+
+/// Result of a migration attempt.
+///
+/// Why: the caller (CLI handler) needs to distinguish "nothing to do, already
+/// 4.x" from "migrated N rows" to print the right operator message and choose
+/// an exit status, without re-opening the file itself.
+/// What: `AlreadyV4` when the source already opens with redb 4.x (no-op);
+/// `Migrated` carrying per-table row counts, the backup path, and the total
+/// rows copied.
+/// Test: the round-trip test asserts `Migrated` with the expected row total;
+/// the idempotency test asserts a second run returns `AlreadyV4`.
+#[derive(Debug)]
+pub enum MigrationOutcome {
+    /// The file at the destination path already opens with redb 4.x — no
+    /// migration was performed.
+    AlreadyV4,
+    /// The 2.x source was copied into a fresh 4.x corpus.
+    Migrated {
+        /// Per-table `(name, rows_copied)` in catalogue order.
+        per_table: Vec<(&'static str, u64)>,
+        /// Total rows copied across all tables.
+        total_rows: u64,
+        /// Where the original 2.x bytes were preserved.
+        backup: PathBuf,
+        /// The stored `schema_version` carried over from the source (or `0` if
+        /// the source had no `_meta`/legacy corpus).
+        schema_version: u32,
+    },
+}
+
+// ── Public entry point ──────────────────────────────────────────────────────
+
+/// Migrate a redb 2.x corpus at `dest` (or its `*.v2-incompatible` backup)
+/// into a redb 4.x corpus at `dest`, preserving every row.
+///
+/// Why: see module docs — lets an upgrade preserve the index instead of
+/// recreating it empty and re-embedding every chunk.
+/// What: resolves the actual 2.x source (the live path, else the
+/// `*.v2-incompatible` sibling the auto-recovery may have moved aside). If the
+/// destination already opens with redb 4.x, returns [`MigrationOutcome::AlreadyV4`]
+/// (idempotent no-op). Otherwise opens the source read-only with redb 2.6,
+/// copies all catalogued tables into a staging 4.x file, verifies per-table row
+/// counts match, backs up the original via the
+/// [`crate::core::corpus_recovery`] numbered-backup convention, and atomically
+/// renames the staging file into `dest`.
+/// Test: `tests::round_trip_v2_to_v4` and `tests::idempotent_on_v4`.
+pub fn migrate_redb_corpus(dest: &Path) -> Result<MigrationOutcome> {
+    // Resolve which file actually holds 2.x data to migrate. This may be `dest`
+    // itself (the live path is still the old 2.x file) or a `*.v2-incompatible`
+    // sibling the auto-recovery already moved aside while leaving an empty 4.x
+    // file at `dest`.
+    let source = match resolve_source(dest) {
+        Ok(s) => s,
+        Err(_) => {
+            // No 2.x data anywhere. If `dest` opens with redb 4.x it is already
+            // migrated (or freshly created) — a safe no-op. Otherwise surface a
+            // clear error.
+            if dest.exists() && opens_with_v4(dest) {
+                tracing::info!(
+                    path = %dest.display(),
+                    "redb corpus already opens with redb 4.x and no 2.x backup found — \
+                     nothing to migrate"
+                );
+                return Ok(MigrationOutcome::AlreadyV4);
+            }
+            anyhow::bail!(
+                "no readable redb 2.x corpus found at {} or its {INCOMPATIBLE_CORPUS_SUFFIX} \
+                 sibling(s), and {} does not open as a redb 4.x corpus either",
+                dest.display(),
+                dest.display()
+            );
+        }
+    };
+
+    tracing::info!(
+        source = %source.display(),
+        dest = %dest.display(),
+        "migrating redb 2.x corpus → 4.x (preserving rows, no re-embedding)"
+    );
+
+    // Build the new 4.x corpus in a sibling staging file so `dest` is only ever
+    // replaced atomically by a fully written, verified file.
+    let staging = staging_path(dest);
+    // Discard any stale staging file from a previously aborted run.
+    remove_if_exists(&staging)
+        .with_context(|| format!("clear stale staging file {}", staging.display()))?;
+
+    let (per_table, total_rows, schema_version) = copy::copy_all_tables(&source, &staging)
+        .with_context(|| {
+            format!(
+                "copy redb 2.x rows from {} into staging 4.x corpus {}",
+                source.display(),
+                staging.display()
+            )
+        })?;
+
+    // Back up the original 2.x file (numbered, non-clobbering). If `source` IS
+    // the live `dest`, this moves it aside and frees `dest` for the rename. If
+    // `source` is already a `*.v2-incompatible` sibling, we still preserve it.
+    let backup = preserve_source(dest, &source)
+        .context("preserve the original 2.x corpus before installing the migrated 4.x corpus")?;
+
+    // Atomically install the verified staging corpus at the canonical path.
+    std::fs::rename(&staging, dest).with_context(|| {
+        format!(
+            "atomically rename migrated corpus {} → {}",
+            staging.display(),
+            dest.display()
+        )
+    })?;
+
+    tracing::info!(
+        dest = %dest.display(),
+        total_rows,
+        schema_version,
+        backup = %backup.display(),
+        "redb 2.x → 4.x migration complete (no re-embedding)"
+    );
+    for (name, rows) in &per_table {
+        tracing::info!(table = name, rows, "migrated table");
+    }
+
+    Ok(MigrationOutcome::Migrated {
+        per_table,
+        total_rows,
+        backup,
+        schema_version,
+    })
+}
+
+// ── Detection / source resolution ───────────────────────────────────────────
+
+/// Report whether the file at `path` opens cleanly with the redb 4.x engine.
+///
+/// Why: the detection step must not treat a healthy 4.x corpus as a migration
+/// candidate. A successful 4.x open is the definitive "already migrated" signal.
+/// What: attempts `redb::Database::open(path)` and returns whether it succeeded.
+/// Any open error (including `UpgradeRequired` for a 2.x file) returns `false`.
+/// Test: `tests::idempotent_on_v4` relies on this returning `true` for a 4.x DB.
+fn opens_with_v4(path: &Path) -> bool {
+    redb::Database::open(path).is_ok()
+}
+
+/// Resolve the actual 2.x source file for a destination path.
+///
+/// Why: the auto-recovery path may already have moved the stale 2.x file aside
+/// to `index.redb.v2-incompatible` and created a fresh empty 4.x file at
+/// `index.redb`. In that case the rows to preserve live in the backup sibling,
+/// not at the canonical path. We must find whichever file actually holds the
+/// 2.x data.
+/// What: prefers `dest` if it exists and is genuinely a 2.x file (opens with
+/// redb2 but not redb4); otherwise falls back to the first existing
+/// `*.v2-incompatible[.N]` sibling that is a 2.x file. Errors if neither
+/// candidate is a readable 2.x corpus.
+/// Test: `tests::round_trip_v2_to_v4` (source == dest) and
+/// `tests::round_trip_from_incompatible_sibling` (source == sibling).
+fn resolve_source(dest: &Path) -> Result<PathBuf> {
+    // Candidate 1: the canonical path, if it is itself a 2.x file.
+    if dest.exists() && is_v2_corpus(dest) {
+        return Ok(dest.to_path_buf());
+    }
+
+    // Candidate 2..: the numbered `.v2-incompatible` siblings, newest-numbered
+    // first is not important — any readable 2.x sibling works; we take the
+    // first that opens with redb2.
+    for sibling in incompatible_siblings(dest) {
+        if sibling.exists() && is_v2_corpus(&sibling) {
+            return Ok(sibling);
+        }
+    }
+
+    anyhow::bail!(
+        "no readable redb 2.x corpus found at {} or its {INCOMPATIBLE_CORPUS_SUFFIX} sibling(s)",
+        dest.display()
+    )
+}
+
+/// Report whether `path` is an old (pre-4.x) redb corpus the redb 2.x engine
+/// should read.
+///
+/// Why: this is the load-bearing classifier, and it must NOT probe with
+/// `redb2::Database::open` directly — redb 2.6 panics with an internal
+/// `unreachable!()` when it tries to parse a redb 4.x file's region layout, so
+/// using it as a probe on an arbitrary file would crash the process. Instead we
+/// classify with the redb **4.x** engine, which returns clean `DatabaseError`s:
+/// a 4.x file opens, and an older 2.x file fails with `UpgradeRequired` (or a
+/// related incompatible-format error). Only a positive "incompatible old
+/// format" classification means redb2 can safely read it.
+/// What: opens `path` with redb 4.x. Returns `true` only when the open fails
+/// with an incompatible/old-format error (reusing
+/// [`crate::core::corpus_recovery::is_incompatible_corpus_format`]). A
+/// successful 4.x open (already migrated), a missing file, or any transient
+/// error returns `false`.
+/// Test: covered by `resolve_source` round-trip tests and `idempotent_on_v4`
+/// (which must NOT classify a 4.x file as 2.x and must not panic).
+fn is_v2_corpus(path: &Path) -> bool {
+    match redb::Database::open(path) {
+        Ok(_) => false, // a clean 4.x open → definitely not an old 2.x file
+        Err(e) => crate::core::corpus_recovery::is_incompatible_corpus_format(&e),
+    }
+}
+
+/// Enumerate the candidate `*.v2-incompatible[.N]` sibling paths for `dest`.
+///
+/// Why: the auto-recovery backup convention appends `.v2-incompatible` and then
+/// `.1`, `.2`, … on repeated failures (see `corpus_recovery`). Source
+/// resolution must consider all of them.
+/// What: yields `<dest>.v2-incompatible` followed by `<dest>.v2-incompatible.1`
+/// … up to a small bound (`64`), which far exceeds any realistic number of
+/// failed boots.
+/// Test: covered indirectly by `resolve_source`'s sibling round-trip test.
+fn incompatible_siblings(dest: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut base = dest.as_os_str().to_os_string();
+    base.push(INCOMPATIBLE_CORPUS_SUFFIX);
+    out.push(PathBuf::from(base));
+    for n in 1u32..64 {
+        let mut s = dest.as_os_str().to_os_string();
+        s.push(INCOMPATIBLE_CORPUS_SUFFIX);
+        s.push(format!(".{n}"));
+        out.push(PathBuf::from(s));
+    }
+    out
+}
+
+// ── Backup / staging helpers ────────────────────────────────────────────────
+
+/// Suffix for the staging file the new 4.x corpus is built in before the
+/// atomic rename into place.
+///
+/// Why: building the new corpus at a sibling temp path and renaming atomically
+/// guarantees the canonical `index.redb` is only ever replaced by a fully
+/// written, row-verified file — a crash mid-migration leaves the original
+/// untouched and the half-written staging file is discarded on the next run.
+/// What: the literal `".v4-migrating"` appended to the destination path.
+/// Test: covered by `migrate_redb_corpus`'s round-trip test (the staging file
+/// is renamed away on success and must not linger).
+const STAGING_SUFFIX: &str = ".v4-migrating";
+
+/// Compute the staging file path for a destination corpus.
+///
+/// Why: a single deterministic staging path keeps the migration's temp file
+/// next to the destination (same filesystem → atomic rename) and easy to find
+/// if a run aborts.
+/// What: appends [`STAGING_SUFFIX`] to `dest`.
+/// Test: covered by the round-trip test (the staging file must not survive a
+/// successful run).
+fn staging_path(dest: &Path) -> PathBuf {
+    let mut s = dest.as_os_str().to_os_string();
+    s.push(STAGING_SUFFIX);
+    PathBuf::from(s)
+}
+
+/// Ensure the original 2.x bytes are preserved, freeing `dest` for the rename.
+///
+/// Why: we must never lose the source data, and `std::fs::rename(staging,
+/// dest)` requires `dest` to be replaceable. Two cases. (a) `source == dest`
+/// (the live path is the 2.x file): move it aside to a numbered
+/// `*.v2-incompatible` backup so `dest` is freed. (b) `source` is already a
+/// `*.v2-incompatible` sibling (auto-recovery already moved it): the sibling IS
+/// the backup; just remove the empty 4.x file the recovery created at `dest` so
+/// the rename can land.
+/// What: returns the path where the original bytes now live.
+/// Test: `tests::round_trip_v2_to_v4` (case 1) and
+/// `tests::round_trip_from_incompatible_sibling` (case 2).
+fn preserve_source(dest: &Path, source: &Path) -> Result<PathBuf> {
+    if source == dest {
+        // Live path is the 2.x file → move it aside (numbered, non-clobbering),
+        // which also frees `dest` for the rename.
+        let backup = backup_incompatible_corpus(dest)
+            .with_context(|| format!("back up original 2.x corpus {}", dest.display()))?;
+        Ok(backup)
+    } else {
+        // `source` is already the preserved sibling. The auto-recovery may have
+        // created a fresh (empty) 4.x file at `dest`; remove it so the verified
+        // staging file can be renamed into place.
+        remove_if_exists(dest).with_context(|| {
+            format!(
+                "remove the empty recovery corpus at {} so the migrated corpus can replace it",
+                dest.display()
+            )
+        })?;
+        Ok(source.to_path_buf())
+    }
+}
+
+/// Remove a file if it exists; a missing file is not an error.
+///
+/// Why: staging-file cleanup and the empty-recovery-file removal both want
+/// idempotent "delete if present" semantics so re-runs are safe.
+/// What: deletes `path`, swallowing `NotFound`, surfacing other I/O errors.
+/// Test: exercised by the idempotency and round-trip tests.
+fn remove_if_exists(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}

--- a/crates/trusty-search/src/core/redb_migrate/tests.rs
+++ b/crates/trusty-search/src/core/redb_migrate/tests.rs
@@ -1,0 +1,323 @@
+//! Tests for the redb 2.x → 4.x corpus migration.
+//!
+//! Why: the migration must be proven against genuine redb 2.6 on-disk files (a
+//! synthetic 4.x file would not exercise the cross-format copy). These tests
+//! build 2.6 fixtures with the `redb2` engine, migrate them, and assert the
+//! result opens with the live redb 4.x `CorpusStore`.
+//! What: round-trip (in-place and from a `.v2-incompatible` sibling),
+//! idempotency on an already-4.x corpus, and a `#[ignore]`d real-corpus smoke.
+//! Test: this module IS the test surface for `super`.
+
+use super::*;
+use crate::core::corpus::CorpusStore;
+
+/// Seed a small redb 2.6 corpus fixture at `path` with representative rows
+/// across all three table shapes plus a `_meta` schema_version.
+///
+/// Why: the migration must be tested against a genuine 2.x on-disk file, not
+/// a 4.x file — that is the whole point. Writing the fixture with the redb2
+/// engine produces the exact format the tool must read.
+/// What: writes two `chunks`, one `entities`, one `kg_nodes`, one `kg_edges`,
+/// one `kg_communities` (u64 key), one `kg_symbol_community` (u64 value), and
+/// a `_meta` `schema_version = 4` row, then commits.
+/// Test: this helper underpins every round-trip assertion below.
+fn seed_v2_fixture(path: &Path, schema_version: u32) {
+    use crate::core::chunker::{ChunkType, RawChunk};
+
+    // Real corpus chunk values are serde_json-encoded `RawChunk`; encode
+    // genuine ones so the migrated corpus round-trips through the live
+    // `CorpusStore::load_all_chunks` (which deserializes each row).
+    let raw = |id: &str| RawChunk {
+        id: id.to_string(),
+        file: "src/lib.rs".to_string(),
+        start_line: 1,
+        end_line: 1,
+        content: format!("fn {id}() {{}}"),
+        function_name: None,
+        language: Some("rust".to_string()),
+        chunk_type: ChunkType::Code,
+        calls: Vec::new(),
+        inherits_from: Vec::new(),
+        chunk_depth: 0,
+        parent_chunk_id: None,
+        child_chunk_ids: Vec::new(),
+        nlp_keywords: Vec::new(),
+        nlp_code_refs: Vec::new(),
+        virtual_terms: Vec::new(),
+    };
+
+    let db = redb2::Database::create(path).expect("create v2 fixture");
+    let txn = db.begin_write().expect("v2 write txn");
+    {
+        let mut t = txn
+            .open_table::<&str, &[u8]>(redb2::TableDefinition::new("chunks"))
+            .unwrap();
+        let a = serde_json::to_vec(&raw("a")).unwrap();
+        let b = serde_json::to_vec(&raw("b")).unwrap();
+        t.insert("a:1:1", a.as_slice()).unwrap();
+        t.insert("b:2:2", b.as_slice()).unwrap();
+    }
+    {
+        let mut t = txn
+            .open_table::<&str, &[u8]>(redb2::TableDefinition::new("entities"))
+            .unwrap();
+        t.insert("src/lib.rs", b"[]".as_slice()).unwrap();
+    }
+    {
+        let mut t = txn
+            .open_table::<&str, &[u8]>(redb2::TableDefinition::new("kg_nodes"))
+            .unwrap();
+        t.insert("alpha", br#"{"chunk_id":"a:1:1","file":"a.rs"}"#.as_slice())
+            .unwrap();
+    }
+    {
+        let mut t = txn
+            .open_table::<&str, &[u8]>(redb2::TableDefinition::new("kg_edges"))
+            .unwrap();
+        t.insert("alpha", br#"[["CallsFunction","beta"]]"#.as_slice())
+            .unwrap();
+    }
+    {
+        let mut t = txn
+            .open_table::<u64, &[u8]>(redb2::TableDefinition::new("kg_communities"))
+            .unwrap();
+        t.insert(7u64, b"community-7".as_slice()).unwrap();
+    }
+    {
+        let mut t = txn
+            .open_table::<&str, u64>(redb2::TableDefinition::new("kg_symbol_community"))
+            .unwrap();
+        t.insert("alpha", 7u64).unwrap();
+    }
+    {
+        let mut t = txn
+            .open_table::<&str, &[u8]>(redb2::TableDefinition::new("_meta"))
+            .unwrap();
+        t.insert("schema_version", schema_version.to_le_bytes().as_slice())
+            .unwrap();
+    }
+    txn.commit().expect("commit v2 fixture");
+}
+
+/// Why: the core guarantee — a 2.x corpus at the canonical path migrates to
+/// a 4.x corpus in place, every row survives, the schema_version is
+/// preserved, the original is backed up, and the result opens with the live
+/// `CorpusStore` (redb 4.x).
+/// What: seeds a fixture, migrates, asserts the outcome counts + schema
+/// version, then opens the migrated file via `CorpusStore` and checks the
+/// chunk count and KG rows.
+/// Test: this test.
+#[test]
+fn round_trip_v2_to_v4() {
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("index.redb");
+    seed_v2_fixture(&dest, 4);
+
+    let outcome = migrate_redb_corpus(&dest).expect("migration must succeed");
+    let (total, sv, backup) = match outcome {
+        MigrationOutcome::Migrated {
+            total_rows,
+            schema_version,
+            backup,
+            per_table,
+        } => {
+            // Spot-check a couple of per-table counts.
+            let chunks = per_table.iter().find(|(n, _)| *n == "chunks").unwrap().1;
+            assert_eq!(chunks, 2, "both chunk rows must be copied");
+            (total_rows, schema_version, backup)
+        }
+        MigrationOutcome::AlreadyV4 => panic!("fixture is 2.x, must migrate"),
+    };
+    // 2 chunks + 1 entities + 1 kg_nodes + 1 kg_edges + 1 kg_communities +
+    // 1 kg_symbol_community + 1 _meta = 8 rows.
+    assert_eq!(total, 8, "all rows across all tables must be copied");
+    assert_eq!(sv, 4, "schema_version must be preserved");
+    assert!(backup.exists(), "original 2.x bytes must be backed up");
+
+    // The staging file must be gone (renamed into place).
+    assert!(
+        !staging_path(&dest).exists(),
+        "staging file must not linger after a successful migration"
+    );
+
+    // The migrated file must open with the live 4.x CorpusStore and carry
+    // the data.
+    let store = CorpusStore::open(&dest).expect("migrated corpus must open with redb 4.x");
+    assert_eq!(store.chunk_count().unwrap(), 2, "chunk count preserved");
+    let chunks = store.load_all_chunks().unwrap();
+    assert_eq!(chunks.len(), 2);
+    let (nodes, fwd, _rev) = store.load_kg_graph().unwrap();
+    assert_eq!(nodes.len(), 1, "kg node preserved");
+    assert_eq!(fwd.len(), 1, "kg forward edge preserved");
+    assert_eq!(
+        store.read_schema_version_sync().unwrap(),
+        4,
+        "schema_version readable via CorpusStore after migration"
+    );
+}
+
+/// Why: when the auto-recovery path has already moved the 2.x file aside to
+/// `*.v2-incompatible` and left an empty 4.x file at the canonical path, the
+/// tool must read the sibling, migrate, and replace the empty file.
+/// What: writes a 2.x fixture at the `.v2-incompatible` sibling and an empty
+/// 4.x corpus at the canonical path, runs the migration, and asserts the
+/// canonical path now holds the preserved data.
+/// Test: this test.
+#[test]
+fn round_trip_from_incompatible_sibling() {
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("index.redb");
+    let sibling = dir.path().join("index.redb.v2-incompatible");
+    seed_v2_fixture(&sibling, 3);
+
+    // Simulate the auto-recovery leftover: a fresh empty 4.x corpus at dest.
+    {
+        let _empty = CorpusStore::open(&dest).expect("empty recovery corpus");
+    }
+    assert!(opens_with_v4(&dest), "precondition: dest is empty 4.x");
+
+    let outcome = migrate_redb_corpus(&dest).expect("migration from sibling must succeed");
+    match outcome {
+        MigrationOutcome::Migrated { schema_version, .. } => {
+            assert_eq!(schema_version, 3, "sibling's schema_version preserved");
+        }
+        MigrationOutcome::AlreadyV4 => {
+            panic!("dest is empty but the sibling holds 2.x data — must migrate")
+        }
+    }
+
+    let store = CorpusStore::open(&dest).expect("migrated corpus opens");
+    assert_eq!(
+        store.chunk_count().unwrap(),
+        2,
+        "data from the sibling must now live at the canonical path"
+    );
+}
+
+/// Why: re-running the tool against an already-4.x corpus must be a safe
+/// no-op so an operator can run it blindly.
+/// What: creates a 4.x corpus, runs the migration, asserts `AlreadyV4` and
+/// that no backup/staging files were created.
+/// Test: this test.
+#[test]
+fn idempotent_on_v4() {
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("index.redb");
+    {
+        let store = CorpusStore::open(&dest).expect("create 4.x corpus");
+        store
+            .upsert_chunks(&[])
+            .expect("no-op upsert to keep store warm");
+    }
+
+    let outcome = migrate_redb_corpus(&dest).expect("no-op on 4.x must succeed");
+    assert!(
+        matches!(outcome, MigrationOutcome::AlreadyV4),
+        "an already-4.x corpus must report AlreadyV4"
+    );
+    assert!(
+        !dest.with_file_name("index.redb.v2-incompatible").exists(),
+        "no backup should be created for a no-op"
+    );
+    assert!(!staging_path(&dest).exists(), "no staging file for a no-op");
+}
+
+/// Why: prove the migration against a REAL redb 2.x corpus produced by a
+/// shipped trusty-search build, not just a synthetic fixture — the strongest
+/// evidence the byte-level copy handles a production schema. Machine-specific
+/// (depends on a `*.v2-incompatible` backup existing under the user's data
+/// dir), so it is `#[ignore]`d and run only on demand.
+/// What: copies a real `index.redb.v2-incompatible` into a tempdir (never
+/// touching the original), migrates it, and asserts the result opens with the
+/// live `CorpusStore` and reports a non-zero chunk count. Skips with a clear
+/// message if no such backup is present on the host.
+/// Test: `cargo test -p trusty-search --lib real_v2_incompatible_smoke -- \
+///        --ignored --nocapture`.
+#[test]
+#[ignore = "depends on a machine-specific *.v2-incompatible backup under the data dir"]
+fn real_v2_incompatible_smoke() {
+    // Candidate real backups produced by older shipped builds on this host.
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => {
+            eprintln!("skip: no home dir");
+            return;
+        }
+    };
+    let base = home.join("Library/Application Support/trusty-search/indexes");
+    let mut found: Option<PathBuf> = None;
+    if let Ok(entries) = std::fs::read_dir(&base) {
+        for e in entries.flatten() {
+            let candidate = e.path().join("index.redb.v2-incompatible");
+            if candidate.exists() {
+                found = Some(candidate);
+                break;
+            }
+        }
+    }
+    let real = match found {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "skip: no *.v2-incompatible backup found under {} — nothing to smoke-test",
+                base.display()
+            );
+            return;
+        }
+    };
+    eprintln!(
+        "smoke: migrating a copy of real 2.x corpus {}",
+        real.display()
+    );
+
+    // Copy into a tempdir so the real file is never mutated.
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("index.redb");
+    std::fs::copy(&real, &dest).expect("copy real 2.x corpus into tempdir");
+
+    let outcome = migrate_redb_corpus(&dest).expect("real 2.x corpus must migrate");
+    let copied = match outcome {
+        MigrationOutcome::Migrated {
+            total_rows,
+            schema_version,
+            per_table,
+            ..
+        } => {
+            eprintln!(
+                "smoke: migrated {total_rows} rows, schema_version={schema_version}, \
+                 tables={per_table:?}"
+            );
+            total_rows
+        }
+        MigrationOutcome::AlreadyV4 => panic!("the real backup is 2.x and must migrate"),
+    };
+
+    // The migrated corpus must open with the live 4.x store. We do NOT
+    // assert a non-zero row count: a `*.v2-incompatible` backup can legitimately
+    // be an EMPTY corpus (the daemon materializes all tables at `open` even for
+    // an index that was never populated — e.g. a failed/aborted first index).
+    // The load-bearing guarantee this test proves is that a REAL on-disk 2.x
+    // schema (all nine tables, correct key/value shapes) is read and copied
+    // without error and the result opens with redb 4.x. If the backup happens
+    // to carry chunks, they are preserved (copied == total_rows); if it is
+    // empty, an empty 4.x corpus is the correct, faithful result.
+    let store = CorpusStore::open(&dest).expect("migrated real corpus must open with redb 4.x");
+    let chunks = store.chunk_count().unwrap() as u64;
+    eprintln!("smoke: migrated corpus reports {chunks} chunks (copied {copied} total rows)");
+    // Whatever chunk rows the source had must survive verbatim.
+    let src_chunks = {
+        let db = redb2::Database::open(&real).unwrap();
+        let r = db.begin_read().unwrap();
+        match r.open_table::<&str, &[u8]>(redb2::TableDefinition::new("chunks")) {
+            Ok(t) => {
+                use redb2::ReadableTableMetadata as _;
+                t.len().unwrap()
+            }
+            Err(_) => 0,
+        }
+    };
+    assert_eq!(
+        chunks, src_chunks,
+        "every chunk row in the real 2.x corpus must survive migration"
+    );
+}

--- a/crates/trusty-search/src/main.rs
+++ b/crates/trusty-search/src/main.rs
@@ -615,6 +615,20 @@ enum Commands {
         dry_run: bool,
     },
 
+    /// Migrate a redb 2.x index corpus to redb 4.x, preserving data (issue #702/#707)
+    ///
+    /// Copies an old redb-2.x `index.redb` into a fresh 4.x corpus row-for-row
+    /// (chunks, entities, KG, file hashes, schema version) so an upgrade keeps
+    /// the index WITHOUT re-embedding. Backs up the original first; re-running
+    /// against an already-4.x corpus is a no-op. PATH may be the live
+    /// `index.redb` or its `*.v2-incompatible` recovery backup.
+    #[command(display_order = 28, name = "migrate-redb")]
+    MigrateRedb {
+        /// Path to the index.redb (or its .v2-incompatible backup) to migrate
+        #[arg(value_name = "PATH")]
+        path: std::path::PathBuf,
+    },
+
     /// Remove orphaned index registrations whose root_path no longer exists (issue #489)
     ///
     /// Works OFFLINE — no daemon required. Reads indexes.toml, identifies
@@ -1138,6 +1152,10 @@ async fn run() -> Result<()> {
 
         Commands::MigrateStorage { dry_run } => {
             commands::migrate_storage::handle_migrate_storage(dry_run)?;
+        }
+
+        Commands::MigrateRedb { path } => {
+            commands::migrate_redb::handle_migrate_redb(path)?;
         }
 
         Commands::PruneOrphans { dry_run, yes } => {


### PR DESCRIPTION
Closes #716. Refs #702 / #707 / #704.

## What

Adds a `trusty-search migrate-redb <path>` subcommand that copies a legacy **redb 2.x** `index.redb` into a fresh **redb 4.x** corpus row-for-row, so upgrading to a redb-4.x build **preserves the index without re-embedding**. The redb 2.6→4.x upgrade (#702/#707) otherwise leaves the daemon unable to open old corpora; auto-recovery recreates them empty and forces a full reindex (re-embedding every chunk — the slow part). Only the container format changed, not the row payloads.

## How

- **Dual redb deps (not feature-gated):** `redb` = 4.x (write) + `redb2 = { package = "redb", version = "2.6" }` (read). Both compile and link together (`redb v2.6.3` + `redb v4.1.0` resolve simultaneously). Left ungated so the tool ships in every default `cargo install trusty-search` — an operator who upgrades into the empty-recreate path can preserve data with zero extra build steps. redb is a pure-Rust B-tree (no C deps) so the binary-size cost is small.
- **`core::redb_migrate`** (`mod.rs` / `copy.rs` / `tests.rs`, each <500 lines):
  - Copies all **nine** corpus tables with their exact key/value shapes: `chunks`, `entities`, `kg_nodes`, `kg_edges`, `kg_edges_rev`, `file_hashes` (`&str→&[u8]`); `kg_communities` (`u64→&[u8]`); `kg_symbol_community` (`&str→u64`); `_meta` (`&str→&[u8]`). Names/shapes match `core::corpus` + `core::migration` and were confirmed against a real on-disk 2.x file.
  - **Preserves `_meta` `schema_version`** byte-for-byte so the in-app migration chain (M001…M00x) runs from the correct starting version — app migrations are NOT skipped.
  - **Detection** classifies via the redb **4.x** open error (redb 2.6 panics with an internal `unreachable!()` if used to probe a 4.x file, so it must never be the probe). An already-4.x corpus is a safe idempotent no-op.
  - **Crash-safe install:** writes a staging file → verifies per-table row counts → backs up the original (numbered, non-clobbering, via the existing `corpus_recovery` backup convention) → atomically renames into place. The source is never destroyed until the new file is fully written and verified. Reads either the live `index.redb` or its `*.v2-incompatible` recovery backup.
- **CLI:** `migrate-redb <PATH>` variant + `commands::migrate_redb` handler.

## Tests (all passing)

- `round_trip_v2_to_v4` — seeds a real redb-2.6 fixture (genuine `RawChunk` JSON across all three table shapes + `_meta`), migrates, asserts 8 rows copied, schema_version preserved, original backed up, staging gone, and the result opens via the live 4.x `CorpusStore` with chunks/KG intact.
- `round_trip_from_incompatible_sibling` — migrates from a `.v2-incompatible` sibling when an empty 4.x file already sits at the canonical path.
- `idempotent_on_v4` — re-running on a 4.x corpus is a no-op (no backup/staging created).
- `real_v2_incompatible_smoke` (`#[ignore]`) — copies a REAL `*.v2-incompatible` backup from the host into a tempdir and migrates it; confirmed the nine-table production schema/shapes read and copy without error.

Full suite: **688 lib + 171 integration tests pass, 0 failures**. clippy `-D warnings` clean, `cargo fmt --check` clean, `scripts/check_line_cap.sh` clean (main.rs budget intentionally bumped 1225→1243 for the one new subcommand variant; all new module files are <500 lines).

## Follow-up (NOT in this PR)

Ideal end state: have `corpus_recovery`'s auto-open path attempt this migrate-copy **before** falling back to recreate-empty, for seamless zero-operator-action upgrades with zero re-embedding. Recommended as a low-risk fast-follow rather than bundled here, to keep this PR scoped to the explicit subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)