### PR TITLE
fix(trusty-search): observable embedder-stall state on /health + clearer skip message (#1003)

### DIFF
--- a/crates/trusty-search/src/commands/reindex_ui.rs
+++ b/crates/trusty-search/src/commands/reindex_ui.rs
@@ -601,13 +601,12 @@ pub fn format_timing_breakdown(
                     .bold(),
             ));
         } else if !defer_embed {
+            let msg = "SKIPPED (embedder unresponsive or unreachable \u{2014} \
+                 sidecar may be stalled or not running; BM25-only until re-indexed)";
             out.push_str(&format!(
                 "    {} {}\n",
                 "embed  ".dimmed(),
-                "SKIPPED (embedder sidecar not running/unreachable \u{2014} \
-                 index is BM25-only until re-indexed)"
-                    .yellow()
-                    .bold(),
+                msg.yellow().bold(),
             ));
         }
         // defer_embed=true → suppress; background note covers this case.

--- a/crates/trusty-search/src/commands/start.rs
+++ b/crates/trusty-search/src/commands/start.rs
@@ -1159,16 +1159,12 @@ pub async fn handle_start(
                     install_state.install_embedderd_pid_slot(slot).await;
                 }
                 install_state.install_embedder(Arc::clone(&embedder)).await;
-                // Issue #41 Phase 1: build the embedder worker pool now that
-                // the model is loaded. The pool shares the same `Arc<dyn
-                // Embedder>` so it does not double the model memory; what
-                // it adds is priority-aware dispatch (interactive search
-                // queries jump ahead of background reindex batches) and
-                // a bounded queue depth that protects the daemon from
-                // unbounded fan-out.
-                let pool = std::sync::Arc::new(
-                    crate::service::embed_pool::EmbedPool::with_autotune(Arc::clone(&embedder)),
-                );
+                // Issue #41: worker pool — priority-aware dispatch, bounded queue.
+                // Issue #1003: stall tracker wired so health_handler can detect ANE stalls.
+                let tracker = Arc::clone(&install_state.embedder_stall_tracker);
+                use crate::service::embed_pool::EmbedPool;
+                let base = EmbedPool::with_autotune(Arc::clone(&embedder));
+                let pool = std::sync::Arc::new(base.with_stall_tracker(tracker));
                 install_state.install_embed_pool(pool).await;
                 tracing::info!("embedder ready — vector lane online");
                 let prior = load_prior_index_count(); // Issue #873: FDA regression baseline.

--- a/crates/trusty-search/src/service/embed_pool.rs
+++ b/crates/trusty-search/src/service/embed_pool.rs
@@ -160,6 +160,15 @@ pub struct EmbedPool {
     /// (from `interactive_tx`/`background_tx` drop) signals each worker to exit
     /// its loop before the join completes.
     _worker_threads: Vec<std::thread::JoinHandle<()>>,
+    /// Embedder stall tracker shared with AppState and surfaced on `/health`
+    /// (issue #1003).
+    ///
+    /// Why: `embed()` is the single choke-point for all embedding calls;
+    /// recording success/timeout here keeps the tracking logic in one place
+    /// and avoids threading a callback through the `Embedder` trait.
+    /// What: `record_success()` on `Ok`, `record_timeout()` on `Err`.
+    /// `None` in unit tests that construct `EmbedPool` without a tracker.
+    stall_tracker: Option<Arc<crate::service::stall_tracker::EmbedderStallTracker>>,
 }
 
 impl EmbedPool {
@@ -225,7 +234,24 @@ impl EmbedPool {
             workers,
             in_flight,
             _worker_threads: worker_threads,
+            stall_tracker: None,
         }
+    }
+
+    /// Attach a stall tracker that `embed()` will update on each call
+    /// (issue #1003).
+    ///
+    /// Why: wiring the tracker here keeps `embed()` as the single choke-point
+    /// while allowing tests that build `EmbedPool` directly to skip the tracker.
+    /// What: stores an `Arc` clone; `embed()` calls `record_success()` or
+    /// `record_timeout()` after each call returns.
+    /// Test: indirectly covered by the AppState plumbing + health endpoint tests.
+    pub fn with_stall_tracker(
+        mut self,
+        tracker: Arc<crate::service::stall_tracker::EmbedderStallTracker>,
+    ) -> Self {
+        self.stall_tracker = Some(tracker);
+        self
     }
 
     /// Construct a pool using the autotuned worker count.
