### PR TITLE
fix(trusty-review): make response schemas OpenAI strict-mode compliant (closes #1235)

### DIFF
--- a/crates/trusty-review/src/llm/mod.rs
+++ b/crates/trusty-review/src/llm/mod.rs
@@ -15,10 +15,12 @@ pub mod bedrock;
 pub mod error;
 pub mod models;
 pub mod openrouter;
+pub mod schema;
 
 pub use bedrock::BedrockProvider;
 pub use error::LlmError;
 pub use openrouter::OpenRouterProvider;
+pub use schema::enforce_strict_mode;
 
 use std::sync::Arc;
 

--- a/crates/trusty-review/src/llm/schema.rs
+++ b/crates/trusty-review/src/llm/schema.rs
@@ -99,3 +99,10 @@ pub fn enforce_strict_mode(schema: &mut Value) {
 #[cfg(test)]
 #[path = "schema_tests.rs"]
 mod tests;
+
+// Re-export the recursive strict-mode assertion so the prompt-schema tests in
+// `pipeline::prompt_tests` reuse the single canonical implementation instead of
+// duplicating it. `pub(crate)` keeps it test-only (the `tests` module is
+// `#[cfg(test)]`) and crate-private.
+#[cfg(test)]
+pub(crate) use tests::assert_object_nodes_strict;

--- a/crates/trusty-review/src/llm/schema.rs
+++ b/crates/trusty-review/src/llm/schema.rs
@@ -1,0 +1,101 @@
+//! OpenAI strict-mode JSON Schema enforcement.
+//!
+//! Why: OpenAI's structured-output (`response_format: json_schema`, `strict:
+//! true`) mode — which OpenRouter forwards verbatim for `openai/*` models —
+//! rejects any schema in which an `object` node either omits
+//! `"additionalProperties": false` or fails to list every one of its
+//! `properties` keys in `"required"`.  Hand-written schemas reliably miss one
+//! of these on nested objects (e.g. `findings.items`), producing
+//! `Invalid schema for response_format 'review_output': ...
+//! 'additionalProperties' is required to be supplied and to be false`, which
+//! blocks EVERY OpenAI review.  Bedrock/Anthropic and Gemini are lenient and
+//! accept the stricter-but-valid form unchanged, so enforcing strict mode for
+//! all providers is safe.
+//!
+//! What: [`enforce_strict_mode`] recursively walks a `serde_json::Value` JSON
+//! Schema and, for every node typed `"object"` (or carrying a `properties`
+//! map), sets `"additionalProperties": false` and rewrites `"required"` to
+//! list every property key.  It also descends into array `items`, nested
+//! object `properties`, and the `additionalProperties` schema when it is
+//! itself an object schema (rather than the boolean `false`).
+//!
+//! Test: see `schema_tests.rs` — covers the canonical review/verify shapes,
+//! nested arrays-of-objects, idempotency, and the recursive invariant
+//! (`assert_object_nodes_strict`).
+
+use serde_json::Value;
+
+/// Recursively make a JSON Schema OpenAI strict-mode compliant in place.
+///
+/// Why: a single source of truth for strict-mode compliance means individual
+/// schema builders (`review_response_schema`, `verify_response_schema`) never
+/// have to hand-maintain `additionalProperties`/`required` on every nested
+/// object — they declare the shape and call this once, eliminating the class
+/// of bug where a nested object silently violates strict mode.
+/// What: for every object node, sets `"additionalProperties": false` and makes
+/// `"required"` contain exactly the keys present under `"properties"` (sorted
+/// for deterministic output).  Recurses into `properties` values, array
+/// `items` (object or array of schemas), and a schema-valued
+/// `additionalProperties`.  Non-object values are returned unchanged.
+/// Test: `enforces_additional_properties_false`, `marks_all_properties_required`,
+/// `recurses_into_array_items`, `is_idempotent` in `schema_tests.rs`.
+pub fn enforce_strict_mode(schema: &mut Value) {
+    match schema {
+        Value::Object(map) => {
+            // A node is a closed object schema — the kind strict mode
+            // constrains — when it carries a `properties` map.  We deliberately
+            // gate on `properties` (not a bare `"type": "object"`) so that a
+            // map-style object (object-valued `additionalProperties`, no fixed
+            // `properties`) is not mangled by overwriting its
+            // `additionalProperties` with `false`.  Our review/verify schemas
+            // contain no map types; this keeps the helper correct if one is
+            // ever added.
+            let has_properties = map.get("properties").is_some_and(Value::is_object);
+
+            if has_properties {
+                // Collect property keys first (immutable borrow) before mutating.
+                let mut keys: Vec<String> = map
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .map(|props| props.keys().cloned().collect())
+                    .unwrap_or_default();
+                keys.sort();
+
+                map.insert(
+                    "required".to_string(),
+                    Value::Array(keys.into_iter().map(Value::String).collect()),
+                );
+                map.insert("additionalProperties".to_string(), Value::Bool(false));
+            }
+
+            // Recurse into every nested schema-bearing field.
+            if let Some(props) = map.get_mut("properties").and_then(Value::as_object_mut) {
+                for child in props.values_mut() {
+                    enforce_strict_mode(child);
+                }
+            }
+            if let Some(items) = map.get_mut("items") {
+                enforce_strict_mode(items);
+            }
+            // `additionalProperties` may itself be a sub-schema (object) rather
+            // than the boolean we may have set above; recurse only when it is
+            // still an object schema.
+            if let Some(ap) = map.get_mut("additionalProperties")
+                && ap.is_object()
+            {
+                enforce_strict_mode(ap);
+            }
+        }
+        Value::Array(items) => {
+            // `items` may be an array of schemas (tuple validation); recurse each.
+            for item in items {
+                enforce_strict_mode(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+#[path = "schema_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/llm/schema_tests.rs
+++ b/crates/trusty-review/src/llm/schema_tests.rs
@@ -1,0 +1,186 @@
+//! Unit tests for `enforce_strict_mode`.
+//!
+//! Why: OpenAI strict-mode compliance is a hard provider requirement — a
+//! single non-compliant object node blocks every OpenAI review.  These tests
+//! lock the recursive invariant so a future schema change cannot silently
+//! reintroduce the bug.
+//! What: exercises the canonical review/verify shapes, nested arrays of
+//! objects, and idempotency, and provides a reusable recursive assertion
+//! (`assert_object_nodes_strict`) used here and re-exported for the prompt
+//! schema tests.
+//! Test: this file IS the tests.
+
+use serde_json::{Value, json};
+
+use super::enforce_strict_mode;
+
+/// Recursively assert every object node in a JSON Schema is strict-compliant.
+///
+/// Why: the strict-mode contract is recursive — top-level, array `items`, and
+/// nested object properties must ALL satisfy it; a flat check would miss the
+/// exact bug we are fixing (`findings.items` lacked `additionalProperties`).
+/// What: for every node that is a closed object schema (carries a `properties`
+/// map), asserts `additionalProperties == false` and that `required` lists
+/// exactly the `properties` keys; recurses into `properties`, `items`, and
+/// object-valued `additionalProperties`.
+/// Test: used by the strict-mode assertions in this file.
+fn assert_object_nodes_strict(schema: &Value) {
+    if let Value::Object(map) = schema {
+        // Mirror `enforce_strict_mode`: a node is a closed object schema (the
+        // kind strict mode constrains) when it carries a `properties` map.
+        let has_properties = map.get("properties").is_some_and(Value::is_object);
+
+        if has_properties {
+            assert_eq!(
+                map.get("additionalProperties"),
+                Some(&Value::Bool(false)),
+                "object node must set additionalProperties:false — node: {map:?}"
+            );
+
+            let prop_keys: std::collections::BTreeSet<String> = map
+                .get("properties")
+                .and_then(Value::as_object)
+                .map(|p| p.keys().cloned().collect())
+                .unwrap_or_default();
+            let required_keys: std::collections::BTreeSet<String> = map
+                .get("required")
+                .and_then(Value::as_array)
+                .map(|r| {
+                    r.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            assert_eq!(
+                prop_keys, required_keys,
+                "every property must be required (and vice versa) — node: {map:?}"
+            );
+        }
+
+        if let Some(props) = map.get("properties").and_then(Value::as_object) {
+            for child in props.values() {
+                assert_object_nodes_strict(child);
+            }
+        }
+        if let Some(items) = map.get("items") {
+            assert_object_nodes_strict(items);
+        }
+        if let Some(ap) = map.get("additionalProperties")
+            && ap.is_object()
+        {
+            assert_object_nodes_strict(ap);
+        }
+    } else if let Value::Array(items) = schema {
+        for item in items {
+            assert_object_nodes_strict(item);
+        }
+    }
+}
+
+#[test]
+fn enforces_additional_properties_false() {
+    let mut schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "string" } },
+        "required": ["a"]
+    });
+    enforce_strict_mode(&mut schema);
+    assert_eq!(schema["additionalProperties"], json!(false));
+}
+
+#[test]
+fn marks_all_properties_required() {
+    // Only `a` was required; strict mode must add `b` too.
+    let mut schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "number" } },
+        "required": ["a"]
+    });
+    enforce_strict_mode(&mut schema);
+    let required: std::collections::BTreeSet<&str> = schema["required"]
+        .as_array()
+        .expect("required array")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(required, ["a", "b"].into_iter().collect());
+}
+
+#[test]
+fn recurses_into_array_items() {
+    // The exact bug shape: an array whose items object lacks strict fields.
+    let mut schema = json!({
+        "type": "object",
+        "properties": {
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": { "title": { "type": "string" }, "line": { "type": ["integer", "null"] } },
+                    "required": ["title"]
+                }
+            }
+        },
+        "required": ["findings"]
+    });
+    enforce_strict_mode(&mut schema);
+    assert_object_nodes_strict(&schema);
+    // Specifically assert the nested items object was fixed.
+    let items = &schema["properties"]["findings"]["items"];
+    assert_eq!(items["additionalProperties"], json!(false));
+    let required: std::collections::BTreeSet<&str> = items["required"]
+        .as_array()
+        .expect("required")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(required, ["line", "title"].into_iter().collect());
+}
+
+#[test]
+fn is_idempotent() {
+    let mut schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "string" } },
+        "required": ["a"]
+    });
+    enforce_strict_mode(&mut schema);
+    let once = schema.clone();
+    enforce_strict_mode(&mut schema);
+    assert_eq!(schema, once, "applying strict mode twice must be a no-op");
+}
+
+#[test]
+fn leaves_non_object_schemas_untouched() {
+    // A bare string schema has no object semantics; must not gain `required`.
+    let mut schema = json!({ "type": "string", "enum": ["x", "y"] });
+    let before = schema.clone();
+    enforce_strict_mode(&mut schema);
+    assert_eq!(schema, before);
+}
+
+#[test]
+fn recurses_into_object_valued_additional_properties() {
+    // A map type whose additionalProperties is itself an object schema.
+    let mut schema = json!({
+        "type": "object",
+        "properties": {
+            "meta": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": { "v": { "type": "string" } }
+                }
+            }
+        }
+    });
+    enforce_strict_mode(&mut schema);
+    // The inner additionalProperties object schema must itself be strict.
+    let inner = &schema["properties"]["meta"]["properties"];
+    // `meta` had no `properties`, so its additionalProperties stays the object
+    // schema (we only overwrite to `false` when properties drive the node);
+    // verify recursion still made the inner schema strict.
+    let _ = inner; // meta has no properties; assert via the additionalProperties path
+    let ap = &schema["properties"]["meta"]["additionalProperties"];
+    assert_object_nodes_strict(ap);
+}

