### PR TITLE
Wave 2: extract TokenUsage/PerfRecord + AgentRunner DI seam into trusty-agents-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10686,6 +10686,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -22,3 +22,5 @@ regex = { workspace = true }
 [dev-dependencies]
 # session_registry tests use tempfile for isolated state-dir creation.
 tempfile = { workspace = true }
+# runner::tests uses #[tokio::test] for the async AgentRunner default-impl test.
+tokio = { workspace = true }

--- a/crates/trusty-agents-common/src/lib.rs
+++ b/crates/trusty-agents-common/src/lib.rs
@@ -22,6 +22,33 @@
 //! Test: Compile-tested transitively via `crates/cto-assistant` (downstream
 //!       agent) and `crates/trusty-agents` (host).
 
+/// Portable perf value types: `TokenUsage`, `PhaseRecord`, `PerfTotals`, `PerfRecord`.
+///
+/// Why: Moved to trusty-agents-common in Wave 2 (issue #867, refs #830/#832) so
+///      external crates and the runner seam can reference `TokenUsage` (used in
+///      `AgentOutput`) without depending on the full `trusty-agents` binary crate.
+///      `PerfCollector` (stateful, tokio-dependent) stays in `trusty-agents::perf`.
+/// What: The four portable plain-data types for per-phase token counting,
+///       cost tracking, and full run record serialisation.
+/// Test: Unit tests in `perf::tests` plus compile-tested via `trusty-agents`.
+pub mod perf;
+
+/// AgentRunner DI seam: `HistoryMessage`, `RunContext`, `AgentOutput`, and
+/// the `AgentRunner` async trait.
+///
+/// Why: Moved to trusty-agents-common in Wave 2 (issue #867, refs #830/#832)
+///      so external crates that need to implement or test against `AgentRunner`
+///      can depend on this lightweight crate without pulling in the full
+///      `trusty-agents` binary crate.
+/// What: The runner seam — once `TokenUsage` (perf) is here, the only
+///       remaining dependencies are `std`, `anyhow`, `async-trait`, and
+///       `serde`. `HistoryMessage` is the portable IPC wire form
+///       (`{role, content}` + serde); its `into_typed()` conversion
+///       (requiring `async-openai`) stays in `trusty-agents::session`.
+/// Test: `test_run_with_history_forwards_ctx` in `runner::tests` (bug #122
+///       regression guard); compile-tested via `trusty-agents`.
+pub mod runner;
+
 /// Harness adapter framework: `HarnessAdapter` trait, value types, pattern
 /// helpers, `AdapterRegistry`, and 7 concrete adapters.
 ///

