### PR TITLE
release: tga 2.7.1 (first public binary release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9754,7 +9754,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.2" }
 trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.0" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
-tga = { path = "crates/trusty-git-analytics", version = "2.7.0" }
+tga = { path = "crates/trusty-git-analytics", version = "2.7.1" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2026-06-07
+
+### Changed
+
+- **First public prebuilt-binary Release** — tga is now distributed via the
+  generic binary release workflow (`release.yml`), publishing
+  `tga-<version>-aarch64-apple-darwin.tar.gz` and
+  `tga-<version>-x86_64-unknown-linux-gnu.tar.gz` (with paired `.sha256`
+  checksums) to GitHub Releases on every `tga-v*` tag push.
+- **Install-convention README adoption** — the crate README follows the
+  workspace install-convention (`INSTALL-CONVENTION.md`) so curl-install
+  instructions and Homebrew tap stubs are consistent with trusty-analyze,
+  trusty-review, and trusty-search.
+- **Workspace MIT relicense** — `tga` is MIT licensed (consistent with the
+  workspace-level MIT default for distributable tooling crates).
+
 ## [2.6.1] - 2026-06-04
 
 ### Fixed

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.7.0"
+version = "2.7.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.91) per #254. Required for


### PR DESCRIPTION
## Summary

- Bump `tga` (trusty-git-analytics) version `2.7.0` → `2.7.1` in `crates/trusty-git-analytics/Cargo.toml` and the workspace dep pin in root `Cargo.toml`
- Add `[2.7.1]` CHANGELOG entry noting first public prebuilt-binary Release, install-convention README adoption, and workspace MIT relicense
- Triggers the generic `release.yml` workflow on `tga-v2.7.1` tag push to publish `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu` binaries to GitHub Releases

## Dry-run validation

Workflow run [27105189956](https://github.com/bobmatnyc/trusty-tools/actions/runs/27105189956) confirmed:
- `Build trusty-git-analytics aarch64-apple-darwin` — SUCCESS (3m47s)
- `Build trusty-git-analytics x86_64-unknown-linux-gnu` — SUCCESS (4m53s)
- `Create / update GitHub Release` — SKIPPED (dry_run=true, as expected)

## Test plan

- [x] `cargo check -p tga` passes (Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.23s)
- [x] `cargo metadata` shows tga version `2.7.1`
- [x] All pre-commit hooks pass (trim whitespace, TOML check, 500-line cap, detect secrets)
- [ ] CI green on this PR
- [ ] After merge: push `tga-v2.7.1` tag, monitor release workflow, verify assets appear on GitHub Releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)