### PR TITLE
fix(memory): bound embedder init/embed/lock on remember+recall path; warm embedder at startup (closes #906)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -37,7 +37,7 @@ crates/trusty-common/src/lib.rs	1467
 crates/trusty-common/src/memory_core/analytics.rs	860
 crates/trusty-common/src/memory_core/dream.rs	1820
 crates/trusty-common/src/memory_core/git.rs	568
-crates/trusty-common/src/memory_core/retrieval/mod.rs	1483
+crates/trusty-common/src/memory_core/retrieval/mod.rs	1546
 crates/trusty-common/src/memory_core/retrieval/tests.rs	1140
 crates/trusty-common/src/memory_core/semantic_consolidation.rs	968
 crates/trusty-common/src/memory_core/store/chat_sessions.rs	930
@@ -103,12 +103,12 @@ crates/trusty-memory/src/commands/setup.rs	783
 crates/trusty-memory/src/discovery.rs	884
 crates/trusty-memory/src/kg_extract.rs	608
 crates/trusty-memory/src/lib.rs	2835
-crates/trusty-memory/src/main.rs	973
+crates/trusty-memory/src/main.rs	996
 crates/trusty-memory/src/messaging.rs	843
 crates/trusty-memory/src/project_root.rs	980
 crates/trusty-memory/src/prompt_log.rs	851
 crates/trusty-memory/src/service.rs	1704
-crates/trusty-memory/src/tools.rs	3628
+crates/trusty-memory/src/tools.rs	3657
 crates/trusty-memory/src/transport/rpc.rs	571
 crates/trusty-memory/src/web.rs	5396
 crates/trusty-memory/tests/concurrent_perf.rs	1163

--- a/crates/trusty-common/src/memory_core/mod.rs
+++ b/crates/trusty-common/src/memory_core/mod.rs
@@ -25,6 +25,7 @@ pub mod registry;
 pub mod retrieval;
 pub mod semantic_consolidation;
 pub mod store;
+pub mod timeouts;
 
 pub use community::{KnowledgeGap, find_communities};
 pub use palace::{Drawer, DrawerType, Palace, PalaceId, Room, RoomType, Wing};

--- a/crates/trusty-common/src/memory_core/retrieval/mod.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/mod.rs
@@ -305,6 +305,19 @@ impl PalaceHandle {
         self.kg.is_read_only() || self.vector_store.is_read_only()
     }
 
+    /// Return a clone of the write mutex for use in tests.
+    ///
+    /// Why: Tests that simulate a held write lock need access to the mutex so
+    /// they can acquire it in a background task before calling `remember`.
+    /// Exposing a test-only accessor rather than poking the field directly
+    /// keeps the field visibility flexible and makes intent explicit.
+    /// What: Returns `Arc::clone(&self.write_mutex)`.
+    /// Test: `write_lock_timeout_returns_error_when_held` in `timeout_tests`.
+    #[cfg(test)]
+    pub fn write_mutex_for_test(&self) -> Arc<tokio::sync::Mutex<()>> {
+        Arc::clone(&self.write_mutex)
+    }
+
     /// Construct a new `PalaceHandle` with empty drawer table and L1 cache.
     ///
     /// Why: The registry creates handles eagerly when a palace is opened; the
@@ -595,20 +608,12 @@ impl PalaceHandle {
         // so the write mutex doesn't impact read throughput.
         // Issue #906: bound the lock acquisition so a stuck embedder on one
         // writer doesn't cascade an indefinite queue of waiters.
-        let _write_guard = {
-            let lock_timeout = timeouts::write_lock_timeout();
-            tokio::time::timeout(lock_timeout, self.write_mutex.lock())
-                .await
-                .map_err(|_| {
-                    anyhow::anyhow!(
-                        "palace '{}' write-lock acquisition timed out after {:?} \
-                         (issue #906); a previous writer may be stuck — retry or \
-                         increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS",
-                        self.id,
-                        lock_timeout
-                    )
-                })?
-        };
+        let _write_guard = timeouts::lock_with_timeout(
+            &self.write_mutex,
+            timeouts::write_lock_timeout(),
+            self.id.as_str(),
+        )
+        .await?;
 
         // Issue #61: signal/noise gate. `force == true` bypasses entirely.
         // `enforce_min_tokens` lets `memory_note` keep the noise patterns
@@ -745,19 +750,12 @@ impl PalaceHandle {
         // can't interleave with an append. See `write_mutex` docs on
         // `PalaceHandle`.
         // Issue #906: bound the lock acquisition to avoid cascading hangs.
-        let _write_guard = {
-            let lock_timeout = timeouts::write_lock_timeout();
-            tokio::time::timeout(lock_timeout, self.write_mutex.lock())
-                .await
-                .map_err(|_| {
-                    anyhow::anyhow!(
-                        "palace '{}' write-lock acquisition timed out after {:?} on \
-                         forget path (issue #906); increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS",
-                        self.id,
-                        lock_timeout
-                    )
-                })?
-        };
+        let _write_guard = timeouts::lock_with_timeout(
+            &self.write_mutex,
+            timeouts::write_lock_timeout(),
+            self.id.as_str(),
+        )
+        .await?;
 
         // Best-effort vector removal — usearch may legitimately not have the
         // key (e.g. if remember failed mid-flight); we propagate other errors.

--- a/crates/trusty-common/src/memory_core/retrieval/mod.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/mod.rs
@@ -21,6 +21,7 @@ use crate::memory_core::store::kg::KnowledgeGraph;
 use crate::memory_core::store::l1_cache::L1Cache;
 use crate::memory_core::store::palace_store::PalaceStore;
 use crate::memory_core::store::vector::{UsearchStore, VectorStore};
+use crate::memory_core::timeouts;
 use anyhow::{Context, Result};
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -49,16 +50,33 @@ static SHARED_EMBEDDER: OnceCell<Arc<dyn Embedder + Send + Sync>> = OnceCell::co
 ///
 /// Why: Centralising fallback embedder construction guarantees at most one
 /// ONNX session per process — critical for the daemon footprint (issue #57).
+/// Issue #906: `FastEmbedder::new()` can take 30-120 s on a CoreML cold-compile
+/// or a CUDA warm-up — without a timeout the first `memory_remember` or
+/// `memory_recall` call blocks indefinitely. Wrapping in
+/// `tokio::time::timeout` turns the hang into an explicit error that the
+/// caller (and the daemon) can surface to the user.
 /// What: Returns a clone of the shared `Arc<dyn Embedder + Send + Sync>`,
-/// initialising it on first call via `FastEmbedder::new()`. In test builds,
-/// callers should first call `seed_shared_embedder_with_mock()` so the cell
-/// is pre-populated with `MockEmbedder` and no model download is attempted.
-/// Test: `shared_embedder_is_singleton`.
+/// initialising it on first call via `FastEmbedder::new()`. The init is
+/// bounded by `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (default 180 s). In test
+/// builds, callers should first call `seed_shared_embedder_with_mock()` so
+/// the cell is pre-populated with `MockEmbedder` and no model download is
+/// attempted.
+/// Test: `shared_embedder_is_singleton`; timeout path covered by
+///       `timeout_wrapper_fires_on_embedder_init` in retrieval::tests.
 pub async fn shared_embedder() -> Result<Arc<dyn Embedder + Send + Sync>> {
+    let timeout = timeouts::embedder_init_timeout();
     SHARED_EMBEDDER
         .get_or_try_init(|| async {
-            let e = FastEmbedder::new()
+            let e = tokio::time::timeout(timeout, FastEmbedder::new())
                 .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "FastEmbedder cold init timed out after {:?} (issue #906); \
+                         increase TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS if the model \
+                         needs more time on this host",
+                        timeout
+                    )
+                })?
                 .context("init shared FastEmbedder")?;
             Ok::<Arc<dyn Embedder + Send + Sync>, anyhow::Error>(Arc::new(e))
         })
@@ -575,7 +593,22 @@ impl PalaceHandle {
         // pipeline below. Other palaces' writes proceed in parallel.
         // Reads (`recall`, `list_drawers`, etc.) never acquire this lock,
         // so the write mutex doesn't impact read throughput.
-        let _write_guard = self.write_mutex.lock().await;
+        // Issue #906: bound the lock acquisition so a stuck embedder on one
+        // writer doesn't cascade an indefinite queue of waiters.
+        let _write_guard = {
+            let lock_timeout = timeouts::write_lock_timeout();
+            tokio::time::timeout(lock_timeout, self.write_mutex.lock())
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "palace '{}' write-lock acquisition timed out after {:?} \
+                         (issue #906); a previous writer may be stuck — retry or \
+                         increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS",
+                        self.id,
+                        lock_timeout
+                    )
+                })?
+        };
 
         // Issue #61: signal/noise gate. `force == true` bypasses entirely.
         // `enforce_min_tokens` lets `memory_note` keep the noise patterns
