### PR TITLE
feat(trusty-code): OpenRouter client + bash tool (#1020, #1026)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10786,6 +10786,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "libc",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -45,8 +45,14 @@ async-trait = { workspace = true }
 # Phase 3: TOML config parsing for AgentConfig
 toml = { workspace = true }
 
-# Structured error types for library code (FsError, etc.)
+# Structured error types for library code (FsError, LlmError, etc.)
 thiserror = { workspace = true }
+
+# LLM client: HTTP + TLS for the OpenRouter chat-completions API
+reqwest = { workspace = true }
+
+# Bash tool: process-group kill on Unix (setsid / kill syscalls)
+libc = { workspace = true }
 
 [dev-dependencies]
 # Async test runtime (events, build_info, perf async tests, tools tests)

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -130,6 +130,19 @@ pub mod rbac;
 
 // ── Phase 3 agents + LLM layer (per #642) ──
 
+/// Native OpenRouter LLM client.
+///
+/// Why: trusty-code agents need to invoke LLMs via the OpenRouter API without
+/// depending on third-party Rust SDK crates that pin us to specific provider
+/// contracts. A thin native client gives full control over the wire format,
+/// headers, and error handling.
+/// What: Exports `LlmClient`, `LlmClientConfig`, all request/response types
+/// (`ChatRequest`, `ChatResponse`, `ChatMessage`, `ToolDefinition`, …), and
+/// `LlmError`. The API key is injected at construction time.
+/// Test: `cargo test -p trusty-code` covers serialisation, deserialisation,
+/// and error-mapping unit tests. `--include-ignored` adds the live HTTP test.
+pub mod llm;
+
 /// Agent configuration loading.
 ///
 /// Why: Sub-agents are defined declaratively in TOML files under

--- a/crates/trusty-code/src/llm/client.rs
+++ b/crates/trusty-code/src/llm/client.rs
@@ -1,0 +1,320 @@
+//! HTTP client for the OpenRouter `/v1/chat/completions` endpoint.
+//!
+//! Why: trusty-code needs a native LLM client that speaks the OpenAI
+//! chat-completions schema and works with any OpenRouter-hosted model slug —
+//! without pulling in the `async-openai` crate (which adds dependency weight
+//! and couples us to Anthropic's published API directly).
+//! What: `LlmClient` wraps a `reqwest::Client`, holds the API key and optional
+//! HTTP-Referer header, and exposes a single `chat` method that posts a
+//! `ChatRequest` and returns a `ChatResponse`.  API-key injection happens at
+//! construction time so library code never reads from `std::env` itself.
+//! Test: Unit tests in `llm::types::tests` cover serialisation / deserialisation.
+//! The ignore-gated integration test `live_openrouter_call` in this file sends a
+//! real request (requires `OPENROUTER_API_KEY` in env).
+
+use reqwest::Client;
+
+use super::{error::LlmError, request::ChatRequest, response::ChatResponse};
+
+/// Base URL for OpenRouter's chat-completions endpoint.
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
+
+/// Configuration for `LlmClient`.
+///
+/// Why: Separating config from the client struct makes it easy to construct the
+/// client from different sources (env, TOML config, tests) without duplicating
+/// the validation logic.
+/// What: Carries the API key (mandatory), an optional HTTP-Referer, and an
+/// optional X-Title header forwarded to OpenRouter for analytics.
+/// Test: `LlmClientConfig::from_env` unit-tested in `client_config_from_env`.
+#[derive(Debug, Clone)]
+pub struct LlmClientConfig {
+    /// OpenRouter API key (Bearer token).
+    pub api_key: String,
+
+    /// Optional HTTP-Referer sent to OpenRouter for request attribution.
+    pub http_referer: Option<String>,
+
+    /// Optional X-Title header sent to OpenRouter (appears in dashboards).
+    pub x_title: Option<String>,
+}
+
+impl LlmClientConfig {
+    /// Construct from an explicit API key string.
+    ///
+    /// Why: Tests and callers that already hold the key don't need an env read.
+    /// What: Validates that `api_key` is non-empty; returns `MissingConfig` if
+    /// it is.
+    /// Test: `client_config_direct_construction`.
+    pub fn new(api_key: impl Into<String>) -> Result<Self, LlmError> {
+        let api_key = api_key.into();
+        if api_key.is_empty() {
+            return Err(LlmError::MissingConfig("api_key must not be empty".into()));
+        }
+        Ok(Self {
+            api_key,
+            http_referer: None,
+            x_title: None,
+        })
+    }
+
+    /// Read the API key from the `OPENROUTER_API_KEY` environment variable.
+    ///
+    /// Why: Binary entry points call this once at startup; library helpers
+    /// never read env variables directly (convention from CLAUDE.md).
+    /// What: Reads `OPENROUTER_API_KEY`; returns `MissingConfig` if unset or
+    /// empty.
+    /// Test: `client_config_from_env_missing` (key absent → error).
+    pub fn from_env() -> Result<Self, LlmError> {
+        let key = std::env::var("OPENROUTER_API_KEY").unwrap_or_default();
+        Self::new(key)
+    }
+
+    /// Set the optional HTTP-Referer attribution header.
+    ///
+    /// Why: OpenRouter uses this for per-project analytics in their dashboard.
+    /// What: Builder-style setter; returns `self` for chaining.
+    /// Test: `client_config_builder`.
+    pub fn with_referer(mut self, referer: impl Into<String>) -> Self {
+        self.http_referer = Some(referer.into());
+        self
+    }
+
+    /// Set the optional X-Title attribution header.
+    ///
+    /// Why: Appears in OpenRouter's request logs as a human-readable label.
+    /// What: Builder-style setter; returns `self` for chaining.
+    /// Test: `client_config_builder`.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.x_title = Some(title.into());
+        self
+    }
+}
+
+/// Async HTTP client for the OpenRouter chat-completions API.
+///
+/// Why: Centralises all HTTP mechanics (header injection, error handling,
+/// response parsing) so call sites only deal with `ChatRequest` / `ChatResponse`.
+/// What: Wraps a `reqwest::Client` and `LlmClientConfig`; exposes `chat` as the
+/// sole public method.  The client is cheaply cloneable (`reqwest::Client` uses
+/// an `Arc` internally).
+/// Test: Serialisation/deserialisation unit tests live in `llm::types::tests`.
+/// The `#[ignore]`-gated `live_openrouter_call` test below validates the full
+/// HTTP round-trip.
+#[derive(Debug, Clone)]
+pub struct LlmClient {
+    http: Client,
+    config: LlmClientConfig,
+}
+
+impl LlmClient {
+    /// Construct an `LlmClient` from an explicit config.
+    ///
+    /// Why: Allows dependency injection in tests and in callers that manage
+    /// their own key source.
+    /// What: Builds a `reqwest::Client` with rustls TLS; returns an error if
+    /// the HTTP client cannot be constructed (extremely rare).
+    /// Test: `lm_client_from_config`.
+    pub fn from_config(config: LlmClientConfig) -> Result<Self, LlmError> {
+        let http = Client::builder()
+            .use_rustls_tls()
+            .build()
+            .map_err(LlmError::Transport)?;
+        Ok(Self { http, config })
+    }
+
+    /// Construct from the `OPENROUTER_API_KEY` environment variable.
+    ///
+    /// Why: Convenience entry point for binary code that reads config from env.
+    /// What: Delegates to `LlmClientConfig::from_env`, then `from_config`.
+    /// Test: Integration test `live_openrouter_call` uses this path.
+    pub fn from_env() -> Result<Self, LlmError> {
+        Self::from_config(LlmClientConfig::from_env()?)
+    }
+
+    /// POST a `ChatRequest` to OpenRouter and return the parsed `ChatResponse`.
+    ///
+    /// Why: Single-method surface keeps call sites simple and makes mocking
+    /// (for future test doubles) easy.
+    /// What: Serialises `req` to JSON, adds required OpenRouter headers
+    /// (`Authorization`, optional `HTTP-Referer`, optional `X-Title`), sends
+    /// the POST, and deserialises the response body.  Non-2xx responses are
+    /// mapped to `LlmError::ApiError` with the raw body included.
+    /// Test: `live_openrouter_call` (#[ignore]) validates the happy path.
+    /// Unit tests in `types.rs` cover the serialisation/deserialisation paths.
+    pub async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let mut builder = self
+            .http
+            .post(OPENROUTER_BASE_URL)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json");
+
+        if let Some(referer) = &self.config.http_referer {
+            builder = builder.header("HTTP-Referer", referer.as_str());
+        }
+        if let Some(title) = &self.config.x_title {
+            builder = builder.header("X-Title", title.as_str());
+        }
+
+        let resp = builder.json(req).send().await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(LlmError::ApiError {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        // Read the full body first so we can include it in deserialisation errors.
+        let body = resp.text().await?;
+        serde_json::from_str::<ChatResponse>(&body)
+            .map_err(|source| LlmError::Deserialise { source, body })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::{ChatMessage, ChatRequest};
+
+    /// `LlmClientConfig::new` rejects an empty API key.
+    ///
+    /// Why: An empty key would produce a confusing 401 from the API; we want
+    /// to fail at construction time with a clear error.
+    /// What: Pass an empty string, assert `MissingConfig` error.
+    /// Test: this test.
+    #[test]
+    fn client_config_rejects_empty_key() {
+        let err = LlmClientConfig::new("").unwrap_err();
+        assert!(
+            matches!(err, LlmError::MissingConfig(_)),
+            "expected MissingConfig, got: {err:?}"
+        );
+    }
+
+    /// `LlmClientConfig::new` accepts a non-empty key.
+    ///
+    /// Why: Baseline happy-path for construction.
+    /// What: Pass a fake key, assert `Ok`.
+    /// Test: this test.
+    #[test]
+    fn client_config_direct_construction() {
+        let cfg = LlmClientConfig::new("sk-or-test-key").expect("should succeed");
+        assert_eq!(cfg.api_key, "sk-or-test-key");
+        assert!(cfg.http_referer.is_none());
+        assert!(cfg.x_title.is_none());
+    }
+
+    /// Builder methods chain correctly.
+    ///
+    /// Why: Verify the builder pattern sets optional fields.
+    /// What: Chain `with_referer` and `with_title`, assert both are set.
+    /// Test: this test.
+    #[test]
+    fn client_config_builder() {
+        let cfg = LlmClientConfig::new("sk-or-x")
+            .unwrap()
+            .with_referer("https://example.com")
+            .with_title("trusty-code");
+        assert_eq!(cfg.http_referer.as_deref(), Some("https://example.com"));
+        assert_eq!(cfg.x_title.as_deref(), Some("trusty-code"));
+    }
+
+    /// `LlmClientConfig::from_env` returns `MissingConfig` when the env var is absent.
+    ///
+    /// Why: Prevent silent failures when the key is not configured.
+    /// What: Remove the env var, call `from_env`, assert error.
+    /// Test: this test.
+    #[test]
+    fn client_config_from_env_missing() {
+        // Temporarily unset the key (may already be absent in CI).
+        let prev = std::env::var("OPENROUTER_API_KEY").ok();
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
+        let result = LlmClientConfig::from_env();
+        // Restore before asserting (so other tests are not affected even if this
+        // assertion panics).
+        if let Some(k) = prev {
+            unsafe { std::env::set_var("OPENROUTER_API_KEY", k) };
+        }
+        assert!(
+            result.is_err(),
+            "expected Err when OPENROUTER_API_KEY is unset"
+        );
+    }
+
+    /// `LlmClient::from_config` succeeds with a valid config.
+    ///
+    /// Why: Verifies the reqwest client builds without error.
+    /// What: Construct with a fake key, assert `Ok`.
+    /// Test: this test.
+    #[test]
+    fn lm_client_from_config() {
+        let cfg = LlmClientConfig::new("sk-or-test").unwrap();
+        let client = LlmClient::from_config(cfg);
+        assert!(client.is_ok(), "expected Ok, got: {client:?}");
+    }
+
+    /// Live integration test: send a trivial prompt to a cheap OpenRouter model.
+    ///
+    /// Why: End-to-end validation that `LlmClient::chat` produces a non-empty
+    /// assistant response and non-zero `TokenUsage`.
+    /// What: Read `OPENROUTER_API_KEY` from env; skip (not fail) if absent.
+    /// POST a single-turn prompt to `openai/gpt-4o-mini`; assert non-empty
+    /// `first_text()` and `usage.prompt_tokens > 0`.
+    /// Test: Run with `cargo test -p trusty-code -- --include-ignored`.
+    #[tokio::test]
+    #[ignore = "requires OPENROUTER_API_KEY; skipped in CI"]
+    async fn live_openrouter_call() {
+        // Skip gracefully when the key is not present (e.g. in a dev env that
+        // hasn't set it up yet) so the test doesn't block others.
+        let Ok(key) = std::env::var("OPENROUTER_API_KEY") else {
+            eprintln!("OPENROUTER_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.is_empty() {
+            eprintln!("OPENROUTER_API_KEY is empty — skipping live test");
+            return;
+        }
+
+        let config = LlmClientConfig::new(key)
+            .unwrap()
+            .with_referer("https://github.com/bobmatnyc/trusty-tools")
+            .with_title("trusty-code-integration-test");
+
+        let client = LlmClient::from_config(config).expect("build client");
+
+        let req = ChatRequest {
+            model: "openai/gpt-4o-mini".into(),
+            messages: vec![
+                ChatMessage::system("You are a concise assistant."),
+                ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+            temperature: Some(0.0),
+            max_tokens: Some(16),
+            tools: None,
+            tool_choice: None,
+        };
+
+        let resp = client.chat(&req).await.expect("chat call succeeded");
+
+        // Assert assistant text is non-empty.
+        let text = resp.first_text().expect("assistant produced text");
+        assert!(!text.is_empty(), "assistant text was empty");
+
+        // Assert usage is non-zero.
+        let usage = resp.token_usage();
+        assert!(usage.prompt_tokens > 0, "prompt_tokens should be > 0");
+        assert!(
+            usage.completion_tokens > 0,
+            "completion_tokens should be > 0"
+        );
+
+        eprintln!("live test passed — text: {text:?}, usage: {usage:?}");
+    }
+}

--- a/crates/trusty-code/src/llm/error.rs
+++ b/crates/trusty-code/src/llm/error.rs
@@ -1,0 +1,115 @@
+//! Error types for the LLM client.
+//!
+//! Why: Structured errors let callers pattern-match on failure modes (network
+//! error vs. API-level error vs. deserialisation failure) without parsing
+//! strings.
+//! What: `LlmError` covers the four failure categories the client can produce;
+//! it implements `std::error::Error` via `thiserror`.
+//! Test: `error::tests::*` — error display strings, `From` conversions.
+
+use thiserror::Error;
+
+/// Error type returned by `LlmClient` operations.
+///
+/// Why: Library code must expose structured errors rather than `anyhow::Error`
+/// so consumers can programmatically handle recoverable failures (e.g.
+/// rate-limit → retry, invalid API key → fast-fail).
+/// What: Covers network transport errors, non-200 HTTP responses with an
+/// optional API-level error body, and response deserialisation failures.
+/// Test: `llm_error_display`.
+#[derive(Debug, Error)]
+pub enum LlmError {
+    /// The HTTP transport layer failed (connection refused, TLS error, timeout).
+    ///
+    /// Why: Distinct from API errors so callers can apply retry logic to
+    /// transient network failures without retrying on e.g. invalid-key errors.
+    #[error("HTTP transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+
+    /// The API returned a non-2xx status code.
+    ///
+    /// Why: Callers need both the status code and the raw body to decide
+    /// whether to retry (e.g. 429 Too Many Requests) or give up (e.g. 401
+    /// Unauthorized).
+    #[error("API error {status}: {body}")]
+    ApiError {
+        /// HTTP status code.
+        status: u16,
+        /// Raw response body (may be JSON or plain text).
+        body: String,
+    },
+
+    /// The response body could not be deserialised into `ChatResponse`.
+    ///
+    /// Why: Separates schema-mismatch problems (usually provider bugs or
+    /// version drift) from transport and API-level issues.
+    #[error("response deserialisation failed: {source}\nbody: {body}")]
+    Deserialise {
+        /// The underlying serde error.
+        source: serde_json::Error,
+        /// The raw body that failed to parse (aids debugging).
+        body: String,
+    },
+
+    /// A required configuration value is missing.
+    ///
+    /// Why: Failing at construction time with a clear message is better than
+    /// receiving a cryptic 401 from the API.
+    #[error("missing configuration: {0}")]
+    MissingConfig(String),
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `LlmError::ApiError` formats the status code and body in the display string.
+    ///
+    /// Why: Consumers and logs rely on the `Display` impl; verify it contains
+    /// the key fields.
+    /// What: Construct an `ApiError`, call `to_string()`, assert substrings.
+    /// Test: this test.
+    #[test]
+    fn api_error_display_includes_status_and_body() {
+        let err = LlmError::ApiError {
+            status: 429,
+            body: "rate limited".into(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("429"), "status missing from: {s}");
+        assert!(s.contains("rate limited"), "body missing from: {s}");
+    }
+
+    /// `LlmError::MissingConfig` carries the field name in its display.
+    ///
+    /// Why: Operator experience — the error should tell them exactly which
+    /// configuration field to set.
+    /// What: Construct a `MissingConfig`, assert the key name appears.
+    /// Test: this test.
+    #[test]
+    fn missing_config_display_includes_field_name() {
+        let err = LlmError::MissingConfig("OPENROUTER_API_KEY".into());
+        let s = err.to_string();
+        assert!(s.contains("OPENROUTER_API_KEY"), "field name missing: {s}");
+    }
+
+    /// `LlmError::Deserialise` includes both the error and the body.
+    ///
+    /// Why: Debugging a deserialisation failure requires seeing the raw JSON
+    /// body; confirm it appears in the display.
+    /// What: Construct a deserialise error from a real `serde_json` error.
+    /// Test: this test.
+    #[test]
+    fn deserialise_error_includes_body() {
+        let raw = "{invalid json}";
+        let serde_err = serde_json::from_str::<serde_json::Value>(raw).unwrap_err();
+        let err = LlmError::Deserialise {
+            source: serde_err,
+            body: raw.into(),
+        };
+        let s = err.to_string();
+        assert!(s.contains(raw), "raw body missing: {s}");
+    }
+}

--- a/crates/trusty-code/src/llm/message.rs
+++ b/crates/trusty-code/src/llm/message.rs
@@ -1,0 +1,172 @@
+//! `ChatMessage` wire type and role constructors.
+//!
+//! Why: The conversation-message type is used by both requests (history) and
+//! tool-result injection; isolating it here keeps the request and response
+//! modules free of message construction boilerplate.
+//! What: Defines `ChatMessage` with `role`, `content`, `tool_calls`,
+//! `tool_call_id`, and `name` fields, plus convenience constructors for each
+//! standard role.
+//! Test: `chat_message_constructors`, `chat_message_tool_role_round_trip`,
+//! `chat_message_serialises_all_roles`.
+
+use serde::{Deserialize, Serialize};
+
+use super::request::ToolCall;
+
+/// A single message in the chat conversation.
+///
+/// Why: OpenRouter's `/chat/completions` endpoint uses the standard OpenAI
+/// message schema; `role` distinguishes speaker identity and `content` carries
+/// the text payload (or `null` for tool-call-only turns).
+/// What: `role` is one of `"system"`, `"user"`, `"assistant"`, `"tool"`;
+/// `content` is the text or `None` for assistant turns that only emit tool
+/// calls; `tool_calls` carries the outbound calls for assistant turns;
+/// `tool_call_id` and `name` are populated for `tool` role messages.
+/// Test: `chat_message_serialises_all_roles`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatMessage {
+    /// Conversation role: `"system"`, `"user"`, `"assistant"`, or `"tool"`.
+    pub role: String,
+
+    /// Text content; `None` on assistant turns that only emit tool calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+
+    /// Tool calls emitted by the assistant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+
+    /// For `tool` role messages: the ID of the tool call this message responds to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+
+    /// For `tool` role messages: the name of the function that was called.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl ChatMessage {
+    /// Construct a `system` message.
+    ///
+    /// Why: Convenience constructor; avoids repeated `role.to_string()` boilerplate.
+    /// What: Returns a `ChatMessage` with `role = "system"` and the provided content.
+    /// Test: `chat_message_constructors`.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: "system".into(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// Construct a `user` message.
+    ///
+    /// Why: Convenience constructor for the most common message type.
+    /// What: Returns a `ChatMessage` with `role = "user"` and the provided content.
+    /// Test: `chat_message_constructors`.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".into(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// Construct an `assistant` message with text content.
+    ///
+    /// Why: Convenience constructor for building conversation history from prior
+    /// assistant responses.
+    /// What: Returns a `ChatMessage` with `role = "assistant"` and the provided content.
+    /// Test: `chat_message_constructors`.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".into(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// Construct a `tool` result message.
+    ///
+    /// Why: After executing a tool call, the result must be fed back in a `tool`
+    /// role message referencing the original `tool_call_id`.
+    /// What: Returns a `ChatMessage` with `role = "tool"`, the call ID, function
+    /// name, and result content.
+    /// Test: `chat_message_tool_role_round_trip`.
+    pub fn tool_result(
+        tool_call_id: impl Into<String>,
+        name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        Self {
+            role: "tool".into(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            name: Some(name.into()),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Convenience constructors produce the right `role` strings.
+    ///
+    /// Why: Verify each static constructor sets the role correctly.
+    /// What: Assert roles for `system`, `user`, `assistant`.
+    /// Test: this test.
+    #[test]
+    fn chat_message_constructors() {
+        assert_eq!(ChatMessage::system("s").role, "system");
+        assert_eq!(ChatMessage::user("u").role, "user");
+        assert_eq!(ChatMessage::assistant("a").role, "assistant");
+    }
+
+    /// `tool_result` constructor sets `tool_call_id` and `name`.
+    ///
+    /// Why: Tool result messages have extra required fields; the constructor must
+    /// populate them correctly.
+    /// What: Assert `tool_call_id` and `name` are `Some`.
+    /// Test: this test.
+    #[test]
+    fn chat_message_tool_role_round_trip() {
+        let msg = ChatMessage::tool_result("call_abc", "get_weather", r#"{"temp":72}"#);
+        assert_eq!(msg.role, "tool");
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_abc"));
+        assert_eq!(msg.name.as_deref(), Some("get_weather"));
+        assert_eq!(msg.content.as_deref(), Some(r#"{"temp":72}"#));
+    }
+
+    /// All role constructors serialise the `role` field correctly.
+    ///
+    /// Why: JSON consumers depend on the `role` string value; a typo in any
+    /// constructor would silently break the API.
+    /// What: Serialise each message variant, assert the `role` JSON field value.
+    /// Test: this test.
+    #[test]
+    fn chat_message_serialises_all_roles() {
+        for (msg, expected_role) in [
+            (ChatMessage::system("sys"), "system"),
+            (ChatMessage::user("usr"), "user"),
+            (ChatMessage::assistant("ast"), "assistant"),
+            (ChatMessage::tool_result("id", "fn", "result"), "tool"),
+        ] {
+            let v: serde_json::Value = serde_json::to_value(&msg).expect("serialise");
+            assert_eq!(
+                v["role"].as_str(),
+                Some(expected_role),
+                "role mismatch for expected={expected_role}"
+            );
+        }
+    }
+}

--- a/crates/trusty-code/src/llm/mod.rs
+++ b/crates/trusty-code/src/llm/mod.rs
@@ -1,0 +1,30 @@
+//! Native OpenRouter chat-completions client for trusty-code.
+//!
+//! Why: trusty-code agents need to invoke LLMs via the OpenRouter API without
+//! depending on third-party Rust SDK crates (`async-openai`, etc.) that pin us
+//! to specific provider contracts.  A thin native client gives us full control
+//! over the wire format, headers, and error handling.
+//! What: This module exports `LlmClient`, `LlmClientConfig`, all request/response
+//! types (`ChatRequest`, `ChatResponse`, `ChatMessage`, `ToolDefinition`, …),
+//! and `LlmError`.  The API key is injected at construction time via
+//! `LlmClientConfig::new` or `LlmClientConfig::from_env`; library helpers never
+//! read `std::env` directly.
+//! Test: `cargo test -p trusty-code` covers all unit tests (serialisation,
+//! deserialisation, error mapping).  `cargo test -p trusty-code --
+//! --include-ignored` additionally runs the live `live_openrouter_call` test.
+
+mod client;
+mod error;
+mod message;
+mod request;
+mod response;
+mod usage;
+
+// ── Public API re-exports ─────────────────────────────────────────────────────
+
+pub use client::{LlmClient, LlmClientConfig};
+pub use error::LlmError;
+pub use message::ChatMessage;
+pub use request::{ChatRequest, FunctionCall, FunctionDefinition, ToolCall, ToolDefinition};
+pub use response::{AssistantMessage, ChatChoice, ChatResponse};
+pub use usage::UsageBlock;

--- a/crates/trusty-code/src/llm/request.rs
+++ b/crates/trusty-code/src/llm/request.rs
@@ -1,0 +1,252 @@
+//! Request-side wire types for the OpenRouter / OpenAI chat-completions API.
+//!
+//! Why: Keeping tool definitions, tool-call types, and the request body in one
+//! module lets the serialisation surface evolve without touching response or
+//! message logic.
+//! What: Defines `ToolCall`, `FunctionCall`, `ToolDefinition`,
+//! `FunctionDefinition`, and `ChatRequest` — everything needed to construct
+//! and serialise a `POST /v1/chat/completions` payload.
+//! Test: `chat_request_serialises_required_fields`,
+//! `chat_request_with_tools_serialises`, `tool_definition_serialises`,
+//! `function_definition_round_trip`.
+
+use serde::{Deserialize, Serialize};
+
+use super::message::ChatMessage;
+
+// ── Tool-calling types ─────────────────────────────────────────────────────────
+
+/// A tool call emitted by the model.
+///
+/// Why: The model may decide to invoke one or more functions before producing a
+/// final text response; callers must handle these before the conversation can
+/// continue.
+/// What: `id` is the opaque call identifier used when submitting the result
+/// back; `r#type` is always `"function"`; `function` carries the name and
+/// JSON-encoded arguments.
+/// Test: `tool_call_deserialises_from_fixture` (in `response.rs` tests).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCall {
+    /// Unique call identifier; echoed in the subsequent `tool` result message.
+    pub id: String,
+
+    /// Always `"function"` for the current OpenAI schema.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// The function being called.
+    pub function: FunctionCall,
+}
+
+/// The function name and arguments within a tool call.
+///
+/// Why: Separating this from `ToolCall` keeps the struct layout consistent with
+/// the wire format (OpenAI wraps function details in a nested object).
+/// What: `name` is the registered function name; `arguments` is a JSON string
+/// (not a parsed value) exactly as emitted by the model.
+/// Test: `tool_call_deserialises_from_fixture` (in `response.rs` tests).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FunctionCall {
+    /// Registered function name.
+    pub name: String,
+
+    /// JSON-encoded argument object; parse with `serde_json::from_str` at the
+    /// call site.
+    pub arguments: String,
+}
+
+/// A tool definition submitted with the request.
+///
+/// Why: Providing tool definitions tells the model which functions are available
+/// so it can decide when and how to call them.
+/// What: `r#type` is always `"function"`; `function` carries the JSON Schema
+/// describing the callable function.
+/// Test: `tool_definition_serialises`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolDefinition {
+    /// Always `"function"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// The function schema.
+    pub function: FunctionDefinition,
+}
+
+impl ToolDefinition {
+    /// Construct a function-type tool definition.
+    ///
+    /// Why: All current OpenAI-compatible tools are function tools; this
+    /// constructor bakes in that invariant.
+    /// What: Sets `kind = "function"` and wraps the provided `FunctionDefinition`.
+    /// Test: `tool_definition_serialises`.
+    pub fn function(function: FunctionDefinition) -> Self {
+        Self {
+            kind: "function".into(),
+            function,
+        }
+    }
+}
+
+/// JSON Schema description of a callable function.
+///
+/// Why: The model needs the name, a description, and parameter schema to decide
+/// when and how to call the function correctly.
+/// What: `name` is the call target; `description` guides model selection;
+/// `parameters` is a raw `serde_json::Value` holding the JSON Schema object
+/// for flexibility (different tools may use different schema shapes).
+/// Test: `function_definition_round_trip`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FunctionDefinition {
+    /// The function name as registered with the model.
+    pub name: String,
+
+    /// Human-readable description guiding the model's decision to call it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// JSON Schema object describing the function's parameter shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<serde_json::Value>,
+}
+
+// ── Request type ───────────────────────────────────────────────────────────────
+
+/// The full request body for `POST /v1/chat/completions`.
+///
+/// Why: A dedicated struct keeps the serialisation surface explicit and avoids
+/// ad-hoc `serde_json::json!` construction scattered across call sites.
+/// What: All standard OpenAI chat-completions fields; optional fields use
+/// `skip_serializing_if` so the wire payload stays minimal.
+/// Test: `chat_request_serialises_required_fields`,
+/// `chat_request_with_tools_serialises`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatRequest {
+    /// OpenRouter / OpenAI model slug, e.g. `"anthropic/claude-sonnet-4-5"`.
+    pub model: String,
+
+    /// Conversation history, including the new user turn.
+    pub messages: Vec<ChatMessage>,
+
+    /// Sampling temperature in `[0.0, 2.0]`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+
+    /// Maximum tokens to generate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+
+    /// Tools the model may call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolDefinition>>,
+
+    /// Tool-choice policy: `"none"`, `"auto"`, `"required"`, or a specific
+    /// function selector.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<serde_json::Value>,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal `ChatRequest` serialises required fields only.
+    ///
+    /// Why: Verify that optional fields with `None` values are omitted from the
+    /// JSON payload, keeping requests lean.
+    /// What: Build a minimal request, serialise it, check required fields present
+    /// and optional fields absent.
+    /// Test: this test.
+    #[test]
+    fn chat_request_serialises_required_fields() {
+        let req = ChatRequest {
+            model: "anthropic/claude-haiku-4-5".into(),
+            messages: vec![ChatMessage::user("hello")],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&req).expect("serialise");
+        assert_eq!(v["model"], "anthropic/claude-haiku-4-5");
+        assert_eq!(v["messages"][0]["role"], "user");
+        assert_eq!(v["messages"][0]["content"], "hello");
+        assert!(v.get("temperature").is_none() || v["temperature"].is_null());
+        assert!(v.get("tools").is_none() || v["tools"].is_null());
+    }
+
+    /// `ChatRequest` with tools serialises the `tools` and `tool_choice` fields.
+    ///
+    /// Why: Tool-calling requests must include the tool schema; validate that
+    /// the serialised payload matches the OpenAI wire format.
+    /// What: Build a request with one `ToolDefinition`, serialise, assert schema
+    /// structure.
+    /// Test: this test.
+    #[test]
+    fn chat_request_with_tools_serialises() {
+        let tool = ToolDefinition::function(FunctionDefinition {
+            name: "get_weather".into(),
+            description: Some("Returns weather data".into()),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": { "location": { "type": "string" } },
+                "required": ["location"]
+            })),
+        });
+        let req = ChatRequest {
+            model: "openai/gpt-4o-mini".into(),
+            messages: vec![ChatMessage::user("What's the weather?")],
+            temperature: Some(0.0),
+            max_tokens: Some(256),
+            tools: Some(vec![tool]),
+            tool_choice: Some(serde_json::json!("auto")),
+        };
+        let v: serde_json::Value = serde_json::to_value(&req).expect("serialise");
+        assert_eq!(v["tools"][0]["type"], "function");
+        assert_eq!(v["tools"][0]["function"]["name"], "get_weather");
+        assert_eq!(v["tool_choice"], "auto");
+        assert_eq!(v["temperature"], 0.0_f32);
+        assert_eq!(v["max_tokens"], 256);
+    }
+
+    /// `ToolDefinition::function` sets `kind = "function"`.
+    ///
+    /// Why: The wire format requires `type: "function"`; verify the constructor
+    /// bakes in that invariant.
+    /// What: Build via `ToolDefinition::function`, serialise, assert `type` field.
+    /// Test: this test.
+    #[test]
+    fn tool_definition_serialises() {
+        let tool = ToolDefinition::function(FunctionDefinition {
+            name: "ping".into(),
+            description: None,
+            parameters: None,
+        });
+        let v: serde_json::Value = serde_json::to_value(&tool).expect("serialise");
+        assert_eq!(v["type"], "function");
+        assert_eq!(v["function"]["name"], "ping");
+    }
+
+    /// `FunctionDefinition` round-trips through JSON.
+    ///
+    /// Why: Parameter schemas are `serde_json::Value`; verify the round-trip
+    /// preserves structure.
+    /// What: Build a `FunctionDefinition` with a parameters schema, serialise
+    /// and deserialise, assert fields match.
+    /// Test: this test.
+    #[test]
+    fn function_definition_round_trip() {
+        let params = serde_json::json!({"type": "object", "properties": {}});
+        let def = FunctionDefinition {
+            name: "my_fn".into(),
+            description: Some("does stuff".into()),
+            parameters: Some(params.clone()),
+        };
+        let serialised = serde_json::to_string(&def).expect("serialise");
+        let de: FunctionDefinition = serde_json::from_str(&serialised).expect("deserialise");
+        assert_eq!(de.name, "my_fn");
+        assert_eq!(de.description.as_deref(), Some("does stuff"));
+        assert_eq!(de.parameters.as_ref(), Some(&params));
+    }
+}

--- a/crates/trusty-code/src/llm/response.rs
+++ b/crates/trusty-code/src/llm/response.rs
@@ -1,0 +1,240 @@
+//! Response-side wire types for the OpenRouter / OpenAI chat-completions API.
+//!
+//! Why: Keeping `AssistantMessage`, `ChatChoice`, and `ChatResponse` in their
+//! own module separates the deserialisation surface from request construction
+//! and makes response-handling logic easy to find and test.
+//! What: Defines the response hierarchy returned by `POST /v1/chat/completions`
+//! and helper methods on `ChatResponse` for accessing common fields.
+//! Test: `chat_response_deserialises_fixture`, `tool_call_deserialises_from_fixture`,
+//! `chat_response_first_text_content`, `chat_response_first_tool_calls`,
+//! `chat_response_usage_into_token_usage`.
+
+use serde::Deserialize;
+
+use crate::perf::TokenUsage;
+
+use super::request::ToolCall;
+use super::usage::UsageBlock;
+
+/// The assistant message within a choice.
+///
+/// Why: Mirrors `ChatMessage` but uses explicit struct rather than re-using the
+/// request type to keep request/response paths cleanly separated and avoid
+/// accidental mis-serialisation.
+/// What: `content` is the text (or `None` for tool-only turns); `tool_calls`
+/// carries any function invocations.
+/// Test: `assistant_message_text_and_tool_calls`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssistantMessage {
+    /// Text content; `None` when the turn consists solely of tool calls.
+    pub content: Option<String>,
+
+    /// Tool calls emitted this turn.
+    #[serde(default)]
+    pub tool_calls: Vec<ToolCall>,
+}
+
+/// One choice in the model response.
+///
+/// Why: The API returns a `choices` array (allowing `n > 1`); we always request
+/// a single choice but the struct must match the wire schema.
+/// What: `message` holds the assistant turn (text and/or tool calls);
+/// `finish_reason` carries the stop condition.
+/// Test: `chat_response_deserialises_fixture`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatChoice {
+    /// The assistant message produced for this choice.
+    pub message: AssistantMessage,
+
+    /// Why the model stopped: `"stop"`, `"tool_calls"`, `"length"`, `"content_filter"`.
+    pub finish_reason: Option<String>,
+}
+
+/// The top-level response from `POST /v1/chat/completions`.
+///
+/// Why: Wraps the `choices` array and `usage` block so callers receive a single
+/// typed value from `LlmClient::chat`.
+/// What: `id` is the response ID; `choices` contains the generated turns;
+/// `usage` carries token accounting.
+/// Test: `chat_response_deserialises_fixture`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatResponse {
+    /// Opaque response identifier from the provider.
+    pub id: String,
+
+    /// Generated choices (one per `n`; we always request `n = 1`).
+    pub choices: Vec<ChatChoice>,
+
+    /// Token accounting for this request.
+    #[serde(default)]
+    pub usage: UsageBlock,
+}
+
+impl ChatResponse {
+    /// Extract the first choice's text content, if any.
+    ///
+    /// Why: The vast majority of calls want the assistant's text response; this
+    /// convenience method avoids repetitive indexing at every call site.
+    /// What: Returns `choices[0].message.content.clone()` or `None` when the
+    /// response has no choices or the content is absent.
+    /// Test: `chat_response_first_text_content`.
+    pub fn first_text(&self) -> Option<String> {
+        self.choices.first()?.message.content.clone()
+    }
+
+    /// Extract the first choice's tool calls.
+    ///
+    /// Why: Tool-call workflows need quick access to the emitted calls without
+    /// indexing into nested fields each time.
+    /// What: Returns a reference to `choices[0].message.tool_calls`, or an empty
+    /// slice when there are no choices.
+    /// Test: `chat_response_first_tool_calls`.
+    pub fn first_tool_calls(&self) -> &[ToolCall] {
+        self.choices
+            .first()
+            .map(|c| c.message.tool_calls.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Extract the finish reason from the first choice.
+    ///
+    /// Why: Callers need the stop condition to decide whether to continue the
+    /// tool-call loop or surface the response.
+    /// What: Returns `choices[0].finish_reason.as_deref()` or `None`.
+    /// Test: `chat_response_deserialises_fixture`.
+    pub fn finish_reason(&self) -> Option<&str> {
+        self.choices.first()?.finish_reason.as_deref()
+    }
+
+    /// Convert the response's `usage` block into `TokenUsage`.
+    ///
+    /// Why: `PerfCollector::record_phase` accepts `&TokenUsage`; this method
+    /// keeps the conversion at one place.
+    /// What: Delegates to `UsageBlock::into_token_usage`.
+    /// Test: `chat_response_usage_into_token_usage`.
+    pub fn token_usage(self) -> TokenUsage {
+        self.usage.into_token_usage()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A representative API response fixture deserialises correctly.
+    ///
+    /// Why: Ensures the struct layout matches the real OpenRouter wire format.
+    /// What: Parse a JSON string modelled on an actual response; assert all
+    /// top-level fields are populated.
+    /// Test: this test.
+    #[test]
+    fn chat_response_deserialises_fixture() {
+        let fixture = r#"{
+          "id": "gen-abc123",
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "Hello, world!",
+                "tool_calls": []
+              },
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 4,
+            "total_tokens": 14
+          }
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise fixture");
+        assert_eq!(resp.id, "gen-abc123");
+        assert_eq!(resp.first_text().as_deref(), Some("Hello, world!"));
+        assert_eq!(resp.finish_reason(), Some("stop"));
+        assert!(resp.first_tool_calls().is_empty());
+    }
+
+    /// A response with a tool call deserialises `tool_calls`.
+    ///
+    /// Why: Tool-calling workflow depends on correctly parsing `tool_calls` from
+    /// the response.
+    /// What: Parse a fixture with `tool_calls` populated; assert name and args.
+    /// Test: this test.
+    #[test]
+    fn tool_call_deserialises_from_fixture() {
+        let fixture = r#"{
+          "id": "gen-xyz",
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                  {
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                      "name": "get_weather",
+                      "arguments": "{\"location\":\"Seattle\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 25,
+            "completion_tokens": 15,
+            "total_tokens": 40
+          }
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        assert!(resp.first_text().is_none());
+        let calls = resp.first_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_001");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(resp.finish_reason(), Some("tool_calls"));
+    }
+
+    /// `ChatResponse::token_usage` delegates to `UsageBlock::into_token_usage`.
+    ///
+    /// Why: Callers use `response.token_usage()` rather than digging into
+    /// `response.usage`; this test ensures the method works end-to-end.
+    /// What: Build a full response fixture, call `token_usage()`, assert counts.
+    /// Test: this test.
+    #[test]
+    fn chat_response_usage_into_token_usage() {
+        let fixture = r#"{
+          "id": "gen-zzz",
+          "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 8, "completion_tokens": 3, "total_tokens": 11,
+                    "cache_read_input_tokens": 5, "cache_creation_input_tokens": 2}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let usage = resp.token_usage();
+        assert_eq!(usage.prompt_tokens, 8);
+        assert_eq!(usage.completion_tokens, 3);
+        assert_eq!(usage.cache_read_tokens, 5);
+        assert_eq!(usage.cache_creation_tokens, 2);
+    }
+
+    /// `ChatResponse::first_text` returns `None` for an empty choices list.
+    ///
+    /// Why: Callers must handle missing text gracefully; validate the `None`
+    /// path without panicking.
+    /// What: Deserialise a response with an empty `choices` array, assert
+    /// `first_text()` is `None`.
+    /// Test: this test.
+    #[test]
+    fn chat_response_first_text_content_empty_choices() {
+        let fixture = r#"{"id":"x","choices":[],"usage":{}}"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        assert!(resp.first_text().is_none());
+        assert!(resp.first_tool_calls().is_empty());
+        assert!(resp.finish_reason().is_none());
+    }
+}

