### PR TITLE
feat(trusty-mpm): unattended supervisor daemon for 24/7 fleet operation (#1206)

### DIFF
--- a/crates/trusty-mpm/deploy/supervisor/README.md
+++ b/crates/trusty-mpm/deploy/supervisor/README.md
@@ -1,0 +1,99 @@
+# trusty-mpm unattended supervisor (#1206)
+
+The **supervisor** is a lightweight, always-on process that keeps a managed-session
+fleet running 24/7 with **no live caller attached**. It is a passive **observer +
+auto-resumer**, *not* a decision-maker:
+
+- It **auto-resumes** enduring (`stopped`) sessions so a rebooted host or an exited
+  runtime does not leave work parked. (Gated by `TRUSTY_MPM_AUTO_RESUME`.)
+- It **observes** session health and classifies idle `active` sessions via the
+  activity monitor (optional; needs `OPENROUTER_API_KEY`, otherwise `unknown`).
+- It **surfaces** `pending_decision`s over `/metrics` for a human or a higher-level
+  fleet manager — it **never auto-answers** a decision.
+- It **survives reboots** under launchd (macOS) or systemd (Linux).
+- It exposes fleet state on `GET /metrics` and a liveness probe on `GET /health`.
+
+## Run it by hand
+
+```bash
+# Observe-only (no resume):
+tm supervisor
+
+# Auto-resume stopped sessions, poll every 30s, metrics on :7881:
+TRUSTY_MPM_AUTO_RESUME=1 tm supervisor --interval 30 --addr 127.0.0.1:7881
+
+# Or pass --auto-resume instead of the env var:
+tm supervisor --auto-resume
+```
+
+Then query fleet state:
+
+```bash
+curl -s http://127.0.0.1:7881/metrics | jq
+curl -s http://127.0.0.1:7881/health        # {"status":"ok"}
+```
+
+## Configuration (env vars)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TRUSTY_MPM_AUTO_RESUME` | `0` (off) | `1`/`true` enables auto-resume of `stopped` sessions. **This is the master switch for resume.** |
+| `TRUSTY_MPM_SUPERVISOR_INTERVAL` | `30` | Poll interval, seconds. |
+| `TRUSTY_MPM_SUPERVISOR_CLASSIFY` | `1` (on) | `0`/`false` disables idle classification (no LLM spend). |
+| `TRUSTY_MPM_SUPERVISOR_ADDR` | `127.0.0.1:7881` | `/metrics` + `/health` bind address. |
+| `OPENROUTER_API_KEY` | — | Required for real activity classification; absent ⇒ `unknown`. |
+
+CLI flags (`--interval`, `--addr`, `--auto-resume`, `--no-classify`) override the
+env vars.
+
+## Enabling auto-resume
+
+Auto-resume is **opt-in** for safety — by default the supervisor runs observe-only
+and only surfaces fleet state. To enable it, do **one** of:
+
+- export `TRUSTY_MPM_AUTO_RESUME=1` in the supervisor's environment (the launchd
+  plist / systemd unit below already set this), **or**
+- pass `tm supervisor --auto-resume`.
+
+## Persistence — macOS (launchd)
+
+```bash
+# 1. Find your tm binary and username:
+which tm          # e.g. /Users/you/.cargo/bin/tm
+whoami            # e.g. you
+
+# 2. Copy the plist and substitute the placeholders:
+mkdir -p ~/Library/LaunchAgents ~/.trusty-mpm/logs
+sed -e "s|__USER__|$(whoami)|g" \
+    -e "s|__TM_BINARY_PATH__|$(which tm)|g" \
+    crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist \
+    > ~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist
+
+# 3. Load it (and restart it after any `cargo install` of tm):
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist
+
+# Restart / reload:
+launchctl bootout   gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist
+```
+
+`RunAtLoad` + `KeepAlive` make it survive reboots and restart on crash.
+
+## Persistence — Linux (systemd user service)
+
+```bash
+mkdir -p ~/.config/systemd/user
+sed "s|__TM_BINARY_PATH__|$(which tm)|g" \
+    crates/trusty-mpm/deploy/supervisor/trusty-mpm-supervisor.service \
+    > ~/.config/systemd/user/trusty-mpm-supervisor.service
+
+systemctl --user daemon-reload
+systemctl --user enable --now trusty-mpm-supervisor.service
+loginctl enable-linger "$USER"     # run without an active login session
+```
+
+## Logs
+
+- macOS: `~/.trusty-mpm/logs/supervisor.{out,err}.log` plus the daily-rotated
+  `~/.trusty-mpm/logs/trusty-mpm.log*`.
+- Linux: `journalctl --user -u trusty-mpm-supervisor -f`.

