### PR TITLE
feat(trusty-code): extract leaf modules (events/ipc/perf/intent/progress/build_info) from open-mpm (#640)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6612,6 +6612,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "trusty-code",
  "trusty-common",
  "trusty-memory",
  "trusty-search",
@@ -10775,10 +10776,15 @@ name = "trusty-code"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 
 [workspace.dependencies]
 # ── Internal crates (path deps so the monorepo builds without publish cycles) ──
+# trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
+# publish=false; version 0.0.0 intentionally — pre-release scaffold.
+trusty-code = { path = "crates/trusty-code" }
 trusty-common = { path = "crates/trusty-common", version = "0.14.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.

--- a/crates/open-mpm/Cargo.toml
+++ b/crates/open-mpm/Cargo.toml
@@ -27,6 +27,11 @@ include = [
 ]
 
 [dependencies]
+# Why (#640): Phase 1 leaf/protocol modules (events, ipc, perf, intent,
+#      progress, build_info) now live in trusty-code. open-mpm re-exports
+#      them so all existing consumers keep compiling unchanged. The
+#      reconciliation (removing open-mpm's own copies) is tracked in #647.
+trusty-code = { workspace = true }
 # Why: issue #460 unified rpc.discover — host needs the ServiceDescriptor
 #      trait + OpenRpcBuilder, plus the in-process MemoryMcpService and
 #      SearchMcpService impls. trusty-search now aligns on tree-sitter 0.26

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Per-project Claude-Code-compatible MPM orchestration harness (bin: tcode). Phase 0 scaffold; full extraction tracked in #587."
+description = "Per-project Claude-Code-compatible MPM orchestration harness (bin: tcode). Phase 1 leaf/protocol modules extracted from open-mpm (#640). Full extraction tracked in #587."
 publish = false
 
 [[bin]]
@@ -18,8 +18,27 @@ name = "trusty_code"
 path = "src/lib.rs"
 
 [dependencies]
+# Core error handling and async runtime
 anyhow = { workspace = true }
-clap = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+# Serialization (events, ipc, perf, build_info)
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Timestamp support (perf, build_info)
+chrono = { workspace = true }
+
+# UUID generation (ipc task IDs)
+uuid = { workspace = true }
+
+# CLI entry point (tcode binary)
+clap = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+# Async test runtime (events, build_info, perf async tests)
+tokio = { workspace = true }
+# Temp directories for build_info tests
+tempfile = { workspace = true }

--- a/crates/trusty-code/build.rs
+++ b/crates/trusty-code/build.rs
@@ -1,0 +1,36 @@
+//! Build script: expose git commit metadata as a compile-time environment
+//! variable so `build_info::GIT_HASH` is always populated.
+//!
+//! Why: Bug reports and log lines need a deterministic identifier for the
+//! running binary — `CARGO_PKG_VERSION` alone collapses every commit on a
+//! dev branch into the same version string. Pairing it with the short git
+//! SHA gives a deterministic identifier for correlation.
+//! What: Queries `git rev-parse --short HEAD` at build time and exposes the
+//! result as `GIT_COMMIT_HASH`, or falls back to `"unknown"` if git is
+//! unavailable.
+//! Test: After `cargo build`, the compiled binary's startup banner should
+//! include either a 7-char hash or the literal `"unknown"`.
+
+use std::process::Command;
+
+fn main() {
+    // Re-run whenever HEAD moves so a new commit triggers a rebuild.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={git_hash}");
+}

--- a/crates/trusty-code/src/build_info.rs
+++ b/crates/trusty-code/src/build_info.rs
@@ -1,0 +1,258 @@
+//! Build and version tracking.
+//!
+//! Why: We need a monotonic build counter that increments on every process
+//! start, independent of the semver version. The combined `vX.Y.Z build #N`
+//! string lets us correlate log lines and performance telemetry with the
+//! exact binary invocation that produced them. Keeping the counter on disk
+//! (rather than baked into the binary) lets a single `cargo build` produce
+//! many distinct "builds" across repeated `cargo run` invocations during
+//! development — which is exactly when we need the disambiguation.
+//!
+//! What: Reads `.open-mpm/state/build.json` relative to the current working
+//! directory, increments the `build` counter (defaulting to 0 if the file
+//! is missing or malformed), and writes the result back atomically via
+//! `rename(2)` from a sibling `.tmp` file.
+//!
+//! Test: `BuildInfo::load_and_increment` in an empty temp dir returns
+//! `build == 1`; calling it again returns `build == 2`; a corrupt
+//! `build.json` is treated as "build = 0" and replaced on the next call.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+/// Compile-time semver from Cargo.toml.
+///
+/// Why: Canonical version string embedded in the binary so runtime code never
+/// needs to read Cargo.toml.
+/// What: `env!("CARGO_PKG_VERSION")` forwarded as a `'static str`.
+/// Test: Asserted non-empty in `version_string_contains_version`.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The package name, resolved at compile time.
+///
+/// Why: Allows display strings to use the correct crate name without
+/// hardcoding it, so this module is reusable across open-mpm and trusty-code.
+/// What: `env!("CARGO_PKG_NAME")` forwarded as a `'static str`.
+/// Test: Indirectly via `version_string_contains_version`.
+pub const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+
+/// Short git commit hash captured at build time by `build.rs`.
+///
+/// Why: Correlates a running binary to the exact commit that produced it.
+/// What: Populated from `git rev-parse --short HEAD` during compilation;
+/// falls back to `"unknown"` when git is unavailable.
+/// Test: `version_string_contains_version` confirms both fields render.
+pub const GIT_HASH: &str = env!("GIT_COMMIT_HASH");
+
+/// Human-readable banner used by the CTRL REPL and `--version` output.
+///
+/// Why: One canonical format keeps log grep and support reports consistent.
+/// What: Returns `<pkg-name> vX.Y.Z (<git-hash>)`.
+/// Test: `version_string_contains_version` checks both substrings render.
+pub fn version_string() -> String {
+    format!("{PKG_NAME} v{VERSION} ({GIT_HASH})")
+}
+
+/// On-disk shape of `build.json`.
+///
+/// Why: Kept as a private struct so callers go through `BuildInfo` for
+/// `started_at`/`version` handling instead of reading raw JSON.
+/// What: Just the two persisted fields; version is a compile-time constant
+/// and doesn't round-trip through disk.
+/// Test: Serialized/deserialized in unit tests below.
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedBuild {
+    build: u64,
+    started_at: String,
+}
+
+/// Runtime build metadata surfaced to logs, the `--version` flag, and
+/// downstream instrumentation.
+///
+/// Why: Centralizes "which binary + which invocation" so later instrumentation
+/// can tag every telemetry event with the same build stamp the startup log
+/// line shows.
+/// What: Holds the compile-time semver, the incremented build counter, and
+/// the ISO8601 UTC start timestamp.
+/// Test: `display_string` returns `<pkg-name> vX.Y.Z build #N`.
+#[derive(Debug, Clone)]
+pub struct BuildInfo {
+    pub version: &'static str,
+    pub build: u64,
+    // Exposed for the performance instrumentation module which will stamp
+    // telemetry events with the process start time.
+    #[allow(dead_code)]
+    pub started_at: String,
+}
+
+impl BuildInfo {
+    /// Load the persistent counter, increment it, and persist back using
+    /// the given state directory.
+    ///
+    /// Why: Single entry point ensures every process start gets a fresh
+    /// build number even if the caller forgets to save.
+    /// What: Uses `<state_dir>/build.json`. See `load_and_increment_in` for
+    /// the testable, directory-parameterized version.
+    /// Test: See `load_and_increment_in` tests.
+    pub async fn load_and_increment(state_dir: &Path) -> Result<Self> {
+        tokio::fs::create_dir_all(state_dir).await?;
+        Self::load_and_increment_in(state_dir).await
+    }
+
+    /// Same as `load_and_increment` but with an explicit base directory.
+    ///
+    /// Why: Tests need to drive the counter against a temp dir without
+    /// mutating the real state directory in the project.
+    /// What: Creates `<dir>` if missing, reads/parses `<dir>/build.json`
+    /// (treating missing or malformed as build=0), increments, writes back
+    /// atomically.
+    /// Test: See unit tests at the bottom of this file.
+    pub async fn load_and_increment_in(dir: &Path) -> Result<Self> {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .with_context(|| format!("failed to create {}", dir.display()))?;
+
+        let file = dir.join("build.json");
+        let previous = read_previous(&file).await;
+
+        let next = previous.saturating_add(1);
+        let started_at = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        let persisted = PersistedBuild {
+            build: next,
+            started_at: started_at.clone(),
+        };
+        write_atomic(dir, &file, &persisted).await?;
+
+        Ok(Self {
+            version: env!("CARGO_PKG_VERSION"),
+            build: next,
+            started_at,
+        })
+    }
+
+    /// Human-readable banner used by the startup log line and `--version`.
+    ///
+    /// Why: Single canonical format so grep/tooling can match it uniformly.
+    /// What: `<pkg-name> vX.Y.Z build #N`.
+    /// Test: Asserted directly in unit tests.
+    pub fn display_string(&self) -> String {
+        format!("{PKG_NAME} v{} build #{}", self.version, self.build)
+    }
+}
+
+/// Read the previous `build` counter from `file`, returning 0 if the file
+/// is missing, unreadable, or corrupt.
+///
+/// Why: We never want to fail startup just because the counter file got
+/// wedged; treating it as 0 means the next write replaces the bad content.
+/// What: Async read + `serde_json` parse.
+/// Test: `load_and_increment_in` tests cover missing + corrupt cases.
+async fn read_previous(file: &Path) -> u64 {
+    match tokio::fs::read(file).await {
+        Ok(bytes) => match serde_json::from_slice::<PersistedBuild>(&bytes) {
+            Ok(p) => p.build,
+            Err(_) => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
+/// Atomic write: serialize to `<file>.tmp`, fsync implicit via rename.
+///
+/// Why: A crash during write must never leave `build.json` half-written —
+/// `rename(2)` on the same filesystem is atomic, so readers always see a
+/// complete file.
+/// What: Writes to `<dir>/build.json.tmp`, renames over the target path.
+/// Test: Covered by `load_and_increment_in` tests.
+async fn write_atomic(dir: &Path, file: &Path, payload: &PersistedBuild) -> Result<()> {
+    let tmp: PathBuf = dir.join("build.json.tmp");
+    let bytes = serde_json::to_vec_pretty(payload).context("serialize build.json")?;
+    tokio::fs::write(&tmp, &bytes)
+        .await
+        .with_context(|| format!("failed to write {}", tmp.display()))?;
+    tokio::fs::rename(&tmp, file)
+        .await
+        .with_context(|| format!("failed to rename {} -> {}", tmp.display(), file.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn starts_at_one_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let info = BuildInfo::load_and_increment_in(dir.path()).await.unwrap();
+        assert_eq!(info.build, 1);
+        assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+        assert!(info.started_at.ends_with('Z'));
+
+        // File exists and is valid JSON with build=1.
+        let bytes = tokio::fs::read(dir.path().join("build.json"))
+            .await
+            .unwrap();
+        let p: PersistedBuild = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(p.build, 1);
+    }
+
+    #[tokio::test]
+    async fn increments_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = BuildInfo::load_and_increment_in(dir.path()).await.unwrap();
+        let b = BuildInfo::load_and_increment_in(dir.path()).await.unwrap();
+        let c = BuildInfo::load_and_increment_in(dir.path()).await.unwrap();
+        assert_eq!(a.build, 1);
+        assert_eq!(b.build, 2);
+        assert_eq!(c.build, 3);
+    }
+
+    #[tokio::test]
+    async fn corrupt_file_resets_to_one() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path()).await.unwrap();
+        tokio::fs::write(dir.path().join("build.json"), b"not json at all")
+            .await
+            .unwrap();
+
+        let info = BuildInfo::load_and_increment_in(dir.path()).await.unwrap();
+        assert_eq!(info.build, 1, "corrupt file should be treated as build=0");
+    }
+
+    #[tokio::test]
+    async fn display_string_format() {
+        let info = BuildInfo {
+            version: "0.1.0",
+            build: 42,
+            started_at: "2026-04-22T17:31:30Z".to_string(),
+        };
+        // PKG_NAME is "trusty-code" in this crate.
+        let s = info.display_string();
+        assert!(s.contains("v0.1.0"), "got: {s}");
+        assert!(s.contains("build #42"), "got: {s}");
+    }
+
+    #[test]
+    fn version_string_contains_version() {
+        let s = version_string();
+        assert!(s.contains("v"));
+        assert!(s.contains(VERSION));
+        // GIT_HASH is either a short hash or "unknown"; rendered in parens.
+        assert!(s.contains(GIT_HASH));
+    }
+
+    #[tokio::test]
+    async fn creates_missing_parent_dir() {
+        let root = tempfile::tempdir().unwrap();
+        let nested = root.path().join("deep").join(".state");
+        assert!(!nested.exists());
+
+        let info = BuildInfo::load_and_increment_in(&nested).await.unwrap();
+        assert_eq!(info.build, 1);
+        assert!(nested.join("build.json").exists());
+    }
+}

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -1,0 +1,438 @@
+//! Process-wide event bus for real-time UI streaming (#192 Phase B).
+//!
+//! Why: The 2-second stderr polling model from #149 is slow, lossy, and only
+//! handles workflow phase transitions. The UI needs immediate feedback on
+//! every PM thinking turn, every sub-agent message, every tool call — across
+//! both the in-process Axum server path AND the subprocess workflow path.
+//! A `tokio::sync::broadcast` channel exposed via a process-global `OnceLock`
+//! lets any code path emit events without threading the bus through dozens of
+//! function signatures, while SSE subscribers fan out to all browsers.
+//! What: Defines the `Event` enum (the wire format), a process-global
+//! `EVENT_BUS` initialised lazily from any thread, helpers to publish and
+//! subscribe, and a `__OMPM_EVENT__ <json>\n` stderr-relay protocol so events
+//! emitted by `--workflow` subprocesses can be re-broadcast by the parent
+//! API server.
+//! Test: `events::publish` round-trips through `subscribe()`. The relay
+//! prefix is stable so the parent stderr reader can detect and re-publish.
+
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Stderr line prefix used to relay events from a workflow subprocess to its
+/// parent API server. The parent reads stderr line-by-line; lines starting
+/// with this prefix are parsed as `Event` JSON and re-published on the
+/// parent's event bus instead of being mirrored to terminal stderr.
+///
+/// Why: Workflow phase + agent telemetry must reach the API server even
+/// though the workflow runs in a child process. Reusing the same stderr
+/// channel that already carries `__OMPM_PROGRESS__` (the legacy 2s-poll
+/// path) avoids inventing yet another IPC mechanism.
+/// What: Match by exact byte prefix; payload after the space is one JSON
+/// object decodable as `Event`.
+pub const EVENT_LINE_PREFIX: &str = "__OMPM_EVENT__ ";
+
+/// Capacity of the broadcast channel. Larger than `bus`'s 256 because event
+/// volume is much higher (every PM thought, every agent line). 1024 keeps
+/// memory bounded (~256KB at 256 bytes/event) while tolerating slow SSE
+/// subscribers without dropping recent events under typical load.
+const CHANNEL_CAPACITY: usize = 1024;
+
+/// Real-time event types streamed to UI clients (browser, future Tauri).
+///
+/// Why: A single tagged enum keeps wire-format evolution tractable —
+/// `serde(tag = "type")` produces `{"type":"agent_message", ...}` so the UI
+/// can pattern-match on type and the back-end can grow new variants without
+/// breaking older clients (unknown variants degrade to "ignored event").
+/// What: Variants cover the full PM lifecycle plus a `Ping` keepalive so SSE
+/// connections don't time out behind reverse proxies. `session_id` correlates
+/// events to a specific task; the UI filters by session when scoped to a
+/// task view.
+/// Test: `event_serializes_with_type_tag` asserts the wire shape for one
+/// variant; `Event::Ping` round-trips for the keepalive path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Event {
+    // -- Session lifecycle --
+    SessionStarted {
+        session_id: String,
+        project: String,
+    },
+    SessionDone {
+        session_id: String,
+        status: String,
+    },
+    SessionCancelled {
+        session_id: String,
+    },
+
+    // -- PM activity --
+    PmThinking {
+        session_id: String,
+        text: String,
+    },
+    PmDelegating {
+        session_id: String,
+        agent: String,
+        task_preview: String,
+    },
+
+    // -- Agent activity --
+    AgentSpawned {
+        session_id: String,
+        agent: String,
+    },
+    AgentMessage {
+        session_id: String,
+        agent: String,
+        text: String,
+    },
+    AgentDone {
+        session_id: String,
+        agent: String,
+        status: String,
+    },
+    AgentFailed {
+        session_id: String,
+        agent: String,
+        error: String,
+    },
+
+    // -- Tool calls --
+    ToolCalled {
+        session_id: String,
+        tool: String,
+        preview: String,
+    },
+    ToolResult {
+        session_id: String,
+        tool: String,
+        preview: String,
+    },
+
+    // -- AST analysis --
+    /// Emitted when an AST-native tool performs a structural code operation
+    /// (symbol lookup, edit, insert, import, validation, patch apply, or
+    /// project pre-indexing). Surfaces in the REPL's thinking-step display
+    /// so users can see structural analysis happening in real time.
+    ///
+    /// Why: AST-native tools replace whole-file rewrites with surgical edits.
+    /// Without dedicated telemetry the user only sees opaque `ToolCalled`
+    /// events and loses the narrative of "indexed project → looked up symbol
+    /// → staged edit → applied patch". This event makes the AST narrative
+    /// visible.
+    /// What: `op` is a short label (`index`, `lookup`, `edit`, `insert`,
+    /// `import`, `validate`, `patch`); `detail` is a human-readable
+    /// substring (e.g. "42 symbols from src/" or "fn parse_args in main.rs").
+    /// Test: `ast_operation_round_trips_through_subscribe` round-trips one
+    /// variant through the bus.
+    AstOperation {
+        session_id: String,
+        op: String,
+        detail: String,
+    },
+
+    // -- Phase (workflow) --
+    PhaseStarted {
+        session_id: String,
+        phase: String,
+    },
+    PhaseDone {
+        session_id: String,
+        phase: String,
+        status: String,
+    },
+    /// #196: a phase was skipped because the active persona opts out of it.
+    ///
+    /// Why: Operators and the UI need visibility when persona-aware skipping
+    /// changes the executed workflow shape (e.g. `[hacker]` skipping QA).
+    /// Without this event the run looks like phases silently disappeared.
+    /// What: Carries the phase name and the persona that triggered the skip.
+    PhaseSkipped {
+        session_id: String,
+        phase: String,
+        persona: String,
+    },
+
+    // -- Persona (workflow) --
+    /// #196: emitted once per workflow run when a persona is detected from the
+    /// task text. Lets the UI surface "running in [hacker] mode" before any
+    /// phases execute, so users immediately see why the pipeline shape may
+    /// differ from the default.
+    PersonaDetected {
+        session_id: String,
+        persona: String,
+    },
+
+    // -- LLM call lifecycle (#199) --
+    /// Emitted just before any LLM chat-completion HTTP call leaves the
+    /// process. Pairs with `LlmResponded` so consumers can compute latency
+    /// independently and surface in-flight calls in the UI.
+    ///
+    /// Why: Operators debugging slow runs need to see WHICH model is in flight
+    /// at any moment, not just retroactively in totals. `prompt_tokens` is
+    /// optional because we don't always know the prompt size up front.
+    /// What: `agent_name` may be empty for top-level PM calls; `model` is the
+    /// resolved provider/model string sent on the wire.
+    LlmRequested {
+        session_id: String,
+        agent_name: String,
+        model: String,
+        prompt_tokens: Option<u32>,
+    },
+
+    /// Emitted after every LLM chat-completion HTTP call returns successfully.
+    /// Carries the wall-clock latency so the UI can render "model X took Yms"
+    /// badges without waiting for end-of-run perf aggregation.
+    LlmResponded {
+        session_id: String,
+        agent_name: String,
+        model: String,
+        completion_tokens: Option<u32>,
+        latency_ms: u64,
+    },
+
+    /// Emitted when an agent's actual work loop begins — distinct from
+    /// `AgentSpawned`, which fires when the subprocess is kicked off.
+    /// `AgentStarted` fires AFTER the spawn handshake (or at the start of an
+    /// in-process runner loop) so the UI can show "spawning…" vs. "running"
+    /// states. `runner_type` is one of "subprocess", "claude-code", "inline".
+    AgentStarted {
+        session_id: String,
+        agent_name: String,
+        runner_type: String,
+    },
+
+    /// Emitted when an agent produces its final result before returning to
+    /// the PM. Lets the UI render "agent X returned a Y-word report" badges
+    /// without parsing the result body.
+    ///
+    /// Why: A coarse signal of agent productivity that complements
+    /// `AgentDone`. `word_count` is a cheap whitespace-split count; status
+    /// mirrors the agent's IPC status field ("success" or "error").
+    ReportGenerated {
+        session_id: String,
+        agent_name: String,
+        word_count: usize,
+        status: String,
+    },
+
+    /// Emitted when a session recap is generated after N completed tasks (#371).
+    /// Carries the session ID, a one-line prose summary, and structured table rows.
+    /// Consumed by TUI (renders `※ recap:` banner) and SSE → GUI (RecapPanel).
+    RecapGenerated {
+        session_id: String,
+        /// One-line prose summary, e.g. "Fixed a bug where X. Y is now deployed."
+        summary: String,
+        /// Structured rows for the recap table: [(step_label, result_text)]
+        table_rows: Vec<(String, String)>,
+    },
+
+    // -- Keepalive --
+    Ping,
+}
+
+impl Event {
+    /// Return the event's `session_id` if it has one. Used by the SSE
+    /// handler to filter the broadcast stream to a single task subscription.
+    ///
+    /// Why: Variants without a session (currently just `Ping`) must always
+    /// pass the filter — losing keepalives would defeat their purpose.
+    /// What: Returns `Some(&str)` for variants that carry a session, `None`
+    /// for keepalives. The SSE filter treats `None` as "always include".
+    pub fn session_id(&self) -> Option<&str> {
+        match self {
+            Event::SessionStarted { session_id, .. }
+            | Event::SessionDone { session_id, .. }
+            | Event::SessionCancelled { session_id }
+            | Event::PmThinking { session_id, .. }
+            | Event::PmDelegating { session_id, .. }
+            | Event::AgentSpawned { session_id, .. }
+            | Event::AgentMessage { session_id, .. }
+            | Event::AgentDone { session_id, .. }
+            | Event::AgentFailed { session_id, .. }
+            | Event::ToolCalled { session_id, .. }
+            | Event::ToolResult { session_id, .. }
+            | Event::AstOperation { session_id, .. }
+            | Event::PhaseStarted { session_id, .. }
+            | Event::PhaseDone { session_id, .. }
+            | Event::PhaseSkipped { session_id, .. }
+            | Event::PersonaDetected { session_id, .. }
+            | Event::LlmRequested { session_id, .. }
+            | Event::LlmResponded { session_id, .. }
+            | Event::AgentStarted { session_id, .. }
+            | Event::ReportGenerated { session_id, .. }
+            | Event::RecapGenerated { session_id, .. } => Some(session_id),
+            Event::Ping => None,
+        }
+    }
+}
+
+/// Process-global event bus, initialised on first access.
+///
+/// Why: Threading a `broadcast::Sender<Event>` through every code path that
+/// might want to emit telemetry (workflow engine, agent runners, ctrl) would
+/// touch hundreds of function signatures. A `OnceLock` mirrors how `tracing`
+/// solves the same problem — emit-from-anywhere with zero overhead when no
+/// one is listening.
+/// What: `Sender::send` is non-blocking; when there are no subscribers it
+/// returns an error which we silently drop (events without listeners are
+/// the expected baseline).
+static EVENT_BUS: OnceLock<broadcast::Sender<Event>> = OnceLock::new();
+
+/// Get (or initialise) the process-global event bus sender.
+///
+/// Why: Called from any code path that wants to emit. First call wins; all
+/// subsequent calls receive the same `Sender`. Cheap (single atomic load on
+/// the hot path).
+/// What: Returns a clone of the global sender. The receiver half is created
+/// per subscriber via `subscribe()`.
+/// Test: `bus_is_singleton` confirms repeated calls return the same channel.
+pub fn bus() -> broadcast::Sender<Event> {
+    EVENT_BUS
+        .get_or_init(|| broadcast::channel(CHANNEL_CAPACITY).0)
+        .clone()
+}
+
+/// Subscribe to all future events on the global bus.
+///
+/// Why: SSE handlers + tests both need a fresh receiver without sharing one.
+/// `broadcast::Receiver::recv` is `&mut self` so each subscriber owns one.
+/// What: Returns a new `Receiver` that begins receiving events emitted after
+/// the call returns. Lagged subscribers receive `RecvError::Lagged(n)` and
+/// can resume.
+pub fn subscribe() -> broadcast::Receiver<Event> {
+    bus().subscribe()
+}
+
+/// Publish one event to the bus (best-effort, never panics).
+///
+/// Why: Most callers don't care whether anyone is listening — events are
+/// telemetry, not control flow. Failures (no subscribers) are normal.
+/// What: Sends the event on the broadcast channel, ignoring `SendError`.
+/// Test: `publish_round_trips_through_subscribe`.
+pub fn publish(event: Event) {
+    let _ = bus().send(event);
+}
+
+/// Publish an event AND emit it on stderr with the `__OMPM_EVENT__` prefix
+/// so a parent process can re-broadcast on its own bus.
+///
+/// Why: Workflow runs spawn as `open-mpm --workflow ...` subprocesses of the
+/// API server (`api/server.rs::run_task`). Events emitted inside that child
+/// reach the parent's bus only via the existing stderr stream. This helper
+/// does both in one call so emit sites don't have to know whether they're
+/// running as a child.
+/// What: Calls `publish(event.clone())` for in-process subscribers, then
+/// writes one NDJSON line to stderr prefixed with `__OMPM_EVENT__ `. The
+/// parent's stderr reader (in `api::server::run_task`) detects the prefix
+/// and re-publishes on its own bus.
+/// Test: Indirect — exercised by the workflow integration path.
+pub fn emit(event: Event) {
+    publish(event.clone());
+    if let Ok(line) = serde_json::to_string(&event) {
+        eprintln!("{EVENT_LINE_PREFIX}{line}");
+    }
+}
+
+/// Truncate a string to at most `max` characters, appending an ellipsis
+/// marker when truncation occurred. Operates on chars (not bytes) so
+/// multi-byte characters are not split.
+///
+/// Why: Event payloads should be human-readable previews; raw multi-KB
+/// agent outputs would saturate the broadcast channel and overwhelm the SSE
+/// stream. Centralising preview construction keeps emit sites tidy.
+/// What: Returns `s` unchanged when shorter than `max`; otherwise returns
+/// the first `max` chars plus a Unicode horizontal ellipsis.
+pub fn preview(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push('\u{2026}');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_serializes_with_type_tag() {
+        let ev = Event::PmThinking {
+            session_id: "s1".into(),
+            text: "considering options".into(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"type\":\"pm_thinking\""), "{s}");
+        assert!(s.contains("\"session_id\":\"s1\""), "{s}");
+    }
+
+    #[test]
+    fn ping_roundtrips() {
+        let s = serde_json::to_string(&Event::Ping).unwrap();
+        let back: Event = serde_json::from_str(&s).unwrap();
+        assert!(matches!(back, Event::Ping));
+    }
+
+    #[test]
+    fn session_id_returns_correct_field() {
+        let ev = Event::AgentMessage {
+            session_id: "abc".into(),
+            agent: "python".into(),
+            text: "hi".into(),
+        };
+        assert_eq!(ev.session_id(), Some("abc"));
+        assert_eq!(Event::Ping.session_id(), None);
+    }
+
+    #[test]
+    fn bus_is_singleton() {
+        let a = bus();
+        let b = bus();
+        // Two senders to the same channel: a message sent on `a` should be
+        // visible to a receiver from `b`.
+        let mut rx = b.subscribe();
+        let _ = a.send(Event::Ping);
+        // Drain via try_recv to avoid an async runtime in this sync test.
+        let got = rx.try_recv().expect("expected ping");
+        assert!(matches!(got, Event::Ping));
+    }
+
+    #[tokio::test]
+    async fn publish_round_trips_through_subscribe() {
+        let mut rx = subscribe();
+        publish(Event::SessionStarted {
+            session_id: "t1".into(),
+            project: "demo".into(),
+        });
+        let got = rx.recv().await.unwrap();
+        match got {
+            Event::SessionStarted {
+                session_id,
+                project,
+            } => {
+                assert_eq!(session_id, "t1");
+                assert_eq!(project, "demo");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preview_truncates_at_char_boundary() {
+        assert_eq!(preview("hi", 5), "hi");
+        let out = preview("abcdef", 3);
+        assert_eq!(out.chars().count(), 4); // 3 + ellipsis
+        assert!(out.starts_with("abc"));
+        assert!(out.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn event_line_prefix_is_stable() {
+        // Lock in the wire constant — changing it breaks the parent/child
+        // relay protocol.
+        assert_eq!(EVENT_LINE_PREFIX, "__OMPM_EVENT__ ");
+    }
+}

--- a/crates/trusty-code/src/intent/classifier_property_tests.rs
+++ b/crates/trusty-code/src/intent/classifier_property_tests.rs
@@ -1,0 +1,383 @@
+//! Property-based and parameterized tests for `src/intent/mod.rs`.
+//!
+//! ## Integration
+//!
+//! Add to the bottom of `src/intent/mod.rs`:
+//!
+//! ```rust
+//! #[cfg(test)]
+//! #[path = "property_tests.rs"]
+//! mod property_tests;
+//! ```
+//!
+//! Then copy this file to `src/intent/property_tests.rs`.
+//!
+//! ## Coverage: 22 tests
+//!
+//! - Invariants: totality (never panics), determinism, whitespace invariance
+//! - Slash prefix always Implementation
+//! - Action verb dominance across all verb x context combinations (23 * 6 = 138 cases)
+//! - Word count boundary sweep (1-15 words)
+//! - Constant-list completeness guards (count, lowercase, no duplicates, no overlap)
+//! - Regression: underscored identifiers must not split into action verbs
+
+use super::*;
+
+// =====================================================================
+// Invariant 1: classify_intent is total — never panics
+// =====================================================================
+
+#[test]
+fn never_panics_on_adversarial_inputs() {
+    let adversarial: Vec<String> = vec![
+        "".into(),
+        " ".into(),
+        "\0".into(),
+        "\x01\x02\x03".into(),
+        "a".repeat(10_000),
+        "/".into(),
+        "//".into(),
+        "\n\n\n".into(),
+        "\u{1F525}\u{1F680}\u{1F480}".into(),
+        "caf\u{00E9} r\u{00E9}sum\u{00E9} na\u{00EF}ve".into(),
+        "\u{4E2D}\u{6587}\u{8F93}\u{5165}".into(),
+        "\u{0645}\u{0631}\u{062D}\u{0628}\u{0627}".into(),
+        "write ".into(),
+        " write".into(),
+        "write\0script".into(),
+    ];
+    for input in &adversarial {
+        let _ = classify_intent(input);
+    }
+}
+
+// =====================================================================
+// Invariant 2: classify_intent is deterministic
+// =====================================================================
+
+#[test]
+fn deterministic_across_calls() {
+    let inputs = [
+        "hello",
+        "write a script",
+        "explain the code",
+        "what is this?",
+        "the quick brown fox jumps over the lazy dog and then some more words",
+    ];
+    for input in &inputs {
+        let first = classify_intent(input);
+        let second = classify_intent(input);
+        assert_eq!(first, second, "non-deterministic for '{}'", input);
+    }
+}
+
+// =====================================================================
+// Invariant 3: Leading/trailing whitespace does not change classification
+// =====================================================================
+
+#[test]
+fn whitespace_invariance() {
+    let inputs = [
+        "hello",
+        "write a script",
+        "explain the code",
+        "what is this",
+        "thanks",
+    ];
+    for input in &inputs {
+        let plain = classify_intent(input);
+        let padded = classify_intent(&format!("  {}  ", input));
+        assert_eq!(
+            plain, padded,
+            "whitespace changed classification for '{}'",
+            input
+        );
+    }
+}
+
+// =====================================================================
+// Invariant 4: Slash prefix always yields Implementation
+// =====================================================================
+
+#[test]
+fn slash_prefix_always_implementation() {
+    let slash_inputs = [
+        "/",
+        "/a",
+        "/hello",
+        "/explain something",
+        "/123",
+        "/ spaced",
+    ];
+    for input in &slash_inputs {
+        assert_eq!(
+            classify_intent(input),
+            IntentClass::Implementation,
+            "slash input '{}' should be Implementation",
+            input
+        );
+    }
+}
+
+// =====================================================================
+// Invariant 5: Any input containing an action verb must return Implementation
+// =====================================================================
+
+#[test]
+fn action_verb_always_dominates() {
+    let action_verbs = [
+        "write",
+        "create",
+        "build",
+        "run",
+        "fix",
+        "implement",
+        "add",
+        "update",
+        "delete",
+        "test",
+        "deploy",
+        "generate",
+        "show",
+        "list",
+        "find",
+        "search",
+        "refactor",
+        "remove",
+        "rename",
+        "install",
+        "compile",
+        "debug",
+        "check",
+    ];
+    let contexts = [
+        "{v} something",
+        "please {v} the thing",
+        "can you {v} it",
+        "explain how to {v} a test",
+        "what should I {v}",
+        "hello, {v} a script",
+    ];
+    for verb in &action_verbs {
+        for ctx in &contexts {
+            let input = ctx.replace("{v}", verb);
+            assert_eq!(
+                classify_intent(&input),
+                IntentClass::Implementation,
+                "action verb '{}' in '{}' should be Implementation",
+                verb,
+                input
+            );
+        }
+    }
+}
+
+// =====================================================================
+// Parameterized: word count boundary sweep (no verb signals)
+// =====================================================================
+
+#[test]
+fn word_count_boundary_sweep() {
+    let filler = [
+        "that",
+        "new",
+        "library",
+        "seems",
+        "pretty",
+        "nice",
+        "honestly",
+        "really",
+        "quite",
+        "rather",
+        "overall",
+        "certainly",
+        "definitely",
+        "absolutely",
+        "probably",
+    ];
+
+    for n in 1..=15 {
+        let input: String = filler
+            .iter()
+            .cycle()
+            .take(n)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let result = classify_intent(&input);
+        if n <= 10 {
+            assert_eq!(
+                result,
+                IntentClass::Conversational,
+                "word_count={} should be Conversational, got {:?}",
+                n,
+                result
+            );
+        } else {
+            assert_eq!(
+                result,
+                IntentClass::Implementation,
+                "word_count={} (>10) should be Implementation, got {:?}",
+                n,
+                result
+            );
+        }
+    }
+}
+
+// =====================================================================
+// Constant-list completeness guards
+// =====================================================================
+
+#[test]
+fn action_verbs_count_matches_expected() {
+    assert_eq!(
+        ACTION_VERBS.len(),
+        23,
+        "ACTION_VERBS count changed — update tests if intentional"
+    );
+}
+
+#[test]
+fn research_verbs_count_matches_expected() {
+    assert_eq!(
+        RESEARCH_VERBS.len(),
+        16,
+        "RESEARCH_VERBS count changed — update tests if intentional"
+    );
+}
+
+#[test]
+fn question_words_count_matches_expected() {
+    assert_eq!(
+        QUESTION_WORDS.len(),
+        16,
+        "QUESTION_WORDS count changed — update tests if intentional"
+    );
+}
+
+#[test]
+fn greetings_count_matches_expected() {
+    assert_eq!(
+        GREETINGS.len(),
+        13,
+        "GREETINGS count changed — update tests if intentional"
+    );
+}
+
+#[test]
+fn closings_count_matches_expected() {
+    assert_eq!(
+        CLOSINGS.len(),
+        11,
+        "CLOSINGS count changed — update tests if intentional"
+    );
+}
+
+#[test]
+fn self_questions_count_matches_expected() {
+    assert_eq!(
+        SELF_QUESTIONS.len(),
+        11,
+        "SELF_QUESTIONS count changed — update tests if intentional"
+    );
+}
+
+// =====================================================================
+// All constant entries are lowercase (normalization assumption)
+// =====================================================================
+
+#[test]
+fn all_constants_are_lowercase() {
+    for v in ACTION_VERBS {
+        assert_eq!(*v, v.to_lowercase(), "ACTION_VERBS not lowercase: {}", v);
+    }
+    for v in RESEARCH_VERBS {
+        assert_eq!(*v, v.to_lowercase(), "RESEARCH_VERBS not lowercase: {}", v);
+    }
+    for v in QUESTION_WORDS {
+        assert_eq!(*v, v.to_lowercase(), "QUESTION_WORDS not lowercase: {}", v);
+    }
+    for v in GREETINGS {
+        assert_eq!(*v, v.to_lowercase(), "GREETINGS not lowercase: {}", v);
+    }
+    for v in CLOSINGS {
+        assert_eq!(*v, v.to_lowercase(), "CLOSINGS not lowercase: {}", v);
+    }
+    for v in SELF_QUESTIONS {
+        assert_eq!(*v, v.to_lowercase(), "SELF_QUESTIONS not lowercase: {}", v);
+    }
+}
+
+// =====================================================================
+// No duplicates in constant lists
+// =====================================================================
+
+#[test]
+fn no_duplicate_action_verbs() {
+    let mut seen = std::collections::HashSet::new();
+    for v in ACTION_VERBS {
+        assert!(seen.insert(*v), "duplicate ACTION_VERB: {}", v);
+    }
+}
+
+#[test]
+fn no_duplicate_research_verbs() {
+    let mut seen = std::collections::HashSet::new();
+    for v in RESEARCH_VERBS {
+        assert!(seen.insert(*v), "duplicate RESEARCH_VERB: {}", v);
+    }
+}
+
+#[test]
+fn no_duplicate_greetings() {
+    let mut seen = std::collections::HashSet::new();
+    for v in GREETINGS {
+        assert!(seen.insert(*v), "duplicate GREETING: {}", v);
+    }
+}
+
+#[test]
+fn no_duplicate_closings() {
+    let mut seen = std::collections::HashSet::new();
+    for v in CLOSINGS {
+        assert!(seen.insert(*v), "duplicate CLOSING: {}", v);
+    }
+}
+
+// =====================================================================
+// No overlap between action and research verb lists
+// =====================================================================
+
+#[test]
+fn no_overlap_between_action_and_research_verbs() {
+    for av in ACTION_VERBS {
+        assert!(
+            !RESEARCH_VERBS.contains(av),
+            "'{}' appears in both ACTION_VERBS and RESEARCH_VERBS",
+            av
+        );
+    }
+}
+
+// =====================================================================
+// Regression: underscored identifiers must not split
+// =====================================================================
+
+#[test]
+fn underscored_identifiers_do_not_split() {
+    let identifiers_with_verbs = [
+        "what does run_pm_task do",
+        "what does build_info return",
+        "what does test_helper mean",
+        "what does delete_session handle",
+    ];
+    for input in &identifiers_with_verbs {
+        assert_eq!(
+            classify_intent(input),
+            IntentClass::Research,
+            "underscored identifier in '{}' should not trigger Implementation",
+            input
+        );
+    }
+}

--- a/crates/trusty-code/src/intent/classifier_tests.rs
+++ b/crates/trusty-code/src/intent/classifier_tests.rs
@@ -1,0 +1,334 @@
+//! Comprehensive classifier tests for `src/intent/mod.rs`.
+//!
+//! ## Integration
+//!
+//! The `intent` module is `mod intent` in `main.rs` (not re-exported via `lib.rs`),
+//! so these tests must live inside the module. Add to the bottom of `src/intent/mod.rs`:
+//!
+//! ```rust
+//! #[cfg(test)]
+//! #[path = "classifier_tests.rs"]
+//! mod classifier_tests;
+//! ```
+//!
+//! Then copy this file to `src/intent/classifier_tests.rs`.
+//!
+//! ## Coverage: 49 tests
+//!
+//! - Every constant list entry exercised at least once
+//! - Priority rules (action verb > research verb > question word)
+//! - Boundary conditions (word count thresholds: 4, 6, 10, 15)
+//! - Normalization edge cases (unicode, punctuation, underscores)
+//! - Compositional properties (greeting + action verb, question + action verb)
+//! - normalize() unit tests
+//! - IntentClass enum trait tests (Debug, Clone, Copy, PartialEq)
+
+use super::*;
+
+// =====================================================================
+// Section 1: Empty / whitespace / punctuation-only inputs
+// =====================================================================
+
+#[test]
+fn empty_input_is_conversational() {
+    assert_eq!(classify_intent(""), IntentClass::Conversational);
+    assert_eq!(classify_intent("   "), IntentClass::Conversational);
+    assert_eq!(classify_intent("\n\t  "), IntentClass::Conversational);
+}
+
+#[test]
+fn punctuation_only_is_conversational() {
+    assert_eq!(classify_intent("???"), IntentClass::Conversational);
+    assert_eq!(classify_intent("..."), IntentClass::Conversational);
+    assert_eq!(classify_intent("!!!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("@#$%^&*"), IntentClass::Conversational);
+}
+
+// =====================================================================
+// Section 2: Exhaustive GREETINGS constant coverage
+// =====================================================================
+
+#[test]
+fn every_greeting_constant_is_conversational() {
+    let greetings = [
+        "hello",
+        "hi",
+        "hey",
+        "howdy",
+        "greetings",
+        "sup",
+        "yo",
+        "good morning",
+        "good afternoon",
+        "good evening",
+        "hey there",
+        "hi there",
+        "hello there",
+    ];
+    for g in &greetings {
+        assert_eq!(
+            classify_intent(g),
+            IntentClass::Conversational,
+            "greeting '{}' should be Conversational",
+            g
+        );
+    }
+}
+
+#[test]
+fn greetings_with_varied_punctuation() {
+    assert_eq!(classify_intent("Hello!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("hi."), IntentClass::Conversational);
+    assert_eq!(classify_intent("Hey,"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Hello!!!"), IntentClass::Conversational);
+    assert_eq!(
+        classify_intent("good morning!"),
+        IntentClass::Conversational
+    );
+    assert_eq!(classify_intent("HOWDY!!"), IntentClass::Conversational);
+}
+
+#[test]
+fn greeting_prefix_short_message_is_conversational() {
+    assert_eq!(classify_intent("hello friend"), IntentClass::Conversational);
+    assert_eq!(
+        classify_intent("hi there my friend"),
+        IntentClass::Conversational
+    );
+    assert_eq!(
+        classify_intent("hey everybody"),
+        IntentClass::Conversational
+    );
+}
+
+#[test]
+fn greeting_prefix_long_message_without_verbs() {
+    // 7 words, greeting prefix, no verbs -> 5-10 range -> Conversational.
+    assert_eq!(
+        classify_intent("hello there my dear old trusted companion"),
+        IntentClass::Conversational
+    );
+}
+
+// =====================================================================
+// Section 3: Exhaustive CLOSINGS constant coverage
+// =====================================================================
+
+#[test]
+fn every_closing_constant_is_conversational() {
+    let closings = [
+        "bye",
+        "goodbye",
+        "thanks",
+        "thank you",
+        "cheers",
+        "later",
+        "see ya",
+        "see you",
+        "ok thanks",
+        "thx",
+        "ty",
+    ];
+    for c in &closings {
+        assert_eq!(
+            classify_intent(c),
+            IntentClass::Conversational,
+            "closing '{}' should be Conversational",
+            c
+        );
+    }
+}
+
+#[test]
+fn closings_with_punctuation() {
+    assert_eq!(classify_intent("Thanks!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Bye."), IntentClass::Conversational);
+    assert_eq!(classify_intent("CHEERS!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("thank you!"), IntentClass::Conversational);
+}
+
+#[test]
+fn closing_prefix_short_message_is_conversational() {
+    assert_eq!(
+        classify_intent("thanks for that"),
+        IntentClass::Conversational
+    );
+    assert_eq!(classify_intent("bye for now"), IntentClass::Conversational);
+}
+
+// =====================================================================
+// Section 4: Exhaustive SELF_QUESTIONS constant coverage
+// =====================================================================
+
+#[test]
+fn every_self_question_constant_is_conversational() {
+    let self_questions = [
+        "how are you",
+        "what are you",
+        "who are you",
+        "what can you do",
+        "what is open-mpm",
+        "what is open mpm",
+        "what do you do",
+        "what's your name",
+        "whats your name",
+        "are you there",
+        "you there",
+    ];
+    for q in &self_questions {
+        assert_eq!(
+            classify_intent(q),
+            IntentClass::Conversational,
+            "self-question '{}' should be Conversational",
+            q
+        );
+    }
+}
+
+#[test]
+fn self_questions_with_punctuation() {
+    assert_eq!(
+        classify_intent("What can you do?"),
+        IntentClass::Conversational
+    );
+    assert_eq!(classify_intent("How are you?"), IntentClass::Conversational);
+    assert_eq!(
+        classify_intent("Who are you??"),
+        IntentClass::Conversational
+    );
+}
+
+// =====================================================================
+// Section 5: Slash commands -> always Implementation
+// =====================================================================
+
+#[test]
+fn slash_commands_are_implementation() {
+    assert_eq!(classify_intent("/help"), IntentClass::Implementation);
+    assert_eq!(
+        classify_intent("/connect /tmp/foo"),
+        IntentClass::Implementation
+    );
+    assert_eq!(classify_intent("/status"), IntentClass::Implementation);
+    assert_eq!(classify_intent("/build"), IntentClass::Implementation);
+    assert_eq!(
+        classify_intent("/unknown-command"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn slash_command_with_whitespace_prefix() {
+    assert_eq!(classify_intent("  /help"), IntentClass::Implementation);
+}
+
+// =====================================================================
+// Section 6: Exhaustive ACTION_VERBS constant coverage
+// =====================================================================
+
+#[test]
+fn every_action_verb_triggers_implementation() {
+    let action_verbs = [
+        "write",
+        "create",
+        "build",
+        "run",
+        "fix",
+        "implement",
+        "add",
+        "update",
+        "delete",
+        "test",
+        "deploy",
+        "generate",
+        "show",
+        "list",
+        "find",
+        "search",
+        "refactor",
+        "remove",
+        "rename",
+        "install",
+        "compile",
+        "debug",
+        "check",
+    ];
+    for verb in &action_verbs {
+        let input = format!("{} something now", verb);
+        assert_eq!(
+            classify_intent(&input),
+            IntentClass::Implementation,
+            "action verb '{}' should trigger Implementation",
+            verb
+        );
+    }
+}
+
+#[test]
+fn action_verb_case_insensitive() {
+    assert_eq!(
+        classify_intent("WRITE A SCRIPT"),
+        IntentClass::Implementation
+    );
+    assert_eq!(classify_intent("Fix The Bug"), IntentClass::Implementation);
+    assert_eq!(
+        classify_intent("Deploy to production"),
+        IntentClass::Implementation
+    );
+}
+
+// =====================================================================
+// Section 7: Exhaustive RESEARCH_VERBS constant coverage
+// =====================================================================
+
+#[test]
+fn every_research_verb_triggers_research() {
+    let research_verbs = [
+        "explain",
+        "analyze",
+        "analyse",
+        "investigate",
+        "review",
+        "examine",
+        "explore",
+        "describe",
+        "summarize",
+        "summarise",
+        "understand",
+        "diagnose",
+        "audit",
+        "assess",
+        "evaluate",
+        "compare",
+    ];
+    for verb in &research_verbs {
+        let input = format!("{} the architecture", verb);
+        assert_eq!(
+            classify_intent(&input),
+            IntentClass::Research,
+            "research verb '{}' should trigger Research",
+            verb
+        );
+    }
+}
+
+// =====================================================================
+// Section 8: Exhaustive QUESTION_WORDS constant coverage
+// =====================================================================
+
+#[test]
+fn every_question_word_as_opener_triggers_research() {
+    let question_words = [
+        "what", "why", "how", "when", "where", "which", "who", "whose", "whom", "does", "is",
+        "are", "can", "could", "would", "should",
+    ];
+    for qw in &question_words {
+        let input = format!("{} the data looks like", qw);
+        assert_eq!(
+            classify_intent(&input),
+            IntentClass::Research,
+            "question word '{}' as opener should trigger Research",
+            qw
+        );
+    }
+}

--- a/crates/trusty-code/src/intent/classifier_tests_2.rs
+++ b/crates/trusty-code/src/intent/classifier_tests_2.rs
@@ -1,0 +1,361 @@
+//! Comprehensive classifier tests for `src/intent/mod.rs` (part 2 of 2).
+//!
+//! Why: Split from `classifier_tests.rs` per #366 to keep each test file under
+//! the 500-line cap; wired via `#[path]` from `intent/mod.rs` so `super::*`
+//! still resolves to the `intent` module.
+//! Test: This module is itself part of the classifier test coverage.
+
+use super::*;
+
+#[test]
+fn question_word_not_first_does_not_trigger_research() {
+    // 4 words, no signals -> Conversational.
+    assert_eq!(
+        classify_intent("the what of it"),
+        IntentClass::Conversational
+    );
+}
+
+// =====================================================================
+// Section 9: Priority rules — action verb wins over everything
+// =====================================================================
+
+#[test]
+fn action_verb_wins_over_question_word() {
+    assert_eq!(
+        classify_intent("how do I fix this bug"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("what should I write here"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("where should I deploy this"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn action_verb_wins_over_research_verb() {
+    assert_eq!(
+        classify_intent("explain how to write a test"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("review and fix the code"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("analyze then refactor the module"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn action_verb_wins_over_greeting_prefix() {
+    assert_eq!(
+        classify_intent("hi, can you write a script that adds two numbers?"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Hello, please fix the failing test in src/main.rs"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("hey, run the tests"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn write_a_review_is_implementation() {
+    assert_eq!(
+        classify_intent("write a review"),
+        IntentClass::Implementation
+    );
+}
+
+// =====================================================================
+// Section 10: Question-mark fallback
+// =====================================================================
+
+#[test]
+fn short_question_mark_is_research() {
+    assert_eq!(
+        classify_intent("is bedrock enabled?"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("does this support tokio?"),
+        IntentClass::Research
+    );
+}
+
+#[test]
+fn question_mark_on_long_input_without_action_verb() {
+    let long_q = "so I was wondering about the overall performance characteristics \
+                  of the system under heavy load with many concurrent users?";
+    assert_eq!(classify_intent(long_q), IntentClass::Implementation);
+}
+
+#[test]
+fn question_mark_at_15_words_boundary() {
+    let input = "that thing about the data pipeline staging environment having problems \
+                 every single night recently?";
+    let word_count = input.split_whitespace().count();
+    assert!(word_count <= 15, "expected <=15 words, got {}", word_count);
+    assert_eq!(classify_intent(input), IntentClass::Research);
+}
+
+// =====================================================================
+// Section 11: Word count boundary conditions
+// =====================================================================
+
+#[test]
+fn four_word_input_no_signals_is_conversational() {
+    assert_eq!(
+        classify_intent("just a random thought"),
+        IntentClass::Conversational
+    );
+}
+
+#[test]
+fn five_to_ten_words_no_signals_is_conversational() {
+    assert_eq!(
+        classify_intent("that new library seems pretty nice honestly"),
+        IntentClass::Conversational
+    );
+}
+
+#[test]
+fn eleven_plus_words_no_verbs_is_implementation() {
+    let long = "the failing integration test for the auth middleware on staging \
+                seems related to the recent token refresh changes from last week";
+    assert!(long.split_whitespace().count() > 10);
+    assert_eq!(classify_intent(long), IntentClass::Implementation);
+}
+
+#[test]
+fn greeting_prefix_word_count_boundary_at_six() {
+    assert_eq!(
+        classify_intent("hello my dear old trusted friend"),
+        IntentClass::Conversational
+    );
+    assert_eq!(
+        classify_intent("hello my dear old trusted good friend"),
+        IntentClass::Conversational
+    );
+}
+
+// =====================================================================
+// Section 12: "help me" special case
+// =====================================================================
+
+#[test]
+fn help_me_is_implementation() {
+    assert_eq!(
+        classify_intent("help me debug this issue"),
+        IntentClass::Implementation
+    );
+    assert_eq!(classify_intent("help me"), IntentClass::Implementation);
+}
+
+#[test]
+fn help_alone_is_conversational() {
+    assert_eq!(classify_intent("help"), IntentClass::Conversational);
+}
+
+#[test]
+fn help_question_mark_is_research() {
+    assert_eq!(classify_intent("help?"), IntentClass::Research);
+}
+
+// =====================================================================
+// Section 13: Normalization edge cases
+// =====================================================================
+
+#[test]
+fn case_insensitivity() {
+    assert_eq!(classify_intent("HELLO"), IntentClass::Conversational);
+    assert_eq!(
+        classify_intent("EXPLAIN the architecture"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("WRITE A SCRIPT"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn underscores_preserved_prevent_false_action_match() {
+    assert_eq!(
+        classify_intent("what does run_pm_task_with_session do"),
+        IntentClass::Research
+    );
+}
+
+#[test]
+fn hyphens_preserved_in_identifiers() {
+    assert_eq!(
+        classify_intent("what is open-mpm"),
+        IntentClass::Conversational
+    );
+}
+
+#[test]
+fn apostrophe_preserved() {
+    assert_eq!(
+        classify_intent("what's your name"),
+        IntentClass::Conversational
+    );
+}
+
+#[test]
+fn mixed_punctuation_normalized() {
+    assert_eq!(classify_intent("Hello!!!"), IntentClass::Conversational);
+    assert_eq!(
+        classify_intent("Write...a...script"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn unicode_lowercasing() {
+    assert_eq!(classify_intent("GRÜßE"), IntentClass::Conversational);
+}
+
+#[test]
+fn tabs_and_newlines_treated_as_whitespace() {
+    assert_eq!(
+        classify_intent("write\ta\nscript"),
+        IntentClass::Implementation
+    );
+}
+
+// =====================================================================
+// Section 14: Single ambiguous words
+// =====================================================================
+
+#[test]
+fn single_ambiguous_word_is_conversational() {
+    assert_eq!(classify_intent("yes"), IntentClass::Conversational);
+    assert_eq!(classify_intent("ok"), IntentClass::Conversational);
+    assert_eq!(classify_intent("cool"), IntentClass::Conversational);
+    assert_eq!(classify_intent("sure"), IntentClass::Conversational);
+    assert_eq!(classify_intent("nope"), IntentClass::Conversational);
+}
+
+// =====================================================================
+// Section 15: Normalize function unit tests
+// =====================================================================
+
+#[test]
+fn normalize_strips_punctuation_preserves_apostrophe() {
+    assert_eq!(normalize("Hello!!!"), "hello");
+    assert_eq!(normalize("what's up?"), "what's up");
+    assert_eq!(normalize("open-mpm"), "open-mpm");
+    assert_eq!(normalize("run_pm_task"), "run_pm_task");
+}
+
+#[test]
+fn normalize_collapses_whitespace() {
+    assert_eq!(normalize("  hello   world  "), "hello world");
+    assert_eq!(normalize("a\t\nb"), "a b");
+}
+
+#[test]
+fn normalize_empty_and_punctuation() {
+    assert_eq!(normalize(""), "");
+    assert_eq!(normalize("!!!"), "");
+    assert_eq!(normalize("   "), "");
+}
+
+// =====================================================================
+// Section 16: Real-world scenarios
+// =====================================================================
+
+#[test]
+fn real_world_task_requests() {
+    assert_eq!(
+        classify_intent("Write a Python script that formats data as a markdown table"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Create a REST API endpoint for user registration"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Refactor the database module to use connection pooling"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Deploy the staging environment"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn real_world_research_requests() {
+    assert_eq!(
+        classify_intent("What does the workflow engine do?"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("Explain the IPC protocol between PM and sub-agents"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("How does context budgeting work in the memory system?"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("Compare the performance of redb vs sled"),
+        IntentClass::Research
+    );
+}
+
+#[test]
+fn real_world_conversational() {
+    assert_eq!(
+        classify_intent("Good afternoon!"),
+        IntentClass::Conversational
+    );
+    assert_eq!(classify_intent("Thank you!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("ok thanks"), IntentClass::Conversational);
+    assert_eq!(classify_intent("see ya"), IntentClass::Conversational);
+}
+
+// =====================================================================
+// Section 17: IntentClass enum properties
+// =====================================================================
+
+#[test]
+fn intent_class_debug_display() {
+    assert_eq!(
+        format!("{:?}", IntentClass::Conversational),
+        "Conversational"
+    );
+    assert_eq!(format!("{:?}", IntentClass::Research), "Research");
+    assert_eq!(
+        format!("{:?}", IntentClass::Implementation),
+        "Implementation"
+    );
+}
+
+#[test]
+fn intent_class_clone_and_copy() {
+    let a = IntentClass::Research;
+    let b = a;
+    let c = a;
+    assert_eq!(a, b);
+    assert_eq!(a, c);
+}
+
+#[test]
+fn intent_class_equality() {
+    assert_eq!(IntentClass::Conversational, IntentClass::Conversational);
+    assert_ne!(IntentClass::Conversational, IntentClass::Research);
+    assert_ne!(IntentClass::Research, IntentClass::Implementation);
+}

--- a/crates/trusty-code/src/intent/mod.rs
+++ b/crates/trusty-code/src/intent/mod.rs
@@ -1,0 +1,323 @@
+//! Intent classification for PM orchestrator fast-pathing.
+//!
+//! Why: The PM system prompt instructs "always use delegate_to_agent", which
+//! means even trivial conversational inputs like "Hello" trigger sub-agent
+//! spawning — a 60-90s round trip for what should be a sub-second reply.
+//! Research questions ("explain X", "what does Y do") similarly don't need
+//! the full prescriptive subprocess pipeline — they can run in-process with
+//! tools. Classifying input cheaply (no network) lets the controller route
+//! each intent to its lowest-cost path.
+//! What: A pure-Rust heuristic classifier returning `IntentClass::Conversational`,
+//! `IntentClass::Research`, or `IntentClass::Implementation`. No regex crate,
+//! no LLM — just lowercased string matching and word-count gates. Slash
+//! commands are always Implementation so the user can force the full pipeline.
+//! Test: `cargo test intent::` exercises greetings, closings, self-questions,
+//! research verbs, question words, action-verb tasks, and edge cases.
+//! See `tests` module below — fixes #199, #203.
+
+/// Classification of user input for PM fast-pathing.
+///
+/// Why: Distinguishes conversational chatter (no work) from research questions
+/// (in-process with tools) from implementation requests (full prescriptive
+/// subprocess pipeline) so the controller routes each to its lowest-cost path.
+/// What: `Conversational` -> reply directly, no tools.
+/// `Research` -> in-process PM loop with `delegate_to_agent` available.
+/// `Implementation` -> full subprocess prescriptive workflow.
+/// Test: Pattern-match in `submit_task` + `run_pm_task_with_session`; covered
+/// by `tests::*` below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntentClass {
+    /// Greeting, thanks, or simple self-referential question — answer directly.
+    Conversational,
+    /// Research/explain/analyze — in-process PM loop with tools.
+    Research,
+    /// Action request — route through the full prescriptive subprocess pipeline.
+    Implementation,
+}
+
+/// Action verbs that strongly indicate an implementation request.
+///
+/// Why: Centralizing the verb list as a constant keeps the classifier honest
+/// — any change to "what counts as a task verb" lives in one place.
+/// What: Lowercase verb tokens; matched as whole words against normalized input.
+const ACTION_VERBS: &[&str] = &[
+    "write",
+    "create",
+    "build",
+    "run",
+    "fix",
+    "implement",
+    "add",
+    "update",
+    "delete",
+    "test",
+    "deploy",
+    "generate",
+    "show",
+    "list",
+    "find",
+    "search",
+    "refactor",
+    "remove",
+    "rename",
+    "install",
+    "compile",
+    "debug",
+    "check",
+];
+
+/// Research verbs that signal "explain / analyze / investigate" intent.
+///
+/// Why: Research questions don't need the prescriptive subprocess pipeline.
+/// They benefit from PM's tool-armed in-process loop (delegate to a sub-agent
+/// only when needed) for fast turnaround on read-only tasks.
+/// What: Lowercase verb tokens; matched as whole words against normalized input.
+/// Note: An ACTION_VERB elsewhere in the input wins over a research verb
+/// (e.g. "explain how to fix this" -> Implementation, because "fix" is
+/// concrete work).
+const RESEARCH_VERBS: &[&str] = &[
+    "explain",
+    "analyze",
+    "analyse",
+    "investigate",
+    "review",
+    "examine",
+    "explore",
+    "describe",
+    "summarize",
+    "summarise",
+    "understand",
+    "diagnose",
+    "audit",
+    "assess",
+    "evaluate",
+    "compare",
+];
+
+/// Question words that signal an interrogative (research) intent.
+///
+/// Why: When input starts with a question word and lacks an action verb, it's
+/// almost always a research question (e.g. "what does X do", "why is Y slow").
+/// What: Lowercase tokens; matched only as the FIRST word of normalized input.
+const QUESTION_WORDS: &[&str] = &[
+    "what", "why", "how", "when", "where", "which", "who", "whose", "whom", "does", "is", "are",
+    "can", "could", "would", "should",
+];
+
+/// Greeting prefixes that signal a conversational opener.
+///
+/// Why: Recognized as whole-message matches OR as the first word of a short
+/// input. Kept as a constant so additions (e.g. "salutations") are a one-liner.
+/// What: Lowercase, punctuation-stripped greeting tokens.
+const GREETINGS: &[&str] = &[
+    "hello",
+    "hi",
+    "hey",
+    "howdy",
+    "greetings",
+    "sup",
+    "yo",
+    "good morning",
+    "good afternoon",
+    "good evening",
+    "hey there",
+    "hi there",
+    "hello there",
+];
+
+/// Closing / gratitude phrases.
+///
+/// Why: Same rationale as `GREETINGS` — single source of truth.
+const CLOSINGS: &[&str] = &[
+    "bye",
+    "goodbye",
+    "thanks",
+    "thank you",
+    "cheers",
+    "later",
+    "see ya",
+    "see you",
+    "ok thanks",
+    "thx",
+    "ty",
+];
+
+/// Self-referential conversational questions.
+///
+/// Why: Users frequently probe "what can you do?" before delegating real work.
+/// Answering directly (≤2 sentences from the PM) is faster than spawning an agent.
+const SELF_QUESTIONS: &[&str] = &[
+    "how are you",
+    "what are you",
+    "who are you",
+    "what can you do",
+    "what is open-mpm",
+    "what is open mpm",
+    "what do you do",
+    "what's your name",
+    "whats your name",
+    "are you there",
+    "you there",
+];
+
+/// Strip surrounding/embedded punctuation for matching.
+///
+/// Why: Users write "Hello!" / "hi." / "hey," — comparing to plain "hello"
+/// requires normalization. We keep apostrophes (so "what's" stays whole)
+/// and internal hyphens (so "open-mpm" stays whole).
+/// What: Lowercases and replaces ASCII punctuation (except `'`, `-`, `_`)
+/// with spaces, then collapses runs of whitespace. Underscores are preserved
+/// so identifiers like `run_pm_task_with_session` remain a single token
+/// rather than fragmenting into "run" / "task" (which would falsely match
+/// ACTION_VERBS).
+/// Test: Covered indirectly by classifier tests — "Hello!!!" must classify
+/// the same as "hello".
+fn normalize(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_alphanumeric() || ch == '\'' || ch == '-' || ch == '_' || ch.is_whitespace() {
+            for low in ch.to_lowercase() {
+                out.push(low);
+            }
+        } else {
+            out.push(' ');
+        }
+    }
+    // Collapse whitespace.
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Classify a user input string into a coarse intent class.
+///
+/// Why: Lets `submit_task` and `run_pm_task_with_session` route each input
+/// to its cheapest viable path — direct reply (Conversational), in-process
+/// tool-armed loop (Research), or full subprocess pipeline (Implementation).
+/// What: Applies heuristics in priority order — empty, slash command, greeting,
+/// closing, self-question, research-question, action-verb scan, length-based
+/// fallback.
+/// Test: `tests::*` below covers greetings, closings, self-questions, research
+/// verbs, question words, clear task verbs, slash commands, and edge cases.
+pub fn classify_intent(input: &str) -> IntentClass {
+    let trimmed = input.trim();
+
+    // Empty / whitespace-only -> conversational (the caller will produce a
+    // friendly default; no point in calling the LLM for "").
+    if trimmed.is_empty() {
+        return IntentClass::Conversational;
+    }
+
+    // Slash commands always go through the full pipeline. They have explicit
+    // semantics and the user is signaling intent unambiguously.
+    if trimmed.starts_with('/') {
+        return IntentClass::Implementation;
+    }
+
+    let normalized = normalize(trimmed);
+    if normalized.is_empty() {
+        // All punctuation — nothing actionable.
+        return IntentClass::Conversational;
+    }
+
+    // Whole-message matches against canned phrase lists. These are the
+    // strongest signals: "hello.", "thanks!", "what can you do?" etc.
+    if GREETINGS.iter().any(|g| &normalized == g) {
+        return IntentClass::Conversational;
+    }
+    if CLOSINGS.iter().any(|c| &normalized == c) {
+        return IntentClass::Conversational;
+    }
+    if SELF_QUESTIONS.iter().any(|q| &normalized == q) {
+        return IntentClass::Conversational;
+    }
+
+    // Prefix matches for greetings — "hello there friend" still reads as a
+    // greeting; "hello, can you write a script" should NOT (action verb wins).
+    let words: Vec<&str> = normalized.split_whitespace().collect();
+    let word_count = words.len();
+
+    let has_action_verb = words.iter().any(|w| ACTION_VERBS.contains(w));
+    let has_research_verb = words.iter().any(|w| RESEARCH_VERBS.contains(w));
+    let starts_with_question_word = words
+        .first()
+        .map(|w| QUESTION_WORDS.contains(w))
+        .unwrap_or(false);
+    let ends_with_question_mark = trimmed.ends_with('?');
+
+    // Greeting prefix on a short message (no action/research verb) -> conversational.
+    if !has_action_verb && !has_research_verb && !starts_with_question_word {
+        for g in GREETINGS {
+            if normalized.starts_with(g)
+                && (normalized.len() == g.len()
+                    || normalized.as_bytes().get(g.len()) == Some(&b' '))
+                && word_count <= 6
+            {
+                return IntentClass::Conversational;
+            }
+        }
+        for c in CLOSINGS {
+            if normalized.starts_with(c)
+                && (normalized.len() == c.len()
+                    || normalized.as_bytes().get(c.len()) == Some(&b' '))
+                && word_count <= 6
+            {
+                return IntentClass::Conversational;
+            }
+        }
+    }
+
+    // Action verbs ALWAYS win — even over question words and research verbs.
+    // "how do I fix this bug" -> Implementation (because "fix" is concrete work).
+    // "explain how to write a test" -> Implementation (because "write" wins).
+    if has_action_verb {
+        return IntentClass::Implementation;
+    }
+
+    // Research signal: starts with question word OR contains a research verb,
+    // and lacks an action verb (checked above).
+    if starts_with_question_word || has_research_verb {
+        return IntentClass::Research;
+    }
+
+    // Question mark on a short input with no action verb -> Research
+    // (e.g. "is bedrock enabled?", "does this support tokio?").
+    if ends_with_question_mark && word_count <= 15 {
+        return IntentClass::Research;
+    }
+
+    // "help me ..." is an implementation request even though "help" alone
+    // isn't a verb we list (to avoid catching "help?").
+    if normalized.starts_with("help me ") || normalized == "help me" {
+        return IntentClass::Implementation;
+    }
+
+    // Short input, no action/research/question signal -> probably conversational.
+    if word_count <= 4 {
+        return IntentClass::Conversational;
+    }
+
+    // Long input without action verbs but past the threshold -> Implementation.
+    if word_count > 10 {
+        return IntentClass::Implementation;
+    }
+
+    // Ambiguous middle range (5-10 words, no action verb): treat as
+    // conversational. The user can re-issue with an action verb if they
+    // actually wanted delegation.
+    IntentClass::Conversational
+}
+
+#[cfg(test)]
+#[path = "classifier_tests.rs"]
+mod classifier_tests;
+
+#[cfg(test)]
+#[path = "classifier_tests_2.rs"]
+mod classifier_tests_2;
+
+#[cfg(test)]
+#[path = "classifier_property_tests.rs"]
+mod classifier_property_tests;
+
+#[cfg(test)]
+#[path = "unit_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/intent/unit_tests.rs
+++ b/crates/trusty-code/src/intent/unit_tests.rs
@@ -1,0 +1,229 @@
+//! Unit tests for `intent` classification (extracted from `mod.rs`, #366).
+//!
+//! Why: Keeps `intent/mod.rs` under the 500-line cap while preserving the
+//! in-module test access (`#[path]` keeps `super::*` resolving to `intent`).
+//! What: Direct classifier assertions over representative prompts.
+//! Test: This module is itself the test coverage.
+
+use super::*;
+
+#[test]
+fn empty_input_is_conversational() {
+    assert_eq!(classify_intent(""), IntentClass::Conversational);
+    assert_eq!(classify_intent("   "), IntentClass::Conversational);
+    assert_eq!(classify_intent("\n\t  "), IntentClass::Conversational);
+}
+
+#[test]
+fn pure_greetings_are_conversational() {
+    assert_eq!(classify_intent("Hello"), IntentClass::Conversational);
+    assert_eq!(classify_intent("hi"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Hey there"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Howdy!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Good morning"), IntentClass::Conversational);
+    assert_eq!(classify_intent("yo"), IntentClass::Conversational);
+}
+
+#[test]
+fn greetings_with_punctuation_are_conversational() {
+    assert_eq!(classify_intent("Hello!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("hi."), IntentClass::Conversational);
+    assert_eq!(classify_intent("Hey,"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Hello!!!"), IntentClass::Conversational);
+}
+
+#[test]
+fn closings_are_conversational() {
+    assert_eq!(classify_intent("Thanks!"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Bye"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Thank you"), IntentClass::Conversational);
+    assert_eq!(classify_intent("cheers"), IntentClass::Conversational);
+    assert_eq!(classify_intent("later"), IntentClass::Conversational);
+}
+
+#[test]
+fn self_questions_are_conversational() {
+    assert_eq!(
+        classify_intent("What can you do?"),
+        IntentClass::Conversational
+    );
+    assert_eq!(classify_intent("How are you?"), IntentClass::Conversational);
+    assert_eq!(classify_intent("Who are you"), IntentClass::Conversational);
+    assert_eq!(
+        classify_intent("what is open-mpm"),
+        IntentClass::Conversational
+    );
+}
+
+#[test]
+fn action_verbs_signal_implementation() {
+    assert_eq!(
+        classify_intent("Write a Python script"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Fix the bug in main.rs"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Run the tests"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Build a markdown table formatter"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Implement intent classification"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn slash_commands_are_implementation() {
+    assert_eq!(classify_intent("/help"), IntentClass::Implementation);
+    assert_eq!(
+        classify_intent("/connect /tmp/foo"),
+        IntentClass::Implementation
+    );
+    assert_eq!(classify_intent("/status"), IntentClass::Implementation);
+}
+
+#[test]
+fn greeting_plus_task_is_implementation() {
+    // Action verb wins over greeting prefix.
+    assert_eq!(
+        classify_intent("hi, can you write a script that adds two numbers?"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("Hello, please fix the failing test in src/main.rs"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn single_ambiguous_word_is_conversational() {
+    // "yes", "ok", "cool" — short, no verb -> conversational.
+    assert_eq!(classify_intent("yes"), IntentClass::Conversational);
+    assert_eq!(classify_intent("ok"), IntentClass::Conversational);
+    assert_eq!(classify_intent("cool"), IntentClass::Conversational);
+}
+
+#[test]
+fn long_descriptive_input_routes_to_implementation() {
+    // > 10 words, no action verb, but clearly a request for work.
+    let long = "the failing integration test for the auth middleware on staging \
+                seems related to the recent token refresh changes from last week";
+    assert_eq!(classify_intent(long), IntentClass::Implementation);
+}
+
+#[test]
+fn help_me_is_implementation() {
+    assert_eq!(
+        classify_intent("help me debug this issue"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn case_insensitive() {
+    assert_eq!(classify_intent("HELLO"), IntentClass::Conversational);
+    assert_eq!(
+        classify_intent("WRITE A SCRIPT"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn punctuation_only_is_conversational() {
+    assert_eq!(classify_intent("???"), IntentClass::Conversational);
+    assert_eq!(classify_intent("..."), IntentClass::Conversational);
+}
+
+#[test]
+fn search_verb_is_implementation() {
+    assert_eq!(
+        classify_intent("search the codebase for TODO"),
+        IntentClass::Implementation
+    );
+    assert_eq!(
+        classify_intent("find all uses of delegate_to_agent"),
+        IntentClass::Implementation
+    );
+}
+
+// ---- Research-class tests (#203) ----
+
+#[test]
+fn question_words_signal_research() {
+    assert_eq!(
+        classify_intent("what does run_pm_task_with_session do"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("how does the intent classifier work"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("why is the server not starting"),
+        IntentClass::Research
+    );
+}
+
+#[test]
+fn research_verbs_signal_research() {
+    assert_eq!(
+        classify_intent("explain the architecture"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("review the authentication code"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("analyze the performance bottleneck"),
+        IntentClass::Research
+    );
+    assert_eq!(
+        classify_intent("describe how sessions work"),
+        IntentClass::Research
+    );
+}
+
+#[test]
+fn short_question_mark_is_research() {
+    assert_eq!(
+        classify_intent("is bedrock enabled?"),
+        IntentClass::Research
+    );
+}
+
+#[test]
+fn action_verb_wins_over_question_word() {
+    // "how do I fix this bug" — starts with "how" but contains "fix"
+    // (action verb) -> Implementation.
+    assert_eq!(
+        classify_intent("how do I fix this bug"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn action_verb_wins_over_research_verb() {
+    // "explain how to write a test" — contains both "explain" (research)
+    // and "write" (action) -> Implementation.
+    assert_eq!(
+        classify_intent("explain how to write a test"),
+        IntentClass::Implementation
+    );
+}
+
+#[test]
+fn write_a_review_is_implementation() {
+    // "write" is an action verb even though "review" is a research verb.
+    assert_eq!(
+        classify_intent("write a review"),
+        IntentClass::Implementation
+    );
+}

--- a/crates/trusty-code/src/ipc/mod.rs
+++ b/crates/trusty-code/src/ipc/mod.rs
@@ -1,0 +1,388 @@
+//! NDJSON IPC protocol for PM <-> sub-agent communication.
+//!
+//! Why: Provides a minimal, newline-delimited JSON protocol so the PM and
+//! sub-agent subprocesses can exchange structured messages over stdin/stdout
+//! without framing ambiguity.
+//! What: Defines the `IpcMessage` enum (Task / Result / Error), the
+//! `HistoryMessage` wire type for conversation history, and helpers to
+//! serialize to/from single-line JSON.
+//! Test: Round-trip each variant through `serialize_message` + `parse_message`
+//! and assert equality (see unit tests below).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::perf::TokenUsage;
+
+/// Simple `{role, content}` serializable form used over IPC.
+///
+/// Why: The LLM-client typed message format (e.g. `ChatCompletionRequestMessage`
+/// from async-openai) has a complex shape that does not round-trip cleanly
+/// through JSON IPC. A tiny `HistoryMessage` is trivially serde-friendly and
+/// sufficient to rebuild the typed messages on the sub-agent side. This type
+/// lives in the `ipc` module because it IS an IPC wire type — it only ever
+/// exists to cross the PM→sub-agent boundary.
+/// What: Pair of `role` ("user"|"assistant"|"system") and `content` strings.
+/// Test: See `ipc::tests` round-trips.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HistoryMessage {
+    pub role: String,
+    pub content: String,
+}
+
+impl HistoryMessage {
+    /// Construct a `HistoryMessage` with role=`"user"`.
+    ///
+    /// Why: Callers serialize a dialog turn over IPC without touching the
+    /// role string directly, avoiding typos.
+    /// What: Plain struct literal with `role="user"`.
+    /// Test: Indirectly via IPC round-trip tests.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: content.into(),
+        }
+    }
+
+    /// Construct a `HistoryMessage` with role=`"assistant"`.
+    ///
+    /// Why: Symmetric with `user` — keeps IPC construction declarative.
+    /// What: Plain struct literal with `role="assistant"`.
+    /// Test: Indirectly via IPC round-trip tests.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: content.into(),
+        }
+    }
+}
+
+/// A single IPC message exchanged between the PM and a sub-agent.
+///
+/// Why: Discriminated union keeps message handling type-safe while serializing
+/// to a compact single-line JSON form suitable for NDJSON framing.
+/// What: Three variants — Task (PM -> sub), Result (sub -> PM success),
+/// Error (sub -> PM failure). All carry a correlation `id`.
+/// Test: Serialize each variant, assert the `"type"` tag matches; parse back
+/// and assert structural equality.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum IpcMessage {
+    /// PM -> sub-agent: new task to execute.
+    ///
+    /// `history`, when present, carries prior user/assistant turns that the
+    /// sub-agent should prepend to its chat request. `session_reset`, when
+    /// true, instructs the sub-agent to behave as if no history exists; its
+    /// primary use is flushing stale state mid-run without round-tripping
+    /// through the PM. Both fields are optional and omitted from the wire when
+    /// absent so existing tools and older agents keep working unchanged.
+    Task {
+        id: String,
+        task: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        history: Option<Vec<HistoryMessage>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_reset: Option<bool>,
+    },
+    /// Sub-agent -> PM: successful result.
+    ///
+    /// `content` is the full agent output. `summary` is an optional concise
+    /// summary (~200-500 words) that downstream workflow phases substitute via
+    /// `{{phase_name}}` templates — keeping prompt sizes bounded. Missing =
+    /// no summary extracted.
+    Result {
+        id: String,
+        content: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+        /// Aggregated LLM token usage for this task.
+        ///
+        /// Why: Sub-agents own the LLM round-trips; PM/WorkflowEngine needs
+        /// the counts to produce per-phase performance records. Optional for
+        /// backward compat with tool-only (non-LLM) results.
+        /// What: `TokenUsage` with Anthropic cache fields; serializes under
+        /// the `"usage"` key and is omitted when absent.
+        /// Test: `ipc::tests::result_with_usage_roundtrip`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<TokenUsage>,
+        status: String,
+    },
+    /// Sub-agent -> PM: execution failure.
+    Error {
+        id: String,
+        error: String,
+        status: String,
+    },
+}
+
+impl IpcMessage {
+    /// Convenience constructor for a Task message with a fresh UUIDv4 id.
+    ///
+    /// Why: Callers should not have to generate UUIDs manually.
+    /// What: Wraps `uuid::Uuid::new_v4()` and builds a minimal Task variant.
+    /// Test: `ipc::tests::task_roundtrip`.
+    pub fn new_task(task: impl Into<String>) -> Self {
+        IpcMessage::Task {
+            id: uuid::Uuid::new_v4().to_string(),
+            task: task.into(),
+            history: None,
+            session_reset: None,
+        }
+    }
+
+    /// Convenience constructor for a Task carrying prior session history.
+    ///
+    /// Why: Persistent-session agents need their caller to forward the
+    /// accumulated user/assistant turns so the sub-agent can rebuild context
+    /// in a fresh process.
+    /// What: Same as `new_task` but sets `history` when non-empty.
+    /// Test: `ipc::tests::task_with_history_roundtrip`.
+    #[allow(dead_code)]
+    pub fn new_task_with_history(task: impl Into<String>, history: Vec<HistoryMessage>) -> Self {
+        IpcMessage::Task {
+            id: uuid::Uuid::new_v4().to_string(),
+            task: task.into(),
+            history: if history.is_empty() {
+                None
+            } else {
+                Some(history)
+            },
+            session_reset: None,
+        }
+    }
+
+    /// Convenience constructor for a success Result message (no summary).
+    ///
+    /// Why: Most test helpers only need content + status.
+    /// What: Returns a `Result` variant with `summary=None` and `usage=None`.
+    /// Test: `ipc::tests::result_roundtrip`.
+    #[allow(dead_code)]
+    pub fn new_result(id: impl Into<String>, content: impl Into<String>) -> Self {
+        IpcMessage::Result {
+            id: id.into(),
+            content: content.into(),
+            summary: None,
+            usage: None,
+            status: "success".into(),
+        }
+    }
+
+    /// Convenience constructor for a success Result message with a summary.
+    ///
+    /// Why: Sub-agents producing output for downstream phases should emit a
+    /// concise summary so prompt context doesn't balloon.
+    /// What: Returns a `Result` variant with both `content` and `summary` set.
+    /// Test: `ipc::tests::result_with_summary_roundtrip`.
+    #[allow(dead_code)]
+    pub fn new_result_with_summary(
+        id: impl Into<String>,
+        content: impl Into<String>,
+        summary: Option<String>,
+    ) -> Self {
+        IpcMessage::Result {
+            id: id.into(),
+            content: content.into(),
+            summary,
+            usage: None,
+            status: "success".into(),
+        }
+    }
+
+    /// Constructor for a success `Result` message with optional summary and
+    /// aggregated token usage.
+    ///
+    /// Why: Sub-agents aggregate per-turn `TokenUsage` across the whole task
+    /// and bubble it up via IPC so `WorkflowEngine` can build the per-phase
+    /// performance record.
+    /// What: Returns a `Result` variant populating all three optional fields.
+    /// Test: `ipc::tests::result_with_usage_roundtrip`.
+    pub fn new_result_full(
+        id: impl Into<String>,
+        content: impl Into<String>,
+        summary: Option<String>,
+        usage: Option<TokenUsage>,
+    ) -> Self {
+        IpcMessage::Result {
+            id: id.into(),
+            content: content.into(),
+            summary,
+            usage,
+            status: "success".into(),
+        }
+    }
+
+    /// Convenience constructor for an Error message.
+    ///
+    /// Why: Keeps error construction consistent at call sites.
+    /// What: Returns an `Error` variant with `status="error"`.
+    /// Test: `ipc::tests::error_roundtrip`.
+    pub fn new_error(id: impl Into<String>, error: impl Into<String>) -> Self {
+        IpcMessage::Error {
+            id: id.into(),
+            error: error.into(),
+            status: "error".into(),
+        }
+    }
+}
+
+/// Serialize an IpcMessage to a single NDJSON line (trailing `\n`).
+///
+/// Why: Callers write one message per line to the IPC pipe; centralizing the
+/// newline here prevents framing bugs at call sites.
+/// What: Returns `"{...json...}\n"`.
+/// Test: Assert output ends with `\n` and contains no embedded newlines in
+/// the JSON prefix.
+pub fn serialize_message(msg: &IpcMessage) -> Result<String> {
+    let mut s = serde_json::to_string(msg).context("failed to serialize IpcMessage")?;
+    s.push('\n');
+    Ok(s)
+}
+
+/// Parse a single NDJSON line into an IpcMessage.
+///
+/// Why: Callers read one line at a time from the IPC pipe; this helper
+/// strips any trailing newline and decodes the JSON object.
+/// What: Returns `Ok(IpcMessage)` or an error with context.
+/// Test: Feed known-good JSON for each variant and assert equality; feed
+/// malformed JSON and assert `Err`.
+pub fn parse_message(line: &str) -> Result<IpcMessage> {
+    let trimmed = line.trim_end_matches(['\n', '\r']);
+    serde_json::from_str::<IpcMessage>(trimmed)
+        .with_context(|| format!("failed to parse IpcMessage from line: {trimmed}"))
+}
+
+/// Extract a summary from an agent's content output.
+///
+/// Why: Downstream workflow phases need a concise summary (~200-500 words)
+/// rather than 30k chars of raw code. Agents are instructed to append a
+/// `## Summary` section; this helper extracts it so the engine can forward
+/// only the summary into subsequent phase templates.
+/// What: Looks for a case-insensitive `## Summary` heading at the end of the
+/// content. If found, returns everything AFTER that header (trimmed). If not
+/// found, returns the first 500 chars of content as a fallback.
+/// Test: See `extract_summary_finds_trailing_section` and
+/// `extract_summary_fallback_uses_prefix`.
+pub fn extract_summary(content: &str) -> String {
+    let lower = content.to_ascii_lowercase();
+    // Find the LAST `## summary` heading (case-insensitive) so agents that
+    // reference the word "summary" inline don't trigger a false match.
+    let mut best: Option<usize> = None;
+    let needle = "## summary";
+    let mut start = 0usize;
+    while let Some(pos) = lower[start..].find(needle) {
+        let abs = start + pos;
+        // Must be at start of line (preceded by newline or be at offset 0).
+        let at_line_start = abs == 0 || lower.as_bytes()[abs - 1] == b'\n';
+        if at_line_start {
+            best = Some(abs);
+        }
+        start = abs + needle.len();
+    }
+
+    if let Some(h) = best {
+        // Advance past the rest of the header line.
+        let after_header = &content[h..];
+        if let Some(nl) = after_header.find('\n') {
+            return after_header[nl + 1..].trim().to_string();
+        }
+        // Header with no newline after it — nothing to return.
+        return String::new();
+    }
+
+    // Fallback: first 500 chars.
+    let trimmed = content.trim();
+    if trimmed.chars().count() <= 500 {
+        return trimmed.to_string();
+    }
+    let prefix: String = trimmed.chars().take(500).collect();
+    prefix
+}
+
+/// Parse `## File: <path>` / `### \`<path>\`` sections from LLM output into
+/// a list of `(relative_path, body)` pairs, without touching the filesystem.
+///
+/// Why: The workflow engine must be able to materialize code-phase output to
+/// disk BETWEEN phases so the QA phase can run tests against it. Keeping the
+/// parse step pure makes it testable and reusable.
+/// What: Scans line-by-line for `## File: <path>`, `### File: <path>`, or
+/// `## \`path\`` / `### \`path\`` markdown headers, then captures the next
+/// fenced code block as the file body. Empty / unterminated blocks are
+/// skipped. Returns `Vec<(PathBuf, String)>` in the order they appear.
+/// Test: `extract_files_from_content_parses_multiple_files` asserts two
+/// files are returned from a document with two `## File:` sections.
+pub fn extract_files_from_content(content: &str) -> Vec<(PathBuf, String)> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut out: Vec<(PathBuf, String)> = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim_start();
+
+        let rel_path: Option<String> = if let Some(rest) = trimmed.strip_prefix("## File:") {
+            Some(rest.trim().trim_matches('`').to_string())
+        } else if let Some(rest) = trimmed.strip_prefix("### File:") {
+            Some(rest.trim().trim_matches('`').to_string())
+        } else if let Some(rest) = trimmed.strip_prefix("### ") {
+            let s = rest.trim();
+            if s.starts_with('`') && s.ends_with('`') && s.len() >= 2 {
+                Some(s.trim_matches('`').to_string())
+            } else {
+                None
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("## ") {
+            let s = rest.trim();
+            if s.starts_with('`') && s.ends_with('`') && s.len() >= 2 {
+                Some(s.trim_matches('`').to_string())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let Some(rel) = rel_path else {
+            i += 1;
+            continue;
+        };
+
+        if rel.is_empty() {
+            i += 1;
+            continue;
+        }
+
+        let mut j = i + 1;
+        while j < lines.len() && !lines[j].trim_start().starts_with("```") {
+            j += 1;
+        }
+        if j >= lines.len() {
+            break;
+        }
+
+        let body_start = j + 1;
+        let mut k = body_start;
+        while k < lines.len() && !lines[k].trim_start().starts_with("```") {
+            k += 1;
+        }
+
+        let body = if k > body_start {
+            lines[body_start..k].join("\n")
+        } else {
+            String::new()
+        };
+        let mut final_body = body;
+        if !final_body.ends_with('\n') {
+            final_body.push('\n');
+        }
+
+        out.push((PathBuf::from(rel), final_body));
+        i = k + 1;
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-code/src/ipc/tests.rs
+++ b/crates/trusty-code/src/ipc/tests.rs
@@ -1,0 +1,197 @@
+//! Unit tests for the NDJSON IPC message protocol.
+//!
+//! Why: Message framing, parsing, and summary extraction are the wire contract
+//! between PM and sub-agents; round-trip and edge-case coverage guards it.
+//! What: serialize/parse round-trips, malformed-line handling, summary extraction.
+//! Test: This module is itself the test coverage.
+
+use super::*;
+
+#[test]
+fn task_roundtrip() {
+    let msg = IpcMessage::Task {
+        id: "abc".into(),
+        task: "do stuff".into(),
+        history: None,
+        session_reset: None,
+    };
+    let wire = serialize_message(&msg).unwrap();
+    assert!(wire.ends_with('\n'));
+    let back = parse_message(&wire).unwrap();
+    assert_eq!(msg, back);
+}
+
+#[test]
+fn task_with_history_roundtrip() {
+    let msg = IpcMessage::new_task_with_history(
+        "go",
+        vec![
+            HistoryMessage::user("earlier-q"),
+            HistoryMessage::assistant("earlier-a"),
+        ],
+    );
+    let wire = serialize_message(&msg).unwrap();
+    let back = parse_message(&wire).unwrap();
+    assert_eq!(msg, back);
+    match back {
+        IpcMessage::Task { history, .. } => {
+            let h = history.expect("history present");
+            assert_eq!(h.len(), 2);
+            assert_eq!(h[0].role, "user");
+            assert_eq!(h[1].role, "assistant");
+        }
+        _ => panic!("expected Task"),
+    }
+}
+
+#[test]
+fn task_legacy_wire_parses_without_history() {
+    // Pre-#51 wire format omits `history`/`session_reset`.
+    let wire = r#"{"type":"task","id":"x","task":"y"}"#;
+    let msg = parse_message(wire).unwrap();
+    match msg {
+        IpcMessage::Task {
+            history,
+            session_reset,
+            ..
+        } => {
+            assert!(history.is_none());
+            assert!(session_reset.is_none());
+        }
+        _ => panic!("expected Task"),
+    }
+}
+
+#[test]
+fn result_roundtrip() {
+    let msg = IpcMessage::new_result("id1", "output");
+    let wire = serialize_message(&msg).unwrap();
+    let back = parse_message(&wire).unwrap();
+    assert_eq!(msg, back);
+}
+
+#[test]
+fn error_roundtrip() {
+    let msg = IpcMessage::new_error("id1", "something broke");
+    let wire = serialize_message(&msg).unwrap();
+    let back = parse_message(&wire).unwrap();
+    assert_eq!(msg, back);
+}
+
+#[test]
+fn parse_rejects_garbage() {
+    assert!(parse_message("not json").is_err());
+}
+
+#[test]
+fn result_with_summary_roundtrip() {
+    let msg = IpcMessage::new_result_with_summary(
+        "id1",
+        "full content body",
+        Some("short summary".into()),
+    );
+    let wire = serialize_message(&msg).unwrap();
+    let back = parse_message(&wire).unwrap();
+    assert_eq!(msg, back);
+    match back {
+        IpcMessage::Result { summary, .. } => {
+            assert_eq!(summary, Some("short summary".to_string()));
+        }
+        _ => panic!("expected Result"),
+    }
+}
+
+#[test]
+fn result_with_usage_roundtrip() {
+    let usage = TokenUsage::new(100, 50, 10, 5);
+    let msg = IpcMessage::new_result_full("id1", "content", Some("sum".into()), Some(usage));
+    let wire = serialize_message(&msg).unwrap();
+    let back = parse_message(&wire).unwrap();
+    assert_eq!(msg, back);
+    match back {
+        IpcMessage::Result { usage, .. } => {
+            let u = usage.expect("usage present");
+            assert_eq!(u.prompt_tokens, 100);
+            assert_eq!(u.completion_tokens, 50);
+            assert_eq!(u.cache_read_tokens, 10);
+            assert_eq!(u.cache_creation_tokens, 5);
+        }
+        _ => panic!("expected Result"),
+    }
+}
+
+#[test]
+fn result_without_summary_parses_old_wire_format() {
+    // Prior-version wire format lacks `summary`.
+    let wire = r#"{"type":"result","id":"x","content":"y","status":"success"}"#;
+    let msg = parse_message(wire).unwrap();
+    match msg {
+        IpcMessage::Result { summary, .. } => assert!(summary.is_none()),
+        _ => panic!("expected Result"),
+    }
+}
+
+#[test]
+fn extract_summary_finds_trailing_section() {
+    let content =
+        "Some code here\nmore stuff\n\n## Summary\nThis is the concise summary the agent wrote.";
+    let s = extract_summary(content);
+    assert_eq!(s, "This is the concise summary the agent wrote.");
+}
+
+#[test]
+fn extract_summary_is_case_insensitive() {
+    let content = "header\n\n## SUMMARY\nbody text here";
+    let s = extract_summary(content);
+    assert_eq!(s, "body text here");
+}
+
+#[test]
+fn extract_summary_finds_last_summary_section() {
+    // Agents may mention the word "summary" inline but only the trailing
+    // ## Summary block counts.
+    let content = "## Summary of Research Findings (inline)\nignored\n\n## Summary\nreal summary";
+    let s = extract_summary(content);
+    assert_eq!(s, "real summary");
+}
+
+#[test]
+fn extract_summary_fallback_uses_prefix() {
+    let long = "a".repeat(2000);
+    let s = extract_summary(&long);
+    assert_eq!(s.chars().count(), 500);
+}
+
+#[test]
+fn extract_summary_fallback_short_content_verbatim() {
+    let content = "short output";
+    let s = extract_summary(content);
+    assert_eq!(s, "short output");
+}
+
+#[test]
+fn extract_files_from_content_parses_multiple_files() {
+    let content = "Intro text.\n\n## File: app/main.py\n```python\nprint(\"hi\")\n```\n\n## File: app/util.py\n```python\ndef f():\n    return 1\n```\n";
+    let files = extract_files_from_content(content);
+    assert_eq!(files.len(), 2);
+    assert_eq!(files[0].0, PathBuf::from("app/main.py"));
+    assert!(files[0].1.contains("print(\"hi\")"));
+    assert!(files[0].1.ends_with('\n'));
+    assert_eq!(files[1].0, PathBuf::from("app/util.py"));
+    assert!(files[1].1.contains("def f():"));
+}
+
+#[test]
+fn extract_files_from_content_returns_empty_when_no_markers() {
+    let files = extract_files_from_content("Just prose, no file sections.");
+    assert!(files.is_empty());
+}
+
+#[test]
+fn extract_files_from_content_handles_backtick_header() {
+    let content = "### `scripts/go.sh`\n```bash\necho hi\n```\n";
+    let files = extract_files_from_content(content);
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].0, PathBuf::from("scripts/go.sh"));
+    assert!(files[0].1.contains("echo hi"));
+}

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -8,8 +8,8 @@
 //! fills that role. It is the Claude-Code-native orchestration entry point —
 //! driven by API, CLI, or TUI — that runs the PM main-loop, enforces the
 //! mandatory workflow, and delegates authority to typed sub-agents according to
-//! MPM protocols. Extraction from open-mpm is tracked in epic #587; this Phase 0
-//! establishes the crate and binary skeleton before any logic is moved.
+//! MPM protocols. Extraction from open-mpm is tracked in epic #587; Phase 1
+//! moves the leaf/protocol modules here.
 //!
 //! # Design constraints
 //!
@@ -28,21 +28,89 @@
 //!
 //! # What
 //!
-//! Currently a Phase 0 scaffold. The public surface is intentionally empty until
-//! Phase 1 begins moving PM main-loop logic from open-mpm (#587).
+//! Phase 1 public surface (leaf/protocol modules extracted from open-mpm per
+//! #640):
+//!
+//! * [`events`] — process-global broadcast event bus (`Event` enum, `publish`,
+//!   `subscribe`, `emit`).
+//! * [`ipc`] — NDJSON IPC protocol for PM ↔ sub-agent communication
+//!   (`IpcMessage`, `HistoryMessage`, `serialize_message`, `parse_message`).
+//! * [`perf`] — per-phase latency + token/cost instrumentation (`TokenUsage`,
+//!   `PerfCollector`, `PerfRecord`, `cost_usd`).
+//! * [`intent`] — pure-Rust heuristic intent classifier (`IntentClass`,
+//!   `classify_intent`) for PM fast-pathing.
+//! * [`progress`] — real-time phase progress reporter (`ProgressReporter`,
+//!   `format_duration`).
+//! * [`build_info`] — monotonic build counter + version banner (`BuildInfo`,
+//!   `VERSION`, `GIT_HASH`, `version_string`).
 //!
 //! # Test
 //!
-//! `cargo test -p trusty-code` — the test suite is empty at Phase 0. Integration
-//! tests will be added in Phase 1 as the PM loop is introduced. The smoke test
-//! for this phase is `tcode --version` and the stub subcommand exit codes
-//! verified by `cargo run -p trusty-code -- serve --project .` (non-zero exit
-//! with "not yet implemented" message).
+//! `cargo test -p trusty-code` — all leaf modules carry their own unit tests.
+//! The event bus has a round-trip async test (`publish_round_trips_through_subscribe`).
+//! Phase 2+ will add integration tests as the PM loop is introduced.
+
+// ── Phase 1 leaf/protocol modules (extracted from open-mpm per #640) ──
+
+/// Process-wide broadcast event bus for real-time UI streaming.
+///
+/// Why: Centralises telemetry emission so any code path can publish events
+/// without threading a sender through dozens of call sites.
+/// What: `Event` enum, `publish`/`subscribe`/`emit` helpers, the
+/// `EVENT_LINE_PREFIX` constant for subprocess relay.
+/// Test: `events::tests::publish_round_trips_through_subscribe`.
+pub mod events;
+
+/// NDJSON IPC protocol for PM ↔ sub-agent communication.
+///
+/// Why: Provides a framing-safe wire protocol over stdin/stdout pipes so the
+/// PM and sub-agent subprocesses exchange structured messages without ambiguity.
+/// What: `IpcMessage` enum (Task/Result/Error), `HistoryMessage` wire type,
+/// `serialize_message`/`parse_message` helpers, `extract_summary`/
+/// `extract_files_from_content` utilities.
+/// Test: `ipc::tests::*` round-trips every variant.
+pub mod ipc;
+
+/// Per-phase latency + token/cost instrumentation.
+///
+/// Why: Tracks how long each workflow phase takes, how many tokens it consumed,
+/// and the resulting USD cost so runs can be compared build-over-build.
+/// What: `TokenUsage`, `PhaseRecord`, `PerfRecord`, `PerfTotals`,
+/// `PerfCollector`, `cost_usd`.
+/// Test: `perf::tests::*`.
+pub mod perf;
+
+/// Pure-Rust heuristic intent classifier for PM fast-pathing.
+///
+/// Why: Avoids routing trivial conversational inputs through the full
+/// subprocess pipeline — a 60-90s round trip for what should be sub-second.
+/// What: `IntentClass` enum, `classify_intent` function.
+/// Test: `intent::classifier_tests::*`, `intent::classifier_tests_2::*`,
+/// `intent::classifier_property_tests::*`, `intent::tests::*`.
+pub mod intent;
+
+/// Real-time phase progress reporter to stderr.
+///
+/// Why: Workflow runs take 20–70 minutes; users need live feedback without
+/// polluting stdout (reserved for structured JSON output).
+/// What: `ProgressReporter` struct with phase/wave lifecycle hooks and
+/// `format_duration` helper.
+/// Test: `progress::tests::*`.
+pub mod progress;
+
+/// Build and version tracking.
+///
+/// Why: A monotonic build counter that increments on every process start gives
+/// a deterministic identifier that pairs with semver for log correlation.
+/// What: `BuildInfo` struct, `VERSION`/`GIT_HASH`/`PKG_NAME` constants,
+/// `version_string` helper.
+/// Test: `build_info::tests::*`.
+pub mod build_info;
 
 /// Version string, re-exported so integration tests can assert it without
 /// hard-coding the constant.
 ///
-/// Why: single source of truth for the version across CLI and any future API
+/// Why: Single source of truth for the version across CLI and any future API
 /// responses that embed it.
 /// What: the `CARGO_PKG_VERSION` compile-time env var, captured at build time.
 /// Test: `cargo run -p trusty-code -- --version` must print this value.

--- a/crates/trusty-code/src/perf/mod.rs
+++ b/crates/trusty-code/src/perf/mod.rs
@@ -1,0 +1,450 @@
+//! Performance instrumentation — per-phase latency + token/cost capture.
+//!
+//! Why: (#47) We need to track how long each workflow phase takes, how many
+//! tokens it consumed (prompt / completion / Anthropic cache read / cache
+//! creation), and the resulting USD cost so we can compare runs build-over-
+//! build and catch regressions or prompt-caching wins. Persisting one JSON
+//! file per run under `docs/performance/runs/` plus a one-line summary log
+//! keeps the data greppable without a database.
+//! What: `PerfCollector` is constructed at workflow start, `record_phase`
+//! appends a `PhaseRecord` after each phase, and `flush` writes the final
+//! JSON + log line. `TokenUsage` is the provider-agnostic shape captured
+//! from each LLM call (extended with Anthropic-specific `cache_read` /
+//! `cache_creation` fields which are zero for non-Anthropic models).
+//! Test: `cost_usd_known_model`, `collector_records_phases`,
+//! `collector_totals_sum_phases`, `collector_flush_writes_json_and_log`.
+//!
+//! Module layout (see #366 split):
+//! - `mod.rs` — perf record types + `PerfCollector` lifecycle
+//! - `pricing.rs` — `cost_usd` + the model pricing table + formatters
+//! - `tests.rs` — unit tests
+
+mod pricing;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use pricing::{filename_stamp, truncate_preview};
+
+pub use pricing::cost_usd;
+
+/// Token usage captured from a single LLM round-trip.
+///
+/// Why: (#50) Anthropic's OpenRouter responses carry cache_read_input_tokens
+/// and cache_creation_input_tokens alongside the standard prompt/completion
+/// counts. Exposing those as first-class fields lets `PerfCollector` track
+/// cache effectiveness over time. For non-Anthropic models these stay 0.
+/// What: Plain struct; additive (`+`-style) accumulation is done inline in
+/// `PerfCollector::totals`.
+/// Test: `token_usage_default_is_zeros`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub cache_read_tokens: u32,
+    pub cache_creation_tokens: u32,
+}
+
+impl TokenUsage {
+    /// Construct a `TokenUsage` from the four individual counts.
+    pub fn new(prompt: u32, completion: u32, cache_read: u32, cache_creation: u32) -> Self {
+        Self {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            cache_read_tokens: cache_read,
+            cache_creation_tokens: cache_creation,
+        }
+    }
+
+    /// Add another usage record into this one (in place).
+    ///
+    /// Why: Each phase may comprise multiple LLM turns (tool loop); we sum
+    /// them into a single `PhaseRecord`.
+    /// What: Field-wise saturating add.
+    /// Test: `token_usage_accumulates`.
+    pub fn add(&mut self, other: &TokenUsage) {
+        self.prompt_tokens = self.prompt_tokens.saturating_add(other.prompt_tokens);
+        self.completion_tokens = self
+            .completion_tokens
+            .saturating_add(other.completion_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(other.cache_read_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(other.cache_creation_tokens);
+    }
+}
+
+/// One phase's measured performance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PhaseRecord {
+    pub name: String,
+    pub duration_ms: u64,
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub cache_read_tokens: u32,
+    pub cache_creation_tokens: u32,
+    pub cost_usd: f64,
+}
+
+/// Totals rolled up from every `PhaseRecord` in a run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PerfTotals {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub cache_read_tokens: u32,
+    pub cache_creation_tokens: u32,
+    pub cost_usd: f64,
+}
+
+/// Full performance record persisted to `docs/performance/runs/`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerfRecord {
+    pub build: u64,
+    pub version: String,
+    pub workflow: String,
+    pub task_preview: String,
+    pub started_at: String,
+    pub total_duration_ms: u64,
+    pub phases: Vec<PhaseRecord>,
+    pub totals: PerfTotals,
+    /// Run outcome (#56): "success" | "partial" | "failed".
+    ///
+    /// Why: When a phase fails mid-workflow, we still want to persist the
+    /// perf record so we can see where/how the run died. A separate `status`
+    /// field distinguishes clean completions from partial runs in tooling
+    /// that scans `runs/*.json`.
+    /// What: Defaults to "success" for back-compat with older fixtures.
+    #[serde(default = "default_status")]
+    pub status: String,
+    /// Name of the phase that failed, when `status != "success"` (#56).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_phase: Option<String>,
+    /// Distinct skill names injected into any phase prompt during this run
+    /// (#171).
+    ///
+    /// Why: Post-run persistence needs to know which skills were used so it
+    /// can increment `use_count` and refresh `last_used`. Carrying the list
+    /// through `PerfRecord` keeps the data in one place that's already
+    /// flushed to disk for analysis.
+    /// What: Deduplicated, insertion-order-preserved list of skill names.
+    /// Defaults to empty for back-compat with older fixtures.
+    #[serde(default)]
+    pub skills_used: Vec<String>,
+    /// Distinct skill names matched by the pre-plan discovery step (#173).
+    ///
+    /// Why: Discovery surfaces every skill the engine considered relevant for
+    /// a task — even if downstream prompt assembly only injected a subset (or
+    /// none). Recording the broader candidate set separately from
+    /// `skills_used` lets us measure recall vs. precision over time and
+    /// audit which signals the discovery step matched on.
+    /// What: Deduplicated, insertion-order-preserved list of skill names.
+    /// Defaults to empty for back-compat with older fixtures.
+    #[serde(default)]
+    pub skills_considered: Vec<String>,
+    /// Tests passed in the QA phase, when the QA agent emitted a parsable
+    /// JSON envelope with a `passed` count.
+    ///
+    /// Why: Run-over-run comparisons want raw test counts, not just the
+    /// pass/fail status. Tracking `tests_passed`/`tests_failed` separately
+    /// from `status` lets dashboards show "1118/1118 passing" without
+    /// re-parsing QA output.
+    /// What: `Some(N)` when QA returned a JSON envelope with `passed`,
+    /// `None` otherwise. Defaults to `None` for back-compat with older
+    /// fixtures and for runs that skip the QA phase.
+    /// Test: `test_run_record_serializes_test_counts`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tests_passed: Option<u64>,
+    /// Tests failed in the QA phase, paired with `tests_passed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tests_failed: Option<u64>,
+}
+
+fn default_status() -> String {
+    "success".to_string()
+}
+
+/// Accumulator used during workflow execution.
+///
+/// Why: Keeping the collector off the workflow context lets us evolve perf
+/// schema without churning `WorkflowContext`; the engine just calls
+/// `record_phase`/`flush`.
+/// What: Holds the build stamp, workflow name, a 120-char preview of the
+/// user task, the wall-clock start `Instant`, and a growing `Vec<PhaseRecord>`.
+/// `flush(out_dir)` writes `runs/YYYYMMDD-HHMMSS-build<N>.json` and appends a
+/// summary line to `runs.log`.
+/// Test: see unit tests at bottom of this file.
+pub struct PerfCollector {
+    build: u64,
+    workflow: String,
+    task_preview: String,
+    started_at: Instant,
+    started_at_iso: String,
+    phases: Vec<PhaseRecord>,
+    model: String,
+    /// #56: run status; set via `set_status`. Defaults to "success".
+    status: String,
+    /// #56: name of the phase that failed, if any.
+    failed_phase: Option<String>,
+    /// #171: distinct skills injected during the run, insertion-ordered.
+    skills_used: Vec<String>,
+    /// #173: distinct skills matched by pre-plan discovery, insertion-ordered.
+    skills_considered: Vec<String>,
+    /// QA-emitted passed test count, when available.
+    tests_passed: Option<u64>,
+    /// QA-emitted failed test count, when available.
+    tests_failed: Option<u64>,
+}
+
+impl PerfCollector {
+    /// Construct a new collector.
+    ///
+    /// Why: Called at workflow start so the wall-clock anchor is the true
+    /// run start, not a lazy "first phase" moment.
+    /// What: Captures the build number, workflow name, truncated task preview,
+    /// start `Instant`, and start ISO8601 UTC timestamp.
+    /// Test: `collector_records_phases`.
+    pub fn new(build: u64, workflow: &str, task: &str) -> Self {
+        Self {
+            build,
+            workflow: workflow.to_string(),
+            task_preview: truncate_preview(task, 120),
+            started_at: Instant::now(),
+            started_at_iso: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            phases: Vec::new(),
+            model: String::new(),
+            status: "success".to_string(),
+            failed_phase: None,
+            skills_used: Vec::new(),
+            skills_considered: Vec::new(),
+            tests_passed: None,
+            tests_failed: None,
+        }
+    }
+
+    /// Record QA test counts (Fix 3 / parity with claude-mpm).
+    ///
+    /// Why: When the QA agent emits a parsable JSON envelope, we want the
+    /// exact `passed`/`failed` counts on the perf record so dashboards can
+    /// chart them over time without re-parsing agent output.
+    /// What: Stores the two counts; included in the flushed JSON and the
+    /// `runs.log` summary line.
+    /// Test: `test_run_record_serializes_test_counts`.
+    pub fn set_test_counts(&mut self, passed: u64, failed: u64) {
+        self.tests_passed = Some(passed);
+        self.tests_failed = Some(failed);
+    }
+
+    /// Record that `name` was surfaced by pre-plan skill discovery (#173).
+    ///
+    /// Why: Discovery considers a broader set of skills than what is actually
+    /// injected. Tracking the full candidate set separately preserves the
+    /// recall side of the recall/precision picture for post-run analysis.
+    /// What: Appends `name` to `skills_considered` if not already present
+    /// (insertion-ordered de-dup).
+    /// Test: `collector_records_skills_considered`.
+    pub fn record_skill_considered(&mut self, name: &str) {
+        if !self.skills_considered.iter().any(|s| s == name) {
+            self.skills_considered.push(name.to_string());
+        }
+    }
+
+    /// Record that `name` was injected into a phase prompt during this run
+    /// (#171).
+    ///
+    /// Why: Post-run persistence (`update_skill_usage` in `main.rs`) needs the
+    /// list of injected skills to update `use_count` and `last_used`. Tracking
+    /// here keeps the collector the single source of truth for the run.
+    /// What: Appends `name` to `skills_used` if not already present
+    /// (insertion-ordered de-dup).
+    /// Test: Indirect via `update_skill_usage` integration in main.
+    pub fn record_skill_used(&mut self, name: &str) {
+        if !self.skills_used.iter().any(|s| s == name) {
+            self.skills_used.push(name.to_string());
+        }
+    }
+
+    /// Set the run status (#56).
+    ///
+    /// Why: The workflow engine calls this after the phase loop to record
+    /// "success" on clean completion and "partial" / "failed" when a phase
+    /// returned an error, so the flushed JSON reflects reality.
+    /// What: Stores the status string verbatim; `flush` serializes it.
+    /// Test: `collector_flush_records_failed_status`.
+    pub fn set_status(&mut self, status: &str) {
+        self.status = status.to_string();
+    }
+
+    /// Record which phase failed (#56).
+    ///
+    /// Why: Paired with `set_status`, this lets analysis tooling group failed
+    /// runs by failing phase without having to parse the last `phases` entry.
+    /// What: Stores the phase name; included in the flushed JSON when set.
+    /// Test: `collector_flush_records_failed_status`.
+    pub fn set_failed_phase(&mut self, phase: &str) {
+        self.failed_phase = Some(phase.to_string());
+    }
+
+    /// Record the dominant model used by the run for pricing.
+    ///
+    /// Why: The LLM pricing table is keyed by model substring. The workflow
+    /// engine doesn't know the model up front (each phase's agent may use a
+    /// different one), so we let the caller set/override as needed.
+    /// What: Stores the latest model string; pricing is looked up per
+    /// `record_phase` call using the `model` argument passed there, not this
+    /// field (this is retained for future aggregate analysis).
+    /// Test: implicit via `collector_flush_writes_json_and_log`.
+    #[allow(dead_code)]
+    pub fn set_model(&mut self, model: &str) {
+        self.model = model.to_string();
+    }
+
+    /// Append a phase's measurements, computing its USD cost from `model`.
+    ///
+    /// Why: Engines call this once per phase with the agent model and the
+    /// summed `TokenUsage` from all LLM turns in that phase.
+    /// What: Computes `cost_usd` via `cost_usd(model, ...)`, pushes a
+    /// `PhaseRecord`.
+    /// Test: `collector_records_phases`.
+    pub fn record_phase(&mut self, name: &str, duration_ms: u64, model: &str, usage: &TokenUsage) {
+        let cost = cost_usd(
+            model,
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            usage.cache_read_tokens,
+            usage.cache_creation_tokens,
+        );
+        self.phases.push(PhaseRecord {
+            name: name.to_string(),
+            duration_ms,
+            prompt_tokens: usage.prompt_tokens,
+            completion_tokens: usage.completion_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+            cache_creation_tokens: usage.cache_creation_tokens,
+            cost_usd: cost,
+        });
+    }
+
+    /// Sum all phase records into a single `PerfTotals`.
+    fn totals(&self) -> PerfTotals {
+        let mut t = PerfTotals::default();
+        for p in &self.phases {
+            t.prompt_tokens = t.prompt_tokens.saturating_add(p.prompt_tokens);
+            t.completion_tokens = t.completion_tokens.saturating_add(p.completion_tokens);
+            t.cache_read_tokens = t.cache_read_tokens.saturating_add(p.cache_read_tokens);
+            t.cache_creation_tokens = t
+                .cache_creation_tokens
+                .saturating_add(p.cache_creation_tokens);
+            t.cost_usd += p.cost_usd;
+        }
+        t
+    }
+
+    /// Build the final `PerfRecord` without writing to disk.
+    ///
+    /// Why: Exposed for tests and for in-process consumers (the #151 JSON
+    /// envelope projects this record into a `PmResponse`). `flush` calls
+    /// this internally.
+    pub fn build_record(&self) -> PerfRecord {
+        let total_duration_ms = self.started_at.elapsed().as_millis() as u64;
+        PerfRecord {
+            build: self.build,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            workflow: self.workflow.clone(),
+            task_preview: self.task_preview.clone(),
+            started_at: self.started_at_iso.clone(),
+            total_duration_ms,
+            phases: self.phases.clone(),
+            totals: self.totals(),
+            status: self.status.clone(),
+            failed_phase: self.failed_phase.clone(),
+            skills_used: self.skills_used.clone(),
+            skills_considered: self.skills_considered.clone(),
+            tests_passed: self.tests_passed,
+            tests_failed: self.tests_failed,
+        }
+    }
+
+    /// Persist the record to `out_dir/runs/<stamp>.json` and append a
+    /// summary line to `out_dir/runs.log`.
+    ///
+    /// Why: A single JSON per run is easy to diff and feed to tooling; the
+    /// log line is a human-readable one-liner suitable for `tail -f`.
+    /// What: Computes total duration, serializes to pretty JSON, writes the
+    /// file atomically-ish (direct write is fine for append-only telemetry),
+    /// then appends a one-line summary to `runs.log`.
+    /// Test: `collector_flush_writes_json_and_log`.
+    pub async fn flush(&self, out_dir: &Path) -> Result<()> {
+        let record = self.build_record();
+        let runs_dir = out_dir.join("runs");
+        tokio::fs::create_dir_all(&runs_dir)
+            .await
+            .with_context(|| format!("failed to create {}", runs_dir.display()))?;
+
+        // Stamp filename: YYYYMMDD-HHMMSS-build<N>.json
+        // Derived from `started_at_iso` (UTC) so filenames are deterministic
+        // given the same start time — useful for test fixtures.
+        let stamp = filename_stamp(&self.started_at_iso, self.build);
+        let json_path = runs_dir.join(format!("{stamp}.json"));
+        let pretty = serde_json::to_vec_pretty(&record).context("serialize PerfRecord")?;
+        tokio::fs::write(&json_path, &pretty)
+            .await
+            .with_context(|| format!("failed to write {}", json_path.display()))?;
+
+        // One-line summary: tab-separated key=value pairs.
+        // `tests_passed` / `tests_failed` are appended as the LAST two columns
+        // for back-compat with log readers that only parse the first N
+        // columns. Render `None` as "-" so the column is always present.
+        let fmt_opt = |n: Option<u64>| -> String {
+            n.map(|v| v.to_string()).unwrap_or_else(|| "-".to_string())
+        };
+        let line = format!(
+            "{ts}\tbuild={b}\tworkflow={w}\tdur_ms={d}\tprompt={p}\tcompletion={c}\tcache_r={cr}\tcache_w={cc}\tcost_usd={cost:.6}\ttests_passed={tp}\ttests_failed={tf}\n",
+            ts = self.started_at_iso,
+            b = self.build,
+            w = self.workflow,
+            d = record.total_duration_ms,
+            p = record.totals.prompt_tokens,
+            c = record.totals.completion_tokens,
+            cr = record.totals.cache_read_tokens,
+            cc = record.totals.cache_creation_tokens,
+            cost = record.totals.cost_usd,
+            tp = fmt_opt(record.tests_passed),
+            tf = fmt_opt(record.tests_failed),
+        );
+        let log_path = out_dir.join("runs.log");
+        // Ensure parent exists (out_dir itself might not yet).
+        if let Some(parent) = log_path.parent() {
+            tokio::fs::create_dir_all(parent).await.ok();
+        }
+        // Append.
+        use tokio::io::AsyncWriteExt;
+        let mut f = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .await
+            .with_context(|| format!("failed to open {}", log_path.display()))?;
+        f.write_all(line.as_bytes())
+            .await
+            .context("failed to append perf log line")?;
+        f.flush().await.ok();
+
+        tracing::info!(
+            path = %json_path.display(),
+            build = self.build,
+            total_ms = record.total_duration_ms,
+            total_cost_usd = record.totals.cost_usd,
+            "wrote perf record"
+        );
+        Ok(())
+    }
+}

--- a/crates/trusty-code/src/perf/pricing.rs
+++ b/crates/trusty-code/src/perf/pricing.rs
@@ -1,0 +1,109 @@
+//! Cost computation, model pricing table, and small formatting helpers.
+//!
+//! Why: The pricing table + cost math is mechanically independent of the
+//! collector's lifecycle; isolating it keeps `mod.rs` focused on recording
+//! and persisting performance records.
+//! What: `cost_usd` (public), the `pricing_for`/`per_million` rate helpers, and
+//! the `filename_stamp` / `truncate_preview` formatters used by the collector.
+//! Test: `cost_usd_*` / `filename_stamp_format` / `truncate_preview_*` in
+//! `perf::tests`.
+
+/// Compute USD cost for a single LLM call given the model name and token
+/// counts. Unknown models fall back to Sonnet-class pricing.
+///
+/// Why: (#47) We hard-code the pricing table rather than hit a live endpoint
+/// so offline/CI runs still produce comparable cost figures. Pricing is
+/// per-million-tokens as published by Anthropic and OpenRouter.
+/// What: Substring-matches the model string (e.g. "anthropic/claude-sonnet-4-5"
+/// or "claude-haiku-4") and multiplies each token bucket by its rate.
+/// Test: `cost_usd_known_model`, `cost_usd_unknown_defaults_to_sonnet`.
+pub fn cost_usd(
+    model: &str,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    cache_read: u32,
+    cache_creation: u32,
+) -> f64 {
+    // Rates in USD per token (not per million).
+    let (rate_in, rate_out, rate_cache_r, rate_cache_w) = pricing_for(model);
+    let to_usd = |tokens: u32, rate: f64| tokens as f64 * rate;
+    to_usd(prompt_tokens, rate_in)
+        + to_usd(completion_tokens, rate_out)
+        + to_usd(cache_read, rate_cache_r)
+        + to_usd(cache_creation, rate_cache_w)
+}
+
+/// Returns (input, output, cache_read, cache_creation) rates per token.
+fn pricing_for(model: &str) -> (f64, f64, f64, f64) {
+    let m = model.to_ascii_lowercase();
+    // Claude Sonnet 4.x — $3 in, $15 out, $0.30 cache read, $3.75 cache write
+    if m.contains("sonnet-4") || m.contains("claude-sonnet-4") {
+        return (
+            per_million(3.0),
+            per_million(15.0),
+            per_million(0.30),
+            per_million(3.75),
+        );
+    }
+    // Claude Haiku 3/4 — $0.80 in, $4 out, $0.08 cache read, $1 cache write
+    if m.contains("haiku-3") || m.contains("haiku-4") || m.contains("claude-haiku") {
+        return (
+            per_million(0.80),
+            per_million(4.0),
+            per_million(0.08),
+            per_million(1.0),
+        );
+    }
+    // Claude Opus 4 — $15 in, $75 out (cache rates not published here, use
+    // conservative 10% / 125% of input, matching Anthropic convention).
+    if m.contains("opus-4") || m.contains("claude-opus") {
+        return (
+            per_million(15.0),
+            per_million(75.0),
+            per_million(1.50),
+            per_million(18.75),
+        );
+    }
+    // Default: Sonnet-class rates.
+    (
+        per_million(3.0),
+        per_million(15.0),
+        per_million(0.30),
+        per_million(3.75),
+    )
+}
+
+fn per_million(usd: f64) -> f64 {
+    usd / 1_000_000.0
+}
+
+/// Build the canonical filename stamp from an ISO8601 timestamp + build #.
+///
+/// Why: Deterministic filenames let tests assert exact paths and let humans
+/// sort runs chronologically with `ls`.
+/// What: Converts `2026-04-22T17:31:30Z` + build=42 to `20260422-173130-build42`.
+/// Test: `filename_stamp_format`.
+pub(super) fn filename_stamp(iso: &str, build: u64) -> String {
+    // Strip non-digit chars to keep only YYYYMMDDHHMMSS, then reinsert the dash.
+    let digits: String = iso.chars().filter(|c| c.is_ascii_digit()).collect();
+    // Expected layout: YYYYMMDDHHMMSS (14 digits). If shorter, just pad.
+    let date = digits.get(0..8).unwrap_or("00000000");
+    let time = digits.get(8..14).unwrap_or("000000");
+    format!("{date}-{time}-build{build}")
+}
+
+pub(super) fn truncate_preview(s: &str, max_chars: usize) -> String {
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= max_chars {
+        return trimmed.to_string();
+    }
+    let mut out = String::with_capacity(max_chars + 3);
+    for (i, ch) in trimmed.chars().enumerate() {
+        if i >= max_chars {
+            break;
+        }
+        out.push(ch);
+    }
+    out.push_str("...");
+    out
+}

--- a/crates/trusty-code/src/perf/tests.rs
+++ b/crates/trusty-code/src/perf/tests.rs
@@ -1,0 +1,294 @@
+//! Unit tests for cost computation and the `PerfCollector` lifecycle.
+//!
+//! Why: Cost math underpins every billing/UX figure; the collector's
+//! record/flush behavior is the persistence contract.
+//! What: `cost_usd_*` pricing cases, `truncate_preview`/`filename_stamp`
+//! formatters, and collector record/total/flush tests.
+//! Test: This module is itself the test coverage.
+
+use super::*;
+
+#[test]
+fn token_usage_default_is_zeros() {
+    let u = TokenUsage::default();
+    assert_eq!(u.prompt_tokens, 0);
+    assert_eq!(u.completion_tokens, 0);
+    assert_eq!(u.cache_read_tokens, 0);
+    assert_eq!(u.cache_creation_tokens, 0);
+}
+
+#[test]
+fn token_usage_accumulates() {
+    let mut a = TokenUsage::new(10, 5, 2, 1);
+    a.add(&TokenUsage::new(3, 7, 0, 4));
+    assert_eq!(a, TokenUsage::new(13, 12, 2, 5));
+}
+
+#[test]
+fn cost_usd_known_sonnet() {
+    // 1M prompt tokens of sonnet = $3.00
+    let c = cost_usd("anthropic/claude-sonnet-4-5", 1_000_000, 0, 0, 0);
+    assert!((c - 3.0).abs() < 1e-9, "got {c}");
+}
+
+#[test]
+fn cost_usd_known_haiku() {
+    // 1M output tokens of haiku = $4.00
+    let c = cost_usd("anthropic/claude-haiku-4", 0, 1_000_000, 0, 0);
+    assert!((c - 4.0).abs() < 1e-9, "got {c}");
+}
+
+#[test]
+fn cost_usd_cache_read_is_cheaper() {
+    // Cache-read is 10x cheaper than fresh input on Sonnet.
+    let fresh = cost_usd("claude-sonnet-4-6", 1_000_000, 0, 0, 0);
+    let cached = cost_usd("claude-sonnet-4-6", 0, 0, 1_000_000, 0);
+    assert!(cached < fresh);
+    assert!((cached - 0.30).abs() < 1e-9);
+}
+
+// --- #29: Cost calculation tests for cache hits ---
+
+#[test]
+fn cost_usd_sonnet_cache_creation_matches_spec() {
+    // #29: Cache write rate for claude-sonnet-4-6 is $3.75/MTok.
+    // 1M cache_creation tokens should cost exactly $3.75.
+    let c = cost_usd("anthropic/claude-sonnet-4-6", 0, 0, 0, 1_000_000);
+    assert!(
+        (c - 3.75).abs() < 1e-9,
+        "expected $3.75 for 1M cache write tokens on sonnet-4-6, got {c}"
+    );
+}
+
+#[test]
+fn cost_usd_sonnet_cache_read_is_one_tenth_of_input() {
+    // #29: Cache read is $0.30/MTok vs input $3.00/MTok — exactly 10%.
+    // This is the headline savings figure for prompt caching.
+    let fresh_input = cost_usd("claude-sonnet-4-6", 1_000_000, 0, 0, 0);
+    let cache_read = cost_usd("claude-sonnet-4-6", 0, 0, 1_000_000, 0);
+    let ratio = cache_read / fresh_input;
+    assert!(
+        (ratio - 0.10).abs() < 1e-9,
+        "cache_read should be 10% of input cost, got {ratio} (fresh={fresh_input}, cached={cache_read})"
+    );
+}
+
+#[test]
+fn cost_usd_sonnet_mixed_cache_hit_scenario() {
+    // #29: Realistic scenario — a turn where most input is a cache hit:
+    // 100 fresh prompt tokens + 50 completion + 9000 cache_read + 1000 cache_creation.
+    // Sonnet rates: $3/MTok in, $15/MTok out, $0.30/MTok cache_r, $3.75/MTok cache_w.
+    let c = cost_usd("anthropic/claude-sonnet-4-6", 100, 50, 9_000, 1_000);
+    // 100 * 3e-6 = 0.0003, 50 * 15e-6 = 0.00075, 9000 * 0.30e-6 = 0.0027,
+    // 1000 * 3.75e-6 = 0.00375. Total = 0.00750.
+    let expected = 0.0003 + 0.00075 + 0.0027 + 0.00375;
+    assert!((c - expected).abs() < 1e-9, "expected {expected}, got {c}");
+}
+
+#[test]
+fn cost_usd_unknown_defaults_to_sonnet() {
+    let u = cost_usd("some/unknown-model", 1_000_000, 0, 0, 0);
+    assert!((u - 3.0).abs() < 1e-9);
+}
+
+#[test]
+fn collector_records_phases() {
+    let mut c = PerfCollector::new(7, "prescriptive", "write x");
+    c.record_phase(
+        "research",
+        500,
+        "claude-sonnet-4-5",
+        &TokenUsage::new(1000, 500, 0, 0),
+    );
+    c.record_phase(
+        "code",
+        1200,
+        "claude-sonnet-4-5",
+        &TokenUsage::new(2000, 1000, 500, 200),
+    );
+    let r = c.build_record();
+    assert_eq!(r.phases.len(), 2);
+    assert_eq!(r.phases[0].prompt_tokens, 1000);
+    assert_eq!(r.totals.prompt_tokens, 3000);
+    assert_eq!(r.totals.completion_tokens, 1500);
+    assert_eq!(r.totals.cache_read_tokens, 500);
+    assert_eq!(r.totals.cache_creation_tokens, 200);
+    // Sanity: some cost accrued.
+    assert!(r.totals.cost_usd > 0.0);
+    assert_eq!(r.build, 7);
+    assert_eq!(r.workflow, "prescriptive");
+}
+
+#[test]
+fn truncate_preview_respects_limit() {
+    let s = "x".repeat(200);
+    let p = truncate_preview(&s, 120);
+    assert_eq!(p.chars().count(), 123, "120 chars + ellipsis");
+    assert!(p.ends_with("..."));
+}
+
+#[test]
+fn truncate_preview_short_string_unchanged() {
+    let p = truncate_preview("hi", 120);
+    assert_eq!(p, "hi");
+}
+
+#[test]
+fn filename_stamp_format() {
+    let s = filename_stamp("2026-04-22T17:31:30Z", 42);
+    assert_eq!(s, "20260422-173130-build42");
+}
+
+#[tokio::test]
+async fn collector_flush_records_failed_status() {
+    // #56: When a workflow phase fails, the engine sets status=partial
+    // and records the failing phase, then flushes. Verify the JSON round-
+    // trips those fields.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut c = PerfCollector::new(11, "test-wf", "broken task");
+    c.record_phase(
+        "research",
+        50,
+        "claude-sonnet-4-6",
+        &TokenUsage::new(100, 50, 0, 0),
+    );
+    c.set_status("partial");
+    c.set_failed_phase("plan");
+    c.flush(tmp.path()).await.unwrap();
+
+    let runs = tmp.path().join("runs");
+    let mut entries = tokio::fs::read_dir(&runs).await.unwrap();
+    let mut rec: Option<PerfRecord> = None;
+    while let Some(e) = entries.next_entry().await.unwrap() {
+        if e.path().extension().and_then(|s| s.to_str()) == Some("json") {
+            let bytes = tokio::fs::read(e.path()).await.unwrap();
+            rec = Some(serde_json::from_slice(&bytes).unwrap());
+        }
+    }
+    let rec = rec.expect("perf json written");
+    assert_eq!(rec.status, "partial");
+    assert_eq!(rec.failed_phase.as_deref(), Some("plan"));
+}
+
+#[test]
+fn collector_default_status_is_success() {
+    // #56: New collectors default to status=success so clean runs don't
+    // need to explicitly call set_status.
+    let c = PerfCollector::new(1, "wf", "task");
+    let r = c.build_record();
+    assert_eq!(r.status, "success");
+    assert!(r.failed_phase.is_none());
+}
+
+/// Why: Fix 3 / claude-mpm parity — when the QA agent emits structured
+/// pass/fail counts, those counts must round-trip through the perf
+/// record's JSON form AND appear in the `runs.log` summary line.
+/// What: Constructs a `PerfCollector`, sets test counts, flushes, and
+/// asserts both the JSON file and the log line carry "42" and "0".
+/// Test: this function (`test_run_record_serializes_test_counts`).
+#[tokio::test]
+async fn test_run_record_serializes_test_counts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut c = PerfCollector::new(99, "test-wf", "task with tests");
+    c.record_phase("qa", 10, "claude-sonnet-4-6", &TokenUsage::new(10, 5, 0, 0));
+    c.set_test_counts(42, 0);
+    c.flush(tmp.path()).await.unwrap();
+
+    // JSON round-trip retains the counts.
+    let runs = tmp.path().join("runs");
+    let mut entries = tokio::fs::read_dir(&runs).await.unwrap();
+    let mut rec: Option<PerfRecord> = None;
+    while let Some(e) = entries.next_entry().await.unwrap() {
+        if e.path().extension().and_then(|s| s.to_str()) == Some("json") {
+            let bytes = tokio::fs::read(e.path()).await.unwrap();
+            rec = Some(serde_json::from_slice(&bytes).unwrap());
+        }
+    }
+    let rec = rec.expect("perf json written");
+    assert_eq!(rec.tests_passed, Some(42));
+    assert_eq!(rec.tests_failed, Some(0));
+
+    // Raw JSON bytes contain the literal "42" and "0" values.
+    let json_str = serde_json::to_string(&rec).unwrap();
+    assert!(json_str.contains("\"tests_passed\":42"));
+    assert!(json_str.contains("\"tests_failed\":0"));
+
+    // runs.log line ends with the new columns.
+    let log = tokio::fs::read_to_string(tmp.path().join("runs.log"))
+        .await
+        .unwrap();
+    assert!(
+        log.contains("tests_passed=42"),
+        "runs.log missing tests_passed=42: {log}"
+    );
+    assert!(
+        log.contains("tests_failed=0"),
+        "runs.log missing tests_failed=0: {log}"
+    );
+}
+
+/// Why: Back-compat — when QA didn't run or emitted no JSON envelope,
+/// the counts must be `None`, omitted from JSON via `skip_serializing_if`,
+/// and rendered as `-` in `runs.log`.
+#[tokio::test]
+async fn run_record_omits_test_counts_when_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut c = PerfCollector::new(100, "test-wf", "no qa");
+    c.record_phase(
+        "research",
+        5,
+        "claude-sonnet-4-6",
+        &TokenUsage::new(10, 5, 0, 0),
+    );
+    c.flush(tmp.path()).await.unwrap();
+
+    let log = tokio::fs::read_to_string(tmp.path().join("runs.log"))
+        .await
+        .unwrap();
+    assert!(
+        log.contains("tests_passed=-"),
+        "expected '-' placeholder: {log}"
+    );
+    assert!(
+        log.contains("tests_failed=-"),
+        "expected '-' placeholder: {log}"
+    );
+}
+
+#[tokio::test]
+async fn collector_flush_writes_json_and_log() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut c = PerfCollector::new(5, "test-wf", "hello task");
+    c.record_phase(
+        "plan",
+        100,
+        "claude-sonnet-4-5",
+        &TokenUsage::new(100, 50, 0, 0),
+    );
+    c.flush(tmp.path()).await.unwrap();
+
+    // A runs/ dir was created with at least one .json inside.
+    let runs = tmp.path().join("runs");
+    assert!(runs.exists());
+    let mut entries = tokio::fs::read_dir(&runs).await.unwrap();
+    let mut found_json = false;
+    while let Some(e) = entries.next_entry().await.unwrap() {
+        if e.path().extension().and_then(|s| s.to_str()) == Some("json") {
+            found_json = true;
+            let bytes = tokio::fs::read(e.path()).await.unwrap();
+            let rec: PerfRecord = serde_json::from_slice::<PerfRecord>(&bytes).unwrap();
+            assert_eq!(rec.build, 5);
+            assert_eq!(rec.workflow, "test-wf");
+            assert_eq!(rec.phases.len(), 1);
+            assert_eq!(rec.phases[0].name, "plan");
+        }
+    }
+    assert!(found_json, "expected at least one .json run file");
+
+    // runs.log exists and contains the build tag.
+    let log = tokio::fs::read_to_string(tmp.path().join("runs.log"))
+        .await
+        .unwrap();
+    assert!(log.contains("build=5"));
+    assert!(log.contains("workflow=test-wf"));
+}

--- a/crates/trusty-code/src/progress.rs
+++ b/crates/trusty-code/src/progress.rs
@@ -1,0 +1,255 @@
+//! Real-time phase progress streaming to the terminal (#149).
+//!
+//! Why: Workflow runs take 20–70 minutes and previously emitted nothing on
+//! stdout/stderr until the `observe` phase completed. Users had no signal that
+//! the harness was alive, which is terrible UX. Streaming a one-line summary
+//! per phase (and per code-wave) to stderr — colorized when stderr is a TTY —
+//! gives operators live progress without polluting stdout (which is reserved
+//! for the structured `--json` envelope).
+//!
+//! What: `ProgressReporter` is a tiny stderr-printer with three lifecycle
+//! hooks (`phase_start`, `phase_done`, `phase_failed`) plus a `wave_start` /
+//! `wave_done` pair for the code phase's per-wave loop and a final
+//! `workflow_done` summary. Output is pure stderr `eprintln!` — no logging
+//! framework, no allocations on the hot path beyond the formatted line.
+//!
+//! Test: see unit tests at the bottom of this file:
+//! - `progress_reporter_formats_phase_start`
+//! - `progress_reporter_formats_phase_done_no_color`
+
+use std::io::IsTerminal;
+use std::time::{Duration, Instant};
+
+/// ANSI color helpers used when stderr is a TTY. Plain strings otherwise.
+///
+/// Why: Colorizing only when the output is interactive avoids dumping escape
+/// codes into log files / CI captures while still giving humans a readable
+/// stream when running locally.
+/// What: `wrap` returns either `\x1b[<code>m{}\x1b[0m` or the original string
+/// based on `use_color`.
+fn wrap(use_color: bool, code: &str, s: &str) -> String {
+    if use_color {
+        format!("\x1b[{code}m{s}\x1b[0m")
+    } else {
+        s.to_string()
+    }
+}
+
+const COLOR_BOLD: &str = "1";
+const COLOR_DIM: &str = "2";
+const COLOR_GREEN: &str = "32";
+const COLOR_RED: &str = "31";
+const COLOR_CYAN: &str = "36";
+
+/// Streams human-readable progress lines to stderr while a workflow runs.
+///
+/// Why: A purpose-built reporter (vs. ad-hoc `eprintln!`s sprinkled in the
+/// engine) keeps the formatting in one place so the terminal output stays
+/// consistent across phases, waves, and failure paths.
+/// What: Stores the workflow start `Instant` so `workflow_done` can compute a
+/// total elapsed, plus a `use_color` flag captured once at construction.
+/// Test: `progress_reporter_formats_phase_start`,
+/// `progress_reporter_formats_phase_done_no_color`.
+pub struct ProgressReporter {
+    #[allow(dead_code)]
+    start: Instant,
+    use_color: bool,
+}
+
+impl Default for ProgressReporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProgressReporter {
+    /// Construct a reporter, detecting whether stderr is a TTY for color.
+    ///
+    /// Why: Avoid emitting ANSI codes when stderr is piped/captured.
+    /// What: Captures `Instant::now()` and `std::io::stderr().is_terminal()`.
+    /// Test: Indirect via formatting tests (force-disable color via `with_color`).
+    pub fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            use_color: std::io::stderr().is_terminal(),
+        }
+    }
+
+    /// Force-set the color flag (used by tests for deterministic output).
+    #[allow(dead_code)]
+    pub fn with_color(mut self, use_color: bool) -> Self {
+        self.use_color = use_color;
+        self
+    }
+
+    /// Format a phase-start line. Public for testing; production paths call
+    /// `phase_start` which prints to stderr.
+    pub fn format_phase_start(&self, phase: &str) -> String {
+        let arrow = wrap(self.use_color, COLOR_CYAN, "▶");
+        let arrow = wrap(self.use_color, COLOR_DIM, &arrow);
+        let name = wrap(self.use_color, COLOR_BOLD, &format!("{phase:<10}"));
+        format!("[open-mpm] {arrow} {name} starting…")
+    }
+
+    /// Print "phase starting" to stderr.
+    pub fn phase_start(&self, phase: &str) {
+        eprintln!("\r{}", self.format_phase_start(phase));
+    }
+
+    /// Format a phase-done line.
+    pub fn format_phase_done(
+        &self,
+        phase: &str,
+        elapsed: Duration,
+        cost: f32,
+        note: Option<&str>,
+    ) -> String {
+        let check = wrap(self.use_color, COLOR_GREEN, "✓");
+        let name = wrap(self.use_color, COLOR_BOLD, &format!("{phase:<10}"));
+        let stats = format!("({}, ~${:.2})", format_duration(elapsed), cost);
+        let stats = wrap(self.use_color, COLOR_DIM, &stats);
+        match note {
+            Some(n) if !n.is_empty() => {
+                format!("[open-mpm] {check} {name} done  {stats} — {n}")
+            }
+            _ => format!("[open-mpm] {check} {name} done  {stats}"),
+        }
+    }
+
+    /// Print "phase done" to stderr, with elapsed time and cost.
+    pub fn phase_done(&self, phase: &str, elapsed: Duration, cost: f32, note: Option<&str>) {
+        eprintln!("\r{}", self.format_phase_done(phase, elapsed, cost, note));
+    }
+
+    /// Print "phase failed" to stderr with elapsed time and a short error.
+    pub fn phase_failed(&self, phase: &str, elapsed: Duration, error: &str) {
+        let cross = wrap(self.use_color, COLOR_RED, "✗");
+        let name = wrap(self.use_color, COLOR_BOLD, &format!("{phase:<10}"));
+        let stats = wrap(
+            self.use_color,
+            COLOR_DIM,
+            &format!("({})", format_duration(elapsed)),
+        );
+        // Truncate long errors to keep the line readable.
+        let short = error.lines().next().unwrap_or(error);
+        let short: String = short.chars().take(120).collect();
+        eprintln!("\r[open-mpm] {cross} {name} failed {stats} — {short}");
+    }
+
+    /// Print a "code wave starting" line for the wave-loop branch of the code
+    /// phase. The wave loop runs sequentially across multiple files; surfacing
+    /// per-wave progress prevents the code phase from looking stuck.
+    pub fn wave_start(&self, wave_index: usize, wave_total: usize, file_count: usize) {
+        let arrow = wrap(self.use_color, COLOR_DIM, "▶");
+        let name = wrap(self.use_color, COLOR_BOLD, "code      ");
+        eprintln!(
+            "\r[open-mpm] {arrow} {name} wave {wave_index}/{wave_total}  ({file_count} file{plural})",
+            plural = if file_count == 1 { "" } else { "s" },
+        );
+    }
+
+    /// Print a "code wave done" line. Symmetric counterpart to `wave_start`.
+    pub fn wave_done(&self, wave_index: usize, wave_total: usize, elapsed: Duration) {
+        let check = wrap(self.use_color, COLOR_GREEN, "✓");
+        let name = wrap(self.use_color, COLOR_BOLD, "code      ");
+        let stats = wrap(
+            self.use_color,
+            COLOR_DIM,
+            &format!("({})", format_duration(elapsed)),
+        );
+        eprintln!("\r[open-mpm] {check} {name} wave {wave_index}/{wave_total} done {stats}");
+    }
+
+    /// Print the final workflow-complete summary line.
+    pub fn workflow_done(&self, total_elapsed: Duration, total_cost: f32) {
+        let check = wrap(self.use_color, COLOR_GREEN, "✓");
+        let name = wrap(self.use_color, COLOR_BOLD, "workflow  ");
+        let stats = wrap(
+            self.use_color,
+            COLOR_DIM,
+            &format!(
+                "({}, ${:.2} total)",
+                format_duration(total_elapsed),
+                total_cost
+            ),
+        );
+        eprintln!("\r[open-mpm] {check} {name} complete  {stats}");
+    }
+
+    /// Workflow-level start time accessor (used by callers that want to show
+    /// the wall-clock elapsed alongside per-phase numbers).
+    #[allow(dead_code)]
+    pub fn workflow_started(&self) -> Instant {
+        self.start
+    }
+}
+
+/// Format a `Duration` as `MmSSs` for short runs and `Hh MmSSs` for long ones.
+///
+/// Why: Operators care about seconds for sub-minute phases and want to see
+/// minutes/seconds for long ones. Strict `secs.millis` is not friendly when a
+/// phase runs for several minutes.
+/// What: `42s`, `3m12s`, `1h05m12s`.
+/// Test: `format_duration_renders_human_friendly`.
+pub fn format_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    if h > 0 {
+        format!("{h}h{m:02}m{s:02}s")
+    } else if m > 0 {
+        format!("{m}m{s:02}s")
+    } else {
+        format!("{s}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_reporter_formats_phase_start() {
+        let r = ProgressReporter::new().with_color(false);
+        let s = r.format_phase_start("research");
+        assert!(s.contains("research"), "got: {s}");
+        assert!(s.contains("starting"), "got: {s}");
+        assert!(s.starts_with("[open-mpm]"), "got: {s}");
+        // No ANSI when color disabled.
+        assert!(!s.contains("\x1b["), "expected no ANSI in: {s}");
+    }
+
+    #[test]
+    fn progress_reporter_formats_phase_done_no_color() {
+        let r = ProgressReporter::new().with_color(false);
+        let s = r.format_phase_done("plan", Duration::from_secs(18), 0.04, None);
+        assert!(s.contains("plan"), "got: {s}");
+        assert!(s.contains("done"), "got: {s}");
+        assert!(s.contains("18s"), "got: {s}");
+        assert!(s.contains("$0.04"), "got: {s}");
+        assert!(!s.contains("\x1b["), "expected no ANSI in: {s}");
+    }
+
+    #[test]
+    fn progress_reporter_phase_done_includes_note() {
+        let r = ProgressReporter::new().with_color(false);
+        let s = r.format_phase_done("qa", Duration::from_secs(28), 0.09, Some("35/35 passed"));
+        assert!(s.contains("35/35 passed"), "got: {s}");
+    }
+
+    #[test]
+    fn progress_reporter_uses_color_when_enabled() {
+        let r = ProgressReporter::new().with_color(true);
+        let s = r.format_phase_start("research");
+        assert!(s.contains("\x1b["), "expected ANSI in: {s}");
+    }
+
+    #[test]
+    fn format_duration_renders_human_friendly() {
+        assert_eq!(format_duration(Duration::from_secs(42)), "42s");
+        assert_eq!(format_duration(Duration::from_secs(192)), "3m12s");
+        assert_eq!(format_duration(Duration::from_secs(3912)), "1h05m12s");
+        assert_eq!(format_duration(Duration::from_secs(0)), "0s");
+    }
+}

--- a/crates/trusty-review/src/config/config_resolve_index_tests.rs
+++ b/crates/trusty-review/src/config/config_resolve_index_tests.rs
@@ -14,6 +14,7 @@ use crate::integrations::{
     search_client::{IndexInfo, SearchClient, SearchClientError, SearchResult},
 };
 use async_trait::async_trait;
+use serial_test::serial;
 
 // ─── Mock clients ─────────────────────────────────────────────────────────────
 
@@ -104,6 +105,7 @@ async fn resolve_index_noop_when_explicit() {
 /// resolved value.
 /// Test: this test.
 #[tokio::test]
+#[serial]
 async fn resolve_index_updates_when_match_found() {
     let root = tempfile::tempdir().unwrap();
     // Create .git so find_git_root stops here.
@@ -196,6 +198,7 @@ async fn resolve_index_keeps_default_when_no_match() {
 /// call would consume it.
 /// Test: this test.
 #[tokio::test]
+#[serial]
 async fn wiring_cmd_run_resolve_index_updates_before_pipeline() {
     let root = tempfile::tempdir().unwrap();
     std::fs::create_dir(root.path().join(".git")).unwrap();
@@ -259,6 +262,7 @@ async fn wiring_build_app_state_explicit_index_unchanged() {
 /// of config.search_index return the derived value.
 /// Test: this test.
 #[tokio::test]
+#[serial]
 async fn wiring_cmd_compare_resolve_index_applies_to_all_model_runs() {
     let root = tempfile::tempdir().unwrap();
     std::fs::create_dir(root.path().join(".git")).unwrap();

--- a/crates/trusty-search/src/commands/startup_checks.rs
+++ b/crates/trusty-search/src/commands/startup_checks.rs
@@ -14,7 +14,14 @@
 //! Test: `should_warn_cpu_on_apple_silicon_*` tests in this module's `tests`.
 
 // ── Fix D (issue #747) ───────────────────────────────────────────────────────
-
+//
+// The two helpers below are only referenced from the `#[cfg(all(target_os =
+// "macos", target_arch = "aarch64"))]` block inside
+// `warn_if_stale_cpu_device_on_apple_silicon` and from the unit-test module.
+// Gate them to the same platform union so the dead_code lint is silent on
+// Linux CI while keeping the tests runnable everywhere (the logic itself is
+// platform-independent; only the *warning emission* is gated to Apple Silicon).
+#[cfg(any(all(target_os = "macos", target_arch = "aarch64"), test))]
 /// Pure predicate: should the daemon warn about a stale `TRUSTY_DEVICE=cpu`
 /// setting on Apple Silicon?
 ///
@@ -48,6 +55,7 @@ pub fn should_warn_cpu_on_apple_silicon(
     !explicit && is_apple_silicon && device.eq_ignore_ascii_case("cpu")
 }
 
+#[cfg(any(all(target_os = "macos", target_arch = "aarch64"), test))]
 /// Return `true` when `TRUSTY_DEVICE_EXPLICIT` is set to a truthy value.
 ///
 /// Why: lets `warn_if_stale_cpu_device_on_apple_silicon` honour the

--- a/crates/trusty-search/src/service/warm_boot/probe.rs
+++ b/crates/trusty-search/src/service/warm_boot/probe.rs
@@ -134,6 +134,9 @@ pub(super) enum VolumeAccessibility {
 ///
 /// Test: `volume_key_boot_volume`, `volume_key_external_volume`,
 ///       `volume_key_linux_lowercase_volumes_is_root`.
+// `path` is consumed only inside the macOS cfg block; on other platforms it
+// intentionally goes unused (the function always returns `/`).
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
 pub(super) fn volume_key(path: &Path) -> PathBuf {
     // The `/Volumes/<label>` convention is macOS-specific.
     #[cfg(target_os = "macos")]

--- a/crates/trusty-search/src/service/warm_boot/probe_tests.rs
+++ b/crates/trusty-search/src/service/warm_boot/probe_tests.rs
@@ -53,8 +53,11 @@ fn volume_key_boot_volume() {
 
 /// Why: guard that external macOS volumes extract the `/Volumes/<label>` key.
 /// What: paths under `/Volumes/SSD1` or `/Volumes/ExternalDrive` return
-/// `/Volumes/<label>`.
-/// Test: this test.
+/// `/Volumes/<label>`. This test is gated to macOS because `volume_key` only
+/// applies the `/Volumes/<label>` logic under `#[cfg(target_os = "macos")]`;
+/// on Linux, `/Volumes/...` correctly returns `/` (no macOS-style mounts).
+/// Test: this test — macOS only.
+#[cfg(target_os = "macos")]
 #[test]
 fn volume_key_external_volume() {
     assert_eq!(


### PR DESCRIPTION
## Summary

Phase 1 of epic #587 — move the six leaf/protocol modules out of `open-mpm` and into the new `trusty-code` crate so they have a stable, independently-versioned home.

**Extracted modules:**
- `events.rs` — process-global broadcast event bus (`Event` enum, `publish`/`subscribe`/`emit`, stderr relay protocol)
- `ipc/` — NDJSON IPC protocol for PM ↔ sub-agent communication (`IpcMessage`, `HistoryMessage`, `serialize_message`/`parse_message`, `extract_summary`/`extract_files_from_content`)
- `perf/` — per-phase latency + token/cost instrumentation (`PerfCollector`, `TokenUsage`, `PhaseRecord`, `PerfRecord`, `cost_usd`)
- `intent/` — pure-Rust heuristic intent classifier (`IntentClass`, `classify_intent`) with 4 test files (property, unit × 2, edge-case)
- `progress.rs` — real-time phase progress reporter to stderr (`ProgressReporter`, `format_duration`)
- `build_info.rs` — monotonic build counter + version banner (`BuildInfo`, `VERSION`, `GIT_HASH`, `version_string`)

**Supporting additions:**
- `build.rs` — exposes `GIT_COMMIT_HASH` env var at compile time
- `crates/trusty-code/Cargo.toml` — workspace registration, `publish = false`, `edition = "2024"`, `license.workspace = true` (inherits Elastic-2.0)
- `Cargo.toml` (workspace) — adds `trusty-code` to `[workspace.dependencies]`
- `crates/open-mpm/Cargo.toml` — adds `trusty-code` dep so all existing open-mpm consumers keep compiling without change; removal of open-mpm's own duplicate copies is tracked in #647

## Scope vs. #640

Issue #640 lists: `ipc/`, `perf/`, `progress/`, `build_info.rs`, `events.rs`, `intent/` — all six are present. This PR fully satisfies #640's stated scope.

## Verification results

```
cargo check -p trusty-code       → Finished (0 errors, 0 warnings)
cargo check (workspace-wide)     → Finished (0 errors, 0 warnings for trusty-code)
cargo clippy -p trusty-code --all-targets -- -D warnings → Finished (0 warnings)
cargo test -p trusty-code        → 142 passed; 0 failed; 0 ignored
cargo fmt --check -p trusty-code → (no output = clean)
bash scripts/check_line_cap.sh   → line-cap: 172 allowlisted, 0 violations — OK
```

All pre-commit hooks pass (trim whitespace, TOML, large-file check, secrets, 500-line cap ratchet).

## Test plan

- [ ] `cargo test -p trusty-code` — 142 tests covering all 6 modules
- [ ] `cargo check` (workspace) — verifies open-mpm still compiles with the new dep
- [ ] `cargo clippy -p trusty-code --all-targets -- -D warnings` — zero warnings
- [ ] Line-cap gate passes (no new files over 500 lines; all modules well under cap)

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)