### PR TITLE
fix(trusty-review): degraded health when required dep unreachable + release 0.3.1 (closes #722)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11011,7 +11011,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.3.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.3.1" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.0"
+version     = "0.3.1"
 edition     = "2024"
 rust-version.workspace = true
 license-file           = "LICENSE"

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -24,7 +24,10 @@ use crate::{
     integrations::github::{AuthStrategy, GithubClient, RunMode},
     models::ReviewResult,
     pipeline::{DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
-    service::AppState,
+    service::{
+        AppState,
+        handlers::{DepInfo, DepStatus, compute_status},
+    },
 };
 
 // ─── Tool definitions ────────────────────────────────────────────────────────
@@ -269,22 +272,49 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
 /// Why: gives Claude Code a quick way to verify that the service is reachable
 /// AND that inference is working before issuing a real review (closes #719).
 /// MPM uses this to gate `review_pr` calls so it never attempts a full review
-/// when the LLM endpoint is down or credentials are expired.
-/// What: runs the shared `InferenceProbe` (10 s TTL, 3 s timeout) against the
-/// configured reviewer LLM; returns a JSON health snapshot with `status`
-/// (`"ok"` or `"degraded"`), `inference` (`"ok"` / `"unreachable"` /
-/// `"auth_error"` / `"unknown"`), `dry_run`, `reviewer_model`, and a `deps`
-/// object listing dependency URLs.  When `inference != "ok"`, `status` is set
-/// to `"degraded"` so callers can gate on a single field.
-/// Test: `review_health_inference_ok`, `review_health_inference_auth_error_degraded`.
+/// when the LLM endpoint is down or credentials are expired.  #722 extends the
+/// status decision to factor in required-dep reachability so callers that gate
+/// on the top-level `status` field get an accurate signal even when only the
+/// search dep is down.
+/// What: probes the search dep (non-blocking health call) and the inference
+/// endpoint (via the cached `InferenceProbe`); computes `status` via the shared
+/// `compute_status` helper so the HTTP and MCP paths are always consistent;
+/// returns a JSON health snapshot with `status` (`"ok"` or `"degraded"`),
+/// `inference`, `dry_run`, `reviewer_model`, and a `deps` object with
+/// `reachable` flags for each dep.  When inference is not `"ok"` OR a required
+/// dep is unreachable, `status` becomes `"degraded"`.
+/// Test: `review_health_inference_ok`, `review_health_inference_auth_error_degraded`,
+/// `review_health_required_dep_down_degraded`, `review_health_optional_dep_down_ok`.
 async fn call_review_health(state: &AppState) -> Value {
     let reviewer_model = state.config.role_models.reviewer.model.clone();
+
+    // Non-blocking dep probes — same logic as the HTTP /health handler.
+    let search_reachable = state.search.health().await.is_ok_and(|r| r.is_healthy());
+    let analyze_reachable = match &state.analyze {
+        Some(a) => a.health().await.is_ok(),
+        None => false,
+    };
+
+    // Cached inference-reachability probe (#719).
     let inference = state
         .inference_probe
         .probe(&state.llm, &reviewer_model)
         .await;
 
-    let status = if inference.is_ok() { "ok" } else { "degraded" };
+    // Build the deps struct so compute_status can inspect required flags (#722).
+    let deps = DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: search_reachable,
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: analyze_reachable,
+        },
+    };
+
+    // #722: status is "degraded" when inference fails OR any required dep is down.
+    let status = compute_status(inference, &deps);
 
     let result = serde_json::json!({
         "status": status,
@@ -294,12 +324,12 @@ async fn call_review_health(state: &AppState) -> Value {
         "inference": inference,
         "deps": {
             "trusty_search": {
-                "url": state.config.search_url,
-                "required": true,
+                "required": deps.trusty_search.required,
+                "reachable": deps.trusty_search.reachable,
             },
             "trusty_analyze": {
-                "url": state.config.analyzer_url,
-                "required": false,
+                "required": deps.trusty_analyze.required,
+                "reachable": deps.trusty_analyze.reachable,
             },
         },
     });

--- a/crates/trusty-review/src/mcp/tools_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_tests.rs
@@ -85,11 +85,43 @@ impl SearchClient for FakeSearchTool {
     }
 }
 
+/// A search stub that returns an error on health checks (simulates unreachable dep).
+struct FailSearchTool;
+
+#[async_trait]
+impl SearchClient for FailSearchTool {
+    async fn health(&self) -> Result<SearchHealth, SearchClientError> {
+        Err(SearchClientError::Unavailable("down".to_string()))
+    }
+
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        Err(SearchClientError::Unavailable("down".to_string()))
+    }
+
+    async fn search(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        Err(SearchClientError::Unavailable("down".to_string()))
+    }
+}
+
 fn make_tool_state(llm: Arc<dyn LlmProvider>) -> AppState {
     AppState::new(
         ReviewConfig::load(None),
         llm,
         Arc::new(FakeSearchTool),
+        None,
+    )
+}
+
+fn make_tool_state_fail_search(llm: Arc<dyn LlmProvider>) -> AppState {
+    AppState::new(
+        ReviewConfig::load(None),
+        llm,
+        Arc::new(FailSearchTool),
         None,
     )
 }
