### PR TITLE
docs: Homebrew install instructions (tap now live)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,58 @@ documentation.
 └───────────────────────────────────────────────────────────────┘
 ```
 
-## Quick Start — All Crates
+## Installation
+
+### With Homebrew (recommended for end users)
+
+The easiest way to install any trusty-* binary. First, add the tap:
+
+```bash
+brew tap bobmatnyc/trusty
+```
+
+Then install any of the six published binaries:
+
+```bash
+brew install trusty-search
+brew install trusty-memory
+brew install trusty-analyze
+brew install trusty-review
+brew install trusty-mpm
+brew install trusty-git-analytics
+```
+
+Or combine into a single command:
+
+```bash
+brew install bobmatnyc/trusty/trusty-search \
+             bobmatnyc/trusty/trusty-memory \
+             bobmatnyc/trusty/trusty-analyze \
+             bobmatnyc/trusty/trusty-review \
+             bobmatnyc/trusty/trusty-mpm \
+             bobmatnyc/trusty/trusty-git-analytics
+```
+
+### From Source with Cargo
+
+If you prefer to build from the latest source or need a crate not distributed via Homebrew:
+
+```bash
+git clone https://github.com/bobmatnyc/trusty-tools
+cd trusty-tools
+
+# Build all crates
+cargo build --release
+
+# Run all tests
+cargo test
+
+# Install the CLI tools
+cargo install --path crates/trusty-search --locked
+# More tools available via: cargo install --path crates/<crate>
+```
+
+## Quick Start — All Crates (Source Build)
 
 ```bash
 git clone https://github.com/bobmatnyc/trusty-tools

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -115,6 +115,24 @@ cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-analyze \
 
 The installed binary is named `trusty-analyze`.
 
+### With Homebrew (recommended)
+
+```bash
+brew tap bobmatnyc/trusty
+brew install trusty-analyze
+```
+
+Or install directly without tapping:
+
+```bash
+brew install bobmatnyc/trusty/trusty-analyze
+```
+
+Homebrew provides:
+- Automatic updates via `brew upgrade trusty-analyze`
+- Standard macOS / Linux PATH integration
+- Easy dependency management
+
 ## Quick Start
 
 ```bash

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -56,19 +56,23 @@ To install a specific version:
 cargo install --git https://github.com/bobmatnyc/trusty-tools --tag tga-v2.7.0 tga --locked
 ```
 
-### With Homebrew (planned — not yet available)
+### With Homebrew (recommended)
 
 ```bash
 brew tap bobmatnyc/trusty
-brew install tga
+brew install trusty-git-analytics
 ```
 
-This installation method is under development. For now, use GitHub Releases or `cargo install`.
+Or install directly without tapping:
 
-Once available, this will provide:
-- Automatic updates via `brew upgrade tga`
+```bash
+brew install bobmatnyc/trusty/trusty-git-analytics
+```
+
+Homebrew provides:
+- Automatic updates via `brew upgrade trusty-git-analytics`
 - Standard macOS / Linux PATH integration
-- Optional dependency resolution (e.g., system libraries for ONNX Runtime)
+- Easy dependency management
 
 ### Prerequisites & Special Cases
 

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -67,19 +67,23 @@ To install a specific version:
 cargo install --git https://github.com/bobmatnyc/trusty-tools --tag trusty-memory-v0.15.0 trusty-memory --locked
 ```
 
-### With Homebrew (planned — not yet available)
+### With Homebrew (recommended)
 
 ```bash
 brew tap bobmatnyc/trusty
 brew install trusty-memory
 ```
 
-This installation method is under development. For now, use GitHub Releases or `cargo install`.
+Or install directly without tapping:
 
-Once available, this will provide:
+```bash
+brew install bobmatnyc/trusty/trusty-memory
+```
+
+Homebrew provides:
 - Automatic updates via `brew upgrade trusty-memory`
 - Standard macOS / Linux PATH integration
-- Optional dependency resolution (e.g., system libraries for ONNX Runtime)
+- Easy dependency management
 
 ### Prerequisites & Special Cases
 

--- a/crates/trusty-mpm/README.md
+++ b/crates/trusty-mpm/README.md
@@ -50,19 +50,23 @@ To install a specific version:
 cargo install --git https://github.com/bobmatnyc/trusty-tools --tag trusty-mpm-v0.6.2 trusty-mpm --locked
 ```
 
