### PR TITLE
docs(trusty-review): document 0.3.x features (inference probe, health gating, footer)

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.2] — 2026-06-03
+
+### Added
+
+- **Model + token-usage footer on posted reviews** (#728) — every posted PR review
+  comment now includes a metadata footer with the reviewer model slug, input/output
+  token counts, and cost estimate (e.g., `🤖 Reviewed by us.anthropic.claude-sonnet-4-6 · tokens ↑1234 ↓567 · est. $0.01`).
+  Single-source-of-truth with the `ReviewResult` struct fields; appears identically in dry-run output.
+
+---
+
+## [0.3.1] — 2026-06-03
+
+### Fixed
+
+- **Required-dependency health gating** (#722) — `review_health` now reports
+  `status: degraded` only when a *required* dependency (trusty-search) is unreachable.
+  Non-required dependencies (trusty-analyze) being unavailable does NOT degrade status.
+  Centralized `compute_status` logic shared by HTTP + MCP paths.
+
+---
+
+## [0.3.0] — 2026-06-03
+
+### Added
+
+- **Inference reachability probe in health endpoint** (#719) — `review_health` now
+  includes an `inference` field (`ok` | `unreachable` | `auth_error` | `unknown`),
+  always-on with 10s TTL and 3s timeout. Covers Bedrock + OpenRouter availability.
+  When inference != ok, service status is degraded.
+
+---
+
 ## [0.2.0] — 2026-06-03
 
 ### Added

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -63,7 +63,7 @@ Endpoints:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/health` | Liveness + dependency status |
+| GET | `/health` | Liveness, dependency + inference status (see MCP `review_health` for schema) |
 | GET | `/status` | In-flight count + last error |
 | POST | `/review` | Synchronous on-demand review |
 | POST | `/pr/github/webhook` | GitHub PR webhook (HMAC-validated) |
@@ -110,7 +110,19 @@ Wire into Claude Code via `.mcp.json`:
 }
 ```
 
-Returns a `ReviewResult` JSON object (verdict, findings, token counts, cost estimate).
+Returns a `ReviewResult` JSON object with:
+- `verdict` (APPROVE | APPROVE* | REQUEST_CHANGES | BLOCK | Unknown)
+- `findings` (array of findings with severity + confidence)
+- `input_tokens` / `output_tokens` — LLM token usage
+- `cost_estimate_usd` — estimated API cost
+
+When posted to GitHub, the review comment includes a footer:
+
+```
+🤖 Reviewed by us.anthropic.claude-sonnet-4-6 · tokens ↑1234 ↓567 · est. $0.01
+```
+
+(↑ = input tokens, ↓ = output tokens). The footer appears identically in dry-run output.
 
 #### `review_diff`
 
@@ -131,7 +143,38 @@ Returns a `ReviewResult` JSON object (verdict, findings, token counts, cost esti
 { "name": "review_health", "arguments": {} }
 ```
 
-Returns `{ "status": "ok", "version": "...", "dry_run": true, "reviewer_model": "...", "deps": {...} }`.
+Returns a health status object:
+
+```json
+{
+  "status": "ok",
+  "version": "0.3.2",
+  "dry_run": true,
+  "reviewer_model": "us.anthropic.claude-sonnet-4-6",
+  "inference": "ok",
+  "deps": {
+    "trusty_search": {
+      "required": true,
+      "reachable": true
+    },
+    "trusty_analyze": {
+      "required": false,
+      "reachable": true
+    }
+  }
+}
+```
+
+**Status values:**
+- `ok` — all dependencies healthy and inference reachable.
+- `degraded` — a required dependency (trusty-search) or inference is unreachable.
+- `unknown` — cannot determine health state.
+
+**Inference field values:**
+- `ok` — AWS Bedrock and/or OpenRouter accessible.
+- `unreachable` — both inference providers unreachable (network/DNS error).
+- `auth_error` — inference provider reachable but auth failed (bad API key).
+- `unknown` — inference probe could not determine status.
 
 ## Environment variables
 

--- a/docs/trusty-review/research/health-inference-footer-2026-06-03.md
+++ b/docs/trusty-review/research/health-inference-footer-2026-06-03.md
@@ -1,0 +1,119 @@
+# trusty-review 0.3.x — Health, Inference, and Footer Features
+
+**Date:** 2026-06-03  
+**Issues:** #728, #722, #719  
+**Versions:** 0.3.0, 0.3.1, 0.3.2
+
+---
+
+## Overview
+
+Three refinements to trusty-review's health reporting and review output completed in June 2026:
+
+1. **Inference reachability probe** (0.3.0, #719) — proactive detection of Bedrock/OpenRouter availability.
+2. **Required-dependency gating** (0.3.1, #722) — health status reflects only critical dependencies (trusty-search).
+3. **Review comment footer** (0.3.2, #728) — model + token-usage transparency on posted PR reviews.
+
+---
+
+## Feature Details
+
+### 0.3.0: Inference Reachability Probe (#719)
+
+**Problem:** No visibility into LLM inference availability until a review is attempted.
+
+**Solution:** `review_health` endpoint now includes an `inference` field:
+
+- `ok` — AWS Bedrock and/or OpenRouter accessible.
+- `unreachable` — both providers unreachable (network/DNS error).
+- `auth_error` — provider reachable but authentication failed.
+- `unknown` — probe could not determine status.
+
+**Implementation:**
+- Always-on cached probe: 10s TTL, 3s timeout.
+- Covers both Bedrock and OpenRouter endpoints.
+- Service status transitions to `degraded` when inference != `ok`.
+
+**Consumer impact:** Operators and users get early warning of LLM unavailability before paying for a review run that will fail.
+
+---
+
+### 0.3.1: Required-Dependency Health Gating (#722)
+
+**Problem:** Health status was ambiguous about which deps were critical vs. optional.
+
+**Solution:** Centralized `compute_status` logic that:
+
+- Reports `status: degraded` **only** when a **required** dependency (trusty-search) is unreachable.
+- Non-required dependencies (trusty-analyze) being down does **not** degrade status.
+- Applies consistently to HTTP `/health` and MCP `review_health` tool paths.
+
+**Background:** As of #590, trusty-search is mandatory for contextual reviews; trusty-analyze is strongly preferred but can be opted out via config. The health response now reflects this distinction.
+
+**Consumer impact:** Operators can see at a glance that trusty-search is the critical blocker; analyze unavailability is a non-event.
+
+---
+
+### 0.3.2: Review Comment Footer (#728)
+
+**Problem:** Posted PR reviews had no source attribution or cost transparency.
+
+**Solution:** Every posted review comment now ends with:
+
+```
+🤖 Reviewed by us.anthropic.claude-sonnet-4-6 · tokens ↑1234 ↓567 · est. $0.01
+```
+
+- **Model:** Reviewer model slug (e.g., `us.anthropic.claude-sonnet-4-6` for Bedrock Sonnet).
+- **↑ input tokens:** LLM prompt token count.
+- **↓ output tokens:** LLM completion token count.
+- **Cost:** Estimated USD spend (sourced from Bedrock pricing tables or OpenRouter).
+
+**Implementation:**
+- Single-source-of-truth with `ReviewResult` struct fields: `model`, `input_tokens`, `output_tokens`, `cost_estimate_usd`.
+- Generated in `pipeline/post.rs::finalize_review()`.
+- Appears identically in dry-run output and live posts.
+
+**Consumer impact:** Full transparency on model choice, token usage, and inference costs. Useful for cost allocation and model selection tuning.
+
+---
+
+## Health Response Schema (0.3.2+)
+
+```json
+{
+  "status": "ok|degraded|unknown",
+  "version": "0.3.2",
+  "dry_run": true,
+  "reviewer_model": "us.anthropic.claude-sonnet-4-6",
+  "inference": "ok|unreachable|auth_error|unknown",
+  "deps": {
+    "trusty_search": {
+      "required": true,
+      "reachable": true
+    },
+    "trusty_analyze": {
+      "required": false,
+      "reachable": true
+    }
+  }
+}
+```
+
+---
+
+## Testing & Validation
+
+All three features are exercised by:
+- MCP tool `review_health` (probes health endpoint).
+- HTTP `GET /health` (direct daemon endpoint).
+- Integration tests in `service/handlers_tests.rs`.
+- Manual dry-run reviews (footer visible in comment body).
+
+---
+
+## Future Directions
+
+- Expand `inference` probe to include latency metrics (p50/p95 response time).
+- Per-model cost breakdown (if review uses multiple reviewer candidates in future compare logic).
+- Webhook signature validation before health-check calls (currently omitted for liveness simplicity).


### PR DESCRIPTION
Documentation updates for trusty-review 0.3.0, 0.3.1, and 0.3.2:

## Changes

**CHANGELOG.md:**
- Added entries for v0.3.0 (inference reachability probe, #719)
- Added entries for v0.3.1 (required-dependency gating, #722)
- Added entries for v0.3.2 (model + token-usage footer, #728)

**README.md:**
- Enhanced `review_health` MCP tool documentation with complete response schema
- Added health status field descriptions (ok/degraded/unknown)
- Added inference field values (ok/unreachable/auth_error/unknown)
- Documented review comment footer with model, token counts, and cost estimate
- Updated HTTP /health endpoint description

**Research doc:**
- Created `health-inference-footer-2026-06-03.md` documenting the feature set with implementation details and testing notes

## Files Modified
- `crates/trusty-review/CHANGELOG.md` — version history updates
- `crates/trusty-review/README.md` — API and health documentation
- `docs/trusty-review/research/health-inference-footer-2026-06-03.md` — new feature research doc

## Verification
- No code changes (docs only)
- All Cargo files untouched
- Consistent with existing documentation style and conventions