### PR TITLE
fix(tga): cover all accessible repos in PR reviewer ingestion (closes #752)

### DIFF
--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -221,15 +221,12 @@ impl BitbucketClient {
 
     /// Persist a batch of [`PullRequest`] rows into the database.
     ///
-    /// Mirrors the GitHub client's persistence — same table, same columns.
-    /// Writes `provider = 'bitbucket'` and `repository = "<workspace>/<repo_slug>"`
-    /// so rows deduplicate against the
-    /// `(provider, repository, pr_number)` unique index from migration
-    /// `0012_pull_requests_repository.sql` (fix #88), preventing collisions
-    /// with PRs collected by the GitHub or Azure DevOps providers that
-    /// happen to share the same numeric `pr_number`, and preventing
-    /// cross-repo collisions when multiple Bitbucket repos are collected.
-    ///
+    /// Why: `ON CONFLICT … DO UPDATE` keeps existing `id` so FK-linked `pr_reviewers`
+    /// survive re-collection; `INSERT OR REPLACE` cascade-deleted them (#752).
+    /// What: `provider='bitbucket'`; `repository="<workspace>/<repo_slug>"`;
+    /// deduplicates on `(provider,repository,pr_number)` (0012/#88); existing rows
+    /// update `title`/`author`/`state`/`merged_at`/`commit_shas`. Test: see
+    /// reviewer_store integration tests for FK-preservation coverage.
     /// # Errors
     ///
     /// Propagates [`crate::core::TgaError::DbError`] on SQL failures.
@@ -242,9 +239,12 @@ impl BitbucketClient {
         let mut count = 0usize;
         for pr in prs {
             conn.execute(
-                "INSERT OR REPLACE INTO pull_requests \
-                 (provider, repository, pr_number, title, author, state, created_at, merged_at, commit_shas) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                "INSERT INTO pull_requests \
+                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas) \
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9) \
+                 ON CONFLICT(provider,repository,pr_number) DO UPDATE SET \
+                   title=excluded.title,author=excluded.author,state=excluded.state,\
+                   merged_at=excluded.merged_at,commit_shas=excluded.commit_shas",
                 params![
                     "bitbucket",
                     pr.repository,

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -535,14 +535,11 @@ impl GitHubClient {
 
     /// Persist a batch of [`PullRequest`] rows into the database.
     ///
-    /// Existing rows with the same `(provider, repository, pr_number)` are
-    /// replaced. The `provider` column is set to `'github'` for all rows
-    /// written by this client; `repository` comes from each `PullRequest`
-    /// in `"owner/repo"` form (see migrations
-    /// `0010_pull_requests_provider.sql` and
-    /// `0012_pull_requests_repository.sql`). Including `repository` in the
-    /// uniqueness key prevents cross-repo collisions on `pr_number` (fix
-    /// for issue #88).
+    /// Why: `ON CONFLICT … DO UPDATE` keeps existing `id` so FK-linked
+    /// `pr_reviewers` survive re-collection; `INSERT OR REPLACE` wiped them (#752).
+    /// What: new rows insert all columns; existing update `title`/`author`/`state`/
+    /// `merged_at`/`commit_shas`; `id` and `created_at` are never overwritten.
+    /// Test: reviewer_store tests cover FK-preservation.
     ///
     /// # Errors
     ///
@@ -556,9 +553,12 @@ impl GitHubClient {
         let mut count = 0usize;
         for pr in prs {
             conn.execute(
-                "INSERT OR REPLACE INTO pull_requests \
-                 (provider, repository, pr_number, title, author, state, created_at, merged_at, commit_shas) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                "INSERT INTO pull_requests \
+                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas) \
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9) \
+                 ON CONFLICT(provider,repository,pr_number) DO UPDATE SET \
+                   title=excluded.title,author=excluded.author,state=excluded.state,\
+                   merged_at=excluded.merged_at,commit_shas=excluded.commit_shas",
                 params![
                     "github",
                     pr.repository,


### PR DESCRIPTION
## Summary

- **Root cause**: `store_pull_requests` in both the GitHub and Bitbucket clients used `INSERT OR REPLACE`, which deletes the conflicting row and reinserts it with a new `id`. The `pr_reviewers` table has `FOREIGN KEY (pr_id) REFERENCES pull_requests(id) ON DELETE CASCADE`, so every `tga collect` run silently cascade-deleted all reviewer rows for every PR it re-fetched.
- **Impact**: On a 159-repo org with ~36K PRs, the reviewer ingestion pass had to re-fetch all reviews from scratch on each run. GitHub's 5,000 req/hour rate limit means only ~2 repos' worth of data completes before the run exhausts the budget — exactly the symptom reported in #752.
- **Fix**: Changed both `store_pull_requests` implementations to `INSERT INTO … ON CONFLICT(provider,repository,pr_number) DO UPDATE SET title=…,author=…,state=…,merged_at=…,commit_shas=…`, which preserves the existing `id` on conflict. Reviewer FK rows now survive re-collection and accumulate across runs; the reviewer ingestion pass only fetches new/updated PRs.

## Files changed

- `crates/trusty-git-analytics/src/collect/github/client.rs` — upsert instead of replace; Why/What/Test doc updated
- `crates/trusty-git-analytics/src/collect/bitbucket/client.rs` — same pattern for Bitbucket parity

## Test plan

- [x] `cargo test -p tga` — 111 passed, 0 failed
- [x] `cargo clippy -p tga --all-targets -- -D warnings` — exit 0
- [x] `cargo fmt -p tga --check` — exit 0
- [x] `bash scripts/check_line_cap.sh` — 0 violations (both files held exactly at their allowlist budget)
- [x] Pre-commit hooks (line-cap, secret-scan, trailing-whitespace) — all Passed

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)