### PR TITLE
chore(line-cap): looser 1500-SLOC cap for test/benchmark files

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -1,10 +1,12 @@
-# .line-cap-allowlist.tsv — grandfathered files over the 500-SLOC cap (issue #610).
+# .line-cap-allowlist.tsv — grandfathered files over the SLOC cap (issue #610).
 # Format: <relative/path><TAB><budget>  (budget = frozen max SLOC count; code lines only).
+# Dual cap: production source = 500 SLOC; test/benchmark files = 1500 SLOC.
+# Test/benchmark = basename is tests.rs, ends with _test.rs or _tests.rs,
+#   or path contains /tests/ or /benches/ segment. All others = production.
 # SLOC excludes blank lines, // line comments, /// doc comments, //! inner-doc comments,
 # and /* ... */ block comments (including multi-line spans). Trailing-comment lines count.
-# Ratchet: budgets may only DECREASE; when a file drops <= 500 SLOC remove it.
+# Ratchet: budgets may only DECREASE; when a file drops <= its applicable cap, remove it.
 # Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap).
-crates/trusty-agents/src/tools/memory/tests.rs	510
 crates/trusty-analyze/src/core/review.rs	555
 crates/trusty-analyze/src/lang/adapters/go.rs	610
 crates/trusty-analyze/src/lang/adapters/php.rs	642
@@ -18,7 +20,6 @@ crates/trusty-common/src/embedder/mod.rs	753
 crates/trusty-common/src/memory_core/analytics.rs	623
 crates/trusty-common/src/memory_core/dream.rs	1199
 crates/trusty-common/src/memory_core/retrieval/mod.rs	830
-crates/trusty-common/src/memory_core/retrieval/tests.rs	875
 crates/trusty-common/src/memory_core/semantic_consolidation.rs	615
 crates/trusty-common/src/memory_core/store/chat_sessions.rs	690
 crates/trusty-common/src/memory_core/store/kg_redb.rs	1442
@@ -63,12 +64,9 @@ crates/trusty-memory/src/project_root.rs	501
 crates/trusty-memory/src/prompt_log.rs	542
 crates/trusty-memory/src/service.rs	1075
 crates/trusty-memory/src/tools.rs	2599
-crates/trusty-memory/tests/concurrent_perf.rs	569
-crates/trusty-memory/tests/mcp_stdio_tools.rs	683
 crates/trusty-mpm/src/client/executor.rs	666
 crates/trusty-mpm/src/client/http_client.rs	897
 crates/trusty-mpm/src/core/session_launch.rs	705
-crates/trusty-mpm/src/daemon/api_tests.rs	1046
 crates/trusty-mpm/src/daemon/bug_report/scrubber.rs	565
 crates/trusty-mpm/src/daemon/claude_config.rs	894
 crates/trusty-mpm/src/daemon/state.rs	770
@@ -77,7 +75,6 @@ crates/trusty-mpm/src/telegram/formatter.rs	504
 crates/trusty-mpm/src/tui/dashboard.rs	696
 crates/trusty-mpm/src/tui/health.rs	2200
 crates/trusty-mpm/src/tui/mod.rs	520
-crates/trusty-review/src/pipeline/runner_tests.rs	598
 crates/trusty-search/src/commands/doctor_checks.rs	503
 crates/trusty-search/src/commands/reindex_ui.rs	820
 crates/trusty-search/src/commands/start.rs	1085
@@ -94,7 +91,3 @@ crates/trusty-search/src/service/call_chain.rs	738
 crates/trusty-search/src/service/embedder_supervisor.rs	521
 crates/trusty-search/src/service/persistence.rs	579
 crates/trusty-search/src/service/reindex/mod.rs	1658
-crates/trusty-search/src/service/reindex/tests.rs	1113
-crates/trusty-search/tests/benchmark_harness.rs	544
-crates/trusty-search/tests/benchmark_open_mpm_kg.rs	665
-crates/trusty-search/tests/benchmark_open_mpm.rs	568

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,15 +219,30 @@ application/binary code and `thiserror` for library error types. Reserve
 `expect()` only for cases that are genuinely programmer errors (invariants that
 can never occur at runtime).
 
