### PR TITLE
docs: hygiene sweep (MSRV comment, analyze publish note, memory spec v0.15, review doc dirs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,10 @@
 # with local branch refs and commit history. The test job uses fetch-depth: 0
 # to ensure a full (non-shallow) clone is present.
 #
-# MSRV NOTE: [workspace.package] rust-version = "1.88" in Cargo.toml is STALE.
-# The current Cargo.lock pulls aws-sdk-* / aws-smithy-* crates at versions that
-# declare rust-version = "1.91.1". The effective MSRV is therefore 1.91, not 1.88.
-# The msrv job below is pinned to 1.91 to reflect reality. The Cargo.toml
-# rust-version field should be updated to "1.91" in a follow-up commit.
+# MSRV NOTE: the effective MSRV is 1.91, declared as [workspace.package]
+# rust-version = "1.91" in the root Cargo.toml. It is driven by indirect
+# aws-sdk-* / aws-smithy-* crates that declare rust-version = "1.91.1". The
+# msrv job below pins dtolnay/rust-toolchain@1.91 to enforce this floor.
 
 name: CI
 
@@ -188,12 +187,11 @@ jobs:
   # is that the code *compiles* on the minimum toolchain, not that tests pass.
   # trusty-mpm-gui excluded: see clippy note above.
   #
-  # Toolchain is 1.91 — NOT the 1.88 declared in [workspace.package].rust-version.
-  # The current Cargo.lock pulls aws-sdk-*/aws-smithy-* at versions that require
-  # rustc >= 1.91.1. [workspace.package].rust-version = "1.88" in the root
-  # Cargo.toml is therefore stale and should be updated to "1.91". This CI job
-  # enforces the real minimum; the Cargo.toml value is a known inconsistency
-  # tracked as a follow-up: bump rust-version to 1.91 in Cargo.toml.
+  # Toolchain is 1.91, matching [workspace.package].rust-version = "1.91" in the
+  # root Cargo.toml. The current Cargo.lock pulls aws-sdk-*/aws-smithy-* at
+  # versions that require rustc >= 1.91.1, which sets the effective MSRV. This
+  # job pins the toolchain to that floor so the workspace is guaranteed to
+  # compile on the declared minimum.
   # --------------------------------------------------------------------------
   msrv:
     name: MSRV check (1.91)

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -131,6 +131,20 @@ trusty-analyze analyze <index-id> --top-k 20
 trusty-analyze health
 ```
 
+### Ops health check
+
+Probe the daemon over HTTP without the CLI — useful for monitoring, systemd
+`ExecStartPost`, or container readiness probes:
+
+```bash
+curl http://127.0.0.1:7879/health
+# → {"status":"ok","search_reachable":true}
+```
+
+`search_reachable` reflects whether the upstream `trusty-search` daemon (port
+7878) is responding; a `false` here means analysis endpoints will fail even
+though the analyzer process itself is up.
+
 ## Features
 
 - Cyclomatic and cognitive complexity per chunk, file, and index
@@ -308,6 +322,24 @@ cargo clippy -p trusty-analyze --all-targets -- -D warnings
 ```
 
 See [CLAUDE.md](./CLAUDE.md) for full architecture, API reference, and project history.
+
+## Publishing
+
+`trusty-analyze` is a **UI-embedding crate**: its `build.rs` invokes `pnpm` to
+build the embedded Svelte dashboard served from `src/service/` unless told to
+skip it. When publishing, always set `SKIP_UI_BUILD=1` so the committed
+`ui-dist/` bundle is used as-is:
+
+```bash
+SKIP_UI_BUILD=1 cargo publish -p trusty-analyze
+```
+
+Without the flag, `cargo publish` runs `build.rs` inside the verification
+tarball, where `pnpm` tries to write outside `OUT_DIR` and the publish fails.
+The same flag applies to the sibling UI-embedding crates (`trusty-search`,
+`trusty-memory`). See the workspace release workflow in the root
+[CLAUDE.md](../../CLAUDE.md) and the `cargo-publish` skill for the full
+tag → publish → install sequence (`trusty-analyze-v<version>`).
 
 ## License
 

--- a/docs/trusty-memory/spec/ARCHITECTURE.md
+++ b/docs/trusty-memory/spec/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # trusty-memory — System Architecture
 
 > **Status:** Canonical · Living Document
-> **Last reviewed:** 2026-06-01
-> **Derived from:** code/docs/tickets audit (v0.14.0)
+> **Last reviewed:** 2026-06-08
+> **Derived from:** code/docs/tickets audit (v0.15.0)
 
 **Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
 
@@ -10,6 +10,22 @@ This document describes how trusty-memory fits together: the **frontend/core
 split**, the multi-transport model, the bundled BM25 sidecar, the fire-and-forget
 remember path, the storage model, the progressive-retrieval layering, and the
 source-module map.
+
+## 0.15.0 changes
+
+This revision refreshes the spec to v0.15.0. The changes affecting architecture:
+
+- **redb 4.x store migration (#702)** — all embedded redb stores (activity and
+  memory) were upgraded from redb 2.x to 4.x. Existing 2.x stores are detected as
+  incompatible on first start, backed up to `*.v2-incompatible`, and recreated
+  empty (graceful recovery rather than a hard failure). This affects the storage
+  model below — the on-disk format is no longer interchangeable with pre-0.15.0
+  daemons.
+- **Dashboard auto-start (#687)** — the embedded Svelte web UI dashboard now
+  auto-starts on first daemon launch; no separate manual invocation is required.
+- **`add_alias` / `discover_aliases` optional `palace` param (#664)** — both MCP
+  tools now accept an optional `palace` argument to scope alias operations to a
+  specific palace instead of the active/default one.
 
 Module paths under `memory_core/` refer to
 `crates/trusty-common/src/memory_core/`; all other paths refer to

--- a/docs/trusty-memory/spec/PRD.md
+++ b/docs/trusty-memory/spec/PRD.md
@@ -1,11 +1,26 @@
 # trusty-memory — Product Requirements Document
 
 > **Status:** Canonical · Living Document
-> **Last reviewed:** 2026-06-01
-> **Derived from:** code/docs/tickets audit (v0.14.0)
+> **Last reviewed:** 2026-06-08
+> **Derived from:** code/docs/tickets audit (v0.15.0)
 
 **Status legend:** ✅ Implemented · 🟡 Partial · 🔵 Designed-not-built · ⚪ Aspirational
 Each requirement is framed **Vision / Current / Gap**.
+
+## 0.15.0 changes
+
+This revision refreshes the PRD to v0.15.0. Product-visible changes since v0.14.0:
+
+- **redb 4.x store migration (#702)** — embedded activity and memory stores moved
+  from redb 2.x to 4.x. On first start after upgrade, incompatible 2.x stores are
+  backed up to `*.v2-incompatible` and recreated empty (graceful recovery, no
+  crash). Operators upgrading from <0.15.0 should expect a one-time reset of these
+  stores.
+- **Dashboard auto-start (#687)** — the web UI dashboard auto-starts on first
+  daemon launch; operators no longer need a manual command to bring it up.
+- **`add_alias` / `discover_aliases` optional `palace` param (#664)** — both MCP
+  tools now accept an optional `palace` argument so callers can scope alias
+  operations to a named palace.
 
 ---
 

--- a/docs/trusty-review/regression-testing/README.md
+++ b/docs/trusty-review/regression-testing/README.md
@@ -1,0 +1,82 @@
+# Regression Testing & Benchmark Snapshots
+
+This folder contains snapshots of [trusty-review](../../../crates/trusty-review/) review-quality and performance benchmarks, one per release that is measured.
+
+## Purpose
+
+Snapshots in this folder provide:
+- **Baseline data** for each release: review-finding precision/recall, verdict accuracy, end-to-end latency, token cost
+- **Historical context**: Quality and performance trajectory across releases
+- **Regression detection**: Spot anomalies when new releases ship
+- **Investigation artifacts**: Raw results for deep-dive analysis when regressions are detected
+
+## Methodology
+
+All benchmarks should use a consistent setup so snapshots are comparable release-over-release:
+
+**Corpus**: a fixed set of reference PRs (or synthetic diffs) with known expected findings.
+
+**Comparators** (where applicable):
+- The previous trusty-review release — primary regression comparator
+- A raw "LLM-only, no context" review — to measure the value added by search/analyze context
+
+**Metrics** (adapt to the suite that lands):
+- **Finding precision / recall**: Fraction of surfaced findings that are real / fraction of seeded issues caught
+- **Verdict accuracy**: Agreement of the structured verdict with the expected outcome
+- **Latency**: End-to-end review time (diff fetch + context retrieval + LLM call), reported as mean / p50 / p95
+- **Token cost**: Prompt + completion tokens per review (proxy for $ cost)
+
+## File Naming Convention
+
+```
+v{VERSION}-{YYYY-MM-DD}.md
+```
+
+Examples:
+- `v0.3.6-2026-06-08.md` — v0.3.6 benchmarked on June 8, 2026
+- `v0.4.0-2026-07-01.md` — v0.4.0 benchmarked on July 1, 2026
+
+Alternate-corpus baselines (e.g. a synthetic-diff suite) live alongside the
+version snapshots with a descriptive name, e.g.
+`synthetic-corpus-baseline-{YYYY-MM-DD}.md`.
+
+## Snapshot Index
+
+_No snapshots recorded yet._
+
+### Latest
+
+`current.md` — symlink to the latest version snapshot. Create it when the first
+snapshot lands:
+
+```bash
+ln -sf v{VERSION}-{YYYY-MM-DD}.md docs/trusty-review/regression-testing/current.md
+```
+
+## Adding a New Snapshot
+
+When benchmarking a release:
+
+1. **Run the review benchmark suite** against the fixed reference-PR corpus.
+2. **Record results** in a new file following the naming convention:
+   ```
+   docs/trusty-review/regression-testing/v{VERSION}-{YYYY-MM-DD}.md
+   ```
+3. **Update the `current.md` symlink** to point at the new snapshot.
+4. **File a regression bug** if any primary quality metric (precision, recall, or
+   verdict accuracy) regresses materially versus the prior release.
+
+## Snapshot Structure
+
+Each snapshot `.md` file should include:
+
+- **Header**: Version, date, corpus state (PR count / diff size, model id used)
+- **Summary table**: Per-PR expected vs. actual findings and verdict
+- **Aggregate metrics**: Precision, recall, verdict accuracy, latency stats, token cost
+- **Anomalies**: Any unexpected per-PR results or performance patterns
+- **Relevant PRs/fixes**: Links to issues/PRs that landed in this release
+- **Cross-links**: Link to related tickets and the sessions narrative for the release
+
+---
+
+**Related**: [Session Summaries Index](../sessions/README.md) | [Research & Decision Documents Index](../research/README.md) | [Spec](../spec/)

--- a/docs/trusty-review/sessions/README.md
+++ b/docs/trusty-review/sessions/README.md
@@ -1,0 +1,27 @@
+# Session Summaries
+
+This folder contains session-summary documents that capture the trajectory, decisions, and empirical findings of individual engineering sessions for [trusty-review](../../../crates/trusty-review/).
+
+## Purpose
+
+Session documents provide:
+- **Narrative context**: The arc from problem statement to shipped features
+- **Decision rationale**: Why each architectural choice was made in sequence
+- **Empirical evidence**: Review-quality and latency findings that shaped each decision
+- **Prioritized backlogs**: What shipped, what's blocked, and why
+
+These are distinct from [regression-testing/](../regression-testing/) (which tracks metrics over time), [research/](../research/) (which captures isolated investigation artifacts), and [spec/](../spec/) (which holds the canonical PRD/architecture).
+
+## Naming Convention
+
+`SESSION-<YYYY-MM-DD>-<topic>.md`
+
+Example: `SESSION-2026-06-08-review-health.md`
+
+## Session Summaries
+
+_None yet. Add new session narratives here following the naming convention above._
+
+---
+
+**Related**: [Regression Testing Index](../regression-testing/README.md) | [Research & Decision Documents Index](../research/README.md) | [Spec](../spec/)


### PR DESCRIPTION
Docs-only hygiene sweep — no Rust code changes. Closes four tracked doc issues in one PR.

## Changes

- **(closes #944) CI MSRV comments** — `.github/workflows/ci.yml` had two stale comment blocks claiming `[workspace.package] rust-version = "1.88"` was STALE and "should be updated to 1.91". The root `Cargo.toml` already reads `rust-version = "1.91"`. Rewrote both comments to state the effective MSRV is 1.91, enforced by the pinned `dtolnay/rust-toolchain@1.91`. No job logic changed.
- **(closes #945) trusty-analyze publish note + health idiom** — `crates/trusty-analyze/README.md` gained a `## Publishing` section documenting that this is a UI-embedding crate and must be published with `SKIP_UI_BUILD=1 cargo publish -p trusty-analyze` (otherwise `build.rs` runs `pnpm` in the verification tarball and fails). Also added an ops health-check idiom near Quick Start: `curl http://127.0.0.1:7879/health` → `{"status":"ok","search_reachable":true}`.
- **(closes #946) trusty-memory spec v0.15.0** — bumped `docs/trusty-memory/spec/ARCHITECTURE.md` and `PRD.md` headers from v0.14.0 / 2026-06-01 to v0.15.0 / 2026-06-08, and added a `## 0.15.0 changes` subsection to each summarizing redb 4.x store migration (#702), dashboard auto-start (#687), and `add_alias`/`discover_aliases` optional palace param (#664). Specifics pulled from `crates/trusty-memory/CHANGELOG.md`.
- **(closes #947) trusty-review doc subdirs** — created `docs/trusty-review/sessions/README.md` and `docs/trusty-review/regression-testing/README.md` per the CLAUDE.md three-subdir convention, modeled on the trusty-search worked examples and adapted for a PR-review service. No baseline snapshot fabricated (that is #948) — README scaffolds only.

Closes #944, #945, #946, #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)