### PR TITLE
chore(trusty-mpm): supervisor daemon review follow-ups (closes #1214)

### DIFF
--- a/crates/trusty-mpm/deploy/supervisor/README.md
+++ b/crates/trusty-mpm/deploy/supervisor/README.md
@@ -41,6 +41,7 @@ curl -s http://127.0.0.1:7881/health        # {"status":"ok"}
 | `TRUSTY_MPM_SUPERVISOR_INTERVAL` | `30` | Poll interval, seconds. |
 | `TRUSTY_MPM_SUPERVISOR_CLASSIFY` | `1` (on) | `0`/`false` disables idle classification (no LLM spend). |
 | `TRUSTY_MPM_SUPERVISOR_ADDR` | `127.0.0.1:7881` | `/metrics` + `/health` bind address. |
+| `TRUSTY_LLM_MODEL` | `openai/gpt-4o-mini` | OpenRouter model used for idle-session activity classification. |
 | `OPENROUTER_API_KEY` | — | Required for real activity classification; absent ⇒ `unknown`. |
 
 CLI flags (`--interval`, `--addr`, `--auto-resume`, `--no-classify`) override the
@@ -49,10 +50,13 @@ env vars.
 ## Enabling auto-resume
 
 Auto-resume is **opt-in** for safety — by default the supervisor runs observe-only
-and only surfaces fleet state. To enable it, do **one** of:
+and only surfaces fleet state. The launchd plist and systemd unit below ship with
+`TRUSTY_MPM_AUTO_RESUME` **commented out**, so an out-of-the-box install never
+resumes sessions until you opt in. To enable it, do **one** of:
 
-- export `TRUSTY_MPM_AUTO_RESUME=1` in the supervisor's environment (the launchd
-  plist / systemd unit below already set this), **or**
+- **uncomment / set `TRUSTY_MPM_AUTO_RESUME=1`** in the supervisor's environment
+  (uncomment the `TRUSTY_MPM_AUTO_RESUME` block in the plist, or the
+  `Environment=TRUSTY_MPM_AUTO_RESUME=1` line in the systemd unit), **or**
 - pass `tm supervisor --auto-resume`.
 
 ## Persistence — macOS (launchd)

--- a/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
+++ b/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
@@ -26,12 +26,16 @@
         <string>supervisor</string>
     </array>
 
-    <!-- Seed config. TRUSTY_MPM_AUTO_RESUME=1 enables auto-resume of stopped
-         sessions; remove it (or set 0) to run observe-only. -->
+    <!-- Seed config. Auto-resume ships DISABLED for safety (the README's
+         "opt-in" stance): the supervisor runs observe-only until you explicitly
+         turn it on. To ENABLE auto-resume of stopped sessions, UNCOMMENT the
+         TRUSTY_MPM_AUTO_RESUME block below (or pass `tm supervisor --auto-resume`). -->
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- ENABLE AUTO-RESUME: uncomment the two lines below to set it to 1.
         <key>TRUSTY_MPM_AUTO_RESUME</key>
         <string>1</string>
+        -->
         <key>TRUSTY_MPM_SUPERVISOR_INTERVAL</key>
         <string>30</string>
         <key>TRUSTY_MPM_SUPERVISOR_ADDR</key>

--- a/crates/trusty-mpm/deploy/supervisor/trusty-mpm-supervisor.service
+++ b/crates/trusty-mpm/deploy/supervisor/trusty-mpm-supervisor.service
@@ -28,9 +28,11 @@ ExecStart=__TM_BINARY_PATH__ supervisor
 Restart=always
 RestartSec=5
 
-# Seed config. TRUSTY_MPM_AUTO_RESUME=1 enables auto-resume of stopped sessions;
-# remove it (or set 0) to run observe-only.
-Environment=TRUSTY_MPM_AUTO_RESUME=1
+# Seed config. Auto-resume ships DISABLED for safety (the README's "opt-in"
+# stance): the supervisor runs observe-only until you explicitly turn it on.
+# To ENABLE auto-resume of stopped sessions, UNCOMMENT the line below (set it to
+# 1), or pass `tm supervisor --auto-resume`.
+# Environment=TRUSTY_MPM_AUTO_RESUME=1
 Environment=TRUSTY_MPM_SUPERVISOR_INTERVAL=30
 Environment=TRUSTY_MPM_SUPERVISOR_ADDR=127.0.0.1:7881
 Environment=RUST_LOG=info