-🔴 **500-SLOC file size hard cap (MECHANICALLY ENFORCED)** — no source file
-(`.rs`) should exceed 500 lines of code (SLOC). As of issue #610 this is no
-longer advice: it is gated by `scripts/check_line_cap.sh`, wired into CI
-(`.github/workflows/line-cap.yml`) and the local pre-commit hook (`line-cap`).
-A new tracked `.rs` file over 500 SLOC **cannot merge**. Files approaching this
-limit are a signal to split into focused submodules before the next feature
-lands on them. When splitting, prefer: one public module per logical concept, a
-thin `mod.rs` that re-exports, and sibling files with clear single
-responsibilities.
+🔴 **SLOC file size hard cap (MECHANICALLY ENFORCED, dual-cap since #1131):**
+
+| File type | SLOC cap |
+|---|---|
+| Production source files | **500 SLOC** |
+| Test / benchmark files | **1500 SLOC** |
+
+A file is classified as a **test/benchmark file** when ANY of these match:
+- basename is exactly `tests.rs`
+- basename ends with `_test.rs` or `_tests.rs`
+- path contains a `/tests/` directory segment (covers `crates/*/tests/*.rs`
+  integration tests AND any `src/**/tests/*.rs` inline test modules)
+- path contains a `/benches/` directory segment
+
+All other tracked `.rs` files are **production files**, capped at 500 SLOC.
+
+As of issue #610 the production cap is no longer advice: it is gated by
+`scripts/check_line_cap.sh`, wired into CI (`.github/workflows/line-cap.yml`)
+and the local pre-commit hook (`line-cap`). A new tracked production `.rs` file
+over 500 SLOC **cannot merge**; a new test/benchmark `.rs` file over 1500 SLOC
+**cannot merge**. Files approaching their limit are a signal to split into
+focused submodules before the next feature lands on them. When splitting, prefer:
+one public module per logical concept, a thin `mod.rs` that re-exports, and
+sibling files with clear single responsibilities.
 
 **SLOC definition:** a line counts only when it contains non-whitespace source
 code after all comment matter is stripped. These are **excluded** from the count:
@@ -242,15 +257,16 @@ has code. The counter is a pragmatic awk heuristic that errs toward leniency:
 edge cases (e.g. `//` inside a string literal) may undercount SLOC but will
 never falsely fail a legitimate file.
 
-**The ratchet (allowlist that can only shrink):** grandfathered files over the
-cap are listed in `.line-cap-allowlist.tsv` (one `relative/path<TAB>budget` line
-each, where `budget` is that file's frozen max SLOC count). The gate enforces:
+**The ratchet (allowlist that can only shrink):** grandfathered files over their
+applicable cap are listed in `.line-cap-allowlist.tsv` (one
+`relative/path<TAB>budget` line each, where `budget` is that file's frozen max
+SLOC count). The gate enforces per-applicable-cap ratchet semantics:
 
-- a file ≤ 500 SLOC and **not** allowlisted → OK;
-- a file > 500 SLOC and **not** allowlisted → **FAIL** (new oversized file — split it);
-- an allowlisted file whose current SLOC **exceeds its budget** → **FAIL** (it grew — split it);
-- an allowlisted file now **≤ 500 SLOC** → **FAIL** (it dropped under cap — remove its allowlist entry; this is the ratchet-down forcing function);
-- an allowlisted file with `500 < SLOC ≤ budget` → OK (grandfathered, not growing).
+- SLOC ≤ applicable cap and **not** allowlisted → OK;
+- SLOC > applicable cap and **not** allowlisted → **FAIL** (new oversized file — split it);
+- allowlisted, current SLOC **exceeds its budget** → **FAIL** (it grew — split it);
+- allowlisted, current SLOC **≤ applicable cap** → **FAIL** (drop the entry; ratchet-down forcing function);
+- allowlisted, `applicable_cap < SLOC ≤ budget` → OK (grandfathered, not growing).
 
 So allowlisted files may only shrink, and no new oversized file may be added.
 As the #607 sweep and per-crate refactors land, the allowlist ratchets down
@@ -259,9 +275,9 @@ toward empty.
 **Run it locally:** `bash scripts/check_line_cap.sh` (exit 0 = clean). After you
 intentionally split a file (or a file otherwise drops below its budget), refresh
 the frozen budgets with `scripts/check_line_cap.sh --update` — this only *lowers*
-budgets or *removes* entries that fell ≤ 500 SLOC; it **refuses** to add a new
-oversized file or raise a budget unless you pass `--seed` (initial bootstrap) or
-`--force-add` (rare, intentional bump). Commit the regenerated
+budgets or *removes* entries that fell ≤ their applicable cap; it **refuses** to
+add a new oversized file or raise a budget unless you pass `--seed` (initial
+bootstrap) or `--force-add` (rare, intentional bump). Commit the regenerated
 `.line-cap-allowlist.tsv` alongside your split.
 
 Past violations (refactor tickets #170/#171/#172 are CLOSED and the splits have
@@ -275,9 +291,9 @@ landed — all three former monoliths are now under the 500-SLOC cap):
   `engine.rs` was split into an `engine/` module; every submodule is now under
   the cap (largest is `engine/executor/run.rs` at ~485 lines).
 
-The largest remaining files in `trusty-agents` (none tied to an open ticket) are
-`tools/memory/tests.rs` and `tm/manager.rs` — file a fresh refactor ticket before
-growing those further. Current per-file SLOC budgets live in `.line-cap-allowlist.tsv`.
+The largest remaining production file in `trusty-agents` (not tied to an open
+ticket) is `tm/manager.rs` — file a fresh refactor ticket before growing it
+further. Current per-file SLOC budgets live in `.line-cap-allowlist.tsv`.
 
 🔴 **`thiserror` for libraries, `anyhow` for binaries** — library crates
 (`trusty-common`, `trusty-embedderd`, `trusty-bm25-daemon`, etc.) define structured error enums with
@@ -670,15 +686,17 @@ installed, the build script fails loudly. Install pnpm or set
 `[patch]` tables inside individual crate `Cargo.toml` files; Cargo ignores
 them. All patches must live in the root `Cargo.toml`.
 
-🔴 **Growing a file past 500 SLOC instead of splitting** — the compiler does not
-stop you, but continued feature additions to a 1,000+ SLOC file make the module
-harder to review, reason about, and test. Split proactively. The cap counts code
-lines only (SLOC): blank lines, `//` comments, `///` doc comments, `//!`
-inner-doc comments, and `/* ... */` block comments (including multi-line spans)
-are all excluded from the count. The trusty-agents `ctrl/`, `runtime/`, and
-`workflow/engine/` modules (#170, #171, #172) were the canonical examples of
-files that grew past the cap; all three have since been split into focused
-submodules and now serve as the worked examples of a clean split.
+🔴 **Growing a file past its SLOC cap instead of splitting** — the compiler does
+not stop you, but continued feature additions make the module harder to review,
+reason about, and test. Split proactively. The applicable cap is **500 SLOC for
+production files** and **1500 SLOC for test/benchmark files** (see the Key
+Conventions section for the exact classification rules). SLOC counts code lines
+only: blank lines, `//` comments, `///` doc comments, `//!` inner-doc comments,
+and `/* ... */` block comments (including multi-line spans) are all excluded.
+The trusty-agents `ctrl/`, `runtime/`, and `workflow/engine/` modules (#170,
+#171, #172) were the canonical examples of files that grew past the prod cap;
+all three have since been split into focused submodules and now serve as the
+worked examples of a clean split.
 
 🟢 **MSRV drift** — the workspace pins `rust-version = "1.91"`. Running
 `rustup update` and picking up a new nightly may introduce syntax that

--- a/scripts/check_line_cap.sh
+++ b/scripts/check_line_cap.sh
@@ -1,28 +1,41 @@
 #!/usr/bin/env bash
 #
-# check_line_cap.sh — ratcheted 500-SLOC file-size cap enforcement (issue #610).
+# check_line_cap.sh — ratcheted SLOC file-size cap enforcement (issue #610).
 #
-# Why: the 500-line file cap documented in CLAUDE.md had zero mechanical
+# Why: the 500-SLOC file cap documented in CLAUDE.md had zero mechanical
 #   enforcement, so source files silently grew past it under feature pressure
 #   (e.g. trusty-search/src/service/server.rs reached 5,403 lines). Advice
 #   without a gate loses. This script turns the cap into a CI/pre-commit gate
 #   whose grandfather allowlist can only SHRINK — no new oversized files, and
 #   existing oversized files may never grow.
 #
+# DUAL-CAP RULES (issue #1131):
+#   Production source files   → PROD_CAP = 500 SLOC
+#   Test / benchmark files    → TEST_CAP = 1500 SLOC
+#
+#   A file is classified as a test/benchmark file when ANY of these match:
+#     - basename is exactly `tests.rs`
+#     - basename ends with `_test.rs` or `_tests.rs`
+#     - path contains a `/tests/` directory segment
+#       (covers both `crates/*/tests/*.rs` integration tests and
+#        any `src/**/tests/*.rs` inline test modules)
+#     - path contains a `/benches/` directory segment
+#   All other tracked `.rs` files are production files capped at 500 SLOC.
+#
 # What: scans every tracked `.rs` file (`git ls-files '*.rs'`) and enforces:
-#   - <= CAP SLOC, not allowlisted          -> OK
-#   - >  CAP SLOC, not allowlisted          -> FAIL  (new oversized file)
-#   - allowlisted, current > recorded budget -> FAIL  (grew beyond frozen budget)
-#   - allowlisted, current <= CAP            -> FAIL  (now under cap; drop the entry)
-#   - allowlisted, CAP < current <= budget   -> OK    (grandfathered, not growing)
+#   - SLOC <= applicable cap, not allowlisted                    -> OK
+#   - SLOC >  applicable cap, not allowlisted                    -> FAIL  (new oversized file)
+#   - allowlisted, current SLOC > recorded budget                -> FAIL  (grew beyond frozen budget)
+#   - allowlisted, current SLOC <= applicable cap                -> FAIL  (now under cap; drop the entry)
+#   - allowlisted, applicable_cap < current SLOC <= budget       -> OK    (grandfathered, not growing)
 #   Exit non-zero on any FAIL; exit 0 when clean. Prints a one-line summary.
 #
 #   --update     regenerates the allowlist but only SAFELY: it may LOWER an
-#                existing budget or REMOVE entries that dropped <= CAP. It
-#                REFUSES to raise a budget or add a brand-new > CAP file unless
-#                --seed or --force-add is also passed.
+#                existing budget or REMOVE entries that dropped <= applicable cap.
+#                It REFUSES to raise a budget or add a brand-new > cap file
+#                unless --seed or --force-add is also passed.
 #   --seed       initial seeding: allowed to add brand-new entries. Implies update.
-#   --force-add  like --update but permits adding new > CAP files / raising
+#   --force-add  like --update but permits adding new > cap files / raising
 #                budgets (escape hatch; use sparingly, e.g. an unavoidable bump).
 #
 # SLOC definition — a line is counted ONLY when it contains non-whitespace
@@ -44,8 +57,9 @@
 #   string containing /*) can be noted as exceptions in a code comment.
 #
 # Test: exercised in the PR that introduced SLOC counting (clean tree exits 0;
-#   a file with 600 code lines fails; 600 comment-only lines passes). The logic
-#   is pure SLOC counting against the committed allowlist; no unit-test harness.
+#   a production file with 600 SLOC fails; 600 SLOC in a test path passes;
+#   1600 SLOC in a test path fails). The logic is pure SLOC counting against
+#   the committed allowlist; no unit-test harness.
 #
 # Portability: works on bash 3.2 (macOS system bash) and bash 5 (Linux CI).
 #   Uses POSIX tools only — `git`, `sort`, `awk`. No associative arrays,
@@ -56,7 +70,8 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-CAP=500
+PROD_CAP=500
+TEST_CAP=1500
 
 # Resolve repo root so the script works from any cwd.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -69,7 +84,7 @@ cd "$REPO_ROOT"
 # Mode parsing
 # ---------------------------------------------------------------------------
 MODE="check"      # check | update
-ALLOW_GROW=0      # may add new >CAP files / raise budgets (--seed or --force-add)
+ALLOW_GROW=0      # may add new >cap files / raise budgets (--seed or --force-add)
 for arg in "$@"; do
   case "$arg" in
     --update)    MODE="update" ;;
@@ -156,6 +171,36 @@ END { print sloc }
 '
 
 # ---------------------------------------------------------------------------
+# cap_for_path: print the applicable SLOC cap for a given repo-relative path.
+#
+# A file is a test/benchmark file when any of these match:
+#   - basename is `tests.rs`
+#   - basename ends with `_test.rs` or `_tests.rs`
+#   - path contains a `/tests/` directory segment
+#   - path contains a `/benches/` directory segment
+# All other files are production files.
+#
+# Implementation uses only shell parameter expansion (no external commands)
+# so it works on bash 3.2 (macOS) and bash 5 (Linux) without relying on
+# `basename` being in PATH — which may not be the case in all CI environments.
+# ---------------------------------------------------------------------------
+cap_for_path() {
+  local path="$1"
+  # Extract basename using parameter expansion: strip leading directory portion.
+  local base="${path##*/}"
+  # Match test/benchmark patterns
+  case "$base" in
+    tests.rs|*_test.rs|*_tests.rs)
+      echo "$TEST_CAP"; return ;;
+  esac
+  case "$path" in
+    */tests/*|*/benches/*)
+      echo "$TEST_CAP"; return ;;
+  esac
+  echo "$PROD_CAP"
+}
+
+# ---------------------------------------------------------------------------
 # Build a current snapshot: "<sloc>\t<path>" for every tracked .rs file that
 # still exists in the working tree. Computed once, reused by both modes.
 # ---------------------------------------------------------------------------
@@ -182,26 +227,49 @@ if [ "$MODE" = "update" ]; then
   # shellcheck disable=SC2064
   trap 'rm -f "$CURRENT" "$NEWLIST" "$NEWLIST.body" "$ERRFILE"' EXIT
 
+  # Build a per-path cap map: "<path>\t<cap>" for all tracked .rs files.
+  # This is written to a temp file so the awk merge step can read it.
+  CAPMAP="$(mktemp "${TMPDIR:-/tmp}/linecap.cap.XXXXXX")"
+  # shellcheck disable=SC2064
+  trap 'rm -f "$CURRENT" "$NEWLIST" "$NEWLIST.body" "$ERRFILE" "$CAPMAP"' EXIT
+
+  git ls-files '*.rs' | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    cap="$(cap_for_path "$f")"
+    printf '%s\t%s\n' "$f" "$cap"
+  done > "$CAPMAP"
+
   # Tag each input stream so awk distinguishes them even when the allowlist is
-  # empty (a plain FNR==NR split breaks on an empty first file). Allowlist rows
-  # become "A<TAB>path<TAB>budget"; snapshot rows become "C<TAB>sloc<TAB>path".
+  # empty (a plain FNR==NR split breaks on an empty first file):
+  #   Allowlist rows: "A<TAB>path<TAB>budget"
+  #   Snapshot rows:  "C<TAB>sloc<TAB>path"
+  #   Cap-map rows:   "P<TAB>path<TAB>cap"
+  #
+  # IMPORTANT: P rows must come BEFORE C rows so that the file_cap[] array
+  # is fully populated when C rows are processed (awk is single-pass).
   {
     awk 'BEGIN{FS=OFS="\t"} $0 !~ /^#/ && NF>=2 {print "A", $1, $2}' "$ALLOWLIST_READ"
+    awk 'BEGIN{FS=OFS="\t"} NF>=2 {print "P", $1, $2}' "$CAPMAP"
     awk 'BEGIN{FS=OFS="\t"} NF>=2 {print "C", $1, $2}' "$CURRENT"
-  } | awk -v cap="$CAP" -v allow_grow="$ALLOW_GROW" -v errfile="$ERRFILE" '
+  } | awk -v allow_grow="$ALLOW_GROW" -v errfile="$ERRFILE" \
+         -v prod_cap="$PROD_CAP" -v test_cap="$TEST_CAP" '
     BEGIN { FS = OFS = "\t" }
     # ----- allowlist rows: A <path> <budget> -----
     $1 == "A" { old[$2] = $3; next }
+    # ----- cap-map rows: P <path> <cap> -----
+    $1 == "P" { file_cap[$2] = $3 + 0; next }
     # ----- snapshot rows:  C <sloc> <path> -----
     {
       n = $2 + 0
       path = $3
-      if (n <= cap) next                 # under cap -> drop from list
+      cap = (path in file_cap) ? file_cap[path] : prod_cap
+      cap_label = (cap == prod_cap) ? (prod_cap " prod cap") : (test_cap " test cap")
+      if (n <= cap) next                 # under applicable cap -> drop from list
       if (path in old) {
         if (n > old[path] + 0) {
           if (allow_grow == 1) { keep[path] = n }
           else {
-            printf "REFUSE: %s grew to %d SLOC (frozen budget %s). Split it before updating the allowlist.\n", path, n, old[path] > errfile
+            printf "REFUSE: %s grew to %d SLOC (frozen budget %s; %s). Split it before updating the allowlist.\n", path, n, old[path], cap_label > errfile
             err = 1
           }
         } else {
@@ -210,7 +278,7 @@ if [ "$MODE" = "update" ]; then
       } else {
         if (allow_grow == 1) { keep[path] = n }
         else {
-          printf "REFUSE: %s is a new oversized file (%d SLOC > %d). Split it; do not add it to the allowlist.\n", path, n, cap > errfile
+          printf "REFUSE: %s is a new oversized file (%d SLOC > %s). Split it; do not add it to the allowlist.\n", path, n, cap_label > errfile
           err = 1
         }
       }
@@ -233,11 +301,14 @@ if [ "$MODE" = "update" ]; then
 
   count="$(awk 'END{print NR}' "$NEWLIST.body")"
   {
-    echo "# .line-cap-allowlist.tsv — grandfathered files over the ${CAP}-SLOC cap (issue #610)."
+    echo "# .line-cap-allowlist.tsv — grandfathered files over the SLOC cap (issue #610)."
     echo "# Format: <relative/path><TAB><budget>  (budget = frozen max SLOC count; code lines only)."
+    echo "# Dual cap: production source = ${PROD_CAP} SLOC; test/benchmark files = ${TEST_CAP} SLOC."
+    echo "# Test/benchmark = basename is tests.rs, ends with _test.rs or _tests.rs,"
+    echo "#   or path contains /tests/ or /benches/ segment. All others = production."
     echo "# SLOC excludes blank lines, // line comments, /// doc comments, //! inner-doc comments,"
     echo "# and /* ... */ block comments (including multi-line spans). Trailing-comment lines count."
-    echo "# Ratchet: budgets may only DECREASE; when a file drops <= ${CAP} SLOC remove it."
+    echo "# Ratchet: budgets may only DECREASE; when a file drops <= its applicable cap, remove it."
     echo "# Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap)."
     sort "$NEWLIST.body"
   } > "$ALLOWLIST"
@@ -254,32 +325,53 @@ RESULT="$(mktemp "${TMPDIR:-/tmp}/linecap.res.XXXXXX")"
 # shellcheck disable=SC2064
 trap 'rm -f "$CURRENT" "$RESULT"' EXIT
 
-# Tag both streams (see UPDATE mode for why): allowlist rows -> "A\tpath\tbudget",
-# snapshot rows -> "C\tsloc\tpath". This survives an empty allowlist file.
+# Build a per-path cap map for check mode too.
+CAPMAP_CHK="$(mktemp "${TMPDIR:-/tmp}/linecap.cap.XXXXXX")"
+# shellcheck disable=SC2064
+trap 'rm -f "$CURRENT" "$RESULT" "$CAPMAP_CHK"' EXIT
+
+git ls-files '*.rs' | while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  cap="$(cap_for_path "$f")"
+  printf '%s\t%s\n' "$f" "$cap"
+done > "$CAPMAP_CHK"
+
+# Tag all three streams:
+#   Allowlist rows -> "A\tpath\tbudget"
+#   Snapshot rows  -> "C\tsloc\tpath"
+#   Cap-map rows   -> "P\tpath\tcap"
+#
+# IMPORTANT: P rows must come BEFORE C rows so that file_cap[] is fully
+# populated when C rows arrive (awk is single-pass).
 {
   awk 'BEGIN{FS=OFS="\t"} $0 !~ /^#/ && NF>=2 {print "A", $1, $2}' "$ALLOWLIST_READ"
+  awk 'BEGIN{FS=OFS="\t"} NF>=2 {print "P", $1, $2}' "$CAPMAP_CHK"
   awk 'BEGIN{FS=OFS="\t"} NF>=2 {print "C", $1, $2}' "$CURRENT"
-} | awk -v cap="$CAP" '
+} | awk -v prod_cap="$PROD_CAP" -v test_cap="$TEST_CAP" '
   BEGIN { FS = OFS = "\t" }
   # ----- allowlist rows: A <path> <budget> -----
   $1 == "A" { budget[$2] = $3; have[$2] = 1; next }
+  # ----- cap-map rows: P <path> <cap> -----
+  $1 == "P" { file_cap[$2] = $3 + 0; next }
   # ----- snapshot rows:  C <sloc> <path> -----
   {
     n = $2 + 0; path = $3
     seen[path] = 1
+    cap = (path in file_cap) ? file_cap[path] : prod_cap
+    cap_label = (cap == prod_cap) ? (prod_cap " prod cap") : (test_cap " test cap")
     if (path in budget) {
       allowlisted++
       if (n <= cap) {
-        printf "FAIL: %s is now %d SLOC (<= %d). Remove it from .line-cap-allowlist.tsv (ratchet down).\n", path, n, cap
+        printf "FAIL: %s is now %d SLOC (<= %s). Remove it from .line-cap-allowlist.tsv (ratchet down).\n", path, n, cap_label
         viol++
       } else if (n > budget[path] + 0) {
-        printf "FAIL: %s grew to %d SLOC (frozen budget %s). Split it; the cap is %d SLOC.\n", path, n, budget[path], cap
+        printf "FAIL: %s grew to %d SLOC (frozen budget %s; cap is %s). Split it.\n", path, n, budget[path], cap_label
         viol++
       }
-      # else CAP < n <= budget -> grandfathered, OK
+      # else applicable_cap < n <= budget -> grandfathered, OK
     } else {
       if (n > cap) {
-        printf "FAIL: %s is %d SLOC (> %d) and not allowlisted. New oversized file; split it or it cannot merge.\n", path, n, cap
+        printf "FAIL: %s is %d SLOC (> %s) and not allowlisted. New oversized file; split it or it cannot merge.\n", path, n, cap_label
         viol++
       }
     }
@@ -310,7 +402,8 @@ done < "$RESULT"
 
 if [ "$violations" -gt 0 ]; then
   echo "line-cap: $allowlisted allowlisted, $violations violation(s) — FAILED." >&2
-  echo "Cap is $CAP SLOC/file (code lines; excludes comments and blanks). To re-freeze after an intentional split, run: scripts/check_line_cap.sh --update" >&2
+  echo "Caps: ${PROD_CAP} SLOC (production) / ${TEST_CAP} SLOC (test/benchmark)." >&2
+  echo "To re-freeze after an intentional split, run: scripts/check_line_cap.sh --update" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Introduces a **dual-cap regime** (issue #1131): production source files stay at **500 SLOC**; test/benchmark files get a looser **1500 SLOC** cap.
- A file is classified as test/benchmark when: basename is `tests.rs`, basename ends with `_test.rs` or `_tests.rs`, path contains a `/tests/` segment, or path contains a `/benches/` segment. All others are production files.
- Regenerated `.line-cap-allowlist.tsv`: **10 entries removed** (all test/benchmark files now ≤ 1500 SLOC). `crates/trusty-search/src/core/indexer/tests.rs` (2472 SLOC) remains. Total: 94 → 84.

## Implementation details

- `scripts/check_line_cap.sh`: added `cap_for_path()` using pure shell parameter expansion (no `basename` external command — portable on bash 3.2 / bash 5). Cap-map (P) rows are emitted **before** snapshot (C) rows in the awk pipeline so `file_cap[]` is fully populated on the first pass (ordering bug fix). Messages now report which cap applied, e.g. `> 500 prod cap` or `> 1500 test cap`.
- `.github/workflows/line-cap.yml` and `.pre-commit-config.yaml` just invoke the script — **no changes needed**.
- `CLAUDE.md`: updated the Key Conventions and Common Pitfalls sections to document the dual cap and exact classification rules.

## Three-probe verification (all probes deleted before commit)

**Probe A** — production path `crates/trusty-search/src/zzz_probe.rs`, ~600 SLOC → **FAILED as expected** (> 500 prod cap):
```
FAIL: crates/trusty-search/src/zzz_probe.rs is 600 SLOC (> 500 prod cap) and not allowlisted. New oversized file; split it or it cannot merge.
line-cap: 84 allowlisted, 1 violation(s) — FAILED.
```

**Probe B** — test path `crates/trusty-search/tests/zzz_probe.rs`, ~600 SLOC → **PASSED as expected** (≤ 1500 test cap):
```
line-cap: 84 allowlisted, 0 violations — OK.
```

**Probe C** — test path `crates/trusty-search/tests/zzz_big.rs`, ~1600 SLOC → **FAILED as expected** (> 1500 test cap):
```
FAIL: crates/trusty-search/tests/zzz_big.rs is 1600 SLOC (> 1500 test cap) and not allowlisted. New oversized file; split it or it cannot merge.
line-cap: 84 allowlisted, 1 violation(s) — FAILED.
```

## Allowlist entries removed (test/benchmark files dropped to ≤ 1500 SLOC)

| File | SLOC |
|---|---|
| `crates/trusty-agents/src/tools/memory/tests.rs` | 510 |
| `crates/trusty-common/src/memory_core/retrieval/tests.rs` | 875 |
| `crates/trusty-memory/tests/concurrent_perf.rs` | 569 |
| `crates/trusty-memory/tests/mcp_stdio_tools.rs` | 683 |
| `crates/trusty-mpm/src/daemon/api_tests.rs` | 1046 |
| `crates/trusty-review/src/pipeline/runner_tests.rs` | 598 |
| `crates/trusty-search/src/service/reindex/tests.rs` | 1113 |
| `crates/trusty-search/tests/benchmark_harness.rs` | 544 |
| `crates/trusty-search/tests/benchmark_open_mpm_kg.rs` | 665 |
| `crates/trusty-search/tests/benchmark_open_mpm.rs` | 568 |

## Test plan

- [ ] Confirm CI passes (line-cap job exits 0)
- [ ] Run `bash scripts/check_line_cap.sh` locally — should report 84 allowlisted, 0 violations
- [ ] Verify probe files produce correct failures before deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)