### PR TITLE
fix(trusty-mpm): reload-on-read so daemon reflects supervisor's out-of-process session writes (closes #1219)

### DIFF
--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -295,11 +295,16 @@ impl SessionManager {
 
     /// Look up a session by its managed id.
     ///
-    /// Why: the HTTP GET and activity handlers need a typed, async lookup.
-    /// What: acquires a read lock and delegates to [`SessionStore::get`].
-    /// Test: `manager_create_record`.
+    /// Why: the HTTP GET and activity handlers need a typed, async lookup. Since
+    /// #1219 the lookup must also reflect writes made by another process (the
+    /// supervisor) to the shared store, so it goes through the store's
+    /// reload-on-read `get`. That reload mutates the in-memory map, hence a write
+    /// lock rather than a read lock.
+    /// What: acquires a write lock and delegates to [`SessionStore::get`], which
+    /// reloads from disk first if the backing file changed.
+    /// Test: `manager_create_record`, `manager_get_reflects_out_of_process_write`.
     pub async fn get(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
-        self.store.read().await.get(id).map_err(|e| match e {
+        self.store.write().await.get(id).await.map_err(|e| match e {
             StoreError::NotFound(k) => ManagedError::SessionNotFound(k),
             other => ManagedError::Store(other),
         })
@@ -307,11 +312,21 @@ impl SessionManager {
 
     /// Return all managed sessions.
     ///
-    /// Why: `GET /api/v1/sessions/managed` returns the full list.
-    /// What: acquires a read lock and returns a clone of all stored records.
-    /// Test: `manager_create_record`.
+    /// Why: `GET /api/v1/sessions/managed` returns the full list, and (since
+    /// #1219) must reflect any out-of-process write before answering.
+    /// What: acquires a write lock and delegates to [`SessionStore::all`], which
+    /// reloads from disk first if the backing file changed. On a reload I/O error
+    /// it logs and falls back to the last-known in-memory set so a transient stat
+    /// failure never makes `list` itself fail.
+    /// Test: `manager_create_record`, `manager_get_reflects_out_of_process_write`.
     pub async fn list(&self) -> Vec<SessionRecord> {
-        self.store.read().await.all()
+        match self.store.write().await.all().await {
+            Ok(records) => records,
+            Err(e) => {
+                warn!("session list: reload failed: {e}; returning last-known set");
+                Vec::new()
+            }
+        }
     }
 
     /// Inject text into a live session's tmux pane.
@@ -492,7 +507,7 @@ impl SessionManager {
 
         let mut report = ReconcileReport::default();
         let mut guard = self.store.write().await;
-        let all_records = guard.all();
+        let all_records = guard.all().await?;
 
         // Build a set of store-known tmux names.
         let known_names: std::collections::HashSet<String> =

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -297,14 +297,27 @@ impl SessionManager {
     ///
     /// Why: the HTTP GET and activity handlers need a typed, async lookup. Since
     /// #1219 the lookup must also reflect writes made by another process (the
-    /// supervisor) to the shared store, so it goes through the store's
-    /// reload-on-read `get`. That reload mutates the in-memory map, hence a write
-    /// lock rather than a read lock.
-    /// What: acquires a write lock and delegates to [`SessionStore::get`], which
-    /// reloads from disk first if the backing file changed.
-    /// Test: `manager_create_record`, `manager_get_reflects_out_of_process_write`.
+    /// supervisor) to the shared store, so it reloads-on-read first. That reload
+    /// mutates the in-memory map, hence a write lock rather than a read lock. A
+    /// transient reload error must NOT manifest as a false "session not found":
+    /// if the id is still present in the last-known in-memory map we return that
+    /// record (slightly stale) instead of failing the lookup — only a genuinely
+    /// absent id yields `SessionNotFound`.
+    /// What: acquires a write lock, attempts [`SessionStore::reload_if_changed`];
+    /// on reload success the freshly-reloaded map is consulted, on reload failure
+    /// the last-known map is consulted. Either way the lookup uses
+    /// [`SessionStore::cached_get`], so a reload error degrades to stale-but-present
+    /// rather than "gone".
+    /// Test: `manager_create_record`, `manager_get_reflects_out_of_process_write`,
+    /// `manager_get_returns_last_known_on_reload_error`.
     pub async fn get(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
-        self.store.write().await.get(id).await.map_err(|e| match e {
+        let mut guard = self.store.write().await;
+        if let Err(e) = guard.reload_if_changed().await {
+            // Reload failed (transient I/O): do NOT surface as "not found". Fall
+            // through to the last-known in-memory record if we have it.
+            warn!(id = %id, "session get: reload failed: {e}; using last-known record");
+        }
+        guard.cached_get(id).map_err(|e| match e {
             StoreError::NotFound(k) => ManagedError::SessionNotFound(k),
             other => ManagedError::Store(other),
         })
@@ -313,18 +326,29 @@ impl SessionManager {
     /// Return all managed sessions.
     ///
     /// Why: `GET /api/v1/sessions/managed` returns the full list, and (since
-    /// #1219) must reflect any out-of-process write before answering.
+    /// #1219) must reflect any out-of-process write before answering. Crucially, a
+    /// transient reload I/O error (e.g. an NFS hiccup or a momentarily unreadable
+    /// file) must NOT make the endpoint report ZERO sessions — that would mislead
+    /// the supervisor/operator into thinking the fleet is empty and could trigger
+    /// spurious re-provisioning. The in-memory map already holds the last-known
+    /// set, so a reload failure degrades to "slightly stale", never "fleet empty".
     /// What: acquires a write lock and delegates to [`SessionStore::all`], which
-    /// reloads from disk first if the backing file changed. On a reload I/O error
-    /// it logs and falls back to the last-known in-memory set so a transient stat
-    /// failure never makes `list` itself fail.
-    /// Test: `manager_create_record`, `manager_get_reflects_out_of_process_write`.
+    /// reloads from disk first if the backing file changed. On a reload error it
+    /// logs and falls back to the ACTUAL last-known in-memory set
+    /// ([`SessionStore::cached_all`]) rather than an empty list.
+    /// Test: `manager_get_reflects_out_of_process_write`,
+    /// `manager_list_returns_last_known_on_reload_error`.
     pub async fn list(&self) -> Vec<SessionRecord> {
-        match self.store.write().await.all().await {
+        let mut guard = self.store.write().await;
+        match guard.all().await {
             Ok(records) => records,
             Err(e) => {
-                warn!("session list: reload failed: {e}; returning last-known set");
-                Vec::new()
+                let last_known = guard.cached_all();
+                warn!(
+                    count = last_known.len(),
+                    "session list: reload failed: {e}; returning last-known in-memory set"
+                );
+                last_known
             }
         }
     }

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -60,8 +60,10 @@ struct StoredData {
 /// would compare equal and the reader would miss the second write. Pairing the
 /// mtime with the byte length catches a same-second write that changed the file
 /// size, which a state transition (different JSON length) almost always does.
-/// What: the file's last-modified `SystemTime` and its length in bytes. `None`
-/// for either component means "unknown" (file absent or metadata unsupported).
+/// What: the file's last-modified `SystemTime` (an `Option` — `None` when the
+/// platform/filesystem cannot report an mtime) and its length in bytes. The whole
+/// `FileSig` is wrapped in an `Option` by callers, where `None` means "file
+/// absent / could not be stat'd".
 /// Test: `store_reload_picks_up_external_write`, `store_reload_noop_when_unchanged`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct FileSig {
@@ -149,19 +151,24 @@ impl SessionStore {
     /// logic; factoring it out keeps the two callers in lock-step so a reload can
     /// never diverge from an initial load.
     /// What: if `path` exists, reads and JSON-parses it and returns `(data,
-    /// Some(sig))`; if absent, returns `(empty, None)`. The signature is read
-    /// from the same metadata, so it reflects the bytes just parsed.
-    /// Test: `store_reload_picks_up_external_write`, `store_load_save_round_trip`.
+    /// Some(sig))`; if absent, returns `(empty, None)`. The signature is captured
+    /// from a stat taken AFTER `read_to_string` so it reflects the bytes actually
+    /// parsed: were we to stat first and another process renamed a new file into
+    /// place between the stat and the read, the old (mtime, len) would be paired
+    /// with the new bytes, and `reload_if_changed` would keep seeing a mismatch
+    /// (re-reading on every read) until the next local save reset `last_sig`.
+    /// Re-statting after the read closes that TOCTOU window. If the post-read
+    /// stat fails (file vanished mid-read), `mtime`/`len` fall back to `None`/`0`,
+    /// which compares unequal and harmlessly forces a future reload.
+    /// Test: `store_reload_picks_up_external_write`, `store_load_save_round_trip`,
+    /// `store_read_file_sig_matches_post_read_bytes`.
     async fn read_file(path: &Path) -> Result<(StoredData, Option<FileSig>), StoreError> {
-        match fs::metadata(path).await {
-            Ok(meta) => {
-                let raw = fs::read_to_string(path).await?;
+        match fs::read_to_string(path).await {
+            Ok(raw) => {
                 let data = serde_json::from_str::<StoredData>(&raw)
                     .map_err(|e| StoreError::Serialize(e.to_string()))?;
-                let sig = FileSig {
-                    mtime: meta.modified().ok(),
-                    len: meta.len(),
-                };
+                // Stat AFTER the read so the signature matches the bytes we parsed.
+                let sig = Self::sig_of(path).await.unwrap_or_default();
                 Ok((data, Some(sig)))
             }
             Err(_) => {
@@ -281,7 +288,37 @@ impl SessionStore {
     /// Test: `store_upsert_and_get`, `store_reload_picks_up_external_write`.
     pub async fn all(&mut self) -> Result<Vec<SessionRecord>, StoreError> {
         self.reload_if_changed().await?;
-        Ok(self.data.sessions.values().cloned().collect())
+        Ok(self.cached_all())
+    }
+
+    /// Return all stored session records from the in-memory map WITHOUT reloading.
+    ///
+    /// Why: a transient reload I/O error (e.g. an NFS hiccup) must never make the
+    /// daemon report an EMPTY fleet (#1219 follow-up). When `all()`'s reload fails,
+    /// callers fall back to this last-known set so a stat failure degrades to
+    /// "slightly stale" rather than "all sessions vanished".
+    /// What: clones and collects the current in-memory values; no disk access.
+    /// Test: `store_cached_all_returns_last_known`, exercised end-to-end by
+    /// `manager_list_returns_last_known_on_reload_error` in tests.rs.
+    pub fn cached_all(&self) -> Vec<SessionRecord> {
+        self.data.sessions.values().cloned().collect()
+    }
+
+    /// Look up a record from the in-memory map WITHOUT reloading from disk.
+    ///
+    /// Why: a transient reload error on a single-record lookup must not surface as
+    /// a false "session not found" (#1219 follow-up); `get()` falls back to this
+    /// last-known record when the reload fails but the id is still in memory.
+    /// What: returns a clone of the cached record or `StoreError::NotFound`; no
+    /// disk access.
+    /// Test: `manager_get_returns_last_known_on_reload_error` in tests.rs.
+    pub fn cached_get(&self, id: &ManagedSessionId) -> Result<SessionRecord, StoreError> {
+        let key = id.to_string();
+        self.data
+            .sessions
+            .get(&key)
+            .cloned()
+            .ok_or(StoreError::NotFound(key))
     }
 
     /// Remove a session record from the store and persist.
@@ -472,5 +509,81 @@ mod tests {
         assert_eq!(all.len(), 2, "both X and Y must survive: {all:?}");
         assert!(store_a.get(&id_x).await.is_ok(), "X present");
         assert!(store_a.get(&id_y).await.is_ok(), "Y must survive A's write");
+    }
+
+    /// Why: #1219 follow-up — `cached_all`/`cached_get` are the no-reload fallback
+    /// that keeps a transient reload error from looking like an empty fleet or a
+    /// missing session. This pins that they return the in-memory set without
+    /// touching disk and without reloading.
+    /// What: seeds a record, corrupts the file on disk (which would fail a reload),
+    /// and asserts the cached accessors still return the seeded record.
+    /// Test: this test.
+    #[tokio::test]
+    async fn store_cached_accessors_ignore_disk() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut store = SessionStore::load(dir.path()).await.expect("load");
+        let id = ManagedSessionId::new();
+        store.upsert(make_record(id)).await.expect("upsert");
+
+        // Corrupt the backing file: a reload would now fail, but the cached
+        // accessors never read disk, so they keep serving the last-known record.
+        let path = dir.path().join("sessions.json");
+        std::fs::write(&path, b"{ not json ]").expect("corrupt file");
+
+        assert_eq!(store.cached_all().len(), 1, "cached_all serves last-known");
+        assert_eq!(
+            store.cached_get(&id).expect("cached_get hit").id,
+            id,
+            "cached_get serves last-known record"
+        );
+        let missing = ManagedSessionId::new();
+        assert!(
+            matches!(store.cached_get(&missing), Err(StoreError::NotFound(_))),
+            "cached_get still reports genuinely-absent ids as NotFound"
+        );
+
+        // And `all()`/`get()` now propagate the reload error (the manager layer
+        // is responsible for falling back to the cached accessors).
+        assert!(store.all().await.is_err(), "all() propagates reload error");
+    }
+
+    /// Why: #1227 review (TOCTOU) — `read_file` must capture the file signature
+    /// from a stat taken AFTER the read, so the `(mtime, len)` pair always matches
+    /// the bytes just parsed. If the signature were captured before the read, a
+    /// concurrent rename in the window would pair an old signature with new bytes,
+    /// and `reload_if_changed` would re-read on every subsequent call until the
+    /// next local save reset `last_sig`.
+    /// What: writes a known file, loads it (so `last_sig` is captured post-read),
+    /// and asserts an immediate `reload_if_changed` is a no-op — i.e. the recorded
+    /// signature's `len` equals the on-disk byte length of the content we parsed.
+    /// Test: this test.
+    #[tokio::test]
+    async fn store_read_file_sig_matches_post_read_bytes() {
+        let dir = TempDir::new().expect("tempdir");
+        let id = ManagedSessionId::new();
+
+        // Author a file via a save so it contains real, parseable JSON.
+        let mut writer = SessionStore::load(dir.path()).await.expect("load writer");
+        writer.upsert(make_record(id)).await.expect("seed");
+
+        // Fresh reader loads the same file; its last_sig is captured AFTER the
+        // read, so it must equal the on-disk length.
+        let mut reader = SessionStore::load(dir.path()).await.expect("load reader");
+        let on_disk_len = std::fs::metadata(dir.path().join("sessions.json"))
+            .expect("stat")
+            .len();
+        let sig = reader.last_sig.expect("reader captured a signature");
+        assert_eq!(
+            sig.len, on_disk_len,
+            "recorded signature length must match the bytes that were parsed"
+        );
+
+        // Because the signature matches the parsed bytes, an immediate reload with
+        // no external write is a clean no-op (record still present, unchanged).
+        reader.reload_if_changed().await.expect("reload no-op");
+        assert!(
+            reader.get(&id).await.is_ok(),
+            "record still present after no-op reload"
+        );
     }
 }

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -9,6 +9,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -51,19 +52,56 @@ struct StoredData {
     sessions: HashMap<String, SessionRecord>,
 }
 
+/// A cheap freshness fingerprint for the backing file.
+///
+/// Why: the cross-process reload check (#1219) keys off "did the file change
+/// since we last touched it". An mtime alone is insufficient on filesystems
+/// whose mtime resolution is coarse (1s on some): two writes in the same second
+/// would compare equal and the reader would miss the second write. Pairing the
+/// mtime with the byte length catches a same-second write that changed the file
+/// size, which a state transition (different JSON length) almost always does.
+/// What: the file's last-modified `SystemTime` and its length in bytes. `None`
+/// for either component means "unknown" (file absent or metadata unsupported).
+/// Test: `store_reload_picks_up_external_write`, `store_reload_noop_when_unchanged`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct FileSig {
+    /// File modification time, if the platform/filesystem reports one.
+    mtime: Option<SystemTime>,
+    /// File length in bytes.
+    len: u64,
+}
+
 /// Async, file-backed store for [`SessionRecord`]s.
 ///
 /// Why: the session manager must be able to reload all known sessions after a
 /// crash or restart so that reconciliation can re-adopt live tmux sessions.
-/// What: holds the in-memory map and the path to the backing JSON file; all
-/// mutations call `save()` immediately to keep the file consistent.
-/// Test: `store_load_save_round_trip`, `store_upsert_and_get`.
+/// Critically (#1219), the daemon and the supervisor run as SEPARATE PROCESSES
+/// over the SAME `sessions.json`; without a freshness check the daemon's
+/// load-once in-memory map serves stale state forever once the supervisor writes
+/// a transition. Tracking the file's mtime lets the store detect another
+/// process's write and reload before answering a read, keeping the on-disk file
+/// the single source of truth across processes.
+/// What: holds the in-memory map, the path to the backing JSON file, and the
+/// file modification time observed at the last load/save; all mutations call
+/// `save()` immediately to keep the file consistent, and reads first call
+/// [`Self::reload_if_changed`] to pick up out-of-process writes.
+/// Test: `store_load_save_round_trip`, `store_upsert_and_get`,
+/// `store_reload_picks_up_external_write`.
 #[derive(Debug)]
 pub struct SessionStore {
     /// In-memory sessions map.
     data: StoredData,
     /// Path to the backing `sessions.json` file.
     path: PathBuf,
+    /// Freshness fingerprint of `path` as of the last successful load or save.
+    ///
+    /// Why: comparing this against the file's current fingerprint lets a read
+    /// detect that another process (e.g. the supervisor) wrote the file since
+    /// this store last touched it, triggering a reload. `None` means the file did
+    /// not exist at last observation (a fresh, never-saved store).
+    /// What: the (mtime, len) pair captured from the file's metadata.
+    /// Test: `store_reload_picks_up_external_write`.
+    last_sig: Option<FileSig>,
 }
 
 impl SessionStore {
@@ -77,31 +115,123 @@ impl SessionStore {
     /// Test: `store_load_save_round_trip`.
     pub async fn load(data_dir: &Path) -> Result<Self, StoreError> {
         let path = data_dir.join("sessions.json");
-        let data = if path.exists() {
-            let raw = fs::read_to_string(&path).await?;
-            serde_json::from_str::<StoredData>(&raw)
-                .map_err(|e| StoreError::Serialize(e.to_string()))?
-        } else {
-            debug!(path = %path.display(), "no session store file found; starting fresh");
-            StoredData::default()
-        };
-        Ok(Self { data, path })
+        let (data, last_sig) = Self::read_file(&path).await?;
+        Ok(Self {
+            data,
+            path,
+            last_sig,
+        })
     }
 
-    /// Persist the current in-memory state to disk.
+    /// Stat `path` and return its freshness fingerprint, or `None` if absent.
+    ///
+    /// Why: both the reload check and `save` need to capture the same (mtime,
+    /// len) signature; centralising it keeps "what counts as the file's
+    /// identity" in one place.
+    /// What: on `metadata` success returns `Some(FileSig { mtime, len })`; on any
+    /// stat error (most commonly: file does not exist) returns `None`.
+    /// Test: exercised via `store_reload_*` tests.
+    async fn sig_of(path: &Path) -> Option<FileSig> {
+        let meta = fs::metadata(path).await.ok()?;
+        Some(FileSig {
+            // `modified()` can be unsupported on exotic filesystems; `None` there
+            // makes the (mtime, len) pair compare unequal so reads reload — correct,
+            // just less efficient — rather than risk serving stale data.
+            mtime: meta.modified().ok(),
+            len: meta.len(),
+        })
+    }
+
+    /// Read and parse the backing file, returning the data and its fingerprint.
+    ///
+    /// Why: both [`Self::load`] and [`Self::reload_if_changed`] need the exact
+    /// same "read the file (or treat absence as empty) and capture its signature"
+    /// logic; factoring it out keeps the two callers in lock-step so a reload can
+    /// never diverge from an initial load.
+    /// What: if `path` exists, reads and JSON-parses it and returns `(data,
+    /// Some(sig))`; if absent, returns `(empty, None)`. The signature is read
+    /// from the same metadata, so it reflects the bytes just parsed.
+    /// Test: `store_reload_picks_up_external_write`, `store_load_save_round_trip`.
+    async fn read_file(path: &Path) -> Result<(StoredData, Option<FileSig>), StoreError> {
+        match fs::metadata(path).await {
+            Ok(meta) => {
+                let raw = fs::read_to_string(path).await?;
+                let data = serde_json::from_str::<StoredData>(&raw)
+                    .map_err(|e| StoreError::Serialize(e.to_string()))?;
+                let sig = FileSig {
+                    mtime: meta.modified().ok(),
+                    len: meta.len(),
+                };
+                Ok((data, Some(sig)))
+            }
+            Err(_) => {
+                debug!(path = %path.display(), "no session store file found; starting fresh");
+                Ok((StoredData::default(), None))
+            }
+        }
+    }
+
+    /// Reload the in-memory map from disk if the backing file changed.
+    ///
+    /// Why: #1219 — another process (the supervisor) may have written a state
+    /// transition to the shared `sessions.json` since this store last touched it.
+    /// A read that does not first reconcile with disk serves stale state. The
+    /// on-disk file is authoritative across processes, so reads reload from it.
+    /// What: stats the file; if its (mtime, len) fingerprint differs from
+    /// `last_sig` (covering appeared / disappeared / modified, and same-second
+    /// writes that changed the length), re-reads and replaces `data` and
+    /// `last_sig`. A matching fingerprint is a fast no-op (one stat, no parse).
+    /// This is purely additive over disk state: in-memory writes are always
+    /// flushed via `save()` before this store yields its lock, so a reload can
+    /// never drop an unpersisted local mutation.
+    /// Test: `store_reload_picks_up_external_write`,
+    /// `store_reload_noop_when_unchanged`.
+    pub async fn reload_if_changed(&mut self) -> Result<(), StoreError> {
+        let current = Self::sig_of(&self.path).await;
+        // Reload unless the file is present AND its fingerprint exactly matches
+        // what we last observed. A `None` on either side (file absent, or never
+        // saved) is treated as "changed" so we never miss an external write.
+        let unchanged = matches!((current, self.last_sig), (Some(a), Some(b)) if a == b);
+        if unchanged {
+            return Ok(());
+        }
+        let (data, sig) = Self::read_file(&self.path).await?;
+        self.data = data;
+        self.last_sig = sig;
+        debug!(path = %self.path.display(), "session store reloaded after external change");
+        Ok(())
+    }
+
+    /// Persist the current in-memory state to disk atomically.
     ///
     /// Why: every mutating operation must flush to disk so that the store
-    /// survives a daemon crash immediately after the mutation.
+    /// survives a daemon crash immediately after the mutation. Because the
+    /// daemon and the supervisor read this file from SEPARATE processes (#1219),
+    /// the write must be atomic — a plain `fs::write` truncates then rewrites, so
+    /// a concurrent reader can observe a half-written (unparseable) file. Writing
+    /// a temp file and renaming it into place makes the swap atomic on POSIX, so
+    /// a cross-process reader always sees either the old or the new file whole.
     /// What: serializes `self.data` to JSON, creates parent directories if
-    /// needed, then writes the file atomically via a temp write.
-    /// Test: verified indirectly by every mutating store test.
-    pub async fn save(&self) -> Result<(), StoreError> {
+    /// needed, writes a sibling `sessions.json.tmp`, then renames it over the
+    /// real path; finally records the resulting mtime so a subsequent
+    /// [`Self::reload_if_changed`] treats our own write as "unchanged".
+    /// Test: verified indirectly by every mutating store test;
+    /// `store_reload_picks_up_external_write` exercises the cross-process path.
+    pub async fn save(&mut self) -> Result<(), StoreError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).await?;
         }
         let json = serde_json::to_string_pretty(&self.data)
             .map_err(|e| StoreError::Serialize(e.to_string()))?;
-        fs::write(&self.path, json).await?;
+        // Atomic swap: write to a temp sibling then rename over the target so a
+        // concurrent reader in another process never sees a torn file.
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, json).await?;
+        fs::rename(&tmp, &self.path).await?;
+        // Record the fingerprint of the bytes we just wrote so a subsequent
+        // `reload_if_changed` treats our own write as "unchanged" and does not
+        // pointlessly re-read the file we just authored (#1219).
+        self.last_sig = Self::sig_of(&self.path).await;
         debug!(path = %self.path.display(), "session store saved");
         Ok(())
     }
@@ -110,35 +240,48 @@ impl SessionStore {
     ///
     /// Why: session state changes (Started → Active, Active → Dead, etc.) must
     /// be reflected in the store immediately so recovery sees the latest state.
-    /// What: inserts or replaces the record keyed by its UUID string, then
-    /// saves the store to disk.
-    /// Test: `store_upsert_and_get`.
+    /// A write must not clobber a concurrent out-of-process write (#1219): if
+    /// the supervisor changed OTHER records since this store last loaded, blindly
+    /// re-serializing our stale map would lose their changes. Reloading first
+    /// applies this single-record mutation on top of the freshest disk state.
+    /// What: reloads from disk if the file changed, inserts or replaces the
+    /// record keyed by its UUID string, then saves the store to disk.
+    /// Test: `store_upsert_and_get`, `store_upsert_preserves_concurrent_write`.
     pub async fn upsert(&mut self, record: SessionRecord) -> Result<(), StoreError> {
+        self.reload_if_changed().await?;
         let key = record.id.to_string();
         self.data.sessions.insert(key, record);
         self.save().await
     }
 
-    /// Look up a session record by id.
+    /// Look up a session record by id, reloading from disk first if it changed.
     ///
     /// Why: the manager's `get()` method needs a typed lookup that returns a
-    /// structured not-found error rather than `Option::None`.
-    /// What: returns a clone of the stored record or `StoreError::NotFound`.
-    /// Test: `store_upsert_and_get`.
-    pub fn get(&self, id: &ManagedSessionId) -> Result<SessionRecord, StoreError> {
+    /// structured not-found error rather than `Option::None`. It must also see
+    /// out-of-process writes (#1219): if the supervisor changed the file, the
+    /// daemon's lookup has to reflect that, so this reloads-on-read first.
+    /// What: calls [`Self::reload_if_changed`], then returns a clone of the
+    /// stored record or `StoreError::NotFound`. Takes `&mut self` because a
+    /// reload mutates the in-memory map.
+    /// Test: `store_upsert_and_get`, `store_reload_picks_up_external_write`.
+    pub async fn get(&mut self, id: &ManagedSessionId) -> Result<SessionRecord, StoreError> {
+        self.reload_if_changed().await?;
         let key = id.to_string();
         let record = self.data.sessions.get(&key).cloned();
         record.ok_or(StoreError::NotFound(key))
     }
 
-    /// Return all stored session records.
+    /// Return all stored session records, reloading from disk first if changed.
     ///
     /// Why: the manager's `list()` method and the reconcile pass both need the
-    /// full set of known sessions.
-    /// What: clones and collects all values from the in-memory map.
-    /// Test: `store_upsert_and_get`.
-    pub fn all(&self) -> Vec<SessionRecord> {
-        self.data.sessions.values().cloned().collect()
+    /// full set of known sessions, and (since #1219) must reflect any write made
+    /// by another process before answering.
+    /// What: calls [`Self::reload_if_changed`], then clones and collects all
+    /// values from the in-memory map. Takes `&mut self` for the reload.
+    /// Test: `store_upsert_and_get`, `store_reload_picks_up_external_write`.
+    pub async fn all(&mut self) -> Result<Vec<SessionRecord>, StoreError> {
+        self.reload_if_changed().await?;
+        Ok(self.data.sessions.values().cloned().collect())
     }
 
     /// Remove a session record from the store and persist.
@@ -149,6 +292,9 @@ impl SessionStore {
     /// the id was not present.
     /// Test: `store_remove`.
     pub async fn remove(&mut self, id: &ManagedSessionId) -> Result<(), StoreError> {
+        // Reload first so a concurrent out-of-process write (#1219) is not lost
+        // when we re-serialize, and so the not-found warning is accurate.
+        self.reload_if_changed().await?;
         let key = id.to_string();
         if self.data.sessions.remove(&key).is_none() {
             warn!(id = %key, "remove: session not found in store");
@@ -184,19 +330,28 @@ mod tests {
         }
     }
 
+    /// Build a record with an explicit state so tests can write a specific
+    /// transition straight to disk (simulating an out-of-process write).
+    fn make_record_with_state(id: ManagedSessionId, state: ManagedSessionState) -> SessionRecord {
+        SessionRecord {
+            state,
+            ..make_record(id)
+        }
+    }
+
     #[tokio::test]
     async fn store_load_save_round_trip() {
         let dir = TempDir::new().expect("tempdir");
         let data_dir = dir.path();
 
         let mut store = SessionStore::load(data_dir).await.expect("load empty");
-        assert!(store.all().is_empty());
+        assert!(store.all().await.expect("all").is_empty());
 
         let id = ManagedSessionId::new();
         store.upsert(make_record(id)).await.expect("upsert");
 
-        let store2 = SessionStore::load(data_dir).await.expect("reload");
-        let record = store2.get(&id).expect("get after reload");
+        let mut store2 = SessionStore::load(data_dir).await.expect("reload");
+        let record = store2.get(&id).await.expect("get after reload");
         assert_eq!(record.id, id);
         assert_eq!(record.state, ManagedSessionState::Active);
     }
@@ -209,9 +364,9 @@ mod tests {
         let id = ManagedSessionId::new();
         store.upsert(make_record(id)).await.expect("upsert");
 
-        let record = store.get(&id).expect("get");
+        let record = store.get(&id).await.expect("get");
         assert_eq!(record.id, id);
-        assert_eq!(store.all().len(), 1);
+        assert_eq!(store.all().await.expect("all").len(), 1);
     }
 
     #[tokio::test]
@@ -221,10 +376,101 @@ mod tests {
 
         let id = ManagedSessionId::new();
         store.upsert(make_record(id)).await.expect("upsert");
-        assert_eq!(store.all().len(), 1);
+        assert_eq!(store.all().await.expect("all").len(), 1);
 
         store.remove(&id).await.expect("remove");
-        assert!(store.all().is_empty());
-        assert!(matches!(store.get(&id), Err(StoreError::NotFound(_))));
+        assert!(store.all().await.expect("all").is_empty());
+        assert!(matches!(store.get(&id).await, Err(StoreError::NotFound(_))));
+    }
+
+    /// Why: #1219 — when another process writes the shared `sessions.json`, a
+    /// store that already loaded must pick up the change on its next read rather
+    /// than serving stale state forever. This is the core reload-on-read guard.
+    /// What: store A loads and reads a record (state Active). A SECOND store B
+    /// over the same dir writes a changed record (state Stopped) — standing in
+    /// for the supervisor's out-of-process write. Then store A's `get` must
+    /// return the NEW (Stopped) state, and `all` must reflect it too.
+    /// Test: this test.
+    #[tokio::test]
+    async fn store_reload_picks_up_external_write() {
+        let dir = TempDir::new().expect("tempdir");
+        let id = ManagedSessionId::new();
+
+        // Store A seeds an Active record and reads it into memory.
+        let mut store_a = SessionStore::load(dir.path()).await.expect("load A");
+        store_a
+            .upsert(make_record_with_state(id, ManagedSessionState::Active))
+            .await
+            .expect("upsert A");
+        let before = store_a.get(&id).await.expect("get A before");
+        assert_eq!(before.state, ManagedSessionState::Active);
+
+        // Store B (a different process's view) overwrites the record as Stopped.
+        let mut store_b = SessionStore::load(dir.path()).await.expect("load B");
+        store_b
+            .upsert(make_record_with_state(id, ManagedSessionState::Stopped))
+            .await
+            .expect("upsert B");
+
+        // Store A must now observe the external write, not its stale Active copy.
+        let after = store_a.get(&id).await.expect("get A after");
+        assert_eq!(
+            after.state,
+            ManagedSessionState::Stopped,
+            "store A must reload the external Stopped write"
+        );
+        let all = store_a.all().await.expect("all A");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].state, ManagedSessionState::Stopped);
+    }
+
+    /// Why: the reload check must be a cheap no-op when nothing changed, so the
+    /// common (no concurrent writer) path does not re-parse the file on every
+    /// read. This guards that an unchanged file does not perturb in-memory state.
+    /// What: seeds a record, calls `reload_if_changed` directly, and asserts the
+    /// data is unchanged and the record still readable.
+    /// Test: this test.
+    #[tokio::test]
+    async fn store_reload_noop_when_unchanged() {
+        let dir = TempDir::new().expect("tempdir");
+        let id = ManagedSessionId::new();
+        let mut store = SessionStore::load(dir.path()).await.expect("load");
+        store.upsert(make_record(id)).await.expect("upsert");
+
+        // No external write happened, so this must be a no-op that preserves data.
+        store.reload_if_changed().await.expect("reload no-op");
+        let record = store.get(&id).await.expect("get");
+        assert_eq!(record.id, id);
+    }
+
+    /// Why: an upsert must not clobber a concurrent out-of-process write to a
+    /// DIFFERENT record (#1219). Because upsert reloads before saving, the other
+    /// process's record must survive this store's single-record write.
+    /// What: store A holds record X. Store B writes a new record Y to disk. Then
+    /// store A upserts an update to X. Both X and Y must be present afterward.
+    /// Test: this test.
+    #[tokio::test]
+    async fn store_upsert_preserves_concurrent_write() {
+        let dir = TempDir::new().expect("tempdir");
+        let id_x = ManagedSessionId::new();
+        let id_y = ManagedSessionId::new();
+
+        let mut store_a = SessionStore::load(dir.path()).await.expect("load A");
+        store_a.upsert(make_record(id_x)).await.expect("seed X");
+
+        // Concurrent process writes Y.
+        let mut store_b = SessionStore::load(dir.path()).await.expect("load B");
+        store_b.upsert(make_record(id_y)).await.expect("write Y");
+
+        // Store A updates X (state change). It must reload Y first, not drop it.
+        store_a
+            .upsert(make_record_with_state(id_x, ManagedSessionState::Stopped))
+            .await
+            .expect("update X");
+
+        let all = store_a.all().await.expect("all A");
+        assert_eq!(all.len(), 2, "both X and Y must survive: {all:?}");
+        assert!(store_a.get(&id_x).await.is_ok(), "X present");
+        assert!(store_a.get(&id_y).await.is_ok(), "Y must survive A's write");
     }
 }

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -509,7 +509,7 @@ async fn manager_send_input() {
     // Transition to Active so send_input does not reject.
     {
         let mut store = mgr.store.write().await;
-        let mut r = store.get(&record.id).unwrap();
+        let mut r = store.get(&record.id).await.unwrap();
         r.state = ManagedSessionState::Active;
         store.upsert(r).await.unwrap();
     }
@@ -545,7 +545,7 @@ async fn manager_send_input_rejected_for_stopped_and_decommissioned() {
     // Test Stopped rejection.
     {
         let mut store = mgr.store.write().await;
-        let mut r = store.get(&record.id).unwrap();
+        let mut r = store.get(&record.id).await.unwrap();
         r.state = ManagedSessionState::Stopped;
         store.upsert(r).await.unwrap();
     }
@@ -555,7 +555,7 @@ async fn manager_send_input_rejected_for_stopped_and_decommissioned() {
     // Test Decommissioned rejection.
     {
         let mut store = mgr.store.write().await;
-        let mut r = store.get(&record.id).unwrap();
+        let mut r = store.get(&record.id).await.unwrap();
         r.state = ManagedSessionState::Decommissioned;
         store.upsert(r).await.unwrap();
     }
@@ -593,7 +593,7 @@ async fn manager_env_scrub_command_sent() {
     mgr.send_input(
         &{
             let mut store = mgr.store.write().await;
-            let mut r = store.get(&record.id).unwrap();
+            let mut r = store.get(&record.id).await.unwrap();
             r.state = ManagedSessionState::Active;
             store.upsert(r).await.unwrap();
             record.id
@@ -630,7 +630,7 @@ async fn manager_answer_decision() {
     // Seed a pending decision so answer_decision has something to clear.
     {
         let mut store = mgr.store.write().await;
-        let mut r = store.get(&record.id).unwrap();
+        let mut r = store.get(&record.id).await.unwrap();
         r.pending_decision = Some("merge or rebase?".into());
         r.proposed_default = Some("rebase".into());
         store.upsert(r).await.unwrap();
@@ -804,5 +804,80 @@ async fn manager_create_persists_runtime() {
         reloaded.runtime,
         crate::runtime::RuntimeKind::Tcode,
         "runtime must survive persistence so resume re-spawns the same backend"
+    );
+}
+
+/// Why: #1219 — the daemon and the supervisor each own a `SessionManager` over
+/// the SAME on-disk `sessions.json`. When the supervisor writes a state change
+/// (e.g. auto-resume flips `stopped` → `active`), the daemon's manager MUST
+/// reflect that transition on its next read; previously it served stale state
+/// from its load-once in-memory map forever. This test simulates the supervisor
+/// as a second, independent `SessionManager` over the same data dir, writes a
+/// state change through it, and asserts the first manager's `get` returns the
+/// NEW state — proving reload-on-read.
+/// What: builds two managers over one temp data dir, creates+stops a session via
+/// manager A (so both managers' file is seeded), then resumes via manager B
+/// (out-of-process write to disk), then asserts manager A's `get` returns
+/// `Active`, not the stale `Stopped` it last held in memory.
+/// Test: this test.
+#[tokio::test]
+async fn manager_get_reflects_out_of_process_write() {
+    let dir = TempDir::new().unwrap();
+
+    // Manager A = the daemon's view; Manager B = the supervisor's view.
+    // Both point at the same data dir / sessions.json.
+    let (mgr_a, _fake_a) = make_manager(&dir).await;
+    let (mgr_b, fake_b) = make_manager(&dir).await;
+
+    // Create + stop a session via A. The record is now `Stopped` on disk.
+    let record = mgr_a
+        .create(
+            "shared-state task".into(),
+            Some(PathBuf::from("/tmp/wt-shared")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    let id = record.id;
+    mgr_a.stop(&id).await.expect("stop");
+
+    // A reads the session: it now holds `Stopped` in its in-memory map.
+    let before = mgr_a.get(&id).await.expect("get before");
+    assert_eq!(
+        before.state,
+        ManagedSessionState::Stopped,
+        "precondition: manager A sees the session as Stopped"
+    );
+
+    // The supervisor (manager B) resumes the session out of A's process. This
+    // writes `Active` to the shared sessions.json. B reloads-on-read first, so
+    // it sees the Stopped record A persisted, then transitions it to Active.
+    // The fake tmux driver must report the session as NOT existing so resume's
+    // kill-stale path is a no-op, then must accept the create_session call.
+    fake_b.seeded_names.lock().unwrap().clear();
+    mgr_b.resume(&id).await.expect("supervisor resume");
+
+    // The daemon (manager A) reads again. WITHOUT reload-on-read this returns the
+    // stale `Stopped`; WITH it, A re-reads the file and returns `Active`.
+    let after = mgr_a.get(&id).await.expect("get after");
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Active,
+        "manager A must reflect the out-of-process resume written by manager B"
+    );
+
+    // `list` must also reflect the cross-process write.
+    let listed = mgr_a.list().await;
+    let found = listed
+        .iter()
+        .find(|r| r.id == id)
+        .expect("session present in list");
+    assert_eq!(
+        found.state,
+        ManagedSessionState::Active,
+        "manager A's list must also reflect the out-of-process write"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -881,3 +881,110 @@ async fn manager_get_reflects_out_of_process_write() {
         "manager A's list must also reflect the out-of-process write"
     );
 }
+
+/// Corrupt the manager's backing `sessions.json` so the next reload-on-read
+/// fails. Writing garbage (a) changes the file length so `reload_if_changed`
+/// detects a change and re-reads, and (b) makes `serde_json::from_str` fail with
+/// `StoreError::Serialize` — a faithful stand-in for a transient reload I/O error
+/// (NFS hiccup, partial write observed by a reader, etc.).
+fn corrupt_store_file(mgr: &SessionManager) {
+    let path = mgr.data_dir().join("sessions.json");
+    std::fs::write(&path, b"{ this is not valid json ]").expect("corrupt store file");
+}
+
+/// Why: #1219 follow-up — `list()` must never report an EMPTY fleet because of a
+/// transient reload error. The old code returned `Vec::new()` on reload failure
+/// (despite a comment claiming "last-known set"), which would mislead the
+/// supervisor/operator into thinking every session vanished. This test pins the
+/// corrected behavior: a reload error yields the ACTUAL last-known in-memory set.
+/// What: creates a session (so the manager holds it in memory and on disk), then
+/// corrupts `sessions.json` so the next `list()` reload fails, and asserts
+/// `list()` still returns the previously-loaded record rather than an empty Vec.
+/// Test: this test.
+#[tokio::test]
+async fn manager_list_returns_last_known_on_reload_error() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "fleet-visibility task".into(),
+            Some(PathBuf::from("/tmp/wt-lastknown")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    let id = record.id;
+
+    // Sanity: with a healthy file, list sees the one session.
+    assert_eq!(
+        mgr.list().await.len(),
+        1,
+        "precondition: one session listed"
+    );
+
+    // Inject a transient reload failure by corrupting the backing file.
+    corrupt_store_file(&mgr);
+
+    // The reload now fails — but list() must fall back to the last-known set,
+    // NOT report an empty fleet.
+    let listed = mgr.list().await;
+    assert_eq!(
+        listed.len(),
+        1,
+        "list() must return the last-known set on reload error, not empty: {listed:?}"
+    );
+    assert_eq!(
+        listed[0].id, id,
+        "the last-known record must be the one we created"
+    );
+}
+
+/// Why: #1219 follow-up — a transient reload error on a single-session lookup
+/// must NOT surface as a false `SessionNotFound`; that would make a still-present
+/// session look gone. `get()` must fall back to the last-known in-memory record.
+/// What: creates a session, corrupts `sessions.json` so the next `get()` reload
+/// fails, and asserts `get()` still returns the previously-loaded record instead
+/// of erroring.
+/// Test: this test.
+#[tokio::test]
+async fn manager_get_returns_last_known_on_reload_error() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "single-session task".into(),
+            Some(PathBuf::from("/tmp/wt-getlastknown")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    let id = record.id;
+
+    // Inject a transient reload failure by corrupting the backing file.
+    corrupt_store_file(&mgr);
+
+    // get() must fall back to the last-known record, not a false not-found.
+    let got = mgr
+        .get(&id)
+        .await
+        .expect("get must return last-known record on reload error");
+    assert_eq!(got.id, id, "get() returned the last-known record");
+
+    // A genuinely-absent id must still be a not-found, even under reload error.
+    let missing = ManagedSessionId::new();
+    assert!(
+        matches!(
+            mgr.get(&missing).await,
+            Err(ManagedError::SessionNotFound(_))
+        ),
+        "an unknown id must still yield SessionNotFound"
+    );
+}

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -437,7 +437,7 @@ async fn tick_never_answers_pending_decision() {
     let ids = seed_sessions(&mgr, 1, ManagedSessionState::Active, &ws).await;
     {
         let mut store = mgr.store.write().await;
-        let mut r = store.get(&ids[0]).expect("get");
+        let mut r = store.get(&ids[0]).await.expect("get");
         r.pending_decision = Some("Force-push to main?".into());
         store.upsert(r).await.expect("upsert");
     }


### PR DESCRIPTION
## Summary

Fixes #1219. The `tm supervisor` process and the `trusty-mpm` daemon each own an **independent** `SessionManager` over the **same** on-disk `~/.trusty-mpm/session-manager/sessions.json`. The daemon loads its store once (via a `OnceCell`) and never re-reads the file, so a transition written by the supervisor (e.g. auto-resume flipping `stopped` → `active`) was never observed — `GET /api/v1/sessions/managed/{id}` served stale `stopped` indefinitely.

## Approach chosen + tradeoff

**Option A — reload-on-read (mtime/len-aware store).** The on-disk file stays the single source of truth; neither process is coupled to the other being up.

- `SessionStore` tracks an `(mtime, len)` freshness fingerprint of the backing file.
- `reload_if_changed()` re-reads from disk only when the fingerprint moves; a matching fingerprint is a one-`stat` no-op (no parse) on the common path.
- **Reads** (`get`/`all`) reload-on-read before answering → cross-process writes are reflected within one read.
- **Writes** (`upsert`/`remove`) reload-*before*-write → a single-record mutation is applied on top of the freshest disk state and never clobbers a concurrent out-of-process write to a *different* record.
- `save()` is now **atomic** (temp file + `rename`) so a cross-process reader never observes a torn, unparseable file.

Manager `get`/`list` upgrade from a read lock to a write lock (the reload mutates the in-memory map); their **public signatures are unchanged**, so all HTTP handlers and the supervisor poller are untouched.

**Why not Option B (supervisor drives the daemon via HTTP):** the supervisor is explicitly the *unattended* process meant to keep the fleet moving even when the daemon isn't reachable; coupling it to a running daemon would regress that. Option A is lowest-coupling, keeps the file authoritative, and is purely unit-testable offline.

## Tests

- `session_manager::tests::manager_get_reflects_out_of_process_write` — two `SessionManager`s over one data dir; a `resume` via manager B (the supervisor) is observed by manager A's (the daemon's) `get` **and** `list`. Fails on `main` (returns stale `Stopped` / `SessionNotFound`), passes here.
- `store::tests::store_reload_picks_up_external_write` — an external write is reloaded on the next read.
- `store::tests::store_reload_noop_when_unchanged` — unchanged file is a no-op.
- `store::tests::store_upsert_preserves_concurrent_write` — a write does not drop a concurrent out-of-process record.

`cargo test -p trusty-mpm`: all suites pass (0 failed). `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: clean. `cargo fmt --check`: clean. `bash scripts/check_line_cap.sh`: OK. Workspace `cargo check`: clean.

## Files changed

- `crates/trusty-mpm/src/session_manager/store.rs` — fingerprint, `reload_if_changed`, atomic `save`, reload-aware `get`/`all`/`upsert`/`remove`, new tests.
- `crates/trusty-mpm/src/session_manager/manager.rs` — `get`/`list` use the reload-on-read store under a write lock.
- `crates/trusty-mpm/src/session_manager/tests.rs` — cross-process test + async API updates.
- `crates/trusty-mpm/src/supervisor/tests.rs` — async `store.get` call update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)