### PR TITLE
feat(search): refuse to index sensitive roots — index denylist

### DIFF
--- a/crates/trusty-search/src/commands/index.rs
+++ b/crates/trusty-search/src/commands/index.rs
@@ -21,7 +21,6 @@ use super::reindex_engine::{
     register_index_with_daemon, register_index_with_daemon_filtered, run_reindex_force_opts,
     run_reindex_opts, RegisterFilters,
 };
-use crate::config::{CollectionConfig, GlobalConfig};
 use crate::core::project_config::{ProjectConfig, PROJECT_CONFIG_FILENAME};
 use crate::core::repo_config::{language_to_exts, IndexConfig, RepoConfig, CONFIG_FILENAME};
 use anyhow::Result;
@@ -50,7 +49,26 @@ pub async fn handle_index(
     let cwd = std::env::current_dir().unwrap_or_default();
 
     // 1. Resolve root — hard error on non-existent / inaccessible paths.
+    //    `resolve_project_path` calls `canonicalize`, so `project_path` is
+    //    already fully resolved (symlinks expanded, `..` collapsed).
     let project_path = resolve_project_path(cli_path, &cwd)?;
+
+    // 1a. CLI-side sensitive-root check (defense-in-depth, issue: index-denylist).
+    //    The daemon enforces the authoritative denylist in `validate_root_path`,
+    //    but an early CLI check gives the user a friendly error message *before*
+    //    we attempt to start the daemon (which is expensive). `project_path` is
+    //    already canonical (step 1), so symlink or `..` bypass is impossible.
+    //    Note: for multi-index YAML repos we cannot know which index will be
+    //    denied until we parse the config (each index may have its own root),
+    //    so we only check the top-level `project_path` here and rely on the
+    //    daemon guard for individual slice roots.
+    if let Some(reason) = crate::allowlist::is_denied(&project_path) {
+        anyhow::bail!(
+            "indexing refused: {reason}\n\
+             (the daemon will also refuse this root — \
+             choose a project directory instead)"
+        );
+    }
 
     // 2. Auto-start the daemon (issue #24: CPU-by-default on Apple Silicon
     //    avoids ~72 GB CoreML virtual-RSS spike that jetsam kills ~14s in).
@@ -312,64 +330,9 @@ async fn index_one_with_filters(
     Ok(())
 }
 
-/// Write (or update) entries in the YAML config and the opt-in allowlist.
-///
-/// Why: issue #40 — the YAML config is the user-facing source of truth for
-/// indexed projects. Every successful `trusty-search index` invocation must
-/// add/update its matching `collections:` entry so a daemon restart preserves
-/// the registration and `index remove` has a row to drop. Failures here are
-/// non-fatal because the daemon-side registration already succeeded.
-/// Issue #767: also write to the TOML allowlist (`indexes.toml`). Running
-/// `trusty-search index <path>` is an explicit user gesture that implies
-/// approval; persisting it to the allowlist makes the approval durable across
-/// daemon restarts without requiring a separate `index add` invocation.
-/// What: loads both config files, upserts entries, and saves atomically.
-/// Warnings are emitted via `tracing::warn!` so daemon logs surface them
-/// without polluting stdout.
-/// Test: covered indirectly by `config::tests::roundtrip_preserves_fields`
-/// (round-trip) and `config::tests::upsert_replaces_by_name` (idempotency);
-/// CLI smoke tested by running `trusty-search index` twice and inspecting both
-/// the resulting YAML and TOML files.
-fn persist_collection_to_global_config(
-    index_name: &str,
-    project_path: &std::path::Path,
-    filters: &RegisterFilters,
-) {
-    // 1. Legacy YAML config (config.yaml).
-    let mut cfg = match GlobalConfig::load() {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!("could not load global config to record index '{index_name}': {e:#}");
-            return;
-        }
-    };
-    cfg.upsert_collection(CollectionConfig {
-        name: index_name.to_string(),
-        path: project_path.to_path_buf(),
-        extensions: filters.extensions.clone(),
-        exclude: filters.exclude_globs.clone(),
-        domain_terms: filters.domain_terms.clone(),
-    });
-    if let Err(e) = cfg.save() {
-        tracing::warn!("could not save global config after registering '{index_name}': {e:#}");
-    }
-
-    // 2. Issue #767: also write to the TOML allowlist (indexes.toml).
-    // Skip paths blocked by the denylist (shouldn't be reachable here because
-    // the daemon already validated them, but be defensive).
-    if crate::allowlist::is_denied(project_path).is_none() {
-        let entry = crate::allowlist::AllowlistEntry {
-            path: project_path.to_path_buf(),
-            name: Some(index_name.to_string()),
-            exclude: filters.exclude_globs.clone(),
-            extensions: filters.extensions.clone(),
-            skip_kg: filters.skip_kg,
-        };
-        if let Err(e) = crate::allowlist::add_to_allowlist(entry, None) {
-            tracing::warn!("could not write allowlist entry for '{index_name}': {e:#}");
-        }
-    }
-}
+// `persist_collection_to_global_config` lives in `index_persist.rs` to keep
+// this file under the 500-line cap.
+use super::index_persist::persist_collection_to_global_config;
 
 #[cfg(test)]
 mod tests {

--- a/crates/trusty-search/src/commands/index_persist.rs
+++ b/crates/trusty-search/src/commands/index_persist.rs
@@ -1,0 +1,73 @@
+//! Persistence helpers for `trusty-search index`: writing registrations to the
+//! global YAML config and the TOML allowlist.
+//!
+//! Why: extracted from `index.rs` to keep it under the 500-line cap. These
+//! helpers perform best-effort I/O (failures are logged, not fatal) and have
+//! no external callers beyond `index_one_with_filters`.
+//! What: `persist_collection_to_global_config` writes/updates both the legacy
+//! `config.yaml` and the TOML allowlist (`indexes.toml`) whenever a successful
+//! `trusty-search index` invocation registers a new index.
+//! Test: covered indirectly by `config::tests::roundtrip_preserves_fields`
+//! (round-trip) and `config::tests::upsert_replaces_by_name` (idempotency).
+
+use crate::commands::reindex_engine::RegisterFilters;
+use crate::config::{CollectionConfig, GlobalConfig};
+
+/// Write (or update) entries in the YAML config and the opt-in allowlist.
+///
+/// Why: issue #40 — the YAML config is the user-facing source of truth for
+/// indexed projects. Every successful `trusty-search index` invocation must
+/// add/update its matching `collections:` entry so a daemon restart preserves
+/// the registration and `index remove` has a row to drop. Failures here are
+/// non-fatal because the daemon-side registration already succeeded.
+/// Issue #767: also write to the TOML allowlist (`indexes.toml`). Running
+/// `trusty-search index <path>` is an explicit user gesture that implies
+/// approval; persisting it to the allowlist makes the approval durable across
+/// daemon restarts without requiring a separate `index add` invocation.
+/// What: loads both config files, upserts entries, and saves atomically.
+/// Warnings are emitted via `tracing::warn!` so daemon logs surface them
+/// without polluting stdout.
+/// Test: covered indirectly by `config::tests::roundtrip_preserves_fields`
+/// (round-trip) and `config::tests::upsert_replaces_by_name` (idempotency);
+/// CLI smoke tested by running `trusty-search index` twice and inspecting both
+/// the resulting YAML and TOML files.
+pub(super) fn persist_collection_to_global_config(
+    index_name: &str,
+    project_path: &std::path::Path,
+    filters: &RegisterFilters,
+) {
+    // 1. Legacy YAML config (config.yaml).
+    let mut cfg = match GlobalConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("could not load global config to record index '{index_name}': {e:#}");
+            return;
+        }
+    };
+    cfg.upsert_collection(CollectionConfig {
+        name: index_name.to_string(),
+        path: project_path.to_path_buf(),
+        extensions: filters.extensions.clone(),
+        exclude: filters.exclude_globs.clone(),
+        domain_terms: filters.domain_terms.clone(),
+    });
+    if let Err(e) = cfg.save() {
+        tracing::warn!("could not save global config after registering '{index_name}': {e:#}");
+    }
+
+    // 2. Issue #767: also write to the TOML allowlist (indexes.toml).
+    // Skip paths blocked by the denylist (shouldn't be reachable here because
+    // the daemon already validated them, but be defensive).
+    if crate::allowlist::is_denied(project_path).is_none() {
+        let entry = crate::allowlist::AllowlistEntry {
+            path: project_path.to_path_buf(),
+            name: Some(index_name.to_string()),
+            exclude: filters.exclude_globs.clone(),
+            extensions: filters.extensions.clone(),
+            skip_kg: filters.skip_kg,
+        };
+        if let Err(e) = crate::allowlist::add_to_allowlist(entry, None) {
+            tracing::warn!("could not write allowlist entry for '{index_name}': {e:#}");
+        }
+    }
+}

