### PR TITLE
fix(search): prune stale chunks for changed files on non-force reindex

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -163,7 +163,7 @@ crates/trusty-search/src/service/daemon.rs	774
 crates/trusty-search/src/service/embedder_supervisor.rs	1020
 crates/trusty-search/src/service/grep.rs	827
 crates/trusty-search/src/service/persistence.rs	1017
-crates/trusty-search/src/service/reindex/mod.rs	2789
+crates/trusty-search/src/service/reindex/mod.rs	2855
 crates/trusty-search/src/service/reindex/tests.rs	1674
 crates/trusty-search/src/service/walker.rs	1344
 crates/trusty-search/src/service/warm_boot/probe.rs	518

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -881,6 +881,16 @@ struct ParsedReadyBatch {
     /// Files actually submitted to the indexer (post hash/minified filtering).
     /// Used to size the per-batch commit event.
     batch_files: usize,
+    /// Corpus-relative paths of every file being re-indexed in this batch
+    /// (i.e. the files that were NOT hash-skipped). Used by
+    /// `commit_parsed_and_finalize` to remove stale chunks for changed files
+    /// BEFORE inserting the new chunks (fix for issue #855: delete-then-insert
+    /// semantics to prevent orphan chunk IDs when a file shrinks).
+    ///
+    /// These strings are exactly the keys stored in the corpus (produced by
+    /// `to_corpus_relative_path` in `prepare_batch_payload`), so the removal
+    /// finds precisely the right prior chunks.
+    changed_corpus_paths: Vec<String>,
 }
 
 /// Stage 1 of the pipelined per-batch flow: read every file in `batch`,
@@ -1062,6 +1072,7 @@ async fn prepare_and_parse_batch(ctx: &BatchCtx, batch: &[PathBuf]) -> Option<Pa
         parsed,
         new_hashes: payload.new_hashes,
         batch_files,
+        changed_corpus_paths: payload.changed_corpus_paths,
     })
 }
 
@@ -1073,11 +1084,26 @@ async fn prepare_and_parse_batch(ctx: &BatchCtx, batch: &[PathBuf]) -> Option<Pa
 /// Why: commits must remain sequential (one write lock at a time), but the
 /// producer can already be reading + parsing the next batch in parallel with
 /// this work — that's the whole point of the pipeline (issue #20).
