### PR TITLE
chore(release): tga 2.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9754,7 +9754,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.7.1"
+version = "2.8.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.7.1"
+version = "2.8.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.91) per #254. Required for


### PR DESCRIPTION
Bump tga 2.7.1 → 2.8.0, shipping #1113 (agentic_mode classification + weekly agentic-% metric) and #1005 (Bitbucket app_password env-expand fix). Depends on trusty-common 0.15.0 (now published). cargo publish --dry-run passed. Tag tga-v2.8.0 + cargo publish to follow after merge.