### PR TITLE
chore(trusty-mpm): purge stale Python-era path references from embedded instruction assets

### DIFF
--- a/crates/trusty-mpm/src/assets/instructions/AGENT_DELEGATION.md
+++ b/crates/trusty-mpm/src/assets/instructions/AGENT_DELEGATION.md
@@ -2,8 +2,8 @@
 
 > This file defines the agent routing table and delegation logic for the PM.
 > Override at project level: .trusty-mpm/AGENT_DELEGATION.md
-> Override at user level:    ~/.claude-mpm/AGENT_DELEGATION.md
-> System default:            src/claude_mpm/agents/AGENT_DELEGATION.md (this file)
+> Override at user level:    ~/.trusty-mpm/AGENT_DELEGATION.md
+> System default:            crates/trusty-mpm/src/assets/instructions/AGENT_DELEGATION.md (this file)
 
 ## When to Delegate to Each Agent
 
@@ -13,7 +13,7 @@
 | **Engineer** | Writing/modifying code, implementing features, refactoring | Edit, Write, codebase knowledge, testing workflows | - |
 | **Ops** (Local Ops) | Deploying apps, managing infrastructure, starting servers, port/process management | Environment config, deployment procedures | Use `Local Ops` for localhost/PM2/docker |
 | **QA** (Web QA, API QA) | Testing implementations, verifying deployments, regression tests, browser testing | Playwright (web), fetch (APIs), verification protocols | For browser: use **Web QA** (never use chrome-devtools, claude-in-chrome, or playwright directly) |
-| **Code Critic** | Adversarial code review with rubric-based verdict (APPROVE/WARN/BLOCK). Universal qa-tier agent — code review, design critique, adversarial verdict on any engineer dispatch | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | claude-mpm-agents (universal) |
+| **Code Critic** | Adversarial code review with rubric-based verdict (APPROVE/WARN/BLOCK). Universal qa-tier agent — code review, design critique, adversarial verdict on any engineer dispatch | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | trusty-mpm (universal) |
 | **Documentation Agent** | Creating/updating docs, README, API docs, guides | Style consistency, organization standards | - |
 | **Version Control** | Creating PRs, managing branches, complex git ops | PR workflows, branch management | Check git user for main branch access |
 | **mpm_skills_manager** | Creating/improving skills, recommending skills, stack detection | manifest.json access, validation tools, GitHub PR integration | Triggers: "skill", "stack", "framework" |

--- a/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
+++ b/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
@@ -78,14 +78,13 @@ Generic `ops` agent DEPRECATED. Use platform-specific agents. Default fallback =
 
 Tier models: general = `claude-sonnet-4-6`, coding = `claude-opus-4-6`, planning = `claude-opus-4-7`.
 
-**Per-agent model overrides**: Set in `~/.trusty-mpm/config.yaml` under `models.agents.<agent-name>`. Values: `haiku`, `sonnet`, `opus`, or full model name. Takes priority over built-in defaults and agent frontmatter, but NOT over explicit `model=` in Agent calls.
+**Per-agent model overrides**: Set in `~/.trusty-mpm/config.toml` under `models.agents.<agent-name>`. Values: `haiku`, `sonnet`, `opus`, or full model name. Takes priority over built-in defaults and agent frontmatter, but NOT over explicit `model=` in Agent calls.
 
 Example:
-```yaml
-models:
-  agents:
-    engineer: opus
-    research: sonnet
+```toml
+[models.agents]
+engineer = "opus"
+research = "sonnet"
 ```
 
 3. Sonnet = 5x cheaper than Opus. Haiku = 75x cheaper. Coding tasks use opus for quality; expect 40-60% savings vs. naively using opus everywhere.
@@ -253,7 +252,7 @@ Ticket references → delegate to Version Control agent. No direct ticket tool a
 |---------|-------|------|
 | No ticket | Local file | `{docs_path}/{topic}-{date}.md` |
 
-Default `docs_path`: `docs/research/`. Configurable via `.claude-mpm/config.yaml` key `documentation.docs_path`.
+Default `docs_path`: `docs/research/`. Configurable via `.trusty-mpm/config.toml` key `documentation.docs_path`.
 
 ## Worktree Isolation
 
@@ -270,7 +269,7 @@ PM skills loaded from `.claude/skills/` when relevant context detected:
 ## Agent Deployment
 
 Cache: `~/.trusty-mpm/framework/agents/`.
-Priority: project `.claude/agents/` > user `~/.claude-mpm/agents/` > cached remote.
+Priority: project `.claude/agents/` > user `~/.trusty-mpm/agents/` > cached remote.
 All agents inherit BASE_AGENT.md (git workflow, memory routing, output format, handoff protocol, proactive code quality).
 
 ## Auto-Configuration


### PR DESCRIPTION
## Summary

Fixes stale Python-era path references in the `trusty-mpm` embedded instruction assets (`AGENT_DELEGATION.md`, `PM_INSTRUCTIONS.md`). These assets are delivered verbatim to Claude in live sessions, so wrong paths actively mislead the model.

- Replace `~/.claude-mpm/AGENT_DELEGATION.md` → `~/.trusty-mpm/AGENT_DELEGATION.md` (user-level override path)
- Replace `src/claude_mpm/agents/AGENT_DELEGATION.md` Python source path → `crates/trusty-mpm/src/assets/instructions/AGENT_DELEGATION.md` (Rust asset path)
- Replace `claude-mpm-agents` package label → `trusty-mpm` in the Code Critic routing table
- Replace `~/.trusty-mpm/config.yaml` → `~/.trusty-mpm/config.toml` for per-agent model override reference
- Replace `.claude-mpm/config.yaml` → `.trusty-mpm/config.toml` for `docs_path` config key
- Replace `~/.claude-mpm/agents/` → `~/.trusty-mpm/agents/` in the agent precedence chain
- Update YAML code block to TOML syntax to match the `config.toml` format

Preserved intentionally (still correct):
- `~/.trusty-mpm/framework/agents/` cache path (already correct)
- `~/.trusty-mpm/` prefix on line 272 (already correct)

## Test plan

- [x] `grep -rn "claude-mpm\|config\.yaml\|claude_mpm\|pm-override-system" crates/trusty-mpm/src/assets/` → zero hits after edit
- [x] `cargo check -p trusty-mpm` → clean
- [x] `cargo build -p trusty-mpm` → clean
- [x] `cargo test -p trusty-mpm` → 1020 tests, 0 failures
- [x] `cargo clippy -p trusty-mpm -- -D warnings` → zero warnings
- [x] `cargo fmt --check` → exit 0
- [x] `bash scripts/check_line_cap.sh` → 0 violations
- [x] Pre-commit hooks → all passed

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)