--- a/crates/trusty-agents-common/src/perf.rs
+++ b/crates/trusty-agents-common/src/perf.rs
@@ -1,0 +1,218 @@
+//! Portable perf value types shared between `trusty-agents` and external crates.
+//!
+//! Why: (#47) Tracking per-phase token counts, costs, and durations is a
+//! cross-cutting concern used by the workflow engine, the PM loop, the
+//! session record, and future external analysis tools. Placing the plain-data
+//! types here (without stateful collection or async I/O) lets every layer
+//! reference them without depending on the full `trusty-agents` binary crate.
+//! What: Defines the four portable value types:
+//! - `TokenUsage` — per-LLM-call token counter (prompt/completion/cache)
+//! - `PhaseRecord` — per-phase duration + token snapshot
+//! - `PerfTotals` — rolled-up totals across all phases in a run
+//! - `PerfRecord` — full run record (persisted to `docs/performance/runs/`)
+//! `PerfCollector` (stateful, tokio-dependent) is NOT here — it stays in
+//! `trusty-agents::perf`.
+//! Test: `token_usage_default_is_zeros`, `token_usage_accumulates` in
+//! `trusty-agents::perf::tests`; compile-tested via `trusty-agents-common`
+//! unit tests.
+
+use serde::{Deserialize, Serialize};
+
+/// Token usage captured from a single LLM round-trip.
+///
+/// Why: (#50) Anthropic's OpenRouter responses carry cache_read_input_tokens
+/// and cache_creation_input_tokens alongside the standard prompt/completion
+/// counts. Exposing those as first-class fields lets `PerfCollector` track
+/// cache effectiveness over time. For non-Anthropic models these stay 0.
+/// What: Plain struct; additive (`+`-style) accumulation is done inline in
+/// `PerfCollector::totals`.
+/// Test: `token_usage_default_is_zeros`, `token_usage_accumulates` in
+/// `trusty-agents::perf::tests`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub cache_read_tokens: u32,
+    pub cache_creation_tokens: u32,
+}
+
+impl TokenUsage {
+    /// Construct a `TokenUsage` from the four individual counts.
+    pub fn new(prompt: u32, completion: u32, cache_read: u32, cache_creation: u32) -> Self {
+        Self {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            cache_read_tokens: cache_read,
+            cache_creation_tokens: cache_creation,
+        }
+    }
+
+    /// Add another usage record into this one (in place).
+    ///
+    /// Why: Each phase may comprise multiple LLM turns (tool loop); we sum
+    /// them into a single `PhaseRecord`.
+    /// What: Field-wise saturating add.
+    /// Test: `token_usage_accumulates` in `trusty-agents::perf::tests`.
+    pub fn add(&mut self, other: &TokenUsage) {
+        self.prompt_tokens = self.prompt_tokens.saturating_add(other.prompt_tokens);
+        self.completion_tokens = self
+            .completion_tokens
+            .saturating_add(other.completion_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(other.cache_read_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(other.cache_creation_tokens);
+    }
+}
+
+/// One phase's measured performance.
+///
+/// Why: Recording per-phase data (not just totals) lets post-hoc analysis
+/// pinpoint which phase consumed the most tokens or time.
+/// What: Name, duration, the four token buckets from `TokenUsage`, and the
+/// computed USD cost.
+/// Test: Constructed by `PerfCollector::record_phase` in `trusty-agents::perf`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PhaseRecord {
+    pub name: String,
+    pub duration_ms: u64,
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub cache_read_tokens: u32,
+    pub cache_creation_tokens: u32,
+    pub cost_usd: f64,
+}
+
+/// Totals rolled up from every `PhaseRecord` in a run.
+///
+/// Why: Convenience aggregate so consumers don't have to sum phases themselves.
+/// What: Field-wise sums of the four token buckets plus total cost.
+/// Test: `collector_totals_sum_phases` in `trusty-agents::perf::tests`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PerfTotals {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub cache_read_tokens: u32,
+    pub cache_creation_tokens: u32,
+    pub cost_usd: f64,
+}
+
+/// Full performance record persisted to `docs/performance/runs/`.
+///
+/// Why: One JSON file per run under `runs/` gives greppable history without a
+/// database; the `runs.log` one-liner makes it easy to spot regressions.
+/// What: Build number, version, workflow name, task preview, ISO start time,
+/// total duration, all phases, rolled-up totals, run status, skills used/considered,
+/// and optional QA test counts.
+/// Test: `collector_flush_writes_json_and_log`, `test_run_record_serializes_test_counts`
+/// in `trusty-agents::perf::tests`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerfRecord {
+    pub build: u64,
+    pub version: String,
+    pub workflow: String,
+    pub task_preview: String,
+    pub started_at: String,
+    pub total_duration_ms: u64,
+    pub phases: Vec<PhaseRecord>,
+    pub totals: PerfTotals,
+    /// Run outcome (#56): "success" | "partial" | "failed".
+    ///
+    /// Why: When a phase fails mid-workflow, we still want to persist the
+    /// perf record so we can see where/how the run died. A separate `status`
+    /// field distinguishes clean completions from partial runs in tooling
+    /// that scans `runs/*.json`.
+    /// What: Defaults to "success" for back-compat with older fixtures.
+    #[serde(default = "default_status")]
+    pub status: String,
+    /// Name of the phase that failed, when `status != "success"` (#56).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_phase: Option<String>,
+    /// Distinct skill names injected into any phase prompt during this run
+    /// (#171).
+    ///
+    /// Why: Post-run persistence needs to know which skills were used so it
+    /// can increment `use_count` and refresh `last_used`. Carrying the list
+    /// through `PerfRecord` keeps the data in one place that's already
+    /// flushed to disk for analysis.
+    /// What: Deduplicated, insertion-order-preserved list of skill names.
+    /// Defaults to empty for back-compat with older fixtures.
+    #[serde(default)]
+    pub skills_used: Vec<String>,
+    /// Distinct skill names matched by the pre-plan discovery step (#173).
+    ///
+    /// Why: Discovery surfaces every skill the engine considered relevant for
+    /// a task — even if downstream prompt assembly only injected a subset (or
+    /// none). Recording the broader candidate set separately from
+    /// `skills_used` lets us measure recall vs. precision over time and
+    /// audit which signals the discovery step matched on.
+    /// What: Deduplicated, insertion-order-preserved list of skill names.
+    /// Defaults to empty for back-compat with older fixtures.
+    #[serde(default)]
+    pub skills_considered: Vec<String>,
+    /// Tests passed in the QA phase, when the QA agent emitted a parsable
+    /// JSON envelope with a `passed` count.
+    ///
+    /// Why: Run-over-run comparisons want raw test counts, not just the
+    /// pass/fail status. Tracking `tests_passed`/`tests_failed` separately
+    /// from `status` lets dashboards show "1118/1118 passing" without
+    /// re-parsing QA output.
+    /// What: `Some(N)` when QA returned a JSON envelope with `passed`,
+    /// `None` otherwise. Defaults to `None` for back-compat with older
+    /// fixtures and for runs that skip the QA phase.
+    /// Test: `test_run_record_serializes_test_counts` in `trusty-agents::perf::tests`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tests_passed: Option<u64>,
+    /// Tests failed in the QA phase, paired with `tests_passed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tests_failed: Option<u64>,
+}
+
+fn default_status() -> String {
+    "success".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_usage_default_is_zeros() {
+        let u = TokenUsage::default();
+        assert_eq!(u.prompt_tokens, 0);
+        assert_eq!(u.completion_tokens, 0);
+        assert_eq!(u.cache_read_tokens, 0);
+        assert_eq!(u.cache_creation_tokens, 0);
+    }
+
+    #[test]
+    fn token_usage_accumulates() {
+        let mut a = TokenUsage::new(10, 5, 2, 1);
+        a.add(&TokenUsage::new(3, 7, 0, 4));
+        assert_eq!(a, TokenUsage::new(13, 12, 2, 5));
+    }
+
+    #[test]
+    fn perf_record_status_defaults_to_success() {
+        let rec = PerfRecord {
+            build: 1,
+            version: "0.1.0".to_string(),
+            workflow: "test".to_string(),
+            task_preview: "task".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            total_duration_ms: 100,
+            phases: vec![],
+            totals: PerfTotals::default(),
+            status: default_status(),
+            failed_phase: None,
+            skills_used: vec![],
+            skills_considered: vec![],
+            tests_passed: None,
+            tests_failed: None,
+        };
+        assert_eq!(rec.status, "success");
+        assert!(rec.failed_phase.is_none());
+    }
+}

