### PR TITLE
fix(trusty-analyze): route Kotlin/Swift/Ruby/PHP files to their linters (closes #963)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -21,7 +21,6 @@ crates/trusty-analyze/src/lang/adapters/rust.rs	530
 crates/trusty-analyze/src/lang/adapters/scala.rs	583
 crates/trusty-analyze/src/lang/adapters/swift.rs	531
 crates/trusty-analyze/src/lang/adapters/typescript.rs	680
-crates/trusty-analyze/src/lang/detection.rs	616
 crates/trusty-analyze/src/main.rs	870
 crates/trusty-analyze/src/mcp/mod.rs	1178
 crates/trusty-analyze/tests/stdio_harness.rs	639

--- a/crates/trusty-analyze/src/core/tool_impls/typescript.rs
+++ b/crates/trusty-analyze/src/core/tool_impls/typescript.rs
@@ -25,6 +25,14 @@ impl StaticTool for BiomeTool {
         "typescript"
     }
 
+    /// Why: biome lints JavaScript as well as TypeScript, but the router maps
+    /// `.js/.jsx/.mjs/.cjs` to the `"javascript"` tag. Without this alias that
+    /// bucket holds no tool and every JS file is silently skipped — the JS half
+    /// of the #963 class of "routed-but-no-tool" bug.
+    fn aliases(&self) -> &[&str] {
+        &["javascript"]
+    }
+
     fn is_available(&self) -> bool {
         which::which("biome").is_ok()
     }
@@ -142,5 +150,14 @@ mod tests {
         assert_eq!(severity_from_str("warning"), Severity::Warning);
         assert_eq!(severity_from_str("information"), Severity::Info);
         assert_eq!(severity_from_str("other"), Severity::Hint);
+    }
+
+    #[test]
+    fn biome_covers_typescript_and_javascript() {
+        // biome lints both; the router maps .ts/.tsx → "typescript" and
+        // .js/.jsx/.mjs/.cjs → "javascript", so the tool must claim both or
+        // JS files are silently skipped.
+        assert_eq!(BiomeTool.language(), "typescript");
+        assert_eq!(BiomeTool.aliases(), &["javascript"]);
     }
 }

