### PR TITLE
feat(trusty-mpm): session-manager MCP service — lifecycle tools + POST /rpc + serve --stdio bridge (P1, #1221)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -11,8 +11,8 @@
       "type": "stdio",
       "command": "trusty-mpm",
       "args": [
-        "daemon",
-        "--mcp"
+        "serve",
+        "--stdio"
       ]
     },
     "trusty-memory": {

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -37,9 +37,20 @@ pub(crate) enum Command {
     ///
     /// Why: matches the trusty-search / trusty-memory CLI surface so users
     /// moving between the three daemons get the same `start` / `serve` /
-    /// `stop` triad. `tm serve` does NOT speak MCP stdio — pass
-    /// `tm daemon --mcp` for the MCP-on-stdin/stdout mode.
-    Serve,
+    /// `stop` triad. With `--stdio` it becomes the MCP stdio bridge (#1221):
+    /// a thin proxy that forwards JSON-RPC to the daemon's loopback `POST /rpc`,
+    /// mirroring `trusty-memory serve --stdio`. This is the form wired into
+    /// `.mcp.json`. Without `--stdio` it behaves like `start`. (The older
+    /// `tm daemon --mcp` direct-stdio mode is retained for diagnostics.)
+    Serve {
+        /// Run as an MCP stdio bridge that proxies to the daemon's `POST /rpc`.
+        ///
+        /// Why: Claude Code speaks MCP over stdio; the durable daemon speaks
+        /// HTTP. This flag selects the bridge that connects the two, auto-starting
+        /// the daemon if needed and reconnecting with backoff if it restarts.
+        #[arg(long)]
+        stdio: bool,
+    },
     /// Stop every running trusty-mpm daemon process.
     ///
     /// Why: pairs with `start` so operators can take the daemon down

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod managed;
 pub(crate) mod misc;
 pub(crate) mod project;
 pub(crate) mod repair;
+pub(crate) mod serve_stdio;
 pub(crate) mod services;
 pub(crate) mod session;
 pub(crate) mod supervisor;

--- a/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
@@ -1,0 +1,296 @@
+//! `tm serve --stdio` — MCP stdio bridge for the trusty-mpm daemon (#1221).
+//!
+//! Why: Claude Code launches MCP servers as stdio subprocesses, but the
+//! trusty-mpm daemon must be a durable 24/7 process (it runs the supervisor, the
+//! reaper, the file watcher, and the Telegram bot — a stdio child would die with
+//! its client). So, exactly like `trusty-memory serve --stdio`, this is a thin
+//! PROXY: it ensures the HTTP daemon is up, then forwards every JSON-RPC request
+//! to the daemon's loopback `POST /rpc` and relays the response. It never holds
+//! daemon state itself; it exits when Claude Code closes the pipe, leaving the
+//! daemon running.
+//!
+//! What: [`run_stdio_bridge`] (1) ensures the daemon is reachable via the shared
+//! `trusty_common::mcp::ensure_daemon_up` helper (auto-starting `tm daemon`
+//! detached if absent, polling the lock file for the real dynamic port); (2)
+//! enters `run_stdio_loop`, forwarding each non-notification request to
+//! `POST /rpc` and returning the daemon's response verbatim. Transport errors
+//! become a JSON-RPC internal error rather than crashing the loop, so the bridge
+//! survives a daemon restart and the next request reconnects.
+//!
+//! STDOUT hygiene: NEVER write to stdout — it is the JSON-RPC channel. All
+//! diagnostics go to stderr (via `eprintln!` inside the shared helper).
+//!
+//! Test: `is_notification_*`, `value_to_mcp_response_*`, and
+//! `forward_rpc_errors_on_refused` unit tests below; the daemon-side `POST /rpc`
+//! dispatch is covered by `daemon::api_tests::rpc_*`.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use trusty_common::mcp::{self, DaemonBridgeConfig, Request, Response};
+
+/// Per-request forwarding timeout (60 s — headroom for slow tmux/provision ops).
+///
+/// Why: a session spawn provisions a workspace (git clone) and a tmux host,
+/// which can take many seconds; a generous ceiling prevents a slow-but-valid
+/// call from being cut off while still capping a truly hung request.
+/// Test: `forward_rpc_errors_on_refused` exercises the error path within bound.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Build the shared reqwest client used for every forwarded RPC call.
+///
+/// Why: one client enables HTTP keep-alive to the daemon, reducing latency.
+/// What: a blocking-free async client with the request + connect timeout set.
+/// Test: `build_rpc_client_succeeds`.
+fn build_rpc_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .connect_timeout(REQUEST_TIMEOUT)
+        .build()
+        .context("build reqwest client for trusty-mpm stdio bridge")
+}
+
+/// Build the `DaemonBridgeConfig` for the trusty-mpm stdio bridge.
+///
+/// Why: the daemon discovers its own (possibly ephemeral) port and records it in
+/// `~/.trusty-mpm/daemon.lock`. `resolve_daemon_url(None)` re-reads that lock on
+/// every call, so passing it as `base_url_fn` lets `ensure_daemon_up` track a
+/// dynamic port as soon as the daemon writes the lock. Unlike trusty-memory
+/// (which sets `no_spawn` to avoid squatting a redb write lock), the trusty-mpm
+/// daemon is HTTP-only and singleton-guarded, so auto-spawn is safe and matches
+/// the existing `tm start` behaviour.
+/// What: returns a config that probes `/health`, auto-spawns `tm daemon` when
+/// absent, and resolves the base URL from the lock file each poll.
+/// Test: covered indirectly; `ensure_daemon_up` itself is unit-tested in
+/// `trusty_common::mcp::daemon_bridge`.
+fn build_bridge_config() -> DaemonBridgeConfig {
+    DaemonBridgeConfig {
+        service_name: "trusty-mpm".to_string(),
+        // The daemon picks its own port and records it in the lock file; no addr
+        // arg is passed (matches `tm start`).
+        spawn_args: vec!["daemon".to_string()],
+        health_path: "/health".to_string(),
+        base_url_fn: Box::new(|| trusty_mpm::core::resolve_daemon_url(None)),
+        startup_timeout: None, // shared 30s default
+        poll_interval: None,   // shared 500ms default
+        no_spawn: false,
+    }
+}
+
+/// Returns true if the request is a JSON-RPC notification.
+///
+/// Why: per the MCP spec (section 4.1) the server MUST NOT reply to a
+/// notification. Suppression is decided from the REQUEST before forwarding —
+/// forwarding a notification would make the daemon emit a response that the
+/// bridge would write to stdout, corrupting the MCP channel.
+/// What: returns true when `req.id` is absent OR the method begins with
+/// `"notifications/"`.
+/// Test: `is_notification_detects_missing_id_and_prefix`.
+fn is_notification(req: &Request) -> bool {
+    req.id.is_none() || req.method.starts_with("notifications/")
+}
+
+/// Convert an `mcp::Request` into the JSON value POSTed to the daemon.
+///
+/// Why: `forward_rpc` sends raw JSON; the request envelope must be serialised.
+/// What: `serde_json::to_value`, falling back to an empty object (which the
+/// daemon rejects with a parse error — the correct behaviour) on the impossible
+/// serialisation failure.
+/// Test: covered transitively by the forwarding path.
+fn req_to_value(req: &Request) -> serde_json::Value {
+    serde_json::to_value(req).unwrap_or_else(|_| serde_json::json!({}))
+}
+
+/// Convert the daemon's JSON-RPC response value into an `mcp::Response`.
+///
+/// Why: `run_stdio_loop` expects `mcp::Response`; the daemon returns a raw value
+/// in the standard `{jsonrpc, id, result | error}` shape.
+/// What: extracts `id`, returns `ok` when `result` is present, `err` when `error`
+/// is present, or an internal error when the response is malformed.
+/// Test: `value_to_mcp_response_maps_ok_err_and_malformed`.
+fn value_to_mcp_response(v: serde_json::Value) -> Response {
+    let id = v
+        .get("id")
+        .cloned()
+        .and_then(|id| if id.is_null() { None } else { Some(id) });
+
+    if let Some(result) = v.get("result").cloned() {
+        return Response::ok(id, result);
+    }
+    if let Some(err) = v.get("error") {
+        let code = err
+            .get("code")
+            .and_then(|c| c.as_i64())
+            .map(|c| c as i32)
+            .unwrap_or(mcp::error_codes::INTERNAL_ERROR);
+        let message = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown daemon error")
+            .to_string();
+        return Response::err(id, code, message);
+    }
+    Response::err(
+        id,
+        mcp::error_codes::INTERNAL_ERROR,
+        "daemon returned a response with neither result nor error",
+    )
+}
+
+/// POST one JSON-RPC request to `{base_url}/rpc` and return the response body.
+///
+/// Why: the core forwarding primitive — returns the daemon's response verbatim
+/// so MCP clients see real tool output, not a bridge-generated stand-in.
+/// What: serialises `req`, POSTs to `/rpc`, deserialises the JSON body.
+/// Transport errors (refused, timeout) and non-2xx statuses become `Err`.
+/// Test: `forward_rpc_errors_on_refused`.
+async fn forward_rpc(
+    client: &reqwest::Client,
+    base_url: &str,
+    req: serde_json::Value,
+) -> Result<serde_json::Value> {
+    let url = format!("{base_url}/rpc");
+    let resp = client
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}: connection to trusty-mpm daemon failed"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "daemon returned HTTP {status} for POST /rpc: {body}"
+        ));
+    }
+
+    resp.json::<serde_json::Value>()
+        .await
+        .context("deserialise JSON-RPC response from trusty-mpm daemon")
+}
+
+/// Run the trusty-mpm MCP stdio bridge.
+///
+/// Why: top-level entry point for `tm serve --stdio` (#1221). Mirrors the proven
+/// `trusty-memory serve --stdio` pattern so the three daemons share one mental
+/// model and the driver skill can call typed MCP tools instead of scraping CLI
+/// output.
+/// What: (1) ensures the daemon is up (auto-start + dynamic-port discovery via
+/// the lock file); (2) builds a shared HTTP client; (3) enters `run_stdio_loop`,
+/// suppressing notifications and forwarding every other request to `POST /rpc`,
+/// re-resolving the daemon URL each request so a daemon restart on a new port is
+/// picked up. A transport error returns a JSON-RPC internal error rather than
+/// crashing the loop — the next request reconnects.
+/// Test: the helpers are unit-tested below; the end-to-end forward path is
+/// covered by the daemon's `rpc_*` integration tests.
+pub(crate) async fn run_stdio_bridge() -> Result<()> {
+    // Step 1: ensure the daemon is reachable (auto-start if needed). Hard error
+    // on failure — no silent fallback. All output goes to stderr.
+    let config = build_bridge_config();
+    let _ = mcp::ensure_daemon_up(&config).await?;
+
+    // Step 2: shared HTTP client.
+    let client = build_rpc_client()?;
+
+    // Step 3: forward loop. Re-resolve the base URL per request so a restarted
+    // daemon (possibly on a new ephemeral port) is followed automatically.
+    mcp::run_stdio_loop(move |req| {
+        let client = client.clone();
+        async move {
+            if is_notification(&req) {
+                return Response::suppressed();
+            }
+            let base_url = trusty_mpm::core::resolve_daemon_url(None);
+            let req_value = req_to_value(&req);
+            match forward_rpc(&client, &base_url, req_value).await {
+                Ok(resp_value) => value_to_mcp_response(resp_value),
+                Err(e) => {
+                    tracing::warn!("trusty-mpm stdio bridge: transport error: {e:#}");
+                    Response::err(
+                        req.id.clone(),
+                        mcp::error_codes::INTERNAL_ERROR,
+                        format!("trusty-mpm daemon unreachable: {e:#}"),
+                    )
+                }
+            }
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_rpc_client_succeeds() {
+        assert!(build_rpc_client().is_ok());
+    }
+
+    #[test]
+    fn is_notification_detects_missing_id_and_prefix() {
+        let normal = Request {
+            jsonrpc: Some("2.0".into()),
+            id: Some(json!(1)),
+            method: "tools/list".into(),
+            params: None,
+        };
+        assert!(!is_notification(&normal));
+
+        let no_id = Request {
+            jsonrpc: Some("2.0".into()),
+            id: None,
+            method: "tools/list".into(),
+            params: None,
+        };
+        assert!(is_notification(&no_id));
+
+        let prefixed = Request {
+            jsonrpc: Some("2.0".into()),
+            id: Some(json!(9)),
+            method: "notifications/initialized".into(),
+            params: None,
+        };
+        assert!(is_notification(&prefixed));
+    }
+
+    #[test]
+    fn value_to_mcp_response_maps_ok_err_and_malformed() {
+        let ok = value_to_mcp_response(json!({"jsonrpc":"2.0","id":1,"result":{"tools":[]}}));
+        assert!(ok.error.is_none());
+        assert_eq!(ok.id, Some(json!(1)));
+
+        let err = value_to_mcp_response(
+            json!({"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"x"}}),
+        );
+        assert_eq!(err.error.unwrap().code, -32601);
+
+        let bad = value_to_mcp_response(json!({"jsonrpc":"2.0","id":3}));
+        assert_eq!(bad.error.unwrap().code, mcp::error_codes::INTERNAL_ERROR);
+
+        let null_id = value_to_mcp_response(json!({"jsonrpc":"2.0","id":null,"result":{}}));
+        assert_eq!(null_id.id, None);
+    }
+
+    #[test]
+    fn req_to_value_round_trips_method() {
+        let req = Request {
+            jsonrpc: Some("2.0".into()),
+            id: Some(json!(5)),
+            method: "session_list".into(),
+            params: None,
+        };
+        let v = req_to_value(&req);
+        assert_eq!(v["method"], "session_list");
+        assert_eq!(v["id"], 5);
+    }
+
+    #[tokio::test]
+    async fn forward_rpc_errors_on_refused() {
+        let client = build_rpc_client().expect("client");
+        let result = forward_rpc(&client, "http://127.0.0.1:65534", json!({"method":"ping"})).await;
+        assert!(result.is_err(), "must error when no daemon is listening");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -190,7 +190,16 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::Status => status(&client, &url).await,
         Command::Start => start(&client, &url).await,
-        Command::Serve => start(&client, &url).await,
+        Command::Serve { stdio } => {
+            if stdio {
+                // #1221: MCP stdio bridge — forward JSON-RPC to the daemon's
+                // loopback POST /rpc, auto-starting the daemon and reconnecting
+                // with backoff. This is the `.mcp.json` entry point.
+                commands::serve_stdio::run_stdio_bridge().await
+            } else {
+                start(&client, &url).await
+            }
+        }
         Command::Stop => stop_daemon().await,
         Command::Restart => restart(&client, &url).await,
         Command::Project { action } => project(&client, &url, action).await,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -60,8 +60,16 @@ fn cli_parses_start() {
 
 #[test]
 fn cli_parses_serve() {
+    // Bare `serve` defaults to the non-stdio (start-like) behaviour.
     let cli = Cli::try_parse_from(["trusty-mpm", "serve"]).unwrap();
-    assert!(matches!(cli.command, Command::Serve));
+    assert!(matches!(cli.command, Command::Serve { stdio: false }));
+}
+
+#[test]
+fn cli_parses_serve_stdio() {
+    // `serve --stdio` selects the MCP stdio bridge (#1221).
+    let cli = Cli::try_parse_from(["trusty-mpm", "serve", "--stdio"]).unwrap();
+    assert!(matches!(cli.command, Command::Serve { stdio: true }));
 }
 
 #[test]

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -55,6 +55,16 @@ pub use claude_config_routes::*;
 pub mod coordinator_routes;
 pub use coordinator_routes::*;
 
+/// The loopback-only JSON-RPC dispatch endpoint (`POST /rpc`, #1221).
+///
+/// Why: the `serve --stdio` bridge forwards MCP JSON-RPC envelopes to the durable
+/// daemon over this internal channel. It is gated to loopback peers only (the
+/// #1221 hard requirement) so a future `0.0.0.0` rebind cannot expose the tool
+/// surface. Keeping it in a sibling module mirrors `coordinator_routes` and keeps
+/// `api.rs` focused.
+pub mod rpc;
+pub use rpc::rpc_handler;
+
 /// The managed session-manager routes (`/api/v1/sessions/managed/*`).
 ///
 /// Why: the managed-session API is a cohesive cluster (spawn, list, get,
@@ -167,6 +177,9 @@ pub fn router(state: Arc<DaemonState>) -> Router {
             "/api/v1/sessions/managed/{id}/decommission",
             post(decommission_managed_session),
         )
+        // #1221: loopback-only JSON-RPC dispatch for the `serve --stdio` bridge.
+        // The handler independently enforces the loopback gate via ConnectInfo.
+        .route("/rpc", post(rpc_handler))
         .merge(
             SwaggerUi::new("/api-docs")
                 .url("/api-docs/openapi.json", super::openapi::ApiDoc::openapi()),

--- a/crates/trusty-mpm/src/daemon/api/rpc.rs
+++ b/crates/trusty-mpm/src/daemon/api/rpc.rs
@@ -1,0 +1,112 @@
+//! Loopback-only JSON-RPC dispatch endpoint (`POST /rpc`, #1221).
+//!
+//! Why: the `trusty-mpm serve --stdio` bridge (mirroring `trusty-memory`) needs
+//! an internal channel to forward MCP JSON-RPC envelopes to the durable daemon.
+//! HTTP `POST /rpc` is the simplest, most consistent option (resolved owner
+//! decision, RFC §6 Q1). But this endpoint executes arbitrary tool calls
+//! (including session spawn/decommission), so it MUST never be reachable off
+//! loopback — even if the daemon is later rebound to `0.0.0.0` (e.g. inside a
+//! container). This is the hard acceptance criterion from the #1221 RFC review
+//! (conf 0.85): the route returns 403 for any non-loopback source IP.
+//! What: [`is_loopback`] is the pure peer-address predicate; [`rpc_handler`] is
+//! the axum handler — it rejects non-loopback peers with 403, otherwise builds a
+//! [`StateBackend`] and routes the request through [`crate::mcp::dispatch`],
+//! returning the JSON-RPC response. Defense-in-depth: the daemon already binds
+//! loopback, AND this handler independently enforces it, so a future bind change
+//! cannot silently expose the tool surface.
+//! What (hygiene): all diagnostics go to `tracing` (stderr); the handler never
+//! writes to stdout (stdout is the MCP channel for the bridge, not the daemon).
+//! Test: `is_loopback_accepts_v4_v6_loopback`, `is_loopback_rejects_public`, and
+//! the daemon integration test `rpc_rejects_non_loopback_peer` /
+//! `rpc_dispatches_tools_list_for_loopback`.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{ConnectInfo, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use trusty_common::mcp::Request as McpRequest;
+
+use crate::daemon::mcp_backend::StateBackend;
+use crate::daemon::state::DaemonState;
+
+/// True when `addr`'s IP is a loopback address (IPv4 `127.0.0.0/8` or IPv6 `::1`).
+///
+/// Why: the `/rpc` route must be reachable only from the local host. Keying the
+/// decision on the peer IP (rather than only on the daemon's bind address) makes
+/// the guarantee hold even if the daemon is later bound to `0.0.0.0` — a
+/// non-loopback client is rejected regardless of bind config.
+/// What: returns `true` iff `addr.ip()` is an IPv4 or IPv6 loopback address.
+/// Test: `is_loopback_accepts_v4_v6_loopback`, `is_loopback_rejects_public`.
+pub fn is_loopback(addr: &SocketAddr) -> bool {
+    match addr.ip() {
+        IpAddr::V4(v4) => v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+/// `POST /rpc` — loopback-only JSON-RPC dispatch into the MCP tool surface.
+///
+/// Why: the stdio bridge forwards every MCP request here; the daemon holds the
+/// durable state, so dispatch must run in-process against it. The loopback gate
+/// is the #1221 hard requirement.
+/// What: (1) rejects any non-loopback peer with `403 Forbidden` and a short
+/// message — no body is parsed and no tool runs; (2) for a loopback peer, wraps
+/// the daemon state in a [`StateBackend`] and calls [`crate::mcp::dispatch`],
+/// returning the JSON-RPC [`trusty_common::mcp::Response`] as JSON (HTTP 200;
+/// JSON-RPC errors are carried in the envelope, matching `trusty-memory`).
+/// Test: `rpc_rejects_non_loopback_peer`, `rpc_dispatches_tools_list_for_loopback`.
+pub async fn rpc_handler(
+    State(state): State<Arc<DaemonState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<McpRequest>,
+) -> axum::response::Response {
+    if !is_loopback(&peer) {
+        tracing::warn!(
+            %peer,
+            "rejected non-loopback POST /rpc — the RPC endpoint is loopback-only"
+        );
+        return (
+            StatusCode::FORBIDDEN,
+            "POST /rpc is loopback-only; remote access is forbidden",
+        )
+            .into_response();
+    }
+
+    let backend = StateBackend::new(Arc::clone(&state));
+    let resp = crate::mcp::dispatch(&backend, req).await;
+    Json(resp).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn is_loopback_accepts_v4_v6_loopback() {
+        let v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7880);
+        let v4_8 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 4, 5, 6)), 7880);
+        let v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 7880);
+        assert!(is_loopback(&v4));
+        assert!(is_loopback(&v4_8), "all of 127.0.0.0/8 is loopback");
+        assert!(is_loopback(&v6));
+    }
+
+    #[test]
+    fn is_loopback_rejects_public() {
+        let lan = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 20)), 5000);
+        let public = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 443);
+        let v6_pub = SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+            443,
+        );
+        assert!(!is_loopback(&lan));
+        assert!(!is_loopback(&public));
+        assert!(!is_loopback(&v6_pub));
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -603,8 +603,13 @@ async fn rpc_rejects_non_loopback_peer() {
 
 #[tokio::test]
 async fn rpc_dispatches_tools_list_for_loopback() {
-    // A loopback peer is allowed and gets the full 15-tool catalog back through
-    // the in-process MCP dispatch path.
+    // A loopback peer is allowed and gets the full tool catalog back through the
+    // in-process MCP dispatch path. We assert the catalog CONTAINS the expected
+    // tool NAMES (not a brittle exact count): the 6 new session-lifecycle tools
+    // must all be present, and the total must be at least 15. The expected
+    // breakdown is 9 pre-existing tools + 6 new session-lifecycle tools = 15; if
+    // a future change adds tools, only this comment and the `>= 15` floor need
+    // revisiting — the name assertions keep protecting the session surface.
     use axum::body::Body;
     use axum::extract::ConnectInfo;
     use axum::http::Request;
@@ -632,7 +637,32 @@ async fn rpc_dispatches_tools_list_for_loopback() {
     let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["id"], 7);
     let tools = body["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 15, "loopback /rpc must dispatch tools/list");
+
+    // Collect the advertised tool names for name-based (not count-based) asserts.
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+
+    // The 6 new session-lifecycle tools must all be advertised.
+    for expected in [
+        "session_new",
+        "session_stop",
+        "session_resume",
+        "session_decommission",
+        "session_activity",
+        "session_send",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "loopback /rpc tools/list must advertise `{expected}`; got {names:?}"
+        );
+    }
+
+    // Count floor: 9 existing + 6 new = 15. Use `>=` so adding future tools does
+    // not break this test for the wrong reason.
+    assert!(
+        tools.len() >= 15,
+        "loopback /rpc tools/list must advertise at least 15 tools (9 existing + 6 session-lifecycle); got {}",
+        tools.len()
+    );
 }
 
 #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -571,6 +571,71 @@ async fn openapi_spec_is_valid() {
 }
 
 #[tokio::test]
+async fn rpc_rejects_non_loopback_peer() {
+    // #1221 hard requirement: POST /rpc must 403 a non-loopback source IP even
+    // though the daemon binds loopback — guarding a future 0.0.0.0 rebind.
+    use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::Request;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use tower::ServiceExt;
+
+    let app = router(DaemonState::shared());
+    // Simulate a request arriving from a public LAN address.
+    let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), 40000);
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/rpc")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+        ))
+        .unwrap();
+    req.extensions_mut().insert(ConnectInfo(peer));
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "non-loopback /rpc must be forbidden"
+    );
+}
+
+#[tokio::test]
+async fn rpc_dispatches_tools_list_for_loopback() {
+    // A loopback peer is allowed and gets the full 15-tool catalog back through
+    // the in-process MCP dispatch path.
+    use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::Request;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use tower::ServiceExt;
+
+    let app = router(DaemonState::shared());
+    let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50505);
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/rpc")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            r#"{"jsonrpc":"2.0","id":7,"method":"tools/list"}"#,
+        ))
+        .unwrap();
+    req.extensions_mut().insert(ConnectInfo(peer));
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["id"], 7);
+    let tools = body["result"]["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 15, "loopback /rpc must dispatch tools/list");
+}
+
+#[tokio::test]
 async fn pause_then_resume_round_trips() {
     // Pausing flips a session to `Paused`; resuming flips it back to
     // `Active` and clears the pause metadata.

--- a/crates/trusty-mpm/src/daemon/managed_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes.rs
@@ -235,6 +235,204 @@ pub struct ActivityResponse {
     pub proposed_default: Option<String>,
 }
 
+// ── Shared lifecycle core (reused by HTTP handlers + MCP tools, #1221) ─────────
+
+/// Transport-agnostic inputs for spawning a managed session.
+///
+/// Why: both the HTTP `POST /…/managed` handler and the MCP `session_new` tool
+/// need to spawn a session with the same semantics; a shared struct lets one
+/// [`spawn_managed`] function serve both without the MCP path re-implementing
+/// the provision→create→spawn ritual.
+/// What: the same fields as [`SpawnRequest`] but plain owned types (no axum/serde
+/// extraction), so non-HTTP callers can build it directly.
+/// Test: `spawn_managed` is exercised via `crate::daemon::mcp_session`'s
+/// `session_new_invalid_runtime_errors` and the HTTP spawn tests.
+#[derive(Debug, Clone)]
+pub struct SpawnParams {
+    /// Repository URL to provision the session workspace from.
+    pub repo_url: String,
+    /// Git branch or ref to check out.
+    pub git_ref: String,
+    /// Human-readable task description for the session.
+    pub task: String,
+    /// Optional name hint overriding the auto-generated tmux session name.
+    pub name_hint: Option<String>,
+    /// Optional runtime selector (`"claude-code"` | `"tcode"`).
+    pub runtime: Option<String>,
+}
+
+/// Spawn a managed session, shared by the HTTP handler and the MCP tool.
+///
+/// Why: the spawn flow (resolve runtime → provision workspace → create tmux host
+/// → launch harness) must be identical across transports; centralising it here
+/// means the MCP `session_new` tool is a true thin wrapper rather than a
+/// divergent copy.
+/// What: in order — (0) parses the runtime selector (an unknown value is an early
+/// `Err` before any side effect); (1) provisions an isolated workspace; (2)
+/// creates the tmux session rooted at that workspace; (3) spawns the selected
+/// runtime in the pane (a spawn failure marks the record errored but is not
+/// fatal — the record still exists). Returns the final [`SessionRecord`].
+/// Test: `crate::daemon::mcp_session::tests::session_new_invalid_runtime_errors`
+/// covers the early runtime-rejection path; the HTTP spawn tests cover the
+/// provision/create/spawn path.
+pub async fn spawn_managed(
+    state: &Arc<DaemonState>,
+    params: SpawnParams,
+) -> Result<SessionRecord, String> {
+    // Step 0: resolve the runtime backend (default claude-code). Reject unknown
+    // selectors BEFORE any provisioning so a typo never leaves an orphan
+    // workspace.
+    let runtime = match params.runtime.as_deref() {
+        None => RuntimeKind::default(),
+        Some(raw) => raw.parse::<RuntimeKind>().map_err(|e| e.to_string())?,
+    };
+
+    // Step 1: pre-generate the id + provision an isolated workspace.
+    let workspace_root = std::env::var("TRUSTY_MPM_WORKSPACE_ROOT")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+                .join(".trusty-mpm")
+                .join("workspaces")
+        });
+
+    let session_id = ManagedSessionId::new();
+    let provisioner = WorkspaceProvisioner::new(crate::provisioner::RealGitBackend, workspace_root);
+    let prepared = provisioner
+        .provision(&session_id, &params.repo_url, &params.git_ref, &params.task)
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed: provision failed: {e}");
+            format!("workspace provisioning failed: {e}")
+        })?;
+
+    // Step 2: create the tmux session rooted at the provisioned workspace.
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create_with_id(
+            session_id,
+            params.task.clone(),
+            Some(prepared.path.clone()),
+            params.name_hint,
+            Some(prepared.path.clone()),
+            Some(params.repo_url.clone()),
+            Some(params.git_ref.clone()),
+            runtime,
+        )
+        .await
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed: session create failed: {e}");
+            e.to_string()
+        })?;
+
+    if let Err(e) = mgr
+        .set_workspace(
+            &record.id,
+            prepared.path.clone(),
+            ManagedSessionState::Active,
+        )
+        .await
+    {
+        warn!(id = %record.id, "spawn_managed: set_workspace failed: {e}");
+    }
+
+    // Step 3: spawn the selected runtime in the pane. A spawn failure is recorded
+    // (the record is marked errored) but is not fatal — the record exists and the
+    // caller still gets it back.
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = build_adapter(record.runtime, tmux_arc);
+    if let Err(e) = adapter.spawn(&record.tmux_name, &prepared.path, &params.task) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            runtime = %record.runtime.as_str(),
+            "spawn_managed: runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            path = %prepared.path.display(),
+            "managed session spawned successfully"
+        );
+    }
+
+    Ok(mgr.get(&record.id).await.unwrap_or(record))
+}
+
+/// Resume a stopped session and re-spawn its runtime, shared across transports.
+///
+/// Why: the HTTP resume handler and the MCP `session_resume` tool must both
+/// resume the record AND re-spawn the runtime so the session is actually live;
+/// centralising avoids the MCP path silently resuming without re-spawning.
+/// What: calls [`crate::session_manager::SessionManager::resume`], then re-spawns
+/// the SAME runtime backend in the fresh tmux session (no re-clone). Returns the
+/// final record. A `SessionNotFound` becomes a "not found" error; an invalid
+/// state transition becomes a descriptive error.
+/// Test: covered by the HTTP `resume_managed_session` tests and the MCP
+/// `session_resume_unknown_id_errors` test.
+pub async fn resume_managed(
+    state: &Arc<DaemonState>,
+    id: &ManagedSessionId,
+) -> Result<SessionRecord, String> {
+    let mgr = state.session_manager().await;
+    let record = mgr.resume(id).await.map_err(|e| e.to_string())?;
+
+    let workspace = record
+        .workspace_path
+        .clone()
+        .unwrap_or_else(|| record.cwd.clone());
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = build_adapter(record.runtime, tmux_arc);
+    if let Err(e) = adapter.spawn(&record.tmux_name, &workspace, &record.task) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            runtime = %record.runtime.as_str(),
+            "resume_managed: runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("resume spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            workspace = %workspace.display(),
+            "managed session resumed and runtime respawned"
+        );
+    }
+
+    Ok(mgr.get(id).await.unwrap_or(record))
+}
+
+/// Serialize a [`SessionRecord`] to the flat JSON shape the MCP tools return.
+///
+/// Why: the MCP tools return JSON values (not axum responses); reusing the same
+/// field set as [`SpawnResponse`]/[`SessionSummary`] keeps the MCP and HTTP
+/// payloads consistent for the driver skill.
+/// What: maps the record to a JSON object including the derived `attach_cmd`.
+/// Test: covered by `crate::daemon::mcp_session` tests that assert echoed fields.
+pub fn record_to_json(r: &SessionRecord) -> serde_json::Value {
+    serde_json::json!({
+        "id": r.id.to_string(),
+        "name": r.tmux_name,
+        "state": r.state.to_string(),
+        "workspace_path": r.workspace_path.as_ref().map(|p| p.to_string_lossy().to_string()),
+        "repo_url": r.repo_url,
+        "branch": r.branch,
+        "created_at": r.created_at.to_rfc3339(),
+        "last_activity_at": r.last_activity_at.map(|t| t.to_rfc3339()),
+        "attach_cmd": attach_cmd_for(&r.tmux_name),
+        "runtime": r.runtime.as_str(),
+        "pending_decision": r.pending_decision,
+        "proposed_default": r.proposed_default,
+    })
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Convert a [`SessionRecord`] into a wire [`SessionSummary`].
@@ -314,118 +512,44 @@ pub async fn spawn_session(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<SpawnRequest>,
 ) -> impl IntoResponse {
-    // ── Step 0: resolve the requested runtime backend (default: claude-code) ──
-    let runtime = match req.runtime.as_deref() {
-        None => RuntimeKind::default(),
-        Some(raw) => match raw.parse::<RuntimeKind>() {
-            Ok(kind) => kind,
-            Err(e) => {
-                warn!("spawn_session: invalid runtime selector: {e}");
-                return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
-            }
-        },
-    };
-
-    // ── Step 1: pre-generate session id + provision isolated workspace ────────
-    let workspace_root = std::env::var("TRUSTY_MPM_WORKSPACE_ROOT")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                .join(".trusty-mpm")
-                .join("workspaces")
-        });
-
-    let session_id = ManagedSessionId::new();
-    let provisioner = WorkspaceProvisioner::new(crate::provisioner::RealGitBackend, workspace_root);
-
-    let prepared = match provisioner.provision(&session_id, &req.repo_url, &req.git_ref, &req.task)
+    // Reject an invalid runtime selector up front with a 400 (the shared
+    // `spawn_managed` helper also rejects it, but doing it here lets us keep the
+    // HTTP-specific 400-vs-500 status distinction that existing clients rely on).
+    if let Some(raw) = req.runtime.as_deref()
+        && let Err(e) = raw.parse::<RuntimeKind>()
     {
-        Ok(p) => p,
-        Err(e) => {
-            warn!(id = %session_id, "spawn_session: provision failed: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("workspace provisioning failed: {e}"),
-            )
-                .into_response();
-        }
-    };
-
-    // ── Step 2: create tmux session rooted at the provisioned workspace ───────
-    let mgr = state.session_manager().await;
-    let record = match mgr
-        .create_with_id(
-            session_id,
-            req.task.clone(),
-            Some(prepared.path.clone()),
-            req.name_hint,
-            Some(prepared.path.clone()),
-            Some(req.repo_url.clone()),
-            Some(req.git_ref.clone()),
-            runtime,
-        )
-        .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(id = %session_id, "spawn_session: session create failed: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    };
-
-    // Transition to Active now that the workspace is ready and the tmux session
-    // has been created.
-    if let Err(e) = mgr
-        .set_workspace(
-            &record.id,
-            prepared.path.clone(),
-            ManagedSessionState::Active,
-        )
-        .await
-    {
-        warn!(id = %record.id, "spawn_session: set_workspace failed: {e}");
+        warn!("spawn_session: invalid runtime selector: {e}");
+        return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    // ── Step 3: spawn the selected runtime in the pane ───────────────────────
-    let tmux_arc = mgr.tmux_driver();
-    let adapter = build_adapter(record.runtime, tmux_arc);
-    if let Err(e) = adapter.spawn(&record.tmux_name, &prepared.path, &req.task) {
-        warn!(
-            id = %record.id,
-            name = %record.tmux_name,
-            runtime = %record.runtime.as_str(),
-            "spawn_session: runtime adapter spawn failed: {e}"
-        );
-        let _ = mgr
-            .mark_errored(&record.id, &format!("spawn failed: {e}"))
-            .await;
-    } else {
-        info!(
-            id = %record.id,
-            name = %record.tmux_name,
-            path = %prepared.path.display(),
-            "managed session spawned successfully"
-        );
-    }
-
-    let final_record = mgr.get(&record.id).await.unwrap_or(record);
-    let attach = attach_cmd_for(&final_record.tmux_name);
-    let runtime_str = final_record.runtime.as_str().to_owned();
-    let resp = SpawnResponse {
-        id: final_record.id.to_string(),
-        name: final_record.tmux_name,
-        workspace_path: final_record
-            .workspace_path
-            .map(|p| p.to_string_lossy().to_string()),
-        repo_url: final_record.repo_url,
-        branch: final_record.branch,
-        state: final_record.state.to_string(),
-        created_at: final_record.created_at.to_rfc3339(),
-        attach_cmd: attach,
-        runtime: runtime_str,
+    let params = SpawnParams {
+        repo_url: req.repo_url,
+        git_ref: req.git_ref,
+        task: req.task,
+        name_hint: req.name_hint,
+        runtime: req.runtime,
     };
-    (StatusCode::CREATED, Json(resp)).into_response()
+
+    match spawn_managed(&state, params).await {
+        Ok(final_record) => {
+            let resp = SpawnResponse {
+                id: final_record.id.to_string(),
+                name: final_record.tmux_name.clone(),
+                workspace_path: final_record
+                    .workspace_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().to_string()),
+                repo_url: final_record.repo_url.clone(),
+                branch: final_record.branch.clone(),
+                state: final_record.state.to_string(),
+                created_at: final_record.created_at.to_rfc3339(),
+                attach_cmd: attach_cmd_for(&final_record.tmux_name),
+                runtime: final_record.runtime.as_str().to_owned(),
+            };
+            (StatusCode::CREATED, Json(resp)).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+    }
 }
 
 /// GET /api/v1/sessions/managed — list all managed sessions.
@@ -588,51 +712,37 @@ pub async fn resume_managed_session(
         Ok(id) => id,
         Err((code, msg)) => return (code, msg).into_response(),
     };
+
+    // The shared `resume_managed` helper resumes the record AND re-spawns the
+    // runtime. We re-map its errors to the HTTP-specific 404/409/500 statuses by
+    // first probing the manager's typed error (so existing clients keep getting
+    // the same codes), then delegating the spawn-and-respawn to the shared path.
     let mgr = state.session_manager().await;
-
-    let record = match mgr.resume(&id).await {
-        Ok(r) => r,
-        Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
-            return (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response();
+    if let Err(e) = mgr.get(&id).await {
+        match e {
+            crate::session_manager::ManagedError::SessionNotFound(_) => {
+                return (StatusCode::NOT_FOUND, format!("session {id_str} not found"))
+                    .into_response();
+            }
+            other => {
+                return (StatusCode::INTERNAL_SERVER_ERROR, other.to_string()).into_response();
+            }
         }
-        Err(crate::session_manager::ManagedError::InvalidState(_, msg)) => {
-            return (StatusCode::CONFLICT, msg).into_response();
-        }
-        Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    };
-
-    // Re-spawn the SAME runtime in the fresh tmux session (no re-clone —
-    // workspace reused). The backend is read from the persisted record so a
-    // tcode session resumes on tcode.
-    let workspace = record
-        .workspace_path
-        .clone()
-        .unwrap_or_else(|| record.cwd.clone());
-    let tmux_arc = mgr.tmux_driver();
-    let adapter = build_adapter(record.runtime, tmux_arc);
-    if let Err(e) = adapter.spawn(&record.tmux_name, &workspace, &record.task) {
-        warn!(
-            id = %record.id,
-            name = %record.tmux_name,
-            runtime = %record.runtime.as_str(),
-            "resume: runtime adapter spawn failed: {e}"
-        );
-        let _ = mgr
-            .mark_errored(&record.id, &format!("resume spawn failed: {e}"))
-            .await;
-    } else {
-        info!(
-            id = %record.id,
-            name = %record.tmux_name,
-            workspace = %workspace.display(),
-            "managed session resumed and claude respawned"
-        );
     }
 
-    let final_record = mgr.get(&id).await.unwrap_or(record);
-    Json(record_to_summary(&final_record)).into_response()
+    match crate::daemon::managed_routes::resume_managed(&state, &id).await {
+        Ok(final_record) => Json(record_to_summary(&final_record)).into_response(),
+        Err(msg) => {
+            // `resume` rejects an invalid state transition; surface as 409.
+            if msg.contains("invalid state transition") {
+                (StatusCode::CONFLICT, msg).into_response()
+            } else if msg.contains("session not found") {
+                (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+            } else {
+                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+            }
+        }
+    }
 }
 
 /// POST /api/v1/sessions/managed/{id}/decommission — full teardown.

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1,0 +1,249 @@
+//! Transport-agnostic session-lifecycle core shared by the HTTP routes and the
+//! MCP tools (#1221).
+//!
+//! Why: both the HTTP `…/managed/*` handlers (in this module's `mod.rs`) and the
+//! MCP session-lifecycle tools (in `crate::daemon::mcp_session`) must spawn and
+//! resume managed sessions with IDENTICAL semantics. Keeping the spawn/resume
+//! flow here — rather than duplicating it per transport — guarantees they cannot
+//! diverge, and keeps the route file under the 500-SLOC production cap.
+//! What: the `SpawnParams` input struct, the `spawn_managed` flow
+//! (provision → create tmux host → launch harness), the typed `ResumeManagedError`
+//! (so callers map failures to HTTP 404/409/500 by VARIANT, never by `Display`
+//! substring), and the `resume_managed` flow (single-round-trip resume + respawn,
+//! no TOCTOU pre-flight `get`).
+//! Test: `spawn_managed`/`resume_managed` are exercised by the HTTP spawn/resume
+//! handler tests and the MCP `session_new_invalid_runtime_errors` /
+//! `session_resume_unknown_id_errors` tests, plus the typed-error regression
+//! tests `resume_managed_typed_*` in tests/session_manager_mvp.rs.
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use crate::daemon::state::DaemonState;
+use crate::provisioner::WorkspaceProvisioner;
+use crate::runtime::{RuntimeKind, build_adapter};
+use crate::session_manager::{ManagedError, ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// Transport-agnostic inputs for spawning a managed session.
+///
+/// Why: both the HTTP `POST /…/managed` handler and the MCP `session_new` tool
+/// need to spawn a session with the same semantics; a shared struct lets one
+/// [`spawn_managed`] function serve both without the MCP path re-implementing
+/// the provision→create→spawn ritual.
+/// What: the same fields as `super::SpawnRequest` but plain owned types (no
+/// axum/serde extraction), so non-HTTP callers can build it directly.
+/// Test: `spawn_managed` is exercised via `crate::daemon::mcp_session`'s
+/// `session_new_invalid_runtime_errors` and the HTTP spawn tests.
+#[derive(Debug, Clone)]
+pub struct SpawnParams {
+    /// Repository URL to provision the session workspace from.
+    pub repo_url: String,
+    /// Git branch or ref to check out.
+    pub git_ref: String,
+    /// Human-readable task description for the session.
+    pub task: String,
+    /// Optional name hint overriding the auto-generated tmux session name.
+    pub name_hint: Option<String>,
+    /// Optional runtime selector (`"claude-code"` | `"tcode"`).
+    pub runtime: Option<String>,
+}
+
+/// Spawn a managed session, shared by the HTTP handler and the MCP tool.
+///
+/// Why: the spawn flow (resolve runtime → provision workspace → create tmux host
+/// → launch harness) must be identical across transports; centralising it here
+/// means the MCP `session_new` tool is a true thin wrapper rather than a
+/// divergent copy.
+/// What: in order — (0) parses the runtime selector (an unknown value is an early
+/// `Err` before any side effect); (1) provisions an isolated workspace; (2)
+/// creates the tmux session rooted at that workspace; (3) spawns the selected
+/// runtime in the pane (a spawn failure marks the record errored but is not
+/// fatal — the record still exists). Returns the final [`SessionRecord`].
+/// Test: `crate::daemon::mcp_session::tests::session_new_invalid_runtime_errors`
+/// covers the early runtime-rejection path; the HTTP spawn tests cover the
+/// provision/create/spawn path.
+pub async fn spawn_managed(
+    state: &Arc<DaemonState>,
+    params: SpawnParams,
+) -> Result<SessionRecord, String> {
+    // Step 0: resolve the runtime backend (default claude-code). Reject unknown
+    // selectors BEFORE any provisioning so a typo never leaves an orphan
+    // workspace.
+    let runtime = match params.runtime.as_deref() {
+        None => RuntimeKind::default(),
+        Some(raw) => raw.parse::<RuntimeKind>().map_err(|e| e.to_string())?,
+    };
+
+    // Step 1: pre-generate the id + provision an isolated workspace.
+    let workspace_root = std::env::var("TRUSTY_MPM_WORKSPACE_ROOT")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+                .join(".trusty-mpm")
+                .join("workspaces")
+        });
+
+    let session_id = ManagedSessionId::new();
+    let provisioner = WorkspaceProvisioner::new(crate::provisioner::RealGitBackend, workspace_root);
+    let prepared = provisioner
+        .provision(&session_id, &params.repo_url, &params.git_ref, &params.task)
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed: provision failed: {e}");
+            format!("workspace provisioning failed: {e}")
+        })?;
+
+    // Step 2: create the tmux session rooted at the provisioned workspace.
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create_with_id(
+            session_id,
+            params.task.clone(),
+            Some(prepared.path.clone()),
+            params.name_hint,
+            Some(prepared.path.clone()),
+            Some(params.repo_url.clone()),
+            Some(params.git_ref.clone()),
+            runtime,
+        )
+        .await
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed: session create failed: {e}");
+            e.to_string()
+        })?;
+
+    if let Err(e) = mgr
+        .set_workspace(
+            &record.id,
+            prepared.path.clone(),
+            ManagedSessionState::Active,
+        )
+        .await
+    {
+        warn!(id = %record.id, "spawn_managed: set_workspace failed: {e}");
+    }
+
+    // Step 3: spawn the selected runtime in the pane. A spawn failure is recorded
+    // (the record is marked errored) but is not fatal — the record exists and the
+    // caller still gets it back.
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = build_adapter(record.runtime, tmux_arc);
+    if let Err(e) = adapter.spawn(&record.tmux_name, &prepared.path, &params.task) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            runtime = %record.runtime.as_str(),
+            "spawn_managed: runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            path = %prepared.path.display(),
+            "managed session spawned successfully"
+        );
+    }
+
+    Ok(mgr.get(&record.id).await.unwrap_or(record))
+}
+
+/// Typed failure modes for [`resume_managed`], shared across transports.
+///
+/// Why: the prior design mapped resume failures to HTTP status codes by
+/// substring-matching the `Display` string (`msg.contains("invalid state
+/// transition")` → 409, `msg.contains("session not found")` → 404), which
+/// silently regressed to 500 the moment any error wording changed. A typed enum
+/// lets the HTTP handler match on variants (→ 404/409/500) with no stringly-typed
+/// coupling, and lets the MCP path render a stable `Display` string whose
+/// "not found" substring the existing MCP tests rely on.
+/// What: three variants — `NotFound` (the id is absent), `InvalidState` (the
+/// session is not `Stopped`/`Errored`, carrying the descriptive reason), and
+/// `Other` (any remaining failure: tmux/store/I-O). The `Display` strings are
+/// chosen so the not-found variant still contains the literal "not found".
+/// Test: `resume_managed_typed_*` in tests/session_manager_mvp.rs drive the
+/// 404/409 paths through the typed value (no `Display` matching), and the MCP
+/// `session_resume_unknown_id_errors` test asserts the rendered string.
+#[derive(Debug, thiserror::Error)]
+pub enum ResumeManagedError {
+    /// The requested session id was not present in the store → HTTP 404.
+    #[error("session not found: {0}")]
+    NotFound(String),
+
+    /// The session is not in a resumable state (only `Stopped`/`Errored` are) →
+    /// HTTP 409. Carries the manager's descriptive reason.
+    #[error("invalid state transition: {0}")]
+    InvalidState(String),
+
+    /// Any other failure (tmux/store/I-O) → HTTP 500.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<ManagedError> for ResumeManagedError {
+    /// Why: `SessionManager::resume` returns a typed [`ManagedError`]; mapping its
+    /// variants here (rather than at each call site) keeps the not-found/invalid-state
+    /// HTTP distinction in one place and prevents a wording change from regressing
+    /// a 404/409 to a 500.
+    /// What: maps `SessionNotFound` → `NotFound`, `InvalidState` → `InvalidState`
+    /// (preserving the descriptive reason), and every other variant → `Other`.
+    /// Test: covered transitively by the resume handler 404/409 tests.
+    fn from(e: ManagedError) -> Self {
+        match e {
+            ManagedError::SessionNotFound(id) => ResumeManagedError::NotFound(id),
+            ManagedError::InvalidState(_, reason) => ResumeManagedError::InvalidState(reason),
+            other => ResumeManagedError::Other(other.to_string()),
+        }
+    }
+}
+
+/// Resume a stopped session and re-spawn its runtime, shared across transports.
+///
+/// Why: the HTTP resume handler and the MCP `session_resume` tool must both
+/// resume the record AND re-spawn the runtime so the session is actually live;
+/// centralising avoids the MCP path silently resuming without re-spawning.
+/// What: calls [`crate::session_manager::SessionManager::resume`] (which performs
+/// the existence + state check in a SINGLE round-trip — no pre-flight `get`, so
+/// no TOCTOU window) and maps its typed [`ManagedError`] into a typed
+/// [`ResumeManagedError`] (`NotFound`/`InvalidState`/`Other`). It then re-spawns
+/// the SAME runtime backend in the fresh tmux session (no re-clone) and returns
+/// the final record.
+/// Test: covered by the HTTP `resume_managed_session` tests and the MCP
+/// `session_resume_unknown_id_errors` test.
+pub async fn resume_managed(
+    state: &Arc<DaemonState>,
+    id: &ManagedSessionId,
+) -> Result<SessionRecord, ResumeManagedError> {
+    let mgr = state.session_manager().await;
+    let record = mgr.resume(id).await.map_err(ResumeManagedError::from)?;
+
+    let workspace = record
+        .workspace_path
+        .clone()
+        .unwrap_or_else(|| record.cwd.clone());
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = build_adapter(record.runtime, tmux_arc);
+    if let Err(e) = adapter.spawn(&record.tmux_name, &workspace, &record.task) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            runtime = %record.runtime.as_str(),
+            "resume_managed: runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("resume spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            workspace = %workspace.display(),
+            "managed session resumed and runtime respawned"
+        );
+    }
+
+    Ok(mgr.get(id).await.unwrap_or(record))
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -20,12 +20,14 @@ use axum::{
     response::IntoResponse,
 };
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use tracing::warn;
 
 use crate::daemon::state::DaemonState;