--- a/crates/trusty-agents-common/src/runner.rs
+++ b/crates/trusty-agents-common/src/runner.rs
@@ -1,0 +1,387 @@
+//! AgentRunner DI seam — portable types for task dispatch and agent output.
+//!
+//! Why: The `AgentRunner` trait (plus `RunContext`, `AgentOutput`, and
+//! `HistoryMessage`) is the SOA boundary between the workflow engine/PM loop
+//! and concrete agent implementations (subprocess, in-process, mock). Keeping
+//! these types in `trusty-agents` made it impossible for external crates (e.g.
+//! orchestration harnesses that don't depend on the full `trusty-agents`
+//! binary crate) to implement or mock the runner without a full dependency.
+//! Extracting to `trusty-agents-common` breaks that coupling: any crate that
+//! only needs to implement or test against `AgentRunner` can depend on this
+//! tiny crate.
+//! What: Defines `HistoryMessage` (portable IPC wire type), `RunContext`
+//! (per-invocation directives), `AgentOutput` (agent result envelope), and
+//! the `AgentRunner` async trait.
+//! Note: `HistoryMessage::into_typed()` (which converts to async-openai's
+//! `ChatCompletionRequestMessage`) is NOT here — it requires `async-openai`
+//! and lives in `trusty-agents::session`. Only the portable
+//! `{role, content}` struct + its `user`/`assistant` constructors are here.
+//! Test: Compile-tested via `trusty-agents` which re-exports these types and
+//! has tests that construct `AgentOutput`, `RunContext`, and `HistoryMessage`.
+//! The `test_run_with_history_forwards_ctx` test in
+//! `trusty-agents::tools::traits` exercises the default `run_with_history`
+//! implementation.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::perf::TokenUsage;
+
+/// Simple `{role, content}` serializable form used over IPC.
+///
+/// Why: `ChatCompletionRequestMessage` is an async-openai enum with complex
+/// shape that doesn't round-trip cleanly through NDJSON IPC. A tiny
+/// `HistoryMessage` is trivially serde-friendly and enough to rebuild the
+/// typed messages on the sub-agent side.
+/// What: Pair of `role` ("user"|"assistant"|"system") and `content` strings.
+/// Note: The `into_typed()` method (which converts back to
+/// `ChatCompletionRequestMessage`) requires `async-openai` and therefore
+/// lives in `trusty-agents::session` as a standalone helper function rather
+/// than here. Call sites in `trusty-agents` use
+/// `trusty_agents::session::history_message_into_typed(msg)`.
+/// Test: See `trusty-agents::session` tests + IPC round-trip in
+/// `trusty-agents::ipc::tests`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HistoryMessage {
+    pub role: String,
+    pub content: String,
+}
+
+impl HistoryMessage {
+    /// Construct a `HistoryMessage` with role=`"user"`.
+    ///
+    /// Why: Callers serialize a dialog turn over IPC without touching the
+    /// role string directly, avoiding typos.
+    /// What: Plain struct literal with `role="user"`.
+    /// Test: Indirectly via `history_message_typed_round_trip` in
+    /// `trusty-agents::session::tests`.
+    #[allow(dead_code)]
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: content.into(),
+        }
+    }
+
+    /// Construct a `HistoryMessage` with role=`"assistant"`.
+    ///
+    /// Why: Symmetric with `user` — keeps IPC construction declarative.
+    /// What: Plain struct literal with `role="assistant"`.
+    /// Test: Indirectly via `history_message_typed_round_trip` in
+    /// `trusty-agents::session::tests`.
+    #[allow(dead_code)]
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: content.into(),
+        }
+    }
+}
+
+/// Per-invocation context threaded from orchestrator to agent runner.
+///
+/// Why: Previously, orchestrators (the wave loop in particular) passed
+/// per-call directives like the assigned file path and a tightened turn
+/// budget via process-global env vars (`std::env::set_var`). That is
+/// unsound in Rust 2024 because env mutation is not thread-safe under
+/// multi-threaded tokio runtimes. Threading a `RunContext` through the
+/// `AgentRunner` trait replaces the shared mutation with a per-call value
+/// that runners can apply to the child process (via `Command::env` / `current_dir`)
+/// without touching the parent's environment.
+/// What: Carries optional overrides — the assigned file for single-file
+/// wave-loop invocations, a per-call max-turns cap, and a working directory
+/// that the runner should use as the subprocess CWD.
+/// Test: Exercised indirectly through the wave-loop and runner dispatch
+/// tests (`wave_loop_runs_one_agent_per_file`, runner unit tests).
+#[derive(Debug, Default, Clone)]
+pub struct RunContext {
+    /// When `Some(path)`, the runner should scope any file-writing tool to
+    /// exactly this relative path. The wave loop sets this so each per-file
+    /// agent can only emit its assigned file.
+    pub assigned_file: Option<PathBuf>,
+    /// When `Some(n)`, the runner should enforce a max-turns cap of `n` for
+    /// this single invocation, overriding whatever the agent's TOML sets.
+    pub max_turns_override: Option<u32>,
+    /// When `Some(dir)`, the runner should use `dir` as the subprocess's
+    /// current working directory. Needed for the claude-code runner so the
+    /// CLI's file-writing tools resolve relative paths inside `out_dir`.
+    pub working_dir: Option<PathBuf>,
+    /// When `Some(model)`, the runner should use `model` as the LLM model for
+    /// this invocation, overriding the agent TOML's `[agent].model` /
+    /// `[llm].model_override`. Sourced from the workflow phase's
+    /// `model` field (#107, renamed from `model_override` in #359).
+    ///
+    /// Why: Previously the workflow engine only logged `phase.model`
+    /// as "advisory" — it never reached the runner. For `ClaudeCodeAgentRunner`
+    /// this meant every phase used the plan-agent TOML's model
+    /// (`claude-sonnet-4-6`) regardless of what `config/workflows/*.json`
+    /// specified. Threading the override through `RunContext` lets the runner
+    /// pass it as `--model` to the `claude` CLI (and via
+    /// `TAGENT_MODEL_<AGENT>` env for subprocess runners), preserving the
+    /// documented priority chain (env > phase override > agent TOML > default).
+    /// What: Optional string (e.g. `"anthropic/claude-opus-4-6"`). Runners that
+    /// don't understand it are free to ignore it; the default
+    /// `AgentRunner::run_with_context` still falls back to `run()` for mock
+    /// test doubles.
+    /// Test: `ClaudeCodeAgentRunner::run_with_config_ctx` honors it; the
+    /// engine populates it from `phase.model` in both the non-wave
+    /// and wave-loop paths.
+    pub model: Option<String>,
+}
+
+/// Structured output returned by an `AgentRunner`.
+///
+/// Why: Downstream workflow phases need a concise `summary` (~500 words) for
+/// template substitution while file-extraction still needs the full `content`.
+/// Bundling them in one struct lets callers choose which to consume without
+/// needing separate trait methods.
+/// What: `content` is the raw agent output; `summary` is the extracted
+/// `## Summary` section (or a prefix fallback); `usage` is the aggregated
+/// LLM token count for the invocation.
+/// Test: See workflow engine tests; constructed from `IpcMessage::Result`.
+#[derive(Debug, Clone)]
+pub struct AgentOutput {
+    pub content: String,
+    pub summary: Option<String>,
+    /// Aggregated LLM token usage for this agent invocation (#47).
+    ///
+    /// Why: `WorkflowEngine` needs per-phase token/cost data for the perf
+    /// record. Bubbling it from the sub-agent through the runner trait keeps
+    /// the instrumentation pipeline single-sourced.
+    /// What: `TokenUsage::default()` (all zeros) when no usage was reported
+    /// by the sub-agent (e.g. older binary or pre-LLM tool-only error).
+    /// Test: `perf::tests::collector_records_phases` exercises the sink;
+    /// end-to-end wiring is covered by workflow integration.
+    pub usage: TokenUsage,
+}
+
+impl AgentOutput {
+    /// Build from content alone; summary/usage will be defaults.
+    ///
+    /// Why: Most test doubles and simple callers only care about content;
+    /// a convenience constructor avoids boilerplate.
+    /// What: Constructs with empty summary and zero usage.
+    /// Test: Used across mock runner construction in unit tests.
+    #[allow(dead_code)]
+    pub fn from_content(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            summary: None,
+            usage: TokenUsage::default(),
+        }
+    }
+
+    /// Return summary if present, else fall back to content.
+    ///
+    /// Why: Template substitution in the workflow engine prefers the summary
+    /// (concise) but falls back to full content when no summary was extracted.
+    /// What: Returns `summary.as_deref()` or `&content`.
+    /// Test: Indirect — every template that calls `summary_or_content()`.
+    #[allow(dead_code)]
+    pub fn summary_or_content(&self) -> &str {
+        self.summary.as_deref().unwrap_or(&self.content)
+    }
+}
+
+/// Runs a task against a named agent.
+///
+/// Why: Abstracts over how an agent is executed — subprocess, in-process, or
+/// mock. Lets tests avoid spawning real processes.
+/// What: `run(agent_name, task)` returns the agent's `AgentOutput` (content
+/// plus optional summary). `run_with_history` extends this to pass prior
+/// conversation turns for persistent-session agents (#51); the default
+/// implementation ignores history so legacy impls keep working unchanged.
+/// Test: `tests/` substitute in-memory implementations; `test_run_with_history_forwards_ctx`
+/// in `trusty-agents::tools::traits` is the regression guard for default
+/// `run_with_history` forwarding through `run_with_context`.
+#[async_trait]
+pub trait AgentRunner: Send + Sync {
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput>;
+
+    /// Run a task while forwarding any prior session history.
+    ///
+    /// Why: Persistent-session agents (#51) need their caller to replay
+    /// earlier user/assistant turns so the sub-agent can rebuild context
+    /// in a fresh subprocess. Bug #122: the previous default fell through to
+    /// `run()` instead of `run_with_context()`, so persistent-session callers
+    /// silently lost `working_dir` and `model` carried in `ctx`.
+    /// What: Default implementation ignores `history` and delegates to
+    /// `run_with_context(ctx)`, so `working_dir` and `model` are
+    /// honoured even for runners that do not override `run_with_history`.
+    /// Concrete runners that know how to carry history across the process
+    /// boundary override this.
+    /// Test: `SubprocessAgentRunner` exercises the override; the default
+    /// path is covered by `test_run_with_history_forwards_ctx` and the
+    /// existing mock-runner tests in `workflow`.
+    async fn run_with_history(
+        &self,
+        agent_name: &str,
+        task: &str,
+        _history: &[HistoryMessage],
+        ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        // Default: fall through to run_with_context so working_dir + model
+        // are honoured even when the concrete runner doesn't override run_with_history.
+        self.run_with_context(agent_name, task, ctx).await
+    }
+
+    /// Run a task with a `RunContext` carrying per-invocation overrides.
+    ///
+    /// Why: Replaces unsafe `std::env::set_var` threading of per-call state
+    /// (assigned file, tightened turn budget, working dir) with a structured
+    /// value that runners can apply to the child process only. Default impl
+    /// ignores the context and falls back to `run()` so existing mock runners
+    /// (including test doubles) keep working unchanged.
+    /// What: Concrete runners override this to scope env vars to the child
+    /// (`Command::env`) and optionally set its CWD (`Command::current_dir`).
+    /// Test: Wave-loop tests prove the context fields reach the child.
+    async fn run_with_context(
+        &self,
+        agent_name: &str,
+        task: &str,
+        _ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        self.run(agent_name, task).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+
+    use super::{AgentOutput, AgentRunner, HistoryMessage, RunContext, TokenUsage};
+
+    /// Mock runner that records the RunContext it receives in `run_with_context`.
+    ///
+    /// Why: We need to assert that the trait default `run_with_history` impl
+    /// actually forwards `ctx` to `run_with_context` (bug #122 regression guard).
+    /// What: Stores each ctx snapshot; `run` is unused (test calls only
+    /// `run_with_history`).
+    /// Test: `test_run_with_history_forwards_ctx` constructs one of these,
+    /// calls `run_with_history` with a specific `RunContext`, and asserts the
+    /// recorded snapshot matches.
+    struct CtxCapture {
+        captured: Arc<Mutex<Vec<RunContext>>>,
+    }
+
+    #[async_trait]
+    impl AgentRunner for CtxCapture {
+        async fn run(&self, _agent_name: &str, _task: &str) -> Result<AgentOutput> {
+            Ok(AgentOutput {
+                content: "run".into(),
+                summary: None,
+                usage: TokenUsage::default(),
+            })
+        }
+
+        async fn run_with_context(
+            &self,
+            _agent_name: &str,
+            _task: &str,
+            ctx: &RunContext,
+        ) -> Result<AgentOutput> {
+            self.captured.lock().unwrap().push(ctx.clone());
+            Ok(AgentOutput {
+                content: "run_with_context".into(),
+                summary: None,
+                usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    /// Verifies that the trait default `run_with_history` forwards `ctx` to
+    /// `run_with_context` rather than dropping it (bug #122 regression guard).
+    ///
+    /// Why: Before the fix, the default called `self.run()` which ignores ctx,
+    /// meaning persistent-session agents lost working_dir and model.
+    /// What: Calls `run_with_history` with specific working_dir and model,
+    /// then asserts `run_with_context` received those values.
+    /// Test: Run with `cargo test -p trusty-agents-common test_run_with_history_forwards_ctx`.
+    #[tokio::test]
+    async fn test_run_with_history_forwards_ctx() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = CtxCapture {
+            captured: captured.clone(),
+        };
+
+        let ctx = RunContext {
+            working_dir: Some(PathBuf::from("/tmp/test-wd")),
+            model: Some("anthropic/claude-opus-4-5".to_string()),
+            max_turns_override: Some(5),
+            assigned_file: None,
+        };
+
+        let out = runner
+            .run_with_history("test-agent", "do something", &[], &ctx)
+            .await
+            .expect("run_with_history should succeed");
+
+        assert_eq!(
+            out.content, "run_with_context",
+            "default run_with_history must call run_with_context, not run()"
+        );
+
+        let snaps = captured.lock().unwrap();
+        assert_eq!(
+            snaps.len(),
+            1,
+            "run_with_context should be called exactly once"
+        );
+
+        let recorded = &snaps[0];
+        assert_eq!(
+            recorded.working_dir,
+            Some(PathBuf::from("/tmp/test-wd")),
+            "working_dir must be forwarded through run_with_history"
+        );
+        assert_eq!(
+            recorded.model,
+            Some("anthropic/claude-opus-4-5".to_string()),
+            "model must be forwarded through run_with_history"
+        );
+        assert_eq!(
+            recorded.max_turns_override,
+            Some(5),
+            "max_turns_override must be forwarded through run_with_history"
+        );
+    }
+
+    #[test]
+    fn history_message_constructors() {
+        let u = HistoryMessage::user("hello");
+        assert_eq!(u.role, "user");
+        assert_eq!(u.content, "hello");
+
+        let a = HistoryMessage::assistant("world");
+        assert_eq!(a.role, "assistant");
+        assert_eq!(a.content, "world");
+    }
+
+    #[test]
+    fn agent_output_from_content() {
+        let out = AgentOutput::from_content("test output");
+        assert_eq!(out.content, "test output");
+        assert!(out.summary.is_none());
+        assert_eq!(out.usage, TokenUsage::default());
+    }
+
+    #[test]
+    fn agent_output_summary_or_content_fallback() {
+        let out = AgentOutput::from_content("fallback content");
+        assert_eq!(out.summary_or_content(), "fallback content");
+
+        let out_with_summary = AgentOutput {
+            content: "full content".into(),
+            summary: Some("short summary".into()),
+            usage: TokenUsage::default(),
+        };
+        assert_eq!(out_with_summary.summary_or_content(), "short summary");
+    }
+}

--- a/crates/trusty-agents/src/perf/mod.rs
+++ b/crates/trusty-agents/src/perf/mod.rs
@@ -8,14 +8,20 @@
 //! keeps the data greppable without a database.
 //! What: `PerfCollector` is constructed at workflow start, `record_phase`
 //! appends a `PhaseRecord` after each phase, and `flush` writes the final
-//! JSON + log line. `TokenUsage` is the provider-agnostic shape captured
-//! from each LLM call (extended with Anthropic-specific `cache_read` /
-//! `cache_creation` fields which are zero for non-Anthropic models).
+//! JSON + log line.
+//!
+//! The portable plain-data types (`TokenUsage`, `PhaseRecord`, `PerfTotals`,
+//! `PerfRecord`) were moved to `trusty-agents-common::perf` in Wave 2
+//! (issue #867, refs #830/#832). They are re-exported here so all existing
+//! `crate::perf::TokenUsage` etc. references inside `trusty-agents` continue
+//! to resolve unchanged.
+//!
 //! Test: `cost_usd_known_model`, `collector_records_phases`,
 //! `collector_totals_sum_phases`, `collector_flush_writes_json_and_log`.
 //!
 //! Module layout (see #366 split):
-//! - `mod.rs` — perf record types + `PerfCollector` lifecycle
+//! - `mod.rs` — `PerfCollector` lifecycle + explicit re-exports of the
+//!   portable types from `trusty-agents-common::perf`
 //! - `pricing.rs` — `cost_usd` + the model pricing table + formatters
 //! - `tests.rs` — unit tests
 
@@ -29,148 +35,20 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
 
 use pricing::{filename_stamp, truncate_preview};
 
 pub use pricing::cost_usd;
 
-/// Token usage captured from a single LLM round-trip.
-///
-/// Why: (#50) Anthropic's OpenRouter responses carry cache_read_input_tokens
-/// and cache_creation_input_tokens alongside the standard prompt/completion
-/// counts. Exposing those as first-class fields lets `PerfCollector` track
-/// cache effectiveness over time. For non-Anthropic models these stay 0.
-/// What: Plain struct; additive (`+`-style) accumulation is done inline in
-/// `PerfCollector::totals`.
-/// Test: `token_usage_default_is_zeros`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TokenUsage {
-    pub prompt_tokens: u32,
-    pub completion_tokens: u32,
-    pub cache_read_tokens: u32,
-    pub cache_creation_tokens: u32,
-}
-
-impl TokenUsage {
-    /// Construct a `TokenUsage` from the four individual counts.
-    pub fn new(prompt: u32, completion: u32, cache_read: u32, cache_creation: u32) -> Self {
-        Self {
-            prompt_tokens: prompt,
-            completion_tokens: completion,
-            cache_read_tokens: cache_read,
-            cache_creation_tokens: cache_creation,
-        }
-    }
-
-    /// Add another usage record into this one (in place).
-    ///
-    /// Why: Each phase may comprise multiple LLM turns (tool loop); we sum
-    /// them into a single `PhaseRecord`.
-    /// What: Field-wise saturating add.
-    /// Test: `token_usage_accumulates`.
-    pub fn add(&mut self, other: &TokenUsage) {
-        self.prompt_tokens = self.prompt_tokens.saturating_add(other.prompt_tokens);
-        self.completion_tokens = self
-            .completion_tokens
-            .saturating_add(other.completion_tokens);
-        self.cache_read_tokens = self
-            .cache_read_tokens
-            .saturating_add(other.cache_read_tokens);
-        self.cache_creation_tokens = self
-            .cache_creation_tokens
-            .saturating_add(other.cache_creation_tokens);
-    }
-}
-
-/// One phase's measured performance.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PhaseRecord {
-    pub name: String,
-    pub duration_ms: u64,
-    pub prompt_tokens: u32,
-    pub completion_tokens: u32,
-    pub cache_read_tokens: u32,
-    pub cache_creation_tokens: u32,
-    pub cost_usd: f64,
-}
-
-/// Totals rolled up from every `PhaseRecord` in a run.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct PerfTotals {
-    pub prompt_tokens: u32,
-    pub completion_tokens: u32,
-    pub cache_read_tokens: u32,
-    pub cache_creation_tokens: u32,
-    pub cost_usd: f64,
-}
-
-/// Full performance record persisted to `docs/performance/runs/`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PerfRecord {
-    pub build: u64,
-    pub version: String,
-    pub workflow: String,
-    pub task_preview: String,
-    pub started_at: String,
-    pub total_duration_ms: u64,
-    pub phases: Vec<PhaseRecord>,
-    pub totals: PerfTotals,
-    /// Run outcome (#56): "success" | "partial" | "failed".
-    ///
-    /// Why: When a phase fails mid-workflow, we still want to persist the
-    /// perf record so we can see where/how the run died. A separate `status`
-    /// field distinguishes clean completions from partial runs in tooling
-    /// that scans `runs/*.json`.
-    /// What: Defaults to "success" for back-compat with older fixtures.
-    #[serde(default = "default_status")]
-    pub status: String,
-    /// Name of the phase that failed, when `status != "success"` (#56).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failed_phase: Option<String>,
-    /// Distinct skill names injected into any phase prompt during this run
-    /// (#171).
-    ///
-    /// Why: Post-run persistence needs to know which skills were used so it
-    /// can increment `use_count` and refresh `last_used`. Carrying the list
-    /// through `PerfRecord` keeps the data in one place that's already
-    /// flushed to disk for analysis.
-    /// What: Deduplicated, insertion-order-preserved list of skill names.
-    /// Defaults to empty for back-compat with older fixtures.
-    #[serde(default)]
-    pub skills_used: Vec<String>,
-    /// Distinct skill names matched by the pre-plan discovery step (#173).
-    ///
-    /// Why: Discovery surfaces every skill the engine considered relevant for
-    /// a task — even if downstream prompt assembly only injected a subset (or
-    /// none). Recording the broader candidate set separately from
-    /// `skills_used` lets us measure recall vs. precision over time and
-    /// audit which signals the discovery step matched on.
-    /// What: Deduplicated, insertion-order-preserved list of skill names.
-    /// Defaults to empty for back-compat with older fixtures.
-    #[serde(default)]
-    pub skills_considered: Vec<String>,
-    /// Tests passed in the QA phase, when the QA agent emitted a parsable
-    /// JSON envelope with a `passed` count.
-    ///
-    /// Why: Run-over-run comparisons want raw test counts, not just the
-    /// pass/fail status. Tracking `tests_passed`/`tests_failed` separately
-    /// from `status` lets dashboards show "1118/1118 passing" without
-    /// re-parsing QA output.
-    /// What: `Some(N)` when QA returned a JSON envelope with `passed`,
-    /// `None` otherwise. Defaults to `None` for back-compat with older
-    /// fixtures and for runs that skip the QA phase.
-    /// Test: `test_run_record_serializes_test_counts`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tests_passed: Option<u64>,
-    /// Tests failed in the QA phase, paired with `tests_passed`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tests_failed: Option<u64>,
-}
-
-fn default_status() -> String {
-    "success".to_string()
-}
+// Why: `TokenUsage`, `PhaseRecord`, `PerfTotals`, and `PerfRecord` were
+//      extracted to `trusty-agents-common::perf` in Wave 2 (issue #867) so
+//      external crates and the `AgentRunner` seam can reference `TokenUsage`
+//      without depending on the full `trusty-agents` binary crate. Re-exports
+//      here preserve every existing `crate::perf::TokenUsage` etc. import
+//      in the workspace — internal call sites are unchanged.
+// What: Explicit re-exports of all four portable value types.
+// Test: All existing perf tests still resolve these names and pass.
+pub use trusty_agents_common::perf::{PerfRecord, PerfTotals, PhaseRecord, TokenUsage};
 
 /// Accumulator used during workflow execution.
 ///