--- a/crates/trusty-review/src/llm/schema_tests.rs
+++ b/crates/trusty-review/src/llm/schema_tests.rs
@@ -23,8 +23,10 @@ use super::enforce_strict_mode;
 /// map), asserts `additionalProperties == false` and that `required` lists
 /// exactly the `properties` keys; recurses into `properties`, `items`, and
 /// object-valued `additionalProperties`.
-/// Test: used by the strict-mode assertions in this file.
-fn assert_object_nodes_strict(schema: &Value) {
+/// Test: used by the strict-mode assertions in this file, and re-exported
+/// `pub(crate)` (see `schema.rs`) for the prompt-schema tests in
+/// `pipeline::prompt_tests` so the recursive check lives in exactly one place.
+pub(crate) fn assert_object_nodes_strict(schema: &Value) {
     if let Value::Object(map) = schema {
         // Mirror `enforce_strict_mode`: a node is a closed object schema (the
         // kind strict mode constrains) when it carries a `properties` map.
@@ -175,12 +177,9 @@ fn recurses_into_object_valued_additional_properties() {
         }
     });
     enforce_strict_mode(&mut schema);
-    // The inner additionalProperties object schema must itself be strict.
-    let inner = &schema["properties"]["meta"]["properties"];
-    // `meta` had no `properties`, so its additionalProperties stays the object
-    // schema (we only overwrite to `false` when properties drive the node);
-    // verify recursion still made the inner schema strict.
-    let _ = inner; // meta has no properties; assert via the additionalProperties path
+    // `meta` has no `properties`, so its `additionalProperties` stays the object
+    // schema (we only overwrite it to `false` when `properties` drive the node).
+    // Verify recursion still made that inner object schema strict.
     let ap = &schema["properties"]["meta"]["additionalProperties"];
     assert_object_nodes_strict(ap);
 }

