### PR TITLE
feat(trusty-common): add local-time timestamp prefix to dashboard log lines

### DIFF
--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -115,7 +115,10 @@ r2d2_sqlite = { workspace = true, optional = true }
 git2 = { workspace = true, optional = true }
 dashmap = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
-chrono = { workspace = true, optional = true }
+# Non-optional: the unconditional `log_buffer` module timestamps each captured
+# dashboard log line via `chrono::Local` (issue #846). It must be available in
+# default-features builds, so it cannot be gated behind a feature flag.
+chrono = { workspace = true }
 regex = { workspace = true, optional = true }
 kuzu = { workspace = true, optional = true }
 redb = { workspace = true, optional = true }
@@ -287,7 +290,6 @@ memory-core = [
     "dep:git2",
     "dep:dashmap",
     "dep:futures",
-    "dep:chrono",
     "dep:regex",
     "dep:parking_lot",
     "dep:thiserror",
@@ -326,7 +328,7 @@ sqlite-kg = [
 # ratatui + crossterm; the daemon HTTP clients reuse the `reqwest` already
 # required. Consumed via `trusty_common::monitor::run()` by the
 # `monitor tui` subcommand of `trusty-search` and `trusty-memory`.
-monitor-tui = ["dep:ratatui", "dep:crossterm", "dep:chrono"]
+monitor-tui = ["dep:ratatui", "dep:crossterm"]
 # Enables the `embedder_client` module: HTTP client trait + wire types +
 # InProcessEmbedderClient + RemoteEmbedderClient for the `trusty-embedderd`
 # standalone process (issue #110 Phase 1). Formerly the `trusty-embedder-client`
@@ -343,7 +345,7 @@ embedder-client = ["dep:thiserror", "embedder"]
 # JIRA, and Linear backends (absorbed from the former standalone `trusty-tickets`
 # crate). Pulls in `chrono`, `uuid`, `base64`, `thiserror`, and `toml` as
 # additional optional deps. Requires the `mcp` feature for the stdio loop.
-tickets = ["mcp", "dep:chrono", "dep:uuid", "dep:base64", "dep:thiserror", "dep:toml"]
+tickets = ["mcp", "dep:uuid", "dep:base64", "dep:thiserror", "dep:toml"]
 # Enables the `help` module: declarative CLI help loader (`HelpConfig` parsed
 # from a per-binary `help.yaml` bundled via `include_str!`), the canonical
 # `render_help` formatter, and a Jaro-Winkler-based `suggest("did you mean?")`

--- a/crates/trusty-common/src/log_buffer.rs
+++ b/crates/trusty-common/src/log_buffer.rs
@@ -124,9 +124,12 @@ impl LogBuffer {
 /// Why: wiring this layer into the subscriber means the daemon's normal
 ///      `tracing::info!` / `warn!` calls are captured for `/logs/tail` with
 ///      no extra call sites — the buffer stays in lock-step with stderr.
-/// What: on each event, formats `[<level> <target>] <message> k=v …` into a
-///      single line and pushes it. Level/target/fields are collected via a
-///      lightweight `Visit` implementation.
+/// What: on each event, formats
+///      `<YYYY-MM-DD HH:MM:SS> [<level> <target>] <message> k=v …` into a
+///      single line and pushes it. The leading local-time timestamp (issue
+///      #846) lets the dashboard log view show when each line was emitted.
+///      Level/target/fields are collected via a lightweight `Visit`
+///      implementation.
 /// Test: `layer_captures_events` installs the layer on a real subscriber and
 ///      asserts an emitted event lands in the buffer.
 pub struct LogBufferLayer {
@@ -196,8 +199,14 @@ impl<S: tracing::Subscriber> Layer<S> for LogBufferLayer {
         // Trim the leading `"` artefact that `{:?}` adds for the message when
         // the payload was a quoted string literal — keep lines readable.
         let message = visitor.message.trim_matches('"');
+        // Prepend a local-time timestamp (issue #846) so the dashboard log
+        // view shows per-line timing. We use `chrono::Local` directly rather
+        // than `tracing_subscriber::fmt::time::LocalTime`, which is unsound in
+        // multithreaded programs.
+        let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
         let line = format!(
-            "[{} {}] {}{}",
+            "{} [{} {}] {}{}",
+            ts,
             meta.level(),
             meta.target(),
             message,
@@ -264,5 +273,33 @@ mod tests {
         assert!(line.contains("hello from test"), "line was: {line}");
         assert!(line.contains("answer=42"), "line was: {line}");
         assert!(line.contains("INFO"), "line was: {line}");
+
+        // Issue #846: every line is prefixed with a `YYYY-MM-DD HH:MM:SS `
+        // local-time timestamp. Lock in the shape without over-fitting to a
+        // specific clock value: 4-digit year, then '-', then a space-delimited
+        // time component, with the level appearing after the timestamp.
+        let bytes = line.as_bytes();
+        assert!(
+            bytes.len() >= 19,
+            "line too short to hold a timestamp: {line}"
+        );
+        assert!(
+            bytes[0..4].iter().all(u8::is_ascii_digit),
+            "expected a 4-digit year prefix, line was: {line}"
+        );
+        assert_eq!(
+            bytes[4], b'-',
+            "expected '-' after the year, line was: {line}"
+        );
+        // The timestamp must come before the level/target bracket.
+        let ts_end = line
+            .find(" [")
+            .expect("expected a ' [' after the timestamp");
+        let ts = &line[..ts_end];
+        assert_eq!(
+            ts.len(),
+            19,
+            "timestamp should be exactly 'YYYY-MM-DD HH:MM:SS', got: {ts:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #846.

## What

Prepends a `YYYY-MM-DD HH:MM:SS` **local-time** timestamp to every dashboard log line by editing `LogBufferLayer::on_event` in `crates/trusty-common/src/log_buffer.rs`. This timestamps the Logs view of **both** the trusty-search and trusty-memory dashboards (they share `LogBufferLayer` and each serve `/logs/tail` from the in-memory ring buffer).

Before:
```
[INFO trusty_search::service::reindex] reindex complete: index=mcp-services files=876 ...
```
After:
```
2026-06-06 14:32:07 [INFO trusty_search::service::reindex] reindex complete: index=mcp-services files=876 ...
```

## Changes

- **`crates/trusty-common/src/log_buffer.rs`** — `on_event` now prepends `chrono::Local::now().format("%Y-%m-%d %H:%M:%S")`. Uses `chrono::Local` deliberately (NOT `tracing_subscriber::fmt::time::LocalTime`, which is documented-unsound in multithreaded programs). Why/What/Test doc comment updated. The `layer_captures_events` unit test now asserts the timestamp shape (4-digit year, `-` separators, exact 19-char `YYYY-MM-DD HH:MM:SS` segment).
- **`crates/trusty-common/Cargo.toml`** — `chrono` made non-optional (`chrono = { workspace = true }`). Required because the `log_buffer` module is unconditional, whereas `chrono` was previously only activated by the `monitor-tui`/`tickets`/`memory-core` features — without this a default-features build (e.g. trusty-search's tree) would fail to compile. The now-invalid `dep:chrono` tokens were removed from those three feature definitions; no `chrono/<subfeature>` activations existed, and the workspace dep keeps default features (so `clock`/`Local` stays available).

## Not changed (deliberate)

- **stderr / `init_tracing*` fmt layer** — left untouched. stderr/launchd logs already carry timestamps via `tracing_subscriber`'s default `SystemTime` (UTC) timer. Note: this means stderr stays UTC while the dashboard is local time — an accepted divergence.
- **UI / Svelte** — no changes needed. `LogViewer` renders buffer strings verbatim; level coloring uses a word-boundary regex and filtering is substring-based, so a leading timestamp is safe.

## Verification

- `cargo fmt --check` — clean
- `cargo check -p trusty-common` and `cargo check -p trusty-search` — pass (confirms default-features tree compiles with non-optional chrono)
- `cargo check -p trusty-common --features memory-core,monitor-tui,tickets` — pass (feature unification intact after `dep:chrono` removal)
- `cargo clippy -p trusty-common --all-targets -- -D warnings` — zero warnings
- `cargo test -p trusty-common` — all pass, including the updated `layer_captures_events`
- line-cap gate — `log_buffer.rs` 305 lines, under the 500 cap; 0 violations

Implementation was independently adversarially reviewed (verdict: APPROVE) — commit is clean (exactly 2 source files, no `ui-dist/` artifacts), timestamp correctly prepended, format string exact, and `init_tracing`/UI untouched.

## Manual smoke test for reviewer

Restart a daemon (`launchctl bootout`/`bootstrap`), trigger a reindex, and confirm the dashboard Logs view shows lines like `2026-06-06 14:32:07 [INFO trusty_search::service::reindex] reindex complete: ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)