### PR TITLE
fix(trusty-analyze): resolve CALLS edge targets via qualified node-id scheme across all 13 adapters (closes #913)

### DIFF
--- a/crates/trusty-analyze/src/core/call_resolver.rs
+++ b/crates/trusty-analyze/src/core/call_resolver.rs
@@ -1,0 +1,308 @@
+//! Post-merge call-edge resolution pass.
+//!
+//! Why: Tree-sitter adapters emit call-edge targets in an unresolved sentinel
+//! form (`{lang}:{kind}::{callee}`) because they have no cross-file symbol
+//! resolution.  After the linker deduplicates nodes we have the full canonical
+//! node set and can do a best-effort name match to replace sentinel targets
+//! with real node ids, making the call graph traversable.
+//!
+//! What: Builds a `(language, bare_name) → Vec<&KgNode>` index over the
+//! canonical node set, then rewrites each Calls edge whose target is an
+//! unresolved sentinel.  Same-file candidates are preferred; genuinely
+//! unresolvable (external) targets are left as-is.
+//!
+//! Test: `resolve_calls_*` tests below cover intra-file, cross-file,
+//! class-method-qualified, external, and high-resolution-rate scenarios.
+
+use std::collections::HashMap;
+
+use crate::lang::call_target::parse_call_target;
+use crate::types::{KgEdgeKind, KgGraph, KgNode};
+
+/// Resolve unresolved call-edge targets to canonical node ids.
+///
+/// Why: Adapters emit call edges with sentinel targets of the form
+/// `{lang}:{kind}::{callee}` because tree-sitter has no cross-file symbol
+/// resolution.  After deduplication we have the full canonical node set, so
+/// we do a best-effort name match here: same-file nodes are preferred, then
+/// any unique match across the whole graph.  Targets that cannot be matched
+/// are left as-is (they represent external or unresolvable calls and are
+/// intentionally kept so consumers can distinguish them from real nodes).
+///
+/// What: Builds a lookup index `(lang, name) → Vec<&KgNode>` from the
+/// canonical node set, then for every Calls edge whose `to` matches the
+/// unresolved sentinel format, replaces `to` with the best-matching node id.
+///
+/// Test: See module-level tests below.
+pub fn resolve_calls(graph: KgGraph) -> KgGraph {
+    let KgGraph { nodes, mut edges } = graph;
+
+    // Build a lookup: (language, bare_name) → list of candidate node ids.
+    // We index on `node.name` (the bare unqualified name) so that even
+    // class-qualified nodes like `csharp:Method:Foo.cs:MyClass:Save` are
+    // findable under just `"Save"`.
+    let mut name_index: HashMap<(&str, &str), Vec<&KgNode>> = HashMap::new();
+    for node in &nodes {
+        name_index
+            .entry((node.language.as_str(), node.name.as_str()))
+            .or_default()
+            .push(node);
+    }
+
+    for edge in edges.iter_mut() {
+        if !matches!(edge.kind, KgEdgeKind::Calls) {
+            continue;
+        }
+        let Some(unresolved) = parse_call_target(&edge.to) else {
+            // Already a real node id or unsupported format — leave it.
+            continue;
+        };
+
+        // Determine caller's file from the `from` id for same-file preference.
+        // Node ids have the shape `{lang}:{kind}:{file}:{name}`, so the third
+        // colon-delimited component is the file.
+        let caller_file: Option<&str> = {
+            let parts: Vec<&str> = edge.from.splitn(4, ':').collect();
+            if parts.len() >= 3 {
+                Some(parts[2])
+            } else {
+                None
+            }
+        };
+
+        let candidates = name_index
+            .get(&(unresolved.lang, unresolved.callee))
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+
+        let resolved = match candidates {
+            [] => None,
+            [single] => Some(single.id.as_str()),
+            many => {
+                // Multiple nodes share this name.  Prefer same-file first.
+                caller_file.and_then(|file| {
+                    // Ambiguous cross-file: leave unresolved rather than guess.
+                    many.iter().find(|n| n.file == file).map(|n| n.id.as_str())
+                })
+            }
+        };
+
+        if let Some(id) = resolved {
+            edge.to = id.to_string();
+        }
+        // If unresolvable, the sentinel target is preserved as-is.
+    }
+
+    // Drop self-loops introduced by resolution.
+    edges.retain(|e| e.from != e.to);
+
+    KgGraph { nodes, edges }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::call_target::build_call_target;
+    use crate::types::{KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
+
+    fn mk(id: &str, name: &str, kind: KgNodeKind, lang: &str, file: &str) -> KgNode {
+        KgNode {
+            id: id.into(),
+            kind,
+            name: name.into(),
+            qualified_name: name.into(),
+            language: lang.into(),
+            file: file.into(),
+            start_line: 1,
+            end_line: 10,
+            doc_comment: None,
+            is_public: true,
+            extra: serde_json::Value::Null,
+        }
+    }
+
+    fn cedge(from: &str, to: &str) -> KgEdge {
+        KgEdge {
+            from: from.into(),
+            to: to.into(),
+            kind: KgEdgeKind::Calls,
+            weight: 1.0,
+        }
+    }
+
+    /// Core invariant: the name component in node-id equals callee in call target.
+    /// This is what #913 broke — the two id schemes were using different components.
+    #[test]
+    fn node_id_and_target_share_name_component() {
+        let node_id = "rust:Function:src/foo.rs:helper";
+        let target = build_call_target("rust", "Function", "helper");
+        // splitn(4, ':').nth(3) gives the name component of each format.
+        assert_eq!(
+            node_id.splitn(4, ':').nth(3),
+            target.splitn(4, ':').nth(3),
+            "name component must match between node id and call target"
+        );
+    }
+
+    /// Intra-file call resolves to the callee node id.
+    #[test]
+    fn resolve_calls_intra_file() {
+        let caller_id = "rust:Function:foo.rs:caller";
+        let helper_id = "rust:Function:foo.rs:helper";
+        let mut g = KgGraph::default();
+        g.nodes.push(mk(
+            caller_id,
+            "caller",
+            KgNodeKind::Function,
+            "rust",
+            "foo.rs",
+        ));
+        g.nodes.push(mk(
+            helper_id,
+            "helper",
+            KgNodeKind::Function,
+            "rust",
+            "foo.rs",
+        ));
+        g.edges.push(cedge(
+            caller_id,
+            &build_call_target("rust", "Function", "helper"),
+        ));
+        let out = resolve_calls(g);
+        let call = out
+            .edges
+            .iter()
+            .find(|e| matches!(e.kind, KgEdgeKind::Calls))
+            .unwrap();
+        assert_eq!(call.to, helper_id, "intra-file call must resolve");
+    }
+
+    /// Cross-file call resolves when callee name is unique across the graph.
+    #[test]
+    fn resolve_calls_cross_file() {
+        let caller_id = "rust:Function:src/a.rs:do_work";
+        let callee_id = "rust:Function:src/b.rs:utility";
+        let mut g = KgGraph::default();
+        g.nodes.push(mk(
+            caller_id,
+            "do_work",
+            KgNodeKind::Function,
+            "rust",
+            "src/a.rs",
+        ));
+        g.nodes.push(mk(
+            callee_id,
+            "utility",
+            KgNodeKind::Function,
+            "rust",
+            "src/b.rs",
+        ));
+        g.edges.push(cedge(
+            caller_id,
+            &build_call_target("rust", "Function", "utility"),
+        ));
+        let out = resolve_calls(g);
+        let call = out
+            .edges
+            .iter()
+            .find(|e| matches!(e.kind, KgEdgeKind::Calls))
+            .unwrap();
+        assert_eq!(call.to, callee_id, "cross-file unique callee must resolve");
+    }
+
+    /// Class-qualified C# method call resolves via bare name lookup.
+    /// This is the class-qualifier mismatch case from #913.
+    #[test]
+    fn resolve_calls_class_method_qualified() {
+        let caller_id = "csharp:Method:OrderService.cs:OrderService:Process";
+        let callee_id = "csharp:Method:Repository.cs:Repository:Save";
+        let mut g = KgGraph::default();
+        g.nodes.push(mk(
+            caller_id,
+            "Process",
+            KgNodeKind::Method,
+            "csharp",
+            "OrderService.cs",
+        ));
+        // "Save" is the bare name; the node id includes class qualifier.
+        g.nodes.push(mk(
+            callee_id,
+            "Save",
+            KgNodeKind::Method,
+            "csharp",
+            "Repository.cs",
+        ));
+        g.edges.push(cedge(
+            caller_id,
+            &build_call_target("csharp", "Method", "Save"),
+        ));
+        let out = resolve_calls(g);
+        let call = out
+            .edges
+            .iter()
+            .find(|e| matches!(e.kind, KgEdgeKind::Calls))
+            .unwrap();
+        assert_eq!(
+            call.to, callee_id,
+            "class-method call must resolve to qualified node id"
+        );
+    }
+
+    /// External (stdlib) call preserves the sentinel target.
+    #[test]
+    fn resolve_calls_external_stays_unresolved() {
+        let caller_id = "rust:Function:src/main.rs:main";
+        let ext = build_call_target("rust", "Function", "println");
+        let mut g = KgGraph::default();
+        g.nodes.push(mk(
+            caller_id,
+            "main",
+            KgNodeKind::Function,
+            "rust",
+            "src/main.rs",
+        ));
+        g.edges.push(cedge(caller_id, &ext));
+        let out = resolve_calls(g);
+        let call = out
+            .edges
+            .iter()
+            .find(|e| matches!(e.kind, KgEdgeKind::Calls))
+            .unwrap();
+        assert_eq!(call.to, ext, "external call must keep sentinel target");
+    }
+
+    /// Multi-file fixture asserting ≥75% resolution (was ~5% before fix #913).
+    #[test]
+    fn resolve_calls_high_resolution_rate() {
+        let alpha_id = "rust:Function:a.rs:alpha";
+        let beta_id = "rust:Function:a.rs:beta";
+        let gamma_id = "rust:Function:b.rs:gamma";
+        let mut g = KgGraph::default();
+        g.nodes
+            .push(mk(alpha_id, "alpha", KgNodeKind::Function, "rust", "a.rs"));
+        g.nodes
+            .push(mk(beta_id, "beta", KgNodeKind::Function, "rust", "a.rs"));
+        g.nodes
+            .push(mk(gamma_id, "gamma", KgNodeKind::Function, "rust", "b.rs"));
+        // alpha→beta (intra), alpha→gamma (cross), alpha→delta (external), beta→gamma (cross)
+        for (from, to) in [
+            (alpha_id, "beta"),
+            (alpha_id, "gamma"),
+            (alpha_id, "delta"),
+            (beta_id, "gamma"),
+        ] {
+            g.edges
+                .push(cedge(from, &build_call_target("rust", "Function", to)));
+        }
+        let out = resolve_calls(g);
+        let calls: Vec<_> = out
+            .edges
+            .iter()
+            .filter(|e| matches!(e.kind, KgEdgeKind::Calls))
+            .collect();
+        let ids: std::collections::HashSet<_> = out.nodes.iter().map(|n| n.id.as_str()).collect();
+        let resolved = calls.iter().filter(|e| ids.contains(e.to.as_str())).count();
+        assert_eq!(calls.len(), 4, "should have 4 call edges");
+        assert_eq!(resolved, 3, "3/4 calls must resolve (delta is external)");
+    }
+}

--- a/crates/trusty-analyze/src/core/linker.rs
+++ b/crates/trusty-analyze/src/core/linker.rs
@@ -1,20 +1,29 @@
-//! Post-processing pass that merges duplicate KgNodes across chunks.
+//! Post-processing pass that merges duplicate KgNodes across chunks and
+//! resolves unresolved call-edge targets to real node ids.
 //!
 //! Why: the analyzer processes 40-line overlapping windows, so the same
 //! function can appear in multiple chunks. Without linking, the graph has
 //! many duplicate nodes with different IDs but the same qualified_name.
+//! Additionally, call-edge targets are emitted as unresolved name references
+//! (format `{lang}:{kind}::{callee}`) and must be matched to real node ids
+//! before the graph is returned to consumers.
 //!
 //! What: groups nodes by (language, kind, qualified_name), merges duplicates
-//! into a single node (taking the widest line range), and rewires edges to
-//! point to the canonical node ID. Edges between merged nodes become self-loops
-//! and are removed.
+//! into a single node (taking the widest line range), rewires edges to
+//! point to the canonical node ID, then runs a second pass that resolves
+//! unresolved call-edge targets by name matching against the canonical node set.
+//! Edges between merged nodes become self-loops and are removed.  Call edges
+//! whose callee cannot be found in the node set are preserved with their
+//! unresolved target form so consumers can identify external calls.
 //!
 //! Test: `merge_deduplicates_nodes_with_same_qualified_name` verifies that two
 //! identical fn nodes collapse to one. `self_loops_are_removed_after_merge`
-//! verifies edges between merged nodes are dropped.
+//! verifies edges between merged nodes are dropped.  `resolve_calls_*` tests
+//! verify intra-file, cross-file, and class-method-qualified resolution.
 
 use std::collections::HashMap;
 
+use crate::core::call_resolver::resolve_calls;
 use crate::types::{KgEdge, KgGraph, KgNode};
 
 /// Merge duplicate nodes (same language + kind + qualified_name) and rewire
@@ -124,10 +133,13 @@ pub fn link(graph: KgGraph) -> KgGraph {
         }
     }
 
-    KgGraph {
+    let deduped = KgGraph {
         nodes: canonical_nodes,
         edges: clean_edges,
-    }
+    };
+
+    // Second pass: resolve unresolved call-edge targets.
+    resolve_calls(deduped)
 }
 
 #[cfg(test)]