--- a/crates/trusty-review/src/pipeline/parser_tests.rs
+++ b/crates/trusty-review/src/pipeline/parser_tests.rs
@@ -79,6 +79,47 @@ fn parse_direct_json_finding_with_null_line() {
     assert_eq!(result.findings[0].line, None);
 }
 
+/// Verify a maximally-strict OpenAI-shaped response round-trips cleanly.
+///
+/// Why: under OpenAI strict mode every property is required, so a conforming
+/// response carries ALL top-level fields (`grade`, `grade_justification`,
+/// `verdict`, `summary`, `findings`) and every finding carries ALL its fields
+/// (`title`, `body`, `severity`, `confidence`, `file`, `line`).  This test
+/// proves the `LlmOutputBlock`/`LlmFinding` deserializers parse that fully
+/// populated shape — guarding that the schema tightening (which forces the
+/// model to emit all fields) does not break the parse contract.
+/// What: deserializes a body matching the strict schema exactly and asserts the
+/// verdict, grade, and finding fields are extracted.
+/// Test: no network.
+#[test]
+fn parse_direct_json_strict_full_shape() {
+    let body = serde_json::json!({
+        "grade": "B+",
+        "grade_justification": "solid but missing tests",
+        "verdict": "REQUEST_CHANGES",
+        "summary": "Needs test coverage.",
+        "findings": [
+            {
+                "title": "Missing tests",
+                "body": "The new handler has no unit tests.",
+                "severity": "medium",
+                "confidence": 0.8,
+                "file": "src/handler.rs",
+                "line": null
+            }
+        ]
+    })
+    .to_string();
+
+    let result = parse_review_response(&body);
+    assert!(!result.is_fail_safe, "strict-shaped response must parse");
+    assert_eq!(result.verdict, Verdict::RequestChanges);
+    assert_eq!(result.grade.as_deref(), Some("B+"));
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(result.findings[0].file, "src/handler.rs");
+    assert_eq!(result.findings[0].line, None);
+}
+
 // ── Legacy fenced JSON block path ─────────────────────────────────────────
 
 const BODY_WITH_JSON_APPROVE: &str = r#"

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -28,7 +28,7 @@ use crate::{
         apex_context::ApexContextResult,
         search_client::SearchResult,
     },
