### PR TITLE
chore(build): dedup SKIP_UI_BUILD build.rs logic into shared canonical block (closes #987)

### DIFF
--- a/crates/trusty-analyze/build.rs
+++ b/crates/trusty-analyze/build.rs
@@ -79,8 +79,10 @@ fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
     };
 
     // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    // Only pass --frozen-lockfile when pnpm is the detected manager; npm does
+    // not support that flag (it uses --ci instead) and will error out.
     let mut install_args = vec!["install"];
-    if ui_dir.join("pnpm-lock.yaml").exists() {
+    if pm == "pnpm" && ui_dir.join("pnpm-lock.yaml").exists() {
         install_args.push("--frozen-lockfile");
     }
     let install_ok = Command::new(pm)

--- a/crates/trusty-analyze/build.rs
+++ b/crates/trusty-analyze/build.rs
@@ -5,20 +5,26 @@
 //! `ui/dist/`. Running `pnpm build` here means a plain `cargo build` always
 //! produces a binary with up-to-date assets, with no separate UI build step.
 //! What: Skips entirely if `SKIP_UI_BUILD=1` (CI / first-time bootstrap when
-//! pnpm is unavailable). Otherwise runs `pnpm install` (frozen lockfile if
-//! present) followed by `pnpm build` in `ui/`. Emits cargo:rerun directives
-//! so a `cargo build` only re-runs the JS pipeline when UI sources change.
-//! Test: `SKIP_UI_BUILD=1 cargo check` exits without invoking pnpm; a normal
-//! `cargo build` populates `ui/dist/index.html`.
+//! pnpm is unavailable). Otherwise runs `<pm> install [--frozen-lockfile]`
+//! followed by `<pm> run build` in `ui/`. Emits cargo:rerun directives so a
+//! `cargo build` only re-runs the JS pipeline when UI sources change.
+//!
+//! NOTE: The core UI-build logic (SKIP_UI_BUILD guard, pnpm detection,
+//! install+build pipeline, placeholder fallback) is intentionally kept
+//! identical across trusty-memory, trusty-analyze, trusty-console, and
+//! trusty-search (issue #987). `scripts/check_buildrs_sync.sh` asserts that
+//! the canonical implementation block does not drift between these four files.
+//!
+//! Test: `SKIP_UI_BUILD=1 cargo check -p trusty-analyze` exits without invoking
+//! pnpm; a normal `cargo build` populates `ui/dist/index.html`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
-    let ui_dir = Path::new(&manifest_dir).join("ui");
+    let crate_root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
+    let ui_dir = crate_root.join("ui");
     let dist_dir = ui_dir.join("dist");
-    let pkg_json = ui_dir.join("package.json");
 
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
     println!("cargo:rerun-if-changed=ui/package.json");
@@ -26,97 +32,127 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/index.html");
     println!("cargo:rerun-if-changed=ui/src");
 
+    build_svelte_ui(&ui_dir, &dist_dir, "trusty-analyze");
+}
+
+// ── CANONICAL BLOCK BEGIN (kept in sync by scripts/check_buildrs_sync.sh) ──
+
+/// Run the Svelte UI build pipeline, or degrade gracefully to a placeholder.
+///
+/// Why: Centralises SKIP_UI_BUILD handling, pnpm detection, frozen-lockfile
+/// install, and placeholder fallback so all four UI-embedding crates share
+/// identical logic without a published build-helper crate (#987).
+/// What: Checks SKIP_UI_BUILD, detects pnpm/npm, runs install + build inside
+/// `ui_dir`, writes a placeholder on any failure so the Rust build still
+/// completes even without the JS toolchain.
+/// Test: `SKIP_UI_BUILD=1 cargo check` short-circuits; `cargo build` with pnpm
+/// installed populates `dist_dir/index.html` with real Vite output.
+fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
+    // Step 1: honour explicit skip (CI / `cargo publish --verify`).
     if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
-        println!("cargo:warning=SKIP_UI_BUILD=1 — skipping UI build");
-        ensure_dist_placeholder(&dist_dir);
+        if !dist_dir.join("index.html").exists() {
+            println!(
+                "cargo:warning=SKIP_UI_BUILD=1 but {dist}/ is empty — \
+                 run `pnpm --dir ui install && pnpm --dir ui build` before publishing.",
+                dist = dist_dir.display()
+            );
+            ensure_placeholder(dist_dir, crate_name);
+        }
         return;
     }
 
