### PR TITLE
fix(trusty-review): retune duetto voice — simplification in-scope, per-issue enumeration

### DIFF
--- a/crates/trusty-review/voices/duetto/voice.toml
+++ b/crates/trusty-review/voices/duetto/voice.toml
@@ -40,9 +40,9 @@ Back every substantive claim with evidence: the spec, the convention, CI output,
 
 State severity explicitly. BLOCK only on real correctness bugs, security regressions, data-corruption risk, missing required companion changes (migrations, version bumps, removed-symbol cleanup), or a broken build or tests — and when you block, give a concrete checklist. ADVISE firmly on design, reuse, naming, and coverage as negotiable. DEMOTE pure style to take-it-or-leave-it nits, labeled as such.
 
-Stay scope-disciplined: separate in-scope fixes from out-of-scope cleanups, deferring the latter to a tracked follow-up; do not gold-plate; acknowledge deliberate interim debt.
+Stay scope-disciplined: separate in-scope fixes from out-of-scope cleanups, deferring the latter to a tracked follow-up; acknowledge deliberate interim debt. Always flag the idiomatic or smaller form when a net-new or duplicated implementation is reviewable — simplification suggestions are in-scope correctness feedback, not gold-plating.
 
-Keep a low-ego, collaborative voice: use "we", frame uncertain points as questions, concede quickly when the author is right, name your own confidence boundaries, and give specific credit. But never soften a real correctness defect into a vague question — state bugs plainly with the reason. Lead with the ask; keep comments short and single-issue.
+Keep a low-ego, collaborative voice: use "we", frame uncertain points as questions, concede quickly when the author is right, name your own confidence boundaries, and give specific credit. But never soften a real correctness defect into a vague question — state bugs plainly with the reason. Lead with the ask. Write one finding per distinct issue — do not bundle multiple separate concerns into a single comment even when they are in the same file. Short and specific per finding. When the same simplification or fix pattern appears in multiple methods or sites, flag each site separately rather than consolidating — each is a distinct review point.
 """
 
 [knobs]


### PR DESCRIPTION
## Summary

Retune of the duetto voice package for Sonnet 4.6 based on diagnosis in `eval-results/voice-retune-diagnosis-2026-06-04.md`.

### Edits applied to `crates/trusty-review/voices/duetto/voice.toml`

**H1 (scope-discipline paragraph):** Removed "do not gold-plate"; added explicit statement that simplification suggestions are in-scope correctness feedback.

**H2 (per-issue enumeration):** Replaced "keep comments short and single-issue" with instruction to write one finding per distinct issue.

**H3 (per-site enumeration):** Added sentence requiring each occurrence of a pattern to be flagged separately.

**Preserved verbatim:** correctness-first paragraph, integration-boundary paragraph, Ian Farmer design-for-failure line, Shiv fixture-integrity line.

---

## Calibration Results (NEGATIVE — DO NOT MERGE WITHOUT PM REVIEW)

| Metric | Prior voice | Retuned voice | Baseline |
|--------|-------------|---------------|----------|
| Finding-level recall | 29.7% | **26.7%** | 35.6% |
| Cluster-based recall | 37.4% | not scored | 42.4% |

**The retuned voice did NOT reach baseline parity.** Retuned scored 26.7% finding-level vs prior voice 29.7% and baseline 35.6% — a regression of -2.9pp from prior voice.

### Win verification
- **PR #6485 (Bill NPE):** NOT preserved. The `row.get` NPE finding was not reproduced.
- **PR #6538 verdict:** REGRESSED from REQUEST_CHANGES to APPROVE.

### Key per-PR regressions vs prior voice
- PR #6598: 70.4% → 59.3% (-11.1pp) — the primary target got worse
- PR #6485: 75.0% → 25.0% (-50pp) — the key win regressed

### Hypotheses for regression
1. Non-determinism: single eval pass insufficient; results vary across LLM calls
2. H2/H3 enumeration instructions may be conflicting with principles-layer signal-to-noise suppression
3. Prior wins may have been lucky samples, not reliable effects of the voice addendum

---

## Quality Gate Results

- `cargo check`: PASS
- `cargo clippy -p trusty-review --all-targets -- -D warnings`: PASS (0 warnings)
- `cargo test -p trusty-review`: PASS (755 + 12 tests, 0 failures)
- `cargo fmt --check`: PASS
- `bash scripts/check_line_cap.sh`: PASS (172 allowlisted, 0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)