### PR TITLE
feat(trusty-agents-common): HarnessEvent envelope + bus + filter + ADR-0005 (Wave 3 Phase 0)

### DIFF
--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -18,9 +18,11 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 # adapters/patterns.rs uses regex for pattern compilation.
 regex = { workspace = true }
+# Wave 3 P0 (issue #875): events::bus uses tokio::sync::broadcast for the
+# process-global event bus. The workspace `tokio` already enables "full"
+# (which includes the `sync` feature that provides `broadcast`).
+tokio = { workspace = true }
 
 [dev-dependencies]
 # session_registry tests use tempfile for isolated state-dir creation.
 tempfile = { workspace = true }
-# runner::tests uses #[tokio::test] for the async AgentRunner default-impl test.
-tokio = { workspace = true }

--- a/crates/trusty-agents-common/src/events/bus.rs
+++ b/crates/trusty-agents-common/src/events/bus.rs
@@ -1,0 +1,282 @@
+//! Process-global event bus, the `HarnessEvent` envelope, and the
+//! lagged-receiver helper for the unified harness event stream (ADR-0005).
+//!
+//! Why: Threading a `broadcast::Sender<HarnessEvent>` through every code path
+//!      that might emit telemetry (workflow engine, agent runners, hooks,
+//!      ctrl) would touch hundreds of function signatures. A `OnceLock` mirrors
+//!      how `tracing` solves the same problem — emit-from-anywhere with zero
+//!      overhead when no one is listening. The envelope wraps the per-domain
+//!      payload with cross-cutting metadata (source, session, monotonic seq,
+//!      timestamp) so any subscriber can order, correlate, and route events
+//!      without inspecting the payload.
+//! What: Defines `HarnessPayload` (the domain-tagged inner union),
+//!       `HarnessEvent` (the envelope), the process-global `EVENT_BUS`, a
+//!       monotonic `SEQ` counter, `bus`/`subscribe`/`publish`/`emit` helpers,
+//!       the `__HARNESS_EVENT__` stderr relay prefix, and a `Lag` notice with
+//!       `recv_with_lag` so a lagged subscriber is told how many events it
+//!       skipped and can resume instead of tearing down its stream.
+//! Test: `super::tests` covers serde round-trips of each payload arm, seq
+//!       monotonicity, lagged handling against a constructible test bus, and
+//!       the emit-line formatting helper.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::broadcast;
+
+use super::lifecycle::{HarnessSource, LifecycleEvent};
+
+/// Stderr line prefix used to relay events from a child process to its parent.
+///
+/// Why: A harness may spawn workflow / agent work in a child process whose
+///      events must still reach the parent's bus. Reusing stderr as the IPC
+///      channel (the parent already reads child stderr) avoids inventing a new
+///      transport. A stable, unambiguous prefix lets the parent detect relay
+///      lines and re-publish them rather than mirroring them to the terminal.
+/// What: Match by exact byte prefix; the payload after the space is one JSON
+///       object decodable as `HarnessEvent`.
+/// Test: `super::tests::event_line_prefix_is_stable` and
+///       `super::tests::emit_line_has_prefix_and_parses`.
+pub const EVENT_LINE_PREFIX: &str = "__HARNESS_EVENT__ ";
+
+/// Broadcast channel capacity for the global bus.
+///
+/// Why: Event volume is high (every PM thought, every agent line, every tool
+///      call). 1024 keeps memory bounded (~256 KB at 256 bytes/event) while
+///      tolerating slow subscribers without dropping recent events under
+///      typical load. A subscriber that still falls behind receives a `Lag`
+///      notice rather than silently losing the stream.
+/// What: Used both for the process-global bus and as the default for the
+///       test-only constructible bus.
+pub const CHANNEL_CAPACITY: usize = 1024;
+
+/// Domain-tagged inner union carried inside a `HarnessEvent`.
+///
+/// Why: The "adapt, don't fold" decision (ADR-0005): rather than flattening
+///      lifecycle, hook, and keepalive events into one giant enum, we tag by
+///      *domain* so each harness can grow its own payload taxonomy
+///      independently. Hooks in particular are open-ended (arbitrary
+///      tool/event names + JSON data), so they get an untyped `Value` arm
+///      instead of being modelled variant-by-variant.
+/// What: `serde(tag = "domain", content = "event")` produces
+///       `{"domain":"lifecycle","event":{...}}`, `{"domain":"hook","event":
+///       {"kind":...,"data":...}}`, or `{"domain":"ping"}`. `Ping` is the
+///       transport keepalive (promoted out of the lifecycle enum).
+/// Test: `super::tests::payload_*_round_trips` assert the tag shape for each
+///       arm.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "domain", content = "event", rename_all = "snake_case")]
+pub enum HarnessPayload {
+    /// A structured PM-lifecycle event (session/agent/tool/phase/LLM/...).
+    Lifecycle(LifecycleEvent),
+    /// An open-ended hook event: `kind` names the hook, `data` is its payload.
+    Hook { kind: String, data: Value },
+    /// Transport keepalive so long-lived SSE connections don't time out.
+    Ping,
+}
+
+impl HarnessPayload {
+    /// The domain string for this payload (`"lifecycle"`, `"hook"`, `"ping"`).
+    ///
+    /// Why: `Filter` matches on the domain without serialising the whole
+    ///      payload; keeping the mapping here is the single source of truth.
+    /// What: Returns the same string serde uses for the `domain` tag.
+    /// Test: `super::tests::payload_domain_matches_serde_tag`.
+    pub fn domain(&self) -> &'static str {
+        match self {
+            HarnessPayload::Lifecycle(_) => "lifecycle",
+            HarnessPayload::Hook { .. } => "hook",
+            HarnessPayload::Ping => "ping",
+        }
+    }
+}
+
+/// Cross-harness event envelope: metadata + domain-tagged payload.
+///
+/// Why: Subscribers need to order (`seq`), time-stamp (`at`), attribute
+///      (`source`), and correlate (`session`) events uniformly, regardless of
+///      which harness produced them or which domain the payload belongs to.
+///      Carrying that metadata in the envelope keeps the payload taxonomies
+///      free of repeated bookkeeping fields.
+/// What: `source` is the originating harness; `session` is the optional task
+///       correlation key (omitted from JSON when `None`); `seq` is a
+///       process-monotonic counter; `at` is the emit-time UTC timestamp;
+///       `payload` is the domain-tagged union. All fields derive serde.
+/// Test: `super::tests::harness_event_round_trips` and the per-arm payload
+///       tests build full envelopes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessEvent {
+    /// Which harness produced this event.
+    pub source: HarnessSource,
+    /// Optional task/session correlation key. Omitted from JSON when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+    /// Process-monotonic sequence number assigned at publish time.
+    pub seq: u64,
+    /// Emit-time UTC timestamp.
+    pub at: DateTime<Utc>,
+    /// Domain-tagged payload.
+    pub payload: HarnessPayload,
+}
+
+/// Notice that a subscriber fell behind and skipped `skipped` events.
+///
+/// Why: `broadcast::Receiver` returns `RecvError::Lagged(n)` and then resumes
+///      from the oldest still-buffered event. Silently swallowing that loses
+///      the "you missed N events" signal a UI needs to show a gap; tearing the
+///      stream down on lag is worse. Surfacing it as a typed value lets
+///      subscribers render a gap marker and keep going.
+/// What: A thin newtype-ish struct wrapping the skipped count, returned as the
+///       `Err` arm of `recv_with_lag`.
+/// Test: `super::tests::lagged_receiver_yields_lag_then_resumes`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Lag {
+    /// Number of events the receiver skipped past.
+    pub skipped: u64,
+}
+
+/// Process-global event bus, initialised on first access.
+///
+/// Why: Emit-from-anywhere telemetry without threading a sender through every
+///      signature. First access wins; all later accesses share the same sender.
+/// What: `Sender::send` is non-blocking; with no subscribers it returns an
+///       error which `publish` silently drops (no listeners is the baseline).
+static EVENT_BUS: OnceLock<broadcast::Sender<HarnessEvent>> = OnceLock::new();
+
+/// Process-monotonic sequence source for envelope `seq` assignment.
+///
+/// Why: Subscribers need a total order over events even when timestamps
+///      collide at sub-millisecond resolution. A single atomic counter gives a
+///      cheap, lock-free monotonic sequence shared across all emit sites.
+/// What: Incremented once per `publish`/`emit`; wraps after 2^64 events
+///       (practically never).
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Get (or initialise) the process-global event bus sender.
+///
+/// Why: Called from any code path that wants to emit. Cheap on the hot path
+///      (single atomic load once initialised).
+/// What: Returns a clone of the global sender. Receivers are created per
+///       subscriber via `subscribe()`.
+/// Test: `super::tests::bus_is_singleton`.
+pub fn bus() -> broadcast::Sender<HarnessEvent> {
+    EVENT_BUS
+        .get_or_init(|| broadcast::channel(CHANNEL_CAPACITY).0)
+        .clone()
+}
+
+/// Subscribe to all future events on the global bus.
+///
+/// Why: Subscribers (relays, aggregators, future SSE handlers) each need their
+///      own `Receiver`; `broadcast::Receiver::recv` takes `&mut self`.
+/// What: Returns a fresh `Receiver` that begins receiving events emitted after
+///       the call returns.
+/// Test: `super::tests::publish_round_trips_through_subscribe`.
+pub fn subscribe() -> broadcast::Receiver<HarnessEvent> {
+    bus().subscribe()
+}
+
+/// Allocate the next monotonic sequence number.
+///
+/// Why: Centralising the counter keeps every emit site assigning sequence
+///      numbers from the same source.
+/// What: Fetch-adds the global `SEQ` with `Relaxed` ordering (only monotonic
+///       uniqueness is required, not cross-field synchronisation).
+fn next_seq() -> u64 {
+    SEQ.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Build a fully-populated `HarnessEvent`, assigning `seq` and `at`.
+///
+/// Why: `publish` and `emit` both need to stamp the envelope identically; one
+///      helper avoids drift between the two paths.
+/// What: Allocates the next seq, reads `Utc::now()`, and assembles the envelope.
+/// Test: Exercised by `publish_round_trips_through_subscribe` (seq/at present).
+fn make_event(
+    source: HarnessSource,
+    session: Option<String>,
+    payload: HarnessPayload,
+) -> HarnessEvent {
+    HarnessEvent {
+        source,
+        session,
+        seq: next_seq(),
+        at: Utc::now(),
+        payload,
+    }
+}
+
+/// Publish one event to the global bus (best-effort, never panics).
+///
+/// Why: Events are telemetry, not control flow. Having no subscribers is the
+///      normal baseline, so a send failure is expected and dropped.
+/// What: Stamps the envelope (`seq`, `at`) via `make_event`, then sends on the
+///       broadcast channel, ignoring `SendError`. Returns the assigned `seq` so
+///       callers (and tests) can observe ordering.
+/// Test: `super::tests::publish_round_trips_through_subscribe`,
+///       `super::tests::seq_is_monotonic`.
+pub fn publish(source: HarnessSource, session: Option<String>, payload: HarnessPayload) -> u64 {
+    let event = make_event(source, session, payload);
+    let seq = event.seq;
+    let _ = bus().send(event);
+    seq
+}
+
+/// Publish an event AND emit it on stderr with the `EVENT_LINE_PREFIX` so a
+/// parent process can re-broadcast on its own bus.
+///
+/// Why: Child-process emit sites should not have to know whether they are
+///      running standalone or under a parent relay; doing both in one call
+///      keeps call sites uniform.
+/// What: Builds the envelope once, publishes it for in-process subscribers,
+///       then writes one NDJSON line to stderr prefixed with `EVENT_LINE_PREFIX`.
+///       Returns the assigned `seq`.
+/// Test: `super::tests::emit_line_has_prefix_and_parses` covers the line
+///       formatting via the shared `format_event_line` helper.
+pub fn emit(source: HarnessSource, session: Option<String>, payload: HarnessPayload) -> u64 {
+    let event = make_event(source, session, payload);
+    let seq = event.seq;
+    let line = format_event_line(&event);
+    let _ = bus().send(event);
+    if let Some(line) = line {
+        eprintln!("{line}");
+    }
+    seq
+}
+
+/// Format a single stderr relay line for `event`, or `None` if it cannot be
+/// serialised.
+///
+/// Why: Splitting the formatting out of `emit` makes the wire shape unit-
+///      testable without capturing real stderr.
+/// What: Returns `EVENT_LINE_PREFIX` concatenated with the compact JSON of the
+///       envelope; `None` only on the (practically impossible) serde failure.
+/// Test: `super::tests::emit_line_has_prefix_and_parses`.
+pub fn format_event_line(event: &HarnessEvent) -> Option<String> {
+    serde_json::to_string(event)
+        .ok()
+        .map(|json| format!("{EVENT_LINE_PREFIX}{json}"))
+}
+
+/// Receive the next event, translating broadcast lag into a typed `Lag`.
+///
+/// Why: Raw `broadcast::Receiver::recv` returns `RecvError::Lagged(n)` and then
+///      `RecvError::Closed`; a subscriber that wants to keep going needs the
+///      lag count surfaced as data, not an opaque error it must re-interpret at
+///      every call site. This helper does that translation once.
+/// What: On a successful receive returns `Ok(Ok(event))`; on lag returns
+///       `Ok(Err(Lag { skipped }))` (the stream is still alive — call again to
+///       resume); on a closed channel returns `Err(())`.
+/// Test: `super::tests::lagged_receiver_yields_lag_then_resumes`.
+pub async fn recv_with_lag(
+    rx: &mut broadcast::Receiver<HarnessEvent>,
+) -> Result<Result<HarnessEvent, Lag>, ()> {
+    match rx.recv().await {
+        Ok(event) => Ok(Ok(event)),
+        Err(broadcast::error::RecvError::Lagged(n)) => Ok(Err(Lag { skipped: n })),
+        Err(broadcast::error::RecvError::Closed) => Err(()),
+    }
+}

--- a/crates/trusty-agents-common/src/events/filter.rs
+++ b/crates/trusty-agents-common/src/events/filter.rs
@@ -1,0 +1,73 @@
+//! Subscriber-side event filter for the unified harness bus (ADR-0005).
+//!
+//! Why: The global bus broadcasts *everything* to *every* subscriber. A given
+//!      consumer (a task-scoped SSE stream, a single-harness relay, a
+//!      hook-only aggregator) usually wants a slice of that firehose. Rather
+//!      than running N filtered channels, subscribers filter in their own recv
+//!      loop with a small predicate. Phase 0 deliberately avoids adding a
+//!      Stream dependency: `Filter::matches` is the lightweight primitive
+//!      consumers will call inside `recv_with_lag` loops in later phases.
+//! What: A `Filter` of optional constraints (source, session, domains) plus a
+//!       `matches` predicate that ANDs the present constraints. An empty /
+//!       default filter matches everything.
+//! Test: `super::tests::filter_*` cover each axis, combinations, and the
+//!       default-matches-all case.
+
+use super::bus::HarnessEvent;
+use super::lifecycle::HarnessSource;
+
+/// A conjunctive (AND) filter over `HarnessEvent`s.
+///
+/// Why: Subscribers express "only events from harness X, for session Y, in
+///      domains Z" without bespoke matching logic at each call site. Optional
+///      fields make every constraint opt-in: `None` means "don't constrain on
+///      this axis", so `Filter::default()` is the match-all filter.
+/// What: `source` constrains the originating harness; `session` constrains the
+///       correlation key (an event with no session never matches a session
+///       constraint); `domains` constrains the payload domain string
+///       (`"lifecycle"`, `"hook"`, `"ping"`). `&'static str` is used for
+///       `domains` because the legal domain set is fixed and known at compile
+///       time, avoiding allocation for the common constants.
+/// Test: `super::tests::filter_default_matches_all` and the per-axis cases.
+#[derive(Default, Clone)]
+pub struct Filter {
+    /// Only match events from this harness, if set.
+    pub source: Option<HarnessSource>,
+    /// Only match events carrying exactly this session key, if set.
+    pub session: Option<String>,
+    /// Only match events whose payload domain is in this list, if set.
+    pub domains: Option<Vec<&'static str>>,
+}
+
+impl Filter {
+    /// Whether `ev` satisfies every constraint present in this filter.
+    ///
+    /// Why: The single predicate subscribers call per received event. ANDing
+    ///      only the *present* constraints means an empty filter is a pass-all,
+    ///      which is the ergonomic default for "subscribe to everything".
+    /// What: For each set field, checks the corresponding envelope field;
+    ///       returns `false` on the first mismatch. A `session` constraint
+    ///       requires the event to carry that exact session (events with
+    ///       `session = None` do not match a session constraint). A `domains`
+    ///       constraint matches if the event's domain is in the list.
+    /// Test: `super::tests::filter_by_source`, `filter_by_session`,
+    ///       `filter_by_domain`, `filter_combination`, `filter_default_matches_all`.
+    pub fn matches(&self, ev: &HarnessEvent) -> bool {
+        if let Some(source) = self.source
+            && source != ev.source
+        {
+            return false;
+        }
+        if let Some(session) = &self.session
+            && ev.session.as_deref() != Some(session.as_str())
+        {
+            return false;
+        }
+        if let Some(domains) = &self.domains
+            && !domains.contains(&ev.payload.domain())
+        {
+            return false;
+        }
+        true
+    }
+}

--- a/crates/trusty-agents-common/src/events/lifecycle.rs
+++ b/crates/trusty-agents-common/src/events/lifecycle.rs
@@ -1,0 +1,241 @@
+//! Lifecycle event taxonomy + harness source enum for the shared event bus.
+//!
+//! Why: Wave 3 unifies the three harnesses (trusty-agents, trusty-mpm,
+//!      trusty-code) onto a single event envelope (see ADR-0005). The richest
+//!      existing event taxonomy is `trusty-agents::events::Event` — the full PM
+//!      lifecycle. To avoid a flag-day rewrite, Phase 0 *copies* that taxonomy
+//!      here as `LifecycleEvent` (minus `Ping`, which becomes a transport-level
+//!      `HarnessPayload::Ping` arm). The de-duplication / migration of the
+//!      original `trusty-agents` enum happens in later phases (P1/P2); for now
+//!      this is purely additive and wires up no consumers.
+//! What: Defines `HarnessSource` (which harness produced an event) and
+//!       `LifecycleEvent` (the per-domain lifecycle taxonomy), both
+//!       serde-round-trippable with stable snake_case wire tags.
+//! Test: `super::tests` round-trips representative variants and asserts the
+//!       `{"type": ...}` tag shape; `session_id` is covered there too.
+
+use serde::{Deserialize, Serialize};
+
+/// Which harness emitted an event.
+///
+/// Why: Once all three harnesses share one bus, a subscriber (UI, relay,
+///      aggregator) must be able to tell trusty-agents events from trusty-mpm
+///      or trusty-code events without inspecting the payload. Encoding the
+///      origin in the envelope keeps that routing decision O(1) and explicit.
+/// What: A copy-able enum with three variants serialising as snake_case
+///       (`"agents"`, `"mpm"`, `"code"`).
+/// Test: `super::tests::harness_source_round_trips`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessSource {
+    /// The `trusty-agents` orchestration harness.
+    Agents,
+    /// The `trusty-mpm` platform.
+    Mpm,
+    /// The `trusty-code` per-project harness.
+    Code,
+}
+
+/// Real-time lifecycle events streamed to UI clients across all harnesses.
+///
+/// Why: A single tagged enum keeps wire-format evolution tractable —
+///      `serde(tag = "type")` produces `{"type":"agent_message", ...}` so the
+///      UI can pattern-match on type and the back-end can grow new variants
+///      without breaking older clients (unknown variants degrade to "ignored
+///      event"). This is a verbatim copy of `trusty-agents::events::Event`
+///      *minus* the `Ping` keepalive, which is promoted to a transport-level
+///      `HarnessPayload::Ping` arm (keepalives are not a lifecycle concern).
+/// What: Variants cover the full PM lifecycle — session, PM activity, agent
+///       activity, tool calls, AST analysis, workflow phases, persona
+///       detection, LLM call lifecycle, and report/recap generation.
+///       `session_id` correlates events to a specific task; the UI filters by
+///       session when scoped to a task view.
+/// Test: `super::tests::lifecycle_event_serializes_with_type_tag` asserts the
+///       wire shape; `super::tests::lifecycle_session_id_*` cover the helper.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LifecycleEvent {
+    // -- Session lifecycle --
+    SessionStarted {
+        session_id: String,
+        project: String,
+    },
+    SessionDone {
+        session_id: String,
+        status: String,
+    },
+    SessionCancelled {
+        session_id: String,
+    },
+
+    // -- PM activity --
+    PmThinking {
+        session_id: String,
+        text: String,
+    },
+    PmDelegating {
+        session_id: String,
+        agent: String,
+        task_preview: String,
+    },
+
+    // -- Agent activity --
+    AgentSpawned {
+        session_id: String,
+        agent: String,
+    },
+    AgentMessage {
+        session_id: String,
+        agent: String,
+        text: String,
+    },
+    AgentDone {
+        session_id: String,
+        agent: String,
+        status: String,
+    },
+    AgentFailed {
+        session_id: String,
+        agent: String,
+        error: String,
+    },
+
+    // -- Tool calls --
+    ToolCalled {
+        session_id: String,
+        tool: String,
+        preview: String,
+    },
+    ToolResult {
+        session_id: String,
+        tool: String,
+        preview: String,
+    },
+
+    // -- AST analysis --
+    /// Emitted when an AST-native tool performs a structural code operation
+    /// (symbol lookup, edit, insert, import, validation, patch apply, or
+    /// project pre-indexing). `op` is a short label (`index`, `lookup`,
+    /// `edit`, `insert`, `import`, `validate`, `patch`); `detail` is a
+    /// human-readable substring.
+    AstOperation {
+        session_id: String,
+        op: String,
+        detail: String,
+    },
+
+    // -- Phase (workflow) --
+    PhaseStarted {
+        session_id: String,
+        phase: String,
+    },
+    PhaseDone {
+        session_id: String,
+        phase: String,
+        status: String,
+    },
+    /// A phase was skipped because the active persona opts out of it. Carries
+    /// the phase name and the persona that triggered the skip.
+    PhaseSkipped {
+        session_id: String,
+        phase: String,
+        persona: String,
+    },
+
+    // -- Persona (workflow) --
+    /// Emitted once per workflow run when a persona is detected from the task
+    /// text, so the UI can surface "running in [persona] mode" before any
+    /// phases execute.
+    PersonaDetected {
+        session_id: String,
+        persona: String,
+    },
+
+    // -- LLM call lifecycle --
+    /// Emitted just before any LLM chat-completion HTTP call leaves the
+    /// process. Pairs with `LlmResponded` so consumers can compute latency.
+    /// `agent_name` may be empty for top-level PM calls; `model` is the
+    /// resolved provider/model string sent on the wire.
+    LlmRequested {
+        session_id: String,
+        agent_name: String,
+        model: String,
+        prompt_tokens: Option<u32>,
+    },
+
+    /// Emitted after every LLM chat-completion HTTP call returns successfully.
+    /// Carries wall-clock latency so the UI can render "model X took Yms".
+    LlmResponded {
+        session_id: String,
+        agent_name: String,
+        model: String,
+        completion_tokens: Option<u32>,
+        latency_ms: u64,
+    },
+
+    /// Emitted when an agent's actual work loop begins — distinct from
+    /// `AgentSpawned`. `runner_type` is one of "subprocess", "claude-code",
+    /// "inline".
+    AgentStarted {
+        session_id: String,
+        agent_name: String,
+        runner_type: String,
+    },
+
+    /// Emitted when an agent produces its final result before returning to the
+    /// PM. `word_count` is a cheap whitespace-split count; status mirrors the
+    /// agent's IPC status field ("success" or "error").
+    ReportGenerated {
+        session_id: String,
+        agent_name: String,
+        word_count: usize,
+        status: String,
+    },
+
+    /// Emitted when a session recap is generated after N completed tasks.
+    /// Carries the session ID, a one-line prose summary, and structured rows.
+    RecapGenerated {
+        session_id: String,
+        /// One-line prose summary, e.g. "Fixed a bug where X. Y is now deployed."
+        summary: String,
+        /// Structured rows for the recap table: [(step_label, result_text)]
+        table_rows: Vec<(String, String)>,
+    },
+}
+
+impl LifecycleEvent {
+    /// Return the event's `session_id` if it has one.
+    ///
+    /// Why: Filtering the broadcast stream to a single task subscription needs
+    ///      a uniform accessor across the ~21 variants without each call site
+    ///      re-matching. Every current variant carries a session, but the
+    ///      `Option` keeps the contract stable if a session-less lifecycle
+    ///      variant is ever added.
+    /// What: Returns `Some(&str)` for variants that carry a session.
+    /// Test: `super::tests::lifecycle_session_id_returns_correct_field`.
+    pub fn session_id(&self) -> Option<&str> {
+        match self {
+            LifecycleEvent::SessionStarted { session_id, .. }
+            | LifecycleEvent::SessionDone { session_id, .. }
+            | LifecycleEvent::SessionCancelled { session_id }
+            | LifecycleEvent::PmThinking { session_id, .. }
+            | LifecycleEvent::PmDelegating { session_id, .. }
+            | LifecycleEvent::AgentSpawned { session_id, .. }
+            | LifecycleEvent::AgentMessage { session_id, .. }
+            | LifecycleEvent::AgentDone { session_id, .. }
+            | LifecycleEvent::AgentFailed { session_id, .. }
+            | LifecycleEvent::ToolCalled { session_id, .. }
+            | LifecycleEvent::ToolResult { session_id, .. }
+            | LifecycleEvent::AstOperation { session_id, .. }
+            | LifecycleEvent::PhaseStarted { session_id, .. }
+            | LifecycleEvent::PhaseDone { session_id, .. }
+            | LifecycleEvent::PhaseSkipped { session_id, .. }
+            | LifecycleEvent::PersonaDetected { session_id, .. }
+            | LifecycleEvent::LlmRequested { session_id, .. }
+            | LifecycleEvent::LlmResponded { session_id, .. }
+            | LifecycleEvent::AgentStarted { session_id, .. }
+            | LifecycleEvent::ReportGenerated { session_id, .. }
+            | LifecycleEvent::RecapGenerated { session_id, .. } => Some(session_id),
+        }
+    }
+}

