### PR TITLE
chore(trusty-mpm): TcodeAdapter review follow-ups (#1213)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10992,6 +10992,7 @@ dependencies = [
  "utoipa-swagger-ui",
  "uuid",
  "walkdir",
+ "which 6.0.3",
 ]
 
 [[package]]

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -119,6 +119,9 @@ tracing-subscriber.workspace = true
 colored.workspace = true
 sysinfo.workspace = true
 libc.workspace = true
+# Portable executable lookup on PATH (replaces the non-portable `which` shell-out
+# in the tcode runtime adapter's availability probe — see #1213).
+which.workspace = true
 
 # ── Optional dependencies (feature-gated) ────────────────────────────────────
 

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -461,9 +461,11 @@ pub(crate) enum SessionAction {
         ///
         /// `claude-code` runs Claude Code over OAuth (the default, unchanged
         /// behavior); `tcode` runs trusty-code against the direct Anthropic API
-        /// (the `ANTHROPIC_API_KEY` path).
-        #[arg(long, default_value = "claude-code")]
-        runtime: String,
+        /// (the `ANTHROPIC_API_KEY` path). Typed as [`RuntimeKind`] (a
+        /// `clap::ValueEnum`) so an unsupported value is rejected at parse time
+        /// with a "possible values" hint, not silently forwarded to the daemon.
+        #[arg(long, default_value = "claude-code", value_enum)]
+        runtime: trusty_mpm::runtime::RuntimeKind,
     },
     /// List managed sessions (session-manager MVP).
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -70,7 +70,7 @@ pub(crate) async fn session_new(
     git_ref: String,
     task: String,
     name_hint: Option<String>,
-    runtime: String,
+    runtime: trusty_mpm::runtime::RuntimeKind,
 ) -> anyhow::Result<()> {
     #[derive(Deserialize)]
     struct SpawnResp {
@@ -88,7 +88,9 @@ pub(crate) async fn session_new(
             "ref": git_ref,
             "task": task,
             "name_hint": name_hint,
-            "runtime": runtime,
+            // Send the canonical wire spelling (`claude-code`/`tcode`) so the
+            // daemon's `FromStr` accepts it; the CLI already validated the value.
+            "runtime": runtime.as_str(),
         }))
         .send()
         .await?

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -569,8 +569,8 @@ fn cli_parses_session_new() {
             assert_eq!(git_ref, "feat/x");
             assert_eq!(task, "do the thing");
             assert_eq!(name_hint.as_deref(), Some("ticket-1"));
-            // No --runtime flag → default claude-code.
-            assert_eq!(runtime, "claude-code");
+            // No --runtime flag → default claude-code (now a typed RuntimeKind).
+            assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::ClaudeCode);
         }
         other => panic!("expected session new, got {other:?}"),
     }
@@ -595,10 +595,33 @@ fn cli_parses_session_new_with_tcode_runtime() {
         Command::Session {
             action: SessionAction::New { runtime, .. },
         } => {
-            assert_eq!(runtime, "tcode");
+            assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::Tcode);
         }
         other => panic!("expected session new, got {other:?}"),
     }
+}
+
+#[test]
+fn cli_rejects_unknown_runtime_at_parse_time() {
+    // Why: #1213 — `--runtime` is now a clap `ValueEnum`, so an unsupported
+    // backend must fail during argument parsing (with a "possible values" hint)
+    // rather than being forwarded to the daemon and rejected at the HTTP layer.
+    let err = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "new",
+        "https://github.com/owner/repo",
+        "--task",
+        "do the thing",
+        "--runtime",
+        "gpt",
+    ])
+    .expect_err("unknown runtime must be rejected at parse time");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("claude-code") && msg.contains("tcode"),
+        "error must list the supported runtimes: {msg}"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -108,56 +108,8 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_helpers::FakeTmux;
     use super::*;
