### PR TITLE
fix(search): reject empty/whitespace search queries with 400 (closes #882)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -160,7 +160,7 @@ crates/trusty-search/src/core/search/hierarchy.rs	658
 crates/trusty-search/src/core/store.rs	1275
 crates/trusty-search/src/core/symbol_graph.rs	1667
 crates/trusty-search/src/main.rs	1291
-crates/trusty-search/src/mcp/tools.rs	2184
+crates/trusty-search/src/mcp/tools.rs	2187
 crates/trusty-search/src/service/call_chain.rs	954
 crates/trusty-search/src/service/daemon.rs	774
 crates/trusty-search/src/service/embedder_supervisor.rs	1020

--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -160,7 +160,7 @@ crates/trusty-search/src/core/search/hierarchy.rs	658
 crates/trusty-search/src/core/store.rs	1275
 crates/trusty-search/src/core/symbol_graph.rs	1667
 crates/trusty-search/src/main.rs	1291
-crates/trusty-search/src/mcp/tools.rs	2174
+crates/trusty-search/src/mcp/tools.rs	2184
 crates/trusty-search/src/service/call_chain.rs	954
 crates/trusty-search/src/service/daemon.rs	774
 crates/trusty-search/src/service/embedder_supervisor.rs	1020

--- a/crates/trusty-search/src/mcp/tools.rs
+++ b/crates/trusty-search/src/mcp/tools.rs
@@ -607,8 +607,11 @@ impl McpServer {
         if !status.is_success() {
             // Issue #882: 400 means invalid input — surface as InvalidParams.
             if status == reqwest::StatusCode::BAD_REQUEST {
-                let msg = body.get("error").and_then(Value::as_str)
-                    .unwrap_or("bad request").to_owned();
+                let msg = body
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("bad request")
+                    .to_owned();
                 return Err(DispatchError::InvalidParams(msg));
             }
             return Err(DispatchError::Transport(format!(

--- a/crates/trusty-search/src/mcp/tools.rs
+++ b/crates/trusty-search/src/mcp/tools.rs
@@ -605,6 +605,12 @@ impl McpServer {
             .await
             .map_err(|e| DispatchError::Transport(format!("decode {url}: {e}")))?;
         if !status.is_success() {
+            // Issue #882: 400 means invalid input — surface as InvalidParams.
+            if status == reqwest::StatusCode::BAD_REQUEST {
+                let msg = body.get("error").and_then(Value::as_str)
+                    .unwrap_or("bad request").to_owned();
+                return Err(DispatchError::InvalidParams(msg));
+            }
             return Err(DispatchError::Transport(format!(
                 "POST {url} returned {status}: {body}"
             )));
@@ -2172,3 +2178,7 @@ mod tests {
         assert_eq!(captured.lock().await.as_slice(), &["/search".to_string()]);
     }
 }
+
+// Issue #882: empty-query MCP tests (separate file — line-cap budget).
+#[cfg(test)]
+mod tests_empty_query;

--- a/crates/trusty-search/src/mcp/tools/tests_empty_query.rs
+++ b/crates/trusty-search/src/mcp/tools/tests_empty_query.rs
@@ -4,6 +4,9 @@
 //! MCP layer maps that 400 to a clean InvalidParams error (bare-method) or
 //! `isError: true` (tools/call) rather than an opaque Transport failure.
 //! What: spins up a tiny mock daemon per test and drives the McpServer dispatcher.
+//! Each test wires a `tokio::sync::oneshot` shutdown channel into axum's graceful
+//! shutdown so the listener is torn down deterministically at the end of the test,
+//! preventing port leaks under parallel test runs.
 //! Test: this file.
 
 use serde_json::Value;
@@ -24,12 +27,13 @@ fn req(method: &str, params: Value) -> Request {
 /// opaque transport failure, so the LLM can react with a helpful message.
 /// What: spins up a mock daemon that returns 400 for any search request, then
 /// asserts the bare-method form returns INVALID_PARAMS and the `tools/call`
-/// form returns `isError: true`.
+/// form returns `isError: true`. Graceful shutdown via oneshot channel.
 /// Test: this test.
 #[tokio::test]
 async fn search_tool_empty_query_surfaces_as_invalid_params() {
     use axum::routing::post;
     use axum::{Json, Router};
+    use tokio::sync::oneshot;
 
     async fn bad_search(Json(_body): Json<Value>) -> (axum::http::StatusCode, Json<Value>) {
         (
@@ -41,8 +45,13 @@ async fn search_tool_empty_query_surfaces_as_invalid_params() {
     let app = Router::new().route("/indexes/demo/search", post(bad_search));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, app).await;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                shutdown_rx.await.ok();
+            })
+            .await;
     });
 
     let server = McpServer::new(format!("http://{addr}"));
@@ -82,6 +91,9 @@ async fn search_tool_empty_query_surfaces_as_invalid_params() {
         result["isError"], true,
         "whitespace-only query must return isError=true"
     );
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
 }
 
 /// Why: per-lane tools (`search_lexical`, `search_semantic`, `search_kg`,
@@ -89,11 +101,13 @@ async fn search_tool_empty_query_surfaces_as_invalid_params() {
 /// InvalidParams / tool error when the daemon rejects an empty query.
 /// What: mock daemon returns 400 for any search; asserts `search_lexical`
 /// returns INVALID_PARAMS (bare-method) and isError=true (tools/call).
+/// Graceful shutdown via oneshot channel.
 /// Test: this test.
 #[tokio::test]
 async fn search_lexical_empty_query_surfaces_as_invalid_params() {
     use axum::routing::{get, post};
     use axum::{extract::Path, Json, Router};
+    use tokio::sync::oneshot;
 
     async fn bad_search(
         Path(_id): Path<String>,
@@ -121,8 +135,13 @@ async fn search_lexical_empty_query_surfaces_as_invalid_params() {
         .route("/indexes/{id}/status", get(status_ok));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, app).await;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                shutdown_rx.await.ok();
+            })
+            .await;
     });
 
     let server = McpServer::new(format!("http://{addr}"));
@@ -149,4 +168,170 @@ async fn search_lexical_empty_query_surfaces_as_invalid_params() {
         .await;
     let result = resp.result.expect("result envelope");
     assert_eq!(result["isError"], true);
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+}
+
+/// Why: `search_semantic` goes through the same `run_lane_search` / `post()`
+/// pipeline as `search_lexical`; the 400→InvalidParams mapping must fire even
+/// after the pre-flight stage check passes. This guards regressions where a
+/// future refactor adds an early-exit path that skips the empty-query guard.
+/// What: mock daemon reports `vector` capability ready (so the pre-flight
+/// passes) but returns 400 on the actual search POST. Asserts both the
+/// bare-method and `tools/call` forms surface InvalidParams / isError=true.
+/// Graceful shutdown via oneshot channel.
+/// Test: this test.
+#[tokio::test]
+async fn search_semantic_empty_query_surfaces_as_invalid_params() {
+    use axum::routing::{get, post};
+    use axum::{extract::Path, Json, Router};
+    use tokio::sync::oneshot;
+
+    async fn bad_search(
+        Path(_id): Path<String>,
+        Json(_body): Json<Value>,
+    ) -> (axum::http::StatusCode, Json<Value>) {
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "query must not be empty" })),
+        )
+    }
+    async fn status_vector_ready(Path(id): Path<String>) -> Json<Value> {
+        Json(serde_json::json!({
+            "index_id": id,
+            "search_capabilities": ["bm25", "literal", "vector"],
+            "stages": {
+                "lexical":  { "status": "ready" },
+                "semantic": { "status": "ready" },
+                "graph":    { "status": "pending" },
+            }
+        }))
+    }
+
+    let app = Router::new()
+        .route("/indexes/{id}/search", post(bad_search))
+        .route("/indexes/{id}/status", get(status_vector_ready));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                shutdown_rx.await.ok();
+            })
+            .await;
+    });
+
+    let server = McpServer::new(format!("http://{addr}"));
+
+    // Bare-method form — the pre-flight passes (vector ready) but the POST
+    // returns 400; the MCP layer must map it to INVALID_PARAMS.
+    let resp = server
+        .dispatch(req(
+            "search_semantic",
+            serde_json::json!({ "index_id": "demo", "query": "" }),
+        ))
+        .await;
+    let err = resp.error.expect("expected JSON-RPC error");
+    assert_eq!(
+        err.code,
+        error_codes::INVALID_PARAMS,
+        "search_semantic empty query must map to INVALID_PARAMS, got code={}",
+        err.code
+    );
+
+    // tools/call form — must return isError=true.
+    let resp = server
+        .dispatch(req(
+            "tools/call",
+            serde_json::json!({
+                "name": "search_semantic",
+                "arguments": { "index_id": "demo", "query": "   " }
+            }),
+        ))
+        .await;
+    let result = resp.result.expect("tools/call must return result envelope");
+    assert_eq!(
+        result["isError"], true,
+        "search_semantic whitespace-only query must return isError=true"
+    );
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+}
+
+/// Why: `search_all` with an `index_id` routes through `run_lane_search` with
+/// no stage pre-check (the All lane has no required capability). The
+/// 400→InvalidParams mapping must still fire when the daemon rejects an empty
+/// query, verifying the guard lives in the shared `post()` helper and not just
+/// in the pre-flight branch.
+/// What: mock daemon returns 400 for any search POST. Asserts both the
+/// bare-method and `tools/call` forms surface InvalidParams / isError=true.
+/// Graceful shutdown via oneshot channel.
+/// Test: this test.
+#[tokio::test]
+async fn search_all_empty_query_surfaces_as_invalid_params() {
+    use axum::routing::post;
+    use axum::{extract::Path, Json, Router};
+    use tokio::sync::oneshot;
+
+    async fn bad_search(
+        Path(_id): Path<String>,
+        Json(_body): Json<Value>,
+    ) -> (axum::http::StatusCode, Json<Value>) {
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "query must not be empty" })),
+        )
+    }
+
+    // search_all with index_id routes to /indexes/{id}/search (no status probe).
+    let app = Router::new().route("/indexes/{id}/search", post(bad_search));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                shutdown_rx.await.ok();
+            })
+            .await;
+    });
+
+    let server = McpServer::new(format!("http://{addr}"));
+
+    // Bare-method form.
+    let resp = server
+        .dispatch(req(
+            "search_all",
+            serde_json::json!({ "index_id": "demo", "query": "" }),
+        ))
+        .await;
+    let err = resp.error.expect("expected JSON-RPC error");
+    assert_eq!(
+        err.code,
+        error_codes::INVALID_PARAMS,
+        "search_all empty query must map to INVALID_PARAMS, got code={}",
+        err.code
+    );
+
+    // tools/call form.
+    let resp = server
+        .dispatch(req(
+            "tools/call",
+            serde_json::json!({
+                "name": "search_all",
+                "arguments": { "index_id": "demo", "query": "   " }
+            }),
+        ))
+        .await;
+    let result = resp.result.expect("tools/call must return result envelope");
+    assert_eq!(
+        result["isError"], true,
+        "search_all whitespace-only query must return isError=true"
+    );
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
 }