--- a/crates/trusty-mpm/src/bin/tm/commands/supervisor.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/supervisor.rs
@@ -20,7 +20,35 @@ use trusty_mpm::activity::monitor::{ActivityMonitor, OpenRouterClassifier};
 use trusty_mpm::core::paths::FrameworkPaths;
 use trusty_mpm::session_manager::real_tmux::NoopTmuxDriver;
 use trusty_mpm::session_manager::{ManagedTmuxDriver, RealTmuxDriver, SessionManager};
+use trusty_mpm::supervisor::config::{DEFAULT_LLM_MODEL, ENV_LLM_MODEL};
 use trusty_mpm::supervisor::{Supervisor, SupervisorConfig};
+
+/// Validate the optional `--interval` CLI override and apply it to a config.
+///
+/// Why: previously a `--interval 0` was silently filtered to the default, so an
+/// operator who fat-fingered a zero got no feedback and a cadence they did not
+/// ask for. Rejecting zero with an explicit error gives immediate, actionable
+/// feedback instead of a surprising silent fallback.
+/// What: when `interval` is `Some(0)` returns an error; when `Some(n)` with
+/// `n > 0` sets `cfg.interval` to `n` seconds; when `None` leaves `cfg` untouched
+/// (the env-derived / default cadence stands).
+/// Test: `interval_zero_is_rejected`, `interval_positive_overrides`,
+/// `interval_none_keeps_config` in `super::tests`.
+pub(crate) fn apply_interval_override(
+    cfg: &mut SupervisorConfig,
+    interval: Option<u64>,
+) -> anyhow::Result<()> {
+    match interval {
+        Some(0) => anyhow::bail!(
+            "--interval must be greater than 0 seconds (got 0); omit the flag to use the default"
+        ),
+        Some(secs) => {
+            cfg.interval = std::time::Duration::from_secs(secs);
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}
 
 /// Run the supervisor loop with config resolved from env + CLI overrides.
 ///
@@ -42,9 +70,9 @@ pub(crate) async fn run_supervisor(
     if let Some(a) = addr {
         cfg.metrics_addr = a;
     }
-    if let Some(secs) = interval.filter(|s| *s > 0) {
-        cfg.interval = std::time::Duration::from_secs(secs);
-    }
+    // A zero interval is rejected outright (immediate feedback) rather than
+    // silently falling back to the default.
+    apply_interval_override(&mut cfg, interval)?;
     if auto_resume {
         cfg.auto_resume = true;
     }
@@ -66,8 +94,7 @@ pub(crate) async fn run_supervisor(
 
     // Build the activity monitor unless classification is disabled.
     let monitor = if cfg.classify_idle {
-        let model =
-            std::env::var("TRUSTY_LLM_MODEL").unwrap_or_else(|_| "openai/gpt-4o-mini".to_owned());
+        let model = std::env::var(ENV_LLM_MODEL).unwrap_or_else(|_| DEFAULT_LLM_MODEL.to_owned());
         Some(ActivityMonitor::new(OpenRouterClassifier::new(), model))
     } else {
         None
@@ -113,5 +140,50 @@ pub(crate) async fn run_supervisor(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: a zero interval is a fat-finger that previously vanished into the
+    /// default; it must now surface as an error so the operator notices.
+    /// What: asserts `apply_interval_override(_, Some(0))` is an `Err` and that
+    /// the config interval is left unchanged.
+    /// Test: this test.
+    #[test]
+    fn interval_zero_is_rejected() {
+        let mut cfg = SupervisorConfig::default();
+        let before = cfg.interval;
+        let result = apply_interval_override(&mut cfg, Some(0));
+        assert!(result.is_err(), "--interval 0 must be rejected");
+        assert_eq!(
+            cfg.interval, before,
+            "rejected interval must not mutate cfg"
+        );
+    }
+
+    /// Why: a positive override is the intended path and must replace the
+    /// env/default cadence.
+    /// What: asserts `Some(n)` sets `cfg.interval` to `n` seconds.
+    /// Test: this test.
+    #[test]
+    fn interval_positive_overrides() {
+        let mut cfg = SupervisorConfig::default();
+        apply_interval_override(&mut cfg, Some(45)).expect("positive interval is accepted");
+        assert_eq!(cfg.interval, std::time::Duration::from_secs(45));
+    }
+
+    /// Why: omitting `--interval` must leave the env-derived / default cadence in
+    /// place rather than zeroing it.
+    /// What: asserts `None` leaves `cfg.interval` untouched.
+    /// Test: this test.
+    #[test]
+    fn interval_none_keeps_config() {
+        let mut cfg = SupervisorConfig::default();
+        let before = cfg.interval;
+        apply_interval_override(&mut cfg, None).expect("absent interval is a no-op");
+        assert_eq!(cfg.interval, before);
     }
 }

--- a/crates/trusty-mpm/src/supervisor/config.rs
+++ b/crates/trusty-mpm/src/supervisor/config.rs
@@ -33,6 +33,25 @@ pub const ENV_AUTO_RESUME: &str = "TRUSTY_MPM_AUTO_RESUME";
 /// Test: `interval_env_parsing`.
 pub const ENV_INTERVAL_SECS: &str = "TRUSTY_MPM_SUPERVISOR_INTERVAL";
 
+/// Environment variable that selects the LLM model for idle classification.
+///
+/// Why: idle-session activity classification calls an LLM through OpenRouter;
+/// the model is operator-tunable (cost vs. accuracy) and must be read from one
+/// named constant so the env contract is auditable alongside the other `ENV_*`
+/// knobs rather than buried as a string literal at the read site.
+/// What: the variable an operator sets to override the classification model;
+/// when absent the supervisor falls back to [`DEFAULT_LLM_MODEL`].
+/// Test: `default_llm_model_is_documented` asserts the constant + default pair.
+pub const ENV_LLM_MODEL: &str = "TRUSTY_LLM_MODEL";
+
+/// Default LLM model used for idle classification when [`ENV_LLM_MODEL`] is unset.
+///
+/// Why: a cheap, capable default keeps token spend low for the common case while
+/// still letting operators opt into a stronger model via [`ENV_LLM_MODEL`].
+/// What: the fallback model id passed to the classifier when the env var is absent.
+/// Test: `default_llm_model_is_documented`.
+pub const DEFAULT_LLM_MODEL: &str = "openai/gpt-4o-mini";
+
 /// Environment variable that toggles idle-session activity classification.
 ///
 /// Why: classification calls the activity monitor (which may call an LLM). On a

--- a/crates/trusty-mpm/src/supervisor/http.rs
+++ b/crates/trusty-mpm/src/supervisor/http.rs
@@ -6,8 +6,9 @@
 //! health endpoint" acceptance criterion while keeping the surface minimal.
 //! What: holds a shared [`MetricsHandle`] (an `Arc<RwLock<FleetMetrics>>`) that
 //! the supervisor loop updates after each sweep; [`router`] builds the axum
-//! [`Router`]; [`serve`] binds and serves it. Gated behind the `daemon` feature
-//! because axum is only a dependency there (per the workspace axum-feature rule).
+//! [`Router`]; [`bind`] reserves the port (fail-fast) and [`serve_on`] serves it
+//! on the bound listener. Gated behind the `daemon` feature because axum is only
+//! a dependency there (per the workspace axum-feature rule).
 //! Test: `metrics_endpoint_returns_snapshot`, `health_endpoint_ok` in `super::tests`.
 
 use std::net::SocketAddr;
@@ -124,18 +125,4 @@ pub async fn serve_on(
     }
     axum::serve(listener, router(handle)).await?;
     Ok(())
-}
-
-/// Bind and serve the metrics router until the process exits.
-///
-/// Why: a convenience wrapper for callers that want bind+serve in one step (e.g.
-/// integration tests); production wiring uses [`bind`] + [`serve_on`] so the bind
-/// error can be propagated before the supervisor loop starts.
-/// What: binds a `TcpListener` to `addr` via [`bind`] and serves [`router`] via
-/// [`serve_on`]. Returns an error if either the bind or serve fails.
-/// Test: covered indirectly — handlers are unit-tested via the router; the
-/// bind/serve path mirrors the daemon's own `serve_http`.
-pub async fn serve(handle: MetricsHandle, addr: SocketAddr) -> anyhow::Result<()> {
-    let listener = bind(addr).await?;
-    serve_on(listener, handle).await
 }

--- a/crates/trusty-mpm/src/supervisor/mod.rs
+++ b/crates/trusty-mpm/src/supervisor/mod.rs
@@ -207,7 +207,9 @@ impl<C: LlmClassifier> Supervisor<C> {
 /// never dies mid-sweep (CLAUDE.md #534).
 /// What: completes on the first of `SIGTERM` (unix only) or Ctrl-C; on a signal
 /// installation error it logs and resolves immediately (fail-stop rather than
-/// hang). Side-effect-only beyond the returned future.
+/// hang). On non-unix targets (Windows) `SIGTERM` is unavailable, so shutdown is
+/// intentionally limited to Ctrl-C — acceptable because the supported persistence
+/// targets (launchd/systemd) are both unix. Side-effect-only beyond the future.
 /// Test: covered indirectly — `run`'s shutdown path is unit-tested via
 /// `run_until` with an injected future, since real OS signals can't be raised
 /// deterministically in a parallel test binary.
@@ -229,6 +231,12 @@ async fn shutdown_signal() {
         }
     };
 
+    // On non-unix targets (Windows) there is no SIGTERM; `tokio::signal::unix`
+    // is unix-only. Shutdown there is intentionally limited to Ctrl-C — the
+    // production deployment targets (launchd on macOS, systemd on Linux) are both
+    // unix and stop the daemon with SIGTERM, so Windows is a best-effort/dev path.
+    // A never-resolving future keeps the `select!` arm valid while deferring
+    // entirely to the Ctrl-C handler.
     #[cfg(not(unix))]
     let terminate = std::future::pending::<()>();
 

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -26,7 +26,8 @@ use crate::session_manager::{
 
 use super::Supervisor;
 use super::config::{
-    ENV_AUTO_RESUME, ENV_CLASSIFY_IDLE, ENV_INTERVAL_SECS, ENV_METRICS_ADDR, SupervisorConfig,
+    DEFAULT_LLM_MODEL, ENV_AUTO_RESUME, ENV_CLASSIFY_IDLE, ENV_INTERVAL_SECS, ENV_LLM_MODEL,
+    ENV_METRICS_ADDR, SupervisorConfig,
 };
 use super::metrics::FleetMetrics;
 use super::poller::run_tick;
@@ -209,6 +210,15 @@ fn config_defaults() {
     // An empty injected env yields the same defaults (no process env touched).
     let from_empty = SupervisorConfig::from_env_with(fake_env(&[]));
     assert_eq!(from_empty, c);
+}
+
+#[test]
+fn default_llm_model_is_documented() {
+    // The classification model env var + default are exposed as named constants
+    // so the read site (`commands/supervisor.rs`) and the README config table
+    // share one source of truth rather than a buried string literal.
+    assert_eq!(ENV_LLM_MODEL, "TRUSTY_LLM_MODEL");
+    assert_eq!(DEFAULT_LLM_MODEL, "openai/gpt-4o-mini");
 }
 
 #[test]


### PR DESCRIPTION
Resolves #1214 — advisory cleanups from the PR #1211 review of the unattended supervisor daemon.

## Changes

1. **Auto-resume opt-in safety** (`deploy/supervisor/*`) — the launchd plist and systemd unit shipped with `TRUSTY_MPM_AUTO_RESUME=1` **enabled**, contradicting the README's "opt-in for safety" stance. Both now ship the variable **commented-out / disabled by default** (mirroring how `OPENROUTER_API_KEY` is handled), each with a prominent comment telling the operator to uncomment/set it to enable auto-resume. The README's "Enabling auto-resume" section + install steps are corrected to say *"uncomment/set `TRUSTY_MPM_AUTO_RESUME=1` to enable."*

2. **`--interval 0` validation** (`commands/supervisor.rs`) — `tm supervisor --interval 0` was silently filtered to the default. It now returns an explicit `anyhow::bail!` so the operator gets immediate feedback. Logic extracted into a testable `apply_interval_override()` helper.

3. **Dead `http::serve`** (`supervisor/http.rs`) — the one-step `serve` wrapper was unused by production wiring (prod uses `bind` + `serve_on` for fail-fast port-collision detection). **Removed**; module doc updated.

4. **Non-unix shutdown comment** (`supervisor/mod.rs`) — added a clarifying doc/inline comment noting Windows support is intentionally limited to Ctrl-C (SIGTERM via `tokio::signal::unix` is unix-only; the supported launchd/systemd targets are both unix).

5. **`TRUSTY_LLM_MODEL` docs** (`config.rs` + `commands/supervisor.rs` + README) — the classification model env var was undocumented. Added `ENV_LLM_MODEL` + `DEFAULT_LLM_MODEL` named constants (used at the read site) and documented `TRUSTY_LLM_MODEL` in the supervisor README config table.

## Tests added
- `interval_zero_is_rejected`, `interval_positive_overrides`, `interval_none_keeps_config` (`commands::supervisor::tests`)
- `default_llm_model_is_documented` (`supervisor::tests`)

## Validation
- `cargo test -p trusty-mpm` — all pass (incl. the new interval-zero rejection)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations
- `cargo check` (whole workspace) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)