-    use crate::session_manager::ManagedError;
-    use std::collections::HashMap;
-    use std::sync::Mutex;
-
-    struct FakeTmux {
-        sends: Mutex<Vec<(String, String)>>,
-    }
-
-    impl FakeTmux {
-        fn new() -> Arc<Self> {
-            Arc::new(Self {
-                sends: Mutex::new(Vec::new()),
-            })
-        }
-    }
-
-    impl ManagedTmuxDriver for FakeTmux {
-        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
-            Ok(())
-        }
-
-        fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
-            Ok(())
-        }
-
-        fn send_line(&self, name: &str, text: &str) -> Result<(), ManagedError> {
-            self.sends
-                .lock()
-                .unwrap()
-                .push((name.to_owned(), text.to_owned()));
-            Ok(())
-        }
-
-        fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
-            Ok(String::new())
-        }
-
-        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
-            Ok(Vec::new())
-        }
-
-        fn session_exists(&self, _name: &str) -> bool {
-            false
-        }
-    }
-
-    // We also need a HashMap-based fake for the parking_lot::Mutex version used
-    // in manager tests. This module uses std::sync::Mutex for simplicity.
-    struct _Unused(HashMap<(), ()>);
 
     #[test]
     fn claude_code_adapter_identifies() {

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -14,6 +14,9 @@
 mod claude_code;
 mod tcode;
 
+#[cfg(test)]
+pub(crate) mod test_helpers;
+
 pub use claude_code::ClaudeCodeAdapter;
 pub use tcode::TcodeAdapter;
 
@@ -21,6 +24,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -84,15 +88,20 @@ pub trait RuntimeAdapter: Send + Sync {
 /// SAME backend rather than silently reverting to the default.
 /// What: a two-variant enum with `Default` = [`RuntimeKind::ClaudeCode`] (so
 /// existing behavior is unchanged), stable serde wire strings (`"claude-code"`,
-/// `"tcode"`), and `FromStr` for CLI/HTTP parsing.
+/// `"tcode"`), `FromStr` for HTTP parsing, and a `clap::ValueEnum` impl so the
+/// `--runtime` CLI flag rejects bad values at parse time rather than at the HTTP
+/// layer (#1213). The `ValueEnum` value names are pinned to the same kebab-case
+/// spellings as the serde wire form so the CLI and HTTP surfaces never diverge.
 /// Test: `runtime_kind_default_is_claude_code`, `runtime_kind_from_str_*`,
-/// `runtime_kind_serde_round_trip`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// `runtime_kind_serde_round_trip`, `runtime_kind_value_enum_matches_wire`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum RuntimeKind {
     /// Claude Code CLI over OAuth (the default; `ANTHROPIC_API_KEY` is scrubbed).
+    #[value(name = "claude-code")]
     ClaudeCode,
     /// trusty-code (`tcode`) over the direct Anthropic API (`ANTHROPIC_API_KEY`).
+    #[value(name = "tcode")]
     Tcode,
 }
 
@@ -165,46 +174,8 @@ pub fn build_adapter(
 
 #[cfg(test)]
 mod tests {
+    use super::test_helpers::FakeTmux;
     use super::*;
-    use crate::session_manager::ManagedError;
-    use std::sync::Mutex;
-
-    struct FakeTmux {
-        sends: Mutex<Vec<(String, String)>>,
-    }
-
-    impl FakeTmux {
-        fn new() -> Arc<Self> {
-            Arc::new(Self {
-                sends: Mutex::new(Vec::new()),
-            })
-        }
-    }
-
-    impl ManagedTmuxDriver for FakeTmux {
-        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
-            Ok(())
-        }
-        fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
-            Ok(())
-        }
-        fn send_line(&self, name: &str, text: &str) -> Result<(), ManagedError> {
-            self.sends
-                .lock()
-                .unwrap()
-                .push((name.to_owned(), text.to_owned()));
-            Ok(())
-        }
-        fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
-            Ok(String::new())
-        }
-        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
-            Ok(Vec::new())
-        }
-        fn session_exists(&self, _name: &str) -> bool {
-            false
-        }
-    }
 
     #[test]
     fn runtime_kind_default_is_claude_code() {
@@ -256,6 +227,25 @@ mod tests {
             serde_json::to_string(&RuntimeKind::Tcode).unwrap(),
             "\"tcode\""
         );
+    }
+
+    #[test]
+    fn runtime_kind_value_enum_matches_wire() {
+        // The clap CLI value names must be byte-identical to the serde wire form
+        // and `as_str`, so `--runtime <x>` and `runtime=<x>` accept the same set.
+        for kind in [RuntimeKind::ClaudeCode, RuntimeKind::Tcode] {
+            let value = kind.to_possible_value().expect("kind has a CLI value");
+            assert_eq!(value.get_name(), kind.as_str());
+            // Round-trips back through the HTTP-side `FromStr` parser.
+            let parsed = kind.as_str().parse::<RuntimeKind>().expect("parses");
+            assert_eq!(parsed, kind);
+        }
+        // The CLI exposes exactly the two supported backends, in order.
+        let names: Vec<String> = RuntimeKind::value_variants()
+            .iter()
+            .map(|k| k.to_possible_value().unwrap().get_name().to_owned())
+            .collect();
+        assert_eq!(names, vec!["claude-code".to_owned(), "tcode".to_owned()]);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/runtime/tcode.rs
+++ b/crates/trusty-mpm/src/runtime/tcode.rs
@@ -13,7 +13,6 @@
 //! `tcode_adapter_spawn_sends_run_task` (see the module test block).
 
 use std::path::Path;
-use std::process::Command;
 use std::sync::Arc;
 
 use tracing::debug;
@@ -71,15 +70,44 @@ impl TcodeAdapter {
     /// Return `true` if the `tcode` binary can be found on `PATH`.
     ///
     /// Why: `spawn` must return `RuntimeError::BinaryNotFound` rather than
-    /// sending a command that silently fails inside the pane.
-    /// What: runs `which tcode` and checks the exit status.
+    /// sending a command that silently fails inside the pane. The previous
+    /// implementation shelled out to `which`, which is absent on some targets
+    /// (notably Windows) and adds a subprocess; the `which` crate performs the
+    /// same PATH/PATHEXT resolution portably and in-process (#1213).
+    /// What: resolves `tcode` against `PATH` via [`which::which`] and reports
+    /// whether a matching executable was found (any lookup error → `false`).
     /// Test: `tcode_adapter_binary_check_returns_bool`.
     fn tcode_available() -> bool {
-        Command::new("which")
-            .arg(TCODE_BINARY)
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        which::which(TCODE_BINARY).is_ok()
+    }
+
+    /// Build the `tcode run-task` line and send it to the named tmux pane.
+    ///
+    /// Why: this is the half of `spawn` AFTER the binary-availability gate —
+    /// command construction plus the tmux send. Factoring it out lets the unit
+    /// tests exercise the send path deterministically through `FakeTmux` without
+    /// a real `tcode` binary on PATH (the availability check is the only part
+    /// that depends on the environment), closing the silent-skip gap in #1213.
+    /// What: constructs the command via [`build_spawn_command`], logs it, and
+    /// forwards it to `send_line`, mapping any tmux failure to
+    /// [`RuntimeError::TmuxUnavailable`]. It does NOT check binary availability.
+    /// Test: `tcode_adapter_spawn_sends_run_task` (always runs in CI).
+    fn send_spawn_command(
+        &self,
+        tmux_name: &str,
+        cwd: &Path,
+        task: &str,
+    ) -> Result<(), RuntimeError> {
+        let command = build_spawn_command(cwd, task);
+        debug!(
+            session = %tmux_name,
+            cwd = %cwd.display(),
+            task = %task,
+            "spawning tcode in tmux pane"
+        );
+        self.tmux
+            .send_line(tmux_name, &command)
+            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
     }
 }
 
@@ -129,16 +157,7 @@ impl RuntimeAdapter for TcodeAdapter {
                 "tcode binary not found on PATH — install trusty-code first".into(),
             ));
         }