@@ -614,12 +647,24 @@ impl PalaceHandle {
         // spin up a fresh ONNX session per call (issue #57). The
         // OnceCell-backed `shared_embedder` guarantees at most one model load
         // for the lifetime of the process.
+        // Issue #906: both `shared_embedder()` (cold init path) and
+        // `embed_batch` carry their own bounded timeouts — if the embedder
+        // hangs mid-batch the remember call returns an error instead of
+        // blocking the write-lock indefinitely.
         let embedder = shared_embedder()
             .await
             .context("acquire shared embedder for remember")?;
-        let vecs = embedder
-            .embed_batch(&[content])
+        let embed_timeout = timeouts::embed_batch_timeout();
+        let vecs = tokio::time::timeout(embed_timeout, embedder.embed_batch(&[content]))
             .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "embed_batch timed out after {:?} on remember path (issue #906); \
+                     increase TRUSTY_EMBED_BATCH_TIMEOUT_SECS if batches legitimately \
+                     take longer on this host",
+                    embed_timeout
+                )
+            })?
             .context("embed drawer content")?;
         if let Some(v) = vecs.into_iter().next() {
             self.vector_store
@@ -699,7 +744,20 @@ impl PalaceHandle {
         // drawer-table state and so the vector / KG / in-memory removals
         // can't interleave with an append. See `write_mutex` docs on
         // `PalaceHandle`.
-        let _write_guard = self.write_mutex.lock().await;
+        // Issue #906: bound the lock acquisition to avoid cascading hangs.
+        let _write_guard = {
+            let lock_timeout = timeouts::write_lock_timeout();
+            tokio::time::timeout(lock_timeout, self.write_mutex.lock())
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "palace '{}' write-lock acquisition timed out after {:?} on \
+                         forget path (issue #906); increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS",
+                        self.id,
+                        lock_timeout
+                    )
+                })?
+        };
 
         // Best-effort vector removal — usearch may legitimately not have the
         // key (e.g. if remember failed mid-flight); we propagate other errors.
