### PR TITLE
fix(trusty-search): zero-vector guard skips all-hash-skipped reindex (closes #868)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -166,7 +166,7 @@ crates/trusty-search/src/service/daemon.rs	774
 crates/trusty-search/src/service/embedder_supervisor.rs	1020
 crates/trusty-search/src/service/grep.rs	827
 crates/trusty-search/src/service/persistence.rs	990
-crates/trusty-search/src/service/reindex/mod.rs	4212
+crates/trusty-search/src/service/reindex/mod.rs	4213
 crates/trusty-search/src/service/walker.rs	1344
 crates/trusty-search/src/service/warm_boot/probe.rs	518
 crates/trusty-search/tests/baseline_trusty_tools.rs	721

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11064,7 +11064,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,26 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.24.1] — 2026-06-06
+
+### Fixed
+
+- **#868 — zero-vector guard misfires on all-hash-skipped incremental reindex**
+  — `reindex_outcome` now accepts a `skipped_files` count and computes
+  `newly_submitted = walked_files - skipped_files`. The `Failed` guard only
+  fires when files were actually submitted to the embedder AND produced zero
+  vectors. On a warm no-change reindex (all files hash-skipped), zero vectors
+  is the expected outcome and the corpus is correctly promoted to `Ready`
+  instead of being rolled back to the previous snapshot (closes #868).
+- **F2 — deleted-file prune now persists** — the staging corpus was previously
+  rolled back whenever the zero-vector guard misfired, discarding the
+  deleted-file prune performed earlier in the reindex. With the guard fixed,
+  the staging corpus is promoted correctly and the prune result survives.
+  No behavior change for genuine embedder failures: those still trigger
+  rollback and mark the index `Failed`.
+
+---
+
 ## [0.24.0] — 2026-06-06
 
 ### Fixed

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -2287,6 +2287,7 @@ pub fn spawn_reindex_with_cleanup(
             handle.lexical_only,
             embedder_present,
             total,
+            progress.skipped.load(AtomicOrdering::Acquire),
             total_vector_count,
         );
         // #603: the staging corpus only promotes when the reindex is both not

--- a/crates/trusty-search/src/service/reindex/validate.rs
+++ b/crates/trusty-search/src/service/reindex/validate.rs
@@ -59,7 +59,7 @@ impl ReindexOutcome {
 }
 
 /// Decide whether a finished reindex produced a usable corpus or silently
-/// embedded nothing (#601).
+/// embedded nothing (#601, #868).
 ///
 /// Why: before this gate, the orchestrator marked semantic + graph `Ready`
 /// unconditionally after the batch loop drained. When every embed batch failed
@@ -67,21 +67,33 @@ impl ReindexOutcome {
 /// `chunk_count == 0` and `/health` served a dead index as green. Embedding
 /// failure must be LOUD: a full-pipeline index that walked files but produced
 /// zero vectors is broken, not ready.
+///
+/// The `skipped_files` fix (#868): `walked_files` is the raw filesystem-walker
+/// count BEFORE hash-skip/minified-skip filtering. On a no-change incremental
+/// reindex every file is hash-skipped, so `walked_files > 0` but zero files
+/// are actually submitted to the embedder — zero vectors is EXPECTED, not a
+/// crash. The old guard misfired on this case, rolling back the staging corpus
+/// and degrading the index to BM25-only until the next forced reindex. The fix
+/// computes `newly_submitted = walked_files.saturating_sub(skipped_files)` and
+/// only fires `Failed` when files were actually sent to the embedder.
+///
 /// What: returns [`ReindexOutcome::Failed`] iff the index is **not**
 /// lexical-only, an embedder is wired (`embedder_present`), at least one file
-/// was walked, and `total_vector_count == 0`. A `lexical_only` index, or any
-/// index with no embedder configured (BM25-only / test indexer), legitimately
-/// has zero vectors, so it is always `Ready`. An index that walked zero files
-/// (empty repo / over-aggressive filter) is `Ready` too — that is an
-/// empty-but-valid corpus, not an embedder failure, and is reported separately
-/// via walk diagnostics.
+/// was walked, at least one file was newly submitted for embedding (i.e. not
+/// hash-skipped), and `total_vector_count == 0`. A `lexical_only` index, any
+/// index with no embedder configured (BM25-only / test indexer), an index
+/// that walked zero files (empty repo / over-aggressive filter), or an
+/// incremental reindex where all files were hash-skipped (`newly_submitted ==
+/// 0`) are all `Ready` — none of those is an embedder failure.
 /// Test: `reindex_outcome_*` below — covers the lexical-only exception, the
-/// no-embedder exception, the zero-files exception, the zero-vector failure,
-/// and the healthy path.
+/// no-embedder exception, the zero-files exception, the all-hash-skipped
+/// warm-boot case (#868 regression), the genuine crash, partial-skip crash,
+/// partial-skip success, and the healthy path.
 pub(crate) fn reindex_outcome(
     lexical_only: bool,
     embedder_present: bool,
     walked_files: usize,
+    skipped_files: usize,
     total_vector_count: usize,
 ) -> ReindexOutcome {
     if lexical_only {
@@ -97,10 +109,21 @@ pub(crate) fn reindex_outcome(
         // Nothing to embed: an empty (but valid) corpus, not a failure.
         return ReindexOutcome::Ready;
     }
+    // #868: files actually submitted to the embedder after hash-skip / minified
+    // filtering. On a warm no-change reindex this is 0 — zero vectors is then
+    // EXPECTED, not an embedder crash. Only fire Failed when the embedder was
+    // genuinely invoked but produced nothing.
+    let newly_submitted = walked_files.saturating_sub(skipped_files);
+    if newly_submitted == 0 {
+        // All files were hash-skipped (or minified-skipped); the embedder was
+        // never called. Zero vectors is the correct outcome — not a failure.
+        return ReindexOutcome::Ready;
+    }
     if total_vector_count == 0 {
         return ReindexOutcome::Failed {
             reason: format!(
-                "embedding produced zero vectors for {walked_files} walked file(s) — \
+                "embedding produced zero vectors for {newly_submitted} submitted file(s) \
+                 ({walked_files} walked, {skipped_files} hash-skipped) — \
                  the embedder backend likely failed for every batch (sidecar crash, \
                  OOM, or model-load stall). The previous index was preserved; \
                  check the embedderd logs and retry."
@@ -167,7 +190,7 @@ mod tests {
     #[test]
     fn reindex_outcome_lexical_only_is_ready_with_zero_vectors() {
         // lexical_only=true, embedder irrelevant.
-        let outcome = reindex_outcome(true, true, 100, 0);
+        let outcome = reindex_outcome(true, true, 100, 0, 0);
         assert!(outcome.is_ready());
         assert_eq!(outcome.failure_reason(), None);
     }
@@ -178,24 +201,9 @@ mod tests {
     /// Test: this test.
     #[test]
     fn reindex_outcome_no_embedder_is_ready_with_zero_vectors() {
-        let outcome = reindex_outcome(false, false, 100, 0);
+        let outcome = reindex_outcome(false, false, 100, 0, 0);
         assert!(outcome.is_ready());
         assert_eq!(outcome.failure_reason(), None);
-    }
-
-    /// Why: the core #601 bug — a full-pipeline index WITH an embedder that
-    /// walked files but embedded nothing is broken and must be marked failed.
-    /// Test: this test.
-    #[test]
-    fn reindex_outcome_full_pipeline_zero_vectors_fails() {
-        let outcome = reindex_outcome(false, true, 42, 0);
-        assert!(!outcome.is_ready());
-        let reason = outcome.failure_reason().expect("must carry a reason");
-        assert!(reason.contains("zero vectors"), "reason: {reason}");
-        assert!(
-            reason.contains("42"),
-            "reason should cite file count: {reason}"
-        );
     }
 
     /// Why: an empty repo (or an over-aggressive filter) walks zero files; that
@@ -204,15 +212,15 @@ mod tests {
     /// Test: this test.
     #[test]
     fn reindex_outcome_zero_files_is_ready() {
-        assert!(reindex_outcome(false, true, 0, 0).is_ready());
-        assert!(reindex_outcome(true, true, 0, 0).is_ready());
+        assert!(reindex_outcome(false, true, 0, 0, 0).is_ready());
+        assert!(reindex_outcome(true, true, 0, 0, 0).is_ready());
     }
 
     /// Why: the healthy path — files walked, vectors produced — must be Ready.
     /// Test: this test.
     #[test]
     fn reindex_outcome_healthy_is_ready() {
-        assert!(reindex_outcome(false, true, 42, 1337).is_ready());
+        assert!(reindex_outcome(false, true, 42, 0, 1337).is_ready());
     }
 
     /// Why: a single embedded vector for many files is still "the embedder
@@ -222,7 +230,80 @@ mod tests {
     /// Test: this test.
     #[test]
     fn reindex_outcome_single_vector_is_ready() {
-        assert!(reindex_outcome(false, true, 1000, 1).is_ready());
+        assert!(reindex_outcome(false, true, 1000, 0, 1).is_ready());
+    }
+
+    /// Why: regression test for #868 — a warm-boot incremental reindex where
+    /// all files are hash-skipped produces zero new vectors by design. The old
+    /// guard misfired here, rolling back the staging corpus and degrading the
+    /// index to BM25-only. With `skipped_files == walked_files`, `newly_submitted
+    /// == 0`, so the guard must return Ready.
+    /// Test: this test.
+    #[test]
+    fn reindex_outcome_all_hash_skipped_is_ready() {
+        // #868 scenario: 24 files walked, all 24 hash-skipped, 0 new vectors.
+        let outcome = reindex_outcome(false, true, 24, 24, 0);
+        assert!(
+            outcome.is_ready(),
+            "all-hash-skipped warm reindex must be Ready, got: {:?}",
+            outcome
+        );
+        assert_eq!(outcome.failure_reason(), None);
+    }
+
+    /// Why: when files were actually submitted to the embedder (not all skipped)
+    /// and zero vectors came back, that is a genuine embedder crash — must fail.
+    /// Test: this test.
+    #[test]
+    fn reindex_outcome_genuine_crash_fails() {
+        // 24 walked, 0 skipped → 24 submitted, 0 vectors → crash.
+        let outcome = reindex_outcome(false, true, 24, 0, 0);
+        assert!(!outcome.is_ready());
+        let reason = outcome.failure_reason().expect("must carry a reason");
+        assert!(reason.contains("zero vectors"), "reason: {reason}");
+        assert!(
+            reason.contains("24"),
+            "reason should cite submitted count: {reason}"
+        );
+    }
+
+    /// Why: partial skip with a crash — some files were submitted but none
+    /// embedded. Must fail (the embedder was invoked and produced nothing).
+    /// Test: this test.
+    #[test]
+    fn reindex_outcome_partial_skip_crash_fails() {
+        // 24 walked, 20 skipped → 4 submitted, 0 vectors → crash.
+        let outcome = reindex_outcome(false, true, 24, 20, 0);
+        assert!(!outcome.is_ready());
+        let reason = outcome.failure_reason().expect("must carry a reason");
+        assert!(reason.contains("zero vectors"), "reason: {reason}");
+    }
+
+    /// Why: partial skip where the submitted files were successfully embedded.
+    /// Must be Ready (the embedder worked for the files it was given).
+    /// Test: this test.
+    #[test]
+    fn reindex_outcome_partial_skip_success_is_ready() {
+        // 24 walked, 20 skipped → 4 submitted, 12 vectors → healthy.
+        let outcome = reindex_outcome(false, true, 24, 20, 12);
+        assert!(outcome.is_ready());
+        assert_eq!(outcome.failure_reason(), None);
+    }
+
+    /// Why: the core #601 bug — a full-pipeline index WITH an embedder that
+    /// walked files but embedded nothing is broken and must be marked failed.
+    /// This covers the case with no hash-skips (all files newly submitted).
+    /// Test: this test.
+    #[test]
+    fn reindex_outcome_full_pipeline_zero_vectors_fails() {
+        let outcome = reindex_outcome(false, true, 42, 0, 0);
+        assert!(!outcome.is_ready());
+        let reason = outcome.failure_reason().expect("must carry a reason");
+        assert!(reason.contains("zero vectors"), "reason: {reason}");
+        assert!(
+            reason.contains("42"),
+            "reason should cite submitted count: {reason}"
+        );
     }
 
     /// Why: confirms the strip-prefix root resolves a real symlinked directory


### PR DESCRIPTION
## Summary
Fixes #868. The incremental-reindex zero-vector safety guard in `service/reindex/validate.rs::reindex_outcome` misfired when ALL walked files were hash-skipped (no-change / warm-boot case): it produced 0 vectors as expected, but the guard treated this like an embedder crash, threw fatal, and rolled back the staging corpus — degrading persisted vector/KG to BM25-only, and discarding deleted-file prunes (F2).

## Fix
- `reindex_outcome` now takes `skipped_files`; computes `newly_submitted = walked_files - skipped_files`. Returns `Ready` when `newly_submitted == 0` (zero vectors expected). Only fires `Failed` when `newly_submitted > 0 && total_vector_count == 0` (genuine embedder crash — safety net preserved, narrowed not disabled).
- Call site in `reindex/mod.rs` passes `progress.skipped.load(Acquire)`.
- F2 (deleted-file prune persistence) resolves as a side-effect: staging now commits with the prune applied.

## Tests
- 4 new + 5 updated unit tests in `validate.rs` (incl. #868 regression `reindex_outcome_all_hash_skipped_is_ready`). Full suite: 975 passed, 0 failed. clippy clean, fmt clean, line-cap OK.

## Runtime QA (isolated daemon, live :7878 untouched)
- No-change incremental reindex → `complete`, no fatal, no rollback (was the bug).
- Vectors/KG retained across reindex + daemon restart (chunk_count stable).
- Deleted-file prune persists across restart (F2 regression fixed).
- Genuine-crash guard structurally intact (covered by unit tests).

## Release
Bumps trusty-search 0.24.0 → **0.24.1** + CHANGELOG. Dependent `trusty-agents` pin `^0.24.0` already accepts 0.24.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)