--- a/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
+++ b/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd plist for the trusty-mpm unattended supervisor (#1206).
+
+  Why: macOS-primary persistence. This LaunchAgent keeps the supervisor running
+  24/7 and restarts it after a reboot or a crash, so the managed-session fleet
+  keeps moving with no live caller attached.
+
+  What: runs `tm supervisor`, restarts on exit (KeepAlive), logs to
+  ~/.trusty-mpm/logs/, and seeds the supervisor's policy via EnvironmentVariables.
+  Edit the env block to taste, then load it (see deploy/supervisor/README.md).
+
+  IMPORTANT — replace the placeholders before loading:
+    * __USER__              your macOS short username (e.g. `masa`)
+    * __TM_BINARY_PATH__    absolute path to the `tm` binary, e.g.
+                            /Users/__USER__/.cargo/bin/tm  (run `which tm`)
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.trusty.mpm.supervisor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__TM_BINARY_PATH__</string>
+        <string>supervisor</string>
+    </array>
+
+    <!-- Seed config. TRUSTY_MPM_AUTO_RESUME=1 enables auto-resume of stopped
+         sessions; remove it (or set 0) to run observe-only. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TRUSTY_MPM_AUTO_RESUME</key>
+        <string>1</string>
+        <key>TRUSTY_MPM_SUPERVISOR_INTERVAL</key>
+        <string>30</string>
+        <key>TRUSTY_MPM_SUPERVISOR_ADDR</key>
+        <string>127.0.0.1:7881</string>
+        <key>RUST_LOG</key>
+        <string>info</string>
+        <!-- Optional: enable idle-session activity classification.
+        <key>OPENROUTER_API_KEY</key>
+        <string>sk-or-...</string>
+        -->
+    </dict>
+
+    <!-- Restart on exit and start at login → survives reboots and crashes. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Logs land next to the daemon's own logs. -->
+    <key>StandardOutPath</key>
+    <string>/Users/__USER__/.trusty-mpm/logs/supervisor.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/__USER__/.trusty-mpm/logs/supervisor.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/crates/trusty-mpm/deploy/supervisor/trusty-mpm-supervisor.service
+++ b/crates/trusty-mpm/deploy/supervisor/trusty-mpm-supervisor.service
@@ -1,0 +1,41 @@
+# systemd user unit for the trusty-mpm unattended supervisor (#1206).
+#
+# Why: Linux persistence equivalent to the macOS launchd plist. Keeps the
+# supervisor running 24/7 and restarts it after a reboot or crash so the
+# managed-session fleet keeps moving with no live caller attached.
+#
+# What: runs `tm supervisor` as a long-lived service, restarts on failure, and
+# seeds the supervisor's policy via Environment= lines.
+#
+# Install (per-user, no root):
+#   mkdir -p ~/.config/systemd/user
+#   cp trusty-mpm-supervisor.service ~/.config/systemd/user/
+#   # edit ExecStart path + Environment as needed, then:
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now trusty-mpm-supervisor.service
+#   loginctl enable-linger "$USER"   # so it runs without an active login session
+#
+# Replace __TM_BINARY_PATH__ with the absolute path to `tm` (run `which tm`).
+
+[Unit]
+Description=trusty-mpm unattended fleet supervisor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=__TM_BINARY_PATH__ supervisor
+Restart=always
+RestartSec=5
+
+# Seed config. TRUSTY_MPM_AUTO_RESUME=1 enables auto-resume of stopped sessions;
+# remove it (or set 0) to run observe-only.
+Environment=TRUSTY_MPM_AUTO_RESUME=1
+Environment=TRUSTY_MPM_SUPERVISOR_INTERVAL=30
+Environment=TRUSTY_MPM_SUPERVISOR_ADDR=127.0.0.1:7881
+Environment=RUST_LOG=info
+# Optional: enable idle-session classification.
+# Environment=OPENROUTER_API_KEY=sk-or-...
+
+[Install]
+WantedBy=default.target

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -115,6 +115,36 @@ pub(crate) enum Command {
         #[arg(long)]
         mcp: bool,
     },
+    /// Run the unattended fleet supervisor (24/7 observer + auto-resumer, #1206).
+    ///
+    /// Why: for overnight / unattended operation the fleet needs an always-on
+    /// process that auto-resumes `stopped` sessions, observes session health
+    /// without a live caller, surfaces pending decisions, and exposes fleet
+    /// metrics — all while making NO autonomy decisions itself.
+    /// What: runs the supervisor loop, polling the managed-session store on an
+    /// interval. Auto-resume is gated by `TRUSTY_MPM_AUTO_RESUME=1`; the poll
+    /// cadence, classification toggle, and metrics address are read from env
+    /// (`TRUSTY_MPM_SUPERVISOR_*`) but may be overridden by these flags. Serves
+    /// `/metrics` + `/health` for fleet observability.
+    /// Test: `cli_parses_supervisor`.
+    Supervisor {
+        /// Address the supervisor's `/metrics` + `/health` server binds to.
+        ///
+        /// Overrides `TRUSTY_MPM_SUPERVISOR_ADDR` when supplied.
+        #[arg(long, env = "TRUSTY_MPM_SUPERVISOR_ADDR")]
+        addr: Option<SocketAddr>,
+        /// Poll interval in seconds (overrides `TRUSTY_MPM_SUPERVISOR_INTERVAL`).
+        #[arg(long)]
+        interval: Option<u64>,
+        /// Force auto-resume of `stopped` sessions on (overrides
+        /// `TRUSTY_MPM_AUTO_RESUME`). Without this flag (and without the env
+        /// var) the supervisor runs observe-only.
+        #[arg(long)]
+        auto_resume: bool,
+        /// Disable idle-session activity classification (no LLM calls).
+        #[arg(long)]
+        no_classify: bool,
+    },
     /// Launch a session with full setup: deploys instructions, agents, and
     /// skills, then starts Claude.
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -4,7 +4,7 @@
 //! file well under the 500-line cap and makes the handler surface easy to
 //! navigate.
 //! What: re-exports handler modules — `daemon`, `install`, `launch`,
-//! `misc`, `project`, `services`, `session`, `telegram`.
+//! `misc`, `project`, `services`, `session`, `supervisor`, `telegram`.
 //! Test: each module has its own unit tests; integration coverage lives in
 //! `tests.rs`.
 
@@ -17,4 +17,5 @@ pub(crate) mod project;
 pub(crate) mod repair;
 pub(crate) mod services;
 pub(crate) mod session;
+pub(crate) mod supervisor;
 pub(crate) mod telegram;

--- a/crates/trusty-mpm/src/bin/tm/commands/supervisor.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/supervisor.rs
@@ -73,14 +73,19 @@ pub(crate) async fn run_supervisor(
         None
     };
 
-    // Spawn the /metrics + /health server.
+    // Bind the /metrics + /health listener BEFORE the loop so a port collision
+    // fails fast (propagated out of run_supervisor) instead of leaving the
+    // supervisor running for hours with no metrics endpoint.
     let handle = trusty_mpm::supervisor::new_handle();
     let metrics_addr = cfg.metrics_addr;
+    let listener = trusty_mpm::supervisor::http::bind(metrics_addr).await?;
+
+    // Now that the port is confirmed free, serve on the bound listener. We keep
+    // the JoinHandle and select on it inside the loop so a later serve failure
+    // surfaces rather than being swallowed by a detached task.
     let server_handle = handle.clone();
-    tokio::spawn(async move {
-        if let Err(e) = trusty_mpm::supervisor::http::serve(server_handle, metrics_addr).await {
-            tracing::error!("supervisor metrics server exited: {e}");
-        }
+    let mut server_task = tokio::spawn(async move {
+        trusty_mpm::supervisor::http::serve_on(listener, server_handle).await
     });
 
     tracing::info!(
@@ -92,5 +97,21 @@ pub(crate) async fn run_supervisor(
     );
 
     let supervisor = Supervisor::new(mgr, cfg, monitor);
-    supervisor.run(handle).await
+    // Race the supervisor loop against the metrics server task: if the server
+    // dies (serve error or panic), abort the supervisor and propagate the error
+    // instead of running on without observability.
+    tokio::select! {
+        loop_result = supervisor.run(handle) => loop_result,
+        server_result = &mut server_task => {
+            match server_result {
+                Ok(Ok(())) => {
+                    anyhow::bail!("supervisor metrics server exited unexpectedly")
+                }
+                Ok(Err(e)) => Err(e.context("supervisor metrics server failed")),
+                Err(join_err) => {
+                    Err(anyhow::anyhow!("supervisor metrics server task panicked: {join_err}"))
+                }
+            }
+        }
+    }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/supervisor.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/supervisor.rs
@@ -1,0 +1,96 @@
+//! `supervisor` subcommand — run the unattended 24/7 fleet supervisor (#1206).
+//!
+//! Why: for overnight / unattended operation the managed-session fleet needs an
+//! always-on process that auto-resumes `stopped` sessions, observes health
+//! without a live caller, surfaces pending decisions, and exposes fleet metrics —
+//! all while making NO autonomy decisions. This handler is the operator entry
+//! point (`tm supervisor`) that wires the real session manager + activity monitor
+//! and runs the loop until the process is signalled to stop.
+//! What: builds a [`SessionManager`] over the real tmux driver (falling back to a
+//! no-op driver when tmux is absent), resolves the [`SupervisorConfig`] from env
+//! with CLI overrides, spawns the `/metrics` + `/health` server, and runs the
+//! supervisor loop.
+//! Test: `cli_parses_supervisor` covers flag parsing; the loop logic is unit-
+//! tested in `trusty_mpm::supervisor::tests`.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use trusty_mpm::activity::monitor::{ActivityMonitor, OpenRouterClassifier};
+use trusty_mpm::core::paths::FrameworkPaths;
+use trusty_mpm::session_manager::real_tmux::NoopTmuxDriver;
+use trusty_mpm::session_manager::{ManagedTmuxDriver, RealTmuxDriver, SessionManager};
+use trusty_mpm::supervisor::{Supervisor, SupervisorConfig};
+
+/// Run the supervisor loop with config resolved from env + CLI overrides.
+///
+/// Why: separating config resolution + wiring from the loop itself keeps the
+/// handler readable and lets the CLI flags cleanly override the env defaults.
+/// What: loads the managed-session store under `~/.trusty-mpm/session-manager`,
+/// builds the activity monitor unless `--no-classify` (or the env toggle) disables
+/// it, spawns the metrics server, and runs [`Supervisor::run`]. CLI flags take
+/// precedence over `TRUSTY_MPM_SUPERVISOR_*` / `TRUSTY_MPM_AUTO_RESUME`.
+/// Test: `cli_parses_supervisor`; loop behavior in `supervisor::tests`.
+pub(crate) async fn run_supervisor(
+    addr: Option<SocketAddr>,
+    interval: Option<u64>,
+    auto_resume: bool,
+    no_classify: bool,
+) -> anyhow::Result<()> {
+    // Resolve config from env, then apply CLI overrides (CLI wins).
+    let mut cfg = SupervisorConfig::from_env();
+    if let Some(a) = addr {
+        cfg.metrics_addr = a;
+    }
+    if let Some(secs) = interval.filter(|s| *s > 0) {
+        cfg.interval = std::time::Duration::from_secs(secs);
+    }
+    if auto_resume {
+        cfg.auto_resume = true;
+    }
+    if no_classify {
+        cfg.classify_idle = false;
+    }
+
+    // Build the session manager over the real tmux driver (or a no-op fallback).
+    let data_dir = FrameworkPaths::default().root.join("session-manager");
+    std::fs::create_dir_all(&data_dir)?;
+    let tmux: Arc<dyn ManagedTmuxDriver> = match RealTmuxDriver::discover() {
+        Ok(d) => Arc::new(d),
+        Err(e) => {
+            tracing::warn!("tmux unavailable for supervisor: {e}; using no-op driver");
+            Arc::new(NoopTmuxDriver)
+        }
+    };
+    let mgr = Arc::new(SessionManager::new(&data_dir, tmux).await?);
+
+    // Build the activity monitor unless classification is disabled.
+    let monitor = if cfg.classify_idle {
+        let model =
+            std::env::var("TRUSTY_LLM_MODEL").unwrap_or_else(|_| "openai/gpt-4o-mini".to_owned());
+        Some(ActivityMonitor::new(OpenRouterClassifier::new(), model))
+    } else {
+        None
+    };
+
+    // Spawn the /metrics + /health server.
+    let handle = trusty_mpm::supervisor::new_handle();
+    let metrics_addr = cfg.metrics_addr;
+    let server_handle = handle.clone();
+    tokio::spawn(async move {
+        if let Err(e) = trusty_mpm::supervisor::http::serve(server_handle, metrics_addr).await {
+            tracing::error!("supervisor metrics server exited: {e}");
+        }
+    });
+
+    tracing::info!(
+        addr = %metrics_addr,
+        interval_secs = cfg.interval.as_secs(),
+        auto_resume = cfg.auto_resume,
+        classify_idle = cfg.classify_idle,
+        "starting unattended supervisor"
+    );
+
+    let supervisor = Supervisor::new(mgr, cfg, monitor);
+    supervisor.run(handle).await
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -110,7 +110,12 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "daemon")]
     let mut _error_store: Option<trusty_common::error_capture::ErrorStore> = None;
 
-    if matches!(cli.command, Command::Daemon { .. }) {
+    // Long-running modes (daemon, supervisor) get the full file-rotating tracing
+    // + bug-capture layer; short-lived CLI invocations skip subscriber init.
+    if matches!(
+        cli.command,
+        Command::Daemon { .. } | Command::Supervisor { .. }
+    ) {
         #[cfg(feature = "daemon")]
         {
             // File logging: write daily-rotated logs to ~/.trusty-mpm/logs/ in
@@ -220,6 +225,12 @@ async fn main() -> anyhow::Result<()> {
             tailscale,
             mcp,
         } => run_daemon(addr, tailscale, mcp).await,
+        Command::Supervisor {
+            addr,
+            interval,
+            auto_resume,
+            no_classify,
+        } => commands::supervisor::run_supervisor(addr, interval, auto_resume, no_classify).await,
         Command::Launch { dir } => launch(&client, &url, dir).await,
         Command::Connect { dir } => connect(&client, &url, dir).await,
         Command::Attach { target, json } => attach_cmd(&client, &url, &target, json).await,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -493,6 +493,50 @@ fn cli_parses_daemon_tailscale() {
     }
 }
 
+#[test]
+fn cli_parses_supervisor() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "supervisor"]).unwrap();
+    match cli.command {
+        Command::Supervisor {
+            interval,
+            auto_resume,
+            no_classify,
+            ..
+        } => {
+            assert_eq!(interval, None);
+            assert!(!auto_resume);
+            assert!(!no_classify);
+        }
+        other => panic!("expected Supervisor, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_supervisor_flags() {
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "supervisor",
+        "--interval",
+        "60",
+        "--auto-resume",
+        "--no-classify",
+    ])
+    .unwrap();
+    match cli.command {
+        Command::Supervisor {
+            interval,
+            auto_resume,
+            no_classify,
+            ..
+        } => {
+            assert_eq!(interval, Some(60));
+            assert!(auto_resume);
+            assert!(no_classify);
+        }
+        other => panic!("expected Supervisor, got {other:?}"),
+    }
+}
+
 // ── Session-manager MVP CLI parse tests ─────────────────────────────────────
 
 #[test]

--- a/crates/trusty-mpm/src/lib.rs
+++ b/crates/trusty-mpm/src/lib.rs
@@ -104,6 +104,20 @@ pub mod content;
 /// Test: pure unit tests in `driver::policy::tests` and `driver::correlation::tests`.
 pub mod driver;
 
+/// Unattended supervisor: 24/7 fleet observer + auto-resumer (#1206).
+///
+/// Why: the session manager normally needs a live calling agentic process to keep
+/// a fleet moving. For overnight / unattended operation an always-on supervisor
+/// auto-resumes enduring (`stopped`) sessions, observes session health without a
+/// caller, surfaces `pending_decision`s for a human, and survives reboots under
+/// launchd/systemd. It is a PASSIVE observer — it never makes autonomy decisions.
+/// What: re-exports `Supervisor`, `SupervisorConfig`, `FleetMetrics`, and the
+/// per-tick `run_tick` sweep; the `/metrics` + `/health` HTTP server is gated
+/// behind the `daemon` feature (axum lives there).
+/// Test: `supervisor::tests` covers config parsing, metrics derivation, the
+/// N-session fleet sweep, and the HTTP handlers.
+pub mod supervisor;
+
 // ── Feature-gated modules ────────────────────────────────────────────────────
 
 /// MCP server: six orchestration tools exposed to Claude Code sessions.

--- a/crates/trusty-mpm/src/supervisor/config.rs
+++ b/crates/trusty-mpm/src/supervisor/config.rs
@@ -106,28 +106,44 @@ impl Default for SupervisorConfig {
 }
 
 impl SupervisorConfig {
-    /// Build a config from the documented environment variables.
+    /// Build a config from the process environment.
     ///
     /// Why: the supervisor is launched unattended by launchd/systemd, which can
-    /// only pass configuration through the environment; this is the single place
-    /// that maps env vars onto the typed config.
-    /// What: reads [`ENV_AUTO_RESUME`], [`ENV_INTERVAL_SECS`], [`ENV_CLASSIFY_IDLE`],
-    /// and [`ENV_METRICS_ADDR`], each falling back to its default on absence or a
-    /// parse failure.
-    /// Test: `auto_resume_env_parsing`, `interval_env_parsing`,
-    /// `classify_idle_env_parsing`, `metrics_addr_env_parsing`.
+    /// only pass configuration through the environment; this is the production
+    /// entry point that maps the real process env onto the typed config.
+    /// What: delegates to [`Self::from_env_with`] with a resolver backed by
+    /// [`std::env::var`], reading [`ENV_AUTO_RESUME`], [`ENV_INTERVAL_SECS`],
+    /// [`ENV_CLASSIFY_IDLE`], and [`ENV_METRICS_ADDR`], each falling back to its
+    /// default on absence or a parse failure.
+    /// Test: covered transitively by the `*_env_parsing` tests, which exercise the
+    /// shared [`Self::from_env_with`] logic with an injected resolver.
     pub fn from_env() -> Self {
+        Self::from_env_with(|key| std::env::var(key).ok())
+    }
+
+    /// Build a config from an injectable environment resolver.
+    ///
+    /// Why: the original `from_env` read the process-wide environment directly,
+    /// which forced its tests to call `std::env::set_var`/`remove_var` — a global
+    /// mutation that flakes under parallel test execution. Threading the env
+    /// through a resolver closure lets tests inject a deterministic fake map with
+    /// zero process-wide state, while production passes [`std::env::var`].
+    /// What: for each documented variable, calls `get(key)` to obtain its raw
+    /// value, parses it, and falls back to the [`Self::default`] value on absence
+    /// or a parse failure; the parsing/fallback rules are identical to the legacy
+    /// `from_env`.
+    /// Test: `auto_resume_env_parsing`, `interval_env_parsing`,
+    /// `classify_idle_env_parsing`, `metrics_addr_env_parsing`, `config_defaults`.
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Self {
         let defaults = Self::default();
-        let auto_resume = env_bool(ENV_AUTO_RESUME).unwrap_or(defaults.auto_resume);
-        let classify_idle = env_bool(ENV_CLASSIFY_IDLE).unwrap_or(defaults.classify_idle);
-        let interval = std::env::var(ENV_INTERVAL_SECS)
-            .ok()
+        let auto_resume = env_bool(&get, ENV_AUTO_RESUME).unwrap_or(defaults.auto_resume);
+        let classify_idle = env_bool(&get, ENV_CLASSIFY_IDLE).unwrap_or(defaults.classify_idle);
+        let interval = get(ENV_INTERVAL_SECS)
             .and_then(|v| v.trim().parse::<u64>().ok())
             .filter(|s| *s > 0)
             .map(Duration::from_secs)
             .unwrap_or(defaults.interval);
-        let metrics_addr = std::env::var(ENV_METRICS_ADDR)
-            .ok()
+        let metrics_addr = get(ENV_METRICS_ADDR)
             .and_then(|v| v.trim().parse::<SocketAddr>().ok())
             .unwrap_or(defaults.metrics_addr);
         Self {
@@ -139,16 +155,18 @@ impl SupervisorConfig {
     }
 }
 
-/// Parse a boolean-ish environment variable.
+/// Parse a boolean-ish environment variable via a resolver.
 ///
 /// Why: the env contract accepts `1`/`true`/`yes`/`on` (and their negatives) so
 /// operators are not surprised by which spelling works; sharing one parser keeps
-/// every boolean flag consistent.
+/// every boolean flag consistent. Taking the value through a resolver (rather than
+/// reading `std::env` directly) keeps [`SupervisorConfig::from_env_with`] testable
+/// without process-wide mutation.
 /// What: returns `Some(true)` for truthy spellings, `Some(false)` for falsy ones,
-/// and `None` when the var is unset or unrecognized (so the caller keeps its default).
-/// Test: `env_bool_recognizes_truthy_and_falsy`.
-fn env_bool(key: &str) -> Option<bool> {
-    let raw = std::env::var(key).ok()?;
+/// and `None` when the var is absent or unrecognized (so the caller keeps its default).
+/// Test: `env_bool_recognizes_truthy_and_falsy`, `auto_resume_env_parsing`.
+fn env_bool(get: impl Fn(&str) -> Option<String>, key: &str) -> Option<bool> {
+    let raw = get(key)?;
     match raw.trim().to_ascii_lowercase().as_str() {
         "1" | "true" | "yes" | "on" => Some(true),
         "0" | "false" | "no" | "off" => Some(false),

--- a/crates/trusty-mpm/src/supervisor/config.rs
+++ b/crates/trusty-mpm/src/supervisor/config.rs
@@ -1,0 +1,157 @@
+//! Supervisor configuration: poll cadence, auto-resume policy, idle classification.
+//!
+//! Why: the unattended supervisor must run with no live caller for hours, so its
+//! behavior has to be driven entirely by *seed configuration* an operator sets
+//! once (env vars / a struct) rather than by interactive prompts. Centralizing
+//! the knobs in one struct keeps the env-var contract (`TRUSTY_MPM_AUTO_RESUME`,
+//! `TRUSTY_MPM_SUPERVISOR_INTERVAL`, …) auditable and gives the loop a single
+//! immutable config value to read each tick.
+//! What: defines [`SupervisorConfig`] with the poll interval, the auto-resume
+//! gate, the idle-classification toggle, and the metrics bind address; plus
+//! [`SupervisorConfig::from_env`] which reads the documented env vars with safe
+//! defaults.
+//! Test: `config_defaults`, `auto_resume_env_parsing`, `interval_env_parsing`,
+//! `classify_idle_env_parsing` in `super::tests`.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+/// Environment variable that gates auto-resume of `stopped` sessions.
+///
+/// Why: auto-resume is the supervisor's most consequential action — it brings a
+/// runtime back without a human present — so it MUST be opt-in via an explicit
+/// env var, matching the existing reconcile-on-boot gate in `DaemonState`.
+/// What: the canonical name an operator sets to `1` / `true` to enable resume.
+/// Test: `auto_resume_env_parsing`.
+pub const ENV_AUTO_RESUME: &str = "TRUSTY_MPM_AUTO_RESUME";
+
+/// Environment variable that overrides the poll interval (in seconds).
+///
+/// Why: overnight fleets want a slow cadence (cheap); active debugging wants a
+/// fast one. An env override lets operators tune without recompiling.
+/// What: parsed as `u64` seconds; invalid / absent values fall back to the default.
+/// Test: `interval_env_parsing`.
+pub const ENV_INTERVAL_SECS: &str = "TRUSTY_MPM_SUPERVISOR_INTERVAL";
+
+/// Environment variable that toggles idle-session activity classification.
+///
+/// Why: classification calls the activity monitor (which may call an LLM). On a
+/// host with no `OPENROUTER_API_KEY`, or when an operator wants zero token spend,
+/// this lets them turn classification off while keeping auto-resume + metrics.
+/// What: set to `0` / `false` to disable; defaults to enabled.
+/// Test: `classify_idle_env_parsing`.
+pub const ENV_CLASSIFY_IDLE: &str = "TRUSTY_MPM_SUPERVISOR_CLASSIFY";
+
+/// Environment variable that overrides the metrics HTTP bind address.
+///
+/// Why: operators co-locating several daemons need to move the metrics port off
+/// the default to avoid collisions.
+/// What: parsed as a `SocketAddr`; invalid / absent values fall back to the default.
+/// Test: `metrics_addr_env_parsing`.
+pub const ENV_METRICS_ADDR: &str = "TRUSTY_MPM_SUPERVISOR_ADDR";
+
+/// Default poll interval when [`ENV_INTERVAL_SECS`] is unset: 30 seconds.
+///
+/// Why: 30s balances responsiveness (a stopped session resumes within half a
+/// minute) against load (the sweep lists sessions and may classify panes).
+/// What: the fallback `Duration` used by [`SupervisorConfig::from_env`].
+/// Test: `config_defaults`.
+pub const DEFAULT_INTERVAL_SECS: u64 = 30;
+
+/// Default metrics bind address when [`ENV_METRICS_ADDR`] is unset.
+///
+/// Why: loopback-only by default keeps fleet state off the network unless the
+/// operator opts in; `7881` sits next to the daemon's `7880`.
+/// What: the fallback address string parsed by [`SupervisorConfig::from_env`].
+/// Test: `config_defaults`.
+pub const DEFAULT_METRICS_ADDR: &str = "127.0.0.1:7881";
+
+/// Immutable configuration for one supervisor run.
+///
+/// Why: the loop reads its policy from one value per tick; bundling the knobs in
+/// a `Clone + Copy`-friendly struct (it is `Clone`; `SocketAddr` is `Copy`) makes
+/// the supervisor trivially testable — a test constructs a config directly rather
+/// than mutating process-wide env vars.
+/// What: carries the poll [`Duration`], the `auto_resume` gate, the
+/// `classify_idle` toggle, and the metrics [`SocketAddr`].
+/// Test: `config_defaults` and every loop test constructs one of these.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupervisorConfig {
+    /// How long to wait between fleet sweeps.
+    pub interval: Duration,
+    /// When `true`, `stopped` sessions are auto-resumed each sweep.
+    pub auto_resume: bool,
+    /// When `true`, idle `active` sessions have their pane classified.
+    pub classify_idle: bool,
+    /// Address the `/metrics` + `/health` HTTP server binds to.
+    pub metrics_addr: SocketAddr,
+}
+
+impl Default for SupervisorConfig {
+    /// Why: a sensible no-env default makes the type usable in tests and as a
+    /// base to override; auto-resume defaults OFF (safety) and classification ON.
+    /// What: 30s interval, `auto_resume = false`, `classify_idle = true`,
+    /// metrics on `127.0.0.1:7881`.
+    /// Test: `config_defaults`.
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(DEFAULT_INTERVAL_SECS),
+            auto_resume: false,
+            classify_idle: true,
+            metrics_addr: DEFAULT_METRICS_ADDR
+                .parse()
+                .expect("DEFAULT_METRICS_ADDR is a valid SocketAddr literal"),
+        }
+    }
+}
+
+impl SupervisorConfig {
+    /// Build a config from the documented environment variables.
+    ///
+    /// Why: the supervisor is launched unattended by launchd/systemd, which can
+    /// only pass configuration through the environment; this is the single place
+    /// that maps env vars onto the typed config.
+    /// What: reads [`ENV_AUTO_RESUME`], [`ENV_INTERVAL_SECS`], [`ENV_CLASSIFY_IDLE`],
+    /// and [`ENV_METRICS_ADDR`], each falling back to its default on absence or a
+    /// parse failure.
+    /// Test: `auto_resume_env_parsing`, `interval_env_parsing`,
+    /// `classify_idle_env_parsing`, `metrics_addr_env_parsing`.
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        let auto_resume = env_bool(ENV_AUTO_RESUME).unwrap_or(defaults.auto_resume);
+        let classify_idle = env_bool(ENV_CLASSIFY_IDLE).unwrap_or(defaults.classify_idle);
+        let interval = std::env::var(ENV_INTERVAL_SECS)
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .filter(|s| *s > 0)
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.interval);
+        let metrics_addr = std::env::var(ENV_METRICS_ADDR)
+            .ok()
+            .and_then(|v| v.trim().parse::<SocketAddr>().ok())
+            .unwrap_or(defaults.metrics_addr);
+        Self {
+            interval,
+            auto_resume,
+            classify_idle,
+            metrics_addr,
+        }
+    }
+}
+
+/// Parse a boolean-ish environment variable.
+///
+/// Why: the env contract accepts `1`/`true`/`yes`/`on` (and their negatives) so
+/// operators are not surprised by which spelling works; sharing one parser keeps
+/// every boolean flag consistent.
+/// What: returns `Some(true)` for truthy spellings, `Some(false)` for falsy ones,
+/// and `None` when the var is unset or unrecognized (so the caller keeps its default).
+/// Test: `env_bool_recognizes_truthy_and_falsy`.
+fn env_bool(key: &str) -> Option<bool> {
+    let raw = std::env::var(key).ok()?;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}

--- a/crates/trusty-mpm/src/supervisor/http.rs
+++ b/crates/trusty-mpm/src/supervisor/http.rs
@@ -88,17 +88,54 @@ async fn metrics(State(handle): State<MetricsHandle>) -> Json<FleetMetrics> {
     Json(snapshot)
 }
 
+/// Bind a `TcpListener` for the metrics server on `addr`.
+///
+/// Why: the supervisor must fail *fast* if the metrics port is already in use —
+/// otherwise it would run for hours with no `/metrics` and only a buried log line.
+/// Binding before the loop starts (and propagating the error) turns a silent
+/// degradation into an immediate startup failure the operator sees.
+/// What: binds and returns a `TcpListener`, surfacing any bind error to the
+/// caller with the offending address as context.
+/// Test: covered indirectly by `run_supervisor` (bind-before-loop); the failure
+/// path mirrors the daemon's own listener bind.
+pub async fn bind(addr: SocketAddr) -> anyhow::Result<tokio::net::TcpListener> {
+    use anyhow::Context as _;
+    tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("binding supervisor metrics server to {addr}"))
+}
+
+/// Serve the metrics router on an already-bound listener until the task is dropped.
+///
+/// Why: separating bind from serve lets the caller bind first (failing fast on a
+/// port collision) and only then spawn the serving task, so a bind error can be
+/// propagated synchronously rather than lost inside a detached `tokio::spawn`.
+/// What: logs the bound address and serves [`router`] on `listener`; returns an
+/// error only if serving subsequently fails.
+/// Test: handlers are unit-tested via the router; the serve path mirrors the
+/// daemon's own `serve_http`.
+pub async fn serve_on(
+    listener: tokio::net::TcpListener,
+    handle: MetricsHandle,
+) -> anyhow::Result<()> {
+    let local = listener.local_addr().ok();
+    if let Some(addr) = local {
+        info!("supervisor metrics listening on http://{addr}/metrics");
+    }
+    axum::serve(listener, router(handle)).await?;
+    Ok(())
+}
+
 /// Bind and serve the metrics router until the process exits.
 ///
-/// Why: the supervisor runs this as a background task so fleet state is queryable
-/// for the whole unattended run.
-/// What: binds a `TcpListener` to `addr` and serves [`router`]; logs the bound
-/// address. Returns an error only if the bind or serve fails.
+/// Why: a convenience wrapper for callers that want bind+serve in one step (e.g.
+/// integration tests); production wiring uses [`bind`] + [`serve_on`] so the bind
+/// error can be propagated before the supervisor loop starts.
+/// What: binds a `TcpListener` to `addr` via [`bind`] and serves [`router`] via
+/// [`serve_on`]. Returns an error if either the bind or serve fails.
 /// Test: covered indirectly — handlers are unit-tested via the router; the
 /// bind/serve path mirrors the daemon's own `serve_http`.
 pub async fn serve(handle: MetricsHandle, addr: SocketAddr) -> anyhow::Result<()> {
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    info!("supervisor metrics listening on http://{addr}/metrics");
-    axum::serve(listener, router(handle)).await?;
-    Ok(())
+    let listener = bind(addr).await?;
+    serve_on(listener, handle).await
 }

--- a/crates/trusty-mpm/src/supervisor/http.rs
+++ b/crates/trusty-mpm/src/supervisor/http.rs
@@ -1,0 +1,104 @@
+//! Supervisor metrics HTTP server: `/metrics` and `/health`.
+//!
+//! Why: the unattended supervisor exposes fleet state so an operator or a
+//! higher-level fleet manager can poll it without attaching to any session. A
+//! tiny axum server serving a JSON snapshot satisfies the "metrics exposed on a
+//! health endpoint" acceptance criterion while keeping the surface minimal.
+//! What: holds a shared [`MetricsHandle`] (an `Arc<RwLock<FleetMetrics>>`) that
+//! the supervisor loop updates after each sweep; [`router`] builds the axum
+//! [`Router`]; [`serve`] binds and serves it. Gated behind the `daemon` feature
+//! because axum is only a dependency there (per the workspace axum-feature rule).
+//! Test: `metrics_endpoint_returns_snapshot`, `health_endpoint_ok` in `super::tests`.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{Json, Router, extract::State, routing::get};
+use serde::Serialize;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use super::metrics::FleetMetrics;
+
+/// Shared, lock-guarded fleet-metrics snapshot.
+///
+/// Why: the loop writes a fresh snapshot after each sweep while HTTP handlers read
+/// it concurrently; an `Arc<RwLock<…>>` gives many readers / one writer with no
+/// blocking on the (frequent) read path.
+/// What: a type alias for the shared handle passed to both the loop and the router.
+/// Test: exercised by `metrics_endpoint_returns_snapshot`.
+pub type MetricsHandle = Arc<RwLock<FleetMetrics>>;
+
+/// Build a fresh, empty metrics handle.
+///
+/// Why: the supervisor needs one shared snapshot created before either the loop or
+/// the server starts so both reference the same cell.
+/// What: wraps a default [`FleetMetrics`] in `Arc<RwLock<…>>`.
+/// Test: used by the loop wiring and `metrics_endpoint_returns_snapshot`.
+pub fn new_handle() -> MetricsHandle {
+    Arc::new(RwLock::new(FleetMetrics::default()))
+}
+
+/// Health-check response body.
+///
+/// Why: `/health` returns a stable, machine-checkable shape so liveness probes
+/// (launchd KeepAlive checks, monitoring) can assert `status == "ok"`.
+/// What: a one-field struct serialized as `{"status":"ok"}`.
+/// Test: `health_endpoint_ok`.
+#[derive(Debug, Serialize)]
+struct Health {
+    /// Always `"ok"` while the server is serving.
+    status: &'static str,
+}
+
+/// Build the supervisor's metrics router over a shared [`MetricsHandle`].
+///
+/// Why: separating router construction from `serve` lets tests drive the handlers
+/// in-process (via `tower::ServiceExt::oneshot`) without binding a socket.
+/// What: returns a [`Router`] with `GET /health` and `GET /metrics`, carrying the
+/// handle as axum state.
+/// Test: `metrics_endpoint_returns_snapshot`, `health_endpoint_ok`.
+pub fn router(handle: MetricsHandle) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/metrics", get(metrics))
+        .with_state(handle)
+}
+
+/// `GET /health` — liveness probe.
+///
+/// Why: an always-on supervisor needs a trivially-cheap endpoint a process
+/// supervisor can hit to confirm it is alive.
+/// What: returns `{"status":"ok"}` with a 200.
+/// Test: `health_endpoint_ok`.
+async fn health() -> Json<Health> {
+    Json(Health { status: "ok" })
+}
+
+/// `GET /metrics` — current fleet snapshot.
+///
+/// Why: the single endpoint a human / fleet manager polls to see counts by
+/// lifecycle state, surfaced pending decisions, last activity, and supervisor run
+/// stats.
+/// What: clones the current [`FleetMetrics`] out from under the read lock and
+/// returns it as JSON.
+/// Test: `metrics_endpoint_returns_snapshot`.
+async fn metrics(State(handle): State<MetricsHandle>) -> Json<FleetMetrics> {
+    let snapshot = handle.read().await.clone();
+    Json(snapshot)
+}
+
+/// Bind and serve the metrics router until the process exits.
+///
+/// Why: the supervisor runs this as a background task so fleet state is queryable
+/// for the whole unattended run.
+/// What: binds a `TcpListener` to `addr` and serves [`router`]; logs the bound
+/// address. Returns an error only if the bind or serve fails.
+/// Test: covered indirectly — handlers are unit-tested via the router; the
+/// bind/serve path mirrors the daemon's own `serve_http`.
+pub async fn serve(handle: MetricsHandle, addr: SocketAddr) -> anyhow::Result<()> {
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    info!("supervisor metrics listening on http://{addr}/metrics");
+    axum::serve(listener, router(handle)).await?;
+    Ok(())
+}