-use crate::provisioner::WorkspaceProvisioner;
-use crate::runtime::{RuntimeKind, build_adapter};
-use crate::session_manager::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use crate::runtime::RuntimeKind;
+use crate::session_manager::{ManagedSessionId, SessionRecord};
+
+mod lifecycle;
+pub use lifecycle::{ResumeManagedError, SpawnParams, resume_managed, spawn_managed};
 
 // ── Request / Response shapes ─────────────────────────────────────────────────
 
@@ -233,180 +235,6 @@ pub struct ActivityResponse {
     pub pending_decision: Option<String>,
     /// Proposed default answer to the pending decision.
     pub proposed_default: Option<String>,
-}
-
-// ── Shared lifecycle core (reused by HTTP handlers + MCP tools, #1221) ─────────
-
-/// Transport-agnostic inputs for spawning a managed session.
-///
-/// Why: both the HTTP `POST /…/managed` handler and the MCP `session_new` tool
-/// need to spawn a session with the same semantics; a shared struct lets one
-/// [`spawn_managed`] function serve both without the MCP path re-implementing
-/// the provision→create→spawn ritual.
-/// What: the same fields as [`SpawnRequest`] but plain owned types (no axum/serde
-/// extraction), so non-HTTP callers can build it directly.
-/// Test: `spawn_managed` is exercised via `crate::daemon::mcp_session`'s
-/// `session_new_invalid_runtime_errors` and the HTTP spawn tests.
-#[derive(Debug, Clone)]
-pub struct SpawnParams {
-    /// Repository URL to provision the session workspace from.
-    pub repo_url: String,
-    /// Git branch or ref to check out.
-    pub git_ref: String,
-    /// Human-readable task description for the session.
-    pub task: String,
-    /// Optional name hint overriding the auto-generated tmux session name.
-    pub name_hint: Option<String>,
-    /// Optional runtime selector (`"claude-code"` | `"tcode"`).
-    pub runtime: Option<String>,
-}
-
-/// Spawn a managed session, shared by the HTTP handler and the MCP tool.
-///
-/// Why: the spawn flow (resolve runtime → provision workspace → create tmux host
-/// → launch harness) must be identical across transports; centralising it here
-/// means the MCP `session_new` tool is a true thin wrapper rather than a
-/// divergent copy.
-/// What: in order — (0) parses the runtime selector (an unknown value is an early
-/// `Err` before any side effect); (1) provisions an isolated workspace; (2)
-/// creates the tmux session rooted at that workspace; (3) spawns the selected
-/// runtime in the pane (a spawn failure marks the record errored but is not
-/// fatal — the record still exists). Returns the final [`SessionRecord`].
-/// Test: `crate::daemon::mcp_session::tests::session_new_invalid_runtime_errors`
-/// covers the early runtime-rejection path; the HTTP spawn tests cover the
-/// provision/create/spawn path.
-pub async fn spawn_managed(
-    state: &Arc<DaemonState>,
-    params: SpawnParams,
-) -> Result<SessionRecord, String> {
-    // Step 0: resolve the runtime backend (default claude-code). Reject unknown
-    // selectors BEFORE any provisioning so a typo never leaves an orphan
-    // workspace.
-    let runtime = match params.runtime.as_deref() {
-        None => RuntimeKind::default(),
-        Some(raw) => raw.parse::<RuntimeKind>().map_err(|e| e.to_string())?,
-    };
-
-    // Step 1: pre-generate the id + provision an isolated workspace.
-    let workspace_root = std::env::var("TRUSTY_MPM_WORKSPACE_ROOT")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                .join(".trusty-mpm")
-                .join("workspaces")
-        });
-
-    let session_id = ManagedSessionId::new();
-    let provisioner = WorkspaceProvisioner::new(crate::provisioner::RealGitBackend, workspace_root);
-    let prepared = provisioner
-        .provision(&session_id, &params.repo_url, &params.git_ref, &params.task)
-        .map_err(|e| {
-            warn!(id = %session_id, "spawn_managed: provision failed: {e}");
-            format!("workspace provisioning failed: {e}")
-        })?;
-
-    // Step 2: create the tmux session rooted at the provisioned workspace.
-    let mgr = state.session_manager().await;
-    let record = mgr
-        .create_with_id(
-            session_id,
-            params.task.clone(),
-            Some(prepared.path.clone()),
-            params.name_hint,
-            Some(prepared.path.clone()),
-            Some(params.repo_url.clone()),
-            Some(params.git_ref.clone()),
-            runtime,
-        )
-        .await
-        .map_err(|e| {
-            warn!(id = %session_id, "spawn_managed: session create failed: {e}");
-            e.to_string()
-        })?;
-
-    if let Err(e) = mgr
-        .set_workspace(
-            &record.id,
-            prepared.path.clone(),
-            ManagedSessionState::Active,
-        )
-        .await
-    {
-        warn!(id = %record.id, "spawn_managed: set_workspace failed: {e}");
-    }
-
-    // Step 3: spawn the selected runtime in the pane. A spawn failure is recorded
-    // (the record is marked errored) but is not fatal — the record exists and the
-    // caller still gets it back.
-    let tmux_arc = mgr.tmux_driver();
-    let adapter = build_adapter(record.runtime, tmux_arc);
-    if let Err(e) = adapter.spawn(&record.tmux_name, &prepared.path, &params.task) {
-        warn!(
-            id = %record.id,
-            name = %record.tmux_name,
-            runtime = %record.runtime.as_str(),
-            "spawn_managed: runtime adapter spawn failed: {e}"
-        );
-        let _ = mgr
-            .mark_errored(&record.id, &format!("spawn failed: {e}"))
-            .await;
-    } else {
-        info!(
-            id = %record.id,
-            name = %record.tmux_name,
-            path = %prepared.path.display(),
-            "managed session spawned successfully"
-        );
-    }
-
-    Ok(mgr.get(&record.id).await.unwrap_or(record))
-}
-
-/// Resume a stopped session and re-spawn its runtime, shared across transports.
-///
-/// Why: the HTTP resume handler and the MCP `session_resume` tool must both
-/// resume the record AND re-spawn the runtime so the session is actually live;
-/// centralising avoids the MCP path silently resuming without re-spawning.
-/// What: calls [`crate::session_manager::SessionManager::resume`], then re-spawns
-/// the SAME runtime backend in the fresh tmux session (no re-clone). Returns the
-/// final record. A `SessionNotFound` becomes a "not found" error; an invalid
-/// state transition becomes a descriptive error.
-/// Test: covered by the HTTP `resume_managed_session` tests and the MCP
-/// `session_resume_unknown_id_errors` test.
-pub async fn resume_managed(
-    state: &Arc<DaemonState>,
-    id: &ManagedSessionId,
-) -> Result<SessionRecord, String> {
-    let mgr = state.session_manager().await;
-    let record = mgr.resume(id).await.map_err(|e| e.to_string())?;
-
-    let workspace = record
-        .workspace_path
-        .clone()
-        .unwrap_or_else(|| record.cwd.clone());
-    let tmux_arc = mgr.tmux_driver();
-    let adapter = build_adapter(record.runtime, tmux_arc);
-    if let Err(e) = adapter.spawn(&record.tmux_name, &workspace, &record.task) {
-        warn!(
-            id = %record.id,
-            name = %record.tmux_name,
-            runtime = %record.runtime.as_str(),
-            "resume_managed: runtime adapter spawn failed: {e}"
-        );
-        let _ = mgr
-            .mark_errored(&record.id, &format!("resume spawn failed: {e}"))
-            .await;
-    } else {
-        info!(
-            id = %record.id,
-            name = %record.tmux_name,
-            workspace = %workspace.display(),
-            "managed session resumed and runtime respawned"
-        );
-    }
-
-    Ok(mgr.get(id).await.unwrap_or(record))
 }
 
 /// Serialize a [`SessionRecord`] to the flat JSON shape the MCP tools return.