--- a/crates/trusty-agents/src/runtime/subagent_exec.rs
+++ b/crates/trusty-agents/src/runtime/subagent_exec.rs
@@ -93,7 +93,7 @@ pub(super) async fn run_subagent_single_shot(
             Vec::with_capacity(hist_compressed.len() + 2);
         messages.push(system_msg);
         for h in &hist_compressed {
-            messages.push(h.clone().into_typed()?);
+            messages.push(session::history_message_into_typed(h.clone())?);
         }
         let user_msg: ChatCompletionRequestMessage =
             ChatCompletionRequestUserMessageArgs::default()
@@ -182,7 +182,7 @@ pub(super) async fn run_subagent_with_tools(
     let mut messages: Vec<ChatCompletionRequestMessage> = Vec::new();
     messages.push(system_msg);
     for h in &hist_for_wire {
-        messages.push(h.clone().into_typed()?);
+        messages.push(session::history_message_into_typed(h.clone())?);
     }
     let user_msg: ChatCompletionRequestMessage = ChatCompletionRequestUserMessageArgs::default()
         .content(task_for_wire.as_str())

--- a/crates/trusty-agents/src/session.rs
+++ b/crates/trusty-agents/src/session.rs
@@ -9,6 +9,17 @@
 //! history; `SessionManager` is an `Arc<Mutex<HashMap<..>>>` keyed by agent
 //! name that exposes async `get_history`, `extend_history`, `clear_agent`,
 //! and `clear_all`.
+//!
+//! `HistoryMessage` (the portable `{role, content}` IPC wire type) was moved
+//! to `trusty-agents-common::runner` in Wave 2 (issue #867, refs #830/#832)
+//! and is re-exported here so all existing `crate::session::HistoryMessage`
+//! references resolve unchanged.
+//!
+//! `history_message_into_typed()` is the async-openai conversion helper that
+//! was previously `HistoryMessage::into_typed()`. Because the struct now lives
+//! in `trusty-agents-common` (which does not depend on async-openai), the
+//! method has been hoisted to a standalone function in this module.
+//!
 //! Test: See the `tests` module — empty history for new agent, extend +
 //! retrieve, isolated clear per agent, and global clear.
 
@@ -20,8 +31,39 @@ use async_openai::types::{
     ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
     ChatCompletionRequestUserMessageArgs,
 };
-use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+
+// Why: `HistoryMessage` was extracted to `trusty-agents-common::runner` in
+//      Wave 2 (issue #867) so external crates that implement `AgentRunner`
+//      can reference the IPC wire type without depending on `trusty-agents`.
+//      Re-exporting here preserves every existing `crate::session::HistoryMessage`
+//      import in the workspace.
+// What: Explicit re-export of the portable struct.
+// Test: All existing tests that construct HistoryMessage values still pass.
+pub use trusty_agents_common::runner::HistoryMessage;
+
+/// Convert a `HistoryMessage` into async-openai's typed message format.
+///
+/// Why: This was previously `HistoryMessage::into_typed(self)` but the struct
+/// now lives in `trusty-agents-common` which does not depend on `async-openai`.
+/// Hoisting the conversion to a standalone function here keeps the async-openai
+/// coupling in `trusty-agents` where the dependency already exists.
+/// What: Dispatches on role; unknown roles (including "system") default to user.
+/// Test: `history_message_typed_round_trip` in `session::tests`.
+pub fn history_message_into_typed(msg: HistoryMessage) -> Result<ChatCompletionRequestMessage> {
+    match msg.role.as_str() {
+        "assistant" => Ok(ChatCompletionRequestAssistantMessageArgs::default()
+            .content(msg.content)
+            .build()
+            .context("failed to build assistant message")?
+            .into()),
+        _ => Ok(ChatCompletionRequestUserMessageArgs::default()
+            .content(msg.content)
+            .build()
+            .context("failed to build user message")?
+            .into()),
+    }
+}
 
 /// Conversation history for a single agent.
 ///
@@ -77,69 +119,6 @@ impl AgentSession {
                 .into();
         self.history.push(msg);
         Ok(())
-    }
-}
-
-/// Simple `{role, content}` serializable form used over IPC.
-///
-/// Why: `ChatCompletionRequestMessage` is an async-openai enum with complex
-/// shape that doesn't round-trip cleanly through our JSON IPC. A tiny
-/// `HistoryMessage` is trivially serde-friendly and enough to rebuild the
-/// typed messages on the sub-agent side.
-/// What: Pair of `role` ("user"|"assistant"|"system") and `content` strings.
-/// Test: See session tests + IPC round-trip in `ipc::tests`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct HistoryMessage {
-    pub role: String,
-    pub content: String,
-}
-
-impl HistoryMessage {
-    /// Construct a `HistoryMessage` with role=`"user"`.
-    ///
-    /// Why: Callers serialize a dialog turn over IPC without touching the
-    /// role string directly, avoiding typos.
-    /// What: Plain struct literal with `role="user"`.
-    /// Test: Indirectly via `history_message_typed_round_trip`.
-    #[allow(dead_code)]
-    pub fn user(content: impl Into<String>) -> Self {
-        Self {
-            role: "user".to_string(),
-            content: content.into(),
-        }
-    }
-    /// Construct a `HistoryMessage` with role=`"assistant"`.
-    ///
-    /// Why: Symmetric with `user` — keeps IPC construction declarative.
-    /// What: Plain struct literal with `role="assistant"`.
-    /// Test: Indirectly via `history_message_typed_round_trip`.
-    #[allow(dead_code)]
-    pub fn assistant(content: impl Into<String>) -> Self {
-        Self {
-            role: "assistant".to_string(),
-            content: content.into(),
-        }
-    }
-
-    /// Convert a `HistoryMessage` back into async-openai's typed message.
-    ///
-    /// Why: The sub-agent needs to prepend wire-format history as real
-    /// `ChatCompletionRequestMessage` values in its outgoing request.
-    /// What: Dispatches on role; unknown roles default to user.
-    /// Test: `history_message_typed_round_trip`.
-    pub fn into_typed(self) -> Result<ChatCompletionRequestMessage> {
-        match self.role.as_str() {
-            "assistant" => Ok(ChatCompletionRequestAssistantMessageArgs::default()
-                .content(self.content)
-                .build()
-                .context("failed to build assistant message")?
-                .into()),
-            _ => Ok(ChatCompletionRequestUserMessageArgs::default()
-                .content(self.content)
-                .build()
-                .context("failed to build user message")?
-                .into()),
-        }
     }
 }
 
