### PR TITLE
docs(architecture): spec the three harnesses (trusty-code / trusty-mpm / trusty-agents) on a shared event-driven trusty-common

### DIFF
--- a/crates/open-mpm/README.md
+++ b/crates/open-mpm/README.md
@@ -1,5 +1,14 @@
 # open-mpm
 
+**Harness role:** The **Agentic Harness** (planned rename: `trusty-agents`) —
+a general-purpose agentic harness for non-coding knowledge-worker workflows
+(CRM, HR, scheduling, memory, communications). Distinct from a coding harness.
+Can delegate coding tasks to `trusty-code` and managed multi-agent projects to
+`trusty-mpm`. See
+[docs/architecture/harnesses.md](../../docs/architecture/harnesses.md) for the
+full three-harness architecture, the delegation graph, and the open decision on
+the open-mpm/trusty-mpm boundary (including the proposed rename).
+
 A lightweight, composable AI agent orchestration harness in Rust.
 
 `open-mpm` runs a **PM (Project Manager) orchestrator** that delegates tasks

--- a/crates/trusty-code/README.md
+++ b/crates/trusty-code/README.md
@@ -1,0 +1,69 @@
+# trusty-code
+
+**Harness role:** The **Coding Harness** — per-project, Claude-Code-compatible
+MPM orchestration. See
+[docs/architecture/harnesses.md](../../docs/architecture/harnesses.md) for the
+full three-harness architecture and delegation graph.
+
+Why: Each project needs a harness that is already wired to its own `.claude/`
+configuration — agents, skills, MCP connections, `CLAUDE.md`, and permissions.
+`trusty-code` fills that role. It is the Claude-Code-native orchestration entry
+point that runs the PM main-loop, enforces the mandatory workflow (research →
+plan → implement → verify), and delegates authority to typed coding sub-agents
+according to MPM protocols.
+
+What: Per-project coding orchestration harness. One `tcode serve` process per
+`.claude/` project root. Accepts task requests from CLI clients, TUI frontends,
+and MCP callers. Full extraction from `open-mpm` is tracked in epic #587.
+
+## Status
+
+**Phase 0 scaffold.** The `tcode` binary parses its CLI surface but every
+subcommand stubs out with "not yet implemented". Implementation phases are
+tracked in epic #587.
+
+## Binaries
+
+| Binary | Description |
+|--------|-------------|
+| `tcode` | Per-project Claude-Code-compatible MPM orchestration harness |
+
+## Subcommands (Phase 0 surface — stubs)
+
+| Subcommand | Description |
+|------------|-------------|
+| `tcode serve --project <PATH>` | Start the per-project orchestration server (Phase 1) |
+| `tcode run-task <agent> <task>` | Delegate a single task to a named agent (Phase 2) |
+| `tcode run-workflow <name>` | Execute a named MPM workflow end-to-end (Phase 2) |
+
+## Build
+
+```bash
+cargo build -p trusty-code
+cargo run -p trusty-code -- --version
+cargo test -p trusty-code
+```
+
+## Design Constraints
+
+- **Claude-Code compatible** — reads `.claude/` config, agents, skills, MCP
+  descriptors, `CLAUDE.md`, and permission grants exactly as Claude Code does.
+- **Per-agent model routing** — each agent may specify its own model
+  (AWS Bedrock or OpenRouter).
+- **Single-instance per project** — one `tcode serve` process per `.claude/`
+  root.
+- **Event-driven** — will publish `HarnessEvent` via `trusty-common::events`
+  when Phase 1 lands.
+
+## Architecture Role
+
+trusty-code is the bottom layer of the three-harness stack:
+
+```
+trusty-agents (general agentic)  →  delegates coding tasks to trusty-code
+trusty-mpm (meta-harness)        →  launches and oversees trusty-code sessions
+trusty-code (coding harness)     →  executes per-project coding workflows
+```
+
+See [docs/architecture/harnesses.md](../../docs/architecture/harnesses.md) and
+[ADR-0004](../../docs/adr/0004-three-harnesses-shared-event-driven-common.md).

--- a/crates/trusty-mpm/README.md
+++ b/crates/trusty-mpm/README.md
@@ -1,5 +1,12 @@
 # trusty-mpm
 
+**Harness role:** The **Meta-Harness** — PM-style multi-agent orchestration
+over coding work. Manages multi-project sessions, relays hooks, and exposes an
+MCP server to Claude Code sessions. Delegates coding tasks to `trusty-code`
+(`tcode`). See
+[docs/architecture/harnesses.md](../../docs/architecture/harnesses.md) for the
+full three-harness architecture and delegation graph.
+
 Why: A single `cargo install trusty-mpm` should install all trusty-mpm tooling — the background daemon, the CLI, the TUI dashboard, and the Telegram bot — without requiring users to install eight separate packages and coordinate their versions.
 
 What: Unified crate combining the formerly separate `trusty-mpm-{core,client,mcp,daemon,cli,tui,telegram}` sub-crates into one package with feature-gated `[[bin]]` targets.