-    llm::{ChatMessage, LlmRequest, ResponseSchema, strip_provider_prefix},
+    llm::{ChatMessage, LlmRequest, ResponseSchema, enforce_strict_mode, strip_provider_prefix},
     models::ReviewResult,
     voice::VoiceConfig,
 };
@@ -63,52 +63,66 @@ const REVIEW_SCHEMA_NAME: &str = "review_output";
 /// object describing the `review_output` shape expected by `parse_review_response`.
 /// The schema matches the fields that `LlmOutputBlock` deserializes.
 /// The `grade` and `grade_justification` fields were added in 0.3.4 (#732).
-/// Test: `build_review_prompt_includes_response_schema` in this module.
+///
+/// OpenAI strict mode (forwarded by OpenRouter for `openai/*` models with
+/// `strict: true`) requires EVERY `object` node to set
+/// `"additionalProperties": false` AND to list every property key in
+/// `"required"`.  Rather than hand-maintain those on each nested object — the
+/// omission on `findings.items` is exactly what blocked all OpenAI reviews —
+/// the schema is declared in its natural shape and then made strict-compliant
+/// in one pass by [`enforce_strict_mode`] (#1235).  Fields that are
+/// semantically optional are expressed as nullable types (`line`) or carry a
+/// safe default value the model emits; the `LlmOutputBlock` deserializer uses
+/// `#[serde(default)]` so both lenient (Bedrock/Anthropic, Gemini) and strict
+/// (OpenAI) responses round-trip.
+/// Test: `build_review_prompt_includes_response_schema` and
+/// `review_schema_is_openai_strict_compliant` in this module.
 pub fn review_response_schema() -> ResponseSchema {
-    ResponseSchema {
-        name: REVIEW_SCHEMA_NAME.to_string(),
-        schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "grade": {
-                    "type": "string",
-                    "enum": ["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "D-", "F"],
-                    "description": "Letter grade for overall PR quality (A+ = best, F = worst)"
-                },
-                "grade_justification": {
-                    "type": "string",
-                    "description": "One-line justification for the assigned grade"
-                },
-                "verdict": {
-                    "type": "string",
-                    "enum": ["APPROVE", "APPROVE*", "REQUEST_CHANGES", "BLOCK", "UNKNOWN"],
-                    "description": "Review verdict — one of the five board grades"
-                },
-                "summary": {
-                    "type": "string",
-                    "description": "One-line summary of the review"
-                },
-                "findings": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "title": {"type": "string"},
-                            "body": {"type": "string"},
-                            "severity": {
-                                "type": "string",
-                                "enum": ["low", "medium", "high", "critical"]
-                            },
-                            "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
-                            "file": {"type": "string"},
-                            "line": {"type": ["integer", "null"]}
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "grade": {
+                "type": "string",
+                "enum": ["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "D-", "F"],
+                "description": "Letter grade for overall PR quality (A+ = best, F = worst)"
+            },
+            "grade_justification": {
+                "type": "string",
+                "description": "One-line justification for the assigned grade"
+            },
+            "verdict": {
+                "type": "string",
+                "enum": ["APPROVE", "APPROVE*", "REQUEST_CHANGES", "BLOCK", "UNKNOWN"],
+                "description": "Review verdict — one of the five board grades"
+            },
+            "summary": {
+                "type": "string",
+                "description": "One-line summary of the review"
+            },
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "body": {"type": "string"},
+                        "severity": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high", "critical"]
                         },
-                        "required": ["title", "body"]
+                        "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                        "file": {"type": "string"},
+                        "line": {"type": ["integer", "null"]}
                     }
                 }
-            },
-            "required": ["grade", "grade_justification", "verdict", "summary", "findings"]
-        }),
+            }
+        }
+    });
+    // Make every object node OpenAI strict-mode compliant in one pass.
+    enforce_strict_mode(&mut schema);
+    ResponseSchema {
+        name: REVIEW_SCHEMA_NAME.to_string(),
+        schema,
     }
 }
 

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -423,62 +423,11 @@ fn review_output_schema_enum_matches_board_grades() {
     assert_eq!(values.len(), 5, "schema must have exactly 5 board grades");
 }
 