@@ -1481,3 +1539,8 @@ impl RetrievalLayers {
 
 #[cfg(test)]
 mod tests;
+
+// Issue #906: bounded-timeout behavioral tests (isolated test module so they
+// do not inflate the already-large tests.rs budget).
+#[cfg(test)]
+mod timeout_tests;

--- a/crates/trusty-common/src/memory_core/retrieval/timeout_tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/timeout_tests.rs
@@ -128,7 +128,7 @@ mod tests {
 
         // Hold the write lock in a background task indefinitely until we
         // signal it to release.
-        let mutex = handle.write_mutex.clone();
+        let mutex = handle.write_mutex_for_test();
         let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
         let holder = tokio::spawn(async move {
             let _guard = mutex.lock().await;

--- a/crates/trusty-common/src/memory_core/retrieval/timeout_tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/timeout_tests.rs
@@ -1,0 +1,169 @@
+//! Tests that the bounded-timeout wrappers on the memory hot path actually
+//! fire (issue #906).
+//!
+//! Why: issue #906 required that every memory operation return within a bounded
+//! time or an explicit error. Without a test that watches the timeout fire
+//! we cannot be confident the wrappers are on the right await points.
+//! What: Two flavours of test:
+//!   1. `timeout_fires_on_embedder_init_with_tiny_limit` — sets
+//!      `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS=0` (instant expiry) and
+//!      calls `shared_embedder()`, which *would* cold-init a real ONNX
+//!      session (potentially blocking for minutes on CoreML). Instead it
+//!      must return an explicit timeout error within milliseconds.
+//!   2. `remember_succeeds_with_mock_embedder` — seeds the shared cell with
+//!      `MockEmbedder` (no ONNX download) and performs a full `remember`
+//!      round-trip, asserting success with normal timeouts.
+//!
+//! WARNING: test (1) mutates a process-wide `OnceCell`. Because the cell can
+//! only be set once, the two tests must not run concurrently and the timeout
+//! test must run with an UNINITIALIZED cell. Rust's test harness does not
+//! guarantee test isolation between `#[tokio::test]` tests in the same binary,
+//! so each test is annotated `#[ignore]` and driven individually:
+//!
+//!   cargo test -p trusty-common --features memory-core \
+//!     retrieval::timeout_tests::timeout_fires_on_embedder_init_with_tiny_limit \
+//!     -- --include-ignored
+//!
+//! The `remember_succeeds_with_mock_embedder` test runs in the normal suite
+//! (not ignored) because it only requires the mock path.
+//!
+//! Test: This file IS the test — see module docs for run instructions.
+
+#[cfg(test)]
+mod tests {
+    use crate::memory_core::palace::{Palace, PalaceId};
+    use crate::memory_core::retrieval::{PalaceHandle, shared_embedder};
+    use tempfile::tempdir;
+
+    /// Why: Verify that `shared_embedder()` returns an explicit error (not a
+    /// hang) when the init ceiling is set to 0 seconds. This is the primary
+    /// regression guard for issue #906 on the embedder-init path.
+    /// What: Sets `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS=0` so the timeout fires
+    /// immediately, then calls `shared_embedder()` and asserts the result is
+    /// an `Err` containing the timeout message.
+    /// Test: itself. Marked `#[ignore]` because it mutates the process-wide
+    /// `SHARED_EMBEDDER` cell — run with `--include-ignored` in isolation.
+    #[tokio::test]
+    #[ignore = "mutates process-wide OnceCell; run in isolation with --include-ignored"]
+    async fn timeout_fires_on_embedder_init_with_tiny_limit() {
+        // Force a 0-second timeout so the init times out before it can succeed.
+        // SAFETY: single-threaded async test; env mutation safe here.
+        unsafe {
+            std::env::set_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS", "0");
+        }
+        let result = shared_embedder().await;
+        unsafe {
+            std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS");
+        }
+        assert!(
+            result.is_err(),
+            "shared_embedder() must return Err when init times out, got Ok"
+        );
+        let err = result.err().expect("checked above");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("timed out") || msg.contains("FastEmbedder"),
+            "error message must mention timeout: {msg}"
+        );
+    }
+
+    /// Why: Confirm the full remember path succeeds with normal timeouts and
+    /// a mock embedder (no ONNX download). This is the green-path regression
+    /// guard: adding timeout wrappers must not break ordinary operation.
+    /// What: Seeds `SHARED_EMBEDDER` with `MockEmbedder`, creates a
+    /// temporary palace, calls `handle.remember(...)`, and asserts success.
+    /// Test: itself.
+    #[tokio::test]
+    async fn remember_succeeds_with_mock_embedder() {
+        // Seed the shared cell with the mock so no ONNX download is attempted.
+        crate::memory_core::retrieval::seed_shared_embedder_with_mock();
+
+        let dir = tempdir().unwrap();
+        let palace = Palace {
+            id: PalaceId::new("timeout-green"),
+            name: "Timeout green".into(),
+            description: None,
+            created_at: chrono::Utc::now(),
+            data_dir: dir.path().join("timeout-green"),
+        };
+        std::fs::create_dir_all(&palace.data_dir).unwrap();
+        let handle = PalaceHandle::open(&palace).unwrap();
+
+        let result = handle
+            .remember(
+                "bounded timeout green path".into(),
+                crate::memory_core::palace::RoomType::General,
+                vec![],
+                0.5,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "remember must succeed with mock embedder: {result:?}"
+        );
+    }
+
+    /// Why: Verify that the write-lock timeout returns an explicit error when
+    /// the lock is held indefinitely (simulated by holding it across an async
+    /// sleep that exceeds the configured timeout).
+    /// What: Acquires the per-palace `write_mutex` in a background task,
+    /// then sets `TRUSTY_WRITE_LOCK_TIMEOUT_SECS=0` and attempts `remember`,
+    /// which must time out on lock acquisition.
+    /// Test: itself.
+    #[tokio::test]
+    async fn write_lock_timeout_returns_error_when_held() {
+        crate::memory_core::retrieval::seed_shared_embedder_with_mock();
+
+        let dir = tempdir().unwrap();
+        let palace = Palace {
+            id: PalaceId::new("lock-timeout"),
+            name: "Lock timeout".into(),
+            description: None,
+            created_at: chrono::Utc::now(),
+            data_dir: dir.path().join("lock-timeout"),
+        };
+        std::fs::create_dir_all(&palace.data_dir).unwrap();
+        let handle = PalaceHandle::open(&palace).unwrap();
+
+        // Hold the write lock in a background task indefinitely until we
+        // signal it to release.
+        let mutex = handle.write_mutex.clone();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let holder = tokio::spawn(async move {
+            let _guard = mutex.lock().await;
+            // Hold the lock until released by the test.
+            let _ = release_rx.await;
+        });
+        // Give the holder a moment to acquire.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Set a 0-second write-lock timeout so the next `remember` times out
+        // immediately on lock acquisition.
+        unsafe { std::env::set_var("TRUSTY_WRITE_LOCK_TIMEOUT_SECS", "0") };
+        let result = handle
+            .remember(
+                "should time out on lock".into(),
+                crate::memory_core::palace::RoomType::General,
+                vec![],
+                0.5,
+            )
+            .await;
+        unsafe { std::env::remove_var("TRUSTY_WRITE_LOCK_TIMEOUT_SECS") };
+
+        // Release the holder so it doesn't leak.
+        let _ = release_tx.send(());
+        let _ = holder.await;
+
+        assert!(
+            result.is_err(),
+            "remember must return Err when write-lock times out, got Ok"
+        );
+        let err = result.err().expect("checked above");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("timed out") || msg.contains("write-lock"),
+            "error must mention lock timeout: {msg}"
+        );
+    }
+}

--- a/crates/trusty-common/src/memory_core/retrieval/timeout_tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/timeout_tests.rs
@@ -55,11 +55,12 @@ mod tests {
         unsafe {
             std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS");
         }
-        assert!(
-            result.is_err(),
-            "shared_embedder() must return Err when init times out, got Ok"
-        );
-        let err = result.err().expect("checked above");
+        // `expect_err` requires T: Debug which Arc<dyn Embedder> doesn't
+        // satisfy, so we match instead.
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("shared_embedder() must return Err when init times out, got Ok"),
+        };
         let msg = format!("{err:#}");
         assert!(
             msg.contains("timed out") || msg.contains("FastEmbedder"),
@@ -159,7 +160,7 @@ mod tests {
             result.is_err(),
             "remember must return Err when write-lock times out, got Ok"
         );
-        let err = result.err().expect("checked above");
+        let err = result.expect_err("checked above");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("timed out") || msg.contains("write-lock"),

--- a/crates/trusty-common/src/memory_core/timeouts.rs
+++ b/crates/trusty-common/src/memory_core/timeouts.rs
@@ -1,0 +1,160 @@
+//! Bounded-timeout configuration for memory operations (issue #906).
+//!
+//! Why: The remember/recall path has several `await` points that can hang
+//! indefinitely — most importantly the CoreML cold-compile inside
+//! `FastEmbedder::new()` (30-120 s on Apple Silicon) and the per-call
+//! `embed_batch` invocation. Without explicit bounds a single stuck embedder
+//! blocks every concurrent memory operation in the process forever. This
+//! module centralises the three timeout thresholds and their env-var overrides
+//! so callers get a single import and defaults can be tuned per deployment.
+//!
+//! What: Exports three `std::time::Duration` functions:
+//! `embedder_init_timeout()`, `embed_batch_timeout()`, `write_lock_timeout()`.
+//! Each reads an environment variable and falls back to a sane default.
+//!
+//! Test: `embedder_init_timeout_default`, `embed_batch_timeout_default`,
+//! `write_lock_timeout_default`, `parse_secs_env_falls_back_on_bad_value`,
+//! `parse_secs_env_reads_custom_value` (unit tests at the bottom of this
+//! file; run with `cargo test -p trusty-common --features memory-core`).
+
+use std::time::Duration;
+
+/// Default ceiling for `FastEmbedder::new()` cold init.
+///
+/// Why: CoreML graph compilation on Apple Silicon can take 30-120 s on first
+/// run; 180 s gives ample headroom without risking an indefinite hang.
+const DEFAULT_EMBEDDER_INIT_SECS: u64 = 180;
+
+/// Default ceiling for a single `embed_batch` call.
+///
+/// Why: Normal batches take 10-30 ms; even worst-case single-item batches
+/// should complete well under 10 s. 30 s gives a 100x safety margin.
+const DEFAULT_EMBED_BATCH_SECS: u64 = 30;
+
+/// Default ceiling for per-palace write-mutex acquisition.
+///
+/// Why: The mutex is held only during the embed+upsert+persist pipeline
+/// (< 1 s normally). A long queue of writers could push acquisition time
+/// above 1 s; 60 s is conservative without risking an indefinite cascade.
+const DEFAULT_WRITE_LOCK_SECS: u64 = 60;
+
+/// Return the `FastEmbedder::new()` init timeout.
+///
+/// Why: Overridable via `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` so operators on
+/// slow CI machines or cold CUDA hosts can extend the ceiling without
+/// recompiling.
+/// What: Reads the env var; falls back to `DEFAULT_EMBEDDER_INIT_SECS` (180).
+/// Test: `embedder_init_timeout_default`, `parse_secs_env_reads_custom_value`.
+pub fn embedder_init_timeout() -> Duration {
+    parse_secs_env(
+        "TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS",
+        DEFAULT_EMBEDDER_INIT_SECS,
+    )
+}
+
+/// Return the per-call `embed_batch` timeout.
+///
+/// Why: Overridable via `TRUSTY_EMBED_BATCH_TIMEOUT_SECS` so high-throughput
+/// or GPU-backed deployments can tune the ceiling.
+/// What: Reads the env var; falls back to `DEFAULT_EMBED_BATCH_SECS` (30).
+/// Test: `embed_batch_timeout_default`.
+pub fn embed_batch_timeout() -> Duration {
+    parse_secs_env("TRUSTY_EMBED_BATCH_TIMEOUT_SECS", DEFAULT_EMBED_BATCH_SECS)
+}
+
+/// Return the per-palace write-lock acquisition timeout.
+///
+/// Why: Overridable via `TRUSTY_WRITE_LOCK_TIMEOUT_SECS` to accommodate
+/// unusually deep write queues on write-heavy deployments.
+/// What: Reads the env var; falls back to `DEFAULT_WRITE_LOCK_SECS` (60).
+/// Test: `write_lock_timeout_default`.
+pub fn write_lock_timeout() -> Duration {
+    parse_secs_env("TRUSTY_WRITE_LOCK_TIMEOUT_SECS", DEFAULT_WRITE_LOCK_SECS)
+}
+
+/// Parse a duration from `$name` (seconds), returning `default_secs` on
+/// missing or malformed values.
+///
+/// Why: Centralising the parse keeps each public function a one-liner and
+/// ensures consistent fallback semantics across all three timeouts.
+/// What: Reads `std::env::var(name)`, attempts `u64` parse, returns
+/// `Duration::from_secs(parsed)` or `Duration::from_secs(default_secs)`.
+/// Test: `parse_secs_env_falls_back_on_bad_value`,
+///       `parse_secs_env_reads_custom_value`.
+fn parse_secs_env(name: &str, default_secs: u64) -> Duration {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(default_secs))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: Guard that the default is 180 s when the env var is absent.
+    /// What: Remove the env var, call `embedder_init_timeout()`, assert 180 s.
+    /// Test: itself.
+    #[test]
+    fn embedder_init_timeout_default() {
+        // SAFETY: single-threaded test; env mutation is safe in this context.
+        unsafe { std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS") };
+        let t = embedder_init_timeout();
+        assert_eq!(t, Duration::from_secs(DEFAULT_EMBEDDER_INIT_SECS));
+    }
+
+    /// Why: Guard that the default is 30 s when the env var is absent.
+    /// What: Remove the env var, call `embed_batch_timeout()`, assert 30 s.
+    /// Test: itself.
+    #[test]
+    fn embed_batch_timeout_default() {
+        unsafe { std::env::remove_var("TRUSTY_EMBED_BATCH_TIMEOUT_SECS") };
+        let t = embed_batch_timeout();
+        assert_eq!(t, Duration::from_secs(DEFAULT_EMBED_BATCH_SECS));
+    }
+
+    /// Why: Guard that the default is 60 s when the env var is absent.
+    /// What: Remove the env var, call `write_lock_timeout()`, assert 60 s.
+    /// Test: itself.
+    #[test]
+    fn write_lock_timeout_default() {
+        unsafe { std::env::remove_var("TRUSTY_WRITE_LOCK_TIMEOUT_SECS") };
+        let t = write_lock_timeout();
+        assert_eq!(t, Duration::from_secs(DEFAULT_WRITE_LOCK_SECS));
+    }
+
+    /// Why: A non-numeric env var must fall back to the default rather than
+    /// panicking.
+    /// What: Set the var to "notanumber", call `parse_secs_env`, assert default.
+    /// Test: itself.
+    #[test]
+    fn parse_secs_env_falls_back_on_bad_value() {
+        unsafe {
+            std::env::set_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS", "notanumber");
+        }
+        let t = parse_secs_env(
+            "TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS",
+            DEFAULT_EMBEDDER_INIT_SECS,
+        );
+        assert_eq!(t, Duration::from_secs(DEFAULT_EMBEDDER_INIT_SECS));
+        unsafe { std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS") };
+    }
+
+    /// Why: A valid numeric env var must be respected.
+    /// What: Set the var to "5", call `parse_secs_env`, assert 5 s.
+    /// Test: itself.
+    #[test]
+    fn parse_secs_env_reads_custom_value() {
+        unsafe {
+            std::env::set_var("TRUSTY_EMBED_BATCH_TIMEOUT_SECS", "5");
+        }
+        let t = parse_secs_env("TRUSTY_EMBED_BATCH_TIMEOUT_SECS", DEFAULT_EMBED_BATCH_SECS);
+        assert_eq!(t, Duration::from_secs(5));
+        unsafe { std::env::remove_var("TRUSTY_EMBED_BATCH_TIMEOUT_SECS") };
+    }
+}

--- a/crates/trusty-common/src/memory_core/timeouts.rs
+++ b/crates/trusty-common/src/memory_core/timeouts.rs
@@ -9,15 +9,19 @@
 //! so callers get a single import and defaults can be tuned per deployment.
 //!
 //! What: Exports three `std::time::Duration` functions:
-//! `embedder_init_timeout()`, `embed_batch_timeout()`, `write_lock_timeout()`.
-//! Each reads an environment variable and falls back to a sane default.
+//! `embedder_init_timeout()`, `embed_batch_timeout()`, `write_lock_timeout()`,
+//! plus a `lock_with_timeout` async helper that applies the write-lock timeout
+//! at every call site uniformly.
 //!
 //! Test: `embedder_init_timeout_default`, `embed_batch_timeout_default`,
-//! `write_lock_timeout_default`, `parse_secs_env_falls_back_on_bad_value`,
-//! `parse_secs_env_reads_custom_value` (unit tests at the bottom of this
-//! file; run with `cargo test -p trusty-common --features memory-core`).
+//! `write_lock_timeout_default`, `parse_secs_with_falls_back_on_bad_value`,
+//! `parse_secs_with_reads_custom_value`, `parse_secs_with_uses_default_when_absent`
+//! (unit tests at the bottom of this file; run with
+//! `cargo test -p trusty-common --features memory-core`).
 
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::{Mutex, MutexGuard};
 
 /// Default ceiling for `FastEmbedder::new()` cold init.
 ///
@@ -44,7 +48,7 @@ const DEFAULT_WRITE_LOCK_SECS: u64 = 60;
 /// slow CI machines or cold CUDA hosts can extend the ceiling without
 /// recompiling.
 /// What: Reads the env var; falls back to `DEFAULT_EMBEDDER_INIT_SECS` (180).
-/// Test: `embedder_init_timeout_default`, `parse_secs_env_reads_custom_value`.
+/// Test: `embedder_init_timeout_default`, `parse_secs_with_reads_custom_value`.
 pub fn embedder_init_timeout() -> Duration {
     parse_secs_env(
         "TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS",
@@ -72,21 +76,75 @@ pub fn write_lock_timeout() -> Duration {
     parse_secs_env("TRUSTY_WRITE_LOCK_TIMEOUT_SECS", DEFAULT_WRITE_LOCK_SECS)
 }
 
+/// Acquire a `tokio::sync::Mutex` with a bounded timeout, returning an error
+/// on expiry.
+///
+/// Why: The write-lock acquisition pattern (get timeout, call
+/// `tokio::time::timeout`, map the elapsed error to a formatted message) was
+/// duplicated at four call sites (retrieval remember + forget paths and
+/// tools.rs memory_remember + memory_note handlers). A single helper
+/// eliminates the duplication and guarantees a consistent error message shape
+/// (issue #906).
+/// What: Calls `tokio::time::timeout(duration, mutex.lock())`. On success
+/// returns the `MutexGuard`. On expiry returns `anyhow::Error` with a message
+/// that includes the palace label and the configured duration.
+/// Test: `write_lock_timeout_returns_error_when_held` in
+/// `memory_core::retrieval::timeout_tests` exercises this path end-to-end.
+pub async fn lock_with_timeout<'a>(
+    mutex: &'a Arc<Mutex<()>>,
+    duration: Duration,
+    label: &str,
+) -> anyhow::Result<MutexGuard<'a, ()>> {
+    tokio::time::timeout(duration, mutex.lock())
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "palace '{}' write-lock acquisition timed out after {:?} \
+                 (issue #906); a previous writer may be stuck — retry or \
+                 increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS",
+                label,
+                duration
+            )
+        })
+}
+
+/// Pure parser: return a `Duration` from a lookup-provided optional string.
+///
+/// Why: Separating the env-lookup side-effect from the parse logic makes the
+/// core behaviour testable without any `unsafe` env mutation. The public
+/// `parse_secs_env` and `embedder_init_timeout` / `embed_batch_timeout` /
+/// `write_lock_timeout` functions delegate here and are themselves trivially
+/// correct once this function is verified.
+/// What: Calls `lookup(key)` to get an optional `String`. If present, tries
+/// `u64` parse; on success returns `Duration::from_secs(parsed)`. Falls back
+/// to `Duration::from_secs(default_secs)` when the key is absent or the value
+/// is non-numeric.
+/// Test: `parse_secs_with_falls_back_on_bad_value`,
+///       `parse_secs_with_reads_custom_value`,
+///       `parse_secs_with_uses_default_when_absent`.
+pub fn parse_secs_with(
+    lookup: impl Fn(&str) -> Option<String>,
+    key: &str,
+    default_secs: u64,
+) -> Duration {
+    lookup(key)
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(default_secs))
+}
+
 /// Parse a duration from `$name` (seconds), returning `default_secs` on
 /// missing or malformed values.
 ///
 /// Why: Centralising the parse keeps each public function a one-liner and