--- a/crates/trusty-analyze/src/core/mod.rs
+++ b/crates/trusty-analyze/src/core/mod.rs
@@ -15,6 +15,7 @@
 //!   trusty-search
 
 pub mod blame;
+pub mod call_resolver;
 pub mod client;
 pub mod complexity;
 pub mod complexity_ts;

--- a/crates/trusty-analyze/src/lang/adapters/c.rs
+++ b/crates/trusty-analyze/src/lang/adapters/c.rs
@@ -17,10 +17,10 @@
 //! Test: see the `tests` module — covers detection, function/struct/enum
 //! extraction, call scoping, dedup, and `#include` imports.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-c-backed analyzer.
 pub struct CAnalyzer;
@@ -159,7 +159,7 @@ fn recurse(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, paren
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -281,7 +281,7 @@ fn emit_include(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, 
 
 /// Extract `call_expression` nodes from a function body and produce
 /// deduplicated `Calls` edges keyed by callee name.
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -308,7 +308,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("c:Function:{file}:{callee}"),
+            to: build_call_target("c", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/cpp.rs
+++ b/crates/trusty-analyze/src/lang/adapters/cpp.rs
@@ -20,10 +20,10 @@
 //! Test: see the `tests` module — covers detection, function/method/class
 //! extraction, qualified method IDs, call scoping, dedup, `#include` imports.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-cpp-backed analyzer.
 pub struct CppAnalyzer;
@@ -223,7 +223,7 @@ fn recurse(
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -322,7 +322,7 @@ fn emit_include(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, 
     }
 }
 
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -352,7 +352,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("cpp:Function:{file}:{callee}"),
+            to: build_call_target("cpp", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/csharp.rs
+++ b/crates/trusty-analyze/src/lang/adapters/csharp.rs
@@ -18,10 +18,10 @@
 //! Test: see the `tests` module — covers detection, method/class/interface
 //! extraction, qualified IDs, call scoping, dedup, `using` imports.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-c-sharp-backed analyzer.
 pub struct CSharpAnalyzer;
@@ -183,7 +183,7 @@ fn recurse(
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -276,7 +276,7 @@ fn emit_using(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, pa
     });
 }
 
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -312,7 +312,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("csharp:Method:{file}:{callee}"),
+            to: build_call_target("csharp", "Method", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/go.rs
+++ b/crates/trusty-analyze/src/lang/adapters/go.rs
@@ -26,10 +26,10 @@
 //! Test: see `tests` module — covers function, method, struct, imports,
 //! call edges (with weights and caller scoping), and doc comments.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-go-backed analyzer.
 pub struct GoAnalyzer;
@@ -288,7 +288,7 @@ fn emit_top_level(node: Node, src: &[u8], chunk: &CodeChunk, file_id: &str, grap
                 weight: 1.0,
             });
             if let Some(body) = node.child_by_field_name("body") {
-                for edge in extract_calls(body, src, &id, &chunk.file) {
+                for edge in extract_calls(body, src, &id) {
                     graph.edges.push(edge);
                 }
             }
@@ -309,7 +309,7 @@ fn emit_top_level(node: Node, src: &[u8], chunk: &CodeChunk, file_id: &str, grap
                 weight: 1.0,
             });
             if let Some(body) = node.child_by_field_name("body") {
-                for edge in extract_calls(body, src, &id, &chunk.file) {
+                for edge in extract_calls(body, src, &id) {
                     graph.edges.push(edge);
                 }
             }
@@ -397,7 +397,7 @@ fn emit_top_level(node: Node, src: &[u8], chunk: &CodeChunk, file_id: &str, grap
 ///
 /// Test: `go_adapter_extracts_call_edges` and
 /// `go_adapter_deduplicates_repeated_calls` cover the happy paths.
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -430,7 +430,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("go:Function:{file}:{callee}"),
+            to: build_call_target("go", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/java.rs
+++ b/crates/trusty-analyze/src/lang/adapters/java.rs
@@ -23,10 +23,10 @@
 //! Test: `java_extracts_class_and_method` covers a minimal class with one
 //! method.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-java-backed analyzer.
 pub struct JavaAnalyzer;
@@ -276,7 +276,7 @@ fn walk(root: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph) {
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -350,7 +350,7 @@ fn walk(root: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph) {
 ///
 /// Test: `java_adapter_extracts_call_edges` and
 /// `java_adapter_deduplicates_repeated_calls` cover the happy paths.
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -391,7 +391,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("java:Method:{file}:{callee}"),
+            to: build_call_target("java", "Method", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/kotlin.rs
+++ b/crates/trusty-analyze/src/lang/adapters/kotlin.rs
@@ -20,10 +20,10 @@
 //!
 //! Test: see the `tests` module.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-kotlin-ng-backed analyzer.
 pub struct KotlinAnalyzer;
@@ -218,7 +218,7 @@ fn recurse(
                 let mut cursor = node.walk();
                 for child in node.children(&mut cursor) {
                     if child.kind() == "function_body" {
-                        for edge in extract_calls(child, src, &id, &chunk.file) {
+                        for edge in extract_calls(child, src, &id) {
                             graph.edges.push(edge);
                         }
                     }
@@ -316,7 +316,7 @@ fn emit_import(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, p
     });
 }
 
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -350,7 +350,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("kotlin:Function:{file}:{callee}"),
+            to: build_call_target("kotlin", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/php.rs
+++ b/crates/trusty-analyze/src/lang/adapters/php.rs
@@ -24,10 +24,10 @@
 //! IDs), interface/trait emission, call edges (scoped + deduped), and `use`
 //! imports.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-php-backed analyzer.
 pub struct PhpAnalyzer;
@@ -241,7 +241,7 @@ fn recurse(
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -260,7 +260,7 @@ fn recurse(
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -463,7 +463,7 @@ fn emit_import_node(
 /// Test: `php_adapter_extracts_call_edges`,
 /// `php_adapter_deduplicates_repeated_calls`,
 /// `php_method_call_edges_scoped_to_method`.
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -508,7 +508,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("php:Method:{file}:{callee}"),
+            to: build_call_target("php", "Method", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/python.rs
+++ b/crates/trusty-analyze/src/lang/adapters/python.rs
@@ -25,10 +25,10 @@
 //! basic happy paths; `python_adapter_extracts_call_edges` and
 //! `python_adapter_deduplicates_repeated_calls` cover call-edge extraction.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-python-backed analyzer.
 pub struct PythonAnalyzer;
@@ -255,7 +255,7 @@ fn walk(root: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph) {
             weight: 1.0,
         });
         if let Some(body) = def.child_by_field_name("body") {
-            for edge in extract_calls(body, src, &id, &chunk.file) {
+            for edge in extract_calls(body, src, &id) {
                 graph.edges.push(edge);
             }
         }
@@ -444,7 +444,7 @@ fn emit_imports(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, 
 /// unique callee with `weight = call_count as f32`.
 /// Test: `python_adapter_extracts_call_edges` and
 /// `python_adapter_deduplicates_repeated_calls` cover the happy paths.
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -479,7 +479,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("python:Function:{file}:{callee}"),
+            to: build_call_target("python", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/ruby.rs
+++ b/crates/trusty-analyze/src/lang/adapters/ruby.rs
@@ -23,10 +23,10 @@
 //! Test: see the `tests` module — covers detection, methods, singleton
 //! methods, modules, call extraction, deduplication, and require imports.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-ruby-backed analyzer.
 pub struct RubyAnalyzer;
@@ -237,7 +237,7 @@ fn recurse(
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -266,7 +266,7 @@ fn recurse(
                     weight: 1.0,
                 });
                 if let Some(body) = node.child_by_field_name("body") {
-                    for edge in extract_calls(body, src, &id, &chunk.file) {
+                    for edge in extract_calls(body, src, &id) {
                         graph.edges.push(edge);
                     }
                 }
@@ -397,7 +397,7 @@ fn emit_require(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, 
 /// `weight = call_count as f32`.
 /// Test: `ruby_adapter_extracts_call_edges`,
 /// `ruby_adapter_deduplicates_repeated_calls`.
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -433,7 +433,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("ruby:Method:{file}:{callee}"),
+            to: build_call_target("ruby", "Method", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/rust.rs
+++ b/crates/trusty-analyze/src/lang/adapters/rust.rs
@@ -21,10 +21,10 @@
 //! Test: `rust_analyzer_extracts_function` parses a minimal `fn hello() {}`
 //! chunk and asserts a Function node is produced.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-rust-backed analyzer.
 pub struct RustAnalyzer;
@@ -185,7 +185,7 @@ fn walk_rust(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph) {
                     // Extract direct calls from the function body and emit
                     // deduplicated Calls edges from this fn to each callee.
                     if let Some(body) = child_by_field(node, "body") {
-                        for edge in extract_calls(body, src, &id, &chunk.file) {
+                        for edge in extract_calls(body, src, &id) {
                             graph.edges.push(edge);
                         }
                     }
@@ -328,7 +328,7 @@ fn has_test_attribute(node: Node, src: &[u8]) -> bool {
 ///
 /// Test: `rust_adapter_extracts_call_edges` and
 /// `rust_adapter_deduplicates_repeated_calls` cover the happy paths.
-fn extract_calls(fn_body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(fn_body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -361,7 +361,7 @@ fn extract_calls(fn_body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("rust:Function:{file}:{callee}"),
+            to: build_call_target("rust", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/scala.rs
+++ b/crates/trusty-analyze/src/lang/adapters/scala.rs
@@ -20,10 +20,10 @@
 //!
 //! Test: see the `tests` module.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-scala-backed analyzer.
 pub struct ScalaAnalyzer;
@@ -203,7 +203,7 @@ fn recurse(
                 // Body can be a `block` (def f() = { ... }) or any expression
                 // (def f() = expr). Scan all children — extract_calls stops at
                 // nested function/class boundaries so this is safe.
-                for edge in extract_calls(node, src, &id, &chunk.file) {
+                for edge in extract_calls(node, src, &id) {
                     graph.edges.push(edge);
                 }
             }
@@ -305,7 +305,7 @@ fn emit_import(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, p
     });
 }
 
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -343,7 +343,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("scala:Function:{file}:{callee}"),
+            to: build_call_target("scala", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/swift.rs
+++ b/crates/trusty-analyze/src/lang/adapters/swift.rs
@@ -18,10 +18,10 @@
 //!
 //! Test: see the `tests` module.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-swift-backed analyzer.
 pub struct SwiftAnalyzer;
@@ -209,7 +209,7 @@ fn recurse(
                 result
             });
             if let Some(body) = body {
-                for edge in extract_calls(body, src, &id, &chunk.file) {
+                for edge in extract_calls(body, src, &id) {
                     graph.edges.push(edge);
                 }
             }
@@ -315,7 +315,7 @@ fn emit_import(node: Node, src: &[u8], chunk: &CodeChunk, graph: &mut KgGraph, p
     });
 }
 
-fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -348,7 +348,7 @@ fn extract_calls(body: Node, src: &[u8], caller_id: &str, file: &str) -> Vec<KgE
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("swift:Function:{file}:{callee}"),
+            to: build_call_target("swift", "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/adapters/typescript.rs
+++ b/crates/trusty-analyze/src/lang/adapters/typescript.rs
@@ -10,10 +10,10 @@
 //! Test: `ts_analyzer_extracts_function` parses `function hello() {}` and
 //! asserts the Function node is produced.
 
+use crate::lang::call_target::build_call_target;
+use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 use crate::types::{CodeChunk, KgEdge, KgEdgeKind, KgGraph, KgNode, KgNodeKind};
 use tree_sitter::{Node, Parser};
-
-use crate::lang::{LanguageAnalyzer, StaticAnalysisResult};
 
 /// tree-sitter-typescript-backed analyzer (also handles TSX).
 pub struct TypeScriptAnalyzer;
@@ -284,7 +284,7 @@ fn emit_named_callable(
         weight: 1.0,
     });
     if let Some(body) = node.child_by_field_name("body") {
-        for edge in extract_calls(body, src, &id, &chunk.file, language) {
+        for edge in extract_calls(body, src, &id, language) {
             graph.edges.push(edge);
         }
     }
@@ -328,7 +328,7 @@ fn emit_arrow_var_declarators(
             weight: 1.0,
         });
         if let Some(body) = val.child_by_field_name("body") {
-            for edge in extract_calls(body, src, &id, &chunk.file, language) {
+            for edge in extract_calls(body, src, &id, language) {
                 graph.edges.push(edge);
             }
         }
@@ -414,13 +414,7 @@ fn emit_class_heritage(
 ///
 /// Test: `ts_adapter_extracts_call_edges` and
 /// `ts_adapter_deduplicates_repeated_calls` cover the happy paths.
-fn extract_calls(
-    body: Node,
-    src: &[u8],
-    caller_id: &str,
-    file: &str,
-    language: &str,
-) -> Vec<KgEdge> {
+fn extract_calls(body: Node, src: &[u8], caller_id: &str, language: &str) -> Vec<KgEdge> {
     use std::collections::HashMap;
 
     let mut counts: HashMap<String, u32> = HashMap::new();
@@ -459,7 +453,7 @@ fn extract_calls(
         .into_iter()
         .map(|(callee, count)| KgEdge {
             from: caller_id.to_string(),
-            to: format!("{language}:Function:{file}:{callee}"),
+            to: build_call_target(language, "Function", &callee),
             kind: KgEdgeKind::Calls,
             weight: count as f32,
         })

--- a/crates/trusty-analyze/src/lang/call_target.rs
+++ b/crates/trusty-analyze/src/lang/call_target.rs
@@ -1,0 +1,109 @@
+//! Shared helpers for building and recognising unresolved call-edge target ids.
+//!
+//! Why: The former per-adapter pattern `format!("{lang}:{kind}:{caller_file}:{bare_callee}")`
+//! produced targets that could never match node ids (wrong file, missing class
+//! qualifier). By centralising the target-id format here every adapter emits
+//! the same shape and the linker's `resolve_calls` pass has a single sentinel
+//! to key on.
+//!
+//! What: A call-edge target is written as `{lang}:{kind}::{callee}` (two
+//! consecutive colons indicate an unresolved file).  The linker later replaces
+//! these with real node ids using a name-keyed lookup.  Genuinely external
+//! targets (callee not found in the node set) keep the sentinel form so
+//! consumers can distinguish "internal but unresolved" from "external".
+//!
+//! Test: `unresolved_target_roundtrips` verifies that `build_call_target` and
+//! `parse_call_target` are inverses.  Resolution behaviour is tested in
+//! `core::linker`.
+
+/// Build the unresolved call-edge target id for a callee.
+///
+/// Why: Every adapter must emit the *same* target format so the linker can
+/// find and resolve them in one pass.  Having a single function prevents the
+/// two id schemes (node id vs edge-target id) from drifting independently.
+///
+/// What: Produces `"{lang}:{kind}::{callee}"` — the double-colon marks the
+/// file component as unresolved.  The kind string should match the `{kind:?}`
+/// display used when minting node ids (e.g. `"Function"` or `"Method"`).
+///
+/// Test: See `unresolved_target_roundtrips` below; also exercised by
+/// `linker::tests::resolve_calls_*` tests.
+#[inline]
+pub fn build_call_target(lang: &str, kind: &str, callee: &str) -> String {
+    format!("{lang}:{kind}::{callee}")
+}
+
+/// A parsed unresolved call-edge target.
+#[derive(Debug, PartialEq)]
+pub struct UnresolvedTarget<'a> {
+    pub lang: &'a str,
+    pub kind: &'a str,
+    pub callee: &'a str,
+}
+
+/// Try to parse an unresolved target produced by `build_call_target`.
+///
+/// Why: The linker needs to detect which edge targets are synthetic
+/// (unresolved) vs already-canonical node ids.
+///
+/// What: Returns `Some(UnresolvedTarget)` if `s` has the form
+/// `"{lang}:{kind}::{callee}"` (three colon-delimited components where the
+/// second segment is empty), `None` otherwise.
+///
+/// Test: `unresolved_target_roundtrips` covers the happy path; non-matching
+/// strings return `None`.
+pub fn parse_call_target(s: &str) -> Option<UnresolvedTarget<'_>> {
+    // Fast path: rule out strings that can't have "::" (two colons together)
+    if !s.contains("::") {
+        return None;
+    }
+    // Expected shape: "lang:kind::callee"
+    // Split on ':' — we want exactly 4 components: lang, kind, "", callee.
+    let parts: Vec<&str> = s.splitn(4, ':').collect();
+    if parts.len() == 4 && parts[2].is_empty() {
+        Some(UnresolvedTarget {
+            lang: parts[0],
+            kind: parts[1],
+            callee: parts[3],
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unresolved_target_roundtrips() {
+        let t = build_call_target("rust", "Function", "my_fn");
+        assert_eq!(t, "rust:Function::my_fn");
+        let parsed = parse_call_target(&t).expect("should parse");
+        assert_eq!(parsed.lang, "rust");
+        assert_eq!(parsed.kind, "Function");
+        assert_eq!(parsed.callee, "my_fn");
+    }
+
+    #[test]
+    fn real_node_id_does_not_parse() {
+        // A real node id has a file component, not an empty one.
+        assert!(parse_call_target("rust:Function:src/lib.rs:my_fn").is_none());
+        assert!(parse_call_target("csharp:Method:Foo.cs:MyClass:MyMethod").is_none());
+    }
+
+    #[test]
+    fn non_target_strings_return_none() {
+        assert!(parse_call_target("").is_none());
+        assert!(parse_call_target("hello").is_none());
+        assert!(parse_call_target("a:b:c").is_none());
+    }
+
+    #[test]
+    fn callee_with_colons_roundtrips() {
+        // Edge case: callee that itself contains colons (e.g. a scoped Rust path)
+        let t = build_call_target("rust", "Function", "std::mem::drop");
+        let parsed = parse_call_target(&t).expect("should parse");
+        assert_eq!(parsed.callee, "std::mem::drop");
+    }
+}

--- a/crates/trusty-analyze/src/lang/mod.rs
+++ b/crates/trusty-analyze/src/lang/mod.rs
@@ -13,6 +13,7 @@
 //! and asserts at least one expected node is extracted.
 
 pub mod adapters;
+pub mod call_target;
 pub mod detection;
 pub mod ext_map;
 #[allow(clippy::module_inception)]


### PR DESCRIPTION
## Summary

- **Root cause**: All 13 tree-sitter adapters built call-edge targets as `{lang}:{kind}:{caller_file}:{bare_callee}`, which never matched the class-qualified node IDs (`{lang}:{Kind}:{file}:{Class}:{Method}`) produced during node creation. Resolution rate was ~4.8% — the call graph was functionally broken.
- **Fix**: Two-pass approach — adapters now emit unresolved sentinel targets via a shared `build_call_target()` helper (`{lang}:{kind}::{callee}`, double-colon = unresolved), then a new `resolve_calls()` pass after `linker::link()` resolves them by indexing nodes on `(language, bare_name)` and applying same-file preference for ambiguous matches.
- **New files**: `lang/call_target.rs` (sentinel builder/parser shared across all adapters), `core/call_resolver.rs` (resolution pass + 6 tests covering intra-file, cross-file, class-method-qualified, external, and high-resolution-rate scenarios).

## Changed files

| File | Change |
|------|--------|
| `lang/call_target.rs` | NEW — `build_call_target` / `parse_call_target` shared helpers |
| `core/call_resolver.rs` | NEW — `resolve_calls()` pass + 6 unit tests |
| `core/linker.rs` | Call `resolve_calls()` as second pass after deduplication |
| `core/mod.rs` | Register `call_resolver` module |
| `lang/mod.rs` | Register `call_target` module |
| `lang/adapters/{rust,python,java,go,typescript,javascript,c,cpp,csharp,kotlin,php,ruby,scala,swift}.rs` | Replace `format!` literal targets with `build_call_target()` |

## Test plan

- [x] `cargo test -p trusty-analyze` — 417 lib + 25 bin + 2 integration = all pass
- [x] `cargo clippy -p trusty-analyze --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — no drift
- [x] `bash scripts/check_line_cap.sh` — 0 violations (168 allowlisted OK)
- [x] `cargo check` (workspace-wide) — clean

Key new test assertions:
- `resolve_calls_class_method_qualified` — directly exercises the #913 regression: a C# `Process` method calling `Save` on a different class resolves to the fully-qualified node ID `csharp:Method:Repository.cs:Repository:Save`
- `resolve_calls_high_resolution_rate` — 3/4 synthetic calls resolve (was ~5% before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)