--- a/docs/adr/0004-three-harnesses-shared-event-driven-common.md
+++ b/docs/adr/0004-three-harnesses-shared-event-driven-common.md
@@ -1,0 +1,185 @@
+# 0004. Three distinct harnesses (coding / meta / agentic) on a shared event-driven trusty-common foundation
+
+- **Status:** Proposed
+- **Date:** 2026-06-05
+- **Scope:** Workspace-wide (all harness crates + `trusty-common`)
+- **Supersedes / Superseded by:** —
+
+## Context
+
+The trusty-tools workspace has grown to include three families of AI
+orchestration crates that serve fundamentally different principals and
+have different responsibilities:
+
+1. **`trusty-code`** — per-project coding orchestration (`tcode` binary), the
+   Claude-Code-compatible harness. Currently a Phase 0 scaffold
+   (`crates/trusty-code/`); full extraction from `open-mpm` is tracked in
+   epic #587.
+
+2. **`trusty-mpm`** — the operator's control plane for multi-project, multi-
+   session workflow management (`tm` / `trusty-mpmd` / TUI / Telegram). It
+   oversees coding sessions, relays hooks, and exposes an MCP server to Claude
+   Code. It delegates coding work downward; it does not execute code itself.
+
+3. **`open-mpm`** (proposed rename: `trusty-agents`) — a general-purpose
+   agentic harness for non-coding knowledge-worker workflows (CRM, HR,
+   scheduling, memory, communications). It uses the same PM-orchestrator +
+   sub-agent subprocess pattern as trusty-code but is not a coding harness.
+
+Two problems motivate this ADR:
+
+**Problem A — unclear boundaries.** Both `open-mpm` and `trusty-mpm` carry
+orchestration/PM-style machinery. `open-mpm/src/workflow/` holds a workflow
+engine that is generic enough to belong in `trusty-mpm`; `open-mpm/src/ctrl/`
+holds both coding-agent orchestration (destined for `trusty-code`) and
+knowledge-worker persona orchestration (staying in `trusty-agents`). Without
+an explicit decision, each harness grows in undefined directions and the
+workspace accumulates duplicate machinery.
+
+**Problem B — event-driven gap.** `open-mpm` has a process-global event bus
+(`src/events.rs`, `tokio::sync::broadcast`) and a UDS inter-project message bus
+(`src/bus/`). `trusty-mpm` has a hook relay but no typed broadcast bus in the
+daemon. `trusty-code` has nothing (Phase 0 stub). The three harnesses cannot
+coordinate, fan out, or stream progress to UIs unless they share an event
+foundation.
+
+Additionally, cross-harness infrastructure (the `ToolExecutor` trait, RBAC
+`ServiceTier` enum, intent classifier, event types) currently lives inside
+`open-mpm` or the thin `open-mpm-agent-api` crate, making it unavailable to
+`trusty-code` and `trusty-mpm` without a peer-crate dependency, which would
+couple harnesses that should be independent.
+
+## Decision
+
+### 1. Three distinct harnesses
+
+We will maintain three distinct harnesses, each with a clear identity and
+scope:
+
+| Harness | Crate | Analogy | Principal |
+|---------|-------|---------|-----------|
+| **trusty-code** | `crates/trusty-code/` | Claude Code | Developer / CI pipeline |
+| **trusty-mpm** | `crates/trusty-mpm/` | Claude MPM | Operator / PM role |
+| **trusty-agents** | `crates/open-mpm/` (rename) | OpenClaw / Hermes | Knowledge worker |
+
+**Boundaries:**
+- PM/workflow/multi-agent orchestration belongs to **trusty-mpm** (the meta-harness).
+- General non-coding assistants belong to **trusty-agents**.
+- Per-project coding execution belongs to **trusty-code**.
+- All three are peers; none is a dependency of another at the library level.
+
+### 2. Rename open-mpm to trusty-agents
+
+We will rename the `open-mpm` crate to `trusty-agents` to reflect its
+actual role. The package `name` in `Cargo.toml` changes from `open-mpm` to
+`trusty-agents`; binaries are renamed accordingly. This rename is tracked
+separately from the #587 extraction work.
+
+### 3. Shared commonality lives in trusty-common
+
+All infrastructure that is needed by more than one harness belongs in
+`trusty-common` behind a feature flag. We will add the following features to
+`trusty-common`:
+
+| Feature | Contents | Migrated from |
+|---------|----------|---------------|
+| `events` | `HarnessEvent` enum, `HarnessKind` enum, `EventBus` type alias | `open-mpm/src/events.rs` |
+| `tool-registry` | `ToolExecutor` trait, `ToolResult`, `ServiceTier` RBAC, `UserIdentity` | `open-mpm-agent-api`, `open-mpm/src/rbac/` |
+| `intent` | `IntentClass` enum, heuristic classifier | `open-mpm/src/intent/` |
+
+The `open-mpm-agent-api` crate may be retired once `tool-registry` is in
+`trusty-common`.
+
+### 4. All three harnesses are event-driven
+
+Every harness will publish a `HarnessEvent` stream via a
+`tokio::sync::broadcast::Sender<HarnessEvent>` (from `trusty-common::events`)
+held in its process-global state. This is a binding architectural principle.
+
+Each harness is responsible for:
+- Publishing lifecycle events (`SessionStarted`, `AgentStarted`, `ToolCall`, etc.)
+- Exposing a subscriber interface (SSE endpoint for HTTP daemons; stderr relay
+  for subprocess flows)
+- Consuming events from delegated harnesses to track delegation progress
+
+The `open-mpm` UDS bus (`src/bus/`) remains for cross-project open-mpm
+coordination; it is distinct from the `HarnessEvent` intra-process bus.
+
+### 5. Inter-harness delegation graph
+
+The delegation graph is:
+
+```
+trusty-agents  →  trusty-code   (coding task: HTTP POST / CLI subprocess)
+trusty-agents  →  trusty-mpm    (managed multi-agent project: MCP agent_delegate)
+trusty-mpm     →  trusty-code   (session launch: SessionLaunchConfig → tcode subprocess)
+```
+
+No reverse edges. No harness takes a Cargo dependency on a sibling harness.
+Delegation is over network/IPC boundaries only.
+
+### 6. Boundary resolution for open-mpm/trusty-mpm overlap
+
+We will apply the following migrations as part of #587 and the rename:
+
+| Module | Current location | Migration target |
+|--------|-----------------|-----------------|
+| `workflow/` (WorkflowEngine, phase-based pipelines) | `open-mpm/src/workflow/` | Migrate to `trusty-mpm` or `trusty-common` (owner decision required — see Open Questions) |
+| Coding-agent ctrl loop | `open-mpm/src/ctrl/` (coding agent subset) | Extract to `trusty-code` via #587 |
+| Knowledge-worker ctrl loop | `open-mpm/src/ctrl/` (persona subset) | Stays in `trusty-agents` |
+| Cross-project session registry | `open-mpm/src/session_registry.rs` | Migrate to `trusty-mpm` |
+| Event bus types | `open-mpm/src/events.rs` | Migrate to `trusty-common::events` |
+| Tool registry + RBAC | `open-mpm/src/tools/traits.rs`, `src/rbac/` | Migrate to `trusty-common::tool-registry` |
+| Intent classifier | `open-mpm/src/intent/` | Migrate to `trusty-common::intent` |
+| Harness adapter detection | `open-mpm/src/adapters/` | Migrate to `trusty-mpm` |
+
+## Consequences
+
+### Positive
+
+- **Clarity for contributors:** a new contributor can identify the right crate
+  for a feature by asking "is this coding? meta-orchestration? knowledge-worker
+  assistance?" with a clear answer.
+- **No peer-crate coupling:** harnesses remain independent; trusty-agents can
+  be deployed without trusty-mpm, and vice versa.
+- **Shared event model:** all three harnesses speak the same `HarnessEvent`
+  wire format, enabling cross-harness monitoring and future unified dashboards.
+- **trusty-common grows the right way:** adding `events`, `tool-registry`, and
+  `intent` features follows the established pattern (previously: `mcp`, `rpc`,
+  `memory-core`, `tickets`, `symgraph`, `embedder`).
+- **`trusty-agents` name signals non-coding:** the rename removes the
+  `mpm` namespace collision and communicates the harness's actual purpose.
+
+### Negative / Risks
+
+- **Migration cost:** moving `WorkflowEngine`, event bus, tool registry, and
+  intent classifier requires coordinated changes across multiple crates and a
+  version bump for each affected crate.
+- **#587 scope risk:** the boundary between "coding ctrl" and "knowledge-worker
+  ctrl" inside `open-mpm/src/ctrl/` is not always obvious from the code alone.
+  The split may surface hidden coupling.
+- **Rename churn:** renaming `open-mpm` to `trusty-agents` requires updating
+  all call sites, `[patch.crates-io]` entries, documentation, and deployment
+  configurations.
+- **Event-driven gap for trusty-code and trusty-mpm:** neither has a broadcast
+  bus today; implementing one requires daemon-level changes to both crates.
+
+### Open Questions
+
+1. **WorkflowEngine destination:** should `open-mpm/src/workflow/` move to
+   `trusty-mpm` (making the meta-harness the sole owner of workflow logic) or
+   to `trusty-common` (making workflow pipelines available to all three
+   harnesses)? Recommendation: `trusty-mpm` first; promote to `trusty-common`
+   only if trusty-agents needs it.
+
+2. **Timing of open-mpm rename:** should the rename happen in the same PR as
+   #587 Phase 1, or in a dedicated rename PR before #587 starts? Recommendation:
+   dedicated rename PR before #587 to reduce scope.
+
+3. **open-mpm-agent-api retirement:** once `tool-registry` lands in
+   `trusty-common`, `open-mpm-agent-api` can be retired. Should it be
+   deprecated immediately or kept as a re-export shim? Recommendation: shim
+   for one release, then remove.
+
+See [docs/architecture/harnesses.md](../architecture/harnesses.md) for the
+full architecture spec, delegation contracts, and event model details.