--- a/crates/trusty-agents-common/src/events/mod.rs
+++ b/crates/trusty-agents-common/src/events/mod.rs
@@ -1,0 +1,338 @@
+//! Unified harness event envelope, bus, and filter (Wave 3 Phase 0; ADR-0005).
+//!
+//! Why: The three harnesses (`trusty-agents`, `trusty-mpm`, `trusty-code`) each
+//!      grew their own ad-hoc event streaming. Wave 3 unifies them on one
+//!      `HarnessEvent` envelope flowing over one process-global broadcast bus,
+//!      so a single subscriber (UI, relay, aggregator) can consume all three.
+//!      Phase 0 lands the *foundation only* — the types, the bus, the
+//!      subscription API, and a lightweight filter — with no consumers wired
+//!      yet. The migration of existing emit sites happens in P1–P4.
+//! What: A thin facade that re-exports the public surface from three focused
+//!       submodules (respecting the 500-line cap): `lifecycle` (the
+//!       `HarnessSource` + `LifecycleEvent` taxonomy), `bus` (the
+//!       `HarnessEvent`/`HarnessPayload` envelope, the global bus, and the
+//!       lagged-receiver helper), and `filter` (the subscriber-side `Filter`).
+//! Test: `tests` (below) is the comprehensive suite for this foundation type;
+//!       submodules document which test exercises each item.
+
+mod bus;
+mod filter;
+mod lifecycle;
+
+pub use bus::{
+    CHANNEL_CAPACITY, EVENT_LINE_PREFIX, HarnessEvent, HarnessPayload, Lag, bus, emit,
+    format_event_line, publish, recv_with_lag, subscribe,
+};
+pub use filter::Filter;
+pub use lifecycle::{HarnessSource, LifecycleEvent};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::sync::broadcast;
+
+    fn sample_lifecycle() -> LifecycleEvent {
+        LifecycleEvent::PmThinking {
+            session_id: "s1".into(),
+            text: "considering options".into(),
+        }
+    }
+
+    fn envelope(payload: HarnessPayload, session: Option<&str>) -> HarnessEvent {
+        HarnessEvent {
+            source: HarnessSource::Agents,
+            session: session.map(str::to_string),
+            seq: 0,
+            at: chrono::Utc::now(),
+            payload,
+        }
+    }
+
+    // ---- HarnessSource ----
+
+    #[test]
+    fn harness_source_round_trips() {
+        for (src, tag) in [
+            (HarnessSource::Agents, "\"agents\""),
+            (HarnessSource::Mpm, "\"mpm\""),
+            (HarnessSource::Code, "\"code\""),
+        ] {
+            let s = serde_json::to_string(&src).expect("serialize source");
+            assert_eq!(s, tag);
+            let back: HarnessSource = serde_json::from_str(&s).expect("deserialize source");
+            assert_eq!(back, src);
+        }
+    }
+
+    // ---- LifecycleEvent ----
+
+    #[test]
+    fn lifecycle_event_serializes_with_type_tag() {
+        let s = serde_json::to_string(&sample_lifecycle()).expect("serialize");
+        assert!(s.contains("\"type\":\"pm_thinking\""), "{s}");
+        assert!(s.contains("\"session_id\":\"s1\""), "{s}");
+    }
+
+    #[test]
+    fn lifecycle_session_id_returns_correct_field() {
+        let ev = LifecycleEvent::AgentMessage {
+            session_id: "abc".into(),
+            agent: "python".into(),
+            text: "hi".into(),
+        };
+        assert_eq!(ev.session_id(), Some("abc"));
+    }
+
+    #[test]
+    fn lifecycle_recap_round_trips() {
+        let ev = LifecycleEvent::RecapGenerated {
+            session_id: "s9".into(),
+            summary: "did a thing".into(),
+            table_rows: vec![("step".into(), "ok".into())],
+        };
+        let s = serde_json::to_string(&ev).expect("serialize recap");
+        let back: LifecycleEvent = serde_json::from_str(&s).expect("deserialize recap");
+        assert_eq!(back, ev);
+    }
+
+    // ---- HarnessPayload tag shapes ----
+
+    #[test]
+    fn payload_lifecycle_round_trips() {
+        let p = HarnessPayload::Lifecycle(sample_lifecycle());
+        let s = serde_json::to_string(&p).expect("serialize");
+        assert!(s.contains("\"domain\":\"lifecycle\""), "{s}");
+        assert!(s.contains("\"event\":{"), "{s}");
+        assert!(s.contains("\"type\":\"pm_thinking\""), "{s}");
+        let back: HarnessPayload = serde_json::from_str(&s).expect("deserialize");
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn payload_hook_round_trips() {
+        let p = HarnessPayload::Hook {
+            kind: "pre_tool_use".into(),
+            data: json!({"tool": "bash", "ok": true}),
+        };
+        let s = serde_json::to_string(&p).expect("serialize");
+        assert!(s.contains("\"domain\":\"hook\""), "{s}");
+        assert!(s.contains("\"kind\":\"pre_tool_use\""), "{s}");
+        let back: HarnessPayload = serde_json::from_str(&s).expect("deserialize");
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn payload_ping_round_trips() {
+        let p = HarnessPayload::Ping;
+        let s = serde_json::to_string(&p).expect("serialize");
+        assert_eq!(s, "{\"domain\":\"ping\"}");
+        let back: HarnessPayload = serde_json::from_str(&s).expect("deserialize");
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn payload_domain_matches_serde_tag() {
+        assert_eq!(
+            HarnessPayload::Lifecycle(sample_lifecycle()).domain(),
+            "lifecycle"
+        );
+        assert_eq!(
+            HarnessPayload::Hook {
+                kind: "x".into(),
+                data: json!(null)
+            }
+            .domain(),
+            "hook"
+        );
+        assert_eq!(HarnessPayload::Ping.domain(), "ping");
+    }
+
+    // ---- HarnessEvent envelope ----
+
+    #[test]
+    fn harness_event_round_trips() {
+        let ev = envelope(HarnessPayload::Ping, Some("sess-1"));
+        let s = serde_json::to_string(&ev).expect("serialize");
+        assert!(s.contains("\"source\":\"agents\""), "{s}");
+        assert!(s.contains("\"session\":\"sess-1\""), "{s}");
+        let back: HarnessEvent = serde_json::from_str(&s).expect("deserialize");
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn harness_event_omits_none_session() {
+        let ev = envelope(HarnessPayload::Ping, None);
+        let s = serde_json::to_string(&ev).expect("serialize");
+        assert!(!s.contains("session"), "session should be omitted: {s}");
+    }
+
+    // ---- bus + seq ----
+
+    #[test]
+    fn bus_is_singleton() {
+        let a = bus();
+        let b = bus();
+        let mut rx = b.subscribe();
+        let _ = a.send(envelope(HarnessPayload::Ping, None));
+        let got = rx.try_recv().expect("expected event");
+        assert!(matches!(got.payload, HarnessPayload::Ping));
+    }
+
+    #[tokio::test]
+    async fn publish_round_trips_through_subscribe() {
+        let mut rx = subscribe();
+        let seq = publish(
+            HarnessSource::Mpm,
+            Some("t1".into()),
+            HarnessPayload::Lifecycle(LifecycleEvent::SessionStarted {
+                session_id: "t1".into(),
+                project: "demo".into(),
+            }),
+        );
+        let got = rx.recv().await.expect("recv");
+        assert_eq!(got.seq, seq);
+        assert_eq!(got.source, HarnessSource::Mpm);
+        assert_eq!(got.session.as_deref(), Some("t1"));
+        match got.payload {
+            HarnessPayload::Lifecycle(LifecycleEvent::SessionStarted { project, .. }) => {
+                assert_eq!(project, "demo");
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn seq_is_monotonic() {
+        let s1 = publish(HarnessSource::Agents, None, HarnessPayload::Ping);
+        let s2 = publish(HarnessSource::Agents, None, HarnessPayload::Ping);
+        let s3 = publish(HarnessSource::Agents, None, HarnessPayload::Ping);
+        assert!(s1 < s2 && s2 < s3, "seq not monotonic: {s1} {s2} {s3}");
+    }
+
+    // ---- emit line formatting ----
+
+    #[test]
+    fn event_line_prefix_is_stable() {
+        assert_eq!(EVENT_LINE_PREFIX, "__HARNESS_EVENT__ ");
+    }
+
+    #[test]
+    fn emit_line_has_prefix_and_parses() {
+        let ev = envelope(HarnessPayload::Ping, Some("sess"));
+        let line = format_event_line(&ev).expect("format line");
+        assert!(line.starts_with(EVENT_LINE_PREFIX), "{line}");
+        let json = line.strip_prefix(EVENT_LINE_PREFIX).expect("strip prefix");
+        let back: HarnessEvent = serde_json::from_str(json).expect("parse relayed line");
+        assert_eq!(back, ev);
+    }
+
+    // ---- lagged receiver ----
+
+    #[tokio::test]
+    async fn lagged_receiver_yields_lag_then_resumes() {
+        // Constructible bus (not the global one) so we control capacity and can
+        // deterministically overflow a slow receiver.
+        let (tx, mut rx) = broadcast::channel::<HarnessEvent>(2);
+
+        // Overflow the buffer: send 5 into a capacity-2 channel without
+        // receiving. The oldest 3 are dropped; the receiver will report Lagged.
+        for _ in 0..5 {
+            let _ = tx.send(envelope(HarnessPayload::Ping, None));
+        }
+
+        // First recv reports the lag (skipped count) instead of an event.
+        match recv_with_lag(&mut rx).await {
+            Ok(Err(Lag { skipped })) => assert_eq!(skipped, 3),
+            other => panic!("expected Lag, got {other:?}"),
+        }
+
+        // Stream resumes: the two still-buffered events are delivered.
+        for _ in 0..2 {
+            match recv_with_lag(&mut rx).await {
+                Ok(Ok(ev)) => assert!(matches!(ev.payload, HarnessPayload::Ping)),
+                other => panic!("expected resumed event, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn recv_with_lag_reports_closed() {
+        let (tx, mut rx) = broadcast::channel::<HarnessEvent>(2);
+        drop(tx);
+        assert!(recv_with_lag(&mut rx).await.is_err());
+    }
+
+    // ---- Filter matrix ----
+
+    #[test]
+    fn filter_default_matches_all() {
+        let f = Filter::default();
+        assert!(f.matches(&envelope(HarnessPayload::Ping, None)));
+        assert!(f.matches(&envelope(
+            HarnessPayload::Lifecycle(sample_lifecycle()),
+            Some("x")
+        )));
+    }
+
+    #[test]
+    fn filter_by_source() {
+        let f = Filter {
+            source: Some(HarnessSource::Mpm),
+            ..Default::default()
+        };
+        let mut ev = envelope(HarnessPayload::Ping, None);
+        ev.source = HarnessSource::Mpm;
+        assert!(f.matches(&ev));
+        ev.source = HarnessSource::Agents;
+        assert!(!f.matches(&ev));
+    }
+
+    #[test]
+    fn filter_by_session() {
+        let f = Filter {
+            session: Some("sess-7".into()),
+            ..Default::default()
+        };
+        assert!(f.matches(&envelope(HarnessPayload::Ping, Some("sess-7"))));
+        assert!(!f.matches(&envelope(HarnessPayload::Ping, Some("other"))));
+        // An event with no session never matches a session constraint.
+        assert!(!f.matches(&envelope(HarnessPayload::Ping, None)));
+    }
+
+    #[test]
+    fn filter_by_domain() {
+        let f = Filter {
+            domains: Some(vec!["hook", "ping"]),
+            ..Default::default()
+        };
+        assert!(f.matches(&envelope(HarnessPayload::Ping, None)));
+        assert!(f.matches(&envelope(
+            HarnessPayload::Hook {
+                kind: "k".into(),
+                data: json!({})
+            },
+            None
+        )));
+        assert!(!f.matches(&envelope(
+            HarnessPayload::Lifecycle(sample_lifecycle()),
+            Some("x")
+        )));
+    }
+
+    #[test]
+    fn filter_combination() {
+        let f = Filter {
+            source: Some(HarnessSource::Code),
+            session: Some("s".into()),
+            domains: Some(vec!["lifecycle"]),
+        };
+        let mut ev = envelope(HarnessPayload::Lifecycle(sample_lifecycle()), Some("s"));
+        ev.source = HarnessSource::Code;
+        assert!(f.matches(&ev));
+
+        // Wrong source fails the conjunction even though session+domain match.
+        ev.source = HarnessSource::Mpm;
+        assert!(!f.matches(&ev));
+    }
+}

--- a/crates/trusty-agents-common/src/lib.rs
+++ b/crates/trusty-agents-common/src/lib.rs
@@ -72,6 +72,22 @@ pub mod adapters;
 ///       the `tests` module of `session_registry.rs`.
 pub mod session_registry;
 
+/// Unified harness event envelope, process-global broadcast bus, and filter.
+///
+/// Why: Wave 3 (epic #830, refs #833) unifies real-time event streaming across
+///      the three harnesses (`trusty-agents`, `trusty-mpm`, `trusty-code`) onto
+///      one `HarnessEvent` envelope flowing over a single process-global
+///      broadcast bus. Phase 0 (this module) lands the foundation only — the
+///      types, the bus, the subscription API, and a lightweight `Filter` — with
+///      NO consumers wired yet. Migration of existing emit sites happens in
+///      P1–P4. See ADR-0005.
+/// What: Re-exports `HarnessEvent`, `HarnessPayload`, `HarnessSource`,
+///       `LifecycleEvent`, `Lag`, `Filter`, the `bus`/`subscribe`/`publish`/
+///       `emit`/`recv_with_lag` helpers, and the `EVENT_LINE_PREFIX` relay
+///       constant from the `events::*` submodules.
+/// Test: `events::tests` is the comprehensive suite for this foundation type.
+pub mod events;
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/docs/adr/0005-harness-event-bus.md
+++ b/docs/adr/0005-harness-event-bus.md
@@ -1,0 +1,141 @@
+# 0005. Shared HarnessEvent envelope + process-global event bus in trusty-agents-common
+
+- **Status:** Accepted
+- **Date:** 2026-06-06
+- **Scope:** Workspace-wide (`trusty-agents-common` foundation; future consumers `trusty-agents`, `trusty-mpm`, `trusty-code`)
+- **Supersedes / Superseded by:** Builds on ADR-0004 (three harnesses on a shared event-driven common)
+
+## Context
+
+ADR-0004 established that the three harnesses — `trusty-code` (coding),
+`trusty-mpm` (meta/control-plane), and `trusty-agents` (agentic) — should share
+an event-driven foundation in the common layer. Today each harness streams
+real-time telemetry its own way:
+
+- `trusty-agents` has the richest taxonomy: `crates/trusty-agents/src/events.rs`
+  defines a ~21-variant `Event` enum (`#[serde(tag = "type")]`) covering the
+  full PM lifecycle (session/agent/tool/phase/LLM/persona/recap), plus a `Ping`
+  keepalive, a process-global `OnceLock<broadcast::Sender<Event>>` bus
+  (capacity 1024), `publish`/`emit` helpers, and a `__OMPM_EVENT__ ` stderr
+  relay prefix for child-to-parent re-broadcast.
+- `trusty-mpm` relays Claude Code **hooks** — open-ended `{kind, data}` events
+  whose taxonomy is not fixed and should not be modelled variant-by-variant.
+- `trusty-code` will grow its own coding-session events.
+
+A single subscriber (UI, SSE relay, aggregator) cannot today consume all three.
+We need one envelope and one bus that all three harnesses emit onto, while
+keeping each harness free to evolve its own payload taxonomy.
+
+This ADR records the Wave 3 **Phase 0** decision: land the foundation type, the
+bus, the subscription API, and a filter in `trusty-agents-common` — **additively,
+with no consumers wired yet** (tracked in issue #875, epic #830, refs #833).
+The existing `trusty-agents::events::Event` enum is left untouched; its variants
+are *copied* into a new `LifecycleEvent` so Phase 0 is a pure addition with zero
+behavior change. De-duplication and consumer migration are deferred to P1–P4.
+
+## Decision
+
+We will add an `events` module to `trusty-agents-common`, split into focused
+submodules to respect the 500-line cap (`mod.rs` facade + `lifecycle.rs` +
+`bus.rs` + `filter.rs`), exposing the following surface.
+
+### Envelope shape
+
+- **`HarnessSource`** — `{ Agents, Mpm, Code }`, snake_case serde. Identifies
+  which harness produced an event so routing is O(1) without payload inspection.
+- **`LifecycleEvent`** — a verbatim copy of `trusty-agents::events::Event`'s
+  variants **except `Ping`**, keeping `#[serde(tag = "type", rename_all =
+  "snake_case")]` and every per-variant field, plus a `session_id()` accessor.
+- **`HarnessPayload`** — `#[serde(tag = "domain", content = "event")]` with arms
+  `Lifecycle(LifecycleEvent)`, `Hook { kind: String, data: serde_json::Value }`,
+  and `Ping`. Wire shape: `{"domain":"lifecycle","event":{...}}`,
+  `{"domain":"hook","event":{"kind":...,"data":...}}`, `{"domain":"ping"}`.
+- **`HarnessEvent`** — the envelope: `{ source, session: Option<String>
+  (skipped when None), seq: u64, at: DateTime<Utc>, payload: HarnessPayload }`.
+
+### Bus + subscription API
+
+- A process-global `static EVENT_BUS: OnceLock<broadcast::Sender<HarnessEvent>>`
+  (capacity 1024), with `bus()` and `subscribe()`.
+- A monotonic `static SEQ: AtomicU64` so `publish`/`emit` stamp `seq` and `at`
+  (`Utc::now()`) automatically. `publish` is best-effort (ignores `SendError`
+  when there are no subscribers) and returns the assigned `seq`.
+- `emit` = `publish` + one NDJSON stderr line prefixed with the public
+  `EVENT_LINE_PREFIX = "__HARNESS_EVENT__ "`. The line formatting is factored
+  into `format_event_line` so it is unit-testable without capturing real stderr.
+- A lagged-receiver helper `recv_with_lag` that translates
+  `broadcast::error::RecvError::Lagged(n)` into a public typed `Lag { skipped }`
+  notice (returned as the `Err` arm of an inner `Result`) and resumes the stream
+  rather than dropping it; `Closed` maps to the outer `Err(())`.
+
+### Filter
+
+- `Filter { source: Option<HarnessSource>, session: Option<String>, domains:
+  Option<Vec<&'static str>> }` with `matches(&HarnessEvent) -> bool`. Present
+  constraints are ANDed; `Filter::default()` matches everything. Domain strings
+  are `"lifecycle" | "hook" | "ping"`. We deliberately ship the lightweight
+  `matches` predicate (no new Stream dependency); subscribers will call it in
+  their `recv_with_lag` loop in later phases.
+
+### Secondary design defaults (recorded for posterity)
+
+1. **MessageBus stays separate.** This event bus carries *telemetry* (fan-out,
+   lossy-under-lag, no delivery guarantee). It is intentionally NOT a
+   command/RPC bus; any future request/response `MessageBus` is a distinct
+   abstraction and is out of scope here.
+2. **In-process + stderr relay only.** Phase 0 scope is the in-process
+   broadcast channel plus the stderr child-to-parent relay prefix. No network
+   transport (SSE/WebSocket wire format) is defined here — see the risk below.
+3. **`session: Option<String>` key.** Correlation is a single optional string,
+   not a typed newtype, matching the existing `session_id: String` fields and
+   keeping the envelope cheap. A session-less event (e.g. a bare `Ping`) never
+   matches a `Filter` session constraint.
+
+### Adapt, don't fold (hooks)
+
+Rather than folding hook events into the lifecycle enum (which would force every
+open-ended Claude Code hook to become a typed variant), `HarnessPayload` tags by
+**domain** and gives hooks an untyped `{kind, data: Value}` arm. Each harness
+adapts its native events into a domain arm; we do not fold disparate taxonomies
+into one mega-enum.
+
+## Consequences
+
+**Easier:**
+
+- One subscriber can consume lifecycle, hook, and keepalive events from all
+  three harnesses over one bus, ordered by `seq` and attributed by `source`.
+- Adding a harness or a new lifecycle variant does not touch the envelope.
+- Hook events flow through without per-event modelling work.
+- The foundation is fully unit-tested (serde round-trips per arm, seq
+  monotonicity, the filter matrix, lagged-then-resume against a constructible
+  test bus, and emit-line formatting) before any consumer depends on it.
+
+**Harder / trade-offs:**
+
+- `LifecycleEvent` is, for now, a **copy** of `trusty-agents::events::Event`.
+  Until P1/P2 migrate `trusty-agents` onto it, the two definitions can drift;
+  the duplication is an accepted, time-boxed cost of a zero-risk additive
+  Phase 0.
+- `trusty-agents-common` gains a regular (non-dev) `tokio` dependency. The
+  workspace `tokio` already enables `"full"` (which includes `sync`/`broadcast`),
+  so no feature override is needed, but the crate is no longer tokio-free.
+
+**Neutral / follow-up — phased migration plan:**
+
+- **P0 (this ADR, #875):** land types + bus + filter + tests, no consumers.
+- **P1:** migrate `trusty-agents` emit sites onto `HarnessEvent`
+  (`source = Agents`), collapse the copied `LifecycleEvent` back to a single
+  definition, and re-export for source compatibility.
+- **P2:** route `trusty-mpm` hook relays through `HarnessPayload::Hook`
+  (`source = Mpm`).
+- **P3:** emit `trusty-code` coding-session events (`source = Code`).
+- **P4:** define the SSE/WebSocket **wire shape** for browser/Tauri
+  subscribers and the network relay.
+
+**Key risk — SSE wire shape.** Phase 0 fixes the *internal* JSON shape of
+`HarnessEvent` but does NOT commit to the *external* SSE/WebSocket contract
+(P4). If the internal shape leaks directly onto the wire before P4 deliberately
+designs that contract, we risk freezing an accidental public API. Consumers in
+P1–P3 must treat `HarnessEvent`'s JSON as an internal detail until P4 ratifies
+the external schema.


### PR DESCRIPTION
## Wave 3 Phase 0 — shared HarnessEvent foundation (additive, no consumers)

Lands the foundational unified-event types, a process-global broadcast bus, a subscription API, and a lightweight `Filter` in `trusty-agents-common`. **Purely additive: no consumers wired, zero behavior change anywhere else.** `LifecycleEvent` is a COPY of the existing `trusty-agents::events::Event` enum for now; de-duplication / consumer migration is deferred to P1–P4.

Closes #875. Refs #830 (epic), #833.

## Public API surface landed (`trusty_agents_common::events`)

- `HarnessSource { Agents, Mpm, Code }` — snake_case serde.
- `LifecycleEvent` — verbatim copy of `Event`'s ~21 variants **minus `Ping`**; keeps `#[serde(tag="type", rename_all="snake_case")]` + `session_id()`.
- `HarnessPayload` — `#[serde(tag="domain", content="event")]`: `Lifecycle(..)`, `Hook { kind, data }`, `Ping`; plus `domain()`.
- `HarnessEvent` — `{ source, session: Option<String> (skipped when None), seq: u64, at: DateTime<Utc>, payload }`.
- `bus()`, `subscribe()`, `publish(source, session, payload) -> u64`, `emit(..) -> u64`, `format_event_line(..)`, `recv_with_lag(..) -> Result<Result<HarnessEvent, Lag>, ()>`.
- `Lag { skipped: u64 }`, `EVENT_LINE_PREFIX = "__HARNESS_EVENT__ "`, `CHANNEL_CAPACITY`.
- `Filter { source, session, domains }` with `matches(&HarnessEvent) -> bool` (default matches all).

Split across `events/{mod,lifecycle,bus,filter}.rs` to respect the 500-line cap (largest = mod.rs at 337 lines incl. tests).

## ADR

`docs/adr/0005-harness-event-bus.md` (Nygard, Status: Accepted). Captures the envelope shape, the **adapt-not-fold** hook decision, the three secondary defaults (MessageBus stays separate; in-process + stderr-relay scope only; `Option<String>` session key), and the **P0–P4 migration plan** with the **SSE-wire-shape risk** (internal JSON shape is NOT yet the external contract).

## Constraints honored

- No consumers touched: `trusty-agents/src/events.rs`, `trusty-code`, `trusty-mpm` unchanged.
- No `unwrap()` in lib code; Why/What/Test docs on all public items.
- `tokio` promoted dev-dep → regular dep (workspace `"full"` already provides `broadcast`); all deps `{ workspace = true }`.

## Verification

- `cargo build --workspace` — green (1m33s).
- `cargo test -p trusty-agents-common` — 72 passed, 0 failed.
- `cargo test --workspace` — green (EXIT=0). (A `trusty-common` env-var test race is a known pre-existing flake unrelated to this PR; passes cleanly in isolation.)
- `cargo clippy --workspace --all-targets -- -D warnings` — EXIT=0, 0 errors.
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — OK (0 violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)