### PR TITLE
fix(trusty-analyze): run_diagnostics signals tools-unavailable vs clean (closes #915)

### DIFF
--- a/crates/trusty-analyze/src/core/mod.rs
+++ b/crates/trusty-analyze/src/core/mod.rs
@@ -56,7 +56,7 @@ pub use review::{
 };
 pub use scip::{extract_kg_from_scip, index_to_graph as scip_index_to_graph, ScipIngestSummary};
 pub use tool_registry::{global_registry, ToolRegistry};
-pub use tools::{Severity as DiagnosticSeverity, StaticTool, ToolDiagnostic};
+pub use tools::{DiagnosticsReport, Severity as DiagnosticSeverity, StaticTool, ToolDiagnostic};
 
 #[cfg(test)]
 mod integration_tests;

--- a/crates/trusty-analyze/src/core/tool_registry.rs
+++ b/crates/trusty-analyze/src/core/tool_registry.rs
@@ -25,10 +25,21 @@ use crate::core::tool_impls::{
 use crate::core::tools::{StaticTool, ToolDiagnostic};
 
 /// Holds the set of available external static-analysis tools, indexed by the
-/// language tag each one analyzes.
+/// language tag each one analyzes, plus the names of tools that were probed
+/// but not found on `PATH`.
+///
+/// Why: storing unavailable tool names alongside available ones lets callers
+/// distinguish "no tools configured" from "ran tools, found nothing" (#915).
+/// What: `tools` maps language tags to available tools; `unavailable_names`
+/// records the `name()` of every tool whose `is_available()` returned false
+/// at `discover()` / `from_tools()` time.
+/// Test: `discover_records_unavailable_tools` and
+/// `from_tools_records_all_unavailable`.
 pub struct ToolRegistry {
     /// Language tag → list of available tools for that language.
     tools: DashMap<String, Vec<Arc<dyn StaticTool>>>,
+    /// Names of tools that were probed but not available on `PATH`.
+    unavailable_names: Vec<String>,
 }
 
 impl ToolRegistry {
@@ -74,18 +85,20 @@ impl ToolRegistry {
 
     /// Build a registry from an explicit tool list: keep the available ones and
     /// bucket each under its primary [`language`](StaticTool::language) plus any
-    /// [`aliases`](StaticTool::aliases).
+    /// [`aliases`](StaticTool::aliases). Records the names of unavailable tools.
     ///
     /// Why: separating the fanout from the hardcoded tool list lets tests
     /// exercise alias registration with a synthetic always-available tool,
     /// without depending on which binaries happen to be installed on the host.
-    /// What: probes `is_available()`, then for each kept tool inserts an `Arc`
-    /// clone into every bucket it claims.
-    /// Test: `aliases_register_tool_under_every_bucket`.
+    /// Recording unavailable names supports the #915 signal (callers can
+    /// distinguish "ran but clean" from "tools not installed").
+    /// What: probes `is_available()`, keeps available tools in buckets, and
+    /// records the `name()` of each unavailable tool in `unavailable_names`.
+    /// Test: `aliases_register_tool_under_every_bucket`,
+    /// `from_tools_records_all_unavailable`.
     fn from_tools(all_tools: Vec<Arc<dyn StaticTool>>) -> Self {
-        let registry = ToolRegistry {
-            tools: DashMap::new(),
-        };
+        let mut unavailable_names = Vec::new();
+        let registry_tools = DashMap::new();
 
         for tool in all_tools {
             if tool.is_available() {
@@ -98,18 +111,21 @@ impl ToolRegistry {
                 // a multi-language linter (e.g. biome → typescript + javascript)
                 // is reachable from each bucket its files route to.
                 for lang in std::iter::once(tool.language()).chain(tool.aliases().iter().copied()) {
-                    registry
-                        .tools
+                    registry_tools
                         .entry(lang.to_string())
-                        .or_default()
+                        .or_insert_with(Vec::new)
                         .push(Arc::clone(&tool));
                 }
             } else {
                 tracing::debug!(tool = tool.name(), "static tool not available");
+                unavailable_names.push(tool.name().to_string());
             }
         }
 
-        registry
+        ToolRegistry {
+            tools: registry_tools,
+            unavailable_names,
+        }
     }
 
     /// All available tools registered for `lang`. Empty if none.
@@ -123,6 +139,19 @@ impl ToolRegistry {
     /// All language tags that have at least one available tool.
     pub fn languages(&self) -> Vec<String> {
         self.tools.iter().map(|e| e.key().clone()).collect()
+    }
+
+    /// Names of tools that were probed at registry construction time but whose
+    /// backing binary was not found on `PATH`.
+    ///
+    /// Why: exposes the "tools not installed" signal (#915) so callers can
+    /// distinguish "ran tools, found nothing" from "no tools available at all".
+    /// What: returns a reference to the stored unavailable-name list. The list
+    /// contains one entry per tool whose `is_available()` returned false during
+    /// `from_tools()`.
+    /// Test: `from_tools_records_all_unavailable` in this module's tests.
+    pub fn unavailable_names(&self) -> &[String] {
+        &self.unavailable_names
     }
 
     /// Run every available file-scoped tool for `lang` against `file` and
@@ -286,6 +315,97 @@ mod tests {
         fn run(&self, _file: &Path, _content: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
             Ok(Vec::new())
         }
+    }
+
+    /// Unavailable tools must be recorded under `unavailable_names()` so
+    /// callers can distinguish "no tools configured" from "ran, found nothing".
+    ///
+    /// Why: #915 — an all-unavailable host returns zero diagnostics with no
+    /// signal, indistinguishable from "code is clean." Recording unavailable
+    /// names is the fix.
+    /// What: builds a registry from one always-available and one always-absent
+    /// tool. Asserts `unavailable_names()` contains exactly the absent tool.
+    /// Test: this test.
+    #[test]
+    fn from_tools_records_all_unavailable() {
+        struct AlwaysAvailable;
+        impl StaticTool for AlwaysAvailable {
+            fn name(&self) -> &str {
+                "always-on"
+            }
+            fn language(&self) -> &str {
+                "rust"
+            }
+            fn is_available(&self) -> bool {
+                true
+            }
+            fn run(&self, _: &Path, _: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
+                Ok(Vec::new())
+            }
+        }
+
+        struct NeverAvailable;
+        impl StaticTool for NeverAvailable {
+            fn name(&self) -> &str {
+                "never-on"
+            }
+            fn language(&self) -> &str {
+                "python"
+            }
+            fn is_available(&self) -> bool {
+                false
+            }
+            fn run(&self, _: &Path, _: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let r = ToolRegistry::from_tools(vec![Arc::new(AlwaysAvailable), Arc::new(NeverAvailable)]);
+
+        assert_eq!(r.unavailable_names(), &["never-on"]);
+        // The available tool is NOT in unavailable_names.
+        assert!(
+            !r.unavailable_names().contains(&"always-on".to_string()),
+            "available tool must not appear in unavailable_names"
+        );
+        // The available tool is still reachable in the tools bucket.
+        assert_eq!(r.tools_for("rust").len(), 1);
+        // The absent tool has no bucket.
+        assert!(r.tools_for("python").is_empty());
+    }
+
+    /// A fully-discovered registry on a host with no linters still reports an
+    /// empty `unavailable_names` if all known tools are found (the happy-path
+    /// sanity check).
+    ///
+    /// Why: ensures `unavailable_names()` doesn't accidentally leak available
+    /// tools when all are installed.
+    /// What: builds a registry with only always-available tools; asserts
+    /// `unavailable_names()` is empty.
+    /// Test: this test.
+    #[test]
+    fn from_tools_available_only_has_empty_unavailable() {
+        struct OnlyAvailable;
+        impl StaticTool for OnlyAvailable {
+            fn name(&self) -> &str {
+                "on-tool"
+            }
+            fn language(&self) -> &str {
+                "go"
+            }
+            fn is_available(&self) -> bool {
+                true
+            }
+            fn run(&self, _: &Path, _: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
+                Ok(Vec::new())
+            }
+        }
+        let r = ToolRegistry::from_tools(vec![Arc::new(OnlyAvailable)]);
+        assert!(
+            r.unavailable_names().is_empty(),
+            "no unavailable tools expected, got: {:?}",
+            r.unavailable_names()
+        );
     }
 
     #[test]

--- a/crates/trusty-analyze/src/core/tools.rs
+++ b/crates/trusty-analyze/src/core/tools.rs
@@ -49,6 +49,50 @@ pub struct ToolDiagnostic {
     pub message: String,
 }
 
+/// Result envelope for the `run_diagnostics` endpoint and `run_diagnostics_blocking` function.
+///
+/// Why: callers cannot distinguish "no linters installed" from "code is clean"
+/// when the result is only `Vec<ToolDiagnostic>`. Recording which tools were
+/// actually invoked vs. which were absent from `PATH` lets callers surface
+/// "tools unavailable" as a distinct signal rather than silently empty results.
+/// (#915)
+///
+/// What: carries the full diagnostics list together with two disjoint name
+/// lists — `tools_run` (invoked successfully) and `tools_unavailable` (known
+/// but not on `PATH`). Both lists contain deduplicated tool names. A fully
+/// clean run has `tools_run` non-empty and `tools_unavailable` empty; a fully
+/// unconfigured host has `tools_run` empty and `tools_unavailable` non-empty.
+///
+/// Test: `diagnostics_report_marks_unavailable_tool` and
+/// `diagnostics_report_clean_run` in `diagnostics_dispatch` tests.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DiagnosticsReport {
+    /// Tool names that were discovered on `PATH` and invoked during this run.
+    pub tools_run: Vec<String>,
+    /// Tool names that are known to the registry but whose binary was not
+    /// found on `PATH` at daemon startup and therefore could not be invoked.
+    pub tools_unavailable: Vec<String>,
+    /// All findings emitted by the tools that ran.
+    pub diagnostics: Vec<ToolDiagnostic>,
+}
+
+impl DiagnosticsReport {
+    /// Construct an empty report with no tools run and no diagnostics.
+    ///
+    /// Why: callers that encounter an early-exit condition (empty corpus,
+    /// scratch-dir failure) need a well-formed empty report rather than
+    /// having to construct one manually.
+    /// What: returns a `DiagnosticsReport` with all vectors empty.
+    /// Test: exercised implicitly by all failure-path tests.
+    pub fn empty() -> Self {
+        Self {
+            tools_run: Vec::new(),
+            tools_unavailable: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
 /// Plugin interface for an external static-analysis tool.
 ///
 /// Implementations shell out to a binary (clippy, ruff, ...), parse its

--- a/crates/trusty-analyze/src/service/diagnostics_dispatch.rs
+++ b/crates/trusty-analyze/src/service/diagnostics_dispatch.rs
@@ -17,7 +17,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::core::ToolDiagnostic;
+use crate::core::{DiagnosticsReport, ToolDiagnostic};
 
 /// Abs-to-rel mapping: given the absolute on-disk path of a diagnostic and
 /// the `(rel, real)` pairs for the current language bucket, return the
@@ -34,9 +34,12 @@ use crate::core::ToolDiagnostic;
 /// absolute (which it always is — it is `Path::new(root).join(rel)`), so any
 /// case where exact equality fails (symlink resolution, case differences on a
 /// case-insensitive FS like macOS) silently drops all diagnostics.
-/// Test: `abs_to_rel_exact`, `abs_to_rel_suffix_match`, and
-/// `abs_to_rel_case_insensitive_returns_none` below.
-fn abs_to_rel<'a>(abs_diag_file: &str, rel_real_pairs: &'a [(String, String)]) -> Option<&'a str> {
+/// Test: `abs_to_rel_exact_match`, `abs_to_rel_suffix_match_absolute_real`,
+/// and `abs_to_rel_no_match_returns_none` in `diagnostics_dispatch_tests.rs`.
+pub(crate) fn abs_to_rel<'a>(
+    abs_diag_file: &str,
+    rel_real_pairs: &'a [(String, String)],
+) -> Option<&'a str> {
     for (rel, real) in rel_real_pairs {
         // Exact match — the common production path.
         if abs_diag_file == real.as_str() || abs_diag_file == rel.as_str() {
@@ -62,8 +65,9 @@ fn abs_to_rel<'a>(abs_diag_file: &str, rel_real_pairs: &'a [(String, String)]) -
 /// tool registry.
 ///
 /// Why: the production call site uses the global (lazily-discovered) registry
-/// of whatever tools are installed on the host. This wrapper keeps the
-/// existing call signature unchanged so no callers need updating.
+/// of whatever tools are installed on the host. Returns a `DiagnosticsReport`
+/// so callers can distinguish "ran tools, found nothing" from "no tools
+/// available" (#915).
 /// What: delegates to `run_diagnostics_blocking_with_registry` with
 /// `global_registry()`.
 /// Test: `run_diagnostics_blocking_skips_unknown_languages`,
@@ -73,7 +77,7 @@ pub fn run_diagnostics_blocking(
     language_filter: Option<String>,
     tool_filter: Option<Vec<String>>,
     root_path: Option<String>,
-) -> Vec<ToolDiagnostic> {
+) -> DiagnosticsReport {
     use crate::core::global_registry;
     run_diagnostics_blocking_with_registry(
         by_file,
@@ -89,7 +93,8 @@ pub fn run_diagnostics_blocking(
 /// Why: tests need to inject a synthetic `ToolRegistry` (containing fake
 /// project-scoped tools that count `run_project` invocations) to assert the
 /// skip-when-no-root contract is actually enforced rather than just not
-/// panicking.
+/// panicking. Returns `DiagnosticsReport` to distinguish "ran tools, found
+/// nothing" from "no tools available" (#915).
 /// What: same dispatch logic as the production path, but accepts any
 /// `&ToolRegistry` instead of always using `global_registry()`.
 ///   1. Groups `by_file` entries by language (honouring `language_filter`).
@@ -107,26 +112,36 @@ pub fn run_diagnostics_blocking(
 ///      `diag.file` (absolute) back to the index-relative rel via
 ///      `abs_to_rel`. Drop diagnostics that don't map to any indexed file.
 ///      When `root_path` is `None`, log at info and skip (graceful degradation).
-///   5. Returns the merged `Vec<ToolDiagnostic>`.
+///   5. Returns a `DiagnosticsReport` with `tools_run`, `tools_unavailable`,
+///      and `diagnostics` populated.
 ///
 /// Test: `run_diagnostics_blocking_project_scoped_skips_when_no_root` uses
 /// this directly with a `FakeProjectScopedTool` registry.
 /// `run_diagnostics_blocking_with_registry_two_files_same_basename` (below)
 /// proves the per-file subdir isolation prevents basename collisions.
+/// `report_marks_unavailable_tool` proves that tools absent from PATH are
+/// reported under `tools_unavailable`.
 pub fn run_diagnostics_blocking_with_registry(
     by_file: HashMap<String, String>,
     language_filter: Option<String>,
     tool_filter: Option<Vec<String>>,
     root_path: Option<String>,
     registry: &crate::core::tool_registry::ToolRegistry,
-) -> Vec<ToolDiagnostic> {
+) -> DiagnosticsReport {
     use crate::lang::LanguageDetector;
+
+    // Collect unavailable tool names from the registry upfront.
+    let tools_unavailable: Vec<String> = registry.unavailable_names().to_vec();
 
     let scratch = match tempfile::tempdir() {
         Ok(d) => d,
         Err(e) => {
             tracing::warn!("failed to create scratch dir for diagnostics: {e}");
-            return Vec::new();
+            return DiagnosticsReport {
+                tools_run: Vec::new(),
+                tools_unavailable,
+                diagnostics: Vec::new(),
+            };
         }
     };
 
@@ -144,7 +159,9 @@ pub fn run_diagnostics_blocking_with_registry(
         by_lang.entry(lang).or_default().push((file, content));
     }
 
-    let mut out = Vec::new();
+    let mut out: Vec<ToolDiagnostic> = Vec::new();
+    // Deduplicated set of tool names that were actually invoked.
+    let mut tools_run_set: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for (lang, file_pairs) in &by_lang {
         let tools = registry.tools_for(lang);
@@ -194,6 +211,7 @@ pub fn run_diagnostics_blocking_with_registry(
                     continue;
                 }
                 for tool in &file_tools {
+                    tools_run_set.insert(tool.name().to_string());
                     let result = tool.run(&path, content);
                     match result {
                         Ok(mut diags) => {
@@ -255,6 +273,7 @@ pub fn run_diagnostics_blocking_with_registry(
             .collect();
 
         for tool in &proj_tools {
+            tools_run_set.insert(tool.name().to_string());
             match tool.run_project(&real_paths) {
                 Ok(diags) => {
                     for mut diag in diags {
@@ -280,181 +299,16 @@ pub fn run_diagnostics_blocking_with_registry(
         }
     }
 
-    out
+    let mut tools_run: Vec<String> = tools_run_set.into_iter().collect();
+    tools_run.sort();
+
+    DiagnosticsReport {
+        tools_run,
+        tools_unavailable,
+        diagnostics: out,
+    }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Why: two files with identical basenames in different index directories
-    /// must each produce diagnostics independently; the basename-collision bug
-    /// (writing `scratch/main.rs` twice) silently drops the first file's
-    /// diagnostics. This test FAILS against `scratch.path().join(&name)` (the
-    /// old code) and PASSES after the per-file `scratch/<idx>/name` fix.
-    ///
-    /// What: injects a `FakeFileScopedTool` that records every `(path, content)`
-    /// it receives. Passes two same-basename Rust files. Asserts: (a) the fake
-    /// tool was called twice, (b) the two paths are distinct, (c) neither
-    /// rel_file mapping is lost (both appear in the output).
-    ///
-    /// Test: this test itself. Does not require any external linter.
-    #[test]
-    fn run_diagnostics_blocking_with_registry_two_files_same_basename() {
-        use crate::core::tool_registry::ToolRegistry;
-        use crate::core::tools::{StaticTool, ToolDiagnostic};
-        use std::path::{Path, PathBuf};
-        use std::sync::{Arc, Mutex};
-
-        /// A fake file-scoped tool that records the (path, content) passed to
-        /// each `run` call and returns a single dummy diagnostic so the caller
-        /// can assert both files' diagnostics survive the pipeline.
-        #[derive(Clone)]
-        struct FakeFileScopedTool {
-            calls: Arc<Mutex<Vec<(PathBuf, String)>>>,
-        }
-        impl StaticTool for FakeFileScopedTool {
-            fn name(&self) -> &str {
-                "fake-file-scoped"
-            }
-            fn language(&self) -> &str {
-                "rust"
-            }
-            fn is_available(&self) -> bool {
-                true
-            }
-            fn is_project_scoped(&self) -> bool {
-                false
-            }
-            fn run(&self, file: &Path, content: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
-                self.calls
-                    .lock()
-                    .unwrap()
-                    .push((file.to_path_buf(), content.to_string()));
-                // Return one diagnostic so the caller can assert it maps back
-                // to the correct index-relative path.
-                Ok(vec![ToolDiagnostic {
-                    file: file.to_string_lossy().into_owned(),
-                    line: 1,
-                    col: 1,
-                    message: "fake".into(),
-                    severity: crate::core::tools::Severity::Warning,
-                    tool: "fake-file-scoped".into(),
-                    code: None,
-                }])
-            }
-            fn run_project(&self, _files: &[PathBuf]) -> anyhow::Result<Vec<ToolDiagnostic>> {
-                Ok(Vec::new())
-            }
-        }
-
-        let calls = Arc::new(Mutex::new(Vec::<(PathBuf, String)>::new()));
-        let tool = FakeFileScopedTool {
-            calls: Arc::clone(&calls),
-        };
-        let registry = ToolRegistry::from_tools_for_test(vec![Arc::new(tool)]);
-
-        let mut by_file = HashMap::new();
-        by_file.insert("src/a/main.rs".to_string(), "fn a() {}".to_string());
-        by_file.insert("src/b/main.rs".to_string(), "fn b() {}".to_string());
-
-        let diags = run_diagnostics_blocking_with_registry(
-            by_file, None, // language_filter
-            None, // tool_filter
-            None, // root_path
-            &registry,
-        );
-
-        let recorded = calls.lock().unwrap();
-        // Both files must have been sent to the tool.
-        assert_eq!(
-            recorded.len(),
-            2,
-            "expected 2 tool invocations (one per file), got {}; \
-             basename collision likely dropped one",
-            recorded.len()
-        );
-        // The two scratch paths must be distinct — collision means same path.
-        let path0 = &recorded[0].0;
-        let path1 = &recorded[1].0;
-        assert_ne!(
-            path0, path1,
-            "the two files were written to the same scratch path ({path0:?}); \
-             per-file subdir isolation is broken"
-        );
-        // Both diagnostics must survive back-mapping (neither was lost).
-        assert_eq!(
-            diags.len(),
-            2,
-            "expected 2 diagnostics in output (one per file), got {}; \
-             one file's diagnostics were silently dropped",
-            diags.len()
-        );
-        // Verify both index-relative paths appear in the output.
-        let files: Vec<&str> = diags.iter().map(|d| d.file.as_str()).collect();
-        assert!(
-            files.contains(&"src/a/main.rs"),
-            "src/a/main.rs missing from output: {files:?}"
-        );
-        assert!(
-            files.contains(&"src/b/main.rs"),
-            "src/b/main.rs missing from output: {files:?}"
-        );
-    }
-
-    #[test]
-    fn abs_to_rel_exact_match() {
-        // Exact equality on the `real` path (the most common production case).
-        let pairs = vec![(
-            "src/Foo.cs".to_string(),
-            "/home/user/proj/src/Foo.cs".to_string(),
-        )];
-        assert_eq!(
-            abs_to_rel("/home/user/proj/src/Foo.cs", &pairs),
-            Some("src/Foo.cs")
-        );
-    }
-
-    #[test]
-    fn abs_to_rel_suffix_match_absolute_real() {
-        // The suffix branch must work even when `real` is an absolute path.
-        // Previously, forming `"/{real}"` produced `"//home/…"` — an
-        // impossible match for any absolute Roslyn-emitted path. With the
-        // `trim_start_matches('/')` fix, the format string becomes
-        // `"/home/user/proj/src/Bar.cs"` and suffix matching works correctly.
-        let pairs = vec![(
-            "src/Bar.cs".to_string(),
-            "/home/user/proj/src/Bar.cs".to_string(),
-        )];
-        // A path that shares the full suffix of `real` (e.g. a different
-        // mount-point prefix) should match via the component-anchored suffix.
-        // real_suffix = "home/user/proj/src/Bar.cs"
-        // format = "/home/user/proj/src/Bar.cs"
-        // abs ends_with "/home/user/proj/src/Bar.cs" → true
-        assert_eq!(
-            abs_to_rel("/symlink-root/home/user/proj/src/Bar.cs", &pairs),
-            Some("src/Bar.cs"),
-        );
-        // A path with no component overlap at all must not match.
-        assert_eq!(abs_to_rel("/completely/different/Qux.cs", &pairs), None);
-    }
-
-    #[test]
-    fn abs_to_rel_no_match_returns_none() {
-        let pairs = vec![(
-            "src/Baz.cs".to_string(),
-            "/home/user/proj/src/Baz.cs".to_string(),
-        )];
-        assert_eq!(abs_to_rel("/completely/different/path.cs", &pairs), None);
-    }
-
-    #[test]
-    fn abs_to_rel_rel_exact_match() {
-        // When the diagnostic file is already a relative path matching `rel`.
-        let pairs = vec![(
-            "src/Qux.cs".to_string(),
-            "/home/user/proj/src/Qux.cs".to_string(),
-        )];
-        assert_eq!(abs_to_rel("src/Qux.cs", &pairs), Some("src/Qux.cs"));
-    }
-}
+#[path = "diagnostics_dispatch_tests.rs"]
+mod tests;

--- a/crates/trusty-analyze/src/service/diagnostics_dispatch_tests.rs
+++ b/crates/trusty-analyze/src/service/diagnostics_dispatch_tests.rs
@@ -1,0 +1,261 @@
+//! Tests for `diagnostics_dispatch` — extracted to keep the production module
+//! under the 500-line cap (#610).
+//!
+//! Why: the dispatch module grew with #915 (tools_run / tools_unavailable
+//! signal tests) to the point where inline tests would push it past 500 lines.
+//! Extracting here follows the `analysis.rs` / `analysis_tests.rs` pattern.
+//! What: exercises `run_diagnostics_blocking_with_registry` via fake tools that
+//! do not require any binary on PATH.
+//! Test: `cargo test -p trusty-analyze` runs all tests in this module.
+
+use std::collections::HashMap;
+
+use super::{abs_to_rel, run_diagnostics_blocking_with_registry};
+
+/// Why: two files with identical basenames in different index directories
+/// must each produce diagnostics independently; the basename-collision bug
+/// (writing `scratch/main.rs` twice) silently drops the first file's
+/// diagnostics. This test FAILS against `scratch.path().join(&name)` (the
+/// old code) and PASSES after the per-file `scratch/<idx>/name` fix.
+///
+/// What: injects a `FakeFileScopedTool` that records every `(path, content)`
+/// it receives. Passes two same-basename Rust files. Asserts: (a) the fake
+/// tool was called twice, (b) the two paths are distinct, (c) neither
+/// rel_file mapping is lost (both appear in the output), and (d) the tool
+/// name appears in `tools_run`.
+///
+/// Test: this test itself. Does not require any external linter.
+#[test]
+fn run_diagnostics_blocking_with_registry_two_files_same_basename() {
+    use crate::core::tool_registry::ToolRegistry;
+    use crate::core::tools::{StaticTool, ToolDiagnostic};
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct FakeFileScopedTool {
+        calls: Arc<Mutex<Vec<(PathBuf, String)>>>,
+    }
+    impl StaticTool for FakeFileScopedTool {
+        fn name(&self) -> &str {
+            "fake-file-scoped"
+        }
+        fn language(&self) -> &str {
+            "rust"
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn is_project_scoped(&self) -> bool {
+            false
+        }
+        fn run(&self, file: &Path, content: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((file.to_path_buf(), content.to_string()));
+            Ok(vec![ToolDiagnostic {
+                file: file.to_string_lossy().into_owned(),
+                line: 1,
+                col: 1,
+                message: "fake".into(),
+                severity: crate::core::tools::Severity::Warning,
+                tool: "fake-file-scoped".into(),
+                code: None,
+            }])
+        }
+        fn run_project(&self, _files: &[PathBuf]) -> anyhow::Result<Vec<ToolDiagnostic>> {
+            Ok(Vec::new())
+        }
+    }
+
+    let calls = Arc::new(Mutex::new(Vec::<(PathBuf, String)>::new()));
+    let tool = FakeFileScopedTool {
+        calls: Arc::clone(&calls),
+    };
+    let registry = ToolRegistry::from_tools_for_test(vec![Arc::new(tool)]);
+
+    let mut by_file = HashMap::new();
+    by_file.insert("src/a/main.rs".to_string(), "fn a() {}".to_string());
+    by_file.insert("src/b/main.rs".to_string(), "fn b() {}".to_string());
+
+    let report = run_diagnostics_blocking_with_registry(by_file, None, None, None, &registry);
+
+    let recorded = calls.lock().unwrap();
+    assert_eq!(
+        recorded.len(),
+        2,
+        "expected 2 tool invocations (one per file), got {}; \
+         basename collision likely dropped one",
+        recorded.len()
+    );
+    let path0 = &recorded[0].0;
+    let path1 = &recorded[1].0;
+    assert_ne!(
+        path0, path1,
+        "the two files were written to the same scratch path ({path0:?}); \
+         per-file subdir isolation is broken"
+    );
+    assert_eq!(
+        report.diagnostics.len(),
+        2,
+        "expected 2 diagnostics in output (one per file), got {}; \
+         one file's diagnostics were silently dropped",
+        report.diagnostics.len()
+    );
+    let files: Vec<&str> = report.diagnostics.iter().map(|d| d.file.as_str()).collect();
+    assert!(
+        files.contains(&"src/a/main.rs"),
+        "src/a/main.rs missing from output: {files:?}"
+    );
+    assert!(
+        files.contains(&"src/b/main.rs"),
+        "src/b/main.rs missing from output: {files:?}"
+    );
+    assert!(
+        report.tools_run.contains(&"fake-file-scoped".to_string()),
+        "expected fake-file-scoped in tools_run: {:?}",
+        report.tools_run
+    );
+}
+
+/// Why: #915 — when no tool binary is on PATH, the report must list those
+/// tools under `tools_unavailable`, not silently return empty diagnostics
+/// that look identical to "code is clean."
+/// What: builds a registry with one unavailable tool; runs dispatch; asserts
+/// `tools_unavailable` contains the tool name and `tools_run` is empty.
+/// Test: this test.
+#[test]
+fn report_marks_unavailable_tool() {
+    use crate::core::tool_registry::ToolRegistry;
+    use crate::core::tools::{StaticTool, ToolDiagnostic};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    struct NeverAvailableTool;
+    impl StaticTool for NeverAvailableTool {
+        fn name(&self) -> &str {
+            "absent-linter"
+        }
+        fn language(&self) -> &str {
+            "rust"
+        }
+        fn is_available(&self) -> bool {
+            false
+        }
+        fn run(&self, _: &Path, _: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
+            Ok(Vec::new())
+        }
+        fn run_project(&self, _: &[PathBuf]) -> anyhow::Result<Vec<ToolDiagnostic>> {
+            Ok(Vec::new())
+        }
+    }
+
+    let registry = ToolRegistry::from_tools_for_test(vec![Arc::new(NeverAvailableTool)]);
+    let mut by_file = HashMap::new();
+    by_file.insert("src/main.rs".to_string(), "fn main() {}".to_string());
+    let report = run_diagnostics_blocking_with_registry(by_file, None, None, None, &registry);
+
+    assert!(report.diagnostics.is_empty(), "no diagnostics expected");
+    assert!(report.tools_run.is_empty(), "no tools should run");
+    assert!(
+        report
+            .tools_unavailable
+            .contains(&"absent-linter".to_string()),
+        "absent-linter must appear in tools_unavailable: {:?}",
+        report.tools_unavailable
+    );
+}
+
+/// Why: a genuinely clean run (tool available, no findings) must show the
+/// tool in `tools_run` and an empty `tools_unavailable`, so callers can
+/// tell the difference from #915's "no tools installed" scenario.
+/// What: builds a registry with a no-findings fake tool; asserts `tools_run`
+/// contains the tool name and `tools_unavailable` is empty.
+/// Test: this test.
+#[test]
+fn report_clean_run_populates_tools_run() {
+    use crate::core::tool_registry::ToolRegistry;
+    use crate::core::tools::{StaticTool, ToolDiagnostic};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    struct CleanTool;
+    impl StaticTool for CleanTool {
+        fn name(&self) -> &str {
+            "clean-linter"
+        }
+        fn language(&self) -> &str {
+            "python"
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn run(&self, _: &Path, _: &str) -> anyhow::Result<Vec<ToolDiagnostic>> {
+            Ok(Vec::new()) // no findings
+        }
+        fn run_project(&self, _: &[PathBuf]) -> anyhow::Result<Vec<ToolDiagnostic>> {
+            Ok(Vec::new())
+        }
+    }
+
+    let registry = ToolRegistry::from_tools_for_test(vec![Arc::new(CleanTool)]);
+    let mut by_file = HashMap::new();
+    by_file.insert("app.py".to_string(), "x = 1".to_string());
+    let report = run_diagnostics_blocking_with_registry(by_file, None, None, None, &registry);
+
+    assert!(report.diagnostics.is_empty(), "no findings expected");
+    assert!(
+        report.tools_unavailable.is_empty(),
+        "tools_unavailable must be empty when tool is installed: {:?}",
+        report.tools_unavailable
+    );
+    assert!(
+        report.tools_run.contains(&"clean-linter".to_string()),
+        "clean-linter must appear in tools_run: {:?}",
+        report.tools_run
+    );
+}
+
+#[test]
+fn abs_to_rel_exact_match() {
+    let pairs = vec![(
+        "src/Foo.cs".to_string(),
+        "/home/user/proj/src/Foo.cs".to_string(),
+    )];
+    assert_eq!(
+        abs_to_rel("/home/user/proj/src/Foo.cs", &pairs),
+        Some("src/Foo.cs")
+    );
+}
+
+#[test]
+fn abs_to_rel_suffix_match_absolute_real() {
+    let pairs = vec![(
+        "src/Bar.cs".to_string(),
+        "/home/user/proj/src/Bar.cs".to_string(),
+    )];
+    assert_eq!(
+        abs_to_rel("/symlink-root/home/user/proj/src/Bar.cs", &pairs),
+        Some("src/Bar.cs"),
+    );
+    assert_eq!(abs_to_rel("/completely/different/Qux.cs", &pairs), None);
+}
+
+#[test]
+fn abs_to_rel_no_match_returns_none() {
+    let pairs = vec![(
+        "src/Baz.cs".to_string(),
+        "/home/user/proj/src/Baz.cs".to_string(),
+    )];
+    assert_eq!(abs_to_rel("/completely/different/path.cs", &pairs), None);
+}
+
+#[test]
+fn abs_to_rel_rel_exact_match() {
+    let pairs = vec![(
+        "src/Qux.cs".to_string(),
+        "/home/user/proj/src/Qux.cs".to_string(),
+    )];
+    assert_eq!(abs_to_rel("src/Qux.cs", &pairs), Some("src/Qux.cs"));
+}

--- a/crates/trusty-analyze/src/service/handlers/analysis.rs
+++ b/crates/trusty-analyze/src/service/handlers/analysis.rs
@@ -332,20 +332,20 @@ pub async fn diagnostics_for_index(
 
     // Heavy work (process spawns, blocking I/O) runs off the async runtime.
     let language_filter = params.language.clone();
-    let all_diagnostics: Vec<crate::core::ToolDiagnostic> =
-        tokio::task::spawn_blocking(move || {
-            crate::service::diagnostics_dispatch::run_diagnostics_blocking(
-                by_file,
-                language_filter,
-                tool_filter,
-                root_path,
-            )
-        })
-        .await
-        .map_err(|e| ApiError::internal(format!("diagnostics task panicked: {e}")))?;
+    let report: crate::core::DiagnosticsReport = tokio::task::spawn_blocking(move || {
+        crate::service::diagnostics_dispatch::run_diagnostics_blocking(
+            by_file,
+            language_filter,
+            tool_filter,
+            root_path,
+        )
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("diagnostics task panicked: {e}")))?;
 
-    let total = all_diagnostics.len();
-    let page: Vec<&crate::core::ToolDiagnostic> = all_diagnostics
+    let total = report.diagnostics.len();
+    let page: Vec<&crate::core::ToolDiagnostic> = report
+        .diagnostics
         .iter()
         .skip(params.offset)
         .take(params.limit)
@@ -360,6 +360,8 @@ pub async fn diagnostics_for_index(
         "limit": params.limit,
         "returned": returned,
         "truncated": truncated,
+        "tools_run": report.tools_run,
+        "tools_unavailable": report.tools_unavailable,
         "diagnostics": page,
     })))
 }

--- a/crates/trusty-analyze/src/service/handlers/analysis_tests.rs
+++ b/crates/trusty-analyze/src/service/handlers/analysis_tests.rs
@@ -50,7 +50,7 @@ fn run_diagnostics_blocking_two_files_same_basename() {
     // We cannot assert on diagnostic counts (no tools in CI), but if the
     // basename collision bug were still present this would panic on the
     // second create_dir_all (or silently overwrite) — not crash-free.
-    let _result = diagnostics_dispatch::run_diagnostics_blocking(by_file, None, None, None);
+    let _report = diagnostics_dispatch::run_diagnostics_blocking(by_file, None, None, None);
     // Reaching here without panic means the subdir isolation works.
 }
 

--- a/crates/trusty-analyze/src/service/tests.rs
+++ b/crates/trusty-analyze/src/service/tests.rs
@@ -130,9 +130,11 @@ fn run_diagnostics_blocking_skips_unknown_languages() {
     // diagnostics pipeline; it should simply be skipped.
     let mut by_file = HashMap::new();
     by_file.insert("notes.txt".to_string(), "hello world".to_string());
-    let diags =
+    let report =
         crate::service::diagnostics_dispatch::run_diagnostics_blocking(by_file, None, None, None);
-    assert!(diags.is_empty());
+    assert!(report.diagnostics.is_empty());
+    // tools_run must be empty when no language-matched tools ran.
+    assert!(report.tools_run.is_empty());
 }
 
 #[test]
@@ -141,13 +143,13 @@ fn run_diagnostics_blocking_respects_language_filter() {
     // installed, because the language filter excludes it.
     let mut by_file = HashMap::new();
     by_file.insert("main.rs".to_string(), "fn main() {}".to_string());
-    let diags = crate::service::diagnostics_dispatch::run_diagnostics_blocking(
+    let report = crate::service::diagnostics_dispatch::run_diagnostics_blocking(
         by_file,
         Some("python".to_string()),
         None,
         None,
     );
-    assert!(diags.is_empty());
+    assert!(report.diagnostics.is_empty());
 }
 
 /// Why: project-scoped tools (e.g. Roslyn) must be completely skipped — not
@@ -206,7 +208,7 @@ fn run_diagnostics_blocking_project_scoped_skips_when_no_root() {
     let mut by_file = std::collections::HashMap::new();
     by_file.insert("src/Foo.cs".to_string(), "class Foo {}".to_string());
 
-    let diags = crate::service::diagnostics_dispatch::run_diagnostics_blocking_with_registry(
+    let report = crate::service::diagnostics_dispatch::run_diagnostics_blocking_with_registry(
         by_file, None, // language_filter
         None, // tool_filter
         None, // root_path — the None case we are testing
@@ -215,8 +217,9 @@ fn run_diagnostics_blocking_project_scoped_skips_when_no_root() {
 
     // Contract: result is empty (no diagnostics produced without a root path).
     assert!(
-        diags.is_empty(),
-        "expected no diagnostics when root_path is None, got: {diags:?}"
+        report.diagnostics.is_empty(),
+        "expected no diagnostics when root_path is None, got: {:?}",
+        report.diagnostics
     );
     // Contract: run_project was never called.
     let calls = *counter.lock().unwrap();


### PR DESCRIPTION
## Summary

- **New `DiagnosticsReport` struct** (`core/tools.rs`) wraps `Vec<ToolDiagnostic>` with two new fields: `tools_run: Vec<String>` (tool names that were invoked) and `tools_unavailable: Vec<String>` (tool names whose binary was absent from PATH at daemon startup). Callers can now distinguish "linters not installed" from "code is clean" — both previously returned an empty diagnostics array with no signal.

- **`ToolRegistry` tracks unavailable tools**: `from_tools()` records the `name()` of every tool whose `is_available()` returned `false`; the new `unavailable_names()` accessor exposes them.

- **HTTP response enriched** (`GET /indexes/{id}/diagnostics`): `tools_run` and `tools_unavailable` fields added to the JSON envelope. Additive, backward-compatible.

- **MCP `run_diagnostics` tool** receives the new fields automatically via the existing HTTP passthrough — no MCP-layer changes needed.

- **`diagnostics_dispatch_tests.rs` extracted** from the inline test module to keep `diagnostics_dispatch.rs` under the 500-line cap (#610).

## New tests

| Test | What it proves |
|---|---|
| `core::tool_registry::tests::from_tools_records_all_unavailable` | Unavailable tools land in `unavailable_names()`, available tools do not |
| `core::tool_registry::tests::from_tools_available_only_has_empty_unavailable` | No false-positive unavailable entries when all tools are installed |
| `service::diagnostics_dispatch::tests::report_marks_unavailable_tool` | End-to-end: absent-linter → `tools_unavailable` non-empty, `tools_run` empty |
| `service::diagnostics_dispatch::tests::report_clean_run_populates_tools_run` | End-to-end: clean tool → `tools_run` non-empty, `tools_unavailable` empty |
| (existing) `run_diagnostics_blocking_with_registry_two_files_same_basename` | Updated to assert `tools_run` contains the fake tool name |

## Test plan

- [x] `cargo check -p trusty-analyze` — compiles
- [x] `cargo test -p trusty-analyze` — 421 lib + 25 bin tests pass, 0 failures
- [x] `cargo clippy -p trusty-analyze --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — no formatting drift
- [x] `bash scripts/check_line_cap.sh` — 168 allowlisted, 0 violations
- [x] `cargo check` (workspace-wide) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)