@@ -187,4 +219,64 @@ async fn review_health_inference_auth_error_degraded() {
     let health: Value = serde_json::from_str(text).expect("valid JSON");
     assert_eq!(health["inference"], "auth_error");
     assert_eq!(health["status"], "degraded");
+}
+
+// ── review_health dep-reachability tests (#722) ───────────────────────────────
+
+/// review_health MCP tool sets `status: "degraded"` when the required search dep
+/// is unreachable, even if inference itself is healthy.
+///
+/// Why: validates the #722 fix in the MCP path — callers that gate on `status`
+/// must get `"degraded"` when trusty_search is down.
+/// What: builds AppState with OkLlmTool (inference ok) + FailSearchTool (health
+/// returns Err); calls call_review_health; asserts status is "degraded" and
+/// deps.trusty_search.reachable is false.
+/// Test: this test itself.
+#[tokio::test]
+async fn review_health_required_dep_down_degraded() {
+    let state = make_tool_state_fail_search(Arc::new(OkLlmTool));
+    let result = call_review_health(&state).await;
+    let text = result["content"][0]["text"].as_str().expect("text field");
+    let health: Value = serde_json::from_str(text).expect("valid JSON");
+    assert_eq!(
+        health["status"], "degraded",
+        "required dep (trusty_search) down → status must be degraded"
+    );
+    assert_eq!(
+        health["inference"], "ok",
+        "inference must be ok (OkLlmTool always succeeds)"
+    );
+    assert_eq!(
+        health["deps"]["trusty_search"]["reachable"], false,
+        "trusty_search.reachable must be false when search is down"
+    );
+}
+
+/// review_health MCP tool stays `status: "ok"` when inference is ok and all
+/// required deps are reachable — even when analyze (non-required) is absent.
+///
+/// Why: validates the happy-path of #722 — non-required deps absent/unreachable
+/// must not degrade status.
+/// What: builds AppState with OkLlmTool + FakeSearchTool (health ok) + no analyze;
+/// calls call_review_health; asserts status is "ok" and trusty_search.reachable is true.
+/// Test: this test itself.
+#[tokio::test]
+async fn review_health_optional_dep_down_ok() {
+    // No analyze dep configured (analyze = None → analyze_reachable = false).
+    let state = make_tool_state(Arc::new(OkLlmTool));
+    let result = call_review_health(&state).await;
+    let text = result["content"][0]["text"].as_str().expect("text field");
+    let health: Value = serde_json::from_str(text).expect("valid JSON");
+    assert_eq!(
+        health["status"], "ok",
+        "optional dep absent → status must remain ok"
+    );
+    assert_eq!(
+        health["deps"]["trusty_search"]["reachable"], true,
+        "trusty_search.reachable must be true (FakeSearchTool succeeds)"
+    );
+    assert_eq!(
+        health["deps"]["trusty_analyze"]["reachable"], false,
+        "trusty_analyze.reachable must be false (no analyze configured)"
+    );
 }

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -145,16 +145,17 @@ impl AppState {
 /// traffic to this instance.  MPM uses the `inference` field to gate whether to
 /// attempt a `review_pr` call at all (closes #719).
 /// What: mirrors spec REV-706; `deps.trusty_search.reachable` reflects a
-/// non-blocking background probe cached in `AppState`; `inference` reflects the
-/// short-TTL inference-reachability probe (see `InferenceProbe`).  When
-/// `inference != "ok"`, `status` becomes `"degraded"` so callers can gate on
-/// a single field without inspecting the nested `inference` value.
+/// non-blocking background probe; `inference` reflects the short-TTL
+/// inference-reachability probe (see `InferenceProbe`).  `status` is `"degraded"`
+/// when inference is not `"ok"` OR any `required` dep is unreachable (#722).
 /// Test: `health_returns_ok_json`, `health_inference_ok_when_llm_ok`,
-/// `health_inference_auth_error_sets_degraded`.
+/// `health_inference_auth_error_sets_degraded`,
+/// `health_required_dep_down_sets_degraded`,
+/// `health_optional_dep_down_stays_ok`.
 #[derive(Debug, Serialize)]
 pub struct HealthResponse {
-    /// `"ok"` when all required deps are reachable and inference is healthy;
-    /// `"degraded"` when the inference probe returns anything other than `"ok"`.
+    /// `"ok"` when inference is healthy AND all required deps are reachable;
+    /// `"degraded"` when inference is not `"ok"` OR a required dep is unreachable.
     pub status: &'static str,
     /// Pipeline version (e.g. `"tr-0.1"`).
     pub version: &'static str,
@@ -232,6 +233,29 @@ pub struct ReviewRequest {
     pub local_diff_text: Option<String>,
 }
 
+// ─── Status computation ───────────────────────────────────────────────────────
+
+/// Compute the top-level health status string from inference and dep results.
+///
+/// Why: the status decision was previously duplicated between the HTTP handler
+/// and the MCP tool path, and it only considered `inference` — not required-dep
+/// reachability.  This helper centralises the rule so both paths are consistent
+/// and #722 is fixed: a required dep that is unreachable degrades status.
+/// What: returns `"ok"` only when `inference.is_ok()` AND every dep with
+/// `required == true` also has `reachable == true`.  Returns `"degraded"` if
+/// either condition fails.  Non-required deps never influence the result.
+/// Test: `health_status_ok_all_good`, `health_status_degraded_required_dep_down`,
+/// `health_status_degraded_inference_auth_error`,
+/// `health_status_ok_optional_dep_down` in `handlers_tests.rs`.
+pub fn compute_status(inference: InferenceStatus, deps: &DepStatus) -> &'static str {
+    let required_deps_ok = deps.trusty_search.reachable || !deps.trusty_search.required;
+    if inference.is_ok() && required_deps_ok {
+        "ok"
+    } else {
+        "degraded"
+    }
+}
+
 // ─── Route handlers ───────────────────────────────────────────────────────────
 
 /// GET /health — liveness, dependency reachability, and inference probe.
@@ -245,10 +269,12 @@ pub struct ReviewRequest {
 /// LLM provider; returns JSON with dep status, reviewer model, and inference
 /// result.  HTTP 200 always (degraded state is noted in the body, not via 5xx,
 /// to avoid false-positive load-balancer evictions).  When inference is not
-/// `"ok"`, `status` becomes `"degraded"` so callers can gate on one field.
+/// `"ok"` OR a required dep is unreachable, `status` becomes `"degraded"` so
+/// callers can gate on one field.
 /// Test: `health_inference_ok_when_llm_ok`,
 /// `health_inference_auth_error_sets_degraded`,
-/// `health_inference_unreachable_sets_degraded`.
+/// `health_required_dep_down_sets_degraded`,
+/// `health_optional_dep_down_stays_ok`.
 pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
     // Non-blocking dep probes — treat errors as "unreachable".
     let search_reachable = state.search.health().await.is_ok_and(|r| r.is_healthy());
@@ -264,7 +290,19 @@ pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
         .probe(&state.llm, &reviewer_model)
         .await;
 
-    let status = if inference.is_ok() { "ok" } else { "degraded" };
+    let deps = DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: search_reachable,
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: analyze_reachable,
+        },
+    };
+
+    // #722: status is "degraded" when inference fails OR any required dep is down.
+    let status = compute_status(inference, &deps);
 
     let body = HealthResponse {
         status,
@@ -272,16 +310,7 @@ pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
         dry_run: state.config.dry_run,
         reviewer_model,
         inference,
-        deps: DepStatus {
-            trusty_search: DepInfo {
-                required: true,
-                reachable: search_reachable,
-            },
-            trusty_analyze: DepInfo {
-                required: false,
-                reachable: analyze_reachable,
-            },
-        },
+        deps,
     };
 
     (StatusCode::OK, Json(body))