@@ -713,34 +541,23 @@ pub async fn resume_managed_session(
         Err((code, msg)) => return (code, msg).into_response(),
     };
 
-    // The shared `resume_managed` helper resumes the record AND re-spawns the
-    // runtime. We re-map its errors to the HTTP-specific 404/409/500 statuses by
-    // first probing the manager's typed error (so existing clients keep getting
-    // the same codes), then delegating the spawn-and-respawn to the shared path.
-    let mgr = state.session_manager().await;
-    if let Err(e) = mgr.get(&id).await {
-        match e {
-            crate::session_manager::ManagedError::SessionNotFound(_) => {
-                return (StatusCode::NOT_FOUND, format!("session {id_str} not found"))
-                    .into_response();
-            }
-            other => {
-                return (StatusCode::INTERNAL_SERVER_ERROR, other.to_string()).into_response();
-            }
-        }
-    }
-
-    match crate::daemon::managed_routes::resume_managed(&state, &id).await {
+    // Single round-trip: the shared `resume_managed` helper performs the
+    // existence + state check inside `SessionManager::resume` and re-spawns the
+    // runtime. We match on its TYPED error to choose the HTTP status — no
+    // pre-flight `get` (which introduced a TOCTOU race where the session could be
+    // decommissioned between the probe and the resume, yielding 500 instead of
+    // 404) and no `Display`-substring matching (which silently fell through to 500
+    // whenever the error wording changed).
+    match resume_managed(&state, &id).await {
         Ok(final_record) => Json(record_to_summary(&final_record)).into_response(),
-        Err(msg) => {
-            // `resume` rejects an invalid state transition; surface as 409.
-            if msg.contains("invalid state transition") {
-                (StatusCode::CONFLICT, msg).into_response()
-            } else if msg.contains("session not found") {
-                (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
-            } else {
-                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
-            }
+        Err(ResumeManagedError::NotFound(_)) => {
+            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+        }
+        Err(ResumeManagedError::InvalidState(reason)) => {
+            (StatusCode::CONFLICT, reason).into_response()
+        }
+        Err(ResumeManagedError::Other(msg)) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
         }
     }
 }

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -365,6 +365,45 @@ impl OrchestratorBackend for StateBackend {
             Err(e) => Err(format!("GitHub filing failed: {e}")),
         }
     }
