### PR TITLE
feat(trusty-code): bash tool (#1026)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10786,6 +10786,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -45,6 +45,9 @@ async-trait = { workspace = true }
 # Phase 3: TOML config parsing for AgentConfig
 toml = { workspace = true }
 
+# Unix process-group kill support for BashTool timeout enforcement
+libc = { workspace = true }
+
 [dev-dependencies]
 # Async test runtime (events, build_info, perf async tests, tools tests)
 tokio = { workspace = true }

--- a/crates/trusty-code/src/tools/bash/mod.rs
+++ b/crates/trusty-code/src/tools/bash/mod.rs
@@ -1,0 +1,315 @@
+//! `bash` tool — execute a shell command with timeout enforcement and output capture.
+//!
+//! Why: The coder agent loop needs to run commands (pytest, cargo test, etc.)
+//! and read their output to iterate. Surfacing a non-zero exit code as a
+//! recoverable `ToolResult` (not a hard error) lets the LLM read failing test
+//! output and self-correct without aborting the loop.
+//! What: `BashTool` implements `ToolExecutor`; it runs a command via `sh -c`
+//! inside `tokio::process::Command`, enforces a configurable timeout, kills the
+//! child (and its process group on Unix) on expiry, captures stdout + stderr
+//! (each truncated to 100 KB), and returns a structured result that includes
+//! the exit code, captured output, and a timeout flag.
+//! Test: Unit tests live in `bash::tests`; they cover fast success, non-zero
+//! exit, timeout-kill, cwd honoring, stdout/stderr truncation, registry
+//! registration, and dispatch.
+
+#[cfg(test)]
+mod tests;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::tools::traits::{ServiceTier, ToolExecutor, ToolResult};
+
+/// Maximum bytes captured from stdout or stderr before truncation.
+pub(crate) const MAX_OUTPUT_BYTES: usize = 100 * 1024; // 100 KB
+
+/// Default command timeout in seconds.
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+/// Executes arbitrary shell commands on behalf of the coder agent loop.
+///
+/// Why: Lets the LLM run test suites (pytest, cargo test, etc.), build steps,
+/// and diagnostic commands without a separate MCP bridge. Capturing output
+/// as a `ToolResult` (not a fatal error) on non-zero exit means the model
+/// can read failing test output and iterate.
+/// What: Wraps `tokio::process::Command` launched via `sh -c`; enforces a
+/// configurable per-call timeout; kills the child process group (POSIX) on
+/// expiry; truncates large outputs.
+/// Test: `bash::tests::fast_command_exit_zero`, `nonzero_exit_is_recoverable`,
+/// `timeout_kills_child`, `cwd_is_honored`, `stdout_truncation`,
+/// `registry_registration_and_dispatch`.
+pub struct BashTool {
+    /// Working directory for the spawned process. `None` means inherit the
+    /// tcode process's current directory.
+    pub working_dir: Option<PathBuf>,
+    /// Default timeout applied when the caller does not supply `timeout_secs`.
+    pub default_timeout: Duration,
+}
+
+impl BashTool {
+    /// Construct with an optional working directory and default timeout.
+    ///
+    /// Why: Callers providing a `RunContext` can inject `working_dir` so the
+    /// shell respects the project root without mutating global process state.
+    /// What: Stores `working_dir` and `default_timeout`.
+    /// Test: Constructed in all `BashTool` tests.
+    pub fn new(working_dir: Option<PathBuf>, default_timeout: Duration) -> Self {
+        Self {
+            working_dir,
+            default_timeout,
+        }
+    }
+
+    /// Construct with default settings (no cwd override, 120 s timeout).
+    ///
+    /// Why: Convenience constructor for callers that accept process defaults.
+    /// What: Delegates to `new(None, DEFAULT_TIMEOUT_SECS seconds)`.
+    /// Test: `bash::tests::fast_command_exit_zero`.
+    pub fn default_config() -> Self {
+        Self::new(None, Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for BashTool {
+    fn name(&self) -> &str {
+        "bash"
+    }
+
+    /// OpenAI-function schema for the bash tool.
+    ///
+    /// Why: The LLM function-calling loop requires a JSON schema to generate
+    /// valid calls. Declaring `command` as required and `timeout_secs` as
+    /// optional keeps the schema minimal while supporting per-call overrides.
+    /// What: Returns a `{ type: "function", function: { … } }` Value.
+    /// Test: Checked via `bash::tests::registry_registration_and_dispatch`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Execute a shell command and return its stdout, stderr, and exit code. Non-zero exit codes are surfaced as recoverable results, not errors — the model should read the output and iterate.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to run (passed to `sh -c`)."
+                        },
+                        "timeout_secs": {
+                            "type": "integer",
+                            "description": "Optional timeout in seconds. Defaults to 120. The child process (and its group) is killed on expiry.",
+                            "minimum": 1
+                        }
+                    },
+                    "required": ["command"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Mark as RESTRICTED so ReadOnly/Analytics callers cannot invoke it.
+    ///
+    /// Why: Shell execution is a privileged capability. Untrusted or
+    /// analytics-only callers must not be able to run arbitrary commands.
+    /// What: Returns `[ReadOnly, Analytics]` — callers in either tier are
+    /// blocked at the registry's `dispatch_for_user` boundary.
+    /// Test: Covered by `crate::tools::registry` tier-gating tests; also
+    /// checked via `bash::tests::restricted_tiers_includes_readonly_and_analytics`.
+    fn restricted_tiers(&self) -> &[ServiceTier] {
+        &[ServiceTier::ReadOnly, ServiceTier::Analytics]
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        // ── Parse arguments ────────────────────────────────────────────────
+        let Some(command) = args.get("command").and_then(Value::as_str) else {
+            return ToolResult::err("bash: missing required 'command' parameter");
+        };
+        if command.trim().is_empty() {
+            return ToolResult::err("bash: 'command' must not be empty");
+        }
+
+        let timeout_secs: u64 = args
+            .get("timeout_secs")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.default_timeout.as_secs());
+        let call_timeout = Duration::from_secs(timeout_secs);
+
+        // ── Build the subprocess ───────────────────────────────────────────
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(command);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd.stdin(std::process::Stdio::null());
+
+        if let Some(ref dir) = self.working_dir {
+            cmd.current_dir(dir);
+        }
+
+        // On Unix, spawn the child into its own process group so that a
+        // timeout kill reaches the entire process tree, not just the shell.
+        // SAFETY: `setsid()` is documented async-signal-safe. The closure
+        // runs in the forked child after `fork()` but before `exec()`.
+        #[cfg(unix)]
+        unsafe {
+            cmd.pre_exec(|| {
+                // Create a new session; this process becomes the leader of
+                // a new process group with pgid == pid.
+                if libc::setsid() == -1 {
+                    // Non-fatal: fall back to the parent's pgid.
+                }
+                Ok(())
+            });
+        }
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return ToolResult::err(format!("bash: failed to spawn command: {e}"));
+            }
+        };
+
+        // Grab the piped handles before consuming `child` in the wait call.
+        let mut stdout_handle = child.stdout.take().expect("stdout is piped");
+        let mut stderr_handle = child.stderr.take().expect("stderr is piped");
+
+        // ── Read stdout + stderr + wait with timeout ───────────────────────
+        let run_result = timeout(call_timeout, async {
+            let mut stdout_bytes = Vec::new();
+            let mut stderr_bytes = Vec::new();
+
+            // Read both streams concurrently to avoid pipe deadlocks.
+            let (stdout_res, stderr_res, wait_res) = tokio::join!(
+                read_capped(&mut stdout_handle, MAX_OUTPUT_BYTES),
+                read_capped(&mut stderr_handle, MAX_OUTPUT_BYTES),
+                child.wait()
+            );
+
+            stdout_bytes.extend_from_slice(&stdout_res);
+            stderr_bytes.extend_from_slice(&stderr_res);
+
+            let status = wait_res?;
+            Ok::<_, std::io::Error>((stdout_bytes, stderr_bytes, status))
+        })
+        .await;
+
+        match run_result {
+            // ── Timed out ─────────────────────────────────────────────────
+            Err(_elapsed) => {
+                // Kill the child's entire process group on Unix so background
+                // processes spawned by the shell are also reaped.
+                #[cfg(unix)]
+                {
+                    if let Some(pid) = child.id() {
+                        // SAFETY: `kill` is a safe POSIX syscall. The pid value
+                        // comes from the kernel; `i32::try_from` is fallible but
+                        // realistically cannot overflow for valid process IDs.
+                        if let Ok(signed_pid) = i32::try_from(pid) {
+                            // Negative pgid means "kill the whole process group".
+                            unsafe {
+                                libc::kill(-signed_pid, libc::SIGKILL);
+                            }
+                        }
+                    }
+                }
+                // Always attempt child.kill() as a fallback (handles non-Unix
+                // or the case where setsid failed and we fall back to the child
+                // itself).
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+
+                ToolResult::err(format!(
+                    "bash: command timed out after {timeout_secs}s and was killed\ncommand: {command}"
+                ))
+            }
+
+            // ── Completed (exit 0 or non-zero) ────────────────────────────
+            Ok(Ok((stdout_bytes, stderr_bytes, status))) => {
+                let stdout = lossy_truncated(&stdout_bytes, MAX_OUTPUT_BYTES);
+                let stderr = lossy_truncated(&stderr_bytes, MAX_OUTPUT_BYTES);
+                let exit_code = status.code().unwrap_or(-1);
+
+                let mut out = String::new();
+                if !stdout.is_empty() {
+                    out.push_str("stdout:\n");
+                    out.push_str(&stdout);
+                    if !stdout.ends_with('\n') {
+                        out.push('\n');
+                    }
+                }
+                if !stderr.is_empty() {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str("stderr:\n");
+                    out.push_str(&stderr);
+                    if !stderr.ends_with('\n') {
+                        out.push('\n');
+                    }
+                }
+                out.push_str(&format!("exit_code: {exit_code}"));
+
+                // Non-zero exit is a *recoverable* result (failing pytest output
+                // should be fed back to the model, not abort the loop).
+                ToolResult::ok(out)
+            }
+
+            // ── IO error from wait() ───────────────────────────────────────
+            Ok(Err(io_err)) => {
+                ToolResult::err(format!("bash: IO error while waiting for child: {io_err}"))
+            }
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Read up to `cap` bytes from an async reader without exceeding memory.
+///
+/// Why: Commands like `find /` can produce GB of output; we must bound
+/// memory without blocking the executor.
+/// What: Reads the full stream into a `Vec<u8>` capped at `cap` bytes;
+/// silently discards the remainder (the caller appends a truncation notice).
+/// Test: `bash::tests::stdout_truncation`.
+pub(crate) async fn read_capped<R: AsyncReadExt + Unpin>(reader: &mut R, cap: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(cap.min(4096));
+    let mut tmp = [0u8; 4096];
+    loop {
+        match reader.read(&mut tmp).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let remaining = cap.saturating_sub(buf.len());
+                if remaining == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&tmp[..n.min(remaining)]);
+            }
+            Err(_) => break,
+        }
+    }
+    buf
+}
+
+/// Convert bytes to a lossy UTF-8 string, appending a truncation notice when
+/// the captured byte count exactly equals `cap`.
+///
+/// Why: The LLM needs text; raw bytes are not useful. The truncation notice
+/// tells the model that output was cut so it can adjust.
+/// What: Calls `String::from_utf8_lossy`, then checks for truncation.
+/// Test: `bash::tests::stdout_truncation`.
+pub(crate) fn lossy_truncated(bytes: &[u8], cap: usize) -> String {
+    let s = String::from_utf8_lossy(bytes).into_owned();
+    if bytes.len() >= cap {
+        format!("{s}\n[... output truncated at {cap} bytes ...]")
+    } else {
+        s
+    }
+}

