### PR TITLE
fix(trusty-mpm): make canonical `tm session stop/resume` managed-aware (closes #1218)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -369,7 +369,11 @@ pub(crate) enum SessionAction {
         #[arg(long)]
         dir: Option<String>,
     },
-    /// Stop a session by id or friendly name.
+    /// Stop a session by id or friendly name (managed or project session).
+    ///
+    /// Managed-aware (#1218): if the id/name is a managed session, this stops its
+    /// runtime (workspace preserved, resumable); otherwise it stops the local
+    /// project session.
     Stop {
         /// Session id or friendly name (e.g. `tmpm-quiet-falcon`).
         id_or_name: String,
@@ -412,7 +416,11 @@ pub(crate) enum SessionAction {
         #[arg(long)]
         note: Option<String>,
     },
-    /// Resume a paused session.
+    /// Resume a stopped/paused session (managed or project session).
+    ///
+    /// Managed-aware (#1218): if the id/name is a managed session, this re-spawns
+    /// its runtime in the existing workspace; otherwise it resumes the local
+    /// paused project session.
     Resume {
         /// Session id or friendly name.
         id_or_name: String,

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -45,12 +45,69 @@ pub(crate) fn deprecation_notice(old: &str, new: &str) {
 /// What: mirrors `daemon::managed_routes::SessionSummary`.
 /// Test: rendered by `ls`; round-trip covered by the integration test.
 #[derive(Debug, Deserialize)]
-struct ManagedSummary {
-    id: String,
-    name: String,
+pub(crate) struct ManagedSummary {
+    pub(crate) id: String,
+    pub(crate) name: String,
     state: String,
     #[serde(default)]
     pending_decision: Option<String>,
+}
+
+/// Decide whether an id-or-name refers to a MANAGED session, returning its UUID.
+///
+/// Why: the canonical `tm session stop`/`resume` verbs must operate on managed
+/// sessions (the documented #842 driver-skill behavior) while still serving the
+/// older local/project-session family. #1218: those verbs were routing every
+/// argument to the project-sessions API, so managed UUIDs came back "not found".
+/// This classifier is the pure decision that makes the verbs managed-aware: if
+/// the argument matches a managed session by id or friendly name, the caller
+/// routes to the managed endpoint; otherwise it falls back to project-sessions.
+/// What: scans the managed-session list, matching `id_or_name` against each
+/// session's `id` (UUID) or `name`; returns `Some(id)` on the first hit, else
+/// `None`. Matching the canonical UUID (not the input) lets a friendly-name
+/// argument resolve to the id the managed endpoints require.
+/// Test: `classify_managed_target_*` in `tests.rs`.
+pub(crate) fn classify_managed_target(
+    sessions: &[ManagedSummary],
+    id_or_name: &str,
+) -> Option<String> {
+    sessions
+        .iter()
+        .find(|s| s.id == id_or_name || s.name == id_or_name)
+        .map(|s| s.id.clone())
+}
+
+/// Resolve an id-or-name to a MANAGED session id by querying the daemon.
+///
+/// Why: `tm session stop`/`resume` need to know — before choosing an endpoint —
+/// whether the argument is a managed session (#1218). Fetching the managed list
+/// and applying [`classify_managed_target`] keeps that decision in one place and
+/// off the project-session path.
+/// What: GETs `/api/v1/sessions/managed`, deserializes the session list, and
+/// returns `classify_managed_target(&sessions, id_or_name)`. A non-200 response
+/// or a body that fails to parse yields `None` (treated as "not managed") so the
+/// caller transparently falls back to the project-session path rather than erroring.
+/// Test: HTTP wiring covered by the integration test; the matching logic by
+/// `classify_managed_target_*`.
+pub(crate) async fn resolve_managed_id(
+    client: &reqwest::Client,
+    url: &str,
+    id_or_name: &str,
+) -> Option<String> {
+    #[derive(Deserialize)]
+    struct ListResp {
+        sessions: Vec<ManagedSummary>,
+    }
+    let resp = client
+        .get(format!("{url}/api/v1/sessions/managed"))
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: ListResp = resp.json().await.ok()?;
+    classify_managed_target(&body.sessions, id_or_name)
 }
 
 /// `tm session new` — spawn a managed session from a repo + ref.

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -19,8 +19,10 @@ use crate::types::{EventRow, SessionRow};
 /// Why: a session is a Claude Code instance; operators start, stop, list,
 /// reap, and inspect them per project from the shell.
 /// What: `Start` posts `POST /sessions` with the project path; `Stop` and
-/// `Info` resolve a session by id or friendly name; `List` and `Clean` scope
-/// to the project directory.
+/// `Resume` are managed-aware (#1218) — they route to the managed runtime-stop/
+/// resume endpoints when the id/name resolves to a managed session, falling back
+/// to the project-session path otherwise; `Info` resolves a session by id or
+/// friendly name; `List` and `Clean` scope to the project directory.
 /// Test: `cli_parses_session_start`, `cli_parses_session_stop`,
 /// `cli_parses_session_list`, `cli_parses_session_clean`,
 /// `cli_parses_session_info`.
@@ -113,15 +115,26 @@ pub(crate) async fn session(
             }
         }
         SessionAction::Stop { id_or_name } => {
-            let resp = client
-                .delete(format!("{url}/sessions/{id_or_name}"))
-                .send()
-                .await?;
-            if resp.status() == reqwest::StatusCode::NOT_FOUND {
-                println!("not found");
+            // #1218: `stop` is managed-aware. If the argument resolves to a
+            // MANAGED session (by id or friendly name), route to the managed
+            // runtime-stop endpoint; otherwise fall back to the project-session
+            // DELETE path. This keeps one intuitive verb that does the right
+            // thing for both families (the #842 driver skill documents `stop`).
+            if let Some(managed_id) =
+                crate::commands::managed::resolve_managed_id(client, url, &id_or_name).await
+            {
+                crate::commands::managed::session_stop(client, url, managed_id).await?;
             } else {
-                resp.error_for_status()?;
-                println!("stopped {id_or_name}");
+                let resp = client
+                    .delete(format!("{url}/sessions/{id_or_name}"))
+                    .send()
+                    .await?;
+                if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                    println!("not found");
+                } else {
+                    resp.error_for_status()?;
+                    println!("stopped {id_or_name}");
+                }
             }
         }
         SessionAction::List { dir } => {
@@ -273,20 +286,29 @@ pub(crate) async fn session(
             }
         }
         SessionAction::Resume { id_or_name } => {
-            let resp = client
-                .post(format!("{url}/sessions/{id_or_name}/resume"))
-                .send()
-                .await?;
-            match resp.status() {
-                reqwest::StatusCode::NOT_FOUND => {
-                    println!("session '{id_or_name}' not found");
-                }
-                reqwest::StatusCode::CONFLICT => {
-                    println!("session '{id_or_name}' is not paused");
-                }
-                _ => {
-                    resp.error_for_status()?;
-                    println!("resumed {id_or_name}");
+            // #1218: `resume` is managed-aware (mirrors `Stop`). A managed
+            // session id/name routes to the managed resume endpoint; anything
+            // else falls back to the project-session pause/resume path.
+            if let Some(managed_id) =
+                crate::commands::managed::resolve_managed_id(client, url, &id_or_name).await
+            {
+                crate::commands::managed::session_resume(client, url, managed_id).await?;
+            } else {
+                let resp = client
+                    .post(format!("{url}/sessions/{id_or_name}/resume"))
+                    .send()
+                    .await?;
+                match resp.status() {
+                    reqwest::StatusCode::NOT_FOUND => {
+                        println!("session '{id_or_name}' not found");
+                    }
+                    reqwest::StatusCode::CONFLICT => {
+                        println!("session '{id_or_name}' is not paused");
+                    }
+                    _ => {
+                        resp.error_for_status()?;
+                        println!("resumed {id_or_name}");
+                    }
                 }
             }
         }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -774,6 +774,64 @@ fn deprecation_notice_format() {
 }
 
 #[test]
+fn classify_managed_target_matches_by_id() {
+    // #1218: the canonical `stop`/`resume` verbs must recognize a managed
+    // session by its UUID and route to the managed endpoint, not project-sessions.
+    use crate::commands::managed::{ManagedSummary, classify_managed_target};
+    let uuid = "11111111-2222-3333-4444-555555555555";
+    let sessions: Vec<ManagedSummary> = serde_json::from_value(serde_json::json!([
+        { "id": uuid, "name": "tmpm-quiet-falcon", "state": "running" }
+    ]))
+    .unwrap();
+    assert_eq!(
+        classify_managed_target(&sessions, uuid),
+        Some(uuid.to_string()),
+        "a managed UUID must resolve to the managed id (routes to managed endpoint)"
+    );
+}
+
+#[test]
+fn classify_managed_target_matches_by_name_returns_id() {
+    // A friendly managed name must resolve to the canonical UUID the managed
+    // endpoints require, so `tm session stop <name>` works for managed sessions.
+    use crate::commands::managed::{ManagedSummary, classify_managed_target};
+    let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    let sessions: Vec<ManagedSummary> = serde_json::from_value(serde_json::json!([
+        { "id": uuid, "name": "tmpm-brave-otter", "state": "stopped" }
+    ]))
+    .unwrap();
+    assert_eq!(
+        classify_managed_target(&sessions, "tmpm-brave-otter"),
+        Some(uuid.to_string()),
+        "a managed name must resolve to its id, not be passed through verbatim"
+    );
+}
+
+#[test]
+fn classify_managed_target_unknown_falls_back_to_none() {
+    // A non-managed id/name must NOT match — the caller then falls back to the
+    // project-session path, preserving the local/project-session family (#1218).
+    use crate::commands::managed::{ManagedSummary, classify_managed_target};
+    let sessions: Vec<ManagedSummary> = serde_json::from_value(serde_json::json!([
+        { "id": "11111111-2222-3333-4444-555555555555", "name": "tmpm-quiet-falcon", "state": "running" }
+    ]))
+    .unwrap();
+    assert_eq!(
+        classify_managed_target(&sessions, "some-local-session-name"),
+        None,
+        "an unknown id/name must yield None so `stop`/`resume` fall back to project-sessions"
+    );
+}
+
+#[test]
+fn classify_managed_target_empty_list_is_none() {
+    // With no managed sessions, every argument falls back to project-sessions.
+    use crate::commands::managed::{ManagedSummary, classify_managed_target};
+    let sessions: Vec<ManagedSummary> = Vec::new();
+    assert_eq!(classify_managed_target(&sessions, "anything"), None);
+}
+
+#[test]
 fn cli_parses_catalog_sync() {
     let cli = Cli::try_parse_from(["trusty-mpm", "catalog", "sync", "--force"]).unwrap();
     match cli.command {


### PR DESCRIPTION
## Summary

Fixes #1218. The canonical `tm session stop <id>` / `tm session resume <id>` verbs routed every argument to the **old project/local-sessions API** (`DELETE /sessions/{id}`, `POST /sessions/{id}/resume`), so a managed-session UUID returned `not found`. Only the hidden, deprecated `managed-stop` / `managed-resume` / `runtime-stop` aliases reached the correct managed endpoints — but the #1205 deprecation notices told operators to "use 'stop'/'resume'", steering them straight at the broken path.

The shipped claude-mpm `session-manager-driver` skill (#842) documents `tm session stop/resume <id>` as the canonical managed verbs, so these commands were broken end-to-end.

## Approach chosen — make `stop`/`resume` managed-aware (issue option a)

Each verb now **resolves the id/name against the managed-session list first** (`GET /api/v1/sessions/managed`):
- **hit** → route to `POST /api/v1/sessions/managed/{id}/runtime-stop` (or `/resume`)
- **miss** → fall back to the existing project-session path, unchanged

One intuitive verb does the right thing for both families. No daemon change required. A friendly managed name resolves to the canonical UUID the managed endpoints require.

### Why this approach
- Keeps a single, documented, non-deprecated verb (`stop`/`resume`) driving managed lifecycle — matches the #842 driver skill exactly, so **the skill needs no change**.
- Preserves local/project-session behavior (fall-through is untouched).
- Routing decision is a pure, unit-tested function (`classify_managed_target`) — the HTTP fetch (`resolve_managed_id`) is a thin wrapper that degrades to "not managed" (fall back) on any error.
- All deprecation messages now point at verbs that actually work; the deprecated aliases remain valid forwards to the managed endpoints.

## #842 driver skill status

**Stays correct as written** — the skill's documented mapping (`tm session stop <id>` → `runtime-stop`, `tm session resume <id>` → `resume`) is exactly what this fix delivers. No follow-up edit to the claude-mpm repo is needed.

## Tests

- Added `classify_managed_target_matches_by_id`, `_matches_by_name_returns_id`, `_unknown_falls_back_to_none`, `_empty_list_is_none` — assert the canonical verbs resolve managed ids/names to the managed endpoint and that unknown args fall back to project-sessions.
- Existing project-session and managed parse tests unchanged and passing.

## Verification

- `cargo test -p trusty-mpm` — 969 + 131 + 34 + … passed, 0 failed
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations
- `cargo check` (workspace) — clean
- Manual: `tm session --help` shows the corrected verb descriptions; deprecated aliases hidden and point at working verbs.

## Files changed

- `crates/trusty-mpm/src/bin/tm/commands/managed.rs` — `classify_managed_target` + `resolve_managed_id`
- `crates/trusty-mpm/src/bin/tm/commands/session.rs` — managed-aware `Stop`/`Resume`
- `crates/trusty-mpm/src/bin/tm/cli.rs` — verb doc strings
- `crates/trusty-mpm/src/bin/tm/tests.rs` — regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)