-/// Recursively assert every object node of a JSON Schema is OpenAI strict-mode
-/// compliant: `additionalProperties == false` and `required` lists exactly the
-/// `properties` keys.
-///
-/// Why: the OpenAI strict-mode contract is recursive; a flat check on the top
-/// level would miss the exact regression we are guarding (`findings.items`
-/// previously lacked `additionalProperties`, blocking all OpenAI reviews).
-/// What: walks the schema, asserting the invariant on each object node and
-/// recursing into `properties`, array `items`, and object-valued
-/// `additionalProperties`.
-/// Test: invoked by `review_schema_is_openai_strict_compliant`.
-fn assert_strict(schema: &serde_json::Value) {
-    use serde_json::Value;
-    if let Value::Object(map) = schema {
-        let has_properties = map.get("properties").is_some_and(Value::is_object);
-        if has_properties {
-            assert_eq!(
-                map.get("additionalProperties"),
-                Some(&Value::Bool(false)),
-                "object node must set additionalProperties:false — {map:?}"
-            );
-            let props: std::collections::BTreeSet<&str> = map["properties"]
-                .as_object()
-                .expect("properties object")
-                .keys()
-                .map(String::as_str)
-                .collect();
-            let required: std::collections::BTreeSet<&str> = map
-                .get("required")
-                .and_then(Value::as_array)
-                .map(|r| r.iter().filter_map(Value::as_str).collect())
-                .unwrap_or_default();
-            assert_eq!(
-                props, required,
-                "every property must be listed in required — {map:?}"
-            );
-        }
-        if let Some(p) = map.get("properties").and_then(Value::as_object) {
-            for c in p.values() {
-                assert_strict(c);
-            }
-        }
-        if let Some(i) = map.get("items") {
-            assert_strict(i);
-        }
-        if let Some(ap) = map.get("additionalProperties")
-            && ap.is_object()
-        {
-            assert_strict(ap);
-        }
-    } else if let Value::Array(items) = schema {
-        for i in items {
-            assert_strict(i);
-        }
-    }
-}
+// The recursive strict-mode assertion lives in `llm::schema_tests`
+// (`assert_object_nodes_strict`) and is re-exported `pub(crate)` from
+// `llm::schema`. We reuse it here instead of duplicating the walk so the
+// invariant is defined in exactly one place.
+use crate::llm::schema::assert_object_nodes_strict as assert_strict;
 
 /// The review response schema must be OpenAI strict-mode compliant top-to-bottom.
 ///

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -423,6 +423,100 @@ fn review_output_schema_enum_matches_board_grades() {
     assert_eq!(values.len(), 5, "schema must have exactly 5 board grades");
 }
 