--- a/crates/trusty-code/src/tools/bash/tests.rs
+++ b/crates/trusty-code/src/tools/bash/tests.rs
@@ -1,0 +1,250 @@
+//! Tests for `BashTool`.
+//!
+//! Why: Collects all bash tool tests in a dedicated file so `bash/mod.rs`
+//! stays under the 500-line cap while preserving full coverage.
+//! What: Fast-path, error-path, timeout, cwd, truncation, registry, and
+//! RBAC tier tests.
+//! Test: Each `#[tokio::test]` / `#[test]` function is its own test case.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+use super::BashTool;
+use crate::tools::registry::ToolRegistry;
+use crate::tools::traits::ToolExecutor;
+
+/// A fast command (echo) returns captured stdout and exit 0.
+///
+/// Why: Basic smoke test for the happy path.
+/// What: Runs `echo hello`; asserts stdout contains "hello" and exit 0.
+/// Test: This test.
+#[tokio::test]
+async fn fast_command_exit_zero() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "echo hello"})).await;
+    assert!(
+        !result.is_error(),
+        "echo should succeed: {}",
+        result.content()
+    );
+    let content = result.content();
+    assert!(content.contains("hello"), "stdout must contain 'hello'");
+    assert!(content.contains("exit_code: 0"), "exit code must be 0");
+}
+
+/// A failing command surfaces the non-zero exit code as a recoverable result.
+///
+/// Why: The LLM loop must read pytest failures, not abort on them. A non-zero
+/// exit must come back as `ToolResult::ok` with the code embedded in the
+/// output so the model can read and react.
+/// What: Runs `false`; asserts result is not an error variant and content
+/// contains "exit_code: 1".
+/// Test: This test.
+#[tokio::test]
+async fn nonzero_exit_is_recoverable() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "false"})).await;
+    assert!(
+        !result.is_error(),
+        "non-zero exit must be recoverable ToolResult::ok, not ToolResult::Error"
+    );
+    assert!(
+        result.content().contains("exit_code: 1"),
+        "exit code 1 must appear in content, got: {}",
+        result.content()
+    );
+}
+
+/// A custom non-zero exit code is captured correctly.
+///
+/// Why: Validates that arbitrary exit codes propagate correctly.
+/// What: Runs `sh -c 'exit 42'`; asserts content contains "exit_code: 42".
+/// Test: This test.
+#[tokio::test]
+async fn custom_exit_code_is_captured() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "sh -c 'exit 42'"})).await;
+    assert!(!result.is_error());
+    assert!(
+        result.content().contains("exit_code: 42"),
+        "exit_code 42 must appear, got: {}",
+        result.content()
+    );
+}
+
+/// A sleeping command with a sub-second timeout is killed promptly.
+///
+/// Why: Without kill logic, a leaked child blocks the test suite.
+/// What: Runs `sleep 30` with a 1-second timeout; asserts the call returns
+/// well under the sleep duration and the result is an error (timeout).
+/// Test: This test.
+#[cfg(unix)]
+#[tokio::test]
+async fn timeout_kills_child() {
+    let tool = BashTool::new(None, Duration::from_secs(120));
+    let start = Instant::now();
+    let result = tool
+        .execute(json!({"command": "sleep 30", "timeout_secs": 1}))
+        .await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_error(),
+        "timed-out command must return an error variant"
+    );
+    assert!(
+        result.content().contains("timed out"),
+        "error must mention timeout, got: {}",
+        result.content()
+    );
+    // Should return well within the 30-second sleep duration.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "timeout must fire in under 10 s, took {}ms",
+        elapsed.as_millis()
+    );
+}
+
+/// The working directory is honored for spawned commands.
+///
+/// Why: The coder loop needs `pwd` to reflect the project root, not the
+/// tcode binary's current directory.
+/// What: Creates a tempdir, sets it as `working_dir`, runs `pwd`, asserts
+/// the output matches.
+/// Test: This test.
+#[tokio::test]
+async fn cwd_is_honored() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = tmp.path().canonicalize().expect("canonicalize");
+    let tool = BashTool::new(Some(canonical.clone()), Duration::from_secs(10));
+    let result = tool.execute(json!({"command": "pwd"})).await;
+    assert!(
+        !result.is_error(),
+        "pwd should succeed: {}",
+        result.content()
+    );
+    let content = result.content();
+    assert!(
+        content.contains(canonical.to_string_lossy().as_ref()),
+        "pwd output must contain the tempdir path, got: {content}"
+    );
+}
+
+/// stdout output exceeding MAX_OUTPUT_BYTES is truncated with a notice.
+///
+/// Why: Unbounded output would exhaust memory and produce an unusably large
+/// LLM context window entry.
+/// What: Generates > 100 KB of stdout; asserts the content contains the
+/// truncation notice.
+/// Test: This test.
+#[tokio::test]
+async fn stdout_truncation() {
+    let tool = BashTool::new(None, Duration::from_secs(30));
+    // Generate ~110 KB of output (each `yes` line is 2 bytes "y\n").
+    // head -c limits to a byte count so we stay deterministic.
+    let result = tool
+        .execute(json!({"command": "yes | head -c 110000"}))
+        .await;
+    assert!(
+        !result.is_error(),
+        "yes|head should succeed: {}",
+        result.content()
+    );
+    let content = result.content();
+    assert!(
+        content.contains("truncated"),
+        "output must include truncation notice, got length={}",
+        content.len()
+    );
+}
+
+/// Missing `command` argument returns a structured error.
+///
+/// Why: Guard against malformed LLM function calls.
+/// What: `execute({})` without `command`; expects error.
+/// Test: This test.
+#[tokio::test]
+async fn missing_command_returns_error() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({})).await;
+    assert!(result.is_error());
+    assert!(
+        result.content().contains("missing required 'command'"),
+        "got: {}",
+        result.content()
+    );
+}
+
+/// Empty `command` string is rejected with a structured error.
+///
+/// Why: An empty command would spawn `sh -c ''` which silently succeeds but
+/// does nothing useful; better to surface an error.
+/// What: `execute({"command": "   "})` returns error.
+/// Test: This test.
+#[tokio::test]
+async fn empty_command_returns_error() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "   "})).await;
+    assert!(result.is_error());
+    assert!(
+        result.content().contains("must not be empty"),
+        "got: {}",
+        result.content()
+    );
+}
+
+/// The bash tool registers in a `ToolRegistry` and is callable via `dispatch`.
+///
+/// Why: End-to-end guard that the registry plumbing works and the schema
+/// roundtrip is correct.
+/// What: Registers `BashTool`; asserts `contains("bash")` and `schemas()`
+/// returns one entry; dispatches `echo ok` and checks output.
+/// Test: This test.
+#[tokio::test]
+async fn registry_registration_and_dispatch() {
+    let mut reg = ToolRegistry::new();
+    reg.register(Arc::new(BashTool::default_config()));
+
+    assert!(reg.contains("bash"), "registry must know about 'bash'");
+    assert_eq!(reg.schemas().len(), 1, "exactly one schema");
+
+    let schema_val = reg.schemas().into_iter().next().expect("schema");
+    let fn_name = schema_val
+        .pointer("/function/name")
+        .and_then(Value::as_str)
+        .expect("function.name");
+    assert_eq!(fn_name, "bash");
+
+    let result = reg
+        .dispatch("bash", json!({"command": "echo registry-ok"}))
+        .await;
+    assert!(
+        !result.is_error(),
+        "dispatch must succeed: {}",
+        result.content()
+    );
+    assert!(result.content().contains("registry-ok"));
+}
+
+/// `restricted_tiers` includes `ReadOnly` and `Analytics`.
+///
+/// Why: The RBAC check at `dispatch_for_user` reads `restricted_tiers()`; we
+/// must guarantee the bash tool is never accessible to low-trust callers.
+/// What: Constructs `BashTool` and checks the returned slice.
+/// Test: This test.
+#[test]
+fn restricted_tiers_includes_readonly_and_analytics() {
+    use crate::tools::traits::ServiceTier;
+    let tool = BashTool::default_config();
+    let tiers = tool.restricted_tiers();
+    assert!(
+        tiers.contains(&ServiceTier::ReadOnly),
+        "ReadOnly must be restricted"
+    );
+    assert!(
+        tiers.contains(&ServiceTier::Analytics),
+        "Analytics must be restricted"
+    );
+}

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -10,11 +10,14 @@
 //! Test: Unit tests live in each submodule; integration tests use
 //! `DelegateToAgentTool` with a `MockAgentRunner`.
 
