### PR TITLE
fix(trusty-review): calibrate adversarial verifier — 16-token truncation, symmetric burden-of-proof, verdict preservation on error-refutations (closes #726)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11011,7 +11011,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.3.2" }
+trusty-review = { path = "crates/trusty-review", version = "0.3.3" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,51 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.3] — 2026-06-03
+
+### Fixed
+
+- **Adversarial verifier calibration — fixes 100% refutation rate** (#726)
+
+  Three root causes were identified and fixed together:
+
+  1. **Token truncation (root cause):** The verifier role's `default_max_tokens`
+     was `16`, which is too small to hold a complete `{"judgment":"CONFIRMED","reason":"…"}`
+     JSON object. Bedrock truncated the response mid-JSON, making it unparseable,
+     which triggered a conservative refutation on every call.  Bumped to `128`.
+     The module-level fallback constant `VERIFY_MAX_TOKENS` was also raised from
+     `64` to `128` for consistency.
+
+  2. **Biased burden-of-proof prompt:** The verifier system prompt contained
+     "The default answer is REFUTED. When in doubt, REFUTE." — a strong default
+     that compounded the truncation problem.  Replaced with a symmetric,
+     evidence-weighing instruction that asks the model to decide on the actual diff
+     content without defaulting to either verdict.  The truncation/hallucination
+     hard rule (REFUTE anything referencing a file/line absent from the diff) is
+     preserved unchanged.
+
+  3. **Verdict collapse on non-clean refutations:** Unparseable/truncated verifier
+     responses were mapped to plain `VerifyOutcome::Refuted`, indistinguishable
+     from a clean model REFUTED.  `rederive_verdict` then treated all-refuted
+     rounds as "escalation rested on refuted evidence" and dropped the verdict to
+     `APPROVE`.  Two fixes:
+     - Unparseable responses are now mapped to the distinct `TruncationRefuted`
+       variant (already present in `VerifyOutcome`), separating infrastructure
+       failures from clean model judgments.
+     - `rederive_verdict` uses a three-way baseline rule: (a) any confirmed →
+       keep `primary_verdict`; (b) at least one clean model REFUTED → drop to
+       `APPROVE`; (c) all demotions were `TruncationRefuted`/`ErrorRefuted` →
+       preserve `primary_verdict` (verifier infra failed, not the reviewer's
+       reasoning).
+
+  **Regression fixture:** `verify_join_handle_regression_pr720` models the
+  dropped-`JoinHandle` finding from PR #720 (the true-positive that was wrongly
+  refuted in the original incident).  Asserts that (a) a CONFIRMED judgment
+  preserves the finding, and (b) a truncated judgment does NOT collapse the
+  verdict to APPROVE.
+
+---
+
 ## [0.3.2] — 2026-06-03
 
 ### Added

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.2"
+version     = "0.3.3"
 edition     = "2024"
 rust-version.workspace = true
 license-file           = "LICENSE"

--- a/crates/trusty-review/src/config/role_models.rs
+++ b/crates/trusty-review/src/config/role_models.rs
@@ -107,7 +107,7 @@ impl RoleModels {
             crate::llm::models::DEFAULT_VERIFIER_MODEL,
             Provider::Bedrock,
             1.0,
-            16,
+            128,
         );
         let summarizer = resolve_role(
             cli_overrides.and_then(|c| c.summarizer_model.as_deref()),

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -14,19 +14,14 @@
 //! refuted relaxes correctly.  `probe_verifier_liveness` is the startup gate that
 //! refuses live mode when the verifier model is unavailable.
 //!
-//! ## Why the liveness gate exists (incident rationale)
-//! code-intelligence suffered a production incident where a **stale verifier
-//! model** (an inference profile that had been deactivated) caused every
-//! verification call to fail with `ResourceNotFoundException`.  Those errors were
-//! swallowed as REFUTED, so EVERY finding was silently auto-refuted and EVERY
-//! review collapsed to APPROVE — the reviewer was effectively neutered with no
-//! visible signal.  The startup liveness probe (`probe_verifier_liveness`) exists
-//! specifically to make that failure mode loud: in live mode we refuse to start
-//! when the verifier model is dead, rather than running a defanged reviewer.
+//! ## Liveness gate
+//! The startup liveness probe (`probe_verifier_liveness`, in `verify_liveness.rs`)
+//! refuses live mode when the verifier model is dead, so a stale inference profile
+//! cannot silently auto-refute every finding.  See that module for the full incident
+//! rationale.
 //!
-//! Test: see `verify_tests.rs` — candidate selection per verdict, CONFIRMED
-//! keeps / REFUTED demotes, verdict re-derivation after demotion, and the
-//! liveness-gate decision logic with an injected model-unavailable provider.
+//! Test: `verify_tests.rs` — candidate selection, CONFIRMED/REFUTED outcomes,
+//! verdict re-derivation, truncation regression (#726), and liveness-gate logic.
 
 use std::sync::Arc;
 
@@ -163,22 +158,32 @@ pub async fn run_verification_round(
         .await;
 
     // Apply outcomes: record on the finding and demote refuted ones.  Track
-    // whether ANY candidate was confirmed — that decides whether the model's
-    // original escalation is still grounded (see `rederive_verdict`).
+    // whether ANY candidate was confirmed AND whether at least one demotion was a
+    // clean model REFUTED (as opposed to an infrastructure failure class).  These
+    // two bits together let `rederive_verdict` decide the right baseline.
     let mut any_confirmed = false;
+    let mut any_clean_refuted = false;
     for (idx, outcome) in outcomes {
-        if matches!(outcome, VerifyOutcome::Confirmed) {
-            any_confirmed = true;
+        match &outcome {
+            VerifyOutcome::Confirmed => any_confirmed = true,
+            VerifyOutcome::Refuted => any_clean_refuted = true,
+            _ => {}
         }
         apply_outcome(&mut findings[idx], outcome);
     }
 
     // Re-derive the verdict from the SURVIVING findings (refuted ones excluded).
-    let final_verdict = rederive_verdict(primary_verdict.clone(), any_confirmed, findings);
+    let final_verdict = rederive_verdict(
+        primary_verdict.clone(),
+        any_confirmed,
+        any_clean_refuted,
+        findings,
+    );
     info!(
         primary = %primary_verdict,
         final = %final_verdict,
         any_confirmed,
+        any_clean_refuted,
         "verification round complete — verdict re-derived"
     );
     final_verdict
@@ -195,28 +200,38 @@ pub async fn run_verification_round(
 ///      bound, so always passing the original BLOCK would pin the result at
 ///      BLOCK even when every blocking finding was refuted.
 ///
-/// The rule, designed to satisfy the ticket's example ("a BLOCK whose only
-/// blocking finding was REFUTED should fall back") without throwing away
-/// legitimate model escalation on *confirmed* findings:
-///   - Always exclude refuted findings from the floor computation.
-///   - If at least one candidate was CONFIRMED, the model's escalation is still
-///     grounded, so use the original `primary_verdict` as the lower bound:
-///     `max(primary_verdict, survivor_floor)` (preserves e.g. a model
-///     REQUEST_CHANGES backed by a confirmed Medium finding).
-///   - If NO candidate was confirmed (all refuted), the escalation rested on
-///     refuted evidence, so drop the lower bound to a neutral `APPROVE` baseline
-///     and let the surviving findings alone decide — relaxing the verdict.
+/// The baseline selection rule (designed to satisfy the ticket's examples while
+/// fixing the #726 verdict-collapse-on-infrastructure-failure bug):
+///
+///   a) ANY confirmed → the model's escalation is grounded, keep `primary_verdict`
+///      as the lower bound so e.g. a REQUEST_CHANGES backed by a confirmed Medium
+///      finding is not silently downgraded.
+///
+///   b) At least one clean model REFUTED (i.e. `any_clean_refuted`), no confirmed
+///      → the escalation rested on refuted evidence, drop to neutral `APPROVE`
+///      baseline and let the survivors decide.
+///
+///   c) ALL demotions were non-clean (TruncationRefuted / ErrorRefuted), nothing
+///      confirmed → the verification infrastructure failed, NOT the model's
+///      reasoning.  Preserve `primary_verdict` so a BLOCK is not silently discarded
+///      because the verifier's JSON was truncated or the model was unreachable.
+///      This is the bug fixed in #726: a 16-token cap caused 100% TruncationRefuted,
+///      which previously fell into path (b) and collapsed every review to APPROVE.
 ///
 /// `UNKNOWN` is handled by the caller and never reaches here.
-/// What: filters out refutation-variant findings, picks the baseline per the
-/// rule above, then calls `derive_verdict(baseline, survivors)`.
-/// Test: `rederive_excludes_refuted_relaxes`, `rederive_keeps_confirmed_block`,
-/// `rederive_mixed_keeps_only_surviving_floor`, and the end-to-end
-/// `verify_refuted_demotes_and_block_relaxes` /
-/// `run_review_verification_confirms_and_preserves_verdict`.
+/// What: filters out all refutation-variant findings from the survivor set, selects
+/// the baseline via the three-way rule above, then calls
+/// `derive_verdict(baseline, survivors)`.
+/// Test: `rederive_excludes_refuted_relaxes` (path b),
+/// `rederive_keeps_confirmed_block` (path a),
+/// `rederive_error_refuted_preserves_primary_verdict` (path c — regression for #726),
+/// `rederive_truncation_refuted_preserves_primary_verdict` (path c),
+/// and the end-to-end `verify_refuted_demotes_and_block_relaxes` /
+/// `verify_join_handle_regression_pr720`.
 fn rederive_verdict(
     primary_verdict: Verdict,
     any_confirmed: bool,
+    any_clean_refuted: bool,
     findings: &[Finding],
 ) -> Verdict {
     let survivors: Vec<Finding> = findings
@@ -231,13 +246,25 @@ fn rederive_verdict(
         })
         .cloned()
         .collect();
-    // Confirmed evidence keeps the model's escalation as a lower bound; an
-    // all-refuted candidate set drops to a neutral baseline so the verdict relaxes.
+
+    // Three-way baseline selection (see Why above):
+    //  a) any confirmed   → keep model's escalation (grounded evidence)
+    //  b) clean refuted   → drop to APPROVE (model said REFUTED on merits)
+    //  c) infra-only fail → keep model's escalation (don't discard on truncation/error)
     let baseline = if any_confirmed {
+        // Path (a): confirmed evidence supports the escalation.
         primary_verdict
-    } else {
+    } else if any_clean_refuted {
+        // Path (b): at least one clean REFUTED from the model — escalation rested
+        // on refuted evidence; let survivors alone decide.
         Verdict::Approve
+    } else {
+        // Path (c): all demotions were infrastructure failures (TruncationRefuted /
+        // ErrorRefuted) — preserve the model's escalation rather than silently
+        // collapsing to APPROVE due to verifier infra failure.
+        primary_verdict
     };
+
     derive_verdict(baseline, &survivors)
 }
 
@@ -295,16 +322,19 @@ struct VerifyJudgment {
 /// lifecycle error (`is_alarm`) from the verifier model must NOT be silently
 /// swallowed as a plain refutation — that is exactly the incident this phase
 /// guards against.  Such errors map to `ErrorRefuted { error_class }` AND emit
-/// the `verification_model_error` signal; only a clean CONFIRMED/REFUTED judgment
-/// (or a transient error, which is conservatively treated as unverifiable) maps
-/// to the ordinary outcomes.
+/// the `verification_model_error` signal.  An unparseable/truncated response maps
+/// to `TruncationRefuted` (distinct from a clean model `Refuted`) so
+/// `rederive_verdict` can tell apart "the model said REFUTED" from "the provider
+/// returned garbage", and preserve the model's escalation in the latter case.
 /// What: calls the verifier, parses the forced JSON judgment, and returns
 /// `Confirmed` / `Refuted` accordingly.  On an alarm-class `LlmError`, emits the
-/// signal and returns `ErrorRefuted`.  On a transient error or unparseable
-/// output, returns `Refuted` (conservative: an unverifiable finding must not be
-/// allowed to block) without raising the alarm.
+/// signal and returns `ErrorRefuted`.  On a transient error returns plain `Refuted`
+/// (conservative: unverifiable via transient fault — not a structural problem).
+/// On a successful call that returns unparseable output returns `TruncationRefuted`
+/// (structurally distinct from a clean REFUTED judgment).
 /// Test: `verify_one_confirmed`, `verify_one_refuted`,
-/// `verify_one_model_unavailable_emits_signal`.
+/// `verify_one_model_unavailable_emits_signal`,
+/// `verify_truncated_response_is_truncation_refuted`.
 async fn verify_one(verifier: &Arc<dyn LlmProvider>, req: crate::llm::LlmRequest) -> VerifyOutcome {
     let model = req.model.clone();
     match verifier.complete(req).await {
@@ -314,9 +344,11 @@ async fn verify_one(verifier: &Arc<dyn LlmProvider>, req: crate::llm::LlmRequest
             None => {
                 warn!(
                     text = %truncate(&resp.text, 120),
-                    "verifier returned unparseable judgment — treating as REFUTED (conservative)"
+                    "verifier returned unparseable/truncated judgment — recording TruncationRefuted"
                 );
-                VerifyOutcome::Refuted
+                // Use a structurally distinct variant so rederive_verdict can
+                // distinguish "model said REFUTED" from "provider returned garbage".
+                VerifyOutcome::TruncationRefuted
             }
         },
         Err(e) if e.is_alarm() => {

--- a/crates/trusty-review/src/pipeline/verify_liveness.rs
+++ b/crates/trusty-review/src/pipeline/verify_liveness.rs
@@ -14,7 +14,7 @@
 //!
 //! Test: `liveness_alive_allows_start`, `liveness_model_unavailable_refuses`,
 //! `liveness_access_denied_refuses`, `liveness_transient_allows_start`,
-//! `liveness_rate_limited_allows_start` in `verify_tests.rs`.
+//! `liveness_rate_limited_allows_start` in the `tests` module below.
 
 use std::sync::Arc;
 
@@ -36,7 +36,7 @@ use crate::{
 /// What: `Ok` means the verifier model is alive (or the probe was disabled);
 /// `Refuse` carries the human-readable reason and the error class for the signal.
 /// Test: `liveness_alive_allows_start`, `liveness_model_unavailable_refuses`,
-/// `liveness_transient_allows_start`.
+/// `liveness_transient_allows_start` in `tests`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LivenessDecision {
     /// The verifier model responded (or the probe was skipped) — start is allowed.
@@ -64,7 +64,7 @@ pub enum LivenessDecision {
 /// `ModelNotReady` / `Validation` / `AccessDenied`) returns `Refuse`, after
 /// emitting the `verification_model_error` signal.
 /// Test: `liveness_alive_allows_start`, `liveness_model_unavailable_refuses`,
-/// `liveness_transient_allows_start`.
+/// `liveness_transient_allows_start` in `tests`.
 pub async fn probe_verifier_liveness(
     verifier: &Arc<dyn LlmProvider>,
     verifier_model: &str,
@@ -286,5 +286,80 @@ mod tests {
     async fn enforce_dry_run_missing_verifier_allows() {
         let c = cfg(true, true, true);
         assert!(enforce_verifier_liveness(&c, None).await.is_ok());
+    }
+
+    // ── probe_verifier_liveness direct tests ─────────────────────────────────
+
+    #[tokio::test]
+    async fn liveness_alive_allows_start() {
+        // The verifier responds (any text) → Ok.
+        let decision = probe_verifier_liveness(&alive(), "us.anthropic.claude-haiku-4-5").await;
+        assert_eq!(
+            decision,
+            LivenessDecision::Ok,
+            "a responding model allows start"
+        );
+    }
+
+    #[tokio::test]
+    async fn liveness_model_unavailable_refuses() {
+        // ModelNotFound is an alarm-class error → Refuse (the incident path).
+        let dead_model: Arc<dyn LlmProvider> = Arc::new(StubVerifier {
+            err: Some(|| LlmError::ModelNotFound("no-such-profile".to_string())),
+        });
+        let decision = probe_verifier_liveness(&dead_model, "no-such-profile").await;
+        match decision {
+            LivenessDecision::Refuse {
+                error_class,
+                reason,
+            } => {
+                assert_eq!(error_class, "ModelNotFound");
+                assert!(reason.contains("no-such-profile"), "reason names the model");
+                assert!(
+                    reason.contains("refusing to start"),
+                    "reason must state the refusal"
+                );
+            }
+            LivenessDecision::Ok => panic!("an unavailable verifier model must refuse start"),
+        }
+    }
+
+    #[tokio::test]
+    async fn liveness_access_denied_refuses() {
+        let access_denied: Arc<dyn LlmProvider> = Arc::new(StubVerifier {
+            err: Some(|| LlmError::AccessDenied("bad iam".to_string())),
+        });
+        let decision = probe_verifier_liveness(&access_denied, "m").await;
+        assert!(
+            matches!(decision, LivenessDecision::Refuse { .. }),
+            "AccessDenied is alarm-class and must refuse start"
+        );
+    }
+
+    #[tokio::test]
+    async fn liveness_transient_allows_start() {
+        // A transient error during the probe must NOT block startup.
+        let transient: Arc<dyn LlmProvider> = Arc::new(StubVerifier {
+            err: Some(|| LlmError::Transport("connection reset".to_string())),
+        });
+        let decision = probe_verifier_liveness(&transient, "m").await;
+        assert_eq!(
+            decision,
+            LivenessDecision::Ok,
+            "a transient probe error must not block startup"
+        );
+    }
+
+    #[tokio::test]
+    async fn liveness_rate_limited_allows_start() {
+        let rate_limited: Arc<dyn LlmProvider> = Arc::new(StubVerifier {
+            err: Some(|| LlmError::RateLimited),
+        });
+        let decision = probe_verifier_liveness(&rate_limited, "m").await;
+        assert_eq!(
+            decision,
+            LivenessDecision::Ok,
+            "rate-limit during probe is transient"
+        );
     }
 }

--- a/crates/trusty-review/src/pipeline/verify_prompt.rs
+++ b/crates/trusty-review/src/pipeline/verify_prompt.rs
@@ -35,9 +35,13 @@ const VERIFY_TEMPERATURE: f32 = 1.0;
 /// Maximum output tokens for a verification call.
 ///
 /// Why: the response is a single judgment plus a short reason; a tight cap keeps
-/// latency and cost low (verifier calls are high-volume).
-/// What: 64 tokens is ample for `{"judgment":"REFUTED","reason":"..."}`.
-const VERIFY_MAX_TOKENS: u32 = 64;
+/// latency and cost low (verifier calls are high-volume).  128 is the minimum
+/// that reliably fits `{"judgment":"CONFIRMED","reason":"..."}` plus any provider
+/// framing overhead — the previous value of 64 caused Bedrock to truncate the
+/// response mid-JSON, making it unparseable and forcing a conservative
+/// TruncationRefuted outcome on every call (#726).
+/// What: 128 tokens is ample for the forced-schema JSON object.
+const VERIFY_MAX_TOKENS: u32 = 128;
 
 /// Name used for the verifier's forced-output tool / json_schema.
 ///
@@ -51,13 +55,16 @@ pub const VERIFY_SCHEMA_NAME: &str = "verification_judgment";
 /// Return the verifier system prompt.
 ///
 /// Why: the verifier is a *fact-checker*, not a re-reviewer — its sole job is to
-/// confirm or refute the specific finding it is handed.  Encoding the
-/// truncation/hallucination guard here (REFUTE anything that references a
-/// file/line not present in the provided diff) is the key false-positive defence
-/// borrowed from the code-intelligence verifier protocol.
+/// confirm or refute the specific finding it is handed.  The previous prompt
+/// contained a "default to REFUTED / when in doubt REFUTE" instruction that
+/// caused 100% refutation rates when combined with a 16-token truncation bug
+/// (#726).  The replacement uses a symmetric, evidence-weighing rule so the
+/// model decides on the actual evidence rather than a biased prior.  The
+/// truncation/hallucination hard rule (REFUTE anything referencing a file/line
+/// absent from the diff) is preserved verbatim — that guard is legitimate.
 /// What: returns a static string instructing the model to emit exactly one of
-/// CONFIRMED / REFUTED with a one-line reason, and to default to REFUTED when the
-/// finding cannot be grounded in the supplied diff.
+/// CONFIRMED / REFUTED with a one-line reason, weighing the evidence in the diff
+/// symmetrically.
 /// Test: `verify_system_prompt_mentions_refuted_guard`.
 pub fn verifier_system_prompt() -> &'static str {
     r#"You are a strict code-review fact-checker. You are given the unified diff of a
@@ -79,8 +86,12 @@ about code that is not in the diff is, by definition, not verifiable and must be
 refuted. This rule is absolute — it overrides any plausibility you might infer.
 
 ## Burden of proof
-The default answer is REFUTED. Answer CONFIRMED only when the diff clearly shows
-the problem the finding describes. When in doubt, REFUTE.
+Weigh the evidence in the diff. Answer CONFIRMED when the finding is grounded in
+the diff and a reasonable engineer would agree it needs attention. Answer REFUTED
+when the finding is speculative, contradicted by the diff, or references code that
+is not present in the diff at all. Decide on the evidence — do not default to
+either verdict. If the concern is real but the diff is merely ambiguous, prefer
+CONFIRMED with a qualifying reason.
 
 Populate the structured response fields: `judgment` (CONFIRMED or REFUTED) and
 `reason` (one short sentence)."#

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -1,11 +1,8 @@
-//! Unit tests for `pipeline::verify` (Phase 2, #583).
+//! Unit tests for `pipeline::verify` (Phase 2, #583, #726).
 //!
-//! Why: split from `verify.rs` to keep that file under the 500-line cap while
-//! fully covering the verification round: candidate selection per primary
-//! verdict, CONFIRMED-keeps / REFUTED-demotes outcome handling, verdict
-//! re-derivation after demotion, and the liveness-gate decision logic with an
-//! injected model-unavailable provider.
-//! What: drives the public verify API with deterministic fake providers.
+//! Why: split from `verify.rs` to keep that file under the 500-line cap.
+//! What: covers candidate selection, outcome application, verdict re-derivation
+//! (paths a/b/c), end-to-end rounds, and truncation regression (#726).
 //! Test: this is the test module; each function is a self-contained unit test.
 
 use std::sync::Arc;
@@ -56,6 +53,27 @@ impl LlmProvider for FixedVerifier {
     }
 }
 
+/// A verifier that always returns the same fixed judgment text.
+struct TruncatedVerifier;
+
+#[async_trait]
+impl LlmProvider for TruncatedVerifier {
+    fn name(&self) -> &str {
+        "truncated-verifier"
+    }
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        // Simulate a response truncated mid-JSON (as seen with max_tokens=16).
+        Ok(LlmResponse {
+            text: r#"{"judg"#.to_string(),
+            model: req.model.clone(),
+            input_tokens: 10,
+            output_tokens: 3,
+            latency_ms: 1,
+            cost_usd: 0.0,
+        })
+    }
+}
+
 /// A verifier that always fails with a configurable `LlmError`.
 struct FailingVerifier {
     make_err: fn() -> LlmError,
@@ -82,6 +100,9 @@ fn confirmed_provider() -> Arc<dyn LlmProvider> {
 }
 fn refuted_provider() -> Arc<dyn LlmProvider> {
     Arc::new(FixedVerifier::refuted())
+}
+fn truncated_provider() -> Arc<dyn LlmProvider> {
+    Arc::new(TruncatedVerifier)
 }
 
 // ── Candidate selection ───────────────────────────────────────────────────────
@@ -178,61 +199,91 @@ fn apply_outcome_error_refuted_also_demotes() {
 
 #[test]
 fn rederive_excludes_refuted_relaxes() {
-    // One High finding, refuted, NO candidate confirmed → excluded + neutral
-    // baseline → APPROVE.
+    // Path (b): one High finding, clean REFUTED, nothing confirmed → excluded +
+    // neutral baseline → APPROVE.
     let mut f = finding(Effort::High, 0.95);
     apply_outcome(&mut f, VerifyOutcome::Refuted);
-    let verdict = rederive_verdict(Verdict::Block, false, &[f]);
+    // any_clean_refuted=true triggers path (b): drop to APPROVE baseline.
+    let verdict = rederive_verdict(Verdict::Block, false, true, &[f]);
     assert_eq!(
         verdict,
         Verdict::Approve,
-        "a refuted-only candidate set must not contribute a BLOCK floor"
+        "a cleanly-refuted candidate set must relax BLOCK to APPROVE (path b)"
     );
 }
 
 #[test]
 fn rederive_keeps_confirmed_block() {
-    // One High finding, confirmed → survives → BLOCK floor.
+    // Path (a): one High finding, confirmed → survives → BLOCK floor.
     let mut f = finding(Effort::High, 0.95);
     apply_outcome(&mut f, VerifyOutcome::Confirmed);
-    let verdict = rederive_verdict(Verdict::Block, true, &[f]);
+    let verdict = rederive_verdict(Verdict::Block, true, false, &[f]);
     assert_eq!(
         verdict,
         Verdict::Block,
-        "a confirmed High finding must keep the BLOCK floor"
+        "a confirmed High finding must keep the BLOCK floor (path a)"
     );
 }
 
 #[test]
 fn rederive_confirmed_preserves_model_escalation() {
-    // Model escalated to REQUEST_CHANGES on a single confirmed Medium finding.
+    // Path (a): model escalated to REQUEST_CHANGES on a single confirmed Medium.
     // Because a candidate was confirmed, the model's escalation is preserved
     // even though the lone-Medium floor alone is only APPROVE*.
     let mut med = finding(Effort::Medium, 0.85);
     apply_outcome(&mut med, VerifyOutcome::Confirmed);
-    let verdict = rederive_verdict(Verdict::RequestChanges, true, &[med]);
+    let verdict = rederive_verdict(Verdict::RequestChanges, true, false, &[med]);
     assert_eq!(
         verdict,
         Verdict::RequestChanges,
-        "confirmed evidence keeps the model's escalation as a lower bound"
+        "confirmed evidence keeps the model's escalation as a lower bound (path a)"
     );
 }
 
 #[test]
 fn rederive_mixed_keeps_only_surviving_floor() {
-    // High refuted + one surviving confirmed Medium, model said BLOCK.
-    // any_confirmed=true → baseline is the model BLOCK, but the BLOCK was driven
-    // by the now-refuted High... this asserts the documented trade-off: with a
-    // confirmed candidate the model's BLOCK is preserved as a lower bound.
+    // Path (a): High refuted + one surviving confirmed Medium, model said BLOCK.
+    // any_confirmed=true → baseline is the model APPROVE*, the Medium floor.
     let mut high = finding(Effort::High, 0.95);
     apply_outcome(&mut high, VerifyOutcome::Refuted);
     let mut med = finding(Effort::Medium, 0.85);
     apply_outcome(&mut med, VerifyOutcome::Confirmed);
-    let verdict = rederive_verdict(Verdict::ApproveWithReservations, true, &[high, med]);
+    let verdict = rederive_verdict(Verdict::ApproveWithReservations, true, true, &[high, med]);
     assert_eq!(
         verdict,
         Verdict::ApproveWithReservations,
-        "surviving single Medium floors to APPROVE*; refuted High is excluded"
+        "surviving single Medium floors to APPROVE*; refuted High is excluded (path a)"
+    );
+}
+
+#[test]
+fn rederive_error_refuted_preserves_primary_verdict() {
+    // Path (c): all demotions are ErrorRefuted (infra fail) → preserve primary.
+    let mut f = finding(Effort::High, 0.95);
+    apply_outcome(
+        &mut f,
+        VerifyOutcome::ErrorRefuted {
+            error_class: "ModelNotFound".to_string(),
+        },
+    );
+    let verdict = rederive_verdict(Verdict::Block, false, false, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "all-ErrorRefuted must preserve primary_verdict (path c)"
+    );
+}
+
+#[test]
+fn rederive_truncation_refuted_preserves_primary_verdict() {
+    // Path (c): all demotions are TruncationRefuted → preserve primary (#726).
+    let mut f = finding(Effort::High, 0.85);
+    apply_outcome(&mut f, VerifyOutcome::TruncationRefuted);
+    let verdict = rederive_verdict(Verdict::Block, false, false, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "all-TruncationRefuted must preserve primary_verdict (path c)"
     );
 }
 
@@ -341,9 +392,8 @@ async fn verify_unknown_is_passthrough() {
 }
 
 #[tokio::test]
-async fn verify_model_unavailable_marks_error_refuted_and_relaxes() {
-    // The verifier model is unavailable (ModelNotFound). The finding must be
-    // ErrorRefuted (NOT silently confirmed), demoted, and the verdict relaxes.
+async fn verify_model_unavailable_marks_error_refuted_and_preserves_verdict() {
+    // ModelNotFound → ErrorRefuted (path c) → primary_verdict preserved (#726).
     let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
         make_err: || LlmError::ModelNotFound("stale-verifier".to_string()),
     });
@@ -358,93 +408,126 @@ async fn verify_model_unavailable_marks_error_refuted_and_relaxes() {
         None,
     )
     .await;
-    assert!(
-        matches!(
-            findings[0].verified,
-            Some(VerifyOutcome::ErrorRefuted { .. })
-        ),
-        "a model error must record ErrorRefuted, not a plain refutation/confirmation"
-    );
+    assert!(matches!(
+        findings[0].verified,
+        Some(VerifyOutcome::ErrorRefuted { .. })
+    ));
     assert_eq!(
         verdict,
-        Verdict::Approve,
-        "an unverifiable (model-down) finding must not be allowed to keep blocking"
+        Verdict::Block,
+        "ErrorRefuted-only round must preserve primary verdict"
     );
 }
 
-// ── Liveness gate decision logic ──────────────────────────────────────────────
+// ── Truncation path (#726 regression) ─────────────────────────────────────────
 
 #[tokio::test]
-async fn liveness_alive_allows_start() {
-    // The verifier responds (any text) → Ok.
-    let verifier = confirmed_provider();
-    let decision = probe_verifier_liveness(&verifier, "us.anthropic.claude-haiku-4-5").await;
+async fn verify_truncated_response_is_truncation_refuted() {
+    // Unparseable/truncated verifier output → TruncationRefuted, confidence demoted.
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    run_verification_round(
+        &truncated_provider(),
+        "m",
+        "+ diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
+    assert!(matches!(
+        findings[0].verified,
+        Some(VerifyOutcome::TruncationRefuted)
+    ));
+    assert!((findings[0].confidence - VERIFY_REFUTED_CONFIDENCE).abs() < f32::EPSILON);
+}
+
+#[tokio::test]
+async fn verify_truncation_preserves_primary_verdict() {
+    // All-TruncationRefuted (path c) → primary verdict preserved (#726 root cause).
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round(
+        &truncated_provider(),
+        "m",
+        "+ diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
     assert_eq!(
-        decision,
-        LivenessDecision::Ok,
-        "a responding model allows start"
+        verdict,
+        Verdict::Block,
+        "truncation-only round must preserve primary verdict (path c)"
     );
 }
 
+/// Regression for the dropped-JoinHandle true-positive from PR #720 that was
+/// silently refuted in the #726 incident (16-token cap truncated all responses).
+/// Why: validates (a) CONFIRMED preserves finding + verdict, (b) TruncationRefuted
+/// does NOT collapse verdict to APPROVE (path c).
+/// Test: this test itself.
 #[tokio::test]
-async fn liveness_model_unavailable_refuses() {
-    // ModelNotFound is an alarm-class error → Refuse (the incident path).
-    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
-        make_err: || LlmError::ModelNotFound("no-such-profile".to_string()),
-    });
-    let decision = probe_verifier_liveness(&verifier, "no-such-profile").await;
-    match decision {
-        LivenessDecision::Refuse {
-            error_class,
-            reason,
-        } => {
-            assert_eq!(error_class, "ModelNotFound");
-            assert!(reason.contains("no-such-profile"), "reason names the model");
-            assert!(
-                reason.contains("refusing to start"),
-                "reason must state the refusal"
-            );
-        }
-        LivenessDecision::Ok => panic!("an unavailable verifier model must refuse start"),
-    }
-}
-
-#[tokio::test]
-async fn liveness_access_denied_refuses() {
-    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
-        make_err: || LlmError::AccessDenied("bad iam".to_string()),
-    });
-    let decision = probe_verifier_liveness(&verifier, "m").await;
-    assert!(
-        matches!(decision, LivenessDecision::Refuse { .. }),
-        "AccessDenied is alarm-class and must refuse start"
+async fn verify_join_handle_regression_pr720() {
+    let mut f = Finding::new(
+        "crates/trusty-search/src/startup.rs",
+        "resource-leak",
+        "JoinHandle dropped immediately; spawned task detached, risking pool exhaustion",
+        "Store the JoinHandle and await it in graceful shutdown",
+        0.85,
+        Effort::Medium,
     );
-}
+    f.line = Some(47);
+    let diff = "+pub fn spawn_warm_boot_task() {\n\
+                +    tokio::spawn(async move { warm_boot().await });\n\
+                +}\n";
 
-#[tokio::test]
-async fn liveness_transient_allows_start() {
-    // A transient error during the probe must NOT block startup — per-finding
-    // verification will retry at run time.
-    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
-        make_err: || LlmError::Transport("connection reset".to_string()),
-    });
-    let decision = probe_verifier_liveness(&verifier, "m").await;
+    // Sub-test (a): CONFIRMED → finding + verdict survive.
+    let mut findings_1 = vec![f.clone()];
+    let v1 = run_verification_round(
+        &confirmed_provider(),
+        "us.anthropic.claude-sonnet-4-6",
+        diff,
+        Verdict::RequestChanges,
+        &mut findings_1,
+        None,
+        None,
+    )
+    .await;
+    assert!(matches!(
+        findings_1[0].verified,
+        Some(VerifyOutcome::Confirmed)
+    ));
     assert_eq!(
-        decision,
-        LivenessDecision::Ok,
-        "a transient probe error must not block startup"
+        v1,
+        Verdict::RequestChanges,
+        "CONFIRMED must hold REQUEST_CHANGES"
+    );
+
+    // Sub-test (b): TruncationRefuted → verdict preserved (path c — #726).
+    let mut findings_2 = vec![f];
+    let v2 = run_verification_round(
+        &truncated_provider(),
+        "us.anthropic.claude-sonnet-4-6",
+        diff,
+        Verdict::RequestChanges,
+        &mut findings_2,
+        None,
+        None,
+    )
+    .await;
+    assert!(matches!(
+        findings_2[0].verified,
+        Some(VerifyOutcome::TruncationRefuted)
+    ));
+    assert_eq!(
+        v2,
+        Verdict::RequestChanges,
+        "truncation must NOT collapse verdict to APPROVE (path c — #726)"
     );
 }
 
-#[tokio::test]
-async fn liveness_rate_limited_allows_start() {
-    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
-        make_err: || LlmError::RateLimited,
-    });
-    let decision = probe_verifier_liveness(&verifier, "m").await;
-    assert_eq!(
-        decision,
-        LivenessDecision::Ok,
-        "rate-limit during probe is transient"
-    );
-}
+// Liveness gate decision logic is tested in `verify_liveness.rs::tests`
+// (`liveness_alive_allows_start`, `liveness_model_unavailable_refuses`, etc.)
+// to keep this file under the 500-line cap and respect module ownership.


### PR DESCRIPTION
## Summary

Fixes the 100% refutation rate observed in the auto-review of PR #720, where a dropped-`JoinHandle` true-positive was silently refuted before reaching PR comments. Three root causes were identified and fixed together.

### Change A — Token truncation (root cause)

- `crates/trusty-review/src/config/role_models.rs`: verifier role `default_max_tokens` **16 → 128**. The previous value was too small to hold a complete `{"judgment":"CONFIRMED","reason":"..."}` JSON object; Bedrock truncated the response mid-JSON on every call.
- `crates/trusty-review/src/pipeline/verify_prompt.rs`: `VERIFY_MAX_TOKENS` fallback constant **64 → 128** for consistency.

### Change B — Symmetric burden-of-proof prompt

Replaced the biased "The default answer is REFUTED. When in doubt, REFUTE." section with:

> Weigh the evidence in the diff. Answer CONFIRMED when the finding is grounded in the diff and a reasonable engineer would agree it needs attention. Answer REFUTED when the finding is speculative, contradicted by the diff, or references code that is not present in the diff at all. Decide on the evidence — do not default to either verdict. If the concern is real but the diff is merely ambiguous, prefer CONFIRMED with a qualifying reason.

The **truncation/hallucination hard rule** (REFUTE anything referencing a file/line absent from the diff) is preserved verbatim in both the system prompt and the user-turn restatement.

### Change D — Verdict preservation on non-clean refutations

**Problem:** unparseable responses were mapped to plain `VerifyOutcome::Refuted` (indistinguishable from a clean model REFUTED), and `rederive_verdict` treated all-refuted rounds as "escalation rested on refuted evidence" → collapsed to `APPROVE`.

**Fix:**
1. Unparseable/truncated responses → `VerifyOutcome::TruncationRefuted` (serde name: `"truncation_refuted"`) — already existed in the enum, now actually used.
2. `rederive_verdict` adopts a **three-way baseline rule**:
   - **(a) any confirmed** → keep `primary_verdict` (grounded escalation)
   - **(b) at least one clean model REFUTED** → drop to `APPROVE` baseline (model refuted on merits)
   - **(c) all demotions were `TruncationRefuted`/`ErrorRefuted`** → **preserve `primary_verdict`** (infra failure must not silently collapse a review to APPROVE — this was the #726 bug)

### Regression fixture

`verify_join_handle_regression_pr720` models the dropped-JoinHandle finding from PR #720:
- Sub-test (a): CONFIRMED judgment → finding + `REQUEST_CHANGES` verdict survive
- Sub-test (b): TruncationRefuted → verdict **NOT** collapsed to APPROVE (path c)

### Other

- Liveness probe tests moved from `verify_tests.rs` to `verify_liveness.rs` (their natural home) to keep both files under the 500-line cap.
- Version bumped 0.3.2 → **0.3.3**

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p trusty-review` — 701 tests pass (689 lib + 12 bin), including:
  - `rederive_error_refuted_preserves_primary_verdict` (path c)
  - `rederive_truncation_refuted_preserves_primary_verdict` (path c)
  - `verify_truncated_response_is_truncation_refuted`
  - `verify_truncation_preserves_primary_verdict`
  - `verify_model_unavailable_marks_error_refuted_and_preserves_verdict`
  - `verify_join_handle_regression_pr720`
  - `liveness_alive_allows_start` / `liveness_model_unavailable_refuses` / etc. (moved to `verify_liveness.rs`)
- [x] `bash scripts/check_line_cap.sh` — 172 allowlisted, 0 violations
- [x] `cargo check` workspace-wide — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)