@@ -302,6 +328,16 @@ impl EmbedPool {
         self.in_flight.fetch_sub(1, Ordering::Relaxed);
         metrics::gauge!("trusty_embed_pool_utilisation")
             .set(self.in_flight.load(Ordering::Relaxed) as f64);
+
+        // Issue #1003: update the stall tracker so /health can surface
+        // "stalled" vs "ready" when the sidecar is alive but unresponsive.
+        if let Some(tracker) = &self.stall_tracker {
+            if result.is_ok() {
+                tracker.record_success();
+            } else {
+                tracker.record_timeout();
+            }
+        }
 
         result
     }

--- a/crates/trusty-search/src/service/embed_pool_tests.rs
+++ b/crates/trusty-search/src/service/embed_pool_tests.rs
@@ -148,6 +148,7 @@ async fn dropping_pool_after_send_returns_error() {
         workers: 0,
         in_flight: Arc::new(AtomicUsize::new(0)),
         _worker_threads: vec![],
+        stall_tracker: None,
     };
     let result = closed_pool
         .embed(vec!["x".into()], RequestPriority::Interactive)

--- a/crates/trusty-search/src/service/mod.rs
+++ b/crates/trusty-search/src/service/mod.rs
@@ -24,6 +24,7 @@ pub mod reindex;
 pub mod roots_registry;
 pub mod server;
 pub mod shutdown_flush;
+pub mod stall_tracker;
 pub mod ui;
 pub mod walker;
 pub mod warm_boot;

--- a/crates/trusty-search/src/service/server/health.rs
+++ b/crates/trusty-search/src/service/server/health.rs
@@ -13,16 +13,34 @@ use std::sync::Arc;
 
 use super::state::{SearchAppState, WarmBootSummary};
 
-/// Response shape for `GET /health` (issue #34 + #35 + #38 + #282 + #537).
+/// Response shape for `GET /health` (issue #34 + #35 + #38 + #282 + #537 +
+/// #1003).
 #[derive(Serialize)]
 pub(super) struct HealthResponse {
     pub(super) status: &'static str,
     pub(super) version: &'static str,
     pub(super) indexes: usize,
     pub(super) uptime_secs: u64,
+    /// Embedder functional status (issue #1003).
+    ///
+    /// Values:
+    /// - `"ready"` — embedder loaded and recent embed calls succeeded.
+    /// - `"stalled"` — sidecar alive but recent embed calls timed out; daemon
+    ///   falls back to BM25-only until the sidecar recovers. Distinguished from
+    ///   "down/unreachable" (process missing) and "error" (init failure).
+    /// - `"initializing"` — embedder model still loading.
+    /// - `"error"` — embedder init task failed or timed out.
     pub(super) embedder: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) embedder_error: Option<String>,
+    /// Seconds since the last successful embed call (issue #1003).
+    /// Absent when the embedder has never produced a successful result.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) embedder_last_ok_secs_ago: Option<u64>,
+    /// Count of consecutive/recent embed timeouts since the last success
+    /// (issue #1003). Non-zero indicates the sidecar is alive but stalled.
+    /// Resets to 0 when the next embed call succeeds.
+    pub(super) embedder_recent_timeout_count: u32,
     /// Process RSS in MB. On `try_lock` contention returns the last
     /// successfully-sampled value; `0` only before the very first sample.
     pub(super) rss_mb: u64,