-    if !pkg_json.exists() {
-        println!("cargo:warning=ui/package.json missing — skipping UI build");
-        ensure_dist_placeholder(&dist_dir);
+    // Step 2: no `ui/package.json` means we are inside an extracted tarball
+    // that already shipped the dist — nothing to build.
+    if !ui_dir.join("package.json").exists() {
+        ensure_placeholder(dist_dir, crate_name);
         return;
     }
 
-    if which("pnpm").is_none() {
+    // Step 3: detect package manager (pnpm preferred, npm fallback).
+    let Some(pm) = detect_pm() else {
         println!(
-            "cargo:warning=pnpm not found on PATH — skipping UI build (set SKIP_UI_BUILD=1 to silence)"
+            "cargo:warning={crate_name}: no pnpm/npm on PATH — skipping UI \
+             build (set SKIP_UI_BUILD=1 to silence, or install pnpm)."
         );
-        ensure_dist_placeholder(&dist_dir);
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    };
+
+    // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    let mut install_args = vec!["install"];
+    if ui_dir.join("pnpm-lock.yaml").exists() {
+        install_args.push("--frozen-lockfile");
+    }
+    let install_ok = Command::new(pm)
+        .args(&install_args)
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !install_ok {
+        println!("cargo:warning={crate_name}: `{pm} install` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
         return;
     }
 
-    // pnpm install — prefer frozen lockfile if a lockfile exists.
-    let lockfile = ui_dir.join("pnpm-lock.yaml");
-    let install_args: Vec<&str> = if lockfile.exists() {
-        vec!["install", "--frozen-lockfile"]
-    } else {
-        vec!["install"]
-    };
-    let install_status = Command::new("pnpm")
-        .args(&install_args)
-        .current_dir(&ui_dir)
-        .status();
-    match install_status {
-        Ok(s) if s.success() => {}
-        Ok(s) => {
-            println!("cargo:warning=pnpm install failed with status {s:?}");
-            ensure_dist_placeholder(&dist_dir);
-            return;
-        }
-        Err(e) => {
-            println!("cargo:warning=failed to spawn pnpm install: {e}");
-            ensure_dist_placeholder(&dist_dir);
-            return;
-        }
-    }
-
-    let build_status = Command::new("pnpm")
-        .args(["build"])
-        .current_dir(&ui_dir)
-        .status();
-    match build_status {
-        Ok(s) if s.success() => {}
-        Ok(s) => {
-            println!("cargo:warning=pnpm build failed with status {s:?}");
-            ensure_dist_placeholder(&dist_dir);
-        }
-        Err(e) => {
-            println!("cargo:warning=failed to spawn pnpm build: {e}");
-            ensure_dist_placeholder(&dist_dir);
-        }
+    // Step 4b: build.
+    let build_ok = Command::new(pm)
+        .args(["run", "build"])
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !build_ok {
+        println!("cargo:warning={crate_name}: `{pm} run build` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
     }
 }
 
-/// Ensure `ui/dist/` exists with at least an index.html so rust-embed can
-/// embed *something* — a missing folder makes the include fail at compile time.
-fn ensure_dist_placeholder(dist_dir: &Path) {
+/// Write a stub `index.html` so embed macros compile without the JS build.
+///
+/// Why: `rust_embed` and `include_dir!` fail at compile time if the referenced
+/// directory is absent or empty; a single-file stub is the minimum viable
+/// artefact that satisfies both macros while making the "UI not built" state
+/// obvious to anyone who opens `/` in a browser.
+/// What: Creates `dist_dir` if needed and writes a minimal HTML document.
+/// Idempotent — exits immediately if `index.html` already exists.
+/// Test: After `SKIP_UI_BUILD=1 cargo build`, `dist_dir/index.html` exists.
+fn ensure_placeholder(dist_dir: &Path, crate_name: &str) {
     if dist_dir.join("index.html").exists() {
         return;
     }
     let _ = std::fs::create_dir_all(dist_dir);
-    let _ = std::fs::write(
-        dist_dir.join("index.html"),
-        "<!doctype html><html><body><p>trusty-analyze: UI assets not built. \
+    let html = format!(
+        "<!doctype html><html><body><p>{crate_name}: UI assets not built. \
          Run <code>pnpm --dir ui install &amp;&amp; pnpm --dir ui build</code> \
-         and rebuild.</p></body></html>",
+         and rebuild.</p></body></html>"
     );
+    let _ = std::fs::write(dist_dir.join("index.html"), html);
 }
 
-/// Cheap which() — avoid a heavy dep just for build.rs.
-fn which(cmd: &str) -> Option<std::path::PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path) {
-        let candidate = dir.join(cmd);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        for ext in ["cmd", "exe"] {
-            let with_ext = dir.join(format!("{cmd}.{ext}"));
-            if with_ext.is_file() {
-                return Some(with_ext);
-            }
-        }
+/// Detect the available Node.js package manager on PATH.
+///
+/// Why: The workspace uses pnpm (lockfile is `pnpm-lock.yaml`), but `npm`
+/// works as a fallback on machines that have Node but not pnpm separately.
+/// What: Probes `pnpm --version` then `npm --version`; returns the first
+/// that exits 0, or `None` when neither is found.
+/// Test: `detect_pm()` returns `Some("pnpm")` on a standard dev machine;
+/// `Some("npm")` on a machine without pnpm; `None` in a bare container.
+fn detect_pm() -> Option<&'static str> {
+    let ok = |bin: &str| {
+        Command::new(bin)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    if ok("pnpm") {
+        Some("pnpm")
+    } else if ok("npm") {
+        Some("npm")
+    } else {
+        None
     }
-    None
 }
+
+// ── CANONICAL BLOCK END ──

--- a/crates/trusty-console/build.rs
+++ b/crates/trusty-console/build.rs
@@ -79,8 +79,10 @@ fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
     };
 
     // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    // Only pass --frozen-lockfile when pnpm is the detected manager; npm does
+    // not support that flag (it uses --ci instead) and will error out.
     let mut install_args = vec!["install"];
-    if ui_dir.join("pnpm-lock.yaml").exists() {
+    if pm == "pnpm" && ui_dir.join("pnpm-lock.yaml").exists() {
         install_args.push("--frozen-lockfile");
     }
     let install_ok = Command::new(pm)

--- a/crates/trusty-console/build.rs
+++ b/crates/trusty-console/build.rs
@@ -5,21 +5,26 @@
 //! `pnpm build` here means a plain `cargo build` always produces a binary
 //! with up-to-date assets, with no separate UI build step.
 //! What: Skips entirely if `SKIP_UI_BUILD=1` (CI / first-time bootstrap
-//! when pnpm is unavailable). Otherwise runs `pnpm install` (frozen lockfile
-//! if present) followed by `pnpm build` in `ui/`. Emits cargo:rerun
-//! directives so a `cargo build` only re-runs the JS pipeline when UI
-//! sources change.
-//! Test: `SKIP_UI_BUILD=1 cargo check` exits without invoking pnpm; a normal
-//! `cargo build` populates `ui/dist/index.html`.
+//! when pnpm is unavailable). Otherwise runs `<pm> install [--frozen-lockfile]`
+//! followed by `<pm> run build` in `ui/`. Emits cargo:rerun directives so a
+//! `cargo build` only re-runs the JS pipeline when UI sources change.
+//!
+//! NOTE: The core UI-build logic (SKIP_UI_BUILD guard, pnpm detection,
+//! install+build pipeline, placeholder fallback) is intentionally kept
+//! identical across trusty-memory, trusty-analyze, trusty-console, and
+//! trusty-search (issue #987). `scripts/check_buildrs_sync.sh` asserts that
+//! the canonical implementation block does not drift between these four files.
+//!
+//! Test: `SKIP_UI_BUILD=1 cargo check -p trusty-console` exits without invoking
+//! pnpm; a normal `cargo build` populates `ui/dist/index.html`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
-    let ui_dir = Path::new(&manifest_dir).join("ui");
+    let crate_root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
+    let ui_dir = crate_root.join("ui");
     let dist_dir = ui_dir.join("dist");
-    let pkg_json = ui_dir.join("package.json");
 
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
     println!("cargo:rerun-if-changed=ui/package.json");
@@ -27,102 +32,127 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/index.html");
     println!("cargo:rerun-if-changed=ui/src");
 
+    build_svelte_ui(&ui_dir, &dist_dir, "trusty-console");
+}
+
+// ── CANONICAL BLOCK BEGIN (kept in sync by scripts/check_buildrs_sync.sh) ──
+
+/// Run the Svelte UI build pipeline, or degrade gracefully to a placeholder.
+///
+/// Why: Centralises SKIP_UI_BUILD handling, pnpm detection, frozen-lockfile
+/// install, and placeholder fallback so all four UI-embedding crates share
+/// identical logic without a published build-helper crate (#987).
+/// What: Checks SKIP_UI_BUILD, detects pnpm/npm, runs install + build inside
+/// `ui_dir`, writes a placeholder on any failure so the Rust build still
+/// completes even without the JS toolchain.
+/// Test: `SKIP_UI_BUILD=1 cargo check` short-circuits; `cargo build` with pnpm
+/// installed populates `dist_dir/index.html` with real Vite output.
+fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
+    // Step 1: honour explicit skip (CI / `cargo publish --verify`).
     if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
-        println!("cargo:warning=SKIP_UI_BUILD=1 — skipping UI build");
-        ensure_dist_placeholder(&dist_dir);
+        if !dist_dir.join("index.html").exists() {
+            println!(
+                "cargo:warning=SKIP_UI_BUILD=1 but {dist}/ is empty — \
+                 run `pnpm --dir ui install && pnpm --dir ui build` before publishing.",
+                dist = dist_dir.display()
+            );
+            ensure_placeholder(dist_dir, crate_name);
+        }
         return;
     }
 
-    if !pkg_json.exists() {
-        println!("cargo:warning=ui/package.json missing — skipping UI build");
-        ensure_dist_placeholder(&dist_dir);
+    // Step 2: no `ui/package.json` means we are inside an extracted tarball
+    // that already shipped the dist — nothing to build.
+    if !ui_dir.join("package.json").exists() {
+        ensure_placeholder(dist_dir, crate_name);
         return;
     }
 
-    if which("pnpm").is_none() {
+    // Step 3: detect package manager (pnpm preferred, npm fallback).
+    let Some(pm) = detect_pm() else {
         println!(
-            "cargo:warning=pnpm not found on PATH — skipping UI build \
-             (set SKIP_UI_BUILD=1 to silence)"
+            "cargo:warning={crate_name}: no pnpm/npm on PATH — skipping UI \
+             build (set SKIP_UI_BUILD=1 to silence, or install pnpm)."
         );
-        ensure_dist_placeholder(&dist_dir);
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    };
+
+    // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    let mut install_args = vec!["install"];
+    if ui_dir.join("pnpm-lock.yaml").exists() {
+        install_args.push("--frozen-lockfile");
+    }
+    let install_ok = Command::new(pm)
+        .args(&install_args)
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !install_ok {
+        println!("cargo:warning={crate_name}: `{pm} install` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
         return;
     }
 
-    let lockfile = ui_dir.join("pnpm-lock.yaml");
-    let install_args: Vec<&str> = if lockfile.exists() {
-        vec!["install", "--frozen-lockfile"]
-    } else {
-        vec!["install"]
-    };
-    let install_status = Command::new("pnpm")
-        .args(&install_args)
-        .current_dir(&ui_dir)
-        .status();
-    match install_status {
-        Ok(s) if s.success() => {}
-        Ok(s) => {
-            println!("cargo:warning=pnpm install failed with status {s:?}");
-            ensure_dist_placeholder(&dist_dir);
-            return;
-        }
-        Err(e) => {
-            println!("cargo:warning=failed to spawn pnpm install: {e}");
-            ensure_dist_placeholder(&dist_dir);
-            return;
-        }
-    }
-
-    let build_status = Command::new("pnpm")
-        .args(["build"])
-        .current_dir(&ui_dir)
-        .status();
-    match build_status {
-        Ok(s) if s.success() => {}
-        Ok(s) => {
-            println!("cargo:warning=pnpm build failed with status {s:?}");
-            ensure_dist_placeholder(&dist_dir);
-        }
-        Err(e) => {
-            println!("cargo:warning=failed to spawn pnpm build: {e}");
-            ensure_dist_placeholder(&dist_dir);
-        }
+    // Step 4b: build.
+    let build_ok = Command::new(pm)
+        .args(["run", "build"])
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !build_ok {
+        println!("cargo:warning={crate_name}: `{pm} run build` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
     }
 }
 
-/// Ensure `ui/dist/` exists with at least an index.html so rust-embed can
-/// embed *something* — a missing folder makes the include fail at compile time.
+/// Write a stub `index.html` so embed macros compile without the JS build.
 ///
-/// Why: When SKIP_UI_BUILD=1 or pnpm is absent, `ui/dist/` may not exist yet;
-/// rust-embed requires the folder to be present at compile time.
-/// What: Creates `ui/dist/` and writes a minimal placeholder `index.html`.
-/// Test: `SKIP_UI_BUILD=1 cargo check` must pass with this placeholder.
-fn ensure_dist_placeholder(dist_dir: &Path) {
+/// Why: `rust_embed` and `include_dir!` fail at compile time if the referenced
+/// directory is absent or empty; a single-file stub is the minimum viable
+/// artefact that satisfies both macros while making the "UI not built" state
+/// obvious to anyone who opens `/` in a browser.
+/// What: Creates `dist_dir` if needed and writes a minimal HTML document.
+/// Idempotent — exits immediately if `index.html` already exists.
+/// Test: After `SKIP_UI_BUILD=1 cargo build`, `dist_dir/index.html` exists.
+fn ensure_placeholder(dist_dir: &Path, crate_name: &str) {
     if dist_dir.join("index.html").exists() {
         return;
     }
     let _ = std::fs::create_dir_all(dist_dir);
-    let _ = std::fs::write(
-        dist_dir.join("index.html"),
-        "<!doctype html><html><body><p>trusty-console: UI assets not built. \
+    let html = format!(
+        "<!doctype html><html><body><p>{crate_name}: UI assets not built. \
          Run <code>pnpm --dir ui install &amp;&amp; pnpm --dir ui build</code> \
-         and rebuild.</p></body></html>",
+         and rebuild.</p></body></html>"
     );
+    let _ = std::fs::write(dist_dir.join("index.html"), html);
 }
 
-/// Cheap which() — avoid a heavy dep just for build.rs.
-fn which(cmd: &str) -> Option<std::path::PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path) {
-        let candidate = dir.join(cmd);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        for ext in ["cmd", "exe"] {
-            let with_ext = dir.join(format!("{cmd}.{ext}"));
-            if with_ext.is_file() {
-                return Some(with_ext);
-            }
-        }
+/// Detect the available Node.js package manager on PATH.
+///
+/// Why: The workspace uses pnpm (lockfile is `pnpm-lock.yaml`), but `npm`
+/// works as a fallback on machines that have Node but not pnpm separately.
+/// What: Probes `pnpm --version` then `npm --version`; returns the first
+/// that exits 0, or `None` when neither is found.
+/// Test: `detect_pm()` returns `Some("pnpm")` on a standard dev machine;
+/// `Some("npm")` on a machine without pnpm; `None` in a bare container.
+fn detect_pm() -> Option<&'static str> {
+    let ok = |bin: &str| {
+        Command::new(bin)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    if ok("pnpm") {
+        Some("pnpm")
+    } else if ok("npm") {
+        Some("npm")
+    } else {
+        None
     }
-    None
 }
+
+// ── CANONICAL BLOCK END ──

--- a/crates/trusty-memory/build.rs
+++ b/crates/trusty-memory/build.rs
@@ -7,10 +7,17 @@
 //! `npm`) to run the Vite build.
 //! What: emits `cargo:rerun` directives for UI source changes, then either
 //! honours `SKIP_UI_BUILD=1` (CI / `cargo publish` flow where `ui/dist/` is
-//! already populated) or runs `<pm> install` + `<pm> run build` inside `ui/`.
-//! If no package manager is available, or the build fails, it emits a
-//! placeholder `ui/dist/index.html` so `RustEmbed` still compiles and warns
-//! loudly.
+//! already populated) or runs `<pm> install [--frozen-lockfile]` + `<pm> run
+//! build` inside `ui/`. If no package manager is available, or the build
+//! fails, it emits a placeholder `ui/dist/index.html` so `RustEmbed` still
+//! compiles and warns loudly.
+//!
+//! NOTE: The core UI-build logic (SKIP_UI_BUILD guard, pnpm detection,
+//! install+build pipeline, placeholder fallback) is intentionally kept
+//! identical across trusty-memory, trusty-analyze, trusty-console, and
+//! trusty-search (issue #987). `scripts/check_buildrs_sync.sh` asserts that
+//! the canonical implementation block does not drift between these four files.
+//!
 //! Test: `SKIP_UI_BUILD=1 cargo check -p trusty-memory` exits without invoking
 //! any JS toolchain; a plain `cargo build` on a host with pnpm/npm installed
 //! populates `ui/dist/index.html`.
@@ -19,134 +26,137 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    let crate_root = crate_root();
+    let crate_root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
     let ui_dir = crate_root.join("ui");
-    let ui_dist = ui_dir.join("dist");
+    let dist_dir = ui_dir.join("dist");
 
-    emit_rerun_directives();
-
-    // Honour explicit skip (CI / `cargo publish --verify`).
-    if skip_requested() {
-        handle_skip(&ui_dist);
-        return;
-    }
-
-    // No `ui/` tree at all (e.g. running build.rs inside an extracted crate
-    // tarball that already shipped `ui/dist/`) → nothing to build.
-    if !has_ui_sources(&ui_dir) {
-        ensure_placeholder(&ui_dist);
-        return;
-    }
-
-    build_ui(&ui_dir, &ui_dist);
-}
-
-/// Resolve the crate root from Cargo's environment.
-fn crate_root() -> PathBuf {
-    PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default())
-}
-
-/// Tell Cargo to re-run this build script when any UI source changes (or the
-/// `SKIP_UI_BUILD` flag flips).
-fn emit_rerun_directives() {
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
     println!("cargo:rerun-if-changed=ui/package.json");
     println!("cargo:rerun-if-changed=ui/vite.config.js");
     println!("cargo:rerun-if-changed=ui/index.html");
     println!("cargo:rerun-if-changed=ui/src");
+
+    build_svelte_ui(&ui_dir, &dist_dir, "trusty-memory");
 }
 
-/// True when the operator opted out of the JS build (`SKIP_UI_BUILD=1`).
-fn skip_requested() -> bool {
-    std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1")
-}
+// ── CANONICAL BLOCK BEGIN (kept in sync by scripts/check_buildrs_sync.sh) ──
 
-/// Skip-flag branch: emit a warning if `ui/dist/` is empty, then ensure the
-/// stub `index.html` exists so `RustEmbed` still compiles.
-fn handle_skip(ui_dist: &Path) {
-    if !ui_dist.join("index.html").exists() {
+/// Run the Svelte UI build pipeline, or degrade gracefully to a placeholder.
+///
+/// Why: Centralises SKIP_UI_BUILD handling, pnpm detection, frozen-lockfile
+/// install, and placeholder fallback so all four UI-embedding crates share
+/// identical logic without a published build-helper crate (#987).
+/// What: Checks SKIP_UI_BUILD, detects pnpm/npm, runs install + build inside
+/// `ui_dir`, writes a placeholder on any failure so the Rust build still
+/// completes even without the JS toolchain.
+/// Test: `SKIP_UI_BUILD=1 cargo check` short-circuits; `cargo build` with pnpm
+/// installed populates `dist_dir/index.html` with real Vite output.
+fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
+    // Step 1: honour explicit skip (CI / `cargo publish --verify`).
+    if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
+        if !dist_dir.join("index.html").exists() {
+            println!(
+                "cargo:warning=SKIP_UI_BUILD=1 but {dist}/ is empty — \
+                 run `pnpm --dir ui install && pnpm --dir ui build` before publishing.",
+                dist = dist_dir.display()
+            );
+            ensure_placeholder(dist_dir, crate_name);
+        }
+        return;
+    }
+
+    // Step 2: no `ui/package.json` means we are inside an extracted tarball
+    // that already shipped the dist — nothing to build.
+    if !ui_dir.join("package.json").exists() {
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    }
+
+    // Step 3: detect package manager (pnpm preferred, npm fallback).
+    let Some(pm) = detect_pm() else {
         println!(
-            "cargo:warning=SKIP_UI_BUILD=1 but ui/dist/ is empty. \
-             Run `pnpm -C ui build` before publishing."
+            "cargo:warning={crate_name}: no pnpm/npm on PATH — skipping UI \
+             build (set SKIP_UI_BUILD=1 to silence, or install pnpm)."
         );
-        ensure_placeholder(ui_dist);
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    };
+
+    // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    let mut install_args = vec!["install"];
+    if ui_dir.join("pnpm-lock.yaml").exists() {
+        install_args.push("--frozen-lockfile");
+    }
+    let install_ok = Command::new(pm)
+        .args(&install_args)
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !install_ok {
+        println!("cargo:warning={crate_name}: `{pm} install` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    }
+
+    // Step 4b: build.
+    let build_ok = Command::new(pm)
+        .args(["run", "build"])
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !build_ok {
+        println!("cargo:warning={crate_name}: `{pm} run build` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
     }
 }
 
-/// True when the crate has a `ui/package.json` (i.e. it's a working copy, not
-/// an extracted publish tarball).
-fn has_ui_sources(ui_dir: &Path) -> bool {
-    ui_dir.join("package.json").exists()
+/// Write a stub `index.html` so embed macros compile without the JS build.
+///
+/// Why: `rust_embed` and `include_dir!` fail at compile time if the referenced
+/// directory is absent or empty; a single-file stub is the minimum viable
+/// artefact that satisfies both macros while making the "UI not built" state
+/// obvious to anyone who opens `/` in a browser.
+/// What: Creates `dist_dir` if needed and writes a minimal HTML document.
+/// Idempotent — exits immediately if `index.html` already exists.
+/// Test: After `SKIP_UI_BUILD=1 cargo build`, `dist_dir/index.html` exists.
+fn ensure_placeholder(dist_dir: &Path, crate_name: &str) {
+    if dist_dir.join("index.html").exists() {
+        return;
+    }
+    let _ = std::fs::create_dir_all(dist_dir);
+    let html = format!(
+        "<!doctype html><html><body><p>{crate_name}: UI assets not built. \
+         Run <code>pnpm --dir ui install &amp;&amp; pnpm --dir ui build</code> \
+         and rebuild.</p></body></html>"
+    );
+    let _ = std::fs::write(dist_dir.join("index.html"), html);
 }
 
-/// Detect the package manager: prefer `pnpm` (the project's lockfile format),
-/// fall back to `npm`. The `ui_dir` argument is currently unused — pnpm is
-/// preferred whenever it is installed — but kept for symmetry with a possible
-/// future per-lockfile selection.
-fn package_manager(_ui_dir: &Path) -> Option<&'static str> {
-    let has = |bin: &str| {
+/// Detect the available Node.js package manager on PATH.
+///
+/// Why: The workspace uses pnpm (lockfile is `pnpm-lock.yaml`), but `npm`
+/// works as a fallback on machines that have Node but not pnpm separately.
+/// What: Probes `pnpm --version` then `npm --version`; returns the first
+/// that exits 0, or `None` when neither is found.
+/// Test: `detect_pm()` returns `Some("pnpm")` on a standard dev machine;
+/// `Some("npm")` on a machine without pnpm; `None` in a bare container.
+fn detect_pm() -> Option<&'static str> {
+    let ok = |bin: &str| {
         Command::new(bin)
             .arg("--version")
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
     };
-    if has("pnpm") {
+    if ok("pnpm") {
         Some("pnpm")
-    } else if has("npm") {
+    } else if ok("npm") {
         Some("npm")
     } else {
         None
     }
 }
 
-/// Run `<pm> install` followed by `<pm> run build` inside `ui/`. Any failure
-/// is downgraded to a placeholder `ui/dist/index.html` plus a `cargo:warning`
-/// so the Rust build still completes.
-fn build_ui(ui_dir: &Path, ui_dist: &Path) {
-    let Some(pm) = package_manager(ui_dir) else {
-        println!(
-            "cargo:warning=no pnpm/npm found; cannot build trusty-memory UI. \
-             Run `pnpm -C ui build` manually or set SKIP_UI_BUILD=1."
-        );
-        ensure_placeholder(ui_dist);
-        return;
-    };
-
-    let install = Command::new(pm).arg("install").current_dir(ui_dir).status();
-    if !matches!(install, Ok(s) if s.success()) {
-        println!("cargo:warning=`{pm} install` failed for trusty-memory UI");
-        ensure_placeholder(ui_dist);
-        return;
-    }
-
-    let build = Command::new(pm)
-        .args(["run", "build"])
-        .current_dir(ui_dir)
-        .status();
-    match build {
-        Ok(s) if s.success() => {}
-        Ok(s) => {
-            println!("cargo:warning=`{pm} run build` exited with {s:?}");
-            ensure_placeholder(ui_dist);
-        }
-        Err(e) => {
-            println!("cargo:warning=failed to spawn `{pm} run build` ({e})");
-            ensure_placeholder(ui_dist);
-        }
-    }
-}
-
-/// Emit a stub `ui/dist/index.html` so `RustEmbed` still compiles even when
-/// the JS build did not run.
-fn ensure_placeholder(ui_dist: &Path) {
-    if ui_dist.join("index.html").exists() {
-        return;
-    }
-    let _ = std::fs::create_dir_all(ui_dist);
-    let _ = std::fs::write(
-        ui_dist.join("index.html"),
-        "<!doctype html><html><body><p>trusty-memory: UI assets not built. \
-         Run <code>pnpm -C ui build</code> and rebuild.</p></body></html>",
-    );
-}
+// ── CANONICAL BLOCK END ──

--- a/crates/trusty-memory/build.rs
+++ b/crates/trusty-memory/build.rs
@@ -83,8 +83,10 @@ fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
     };
 
     // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    // Only pass --frozen-lockfile when pnpm is the detected manager; npm does
+    // not support that flag (it uses --ci instead) and will error out.
     let mut install_args = vec!["install"];
-    if ui_dir.join("pnpm-lock.yaml").exists() {
+    if pm == "pnpm" && ui_dir.join("pnpm-lock.yaml").exists() {
         install_args.push("--frozen-lockfile");
     }
     let install_ok = Command::new(pm)

--- a/crates/trusty-search/build.rs
+++ b/crates/trusty-search/build.rs
@@ -9,8 +9,17 @@
 //! rebuild, then either honours `SKIP_UI_BUILD=1` (CI / `cargo publish`
 //! flow where `make release-prep` has already populated `ui-dist/`) or
 //! shells out to `make release-prep`. If `make` is unavailable or the target
-//! fails, falls back to emitting a placeholder `ui-dist/index.html` so
-//! `include_dir!` still compiles.
+//! fails, falls back to the canonical pnpm build pipeline (shared with
+//! trusty-memory / trusty-analyze / trusty-console per issue #987) and then
+//! copies `ui/dist → ui-dist`. If pnpm is also absent, writes a placeholder
+//! `ui-dist/index.html` so `include_dir!` still compiles.
+//!
+//! NOTE: The core UI-build logic (SKIP_UI_BUILD guard, pnpm detection,
+//! install+build pipeline, placeholder fallback) is intentionally kept
+//! identical across trusty-memory, trusty-analyze, trusty-console, and
+//! trusty-search (issue #987). `scripts/check_buildrs_sync.sh` asserts that
+//! the canonical implementation block does not drift between these four files.
+//!
 //! Test: `SKIP_UI_BUILD=1 cargo check` exits without invoking any JS
 //! toolchain; a plain `cargo build` on a host with `make` + pnpm/npm
 //! installed populates `ui-dist/index.html` via the Makefile.
@@ -19,102 +28,209 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    let crate_root = crate_root();
-    let ui_dist = crate_root.join("ui-dist");
+    let crate_root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
+    // trusty-search embeds from `ui-dist/` at the crate root (the committed
+    // bundle produced by `make release-prep`), not from `ui/dist/`.
+    let ui_dir = crate_root.join("ui");
+    let dist_dir = crate_root.join("ui-dist");
 
-    emit_rerun_directives();
-
-    // Step 1: honour explicit skip (CI / `cargo publish --verify`).
-    if skip_requested() {
-        handle_skip(&ui_dist);
-        return;
-    }
-
-    // Step 2: no `ui/` tree at all (e.g. running build.rs inside an extracted
-    // crate tarball that already shipped `ui-dist/`) → nothing to build.
-    if !has_ui_sources(&crate_root) {
-        ensure_placeholder(&ui_dist);
-        return;
-    }
-
-    // Step 3: delegate to `make release-prep` (build-ui + sync-ui).
-    run_make_release_prep(&crate_root, &ui_dist);
-}
-
-/// Resolve the crate root from Cargo's environment.
-fn crate_root() -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
-    PathBuf::from(manifest_dir)
-}
-
-/// Tell Cargo to re-run this build script when any UI source or the Makefile
-/// changes (or the `SKIP_UI_BUILD` flag flips).
-fn emit_rerun_directives() {
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
     println!("cargo:rerun-if-changed=ui/package.json");
     println!("cargo:rerun-if-changed=ui/vite.config.js");
     println!("cargo:rerun-if-changed=ui/index.html");
     println!("cargo:rerun-if-changed=ui/src");
     println!("cargo:rerun-if-changed=Makefile");
-}
 
-/// True when the operator opted out of the JS build (`SKIP_UI_BUILD=1`).
-fn skip_requested() -> bool {
-    std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1")
-}
-
-/// Skip-flag branch: emit a warning if `ui-dist/` is empty, then ensure the
-/// stub `index.html` exists so `include_dir!` still compiles.
-fn handle_skip(ui_dist: &Path) {
-    if !ui_dist.join("index.html").exists() {
-        println!(
-            "cargo:warning=SKIP_UI_BUILD=1 but ui-dist/ is empty. \
-             Run `make release-prep` before publishing."
-        );
-        ensure_placeholder(ui_dist);
-    }
-}
-
-/// True when the crate has a `ui/package.json` (i.e. it's a working copy, not
-/// an extracted publish tarball).
-fn has_ui_sources(crate_root: &Path) -> bool {
-    crate_root.join("ui").join("package.json").exists()
-}
-
-/// Invoke `make release-prep` and downgrade any failure to a placeholder
-/// `ui-dist/index.html` plus a `cargo:warning` so the Rust build still
-/// completes.
-fn run_make_release_prep(crate_root: &Path, ui_dist: &Path) {
-    let status = Command::new("make")
-        .arg("release-prep")
-        .current_dir(crate_root)
-        .status();
-    match status {
-        Ok(s) if s.success() => {}
-        Ok(s) => {
-            println!("cargo:warning=`make release-prep` exited with {s:?}");
-            ensure_placeholder(ui_dist);
-        }
-        Err(e) => {
+    // Step 1: honour explicit skip (CI / `cargo publish --verify`).
+    if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
+        if !dist_dir.join("index.html").exists() {
             println!(
-                "cargo:warning=failed to spawn `make release-prep` ({e}); \
-                 set SKIP_UI_BUILD=1 or run `make release-prep` manually"
+                "cargo:warning=SKIP_UI_BUILD=1 but ui-dist/ is empty. \
+                 Run `make release-prep` before publishing."
             );
-            ensure_placeholder(ui_dist);
+            ensure_placeholder(&dist_dir, "trusty-search");
         }
-    }
-}
-
-/// Emit a stub `ui-dist/index.html` so `include_dir!("$CARGO_MANIFEST_DIR/ui-dist")`
-/// still compiles even when the JS build did not run.
-fn ensure_placeholder(ui_dist: &Path) {
-    if ui_dist.join("index.html").exists() {
         return;
     }
-    let _ = std::fs::create_dir_all(ui_dist);
-    let _ = std::fs::write(
-        ui_dist.join("index.html"),
-        "<!doctype html><html><body><p>trusty-search: UI assets not built. \
-         Run <code>make release-prep</code> and rebuild.</p></body></html>",
+
+    // Step 2: no `ui/` tree at all (e.g. running build.rs inside an extracted
+    // crate tarball that already shipped `ui-dist/`) → nothing to build.
+    if !ui_dir.join("package.json").exists() {
+        ensure_placeholder(&dist_dir, "trusty-search");
+        return;
+    }
+
+    // Step 3: try `make release-prep` (builds JS + copies ui/dist → ui-dist).
+    let make_ok = Command::new("make")
+        .arg("release-prep")
+        .current_dir(&crate_root)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if make_ok {
+        return;
+    }
+
+    // Step 4: `make` unavailable or failed — fall back to the canonical pnpm
+    // pipeline (shared with trusty-memory / trusty-analyze / trusty-console),
+    // building into `ui/dist`, then copy to `ui-dist`.
+    println!(
+        "cargo:warning=trusty-search: `make release-prep` unavailable or failed; \
+         falling back to direct pnpm build."
     );
+    let tmp_dist = ui_dir.join("dist");
+    build_svelte_ui(&ui_dir, &tmp_dist, "trusty-search");
+    if tmp_dist.join("index.html").exists() {
+        copy_dir_all(&tmp_dist, &dist_dir);
+    } else {
+        ensure_placeholder(&dist_dir, "trusty-search");
+    }
 }
+
+/// Mirror `src` directory into `dst` (replicates the `make release-prep` copy).
+///
+/// Why: When `make` is absent, the `ui/dist → ui-dist` copy step that
+/// `release-prep` normally performs must happen inside build.rs so
+/// `include_dir!("$CARGO_MANIFEST_DIR/ui-dist")` still finds its assets.
+/// What: Recursively copies every file under `src` into `dst`, creating
+/// subdirectories as needed. Individual copy errors are silently skipped so
+/// a partial copy still produces a compilable (if incomplete) binary.
+/// Test: Exercised by `cargo build` on a host without `make`; the
+/// `SKIP_UI_BUILD=1` path short-circuits before this function is reached.
+fn copy_dir_all(src: &Path, dst: &Path) {
+    let _ = std::fs::create_dir_all(dst);
+    let Ok(entries) = std::fs::read_dir(src) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_all(&src_path, &dst_path);
+        } else {
+            let _ = std::fs::copy(&src_path, &dst_path);
+        }
+    }
+}
+
+// ── CANONICAL BLOCK BEGIN (kept in sync by scripts/check_buildrs_sync.sh) ──
+
+/// Run the Svelte UI build pipeline, or degrade gracefully to a placeholder.
+///
+/// Why: Centralises SKIP_UI_BUILD handling, pnpm detection, frozen-lockfile
+/// install, and placeholder fallback so all four UI-embedding crates share
+/// identical logic without a published build-helper crate (#987).
+/// What: Checks SKIP_UI_BUILD, detects pnpm/npm, runs install + build inside
+/// `ui_dir`, writes a placeholder on any failure so the Rust build still
+/// completes even without the JS toolchain.
+/// Test: `SKIP_UI_BUILD=1 cargo check` short-circuits; `cargo build` with pnpm
+/// installed populates `dist_dir/index.html` with real Vite output.
+fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
+    // Step 1: honour explicit skip (CI / `cargo publish --verify`).
+    if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
+        if !dist_dir.join("index.html").exists() {
+            println!(
+                "cargo:warning=SKIP_UI_BUILD=1 but {dist}/ is empty — \
+                 run `pnpm --dir ui install && pnpm --dir ui build` before publishing.",
+                dist = dist_dir.display()
+            );
+            ensure_placeholder(dist_dir, crate_name);
+        }
+        return;
+    }
+
+    // Step 2: no `ui/package.json` means we are inside an extracted tarball
+    // that already shipped the dist — nothing to build.
+    if !ui_dir.join("package.json").exists() {
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    }
+
+    // Step 3: detect package manager (pnpm preferred, npm fallback).
+    let Some(pm) = detect_pm() else {
+        println!(
+            "cargo:warning={crate_name}: no pnpm/npm on PATH — skipping UI \
+             build (set SKIP_UI_BUILD=1 to silence, or install pnpm)."
+        );
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    };
+
+    // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    let mut install_args = vec!["install"];
+    if ui_dir.join("pnpm-lock.yaml").exists() {
+        install_args.push("--frozen-lockfile");
+    }
+    let install_ok = Command::new(pm)
+        .args(&install_args)
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !install_ok {
+        println!("cargo:warning={crate_name}: `{pm} install` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
+        return;
+    }
+
+    // Step 4b: build.
+    let build_ok = Command::new(pm)
+        .args(["run", "build"])
+        .current_dir(ui_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !build_ok {
+        println!("cargo:warning={crate_name}: `{pm} run build` failed — embedding placeholder UI.");
+        ensure_placeholder(dist_dir, crate_name);
+    }
+}
+
+/// Write a stub `index.html` so embed macros compile without the JS build.
+///
+/// Why: `rust_embed` and `include_dir!` fail at compile time if the referenced
+/// directory is absent or empty; a single-file stub is the minimum viable
+/// artefact that satisfies both macros while making the "UI not built" state
+/// obvious to anyone who opens `/` in a browser.
+/// What: Creates `dist_dir` if needed and writes a minimal HTML document.
+/// Idempotent — exits immediately if `index.html` already exists.
+/// Test: After `SKIP_UI_BUILD=1 cargo build`, `dist_dir/index.html` exists.
+fn ensure_placeholder(dist_dir: &Path, crate_name: &str) {
+    if dist_dir.join("index.html").exists() {
+        return;
+    }
+    let _ = std::fs::create_dir_all(dist_dir);
+    let html = format!(
+        "<!doctype html><html><body><p>{crate_name}: UI assets not built. \
+         Run <code>pnpm --dir ui install &amp;&amp; pnpm --dir ui build</code> \
+         and rebuild.</p></body></html>"
+    );
+    let _ = std::fs::write(dist_dir.join("index.html"), html);
+}
+
+/// Detect the available Node.js package manager on PATH.
+///
+/// Why: The workspace uses pnpm (lockfile is `pnpm-lock.yaml`), but `npm`
+/// works as a fallback on machines that have Node but not pnpm separately.
+/// What: Probes `pnpm --version` then `npm --version`; returns the first
+/// that exits 0, or `None` when neither is found.
+/// Test: `detect_pm()` returns `Some("pnpm")` on a standard dev machine;
+/// `Some("npm")` on a machine without pnpm; `None` in a bare container.
+fn detect_pm() -> Option<&'static str> {
+    let ok = |bin: &str| {
+        Command::new(bin)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    if ok("pnpm") {
+        Some("pnpm")
+    } else if ok("npm") {
+        Some("npm")
+    } else {
+        None
+    }
+}
+
+// ── CANONICAL BLOCK END ──

--- a/crates/trusty-search/build.rs
+++ b/crates/trusty-search/build.rs
@@ -93,8 +93,9 @@ fn main() {
 /// `release-prep` normally performs must happen inside build.rs so
 /// `include_dir!("$CARGO_MANIFEST_DIR/ui-dist")` still finds its assets.
 /// What: Recursively copies every file under `src` into `dst`, creating
-/// subdirectories as needed. Individual copy errors are silently skipped so
-/// a partial copy still produces a compilable (if incomplete) binary.
+/// subdirectories as needed. Per-file copy failures emit a `cargo:warning`
+/// so an incomplete ui-dist/ is surfaced at build time rather than silently
+/// producing a binary that serves broken assets.
 /// Test: Exercised by `cargo build` on a host without `make`; the
 /// `SKIP_UI_BUILD=1` path short-circuits before this function is reached.
 fn copy_dir_all(src: &Path, dst: &Path) {
@@ -107,8 +108,12 @@ fn copy_dir_all(src: &Path, dst: &Path) {
         let dst_path = dst.join(entry.file_name());
         if src_path.is_dir() {
             copy_dir_all(&src_path, &dst_path);
-        } else {
-            let _ = std::fs::copy(&src_path, &dst_path);
+        } else if let Err(e) = std::fs::copy(&src_path, &dst_path) {
+            println!(
+                "cargo:warning=trusty-search: failed to copy {} -> {}: {e}",
+                src_path.display(),
+                dst_path.display()
+            );
         }
     }
 }
@@ -157,8 +162,10 @@ fn build_svelte_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
     };
 
     // Step 4a: install — prefer frozen lockfile when pnpm-lock.yaml exists.
+    // Only pass --frozen-lockfile when pnpm is the detected manager; npm does
+    // not support that flag (it uses --ci instead) and will error out.
     let mut install_args = vec!["install"];
-    if ui_dir.join("pnpm-lock.yaml").exists() {
+    if pm == "pnpm" && ui_dir.join("pnpm-lock.yaml").exists() {
         install_args.push("--frozen-lockfile");
     }
     let install_ok = Command::new(pm)

--- a/scripts/check_buildrs_sync.sh
+++ b/scripts/check_buildrs_sync.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# scripts/check_buildrs_sync.sh
+#
+# Why: trusty-memory, trusty-analyze, trusty-console, and trusty-search each
+# contain an identical "CANONICAL BLOCK" in their build.rs (issue #987). Because
+# Cargo cannot share build scripts as a library, the block is duplicated by
+# necessity; this script is the anti-drift gate that fails CI whenever the
+# copies diverge.
+#
+# What: Extracts the text between "CANONICAL BLOCK BEGIN" and
+# "CANONICAL BLOCK END" from each build.rs and asserts they are byte-for-byte
+# identical. Exits 0 on success, 1 on any mismatch with a diff.
+#
+# Test: Run `bash scripts/check_buildrs_sync.sh` from the workspace root.
+# Expected output: "build.rs canonical blocks are in sync across all 4 crates."
+
+set -euo pipefail
+
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+FILES=(
+    "crates/trusty-memory/build.rs"
+    "crates/trusty-analyze/build.rs"
+    "crates/trusty-console/build.rs"
+    "crates/trusty-search/build.rs"
+)
+
+extract_canonical_block() {
+    local file="$1"
+    sed -n '/── CANONICAL BLOCK BEGIN/,/── CANONICAL BLOCK END/p' "$file"
+}
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAILED=0
+REFERENCE=""
+REFERENCE_FILE=""
+
+for rel in "${FILES[@]}"; do
+    abs="$WORKSPACE_ROOT/$rel"
+    if [[ ! -f "$abs" ]]; then
+        echo "ERROR: expected file not found: $rel" >&2
+        FAILED=1
+        continue
+    fi
+    block_file="$TMP_DIR/$(echo "$rel" | tr '/' '_').block"
+    extract_canonical_block "$abs" > "$block_file"
+    if [[ ! -s "$block_file" ]]; then
+        echo "ERROR: no CANONICAL BLOCK found in $rel" >&2
+        FAILED=1
+        continue
+    fi
+    if [[ -z "$REFERENCE" ]]; then
+        REFERENCE="$block_file"
+        REFERENCE_FILE="$rel"
+    else
+        if ! diff -q "$REFERENCE" "$block_file" > /dev/null 2>&1; then
+            echo "FAIL: canonical block in $rel differs from $REFERENCE_FILE:" >&2
+            diff "$REFERENCE" "$block_file" >&2
+            FAILED=1
+        fi
+    fi
+done
+
+if [[ "$FAILED" -eq 0 ]]; then
+    echo "build.rs canonical blocks are in sync across all ${#FILES[@]} crates."
+    exit 0
+else
+    echo "" >&2
+    echo "To fix: update all four build.rs files to share the same canonical block." >&2
+    echo "The reference implementation is in $REFERENCE_FILE." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Standardises the four UI-embedding crates (`trusty-memory`, `trusty-analyze`, `trusty-console`, `trusty-search`) to share an identical `CANONICAL BLOCK` for their SKIP_UI_BUILD guard, pnpm/npm detection, frozen-lockfile install pipeline, and placeholder-fallback logic — resolving the drift described in #987.
- Adds `scripts/check_buildrs_sync.sh`, a diff-based anti-drift gate that extracts the canonical block from all four files and fails if any copy deviates. Wire it into CI with `bash scripts/check_buildrs_sync.sh` as an additional lint step.
- No new published crate is introduced: the `include!`-based approach was attempted and rejected because the shared file is outside each crate's publish tarball boundary.

## What changed in each file

**`crates/trusty-memory/build.rs`** — replaced the bespoke pnpm+npm fallback (different warning messages, `_ui_dir` unused param) with the canonical `build_svelte_ui` / `ensure_placeholder` / `detect_pm` triad.

**`crates/trusty-analyze/build.rs`** — replaced the inline pnpm-only pipeline (manual `which()` helper, no npm fallback, hardcoded `pnpm build` not `pnpm run build`) with the same canonical triad.

**`crates/trusty-console/build.rs`** — same as trusty-analyze (was a copy with identical issues).

**`crates/trusty-search/build.rs`** — kept the `make release-prep` primary path; added a proper pnpm fallback using the canonical block plus a `copy_dir_all` helper that replicates the `ui/dist → ui-dist` step when `make` is absent. The canonical block is now identical to the other three files.

**`scripts/check_buildrs_sync.sh`** (new) — extracts `CANONICAL BLOCK BEGIN…END` from each build.rs and diffs them; exits 0 only when all four are byte-identical.

## Duplication before this PR

The three independently-evolved implementations differed in:
- `trusty-analyze` / `trusty-console`: used `pnpm build` (not `pnpm run build`), had a manual `which()` helper, no npm fallback, no frozen-lockfile detection
- `trusty-memory`: had `npm` fallback but an unused `_ui_dir` parameter in `package_manager()`
- `trusty-search`: delegated to `make` with no pnpm fallback at all

## Test plan

- [x] `SKIP_UI_BUILD=1 cargo build -p trusty-search -p trusty-memory -p trusty-analyze -p trusty-console` — finished in 4s, all four compiled
- [x] `SKIP_UI_BUILD=1 cargo clippy --workspace --all-targets -- -D warnings` — clean (pre-existing tga MSRV config warning only)
- [x] `SKIP_UI_BUILD=1 cargo publish -p trusty-console --dry-run --locked --allow-dirty` — "Uploading trusty-console v0.1.0 … warning: aborting upload due to dry run" — publishable
- [x] `cargo fmt && cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 170 allowlisted, 0 violations
- [x] `bash scripts/check_buildrs_sync.sh` — "canonical blocks are in sync across all 4 crates"
- [x] All pre-commit hooks passed

## Notes for PM

No new crate was added, so there is nothing extra to publish before the next release of the four UI crates. The sync check script (`scripts/check_buildrs_sync.sh`) can be wired into the GitHub Actions CI workflow as a fast lint step — it takes under a second and has no Rust/Cargo dependency.

Generated with [Claude Code](https://claude.ai/claude-code)