### PR TITLE
chore(memory): document/soften invariant expect() calls

### DIFF
--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -1867,7 +1867,7 @@ pub(crate) async fn sse_handler(
         .header("Cache-Control", "no-cache")
         .header("X-Accel-Buffering", "no")
         .body(axum::body::Body::from_stream(stream))
-        .expect("valid SSE response")
+        .expect("valid SSE response") // Why: invariant — SSE headers are compile-time constants; builder cannot fail
 }
 
 #[cfg(test)]

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -480,7 +480,7 @@ enum MonitorTarget {
 static HELP: std::sync::LazyLock<trusty_common::help::HelpConfig> =
     std::sync::LazyLock::new(|| {
         trusty_common::help::load_help(include_str!("../help.yaml"))
-            .expect("trusty-memory help.yaml is bundled and valid")
+            .expect("trusty-memory help.yaml is bundled and valid") // Why: include_str! guarantees presence at compile time; parse is validated in tests
     });
 
 #[tokio::main]


### PR DESCRIPTION
## Summary

- **Site 1** (`crates/trusty-memory/src/lib.rs:1870`): `.expect("valid SSE response")` — appended inline `// Why:` rationale comment documenting that SSE headers are compile-time constants and `Response::builder()` cannot fail here. Preferred the documented-invariant approach (no behavior change) over `unwrap_or_else` because the `unwrap_or_else` form caused `cargo fmt` to expand the closure to 4 lines, which would push `lib.rs` over its 3000-line allowlist budget.
- **Site 2** (`crates/trusty-memory/src/main.rs:483`): `.expect("trusty-memory help.yaml is bundled and valid")` — appended inline `// Why:` rationale comment explaining that `include_str!` guarantees compile-time presence and parse coverage lives in `trusty-common` tests. No behavior change.

Both files remain exactly at their `.line-cap-allowlist.tsv` budgets (lib.rs: 3000, main.rs: 1083).

## Test plan

- [x] `cargo test -p trusty-memory` — all 6 tests pass
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p trusty-memory` — no drift
- [x] `bash scripts/check_line_cap.sh` — 172 allowlisted, 0 violations

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)