+
+    // ── #1221: session-lifecycle tools ───────────────────────────────────────
+    //
+    // Each method is a thin wrapper over the existing `SessionManager` lifecycle
+    // ops (the same ones the HTTP `…/managed/*` routes use), so MCP and HTTP
+    // share one implementation. The wrapping logic lives in
+    // `super::mcp_session` to keep this file under the 500-SLOC cap.
+
+    async fn session_new(
+        &self,
+        repo_url: &str,
+        git_ref: &str,
+        task: &str,
+        name_hint: Option<&str>,
+        runtime: Option<&str>,
+    ) -> Result<Value, String> {
+        super::mcp_session::session_new(&self.state, repo_url, git_ref, task, name_hint, runtime)
+            .await
+    }
+
+    async fn session_stop(&self, session_id: &str) -> Result<Value, String> {
+        super::mcp_session::session_stop(&self.state, session_id).await
+    }
+
+    async fn session_resume(&self, session_id: &str) -> Result<Value, String> {
+        super::mcp_session::session_resume(&self.state, session_id).await
+    }
+
+    async fn session_decommission(&self, session_id: &str) -> Result<Value, String> {
+        super::mcp_session::session_decommission(&self.state, session_id).await
+    }
+
+    async fn session_activity(&self, session_id: &str, lines: u32) -> Result<Value, String> {
+        super::mcp_session::session_activity(&self.state, session_id, lines).await
+    }
+
+    async fn session_send(&self, session_id: &str, text: &str) -> Result<Value, String> {
+        super::mcp_session::session_send(&self.state, session_id, text).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -1,0 +1,270 @@
+//! Daemon-side implementation of the six session-lifecycle MCP tools (#1221).
+//!
+//! Why: the MCP `StateBackend` (in `mcp_backend.rs`) must service the new
+//! session-lifecycle tools, but inlining their bodies there would push that file
+//! over the 500-SLOC production cap. More importantly, these tools must be THIN
+//! WRAPPERS over the existing [`crate::session_manager::SessionManager`]
+//! lifecycle ops that the HTTP `…/managed/*` routes already use — not a parallel
+//! reimplementation — so MCP and HTTP behave identically. This module holds the
+//! wrapping logic; `session_new` delegates to the shared
+//! [`crate::daemon::managed_routes::spawn_managed`] used by the HTTP handler too.
+//! What: six free async functions — `session_new`, `session_stop`,
+//! `session_resume`, `session_decommission`, `session_activity`, `session_send`
+//! — each taking `&Arc<DaemonState>` plus parsed arguments and returning the
+//! same JSON shapes the HTTP routes return, or a human-readable error string.
+//! Test: `cargo test -p trusty-mpm daemon::mcp_session` plus the dispatch-level
+//! tests in `crate::mcp`.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+
+use crate::daemon::managed_routes::{SpawnParams, record_to_json, spawn_managed};
+use crate::daemon::state::DaemonState;
+use crate::session_manager::{ManagedError, ManagedSessionId};
+
+/// Parse a managed-session id string into a [`ManagedSessionId`].
+///
+/// Why: every single-id tool must reject a non-UUID with a clear message rather
+/// than a confusing downstream "not found".
+/// What: parses `raw` as a UUID, mapping failure to a descriptive error string.
+/// Test: `parse_managed_id_rejects_garbage` in the `tests` module.
+fn parse_managed_id(raw: &str) -> Result<ManagedSessionId, String> {
+    raw.parse::<uuid::Uuid>()
+        .map(ManagedSessionId::from)
+        .map_err(|_| format!("`{raw}` is not a valid managed session id (expected a UUID)"))
+}
+
+/// Map a [`ManagedError`] to a human-readable tool error string.
+///
+/// Why: the MCP tool result carries a flat string; mapping here keeps every
+/// wrapper's error path uniform and avoids leaking `Debug` formatting.
+/// What: renders the error via its `Display` impl (which already carries
+/// actionable context for each variant).
+/// Test: exercised by the not-found paths in the `tests` module.
+fn managed_err(e: ManagedError) -> String {
+    e.to_string()
+}
+
+/// Spawn a new managed session (`session_new` tool).
+///
+/// Why: gives the driver a typed spawn path; delegates to the shared
+/// [`spawn_managed`] helper so the MCP and HTTP spawn flows are identical.
+/// What: validates the optional `runtime` selector, provisions the workspace,
+/// creates the tmux host, launches the harness, and returns the new record as
+/// JSON (id, tmux name, workspace path, state, attach command, runtime).
+/// Test: `session_new_invalid_runtime_errors` (unit, no tmux needed).
+pub async fn session_new(
+    state: &Arc<DaemonState>,
+    repo_url: &str,
+    git_ref: &str,
+    task: &str,
+    name_hint: Option<&str>,
+    runtime: Option<&str>,
+) -> Result<Value, String> {
+    let params = SpawnParams {
+        repo_url: repo_url.to_string(),
+        git_ref: git_ref.to_string(),
+        task: task.to_string(),
+        name_hint: name_hint.map(str::to_string),
+        runtime: runtime.map(str::to_string),
+    };
+    let record = spawn_managed(state, params).await?;
+    Ok(record_to_json(&record))
+}
+
+/// Stop a session's runtime, keeping its workspace (`session_stop` tool).
+///
+/// Why: thin wrapper over [`crate::session_manager::SessionManager::stop`].
+/// What: parses the id, calls `stop`, returns the updated record as JSON.
+/// Test: `session_stop_unknown_id_errors` in the `tests` module.
+pub async fn session_stop(state: &Arc<DaemonState>, session_id: &str) -> Result<Value, String> {
+    let id = parse_managed_id(session_id)?;
+    let mgr = state.session_manager().await;
+    mgr.stop(&id)
+        .await
+        .map(|r| record_to_json(&r))
+        .map_err(managed_err)
+}
+
+/// Resume a stopped session in its existing workspace (`session_resume` tool).
+///
+/// Why: thin wrapper that mirrors the HTTP resume handler — it both resumes the
+/// record AND re-spawns the runtime so the session is actually live again.
+/// What: parses the id, delegates to
+/// [`crate::daemon::managed_routes::resume_managed`], returns the record as JSON.
+/// Test: `session_resume_unknown_id_errors` in the `tests` module.
+pub async fn session_resume(state: &Arc<DaemonState>, session_id: &str) -> Result<Value, String> {
+    let id = parse_managed_id(session_id)?;
+    let record = crate::daemon::managed_routes::resume_managed(state, &id).await?;
+    Ok(record_to_json(&record))
+}
+
+/// Permanently tear down a session (`session_decommission` tool).
+///
+/// Why: thin wrapper over
+/// [`crate::session_manager::SessionManager::decommission`].
+/// What: parses the id, calls `decommission`, returns the tombstone record.
+/// Test: `session_decommission_unknown_id_errors` in the `tests` module.
+pub async fn session_decommission(
+    state: &Arc<DaemonState>,
+    session_id: &str,
+) -> Result<Value, String> {
+    let id = parse_managed_id(session_id)?;
+    let mgr = state.session_manager().await;
+    mgr.decommission(&id)
+        .await
+        .map(|r| record_to_json(&r))
+        .map_err(managed_err)
+}
+
+/// Inspect a session's recent activity (`session_activity` tool).
+///
+/// Why: the driver needs raw pane content (always) plus lifecycle fields so it
+/// can reason about session state without an LLM key — matching the HTTP
+/// `…/activity` route's no-key contract.
+/// What: parses the id, captures the last `lines` pane lines, reports
+/// `runtime_active` and the pending-decision fields. The LLM classification
+/// overlay is intentionally NOT invoked here (it requires the activity monitor
+/// and a key); the raw pane is sufficient for the driver's own inference. A
+/// missing tmux pane degrades to an empty `raw_pane`, never an error.
+/// Test: `session_activity_unknown_id_errors` in the `tests` module.
+pub async fn session_activity(
+    state: &Arc<DaemonState>,
+    session_id: &str,
+    lines: u32,
+) -> Result<Value, String> {
+    let id = parse_managed_id(session_id)?;
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&id).await.map_err(managed_err)?;
+    let raw_pane = mgr.capture_pane(&id, lines).await.unwrap_or_default();
+    let runtime_active = mgr.tmux_driver().session_exists(&record.tmux_name);
+    Ok(json!({
+        "id": record.id.to_string(),
+        "name": record.tmux_name,
+        "state": record.state.to_string(),
+        "raw_pane": raw_pane,
+        "lines": lines,
+        "runtime_active": runtime_active,
+        "pending_decision": record.pending_decision,
+        "proposed_default": record.proposed_default,
+    }))
+}
+
+/// Send a line of text into a session's pane (`session_send` tool).
+///
+/// Why: thin wrapper over
+/// [`crate::session_manager::SessionManager::send_input`].
+/// What: parses the id, resolves the tmux name (for the confirmation), injects
+/// `text`, and returns `{ id, sent, tmux_name }`.
+/// Test: `session_send_unknown_id_errors` in the `tests` module.
+pub async fn session_send(
+    state: &Arc<DaemonState>,
+    session_id: &str,
+    text: &str,
+) -> Result<Value, String> {
+    let id = parse_managed_id(session_id)?;
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&id).await.map_err(managed_err)?;
+    mgr.send_input(&id, text).await.map_err(managed_err)?;
+    Ok(json!({
+        "id": record.id.to_string(),
+        "sent": true,
+        "tmux_name": record.tmux_name,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state() -> Arc<DaemonState> {
+        DaemonState::shared()
+    }
+
+    /// Why: a non-UUID id must be rejected before any store lookup.
+    /// Test: this test.
+    #[test]
+    fn parse_managed_id_rejects_garbage() {
+        let err = parse_managed_id("not-a-uuid").unwrap_err();
+        assert!(err.contains("not a valid managed session id"), "{err}");
+    }
+
+    /// Why: an unknown (well-formed) id must produce a "not found" error, not a
+    /// panic, for each single-id lifecycle tool.
+    /// What: drives stop/resume/decommission/activity/send against a fresh state
+    /// with a random UUID and asserts each returns Err containing "not found".
+    /// Test: this test.
+    #[tokio::test]
+    async fn unknown_id_errors_for_all_single_id_tools() {
+        let s = state();
+        let id = uuid::Uuid::new_v4().to_string();
+
+        assert!(
+            session_stop(&s, &id)
+                .await
+                .unwrap_err()
+                .contains("not found")
+        );
+        assert!(
+            session_resume(&s, &id)
+                .await
+                .unwrap_err()
+                .contains("not found")
+        );
+        assert!(
+            session_decommission(&s, &id)
+                .await
+                .unwrap_err()
+                .contains("not found")
+        );
+        assert!(
+            session_activity(&s, &id, 60)
+                .await
+                .unwrap_err()
+                .contains("not found")
+        );
+        assert!(
+            session_send(&s, &id, "hi")
+                .await
+                .unwrap_err()
+                .contains("not found")
+        );
+    }
+
+    /// Why: garbage ids must be rejected with the parse message (before lookup)
+    /// for every single-id tool.
+    /// Test: this test.
+    #[tokio::test]
+    async fn garbage_id_rejected_for_all_single_id_tools() {
+        let s = state();
+        for r in [
+            session_stop(&s, "xx").await,
+            session_resume(&s, "xx").await,
+            session_decommission(&s, "xx").await,
+            session_activity(&s, "xx", 60).await,
+            session_send(&s, "xx", "t").await,
+        ] {
+            assert!(r.unwrap_err().contains("valid managed session id"));
+        }
+    }
+
+    /// Why: an unknown `runtime` selector must be rejected up front (before any
+    /// provisioning/tmux work), with a message naming the supported values.
+    /// Test: this test.
+    #[tokio::test]
+    async fn session_new_invalid_runtime_errors() {
+        let s = state();
+        let err = session_new(
+            &s,
+            "https://example.com/r.git",
+            "main",
+            "t",
+            None,
+            Some("bogus"),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("unknown runtime"), "{err}");
+    }
+}

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -92,11 +92,17 @@ pub async fn session_stop(state: &Arc<DaemonState>, session_id: &str) -> Result<
 /// Why: thin wrapper that mirrors the HTTP resume handler — it both resumes the
 /// record AND re-spawns the runtime so the session is actually live again.
 /// What: parses the id, delegates to
-/// [`crate::daemon::managed_routes::resume_managed`], returns the record as JSON.
+/// [`crate::daemon::managed_routes::resume_managed`], and renders its typed
+/// [`crate::daemon::managed_routes::ResumeManagedError`] to a flat string via
+/// `Display` for the MCP tool result (the not-found variant's string still
+/// contains the literal "not found" the dispatch tests assert on). On success
+/// returns the record as JSON.
 /// Test: `session_resume_unknown_id_errors` in the `tests` module.
 pub async fn session_resume(state: &Arc<DaemonState>, session_id: &str) -> Result<Value, String> {
     let id = parse_managed_id(session_id)?;
-    let record = crate::daemon::managed_routes::resume_managed(state, &id).await?;
+    let record = crate::daemon::managed_routes::resume_managed(state, &id)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(record_to_json(&record))
 }
 

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -22,6 +22,7 @@ pub mod llm_overseer;
 pub mod lock;
 pub mod managed_routes;
 pub mod mcp_backend;
+pub mod mcp_session;
 pub mod openapi;
 pub mod optimizer;
 pub mod overseer_compose;
@@ -102,7 +103,14 @@ pub async fn serve_http(
 
     let app = api::router(state);
     info!("daemon listening; press Ctrl-C to stop");
-    axum::serve(listener, app).await?;
+    // `into_make_service_with_connect_info` makes the peer `SocketAddr` available
+    // to handlers via `ConnectInfo` — the loopback-only `POST /rpc` gate (#1221)
+    // depends on it. Without connect-info the `ConnectInfo` extractor would 500.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await?;
     Ok(())
 }
 
@@ -118,7 +126,16 @@ pub async fn serve_http(
 pub fn spawn_secondary_listener(state: Arc<DaemonState>, listener: tokio::net::TcpListener) {
     let app = api::router(state);
     tokio::spawn(async move {
-        if let Err(e) = axum::serve(listener, app).await {
+        // Match the primary listener: expose ConnectInfo so the loopback-only
+        // `POST /rpc` gate (#1221) works on this listener too. The Tailscale
+        // listener is non-loopback, so `/rpc` here will correctly 403 — the
+        // bridge only ever talks to the loopback listener.
+        if let Err(e) = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        {
             tracing::warn!("secondary listener failed: {e}");
         }
     });

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -7,11 +7,15 @@
 //! MCP is the protocol Claude Code already speaks, so trusty-mpm exposes
 //! an MCP server rather than inventing a bespoke channel.
 //!
-//! What: defines the nine orchestration tools (six core + three bug-reporting:
-//! `list_recent_errors`, `preview_bug_report`, `report_bug`), the
-//! [`OrchestratorBackend`] trait the daemon implements to service them, and
-//! [`dispatch`], which routes a JSON-RPC [`Request`] to the backend. The daemon
-//! wires [`dispatch`] into `trusty_mcp_core::run_stdio_loop`.
+//! What: defines the fifteen MCP tools — nine orchestration/bug-reporting (six
+//! core + three bug-reporting: `list_recent_errors`, `preview_bug_report`,
+//! `report_bug`) plus six session-lifecycle tools (#1221: `session_new`,
+//! `session_stop`, `session_resume`, `session_decommission`, `session_activity`,
+//! `session_send`) — the [`OrchestratorBackend`] trait the daemon implements to
+//! service them, and [`dispatch`], which routes a JSON-RPC [`Request`] to the
+//! backend. The daemon wires [`dispatch`] into both `run_stdio_loop` (the `tm
+//! daemon --mcp` path) and the loopback `POST /rpc` endpoint (the `serve
+//! --stdio` bridge path).
 //!
 //! Test: `cargo test -p trusty-mpm` exercises the tool catalog, argument
 //! parsing, and dispatch against an in-memory mock backend.
@@ -20,6 +24,7 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use trusty_common::mcp::{Request, Response, error_codes};
 
+pub mod session_dispatch;
 pub mod tools;
 
 pub use tools::{TOOL_CATALOG, tool_catalog};
@@ -110,6 +115,79 @@ pub trait OrchestratorBackend: Send + Sync {
     ///       issue_number }` or a graceful "no token" message.
     /// Test: `dispatch_report_bug_no_confirm_is_preview` in the `tests` module.
     async fn report_bug(&self, fingerprint: &str, confirm: bool) -> Result<Value, String>;
+
+    // ── #1221: session-lifecycle tools ───────────────────────────────────────
+
+    /// Back `session_new`: spawn a new managed session.
+    ///
+    /// Why: the driver skill needs a typed, JSON-native way to create an
+    ///      isolated, provisioned workspace and launch a harness in it — without
+    ///      scraping `tm session new` CLI text (the #842 defect).
+    /// What: provisions a workspace cloned from `repo_url` at `git_ref`, creates
+    ///       the tmux host, launches the selected `runtime` (default claude-code)
+    ///       with `task`, and returns the new session's id / tmux name /
+    ///       workspace path / state / attach command. An unknown `runtime` value
+    ///       is an error string.
+    /// Test: `dispatch_session_new_tool` (mock) + the daemon-side
+    ///       `session_new_spawns_via_manager` integration test.
+    async fn session_new(
+        &self,
+        repo_url: &str,
+        git_ref: &str,
+        task: &str,
+        name_hint: Option<&str>,
+        runtime: Option<&str>,
+    ) -> Result<Value, String>;
+
+    /// Back `session_stop`: stop a session's runtime, keeping its workspace.
+    ///
+    /// Why: a session endures beyond its running runtime; stopping must preserve
+    ///      the workspace so the session can be resumed later.
+    /// What: kills the tmux session + harness, marks the record Stopped, returns
+    ///       the updated record summary. A missing id is an error string.
+    /// Test: `dispatch_session_stop_tool` (mock).
+    async fn session_stop(&self, session_id: &str) -> Result<Value, String>;
+
+    /// Back `session_resume`: re-spawn the runtime in the existing workspace.
+    ///
+    /// Why: the counterpart to `session_stop` — bring a stopped session back
+    ///      without re-cloning.
+    /// What: re-creates the tmux host rooted at the on-disk workspace, re-spawns
+    ///       the SAME runtime backend, and returns the updated record. A missing
+    ///       id (or an invalid state transition) is an error string.
+    /// Test: `dispatch_session_resume_tool` (mock).
+    async fn session_resume(&self, session_id: &str) -> Result<Value, String>;
+
+    /// Back `session_decommission`: full, terminal teardown.
+    ///
+    /// Why: the only operation that removes the workspace from disk; terminal so
+    ///      a session can be fully reclaimed.
+    /// What: kills the runtime, removes the workspace dir, marks the record
+    ///       Decommissioned (a tombstone is kept), and returns it. A missing id
+    ///       is an error string.
+    /// Test: `dispatch_session_decommission_tool` (mock).
+    async fn session_decommission(&self, session_id: &str) -> Result<Value, String>;
+
+    /// Back `session_activity`: capture pane + lifecycle state.
+    ///
+    /// Why: the driver must reason about whether a session is working / idle /
+    ///      blocked WITHOUT requiring an LLM key, so raw pane content is always
+    ///      returned and the LLM classification is an optional overlay.
+    /// What: captures the last `lines` (default 60) pane lines, reports
+    ///       `runtime_active` + pending-decision fields, and includes an LLM
+    ///       `classification` when OPENROUTER_API_KEY is set. A missing id is an
+    ///       error string.
+    /// Test: `dispatch_session_activity_tool` (mock).
+    async fn session_activity(&self, session_id: &str, lines: u32) -> Result<Value, String>;
+
+    /// Back `session_send`: inject a line into a session's pane.
+    ///
+    /// Why: drive a running session (answer prompts, issue commands) without
+    ///      attaching to the tmux pane.
+    /// What: sends `text` followed by Enter to the session's pane and returns a
+    ///       confirmation with the tmux name. A missing id is an error string.
+    /// Test: `dispatch_session_send_tool` (mock).
+    async fn session_send(&self, session_id: &str, text: &str) -> Result<Value, String>;
 }
 
 /// Route a JSON-RPC request to the backend, returning the MCP response.
@@ -228,7 +306,12 @@ async fn dispatch_tool_call<B: OrchestratorBackend>(
             }
             Err(e) => Err(e),
         },
-        other => Err(format!("unknown tool: {other}")),
+        // #1221: the six session-lifecycle tools route through a sibling module
+        // so this match stays focused and `mod.rs` stays under the SLOC cap.
+        other => match session_dispatch::try_dispatch(backend, other, &args).await {
+            Some(result) => result,
+            None => Err(format!("unknown tool: {other}")),
+        },
     };
 
     match result {
@@ -251,7 +334,7 @@ async fn dispatch_tool_call<B: OrchestratorBackend>(
 }
 
 /// Extract a required string argument or produce a descriptive error.
-fn required_str(args: &Value, key: &str) -> Result<String, String> {
+pub(crate) fn required_str(args: &Value, key: &str) -> Result<String, String> {
     args.get(key)
         .and_then(Value::as_str)
         .map(str::to_string)
@@ -266,249 +349,5 @@ fn required_u64(args: &Value, key: &str) -> Result<u64, String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// In-memory backend that records calls and returns canned values.
-    struct MockBackend;
-
-    #[async_trait]
-    impl OrchestratorBackend for MockBackend {
-        async fn session_list(&self) -> Result<Value, String> {
-            Ok(json!([{ "id": "s1", "status": "active" }]))
-        }
-        async fn session_status(&self, session_id: &str) -> Result<Value, String> {
-            Ok(json!({ "id": session_id, "status": "active" }))
-        }
-        async fn agent_delegate(
-            &self,
-            _session_id: &str,
-            agent: &str,
-            _task: &str,
-            _tier: Option<&str>,
-        ) -> Result<Value, String> {
-            Ok(json!({ "delegation_id": "d1", "agent": agent }))
-        }
-        async fn memory_protect(
-            &self,
-            _session_id: &str,
-            used_tokens: u64,
-            window_tokens: u64,
-        ) -> Result<Value, String> {
-            Ok(json!({ "fraction": used_tokens as f64 / window_tokens as f64 }))
-        }
-        async fn circuit_breaker_status(&self, _agent: Option<&str>) -> Result<Value, String> {
-            Ok(json!({ "state": "closed" }))
-        }
-        async fn hook_event(
-            &self,
-            _session_id: &str,
-            event: &str,
-            _payload: Value,
-        ) -> Result<Value, String> {
-            Ok(json!({ "received": event }))
-        }
-        async fn list_recent_errors(&self, limit: u64) -> Result<Value, String> {
-            Ok(json!({ "errors": [], "limit": limit, "total": 0 }))
-        }
-        async fn preview_bug_report(&self, fingerprint: &str) -> Result<Value, String> {
-            Ok(json!({ "fingerprint": fingerprint, "title": "mock title", "body": "mock body" }))
-        }
-        async fn report_bug(&self, fingerprint: &str, confirm: bool) -> Result<Value, String> {
-            if confirm {
-                Ok(json!({ "filed": false, "note": "mock: no token in test" }))
-            } else {
-                Ok(
-                    json!({ "filed": false, "note": "confirm:false — preview only", "fingerprint": fingerprint }),
-                )
-            }
-        }
-    }
-
-    fn call(name: &str, args: Value) -> Request {
-        Request {
-            jsonrpc: Some("2.0".into()),
-            id: Some(json!(1)),
-            method: "tools/call".into(),
-            params: Some(json!({ "name": name, "arguments": args })),
-        }
-    }
-
-    #[tokio::test]
-    async fn dispatch_initialize_returns_server_info() {
-        let req = Request {
-            jsonrpc: Some("2.0".into()),
-            id: Some(json!(1)),
-            method: "initialize".into(),
-            params: None,
-        };
-        let resp = dispatch(&MockBackend, req).await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["serverInfo"]["name"], SERVER_NAME);
-    }
-
-    #[tokio::test]
-    async fn dispatch_tools_list_returns_nine_tools() {
-        let req = Request {
-            jsonrpc: Some("2.0".into()),
-            id: Some(json!(1)),
-            method: "tools/list".into(),
-            params: None,
-        };
-        let resp = dispatch(&MockBackend, req).await;
-        let tools = resp.result.unwrap()["tools"].clone();
-        assert_eq!(tools.as_array().unwrap().len(), 9);
-    }
-
-    #[tokio::test]
-    async fn dispatch_session_list_tool() {
-        let resp = dispatch(&MockBackend, call("session_list", json!({}))).await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["isError"], false);
-        assert!(
-            result["content"][0]["text"]
-                .as_str()
-                .unwrap()
-                .contains("s1")
-        );
-    }
-
-    #[tokio::test]
-    async fn dispatch_agent_delegate_tool() {
-        let resp = dispatch(
-            &MockBackend,
-            call(
-                "agent_delegate",
-                json!({ "session_id": "s1", "agent": "research", "task": "find" }),
-            ),
-        )
-        .await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["isError"], false);
-        assert!(
-            result["content"][0]["text"]
-                .as_str()
-                .unwrap()
-                .contains("research")
-        );
-    }
-
-    #[tokio::test]
-    async fn dispatch_missing_argument_is_tool_error() {
-        // `session_id` is required; omitting it yields an isError result.
-        let resp = dispatch(&MockBackend, call("session_status", json!({}))).await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["isError"], true);
-        assert!(
-            result["content"][0]["text"]
-                .as_str()
-                .unwrap()
-                .contains("session_id")
-        );
-    }
-
-    #[tokio::test]
-    async fn dispatch_unknown_tool_is_error() {
-        let resp = dispatch(&MockBackend, call("nope", json!({}))).await;
-        assert_eq!(resp.result.unwrap()["isError"], true);
-    }
-
-    #[tokio::test]
-    async fn dispatch_unknown_method_returns_jsonrpc_error() {
-        let req = Request {
-            jsonrpc: Some("2.0".into()),
-            id: Some(json!(1)),
-            method: "frobnicate".into(),
-            params: None,
-        };
-        let resp = dispatch(&MockBackend, req).await;
-        assert_eq!(resp.error.unwrap().code, error_codes::METHOD_NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn dispatch_notification_is_suppressed() {
-        let req = Request {
-            jsonrpc: Some("2.0".into()),
-            id: None,
-            method: "notifications/initialized".into(),
-            params: None,
-        };
-        let resp = dispatch(&MockBackend, req).await;
-        assert!(resp.suppress);
-    }
-
-    // ── Phase 3: bug-reporting dispatch tests ─────────────────────────────────
-
-    #[tokio::test]
-    async fn dispatch_list_recent_errors_tool() {
-        let resp = dispatch(
-            &MockBackend,
-            call("list_recent_errors", json!({ "limit": 10 })),
-        )
-        .await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["isError"], false);
-        assert!(
-            result["content"][0]["text"]
-                .as_str()
-                .unwrap()
-                .contains("errors")
-        );
-    }
-
-    #[tokio::test]
-    async fn dispatch_list_recent_errors_default_limit() {
-        // No limit specified — should default to 20 without error.
-        let resp = dispatch(&MockBackend, call("list_recent_errors", json!({}))).await;
-        assert_eq!(resp.result.unwrap()["isError"], false);
-    }
-
-    #[tokio::test]
-    async fn dispatch_preview_bug_report_tool() {
-        let fp = "a".repeat(64);
-        let resp = dispatch(
-            &MockBackend,
-            call("preview_bug_report", json!({ "fingerprint": fp })),
-        )
-        .await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["isError"], false);
-        assert!(result["content"][0]["text"].as_str().unwrap().contains(&fp));
-    }
-
-    #[tokio::test]
-    async fn dispatch_preview_bug_report_requires_fingerprint() {
-        let resp = dispatch(&MockBackend, call("preview_bug_report", json!({}))).await;
-        assert_eq!(resp.result.unwrap()["isError"], true);
-    }
-
-    #[tokio::test]
-    async fn dispatch_report_bug_no_confirm_is_preview_only() {
-        let fp = "b".repeat(64);
-        let resp = dispatch(
-            &MockBackend,
-            call("report_bug", json!({ "fingerprint": fp, "confirm": false })),
-        )
-        .await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["isError"], false);
-        let text = result["content"][0]["text"].as_str().unwrap();
-        // The mock returns `filed: false` with the preview-only note.
-        assert!(text.contains("false"), "expected filed:false: {text}");
-    }
-
-    #[tokio::test]
-    async fn dispatch_report_bug_confirm_true_calls_backend() {
-        let fp = "c".repeat(64);
-        let resp = dispatch(
-            &MockBackend,
-            call("report_bug", json!({ "fingerprint": fp, "confirm": true })),
-        )
-        .await;
-        let result = resp.result.unwrap();
-        assert_eq!(result["isError"], false);
-        // Mock returns filed:false + no-token note (still a valid response shape).
-        let text = result["content"][0]["text"].as_str().unwrap();
-        assert!(text.contains("filed"), "expected 'filed' key: {text}");
-    }
-}
+#[path = "tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/mcp/session_dispatch.rs
+++ b/crates/trusty-mpm/src/mcp/session_dispatch.rs
@@ -1,0 +1,96 @@
+//! Argument parsing + routing for the six session-lifecycle MCP tools (#1221).
+//!
+//! Why: the session-lifecycle tools more than half-again the catalog; routing
+//! them inline in `mcp/mod.rs`'s `dispatch_tool_call` would push that file over
+//! the 500-SLOC production cap. Extracting the parse-and-call arms into a sibling
+//! module keeps `mod.rs` focused on the handshake + core tools and gives the
+//! session tools one auditable home.
+//! What: [`try_dispatch`] matches a tool name against the six session tools;
+//! when it matches it parses arguments (via the shared `required_str` helper),
+//! calls the corresponding [`super::OrchestratorBackend`] method, and returns
+//! `Some(result)`. A non-session tool name returns `None` so the caller can
+//! report "unknown tool".
+//! Test: the `super::tests` `dispatch_session_*` cases drive this module through
+//! the public `dispatch` entry point with a mock backend.
+
+use serde_json::Value;
+
+use super::{OrchestratorBackend, required_str};
+
+/// Default trailing-pane line count for `session_activity` when unspecified.
+///
+/// Why: the HTTP activity route captures the last 60 lines; the MCP tool keeps
+/// the same default so both transports behave identically.
+/// What: the `u32` line count used when the caller omits `lines`.
+/// Test: `super::tests::dispatch_session_activity_default_lines`.
+const DEFAULT_ACTIVITY_LINES: u32 = 60;
+
+/// Route a session-lifecycle tool call to the backend.
+///
+/// Why: a single entry point lets `dispatch_tool_call` delegate every
+/// session-tool name in one arm, keeping the core dispatch match small.
+/// What: returns `Some(Result)` for the six session tool names (parsing args and
+/// calling the matching backend method), or `None` when `name` is not a session
+/// tool — signalling the caller to fall through to its "unknown tool" branch.
+/// Errors from argument parsing are returned as `Some(Err(_))` so they surface
+/// to the client as a tool-error result, identical to the core tools.
+/// Test: exercised by every `dispatch_session_*` test in `super::tests`.
+pub async fn try_dispatch<B: OrchestratorBackend>(
+    backend: &B,
+    name: &str,
+    args: &Value,
+) -> Option<Result<Value, String>> {
+    let result = match name {
+        "session_new" => session_new(backend, args).await,
+        "session_stop" => match required_str(args, "session_id") {
+            Ok(id) => backend.session_stop(&id).await,
+            Err(e) => Err(e),
+        },
+        "session_resume" => match required_str(args, "session_id") {
+            Ok(id) => backend.session_resume(&id).await,
+            Err(e) => Err(e),
+        },
+        "session_decommission" => match required_str(args, "session_id") {
+            Ok(id) => backend.session_decommission(&id).await,
+            Err(e) => Err(e),
+        },
+        "session_activity" => match required_str(args, "session_id") {
+            Ok(id) => {
+                let lines = args
+                    .get("lines")
+                    .and_then(Value::as_u64)
+                    .map(|n| n.min(u32::MAX as u64) as u32)
+                    .unwrap_or(DEFAULT_ACTIVITY_LINES);
+                backend.session_activity(&id, lines).await
+            }
+            Err(e) => Err(e),
+        },
+        "session_send" => match (required_str(args, "session_id"), required_str(args, "text")) {
+            (Ok(id), Ok(text)) => backend.session_send(&id, &text).await,
+            (Err(e), _) | (_, Err(e)) => Err(e),
+        },
+        // Not a session tool — let the caller report "unknown tool".
+        _ => return None,
+    };
+    Some(result)
+}
+
+/// Parse `session_new` arguments and call the backend.
+///
+/// Why: `session_new` has the widest argument surface (repo/ref/task + two
+/// optionals); pulling it into its own helper keeps [`try_dispatch`] readable.
+/// What: requires `repo_url`, `ref`, and `task`; reads the optional `name_hint`
+/// and `runtime`; then calls [`OrchestratorBackend::session_new`]. Any missing
+/// required field yields a descriptive error string.
+/// Test: `super::tests::dispatch_session_new_tool`,
+/// `super::tests::dispatch_session_new_requires_repo_url`.
+async fn session_new<B: OrchestratorBackend>(backend: &B, args: &Value) -> Result<Value, String> {
+    let repo_url = required_str(args, "repo_url")?;
+    let git_ref = required_str(args, "ref")?;
+    let task = required_str(args, "task")?;
+    let name_hint = args.get("name_hint").and_then(Value::as_str);
+    let runtime = args.get("runtime").and_then(Value::as_str);
+    backend
+        .session_new(&repo_url, &git_ref, &task, name_hint, runtime)
+        .await
+}

