### PR TITLE
fix(trusty-search): address all four #1129 review advisories (contrib overlay)

### DIFF
--- a/crates/trusty-search/src/core/corpus_contrib.rs
+++ b/crates/trusty-search/src/core/corpus_contrib.rs
@@ -91,21 +91,27 @@ impl CorpusStore {
     /// rows must not linger (a proc deleted from the codebase would otherwise
     /// keep its edges forever).
     /// What: serializes the whole [`ContribGraph`] and inserts it under the
-    /// producer key in one write txn (atomic replace).
-    /// Test: `contrib_replace_per_producer_drops_old_rows`.
-    pub fn save_contrib_graph(&self, graph: &ContribGraph) -> anyhow::Result<()> {
+    /// producer key in one write txn (atomic replace). Returns whether a
+    /// prior contribution was replaced — read from the same insert, so the
+    /// flag is race-free under concurrent same-producer ingest (PR #1129
+    /// review, finding 4).
+    /// Test: `contrib_replace_per_producer_drops_old_rows` (asserts the
+    /// returned flag flips false → true).
+    pub fn save_contrib_graph(&self, graph: &ContribGraph) -> anyhow::Result<bool> {
         let bytes = serde_json::to_vec(graph).context("serialize contrib graph")?;
         let txn = self.db.begin_write().context("begin contrib write txn")?;
+        let replaced;
         {
             let mut table = txn
                 .open_table(KG_CONTRIB_TABLE)
                 .context("open kg_contrib table")?;
-            table
+            replaced = table
                 .insert(graph.producer.as_str(), bytes.as_slice())
-                .context("insert contrib graph")?;
+                .context("insert contrib graph")?
+                .is_some();
         }
         txn.commit().context("commit contrib write txn")?;
-        Ok(())
+        Ok(replaced)
     }
 
     /// Load every producer's contribution, sorted by producer id.
@@ -211,12 +217,14 @@ mod tests {
     #[test]
     fn contrib_replace_per_producer_drops_old_rows() {
         let (_dir, store) = store();
-        store
+        let replaced = store
             .save_contrib_graph(&sample("navigatsql", "dbo.orders"))
             .expect("save v1");
+        assert!(!replaced, "first save must not report a replacement");
         // Second ingest from the same producer: completely replaces the first.
         let v2 = sample("navigatsql", "dbo.customers");
-        store.save_contrib_graph(&v2).expect("save v2");
+        let replaced = store.save_contrib_graph(&v2).expect("save v2");
+        assert!(replaced, "second save must report the replacement");
         let loaded = store.load_contrib_graphs().expect("load");
         assert_eq!(loaded, vec![v2]);
         assert!(!loaded[0].edges.iter().any(|e| e.to == "dbo.orders"));

--- a/crates/trusty-search/src/core/symbol_graph/contrib.rs
+++ b/crates/trusty-search/src/core/symbol_graph/contrib.rs
@@ -55,23 +55,32 @@ pub struct ContribMergeStats {
 /// `None` when nothing resolves (caller counts it as dropped, #816-style).
 /// Test: `contrib_edge_kind_resolution` in `super::tests`.
 pub(crate) fn resolve_edge_kind(edge: &ContribEdge) -> Option<EdgeKind> {
-    if let Some(kind) = edge.kind.as_deref() {
-        let coarse = match kind {
-            "reads" => Some(EdgeKind::Reads),
-            "writes" => Some(EdgeKind::Writes),
-            "references" => Some(EdgeKind::References),
-            "calls_function" | "calls_proc" => Some(EdgeKind::CallsFunction),
-            "accesses_resource" => Some(EdgeKind::AccessesResource),
-            _ => None,
-        };
-        if let Some(k) = coarse {
-            return Some(k);
-        }
-        if let Some(k) = EdgeKind::from_tag(kind) {
-            return Some(k);
-        }
+    if let Some(k) = edge.kind.as_deref().and_then(parse_kind_token) {
+        return Some(k);
     }
     edge.tag.as_deref().and_then(EdgeKind::from_tag)
+}
+
+/// Parse one edge-kind token from the contributed vocabulary.
+///
+/// Why: the ingest path (`resolve_edge_kind`) and the `graph/neighbors`
+/// query filter must accept the exact same vocabulary — a kind added to one
+/// but not the other would silently diverge ingest vs query (PR #1129
+/// review, finding 3). This is the single shared table.
+/// What: coarse lowercase wire names map onto the #817 first-class variants;
+/// anything else falls through to `EdgeKind::from_tag` (PascalCase static
+/// tags and `custom:<label>`). `None` = unrecognized token.
+/// Test: `contrib_edge_kind_resolution` in `contrib_tests`;
+/// `neighbors_rejects_unknown_edge_kind` in `tests_contrib_graph`.
+pub(crate) fn parse_kind_token(token: &str) -> Option<EdgeKind> {
+    match token {
+        "reads" => Some(EdgeKind::Reads),
+        "writes" => Some(EdgeKind::Writes),
+        "references" => Some(EdgeKind::References),
+        "calls_function" | "calls_proc" => Some(EdgeKind::CallsFunction),
+        "accesses_resource" => Some(EdgeKind::AccessesResource),
+        other => EdgeKind::from_tag(other),
+    }
 }
 
 impl SymbolGraph {
@@ -188,14 +197,13 @@ pub async fn save_then_merge_contrib(
         if contribs.is_empty() {
             return graph;
         }
-        // Sole owner here: the save closure above borrowed, never cloned.
-        let mut g = match Arc::try_unwrap(graph) {
-            Ok(g) => g,
-            Err(shared) => {
-                tracing::warn!("index '{index_id}': graph Arc shared — contrib merge skipped");
-                return shared;
-            }
-        };
+        // Usually the sole owner (the save above only borrowed). If a
+        // concurrent `snapshot_symbol_graph` raced us and holds a clone of
+        // the Arc, clone the inner graph rather than skip the merge — the
+        // serving graph must never silently lack contributed edges
+        // (PR #1129 review, finding 1). Clone cost is proportional to the
+        // just-built graph and only paid on the racy path.
+        let mut g = Arc::try_unwrap(graph).unwrap_or_else(|shared| (*shared).clone());
         let stats = g.merge_contrib(&contribs);
         tracing::info!(
             "index '{index_id}': merged {} contributed graph(s): +{} nodes, +{} edges \

--- a/crates/trusty-search/src/core/symbol_graph/contrib_tests.rs
+++ b/crates/trusty-search/src/core/symbol_graph/contrib_tests.rs
@@ -236,6 +236,39 @@ async fn contrib_rebuild_path_merges_after_save() {
 }
 
 #[tokio::test]
+async fn contrib_merge_happens_even_when_arc_is_shared() {
+    // PR #1129 review, finding 1: a concurrent snapshot holding a clone of
+    // the graph Arc must NOT cause the contrib merge to be skipped — the
+    // finalizer clones the inner graph instead.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let corpus = Arc::new(CorpusStore::open(&dir.path().join("c.redb")).expect("open"));
+    corpus
+        .save_contrib_graph(&contrib(
+            "navigatsql",
+            vec![node("dbo.usp_x", "proc"), node("dbo.orders", "table")],
+            vec![edge("dbo.usp_x", "dbo.orders", "writes")],
+        ))
+        .expect("save contrib");
+
+    let graph = Arc::new(SymbolGraph::new());
+    let concurrent_snapshot = Arc::clone(&graph); // simulates snapshot_symbol_graph
+    let merged = super::contrib::save_then_merge_contrib(
+        graph,
+        Some(Arc::clone(&corpus)),
+        "test-idx".into(),
+    )
+    .await;
+    assert_eq!(
+        merged.node_kind("dbo.orders"),
+        Some("table"),
+        "merge must happen despite the shared Arc"
+    );
+    // The concurrently-held snapshot still sees the pre-merge graph (clone
+    // semantics) — it is simply stale, never corrupted.
+    assert_eq!(concurrent_snapshot.node_count(), 0);
+}
+
+#[tokio::test]
 async fn contrib_replace_per_producer_after_remerge() {
     // End-to-end replace semantics: ingest v2 from the same producer, rebuild,
     // and confirm v1's edges are gone from the serving graph.

--- a/crates/trusty-search/src/core/symbol_graph/graph.rs
+++ b/crates/trusty-search/src/core/symbol_graph/graph.rs
@@ -44,7 +44,12 @@ pub struct SymbolNode {
 /// Built from a slice of `(chunk_id, file, function_name, calls)` tuples; the
 /// chunker (`chunk_ast`) is responsible for populating the `function_name` and
 /// `calls` fields per chunk, so the graph just stitches them together.
-#[derive(Debug, Default)]
+///
+/// `Clone` exists for the contributed-overlay merge path: when the rebuild
+/// finalizer cannot take sole ownership of the freshly-built graph (a
+/// concurrent snapshot holds a clone of the `Arc`), it clones the inner
+/// graph so the merge always happens (PR #1129 review, finding 1).
+#[derive(Debug, Default, Clone)]
 pub struct SymbolGraph {
     pub(crate) graph: DiGraph<SymbolNode, EdgeKind>,
     /// Symbol name → node index. Holds the *first* definition seen if a symbol

--- a/crates/trusty-search/src/core/symbol_graph/mod.rs
+++ b/crates/trusty-search/src/core/symbol_graph/mod.rs
@@ -29,6 +29,7 @@ mod persist_tests;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use contrib::parse_kind_token;
 pub use contrib::{save_then_merge_contrib, ContribMergeStats};
 
 // Public type aliases shared across submodules.

--- a/crates/trusty-search/src/service/server/contrib_graph.rs
+++ b/crates/trusty-search/src/service/server/contrib_graph.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use crate::core::corpus::contrib::{ContribEdge, ContribGraph, ContribNode};
 use crate::core::entity::EdgeKind;
 use crate::core::registry::IndexId;
+use crate::core::symbol_graph::parse_kind_token;
 
 use super::state::SearchAppState;
 
@@ -119,16 +120,10 @@ pub(super) async fn ingest_graph_handler(
                 "index has no durable corpus store — contributed graphs require one".into(),
             ));
         };
-        let producer = contrib.producer.clone();
-        let join = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
-            let replaced = corpus
-                .load_contrib_graphs()?
-                .iter()
-                .any(|g| g.producer == producer);
-            corpus.save_contrib_graph(&contrib)?;
-            Ok(replaced)
-        })
-        .await;
+        // `save_contrib_graph` reports the replacement from the insert
+        // itself, so the flag is exact under concurrent same-producer
+        // ingest (PR #1129 review, finding 4).
+        let join = tokio::task::spawn_blocking(move || corpus.save_contrib_graph(&contrib)).await;
         match join {
             Ok(Ok(replaced)) => replaced,
             Ok(Err(e)) => {
@@ -196,24 +191,6 @@ pub(super) struct NeighborEntry {
     pub edge: String,
 }
 
-/// Map one comma-separated `edge_kinds` token to an `EdgeKind`.
-///
-/// Why: the query surface accepts the same vocabulary the ingest accepts, so
-/// a client can filter on exactly what it contributed.
-/// What: coarse lowercase names first, then `EdgeKind::from_tag` (static
-/// PascalCase tags and `custom:*`). `None` = unrecognized token (400).
-/// Test: `neighbors_rejects_unknown_edge_kind` in `tests_contrib_graph`.
-fn parse_edge_kind(token: &str) -> Option<EdgeKind> {
-    match token {
-        "reads" => Some(EdgeKind::Reads),
-        "writes" => Some(EdgeKind::Writes),
-        "references" => Some(EdgeKind::References),
-        "calls_function" | "calls_proc" => Some(EdgeKind::CallsFunction),
-        "accesses_resource" => Some(EdgeKind::AccessesResource),
-        other => EdgeKind::from_tag(other),
-    }
-}
-
 /// `GET /indexes/{id}/graph/neighbors` — bounded BFS over the merged graph.
 ///
 /// Why: the single traversal primitive of ADR-0009 — answers "what writes
@@ -252,7 +229,7 @@ pub(super) async fn graph_neighbors_handler(
         Some(csv) => {
             let mut out = Vec::new();
             for token in csv.split(',').map(str::trim).filter(|t| !t.is_empty()) {
-                let Some(kind) = parse_edge_kind(token) else {
+                let Some(kind) = parse_kind_token(token) else {
                     return Err(err(
                         StatusCode::BAD_REQUEST,
                         format!("unknown edge kind '{token}'"),

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -144,12 +144,15 @@ pub fn build_router(state: SearchAppState) -> Router {
         .route("/indexes/{id}/remove-file", post(remove_file_handler))
         .route("/indexes/{id}/reindex", post(reindex_handler))
         // Contributed-graph ingest (ADR-0009): bulk lane (store + graph
-        // rebuild can run for seconds); raised body limit — full contributed
-        // documents from large codebases run to tens of MB.
+        // rebuild can run for seconds). Body limit 64 MiB — observed maxima
+        // from large pilot corpora are ~20 MB, so this is ~3x headroom while
+        // bounding the per-request RAM/DoS surface (PR #1129 review,
+        // finding 2); revisit with a streaming ingest path if producers
+        // outgrow it.
         .route(
             "/indexes/{id}/graph",
             post(ingest_graph_handler)
-                .layer(axum::extract::DefaultBodyLimit::max(256 * 1024 * 1024)),
+                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024)),
         )
         .route_layer(axum::middleware::from_fn(
             crate::service::concurrency::apply_limiter,


### PR DESCRIPTION
Fast-follow addressing all four advisory findings from the #1129 trusty-review, including the one flagged as wanted before production traffic.

| # | Finding | Fix |
|---|---|---|
| 1 | **Arc-sharing silently skips the merge** (correctness) | `SymbolGraph` derives `Clone`; `save_then_merge_contrib` clones the inner graph on the racy path instead of skipping — the serving graph can never silently lack contributed edges. New test `contrib_merge_happens_even_when_arc_is_shared` holds a concurrent snapshot clone and asserts the merge still lands (and that the stale snapshot is unchanged, never corrupted). Clone cost is paid only on the race. |
| 2 | **256 MiB ingest body limit** | Lowered to **64 MiB** (~3× the observed ~20 MB maxima from large pilot corpora); comment documents the bound and the streaming-ingest revisit condition. |
| 3 | **Duplicate edge-kind vocabulary** | Single shared `parse_kind_token` in `symbol_graph::contrib`, used by both `resolve_edge_kind` (ingest) and the `graph/neighbors` filter — the vocabularies can no longer diverge. Handler's local copy deleted. |
| 4 | **TOCTOU on `replaced`** | `save_contrib_graph` now returns the flag from the `insert` in the single write txn (`redb` returns the prior value); the handler's load-then-save existence check is gone, making `replaced` exact under concurrent same-producer ingest. Test asserts the flag flips false → true. |

Validation: full trusty-search suite green (892 lib + 214 integration, 25 contrib-specific), `clippy --all-targets -D warnings` clean, line-cap 0 violations.

Refs: #1129 review comment, #819, ADR-0009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)