### PR TITLE
feat(tcode): tools layer, agents/identity/logging, tcode run-task (closes #641, #642, #645)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10776,12 +10776,14 @@ name = "trusty-code"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -3,10 +3,13 @@ name = "trusty-code"
 version = "0.0.0"
 edition = "2024"
 rust-version.workspace = true
+# license.workspace resolves to "Elastic-2.0" SPDX; publish=false so crates.io
+# validation is never triggered. When/if publish is enabled, switch to
+# license-file = "LICENSE" per CLAUDE.md note.
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Per-project Claude-Code-compatible MPM orchestration harness (bin: tcode). Phase 1 leaf/protocol modules extracted from open-mpm (#640). Full extraction tracked in #587."
+description = "Per-project Claude-Code-compatible MPM orchestration harness (bin: tcode). Phase 1-3/6 modules extracted from open-mpm. Full extraction tracked in #587."
 publish = false
 
 [[bin]]
@@ -23,7 +26,7 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
-# Serialization (events, ipc, perf, build_info)
+# Serialization (events, ipc, perf, build_info, tools, agents)
 serde = { workspace = true }
 serde_json = { workspace = true }
 
@@ -37,8 +40,14 @@ uuid = { workspace = true }
 clap = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+# Phase 2: async trait dispatch for ToolExecutor, AgentRunner, SearchProvider
+async-trait = { workspace = true }
+
+# Phase 3: TOML config parsing for AgentConfig
+toml = { workspace = true }
+
 [dev-dependencies]
-# Async test runtime (events, build_info, perf async tests)
+# Async test runtime (events, build_info, perf async tests, tools tests)
 tokio = { workspace = true }
-# Temp directories for build_info tests
+# Temp directories for build_info, delegate, and agents tests
 tempfile = { workspace = true }

--- a/crates/trusty-code/src/agents/config.rs
+++ b/crates/trusty-code/src/agents/config.rs
@@ -1,0 +1,249 @@
+//! Agent configuration schema for tcode.
+//!
+//! Why: Sub-agents (and the PM itself) are defined declaratively in TOML so
+//! model, prompt, and LLM parameters can evolve without code changes.
+//! What: `AgentConfig` and all nested config types, deserializable from the
+//! `.claude/agents/<name>.toml` format compatible with Claude Code sub-agents.
+//! Test: `AgentConfig::from_toml_str` on inline TOML succeeds and round-trips.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level agent configuration loaded from `<name>.toml`.
+///
+/// Why: Declarative agent configs let operators define or override agents
+/// without touching Rust code.
+/// What: `agent` carries identity/role; `llm` carries model/token params;
+/// `system_prompt` carries the prompt text; optional sections add capabilities.
+/// Test: `agent_config_roundtrip`, `agent_config_minimal`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentConfig {
+    /// Core identity fields.
+    pub agent: AgentInfo,
+    /// LLM parameters for this agent.
+    #[serde(default)]
+    pub llm: LlmParams,
+    /// System prompt content.
+    #[serde(default)]
+    pub system_prompt: SystemPrompt,
+    /// Optional tool permissions.
+    #[serde(default)]
+    pub tools: Option<ToolsConfig>,
+    /// Optional runner override.
+    #[serde(default)]
+    pub runner: Option<RunnerConfig>,
+}
+
+impl AgentConfig {
+    /// Parse an `AgentConfig` from a TOML string.
+    ///
+    /// Why: Useful in tests and for in-process loading of bundled config.
+    /// What: Delegates to `toml::from_str`.
+    /// Test: `agent_config_roundtrip`.
+    pub fn from_toml_str(s: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(s)
+    }
+
+    /// Load an `AgentConfig` from a TOML file on disk.
+    ///
+    /// Why: Primary entry point for the agent loader during harness startup.
+    /// What: Reads the file, then calls `from_toml_str`.
+    /// Test: Integration tests place a TOML file in a tempdir and call this.
+    pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
+        let src = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("failed to read agent config {}: {e}", path.display()))?;
+        toml::from_str(&src)
+            .map_err(|e| anyhow::anyhow!("invalid agent config {}: {e}", path.display()))
+    }
+}
+
+/// Core identity fields for an agent.
+///
+/// Why: Every agent needs a stable `name` (the dispatch key) and `model`.
+/// What: `name`, optional `role`, optional `model`.
+/// Test: `agent_config_minimal` asserts that `name` is loaded.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentInfo {
+    /// The agent's dispatch key (e.g. `"engineer"`, `"python-engineer"`).
+    pub name: String,
+    /// Optional free-form role description.
+    #[serde(default)]
+    pub role: Option<String>,
+    /// LLM model override (e.g. `"anthropic/claude-sonnet-4-6"`,
+    /// `"bedrock/us.anthropic.claude-sonnet-4-6"`).
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Human-readable description of what this agent does.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// LLM parameters for a single agent.
+///
+/// Why: Each agent may need different temperature, token budget, or provider.
+/// What: Standard LLM knobs, all optional with sensible defaults.
+/// Test: `agent_config_llm_params`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LlmParams {
+    /// Sampling temperature (0.0–1.0).
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    /// Maximum tokens in the LLM response.
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    /// Route directly to Anthropic API instead of OpenRouter.
+    #[serde(default)]
+    pub use_anthropic_direct: bool,
+    /// Model override at the `[llm]` level (lower precedence than `[agent].model`).
+    #[serde(default)]
+    pub model_override: Option<String>,
+}
+
+/// System prompt for an agent.
+///
+/// Why: Keeping the prompt in config (not source code) lets operators tune
+/// agent behavior without a Rust recompile.
+/// What: `content` is the raw prompt text; `append_skills` is a list of skill
+/// names to inject at startup.
+/// Test: `agent_config_system_prompt`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SystemPrompt {
+    /// Raw prompt text.
+    #[serde(default)]
+    pub content: String,
+    /// Skill names to inject into the prompt.
+    #[serde(default)]
+    pub append_skills: Vec<String>,
+}
+
+/// Per-agent tool permissions.
+///
+/// Why: Restricts which tools an agent may call, preventing e.g. the
+/// plan-agent from shelling out.
+/// What: `allowed` is an explicit allowlist; `None` means "all registered tools".
+/// Test: `ToolRegistry::dispatch_gated` tests exercise the allowlist.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ToolsConfig {
+    /// Explicit allowlist of tool names. `None` = all tools permitted.
+    #[serde(default)]
+    pub allowed: Option<Vec<String>>,
+}
+
+/// Runner backend selection for an agent.
+///
+/// Why: Different agents may use different execution backends (subprocess,
+/// in-process, Claude Code CLI).
+/// What: `kind` selects the backend; defaults to `SubProcess`.
+/// Test: `agent_config_runner_kind`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RunnerConfig {
+    /// Which backend to use for this agent.
+    #[serde(default)]
+    pub kind: RunnerKind,
+}
+
+/// Execution backend for agent invocations.
+///
+/// Why: Abstracts over the concrete runner selected at startup so config can
+/// swap backends without code changes.
+/// What: `SubProcess` is the default (spawns a new process via NDJSON IPC);
+/// `ClaudeCode` wraps the `claude` CLI binary.
+/// Test: `runner_kind_deserializes`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerKind {
+    /// Spawn a subprocess; communicate via NDJSON over stdin/stdout.
+    #[default]
+    SubProcess,
+    /// Use the `claude` CLI binary as the runner.
+    ClaudeCode,
+    /// In-process mock runner (tests only).
+    InProcess,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL_TOML: &str = r#"
+[agent]
+name = "engineer"
+"#;
+
+    const FULL_TOML: &str = r#"
+[agent]
+name = "python-engineer"
+role = "engineer"
+model = "anthropic/claude-sonnet-4-6"
+description = "Python software engineer"
+
+[llm]
+temperature = 0.2
+max_tokens = 8192
+
+[system_prompt]
+content = "You are a Python expert."
+
+[tools]
+allowed = ["delegate_to_agent", "search_code"]
+
+[runner]
+kind = "claude_code"
+"#;
+
+    /// Minimal config with only `[agent].name` parses successfully.
+    ///
+    /// Why: Operators should be able to define a minimal agent without
+    /// specifying every optional field.
+    /// What: `from_toml_str(MINIMAL_TOML)` returns `Ok` with `name == "engineer"`.
+    /// Test: This test.
+    #[test]
+    fn agent_config_minimal() {
+        let cfg = AgentConfig::from_toml_str(MINIMAL_TOML).expect("parse minimal");
+        assert_eq!(cfg.agent.name, "engineer");
+        assert!(cfg.agent.model.is_none());
+        assert!(cfg.tools.is_none());
+    }
+
+    /// Full config round-trips through TOML parsing.
+    ///
+    /// Why: Verify all fields are decoded correctly.
+    /// What: `from_toml_str(FULL_TOML)` round-trips all fields.
+    /// Test: This test.
+    #[test]
+    fn agent_config_roundtrip() {
+        let cfg = AgentConfig::from_toml_str(FULL_TOML).expect("parse full");
+        assert_eq!(cfg.agent.name, "python-engineer");
+        assert_eq!(
+            cfg.agent.model.as_deref(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(cfg.llm.temperature, Some(0.2));
+        assert_eq!(cfg.llm.max_tokens, Some(8192));
+        assert_eq!(cfg.system_prompt.content, "You are a Python expert.");
+        let allowed = cfg.tools.as_ref().and_then(|t| t.allowed.as_ref());
+        let expected: Vec<String> =
+            vec!["delegate_to_agent".to_string(), "search_code".to_string()];
+        assert_eq!(allowed.map(|v| v.as_slice()), Some(expected.as_slice()));
+        assert_eq!(
+            cfg.runner.as_ref().map(|r| &r.kind),
+            Some(&RunnerKind::ClaudeCode)
+        );
+    }
+
+    /// `RunnerKind` deserializes from `snake_case` strings via a TOML wrapper table.
+    ///
+    /// Why: Verify the serde rename_all contract.
+    /// What: Parse a `[runner]` table with `kind = "claude_code"` → `RunnerKind::ClaudeCode`.
+    /// Test: This test.
+    #[test]
+    fn runner_kind_deserializes() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            kind: RunnerKind,
+        }
+        let w: Wrapper = toml::from_str("kind = \"claude_code\"").expect("parse runner kind");
+        assert_eq!(w.kind, RunnerKind::ClaudeCode);
+    }
+}

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -1,0 +1,129 @@
+//! Agent configuration loading and types for tcode.
+//!
+//! Why: Sub-agents (and the PM itself) are defined declaratively in TOML files
+//! under `.claude/agents/` so model, prompt, and LLM parameters can evolve
+//! without code changes. This module is the assembly point for config types
+//! and the discovery helpers.
+//! What: Re-exports `AgentConfig` and all nested config types from `config`;
+//! provides `discover_agents` for scanning an agents directory.
+//! Test: `discover_agents` tests place TOML files in a tempdir and verify the
+//! returned list. `AgentConfig::load` tests read individual files.
+
+pub mod config;
+
+pub use config::{
+    AgentConfig, AgentInfo, LlmParams, RunnerConfig, RunnerKind, SystemPrompt, ToolsConfig,
+};
+
+use std::path::Path;
+
+/// Discover all agent configs in the given directory.
+///
+/// Why: tcode needs to know which agents are available before the PM loop
+/// starts so it can validate `delegate_to_agent` calls pre-flight.
+/// What: Scans `dir/*.toml` and returns `(name, path)` pairs sorted by name.
+/// Files that fail to parse are skipped with a tracing warning.
+/// Test: `discover_agents_finds_tomls`, `discover_agents_skips_non_toml`.
+pub fn discover_agents(dir: &Path) -> Vec<(String, std::path::PathBuf)> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        tracing::debug!("agents dir not found or unreadable: {}", dir.display());
+        return vec![];
+    };
+    let mut agents: Vec<(String, std::path::PathBuf)> = entries
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().and_then(|x| x.to_str()) == Some("toml") {
+                let name = p.file_stem()?.to_str()?.to_string();
+                Some((name, p))
+            } else {
+                None
+            }
+        })
+        .collect();
+    agents.sort_by(|a, b| a.0.cmp(&b.0));
+    agents
+}
+
+/// Load all agent configs from the given directory, skipping parse errors.
+///
+/// Why: Startup needs a map of all available agents; individual parse errors
+/// should not crash the whole harness.
+/// What: Calls `discover_agents`, then `AgentConfig::load` on each; returns
+/// successfully parsed configs only. Failures are logged at WARN level.
+/// Test: `load_all_agents_skips_invalid`.
+pub fn load_all_agents(dir: &Path) -> Vec<AgentConfig> {
+    discover_agents(dir)
+        .into_iter()
+        .filter_map(|(name, path)| match AgentConfig::load(&path) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => {
+                tracing::warn!("skipping agent '{name}': {e}");
+                None
+            }
+        })
+        .collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `discover_agents` finds TOML files and returns sorted (name, path) pairs.
+    ///
+    /// Why: Verify the scanning and sorting logic.
+    /// What: Place two TOML + one non-TOML in a tempdir; assert two results in order.
+    /// Test: This test.
+    #[test]
+    fn discover_agents_finds_tomls() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("qa-agent.toml"),
+            "[agent]\nname=\"qa-agent\"\n",
+        )
+        .expect("write");
+        std::fs::write(
+            tmp.path().join("engineer.toml"),
+            "[agent]\nname=\"engineer\"\n",
+        )
+        .expect("write");
+        std::fs::write(tmp.path().join("README.md"), "docs").expect("write");
+
+        let agents = discover_agents(tmp.path());
+        let names: Vec<&str> = agents.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["engineer", "qa-agent"], "sorted by name");
+    }
+
+    /// `discover_agents` returns empty when the directory does not exist.
+    ///
+    /// Why: Guard against panic on a missing `.claude/agents` dir.
+    /// What: Pass a non-existent path; expect empty Vec.
+    /// Test: This test.
+    #[test]
+    fn discover_agents_missing_dir_is_empty() {
+        let agents = discover_agents(std::path::Path::new("/nonexistent/path/agents"));
+        assert!(agents.is_empty());
+    }
+
+    /// `load_all_agents` skips files with invalid TOML.
+    ///
+    /// Why: A single bad config should not crash the harness.
+    /// What: Place one valid + one invalid TOML; `load_all_agents` returns 1 entry.
+    /// Test: This test.
+    #[test]
+    fn load_all_agents_skips_invalid() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("engineer.toml"),
+            "[agent]\nname=\"engineer\"\n",
+        )
+        .expect("write");
+        std::fs::write(tmp.path().join("broken.toml"), "<<NOT TOML>>").expect("write");
+
+        let agents = load_all_agents(tmp.path());
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].agent.name, "engineer");
+    }
+}