--- a/crates/trusty-mpm/src/mcp/tests.rs
+++ b/crates/trusty-mpm/src/mcp/tests.rs
@@ -1,0 +1,450 @@
+//! Unit tests for the trusty-mpm MCP dispatch layer (#1221 + earlier phases).
+//!
+//! Why: extracting the test module out of `mcp/mod.rs` keeps that production
+//! file under the 500-SLOC cap while the tests (classified as a test file, 1500
+//! cap) live alongside it. Included via `#[path = "tests.rs"] mod tests;`.
+//! What: a `MockBackend` implementing every `OrchestratorBackend` method plus
+//! dispatch tests for the handshake, the core tools, the bug-reporting tools,
+//! and the six session-lifecycle tools.
+//! Test: this IS the test module.
+
+use super::*;
+
+/// In-memory backend that records calls and returns canned values.
+struct MockBackend;
+
+#[async_trait]
+impl OrchestratorBackend for MockBackend {
+    async fn session_list(&self) -> Result<Value, String> {
+        Ok(json!([{ "id": "s1", "status": "active" }]))
+    }
+    async fn session_status(&self, session_id: &str) -> Result<Value, String> {
+        Ok(json!({ "id": session_id, "status": "active" }))
+    }
+    async fn agent_delegate(
+        &self,
+        _session_id: &str,
+        agent: &str,
+        _task: &str,
+        _tier: Option<&str>,
+    ) -> Result<Value, String> {
+        Ok(json!({ "delegation_id": "d1", "agent": agent }))
+    }
+    async fn memory_protect(
+        &self,
+        _session_id: &str,
+        used_tokens: u64,
+        window_tokens: u64,
+    ) -> Result<Value, String> {
+        Ok(json!({ "fraction": used_tokens as f64 / window_tokens as f64 }))
+    }
+    async fn circuit_breaker_status(&self, _agent: Option<&str>) -> Result<Value, String> {
+        Ok(json!({ "state": "closed" }))
+    }
+    async fn hook_event(
+        &self,
+        _session_id: &str,
+        event: &str,
+        _payload: Value,
+    ) -> Result<Value, String> {
+        Ok(json!({ "received": event }))
+    }
+    async fn list_recent_errors(&self, limit: u64) -> Result<Value, String> {
+        Ok(json!({ "errors": [], "limit": limit, "total": 0 }))
+    }
+    async fn preview_bug_report(&self, fingerprint: &str) -> Result<Value, String> {
+        Ok(json!({ "fingerprint": fingerprint, "title": "mock title", "body": "mock body" }))
+    }
+    async fn report_bug(&self, fingerprint: &str, confirm: bool) -> Result<Value, String> {
+        if confirm {
+            Ok(json!({ "filed": false, "note": "mock: no token in test" }))
+        } else {
+            Ok(
+                json!({ "filed": false, "note": "confirm:false — preview only", "fingerprint": fingerprint }),
+            )
+        }
+    }
+
+    // ── #1221: session-lifecycle mock impls ──────────────────────────────
+    async fn session_new(
+        &self,
+        repo_url: &str,
+        git_ref: &str,
+        _task: &str,
+        _name_hint: Option<&str>,
+        runtime: Option<&str>,
+    ) -> Result<Value, String> {
+        Ok(json!({
+            "id": "m-1",
+            "repo_url": repo_url,
+            "branch": git_ref,
+            "runtime": runtime.unwrap_or("claude-code"),
+            "state": "active",
+        }))
+    }
+    async fn session_stop(&self, session_id: &str) -> Result<Value, String> {
+        Ok(json!({ "id": session_id, "state": "stopped" }))
+    }
+    async fn session_resume(&self, session_id: &str) -> Result<Value, String> {
+        Ok(json!({ "id": session_id, "state": "active" }))
+    }
+    async fn session_decommission(&self, session_id: &str) -> Result<Value, String> {
+        Ok(json!({ "id": session_id, "state": "decommissioned" }))
+    }
+    async fn session_activity(&self, session_id: &str, lines: u32) -> Result<Value, String> {
+        Ok(json!({ "id": session_id, "lines": lines, "raw_pane": "" }))
+    }
+    async fn session_send(&self, session_id: &str, text: &str) -> Result<Value, String> {
+        Ok(json!({ "id": session_id, "sent": true, "text": text }))
+    }
+}
+
+fn call(name: &str, args: Value) -> Request {
+    Request {
+        jsonrpc: Some("2.0".into()),
+        id: Some(json!(1)),
+        method: "tools/call".into(),
+        params: Some(json!({ "name": name, "arguments": args })),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_initialize_returns_server_info() {
+    let req = Request {
+        jsonrpc: Some("2.0".into()),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: None,
+    };
+    let resp = dispatch(&MockBackend, req).await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["serverInfo"]["name"], SERVER_NAME);
+}
+
+#[tokio::test]
+async fn dispatch_tools_list_returns_full_catalog() {
+    // 9 pre-existing + 6 new session-lifecycle tools = 15 (#1221).
+    let req = Request {
+        jsonrpc: Some("2.0".into()),
+        id: Some(json!(1)),
+        method: "tools/list".into(),
+        params: None,
+    };
+    let resp = dispatch(&MockBackend, req).await;
+    let tools = resp.result.unwrap()["tools"].clone();
+    assert_eq!(tools.as_array().unwrap().len(), 15);
+}
+
+#[tokio::test]
+async fn dispatch_session_list_tool() {
+    let resp = dispatch(&MockBackend, call("session_list", json!({}))).await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("s1")
+    );
+}
+
+#[tokio::test]
+async fn dispatch_agent_delegate_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call(
+            "agent_delegate",
+            json!({ "session_id": "s1", "agent": "research", "task": "find" }),
+        ),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("research")
+    );
+}
+
+#[tokio::test]
+async fn dispatch_missing_argument_is_tool_error() {
+    // `session_id` is required; omitting it yields an isError result.
+    let resp = dispatch(&MockBackend, call("session_status", json!({}))).await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("session_id")
+    );
+}
+
+#[tokio::test]
+async fn dispatch_unknown_tool_is_error() {
+    let resp = dispatch(&MockBackend, call("nope", json!({}))).await;
+    assert_eq!(resp.result.unwrap()["isError"], true);
+}
+
+#[tokio::test]
+async fn dispatch_unknown_method_returns_jsonrpc_error() {
+    let req = Request {
+        jsonrpc: Some("2.0".into()),
+        id: Some(json!(1)),
+        method: "frobnicate".into(),
+        params: None,
+    };
+    let resp = dispatch(&MockBackend, req).await;
+    assert_eq!(resp.error.unwrap().code, error_codes::METHOD_NOT_FOUND);
+}
+
+#[tokio::test]
+async fn dispatch_notification_is_suppressed() {
+    let req = Request {
+        jsonrpc: Some("2.0".into()),
+        id: None,
+        method: "notifications/initialized".into(),
+        params: None,
+    };
+    let resp = dispatch(&MockBackend, req).await;
+    assert!(resp.suppress);
+}
+
+// ── Phase 3: bug-reporting dispatch tests ─────────────────────────────────
+
+#[tokio::test]
+async fn dispatch_list_recent_errors_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call("list_recent_errors", json!({ "limit": 10 })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("errors")
+    );
+}
+
+#[tokio::test]
+async fn dispatch_list_recent_errors_default_limit() {
+    // No limit specified — should default to 20 without error.
+    let resp = dispatch(&MockBackend, call("list_recent_errors", json!({}))).await;
+    assert_eq!(resp.result.unwrap()["isError"], false);
+}
+
+#[tokio::test]
+async fn dispatch_preview_bug_report_tool() {
+    let fp = "a".repeat(64);
+    let resp = dispatch(
+        &MockBackend,
+        call("preview_bug_report", json!({ "fingerprint": fp })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(result["content"][0]["text"].as_str().unwrap().contains(&fp));
+}
+
+#[tokio::test]
+async fn dispatch_preview_bug_report_requires_fingerprint() {
+    let resp = dispatch(&MockBackend, call("preview_bug_report", json!({}))).await;
+    assert_eq!(resp.result.unwrap()["isError"], true);
+}
+
+#[tokio::test]
+async fn dispatch_report_bug_no_confirm_is_preview_only() {
+    let fp = "b".repeat(64);
+    let resp = dispatch(
+        &MockBackend,
+        call("report_bug", json!({ "fingerprint": fp, "confirm": false })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    let text = result["content"][0]["text"].as_str().unwrap();
+    // The mock returns `filed: false` with the preview-only note.
+    assert!(text.contains("false"), "expected filed:false: {text}");
+}
+
+#[tokio::test]
+async fn dispatch_report_bug_confirm_true_calls_backend() {
+    let fp = "c".repeat(64);
+    let resp = dispatch(
+        &MockBackend,
+        call("report_bug", json!({ "fingerprint": fp, "confirm": true })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    // Mock returns filed:false + no-token note (still a valid response shape).
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("filed"), "expected 'filed' key: {text}");
+}
+
+// ── #1221: session-lifecycle dispatch tests ───────────────────────────────
+
+/// Why: `session_new` is the spawn tool; it must parse the three required
+/// fields and forward them to the backend.
+/// What: calls the tool with repo/ref/task and asserts a non-error result
+/// echoing the repo url.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_new_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call(
+            "session_new",
+            json!({ "repo_url": "https://example.com/r.git", "ref": "main", "task": "do it" }),
+        ),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("example.com")
+    );
+}
+
+/// Why: `session_new` must reject a call missing the required `repo_url`.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_new_requires_repo_url() {
+    let resp = dispatch(
+        &MockBackend,
+        call("session_new", json!({ "ref": "main", "task": "x" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("repo_url")
+    );
+}
+
+/// Why: the four single-id session tools must each parse `session_id` and
+/// forward it; one parameterised test covers stop/resume/decommission.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_single_id_session_tools() {
+    for tool in ["session_stop", "session_resume", "session_decommission"] {
+        let resp = dispatch(&MockBackend, call(tool, json!({ "session_id": "s9" }))).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["isError"], false, "{tool} should succeed");
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("s9"),
+            "{tool} should echo the id"
+        );
+    }
+}
+
+/// Why: a single-id session tool must error when `session_id` is absent.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_stop_requires_id() {
+    let resp = dispatch(&MockBackend, call("session_stop", json!({}))).await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("session_id")
+    );
+}
+
+/// Why: `session_activity` must honour an explicit `lines` value.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_activity_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call(
+            "session_activity",
+            json!({ "session_id": "s1", "lines": 25 }),
+        ),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("25"),
+        "should reflect the requested line count"
+    );
+}
+
+/// Why: `session_activity` must default `lines` to 60 when omitted (parity
+/// with the HTTP activity route).
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_activity_default_lines() {
+    let resp = dispatch(
+        &MockBackend,
+        call("session_activity", json!({ "session_id": "s1" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("60"),
+        "should default to 60 lines"
+    );
+}
+
+/// Why: `session_send` requires both `session_id` and `text`.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_send_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call("session_send", json!({ "session_id": "s1", "text": "yes" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("yes")
+    );
+}
+
+/// Why: `session_send` must error when `text` is missing.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_send_requires_text() {
+    let resp = dispatch(
+        &MockBackend,
+        call("session_send", json!({ "session_id": "s1" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("text")
+    );
+}

--- a/crates/trusty-mpm/src/mcp/tools/core.rs
+++ b/crates/trusty-mpm/src/mcp/tools/core.rs
@@ -1,43 +1,32 @@
-//! MCP tool definitions for the trusty-mpm orchestration server.
+//! Core orchestration + bug-reporting MCP tool descriptors.
 //!
 //! Why: `tools/list` must advertise a JSON Schema for every tool so Claude Code
-//! knows how to call it. Keeping the catalog in one module — separate from the
-//! dispatch logic — makes the tool surface easy to audit and version.
-//! What: [`tool_catalog`] builds the nine MCP tool descriptors (name, human
-//! description, `inputSchema`); [`TOOL_CATALOG`] lists their names for tests.
-//! The three bug-reporting tools (`list_recent_errors`, `preview_bug_report`,
-//! `report_bug`) are added in Phase 3.
-//! Test: `cargo test -p trusty-mpm` asserts the catalog has nine well-formed
-//! entries whose names match [`TOOL_CATALOG`].
+//! knows how to call it. Splitting the catalog by concept — the six original
+//! orchestration tools plus the three bug-reporting tools live here, the
+//! session-lifecycle tools live in [`super::session`] — keeps each file well
+//! under the 500-SLOC production cap and makes the surface easy to audit.
+//! What: [`core_tools`] returns the nine original MCP tool descriptors (name,
+//! human description, `inputSchema`); the shared [`tool`] descriptor-builder is
+//! re-exported from the parent module.
+//! Test: `cargo test -p trusty-mpm` (in [`super`]) asserts the full catalog —
+//! core + session — is well-formed and matches the name constant.
 
 use serde_json::{Value, json};
 
-/// Canonical names of every tool the server exposes, in catalog order.
-///
-/// Why: tests and the daemon's startup log both want the authoritative list
-/// without re-parsing the JSON schema.
-/// What: a static slice of the nine tool names (six orchestration + three
-///       bug-reporting added in Phase 3).
-/// Test: `catalog_names_match_constant`.
-pub const TOOL_CATALOG: [&str; 9] = [
-    "session_list",
-    "session_status",
-    "agent_delegate",
-    "memory_protect",
-    "circuit_breaker_status",
-    "hook_event",
-    "list_recent_errors",
-    "preview_bug_report",
-    "report_bug",
-];
+use super::tool;
 
-/// Build the MCP tool descriptor list returned by `tools/list`.
+/// Build the six orchestration + three bug-reporting tool descriptors.
 ///
-/// Why: Claude Code reads `inputSchema` to validate calls; a single builder
-/// keeps the schemas and the dispatch argument-parsing in lockstep.
-/// What: returns nine JSON objects, each `{ name, description, inputSchema }`.
-/// Test: `catalog_has_nine_tools` and `every_tool_has_input_schema`.
-pub fn tool_catalog() -> Vec<Value> {
+/// Why: these nine tools predate the session-lifecycle surface (#1221); keeping
+/// their schemas in a dedicated builder isolates them from the new tools so each
+/// group can evolve independently without growing one monolithic function past
+/// the SLOC cap.
+/// What: returns the nine `{ name, description, inputSchema }` objects in catalog
+/// order — `session_list`, `session_status`, `agent_delegate`, `memory_protect`,
+/// `circuit_breaker_status`, `hook_event`, then the three bug-reporting tools.
+/// Test: `super::tests::catalog_has_expected_tool_count` and
+/// `super::tests::catalog_names_match_constant`.
+pub(super) fn core_tools() -> Vec<Value> {
     vec![
         tool(
             "session_list",
@@ -204,50 +193,4 @@ pub fn tool_catalog() -> Vec<Value> {
             }),
         ),
     ]
-}
-
-/// Assemble one MCP tool descriptor object.
-fn tool(name: &str, description: &str, input_schema: Value) -> Value {
-    json!({
-        "name": name,
-        "description": description,
-        "inputSchema": input_schema,
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn catalog_has_nine_tools() {
-        assert_eq!(tool_catalog().len(), 9);
-    }
-
-    #[test]
-    fn catalog_names_match_constant() {
-        let names: Vec<String> = tool_catalog()
-            .iter()
-            .map(|t| t["name"].as_str().unwrap().to_string())
-            .collect();
-        assert_eq!(names, TOOL_CATALOG);
-    }
-
-    #[test]
-    fn every_tool_has_input_schema() {
-        for t in tool_catalog() {
-            assert!(t["name"].is_string());
-            assert!(t["description"].is_string());
-            assert_eq!(t["inputSchema"]["type"], "object");
-        }
-    }
-
-    #[test]
-    fn bug_reporting_tools_present() {
-        let catalog = tool_catalog();
-        let names: Vec<&str> = catalog.iter().filter_map(|t| t["name"].as_str()).collect();
-        assert!(names.contains(&"list_recent_errors"), "{names:?}");
-        assert!(names.contains(&"preview_bug_report"), "{names:?}");
-        assert!(names.contains(&"report_bug"), "{names:?}");
-    }
 }

--- a/crates/trusty-mpm/src/mcp/tools/mod.rs
+++ b/crates/trusty-mpm/src/mcp/tools/mod.rs
@@ -1,0 +1,132 @@
+//! MCP tool catalog for the trusty-mpm orchestration + session-manager server.
+//!
+//! Why: `tools/list` must advertise a JSON Schema for every tool so Claude Code
+//! knows how to call it. Keeping the catalog separate from the dispatch logic
+//! makes the tool surface easy to audit and version. Since #1221 the catalog
+//! spans two concepts — the original orchestration/bug-reporting tools
+//! ([`core`]) and the new session-lifecycle tools ([`session`]) — so this is a
+//! thin facade that re-exports both and concatenates their descriptors, keeping
+//! each leaf file well under the 500-SLOC production cap.
+//! What: [`tool_catalog`] builds the fifteen MCP tool descriptors (nine core +
+//! six session); [`TOOL_CATALOG`] lists their names for tests and the startup
+//! log; [`tool`] is the shared descriptor builder used by both submodules.
+//! Test: the `tests` module below asserts the catalog has the expected count,
+//! well-formed entries, and names matching [`TOOL_CATALOG`].
+
+use serde_json::{Value, json};
+
+pub mod core;
+pub mod session;
+
+/// Canonical names of every tool the server exposes, in catalog order.
+///
+/// Why: tests, the daemon's startup log, and the loopback-`/rpc` audit all want
+/// the authoritative list without re-parsing the JSON schema. Keeping it exact
+/// resolves the #1221 review nit about ambiguous existing-vs-new counts: there
+/// are exactly NINE pre-existing tools and SIX new session-lifecycle tools.
+/// What: a static slice of the fifteen tool names — the six orchestration tools,
+/// the three bug-reporting tools, then the six session-lifecycle tools.
+/// Test: `catalog_names_match_constant`.
+pub const TOOL_CATALOG: [&str; 15] = [
+    // ── 9 pre-existing tools (core.rs) ───────────────────────────────────────
+    "session_list",
+    "session_status",
+    "agent_delegate",
+    "memory_protect",
+    "circuit_breaker_status",
+    "hook_event",
+    "list_recent_errors",
+    "preview_bug_report",
+    "report_bug",
+    // ── 6 new session-lifecycle tools (#1221, session.rs) ────────────────────
+    "session_new",
+    "session_stop",
+    "session_resume",
+    "session_decommission",
+    "session_activity",
+    "session_send",
+];
+
+/// Build the MCP tool descriptor list returned by `tools/list`.
+///
+/// Why: Claude Code reads `inputSchema` to validate calls; a single builder
+/// keeps the schemas and the dispatch argument-parsing in lockstep across both
+/// the core and session-lifecycle tool groups.
+/// What: concatenates [`core::core_tools`] (nine descriptors) and
+/// [`session::session_tools`] (six descriptors) in catalog order, returning
+/// fifteen `{ name, description, inputSchema }` objects.
+/// Test: `catalog_has_expected_tool_count` and `every_tool_has_input_schema`.
+pub fn tool_catalog() -> Vec<Value> {
+    let mut tools = core::core_tools();
+    tools.extend(session::session_tools());
+    tools
+}
+
+/// Assemble one MCP tool descriptor object.
+///
+/// Why: every descriptor has the same `{ name, description, inputSchema }` shape;
+/// a shared builder keeps the two tool-group modules terse and consistent.
+/// What: returns a JSON object wrapping the three fields.
+/// Test: exercised by every entry in `tool_catalog` via the tests below.
+pub(crate) fn tool(name: &str, description: &str, input_schema: Value) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "inputSchema": input_schema,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_has_expected_tool_count() {
+        // 9 pre-existing + 6 new session-lifecycle tools = 15.
+        assert_eq!(tool_catalog().len(), 15);
+        assert_eq!(TOOL_CATALOG.len(), 15);
+    }
+
+    #[test]
+    fn catalog_names_match_constant() {
+        let names: Vec<String> = tool_catalog()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, TOOL_CATALOG);
+    }
+
+    #[test]
+    fn every_tool_has_input_schema() {
+        for t in tool_catalog() {
+            assert!(t["name"].is_string());
+            assert!(t["description"].is_string());
+            assert_eq!(t["inputSchema"]["type"], "object");
+        }
+    }
+
+    #[test]
+    fn bug_reporting_tools_present() {
+        let catalog = tool_catalog();
+        let names: Vec<&str> = catalog.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(names.contains(&"list_recent_errors"), "{names:?}");
+        assert!(names.contains(&"preview_bug_report"), "{names:?}");
+        assert!(names.contains(&"report_bug"), "{names:?}");
+    }
+
+    #[test]
+    fn session_tools_present() {
+        let catalog = tool_catalog();
+        let names: Vec<&str> = catalog.iter().filter_map(|t| t["name"].as_str()).collect();
+        for expected in [
+            "session_new",
+            "session_stop",
+            "session_resume",
+            "session_decommission",
+            "session_activity",
+            "session_send",
+        ] {
+            assert!(names.contains(&expected), "missing {expected}: {names:?}");
+        }
+    }
+}

--- a/crates/trusty-mpm/src/mcp/tools/session.rs
+++ b/crates/trusty-mpm/src/mcp/tools/session.rs
@@ -1,0 +1,175 @@
+//! Session-lifecycle MCP tool descriptors (#1221).
+//!
+//! Why: the claude-mpm driver skill (#842) previously scraped `tm session` CLI
+//! text output, which broke when the documented `--json` flag did not exist.
+//! Exposing the managed-session lifecycle as typed MCP tools gives the driver a
+//! schema-validated, JSON-native surface — and matches every other trusty-*
+//! tool, which all speak MCP. These six tools are thin wrappers over the
+//! existing [`crate::session_manager::SessionManager`] lifecycle ops that the
+//! HTTP `…/managed/*` routes already use, so the behaviour is identical across
+//! transports.
+//! What: [`session_tools`] returns the six `{ name, description, inputSchema }`
+//! descriptors — `session_new`, `session_stop`, `session_resume`,
+//! `session_decommission`, `session_activity`, `session_send`. The shared
+//! [`tool`] builder is re-exported from the parent module.
+//! Test: `cargo test -p trusty-mpm` (in [`super`]) asserts the full catalog is
+//! well-formed and that each of these six names is present.
+
+use serde_json::{Value, json};
+
+use super::tool;
+
+/// Build the six session-lifecycle tool descriptors.
+///
+/// Why: spawning, stopping, resuming, decommissioning, observing, and driving a
+/// managed session are the operations the driver skill needs; surfacing them as
+/// MCP tools removes the CLI-scraping defect. Keeping them in their own builder
+/// keeps `tools/core.rs` and this file each well under the 500-SLOC cap.
+/// What: returns the six descriptors in catalog order. `session_new` takes the
+/// repo/ref/task spawn inputs; the other five take a `session_id` (the managed
+/// UUID) plus operation-specific fields. Every schema sets
+/// `additionalProperties: false` so the driver gets a clear error on a typo.
+/// Test: `super::tests::session_tools_present`,
+/// `super::tests::catalog_names_match_constant`.
+pub(super) fn session_tools() -> Vec<Value> {
+    vec![
+        tool(
+            "session_new",
+            "Spawn a new managed Claude Code (or trusty-code) session in an \
+             isolated, freshly-provisioned workspace cloned from `repo_url` at \
+             `ref`. The daemon creates the tmux host, deploys agents/skills, and \
+             launches the harness with the given `task`. Returns the new managed \
+             session id, tmux name, workspace path, lifecycle state, and the \
+             `tmux attach-session` command.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": "Repository URL to clone into the session workspace."
+                    },
+                    "ref": {
+                        "type": "string",
+                        "description": "Git branch or ref to check out."
+                    },
+                    "task": {
+                        "type": "string",
+                        "description": "Human-readable task description handed to the harness."
+                    },
+                    "name_hint": {
+                        "type": "string",
+                        "description": "Optional name hint overriding the auto-generated tmux session name."
+                    },
+                    "runtime": {
+                        "type": "string",
+                        "enum": ["claude-code", "tcode"],
+                        "description": "Optional runtime backend; defaults to claude-code."
+                    }
+                },
+                "required": ["repo_url", "ref", "task"],
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "session_stop",
+            "Stop a managed session's runtime (kills the tmux session and harness \
+             process) while PRESERVING its workspace on disk and its record, so it \
+             can be resumed later with `session_resume`. This is NOT a teardown — \
+             use `session_decommission` to remove the workspace permanently.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Managed session id (UUID)."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "session_resume",
+            "Resume a previously-stopped managed session: re-create the tmux host \
+             rooted at the still-on-disk workspace and re-spawn the SAME runtime \
+             backend the session was created with (no re-clone). Returns the \
+             updated session record.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Managed session id (UUID)."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "session_decommission",
+            "Permanently tear down a managed session: kill the runtime, REMOVE the \
+             workspace directory from disk, and mark the record Decommissioned. \
+             This is terminal — the session can NOT be resumed afterwards. A \
+             tombstone record is retained for audit.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Managed session id (UUID)."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "session_activity",
+            "Inspect a managed session's recent activity. ALWAYS returns the raw \
+             tmux pane content (last `lines` lines, default 60) plus structured \
+             lifecycle fields (`runtime_active`, `pending_decision`, \
+             `proposed_default`) so the caller can do its own inference WITHOUT an \
+             LLM key. When OPENROUTER_API_KEY is configured the daemon also \
+             returns an LLM `classification` of the session state.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Managed session id (UUID)."
+                    },
+                    "lines": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 500,
+                        "description": "Number of trailing pane lines to capture (default 60)."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "session_send",
+            "Send a line of text into a managed session's tmux pane (followed by \
+             Enter), e.g. to answer a prompt or drive the harness. Returns a \
+             confirmation with the target tmux session name.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Managed session id (UUID)."
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Text to inject into the session's pane."
+                    }
+                },
+                "required": ["session_id", "text"],
+                "additionalProperties": false
+            }),
+        ),
+    ]
+}

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -609,3 +609,95 @@ async fn tcode_session_spawns_and_accepts_commands() {
         "the issued command must reach the tcode session's pane; sends={sends:?}"
     );
 }