--- a/crates/trusty-analyze/src/core/tool_registry.rs
+++ b/crates/trusty-analyze/src/core/tool_registry.rs
@@ -41,10 +41,6 @@ impl ToolRegistry {
     /// `is_available()` is true, and buckets them by `language()`.
     /// Test: `discover_does_not_panic` ensures construction is total.
     pub fn discover() -> Self {
-        let registry = ToolRegistry {
-            tools: DashMap::new(),
-        };
-
         let all_tools: Vec<Arc<dyn StaticTool>> = vec![
             Arc::new(ClippyTool),
             Arc::new(RuffTool),
@@ -57,6 +53,23 @@ impl ToolRegistry {
             Arc::new(DetektTool),
             Arc::new(ClangtidyTool),
         ];
+        Self::from_tools(all_tools)
+    }
+
+    /// Build a registry from an explicit tool list: keep the available ones and
+    /// bucket each under its primary [`language`](StaticTool::language) plus any
+    /// [`aliases`](StaticTool::aliases).
+    ///
+    /// Why: separating the fanout from the hardcoded tool list lets tests
+    /// exercise alias registration with a synthetic always-available tool,
+    /// without depending on which binaries happen to be installed on the host.
+    /// What: probes `is_available()`, then for each kept tool inserts an `Arc`
+    /// clone into every bucket it claims.
+    /// Test: `aliases_register_tool_under_every_bucket`.
+    fn from_tools(all_tools: Vec<Arc<dyn StaticTool>>) -> Self {
+        let registry = ToolRegistry {
+            tools: DashMap::new(),
+        };
 
         for tool in all_tools {
             if tool.is_available() {
@@ -65,11 +78,16 @@ impl ToolRegistry {
                     language = tool.language(),
                     "static tool available"
                 );
-                registry
-                    .tools
-                    .entry(tool.language().to_string())
-                    .or_default()
-                    .push(tool);
+                // Register under the primary language tag plus every alias, so
+                // a multi-language linter (e.g. biome → typescript + javascript)
+                // is reachable from each bucket its files route to.
+                for lang in std::iter::once(tool.language()).chain(tool.aliases().iter().copied()) {
+                    registry
+                        .tools
+                        .entry(lang.to_string())
+                        .or_default()
+                        .push(Arc::clone(&tool));
+                }
             } else {
                 tracing::debug!(tool = tool.name(), "static tool not available");
             }
@@ -178,5 +196,42 @@ mod tests {
         let a = global_registry() as *const ToolRegistry;
         let b = global_registry() as *const ToolRegistry;
         assert_eq!(a, b, "global registry must be a singleton");
+    }
+
+    /// A synthetic always-available tool that claims a primary language plus an
+    /// alias, so alias registration can be tested without any binary on PATH.
+    struct FakeAliasedTool;
+    impl StaticTool for FakeAliasedTool {
+        fn name(&self) -> &str {
+            "fake-aliased"
+        }
+        fn language(&self) -> &str {
+            "typescript"
+        }
+        fn aliases(&self) -> &[&str] {
+            &["javascript"]
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn run(&self, _file: &Path, _content: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn aliases_register_tool_under_every_bucket() {
+        // Regression: a multi-language linter (biome → typescript + javascript)
+        // must be reachable from its alias bucket, or files routed to that tag
+        // are silently skipped (the JS half of the #963 class of bug).
+        let r = ToolRegistry::from_tools(vec![Arc::new(FakeAliasedTool)]);
+        assert_eq!(r.tools_for("typescript").len(), 1, "primary bucket");
+        assert_eq!(
+            r.tools_for("javascript").len(),
+            1,
+            "alias bucket must be reachable"
+        );
+        assert_eq!(r.tools_for("typescript")[0].name(), "fake-aliased");
+        assert_eq!(r.tools_for("javascript")[0].name(), "fake-aliased");
     }
 }

--- a/crates/trusty-analyze/src/core/tools.rs
+++ b/crates/trusty-analyze/src/core/tools.rs
@@ -72,8 +72,8 @@ pub trait StaticTool: Send + Sync {
     /// skipped (the JS half of the #963 class of bug). Defaults to no aliases.
     /// What: each returned tag gets its own registry entry pointing at this
     /// tool, in addition to `language()`.
-    /// Test: `discover_registers_biome_under_javascript_alias` in
-    /// `tool_registry`.
+    /// Test: `aliases_register_tool_under_every_bucket` and
+    /// `biome_covers_typescript_and_javascript`.
     fn aliases(&self) -> &[&str] {
         &[]
     }

--- a/crates/trusty-analyze/src/core/tools.rs
+++ b/crates/trusty-analyze/src/core/tools.rs
@@ -63,6 +63,21 @@ pub trait StaticTool: Send + Sync {
     /// (`"rust"`, `"python"`, `"typescript"`, ...).
     fn language(&self) -> &str;
 
+    /// Additional language buckets this tool should also be registered under,
+    /// beyond its primary [`language`](Self::language).
+    ///
+    /// Why: a single binary often lints several `LanguageDetector` tags — e.g.
+    /// biome lints both `"typescript"` and `"javascript"`. Without this, files
+    /// routed to the secondary tag find an empty bucket and are silently
+    /// skipped (the JS half of the #963 class of bug). Defaults to no aliases.
+    /// What: each returned tag gets its own registry entry pointing at this
+    /// tool, in addition to `language()`.
+    /// Test: `discover_registers_biome_under_javascript_alias` in
+    /// `tool_registry`.
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+
     /// Cheap availability probe — confirms the backing binary is on `PATH`.
     fn is_available(&self) -> bool;
 

--- a/crates/trusty-analyze/src/lang/detection/frameworks.rs
+++ b/crates/trusty-analyze/src/lang/detection/frameworks.rs
@@ -1,0 +1,311 @@
+//! Manifest-content-based framework inference.
+//!
+//! Why: framework-specific conventions differ significantly from generic
+//! language rules; knowing the framework allows targeted anti-pattern
+//! detection (e.g. Next.js server/client component boundaries, Rails strong
+//! params, Django ORM patterns). Unlike the extension heuristics in the parent
+//! module, this pass *reads* manifest file contents from the project root.
+//!
+//! What: [`detect_frameworks`] inspects package.json, Cargo.toml, Gemfile,
+//! pyproject.toml/requirements.txt, pom.xml/build.gradle, pubspec.yaml, and
+//! composer.json, returning deduplicated, sorted framework name strings.
+//!
+//! Test: unit tests in this module cover each manifest type (see
+//! `detect_frameworks_*`).
+
+use std::path::Path;
+
+/// Why: framework-specific conventions differ significantly from generic
+/// language rules; knowing the framework allows targeted anti-pattern
+/// detection (e.g. Next.js server/client component boundaries, Rails strong
+/// params, Django ORM patterns).
+/// What: reads manifest file contents from the project root and infers
+/// framework names from declared dependencies. Returns deduplicated, sorted
+/// framework name strings.
+/// Test: unit tests in this module covering each manifest type (see
+/// `detect_frameworks_*`).
+pub fn detect_frameworks(project_root: &Path) -> Vec<String> {
+    let mut found: Vec<&'static str> = Vec::new();
+
+    // package.json — JSON parse `dependencies` + `devDependencies`.
+    if let Some(text) = read_manifest(project_root, "package.json") {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+            let mut seen_keys: Vec<String> = Vec::new();
+            for field in ["dependencies", "devDependencies"] {
+                if let Some(obj) = v.get(field).and_then(serde_json::Value::as_object) {
+                    for k in obj.keys() {
+                        seen_keys.push(k.clone());
+                    }
+                }
+            }
+            for key in &seen_keys {
+                if let Some(name) = match key.as_str() {
+                    "next" => Some("Next.js"),
+                    "react" => Some("React"),
+                    "vue" => Some("Vue"),
+                    "svelte" => Some("Svelte"),
+                    "@angular/core" => Some("Angular"),
+                    "vite" => Some("Vite"),
+                    _ => None,
+                } {
+                    push_unique(&mut found, name);
+                }
+            }
+        }
+    }
+
+    // Cargo.toml — simple text scan against `[dependencies]` table keys.
+    if let Some(text) = read_manifest(project_root, "Cargo.toml") {
+        if cargo_has_dep(&text, "axum") {
+            push_unique(&mut found, "Axum");
+        }
+        if cargo_has_dep(&text, "actix-web") {
+            push_unique(&mut found, "Actix-Web");
+        }
+        if cargo_has_dep(&text, "rocket") {
+            push_unique(&mut found, "Rocket");
+        }
+    }
+
+    // pubspec.yaml — presence alone signals Flutter / Dart.
+    if read_manifest(project_root, "pubspec.yaml").is_some() {
+        push_unique(&mut found, "Flutter");
+    }
+
+    // Gemfile — substring search for `rails`.
+    if let Some(text) = read_manifest(project_root, "Gemfile") {
+        if gem_has(&text, "rails") {
+            push_unique(&mut found, "Rails");
+        }
+    }
+
+    // pyproject.toml + requirements.txt — substring search per framework.
+    let py_text = read_manifest(project_root, "pyproject.toml")
+        .or_else(|| read_manifest(project_root, "requirements.txt"))
+        .unwrap_or_default();
+    if !py_text.is_empty() {
+        if python_has(&py_text, "django") {
+            push_unique(&mut found, "Django");
+        }
+        if python_has(&py_text, "fastapi") {
+            push_unique(&mut found, "FastAPI");
+        }
+        if python_has(&py_text, "flask") {
+            push_unique(&mut found, "Flask");
+        }
+    }
+
+    // pom.xml or build.gradle — Spring Boot.
+    let java_text = read_manifest(project_root, "pom.xml")
+        .or_else(|| read_manifest(project_root, "build.gradle"))
+        .or_else(|| read_manifest(project_root, "build.gradle.kts"))
+        .unwrap_or_default();
+    if !java_text.is_empty() && java_text.contains("spring-boot") {
+        push_unique(&mut found, "Spring Boot");
+    }
+
+    // composer.json — Laravel via `laravel/framework`.
+    if let Some(text) = read_manifest(project_root, "composer.json") {
+        if text.contains("laravel/framework") {
+            push_unique(&mut found, "Laravel");
+        }
+    }
+
+    let mut out: Vec<String> = found.iter().map(|s| s.to_string()).collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Read a manifest file from `project_root` if it exists.
+fn read_manifest(project_root: &Path, name: &str) -> Option<String> {
+    std::fs::read_to_string(project_root.join(name)).ok()
+}
+
+/// Push `s` into `out` only if not already present. O(n) but n is tiny.
+fn push_unique(out: &mut Vec<&'static str>, s: &'static str) {
+    if !out.contains(&s) {
+        out.push(s);
+    }
+}
+
+/// True if `text` declares `name` under a Cargo `[dependencies]`-style table.
+///
+/// Why: avoids pulling in a full TOML parser just to look for crate names.
+/// Cargo manifests put each dep on its own line as `name = "..."` or
+/// `name = { ... }`, so a line-prefix match is sufficient.
+/// What: scans lines and returns true if any line (after trimming) starts
+/// with `name` followed by whitespace or `=`.
+fn cargo_has_dep(text: &str, name: &str) -> bool {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix(name) {
+            // Next char must be whitespace or '=' to avoid `name-suffix` matches.
+            if rest.starts_with(|c: char| c.is_whitespace() || c == '=') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// True if `text` (a Gemfile) declares the gem `name`.
+fn gem_has(text: &str, name: &str) -> bool {
+    let needle_single = format!("gem '{name}'");
+    let needle_double = format!("gem \"{name}\"");
+    text.contains(&needle_single) || text.contains(&needle_double)
+}
+
+/// True if `text` (pyproject.toml or requirements.txt) references `name`.
+///
+/// Why: pyproject.toml lists deps in `[project.dependencies]` (PEP 621),
+/// `[tool.poetry.dependencies]`, or `[tool.uv.sources]`; requirements.txt
+/// lists them one per line. A case-insensitive substring match covers all
+/// formats without a full TOML parser.
+/// What: lowercases both haystack and needle, then substring-matches.
+fn python_has(text: &str, name: &str) -> bool {
+    text.to_ascii_lowercase()
+        .contains(&name.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_manifest(dir: &Path, name: &str, contents: &str) {
+        std::fs::write(dir.join(name), contents).expect("write manifest");
+    }
+
+    #[test]
+    fn detect_frameworks_finds_nextjs_and_react_in_package_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "package.json",
+            r#"{ "dependencies": { "next": "14", "react": "18" } }"#,
+        );
+        let fws = detect_frameworks(tmp.path());
+        assert!(fws.contains(&"Next.js".to_string()), "got {fws:?}");
+        assert!(fws.contains(&"React".to_string()), "got {fws:?}");
+    }
+
+    #[test]
+    fn detect_frameworks_finds_vite_in_dev_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "package.json",
+            r#"{ "devDependencies": { "vite": "^5" } }"#,
+        );
+        let fws = detect_frameworks(tmp.path());
+        assert_eq!(fws, vec!["Vite".to_string()]);
+    }
+
+    #[test]
+    fn detect_frameworks_finds_axum_in_cargo_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "Cargo.toml",
+            "[dependencies]\naxum = \"0.7\"\nserde = \"1\"\n",
+        );
+        let fws = detect_frameworks(tmp.path());
+        assert!(fws.contains(&"Axum".to_string()), "got {fws:?}");
+    }
+
+    #[test]
+    fn detect_frameworks_finds_django_and_fastapi_in_requirements() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "requirements.txt",
+            "Django==4.2\nfastapi==0.110\nrequests==2.31\n",
+        );
+        let fws = detect_frameworks(tmp.path());
+        assert!(fws.contains(&"Django".to_string()), "got {fws:?}");
+        assert!(fws.contains(&"FastAPI".to_string()), "got {fws:?}");
+    }
+
+    #[test]
+    fn detect_frameworks_finds_rails_in_gemfile() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "Gemfile",
+            "source 'https://rubygems.org'\ngem 'rails', '~> 7.0'\n",
+        );
+        let fws = detect_frameworks(tmp.path());
+        assert_eq!(fws, vec!["Rails".to_string()]);
+    }
+
+    #[test]
+    fn detect_frameworks_finds_flutter_via_pubspec_presence() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(tmp.path(), "pubspec.yaml", "name: my_app\n");
+        let fws = detect_frameworks(tmp.path());
+        assert_eq!(fws, vec!["Flutter".to_string()]);
+    }
+
+    #[test]
+    fn detect_frameworks_finds_spring_boot_in_pom() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "pom.xml",
+            "<project><dependencies><dependency><groupId>org.springframework.boot</groupId>\
+             <artifactId>spring-boot-starter-web</artifactId></dependency></dependencies></project>",
+        );
+        let fws = detect_frameworks(tmp.path());
+        assert_eq!(fws, vec!["Spring Boot".to_string()]);
+    }
+
+    #[test]
+    fn detect_frameworks_finds_laravel_in_composer_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "composer.json",
+            r#"{ "require": { "laravel/framework": "^10.0" } }"#,
+        );
+        let fws = detect_frameworks(tmp.path());
+        assert_eq!(fws, vec!["Laravel".to_string()]);
+    }
+
+    #[test]
+    fn detect_frameworks_returns_sorted_deduplicated() {
+        let tmp = tempfile::tempdir().unwrap();
+        // React listed in both sections — should appear only once.
+        write_manifest(
+            tmp.path(),
+            "package.json",
+            r#"{
+                "dependencies": { "react": "18", "next": "14" },
+                "devDependencies": { "react": "18", "vite": "5" }
+            }"#,
+        );
+        let fws = detect_frameworks(tmp.path());
+        let mut expected = vec![
+            "Next.js".to_string(),
+            "React".to_string(),
+            "Vite".to_string(),
+        ];
+        expected.sort();
+        assert_eq!(fws, expected);
+    }
+
+    #[test]
+    fn detect_frameworks_returns_empty_for_empty_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fws = detect_frameworks(tmp.path());
+        assert!(fws.is_empty(), "got {fws:?}");
+    }
+
+    #[test]
+    fn cargo_has_dep_avoids_prefix_collisions() {
+        let toml = "[dependencies]\naxum-extra = \"0.9\"\n";
+        // `axum` must NOT match `axum-extra` since the next char is '-' not '=' or whitespace.
+        assert!(!cargo_has_dep(toml, "axum"));
+        let toml2 = "[dependencies]\naxum = \"0.7\"\n";
+        assert!(cargo_has_dep(toml2, "axum"));
+    }
+}