-/// ensures consistent fallback semantics across all three timeouts.
-/// What: Reads `std::env::var(name)`, attempts `u64` parse, returns
-/// `Duration::from_secs(parsed)` or `Duration::from_secs(default_secs)`.
-/// Test: `parse_secs_env_falls_back_on_bad_value`,
-///       `parse_secs_env_reads_custom_value`.
+/// ensures consistent fallback semantics across all three timeouts. Delegates
+/// to `parse_secs_with` with the real env lookup so the pure logic is tested
+/// separately (no env mutation in pure-logic tests).
+/// What: Calls `parse_secs_with` with `std::env::var` as the lookup.
+/// Test: Public-function default tests verify the end-to-end path; pure-logic
+///       tests cover `parse_secs_with` directly without env mutations.
 fn parse_secs_env(name: &str, default_secs: u64) -> Duration {
-    std::env::var(name)
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or_else(|| Duration::from_secs(default_secs))
+    parse_secs_with(|k| std::env::var(k).ok(), name, default_secs)
 }
 
 // ---------------------------------------------------------------------------
@@ -97,64 +155,103 @@ fn parse_secs_env(name: &str, default_secs: u64) -> Duration {
 mod tests {
     use super::*;
 
+    // -------------------------------------------------------------------------
+    // Pure-logic tests — exercise `parse_secs_with` with an injected lookup.
+    // These tests never touch process env: no `unsafe`, no races under the
+    // multi-threaded test harness.
+    // -------------------------------------------------------------------------
+
+    /// Why: Guard that `parse_secs_with` returns the default when the lookup
+    /// returns `None` (key absent).
+    /// What: Pass a lookup that always returns `None`, assert default returned.
+    /// Test: itself.
+    #[test]
+    fn parse_secs_with_uses_default_when_absent() {
+        let t = parse_secs_with(|_| None, "ANY_KEY", DEFAULT_EMBEDDER_INIT_SECS);
+        assert_eq!(t, Duration::from_secs(DEFAULT_EMBEDDER_INIT_SECS));
+    }
+
+    /// Why: Guard that a non-numeric value falls back to the default rather
+    /// than panicking.
+    /// What: Pass a lookup returning `Some("notanumber")`, assert default.
+    /// Test: itself.
+    #[test]
+    fn parse_secs_with_falls_back_on_bad_value() {
+        let t = parse_secs_with(
+            |_| Some("notanumber".to_string()),
+            "ANY_KEY",
+            DEFAULT_EMBEDDER_INIT_SECS,
+        );
+        assert_eq!(t, Duration::from_secs(DEFAULT_EMBEDDER_INIT_SECS));
+    }
+
+    /// Why: Guard that a valid numeric value is respected.
+    /// What: Pass a lookup returning `Some("5")`, assert 5 s returned.
+    /// Test: itself.
+    #[test]
+    fn parse_secs_with_reads_custom_value() {
+        let t = parse_secs_with(
+            |_| Some("5".to_string()),
+            "ANY_KEY",
+            DEFAULT_EMBED_BATCH_SECS,
+        );
+        assert_eq!(t, Duration::from_secs(5));
+    }
+
+    // -------------------------------------------------------------------------
+    // Default-value tests — exercise the public timeout functions to ensure
+    // the defaults are what the module documentation promises. These tests
+    // rely on the env vars being absent at test time; they are serialised
+    // behind a process-wide mutex to avoid interleaving with any other test
+    // that sets those vars (e.g. the `#[ignore]` timeout-fire tests).
+    // -------------------------------------------------------------------------
+
+    /// Serialises tests that read the real env so they cannot interleave.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_MUTEX: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        ENV_MUTEX
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .expect("env_lock mutex poisoned")
+    }
+
     /// Why: Guard that the default is 180 s when the env var is absent.
-    /// What: Remove the env var, call `embedder_init_timeout()`, assert 180 s.
+    /// What: Hold the env mutex, verify the var is unset (or unset it), call
+    /// `embedder_init_timeout()`, assert 180 s.
     /// Test: itself.
     #[test]
     fn embedder_init_timeout_default() {
-        // SAFETY: single-threaded test; env mutation is safe in this context.
+        let _guard = env_lock();
+        // Clear the var so we're testing the absent-key code path.
+        // SAFETY: we hold `env_lock()` which serialises all env-touching
+        // tests in this module; no other thread mutates this var while
+        // the mutex is held.
         unsafe { std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS") };
         let t = embedder_init_timeout();
         assert_eq!(t, Duration::from_secs(DEFAULT_EMBEDDER_INIT_SECS));
     }
 
     /// Why: Guard that the default is 30 s when the env var is absent.
-    /// What: Remove the env var, call `embed_batch_timeout()`, assert 30 s.
+    /// What: Hold the env mutex, unset the var, call `embed_batch_timeout()`,
+    /// assert 30 s.
     /// Test: itself.
     #[test]
     fn embed_batch_timeout_default() {
+        let _guard = env_lock();
         unsafe { std::env::remove_var("TRUSTY_EMBED_BATCH_TIMEOUT_SECS") };
         let t = embed_batch_timeout();
         assert_eq!(t, Duration::from_secs(DEFAULT_EMBED_BATCH_SECS));
     }
 
     /// Why: Guard that the default is 60 s when the env var is absent.
-    /// What: Remove the env var, call `write_lock_timeout()`, assert 60 s.
+    /// What: Hold the env mutex, unset the var, call `write_lock_timeout()`,
+    /// assert 60 s.
     /// Test: itself.
     #[test]
     fn write_lock_timeout_default() {
+        let _guard = env_lock();
         unsafe { std::env::remove_var("TRUSTY_WRITE_LOCK_TIMEOUT_SECS") };
         let t = write_lock_timeout();
         assert_eq!(t, Duration::from_secs(DEFAULT_WRITE_LOCK_SECS));
-    }
-
-    /// Why: A non-numeric env var must fall back to the default rather than
-    /// panicking.
-    /// What: Set the var to "notanumber", call `parse_secs_env`, assert default.
-    /// Test: itself.
-    #[test]
-    fn parse_secs_env_falls_back_on_bad_value() {
-        unsafe {
-            std::env::set_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS", "notanumber");
-        }
-        let t = parse_secs_env(
-            "TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS",
-            DEFAULT_EMBEDDER_INIT_SECS,
-        );
-        assert_eq!(t, Duration::from_secs(DEFAULT_EMBEDDER_INIT_SECS));
-        unsafe { std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS") };
-    }
-
-    /// Why: A valid numeric env var must be respected.
-    /// What: Set the var to "5", call `parse_secs_env`, assert 5 s.
-    /// Test: itself.
-    #[test]
-    fn parse_secs_env_reads_custom_value() {
-        unsafe {
-            std::env::set_var("TRUSTY_EMBED_BATCH_TIMEOUT_SECS", "5");
-        }
-        let t = parse_secs_env("TRUSTY_EMBED_BATCH_TIMEOUT_SECS", DEFAULT_EMBED_BATCH_SECS);
-        assert_eq!(t, Duration::from_secs(5));
-        unsafe { std::env::remove_var("TRUSTY_EMBED_BATCH_TIMEOUT_SECS") };
     }
 }

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -766,6 +766,29 @@ async fn run_serve(
 ///       and populates the map; the log emission is confirmed by the throwaway
 ///       daemon run documented in the session notes.
 fn spawn_startup_tasks(state: &AppState) {
+    // Issue #906: eager embedder warm-up. Spawn BEFORE the palace hydration
+    // task so the CoreML / CUDA cold compile (30-120 s on first run) races
+    // ahead concurrently and the warm embedder is likely ready by the time
+    // the first `memory_remember` / `memory_recall` arrives. Failure here
+    // is non-fatal — we log at ERROR level and continue; the lazy-init path
+    // in `shared_embedder()` will retry on the first real request (and now
+    // returns a bounded error instead of hanging).
+    tokio::spawn(async move {
+        let ws = std::time::Instant::now();
+        tracing::info!("starting background embedder warm-up (issue #906)");
+        match trusty_common::memory_core::retrieval::shared_embedder().await {
+            Ok(_) => tracing::info!(
+                elapsed_ms = ws.elapsed().as_millis() as u64,
+                "background embedder warm-up complete"
+            ),
+            Err(e) => tracing::error!(
+                elapsed_ms = ws.elapsed().as_millis() as u64,
+                "background embedder warm-up failed (memory ops will re-attempt \
+                 on first request): {e:#}"
+            ),
+        }
+    });
+
     let bg_state = state.clone();
     tokio::spawn(async move {
         let started = std::time::Instant::now();

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -30,6 +30,7 @@ use trusty_common::memory_core::retrieval::{
     recall, recall_across_palaces, recall_deep, RememberOptions,
 };
 use trusty_common::memory_core::store::kg::Triple;
+use trusty_common::memory_core::timeouts;
 use uuid::Uuid;
 
 /// Look up the friendly palace name (Palace.name) from the in-memory cache,
@@ -963,8 +964,23 @@ async fn handle_memory_remember(state: &AppState, args: Value) -> Result<Value> 
     // and the `write_drawer` call so the redb write inside
     // `remember_with_options` happens with the gate snapshot still
     // visible to subsequent waiters.
+    // Issue #906: bound the acquisition so a stuck embedder on a prior writer
+    // does not cascade an indefinite queue of callers waiting for this lock.
     let write_lock = state.palace_write_lock(palace);
-    let _write_guard = write_lock.lock().await;
+    let _write_guard = {
+        let lock_timeout = timeouts::write_lock_timeout();
+        tokio::time::timeout(lock_timeout, write_lock.lock())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "memory_remember: palace '{}' write-lock timed out after {:?} \
+                     (issue #906); a previous writer may be stuck — retry or \
+                     increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS",
+                    palace,
+                    lock_timeout
+                )
+            })?
+    };
 
     // Issue #220: rolling dedup window — skip when a near-duplicate
     // landed in the same palace within the last 5 minutes. The
@@ -1057,8 +1073,21 @@ async fn handle_memory_note(state: &AppState, args: Value) -> Result<Value> {
     // `write_drawer` call so the redb write inside
     // `remember_with_options` is visible to subsequent waiters before
     // they snapshot.
+    // Issue #906: bound the acquisition to prevent cascading hangs.
     let write_lock = state.palace_write_lock(palace);
-    let _write_guard = write_lock.lock().await;
+    let _write_guard = {
+        let lock_timeout = timeouts::write_lock_timeout();
+        tokio::time::timeout(lock_timeout, write_lock.lock())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "memory_note: palace '{}' write-lock timed out after {:?} \
+                     (issue #906); increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS if needed",
+                    palace,
+                    lock_timeout
+                )
+            })?
+    };
     // Issue #220: rolling dedup window — same gate as
     // `memory_remember`. `memory_note` has no `force` arg, so the
     // gate is unconditional: curated short-fact writes that happen

--- a/crates/trusty-memory/src/tools.rs
+++ b/crates/trusty-memory/src/tools.rs
@@ -967,20 +967,10 @@ async fn handle_memory_remember(state: &AppState, args: Value) -> Result<Value> 
     // Issue #906: bound the acquisition so a stuck embedder on a prior writer
     // does not cascade an indefinite queue of callers waiting for this lock.
     let write_lock = state.palace_write_lock(palace);
-    let _write_guard = {
-        let lock_timeout = timeouts::write_lock_timeout();
-        tokio::time::timeout(lock_timeout, write_lock.lock())
+    let _write_guard =
+        timeouts::lock_with_timeout(&write_lock, timeouts::write_lock_timeout(), palace)
             .await
-            .map_err(|_| {
-                anyhow::anyhow!(
-                    "memory_remember: palace '{}' write-lock timed out after {:?} \
-                     (issue #906); a previous writer may be stuck — retry or \
-                     increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS",
-                    palace,
-                    lock_timeout
-                )
-            })?
-    };
+            .map_err(|e| anyhow::anyhow!("memory_remember: {e:#}"))?;
 
     // Issue #220: rolling dedup window — skip when a near-duplicate
     // landed in the same palace within the last 5 minutes. The
@@ -1075,19 +1065,10 @@ async fn handle_memory_note(state: &AppState, args: Value) -> Result<Value> {
     // they snapshot.
     // Issue #906: bound the acquisition to prevent cascading hangs.
     let write_lock = state.palace_write_lock(palace);
-    let _write_guard = {
-        let lock_timeout = timeouts::write_lock_timeout();
-        tokio::time::timeout(lock_timeout, write_lock.lock())
+    let _write_guard =
+        timeouts::lock_with_timeout(&write_lock, timeouts::write_lock_timeout(), palace)
             .await
-            .map_err(|_| {
-                anyhow::anyhow!(
-                    "memory_note: palace '{}' write-lock timed out after {:?} \
-                     (issue #906); increase TRUSTY_WRITE_LOCK_TIMEOUT_SECS if needed",
-                    palace,
-                    lock_timeout
-                )
-            })?
-    };
+            .map_err(|e| anyhow::anyhow!("memory_note: {e:#}"))?;
     // Issue #220: rolling dedup window — same gate as
     // `memory_remember`. `memory_note` has no `force` arg, so the
     // gate is unconditional: curated short-fact writes that happen


### PR DESCRIPTION
## Problem

`memory_remember` (and `memory_recall`) could hang indefinitely when:

1. **FastEmbedder cold init** — CoreML graph compilation takes 30-120 s on
   Apple Silicon. `shared_embedder()` called `OnceCell::get_or_try_init` with
   no timeout, so any MCP call that landed on a cold process blocked forever.
2. **`embed_batch`** — even after the model loaded, a stuck ONNX session had no
   ceiling per call.
3. **Write-mutex cascade** — `write_mutex.lock().await` in `remember_with_options()`,
   `forget()`, and the two tools entry-points had no timeout, so a single
   stalled holder cascaded into all waiters blocking indefinitely.

## Fix

Three `await` points now have `tokio::time::timeout` wrappers with
env-tunable defaults:

| Point | Default | Env var |
|---|---|---|
| `shared_embedder()` cold init | 180 s | `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` |
| `embed_batch` per call | 30 s | `TRUSTY_EMBED_BATCH_TIMEOUT_SECS` |
| `write_mutex.lock()` | 60 s | `TRUSTY_WRITE_LOCK_TIMEOUT_SECS` |

A new `trusty_common::memory_core::timeouts` module centralises all three so
every call-site shares one import and operators can tune per deployment.

**Startup warm-up (point 4):** `spawn_startup_tasks()` in `trusty-memory/main.rs`
now fires a background `shared_embedder()` call concurrently with the pin scan,
so CoreML compilation overlaps with other init work rather than blocking the
first live request.

## Files changed

- `crates/trusty-common/src/memory_core/timeouts.rs` — NEW: centralised
  timeout config with 5 unit tests
- `crates/trusty-common/src/memory_core/retrieval/timeout_tests.rs` — NEW:
  behavioural tests (green path, lock-timeout, embedder-init-timeout)
- `crates/trusty-common/src/memory_core/mod.rs` — exports `timeouts` module
- `crates/trusty-common/src/memory_core/retrieval/mod.rs` — wraps
  `shared_embedder()`, `embed_batch`, and two `write_mutex.lock()` calls
- `crates/trusty-memory/src/tools.rs` — wraps two `write_lock.lock()` calls
  in `handle_memory_remember()` and `handle_memory_note()`
- `crates/trusty-memory/src/main.rs` — eager embedder warm-up in
  `spawn_startup_tasks()`
- `.line-cap-allowlist.tsv` — budgets updated for the three modified
  allowlisted files

## Test results

```
cargo test -p trusty-common --features memory-core
307 passed; 0 failed; 11 ignored

cargo test -p trusty-memory
395 passed; 0 failed (across 12 test binaries)

cargo clippy -p trusty-common --features memory-core -- -D warnings  ✓
cargo clippy -p trusty-memory -- -D warnings                          ✓
cargo fmt --check -p trusty-common -p trusty-memory                   ✓
bash scripts/check_line_cap.sh → 172 allowlisted, 0 violations — OK  ✓
```

## End-to-end evidence

Isolated daemon (non-default port + `TRUSTY_DATA_DIR_OVERRIDE`) — no live
palaces touched.

- Normal `memory_remember` returned in **13 ms** (warm path).
- `TRUSTY_WRITE_LOCK_TIMEOUT_SECS=0` test returned `Err("palace … write-lock
  acquisition timed out")` within milliseconds — not a hang.

Closes #906.