--- a/crates/trusty-search/src/mcp/tools/tests_empty_query.rs
+++ b/crates/trusty-search/src/mcp/tools/tests_empty_query.rs
@@ -1,0 +1,152 @@
+//! Issue #882 — MCP tool tests for empty / whitespace-only query rejection.
+//!
+//! Why: the daemon returns HTTP 400 for empty queries; we must verify that the
+//! MCP layer maps that 400 to a clean InvalidParams error (bare-method) or
+//! `isError: true` (tools/call) rather than an opaque Transport failure.
+//! What: spins up a tiny mock daemon per test and drives the McpServer dispatcher.
+//! Test: this file.
+
+use serde_json::Value;
+
+use super::{error_codes, McpServer, Request};
+
+fn req(method: &str, params: Value) -> Request {
+    Request {
+        jsonrpc: Some("2.0".into()),
+        id: Some(Value::from(1u64)),
+        method: method.into(),
+        params: Some(params),
+    }
+}
+
+/// Why: when the daemon returns HTTP 400 for an empty query, the MCP `search`
+/// tool must surface it as a clean InvalidParams / tool error rather than an
+/// opaque transport failure, so the LLM can react with a helpful message.
+/// What: spins up a mock daemon that returns 400 for any search request, then
+/// asserts the bare-method form returns INVALID_PARAMS and the `tools/call`
+/// form returns `isError: true`.
+/// Test: this test.
+#[tokio::test]
+async fn search_tool_empty_query_surfaces_as_invalid_params() {
+    use axum::routing::post;
+    use axum::{Json, Router};
+
+    async fn bad_search(Json(_body): Json<Value>) -> (axum::http::StatusCode, Json<Value>) {
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "query must not be empty" })),
+        )
+    }
+
+    let app = Router::new().route("/indexes/demo/search", post(bad_search));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let server = McpServer::new(format!("http://{addr}"));
+
+    // Bare-method form: expect INVALID_PARAMS JSON-RPC error.
+    let resp = server
+        .dispatch(req(
+            "search",
+            serde_json::json!({ "index_id": "demo", "query": "" }),
+        ))
+        .await;
+    let err = resp.error.expect("expected JSON-RPC error for empty query");
+    assert_eq!(
+        err.code,
+        error_codes::INVALID_PARAMS,
+        "empty query must map to INVALID_PARAMS, got code={}",
+        err.code
+    );
+    assert!(
+        err.message.contains("empty"),
+        "error message must mention 'empty': {}",
+        err.message
+    );
+
+    // tools/call form: expect isError=true in the result envelope.
+    let resp = server
+        .dispatch(req(
+            "tools/call",
+            serde_json::json!({
+                "name": "search",
+                "arguments": { "index_id": "demo", "query": "   " }
+            }),
+        ))
+        .await;
+    let result = resp.result.expect("tools/call must return result envelope");
+    assert_eq!(
+        result["isError"], true,
+        "whitespace-only query must return isError=true"
+    );
+}
+
+/// Why: per-lane tools (`search_lexical`, `search_semantic`, `search_kg`,
+/// `search_all`) share the same POST path — confirm they too return a clean
+/// InvalidParams / tool error when the daemon rejects an empty query.
+/// What: mock daemon returns 400 for any search; asserts `search_lexical`
+/// returns INVALID_PARAMS (bare-method) and isError=true (tools/call).
+/// Test: this test.
+#[tokio::test]
+async fn search_lexical_empty_query_surfaces_as_invalid_params() {
+    use axum::routing::{get, post};
+    use axum::{extract::Path, Json, Router};
+
+    async fn bad_search(
+        Path(_id): Path<String>,
+        Json(_body): Json<Value>,
+    ) -> (axum::http::StatusCode, Json<Value>) {
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "query must not be empty" })),
+        )
+    }
+    async fn status_ok(Path(id): Path<String>) -> Json<Value> {
+        Json(serde_json::json!({
+            "index_id": id,
+            "search_capabilities": ["bm25", "literal"],
+            "stages": {
+                "lexical": { "status": "ready" },
+                "semantic": { "status": "pending" },
+                "graph":   { "status": "pending" },
+            }
+        }))
+    }
+
+    let app = Router::new()
+        .route("/indexes/{id}/search", post(bad_search))
+        .route("/indexes/{id}/status", get(status_ok));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let server = McpServer::new(format!("http://{addr}"));
+
+    // Bare method — expect INVALID_PARAMS.
+    let resp = server
+        .dispatch(req(
+            "search_lexical",
+            serde_json::json!({ "index_id": "demo", "query": "" }),
+        ))
+        .await;
+    let err = resp.error.expect("expected JSON-RPC error");
+    assert_eq!(err.code, error_codes::INVALID_PARAMS);
+
+    // tools/call — expect isError=true.
+    let resp = server
+        .dispatch(req(
+            "tools/call",
+            serde_json::json!({
+                "name": "search_lexical",
+                "arguments": { "index_id": "demo", "query": "   " }
+            }),
+        ))
+        .await;
+    let result = resp.result.expect("result envelope");
+    assert_eq!(result["isError"], true);
+}

