### PR TITLE
fix(trusty-search): surface redb corpus open failure as Failed stage instead of silent chunk_count=0 (closes #1158)

### DIFF
--- a/crates/trusty-search/src/commands/start.rs
+++ b/crates/trusty-search/src/commands/start.rs
@@ -1252,6 +1252,7 @@ mod tests {
             graph_node_count: 0,
             lexical_only: false,
             skip_kg: false,
+            corpus_open_failed: false,
         }
     }
 
@@ -1330,6 +1331,7 @@ mod tests {
             graph_node_count: 7_402,
             lexical_only: true,
             skip_kg: false,
+            corpus_open_failed: false,
         });
         assert_eq!(stages.lexical.status, StageStatus::Ready);
         assert_eq!(stages.semantic.status, StageStatus::Skipped);
@@ -1347,13 +1349,7 @@ mod tests {
     /// trigger can resume cleanly via the hash-skip path.
     #[test]
     fn warm_boot_marks_mid_reindex_as_in_progress() {
-        let stages = derive_warm_boot_stages(WarmBootInputs {
-            chunk_count: 0,
-            hnsw_snapshot_ready: false,
-            graph_node_count: 0,
-            lexical_only: false,
-            skip_kg: false,
-        });
+        let stages = derive_warm_boot_stages(inputs());
         assert_eq!(stages.lexical.status, StageStatus::InProgress);
         assert_eq!(stages.lifecycle_status(), "walking");
         assert!(stages.search_capabilities().is_empty());
@@ -1379,6 +1375,7 @@ mod tests {
             graph_node_count: 7_402,
             lexical_only: false,
             skip_kg: true,
+            corpus_open_failed: false,
         });
         assert_eq!(
             stages.graph.status,
@@ -1407,6 +1404,7 @@ mod tests {
             graph_node_count: 7_402,
             lexical_only: true,
             skip_kg: true,
+            corpus_open_failed: false,
         });
         assert_eq!(stages_both.semantic.status, StageStatus::Skipped);
         assert_eq!(stages_both.graph.status, StageStatus::Skipped);

--- a/crates/trusty-search/src/commands/start_restore.rs
+++ b/crates/trusty-search/src/commands/start_restore.rs
@@ -285,6 +285,11 @@ pub(crate) async fn restore_one_index(
     // `hnsw.usearch` is a `path.exists()` filesystem call (the dim /
     // deserialise check already happened inside the loader), and the
     // symbol-graph node count is an `Arc::clone` + in-memory read.
+    //
+    // Issue #1158: also read `corpus_open_failed` so the classifier emits
+    // `StageStatus::Failed` instead of the silent `InProgress` when the
+    // corpus file existed but could not be opened (incompatible format etc.).
+    let corpus_open_failed = indexer.corpus_open_failed;
     let chunk_count = indexer
         .corpus_store()
         .and_then(|c| c.chunk_count().ok())
@@ -299,10 +304,11 @@ pub(crate) async fn restore_one_index(
         graph_node_count,
         lexical_only,
         skip_kg,
+        corpus_open_failed,
     });
     tracing::info!(
         "warm-boot: index '{}' restored (colocated={}) — chunks={} hnsw_snapshot={} \
-         graph_nodes={} lexical_only={} skip_kg={} → \
+         graph_nodes={} lexical_only={} skip_kg={} corpus_open_failed={} → \
          stages(lexical={:?}, semantic={:?}, graph={:?})",
         entry.id,
         entry.colocated,
@@ -311,6 +317,7 @@ pub(crate) async fn restore_one_index(
         graph_node_count,
         lexical_only,
         skip_kg,
+        corpus_open_failed,
         stages.lexical.status,
         stages.semantic.status,
         stages.graph.status,

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -154,6 +154,18 @@ pub struct CodeIndexer {
 
     /// `true` once the in-memory `chunks` map has been evicted.
     pub(super) chunks_evicted: Arc<AtomicBool>,
+
+    /// Issue #1158: `true` when the redb corpus file existed but could NOT be
+    /// opened on this boot (e.g. incompatible page format, corruption).
+    ///
+    /// Why: the persistence loader logs an ERROR and continues without wiring a
+    /// corpus store when `CorpusStore::open` fails. Without this flag the
+    /// warm-boot stage-classifier only sees `corpus_store() == None` →
+    /// `chunk_count = 0` → `lexical = InProgress`, which is indistinguishable
+    /// from a legitimately empty, freshly-created index.  This flag lets the
+    /// classifier emit `StageStatus::Failed` with an actionable message instead
+    /// of the misleading `InProgress` / "walking" state (closes #1158).
+    pub corpus_open_failed: bool,
 }
 
 /// Coalescing state for `spawn_incremental_persist`.
@@ -209,6 +221,7 @@ impl CodeIndexer {
             created_at: Instant::now(),
             last_activity_ms: Arc::new(AtomicU64::new(0)),
             chunks_evicted: Arc::new(AtomicBool::new(false)),
+            corpus_open_failed: false,
         }
     }
 

--- a/crates/trusty-search/src/service/lazy_restore.rs
+++ b/crates/trusty-search/src/service/lazy_restore.rs
@@ -103,6 +103,9 @@ pub(crate) async fn restore_index_on_demand(
     let skip_kg = entry.skip_kg;
     let defer_embed = entry.defer_embed;
 
+    // Issue #1158: read corpus_open_failed before chunk_count so a redb
+    // incompatible-format failure surfaces as Failed instead of InProgress.
+    let corpus_open_failed = indexer.corpus_open_failed;
     let chunk_count = indexer
         .corpus_store()
         .and_then(|c| c.chunk_count().ok())
@@ -117,17 +120,19 @@ pub(crate) async fn restore_index_on_demand(
         graph_node_count,
         lexical_only,
         skip_kg,
+        corpus_open_failed,
     });
 
     tracing::info!(
         "lazy-load: index '{}' restored — chunks={} hnsw_snapshot={} \
-         graph_nodes={} lexical_only={} skip_kg={}",
+         graph_nodes={} lexical_only={} skip_kg={} corpus_open_failed={}",
         entry.id,
         chunk_count,
         hnsw_snapshot_ready,
         graph_node_count,
         lexical_only,
         skip_kg,
+        corpus_open_failed,
     );
 
     let handle = IndexHandle {

--- a/crates/trusty-search/src/service/persistence_loader.rs
+++ b/crates/trusty-search/src/service/persistence_loader.rs
@@ -105,22 +105,29 @@ pub async fn build_indexer_from_entry(
     let mut indexer =
         CodeIndexer::new(index_id, root_path).with_components(Arc::clone(embedder), store);
 
-    // Issue #28/#840: wire the durable redb corpus store.  Failure is non-fatal
-    // but logged at ERROR (#840) because a missing corpus means the next reindex
-    // cold-starts (Skipped 0).  `open_corpus_with_retry` retries once on
-    // DatabaseAlreadyOpen (stale file lock from a rapid restart).
+    // Issue #28/#840/#1158: wire the durable redb corpus store.  Failure is
+    // non-fatal but logged at ERROR (#840) because a missing corpus means the
+    // next reindex cold-starts (Skipped 0).  `open_corpus_with_retry` retries
+    // once on DatabaseAlreadyOpen (stale file lock from a rapid restart).
+    // Issue #1158: set `corpus_open_failed` so the warm-boot stage-classifier
+    // can emit `StageStatus::Failed` instead of the misleading `InProgress`.
     match persistence::corpus_redb_path_for_entry(entry) {
         Ok(redb_path) => {
             let open_result = open_corpus_with_retry(&redb_path).await;
             match open_result {
                 Ok(corpus) => indexer.set_corpus_store(Arc::new(corpus)),
-                Err(e) => tracing::error!(
-                    "warm-boot: FAILED to open redb corpus for '{index_id}' at {} ({e}). \
-                     The durable corpus store is unavailable — the next reindex will be a \
-                     full cold-start (Skipped 0). Check permissions and whether another \
-                     process holds the redb file lock. (refs #840)",
-                    redb_path.display()
-                ),
+                Err(e) => {
+                    tracing::error!(
+                        "warm-boot: FAILED to open redb corpus for '{index_id}' at {} ({e}). \
+                         The durable corpus store is unavailable — the next reindex will be a \
+                         full cold-start (Skipped 0). Check permissions and whether another \
+                         process holds the redb file lock. (refs #840, #1158)",
+                        redb_path.display()
+                    );
+                    // Issue #1158: mark the failure so the stage-classifier
+                    // emits Failed instead of the misleading InProgress.
+                    indexer.corpus_open_failed = true;
+                }
             }
         }
         Err(e) => tracing::warn!("cannot resolve redb corpus path for '{index_id}': {e}"),

--- a/crates/trusty-search/src/service/warm_boot/stages.rs
+++ b/crates/trusty-search/src/service/warm_boot/stages.rs
@@ -37,6 +37,17 @@ pub struct WarmBootInputs {
     pub lexical_only: bool,
     /// `skip_kg` flag (issue #313): forces graph stage to `Skipped`.
     pub skip_kg: bool,
+    /// Issue #1158: `true` when the redb corpus file existed but could not be
+    /// opened (e.g. incompatible redb page-format, corrupted file).
+    ///
+    /// Why: before this flag, a failed corpus open caused `chunk_count = 0`
+    /// (no corpus store → `unwrap_or(0)`), which the classifier treated as
+    /// `InProgress` — indistinguishable from a freshly-created, never-indexed
+    /// handle. Operators saw `chunks=0` in the warm-boot log and the index
+    /// looked healthy-ish when it was silently broken. This flag lets the
+    /// classifier emit `StageStatus::Failed` with an actionable reason
+    /// instead of the misleading `InProgress` state.
+    pub corpus_open_failed: bool,
 }
 
 /// Pure classifier: given on-disk signals, derive the [`IndexStages`] for a
@@ -44,15 +55,26 @@ pub struct WarmBootInputs {
 ///
 /// Why (issue #135): see [`WarmBootInputs`].
 /// What: applies rules in order:
-///   1. `lexical_only == true` → semantic + graph are `Skipped`.
+///   1. `corpus_open_failed == true` → lexical is `Failed` (issue #1158).
 ///   2. `chunk_count > 0` → lexical is `Ready`.
 ///   3. `chunk_count == 0` → lexical is `InProgress`.
-///   4. `hnsw_snapshot_ready` → semantic is `Ready`.
-///   5. `graph_node_count > 0` → graph is `Ready`.
+///   4. `lexical_only == true` → semantic + graph are `Skipped`.
+///   5. `hnsw_snapshot_ready` → semantic is `Ready`.
+///   6. `graph_node_count > 0` → graph is `Ready`.
 ///
 /// Test: `warm_boot_*` tests in `commands/start.rs`.
 pub fn derive_warm_boot_stages(inputs: WarmBootInputs) -> IndexStages {
-    let lexical = if inputs.chunk_count > 0 {
+    // Issue #1158: corpus open failure must surface as Failed, not InProgress.
+    // Before this guard, `chunk_count == 0` (corpus store absent) was treated
+    // identically to a freshly-created, never-indexed handle — silently
+    // appearing healthy while the durable store was unreadable.
+    let lexical = if inputs.corpus_open_failed {
+        StageState::failed(
+            "redb corpus could not be opened (incompatible or corrupted format); \
+             run `trusty-search index <path> --force` to rebuild from source \
+             (issue #1158)",
+        )
+    } else if inputs.chunk_count > 0 {
         StageState {
             status: StageStatus::Ready,
             ..Default::default()

--- a/crates/trusty-search/tests/warm_boot_corpus_open_failure.rs
+++ b/crates/trusty-search/tests/warm_boot_corpus_open_failure.rs
@@ -1,0 +1,150 @@
+//! Issue #1158 regression tests: redb corpus open failure must surface as
+//! `StageStatus::Failed`, NOT the misleading `InProgress` ("walking").
+//!
+//! Why: before #1158 a failed `CorpusStore::open` (e.g. incompatible redb
+//! page format, or any I/O error) set `corpus_store = None`; `chunk_count`
+//! fell through to `unwrap_or(0)`; `derive_warm_boot_stages` saw `chunk_count
+//! == 0` and emitted `InProgress` — indistinguishable from a freshly-created,
+//! never-indexed handle. The index appeared healthy-ish (`chunks=0`) while the
+//! durable store was actually unreadable.
+//!
+//! This file covers two layers:
+//! 1. Pure classifier unit test — `corpus_open_failed = true` → `Failed`.
+//! 2. Integration test — a directory at the `index.redb` path forces
+//!    `CorpusStore::open` to fail, and the whole pipeline from
+//!    `build_indexer_from_entry` → `derive_warm_boot_stages` emits `Failed`.
+//!
+//! Test: `cargo test -p trusty-search --test warm_boot_corpus_open_failure`
+
+use trusty_search::core::registry::StageStatus;
+use trusty_search::service::warm_boot::{derive_warm_boot_stages, WarmBootInputs};
+
+/// Issue #1158 unit test: the stage classifier must map `corpus_open_failed = true`
+/// to `StageStatus::Failed` with an actionable hint, regardless of `chunk_count`.
+///
+/// Why: the pure-classifier test isolates the business rule from disk I/O so
+/// we can verify the classifier change alone without needing a failing FS.
+/// What: set `corpus_open_failed = true` with `chunk_count = 0`; assert lexical
+/// is `Failed`, `lifecycle_status` is `"failed"`, and no capabilities are
+/// advertised; also assert the failure string contains the reindex hint.
+/// Test: this test.
+#[test]
+fn corpus_open_failed_flag_emits_failed_stage() {
+    let stages = derive_warm_boot_stages(WarmBootInputs {
+        chunk_count: 0,
+        hnsw_snapshot_ready: false,
+        graph_node_count: 0,
+        lexical_only: false,
+        skip_kg: false,
+        corpus_open_failed: true,
+    });
+    assert_eq!(
+        stages.lexical.status,
+        StageStatus::Failed,
+        "corpus_open_failed must emit Failed, not InProgress (issue #1158)"
+    );
+    assert_eq!(
+        stages.lifecycle_status(),
+        "failed",
+        "lifecycle_status must be 'failed' when corpus is unreadable"
+    );
+    assert!(
+        stages.search_capabilities().is_empty(),
+        "a Failed lexical stage must advertise no search capabilities"
+    );
+    // The failure reason must contain an actionable hint.
+    assert!(
+        stages
+            .lexical
+            .failure
+            .as_deref()
+            .unwrap_or("")
+            .contains("trusty-search index"),
+        "failure reason must contain the reindex hint (issue #1158)"
+    );
+}
+
+/// Issue #1158 integration test: a corpus file that cannot be opened (a
+/// directory where redb expects a plain file) must cause
+/// `build_indexer_from_entry` to set `corpus_open_failed = true` on the
+/// returned `CodeIndexer`, which the stage-classifier then maps to
+/// `StageStatus::Failed` — NOT the misleading `InProgress`.
+///
+/// Why: this exercises the full load path from `persistence_loader` →
+/// `corpus_open_failed` flag → `derive_warm_boot_stages` in one shot.
+/// A directory at the `index.redb` path is the most portable way to
+/// force `Database::create()` to fail with an I/O error on every OS
+/// (not just Unix-style permission modes), without needing ONNX or a real
+/// incompatible-format file.
+/// What: places a DIRECTORY at the colocated `index.redb` path, builds an
+/// indexer via `build_indexer_from_entry`, asserts `corpus_open_failed`,
+/// then derives stages and asserts `Failed`.
+/// Test: this test; runs without ONNX / embedder.
+#[tokio::test]
+async fn corpus_open_failure_propagates_to_failed_stage() {
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use trusty_common::embedder::MockEmbedder;
+    use trusty_search::core::Embedder;
+    use trusty_search::service::persistence::PersistedIndex;
+    use trusty_search::service::persistence_loader::build_indexer_from_entry;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    // Create a DIRECTORY at the path where `index.redb` should be.
+    // `redb::Database::create()` will fail with an I/O error when it
+    // tries to open a directory as a file — this is the simplest portable
+    // way to force `CorpusStore::open` to return `Err` and trigger the
+    // `corpus_open_failed = true` path in `persistence_loader`.
+    let colocated_dir = root.join(".trusty-search");
+    std::fs::create_dir_all(&colocated_dir).unwrap();
+    let redb_path = colocated_dir.join("index.redb");
+    std::fs::create_dir_all(&redb_path).unwrap(); // directory, not file
+
+    let entry = PersistedIndex {
+        id: "test-1158".to_string(),
+        root_path: root.clone(),
+        colocated: true,
+        ..Default::default()
+    };
+    let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(8));
+
+    // Phase 1: assert `corpus_open_failed` is set on the indexer.
+    // Before #1158 this would be `false` — the error was swallowed and
+    // `chunk_count` silently fell through to 0.
+    let indexer = build_indexer_from_entry(&entry, &embedder).await.unwrap();
+    assert!(
+        indexer.corpus_open_failed,
+        "a directory at the redb path must set corpus_open_failed=true \
+         (issue #1158 — was silently masked as chunk_count=0)"
+    );
+    assert!(
+        !indexer.has_corpus_store(),
+        "corpus store must not be wired when open failed"
+    );
+
+    // Phase 2: stages derived from this indexer must be Failed, not InProgress.
+    let chunk_count = indexer
+        .corpus_store()
+        .and_then(|c| c.chunk_count().ok())
+        .unwrap_or(0);
+    let stages = derive_warm_boot_stages(WarmBootInputs {
+        chunk_count,
+        hnsw_snapshot_ready: false,
+        graph_node_count: 0,
+        lexical_only: false,
+        skip_kg: false,
+        corpus_open_failed: indexer.corpus_open_failed,
+    });
+    assert_eq!(
+        stages.lexical.status,
+        StageStatus::Failed,
+        "unreadable corpus must surface as Failed stage (issue #1158)"
+    );
+    assert_eq!(
+        stages.lifecycle_status(),
+        "failed",
+        "lifecycle_status must be 'failed' for unreadable corpus"
+    );
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `build_indexer_from_entry` logged an ERROR when `CorpusStore::open` failed (incompatible redb page format, corruption, or I/O error) but continued execution without a corpus store. `chunk_count` fell to `unwrap_or(0)` and `derive_warm_boot_stages` emitted `InProgress` — identical to a freshly-created empty index. The failure was invisible to callers and the status/health endpoints showed `chunks=0 lifecycle=walking` instead of a failure.
- **Fix**: add `corpus_open_failed: bool` to `CodeIndexer` and `WarmBootInputs`; set it in `persistence_loader` on open failure; `derive_warm_boot_stages` checks it first and emits `StageStatus::Failed` with an actionable `trusty-search index <path> --force` hint.
- **Scope**: `trusty-search` only (`persistence_loader`, `indexer/mod`, `warm_boot/stages`, `start_restore`, `lazy_restore`, `commands/start`).

## Changes

- `CodeIndexer`: new `corpus_open_failed: bool` field (default `false`)
- `persistence_loader::build_indexer_from_entry`: set `corpus_open_failed = true` on `CorpusStore::open` error (was: swallow silently)
- `WarmBootInputs`: new `corpus_open_failed: bool` field
- `derive_warm_boot_stages`: `corpus_open_failed` check is the first branch → `StageStatus::Failed` with reindex hint
- `start_restore.rs`, `lazy_restore.rs`: read `indexer.corpus_open_failed` and pass it to `WarmBootInputs`; included in warm-boot log
- All existing `WarmBootInputs` literals updated with `corpus_open_failed: false`
- New `tests/warm_boot_corpus_open_failure.rs`: two regression tests — pure classifier unit test + end-to-end integration test (directory at `index.redb` path forces I/O failure)

## Test plan

- [ ] `cargo test -p trusty-search` — 1121 tests, 0 failures
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] `bash scripts/check_line_cap.sh` — 74 allowlisted, 0 violations
- [ ] New test `corpus_open_failed_flag_emits_failed_stage` — passes
- [ ] New test `corpus_open_failure_propagates_to_failed_stage` — passes (directory at `index.redb` forces corpus open failure; asserts `corpus_open_failed=true` and `StageStatus::Failed`)

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)