### PR TITLE
ci: free disk space on workspace-build jobs (fix linker 'No space left on device')

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Free disk space
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost /usr/local/share/powershell \
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
+
       - name: Install stable toolchain with clippy
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -130,6 +139,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Free disk space
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost /usr/local/share/powershell \
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
 
       # trusty-agents's git tests (list_branches_includes_current) assert that the
       # local branch list includes "main". GitHub Actions PR checkouts only create
@@ -183,6 +201,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
+
+      - name: Free disk space
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost /usr/local/share/powershell \
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
 
       - name: Install Rust 1.91 toolchain
         uses: dtolnay/rust-toolchain@1.91


### PR DESCRIPTION
## Summary

- `ubuntu-latest` runners start with only ~21 GB free on `/`; `cargo test --workspace` in debug mode (all crates + every test binary, debuginfo=2, tree-sitter ×16, onnxruntime, aws-sdk, image/av1 codecs, usearch) overflows the filesystem, producing `No space left on device (os error 28)` → `collect2: ld terminated with signal 7 [Bus error]`, which deterministically blocks every PR
- Add a **"Free disk space"** step to the three workspace-build jobs (**Test**, **Clippy**, **MSRV check**) that removes pre-installed non-Rust SDKs (dotnet, Android SDK, GHC, Boost, PowerShell, Swift, hosted tool cache) and prunes Docker images — reclaiming ~25–30 GB so the total headroom rises to ~46–51 GB
- **Format check** is intentionally excluded: it runs only `cargo fmt --check` and does not build binaries, so it never approaches the limit
- The `rust-cache` configuration and `CARGO_TARGET_DIR` are left untouched; the freed space alone is enough

## What is removed (safe for Rust)

| Path removed | Why safe |
|---|---|
| `/usr/share/dotnet` | .NET SDK, ~1.5 GB |
| `/opt/ghc` | Haskell GHC, ~500 MB |
| `/usr/local/lib/android` | Android SDK, ~9 GB |
| `/usr/local/share/boost` | Boost headers, ~1 GB |
| `/usr/local/share/powershell` | PowerShell, ~500 MB |
| `/usr/share/swift` | Swift toolchain, ~2 GB |
| `${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}` | Tool cache for Node/Java/Python setup-* actions (not used here — Rust is installed under `~/.rustup`/`~/.cargo` by `dtolnay/rust-toolchain`) |
| Docker images | `docker image prune --all --force`, typically ~3–4 GB |

All paths use `|| true` so a missing path never fails the job. `df -h /` is printed before and after for visibility in CI logs.

## Validation

This PR is self-validating: when CI runs on this PR branch, the modified workflow is used, so its own Test/Clippy/MSRV jobs exercise the fix. No local cargo run is needed for a workflow-only change.

Fixes the SIGBUS linker failures blocking all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)