-        let command = build_spawn_command(cwd, task);
-        debug!(
-            session = %tmux_name,
-            cwd = %cwd.display(),
-            task = %task,
-            "spawning tcode in tmux pane"
-        );
-        self.tmux
-            .send_line(tmux_name, &command)
-            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
+        self.send_spawn_command(tmux_name, cwd, task)
     }
 
     /// Return `"tcode"` as the adapter's identifier.
@@ -154,51 +173,8 @@ impl RuntimeAdapter for TcodeAdapter {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_helpers::FakeTmux;
     use super::*;
-    use crate::session_manager::ManagedError;
-    use std::sync::Mutex;
-
-    struct FakeTmux {
-        sends: Mutex<Vec<(String, String)>>,
-    }
-
-    impl FakeTmux {
-        fn new() -> Arc<Self> {
-            Arc::new(Self {
-                sends: Mutex::new(Vec::new()),
-            })
-        }
-    }
-
-    impl ManagedTmuxDriver for FakeTmux {
-        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
-            Ok(())
-        }
-
-        fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
-            Ok(())
-        }
-
-        fn send_line(&self, name: &str, text: &str) -> Result<(), ManagedError> {
-            self.sends
-                .lock()
-                .unwrap()
-                .push((name.to_owned(), text.to_owned()));
-            Ok(())
-        }
-
-        fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
-            Ok(String::new())
-        }
-
-        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
-            Ok(Vec::new())
-        }
-
-        fn session_exists(&self, _name: &str) -> bool {
-            false
-        }
-    }
 
     #[test]
     fn tcode_adapter_identifies() {
@@ -269,22 +245,47 @@ mod tests {
 
     #[test]
     fn tcode_adapter_spawn_sends_run_task() {
-        // If tcode is not installed this test is a no-op (we cannot install it
-        // in CI). We only assert the send when the binary exists.
-        if !TcodeAdapter::tcode_available() {
-            return;
-        }
+        // The send/command-construction path must be exercised in EVERY CI run,
+        // regardless of whether a real `tcode` binary is on PATH. We therefore
+        // drive `send_spawn_command` (the post-availability-check half of
+        // `spawn`) directly: it needs only the `FakeTmux` driver, never a real
+        // binary, so the launch-line assertion below runs unconditionally.
         let fake = FakeTmux::new();
         let adapter = TcodeAdapter::new(fake.clone());
         adapter
-            .spawn("tmpm-test", Path::new("/tmp"), "some task")
-            .expect("spawn");
-        let sends = fake.sends.lock().unwrap();
+            .send_spawn_command("tmpm-test", Path::new("/tmp"), "some task")
+            .expect("send_spawn_command");
+        let sends = fake.sends.lock().expect("send log mutex");
         assert_eq!(sends.len(), 1);
         assert_eq!(sends[0].0, "tmpm-test");
         assert_eq!(
             sends[0].1,
             build_spawn_command(Path::new("/tmp"), "some task")
         );
+    }
+
+    #[test]
+    fn tcode_adapter_spawn_errors_when_binary_missing() {
+        // The availability gate must short-circuit with `BinaryNotFound` and
+        // send NOTHING when `tcode` is absent. We can only assert this branch
+        // deterministically when the binary is genuinely off PATH; when it is
+        // present (e.g. a dev machine with trusty-code installed) we assert the
+        // happy path instead so the test is meaningful in both environments.
+        let fake = FakeTmux::new();
+        let adapter = TcodeAdapter::new(fake.clone());
+        let result = adapter.spawn("tmpm-test", Path::new("/tmp"), "some task");
+        if TcodeAdapter::tcode_available() {
+            assert!(result.is_ok(), "spawn should succeed when tcode is on PATH");
+            assert_eq!(fake.sends.lock().expect("send log mutex").len(), 1);
+        } else {
+            assert!(
+                matches!(result, Err(RuntimeError::BinaryNotFound(_))),
+                "spawn must report BinaryNotFound when tcode is absent: {result:?}"
+            );
+            assert!(
+                fake.sends.lock().expect("send log mutex").is_empty(),
+                "no command may be sent when the binary is missing"
+            );
+        }
     }
 }

--- a/crates/trusty-mpm/src/runtime/test_helpers.rs
+++ b/crates/trusty-mpm/src/runtime/test_helpers.rs
@@ -1,0 +1,75 @@
+//! Shared test doubles for the runtime adapter unit tests.
+//!
+//! Why: the `claude_code`, `tcode`, and `mod` test blocks all need an in-memory
+//! [`ManagedTmuxDriver`] that records the lines sent to it so adapter spawn paths
+//! can be exercised without a real `tmux` binary. Keeping three byte-identical
+//! copies of that fake (one per test module) was a maintenance hazard flagged in
+//! the #1212 review (#1213); this module is the single source of truth.
+//! What: defines [`FakeTmux`], a `Mutex`-guarded recorder implementing
+//! [`ManagedTmuxDriver`]; every method is a no-op except `send_line`, which
+//! appends `(session_name, text)` so tests can assert exactly what was sent.
+//! Test: consumed by the `tcode`/`claude_code`/`mod` test blocks; its own
+//! behaviour is verified transitively through those tests (e.g.
+//! `tcode_adapter_spawn_sends_run_task`).
+
+use std::sync::{Arc, Mutex};
+
+use crate::session_manager::{ManagedError, ManagedTmuxDriver};
+
+/// In-memory [`ManagedTmuxDriver`] that records every `send_line` call.
+///
+/// Why: adapter tests must assert the exact shell line an adapter sends to the
+/// pane without spawning `tmux`; recording sends in a `Mutex<Vec<…>>` makes that
+/// assertion trivial and deterministic.
+/// What: stores a `Vec<(session_name, text)>` behind a `Mutex`; all driver
+/// methods are inert except `send_line`, which pushes the call. `sends` is
+/// `pub(crate)` so test blocks can lock and inspect it.
+/// Test: exercised by every runtime adapter test that calls `spawn`.
+pub(crate) struct FakeTmux {
+    pub(crate) sends: Mutex<Vec<(String, String)>>,
+}
+
+impl FakeTmux {
+    /// Construct an empty recorder wrapped in an `Arc`.
+    ///
+    /// Why: adapters take `Arc<dyn ManagedTmuxDriver + Send + Sync>`, so the fake
+    /// is handed out pre-wrapped; returning `Arc<Self>` (not `Arc<dyn …>`) lets
+    /// the caller keep a typed handle for `clone()` + later inspection.
+    /// What: allocates a `FakeTmux` with an empty send log inside an `Arc`.
+    /// Test: called at the top of every runtime adapter test.
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            sends: Mutex::new(Vec::new()),
+        })
+    }
+}
+
+impl ManagedTmuxDriver for FakeTmux {
+    fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn send_line(&self, name: &str, text: &str) -> Result<(), ManagedError> {
+        self.sends
+            .lock()
+            .expect("FakeTmux send log mutex poisoned")
+            .push((name.to_owned(), text.to_owned()));
+        Ok(())
+    }
+
+    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+        Ok(String::new())
+    }
+
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        Ok(Vec::new())
+    }
+
+    fn session_exists(&self, _name: &str) -> bool {
+        false
+    }
+}


