### PR TITLE
chore(trusty-console): preserve local UI dist bundle + vite.config changes

### DIFF
--- a/crates/trusty-console/ui/dist/index.html
+++ b/crates/trusty-console/ui/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Trusty Console</title>
-    <script type="module" crossorigin src="/ui/assets/index-cA6Z7eyr.js"></script>
+    <script type="module" crossorigin src="/ui/assets/index-ClvBm31D.js"></script>
     <link rel="stylesheet" crossorigin href="/ui/assets/index-PS33z6A0.css">
   </head>
   <body>

--- a/crates/trusty-console/ui/vite.config.js
+++ b/crates/trusty-console/ui/vite.config.js
@@ -4,6 +4,15 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 export default defineConfig({
   plugins: [svelte()],
   base: '/ui/',
+  resolve: {
+    // Ensure browser-side Svelte entry is resolved (not the server stub).
+    // @sveltejs/vite-plugin-svelte adds 'svelte' to conditions, but Svelte 5
+    // does not expose a 'svelte' condition on its root '.' export — only
+    // 'browser' and 'default' (the latter points to index-server.js).
+    // Without 'browser' here Vite falls through to 'default' and bundles the
+    // SSR stubs, making onMount a no-op and mount() a throw.
+    conditions: ['browser'],
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
Preserves previously-uncommitted local changes to the trusty-console UI to avoid losing them during a main fast-forward.

## Changes
- `crates/trusty-console/ui/dist/index.html` — local dist bundle
- `crates/trusty-console/ui/vite.config.js` — vite config changes

⚠️ Note: `dist/index.html` is a generated bundle, so this PR may conflict with an upstream-regenerated bundle. The bundle may need to be rebuilt against current main before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)