### PR TITLE
feat(trusty-mpm): durable session lifecycle (stop/resume/decommission) + optional OpenRouter monitor

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -478,12 +478,45 @@ pub(crate) enum SessionAction {
         /// Managed session id.
         id: String,
     },
-    /// Stop and deregister a managed session.
+    /// Stop and deregister a managed session (legacy alias for ManagedRuntimeStop).
     ///
-    /// Why: terminate a managed session when its work is done.
-    /// What: DELETEs `/api/v1/sessions/managed/{id}`.
+    /// Why: retained for backward compatibility; new scripts should use
+    /// `ManagedRuntimeStop` or `Decommission`.
+    /// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop`.
     /// Test: `cli_parses_session_managed_stop`.
     ManagedStop {
+        /// Managed session id.
+        id: String,
+    },
+    /// Stop the runtime of a managed session, keeping the workspace intact.
+    ///
+    /// Why: a session ENDURES beyond its running runtime; RuntimeStop kills
+    /// the tmux session and claude process but preserves the workspace directory
+    /// so the session can be resumed later.
+    /// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop`.
+    /// Test: `cli_parses_session_runtime_stop`.
+    RuntimeStop {
+        /// Managed session id.
+        id: String,
+    },
+    /// Resume a stopped managed session in its existing workspace (no re-clone).
+    ///
+    /// Why: after `runtime-stop`, the workspace is still on disk; `managed-resume`
+    /// re-spawns the runtime in the SAME workspace without cloning again.
+    /// What: POSTs `/api/v1/sessions/managed/{id}/resume`.
+    /// Test: `cli_parses_session_managed_resume`.
+    ManagedResume {
+        /// Managed session id.
+        id: String,
+    },
+    /// Decommission a managed session: stop runtime + remove workspace from disk.
+    ///
+    /// Why: the ONLY operation that removes the workspace directory. Unlike
+    /// `runtime-stop`, decommission is terminal — no further resume is possible.
+    /// A tombstone record is kept for `ls` history.
+    /// What: POSTs `/api/v1/sessions/managed/{id}/decommission`.
+    /// Test: `cli_parses_session_decommission`.
+    Decommission {
         /// Managed session id.
         id: String,
     },

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -109,13 +109,14 @@ pub(crate) async fn session_ls(
     Ok(())
 }
 
-/// `tm session activity <id>` — classify a managed session's activity state.
+/// `tm session activity <id>` — inspect a managed session's activity state.
 ///
