### PR TITLE
chore(release): trusty-search 0.24.3 + trusty-analyze 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10701,7 +10701,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11095,7 +11095,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -7,6 +7,61 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.6.0] — 2026-06-09
+
+### Added
+
+- **`limit` / `offset` / `omit_content` query parameters on smells + diagnostics
+  endpoints (#917/#918)** — `GET /indexes/:id/smells` and
+  `GET /indexes/:id/diagnostics` now accept:
+  - `limit` (default 500, max enforced server-side)
+  - `offset` (default 0, for cursor-style pagination)
+  - `omit_content` (default **`true`** — see Changed below)
+  The response body gains a pagination envelope:
+  `{ total, returned, truncated, items: [...] }`.
+  `find_smells` and `run_diagnostics` MCP tool input schemas are extended
+  with the same three parameters and wired through `build_query()`.
+
+- **MCP stdio size guard (#917)** — `guard_response_size()` in `mcp/stdio.rs`
+  checks the serialised response length against
+  `TRUSTY_MCP_MAX_RESPONSE_BYTES` (default **2 MB**, read at startup) before
+  `write_all`. Oversized payloads are replaced with a well-formed
+  `isError: true` truncation notice — the JSON-RPC `id` is preserved in the
+  notice so the caller can correlate it — so an over-limit response can never
+  kill the MCP session with `-32000`.
+
+- **`build_query()` numeric/bool value support** — the MCP dispatch helper now
+  parses JSON `Number` (u64) and `Boolean` values, not just strings, so
+  `limit`, `offset`, and `omit_content` fields from MCP tool calls are
+  forwarded correctly to the HTTP layer.
+
+### Changed
+
+- **`omit_content` defaults to `true` (behavior-affecting default change)** —
+  `SmellItem` serialisation omits the raw chunk `content` field by default.
+  This reduces typical smells payloads from multi-megabyte to tens of
+  kilobytes. Pass `omit_content=false` (HTTP) or `"omit_content": false` (MCP)
+  to restore the full text. **Callers that previously relied on `content`
+  being present in smells responses must add `omit_content=false`.**
+
+- **`omit_content` removed from `run_diagnostics` / `DiagnosticsParams`** —
+  `ToolDiagnostic` carries no raw source body, so the field was a no-op.
+  Removing it prevents callers from being misled into believing it affected
+  output.
+
+### Fixed
+
+- **#917 — over-limit smells/diagnostics responses crashed the MCP session** —
+  replaced unbounded `GET /smells` serialisation with the paginated,
+  omit-content-by-default path described above; the stdio size guard provides
+  an additional safety net at the transport layer.
+
+- **JSON-RPC `id` echoed in stdio size-guard truncation notice** — previously
+  the notice hardcoded `"id": null`, violating JSON-RPC 2.0 §5. The guard
+  now parses the id from the oversized bytes and echoes it.
+
+---
+
 ## [0.5.1] — 2026-06-07
 
 ### Added

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.5.3"
+version     = "0.6.0"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,42 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.24.3] — 2026-06-09
+
+### Fixed
+
+- **#1006 — accept-loop starvation under embed backpressure**
+  — Two complementary mitigations close the liveness gap when the embed
+  thread pool saturates:
+
+  - **Worker-thread floor raised to 16** — the Tokio runtime is now built
+    with an explicit `Builder::new_multi_thread()` using
+    `max(available_parallelism, 16)` worker threads. On a 4-core host the
+    default `num_cpus` count (≈8) was too low: once eight slots were occupied
+    by 30-second sidecar-blocking embed calls the axum accept-loop stalled,
+    causing short-timeout `/health` and `/context` connections to fail.
+
+  - **Non-blocking `/health` handler** — `try_current_embedder()` (a new
+    `try_read()` accessor on `state_impl.rs`) replaces the previous
+    `current_embedder().await`; `sys_metrics.try_lock()` replaces the
+    `lock().await` for CPU/RSS sampling. Both fall back gracefully on lock
+    contention: embedder info is omitted, last-sampled RSS/CPU atomics are
+    returned instead of zeros. Eliminates the 30-second blocking window that
+    paralysed the handler when the write lock was held by an active embed run.
+
+  - **Health-metric cache** — `AtomicU64`/`AtomicU32` caches on
+    `SearchAppState` store the last-sampled `rss_mb` and `cpu_pct`; the
+    fallback path reads these instead of reporting zeros, preventing
+    false-alarm monitors that alert on `rss_mb=0` during the rare
+    contention window.
+
+  Unit tests added: `health_non_blocking_when_embedder_slot_write_locked`,
+  `health_includes_embedder_info_when_ready`,
+  `worker_thread_count_at_least_16` (non-tautological: asserts the floor
+  formula, not just `max(N,16)>=16`).
+
+---
+
 ## [0.24.1] — 2026-06-06
 
 ### Fixed

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.24.2"
+version = "0.24.3"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version bumps for two hotfix releases:

- **trusty-search 0.24.3** (patch) — accept-loop starvation fix (#1006): raise Tokio worker-thread floor to `max(cpus, 16)` + non-blocking `/health` handler via `try_current_embedder()` / `try_lock()` + atomic RSS/CPU cache fallback
- **trusty-analyze 0.6.0** (minor) — payload cap + pagination for smells/diagnostics (#917/#918): new `limit`/`offset`/`omit_content` params (default `omit_content=true`), MCP stdio size guard (`TRUSTY_MCP_MAX_RESPONSE_BYTES`, 2 MB default)

Both fixes already merged to main via #1016 (search) and #1018 (analyze). This PR adds the version bumps and CHANGELOG entries.

## Behavior change note (trusty-analyze 0.6.0)

`omit_content` defaults to **`true`** for smells endpoints. Callers relying on raw chunk content in smells responses must add `omit_content=false`.

## Test plan

- [x] `cargo fmt --check` — passed
- [x] `cargo clippy -p trusty-search -p trusty-analyze --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-search` — all pass
- [x] `cargo test -p trusty-analyze` — all pass (405 total)
- [x] Pre-commit hooks (trailing whitespace, TOML, line-cap, secrets) — all passed
- [ ] CI green (watch after merge for flakes per #865/ETXTBSY)
- [ ] `SKIP_UI_BUILD=1 cargo publish -p trusty-search --locked` (post-merge)
- [ ] `SKIP_UI_BUILD=1 cargo publish -p trusty-analyze --locked` (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)