### PR TITLE
feat(trusty-common): add Reads/Writes/AccessesResource KG edge variants (closes #817)

### DIFF
--- a/crates/trusty-analyze/src/types/graph.rs
+++ b/crates/trusty-analyze/src/types/graph.rs
@@ -110,13 +110,26 @@ pub struct KgNode {
 /// `trusty_common::symgraph::contracts` now covers all use cases across the
 /// toolchain (issue #815, ADR-0010 Option C). This type is a **re-export alias**
 /// to that canonical enum so existing call sites continue to compile without
-/// change. All 11 former variants are present in the canonical enum with the
-/// same names and serde representation.
+/// change.
 ///
 /// What: type alias to `trusty_common::symgraph::contracts::EdgeKind`.
-/// All former `KgEdgeKind` variants (`Contains`, `Imports`, `Exports`, `Calls`,
+/// The 11 former `KgEdgeKind` variants (`Contains`, `Imports`, `Exports`, `Calls`,
 /// `Implements`, `Extends`, `References`, `Tests`, `DependsOn`, `GeneratedFrom`,
 /// `RuntimeObservationFor`) are present in the canonical enum.
+/// Note: `Implements` was already in the canonical `contracts::EdgeKind` from
+/// Phase A (structural tree-sitter variants) before the convergence — it is NOT
+/// a new addition from `KgEdgeKind`. The two formerly diverged variants are now
+/// unified into one.
+/// Phase D data-flow variants (`Reads`, `Writes`, `AccessesResource`) added in
+/// issue #817 are also available here; C# and SQL adapter emission is planned.
+///
+/// ## Adapter guidance: `Calls` vs `CallsFunction`
+///
+/// Language adapters in this crate should emit `KgEdgeKind::Calls` (the coarse,
+/// language-neutral call edge). `CallsFunction` is for the trusty-search
+/// `EntityExtractor`'s entity-KG layer, which also maintains a reverse index
+/// via `CalledByFunction`. Emitting `CallsFunction` from a language adapter
+/// would create orphaned reverse-index entries.
 ///
 /// Test: `kg_edge_kind_serde_round_trip` in this module confirms every former
 /// `KgEdgeKind` variant still round-trips through `serde_json`.
@@ -281,6 +294,10 @@ mod tests {
             KgEdgeKind::DependsOn,
             KgEdgeKind::GeneratedFrom,
             KgEdgeKind::RuntimeObservationFor,
+            // Phase D data-flow variants (issue #817)
+            KgEdgeKind::Reads,
+            KgEdgeKind::Writes,
+            KgEdgeKind::AccessesResource,
         ];
         for v in &variants {
             let json = serde_json::to_string(v).expect("serialize KgEdgeKind");

--- a/crates/trusty-common/src/symgraph/contracts.rs
+++ b/crates/trusty-common/src/symgraph/contracts.rs
@@ -91,51 +91,45 @@ impl EntityType {
 
 /// Canonical KG edge-kind vocabulary for the trusty-* toolchain (issue #815, ADR-0010).
 ///
-/// Why: The trusty-* toolchain formerly had three diverged EdgeKind enums at
-/// different abstraction levels (contracts, graph, KgEdgeKind). Any new relation
-/// required changes in multiple places with inconsistent scoring semantics — a
-/// maintenance trap. ADR-0010 Option C converges all three into this single
-/// canonical enum so there is one vocabulary, one place to add variants, and one
-/// `score_multiplier` table.
+/// Why: Three formerly diverged enums (contracts, graph, KgEdgeKind) created a
+/// maintenance trap. ADR-0010 Option C converges them so there is one vocabulary
+/// and one `score_multiplier` table. Phase D adds data-flow variants (#817).
 ///
-/// **Previously separate enums — now type aliases to this type:**
-///   - `crate::symgraph::graph::EdgeKind` (3 coarse variants: `Calls`, `Imports`,
-///     `Contains`; used as petgraph edge weight for the in-memory `SymbolGraph`,
-///     gated behind the `symgraph-parser` feature).
-///   - `trusty_analyze::KgEdgeKind` (11 variants; language-neutral structural
-///     analysis KG for trusty-analyze's tree-sitter adapters).
+/// **Adapter guidance:** language adapters in trusty-analyze should emit `Calls`
+/// (coarse, no reverse index). `CallsFunction` is reserved for the trusty-search
+/// `EntityExtractor` which also maintains the `CalledByFunction` reverse index.
+/// Similarly, `Tests` is the forward direction (test → production symbol) and
+/// `TestedBy` is the reverse — emit the one that matches your traversal direction.
+/// `Implements` was present in Phase A (contracts) before convergence; it is NOT
+/// a new addition from `KgEdgeKind`.
 ///
-/// **Persistence back-compat:** for the 16 Phase A/B/C variants that were
-/// previously stored in trusty-search's redb warm-boot index, the on-disk tag
-/// strings are UNCHANGED. The new variants added from `KgEdgeKind` / `graph::EdgeKind`
-/// (`Calls`, `Contains`, `Imports`, `Exports`, `Extends`, `References`, `Tests`,
-/// `DependsOn`, `GeneratedFrom`, `RuntimeObservationFor`) are new tags; existing
-/// indexes will never contain them.
+/// **score_multiplier wildcard (0.70):** variants without an explicit arm fall
+/// through to `_ => 0.70`. This is intentional — add an arm only when pilot data
+/// justifies deviating from the conservative baseline.
 ///
-/// When adding a new variant here, also add the matching string tag in
-/// `trusty_search::core::symbol_graph::edge_kind_tag` /
-/// `edge_kind_from_tag` to preserve warm-boot compatibility.
+/// Phase A/B/C = original trusty-search KG (16 variants, on-disk tags immutable)
+/// Phase D = data-flow (issue #817): `Reads` 0.80, `Writes` 0.90, `AccessesResource` 0.75
+/// Phase KG = language-neutral structural (formerly `KgEdgeKind` — 10 variants)
+/// Phase SG = symbol-graph coarse (formerly `graph::EdgeKind`; covered by Calls/Imports/Contains)
 ///
-/// Phase A = structural (tree-sitter derived)
-/// Phase B = test-relation
-/// Phase C = doc/concept
-/// Phase KG = language-neutral structural (formerly KgEdgeKind)
-/// Phase SG = symbol-graph coarse (formerly graph::EdgeKind)
+/// When adding a new variant, also add its tag in
+/// `trusty_search::core::symbol_graph::edge_kind_tag` / `edge_kind_from_tag`.
 ///
 /// Test: `edge_kind_score_multiplier_known_values` (this file);
-/// `edge_kind_serde_round_trip` (this file);
-/// `edge_kind_union_coverage` (this file — asserts canonical set covers prior union);
+/// `edge_kind_serde_round_trip`; `edge_kind_union_coverage`;
 /// `edge_kind_tag_round_trip` in `trusty_search::core::symbol_graph::tests`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum EdgeKind {
     // ── trusty-search KG (Phase A/B/C — 16 variants) ──────────────────────
     // Call graph
-    /// Caller → callee. On-disk tag: `"CallsFunction"`.
+    /// Caller → callee. On-disk tag: `"CallsFunction"`. Emitted by the
+    /// trusty-search `EntityExtractor`; use `Calls` in language adapters.
     CallsFunction,
     /// Callee → caller (reverse index of `CallsFunction`). On-disk tag: `"CalledByFunction"`.
     CalledByFunction,
     // Phase A — structural
-    /// Class implements interface / struct implements trait.
+    /// Class implements interface / struct implements trait. Present in Phase A
+    /// since the original `contracts::EdgeKind` — NOT a convergence addition.
     Implements,
     /// Symbol uses a named type.
     UsesType,
@@ -150,7 +144,7 @@ pub enum EdgeKind {
     /// Symbol configures another (dependency injection, builder pattern).
     Configures,
     // Phase B — test relations
-    /// Production symbol is covered by a test.
+    /// Production symbol is covered by a test (reverse of `Tests`).
     TestedBy,
     /// Test uses a shared fixture.
     TestUsesFixture,
@@ -178,8 +172,7 @@ pub enum EdgeKind {
     Exports,
     /// Function A calls function B (language-adapter coarse call edge).
     /// Formerly `KgEdgeKind::Calls` and `graph::EdgeKind::Calls`.
-    /// Distinct from `CallsFunction` which is the trusty-search entity-KG
-    /// call edge with reverse-index support (`CalledByFunction`).
+    /// Distinct from `CallsFunction`: emitted by language adapters, no reverse index.
     Calls,
     /// Class or interface inherits from another.
     /// Formerly `KgEdgeKind::Extends`.
@@ -200,6 +193,17 @@ pub enum EdgeKind {
     /// Profiler measurement attached to a static symbol.
     /// Formerly `KgEdgeKind::RuntimeObservationFor`.
     RuntimeObservationFor,
+
+    // ── Data-flow (Phase D — issue #817) ───────────────────────────────────
+    /// Source reads from a global, config, cache, or shared state (0.80).
+    /// Answers "what reads this?" Language-agnostic (SQL SELECT, config reads).
+    Reads,
+    /// Source writes to (mutates) shared state (0.90 — highest data-flow weight).
+    /// Answers "what mutates this?" — primary impact-analysis query.
+    Writes,
+    /// Source accesses an external resource: HTTP endpoint, queue topic, DB table
+    /// (0.75). Answers "what touches this endpoint/queue/table?".
+    AccessesResource,
 }
 
 impl EdgeKind {
@@ -222,9 +226,14 @@ impl EdgeKind {
             EdgeKind::TestedBy => 0.80,
             EdgeKind::Documents => 0.65,
             EdgeKind::ReferencesConcept => 0.60,
-            // All remaining edges (Phase A/B/C legacy + new structural variants)
-            // use the conservative flat KG-expansion multiplier. Tuning for
-            // individual structural variants is tracked in issue #817.
+            // Phase D data-flow variants (issue #817): tuned starting values.
+            // Writes ranks highest because mutation drives impact cascades.
+            EdgeKind::Writes => 0.90,
+            EdgeKind::Reads => 0.80,
+            EdgeKind::AccessesResource => 0.75,
+            // All remaining edges (Phase A/B/C/KG/SG) use the conservative
+            // flat multiplier (0.70). This wildcard default is intentional —
+            // add an explicit arm only when pilot data justifies a deviation.
             _ => 0.70,
         }
     }
@@ -331,8 +340,13 @@ mod tests {
         assert!((EdgeKind::TestedBy.score_multiplier() - 0.80).abs() < 1e-6);
         assert!((EdgeKind::Documents.score_multiplier() - 0.65).abs() < 1e-6);
         assert!((EdgeKind::ReferencesConcept.score_multiplier() - 0.60).abs() < 1e-6);
-        // Default branch.
+        // Phase D data-flow variants (issue #817).
+        assert!((EdgeKind::Writes.score_multiplier() - 0.90).abs() < 1e-6);
+        assert!((EdgeKind::Reads.score_multiplier() - 0.80).abs() < 1e-6);
+        assert!((EdgeKind::AccessesResource.score_multiplier() - 0.75).abs() < 1e-6);
+        // Default wildcard branch (0.70 is intentional for untuned variants).
         assert!((EdgeKind::CallsFunction.score_multiplier() - 0.70).abs() < 1e-6);
+        assert!((EdgeKind::Calls.score_multiplier() - 0.70).abs() < 1e-6);
     }
 
     /// Verify that every `contracts::EdgeKind` variant round-trips through
@@ -375,6 +389,10 @@ mod tests {
             EdgeKind::DependsOn,
             EdgeKind::GeneratedFrom,
             EdgeKind::RuntimeObservationFor,
+            // Phase D data-flow variants (issue #817)
+            EdgeKind::Reads,
+            EdgeKind::Writes,
+            EdgeKind::AccessesResource,
         ];
         for v in variants {
             let json = serde_json::to_string(&v).expect("serialize EdgeKind");
@@ -420,6 +438,10 @@ mod tests {
         let _ = EdgeKind::GeneratedFrom;
         let _ = EdgeKind::RuntimeObservationFor;
         // graph::EdgeKind coarse variants are covered by Calls, Imports, Contains above.
+        // Phase D data-flow variants (issue #817)
+        let _ = EdgeKind::Reads;
+        let _ = EdgeKind::Writes;
+        let _ = EdgeKind::AccessesResource;
     }
 
     #[test]

--- a/crates/trusty-search/src/core/symbol_graph.rs
+++ b/crates/trusty-search/src/core/symbol_graph.rs
@@ -333,18 +333,12 @@ impl SymbolGraph {
         corpus.save_kg_graph(&nodes, &adj_fwd, &adj_rev)
     }
 
-    /// Load the persisted graph from the supplied [`CorpusStore`]
-    /// (issue #41 phase 2).
+    /// Load the persisted graph from the supplied [`CorpusStore`] (issue #41).
     ///
-    /// Why: warm-boot wants to skip the full `build_from_chunks` rebuild when
-    /// a previously-saved graph is available. Restoring the persisted graph
-    /// directly preserves Phase B/C edges that were computed at ingest time.
-    /// What: reads the three KG tables, reconstructs the `petgraph::DiGraph`,
-    /// and returns `Ok(Some(graph))`. Returns `Ok(None)` when the persisted
-    /// node table is empty (fresh database / not yet saved). Forward edges are
-    /// canonical; the reverse table is consulted to recover edges whose
-    /// source node was filtered out of the forward index (should not normally
-    /// happen but guards against an inconsistent persisted state).
+    /// Why: warm-boot skips full `build_from_chunks` when a saved graph exists,
+    /// preserving Phase B/C edges computed at ingest time.
+    /// What: reads three KG tables, reconstructs the `petgraph::DiGraph`. Returns
+    /// `Ok(None)` when the node table is empty (fresh DB / not yet saved).
     /// Test: `test_save_load_round_trip_preserves_graph`.
     pub fn load_from_corpus(corpus: &CorpusStore) -> anyhow::Result<Option<Self>> {
         let (nodes, adj_fwd, _adj_rev) = corpus.load_kg_graph()?;
@@ -402,14 +396,10 @@ impl SymbolGraph {
         Ok(Some(g))
     }
 
-    /// Edge-kind counts per `EdgeKind` variant present in the graph
-    /// (issue #41 phase 2).
+    /// Edge-kind counts per variant present in the graph (issue #41 phase 2).
     ///
-    /// Why: the `GET /indexes/{id}/graph/stats` endpoint surfaces these
-    /// counts so operators (and agents) can verify graph health without
-    /// scraping Prometheus.
-    /// What: returns a `Vec<(edge_kind_tag, count)>` sorted by tag for stable
-    /// JSON output.
+    /// Why: `GET /indexes/{id}/graph/stats` needs counts by kind for health checks.
+    /// What: `Vec<(tag, count)>` sorted by tag for stable JSON output.
     /// Test: `test_edge_kind_breakdown_counts_by_variant`.
     pub fn edge_kind_breakdown(&self) -> Vec<(String, usize)> {
         let mut counts: HashMap<String, usize> = HashMap::new();
@@ -427,9 +417,8 @@ impl SymbolGraph {
 /// Stable string tag for an `EdgeKind` used for redb persistence and `/graph/stats`.
 ///
 /// Why: funnelling all persistence hops through this helper keeps tags stable
-/// across serde-format changes. Tags for the 16 Phase A/B/C variants are
-/// on-disk and MUST NOT be renamed; the 10 convergence variants are new.
-/// What: returns the variant name string. Test: `edge_kind_tag_round_trip`.
+/// across serde-format changes. The 16 Phase A/B/C tags are on-disk and MUST
+/// NOT be renamed. Test: `edge_kind_tag_round_trip`.
 fn edge_kind_tag(kind: &EdgeKind) -> &'static str {
     match kind {
         EdgeKind::CallsFunction => "CallsFunction",
@@ -458,6 +447,9 @@ fn edge_kind_tag(kind: &EdgeKind) -> &'static str {
         EdgeKind::DependsOn => "DependsOn",
         EdgeKind::GeneratedFrom => "GeneratedFrom",
         EdgeKind::RuntimeObservationFor => "RuntimeObservationFor",
+        EdgeKind::Reads => "Reads",
+        EdgeKind::Writes => "Writes",
+        EdgeKind::AccessesResource => "AccessesResource",
     }
 }
 
@@ -494,6 +486,9 @@ fn edge_kind_from_tag(tag: &str) -> Option<EdgeKind> {
         "DependsOn" => EdgeKind::DependsOn,
         "GeneratedFrom" => EdgeKind::GeneratedFrom,
         "RuntimeObservationFor" => EdgeKind::RuntimeObservationFor,
+        "Reads" => EdgeKind::Reads,
+        "Writes" => EdgeKind::Writes,
+        "AccessesResource" => EdgeKind::AccessesResource,
         _ => return None,
     })
 }
@@ -1668,9 +1663,9 @@ mod tests {
         assert!(g.callers_of("beta", 1).is_empty(), "stale caller edge");
     }
 
-    /// All 26 `EdgeKind` variants (16 legacy + 10 convergence) must survive the
-    /// `edge_kind_tag` → `edge_kind_from_tag` round-trip (issue #815). Also
-    /// asserts legacy tag strings are bit-for-bit unchanged (on-disk back-compat).
+    /// All 29 `EdgeKind` variants (16 legacy + 10 convergence + 3 Phase D
+    /// data-flow) survive `edge_kind_tag` → `edge_kind_from_tag` (issues #815,
+    /// #817). Also asserts legacy tag strings are bit-for-bit stable on-disk.
     #[test]
     fn edge_kind_tag_round_trip() {
         let variants = [
@@ -1700,6 +1695,10 @@ mod tests {
             EdgeKind::DependsOn,
             EdgeKind::GeneratedFrom,
             EdgeKind::RuntimeObservationFor,
+            // Phase D data-flow — 3 new (issue #817)
+            EdgeKind::Reads,
+            EdgeKind::Writes,
+            EdgeKind::AccessesResource,
         ];
         for v in variants {
             let tag = edge_kind_tag(&v);


### PR DESCRIPTION
## Summary

- Adds three first-class Phase D data-flow `EdgeKind` variants to the canonical `contracts::EdgeKind` enum per ADR-0010 (issue #815 convergence):
  - `Reads` — score_multiplier 0.80, tag `"Reads"`: answers "what reads this global/config/cache?"
  - `Writes` — score_multiplier 0.90, tag `"Writes"`: answers "what mutates this state?" (highest data-flow weight because mutation drives cascading effects)
  - `AccessesResource` — score_multiplier 0.75, tag `"AccessesResource"`: HTTP endpoints, queue topics, DB tables
- Updates `edge_kind_tag` / `edge_kind_from_tag` in `trusty-search`'s `core/symbol_graph.rs` for persistence round-trip
- `trusty-analyze::KgEdgeKind` and `crate::symgraph::graph::EdgeKind` gain the variants automatically via their type aliases to the canonical enum
- Adds round-trip tests for each new tag, explicit `score_multiplier` assertions, and extends the union-coverage test

Also folds in doc clarifications from the #1109 review:
- `KgEdgeKind` alias doc: clarifies `Implements` was in Phase A since the original `contracts::EdgeKind` — NOT a convergence addition
- `contracts::EdgeKind` enum doc: adapter guidance for `Calls` vs `CallsFunction` (coarse vs entity-KG with reverse index) and `Tests` vs `TestedBy` (forward vs reverse)
- `score_multiplier` doc: explicitly notes the `_ => 0.70` wildcard default is intentional

## Scope notes

**Adapter emission is out of scope for #817** (per the issue: "Out of scope: populating these edges from tree-sitter"). The variants are available for language adapters and any future C#/SQL adapter, but no language adapter was wired in this PR. Tree-sitter emission is tracked separately.

## Test plan

- [x] `cargo test -p trusty-common --features symgraph` — 70 passed
- [x] `cargo test -p trusty-search` — 861 + 214 = 1075 passed
- [x] `cargo test -p trusty-analyze` — 423 + 25 = 448 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 166 allowlisted, 0 violations
- [x] `cargo build --workspace` (SKIP_UI_BUILD=1) — Finished in 1m08s

## Files changed

- `crates/trusty-common/src/symgraph/contracts.rs` — 3 new variants, updated `score_multiplier`, doc clarifications, test updates
- `crates/trusty-search/src/core/symbol_graph.rs` — 3 arms each in `edge_kind_tag` / `edge_kind_from_tag`, test updated (stayed within 1756-line budget)
- `crates/trusty-analyze/src/types/graph.rs` — `KgEdgeKind` alias doc clarifications + serde round-trip test extended

Closes #817. References ADR-0010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)