--- a/crates/trusty-code/src/identity/mod.rs
+++ b/crates/trusty-code/src/identity/mod.rs
@@ -1,0 +1,250 @@
+//! Caller identity hierarchy for memory scoping in tcode.
+//!
+//! Why: Memory must be scoped according to who is calling — the operator
+//! (full access), the PM (bounded to a session), or a sub-agent (bounded to its
+//! own writes). Agents must not be able to self-elevate; the harness determines
+//! `CallerIdentity` at spawn time and enforces a recall ceiling so agent code
+//! can never bypass it.
+//! What: `CallerIdentity` is a sum type with three variants — `Ctrl`, `Pm`,
+//! `Agent` — each carrying the IDs needed to apply the right scope filter.
+//! `RecallCeiling` is the maximum scope a caller may recall.
+//! Test: See unit tests — agent identity caps recall at Agent; `auto_tags`
+//! returns the expected tag set for each variant.
+
+use serde::{Deserialize, Serialize};
+
+/// Env var name for spawn-time identity injection.
+///
+/// Why: Subprocesses cannot share Rust types with their parent; env vars ferry
+/// identity over the process boundary.
+/// What: `TCODE_CALLER` selects the variant (`ctrl`, `pm`, `agent`).
+/// Test: `caller_identity_from_env_*`.
+pub const ENV_CALLER: &str = "TCODE_CALLER";
+/// Session ID env var.
+pub const ENV_SESSION_ID: &str = "TCODE_SESSION_ID";
+/// Project ID env var.
+pub const ENV_PROJECT_ID: &str = "TCODE_PROJECT_ID";
+/// Agent ID env var.
+pub const ENV_AGENT_ID: &str = "TCODE_AGENT_ID";
+
+/// Which component is making a memory/context call.
+///
+/// Why: Each tier has different access rights to the memory store. Encoding
+/// the tier as a sum type makes the privilege boundary visible in every
+/// signature that needs to enforce it.
+/// What: `Ctrl` is the operator (unrestricted); `Pm` runs one session in a
+/// project; `Agent` is a single sub-agent inside that session.
+/// Test: `auto_tags_for_each_variant`, `max_recall_scope_for_each_variant`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase", tag = "kind")]
+pub enum CallerIdentity {
+    /// Operator / controller — unrestricted.
+    Ctrl,
+    /// PM — bounded to a single session within a project.
+    Pm {
+        session_id: String,
+        project_id: String,
+    },
+    /// Sub-agent — bounded to its own writes within a session.
+    Agent {
+        session_id: String,
+        project_id: String,
+        agent_id: String,
+    },
+}
+
+impl CallerIdentity {
+    /// Maximum scope this caller is allowed to recall.
+    ///
+    /// Why: Enforced by the harness — not by agent code. An agent that passes
+    /// `scope: "all"` is silently downgraded to `Agent`.
+    /// What: `Ctrl` → `All`, `Pm` → `Session`, `Agent` → `Agent`.
+    /// Test: `max_recall_scope_for_each_variant`.
+    pub fn max_recall_scope(&self) -> RecallCeiling {
+        match self {
+            Self::Ctrl => RecallCeiling::All,
+            Self::Pm { .. } => RecallCeiling::Session,
+            Self::Agent { .. } => RecallCeiling::Agent,
+        }
+    }
+
+    /// Tags to automatically apply when this caller stores a memory.
+    ///
+    /// Why: Auto-tagging at write time means future scope filters can match on
+    /// tags without trusting agent-supplied metadata.
+    /// What: `Ctrl` → `["scope/user"]`; `Pm` → session+project tags; `Agent`
+    /// → session+project+agent tags.
+    /// Test: `auto_tags_for_each_variant`.
+    pub fn auto_tags(&self) -> Vec<String> {
+        match self {
+            Self::Ctrl => vec!["scope/user".into()],
+            Self::Pm {
+                session_id,
+                project_id,
+            } => vec![
+                format!("session/{session_id}"),
+                format!("project/{project_id}"),
+            ],
+            Self::Agent {
+                session_id,
+                project_id,
+                agent_id,
+            } => vec![
+                format!("session/{session_id}"),
+                format!("project/{project_id}"),
+                format!("agent/{agent_id}"),
+            ],
+        }
+    }
+
+    /// Try to construct a `CallerIdentity` from environment variables.
+    ///
+    /// Why: Subprocesses receive identity as env vars; this constructor
+    /// centralises the parse logic.
+    /// What: Reads `TCODE_CALLER` and the corresponding ID vars.
+    /// Returns `None` if the env var is absent or unrecognised.
+    /// Test: `caller_identity_from_env_*`.
+    pub fn from_env() -> Option<Self> {
+        let kind = std::env::var(ENV_CALLER).ok()?;
+        match kind.as_str() {
+            "ctrl" => Some(Self::Ctrl),
+            "pm" => {
+                let session_id = std::env::var(ENV_SESSION_ID).ok()?;
+                let project_id = std::env::var(ENV_PROJECT_ID).ok()?;
+                Some(Self::Pm {
+                    session_id,
+                    project_id,
+                })
+            }
+            "agent" => {
+                let session_id = std::env::var(ENV_SESSION_ID).ok()?;
+                let project_id = std::env::var(ENV_PROJECT_ID).ok()?;
+                let agent_id = std::env::var(ENV_AGENT_ID).ok()?;
+                Some(Self::Agent {
+                    session_id,
+                    project_id,
+                    agent_id,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Return the session ID if this identity has one.
+    ///
+    /// Why: Memory tools that scope by session need to extract the ID
+    /// without pattern-matching on the full identity.
+    /// What: `Some(session_id)` for `Pm` and `Agent`, `None` for `Ctrl`.
+    /// Test: `session_id_for_each_variant`.
+    pub fn session_id(&self) -> Option<&str> {
+        match self {
+            Self::Ctrl => None,
+            Self::Pm { session_id, .. } => Some(session_id.as_str()),
+            Self::Agent { session_id, .. } => Some(session_id.as_str()),
+        }
+    }
+}
+
+/// Maximum recall scope for a `CallerIdentity`.
+///
+/// Why: Provides a named ceiling that the memory tool enforces server-side so
+/// agents can't request more than their tier allows.
+/// What: `All` > `Session` > `Agent` in scope breadth.
+/// Test: Covered by `max_recall_scope_for_each_variant`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RecallCeiling {
+    /// May recall all memories.
+    All,
+    /// May recall memories scoped to the current session.
+    Session,
+    /// May recall only its own memories.
+    Agent,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_recall_scope_for_each_variant() {
+        assert_eq!(CallerIdentity::Ctrl.max_recall_scope(), RecallCeiling::All);
+        assert_eq!(
+            CallerIdentity::Pm {
+                session_id: "s1".into(),
+                project_id: "p1".into()
+            }
+            .max_recall_scope(),
+            RecallCeiling::Session
+        );
+        assert_eq!(
+            CallerIdentity::Agent {
+                session_id: "s1".into(),
+                project_id: "p1".into(),
+                agent_id: "a1".into()
+            }
+            .max_recall_scope(),
+            RecallCeiling::Agent
+        );
+    }
+
+    #[test]
+    fn auto_tags_for_each_variant() {
+        let ctrl_tags = CallerIdentity::Ctrl.auto_tags();
+        assert_eq!(ctrl_tags, vec!["scope/user"]);
+
+        let pm_tags = CallerIdentity::Pm {
+            session_id: "s42".into(),
+            project_id: "p7".into(),
+        }
+        .auto_tags();
+        assert!(pm_tags.contains(&"session/s42".to_string()));
+        assert!(pm_tags.contains(&"project/p7".to_string()));
+        assert_eq!(pm_tags.len(), 2);
+
+        let agent_tags = CallerIdentity::Agent {
+            session_id: "s42".into(),
+            project_id: "p7".into(),
+            agent_id: "a99".into(),
+        }
+        .auto_tags();
+        assert!(agent_tags.contains(&"agent/a99".to_string()));
+        assert_eq!(agent_tags.len(), 3);
+    }
+
+    #[test]
+    fn session_id_for_each_variant() {
+        assert_eq!(CallerIdentity::Ctrl.session_id(), None);
+        assert_eq!(
+            CallerIdentity::Pm {
+                session_id: "sess".into(),
+                project_id: "proj".into()
+            }
+            .session_id(),
+            Some("sess")
+        );
+        assert_eq!(
+            CallerIdentity::Agent {
+                session_id: "sess".into(),
+                project_id: "proj".into(),
+                agent_id: "ag".into()
+            }
+            .session_id(),
+            Some("sess")
+        );
+    }
+
+    #[test]
+    fn caller_identity_roundtrips_json() {
+        let agent = CallerIdentity::Agent {
+            session_id: "s1".into(),
+            project_id: "p1".into(),
+            agent_id: "engineer".into(),
+        };
+        let json = serde_json::to_string(&agent).expect("serialize");
+        let back: CallerIdentity = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(agent, back);
+    }
+}

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -8,18 +8,16 @@
 //! fills that role. It is the Claude-Code-native orchestration entry point —
 //! driven by API, CLI, or TUI — that runs the PM main-loop, enforces the
 //! mandatory workflow, and delegates authority to typed sub-agents according to
-//! MPM protocols. Extraction from open-mpm is tracked in epic #587; Phase 1
-//! moves the leaf/protocol modules here.
+//! MPM protocols. Extraction from open-mpm is tracked in epic #587.
 //!
 //! # Design constraints
 //!
 //! * **Claude-Code compatible** — reads `.claude/` config, agents, skills, MCP
 //!   descriptors, `CLAUDE.md`, and permission grants exactly as Claude Code does.
 //! * **API / CLI / TUI driven** — no hooks support (hooks are a Claude Code
-//!   shell-level feature; `tcode` operates above that layer).
-//! * **Per-agent model routing** — each agent in the harness may specify its own
-//!   model, independently choosing between AWS Bedrock models and OpenRouter
-//!   models. The PM is not constrained to a single provider.
+//!   shell-level feature; `tcode` operates above that layer via its event bus).
+//! * **Per-agent model routing** — each agent may specify its own model,
+//!   independently choosing between AWS Bedrock models and OpenRouter models.
 //! * **Single-instance per project** — one `tcode serve` process per `.claude/`
 //!   root; multiple CLI or TUI clients may attach to it.
 //! * **No `unwrap()` in library code** — all fallible paths use `?` with
@@ -31,24 +29,28 @@
 //! Phase 1 public surface (leaf/protocol modules extracted from open-mpm per
 //! #640):
 //!
-//! * [`events`] — process-global broadcast event bus (`Event` enum, `publish`,
-//!   `subscribe`, `emit`).
-//! * [`ipc`] — NDJSON IPC protocol for PM ↔ sub-agent communication
-//!   (`IpcMessage`, `HistoryMessage`, `serialize_message`, `parse_message`).
-//! * [`perf`] — per-phase latency + token/cost instrumentation (`TokenUsage`,
-//!   `PerfCollector`, `PerfRecord`, `cost_usd`).
-//! * [`intent`] — pure-Rust heuristic intent classifier (`IntentClass`,
-//!   `classify_intent`) for PM fast-pathing.
-//! * [`progress`] — real-time phase progress reporter (`ProgressReporter`,
-//!   `format_duration`).
-//! * [`build_info`] — monotonic build counter + version banner (`BuildInfo`,
-//!   `VERSION`, `GIT_HASH`, `version_string`).
+//! * [`events`] — process-global broadcast event bus.
+//! * [`ipc`] — NDJSON IPC protocol for PM ↔ sub-agent communication.
+//! * [`perf`] — per-phase latency + token/cost instrumentation.
+//! * [`intent`] — pure-Rust heuristic intent classifier.
+//! * [`progress`] — real-time phase progress reporter.
+//! * [`build_info`] — monotonic build counter + version banner.
+//!
+//! Phase 2 public surface (tools layer, per #641):
+//!
+//! * [`tools`] — `ToolExecutor` / `AgentRunner` / `SearchProvider` traits,
+//!   `ToolRegistry` dispatcher, `DelegateToAgentTool`, `ToolResult`.
+//! * [`rbac`] — `ServiceTier`, `UserIdentity`, access-control helpers.
+//!
+//! Phase 3 public surface (agents + LLM layer, per #642):
+//!
+//! * [`agents`] — `AgentConfig` TOML schema, `discover_agents`, `load_all_agents`.
+//! * [`identity`] — `CallerIdentity`, `RecallCeiling` for memory scoping.
+//! * [`logging`] — tracing init helpers (`init_tracing`, `init_tracing_for_test`).
 //!
 //! # Test
 //!
-//! `cargo test -p trusty-code` — all leaf modules carry their own unit tests.
-//! The event bus has a round-trip async test (`publish_round_trips_through_subscribe`).
-//! Phase 2+ will add integration tests as the PM loop is introduced.
+//! `cargo test -p trusty-code` — all modules carry their own unit tests.
 
 // ── Phase 1 leaf/protocol modules (extracted from open-mpm per #640) ──
 
@@ -66,8 +68,7 @@ pub mod events;
 /// Why: Provides a framing-safe wire protocol over stdin/stdout pipes so the
 /// PM and sub-agent subprocesses exchange structured messages without ambiguity.
 /// What: `IpcMessage` enum (Task/Result/Error), `HistoryMessage` wire type,
-/// `serialize_message`/`parse_message` helpers, `extract_summary`/
-/// `extract_files_from_content` utilities.
+/// `serialize_message`/`parse_message` helpers.
 /// Test: `ipc::tests::*` round-trips every variant.
 pub mod ipc;
 
@@ -83,16 +84,15 @@ pub mod perf;
 /// Pure-Rust heuristic intent classifier for PM fast-pathing.
 ///
 /// Why: Avoids routing trivial conversational inputs through the full
-/// subprocess pipeline — a 60-90s round trip for what should be sub-second.
+/// subprocess pipeline.
 /// What: `IntentClass` enum, `classify_intent` function.
-/// Test: `intent::classifier_tests::*`, `intent::classifier_tests_2::*`,
-/// `intent::classifier_property_tests::*`, `intent::tests::*`.
+/// Test: `intent::classifier_tests::*`.
 pub mod intent;
 
 /// Real-time phase progress reporter to stderr.
 ///
 /// Why: Workflow runs take 20–70 minutes; users need live feedback without
-/// polluting stdout (reserved for structured JSON output).
+/// polluting stdout.
 /// What: `ProgressReporter` struct with phase/wave lifecycle hooks and
 /// `format_duration` helper.
 /// Test: `progress::tests::*`.
@@ -100,19 +100,70 @@ pub mod progress;
 
 /// Build and version tracking.
 ///
-/// Why: A monotonic build counter that increments on every process start gives
-/// a deterministic identifier that pairs with semver for log correlation.
+/// Why: A monotonic build counter pairs with semver for log correlation.
 /// What: `BuildInfo` struct, `VERSION`/`GIT_HASH`/`PKG_NAME` constants,
 /// `version_string` helper.
 /// Test: `build_info::tests::*`.
 pub mod build_info;
+
+// ── Phase 2 tools layer (per #641) ──
+
+/// Tool system: traits, registry, and the delegate tool.
+///
+/// Why: The PM loop needs a polymorphic tool dispatch layer so new capabilities
+/// plug in without touching orchestration code.
+/// What: `ToolExecutor`, `AgentRunner`, `RunContext`, `AgentOutput`,
+/// `SearchProvider`, `SkillResolver`, `ToolResult`, `ToolRegistry`,
+/// `DelegateToAgentTool`.
+/// Test: `tools::traits::tests::*`, `tools::registry::tests::*`,
+/// `tools::delegate::tests::*`.
+pub mod tools;
+
+/// Role-based access control for tool execution.
+///
+/// Why: tcode exposes tools over multiple surfaces; RBAC gates execution on a
+/// stable tier ladder without per-deployment code branches.
+/// What: `ServiceTier`, `UserIdentity`, `filter_tools_for_user`,
+/// `can_access_tier`.
+/// Test: `rbac::tests::*`.
+pub mod rbac;
+
+// ── Phase 3 agents + LLM layer (per #642) ──
+
+/// Agent configuration loading.
+///
+/// Why: Sub-agents are defined declaratively in TOML files under
+/// `.claude/agents/` so model, prompt, and parameters can evolve without code
+/// changes.
+/// What: `AgentConfig`, `AgentInfo`, `LlmParams`, `SystemPrompt`, `ToolsConfig`,
+/// `RunnerConfig`, `RunnerKind`, `discover_agents`, `load_all_agents`.
+/// Test: `agents::tests::*`.
+pub mod agents;
+
+/// Caller identity hierarchy for memory scoping.
+///
+/// Why: Memory must be scoped according to who is calling — operator, PM, or
+/// sub-agent — so agents cannot self-elevate their recall scope.
+/// What: `CallerIdentity` enum, `RecallCeiling`, env-var constructors.
+/// Test: `identity::tests::*`.
+pub mod identity;
+
+/// Tracing and logging initialisation.
+///
+/// Why: All binaries need consistent stderr-bound tracing setup; centralising
+/// it prevents duplicated setup across entry points.
+/// What: `init_tracing`, `init_tracing_for_test`, `DEFAULT_LOG_LEVEL`.
+/// Test: `logging::tests::*`.
+pub mod logging;
+
+// ── Package-level re-exports ──
 
 /// Version string, re-exported so integration tests can assert it without
 /// hard-coding the constant.
 ///
 /// Why: Single source of truth for the version across CLI and any future API
 /// responses that embed it.
-/// What: the `CARGO_PKG_VERSION` compile-time env var, captured at build time.
+/// What: The `CARGO_PKG_VERSION` compile-time env var, captured at build time.
 /// Test: `cargo run -p trusty-code -- --version` must print this value.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/trusty-code/src/logging/mod.rs
+++ b/crates/trusty-code/src/logging/mod.rs
@@ -1,0 +1,79 @@
+//! Tracing and logging initialisation for tcode.
+//!
+//! Why: All tcode binaries and the library's test harness need consistent
+//! tracing initialisation that writes to stderr (never stdout — stdout is the
+//! API transport channel). Centralising it here prevents duplicated setup and
+//! ensures the `try_init` pattern is used everywhere so test binaries remain
+//! idempotent.
+//! What: `init_tracing` initialises the global tracing subscriber from the
+//! `RUST_LOG` env var. `init_tracing_for_test` is a lightweight variant for
+//! test binaries that silently drops duplicate init errors.
+//! Test: `init_tracing_for_test_is_idempotent` calls the function twice and
+//! asserts no panic.
+
+use tracing_subscriber::EnvFilter;
+
+/// Initialise the global tracing subscriber.
+///
+/// Why: All daemons and CLI entry points call this once at startup to ensure
+/// log output is consistently routed to stderr with the `RUST_LOG` filter.
+/// What: Installs a stderr-bound fmt subscriber with `EnvFilter::from_default_env()`.
+/// Panics if called twice (use `init_tracing_for_test` in test binaries).
+/// Test: Called in `main.rs`; correctness is verified by observing log output.
+pub fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+}
+
+/// Initialise the global tracing subscriber, silently ignoring duplicate inits.
+///
+/// Why: Test binaries may link multiple test modules that all call setup code.
+/// `try_init` returns an error on the second call instead of panicking, so
+/// test runs remain stable regardless of execution order.
+/// What: Calls `try_init()`; swallows the error if already initialised.
+/// Test: `init_tracing_for_test_is_idempotent`.
+pub fn init_tracing_for_test() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
+/// Log level used when no `RUST_LOG` env var is set.
+///
+/// Why: Documents and centralises the default so operators know what to expect
+/// without reading source.
+/// What: A static string literal; the default filter used by `EnvFilter::from_default_env()`.
+/// Test: Not directly tested — the value is advisory documentation.
+pub const DEFAULT_LOG_LEVEL: &str = "info";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `init_tracing_for_test` must be idempotent across multiple calls.
+    ///
+    /// Why: Test binaries are often multi-crate and may call init from several
+    /// setup functions; a panic on re-init would break the test suite.
+    /// What: Calls `init_tracing_for_test` twice; asserts no panic.
+    /// Test: This test.
+    #[test]
+    fn init_tracing_for_test_is_idempotent() {
+        init_tracing_for_test();
+        init_tracing_for_test(); // second call must not panic
+    }
+
+    /// The default log level constant is non-empty.
+    ///
+    /// Why: Guard against accidental empty string.
+    /// What: Asserts `DEFAULT_LOG_LEVEL` is non-empty.
+    /// Test: This test.
+    #[test]
+    fn default_log_level_is_non_empty() {
+        assert!(!DEFAULT_LOG_LEVEL.is_empty());
+    }
+}

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -6,18 +6,19 @@
 //! a stable interface while the underlying implementation is extracted from
 //! open-mpm across Phases 1–N of epic #587.
 //!
-//! What: thin clap CLI with stub subcommands that fail fast with a clear
-//! "not yet implemented" message and the tracking phase/issue reference.
+//! What: thin clap CLI with subcommands. `run-task` is functional as of Phase 6;
+//! `serve` and `run-workflow` remain stubs.
 //!
 //! Test: `cargo run -p trusty-code -- --version` must exit 0 and print the
-//! crate version. Each stub subcommand must exit non-zero.
+//! crate version. `tcode run-task <agent> <task> --project <path>` must
+//! locate the agent config, validate it, and report readiness.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use tracing_subscriber::EnvFilter;
+use tracing::info;
 
 /// tcode — per-project Claude-Code-compatible MPM orchestration harness.
 #[derive(Parser)]
@@ -37,71 +38,182 @@ struct Cli {
 /// Why: defines the stable CLI surface for all Phase 0+ callers. Stubs are
 /// replaced by real implementations as each phase of #587 lands.
 /// What: clap enum; each variant maps to one subcommand.
-/// Test: `tcode --help` lists all variants; each stub exits non-zero.
+/// Test: `tcode --help` lists all variants; functional commands exit 0.
 #[derive(Subcommand)]
 enum Command {
     /// Start the per-project orchestration server.
     ///
-    /// Binds an IPC socket (or HTTP endpoint) and accepts task requests from
-    /// CLI clients, TUI frontends, and MCP callers. One instance per project.
+    /// Binds an IPC socket and accepts task requests from CLI clients, TUI
+    /// frontends, and MCP callers. One instance per project.
     Serve {
         /// Path to the project root (must contain a `.claude/` directory).
         #[arg(long, short, value_name = "PATH")]
         project: PathBuf,
     },
 
-    /// Delegate a single task to a named agent and wait for the result.
+    /// Delegate a single task to a named agent and print the result.
     ///
-    /// Connects to the running `tcode serve` instance for the project and
-    /// dispatches <task> to <agent>. Prints the agent's response to stdout
-    /// and exits 0 on success, non-zero on error.
+    /// Loads the agent config from `<project>/.claude/agents/<agent>.toml`,
+    /// validates it, and reports the agent's capabilities. In a future phase
+    /// this will spawn the agent subprocess and return its result.
     RunTask {
         /// Agent name as declared in `.claude/agents/<name>.toml`.
         agent: String,
 
         /// Free-form task description passed to the agent's system prompt.
         task: String,
+
+        /// Path to the project root (must contain a `.claude/` directory).
+        /// Defaults to the current working directory.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
     },
 
     /// Execute a named MPM workflow end-to-end.
     ///
     /// Loads the workflow definition from `.claude/workflows/<name>.toml` (or
-    /// `.open-mpm/workflows/<name>.toml`) and runs it through the PM
-    /// main-loop. All mandatory workflow stages are enforced.
+    /// `.open-mpm/workflows/<name>.toml`) and runs it through the PM main-loop.
     RunWorkflow {
         /// Workflow name (matches the filename without extension).
         name: String,
+
+        /// Path to the project root.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
     },
 }
 
 fn main() -> Result<()> {
-    // Initialise tracing to stderr (never stdout — stdout is the MCP transport).
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_writer(std::io::stderr)
-        .init();
+    // Initialise tracing to stderr (never stdout — stdout is the API transport).
+    trusty_code::logging::init_tracing();
 
     let cli = Cli::parse();
 
     match cli.command {
         Command::Serve { project } => {
             eprintln!(
-                "tcode serve: not yet implemented (#587 Phase 1) [project={}]",
+                "tcode serve: not yet implemented (#587 Phase 5+) [project={}]",
                 project.display()
             );
             process::exit(1);
         }
 
-        Command::RunTask { agent, task } => {
+        Command::RunTask {
+            agent,
+            task,
+            project,
+        } => run_task(&agent, &task, &project),
+
+        Command::RunWorkflow { name, project } => {
             eprintln!(
-                "tcode run-task: not yet implemented (#587 Phase 2) [agent={agent}, task={task}]"
+                "tcode run-workflow: not yet implemented (#587 Phase 5+) [name={name}, project={}]",
+                project.display()
             );
             process::exit(1);
         }
-
-        Command::RunWorkflow { name } => {
-            eprintln!("tcode run-workflow: not yet implemented (#587 Phase 2) [name={name}]");
-            process::exit(1);
-        }
     }
+}
+
+/// Execute `tcode run-task`: validate agent config and report readiness.
+///
+/// Why: Phase 6 establishes the public API entry point for single-task
+/// dispatch so callers and integration tests have a stable interface to target
+/// before the subprocess runner is wired in (Phase 3b/5).
+/// What: Locates the project `.claude/agents/<agent>.toml`, loads and validates
+/// the config, then prints a JSON-structured status line to stdout. Exits 0 on
+/// success, non-zero on error.
+/// Test: `cargo run -p trusty-code -- run-task engineer "write a test"
+///        --project /path/to/project` exits 0 when engineer.toml exists.
+fn run_task(agent_name: &str, task: &str, project: &Path) -> Result<()> {
+    // Resolve canonical project root.
+    let project_root = project
+        .canonicalize()
+        .unwrap_or_else(|_| project.to_path_buf());
+
+    // Locate the agents directory — prefer `.claude/agents`, fall back to
+    // `.open-mpm/agents` for open-mpm-compatible projects.
+    let agents_dir = locate_agents_dir(&project_root);
+
+    info!(
+        agent = agent_name,
+        project = %project_root.display(),
+        agents_dir = %agents_dir.display(),
+        "tcode run-task: locating agent config"
+    );
+
+    // Discover available agents for helpful error messages.
+    let available = trusty_code::agents::discover_agents(&agents_dir);
+    let available_names: Vec<&str> = available.iter().map(|(n, _)| n.as_str()).collect();
+
+    // Locate the agent's TOML.
+    let agent_toml = agents_dir.join(format!("{agent_name}.toml"));
+    if !agent_toml.exists() {
+        let available_str = if available_names.is_empty() {
+            "(none found)".to_string()
+        } else {
+            available_names.join(", ")
+        };
+        eprintln!(
+            "tcode run-task: unknown agent '{agent_name}'. \
+             Available agents: {available_str}. \
+             Check that {agent_toml} exists.",
+            agent_toml = agent_toml.display()
+        );
+        process::exit(1);
+    }
+
+    // Load and validate the config.
+    let cfg = trusty_code::agents::AgentConfig::load(&agent_toml).unwrap_or_else(|e| {
+        eprintln!("tcode run-task: failed to load agent config: {e}");
+        process::exit(1);
+    });
+
+    let model = cfg
+        .agent
+        .model
+        .as_deref()
+        .or(cfg.llm.model_override.as_deref())
+        .unwrap_or("(default)");
+
+    info!(
+        agent = agent_name,
+        model,
+        task_preview = &task[..task.len().min(80)],
+        "tcode run-task: agent config validated"
+    );
+
+    // Emit a structured status line so machine callers can parse it.
+    // In a future phase this transitions to actually spawning the agent.
+    println!(
+        "{}",
+        serde_json::json!({
+            "status": "ready",
+            "agent": agent_name,
+            "model": model,
+            "task_len": task.len(),
+            "config": agent_toml.display().to_string(),
+            "note": "subprocess dispatch not yet wired (#587 Phase 3b/5)"
+        })
+    );
+
+    Ok(())
+}
+
+/// Locate the agents directory for the given project root.
+///
+/// Why: Projects may use either `.claude/agents` (Claude Code native) or
+/// `.open-mpm/agents` (open-mpm legacy). Checking both preserves compatibility.
+/// What: Returns the first directory that exists; falls back to `.claude/agents`.
+/// Test: Indirect via `run_task` integration.
+fn locate_agents_dir(project_root: &std::path::Path) -> PathBuf {
+    let claude_agents = project_root.join(".claude").join("agents");
+    if claude_agents.exists() {
+        return claude_agents;
+    }
+    let open_mpm_agents = project_root.join(".open-mpm").join("agents");
+    if open_mpm_agents.exists() {
+        return open_mpm_agents;
+    }
+    // Default to .claude/agents (may not exist yet).
+    claude_agents
 }

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -114,6 +114,32 @@ fn main() -> Result<()> {
     }
 }
 
+/// Validate that `agent_name` contains only safe filesystem characters.
+///
+/// Why: The LLM supplies `agent_name` which is joined into a filesystem path
+/// (`<agents_dir>/<agent_name>.toml`). Without this guard a crafted name such
+/// as `../../etc/passwd` escapes the agents directory and enables path
+/// traversal. Restricting to `[a-zA-Z0-9_-]` is safe, predictable, and covers
+/// every real agent name in use.
+/// What: Returns `Ok(())` when every character is ASCII alphanumeric, `_`, or
+/// `-`, and the name is non-empty. Returns `Err` with a descriptive message
+/// otherwise.
+/// Test: `validate_agent_name_rejects_traversal` and
+/// `validate_agent_name_accepts_valid` in this module.
+fn validate_agent_name(agent_name: &str) -> Result<()> {
+    if agent_name.is_empty()
+        || !agent_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        anyhow::bail!(
+            "invalid agent name '{agent_name}': \
+             agent names must be non-empty and contain only [a-zA-Z0-9_-]"
+        );
+    }
+    Ok(())
+}
+
 /// Execute `tcode run-task`: validate agent config and report readiness.
 ///
 /// Why: Phase 6 establishes the public API entry point for single-task
@@ -125,6 +151,12 @@ fn main() -> Result<()> {
 /// Test: `cargo run -p trusty-code -- run-task engineer "write a test"
 ///        --project /path/to/project` exits 0 when engineer.toml exists.
 fn run_task(agent_name: &str, task: &str, project: &Path) -> Result<()> {
+    // Guard against path traversal via LLM-supplied agent_name.
+    if let Err(e) = validate_agent_name(agent_name) {
+        eprintln!("tcode run-task: {e}");
+        process::exit(1);
+    }
+
     // Resolve canonical project root.
     let project_root = project
         .canonicalize()
@@ -175,10 +207,15 @@ fn run_task(agent_name: &str, task: &str, project: &Path) -> Result<()> {
         .or(cfg.llm.model_override.as_deref())
         .unwrap_or("(default)");
 
+    // Char-safe truncation: slicing bytes at offset 80 panics when a multi-byte
+    // UTF-8 character straddles the boundary. Collecting the first 80 chars is
+    // always valid regardless of the Unicode content of the task string.
+    let task_preview: String = task.chars().take(80).collect();
+
     info!(
         agent = agent_name,
         model,
-        task_preview = &task[..task.len().min(80)],
+        task_preview = task_preview.as_str(),
         "tcode run-task: agent config validated"
     );
 
@@ -216,4 +253,62 @@ fn locate_agents_dir(project_root: &std::path::Path) -> PathBuf {
     }
     // Default to .claude/agents (may not exist yet).
     claude_agents
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::validate_agent_name;
+
+    /// A path-traversal agent name is rejected.
+    ///
+    /// Why: Guards the `agents_dir.join(format!("{agent_name}.toml"))` call in
+    /// `run_task` against LLM-supplied names that escape the agents directory.
+    /// What: Asserts that `../../etc/passwd` and similar strings fail validation.
+    /// Test: This test.
+    #[test]
+    fn validate_agent_name_rejects_traversal() {
+        assert!(
+            validate_agent_name("../../etc/passwd").is_err(),
+            "path traversal must be rejected"
+        );
+        assert!(
+            validate_agent_name("../sibling").is_err(),
+            "parent-dir component must be rejected"
+        );
+        assert!(
+            validate_agent_name("agent/subdir").is_err(),
+            "path separator must be rejected"
+        );
+        assert!(
+            validate_agent_name("agent name").is_err(),
+            "space must be rejected"
+        );
+        assert!(
+            validate_agent_name("").is_err(),
+            "empty string must be rejected"
+        );
+        assert!(
+            validate_agent_name("agent\0null").is_err(),
+            "null byte must be rejected"
+        );
+    }
+
+    /// A well-formed agent name is accepted.
+    ///
+    /// Why: Verifies the allowlist does not over-reject legitimate names.
+    /// What: Asserts that common agent names (`engineer`, `qa-agent`, etc.) pass.
+    /// Test: This test.
+    #[test]
+    fn validate_agent_name_accepts_valid() {
+        assert!(validate_agent_name("engineer").is_ok());
+        assert!(validate_agent_name("qa-agent").is_ok());
+        assert!(validate_agent_name("python_engineer").is_ok());
+        assert!(validate_agent_name("rust-engineer-2024").is_ok());
+        assert!(
+            validate_agent_name("A").is_ok(),
+            "single ASCII letter must pass"
+        );
+    }
 }

--- a/crates/trusty-code/src/rbac/mod.rs
+++ b/crates/trusty-code/src/rbac/mod.rs
@@ -1,0 +1,164 @@
+//! Role-based access control for tool execution in tcode.
+//!
+//! Why: tcode exposes tools over multiple transports (CLI, API, TUI). Some
+//! tools (memory writes, shell exec) are unsafe for arbitrary callers while
+//! still being essential for the trusted operator. RBAC gates tool execution
+//! on a small, totally-ordered tier ladder so the same agent definition can be
+//! safely exposed across transports without per-deployment code branches.
+//! What: Defines `ServiceTier` (re-exported from `tools::traits`),
+//! `UserIdentity` (the per-request principal), and `filter_tools_for_user`.
+//! Test: See unit tests below — covers default identity, every tier × restriction
+//! combination, and the filter helper.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::tools::traits::ServiceTier;
+use crate::tools::traits::ToolExecutor;
+
+/// Per-request principal carried from transport into tool dispatch.
+///
+/// Why: Every inbound request (CLI, API call, TUI keystroke) arrives with some
+/// notion of "who is asking". Modeling it as a single `UserIdentity` value
+/// means the tool dispatch layer doesn't have to care which transport produced
+/// the request, and unit tests can construct one without spinning up a transport.
+/// What: `id` is the transport-native identifier; `name` is a human-readable
+/// label for logging; `tier` is the privilege bucket enforced by `can_access_tier`.
+/// Test: `default_is_local_cli_all`, plus indirect coverage via `can_access_tier` cases.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UserIdentity {
+    /// Transport-native identifier (e.g. `"cli"`, `"api"`, Slack `"U…"`).
+    pub id: String,
+    /// Human-readable label, used only for logging.
+    pub name: String,
+    /// Privilege tier enforced at dispatch.
+    pub tier: ServiceTier,
+}
+
+impl Default for UserIdentity {
+    fn default() -> Self {
+        Self {
+            id: "cli".into(),
+            name: "local".into(),
+            tier: ServiceTier::All,
+        }
+    }
+}
+
+impl UserIdentity {
+    /// Construct a new identity with a given tier.
+    ///
+    /// Why: Transport layers need to mint identities with custom IDs per
+    /// inbound request without hand-rolling the struct literal.
+    /// What: Helper constructor; no validation beyond moving fields.
+    /// Test: `new_constructs_with_fields`.
+    pub fn new(id: impl Into<String>, name: impl Into<String>, tier: ServiceTier) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            tier,
+        }
+    }
+
+    /// Whether this identity may invoke a tool whose `restricted_tiers` list
+    /// is `restricted`.
+    ///
+    /// Why: Tools express restrictions as an *inverted* list — they name the
+    /// tiers that are NOT allowed to call them — because that reads naturally
+    /// in config files (`restricted_tiers = ["read_only"]` blocks one tier).
+    /// An empty restriction list always permits access.
+    /// What: Returns `true` if `restricted` is empty, or if `self.tier` is not
+    /// present in `restricted`. Check is membership-based, NOT ordering-based.
+    /// Test: `can_access_tier_empty_always_allows`, `can_access_tier_blocks_listed_tier`,
+    /// `can_access_tier_allows_other_tiers`.
+    pub fn can_access_tier(&self, restricted: &[ServiceTier]) -> bool {
+        restricted.is_empty() || !restricted.contains(&self.tier)
+    }
+}
+
+/// Filter a list of tools to those callable by `user`.
+///
+/// Why: The LLM should not even see tools it isn't allowed to call — presenting
+/// them and then denying at dispatch wastes context and invites retries.
+/// What: Drops any tool whose `restricted_tiers()` blocks `user.tier`. Tools
+/// that haven't opted into RBAC (empty `restricted_tiers`) pass through unchanged.
+/// Test: Exercised in `ToolRegistry::filter_tools_for_user` tests.
+pub fn filter_tools_for_user(
+    tools: &[Arc<dyn ToolExecutor>],
+    user: &UserIdentity,
+) -> Vec<Arc<dyn ToolExecutor>> {
+    tools
+        .iter()
+        .filter(|t| user.can_access_tier(t.restricted_tiers()))
+        .cloned()
+        .collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_service_tier_is_all() {
+        assert_eq!(ServiceTier::default(), ServiceTier::All);
+    }
+
+    #[test]
+    fn service_tier_serializes_snake_case() {
+        let s = serde_json::to_string(&ServiceTier::ReadOnly).expect("serialize");
+        assert_eq!(s, "\"read_only\"");
+        let r: ServiceTier = serde_json::from_str("\"analytics\"").expect("deserialize");
+        assert_eq!(r, ServiceTier::Analytics);
+    }
+
+    #[test]
+    fn default_identity_is_local_cli_all() {
+        let u = UserIdentity::default();
+        assert_eq!(u.id, "cli");
+        assert_eq!(u.name, "local");
+        assert_eq!(u.tier, ServiceTier::All);
+    }
+
+    #[test]
+    fn new_constructs_with_fields() {
+        let u = UserIdentity::new("U123", "alice", ServiceTier::Analytics);
+        assert_eq!(u.id, "U123");
+        assert_eq!(u.name, "alice");
+        assert_eq!(u.tier, ServiceTier::Analytics);
+    }
+
+    #[test]
+    fn can_access_tier_empty_always_allows() {
+        let u = UserIdentity::new("x", "x", ServiceTier::ReadOnly);
+        assert!(u.can_access_tier(&[]));
+        let u = UserIdentity::new("x", "x", ServiceTier::All);
+        assert!(u.can_access_tier(&[]));
+    }
+
+    #[test]
+    fn can_access_tier_blocks_listed_tier() {
+        let u = UserIdentity::new("x", "x", ServiceTier::ReadOnly);
+        assert!(!u.can_access_tier(&[ServiceTier::ReadOnly]));
+        assert!(!u.can_access_tier(&[ServiceTier::All, ServiceTier::ReadOnly]));
+    }
+
+    #[test]
+    fn can_access_tier_allows_other_tiers() {
+        // `All` is not in the blocklist — allowed even though `ReadOnly` is named.
+        let u = UserIdentity::new("x", "x", ServiceTier::All);
+        assert!(u.can_access_tier(&[ServiceTier::ReadOnly]));
+        let u = UserIdentity::new("x", "x", ServiceTier::Analytics);
+        assert!(u.can_access_tier(&[ServiceTier::ReadOnly]));
+        assert!(!u.can_access_tier(&[ServiceTier::Analytics]));
+    }
+
+    #[test]
+    fn can_access_tier_no_implicit_ordering() {
+        // Restrictions are explicit memberships, not ordered comparisons.
+        let u = UserIdentity::new("x", "x", ServiceTier::ReadOnly);
+        assert!(u.can_access_tier(&[ServiceTier::Analytics]));
+    }
+}

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -1,0 +1,317 @@
+//! `delegate_to_agent` tool — the PM's primary tool for dispatching to sub-agents.
+//!
+//! Why: Keeps the delegation schema and its executor colocated so the PM's tool
+//! registry can register a single type that owns both. Pre-flight validation of
+//! `agent_name` against the on-disk agent config directory prevents the LLM from
+//! hallucinating sub-agent names and crashing the subprocess runner with a
+//! confusing IO error (#204 equivalent).
+//! What: `DelegateToAgentTool` wraps an `AgentRunner` and (optionally) an agent
+//! config directory. `execute()` parses `{agent_name, task}`, validates the agent
+//! config exists, and hands off to the runner. On miss, returns a helpful error
+//! listing available agents.
+//! Test: `unknown_agent_returns_helpful_error` builds a tool pointed at a tempdir
+//! containing `engineer.toml` only, calls `execute({"agent_name":"ghost",...})`,
+//! and asserts the error names the unknown agent and lists `engineer`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{AgentRunner, ToolExecutor, ToolResult};
+
+/// Tool executor that delegates a task to a named sub-agent.
+///
+/// Why: Encapsulates the `delegate_to_agent` tool so the PM loop registers a
+/// single `Arc<dyn ToolExecutor>` rather than branching on the tool name inline.
+/// What: Holds an `AgentRunner` for subprocess/in-process dispatch and an
+/// optional `config_dir` for pre-flight agent name validation.
+/// Test: `unknown_agent_returns_helpful_error`, `known_agent_reaches_runner`,
+/// `no_config_dir_skips_validation`.
+pub struct DelegateToAgentTool {
+    runner: Arc<dyn AgentRunner>,
+    /// Directory holding `<agent>.toml` files. When `Some`, `execute()` rejects
+    /// calls whose `agent_name` does not have a matching TOML. When `None`,
+    /// validation is skipped (legacy / test mode).
+    config_dir: Option<PathBuf>,
+}
+
+impl DelegateToAgentTool {
+    /// Construct with an injected `AgentRunner`.
+    ///
+    /// Why: Lets tests substitute an in-process mock runner without touching
+    /// production subprocess code.
+    /// What: Stores `runner`; no pre-flight name validation until `with_config_dir`
+    /// is also called.
+    /// Test: `DelegateToAgentTool::new(Arc::new(MockRunner))` compiles and
+    /// yields a tool whose `name()` is `delegate_to_agent`.
+    pub fn new(runner: Arc<dyn AgentRunner>) -> Self {
+        Self {
+            runner,
+            config_dir: None,
+        }
+    }
+
+    /// Attach an agent config directory for pre-flight `agent_name` validation.
+    ///
+    /// Why: When the LLM hallucinates an agent name, spawning the subprocess
+    /// fails with a generic IO error. Validating up front returns a structured
+    /// `ToolResult::err` listing available agents so the LLM can self-correct.
+    /// What: Stores `dir`. Files matching `<dir>/<agent_name>.toml` are
+    /// considered valid. Missing dir is treated as "no agents available".
+    /// Test: `unknown_agent_returns_helpful_error`.
+    pub fn with_config_dir(mut self, dir: PathBuf) -> Self {
+        self.config_dir = Some(dir);
+        self
+    }
+
+    /// List agent names discoverable in `config_dir`, if any.
+    ///
+    /// Why: Builds the "available agents" hint in error messages so the LLM
+    /// gets immediate, structured feedback when it invents a name.
+    /// What: Reads `<config_dir>/*.toml` and returns each file stem. Returns
+    /// `None` when no `config_dir` was attached.
+    /// Test: Indirect via `unknown_agent_returns_helpful_error`.
+    fn available_agents(&self) -> Option<Vec<String>> {
+        let dir = self.config_dir.as_ref()?;
+        let entries = std::fs::read_dir(dir).ok()?;
+        let mut names: Vec<String> = entries
+            .flatten()
+            .filter_map(|e| {
+                let p = e.path();
+                if p.extension().and_then(|x| x.to_str()) == Some("toml") {
+                    p.file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        names.sort();
+        Some(names)
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for DelegateToAgentTool {
+    fn name(&self) -> &str {
+        "delegate_to_agent"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "delegate_to_agent",
+                "description": "Delegate a task to a specialized sub-agent. Use this for any implementation work (writing code, running analysis, etc.). The sub-agent will be spawned and its result returned to you. NOTE: agent_name must be an actual sub-agent (e.g. 'engineer', 'python-engineer', 'qa-agent'); native tools like search_code, web_search are NOT agent names — call them directly.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": "Short name of the sub-agent. Must match an existing agent config; native tools are not agent names."
+                        },
+                        "task": {
+                            "type": "string",
+                            "description": "Concrete task description for the sub-agent."
+                        }
+                    },
+                    "required": ["agent_name", "task"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(agent_name) = args.get("agent_name").and_then(Value::as_str) else {
+            return ToolResult::err("delegate_to_agent: missing 'agent_name'");
+        };
+        let Some(task) = args.get("task").and_then(Value::as_str) else {
+            return ToolResult::err("delegate_to_agent: missing 'task'");
+        };
+
+        // Pre-flight validation: if a config_dir was attached, verify the agent
+        // config exists before spawning. Converts a generic IO error into a
+        // structured tool error the LLM can act on.
+        if let Some(dir) = &self.config_dir {
+            let agent_toml = dir.join(format!("{agent_name}.toml"));
+            if !agent_toml.exists() {
+                let available = self.available_agents().unwrap_or_default();
+                let available_str = if available.is_empty() {
+                    "(none discovered)".to_string()
+                } else {
+                    available.join(", ")
+                };
+                return ToolResult::err(format!(
+                    "Unknown agent '{agent_name}'. Available agents: {available_str}. \
+                     Note: native tools (search_code, web_search, etc.) are NOT agent \
+                     names — call them directly as tools instead of via delegate_to_agent."
+                ));
+            }
+        }
+
+        match self.runner.run(agent_name, task).await {
+            Ok(out) => ToolResult::ok(out.content),
+            Err(e) => ToolResult::err(format!("sub-agent '{agent_name}' failed: {e:#}")),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use super::DelegateToAgentTool;
+    use crate::tools::traits::{AgentOutput, AgentRunner, ToolExecutor};
+
+    /// Recording mock runner.
+    ///
+    /// Why: Tests need to verify the runner was (or was not) invoked.
+    /// What: Records `(agent_name, task)` pairs in a Mutex-guarded Vec.
+    /// Test: `known_agent_reaches_runner`, `no_config_dir_skips_validation`.
+    struct RecordingRunner {
+        invoked: std::sync::Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl AgentRunner for RecordingRunner {
+        async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+            self.invoked
+                .lock()
+                .expect("lock poisoned")
+                .push((agent_name.to_string(), task.to_string()));
+            Ok(AgentOutput::from_content("ok"))
+        }
+    }
+
+    /// An unknown agent name returns a structured error listing available agents,
+    /// and the runner is NOT invoked.
+    ///
+    /// Why: Guards against hallucinated agent names causing confusing IO errors.
+    /// What: Calls `execute({"agent_name":"ghost",...})` with a tempdir
+    /// containing only `engineer.toml`; expects error with "ghost" and "engineer".
+    /// Test: This test.
+    #[tokio::test]
+    async fn unknown_agent_returns_helpful_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("engineer.toml"),
+            "[agent]\nname = \"engineer\"\n",
+        )
+        .expect("write");
+        std::fs::write(
+            tmp.path().join("qa-agent.toml"),
+            "[agent]\nname = \"qa-agent\"\n",
+        )
+        .expect("write");
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool =
+            DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
+
+        let result = tool
+            .execute(json!({"agent_name": "ghost", "task": "do something"}))
+            .await;
+
+        assert!(result.is_error(), "must reject unknown agent");
+        let msg = result.content();
+        assert!(
+            msg.contains("Unknown agent 'ghost'"),
+            "error must name the unknown agent, got: {msg}"
+        );
+        assert!(
+            msg.contains("engineer") && msg.contains("qa-agent"),
+            "error must list available agents, got: {msg}"
+        );
+        assert!(
+            msg.contains("native tools"),
+            "error must clarify native-vs-agent, got: {msg}"
+        );
+        assert!(
+            runner.invoked.lock().expect("lock").is_empty(),
+            "runner must not be called when validation fails"
+        );
+    }
+
+    /// A valid agent name passes validation and reaches the runner.
+    ///
+    /// Why: Verify the happy-path dispatch contract.
+    /// What: Register `engineer.toml`, dispatch with `agent_name="engineer"`.
+    /// Test: This test.
+    #[tokio::test]
+    async fn known_agent_reaches_runner() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("engineer.toml"),
+            "[agent]\nname = \"engineer\"\n",
+        )
+        .expect("write");
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool =
+            DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
+
+        let result = tool
+            .execute(json!({"agent_name": "engineer", "task": "do the thing"}))
+            .await;
+
+        assert!(
+            !result.is_error(),
+            "valid agent should succeed: {}",
+            result.content()
+        );
+        let invoked = runner.invoked.lock().expect("lock");
+        assert_eq!(invoked.len(), 1, "runner should be called exactly once");
+        assert_eq!(invoked[0].0, "engineer");
+    }
+
+    /// Without `with_config_dir`, validation is skipped — the runner is invoked.
+    ///
+    /// Why: Preserves backward compatibility with callers that don't need
+    /// pre-flight validation (e.g. integration tests).
+    /// What: Construct tool without config_dir; any agent name reaches the runner.
+    /// Test: This test.
+    #[tokio::test]
+    async fn no_config_dir_skips_validation() {
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone());
+
+        let result = tool
+            .execute(json!({"agent_name": "anything-goes", "task": "do it"}))
+            .await;
+
+        assert!(!result.is_error(), "legacy mode should bypass validation");
+        assert_eq!(runner.invoked.lock().expect("lock").len(), 1);
+    }
+
+    /// Missing `agent_name` field returns a structured error.
+    ///
+    /// Why: Guard against malformed LLM function call arguments.
+    /// What: `execute({})` without `agent_name` key.
+    /// Test: This test.
+    #[tokio::test]
+    async fn missing_agent_name_returns_error() {
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner);
+        let result = tool.execute(json!({"task": "something"})).await;
+        assert!(result.is_error());
+        assert!(result.content().contains("missing 'agent_name'"));
+    }
+}

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -133,6 +133,21 @@ impl ToolExecutor for DelegateToAgentTool {
             return ToolResult::err("delegate_to_agent: missing 'task'");
         };
 
+        // Guard against path traversal: the LLM supplies agent_name which is
+        // joined into a filesystem path. Reject any name that is not strictly
+        // [a-zA-Z0-9_-] before the path join so a crafted value like
+        // "../../etc/passwd" cannot escape the agents config directory.
+        if agent_name.is_empty()
+            || !agent_name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return ToolResult::err(format!(
+                "Invalid agent name '{agent_name}': \
+                 agent names must be non-empty and contain only [a-zA-Z0-9_-]"
+            ));
+        }
+
         // Pre-flight validation: if a config_dir was attached, verify the agent
         // config exists before spawning. Converts a generic IO error into a
         // structured tool error the LLM can act on.
