### PR TITLE
docs: adopt shared install-convention README sections for tga, trusty-mpm, trusty-code

### DIFF
--- a/crates/trusty-code/README.md
+++ b/crates/trusty-code/README.md
@@ -16,6 +16,78 @@ What: Per-project coding orchestration harness. One `tcode serve` process per
 `.claude/` project root. Accepts task requests from CLI clients, TUI frontends,
 and MCP callers. Full extraction from `open-mpm` is tracked in epic #587.
 
+## Installation
+
+### From GitHub Releases (recommended for binary users)
+
+Prebuilt binaries are available for macOS (Apple Silicon) and Linux (x86_64).
+
+1. Download the latest release from [GitHub Releases](https://github.com/bobmatnyc/trusty-tools/releases):
+   - Look for assets tagged `trusty-code-v0.0.0`
+   - Download the archive for your platform:
+     - **macOS arm64 (Apple Silicon)**: `trusty-code-v0.0.0-aarch64-apple-darwin.tar.gz`
+     - **Linux x86_64**: `trusty-code-v0.0.0-x86_64-unknown-linux-gnu.tar.gz`
+
+2. Extract and install:
+   ```bash
+   tar xzf trusty-code-v0.0.0-*.tar.gz
+   chmod +x tcode
+   sudo mv tcode /usr/local/bin/    # or ~/.local/bin/ if you prefer user install
+   ```
+
+3. Verify the installation:
+   ```bash
+   tcode --version
+   ```
+
+### From Source with Cargo
+
+Requires Rust 1.91 or later ([install Rust](https://rustup.rs/)).
+
+```bash
+cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-code --locked
+```
+
+This builds from the latest commit on `main` and installs the binary to `~/.cargo/bin/`. Make sure `~/.cargo/bin/` is on your PATH.
+
+To install a specific version:
+```bash
+cargo install --git https://github.com/bobmatnyc/trusty-tools --tag trusty-code-v0.0.0 trusty-code --locked
+```
+
+### With Homebrew (planned — not yet available)
+
+```bash
+brew tap bobmatnyc/trusty
+brew install trusty-code
+```
+
+This installation method is under development. For now, use GitHub Releases or `cargo install`.
+
+Once available, this will provide:
+- Automatic updates via `brew upgrade trusty-code`
+- Standard macOS / Linux PATH integration
+- Optional dependency resolution (e.g., system libraries for ONNX Runtime)
+
+### Prerequisites & Special Cases
+
+#### Prerequisites
+
+- **Claude Code** (optional but recommended): this is a per-project orchestration harness that integrates with Claude Code's internal agent APIs. Standalone usage is not yet documented.
+- **Git**: standard; the tool reads git metadata for branch context.
+
+Configuration and usage details are documented in the `trusty-code` crate README.
+
+### Verify Installation
+
+All installations can be verified by running:
+
+```bash
+tcode --version
+```
+
+Expected output: the semantic version of the installed binary (e.g., `tcode 0.0.0`).
+
 ## Status
 
 **Phase 0 scaffold.** The `tcode` binary parses its CLI surface but every

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -19,28 +19,82 @@ This README and the rustdoc stay in-crate; everything else lives under `docs/`.
 
 ## Installation
 
-### From crates.io (recommended)
+### From GitHub Releases (recommended for binary users)
+
+Prebuilt binaries are available for macOS (Apple Silicon) and Linux (x86_64).
+
+1. Download the latest release from [GitHub Releases](https://github.com/bobmatnyc/trusty-tools/releases):
+   - Look for assets tagged `tga-v2.7.0`
+   - Download the archive for your platform:
+     - **macOS arm64 (Apple Silicon)**: `tga-v2.7.0-aarch64-apple-darwin.tar.gz`
+     - **Linux x86_64**: `tga-v2.7.0-x86_64-unknown-linux-gnu.tar.gz`
+
+2. Extract and install:
+   ```bash
+   tar xzf tga-v2.7.0-*.tar.gz
+   chmod +x tga
+   sudo mv tga /usr/local/bin/    # or ~/.local/bin/ if you prefer user install
+   ```
+
+3. Verify the installation:
+   ```bash
+   tga --version
+   ```
+
+### From Source with Cargo
+
+Requires Rust 1.91 or later ([install Rust](https://rustup.rs/)).
 
 ```bash
-cargo install tga
+cargo install --git https://github.com/bobmatnyc/trusty-tools tga --locked
 ```
 
-This installs the `tga` binary to `~/.cargo/bin/`. Ensure `~/.cargo/bin` is in your `PATH`.
+This builds from the latest commit on `main` and installs the binary to `~/.cargo/bin/`. Make sure `~/.cargo/bin/` is on your PATH.
 
-### From source
+To install a specific version:
+```bash
+cargo install --git https://github.com/bobmatnyc/trusty-tools --tag tga-v2.7.0 tga --locked
+```
+
+### With Homebrew (planned — not yet available)
 
 ```bash
-git clone https://github.com/bobmatnyc/trusty-tools
-cd trusty-tools/crates/trusty-git-analytics
-cargo install --path .
+brew tap bobmatnyc/trusty
+brew install tga
 ```
 
-### Verify installation
+This installation method is under development. For now, use GitHub Releases or `cargo install`.
+
+Once available, this will provide:
+- Automatic updates via `brew upgrade tga`
+- Standard macOS / Linux PATH integration
+- Optional dependency resolution (e.g., system libraries for ONNX Runtime)
+
+### Prerequisites & Special Cases
+
+#### System Requirements
+
+- **Git**: standard; the tool reads git history via git2.
+- **OS**: macOS or Linux (Windows support via WSL2; not officially tested).
+- **Database**: SQLite (bundled; no external SQLite install required).
+
+#### Configuration
+
+The CLI reads from `tga.yaml` or `~/.config/tga/config.yaml`. See the crate README and the configuration specification for details on setting up repository paths, identity resolvers, and report outputs.
+
+```bash
+tga analyze --config /path/to/tga.yaml
+```
+
+### Verify Installation
+
+All installations can be verified by running:
 
 ```bash
 tga --version
-tga --help
 ```
+
+Expected output: the semantic version of the installed binary (e.g., `tga 2.7.0`).
 
 ## Quick Start
 

--- a/crates/trusty-mpm/README.md
+++ b/crates/trusty-mpm/README.md
@@ -13,16 +13,89 @@ What: Unified crate combining the formerly separate `trusty-mpm-{core,client,mcp
 
 ## Installation
 
+### From GitHub Releases (recommended for binary users)
+
+Prebuilt binaries are available for macOS (Apple Silicon) and Linux (x86_64).
+
+1. Download the latest release from [GitHub Releases](https://github.com/bobmatnyc/trusty-tools/releases):
+   - Look for assets tagged `trusty-mpm-v0.6.2`
+   - Download the archive for your platform:
+     - **macOS arm64 (Apple Silicon)**: `trusty-mpm-v0.6.2-aarch64-apple-darwin.tar.gz`
+     - **Linux x86_64**: `trusty-mpm-v0.6.2-x86_64-unknown-linux-gnu.tar.gz`
+
+2. Extract and install:
+   ```bash
+   tar xzf trusty-mpm-v0.6.2-*.tar.gz
+   chmod +x tm trusty-mpm
+   sudo mv tm trusty-mpm /usr/local/bin/    # or ~/.local/bin/ if you prefer user install
+   ```
+
+3. Verify the installation:
+   ```bash
+   tm --version
+   ```
+
+### From Source with Cargo
+
+Requires Rust 1.91 or later ([install Rust](https://rustup.rs/)).
+
 ```bash
-# Install the common toolset (CLI + daemon):
-cargo install trusty-mpm
-
-# Install with TUI and Telegram bot:
-cargo install trusty-mpm --features tui,telegram
-
-# Install just the library (no binaries):
-cargo add trusty-mpm --no-default-features
+cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-mpm --locked
 ```
+
+This builds from the latest commit on `main` and installs the binaries (`tm` and `trusty-mpm`) to `~/.cargo/bin/`. Make sure `~/.cargo/bin/` is on your PATH.
+
+To install a specific version:
+```bash
+cargo install --git https://github.com/bobmatnyc/trusty-tools --tag trusty-mpm-v0.6.2 trusty-mpm --locked
+```
+
+### With Homebrew (planned — not yet available)
+
+```bash
+brew tap bobmatnyc/trusty
+brew install trusty-mpm
+```
+
+This installation method is under development. For now, use GitHub Releases or `cargo install`.
+
+Once available, this will provide:
+- Automatic updates via `brew upgrade trusty-mpm`
+- Standard macOS / Linux PATH integration
+- Optional dependency resolution (e.g., system libraries for ONNX Runtime)
+
+### Prerequisites & Special Cases
+
+#### System Requirements
+
+- **Node.js** (optional): only needed if you plan to use the MPM JavaScript SDK or integrate with third-party JavaScript tooling. The daemon and CLI work independently of Node.
+- **OS**: macOS 12+ or Linux. Windows support is not yet available.
+
+#### Binaries Installed
+
+This crate installs two binaries with the same functionality:
+- `tm` — shorter alias for quick access
+- `trusty-mpm` — canonical name
+
+Both are identical; choose whichever you prefer. The CLI (`tm` / `trusty-mpm`) discovers the running daemon automatically via the standard socket or HTTP port and requires no configuration beyond a running daemon.
+
+#### Configuration
+
+The daemon reads from `~/.config/trusty-mpm/config.yaml` by default. See the `trusty-mpm` crate README for configuration examples and the full option reference.
+
+```bash
+tm daemon --config /path/to/config.yaml
+```
+
+### Verify Installation
+
+All installations can be verified by running:
+
+```bash
+tm --version
+```
+
+Expected output: the semantic version of the installed binary (e.g., `tm 0.6.2`).
 
 ## Feature Flags
 


### PR DESCRIPTION
## Summary

Apply the canonical installation-convention template from `docs/distribution/INSTALL-CONVENTION.md` to standardize install UX across three distributable crates:

- **trusty-git-analytics (tga)**: v2.7.0 — binary: `tga`
- **trusty-mpm**: v0.6.2 — binaries: `tm` and `trusty-mpm`
- **trusty-code**: v0.0.0 — binary: `tcode`

## Changes

Each README now presents installation in this order:

1. **From GitHub Releases** (macOS arm64 + Linux x86_64 prebuilt binaries)
2. **From Source with Cargo** (with `--locked` flag)
3. **With Homebrew** (marked as planned, not yet available)
4. **Prerequisites & Special Cases** (system requirements, optional configs, per-crate notes)
5. **Verify Installation** (`--version` command)

All placeholders filled with actual crate names, versions, and binary names from each crate's `Cargo.toml`.

## Test Plan

- [x] Read the authoritative template at `docs/distribution/INSTALL-CONVENTION.md` (commit 1aa07f7)
- [x] Identified correct crate names, versions, and binary names from each `Cargo.toml`
- [x] Applied template verbatim to trusty-git-analytics README
- [x] Applied template verbatim to trusty-mpm README (with multi-binary note)
- [x] Added Installation section to trusty-code README (was missing)
- [x] Verified all placeholders replaced correctly
- [x] Verified only three README files modified (no Cargo.toml or other files touched)
- [x] Committed with `closes #894` reference
- [x] Pre-commit hooks passed

🤖 Generated with Claude Code