--- a/crates/trusty-search/src/commands/mod.rs
+++ b/crates/trusty-search/src/commands/mod.rs
@@ -41,6 +41,7 @@ pub mod discover;
 pub mod doctor;
 pub mod index;
 pub mod index_allowlist;
+pub(crate) mod index_persist;
 pub mod index_remove;
 pub mod init;
 pub mod integrate;

--- a/crates/trusty-search/src/service/server/helpers.rs
+++ b/crates/trusty-search/src/service/server/helpers.rs
@@ -6,12 +6,27 @@
 //! avoids duplication and keeps the 500-line cap on each handler file.
 //! What: `validate_root_path`, `file_is_within_root`,
 //! `embedder_initializing_response`, `embedder_error_response`.
-//! Test: `file_is_within_root_*` and `create_index_canonicalizes_*` tests.
+//! Test: `file_is_within_root_*`, `create_index_canonicalizes_*`, and
+//! `validate_root_path_denylist_*` tests.
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Json, Response},
 };
 
+/// Validate `path` as a safe, canonical root for indexing.
+///
+/// Why: Defense-in-depth for the daemon — even when the CLI-side check
+/// (`commands/index.rs`) is bypassed (direct HTTP calls, MCP tools, scripts),
+/// the daemon must refuse sensitive roots. The hard denylist in
+/// `crate::allowlist::is_denied` is the authoritative gate; this function
+/// applies it **after** canonicalization so symlink tricks or `..` traversals
+/// cannot bypass the check.
+/// What: in order — (1) rejects empty/non-absolute/non-dir paths; (2)
+/// canonicalizes via `std::fs::canonicalize` to resolve symlinks; (3) calls
+/// `crate::allowlist::is_denied` on the canonical path and returns 400 with the
+/// denial reason when matched.
+/// Test: `validate_root_path_denylist_rejects_ssh`, `_rejects_home`,
+/// `_rejects_tmp`, `_accepts_project_dir` in `tests_index.rs`.
 #[allow(clippy::result_large_err)]
 pub(super) fn validate_root_path(path: &std::path::Path) -> Result<std::path::PathBuf, Response> {
     if path.as_os_str().is_empty() {
@@ -56,20 +71,36 @@ pub(super) fn validate_root_path(path: &std::path::Path) -> Result<std::path::Pa
     // a 400 with the underlying I/O error rather than fall back to the
     // un-canonicalized path — half-resolved paths are exactly what produced the
     // mismatch in the first place.
-    match std::fs::canonicalize(path) {
-        Ok(canonical) => Ok(canonical),
-        Err(e) => Err((
+    let canonical = match std::fs::canonicalize(path) {
+        Ok(p) => p,
+        Err(e) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "root_path {:?} could not be canonicalized: {}",
+                        path.display().to_string(),
+                        e
+                    ),
+                })),
+            )
+                .into_response());
+        }
+    };
+    // Hard denylist check on the canonical path — symlinks and `..` traversals
+    // are already resolved above, so no bypass is possible.
+    if let Some(reason) = crate::allowlist::is_denied(&canonical) {
+        return Err((
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
                 "error": format!(
-                    "root_path {:?} could not be canonicalized: {}",
-                    path.display().to_string(),
-                    e
+                    "indexing refused: {reason}"
                 ),
             })),
         )
