### PR TITLE
fix(trusty-memory): robust MCP transport — compat shim + hardened serve --stdio proxy (closes #1141)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,8 +403,10 @@ the daemon logs an error with the actionable FDA re-grant hint.
 
 As of trusty-common 0.10.0, all three HTTP daemons (trusty-memory, trusty-search,
 trusty-analyze) implement graceful shutdown: they drain in-flight requests before
-exiting when they receive SIGTERM. The `mcp_bridge` binary reconnects automatically
-with exponential backoff when the daemon restarts.
+exiting when they receive SIGTERM. The `serve --stdio` proxy reconnects automatically
+with exponential backoff when the daemon restarts (the `trusty-memory-mcp-bridge`
+binary is a deprecated shim that forwards to `serve --stdio`; update your
+`.mcp.json` to `"command": "trusty-memory", "args": ["serve", "--stdio"]`).
 
 **Use `launchctl bootout` (SIGTERM), not `launchctl kickstart -k` (SIGKILL):**
 

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -55,7 +55,7 @@ path = "src/bin/bm25_daemon.rs"
 #      restores the binary so existing configs stop breaking without requiring
 #      per-project config edits. It emits a one-line deprecation notice to stderr
 #      then re-execs `trusty-memory serve --stdio` (the canonical path since PR1).
-#      The shim is intentionally thin (~70 lines, no library imports beyond std)
+#      The shim is intentionally thin (no library imports beyond std)
 #      to minimise maintenance surface. Users should migrate to
 #      `"command": "trusty-memory", "args": ["serve", "--stdio"]` at their
 #      convenience; this shim will be removed in a future minor version.

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -48,6 +48,24 @@ name = "trusty-bm25-daemon"
 path = "src/bin/bm25_daemon.rs"
 
 [[bin]]
+# Why: Compatibility shim for users who installed trusty-memory before the #914
+#      PR3 epic (commit ba60e0c3) deleted the original byte-pipe bridge + UDS
+#      transport. Those users have `trusty-memory-mcp-bridge` in their .mcp.json
+#      and receive JSON-RPC -32000 because the binary no longer ships. This shim
+#      restores the binary so existing configs stop breaking without requiring
+#      per-project config edits. It emits a one-line deprecation notice to stderr
+#      then re-execs `trusty-memory serve --stdio` (the canonical path since PR1).
+#      The shim is intentionally thin (~70 lines, no library imports beyond std)
+#      to minimise maintenance surface. Users should migrate to
+#      `"command": "trusty-memory", "args": ["serve", "--stdio"]` at their
+#      convenience; this shim will be removed in a future minor version.
+# What: standalone binary at src/bin/mcp_bridge.rs; no required-features (no
+#      axum, no redb — this binary never opens a database).
+# Test: `cargo run --bin trusty-memory-mcp-bridge -- 2>&1 | grep DEPRECATED`
+name = "trusty-memory-mcp-bridge"
+path = "src/bin/mcp_bridge.rs"
+
+[[bin]]
 # Why: Bundle trusty-console into trusty-memory's install surface so
 #      `cargo install trusty-memory` also installs the web dashboard
 #      (Single-Install Convention, epic #943). All dashboard logic lives in

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -3,16 +3,21 @@
 [![crates.io](https://img.shields.io/crates/v/trusty-memory.svg)](https://crates.io/crates/trusty-memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Memory palace MCP server (HTTP/SSE + Unix domain socket) backed by `usearch`
-vector store, SQLite metadata, and `fastembed` embeddings. Stores and retrieves
-natural-language memories organized into named "palaces" (namespaces), with an
-optional knowledge-graph layer for structured triples.
+Memory palace MCP server (HTTP/SSE) backed by `usearch` vector store, SQLite
+metadata, and `fastembed` embeddings. Stores and retrieves natural-language
+memories organized into named "palaces" (namespaces), with an optional
+knowledge-graph layer for structured triples.
 
-Claude Code integration uses the companion `trusty-memory-mcp-bridge` binary
-which speaks stdio MCP and pipes it over the daemon's Unix domain socket.
-The legacy in-process `serve --stdio` flag was removed in issue #150 because
-it deadlocked on redb's exclusive write lock whenever a long-lived daemon
-was already running.
+Claude Code integration uses `trusty-memory serve --stdio` — a direct
+stdio JSON-RPC MCP server that forwards every request to the running HTTP
+daemon and returns daemon responses verbatim. No Unix domain socket is
+involved.
+
+A DEPRECATED `trusty-memory-mcp-bridge` shim binary is also installed by
+`cargo install trusty-memory` so that existing `.mcp.json` configs that still
+reference the old bridge name keep working without per-project changes.
+Run `trusty-memory migrate kuzu-memory` to rewrite configs to the canonical
+form automatically.
 
 Integrates with Claude Code and any other MCP-aware client as a first-class
 long-term memory backend.
@@ -60,7 +65,7 @@ cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-memory --lo
 
 This builds from the latest commit on `main` and installs the binary to `~/.cargo/bin/`. Make sure `~/.cargo/bin/` is on your PATH.
 
-Installing `trusty-memory` produces three binaries in one command: `trusty-memory`, `trusty-memory-mcp-bridge`, and `trusty-bm25-daemon`.
+Installing `trusty-memory` produces four binaries in one command: `trusty-memory`, `trusty-memory-mcp-bridge` (deprecated shim — forwards to `serve --stdio`), `trusty-bm25-daemon`, and `trusty-console`.
 
 To install a specific version:
 ```bash
@@ -172,27 +177,43 @@ call.
 
 Run `trusty-memory setup` once — it installs the launchd LaunchAgent
 (macOS), pre-warms the embedder cache, and patches every Claude settings
-file it finds with the canonical MCP server entry. The MCP entry points
-at `trusty-memory-mcp-bridge`, a thin stdio-to-UDS pipe (PR #149) that
-Claude Code spawns as a child process. The bridge then connects to the
-long-lived daemon over the Unix domain socket the daemon owns.
+file it finds with the canonical MCP server entry.
 
-If you prefer to edit `.mcp.json` (or `~/.claude/mcp.json`) by hand:
+### Canonical MCP config (0.15.3+)
+
+The recommended entry in `.mcp.json` or `~/.claude/mcp.json` is:
 
 ```json
 {
   "mcpServers": {
     "trusty-memory": {
-      "command": "trusty-memory-mcp-bridge",
-      "args": [],
+      "command": "trusty-memory",
+      "args": ["serve", "--stdio"],
       "env": {}
     }
   }
 }
 ```
 
-Claude Code auto-discovers `.mcp.json` on project open. The
-`trusty-memory-mcp-bridge` binary must be on `PATH` and the daemon must be
+`trusty-memory serve --stdio` is a pure daemon-bridge proxy: it ensures the
+HTTP daemon is running (auto-starting it if absent), then forwards every
+JSON-RPC request to `POST /rpc` on the daemon and returns the response
+verbatim. No Unix domain socket is involved. The stdio process never opens
+the redb write-lock directly, so it co-exists safely with the running HTTP
+daemon.
+
+Run `trusty-memory migrate kuzu-memory` to rewrite all Claude settings files
+to the canonical form automatically.
+
+### Compatibility shim (for existing installations)
+
+If your `.mcp.json` still references `trusty-memory-mcp-bridge`, the shim
+binary (installed alongside `trusty-memory` since 0.15.3) forwards to
+`serve --stdio` automatically. You will see a one-line deprecation warning
+on stderr (which Claude Code ignores). Update your config at your
+convenience — the shim will be removed in a future minor version.
+
+Claude Code auto-discovers `.mcp.json` on project open. The daemon must be
 running (started either by `trusty-memory setup`'s LaunchAgent or by
 `trusty-memory start` / `trusty-memory serve`).
 
@@ -201,10 +222,10 @@ running (started either by `trusty-memory setup`'s LaunchAgent or by
 The MCP server registers **23 tools** (authoritative source:
 `src/tools.rs` `tool_definitions`, asserted by the
 `tool_definitions_lists_all_tools` test). All are exposed via both the MCP
-protocol (over the `trusty-memory-mcp-bridge` → UDS path) and the HTTP API
-(`/api/v1/`). The `palace` argument is required unless the server was started
-with `--palace <name>`. The tables below cover the primary surface; the full
-roster also includes `memory_note`, `memory_recall_all`, `palace_delete`,
+protocol (over the `serve --stdio` path) and the HTTP API (`/api/v1/`). The
+`palace` argument is required unless the server was started with `--palace
+<name>`. The tables below cover the primary surface; the full roster also
+includes `memory_note`, `memory_recall_all`, `palace_delete`,
 `palace_update`, `palace_compact`, `kg_gaps`, `kg_bootstrap`, `add_alias`,
 `discover_aliases`, `list_prompt_facts`, `remove_prompt_fact`, and
 `get_prompt_context`.

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -16,8 +16,9 @@ involved.
 A DEPRECATED `trusty-memory-mcp-bridge` shim binary is also installed by
 `cargo install trusty-memory` so that existing `.mcp.json` configs that still
 reference the old bridge name keep working without per-project changes.
-Run `trusty-memory migrate kuzu-memory` to rewrite configs to the canonical
-form automatically.
+To update your config, manually set the `trusty-memory` entry to
+`"command": "trusty-memory", "args": ["serve", "--stdio"]` in your `.mcp.json`
+or `~/.claude/mcp.json`.
 
 Integrates with Claude Code and any other MCP-aware client as a first-class
 long-term memory backend.
@@ -202,16 +203,32 @@ verbatim. No Unix domain socket is involved. The stdio process never opens
 the redb write-lock directly, so it co-exists safely with the running HTTP
 daemon.
 
-Run `trusty-memory migrate kuzu-memory` to rewrite all Claude settings files
-to the canonical form automatically.
+If you are switching from the legacy `kuzu-memory` server, run
+`trusty-memory migrate kuzu-memory` to rewrite all Claude settings files
+automatically (see [Migrating from kuzu-memory](#from-kuzu-memory-mcp-config-issue-278) below).
 
 ### Compatibility shim (for existing installations)
 
 If your `.mcp.json` still references `trusty-memory-mcp-bridge`, the shim
 binary (installed alongside `trusty-memory` since 0.15.3) forwards to
 `serve --stdio` automatically. You will see a one-line deprecation warning
-on stderr (which Claude Code ignores). Update your config at your
-convenience — the shim will be removed in a future minor version.
+on stderr (which Claude Code ignores). To update your config manually, set
+the `trusty-memory` entry to:
+
+```json
+{
+  "mcpServers": {
+    "trusty-memory": {
+      "command": "trusty-memory",
+      "args": ["serve", "--stdio"]
+    }
+  }
+}
+```
+
+There is no automated command to rewrite `trusty-memory-mcp-bridge` entries
+(unlike the kuzu-memory migration). The shim will be removed in a future
+minor version.
 
 Claude Code auto-discovers `.mcp.json` on project open. The daemon must be
 running (started either by `trusty-memory setup`'s LaunchAgent or by

--- a/crates/trusty-memory/src/bin/mcp_bridge.rs
+++ b/crates/trusty-memory/src/bin/mcp_bridge.rs
@@ -13,7 +13,10 @@
 //!   `"command": "trusty-memory-mcp-bridge", "args": []`
 //! with:
 //!   `"command": "trusty-memory", "args": ["serve", "--stdio"]`
-//! Run `trusty-memory migrate kuzu-memory` for an automated rewrite.
+//! There is no automated command for this specific config update; the manual
+//! edit above is the only migration path.  (`trusty-memory migrate kuzu-memory`
+//! is for users switching from the separate kuzu-memory server — it looks for
+//! `kuzu-memory` / `kuzu_memory` keys, not `trusty-memory-mcp-bridge`.)
 //!
 //! What: emits one deprecation warning to stderr (never stdout — MCP JSON-RPC
 //! framing owns stdout), then re-execs `trusty-memory serve --stdio` using
@@ -34,7 +37,7 @@ fn main() -> ExitCode {
     eprintln!(
         "[DEPRECATED] trusty-memory-mcp-bridge is deprecated and will be removed in a future version.\n\
          Update your MCP config to use: \"command\": \"trusty-memory\", \"args\": [\"serve\", \"--stdio\"]\n\
-         Run `trusty-memory migrate kuzu-memory` for an automated config rewrite.\n\
+         (No automated command exists for this config update — edit your .mcp.json manually.)\n\
          Forwarding to `trusty-memory serve --stdio` now…"
     );
 
@@ -47,6 +50,11 @@ fn main() -> ExitCode {
         .and_then(|p| p.parent().map(|d| d.join("trusty-memory")))
         .filter(|p| p.exists())
         .unwrap_or_else(|| std::path::PathBuf::from("trusty-memory"));
+
+    // Emit the delegation target to stderr before exec/spawn so PATH-resolution
+    // issues are visible in logs without needing a debugger.  Never to stdout —
+    // stdout is the JSON-RPC channel.
+    eprintln!("trusty-memory-mcp-bridge: delegating to {}", exe.display());
 
     // Re-exec as `trusty-memory serve --stdio`.
     // On Unix, `exec` replaces this process entirely so no extra zombie stays
@@ -63,19 +71,26 @@ fn main() -> ExitCode {
     }
 
     // Non-Unix fallback: spawn a child, forward stdio, propagate exit status.
+    // Explicit stdio inheritance is listed for self-documentation: the child
+    // must own the same stdin/stdout/stderr file descriptors so the JSON-RPC
+    // framing and error output reach the MCP client and Claude Code logs
+    // without any extra pipe layer.
     #[cfg(not(unix))]
     {
+        use std::process::Stdio;
         let status = std::process::Command::new(&exe)
             .arg("serve")
             .arg("--stdio")
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
             .status();
         match status {
             Ok(s) => {
-                if s.success() {
-                    ExitCode::SUCCESS
-                } else {
-                    ExitCode::FAILURE
-                }
+                // Propagate the child's real exit code so supervisors and
+                // healthcheck scripts see the actual status rather than a
+                // collapsed FAILURE for every non-zero exit.
+                std::process::exit(s.code().unwrap_or(1));
             }
             Err(e) => {
                 eprintln!("trusty-memory-mcp-bridge: spawn failed: {e}");

--- a/crates/trusty-memory/src/bin/mcp_bridge.rs
+++ b/crates/trusty-memory/src/bin/mcp_bridge.rs
@@ -1,0 +1,86 @@
+//! `trusty-memory-mcp-bridge` — DEPRECATED compatibility shim.
+//!
+//! Why: the #914 PR3 epic (commit ba60e0c3) deleted the original byte-pipe
+//! bridge binary and the UDS transport. Users who installed trusty-memory
+//! before that deletion still have `trusty-memory-mcp-bridge` (no args) in
+//! their `.mcp.json` — those deployments receive JSON-RPC -32000 because the
+//! binary no longer ships with `cargo install trusty-memory`.  This shim
+//! restores the binary so existing configs stop breaking; it simply
+//! re-execs the same process as `trusty-memory serve --stdio`, which is the
+//! canonical MCP integration today.
+//!
+//! Migration: update your `.mcp.json` (or `~/.claude/mcp.json`) to replace:
+//!   `"command": "trusty-memory-mcp-bridge", "args": []`
+//! with:
+//!   `"command": "trusty-memory", "args": ["serve", "--stdio"]`
+//! Run `trusty-memory migrate kuzu-memory` for an automated rewrite.
+//!
+//! What: emits one deprecation warning to stderr (never stdout — MCP JSON-RPC
+//! framing owns stdout), then re-execs `trusty-memory serve --stdio` using
+//! the same binary path so no extra process stays alive. On platforms where
+//! `exec` is unavailable it falls back to spawning a child, forwarding
+//! stdio, and exiting with the child's status.
+//!
+//! Test: `cargo run --bin trusty-memory-mcp-bridge -- --help 2>&1 | grep DEPRECATED`
+//! confirms the deprecation warning.  The MCP round-trip path is covered by
+//! `tests/serve_stdio_e2e.rs` (which tests `serve --stdio` directly).
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    // Why: MCP framing owns stdout — any byte written to stdout that is not
+    // a valid JSON-RPC message will corrupt the protocol and cause -32000.
+    // We emit the deprecation warning to stderr only.
+    eprintln!(
+        "[DEPRECATED] trusty-memory-mcp-bridge is deprecated and will be removed in a future version.\n\
+         Update your MCP config to use: \"command\": \"trusty-memory\", \"args\": [\"serve\", \"--stdio\"]\n\
+         Run `trusty-memory migrate kuzu-memory` for an automated config rewrite.\n\
+         Forwarding to `trusty-memory serve --stdio` now…"
+    );
+
+    // Resolve the canonical `trusty-memory` binary path: prefer the sibling
+    // binary in the same directory as this process (covers `cargo install`
+    // and PATH-based invocations equally), then fall back to plain
+    // "trusty-memory" on PATH.
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.join("trusty-memory")))
+        .filter(|p| p.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("trusty-memory"));
+
+    // Re-exec as `trusty-memory serve --stdio`.
+    // On Unix, `exec` replaces this process entirely so no extra zombie stays
+    // alive — the PID Claude Code tracks keeps working.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = std::process::Command::new(&exe)
+            .arg("serve")
+            .arg("--stdio")
+            .exec(); // only returns on error
+        eprintln!("trusty-memory-mcp-bridge: exec failed: {err}");
+        ExitCode::FAILURE
+    }
+
+    // Non-Unix fallback: spawn a child, forward stdio, propagate exit status.
+    #[cfg(not(unix))]
+    {
+        let status = std::process::Command::new(&exe)
+            .arg("serve")
+            .arg("--stdio")
+            .status();
+        match status {
+            Ok(s) => {
+                if s.success() {
+                    ExitCode::SUCCESS
+                } else {
+                    ExitCode::FAILURE
+                }
+            }
+            Err(e) => {
+                eprintln!("trusty-memory-mcp-bridge: spawn failed: {e}");
+                ExitCode::FAILURE
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Root-Cause Verdict

**The "UDS listener bound" disappearance was INTENTIONAL, caused solely by commit ba60e0c3 (#914 PR3, 2026-06-08).**

That commit deliberately deleted:
- `src/bin/mcp_bridge.rs` — the byte-pipe bridge binary
- `src/transport/uds.rs` — the entire UDS transport (including the `spawn_uds_listener` call that emitted "UDS listener bound at …")
- The `[[bin]] trusty-memory-mcp-bridge` entry from `Cargo.toml`

This was the intended design per the #914 epic: PR1 introduced `serve --stdio`; PR2 repointed configs; PR3 deleted the dead code.

**Commit 9a3c5434 (`fix TOCTOU, prefer libc::kill`) is NOT involved** and did not cause any regression. It only hardened `daemon_lock.rs` (the PID lock file — a plain text file, not a UDS socket). There are two entirely separate mechanisms:
- The **UDS MCP transport socket** (deleted by ba60e0c3) — emitted "UDS listener bound at …"
- The **PID lock file** (`daemon.lock`, managed by `daemon_lock.rs`) — hardened by 9a3c5434

**The user's -32000 error** occurs because their `.mcp.json` still references the now-deleted `trusty-memory-mcp-bridge` binary.

## Changes

### A) Compat shim (`src/bin/mcp_bridge.rs`, `Cargo.toml`)

Re-adds `trusty-memory-mcp-bridge` as a thin deprecated `[[bin]]` (~70 lines, zero library deps beyond `std`). On Unix it re-execs `trusty-memory serve --stdio` atomically so no extra process stays alive. On non-Unix it spawns a child and forwards stdio. Emits a one-line deprecation warning to **stderr only** (stdout stays clean for JSON-RPC framing). Bundled by the single-install convention so `cargo install trusty-memory` produces it automatically.

### B) Hardened `serve --stdio` proxy

Already landed in the daemon-bridge architecture (`serve_stdio_bridge.rs`):
- `ensure_daemon_up` with bounded retry/backoff (30 s budget, 500 ms poll)
- Reconnect-on-error: transport failures return a JSON-RPC error response and keep the stdio loop alive
- Actionable error text (never surfaces raw `os error 2`)
- Auto-start of the HTTP daemon if absent

No further changes needed here.

### C) No single-instance locking regression

Commit 9a3c5434 correctly hardened `daemon_lock.rs` with O_EXCL create and `libc::kill`. No fix required.

### D) Docs

- `crates/trusty-memory/README.md`: removes all stale UDS/bridge references; documents `serve --stdio` as canonical integration; documents the deprecated shim path; updates "Installing produces X binaries" count
- `CLAUDE.md`: connection-safe daemon restart note updated to reference `serve --stdio` proxy instead of the deleted `mcp_bridge` binary

## Verification

### Quality bar

```
cargo check                                    # PASS
cargo clippy -p trusty-memory --all-targets -- -D warnings  # 0 warnings
cargo test -p trusty-memory --lib              # 384 passed; 0 failed
cargo fmt --check                              # PASS (no drift)
bash scripts/check_line_cap.sh                 # 0 violations
```

### Smoke tests

**Shim stdout cleanliness:**
```
$ ./target/debug/trusty-memory-mcp-bridge 2>/dev/null | wc -c
0
```

**Shim deprecation warning goes to stderr:**
```
$ ./target/debug/trusty-memory-mcp-bridge 2>&1 1>/dev/null
[DEPRECATED] trusty-memory-mcp-bridge is deprecated and will be removed in a future version.
Update your MCP config to use: "command": "trusty-memory", "args": ["serve", "--stdio"]
...
```

**JSON-RPC initialize round-trip through shim:**
```
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0.0.1"}}}' \
    | ./target/debug/trusty-memory-mcp-bridge 2>/dev/null
{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{}},"protocolVersion":"2024-11-05","serverInfo":{"name":"trusty-memory","version":"0.15.2"}}}
```

**serve --stdio direct path:**
```
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}' \
    | ./target/debug/trusty-memory serve --stdio 2>/dev/null
{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{}},"protocolVersion":"2024-11-05","serverInfo":{"name":"trusty-memory","version":"0.15.2"}}}
```

## Release Recommendation

A **0.15.3 patch release** is recommended immediately. The shim binary is new and only reaches users who `cargo install trusty-memory >= 0.15.3`. Users on 0.15.2 who are affected still need to either:
1. Install 0.15.3 (gets the shim automatically), or
2. Manually update their `.mcp.json` to `"command": "trusty-memory", "args": ["serve", "--stdio"]`

Use `SKIP_UI_BUILD=1 cargo publish -p trusty-memory` per the workspace publish convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)