### PR TITLE
docs(adr): flip ADR-0009 to Accepted (per #819 acceptance)

### DIFF
--- a/docs/adr/0009-external-extractor-kg-ingest-contract.md
+++ b/docs/adr/0009-external-extractor-kg-ingest-contract.md
@@ -1,6 +1,6 @@
 # 0009. External-Extractor KG Ingest Contract — Durable Contributed Overlay in trusty-search
 
-- **Status:** Proposed
+- **Status:** Accepted (2026-06-11 — maintainer acceptance in [#819](https://github.com/bobmatnyc/trusty-tools/issues/819); doc applied to main as `583d389`)
 - **Date:** 2026-06-10
 - **Scope:** Workspace-wide (`trusty-search` storage + query surface, `trusty-analyze` spillover + enrichment bridge, external extractors)
 - **Supersedes / Superseded by:** —

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,5 +66,5 @@ Proposed ──► Accepted ──► Superseded (by ADR-NNNN)
 | [0006](./0006-trusty-controller-naming.md) | Name the stack control plane `trusty-controller` (binary `tctl`) | Accepted |
 | [0007](./0007-tool-contract-versioning-and-verb-model.md) | Monotonic-integer `contract_version` + 3-layer extensible verb model | Accepted |
 | [0008](./0008-project-identity-convention.md) | Project-identity convention: full-path slug of the nearest git root | Accepted |
-| [0009](./0009-external-extractor-kg-ingest-contract.md) | External-extractor KG ingest contract: durable contributed overlay in trusty-search | Proposed |
+| [0009](./0009-external-extractor-kg-ingest-contract.md) | External-extractor KG ingest contract: durable contributed overlay in trusty-search | Accepted |
 | [0010](./0010-kg-edge-kind-extensibility.md) | KG edge-kind extensibility: first-class data-flow variants + Custom escape hatch | Proposed |


### PR DESCRIPTION
Status-only follow-up to your acceptance on #819: flips ADR-0009 and its index row from `Proposed` to `Accepted`, per the lifecycle convention in `docs/adr/README.md`. No content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)