+pub mod bash;
 pub mod delegate;
 pub mod registry;
 pub mod traits;
 
 // Flat re-exports for `crate::tools::*` convenience.
+#[allow(unused_imports)]
+pub use bash::BashTool;
 #[allow(unused_imports)]
 pub use delegate::DelegateToAgentTool;
 pub use registry::ToolRegistry;


### PR DESCRIPTION
## Summary

- Implements `BashTool` — a native `ToolExecutor` in `crates/trusty-code/src/tools/bash/` that lets the coder agent loop run commands (pytest, cargo test, etc.) and read their output to iterate
- Non-zero exit codes are surfaced as recoverable `ToolResult::ok` values (not errors) so failing test output reaches the model instead of aborting the loop
- Configurable per-call timeout with process-group kill on Unix (setsid + SIGKILL) plus `tokio::process::Child::kill()` fallback; child is always reaped
- stdout + stderr each captured and truncated at 100 KB with a notice when truncated
- `RESTRICTED` service tier blocks `ReadOnly` and `Analytics` callers
- OpenAI-function JSON schema: `command` (required) + `timeout_secs` (optional, default 120)
- Split into `bash/mod.rs` (315 lines) + `bash/tests.rs` (250 lines) to satisfy the 500-line file-size cap

## Implementation details

