### PR TITLE
feat(trusty-review): opt-in test-coverage grading/gating dimension

### DIFF
--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -93,6 +93,8 @@ struct TomlFile {
     context: ContextFileConfig,
     #[serde(default)]
     voice: voice::VoiceFileConfig,
+    #[serde(default)]
+    coverage: crate::coverage::CoverageFileConfig,
 }
 
 /// Global service configuration for trusty-review.
@@ -228,6 +230,14 @@ pub struct ReviewConfig {
     /// (default-on per issue #756 spec: "universal/safe").
     /// The config file key is `[voice] principles = false`.
     pub voice_principles: bool,
+
+    // ── Coverage gating (issue #1014) ─────────────────────────────────────
+    /// Resolved coverage-gating policy.
+    ///
+    /// `TRUSTY_REVIEW_COVERAGE_ENABLED=true` enables coverage gating (off by
+    /// default).  All fields configurable via env vars or `[coverage]` TOML table.
+    /// When `enabled = false`, the coverage pipeline is a complete no-op.
+    pub coverage: crate::coverage::CoveragePolicy,
 }
 
 impl ReviewConfig {
@@ -252,6 +262,8 @@ impl ReviewConfig {
         let file_verification = toml_file.as_ref().map(|f| f.verification.clone());
         let file_context = toml_file.as_ref().map(|f| f.context.clone());
         let file_voice: Option<&voice::VoiceFileConfig> = toml_file.as_ref().map(|f| &f.voice);
+        let file_coverage: Option<&crate::coverage::CoverageFileConfig> =
+            toml_file.as_ref().map(|f| &f.coverage);
 
         let env = RoleEnv::from_env();
         let role_models = RoleModels::resolve(cli_overrides, &env, file_models.as_ref());
@@ -313,6 +325,7 @@ impl ReviewConfig {
             apex_path_prefixes: load_apex_path_prefixes(),
             voice_package: voice::load_voice_package(file_voice),
             voice_principles: voice::load_voice_principles(file_voice),
+            coverage: crate::coverage::CoveragePolicy::from_env_and_file(file_coverage),
         }
     }
 

--- a/crates/trusty-review/src/coverage/lcov.rs
+++ b/crates/trusty-review/src/coverage/lcov.rs
@@ -1,0 +1,373 @@
+//! LCOV coverage report parser.
+//!
+//! Why: cargo-llvm-cov and tarpaulin both emit LCOV format; parsing it here
+//! lets the review pipeline ingest real coverage numbers without depending on
+//! external tooling at review time (the CI job produces the file; we consume it).
+//! What: parses the text format into a `CoverageReport` that summarises net line
+//! coverage (%) and — when the diff is provided — new-code coverage (%).
+//! LCOV format reference: genhtml man page / lcov README (DA:line,hits records).
+//! Test: `parse_lcov_empty`, `parse_lcov_basic`, `parse_lcov_multiple_files`,
+//! `new_code_coverage_all_hit`, `new_code_coverage_partial`.
+
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+/// Error produced by the LCOV parser.
+///
+/// Why: callers need a typed error to distinguish "file unreadable" from
+/// "file malformed" — the policy layer treats both as "coverage unavailable"
+/// but the diagnostics differ.
+/// What: wraps I/O errors (when loading from a path) and format errors.
+/// Test: `parse_lcov_bad_da_line`.
+#[derive(Debug, Error)]
+pub enum LcovError {
+    /// The LCOV file could not be read.
+    #[error("failed to read LCOV file: {0}")]
+    Io(#[from] std::io::Error),
+    /// A DA record had an unexpected format (expected "DA:<line>,<hits>").
+    #[error("malformed DA record in LCOV: {0:?}")]
+    MalformedDa(String),
+}
+
+// ─── Data model ───────────────────────────────────────────────────────────────
+
+/// Net coverage summary parsed from an LCOV report.
+///
+/// Why: the policy layer only needs the high-level percentages; it does not
+/// need the full per-file breakdown.  Keeping this slim reduces coupling.
+/// What: `net_pct` is the overall line-hit percentage (hits / instrumented lines);
+/// `lines_hit` and `lines_instrumented` are the raw totals.
+/// Test: `parse_lcov_basic`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoverageReport {
+    /// Total instrumented source lines across all files.
+    pub lines_instrumented: u64,
+    /// Total lines hit (executed at least once) across all files.
+    pub lines_hit: u64,
+    /// Overall line-coverage percentage in [0.0, 100.0].
+    pub net_pct: f64,
+    /// Per-file line-hit data: file path → (hits, instrumented).
+    ///
+    /// Why: enables the new-code coverage calculation — by knowing which lines
+    /// in which files were hit we can intersect with the diff's changed-line set.
+    /// What: keyed by the `SF:` path as it appears in the LCOV file.
+    pub file_coverage: HashMap<String, FileCoverage>,
+}
+
+/// Per-file coverage counters.
+///
+/// Why: the new-code coverage calculation needs per-file, per-line data so it
+/// can intersect with the diff's added-line set.
+/// What: `line_hits` maps 1-based line numbers → hit count.  Lines absent from
+/// the map were not instrumented (e.g. blank lines, comments, macros).
+/// Test: `new_code_coverage_all_hit`, `new_code_coverage_partial`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct FileCoverage {
+    /// Line-number → hit-count mapping (1-based; instrumented lines only).
+    pub line_hits: HashMap<u32, u64>,
+}
+
+impl FileCoverage {
+    /// Count instrumented lines.
+    ///
+    /// Why: needed for per-file coverage percentage.
+    /// What: returns the number of entries in `line_hits`.
+    /// Test: covered transitively.
+    pub fn instrumented(&self) -> usize {
+        self.line_hits.len()
+    }
+
+    /// Count hit lines (executed at least once).
+    ///
+    /// Why: needed for per-file coverage percentage.
+    /// What: counts entries with hit count > 0.
+    /// Test: covered transitively.
+    pub fn hit(&self) -> usize {
+        self.line_hits.values().filter(|&&h| h > 0).count()
+    }
+}
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+/// Parse an LCOV text report from a string slice.
+///
+/// Why: the primary entry point for tests and for callers who already have the
+/// file contents in memory (e.g. read via `std::fs::read_to_string`).
+/// What: iterates over lines; interprets `SF:` (source file), `DA:` (data —
+/// line,hits), and `end_of_record` markers per the LCOV format.  Accumulates
+/// per-file data and computes net totals.  Unknown record types are silently
+/// skipped (forward-compatible with lcov extensions).
+/// Test: `parse_lcov_empty`, `parse_lcov_basic`, `parse_lcov_multiple_files`.
+pub fn parse_lcov(text: &str) -> Result<CoverageReport, LcovError> {
+    let mut file_coverage: HashMap<String, FileCoverage> = HashMap::new();
+    let mut current_file: Option<String> = None;
+
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(sf_path) = line.strip_prefix("SF:") {
+            // New source-file record.
+            let path = sf_path.to_string();
+            current_file = Some(path.clone());
+            file_coverage.entry(path).or_default();
+        } else if let Some(da_data) = line.strip_prefix("DA:") {
+            // Data record: "DA:<line_number>,<hit_count>[,<checksum>]"
+            let data = da_data;
+            // Split on comma; only first two fields are required.
+            let mut parts = data.splitn(3, ',');
+            let line_no_str = parts.next().unwrap_or("");
+            let hits_str = parts.next().unwrap_or("");
+
+            let line_no = line_no_str
+                .trim()
+                .parse::<u32>()
+                .map_err(|_| LcovError::MalformedDa(line.to_string()))?;
+            let hits = hits_str
+                .trim()
+                .parse::<u64>()
+                .map_err(|_| LcovError::MalformedDa(line.to_string()))?;
+
+            if let Some(ref fname) = current_file {
+                file_coverage
+                    .entry(fname.clone())
+                    .or_default()
+                    .line_hits
+                    .insert(line_no, hits);
+            }
+        } else if line == "end_of_record" {
+            current_file = None;
+        }
+        // All other record types (FN:, FNDA:, FNF:, FNH:, BRH:, BRF:, LH:, LF:, …)
+        // are silently skipped — we only use per-line DA records.
+    }
+
+    // Compute net totals.
+    let mut lines_instrumented: u64 = 0;
+    let mut lines_hit: u64 = 0;
+    for fc in file_coverage.values() {
+        lines_instrumented += fc.instrumented() as u64;
+        lines_hit += fc.hit() as u64;
+    }
+
+    let net_pct = if lines_instrumented == 0 {
+        100.0 // No instrumented lines → trivially 100% (don't penalise empty reports).
+    } else {
+        (lines_hit as f64 / lines_instrumented as f64) * 100.0
+    };
+
+    Ok(CoverageReport {
+        lines_instrumented,
+        lines_hit,
+        net_pct,
+        file_coverage,
+    })
+}
+
+/// Parse an LCOV file from disk.
+///
+/// Why: convenience wrapper for the common case of loading from a filesystem
+/// path (e.g. `lcov.info` produced by `cargo llvm-cov --lcov`).
+/// What: reads the file, then calls `parse_lcov`.
+/// Test: `parse_lcov_from_path_roundtrip`.
+pub fn parse_lcov_file(path: &std::path::Path) -> Result<CoverageReport, LcovError> {
+    let text = std::fs::read_to_string(path)?;
+    parse_lcov(&text)
+}
+
+// ─── New-code coverage ────────────────────────────────────────────────────────
+
+/// Compute coverage percentage for lines added in the diff.
+///
+/// Why: "new code" coverage is a better signal for gating than net coverage —
+/// it catches the case where a PR adds substantial untested logic while the
+/// overall project coverage stays high due to an existing test suite.
+/// What: `added_lines` maps relative file path → set of 1-based added line numbers
+/// (as extracted from the unified diff `+` hunks).  We intersect these with the
+/// per-file hit data in `report`.  Lines that appear in the diff but are absent
+/// from the coverage map are counted as NOT covered (conservative).
+/// Returns `None` when `added_lines` is empty (no new instrumented lines) so the
+/// caller can distinguish "no new code" from "0% coverage on new code".
+/// Test: `new_code_coverage_all_hit`, `new_code_coverage_partial`,
+/// `new_code_coverage_no_new_lines`.
+pub fn new_code_coverage(
+    report: &CoverageReport,
+    added_lines: &HashMap<String, Vec<u32>>,
+) -> Option<f64> {
+    let mut total_new: u64 = 0;
+    let mut hit_new: u64 = 0;
+
+    for (file, lines) in added_lines {
+        for &lineno in lines {
+            // Try both exact path match and suffix match (the diff may use relative
+            // paths while the LCOV file uses absolute paths from the build root).
+            let hits = report
+                .file_coverage
+                .get(file)
+                .and_then(|fc| fc.line_hits.get(&lineno))
+                .or_else(|| {
+                    // Suffix-match fallback: find the first LCOV file whose path ends
+                    // with the diff file path (handles absolute vs relative mismatch).
+                    report
+                        .file_coverage
+                        .iter()
+                        .find(|(k, _)| k.ends_with(file.as_str()))
+                        .and_then(|(_, fc)| fc.line_hits.get(&lineno))
+                });
+
+            if let Some(&h) = hits {
+                // Line is instrumented — count it.
+                total_new += 1;
+                if h > 0 {
+                    hit_new += 1;
+                }
+            }
+            // Lines absent from the coverage map are non-instrumented (comments,
+            // blank lines, macros) — skip them to avoid false negatives.
+        }
+    }
+
+    if total_new == 0 {
+        return None; // No instrumented new lines.
+    }
+
+    Some((hit_new as f64 / total_new as f64) * 100.0)
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Empty LCOV input → report with zeros.
+    ///
+    /// Why: an empty file is valid (no tests run yet); the parser must not panic.
+    /// Test: asserts net_pct = 100.0 (trivial), instrumented = 0.
+    #[test]
+    fn parse_lcov_empty() {
+        let report = parse_lcov("").expect("empty LCOV must parse");
+        assert_eq!(report.lines_instrumented, 0);
+        assert_eq!(report.lines_hit, 0);
+        assert!(
+            (report.net_pct - 100.0).abs() < f64::EPSILON,
+            "empty report must return 100% (trivial)"
+        );
+        assert!(report.file_coverage.is_empty());
+    }
+
+    /// Basic single-file LCOV with known hit/miss lines.
+    ///
+    /// Why: verifies the parser accumulates DA records correctly.
+    /// Test: 3 instrumented, 2 hit → 66.66…%
+    #[test]
+    fn parse_lcov_basic() {
+        let lcov = "SF:src/foo.rs\nDA:1,1\nDA:2,0\nDA:3,5\nend_of_record\n";
+        let report = parse_lcov(lcov).expect("parse");
+        assert_eq!(report.lines_instrumented, 3);
+        assert_eq!(report.lines_hit, 2);
+        let expected_pct = (2.0 / 3.0) * 100.0;
+        assert!(
+            (report.net_pct - expected_pct).abs() < 0.01,
+            "expected ~66.67%, got {}",
+            report.net_pct
+        );
+    }
+
+    /// Multi-file LCOV — totals are summed across files.
+    ///
+    /// Why: verifies the accumulator works across multiple SF records.
+    /// Test: two files, 4 total instrumented, 3 hit → 75%.
+    #[test]
+    fn parse_lcov_multiple_files() {
+        let lcov = "SF:src/a.rs\nDA:1,1\nDA:2,1\nend_of_record\nSF:src/b.rs\nDA:10,1\nDA:11,0\nend_of_record\n";
+        let report = parse_lcov(lcov).expect("parse");
+        assert_eq!(report.lines_instrumented, 4);
+        assert_eq!(report.lines_hit, 3);
+        let expected_pct = 75.0;
+        assert!(
+            (report.net_pct - expected_pct).abs() < 0.01,
+            "expected 75%, got {}",
+            report.net_pct
+        );
+    }
+
+    /// Malformed DA record produces `LcovError::MalformedDa`.
+    ///
+    /// Why: the parser must not silently corrupt the totals when a DA record
+    /// is unreadable.
+    /// Test: asserts Err variant.
+    #[test]
+    fn parse_lcov_bad_da_line() {
+        let lcov = "SF:src/foo.rs\nDA:notanumber,1\nend_of_record\n";
+        let result = parse_lcov(lcov);
+        assert!(
+            result.is_err(),
+            "malformed DA line must produce an error, got {result:?}"
+        );
+    }
+
+    /// new_code_coverage: all new lines are hit → 100%.
+    ///
+    /// Why: the happy path must report 100% when every added line is exercised.
+    /// Test: 2 added lines, both hit.
+    #[test]
+    fn new_code_coverage_all_hit() {
+        let lcov = "SF:src/foo.rs\nDA:5,3\nDA:6,1\nend_of_record\n";
+        let report = parse_lcov(lcov).expect("parse");
+        let mut added: HashMap<String, Vec<u32>> = HashMap::new();
+        added.insert("src/foo.rs".to_string(), vec![5, 6]);
+        let pct = new_code_coverage(&report, &added).expect("Some");
+        assert!(
+            (pct - 100.0).abs() < f64::EPSILON,
+            "all hit → 100%, got {pct}"
+        );
+    }
+
+    /// new_code_coverage: partial — one line hit, one not.
+    ///
+    /// Why: verifies the numerator/denominator are computed correctly.
+    /// Test: 2 added lines, 1 hit → 50%.
+    #[test]
+    fn new_code_coverage_partial() {
+        let lcov = "SF:src/foo.rs\nDA:5,1\nDA:6,0\nend_of_record\n";
+        let report = parse_lcov(lcov).expect("parse");
+        let mut added: HashMap<String, Vec<u32>> = HashMap::new();
+        added.insert("src/foo.rs".to_string(), vec![5, 6]);
+        let pct = new_code_coverage(&report, &added).expect("Some");
+        assert!(
+            (pct - 50.0).abs() < 0.01,
+            "50% new-code coverage expected, got {pct}"
+        );
+    }
+
+    /// new_code_coverage: no new lines → returns None.
+    ///
+    /// Why: distinguishes "no new code added" from "0% coverage on new code".
+    /// Test: empty added_lines map → None.
+    #[test]
+    fn new_code_coverage_no_new_lines() {
+        let lcov = "SF:src/foo.rs\nDA:5,1\nend_of_record\n";
+        let report = parse_lcov(lcov).expect("parse");
+        let added: HashMap<String, Vec<u32>> = HashMap::new();
+        let result = new_code_coverage(&report, &added);
+        assert!(result.is_none(), "empty added_lines must return None");
+    }
+
+    /// new_code_coverage: suffix-match fallback for absolute-path LCOV.
+    ///
+    /// Why: `cargo llvm-cov` emits absolute paths in LCOV but the diff uses
+    /// repo-relative paths; the suffix-match fallback must bridge this gap.
+    /// Test: LCOV uses absolute path, diff uses relative.
+    #[test]
+    fn new_code_coverage_absolute_vs_relative() {
+        let lcov = "SF:/home/ci/workspace/trusty-tools/src/foo.rs\nDA:10,2\nend_of_record\n";
+        let report = parse_lcov(lcov).expect("parse");
+        let mut added: HashMap<String, Vec<u32>> = HashMap::new();
+        added.insert("src/foo.rs".to_string(), vec![10]);
+        let pct = new_code_coverage(&report, &added).expect("Some via suffix match");
+        assert!(
+            (pct - 100.0).abs() < f64::EPSILON,
+            "suffix-match fallback must hit → 100%, got {pct}"
+        );
+    }
+}

