### PR TITLE
fix(trusty-analyze): O(1) index root_path lookup in diagnostics (closes #1013)

### DIFF
--- a/crates/trusty-analyze/src/core/client.rs
+++ b/crates/trusty-analyze/src/core/client.rs
@@ -142,6 +142,40 @@ impl TrustySearchClient {
         Ok(body.indexes)
     }
 
+    /// `GET /indexes/:id/status` — fetch the status of a single index, including `root_path`.
+    ///
+    /// Why: the diagnostics path previously called `index_details()` which fetches
+    /// ALL indexes and then linearly scans for the matching id just to obtain
+    /// `root_path`. This is O(n) per request (issue #1013). This method calls the
+    /// per-index status endpoint directly, making the lookup O(1) regardless of
+    /// how many indexes are registered.
+    /// What: GETs `{base}/indexes/{id}/status`, extracts the `root_path` string
+    /// field, and returns `Ok(Some(path))` when present, `Ok(None)` when the field
+    /// is absent or null, and `Err` when the HTTP call fails or the index is not
+    /// found (404).
+    /// Test: `index_status_deserializes_root_path` tests the serde extraction
+    /// without a live server by parsing a hand-built JSON string.
+    pub async fn index_status_root_path(&self, index_id: &str) -> Result<Option<String>> {
+        #[derive(Deserialize)]
+        struct StatusBody {
+            #[serde(default)]
+            root_path: Option<String>,
+        }
+        let url = format!("{}/indexes/{}/status", self.base_url, index_id);
+        let body: StatusBody = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?
+            .error_for_status()
+            .with_context(|| format!("non-2xx from {url}"))?
+            .json()
+            .await
+            .with_context(|| format!("decode {url}"))?;
+        Ok(body.root_path)
+    }
+
     /// `GET /indexes/:id/chunks` — bulk export of every chunk for `index_id`.
     /// Trusty-search must expose this endpoint (added as part of issue #40).
     ///
@@ -255,5 +289,27 @@ mod tests {
         assert_eq!(listing.indexes[0].root_path.as_deref(), Some("/src/myapp"));
         assert_eq!(listing.indexes[1].id, "idx2");
         assert!(listing.indexes[1].root_path.is_none());
+    }
+
+    #[test]
+    fn index_status_deserializes_root_path() {
+        // Simulate the JSON body returned by GET /indexes/:id/status.
+        // The status endpoint returns a richer object; only root_path is needed here.
+
+        // With root_path present (the common production case).
+        #[derive(serde::Deserialize)]
+        struct StatusBody {
+            #[serde(default)]
+            root_path: Option<String>,
+        }
+        let json_with = r#"{"index_id":"myproj","root_path":"/home/user/myproj","chunk_count":42}"#;
+        let s: StatusBody = serde_json::from_str(json_with).expect("parse status with root_path");
+        assert_eq!(s.root_path.as_deref(), Some("/home/user/myproj"));
+
+        // Without root_path (e.g. a future schema change or a test stub).
+        let json_without = r#"{"index_id":"myproj","chunk_count":0}"#;
+        let s2: StatusBody =
+            serde_json::from_str(json_without).expect("parse status without root_path");
+        assert!(s2.root_path.is_none());
     }
 }

--- a/crates/trusty-analyze/src/service/handlers/analysis.rs
+++ b/crates/trusty-analyze/src/service/handlers/analysis.rs
@@ -285,9 +285,10 @@ pub struct DiagnosticsParams {
 /// receive real on-disk paths via `root_path`; file-scoped tools write to a
 /// scratch dir as before.
 /// What: fetches the corpus, reconstructs whole-file content from chunks,
-/// fetches the index root_path (for project-scoped tools), then delegates all
-/// dispatch to `diagnostics_dispatch::run_diagnostics_blocking`. Results are
-/// sliced by `offset`+`limit` and returned with a pagination envelope.
+/// fetches the index root_path via `GET /indexes/:id/status` (O(1) single-index
+/// lookup — issue #1013), then delegates all dispatch to
+/// `diagnostics_dispatch::run_diagnostics_blocking`. Results are sliced by
+/// `offset`+`limit` and returned with a pagination envelope.
 /// Test: `diagnostics_endpoint_returns_empty_when_no_tools` boots the router
 /// with a stub client and confirms a well-formed empty response; pagination
 /// behaviour is unit-tested in `diagnostics_pagination_*` below.
@@ -315,20 +316,17 @@ pub async fn diagnostics_for_index(
         }
     }
 
-    // Fetch index details (including root_path) for project-scoped tools.
+    // Fetch root_path for this specific index via the single-index status
+    // endpoint (issue #1013: previously called index_details() which fetched
+    // ALL indexes and did an O(n) linear scan for the matching id).
     // Errors are non-fatal: project-scoped tools will gracefully skip if
     // root_path is unavailable, while file-scoped tools are unaffected.
-    //
-    // TODO(follow-up): replace this full-index-list round-trip with a
-    // per-index lookup once `GET /indexes/:id/status` exposes `root_path`.
-    // The current call fetches ALL indexes and linear-scans for the matching
-    // id on every request, which is wasteful for large deployments.
     let root_path = state
         .search
-        .index_details()
+        .index_status_root_path(&id)
         .await
         .ok()
-        .and_then(|v| v.into_iter().find(|s| s.id == id).and_then(|s| s.root_path));
+        .flatten();
 
     // Heavy work (process spawns, blocking I/O) runs off the async runtime.
     let language_filter = params.language.clone();


### PR DESCRIPTION
## Summary

- **Root cause**: `diagnostics_for_index` called `index_details()` which hits `GET /indexes?details=true` (fetches all registered indexes) then linear-scans for the matching id to extract `root_path`. This is O(n) in the number of indexes per diagnostics request.
- **Fix**: Added `index_status_root_path(index_id)` to `TrustySearchClient` — a single `GET /indexes/:id/status` call (already exposed by trusty-search and already returns `root_path`). Replaced the O(n) block in `diagnostics_for_index` with the new O(1) method.
- **No trusty-search changes needed**: the `/indexes/:id/status` endpoint already returns `root_path` in its response; this was verified by inspecting `status.rs`.

## Changes

- `crates/trusty-analyze/src/core/client.rs` — added `index_status_root_path(&str) -> Result<Option<String>>` method + `index_status_deserializes_root_path` unit test
- `crates/trusty-analyze/src/service/handlers/analysis.rs` — replaced `index_details()` O(n) call with `index_status_root_path()` O(1) call; removed TODO(follow-up) comment

## Test plan

- [x] `cargo check -p trusty-analyze` — clean
- [x] `cargo clippy -p trusty-analyze --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p trusty-analyze` — 449 passed, 0 failed, 1 ignored
- [x] `cargo fmt --check -p trusty-analyze` — no drift
- [x] `bash scripts/check_line_cap.sh` — 168 allowlisted, 0 violations
- [x] New unit test `index_status_deserializes_root_path` validates both the `root_path`-present and `root_path`-absent JSON shapes without a live server

🤖 Generated with [Claude Code](https://claude.com/claude-code)