### PR TITLE
fix(trusty-review): verdict calibration — advisory findings no longer false-block (closes #1015)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -22,7 +22,7 @@ crates/trusty-analyze/src/lang/adapters/scala.rs	583
 crates/trusty-analyze/src/lang/adapters/swift.rs	531
 crates/trusty-analyze/src/lang/adapters/typescript.rs	680
 crates/trusty-analyze/src/main.rs	870
-crates/trusty-analyze/src/mcp/mod.rs	1158
+crates/trusty-analyze/src/mcp/mod.rs	1157
 crates/trusty-analyze/tests/stdio_harness.rs	639
 crates/trusty-common/src/bm25_client.rs	503
 crates/trusty-common/src/bm25.rs	645
@@ -131,8 +131,8 @@ crates/trusty-mpm/src/tui/dashboard.rs	1040
 crates/trusty-mpm/src/tui/health.rs	3330
 crates/trusty-mpm/src/tui/mod.rs	763
 crates/trusty-review/src/models/mod.rs	531
-crates/trusty-review/src/pipeline/runner_tests.rs	730
-crates/trusty-review/src/pipeline/verify_tests.rs	533
+crates/trusty-review/src/pipeline/runner_tests.rs	738
+crates/trusty-review/src/pipeline/verify_tests.rs	556
 crates/trusty-search/src/commands/doctor_checks.rs	612
 crates/trusty-search/src/commands/integrate.rs	688
 crates/trusty-search/src/commands/reindex_engine.rs	1862

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -14,14 +14,17 @@
 //!    model-proposed APPROVE* downward.  Prevents APPROVE* over-fire on
 //!    clean PRs with speculative low-confidence findings.
 //!
-//! 2. SEVERITY FLOOR: take the stricter of (model-proposed, severity-derived):
+//! 2. SEVERITY FLOOR: take the stricter of (model-proposed, severity-derived).
+//!    As of #1015, Medium findings only count when `confidence > 0.80`
+//!    (`FLOOR_MIN_CONFIDENCE`); advisory-tier Medium findings (0.66–0.80)
+//!    must not force REQUEST_CHANGES on PRs the model judged clean.
 //!
-//!   | Finding set                               | Minimum floor   |
-//!   |-------------------------------------------|-----------------|
-//!   | Any `High` effort (critical/high sev.)    | BLOCK           |
-//!   | ≥2 `Medium` effort findings               | REQUEST_CHANGES |
-//!   | Exactly 1 `Medium` effort finding         | APPROVE*        |
-//!   | Only `Low` effort or no findings           | APPROVE         |
+//!   | Finding set                                          | Minimum floor   |
+//!   |------------------------------------------------------|-----------------|
+//!   | Any `High` effort (critical/high sev.)               | BLOCK           |
+//!   | ≥2 `Medium` effort with confidence > 0.80            | REQUEST_CHANGES |
+//!   | Exactly 1 `Medium` effort with confidence > 0.80     | APPROVE*        |
+//!   | Only `Low` effort or no floor-counting findings      | APPROVE         |
 //!
 //!   The model can never soften a Critical or High finding below the floor.
 //!
@@ -58,6 +61,8 @@
 //! `grade_model_block_kept_when_no_critical_finding`,
 //! `grade_low_confidence_all_medium_yields_approve`,
 //! `grade_high_confidence_medium_beats_low_confidence_check`,
+//! `grade_advisory_medium_below_floor_threshold_does_not_escalate`,
+//! `grade_high_confidence_medium_above_floor_threshold_escalates`,
 //! `derive_verdict_with_grade_grade_a_no_findings_approve`,
 //! `derive_verdict_with_grade_grade_f_no_findings_block`,
 //! `derive_verdict_with_grade_severity_overrides_grade_a`.
@@ -67,7 +72,7 @@ use tracing::debug;
 use crate::models::{Effort, Finding, Verdict};
 use crate::pipeline::letter_grade::{Grade, clamp_grade_to_verdict, verdict_for_grade};
 
-// ─── Confidence threshold ─────────────────────────────────────────────────────
+// ─── Confidence thresholds ────────────────────────────────────────────────────
 
 /// Confidence threshold below which a finding is considered advisory-only.
 ///
@@ -79,6 +84,23 @@ use crate::pipeline::letter_grade::{Grade, clamp_grade_to_verdict, verdict_for_g
 /// substantive; those at or below are advisory.
 /// Test: `grade_low_confidence_all_medium_yields_approve`.
 const LOW_CONFIDENCE_THRESHOLD: f32 = 0.65;
+
+/// Minimum confidence for a Medium-effort finding to count toward the severity
+/// floor (closes #1015).
+///
+/// Why: advisory-tier Medium findings (confidence 0.66–0.80) are often
+/// speculative; letting two of them force REQUEST_CHANGES over-escalates clean
+/// PRs that the model holistically judged APPROVE/B+.  Raising the floor-count
+/// gate ensures only well-grounded Medium findings drive the REQUEST_CHANGES
+/// floor, while the LOW_CONFIDENCE_THRESHOLD override still collapses the
+/// entire batch when ALL findings are at or below 0.65.
+/// What: a Medium finding counts toward the REQUEST_CHANGES floor ONLY when
+/// its `confidence > FLOOR_MIN_CONFIDENCE`.  High-effort findings are
+/// unaffected — a confirmed Critical/High still → BLOCK regardless of
+/// confidence.
+/// Test: `grade_advisory_medium_below_floor_threshold_does_not_escalate`,
+/// `grade_high_confidence_medium_above_floor_threshold_escalates`.
+const FLOOR_MIN_CONFIDENCE: f32 = 0.80;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -154,14 +176,25 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
 /// The low-confidence override is handled separately in `derive_verdict` before
 /// this function is called; by the time this is reached, the batch has at least
 /// one substantive finding.
+///
+/// As of #1015, Medium findings only count toward the REQUEST_CHANGES and
+/// APPROVE* floors when their `confidence > FLOOR_MIN_CONFIDENCE` (0.80).
+/// Advisory-tier Medium findings (confidence 0.66–0.80) are speculative; they
+/// must not force REQUEST_CHANGES over-escalation on PRs the model holistically
+/// judged clean.  High-effort behavior is unchanged: any confirmed High finding
+/// still floors to BLOCK regardless of confidence.
+///
 /// What: applies the four-tier rule set:
 ///
 /// 1. Any `High`-effort finding → BLOCK (Critical/High severity)
-/// 2. ≥2 `Medium`-effort findings → REQUEST_CHANGES
-/// 3. Exactly 1 `Medium`-effort finding → APPROVE*
-/// 4. Only `Low` / no findings → APPROVE
+/// 2. ≥2 `Medium`-effort findings with `confidence > 0.80` → REQUEST_CHANGES
+/// 3. Exactly 1 `Medium`-effort finding with `confidence > 0.80` → APPROVE*
+/// 4. Only `Low` / no floor-counting findings → APPROVE
 ///
-/// Test: `grade_two_medium_yields_request_changes`, `grade_one_medium_yields_approve_star`.
+/// Test: `grade_two_medium_yields_request_changes`,
+/// `grade_one_medium_yields_approve_star`,
+/// `grade_advisory_medium_below_floor_threshold_does_not_escalate`,
+/// `grade_high_confidence_medium_above_floor_threshold_escalates`.
 fn severity_floor(findings: &[Finding]) -> Verdict {
     if findings.is_empty() {
         return Verdict::Approve;
@@ -169,9 +202,12 @@ fn severity_floor(findings: &[Finding]) -> Verdict {
 
     // Partition findings by effort tier.
     let has_high = findings.iter().any(|f| f.effort == Effort::High);
+
+    // Only count Medium findings whose confidence clears the floor threshold
+    // (#1015: advisory-tier Medium findings must not force REQUEST_CHANGES).
     let medium_count = findings
         .iter()
-        .filter(|f| f.effort == Effort::Medium)
+        .filter(|f| f.effort == Effort::Medium && f.confidence > FLOOR_MIN_CONFIDENCE)
         .count();
 
     // Tier 1: any High-effort (critical/high severity) → BLOCK floor.
@@ -179,17 +215,17 @@ fn severity_floor(findings: &[Finding]) -> Verdict {
         return Verdict::Block;
     }
 
-    // Tier 2: ≥2 Medium-effort findings → REQUEST_CHANGES.
+    // Tier 2: ≥2 high-confidence Medium-effort findings → REQUEST_CHANGES.
     if medium_count >= 2 {
         return Verdict::RequestChanges;
     }
 
-    // Tier 3: exactly 1 Medium-effort finding → APPROVE*.
+    // Tier 3: exactly 1 high-confidence Medium-effort finding → APPROVE*.
     if medium_count == 1 {
         return Verdict::ApproveWithReservations;
     }
 
-    // Tier 4: only Low-effort or no findings.
+    // Tier 4: only Low-effort, no findings, or all-advisory Medium findings.
     Verdict::Approve
 }
 

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -48,23 +48,28 @@ fn grade_high_effort_beats_request_changes() {
 
 // ── Tier 2: ≥2 Medium ────────────────────────────────────────────────────────
 
-/// Two Medium findings with sufficient confidence must floor to REQUEST_CHANGES.
+/// Two high-confidence Medium findings (confidence > 0.80) must floor to REQUEST_CHANGES.
 ///
 /// Why: the calibration run showed REQUEST_CHANGES only 36% — this tier closes
-/// the gap for PRs with multiple real concerns.
+/// the gap for PRs with multiple well-grounded concerns.  Only findings with
+/// confidence > FLOOR_MIN_CONFIDENCE (0.80) count toward the floor (#1015).
 #[test]
 fn grade_two_medium_yields_request_changes() {
-    let findings = vec![finding(Effort::Medium, 0.8), finding(Effort::Medium, 0.75)];
+    let findings = vec![finding(Effort::Medium, 0.85), finding(Effort::Medium, 0.82)];
     let verdict = derive_verdict(Verdict::ApproveWithReservations, &findings);
     assert_eq!(verdict, Verdict::RequestChanges);
 }
 
+/// Three high-confidence Medium findings (confidence > 0.80) must floor to REQUEST_CHANGES.
+///
+/// Why: with confidence > FLOOR_MIN_CONFIDENCE, three Medium findings are genuine
+/// concerns warranting REQUEST_CHANGES (#1015).
 #[test]
 fn grade_three_medium_yields_request_changes() {
     let findings = vec![
-        finding(Effort::Medium, 0.7),
-        finding(Effort::Medium, 0.7),
-        finding(Effort::Medium, 0.7),
+        finding(Effort::Medium, 0.85),
+        finding(Effort::Medium, 0.85),
+        finding(Effort::Medium, 0.85),
     ];
     let verdict = derive_verdict(Verdict::Approve, &findings);
     assert_eq!(verdict, Verdict::RequestChanges);
@@ -72,12 +77,14 @@ fn grade_three_medium_yields_request_changes() {
 
 // ── Tier 3: Exactly 1 Medium ─────────────────────────────────────────────────
 
-/// One Medium finding must floor to APPROVE*.
+/// One high-confidence Medium finding (confidence > 0.80) must floor to APPROVE*.
 ///
-/// Why: a single advisory concern should not block the PR but warrants noting.
+/// Why: a single well-grounded concern should not block the PR but warrants
+/// noting.  Only findings with confidence > FLOOR_MIN_CONFIDENCE (0.80) count
+/// toward the floor (#1015).
 #[test]
 fn grade_one_medium_yields_approve_star() {
-    let findings = vec![finding(Effort::Medium, 0.75)];
+    let findings = vec![finding(Effort::Medium, 0.85)];
     let verdict = derive_verdict(Verdict::Approve, &findings);
     assert_eq!(verdict, Verdict::ApproveWithReservations);
 }
@@ -183,21 +190,35 @@ fn grade_confidence_at_threshold_collapses() {
     );
 }
 
-/// One Medium finding with confidence just above threshold is APPROVE*.
+/// One Medium finding above LOW_CONFIDENCE_THRESHOLD but below FLOOR_MIN_CONFIDENCE.
 ///
-/// Why: above the threshold the finding is substantive.
+/// Why: this finding (confidence 0.66) is above the all-advisory-batch collapse
+/// threshold (0.65), so it prevents the low-confidence override from firing.
+/// However, it is below FLOOR_MIN_CONFIDENCE (0.80), so it does NOT count toward
+/// the REQUEST_CHANGES / APPROVE* floor — the floor is APPROVE.
+/// What: one Medium@0.66 → medium_count=0 (not > 0.80) → floor=APPROVE.
+/// Test: this test itself.
 #[test]
 fn grade_high_confidence_medium_beats_low_confidence_check() {
     let findings = vec![finding(Effort::Medium, 0.66)];
     let verdict = derive_verdict(Verdict::Approve, &findings);
-    assert_eq!(verdict, Verdict::ApproveWithReservations);
+    // 0.66 > LOW_CONFIDENCE_THRESHOLD so all-low-confidence override does NOT fire.
+    // 0.66 ≤ FLOOR_MIN_CONFIDENCE so medium_count=0 → floor=APPROVE → APPROVE.
+    assert_eq!(verdict, Verdict::Approve);
 }
 
+/// Mixed-confidence Medium findings: one above FLOOR_MIN_CONFIDENCE, one below.
+///
+/// Why: only the finding with confidence > 0.80 counts toward the floor (#1015).
+/// One floor-counting Medium → APPROVE* (not REQUEST_CHANGES).  The old test
+/// (confidence 0.8, 0.5 → REQUEST_CHANGES) encoded the over-aggressive behavior
+/// that caused #1015; confidence 0.8 is NOT > 0.80.
 #[test]
-fn grade_mixed_confidence_two_medium_not_collapsed() {
-    let findings = vec![finding(Effort::Medium, 0.8), finding(Effort::Medium, 0.5)];
+fn grade_mixed_confidence_two_medium_only_one_counts() {
+    let findings = vec![finding(Effort::Medium, 0.85), finding(Effort::Medium, 0.5)];
     let verdict = derive_verdict(Verdict::Approve, &findings);
-    assert_eq!(verdict, Verdict::RequestChanges);
+    // Only the 0.85 finding counts (> 0.80); one floor-counting Medium → APPROVE*.
+    assert_eq!(verdict, Verdict::ApproveWithReservations);
 }
 
 // ── Compile-break BLOCK rule ─────────────────────────────────────────────────
@@ -309,12 +330,14 @@ fn derive_verdict_with_grade_model_escalates_above_grade() {
 
 /// Grade "C-", model APPROVE, two high-confidence Medium findings → REQUEST_CHANGES.
 ///
-/// Why: grade "C-" → APPROVE*, model APPROVE → effective = APPROVE*. Then
-/// two Medium findings floor to REQUEST_CHANGES (stricter than APPROVE*).
+/// Why: grade "C-" → APPROVE*, model APPROVE → effective = APPROVE*.  Two Medium
+/// findings with confidence > 0.80 floor to REQUEST_CHANGES (stricter than APPROVE*).
 /// Grade "C-" must then clamp to D+ (ceiling of REQUEST_CHANGES band).
+/// Note: confidence must be > FLOOR_MIN_CONFIDENCE (0.80); findings at 0.80 no
+/// longer count (#1015).
 #[test]
 fn derive_verdict_with_grade_floor_stricter_than_grade() {
-    let findings = vec![finding(Effort::Medium, 0.8), finding(Effort::Medium, 0.8)];
+    let findings = vec![finding(Effort::Medium, 0.85), finding(Effort::Medium, 0.85)];
     let (v, g) = derive_verdict_with_grade(Verdict::Approve, Grade::CMinus, &findings);
     assert_eq!(v, Verdict::RequestChanges);
     assert_eq!(
@@ -322,4 +345,88 @@ fn derive_verdict_with_grade_floor_stricter_than_grade() {
         Grade::DPlus,
         "grade must clamp to D+ (ceiling of REQUEST_CHANGES)"
     );
+}
+
+// ── #1015 regression: advisory Medium findings must not over-escalate ────────
+
+/// Model APPROVE/B+ + two Medium findings at confidence 0.70 must NOT escalate
+/// to REQUEST_CHANGES (#1015 primary regression).
+///
+/// Why: advisory-tier Medium findings (confidence ≤ FLOOR_MIN_CONFIDENCE = 0.80)
+/// are speculative; the floor must not override the model's holistic APPROVE/B+
+/// judgment.  This was the live bug: top-level REQUEST_CHANGES on PRs with only
+/// advisory findings.
+/// What: zero floor-counting Mediums (both 0.70 ≤ 0.80) → floor = APPROVE →
+/// final = max(APPROVE, APPROVE) = APPROVE.
+/// Test: this test itself.
+#[test]
+fn grade_approve_b_plus_two_medium_advisory_stays_approve() {
+    let findings = vec![finding(Effort::Medium, 0.70), finding(Effort::Medium, 0.70)];
+    let (v, g) = derive_verdict_with_grade(Verdict::Approve, Grade::BPlus, &findings);
+    assert_eq!(
+        v,
+        Verdict::Approve,
+        "advisory Medium@0.70 must not escalate APPROVE/B+ to REQUEST_CHANGES (#1015)"
+    );
+    // Grade B+ is in the APPROVE band — no clamping needed.
+    assert_eq!(g, Grade::BPlus);
+}
+
+/// Advisory Medium findings do not count even at the LOW_CONFIDENCE_THRESHOLD boundary.
+///
+/// Why: confidence 0.70 is above LOW_CONFIDENCE_THRESHOLD (0.65) so the all-low-
+/// confidence override does NOT fire, but it is below FLOOR_MIN_CONFIDENCE (0.80)
+/// so the floor-count does not trigger either.  These findings are neither
+/// "all advisory noise" nor "confirmed blocking concerns" — and that is correct.
+/// What: two Medium@0.70 → floor = APPROVE → APPROVE.
+/// Test: this test itself.
+#[test]
+fn grade_advisory_medium_below_floor_threshold_does_not_escalate() {
+    let findings = vec![
+        finding(Effort::Medium, 0.70),
+        finding(Effort::Medium, 0.72),
+        finding(Effort::Medium, 0.75),
+    ];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "Medium findings below FLOOR_MIN_CONFIDENCE must not force REQUEST_CHANGES"
+    );
+}
+
+/// Two Medium findings ABOVE the floor threshold DO escalate appropriately.
+///
+/// Why: confirms the complementary behavior — the fix is calibrated, not a
+/// blanket suppression.  Well-grounded Medium findings (confidence > 0.80)
+/// still trigger REQUEST_CHANGES.
+/// What: two Medium@0.85 → both count → floor = REQUEST_CHANGES.
+/// Test: this test itself.
+#[test]
+fn grade_high_confidence_medium_above_floor_threshold_escalates() {
+    let findings = vec![finding(Effort::Medium, 0.85), finding(Effort::Medium, 0.85)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "Medium findings above FLOOR_MIN_CONFIDENCE must still trigger REQUEST_CHANGES"
+    );
+}
+
+/// A confirmed High finding still drives BLOCK even with a B+ grade (#1015 regression).
+///
+/// Why: the fix must not soften correctness blockers.  High-effort findings are
+/// independent of FLOOR_MIN_CONFIDENCE — they always floor to BLOCK.
+/// What: grade B+ (APPROVE) + model APPROVE + one High@0.90 → BLOCK, grade F.
+/// Test: this test itself.
+#[test]
+fn grade_confirmed_high_still_blocks_despite_b_plus_grade() {
+    let findings = vec![finding(Effort::High, 0.90)];
+    let (v, g) = derive_verdict_with_grade(Verdict::Approve, Grade::BPlus, &findings);
+    assert_eq!(
+        v,
+        Verdict::Block,
+        "High-effort finding must still BLOCK regardless of grade (#1015 regression)"
+    );
+    assert_eq!(g, Grade::F, "grade must clamp to F when verdict=BLOCK");
 }

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -653,8 +653,15 @@ async fn run_review_verification_refutes_and_relaxes_verdict() {
     );
 }
 
-/// The verification round, when wired in, CONFIRMS the finding and the verdict
-/// is preserved.
+/// The verification round, when wired in, CONFIRMS the Medium finding; after #1015
+/// a lone confirmed Medium anchors at APPROVE* (path a2), not REQUEST_CHANGES.
+///
+/// Why: before #1015 path (a) preserved primary_verdict (REQUEST_CHANGES) on any
+/// confirmed finding.  After #1015, only confirmed High-effort triggers path (a);
+/// confirmed Medium triggers path (a2) which caps the baseline at APPROVE*.
+/// The APPROVE* result is correct — the model judged REQUEST_CHANGES holistically
+/// but the only confirmed evidence is a single Medium finding, which justifies
+/// at most APPROVE*.
 #[tokio::test]
 async fn run_review_verification_confirms_and_preserves_verdict() {
     let (source, _tmp) = local_diff_source("+fn bad() {}\n");
@@ -676,10 +683,11 @@ async fn run_review_verification_confirms_and_preserves_verdict() {
     );
 
     let result = run_review(&config, input, deps).await;
+    // After #1015: confirmed Medium → path (a2) → APPROVE* (not REQUEST_CHANGES).
     assert_eq!(
         result.verdict,
-        Verdict::RequestChanges,
-        "a confirmed finding must preserve the REQUEST_CHANGES verdict"
+        Verdict::ApproveWithReservations,
+        "confirmed Medium → APPROVE* (path a2 — #1015); not REQUEST_CHANGES"
     );
 }
 

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -35,7 +35,7 @@ use crate::{
         BLOCK_VERDICT_MIN_CONFIDENCE, VERIFY_CANDIDATE_MIN_CONFIDENCE, VERIFY_REFUTED_CONFIDENCE,
     },
     llm::{LlmError, LlmProvider},
-    models::{Finding, Verdict, VerifyOutcome},
+    models::{Effort, Finding, Verdict, VerifyOutcome},
     pipeline::{grade::derive_verdict, verify_prompt::build_verify_request},
 };
 
@@ -157,10 +157,7 @@ pub async fn run_verification_round(
         .collect()
         .await;
 
-    // Apply outcomes: record on the finding and demote refuted ones.  Track
-    // whether ANY candidate was confirmed AND whether at least one demotion was a
-    // clean model REFUTED (as opposed to an infrastructure failure class).  These
-    // two bits together let `rederive_verdict` decide the right baseline.
+    // Apply outcomes: record on the finding and demote refuted ones.
     let mut any_confirmed = false;
     let mut any_clean_refuted = false;
     for (idx, outcome) in outcomes {
@@ -191,43 +188,28 @@ pub async fn run_verification_round(
 
 /// Re-derive the final verdict from the surviving (non-refuted) findings.
 ///
-/// Why: after verification, the *surviving* findings are the ground truth — a
-/// refuted finding can no longer justify a blocking verdict.  Two facts make a
-/// naive `derive_verdict` call insufficient:
-///   1. the severity floor is keyed on a finding's `Effort`, so a refuted
-///      High-effort finding would still force a BLOCK floor on its tier alone;
-///   2. `derive_verdict` also treats its `model_proposed` argument as a lower
-///      bound, so always passing the original BLOCK would pin the result at
-///      BLOCK even when every blocking finding was refuted.
+/// Why: refuted findings can no longer justify a blocking verdict; `derive_verdict`
+/// treats its model_proposed as a lower bound, so always passing the original
+/// BLOCK would pin the result even when every blocking finding was refuted.
 ///
-/// The baseline selection rule (designed to satisfy the ticket's examples while
-/// fixing the #726 verdict-collapse-on-infrastructure-failure bug):
-///
-///   a) ANY confirmed → the model's escalation is grounded, keep `primary_verdict`
-///      as the lower bound so e.g. a REQUEST_CHANGES backed by a confirmed Medium
-///      finding is not silently downgraded.
-///
-///   b) At least one clean model REFUTED (i.e. `any_clean_refuted`), no confirmed
-///      → the escalation rested on refuted evidence, drop to neutral `APPROVE`
-///      baseline and let the survivors decide.
-///
-///   c) ALL demotions were non-clean (TruncationRefuted / ErrorRefuted), nothing
-///      confirmed → the verification infrastructure failed, NOT the model's
-///      reasoning.  Preserve `primary_verdict` so a BLOCK is not silently discarded
-///      because the verifier's JSON was truncated or the model was unreachable.
-///      This is the bug fixed in #726: a 16-token cap caused 100% TruncationRefuted,
-///      which previously fell into path (b) and collapsed every review to APPROVE.
+/// Four-way baseline selection:
+///   a)  confirmed + at least one confirmed High-effort finding
+///       → keep `primary_verdict` (grounded critical evidence, e.g. BLOCK stays BLOCK)
+///   a2) confirmed, but only Medium/Low-effort findings confirmed (#1015)
+///       → cap lower bound at APPROVE*; a lone confirmed Medium must not anchor
+///         REQUEST_CHANGES from a floor-driven escalation
+///   b)  clean model REFUTED, nothing confirmed
+///       → drop to APPROVE baseline (escalation rested on refuted evidence)
+///   c)  all demotions are infra failures (TruncationRefuted/ErrorRefuted), no confirmed
+///       → preserve `primary_verdict` (do not discard on verifier infra failure, #726)
 ///
 /// `UNKNOWN` is handled by the caller and never reaches here.
-/// What: filters out all refutation-variant findings from the survivor set, selects
-/// the baseline via the three-way rule above, then calls
+/// What: filters survivors (non-refuted), selects baseline, calls
 /// `derive_verdict(baseline, survivors)`.
-/// Test: `rederive_excludes_refuted_relaxes` (path b),
-/// `rederive_keeps_confirmed_block` (path a),
-/// `rederive_error_refuted_preserves_primary_verdict` (path c — regression for #726),
-/// `rederive_truncation_refuted_preserves_primary_verdict` (path c),
-/// and the end-to-end `verify_refuted_demotes_and_block_relaxes` /
-/// `verify_join_handle_regression_pr720`.
+/// Test: `rederive_excludes_refuted_relaxes` (b), `rederive_keeps_confirmed_block` (a),
+/// `rederive_confirmed_medium_caps_at_approve_star` (a2 — #1015),
+/// `rederive_error_refuted_preserves_primary_verdict` (c — #726),
+/// `rederive_truncation_refuted_preserves_primary_verdict` (c).
 fn rederive_verdict(
     primary_verdict: Verdict,
     any_confirmed: bool,
@@ -247,13 +229,33 @@ fn rederive_verdict(
         .cloned()
         .collect();
 
-    // Three-way baseline selection (see Why above):
-    //  a) any confirmed   → keep model's escalation (grounded evidence)
-    //  b) clean refuted   → drop to APPROVE (model said REFUTED on merits)
-    //  c) infra-only fail → keep model's escalation (don't discard on truncation/error)
-    let baseline = if any_confirmed {
-        // Path (a): confirmed evidence supports the escalation.
+    // Does any confirmed (surviving) finding have High effort?
+    let any_confirmed_high = survivors
+        .iter()
+        .filter(|f| matches!(f.verified, Some(VerifyOutcome::Confirmed)))
+        .any(|f| f.effort == Effort::High);
+
+    // Four-way baseline selection (see Why above):
+    //  a)  confirmed + at least one High-effort confirmed
+    //      → keep primary_verdict as lower bound (grounded critical evidence)
+    //  a2) confirmed, but only Medium/Low confirmed
+    //      → cap lower bound at APPROVE* (advisory tier); don't let a floor-driven
+    //         REQUEST_CHANGES pin the verdict when the confirmed finding is merely
+    //         Medium-effort (#1015)
+    //  b)  clean refuted, nothing confirmed
+    //      → drop to APPROVE; let survivors alone decide
+    //  c)  infra-only fail (TruncationRefuted / ErrorRefuted), nothing confirmed
+    //      → preserve primary_verdict (don't discard on infra failure #726)
+    let baseline = if any_confirmed && any_confirmed_high {
+        // Path (a): confirmed High-effort evidence supports the escalation fully.
         primary_verdict
+    } else if any_confirmed {
+        // Path (a2): confirmed evidence, but only Medium/Low tier.  Cap the lower
+        // bound at APPROVE* so a lone confirmed Medium cannot permanently anchor a
+        // REQUEST_CHANGES verdict that was itself only floor-driven (#1015).
+        // `derive_verdict(APPROVE*, survivors)` will still escalate further if the
+        // surviving findings warrant it (e.g. a surviving High → BLOCK).
+        Verdict::ApproveWithReservations
     } else if any_clean_refuted {
         // Path (b): at least one clean REFUTED from the model — escalation rested
         // on refuted evidence; let survivors alone decide.

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -226,24 +226,22 @@ fn rederive_keeps_confirmed_block() {
 }
 
 #[test]
-fn rederive_confirmed_preserves_model_escalation() {
-    // Path (a): model escalated to REQUEST_CHANGES on a single confirmed Medium.
-    // Because a candidate was confirmed, the model's escalation is preserved
-    // even though the lone-Medium floor alone is only APPROVE*.
+fn rederive_confirmed_medium_caps_at_approve_star() {
+    // Path (a2) — #1015: confirmed Medium-only caps baseline at APPROVE*; does not
+    // anchor REQUEST_CHANGES from a floor-driven escalation.
     let mut med = finding(Effort::Medium, 0.85);
     apply_outcome(&mut med, VerifyOutcome::Confirmed);
     let verdict = rederive_verdict(Verdict::RequestChanges, true, false, &[med]);
     assert_eq!(
         verdict,
-        Verdict::RequestChanges,
-        "confirmed evidence keeps the model's escalation as a lower bound (path a)"
+        Verdict::ApproveWithReservations,
+        "confirmed Medium caps at APPROVE* (path a2 — #1015)"
     );
 }
 
 #[test]
 fn rederive_mixed_keeps_only_surviving_floor() {
-    // Path (a): High refuted + one surviving confirmed Medium, model said BLOCK.
-    // any_confirmed=true → baseline is the model APPROVE*, the Medium floor.
+    // Path (a2): High refuted + confirmed Medium@0.85, model said APPROVE*.
     let mut high = finding(Effort::High, 0.95);
     apply_outcome(&mut high, VerifyOutcome::Refuted);
     let mut med = finding(Effort::Medium, 0.85);
@@ -463,17 +461,16 @@ async fn verify_truncation_preserves_primary_verdict() {
     );
 }
 
-/// Regression for the dropped-JoinHandle true-positive from PR #720 that was
-/// silently refuted in the #726 incident (16-token cap truncated all responses).
-/// Why: validates (a) CONFIRMED preserves finding + verdict, (b) TruncationRefuted
-/// does NOT collapse verdict to APPROVE (path c).
+/// Regression for the dropped-JoinHandle true-positive (PR #720, #726 incident).
+/// Why: (a) CONFIRMED Medium → APPROVE* (path a2, #1015 — pre-#1015 was REQUEST_CHANGES);
+/// (b) TruncationRefuted must NOT collapse to APPROVE (path c, #726).
 /// Test: this test itself.
 #[tokio::test]
 async fn verify_join_handle_regression_pr720() {
     let mut f = Finding::new(
         "crates/trusty-search/src/startup.rs",
         "resource-leak",
-        "JoinHandle dropped immediately; spawned task detached, risking pool exhaustion",
+        "JoinHandle dropped; spawned task detached, risking pool exhaustion",
         "Store the JoinHandle and await it in graceful shutdown",
         0.85,
         Effort::Medium,
@@ -483,7 +480,7 @@ async fn verify_join_handle_regression_pr720() {
                 +    tokio::spawn(async move { warm_boot().await });\n\
                 +}\n";
 
-    // Sub-test (a): CONFIRMED → finding + verdict survive.
+    // Sub-test (a): CONFIRMED Medium → path (a2): baseline=APPROVE*, stays APPROVE*.
     let mut findings_1 = vec![f.clone()];
     let v1 = run_verification_round(
         &confirmed_provider(),
@@ -499,10 +496,11 @@ async fn verify_join_handle_regression_pr720() {
         findings_1[0].verified,
         Some(VerifyOutcome::Confirmed)
     ));
+    // After #1015: a confirmed Medium caps at APPROVE* (path a2), not REQUEST_CHANGES.
     assert_eq!(
         v1,
-        Verdict::RequestChanges,
-        "CONFIRMED must hold REQUEST_CHANGES"
+        Verdict::ApproveWithReservations,
+        "CONFIRMED Medium → APPROVE* (path a2 — #1015)"
     );
 
     // Sub-test (b): TruncationRefuted → verdict preserved (path c — #726).
@@ -524,7 +522,32 @@ async fn verify_join_handle_regression_pr720() {
     assert_eq!(
         v2,
         Verdict::RequestChanges,
-        "truncation must NOT collapse verdict to APPROVE (path c — #726)"
+        "truncation must NOT collapse to APPROVE (path c — #726)"
+    );
+}
+
+// ── #1015 regression ──────────────────────────────────────────────────────────
+
+/// Regression: APPROVE + two Medium@0.70 must stay APPROVE (#1015).
+/// Advisory Mediums (≤ 0.80) excluded from floor count; APPROVE stays APPROVE.
+#[tokio::test]
+async fn verify_approve_two_advisory_medium_stays_approve() {
+    let verifier = confirmed_provider();
+    let mut findings = vec![finding(Effort::Medium, 0.70), finding(Effort::Medium, 0.70)];
+    let verdict = run_verification_round(
+        &verifier,
+        "m",
+        "+ advisory diff",
+        Verdict::Approve,
+        &mut findings,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "advisory Medium@0.70 must not escalate APPROVE to REQUEST_CHANGES (#1015)"
     );
 }
 


### PR DESCRIPTION
## Summary

- **`grade.rs`** — Add `FLOOR_MIN_CONFIDENCE = 0.80` const; `severity_floor` now only counts Medium findings with `confidence > 0.80` toward the REQUEST_CHANGES and APPROVE* floors. Advisory-tier Medium findings (0.66–0.80) no longer force REQUEST_CHANGES. High-effort behavior unchanged — any confirmed High still floors to BLOCK.

- **`verify.rs`** — Split `rederive_verdict` path (a) into (a) and (a2):
  - **(a)** confirmed + at least one **High-effort** confirmed → keep `primary_verdict` as lower bound
  - **(a2)** confirmed, but only **Medium/Low** confirmed → cap baseline at APPROVE* so a lone confirmed Medium no longer permanently anchors a REQUEST_CHANGES verdict that was floor-driven (#1015)
  - Paths (b) (clean REFUTED) and (c) (infra failure, #726) unchanged.

## Root cause

`severity_floor` counted all Medium findings regardless of confidence. Two advisory Medium@0.70 findings forced REQUEST_CHANGES even when the model holistically judged APPROVE/B+ ("no correctness blockers"). The all-low-confidence override (fires only when ALL findings ≤ 0.65) did not help because 0.70 > 0.65.

After verification, path (a) of `rederive_verdict` preserved `primary_verdict` (REQUEST_CHANGES) as the lower bound on ANY confirmed finding, even a lone Medium — anchoring the over-escalated verdict permanently.

## Regression tests added

| Test | Coverage |
|------|----------|
| `grade_approve_b_plus_two_medium_advisory_stays_approve` | APPROVE/B+ + 2×Medium@0.70 → APPROVE (primary regression) |
| `grade_advisory_medium_below_floor_threshold_does_not_escalate` | 3×Medium@0.70–0.75 → APPROVE |
| `grade_high_confidence_medium_above_floor_threshold_escalates` | 2×Medium@0.85 → REQUEST_CHANGES (genuine concerns preserved) |
| `grade_confirmed_high_still_blocks_despite_b_plus_grade` | High@0.90 + B+ → BLOCK (correctness blocker preserved) |
| `rederive_confirmed_medium_caps_at_approve_star` | confirmed Medium → APPROVE* not REQUEST_CHANGES (path a2) |
| `verify_approve_two_advisory_medium_stays_approve` | end-to-end: APPROVE + 2×advisory Medium@0.70 confirmed → APPROVE |

## Tests updated (old over-aggressive behavior)

- `grade_two_medium_yields_request_changes` — bumped confidences to 0.85/0.82 (> 0.80)
- `grade_three_medium_yields_request_changes` — bumped confidences to 0.85
- `grade_mixed_confidence_two_medium_not_collapsed` → renamed `grade_mixed_confidence_two_medium_only_one_counts`, asserts APPROVE* (one counts, one doesn't)
- `grade_one_medium_yields_approve_star` — bumped confidence to 0.85
- `grade_high_confidence_medium_beats_low_confidence_check` — updated: 0.66 is above LOW_CONFIDENCE_THRESHOLD but ≤ FLOOR_MIN_CONFIDENCE → APPROVE now (not APPROVE*)
- `derive_verdict_with_grade_floor_stricter_than_grade` — bumped confidences to 0.85
- `rederive_confirmed_preserves_model_escalation` → renamed `rederive_confirmed_medium_caps_at_approve_star`, asserts APPROVE* (path a2)
- `run_review_verification_confirms_and_preserves_verdict` — updated to assert APPROVE* (not REQUEST_CHANGES)
- `verify_join_handle_regression_pr720` sub-test (a) — updated to assert APPROVE* (path a2 post-#1015)

## High/critical blocking behavior preserved

- `grade_critical_high_effort_yields_block`, `grade_floor_overrides_model_approve`, `grade_confirmed_high_still_blocks_despite_b_plus_grade` all pass unchanged
- High-effort findings still unconditionally floor to BLOCK in `severity_floor`
- path (a) of `rederive_verdict` still preserves `primary_verdict` when there is at least one confirmed **High-effort** finding

## Test run

```
test result: ok. 767 passed; 0 failed; 3 ignored
```

## Release note

NOTE: this fix requires a `trusty-review` version bump + `cargo publish` + `cargo install --path crates/trusty-review --locked` to take effect on the running gate. That is a follow-up release step, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)