+///
+/// Issue #855 (delete-then-insert for changed files): before writing the new
+/// chunks, remove every prior chunk belonging to each CHANGED file. This
+/// prevents orphan chunk IDs when a file re-chunks to FEWER chunks (e.g. a
+/// function is deleted): the old chunk IDs carried into the staging store by
+/// `copy_all_from` would otherwise survive alongside the new IDs, and search
+/// would return stale content until the next `--force` reindex.
+///
+/// Sequencing is critical: the removal MUST happen BEFORE the new chunks are
+/// written (so we only remove the old set, not what we just inserted). The
+/// write lock is held for the entire remove-then-insert window so no reader
+/// can observe a partially-updated state. The KG is NOT rebuilt here (matching
+/// `remove_file_no_kg_rebuild`); the reindex orchestrator rebuilds it once at
+/// Phase 3, which is already the existing behaviour.
 async fn commit_parsed_and_finalize(ctx: &BatchCtx, ready: ParsedReadyBatch) -> BatchOutcome {
     let ParsedReadyBatch {
         parsed,
         new_hashes,
         batch_files,
+        changed_corpus_paths,
     } = ready;
     let parse_ms = parsed.parse_ms;
     let embed_ms = parsed.embed_ms;
@@ -1085,6 +1111,29 @@ async fn commit_parsed_and_finalize(ctx: &BatchCtx, ready: ParsedReadyBatch) -> 
 
     let commit = {
         let indexer = ctx.handle.indexer.write().await;
+
+        // Issue #855: delete-then-insert for changed files. For every file
+        // being re-indexed in this batch, remove its previous chunks from ALL
+        // stores (in-memory map, HNSW, BM25, redb) before writing the new
+        // chunks. Brand-new files (not previously in the corpus) have no prior
+        // chunks to remove; `remove_file_no_kg_rebuild` returns 0 for them
+        // without error.
+        //
+        // This must run INSIDE the same write-lock window as the subsequent
+        // `commit_parsed_batch` so the two operations are atomic from the
+        // perspective of concurrent readers (a search holding the READ lock
+        // will either see the full old set or the full new set, never a mix).
+        for file_path in &changed_corpus_paths {
+            if let Err(e) = indexer.remove_file_no_kg_rebuild(file_path).await {
+                tracing::warn!(
+                    "reindex[{}]: #855 pre-commit remove failed for {} ({e}) \
+                     — stale chunks may persist until next --force reindex",
+                    ctx.index_id.0,
+                    file_path,
+                );
+            }
+        }
+
         match indexer.commit_parsed_batch(parsed, true).await {
             Ok(c) => c,
             Err(e) => {
@@ -1120,6 +1169,11 @@ struct BatchPayload {
     to_index: Vec<(String, String)>,
     to_index_paths: Vec<PathBuf>,
     new_hashes: Vec<(PathBuf, String)>,
+    /// Corpus-relative paths of files being re-indexed (same strings as the
+    /// first element of each `to_index` entry). Carried separately so
+    /// `commit_parsed_and_finalize` can remove stale chunks before inserting
+    /// new ones without re-deriving the paths from `new_hashes`.
+    changed_corpus_paths: Vec<String>,
 }
 
 /// Read every file in `batch` concurrently, then drop read errors, minified
@@ -1141,6 +1195,12 @@ async fn prepare_batch_payload(ctx: &BatchCtx, batch: &[PathBuf]) -> BatchPayloa
     let mut to_index: Vec<(String, String)> = Vec::with_capacity(batch.len());
     let mut to_index_paths: Vec<PathBuf> = Vec::with_capacity(batch.len());
     let mut new_hashes: Vec<(PathBuf, String)> = Vec::with_capacity(batch.len());
+    // Issue #855: track the corpus-relative path of every file being
+    // re-indexed so `commit_parsed_and_finalize` can remove the prior
+    // chunks before inserting the new set (delete-then-insert per changed
+    // file). Only changed files (hash-miss) reach this list; unchanged and
+    // error files are skipped before the push below.
+    let mut changed_corpus_paths: Vec<String> = Vec::with_capacity(batch.len());
     for (path, content_res) in read_results {
         // Use the shared canonical normalisation from `prune` so every
         // relative-path string stored in the corpus is produced by the
@@ -1192,12 +1252,18 @@ async fn prepare_batch_payload(ctx: &BatchCtx, batch: &[PathBuf]) -> BatchPayloa
         to_index.push((path_str, content));
         to_index_paths.push(path.clone());
         new_hashes.push((path, h));
+        // Issue #855: record the corpus-relative path so the commit phase
+        // can remove prior (stale) chunks for this file before inserting the
+        // new set.  `rel` is the canonical corpus key — same string written
+        // to the chunk's `file` field, so removal finds exactly the right rows.
+        changed_corpus_paths.push(rel);
     }
 
     BatchPayload {
         to_index,
         to_index_paths,
         new_hashes,
+        changed_corpus_paths,
     }
 }
 

--- a/crates/trusty-search/src/service/reindex/prune_tests.rs
+++ b/crates/trusty-search/src/service/reindex/prune_tests.rs
@@ -1,10 +1,11 @@
-//! Issue #848 regression tests for the prune pass.
+//! Issue #848 and #855 regression tests for the prune pass and orphan-chunk fix.
 //!
 //! Why: isolated here to keep `prune.rs` under the 500-line cap while
 //! preserving full coverage for the path-normalisation helper and the
 //! data-safety disk-existence guard.
-//! What: four tests — normalisation round-trip, disk-existence guard predicate,
-//! `list_indexed_files` distinctness, pre-fix and post-fix prune models.
+//! What: five tests — normalisation round-trip, disk-existence guard predicate,
+//! `list_indexed_files` distinctness, pre-fix and post-fix prune models (#848),
+//! and orphan-chunk regression test (#855).
 //! Test: all tests in this file run as part of `cargo test -p trusty-search`.
 
 use super::to_corpus_relative_path;
@@ -311,5 +312,185 @@ fn prune_pass_removes_deleted_file_from_staged_corpus() {
     assert!(
         hashes.iter().any(|(f, _)| f == "kept.rs"),
         "#848 POST-FIX: file-hash entry for kept.rs must still be present"
+    );
+}
+
+/// Issue #855 — orphan-chunk regression model: when a changed file re-chunks
+/// to FEWER chunks (e.g. a function is deleted), the old chunk IDs that were
+/// carried into the staging corpus by `copy_all_from` must be removed BEFORE
+/// the new, smaller chunk set is written (delete-then-insert semantics).
+///
+/// Without the fix, the staging corpus would contain BOTH the new chunks AND
+/// the old chunks that no longer exist in the file — "orphan" rows that are
+/// promoted to the live corpus and returned by search until the next `--force`
+/// reindex.
+///
+/// Why: this is the core regression proof for issue #855. The pre-fix
+/// sub-test documents the wrong behaviour (orphan chunks survive); the
+/// post-fix sub-test documents the correct behaviour (orphan chunks are gone).
+///
+/// What: models the staging corpus lifecycle at the CorpusStore level:
+///   1. Seeds a live corpus with a file `shrunk.rs` having 3 chunks.
+///   2. Seeds a staging corpus from live (`copy_all_from`).
+///   3. PRE-FIX: verifies that a naive upsert-only re-commit of 1 new chunk
+///      leaves the 2 old chunks still present (proving the bug).
+///   4. POST-FIX: applies the delete-then-insert pattern (delete old chunks
+///      before inserting the new one) and verifies exactly 1 chunk survives.
+///
+/// Test: this test.
+#[test]
+fn changed_file_orphan_chunks_removed_before_reinsert() {
+    use crate::core::chunker::{ChunkType, RawChunk};
+    use crate::core::corpus::CorpusStore;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    let chunk = |file: &str, id: &str, content: &str| RawChunk {
+        id: id.to_string(),
+        file: file.to_string(),
+        start_line: 1,
+        end_line: 1,
+        content: content.to_string(),
+        function_name: None,
+        language: Some("rust".to_string()),
+        chunk_type: ChunkType::Code,
+        calls: Vec::new(),
+        inherits_from: Vec::new(),
+        chunk_depth: 0,
+        parent_chunk_id: None,
+        child_chunk_ids: Vec::new(),
+        nlp_keywords: Vec::new(),
+        nlp_code_refs: Vec::new(),
+        virtual_terms: Vec::new(),
+    };
+
+    // ─── Live corpus: shrunk.rs has 3 chunks ─────────────────────────────────
+    let live_path = dir.path().join("855_live.redb");
+    {
+        let live = CorpusStore::open(&live_path).unwrap();
+        live.upsert_chunks(&[
+            chunk("shrunk.rs", "shrunk:fn_a", "fn fn_a() {}"),
+            chunk("shrunk.rs", "shrunk:fn_b", "fn fn_b() {}"),
+            chunk("shrunk.rs", "shrunk:fn_c", "fn fn_c() {}"),
+        ])
+        .unwrap();
+        live.upsert_file_hashes(&[("shrunk.rs", "old_hash")])
+            .unwrap();
+    }
+
+    // ─── Staging seeded from live (copy_all_from) ─────────────────────────────
+    let staging_path = dir.path().join("855_staging.redb");
+    {
+        let live = CorpusStore::open(&live_path).unwrap();
+        let staging = CorpusStore::open_fresh(&staging_path).unwrap();
+        staging.copy_all_from(&live).unwrap();
+        // Verify: staging starts with all 3 chunks.
+        let initial = staging.list_indexed_files().unwrap();
+        assert!(
+            initial.iter().any(|f| f == "shrunk.rs"),
+            "#855 setup: staging must contain shrunk.rs after copy_all_from"
+        );
+        let initial_chunks = staging
+            .load_all_chunks()
+            .unwrap()
+            .into_iter()
+            .filter(|c| c.file == "shrunk.rs")
+            .count();
+        assert_eq!(
+            initial_chunks, 3,
+            "#855 setup: staging must start with 3 chunks for shrunk.rs"
+        );
+    }
+
+    // ─── PRE-FIX model: upsert-only re-commit (the bug) ──────────────────────
+    // Simulate what the OLD non-force reindex did: just upsert the 1 new chunk
+    // without first deleting the old 3.  The 2 orphan chunks survive.
+    let prefix_staging_path = dir.path().join("855_prefix_staging.redb");
+    {
+        let live = CorpusStore::open(&live_path).unwrap();
+        let staging = CorpusStore::open_fresh(&prefix_staging_path).unwrap();
+        staging.copy_all_from(&live).unwrap();
+        // Only upsert 1 new chunk (no delete of old ones).
+        staging
+            .upsert_chunks(&[chunk("shrunk.rs", "shrunk:fn_a", "fn fn_a_new() {}")])
+            .unwrap();
+    }
+    let prefix = CorpusStore::open(&prefix_staging_path).unwrap();
+    let prefix_chunks: Vec<_> = prefix
+        .load_all_chunks()
+        .unwrap()
+        .into_iter()
+        .filter(|c| c.file == "shrunk.rs")
+        .collect();
+    assert_eq!(
+        prefix_chunks.len(),
+        3, // 1 new + 2 orphans → DATA LOSS BUG
+        "#855 PRE-FIX model: upsert-only must leave 3 chunks (1 new + 2 orphan), \
+         proving the orphan-chunk bug exists"
+    );
+    // The orphan chunks with stale content must still be present.
+    assert!(
+        prefix_chunks.iter().any(|c| c.id == "shrunk:fn_b"),
+        "#855 PRE-FIX model: orphan chunk shrunk:fn_b must survive upsert-only"
+    );
+    assert!(
+        prefix_chunks.iter().any(|c| c.id == "shrunk:fn_c"),
+        "#855 PRE-FIX model: orphan chunk shrunk:fn_c must survive upsert-only"
+    );
+
+    // ─── POST-FIX model: delete-then-insert (the fix) ─────────────────────────
+    // Simulate what the FIXED non-force reindex does: delete all prior chunks
+    // for shrunk.rs, THEN insert the 1 new chunk.  Exactly 1 chunk survives.
+    let postfix_staging_path = dir.path().join("855_postfix_staging.redb");
+    {
+        let live = CorpusStore::open(&live_path).unwrap();
+        let staging = CorpusStore::open_fresh(&postfix_staging_path).unwrap();
+        staging.copy_all_from(&live).unwrap();
+
+        // Step 1: delete all old chunks for shrunk.rs (the fix).
+        let old_chunk_ids: Vec<String> = staging
+            .load_all_chunks()
+            .unwrap()
+            .into_iter()
+            .filter(|c| c.file == "shrunk.rs")
+            .map(|c| c.id)
+            .collect();
+        staging.delete_chunks(&old_chunk_ids).unwrap();
+
+        // Step 2: insert only the 1 new chunk.
+        staging
+            .upsert_chunks(&[chunk("shrunk.rs", "shrunk:fn_a", "fn fn_a_new() {}")])
+            .unwrap();
+    }
+    let postfix = CorpusStore::open(&postfix_staging_path).unwrap();
+    let postfix_chunks: Vec<_> = postfix
+        .load_all_chunks()
+        .unwrap()
+        .into_iter()
+        .filter(|c| c.file == "shrunk.rs")
+        .collect();
+    assert_eq!(
+        postfix_chunks.len(),
+        1, // exactly 1 new chunk, no orphans
+        "#855 POST-FIX: delete-then-insert must leave exactly 1 chunk for shrunk.rs; \
+         found: {:?}",
+        postfix_chunks.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        postfix_chunks[0].id, "shrunk:fn_a",
+        "#855 POST-FIX: the surviving chunk must be the newly inserted one"
+    );
+    assert_eq!(
+        postfix_chunks[0].content, "fn fn_a_new() {}",
+        "#855 POST-FIX: the surviving chunk must have the NEW content, not stale content"
+    );
+    // The orphan chunks must be gone.
+    assert!(
+        !postfix_chunks.iter().any(|c| c.id == "shrunk:fn_b"),
+        "#855 POST-FIX: orphan chunk shrunk:fn_b must be removed by delete-then-insert"
+    );
+    assert!(
+        !postfix_chunks.iter().any(|c| c.id == "shrunk:fn_c"),
+        "#855 POST-FIX: orphan chunk shrunk:fn_c must be removed by delete-then-insert"
     );
 }


### PR DESCRIPTION
## Summary

Fixes a DATA LOSS bug (#855) where a non-force incremental reindex of a file that produces fewer chunks than the previous version leaves orphan/stale chunk IDs in all stores (redb, HNSW, BM25, in-memory).

## Root Cause

The staging corpus is seeded by `copy_all_from`, which carries ALL prior rows. The batch loop then calls `commit_parsed_batch`, which uses INSERT-OR-OVERWRITE semantics. When a file re-chunks to fewer chunks (e.g. a function is deleted), the old chunk IDs are never removed — they survive in the staging corpus, are promoted to the live corpus during the atomic swap, and are returned by search until the next `--force` reindex.

The deleted-file prune pass (issue #848) does not catch this: it computes `staged_set − walked_set`, but a *changed* file appears in both sets and is never classified as deleted.

## Fix

Three-file change:

1. **`crates/trusty-search/src/service/reindex/mod.rs`**: Add `changed_corpus_paths: Vec<String>` to `BatchPayload` and `ParsedReadyBatch`. In `commit_parsed_and_finalize`, inside the WRITE-lock window (before `commit_parsed_batch`), iterate the changed paths and call `remove_file_no_kg_rebuild` for each. This provides delete-then-insert atomicity: readers on the read lock see either the full old chunk set or the full new chunk set, never a partially-updated state.

2. **`crates/trusty-search/src/service/reindex/prune_tests.rs`**: Add `changed_file_orphan_chunks_removed_before_reinsert` regression test with:
   - PRE-FIX model: verifies upsert-only leaves 3 chunks (1 new + 2 orphans), proving the bug exists
   - POST-FIX model: verifies delete-then-insert leaves exactly 1 chunk with the new content, orphans gone

3. **`.line-cap-allowlist.tsv`**: Updated budget for `mod.rs` (2789 → 2855) to reflect the 66 lines added for the fix and its documentation.

## Design Notes

- Brand-new files have no prior chunks; `remove_file_no_kg_rebuild` returns 0 for them (harmless no-op)
- The KG is NOT rebuilt per-file (matching `remove_file_no_kg_rebuild`'s contract); Phase 3 rebuilds it once for the whole reindex as before
- The removal happens inside the same write-lock window as `commit_parsed_batch` so the operation is atomic from readers' perspective
- Force reindexes (empty staging, full re-walk) are unaffected — this fix only applies to the non-force incremental path

## Test Plan

- [ ] `cargo test -p trusty-search` — all 812+ tests pass, including `changed_file_orphan_chunks_removed_before_reinsert` (no daemon, no ONNX model required)
- [ ] `cargo clippy -p trusty-search --all-targets -- -D warnings` — no warnings
- [ ] `cargo fmt --check` — clean
- [ ] `bash scripts/check_line_cap.sh` — 0 violations

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)