### PR TITLE
chore(release): trusty-search 0.23.1 + trusty-review 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11011,7 +11011,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11052,7 +11052,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.2.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.3.0" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.2.0"
+version     = "0.3.0"
 edition     = "2024"
 rust-version.workspace = true
 license-file           = "LICENSE"

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version-bump PR for two crates containing the #718 and #719 fixes that already merged to main.

### trusty-search 0.23.0 → 0.23.1 (patch)

Bug fix release — launchd warm-boot resilience (#718):

- **Data-dir resolution**: `resolve_data_dir` now anchors the database path to the config directory instead of CWD, preventing "wrong path on launchd restart" failures.
- **Two-phase restore**: Index restore now runs in two phases (metadata first, then corpus) so a warm-boot with an already-open redb corpus does not deadlock.
- **Per-index spawn_blocking timeout**: Each index restore is wrapped in a `tokio::time::timeout`; a hung restore now fails loudly instead of blocking the daemon startup indefinitely.
- **Loud TCC diagnostics**: When the daemon can't open a redb file (macOS TCC / Full Disk Access denial), it now logs the exact path and errno so operators can diagnose without `Console.app`.

### trusty-review 0.2.0 → 0.3.0 (minor)

New feature — inference reachability probe in `review_health` (#719):

- `review_health` now includes an inference reachability probe that pings the configured LLM endpoint (OpenRouter or Bedrock) and reports latency + model availability in the health response, making it possible to detect misconfigured API keys or unreachable inference endpoints before submitting a review.

### Dependency pin notes

- **Root `Cargo.toml` `[workspace.dependencies]`**: `trusty-review` version updated from `"0.2.0"` to `"0.3.0"` (required for correct version metadata on `cargo publish`).
- **`trusty-analyze`**: No change required. Its dep is `trusty-review = { workspace = true, optional = true }` — a pure workspace path dep with no hard version constraint that would fail at 0.3.0. `cargo check -p trusty-analyze` confirmed clean compilation.

## Test plan

- [ ] CI passes all jobs on this branch
- [ ] If `memory_core::retrieval::tests::recall_logs_events_when_log_present` fails, re-run that job once (known flaky)
- [ ] Any other CI failure must be investigated before merging — do not re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)