-            .into_response()),
+            .into_response());
     }
+    Ok(canonical)
 }
 
 /// Determine whether a chunk's stored `file` field falls within an index's

--- a/crates/trusty-search/src/service/server/helpers.rs
+++ b/crates/trusty-search/src/service/server/helpers.rs
@@ -46,7 +46,7 @@ pub(super) fn validate_root_path(path: &std::path::Path) -> Result<std::path::Pa
                     "root_path must be absolute (got {:?}); relative paths \
                      would be resolved against the daemon's CWD which is \
                      not the caller's CWD",
-                    path.display().to_string()
+                    path.display()
                 ),
             })),
         )
@@ -58,7 +58,7 @@ pub(super) fn validate_root_path(path: &std::path::Path) -> Result<std::path::Pa
             Json(serde_json::json!({
                 "error": format!(
                     "root_path {:?} does not exist or is not a directory",
-                    path.display().to_string()
+                    path.display()
                 ),
             })),
         )
@@ -79,7 +79,7 @@ pub(super) fn validate_root_path(path: &std::path::Path) -> Result<std::path::Pa
                 Json(serde_json::json!({
                     "error": format!(
                         "root_path {:?} could not be canonicalized: {}",
-                        path.display().to_string(),
+                        path.display(),
                         e
                     ),
                 })),

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -27,6 +27,8 @@ mod tickers;
 
 // cfg(test) sub-modules — each < 500 lines
 #[cfg(test)]
+mod tests_denylist;
+#[cfg(test)]
 mod tests_grep;
 #[cfg(test)]
 mod tests_health;

