### PR TITLE
chore(release): trusty-search 0.24.0

### DIFF
--- a/crates/open-mpm/Cargo.toml
+++ b/crates/open-mpm/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.15.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.23.0" }
+trusty-search = { path = "../trusty-search", version = "0.24.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,38 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.24.0] — 2026-06-06
+
+### Fixed
+
+- **#839 — incremental reindex data-loss carryover** — unchanged chunks are now
+  carried from the durable corpus into the staging corpus on every non-force
+  reindex, so files that were not re-parsed do not disappear from search results
+  after a reindex completes (closes #839, PR #844).
+- **#840/#849 — warm-boot opens durable redb corpus** — on daemon restart the
+  existing on-disk redb corpus is opened and chunk-hashes loaded immediately,
+  so the first reindex after a restart is incremental (only new/changed files)
+  rather than a full re-embed; the SSE `start` event now includes a
+  `hashes_loaded` field reporting the number of pre-loaded hashes (PR #849).
+- **#848 — prune deleted files on non-force reindex** — files that have been
+  removed from disk are now pruned from the corpus during a standard (non-force)
+  reindex, so the index no longer accumulates stale chunks for deleted files
+  (closes #848, PR #854).
+
+### Changed
+
+- **#826 — concurrent CHUNK+EMBED progress bars** — the reindex CLI now shows
+  the CHUNK and EMBED phases concurrently with live CPS stats, fixes the
+  spurious "Embed 0/1" display, and un-sticks the embedder-ready indicator
+  (closes #823, PR #826).
+- **#828 — server.rs split** — `service/server.rs` refactored into focused
+  submodules under the 500-line cap (closes #799, PR #828).
+- **#805 — watcher path normalization** — file-watcher paths are now normalized
+  to repo-root-relative before comparison, fixing spurious "file not in index"
+  warnings on macOS (PR #805).
+
+---
+
 ## [0.23.6] — 2026-06-04
 
 ### Changed

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.23.7"
+version = "0.24.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version bump `0.23.7` → `0.24.0` for trusty-search. MINOR bump because this bundles 6 unreleased fix/refactor PRs that shipped to main since the last patch series.

**Bundled fixes:**
- **#839/#844** — incremental reindex data-loss: unchanged chunks now carried into staging corpus on non-force reindex
- **#840/#849** — warm-boot opens durable redb corpus so daemon restarts yield incremental (not full) reindex; `hashes_loaded` in SSE `start` event
- **#848/#854** — prune deleted files on non-force reindex (stale chunks no longer accumulate for removed files)
- **#826** — concurrent CHUNK+EMBED progress bars, fix Embed 0/1, unstick embedder_ready
- **#828** — `server.rs` split into submodules under 500-line cap
- **#805** — normalize file-watcher paths to repo-root-relative

## Changes

- `crates/trusty-search/Cargo.toml`: `version = "0.23.7"` → `"0.24.0"`
- `crates/trusty-search/CHANGELOG.md`: added 0.24.0 entry

## Test plan

- [ ] CI passes (fmt, clippy, tests, line-cap)
- [ ] `git show origin/main:crates/trusty-search/Cargo.toml | grep version` shows `0.24.0` after merge
- [ ] Tag `trusty-search-v0.24.0` pushed and daemon redeployed via `cargo install --locked`
- [ ] `/health` shows `"version":"0.24.0"` post-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)