+/// Recursively assert every object node of a JSON Schema is OpenAI strict-mode
+/// compliant: `additionalProperties == false` and `required` lists exactly the
+/// `properties` keys.
+///
+/// Why: the OpenAI strict-mode contract is recursive; a flat check on the top
+/// level would miss the exact regression we are guarding (`findings.items`
+/// previously lacked `additionalProperties`, blocking all OpenAI reviews).
+/// What: walks the schema, asserting the invariant on each object node and
+/// recursing into `properties`, array `items`, and object-valued
+/// `additionalProperties`.
+/// Test: invoked by `review_schema_is_openai_strict_compliant`.
+fn assert_strict(schema: &serde_json::Value) {
+    use serde_json::Value;
+    if let Value::Object(map) = schema {
+        let has_properties = map.get("properties").is_some_and(Value::is_object);
+        if has_properties {
+            assert_eq!(
+                map.get("additionalProperties"),
+                Some(&Value::Bool(false)),
+                "object node must set additionalProperties:false — {map:?}"
+            );
+            let props: std::collections::BTreeSet<&str> = map["properties"]
+                .as_object()
+                .expect("properties object")
+                .keys()
+                .map(String::as_str)
+                .collect();
+            let required: std::collections::BTreeSet<&str> = map
+                .get("required")
+                .and_then(Value::as_array)
+                .map(|r| r.iter().filter_map(Value::as_str).collect())
+                .unwrap_or_default();
+            assert_eq!(
+                props, required,
+                "every property must be listed in required — {map:?}"
+            );
+        }
+        if let Some(p) = map.get("properties").and_then(Value::as_object) {
+            for c in p.values() {
+                assert_strict(c);
+            }
+        }
+        if let Some(i) = map.get("items") {
+            assert_strict(i);
+        }
+        if let Some(ap) = map.get("additionalProperties")
+            && ap.is_object()
+        {
+            assert_strict(ap);
+        }
+    } else if let Value::Array(items) = schema {
+        for i in items {
+            assert_strict(i);
+        }
+    }
+}
+
+/// The review response schema must be OpenAI strict-mode compliant top-to-bottom.
+///
+/// Why: OpenRouter forwards the schema with `strict: true` for `openai/*`
+/// models; if ANY object node (top-level OR the nested `findings.items`) omits
+/// `additionalProperties:false` or fails to list every property in `required`,
+/// OpenAI rejects the request and EVERY OpenAI review fails.  This locks the
+/// recursive invariant against regression.
+/// What: builds `review_response_schema()` and walks it with `assert_strict`,
+/// then spot-checks the previously-broken `findings.items` node directly.
+/// Test: no network — pure schema inspection.
+#[test]
+fn review_schema_is_openai_strict_compliant() {
+    let schema = review_response_schema();
+    assert_strict(&schema.schema);
+
+    // Spot-check the exact node that was non-compliant before the fix.
+    let items = &schema.schema["properties"]["findings"]["items"];
+    assert_eq!(
+        items["additionalProperties"],
+        serde_json::json!(false),
+        "findings.items must set additionalProperties:false"
+    );
+    let required: std::collections::BTreeSet<&str> = items["required"]
+        .as_array()
+        .expect("findings.items.required array")
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    assert_eq!(
+        required,
+        ["body", "confidence", "file", "line", "severity", "title"]
+            .into_iter()
+            .collect(),
+        "findings.items must require every property under strict mode"
+    );
+}
+
 /// Verify the system prompt describes UNKNOWN.
 ///
 /// Why: the model must know what UNKNOWN means and when to use it; if it is

--- a/crates/trusty-review/src/pipeline/verify_prompt.rs
+++ b/crates/trusty-review/src/pipeline/verify_prompt.rs
@@ -18,7 +18,7 @@
 //! `verify_schema_enumerates_judgments` in `verify_prompt_tests.rs`.
 
 use crate::{
-    llm::{ChatMessage, LlmRequest, ResponseSchema, strip_provider_prefix},
+    llm::{ChatMessage, LlmRequest, ResponseSchema, enforce_strict_mode, strip_provider_prefix},
     models::Finding,
 };
 
@@ -105,26 +105,33 @@ Populate the structured response fields: `judgment` (CONFIRMED or REFUTED) and
 /// guessed" failure mode — the provider guarantees `LlmResponse.text` is a clean
 /// JSON object with a `judgment` enum, so a parse can never silently default.
 /// What: returns a `ResponseSchema` whose object requires `judgment` ∈
