### PR TITLE
fix(tga): expand ${ENV_VAR} references in all provider configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9858,7 +9858,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.1" }
 trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.0" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
-tga = { path = "crates/trusty-git-analytics", version = "2.5.0" }
+tga = { path = "crates/trusty-git-analytics", version = "2.6.1" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2026-06-04
+
+### Fixed
+
+- **GitHub (and all other provider) clients now expand `${ENV_VAR}` references
+  in config credentials (#741)** — the GitHub client was passing the literal
+  `${GITHUB_TOKEN}` placeholder string as the Bearer token, causing GitHub to
+  return 401 Unauthorized and silently drop all PR collection. The Linear
+  client had a private `expand_env_var` helper, but it was not shared. A new
+  `collect::env_expand` module provides the canonical implementation; the
+  GitHub, Bitbucket, Azure DevOps, and Linear clients all now run their
+  token/key/PAT through it before use so `${ENV_VAR}` placeholders in
+  `config.yaml` work consistently across every collector.
+
 ## [2.2.1] - 2026-05-29
 
 ### Fixed

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.6.0"
+version = "2.6.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.91) per #254. Required for

--- a/crates/trusty-git-analytics/src/collect/azdo/client.rs
+++ b/crates/trusty-git-analytics/src/collect/azdo/client.rs
@@ -558,8 +558,9 @@ fn build_client() -> Result<reqwest::Client, AzdoError> {
 }
 
 impl AzureDevOpsClient {
-    /// Construct a new client. Does not validate or contact ADO.
-    pub fn new(config: AzureDevOpsConfig) -> Self {
+    /// Construct a new client; expands any `${ENV_VAR}` in `pat` (issue #741).
+    pub fn new(mut config: AzureDevOpsConfig) -> Self {
+        config.pat = crate::collect::env_expand::expand_env_var(&config.pat);
         Self { config }
     }
 
@@ -1569,7 +1570,6 @@ mod tests {
     }
 
     // ----- Phase 1 carry-over tests -----
-
     #[test]
     fn stub_connection_info_has_phase_1() {
         let client = AzureDevOpsClient::new(sample_config());

--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -93,9 +93,9 @@ impl BitbucketClient {
         let token = config
             .token
             .as_deref()
-            .map(str::trim)
+            .map(crate::collect::env_expand::expand_env_var)
+            .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
-            .map(String::from)
             .or_else(|| {
                 std::env::var("BITBUCKET_TOKEN")
                     .ok()

--- a/crates/trusty-git-analytics/src/collect/env_expand.rs
+++ b/crates/trusty-git-analytics/src/collect/env_expand.rs
@@ -1,0 +1,73 @@
+//! Shared `${ENV_VAR}` placeholder expansion for config values.
+//!
+//! Every provider client that reads credentials from config (GitHub, Linear,
+//! Bitbucket, Azure DevOps) should run its token/key through
+//! [`expand_env_var`] before use so that YAML values like
+//! `token: "${GITHUB_TOKEN}"` work without manual pre-processing.
+
+/// Resolve a `${VAR_NAME}` placeholder against the process environment.
+///
+/// Why: config files often store credentials as `${ENV_VAR}` references so
+/// secrets stay out of YAML on disk; previously only the Linear client
+/// expanded these, causing GitHub (and other providers) to pass the literal
+/// placeholder string as a Bearer token, causing 401 Unauthorized errors
+/// (issue #741).
+/// What: if `raw` has the exact form `${NAME}` (non-empty `NAME`), returns
+/// `std::env::var(NAME)` (empty string when the var is unset); otherwise
+/// returns `raw` unchanged.
+/// Test: `expand_env_var_placeholder`, `expand_env_var_passthrough`,
+/// `expand_env_var_unset_var`, `expand_env_var_partial_placeholder` below.
+pub fn expand_env_var(raw: &str) -> String {
+    if raw.starts_with("${") && raw.ends_with('}') && raw.len() > 3 {
+        let var = &raw[2..raw.len() - 1];
+        if !var.is_empty() {
+            return std::env::var(var).unwrap_or_default();
+        }
+    }
+    raw.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Plain string with no placeholder syntax passes through unchanged.
+    #[test]
+    fn expand_env_var_passthrough() {
+        assert_eq!(expand_env_var("ghp_actualtoken"), "ghp_actualtoken");
+        assert_eq!(expand_env_var(""), "");
+        assert_eq!(expand_env_var("no-special-chars"), "no-special-chars");
+    }
+
+    /// `${VAR}` whose value is set in the environment resolves to that value.
+    #[test]
+    fn expand_env_var_placeholder() {
+        std::env::set_var("TGA_TEST_TOKEN_741", "resolved-value");
+        assert_eq!(expand_env_var("${TGA_TEST_TOKEN_741}"), "resolved-value");
+        std::env::remove_var("TGA_TEST_TOKEN_741");
+    }
+
+    /// `${VAR}` for an unset variable returns the empty string (not the
+    /// literal placeholder), so callers can detect a missing credential.
+    #[test]
+    fn expand_env_var_unset_var() {
+        std::env::remove_var("TGA_TEST_DEFINITELY_UNSET_741");
+        assert_eq!(
+            expand_env_var("${TGA_TEST_DEFINITELY_UNSET_741}"),
+            "",
+            "unset var should expand to empty string, not the literal placeholder"
+        );
+    }
+
+    /// Strings that look like partial placeholders are passed through as-is.
+    #[test]
+    fn expand_env_var_partial_placeholder() {
+        // Missing closing brace — no match, returned as-is.
+        assert_eq!(expand_env_var("${NOCLOSE"), "${NOCLOSE");
+        // Missing opening / dollar.
+        assert_eq!(expand_env_var("VAR}"), "VAR}");
+        assert_eq!(expand_env_var("$VAR"), "$VAR");
+        // Empty name `${}` — passes through unchanged.
+        assert_eq!(expand_env_var("${}"), "${}");
+    }
+}

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -10,6 +10,7 @@ use tracing::{debug, warn};
 
 use async_trait::async_trait;
 
+use crate::collect::env_expand::expand_env_var;
 use crate::collect::errors::{CollectError, Result};
 use crate::collect::pr_provider::PrProvider;
 use crate::core::config::{GithubConfig, RepositoryConfig};
@@ -190,8 +191,8 @@ fn build_http_client(config: &GithubConfig) -> Result<reqwest::Client> {
         ACCEPT,
         HeaderValue::from_static("application/vnd.github+json"),
     );
-    if let Some(token) = &config.token {
-        let val = HeaderValue::from_str(&format!("Bearer {token}"))
+    if let Some(raw) = &config.token {
+        let val = HeaderValue::from_str(&format!("Bearer {}", expand_env_var(raw)))
             .map_err(|e| CollectError::Config(format!("invalid token header: {e}")))?;
         headers.insert(AUTHORIZATION, val);
     }
@@ -883,7 +884,6 @@ mod tests {
     // -----------------------------------------------------------------------
     // Issue #87: multi-repo / org-wide resolution
     // -----------------------------------------------------------------------
-
     use std::path::PathBuf;
 
     use crate::core::config::RepositoryConfig;

--- a/crates/trusty-git-analytics/src/collect/linear/client.rs
+++ b/crates/trusty-git-analytics/src/collect/linear/client.rs
@@ -271,17 +271,15 @@ pub fn store_linear_issues(db: &Database, issues: &[LinearIssue]) -> crate::core
     Ok(count)
 }
 
-/// Resolve a `${VAR_NAME}` placeholder against the process environment.
+/// Thin local alias so existing call-sites in this module require no changes.
 ///
-/// If `raw` has the form `${NAME}`, returns the value of `NAME` (empty string
-/// if unset). Otherwise returns `raw` unchanged.
+/// Why: delegates to the canonical shared implementation in
+/// [`crate::collect::env_expand::expand_env_var`] to avoid duplication.
+/// What: passes `raw` straight through to the shared function.
+/// Test: the shared function's own test suite covers all cases; see
+/// `crate::collect::env_expand`.
 fn expand_env_var(raw: &str) -> String {
-    if raw.starts_with("${") && raw.ends_with('}') && raw.len() > 3 {
-        let var = &raw[2..raw.len() - 1];
-        std::env::var(var).unwrap_or_default()
-    } else {
-        raw.to_string()
-    }
+    crate::collect::env_expand::expand_env_var(raw)
 }
 
 #[cfg(test)]
@@ -309,11 +307,6 @@ mod tests {
         let msg = "abc-123 should not match";
         let ids = LinearClient::extract_issue_ids(msg);
         assert!(ids.is_empty());
-    }
-
-    #[test]
-    fn expand_env_var_returns_literal_when_no_placeholder() {
-        assert_eq!(expand_env_var("lin_api_xyz"), "lin_api_xyz");
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/collect/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/mod.rs
@@ -21,6 +21,7 @@ pub mod ai_attribution;
 pub mod azdo;
 pub mod bitbucket;
 pub mod collector;
+pub mod env_expand;
 pub mod errors;
 pub mod git;
 pub mod github;


### PR DESCRIPTION
## Summary

- **Root cause (#741)**: `build_http_client` in the GitHub client was passing the raw config value (e.g. `${GITHUB_TOKEN}`) directly as the `Authorization: Bearer` header without expanding it against the process environment. GitHub rejects the literal placeholder with 401 Unauthorized, so all PR collection silently failed for users with env-var tokens in their config.
- **Fix**: Extracted the existing `expand_env_var` helper from `linear/client.rs` into a new shared module `collect::env_expand`, then applied it consistently in all four provider clients (GitHub, Linear, Bitbucket, ADO).
- **Version**: tga 2.6.0 → 2.6.1 (patch bump, bug fix only).

### Expansion semantics

| Input | Behaviour |
|-------|-----------|
| `${VAR_NAME}` where `VAR_NAME` is set | Returns the env var value |
| `${VAR_NAME}` where `VAR_NAME` is unset | Returns empty string (caller detects missing credential) |
| Anything else (literal token, partial syntax, `$VAR`, `${}`) | Returned unchanged |

### Files changed

- **NEW** `crates/trusty-git-analytics/src/collect/env_expand.rs` — shared `expand_env_var` function + 4 unit tests
- `collect/mod.rs` — adds `pub mod env_expand`
- `collect/github/client.rs` — `build_http_client` now calls `expand_env_var` on `config.token`
- `collect/linear/client.rs` — private helper delegates to shared module; duplicate test removed
- `collect/bitbucket/client.rs` — `config.token` expanded before the Bearer/Basic auth selector
- `collect/azdo/client.rs` — `AzureDevOpsClient::new` expands `config.pat` at construction
- `crates/trusty-git-analytics/Cargo.toml` — version 2.6.0 → 2.6.1
- `Cargo.toml` (workspace) — tga dep pin updated to 2.6.1
- `CHANGELOG.md` — entry for 2.6.1

## Test plan

- [x] `cargo test -p tga` — all 111 unit tests + 1 bitbucket live + 1 integration pass
- [x] `cargo clippy -p tga --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p tga` — no drift
- [x] `cargo check` — workspace-wide clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations, 172 allowlisted OK
- [x] New tests: `expand_env_var_passthrough`, `expand_env_var_placeholder`, `expand_env_var_unset_var`, `expand_env_var_partial_placeholder` in `collect::env_expand`

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)