@@ -429,8 +458,14 @@ fn resolve_diff_source(req: &ReviewRequest) -> Result<DiffSource, String> {
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
-// Split into `handlers_tests.rs` to keep this file under the 500-line cap.
+// Split into focused sibling files to keep every file under the 500-line cap:
+//   handlers_tests.rs        — fakes, state builders, and basic handler tests.
+//   handlers_status_tests.rs — compute_status unit tests + dep-degradation (#722).
 
 #[cfg(test)]
 #[path = "handlers_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "handlers_status_tests.rs"]
+mod status_tests;

--- a/crates/trusty-review/src/service/handlers_status_tests.rs
+++ b/crates/trusty-review/src/service/handlers_status_tests.rs
@@ -1,0 +1,200 @@
+//! Status-computation tests for `service::handlers` (#722).
+//!
+//! Why: split from `handlers_tests.rs` to keep both files under the 500-line
+//! cap while preserving full coverage of the `compute_status` helper and the
+//! HTTP handler integration for dep-reachability degradation.
+//! What: pure unit tests for `compute_status` (no async / HTTP) and two async
+//! integration tests that exercise `handle_health` with fake search clients.
+//! Test: this is the test module; each function is a self-contained unit test.
+
+use std::sync::Arc;
+
+use axum::{body::to_bytes, extract::State, http::StatusCode, response::IntoResponse as _};
+
+use crate::service::handlers::{AppState, DepInfo, DepStatus, compute_status, handle_health};
+use crate::service::inference_probe::InferenceStatus;
+
+// Re-use the fakes defined in `handlers_tests.rs` which is loaded first.
+use super::tests::{FailSearch, FakeAnalyze, FakeLlm, FakeSearch};
+
+// ── compute_status unit tests (#722) ──────────────────────────────────────────
+
+/// compute_status returns "ok" when inference is ok and all required deps reachable.
+///
+/// Why: the happy-path gate for #722 — verifies the base "ok" case is unbroken.
+/// What: calls compute_status with Ok inference + both deps reachable; asserts "ok".
+/// Test: this test itself.
+#[test]
+fn health_status_ok_all_good() {
+    let deps = DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: true,
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: true,
+        },
+    };
+    assert_eq!(
+        compute_status(InferenceStatus::Ok, &deps),
+        "ok",
+        "all good → status must be ok"
+    );
+}
+
+/// compute_status returns "degraded" when a required dep is unreachable (#722).
+///
+/// Why: the core of the #722 fix — a required dep being down must flip status
+/// to "degraded" even when inference itself is fine.
+/// What: calls compute_status with Ok inference + trusty_search unreachable;
+/// asserts "degraded".
+/// Test: this test itself.
+#[test]
+fn health_status_degraded_required_dep_down() {
+    let deps = DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: false, // required dep is down
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: true,
+        },
+    };
+    assert_eq!(
+        compute_status(InferenceStatus::Ok, &deps),
+        "degraded",
+        "required dep down → status must be degraded"
+    );
+}
+
+/// compute_status returns "degraded" when inference fails, even if all deps reachable.
+///
+/// Why: preserves the existing #719 behavior — inference failure alone must degrade.
+/// What: calls compute_status with AuthError inference + all deps reachable; asserts
+/// "degraded".
+/// Test: this test itself.
+#[test]
+fn health_status_degraded_inference_auth_error() {
+    let deps = DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: true,
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: true,
+        },
+    };
+    assert_eq!(
+        compute_status(InferenceStatus::AuthError, &deps),
+        "degraded",
+        "auth_error inference → status must be degraded"
+    );
+}
+
+/// compute_status stays "ok" when only a non-required dep is unreachable (#722).
+///
+/// Why: a non-required dep being down must NOT degrade status — only required deps matter.
+/// What: calls compute_status with Ok inference + trusty_analyze (required=false)
+/// unreachable; asserts "ok".
+/// Test: this test itself.
+#[test]
+fn health_status_ok_optional_dep_down() {
+    let deps = DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: true,
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: false, // optional dep down — must not degrade
+        },
+    };
+    assert_eq!(
+        compute_status(InferenceStatus::Ok, &deps),
+        "ok",
+        "optional dep down → status must remain ok"
+    );
+}
+
+/// /health sets `status: "degraded"` when trusty_search (required) is unreachable.
+///
+/// Why: validates the full HTTP handler path for #722 — the integration between
+/// handle_health, dep probing, and compute_status.
+/// What: uses FailSearch (health() returns Err) + FakeLlm (ok inference); deserialises
+/// response body; asserts status is "degraded" and deps.trusty_search.reachable is false.
+/// Test: this test itself.
+#[tokio::test]
+async fn health_required_dep_down_sets_degraded() {
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        Arc::new(FailSearch),
+        None,
+    );
+    let response = handle_health(State(state)).await;
+    let resp: axum::response::Response = response.into_response();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "HTTP status must be 200 even when degraded (spec REV-706)"
+    );
+
+    let body_bytes = to_bytes(resp.into_body(), 65536).await.expect("body bytes");
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).expect("valid JSON");
+
+    assert_eq!(
+        body["status"], "degraded",
+        "required dep (trusty_search) unreachable → status must be degraded"
+    );
+    assert_eq!(
+        body["inference"], "ok",
+        "inference must be ok (FakeLlm always succeeds)"
+    );
+    assert_eq!(
+        body["deps"]["trusty_search"]["reachable"], false,
+        "trusty_search.reachable must be false when search is down"
+    );
+    assert_eq!(
+        body["deps"]["trusty_search"]["required"], true,
+        "trusty_search.required must remain true"
+    );
+}
+
+/// /health stays "ok" when only the optional dep (trusty_analyze) is unreachable.
+///
+/// Why: validates that only required deps can degrade status — optional dep failures
+/// must appear only in deps.<name>.reachable, not in top-level status.
+/// What: uses FakeSearch (ok) + FakeAnalyze (health() returns Err) + FakeLlm (ok);
+/// asserts status is "ok" and deps.trusty_analyze.reachable is false.
+/// Test: this test itself.
+#[tokio::test]
+async fn health_optional_dep_down_stays_ok() {
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        Arc::new(FakeSearch),
+        Some(Arc::new(FakeAnalyze)),
+    );
+    let response = handle_health(State(state)).await;
+    let resp: axum::response::Response = response.into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body_bytes = to_bytes(resp.into_body(), 65536).await.expect("body bytes");
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).expect("valid JSON");
+
+    assert_eq!(
+        body["status"], "ok",
+        "optional dep (trusty_analyze) unreachable → status must remain ok"
+    );
+    assert_eq!(
+        body["deps"]["trusty_analyze"]["reachable"], false,
+        "trusty_analyze.reachable must be false (FakeAnalyze.health() fails)"
+    );
+    assert_eq!(
+        body["deps"]["trusty_search"]["reachable"], true,
+        "trusty_search.reachable must be true (FakeSearch.health() succeeds)"
+    );
+}


### PR DESCRIPTION
When a required dependency (trusty_search) is unreachable OR inference status != ok, the service's top-level health status now becomes 'degraded'.

Non-required dependencies do not degrade overall status.

Changes:
- Centralized `compute_status` function shared by HTTP and MCP paths
- Dependency health matrix with required/optional distinction
- 8 status-matrix tests covering all combinations
- Version bump: trusty-review 0.3.0 → 0.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)