--- a/crates/trusty-search/src/service/server/files.rs
+++ b/crates/trusty-search/src/service/server/files.rs
@@ -193,6 +193,14 @@ pub(super) async fn grep_handler(
     Path(id): Path<String>,
     Json(req): Json<crate::service::grep::GrepRequest>,
 ) -> Result<Json<crate::service::grep::GrepResponse>, (StatusCode, Json<serde_json::Value>)> {
+    // Issue #882: empty / whitespace-only patterns match every line in every
+    // file, producing a meaningless dump of the entire corpus.
+    if req.pattern.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "pattern must not be empty" })),
+        ));
+    }
     let compiled = crate::service::grep::CompiledGrep::compile(&req).map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -238,6 +246,13 @@ pub(super) async fn global_grep_handler(
     State(state): State<Arc<SearchAppState>>,
     Json(req): Json<crate::service::grep::GrepRequest>,
 ) -> Result<Json<crate::service::grep::GrepResponse>, (StatusCode, Json<serde_json::Value>)> {
+    // Issue #882: same guard as grep_handler — an empty pattern matches every line.
+    if req.pattern.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "pattern must not be empty" })),
+        ));
+    }
     let compiled = crate::service::grep::CompiledGrep::compile(&req).map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -51,9 +51,23 @@ pub(super) async fn search_handler(
     State(state): State<Arc<SearchAppState>>,
     Path(id): Path<String>,
     Json(mut query): Json<SearchQuery>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    // Issue #882: reject empty / whitespace-only queries before touching the
+    // index. An empty query falls through to a pure k-NN vector search that
+    // returns arbitrary top-k results — not useful and potentially expensive.
+    if query.text.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "query must not be empty" })),
+        ));
+    }
     let index_id = IndexId::new(id);
