### PR TITLE
fix(review): propagate reqwest client-build errors (no startup panics)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -133,7 +133,6 @@ crates/trusty-mpm/src/telegram/mod.rs	632
 crates/trusty-mpm/src/tui/dashboard.rs	1040
 crates/trusty-mpm/src/tui/health.rs	3330
 crates/trusty-mpm/src/tui/mod.rs	763
-crates/trusty-review/src/integrations/analyze_client.rs	622
 crates/trusty-review/src/models/mod.rs	531
 crates/trusty-review/src/pipeline/runner_tests.rs	730
 crates/trusty-review/src/pipeline/verify_tests.rs	533

--- a/crates/trusty-review/src/commands/compare.rs
+++ b/crates/trusty-review/src/commands/compare.rs
@@ -72,7 +72,8 @@ pub struct CompareArgs {
 pub async fn cmd_compare(mut config: ReviewConfig, args: CompareArgs) -> Result<()> {
     // Resolve the search index from the daemon once before the per-model loop.
     // When TRUSTY_SEARCH_INDEX is explicitly set, resolve_index is a no-op.
-    let search_for_resolve = HttpSearchClient::from_config(&config);
+    let search_for_resolve = HttpSearchClient::from_config(&config)
+        .map_err(|e| anyhow::anyhow!("failed to build search HTTP client: {e}"))?;
     config.resolve_index(&search_for_resolve).await;
 
     let models: Vec<String> = args.models.clone().unwrap_or_else(|| {
@@ -157,7 +158,8 @@ async fn resolve_diff_source_compare(
         .pr
         .ok_or_else(|| anyhow::anyhow!("PR number is required (or use --local-diff)"))?;
 
-    let client = GithubClient::new();
+    let client = GithubClient::new()
+        .map_err(|e| anyhow::anyhow!("failed to build GitHub HTTP client: {e}"))?;
     let token = AuthStrategy::select(RunMode::Cli, None)
         .resolve_token(&client, config, &owner)
         .await

--- a/crates/trusty-review/src/commands/run.rs
+++ b/crates/trusty-review/src/commands/run.rs
@@ -97,7 +97,8 @@ pub async fn cmd_run(config: ReviewConfig, args: RunArgs) -> Result<()> {
     // When the operator set TRUSTY_SEARCH_INDEX explicitly, resolve_index is
     // a no-op.  On any failure (daemon unreachable, no match) it logs a
     // warning and leaves search_index at its current value.
-    let search_for_resolve = HttpSearchClient::from_config(&config_with_overrides);
+    let search_for_resolve = HttpSearchClient::from_config(&config_with_overrides)
+        .map_err(|e| anyhow::anyhow!("failed to build search HTTP client: {e}"))?;
     config_with_overrides
         .resolve_index(&search_for_resolve)
         .await;
@@ -161,7 +162,8 @@ pub async fn resolve_diff_source_run(config: &ReviewConfig, args: &RunArgs) -> R
         .pr
         .context("PR number is required (or use --local-diff)")?;
 
-    let client = GithubClient::new();
+    let client = GithubClient::new()
+        .map_err(|e| anyhow::anyhow!("failed to build GitHub HTTP client: {e}"))?;
     let token = AuthStrategy::select(RunMode::Cli, None)
         .resolve_token(&client, config, &owner)
         .await
@@ -199,12 +201,14 @@ pub async fn build_deps_async(
 
     let verifier = cli_verify::build_verifier_opt(config).await;
 
-    let search = HttpSearchClient::from_config(config);
+    let search = HttpSearchClient::from_config(config)
+        .map_err(|e| anyhow::anyhow!("failed to build search HTTP client: {e}"))?;
     // Use the on-demand subprocess client instead of the HTTP daemon client.
     // Rationale: #632 — trusty-analyze is invoked on demand as a subprocess
     // (trusty-analyze review --index-id <id> -) rather than requiring a
     // long-running trusty-analyze serve daemon.
-    let analyze = SubprocessAnalyzeClient::from_config(config);
+    let analyze = SubprocessAnalyzeClient::from_config(config)
+        .map_err(|e| anyhow::anyhow!("failed to build analyze HTTP client: {e}"))?;
 
     Ok(ReviewDeps {
         llm,

--- a/crates/trusty-review/src/commands/serve.rs
+++ b/crates/trusty-review/src/commands/serve.rs
@@ -132,13 +132,15 @@ async fn build_app_state(mut config: ReviewConfig) -> Result<AppState> {
     // registered root_path is matched against the current repo and the correct
     // index id is used even when TRUSTY_SEARCH_INDEX is not set.  The call is
     // a no-op when search_index_explicit is true (operator overrode it).
-    let search = HttpSearchClient::from_config(&config);
+    let search = HttpSearchClient::from_config(&config)
+        .map_err(|e| anyhow::anyhow!("failed to build search HTTP client: {e}"))?;
     config.resolve_index(&search).await;
     // Use the on-demand subprocess client instead of the HTTP daemon client.
     // Rationale: #632 — trusty-analyze is invoked on demand as a subprocess
     // (trusty-analyze review --index-id <id> -) rather than requiring a
     // long-running trusty-analyze serve daemon.
-    let analyze = SubprocessAnalyzeClient::from_config(&config);
+    let analyze = SubprocessAnalyzeClient::from_config(&config)
+        .map_err(|e| anyhow::anyhow!("failed to build analyze HTTP client: {e}"))?;
 
     let dedup_path = config.log_dir.join("dedup.redb");
     let dedup = match trusty_review::store::DedupStore::open(&dedup_path) {

--- a/crates/trusty-review/src/integrations/analyze_client.rs
+++ b/crates/trusty-review/src/integrations/analyze_client.rs
@@ -32,7 +32,9 @@ use serde::{Deserialize, Serialize};
 /// matching on strings.
 /// What: `Transport`, `Api`, `Parse`, `Unavailable` match the equivalent
 /// `SearchClientError` variants.  All errors are treated as "graceful
-/// degradation" by the pipeline — none should block a review.
+/// degradation" by the pipeline — none should block a review.  `ClientInit`
+/// covers TLS-backend initialisation failures at construction time so callers
+/// receive an `Err` instead of a panic.
 /// Test: `analyze_error_display`.
 #[derive(Debug, thiserror::Error)]
 pub enum AnalyzeClientError {
@@ -56,6 +58,10 @@ pub enum AnalyzeClientError {
     /// Daemon is unreachable or unhealthy.
     #[error("trusty-analyze unavailable: {0}")]
     Unavailable(String),
+
+    /// reqwest client construction failed (TLS backend unavailable).
+    #[error("failed to build HTTP client: {0}")]
+    ClientInit(String),
 }
 
 // ─── Response types ───────────────────────────────────────────────────────────
@@ -219,32 +225,35 @@ impl HttpAnalyzeClient {
     /// the config system.
     /// What: builds two reqwest clients — `probe_http` (5s timeout) and
     /// `analysis_http` (180s timeout) — matching the timeout table in spec
-    /// REV-440.
+    /// REV-440.  Returns `Err(ClientInit)` if the TLS backend cannot be
+    /// initialised — surfaces the failure to the caller rather than panicking
+    /// at daemon startup (closes #953).
     /// Test: `http_analyze_client_url_is_configurable`.
-    pub fn new(base_url: impl Into<String>) -> Self {
+    pub fn new(base_url: impl Into<String>) -> Result<Self, AnalyzeClientError> {
         let raw = base_url.into();
         let base_url = raw.trim_end_matches('/').to_string();
         let probe_http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(5))
             .build()
-            .expect("reqwest::Client::build failed");
+            .map_err(|e| AnalyzeClientError::ClientInit(e.to_string()))?;
         let analysis_http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(180))
             .build()
-            .expect("reqwest::Client::build failed");
-        Self {
+            .map_err(|e| AnalyzeClientError::ClientInit(e.to_string()))?;
+        Ok(Self {
             base_url,
             probe_http,
             analysis_http,
-        }
+        })
     }
 
     /// Construct from a `ReviewConfig`, reading `analyzer_url`.
     ///
     /// Why: the pipeline constructs the client from its injected config.
-    /// What: calls `Self::new(config.analyzer_url.clone())`.
+    /// What: calls `Self::new(config.analyzer_url.clone())` and propagates any
+    /// TLS-backend init failure as `Err`.
     /// Test: `http_analyze_client_from_config`.
-    pub fn from_config(config: &crate::config::ReviewConfig) -> Self {
+    pub fn from_config(config: &crate::config::ReviewConfig) -> Result<Self, AnalyzeClientError> {
         Self::new(config.analyzer_url.clone())
     }
 
@@ -421,202 +430,5 @@ impl AnalyzeClient for HttpAnalyzeClient {
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn analyze_client_trait_object_compiles() {
-        fn _accepts_dyn(_c: &dyn AnalyzeClient) {}
-    }
-
-    #[test]
-    fn http_analyze_client_url_is_configurable() {
-        let client = HttpAnalyzeClient::new("http://127.0.0.1:7879");
-        assert_eq!(client.base_url(), "http://127.0.0.1:7879");
-    }
-
-    #[test]
-    fn http_analyze_client_strips_trailing_slash() {
-        let client = HttpAnalyzeClient::new("http://127.0.0.1:7879/");
-        assert_eq!(client.base_url(), "http://127.0.0.1:7879");
-    }
-
-    #[test]
-    fn http_analyze_client_from_config() {
-        let mut config = crate::config::ReviewConfig::load(None);
-        config.analyzer_url = "http://localhost:8888".to_string();
-        let client = HttpAnalyzeClient::from_config(&config);
-        assert_eq!(client.base_url(), "http://localhost:8888");
-    }
-
-    #[test]
-    fn analyze_health_response_is_healthy() {
-        let resp = AnalyzeHealthResponse {
-            status: "ok".to_string(),
-            search_reachable: true,
-        };
-        assert!(resp.is_healthy());
-    }
-
-    #[test]
-    fn analyze_health_response_not_ok() {
-        let resp = AnalyzeHealthResponse {
-            status: "starting".to_string(),
-            search_reachable: false,
-        };
-        assert!(!resp.is_healthy());
-    }
-
-    #[test]
-    fn analyze_health_search_not_reachable() {
-        // status == "ok" but search_reachable == false → not healthy.
-        let resp = AnalyzeHealthResponse {
-            status: "ok".to_string(),
-            search_reachable: false,
-        };
-        assert!(
-            !resp.is_healthy(),
-            "is_healthy must be false when search_reachable is false"
-        );
-    }
-
-    #[test]
-    fn analyze_health_response_deserialises() {
-        let json = r#"{"status":"ok","search_reachable":true}"#;
-        let resp: AnalyzeHealthResponse = serde_json::from_str(json).unwrap();
-        assert!(resp.is_healthy());
-    }
-
-    #[test]
-    fn analyze_index_info_deserialises() {
-        let json = r#"{"id":"main"}"#;
-        let info: AnalyzeIndexInfo = serde_json::from_str(json).unwrap();
-        assert_eq!(info.id, "main");
-    }
-
-    #[test]
-    fn hotspot_deserialises() {
-        let json = r#"{
-            "file": "src/service/mod.rs",
-            "function_name": "handle_webhook",
-            "cyclomatic": 18,
-            "cognitive": 22
-        }"#;
-        let h: ComplexityHotspot = serde_json::from_str(json).unwrap();
-        assert_eq!(h.file, "src/service/mod.rs");
-        assert_eq!(h.function_name.as_deref(), Some("handle_webhook"));
-        assert_eq!(h.cyclomatic, 18);
-    }
-
-    #[test]
-    fn smell_deserialises() {
-        let json = r#"{"file":"src/main.rs","category":"long_method","severity":"high","line":42}"#;
-        let s: Smell = serde_json::from_str(json).unwrap();
-        assert_eq!(s.file, "src/main.rs");
-        assert_eq!(s.category, "long_method");
-        assert_eq!(s.line, Some(42));
-    }
-
-    #[test]
-    fn analyze_error_display() {
-        let err = AnalyzeClientError::Transport("connection refused".to_string());
-        assert!(err.to_string().contains("connection refused"));
-
-        let err = AnalyzeClientError::Unavailable("timeout".to_string());
-        assert!(err.to_string().contains("timeout"));
-    }
-
-    /// Documents the spec REV-441 invariant: has_analysis NEVER calls /quality.
-    ///
-    /// Why: the O(corpus) /quality endpoint always times out at 5s and made
-    /// the sidecar appear perpetually unavailable (lesson §12.3).
-    /// What: this is a documentation test — the actual enforcement is in the
-    /// implementation above which calls only /health and /indexes.
-    /// Test: read `has_analysis` above to verify no call to /quality is present.
-    #[test]
-    fn two_step_probe_never_calls_quality() {
-        // Search the has_analysis implementation for any URL string that would
-        // route to the /quality endpoint.  We locate the has_analysis fn body in
-        // the source and scan for string literals containing "/quality".
-        //
-        // Strategy: find lines that form a URL path to /quality in non-comment
-        // code.  The sentinel we look for is a format string or string literal
-        // containing `/quality"` (closing quote distinguishes the path literal from
-        // documentation strings that talk *about* the endpoint).
-        let source = include_str!("analyze_client.rs");
-
-        // Locate the `has_analysis` function body by looking for lines between
-        // `async fn has_analysis` and the next top-level `async fn`.
-        let in_has_analysis: Vec<&str> = {
-            let mut capturing = false;
-            let mut brace_depth: i32 = 0;
-            let mut lines = Vec::new();
-            for line in source.lines() {
-                let trimmed = line.trim_start();
-                if !capturing && trimmed.contains("async fn has_analysis") {
-                    capturing = true;
-                }
-                if capturing {
-                    lines.push(line);
-                    brace_depth += line.chars().filter(|&c| c == '{').count() as i32;
-                    brace_depth -= line.chars().filter(|&c| c == '}').count() as i32;
-                    if brace_depth <= 0 && lines.len() > 1 {
-                        break;
-                    }
-                }
-            }
-            lines
-        };
-
-        // Within the has_analysis body, look for non-comment lines that contain
-        // the string literal path `/quality"` (path fragment followed by a quote),
-        // which would indicate a URL string targeting the quality endpoint.
-        let quality_url_in_body = in_has_analysis
-            .iter()
-            .filter(|l| !l.trim_start().starts_with("//"))
-            .any(|l| l.contains("/quality\"") || l.contains("/quality?"));
-
-        assert!(
-            !quality_url_in_body,
-            "has_analysis must NEVER construct a URL to /quality (spec REV-441, lesson §12.3)"
-        );
-
-        // Also verify we actually found the function body (guards against the test
-        // silently passing if the function was renamed).
-        assert!(
-            !in_has_analysis.is_empty(),
-            "could not locate has_analysis fn body in analyze_client.rs — test is broken"
-        );
-    }
-
-    #[tokio::test]
-    async fn two_step_probe_returns_false_on_transport_error() {
-        // Port 1 is always refused; has_analysis must return false (not panic).
-        let client = HttpAnalyzeClient::new("http://127.0.0.1:1");
-        let result = client.has_analysis("main").await;
-        assert!(
-            !result,
-            "has_analysis must return false on transport error, not panic"
-        );
-    }
-
-    #[tokio::test]
-    async fn complexity_hotspots_transport_error_propagates() {
-        let client = HttpAnalyzeClient::new("http://127.0.0.1:1");
-        let result = client.complexity_hotspots("main", Some(5)).await;
-        assert!(
-            result.is_err(),
-            "transport error must surface as Err from complexity_hotspots"
-        );
-    }
-
-    #[tokio::test]
-    async fn smells_transport_error_propagates() {
-        let client = HttpAnalyzeClient::new("http://127.0.0.1:1");
-        let result = client.smells("main").await;
-        assert!(
-            result.is_err(),
-            "transport error must surface as Err from smells"
-        );
-    }
-}
+#[path = "analyze_client_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/integrations/analyze_client_tests.rs
+++ b/crates/trusty-review/src/integrations/analyze_client_tests.rs
@@ -1,0 +1,206 @@
+//! Unit tests for `AnalyzeClient` types and `HttpAnalyzeClient`.
+//!
+//! Why: split from `analyze_client.rs` to keep that file under the 500-line cap
+//! (issue #610).  All tests exercise the parse helpers, URL construction, and
+//! the two-step probe behaviour; no running daemon is required.
+//! What: covers `AnalyzeHealthResponse`, `AnalyzeIndexInfo`, `ComplexityHotspot`,
+//! `Smell`, `AnalyzeClientError`, and `HttpAnalyzeClient` construction.
+//! Test: each function is a self-contained unit test.
+
+use super::*;
+
+#[test]
+fn analyze_client_trait_object_compiles() {
+    fn _accepts_dyn(_c: &dyn AnalyzeClient) {}
+}
+
+#[test]
+fn http_analyze_client_url_is_configurable() {
+    let client = HttpAnalyzeClient::new("http://127.0.0.1:7879").expect("TLS init should succeed");
+    assert_eq!(client.base_url(), "http://127.0.0.1:7879");
+}
+
+#[test]
+fn http_analyze_client_strips_trailing_slash() {
+    let client = HttpAnalyzeClient::new("http://127.0.0.1:7879/").expect("TLS init should succeed");
+    assert_eq!(client.base_url(), "http://127.0.0.1:7879");
+}
+
+#[test]
+fn http_analyze_client_from_config() {
+    let mut config = crate::config::ReviewConfig::load(None);
+    config.analyzer_url = "http://localhost:8888".to_string();
+    let client = HttpAnalyzeClient::from_config(&config).expect("TLS init should succeed");
+    assert_eq!(client.base_url(), "http://localhost:8888");
+}
+
+#[test]
+fn analyze_health_response_is_healthy() {
+    let resp = AnalyzeHealthResponse {
+        status: "ok".to_string(),
+        search_reachable: true,
+    };
+    assert!(resp.is_healthy());
+}
+
+#[test]
+fn analyze_health_response_not_ok() {
+    let resp = AnalyzeHealthResponse {
+        status: "starting".to_string(),
+        search_reachable: false,
+    };
+    assert!(!resp.is_healthy());
+}
+
+#[test]
+fn analyze_health_search_not_reachable() {
+    // status == "ok" but search_reachable == false → not healthy.
+    let resp = AnalyzeHealthResponse {
+        status: "ok".to_string(),
+        search_reachable: false,
+    };
+    assert!(
+        !resp.is_healthy(),
+        "is_healthy must be false when search_reachable is false"
+    );
+}
+
+#[test]
+fn analyze_health_response_deserialises() {
+    let json = r#"{"status":"ok","search_reachable":true}"#;
+    let resp: AnalyzeHealthResponse = serde_json::from_str(json).unwrap();
+    assert!(resp.is_healthy());
+}
+
+#[test]
+fn analyze_index_info_deserialises() {
+    let json = r#"{"id":"main"}"#;
+    let info: AnalyzeIndexInfo = serde_json::from_str(json).unwrap();
+    assert_eq!(info.id, "main");
+}
+
+#[test]
+fn hotspot_deserialises() {
+    let json = r#"{
+        "file": "src/service/mod.rs",
+        "function_name": "handle_webhook",
+        "cyclomatic": 18,
+        "cognitive": 22
+    }"#;
+    let h: ComplexityHotspot = serde_json::from_str(json).unwrap();
+    assert_eq!(h.file, "src/service/mod.rs");
+    assert_eq!(h.function_name.as_deref(), Some("handle_webhook"));
+    assert_eq!(h.cyclomatic, 18);
+}
+
+#[test]
+fn smell_deserialises() {
+    let json = r#"{"file":"src/main.rs","category":"long_method","severity":"high","line":42}"#;
+    let s: Smell = serde_json::from_str(json).unwrap();
+    assert_eq!(s.file, "src/main.rs");
+    assert_eq!(s.category, "long_method");
+    assert_eq!(s.line, Some(42));
+}
+
+#[test]
+fn analyze_error_display() {
+    let err = AnalyzeClientError::Transport("connection refused".to_string());
+    assert!(err.to_string().contains("connection refused"));
+
+    let err = AnalyzeClientError::Unavailable("timeout".to_string());
+    assert!(err.to_string().contains("timeout"));
+}
+
+/// Documents the spec REV-441 invariant: has_analysis NEVER calls /quality.
+///
+/// Why: the O(corpus) /quality endpoint always times out at 5s and made
+/// the sidecar appear perpetually unavailable (lesson §12.3).
+/// What: this is a documentation test — the actual enforcement is in the
+/// implementation above which calls only /health and /indexes.
+/// Test: read `has_analysis` above to verify no call to /quality is present.
+#[test]
+fn two_step_probe_never_calls_quality() {
+    // Search the has_analysis implementation for any URL string that would
+    // route to the /quality endpoint.  We locate the has_analysis fn body in
+    // the source and scan for string literals containing "/quality".
+    //
+    // Strategy: find lines that form a URL path to /quality in non-comment
+    // code.  The sentinel we look for is a format string or string literal
+    // containing `/quality"` (closing quote distinguishes the path literal from
+    // documentation strings that talk *about* the endpoint).
+    let source = include_str!("analyze_client.rs");
+
+    // Locate the `has_analysis` function body by looking for lines between
+    // `async fn has_analysis` and the next top-level `async fn`.
+    let in_has_analysis: Vec<&str> = {
+        let mut capturing = false;
+        let mut brace_depth: i32 = 0;
+        let mut lines = Vec::new();
+        for line in source.lines() {
+            let trimmed = line.trim_start();
+            if !capturing && trimmed.contains("async fn has_analysis") {
+                capturing = true;
+            }
+            if capturing {
+                lines.push(line);
+                brace_depth += line.chars().filter(|&c| c == '{').count() as i32;
+                brace_depth -= line.chars().filter(|&c| c == '}').count() as i32;
+                if brace_depth <= 0 && lines.len() > 1 {
+                    break;
+                }
+            }
+        }
+        lines
+    };
+
+    // Within the has_analysis body, look for non-comment lines that contain
+    // the string literal path `/quality"` (path fragment followed by a quote),
+    // which would indicate a URL string targeting the quality endpoint.
+    let quality_url_in_body = in_has_analysis
+        .iter()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .any(|l| l.contains("/quality\"") || l.contains("/quality?"));
+
+    assert!(
+        !quality_url_in_body,
+        "has_analysis must NEVER construct a URL to /quality (spec REV-441, lesson §12.3)"
+    );
+
+    // Also verify we actually found the function body (guards against the test
+    // silently passing if the function was renamed).
+    assert!(
+        !in_has_analysis.is_empty(),
+        "could not locate has_analysis fn body in analyze_client.rs — test is broken"
+    );
+}
+
+#[tokio::test]
+async fn two_step_probe_returns_false_on_transport_error() {
+    // Port 1 is always refused; has_analysis must return false (not panic).
+    let client = HttpAnalyzeClient::new("http://127.0.0.1:1").expect("TLS init should succeed");
+    let result = client.has_analysis("main").await;
+    assert!(
+        !result,
+        "has_analysis must return false on transport error, not panic"
+    );
+}
+
+#[tokio::test]
+async fn complexity_hotspots_transport_error_propagates() {
+    let client = HttpAnalyzeClient::new("http://127.0.0.1:1").expect("TLS init should succeed");
+    let result = client.complexity_hotspots("main", Some(5)).await;
+    assert!(
+        result.is_err(),
+        "transport error must surface as Err from complexity_hotspots"
+    );
+}
+
+#[tokio::test]
+async fn smells_transport_error_propagates() {
+    let client = HttpAnalyzeClient::new("http://127.0.0.1:1").expect("TLS init should succeed");
+    let result = client.smells("main").await;
+    assert!(
+        result.is_err(),
+        "transport error must surface as Err from smells"
+    );
+}

--- a/crates/trusty-review/src/integrations/context/confluence.rs
+++ b/crates/trusty-review/src/integrations/context/confluence.rs
@@ -71,20 +71,33 @@ impl ReqwestConfluenceTransport {
     /// Construct with a default 15s-timeout client.
     ///
     /// Why: bound the worst-case latency of an enrichment call.
-    /// What: builds a reqwest client; panics only on TLS-backend init failure.
+    /// What: builds a reqwest client.  Returns `Err(ContextSourceError::Transport)`
+    /// if the TLS backend cannot be initialised — surfaces the failure to
+    /// `ConfluenceSource::from_config` instead of panicking at startup (closes
+    /// #953).
     /// Test: covered transitively by `ConfluenceSource::from_config`.
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self, ContextSourceError> {
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(15))
             .build()
-            .expect("reqwest::Client::build failed — TLS backend unavailable");
-        Self { http }
+            .map_err(|e| ContextSourceError::Transport {
+                src: "confluence",
+                err: super::TransportErr(format!("failed to build HTTP client: {e}")),
+            })?;
+        Ok(Self { http })
     }
 }
 
 impl Default for ReqwestConfluenceTransport {
+    /// Construct with default settings; panics only on TLS-backend init failure.
+    ///
+    /// Why: `Default` cannot return `Result`; kept for compatibility.
+    /// Production callers inside `from_config` use `Self::new()` and handle the
+    /// error gracefully instead.
+    /// What: delegates to `Self::new().expect(…)`.
+    /// Test: covered by `ConfluenceSource::from_config`.
     fn default() -> Self {
-        Self::new()
+        Self::new().expect("reqwest::Client::build failed — TLS backend unavailable")
     }
 }
 
@@ -134,6 +147,33 @@ impl ConfluenceTransport for ReqwestConfluenceTransport {
     }
 }
 
+// ─── Disabled transport (fallback on TLS-init failure) ──────────────────────
+
+/// A no-op `ConfluenceTransport` used when TLS backend init fails.
+///
+/// Why: `from_config` must never panic; when `ReqwestConfluenceTransport::new()`
+/// fails the source is constructed with this sentinel so it is permanently
+/// disabled and `gather` never calls it (guarded by `is_enabled`).
+/// What: always returns an `Api` error — but since `is_enabled()` is false the
+/// orchestrator skips `gather` entirely and this code is never reached.
+/// Test: covered implicitly by the `from_config` TLS-failure path.
+struct DisabledTransport;
+
+#[async_trait]
+impl ConfluenceTransport for DisabledTransport {
+    async fn search_cql(
+        &self,
+        _creds: &AtlassianCreds,
+        _cql: &str,
+        _limit: u32,
+    ) -> Result<String, ContextSourceError> {
+        Err(ContextSourceError::Transport {
+            src: SOURCE_NAME,
+            err: super::TransportErr("HTTP transport unavailable (TLS init failed)".to_string()),
+        })
+    }
+}
+
 // ─── The source ─────────────────────────────────────────────────────────────
 
 /// LIVE Confluence context source.
@@ -155,16 +195,33 @@ impl ConfluenceSource {
     ///
     /// Why: the runner wires the source without knowing credential mechanics.
     /// What: resolves `AtlassianCreds::from_env_for(Confluence)`, computes
-    /// `effective_enabled`, and attaches the production transport.
+    /// `effective_enabled`, and attaches the production transport.  If the
+    /// reqwest TLS backend cannot be initialised the source is constructed in a
+    /// permanently-disabled state (enabled=false) so it degrades gracefully
+    /// instead of panicking at startup (closes #953).
     /// Test: `disabled_when_no_creds`.
     pub fn from_config(cfg: &super::SourceConfig) -> Self {
         let creds = AtlassianCreds::from_env_for(AtlassianProduct::Confluence);
+        let transport = match ReqwestConfluenceTransport::new() {
+            Ok(t) => Box::new(t) as Box<dyn ConfluenceTransport>,
+            Err(e) => {
+                tracing::error!(
+                    "confluence: failed to build HTTP transport (source disabled): {e}"
+                );
+                return Self {
+                    enabled: false,
+                    mode: cfg.mode,
+                    creds: None,
+                    transport: Box::new(DisabledTransport),
+                };
+            }
+        };
         let enabled = cfg.effective_enabled(creds.is_some());
         Self {
             enabled,
             mode: cfg.mode,
             creds,
-            transport: Box::new(ReqwestConfluenceTransport::new()),
+            transport,
         }
     }
 

--- a/crates/trusty-review/src/integrations/context/github_issues.rs
+++ b/crates/trusty-review/src/integrations/context/github_issues.rs
@@ -131,7 +131,10 @@ impl DualModeTokenResolver {
 #[async_trait]
 impl IssueTokenResolver for DualModeTokenResolver {
     async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError> {
-        let client = GithubClient::new();
+        let client = GithubClient::new().map_err(|e| ContextSourceError::NotConfigured {
+            src: SOURCE_NAME,
+            reason: format!("failed to build HTTP client: {e}"),
+        })?;
         AuthStrategy::select(self.run_mode, None)
             .resolve_token(&client, &self.config, owner)
             .await
@@ -177,20 +180,29 @@ impl ReqwestIssueSearch {
     /// Construct with a default 15s-timeout client.
     ///
     /// Why: bound the worst-case latency of an enrichment call.
-    /// What: builds a reqwest client; panics only on TLS-backend init failure.
+    /// What: builds a reqwest client.  Returns `Err(ContextSourceError::Transport)`
+    /// if the TLS backend cannot be initialised — surfaces the failure to
+    /// `GithubIssuesSource::from_config` instead of panicking at startup (closes
+    /// #953).
     /// Test: covered transitively by `GithubIssuesSource::from_config`.
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self, ContextSourceError> {
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(15))
             .build()
-            .expect("reqwest::Client::build failed — TLS backend unavailable");
-        Self { http }
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("failed to build HTTP client: {e}")),
+            })?;
+        Ok(Self { http })
     }
 }
 
 impl Default for ReqwestIssueSearch {
+    /// Why: `Default` cannot return `Result`; production callers use `new()`.
+    /// What: delegates to `Self::new().expect(…)`.
+    /// Test: covered by `GithubIssuesSource::from_config`.
     fn default() -> Self {
-        Self::new()
+        Self::new().expect("reqwest::Client::build failed — TLS backend unavailable")
     }
 }
 
@@ -236,6 +248,39 @@ impl IssueSearchTransport for ReqwestIssueSearch {
             });
         }
         Ok(text)
+    }
+}
+
+// Disabled sentinels: used by `from_config` when TLS init fails to build a
+// permanently-disabled source.  `is_enabled()` is false so `gather` is never
+// called; these impls satisfy the trait bounds but are unreachable dead-ends.
+
+struct DisabledTokenResolver;
+
+#[async_trait]
+impl IssueTokenResolver for DisabledTokenResolver {
+    async fn resolve(&self, _owner: &str) -> Result<String, ContextSourceError> {
+        Err(ContextSourceError::NotConfigured {
+            src: SOURCE_NAME,
+            reason: "HTTP transport unavailable (TLS init failed)".to_string(),
+        })
+    }
+}
+
+struct DisabledIssueSearch;
+
+#[async_trait]
+impl IssueSearchTransport for DisabledIssueSearch {
+    async fn search(
+        &self,
+        _token: &str,
+        _query: &str,
+        _per_page: u32,
+    ) -> Result<String, ContextSourceError> {
+        Err(ContextSourceError::Transport {
+            src: SOURCE_NAME,
+            err: TransportErr("HTTP transport unavailable (TLS init failed)".to_string()),
+        })
     }
 }
 
@@ -294,16 +339,33 @@ impl GithubIssuesSource {
     /// available.  An explicit `enabled = false` still wins.
     /// What: computes `effective_enabled(true)` (auto-enable when not explicitly
     /// disabled), and attaches the `DualModeTokenResolver` + prod transport.
+    /// If the reqwest TLS backend cannot be initialised the source is constructed
+    /// in a permanently-disabled state so it degrades gracefully instead of
+    /// panicking at startup (closes #953).
     /// Test: `from_config_respects_explicit_disable`.
     pub fn from_config(cfg: &super::SourceConfig, run_mode: RunMode, config: ReviewConfig) -> Self {
         // GitHub credentials may come from `gh` even with no env token, so we
         // cannot cheaply pre-detect them; treat as available and fail-open later.
+        let transport = match ReqwestIssueSearch::new() {
+            Ok(t) => Box::new(t) as Box<dyn IssueSearchTransport>,
+            Err(e) => {
+                tracing::error!(
+                    "github_issues: failed to build HTTP transport (source disabled): {e}"
+                );
+                return Self {
+                    enabled: false,
+                    mode: cfg.mode,
+                    token: Box::new(DisabledTokenResolver),
+                    transport: Box::new(DisabledIssueSearch),
+                };
+            }
+        };
         let enabled = cfg.effective_enabled(true);
         Self {
             enabled,
             mode: cfg.mode,
             token: Box::new(DualModeTokenResolver::new(run_mode, config)),
-            transport: Box::new(ReqwestIssueSearch::new()),
+            transport,
         }
     }
 
@@ -431,9 +493,6 @@ impl ContextSource for GithubIssuesSource {
         Self::parse_section(&body)
     }
 }
-
-// ─── Unit tests ─────────────────────────────────────────────────────────────
-// Extracted to github_issues_tests.rs to keep this file under the 500-line cap.
 
 #[cfg(test)]
 #[path = "github_issues_tests.rs"]

--- a/crates/trusty-review/src/integrations/context/jira.rs
+++ b/crates/trusty-review/src/integrations/context/jira.rs
@@ -80,21 +80,32 @@ impl ReqwestJiraTransport {
     ///
     /// Why: external enrichment must not hang a review; a tight timeout bounds
     /// the worst case (the orchestrator also wraps each source in a timeout).
-    /// What: builds a reqwest client; panics only on TLS-backend init failure
-    /// (a programmer/environment error, never a runtime condition).
-    /// Test: covered transitively by `JiraSource::with_default_transport`.
-    pub fn new() -> Self {
+    /// What: builds a reqwest client.  Returns `Err(ContextSourceError::Transport)`
+    /// if the TLS backend cannot be initialised — surfaces the failure to
+    /// `JiraSource::from_config` instead of panicking at startup (closes #953).
+    /// Test: covered transitively by `JiraSource::from_config`.
+    pub fn new() -> Result<Self, ContextSourceError> {
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(15))
             .build()
-            .expect("reqwest::Client::build failed — TLS backend unavailable");
-        Self { http }
+            .map_err(|e| ContextSourceError::Transport {
+                src: "jira",
+                err: super::TransportErr(format!("failed to build HTTP client: {e}")),
+            })?;
+        Ok(Self { http })
     }
 }
 
 impl Default for ReqwestJiraTransport {
+    /// Construct with default settings; panics only on TLS-backend init failure.
+    ///
+    /// Why: `Default` cannot return `Result`; kept for compatibility.
+    /// Production callers inside `from_config` use `Self::new()` and handle the
+    /// error gracefully instead.
+    /// What: delegates to `Self::new().expect(…)`.
+    /// Test: covered by `JiraSource::from_config`.
     fn default() -> Self {
-        Self::new()
+        Self::new().expect("reqwest::Client::build failed — TLS backend unavailable")
     }
 }
 
@@ -145,6 +156,33 @@ impl JiraTransport for ReqwestJiraTransport {
     }
 }
 
+// ─── Disabled transport (fallback on TLS-init failure) ──────────────────────
+
+/// A no-op `JiraTransport` used when TLS backend init fails.
+///
+/// Why: `from_config` must never panic; when `ReqwestJiraTransport::new()`
+/// fails the source is constructed with this sentinel so it is permanently
+/// disabled and `gather` never calls it (guarded by `is_enabled`).
+/// What: always returns an `Api` error — but since `is_enabled()` is false the
+/// orchestrator skips `gather` entirely and this code is never reached.
+/// Test: covered implicitly by the `from_config` TLS-failure path.
+struct DisabledJiraTransport;
+
+#[async_trait]
+impl JiraTransport for DisabledJiraTransport {
+    async fn search_jql(
+        &self,
+        _creds: &AtlassianCreds,
+        _jql: &str,
+        _max_results: u32,
+    ) -> Result<String, ContextSourceError> {
+        Err(ContextSourceError::Transport {
+            src: SOURCE_NAME,
+            err: super::TransportErr("HTTP transport unavailable (TLS init failed)".to_string()),
+        })
+    }
+}
+
 // ─── The source ─────────────────────────────────────────────────────────────
 
 /// LIVE JIRA context source.
@@ -171,15 +209,30 @@ impl JiraSource {
     /// auto-disable (no creds → disabled unless explicitly enabled).
     /// What: resolves `AtlassianCreds::from_env_for(Jira)`, computes
     /// `effective_enabled(creds_present)`, and attaches the production transport.
+    /// If the reqwest TLS backend cannot be initialised the source is constructed
+    /// in a permanently-disabled state so it degrades gracefully instead of
+    /// panicking at startup (closes #953).
     /// Test: `disabled_when_no_creds`.
     pub fn from_config(cfg: &super::SourceConfig) -> Self {
         let creds = AtlassianCreds::from_env_for(AtlassianProduct::Jira);
+        let transport = match ReqwestJiraTransport::new() {
+            Ok(t) => Box::new(t) as Box<dyn JiraTransport>,
+            Err(e) => {
+                tracing::error!("jira: failed to build HTTP transport (source disabled): {e}");
+                return Self {
+                    enabled: false,
+                    mode: cfg.mode,
+                    creds: None,
+                    transport: Box::new(DisabledJiraTransport),
+                };
+            }
+        };
         let enabled = cfg.effective_enabled(creds.is_some());
         Self {
             enabled,
             mode: cfg.mode,
             creds,
-            transport: Box::new(ReqwestJiraTransport::new()),
+            transport,
         }
     }
 
@@ -288,177 +341,5 @@ impl ContextSource for JiraSource {
 // ─── Unit tests ─────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn creds() -> AtlassianCreds {
-        AtlassianCreds {
-            email: "bob@acme.com".to_string(),
-            token: "tok".to_string(), // pragma: allowlist secret
-            base_url: "https://acme.atlassian.net".to_string(),
-        }
-    }
-
-    /// A `JiraTransport` returning a fixed body (or error) without network.
-    struct FakeJira {
-        body: Result<String, ()>,
-    }
-
-    #[async_trait]
-    impl JiraTransport for FakeJira {
-        async fn search_jql(
-            &self,
-            _creds: &AtlassianCreds,
-            _jql: &str,
-            _max: u32,
-        ) -> Result<String, ContextSourceError> {
-            self.body.clone().map_err(|_| ContextSourceError::Api {
-                src: SOURCE_NAME,
-                status: 500,
-                body: "boom".to_string(),
-            })
-        }
-    }
-
-    fn subject() -> ReviewSubject {
-        ReviewSubject {
-            owner: "acme".to_string(),
-            repo: "backend".to_string(),
-            title: "Add token refresh".to_string(),
-            identifiers: vec!["TokenStore".to_string()],
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn query_builds_jql_keyword() {
-        // No ticket key in title/body → keyword fallback path.
-        let jql = JiraSource::build_jql(&subject()).expect("has signal");
-        assert!(jql.contains("text ~ \"Add token refresh TokenStore\""));
-        assert!(jql.contains("ORDER BY updated DESC"));
-    }
-
-    #[test]
-    fn query_builds_jql_ticket_ids() {
-        // Fix 1: a ticket key in the title → exact issueKey lookup, NOT keyword.
-        let subj = ReviewSubject {
-            title: "PROJ-42 add token refresh".to_string(),
-            identifiers: vec!["TokenStore".to_string()],
-            ..Default::default()
-        };
-        let jql = JiraSource::build_jql(&subj).expect("has signal");
-        assert_eq!(jql, "issueKey in (PROJ-42) ORDER BY updated DESC");
-        assert!(!jql.contains("text ~"));
-    }
-
-    #[test]
-    fn query_ticket_ids_scan_body_too() {
-        // A key only in the PR body is still found (title has no key).
-        let subj = ReviewSubject {
-            title: "Add token refresh".to_string(),
-            body: "Implements PROJ-7 and PROJ-8.".to_string(),
-            ..Default::default()
-        };
-        let jql = JiraSource::build_jql(&subj).expect("has signal");
-        assert_eq!(jql, "issueKey in (PROJ-7, PROJ-8) ORDER BY updated DESC");
-    }
-
-    #[test]
-    fn query_ticket_ids_dedup_and_capped() {
-        // Duplicates collapse; the list is capped at MAX_RESULTS keys.
-        let ids: Vec<String> = (1..=10).map(|n| format!("PROJ-{n}")).collect();
-        let subj = ReviewSubject {
-            title: format!("{} PROJ-1", ids.join(" ")),
-            ..Default::default()
-        };
-        let jql = JiraSource::build_jql(&subj).expect("has signal");
-        // Exactly MAX_RESULTS (5) keys, comma-separated.
-        let inner = jql
-            .trim_start_matches("issueKey in (")
-            .split(')')
-            .next()
-            .unwrap();
-        assert_eq!(inner.split(", ").count(), MAX_RESULTS as usize);
-    }
-
-    #[test]
-    fn query_strips_quotes() {
-        let subj = ReviewSubject {
-            title: "Add \"quoted\" thing".to_string(),
-            ..Default::default()
-        };
-        let jql = JiraSource::build_jql(&subj).unwrap();
-        // No raw double-quotes inside the keyword payload would break the JQL.
-        assert!(!jql.contains("\"quoted\""));
-    }
-
-    #[test]
-    fn query_none_without_signal() {
-        let subj = ReviewSubject::default();
-        assert!(JiraSource::build_jql(&subj).is_none());
-    }
-
-    #[tokio::test]
-    async fn disabled_when_no_creds() {
-        // Forced-on but no creds → NotConfigured (fail-open at orchestrator).
-        let src = JiraSource::new(
-            true,
-            RetrievalMode::Live,
-            None,
-            Box::new(FakeJira {
-                body: Ok("{}".into()),
-            }),
-        );
-        let r = src.gather(&subject()).await;
-        assert!(matches!(r, Err(ContextSourceError::NotConfigured { .. })));
-    }
-
-    #[tokio::test]
-    async fn semantic_mode_errors() {
-        let src = JiraSource::new(
-            true,
-            RetrievalMode::Semantic,
-            Some(creds()),
-            Box::new(FakeJira {
-                body: Ok("{}".into()),
-            }),
-        );
-        let r = src.gather(&subject()).await;
-        assert!(matches!(
-            r,
-            Err(ContextSourceError::SemanticNotImplemented { src: "jira" })
-        ));
-    }
-
-    #[tokio::test]
-    async fn gather_with_fake_transport() {
-        let body =
-            r#"{"issues":[{"key":"PROJ-7","fields":{"summary":"Fix","status":{"name":"Open"}}}]}"#;
-        let src = JiraSource::new(
-            true,
-            RetrievalMode::Live,
-            Some(creds()),
-            Box::new(FakeJira {
-                body: Ok(body.to_string()),
-            }),
-        );
-        let section = src.gather(&subject()).await.expect("ok");
-        assert_eq!(section.snippets.len(), 1);
-        assert_eq!(section.snippets[0].title, "PROJ-7 — Fix");
-    }
-
-    #[tokio::test]
-    async fn gather_propagates_api_error_for_logging() {
-        let src = JiraSource::new(
-            true,
-            RetrievalMode::Live,
-            Some(creds()),
-            Box::new(FakeJira { body: Err(()) }),
-        );
-        let r = src.gather(&subject()).await;
-        assert!(matches!(
-            r,
-            Err(ContextSourceError::Api { status: 500, .. })
-        ));
-    }
-}
+#[path = "jira_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/integrations/context/jira_tests.rs
+++ b/crates/trusty-review/src/integrations/context/jira_tests.rs
@@ -1,0 +1,182 @@
+//! Unit tests for `JiraSource` and related helpers.
+//!
+//! Why: split from `jira.rs` to keep that file under the 500-line cap
+//! (issue #610).  All tests use fake transports — no network required.
+//! What: covers JQL construction, ticket-key extraction, gather flow,
+//! fail-open behaviour, and disabled-when-no-creds path.
+//! Test: each function is a self-contained unit or async unit test.
+
+use async_trait::async_trait;
+
+use super::*;
+
+fn creds() -> AtlassianCreds {
+    AtlassianCreds {
+        email: "bob@acme.com".to_string(),
+        token: "tok".to_string(), // pragma: allowlist secret
+        base_url: "https://acme.atlassian.net".to_string(),
+    }
+}
+
+/// A `JiraTransport` returning a fixed body (or error) without network.
+struct FakeJira {
+    body: Result<String, ()>,
+}
+
+#[async_trait]
+impl JiraTransport for FakeJira {
+    async fn search_jql(
+        &self,
+        _creds: &AtlassianCreds,
+        _jql: &str,
+        _max: u32,
+    ) -> Result<String, ContextSourceError> {
+        self.body.clone().map_err(|_| ContextSourceError::Api {
+            src: SOURCE_NAME,
+            status: 500,
+            body: "boom".to_string(),
+        })
+    }
+}
+
+fn subject() -> ReviewSubject {
+    ReviewSubject {
+        owner: "acme".to_string(),
+        repo: "backend".to_string(),
+        title: "Add token refresh".to_string(),
+        identifiers: vec!["TokenStore".to_string()],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn query_builds_jql_keyword() {
+    // No ticket key in title/body → keyword fallback path.
+    let jql = JiraSource::build_jql(&subject()).expect("has signal");
+    assert!(jql.contains("text ~ \"Add token refresh TokenStore\""));
+    assert!(jql.contains("ORDER BY updated DESC"));
+}
+
+#[test]
+fn query_builds_jql_ticket_ids() {
+    // Fix 1: a ticket key in the title → exact issueKey lookup, NOT keyword.
+    let subj = ReviewSubject {
+        title: "PROJ-42 add token refresh".to_string(),
+        identifiers: vec!["TokenStore".to_string()],
+        ..Default::default()
+    };
+    let jql = JiraSource::build_jql(&subj).expect("has signal");
+    assert_eq!(jql, "issueKey in (PROJ-42) ORDER BY updated DESC");
+    assert!(!jql.contains("text ~"));
+}
+
+#[test]
+fn query_ticket_ids_scan_body_too() {
+    // A key only in the PR body is still found (title has no key).
+    let subj = ReviewSubject {
+        title: "Add token refresh".to_string(),
+        body: "Implements PROJ-7 and PROJ-8.".to_string(),
+        ..Default::default()
+    };
+    let jql = JiraSource::build_jql(&subj).expect("has signal");
+    assert_eq!(jql, "issueKey in (PROJ-7, PROJ-8) ORDER BY updated DESC");
+}
+
+#[test]
+fn query_ticket_ids_dedup_and_capped() {
+    // Duplicates collapse; the list is capped at MAX_RESULTS keys.
+    let ids: Vec<String> = (1..=10).map(|n| format!("PROJ-{n}")).collect();
+    let subj = ReviewSubject {
+        title: format!("{} PROJ-1", ids.join(" ")),
+        ..Default::default()
+    };
+    let jql = JiraSource::build_jql(&subj).expect("has signal");
+    // Exactly MAX_RESULTS (5) keys, comma-separated.
+    let inner = jql
+        .trim_start_matches("issueKey in (")
+        .split(')')
+        .next()
+        .unwrap();
+    assert_eq!(inner.split(", ").count(), MAX_RESULTS as usize);
+}
+
+#[test]
+fn query_strips_quotes() {
+    let subj = ReviewSubject {
+        title: "Add \"quoted\" thing".to_string(),
+        ..Default::default()
+    };
+    let jql = JiraSource::build_jql(&subj).unwrap();
+    // No raw double-quotes inside the keyword payload would break the JQL.
+    assert!(!jql.contains("\"quoted\""));
+}
+
+#[test]
+fn query_none_without_signal() {
+    let subj = ReviewSubject::default();
+    assert!(JiraSource::build_jql(&subj).is_none());
+}
+
+#[tokio::test]
+async fn disabled_when_no_creds() {
+    // Forced-on but no creds → NotConfigured (fail-open at orchestrator).
+    let src = JiraSource::new(
+        true,
+        RetrievalMode::Live,
+        None,
+        Box::new(FakeJira {
+            body: Ok("{}".into()),
+        }),
+    );
+    let r = src.gather(&subject()).await;
+    assert!(matches!(r, Err(ContextSourceError::NotConfigured { .. })));
+}
+
+#[tokio::test]
+async fn semantic_mode_errors() {
+    let src = JiraSource::new(
+        true,
+        RetrievalMode::Semantic,
+        Some(creds()),
+        Box::new(FakeJira {
+            body: Ok("{}".into()),
+        }),
+    );
+    let r = src.gather(&subject()).await;
+    assert!(matches!(
+        r,
+        Err(ContextSourceError::SemanticNotImplemented { src: "jira" })
+    ));
+}
+
+#[tokio::test]
+async fn gather_with_fake_transport() {
+    let body =
+        r#"{"issues":[{"key":"PROJ-7","fields":{"summary":"Fix","status":{"name":"Open"}}}]}"#;
+    let src = JiraSource::new(
+        true,
+        RetrievalMode::Live,
+        Some(creds()),
+        Box::new(FakeJira {
+            body: Ok(body.to_string()),
+        }),
+    );
+    let section = src.gather(&subject()).await.expect("ok");
+    assert_eq!(section.snippets.len(), 1);
+    assert_eq!(section.snippets[0].title, "PROJ-7 — Fix");
+}
+
+#[tokio::test]
+async fn gather_propagates_api_error_for_logging() {
+    let src = JiraSource::new(
+        true,
+        RetrievalMode::Live,
+        Some(creds()),
+        Box::new(FakeJira { body: Err(()) }),
+    );
+    let r = src.gather(&subject()).await;
+    assert!(matches!(
+        r,
+        Err(ContextSourceError::Api { status: 500, .. })
+    ));
+}

--- a/crates/trusty-review/src/integrations/github/auth/app.rs
+++ b/crates/trusty-review/src/integrations/github/auth/app.rs
@@ -288,7 +288,7 @@ mod tests {
     async fn resolve_app_token_no_credentials_errors() {
         // App mode without app_id/private_key must yield an Auth error
         // (no network call is made).
-        let client = GithubClient::new();
+        let client = GithubClient::new().expect("TLS init should succeed in tests");
         let result = resolve_app_token(&client, None, None, &[], "any-owner").await;
         match result {
             Err(GithubError::Auth(_)) => {}
@@ -301,7 +301,7 @@ mod tests {
         // App creds present but no installation matches the owner → MissingToken.
         // mint_app_jwt runs but exchange is never reached (no match), so this is
         // network-free.
-        let client = GithubClient::new();
+        let client = GithubClient::new().expect("TLS init should succeed in tests");
         let installs = vec![("otherorg".to_string(), 123_u64)];
         let result = resolve_app_token(
             &client,

--- a/crates/trusty-review/src/integrations/github/auth/strategy.rs
+++ b/crates/trusty-review/src/integrations/github/auth/strategy.rs
@@ -370,7 +370,7 @@ mod tests {
         let mut config = ReviewConfig::load(None);
         config.github_app_id = None;
         config.github_app_private_key = None;
-        let client = GithubClient::new();
+        let client = GithubClient::new().expect("TLS init should succeed in tests");
         let result = AuthStrategy::App
             .resolve_token(&client, &config, "acme")
             .await;

--- a/crates/trusty-review/src/integrations/github/mod.rs
+++ b/crates/trusty-review/src/integrations/github/mod.rs
@@ -89,8 +89,11 @@ impl GithubClient {
     ///
     /// Why: most callers do not need to customise timeout or TLS settings.
     /// What: builds a `reqwest::Client` with a 30-second request timeout.
+    /// Returns `Err(GithubError::Transport)` if the TLS backend cannot be
+    /// initialised — surfaces the failure to the caller rather than panicking
+    /// at daemon startup (closes #953).
     /// Test: used by auth and pr module tests.
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self, GithubError> {
         Self::with_timeout(std::time::Duration::from_secs(30))
     }
 
@@ -98,25 +101,32 @@ impl GithubClient {
     ///
     /// Why: tests use short timeouts (e.g. 200ms) to verify transport-error
     /// handling quickly.
-    /// What: builds a `reqwest::Client` with the specified timeout; panics only
-    /// if the TLS backend cannot be initialised (a programmer error — not a
-    /// runtime condition).
+    /// What: builds a `reqwest::Client` with the specified timeout.  Returns
+    /// `Err(GithubError::Transport)` if the TLS backend cannot be initialised
+    /// — surfaces the failure instead of panicking at startup (closes #953).
     /// Test: used by pr module transport-error tests.
-    pub fn with_timeout(timeout: std::time::Duration) -> Self {
+    pub fn with_timeout(timeout: std::time::Duration) -> Result<Self, GithubError> {
         let http = reqwest::Client::builder()
             .timeout(timeout)
             .build()
-            .expect("reqwest::Client::build failed — TLS backend unavailable");
-        Self {
+            .map_err(|e| GithubError::Transport(format!("failed to build HTTP client: {e}")))?;
+        Ok(Self {
             http,
             user_agent: "trusty-review".to_string(),
-        }
+        })
     }
 }
 
 impl Default for GithubClient {
+    /// Construct with default settings; panics only on TLS-backend init failure.
+    ///
+    /// Why: `Default` cannot return `Result`; kept for test code and contexts
+    /// where the caller already knows TLS is available.  Production paths should
+    /// use `GithubClient::new()` and propagate the error.
+    /// What: delegates to `Self::new().expect(…)`.
+    /// Test: `github_client_default_constructs`.
     fn default() -> Self {
-        Self::new()
+        Self::new().expect("reqwest::Client::build failed — TLS backend unavailable")
     }
 }
 

--- a/crates/trusty-review/src/integrations/github/posting.rs
+++ b/crates/trusty-review/src/integrations/github/posting.rs
@@ -346,7 +346,8 @@ mod tests {
     async fn post_pr_review_transport_error_on_unreachable() {
         // Posting to a guaranteed-unreachable host yields a Transport error,
         // never a panic. (127.0.0.1:1 is always refused.)
-        let client = GithubClient::with_timeout(std::time::Duration::from_millis(200));
+        let client = GithubClient::with_timeout(std::time::Duration::from_millis(200))
+            .expect("TLS init should succeed in tests");
         let result = sample_result();
         // Override the base by hitting a refused port through a raw request:
         // post_pr_review always targets api.github.com, so we instead assert the

--- a/crates/trusty-review/src/integrations/github/pr.rs
+++ b/crates/trusty-review/src/integrations/github/pr.rs
@@ -244,7 +244,8 @@ mod tests {
     #[tokio::test]
     async fn fetch_pr_diff_transport_error_on_unreachable_host() {
         // Sending to a guaranteed-unreachable address must yield a Transport error.
-        let client = GithubClient::with_timeout(std::time::Duration::from_millis(200));
+        let client = GithubClient::with_timeout(std::time::Duration::from_millis(200))
+            .expect("TLS init should succeed in tests");
         // 127.0.0.1:1 is always refused (port 1 is reserved/privileged).
         let result = client
             .http

--- a/crates/trusty-review/src/integrations/search_client.rs
+++ b/crates/trusty-review/src/integrations/search_client.rs
@@ -34,7 +34,8 @@ use serde::{Deserialize, Serialize};
 /// context).
 /// What: `Transport` wraps reqwest failures; `Api` carries non-2xx responses;
 /// `Parse` indicates unexpected JSON; `Unavailable` is the soft degradation
-/// signal.
+/// signal; `ClientInit` covers TLS-backend initialisation failures at
+/// construction time so callers receive an `Err` instead of a panic.
 /// Test: `search_error_display`.
 #[derive(Debug, thiserror::Error)]
 pub enum SearchClientError {
@@ -58,6 +59,10 @@ pub enum SearchClientError {
     /// trusty-search health check failed: service is unavailable.
     #[error("trusty-search is unavailable: {0}")]
     Unavailable(String),
+
+    /// reqwest client construction failed (TLS backend unavailable).
+    #[error("failed to build HTTP client: {0}")]
+    ClientInit(String),
 }
 
 // ─── Response types ───────────────────────────────────────────────────────────
@@ -221,25 +226,28 @@ impl HttpSearchClient {
     /// Why: allows tests and library consumers to point the client at any URL
     /// without going through the config system.
     /// What: strips any trailing slash from `base_url` to avoid double-slash
-    /// path construction.
+    /// path construction.  Returns `Err(ClientInit)` if the TLS backend cannot
+    /// be initialised — surfaces the failure to the caller rather than panicking
+    /// at daemon startup (closes #953).
     /// Test: `http_search_client_url_is_configurable`.
-    pub fn new(base_url: impl Into<String>) -> Self {
+    pub fn new(base_url: impl Into<String>) -> Result<Self, SearchClientError> {
         let raw = base_url.into();
         let base_url = raw.trim_end_matches('/').to_string();
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
-            .expect("reqwest::Client::build failed");
-        Self { base_url, http }
+            .map_err(|e| SearchClientError::ClientInit(e.to_string()))?;
+        Ok(Self { base_url, http })
     }
 
     /// Construct from a `ReviewConfig`, reading `search_url`.
     ///
     /// Why: the pipeline constructs the client from its injected config rather
     /// than reading env vars.
-    /// What: calls `Self::new(config.search_url.clone())`.
+    /// What: calls `Self::new(config.search_url.clone())` and propagates any
+    /// TLS-backend init failure as `Err`.
     /// Test: `http_search_client_from_config`.
-    pub fn from_config(config: &crate::config::ReviewConfig) -> Self {
+    pub fn from_config(config: &crate::config::ReviewConfig) -> Result<Self, SearchClientError> {
         Self::new(config.search_url.clone())
     }
 

--- a/crates/trusty-review/src/integrations/search_client_tests.rs
+++ b/crates/trusty-review/src/integrations/search_client_tests.rs
@@ -23,13 +23,13 @@ fn search_client_trait_object_compiles() {
 
 #[test]
 fn http_search_client_url_is_configurable() {
-    let client = HttpSearchClient::new("http://127.0.0.1:7878");
+    let client = HttpSearchClient::new("http://127.0.0.1:7878").expect("TLS init should succeed");
     assert_eq!(client.base_url(), "http://127.0.0.1:7878");
 }
 
 #[test]
 fn http_search_client_strips_trailing_slash() {
-    let client = HttpSearchClient::new("http://127.0.0.1:7878/");
+    let client = HttpSearchClient::new("http://127.0.0.1:7878/").expect("TLS init should succeed");
     // Trailing slash must be removed to prevent double-slash paths.
     assert_eq!(client.base_url(), "http://127.0.0.1:7878");
 }
@@ -38,7 +38,7 @@ fn http_search_client_strips_trailing_slash() {
 fn http_search_client_from_config() {
     let mut config = crate::config::ReviewConfig::load(None);
     config.search_url = "http://localhost:9999".to_string();
-    let client = HttpSearchClient::from_config(&config);
+    let client = HttpSearchClient::from_config(&config).expect("TLS init should succeed");
     assert_eq!(client.base_url(), "http://localhost:9999");
 }
 
@@ -187,7 +187,7 @@ fn search_error_display() {
 #[tokio::test]
 async fn health_check_transport_error_on_unreachable() {
     // Port 1 is always refused; this verifies graceful transport error handling.
-    let client = HttpSearchClient::new("http://127.0.0.1:1");
+    let client = HttpSearchClient::new("http://127.0.0.1:1").expect("TLS init should succeed");
     let result = client.health().await;
     assert!(
         result.is_err(),
@@ -202,7 +202,7 @@ async fn health_check_transport_error_on_unreachable() {
 
 #[tokio::test]
 async fn search_transport_error_on_unreachable() {
-    let client = HttpSearchClient::new("http://127.0.0.1:1");
+    let client = HttpSearchClient::new("http://127.0.0.1:1").expect("TLS init should succeed");
     let result = client.search("main", "fn auth", Some(5)).await;
     assert!(
         result.is_err(),

--- a/crates/trusty-review/src/integrations/subprocess_analyze_client/client.rs
+++ b/crates/trusty-review/src/integrations/subprocess_analyze_client/client.rs
@@ -40,26 +40,33 @@ impl SubprocessAnalyzeClient {
     /// Why: allows callers and tests to inject specific paths without relying on
     /// PATH or env vars.
     /// What: builds the probe client (5-second timeout, matching the HTTP path).
+    /// Returns `Err(AnalyzeClientError::ClientInit)` if the TLS backend cannot
+    /// be initialised — surfaces the failure to the caller rather than panicking
+    /// at daemon startup (closes #953).
     /// Test: `subprocess_client_health_check_fails_gracefully`.
-    pub fn new(binary: impl Into<String>, search_url: impl Into<String>) -> Self {
+    pub fn new(
+        binary: impl Into<String>,
+        search_url: impl Into<String>,
+    ) -> Result<Self, AnalyzeClientError> {
         let probe_http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(5))
             .build()
-            .expect("reqwest::Client::build is infallible with valid config");
-        Self {
+            .map_err(|e| AnalyzeClientError::ClientInit(e.to_string()))?;
+        Ok(Self {
             binary: binary.into(),
             search_url: search_url.into(),
             probe_http,
-        }
+        })
     }
 
     /// Construct from a `ReviewConfig`.
     ///
     /// Why: the canonical factory used by both `run.rs` and `serve.rs`.
     /// What: reads `TRUSTY_ANALYZE_BIN` (falls back to `"trusty-analyze"`) for
-    /// the binary; takes `config.search_url` for the health probe.
+    /// the binary; takes `config.search_url` for the health probe.  Propagates
+    /// any TLS-backend init failure as `Err`.
     /// Test: `subprocess_client_from_config`.
-    pub fn from_config(config: &crate::config::ReviewConfig) -> Self {
+    pub fn from_config(config: &crate::config::ReviewConfig) -> Result<Self, AnalyzeClientError> {
         let binary = std::env::var(ENV_ANALYZE_BIN)
             .ok()
             .filter(|s| !s.is_empty())

--- a/crates/trusty-review/src/integrations/subprocess_analyze_client/tests.rs
+++ b/crates/trusty-review/src/integrations/subprocess_analyze_client/tests.rs
@@ -17,7 +17,8 @@ use super::{
 
 #[test]
 fn subprocess_client_binary_accessor() {
-    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878");
+    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878")
+        .expect("TLS init should succeed");
     assert_eq!(client.binary(), "trusty-analyze");
 }
 
@@ -25,7 +26,8 @@ fn subprocess_client_binary_accessor() {
 #[tokio::test]
 async fn subprocess_client_health_check_fails_gracefully() {
     // Port 1 is always refused.
-    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:1");
+    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:1")
+        .expect("TLS init should succeed");
     let result = client.health().await;
     assert!(
         result.is_err(),
@@ -40,7 +42,8 @@ async fn subprocess_client_health_check_fails_gracefully() {
 /// has_analysis must return false (not panic) on transport error.
 #[tokio::test]
 async fn subprocess_client_has_analysis_returns_false_on_error() {
-    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:1");
+    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:1")
+        .expect("TLS init should succeed");
     assert!(
         !client.has_analysis("main").await,
         "has_analysis must return false on error"
@@ -50,7 +53,8 @@ async fn subprocess_client_has_analysis_returns_false_on_error() {
 /// complexity_hotspots always returns empty for the subprocess model.
 #[tokio::test]
 async fn subprocess_client_hotspots_returns_empty() {
-    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878");
+    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878")
+        .expect("TLS init should succeed");
     let result = client.complexity_hotspots("main", Some(10)).await.unwrap();
     assert!(
         result.is_empty(),
@@ -61,7 +65,8 @@ async fn subprocess_client_hotspots_returns_empty() {
 /// smells always returns empty for the subprocess model.
 #[tokio::test]
 async fn subprocess_client_smells_returns_empty() {
-    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878");
+    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878")
+        .expect("TLS init should succeed");
     let result = client.smells("main").await.unwrap();
     assert!(
         result.is_empty(),
@@ -74,7 +79,8 @@ async fn subprocess_client_smells_returns_empty() {
 async fn subprocess_client_binary_not_found() {
     // "trusty-analyze-nonexistent-binary" is guaranteed not to be on PATH.
     let client =
-        SubprocessAnalyzeClient::new("trusty-analyze-nonexistent-binary", "http://127.0.0.1:1");
+        SubprocessAnalyzeClient::new("trusty-analyze-nonexistent-binary", "http://127.0.0.1:1")
+            .expect("TLS init should succeed");
     // health() probes search first; search is down so it short-circuits with
     // Unavailable before reaching the binary check.  We test analyze_diff
     // directly for the binary-not-found path.
@@ -221,6 +227,7 @@ fn spawn_analyze_review_with_fake_binary_that_fails() {
 #[test]
 fn subprocess_client_trait_object_compiles() {
     fn _accepts_dyn(_c: &dyn AnalyzeClient) {}
-    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878");
+    let client = SubprocessAnalyzeClient::new("trusty-analyze", "http://127.0.0.1:7878")
+        .expect("TLS init should succeed");
     _accepts_dyn(&client);
 }

--- a/crates/trusty-review/src/mcp/mod.rs
+++ b/crates/trusty-review/src/mcp/mod.rs
@@ -109,8 +109,10 @@ pub async fn build_review_state() -> Result<AppState> {
         None
     };
 
-    let search = HttpSearchClient::from_config(&config);
-    let analyze = HttpAnalyzeClient::from_config(&config);
+    let search = HttpSearchClient::from_config(&config)
+        .map_err(|e| anyhow::anyhow!("failed to build search HTTP client: {e}"))?;
+    let analyze = HttpAnalyzeClient::from_config(&config)
+        .map_err(|e| anyhow::anyhow!("failed to build analyze HTTP client: {e}"))?;
 
     info!(
         reviewer_model = %config.role_models.reviewer.model,

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -184,7 +184,8 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
         .to_string();
 
     // Resolve GitHub token.
-    let client = GithubClient::new();
+    let client = GithubClient::new()
+        .map_err(|e| ToolError::InvalidParams(format!("failed to build HTTP client: {e}")))?;
     let token = AuthStrategy::select(RunMode::Serve, None)
         .resolve_token(&client, &state.config, owner)
         .await

--- a/crates/trusty-review/src/pipeline/diff.rs
+++ b/crates/trusty-review/src/pipeline/diff.rs
@@ -65,7 +65,7 @@ pub async fn load_diff(source: &DiffSource) -> Result<String, GithubError> {
             pr,
             token,
         } => {
-            let client = GithubClient::new();
+            let client = GithubClient::new()?;
             debug!(owner, repo, pr, "fetching PR diff from GitHub");
             fetch_pr_diff(&client, owner, repo, *pr, token).await
         }

--- a/crates/trusty-review/src/pipeline/post.rs
+++ b/crates/trusty-review/src/pipeline/post.rs
@@ -297,7 +297,7 @@ async fn post_live(
     config: &ReviewConfig,
     ctx: &PostContext<'_>,
 ) -> Result<(), crate::integrations::github::GithubError> {
-    let client = GithubClient::new();
+    let client = GithubClient::new()?;
     let strategy = AuthStrategy::select(ctx.run_mode, None);
     let token = strategy.resolve_token(&client, config, ctx.owner).await?;
     let posted = post_pr_review(&client, ctx.owner, ctx.repo, ctx.pr, &token, result).await?;

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -400,7 +400,7 @@ async fn fetch_github_pr_meta(
     pr: u64,
     run_mode: RunMode,
 ) -> Result<(ReviewPrMeta, String), GithubError> {
-    let client = GithubClient::new();
+    let client = GithubClient::new()?;
     let token = AuthStrategy::select(run_mode, None)
         .resolve_token(&client, config, owner)
         .await?;

--- a/crates/trusty-review/src/profile/reporter.rs
+++ b/crates/trusty-review/src/profile/reporter.rs
@@ -168,7 +168,13 @@ impl Reporter {
     /// no real network calls).
     pub async fn upsert_github_issue(&self, profile: &ContributorProfile) -> Option<String> {
         let config = self.github_config.as_ref()?;
-        let client = GithubClient::new();
+        let client = match GithubClient::new() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "upsert_github_issue: failed to build HTTP client — skipping");
+                return None;
+            }
+        };
         let markdown = render_markdown(profile);
 
         match reporter_github::github_upsert_issue(&client, config, profile, &markdown).await {


### PR DESCRIPTION
## Summary

Closes #953

Eight production constructors previously called `.expect()` on `reqwest::Client::builder().build()`, panicking on TLS init failure at daemon startup. This PR makes them return `Result` and propagates the error to callers, so TLS failures surface as structured errors instead of killing the process.

## Constructors converted

| Constructor | New return type | Error variant |
|---|---|---|
| `HttpSearchClient::new` | `Result<Self, SearchClientError>` | `SearchClientError::ClientInit(String)` |
| `HttpSearchClient::from_config` | `Result<Self, SearchClientError>` | (delegates to `new`) |
| `HttpAnalyzeClient::new` | `Result<Self, AnalyzeClientError>` | `AnalyzeClientError::ClientInit(String)` |
| `HttpAnalyzeClient::from_config` | `Result<Self, AnalyzeClientError>` | (delegates to `new`) |
| `SubprocessAnalyzeClient::new` | `Result<Self, AnalyzeClientError>` | `AnalyzeClientError::ClientInit(String)` |
| `SubprocessAnalyzeClient::from_config` | `Result<Self, AnalyzeClientError>` | (delegates to `new`) |
| `GithubClient::new` | `Result<Self, GithubError>` | `GithubError::Transport(String)` |
| `GithubClient::with_timeout` | `Result<Self, GithubError>` | `GithubError::Transport(String)` |
| `ReqwestConfluenceTransport::new` | `Result<Self, ContextSourceError>` | `ContextSourceError::Transport` |
| `ReqwestJiraTransport::new` | `Result<Self, ContextSourceError>` | `ContextSourceError::Transport` |
| `ReqwestIssueSearch::new` | `Result<Self, ContextSourceError>` | `ContextSourceError::Transport` |

## Caller update strategy

- **Binary/command callers** (`run`, `serve`, `compare`, `mcp/mod`): propagate with `.map_err(|e| anyhow::anyhow!(...))? ` into their existing `anyhow::Result` returns.
- **Pipeline callers** (`diff.rs`, `post.rs`, `runner.rs`): propagate with `?` into existing `GithubError` return types.
- **MCP tools.rs**: maps to `ToolError::InvalidParams`.
- **reporter.rs**: degrades gracefully — logs a `warn!` and returns `None`.
- **Context-source `from_config`** (Confluence, Jira, GitHub Issues): keeps infallible `Self` return type; on TLS failure, constructs a permanently-disabled source with no-op sentinel trait impls (`DisabledTransport`, `DisabledJiraTransport`, `DisabledTokenResolver`, `DisabledIssueSearch`). The orchestrator's `is_enabled()` check skips them without error — consistent with the existing fail-open pattern.
- **`Default` impls**: kept panicking with clear doc comments; production callers use `new()`.
- **Test call sites**: updated with `.expect("TLS init should succeed in tests")`.

## Bonus: line-cap compliance

Adding the sentinel structs pushed `analyze_client.rs` and `jira.rs` over the 500-line cap. Extracted their test sections into sibling `*_tests.rs` files (matching the existing project pattern for `search_client_tests.rs` and `github_issues_tests.rs`). Also ratcheted `.line-cap-allowlist.tsv` down by removing the now-under-cap entry for `analyze_client.rs`.

## Test plan

- [ ] `cargo test -p trusty-review` — all 762 lib + 12 binary tests pass
- [ ] `cargo clippy -p trusty-review --all-targets -- -D warnings` — zero warnings
- [ ] `cargo fmt --check -p trusty-review` — no formatting drift
- [ ] `bash scripts/check_line_cap.sh` — 0 violations
- [ ] Pre-commit hooks pass (trim whitespace, secrets check, line-cap gate)

All four verified green before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)