@@ -313,5 +328,77 @@ mod tests {
         let result = tool.execute(json!({"task": "something"})).await;
         assert!(result.is_error());
         assert!(result.content().contains("missing 'agent_name'"));
+    }
+
+    /// A path-traversal agent name is rejected before any filesystem access.
+    ///
+    /// Why: The LLM supplies `agent_name` which is joined into a filesystem path.
+    /// A crafted name like `../../etc/passwd` must be caught before the join to
+    /// prevent escaping the agents config directory.
+    /// What: Calls `execute` with a traversal string; asserts error and runner
+    /// not invoked.
+    /// Test: This test.
+    #[tokio::test]
+    async fn path_traversal_agent_name_is_rejected() {
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        // No config_dir — traversal guard fires before config check.
+        let tool = DelegateToAgentTool::new(runner.clone());
+
+        for bad_name in &[
+            "../../etc/passwd",
+            "../sibling",
+            "agent/sub",
+            "agent name",
+            "",
+        ] {
+            let result = tool
+                .execute(json!({"agent_name": bad_name, "task": "do it"}))
+                .await;
+            assert!(
+                result.is_error(),
+                "traversal/invalid name '{bad_name}' must be rejected"
+            );
+            assert!(
+                result.content().contains("Invalid agent name"),
+                "error must describe the problem, got: {}",
+                result.content()
+            );
+        }
+        assert!(
+            runner.invoked.lock().expect("lock").is_empty(),
+            "runner must never be called for invalid names"
+        );
+    }
+
+    /// A valid agent name passes the sanitisation guard and reaches the runner.
+    ///
+    /// Why: Confirms the allowlist does not over-reject legitimate names.
+    /// What: `execute({"agent_name":"engineer",...})` without config_dir; runner
+    /// is called once.
+    /// Test: This test.
+    #[tokio::test]
+    async fn valid_agent_name_passes_sanitization() {
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone());
+
+        for good_name in &["engineer", "qa-agent", "python_engineer", "rust-2024"] {
+            let result = tool
+                .execute(json!({"agent_name": good_name, "task": "do it"}))
+                .await;
+            assert!(
+                !result.is_error(),
+                "valid name '{good_name}' must be accepted: {}",
+                result.content()
+            );
+        }
+        assert_eq!(
+            runner.invoked.lock().expect("lock").len(),
+            4,
+            "runner must be called for each valid name"
+        );
     }
 }

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -1,0 +1,24 @@
+//! Tool system for tcode — traits, registry, and the delegate tool.
+//!
+//! Why: The PM loop and sub-agent loops need a polymorphic tool dispatch layer
+//! so new capabilities (web search, file ops, memory, etc.) plug in without
+//! touching the core orchestration code. This module is the assembly point.
+//! What: Re-exports `ToolExecutor`, `AgentRunner`, `RunContext`, `AgentOutput`,
+//! `SearchProvider`, `SearchResult`, `SkillResolver`, and `ToolResult` from
+//! `traits`; `ToolRegistry` from `registry`; and `DelegateToAgentTool` from
+//! `delegate`.
+//! Test: Unit tests live in each submodule; integration tests use
+//! `DelegateToAgentTool` with a `MockAgentRunner`.
+
+pub mod delegate;
+pub mod registry;
+pub mod traits;
+
+// Flat re-exports for `crate::tools::*` convenience.
+#[allow(unused_imports)]
+pub use delegate::DelegateToAgentTool;
+pub use registry::ToolRegistry;
+pub use traits::{
+    AgentOutput, AgentRunner, HistoryMessage, RunContext, SearchProvider, SearchResult,
+    ServiceTier, SkillResolver, ToolExecutor, ToolResult,
+};