-    let handle = state.registry.get(&index_id).ok_or(StatusCode::NOT_FOUND)?;
+    let handle = state.registry.get(&index_id).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": format!("unknown index: {}", index_id.0) })),
+        )
+    })?;
     // Use the same domain-aware classifier as `CodeIndexer::search` so the
     // intent reported back to the caller matches what was used for routing.
     let intent = QueryClassifier::classify_with_domain(&query.text, &handle.domain_terms);
@@ -80,10 +94,12 @@ pub(super) async fn search_handler(
     handle.search_pressure.notify_one();
     let started = std::time::Instant::now();
     let indexer = handle.indexer.read().await;
-    let mut results = indexer
-        .search(&query)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut results = indexer.search(&query).await.map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "internal search error" })),
+        )
+    })?;
     // Issue #64: defense-in-depth post-filter. Chunks are stored with `file`
     // paths relative to the index root, so anything that escapes the root
     // (absolute path pointing elsewhere, `..` traversal, or simply a path
@@ -233,7 +249,15 @@ fn default_global_top_k() -> usize {
 pub(super) async fn global_search_handler(
     State(state): State<Arc<SearchAppState>>,
     Json(req): Json<GlobalSearchRequest>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    // Issue #882: reject empty / whitespace-only queries before fan-out.
+    if req.query.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "query must not be empty" })),
+        ));
+    }
+
     use crate::core::search::rrf::{rrf_fuse, RRF_K};
 
     let all_ids = state.registry.list();

