### PR TITLE
fix(ci): ignore HuggingFace network tests + fix trusty-memory foreground.rs compile error

### DIFF
--- a/crates/open-mpm/src/memory/embed.rs
+++ b/crates/open-mpm/src/memory/embed.rs
@@ -170,6 +170,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires network access to HuggingFace to download ONNX model; run with --include-ignored"]
     fn smoke_single_embedding_shape_and_finiteness() {
         let embedder = shared_embedder();
         let v = embedder
@@ -183,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires local embedding service / ONNX model load; flaky under parallel test init (os error 57)"]
+    #[ignore = "requires network access to HuggingFace to download ONNX model; run with --include-ignored"]
     fn batch_returns_distinct_vectors_per_input() {
         let embedder = shared_embedder();
         let out = embedder
@@ -198,6 +199,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires network access to HuggingFace to download ONNX model; run with --include-ignored"]
     fn semantic_sanity_paraphrase_beats_unrelated() {
         let embedder = shared_embedder();
         let vs = embedder

--- a/crates/trusty-memory/src/foreground.rs
+++ b/crates/trusty-memory/src/foreground.rs
@@ -12,8 +12,9 @@
 use anyhow::Result;
 use std::net::SocketAddr;
 
-use crate::commands::daemon_lock;
-use crate::{run_http_on, AppState, DEFAULT_HTTP_PORT};
+use crate::DEFAULT_HTTP_PORT;
+#[cfg(feature = "axum-server")]
+use crate::{commands::daemon_lock, run_http_on, AppState};
 
 /// Bind a `TcpListener` to `127.0.0.1:DEFAULT_HTTP_PORT` for the
 /// launchd/supervisor `serve --foreground` path — abort on collision.


### PR DESCRIPTION
## Summary

- Marks all three `memory::embed` tests in `open-mpm` with `#[ignore = "requires network access to HuggingFace to download ONNX model; run with --include-ignored"]`, stopping the persistent CI 429 flake that masked real failures across every PR
- Fixes a pre-existing compile error in `trusty-memory/src/foreground.rs` where `run_http_on`/`AppState`/`daemon_lock` were imported unconditionally despite `run_http_on` being gated on `#[cfg(feature = "axum-server")]`

Closes #812.

## Root cause

`FastEmbedder::new()` downloads `AllMiniLML6V2` (~23MB ONNX) from HuggingFace on every CI run. Without auth, CI hits the unauthenticated rate limit → HTTP 429 → `memory::embed::tests::smoke_single_embedding_shape_and_finiteness` and `semantic_sanity_paraphrase_beats_unrelated` failed on every workspace `Test` run. `batch_returns_distinct_vectors_per_input` was already `#[ignore]` but with a vague reason string that didn't mention the network dependency.

This matches the existing convention: ONNX-backed tests throughout the workspace (`trusty-embedderd`, `trusty-search`) are all `#[ignore]`-tagged. The `CLAUDE.md` documents this explicitly.

## Test plan

- [x] `cargo test -p open-mpm`: **1867 passed; 0 failed; 7 ignored** (embed tests skipped)
- [x] `cargo clippy -p open-mpm --all-targets -- -D warnings`: clean
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] `bash scripts/check_line_cap.sh`: exit 0
- [x] `cargo test -p open-mpm -- --include-ignored` still compiles (opt-in network run)
- [x] No production code changed — only `#[ignore]` annotations and import gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)