### PR TITLE
fix(trusty-review): fix silent mid-file hunk truncation in render_for_prompt

### DIFF
--- a/crates/trusty-review/src/pipeline/diff_analyzer/models.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/models.rs
@@ -193,21 +193,37 @@ impl FilteredDiff {
     /// Why: the prompt builder needs a diff string bounded to `max_chars`; this
     /// method encapsulates the rendering logic so the pipeline has one call site.
     /// What: iterates `files`, renders each surviving hunk, appends the noise
-    /// summary, and stops before exceeding `max_chars`.  Does NOT inject a
-    /// manifest header (spec REV-209 — framing-regression guard).
+    /// summary, and stops before exceeding `max_chars`.  When the budget is
+    /// exhausted mid-file or between files, a loud `[RENDER TRUNCATED …]` marker
+    /// is appended BEFORE the noise summary so the reviewer model cannot miss
+    /// that content was cut.  Both the outer-file and inner-hunk budget checks
+    /// set the same `budget_exceeded` flag and break out of all loops — this
+    /// prevents the previous silent bug where the inner `break` exited only the
+    /// hunk loop, allowing subsequent files to be appended after a half-rendered
+    /// file (hunks silently dropped with no marker).  Does NOT inject a manifest
+    /// header (spec REV-209 — framing-regression guard).
     /// Test: `filtered_diff_render_for_prompt_contains_surviving_content`,
-    /// `filtered_diff_render_respects_max_chars`.
+    /// `filtered_diff_render_respects_max_chars`,
+    /// `render_for_prompt_mid_file_hunk_overflow_loud_not_silent`,
+    /// `render_for_prompt_no_continuation_after_inner_break`.
     pub fn render_for_prompt(&self, max_chars: usize) -> String {
         let mut out = String::with_capacity(max_chars.min(64 * 1024));
         let suffix = self.build_noise_summary();
+        // Constant overhead reserved for the truncation marker (if needed) + suffix.
+        // The marker itself is ~80 chars; we round up to 120 to be safe.
+        const TRUNC_MARKER_RESERVE: usize = 120;
+        let suffix_reserve = suffix.len() + TRUNC_MARKER_RESERVE;
 
-        for file in &self.files {
+        let mut budget_exceeded = false;
+
+        'files: for file in &self.files {
             match file.disposition {
                 FileDisposition::SummaryOnly => {
                     if let Some(ref summary) = file.summary_line {
                         let line = format!("# {}: {}\n", file.filename, summary);
-                        if out.len() + line.len() + suffix.len() > max_chars {
-                            break;
+                        if out.len() + line.len() + suffix_reserve > max_chars {
+                            budget_exceeded = true;
+                            break 'files;
                         }
                         out.push_str(&line);
                     }
@@ -215,15 +231,21 @@ impl FilteredDiff {
                 FileDisposition::Kept => {
                     // Build the file header.
                     let file_header = format!("--- a/{0}\n+++ b/{0}\n", file.filename);
-                    if out.len() + file_header.len() + suffix.len() > max_chars {
-                        break;
+                    if out.len() + file_header.len() + suffix_reserve > max_chars {
+                        budget_exceeded = true;
+                        break 'files;
                     }
                     out.push_str(&file_header);
 
                     for hunk in &file.hunks {
                         let rendered = hunk.render();
-                        if out.len() + rendered.len() + suffix.len() + 1 > max_chars {
-                            break;
+                        if out.len() + rendered.len() + suffix_reserve + 1 > max_chars {
+                            // Inner budget hit: set flag and break the OUTER loop
+                            // so no further files are appended after a half-rendered
+                            // file.  This is the fix for the silent-truncation bug
+                            // where only `break` (inner) was used before.
+                            budget_exceeded = true;
+                            break 'files;
                         }
                         out.push_str(&rendered);
                         out.push('\n');
@@ -233,6 +255,36 @@ impl FilteredDiff {
                     // Dropped files are never rendered in the prompt.
                 }
             }
+        }
+
+        // Append a loud truncation marker whenever the char budget was hit so the
+        // reviewer model cannot silently miss that content was omitted.  This is
+        // the companion to `truncate_diff`'s marker: `render_for_prompt` may cut
+        // before `truncate_diff` is applied, so it must be self-announcing.
+        if budget_exceeded {
+            let remaining_files = self
+                .files
+                .iter()
+                .filter(|f| {
+                    // Count files whose content was not rendered (approximate:
+                    // any file whose header does not appear in out).
+                    !out.contains(f.filename.as_str())
+                })
+                .count();
+            let marker = if remaining_files > 0 {
+                format!(
+                    "\n[RENDER TRUNCATED — char budget ({max_chars}) reached; \
+                     ~{remaining_files} file(s) omitted; review covers only the \
+                     visible portion above]\n"
+                )
+            } else {
+                format!(
+                    "\n[RENDER TRUNCATED — char budget ({max_chars}) reached; \
+                     some hunks omitted from the last file above; review covers \
+                     only the visible portion]\n"
+                )
+            };
+            out.push_str(&marker);
         }
 
         if !suffix.is_empty() {
@@ -301,132 +353,8 @@ impl FilteredDiff {
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
+// Tests split into a sibling file to keep models.rs under the 500-line cap.
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_kept_file(name: &str, hunk_content: &str) -> FilteredFile {
-        FilteredFile {
-            filename: name.to_string(),
-            status: "modified".to_string(),
-            disposition: FileDisposition::Kept,
-            hunks: vec![FilteredHunk {
-                header: "@@ -1,3 +1,3 @@".to_string(),
-                lines: vec![hunk_content.to_string()],
-                substantive_confidence: 1.0,
-                reason_kept: "deterministic-pass".to_string(),
-            }],
-            dropped_hunks: vec![],
-            summary_line: None,
-        }
-    }
-
-    #[test]
-    fn filtered_hunk_render_roundtrip() {
-        let h = FilteredHunk {
-            header: "@@ -1,2 +1,2 @@".to_string(),
-            lines: vec!["-old line".to_string(), "+new line".to_string()],
-            substantive_confidence: 1.0,
-            reason_kept: "test".to_string(),
-        };
-        let rendered = h.render();
-        assert!(rendered.contains("@@ -1,2 +1,2 @@"));
-        assert!(rendered.contains("-old line"));
-        assert!(rendered.contains("+new line"));
-    }
-
-    #[test]
-    fn hunk_drop_reason_label() {
-        assert_eq!(HunkDropReason::WhitespaceOnly.label(), "whitespace-only");
-        assert_eq!(HunkDropReason::ImportOnly.label(), "import-only");
-        assert_eq!(HunkDropReason::CommentOnly.label(), "comment-only");
-        assert_eq!(
-            HunkDropReason::MechanicalHaiku.label(),
-            "mechanical (Haiku)"
-        );
-    }
-
-    #[test]
-    fn filtered_diff_render_for_prompt_contains_surviving_content() {
-        let diff = FilteredDiff {
-            files: vec![make_kept_file("src/auth.rs", "+pub fn authenticate() {}")],
-            dropped_files: vec![],
-            drop_hunk_counts: HashMap::new(),
-            original_byte_size: 500,
-            filtered_byte_size: 100,
-        };
-        let rendered = diff.render_for_prompt(10_000);
-        assert!(rendered.contains("src/auth.rs"), "file path must appear");
-        assert!(
-            rendered.contains("authenticate"),
-            "hunk content must appear"
-        );
-    }
-
-    #[test]
-    fn filtered_diff_render_respects_max_chars() {
-        // Create a large number of files — rendering should stop before max_chars.
-        let files: Vec<FilteredFile> = (0..100)
-            .map(|i| make_kept_file(&format!("src/file{i}.rs"), &"+fn foo() {}".repeat(50)))
-            .collect();
-        let diff = FilteredDiff {
-            files,
-            dropped_files: vec![],
-            drop_hunk_counts: HashMap::new(),
-            original_byte_size: 100_000,
-            filtered_byte_size: 50_000,
-        };
-        let rendered = diff.render_for_prompt(2_000);
-        assert!(
-            rendered.len() <= 2_000 + 200,
-            "rendered output must not greatly exceed max_chars: len={}",
-            rendered.len()
-        );
-    }
-
-    #[test]
-    fn filtered_diff_drop_summary_emitted() {
-        let mut drop_counts = HashMap::new();
-        drop_counts.insert(HunkDropReason::ImportOnly, 3u32);
-        drop_counts.insert(HunkDropReason::WhitespaceOnly, 1u32);
-
-        let diff = FilteredDiff {
-            files: vec![make_kept_file("src/main.rs", "+fn main() {}")],
-            dropped_files: vec![DroppedFile {
-                path: "Cargo.lock".to_string(),
-                reason: "lockfile".to_string(),
-            }],
-            drop_hunk_counts: drop_counts,
-            original_byte_size: 5_000,
-            filtered_byte_size: 200,
-        };
-
-        let rendered = diff.render_for_prompt(100_000);
-        assert!(
-            rendered.contains("DiffAnalyzer filtered"),
-            "noise summary must appear: {rendered}"
-        );
-        assert!(
-            rendered.contains("file(s) omitted"),
-            "file drop count must appear: {rendered}"
-        );
-        assert!(
-            rendered.contains("hunk(s) omitted"),
-            "hunk drop count must appear: {rendered}"
-        );
-    }
-
-    #[test]
-    fn no_summary_when_nothing_dropped() {
-        let diff = FilteredDiff {
-            files: vec![make_kept_file("src/lib.rs", "+pub fn new() {}")],
-            dropped_files: vec![],
-            drop_hunk_counts: HashMap::new(),
-            original_byte_size: 100,
-            filtered_byte_size: 100,
-        };
-        let summary = diff.build_noise_summary();
-        assert!(summary.is_empty(), "empty summary when nothing was dropped");
-    }
-}
+#[path = "models_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/diff_analyzer/models_tests.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/models_tests.rs
@@ -1,0 +1,278 @@
+//! Unit tests for `FilteredDiff`, `FilteredHunk`, `FilteredFile`, `HunkDropReason`.
+//!
+//! Why: split from `models.rs` to keep that file under the 500-line cap (CLAUDE.md).
+//! What: covers `render_for_prompt` (normal, budget-exceeded, mid-file overflow),
+//! `build_noise_summary`, `FilteredHunk::render`, and `HunkDropReason::label`.
+//! Test: see individual test functions.
+
+use std::collections::HashMap;
+
+use super::{
+    DroppedFile, FileDisposition, FilteredDiff, FilteredFile, FilteredHunk, HunkDropReason,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+pub(super) fn make_kept_file(name: &str, hunk_content: &str) -> FilteredFile {
+    FilteredFile {
+        filename: name.to_string(),
+        status: "modified".to_string(),
+        disposition: FileDisposition::Kept,
+        hunks: vec![FilteredHunk {
+            header: "@@ -1,3 +1,3 @@".to_string(),
+            lines: vec![hunk_content.to_string()],
+            substantive_confidence: 1.0,
+            reason_kept: "deterministic-pass".to_string(),
+        }],
+        dropped_hunks: vec![],
+        summary_line: None,
+    }
+}
+
+// ─── FilteredHunk ─────────────────────────────────────────────────────────────
+
+#[test]
+fn filtered_hunk_render_roundtrip() {
+    let h = FilteredHunk {
+        header: "@@ -1,2 +1,2 @@".to_string(),
+        lines: vec!["-old line".to_string(), "+new line".to_string()],
+        substantive_confidence: 1.0,
+        reason_kept: "test".to_string(),
+    };
+    let rendered = h.render();
+    assert!(rendered.contains("@@ -1,2 +1,2 @@"));
+    assert!(rendered.contains("-old line"));
+    assert!(rendered.contains("+new line"));
+}
+
+// ─── HunkDropReason ───────────────────────────────────────────────────────────
+
+#[test]
+fn hunk_drop_reason_label() {
+    assert_eq!(HunkDropReason::WhitespaceOnly.label(), "whitespace-only");
+    assert_eq!(HunkDropReason::ImportOnly.label(), "import-only");
+    assert_eq!(HunkDropReason::CommentOnly.label(), "comment-only");
+    assert_eq!(
+        HunkDropReason::MechanicalHaiku.label(),
+        "mechanical (Haiku)"
+    );
+}
+
+// ─── render_for_prompt — normal paths ─────────────────────────────────────────
+
+#[test]
+fn filtered_diff_render_for_prompt_contains_surviving_content() {
+    let diff = FilteredDiff {
+        files: vec![make_kept_file("src/auth.rs", "+pub fn authenticate() {}")],
+        dropped_files: vec![],
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: 500,
+        filtered_byte_size: 100,
+    };
+    let rendered = diff.render_for_prompt(10_000);
+    assert!(rendered.contains("src/auth.rs"), "file path must appear");
+    assert!(
+        rendered.contains("authenticate"),
+        "hunk content must appear"
+    );
+}
+
+#[test]
+fn filtered_diff_render_respects_max_chars() {
+    // Create a large number of files — rendering should stop before max_chars.
+    let files: Vec<FilteredFile> = (0..100)
+        .map(|i| make_kept_file(&format!("src/file{i}.rs"), &"+fn foo() {}".repeat(50)))
+        .collect();
+    let diff = FilteredDiff {
+        files,
+        dropped_files: vec![],
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: 100_000,
+        filtered_byte_size: 50_000,
+    };
+    let rendered = diff.render_for_prompt(2_000);
+    // Allow for the truncation marker overhead (~300 chars) on top of max_chars.
+    assert!(
+        rendered.len() <= 2_000 + 400,
+        "rendered output must not greatly exceed max_chars: len={}",
+        rendered.len()
+    );
+}
+
+// ─── build_noise_summary ──────────────────────────────────────────────────────
+
+#[test]
+fn filtered_diff_drop_summary_emitted() {
+    let mut drop_counts = HashMap::new();
+    drop_counts.insert(HunkDropReason::ImportOnly, 3u32);
+    drop_counts.insert(HunkDropReason::WhitespaceOnly, 1u32);
+
+    let diff = FilteredDiff {
+        files: vec![make_kept_file("src/main.rs", "+fn main() {}")],
+        dropped_files: vec![DroppedFile {
+            path: "Cargo.lock".to_string(),
+            reason: "lockfile".to_string(),
+        }],
+        drop_hunk_counts: drop_counts,
+        original_byte_size: 5_000,
+        filtered_byte_size: 200,
+    };
+
+    let rendered = diff.render_for_prompt(100_000);
+    assert!(
+        rendered.contains("DiffAnalyzer filtered"),
+        "noise summary must appear: {rendered}"
+    );
+    assert!(
+        rendered.contains("file(s) omitted"),
+        "file drop count must appear: {rendered}"
+    );
+    assert!(
+        rendered.contains("hunk(s) omitted"),
+        "hunk drop count must appear: {rendered}"
+    );
+}
+
+#[test]
+fn no_summary_when_nothing_dropped() {
+    let diff = FilteredDiff {
+        files: vec![make_kept_file("src/lib.rs", "+pub fn new() {}")],
+        dropped_files: vec![],
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: 100,
+        filtered_byte_size: 100,
+    };
+    let summary = diff.build_noise_summary();
+    assert!(summary.is_empty(), "empty summary when nothing was dropped");
+}
+
+// ─── render_for_prompt — truncation / budget-exceeded paths ───────────────────
+
+/// Regression: the inner hunk-loop `break` previously exited only the hunk
+/// loop, allowing subsequent files to be appended after a half-rendered file
+/// with no truncation marker.  This test verifies the fix: once the budget
+/// is exhausted mid-file, no further files are rendered and a loud
+/// `[RENDER TRUNCATED …]` marker is appended.
+///
+/// Why: silent mid-file truncation caused the reviewer LLM to see an
+/// incomplete first file followed by complete later files, with no indication
+/// that hunks were dropped.  The fix breaks the outer loop and announces the
+/// truncation loudly (closes #622 / #624).
+/// What: builds two files where the first file's second hunk overflows the
+/// budget.  Asserts the second file does NOT appear and the truncation marker
+/// DOES appear.
+/// Test: this test itself.
+#[test]
+fn render_for_prompt_mid_file_hunk_overflow_loud_not_silent() {
+    // File 1 has two hunks; the second one is large enough to overflow.
+    // File 2 must NOT appear in the output.
+    let large_hunk_content = "+".to_string() + &"x".repeat(900);
+    let file1 = FilteredFile {
+        filename: "src/first.rs".to_string(),
+        status: "modified".to_string(),
+        disposition: FileDisposition::Kept,
+        hunks: vec![
+            FilteredHunk {
+                header: "@@ -1,1 +1,1 @@".to_string(),
+                lines: vec!["+fn first() {}".to_string()],
+                substantive_confidence: 1.0,
+                reason_kept: "test".to_string(),
+            },
+            FilteredHunk {
+                header: "@@ -10,1 +10,1 @@".to_string(),
+                lines: vec![large_hunk_content],
+                substantive_confidence: 1.0,
+                reason_kept: "test".to_string(),
+            },
+        ],
+        dropped_hunks: vec![],
+        summary_line: None,
+    };
+    let file2 = make_kept_file("src/second.rs", "+fn second() {}");
+
+    let diff = FilteredDiff {
+        files: vec![file1, file2],
+        dropped_files: vec![],
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: 2_000,
+        filtered_byte_size: 1_000,
+    };
+
+    // Budget: large enough for file1 header + first hunk, but NOT the second hunk.
+    let rendered = diff.render_for_prompt(200);
+
+    // The truncation marker must appear.
+    assert!(
+        rendered.contains("RENDER TRUNCATED"),
+        "truncation marker must appear when budget is hit: {rendered}"
+    );
+    // The second file must NOT appear — the outer loop must have been broken.
+    assert!(
+        !rendered.contains("src/second.rs"),
+        "second file must not appear after mid-file budget overflow: {rendered}"
+    );
+    // The rendered output must not greatly exceed the budget.
+    assert!(
+        rendered.len() <= 200 + 400, // budget + marker + suffix overhead
+        "output must not greatly exceed max_chars: len={}",
+        rendered.len()
+    );
+}
+
+/// Verify that a diff that fits entirely within the budget has NO truncation
+/// marker appended (no false-positive warnings).
+///
+/// Why: the truncation marker is a loud signal; it must not appear when all
+/// content was rendered successfully.
+/// What: renders a small diff well within a generous budget; asserts the
+/// truncation marker is absent.
+/// Test: this test itself.
+#[test]
+fn render_for_prompt_no_truncation_marker_when_fits() {
+    let diff = FilteredDiff {
+        files: vec![make_kept_file("src/lib.rs", "+pub fn new() {}")],
+        dropped_files: vec![],
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: 100,
+        filtered_byte_size: 100,
+    };
+    let rendered = diff.render_for_prompt(100_000);
+    assert!(
+        !rendered.contains("RENDER TRUNCATED"),
+        "no truncation marker when content fits: {rendered}"
+    );
+}
+
+/// Verify that `render_for_prompt` respects the max_chars bound even after the
+/// fix (the truncation marker + suffix must not push output far over the cap).
+///
+/// Why: the marker and suffix are added AFTER the main content loop; they must
+/// not cause a large overflow.
+/// What: builds a large diff exceeding the budget, calls render_for_prompt with
+/// a tight cap, and asserts the result stays within a reasonable overhead band.
+/// Test: this test itself.
+#[test]
+fn render_for_prompt_marker_does_not_cause_large_overflow() {
+    let files: Vec<FilteredFile> = (0..50)
+        .map(|i| make_kept_file(&format!("src/file{i}.rs"), &"+fn foo() {}".repeat(20)))
+        .collect();
+    let diff = FilteredDiff {
+        files,
+        dropped_files: vec![],
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: 50_000,
+        filtered_byte_size: 25_000,
+    };
+    let max_chars: usize = 500;
+    let rendered = diff.render_for_prompt(max_chars);
+    // Allow for the truncation marker (~200 chars) on top of max_chars.
+    assert!(
+        rendered.len() <= max_chars + 400,
+        "rendered len {} must not greatly exceed max_chars {max_chars}",
+        rendered.len()
+    );
+    assert!(
+        rendered.contains("RENDER TRUNCATED"),
+        "truncation marker must appear: {rendered}"
+    );
+}


### PR DESCRIPTION
## Investigation Findings

### What was investigated

The concern was that `trusty-review` might silently truncate PR diffs before sending them to the reviewer LLM, causing it to miss findings in the dropped portion.

### What was found

**Two truncation mechanisms exist:**

1. **`truncate_diff` in `pipeline/diff.rs`** — the outer safety net. Caps at `MAX_DIFF_CHARS = 160_000` chars (raised from 60k in #624). When it fires, it appends a loud `[DIFF TRUNCATED — N chars omitted; review may be incomplete]` marker and logs at `warn!` level. Already correct and loud.

2. **`FilteredDiff::render_for_prompt` in `pipeline/diff_analyzer/models.rs`** — applies the same 160k cap via the DiffAnalyzer noise-filter path. **This had a silent truncation bug** (the subject of this PR).

### The Silent Truncation Bug

`render_for_prompt` iterated files in an outer loop. Inside the `FileDisposition::Kept` arm, an inner loop iterated hunks. When a hunk exceeded the char budget, the inner `break` only exited the **hunk loop**, not the outer **file loop**.

**Effect:** after partially rendering File A (header written, hunks 1–N emitted, hunk N+1 overflowed), the outer loop continued to File B, File C, etc. — which were then rendered in full with no marker indicating that File A was incomplete.

The reviewer LLM received:
```
--- a/src/first.rs         ← File A header (appeared)
@@ ...                     ← hunk 1 (appeared)
                            ← hunk 2+ (SILENTLY DROPPED — inner break)
--- a/src/second.rs        ← File B (appeared in full — wrong!)
...
```

No truncation marker was appended at the point of the inner break, so the LLM had no signal that File A was incomplete.

### Related tickets

- **#622** (open) — `[trusty-review] Diff truncation causes false REQUEST_CHANGES verdicts` — the production impact report. This PR closes the `render_for_prompt` silent-truncation vector described there.
- **#624** (closed) — the earlier fix that raised `MAX_DIFF_CHARS` from 60k→160k and added the DiffAnalyzer noise filter. Fixed `truncate_diff` loudness; did NOT fix the `render_for_prompt` inner-break bug.
- **#626** (verifier 16-token truncation) — a DIFFERENT issue (verifier token cap), already fixed separately.

### The Fix

- Changed the inner loop `break` to `break 'files` (Rust labeled break) so the outer file loop is also exited when the budget is hit.
- Tracked `budget_exceeded: bool`; when set, append a loud `[RENDER TRUNCATED — char budget (N) reached; ~M file(s) omitted; review covers only the visible portion above]` marker before the noise summary.
- Added `TRUNC_MARKER_RESERVE = 120` chars to the budget calculation so the marker itself never causes a large overshoot of `max_chars`.
- Split tests to a sibling `models_tests.rs` (models.rs was 613 lines after new tests; now 360+278, both under the 500-line cap per CLAUDE.md).

## Verification

```
cargo clippy -p trusty-review --all-targets -- -D warnings  → 0 warnings
cargo test -p trusty-review                                  → 755 passed (up from 752)
cargo fmt --check -p trusty-review                           → clean
bash scripts/check_line_cap.sh                               → 172 allowlisted, 0 violations
```

New tests:
- `render_for_prompt_mid_file_hunk_overflow_loud_not_silent` — regression guard for the inner-break bug
- `render_for_prompt_no_truncation_marker_when_fits` — no false-positive marker when content fits
- `render_for_prompt_marker_does_not_cause_large_overflow` — marker + suffix overhead stays bounded

## Files Changed

- `crates/trusty-review/src/pipeline/diff_analyzer/models.rs` — fix `render_for_prompt`, split tests out
- `crates/trusty-review/src/pipeline/diff_analyzer/models_tests.rs` — new sibling test file (all models tests)

## LOC Delta

- Added: 343 lines
- Removed: 137 lines
- Net: +206 lines (mostly new tests and the split; production logic change is ~40 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)