### PR DESCRIPTION
Resolves #1213 — advisory cleanups from the trusty-review of PR #1212.

## Changes

### 1. `tcode_available()` portability (`runtime/tcode.rs`)
Replaced the non-portable `Command::new("which")` shell-out with the in-process
`which::which(TCODE_BINARY).is_ok()`. The `which` crate is **already a workspace
dependency** (`which = "6"` in the root `Cargo.toml`), so per the ticket's
preference order this is the right call — it resolves `PATH`/`PATHEXT` portably
(works on Windows, no subprocess). Added `which.workspace = true` to
`trusty-mpm/Cargo.toml`.

> Evidence the `--version` probe would also work: `cargo run -p trusty-code -- --version`
> prints `tcode 0.0.0` and exits `0` (clap auto-provides `--version` since the
> binary sets `version`). I still chose the `which` crate because it is already
> a workspace dep and avoids spawning a subprocess.

### 2. `--runtime` CLI validation (`cli.rs` + `runtime/mod.rs`)
`RuntimeKind` now derives `clap::ValueEnum` with value names pinned to the
kebab-case wire form (`claude-code`/`tcode`). The `--runtime` flag is typed as
`RuntimeKind` (default `claude-code`) instead of `String`, so unsupported values
fail at **parse time** with a "possible values" hint instead of being forwarded
to the daemon. The HTTP path is unchanged: the CLI sends `runtime.as_str()` and
the daemon's existing `FromStr`/serde still apply.

### 3. `FakeTmux` dedup (`runtime/test_helpers.rs`)
Extracted the triplicated `FakeTmux` test double + `ManagedTmuxDriver` impl into
a single shared `#[cfg(test)] pub(crate) mod test_helpers`, consumed by the
`tcode`, `claude_code`, and `mod` test blocks. (Also deduped the `claude_code`
copy the ticket didn't explicitly name — net LOC reduction.)

### 4. Deterministic spawn test (`runtime/tcode.rs`)
`tcode_adapter_spawn_sends_run_task` no longer early-returns when `tcode` is off
PATH. The send/command-construction half of `spawn` is factored into a new
`send_spawn_command` method, which the test drives via `FakeTmux`
unconditionally — the launch-line assertion now **always** runs in CI. A new
`tcode_adapter_spawn_errors_when_binary_missing` test covers the availability
gate in both environments (binary present vs. absent).

## New tests
- `runtime_kind_value_enum_matches_wire`
- `cli_rejects_unknown_runtime_at_parse_time`
- `tcode_adapter_spawn_errors_when_binary_missing`

## Validation
- `cargo test -p trusty-mpm` — all pass (incl. the now-always-run spawn test)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — OK (15 allowlisted, 0 violations)
- `cargo check` (whole workspace) — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)