-/// Why: inspect what a session is doing without attaching; the LLM verdict
-/// tells the calling agentic process whether to intervene.
-/// What: GETs `/api/v1/sessions/managed/{id}/activity` and prints the verdict
-/// fields (state, summary, confidence, cache_hit, token costs) plus any pending
-/// decision.
+/// Why: inspect what a session is doing without attaching; the raw pane is
+/// always returned for the calling agentic process to reason over. The LLM
+/// classification is shown when available (OpenRouter key set); when absent,
+/// `classification: null` and the raw pane are still returned with no error.
+/// What: GETs `/api/v1/sessions/managed/{id}/activity` and prints the raw pane,
+/// structured state, classification (or "no classifier"), and pending decision.
 /// Test: HTTP path covered by the integration test.
 pub(crate) async fn session_activity(
     client: &reqwest::Client,
@@ -124,6 +125,8 @@ pub(crate) async fn session_activity(
 ) -> anyhow::Result<()> {
     #[derive(Deserialize)]
     struct ActivityResp {
+        raw_pane: String,
+        runtime_active: bool,
         state: String,
         summary: String,
         confidence: f32,
@@ -133,6 +136,8 @@ pub(crate) async fn session_activity(
         latency_ms: u64,
         total_input_tokens: u64,
         total_output_tokens: u64,
+        #[serde(default)]
+        classification: Option<String>,
         #[serde(default)]
         pending_decision: Option<String>,
         #[serde(default)]
@@ -147,8 +152,19 @@ pub(crate) async fn session_activity(
         return Ok(());
     }
     let a: ActivityResp = resp.error_for_status()?.json().await?;
+    let runtime_str = if a.runtime_active {
+        "running"
+    } else {
+        "stopped"
+    };
+    println!("runtime:    {runtime_str}");
     println!("state:      {} (confidence: {:.2})", a.state, a.confidence);
     println!("summary:    {}", a.summary);
+    let classification_str = a
+        .classification
+        .as_deref()
+        .unwrap_or("(no classifier — raw pane available for agentic inference)");
+    println!("classification: {classification_str}");
     let cache = if a.cache_hit { "hit" } else { "miss" };
     println!(
         "cache:      {} | tokens: in={} out={} | latency: {}ms",
@@ -163,6 +179,10 @@ pub(crate) async fn session_activity(
         if let Some(default) = &a.proposed_default {
             println!("  proposed default: {default}");
         }
+    }
+    if !a.raw_pane.is_empty() {
+        println!("--- raw pane (last 60 lines) ---");
+        println!("{}", a.raw_pane);
     }
     Ok(())
 }
@@ -232,18 +252,33 @@ pub(crate) async fn session_attach(
     Ok(())
 }
 
-/// `tm session managed-stop <id>` — stop and deregister a managed session.
+/// `tm session managed-stop <id>` — stop runtime only (keep workspace, legacy alias).
 ///
-/// Why: terminate a managed session when its work is done.
-/// What: DELETEs `/api/v1/sessions/managed/{id}`.
+/// Why: backward-compatible alias for `session_runtime_stop`; existing scripts
+/// that call `managed-stop` get the new non-destructive behavior.
+/// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop`.
 /// Test: HTTP path covered by the integration test.
 pub(crate) async fn session_managed_stop(
     client: &reqwest::Client,
     url: &str,
     id: String,
 ) -> anyhow::Result<()> {
+    session_runtime_stop(client, url, id).await
+}
+
+/// `tm session runtime-stop <id>` — stop the runtime, keep the workspace.
+///
+/// Why: a session ENDURES beyond its runtime; `runtime-stop` kills only the
+/// tmux session and claude process, preserving the workspace for later `resume`.
+/// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop`.
+/// Test: HTTP path covered by the integration test.
+pub(crate) async fn session_runtime_stop(
+    client: &reqwest::Client,
+    url: &str,
+    id: String,
+) -> anyhow::Result<()> {
     let resp = client
-        .delete(format!("{url}/api/v1/sessions/managed/{id}"))
+        .post(format!("{url}/api/v1/sessions/managed/{id}/runtime-stop"))
         .send()
         .await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
@@ -251,7 +286,67 @@ pub(crate) async fn session_managed_stop(
         return Ok(());
     }
     resp.error_for_status()?;
-    println!("stopped {id}");
+    println!("runtime stopped {id} (workspace intact; use 'resume' to restart)");
+    Ok(())
+}
+
+/// `tm session managed-resume <id>` — resume a stopped session in its existing workspace.
+///
+/// Why: after `runtime-stop`, the workspace is still on disk; `managed-resume`
+/// re-spawns the runtime there without re-cloning.
+/// What: POSTs `/api/v1/sessions/managed/{id}/resume`.
+/// Test: HTTP path covered by the integration test.
+pub(crate) async fn session_managed_resume(
+    client: &reqwest::Client,
+    url: &str,
+    id: String,
+) -> anyhow::Result<()> {
+    let resp = client
+        .post(format!("{url}/api/v1/sessions/managed/{id}/resume"))
+        .send()
+        .await?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        println!("not found");
+        return Ok(());
+    }
+    if resp.status() == reqwest::StatusCode::CONFLICT {
+        let msg = resp.text().await.unwrap_or_default();
+        println!("cannot resume: {msg}");
+        return Ok(());
+    }
+    #[derive(Deserialize)]
+    struct ResumeResp {
+        id: String,
+        name: String,
+        state: String,
+    }
+    let body: ResumeResp = resp.error_for_status()?.json().await?;
+    println!("resumed {} ({}) [{}]", body.name, body.id, body.state);
+    Ok(())
+}
+
+/// `tm session decommission <id>` — full teardown (remove workspace from disk).
+///
+/// Why: the ONLY operation that permanently removes the workspace directory.
+/// Unlike `runtime-stop`, decommission is terminal — no resume is possible.
+/// A tombstone record is kept so `ls` shows history.
+/// What: POSTs `/api/v1/sessions/managed/{id}/decommission`.
+/// Test: HTTP path covered by the integration test.
+pub(crate) async fn session_decommission(
+    client: &reqwest::Client,
+    url: &str,
+    id: String,
+) -> anyhow::Result<()> {
+    let resp = client
+        .post(format!("{url}/api/v1/sessions/managed/{id}/decommission"))
+        .send()
+        .await?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        println!("not found");
+        return Ok(());
+    }
+    resp.error_for_status()?;
+    println!("decommissioned {id} (workspace removed; tombstone record kept)");
     Ok(())
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -369,6 +369,15 @@ pub(crate) async fn session(
         SessionAction::ManagedStop { id } => {
             crate::commands::managed::session_managed_stop(client, url, id).await?
         }
+        SessionAction::RuntimeStop { id } => {
+            crate::commands::managed::session_runtime_stop(client, url, id).await?
+        }
+        SessionAction::ManagedResume { id } => {
+            crate::commands::managed::session_managed_resume(client, url, id).await?
+        }
+        SessionAction::Decommission { id } => {
+            crate::commands::managed::session_decommission(client, url, id).await?
+        }
     }
     Ok(())
 }

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -57,13 +57,15 @@ pub use coordinator_routes::*;
 
 /// The managed session-manager routes (`/api/v1/sessions/managed/*`).
 ///
-/// Why: the managed-session API is a new cohesive cluster (spawn, list, get,
-/// send, answer, attach-cmd, stop). The handlers live in
-/// [`crate::daemon::managed_routes`]; importing them here lets `router` refer to
-/// them unqualified, mirroring the `coordinator_routes` wiring.
+/// Why: the managed-session API is a cohesive cluster (spawn, list, get,
+/// send, answer, attach-cmd, stop/runtime-stop/resume/decommission, activity).
+/// The handlers live in [`crate::daemon::managed_routes`]; importing them here
+/// lets `router` refer to them unqualified, mirroring the `coordinator_routes`
+/// wiring.
 use super::managed_routes::{
-    answer_session_decision, get_attach_cmd, get_managed_session, get_session_activity,
-    list_managed_sessions, send_to_session, spawn_session, stop_managed_session,
+    answer_session_decision, decommission_managed_session, get_attach_cmd, get_managed_session,
+    get_session_activity, list_managed_sessions, resume_managed_session, send_to_session,
+    spawn_session, stop_managed_session, stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.
@@ -152,6 +154,18 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route(
             "/api/v1/sessions/managed/{id}/activity",
             get(get_session_activity),
+        )
+        .route(
+            "/api/v1/sessions/managed/{id}/runtime-stop",
+            post(stop_managed_session_runtime),
+        )
+        .route(
+            "/api/v1/sessions/managed/{id}/resume",
+            post(resume_managed_session),
+        )
+        .route(
+            "/api/v1/sessions/managed/{id}/decommission",
+            post(decommission_managed_session),
         )
         .merge(
             SwaggerUi::new("/api-docs")

--- a/crates/trusty-mpm/src/daemon/managed_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes.rs
@@ -22,7 +22,6 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use crate::activity::monitor::ActivityCheckResult;
 use crate::daemon::state::DaemonState;
 use crate::provisioner::WorkspaceProvisioner;
 use crate::runtime::{ClaudeCodeAdapter, RuntimeAdapter};
@@ -180,26 +179,36 @@ pub struct AttachCmdResponse {
 
 /// Response body for GET /api/v1/sessions/managed/{id}/activity.
 ///
-/// Why: the calling agentic process needs the full activity picture —
-/// the LLM verdict, cost metrics, cache status, and cumulative tally — in
-/// one response so it can decide whether to intervene or let the session run.
-/// What: the activity state string, a human-readable summary, a confidence
-/// score, whether the check hit the content-hash cache, token counts for this
-/// check, cumulative token tally, and any pending decision fields.
-/// Test: activity route handler test.
+/// Why: the calling agentic process needs the full activity picture without
+/// requiring an LLM key — raw pane content and structured lifecycle fields are
+/// always available; the LLM classification is an optional overlay when
+/// OpenRouter is configured. This lets the calling agentic process do its own
+/// inference over the raw pane content.
+/// What: always-present fields: `raw_pane` (last 60 lines), `runtime_active`
+/// (tmux session alive or not), `pending_decision`, `proposed_default`. LLM
+/// fields (`state`, `summary`, `confidence`, `classification`) are populated
+/// when the classifier ran successfully; `classification` is `null` when the
+/// key is absent or the classifier was not invoked.
+/// Test: activity route handler test; `activity_no_key_returns_raw_pane` test.
 #[derive(Debug, Serialize)]
 pub struct ActivityResponse {
-    /// Activity state: working, idle, blocked_on_permission, errored, done, unknown.
+    /// Raw pane content (last 60 lines). Always present so the calling agentic
+    /// process can reason over the raw terminal output directly.
+    pub raw_pane: String,
+    /// Whether the tmux runtime session is currently alive.
+    pub runtime_active: bool,
+    /// Activity state from LLM classification: working, idle, blocked_on_permission,
+    /// errored, done, unknown. Populated from classifier verdict or "unknown".
     pub state: String,
-    /// Human-readable summary of what the session is doing.
+    /// Human-readable summary of what the session is doing (from LLM or fallback).
     pub summary: String,
-    /// Confidence of the classification (0.0–1.0).
+    /// Confidence of the classification (0.0–1.0). 0.0 when no classifier ran.
     pub confidence: f32,
     /// True when the verdict was served from the content-hash cache.
     pub cache_hit: bool,
-    /// Input token count for this check (0 on cache hit).
+    /// Input token count for this check (0 on cache hit or no classifier).
     pub input_tokens: u32,
-    /// Output token count for this check (0 on cache hit).
+    /// Output token count for this check (0 on cache hit or no classifier).
     pub output_tokens: u32,
     /// Latency in milliseconds for this check.
     pub latency_ms: u64,
@@ -207,6 +216,9 @@ pub struct ActivityResponse {
     pub total_input_tokens: u64,
     /// Cumulative output tokens across all checks for this session.
     pub total_output_tokens: u64,
+    /// LLM classification result. `null` when no OpenRouter key or classifier
+    /// not configured; string state name when classifier ran.
+    pub classification: Option<String>,
     /// A pending decision question, if surfaced by a previous activity check.
     pub pending_decision: Option<String>,
     /// Proposed default answer to the pending decision.
@@ -293,13 +305,6 @@ pub async fn spawn_session(
     Json(req): Json<SpawnRequest>,
 ) -> impl IntoResponse {
     // ── Step 1: pre-generate session id + provision isolated workspace ────────
-    // The id must be known before provisioning because the provisioner embeds it
-    // in the workspace path (<root>/<project>/<id>/). Provisioning before tmux
-    // session creation is the invariant that ensures the pane opens in the
-    // workspace, not in $HOME.
-    //
-    // Allow tests (and operators) to override the workspace root via an env var
-    // so the provisioner does not write into the real ~/.trusty-mpm tree.
     let workspace_root = std::env::var("TRUSTY_MPM_WORKSPACE_ROOT")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| {
@@ -326,8 +331,6 @@ pub async fn spawn_session(
     };
 
     // ── Step 2: create tmux session rooted at the provisioned workspace ───────
-    // Pass `cwd = Some(workspace_path)` so `tmux new-session -c <workspace>` is
-    // issued. The pane will open IN the workspace directory, never in $HOME.
     let mgr = state.session_manager().await;
     let record = match mgr
         .create_with_id(
@@ -349,8 +352,7 @@ pub async fn spawn_session(
     };
 
     // Transition to Active now that the workspace is ready and the tmux session
-    // has been created. This is best-effort: if it fails the state stays
-    // Starting and the caller can still inspect and attach.
+    // has been created.
     if let Err(e) = mgr
         .set_workspace(
             &record.id,
@@ -371,8 +373,6 @@ pub async fn spawn_session(
             name = %record.tmux_name,
             "spawn_session: ClaudeCodeAdapter::spawn failed: {e}"
         );
-        // Mark errored but still return a 201 so the caller can inspect the
-        // workspace and attach manually. The error is surfaced in the state field.
         let _ = mgr
             .mark_errored(&record.id, &format!("spawn failed: {e}"))
             .await;
@@ -385,7 +385,6 @@ pub async fn spawn_session(
         );
     }
 
-    // Re-fetch the record after all mutations so the response reflects the final state.
     let final_record = mgr.get(&record.id).await.unwrap_or(record);
     let attach = attach_cmd_for(&final_record.tmux_name);
     let resp = SpawnResponse {
@@ -524,13 +523,14 @@ pub async fn get_attach_cmd(
     }
 }
 
-/// DELETE /api/v1/sessions/managed/{id} — stop and deregister a session.
+/// POST /api/v1/sessions/managed/{id}/runtime-stop — stop the runtime only (keep workspace).
 ///
-/// Why: the calling agentic process or operator terminates a session when work
-/// is done; the record is marked Dead for post-mortem inspection.
-/// What: delegates to SessionManager::stop.
-/// Test: stop handler test.
-pub async fn stop_managed_session(
+/// Why: a session ENDURES beyond its running runtime; `runtime-stop` kills the
+/// tmux session and claude process but preserves the workspace directory and
+/// record so the session can be resumed later.
+/// What: delegates to SessionManager::stop; returns the updated record summary.
+/// Test: stop handler test; `manager_stop_keeps_workspace`.
+pub async fn stop_managed_session_runtime(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
@@ -545,17 +545,123 @@ pub async fn stop_managed_session(
     }
 }
 
-/// GET /api/v1/sessions/managed/{id}/activity — classify a session's activity.
+/// POST /api/v1/sessions/managed/{id}/resume — re-spawn the runtime in the existing workspace.
+///
+/// Why: after `stop`, the workspace is still on disk; `resume` brings back the
+/// runtime without re-cloning by creating a fresh tmux session with
+/// cwd = workspace_path and spawning claude inside it.
+/// What: delegates to SessionManager::resume, then calls ClaudeCodeAdapter::spawn
+/// on the fresh tmux session.
+/// Test: `manager_resume_respawns_in_existing_workspace`.
+pub async fn resume_managed_session(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(id_str): AxumPath<String>,
+) -> impl IntoResponse {
+    let id = match parse_id(&id_str) {
+        Ok(id) => id,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    let mgr = state.session_manager().await;
+
+    let record = match mgr.resume(&id).await {
+        Ok(r) => r,
+        Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
+            return (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response();
+        }
+        Err(crate::session_manager::ManagedError::InvalidState(_, msg)) => {
+            return (StatusCode::CONFLICT, msg).into_response();
+        }
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+
+    // Spawn claude in the fresh tmux session (no re-clone — workspace reused).
+    let workspace = record
+        .workspace_path
+        .clone()
+        .unwrap_or_else(|| record.cwd.clone());
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = ClaudeCodeAdapter::new(tmux_arc);
+    if let Err(e) = adapter.spawn(&record.tmux_name, &workspace, &record.task) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            "resume: ClaudeCodeAdapter::spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("resume spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            workspace = %workspace.display(),
+            "managed session resumed and claude respawned"
+        );
+    }
+
+    let final_record = mgr.get(&id).await.unwrap_or(record);
+    Json(record_to_summary(&final_record)).into_response()
+}
+
+/// POST /api/v1/sessions/managed/{id}/decommission — full teardown.
+///
+/// Why: the ONLY operation that removes the workspace from disk. Unlike `stop`,
+/// decommission is terminal — no further `resume` is possible.
+/// What: delegates to SessionManager::decommission (kills runtime, removes
+/// workspace dir, marks record Decommissioned). A tombstone record is kept.
+/// Test: `manager_decommission_removes_workspace`.
+pub async fn decommission_managed_session(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(id_str): AxumPath<String>,
+) -> impl IntoResponse {
+    let id = match parse_id(&id_str) {
+        Ok(id) => id,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    let mgr = state.session_manager().await;
+    match mgr.decommission(&id).await {
+        Ok(record) => Json(record_to_summary(&record)).into_response(),
+        Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
+            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// DELETE /api/v1/sessions/managed/{id} — stop and deregister (legacy alias).
+///
+/// Why: the original MVP wired DELETE to a "stop" that marked the record Dead.
+/// The new semantic is `POST /{id}/runtime-stop` (keep workspace) and
+/// `POST /{id}/decommission` (full teardown). This handler now delegates to
+/// `runtime-stop` (marks Stopped, keeps workspace) so existing scripts that use
+/// DELETE do not experience data loss.
+/// What: delegates to SessionManager::stop.
+/// Test: covered by `stop_managed_session_runtime` tests.
+pub async fn stop_managed_session(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(id_str): AxumPath<String>,
+) -> impl IntoResponse {
+    stop_managed_session_runtime(State(state), AxumPath(id_str)).await
+}
+
+/// GET /api/v1/sessions/managed/{id}/activity — inspect session activity.
 ///
 /// Why: the calling agentic process needs to know whether the session is
-/// working, idle, blocked, errored, or done, without attaching to the tmux
-/// pane. The content-hash cache eliminates redundant LLM calls when the pane
-/// content has not changed.
-/// What: captures the pane via the session's tmux driver, hashes the content,
-/// and calls `ActivityMonitor::check` with the OpenRouterClassifier. Returns
-/// the verdict (state, summary, confidence), cache_hit, per-check token counts,
-/// cumulative tally, and the session's pending_decision fields.
-/// Test: `handler_activity_cache_hit` in tests/session_manager_mvp.rs.
+/// working, idle, blocked, errored, or done WITHOUT requiring an LLM key.
+/// The raw pane content is ALWAYS returned so the calling agentic process can
+/// perform its own inference. The OpenRouter LLM classifier is invoked ONLY
+/// when configured (i.e. when OPENROUTER_API_KEY is set).
+/// What: captures the pane via the session's tmux driver (last 60 lines);
+/// determines `runtime_active` from tmux presence; calls `ActivityMonitor::check`
+/// — which already converts `MissingApiKey` to an Unknown verdict non-erroring —
+/// and returns the verdict alongside `raw_pane` and `classification` (null when
+/// no classifier ran or key absent).
+/// The hash-skip cache and cost instrumentation remain active for the
+/// optional-classifier path.
+/// Test: `activity_no_key_returns_raw_pane` in tests/session_manager_mvp.rs;
+/// `handler_activity_cache_hit`.
 pub async fn get_session_activity(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
@@ -572,18 +678,24 @@ pub async fn get_session_activity(
         }
     };
 
-    // Capture the last 60 pane lines.
+    // Capture the last 60 pane lines (may return empty string when tmux is gone).
     let pane_text = mgr
         .capture_pane(&id, 60)
         .await
         .unwrap_or_else(|_| String::new());
 
+    // Determine runtime_active from the driver directly.
+    let runtime_active = mgr.tmux_driver().session_exists(&record.tmux_name);
+
     // Run the activity check through the shared ActivityMonitor.
+    // ActivityMonitor::check already handles MissingApiKey non-erroring — it
+    // converts it to an Unknown verdict with 0 tokens. We never propagate
+    // ActivityError to the HTTP response; unknown is a valid result.
     let monitor = state.activity_monitor();
-    let result: ActivityCheckResult = match monitor.check(&id_str, &pane_text).await {
+    let result = match monitor.check(&id_str, &pane_text).await {
         Ok(r) => r,
         Err(e) => {
-            warn!(session = %id_str, "activity check failed: {e}");
+            warn!(session = %id_str, "activity check error (non-key): {e}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("activity check failed: {e}"),
@@ -592,7 +704,18 @@ pub async fn get_session_activity(
         }
     };
 
+    // Determine whether the LLM actually classified (vs. falling back to Unknown
+    // due to missing key). classification is null when no key / no LLM ran.
+    let api_key_present = std::env::var("OPENROUTER_API_KEY").is_ok();
+    let classification = if api_key_present {
+        Some(format!("{:?}", result.verdict.state).to_lowercase())
+    } else {
+        None
+    };
+
     Json(ActivityResponse {
+        raw_pane: pane_text,
+        runtime_active,
         state: format!("{:?}", result.verdict.state).to_lowercase(),
         summary: result.verdict.summary,
         confidence: result.verdict.confidence,
@@ -602,6 +725,7 @@ pub async fn get_session_activity(
         latency_ms: result.cost.latency_ms,
         total_input_tokens: result.tally.total_input_tokens,
         total_output_tokens: result.tally.total_output_tokens,
+        classification,
         pending_decision: record.pending_decision,
         proposed_default: record.proposed_default,
     })

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -363,8 +363,13 @@ impl DaemonState {
                             std::sync::Arc::new(crate::session_manager::real_tmux::NoopTmuxDriver)
                         }
                     };
-                match crate::session_manager::SessionManager::new(&data_dir, tmux.clone()).await {
-                    Ok(mgr) => std::sync::Arc::new(mgr),
+                let mgr = match crate::session_manager::SessionManager::new(
+                    &data_dir,
+                    tmux.clone(),
+                )
+                .await
+                {
+                    Ok(mgr) => mgr,
                     Err(e) => {
                         tracing::error!(
                             "failed to load managed session store at {}: {e}; using temp dir",
@@ -372,12 +377,36 @@ impl DaemonState {
                         );
                         let tmp = std::env::temp_dir().join("trusty-mpm-session-manager");
                         let _ = std::fs::create_dir_all(&tmp);
-                        let mgr = crate::session_manager::SessionManager::new(&tmp, tmux)
+                        crate::session_manager::SessionManager::new(&tmp, tmux)
                             .await
-                            .expect("temp-dir session store must load");
-                        std::sync::Arc::new(mgr)
+                            .expect("temp-dir session store must load")
+                    }
+                };
+                // Reconcile persisted session records against live tmux state:
+                // sessions whose tmux is gone are flipped to Stopped (resumable);
+                // live sessions are re-adopted as Active.
+                let auto_resume = std::env::var("TRUSTY_MPM_AUTO_RESUME")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                match mgr.reconcile_on_boot(auto_resume).await {
+                    Ok(report) => {
+                        let n_adopted = report.adopted.len();
+                        let n_stopped = report.stopped.len();
+                        let n_external = report.external_adopted.len();
+                        if n_adopted > 0 || n_stopped > 0 || n_external > 0 {
+                            tracing::info!(
+                                adopted = n_adopted,
+                                stopped = n_stopped,
+                                external = n_external,
+                                "session-manager reconcile complete"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("session-manager reconcile failed: {e}");
                     }
                 }
+                std::sync::Arc::new(mgr)
             })
             .await
             .clone()

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -363,11 +363,8 @@ impl DaemonState {
                             std::sync::Arc::new(crate::session_manager::real_tmux::NoopTmuxDriver)
                         }
                     };
-                let mgr = match crate::session_manager::SessionManager::new(
-                    &data_dir,
-                    tmux.clone(),
-                )
-                .await
+                let mgr = match crate::session_manager::SessionManager::new(&data_dir, tmux.clone())
+                    .await
                 {
                     Ok(mgr) => mgr,
                     Err(e) => {

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -5,12 +5,12 @@
 //! logic here keeps the HTTP handlers thin and makes the manager unit-testable
 //! through the [`ManagedTmuxDriver`] trait seam.
 //! What: [`SessionManager`] wraps a [`SessionStore`] and a [`ManagedTmuxDriver`]
-//! and provides `create`, `list`, `get`, `send_input`, `stop`, and
-//! `reconcile_on_boot`. [`ReconcileReport`] describes what the reconciliation
-//! pass found. [`ManagedError`] is the module's error type.
-//! Test: `manager_create_record`, `manager_stop_marks_dead`,
-//! `manager_reconcile_adopts_and_orphans`, `env_scrub_command` in this file;
-//! see also `activity` and `runtime` module tests for the trait seam.
+//! and provides `create`, `list`, `get`, `send_input`, `stop`, `resume`,
+//! `decommission`, and `reconcile_on_boot`. [`ReconcileReport`] describes
+//! what the reconciliation pass found. [`ManagedError`] is the module's error type.
+//! Test: `manager_create_record`, `manager_stop_keeps_workspace`,
+//! `manager_resume_respawns`, `manager_decommission_removes_workspace`,
+//! `manager_reconcile_gone_tmux_yields_stopped` in tests.rs.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,7 +30,7 @@ use super::store::{SessionStore, StoreError};
 /// Why: HTTP handlers dispatch on error variants to choose status codes;
 /// a typed enum keeps that mapping clean and avoids stringly-typed matching.
 /// What: one variant per failure mode: tmux problems, missing sessions,
-/// store I/O, and miscellaneous I/O errors.
+/// store I/O, miscellaneous I/O errors, and invalid state transitions.
 /// Test: `ManagedError` variants are exercised by the manager unit tests.
 #[derive(Debug, Error)]
 pub enum ManagedError {
@@ -53,6 +53,10 @@ pub enum ManagedError {
     /// A name derived from the cwd hint collided with an existing session.
     #[error("name already in use: {0} — use `tm session ls` to find it")]
     NameCollision(String),
+
+    /// The operation is not valid for the current session state.
+    #[error("invalid state transition for session {0}: {1}")]
+    InvalidState(String, String),
 }
 
 /// Trait seam over tmux operations used by the session manager.
@@ -90,16 +94,16 @@ pub trait ManagedTmuxDriver: Send + Sync {
 /// Summary of what a reconciliation pass found and changed.
 ///
 /// Why: operators and the daemon start-up log need to know how many sessions
-/// were re-adopted and how many were declared orphaned after a restart.
-/// What: counts of adopted (live) and orphaned (dead) sessions, plus the
+/// were re-adopted and how many were marked stopped after a restart.
+/// What: counts of re-adopted (live) and stopped (gone) sessions, plus the
 /// tmux names of sessions that were unknown to the store before reconciliation.
-/// Test: `manager_reconcile_adopts_and_orphans`.
+/// Test: `manager_reconcile_gone_tmux_yields_stopped` in tests.rs.
 #[derive(Debug, Default)]
 pub struct ReconcileReport {
     /// tmux session names that were live and re-adopted into the store.
     pub adopted: Vec<String>,
-    /// Session ids that were in the store but had no live tmux session.
-    pub orphaned: Vec<String>,
+    /// Session ids whose tmux session was gone; marked Stopped (resumable).
+    pub stopped: Vec<String>,
     /// tmux sessions with the `tmpm-` prefix that the store did not know about.
     pub external_adopted: Vec<String>,
 }
@@ -112,8 +116,8 @@ pub struct ReconcileReport {
 /// What: wraps a [`SessionStore`] behind an async `RwLock` and a
 /// [`ManagedTmuxDriver`] behind an `Arc`; all public methods are `async`
 /// so the HTTP handlers can await them directly.
-/// Test: `manager_create_record`, `manager_stop_marks_dead`,
-/// `manager_reconcile_adopts_and_orphans`.
+/// Test: `manager_create_record`, `manager_stop_keeps_workspace`,
+/// `manager_resume_respawns`, `manager_decommission_removes_workspace`.
 pub struct SessionManager {
     /// Persisted session store; `pub(crate)` for test helpers that need to
     /// seed internal state without going through the public API.
@@ -159,7 +163,7 @@ impl SessionManager {
     /// flow in one operation so the HTTP handler stays thin.
     /// What: derives the tmux name from `name_hint` (→ `name_from_dir`) or from
     /// the generated UUID (→ `name_from_uuid`), creates the tmux session via the
-    /// driver, persists a [`SessionRecord`] in state `Starting`, and returns it.
+    /// driver, persists a [`SessionRecord`] in state `Provisioning`, and returns it.
     /// Test: `manager_create_record`.
     pub async fn create(
         &self,
@@ -192,7 +196,7 @@ impl SessionManager {
     /// Some(workspace_path)` so `tmux new-session -c <workspace>` is issued.
     /// What: identical to [`create`] except the id is supplied by the caller.
     /// Creates the tmux session at `cwd` via the driver, persists a
-    /// [`SessionRecord`] in state `Starting`, and returns it.
+    /// [`SessionRecord`] in state `Provisioning`, and returns it.
     /// Test: `spawn_session_tmux_cwd_is_workspace` in session_manager/tests.rs;
     /// `handler_spawn_creates_tmux_at_workspace_cwd` in session_manager_mvp.rs.
     #[allow(clippy::too_many_arguments)]
@@ -231,7 +235,7 @@ impl SessionManager {
             tmux_name: tmux_name.clone(),
             cwd,
             task,
-            state: ManagedSessionState::Starting,
+            state: ManagedSessionState::Provisioning,
             created_at: Utc::now(),
             last_activity_at: None,
             workspace_path,
@@ -295,14 +299,14 @@ impl SessionManager {
     ///
     /// Why: `POST /api/v1/sessions/managed/{id}/send` lets the operator or
     /// automation feed text into a running session without attaching.
-    /// What: looks up the record, verifies it is not Dead/Orphaned, calls
-    /// `tmux.send_line(tmux_name, text)`, and updates `last_activity_at`.
+    /// What: looks up the record, verifies it is not Stopped/Decommissioned,
+    /// calls `tmux.send_line(tmux_name, text)`, and updates `last_activity_at`.
     /// Test: `manager_send_input`.
     pub async fn send_input(&self, id: &ManagedSessionId, text: &str) -> Result<(), ManagedError> {
         let mut record = self.get(id).await?;
         if matches!(
             record.state,
-            ManagedSessionState::Dead | ManagedSessionState::Orphaned
+            ManagedSessionState::Stopped | ManagedSessionState::Decommissioned
         ) {
             return Err(ManagedError::TmuxUnavailable(format!(
                 "session {} is {}; cannot inject input",
@@ -318,35 +322,144 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Stop a managed session: kill the tmux session and mark the record Dead.
+    /// Stop the runtime of a managed session, keeping the workspace intact.
     ///
-    /// Why: `DELETE /api/v1/sessions/managed/{id}` must both terminate the tmux
-    /// process and persist the terminal state so `ls` shows it correctly.
+    /// Why: a session ENDURES beyond its running runtime. `stop` terminates the
+    /// tmux session and the `claude` process inside it, but PRESERVES the
+    /// workspace directory on disk and the session record so the session can
+    /// be resumed later via `resume`.
     /// What: kills the tmux session (best-effort; logs a warning on failure
-    /// since the session may already be gone), marks the record `Dead`, and
-    /// persists.
-    /// Test: `manager_stop_marks_dead`.
+    /// since the session may already be gone), marks the record `Stopped`
+    /// (workspace path untouched), and persists.
+    /// Test: `manager_stop_keeps_workspace` — asserts state is `Stopped` and
+    /// workspace dir still exists on disk.
     pub async fn stop(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
         if let Err(e) = self.tmux.kill_session(&record.tmux_name) {
             warn!(name = %record.tmux_name, "kill_session failed (may already be gone): {e}");
         }
-        record.state = ManagedSessionState::Dead;
+        record.state = ManagedSessionState::Stopped;
         self.store.write().await.upsert(record.clone()).await?;
-        info!(id = %id, name = %record.tmux_name, "managed session stopped");
+        info!(id = %id, name = %record.tmux_name, "managed session stopped (workspace intact)");
+        Ok(record)
+    }
+
+    /// Resume a stopped session by re-spawning the runtime in its existing workspace.
+    ///
+    /// Why: a session ENDURES until decommissioned; after `stop` the workspace
+    /// directory is still on disk and `resume` brings the runtime back without
+    /// re-cloning. A new tmux session is created with `cwd = workspace_path` and
+    /// the caller is responsible for spawning claude inside it (via
+    /// `ClaudeCodeAdapter::spawn`) so the runtime restarts cleanly.
+    /// What: validates the session is `Stopped` or `Errored`, creates a fresh
+    /// tmux session with `cwd = workspace_path` (falls back to `cwd` when
+    /// `workspace_path` is absent), marks the record `Active`, and persists.
+    /// Returns the updated record; the HTTP handler then calls
+    /// `ClaudeCodeAdapter::spawn` on the new tmux session.
+    /// Test: `manager_resume_respawns` — asserts a new `create_session` call is
+    /// issued with cwd = existing workspace_path, no re-clone occurs.
+    pub async fn resume(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
+        let mut record = self.get(id).await?;
+        match record.state {
+            ManagedSessionState::Stopped | ManagedSessionState::Errored => {}
+            ref s => {
+                return Err(ManagedError::InvalidState(
+                    id.to_string(),
+                    format!(
+                        "cannot resume a session in state '{s}'; only Stopped or Errored sessions can be resumed"
+                    ),
+                ));
+            }
+        }
+
+        // Use workspace_path as cwd if set, otherwise fall back to cwd.
+        let workdir = record
+            .workspace_path
+            .as_ref()
+            .unwrap_or(&record.cwd)
+            .to_string_lossy()
+            .to_string();
+
+        // Kill the old tmux session if still somehow alive (best-effort).
+        if self.tmux.session_exists(&record.tmux_name)
+            && let Err(e) = self.tmux.kill_session(&record.tmux_name)
+        {
+            warn!(name = %record.tmux_name, "resume: kill stale session failed: {e}");
+        }
+
+        // Create a fresh tmux session rooted at the EXISTING workspace.
+        // No re-clone — workspace_path is reused as-is.
+        self.tmux
+            .create_session(&record.tmux_name, &workdir)
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
+
+        record.state = ManagedSessionState::Active;
+        record.last_activity_at = Some(Utc::now());
+        self.store.write().await.upsert(record.clone()).await?;
+        info!(id = %id, name = %record.tmux_name, workdir = %workdir, "managed session resumed");
+        Ok(record)
+    }
+
+    /// Decommission a session: stop the runtime, remove the workspace from disk,
+    /// and mark the record `Decommissioned`.
+    ///
+    /// Why: the only full teardown operation. Unlike `stop`, this removes the
+    /// workspace directory from disk so no future `resume` is possible. A
+    /// tombstone record is kept in the store so `ls` can show history.
+    /// What: kills the tmux session (best-effort), removes the workspace directory
+    /// via `std::fs::remove_dir_all` when `workspace_path` is set, clears
+    /// `workspace_path` on the record, marks it `Decommissioned`, and persists.
+    /// Test: `manager_decommission_removes_workspace` — asserts the workspace dir
+    /// is gone from disk and the record state is `Decommissioned`.
+    pub async fn decommission(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
+        let mut record = self.get(id).await?;
+
+        // Kill the runtime (best-effort).
+        if self.tmux.session_exists(&record.tmux_name)
+            && let Err(e) = self.tmux.kill_session(&record.tmux_name)
+        {
+            warn!(name = %record.tmux_name, "decommission: kill_session failed: {e}");
+        }
+
+        // Remove the workspace directory from disk.
+        if let Some(ref ws) = record.workspace_path {
+            if ws.exists() {
+                std::fs::remove_dir_all(ws).map_err(|e| {
+                    ManagedError::Io(std::io::Error::new(
+                        e.kind(),
+                        format!("remove workspace {:?}: {e}", ws),
+                    ))
+                })?;
+                info!(id = %id, workspace = %ws.display(), "decommission: workspace removed from disk");
+            } else {
+                warn!(id = %id, workspace = %ws.display(), "decommission: workspace path absent (already removed?)");
+            }
+        }
+
+        // Tombstone: clear workspace_path, mark Decommissioned, persist.
+        record.workspace_path = None;
+        record.state = ManagedSessionState::Decommissioned;
+        self.store.write().await.upsert(record.clone()).await?;
+        info!(id = %id, name = %record.tmux_name, "managed session decommissioned");
         Ok(record)
     }
 
     /// Reconcile daemon state against live tmux sessions after a restart.
     ///
     /// Why: the daemon may have crashed or been restarted while sessions were
-    /// running; reconciliation re-adopts live sessions and marks vanished ones
-    /// as Orphaned so operators can see what happened.
+    /// running. A persisted record whose tmux session is GONE (e.g. after reboot)
+    /// must become `Stopped` (resumable), NOT a "lost" or "orphaned" session —
+    /// a stopped runtime does NOT mean the session itself is lost.
     /// What: lists all tmux sessions, filters to `tmpm-` prefix, cross-references
-    /// against the store, marks live store records Active, dead ones Orphaned,
-    /// and adopts external `tmpm-` sessions not in the store.
-    /// Test: `manager_reconcile_adopts_and_orphans`.
-    pub async fn reconcile_on_boot(&self) -> Result<ReconcileReport, ManagedError> {
+    /// against the store: live → `Active`; gone → `Stopped` (unless already
+    /// `Decommissioned`). External `tmpm-` sessions unknown to the store are
+    /// adopted as `Active`.
+    /// When `auto_resume` is true, all `Stopped` sessions are immediately resumed.
+    /// Test: `manager_reconcile_gone_tmux_yields_stopped`.
+    pub async fn reconcile_on_boot(
+        &self,
+        auto_resume: bool,
+    ) -> Result<ReconcileReport, ManagedError> {
         let live_names: std::collections::HashSet<String> = self
             .tmux
             .list_sessions()
@@ -366,28 +479,28 @@ impl SessionManager {
         let known_names: std::collections::HashSet<String> =
             all_records.iter().map(|r| r.tmux_name.clone()).collect();
 
+        // Collect ids of sessions to auto-resume after the write guard is released.
+        let mut to_resume: Vec<ManagedSessionId> = Vec::new();
+
         // Reconcile store records against live sessions.
         for mut record in all_records {
+            // Decommissioned tombstones are never touched by reconciliation.
+            if matches!(record.state, ManagedSessionState::Decommissioned) {
+                continue;
+            }
+
             if live_names.contains(&record.tmux_name) {
-                // Session is alive — adopt it.
-                if !matches!(
-                    record.state,
-                    ManagedSessionState::Dead | ManagedSessionState::Orphaned
-                ) {
-                    record.state = ManagedSessionState::Active;
-                    report.adopted.push(record.tmux_name.clone());
-                    info!(name = %record.tmux_name, "reconcile: re-adopted live session");
-                } else {
-                    // Was dead/orphaned before but now exists — adopt it.
-                    record.state = ManagedSessionState::Adopted;
-                    report.adopted.push(record.tmux_name.clone());
-                }
+                // Session is alive — re-adopt as Active.
+                record.state = ManagedSessionState::Active;
+                report.adopted.push(record.tmux_name.clone());
+                info!(name = %record.tmux_name, "reconcile: re-adopted live session");
             } else {
-                // Session is gone — mark orphaned unless already dead.
-                if !matches!(record.state, ManagedSessionState::Dead) {
-                    record.state = ManagedSessionState::Orphaned;
-                    report.orphaned.push(record.id.to_string());
-                    warn!(name = %record.tmux_name, "reconcile: session gone, marked orphaned");
+                // Session is gone — mark Stopped (resumable), never Orphaned.
+                record.state = ManagedSessionState::Stopped;
+                report.stopped.push(record.id.to_string());
+                warn!(name = %record.tmux_name, "reconcile: tmux session gone, marked Stopped (workspace intact, resumable)");
+                if auto_resume {
+                    to_resume.push(record.id);
                 }
             }
             guard.upsert(record).await?;
@@ -401,7 +514,7 @@ impl SessionManager {
                     tmux_name: name.clone(),
                     cwd: PathBuf::from("/unknown"),
                     task: "externally created".into(),
-                    state: ManagedSessionState::Adopted,
+                    state: ManagedSessionState::Active,
                     created_at: Utc::now(),
                     last_activity_at: None,
                     workspace_path: None,
@@ -413,6 +526,21 @@ impl SessionManager {
                 guard.upsert(external).await?;
                 report.external_adopted.push(name.clone());
                 info!(name = %name, "reconcile: adopted external tmpm- session");
+            }
+        }
+
+        // Release write guard before auto-resume (which needs its own locks).
+        drop(guard);
+
+        if auto_resume && !to_resume.is_empty() {
+            info!(
+                "reconcile: auto_resume=true, resuming {} stopped sessions",
+                to_resume.len()
+            );
+            for sid in to_resume {
+                if let Err(e) = self.resume(&sid).await {
+                    warn!(id = %sid, "reconcile: auto_resume failed: {e}");
+                }
             }
         }
 
@@ -459,7 +587,7 @@ impl SessionManager {
     /// Mark a session as errored with a message.
     ///
     /// Why: when provisioning or spawning fails the session must not remain in
-    /// `Starting`; marking it errored surfaces the failure to `tm session ls`.
+    /// `Provisioning`; marking it errored surfaces the failure to `tm session ls`.
     /// What: transitions the record to `ManagedSessionState::Errored` and appends
     /// the error message to the task field for observability, then persists.
     /// Test: covered by handler_spawn_wires_provision_and_spawn error path.

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -69,44 +69,53 @@ impl From<Uuid> for ManagedSessionId {
 
 /// Lifecycle state of a managed session.
 ///
-/// Why: the session manager needs to track where each session is in its
-/// lifecycle so operators and reconciliation logic can make informed decisions
-/// about what actions are valid (e.g. you cannot send input to a Dead session).
-/// What: FSM states from initial creation through active use to termination and
-/// post-mortem states for orphaned / re-adopted sessions.
+/// Why: a session ENDURES from provisioning until explicit decommissioning —
+/// the running `claude` process is transient inside an enduring session.
+/// The state machine captures where in the lifecycle a session currently sits
+/// so operators and reconciliation logic can make informed decisions.
+///
+/// FSM: `Provisioning` → `Active` ⇄ `Stopped` / `Errored` → `Decommissioned`.
+///
+/// Key invariant: `Stopped` means the RUNTIME is not running but the workspace
+/// directory and record are INTACT and RESUMABLE. Only `Decommissioned` means
+/// the workspace has been removed from disk.
+///
+/// What: five variants covering the full lifecycle from first provisioning
+/// through active use, voluntary/involuntary runtime stop, resume, and final
+/// teardown. `Dead`/`Orphaned`/`Idle`/`Adopted` are intentionally absent —
+/// a stopped-or-gone runtime must never read as "session lost".
 /// Test: `state_display`, serde round-trips in `record_serde_round_trip`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ManagedSessionState {
-    /// The session has been created in the store but tmux setup is in progress.
-    Starting,
-    /// The tmux session exists and is actively running.
+    /// Workspace is being provisioned; tmux session and runtime not yet started.
+    Provisioning,
+    /// Workspace provisioned, tmux session created, runtime (claude) is running.
     Active,
-    /// The tmux session exists but has been quiet for a while.
-    Idle,
-    /// The tmux session has been killed or exited; terminal state.
-    Dead,
-    /// The session record exists in the store but no tmux session was found
-    /// during reconciliation — the daemon may have crashed.
-    Orphaned,
-    /// A tmux session with the right prefix was found during reconciliation
-    /// and adopted into the store.
-    Adopted,
-    /// The session failed to provision or spawn; the record is preserved for
-    /// post-mortem inspection but the session is not running.
+    /// Runtime is NOT running; workspace directory and record INTACT and RESUMABLE.
+    ///
+    /// Entered when: (a) the operator calls `stop`, (b) the runtime exits on its
+    /// own, or (c) the daemon restarts and finds no live tmux session for a
+    /// previously-active record (post-reboot reconciliation).
+    Stopped,
+    /// Provisioning or runtime spawn failed; record preserved for post-mortem.
+    ///
+    /// Resumable after the operator fixes the underlying issue and calls `resume`.
     Errored,
+    /// Terminal state: workspace removed from disk; only a tombstone record remains.
+    ///
+    /// Entered when the operator calls `decommission`. No resume is possible.
+    Decommissioned,
 }
 
 impl fmt::Display for ManagedSessionState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            Self::Starting => "starting",
+            Self::Provisioning => "provisioning",
             Self::Active => "active",
-            Self::Idle => "idle",
-            Self::Dead => "dead",
-            Self::Orphaned => "orphaned",
-            Self::Adopted => "adopted",
+            Self::Stopped => "stopped",
             Self::Errored => "errored",
+            Self::Decommissioned => "decommissioned",
         };
         write!(f, "{s}")
     }
@@ -116,10 +125,12 @@ impl fmt::Display for ManagedSessionState {
 ///
 /// Why: persistence enables crash recovery — the manager can reload all known
 /// sessions on startup and reconcile them against live tmux state rather than
-/// losing track of sessions between restarts.
+/// losing track of sessions between restarts. Records survive daemon restarts;
+/// decommissioned tombstones too, so `ls` can show history.
 /// What: captures every field needed to identify, describe, and operate on a
 /// session: its id, tmux name, working directory, human-readable task
-/// description, lifecycle state, and timestamps.
+/// description, lifecycle state, timestamps, workspace path, git coordinates,
+/// and any pending decision fields.
 /// Test: `record_serde_round_trip`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionRecord {
@@ -177,12 +188,17 @@ mod tests {
 
     #[test]
     fn state_display() {
-        assert_eq!(ManagedSessionState::Starting.to_string(), "starting");
+        assert_eq!(
+            ManagedSessionState::Provisioning.to_string(),
+            "provisioning"
+        );
         assert_eq!(ManagedSessionState::Active.to_string(), "active");
-        assert_eq!(ManagedSessionState::Idle.to_string(), "idle");
-        assert_eq!(ManagedSessionState::Dead.to_string(), "dead");
-        assert_eq!(ManagedSessionState::Orphaned.to_string(), "orphaned");
-        assert_eq!(ManagedSessionState::Adopted.to_string(), "adopted");
+        assert_eq!(ManagedSessionState::Stopped.to_string(), "stopped");
+        assert_eq!(ManagedSessionState::Errored.to_string(), "errored");
+        assert_eq!(
+            ManagedSessionState::Decommissioned.to_string(),
+            "decommissioned"
+        );
     }
 
     #[test]
@@ -206,5 +222,52 @@ mod tests {
         assert_eq!(back.id, record.id);
         assert_eq!(back.tmux_name, record.tmux_name);
         assert_eq!(back.state, record.state);
+    }
+
+    #[test]
+    fn stopped_state_survives_serde() {
+        // Why: reconciliation persists Stopped state; this guards the serde
+        // round-trip for the new variant.
+        let record = SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-test".into(),
+            cwd: PathBuf::from("/tmp"),
+            task: "task".into(),
+            state: ManagedSessionState::Stopped,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: Some(PathBuf::from("/tmp/ws")),
+            repo_url: Some("https://github.com/owner/repo".into()),
+            branch: Some("main".into()),
+            pending_decision: None,
+            proposed_default: None,
+        };
+        let json = serde_json::to_string(&record).expect("serialize");
+        let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.state, ManagedSessionState::Stopped);
+        assert_eq!(back.workspace_path, record.workspace_path);
+    }
+
+    #[test]
+    fn decommissioned_state_survives_serde() {
+        // Why: tombstone records for decommissioned sessions must survive restarts.
+        let record = SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-gone".into(),
+            cwd: PathBuf::from("/tmp"),
+            task: "task".into(),
+            state: ManagedSessionState::Decommissioned,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None, // removed from disk
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+        };
+        let json = serde_json::to_string(&record).expect("serialize");
+        let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.state, ManagedSessionState::Decommissioned);
+        assert!(back.workspace_path.is_none());
     }
 }

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -2,8 +2,10 @@
 //!
 //! Why: tests in a separate file keep manager.rs under the 500 SLOC production
 //! cap while the 1500 SLOC test cap gives the test suite room to grow.
-//! What: full lifecycle tests for create, stop, send_input, reconcile,
-//! answer_decision, and the env-scrub command convention.
+//! What: full lifecycle tests for create, stop (keep workspace), resume
+//! (re-spawn in existing workspace), decommission (remove workspace from disk),
+//! send_input, reconcile (gone tmux → Stopped), answer_decision,
+//! and the env-scrub command convention.
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
 
 use std::collections::HashMap;
@@ -131,7 +133,7 @@ async fn manager_create_record() {
         "tmux_name has prefix: {}",
         record.tmux_name
     );
-    assert_eq!(record.state, ManagedSessionState::Starting);
+    assert_eq!(record.state, ManagedSessionState::Provisioning);
     assert_eq!(record.task, "implement OAuth2");
 
     let listed = mgr.list().await;
@@ -180,17 +182,25 @@ async fn manager_name_hint_overrides() {
     assert_eq!(record.tmux_name, "tmpm-ticket-1234");
 }
 
+/// `stop` must kill the runtime but KEEP the workspace directory and record,
+/// setting state to `Stopped` (not `Dead` or any terminal state).
+///
+/// Why: a session ENDURES beyond its running runtime; stop is non-destructive.
+/// What: creates a session with a temp workspace dir, stops it, asserts state
+/// is `Stopped`, workspace dir still exists, tmux kill was called.
+/// Test: this function IS the test.
 #[tokio::test]
-async fn manager_stop_marks_dead() {
+async fn manager_stop_keeps_workspace() {
     let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
     let (mgr, fake) = make_manager(&dir).await;
 
     let record = mgr
         .create(
             "task".into(),
-            Some(PathBuf::from("/tmp/x")),
+            Some(workspace_dir.path().to_owned()),
             None,
-            None,
+            Some(workspace_dir.path().to_owned()),
             None,
             None,
         )
@@ -198,8 +208,279 @@ async fn manager_stop_marks_dead() {
         .expect("create");
 
     let stopped = mgr.stop(&record.id).await.expect("stop");
-    assert_eq!(stopped.state, ManagedSessionState::Dead);
+
+    // State must be Stopped (runtime gone) not Dead (which implied loss).
+    assert_eq!(stopped.state, ManagedSessionState::Stopped);
+
+    // tmux session must have been killed.
     assert!(fake.kill_calls.lock().unwrap().contains(&record.tmux_name));
+
+    // Workspace directory must STILL EXIST on disk.
+    assert!(
+        workspace_dir.path().exists(),
+        "workspace dir must survive a stop; it is still on disk for resume"
+    );
+
+    // workspace_path field must still be set in the persisted record.
+    let after = mgr.get(&record.id).await.unwrap();
+    assert_eq!(after.state, ManagedSessionState::Stopped);
+    assert!(
+        after.workspace_path.is_some(),
+        "workspace_path must be preserved in the record after stop"
+    );
+}
+
+/// `resume` must create a NEW tmux session rooted at the EXISTING workspace,
+/// NOT re-clone the repository.
+///
+/// Why: workspace is provisioned once; resume only re-spawns the runtime.
+/// What: creates a session with a workspace dir, stops it, resumes it, and
+/// asserts: (a) a second `create_session` call was issued, (b) its cwd equals
+/// the original workspace_path, (c) state transitions to Active.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_resume_respawns_in_existing_workspace() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let workspace_path = workspace_dir.path().to_owned();
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_path.clone()),
+            Some("my-session".into()),
+            Some(workspace_path.clone()),
+            Some("https://github.com/owner/repo".into()),
+            Some("main".into()),
+        )
+        .await
+        .expect("create");
+
+    // Stop the session.
+    mgr.stop(&record.id).await.expect("stop");
+
+    // Record the create_session call count before resume.
+    let creates_before = fake.create_cwd_calls.lock().unwrap().len();
+
+    // Resume the session.
+    let resumed = mgr.resume(&record.id).await.expect("resume");
+
+    // State must be Active.
+    assert_eq!(resumed.state, ManagedSessionState::Active);
+
+    // A NEW create_session must have been issued.
+    // Drop the lock guard before the next await point.
+    let (create_len, resume_cwd) = {
+        let create_calls = fake.create_cwd_calls.lock().unwrap();
+        let len = create_calls.len();
+        let cwd = create_calls
+            .get(creates_before)
+            .map(|c| c.1.clone())
+            .unwrap_or_default();
+        (len, cwd)
+    };
+    assert!(
+        create_len > creates_before,
+        "resume must issue a new tmux create_session call"
+    );
+
+    // The new create_session must use the EXISTING workspace as cwd.
+    assert_eq!(
+        resume_cwd,
+        workspace_path.to_string_lossy().to_string(),
+        "resume must use the EXISTING workspace path as cwd, not re-clone"
+    );
+
+    // workspace_path field must still be set (no re-clone).
+    let after = mgr.get(&record.id).await.unwrap();
+    assert_eq!(
+        after.workspace_path.as_deref(),
+        Some(workspace_path.as_path()),
+        "workspace_path must be preserved after resume (no re-clone)"
+    );
+}
+
+/// `decommission` must remove the workspace directory from disk and set state
+/// to `Decommissioned`, but keep a tombstone record.
+///
+/// Why: decommission is the ONLY teardown that removes disk artifacts; without
+/// it the workspace dir accumulates indefinitely.
+/// What: creates a session with a real temp workspace dir, decommissions it,
+/// asserts the workspace dir is gone from disk and the record state is
+/// `Decommissioned` with `workspace_path = None`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_decommission_removes_workspace() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    // Create a real temp workspace directory that we can check after decommission.
+    let workspace_dir = TempDir::new().unwrap();
+    let workspace_path = workspace_dir.path().to_owned();
+    // Write a sentinel file so we can verify the dir was removed.
+    std::fs::write(workspace_path.join("sentinel.txt"), "exists").unwrap();
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_path.clone()),
+            None,
+            Some(workspace_path.clone()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    // Decommission.
+    let tombstone = mgr.decommission(&record.id).await.expect("decommission");
+
+    // State must be Decommissioned.
+    assert_eq!(tombstone.state, ManagedSessionState::Decommissioned);
+
+    // workspace_path must be cleared in the tombstone record.
+    assert!(
+        tombstone.workspace_path.is_none(),
+        "workspace_path must be None after decommission (workspace was deleted)"
+    );
+
+    // Workspace directory MUST be gone from disk.
+    // Note: TempDir's Drop won't fail if the dir is already removed.
+    assert!(
+        !workspace_path.exists(),
+        "workspace directory must be removed from disk after decommission"
+    );
+
+    // Tombstone record must still be queryable (for `ls` history).
+    let after = mgr.get(&record.id).await.unwrap();
+    assert_eq!(after.state, ManagedSessionState::Decommissioned);
+    assert!(after.workspace_path.is_none());
+}
+
+/// Reconciliation with a gone tmux session must yield `Stopped` (resumable),
+/// not `Orphaned` or `Dead` (both imply the session is lost).
+///
+/// Why: a gone tmux after a daemon restart means the RUNTIME stopped, not
+/// the SESSION. The record and workspace are intact and resumable.
+/// What: seeds a live tmux session for one record and no live session for
+/// another (simulating reboot), runs reconcile, asserts: live → Active,
+/// gone → Stopped (not Orphaned).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_reconcile_gone_tmux_yields_stopped() {
+    let dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+
+    // Seed a live tmux session.
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("tmpm-live-session".into());
+
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let live_record = SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: "tmpm-live-session".into(),
+        cwd: PathBuf::from("/tmp"),
+        task: "live task".into(),
+        state: ManagedSessionState::Active,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: Some(PathBuf::from("/tmp/live-ws")),
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+    };
+    // A record whose tmux session will NOT be found (simulating reboot).
+    let rebooted_record = SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: "tmpm-rebooted-session".into(),
+        cwd: PathBuf::from("/tmp"),
+        task: "rebooted task".into(),
+        state: ManagedSessionState::Active,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: Some(PathBuf::from("/tmp/rebooted-ws")),
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+    };
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(live_record.clone()).await.unwrap();
+        store.upsert(rebooted_record.clone()).await.unwrap();
+    }
+
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+    assert!(report.adopted.contains(&"tmpm-live-session".to_string()));
+    // The gone session must be in the `stopped` list, NOT `orphaned`.
+    assert!(
+        report.stopped.contains(&rebooted_record.id.to_string()),
+        "gone session must be in report.stopped; report: {:?}",
+        report
+    );
+
+    // Live session → Active.
+    let live = mgr.get(&live_record.id).await.unwrap();
+    assert_eq!(live.state, ManagedSessionState::Active);
+
+    // Gone session → Stopped (RESUMABLE), workspace_path preserved.
+    let rebooted = mgr.get(&rebooted_record.id).await.unwrap();
+    assert_eq!(
+        rebooted.state,
+        ManagedSessionState::Stopped,
+        "gone-tmux session must be Stopped (resumable), not Orphaned or Dead"
+    );
+    assert!(
+        rebooted.workspace_path.is_some(),
+        "workspace_path must be preserved after reconcile→Stopped"
+    );
+}
+
+/// Decommissioned tombstones are not touched by reconciliation.
+///
+/// Why: a decommissioned session has no workspace and no tmux; reconciliation
+/// must not try to resurrect or re-stop it.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_reconcile_skips_decommissioned() {
+    let dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let tombstone = SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: "tmpm-decomm".into(),
+        cwd: PathBuf::from("/tmp"),
+        task: "done task".into(),
+        state: ManagedSessionState::Decommissioned,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: None,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+    };
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(tombstone.clone()).await.unwrap();
+    }
+
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    // Tombstone must not appear in adopted or stopped lists.
+    assert!(!report.adopted.contains(&tombstone.tmux_name));
+    assert!(!report.stopped.contains(&tombstone.id.to_string()));
+
+    // State must remain Decommissioned after reconcile.
+    let after = mgr.get(&tombstone.id).await.unwrap();
+    assert_eq!(after.state, ManagedSessionState::Decommissioned);
 }
 
 #[tokio::test]
@@ -234,67 +515,49 @@ async fn manager_send_input() {
     assert!(calls.iter().any(|(_, text)| text == "hello from test"));
 }
 
+/// send_input must be rejected for Stopped and Decommissioned sessions.
+///
+/// Why: those states mean the tmux session is gone; sending would fail silently.
+/// Test: this function IS the test.
 #[tokio::test]
-async fn manager_reconcile_adopts_and_orphans() {
+async fn manager_send_input_rejected_for_stopped_and_decommissioned() {
     let dir = TempDir::new().unwrap();
-    let fake = FakeTmuxDriver::new();
+    let (mgr, _fake) = make_manager(&dir).await;
 
-    // Seed a live tmux session without going through manager.create so
-    // the session is in tmux but in the store as Active (simulating a
-    // prior run).
-    fake.seeded_names
-        .lock()
-        .unwrap()
-        .push("tmpm-live-session".into());
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/x")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
 
-    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
-
-    // Create a record that maps to the live session.
-    let live_record = SessionRecord {
-        id: ManagedSessionId::new(),
-        tmux_name: "tmpm-live-session".into(),
-        cwd: PathBuf::from("/tmp"),
-        task: "live task".into(),
-        state: ManagedSessionState::Active,
-        created_at: Utc::now(),
-        last_activity_at: None,
-        workspace_path: None,
-        repo_url: None,
-        branch: None,
-        pending_decision: None,
-        proposed_default: None,
-    };
-    // A dead record whose tmux session will not be found.
-    let dead_record = SessionRecord {
-        id: ManagedSessionId::new(),
-        tmux_name: "tmpm-dead-session".into(),
-        cwd: PathBuf::from("/tmp"),
-        task: "dead task".into(),
-        state: ManagedSessionState::Active,
-        created_at: Utc::now(),
-        last_activity_at: None,
-        workspace_path: None,
-        repo_url: None,
-        branch: None,
-        pending_decision: None,
-        proposed_default: None,
-    };
+    // Test Stopped rejection.
     {
         let mut store = mgr.store.write().await;
-        store.upsert(live_record.clone()).await.unwrap();
-        store.upsert(dead_record.clone()).await.unwrap();
+        let mut r = store.get(&record.id).unwrap();
+        r.state = ManagedSessionState::Stopped;
+        store.upsert(r).await.unwrap();
     }
+    let result = mgr.send_input(&record.id, "test").await;
+    assert!(result.is_err(), "send_input must fail for Stopped sessions");
 
-    let report = mgr.reconcile_on_boot().await.expect("reconcile");
-    assert!(report.adopted.contains(&"tmpm-live-session".to_string()));
-    assert!(report.orphaned.contains(&dead_record.id.to_string()));
-
-    // Verify store state.
-    let live = mgr.get(&live_record.id).await.unwrap();
-    assert_eq!(live.state, ManagedSessionState::Active);
-
-    let dead = mgr.get(&dead_record.id).await.unwrap();
-    assert_eq!(dead.state, ManagedSessionState::Orphaned);
+    // Test Decommissioned rejection.
+    {
+        let mut store = mgr.store.write().await;
+        let mut r = store.get(&record.id).unwrap();
+        r.state = ManagedSessionState::Decommissioned;
+        store.upsert(r).await.unwrap();
+    }
+    let result = mgr.send_input(&record.id, "test").await;
+    assert!(
+        result.is_err(),
+        "send_input must fail for Decommissioned sessions"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- **Durable session FSM**: Replace `Dead`/`Orphaned`/`Idle`/`Adopted` with a clean 5-state lifecycle: `Provisioning → Active ⇄ Stopped / Errored → Decommissioned`. A session ENDURES from provisioning to explicit decommission; the running `claude` process is transient.
- **New operations**: `stop` (kill runtime, keep workspace, mark `Stopped`), `resume` (re-spawn in EXISTING workspace, no re-clone, mark `Active`), `decommission` (remove workspace from disk, mark `Decommissioned`, keep tombstone)
- **Reconciliation on daemon start**: live tmux → re-adopted as `Active`; persisted record with GONE tmux → `Stopped` (resumable), never `Orphaned`. `TRUSTY_MPM_AUTO_RESUME=1` opt-in to auto-spawn stopped sessions.
- **Optional OpenRouter**: activity endpoint returns `raw_pane` (always), `runtime_active`, `pending_decision`, `proposed_default`, and `classification: null` when `OPENROUTER_API_KEY` is absent — no error. LLM classifier only invoked when key is configured.

## API/CLI surface added

| HTTP | Method | Description |
|------|--------|-------------|
| `/api/v1/sessions/managed/{id}/runtime-stop` | `POST` | Non-destructive stop (workspace intact) |
| `/api/v1/sessions/managed/{id}/resume` | `POST` | Re-spawn claude in existing workspace |
| `/api/v1/sessions/managed/{id}/decommission` | `POST` | Terminal teardown (removes workspace dir) |

Backward compat: `DELETE /{id}` now delegates to `runtime-stop` (non-destructive).

CLI: `tm session runtime-stop <id>`, `tm session resume <id>`, `tm session decommission <id>`.

## Tests

Unit tests added (all pass, 0 stubs):
- `manager_stop_keeps_workspace` — state=`Stopped` AND workspace dir survives on disk
- `manager_resume_respawns_in_existing_workspace` — new tmux create with cwd=existing workspace (no re-clone)
- `manager_decommission_removes_workspace` — workspace dir deleted, `workspace_path=None`, state=`Decommissioned`
- `manager_reconcile_gone_tmux_yields_stopped` — daemon restart with dead tmux → `Stopped`, not `Orphaned`
- `manager_reconcile_skips_decommissioned` — tombstones untouched by reconcile
- `manager_send_input_rejected_for_stopped_and_decommissioned` — FSM guard
- `stopped_state_survives_serde` / `decommissioned_state_survives_serde` — new variant serde

Anti-stub check: `grep -rin "TODO\|follow-up\|unimplemented\|todo!" src/daemon/managed_routes.rs src/session_manager/` → empty.

## Live verification (verbatim)

```
# Session created: 432379c2 state=active workspace=/tmp/mpm-verify-WNYn/hello-world/432379c2...
POST /runtime-stop → {"state":"stopped","workspace_path":"/tmp/mpm-verify-WNYn/..."}
tmux ls → (no tmpm sessions) — runtime killed
ls /tmp/mpm-verify-WNYn/hello-world/432379c2... → CLAUDE.md README — workspace intact ✓

POST /resume → {"state":"active","last_activity_at":"...04:16:27..."}
tmux ls → tmpm-432379c2...: 1 windows (created Mon Jun 15 00:16:27 2026)
pane_current_path = /private/tmp/mpm-verify-WNYn/hello-world/432379c2... — SAME workspace, no re-clone ✓

# Daemon restarted with active record + dead tmux:
WARN reconcile: tmux session gone, marked Stopped (workspace intact, resumable) name=tmpm-432379c2...
INFO session-manager reconcile complete adopted=0 stopped=3 external=0
GET /{id} → {"state":"stopped"} — Stopped not Orphaned ✓

GET /{id}/activity (no OPENROUTER_API_KEY) → {"raw_pane":"","runtime_active":false,
  "classification":null,"summary":"OPENROUTER_API_KEY not configured"} — no error ✓

POST /decommission → {"state":"decommissioned","workspace_path":null}
ls /tmp/mpm-verify-WNYn/hello-world/432379c2... → No such file or directory — WORKSPACE REMOVED ✓
GET /{id} → {"state":"decommissioned"} — tombstone survives ✓
```

## Quality bar

- `cargo build -p trusty-mpm` — PASS
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — 0 warnings
- `cargo test -p trusty-mpm` — 891 passed, 0 failed
- `cargo fmt -p trusty-mpm --check` — PASS
- `bash scripts/check_line_cap.sh` — 15 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)