--- a/crates/trusty-code/src/llm/usage.rs
+++ b/crates/trusty-code/src/llm/usage.rs
@@ -1,0 +1,106 @@
+//! Token-usage wire types for the OpenRouter / OpenAI chat-completions API.
+//!
+//! Why: Isolating the `UsageBlock` → `TokenUsage` mapping in its own module
+//! keeps request and response types independent and makes the accounting logic
+//! easy to audit and test in isolation.
+//! What: Defines `UsageBlock` (the wire representation) and its conversion to
+//! the crate's `TokenUsage`.
+//! Test: `usage_block_maps_to_token_usage`, `default_usage_block_is_zero`.
+
+use serde::Deserialize;
+
+use crate::perf::TokenUsage;
+
+/// Token usage block from the API response.
+///
+/// Why: Mapping the wire `usage` object to our internal `TokenUsage` is easiest
+/// when we first deserialise into this intermediate struct.
+/// What: Carries `prompt_tokens`, `completion_tokens`, and `total_tokens` from
+/// the wire; optional Anthropic-specific cache fields (present on Anthropic
+/// models routed via OpenRouter).
+/// Test: `usage_block_maps_to_token_usage`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct UsageBlock {
+    /// Tokens consumed by the prompt (including cached tokens).
+    #[serde(default)]
+    pub prompt_tokens: u32,
+
+    /// Tokens produced by the completion.
+    #[serde(default)]
+    pub completion_tokens: u32,
+
+    /// Sum of prompt + completion; informational only.
+    #[serde(default)]
+    pub total_tokens: u32,
+
+    /// Anthropic-only: prompt tokens served from the cache (not re-computed).
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+
+    /// Anthropic-only: prompt tokens written into the cache this turn.
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+}
+
+impl UsageBlock {
+    /// Convert this wire usage block into the crate's `TokenUsage`.
+    ///
+    /// Why: `PerfCollector` speaks `TokenUsage`; this conversion centralises the
+    /// mapping so callers don't need to know the wire field names.
+    /// What: Maps `prompt_tokens` → `prompt_tokens`, `completion_tokens` →
+    /// `completion_tokens`, `cache_read_input_tokens` → `cache_read_tokens`,
+    /// `cache_creation_input_tokens` → `cache_creation_tokens`.
+    /// Test: `usage_block_maps_to_token_usage`.
+    pub fn into_token_usage(self) -> TokenUsage {
+        TokenUsage::new(
+            self.prompt_tokens,
+            self.completion_tokens,
+            self.cache_read_input_tokens,
+            self.cache_creation_input_tokens,
+        )
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `UsageBlock::into_token_usage` maps all four fields correctly.
+    ///
+    /// Why: Correct usage mapping is critical for cost tracking; a mis-map
+    /// would silently produce wrong cost calculations.
+    /// What: Build a `UsageBlock` with known values, convert, assert each field.
+    /// Test: this test.
+    #[test]
+    fn usage_block_maps_to_token_usage() {
+        let block = UsageBlock {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            total_tokens: 150,
+            cache_read_input_tokens: 20,
+            cache_creation_input_tokens: 10,
+        };
+        let usage = block.into_token_usage();
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 50);
+        assert_eq!(usage.cache_read_tokens, 20);
+        assert_eq!(usage.cache_creation_tokens, 10);
+    }
+
+    /// Default `UsageBlock` produces a zero `TokenUsage`.
+    ///
+    /// Why: When the API omits the `usage` field (rare but possible), the
+    /// default should not crash and should produce zero counts.
+    /// What: Build `UsageBlock::default()`, convert, assert all zeros.
+    /// Test: this test.
+    #[test]
+    fn default_usage_block_is_zero() {
+        let usage = UsageBlock::default().into_token_usage();
+        assert_eq!(usage.prompt_tokens, 0);
+        assert_eq!(usage.completion_tokens, 0);
+        assert_eq!(usage.cache_read_tokens, 0);
+        assert_eq!(usage.cache_creation_tokens, 0);
+    }
+}