--- a/crates/trusty-mpm/src/supervisor/metrics.rs
+++ b/crates/trusty-mpm/src/supervisor/metrics.rs
@@ -1,0 +1,134 @@
+//! Fleet metrics: lifecycle-state counts, pending decisions, last-activity, run stats.
+//!
+//! Why: the whole point of an unattended supervisor is that a human (or a
+//! higher-level fleet manager) can glance at fleet state without attaching to any
+//! session. The supervisor surfaces that state over `/metrics`, so it needs a
+//! serializable snapshot type computed purely from the session records plus the
+//! supervisor's own run counters.
+//! What: defines [`FleetMetrics`] (counts by [`ManagedSessionState`], surfaced
+//! `pending_decisions`, last-activity timestamp, and cumulative supervisor run
+//! stats) and [`PendingDecision`]; [`FleetMetrics::from_records`] derives the
+//! per-state snapshot from a slice of [`SessionRecord`]s.
+//! Test: `metrics_counts_by_state`, `metrics_surfaces_pending_decisions`,
+//! `metrics_last_activity_is_max` in `super::tests`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::session_manager::{ManagedSessionState, SessionRecord};
+
+/// A pending decision surfaced (not answered) by the supervisor.
+///
+/// Why: the supervisor is a passive OBSERVER — it never auto-answers a
+/// `pending_decision`. Instead it surfaces each one so a human or fleet manager
+/// can act. This struct is the wire shape for one such surfaced decision.
+/// What: the managed session id, the human-readable tmux name, the decision text,
+/// and the harness's proposed default (if any).
+/// Test: `metrics_surfaces_pending_decisions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingDecision {
+    /// Stringified managed session id the decision belongs to.
+    pub session_id: String,
+    /// Friendly tmux name for the session (operator-facing).
+    pub tmux_name: String,
+    /// The decision question the harness is blocked on.
+    pub question: String,
+    /// The harness's proposed default answer, if it supplied one.
+    pub proposed_default: Option<String>,
+}
+
+/// Cumulative counters for the supervisor's own activity over a run.
+///
+/// Why: operators need to confirm the supervisor is actually doing work (and how
+/// much) — how many sweeps it has run, how many sessions it has auto-resumed, and
+/// how many idle sessions it has classified — to trust an unattended process.
+/// What: monotonically-increasing counters updated by the loop after each sweep.
+/// Test: `metrics_run_stats_accumulate` (driven through the loop in `super::tests`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupervisorRunStats {
+    /// Number of fleet sweeps completed since the supervisor started.
+    pub sweeps: u64,
+    /// Number of `stopped` sessions auto-resumed across all sweeps.
+    pub auto_resumed: u64,
+    /// Number of resume attempts that failed across all sweeps.
+    pub resume_failures: u64,
+    /// Number of idle `active` sessions classified across all sweeps.
+    pub classified: u64,
+}
+
+/// A serializable snapshot of fleet state for the `/metrics` endpoint.
+///
+/// Why: a single JSON object that a dashboard, `curl`, or fleet manager can poll
+/// gives full visibility into the unattended fleet — counts by lifecycle state,
+/// the decisions waiting on a human, the freshest activity, and what the
+/// supervisor itself has done.
+/// What: per-[`ManagedSessionState`] counts, the total, the surfaced
+/// `pending_decisions`, the maximum `last_activity_at` across the fleet, and the
+/// supervisor's [`SupervisorRunStats`].
+/// Test: `metrics_counts_by_state`, `metrics_surfaces_pending_decisions`,
+/// `metrics_last_activity_is_max`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetMetrics {
+    /// Sessions in `provisioning`.
+    pub provisioning: u64,
+    /// Sessions in `active`.
+    pub active: u64,
+    /// Sessions in `stopped` (resumable).
+    pub stopped: u64,
+    /// Sessions in `errored`.
+    pub errored: u64,
+    /// Sessions in `decommissioned` (tombstones).
+    pub decommissioned: u64,
+    /// Total session records (including tombstones).
+    pub total: u64,
+    /// Decisions waiting on a human, surfaced (never auto-answered).
+    pub pending_decisions: Vec<PendingDecision>,
+    /// The most recent `last_activity_at` across the whole fleet, if any.
+    pub last_activity_at: Option<DateTime<Utc>>,
+    /// The supervisor's own cumulative run statistics.
+    pub run_stats: SupervisorRunStats,
+}
+
+impl FleetMetrics {
+    /// Derive the per-state snapshot from a slice of session records.
+    ///
+    /// Why: the supervisor recomputes fleet state from the authoritative session
+    /// store on every sweep and on every `/metrics` request; this pure function
+    /// keeps that derivation in one tested place, independent of I/O.
+    /// What: tallies records by [`ManagedSessionState`], collects every record
+    /// carrying a `pending_decision` into a [`PendingDecision`], and tracks the
+    /// maximum `last_activity_at`. Leaves `run_stats` at its default — the caller
+    /// overlays the supervisor's live counters.
+    /// Test: `metrics_counts_by_state`, `metrics_surfaces_pending_decisions`,
+    /// `metrics_last_activity_is_max`.
+    pub fn from_records(records: &[SessionRecord]) -> Self {
+        let mut m = FleetMetrics {
+            total: records.len() as u64,
+            ..Default::default()
+        };
+        for r in records {
+            match r.state {
+                ManagedSessionState::Provisioning => m.provisioning += 1,
+                ManagedSessionState::Active => m.active += 1,
+                ManagedSessionState::Stopped => m.stopped += 1,
+                ManagedSessionState::Errored => m.errored += 1,
+                ManagedSessionState::Decommissioned => m.decommissioned += 1,
+            }
+            if let Some(ref question) = r.pending_decision {
+                m.pending_decisions.push(PendingDecision {
+                    session_id: r.id.to_string(),
+                    tmux_name: r.tmux_name.clone(),
+                    question: question.clone(),
+                    proposed_default: r.proposed_default.clone(),
+                });
+            }
+            if let Some(ts) = r.last_activity_at {
+                m.last_activity_at = Some(match m.last_activity_at {
+                    Some(cur) if cur >= ts => cur,
+                    _ => ts,
+                });
+            }
+        }
+        m
+    }
+}