--- a/docs/adr/0004-three-harnesses-shared-event-driven-common.md
+++ b/docs/adr/0004-three-harnesses-shared-event-driven-common.md
@@ -1,6 +1,6 @@
 # 0004. Three distinct harnesses (coding / meta / agentic) on a shared event-driven trusty-common foundation
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-05
 - **Scope:** Workspace-wide (all harness crates + `trusty-common`)
 - **Supersedes / Superseded by:** —
@@ -124,7 +124,7 @@ We will apply the following migrations as part of #587 and the rename:
 
 | Module | Current location | Migration target |
 |--------|-----------------|-----------------|
-| `workflow/` (WorkflowEngine, phase-based pipelines) | `open-mpm/src/workflow/` | Migrate to `trusty-mpm` or `trusty-common` (owner decision required — see Open Questions) |
+| `workflow/` (WorkflowEngine, phase-based pipelines) | `open-mpm/src/workflow/` | Migrate to `trusty-mpm` (accepted — see Accepted Decisions) |
 | Coding-agent ctrl loop | `open-mpm/src/ctrl/` (coding agent subset) | Extract to `trusty-code` via #587 |
 | Knowledge-worker ctrl loop | `open-mpm/src/ctrl/` (persona subset) | Stays in `trusty-agents` |
 | Cross-project session registry | `open-mpm/src/session_registry.rs` | Migrate to `trusty-mpm` |
@@ -164,22 +164,61 @@ We will apply the following migrations as part of #587 and the rename:
 - **Event-driven gap for trusty-code and trusty-mpm:** neither has a broadcast
   bus today; implementing one requires daemon-level changes to both crates.
 