--- a/crates/trusty-review/src/coverage/mod.rs
+++ b/crates/trusty-review/src/coverage/mod.rs
@@ -1,0 +1,175 @@
+//! Test-coverage ingestion and verdict-gating for trusty-review (issue #1014).
+//!
+//! Why: the existing system prompt says "do not block on test coverage" and the
+//! reviewer ingests NO coverage data.  This module makes coverage a first-class,
+//! OPTIONAL, configurable gating input without breaking any existing behaviour.
+//!
+//! When `CoveragePolicy::enabled` is false (the default), every function in this
+//! module is a no-op and the pipeline is completely unchanged.  When enabled by
+//! the operator (opt-in), coverage can lower the letter grade and floor the
+//! verdict to REQUEST_CHANGES when:
+//!   - new-code coverage falls below `min_new_code_pct` (default 80%), OR
+//!   - net coverage drops more than `max_net_drop_pct` pp (default 1pp).
+//!
+//! What: two submodules:
+//!   - `lcov`   — LCOV format parser (`CoverageReport`, `parse_lcov`, `new_code_coverage`).
+//!   - `policy` — `CoveragePolicy`, `CoverageVerdictContrib`, `evaluate_coverage`.
+//!
+//! The runner calls `apply_coverage_floor` (re-exported here) AFTER the LLM-grade
+//! derivation step but BEFORE finalisation, so coverage can only TIGHTEN, never
+//! loosen, the verdict.
+//!
+//! Configuration:
+//!   | Env var                            | TOML key                  | Default |
+//!   |------------------------------------|---------------------------|---------|
+//!   | `TRUSTY_REVIEW_COVERAGE_ENABLED`   | `[coverage] enabled`      | false   |
+//!   | `TRUSTY_REVIEW_MIN_NEW_CODE_PCT`   | `[coverage] min_new_code_pct` | 80.0 |
+//!   | `TRUSTY_REVIEW_MAX_NET_DROP_PCT`   | `[coverage] max_net_drop_pct` | 1.0  |
+//!   | `TRUSTY_REVIEW_LCOV_PATH`          | `[coverage] lcov_path`    | (none)  |
+//!
+//! Test: see `lcov` and `policy` submodule tests.
+
+pub mod lcov;
+pub mod policy;
+
+pub use lcov::{
+    CoverageReport, FileCoverage, LcovError, new_code_coverage, parse_lcov, parse_lcov_file,
+};
+pub use policy::{CoverageFileConfig, CoveragePolicy, CoverageVerdictContrib, evaluate_coverage};
+
+use crate::{
+    models::Verdict,
+    pipeline::letter_grade::{Grade, clamp_grade_to_verdict},
+};
+
+/// Apply the coverage floor to the current verdict and grade, if triggered.
+///
+/// Why: the runner calls this as a final floor AFTER the LLM + severity derivation.
+/// It can only TIGHTEN (REQUEST_CHANGES) — it never softens a BLOCK or escalates
+/// APPROVE to BLOCK (coverage is not a correctness bug).
+/// What: if `contrib.floor` is `Some(Verdict::RequestChanges)` and the current
+/// verdict is weaker (APPROVE or APPROVE*), the verdict is raised to REQUEST_CHANGES
+/// and the grade is clamped to at most D+.  A BLOCK verdict is never weakened.
+/// When `contrib.floor` is None (coverage passed or policy disabled), returns
+/// the inputs unchanged.
+/// Test: `apply_coverage_floor_noop_when_no_floor`,
+/// `apply_coverage_floor_tightens_approve`,
+/// `apply_coverage_floor_does_not_weaken_block`.
+pub fn apply_coverage_floor(
+    verdict: Verdict,
+    grade: Grade,
+    contrib: &CoverageVerdictContrib,
+) -> (Verdict, Grade) {
+    let Some(floor) = contrib.floor.as_ref() else {
+        // Coverage passed (or policy disabled) — return unchanged.
+        return (verdict, grade);
+    };
+
+    // Only REQUEST_CHANGES is a valid coverage floor (coverage cannot BLOCK).
+    // A BLOCK verdict must never be softened; a REQUEST_CHANGES verdict is
+    // idempotent if already set.
+    let new_verdict = match (&verdict, floor) {
+        // Already at BLOCK — leave it (don't soften).
+        (Verdict::Block, _) => Verdict::Block,
+        // Coverage floor tightens APPROVE or APPROVE* to REQUEST_CHANGES.
+        (Verdict::Approve | Verdict::ApproveWithReservations, Verdict::RequestChanges) => {
+            Verdict::RequestChanges
+        }
+        // Already at or beyond REQUEST_CHANGES — leave it.
+        _ => verdict,
+    };
+
+    let new_grade = if let Some(ceiling) = contrib.grade_ceiling {
+        // Clamp grade to the ceiling implied by the floor (D+ for REQUEST_CHANGES).
+        if grade > ceiling { ceiling } else { grade }
+    } else {
+        // Ensure grade/verdict consistency regardless.
+        clamp_grade_to_verdict(grade, &new_verdict)
+    };
+
+    (new_verdict, new_grade)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coverage::policy::CoverageVerdictContrib;
+
+    fn pass_contrib() -> CoverageVerdictContrib {
+        CoverageVerdictContrib {
+            floor: None,
+            grade_ceiling: None,
+            summary: "pass".to_string(),
+        }
+    }
+
+    fn fail_contrib() -> CoverageVerdictContrib {
+        CoverageVerdictContrib {
+            floor: Some(Verdict::RequestChanges),
+            grade_ceiling: Some(Grade::DPlus),
+            summary: "fail".to_string(),
+        }
+    }
+
+    /// apply_coverage_floor is a no-op when contrib has no floor.
+    ///
+    /// Why: the off-by-default path must return the inputs unchanged.
+    /// Test: pass_contrib → same verdict/grade.
+    #[test]
+    fn apply_coverage_floor_noop_when_no_floor() {
+        let (v, g) = apply_coverage_floor(Verdict::Approve, Grade::A, &pass_contrib());
+        assert_eq!(v, Verdict::Approve);
+        assert_eq!(g, Grade::A);
+    }
+
+    /// apply_coverage_floor tightens APPROVE to REQUEST_CHANGES.
+    ///
+    /// Why: a PR with zero new-code coverage must floor to REQUEST_CHANGES
+    /// even if the LLM gave it an A.
+    /// Test: fail_contrib on APPROVE/A → REQUEST_CHANGES/D+.
+    #[test]
+    fn apply_coverage_floor_tightens_approve() {
+        let (v, g) = apply_coverage_floor(Verdict::Approve, Grade::A, &fail_contrib());
+        assert_eq!(v, Verdict::RequestChanges);
+        assert_eq!(g, Grade::DPlus, "grade must be clamped to D+");
+    }
+
+    /// apply_coverage_floor tightens APPROVE* to REQUEST_CHANGES.
+    ///
+    /// Why: APPROVE* is still weaker than REQUEST_CHANGES; coverage must tighten.
+    /// Test: fail_contrib on APPROVE*/C → REQUEST_CHANGES/D+.
+    #[test]
+    fn apply_coverage_floor_tightens_approve_star() {
+        let (v, g) =
+            apply_coverage_floor(Verdict::ApproveWithReservations, Grade::C, &fail_contrib());
+        assert_eq!(v, Verdict::RequestChanges);
+        assert_eq!(g, Grade::DPlus);
+    }
+
+    /// apply_coverage_floor does NOT weaken a BLOCK verdict.
+    ///
+    /// Why: a compile error (BLOCK) must never be softened by coverage gating.
+    /// Test: fail_contrib on BLOCK/F → BLOCK/F unchanged.
+    #[test]
+    fn apply_coverage_floor_does_not_weaken_block() {
+        let (v, g) = apply_coverage_floor(Verdict::Block, Grade::F, &fail_contrib());
+        assert_eq!(v, Verdict::Block, "BLOCK must not be softened by coverage");
+        assert_eq!(g, Grade::F);
+    }
+
+    /// apply_coverage_floor is idempotent on REQUEST_CHANGES.
+    ///
+    /// Why: if severity floors already gave REQUEST_CHANGES, coverage adding
+    /// the same floor must not change the outcome.
+    /// Test: fail_contrib on REQUEST_CHANGES/D → REQUEST_CHANGES/D+.
+    #[test]
+    fn apply_coverage_floor_idempotent_on_request_changes() {
+        let (v, g) = apply_coverage_floor(Verdict::RequestChanges, Grade::D, &fail_contrib());
+        assert_eq!(v, Verdict::RequestChanges);
+        // Grade D < D+ ceiling → clamped up to D+ (grade can only improve from D to D+)
+        // Actually D+ ceiling means grade must be AT MOST D+.  D < D+, so D stays D.
+        // The `grade > ceiling` comparison uses Ord where D+ > D (ordinal 3 > 2),
+        // so D does NOT exceed the D+ ceiling — grade stays D.
+        assert_eq!(g, Grade::D, "D does not exceed D+ ceiling so stays D");
+    }
+}