-/// {CONFIRMED, REFUTED} plus an optional one-line `reason`.
-/// Test: `verify_schema_enumerates_judgments`.
+/// {CONFIRMED, REFUTED} plus a one-line `reason`.  The schema is declared in
+/// its natural shape and then made OpenAI strict-mode compliant in one pass by
+/// [`enforce_strict_mode`] (every object node gets `additionalProperties:false`
+/// and all properties listed in `required`).  `reason` thus becomes required
+/// for strict providers; the `VerifyJudgment` deserializer keeps
+/// `#[serde(default)]` on it so lenient providers that omit it still parse.
+/// Test: `verify_schema_enumerates_judgments`,
+/// `verify_schema_is_openai_strict_compliant`.
 pub fn verify_response_schema() -> ResponseSchema {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "judgment": {
+                "type": "string",
+                "enum": ["CONFIRMED", "REFUTED"],
+                "description": "Binary verification judgment for the finding"
+            },
+            "reason": {
+                "type": "string",
+                "description": "One short sentence justifying the judgment"
+            }
+        }
+    });
+    enforce_strict_mode(&mut schema);
     ResponseSchema {
         name: VERIFY_SCHEMA_NAME.to_string(),
-        schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "judgment": {
-                    "type": "string",
-                    "enum": ["CONFIRMED", "REFUTED"],
-                    "description": "Binary verification judgment for the finding"
-                },
-                "reason": {
-                    "type": "string",
-                    "description": "One short sentence justifying the judgment"
-                }
-            },
-            "required": ["judgment"]
-        }),
+        schema,
     }
 }
 

--- a/crates/trusty-review/src/pipeline/verify_prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_prompt_tests.rs
@@ -99,6 +99,36 @@ fn verify_schema_enumerates_judgments() {
     assert_eq!(enum_vals[1], "REFUTED");
 }
 
+/// The verify response schema must be OpenAI strict-mode compliant.
+///
+/// Why: the verify pass also runs through OpenRouter with `strict: true` for
+/// `openai/*` models; a missing `additionalProperties:false` or an incomplete
+/// `required` list would block every OpenAI verification call exactly as the
+/// review schema bug blocked reviews.
+/// What: asserts the top-level object sets `additionalProperties:false` and
+/// requires BOTH `judgment` and `reason` (strict mode requires all properties).
+/// Test: no network — pure schema inspection.
+#[test]
+fn verify_schema_is_openai_strict_compliant() {
+    let schema = verify_response_schema();
+    assert_eq!(
+        schema.schema["additionalProperties"],
+        serde_json::json!(false),
+        "verify schema object must set additionalProperties:false"
+    );
+    let required: std::collections::BTreeSet<&str> = schema.schema["required"]
+        .as_array()
+        .expect("required array")
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    assert_eq!(
+        required,
+        ["judgment", "reason"].into_iter().collect(),
+        "strict mode requires every property (judgment AND reason)"
+    );
+}
+
 #[test]
 fn verify_system_prompt_mentions_refuted_guard() {
     let sys = verifier_system_prompt();

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -551,6 +551,68 @@ async fn verify_approve_two_advisory_medium_stays_approve() {
     );
 }
 