--- a/crates/trusty-search/src/service/server/tests_search.rs
+++ b/crates/trusty-search/src/service/server/tests_search.rs
@@ -1,7 +1,73 @@
 //! Tests for `file_is_within_root` and the search handler.
 use super::helpers::file_is_within_root;
 use super::*;
-use axum::Json;
+use axum::{http::StatusCode, Json};
+
+// ── Issue #882: empty / whitespace-only query validation ──────────────────────
+
+/// Why: an empty query must be rejected before touching the index so callers
+/// get an actionable error instead of arbitrary top-k results from a pure
+/// k-NN fallback.
+/// What: builds a minimal bare index and asserts search_handler returns HTTP
+/// 400 with `{"error": "query must not be empty"}` for both `""` and `"   "`.
+/// Test: this test.
+#[tokio::test]
+async fn search_handler_rejects_empty_query() {
+    use crate::core::embed::{Embedder, MockEmbedder};
+    use crate::core::indexer::{CodeIndexer, SearchQuery, SearchStage};
+    use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+    use crate::core::store::{UsearchStore, VectorStore};
+    use tempfile::tempdir;
+
+    let tmp = tempdir().unwrap();
+    let dim = 16;
+    let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(dim));
+    let store: Arc<dyn VectorStore> = Arc::new(UsearchStore::new(dim).expect("usearch"));
+    let indexer = CodeIndexer::new("empty-q-test", tmp.path())
+        .with_components(Arc::clone(&embedder), Arc::clone(&store));
+    let registry = IndexRegistry::new();
+    let handle = IndexHandle::bare(
+        IndexId::new("empty-q-idx"),
+        Arc::new(tokio::sync::RwLock::new(indexer)),
+        tmp.path().to_path_buf(),
+    );
+    registry.register(handle);
+    let state = Arc::new(SearchAppState::new(registry));
+    state.install_embedder(embedder).await;
+
+    for text in ["", "   ", "\t\n"] {
+        let resp = search_handler(
+            axum::extract::State(Arc::clone(&state)),
+            axum::extract::Path("empty-q-idx".to_string()),
+            axum::extract::Json(SearchQuery {
+                text: text.to_string(),
+                top_k: 5,
+                expand_graph: false,
+                compact: false,
+                branch_files: None,
+                branch_boost: 1.5,
+                branch: None,
+                stage: Some(SearchStage::Lexical),
+                mode: crate::core::indexer::SearchMode::Code,
+                exclude_archived: false,
+                refine_query: None,
+            }),
+        )
+        .await;
+
+        let (status, Json(body)) = resp.expect_err("empty query must return Err");
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "expected 400 for query={text:?}, got {status}"
+        );
+        assert_eq!(
+            body.get("error").and_then(|v| v.as_str()),
+            Some("query must not be empty"),
+            "wrong error body for query={text:?}: {body:?}"
+        );
+    }
+}
 #[test]
 fn file_is_within_root_relative_ok() {
     let root = std::path::Path::new("/Users/me/proj");

--- a/crates/trusty-search/src/service/server/tests_search.rs
+++ b/crates/trusty-search/src/service/server/tests_search.rs
@@ -68,6 +68,7 @@ async fn search_handler_rejects_empty_query() {
         );
     }
 }
