### PR TITLE
chore(release): trusty-review 0.3.8, trusty-analyze 0.7.0, trusty-search 0.24.4, trusty-memory 0.15.2

### DIFF
--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -7,6 +7,47 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.7.0] — 2026-06-09
+
+### Added
+
+- **`tools_run` / `tools_unavailable` fields in `run_diagnostics` response
+  (#915)** — `DiagnosticsResponse` (HTTP) and the `run_diagnostics` MCP tool
+  result now include:
+  - `tools_run: Vec<String>` — names of analysis tools that executed
+    successfully.
+  - `tools_unavailable: Vec<String>` — names of tools that were requested but
+    could not run (binary missing, feature disabled, index has no data, etc.).
+  These are additive fields; no existing fields were removed or renamed.
+  Callers that previously used an empty `diagnostics` list to infer
+  "nothing ran" now get an explicit signal.
+
+- **Distinguish clean from tools-unavailable in `run_diagnostics` (#915)** —
+  `run_diagnostics` now correctly distinguishes between "all tools ran, no
+  issues found" (clean) and "tools were unavailable so nothing ran"
+  (degraded). Previously both cases returned an empty diagnostics list with
+  no indication of which had occurred.
+
+### Fixed
+
+- **CALLS edge targets resolved via qualified node-id scheme across all 13
+  language adapters (#913)** — the call-graph builder now uses the same
+  qualified `<language>/<path>/<symbol>` node-id scheme that the entity
+  linker uses when resolving callee targets. Previous adapters emitted bare
+  symbol names as CALLS targets, which never matched any node in the graph,
+  resulting in zero CALLS edges in `extract_graph` results. All 13 adapters
+  (Rust, Python, TypeScript, JavaScript, Java, Go, C, C++, C#, Kotlin, PHP,
+  Ruby, Scala) are fixed.
+
+### Note on behavior change
+
+The `omit_content` default changed to `true` in 0.6.0 (released same day).
+Callers that relied on `content` being present in smells responses must add
+`omit_content=false`. This bump to 0.7.0 (MINOR) is driven by the additive
+`tools_run`/`tools_unavailable` response envelope.
+
+---
+
 ## [0.6.0] — 2026-06-09
 
 ### Added

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.6.0"
+version     = "0.7.0"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — trusty-memory
 
+## [0.15.2] — 2026-06-09
+
+### Fixed
+
+- **Lock TOCTOU hardening (#797)** — palace and store operations now acquire
+  the advisory lock before any stat/open sequence, eliminating the window in
+  which a concurrent writer could observe a partially-written file between the
+  existence check and the open.
+
+- **`libc::kill` replaces unsafe `set_var` in tests (#797)** — test helpers
+  that previously used `std::env::set_var` (unsound in multi-threaded tests)
+  now signal the daemon via `libc::kill`, making the test suite safe to run
+  with `--test-threads > 1`. Test isolation improved.
+
+- **Module documentation corrected (#797)** — doc comments that referenced
+  internal implementation details now reflect the current architecture.
+
+---
+
+## [0.15.1] — 2026-06-05
+
+### Fixed
+
+- Minor stability fixes after the redb 4.x migration; no user-visible API changes.
+
+---
+
 ## [0.15.0] — 2026-06-03
 
 ### Added

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.8] — 2026-06-09
+
+### Fixed
+
+- **Verdict calibration: stop Medium findings from over-escalating the rolled-up
+  verdict (#1015)** — advisory Medium findings no longer push the rolled-up
+  verdict above `APPROVE`. The severity-floor escalation that converts a
+  grade-derived verdict to `REQUEST_CHANGES` now only fires for High/Critical
+  findings; Medium findings preserve the grade verdict. Prevents mechanical
+  `REQUEST_CHANGES` on reviews where all findings are advisory Medium or lower.
+
+---
+
 ## [0.3.6] — 2026-06-07
 
 ### Added

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.7"
+version     = "0.3.8"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,33 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.24.4] — 2026-06-09
+
+### Fixed
+
+- **Embed-pool sidecar calls isolated from the async executor to prevent
+  accept-loop starvation (#1017)** — `embed_batch` calls to the stdio sidecar
+  are now dispatched via `tokio::task::spawn_blocking` so they cannot occupy
+  async worker threads. Under sustained embed load the executor no longer
+  starves the axum accept-loop, eliminating the class of request-timeout
+  failures seen in issue #1017.
+
+- **Graceful `admin_stop` without corpus corruption (#829)** — the admin-stop
+  endpoint now flushes in-flight writes and closes redb handles before
+  signalling the daemon to exit. Previously a `POST /admin/stop` could race
+  with an ongoing reindex commit and leave the corpus in an inconsistent state.
+
+- **Non-blocking `canonicalize` in index registration path (#829)** —
+  `std::fs::canonicalize` is now wrapped in `tokio::task::spawn_blocking` so
+  a slow or unreachable filesystem path no longer stalls the async acceptor
+  while resolving symlinks.
+
+- **PID-slot reclamation (#829)** — stale PID lockfiles from previously crashed
+  daemon instances are now detected and removed at startup, preventing spurious
+  "daemon already running" errors after an unclean shutdown.
+
+---
+
 ## [0.24.3] — 2026-06-09
 
 ### Fixed

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.24.3"
+version = "0.24.4"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version bumps for four crates — all fixes already merged to main in PRs #1054/#1055/#1056/#1058/#1059/#1060.

- **trusty-review 0.3.7 → 0.3.8** (patch): verdict calibration fix — advisory Medium findings no longer over-escalate rolled-up verdict (#1015, PR #1055)
- **trusty-analyze 0.6.0 → 0.7.0** (MINOR): CALLS edge target resolution fixed across all 13 adapters (#913, PR #1056); `tools_run`/`tools_unavailable` additive response fields + clean-vs-unavailable distinction in `run_diagnostics` (#915, PR #1058)
- **trusty-search 0.24.3 → 0.24.4** (patch): embed-pool executor isolation (#1017, PR #1054); graceful admin_stop + PID-slot reclamation + non-blocking canonicalize (#829, PR #1060)
- **trusty-memory 0.15.1 → 0.15.2** (patch): lock TOCTOU hardening, unsafe `set_var` → `libc::kill` in tests, module doc corrections (#797, PR #1059)

No code changes — version bumps + changelog entries only. trusty-common is unchanged at 0.14.3.

## Test plan

- [ ] CI passes (lint/test/line-cap)
- [ ] After merge: create 4 tags, publish to crates.io in order, verify versions propagate, reinstall binaries, restart daemons