+// ── Verify-path schema deserialization (#1235 strict-mode regression guard) ────
+//
+// Symmetric to the review path's `parse_direct_json_strict_full_shape`
+// (`parser_tests.rs`). The #1235 strict-mode fix makes `reason` a REQUIRED
+// property on the OpenAI verify schema; `#[serde(default)]` on
+// `VerifyJudgment::reason` is what keeps lenient providers (Bedrock / Anthropic /
+// Gemini) that OMIT `reason` deserializing instead of silently failing the
+// verify path. These tests pin that invariant so a future edit that drops the
+// `#[serde(default)]` fails loudly.
+
+/// Full-shape verify response (`judgment` + `reason`) deserializes and is parsed.
+///
+/// Why: proves the happy path for strict providers that emit every required
+/// field round-trips into `VerifyJudgment` and maps to the right decision.
+/// What: deserializes `{"judgment":"CONFIRMED","reason":...}` and confirms both
+/// the typed struct fields and `parse_judgment` agree it is CONFIRMED.
+/// Test: this is the test.
+#[test]
+fn verify_judgment_full_shape_deserializes() {
+    let body = serde_json::json!({
+        "judgment": "CONFIRMED",
+        "reason": "the finding is present in the diff at the cited line",
+    })
+    .to_string();
+
+    let parsed: VerifyJudgment =
+        serde_json::from_str(&body).expect("full-shape verify response must deserialize");
+    assert_eq!(parsed.judgment, "CONFIRMED");
+    assert_eq!(
+        parsed.reason,
+        "the finding is present in the diff at the cited line"
+    );
+
+    // End-to-end through the public parser entry point.
+    assert_eq!(parse_judgment(&body), Some(true));
+}
+
+/// Verify response that OMITS `reason` still deserializes (proves `#[serde(default)]`).
+///
+/// Why: lenient providers (Bedrock / Anthropic / Gemini) ignore the strict
+/// schema and may omit `reason`. Without `#[serde(default)]` on
+/// `VerifyJudgment::reason` this would fail to deserialize and silently break
+/// the verify path — the #1235 regression this PR guards against.
+/// What: deserializes `{"judgment":"REFUTED"}` (no `reason`), asserts `reason`
+/// defaults to the empty string, and that `parse_judgment` still maps REFUTED.
+/// Test: this is the test.
+#[test]
+fn verify_judgment_omits_reason_still_deserializes() {
+    let body = serde_json::json!({ "judgment": "REFUTED" }).to_string();
+
+    let parsed: VerifyJudgment = serde_json::from_str(&body)
+        .expect("verify response omitting `reason` must still deserialize (#[serde(default)])");
+    assert_eq!(parsed.judgment, "REFUTED");
+    assert_eq!(
+        parsed.reason, "",
+        "omitted `reason` must default to empty string"
+    );
+
+    // End-to-end: a reason-less judgment still yields a clean decision.
+    assert_eq!(parse_judgment(&body), Some(false));
+}
+
 // Liveness gate decision logic is tested in `verify_liveness.rs::tests`
 // (`liveness_alive_allows_start`, `liveness_model_unavailable_refuses`, etc.)
 // to keep this file under the 500-line cap and respect module ownership.


### PR DESCRIPTION
Closes #1235.

## Problem

`trusty-review`'s structured-output JSON schemas were **not OpenAI strict-mode compliant**, breaking **every** `openrouter/openai/*` review and verify call. `llm/openrouter.rs` sends the schema with `strict: true`; OpenAI strict mode requires, for **every** `object` node:
- `"additionalProperties": false`, and
- every property key listed in `"required"`.

`review_response_schema()`'s `findings.items` object had neither (no `additionalProperties`, `required` only listed `title`/`body`), so OpenAI rejected the request:

```
Invalid schema for response_format 'review_output': In context=('properties','findings','items'),
'additionalProperties' is required to be supplied and to be false.
```

The verify-pass schema (`verify_response_schema()`) had the identical defect. Lenient providers (Bedrock/Anthropic tool-use, Gemini) accept the stricter form, which masked the bug.

## Fix

- New `llm::schema::enforce_strict_mode()` — recursively walks a `serde_json::Value` JSON Schema and makes every closed object node (one carrying a `properties` map) strict-compliant: sets `additionalProperties: false` and rewrites `required` to list every property. Descends into `properties`, array `items`, and object-valued `additionalProperties`. Idempotent; gates on `properties` (not a bare `type:object`) so map-types are not mangled.
- Both `review_response_schema()` and `verify_response_schema()` now declare their natural shape and call `enforce_strict_mode()` once — single source of truth, no hand-maintained `required`/`additionalProperties` per nested object.

## Deserialization compatibility

The `LlmOutputBlock`/`LlmFinding` and `VerifyJudgment` deserializers already use `#[serde(default)]` on the now-always-emitted fields (`grade`, `severity`, `confidence`, `file`, `reason`, …), so both lenient and strict provider responses round-trip. `line` stays `["integer","null"]`.

## Provider impact

- **OpenAI** (`openrouter/openai/*`): unblocked — schema is now accepted.
- **Bedrock/Anthropic, Gemini**: unchanged — a stricter-but-valid schema still passes their lenient validation.

## Tests

- `review_schema_is_openai_strict_compliant` / `verify_schema_is_openai_strict_compliant` — recursive invariant over the generated schemas (every object node: `additionalProperties:false` + all properties required), plus a direct spot-check of the previously-broken `findings.items`.
- `enforce_strict_mode` unit suite — array items, idempotency, nullable, non-object passthrough, map-type safety (6 tests).
- `parse_direct_json_strict_full_shape` — maximally-strict full-shape deserialization round-trip.
- Full suite: **828 passed, 0 failed, 3 ignored**.

## Verification

- `cargo test -p trusty-review` — 828 passed
- `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — OK (0 violations)
- `cargo check` (workspace) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)