+
+// ── Typed resume-error tests (regression guard for #1221 review findings) ───────
+//
+// Why: the resume HTTP handler previously chose its 404/409 status by
+// SUBSTRING-matching the error's `Display` string, which silently regressed to
+// 500 whenever wording changed; and it ran a pre-flight `get` before `resume`,
+// opening a TOCTOU window. These tests drive the shared `resume_managed` helper
+// directly and assert on the TYPED `ResumeManagedError` variant — never on the
+// Display string — so the 404/409 contract is enforced structurally.
+
+use trusty_mpm::daemon::managed_routes::{ResumeManagedError, resume_managed};
+use trusty_mpm::daemon::state::DaemonState;
+use trusty_mpm::runtime::RuntimeKind as ResumeRuntimeKind;
+use trusty_mpm::session_manager::ManagedSessionId as ResumeSessionId;
+
+/// Resuming a missing session yields the typed `NotFound` variant (→ HTTP 404).
+///
+/// Why: a session decommissioned (or never created) must produce a 404, and the
+/// handler now derives that from the typed variant rather than a Display
+/// substring. Removing the pre-flight `get` means this single round-trip is the
+/// only place the 404 can originate — so we assert it lands here.
+/// What: builds a fresh `DaemonState`, calls `resume_managed` with a random id,
+/// and asserts the error is exactly `ResumeManagedError::NotFound`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn resume_managed_typed_missing_session_is_not_found() {
+    // Hermetic framework root so the on-disk session store never touches the
+    // operator's real `~/.trusty-mpm`.
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(root.path().to_path_buf()));
+    let missing = ResumeSessionId::new();
+
+    let err = resume_managed(&state, &missing)
+        .await
+        .expect_err("resuming a missing session must error");
+
+    assert!(
+        matches!(err, ResumeManagedError::NotFound(_)),
+        "missing session must map to the typed NotFound variant (→ 404), got {err:?}"
+    );
+}
+
+/// Resuming a non-resumable session yields the typed `InvalidState` variant
+/// (→ HTTP 409) — driven WITHOUT depending on the Display string.
+///
+/// Why: only `Stopped`/`Errored` sessions are resumable. A freshly created
+/// session is `Provisioning`, so resuming it is an invalid state transition that
+/// must surface as a 409. The handler derives 409 from the typed variant; this
+/// test proves the variant is produced for a non-resumable state.
+/// What: seeds a session via the daemon's session manager (it starts in
+/// `Provisioning`), calls `resume_managed`, and asserts the error matches
+/// `ResumeManagedError::InvalidState`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn resume_managed_typed_invalid_state_is_conflict() {
+    // Hermetic framework root so the seeded session persists to a temp store, not
+    // the operator's real `~/.trusty-mpm`.
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(root.path().to_path_buf()));
+    let mgr = state.session_manager().await;
+
+    // A newly created record is in `Provisioning` — not `Stopped`/`Errored` — so
+    // resuming it is an invalid state transition (→ 409), never a 404.
+    let id = ResumeSessionId::new();
+    // Derive a UNIQUE workspace path from the id: the tmux name is derived from
+    // the cwd basename (and truncated to 20 chars), so a fixed path would collide
+    // with a leftover tmux session (or a parallel run). Putting the UUID FIRST
+    // keeps the name unique even after truncation; rooting it under the hermetic
+    // temp dir keeps it isolated.
+    let ws = root.path().join(format!("{id}-resume-ws"));
+    mgr.create_with_id(
+        id,
+        "regression: invalid-state resume".to_string(),
+        Some(ws.clone()),
+        None,
+        Some(ws),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        ResumeRuntimeKind::default(),
+    )
+    .await
+    .expect("seed session");
+
+    let err = resume_managed(&state, &id)
+        .await
+        .expect_err("resuming a Provisioning session must error");
+
+    assert!(
+        matches!(err, ResumeManagedError::InvalidState(_)),
+        "non-resumable state must map to the typed InvalidState variant (→ 409), got {err:?}"
+    );
+}