--- a/crates/trusty-code/src/tools/bash/mod.rs
+++ b/crates/trusty-code/src/tools/bash/mod.rs
@@ -1,0 +1,315 @@
+//! `bash` tool — execute a shell command with timeout enforcement and output capture.
+//!
+//! Why: The coder agent loop needs to run commands (pytest, cargo test, etc.)
+//! and read their output to iterate. Surfacing a non-zero exit code as a
+//! recoverable `ToolResult` (not a hard error) lets the LLM read failing test
+//! output and self-correct without aborting the loop.
+//! What: `BashTool` implements `ToolExecutor`; it runs a command via `sh -c`
+//! inside `tokio::process::Command`, enforces a configurable timeout, kills the
+//! child (and its process group on Unix) on expiry, captures stdout + stderr
+//! (each truncated to 100 KB), and returns a structured result that includes
+//! the exit code, captured output, and a timeout flag.
+//! Test: Unit tests live in `bash::tests`; they cover fast success, non-zero
+//! exit, timeout-kill, cwd honoring, stdout/stderr truncation, registry
+//! registration, and dispatch.
+
+#[cfg(test)]
+mod tests;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::tools::traits::{ServiceTier, ToolExecutor, ToolResult};
+
+/// Maximum bytes captured from stdout or stderr before truncation.
+pub(crate) const MAX_OUTPUT_BYTES: usize = 100 * 1024; // 100 KB
+
+/// Default command timeout in seconds.
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+/// Executes arbitrary shell commands on behalf of the coder agent loop.
+///
+/// Why: Lets the LLM run test suites (pytest, cargo test, etc.), build steps,
+/// and diagnostic commands without a separate MCP bridge. Capturing output
+/// as a `ToolResult` (not a fatal error) on non-zero exit means the model
+/// can read failing test output and iterate.
+/// What: Wraps `tokio::process::Command` launched via `sh -c`; enforces a
+/// configurable per-call timeout; kills the child process group (POSIX) on
+/// expiry; truncates large outputs.
+/// Test: `bash::tests::fast_command_exit_zero`, `nonzero_exit_is_recoverable`,
+/// `timeout_kills_child`, `cwd_is_honored`, `stdout_truncation`,
+/// `registry_registration_and_dispatch`.
+pub struct BashTool {
+    /// Working directory for the spawned process. `None` means inherit the
+    /// tcode process's current directory.
+    pub working_dir: Option<PathBuf>,
+    /// Default timeout applied when the caller does not supply `timeout_secs`.
+    pub default_timeout: Duration,
+}
+
+impl BashTool {
+    /// Construct with an optional working directory and default timeout.
+    ///
+    /// Why: Callers providing a `RunContext` can inject `working_dir` so the
+    /// shell respects the project root without mutating global process state.
+    /// What: Stores `working_dir` and `default_timeout`.
+    /// Test: Constructed in all `BashTool` tests.
+    pub fn new(working_dir: Option<PathBuf>, default_timeout: Duration) -> Self {
+        Self {
+            working_dir,
+            default_timeout,
+        }
+    }
+
+    /// Construct with default settings (no cwd override, 120 s timeout).
+    ///
+    /// Why: Convenience constructor for callers that accept process defaults.
+    /// What: Delegates to `new(None, DEFAULT_TIMEOUT_SECS seconds)`.
+    /// Test: `bash::tests::fast_command_exit_zero`.
+    pub fn default_config() -> Self {
+        Self::new(None, Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for BashTool {
+    fn name(&self) -> &str {
+        "bash"
+    }
+
+    /// OpenAI-function schema for the bash tool.
+    ///
+    /// Why: The LLM function-calling loop requires a JSON schema to generate
+    /// valid calls. Declaring `command` as required and `timeout_secs` as
+    /// optional keeps the schema minimal while supporting per-call overrides.
+    /// What: Returns a `{ type: "function", function: { … } }` Value.
+    /// Test: Checked via `bash::tests::registry_registration_and_dispatch`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Execute a shell command and return its stdout, stderr, and exit code. Non-zero exit codes are surfaced as recoverable results, not errors — the model should read the output and iterate.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to run (passed to `sh -c`)."
+                        },
+                        "timeout_secs": {
+                            "type": "integer",
+                            "description": "Optional timeout in seconds. Defaults to 120. The child process (and its group) is killed on expiry.",
+                            "minimum": 1
+                        }
+                    },
+                    "required": ["command"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Mark as RESTRICTED so ReadOnly/Analytics callers cannot invoke it.
+    ///
+    /// Why: Shell execution is a privileged capability. Untrusted or
+    /// analytics-only callers must not be able to run arbitrary commands.
+    /// What: Returns `[ReadOnly, Analytics]` — callers in either tier are
+    /// blocked at the registry's `dispatch_for_user` boundary.
+    /// Test: Covered by `crate::tools::registry` tier-gating tests; also
+    /// checked via `bash::tests::restricted_tiers_includes_readonly_and_analytics`.
+    fn restricted_tiers(&self) -> &[ServiceTier] {
+        &[ServiceTier::ReadOnly, ServiceTier::Analytics]
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        // ── Parse arguments ────────────────────────────────────────────────
+        let Some(command) = args.get("command").and_then(Value::as_str) else {
+            return ToolResult::err("bash: missing required 'command' parameter");
+        };
+        if command.trim().is_empty() {
+            return ToolResult::err("bash: 'command' must not be empty");
+        }
+
+        let timeout_secs: u64 = args
+            .get("timeout_secs")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.default_timeout.as_secs());
+        let call_timeout = Duration::from_secs(timeout_secs);
+
+        // ── Build the subprocess ───────────────────────────────────────────
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(command);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd.stdin(std::process::Stdio::null());
+
+        if let Some(ref dir) = self.working_dir {
+            cmd.current_dir(dir);
+        }
+
+        // On Unix, spawn the child into its own process group so that a
+        // timeout kill reaches the entire process tree, not just the shell.
+        // SAFETY: `setsid()` is documented async-signal-safe. The closure
+        // runs in the forked child after `fork()` but before `exec()`.
+        #[cfg(unix)]
+        unsafe {
+            cmd.pre_exec(|| {
+                // Create a new session; this process becomes the leader of
+                // a new process group with pgid == pid.
+                if libc::setsid() == -1 {
+                    // Non-fatal: fall back to the parent's pgid.
+                }
+                Ok(())
+            });
+        }
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return ToolResult::err(format!("bash: failed to spawn command: {e}"));
+            }
+        };
+
+        // Grab the piped handles before consuming `child` in the wait call.
+        let mut stdout_handle = child.stdout.take().expect("stdout is piped");
+        let mut stderr_handle = child.stderr.take().expect("stderr is piped");
+
+        // ── Read stdout + stderr + wait with timeout ───────────────────────
+        let run_result = timeout(call_timeout, async {
+            let mut stdout_bytes = Vec::new();
+            let mut stderr_bytes = Vec::new();
+
+            // Read both streams concurrently to avoid pipe deadlocks.
+            let (stdout_res, stderr_res, wait_res) = tokio::join!(
+                read_capped(&mut stdout_handle, MAX_OUTPUT_BYTES),
+                read_capped(&mut stderr_handle, MAX_OUTPUT_BYTES),
+                child.wait()
+            );
+
+            stdout_bytes.extend_from_slice(&stdout_res);
+            stderr_bytes.extend_from_slice(&stderr_res);
+
+            let status = wait_res?;
+            Ok::<_, std::io::Error>((stdout_bytes, stderr_bytes, status))
+        })
+        .await;
+
+        match run_result {
+            // ── Timed out ─────────────────────────────────────────────────
+            Err(_elapsed) => {
+                // Kill the child's entire process group on Unix so background
+                // processes spawned by the shell are also reaped.
+                #[cfg(unix)]
+                {
+                    if let Some(pid) = child.id() {
+                        // SAFETY: `kill` is a safe POSIX syscall. The pid value
+                        // comes from the kernel; `i32::try_from` is fallible but
+                        // realistically cannot overflow for valid process IDs.
+                        if let Ok(signed_pid) = i32::try_from(pid) {
+                            // Negative pgid means "kill the whole process group".
+                            unsafe {
+                                libc::kill(-signed_pid, libc::SIGKILL);
+                            }
+                        }
+                    }
+                }
+                // Always attempt child.kill() as a fallback (handles non-Unix
+                // or the case where setsid failed and we fall back to the child
+                // itself).
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+
+                ToolResult::err(format!(
+                    "bash: command timed out after {timeout_secs}s and was killed\ncommand: {command}"
+                ))
+            }
+
+            // ── Completed (exit 0 or non-zero) ────────────────────────────
+            Ok(Ok((stdout_bytes, stderr_bytes, status))) => {
+                let stdout = lossy_truncated(&stdout_bytes, MAX_OUTPUT_BYTES);
+                let stderr = lossy_truncated(&stderr_bytes, MAX_OUTPUT_BYTES);
+                let exit_code = status.code().unwrap_or(-1);
+
+                let mut out = String::new();
+                if !stdout.is_empty() {
+                    out.push_str("stdout:\n");
+                    out.push_str(&stdout);
+                    if !stdout.ends_with('\n') {
+                        out.push('\n');
+                    }
+                }
+                if !stderr.is_empty() {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str("stderr:\n");
+                    out.push_str(&stderr);
+                    if !stderr.ends_with('\n') {
+                        out.push('\n');
+                    }
+                }
+                out.push_str(&format!("exit_code: {exit_code}"));
+
+                // Non-zero exit is a *recoverable* result (failing pytest output
+                // should be fed back to the model, not abort the loop).
+                ToolResult::ok(out)
+            }
+
+            // ── IO error from wait() ───────────────────────────────────────
+            Ok(Err(io_err)) => {
+                ToolResult::err(format!("bash: IO error while waiting for child: {io_err}"))
+            }
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Read up to `cap` bytes from an async reader without exceeding memory.
+///
+/// Why: Commands like `find /` can produce GB of output; we must bound
+/// memory without blocking the executor.
+/// What: Reads the full stream into a `Vec<u8>` capped at `cap` bytes;
+/// silently discards the remainder (the caller appends a truncation notice).
+/// Test: `bash::tests::stdout_truncation`.
+pub(crate) async fn read_capped<R: AsyncReadExt + Unpin>(reader: &mut R, cap: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(cap.min(4096));
+    let mut tmp = [0u8; 4096];
+    loop {
+        match reader.read(&mut tmp).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let remaining = cap.saturating_sub(buf.len());
+                if remaining == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&tmp[..n.min(remaining)]);
+            }
+            Err(_) => break,
+        }
+    }
+    buf
+}
+
+/// Convert bytes to a lossy UTF-8 string, appending a truncation notice when
+/// the captured byte count exactly equals `cap`.
+///
+/// Why: The LLM needs text; raw bytes are not useful. The truncation notice
+/// tells the model that output was cut so it can adjust.
+/// What: Calls `String::from_utf8_lossy`, then checks for truncation.
+/// Test: `bash::tests::stdout_truncation`.
+pub(crate) fn lossy_truncated(bytes: &[u8], cap: usize) -> String {
+    let s = String::from_utf8_lossy(bytes).into_owned();
+    if bytes.len() >= cap {
+        format!("{s}\n[... output truncated at {cap} bytes ...]")
+    } else {
+        s
+    }
+}