+
 #[test]
 fn file_is_within_root_relative_ok() {
     let root = std::path::Path::new("/Users/me/proj");


### PR DESCRIPTION
## Summary

- HTTP handlers for all search lanes (hybrid, lexical, semantic, grep) now return `400 {"error":"query must not be empty"}` when the trimmed query text (or grep `pattern`) is empty or whitespace-only.
- The MCP `post()` helper maps HTTP 400 → `DispatchError::InvalidParams` so LLM agents receive an actionable INVALID_PARAMS error instead of an opaque transport failure.
- Tests added: HTTP handler unit test (`tests_search.rs`) iterates `["", "   ", "\t\n"]` and asserts 400; MCP tests (`mcp/tools/tests_empty_query.rs`) use a mock daemon to verify INVALID_PARAMS is surfaced.

## Root-cause investigation (Part 1 of #882)

**No internal caller legitimately issues empty queries.** Findings by entry point:

| Entry point | Location | Empty-query behaviour before fix |
|---|---|---|
| Svelte admin UI | `ui/src/lib/views/Search.svelte:44` | `if (!query.trim()) return;` — client-side guard, **never reaches server** |
| UI submit button | `ui/src/lib/views/Search.svelte:226` | `disabled={loading \|\| !query.trim()}` — additional guard |
| CLI `query` subcommand | `src/commands/query.rs:37-55` | No empty guard — `trusty-search query ""` would reach the server |
| HTTP `POST /indexes/:id/search` | `src/service/server/search.rs` | **No guard** — fell through to `Unknown` intent → pure k-NN returning arbitrary top-k |
| HTTP global search | `src/service/server/search.rs` | **No guard** — same |
| HTTP `POST /indexes/:id/files/grep` | `src/service/server/files.rs` | **No guard** — empty regex matches every line in the corpus |
| MCP `search` / `search_lexical` tools | `src/mcp/tools.rs` → HTTP | Passed empty string straight to HTTP; server returned 200 + spurious results |

**Most likely real-world source:** LLM-generated MCP tool calls with an empty `query` argument (e.g., an agent invokes `search` before it has formulated a query) and direct API calls from scripts or integration tests that do not validate inputs client-side. The CLI path (`trusty-search query ""`) is also a plausible manual accident. The Svelte UI is the only path that was already guarded.

**Previous behaviour:** empty query → `QueryClassifier` returns `Unknown` intent → pure k-NN vector fallback using a zero-norm embedding (all zeros) → returned arbitrary high-similarity chunks based on model biases — expensive, semantically meaningless, and confusing to callers.

## Changed files

- `crates/trusty-search/src/service/server/search.rs` — empty query guards + unified error response type for `search_handler` and `global_search_handler`
- `crates/trusty-search/src/service/server/files.rs` — empty pattern guards for `grep_handler` and `global_grep_handler`
- `crates/trusty-search/src/mcp/tools.rs` — `post()` helper maps HTTP 400 → `DispatchError::InvalidParams`
- `crates/trusty-search/src/service/server/tests_search.rs` — HTTP handler unit test
- `crates/trusty-search/src/mcp/tools/tests_empty_query.rs` (new) — MCP invalid-params tests
- `.line-cap-allowlist.tsv` — allowlist budget updated for 10-line net addition to `tools.rs`

## Test plan

- [x] `cargo test -p trusty-search --lib` — 780 passed, 0 failed, 1 ignored
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] End-to-end with isolated daemon (port 57344, temp data dir):
  - `POST /indexes/e2e-test-882/search {"text":""}` → `{"error":"query must not be empty"}` HTTP 400
  - `POST /indexes/e2e-test-882/search {"text":"   "}` → `{"error":"query must not be empty"}` HTTP 400
  - `POST /indexes/e2e-test-882/search {"text":"hello"}` → HTTP 200 with results

🤖 Generated with [Claude Code](https://claude.com/claude-code)