--- a/crates/trusty-review/src/coverage/policy.rs
+++ b/crates/trusty-review/src/coverage/policy.rs
@@ -1,0 +1,449 @@
+//! Coverage policy — configurable thresholds and grade/verdict contribution.
+//!
+//! Why: today the system prompt says "do not block on test coverage"; this
+//! module makes coverage a first-class, OPTIONAL gating signal (issue #1014).
+//! When `enabled = false` (the default), this module is a no-op and the
+//! existing verdict pipeline is unchanged.  When enabled, low or zero new-code
+//! coverage can lower the grade and/or force REQUEST_CHANGES.
+//!
+//! What: `CoveragePolicy` holds the opt-in flag and two configurable thresholds:
+//!   - `min_new_code_pct` — minimum acceptable coverage for new/changed lines.
+//!     When new-code coverage falls below this, verdict floors to REQUEST_CHANGES
+//!     and the grade is clamped to D+ or lower.
+//!   - `max_net_drop_pct` — maximum allowed drop in net project coverage (in
+//!     percentage points).  A drop exceeding this also floors to REQUEST_CHANGES.
+//!
+//! `CoverageVerdictContrib` is returned by `evaluate_coverage` and carries the
+//! recommended floor and a human-readable reason for inclusion in the review body.
+//!
+//! Test: `coverage_policy_off_is_noop`, `coverage_policy_zero_new_code`,
+//! `coverage_policy_below_threshold`, `coverage_policy_net_drop`,
+//! `coverage_policy_pass`.
+
+use serde::Deserialize;
+
+use crate::{coverage::lcov::CoverageReport, models::Verdict, pipeline::letter_grade::Grade};
+
+// ─── Policy defaults ──────────────────────────────────────────────────────────
+
+/// Default minimum new-code coverage (percentage points).
+///
+/// Why: an 80% floor is common in industry and matches cargo-tarpaulin's
+/// default output threshold; operators can lower it via config.
+/// What: `min_new_code_pct` defaults to 80.0.
+pub const DEFAULT_MIN_NEW_CODE_PCT: f64 = 80.0;
+
+/// Default maximum net coverage drop (percentage points).
+///
+/// Why: a 1-point drop in overall coverage is a clear regression signal;
+/// tighter than 5% to catch subtle regressions without over-triggering.
+/// What: `max_net_drop_pct` defaults to 1.0 (one percentage point).
+pub const DEFAULT_MAX_NET_DROP_PCT: f64 = 1.0;
+
+// ─── TOML file config ─────────────────────────────────────────────────────────
+
+/// `[coverage]` section of the review config TOML file.
+///
+/// Why: operators who want persistent coverage gating can set `enabled = true`
+/// in their `config.toml` rather than exporting an env var on every machine.
+/// What: all fields have `#[serde(default)]` so missing keys fall back to their
+/// coded defaults without erroring.
+/// Test: `coverage_file_config_defaults`.
+#[derive(Debug, Default, Deserialize)]
+pub struct CoverageFileConfig {
+    /// `enabled` — whether coverage gating is active.  Default: false (opt-in).
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// `min_new_code_pct` — minimum coverage on new/changed lines.
+    #[serde(default)]
+    pub min_new_code_pct: Option<f64>,
+    /// `max_net_drop_pct` — maximum allowed net coverage drop (pct-points).
+    #[serde(default)]
+    pub max_net_drop_pct: Option<f64>,
+    /// `lcov_path` — path to the LCOV report file produced by CI.
+    #[serde(default)]
+    pub lcov_path: Option<String>,
+}
+
+// ─── Resolved policy ──────────────────────────────────────────────────────────
+
+/// Resolved coverage policy, combining env vars + TOML config.
+///
+/// Why: mirrors the pattern used by `VerificationConfig` and `ContextConfig`
+/// in this codebase — resolve once at startup, pass around as a plain struct.
+/// What: `enabled` gates the entire feature; when false all fields are ignored.
+/// Test: `coverage_policy_from_env`, `coverage_policy_from_file`.
+#[derive(Debug, Clone)]
+pub struct CoveragePolicy {
+    /// Whether coverage gating is active.  `false` = no-op (default).
+    pub enabled: bool,
+    /// Minimum coverage on new/changed instrumented lines (percentage, 0–100).
+    pub min_new_code_pct: f64,
+    /// Maximum allowed drop in net line coverage (percentage points).
+    pub max_net_drop_pct: f64,
+    /// Optional path to an LCOV report file.  When set, the pipeline loads it
+    /// before the LLM call.  When absent, callers must supply the report externally
+    /// or coverage is skipped.
+    pub lcov_path: Option<std::path::PathBuf>,
+}
+
+impl Default for CoveragePolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_new_code_pct: DEFAULT_MIN_NEW_CODE_PCT,
+            max_net_drop_pct: DEFAULT_MAX_NET_DROP_PCT,
+            lcov_path: None,
+        }
+    }
+}
+
+impl CoveragePolicy {
+    /// Resolve from env vars merged over an optional TOML file config.
+    ///
+    /// Why: follows the same two-layer resolution used by other config types
+    /// in this codebase (env vars win; TOML is the fallback).
+    /// What: reads `TRUSTY_REVIEW_COVERAGE_ENABLED`, `TRUSTY_REVIEW_MIN_NEW_CODE_PCT`,
+    /// `TRUSTY_REVIEW_MAX_NET_DROP_PCT`, `TRUSTY_REVIEW_LCOV_PATH`.  Absent vars
+    /// fall back to the TOML file, then to the coded defaults.
+    /// Test: `coverage_policy_from_env`.
+    pub fn from_env_and_file(file: Option<&CoverageFileConfig>) -> Self {
+        let enabled = load_env_bool("TRUSTY_REVIEW_COVERAGE_ENABLED")
+            .or_else(|| file.and_then(|f| f.enabled))
+            .unwrap_or(false);
+
+        let min_new_code_pct = load_env_f64("TRUSTY_REVIEW_MIN_NEW_CODE_PCT")
+            .or_else(|| file.and_then(|f| f.min_new_code_pct))
+            .unwrap_or(DEFAULT_MIN_NEW_CODE_PCT)
+            .clamp(0.0, 100.0);
+
+        let max_net_drop_pct = load_env_f64("TRUSTY_REVIEW_MAX_NET_DROP_PCT")
+            .or_else(|| file.and_then(|f| f.max_net_drop_pct))
+            .unwrap_or(DEFAULT_MAX_NET_DROP_PCT)
+            .clamp(0.0, 100.0);
+
+        let lcov_path = std::env::var("TRUSTY_REVIEW_LCOV_PATH")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .map(std::path::PathBuf::from)
+            .or_else(|| {
+                file.and_then(|f| f.lcov_path.as_ref())
+                    .filter(|s| !s.trim().is_empty())
+                    .map(std::path::PathBuf::from)
+            });
+
+        Self {
+            enabled,
+            min_new_code_pct,
+            max_net_drop_pct,
+            lcov_path,
+        }
+    }
+}
+
+// ─── Evaluation ───────────────────────────────────────────────────────────────
+
+/// The coverage evaluation verdict contribution.
+///
+/// Why: the runner applies this AFTER the LLM verdict, so it needs both the
+/// recommended floor and a human-readable reason to inject into the review body.
+/// What: `floor` is `None` when coverage passes (no downgrade needed).  `reason`
+/// is always set for diagnostics; it is only injected into the body when `floor`
+/// is `Some`.
+/// Test: `coverage_policy_zero_new_code`, `coverage_policy_pass`.
+#[derive(Debug, Clone)]
+pub struct CoverageVerdictContrib {
+    /// Recommended minimum verdict floor (None = pass, no floor applied).
+    pub floor: Option<Verdict>,
+    /// Recommended minimum grade ceiling when a floor is triggered.
+    /// `None` = no grade clamp.
+    pub grade_ceiling: Option<Grade>,
+    /// Human-readable summary for the review body (always populated).
+    pub summary: String,
+}
+
+/// Evaluate the coverage report against the policy and return a verdict contribution.
+///
+/// Why: this is the single place that maps coverage numbers to review outcomes.
+/// It is intentionally pure (no side-effects, no I/O) so it is trivially testable.
+/// What: checks two conditions:
+///   1. `new_code_pct` (if present) vs `policy.min_new_code_pct` — new code with
+///      zero or below-threshold coverage floors to REQUEST_CHANGES with grade D+.
+///   2. Net coverage drop (current `net_pct` vs `baseline_net_pct`) vs
+///      `policy.max_net_drop_pct` — a drop exceeding the threshold floors to
+///      REQUEST_CHANGES with grade D+.
+///
+/// When `policy.enabled` is false, returns a pass contrib (no floor).
+/// When both conditions trigger, the most severe floor wins (both are REQUEST_CHANGES).
+///
+/// Test: `coverage_policy_off_is_noop`, `coverage_policy_zero_new_code`,
+/// `coverage_policy_below_threshold`, `coverage_policy_net_drop`,
+/// `coverage_policy_pass`.
+pub fn evaluate_coverage(
+    policy: &CoveragePolicy,
+    report: &CoverageReport,
+    new_code_pct: Option<f64>,
+    baseline_net_pct: Option<f64>,
+) -> CoverageVerdictContrib {
+    // OFF by default: when disabled this is a strict no-op.
+    if !policy.enabled {
+        return CoverageVerdictContrib {
+            floor: None,
+            grade_ceiling: None,
+            summary: format!(
+                "Coverage: {:.1}% ({}/{} lines hit) — gating disabled (opt-in).",
+                report.net_pct, report.lines_hit, report.lines_instrumented
+            ),
+        };
+    }
+
+    let mut reasons: Vec<String> = Vec::new();
+    let mut needs_floor = false;
+
+    // Condition 1: new-code coverage below threshold.
+    if let Some(nc_pct) = new_code_pct
+        && nc_pct < policy.min_new_code_pct
+    {
+        needs_floor = true;
+        if nc_pct < 0.1 {
+            // Treat effectively-zero as zero to avoid floating-point noise.
+            reasons.push(format!(
+                "new-code coverage is 0% (threshold: {:.0}%)",
+                policy.min_new_code_pct
+            ));
+        } else {
+            reasons.push(format!(
+                "new-code coverage is {nc_pct:.1}% (below threshold: {:.0}%)",
+                policy.min_new_code_pct
+            ));
+        }
+    }
+
+    // Condition 2: net coverage drop exceeds threshold.
+    if let Some(baseline) = baseline_net_pct {
+        let drop = baseline - report.net_pct;
+        if drop > policy.max_net_drop_pct {
+            needs_floor = true;
+            reasons.push(format!(
+                "net coverage dropped {drop:.1}pp ({:.1}% → {:.1}%; max allowed: {:.1}pp)",
+                baseline, report.net_pct, policy.max_net_drop_pct
+            ));
+        }
+    }
+
+    // Build summary line.
+    let new_code_part = new_code_pct
+        .map(|p| format!(", new-code: {p:.1}%"))
+        .unwrap_or_default();
+    let summary_base = format!(
+        "Coverage: {:.1}%{new_code_part} ({}/{} lines hit).",
+        report.net_pct, report.lines_hit, report.lines_instrumented
+    );
+
+    if needs_floor {
+        let reason_text = reasons.join("; ");
+        CoverageVerdictContrib {
+            floor: Some(Verdict::RequestChanges),
+            grade_ceiling: Some(Grade::DPlus),
+            summary: format!("{summary_base} COVERAGE GATE TRIGGERED: {reason_text}."),
+        }
+    } else {
+        let pass_note = if new_code_pct.is_some() || baseline_net_pct.is_some() {
+            " Coverage thresholds met."
+        } else {
+            ""
+        };
+        CoverageVerdictContrib {
+            floor: None,
+            grade_ceiling: None,
+            summary: format!("{summary_base}{pass_note}"),
+        }
+    }
+}
+
+// ─── Env-var helpers ──────────────────────────────────────────────────────────
+
+/// Parse a boolean env var: "true"/"1"/"yes" → Some(true); "false"/"0"/"no" → Some(false).
+///
+/// Why: follows the same convention used by `load_voice_principles` in this codebase.
+/// What: absent or unrecognised values return None so the TOML / coded default wins.
+/// Test: covered transitively by `coverage_policy_from_env`.
+fn load_env_bool(var: &str) -> Option<bool> {
+    let val = std::env::var(var).ok()?;
+    match val.trim().to_lowercase().as_str() {
+        "true" | "1" | "yes" => Some(true),
+        "false" | "0" | "no" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse an f64 env var.
+///
+/// Why: avoids `unwrap` in config loading code.
+/// What: absent or unparseable values return None.
+/// Test: covered transitively.
+fn load_env_f64(var: &str) -> Option<f64> {
+    std::env::var(var).ok()?.trim().parse().ok()
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coverage::lcov::parse_lcov;
+
+    fn make_policy(enabled: bool) -> CoveragePolicy {
+        CoveragePolicy {
+            enabled,
+            min_new_code_pct: 80.0,
+            max_net_drop_pct: 1.0,
+            lcov_path: None,
+        }
+    }
+
+    fn zero_report() -> CoverageReport {
+        parse_lcov("").expect("empty")
+    }
+
+    fn report_with_pct(pct: f64) -> CoverageReport {
+        // Construct a synthetic report with the given net percentage.
+        let mut report = zero_report();
+        report.lines_instrumented = 100;
+        report.lines_hit = pct.round() as u64;
+        report.net_pct = pct;
+        report
+    }
+
+    /// When policy is disabled, evaluate_coverage is a no-op regardless of values.
+    ///
+    /// Why: the default (off) behaviour must be strictly unchanged from today.
+    /// Test: passes zero coverage with policy.enabled=false; expects no floor.
+    #[test]
+    fn coverage_policy_off_is_noop() {
+        let policy = make_policy(false);
+        let report = report_with_pct(0.0);
+        let contrib = evaluate_coverage(&policy, &report, Some(0.0), Some(90.0));
+        assert!(
+            contrib.floor.is_none(),
+            "disabled policy must never produce a floor"
+        );
+        assert!(
+            contrib.grade_ceiling.is_none(),
+            "disabled policy must never produce a grade ceiling"
+        );
+    }
+
+    /// New-code coverage of zero triggers REQUEST_CHANGES floor.
+    ///
+    /// Why: adding public code with 0% coverage must pull the verdict down.
+    /// Test: new_code_pct=0.0, threshold=80% → floor=REQUEST_CHANGES.
+    #[test]
+    fn coverage_policy_zero_new_code() {
+        let policy = make_policy(true);
+        let report = report_with_pct(85.0); // Net is fine.
+        let contrib = evaluate_coverage(&policy, &report, Some(0.0), None);
+        assert_eq!(
+            contrib.floor,
+            Some(Verdict::RequestChanges),
+            "0% new-code coverage must floor to REQUEST_CHANGES"
+        );
+        assert_eq!(contrib.grade_ceiling, Some(Grade::DPlus));
+        assert!(
+            contrib.summary.contains("0%"),
+            "summary must mention 0%: {}",
+            contrib.summary
+        );
+    }
+
+    /// New-code coverage below threshold (but not zero) triggers floor.
+    ///
+    /// Why: partial coverage of new code below the threshold is still a gate violation.
+    /// Test: new_code_pct=50%, threshold=80% → floor=REQUEST_CHANGES.
+    #[test]
+    fn coverage_policy_below_threshold() {
+        let policy = make_policy(true);
+        let report = report_with_pct(90.0);
+        let contrib = evaluate_coverage(&policy, &report, Some(50.0), None);
+        assert_eq!(
+            contrib.floor,
+            Some(Verdict::RequestChanges),
+            "50% new-code coverage below 80% threshold must floor"
+        );
+        assert!(
+            contrib.summary.contains("50.0%"),
+            "summary must mention 50.0%: {}",
+            contrib.summary
+        );
+    }
+
+    /// Net coverage drop exceeding max_net_drop_pct triggers floor.
+    ///
+    /// Why: a PR that causes a large regression in overall coverage must be flagged.
+    /// Test: net=80%, baseline=85%, drop=5pp, max=1pp → floor=REQUEST_CHANGES.
+    #[test]
+    fn coverage_policy_net_drop() {
+        let policy = make_policy(true);
+        let report = report_with_pct(80.0);
+        let contrib = evaluate_coverage(&policy, &report, None, Some(85.0));
+        assert_eq!(
+            contrib.floor,
+            Some(Verdict::RequestChanges),
+            "5pp drop exceeding 1pp threshold must floor"
+        );
+        assert!(
+            contrib.summary.contains("COVERAGE GATE TRIGGERED"),
+            "summary must contain trigger marker: {}",
+            contrib.summary
+        );
+    }
+
+    /// All conditions pass — no floor, no grade ceiling.
+    ///
+    /// Why: the happy path must produce no floor so existing-passing PRs are
+    /// unaffected even when coverage gating is enabled.
+    /// Test: good new-code pct + no net drop → floor=None.
+    #[test]
+    fn coverage_policy_pass() {
+        let policy = make_policy(true);
+        let report = report_with_pct(90.0);
+        let contrib = evaluate_coverage(&policy, &report, Some(90.0), Some(89.5));
+        assert!(
+            contrib.floor.is_none(),
+            "all conditions pass → no floor: {:?}",
+            contrib
+        );
+        assert!(contrib.grade_ceiling.is_none());
+        assert!(
+            contrib.summary.contains("Coverage thresholds met"),
+            "summary should confirm pass: {}",
+            contrib.summary
+        );
+    }
+
+    /// When no new-code lines are instrumented (new_code_pct=None) and no baseline,
+    /// the policy still produces no floor (cannot gate on data we don't have).
+    ///
+    /// Why: when the diff has no testable lines, we must not penalise the PR.
+    /// Test: both optional inputs are None → floor=None even with policy enabled.
+    #[test]
+    fn coverage_policy_no_data_no_floor() {
+        let policy = make_policy(true);
+        let report = report_with_pct(80.0);
+        let contrib = evaluate_coverage(&policy, &report, None, None);
+        assert!(
+            contrib.floor.is_none(),
+            "no new-code data and no baseline → no floor"
+        );
+    }
+
+    /// CoveragePolicy::default() produces enabled=false.
+    ///
+    /// Why: the default must be off so existing deployments are unaffected.
+    /// Test: Default::default().enabled == false.
+    #[test]
+    fn coverage_policy_default_is_off() {
+        let policy = CoveragePolicy::default();
+        assert!(!policy.enabled, "default policy must be disabled (opt-in)");
+    }
+}

--- a/crates/trusty-review/src/lib.rs
+++ b/crates/trusty-review/src/lib.rs
@@ -18,6 +18,11 @@ pub mod integrations;
 pub mod llm;
 pub mod models;
 pub mod pipeline;
+// Why: coverage ingestion and verdict-gating (issue #1014).  Always compiled —
+// no feature gate — because `CoveragePolicy` is a pure data type used by
+// `ReviewConfig` and the runner in all modes.  The feature is off by default
+// (opt-in via `TRUSTY_REVIEW_COVERAGE_ENABLED=true`).
+pub mod coverage;
 // Why: the voice module holds the 3-layer prompt composition types and logic
 // (stock → principles → voice).  Always compiled — no feature gate — because
 // VoiceConfig is a pure data type used by the prompt builder in all modes.

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -44,6 +44,18 @@ pub mod verify_prompt;
 // under the 500-line cap (#610).  Exposes `build_voice_config` for use by the
 // runner and for direct testing.
 pub mod voice_config;
+// Why: coverage data loading extracted from runner.rs to keep that file under
+// the 500-line cap (#610) after adding coverage-gating pipeline (#1014).
+pub mod runner_coverage;
+// Why: helper functions (apply_grade_and_floor, fetch_github_pr_meta, abort_dry,
+// finalize_run) extracted from runner.rs to keep it under the 500-line cap (#610).
+pub mod runner_helpers;
+// Why: system-prompt string constants extracted from prompt.rs to keep it under
+// the 500-line cap (#610) after the two coverage-gating variants were added (#1014).
+pub mod prompt_templates;
+// Why: user-message builder extracted from prompt.rs to keep it under the
+// 500-line cap (#610) — the function is 145 lines on its own.
+pub mod prompt_user_msg;
 
 pub use context_gate::{GateOutcome, degraded_banner, preflight_context};
 pub use diff::DiffSource;
@@ -55,7 +67,9 @@ pub use output::{log_json_path, print_review_result, write_review_log};
 pub use parser::{ParsedReview, parse_review_response};
 pub use post::{FinalizeAction, PostContext, decide_action, finalize_review};
 pub use prompt::{
-    ReviewContext, ReviewPrMeta, build_review_prompt, build_system_prompt, reviewer_system_prompt,
+    ReviewContext, ReviewPrMeta, build_review_prompt, build_review_prompt_with_coverage,
+    build_system_prompt, build_system_prompt_with_coverage, reviewer_system_prompt,
+    reviewer_system_prompt_with_coverage,
 };
 pub use runner::{ReviewDeps, ReviewInput, run_review};
 pub use trigger::{TriggerDecision, classify_review_request, effective_dry_run};

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -22,6 +22,7 @@
 //! `prompt_includes_context_blocks`.
 
 use crate::{
+    coverage::CoverageVerdictContrib,
     integrations::{
         analyze_client::{ComplexityHotspot, Smell},
         apex_context::ApexContextResult,
@@ -31,6 +32,12 @@ use crate::{
     models::ReviewResult,
     voice::VoiceConfig,
 };
+
+// System prompt templates are in a separate file to keep this module under the
+// 500-line cap (#610) — the two large prompt constants are ~160 lines combined.
+use super::prompt_templates::{SYSTEM_PROMPT_COVERAGE_GATING, SYSTEM_PROMPT_STOCK};
+// User-message builder extracted to keep this module under the 500-line cap (#610).
+use super::prompt_user_msg::build_user_message;
 
 // ─── Prompt constants ─────────────────────────────────────────────────────────
 
@@ -130,6 +137,14 @@ pub struct ReviewContext {
     /// APEX is disabled (`apex_index` not configured) or no matching docs are
     /// found.  Fail-open: a search error produces an empty vec, never an error.
     pub apex_results: Vec<ApexContextResult>,
+    /// Coverage verdict contribution from the coverage policy (#1014).
+    ///
+    /// `None` when coverage gating is disabled (the default) or when no LCOV
+    /// file was available.  When `Some`, the summary string is injected into the
+    /// user message as an informational block so the LLM can reference it in
+    /// findings; the `floor` is applied deterministically by the runner AFTER
+    /// the LLM response, not by the model itself.
+    pub coverage_contrib: Option<CoverageVerdictContrib>,
 }
 
 // ─── System prompt ────────────────────────────────────────────────────────────
@@ -141,81 +156,34 @@ pub struct ReviewContext {
 /// REQUEST_CHANGES/BLOCK.  Kept as a function for backward compatibility and
 /// for tests that need only the stock text.  For the full 3-layer prompt
 /// (stock → principles → voice) use `build_system_prompt(voice_config)`.
+/// The `coverage_gating_enabled` parameter controls whether the prompt tells
+/// the model that coverage can gate the verdict (#1014).  When `false`, the
+/// stock advisory text ("do not block on coverage") is preserved unchanged.
 /// What: returns a static string; the output-format section uses structured
 /// output language — the provider forces JSON via `response_schema` so the
 /// model need not emit a fenced block.
-/// Test: `system_prompt_contains_policy`.
+/// Test: `system_prompt_contains_policy`, `system_prompt_coverage_gating_on`,
+/// `system_prompt_coverage_gating_off`.
 pub fn reviewer_system_prompt() -> &'static str {
-    r#"You are a senior software engineer performing a pull-request code review.
+    reviewer_system_prompt_with_coverage(false)
+}
 
-## Letter grade (MANDATORY — assign exactly one)
-
-Assign a letter grade on the 13-step scale: A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F.
-
-| Grade band        | Quality signal                                              |
-|-------------------|-------------------------------------------------------------|
-| A+, A, A-         | Excellent to exceptional — clean, correct, well-structured. |
-| B+, B, B-         | Good to solid — acceptable, minor nits only.                |
-| C+, C, C-         | Marginal — notable issues or advisory concerns.             |
-| D+, D, D-         | Poor — significant problems requiring changes before merge. |
-| F                 | Failing — compile error, data corruption, security bypass.  |
-
-Provide a one-line justification in `grade_justification`.
-
-## Verdict (MANDATORY — pick exactly one)
-
-| Verdict         | Grade band      | When to use |
-|-----------------|-----------------|-------------|
-| BLOCK           | F               | Compile error introduced by this diff, data corruption, security/auth bypass. |
-| REQUEST_CHANGES | D+, D, D-       | Confirmed correctness bug, silent data loss, missing required migration/backfill, resource leak, unhandled exception path with real failure consequence. |
-| APPROVE*        | C+, C, C-       | Advisory concern the author may reasonably disagree with; the code ships but you want the note on record. |
-| APPROVE         | B- or above     | No significant concerns; the change is clean and correct. |
-| UNKNOWN         | —               | The diff was too truncated, context-free, or otherwise insufficient to assess. |
-
-**Keep your verdict consistent with your grade.** A grade of "D" must have verdict REQUEST_CHANGES;
-a grade of "F" must have verdict BLOCK; a grade of "B-" or above must have verdict APPROVE.
-
-- Your default verdict is APPROVE (default grade A-). You bear the burden of proof to escalate.
-- APPROVE* requires at least one Medium finding. Do not emit APPROVE* with only Low findings.
-- REQUEST_CHANGES requires ALL THREE: (a) a specific wrong line cited verbatim,
-  (b) a traceable failure path, (c) a concrete fix proposed.
-- Do NOT emit UNKNOWN just because the PR is large; use it only when you
-  genuinely cannot tell if the change is correct.
-- **Do not under-rate a clearly blocking issue as advisory.** If it would break
-  a build or corrupt data in production, assign severity=critical and verdict=BLOCK.
-
-## Compile-break rule (CRITICAL)
-If the diff REMOVES a symbol (enum value, method, constant, field, function
-signature change) AND the same diff still shows remaining references or
-call-sites to that removed symbol elsewhere in the codebase, that is a
-compile-time regression.  Assign the finding severity=critical and
-verdict=BLOCK (grade=F).  No other context softens this.
-
-## Severity anchors for findings
-Every finding MUST have a `severity` from:
-- **critical** — compile error, data corruption, security bypass, auth failure.
-- **high**     — confirmed correctness bug, silent data loss, unhandled exception
-  path, missing required migration, resource leak with real consequence.
-- **medium**   — advisory: code smell, suboptimal pattern, minor risk, the author
-  may reasonably disagree.
-- **low**      — cosmetic, documentation gap, style preference.
-
-## What to review
-Focus on: correctness bugs, security issues, data-loss risks, logic errors.
-Note but do not block on: style, minor naming, documentation gaps, test coverage.
-
-## Output (REQUIRED — populate the structured response fields)
-- `grade`: one of A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F.
-- `grade_justification`: one-sentence reason for the grade.
-- `verdict`: one of APPROVE, APPROVE*, REQUEST_CHANGES, BLOCK, UNKNOWN.
-- `summary`: one sentence summary of the review.
-- `findings`: array of issues found (empty array if none).
-  Each finding has: title, body (detailed description), severity (low/medium/high/critical),
-  confidence (0.0–1.0), file (source file path), line (null if not applicable).
-
-`confidence` is a float in [0.0, 1.0].
-`line` may be null if no specific line is applicable.
-`findings` may be an empty array if there are no issues."#
+/// Build the base system prompt with optional coverage-gating language.
+///
+/// Why: when coverage gating is enabled, the "do not block on coverage" advisory
+/// in the stock prompt becomes inaccurate (the runner WILL lower the verdict if
+/// coverage is insufficient).  This function is the single source of truth for
+/// both variants.
+/// What: when `coverage_gating_enabled` is false, the prompt is identical to the
+/// pre-#1014 stock text.  When true, the "Note but do not block on" coverage line
+/// is replaced with an informational note about the coverage context block.
+/// Test: `system_prompt_coverage_gating_on`, `system_prompt_coverage_gating_off`.
+pub fn reviewer_system_prompt_with_coverage(coverage_gating_enabled: bool) -> &'static str {
+    if coverage_gating_enabled {
+        SYSTEM_PROMPT_COVERAGE_GATING
+    } else {
+        SYSTEM_PROMPT_STOCK
+    }
 }
 
 // ─── Layered system prompt ────────────────────────────────────────────────────
@@ -228,10 +196,26 @@ Note but do not block on: style, minor naming, documentation gaps, test coverage
 /// What: appends principles then voice addenda to the stock base when they are
 /// non-empty; a blank separator line is inserted between layers.  When
 /// `voice_config` is all-None (stock-only), the output equals `reviewer_system_prompt()`.
+/// `coverage_gating_enabled` selects the stock base variant (#1014): when true the
+/// "do not block on coverage" advisory is replaced with an informational note.
 /// Test: `build_system_prompt_stock_only`, `build_system_prompt_with_principles`,
 /// `build_system_prompt_full_pipeline` in `prompt_tests.rs`.
 pub fn build_system_prompt(voice_config: &VoiceConfig) -> String {
-    let stock = reviewer_system_prompt();
+    build_system_prompt_with_coverage(voice_config, false)
+}
+
+/// Build the layered system prompt with an explicit coverage-gating flag.
+///
+/// Why: the runner calls this with `coverage_gating_enabled = config.coverage.enabled`
+/// so the system prompt accurately reflects whether coverage can gate the verdict.
+/// What: selects the stock base via `reviewer_system_prompt_with_coverage`, then
+/// appends the principles and voice addenda exactly as `build_system_prompt` does.
+/// Test: `build_system_prompt_coverage_gating_on`.
+pub fn build_system_prompt_with_coverage(
+    voice_config: &VoiceConfig,
+    coverage_gating_enabled: bool,
+) -> String {
+    let stock = reviewer_system_prompt_with_coverage(coverage_gating_enabled);
     let addendum = voice_config.combined_addendum();
     if addendum.is_empty() {
         return stock.to_string();
@@ -252,13 +236,16 @@ pub fn build_system_prompt(voice_config: &VoiceConfig) -> String {
 /// Bedrock tool-use or OpenRouter json_schema.
 /// `reviewer_model` may carry a `bedrock/` or `openrouter/` routing prefix;
 /// this function strips it before setting `LlmRequest.model`.
+/// `coverage_gating_enabled` selects the coverage-aware system prompt variant
+/// (#1014): when true, the "do not block on coverage" advisory is replaced.
 /// Test: `build_review_prompt_includes_diff`, `prompt_includes_context_blocks`,
 /// `build_review_prompt_strips_bedrock_prefix`,
 /// `build_review_prompt_includes_response_schema`,
 /// `build_review_prompt_with_voice_config_principles`,
-/// `build_review_prompt_with_voice_config_full`.
-// Eight arguments are required to fully specify the review (PR identity, diff,
-// context, model, voice).  The parameter count is structural, not incidental;
+/// `build_review_prompt_with_voice_config_full`,
+/// `build_review_prompt_coverage_gating_injects_block`.
+// Nine arguments are required to fully specify the review (PR identity, diff,
+// context, model, voice, coverage flag).  The parameter count is structural;
 // splitting would make the API less ergonomic without improving cohesion.
 #[allow(clippy::too_many_arguments)]
 pub fn build_review_prompt(
@@ -271,10 +258,73 @@ pub fn build_review_prompt(
     reviewer_model: &str,
     voice_config: &VoiceConfig,
 ) -> LlmRequest {
+    build_review_prompt_inner(
+        owner,
+        repo,
+        pr_meta,
+        diff,
+        context,
+        external_context,
+        reviewer_model,
+        voice_config,
+        false,
+    )
+}
+
+/// Build the `LlmRequest` with coverage-gating flag exposed (used by the runner).
+///
+/// Why: the runner calls this variant when `config.coverage.enabled` is true so
+/// the system prompt reflects that coverage can gate the verdict (#1014).
+/// What: identical to `build_review_prompt` but passes `coverage_gating_enabled`
+/// through to `build_system_prompt_with_coverage`.
+/// Test: `build_review_prompt_coverage_gating_injects_block`.
+#[allow(clippy::too_many_arguments)]
+pub fn build_review_prompt_with_coverage(
+    owner: &str,
+    repo: &str,
+    pr_meta: &ReviewPrMeta,
+    diff: &str,
+    context: &ReviewContext,
+    external_context: &str,
+    reviewer_model: &str,
+    voice_config: &VoiceConfig,
+    coverage_gating_enabled: bool,
+) -> LlmRequest {
+    build_review_prompt_inner(
+        owner,
+        repo,
+        pr_meta,
+        diff,
+        context,
+        external_context,
+        reviewer_model,
+        voice_config,
+        coverage_gating_enabled,
+    )
+}
+
+/// Internal implementation shared by both `build_review_prompt` variants.
+///
+/// Why: avoids code duplication between the public API-stable function and the
+/// coverage-aware variant while keeping the public interface clean.
+/// What: assembles the full `LlmRequest` from all inputs.
+/// Test: covered transitively by all `build_review_prompt_*` tests.
+#[allow(clippy::too_many_arguments)]
+fn build_review_prompt_inner(
+    owner: &str,
+    repo: &str,
+    pr_meta: &ReviewPrMeta,
+    diff: &str,
+    context: &ReviewContext,
+    external_context: &str,
+    reviewer_model: &str,
+    voice_config: &VoiceConfig,
+    coverage_gating_enabled: bool,
+) -> LlmRequest {
     let user_message = build_user_message(owner, repo, pr_meta, diff, context, external_context);
     LlmRequest {
         model: strip_provider_prefix(reviewer_model).to_string(),
-        system: build_system_prompt(voice_config),
+        system: build_system_prompt_with_coverage(voice_config, coverage_gating_enabled),
         messages: vec![ChatMessage {
             role: "user".to_string(),
             content: user_message,
@@ -323,152 +373,6 @@ impl ReviewPrMeta {
             url: result.pr_url.clone(),
         }
     }
-}
-
-/// Build the user-turn message for the review prompt.
-///
-/// Why: the user message carries all the review input: PR identity, diff, and
-/// context blocks.  Splitting it from the system prompt makes each independently
-/// tweakable.
-/// What: formats PR metadata as a header, then the diff block, then optional
-/// context sections for code search and static analysis, then any external
-/// context (`## Related <source>` markdown already rendered by the context
-/// orchestrator — JIRA / Confluence / GitHub Issues; APEX in PR-B).
-/// Test: `prompt_includes_context_blocks`, `prompt_includes_external_context`.
-fn build_user_message(
-    owner: &str,
-    repo: &str,
-    pr_meta: &ReviewPrMeta,
-    diff: &str,
-    context: &ReviewContext,
-    external_context: &str,
-) -> String {
-    let mut msg = String::with_capacity(diff.len() + 2048);
-
-    // PR header.
-    msg.push_str(&format!("## PR: {owner}/{repo}"));
-    if !pr_meta.title.is_empty() {
-        msg.push_str(&format!(" — {}", pr_meta.title));
-    }
-    msg.push('\n');
-    if !pr_meta.author.is_empty() {
-        msg.push_str(&format!("Author: @{}\n", pr_meta.author));
-    }
-    if !pr_meta.url.is_empty() {
-        msg.push_str(&format!("URL: {}\n", pr_meta.url));
-    }
-    msg.push('\n');
-
-    // Diff block.
-    msg.push_str("## Unified diff\n\n");
-    msg.push_str("```diff\n");
-    msg.push_str(diff);
-    if !diff.ends_with('\n') {
-        msg.push('\n');
-    }
-    msg.push_str("```\n\n");
-
-    // Code search context block.
-    if !context.search_results.is_empty() {
-        msg.push_str("## Related code (from trusty-search)\n\n");
-        for (i, result) in context.search_results.iter().enumerate().take(10) {
-            msg.push_str(&format!("### Context {} — {}\n", i + 1, result.file));
-            if let Some(ref snippet) = result.snippet {
-                msg.push_str("```\n");
-                msg.push_str(snippet);
-                if !snippet.ends_with('\n') {
-                    msg.push('\n');
-                }
-                msg.push_str("```\n");
-            }
-            msg.push('\n');
-        }
-    }
-
-    // Static-analysis context block.
-    if !context.complexity_hotspots.is_empty() {
-        msg.push_str("## Complexity hotspots (from trusty-analyze)\n\n");
-        for h in context.complexity_hotspots.iter().take(5) {
-            let fn_part = h
-                .function_name
-                .as_deref()
-                .map(|f| format!(" `{f}`"))
-                .unwrap_or_default();
-            msg.push_str(&format!(
-                "- `{}`{fn_part}: cyclomatic={}, cognitive={}\n",
-                h.file, h.cyclomatic, h.cognitive
-            ));
-        }
-        msg.push('\n');
-    }
-
-    if !context.smells.is_empty() {
-        msg.push_str("## Code smells (from trusty-analyze)\n\n");
-        for s in context.smells.iter().take(10) {
-            let line_part = s.line.map(|l| format!(" (line {l})")).unwrap_or_default();
-            msg.push_str(&format!(
-                "- `{}` — {} [{}]{line_part}\n",
-                s.file, s.category, s.severity
-            ));
-        }
-        msg.push('\n');
-    }
-
-    // APEX product-spec context block (Phase 6 PR-B, REV-420).
-    // Each result is a snippet from the spec/docs corpus that semantically
-    // matches the PR content.  Cite format: [apex: `path:line` — "excerpt"].
-    if !context.apex_results.is_empty() {
-        msg.push_str("## Related APEX product specs\n\n");
-        // defensive: apex_results already capped in fetch_apex_context; guard against future refactors
-        for (i, apex) in context
-            .apex_results
-            .iter()
-            .enumerate()
-            .take(crate::config::constants::MAX_APEX_RESULTS)
-        {
-            let line_suffix = apex.start_line.map(|l| format!(":{l}")).unwrap_or_default();
-            msg.push_str(&format!(
-                "### APEX {} — `{}{}`\n",
-                i + 1,
-                apex.file,
-                line_suffix
-            ));
-            if !apex.snippet.is_empty() {
-                msg.push_str("```\n");
-                msg.push_str(&apex.snippet);
-                if !apex.snippet.ends_with('\n') {
-                    msg.push('\n');
-                }
-                msg.push_str("```\n");
-            }
-            msg.push('\n');
-        }
-        msg.push_str(
-            "When citing an APEX spec, use the format: \
-             [apex: `path/to/spec.md:15` — \"brief excerpt\"]\n\n",
-        );
-    }
-
-    // External context block (rendered `## Related <source>` markdown from the
-    // context orchestrator — JIRA / Confluence / GitHub Issues).
-    // It is appended verbatim because the orchestrator already owns the heading
-    // + bullet format, keeping this builder source-agnostic.
-    let external = external_context.trim();
-    if !external.is_empty() {
-        msg.push_str(external);
-        if !external.ends_with('\n') {
-            msg.push('\n');
-        }
-        msg.push('\n');
-    }
-
-    // Structured-output instruction (schema-enforced; no need to emit a fence).
-    msg.push_str(
-        "Please review the diff above and populate the structured response \
-         fields (verdict, summary, findings) as specified in the system prompt.\n",
-    );
-
-    msg
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -1,0 +1,164 @@
+//! System-prompt templates for the reviewer role.
+//!
+//! Why: the two prompt constants (stock and coverage-gating variant) are each
+//! ~70–90 lines of prose; extracting them here keeps `prompt.rs` under the
+//! 500-line cap (#610) after the #1014 coverage-gating additions.
+//!
+//! What: two `pub const` strings exported to `prompt.rs`.  The stock constant
+//! is the pre-#1014 text (unchanged behaviour when coverage gating is off).
+//! The coverage-gating variant replaces the "do not block on coverage" advisory
+//! with an informational note that the runner will apply a deterministic floor.
+//!
+//! Test: `system_prompt_coverage_gating_on`, `system_prompt_coverage_gating_off`
+//! in `prompt_tests.rs`.
+
+// Stock prompt (unchanged from pre-#1014, no coverage gating language).
+pub const SYSTEM_PROMPT_STOCK: &str = r#"You are a senior software engineer performing a pull-request code review.
+
+## Letter grade (MANDATORY — assign exactly one)
+
+Assign a letter grade on the 13-step scale: A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F.
+
+| Grade band        | Quality signal                                              |
+|-------------------|-------------------------------------------------------------|
+| A+, A, A-         | Excellent to exceptional — clean, correct, well-structured. |
+| B+, B, B-         | Good to solid — acceptable, minor nits only.                |
+| C+, C, C-         | Marginal — notable issues or advisory concerns.             |
+| D+, D, D-         | Poor — significant problems requiring changes before merge. |
+| F                 | Failing — compile error, data corruption, security bypass.  |
+
+Provide a one-line justification in `grade_justification`.
+
+## Verdict (MANDATORY — pick exactly one)
+
+| Verdict         | Grade band      | When to use |
+|-----------------|-----------------|-------------|
+| BLOCK           | F               | Compile error introduced by this diff, data corruption, security/auth bypass. |
+| REQUEST_CHANGES | D+, D, D-       | Confirmed correctness bug, silent data loss, missing required migration/backfill, resource leak, unhandled exception path with real failure consequence. |
+| APPROVE*        | C+, C, C-       | Advisory concern the author may reasonably disagree with; the code ships but you want the note on record. |
+| APPROVE         | B- or above     | No significant concerns; the change is clean and correct. |
+| UNKNOWN         | —               | The diff was too truncated, context-free, or otherwise insufficient to assess. |
+
+**Keep your verdict consistent with your grade.** A grade of "D" must have verdict REQUEST_CHANGES;
+a grade of "F" must have verdict BLOCK; a grade of "B-" or above must have verdict APPROVE.
+
+- Your default verdict is APPROVE (default grade A-). You bear the burden of proof to escalate.
+- APPROVE* requires at least one Medium finding. Do not emit APPROVE* with only Low findings.
+- REQUEST_CHANGES requires ALL THREE: (a) a specific wrong line cited verbatim,
+  (b) a traceable failure path, (c) a concrete fix proposed.
+- Do NOT emit UNKNOWN just because the PR is large; use it only when you
+  genuinely cannot tell if the change is correct.
+- **Do not under-rate a clearly blocking issue as advisory.** If it would break
+  a build or corrupt data in production, assign severity=critical and verdict=BLOCK.
+
+## Compile-break rule (CRITICAL)
+If the diff REMOVES a symbol (enum value, method, constant, field, function
+signature change) AND the same diff still shows remaining references or
+call-sites to that removed symbol elsewhere in the codebase, that is a
+compile-time regression.  Assign the finding severity=critical and
+verdict=BLOCK (grade=F).  No other context softens this.
+
+## Severity anchors for findings
+Every finding MUST have a `severity` from:
+- **critical** — compile error, data corruption, security bypass, auth failure.
+- **high**     — confirmed correctness bug, silent data loss, unhandled exception
+  path, missing required migration, resource leak with real consequence.
+- **medium**   — advisory: code smell, suboptimal pattern, minor risk, the author
+  may reasonably disagree.
+- **low**      — cosmetic, documentation gap, style preference.
+
+## What to review
+Focus on: correctness bugs, security issues, data-loss risks, logic errors.
+Note but do not block on: style, minor naming, documentation gaps, test coverage.
+
+## Output (REQUIRED — populate the structured response fields)
+- `grade`: one of A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F.
+- `grade_justification`: one-sentence reason for the grade.
+- `verdict`: one of APPROVE, APPROVE*, REQUEST_CHANGES, BLOCK, UNKNOWN.
+- `summary`: one sentence summary of the review.
+- `findings`: array of issues found (empty array if none).
+  Each finding has: title, body (detailed description), severity (low/medium/high/critical),
+  confidence (0.0–1.0), file (source file path), line (null if not applicable).
+
+`confidence` is a float in [0.0, 1.0].
+`line` may be null if no specific line is applicable.
+`findings` may be an empty array if there are no issues."#;
+
+// Coverage-gating variant — "do not block on coverage" is replaced with an
+// informational note because the runner will apply a coverage floor (#1014).
+pub const SYSTEM_PROMPT_COVERAGE_GATING: &str = r#"You are a senior software engineer performing a pull-request code review.
+
+## Letter grade (MANDATORY — assign exactly one)
+
+Assign a letter grade on the 13-step scale: A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F.
+
+| Grade band        | Quality signal                                              |
+|-------------------|-------------------------------------------------------------|
+| A+, A, A-         | Excellent to exceptional — clean, correct, well-structured. |
+| B+, B, B-         | Good to solid — acceptable, minor nits only.                |
+| C+, C, C-         | Marginal — notable issues or advisory concerns.             |
+| D+, D, D-         | Poor — significant problems requiring changes before merge. |
+| F                 | Failing — compile error, data corruption, security bypass.  |
+
+Provide a one-line justification in `grade_justification`.
+
+## Verdict (MANDATORY — pick exactly one)
+
+| Verdict         | Grade band      | When to use |
+|-----------------|-----------------|-------------|
+| BLOCK           | F               | Compile error introduced by this diff, data corruption, security/auth bypass. |
+| REQUEST_CHANGES | D+, D, D-       | Confirmed correctness bug, silent data loss, missing required migration/backfill, resource leak, unhandled exception path with real failure consequence. |
+| APPROVE*        | C+, C, C-       | Advisory concern the author may reasonably disagree with; the code ships but you want the note on record. |
+| APPROVE         | B- or above     | No significant concerns; the change is clean and correct. |
+| UNKNOWN         | —               | The diff was too truncated, context-free, or otherwise insufficient to assess. |
+
+**Keep your verdict consistent with your grade.** A grade of "D" must have verdict REQUEST_CHANGES;
+a grade of "F" must have verdict BLOCK; a grade of "B-" or above must have verdict APPROVE.
+
+- Your default verdict is APPROVE (default grade A-). You bear the burden of proof to escalate.
+- APPROVE* requires at least one Medium finding. Do not emit APPROVE* with only Low findings.
+- REQUEST_CHANGES requires ALL THREE: (a) a specific wrong line cited verbatim,
+  (b) a traceable failure path, (c) a concrete fix proposed.
+- Do NOT emit UNKNOWN just because the PR is large; use it only when you
+  genuinely cannot tell if the change is correct.
+- **Do not under-rate a clearly blocking issue as advisory.** If it would break
+  a build or corrupt data in production, assign severity=critical and verdict=BLOCK.
+
+## Compile-break rule (CRITICAL)
+If the diff REMOVES a symbol (enum value, method, constant, field, function
+signature change) AND the same diff still shows remaining references or
+call-sites to that removed symbol elsewhere in the codebase, that is a
+compile-time regression.  Assign the finding severity=critical and
+verdict=BLOCK (grade=F).  No other context softens this.
+
+## Severity anchors for findings
+Every finding MUST have a `severity` from:
+- **critical** — compile error, data corruption, security bypass, auth failure.
+- **high**     — confirmed correctness bug, silent data loss, unhandled exception
+  path, missing required migration, resource leak with real consequence.
+- **medium**   — advisory: code smell, suboptimal pattern, minor risk, the author
+  may reasonably disagree.
+- **low**      — cosmetic, documentation gap, style preference.
+
+## What to review
+Focus on: correctness bugs, security issues, data-loss risks, logic errors.
+Note but do not block on: style, minor naming, documentation gaps.
+
+## Test coverage
+A coverage report has been provided in the user message (## Test coverage context).
+You may note coverage gaps as findings (severity=low or medium), but do NOT use
+coverage to escalate your verdict — the runner applies a separate deterministic
+coverage floor after your response based on the configured policy.
+
+## Output (REQUIRED — populate the structured response fields)
+- `grade`: one of A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F.
+- `grade_justification`: one-sentence reason for the grade.
+- `verdict`: one of APPROVE, APPROVE*, REQUEST_CHANGES, BLOCK, UNKNOWN.
+- `summary`: one sentence summary of the review.
+- `findings`: array of issues found (empty array if none).
+  Each finding has: title, body (detailed description), severity (low/medium/high/critical),
+  confidence (0.0–1.0), file (source file path), line (null if not applicable).
+
+`confidence` is a float in [0.0, 1.0].
+`line` may be null if no specific line is applicable.
+`findings` may be an empty array if there are no issues."#;

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -189,6 +189,7 @@ fn prompt_includes_context_blocks() {
             line: Some(20),
         }],
         apex_results: vec![],
+        coverage_contrib: None,
     };
 
     let req = build_review_prompt(

--- a/crates/trusty-review/src/pipeline/prompt_user_msg.rs
+++ b/crates/trusty-review/src/pipeline/prompt_user_msg.rs
@@ -1,0 +1,165 @@
+//! User-turn message builder for the review prompt.
+//!
+//! Why: extracted from `prompt.rs` to keep that file under the 500-line cap
+//! (#610) after the coverage-gating additions (#1014) caused it to grow.
+//! What: the single public-within-pipeline function `build_user_message` formats
+//! the PR identity, diff, and all context blocks into the user-turn text.
+//! Test: `prompt_includes_context_blocks`, `prompt_includes_external_context`
+//! in `prompt_tests.rs`.
+
+use super::prompt::{ReviewContext, ReviewPrMeta};
+
+/// Build the user-turn message for the review prompt.
+///
+/// Why: the user message carries all the review input: PR identity, diff, and
+/// context blocks.  Splitting it from the system prompt makes each independently
+/// tweakable.
+/// What: formats PR metadata as a header, then the diff block, then optional
+/// context sections for code search and static analysis, then any external
+/// context (`## Related <source>` markdown already rendered by the context
+/// orchestrator — JIRA / Confluence / GitHub Issues; APEX in PR-B).
+/// Test: `prompt_includes_context_blocks`, `prompt_includes_external_context`.
+pub(super) fn build_user_message(
+    owner: &str,
+    repo: &str,
+    pr_meta: &ReviewPrMeta,
+    diff: &str,
+    context: &ReviewContext,
+    external_context: &str,
+) -> String {
+    let mut msg = String::with_capacity(diff.len() + 2048);
+
+    // PR header.
+    msg.push_str(&format!("## PR: {owner}/{repo}"));
+    if !pr_meta.title.is_empty() {
+        msg.push_str(&format!(" — {}", pr_meta.title));
+    }
+    msg.push('\n');
+    if !pr_meta.author.is_empty() {
+        msg.push_str(&format!("Author: @{}\n", pr_meta.author));
+    }
+    if !pr_meta.url.is_empty() {
+        msg.push_str(&format!("URL: {}\n", pr_meta.url));
+    }
+    msg.push('\n');
+
+    // Diff block.
+    msg.push_str("## Unified diff\n\n");
+    msg.push_str("```diff\n");
+    msg.push_str(diff);
+    if !diff.ends_with('\n') {
+        msg.push('\n');
+    }
+    msg.push_str("```\n\n");
+
+    // Code search context block.
+    if !context.search_results.is_empty() {
+        msg.push_str("## Related code (from trusty-search)\n\n");
+        for (i, result) in context.search_results.iter().enumerate().take(10) {
+            msg.push_str(&format!("### Context {} — {}\n", i + 1, result.file));
+            if let Some(ref snippet) = result.snippet {
+                msg.push_str("```\n");
+                msg.push_str(snippet);
+                if !snippet.ends_with('\n') {
+                    msg.push('\n');
+                }
+                msg.push_str("```\n");
+            }
+            msg.push('\n');
+        }
+    }
+
+    // Static-analysis context block.
+    if !context.complexity_hotspots.is_empty() {
+        msg.push_str("## Complexity hotspots (from trusty-analyze)\n\n");
+        for h in context.complexity_hotspots.iter().take(5) {
+            let fn_part = h
+                .function_name
+                .as_deref()
+                .map(|f| format!(" `{f}`"))
+                .unwrap_or_default();
+            msg.push_str(&format!(
+                "- `{}`{fn_part}: cyclomatic={}, cognitive={}\n",
+                h.file, h.cyclomatic, h.cognitive
+            ));
+        }
+        msg.push('\n');
+    }
+
+    if !context.smells.is_empty() {
+        msg.push_str("## Code smells (from trusty-analyze)\n\n");
+        for s in context.smells.iter().take(10) {
+            let line_part = s.line.map(|l| format!(" (line {l})")).unwrap_or_default();
+            msg.push_str(&format!(
+                "- `{}` — {} [{}]{line_part}\n",
+                s.file, s.category, s.severity
+            ));
+        }
+        msg.push('\n');
+    }
+
+    // APEX product-spec context block (Phase 6 PR-B, REV-420).
+    // Each result is a snippet from the spec/docs corpus that semantically
+    // matches the PR content.  Cite format: [apex: `path:line` — "excerpt"].
+    if !context.apex_results.is_empty() {
+        msg.push_str("## Related APEX product specs\n\n");
+        // defensive: apex_results already capped in fetch_apex_context; guard against future refactors
+        for (i, apex) in context
+            .apex_results
+            .iter()
+            .enumerate()
+            .take(crate::config::constants::MAX_APEX_RESULTS)
+        {
+            let line_suffix = apex.start_line.map(|l| format!(":{l}")).unwrap_or_default();
+            msg.push_str(&format!(
+                "### APEX {} — `{}{}`\n",
+                i + 1,
+                apex.file,
+                line_suffix
+            ));
+            if !apex.snippet.is_empty() {
+                msg.push_str("```\n");
+                msg.push_str(&apex.snippet);
+                if !apex.snippet.ends_with('\n') {
+                    msg.push('\n');
+                }
+                msg.push_str("```\n");
+            }
+            msg.push('\n');
+        }
+        msg.push_str(
+            "When citing an APEX spec, use the format: \
+             [apex: `path/to/spec.md:15` — \"brief excerpt\"]\n\n",
+        );
+    }
+
+    // External context block (rendered `## Related <source>` markdown from the
+    // context orchestrator — JIRA / Confluence / GitHub Issues).
+    // It is appended verbatim because the orchestrator already owns the heading
+    // + bullet format, keeping this builder source-agnostic.
+    let external = external_context.trim();
+    if !external.is_empty() {
+        msg.push_str(external);
+        if !external.ends_with('\n') {
+            msg.push('\n');
+        }
+        msg.push('\n');
+    }
+
+    // Coverage context block (#1014): inject the coverage summary when available.
+    // The runner applies the deterministic floor AFTER the LLM call; we surface
+    // the numbers here so the LLM can reference them in findings if relevant.
+    if let Some(ref cov) = context.coverage_contrib {
+        msg.push_str("## Test coverage context\n\n");
+        msg.push_str(&cov.summary);
+        msg.push_str("\n\n");
+    }
+
+    // Structured-output instruction (schema-enforced; no need to emit a fence).
+    msg.push_str(
+        "Please review the diff above and populate the structured response \
+         fields (verdict, summary, findings) as specified in the system prompt.\n",
+    );
+
+    msg
+}

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -15,25 +15,20 @@ use std::sync::Arc;
 
 use tracing::{debug, info, warn};
 
+use super::runner_coverage::load_coverage_contrib;
+use super::runner_helpers::{abort_dry, apply_grade_and_floor, fetch_github_pr_meta, finalize_run};
 use crate::{
     config::ReviewConfig,
-    integrations::{
-        analyze_client::AnalyzeClient,
-        github::{AuthStrategy, GithubClient, GithubError, RunMode, fetch_pr_metadata},
-        search_client::SearchClient,
-    },
+    coverage::{CoverageVerdictContrib, apply_coverage_floor},
+    integrations::{analyze_client::AnalyzeClient, github::RunMode, search_client::SearchClient},
     llm::LlmProvider,
     models::{ReviewResult, ReviewStatus, Verdict},
     pipeline::{
         context_gate::{GateOutcome, degraded_banner, preflight_context},
         diff::{DiffSource, extract_changed_files, extract_identifiers, load_diff, truncate_diff},
         diff_analyzer::DiffAnalyzer, // noise filter (Stages A+B); #624
-        grade::derive_verdict_with_grade,
-        letter_grade::default_grade_for_verdict,
-        output::{print_review_result, write_review_log},
         parser::parse_review_response,
-        post::{PostContext, finalize_review},
-        prompt::{ReviewPrMeta, build_review_prompt},
+        prompt::{ReviewPrMeta, build_review_prompt_with_coverage},
         runner_context::{gather_context, gather_external_context_md},
         trigger::TriggerDecision,
         verify::maybe_verify,
@@ -257,7 +252,7 @@ pub async fn run_review(
     // config.apex_index: empty = disabled.
     let title = &pr_meta.title;
     let body = &pr_meta.body;
-    let (context, external_context) = tokio::join!(
+    let (mut context, external_context) = tokio::join!(
         gather_context(config, &deps, &identifiers, &changed_files, title, body),
         gather_external_context_md(
             config,
@@ -271,10 +266,21 @@ pub async fn run_review(
         ),
     );
 
+    // ── Step 5b: load coverage data and build coverage verdict contrib (#1014) ──
+    // Coverage is FAIL-OPEN and OFF by default.  When `config.coverage.enabled`
+    // is false (the default), `load_coverage_contrib` returns None and the entire
+    // coverage pipeline is skipped.  Failures (e.g. LCOV file missing) produce a
+    // warning and None — never an error that blocks the review.
+    let coverage_contrib: Option<CoverageVerdictContrib> =
+        load_coverage_contrib(config, &diff).await;
+
+    // Inject the coverage contrib into the context struct for prompt assembly.
+    context.coverage_contrib = coverage_contrib.clone();
+
     // ── Step 6: build prompt and call LLM ─────────────────────────────────
     // Build the 3-layer VoiceConfig (stock + principles + voice) from config.
     let voice_config = build_voice_config(config);
-    let llm_req = build_review_prompt(
+    let llm_req = build_review_prompt_with_coverage(
         &owner,
         &repo,
         &pr_meta,
@@ -283,6 +289,7 @@ pub async fn run_review(
         &external_context,
         &input.reviewer_model,
         &voice_config,
+        config.coverage.enabled,
     );
     debug!(model = %input.reviewer_model, "calling LLM reviewer");
 
@@ -327,7 +334,7 @@ pub async fn run_review(
         );
     }
 
-    // ── Step 7b–7d: grade derivation, verification, grade reconciliation ─────
+    // ── Step 7b–7e: grade derivation, coverage floor, verification, reconcile ─
     let (final_verdict, final_grade) = apply_grade_and_floor(&parsed);
     info!(
         verdict = %final_verdict,
@@ -335,6 +342,26 @@ pub async fn run_review(
         findings_count = parsed.findings.len(),
         "final verdict + grade after severity-anchored floor"
     );
+
+    // 7b-post: apply coverage floor AFTER severity derivation (#1014).
+    // Coverage can only TIGHTEN (REQUEST_CHANGES) — never soften a BLOCK.
+    // This is a no-op when coverage gating is disabled (the default).
+    let (final_verdict, final_grade) = if let Some(ref cov) = coverage_contrib {
+        let before = final_verdict.clone();
+        let (cv, cg) = apply_coverage_floor(final_verdict, final_grade, cov);
+        if cv != before {
+            info!(
+                before = %before,
+                after = %cv,
+                reason = %cov.summary,
+                "coverage floor tightened verdict"
+            );
+        }
+        (cv, cg)
+    } else {
+        (final_verdict, final_grade)
+    };
+
     let mut findings = parsed.findings;
     // 7c: verification round — re-derives verdict from surviving findings.
     result.verdict = maybe_verify(
@@ -353,145 +380,6 @@ pub async fn run_review(
     );
 
     finalize_run(result, config, &input, deps.dedup.as_ref()).await
-}
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/// Derive (verdict, grade) from a `ParsedReview` using grade + severity floor.
-///
-/// Why: extracted to keep `run_review` under the line cap and make it testable.
-/// What: fail-safe → (APPROVE, default grade); normal → resolves LLM grade string
-/// (or default), calls `derive_verdict_with_grade` for max(grade, model) + floor.
-/// Test: covered by runner integration tests.
-fn apply_grade_and_floor(
-    parsed: &crate::pipeline::parser::ParsedReview,
-) -> (Verdict, crate::pipeline::letter_grade::Grade) {
-    if parsed.is_fail_safe {
-        let v = parsed.verdict.clone();
-        let g = default_grade_for_verdict(&v);
-        return (v, g);
-    }
-    let grade = parsed
-        .grade
-        .as_deref()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or_else(|| {
-            let g = default_grade_for_verdict(&parsed.verdict);
-            warn!(
-                verdict = %parsed.verdict,
-                default_grade = %g,
-                "LLM grade absent or unparseable — using default for verdict"
-            );
-            g
-        });
-    derive_verdict_with_grade(parsed.verdict.clone(), grade, &parsed.findings)
-}
-
-/// Fetch PR metadata and return `(ReviewPrMeta, head_sha)`.
-///
-/// Why: centralises the GitHub API call and head-SHA surfacing so the runner
-/// can key the dedup store.
-/// What: resolves token via run_mode, calls `fetch_pr_metadata`.
-/// Test: tested indirectly via mock in integration tests.
-async fn fetch_github_pr_meta(
-    config: &ReviewConfig,
-    owner: &str,
-    repo: &str,
-    pr: u64,
-    run_mode: RunMode,
-) -> Result<(ReviewPrMeta, String), GithubError> {
-    let client = GithubClient::new()?;
-    let token = AuthStrategy::select(run_mode, None)
-        .resolve_token(&client, config, owner)
-        .await?;
-    let meta = fetch_pr_metadata(&client, owner, repo, pr, &token).await?;
-    let head_sha = meta.head.sha.clone();
-    Ok((
-        ReviewPrMeta {
-            title: meta.title,
-            // Fix 3 (#599): thread the PR description through so the external
-            // context sources can scan it for ticket keys + fold it into queries.
-            body: meta.body.unwrap_or_default(),
-            author: meta.user.login,
-            url: meta.html_url,
-        },
-        head_sha,
-    ))
-}
-
-/// Finalise an *aborted* review as dry-run only, releasing the dedup claim.
-///
-/// Why: a review that aborts before producing a real verdict (diff-load failure
-/// or LLM transport error) must never be posted live — it carries only a
-/// fail-safe APPROVE/UNKNOWN.  It must also *release* its dedup claim so a later
-/// retry (e.g. once the LLM recovers) can re-run instead of being suppressed.
-/// What: releases the in-progress dedup claim (fail-safe on error), writes the
-/// dry-run log so the failure is inspectable, prints when requested, and returns
-/// the result flagged `dry_run = true`.
-/// Test: `run_review_fail_safe_on_llm_error`, `run_review_missing_diff_file_sets_error`.
-fn abort_dry(
-    mut result: ReviewResult,
-    config: &ReviewConfig,
-    input: &ReviewInput,
-    deps: &ReviewDeps,
-) -> ReviewResult {
-    result.dry_run = true;
-    // Release the in-progress claim so a retry can re-run this head SHA.
-    if !result.head_sha.is_empty()
-        && let Some(store) = deps.dedup.as_ref()
-        && let Err(e) = store.release(
-            &result.owner,
-            &result.repo,
-            result.pr_number,
-            &result.head_sha,
-        )
-    {
-        warn!("dedup release() after abort failed (non-fatal): {e}");
-    }
-    if input.write_log {
-        write_review_log(&result, &config.log_dir);
-    }
-    if input.print_result {
-        print_review_result(&result);
-    }
-    result
-}
-
-/// Apply post-or-log finalisation (Phase 1, #582) for a completed review.
-///
-/// Why: single exit path so live/dry policy is applied exactly once.
-/// What: builds `PostContext` from result fields, delegates to `finalize_review`.
-/// Test: `post::tests` cover branch selection; runner tests assert dry-run.
-async fn finalize_run(
-    result: ReviewResult,
-    config: &ReviewConfig,
-    input: &ReviewInput,
-    dedup: Option<&Arc<DedupStore>>,
-) -> ReviewResult {
-    // Clone the dedup-key fields up front so `result` can be moved into
-    // `finalize_review` while `PostContext` borrows the owned copies.
-    let owner = result.owner.clone();
-    let repo = result.repo.clone();
-    let pr = result.pr_number;
-    let head_sha = result.head_sha.clone();
-    let post_ctx = PostContext {
-        owner: &owner,
-        repo: &repo,
-        pr,
-        head_sha: &head_sha,
-        run_mode: input.run_mode,
-        dedup,
-    };
-    finalize_review(
-        result,
-        config,
-        input.trigger,
-        input.allow_posting,
-        input.write_log,
-        input.print_result,
-        post_ctx,
-    )
-    .await
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -135,6 +135,9 @@ pub(crate) async fn gather_context(
         complexity_hotspots,
         smells,
         apex_results,
+        // Coverage contrib is populated by the runner AFTER context gathering
+        // (step 5b), once the diff is available for new-code extraction (#1014).
+        coverage_contrib: None,
     }
 }
 

--- a/crates/trusty-review/src/pipeline/runner_coverage.rs
+++ b/crates/trusty-review/src/pipeline/runner_coverage.rs
@@ -1,0 +1,204 @@
+//! Coverage data loading for the review runner (issue #1014).
+//!
+//! Why: extracted from `runner.rs` to keep that file under the 500-line cap
+//! (#610) after adding the coverage-gating pipeline.  All coverage-specific
+//! runner logic lives here; the runner itself only calls `load_coverage_contrib`.
+//!
+//! What: `load_coverage_contrib` is the single entry point used by the runner
+//! (step 5b).  `extract_added_lines_from_diff` is a pure helper that parses
+//! the diff for added-line numbers so the LCOV intersection can be computed.
+//!
+//! Test: `extract_added_lines_basic`, `extract_added_lines_multi_file`,
+//! `extract_added_lines_hunk_restart`.
+
+use std::collections::HashMap;
+
+use tracing::{info, warn};
+
+use crate::{
+    config::ReviewConfig,
+    coverage::{CoverageVerdictContrib, evaluate_coverage, new_code_coverage, parse_lcov_file},
+};
+
+/// Load coverage data from the configured LCOV path and evaluate the policy.
+///
+/// Why: the runner calls this once per review; it is async (future-proofed for
+/// fetching coverage from a remote URL) but currently only reads from disk.
+/// The function is FAIL-OPEN: any error produces a tracing warning and `None`,
+/// never an error that blocks the review.
+/// What: when `config.coverage.enabled` is false, returns None immediately (no-op).
+/// When enabled, reads `config.coverage.lcov_path` (if set), parses it, extracts
+/// added-line data from the diff for new-code coverage, and calls `evaluate_coverage`.
+/// Test: runner_tests.rs — `run_review_coverage_off_is_noop`,
+/// `run_review_coverage_floors_approve`.
+pub async fn load_coverage_contrib(
+    config: &ReviewConfig,
+    diff: &str,
+) -> Option<CoverageVerdictContrib> {
+    // OFF by default — strict no-op.
+    if !config.coverage.enabled {
+        return None;
+    }
+
+    let path = config.coverage.lcov_path.as_ref()?;
+
+    let report = match parse_lcov_file(path) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                "coverage: failed to load LCOV file (proceeding without coverage): {e}"
+            );
+            return None;
+        }
+    };
+
+    // Extract added lines from the diff for new-code coverage calculation.
+    let added_lines = extract_added_lines_from_diff(diff);
+    let new_code_pct = new_code_coverage(&report, &added_lines);
+
+    let contrib = evaluate_coverage(&config.coverage, &report, new_code_pct, None);
+
+    info!(
+        net_pct = report.net_pct,
+        new_code_pct = new_code_pct.unwrap_or(-1.0),
+        floor = ?contrib.floor,
+        "coverage evaluation complete"
+    );
+
+    Some(contrib)
+}
+
+/// Extract added lines ("+"-prefixed) from a unified diff, keyed by file path.
+///
+/// Why: the new-code coverage calculation needs to know which lines were added
+/// so it can intersect with the per-file LCOV hit data.
+/// What: iterates over diff lines; tracks the current file via "+++ b/" headers
+/// and the current hunk start via "@@ … +<start>,<count> @@" markers.
+/// Lines beginning with "+" (but not "+++") are counted as added at the inferred
+/// line number.  Non-instrumented lines (blank lines, comments) will simply be
+/// absent from the LCOV map and are ignored by `new_code_coverage`.
+/// Test: `extract_added_lines_basic`, `extract_added_lines_multi_file`.
+pub fn extract_added_lines_from_diff(diff: &str) -> HashMap<String, Vec<u32>> {
+    let mut result: HashMap<String, Vec<u32>> = HashMap::new();
+    let mut current_file: Option<String> = None;
+    let mut current_line: u32 = 0;
+
+    for line in diff.lines() {
+        if let Some(stripped) = line.strip_prefix("+++ b/") {
+            // New file in the diff.
+            let path = stripped.to_string();
+            current_file = Some(path);
+            current_line = 0;
+        } else if line.starts_with("--- ") || line.starts_with("+++ ") {
+            // Other header line — ignore.
+        } else if line.starts_with("@@ ") {
+            // Hunk header: "@@ -<old_start>,<old_count> +<new_start>,<new_count> @@"
+            // Extract the new-file start line number.
+            if let Some(plus_pos) = line.find('+') {
+                let rest = &line[plus_pos + 1..];
+                let end = rest.find([',', ' ']).unwrap_or(rest.len());
+                if let Ok(n) = rest[..end].parse::<u32>() {
+                    // Hunk starts at line n; we'll increment as we see lines.
+                    current_line = n.saturating_sub(1);
+                }
+            }
+        } else if line.starts_with('+') {
+            // Added line.
+            current_line += 1;
+            if let Some(ref file) = current_file {
+                result.entry(file.clone()).or_default().push(current_line);
+            }
+        } else if line.starts_with('-') {
+            // Removed line — does not advance the new-file line counter.
+        } else {
+            // Context line — advances the new-file line counter.
+            current_line += 1;
+        }
+    }
+
+    result
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// extract_added_lines_from_diff: single file, single hunk.
+    ///
+    /// Why: the basic case must map "+"-prefixed lines to the correct 1-based
+    /// line numbers in the new file.
+    /// Test: simple diff with one added line at line 3.
+    #[test]
+    fn extract_added_lines_basic() {
+        let diff = "\
+--- a/src/foo.rs
++++ b/src/foo.rs
+@@ -1,2 +1,3 @@
+ fn foo() {
++    let x = 1;
+ }
+";
+        let added = extract_added_lines_from_diff(diff);
+        let lines = added.get("src/foo.rs").expect("src/foo.rs must be present");
+        assert_eq!(lines, &[2], "added line must be at new-file line 2");
+    }
+
+    /// extract_added_lines_from_diff: multi-file diff.
+    ///
+    /// Why: verifies the file-tracking logic resets correctly across file boundaries.
+    /// Test: two files; each with one added line.
+    #[test]
+    fn extract_added_lines_multi_file() {
+        let diff = "\
+--- a/src/a.rs
++++ b/src/a.rs
+@@ -1,1 +1,2 @@
+ fn a() {}
++fn b() {}
+--- a/src/b.rs
++++ b/src/b.rs
+@@ -1,1 +1,2 @@
+ fn c() {}
++fn d() {}
+";
+        let added = extract_added_lines_from_diff(diff);
+        assert!(added.contains_key("src/a.rs"), "src/a.rs must be present");
+        assert!(added.contains_key("src/b.rs"), "src/b.rs must be present");
+        // Both have one added line at new-file line 2.
+        assert_eq!(added["src/a.rs"], [2]);
+        assert_eq!(added["src/b.rs"], [2]);
+    }
+
+    /// extract_added_lines_from_diff: hunk with explicit start line > 1.
+    ///
+    /// Why: verifies the @@ parser correctly reads the new-file start offset.
+    /// Test: hunk starting at line 10 with one added line.
+    #[test]
+    fn extract_added_lines_hunk_restart() {
+        let diff = "\
+--- a/src/foo.rs
++++ b/src/foo.rs
+@@ -10,2 +10,3 @@
+ existing_line();
++new_line();
+ another_existing();
+";
+        let added = extract_added_lines_from_diff(diff);
+        let lines = added.get("src/foo.rs").expect("must be present");
+        // Context line at 10, added line at 11.
+        assert_eq!(lines, &[11]);
+    }
+
+    /// extract_added_lines_from_diff: empty diff → empty map.
+    ///
+    /// Why: an empty diff must not panic or produce spurious entries.
+    /// Test: empty string input.
+    #[test]
+    fn extract_added_lines_empty() {
+        let added = extract_added_lines_from_diff("");
+        assert!(added.is_empty(), "empty diff must produce empty map");
+    }
+}

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -1,0 +1,168 @@
+//! Helper functions for the review runner (extracted from runner.rs).
+//!
+//! Why: extracted from `runner.rs` to keep that file under the 500-line cap
+//! (#610) after the coverage-gating additions in #1014.  All functions here
+//! are small, cohesive helpers called exactly once by `run_review`.
+//!
+//! What: grade derivation, GitHub PR metadata fetch, abort-dry, and finalise-run.
+//!
+//! Test: covered transitively by runner integration tests.
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::integrations::github::{
+    AuthStrategy, GithubClient, GithubError, RunMode, fetch_pr_metadata,
+};
+use crate::{
+    config::ReviewConfig,
+    models::{ReviewResult, Verdict},
+    pipeline::{
+        grade::derive_verdict_with_grade,
+        letter_grade::default_grade_for_verdict,
+        output::{print_review_result, write_review_log},
+        post::{PostContext, finalize_review},
+        prompt::ReviewPrMeta,
+    },
+    store::DedupStore,
+};
+
+use super::runner::{ReviewDeps, ReviewInput};
+
+/// Derive (verdict, grade) from a `ParsedReview` using grade + severity floor.
+///
+/// Why: extracted to keep `run_review` under the line cap and make it testable.
+/// What: fail-safe → (APPROVE, default grade); normal → resolves LLM grade string
+/// (or default), calls `derive_verdict_with_grade` for max(grade, model) + floor.
+/// Test: covered by runner integration tests.
+pub(super) fn apply_grade_and_floor(
+    parsed: &crate::pipeline::parser::ParsedReview,
+) -> (Verdict, crate::pipeline::letter_grade::Grade) {
+    if parsed.is_fail_safe {
+        let v = parsed.verdict.clone();
+        let g = default_grade_for_verdict(&v);
+        return (v, g);
+    }
+    let grade = parsed
+        .grade
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| {
+            let g = default_grade_for_verdict(&parsed.verdict);
+            warn!(
+                verdict = %parsed.verdict,
+                default_grade = %g,
+                "LLM grade absent or unparseable — using default for verdict"
+            );
+            g
+        });
+    derive_verdict_with_grade(parsed.verdict.clone(), grade, &parsed.findings)
+}
+
+/// Fetch PR metadata and return `(ReviewPrMeta, head_sha)`.
+///
+/// Why: centralises the GitHub API call and head-SHA surfacing so the runner
+/// can key the dedup store.
+/// What: resolves token via run_mode, calls `fetch_pr_metadata`.
+/// Test: tested indirectly via mock in integration tests.
+pub(super) async fn fetch_github_pr_meta(
+    config: &ReviewConfig,
+    owner: &str,
+    repo: &str,
+    pr: u64,
+    run_mode: RunMode,
+) -> Result<(ReviewPrMeta, String), GithubError> {
+    let client = GithubClient::new()?;
+    let token = AuthStrategy::select(run_mode, None)
+        .resolve_token(&client, config, owner)
+        .await?;
+    let meta = fetch_pr_metadata(&client, owner, repo, pr, &token).await?;
+    let head_sha = meta.head.sha.clone();
+    Ok((
+        ReviewPrMeta {
+            title: meta.title,
+            // Fix 3 (#599): thread the PR description through so the external
+            // context sources can scan it for ticket keys + fold it into queries.
+            body: meta.body.unwrap_or_default(),
+            author: meta.user.login,
+            url: meta.html_url,
+        },
+        head_sha,
+    ))
+}
+
+/// Finalise an *aborted* review as dry-run only, releasing the dedup claim.
+///
+/// Why: a review that aborts before producing a real verdict (diff-load failure
+/// or LLM transport error) must never be posted live — it carries only a
+/// fail-safe APPROVE/UNKNOWN.  It must also *release* its dedup claim so a later
+/// retry (e.g. once the LLM recovers) can re-run instead of being suppressed.
+/// What: releases the in-progress dedup claim (fail-safe on error), writes the
+/// dry-run log so the failure is inspectable, prints when requested, and returns
+/// the result flagged `dry_run = true`.
+/// Test: `run_review_fail_safe_on_llm_error`, `run_review_missing_diff_file_sets_error`.
+pub(super) fn abort_dry(
+    mut result: ReviewResult,
+    config: &ReviewConfig,
+    input: &ReviewInput,
+    deps: &ReviewDeps,
+) -> ReviewResult {
+    result.dry_run = true;
+    // Release the in-progress claim so a retry can re-run this head SHA.
+    if !result.head_sha.is_empty()
+        && let Some(store) = deps.dedup.as_ref()
+        && let Err(e) = store.release(
+            &result.owner,
+            &result.repo,
+            result.pr_number,
+            &result.head_sha,
+        )
+    {
+        warn!("dedup release() after abort failed (non-fatal): {e}");
+    }
+    if input.write_log {
+        write_review_log(&result, &config.log_dir);
+    }
+    if input.print_result {
+        print_review_result(&result);
+    }
+    result
+}
+
+/// Apply post-or-log finalisation (Phase 1, #582) for a completed review.
+///
+/// Why: single exit path so live/dry policy is applied exactly once.
+/// What: builds `PostContext` from result fields, delegates to `finalize_review`.
+/// Test: `post::tests` cover branch selection; runner tests assert dry-run.
+pub(super) async fn finalize_run(
+    result: ReviewResult,
+    config: &ReviewConfig,
+    input: &ReviewInput,
+    dedup: Option<&Arc<DedupStore>>,
+) -> ReviewResult {
+    // Clone the dedup-key fields up front so `result` can be moved into
+    // `finalize_review` while `PostContext` borrows the owned copies.
+    let owner = result.owner.clone();
+    let repo = result.repo.clone();
+    let pr = result.pr_number;
+    let head_sha = result.head_sha.clone();
+    let post_ctx = PostContext {
+        owner: &owner,
+        repo: &repo,
+        pr,
+        head_sha: &head_sha,
+        run_mode: input.run_mode,
+        dedup,
+    };
+    finalize_review(
+        result,
+        config,
+        input.trigger,
+        input.allow_posting,
+        input.write_log,
+        input.print_result,
+        post_ctx,
+    )
+    .await
+}


### PR DESCRIPTION
## Summary
Adds an opt-in, off-by-default test-coverage grading/gating dimension to trusty-review.

- Ingests LCOV coverage (cargo-llvm-cov / tarpaulin); parses net + new-code coverage.
- OFF by default: when `TRUSTY_REVIEW_COVERAGE_ENABLED` is unset, behavior is identical to today.
- Config knobs: `TRUSTY_REVIEW_COVERAGE_ENABLED`, `TRUSTY_REVIEW_MIN_NEW_CODE_PCT` (default 80), `TRUSTY_REVIEW_MAX_NET_DROP_PCT` (default 1.0pp), `TRUSTY_REVIEW_LCOV_PATH`; also configurable via `[coverage]` in TOML.
- Deterministic verdict floor: low new-code coverage or a net coverage drop floors the verdict to REQUEST_CHANGES and caps the grade — never weakens a BLOCK, preserving #1015 calibration.

## Test plan
- `cargo test -p trusty-review` — 814 tests pass
- clippy clean, fmt clean, line-cap clean
- Unit tests for LCOV parsing, off-by-default, and on→REQUEST_CHANGES

Closes #1014