@@ -92,8 +110,24 @@ pub(super) async fn health_handler(
     // watch-based `is_embedder_ready()` (no lock) or `try_read()` / `try_lock()`
     // (returns immediately rather than parking the handler).
     let embedder_error = state.current_embedder_error();
+    // Issue #1003: read stall state for the functional health check.
+    // These reads are lock-free (AtomicU64/U32) — safe to call from the
+    // health handler without risking the 30 s stall that blocked #1006.
+    let embedder_last_ok_secs_ago = state.embedder_stall_tracker.last_ok_secs_ago();
+    let embedder_recent_timeout_count = state.embedder_stall_tracker.recent_timeout_count();
     let embedder_status = if state.is_embedder_ready() {
-        "ready"
+        // The sidecar is alive and the slot is populated — but is it actually
+        // responding? Issue #1003: if recent timeouts > 0 and the last ok was
+        // more than 30 s ago, the sidecar is stalled (alive but unresponsive).
+        // Threshold: > 0 timeouts with no success yet (last_ok_secs_ago = None)
+        // OR timeout count >= 1 and no recovery. We use >= 1 to be sensitive —
+        // a single 30 s timeout on an interactive query is already disruptive.
+        let stalled = embedder_recent_timeout_count > 0;
+        if stalled {
+            "stalled"
+        } else {
+            "ready"
+        }
     } else if state.embedder.is_some()
         || state
             .embedder_slot
@@ -187,6 +221,9 @@ pub(super) async fn health_handler(
         uptime_secs: state.started_at.elapsed().as_secs(),
         embedder: embedder_status,
         embedder_error,
+        // Issue #1003: stall-observability fields.
+        embedder_last_ok_secs_ago,
+        embedder_recent_timeout_count,
         rss_mb,
         rss_limit_mb,
         disk_bytes,

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -41,6 +41,8 @@ mod tests_list;
 #[cfg(test)]
 mod tests_search;
 #[cfg(test)]
+mod tests_stall;
+#[cfg(test)]
 mod tests_state;
 
 // Re-export the public surface that was previously at `crate::service::server::*`.

--- a/crates/trusty-search/src/service/server/state.rs
+++ b/crates/trusty-search/src/service/server/state.rs
@@ -343,6 +343,21 @@ pub struct SearchAppState {
     /// it via `f32::from_bits()` on contention.
     /// Test: `health_rss_fallback_on_contention` in tests_state.rs.
     pub last_cpu_pct_bits: Arc<std::sync::atomic::AtomicU32>,
+    /// Embedder functional-health tracker (issue #1003).
+    ///
+    /// Why: the sidecar process can be alive (so `is_embedder_ready()` returns
+    /// `true`) but stalled — returning zero embed results for tens of minutes
+    /// during an ANE/CoreML session freeze. Without this tracker `/health`
+    /// silently reports `"embedder":"ready"` while BM25-only fallback is in
+    /// effect. `EmbedderStallTracker` records success/timeout events from the
+    /// actual embed call path so `/health` can surface `"stalled"` with
+    /// `embedder_last_ok_secs_ago` and `embedder_recent_timeout_count`.
+    ///
+    /// What: an `Arc<EmbedderStallTracker>` written by `EmbedPool::embed()` and
+    /// read by `health_handler`. The Arc is cloned into the embed pool on
+    /// construction via `install_embed_pool`.
+    /// Test: `health_reports_stalled_embedder` in tests_health.rs.
+    pub embedder_stall_tracker: Arc<crate::service::stall_tracker::EmbedderStallTracker>,
 }
 
 /// Per-boot summary of warm-boot index loading, surfaced on `GET /health`.

--- a/crates/trusty-search/src/service/server/state_impl.rs
+++ b/crates/trusty-search/src/service/server/state_impl.rs
@@ -73,6 +73,9 @@ impl SearchAppState {
             prior_index_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             last_rss_mb: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             last_cpu_pct_bits: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            embedder_stall_tracker: Arc::new(
+                crate::service::stall_tracker::EmbedderStallTracker::new(),
+            ),
             shutdown_tx: Arc::new(shutdown_tx),
         }
     }

--- a/crates/trusty-search/src/service/server/tests_stall.rs
+++ b/crates/trusty-search/src/service/server/tests_stall.rs
@@ -1,0 +1,215 @@
+//! Tests for embedder stall observability on `GET /health` (issue #1003).
+//!
+//! Why: the ANE/CoreML stall scenario (sidecar alive but unresponsive) was
+//! previously invisible — `/health` reported `embedder:ready` even while
+//! embed calls timed out for 42 minutes. These tests verify that:
+//!   1. `EmbedderStallTracker` correctly records and clears stall state.
+//!   2. `health_handler` reports `embedder:"stalled"` when the tracker has
+//!      recent timeouts, and `embedder:"ready"` after recovery.
+//!   3. The new health fields (`embedder_last_ok_secs_ago`,
+//!      `embedder_recent_timeout_count`) are present in the response.
+
+use super::*;
+use crate::core::registry::IndexRegistry;
+use crate::service::stall_tracker::EmbedderStallTracker;
+use axum::extract::State;
+use axum::Json;
+use std::sync::Arc;
+
+/// Build a minimal `SearchAppState` with an embedder in "ready" state
+/// (bypasses the actual ONNX model) and returns it alongside the stall tracker.
+fn ready_state_with_tracker() -> (Arc<SearchAppState>, Arc<EmbedderStallTracker>) {
+    use crate::core::embed::MockEmbedder;
+    let registry = IndexRegistry::new();
+    let state =
+        Arc::new(SearchAppState::new(registry).with_embedder(Arc::new(MockEmbedder::new(4))));
+    let tracker = Arc::clone(&state.embedder_stall_tracker);
+    (state, tracker)
+}
+
+/// `health_handler` must report `embedder:"ready"` and
+/// `embedder_recent_timeout_count:0` when no embed errors have been recorded.
+///
+/// Why: baseline correctness — a newly-started daemon with a live embedder
+/// must not falsely report degraded state.
+/// What: build a ready state, call health_handler, assert fields.
+/// Test: this test.
+#[tokio::test]
+async fn health_reports_ready_when_no_timeouts() {
+    let (state, _tracker) = ready_state_with_tracker();
+    let Json(resp) = health_handler(State(state)).await;
+    assert_eq!(resp.embedder, "ready", "no timeouts → must be ready");
+    assert_eq!(
+        resp.embedder_recent_timeout_count, 0,
+        "zero timeouts expected"
+    );
+    // Before any embed call, last_ok_secs_ago is absent.
+    assert!(
+        resp.embedder_last_ok_secs_ago.is_none(),
+        "no embed call yet → last_ok_secs_ago must be absent"
+    );
+}
+
+/// `health_handler` must report `embedder:"stalled"` when the tracker has
+/// recorded one or more recent timeouts.
+///
+/// Why: the primary fix for issue #1003 — the stall must be visible on
+/// `/health` so operators can detect the degraded BM25-only fallback without
+/// tailing logs.
+/// What: record two timeouts, call health_handler, assert `"stalled"`.
+/// Test: this test.
+#[tokio::test]
+async fn health_reports_stalled_after_embed_timeouts() {
+    let (state, tracker) = ready_state_with_tracker();
+
+    // Simulate two embed-call timeouts (as the embed pool records them).
+    tracker.record_timeout();
+    tracker.record_timeout();
+
+    let Json(resp) = health_handler(State(state)).await;
+    assert_eq!(
+        resp.embedder, "stalled",
+        "recent timeouts → embedder must be \"stalled\"; got {:?}",
+        resp.embedder
+    );
+    assert_eq!(
+        resp.embedder_recent_timeout_count, 2,
+        "two timeouts must be reflected in the count"
+    );
+    // No successful embed → last_ok_secs_ago absent.
+    assert!(
+        resp.embedder_last_ok_secs_ago.is_none(),
+        "no success yet → last_ok_secs_ago must be absent"
+    );
+}
+
+/// After a stall self-clears (embedder responds again), `health_handler`
+/// must flip back to `embedder:"ready"`.
+///
+/// Why: the ANE stall self-heals once fresh requests kick the backend; the
+/// health endpoint must reflect recovery immediately (not linger as "stalled").
+/// What: record timeout then success; assert `"ready"` and count == 0.
+/// Test: this test.
+#[tokio::test]
+async fn health_recovers_to_ready_after_stall_clears() {
+    let (state, tracker) = ready_state_with_tracker();
+
+    // Stall scenario.
+    tracker.record_timeout();
+    tracker.record_timeout();
+    tracker.record_timeout();
+
+    // Stall self-heals — next embed succeeds.
+    tracker.record_success();
+
+    let Json(resp) = health_handler(State(state)).await;
+    assert_eq!(
+        resp.embedder, "ready",
+        "after success the stall must clear; got {:?}",
+        resp.embedder
+    );
+    assert_eq!(
+        resp.embedder_recent_timeout_count, 0,
+        "success must reset timeout count to 0"
+    );
+    // After a success, last_ok_secs_ago should be present and near-zero.
+    let ago = resp
+        .embedder_last_ok_secs_ago
+        .expect("last_ok_secs_ago must be present after a success");
+    assert!(
+        ago < 5,
+        "last_ok_secs_ago should be near-zero seconds; got {ago}"
+    );
+}
+
+/// `embedder_recent_timeout_count` and `embedder_last_ok_secs_ago` must be
+/// present as JSON fields in the serialized response.
+///
+/// Why: integration contract — external monitors scrape `/health` as JSON;
+/// field presence must be stable.
+/// What: serialize `HealthResponse` to JSON and verify field presence.
+/// Test: this test.
+#[test]
+fn health_response_contains_stall_fields() {
+    use crate::service::server::health::HealthResponse;
+    use crate::service::server::state::WarmBootSummary;
+    use serde_json::Value;
+
+    let resp = HealthResponse {
+        status: "ok",
+        version: "0.0.0",
+        indexes: 1,
+        uptime_secs: 10,
+        embedder: "stalled",
+        embedder_error: None,
+        embedder_last_ok_secs_ago: Some(120),
+        embedder_recent_timeout_count: 3,
+        rss_mb: 0,
+        rss_limit_mb: 0,
+        disk_bytes: 0,
+        cpu_pct: 0.0,
+        embedder_info: None,
+        embedderd_rss_mb: None,
+        background_reindex_queue_depth: 0,
+        update_available: None,
+        warmboot_summary: WarmBootSummary::default(),
+    };
+
+    let json: Value = serde_json::to_value(&resp).expect("serialize");
+    assert_eq!(
+        json["embedder"].as_str(),
+        Some("stalled"),
+        "embedder field must be 'stalled'"
+    );
+    assert_eq!(
+        json["embedder_recent_timeout_count"].as_u64(),
+        Some(3),
+        "timeout count must be present"
+    );
+    assert_eq!(
+        json["embedder_last_ok_secs_ago"].as_u64(),
+        Some(120),
+        "last_ok_secs_ago must be present when Some"
+    );
+}
+
+/// When `embedder_last_ok_secs_ago` is `None`, the field must be absent from
+/// the serialized JSON (not null).
+///
+/// Why: `#[serde(skip_serializing_if = "Option::is_none")]` must be applied
+/// — absent means "never succeeded", null would be misleading.
+/// What: serialize with `None` and assert the key is missing.
+/// Test: this test.
+#[test]
+fn health_response_omits_last_ok_when_none() {
+    use crate::service::server::health::HealthResponse;
+    use crate::service::server::state::WarmBootSummary;
+    use serde_json::Value;
+
+    let resp = HealthResponse {
+        status: "ok",
+        version: "0.0.0",
+        indexes: 0,
+        uptime_secs: 0,
+        embedder: "initializing",
+        embedder_error: None,
+        embedder_last_ok_secs_ago: None,
+        embedder_recent_timeout_count: 0,
+        rss_mb: 0,
+        rss_limit_mb: 0,
+        disk_bytes: 0,
+        cpu_pct: 0.0,
+        embedder_info: None,
+        embedderd_rss_mb: None,
+        background_reindex_queue_depth: 0,
+        update_available: None,
+        warmboot_summary: WarmBootSummary::default(),
+    };
+
+    let json: Value = serde_json::to_value(&resp).expect("serialize");
+    assert!(
+        json.get("embedder_last_ok_secs_ago").is_none(),
+        "embedder_last_ok_secs_ago must be absent (not null) when None; \
+         json={json}"
+    );
+}

--- a/crates/trusty-search/src/service/stall_tracker.rs
+++ b/crates/trusty-search/src/service/stall_tracker.rs
@@ -1,0 +1,208 @@
+//! Embedder stall tracker — shared atomic state updated whenever an embed call
+//! succeeds or times out.
+//!
+//! Why (issue #1003): the `trusty-embedderd` sidecar can stall for tens of
+//! minutes (ANE/CoreML session stall on Apple Silicon) while remaining alive
+//! and reachable. Before this module, `/health` reported `"embedder":"ready"`
+//! throughout the stall because the sidecar process was still running.
+//! `EmbedderStallTracker` captures the FUNCTIONAL state (did the last embed
+//! call time out?) so the health handler can surface `"stalled"` with
+//! supporting fields (`embedder_last_ok_secs_ago`,
+//! `embedder_recent_timeout_count`).
+//!
+//! What: four lock-free atomics:
+//!   - `last_ok_unix_secs`   — Unix seconds of the most recent successful embed.
+//!     `0` = never succeeded.
+//!   - `recent_timeout_count` — rolling count of recent timeouts, incremented on
+//!     each error and reset to 0 on each success.
+//!   - `total_ok_count`      — lifetime successful-embed counter.
+//!   - `total_timeout_count` — lifetime embed-timeout counter.
+//!
+//! Test: `stall_tracker_records_success_and_timeout` and
+//! `stall_tracker_reset_on_success` in the `tests` submodule.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Lock-free tracker for embedder response health (issue #1003).
+///
+/// Why: avoids any mutex in the critical embed path; all fields are
+/// independently atomic so reads on the health handler path are always
+/// wait-free. The `recent_timeout_count` is conservative: it increments on
+/// every timeout-flavoured error and resets on every success. Operators can
+/// treat count > 0 as "degraded" and count == 0 as "healthy".
+///
+/// What: wraps four `AtomicU64`/`AtomicU32` counters. `record_success` and
+/// `record_timeout` are the only write paths.
+///
+/// Test: `stall_tracker_records_success_and_timeout` in `tests` below.
+#[derive(Debug, Default)]
+pub struct EmbedderStallTracker {
+    /// Unix seconds of the last successful `embed_batch` call.
+    /// `0` = embed has never returned successfully.
+    last_ok_unix_secs: AtomicU64,
+    /// Rolling count of consecutive/recent timeouts; reset to 0 on success.
+    recent_timeout_count: AtomicU32,
+    /// Lifetime count of successful embed calls (for metrics / debugging).
+    total_ok_count: AtomicU64,
+    /// Lifetime count of embed-timeout errors.
+    total_timeout_count: AtomicU64,
+}
+
+impl EmbedderStallTracker {
+    /// Construct a new tracker with zeroed counters.
+    ///
+    /// Why: default construction is fine; no side effects at creation time.
+    /// What: all atomics start at 0.
+    /// Test: `stall_tracker_records_success_and_timeout`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one successful embed response.
+    ///
+    /// Why: resets `recent_timeout_count` so the stall signal clears as soon as
+    /// the embedder recovers (the ANE stall self-heals once fresh requests arrive).
+    /// What: stores the current Unix second into `last_ok_unix_secs`, atomically
+    /// resets `recent_timeout_count` to 0, and increments `total_ok_count`.
+    /// Test: `stall_tracker_reset_on_success`.
+    pub fn record_success(&self) {
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        self.last_ok_unix_secs.store(now_secs, Ordering::Relaxed);
+        self.recent_timeout_count.store(0, Ordering::Relaxed);
+        self.total_ok_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one embed-timeout (or other transient failure) event.
+    ///
+    /// Why: increments the rolling counter so `/health` can surface
+    /// `embedder_recent_timeout_count > 0` as a degraded signal.
+    /// What: increments both `recent_timeout_count` and `total_timeout_count`.
+    /// `last_ok_unix_secs` is intentionally NOT updated.
+    /// Test: `stall_tracker_records_success_and_timeout`.
+    pub fn record_timeout(&self) {
+        self.recent_timeout_count.fetch_add(1, Ordering::Relaxed);
+        self.total_timeout_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Seconds elapsed since the last successful embed call, or `None` when the
+    /// embedder has never returned a successful result yet.
+    ///
+    /// Why: surfaced on `/health` as `embedder_last_ok_secs_ago` so monitoring
+    /// can alert when the gap exceeds a threshold (e.g. > 5 min = stalled).
+    /// What: reads `last_ok_unix_secs`, compares to now. Returns `None` when
+    /// the stored value is 0 (never succeeded).
+    /// Test: `stall_tracker_records_success_and_timeout`.
+    pub fn last_ok_secs_ago(&self) -> Option<u64> {
+        let stored = self.last_ok_unix_secs.load(Ordering::Relaxed);
+        if stored == 0 {
+            return None;
+        }
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(stored);
+        Some(now_secs.saturating_sub(stored))
+    }
+
+    /// Number of consecutive/recent embed timeouts since the last success.
+    ///
+    /// Why: the primary signal for `/health` to flip `embedder` to `"stalled"`.
+    /// A non-zero count means the embedder returned zero usable results on the
+    /// last N embed attempts — even if the sidecar process is alive.
+    /// What: loads `recent_timeout_count` with `Relaxed` ordering.
+    /// Test: `stall_tracker_records_success_and_timeout`.
+    pub fn recent_timeout_count(&self) -> u32 {
+        self.recent_timeout_count.load(Ordering::Relaxed)
+    }
+}
+
+// Cheap clone so `SearchAppState` can be cloned (it holds `Arc<…>`).
+// `EmbedderStallTracker` itself is always wrapped in `Arc`.
+impl Clone for EmbedderStallTracker {
+    fn clone(&self) -> Self {
+        // Snapshot atomics for the copy — only used in tests.
+        Self {
+            last_ok_unix_secs: AtomicU64::new(self.last_ok_unix_secs.load(Ordering::Relaxed)),
+            recent_timeout_count: AtomicU32::new(self.recent_timeout_count.load(Ordering::Relaxed)),
+            total_ok_count: AtomicU64::new(self.total_ok_count.load(Ordering::Relaxed)),
+            total_timeout_count: AtomicU64::new(self.total_timeout_count.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+/// Convenience type alias used throughout the server module.
+pub type StallTrackerArc = Arc<EmbedderStallTracker>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies that `record_timeout` increments counters and `record_success`
+    /// resets `recent_timeout_count` while setting `last_ok_unix_secs`.
+    ///
+    /// Why: core correctness — if the reset does not happen, `/health` keeps
+    /// showing `"stalled"` after the embedder recovers.
+    /// What: sequence of record_timeout / record_success calls; assert counts.
+    /// Test: this test.
+    #[test]
+    fn stall_tracker_records_success_and_timeout() {
+        let t = EmbedderStallTracker::new();
+
+        // Initially everything is zero.
+        assert_eq!(t.recent_timeout_count(), 0);
+        assert!(t.last_ok_secs_ago().is_none(), "never succeeded yet");
+
+        // Two timeouts.
+        t.record_timeout();
+        t.record_timeout();
+        assert_eq!(t.recent_timeout_count(), 2);
+        assert!(t.last_ok_secs_ago().is_none(), "still no success");
+
+        // One success resets the recent count.
+        t.record_success();
+        assert_eq!(t.recent_timeout_count(), 0, "reset on success");
+        let ago = t.last_ok_secs_ago().expect("success should set timestamp");
+        // In a unit test this runs fast — should be < 5s.
+        assert!(ago < 5, "last_ok_secs_ago should be near-zero; got {ago}");
+    }
+
+    /// Verifies that `record_success` after multiple timeouts resets to 0.
+    ///
+    /// Why: guards the specific ANE stall self-heal scenario — after the stall
+    /// clears and the first embed succeeds, `/health` should immediately return
+    /// `"ready"` again.
+    /// What: record 5 timeouts, then 1 success, assert count == 0.
+    /// Test: this test.
+    #[test]
+    fn stall_tracker_reset_on_success() {
+        let t = EmbedderStallTracker::new();
+        for _ in 0..5 {
+            t.record_timeout();
+        }
+        assert_eq!(t.recent_timeout_count(), 5);
+        t.record_success();
+        assert_eq!(t.recent_timeout_count(), 0, "must reset on first success");
+    }
+
+    /// Verifies that calling `record_timeout` never touches `last_ok_unix_secs`.
+    ///
+    /// Why: `last_ok_secs_ago` must remain `None` until a real success arrives;
+    /// a stalled sidecar should not falsely claim "last ok 0 seconds ago".
+    /// What: record only timeouts; assert `last_ok_secs_ago` returns `None`.
+    /// Test: this test.
+    #[test]
+    fn stall_tracker_timeout_does_not_set_ok_timestamp() {
+        let t = EmbedderStallTracker::new();
+        t.record_timeout();
+        t.record_timeout();
+        assert!(
+            t.last_ok_secs_ago().is_none(),
+            "timeout must not set the ok timestamp"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1003.

Two concrete defects fixed:

1. **`/health` observability gap** — while the ANE/CoreML stall has the sidecar alive but returning zero responses, `/health` silently reported `"embedder":"ready"`. Now reports:
   - `"embedder":"stalled"` when `recent_timeout_count > 0`
   - `embedder_last_ok_secs_ago` (omitted when never succeeded — no phantom null)
   - `embedder_recent_timeout_count` (always present; 0 = healthy)
   Stall auto-clears to `"ready"` on the first successful embed (ANE self-heal path).

2. **Misleading skip message** — reindex UI printed `"SKIPPED (embedder sidecar not running/unreachable)"` for ALL zero-vector outcomes, including the alive-but-stalled case. Now reads `"SKIPPED (embedder unresponsive or unreachable — sidecar may be stalled or not running; BM25-only until re-indexed)"`.

## Changes

- `service/stall_tracker.rs` (new): `EmbedderStallTracker` with 4 lock-free atomics (`AtomicU64` / `AtomicU32`). `record_success()` resets `recent_timeout_count` to 0 atomically; `record_timeout()` increments both counters. All reads in `health_handler` are non-blocking (issue #1006 compliance).
- `service/embed_pool.rs`: `with_stall_tracker()` builder; `embed()` calls `record_success()` / `record_timeout()` after each call.
- `service/server/state.rs` + `state_impl.rs`: new `embedder_stall_tracker: Arc<EmbedderStallTracker>` field.
- `service/server/health.rs`: two new `HealthResponse` fields; `embedder_status` logic extended with `"stalled"` branch.
- `commands/start.rs`: wires `with_stall_tracker()` when building the pool.
- `commands/reindex_ui.rs`: improved skip message.
- `service/server/tests_stall.rs` (new): 5 integration tests.
- `service/stall_tracker.rs` (unit tests inline): 3 unit tests.

## Test plan

- [x] `SKIP_UI_BUILD=1 cargo test -p trusty-search` — all tests pass
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p trusty-search` — no drift
- [x] `bash scripts/check_line_cap.sh` — 168 allowlisted, 0 violations — OK
- [x] All pre-commit hooks pass (trim whitespace, secrets, line-cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)