### PR TITLE
chore(trusty-memory): pin project palace ID to 'trusty-tools' (#1217 continuity)

### DIFF
--- a/.trusty-tools/trusty-memory.yaml
+++ b/.trusty-tools/trusty-memory.yaml
@@ -5,4 +5,4 @@
 
 schema_version: 1
 palace: trusty-tools
-note: 'Pinned 2026-05-30: canonical checkout /Volumes/SSD1/Projects/trusty-tools (moved off /Volumes/Kemono)'
+note: 'Pinned to ''trusty-tools'' for continuity with existing palace memories. This pin (read by pinned_slug_at, Step 2 of cwd_palace_slug_at) overrides the #1224 git-path identity derivation, which would otherwise default this repo to the owner/repo slug ''bobmatnyc-trusty-tools'' and orphan all existing memories. Origin: pinned 2026-05-30 for the canonical checkout /Volumes/SSD1/Projects/trusty-tools (moved off /Volumes/Kemono).'


### PR DESCRIPTION
## Summary

Keeps this repo's trusty-memory palace ID permanently pinned to **`trusty-tools`**, preserving continuity with all existing `trusty-tools` palace memories after the **#1224** default-derivation change.

After #1224, the *default* palace ID for this repo would derive from git identity to the GitHub `owner/repo` slug **`bobmatnyc-trusty-tools`**, orphaning every memory stored under `trusty-tools`. The committed pin file at `.trusty-tools/trusty-memory.yaml` (`palace: trusty-tools`) prevents that: `pinned_slug_at` is consulted at **Step 2** of `cwd_palace_slug_at` — *before* the Step 3 git-path derivation — so the pin always wins.

## What changed

The pin file already pinned `palace: trusty-tools` (committed in #448 / #468 before a drive reorg). This PR only updates the human-readable `note` to document the **#1224 continuity rationale** so the intent is self-explanatory to future readers. No schema or value change; `schema_version: 1`, `palace: trusty-tools` unchanged.

```yaml
schema_version: 1
palace: trusty-tools
note: 'Pinned to ''trusty-tools'' for continuity with existing palace memories. This pin (read by pinned_slug_at, Step 2 of cwd_palace_slug_at) overrides the #1224 git-path identity derivation, which would otherwise default this repo to the owner/repo slug ''bobmatnyc-trusty-tools'' and orphan all existing memories. Origin: pinned 2026-05-30 for the canonical checkout /Volumes/SSD1/Projects/trusty-tools (moved off /Volumes/Kemono).'
```

## Schema evidence (`crates/trusty-memory/src/project_root/pin_file.rs`)

- `PIN_FILE_REL = ".trusty-tools/trusty-memory.yaml"`
- Parser: `read_project_pin` → `serde_yaml::from_str::<ProjectPin>`
- `ProjectPin { schema_version: u32, palace: String, note: Option<String> }` — `palace` is stored verbatim (no re-slugification)
- `pinned_slug_at` returns `Some(pin.palace)` strictly when the pin exists and is non-empty (never the basename fallback)
- `cwd_palace_slug_at` (`messaging/operations.rs`): Step 1 env override → **Step 2 `pinned_slug_at` (this file)** → Step 3 git owner/repo derivation (`bobmatnyc-trusty-tools`)

## Verification

End-to-end against the **real committed pin file** at the repo root (throwaway integration test, since removed — permanent coverage lives in the existing unit tests):

- `read_project_pin(repo_root)` → `palace == "trusty-tools"`, `schema_version == 1` ✅
- `pinned_slug_at(repo_root)` → `Some("trusty-tools")` ✅
- `cwd_palace_slug_at(repo_root)` → `"trusty-tools"` (run from inside this git repo whose origin is `bobmatnyc/trusty-tools`; pin still wins over the #1224 git derivation) ✅

Existing permanent unit tests also pass:
- `cwd_palace_slug_at_prefers_pin_file` — pin overrides basename/git
- `cwd_palace_slug_at_uses_git_owner_repo` — git fallback produces the `owner-repo` style (the would-be `bobmatnyc-trusty-tools`)
- `pinned_slug_at_returns_pin_when_present` / `_returns_none_without_pin`, `write_and_read_pin_round_trips`, `pin_file_read_when_present`

Completion-contract checks (YAML-only change):
- `cargo test -p trusty-memory` — all pass, 0 failures
- `cargo check -p trusty-memory` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — `15 allowlisted, 0 violations — OK`

## Files changed
- `.trusty-tools/trusty-memory.yaml` (note text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)