-### With Homebrew (planned — not yet available)
+### With Homebrew (recommended)
 
 ```bash
 brew tap bobmatnyc/trusty
 brew install trusty-mpm
 ```
 
-This installation method is under development. For now, use GitHub Releases or `cargo install`.
+Or install directly without tapping:
 
-Once available, this will provide:
+```bash
+brew install bobmatnyc/trusty/trusty-mpm
+```
+
+Homebrew provides:
 - Automatic updates via `brew upgrade trusty-mpm`
 - Standard macOS / Linux PATH integration
-- Optional dependency resolution (e.g., system libraries for ONNX Runtime)
+- Easy dependency management
 
 ### Prerequisites & Special Cases
 

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -36,6 +36,24 @@ cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-review --lo
 
 This builds and installs the `trusty-review` binary from the latest `main` branch.
 
+### With Homebrew (recommended)
+
+```bash
+brew tap bobmatnyc/trusty
+brew install trusty-review
+```
+
+Or install directly without tapping:
+
+```bash
+brew install bobmatnyc/trusty/trusty-review
+```
+
+Homebrew provides:
+- Automatic updates via `brew upgrade trusty-review`
+- Standard macOS / Linux PATH integration
+- Easy dependency management
+
 ### Prerequisites
 
 > **Required:** A GitHub token (`GITHUB_TOKEN`) or GitHub App credentials for PR

--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -63,19 +63,23 @@ To install a specific version:
 cargo install --git https://github.com/bobmatnyc/trusty-tools --tag trusty-search-v0.24.1 trusty-search --locked
 ```
 
-### With Homebrew (planned — not yet available)
+### With Homebrew (recommended)
 
 ```bash
 brew tap bobmatnyc/trusty
 brew install trusty-search
 ```
 
-This installation method is under development. For now, use GitHub Releases or `cargo install`.
+Or install directly without tapping:
 
-Once available, this will provide:
+```bash
+brew install bobmatnyc/trusty/trusty-search
+```
+
+Homebrew provides:
 - Automatic updates via `brew upgrade trusty-search`
 - Standard macOS / Linux PATH integration
-- Optional dependency resolution (e.g., system libraries for ONNX Runtime)
+- Easy dependency management
 
 ### Prerequisites & Special Cases
 


### PR DESCRIPTION
## Summary

Updated installation documentation across 7 README files to reflect that the Homebrew tap (`bobmatnyc/trusty`) is now **fully live and operational**.

All six published binaries are now installable via Homebrew:
- `brew install bobmatnyc/trusty/trusty-search`
- `brew install bobmatnyc/trusty/trusty-memory`
- `brew install bobmatnyc/trusty/trusty-analyze`
- `brew install bobmatnyc/trusty/trusty-review`
- `brew install bobmatnyc/trusty/trusty-mpm`
- `brew install bobmatnyc/trusty/trusty-git-analytics`

Or with the tap: `brew tap bobmatnyc/trusty && brew install <name>`

## Changes

### Top-level README.md
- Added new "## Installation" section with **Homebrew as the first/recommended method** for end users
- Included both tapped and direct install examples
- Kept "From Source with Cargo" as the alternative for source builds

### Per-crate READMEs
- **trusty-search/README.md**: Replaced placeholder "planned — not yet available" with working instructions
- **trusty-memory/README.md**: Replaced placeholder "planned — not yet available" with working instructions
- **trusty-analyze/README.md**: Added new Homebrew section (was missing entirely)
- **trusty-review/README.md**: Added new Homebrew section (was missing entirely)
- **trusty-mpm/README.md**: Replaced placeholder "planned — not yet available" with working instructions
- **trusty-git-analytics/README.md**: Replaced placeholder "planned — not yet available" with working instructions

**Note:** trusty-code (publish=false) is not distributed via Homebrew and has no Homebrew instructions.

## Testing

- ✅ Verified all 7 README files have consistent, correct Homebrew instructions
- ✅ Verified exactly 6 brew install commands (one for each published binary)
- ✅ Verified line-cap script passes (no .rs file violations)
- ✅ Verified git diff shows only intended README changes
- ✅ Verified commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)