### PR TITLE
feat(trusty-review): footer attribution reads "Trusty-Review (<model>)" (closes #734)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11011,7 +11011,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.3.4" }
+trusty-review = { path = "crates/trusty-review", version = "0.3.5" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.5] — 2026-06-03
+
+### Changed
+
+- **Footer attribution (#734)** — the review footer now reads
+  `Reviewed by Trusty-Review (\`<model>\`)` instead of `Reviewed by \`<model>\``.
+  The brand name `Trusty-Review` appears in plain text; the model slug remains
+  in backticks inside parentheses.  Both the grade-prefixed form
+  (`Grade: B+ · 🤖 Reviewed by Trusty-Review (\`model\`) · …`) and the no-grade
+  form (`🤖 Reviewed by Trusty-Review (\`model\`) · …`) are updated.
+  Single source of truth remains `format_review_footer` in `pipeline/post.rs`.
+
+---
+
 ## [0.3.4] — 2026-06-03
 
 ### Added

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.4"
+version     = "0.3.5"
 edition     = "2024"
 rust-version.workspace = true
 license-file           = "LICENSE"

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -136,7 +136,7 @@ the post-verification verdict.
 When posted to GitHub, the review comment includes a footer:
 
 ```
-Grade: B+ · 🤖 Reviewed by us.anthropic.claude-sonnet-4-6 · tokens ↑1234 ↓567 · est. $0.01
+Grade: B+ · 🤖 Reviewed by Trusty-Review (`us.anthropic.claude-sonnet-4-6`) · tokens ↑1234 ↓567 · est. $0.01
 ```
 
 (↑ = input tokens, ↓ = output tokens). The footer appears identically in dry-run output.

--- a/crates/trusty-review/src/integrations/github/posting.rs
+++ b/crates/trusty-review/src/integrations/github/posting.rs
@@ -372,7 +372,7 @@ mod tests {
     /// `format_review_footer(grade, model, in, out, cost)` and appends it to
     /// `review_body`, then `build_review_comment_body` includes it in the prose
     /// section.  Asserts the exact footer string
-    /// `Grade: B+ · 🤖 Reviewed by \`us.anthropic.claude-sonnet-4-6\` · tokens ↑13,499 ↓1,718 · est. $0.066`
+    /// `Grade: B+ · 🤖 Reviewed by Trusty-Review (\`us.anthropic.claude-sonnet-4-6\`) · tokens ↑13,499 ↓1,718 · est. $0.066`
     /// Test: this test itself (no network, no FS).
     #[test]
     fn body_footer_contains_grade() {
@@ -398,7 +398,7 @@ mod tests {
         result.review_body.push_str(&footer);
 
         // The consolidated footer must use thousands separators and rounded cost.
-        let expected_footer = "Grade: B+ · 🤖 Reviewed by `us.anthropic.claude-sonnet-4-6` · tokens ↑13,499 ↓1,718 · est. $0.066";
+        let expected_footer = "Grade: B+ · 🤖 Reviewed by Trusty-Review (`us.anthropic.claude-sonnet-4-6`) · tokens ↑13,499 ↓1,718 · est. $0.066";
         assert!(
             result.review_body.contains(expected_footer),
             "review_body must contain the exact consolidated footer: {expected_footer}\nActual review_body:\n{}",

--- a/crates/trusty-review/src/pipeline/post.rs
+++ b/crates/trusty-review/src/pipeline/post.rs
@@ -49,7 +49,7 @@ use crate::{
 /// of truth: the same footer text appears in the live GitHub comment AND in the
 /// dry-run / MCP response, so callers see exactly what was (or would be) posted
 /// (closes #728, #732).
-/// What: formats one line `[Grade: <g> · ]🤖 Reviewed by \`<model>\` · tokens ↑<in> ↓<out> · est. $<cost>`
+/// What: formats one line `[Grade: <g> · ]🤖 Reviewed by Trusty-Review (\`<model>\`) · tokens ↑<in> ↓<out> · est. $<cost>`
 /// where the grade prefix is included when `grade` is `Some`, token counts use
 /// thousands separators, and cost is rounded to 3 decimal places (e.g. `$0.066`).
 /// An empty model string is rendered as `(unknown)` so the line is always well-formed.
@@ -78,7 +78,7 @@ pub fn format_review_footer(
         _ => String::new(),
     };
     format!(
-        "\n---\n{grade_prefix}🤖 Reviewed by `{model_display}` · tokens ↑{in_fmt} ↓{out_fmt} · est. ${cost_fmt}"
+        "\n---\n{grade_prefix}🤖 Reviewed by Trusty-Review (`{model_display}`) · tokens ↑{in_fmt} ↓{out_fmt} · est. ${cost_fmt}"
     )
 }
 
@@ -335,7 +335,7 @@ mod tests {
         );
         assert_eq!(
             footer,
-            "\n---\n🤖 Reviewed by `us.anthropic.claude-sonnet-4-6` · tokens ↑13,499 ↓1,718 · est. $0.066"
+            "\n---\n🤖 Reviewed by Trusty-Review (`us.anthropic.claude-sonnet-4-6`) · tokens ↑13,499 ↓1,718 · est. $0.066"
         );
     }
 
@@ -346,7 +346,7 @@ mod tests {
     /// Any format drift is caught immediately by this exact assertion.
     /// What: asserts the full footer line for grade=B+,
     ///   model=us.anthropic.claude-sonnet-4-6, in=13499, out=1718, cost=0.066267
-    ///   → `Grade: B+ · 🤖 Reviewed by \`us.anthropic.claude-sonnet-4-6\` · tokens ↑13,499 ↓1,718 · est. $0.066`
+    ///   → `Grade: B+ · 🤖 Reviewed by Trusty-Review (\`us.anthropic.claude-sonnet-4-6\`) · tokens ↑13,499 ↓1,718 · est. $0.066`
     /// Test: this test itself (no network, no FS).
     #[test]
     fn footer_format_with_grade() {
@@ -359,7 +359,7 @@ mod tests {
         );
         assert_eq!(
             footer,
-            "\n---\nGrade: B+ · 🤖 Reviewed by `us.anthropic.claude-sonnet-4-6` · tokens ↑13,499 ↓1,718 · est. $0.066"
+            "\n---\nGrade: B+ · 🤖 Reviewed by Trusty-Review (`us.anthropic.claude-sonnet-4-6`) · tokens ↑13,499 ↓1,718 · est. $0.066"
         );
     }
 


### PR DESCRIPTION
## Summary

- Changes `format_review_footer` in `pipeline/post.rs` (single source of truth) so the attribution reads `Reviewed by Trusty-Review (\`<model>\`)` instead of `Reviewed by \`<model>\``.
- Updates all footer unit-test exact-string assertions (`footer_format_known_tuple`, `footer_format_with_grade`, `body_footer_contains_grade`) to the new format.
- Bumps `trusty-review` from 0.3.4 → 0.3.5 and updates the root workspace pin.
- Adds CHANGELOG 0.3.5 entry and updates the README footer example.

Closes #734.

## New footer strings

**With grade:**
```
Grade: B+ · 🤖 Reviewed by Trusty-Review (`us.anthropic.claude-sonnet-4-6`) · tokens ↑13,499 ↓1,718 · est. $0.066
```

**Without grade:**
```
🤖 Reviewed by Trusty-Review (`us.anthropic.claude-sonnet-4-6`) · tokens ↑13,499 ↓1,718 · est. $0.066
```

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test -p trusty-review` — 732 passed, 0 failed (incl. updated footer tests)
- [x] `bash scripts/check_line_cap.sh` — exit 0, 172 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)