--- a/crates/trusty-code/src/tools/bash/tests.rs
+++ b/crates/trusty-code/src/tools/bash/tests.rs
@@ -1,0 +1,250 @@
+//! Tests for `BashTool`.
+//!
+//! Why: Collects all bash tool tests in a dedicated file so `bash/mod.rs`
+//! stays under the 500-line cap while preserving full coverage.
+//! What: Fast-path, error-path, timeout, cwd, truncation, registry, and
+//! RBAC tier tests.
+//! Test: Each `#[tokio::test]` / `#[test]` function is its own test case.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+use super::BashTool;
+use crate::tools::registry::ToolRegistry;
+use crate::tools::traits::ToolExecutor;
+
+/// A fast command (echo) returns captured stdout and exit 0.
+///
+/// Why: Basic smoke test for the happy path.
+/// What: Runs `echo hello`; asserts stdout contains "hello" and exit 0.
+/// Test: This test.
+#[tokio::test]
+async fn fast_command_exit_zero() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "echo hello"})).await;
+    assert!(
+        !result.is_error(),
+        "echo should succeed: {}",
+        result.content()
+    );
+    let content = result.content();
+    assert!(content.contains("hello"), "stdout must contain 'hello'");
+    assert!(content.contains("exit_code: 0"), "exit code must be 0");
+}
+
+/// A failing command surfaces the non-zero exit code as a recoverable result.
+///
+/// Why: The LLM loop must read pytest failures, not abort on them. A non-zero
+/// exit must come back as `ToolResult::ok` with the code embedded in the
+/// output so the model can read and react.
+/// What: Runs `false`; asserts result is not an error variant and content
+/// contains "exit_code: 1".
+/// Test: This test.
+#[tokio::test]
+async fn nonzero_exit_is_recoverable() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "false"})).await;
+    assert!(
+        !result.is_error(),
+        "non-zero exit must be recoverable ToolResult::ok, not ToolResult::Error"
+    );
+    assert!(
+        result.content().contains("exit_code: 1"),
+        "exit code 1 must appear in content, got: {}",
+        result.content()
+    );
+}
+
+/// A custom non-zero exit code is captured correctly.
+///
+/// Why: Validates that arbitrary exit codes propagate correctly.
+/// What: Runs `sh -c 'exit 42'`; asserts content contains "exit_code: 42".
+/// Test: This test.
+#[tokio::test]
+async fn custom_exit_code_is_captured() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "sh -c 'exit 42'"})).await;
+    assert!(!result.is_error());
+    assert!(
+        result.content().contains("exit_code: 42"),
+        "exit_code 42 must appear, got: {}",
+        result.content()
+    );
+}
+
+/// A sleeping command with a sub-second timeout is killed promptly.
+///
+/// Why: Without kill logic, a leaked child blocks the test suite.
+/// What: Runs `sleep 30` with a 1-second timeout; asserts the call returns
+/// well under the sleep duration and the result is an error (timeout).
+/// Test: This test.
+#[cfg(unix)]
+#[tokio::test]
+async fn timeout_kills_child() {
+    let tool = BashTool::new(None, Duration::from_secs(120));
+    let start = Instant::now();
+    let result = tool
+        .execute(json!({"command": "sleep 30", "timeout_secs": 1}))
+        .await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_error(),
+        "timed-out command must return an error variant"
+    );
+    assert!(
+        result.content().contains("timed out"),
+        "error must mention timeout, got: {}",
+        result.content()
+    );
+    // Should return well within the 30-second sleep duration.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "timeout must fire in under 10 s, took {}ms",
+        elapsed.as_millis()
+    );
+}
+
+/// The working directory is honored for spawned commands.
+///
+/// Why: The coder loop needs `pwd` to reflect the project root, not the
+/// tcode binary's current directory.
+/// What: Creates a tempdir, sets it as `working_dir`, runs `pwd`, asserts
+/// the output matches.
+/// Test: This test.
+#[tokio::test]
+async fn cwd_is_honored() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = tmp.path().canonicalize().expect("canonicalize");
+    let tool = BashTool::new(Some(canonical.clone()), Duration::from_secs(10));
+    let result = tool.execute(json!({"command": "pwd"})).await;
+    assert!(
+        !result.is_error(),
+        "pwd should succeed: {}",
+        result.content()
+    );
+    let content = result.content();
+    assert!(
+        content.contains(canonical.to_string_lossy().as_ref()),
+        "pwd output must contain the tempdir path, got: {content}"
+    );
+}
+
+/// stdout output exceeding MAX_OUTPUT_BYTES is truncated with a notice.
+///
+/// Why: Unbounded output would exhaust memory and produce an unusably large
+/// LLM context window entry.
+/// What: Generates > 100 KB of stdout; asserts the content contains the
+/// truncation notice.
+/// Test: This test.
+#[tokio::test]
+async fn stdout_truncation() {
+    let tool = BashTool::new(None, Duration::from_secs(30));
+    // Generate ~110 KB of output (each `yes` line is 2 bytes "y\n").
+    // head -c limits to a byte count so we stay deterministic.
+    let result = tool
+        .execute(json!({"command": "yes | head -c 110000"}))
+        .await;
+    assert!(
+        !result.is_error(),
+        "yes|head should succeed: {}",
+        result.content()
+    );
+    let content = result.content();
+    assert!(
+        content.contains("truncated"),
+        "output must include truncation notice, got length={}",
+        content.len()
+    );
+}
+
+/// Missing `command` argument returns a structured error.
+///
+/// Why: Guard against malformed LLM function calls.
+/// What: `execute({})` without `command`; expects error.
+/// Test: This test.
+#[tokio::test]
+async fn missing_command_returns_error() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({})).await;
+    assert!(result.is_error());
+    assert!(
+        result.content().contains("missing required 'command'"),
+        "got: {}",
+        result.content()
+    );
+}
+
+/// Empty `command` string is rejected with a structured error.
+///
+/// Why: An empty command would spawn `sh -c ''` which silently succeeds but
+/// does nothing useful; better to surface an error.
+/// What: `execute({"command": "   "})` returns error.
+/// Test: This test.
+#[tokio::test]
+async fn empty_command_returns_error() {
+    let tool = BashTool::default_config();
+    let result = tool.execute(json!({"command": "   "})).await;
+    assert!(result.is_error());
+    assert!(
+        result.content().contains("must not be empty"),
+        "got: {}",
+        result.content()
+    );
+}
+
+/// The bash tool registers in a `ToolRegistry` and is callable via `dispatch`.
+///
+/// Why: End-to-end guard that the registry plumbing works and the schema
+/// roundtrip is correct.
+/// What: Registers `BashTool`; asserts `contains("bash")` and `schemas()`
+/// returns one entry; dispatches `echo ok` and checks output.
+/// Test: This test.
+#[tokio::test]
+async fn registry_registration_and_dispatch() {
+    let mut reg = ToolRegistry::new();
+    reg.register(Arc::new(BashTool::default_config()));
+
+    assert!(reg.contains("bash"), "registry must know about 'bash'");
+    assert_eq!(reg.schemas().len(), 1, "exactly one schema");
+
+    let schema_val = reg.schemas().into_iter().next().expect("schema");
+    let fn_name = schema_val
+        .pointer("/function/name")
+        .and_then(Value::as_str)
+        .expect("function.name");
+    assert_eq!(fn_name, "bash");
+
+    let result = reg
+        .dispatch("bash", json!({"command": "echo registry-ok"}))
+        .await;
+    assert!(
+        !result.is_error(),
+        "dispatch must succeed: {}",
+        result.content()
+    );
+    assert!(result.content().contains("registry-ok"));
+}
+
+/// `restricted_tiers` includes `ReadOnly` and `Analytics`.
+///
+/// Why: The RBAC check at `dispatch_for_user` reads `restricted_tiers()`; we
+/// must guarantee the bash tool is never accessible to low-trust callers.
+/// What: Constructs `BashTool` and checks the returned slice.
+/// Test: This test.
+#[test]
+fn restricted_tiers_includes_readonly_and_analytics() {
+    use crate::tools::traits::ServiceTier;
+    let tool = BashTool::default_config();
+    let tiers = tool.restricted_tiers();
+    assert!(
+        tiers.contains(&ServiceTier::ReadOnly),
+        "ReadOnly must be restricted"
+    );
+    assert!(
+        tiers.contains(&ServiceTier::Analytics),
+        "Analytics must be restricted"
+    );
+}

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -10,12 +10,15 @@
 //! Test: Unit tests live in each submodule; integration tests use
 //! `DelegateToAgentTool` with a `MockAgentRunner`.
 