+### Accepted Decisions
+
+#### open-mpm ⟷ trusty-mpm boundary — ACCEPTED
+
+The owner accepted the recommended boundary split. The following modules **move**
+out of `open-mpm` (trusty-agents) as part of #587 and the rename:
+
+| Module | Destination |
+|--------|-------------|
+| `src/workflow/` (WorkflowEngine, phase-based pipelines) | **trusty-mpm** |
+| `src/session_registry.rs` (cross-project sessions) | **trusty-mpm** |
+| `src/adapters/` (harness detection) | **trusty-mpm** |
+| Coding-agent ctrl loop (subset of `src/ctrl/`) | **trusty-code** (via #587) |
+| `src/events.rs`, `src/bus/` (event types) | **trusty-common** (`events` feature) |
+| `src/tools/traits.rs`, `src/rbac/` (ToolExecutor, ServiceTier, RBAC) | **trusty-common** (`tool-registry` feature) |
+| `src/intent/` (IntentClass, heuristic classifier) | **trusty-common** (`intent` feature) |
+
+The following **stay** in trusty-agents after the split:
+- Knowledge-worker ctrl loop (persona-driven subset of `src/ctrl/`)
+- MCP service bridge (`mcp_service_tools.rs`)
+- Domain personas (Izzie and custom TOML definitions)
+- REPL, HTTP API, Slack, Telegram transports
+- Per-conversation session state
+
+#### License — ACCEPTED
+
+The trusty-agents framework crate (`crates/open-mpm/`, planned rename
+`trusty-agents`) and its companion crates (`trusty-agents-api`,
+`trusty-agents-local`) will be licensed under **Elastic License 2.0**,
+matching trusty-search. This is NOT MIT. The license applies to all three
+crates; Cargo.toml metadata will be updated during the P0 rename — that
+change is not part of this PR.
+
 ### Open Questions
 
-1. **WorkflowEngine destination:** should `open-mpm/src/workflow/` move to
-   `trusty-mpm` (making the meta-harness the sole owner of workflow logic) or
-   to `trusty-common` (making workflow pipelines available to all three
-   harnesses)? Recommendation: `trusty-mpm` first; promote to `trusty-common`
-   only if trusty-agents needs it.
+The following questions are still open and require further owner decisions
+before the corresponding work begins:
 
-2. **Timing of open-mpm rename:** should the rename happen in the same PR as
-   #587 Phase 1, or in a dedicated rename PR before #587 starts? Recommendation:
-   dedicated rename PR before #587 to reduce scope.
+1. **Model strategy:** what is the default model routing policy for
+   trusty-agents personas (OpenRouter vs. Bedrock; model tier selection)?
+
+2. **Relationship to duetto-intelligence gateway:** how do trusty-agents
+   personas interact with the duetto-intelligence MCP gateway — do they call
+   it as a tool, or does trusty-agents embed the gateway logic directly?
 
 3. **open-mpm-agent-api retirement:** once `tool-registry` lands in
    `trusty-common`, `open-mpm-agent-api` can be retired. Should it be
    deprecated immediately or kept as a re-export shim? Recommendation: shim
-   for one release, then remove.
+   for one release, then remove. Owner decision pending.
+
+4. **v1 assistant scope:** what is the minimal useful v1 for trusty-agents
+   as a standalone harness (without the coding ctrl extracted to trusty-code)?
+
+5. **Timing vs. trusty-code #587:** should the open-mpm rename and boundary
+   migrations happen before, during, or after #587 Phase 1?
 
 See [docs/architecture/harnesses.md](../architecture/harnesses.md) for the
 full architecture spec, delegation contracts, and event model details.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,3 +61,4 @@ Proposed ──► Accepted ──► Superseded (by ADR-NNNN)
 | [0001](./0001-docs-live-top-level.md) | Design/research/ADR docs live in top-level `docs/` | Accepted |
 | [0002](./0002-single-install-convention.md) | Single-install convention for main crates | Accepted |
 | [0003](./0003-msrv-and-edition-policy.md) | MSRV 1.88 and per-crate Rust edition policy | Accepted |
+| [0004](./0004-three-harnesses-shared-event-driven-common.md) | Three distinct harnesses on a shared event-driven trusty-common foundation | Proposed |

--- a/docs/architecture/harnesses.md
+++ b/docs/architecture/harnesses.md
@@ -1,6 +1,6 @@
 # Three-Harness Architecture — trusty-tools
 
-**Status:** Draft
+**Status:** Accepted
 **Version:** v1
 **Subsystem:** HARNESSES
 **Owner:** Engineering / Architecture
@@ -36,7 +36,7 @@ procedures (those live in the crate-level README and `docs/<crate>/`).
 | [Shared Foundation — trusty-common](#shared-foundation--trusty-common) | What belongs to all harnesses |
 | [Event-Driven Mandate](#event-driven-mandate) | Binding architectural principle + event model |
 | [Inter-Harness Delegation](#inter-harness-delegation) | Call graph, boundaries, transport |
-| [Open Decision — Boundary Between trusty-mpm and trusty-agents](#open-decision--boundary-between-trusty-mpm-and-trusty-agents) | Flagged question with recommendation |
+| [Accepted Decision — Boundary Between trusty-mpm and trusty-agents](#accepted-decision--boundary-between-trusty-mpm-and-trusty-agents) | Owner-accepted boundary split + Elastic-2.0 license |
 | [Current Status vs. Target State](#current-status-vs-target-state) | What exists today and what is planned |
 
 ---
@@ -386,9 +386,10 @@ pub enum HarnessKind { TrustyCode, TrustyMpm, TrustyAgents }
 
 ---
 
-## Open Decision — Boundary Between trusty-mpm and trusty-agents
+## Accepted Decision — Boundary Between trusty-mpm and trusty-agents
 
-**Status: OPEN — requires owner decision before work begins on epic #587.**
+**Status: ACCEPTED — boundary and license recorded; implementation proceeds
+under epic #587 and the P0 rename.**
 
 ### The Problem
 
@@ -406,51 +407,46 @@ machinery that overlaps:
 | MCP service bridge | `src/tools/mcp_service_tools.rs` | Implicit (Claude Code sessions invoke MCP servers directly) |
 | Event bus | `src/events.rs`, `src/bus/` | Partial (hook relay only) |
 
-### The Clean Line (Proposed)
+### The Accepted Line
 
 **PM / workflow / multi-agent orchestration belongs to trusty-mpm (the meta-harness).
 General non-coding assistants belong to trusty-agents.**
 
-More precisely:
+More precisely (all items below are accepted; Cargo.toml updates happen during
+the P0 rename, not in this PR):
 
 1. **`open-mpm/src/workflow/`** — the `WorkflowEngine` and declarative phase
    pipelines (`WorkflowDef`, `PhaseDef`, parallel phases, worktree management,
-   autopush) are **generic orchestration logic** that belongs in `trusty-mpm` or
-   eventually `trusty-common`. They are not specific to knowledge-worker workflows.
-   **Recommendation: migrate to trusty-mpm or trusty-common.**
+   autopush) are **generic orchestration logic**.
+   **Decision: migrate to trusty-mpm.**
 
-2. **`open-mpm/src/ctrl/`** (the PM orchestrator loop) — this is the core of
-   what will become trusty-code. The subset that drives coding agents belongs in
-   `trusty-code` (epic #587). The subset that drives knowledge-worker personas
-   stays in trusty-agents. The split follows intent: if the agent being driven is
-   a coding agent, it belongs to trusty-code; if it is a domain persona (Izzie,
-   CRM assistant), it belongs to trusty-agents.
-   **Recommendation: split by agent type as part of #587 extraction.**
+2. **`open-mpm/src/ctrl/`** (the PM orchestrator loop) — the subset that drives
+   coding agents belongs in `trusty-code` (epic #587); the subset that drives
+   knowledge-worker personas stays in trusty-agents. The split follows intent:
+   coding agent → trusty-code; domain persona (Izzie, CRM assistant) → trusty-agents.
+   **Decision: split by agent type as part of #587 extraction.**
 
-3. **`open-mpm/src/session*.rs`** (session registry, session record) — session
-   management at the multi-project level belongs to `trusty-mpm`. Session state
-   that is intrinsic to a single knowledge-worker conversation stays in
-   trusty-agents.
-   **Recommendation: trusty-mpm owns cross-project sessions; trusty-agents owns
+3. **`open-mpm/src/session_registry.rs`** (cross-project session registry) —
+   session management at the multi-project level belongs to `trusty-mpm`.
+   Per-conversation session state intrinsic to a single knowledge-worker
+   conversation stays in trusty-agents.
+   **Decision: trusty-mpm owns cross-project sessions; trusty-agents owns
    per-conversation session state for its own loops.**
 
 4. **`open-mpm/src/tools/`, `src/rbac/`, `src/identity/`** — the
-   `ToolExecutor` trait + `ServiceTier` RBAC + `UserIdentity` are already
-   partially in `open-mpm-agent-api`. These are shared primitives.
-   **Recommendation: migrate to `trusty-common` behind a `tool-registry` feature
-   flag.**
+   `ToolExecutor` trait + `ServiceTier` RBAC + `UserIdentity` are shared primitives.
+   **Decision: migrate to `trusty-common` behind a `tool-registry` feature flag.**
 
 5. **`open-mpm/src/events.rs`, `src/bus/`** — the event bus belongs to
    `trusty-common` so all harnesses can share it.
-   **Recommendation: migrate to `trusty-common::events`.**
+   **Decision: migrate to `trusty-common::events`.**
 
 6. **`open-mpm/src/intent/`** — the intent classifier is a shared primitive.
-   **Recommendation: migrate to `trusty-common::intent`.**
+   **Decision: migrate to `trusty-common::intent`.**
 
-7. **`open-mpm/src/adapters/`** (harness adapter detection) — this is trusty-mpm
-   level functionality (recognising which harness is in a tmux pane). It currently
-   lives in open-mpm for historical reasons.
-   **Recommendation: migrate to trusty-mpm or trusty-common.**
+7. **`open-mpm/src/adapters/`** (harness adapter detection) — trusty-mpm-level
+   functionality (recognising which harness is in a tmux pane).
+   **Decision: migrate to trusty-mpm.**
 
 ### What Stays Exclusively in trusty-agents After the Split
 
@@ -463,19 +459,32 @@ More precisely:
 - Per-conversation session state and interaction log
 - Intent classifier (until extracted to trusty-common)
 
-### Owner's Decision Required
+### License Decision — ACCEPTED
 
-Before any code moves, the owner must decide:
+**trusty-agents (crates/open-mpm/, planned rename) and its companion crates
+(`trusty-agents-api`, `trusty-agents-local`) are licensed under Elastic
+License 2.0, matching trusty-search. This is NOT MIT.**
 
-1. Does `open-mpm/src/workflow/` consolidate into `trusty-mpm`, or does it remain
-   in trusty-agents as a shared utility?
-2. Does the PM main loop in `open-mpm/src/ctrl/` split simultaneously with #587,
-   or does that split happen in a later phase?
-3. Is the rename `open-mpm` → `trusty-agents` in-scope for the same PR as #587,
-   or a separate rename commit?
+This decision is recorded in
+[ADR-0004](../adr/0004-three-harnesses-shared-event-driven-common.md) under
+"Accepted Decisions". The `license` field in the three Cargo.toml files will be
+set to `"Elastic-2.0"` during the P0 rename PR — it is not changed in this
+documentation-only PR.
 
-This document records the proposed answers; the ADR (below) records the final
-decision once the owner has reviewed.
+### Remaining Open Questions
+
+The boundary and license decisions are now settled. The following questions
+remain open and will be addressed in subsequent PRs or the #587 implementation:
+
+1. **Model strategy:** default model routing policy for trusty-agents personas.
+2. **Relationship to duetto-intelligence gateway:** tool vs. embedded integration.
+3. **open-mpm-agent-api retirement timing:** shim or immediate deprecation once
+   `trusty-common::tool-registry` is ready.
+4. **v1 assistant scope:** minimal useful v1 trusty-agents without tcode extracted.
+5. **Rename timing vs. #587:** dedicated rename PR before vs. within #587 Phase 1.
+
+See [ADR-0004](../adr/0004-three-harnesses-shared-event-driven-common.md) for
+the full decision record.
 
 ---
 

--- a/docs/architecture/harnesses.md
+++ b/docs/architecture/harnesses.md
@@ -1,0 +1,508 @@
+# Three-Harness Architecture — trusty-tools
+
+**Status:** Draft
+**Version:** v1
+**Subsystem:** HARNESSES
+**Owner:** Engineering / Architecture
+**Last-updated:** 2026-06-05
+**Related:** [ADR-0004](../adr/0004-three-harnesses-shared-event-driven-common.md),
+[trusty-code](../../crates/trusty-code/README.md),
+[trusty-mpm](../../crates/trusty-mpm/README.md),
+[open-mpm](../../crates/open-mpm/README.md)
+
+---
+
+## Purpose & Scope
+
+The trusty-tools workspace organises its AI orchestration crates into **three
+distinct harnesses**, each serving a different principal and carrying different
+responsibilities. This document defines those boundaries, their shared
+foundation in `trusty-common`, the event-driven mandate that applies to all
+three, and the inter-harness delegation graph.
+
+**In scope:** harness identity, responsibilities, shared surface, event model,
+and delegation edges. **Out of scope:** internal implementation details of any
+single harness, tool lists, model routing specifics, and per-crate release
+procedures (those live in the crate-level README and `docs/<crate>/`).
+
+---
+
+## Table of Contents
+
+| Section | Topic |
+|---------|-------|
+| [Harness Definitions](#harness-definitions) | The three harnesses: purpose, analogy, scope |
+| [Comparison Table](#comparison-table) | Side-by-side harness summary |
+| [Shared Foundation — trusty-common](#shared-foundation--trusty-common) | What belongs to all harnesses |
+| [Event-Driven Mandate](#event-driven-mandate) | Binding architectural principle + event model |
+| [Inter-Harness Delegation](#inter-harness-delegation) | Call graph, boundaries, transport |
+| [Open Decision — Boundary Between trusty-mpm and trusty-agents](#open-decision--boundary-between-trusty-mpm-and-trusty-agents) | Flagged question with recommendation |
+| [Current Status vs. Target State](#current-status-vs-target-state) | What exists today and what is planned |
+
+---
+
+## Harness Definitions
+
+### 1. trusty-code — the Coding Harness
+
+**Crate:** `crates/trusty-code/` — package `-p trusty-code`, binary `tcode`
+**Analogy:** Claude Code — a per-project coding orchestration harness.
+
+**Purpose:** Provides the per-project Claude-Code-compatible MPM orchestration
+entry point. One `tcode serve` process runs per project root (identified by a
+`.claude/` directory). It runs the PM main loop, enforces the mandatory
+workflow (research → plan → implement → verify), and delegates authority to
+typed coding sub-agents (engineer, QA, ticketing, security) via MCP and/or
+subprocess IPC.
+
+**What it owns:**
+- The `tcode` binary and its IPC socket / HTTP endpoint
+- Per-project agent configuration (`.claude/agents/<name>.toml`)
+- Per-project skill injection (`.claude/skills/`)
+- Per-project workflow definitions (`.claude/workflows/<name>.toml`)
+- The PM main-loop for code-generation, edit, run, test cycles
+- Integration with Claude Code hooks (pre-tool-use, post-tool-use, stop)
+
+**What it does not own:**
+- Multi-project session management (that is trusty-mpm)
+- Non-coding assistant workflows (HR, CRM, scheduling — trusty-agents)
+- The daemon / TUI / Telegram transports (trusty-mpm)
+- Search, memory, or analysis infrastructure (trusty-search / trusty-memory / trusty-analyze / trusty-common)
+
+**Current state:** Phase 0 scaffold (`crates/trusty-code/src/main.rs` lines 1-107,
+`src/lib.rs` lines 1-62). The `tcode` binary parses its CLI surface (`serve`,
+`run-task`, `run-workflow`) but every subcommand stubs out with "not yet
+implemented (#587 Phase N)". Full extraction from `open-mpm` is tracked in
+epic #587.
+
+---
+
+### 2. trusty-mpm — the Meta-Harness
+
+**Crate:** `crates/trusty-mpm/` — package `-p trusty-mpm`,
+binaries: `tm` / `trusty-mpm` (CLI), `trusty-mpmd` (daemon), `trusty-mpm-tui`,
+`trusty-mpm-telegram`
+**Analogy:** Claude MPM — a PM-style multi-agent orchestrator *over* coding work.
+
+**Purpose:** Manages multi-project, multi-session AI workflows. It is the
+"operator's control plane": it runs the background daemon, relays hooks, tracks
+circuit-breaker state, exposes an MCP server to Claude Code sessions, and
+provides the TUI dashboard and Telegram bot for human oversight. It delegates
+coding tasks downward to `tcode` (trusty-code) instances; it does not execute
+code itself.
+
+**What it owns:**
+- `trusty-mpmd`: the always-on background daemon (HTTP API, hook relay, session
+  registry, watcher — `crates/trusty-mpm/src/daemon/`)
+- `tm` / `trusty-mpm` CLI: session control, service discovery, agent deploy
+- TUI: `ratatui`-based coordinator dashboard
+- Telegram bot: async operator notifications
+- MCP server: nine orchestration tools exposed to Claude Code sessions
+  (`session_list`, `session_status`, `agent_delegate`, `memory_protect`,
+  `circuit_breaker_status`, `list_recent_errors`, `preview_bug_report`,
+  `report_bug`, `hook_event` — `crates/trusty-mpm/src/mcp/`)
+- Session overseer + circuit breaker logic (`crates/trusty-mpm/src/core/overseer.rs`,
+  `src/core/circuit.rs`)
+- Cross-project session registry (`crates/trusty-mpm/src/core/session_store.rs`)
+- The `OrchestratorBackend` trait that binds MCP ↔ daemon
+  (`crates/trusty-mpm/src/mcp/mod.rs`)
+
+**What it does not own:**
+- Per-project coding execution (delegated to trusty-code)
+- General knowledge-worker assistant workflows (trusty-agents)
+- Search / memory / analysis infrastructure
+
+---
+
+### 3. trusty-agents — the Agentic Harness
+
+**Crate:** `crates/open-mpm/` (current name; planned rename to `trusty-agents`)
+**Package:** `-p open-mpm`, binaries: `open-mpm` / `ompm` (REPL + API server)
+**Analogy:** OpenClaw / Hermes — a general agentic harness for knowledge-worker tasks.
+
+**Purpose:** Provides a general-purpose agentic harness for non-coding workflows:
+CRM interaction, HR queries, scheduling, knowledge retrieval, memory management,
+communications (Slack, Telegram), and any domain-specific assistant persona. It
+uses the same PM-orchestrator-plus-sub-agent subprocess pattern as trusty-code
+but is NOT a coding harness. It is the integration point for external MCP
+services (`mcp_service_tools.rs`) and exposes configurable personas (Izzie,
+custom) via TOML agent definitions.
+
+**What it owns:**
+- PM orchestrator main loop with in-process `delegate_to_agent` tool
+  (`crates/open-mpm/src/ctrl/`)
+- Intent classifier for fast-pathing (conversational / research / implementation)
+  (`crates/open-mpm/src/intent/`)
+- MCP service bridge: wraps any MCP server's tools as `ToolExecutor` instances
+  (`crates/open-mpm/src/tools/mcp_service_tools.rs`)
+- Tool registry + RBAC + identity primitives (`crates/open-mpm/src/tools/`,
+  `src/rbac/`, `src/identity/`)
+- Persona system (agent TOML + skill injection)
+- Transports: REPL (`src/repl/`), HTTP API (`src/api/`), Slack (`src/slack/`),
+  Telegram (`src/telegram/`)
+- Harness adapter detection (recognises Claude Code, open-mpm, claude-mpm, Codex,
+  Gemini panes — `src/adapters/`)
+- Process-global event bus + SSE relay (`crates/open-mpm/src/events.rs`,
+  `src/bus/`)
+- Workflow engine for complex declarative pipelines (`crates/open-mpm/src/workflow/`)
+- Agent plugin API (`crates/open-mpm-agent-api/`) for external agent injection
+
+**What it does not own:**
+- Per-project coding workflow enforcement (trusty-code)
+- Multi-project session management / circuit breaker / hook relay (trusty-mpm)
+- Search infrastructure (trusty-search)
+- Memory storage engine (trusty-common `memory-core` feature + trusty-memory)
+
+**Planned rename:** `open-mpm` → `trusty-agents`. See
+[ADR-0004](../adr/0004-three-harnesses-shared-event-driven-common.md) §Decision
+for the rationale.
+
+---
+
+## Comparison Table
+
+| Dimension | trusty-code | trusty-mpm | trusty-agents |
+|-----------|-------------|------------|---------------|
+| **Analogy** | Claude Code | Claude MPM | OpenClaw / Hermes |
+| **Primary user** | Developer / CI pipeline | Operator / PM role | Knowledge worker |
+| **Scope** | One project, coding tasks | Many projects, orchestration control | Any domain, non-coding workflows |
+| **Main binary** | `tcode` | `tm` / `trusty-mpmd` | `open-mpm` / `ompm` |
+| **Core loop** | PM main loop (per project) | Session daemon + hook relay | PM main loop (per persona) |
+| **Agent model** | Coding sub-agents (engineer, QA, ticketing) | Overseer / delegation authority | Domain personas + MCP bridge |
+| **Tool source** | Claude Code tools + project skill files | Orchestration tools (MCP) | Any MCP service + native tools |
+| **Transports** | IPC socket / HTTP | HTTP API / MCP / TUI / Telegram | REPL / HTTP API / Slack / Telegram |
+| **What it delegates** | Sub-agents within project | Coding work to trusty-code | Coding tasks to trusty-code; managed projects to trusty-mpm |
+| **What it does not do** | Multi-project management | Execute code directly | Manage multi-project sessions |
+| **Crate status** | Phase 0 scaffold | Production | Production |
+| **Current crate name** | `trusty-code` | `trusty-mpm` | `open-mpm` (rename planned) |
+
+---
+
+## Shared Foundation — trusty-common
+
+**Binding principle:** Shared commonality lives in `trusty-common`. All three
+harnesses build their specialisation on top of it.
+
+`trusty-common` (`crates/trusty-common/`) is the cross-harness foundation. Its
+module surface is organised behind feature flags so each harness pulls in only
+what it needs. The following are relevant to all three harnesses:
+
+### Always-on (no feature flag required)
+
+| Module | Role for harnesses |
+|--------|--------------------|
+| `chat` | OpenRouter / Anthropic chat-completions client — the LLM call abstraction all three harnesses use |
+| `claude_config` | Reads `.claude/` configuration (agents, CLAUDE.md, permissions) — shared between trusty-code and trusty-mpm |
+| `project_discovery` | Locates project roots from a working directory |
+| `shutdown` | SIGTERM + SIGINT graceful-shutdown signal — every daemon in all three harnesses uses this |
+| `log_buffer` | Bounded in-memory log ring buffer for `/logs/tail` endpoints |
+| `sys_metrics` | RSS / CPU sampling for `/health` endpoints |
+
+### Feature-gated modules relevant to all three harnesses
+
+| Feature | Module | Purpose |
+|---------|--------|---------|
+| `mcp` | `trusty_common::mcp` | JSON-RPC 2.0 / MCP primitives (envelope types, stdio dispatch loop, OpenRPC discovery). Every MCP server in the workspace imports from here. |
+| `rpc` | `trusty_common::rpc` | General-purpose JSON-RPC client + stdio/HTTP transports |
+| `memory-core` | `trusty_common::memory_core` | Memory palace storage engine (palace, note, retrieval) — trusty-memory's backend; also used by trusty-agents |
+| `tickets` | `trusty_common::tickets` | Issue-tracker integration primitives |
+| `symgraph` | `trusty_common::symgraph` | Knowledge-graph data types (EntityType, RawEntity, EdgeKind) — used by trusty-search |
+| `embedder` | `trusty_common::embedder` | Text-embedding abstraction (Embedder trait, FastEmbedder) — used by trusty-search and trusty-analyze |
+| `bm25` | `trusty_common::bm25` | BM25 lexical index — used by trusty-search |
+| `axum-server` | `trusty_common::server` | Shared axum middleware (CORS, trace, gzip) — every HTTP daemon uses this |
+| `migrations` | `trusty_common::migrations` | Schema migration kernel shared by data-layer crates |
+
+### What SHOULD migrate to trusty-common (target state)
+
+The following currently live in `open-mpm` but belong in `trusty-common` as
+shared infrastructure so all three harnesses can use them without taking a
+dependency on a peer harness crate:
+
+1. **Tool registry and RBAC primitives** (`open-mpm/src/tools/traits.rs`,
+   `src/rbac/`, `src/identity/`) — the `ToolExecutor` trait, `ServiceTier` RBAC
+   enum, and `UserIdentity` are already partially extracted into
+   `open-mpm-agent-api` to break the cargo cycle. The next step is migrating
+   them into `trusty-common` behind a `tool-registry` feature flag so
+   trusty-code can use them without depending on `open-mpm`.
+2. **Shared event types** — see the [Event-Driven Mandate](#event-driven-mandate)
+   section below.
+3. **Intent classifier** (`open-mpm/src/intent/`) — the heuristic
+   `IntentClass` (Conversational / Research / Implementation) is a
+   cross-harness primitive.
+
+---
+
+## Event-Driven Mandate
+
+**Binding architectural principle: all three harnesses are event-driven.**
+
+An agent harness that blocks synchronously at each step is fragile: it cannot
+fan out to multiple sub-agents, cannot stream progress to a UI, and cannot relay
+events across process boundaries. The trusty-tools architecture requires that
+every harness publishes and subscribes to a well-defined event stream rather than
+operating in pure request-response mode.
+
+### Shared Event Model
+
+The shared event model lives (or will live) in `trusty-common` behind an `events`
+feature flag. It consists of:
+
+**Event envelope (wire format):**
+```rust
+// Target: trusty_common::events::HarnessEvent (to be extracted from open-mpm)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum HarnessEvent {
+    // Session lifecycle
+    SessionStarted   { session_id: String, project: String, harness: HarnessKind },
+    SessionFinished  { session_id: String, exit_code: i32 },
+    SessionError     { session_id: String, message: String },
+
+    // Agent lifecycle  
+    AgentStarted     { session_id: String, agent: String },
+    AgentFinished    { session_id: String, agent: String, elapsed_ms: u64 },
+    AgentMessage     { session_id: String, agent: String, content: String },
+
+    // Tool execution
+    ToolCall         { session_id: String, tool: String, args: serde_json::Value },
+    ToolResult       { session_id: String, tool: String, success: bool },
+
+    // PM / workflow
+    WorkflowPhase    { session_id: String, phase: String },
+    DelegationStarted{ session_id: String, target_harness: HarnessKind, task: String },
+    DelegationResult { session_id: String, target_harness: HarnessKind, success: bool },
+
+    // Infrastructure
+    Ping             { session_id: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessKind { TrustyCode, TrustyMpm, TrustyAgents }
+```
+
+**Transport mechanisms (per harness boundary):**
+
+| Boundary | Transport | Implementation |
+|----------|-----------|----------------|
+| Within a harness process | `tokio::sync::broadcast` | `open-mpm/src/events.rs` (EVENT_BUS OnceLock); to be replicated in trusty-mpm daemon |
+| Harness → UI (browser/TUI) | Server-Sent Events (SSE) over HTTP | open-mpm API `/events` endpoint; trusty-mpmd SSE stream |
+| trusty-mpm → trusty-code | HTTP POST to `tcode serve` endpoint | Planned in trusty-code Phase 1 (#587) |
+| Subprocess → parent | Stderr relay (`__OMPM_EVENT__ <json>`) | `open-mpm/src/events.rs` EVENT_LINE_PREFIX |
+| Cross-project (open-mpm) | Unix Domain Socket NDJSON bus | `open-mpm/src/bus/mod.rs` MessageBus |
+
+### Current Event-Driven Status
+
+| Harness | Event bus today | Gap |
+|---------|-----------------|-----|
+| **trusty-agents (open-mpm)** | Full: `EVENT_BUS` broadcast channel + SSE relay + UDS MessageBus; `Event` enum covers full PM lifecycle (`src/events.rs`, `src/bus/mod.rs`) | Events not yet typed in shared `trusty-common`; bus types are crate-private |
+| **trusty-mpm** | Partial: hook relay and daemon state changes fire events; no process-global broadcast bus exposed to MCP layer | Missing: typed event bus in daemon; MCP notifications not streamed |
+| **trusty-code** | None: Phase 0 stub | Requires full implementation in Phase 1+ (#587) |
+
+**Required work to close the gap:**
+1. Extract `open-mpm`'s `Event` enum (with `HarnessKind` tag) into `trusty-common::events`.
+2. Add a `broadcast::Sender<HarnessEvent>` to `trusty-mpmd`'s daemon state.
+3. Implement event emission in trusty-code Phase 1.
+
+---
+
+## Inter-Harness Delegation
+
+### Delegation Graph
+
+```
+                              ┌────────────────────┐
+                              │   Human / Operator │
+                              └─────────┬──────────┘
+                                        │ (chat, Telegram, TUI, Slack)
+                                        ▼
+                   ┌────────────────────────────────────────┐
+                   │        trusty-agents (open-mpm)        │
+                   │  General agentic harness               │
+                   │  - Intent classifier                   │
+                   │  - MCP service bridge                  │
+                   │  - Domain personas (Izzie, custom)     │
+                   └──────────────┬─────────────────────────┘
+                                  │ (1) coding task
+                                  │ (2) managed multi-agent project
+                          ┌───────┴────────────┐
+                          │                    │
+                          ▼                    ▼
+        ┌─────────────────────────┐   ┌──────────────────────────────┐
+        │  trusty-code (tcode)    │   │  trusty-mpm (tm / mpmd)      │
+        │  Coding harness         │   │  Meta-harness (PM control)   │
+        │  - PM main loop         │◄──│  - Multi-project sessions    │
+        │  - coding sub-agents    │   │  - Circuit breaker / overseer│
+        │  - per-project config   │   │  - Hook relay                │
+        │  - workflows            │   │  - MCP server to Claude Code │
+        └─────────────────────────┘   └──────────────────────────────┘
+                   ▲
+                   │ (3) session delegation
+                   │
+        ┌──────────┴───────────────────────────────────────────────┐
+        │                    trusty-mpm                            │
+        │  delegates coding work to tcode; monitors its sessions   │
+        └──────────────────────────────────────────────────────────┘
+```
+
+### Delegation Edges (Defined)
+
+| From | To | Trigger | Transport | What is passed | What is returned |
+|------|----|---------|-----------|----------------|-----------------|
+| **trusty-agents** | **trusty-code** | Intent classified as `Implementation` — a coding task | HTTP POST to `tcode serve` IPC endpoint (Phase 1) OR CLI subprocess `tcode run-task <agent> <task>` | Task description, agent name, optional context | Result text, exit code |
+| **trusty-agents** | **trusty-mpm** | Multi-agent project requiring session management, QA enforcement, or hook relay | HTTP POST to `trusty-mpmd` API OR MCP tool `agent_delegate` | Task description, workflow name, session constraints | Session ID, delegation ID, result |
+| **trusty-mpm** | **trusty-code** | New coding session created or existing session overseen | Session launch via `session_launch::SessionLaunchConfig` (`crates/trusty-mpm/src/core/session_launch.rs`) → spawns `tcode serve` subprocess | Project path, agent config, model tier, overseer policy | Session ID; events relayed via hook relay |
+
+### Delegation Contracts
+
+**trusty-agents → trusty-code (coding delegation):**
+- Inputs: `{ agent: String, task: String, project_path: PathBuf, context: Option<String> }`
+- Outputs: `{ result: String, exit_code: i32, session_id: String }`
+- Precondition: `tcode serve` must be running for `project_path`; or trusty-agents
+  spawns a transient `tcode` instance
+- Error: timeout, agent not found, or compilation failure — returned as
+  `DelegationResult { success: false }`
+
+**trusty-agents → trusty-mpm (managed project delegation):**
+- Inputs: MCP tool call `agent_delegate(session_id, agent, task, tier?)`
+- Outputs: `{ delegation_id: String }` (async — caller subscribes to events
+  for completion)
+- Precondition: `trusty-mpmd` running; session established
+- Error: circuit-breaker open, session not found — MCP error response
+
+**trusty-mpm → trusty-code (session management):**
+- Inputs: `SessionLaunchConfig { project_path, agent_names, overseer_policy, model_tier }`
+- Outputs: `SessionId` registered in session store; events relayed via hook relay
+- Precondition: `tcode` binary on PATH; project has `.claude/` config
+- Error: binary not found, project not initialised — `SessionStatus::Error`
+
+### What is NOT a cross-harness delegation
+
+- trusty-search, trusty-memory, trusty-analyze are **tool-layer services**, not
+  harnesses. All three harnesses call them over HTTP/MCP as tools; this is not
+  delegation in the harness sense.
+- trusty-code calling its own sub-agents (engineer, QA, ticketing) is
+  **intra-harness** delegation, not cross-harness.
+
+---
+
+## Open Decision — Boundary Between trusty-mpm and trusty-agents
+
+**Status: OPEN — requires owner decision before work begins on epic #587.**
+
+### The Problem
+
+Both `open-mpm` (trusty-agents) and `trusty-mpm` carry orchestration/PM-style
+machinery that overlaps:
+
+| Capability | open-mpm location | trusty-mpm location |
+|------------|-------------------|---------------------|
+| PM main loop | `src/ctrl/` (agent orchestrator REPL) | Not present (delegates to tcode) |
+| Workflow engine | `src/workflow/` (phase-based pipelines) | Not present |
+| Multi-agent session management | `src/session*.rs`, `src/session/` | `src/core/session_store.rs`, `src/daemon/` |
+| Intent classification | `src/intent/` (heuristic classifier) | Not present |
+| Tool registry + RBAC | `src/tools/`, `src/rbac/` | Not present (uses Claude Code's tool layer) |
+| Harness adapter detection | `src/adapters/` | Implicit (via hook relay) |
+| MCP service bridge | `src/tools/mcp_service_tools.rs` | Implicit (Claude Code sessions invoke MCP servers directly) |
+| Event bus | `src/events.rs`, `src/bus/` | Partial (hook relay only) |
+
+### The Clean Line (Proposed)
+
+**PM / workflow / multi-agent orchestration belongs to trusty-mpm (the meta-harness).
+General non-coding assistants belong to trusty-agents.**
+
+More precisely:
+
+1. **`open-mpm/src/workflow/`** — the `WorkflowEngine` and declarative phase
+   pipelines (`WorkflowDef`, `PhaseDef`, parallel phases, worktree management,
+   autopush) are **generic orchestration logic** that belongs in `trusty-mpm` or
+   eventually `trusty-common`. They are not specific to knowledge-worker workflows.
+   **Recommendation: migrate to trusty-mpm or trusty-common.**
+
+2. **`open-mpm/src/ctrl/`** (the PM orchestrator loop) — this is the core of
+   what will become trusty-code. The subset that drives coding agents belongs in
+   `trusty-code` (epic #587). The subset that drives knowledge-worker personas
+   stays in trusty-agents. The split follows intent: if the agent being driven is
+   a coding agent, it belongs to trusty-code; if it is a domain persona (Izzie,
+   CRM assistant), it belongs to trusty-agents.
+   **Recommendation: split by agent type as part of #587 extraction.**
+
+3. **`open-mpm/src/session*.rs`** (session registry, session record) — session
+   management at the multi-project level belongs to `trusty-mpm`. Session state
+   that is intrinsic to a single knowledge-worker conversation stays in
+   trusty-agents.
+   **Recommendation: trusty-mpm owns cross-project sessions; trusty-agents owns
+   per-conversation session state for its own loops.**
+
+4. **`open-mpm/src/tools/`, `src/rbac/`, `src/identity/`** — the
+   `ToolExecutor` trait + `ServiceTier` RBAC + `UserIdentity` are already
+   partially in `open-mpm-agent-api`. These are shared primitives.
+   **Recommendation: migrate to `trusty-common` behind a `tool-registry` feature
+   flag.**
+
+5. **`open-mpm/src/events.rs`, `src/bus/`** — the event bus belongs to
+   `trusty-common` so all harnesses can share it.
+   **Recommendation: migrate to `trusty-common::events`.**
+
+6. **`open-mpm/src/intent/`** — the intent classifier is a shared primitive.
+   **Recommendation: migrate to `trusty-common::intent`.**
+
+7. **`open-mpm/src/adapters/`** (harness adapter detection) — this is trusty-mpm
+   level functionality (recognising which harness is in a tmux pane). It currently
+   lives in open-mpm for historical reasons.
+   **Recommendation: migrate to trusty-mpm or trusty-common.**
+
+### What Stays Exclusively in trusty-agents After the Split
+
+- MCP service bridge (`mcp_service_tools.rs`) — wrapping external MCP servers as
+  tool executors for knowledge-worker personas
+- Domain persona definitions (Izzie and custom TOML personas)
+- Knowledge-worker tool set: `granola_*`, `gmail_*`, calendar, web search, memory
+  read/write, ticketing
+- REPL, HTTP API, Slack, Telegram transports for knowledge-worker interaction
+- Per-conversation session state and interaction log
+- Intent classifier (until extracted to trusty-common)
+
+### Owner's Decision Required
+
+Before any code moves, the owner must decide:
+
+1. Does `open-mpm/src/workflow/` consolidate into `trusty-mpm`, or does it remain
+   in trusty-agents as a shared utility?
+2. Does the PM main loop in `open-mpm/src/ctrl/` split simultaneously with #587,
+   or does that split happen in a later phase?
+3. Is the rename `open-mpm` → `trusty-agents` in-scope for the same PR as #587,
+   or a separate rename commit?
+
+This document records the proposed answers; the ADR (below) records the final
+decision once the owner has reviewed.
+
+---
+
+## Current Status vs. Target State
+
+| Harness | Today | Target |
+|---------|-------|--------|
+| **trusty-code** | Phase 0: CLI stub only | Full coding PM loop, extracted from open-mpm (#587) |
+| **trusty-mpm** | Production: daemon, MCP, TUI, Telegram | + Typed event bus; + session delegation to tcode; + workflow engine (migrated from open-mpm) |
+| **trusty-agents (open-mpm)** | Production: PM loop, intent router, MCP bridge, personas | Renamed `trusty-agents`; coding-specific ctrl extracted to tcode; shared primitives migrated to trusty-common |
+| **trusty-common** | Foundation: chat, mcp, rpc, memory-core, embedder, symgraph, bm25 | + `events` feature (shared event types); + `tool-registry` feature (ToolExecutor, RBAC); + `intent` module |
+
+---
+
+## References
+
+- [ADR-0004](../adr/0004-three-harnesses-shared-event-driven-common.md) — records
+  the three-harness + event-driven + shared-trusty-common decisions
+- `crates/trusty-code/src/main.rs` — Phase 0 CLI surface (lines 1-107)
+- `crates/trusty-code/src/lib.rs` — Phase 0 library skeleton (lines 1-62)
+- `crates/open-mpm/src/events.rs` — current event bus + Event enum
+- `crates/open-mpm/src/bus/mod.rs` — UDS inter-project message bus
+- `crates/open-mpm/src/intent/mod.rs` — intent classifier
+- `crates/open-mpm/src/tools/mcp_service_tools.rs` — MCP service bridge
+- `crates/open-mpm/src/workflow/mod.rs` — workflow engine
+- `crates/trusty-mpm/src/mcp/mod.rs` — OrchestratorBackend trait + MCP tools
+- `crates/trusty-mpm/src/core/overseer.rs` — OverseerDecision + Overseer trait
+- `crates/trusty-mpm/src/core/session_store.rs` — cross-project session registry
+- `crates/trusty-common/src/lib.rs` — feature-gated shared modules
+- Epic #587 — trusty-code extraction phases


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/harnesses.md` — the architecture overview spec defining the three harnesses (coding / meta / agentic), their shared `trusty-common` foundation, the event-driven mandate + shared event model, and the inter-harness delegation graph
- Adds `docs/adr/0004-three-harnesses-shared-event-driven-common.md` — the ADR recording all three-harness decisions, the `open-mpm` → `trusty-agents` rename, and the open-mpm/trusty-mpm boundary proposal (Status: Proposed — flagged open questions require owner decision before implementation)
- Adds `crates/trusty-code/README.md` (was missing) and adds harness-role cross-links to `crates/trusty-mpm/README.md` and `crates/open-mpm/README.md`
- Updates `docs/adr/README.md` index

**No `.rs` files were modified.** `bash scripts/check_line_cap.sh` exits 0.

## Three-Harness Boundaries

| Harness | Crate | Analogy | Principal |
|---------|-------|---------|-----------|
| **trusty-code** | `crates/trusty-code/` | Claude Code | Developer / CI pipeline |
| **trusty-mpm** | `crates/trusty-mpm/` | Claude MPM | Operator / PM role |
| **trusty-agents** | `crates/open-mpm/` (rename) | OpenClaw / Hermes | Knowledge worker |

## Shared trusty-common Surface

Always-on: `chat`, `claude_config`, `project_discovery`, `shutdown`, `log_buffer`, `sys_metrics`

Feature-gated (already present): `mcp`, `rpc`, `memory-core`, `embedder`, `symgraph`, `bm25`, `axum-server`, `migrations`

**Proposed additions** (documented in spec, not yet implemented): `events` feature (shared HarnessEvent enum), `tool-registry` feature (ToolExecutor/RBAC), `intent` module

## Delegation Graph

```
trusty-agents → trusty-code   (coding task: HTTP POST / CLI subprocess)
trusty-agents → trusty-mpm    (managed multi-agent project: MCP agent_delegate)
trusty-mpm    → trusty-code   (session launch: SessionLaunchConfig → tcode subprocess)
```

No reverse edges. No harness takes a Cargo dependency on a sibling harness.

## Flagged Open Decision (ADR-0004)

**open-mpm/trusty-mpm boundary — Status: Proposed, requires owner decision.**

Recommendation (documented in spec and ADR):
- `open-mpm/src/workflow/` (WorkflowEngine) → migrate to `trusty-mpm` first; promote to `trusty-common` only if trusty-agents needs it
- Coding ctrl loop in `open-mpm/src/ctrl/` → extract to `trusty-code` as part of epic #587
- Knowledge-worker ctrl loop → stays in `trusty-agents`
- Cross-project session registry → migrate to `trusty-mpm`
- Event bus types, tool registry/RBAC, intent classifier → migrate to `trusty-common`
- Harness adapter detection (`src/adapters/`) → migrate to `trusty-mpm`

Three open questions listed in ADR-0004 §Open Questions for owner decision before any code moves.

## Test plan

- [ ] `bash scripts/check_line_cap.sh` in worktree exits 0 (verified: "172 allowlisted, 0 violations")
- [ ] All pre-commit hooks pass (verified: trim-whitespace, secrets-detect, line-cap all Passed)
- [ ] Markdown renders sanely in GitHub (review PR preview)
- [ ] All cross-links in the spec and ADR resolve to existing files in the repo
- [ ] ADR-0004 index entry in `docs/adr/README.md` points to correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)