### PR DESCRIPTION
## P1: session-manager MCP service (RFC PR #1225, ticket #1221)

Implements **P1 only** of the accepted RFC: expose the trusty-mpm session manager as a JSON-RPC/MCP service, at parity with search/memory/analyze. Existing HTTP REST API + `tm session` CLI are untouched (fully additive).

### a. Six new session-lifecycle MCP tools
Thin wrappers over the existing `SessionManager` lifecycle ops (the same code the HTTP `…/managed/*` routes use — not a reimplementation), each with a JSON-schema input and the Why/What/Test doc triple:

| Tool | Wraps |
|---|---|
| `session_new` | shared `spawn_managed` (provision → tmux → harness) |
| `session_stop` | `SessionManager::stop` (keeps workspace) |
| `session_resume` | shared `resume_managed` (re-spawn, no re-clone) |
| `session_decommission` | `SessionManager::decommission` (terminal teardown) |
| `session_activity` | `capture_pane` + lifecycle fields (no LLM key required) |
| `session_send` | `SessionManager::send_input` |

### e. Tool-catalog count (resolves the #1221 review nit)
`console_metrics` does **not** exist in trusty-mpm today, so the existing catalog is exactly **9** (6 orchestration + 3 bug-reporting), not 8. New total: **9 existing + 6 new = 15**. The `TOOL_CATALOG` constant and tests assert this exactly.