--- a/crates/trusty-code/src/tools/registry.rs
+++ b/crates/trusty-code/src/tools/registry.rs
@@ -1,0 +1,360 @@
+//! Tool registry — HashMap dispatcher + schema emitter.
+//!
+//! Why: Replaces hardcoded `if name == "delegate_to_agent"` dispatch with a
+//! polymorphic registry so new tools (`web_search`, `load_skill`, etc.) plug in
+//! without touching the PM loop. This is the SOA seam.
+//! What: `ToolRegistry` holds `Arc<dyn ToolExecutor>` keyed by name; emits a
+//! vector of JSON schemas for the LLM request; dispatches named tool calls to
+//! the right executor. RBAC-gated dispatch via `dispatch_for_user`.
+//! Test: Unit tests construct a registry with a `MockTool` and assert that
+//! `dispatch("mock")` returns the mock's output and `schemas()` contains the
+//! mock's schema.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::rbac::UserIdentity;
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Registry of tools available to an LLM session.
+///
+/// Why: Centralizes tool lookup and schema emission so the PM loop and
+/// multi-turn sub-agent loop stay short and test-friendly.
+/// What: `HashMap<String, Arc<dyn ToolExecutor>>` with `register`, `dispatch`,
+/// `dispatch_gated`, `dispatch_for_user`, `schemas`, and `filter_tools_for_user`.
+/// Test: See unit tests below.
+#[derive(Default)]
+pub struct ToolRegistry {
+    tools: HashMap<String, Arc<dyn ToolExecutor>>,
+}
+
+impl ToolRegistry {
+    /// Construct an empty registry.
+    ///
+    /// Why: Callers build up the registry incrementally via `register`.
+    /// What: Returns a `ToolRegistry` with no tools registered.
+    /// Test: `new_registry_is_empty`.
+    pub fn new() -> Self {
+        Self {
+            tools: HashMap::new(),
+        }
+    }
+
+    /// Register a tool by its `name()`.
+    ///
+    /// Why: Using the tool's own name prevents mismatches between registered
+    /// key and schema-declared function name.
+    /// What: Inserts into the map. A `debug_assert!` panics in debug builds on
+    /// duplicate names so collisions surface during development.
+    /// Test: `register_then_dispatch_succeeds`, `register_panics_on_duplicate_in_debug`.
+    pub fn register(&mut self, tool: Arc<dyn ToolExecutor>) {
+        let name = tool.name().to_string();
+        debug_assert!(
+            !self.tools.contains_key(&name),
+            "duplicate tool registration for '{name}' — collisions overwrite and cause dispatch bugs"
+        );
+        self.tools.insert(name, tool);
+    }
+
+    /// Whether a tool with the given name is registered.
+    ///
+    /// Why: Lets callers skip registration when a tool already exists.
+    /// What: HashMap membership check.
+    /// Test: `contains_after_register`.
+    pub fn contains(&self, name: &str) -> bool {
+        self.tools.contains_key(name)
+    }
+
+    /// Dispatch a named tool call.
+    ///
+    /// Why: Single place where missing-tool errors are surfaced as a structured
+    /// `ToolResult::Error` so the LLM loop can continue.
+    /// What: Looks up `name`, calls `execute(args)`, returns the `ToolResult`.
+    /// Test: Dispatch to an unregistered name returns `ToolResult::Error`;
+    /// dispatch to a registered one returns `ToolResult::Success`.
+    pub async fn dispatch(&self, name: &str, args: Value) -> ToolResult {
+        let Some(tool) = self.tools.get(name) else {
+            return ToolResult::err(format!("no tool registered with name '{name}'"));
+        };
+        tool.execute(args).await
+    }
+
+    /// Dispatch with an optional per-agent allowlist.
+    ///
+    /// Why: Per-agent tool gating prevents, e.g., the plan-agent from shelling
+    /// out or the research-agent from delegating. Allowlist is checked
+    /// centrally so every call site inherits the same policy.
+    /// What: If `allowed` is `Some` and does not contain `name`, returns a
+    /// recoverable `ToolResult::Error` naming what is permitted. Otherwise
+    /// delegates to `dispatch`.
+    /// Test: `dispatch_gated_rejects_disallowed`.
+    pub async fn dispatch_gated(
+        &self,
+        name: &str,
+        args: Value,
+        allowed: Option<&[String]>,
+    ) -> ToolResult {
+        if let Some(list) = allowed
+            && !list.iter().any(|a| a == name)
+        {
+            return ToolResult::err(format!(
+                "Tool '{name}' is not permitted for this agent. Allowed: {}",
+                list.join(", ")
+            ));
+        }
+        self.dispatch(name, args).await
+    }
+
+    /// Dispatch honoring a `UserIdentity`'s `ServiceTier`.
+    ///
+    /// Why: Some tools must be denied to less-trusted transports (Slack guest
+    /// users, unauthenticated HTTP) even if the LLM tries to call them.
+    /// Enforcing the tier check at the dispatch boundary means transport authors
+    /// can't accidentally bypass RBAC by forgetting to pre-filter the tool list.
+    /// What: If the tool is registered AND `user.can_access_tier` is `false`,
+    /// returns `ToolResult::Error`. Otherwise delegates to `dispatch_gated`.
+    /// Test: `dispatch_for_user_blocks_restricted_tier`.
+    pub async fn dispatch_for_user(
+        &self,
+        name: &str,
+        args: Value,
+        allowed: Option<&[String]>,
+        user: &UserIdentity,
+    ) -> ToolResult {
+        if let Some(tool) = self.tools.get(name)
+            && !user.can_access_tier(tool.restricted_tiers())
+        {
+            return ToolResult::err("This tool is not available for your access tier.");
+        }
+        self.dispatch_gated(name, args, allowed).await
+    }
+
+    /// Emit all registered tool schemas as raw JSON values.
+    ///
+    /// Why: The sub-agent tool-calling loop attaches raw JSON schemas to LLM
+    /// requests; the OpenAI-compatible schema is produced by each tool.
+    /// What: Collects `tool.schema()` for every registered tool.
+    /// Test: Registering two tools returns a vector of length 2.
+    pub fn schemas(&self) -> Vec<Value> {
+        self.tools.values().map(|t| t.schema()).collect()
+    }
+
+    /// Return the subset of registered tools that `user` may invoke.
+    ///
+    /// Why: Schema emission for the LLM request must reflect what the user can
+    /// actually call, otherwise the model will hallucinate denied calls.
+    /// What: Returns cloned `Arc`s for tools where `user.can_access_tier` is true.
+    /// Test: `filter_tools_for_user_drops_restricted`.
+    pub fn filter_tools_for_user(&self, user: &UserIdentity) -> Vec<Arc<dyn ToolExecutor>> {
+        self.tools
+            .values()
+            .filter(|t| user.can_access_tier(t.restricted_tiers()))
+            .cloned()
+            .collect()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
+
+    use super::ToolRegistry;
+    use crate::rbac::{ServiceTier, UserIdentity};
+    use crate::tools::traits::{ToolExecutor, ToolResult};
+
+    /// Minimal mock tool for registry tests.
+    struct MockTool {
+        name: &'static str,
+        restricted: Vec<ServiceTier>,
+    }
+
+    impl MockTool {
+        fn new(name: &'static str) -> Self {
+            Self {
+                name,
+                restricted: vec![],
+            }
+        }
+
+        fn restricted(mut self, tier: ServiceTier) -> Self {
+            self.restricted.push(tier);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl ToolExecutor for MockTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn schema(&self) -> Value {
+            json!({"type": "function", "function": {"name": self.name, "description": "mock"}})
+        }
+
+        async fn execute(&self, _args: Value) -> ToolResult {
+            ToolResult::ok(format!("mock-{} executed", self.name))
+        }
+
+        fn restricted_tiers(&self) -> &[ServiceTier] {
+            &self.restricted
+        }
+    }
+
+    /// A new registry has no tools.
+    ///
+    /// Why: Guard the baseline.
+    /// What: `new()` + `contains("any")` → false.
+    /// Test: This test.
+    #[test]
+    fn new_registry_is_empty() {
+        let reg = ToolRegistry::new();
+        assert!(!reg.contains("anything"));
+        assert!(reg.schemas().is_empty());
+    }
+
+    /// Registering a tool makes it findable.
+    ///
+    /// Why: Verify the basic register+contains contract.
+    /// What: Register "mock", then `contains("mock")` is true.
+    /// Test: This test.
+    #[test]
+    fn contains_after_register() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("mock")));
+        assert!(reg.contains("mock"));
+    }
+
+    /// Dispatch to an unknown tool returns a structured error.
+    ///
+    /// Why: The LLM loop must not panic or abort on a missing tool.
+    /// What: `dispatch("unknown", {})` returns `ToolResult::Error`.
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_unknown_returns_error() {
+        let reg = ToolRegistry::new();
+        let result = reg.dispatch("unknown", json!({})).await;
+        assert!(result.is_error());
+        assert!(result.content().contains("no tool registered"));
+    }
+
+    /// Dispatch to a registered tool returns its output.
+    ///
+    /// Why: Verify the happy-path dispatch contract.
+    /// What: Register "mock", dispatch to it, assert success content.
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_registered_tool_succeeds() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("mock")));
+        let result = reg.dispatch("mock", json!({})).await;
+        assert!(!result.is_error());
+        assert!(result.content().contains("mock-mock executed"));
+    }
+
+    /// `schemas()` returns one entry per registered tool.
+    ///
+    /// Why: Verify schema emission count.
+    /// What: Register two tools; `schemas()` returns 2 items.
+    /// Test: This test.
+    #[test]
+    fn schemas_returns_one_per_tool() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("tool_a")));
+        reg.register(Arc::new(MockTool::new("tool_b")));
+        assert_eq!(reg.schemas().len(), 2);
+    }
+
+    /// `dispatch_gated` rejects a tool not in the allowlist.
+    ///
+    /// Why: Per-agent allowlists must be enforced at dispatch.
+    /// What: Register "mock", call `dispatch_gated("mock", {}, Some(&["other"]))`,
+    /// expect error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_gated_rejects_disallowed() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("mock")));
+        let allowed = vec!["other".to_string()];
+        let result = reg.dispatch_gated("mock", json!({}), Some(&allowed)).await;
+        assert!(result.is_error());
+        assert!(result.content().contains("not permitted"));
+    }
+
+    /// `dispatch_gated` with `allowed = None` passes through.
+    ///
+    /// Why: `None` allowlist means no per-agent restriction.
+    /// What: `dispatch_gated("mock", {}, None)` calls through to dispatch.
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_gated_none_allowlist_permits() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("mock")));
+        let result = reg.dispatch_gated("mock", json!({}), None).await;
+        assert!(!result.is_error());
+    }
+
+    /// `dispatch_for_user` blocks a restricted tier.
+    ///
+    /// Why: RBAC must be enforced at dispatch.
+    /// What: Register a tool restricted to `[ReadOnly]`, dispatch as a
+    /// `ReadOnly` user, expect error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_for_user_blocks_restricted_tier() {
+        let mut reg = ToolRegistry::new();
+        let tool = MockTool::new("secret_tool").restricted(ServiceTier::ReadOnly);
+        reg.register(Arc::new(tool));
+
+        let user = UserIdentity::new("u1", "alice", ServiceTier::ReadOnly);
+        let result = reg
+            .dispatch_for_user("secret_tool", json!({}), None, &user)
+            .await;
+        assert!(result.is_error());
+        assert!(result.content().contains("access tier"));
+    }
+
+    /// `dispatch_for_user` allows an unrestricted tier.
+    ///
+    /// Why: `All` tier must pass unrestricted tools.
+    /// What: Register an unrestricted tool, dispatch as `All`, expect success.
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_for_user_allows_unrestricted() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("open_tool")));
+
+        let user = UserIdentity::default(); // tier = All
+        let result = reg
+            .dispatch_for_user("open_tool", json!({}), None, &user)
+            .await;
+        assert!(!result.is_error());
+    }
+
+    /// `filter_tools_for_user` drops tools that the user's tier is blocked for.
+    ///
+    /// Why: LLM should not see tools it cannot call.
+    /// What: Register one restricted and one open tool; filter for `ReadOnly`.
+    /// Expected: only the open tool survives.
+    /// Test: This test.
+    #[test]
+    fn filter_tools_for_user_drops_restricted() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("open")));
+        reg.register(Arc::new(
+            MockTool::new("restricted").restricted(ServiceTier::ReadOnly),
+        ));
+
+        let user = UserIdentity::new("u", "u", ServiceTier::ReadOnly);
+        let filtered = reg.filter_tools_for_user(&user);
+        assert_eq!(filtered.len(), 1, "only the open tool should survive");
+        assert_eq!(filtered[0].name(), "open");
+    }
+}

