### PR TITLE
docs(adr): accept ADR-0011 — tctl owns service lifecycle

### DIFF
--- a/docs/adr/0011-tctl-owns-service-lifecycle.md
+++ b/docs/adr/0011-tctl-owns-service-lifecycle.md
@@ -1,7 +1,8 @@
 # 0011. `tctl` owns service lifecycle (headless control plane); `trusty-console` owns the single HTTP surface
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-15
+- **Accepted:** 2026-06-15 (owner sign-off via PR #1240 merge)
 - **Scope:** Workspace-wide (trusty-controller boot model; reconciles DOC-7 with
   the #1104 console architecture). Consumed by
   `docs/trusty-controller/research/02-design/DOC-12-bootstrap-orchestration.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,4 +68,4 @@ Proposed ──► Accepted ──► Superseded (by ADR-NNNN)
 | [0008](./0008-project-identity-convention.md) | Project-identity convention: full-path slug of the nearest git root | Accepted |
 | [0009](./0009-external-extractor-kg-ingest-contract.md) | External-extractor KG ingest contract: durable contributed overlay in trusty-search | Accepted |
 | [0010](./0010-kg-edge-kind-extensibility.md) | KG edge-kind extensibility: first-class data-flow variants + Custom escape hatch | Proposed |
-| [0011](./0011-tctl-owns-service-lifecycle.md) | `tctl` headless control plane (owns boot/lifecycle); `trusty-console` is the single HTTP surface | Proposed |
+| [0011](./0011-tctl-owns-service-lifecycle.md) | `tctl` headless control plane (owns boot/lifecycle); `trusty-console` is the single HTTP surface | Accepted |

--- a/docs/trusty-controller/research/02-design/DOC-12-bootstrap-orchestration.md
+++ b/docs/trusty-controller/research/02-design/DOC-12-bootstrap-orchestration.md
@@ -717,8 +717,9 @@ the body sections noted.
 - [x] Owner review of §3 sequence + §5 gating + §6 Claude-Code policy (Bob, 2026-06-15)
 - [x] Resolve Open Questions Q1–Q6 with Bob (RESOLVED 2026-06-15 — see Open
       questions section: Q1/Q2/Q3/Q6 by decision, Q4/Q5 by recommendation)
-- [ ] Land ADR-0011 (tctl headless / console single-HTTP) — drafted alongside;
-      flip its status Proposed → Accepted on owner sign-off
+- [x] Land ADR-0011 (tctl headless / console single-HTTP) — drafted alongside;
+      flip its status Proposed → Accepted on owner sign-off (Accepted 2026-06-15
+      via PR #1240 merge)
 - [x] Re-status DOC-7 → Superseded (Q4 confirmed 2026-06-15) — banner + README
       index updated
 - [ ] (impl-time) build `tctl up` staging in `crates/trusty-controller/src/`


### PR DESCRIPTION
Owner approved ADR-0011 via the merge of PR #1240 (2026-06-15). This small, doc-only change flips its lifecycle state from Proposed to Accepted and closes the corresponding follow-up item.

## Changes

- **`docs/adr/0011-tctl-owns-service-lifecycle.md`**: Status `Proposed` → `Accepted`; added an explicit acceptance date line (2026-06-15, owner sign-off via PR #1240 merge) consistent with the front-matter style.
- **`docs/adr/README.md`**: ADR index entry for 0011 `Proposed` → `Accepted` for consistency.
- **`docs/trusty-controller/research/02-design/DOC-12-bootstrap-orchestration.md`**: Checked off the Remaining-Work item to flip ADR-0011 Proposed→Accepted on owner sign-off.

DOC-7's supersession banner references ADR-0011 only as a cross-reference (it never labels ADR-0011 itself "Proposed"), so no change was needed there.

Doc-only — no cargo build/test required. `bash scripts/check_line_cap.sh` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)