--- a/crates/trusty-mpm/src/supervisor/mod.rs
+++ b/crates/trusty-mpm/src/supervisor/mod.rs
@@ -24,6 +24,7 @@ pub mod http;
 #[cfg(test)]
 mod tests;
 
+use std::future::Future;
 use std::sync::Arc;
 
 use tracing::{info, warn};
@@ -121,19 +122,43 @@ impl<C: LlmClassifier> Supervisor<C> {
         m
     }
 
-    /// Run the supervisor loop forever, publishing snapshots after each sweep.
+    /// Run the supervisor loop until an OS shutdown signal arrives.
     ///
     /// Why: this is the unattended heartbeat — it keeps the fleet moving (auto-
     /// resume), keeps observing (classification), and keeps the `/metrics`
-    /// snapshot fresh, with no live caller, until the process is signalled to stop.
-    /// What: on an interval timer (`cfg.interval`), runs [`Self::tick`], then
-    /// writes [`Self::snapshot`] into the shared `handle` so HTTP readers see the
-    /// latest state. The loop never returns under normal operation; a fleet sweep
-    /// that errors internally is already degraded-handled inside `run_tick`.
-    /// Test: the per-iteration behavior is tested via `tick` + `snapshot`; the
-    /// timer wrapper itself is a thin shell exercised at runtime.
+    /// snapshot fresh, with no live caller. Per the project's connection-safe
+    /// restart convention (CLAUDE.md #534) it must stop *cleanly* on SIGTERM /
+    /// Ctrl-C: never killed mid-sweep, so a `cargo install` + restart cannot
+    /// interrupt a half-applied auto-resume.
+    /// What: delegates to [`Self::run_until`] with a shutdown future that resolves
+    /// on `SIGTERM` (unix) or Ctrl-C, so the loop finishes the in-flight sweep,
+    /// emits a final tracing line, and returns `Ok(())`.
+    /// Test: the per-iteration behavior is tested via `tick` + `snapshot`; clean
+    /// shutdown is tested via `run_until` with an injected shutdown future
+    /// (`supervisor_run_until_stops_cleanly`).
     #[cfg(feature = "daemon")]
