### PR TITLE
feat(review): port subcommand + systemd unit (ops parity)

### DIFF
--- a/crates/trusty-review/src/commands/mod.rs
+++ b/crates/trusty-review/src/commands/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod compare;
 pub mod daemon_utils;
+pub mod port;
 pub mod run;
 #[cfg(feature = "http-server")]
 pub mod serve;

--- a/crates/trusty-review/src/commands/port.rs
+++ b/crates/trusty-review/src/commands/port.rs
@@ -59,9 +59,14 @@ pub fn parse_port_from_addr(addr: &str) -> Option<u16> {
 /// Why: separating the formatting logic from the I/O lets unit tests assert
 /// the output string without spawning a daemon or touching a discovery file.
 /// What: takes a validated `host:port` string plus the desired format and
-/// returns the formatted string to print. Returns `None` when the port cannot
-/// be parsed from the address (which would indicate a corrupt discovery file).
-/// Test: `format_output_*` unit tests cover all three variants and edge cases.
+/// returns the formatted string to print. For the JSON format, IPv6 bracket
+/// notation (e.g. `[::1]`) is stripped from the `addr` field because the JSON
+/// consumer receives a plain hostname, not a URI — the brackets are only
+/// required in URI authority syntax. The `--addr` output keeps the original
+/// string unchanged for URI validity. Returns `None` when the port cannot be
+/// parsed from the address (which would indicate a corrupt discovery file).
+/// Test: `format_output_*` unit tests cover all three variants and edge cases,
+/// including the IPv6 bracket-stripping behaviour for the JSON path.
 pub fn format_output(addr: &str, format: PortFormat) -> Option<String> {
     match format {
         PortFormat::Port => {
@@ -72,7 +77,10 @@ pub fn format_output(addr: &str, format: PortFormat) -> Option<String> {
         PortFormat::Json => {
             let port = parse_port_from_addr(addr)?;
             let colon = addr.rfind(':')?;
-            let host = &addr[..colon];
+            let host_part = &addr[..colon];
+            // Strip surrounding brackets for IPv6 addresses (e.g. `[::1]` → `::1`)
+            // so the JSON `addr` field contains a plain host, not a URI bracket form.
+            let host = host_part.trim_matches(|c| c == '[' || c == ']');
             Some(format!(r#"{{"addr":"{host}","port":{port}}}"#))
         }
     }
@@ -85,28 +93,22 @@ pub fn format_output(addr: &str, format: PortFormat) -> Option<String> {
 /// work without guessing. Closes issue #957 (ops parity with trusty-search).
 /// What: reads the address from the `http_addr` discovery file via
 /// `trusty_common::read_daemon_addr("trusty-review")`, formats it per the
-/// caller's flags, and prints to stdout. On any error (no daemon, missing
-/// file, corrupt address) the message goes to stderr and the function returns
-/// `Err` so `main` exits non-zero.
+/// caller's flags, and prints to stdout. Returns `Err` (with a human-readable
+/// message) on any error (no daemon, missing file, corrupt address) so `main`
+/// can exit non-zero via the normal anyhow error path without bypassing Drop.
 /// Test: unit tests cover all format variants; the discovery-file path is
 /// covered by `daemon_utils` tests that write fake discovery files.
 pub fn handle_port(format: PortFormat) -> Result<()> {
     let addr = match trusty_common::read_daemon_addr("trusty-review") {
         Ok(Some(a)) if !a.is_empty() => a,
         Ok(Some(_)) | Ok(None) => {
-            // Fall back to the default port as a best-effort hint.  We
-            // cannot confirm the daemon is actually running on this port,
-            // so exit non-zero with a clear explanation rather than
-            // silently printing a potentially wrong address.
-            eprintln!(
+            anyhow::bail!(
                 "trusty-review: no daemon running (address file not found). \
                  Start with `trusty-review serve`."
             );
-            std::process::exit(1);
         }
         Err(e) => {
-            eprintln!("trusty-review: could not read daemon address: {e:#}");
-            std::process::exit(1);
+            anyhow::bail!("trusty-review: could not read daemon address: {e:#}");
         }
     };
 
@@ -116,12 +118,11 @@ pub fn handle_port(format: PortFormat) -> Result<()> {
             Ok(())
         }
         None => {
-            eprintln!(
+            anyhow::bail!(
                 "trusty-review: daemon address file contains an unrecognised \
                  address `{addr}` (expected host:port). \
                  Re-start the daemon with `trusty-review serve`."
             );
-            std::process::exit(1);
         }
     }
 }
@@ -175,8 +176,21 @@ mod tests {
     /// Why: on dual-stack hosts the daemon might bind `[::1]:7880`; `rfind`
     /// correctly splits on the final `:` rather than the first.
     #[test]
-    fn format_output_ipv6_port() {
+    fn parse_port_ipv6() {
         assert_eq!(parse_port_from_addr("[::1]:7880"), Some(7880));
+    }
+
+    /// `--json` with an IPv6 address strips the brackets from the `addr` field.
+    ///
+    /// Why: JSON consumers expect a plain hostname (`::1`), not the URI
+    /// bracket form (`[::1]`); the `--addr` output keeps brackets for URI
+    /// validity, but JSON is a different serialisation context.
+    #[test]
+    fn format_output_json_ipv6_strips_brackets() {
+        assert_eq!(
+            format_output("[::1]:7880", PortFormat::Json),
+            Some(r#"{"addr":"::1","port":7880}"#.to_string())
+        );
     }
 
     /// A corrupt address (no `:`) returns `None` instead of panicking.

--- a/crates/trusty-review/src/commands/port.rs
+++ b/crates/trusty-review/src/commands/port.rs
@@ -1,0 +1,225 @@
+//! Handler for `trusty-review port` — report the daemon's listening port.
+//!
+//! Why: operators and scripts need to discover which port the running
+//! trusty-review daemon is on without guessing. The `http_addr` file already
+//! records the exact address the daemon bound; this command exposes it as a
+//! first-class, machine-parsable CLI surface, matching the ops parity target
+//! of issue #957.
+//!
+//! What: reads the daemon's persisted address via `trusty_common::read_daemon_addr`
+//! and prints one of three formats to stdout based on the caller's flags:
+//!   - default: bare port number  →  `7880\n`
+//!   - `--addr`: `host:port`      →  `127.0.0.1:7880\n`
+//!   - `--json`: JSON object      →  `{"addr":"127.0.0.1","port":7880}\n`
+//!
+//! Every intentional port/JSON output goes to **stdout**. Error messages go
+//! to **stderr**. When no daemon is running the command exits non-zero so
+//! shell substitution (`$(trusty-review port)`) fails cleanly.
+//!
+//! Test: unit tests in this module cover all three output formats plus the
+//! missing-daemon error path using a fake address string.
+
+use anyhow::Result;
+
+/// Output format requested by the caller.
+///
+/// Why: the three output shapes have distinct audiences — bare port for shell
+/// substitution, host:port for direct `curl`, JSON for scripted consumers.
+/// Encoding the choice as an enum keeps `handle_port` a thin dispatcher and
+/// makes each formatter independently testable.
+/// What: one variant per flag; `Port` is the bare-port default case.
+/// Test: `format_output_*` unit tests exercise all three variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortFormat {
+    /// Bare port number (default).
+    Port,
+    /// `host:port` string.
+    Addr,
+    /// `{"addr":"…","port":…}` JSON object.
+    Json,
+}
+
+/// Parse a `host:port` string and return the port as `u16`.
+///
+/// Why: `read_daemon_addr` returns the full `host:port` string; extracting
+/// the port number for the `Port` and `Json` output modes requires splitting
+/// on the last `:` (to handle IPv6 addresses where the host itself contains
+/// `:`).
+/// What: splits on the final `:`, parses the port, returns `None` on any
+/// parse failure so the caller can emit a helpful error rather than panicking.
+/// Test: `parse_port_from_addr_*` unit tests cover normal, IPv6, and malformed
+/// inputs.
+pub fn parse_port_from_addr(addr: &str) -> Option<u16> {
+    let colon = addr.rfind(':')?;
+    addr[colon + 1..].parse::<u16>().ok()
+}
+
+/// Format the daemon address for output based on the requested `PortFormat`.
+///
+/// Why: separating the formatting logic from the I/O lets unit tests assert
+/// the output string without spawning a daemon or touching a discovery file.
+/// What: takes a validated `host:port` string plus the desired format and
+/// returns the formatted string to print. Returns `None` when the port cannot
+/// be parsed from the address (which would indicate a corrupt discovery file).
+/// Test: `format_output_*` unit tests cover all three variants and edge cases.
+pub fn format_output(addr: &str, format: PortFormat) -> Option<String> {
+    match format {
+        PortFormat::Port => {
+            let port = parse_port_from_addr(addr)?;
+            Some(port.to_string())
+        }
+        PortFormat::Addr => Some(addr.to_string()),
+        PortFormat::Json => {
+            let port = parse_port_from_addr(addr)?;
+            let colon = addr.rfind(':')?;
+            let host = &addr[..colon];
+            Some(format!(r#"{{"addr":"{host}","port":{port}}}"#))
+        }
+    }
+}
+
+/// Entry point for `trusty-review port [--json | --addr]`.
+///
+/// Why: exposes the daemon's listening port as a first-class CLI command so
+/// shell substitutions like `curl http://127.0.0.1:$(trusty-review port)/health`
+/// work without guessing. Closes issue #957 (ops parity with trusty-search).
+/// What: reads the address from the `http_addr` discovery file via
+/// `trusty_common::read_daemon_addr("trusty-review")`, formats it per the
+/// caller's flags, and prints to stdout. On any error (no daemon, missing
+/// file, corrupt address) the message goes to stderr and the function returns
+/// `Err` so `main` exits non-zero.
+/// Test: unit tests cover all format variants; the discovery-file path is
+/// covered by `daemon_utils` tests that write fake discovery files.
+pub fn handle_port(format: PortFormat) -> Result<()> {
+    let addr = match trusty_common::read_daemon_addr("trusty-review") {
+        Ok(Some(a)) if !a.is_empty() => a,
+        Ok(Some(_)) | Ok(None) => {
+            // Fall back to the default port as a best-effort hint.  We
+            // cannot confirm the daemon is actually running on this port,
+            // so exit non-zero with a clear explanation rather than
+            // silently printing a potentially wrong address.
+            eprintln!(
+                "trusty-review: no daemon running (address file not found). \
+                 Start with `trusty-review serve`."
+            );
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("trusty-review: could not read daemon address: {e:#}");
+            std::process::exit(1);
+        }
+    };
+
+    match format_output(&addr, format) {
+        Some(out) => {
+            println!("{out}");
+            Ok(())
+        }
+        None => {
+            eprintln!(
+                "trusty-review: daemon address file contains an unrecognised \
+                 address `{addr}` (expected host:port). \
+                 Re-start the daemon with `trusty-review serve`."
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── format_output ──────────────────────────────────────────────────────────
+
+    /// Default format emits the bare port number.
+    ///
+    /// Why: the primary use case is shell substitution; anything other than a
+    /// bare integer in stdout would break `curl http://…:$(trusty-review port)/…`.
+    #[test]
+    fn format_output_port_default() {
+        assert_eq!(
+            format_output("127.0.0.1:7880", PortFormat::Port),
+            Some("7880".to_string())
+        );
+    }
+
+    /// `--addr` format emits the full `host:port` string unchanged.
+    ///
+    /// Why: callers using `curl http://$(trusty-review port --addr)/health`
+    /// need the host included.
+    #[test]
+    fn format_output_addr() {
+        assert_eq!(
+            format_output("127.0.0.1:7880", PortFormat::Addr),
+            Some("127.0.0.1:7880".to_string())
+        );
+    }
+
+    /// `--json` format emits a JSON object with `addr` and `port` fields.
+    ///
+    /// Why: scripted consumers may want both fields in a structured payload
+    /// without shelling out twice or parsing the port themselves.
+    #[test]
+    fn format_output_json() {
+        assert_eq!(
+            format_output("127.0.0.1:7880", PortFormat::Json),
+            Some(r#"{"addr":"127.0.0.1","port":7880}"#.to_string())
+        );
+    }
+
+    /// IPv6 addresses use the last `:` as the port separator.
+    ///
+    /// Why: on dual-stack hosts the daemon might bind `[::1]:7880`; `rfind`
+    /// correctly splits on the final `:` rather than the first.
+    #[test]
+    fn format_output_ipv6_port() {
+        assert_eq!(parse_port_from_addr("[::1]:7880"), Some(7880));
+    }
+
+    /// A corrupt address (no `:`) returns `None` instead of panicking.
+    ///
+    /// Why: the caller converts `None` to a human-readable error rather than
+    /// crashing — this validates the safety net.
+    #[test]
+    fn format_output_malformed_returns_none() {
+        assert_eq!(format_output("not-an-addr", PortFormat::Port), None);
+        assert_eq!(format_output("", PortFormat::Port), None);
+    }
+
+    /// `--json` with a port that doesn't parse returns `None`.
+    ///
+    /// Why: same safety-net; a non-numeric port must not produce garbage JSON.
+    #[test]
+    fn format_output_json_malformed_returns_none() {
+        assert_eq!(format_output("127.0.0.1:notaport", PortFormat::Json), None);
+    }
+
+    // ── parse_port_from_addr ────────────────────────────────────────────────────
+
+    /// Standard IPv4 address parses correctly.
+    #[test]
+    fn parse_port_standard() {
+        assert_eq!(parse_port_from_addr("127.0.0.1:7880"), Some(7880));
+    }
+
+    /// Port 0 is valid (OS-assigned).
+    #[test]
+    fn parse_port_zero() {
+        assert_eq!(parse_port_from_addr("127.0.0.1:0"), Some(0));
+    }
+
+    /// Missing colon returns `None`.
+    #[test]
+    fn parse_port_no_colon() {
+        assert_eq!(parse_port_from_addr("127.0.0.1"), None);
+    }
+
+    /// Port too large (>65535) returns `None`.
+    #[test]
+    fn parse_port_overflow() {
+        assert_eq!(parse_port_from_addr("127.0.0.1:99999"), None);
+    }
+}

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -21,6 +21,7 @@ use clap::{Parser, Subcommand};
 use trusty_review::config::ReviewConfig;
 
 use commands::compare::{CompareArgs, cmd_compare};
+use commands::port::{PortFormat, handle_port};
 use commands::run::{RunArgs, cmd_run};
 #[cfg(feature = "http-server")]
 use commands::serve::{ServeArgs, cmd_serve};
@@ -68,6 +69,27 @@ enum Commands {
     /// override) and prints a comparison table.  Always dry-run.
     Compare(CompareArgs),
 
+    /// Report the listening port of the running trusty-review daemon.
+    ///
+    /// Reads the `http_addr` discovery file written at daemon bind time and
+    /// prints the address in one of three machine-readable formats:
+    ///
+    ///   trusty-review port          → bare port:  7880
+    ///   trusty-review port --addr   → host:port:  127.0.0.1:7880
+    ///   trusty-review port --json   → JSON:       {"addr":"127.0.0.1","port":7880}
+    ///
+    /// Exits non-zero when no daemon discovery file is found so shell
+    /// substitution (`$(trusty-review port)`) fails safely.
+    Port {
+        /// Print `host:port` instead of the bare port number.
+        #[arg(long, conflicts_with = "json")]
+        addr: bool,
+
+        /// Print a JSON object `{"addr":"…","port":…}`.
+        #[arg(long, conflicts_with = "addr")]
+        json: bool,
+    },
+
     /// Start the long-lived HTTP webhook server (port 7880 by default).
     ///
     /// Exposes:
@@ -112,6 +134,19 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
+    // `port` is synchronous — dispatch before the async runtime to keep the
+    // binary start-up cost minimal for machine-readable invocations.
+    if let Commands::Port { addr, json } = &cli.command {
+        let format = if *json {
+            PortFormat::Json
+        } else if *addr {
+            PortFormat::Addr
+        } else {
+            PortFormat::Port
+        };
+        return handle_port(format);
+    }
+
     let rt = tokio::runtime::Runtime::new().context("build tokio runtime")?;
     rt.block_on(async_main(cli))
 }
@@ -126,5 +161,9 @@ async fn async_main(cli: Cli) -> Result<()> {
         Commands::Serve(args) => cmd_serve(config, args).await,
         #[cfg(feature = "profile")]
         Commands::Profile(args) => cli_profile::cmd_profile(config, args).await,
+        // Port is handled synchronously in `main` before this function is
+        // called; this arm is unreachable at runtime but required for
+        // exhaustive match.
+        Commands::Port { .. } => unreachable!("port dispatched before async_main"),
     }
 }

--- a/deploy/systemd/trusty-review.service
+++ b/deploy/systemd/trusty-review.service
@@ -1,0 +1,133 @@
+# trusty-review.service — production systemd unit for the trusty-review HTTP daemon
+#
+# DEPLOYMENT CONTEXT
+# ------------------
+# trusty-review is the LLM-backed PR-review service.  It uses the `serve`
+# subcommand to start a foreground HTTP daemon on port 7880 (distinct from
+# trusty-search :7878 and trusty-analyze :7879).
+#
+# KEY TIMING NOTE (LLM calls)
+# ---------------------------
+# Review requests fan out to LLM providers (Bedrock, OpenRouter) whose
+# round-trips can take 30–90 seconds for large diffs.  The stop timeout must
+# therefore be generous enough to let the drain phase complete all in-flight
+# LLM calls before systemd escalates to SIGKILL.  120 s is chosen to cover
+# the 90 s worst-case LLM latency plus a 30 s buffer for response processing.
+#
+# GRACEFUL SHUTDOWN
+# -----------------
+# `trusty-review serve` implements graceful SIGTERM drain (axum `serve_with_graceful_shutdown`):
+# the daemon drains all in-flight HTTP requests before exiting.  Without a
+# generous TimeoutStopSec, systemd would SIGKILL mid-review after 90 s (the
+# default), producing incomplete review output and potentially corrupt dedup.redb.
+#
+# INSTALLATION
+# ------------
+# See README.md in this directory for the full install + restart workflow.
+
+[Unit]
+Description=trusty-review LLM-backed PR-review daemon
+# Wait for the network stack before starting — the daemon binds a TCP port
+# and makes outbound HTTPS connections to LLM APIs and GitHub.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# ── Process type ─────────────────────────────────────────────────────────────
+# Type=simple: `trusty-review serve` stays in the foreground; it does NOT
+# call sd_notify(), so Type=notify is incorrect.
+Type=simple
+
+# ── Identity ─────────────────────────────────────────────────────────────────
+# Run as a dedicated non-root user.  Create before enabling:
+#   useradd --system --no-create-home --shell /sbin/nologin trusty
+# Adjust Group= if your deployment uses a shared data group.
+User=trusty
+Group=trusty
+
+# ── Binary ───────────────────────────────────────────────────────────────────
+# Adjust the path to match where `cargo install trusty-review` placed the
+# binary (typically /usr/local/bin or ~/.cargo/bin for the trusty user).
+# Use an absolute path; systemd does not search PATH for ExecStart.
+#
+# `serve` starts the HTTP daemon in the foreground.  Do NOT add `--stdio`;
+# that flag switches to the MCP JSON-RPC stdio mode, which is wrong for
+# systemd supervision.
+#
+# --port 7880: explicit port; change to match your deployment or omit to use
+#              the compiled-in default (7880).
+ExecStart=/usr/local/bin/trusty-review serve \
+    --port 7880 \
+    --bind 127.0.0.1
+
+# ── Graceful shutdown (LLM-aware timeout) ────────────────────────────────────
+# KillSignal=SIGTERM: instruct systemd to send SIGTERM first (graceful).
+# This is systemd's default, but stated explicitly for clarity.  The daemon's
+# SIGTERM handler drains in-flight HTTP requests before exiting.
+KillSignal=SIGTERM
+
+# TimeoutStopSec=120: PRIMARY STOP BUDGET.
+# After SIGTERM, systemd waits this many seconds before escalating to SIGKILL.
+# 120 s covers:
+#   1. In-flight LLM calls that can take 30–90 s for large diffs.
+#   2. Final response processing and dedup.redb transaction flush.
+# Increase to 180 s or more if reviews of very large PRs (many files, high
+# token counts) routinely exceed 90 s LLM latency on your deployment.
+TimeoutStopSec=120
+
+# ── Restart policy ───────────────────────────────────────────────────────────
+# Restart on abnormal exits (crash, signal) but not on clean `systemctl stop`.
+Restart=on-failure
+# 5 s back-off before restarting to avoid rapid crashloop on transient errors
+# (e.g. LLM API rate-limit, network partition, bad config file).
+RestartSec=5
+
+# ── Working directory ─────────────────────────────────────────────────────────
+# Point at the directory that holds the review logs and dedup.redb store.
+# Adjust to match your deployment's data layout.
+WorkingDirectory=/data/trusty-review
+
+# ── Environment ──────────────────────────────────────────────────────────────
+# Core logging level.  Use debug for initial bring-up; info for steady state.
+Environment=RUST_LOG=info
+
+# GITHUB_TOKEN: required for fetching PR diffs from private repos.
+# Set to a GitHub personal-access-token or GitHub App installation token with
+# `pull_requests: read` and `contents: read` scopes.
+# Environment=GITHUB_TOKEN=ghp_…
+
+# AWS credentials: required when TRUSTY_LLM_MODEL is set to a bedrock/… model.
+# The full AWS credential chain (env vars, ~/.aws/credentials, IAM instance
+# role) is supported; set these only if you cannot use instance metadata.
+# Environment=AWS_REGION=us-east-1
+# Environment=AWS_ACCESS_KEY_ID=AKIA…
+# Environment=AWS_SECRET_ACCESS_KEY=…
+
+# OPENROUTER_API_KEY: required when using OpenRouter-routed LLM models (the
+# default when TRUSTY_LLM_MODEL is not set or is not prefixed with bedrock/).
+# Environment=OPENROUTER_API_KEY=sk-or-…
+
+# PR_INTELLIGENCE_DRY_RUN: set to "true" to suppress all GitHub comment posting
+# (safe default for staging environments; false in production to post reviews).
+# Environment=PR_INTELLIGENCE_DRY_RUN=true
+
+# TRUSTY_LLM_MODEL: override the LLM model used for reviews.
+# Default: determined by config.toml / compiled-in fallback.
+# Examples:
+#   bedrock/us.anthropic.claude-sonnet-4-6  → routes through AWS Bedrock
+#   anthropic/claude-3-5-sonnet             → routes through OpenRouter
+# Environment=TRUSTY_LLM_MODEL=bedrock/us.anthropic.claude-sonnet-4-6
+
+# TRUSTY_SEARCH_URL: base URL of the trusty-search daemon for code context
+# retrieval.  Auto-detected from the trusty-search discovery file when unset.
+# Environment=TRUSTY_SEARCH_URL=http://127.0.0.1:7878
+
+# ── File descriptor limit ─────────────────────────────────────────────────────
+# Raise the open-file limit for the dedup.redb store and concurrent HTTP
+# keep-alive connections.
+LimitNOFILE=65536
+
+[Install]
+# Start when the system reaches multi-user (non-graphical) mode — the standard
+# target for daemon services on EC2 and other headless Linux hosts.
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- **`trusty-review port` subcommand**: mirrors `trusty-search port` exactly — bare port (default), `--addr` (`host:port`), `--json` (`{"addr":…,"port":…}`). Reads the daemon's `http_addr` discovery file via `trusty_common::read_daemon_addr("trusty-review")`. Dispatched synchronously before the async runtime for minimal latency. Exits non-zero when no discovery file is present so `$(trusty-review port)` shell substitution fails safely.
- **`deploy/systemd/trusty-review.service`**: production systemd unit modelled on `deploy/systemd/trusty-search.service`. Key parameters: `Type=simple`, `ExecStart=trusty-review serve`, `KillSignal=SIGTERM`, `TimeoutStopSec=120` (LLM calls run 30–90 s; 120 s gives full drain headroom), `Restart=on-failure`. Commented env stanzas for `GITHUB_TOKEN`, `AWS_REGION`/`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, `OPENROUTER_API_KEY`, and `PR_INTELLIGENCE_DRY_RUN`.
- **10 unit tests** in `commands/port.rs` covering all three output formats, IPv6, malformed addresses, port 0, and overflow.

## How port resolution works

`handle_port` calls `trusty_common::read_daemon_addr("trusty-review")`, which reads `~/.local/share/trusty-review/http_addr` (Linux) or `~/Library/Application Support/trusty-review/http_addr` (macOS) — the file the daemon writes at bind time. The raw `host:port` string is then formatted per the caller's flag.

## Test plan

- [ ] `cargo test -p trusty-review` — all 22 tests pass (10 new in `commands::port`)
- [ ] `cargo clippy -p trusty-review --all-targets -- -D warnings` — zero warnings
- [ ] `cargo fmt --check` — no drift
- [ ] `bash scripts/check_line_cap.sh` — 0 violations (new `port.rs` is 220 lines, well under 500)
- [ ] `trusty-review port --help` prints the three format options
- [ ] `trusty-review serve` + `trusty-review port` prints the correct port
- [ ] `trusty-review port --addr` prints `host:port`
- [ ] `trusty-review port --json` prints `{"addr":"…","port":…}`
- [ ] With no daemon running: `trusty-review port` exits non-zero with a message on stderr

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)