--- a/crates/trusty-analyze/src/lang/detection/mod.rs
+++ b/crates/trusty-analyze/src/lang/detection/mod.rs
@@ -7,12 +7,16 @@
 //! What: `LanguageDetector::detect_file` maps an extension to a language
 //! string; `LanguageDetector::detect` aggregates over a slice of paths and
 //! also recognizes build manifests (Cargo.toml, package.json, etc.).
+//! Manifest-content-based framework inference lives in the [`frameworks`]
+//! submodule and is re-exported as [`detect_frameworks`].
 //!
 //! Test: `detect_file_extension_mapping` covers each supported extension;
 //! `detect_picks_primary_language` ensures the most common extension wins.
 
 use std::collections::HashMap;
-use std::path::Path;
+
+mod frameworks;
+pub use frameworks::detect_frameworks;
 
 /// Detected language(s) for a repository or set of files.
 #[derive(Debug, Clone)]
@@ -101,7 +105,29 @@ fn detect_cpp(lower: &str) -> Option<&'static str> {
     }
 }
 
+fn detect_kotlin(lower: &str) -> Option<&'static str> {
+    (lower.ends_with(".kt") || lower.ends_with(".kts")).then_some("kotlin")
+}
+
+fn detect_swift(lower: &str) -> Option<&'static str> {
+    lower.ends_with(".swift").then_some("swift")
+}
+
+fn detect_ruby(lower: &str) -> Option<&'static str> {
+    lower.ends_with(".rb").then_some("ruby")
+}
+
+fn detect_php(lower: &str) -> Option<&'static str> {
+    lower.ends_with(".php").then_some("php")
+}
+
 /// Ordered list of per-language detectors. First match wins.
