### PR TITLE
test(search,ci): add optional trusty-search daemon-smoke CI job (closes #952)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,10 @@ jobs:
           # CPU device — explicit to avoid any GPU EP probe on the runner.
           TRUSTY_DEVICE: cpu
           RUST_LOG: "info"
+          # GitHub ubuntu-latest runners report ~15.6 GB RAM, just below the
+          # 16 GB startup floor. This smoke test only checks HTTP connectivity,
+          # not indexing or embedding, so the RAM floor adds no value here.
+          TRUSTY_SKIP_RAM_CHECK: "1"
         run: |
           mkdir -p /tmp/ts-smoke
           ./target/release/trusty-search start \
@@ -346,7 +350,8 @@ jobs:
 
       - name: Assert /health returns status=ok
         run: |
-          HEALTH_STATUS=$(python3 -c "import json,sys; d=json.load(open('/tmp/ts-smoke/health.json')); print(d.get('status',''))")
+          # jq is preinstalled on ubuntu-latest; use it instead of python3 for clarity.
+          HEALTH_STATUS=$(jq -r '.status // ""' /tmp/ts-smoke/health.json)
           echo "status field: ${HEALTH_STATUS}"
           if [ "${HEALTH_STATUS}" != "ok" ]; then
             echo "ERROR: /health did not return status=ok (got: ${HEALTH_STATUS})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,132 @@ jobs:
 
       - name: cargo check --workspace
         run: cargo check --workspace --exclude trusty-mpm-gui
+
+  # --------------------------------------------------------------------------
+  # search-daemon-smoke: build the trusty-search release binary and verify
+  # that the HTTP daemon starts and answers /health with status=ok.
+  #
+  # Design notes (issue #952):
+  #
+  # FLAKE AVOIDANCE — issue #865 documented fastembed/ONNX HTTP-429 flake
+  # when the model is downloaded at startup. This job avoids that by:
+  #   1. TRUSTY_NO_KG=1 — skip knowledge-graph init (no network calls needed).
+  #   2. The /health endpoint returns HTTP 200 with status="ok" immediately
+  #      once the axum server binds, even while the embedder is still
+  #      initialising in the background. The embedder field reports
+  #      "initialising" but the HTTP status is always 200 — the smoke check
+  #      only needs the server to be reachable, not for the model to be ready.
+  #   3. --no-auto-discover — skip the startup project-scan so the daemon does
+  #      not walk ~/Projects or ~/code on the ephemeral runner.
+  #   4. --data-dir /tmp/ts-smoke — fully isolated data directory so no
+  #      indexes.toml, lockfile, or port-file collides with any other process.
+  #
+  # OPTIONAL — this job is marked continue-on-error: true because:
+  #   • It requires a full release build of trusty-search (~15-20 min on cold
+  #     cache), which adds significant wall-clock cost on top of the existing
+  #     four jobs.
+  #   • A timeout/kill race in the ephemeral runner is unlikely but not zero.
+  #   • The functional correctness of the daemon is covered by unit + integration
+  #     tests in the `test` job; this job only checks that the binary starts and
+  #     the HTTP server binds.
+  #
+  # If flakiness is never observed in practice, remove continue-on-error to
+  # make it a hard gate.
+  #
+  # TEARDOWN — the daemon is killed at the end via the stored PID. This is
+  # correct CI behaviour: ephemeral runners are discarded after the job
+  # completes, but explicit teardown ensures the port is freed if a later step
+  # reuses the runner.
+  # --------------------------------------------------------------------------
+  search-daemon-smoke:
+    name: trusty-search daemon smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Free disk space
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost /usr/local/share/powershell \
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libssl-dev
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: search-daemon-smoke
+
+      # SKIP_UI_BUILD=1 is already set globally via env: at the workflow level.
+      # The committed ui-dist/ bundle is used as-is; pnpm is not required.
+      - name: Build trusty-search release binary
+        run: cargo build --release -p trusty-search
+
+      - name: Start trusty-search daemon (background)
+        env:
+          # Skip KG init — no network calls, no model downloads at startup.
+          TRUSTY_NO_KG: "1"
+          # CPU device — explicit to avoid any GPU EP probe on the runner.
+          TRUSTY_DEVICE: cpu
+          RUST_LOG: "info"
+        run: |
+          mkdir -p /tmp/ts-smoke
+          ./target/release/trusty-search start \
+            --foreground \
+            --port 7999 \
+            --data-dir /tmp/ts-smoke \
+            --no-auto-discover \
+            > /tmp/ts-smoke/daemon.log 2>&1 &
+          echo $! > /tmp/ts-smoke/daemon.pid
+          echo "Daemon PID: $(cat /tmp/ts-smoke/daemon.pid)"
+
+      - name: Wait for /health (poll up to 30 s)
+        run: |
+          PORT=7999
+          DEADLINE=$(( $(date +%s) + 30 ))
+          until curl -sf "http://127.0.0.1:${PORT}/health" > /tmp/ts-smoke/health.json 2>/dev/null; do
+            if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
+              echo "--- daemon log ---"
+              cat /tmp/ts-smoke/daemon.log || true
+              echo "--- end daemon log ---"
+              echo "ERROR: /health did not respond within 30 s" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Daemon is up. Health response:"
+          cat /tmp/ts-smoke/health.json
+
+      - name: Assert /health returns status=ok
+        run: |
+          HEALTH_STATUS=$(python3 -c "import json,sys; d=json.load(open('/tmp/ts-smoke/health.json')); print(d.get('status',''))")
+          echo "status field: ${HEALTH_STATUS}"
+          if [ "${HEALTH_STATUS}" != "ok" ]; then
+            echo "ERROR: /health did not return status=ok (got: ${HEALTH_STATUS})"
+            cat /tmp/ts-smoke/health.json
+            exit 1
+          fi
+          echo "OK: status=ok confirmed"
+
+      - name: Tear down daemon
+        if: always()
+        run: |
+          if [ -f /tmp/ts-smoke/daemon.pid ]; then
+            PID=$(cat /tmp/ts-smoke/daemon.pid)
+            echo "Killing daemon PID ${PID}"
+            kill "${PID}" 2>/dev/null || true
+          fi


### PR DESCRIPTION
## Summary

- Adds a new `search-daemon-smoke` CI job to `.github/workflows/ci.yml` that builds the `trusty-search` release binary, starts the daemon on an isolated port/data-dir, polls `/health` until HTTP 200, asserts `status=ok`, and tears the daemon down.
- This is the remaining CI portion of #952; the unit-test portion landed in PR #964 and is not re-added here.
- The job is marked `continue-on-error: true` (optional, non-blocking) with a clear comment on how to promote it to a hard gate once stability is confirmed.

## Flake-avoidance decision (re: issue #865)

Issue #865 documented `fastembed`/ONNX HTTP-429 flake when the model is downloaded at daemon startup. This job avoids that entirely:

1. **`TRUSTY_NO_KG=1`** — skip knowledge-graph init; no network calls at startup.
2. **`/health` is always HTTP 200** — the axum server responds immediately once bound. The `status` field is always `"ok"` regardless of embedder state (the embedder field shows `"initialising"` while the background task runs, but HTTP 200 and `status=ok` are unconditional). The smoke test only needs the server to be reachable, not for the ONNX model to be loaded.
3. **`--no-auto-discover`** — skip the startup project-scan so the daemon doesn't walk `~/Projects` or `~/code` on the ephemeral runner.
4. **`--data-dir /tmp/ts-smoke`** — fully isolated data directory; no lockfile or port-file conflict.
5. **`TRUSTY_DEVICE=cpu`** — explicit CPU-only to avoid any GPU EP probe on the runner.

This approach was verified with a local dry-run against the release binary: the daemon came up in under 6 seconds, `/health` responded with `{"status":"ok",...}`, and the poll loop + assertion both passed.

## Why `continue-on-error: true` (optional)?

- A release build of `trusty-search` adds ~15–20 min of wall-clock time on a cold cache, which is significant on top of the existing four jobs.
- The functional correctness of the daemon (request handling, indexing, search) is already covered by the unit + integration tests in the `test` job; this smoke job only verifies that the binary starts and the HTTP server binds.
- Once the job has been observed to be stable on a few PRs, remove `continue-on-error: true` to make it a hard gate.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml,sys; yaml.safe_load(open(...))'` — verified, output: `YAML parses OK, Jobs: ['fmt', 'clippy', 'test', 'msrv', 'search-daemon-smoke']`)
- [x] Local dry-run: started daemon on port 7999 with `--foreground --no-auto-discover --data-dir /tmp/ts-smoke-dryrun TRUSTY_NO_KG=1` against an existing release binary; `/health` returned `{"status":"ok",...}` in under 6 s; `status=ok` assertion passed; daemon killed cleanly.
- [x] Pre-commit hooks: all passed (trim whitespace, check yaml, 500-line cap).
- [ ] CI run on this PR — will confirm the job passes on Ubuntu runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)