--- a/crates/trusty-code/src/tools/traits.rs
+++ b/crates/trusty-code/src/tools/traits.rs
@@ -1,0 +1,484 @@
+//! Core trait abstractions for tool execution, agent running, search, and skills.
+//!
+//! Why: DI through traits lets tcode swap concrete implementations (subprocess
+//! runner vs. in-process mock; Brave vs. Tavily search; fs skill store vs.
+//! embedded) without changing call sites. This is the SOA seam that keeps
+//! the workflow engine and PM loop testable.
+//! What: Defines `ToolExecutor`, `AgentRunner`, `SearchProvider`, and
+//! `SkillResolver`. All are object-safe (`dyn`-able) and `Send + Sync`.
+//! Test: Mock impls of each trait are constructed in unit tests for
+//! `ToolRegistry`, delegating commands, and related code.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ── ToolResult ──────────────────────────────────────────────────────────────
+
+/// Structured result of a tool execution.
+///
+/// Why: Hard-failing the LLM loop on every tool error is brittle — the model
+/// often can recover (retry with different args, fall back to another tool, or
+/// explain the failure in its final answer). A structured error lets the caller
+/// surface failure back to the LLM as a `tool_result` with `is_error: true`
+/// while keeping the loop running.
+/// What: `Success(String)` carries a successful textual result; `Error` carries
+/// a message plus a `recoverable` flag.
+/// Test: `ToolResult::err(...).is_error()` is true; `ok(...).content()` returns
+/// the success string. Exercised in `tools::registry` and delegate tests.
+#[derive(Debug)]
+pub enum ToolResult {
+    /// Tool executed successfully; inner string is the textual result.
+    Success(String),
+    /// Tool failed; `message` describes why; `recoverable` advises the LLM loop.
+    Error { message: String, recoverable: bool },
+}
+
+impl ToolResult {
+    /// Construct a successful result.
+    ///
+    /// Why: Single canonical happy-path constructor used by every tool.
+    /// What: Wraps `s` in `Success`.
+    /// Test: Trivially exercised by every successful tool execute().
+    pub fn ok(s: impl Into<String>) -> Self {
+        ToolResult::Success(s.into())
+    }
+
+    /// Construct a recoverable error.
+    ///
+    /// Why: Most tool failures are non-fatal — wrong arg, transient network,
+    /// empty result. The LLM should see the error and decide.
+    /// What: Wraps `msg` with `recoverable = true`.
+    /// Test: Exercised by delegate and registry tests.
+    pub fn err(msg: impl Into<String>) -> Self {
+        ToolResult::Error {
+            message: msg.into(),
+            recoverable: true,
+        }
+    }
+
+    /// Construct a fatal (non-recoverable) error.
+    ///
+    /// Why: Some failures (invariant violations, credential rejection) should
+    /// not be retried; callers should bail.
+    /// What: Wraps `msg` with `recoverable = false`.
+    /// Test: Checked by `is_fatal` predicates in tests.
+    pub fn fatal(msg: impl Into<String>) -> Self {
+        ToolResult::Error {
+            message: msg.into(),
+            recoverable: false,
+        }
+    }
+
+    /// Whether this result is an error variant.
+    ///
+    /// Why: Dispatch paths need a cheap predicate to log/branch on failure.
+    /// What: Returns `true` for any `Error`, `false` for `Success`.
+    /// Test: `ToolResult::err("x").is_error()` is true.
+    pub fn is_error(&self) -> bool {
+        matches!(self, ToolResult::Error { .. })
+    }
+
+    /// Whether this error is fatal (not recoverable). `false` for Success.
+    ///
+    /// Why: Callers that distinguish fatal-vs-recoverable need this to decide
+    /// whether to retry or bail.
+    /// What: True only for `Error { recoverable: false, .. }`.
+    /// Test: `ToolResult::fatal("x").is_fatal()` is true.
+    pub fn is_fatal(&self) -> bool {
+        matches!(
+            self,
+            ToolResult::Error {
+                recoverable: false,
+                ..
+            }
+        )
+    }
+
+    /// Extract the message string for both variants.
+    ///
+    /// Why: Callers like the LLM loop need the raw string regardless of
+    /// success/failure to pass back as `tool_result` content.
+    /// What: Returns the payload string for both `Success` and `Error`.
+    /// Test: `ToolResult::ok("hi").content()` == "hi";
+    ///       `ToolResult::err("oops").content()` == "oops".
+    pub fn content(&self) -> &str {
+        match self {
+            ToolResult::Success(s) => s.as_str(),
+            ToolResult::Error { message, .. } => message.as_str(),
+        }
+    }
+}
+
+// ── ToolExecutor ─────────────────────────────────────────────────────────────
+
+/// Access tiers controlling which users/transports may invoke a tool.
+///
+/// Why: tcode exposes tools over multiple surfaces (CLI, API, TUI). Some tools
+/// (memory writes, shell exec) are unsafe for untrusted callers. `ServiceTier`
+/// provides a stable ladder that tools can declare their restrictions against.
+/// What: Ordered by trust level — `All` is the highest-privilege tier.
+/// Test: `rbac::tests::*` cover tier matching logic.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTier {
+    /// Trusted operator — full tool access.
+    #[default]
+    All,
+    /// Analytics/reporting callers — read-heavy, no mutations.
+    Analytics,
+    /// Read-only callers — can only observe state.
+    ReadOnly,
+}
+
+/// Object-safe executor interface for a single named tool.
+///
+/// Why: Abstracts over all tool kinds (fs, shell, web search, delegate, MCP
+/// bridge) so the registry and dispatch loop are tool-agnostic. New tools drop
+/// in by implementing this trait without touching the PM loop.
+/// What: `name()` is the string key used in LLM function calls; `schema()`
+/// emits the JSON function descriptor; `execute(args)` performs the action.
+/// Test: `ToolRegistry` tests register a `MockTool` implementing this trait.
+#[async_trait]
+pub trait ToolExecutor: Send + Sync {
+    /// The tool's function name as exposed to the LLM.
+    fn name(&self) -> &str;
+
+    /// JSON schema describing the tool's parameters (OpenAI function format).
+    fn schema(&self) -> Value;
+
+    /// Execute the tool with the given JSON argument object.
+    async fn execute(&self, args: Value) -> ToolResult;
+
+    /// Access tiers that are **blocked** from calling this tool.
+    ///
+    /// Why: Tools declare which tiers they restrict; an empty list means
+    /// universally accessible. This inverted model means adding RBAC to
+    /// existing tools is a no-op by default.
+    /// What: Returns a slice of `ServiceTier` values that are NOT allowed.
+    /// Test: `rbac::tests::can_access_tier_*`.
+    fn restricted_tiers(&self) -> &[ServiceTier] {
+        &[]
+    }
+}
+
+// ── RunContext ───────────────────────────────────────────────────────────────
+
+/// Per-invocation context threaded from orchestrator to agent runner.
+///
+/// Why: Passing per-call directives (assigned file, turn budget, working dir)
+/// as a `RunContext` instead of via `std::env::set_var` is sound under
+/// multi-threaded tokio — env mutation is not thread-safe in Rust 2024.
+/// What: Carries optional overrides; runners apply them to child processes via
+/// `Command::env` / `Command::current_dir`.
+/// Test: Exercised in `AgentRunner` trait tests (`test_run_with_history_forwards_ctx`).
+#[derive(Debug, Default, Clone)]
+pub struct RunContext {
+    /// Path to scope any file-writing tool to for this call.
+    pub assigned_file: Option<PathBuf>,
+    /// Max-turns cap override for this invocation.
+    pub max_turns_override: Option<u32>,
+    /// Working directory for the subprocess.
+    pub working_dir: Option<PathBuf>,
+    /// LLM model override for this invocation.
+    pub model: Option<String>,
+}
+
+// ── AgentOutput ──────────────────────────────────────────────────────────────
+
+/// Structured output returned by an `AgentRunner`.
+///
+/// Why: Downstream phases need a concise `summary` for template substitution
+/// while also needing the full `content` for file extraction. Bundling them
+/// avoids separate trait methods.
+/// What: `content` is raw agent output; `summary` is the extracted `## Summary`
+/// section (or a prefix fallback).
+/// Test: Constructed from IPC result messages in integration paths.
+#[derive(Debug, Clone)]
+pub struct AgentOutput {
+    /// Raw output from the agent.
+    pub content: String,
+    /// Extracted summary (e.g. `## Summary` section), if present.
+    pub summary: Option<String>,
+    /// Aggregated LLM token usage for this invocation.
+    pub usage: crate::perf::TokenUsage,
+}
+
+impl AgentOutput {
+    /// Build from content alone; summary/usage will be defaults.
+    ///
+    /// Why: Convenience constructor for simple agent results.
+    /// What: Sets `content`, leaves `summary` None, `usage` zeroed.
+    /// Test: Used in mock runners throughout this crate's tests.
+    pub fn from_content(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            summary: None,
+            usage: crate::perf::TokenUsage::default(),
+        }
+    }
+
+    /// Return summary if present, else fall back to content.
+    ///
+    /// Why: Callers that want a short form for template injection should not
+    /// have to branch on `Option`.
+    /// What: Returns `&summary` if `Some`, otherwise `&content`.
+    /// Test: `agent_output_summary_or_content_fallback`.
+    pub fn summary_or_content(&self) -> &str {
+        self.summary.as_deref().unwrap_or(&self.content)
+    }
+}
+
+// ── AgentRunner ──────────────────────────────────────────────────────────────
+
+/// Runs a task against a named agent.
+///
+/// Why: Abstracts over how an agent is executed — subprocess, in-process, or
+/// mock. Lets tests avoid spawning real processes.
+/// What: `run(agent_name, task)` returns the agent's `AgentOutput`.
+/// `run_with_context` extends this to pass per-invocation overrides; the
+/// default forwards to `run()` so existing mock runners keep working.
+/// Test: `MockAgentRunner` in tests implements this; `test_run_with_history_forwards_ctx`
+/// verifies the default delegation chain.
+#[async_trait]
+pub trait AgentRunner: Send + Sync {
+    /// Run a task against the named agent.
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput>;
+
+    /// Run with per-invocation overrides in `ctx`.
+    ///
+    /// Why: Replaces `std::env::set_var` threading of per-call state. Default
+    /// impl ignores `ctx` and falls back to `run()` so legacy mock runners
+    /// keep working unchanged.
+    /// What: Concrete runners override this to scope env vars to the child.
+    /// Test: Wave-loop and runner tests prove context fields reach the child.
+    async fn run_with_context(
+        &self,
+        agent_name: &str,
+        task: &str,
+        _ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        self.run(agent_name, task).await
+    }
+
+    /// Run a task while forwarding prior session history.
+    ///
+    /// Why: Persistent-session agents need prior turns so the sub-agent can
+    /// rebuild context in a fresh subprocess.
+    /// What: Default delegates to `run_with_context(ctx)` so `working_dir`
+    /// and `model` are honoured even when the runner does not override this.
+    /// Test: `test_run_with_history_forwards_ctx`.
+    async fn run_with_history(
+        &self,
+        agent_name: &str,
+        task: &str,
+        _history: &[HistoryMessage],
+        ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        self.run_with_context(agent_name, task, ctx).await
+    }
+}
+
+// ── HistoryMessage ───────────────────────────────────────────────────────────
+
+/// A prior conversation turn forwarded to persistent-session agents.
+///
+/// Why: Persistent-session runners replay history on each subprocess restart
+/// so the sub-agent preserves conversational context.
+/// What: `role` is `"user"` or `"assistant"`; `content` is the turn text.
+/// Test: Used in `AgentRunner::run_with_history` signature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryMessage {
+    pub role: String,
+    pub content: String,
+}
+
+// ── SearchProvider ───────────────────────────────────────────────────────────
+
+/// A search hit returned by a `SearchProvider`.
+///
+/// Why: Uniform result type for web/code search so callers are provider-agnostic.
+/// What: `title`, `url`, `snippet` — the minimal useful set.
+/// Test: Used in `SearchProvider` mock tests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+}
+
+/// Web/code search backend abstraction.
+///
+/// Why: Swap Brave for Tavily / DuckDuckGo / a test stub by changing the
+/// registered impl — no callers change.
+/// What: `search(query, n)` returns up to `n` results.
+/// Test: A stub `SearchProvider` returns a fixed vector in mock tests.
+#[async_trait]
+pub trait SearchProvider: Send + Sync {
+    /// Run a search for `query` and return up to `n` results.
+    async fn search(&self, query: &str, n: usize) -> Result<Vec<SearchResult>>;
+}
+
+// ── SkillResolver ────────────────────────────────────────────────────────────
+
+/// Resolves named skills to their Markdown content.
+///
+/// Why: Skill sources vary (project `.claude/`, user `~/.claude/`, bundled
+/// config); callers should not care which.
+/// What: `resolve(name)` returns `Some(content)` if found. `list()` returns
+/// all discoverable names.
+/// Test: A `FsSkillResolver` in tests places a file in a tempdir and asserts
+/// `resolve()` returns its contents.
+pub trait SkillResolver: Send + Sync {
+    /// Look up a skill by name and return its Markdown content, if found.
+    fn resolve(&self, name: &str) -> Option<String>;
+    /// List all discoverable skill names.
+    fn list(&self) -> Vec<String>;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::perf::TokenUsage;
+
+    /// Mock runner that records the `RunContext` received in `run_with_context`.
+    ///
+    /// Why: We need to assert that the default `run_with_history` impl actually
+    /// forwards `ctx` to `run_with_context` (regression guard).
+    /// What: Records each ctx snapshot; `run` is unused in this test.
+    /// Test: `test_run_with_history_forwards_ctx`.
+    struct CtxCapture {
+        captured: Arc<Mutex<Vec<RunContext>>>,
+    }
+
+    #[async_trait]
+    impl AgentRunner for CtxCapture {
+        async fn run(&self, _agent_name: &str, _task: &str) -> Result<AgentOutput> {
+            Ok(AgentOutput::from_content("run"))
+        }
+
+        async fn run_with_context(
+            &self,
+            _agent_name: &str,
+            _task: &str,
+            ctx: &RunContext,
+        ) -> Result<AgentOutput> {
+            self.captured
+                .lock()
+                .expect("lock poisoned")
+                .push(ctx.clone());
+            Ok(AgentOutput::from_content("run_with_context"))
+        }
+        // NOTE: run_with_history is intentionally NOT overridden — we test the
+        // default impl defined in the trait.
+    }
+
+    /// Verifies that the default `run_with_history` forwards `ctx` to
+    /// `run_with_context` rather than dropping it.
+    ///
+    /// Why: Without this, persistent-session agents lose `working_dir` and
+    /// `model` when the default implementation falls through.
+    /// What: Calls `run_with_history` with specific `working_dir` and `model`,
+    /// then asserts `run_with_context` received those values.
+    /// Test: This test itself.
+    #[tokio::test]
+    async fn test_run_with_history_forwards_ctx() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = CtxCapture {
+            captured: captured.clone(),
+        };
+
+        let ctx = RunContext {
+            working_dir: Some(PathBuf::from("/tmp/test-wd")),
+            model: Some("anthropic/claude-opus-4-5".to_string()),
+            max_turns_override: Some(5),
+            assigned_file: None,
+        };
+
+        let out = runner
+            .run_with_history("test-agent", "do something", &[], &ctx)
+            .await
+            .expect("run_with_history should succeed");
+
+        assert_eq!(
+            out.content, "run_with_context",
+            "default run_with_history must call run_with_context, not run()"
+        );
+
+        let snaps = captured.lock().expect("lock poisoned");
+        assert_eq!(
+            snaps.len(),
+            1,
+            "run_with_context must be called exactly once"
+        );
+
+        let recorded = &snaps[0];
+        assert_eq!(
+            recorded.working_dir,
+            Some(PathBuf::from("/tmp/test-wd")),
+            "working_dir must be forwarded"
+        );
+        assert_eq!(
+            recorded.model,
+            Some("anthropic/claude-opus-4-5".to_string()),
+            "model must be forwarded"
+        );
+        assert_eq!(
+            recorded.max_turns_override,
+            Some(5),
+            "max_turns_override must be forwarded"
+        );
+    }
+
+    /// Verify `ToolResult` predicates and content accessor.
+    ///
+    /// Why: Guard the semantics of `is_error`, `is_fatal`, and `content`.
+    /// What: Constructs each variant and checks all three predicates.
+    /// Test: This test itself.
+    #[test]
+    fn tool_result_predicates() {
+        let ok = ToolResult::ok("hello");
+        assert!(!ok.is_error());
+        assert!(!ok.is_fatal());
+        assert_eq!(ok.content(), "hello");
+
+        let err = ToolResult::err("oops");
+        assert!(err.is_error());
+        assert!(!err.is_fatal());
+        assert_eq!(err.content(), "oops");
+
+        let fatal = ToolResult::fatal("crash");
+        assert!(fatal.is_error());
+        assert!(fatal.is_fatal());
+        assert_eq!(fatal.content(), "crash");
+    }
+
+    /// Verify `AgentOutput::summary_or_content` fallback.
+    ///
+    /// Why: Callers rely on this to get a short form without branching.
+    /// What: `summary=Some` returns summary; `summary=None` returns content.
+    /// Test: This test itself.
+    #[test]
+    fn agent_output_summary_or_content_fallback() {
+        let with_summary = AgentOutput {
+            content: "full content".into(),
+            summary: Some("short summary".into()),
+            usage: TokenUsage::default(),
+        };
+        assert_eq!(with_summary.summary_or_content(), "short summary");
+
+        let no_summary = AgentOutput::from_content("just content");
+        assert_eq!(no_summary.summary_or_content(), "just content");
+    }
+}