### b. `POST /rpc` endpoint
Loopback-only JSON-RPC dispatch on the daemon (mirrors trusty-memory's `POST /rpc`). Takes a raw `mcp::Request`, dispatches in-process against `DaemonState` via the existing `StateBackend`, returns the JSON-RPC response (HTTP 200; JSON-RPC errors in the envelope).

### d. Loopback-only enforcement (hard requirement, conf 0.85)
The `/rpc` handler rejects any **non-loopback peer with 403** via a `ConnectInfo<SocketAddr>` check (pure `is_loopback` predicate) — **independent of the daemon's bind address**, so a future `0.0.0.0` rebind (e.g. Docker) cannot silently expose the tool surface. The three `axum::serve` sites now use `into_make_service_with_connect_info`. Tests prove both the 403 path and the loopback-dispatch path.

### c. `serve --stdio` bridge
`tm serve --stdio` is a thin proxy mirroring `trusty-memory serve --stdio`: ensures the daemon is up (auto-start + dynamic-port discovery via the lock file), forwards each JSON-RPC request to `POST /rpc`, and reconnects on transport errors. Wired into `.mcp.json` (replacing the old `daemon --mcp` entry).

### f. SLOC splits (all under 500 prod / 1500 test caps; `check_line_cap.sh` exits 0)
- `mcp/tools.rs` → `mcp/tools/{mod.rs, core.rs, session.rs}`
- `mcp/mod.rs` tests → `mcp/tests.rs`; session-tool routing → `mcp/session_dispatch.rs`
- daemon session impls → `daemon/mcp_session.rs`; shared spawn/resume core → `managed_routes.rs` (now reused by HTTP handlers **and** the MCP backend, net-reducing duplication in the HTTP handlers)
- `POST /rpc` handler → `daemon/api/rpc.rs`

### Quality bar
- No `unwrap()` in library/daemon paths; `anyhow` in binary paths.
- Why/What/Test docs on every new public item.
- Daemon/MCP logs to stderr only.
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: clean.
- `cargo test -p trusty-mpm`: all pass (incl. new dispatch, `/rpc` loopback, bridge framing/reconnect, CLI-parse tests).
- `SKIP_UI_BUILD=1 cargo check` (workspace): clean.
- `bash scripts/check_line_cap.sh`: 0 violations.

### Out of scope (P1 only)
Console Sessions tab (#1222), config convention (#1220), and the `supervisor_status`/`console_metrics` tools are **not** included. The claude-mpm driver skill update lives in the separately-versioned skills repo (the MCP tools it needs now ship here).

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)