### PR TITLE
fix(trusty-memory): guard pid_alive against out-of-range PIDs to prevent stale-lock reclaim failure

### DIFF
--- a/crates/trusty-memory/src/commands/daemon_lock.rs
+++ b/crates/trusty-memory/src/commands/daemon_lock.rs
@@ -91,15 +91,36 @@ pub fn lock_file_path() -> Option<PathBuf> {
 ///
 /// Why: `kill -0 <pid>` returns success when the process exists (regardless
 /// of whether we have permission to signal it) and `ESRCH` when it does not
-/// exist. Using the shell rather than `nix` keeps the dependency surface
-/// minimal, matching the pattern used by `commands::stop`.
-/// What: runs `/bin/kill -0 <pid>` and returns `true` iff the exit code is 0.
+/// exist. However, the shell `kill` utility parses PID strings as signed
+/// 32-bit integers on many Linux implementations, so passing a value greater
+/// than `i32::MAX` (e.g. `u32::MAX` = 4,294,967,295) causes a signed overflow
+/// to -1. On Linux, `kill -0 -1` sends signal 0 to every process the caller
+/// may signal — a broadcast that always succeeds — causing `pid_alive` to
+/// return `true` for a nonexistent PID. A PID of 0 has similar process-group
+/// semantics. Neither 0 nor any value above `i32::MAX` can be a valid user
+/// process PID on any 32- or 64-bit Unix, so we guard against both before
+/// calling `kill`.
+/// What: returns `false` immediately for `pid == 0` or `pid > i32::MAX` (no
+/// `kill` call, no signed-overflow risk). For valid positive PIDs in
+/// `1..=i32::MAX`, runs `kill -0 <pid>` and returns `true` iff exit code is 0.
 /// On non-Unix platforms always returns `false` (stale lock is reclaimed).
-/// Test: `pid_alive_returns_false_for_nonexistent_pid` (uses a PID that is
-/// guaranteed not to exist).
+/// Test: `pid_alive_returns_false_for_pid_zero` (asserts `false` for
+/// `u32::MAX` and `0` without calling `kill`);
+/// `pid_alive_returns_true_for_current_pid` (asserts `true` for a known-live
+/// PID); `acquire_lock_reclaims_stale_pid` (end-to-end stale-lock reclaim).
 pub fn pid_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
+        // Guard: PID 0 targets the current process group and PID values above
+        // i32::MAX overflow to negative numbers when parsed by the shell `kill`
+        // binary (which reads its argument as a signed 32-bit integer on Linux).
+        // A negative argument to `kill -0` signals a process group, not an
+        // individual process, so it may spuriously succeed. Neither 0 nor any
+        // value > i32::MAX can represent a real user process on any supported
+        // platform, so we short-circuit here without calling `kill`.
+        if pid == 0 || pid > i32::MAX as u32 {
+            return false;
+        }
         std::process::Command::new("kill")
             .arg("-0")
             .arg(pid.to_string())
@@ -308,21 +329,27 @@ mod tests {
         );
     }
 
-    /// Why: a PID that is guaranteed not to exist on any modern OS (PID 0
-    /// is the scheduler, never a user process) should be reported as dead.
-    /// What: asserts `pid_alive(0)` returns `false`.
-    /// Test: itself.
+    /// Why: out-of-range PIDs (0 and values > i32::MAX) must return `false`
+    /// WITHOUT calling `kill`, because the shell `kill` binary parses its PID
+    /// argument as a signed 32-bit integer on Linux. Passing u32::MAX
+    /// (4,294,967,295) overflows to -1, and `kill -0 -1` broadcasts to all
+    /// signable processes — always succeeding and falsely reporting the PID as
+    /// alive. PID 0 has similar process-group semantics. The guard in
+    /// `pid_alive` rejects both without invoking `kill`.
+    /// What: asserts `pid_alive(u32::MAX)` and `pid_alive(0)` both return
+    /// `false` deterministically, independent of what processes are running.
+    /// Test: itself (no `kill` call for either value — pure guard logic).
     #[cfg(unix)]
     #[test]
     fn pid_alive_returns_false_for_pid_zero() {
-        // PID 0 is the scheduler; kill -0 0 sends to the current process
-        // group, not PID 0. Use u32::MAX as a guaranteed-nonexistent PID.
-        // On Linux the max PID is 4,194,304; on macOS it is 99,999. Neither
-        // reaches u32::MAX so this PID cannot exist.
+        // u32::MAX (4,294,967,295): would overflow to -1 on Linux shell `kill`,
+        // causing kill(-1, 0) to broadcast — must be rejected by the guard.
         assert!(
             !pid_alive(u32::MAX),
             "PID u32::MAX cannot be alive on any real system"
         );
+        // PID 0: process-group sentinel, never a real user process.
+        assert!(!pid_alive(0), "PID 0 is never a live user process");
     }
 
     // ── acquire_lock ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause**: `pid_alive(u32::MAX)` incorrectly returned `true` on Linux CI, causing the stale-lock reclaim path in `acquire_lock` to refuse instead of reclaim.
- **Mechanism**: The shell `kill` binary on Linux parses its PID argument as a signed 32-bit integer. `u32::MAX` = 4,294,967,295 overflows `i32` to **-1**. `kill -0 -1` broadcasts signal 0 to every process the caller may signal — always succeeding — so `pid_alive` returned `true` for a PID that cannot exist. PID 0 has similar process-group-broadcast semantics.
- **Fix**: Add an upfront guard in `pid_alive` that returns `false` immediately for `pid == 0` or `pid > i32::MAX` without calling `kill`. Normal valid PIDs in `1..=i32::MAX` continue to use `kill -0` as before. No new dependencies.

## Failing tests (now green)

```
commands::daemon_lock::tests::pid_alive_returns_false_for_pid_zero   ✓
commands::daemon_lock::tests::acquire_lock_reclaims_stale_pid        ✓
```

## Production impact

A lock file containing a corrupt or adversarially-crafted PID value ≥ `i32::MAX` would have permanently blocked daemon startup without operator intervention (`rm daemon.lock`). The guard makes such values always treated as stale and reclaimed automatically.

## Changes

- `crates/trusty-memory/src/commands/daemon_lock.rs`: guard `pid_alive` against `pid == 0 || pid > i32::MAX`; extend `pid_alive_returns_false_for_pid_zero` test to assert both `u32::MAX` and `0` return false; update Why/What/Test docstring.

## Test plan

- [x] `cargo test -p trusty-memory -- commands::daemon_lock` — 10/10 pass
- [x] `cargo test -p trusty-memory` — all tests pass
- [x] `cargo clippy -p trusty-memory -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — no drift
- [x] `bash scripts/check_line_cap.sh` — 0 violations

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)