### PR TITLE
test(trusty-common): make daemon_guard port tests hermetic (bind-port-0)

### DIFF
--- a/crates/trusty-common/src/daemon_guard.rs
+++ b/crates/trusty-common/src/daemon_guard.rs
@@ -218,12 +218,19 @@ mod tests {
 
     /// Why: `probe_once` against an unbound localhost port must return `false`
     /// without panicking, within a generous wall-clock bound.
-    /// What: probes port 65535 (never bound in the test environment).
+    /// What: binds a `TcpListener` to port 0 to let the OS assign a free
+    /// ephemeral port, reads that port, drops the listener to free it, then
+    /// probes the now-guaranteed-unbound address. This avoids hard-coding port
+    /// 65535 which can be bound on busy CI hosts.
     /// Test: this test.
     #[tokio::test]
     async fn probe_once_returns_false_for_refused_port() {
+        // Bind port 0 to get a free OS-assigned port, then release it.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
         let started = Instant::now();
-        let ok = probe_once("http://127.0.0.1:65535/health").await;
+        let ok = probe_once(&format!("http://127.0.0.1:{port}/health")).await;
         assert!(!ok, "probe must fail against an unbound port");
         assert!(
             started.elapsed() < Duration::from_secs(6),
@@ -282,12 +289,21 @@ mod tests {
 
     /// Why: when the daemon never starts, `spin_until_ready` must return `Err`
     /// after the timeout rather than looping forever.
-    /// What: uses a very short timeout and a definitely-free port.
+    /// What: binds a `TcpListener` to port 0 to get a free OS-assigned port,
+    /// drops the listener to free it, then spins against that now-unbound port
+    /// with a very short timeout. This avoids using privileged port 1 which
+    /// produces ETIMEDOUT instead of ECONNREFUSED on some macOS/BSD configs and
+    /// can cause the test to stall for the full `PROBE_TIMEOUT` rather than
+    /// returning immediately.
     /// Test: this test.
     #[tokio::test]
     async fn spin_until_ready_times_out_for_down_daemon() {
+        // Bind port 0 to get a free OS-assigned port, then release it.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
         let cfg = DaemonGuardConfig {
-            health_url: "http://127.0.0.1:1/health".to_string(),
+            health_url: format!("http://127.0.0.1:{port}/health"),
             service_name: "test-daemon".to_string(),
             startup_timeout: Duration::from_millis(200),
             poll_interval: Duration::from_millis(50),


### PR DESCRIPTION
## Part A: Test hardening (DONE)

Fixes two flaky unit tests in `crates/trusty-common/src/daemon_guard.rs` flagged in the trusty-review of PR #1147.

### What changed

**File:** `crates/trusty-common/src/daemon_guard.rs`

Both tests now use the bind-port-0-then-drop idiom already established in `crates/trusty-analyze/src/commands/daemon_guard.rs`:

```rust
let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
let port = listener.local_addr().unwrap().port();
drop(listener);
// probe http://127.0.0.1:{port}/health — port is now guaranteed-unbound
```

**`probe_once_returns_false_for_refused_port`** (was line ~232):
- Before: hard-coded `http://127.0.0.1:65535/health` — port 65535 is a valid ephemeral port that can be bound on busy CI hosts, causing a spurious test pass (probe returns true).
- After: binds port 0 to get a free OS-assigned port, drops the listener, then probes — port is guaranteed unbound.

**`spin_until_ready_times_out_for_down_daemon`** (was line ~272):
- Before: used privileged port 1, which on some macOS/BSD configs produces ETIMEDOUT instead of ECONNREFUSED, causing the test to stall for the full `PROBE_TIMEOUT` (750 ms) on each probe iteration rather than failing fast.
- After: same bind-port-0-then-drop pattern — unprivileged, ephemeral, guaranteed-free.

### Verification

```
running 4 tests
test daemon_guard::tests::probe_once_returns_false_for_bad_url ... ok
test daemon_guard::tests::probe_once_returns_false_for_refused_port ... ok
test daemon_guard::tests::spin_until_ready_returns_ok_for_live_server ... ok
test daemon_guard::tests::spin_until_ready_times_out_for_down_daemon ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 69 filtered out; finished in 0.21s

test result: ok. 67 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.21s
```

`cargo clippy --workspace --all-targets -- -D warnings` → `Finished` (zero warnings)
`cargo fmt --check` → clean (exit 0)
`bash scripts/check_line_cap.sh` → `line-cap: 75 allowlisted, 0 violations — OK. EXIT=0`

---

## Part B: Issue #1083 — Status Assessment (DEFERRED — already substantially complete)

After reading `gh issue view 1083` and inspecting the three daemon-backed crates in detail, **#1083 is already implemented** in PR #1147 (the merge that became the current `origin/main`):

| Service | Status |
|---------|--------|
| `trusty-memory` | Done (PR #1080) |
| `trusty-search` | Done — `crates/trusty-search/src/commands/serve.rs` calls `trusty_common::mcp::ensure_daemon_up` with `DaemonBridgeConfig` |
| `trusty-analyze` | Done — `crates/trusty-analyze/src/commands/daemon_guard.rs::ensure_mcp_daemon_up` calls `trusty_common::mcp::ensure_daemon_up` with `DaemonBridgeConfig` |
| `trusty-common` shared helper | Done — `mcp::DaemonBridgeConfig` + `mcp::ensure_daemon_up` exist and are used by both consumers |

No code changes for Part B were made. The issue ticket itself should be updated/closed by the maintainer once verified.

---

Closes the review follow-up from #1147.
Related: #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)