### PR TITLE
fix(trusty-review): raise inference health-probe timeout for Bedrock cold-start (closes #739)

### DIFF
--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -241,15 +241,25 @@ pub struct ReviewRequest {
 /// and the MCP tool path, and it only considered `inference` — not required-dep
 /// reachability.  This helper centralises the rule so both paths are consistent
 /// and #722 is fixed: a required dep that is unreachable degrades status.
-/// What: returns `"ok"` only when `inference.is_ok()` AND every dep with
-/// `required == true` also has `reachable == true`.  Returns `"degraded"` if
-/// either condition fails.  Non-required deps never influence the result.
+/// `Unknown` inference (probe timed out) does NOT degrade status (#739):
+/// a slow Bedrock cold-start must not falsely report "degraded" — the operator's
+/// real review calls have a ~300 s budget, far beyond the probe window.
+/// What: returns `"ok"` only when `inference` is `Ok` or `Unknown` (timed-out
+/// probe — could not confirm but not a hard failure) AND every dep with
+/// `required == true` also has `reachable == true`.  Returns `"degraded"` when
+/// inference is `Unreachable` or `AuthError` OR a required dep is unreachable.
+/// Non-required deps never influence the result.
 /// Test: `health_status_ok_all_good`, `health_status_degraded_required_dep_down`,
 /// `health_status_degraded_inference_auth_error`,
-/// `health_status_ok_optional_dep_down` in `handlers_tests.rs`.
+/// `health_status_ok_optional_dep_down`,
+/// `health_status_ok_inference_unknown` in `handlers_status_tests.rs`.
 pub fn compute_status(inference: InferenceStatus, deps: &DepStatus) -> &'static str {
     let required_deps_ok = deps.trusty_search.reachable || !deps.trusty_search.required;
-    if inference.is_ok() && required_deps_ok {
+    // `Unknown` (probe timed out) is treated the same as `Ok` for the purpose of
+    // computing the top-level status: we do not degrade because we couldn't confirm
+    // reachability within the probe window (#739).
+    let inference_ok = inference.is_ok() || inference == InferenceStatus::Unknown;
+    if inference_ok && required_deps_ok {
         "ok"
     } else {
         "degraded"
@@ -265,12 +275,15 @@ pub fn compute_status(inference: InferenceStatus, deps: &DepStatus) -> &'static 
 /// gate whether to attempt a `review_pr` call (closes #719).
 /// What: performs non-blocking health probes against trusty-search and
 /// trusty-analyze (both via `.health()` on the trait objects); runs the cached
-/// inference-reachability probe (10 s TTL, 3 s timeout) against the configured
-/// LLM provider; returns JSON with dep status, reviewer model, and inference
-/// result.  HTTP 200 always (degraded state is noted in the body, not via 5xx,
-/// to avoid false-positive load-balancer evictions).  When inference is not
-/// `"ok"` OR a required dep is unreachable, `status` becomes `"degraded"` so
-/// callers can gate on one field.
+/// inference-reachability probe (10 s TTL, timeout configurable via
+/// `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS`, default 10 s — see #739) against the
+/// configured LLM provider; returns JSON with dep status, reviewer model, and
+/// inference result.  HTTP 200 always (degraded state is noted in the body,
+/// not via 5xx, to avoid false-positive load-balancer evictions).  When
+/// inference is `"unreachable"` or `"auth_error"` OR a required dep is
+/// unreachable, `status` becomes `"degraded"`.  A probe timeout returns
+/// `"unknown"` (not `"degraded"`) so a slow Bedrock cold-start does not
+/// falsely degrade status (#739).
 /// Test: `health_inference_ok_when_llm_ok`,
 /// `health_inference_auth_error_sets_degraded`,
 /// `health_required_dep_down_sets_degraded`,

--- a/crates/trusty-review/src/service/handlers_status_tests.rs
+++ b/crates/trusty-review/src/service/handlers_status_tests.rs
@@ -94,6 +94,35 @@ fn health_status_degraded_inference_auth_error() {
     );
 }
 
+/// compute_status stays "ok" when inference is `Unknown` (probe timed out) (#739).
+///
+/// Why: a slow Bedrock cold-start causes the probe to time out and return
+/// `Unknown`.  This must NOT degrade health — real review calls have a much
+/// longer budget than the probe window.  The probe reports "could not confirm"
+/// rather than "definitely unreachable", so the top-level status should not
+/// penalise the operator.
+/// What: calls compute_status with Unknown inference + all deps reachable;
+/// asserts "ok".
+/// Test: this test itself.
+#[test]
+fn health_status_ok_inference_unknown() {
+    let deps = DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: true,
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: true,
+        },
+    };
+    assert_eq!(
+        compute_status(InferenceStatus::Unknown, &deps),
+        "ok",
+        "Unknown inference (probe timed out) must not degrade status (#739)"
+    );
+}
+
 /// compute_status stays "ok" when only a non-required dep is unreachable (#722).
 ///
 /// Why: a non-required dep being down must NOT degrade status — only required deps matter.

--- a/crates/trusty-review/src/service/inference_probe.rs
+++ b/crates/trusty-review/src/service/inference_probe.rs
@@ -8,9 +8,13 @@
 //!
 //! What: `InferenceProbe` wraps a short-TTL cache (default 10 s) around a
 //! minimal real LLM call (max_tokens=1).  The cache means repeated `/health`
-//! polls don't hammer the provider; a 3 s timeout means a hung endpoint can't
-//! stall health checks.  `InferenceStatus` maps provider errors to the four
-//! states: `ok`, `unreachable`, `auth_error`, `unknown`.
+//! polls don't hammer the provider.  The per-probe timeout is configurable via
+//! `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS` (default 10 s, see #739); a timed-out
+//! probe returns `Unknown` rather than `Unreachable` so a slow Bedrock cold-start
+//! does not falsely degrade health — real review calls have a ~300 s budget, so
+//! a probe timeout should not be treated as a hard unreachability signal.
+//! `InferenceStatus` maps provider errors to the four states: `ok`,
+//! `unreachable`, `auth_error`, `unknown`.
 //!
 //! Test: `probe_status_*` unit tests in this module inject stub providers and
 //! verify each status transition. Live credential tests are separate (ignored).
@@ -20,6 +24,35 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+
+// ─── Configurable timeout helper ─────────────────────────────────────────────
+
+/// Return the per-probe hard timeout, consulting `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS`.
+///
+/// Why: AWS Bedrock cold-starts were measured at ~7.4 s (#739), which exceeded
+/// the previous hard-coded 3 s timeout and caused spurious `unreachable` /
+/// `degraded` health results.  Making the timeout configurable lets operators
+/// tune it without recompiling; 10 s comfortably covers observed cold-start
+/// latency while still bounding health-check latency.
+/// What: reads `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS` from the environment; parses
+/// it as a `u64`; falls back to `DEFAULT_HEALTH_TIMEOUT_SECS` (10) on any
+/// parse failure or if the variable is unset.  A value of 0 is treated as
+/// "use default" to prevent an accidentally zero timeout from hanging forever.
+/// Test: `health_probe_timeout_default`, `health_probe_timeout_env_override`,
+/// `health_probe_timeout_env_invalid_falls_back`,
+/// `health_probe_timeout_env_zero_falls_back` in the `tests` module.
+pub fn health_probe_timeout() -> Duration {
+    const DEFAULT_HEALTH_TIMEOUT_SECS: u64 = 10;
+    const ENV_VAR: &str = "TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS";
+
+    let secs = std::env::var(ENV_VAR)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .unwrap_or(DEFAULT_HEALTH_TIMEOUT_SECS);
+
+    Duration::from_secs(secs)
+}
 
 #[cfg(test)]
 use crate::llm::LlmResponse;
@@ -117,14 +150,18 @@ pub struct InferenceProbe {
 }
 
 impl Default for InferenceProbe {
-    /// Default TTL is 10 seconds; probe timeout is 3 seconds.
+    /// Default TTL is 10 seconds; probe timeout reads `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS` (default 10 s).
     ///
-    /// Why: matches the design brief — 10 s prevents hammering providers on
-    /// repeated health polls; 3 s ensures a hung endpoint doesn't stall /health.
-    /// What: returns an `InferenceProbe` with `ttl=10s`, `probe_timeout=3s`.
+    /// Why: the previous hard-coded 3 s timeout was shorter than observed AWS
+    /// Bedrock cold-start latency (~7.4 s), causing spurious `unreachable` /
+    /// `degraded` health results (#739).  The timeout is now 10 s by default and
+    /// configurable via `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS` so operators can tune
+    /// it without recompiling.
+    /// What: returns an `InferenceProbe` with `ttl=10s` and `probe_timeout` from
+    /// `health_probe_timeout()`.
     /// Test: `probe_default_starts_unknown`.
     fn default() -> Self {
-        Self::new(Duration::from_secs(10), Duration::from_secs(3))
+        Self::new(Duration::from_secs(10), health_probe_timeout())
     }
 }
 
@@ -188,8 +225,12 @@ impl InferenceProbe {
 /// What: sends a 1-token completion with a trivial prompt through the provider;
 /// maps any error to `InferenceStatus` via `map_llm_error`.  The call is
 /// wrapped in `tokio::time::timeout` so a hung endpoint never stalls /health.
+/// A timeout returns `Unknown` rather than `Unreachable` (#739): the probe
+/// budget is much shorter than the real review budget (~300 s), so a slow
+/// cold-start should not be reported as "endpoint unreachable" — it is simply
+/// "could not confirm reachability within the probe window".
 /// Test: `probe_returns_ok_on_success`, `probe_returns_auth_error_on_access_denied`,
-/// `probe_returns_unreachable_on_transport`, `probe_respects_timeout`.
+/// `probe_returns_unreachable_on_transport`, `probe_timeout_returns_unknown`.
 async fn run_probe(llm: &Arc<dyn LlmProvider>, model: &str, timeout: Duration) -> InferenceStatus {
     let req = LlmRequest {
         model: model.to_string(),
@@ -206,10 +247,12 @@ async fn run_probe(llm: &Arc<dyn LlmProvider>, model: &str, timeout: Duration) -
     let result = tokio::time::timeout(timeout, llm.complete(req)).await;
 
     match result {
-        // Timed out → endpoint unreachable / hung.
+        // Timed out → could not confirm reachability within the probe window.
+        // Use `Unknown` (not `Unreachable`) so a slow Bedrock cold-start does not
+        // falsely degrade health (#739).  Real review calls have a ~300 s budget.
         Err(_elapsed) => {
-            debug!("inference probe: timed out");
-            InferenceStatus::Unreachable
+            debug!("inference probe: timed out — returning Unknown (not Unreachable)");
+            InferenceStatus::Unknown
         }
         // Call completed — check the inner result.
         Ok(Ok(_)) => InferenceStatus::Ok,
@@ -221,255 +264,10 @@ async fn run_probe(llm: &Arc<dyn LlmProvider>, model: &str, timeout: Duration) -
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
+// Split into a sibling file to keep this file under the 500-line cap (#610).
+// The sibling file is included as the module body via `#[path = ...]` so it
+// has full access to private items (`run_probe`, etc.) just as inline tests would.
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use async_trait::async_trait;
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    // ── Stub providers ────────────────────────────────────────────────────────
-
-    struct OkLlm;
-
-    #[async_trait]
-    impl LlmProvider for OkLlm {
-        fn name(&self) -> &str {
-            "ok-stub"
-        }
-
-        async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
-            Ok(LlmResponse {
-                text: "hi".to_string(),
-                model: req.model.clone(),
-                input_tokens: 1,
-                output_tokens: 1,
-                latency_ms: 0,
-                cost_usd: 0.0,
-            })
-        }
-    }
-
-    struct AuthErrorLlm;
-
-    #[async_trait]
-    impl LlmProvider for AuthErrorLlm {
-        fn name(&self) -> &str {
-            "auth-error-stub"
-        }
-
-        async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
-            Err(LlmError::AccessDenied("invalid api key".into()))
-        }
-    }
-
-    struct TransportErrorLlm;
-
-    #[async_trait]
-    impl LlmProvider for TransportErrorLlm {
-        fn name(&self) -> &str {
-            "transport-stub"
-        }
-
-        async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
-            Err(LlmError::Transport("connection refused".into()))
-        }
-    }
-
-    struct HungLlm;
-
-    #[async_trait]
-    impl LlmProvider for HungLlm {
-        fn name(&self) -> &str {
-            "hung-stub"
-        }
-
-        async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
-            // Simulate an endpoint that never responds within the probe timeout.
-            tokio::time::sleep(Duration::from_secs(60)).await;
-            Err(LlmError::Transport("hung".into()))
-        }
-    }
-
-    /// A counting stub to verify the cache prevents redundant probes.
-    struct CountingLlm {
-        calls: Arc<AtomicU32>,
-    }
-
-    #[async_trait]
-    impl LlmProvider for CountingLlm {
-        fn name(&self) -> &str {
-            "counting-stub"
-        }
-
-        async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
-            self.calls.fetch_add(1, Ordering::Relaxed);
-            Ok(LlmResponse {
-                text: "x".into(),
-                model: req.model.clone(),
-                input_tokens: 1,
-                output_tokens: 1,
-                latency_ms: 0,
-                cost_usd: 0.0,
-            })
-        }
-    }
-
-    // ── InferenceStatus tests ─────────────────────────────────────────────────
-
-    #[test]
-    fn probe_status_serialises_lowercase() {
-        assert_eq!(
-            serde_json::to_string(&InferenceStatus::Ok).unwrap(),
-            "\"ok\""
-        );
-        assert_eq!(
-            serde_json::to_string(&InferenceStatus::Unreachable).unwrap(),
-            "\"unreachable\""
-        );
-        assert_eq!(
-            serde_json::to_string(&InferenceStatus::AuthError).unwrap(),
-            "\"auth_error\""
-        );
-        assert_eq!(
-            serde_json::to_string(&InferenceStatus::Unknown).unwrap(),
-            "\"unknown\""
-        );
-    }
-
-    #[test]
-    fn probe_status_is_ok() {
-        assert!(InferenceStatus::Ok.is_ok());
-        assert!(!InferenceStatus::Unreachable.is_ok());
-        assert!(!InferenceStatus::AuthError.is_ok());
-        assert!(!InferenceStatus::Unknown.is_ok());
-    }
-
-    // ── Error mapping tests ───────────────────────────────────────────────────
-
-    #[test]
-    fn error_mapping_access_denied_is_auth_error() {
-        let status = map_llm_error(&LlmError::AccessDenied("denied".into()));
-        assert_eq!(status, InferenceStatus::AuthError);
-    }
-
-    #[test]
-    fn error_mapping_model_not_found_is_auth_error() {
-        let status = map_llm_error(&LlmError::ModelNotFound("no-model".into()));
-        assert_eq!(status, InferenceStatus::AuthError);
-    }
-
-    #[test]
-    fn error_mapping_model_not_ready_is_auth_error() {
-        let status = map_llm_error(&LlmError::ModelNotReady("creating".into()));
-        assert_eq!(status, InferenceStatus::AuthError);
-    }
-
-    #[test]
-    fn error_mapping_validation_is_auth_error() {
-        let status = map_llm_error(&LlmError::Validation("bad prefix".into()));
-        assert_eq!(status, InferenceStatus::AuthError);
-    }
-
-    #[test]
-    fn error_mapping_transport_is_unreachable() {
-        let status = map_llm_error(&LlmError::Transport("connection refused".into()));
-        assert_eq!(status, InferenceStatus::Unreachable);
-    }
-
-    #[test]
-    fn error_mapping_rate_limited_is_unreachable() {
-        let status = map_llm_error(&LlmError::RateLimited);
-        assert_eq!(status, InferenceStatus::Unreachable);
-    }
-
-    #[test]
-    fn error_mapping_upstream_5xx_is_unreachable() {
-        let status = map_llm_error(&LlmError::Upstream {
-            status: 503,
-            body: "overloaded".into(),
-        });
-        assert_eq!(status, InferenceStatus::Unreachable);
-    }
-
-    // ── Live probe tests ──────────────────────────────────────────────────────
-
-    #[tokio::test]
-    async fn probe_returns_ok_on_success() {
-        let llm: Arc<dyn LlmProvider> = Arc::new(OkLlm);
-        let status = run_probe(&llm, "test-model", Duration::from_secs(5)).await;
-        assert_eq!(status, InferenceStatus::Ok);
-    }
-
-    #[tokio::test]
-    async fn probe_returns_auth_error_on_access_denied() {
-        let llm: Arc<dyn LlmProvider> = Arc::new(AuthErrorLlm);
-        let status = run_probe(&llm, "test-model", Duration::from_secs(5)).await;
-        assert_eq!(status, InferenceStatus::AuthError);
-    }
-
-    #[tokio::test]
-    async fn probe_returns_unreachable_on_transport() {
-        let llm: Arc<dyn LlmProvider> = Arc::new(TransportErrorLlm);
-        let status = run_probe(&llm, "test-model", Duration::from_secs(5)).await;
-        assert_eq!(status, InferenceStatus::Unreachable);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn probe_respects_timeout() {
-        // The HungLlm sleeps 60 s; the probe timeout is 10 ms.
-        // With paused clock, `tokio::time::sleep` returns instantly when
-        // the runtime advances time; `timeout` fires before HungLlm wakes.
-        let llm: Arc<dyn LlmProvider> = Arc::new(HungLlm);
-        let status = run_probe(&llm, "test-model", Duration::from_millis(10)).await;
-        assert_eq!(
-            status,
-            InferenceStatus::Unreachable,
-            "hung endpoint must produce Unreachable"
-        );
-    }
-
-    // ── Cache TTL tests ───────────────────────────────────────────────────────
-
-    #[tokio::test]
-    async fn probe_cache_prevents_redundant_calls() {
-        let calls = Arc::new(AtomicU32::new(0));
-        let llm: Arc<dyn LlmProvider> = Arc::new(CountingLlm {
-            calls: Arc::clone(&calls),
-        });
-
-        // Long TTL: 60 s — the cache should remain warm across both calls.
-        let probe = InferenceProbe::new(Duration::from_secs(60), Duration::from_secs(5));
-
-        let s1 = probe.probe(&llm, "m").await;
-        let s2 = probe.probe(&llm, "m").await;
-
-        assert_eq!(s1, InferenceStatus::Ok);
-        assert_eq!(s2, InferenceStatus::Ok);
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            1,
-            "provider must be called exactly once when cache is warm"
-        );
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn probe_cache_ttl_zero_always_reprobes() {
-        let calls = Arc::new(AtomicU32::new(0));
-        let llm: Arc<dyn LlmProvider> = Arc::new(CountingLlm {
-            calls: Arc::clone(&calls),
-        });
-
-        // TTL of 0 means the cache always looks stale.
-        let probe = InferenceProbe::new(Duration::ZERO, Duration::from_secs(5));
-
-        probe.probe(&llm, "m").await;
-        probe.probe(&llm, "m").await;
-
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            2,
-            "zero TTL must reprobe on every call"
-        );
-    }
-}
+#[path = "inference_probe_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/service/inference_probe_tests.rs
+++ b/crates/trusty-review/src/service/inference_probe_tests.rs
@@ -1,0 +1,345 @@
+//! Unit tests for `service::inference_probe`.
+//!
+//! Why: split from `inference_probe.rs` to keep that file under the 500-line
+//! cap (#610) while preserving full coverage of the probe logic, error mapping,
+//! cache TTL, and the configurable timeout helper (#739).
+//! What: exercises `InferenceStatus`, `map_llm_error`, `run_probe`,
+//! `InferenceProbe`, and `health_probe_timeout` via stub `LlmProvider` impls.
+//! Test: this is the test module; every function is a self-contained test.
+
+use super::*;
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+// ── Stub providers ────────────────────────────────────────────────────────
+
+struct OkLlm;
+
+#[async_trait]
+impl LlmProvider for OkLlm {
+    fn name(&self) -> &str {
+        "ok-stub"
+    }
+
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Ok(LlmResponse {
+            text: "hi".to_string(),
+            model: req.model.clone(),
+            input_tokens: 1,
+            output_tokens: 1,
+            latency_ms: 0,
+            cost_usd: 0.0,
+        })
+    }
+}
+
+struct AuthErrorLlm;
+
+#[async_trait]
+impl LlmProvider for AuthErrorLlm {
+    fn name(&self) -> &str {
+        "auth-error-stub"
+    }
+
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Err(LlmError::AccessDenied("invalid api key".into()))
+    }
+}
+
+struct TransportErrorLlm;
+
+#[async_trait]
+impl LlmProvider for TransportErrorLlm {
+    fn name(&self) -> &str {
+        "transport-stub"
+    }
+
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Err(LlmError::Transport("connection refused".into()))
+    }
+}
+
+struct HungLlm;
+
+#[async_trait]
+impl LlmProvider for HungLlm {
+    fn name(&self) -> &str {
+        "hung-stub"
+    }
+
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        // Simulate an endpoint that never responds within the probe timeout.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        Err(LlmError::Transport("hung".into()))
+    }
+}
+
+/// A counting stub to verify the cache prevents redundant probes.
+struct CountingLlm {
+    calls: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl LlmProvider for CountingLlm {
+    fn name(&self) -> &str {
+        "counting-stub"
+    }
+
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(LlmResponse {
+            text: "x".into(),
+            model: req.model.clone(),
+            input_tokens: 1,
+            output_tokens: 1,
+            latency_ms: 0,
+            cost_usd: 0.0,
+        })
+    }
+}
+
+// ── InferenceStatus tests ─────────────────────────────────────────────────
+
+#[test]
+fn probe_status_serialises_lowercase() {
+    assert_eq!(
+        serde_json::to_string(&InferenceStatus::Ok).unwrap(),
+        "\"ok\""
+    );
+    assert_eq!(
+        serde_json::to_string(&InferenceStatus::Unreachable).unwrap(),
+        "\"unreachable\""
+    );
+    assert_eq!(
+        serde_json::to_string(&InferenceStatus::AuthError).unwrap(),
+        "\"auth_error\""
+    );
+    assert_eq!(
+        serde_json::to_string(&InferenceStatus::Unknown).unwrap(),
+        "\"unknown\""
+    );
+}
+
+#[test]
+fn probe_status_is_ok() {
+    assert!(InferenceStatus::Ok.is_ok());
+    assert!(!InferenceStatus::Unreachable.is_ok());
+    assert!(!InferenceStatus::AuthError.is_ok());
+    assert!(!InferenceStatus::Unknown.is_ok());
+}
+
+// ── Error mapping tests ───────────────────────────────────────────────────
+
+#[test]
+fn error_mapping_access_denied_is_auth_error() {
+    let status = map_llm_error(&LlmError::AccessDenied("denied".into()));
+    assert_eq!(status, InferenceStatus::AuthError);
+}
+
+#[test]
+fn error_mapping_model_not_found_is_auth_error() {
+    let status = map_llm_error(&LlmError::ModelNotFound("no-model".into()));
+    assert_eq!(status, InferenceStatus::AuthError);
+}
+
+#[test]
+fn error_mapping_model_not_ready_is_auth_error() {
+    let status = map_llm_error(&LlmError::ModelNotReady("creating".into()));
+    assert_eq!(status, InferenceStatus::AuthError);
+}
+
+#[test]
+fn error_mapping_validation_is_auth_error() {
+    let status = map_llm_error(&LlmError::Validation("bad prefix".into()));
+    assert_eq!(status, InferenceStatus::AuthError);
+}
+
+#[test]
+fn error_mapping_transport_is_unreachable() {
+    let status = map_llm_error(&LlmError::Transport("connection refused".into()));
+    assert_eq!(status, InferenceStatus::Unreachable);
+}
+
+#[test]
+fn error_mapping_rate_limited_is_unreachable() {
+    let status = map_llm_error(&LlmError::RateLimited);
+    assert_eq!(status, InferenceStatus::Unreachable);
+}
+
+#[test]
+fn error_mapping_upstream_5xx_is_unreachable() {
+    let status = map_llm_error(&LlmError::Upstream {
+        status: 503,
+        body: "overloaded".into(),
+    });
+    assert_eq!(status, InferenceStatus::Unreachable);
+}
+
+// ── Live probe tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn probe_returns_ok_on_success() {
+    let llm: Arc<dyn LlmProvider> = Arc::new(OkLlm);
+    let status = run_probe(&llm, "test-model", Duration::from_secs(5)).await;
+    assert_eq!(status, InferenceStatus::Ok);
+}
+
+#[tokio::test]
+async fn probe_returns_auth_error_on_access_denied() {
+    let llm: Arc<dyn LlmProvider> = Arc::new(AuthErrorLlm);
+    let status = run_probe(&llm, "test-model", Duration::from_secs(5)).await;
+    assert_eq!(status, InferenceStatus::AuthError);
+}
+
+#[tokio::test]
+async fn probe_returns_unreachable_on_transport() {
+    let llm: Arc<dyn LlmProvider> = Arc::new(TransportErrorLlm);
+    let status = run_probe(&llm, "test-model", Duration::from_secs(5)).await;
+    assert_eq!(status, InferenceStatus::Unreachable);
+}
+
+#[tokio::test(start_paused = true)]
+async fn probe_timeout_returns_unknown() {
+    // The HungLlm sleeps 60 s; the probe timeout is 10 ms.
+    // With paused clock, `tokio::time::sleep` returns instantly when
+    // the runtime advances time; `timeout` fires before HungLlm wakes.
+    // Timeout → `Unknown` (not `Unreachable`) so a slow Bedrock cold-start
+    // does not falsely degrade health (#739).
+    let llm: Arc<dyn LlmProvider> = Arc::new(HungLlm);
+    let status = run_probe(&llm, "test-model", Duration::from_millis(10)).await;
+    assert_eq!(
+        status,
+        InferenceStatus::Unknown,
+        "probe timeout must return Unknown, not Unreachable (#739)"
+    );
+}
+
+// ── Cache TTL tests ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn probe_cache_prevents_redundant_calls() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let llm: Arc<dyn LlmProvider> = Arc::new(CountingLlm {
+        calls: Arc::clone(&calls),
+    });
+
+    // Long TTL: 60 s — the cache should remain warm across both calls.
+    let probe = InferenceProbe::new(Duration::from_secs(60), Duration::from_secs(5));
+
+    let s1 = probe.probe(&llm, "m").await;
+    let s2 = probe.probe(&llm, "m").await;
+
+    assert_eq!(s1, InferenceStatus::Ok);
+    assert_eq!(s2, InferenceStatus::Ok);
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "provider must be called exactly once when cache is warm"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn probe_cache_ttl_zero_always_reprobes() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let llm: Arc<dyn LlmProvider> = Arc::new(CountingLlm {
+        calls: Arc::clone(&calls),
+    });
+
+    // TTL of 0 means the cache always looks stale.
+    let probe = InferenceProbe::new(Duration::ZERO, Duration::from_secs(5));
+
+    probe.probe(&llm, "m").await;
+    probe.probe(&llm, "m").await;
+
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        2,
+        "zero TTL must reprobe on every call"
+    );
+}
+
+// ── health_probe_timeout() tests ──────────────────────────────────────────
+
+/// Returns 10 s when the env var is absent.
+///
+/// Why: verifies the documented default so operators know what to expect
+/// without setting the variable.
+/// What: calls `health_probe_timeout()` with the env var unset.
+/// Test: this test (serial to prevent env-var races with sibling tests).
+#[test]
+#[serial_test::serial]
+fn health_probe_timeout_default() {
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS") };
+    let t = health_probe_timeout();
+    assert_eq!(
+        t,
+        Duration::from_secs(10),
+        "default probe timeout must be 10 s (#739)"
+    );
+}
+
+/// Returns the caller-supplied value when the env var is a valid non-zero u64.
+///
+/// Why: verifies that operators can raise or lower the timeout without
+/// recompiling.
+/// What: sets `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS=15` and checks the result.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn health_probe_timeout_env_override() {
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::set_var("TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS", "15") };
+    let t = health_probe_timeout();
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS") };
+    assert_eq!(
+        t,
+        Duration::from_secs(15),
+        "env-var override must be honoured"
+    );
+}
+
+/// Falls back to 10 s when the env var contains a non-numeric value.
+///
+/// Why: a mis-typed env var (e.g. `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS=ten`)
+/// must not panic or produce an unintended value; fallback to default is safest.
+/// What: sets an invalid value and asserts the default is used.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn health_probe_timeout_env_invalid_falls_back() {
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::set_var("TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS", "not-a-number") };
+    let t = health_probe_timeout();
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS") };
+    assert_eq!(
+        t,
+        Duration::from_secs(10),
+        "invalid env var must fall back to 10 s default"
+    );
+}
+
+/// Falls back to 10 s when the env var is zero (prevents a zero timeout).
+///
+/// Why: a zero timeout would make every probe immediately time out and return
+/// `Unknown`, rendering the inference field permanently `unknown`.  Treating
+/// zero as "use default" is a safe guard against misconfiguration.
+/// What: sets `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS=0` and asserts the default.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn health_probe_timeout_env_zero_falls_back() {
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::set_var("TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS", "0") };
+    let t = health_probe_timeout();
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS") };
+    assert_eq!(
+        t,
+        Duration::from_secs(10),
+        "zero env var must fall back to 10 s default"
+    );
+}


