### PR TITLE
release: trusty-analyze 0.5.1 + trusty-review 0.3.6 (binary distribution + MIT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10701,7 +10701,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.3.5" }
+trusty-review = { path = "crates/trusty-review", version = "0.3.6" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -7,6 +7,41 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.5.1] — 2026-06-07
+
+### Added
+
+- **Prebuilt binary distribution via GitHub Releases** — the `trusty-analyze`
+  binary is now published to GitHub Releases on every tagged version for
+  `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, and
+  `x86_64-unknown-linux-gnu` (Amazon Linux 2023 `load-dynamic` variant).
+  Install without Rust toolchain:
+  ```
+  curl -L https://github.com/bobmatnyc/trusty-tools/releases/download/trusty-analyze-v0.5.1/trusty-analyze-aarch64-apple-darwin.tar.gz | tar xz
+  ```
+  or via `cargo install --git`:
+  ```
+  cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-analyze --locked
+  ```
+- **Cargo.toml packaging metadata** — added `exclude`, `keywords`, `categories`,
+  and `[package.metadata.docs.rs]` so docs.rs renders the full API surface
+  (including the `http-server` feature) and the crates.io page is correctly
+  categorised.
+- **Expanded `lib.rs` module-level docs** — top-level rustdoc now covers the
+  analysis pipeline, transport options (HTTP API + MCP stdio/SSE), feature
+  flags (`http-server`, `bundled-ort`, `load-dynamic`, `cuda`, `ner`, `review`),
+  and quickstart examples.
+- **CHANGELOG backfill** — all patch releases since 0.1.0 documented with
+  accurate dates and descriptions.
+
+### Changed
+
+- **Workspace MIT relicense** — the workspace `license` field was changed from
+  `Elastic-2.0` to `MIT`; `trusty-analyze` inherits `license.workspace = true`
+  and is now MIT-licensed.
+
+---
+
 ## [0.5.0] — 2026-06-03
 
 ### Added
@@ -219,7 +254,8 @@ GET  /indexes/:id/clusters?k=N&method=bow|neural
 
 ---
 
-[Unreleased]: https://github.com/bobmatnyc/trusty-tools/compare/trusty-analyze-v0.5.0...HEAD
+[Unreleased]: https://github.com/bobmatnyc/trusty-tools/compare/trusty-analyze-v0.5.1...HEAD
+[0.5.1]: https://github.com/bobmatnyc/trusty-tools/releases/tag/trusty-analyze-v0.5.1
 [0.5.0]: https://github.com/bobmatnyc/trusty-tools/releases/tag/trusty-analyze-v0.5.0
 [0.4.2]: https://github.com/bobmatnyc/trusty-tools/releases/tag/trusty-analyze-v0.4.2
 [0.4.1]: https://github.com/bobmatnyc/trusty-tools/releases/tag/trusty-analyze-v0.4.1

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.5.0"
+version     = "0.5.1"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.6] — 2026-06-07
+
+### Added
+
+- **Prebuilt binary distribution via GitHub Releases** — the `trusty-review`
+  binary is now published to GitHub Releases on every tagged version for
+  `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu`. Install without a
+  Rust toolchain:
+  ```
+  curl -L https://github.com/bobmatnyc/trusty-tools/releases/download/trusty-review-v0.3.6/trusty-review-aarch64-apple-darwin.tar.gz | tar xz
+  ```
+  or via `cargo install --git`:
+  ```
+  cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-review --locked
+  ```
+- **README install-convention docs** — README updated with a prebuilt-binary
+  install section and explicit `cargo install --git` instructions alongside the
+  existing `cargo install trusty-review` (crates.io) path.
+
+### Changed
+
+- **`profile` Cargo feature gate** — the contributor-profile pipeline
+  (`tga` + `rusqlite` heavy deps) is now gated behind the opt-in `profile`
+  feature (still on by default). Users who only need core review without
+  `git2`/`rusqlite` compilation overhead can build with:
+  ```
+  cargo install trusty-review --no-default-features --features http-server,mcp
+  ```
+- **Workspace MIT relicense** — the workspace `license` field was changed from
+  `Elastic-2.0` to `MIT`; `trusty-review` inherits `license.workspace = true`
+  and is now MIT-licensed.
+
+---
+
 ## [0.3.5] — 2026-06-03
 
 ### Changed

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.5"
+version     = "0.3.6"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Summary

- **trusty-analyze**: `0.5.0` → `0.5.1` — prebuilt binary distribution via GitHub Releases, `cargo install --git` docs, CHANGELOG backfill, packaging metadata, expanded lib.rs docs, MIT relicense reflection
- **trusty-review**: `0.3.5` → `0.3.6` — prebuilt binary distribution via GitHub Releases, install-convention README, `profile` feature gate documentation, MIT relicense reflection
- **Root `Cargo.toml`**: workspace dep pin `trusty-review` bumped `0.3.5` → `0.3.6` to keep path+version resolution consistent

## Verification

- `cargo check -p trusty-analyze -p trusty-review` — clean (`Finished dev profile`)
- `cargo metadata --no-deps` confirms `trusty-analyze = 0.5.1`, `trusty-review = 0.3.6`
- All pre-commit hooks passed (line-cap, secrets scan, TOML check)

## Test plan

- [ ] CI passes (note: trusty-memory HF 429 and transient "no space left" are known flakes — rerun up to 3× for those signatures)
- [ ] After merge: push tags `trusty-analyze-v0.5.1` and `trusty-review-v0.3.6` to trigger `release.yml` binary builds
- [ ] Confirm GitHub Releases created with expected `.tar.gz` + `.sha256` assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)