--- a/crates/trusty-search/src/service/server/tests_denylist.rs
+++ b/crates/trusty-search/src/service/server/tests_denylist.rs
@@ -200,9 +200,15 @@ fn validate_root_path_denylist_blocks_symlink_to_ssh() {
     if !ssh.is_dir() {
         return; // No ~/.ssh on this machine — skip.
     }
-    // Create a symlink in a non-denied location pointing at ~/.ssh.
-    // We use /tmp for the symlink itself (the link file lives there, not the target).
-    let link = std::env::temp_dir().join(format!("ts-denylist-ssh-link-{}", std::process::id()));
+    // Create a symlink under target/ so both the symlink location and resolved
+    // target are unambiguous: the link itself lives in a non-denied path, but
+    // its resolved target (~/.ssh) is in SENSITIVE_PATH_PREFIXES.  Using
+    // std::env::temp_dir() is unreliable here because on macOS it returns
+    // /private/var/folders/… which is itself in the denylist, causing the
+    // rejection to fire at the wrong check.
+    let base = std::env::current_dir().expect("cwd").join("target");
+    std::fs::create_dir_all(&base).ok();
+    let link = base.join(format!("ts-denylist-ssh-link-{}", std::process::id()));
     let _ = std::fs::remove_file(&link);
     if std::os::unix::fs::symlink(&ssh, &link).is_err() {
         return; // Cannot create symlink — skip.

--- a/crates/trusty-search/src/service/server/tests_denylist.rs
+++ b/crates/trusty-search/src/service/server/tests_denylist.rs
@@ -1,0 +1,183 @@
+//! Unit and integration tests for the sensitive-root denylist enforced by
+//! `validate_root_path` (issue: index-denylist).
+//!
+//! Why: keeping these tests in a sibling file prevents `tests_index.rs`
+//! from exceeding the 500-line cap while keeping every assertion co-located
+//! with the server module they validate.
+//! What: covers daemon-side denylist rejection via `create_index_handler`
+//! and directly via `super::helpers::validate_root_path`; also covers the
+//! symlink-bypass prevention and safe-path acceptance.
+//! Test: all tests in this file are collected by `cargo test -p trusty-search`.
+use super::*;
+use crate::core::embed::Embedder;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use std::sync::Arc;
+
+/// The denylist must block ~/.ssh even when called directly through the
+/// create_index HTTP handler (daemon-side guard, not just CLI).
+///
+/// Why: defense-in-depth — a direct `POST /indexes` call (bypassing the CLI)
+/// must also be refused. This test pins the server-side behavior so a refactor
+/// of `validate_root_path` can never silently remove the guard.
+/// What: calls `create_index_handler` with root_path = ~/.ssh; asserts 400 and
+/// an error body containing "indexing refused".
+/// Test: this test.
+#[tokio::test]
+async fn validate_root_path_denylist_rejects_ssh() {
+    let home = dirs::home_dir().expect("home dir required for this test");
+    let ssh_path = home.join(".ssh");
+    // Only run this test when ~/.ssh actually exists (common on developer
+    // machines); skip on environments without it to avoid a 400 for a
+    // different reason ("does not exist").
+    if !ssh_path.is_dir() {
+        return;
+    }
+
+    use crate::core::registry::IndexRegistry;
+    let state = SearchAppState::new(IndexRegistry::new());
+    let embedder: Arc<dyn Embedder> = Arc::new(crate::core::embed::MockEmbedder::new(8));
+    state.install_embedder(embedder).await;
+    let state_arc = Arc::new(state);
+
+    let resp = create_index_handler(
+        State(Arc::clone(&state_arc)),
+        Json(CreateIndexRequest {
+            id: "sensitive-ssh".into(),
+            root_path: ssh_path,
+            include_paths: None,
+            exclude_globs: None,
+            extensions: None,
+            domain_terms: None,
+            path_filter: None,
+            include_docs: None,
+            respect_gitignore: None,
+            lexical_only: None,
+            skip_kg: None,
+        }),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "~/.ssh must be refused with 400"
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 65536)
+        .await
+        .expect("body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    let err = json.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("indexing refused"),
+        "error must mention 'indexing refused', got: {err:?}"
+    );
+}
+
+/// The denylist must block $HOME itself at the daemon layer.
+///
+/// Why: indexing $HOME would capture an enormous amount of private data.
+/// This test verifies the daemon-side guard rejects it regardless of the
+/// caller (CLI bypass, direct HTTP, MCP tool).
+/// What: calls `validate_root_path` directly with the home directory and
+/// asserts an `Err` response.
+/// Test: this test.
+#[test]
+fn validate_root_path_denylist_rejects_home() {
+    let home = dirs::home_dir().expect("home dir required");
+    // Home must exist as a directory on all CI machines.
+    if !home.is_dir() {
+        return;
+    }
+    let result = super::helpers::validate_root_path(&home);
+    assert!(
+        result.is_err(),
+        "$HOME itself must be rejected by validate_root_path"
+    );
+}
+
+/// The denylist must block /tmp at the daemon layer.
+///
+/// Why: /tmp is an OS-managed ephemeral directory; indexing it is meaningless
+/// and potentially dangerous.
+/// What: creates a real sub-directory under /tmp (so the "not a dir" check
+/// passes), then calls `validate_root_path` and asserts an `Err` response.
+/// Test: this test.
+#[test]
+fn validate_root_path_denylist_rejects_tmp() {
+    // Create a real subdir under /tmp so the is_dir check passes.
+    let tmp = std::env::temp_dir().join(format!("ts-denylist-test-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    if !tmp.is_dir() {
+        // Can't create tmp dir (permission issue in this environment) — skip.
+        return;
+    }
+    let result = super::helpers::validate_root_path(&tmp);
+    let _ = std::fs::remove_dir_all(&tmp);
+    assert!(
+        result.is_err(),
+        "/tmp subdirectory must be rejected by validate_root_path"
+    );
+}
+
+/// A normal project directory must NOT be denied by `validate_root_path`.
+///
+/// Why: the denylist must not block legitimate developer project dirs.
+/// What: finds a well-known non-sensitive directory that exists on this
+/// machine and asserts `validate_root_path` returns `Ok`.
+/// Test: this test.
+#[test]
+fn validate_root_path_accepts_safe_project_dir() {
+    // Strategy: find a directory that (a) exists, (b) is not sensitive.
+    // On both macOS and Linux, /usr or /opt tend to be present and non-sensitive.
+    // We skip on systems where neither exists.
+    let candidate = [
+        std::path::Path::new("/usr/local/share"),
+        std::path::Path::new("/usr/share"),
+        std::path::Path::new("/opt"),
+        std::path::Path::new("/srv"),
+    ]
+    .iter()
+    .find(|p| p.is_dir())
+    .copied();
+
+    if let Some(path) = candidate {
+        let result = super::helpers::validate_root_path(path);
+        assert!(
+            result.is_ok(),
+            "expected Ok for safe directory {:?}, got Err",
+            path
+        );
+    }
+    // If none of the well-known paths exist (unusual CI environment), skip gracefully.
+}
+
+/// Symlink-bypass test: a symlink pointing at ~/.ssh must still be refused.
+///
+/// Why: canonicalization in `validate_root_path` resolves symlinks before
+/// the denylist check, so `ln -s ~/.ssh /tmp/safe-looking` cannot bypass it.
+/// What: creates a symlink at a temp path pointing at ~/.ssh; calls
+/// `validate_root_path` with the symlink path; asserts `Err`.
+/// Test: this test (Unix-only).
+#[cfg(unix)]
+#[test]
+fn validate_root_path_denylist_blocks_symlink_to_ssh() {
+    let home = dirs::home_dir().expect("home dir");
+    let ssh = home.join(".ssh");
+    if !ssh.is_dir() {
+        return; // No ~/.ssh on this machine — skip.
+    }
+    // Create a symlink in a non-denied location pointing at ~/.ssh.
+    // We use /tmp for the symlink itself (the link file lives there, not the target).
+    let link = std::env::temp_dir().join(format!("ts-denylist-ssh-link-{}", std::process::id()));
+    let _ = std::fs::remove_file(&link);
+    if std::os::unix::fs::symlink(&ssh, &link).is_err() {
+        return; // Cannot create symlink — skip.
+    }
+    let result = super::helpers::validate_root_path(&link);
+    let _ = std::fs::remove_file(&link);
+    assert!(
+        result.is_err(),
+        "symlink to ~/.ssh must be refused (canonicalization must resolve the symlink)"
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_denylist.rs
+++ b/crates/trusty-search/src/service/server/tests_denylist.rs
@@ -96,28 +96,61 @@ fn validate_root_path_denylist_rejects_home() {
     );
 }
 
-/// The denylist must block /tmp at the daemon layer.
+/// The denylist must block /tmp, /private/tmp, and /var/folders at the daemon
+/// layer via `validate_root_path` — tested using LITERAL path values.
 ///
-/// Why: /tmp is an OS-managed ephemeral directory; indexing it is meaningless
-/// and potentially dangerous.
-/// What: creates a real sub-directory under /tmp (so the "not a dir" check
-/// passes), then calls `validate_root_path` and asserts an `Err` response.
-/// Test: this test.
+/// Why: the previous test used `std::env::temp_dir()` which on macOS returns
+/// `/var/folders/…` (not `/tmp`). That meant the assertion "a /tmp subdir is
+/// denied" was actually testing a completely different prefix, making the test
+/// pass for the wrong reason. By constructing each path prefix that
+/// `SENSITIVE_PATH_PREFIXES` covers and asserting each one, we verify exactly
+/// the rules stated in the denylist — not the ambient OS temp directory.
+/// What: calls `validate_root_path` (which calls `is_denied` on the canonical
+/// path) with paths rooted at every prefix in `SENSITIVE_PATH_PREFIXES` that
+/// covers ephemeral OS directories. Because these directories don't exist on
+/// disk, `validate_root_path` will return `Err` at the "does not exist" check
+/// rather than the denylist check; so we test `is_denied` directly (the public
+/// function that the daemon's validate path calls after canonicalization). This
+/// validates the denylist logic in isolation — the daemon's canonical guard
+/// would apply the same check after the path is resolved.
+/// Test: this test; see also `allowlist::tests::denylist_blocks_tmp` which
+/// tests `is_denied` directly for `/tmp/my-project`.
 #[test]
-fn validate_root_path_denylist_rejects_tmp() {
-    // Create a real subdir under /tmp so the is_dir check passes.
-    let tmp = std::env::temp_dir().join(format!("ts-denylist-test-{}", std::process::id()));
-    let _ = std::fs::create_dir_all(&tmp);
-    if !tmp.is_dir() {
-        // Can't create tmp dir (permission issue in this environment) — skip.
-        return;
+fn validate_root_path_denylist_rejects_tmp_literal_paths() {
+    use crate::allowlist::{is_denied, SENSITIVE_PATH_PREFIXES};
+
+    // Build one representative sub-path for each OS-temp prefix in the denylist.
+    // These are the LITERAL prefix values from SENSITIVE_PATH_PREFIXES — not
+    // whatever std::env::temp_dir() happens to return on the current host.
+    let tmp_subpaths: &[&str] = &[
+        "/tmp/ts-denylist-probe",         // SENSITIVE_PATH_PREFIXES[0]: "/tmp/"
+        "/private/tmp/ts-denylist-probe", // SENSITIVE_PATH_PREFIXES[1]: "/private/tmp"
+        "/var/folders/ts-denylist-probe", // SENSITIVE_PATH_PREFIXES[2]: "/var/folders"
+        "/private/var/folders/ts-denylist-probe", // SENSITIVE_PATH_PREFIXES[3]: "/private/var/folders"
+    ];
+
+    // Cross-check: every path we're testing is actually covered by a prefix in
+    // the static table — this assertion documents the coupling and catches
+    // future renames of the prefix strings.
+    for subpath in tmp_subpaths {
+        let covered = SENSITIVE_PATH_PREFIXES
+            .iter()
+            .any(|prefix| subpath.starts_with(prefix));
+        assert!(
+            covered,
+            "test path {subpath:?} is not covered by any SENSITIVE_PATH_PREFIXES entry — \
+             update the test or the denylist"
+        );
     }
-    let result = super::helpers::validate_root_path(&tmp);
-    let _ = std::fs::remove_dir_all(&tmp);
-    assert!(
-        result.is_err(),
-        "/tmp subdirectory must be rejected by validate_root_path"
-    );
+
+    // Now verify is_denied rejects every literal path.
+    for subpath in tmp_subpaths {
+        let path = std::path::Path::new(subpath);
+        assert!(
+            is_denied(path).is_some(),
+            "expected is_denied to block {subpath:?} (covers SENSITIVE_PATH_PREFIXES rule)"
+        );
+    }
 }
 
 /// A normal project directory must NOT be denied by `validate_root_path`.

--- a/crates/trusty-search/src/service/server/tests_index.rs
+++ b/crates/trusty-search/src/service/server/tests_index.rs
@@ -249,10 +249,11 @@ async fn create_index_rejects_nonexistent_root_path() {
 /// `file_is_within_root` won't match.
 ///
 /// Note: `tempfile::tempdir()` creates dirs under `/tmp/` which is now in
-/// the sensitive-root denylist. This test uses a directory under
-/// `std::env::current_dir()` (the workspace root, not under /tmp) so that
+/// the sensitive-root denylist. This test uses `tempfile::Builder` with a
+/// `prefix_dir` under `target/` (which is never in the denylist) so that
 /// `validate_root_path` accepts the directory while still exercising the
-/// symlink-canonicalization logic.
+/// symlink-canonicalization logic. `TempDir` provides RAII cleanup even on
+/// panic, ensuring no leaked directories in `target/`.
 #[cfg(unix)]
 #[tokio::test]
 async fn create_index_canonicalizes_symlinked_root_path() {
@@ -265,16 +266,19 @@ async fn create_index_canonicalizes_symlinked_root_path() {
     state.install_embedder(embedder).await;
     let state_arc = Arc::new(state);
 
-    // Create a non-denied real directory under the workspace root so the
-    // denylist does not block the registration. /tmp is denied.
+    // Create the real directory under target/ (not /tmp) so the denylist allows
+    // it. TempDir provides RAII cleanup even on panic.
     let cwd = std::env::current_dir().expect("cwd");
-    let real_root = cwd.join(format!("target/test-symlink-real-{}", std::process::id()));
-    std::fs::create_dir_all(&real_root).expect("create real_root");
-    let real_root = std::fs::canonicalize(&real_root).expect("canonicalize real root");
-    let link_path = cwd.join(format!(
-        "target/trusty-search-server-symlink-{}",
-        std::process::id()
-    ));
+    let base = cwd.join("target");
+    std::fs::create_dir_all(&base).expect("create target/");
+    let real_dir = tempfile::Builder::new()
+        .prefix("ts-symlink-real-")
+        .tempdir_in(&base)
+        .expect("create real_root under target/");
+    let real_root = std::fs::canonicalize(real_dir.path()).expect("canonicalize real root");
+
+    // The symlink lives alongside the real dir (also under target/).
+    let link_path = base.join(format!("ts-symlink-link-{}", std::process::id()));
     let _ = std::fs::remove_file(&link_path);
     symlink(&real_root, &link_path).expect("create symlink");
 
@@ -298,8 +302,7 @@ async fn create_index_canonicalizes_symlinked_root_path() {
         }),
     )
     .await;
-    let _ = std::fs::remove_file(&link_path); // best-effort cleanup
-    let _ = std::fs::remove_dir_all(&real_root);
+    let _ = std::fs::remove_file(&link_path); // cleanup symlink (TempDir drops real_dir)
     assert_eq!(resp.status(), StatusCode::OK);
 
     let handle = state_arc
@@ -318,9 +321,10 @@ async fn create_index_canonicalizes_symlinked_root_path() {
 
 /// Issue #63: an absolute, existing directory must be accepted.
 ///
-/// Note: uses a non-denied path (under the workspace `target/` directory)
-/// rather than `tempfile::tempdir()` (which creates dirs under `/tmp/`,
-/// now in the sensitive-root denylist).
+/// Note: uses `tempfile::Builder` rooted under `target/` (never in the
+/// denylist) instead of `tempfile::tempdir()` (which creates dirs under
+/// `/tmp/`, now in the sensitive-root denylist). `TempDir` provides RAII
+/// cleanup even on panic — no leaked directories.
 #[tokio::test]
 async fn create_index_accepts_valid_absolute_root_path() {
     use crate::core::registry::IndexRegistry;
@@ -330,16 +334,20 @@ async fn create_index_accepts_valid_absolute_root_path() {
     state.install_embedder(embedder).await;
     let state_arc = Arc::new(state);
 
-    // Use a directory under the workspace root (not /tmp) so the denylist passes.
+    // TempDir under target/ — RAII cleanup on drop, never under /tmp/.
     let cwd = std::env::current_dir().expect("cwd");
-    let test_dir = cwd.join(format!("target/test-valid-abs-{}", std::process::id()));
-    std::fs::create_dir_all(&test_dir).expect("create test_dir");
+    let base = cwd.join("target");
+    std::fs::create_dir_all(&base).expect("create target/");
+    let test_dir = tempfile::Builder::new()
+        .prefix("ts-valid-abs-")
+        .tempdir_in(&base)
+        .expect("create test_dir under target/");
 
     let resp = create_index_handler(
         State(Arc::clone(&state_arc)),
         Json(CreateIndexRequest {
             id: "valid-abs".into(),
-            root_path: test_dir.clone(),
+            root_path: test_dir.path().to_path_buf(),
             include_paths: None,
             exclude_globs: None,
             extensions: None,
@@ -352,7 +360,7 @@ async fn create_index_accepts_valid_absolute_root_path() {
         }),
     )
     .await;
-    let _ = std::fs::remove_dir_all(&test_dir); // best-effort cleanup
+    // test_dir is dropped here → RAII cleanup
     assert_eq!(resp.status(), StatusCode::OK);
 }
 // Denylist tests live in `tests_denylist.rs` (split to keep this file ≤ 500 lines).

--- a/crates/trusty-search/src/service/server/tests_index.rs
+++ b/crates/trusty-search/src/service/server/tests_index.rs
@@ -247,6 +247,12 @@ async fn create_index_rejects_nonexistent_root_path() {
 /// the symlink alias, the walker emits file paths under the alias, and
 /// search queries from the canonical mount point return zero hits because
 /// `file_is_within_root` won't match.
+///
+/// Note: `tempfile::tempdir()` creates dirs under `/tmp/` which is now in
+/// the sensitive-root denylist. This test uses a directory under
+/// `std::env::current_dir()` (the workspace root, not under /tmp) so that
+/// `validate_root_path` accepts the directory while still exercising the
+/// symlink-canonicalization logic.
 #[cfg(unix)]
 #[tokio::test]
 async fn create_index_canonicalizes_symlinked_root_path() {
@@ -259,11 +265,14 @@ async fn create_index_canonicalizes_symlinked_root_path() {
     state.install_embedder(embedder).await;
     let state_arc = Arc::new(state);
 
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let real_root = std::fs::canonicalize(tmp.path()).expect("canonicalize real root");
-    let parent = real_root.parent().expect("tempdir has parent");
-    let link_path = parent.join(format!(
-        "trusty-search-server-symlink-{}",
+    // Create a non-denied real directory under the workspace root so the
+    // denylist does not block the registration. /tmp is denied.
+    let cwd = std::env::current_dir().expect("cwd");
+    let real_root = cwd.join(format!("target/test-symlink-real-{}", std::process::id()));
+    std::fs::create_dir_all(&real_root).expect("create real_root");
+    let real_root = std::fs::canonicalize(&real_root).expect("canonicalize real root");
+    let link_path = cwd.join(format!(
+        "target/trusty-search-server-symlink-{}",
         std::process::id()
     ));
     let _ = std::fs::remove_file(&link_path);
@@ -290,6 +299,7 @@ async fn create_index_canonicalizes_symlinked_root_path() {
     )
     .await;
     let _ = std::fs::remove_file(&link_path); // best-effort cleanup
+    let _ = std::fs::remove_dir_all(&real_root);
     assert_eq!(resp.status(), StatusCode::OK);
 
     let handle = state_arc
@@ -307,6 +317,10 @@ async fn create_index_canonicalizes_symlinked_root_path() {
 }
 
 /// Issue #63: an absolute, existing directory must be accepted.
+///
+/// Note: uses a non-denied path (under the workspace `target/` directory)
+/// rather than `tempfile::tempdir()` (which creates dirs under `/tmp/`,
+/// now in the sensitive-root denylist).
 #[tokio::test]
 async fn create_index_accepts_valid_absolute_root_path() {
     use crate::core::registry::IndexRegistry;
@@ -315,12 +329,17 @@ async fn create_index_accepts_valid_absolute_root_path() {
     let embedder: Arc<dyn Embedder> = Arc::new(crate::core::embed::MockEmbedder::new(8));
     state.install_embedder(embedder).await;
     let state_arc = Arc::new(state);
-    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Use a directory under the workspace root (not /tmp) so the denylist passes.
+    let cwd = std::env::current_dir().expect("cwd");
+    let test_dir = cwd.join(format!("target/test-valid-abs-{}", std::process::id()));
+    std::fs::create_dir_all(&test_dir).expect("create test_dir");
+
     let resp = create_index_handler(
         State(Arc::clone(&state_arc)),
         Json(CreateIndexRequest {
             id: "valid-abs".into(),
-            root_path: tmp.path().to_path_buf(),
+            root_path: test_dir.clone(),
             include_paths: None,
             exclude_globs: None,
             extensions: None,
@@ -333,5 +352,7 @@ async fn create_index_accepts_valid_absolute_root_path() {
         }),
     )
     .await;
+    let _ = std::fs::remove_dir_all(&test_dir); // best-effort cleanup
     assert_eq!(resp.status(), StatusCode::OK);
 }
+// Denylist tests live in `tests_denylist.rs` (split to keep this file ≤ 500 lines).

--- a/crates/trusty-search/src/service/server/tests_state.rs
+++ b/crates/trusty-search/src/service/server/tests_state.rs
@@ -36,15 +36,19 @@ async fn create_index_returns_503_with_error_when_embedder_failed() {
         .install_embedder_error("init timed out after 60s")
         .await;
     let state_arc = Arc::new(state);
-    // Use a real tempdir so the issue #63 root_path validator (which now
-    // runs ahead of the embedder check) accepts the path and the
-    // handler proceeds to the embedder-error branch we're asserting on.
-    let tmp = tempfile::tempdir().expect("tempdir");
+    // Use a real non-denied directory so the `validate_root_path` guard
+    // (issue #63 + index-denylist) accepts the path and the handler
+    // proceeds to the embedder-error branch we're asserting on.
+    // Note: `tempfile::tempdir()` creates dirs under /tmp which is now
+    // in the sensitive-root denylist — use target/ under the workspace root.
+    let cwd = std::env::current_dir().expect("cwd");
+    let test_dir = cwd.join(format!("target/test-embedder-fail-{}", std::process::id()));
+    std::fs::create_dir_all(&test_dir).expect("create test_dir");
     let resp = create_index_handler(
         State(state_arc),
         Json(CreateIndexRequest {
             id: "demo".to_string(),
-            root_path: tmp.path().to_path_buf(),
+            root_path: test_dir.clone(),
             include_paths: None,
             exclude_globs: None,
             extensions: None,
@@ -74,6 +78,7 @@ async fn create_index_returns_503_with_error_when_embedder_failed() {
         err_str.contains("init timed out after 60s"),
         "expected recorded timeout message to be surfaced, got: {err_str}",
     );
+    let _ = std::fs::remove_dir_all(&test_dir); // best-effort cleanup
 }
 
 /// Issue #121: after the embedder is installed successfully, a previously

--- a/crates/trusty-search/src/service/server/tests_state.rs
+++ b/crates/trusty-search/src/service/server/tests_state.rs
@@ -41,14 +41,17 @@ async fn create_index_returns_503_with_error_when_embedder_failed() {
     // proceeds to the embedder-error branch we're asserting on.
     // Note: `tempfile::tempdir()` creates dirs under /tmp which is now
     // in the sensitive-root denylist — use target/ under the workspace root.
-    let cwd = std::env::current_dir().expect("cwd");
-    let test_dir = cwd.join(format!("target/test-embedder-fail-{}", std::process::id()));
-    std::fs::create_dir_all(&test_dir).expect("create test_dir");
+    let base = std::env::current_dir().expect("cwd").join("target");
+    std::fs::create_dir_all(&base).ok();
+    let test_dir = tempfile::Builder::new()
+        .prefix("ts-embedder-fail-")
+        .tempdir_in(&base)
+        .expect("create test_dir under target/");
     let resp = create_index_handler(
         State(state_arc),
         Json(CreateIndexRequest {
             id: "demo".to_string(),
-            root_path: test_dir.clone(),
+            root_path: test_dir.path().to_path_buf(),
             include_paths: None,
             exclude_globs: None,
             extensions: None,
@@ -78,7 +81,6 @@ async fn create_index_returns_503_with_error_when_embedder_failed() {
         err_str.contains("init timed out after 60s"),
         "expected recorded timeout message to be surfaced, got: {err_str}",
     );
-    let _ = std::fs::remove_dir_all(&test_dir); // best-effort cleanup
 }
 
 /// Issue #121: after the embedder is installed successfully, a previously


### PR DESCRIPTION
## Summary

- **Daemon guard**: `validate_root_path` in `service/server/helpers.rs` now calls `allowlist::is_denied()` after `std::fs::canonicalize()`. Symlinks resolving to a sensitive root are refused before any index is created. Returns `HTTP 400 {"error":"indexing refused: <reason>"}`.
- **CLI early check**: `commands/index.rs` (block 0a) calls `is_denied()` before contacting the daemon — defense-in-depth so the user gets a clear error even without a running daemon.
- **5 new tests** in `service/server/tests_denylist.rs`: rejects `~/.ssh`, rejects `$HOME` itself, rejects `/tmp`, accepts a safe project dir, and refuses a symlink that resolves to `~/.ssh` (unix-only).

## Denylist coverage

Enforced via the existing `crate::allowlist::is_denied()` — already covers:

| Category | Examples |
|---|---|
| Home top-level dirs | `$HOME` itself, `~/Desktop`, `~/Downloads`, `~/Documents`, `~/Library` |
| Hidden credential dirs | `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube`, `~/.config` |
| Sensitive component names | `.ssh`, `.aws`, `.gnupg`, `.kube`, `secrets`, `credentials`, `.env`, … |
| Temp/system paths | `/tmp`, `/private/tmp`, `/var/folders`, `/Library/Application Support` |

Legitimate project directories (e.g. `~/Projects/my-app`) are accepted.

## Files changed

| File | Change |
|---|---|
| `crates/trusty-search/src/service/server/helpers.rs` | Add `is_denied()` guard after canonicalization |
| `crates/trusty-search/src/service/server/mod.rs` | Register new `tests_denylist` test module |
| `crates/trusty-search/src/service/server/tests_denylist.rs` | **New** — 5 denylist tests |
| `crates/trusty-search/src/service/server/tests_index.rs` | Fix `/tmp`-based temp dirs; move denylist tests out |
| `crates/trusty-search/src/service/server/tests_state.rs` | Fix `/tmp`-based temp dir |
| `crates/trusty-search/src/commands/index.rs` | Add CLI-side denylist check (block 0a) |
| `crates/trusty-search/src/commands/index_persist.rs` | **New** — extracted `persist_collection_to_global_config` to keep `index.rs` under 500-line cap |
| `crates/trusty-search/src/commands/mod.rs` | Register `index_persist` module |

LOC delta: +363 / -80 = +283 net (mostly new tests + extracted module)

## Test plan

- [x] `cargo test -p trusty-search` — 795 tests pass, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — no drift
- [x] `bash scripts/check_line_cap.sh` — 172 allowlisted, 0 violations
- [x] Pre-commit hooks pass (line-cap, secrets, trailing-whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)