+///
+/// Why: `run_diagnostics` gates every file on `detect_file` before dispatching
+/// to its linters, so any language missing here is silently skipped even when
+/// its linter is installed (issue #963). The tags returned must match the
+/// `StaticTool::language()` bucket keys (`kotlin`/`swift`/`ruby`/`php`) and the
+/// tree-sitter adapter self-reports, or routed files reach no tool.
 type LanguageDetectorFn = fn(&str) -> Option<&'static str>;
 const LANGUAGE_DETECTORS: &[LanguageDetectorFn] = &[
     detect_rust,
@@ -111,6 +137,10 @@ const LANGUAGE_DETECTORS: &[LanguageDetectorFn] = &[
     detect_java,
     detect_go,
     detect_cpp,
+    detect_kotlin,
+    detect_swift,
+    detect_ruby,
+    detect_php,
 ];
 
 /// Per-build-system manifest matchers. Each helper returns the canonical
@@ -214,159 +244,6 @@ impl LanguageDetector {
     }
 }
 
-/// Why: framework-specific conventions differ significantly from generic
-/// language rules; knowing the framework allows targeted anti-pattern
-/// detection (e.g. Next.js server/client component boundaries, Rails strong
-/// params, Django ORM patterns).
-/// What: reads manifest file contents from the project root and infers
-/// framework names from declared dependencies. Returns deduplicated, sorted
-/// framework name strings.
-/// Test: unit tests in this module covering each manifest type (see
-/// `detect_frameworks_*`).
-pub fn detect_frameworks(project_root: &Path) -> Vec<String> {
-    let mut found: Vec<&'static str> = Vec::new();
-
-    // package.json — JSON parse `dependencies` + `devDependencies`.
-    if let Some(text) = read_manifest(project_root, "package.json") {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
-            let mut seen_keys: Vec<String> = Vec::new();
-            for field in ["dependencies", "devDependencies"] {
-                if let Some(obj) = v.get(field).and_then(serde_json::Value::as_object) {
-                    for k in obj.keys() {
-                        seen_keys.push(k.clone());
-                    }
-                }
-            }
-            for key in &seen_keys {
-                if let Some(name) = match key.as_str() {
-                    "next" => Some("Next.js"),
-                    "react" => Some("React"),
-                    "vue" => Some("Vue"),
-                    "svelte" => Some("Svelte"),
-                    "@angular/core" => Some("Angular"),
-                    "vite" => Some("Vite"),
-                    _ => None,
-                } {
-                    push_unique(&mut found, name);
-                }
-            }
-        }
-    }
-
-    // Cargo.toml — simple text scan against `[dependencies]` table keys.
-    if let Some(text) = read_manifest(project_root, "Cargo.toml") {
-        if cargo_has_dep(&text, "axum") {
-            push_unique(&mut found, "Axum");
-        }
-        if cargo_has_dep(&text, "actix-web") {
-            push_unique(&mut found, "Actix-Web");
-        }
-        if cargo_has_dep(&text, "rocket") {
-            push_unique(&mut found, "Rocket");
-        }
-    }
-
-    // pubspec.yaml — presence alone signals Flutter / Dart.
-    if read_manifest(project_root, "pubspec.yaml").is_some() {
-        push_unique(&mut found, "Flutter");
-    }
-
-    // Gemfile — substring search for `rails`.
-    if let Some(text) = read_manifest(project_root, "Gemfile") {
-        if gem_has(&text, "rails") {
-            push_unique(&mut found, "Rails");
-        }
-    }
-
-    // pyproject.toml + requirements.txt — substring search per framework.
-    let py_text = read_manifest(project_root, "pyproject.toml")
-        .or_else(|| read_manifest(project_root, "requirements.txt"))
-        .unwrap_or_default();
-    if !py_text.is_empty() {
-        if python_has(&py_text, "django") {
-            push_unique(&mut found, "Django");
-        }
-        if python_has(&py_text, "fastapi") {
-            push_unique(&mut found, "FastAPI");
-        }
-        if python_has(&py_text, "flask") {
-            push_unique(&mut found, "Flask");
-        }
-    }
-
-    // pom.xml or build.gradle — Spring Boot.
-    let java_text = read_manifest(project_root, "pom.xml")
-        .or_else(|| read_manifest(project_root, "build.gradle"))
-        .or_else(|| read_manifest(project_root, "build.gradle.kts"))
-        .unwrap_or_default();
-    if !java_text.is_empty() && java_text.contains("spring-boot") {
-        push_unique(&mut found, "Spring Boot");
-    }
-
-    // composer.json — Laravel via `laravel/framework`.
-    if let Some(text) = read_manifest(project_root, "composer.json") {
-        if text.contains("laravel/framework") {
-            push_unique(&mut found, "Laravel");
-        }
-    }
-
-    let mut out: Vec<String> = found.iter().map(|s| s.to_string()).collect();
-    out.sort();
-    out.dedup();
-    out
-}
-
-/// Read a manifest file from `project_root` if it exists.
-fn read_manifest(project_root: &Path, name: &str) -> Option<String> {
-    std::fs::read_to_string(project_root.join(name)).ok()
-}
-
-/// Push `s` into `out` only if not already present. O(n) but n is tiny.
-fn push_unique(out: &mut Vec<&'static str>, s: &'static str) {
-    if !out.contains(&s) {
-        out.push(s);
-    }
-}
-
-/// True if `text` declares `name` under a Cargo `[dependencies]`-style table.
-///
-/// Why: avoids pulling in a full TOML parser just to look for crate names.
-/// Cargo manifests put each dep on its own line as `name = "..."` or
-/// `name = { ... }`, so a line-prefix match is sufficient.
-/// What: scans lines and returns true if any line (after trimming) starts
-/// with `name` followed by whitespace or `=`.
-fn cargo_has_dep(text: &str, name: &str) -> bool {
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix(name) {
-            // Next char must be whitespace or '=' to avoid `name-suffix` matches.
-            if rest.starts_with(|c: char| c.is_whitespace() || c == '=') {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// True if `text` (a Gemfile) declares the gem `name`.
-fn gem_has(text: &str, name: &str) -> bool {
-    let needle_single = format!("gem '{name}'");
-    let needle_double = format!("gem \"{name}\"");
-    text.contains(&needle_single) || text.contains(&needle_double)
-}
-
-/// True if `text` (pyproject.toml or requirements.txt) references `name`.
-///
-/// Why: pyproject.toml lists deps in `[project.dependencies]` (PEP 621),
-/// `[tool.poetry.dependencies]`, or `[tool.uv.sources]`; requirements.txt
-/// lists them one per line. A case-insensitive substring match covers all
-/// formats without a full TOML parser.
-/// What: lowercases both haystack and needle, then substring-matches.
-fn python_has(text: &str, name: &str) -> bool {
-    text.to_ascii_lowercase()
-        .contains(&name.to_ascii_lowercase())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -402,7 +279,40 @@ mod tests {
             Some("java".into())
         );
         assert_eq!(LanguageDetector::detect_file("main.go"), Some("go".into()));
+        assert_eq!(
+            LanguageDetector::detect_file("Main.kt"),
+            Some("kotlin".into())
+        );
+        assert_eq!(
+            LanguageDetector::detect_file("build.gradle.kts"),
+            Some("kotlin".into())
+        );
+        assert_eq!(
+            LanguageDetector::detect_file("App.swift"),
+            Some("swift".into())
+        );
+        assert_eq!(LanguageDetector::detect_file("app.rb"), Some("ruby".into()));
+        assert_eq!(
+            LanguageDetector::detect_file("index.php"),
+            Some("php".into())
+        );
         assert_eq!(LanguageDetector::detect_file("README.md"), None);
+    }
+
+    #[test]
+    fn detect_file_returns_linter_bucket_keys_for_kotlin_swift_ruby_php() {
+        // Regression for #963: these tags must match the `StaticTool::language()`
+        // bucket keys so `run_diagnostics` can route .kt/.swift/.rb/.php files
+        // to detekt/swiftlint/rubocop/phpstan instead of dropping them.
+        assert_eq!(detect_kotlin("foo.kt"), Some("kotlin"));
+        assert_eq!(detect_kotlin("foo.kts"), Some("kotlin"));
+        assert_eq!(detect_kotlin("foo.java"), None);
+        assert_eq!(detect_swift("foo.swift"), Some("swift"));
+        assert_eq!(detect_swift("foo.kt"), None);
+        assert_eq!(detect_ruby("foo.rb"), Some("ruby"));
+        assert_eq!(detect_ruby("foo.rs"), None);
+        assert_eq!(detect_php("foo.php"), Some("php"));
+        assert_eq!(detect_php("foo.py"), None);
     }
 
     #[test]
@@ -462,145 +372,6 @@ mod tests {
         assert!(matches_basename("a/b/cargo.toml", &["cargo.toml"]));
         assert!(!matches_basename("cargo.toml.bak", &["cargo.toml"]));
         assert!(!matches_basename("notcargo.toml", &["cargo.toml"]));
-    }
-
-    // --- detect_frameworks tests --------------------------------------------
-
-    fn write_manifest(dir: &Path, name: &str, contents: &str) {
-        std::fs::write(dir.join(name), contents).expect("write manifest");
-    }
-
-    #[test]
-    fn detect_frameworks_finds_nextjs_and_react_in_package_json() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(
-            tmp.path(),
-            "package.json",
-            r#"{ "dependencies": { "next": "14", "react": "18" } }"#,
-        );
-        let fws = detect_frameworks(tmp.path());
-        assert!(fws.contains(&"Next.js".to_string()), "got {fws:?}");
-        assert!(fws.contains(&"React".to_string()), "got {fws:?}");
-    }
-
-    #[test]
-    fn detect_frameworks_finds_vite_in_dev_dependencies() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(
-            tmp.path(),
-            "package.json",
-            r#"{ "devDependencies": { "vite": "^5" } }"#,
-        );
-        let fws = detect_frameworks(tmp.path());
-        assert_eq!(fws, vec!["Vite".to_string()]);
-    }
-
-    #[test]
-    fn detect_frameworks_finds_axum_in_cargo_toml() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(
-            tmp.path(),
-            "Cargo.toml",
-            "[dependencies]\naxum = \"0.7\"\nserde = \"1\"\n",
-        );
-        let fws = detect_frameworks(tmp.path());
-        assert!(fws.contains(&"Axum".to_string()), "got {fws:?}");
-    }
-
-    #[test]
-    fn detect_frameworks_finds_django_and_fastapi_in_requirements() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(
-            tmp.path(),
-            "requirements.txt",
-            "Django==4.2\nfastapi==0.110\nrequests==2.31\n",
-        );
-        let fws = detect_frameworks(tmp.path());
-        assert!(fws.contains(&"Django".to_string()), "got {fws:?}");
-        assert!(fws.contains(&"FastAPI".to_string()), "got {fws:?}");
-    }
-
-    #[test]
-    fn detect_frameworks_finds_rails_in_gemfile() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(
-            tmp.path(),
-            "Gemfile",
-            "source 'https://rubygems.org'\ngem 'rails', '~> 7.0'\n",
-        );
-        let fws = detect_frameworks(tmp.path());
-        assert_eq!(fws, vec!["Rails".to_string()]);
-    }
-
-    #[test]
-    fn detect_frameworks_finds_flutter_via_pubspec_presence() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(tmp.path(), "pubspec.yaml", "name: my_app\n");
-        let fws = detect_frameworks(tmp.path());
-        assert_eq!(fws, vec!["Flutter".to_string()]);
-    }
-
-    #[test]
-    fn detect_frameworks_finds_spring_boot_in_pom() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(
-            tmp.path(),
-            "pom.xml",
-            "<project><dependencies><dependency><groupId>org.springframework.boot</groupId>\
-             <artifactId>spring-boot-starter-web</artifactId></dependency></dependencies></project>",
-        );
-        let fws = detect_frameworks(tmp.path());
-        assert_eq!(fws, vec!["Spring Boot".to_string()]);
-    }
-
-    #[test]
-    fn detect_frameworks_finds_laravel_in_composer_json() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_manifest(
-            tmp.path(),
-            "composer.json",
-            r#"{ "require": { "laravel/framework": "^10.0" } }"#,
-        );
-        let fws = detect_frameworks(tmp.path());
-        assert_eq!(fws, vec!["Laravel".to_string()]);
-    }
-
-    #[test]
-    fn detect_frameworks_returns_sorted_deduplicated() {
-        let tmp = tempfile::tempdir().unwrap();
-        // React listed in both sections — should appear only once.
-        write_manifest(
-            tmp.path(),
-            "package.json",
-            r#"{
-                "dependencies": { "react": "18", "next": "14" },
-                "devDependencies": { "react": "18", "vite": "5" }
-            }"#,
-        );
-        let fws = detect_frameworks(tmp.path());
-        let mut expected = vec![
-            "Next.js".to_string(),
-            "React".to_string(),
-            "Vite".to_string(),
-        ];
-        expected.sort();
-        assert_eq!(fws, expected);
-    }
-
-    #[test]
-    fn detect_frameworks_returns_empty_for_empty_project() {
-        let tmp = tempfile::tempdir().unwrap();
-        let fws = detect_frameworks(tmp.path());
-        assert!(fws.is_empty(), "got {fws:?}");
-    }
-
-    #[test]
-    fn cargo_has_dep_avoids_prefix_collisions() {
-        let toml = "[dependencies]\naxum-extra = \"0.9\"\n";
-        // `axum` must NOT match `axum-extra` since the next char is '-' not '=' or whitespace.
-        assert!(!cargo_has_dep(toml, "axum"));
-        let toml2 = "[dependencies]\naxum = \"0.7\"\n";
-        assert!(cargo_has_dep(toml2, "axum"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`run_diagnostics` gates every file on `LanguageDetector::detect_file` before dispatching to its linters, but `LANGUAGE_DETECTORS` only carried **7** detectors. Files whose extension wasn't in that table (`.kt`/`.kts`/`.swift`/`.rb`/`.php`) were `continue`-skipped *before any linter ran*, so **detekt, swiftlint, rubocop, and phpstan could never fire through the endpoint** even when installed — `diagnostics` returned `count: 0`, which reads as "clean code" rather than "not run" (#963).

## Fix

- Add `detect_kotlin` / `detect_swift` / `detect_ruby` / `detect_php`, returning tags (`kotlin`/`swift`/`ruby`/`php`) that match the `StaticTool::language()` bucket keys, and append them to `LANGUAGE_DETECTORS`.
- The C/C++ note in the issue turned out to be a non-issue: `clang-tidy` already registers under `cpp` (with an explicit comment), matching `detect_cpp`'s tag — no mismatch.

## Note on the optional "log loudly" suggestion

The issue also suggested a `debug!` when a file is skipped for an unknown extension. `service/mod.rs` (the skip site) sits **exactly at its frozen line-cap budget (2163)**, so adding even one line fails the line-cap gate, and splitting a 2167-line service file is out of scope for this bug fix. Deferred — happy to land it alongside a future `service/mod.rs` split. The primary cause (missing detectors) is fully fixed.

## On detection semantics (raised in review)

Routing is **purely extension-based** — the file's bytes are never inspected at the `detect_file` gate. The tree-sitter adapters parse contents only *after* routing, for AST/complexity analysis, and are not consulted by the diagnostics router. This PR completes the *extension table*, not content recognition.

## File split (line-cap compliance)

The feature pushed `detection.rs` over its frozen line-cap budget, so it's split into:
- `detection/mod.rs` — extension + build-system detection (387 lines)
- `detection/frameworks.rs` — manifest-content framework inference (311 lines)

Both well under the 500-line cap; the allowlist entry is ratcheted away.

## Test

- `detect_file_extension_mapping` now covers `.kt`/`.kts`/`.swift`/`.rb`/`.php`.
- New `detect_file_returns_linter_bucket_keys_for_kotlin_swift_ruby_php` locks the tags to the linter bucket keys.
- `cargo test -p trusty-analyze --lib` → 340 passed; `clippy` clean; `fmt --check` clean; `check_line_cap.sh` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)