**Timeout/kill approach:** `setsid()` via `pre_exec` puts the child shell in a new process group. On timeout: `libc::kill(-pgid, SIGKILL)` kills the entire group (children of the shell are also reaped), then `child.kill().await` + `child.wait().await` as belt-and-suspenders. This prevents zombie processes and leaked `sleep` / test-runner children.

**Exit-code-as-recoverable-result:** `ToolResult::ok(…)` carries the exit code as `exit_code: N` text. The LLM loop reads it and can retry or react — `ToolResult::Error` is only returned for timeout, spawn failure, or IO error.

## Test plan

- [x] `fast_command_exit_zero` — `echo hello` returns stdout and exit 0
- [x] `nonzero_exit_is_recoverable` — `false` returns exit_code: 1 as ToolResult::ok
- [x] `custom_exit_code_is_captured` — `exit 42` appears in content
- [x] `timeout_kills_child` (`#[cfg(unix)]`) — `sleep 30` with 1s timeout returns in < 10s
- [x] `cwd_is_honored` — `pwd` in a tempdir returns that tempdir's path
- [x] `stdout_truncation` — `yes | head -c 110000` truncation notice in output
- [x] `missing_command_returns_error` / `empty_command_returns_error` — arg guards
- [x] `registry_registration_and_dispatch` — schema round-trip + dispatch
- [x] `restricted_tiers_includes_readonly_and_analytics` — RBAC tier

All 191 crate tests pass. `cargo clippy -- -D warnings`, `cargo fmt --check`, `bash scripts/check_line_cap.sh` all clean.

Closes #1026. Milestone: trusty-code: article-ready model-comparison harness (#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)