### PR DESCRIPTION
## Summary

Implements three sequential phases of the trusty-code (tcode) extraction campaign — tools layer (#641), agents/LLM layer (#642), and the `tcode run-task` public entry point (#645) — all in one independently mergeable PR.

### Phase 2 — Tools layer (closes #641)

- **`tools::traits`** — `ToolExecutor`, `AgentRunner` (with `run_with_context`/`run_with_history`), `RunContext`, `AgentOutput`, `SearchProvider`, `SkillResolver`, `ToolResult`, `ServiceTier`, `HistoryMessage`. Clean, open-mpm-independent implementations; no cargo dep on open-mpm.
- **`tools::registry`** — `ToolRegistry`: HashMap dispatcher with `register`, `dispatch`, `dispatch_gated` (per-agent allowlist), `dispatch_for_user` (RBAC tier), `schemas`, `filter_tools_for_user`.
- **`tools::delegate`** — `DelegateToAgentTool`: pre-flight agent-name validation against the config dir + `AgentRunner` dispatch.
- **`rbac`** — `UserIdentity`, `ServiceTier` (re-exported from `tools::traits`), `filter_tools_for_user`. Mirrors the open-mpm RBAC surface without the dependency.

### Phase 3 — Agents + LLM layer (closes #642)

- **`agents::config`** — `AgentConfig` TOML schema: `AgentInfo`, `LlmParams`, `SystemPrompt`, `ToolsConfig`, `RunnerConfig`, `RunnerKind`. Deserializable from `.claude/agents/<name>.toml` (Claude Code sub-agent format).
- **`agents::mod`** — `discover_agents` (sorted `(name, path)` pairs from a dir), `load_all_agents` (skips bad configs with a WARN log).
- **`identity`** — `CallerIdentity` enum (`Ctrl`/`Pm`/`Agent`), `RecallCeiling`, `auto_tags`, `max_recall_scope`, `session_id`, `from_env` (env-var constructor for subprocess identity injection).
- **`logging`** — `init_tracing`, `init_tracing_for_test` (idempotent), `DEFAULT_LOG_LEVEL`.

### Phase 6 — Public API + CLI entry points (closes #645)

- `tcode run-task <agent> <task> [--project PATH]` is now **functional**: locates `.claude/agents/<agent>.toml` (falls back to `.open-mpm/agents` for open-mpm-compatible projects), validates the config, and emits a structured JSON status line to stdout.
- `tcode serve` and `tcode run-workflow` remain stubs (Phase 5 work — the per-project socket server and workflow engine have not been extracted yet).
- `lib.rs` updated with Why/What/Test module docs for all new modules.
- `Cargo.toml` adds `async-trait` and `toml` workspace dependencies.

## Deferred scope

- `tcode run-task` currently validates agent config and returns a `{"status":"ready", ...}` JSON line; it does NOT yet spawn the agent subprocess. That requires the subprocess runner from open-mpm's `agents::claude_code_runner`/`SubprocessAgentRunner` (Phase 3b/5 work — tracked in the phase decomposition on #587).
- `tcode serve` (per-project IPC socket server) — Phase 5.
- `tcode run-workflow` (full workflow engine) — Phase 5.
- LLM stack (OpenRouter/Bedrock adapters) — Phase 3b/5.
- Skills/context/session modules — Phase 4.

## Test plan

- [x] `cargo test -p trusty-code` — 179 tests, all green
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p trusty-code` — clean
- [x] `bash scripts/check_line_cap.sh` — exit 0 (171 allowlisted, 0 violations)
- [x] Pre-commit hooks all passed on commit

Closes #641, #642, #645. Part of epic #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)