+pub mod bash;
 pub mod delegate;
 pub mod fs;
 pub mod registry;
 pub mod traits;
 
 // Flat re-exports for `crate::tools::*` convenience.
+#[allow(unused_imports)]
+pub use bash::BashTool;
 #[allow(unused_imports)]
 pub use delegate::DelegateToAgentTool;
 pub use fs::{EditTool, ReadFileTool, WriteFileTool};


### PR DESCRIPTION
Integrates the native OpenRouter LLM client (#1020) and bash tool (#1026) onto main (fs tools #1025 already merged). Supersedes PRs #1040 and #1042. Milestone #1. Native build, no extraction. closes #1020 closes #1026

## Summary

- Copies `llm/` module (7 files: mod, client, error, message, request, response, usage) from the `feat/tcode-openrouter-client` worktree
- Copies `tools/bash/` module (mod + tests) from the `feat/tcode-bash-tool` worktree
- Unions `Cargo.toml` deps: adds `reqwest = { workspace = true }` and `libc = { workspace = true }` (thiserror already present from #1025)
- Adds `pub mod llm;` to `lib.rs` with Why/What/Test doc block
- Adds `pub mod bash;` + `BashTool` re-export to `tools/mod.rs`

## Test plan

- [x] `cargo check -p trusty-code` — clean
- [x] `cargo test -p trusty-code` — 236 passed, 1 ignored (live OpenRouter test gated by `#[ignore]`), 0 failed
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — no drift
- [x] `bash scripts/check_line_cap.sh` — 0 violations, no new allowlist entries (all new files well under 500 lines)
- [x] workspace `cargo check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)