### PR DESCRIPTION
## Summary

- **Raise probe timeout** from hard-coded 3 s to 10 s default, configurable via `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS` env var. AWS Bedrock cold-starts were measured at ~7.4 s, causing spurious `unreachable`/`degraded` health on a perfectly working backend.
- **Map probe timeout → `Unknown`** (was `Unreachable`): the probe budget is much shorter than the real review call budget (~300 s), so a timeout means "could not confirm reachability in the probe window" — not "endpoint is down". A genuine network/auth failure still maps to `Unreachable`/`AuthError` as before.
- **`compute_status` treats `Unknown` as non-degrading**: top-level `status` only degrades on `Unreachable` or `AuthError` inference, not on a probe timeout.

## Files changed

| File | Change |
|---|---|
| `service/inference_probe.rs` | Add `health_probe_timeout()` helper; update `Default` to use it; change timeout arm to `Unknown`; split tests to sibling file (500-line cap) |
| `service/inference_probe_tests.rs` | New file: all probe tests + 4 new `health_probe_timeout` env-override tests |
| `service/handlers.rs` | Update `compute_status` to not degrade on `Unknown`; update doc comments |
| `service/handlers_status_tests.rs` | Add `health_status_ok_inference_unknown` test |

## Test plan

- [x] `cargo test -p trusty-review` — 760 lib + 12 bin passed, 0 failed
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-review --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations (inference_probe.rs: 273 lines, inference_probe_tests.rs: 345 lines)
- [x] All pre-commit hooks passed

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)