-    pub async fn run(mut self, handle: http::MetricsHandle) -> anyhow::Result<()> {
+    pub async fn run(self, handle: http::MetricsHandle) -> anyhow::Result<()> {
+        self.run_until(handle, shutdown_signal()).await
+    }
+
+    /// Run the supervisor loop until `shutdown` resolves, publishing snapshots.
+    ///
+    /// Why: a bare `loop { timer.tick().await; … }` is killed mid-sweep when the
+    /// process is signalled, which can leave an auto-resume half-applied. Selecting
+    /// the timer tick against an injectable shutdown future gives a clean stop AND
+    /// keeps the loop testable: production passes the OS-signal future, a unit test
+    /// passes a future it controls (e.g. a oneshot) to trigger a deterministic stop.
+    /// What: on an interval timer (`cfg.interval`), `select!`s the next tick against
+    /// `shutdown`. On a tick it runs [`Self::tick`] and republishes [`Self::snapshot`]
+    /// into `handle`; once `shutdown` resolves it breaks the loop *after* any
+    /// in-flight sweep completes, logs a final line, and returns `Ok(())`.
+    /// Test: `supervisor_run_until_stops_cleanly`.
+    #[cfg(feature = "daemon")]
+    pub async fn run_until(
+        mut self,
+        handle: http::MetricsHandle,
+        shutdown: impl Future<Output = ()>,
+    ) -> anyhow::Result<()> {
         info!(
             interval_secs = self.cfg.interval.as_secs(),
             auto_resume = self.cfg.auto_resume,
@@ -150,10 +175,65 @@ impl<C: LlmClassifier> Supervisor<C> {
         // Publish an initial snapshot before the first sleep so /metrics is
         // populated immediately on startup rather than after one full interval.
         *handle.write().await = self.snapshot().await;
+        // Pin the shutdown future so it can be polled across loop iterations.
+        let mut shutdown = std::pin::pin!(shutdown);
         loop {
-            timer.tick().await;
-            self.tick().await;
-            *handle.write().await = self.snapshot().await;
+            tokio::select! {
+                // Bias toward shutdown so a signal that arrives during a long
+                // interval is never starved by the timer.
+                biased;
+                () = &mut shutdown => {
+                    info!(
+                        sweeps = self.stats.sweeps,
+                        auto_resumed = self.stats.auto_resumed,
+                        "supervisor received shutdown signal; stopping cleanly"
+                    );
+                    return Ok(());
+                }
+                _ = timer.tick() => {
+                    self.tick().await;
+                    *handle.write().await = self.snapshot().await;
+                }
+            }
         }
+    }
+}
+
+/// Resolve when the process receives an OS shutdown signal (SIGTERM / Ctrl-C).
+///
+/// Why: an unattended launchd/systemd daemon is stopped with `SIGTERM`
+/// (`launchctl bootout`), and an interactive run is stopped with Ctrl-C
+/// (`SIGINT`); the supervisor must treat either as a clean-shutdown request so it
+/// never dies mid-sweep (CLAUDE.md #534).
+/// What: completes on the first of `SIGTERM` (unix only) or Ctrl-C; on a signal
+/// installation error it logs and resolves immediately (fail-stop rather than
+/// hang). Side-effect-only beyond the returned future.
+/// Test: covered indirectly — `run`'s shutdown path is unit-tested via
+/// `run_until` with an injected future, since real OS signals can't be raised
+/// deterministically in a parallel test binary.
+#[cfg(feature = "daemon")]
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            warn!("failed to listen for Ctrl-C: {e}");
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => warn!("failed to install SIGTERM handler: {e}"),
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 }

--- a/crates/trusty-mpm/src/supervisor/mod.rs
+++ b/crates/trusty-mpm/src/supervisor/mod.rs
@@ -1,0 +1,159 @@
+//! Unattended supervisor: 24/7 fleet observer + auto-resumer.
+//!
+//! Why: the session manager normally needs a live calling agentic process to keep
+//! a fleet moving. For overnight / unattended operation (#1206) we need an
+//! always-on, lightweight supervisor that auto-resumes enduring (`stopped`)
+//! sessions, observes session health without a caller, surfaces `pending_decision`s
+//! for a human, and survives reboots under launchd/systemd. It is a PASSIVE
+//! observer — it never makes autonomy decisions and never auto-answers a decision;
+//! it feeds fleet state back to a human or a higher-level fleet manager.
+//! What: re-exports the config, metrics, poller, and (feature-gated) HTTP types,
+//! and defines [`Supervisor`] — the long-running loop that, each tick, runs a
+//! fleet sweep ([`poller::run_tick`]), folds the result into [`SupervisorRunStats`],
+//! and publishes a fresh [`FleetMetrics`] snapshot for the `/metrics` endpoint.
+//! Test: `super::tests` covers config parsing, metrics derivation, the per-tick
+//! sweep (including an N-session fleet), and the HTTP handlers.
+
+pub mod config;
+pub mod metrics;
+pub mod poller;
+
+#[cfg(feature = "daemon")]
+pub mod http;
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use crate::activity::monitor::{ActivityMonitor, LlmClassifier};
+use crate::session_manager::SessionManager;
+
+pub use config::SupervisorConfig;
+pub use metrics::{FleetMetrics, PendingDecision, SupervisorRunStats};
+pub use poller::{TickReport, run_tick};
+
+#[cfg(feature = "daemon")]
+pub use http::{MetricsHandle, new_handle};
+
+/// The unattended fleet supervisor.
+///
+/// Why: bundling the session manager handle, the config, an optional activity
+/// classifier, and the live run stats into one struct gives the loop a single
+/// owner and makes the supervisor straightforward to construct and test.
+/// What: holds an `Arc<SessionManager>`, an immutable [`SupervisorConfig`], an
+/// optional [`ActivityMonitor`] (classification is skipped when `None` or when
+/// `cfg.classify_idle` is false), and the accumulating [`SupervisorRunStats`].
+/// Test: `supervisor_tick_updates_stats`, `supervisor_snapshot_reflects_fleet`.
+pub struct Supervisor<C: LlmClassifier> {
+    /// The session manager whose fleet this supervisor watches.
+    mgr: Arc<SessionManager>,
+    /// Immutable run configuration (cadence + policy).
+    cfg: SupervisorConfig,
+    /// Optional activity classifier for idle `active` sessions.
+    monitor: Option<ActivityMonitor<C>>,
+    /// Cumulative counters across every sweep this run.
+    stats: SupervisorRunStats,
+}
+
+impl<C: LlmClassifier> Supervisor<C> {
+    /// Construct a supervisor over a session manager and config.
+    ///
+    /// Why: callers wire the supervisor with whatever classifier they have (a real
+    /// `OpenRouterClassifier` in production, a mock in tests, or `None` to skip
+    /// classification); dependency injection keeps the loop testable offline.
+    /// What: stores the handles and zeroes the run stats.
+    /// Test: every `supervisor_*` test constructs via this.
+    pub fn new(
+        mgr: Arc<SessionManager>,
+        cfg: SupervisorConfig,
+        monitor: Option<ActivityMonitor<C>>,
+    ) -> Self {
+        Self {
+            mgr,
+            cfg,
+            monitor,
+            stats: SupervisorRunStats::default(),
+        }
+    }
+
+    /// Borrow the current cumulative run stats.
+    ///
+    /// Why: tests and the metrics snapshot need read access to the counters the
+    /// loop maintains.
+    /// What: returns a reference to the live [`SupervisorRunStats`].
+    /// Test: `supervisor_tick_updates_stats`.
+    pub fn stats(&self) -> &SupervisorRunStats {
+        &self.stats
+    }
+
+    /// Run one sweep and fold the result into the cumulative run stats.
+    ///
+    /// Why: the timer loop and the tests both need "do exactly one sweep and
+    /// update stats" as an atomic step; exposing it separately keeps the loop a
+    /// trivial timer wrapper and lets tests advance the supervisor deterministically.
+    /// What: calls [`poller::run_tick`], increments `sweeps`, and adds the tick's
+    /// resumed / failure / classified counts into `self.stats`; returns the
+    /// [`TickReport`] for the caller to inspect.
+    /// Test: `supervisor_tick_updates_stats`, `supervisor_fleet_resume_e2e`.
+    pub async fn tick(&mut self) -> TickReport {
+        let report = run_tick(&self.mgr, &self.cfg, self.monitor.as_ref()).await;
+        self.stats.sweeps += 1;
+        self.stats.auto_resumed += report.resumed.len() as u64;
+        self.stats.resume_failures += report.resume_failures as u64;
+        self.stats.classified += report.classified as u64;
+        report
+    }
+
+    /// Compute a fresh fleet-metrics snapshot overlaid with current run stats.
+    ///
+    /// Why: the `/metrics` endpoint must reflect both the authoritative session
+    /// store AND what the supervisor itself has done; this composes the two.
+    /// What: derives [`FleetMetrics::from_records`] from `mgr.list()` and copies the
+    /// live `run_stats` in.
+    /// Test: `supervisor_snapshot_reflects_fleet`.
+    pub async fn snapshot(&self) -> FleetMetrics {
+        let records = self.mgr.list().await;
+        let mut m = FleetMetrics::from_records(&records);
+        m.run_stats = self.stats.clone();
+        m
+    }
+
+    /// Run the supervisor loop forever, publishing snapshots after each sweep.
+    ///
+    /// Why: this is the unattended heartbeat — it keeps the fleet moving (auto-
+    /// resume), keeps observing (classification), and keeps the `/metrics`
+    /// snapshot fresh, with no live caller, until the process is signalled to stop.
+    /// What: on an interval timer (`cfg.interval`), runs [`Self::tick`], then
+    /// writes [`Self::snapshot`] into the shared `handle` so HTTP readers see the
+    /// latest state. The loop never returns under normal operation; a fleet sweep
+    /// that errors internally is already degraded-handled inside `run_tick`.
+    /// Test: the per-iteration behavior is tested via `tick` + `snapshot`; the
+    /// timer wrapper itself is a thin shell exercised at runtime.
+    #[cfg(feature = "daemon")]
+    pub async fn run(mut self, handle: http::MetricsHandle) -> anyhow::Result<()> {
+        info!(
+            interval_secs = self.cfg.interval.as_secs(),
+            auto_resume = self.cfg.auto_resume,
+            classify_idle = self.cfg.classify_idle,
+            "supervisor loop starting"
+        );
+        if !self.cfg.auto_resume {
+            warn!(
+                "supervisor: auto-resume DISABLED ({}=1 to enable); running as observe-only",
+                config::ENV_AUTO_RESUME
+            );
+        }
+        let mut timer = tokio::time::interval(self.cfg.interval);
+        // Publish an initial snapshot before the first sleep so /metrics is
+        // populated immediately on startup rather than after one full interval.
+        *handle.write().await = self.snapshot().await;
+        loop {
+            timer.tick().await;
+            self.tick().await;
+            *handle.write().await = self.snapshot().await;
+        }
+    }
+}

--- a/crates/trusty-mpm/src/supervisor/poller.rs
+++ b/crates/trusty-mpm/src/supervisor/poller.rs
@@ -1,0 +1,151 @@
+//! One fleet sweep: detect `stopped` → auto-resume, classify idle `active` sessions.
+//!
+//! Why: the supervisor's behavior per tick must be a single, testable unit so we
+//! can assert "N stopped sessions get resumed" without spinning real timers. This
+//! module is that unit — a pure-ish async function over the [`SessionManager`] and
+//! an optional classifier, returning a [`TickReport`] of what it did.
+//! What: defines [`TickReport`] and [`run_tick`], which (1) lists all sessions,
+//! (2) auto-resumes every `stopped` session when `auto_resume` is set, and (3)
+//! classifies idle `active` sessions through the activity monitor when a
+//! classifier is supplied. It is a passive observer: it never answers a
+//! `pending_decision`.
+//! Test: `tick_auto_resumes_stopped`, `tick_skips_resume_when_disabled`,
+//! `tick_fleet_of_n_resumed`, `tick_classifies_active`,
+//! `tick_never_answers_pending_decision` in `super::tests`.
+
+use std::sync::Arc;
+
+use tracing::{debug, info, warn};
+
+use crate::activity::monitor::{ActivityMonitor, LlmClassifier};
+use crate::session_manager::{ManagedSessionState, SessionManager};
+
+use super::config::SupervisorConfig;
+
+/// What a single fleet sweep observed and changed.
+///
+/// Why: the loop accumulates these into the supervisor's run stats, and tests
+/// assert on them directly; returning a struct (rather than mutating shared
+/// state) keeps [`run_tick`] easy to reason about and verify.
+/// What: counts of sessions seen, resumed, resume-failures, and classified, plus
+/// the ids that were resumed (for logging / assertions).
+/// Test: returned and asserted by every `tick_*` test.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TickReport {
+    /// Total session records observed this sweep.
+    pub observed: usize,
+    /// Stringified ids of sessions auto-resumed this sweep.
+    pub resumed: Vec<String>,
+    /// Number of resume attempts that failed this sweep.
+    pub resume_failures: usize,
+    /// Number of idle `active` sessions classified this sweep.
+    pub classified: usize,
+}
+
+/// Run a single fleet sweep against the session manager.
+///
+/// Why: this is the supervisor's heartbeat. Factoring it out of the timer loop
+/// makes the consequential logic (auto-resume gating, classification) unit-
+/// testable with a [`crate::session_manager::tests`]-style fake tmux driver and a
+/// mock classifier, with zero real time elapsed.
+/// What: lists all sessions via `mgr.list()`; for each `Stopped` session, resumes
+/// it when `cfg.auto_resume` is true (counting successes / failures); for each
+/// `Active` session, classifies its pane through `monitor` when `cfg.classify_idle`
+/// is true and a `monitor` is supplied. Never touches `pending_decision` — the
+/// supervisor surfaces decisions via metrics but never answers them. Returns a
+/// [`TickReport`].
+/// Test: `tick_auto_resumes_stopped`, `tick_skips_resume_when_disabled`,
+/// `tick_fleet_of_n_resumed`, `tick_classifies_active`,
+/// `tick_never_answers_pending_decision`.
+pub async fn run_tick<C: LlmClassifier>(
+    mgr: &Arc<SessionManager>,
+    cfg: &SupervisorConfig,
+    monitor: Option<&ActivityMonitor<C>>,
+) -> TickReport {
+    let records = mgr.list().await;
+    let mut report = TickReport {
+        observed: records.len(),
+        ..Default::default()
+    };
+
+    for record in records {
+        match record.state {
+            ManagedSessionState::Stopped if cfg.auto_resume => match mgr.resume(&record.id).await {
+                Ok(_) => {
+                    info!(
+                        id = %record.id,
+                        name = %record.tmux_name,
+                        "supervisor: auto-resumed stopped session"
+                    );
+                    report.resumed.push(record.id.to_string());
+                }
+                Err(e) => {
+                    warn!(
+                        id = %record.id,
+                        name = %record.tmux_name,
+                        "supervisor: auto-resume failed: {e}"
+                    );
+                    report.resume_failures += 1;
+                }
+            },
+            ManagedSessionState::Active if cfg.classify_idle => {
+                if let Some(monitor) = monitor
+                    && classify_active(mgr, monitor, &record.id, &record.tmux_name).await
+                {
+                    report.classified += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    debug!(
+        observed = report.observed,
+        resumed = report.resumed.len(),
+        resume_failures = report.resume_failures,
+        classified = report.classified,
+        "supervisor: sweep complete"
+    );
+    report
+}
+
+/// Classify one active session's pane through the activity monitor.
+///
+/// Why: keeping the capture+classify+log sequence in a helper keeps [`run_tick`]
+/// readable and lets the error paths (no pane, classifier failure) degrade
+/// quietly without aborting the whole sweep — an unattended supervisor must never
+/// die because one session's tmux pane was momentarily unreadable.
+/// What: captures the last 60 pane lines, runs `monitor.check`, logs the verdict
+/// at debug, and returns `true` iff a classification was produced (cache hit or
+/// fresh LLM verdict). Capture / classify errors log a warning and return `false`.
+/// Test: `tick_classifies_active` (via `run_tick`).
+async fn classify_active<C: LlmClassifier>(
+    mgr: &Arc<SessionManager>,
+    monitor: &ActivityMonitor<C>,
+    id: &crate::session_manager::ManagedSessionId,
+    tmux_name: &str,
+) -> bool {
+    let pane = match mgr.capture_pane(id, 60).await {
+        Ok(text) => text,
+        Err(e) => {
+            warn!(id = %id, name = %tmux_name, "supervisor: pane capture failed: {e}");
+            return false;
+        }
+    };
+    match monitor.check(&id.to_string(), &pane).await {
+        Ok(result) => {
+            debug!(
+                id = %id,
+                name = %tmux_name,
+                state = ?result.verdict.state,
+                cache_hit = result.cache_hit,
+                "supervisor: classified idle session"
+            );
+            true
+        }
+        Err(e) => {
+            warn!(id = %id, name = %tmux_name, "supervisor: classification failed: {e}");
+            false
+        }
+    }
+}

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -170,6 +170,7 @@ async fn seed_sessions(
             pending_decision: None,
             proposed_default: None,
             correlation: Default::default(),
+            runtime: Default::default(),
         };
         store.upsert(rec).await.expect("seed upsert");
         ids.push(id);
@@ -180,6 +181,24 @@ async fn seed_sessions(
 
 // ── Config tests ─────────────────────────────────────────────────────────────
 
+/// Build an env resolver over a fixed `(key, value)` map.
+///
+/// Why: the `*_env_parsing` tests must exercise `SupervisorConfig::from_env_with`
+/// with deterministic input and NO process-wide mutation, so they cannot flake
+/// when the test runner schedules them on parallel threads. A closure over a local
+/// `HashMap` is the injectable fake env.
+/// What: returns an `impl Fn(&str) -> Option<String>` that looks each key up in the
+/// supplied pairs, mirroring `std::env::var(key).ok()`.
+/// Test: used by `auto_resume_env_parsing`, `interval_env_parsing`,
+/// `classify_idle_env_parsing`, `metrics_addr_env_parsing`.
+fn fake_env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+    let map: HashMap<String, String> = pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+        .collect();
+    move |key: &str| map.get(key).cloned()
+}
+
 #[test]
 fn config_defaults() {
     let c = SupervisorConfig::default();
@@ -187,53 +206,67 @@ fn config_defaults() {
     assert!(!c.auto_resume);
     assert!(c.classify_idle);
     assert_eq!(c.metrics_addr.to_string(), "127.0.0.1:7881");
+    // An empty injected env yields the same defaults (no process env touched).
+    let from_empty = SupervisorConfig::from_env_with(fake_env(&[]));
+    assert_eq!(from_empty, c);
 }
 
 #[test]
 fn auto_resume_env_parsing() {
-    // SAFETY: single-threaded test; we restore by removing afterward. Env-var
-    // tests in this crate already use this pattern (see activity monitor tests).
-    unsafe { std::env::set_var(ENV_AUTO_RESUME, "true") };
-    assert!(SupervisorConfig::from_env().auto_resume);
-    unsafe { std::env::set_var(ENV_AUTO_RESUME, "0") };
-    assert!(!SupervisorConfig::from_env().auto_resume);
-    unsafe { std::env::remove_var(ENV_AUTO_RESUME) };
+    // Injected env — no std::env::set_var, so this is parallel-safe.
+    let on = SupervisorConfig::from_env_with(fake_env(&[(ENV_AUTO_RESUME, "true")]));
+    assert!(on.auto_resume);
+    let off = SupervisorConfig::from_env_with(fake_env(&[(ENV_AUTO_RESUME, "0")]));
+    assert!(!off.auto_resume);
+    // Absent → default (off).
+    let unset = SupervisorConfig::from_env_with(fake_env(&[]));
+    assert!(!unset.auto_resume);
 }
 
 #[test]
 fn interval_env_parsing() {
-    unsafe { std::env::set_var(ENV_INTERVAL_SECS, "5") };
-    assert_eq!(SupervisorConfig::from_env().interval.as_secs(), 5);
+    let five = SupervisorConfig::from_env_with(fake_env(&[(ENV_INTERVAL_SECS, "5")]));
+    assert_eq!(five.interval.as_secs(), 5);
     // Zero is rejected (falls back to default), as is garbage.
-    unsafe { std::env::set_var(ENV_INTERVAL_SECS, "0") };
-    assert_eq!(SupervisorConfig::from_env().interval.as_secs(), 30);
-    unsafe { std::env::set_var(ENV_INTERVAL_SECS, "notanumber") };
-    assert_eq!(SupervisorConfig::from_env().interval.as_secs(), 30);
-    unsafe { std::env::remove_var(ENV_INTERVAL_SECS) };
+    let zero = SupervisorConfig::from_env_with(fake_env(&[(ENV_INTERVAL_SECS, "0")]));
+    assert_eq!(zero.interval.as_secs(), 30);
+    let garbage = SupervisorConfig::from_env_with(fake_env(&[(ENV_INTERVAL_SECS, "notanumber")]));
+    assert_eq!(garbage.interval.as_secs(), 30);
 }
 
 #[test]
 fn classify_idle_env_parsing() {
-    unsafe { std::env::set_var(ENV_CLASSIFY_IDLE, "off") };
-    assert!(!SupervisorConfig::from_env().classify_idle);
-    unsafe { std::env::remove_var(ENV_CLASSIFY_IDLE) };
+    let off = SupervisorConfig::from_env_with(fake_env(&[(ENV_CLASSIFY_IDLE, "off")]));
+    assert!(!off.classify_idle);
     // Unset → default (enabled).
-    assert!(SupervisorConfig::from_env().classify_idle);
+    let unset = SupervisorConfig::from_env_with(fake_env(&[]));
+    assert!(unset.classify_idle);
 }
 
 #[test]
 fn metrics_addr_env_parsing() {
-    unsafe { std::env::set_var(ENV_METRICS_ADDR, "127.0.0.1:9999") };
-    assert_eq!(
-        SupervisorConfig::from_env().metrics_addr.to_string(),
-        "127.0.0.1:9999"
-    );
-    unsafe { std::env::set_var(ENV_METRICS_ADDR, "garbage") };
-    assert_eq!(
-        SupervisorConfig::from_env().metrics_addr.to_string(),
-        "127.0.0.1:7881"
-    );
-    unsafe { std::env::remove_var(ENV_METRICS_ADDR) };
+    let custom = SupervisorConfig::from_env_with(fake_env(&[(ENV_METRICS_ADDR, "127.0.0.1:9999")]));
+    assert_eq!(custom.metrics_addr.to_string(), "127.0.0.1:9999");
+    // Garbage falls back to the default address.
+    let garbage = SupervisorConfig::from_env_with(fake_env(&[(ENV_METRICS_ADDR, "garbage")]));
+    assert_eq!(garbage.metrics_addr.to_string(), "127.0.0.1:7881");
+}
+
+#[test]
+fn env_bool_recognizes_truthy_and_falsy() {
+    // Every documented truthy spelling enables auto-resume…
+    for truthy in ["1", "true", "yes", "on", "TRUE", " On "] {
+        let c = SupervisorConfig::from_env_with(fake_env(&[(ENV_AUTO_RESUME, truthy)]));
+        assert!(c.auto_resume, "{truthy:?} should be truthy");
+    }
+    // …and every falsy spelling keeps it off.
+    for falsy in ["0", "false", "no", "off", "FALSE"] {
+        let c = SupervisorConfig::from_env_with(fake_env(&[(ENV_AUTO_RESUME, falsy)]));
+        assert!(!c.auto_resume, "{falsy:?} should be falsy");
+    }
+    // Unrecognized spelling → fall back to the default (off).
+    let unknown = SupervisorConfig::from_env_with(fake_env(&[(ENV_AUTO_RESUME, "maybe")]));
+    assert!(!unknown.auto_resume);
 }
 
 // ── Metrics tests ────────────────────────────────────────────────────────────
@@ -253,6 +286,7 @@ fn rec(state: ManagedSessionState, pending: Option<&str>) -> SessionRecord {
         pending_decision: pending.map(|s| s.to_owned()),
         proposed_default: None,
         correlation: Default::default(),
+        runtime: Default::default(),
     }
 }
 
@@ -504,6 +538,50 @@ mod http_tests {
             .unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn supervisor_run_until_stops_cleanly() {
+        // The loop must finish cleanly when its injected shutdown future resolves,
+        // having published at least the initial snapshot — never killed mid-sweep.
+        let dir = TempDir::new().unwrap();
+        let ws = TempDir::new().unwrap();
+        let tmux = FakeTmux::new();
+        let mgr = make_manager(&dir, tmux.clone()).await;
+        seed_sessions(&mgr, 2, ManagedSessionState::Stopped, &ws).await;
+
+        // A long interval guarantees the loop is parked on the timer when the
+        // shutdown signal fires, exercising the biased select's shutdown arm.
+        let cfg = SupervisorConfig {
+            interval: std::time::Duration::from_secs(3600),
+            auto_resume: true,
+            classify_idle: false,
+            ..SupervisorConfig::default()
+        };
+        let sup: Supervisor<StubClassifier> = Supervisor::new(mgr, cfg, None);
+
+        let handle = http::new_handle();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        // Fire shutdown almost immediately; the loop should observe it and return.
+        tokio::spawn(async move {
+            let _ = tx.send(());
+        });
+        let shutdown = async move {
+            let _ = rx.await;
+        };
+
+        // Bound the test so a regression (loop ignoring shutdown) fails fast
+        // instead of hanging the suite.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            sup.run_until(handle.clone(), shutdown),
+        )
+        .await
+        .expect("run_until must return promptly after shutdown");
+        result.expect("clean shutdown returns Ok");
+
+        // The initial snapshot was published before the loop parked on the timer.
+        assert_eq!(handle.read().await.stopped, 2);
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -1,0 +1,539 @@
+//! Unit + integration tests for the unattended supervisor.
+//!
+//! Why: the supervisor is a long-running unattended process; its consequential
+//! behavior (auto-resume gating, the N-session fleet sweep, metrics derivation,
+//! HTTP handlers) must be proven offline — no real timers, tmux, or LLM. A
+//! separate test file also keeps the production modules under the 500 SLOC cap.
+//! What: a self-contained `FakeTmux` driver and a `StubClassifier`, plus tests
+//! for config env parsing, [`FleetMetrics`] derivation, per-tick sweeps, the
+//! N-session fleet auto-resume (the #1206 acceptance criterion), the
+//! never-answer-pending-decision invariant, and the `/metrics` + `/health` routes.
+//! Test: this file IS the test module; run `cargo test -p trusty-mpm`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+use tempfile::TempDir;
+
+use crate::activity::cache::{ActivityState, ActivityVerdict};
+use crate::activity::monitor::{ActivityError, ActivityMonitor, LlmClassifier};
+use crate::session_manager::{
+    ManagedError, ManagedSessionId, ManagedSessionState, ManagedTmuxDriver, SessionManager,
+    SessionRecord,
+};
+
+use super::Supervisor;
+use super::config::{
+    ENV_AUTO_RESUME, ENV_CLASSIFY_IDLE, ENV_INTERVAL_SECS, ENV_METRICS_ADDR, SupervisorConfig,
+};
+use super::metrics::FleetMetrics;
+use super::poller::run_tick;
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+/// A minimal fake tmux driver for supervisor tests.
+///
+/// Why: the session manager needs a `ManagedTmuxDriver` to operate, but the
+/// supervisor tests must run with no real tmux; this records the calls the
+/// supervisor causes (kills + creates during resume) so tests can assert resume
+/// actually re-spawned a tmux session.
+/// What: tracks created sessions in a map and counts create/kill calls.
+/// Test: used by every supervisor test that builds a `SessionManager`.
+struct FakeTmux {
+    sessions: Mutex<HashMap<String, String>>,
+    create_calls: Mutex<u32>,
+    kill_calls: Mutex<u32>,
+}
+
+impl FakeTmux {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            sessions: Mutex::new(HashMap::new()),
+            create_calls: Mutex::new(0),
+            kill_calls: Mutex::new(0),
+        })
+    }
+}
+
+impl ManagedTmuxDriver for FakeTmux {
+    fn create_session(&self, name: &str, workdir: &str) -> Result<(), ManagedError> {
+        *self.create_calls.lock().expect("lock") += 1;
+        self.sessions
+            .lock()
+            .expect("lock")
+            .insert(name.to_owned(), workdir.to_owned());
+        Ok(())
+    }
+
+    fn kill_session(&self, name: &str) -> Result<(), ManagedError> {
+        *self.kill_calls.lock().expect("lock") += 1;
+        self.sessions.lock().expect("lock").remove(name);
+        Ok(())
+    }
+
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+        Ok("working on the task...\n$ cargo test".to_owned())
+    }
+
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        Ok(self
+            .sessions
+            .lock()
+            .expect("lock")
+            .keys()
+            .cloned()
+            .collect())
+    }
+}
+
+/// A stub LLM classifier that never touches the network.
+///
+/// Why: idle-session classification must be testable without an API key; this
+/// returns a fixed verdict and counts calls so tests can assert classification ran.
+/// What: implements [`LlmClassifier::classify`] returning a constant `Working`
+/// verdict and bumping a call counter.
+/// Test: `tick_classifies_active`.
+struct StubClassifier;
+
+impl StubClassifier {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl LlmClassifier for StubClassifier {
+    async fn classify(
+        &self,
+        _pane_text: &str,
+    ) -> Result<(ActivityVerdict, u32, u32), ActivityError> {
+        Ok((
+            ActivityVerdict {
+                state: ActivityState::Working,
+                summary: "stub".into(),
+                confidence: 1.0,
+            },
+            10,
+            2,
+        ))
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Build a session manager backed by a fake tmux driver under a temp dir.
+async fn make_manager(dir: &TempDir, tmux: Arc<FakeTmux>) -> Arc<SessionManager> {
+    Arc::new(
+        SessionManager::new(dir.path(), tmux)
+            .await
+            .expect("session manager"),
+    )
+}
+
+/// Build a `SupervisorConfig` with auto-resume on and classification off.
+fn resume_cfg() -> SupervisorConfig {
+    SupervisorConfig {
+        auto_resume: true,
+        classify_idle: false,
+        ..SupervisorConfig::default()
+    }
+}
+
+/// Seed `n` records directly into the store in a given state, with a workspace
+/// so `resume` has a directory to re-spawn into.
+async fn seed_sessions(
+    mgr: &Arc<SessionManager>,
+    n: usize,
+    state: ManagedSessionState,
+    ws: &TempDir,
+) -> Vec<ManagedSessionId> {
+    let mut ids = Vec::new();
+    let mut store = mgr.store.write().await;
+    for i in 0..n {
+        let id = ManagedSessionId::new();
+        let rec = SessionRecord {
+            id,
+            tmux_name: format!("tmpm-fleet-{i}"),
+            cwd: ws.path().to_path_buf(),
+            task: format!("fleet task {i}"),
+            state: state.clone(),
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: Some(ws.path().to_path_buf()),
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+        };
+        store.upsert(rec).await.expect("seed upsert");
+        ids.push(id);
+    }
+    drop(store);
+    ids
+}
+
+// ── Config tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn config_defaults() {
+    let c = SupervisorConfig::default();
+    assert_eq!(c.interval.as_secs(), 30);
+    assert!(!c.auto_resume);
+    assert!(c.classify_idle);
+    assert_eq!(c.metrics_addr.to_string(), "127.0.0.1:7881");
+}
+
+#[test]
+fn auto_resume_env_parsing() {
+    // SAFETY: single-threaded test; we restore by removing afterward. Env-var
+    // tests in this crate already use this pattern (see activity monitor tests).
+    unsafe { std::env::set_var(ENV_AUTO_RESUME, "true") };
+    assert!(SupervisorConfig::from_env().auto_resume);
+    unsafe { std::env::set_var(ENV_AUTO_RESUME, "0") };
+    assert!(!SupervisorConfig::from_env().auto_resume);
+    unsafe { std::env::remove_var(ENV_AUTO_RESUME) };
+}
+
+#[test]
+fn interval_env_parsing() {
+    unsafe { std::env::set_var(ENV_INTERVAL_SECS, "5") };
+    assert_eq!(SupervisorConfig::from_env().interval.as_secs(), 5);
+    // Zero is rejected (falls back to default), as is garbage.
+    unsafe { std::env::set_var(ENV_INTERVAL_SECS, "0") };
+    assert_eq!(SupervisorConfig::from_env().interval.as_secs(), 30);
+    unsafe { std::env::set_var(ENV_INTERVAL_SECS, "notanumber") };
+    assert_eq!(SupervisorConfig::from_env().interval.as_secs(), 30);
+    unsafe { std::env::remove_var(ENV_INTERVAL_SECS) };
+}
+
+#[test]
+fn classify_idle_env_parsing() {
+    unsafe { std::env::set_var(ENV_CLASSIFY_IDLE, "off") };
+    assert!(!SupervisorConfig::from_env().classify_idle);
+    unsafe { std::env::remove_var(ENV_CLASSIFY_IDLE) };
+    // Unset → default (enabled).
+    assert!(SupervisorConfig::from_env().classify_idle);
+}
+
+#[test]
+fn metrics_addr_env_parsing() {
+    unsafe { std::env::set_var(ENV_METRICS_ADDR, "127.0.0.1:9999") };
+    assert_eq!(
+        SupervisorConfig::from_env().metrics_addr.to_string(),
+        "127.0.0.1:9999"
+    );
+    unsafe { std::env::set_var(ENV_METRICS_ADDR, "garbage") };
+    assert_eq!(
+        SupervisorConfig::from_env().metrics_addr.to_string(),
+        "127.0.0.1:7881"
+    );
+    unsafe { std::env::remove_var(ENV_METRICS_ADDR) };
+}
+
+// ── Metrics tests ────────────────────────────────────────────────────────────
+
+fn rec(state: ManagedSessionState, pending: Option<&str>) -> SessionRecord {
+    SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: "tmpm-x".into(),
+        cwd: PathBuf::from("/tmp"),
+        task: "t".into(),
+        state,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: None,
+        repo_url: None,
+        branch: None,
+        pending_decision: pending.map(|s| s.to_owned()),
+        proposed_default: None,
+        correlation: Default::default(),
+    }
+}
+
+#[test]
+fn metrics_counts_by_state() {
+    let records = vec![
+        rec(ManagedSessionState::Active, None),
+        rec(ManagedSessionState::Active, None),
+        rec(ManagedSessionState::Stopped, None),
+        rec(ManagedSessionState::Errored, None),
+        rec(ManagedSessionState::Decommissioned, None),
+        rec(ManagedSessionState::Provisioning, None),
+    ];
+    let m = FleetMetrics::from_records(&records);
+    assert_eq!(m.active, 2);
+    assert_eq!(m.stopped, 1);
+    assert_eq!(m.errored, 1);
+    assert_eq!(m.decommissioned, 1);
+    assert_eq!(m.provisioning, 1);
+    assert_eq!(m.total, 6);
+}
+
+#[test]
+fn metrics_surfaces_pending_decisions() {
+    let records = vec![
+        rec(ManagedSessionState::Active, Some("Merge PR #42?")),
+        rec(ManagedSessionState::Active, None),
+    ];
+    let m = FleetMetrics::from_records(&records);
+    assert_eq!(m.pending_decisions.len(), 1);
+    assert_eq!(m.pending_decisions[0].question, "Merge PR #42?");
+}
+
+#[test]
+fn metrics_last_activity_is_max() {
+    let early = Utc::now() - chrono::Duration::hours(2);
+    let late = Utc::now();
+    let mut r1 = rec(ManagedSessionState::Active, None);
+    r1.last_activity_at = Some(early);
+    let mut r2 = rec(ManagedSessionState::Active, None);
+    r2.last_activity_at = Some(late);
+    let m = FleetMetrics::from_records(&[r1, r2]);
+    assert_eq!(m.last_activity_at, Some(late));
+}
+
+// ── Tick / sweep tests ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tick_auto_resumes_stopped() {
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    seed_sessions(&mgr, 1, ManagedSessionState::Stopped, &ws).await;
+
+    let report = run_tick::<StubClassifier>(&mgr, &resume_cfg(), None).await;
+    assert_eq!(report.resumed.len(), 1);
+    assert_eq!(report.resume_failures, 0);
+
+    // The session is now Active and tmux create was called.
+    let after = mgr.list().await;
+    assert_eq!(after[0].state, ManagedSessionState::Active);
+    assert_eq!(*tmux.create_calls.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn tick_skips_resume_when_disabled() {
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    seed_sessions(&mgr, 3, ManagedSessionState::Stopped, &ws).await;
+
+    let cfg = SupervisorConfig {
+        auto_resume: false,
+        classify_idle: false,
+        ..SupervisorConfig::default()
+    };
+    let report = run_tick::<StubClassifier>(&mgr, &cfg, None).await;
+    assert!(report.resumed.is_empty());
+    // Still stopped — observer mode did not resume.
+    assert!(
+        mgr.list()
+            .await
+            .iter()
+            .all(|r| r.state == ManagedSessionState::Stopped)
+    );
+}
+
+#[tokio::test]
+async fn tick_fleet_of_n_resumed() {
+    // The #1206 acceptance criterion: a fleet of N stopped sessions is
+    // auto-resumed unattended in a single sweep.
+    const N: usize = 12;
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    seed_sessions(&mgr, N, ManagedSessionState::Stopped, &ws).await;
+
+    let report = run_tick::<StubClassifier>(&mgr, &resume_cfg(), None).await;
+    assert_eq!(report.observed, N);
+    assert_eq!(report.resumed.len(), N);
+    assert_eq!(report.resume_failures, 0);
+
+    let after = mgr.list().await;
+    assert_eq!(after.len(), N);
+    assert!(after.iter().all(|r| r.state == ManagedSessionState::Active));
+    assert_eq!(*tmux.create_calls.lock().unwrap(), N as u32);
+}
+
+#[tokio::test]
+async fn tick_classifies_active() {
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    seed_sessions(&mgr, 2, ManagedSessionState::Active, &ws).await;
+
+    let monitor = ActivityMonitor::new(StubClassifier::new(), "test-model");
+    let cfg = SupervisorConfig {
+        auto_resume: false,
+        classify_idle: true,
+        ..SupervisorConfig::default()
+    };
+    let report = run_tick(&mgr, &cfg, Some(&monitor)).await;
+    assert_eq!(report.classified, 2);
+}
+
+#[tokio::test]
+async fn tick_never_answers_pending_decision() {
+    // The supervisor is a passive observer: a session blocked on a decision is
+    // NOT auto-answered. After a sweep the pending_decision must be intact.
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    let ids = seed_sessions(&mgr, 1, ManagedSessionState::Active, &ws).await;
+    {
+        let mut store = mgr.store.write().await;
+        let mut r = store.get(&ids[0]).expect("get");
+        r.pending_decision = Some("Force-push to main?".into());
+        store.upsert(r).await.expect("upsert");
+    }
+
+    let monitor = ActivityMonitor::new(StubClassifier::new(), "test-model");
+    let cfg = SupervisorConfig {
+        auto_resume: true,
+        classify_idle: true,
+        ..SupervisorConfig::default()
+    };
+    run_tick(&mgr, &cfg, Some(&monitor)).await;
+
+    let after = mgr.list().await;
+    assert_eq!(
+        after[0].pending_decision.as_deref(),
+        Some("Force-push to main?"),
+        "supervisor must never answer or clear a pending decision"
+    );
+}
+
+// ── Supervisor struct tests ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn supervisor_tick_updates_stats() {
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    seed_sessions(&mgr, 4, ManagedSessionState::Stopped, &ws).await;
+
+    let mut sup: Supervisor<StubClassifier> = Supervisor::new(mgr, resume_cfg(), None);
+    sup.tick().await;
+    assert_eq!(sup.stats().sweeps, 1);
+    assert_eq!(sup.stats().auto_resumed, 4);
+    // A second sweep finds them all Active now → no more resumes.
+    sup.tick().await;
+    assert_eq!(sup.stats().sweeps, 2);
+    assert_eq!(sup.stats().auto_resumed, 4);
+}
+
+#[tokio::test]
+async fn supervisor_snapshot_reflects_fleet() {
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    seed_sessions(&mgr, 3, ManagedSessionState::Stopped, &ws).await;
+
+    let mut sup: Supervisor<StubClassifier> = Supervisor::new(mgr, resume_cfg(), None);
+    let before = sup.snapshot().await;
+    assert_eq!(before.stopped, 3);
+    assert_eq!(before.active, 0);
+
+    sup.tick().await;
+    let after = sup.snapshot().await;
+    assert_eq!(after.stopped, 0);
+    assert_eq!(after.active, 3);
+    assert_eq!(after.run_stats.auto_resumed, 3);
+}
+
+#[tokio::test]
+async fn supervisor_classifier_invoked_on_active() {
+    // Confirm the supervisor actually drives the classifier on active sessions.
+    let dir = TempDir::new().unwrap();
+    let ws = TempDir::new().unwrap();
+    let tmux = FakeTmux::new();
+    let mgr = make_manager(&dir, tmux.clone()).await;
+    seed_sessions(&mgr, 2, ManagedSessionState::Active, &ws).await;
+
+    let monitor = ActivityMonitor::new(StubClassifier::new(), "test-model");
+    let cfg = SupervisorConfig {
+        auto_resume: false,
+        classify_idle: true,
+        ..SupervisorConfig::default()
+    };
+    let mut sup = Supervisor::new(mgr, cfg, Some(monitor));
+    let report = sup.tick().await;
+    assert_eq!(report.classified, 2);
+    assert_eq!(sup.stats().classified, 2);
+}
+
+// ── HTTP tests (daemon feature) ──────────────────────────────────────────────
+
+#[cfg(feature = "daemon")]
+mod http_tests {
+    use super::*;
+    use crate::supervisor::http;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt as _;
+
+    #[tokio::test]
+    async fn health_endpoint_ok() {
+        let handle = http::new_handle();
+        let app = http::router(handle);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_returns_snapshot() {
+        let handle = http::new_handle();
+        // Seed the shared snapshot as the loop would.
+        {
+            let records = vec![
+                rec(ManagedSessionState::Active, None),
+                rec(ManagedSessionState::Stopped, None),
+            ];
+            *handle.write().await = FleetMetrics::from_records(&records);
+        }
+        let app = http::router(handle);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        let m: FleetMetrics = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(m.active, 1);
+        assert_eq!(m.stopped, 1);
+        assert_eq!(m.total, 2);
+    }
+}


### PR DESCRIPTION
Closes #1206.

## Summary

Adds an always-on, lightweight **supervisor** that keeps a managed-session fleet running 24/7 with **no live caller attached**. It is a PASSIVE observer + auto-resumer — it never makes autonomy decisions and never auto-answers a `pending_decision`; it surfaces fleet state for a human or a higher-level fleet manager.

## Acceptance criteria

- [x] `tm supervisor` command spins up the supervisor
- [x] Supervisor polls the managed-session store for `stopped` sessions and auto-resumes them (gated by `TRUSTY_MPM_AUTO_RESUME`)
- [x] Activity classification runs on idle `active` sessions without a caller (via the existing activity monitor; `unknown` when no `OPENROUTER_API_KEY`)
- [x] Supervisor persists across reboots — launchd plist (macOS-primary) + systemd user unit + install README
- [x] Metrics exposed on `GET /metrics` (and `GET /health`)
- [x] `TRUSTY_MPM_AUTO_RESUME` env var controls resume policy (CLI `--auto-resume` override)
- [x] Integration test verifies a fleet of N stopped sessions can be auto-resumed unattended (`tick_fleet_of_n_resumed`, N=12)

## What landed

New `supervisor/` module (thin `mod.rs` facade + focused submodules, all < 500 SLOC):

| File | Role |
|---|---|
| `config.rs` | `SupervisorConfig` + env contract (`TRUSTY_MPM_AUTO_RESUME`, `TRUSTY_MPM_SUPERVISOR_{INTERVAL,CLASSIFY,ADDR}`) |
| `poller.rs` | `run_tick` — per-sweep detect `stopped` → auto-resume (gated), classify idle `active` |
| `metrics.rs` | `FleetMetrics` — counts by lifecycle state, surfaced pending decisions, last-activity, run stats |
| `http.rs` | `GET /metrics` + `GET /health` (axum, behind the `daemon` feature) |
| `mod.rs` | `Supervisor` loop: tick → fold run stats → publish snapshot |

CLI verb `tm supervisor [--addr --interval --auto-resume --no-classify]` wired into `lib.rs` + `main.rs` (long-running tracing init, same as `daemon`). Auto-resume is **opt-in** for safety (observe-only by default).

Persistence artifacts under `crates/trusty-mpm/deploy/supervisor/`:
- `com.trusty.mpm.supervisor.plist` (launchd, `RunAtLoad` + `KeepAlive`)
- `trusty-mpm-supervisor.service` (systemd user unit)
- `README.md` (enable + auto-resume guidance)

## Enable auto-resume

One of:
- `TRUSTY_MPM_AUTO_RESUME=1 tm supervisor`, or
- `tm supervisor --auto-resume`

The launchd plist / systemd unit already set `TRUSTY_MPM_AUTO_RESUME=1`.

## Validation

- `cargo test -p trusty-mpm` — all pass (946 lib + 122 bin + integration; 18 supervisor + 2 CLI parse tests)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — OK
- `bash scripts/check_line_cap.sh` — 0 violations
- `cargo check` (workspace) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)