### PR TITLE
fix(memory): cap recall at top_k + doc drift (closes #877, #881)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -37,8 +37,8 @@ crates/trusty-common/src/lib.rs	1467
 crates/trusty-common/src/memory_core/analytics.rs	860
 crates/trusty-common/src/memory_core/dream.rs	1820
 crates/trusty-common/src/memory_core/git.rs	568
-crates/trusty-common/src/memory_core/retrieval/mod.rs	1469
-crates/trusty-common/src/memory_core/retrieval/tests.rs	1072
+crates/trusty-common/src/memory_core/retrieval/mod.rs	1483
+crates/trusty-common/src/memory_core/retrieval/tests.rs	1140
 crates/trusty-common/src/memory_core/semantic_consolidation.rs	968
 crates/trusty-common/src/memory_core/store/chat_sessions.rs	930
 crates/trusty-common/src/memory_core/store/hnsw_store.rs	766

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,7 +577,7 @@ curl http://127.0.0.1:$(trusty-search port)/health
 trusty-memory port                                   # bare port: 7070
 trusty-memory port --addr                            # host:port: 127.0.0.1:7070
 trusty-memory port --json                            # {"addr":"127.0.0.1","port":7070}
-curl http://127.0.0.1:$(trusty-memory port)/api/v1/health
+curl http://127.0.0.1:$(trusty-memory port)/health
 
 # Fire-and-forget memory note from any agent (no MCP tool needed):
 # Sub-agents spawned via Claude Code's Agent tool do not inherit MCP

--- a/crates/trusty-common/src/memory_core/retrieval/mod.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/mod.rs
@@ -1301,12 +1301,15 @@ pub fn expand_query(query: &str) -> String {
 /// What: Runs `retrieve_l2` to obtain vector-similarity scores, builds a
 /// score map from those results, applies `rescore_l1_by_similarity` to patch
 /// L1 entries so importance alone can't dominate relevance-first ranking
-/// (issue #633), deduplicates by drawer id, and finally sorts the merged list
-/// by score descending.  Applies `expand_query` before embedding to bridge
-/// the user-vocabulary / technical-vocabulary gap.
+/// (issue #633), deduplicates by drawer id, sorts the merged list by score
+/// descending, and finally **truncates to `top_k`** (issue #877) so the
+/// caller always receives at most `top_k` results regardless of how many
+/// L0/L1 entries the palace has.  Applies `expand_query` before embedding
+/// to bridge the user-vocabulary / technical-vocabulary gap.
 /// Test: `recall_ranks_by_similarity_over_importance` verifies that a
 /// low-importance but on-topic drawer outranks a high-importance but
 /// off-topic drawer after this function returns.
+/// `recall_top_k_caps_result_count` (issue #877) verifies the length cap.
 pub async fn recall(
     handle: &PalaceHandle,
     embedder: &dyn Embedder,
@@ -1336,6 +1339,12 @@ pub async fn recall(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
+    // Issue #877: enforce the top_k contract. L0+L1 can add up to
+    // L1_CAP+1 entries before any L2 hits are merged; without this truncation
+    // the caller receives more than top_k results whenever the palace has a
+    // non-empty identity string plus several high-importance drawers.
+    combined.truncate(top_k);
+
     log_recall(handle, query, &combined);
     Ok(combined)
 }
@@ -1346,7 +1355,9 @@ pub async fn recall(
 /// instead of the metadata-filtered L2.
 /// What: Same as `recall` but uses `retrieve_l3` for the heavy layer.
 /// L1 entries are still re-scored via `rescore_l1_by_similarity` so the
-/// final ranking is similarity-first (issue #633).
+/// final ranking is similarity-first (issue #633). The merged list is
+/// **truncated to `top_k`** (issue #877) before returning so the caller
+/// always receives at most `top_k` results.
 /// Test: Symmetric with `recall`; covered indirectly.
 pub async fn recall_deep(
     handle: &PalaceHandle,
@@ -1371,6 +1382,9 @@ pub async fn recall_deep(
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
+
+    // Issue #877: enforce the top_k contract (same as `recall`).
+    combined.truncate(top_k);
 
     log_recall(handle, query, &combined);
     Ok(combined)

--- a/crates/trusty-common/src/memory_core/retrieval/tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/tests.rs
@@ -1070,3 +1070,71 @@ fn rescore_l1_by_similarity_patches_scores() {
         results[2].score
     );
 }
+
+/// Regression test for issue #877 — recall must never return more than
+/// top_k results even when the palace has more L0+L1 entries than top_k.
+///
+/// Why: `recall` builds L0+L1 (up to L1_CAP+1 = 16 entries) before merging
+/// L2 hits. Without a final `.truncate(top_k)` call the caller receives
+/// L0+L1+L2 results, which can far exceed the requested top_k (e.g.
+/// top_k=5 → 15 results when the palace has 14 L1 drawers plus identity).
+/// What: Populate a palace with more drawers than top_k, run recall with a
+/// small top_k, and assert `results.len() <= top_k` for both the shallow
+/// and deep paths.
+/// Test: This test itself.
+#[tokio::test]
+async fn recall_top_k_caps_result_count() {
+    init_embedder();
+    use crate::memory_core::palace::Palace;
+    let dir = tempdir().unwrap();
+    let palace = Palace {
+        id: PalaceId::new("topk-cap-test"),
+        name: "TopKCap".into(),
+        description: None,
+        created_at: chrono::Utc::now(),
+        data_dir: dir.path().join("topk-cap-test"),
+    };
+    std::fs::create_dir_all(&palace.data_dir).unwrap();
+    let handle = PalaceHandle::open(&palace).unwrap();
+
+    // Insert 20 drawers — enough to populate all 15 L1 slots plus 5 extras,
+    // so L0+L1 alone would return 16 entries (identity + 15 L1 drawers).
+    for i in 0..20u32 {
+        handle
+            .remember(
+                format!(
+                    "test fact number {i} about the recall top-k cap regression \
+                     with enough tokens to pass the default filter check"
+                ),
+                RoomType::General,
+                vec![],
+                // Varying importance so the L1 snapshot gets different drawers.
+                (i as f32) * 0.04 + 0.1,
+            )
+            .await
+            .unwrap();
+    }
+
+    let embedder = shared_embedder().await.unwrap();
+    let top_k = 5_usize;
+
+    // Shallow recall (L0+L1+L2) must return <= top_k.
+    let shallow = recall(&handle, embedder.as_ref(), "test fact recall", top_k)
+        .await
+        .unwrap();
+    assert!(
+        shallow.len() <= top_k,
+        "shallow recall: expected at most {top_k} results, got {}",
+        shallow.len()
+    );
+
+    // Deep recall (L0+L1+L3) must also return <= top_k.
+    let deep = recall_deep(&handle, embedder.as_ref(), "test fact recall", top_k)
+        .await
+        .unwrap();
+    assert!(
+        deep.len() <= top_k,
+        "deep recall: expected at most {top_k} results, got {}",
+        deep.len()
+    );
+}

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -57,7 +57,7 @@ trusty-memory port --addr        # host:port: 127.0.0.1:7070
 trusty-memory port --json        # {"addr":"127.0.0.1","port":7070}
 
 # Shell substitution — stdout is clean (logs go to stderr):
-curl http://127.0.0.1:$(trusty-memory port)/api/v1/health
+curl http://127.0.0.1:$(trusty-memory port)/health
 ```
 
 Exits non-zero with a message on stderr when no daemon is running, so shell
@@ -68,6 +68,12 @@ substitution fails cleanly.
 The same `trusty-memory serve` daemon serves the embedded Svelte admin UI
 at the bound address (printed by `trusty-memory monitor web` once the
 daemon is running) and a REST API under `/api/v1/`.
+
+Key REST API field names (verified against `src/web.rs` and `src/service.rs`):
+- Recall endpoints (`GET /api/v1/palaces/{id}/recall` and `GET /api/v1/recall`) accept
+  the query string as **`q`** (not `query`): `?q=my+search+term&top_k=5`.
+- Drawer-create body (`POST /api/v1/palaces/{id}/drawers`) expects a **`content`** field
+  (not `text`) for the drawer body.
 
 ### Bind to a named palace
 
@@ -418,18 +424,19 @@ Memories and vector indexes persist under the OS-standard data directory:
 - **Linux**: `~/.local/share/trusty-memory/<palace-id>/`
 
 Each palace directory contains:
-- `drawers.db` — SQLite metadata store
-- `vectors.usearch` — usearch vector index
-- `kg.db` — knowledge-graph triples (SQLite)
-- `chat_sessions.db` — chat session history
+- `kg.redb` — redb store for drawer metadata and knowledge-graph triples
+- `index.usearch` — usearch vector index (approximate nearest-neighbour)
+- `recall.redb` — recall analytics log (redb; migrated from `recall.db` on first open)
+- `l1_cache.json` — top-15 drawers by importance (L1 hot cache, rebuilt at each write)
+- `palace.json` — palace metadata (name, description, created_at)
 
 ## Architecture
 
 ```
 trusty-memory (this crate)          trusty-common `memory-core` feature
   axum HTTP/SSE server     ──────►  PalaceRegistry
-  Unix domain socket       ──────►  usearch vector index
-  embedded Svelte UI               SQLite metadata + KG
+  Unix domain socket       ──────►  usearch vector index (index.usearch)
+  embedded Svelte UI               redb metadata + KG (kg.redb)
   23 MCP tools                     fastembed (AllMiniLML6V2Q)
 
 trusty-memory-mcp-bridge (separate binary, PR #149)
@@ -437,7 +444,7 @@ trusty-memory-mcp-bridge (separate binary, PR #149)
 ```
 
 The `memory-core` feature of `trusty-common` owns the storage engine: `usearch` for approximate
-nearest-neighbor search, SQLite for metadata and knowledge-graph triples, and
+nearest-neighbor search, `redb` for drawer metadata and knowledge-graph triples, and
 `fastembed` for 384-dim text embeddings. The MCP server (`trusty-memory`) is a
 thin protocol layer on top.
 


### PR DESCRIPTION
## Summary

- **#877 (MEDIUM)** — `recall()` and `recall_deep()` in `retrieval/mod.rs` built a merged L0+L1 list (up to `L1_CAP+1 = 16` entries) before sort but never called `.truncate(top_k)`, so callers received more results than requested whenever a palace had more high-importance drawers than `top_k`. Fixed by adding `combined.truncate(top_k)` after the final sort in both code paths.
- **#881 (LOW)** — Three doc-drift fixes: correct `/health` path in CLAUDE.md, replace obsolete SQLite filenames with actual redb/json storage files in README.md, and add API field-name notes (`q` not `query`, `content` not `text`).

## Changes

| File | Change |
|---|---|
| `crates/trusty-common/src/memory_core/retrieval/mod.rs` | Add `combined.truncate(top_k)` after sort in `recall()` and `recall_deep()`; update doc comments |
| `crates/trusty-common/src/memory_core/retrieval/tests.rs` | Add `recall_top_k_caps_result_count` regression test |
| `.line-cap-allowlist.tsv` | Bump budgets for the two files above |
| `CLAUDE.md` | Fix health endpoint: `api/v1/health` → `/health` |
| `crates/trusty-memory/README.md` | Fix storage file table (redb not SQLite); fix architecture prose; add API field-name notes |

## Test plan

- [x] `cargo test -p trusty-common --features memory-core retrieval::tests` — 22 passed (includes new `recall_top_k_caps_result_count`)
- [x] `cargo test -p trusty-memory` — all tests passed
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` — exit 0
- [x] `bash scripts/check_line_cap.sh` — `172 allowlisted, 0 violations — OK`
- [x] End-to-end: isolated daemon on port 17777, 20 facts written, verified:
  - `?top_k=5` → **5** results
  - `?top_k=3` → **3** results
  - `?top_k=10` → **10** results
  - `?deep=true&top_k=5` → **5** results

🤖 Generated with [Claude Code](https://claude.com/claude-code)