@@ -283,8 +262,8 @@ mod tests {
     fn history_message_typed_round_trip() {
         let u = HistoryMessage::user("hello");
         let a = HistoryMessage::assistant("world");
-        let _: ChatCompletionRequestMessage = u.into_typed().unwrap();
-        let _: ChatCompletionRequestMessage = a.into_typed().unwrap();
+        let _: ChatCompletionRequestMessage = history_message_into_typed(u).unwrap();
+        let _: ChatCompletionRequestMessage = history_message_into_typed(a).unwrap();
     }
 
     #[tokio::test]

--- a/crates/trusty-agents/src/tools/traits.rs
+++ b/crates/trusty-agents/src/tools/traits.rs
@@ -6,10 +6,15 @@
 //! the workflow engine and PM loop testable.
 //! What: Defines `ToolExecutor`, `AgentRunner`, `SearchProvider`, and
 //! `SkillResolver`. All are object-safe (`dyn`-able) and `Send + Sync`.
+//!
+//! `ToolExecutor`, `ToolResult`, and `ToolExecutionTier` live in
+//! `trusty-agents-common` (moved in the original extraction). `AgentRunner`,
+//! `RunContext`, and `AgentOutput` were moved to `trusty-agents-common::runner`
+//! in Wave 2 (issue #867, refs #830/#832). All are re-exported here so every
+//! existing `crate::tools::traits::X` import resolves unchanged.
+//!
 //! Test: Mock impls of each trait are constructed in unit tests for
 //! `ToolRegistry`, `WorkflowEngine`, and related code.
-
-use std::path::PathBuf;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -24,159 +29,15 @@ use serde::{Deserialize, Serialize};
 // Test: All existing tool tests still resolve these names and pass.
 pub use trusty_agents_common::{ToolExecutionTier, ToolExecutor, ToolResult};
 
-/// Per-invocation context threaded from orchestrator to agent runner.
-///
-/// Why: Previously, orchestrators (the wave loop in particular) passed
-/// per-call directives like the assigned file path and a tightened turn
-/// budget via process-global env vars (`std::env::set_var`). That is
-/// unsound in Rust 2024 because env mutation is not thread-safe under
-/// multi-threaded tokio runtimes. Threading a `RunContext` through the
-/// `AgentRunner` trait replaces the shared mutation with a per-call value
-/// that runners can apply to the child process (via `Command::env` / `current_dir`)
-/// without touching the parent's environment.
-/// What: Carries optional overrides — the assigned file for single-file
-/// wave-loop invocations, a per-call max-turns cap, and a working directory
-/// that the runner should use as the subprocess CWD.
-/// Test: Exercised indirectly through the wave-loop and runner dispatch
-/// tests (`wave_loop_runs_one_agent_per_file`, runner unit tests).
-#[derive(Debug, Default, Clone)]
-pub struct RunContext {
-    /// When `Some(path)`, the runner should scope any file-writing tool to
-    /// exactly this relative path. The wave loop sets this so each per-file
-    /// agent can only emit its assigned file.
-    pub assigned_file: Option<PathBuf>,
-    /// When `Some(n)`, the runner should enforce a max-turns cap of `n` for
-    /// this single invocation, overriding whatever the agent's TOML sets.
-    pub max_turns_override: Option<u32>,
-    /// When `Some(dir)`, the runner should use `dir` as the subprocess's
-    /// current working directory. Needed for the claude-code runner so the
-    /// CLI's file-writing tools resolve relative paths inside `out_dir`.
-    pub working_dir: Option<PathBuf>,
-    /// When `Some(model)`, the runner should use `model` as the LLM model for
-    /// this invocation, overriding the agent TOML's `[agent].model` /
-    /// `[llm].model_override`. Sourced from the workflow phase's
-    /// `model` field (#107, renamed from `model_override` in #359).
-    ///
-    /// Why: Previously the workflow engine only logged `phase.model`
-    /// as "advisory" — it never reached the runner. For `ClaudeCodeAgentRunner`
-    /// this meant every phase used the plan-agent TOML's model
-    /// (`claude-sonnet-4-6`) regardless of what `config/workflows/*.json`
-    /// specified. Threading the override through `RunContext` lets the runner
-    /// pass it as `--model` to the `claude` CLI (and via
-    /// `TAGENT_MODEL_<AGENT>` env for subprocess runners), preserving the
-    /// documented priority chain (env > phase override > agent TOML > default).
-    /// What: Optional string (e.g. `"anthropic/claude-opus-4-6"`). Runners that
-    /// don't understand it are free to ignore it; the default
-    /// `AgentRunner::run_with_context` still falls back to `run()` for mock
-    /// test doubles.
-    /// Test: `ClaudeCodeAgentRunner::run_with_config_ctx` honors it; the
-    /// engine populates it from `phase.model` in both the non-wave
-    /// and wave-loop paths.
-    pub model: Option<String>,
-}
-
-/// Structured output returned by an `AgentRunner`.
-///
-/// Why: Downstream workflow phases need a concise `summary` (~500 words) for
-/// template substitution while file-extraction still needs the full `content`.
-/// Bundling them in one struct lets callers choose which to consume without
-/// needing separate trait methods.
-/// What: `content` is the raw agent output; `summary` is the extracted
-/// `## Summary` section (or a prefix fallback).
-/// Test: See workflow engine tests; constructed from `IpcMessage::Result`.
-#[derive(Debug, Clone)]
-pub struct AgentOutput {
-    pub content: String,
-    pub summary: Option<String>,
-    /// Aggregated LLM token usage for this agent invocation (#47).
-    ///
-    /// Why: `WorkflowEngine` needs per-phase token/cost data for the perf
-    /// record. Bubbling it from the sub-agent through the runner trait keeps
-    /// the instrumentation pipeline single-sourced.
-    /// What: `TokenUsage::default()` (all zeros) when no usage was reported
-    /// by the sub-agent (e.g. older binary or pre-LLM tool-only error).
-    /// Test: `perf::tests::collector_records_phases` exercises the sink;
-    /// end-to-end wiring is covered by workflow integration.
-    pub usage: crate::perf::TokenUsage,
-}
-
-impl AgentOutput {
-    /// Build from content alone; summary/usage will be defaults.
-    #[allow(dead_code)]
-    pub fn from_content(content: impl Into<String>) -> Self {
-        Self {
-            content: content.into(),
-            summary: None,
-            usage: crate::perf::TokenUsage::default(),
-        }
-    }
-
-    /// Return summary if present, else fall back to content.
-    #[allow(dead_code)]
-    pub fn summary_or_content(&self) -> &str {
-        self.summary.as_deref().unwrap_or(&self.content)
-    }
-}
-
-/// Runs a task against a named agent.
-///
-/// Why: Abstracts over how an agent is executed — subprocess, in-process, or
-/// mock. Lets tests avoid spawning real processes.
-/// What: `run(agent_name, task)` returns the agent's `AgentOutput` (content
-/// plus optional summary). `run_with_history` extends this to pass prior
-/// conversation turns for persistent-session agents (#51); the default
-/// implementation ignores history so legacy impls keep working unchanged.
-/// Test: `tests/` substitute in-memory implementations.
-#[async_trait]
-pub trait AgentRunner: Send + Sync {
-    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput>;
-
-    /// Run a task while forwarding any prior session history.
-    ///
-    /// Why: Persistent-session agents (#51) need their caller to replay
-    /// earlier user/assistant turns so the sub-agent can rebuild context
-    /// in a fresh subprocess. Bug #122: the previous default fell through to
-    /// `run()` instead of `run_with_context()`, so persistent-session callers
-    /// silently lost `working_dir` and `model` carried in `ctx`.
-    /// What: Default implementation ignores `history` and delegates to
-    /// `run_with_context(ctx)`, so `working_dir` and `model` are
-    /// honoured even for runners that do not override `run_with_history`.
-    /// Concrete runners that know how to carry history across the process
-    /// boundary override this.
-    /// Test: `SubprocessAgentRunner` exercises the override; the default
-    /// path is covered by `test_run_with_history_forwards_ctx` and the
-    /// existing mock-runner tests in `workflow`.
-    async fn run_with_history(
-        &self,
-        agent_name: &str,
-        task: &str,
-        _history: &[crate::session::HistoryMessage],
-        ctx: &RunContext,
-    ) -> Result<AgentOutput> {
-        // Default: fall through to run_with_context so working_dir + model
-        // are honoured even when the concrete runner doesn't override run_with_history.
-        self.run_with_context(agent_name, task, ctx).await
-    }
-
-    /// Run a task with a `RunContext` carrying per-invocation overrides.
-    ///
-    /// Why: Replaces unsafe `std::env::set_var` threading of per-call state
-    /// (assigned file, tightened turn budget, working dir) with a structured
-    /// value that runners can apply to the child process only. Default impl
-    /// ignores the context and falls back to `run()` so existing mock runners
-    /// (including test doubles) keep working unchanged.
-    /// What: Concrete runners override this to scope env vars to the child
-    /// (`Command::env`) and optionally set its CWD (`Command::current_dir`).
-    /// Test: Wave-loop tests prove the context fields reach the child.
-    async fn run_with_context(
-        &self,
-        agent_name: &str,
-        task: &str,
-        _ctx: &RunContext,
-    ) -> Result<AgentOutput> {
-        self.run(agent_name, task).await
-    }
-}
+// Why: `AgentRunner`, `RunContext`, `AgentOutput`, and `HistoryMessage` were
+//      extracted to `trusty-agents-common::runner` in Wave 2 (issue #867,
+//      refs #830/#832) so external crates can implement or mock the runner
+//      seam without depending on the full `trusty-agents` binary crate.
+//      Re-exports here preserve every existing `crate::tools::traits::AgentRunner`,
+//      `RunContext`, `AgentOutput` reference inside `trusty-agents`.
+// What: Explicit re-exports from the shared runner module.
+// Test: All existing AgentRunner tests and workflow tests still resolve and pass.
+pub use trusty_agents_common::runner::{AgentOutput, AgentRunner, RunContext};
 
 /// A search hit returned by a `SearchProvider`.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #867. Refs #830, #832.

## Summary

- **Part A**: Extract portable perf value types (`TokenUsage`, `PhaseRecord`, `PerfTotals`, `PerfRecord`) from `trusty-agents::perf` into `trusty-agents-common::perf`. `PerfCollector` (stateful, tokio-async, file I/O) stays in `trusty-agents`.
- **Part B**: Extract the AgentRunner DI seam (`HistoryMessage`, `RunContext`, `AgentOutput`, `AgentRunner` trait) from `trusty-agents::tools::traits` into `trusty-agents-common::runner`. All four types are now reachable by external crates without depending on the full `trusty-agents` binary crate.

## What moved

**Part A (`trusty-agents-common/src/perf.rs`):**
- `TokenUsage` — 4-field token counter
- `PhaseRecord` — per-phase duration + token snapshot  
- `PerfTotals` — rolled-up totals
- `PerfRecord` — full run record (serializable JSON)

**Part B (`trusty-agents-common/src/runner.rs`):**
- `HistoryMessage` — portable `{role, content}` IPC wire struct
- `RunContext` — per-invocation directives (assigned_file, max_turns_override, working_dir, model)
- `AgentOutput` — content + summary + TokenUsage
- `AgentRunner` — async trait with `run`/`run_with_history`/`run_with_context`

## Portability note for HistoryMessage

`HistoryMessage::into_typed()` required `async-openai` and therefore could NOT move to `trusty-agents-common`. It was hoisted to `session::history_message_into_typed(msg)` — a standalone free function in `trusty-agents::session`. The two call sites in `runtime/subagent_exec.rs` were updated. This is the only API surface change; the struct itself is now in common.

## Compat shims (explicit, no wildcards)

`trusty-agents/src/perf/mod.rs`:
```rust
pub use trusty_agents_common::perf::{PerfRecord, PerfTotals, PhaseRecord, TokenUsage};
```

`trusty-agents/src/tools/traits.rs`:
```rust
pub use trusty_agents_common::runner::{AgentOutput, AgentRunner, RunContext};
```

`trusty-agents/src/session.rs`:
```rust
pub use trusty_agents_common::runner::HistoryMessage;
```

## Back-reference proof

```
$ grep -rn "crate::" crates/trusty-agents-common/src/perf.rs crates/trusty-agents-common/src/runner.rs
crates/trusty-agents-common/src/runner.rs:31:use crate::perf::TokenUsage;
```

Only `crate::perf::TokenUsage` — an intra-crate reference within `trusty-agents-common` (runner imports perf from the same crate). Zero back-references into `trusty-agents` internals.

## Test plan

- [ ] `cargo build --workspace` → clean
- [ ] `cargo test --workspace` → 7123 passed, 0 failed
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [ ] `cargo fmt --check` → clean
- [ ] `bash scripts/check_line_cap.sh` → 0 violations (172 allowlisted)
- [ ] No `::*` wildcards in any re-export shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)