### PR TITLE
feat(trusty-mpm): configurable issue state-management — tm issue verbs + YAML config + Unicorn Factory default (closes #1246)

### DIFF
--- a/crates/trusty-mpm/examples/issue-state/unicorn-factory.yaml
+++ b/crates/trusty-mpm/examples/issue-state/unicorn-factory.yaml
@@ -1,0 +1,242 @@
+# issue-state.yaml — default Unicorn Factory model
+# Extracted from src/unicorn/github_client.py + executor.py
+# All label names and colors are hardcoded in _canonical_labels() and
+# applied by the executor; this YAML is a faithful, behavior-preserving
+# externalization of that logic.
+#
+# This file is committed at crates/trusty-mpm/examples/issue-state/
+# unicorn-factory.yaml and embedded in the `tm` binary via include_str! as the
+# built-in default state model (see commands/issue/config.rs).
+
+version: 1
+
+# ---------------------------------------------------------------------------
+# Label families
+# Labels are organized into four families. All family prefixes are
+# configurable; defaults produce the canonical unicorn:* / blast:* namespace.
+# ---------------------------------------------------------------------------
+
+label_config:
+  base: "unicorn"               # workflow.labels.base  (manifest.py WorkflowLabelsConfig)
+  approved: "unicorn:approved"  # workflow.labels.approved
+  blast_prefix: "blast:"        # workflow.labels.blast_prefix
+  status_prefix: "unicorn:"     # workflow.labels.status_prefix (UNI-REQ-018)
+
+# ---------------------------------------------------------------------------
+# States (the unicorn:* lifecycle labels)
+# ---------------------------------------------------------------------------
+
+states:
+
+  # Initial state — set at issue creation by ticket_builder.py
+  - name: queued
+    label:
+      name: "unicorn:queued"
+      color: "BFD4F2"
+      description: "Queued: awaiting human review"
+    order: 1
+
+  # Gate state — human applies this label to approve execution
+  - name: approved
+    label:
+      name: "unicorn:approved"
+      color: "0E8A16"
+      description: "Human-approved: execution eligible"
+    order: 2
+
+  # Running state — executor applies this label when the session starts
+  - name: active-development
+    label:
+      name: "unicorn:active-development"
+      color: "1D76DB"
+      description: "Executor actively working"
+    order: 3
+
+  # Control-channel halt states — human applies; watcher polls for these
+  - name: paused
+    label:
+      name: "unicorn:paused"
+      color: "E4E669"
+      description: "Execution intentionally suspended"
+    order: 4
+
+  - name: blocked
+    label:
+      name: "unicorn:blocked"
+      color: "E11D48"
+      description: "Execution halted; needs human input"
+    order: 5
+
+  # Terminal states
+  - name: done
+    label:
+      name: "unicorn:done"
+      color: "0075CA"
+      description: "Execution complete; PR opened — terminal"
+    terminal: true
+    order: 6
+
+  - name: failed
+    label:
+      name: "unicorn:failed"
+      color: "B60205"
+      description: "Execution failed — terminal"
+    terminal: true
+    order: 7
+
+# ---------------------------------------------------------------------------
+# Additional label families (not part of state machine, but seeded by bootstrap)
+# ---------------------------------------------------------------------------
+
+extra_labels:
+
+  # Base / ownership label — applied to all issues at creation
+  - name: "unicorn"
+    color: "7B68EE"
+    description: "Unicorn Factory work item"
+
+  # Blast-radius labels — applied at issue creation from AWP blast_radius field
+  - name: "blast:low"
+    color: "BFD4F2"
+    description: "Low blast radius"
+  - name: "blast:medium"
+    color: "FBCA04"
+    description: "Medium blast radius"
+  - name: "blast:high"
+    color: "E11D48"
+    description: "High blast radius"
+
+  # PR-tier labels — applied to PRs by executor._create_tiered_pr()
+  # blast:low → T4, blast:medium → T3, blast:high or missing → T2 (draft)
+  - name: "T2"
+    color: "E11D48"
+    description: "Tier 2 PR: high blast — SELT/CTO review required"
+  - name: "T3"
+    color: "FBCA04"
+    description: "Tier 3 PR: medium blast — 1 reviewer required"
+  - name: "T4"
+    color: "0075CA"
+    description: "Tier 4 PR: low blast — CI passing is sufficient"
+
+  # Approval-level labels — applied to PRs by executor._classify_and_gate()
+  # Level matrix (blast × project_class):
+  #   blast:low   × internal   → level 1 (auto-merge eligible)
+  #   blast:low   × production → level 2
+  #   blast:medium × any       → level 2
+  #   blast:high   × any       → level 3
+  - name: "approval:level-1"
+    color: "0E8A16"
+    description: "Approval level 1: trusty-review + CI sufficient"
+  - name: "approval:level-2"
+    color: "FBCA04"
+    description: "Approval level 2: harness owner review required"
+  - name: "approval:level-3"
+    color: "E11D48"
+    description: "Approval level 3: harness owner review required"
+
+# ---------------------------------------------------------------------------
+# State machine transitions
+# ---------------------------------------------------------------------------
+
+transitions:
+
+  # Ticket creation: no prior state → queued (ticket_builder.py build_issue_payloads)
+  - from: null
+    to: queued
+    trigger: issue_created
+    description: "ticket_builder applies unicorn:queued at issue creation"
+
+  # Human approval gate (human manually applies unicorn:approved label)
+  # The scheduler (OnApproveScheduler) polls for this label to trigger execution.
+  - from: queued
+    to: approved
+    trigger: human_label
+    description: "Human reviewer applies unicorn:approved to gate execution"
+
+  # Execution start: executor Phase 3 (add active-dev first, then remove approved)
+  - from: approved
+    to: active-development
+    trigger: executor_start
+    description: "executor.execute() Phase 3 — add new label first, then remove old"
+
+  # Control-channel halt: human applies paused/blocked during active session
+  # The _run_with_watcher polls get_issue() every poll_interval_seconds.
+  # On detection: session is cancelled (subprocess killed); human label is left in place.
+  - from: active-development
+    to: paused
+    trigger: human_label
+    description: "Human applies unicorn:paused; watcher cancels session"
+
+  - from: active-development
+    to: blocked
+    trigger: human_label
+    description: "Human applies unicorn:blocked; watcher cancels session"
+
+  # Happy path terminal: PR opened and (if level-1) auto-merged
+  - from: active-development
+    to: done
+    trigger: executor_complete
+    description: "executor Phase 6 success path — add done, remove active-development"
+
+  # Failure terminal: any exception in execute() after worktree creation
+  - from: active-development
+    to: failed
+    trigger: executor_failure
+    description: "executor Phase 6 failure path — add failed, remove active-development"
+
+# ---------------------------------------------------------------------------
+# Assignee / identity model
+# ---------------------------------------------------------------------------
+
+assignee_model:
+
+  # Strategy: the harness self-assigns issues using a named bot identity.
+  # The identity is derived from the manifest at runtime (never hardcoded):
+  #   - manifest.identity (explicit, e.g. "bob-unicorn") if set, else
+  #   - "{manifest.github.accountable_user}-unicorn" if accountable_user is set, else
+  #   - "{manifest.author}-unicorn"
+  # Pattern enforced: ^[a-z0-9][a-z0-9-]*-unicorn$  (e.g. "bob-unicorn")
+  # Source: manifest.py derive_identity() + _IDENTITY_PATTERN
+  strategy: bot_identity
+  identity_pattern: "{accountable_user_or_author}-unicorn"
+  identity_example: "bob-unicorn"
+
+  # Git attribution (commit trailers injected into every harness commit):
+  #   Unicorn: {identity}
+  #   Unicorn-Issue: #{issue_number}
+  # NOTE: The {identity} here is used ONLY for git commit attribution (user.name +
+  # trailers), NOT as a GitHub assignee. It is a bot identity for tracking which
+  # unicorn executed the work.
+  # Git user.name and user.email are set per-worktree (not globally):
+  #   user.name  = {identity}
+  #   user.email = {identity}@users.noreply.github.com
+  git_attribution:
+    user_name: "{identity}"
+    user_email: "{identity}@users.noreply.github.com"
+    commit_trailers:
+      - "Unicorn: {identity}"
+      - "Unicorn-Issue: #{issue_number}"
+    scope: worktree_local  # git config --worktree; never touches shared .git/config
+
+  # Assignment timing: issues receive assignees at creation from
+  # manifest.github.review_assignees (the human reviewers, not the bot).
+  # The coding-trigger eligibility check (UNI-REQ-014) additionally requires
+  # the issue to be assigned to manifest.github.accountable_user before execution.
+  per_state:
+    queued:
+      assignees: "{manifest.github.review_assignees}"  # human reviewers
+      description: "Set at creation by ticket_builder; review_assignees for human approval gate"
+    approved:
+      assignees: unchanged
+      description: "Human applies label; assignees unchanged from queued state"
+    active-development:
+      assignees: unchanged
+      description: "Executor does not modify assignees; accountable_user must already be assigned"
+    done:
+      assignees: unchanged
+    failed:
+      assignees: unchanged
+    paused:
+      assignees: unchanged
+    blocked:
+      assignees: unchanged

--- a/crates/trusty-mpm/help.yaml
+++ b/crates/trusty-mpm/help.yaml
@@ -178,3 +178,54 @@ commands:
         description: Note to post as an issue comment for the audit trail (repeatable)
       - name: runtime
         description: "Runtime backend for the spawned session: claude-code (default) or tcode"
+  issue:
+    description: YAML-configurable issue state-management (labels/transitions/assignee); gh default
+    examples:
+      - cmd: trusty-mpm issue seed-labels
+      - cmd: trusty-mpm issue seed-labels --dry-run
+      - cmd: trusty-mpm issue transition 1232 approved --note "approved by reviewer"
+      - cmd: trusty-mpm issue current 1232
+      - cmd: trusty-mpm issue states
+      - cmd: trusty-mpm issue seed-config --force
+      - cmd: trusty-mpm issue repair 1232
+    flags:
+      - name: system
+        description: "Ticket backend: gh (default), jira, or linear"
+    subcommands:
+      seed-labels:
+        description: Create any missing state + family labels in the repo (idempotent)
+        flags:
+          - name: config
+            description: Explicit path to an issue-state YAML (overrides discovery)
+          - name: dry-run
+            description: Print what would be created without creating anything
+      transition:
+        description: Move an issue to a target state, validating the edge against the model
+        args: [issue, to_state]
+        flags:
+          - name: config
+            description: Explicit path to an issue-state YAML (overrides discovery)
+          - name: note
+            description: Optional note appended to the transition audit comment
+      current:
+        description: Report an issue's current state, derived from its labels
+        args: [issue]
+        flags:
+          - name: config
+            description: Explicit path to an issue-state YAML (overrides discovery)
+      states:
+        description: List the configured states and transitions (reads YAML only)
+        flags:
+          - name: config
+            description: Explicit path to an issue-state YAML (overrides discovery)
+      seed-config:
+        description: Write the embedded default model to ~/.trusty-tools/trusty-mpm/issue-state.yaml
+        flags:
+          - name: force
+            description: Overwrite an existing user config file
+      repair:
+        description: Resolve a mid-transition issue carrying multiple state labels
+        args: [issue]
+        flags:
+          - name: config
+            description: Explicit path to an issue-state YAML (overrides discovery)

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -290,6 +290,94 @@ pub(crate) enum Command {
         #[arg(long, default_value = "claude-code", value_enum)]
         runtime: trusty_mpm::runtime::RuntimeKind,
     },
+
+    /// YAML-configurable issue state-management (labels/transitions/assignee).
+    ///
+    /// Why: externalizes the (formerly hardcoded) issue state machine — the
+    /// label set, the allowed transitions, and the assignee model — into a YAML
+    /// contract owned by trusty-mpm (#1246). The Unicorn Factory consumes these
+    /// verbs by shelling out; the YAML is the portable shared contract. Every
+    /// verb maps to a concrete GitHub label/assignee/comment mutation so issue
+    /// state stays reconstructable from GitHub artifacts alone.
+    /// What: a verb group (`seed-labels`, `transition`, `current`, `states`,
+    /// `seed-config`, `repair`) over the selected `[system]` backend (`gh`
+    /// default; `jira`/`linear` are not-yet-supported stubs). Config discovery:
+    /// `--config` > `./issue-state.yaml` > `~/.trusty-tools/trusty-mpm/
+    /// issue-state.yaml` > the embedded Unicorn Factory default.
+    /// Test: `cli_parses_issue_*` in `tests.rs`; verb logic in the
+    /// `commands::issue` submodule unit tests.
+    Issue {
+        /// Issue verb to run.
+        #[command(subcommand)]
+        cmd: IssueCmd,
+        /// Ticket backend: `gh` (default), `jira`, or `linear`.
+        #[arg(long, default_value = "gh", value_enum, global = true)]
+        system: crate::commands::ticket::system::TicketSystemKind,
+    },
+}
+
+/// Verbs for the `tm issue` state-management command group (#1246).
+///
+/// Why: each operation (seed labels, transition state, inspect, repair) is a
+/// distinct, scriptable verb; a sub-subcommand enum keeps them discoverable and
+/// individually parseable.
+/// What: `SeedLabels` (idempotent create-missing), `Transition` (validated
+/// atomic state change), `Current` (read state from labels), `States` (list the
+/// model), `SeedConfig` (write the default YAML to disk), `Repair` (resolve a
+/// multi-state issue).
+/// Test: `cli_parses_issue_*` in `tests.rs`.
+#[derive(Debug, Subcommand)]
+pub(crate) enum IssueCmd {
+    /// Create any missing labels (states + extra families) in the repo.
+    SeedLabels {
+        /// Explicit path to an issue-state YAML (overrides discovery).
+        #[arg(long)]
+        config: Option<std::path::PathBuf>,
+        /// Print what would be created without creating anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Move an issue to `<to-state>`, validating the edge against the model.
+    Transition {
+        /// Issue number (e.g. `1232`).
+        issue: u64,
+        /// Target state name (e.g. `approved`).
+        to_state: String,
+        /// Explicit path to an issue-state YAML (overrides discovery).
+        #[arg(long)]
+        config: Option<std::path::PathBuf>,
+        /// Optional note appended to the transition audit comment.
+        #[arg(long)]
+        note: Option<String>,
+    },
+    /// Report an issue's current state, derived from its labels.
+    Current {
+        /// Issue number.
+        issue: u64,
+        /// Explicit path to an issue-state YAML (overrides discovery).
+        #[arg(long)]
+        config: Option<std::path::PathBuf>,
+    },
+    /// List the configured states and transitions (reads YAML only).
+    States {
+        /// Explicit path to an issue-state YAML (overrides discovery).
+        #[arg(long)]
+        config: Option<std::path::PathBuf>,
+    },
+    /// Write the embedded default model to the user config path.
+    SeedConfig {
+        /// Overwrite an existing user config file.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Resolve a mid-transition issue carrying multiple state labels.
+    Repair {
+        /// Issue number.
+        issue: u64,
+        /// Explicit path to an issue-state YAML (overrides discovery).
+        #[arg(long)]
+        config: Option<std::path::PathBuf>,
+    },
 }
 
 /// Actions for the `catalog` subcommand.

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/config.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/config.rs
@@ -1,0 +1,396 @@
+//! YAML schema types + load/discovery for the `tm issue` state model (#1246).
+//!
+//! Why: the issue state machine (label set, allowed transitions, assignee model)
+//! is *configuration*, not harness code. This module defines the serde shape of
+//! that YAML contract, embeds the Unicorn Factory default via `include_str!`, and
+//! resolves which model to load (flag > CWD file > user config > embedded
+//! default, RFC §6). Validation lives in the sibling `validate` module to keep
+//! both files under the 500-SLOC production cap.
+//! What: the [`StateModel`] root and its nested types ([`LabelConfig`],
+//! [`StateDef`], [`StateLabel`], [`ExtraLabel`], [`Transition`], [`Trigger`],
+//! [`AssigneeModel`]), the embedded [`DEFAULT_MODEL_YAML`], and the loader
+//! ([`load_model`] / [`resolve_config_path`] / [`user_config_path`]).
+//! Test: round-trip + discovery tests in this file; validation tests in
+//! `validate.rs`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// The embedded default state model — the exact Unicorn Factory schema (#1246).
+///
+/// Why: every `tm issue` invocation must work with zero on-disk config; the
+/// committed example is compiled in as the always-available fallback (mirrors
+/// `tm services`' `DEFAULT_MANIFEST_YAML`).
+/// What: the verbatim contents of `examples/issue-state/unicorn-factory.yaml`.
+/// Test: `embedded_default_parses`, `embedded_default_round_trips`.
+pub(crate) const DEFAULT_MODEL_YAML: &str =
+    include_str!("../../../../../examples/issue-state/unicorn-factory.yaml");
+
+/// The only schema version this build understands.
+///
+/// Why: load-time version gating lets a future breaking schema change be
+/// rejected with a clear error instead of mis-parsing.
+/// What: the integer compared against `StateModel.version`.
+/// Test: `validate_rejects_unknown_version` (in `validate.rs`).
+pub(crate) const SUPPORTED_VERSION: u32 = 1;
+
+/// Root of the issue state-model YAML.
+///
+/// Why: the single deserialization target for the whole contract; everything
+/// `tm issue` does is driven by these fields, never by hardcoded label strings.
+/// What: schema `version`, the `label_config` family prefixes, the ordered
+/// `states`, the non-state `extra_labels`, the `transitions` graph, and the
+/// `assignee_model`.
+/// Test: `embedded_default_parses` deserializes the full factory model.
+///
+/// `Eq` is intentionally NOT derived: `AssigneeModel` carries opaque
+/// `serde_yaml::Value` fields which are only `PartialEq`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct StateModel {
+    /// Schema version (must equal [`SUPPORTED_VERSION`]).
+    pub(crate) version: u32,
+    /// Label-family prefixes (base/approved/blast/status).
+    pub(crate) label_config: LabelConfig,
+    /// Ordered lifecycle states.
+    pub(crate) states: Vec<StateDef>,
+    /// Non-state label families seeded by bootstrap.
+    #[serde(default)]
+    pub(crate) extra_labels: Vec<ExtraLabel>,
+    /// Allowed `from → to` transition edges.
+    pub(crate) transitions: Vec<Transition>,
+    /// Per-state assignee / identity model.
+    pub(crate) assignee_model: AssigneeModel,
+}
+
+/// Configurable label-family prefixes.
+///
+/// Why: the canonical `unicorn:*` / `blast:*` namespace is configurable so other
+/// consumers can rename the families without code changes.
+/// What: the base/ownership label, the approval-gate label, and the blast/status
+/// prefixes.
+/// Test: parsed as part of `embedded_default_parses`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct LabelConfig {
+    /// Ownership/base label applied to every work item (e.g. `unicorn`).
+    pub(crate) base: String,
+    /// The approval-gate label (e.g. `unicorn:approved`).
+    pub(crate) approved: String,
+    /// Prefix for blast-radius labels (e.g. `blast:`).
+    pub(crate) blast_prefix: String,
+    /// Prefix for the lifecycle labels (e.g. `unicorn:`).
+    pub(crate) status_prefix: String,
+}
+
+/// One lifecycle state and the GitHub label that represents it.
+///
+/// Why: a state's visible artifact is its label; bundling the name, label,
+/// ordering, and terminal flag keeps the state machine and the seeding driven by
+/// one source.
+/// What: the machine `name` (the unique key used by `tm issue transition`), the
+/// state `label`, an optional `order`, and a `terminal` flag.
+/// Test: `embedded_default_parses`; terminal-edge checks live in `validate.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct StateDef {
+    /// Machine state name (e.g. `queued`).
+    pub(crate) name: String,
+    /// The GitHub label representing this state.
+    pub(crate) label: StateLabel,
+    /// Optional display/sort ordering (informational; does not gate transitions).
+    #[serde(default)]
+    pub(crate) order: Option<u32>,
+    /// `true` for terminal states (no outbound edges allowed).
+    #[serde(default)]
+    pub(crate) terminal: bool,
+}
+
+/// A state's GitHub label (name + color + description).
+///
+/// Why: `seed-labels` needs the exact name/color/description to create the label.
+/// What: the label `name`, 6-hex `color` (no `#`), and optional `description`.
+/// Test: `embedded_default_parses`; hex validation in `validate.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct StateLabel {
+    /// Label name (e.g. `unicorn:queued`).
+    pub(crate) name: String,
+    /// 6-hex color, no `#`.
+    pub(crate) color: String,
+    /// Optional label description.
+    #[serde(default)]
+    pub(crate) description: String,
+}
+
+/// A non-state label family member (ownership/blast/PR-tier/approval).
+///
+/// Why: bootstrap seeds these alongside the state labels even though they are not
+/// part of the transition graph.
+/// What: the label `name`, `color`, and optional `description`.
+/// Test: `embedded_default_parses`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ExtraLabel {
+    /// Label name (e.g. `blast:high`, `T2`, `approval:level-1`).
+    pub(crate) name: String,
+    /// 6-hex color, no `#`.
+    pub(crate) color: String,
+    /// Optional label description.
+    #[serde(default)]
+    pub(crate) description: String,
+}
+
+/// One allowed `from → to` edge in the state machine.
+///
+/// Why: enumerating the legal edges is what lets `tm issue transition` reject
+/// illegal moves before any `gh` mutation.
+/// What: `from` (a state name, or `None` for the creation edge), `to` (a state
+/// name), the `trigger` annotation, and an optional human `description`.
+/// Test: `embedded_default_parses`; edge checks in `state.rs`/`validate.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Transition {
+    /// Source state name, or `None` for the `null → <entry>` creation edge.
+    #[serde(default)]
+    pub(crate) from: Option<String>,
+    /// Destination state name.
+    pub(crate) to: String,
+    /// What drives this edge.
+    pub(crate) trigger: Trigger,
+    /// Optional human description.
+    #[serde(default)]
+    pub(crate) description: String,
+}
+
+/// What drives a transition edge.
+///
+/// Why: typing the trigger as an enum rejects unknown trigger strings at load
+/// time and documents who/what performs each edge.
+/// What: the five recognised triggers from the factory model.
+/// Test: `embedded_default_parses`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Trigger {
+    /// Issue creation (`null → entry`).
+    IssueCreated,
+    /// A human applies a label.
+    HumanLabel,
+    /// The executor starts work.
+    ExecutorStart,
+    /// The executor completes successfully.
+    ExecutorComplete,
+    /// The executor fails.
+    ExecutorFailure,
+}
+
+/// The assignee / identity model.
+///
+/// Why: who gets assigned (and how the bot identity is derived for git
+/// attribution) is part of the externalized contract.
+/// What: the `strategy`, the `identity_pattern`/`identity_example`, the
+/// `git_attribution` map, and the `per_state` assignee rules. `git_attribution`
+/// is kept as opaque YAML (`serde_yaml::Value`) because `tm issue` does not act
+/// on it — it is a git-config concern owned by the consuming harness.
+/// Test: `embedded_default_parses`; strategy validation in `validate.rs`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct AssigneeModel {
+    /// Assignment strategy (e.g. `bot_identity`).
+    pub(crate) strategy: String,
+    /// How the bot identity is derived (free-form template).
+    #[serde(default)]
+    pub(crate) identity_pattern: Option<String>,
+    /// An example identity (informational).
+    #[serde(default)]
+    pub(crate) identity_example: Option<String>,
+    /// Git attribution block (opaque to `tm issue`; consumed by the harness).
+    #[serde(default)]
+    pub(crate) git_attribution: Option<serde_yaml::Value>,
+    /// Per-state assignee rules (opaque values: `unchanged` or a template).
+    #[serde(default)]
+    pub(crate) per_state: std::collections::BTreeMap<String, serde_yaml::Value>,
+}
+
+/// The on-disk basename used for both the CWD and user-config locations.
+///
+/// Why: the project file and the user-config file share a name and differ only
+/// by location (RFC §6); naming it once keeps the two in sync.
+/// What: `issue-state.yaml`.
+/// Test: `user_config_path_uses_basename`.
+pub(crate) const CONFIG_BASENAME: &str = "issue-state.yaml";
+
+/// The user-config path: `~/.trusty-tools/trusty-mpm/issue-state.yaml`.
+///
+/// Why: aligns with the #1220 `~/.trusty-tools/<crate>/config.yaml` convention.
+/// What: joins `dirs::home_dir()` with the trusty-tools/trusty-mpm subpath.
+/// Test: `user_config_path_uses_basename`.
+pub(crate) fn user_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| {
+        h.join(".trusty-tools")
+            .join("trusty-mpm")
+            .join(CONFIG_BASENAME)
+    })
+}
+
+/// Resolve which config path to load, by precedence (RFC §6).
+///
+/// Why: a single, testable precedence resolver keeps the discovery rule in one
+/// place: `--config` flag > `./issue-state.yaml` > user config > (None ⇒
+/// embedded default).
+/// What: returns `Some(path)` for the first location that exists, or `None` to
+/// signal "use the embedded default". An explicit `--config` path is returned
+/// even if missing, so the loader can surface a clear not-found error.
+/// Test: `resolve_prefers_flag`, `resolve_prefers_cwd`, `resolve_none_means_default`.
+pub(crate) fn resolve_config_path(
+    flag: Option<&Path>,
+    cwd_exists: bool,
+    user_path: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(f) = flag {
+        return Some(f.to_path_buf());
+    }
+    if cwd_exists {
+        return Some(PathBuf::from(CONFIG_BASENAME));
+    }
+    if let Some(u) = user_path
+        && u.exists()
+    {
+        return Some(u.to_path_buf());
+    }
+    None
+}
+
+/// Load + validate the effective state model, honouring the discovery precedence.
+///
+/// Why: the one entry point every `tm issue` verb calls to obtain a validated
+/// model; folding discovery + parse + validate here keeps the verbs thin.
+/// What: resolves the path (flag > CWD > user > embedded), reads + parses the
+/// YAML (or the embedded default when no file is found), then runs
+/// [`super::validate::validate_model`]; returns the validated [`StateModel`].
+/// Test: `load_embedded_default_ok`, `load_explicit_missing_errors`.
+pub(crate) fn load_model(flag: Option<&Path>) -> anyhow::Result<StateModel> {
+    let user = user_config_path();
+    let cwd_path = PathBuf::from(CONFIG_BASENAME);
+    let chosen = resolve_config_path(flag, cwd_path.exists(), user.as_deref());
+
+    let yaml = match &chosen {
+        Some(path) => std::fs::read_to_string(path).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to read issue-state config `{}`: {e}",
+                path.display()
+            )
+        })?,
+        None => DEFAULT_MODEL_YAML.to_string(),
+    };
+
+    let model: StateModel = serde_yaml::from_str(&yaml).map_err(|e| {
+        let src = chosen
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "embedded default".to_string());
+        anyhow::anyhow!("failed to parse issue-state model ({src}): {e}")
+    })?;
+    super::validate::validate_model(&model)?;
+    Ok(model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_default_parses() {
+        let m: StateModel = serde_yaml::from_str(DEFAULT_MODEL_YAML).expect("default parses");
+        assert_eq!(m.version, SUPPORTED_VERSION);
+        assert_eq!(m.label_config.base, "unicorn");
+        // States: the 7 unicorn:* lifecycle states; no `in-review`.
+        let names: Vec<&str> = m.states.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "queued",
+                "approved",
+                "active-development",
+                "paused",
+                "blocked",
+                "done",
+                "failed"
+            ]
+        );
+        assert!(
+            !names.contains(&"in-review"),
+            "there must be no in-review state"
+        );
+        // Terminal states.
+        let terminals: Vec<&str> = m
+            .states
+            .iter()
+            .filter(|s| s.terminal)
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(terminals, vec!["done", "failed"]);
+        // The creation edge is null → queued.
+        let entry = m
+            .transitions
+            .iter()
+            .find(|t| t.from.is_none())
+            .expect("creation edge");
+        assert_eq!(entry.to, "queued");
+        assert_eq!(entry.trigger, Trigger::IssueCreated);
+        // Assignee strategy is bot_identity (attribution-only).
+        assert_eq!(m.assignee_model.strategy, "bot_identity");
+        // Extra label families are present (unicorn, blast:*, T2-4, approval:*).
+        assert!(m.extra_labels.iter().any(|l| l.name == "blast:high"));
+        assert!(m.extra_labels.iter().any(|l| l.name == "approval:level-1"));
+    }
+
+    #[test]
+    fn embedded_default_round_trips() {
+        // Parse → serialize → parse must be stable (proves Serialize is complete).
+        let m: StateModel = serde_yaml::from_str(DEFAULT_MODEL_YAML).expect("parse");
+        let s = serde_yaml::to_string(&m).expect("serialize");
+        let m2: StateModel = serde_yaml::from_str(&s).expect("reparse");
+        assert_eq!(m, m2);
+    }
+
+    #[test]
+    fn load_embedded_default_ok() {
+        // No flag, and (in CI/clean env) no on-disk file → embedded default.
+        // To make this deterministic regardless of CWD, exercise the parse path
+        // the same way load_model does for the None case.
+        let model: StateModel = serde_yaml::from_str(DEFAULT_MODEL_YAML).expect("default parses");
+        super::super::validate::validate_model(&model).expect("default is valid");
+    }
+
+    #[test]
+    fn load_explicit_missing_errors() {
+        let missing = Path::new("/nonexistent/issue-state-does-not-exist.yaml");
+        let err = load_model(Some(missing)).unwrap_err().to_string();
+        assert!(err.contains("failed to read"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_prefers_flag() {
+        let flag = PathBuf::from("/tmp/custom.yaml");
+        let got = resolve_config_path(Some(&flag), true, None);
+        assert_eq!(got, Some(flag));
+    }
+
+    #[test]
+    fn resolve_prefers_cwd() {
+        // No flag, CWD file exists → the CWD basename wins over user/default.
+        let got = resolve_config_path(None, true, None);
+        assert_eq!(got, Some(PathBuf::from(CONFIG_BASENAME)));
+    }
+
+    #[test]
+    fn resolve_none_means_default() {
+        // No flag, no CWD file, no user file → None (use embedded default).
+        let got = resolve_config_path(None, false, None);
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn user_config_path_uses_basename() {
+        if let Some(p) = user_config_path() {
+            assert!(p.ends_with(CONFIG_BASENAME));
+            assert!(p.to_string_lossy().contains(".trusty-tools"));
+            assert!(p.to_string_lossy().contains("trusty-mpm"));
+        }
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -1,0 +1,157 @@
+//! `tm issue …` — YAML-configurable issue state-management verbs (#1246).
+//!
+//! Why: externalizes the Unicorn Factory's hardcoded issue state machine (label
+//! set, allowed transitions, assignee model) into a YAML contract owned by
+//! trusty-mpm, surfaced as `tm issue` verbs the Python harness consumes by
+//! shelling out. Every operation maps to a concrete label/assignee/comment
+//! mutation, so issue state stays reconstructable from GitHub artifacts alone.
+//! What: the [`issue`] dispatcher that selects the `gh` backend, loads + validates
+//! the model (config discovery: flag > CWD > user > embedded default), and runs
+//! the requested verb (`seed-labels`, `transition`, `current`, `states`,
+//! `seed-config`, `repair`). Schema types live in `config.rs`, validation in
+//! `validate.rs`, the state machine in `state.rs`, the operations in `ops.rs`.
+//! Test: pure logic is unit-tested in the submodules (`config`/`validate`/
+//! `state`/`ops`); CLI parsing in `tests.rs`.
+
+pub(crate) mod config;
+pub(crate) mod ops;
+pub(crate) mod state;
+pub(crate) mod validate;
+
+use std::path::PathBuf;
+
+use crate::cli::IssueCmd;
+use crate::commands::ticket::runner::RealCommandRunner;
+use crate::commands::ticket::system::{
+    GhTicketSystem, TicketSystem, TicketSystemKind, not_yet_supported,
+};
+
+use config::{StateModel, load_model};
+
+/// `tm issue <subcommand>` dispatcher.
+///
+/// Why: the single operator/harness entry point for the state-management verbs.
+/// What: builds the `gh`-backed [`TicketSystem`] (rejecting non-`gh` backends
+/// with the shared stub error), then dispatches each [`IssueCmd`] variant —
+/// loading + validating the model first for the verbs that need it.
+/// Test: parsing in `tests.rs`; per-verb logic in the submodule unit tests.
+pub(crate) fn issue(cmd: IssueCmd, system: TicketSystemKind) -> anyhow::Result<()> {
+    let backend = match system {
+        TicketSystemKind::Gh => GhTicketSystem::new(RealCommandRunner),
+        TicketSystemKind::Jira => return Err(not_yet_supported("jira")),
+        TicketSystemKind::Linear => return Err(not_yet_supported("linear")),
+    };
+    dispatch(&backend, cmd)
+}
+
+/// Dispatch a parsed [`IssueCmd`] against a backend (generic for testability).
+///
+/// Why: separating dispatch from backend construction keeps the verb wiring
+/// independent of `gh`, so the orchestration could be exercised with a fake.
+/// What: matches each verb, loads the model where required, runs the op, and
+/// prints a human summary.
+/// Test: per-verb ops are unit-tested; this is thin glue.
+fn dispatch<S: TicketSystem>(backend: &S, cmd: IssueCmd) -> anyhow::Result<()> {
+    match cmd {
+        IssueCmd::SeedLabels { config, dry_run } => {
+            let model = load_model(config.as_deref())?;
+            let report = ops::seed_labels(backend, &model, dry_run)?;
+            print_seed_report(&report);
+        }
+        IssueCmd::Transition {
+            issue,
+            to_state,
+            config,
+            note,
+        } => {
+            let model = load_model(config.as_deref())?;
+            let report = ops::transition(backend, &model, issue, &to_state, note.as_deref())?;
+            let from = report.from.as_deref().unwrap_or("(none)");
+            println!("transitioned #{issue}: {from} → {}", report.to);
+            if report.assignee_changed {
+                println!("  assignee rule applied");
+            }
+        }
+        IssueCmd::Current { issue, config } => {
+            let model = load_model(config.as_deref())?;
+            let state = ops::current(backend, &model, issue)?;
+            println!("{state}");
+        }
+        IssueCmd::States { config } => {
+            let model = load_model(config.as_deref())?;
+            print_states(&model);
+        }
+        IssueCmd::SeedConfig { force } => {
+            seed_config(force)?;
+        }
+        IssueCmd::Repair { issue, config } => {
+            let model = load_model(config.as_deref())?;
+            let kept = ops::repair(backend, &model, issue)?;
+            println!("repaired #{issue}: resolved to `{kept}`");
+        }
+    }
+    Ok(())
+}
+
+/// Print a `seed-labels` summary.
+///
+/// Why: operators need to see what was created vs. already present.
+/// What: prints the created and already-present label lists, flagging dry-runs.
+/// Test: side-effect-only (stdout); the report itself is unit-tested in `ops`.
+fn print_seed_report(report: &ops::SeedReport) {
+    if report.dry_run {
+        println!("[dry-run] would create {} label(s):", report.created.len());
+    } else {
+        println!("created {} label(s):", report.created.len());
+    }
+    for name in &report.created {
+        println!("  + {name}");
+    }
+    println!("already present: {} label(s)", report.already_present.len());
+}
+
+/// Print the configured states and transitions.
+///
+/// Why: operator introspection of the active model (reads YAML only, no `gh`).
+/// What: lists each state (label, terminal flag) then each transition edge.
+/// Test: side-effect-only (stdout); the model is unit-tested in `config`.
+fn print_states(model: &StateModel) {
+    println!("states ({}):", model.states.len());
+    for s in &model.states {
+        let term = if s.terminal { " [terminal]" } else { "" };
+        println!("  {} → {}{}", s.name, s.label.name, term);
+    }
+    println!("transitions ({}):", model.transitions.len());
+    for t in &model.transitions {
+        let from = t.from.as_deref().unwrap_or("null");
+        println!("  {from} → {} ({:?})", t.to, t.trigger);
+    }
+}
+
+/// `tm issue seed-config [--force]` — write the embedded default to user config.
+///
+/// Why: lets operators start from a copy of the default model and edit it,
+/// mirroring `tm services init` (RFC §6).
+/// What: writes [`config::DEFAULT_MODEL_YAML`] to
+/// `~/.trusty-tools/trusty-mpm/issue-state.yaml`, creating parent dirs; refuses
+/// to overwrite an existing file unless `--force`.
+/// Test: side-effect-only (filesystem); covered manually + by the dispatch glue.
+fn seed_config(force: bool) -> anyhow::Result<()> {
+    let path: PathBuf = config::user_config_path()
+        .ok_or_else(|| anyhow::anyhow!("could not resolve home directory for the user config"))?;
+    if path.exists() && !force {
+        anyhow::bail!(
+            "config already exists at {} — pass --force to overwrite",
+            path.display()
+        );
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            anyhow::anyhow!("failed to create config dir {}: {e}", parent.display())
+        })?;
+    }
+    std::fs::write(&path, config::DEFAULT_MODEL_YAML)
+        .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
+    println!("wrote default issue-state model to {}", path.display());
+    Ok(())
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs
@@ -1,0 +1,292 @@
+//! The `tm issue` operations: seed-labels, transition, current, repair (#1246).
+//!
+//! Why: these are the GitHub-mutating verbs that interpret the YAML state model.
+//! Each is written generically over the extended [`TicketSystem`] trait so it is
+//! fully unit-testable behind a fake backend (no live `gh`), and each maps every
+//! action to a concrete label/assignee/comment mutation so issue state stays
+//! reconstructable from GitHub artifacts (the visibility north star).
+//! What: [`seed_labels`], [`transition`], [`current`], and [`repair`], plus the
+//! [`SeedReport`]/[`TransitionReport`] result types the dispatcher prints.
+//! Test: the `ops_*` tests in `ops_tests.rs` drive a `FakeSystem`.
+
+use crate::commands::ticket::labels::{AssigneeTarget, RepoLabel};
+use crate::commands::ticket::system::TicketSystem;
+
+use super::config::StateModel;
+use super::state::{CurrentState, StateMachine};
+
+/// Outcome of a `seed-labels` run (for printing + assertion).
+///
+/// Why: separating "what happened" from "how it's printed" makes the operation
+/// pure-ish and lets tests assert the created/present split exactly.
+/// What: the labels created and the labels already present, plus whether the run
+/// was a dry-run.
+/// Test: `ops_seed_creates_only_missing`, `ops_seed_dry_run_creates_nothing`.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct SeedReport {
+    /// Labels that were (or would be) created.
+    pub(crate) created: Vec<String>,
+    /// Labels already present in the repo (left untouched).
+    pub(crate) already_present: Vec<String>,
+    /// Whether this was a dry-run (no `create_label` calls made).
+    pub(crate) dry_run: bool,
+}
+
+/// Outcome of a `transition` (for printing + assertion).
+///
+/// Why: records the resolved from/to and whether an assignee mutation applied,
+/// so the audit comment and tests can reflect exactly what changed.
+/// What: the resolved `from` (or `None` for the creation edge), the `to`, and
+/// whether an assignee change was applied.
+/// Test: `ops_transition_happy_path`, `ops_transition_assignee_unchanged`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct TransitionReport {
+    /// Resolved source state, or `None` for the `null → entry` creation edge.
+    pub(crate) from: Option<String>,
+    /// Destination state.
+    pub(crate) to: String,
+    /// Whether an assignee mutation was applied.
+    pub(crate) assignee_changed: bool,
+}
+
+/// Collect every label the model declares (state labels + extra labels).
+///
+/// Why: seeding ensures both families exist; gathering them once keeps the diff
+/// simple.
+/// What: maps state labels and extra labels into [`RepoLabel`]s.
+/// Test: exercised via `ops_seed_creates_only_missing`.
+fn declared_labels(model: &StateModel) -> Vec<RepoLabel> {
+    let mut out: Vec<RepoLabel> = model
+        .states
+        .iter()
+        .map(|s| RepoLabel {
+            name: s.label.name.clone(),
+            color: s.label.color.clone(),
+            description: s.label.description.clone(),
+        })
+        .collect();
+    out.extend(model.extra_labels.iter().map(|l| RepoLabel {
+        name: l.name.clone(),
+        color: l.color.clone(),
+        description: l.description.clone(),
+    }));
+    out
+}
+
+/// `tm issue seed-labels` — idempotent create-missing of all model labels.
+///
+/// Why: a repo must have the state + family labels before transitions can apply
+/// them; create-missing is non-destructive so re-runs are safe.
+/// What: lists existing repo labels, then for each declared label not present
+/// creates it (unless `dry_run`); leaves existing labels (incl. drifted
+/// color/description) untouched (RFC §5.1). Returns a [`SeedReport`].
+/// Test: `ops_seed_creates_only_missing`, `ops_seed_dry_run_creates_nothing`,
+/// `ops_seed_idempotent_when_all_present`.
+pub(crate) fn seed_labels<S: TicketSystem>(
+    sys: &S,
+    model: &StateModel,
+    dry_run: bool,
+) -> anyhow::Result<SeedReport> {
+    let existing = sys.list_repo_labels()?;
+    let existing_names: std::collections::BTreeSet<&str> =
+        existing.iter().map(|l| l.name.as_str()).collect();
+
+    let mut report = SeedReport {
+        dry_run,
+        ..Default::default()
+    };
+    for label in declared_labels(model) {
+        if existing_names.contains(label.name.as_str()) {
+            report.already_present.push(label.name.clone());
+            continue;
+        }
+        if !dry_run {
+            sys.create_label(&label)?;
+        }
+        report.created.push(label.name.clone());
+    }
+    Ok(report)
+}
+
+/// `tm issue transition <issue#> <to-state>` — validated, atomic state change.
+///
+/// Why: the core verb. It must reject illegal edges BEFORE any `gh` mutation
+/// (visibility + safety), perform the swap in one call, apply the per-state
+/// assignee rule, and post an audit comment so the change is reconstructable.
+/// What: resolves `<to>` to a known state; fetches the issue; resolves the
+/// current state from its labels (erroring clearly on zero/multiple); checks the
+/// `from → to` edge; performs the single-call swap (`swap_labels`); applies the
+/// assignee rule via `set_assignee` (no-op for the factory `unchanged` rules);
+/// and posts an audit comment with any `note`. Returns a [`TransitionReport`].
+/// Test: `ops_transition_happy_path`, `ops_transition_rejects_invalid`,
+/// `ops_transition_rejects_zero_state`, `ops_transition_rejects_multi_state`,
+/// `ops_transition_assignee_unchanged`.
+pub(crate) fn transition<S: TicketSystem>(
+    sys: &S,
+    model: &StateModel,
+    issue: u64,
+    to: &str,
+    note: Option<&str>,
+) -> anyhow::Result<TransitionReport> {
+    let sm = StateMachine::new(model);
+
+    // 1. Target must be a known state.
+    if !sm.is_state(to) {
+        anyhow::bail!(
+            "unknown target state `{to}`; valid states: [{}]",
+            sm.state_names().join(", ")
+        );
+    }
+
+    // 2. Fetch the issue and resolve its current state from labels.
+    let issue_obj = sys.validate(issue)?;
+    let from: Option<String> = match sm.resolve_current_state(&issue_obj.labels) {
+        CurrentState::One(s) => Some(s.to_string()),
+        CurrentState::None => None,
+        CurrentState::Many(states) => {
+            anyhow::bail!(
+                "issue #{issue} carries multiple state labels {states:?}; \
+                 run `tm issue repair {issue}` to resolve to a single state first"
+            );
+        }
+    };
+
+    // 3. Validate the edge BEFORE any gh mutation.
+    if !sm.transition_allowed(from.as_deref(), to) {
+        let from_disp = from.as_deref().unwrap_or("null");
+        let allowed = sm.allowed_targets_from(from.as_deref());
+        anyhow::bail!(
+            "invalid transition {from_disp} → {to}; allowed from {from_disp}: [{}]",
+            allowed.join(", ")
+        );
+    }
+
+    // 4. Atomic label swap (single-call default). The creation edge (from=None)
+    //    only adds the entry label.
+    let to_label = sm
+        .state_label(to)
+        .ok_or_else(|| anyhow::anyhow!("internal: state `{to}` has no label"))?;
+    match from.as_deref().and_then(|f| sm.state_label(f)) {
+        Some(from_label) => sys.swap_labels(issue, to_label, from_label)?,
+        None => sys.add_label(issue, to_label)?,
+    }
+
+    // 5. Apply the per-state assignee rule (no-op for factory `unchanged`).
+    let mut assignee_changed = false;
+    if let Some(target) = sm.assignee_target_for(to) {
+        // The `None` clear-all rule needs the current assignee set (read side).
+        let current = if matches!(target, AssigneeTarget::None) {
+            issue_obj.assignees.clone()
+        } else {
+            Vec::new()
+        };
+        sys.set_assignee(issue, &target, &current)?;
+        assignee_changed = true;
+    }
+
+    // 6. Audit comment (visibility): record from → to + any note.
+    let from_disp = from.as_deref().unwrap_or("(none)");
+    let mut body = format!("tm issue transition: `{from_disp}` → `{to}`");
+    if assignee_changed {
+        body.push_str(" (assignee rule applied)");
+    }
+    if let Some(n) = note {
+        body.push_str("\n\n");
+        body.push_str(n);
+    }
+    sys.comment(issue, &body)?;
+
+    Ok(TransitionReport {
+        from,
+        to: to.to_string(),
+        assignee_changed,
+    })
+}
+
+/// `tm issue current <issue#>` — report the issue's current state from labels.
+///
+/// Why: the read side of the visibility north star — reconstruct state from
+/// GitHub artifacts alone.
+/// What: fetches the issue, resolves the single state label; returns the state
+/// name, or an error for zero/multiple (with a `repair` hint for multiple).
+/// Test: `ops_current_reports_state`, `ops_current_errors_on_none`.
+pub(crate) fn current<S: TicketSystem>(
+    sys: &S,
+    model: &StateModel,
+    issue: u64,
+) -> anyhow::Result<String> {
+    let sm = StateMachine::new(model);
+    let issue_obj = sys.validate(issue)?;
+    match sm.resolve_current_state(&issue_obj.labels) {
+        CurrentState::One(s) => Ok(s.to_string()),
+        CurrentState::None => anyhow::bail!(
+            "issue #{issue} carries no recognised state label; valid states: [{}]",
+            sm.state_names().join(", ")
+        ),
+        CurrentState::Many(states) => anyhow::bail!(
+            "issue #{issue} carries multiple state labels {states:?}; \
+             run `tm issue repair {issue}` to resolve"
+        ),
+    }
+}
+
+/// `tm issue repair <issue#>` — resolve a multi-state issue to a single state.
+///
+/// Why: a crash mid-transition can leave two state labels on an issue, violating
+/// the "exactly one state" invariant. `repair` removes the stale label(s),
+/// keeping the most-advanced state (highest `order`) so recovery is deterministic.
+/// What: fetches the issue; if exactly one (or zero) state label is present it
+/// reports nothing to do (zero is an explicit clear error); if multiple are
+/// present it keeps the highest-`order` state and removes the others' labels.
+/// Returns the kept state name.
+/// Test: `ops_repair_resolves_two_labels`, `ops_repair_noop_when_single`,
+/// `ops_repair_errors_on_zero`.
+pub(crate) fn repair<S: TicketSystem>(
+    sys: &S,
+    model: &StateModel,
+    issue: u64,
+) -> anyhow::Result<String> {
+    let sm = StateMachine::new(model);
+    let issue_obj = sys.validate(issue)?;
+    let present: Vec<&str> = match sm.resolve_current_state(&issue_obj.labels) {
+        CurrentState::One(s) => {
+            // Nothing to repair — already a single, unambiguous state.
+            return Ok(s.to_string());
+        }
+        CurrentState::None => anyhow::bail!(
+            "issue #{issue} carries no state label; nothing to repair — \
+             apply a state with `tm issue transition` instead"
+        ),
+        CurrentState::Many(states) => states,
+    };
+
+    // Keep the most-advanced state (highest declared `order`; fall back to the
+    // first-declared on ties / missing order), remove the rest.
+    let keep = present
+        .iter()
+        .max_by_key(|name| {
+            model
+                .states
+                .iter()
+                .find(|s| &s.name == *name)
+                .and_then(|s| s.order)
+                .unwrap_or(0)
+        })
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("internal: empty multi-state set"))?;
+
+    for name in present.iter().filter(|n| **n != keep) {
+        if let Some(label) = sm.state_label(name) {
+            sys.remove_label(issue, label)?;
+        }
+    }
+    sys.comment(
+        issue,
+        &format!("tm issue repair: resolved multiple state labels to `{keep}`"),
+    )?;
+    Ok(keep.to_string())
+}
+
+#[cfg(test)]
+#[path = "ops_tests.rs"]
+mod ops_tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
@@ -1,0 +1,461 @@
+//! Unit tests for the `tm issue` operations, driven by a fake [`TicketSystem`].
+//!
+//! Why: every operation must be verifiable without a live `gh`/GitHub. A
+//! scripted [`FakeSystem`] records each backend call so tests assert the exact
+//! label/assignee/comment mutations (and, crucially, that invalid transitions
+//! error BEFORE any mutation).
+//! What: [`FakeSystem`] (a `TicketSystem` impl recording calls + returning a
+//! scripted issue) and the `ops_*` tests for seed-labels, transition, current,
+//! and repair.
+//! Test: this IS the test module (classified test file: 1500-SLOC cap).
+
+use std::cell::RefCell;
+
+use super::*;
+use crate::commands::ticket::labels::{AssigneeTarget, RepoLabel};
+use crate::commands::ticket::system::{Issue, TicketSystem};
+
+/// A recorded backend call (for assertion).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Call {
+    ListRepoLabels,
+    CreateLabel(String),
+    AddLabel(u64, String),
+    RemoveLabel(u64, String),
+    SwapLabels(u64, String, String),
+    SetAssignee(u64, AssigneeTarget, Vec<String>),
+    Comment(u64, String),
+    Validate(u64),
+}
+
+/// A scripted [`TicketSystem`] recording every call.
+struct FakeSystem {
+    issue: Issue,
+    repo_labels: Vec<RepoLabel>,
+    calls: RefCell<Vec<Call>>,
+}
+
+impl FakeSystem {
+    fn new(issue: Issue) -> Self {
+        Self {
+            issue,
+            repo_labels: Vec::new(),
+            calls: RefCell::new(Vec::new()),
+        }
+    }
+    fn with_repo_labels(mut self, labels: Vec<RepoLabel>) -> Self {
+        self.repo_labels = labels;
+        self
+    }
+    fn calls(&self) -> Vec<Call> {
+        self.calls.borrow().clone()
+    }
+    fn record(&self, c: Call) {
+        self.calls.borrow_mut().push(c);
+    }
+}
+
+impl TicketSystem for FakeSystem {
+    fn name(&self) -> &'static str {
+        "fake"
+    }
+    fn validate(&self, issue_number: u64) -> anyhow::Result<Issue> {
+        self.record(Call::Validate(issue_number));
+        Ok(self.issue.clone())
+    }
+    fn comment(&self, issue_number: u64, body: &str) -> anyhow::Result<()> {
+        self.record(Call::Comment(issue_number, body.to_string()));
+        Ok(())
+    }
+    fn list_repo_labels(&self) -> anyhow::Result<Vec<RepoLabel>> {
+        self.record(Call::ListRepoLabels);
+        Ok(self.repo_labels.clone())
+    }
+    fn create_label(&self, label: &RepoLabel) -> anyhow::Result<()> {
+        self.record(Call::CreateLabel(label.name.clone()));
+        Ok(())
+    }
+    fn add_label(&self, issue: u64, label: &str) -> anyhow::Result<()> {
+        self.record(Call::AddLabel(issue, label.to_string()));
+        Ok(())
+    }
+    fn remove_label(&self, issue: u64, label: &str) -> anyhow::Result<()> {
+        self.record(Call::RemoveLabel(issue, label.to_string()));
+        Ok(())
+    }
+    fn swap_labels(&self, issue: u64, add: &str, remove: &str) -> anyhow::Result<()> {
+        self.record(Call::SwapLabels(issue, add.to_string(), remove.to_string()));
+        Ok(())
+    }
+    fn set_assignee(
+        &self,
+        issue: u64,
+        who: &AssigneeTarget,
+        current: &[String],
+    ) -> anyhow::Result<()> {
+        self.record(Call::SetAssignee(issue, who.clone(), current.to_vec()));
+        Ok(())
+    }
+}
+
+fn model() -> StateModel {
+    serde_yaml::from_str(super::super::config::DEFAULT_MODEL_YAML).expect("default parses")
+}
+
+fn issue_with_labels(number: u64, labels: &[&str]) -> Issue {
+    Issue {
+        number,
+        title: "t".to_string(),
+        body: String::new(),
+        labels: labels.iter().map(|s| s.to_string()).collect(),
+        assignees: Vec::new(),
+        open: true,
+    }
+}
+
+// ---- seed-labels ----------------------------------------------------------
+
+#[test]
+fn ops_seed_creates_only_missing() {
+    let m = model();
+    // Repo already has the base `unicorn` label and `unicorn:queued`.
+    let existing = vec![
+        RepoLabel {
+            name: "unicorn".to_string(),
+            color: "7B68EE".to_string(),
+            description: String::new(),
+        },
+        RepoLabel {
+            name: "unicorn:queued".to_string(),
+            color: "BFD4F2".to_string(),
+            description: String::new(),
+        },
+    ];
+    let sys = FakeSystem::new(issue_with_labels(1, &[])).with_repo_labels(existing);
+    let report = seed_labels(&sys, &m, false).expect("seed");
+
+    // Present ones not re-created.
+    assert!(report.already_present.contains(&"unicorn".to_string()));
+    assert!(
+        report
+            .already_present
+            .contains(&"unicorn:queued".to_string())
+    );
+    // Missing ones created.
+    assert!(report.created.contains(&"unicorn:approved".to_string()));
+    assert!(report.created.contains(&"blast:high".to_string()));
+    assert!(report.created.contains(&"approval:level-1".to_string()));
+    // No create call for the already-present labels.
+    let create_names: Vec<String> = sys
+        .calls()
+        .into_iter()
+        .filter_map(|c| match c {
+            Call::CreateLabel(n) => Some(n),
+            _ => None,
+        })
+        .collect();
+    assert!(!create_names.contains(&"unicorn".to_string()));
+    assert!(!create_names.contains(&"unicorn:queued".to_string()));
+}
+
+#[test]
+fn ops_seed_dry_run_creates_nothing() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(1, &[]));
+    let report = seed_labels(&sys, &m, true).expect("seed dry");
+    assert!(report.dry_run);
+    // Everything reported as created (would-be), but ZERO create calls.
+    assert!(!report.created.is_empty());
+    let create_calls = sys
+        .calls()
+        .into_iter()
+        .filter(|c| matches!(c, Call::CreateLabel(_)))
+        .count();
+    assert_eq!(create_calls, 0, "dry-run must make zero create_label calls");
+}
+
+#[test]
+fn ops_seed_idempotent_when_all_present() {
+    let m = model();
+    let all: Vec<RepoLabel> = {
+        let mut v: Vec<RepoLabel> = m
+            .states
+            .iter()
+            .map(|s| RepoLabel {
+                name: s.label.name.clone(),
+                color: s.label.color.clone(),
+                description: s.label.description.clone(),
+            })
+            .collect();
+        v.extend(m.extra_labels.iter().map(|l| RepoLabel {
+            name: l.name.clone(),
+            color: l.color.clone(),
+            description: l.description.clone(),
+        }));
+        v
+    };
+    let sys = FakeSystem::new(issue_with_labels(1, &[])).with_repo_labels(all);
+    let report = seed_labels(&sys, &m, false).expect("seed");
+    assert!(report.created.is_empty(), "second run creates nothing");
+}
+
+// ---- transition -----------------------------------------------------------
+
+#[test]
+fn ops_transition_happy_path() {
+    let m = model();
+    // Issue is currently `queued`; transition to `approved`.
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn", "unicorn:queued"]));
+    let report = transition(&sys, &m, 5, "approved", None).expect("transition");
+    assert_eq!(report.from.as_deref(), Some("queued"));
+    assert_eq!(report.to, "approved");
+    assert!(!report.assignee_changed, "factory rule is unchanged");
+
+    // Exactly one swap call with the right labels.
+    let swaps: Vec<Call> = sys
+        .calls()
+        .into_iter()
+        .filter(|c| matches!(c, Call::SwapLabels(..)))
+        .collect();
+    assert_eq!(swaps.len(), 1);
+    assert_eq!(
+        swaps[0],
+        Call::SwapLabels(
+            5,
+            "unicorn:approved".to_string(),
+            "unicorn:queued".to_string()
+        )
+    );
+}
+
+#[test]
+fn ops_transition_records_single_swap_and_no_assignee() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn:approved"]));
+    transition(&sys, &m, 5, "active-development", None).expect("transition");
+    let calls = sys.calls();
+    // No set_assignee call (factory `unchanged`).
+    assert!(
+        !calls.iter().any(|c| matches!(c, Call::SetAssignee(..))),
+        "no assignee mutation for unchanged rule"
+    );
+    // Exactly one swap.
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|c| matches!(c, Call::SwapLabels(..)))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn ops_transition_creation_edge_adds_label() {
+    let m = model();
+    // No state label present → from = None; null → queued is allowed.
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn"]));
+    let report = transition(&sys, &m, 5, "queued", None).expect("transition");
+    assert_eq!(report.from, None);
+    // Creation edge uses add_label (not swap).
+    let calls = sys.calls();
+    assert!(
+        calls
+            .iter()
+            .any(|c| matches!(c, Call::AddLabel(5, l) if l == "unicorn:queued"))
+    );
+    assert!(!calls.iter().any(|c| matches!(c, Call::SwapLabels(..))));
+}
+
+#[test]
+fn ops_transition_rejects_invalid_terminal() {
+    let m = model();
+    // done → active-development is not a valid edge (terminal source).
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn:done"]));
+    let err = transition(&sys, &m, 5, "active-development", None)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("invalid transition"), "got: {err}");
+    // NO mutation recorded (only the read).
+    assert!(
+        !sys.calls().iter().any(|c| matches!(
+            c,
+            Call::SwapLabels(..) | Call::AddLabel(..) | Call::RemoveLabel(..)
+        )),
+        "must not mutate on invalid transition"
+    );
+}
+
+#[test]
+fn ops_transition_rejects_invalid_skip_gate() {
+    let m = model();
+    // queued → done has no edge.
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn:queued"]));
+    let err = transition(&sys, &m, 5, "done", None)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("invalid transition"), "got: {err}");
+    assert!(
+        !sys.calls()
+            .iter()
+            .any(|c| matches!(c, Call::SwapLabels(..)))
+    );
+}
+
+#[test]
+fn ops_transition_rejects_unknown_target() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn:queued"]));
+    let err = transition(&sys, &m, 5, "nonsense", None)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unknown target state"), "got: {err}");
+    // Rejected before even reading the issue.
+    assert!(
+        sys.calls().is_empty(),
+        "must reject unknown target before any gh call"
+    );
+}
+
+#[test]
+fn ops_transition_rejects_zero_state() {
+    let m = model();
+    // No state label, but target is not reachable via the creation edge.
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn"]));
+    let err = transition(&sys, &m, 5, "approved", None)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("invalid transition"), "got: {err}");
+}
+
+#[test]
+fn ops_transition_rejects_multi_state() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(
+        5,
+        &["unicorn:queued", "unicorn:approved"],
+    ));
+    let err = transition(&sys, &m, 5, "active-development", None)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("multiple state labels"), "got: {err}");
+    assert!(err.contains("repair"), "should hint repair, got: {err}");
+}
+
+#[test]
+fn ops_transition_posts_audit_comment_with_note() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn:queued"]));
+    transition(&sys, &m, 5, "approved", Some("approved by reviewer")).expect("transition");
+    let comment = sys.calls().into_iter().find_map(|c| match c {
+        Call::Comment(_, b) => Some(b),
+        _ => None,
+    });
+    let body = comment.expect("audit comment posted");
+    assert!(body.contains("queued"));
+    assert!(body.contains("approved"));
+    assert!(body.contains("approved by reviewer"));
+}
+
+#[test]
+fn ops_transition_applies_assignee_for_self_rule() {
+    // Synthetic model whose target state uses `assignees: self`.
+    let yaml = r#"
+version: 1
+label_config: { base: x, approved: x:a, blast_prefix: "b:", status_prefix: "x:" }
+states:
+  - { name: open, label: { name: "x:open", color: "AABBCC" } }
+  - { name: working, label: { name: "x:working", color: "AABBCC" } }
+transitions:
+  - { from: null, to: open, trigger: issue_created }
+  - { from: open, to: working, trigger: executor_start }
+assignee_model:
+  strategy: self
+  per_state:
+    working:
+      assignees: self
+"#;
+    let m: StateModel = serde_yaml::from_str(yaml).expect("synthetic parses");
+    super::super::validate::validate_model(&m).expect("valid");
+    let sys = FakeSystem::new(issue_with_labels(9, &["x:open"]));
+    let report = transition(&sys, &m, 9, "working", None).expect("transition");
+    assert!(report.assignee_changed);
+    assert!(
+        sys.calls()
+            .iter()
+            .any(|c| matches!(c, Call::SetAssignee(9, AssigneeTarget::SelfUser, _)))
+    );
+}
+
+// ---- current --------------------------------------------------------------
+
+#[test]
+fn ops_current_reports_state() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(
+        5,
+        &["unicorn", "unicorn:active-development"],
+    ));
+    assert_eq!(current(&sys, &m, 5).expect("current"), "active-development");
+}
+
+#[test]
+fn ops_current_errors_on_none() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn"]));
+    let err = current(&sys, &m, 5).unwrap_err().to_string();
+    assert!(err.contains("no recognised state label"), "got: {err}");
+}
+
+#[test]
+fn ops_current_errors_on_many() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn:queued", "unicorn:done"]));
+    let err = current(&sys, &m, 5).unwrap_err().to_string();
+    assert!(err.contains("multiple state labels"), "got: {err}");
+}
+
+// ---- repair ---------------------------------------------------------------
+
+#[test]
+fn ops_repair_resolves_two_labels() {
+    let m = model();
+    // Mid-transition: both queued (order 1) and approved (order 2) present.
+    // repair keeps the most-advanced (approved) and removes queued.
+    let sys = FakeSystem::new(issue_with_labels(
+        5,
+        &["unicorn:queued", "unicorn:approved"],
+    ));
+    let kept = repair(&sys, &m, 5).expect("repair");
+    assert_eq!(kept, "approved");
+    let removed: Vec<String> = sys
+        .calls()
+        .into_iter()
+        .filter_map(|c| match c {
+            Call::RemoveLabel(_, l) => Some(l),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(removed, vec!["unicorn:queued".to_string()]);
+}
+
+#[test]
+fn ops_repair_noop_when_single() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn:approved"]));
+    let kept = repair(&sys, &m, 5).expect("repair");
+    assert_eq!(kept, "approved");
+    // No remove calls.
+    assert!(
+        !sys.calls()
+            .iter()
+            .any(|c| matches!(c, Call::RemoveLabel(..)))
+    );
+}
+
+#[test]
+fn ops_repair_errors_on_zero() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(5, &["unicorn"]));
+    let err = repair(&sys, &m, 5).unwrap_err().to_string();
+    assert!(err.contains("no state label"), "got: {err}");
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/state.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/state.rs
@@ -1,0 +1,317 @@
+//! The state-machine view over a validated [`StateModel`] (#1246).
+//!
+//! Why: the operations (`transition`, `current`, `repair`) need answers to
+//! "what state is this issue in?", "is this edge allowed?", and "what assignee
+//! rule applies to the target state?". Centralising those derivations here keeps
+//! `ops.rs` focused on the `gh` orchestration and keeps the pure logic unit-
+//! testable without a runner.
+//! What: [`StateMachine`] wrapping a `&StateModel` with `transition_allowed`,
+//! `resolve_current_state` (from an issue's labels), `state_label`,
+//! `assignee_target_for`, and `allowed_targets_from`.
+//! Test: the `sm_*` tests in this file.
+
+use super::config::StateModel;
+use crate::commands::ticket::labels::AssigneeTarget;
+
+/// A read-only state-machine view over a validated model.
+///
+/// Why: borrowing the model (rather than owning a copy) keeps the operations
+/// cheap and makes it obvious the machine never mutates config.
+/// What: holds `&StateModel`; all methods are pure derivations over it.
+/// Test: constructed in every `sm_*` test.
+pub(crate) struct StateMachine<'a> {
+    model: &'a StateModel,
+}
+
+impl<'a> StateMachine<'a> {
+    /// Build a machine over a validated model.
+    ///
+    /// Why: validation is the caller's responsibility (done at load); this is a
+    /// zero-cost wrapper.
+    /// What: stores the borrow.
+    /// Test: `sm_transition_allowed`.
+    pub(crate) fn new(model: &'a StateModel) -> Self {
+        Self { model }
+    }
+
+    /// The GitHub label for a state name, if the state exists.
+    ///
+    /// Why: the transition swap and seeding need the visible label for a state.
+    /// What: linear lookup by state name → `&label.name`.
+    /// Test: `sm_state_label`.
+    pub(crate) fn state_label(&self, state: &str) -> Option<&'a str> {
+        self.model
+            .states
+            .iter()
+            .find(|s| s.name == state)
+            .map(|s| s.label.name.as_str())
+    }
+
+    /// Whether `state` is a known state name.
+    ///
+    /// Why: `tm issue transition` must reject an unknown target with the list of
+    /// valid states.
+    /// What: returns `true` iff a state with that name exists.
+    /// Test: `sm_is_state`.
+    pub(crate) fn is_state(&self, state: &str) -> bool {
+        self.model.states.iter().any(|s| s.name == state)
+    }
+
+    /// All state names, in declared order (for error messages / `states` verb).
+    ///
+    /// Why: a clear "valid states: [...]" hint when a target is unknown.
+    /// What: maps the states to their names.
+    /// Test: `sm_state_names`.
+    pub(crate) fn state_names(&self) -> Vec<&'a str> {
+        self.model.states.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    /// Whether the `from → to` edge is in the transition graph.
+    ///
+    /// Why: the core guard — illegal moves are rejected before any `gh` call.
+    /// What: returns `true` iff a transition with matching `from`/`to` exists.
+    /// `from = None` matches the `null → entry` creation edge.
+    /// Test: `sm_transition_allowed`, `sm_transition_rejects_unlisted`.
+    pub(crate) fn transition_allowed(&self, from: Option<&str>, to: &str) -> bool {
+        self.model
+            .transitions
+            .iter()
+            .any(|t| t.from.as_deref() == from && t.to == to)
+    }
+
+    /// The allowed destination states from a given source.
+    ///
+    /// Why: when a transition is rejected, the error lists what *is* allowed.
+    /// What: collects `to` for every transition whose `from` matches.
+    /// Test: `sm_allowed_targets_from`.
+    pub(crate) fn allowed_targets_from(&self, from: Option<&str>) -> Vec<&'a str> {
+        self.model
+            .transitions
+            .iter()
+            .filter(|t| t.from.as_deref() == from)
+            .map(|t| t.to.as_str())
+            .collect()
+    }
+
+    /// Resolve the issue's current state from the labels present on it.
+    ///
+    /// Why: the visibility north star requires exactly one state label; this
+    /// reconstructs state from GitHub artifacts alone. Zero or multiple matches
+    /// is surfaced as an error (the caller turns `Multiple` into a `repair`
+    /// hint).
+    /// What: intersects the issue's labels with the state labels and classifies
+    /// the result as `None` / `One` / `Many`.
+    /// Test: `sm_resolve_one`, `sm_resolve_none`, `sm_resolve_many`.
+    pub(crate) fn resolve_current_state(&self, issue_labels: &[String]) -> CurrentState<'a> {
+        let matches: Vec<&'a str> = self
+            .model
+            .states
+            .iter()
+            .filter(|s| issue_labels.iter().any(|l| l == &s.label.name))
+            .map(|s| s.name.as_str())
+            .collect();
+        match matches.len() {
+            0 => CurrentState::None,
+            1 => CurrentState::One(matches[0]),
+            _ => CurrentState::Many(matches),
+        }
+    }
+
+    /// The effective assignee rule for a target state.
+    ///
+    /// Why: `tm issue transition` applies the per-state assignee rule. For the
+    /// factory model every per-state rule is `unchanged` (a no-op); other models
+    /// may map to `self`/`bot`/`none`.
+    /// What: reads `assignee_model.per_state[state].assignees`. `unchanged` (or a
+    /// missing rule, or a non-recognised template) yields `None` (no mutation);
+    /// `self`/`me` → `SelfUser`; `none`/`unassigned` → `AssigneeTarget::None`;
+    /// any other bare string is treated as a literal login.
+    ///
+    /// Templated values like `{manifest.github.review_assignees}` are NOT
+    /// resolvable by `tm issue` (it has no manifest), so they are treated as
+    /// `unchanged` (no-op) rather than guessed — the consuming harness owns
+    /// creation-time assignment.
+    /// Test: `sm_assignee_unchanged`, `sm_assignee_self`, `sm_assignee_none`,
+    /// `sm_assignee_template_is_noop`.
+    pub(crate) fn assignee_target_for(&self, state: &str) -> Option<AssigneeTarget> {
+        let rule = self.model.assignee_model.per_state.get(state)?;
+        // The rule is a YAML mapping `{ assignees: <value>, description?: ... }`.
+        let value = rule.get("assignees")?;
+        let s = value.as_str()?.trim();
+        match s {
+            "unchanged" => None,
+            "self" | "me" | "@me" => Some(AssigneeTarget::SelfUser),
+            "none" | "unassigned" | "" => Some(AssigneeTarget::None),
+            // A `{template}` we cannot resolve → no-op (harness owns it).
+            t if t.starts_with('{') => None,
+            // A bare login literal.
+            literal => Some(AssigneeTarget::Login(literal.to_string())),
+        }
+    }
+}
+
+/// The outcome of resolving an issue's current state from its labels.
+///
+/// Why: the three cases drive different behavior (proceed / error / repair-hint).
+/// What: `None` (no state label), `One(state)`, `Many(states)`.
+/// Test: produced by `resolve_current_state` tests.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CurrentState<'a> {
+    /// No state label present on the issue.
+    None,
+    /// Exactly one state label present (the healthy case).
+    One(&'a str),
+    /// Multiple state labels present (mid-transition; needs `repair`).
+    Many(Vec<&'a str>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::DEFAULT_MODEL_YAML;
+    use super::*;
+
+    fn model() -> StateModel {
+        serde_yaml::from_str(DEFAULT_MODEL_YAML).expect("default parses")
+    }
+
+    #[test]
+    fn sm_state_label() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        assert_eq!(sm.state_label("queued"), Some("unicorn:queued"));
+        assert_eq!(sm.state_label("nope"), None);
+    }
+
+    #[test]
+    fn sm_is_state() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        assert!(sm.is_state("approved"));
+        assert!(!sm.is_state("in-review"));
+    }
+
+    #[test]
+    fn sm_state_names() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        assert!(sm.state_names().contains(&"failed"));
+        assert_eq!(sm.state_names().len(), 7);
+    }
+
+    #[test]
+    fn sm_transition_allowed() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        // Creation edge.
+        assert!(sm.transition_allowed(None, "queued"));
+        // Happy path.
+        assert!(sm.transition_allowed(Some("queued"), "approved"));
+        assert!(sm.transition_allowed(Some("approved"), "active-development"));
+        assert!(sm.transition_allowed(Some("active-development"), "done"));
+        assert!(sm.transition_allowed(Some("active-development"), "failed"));
+        // Halt edges.
+        assert!(sm.transition_allowed(Some("active-development"), "paused"));
+        assert!(sm.transition_allowed(Some("active-development"), "blocked"));
+    }
+
+    #[test]
+    fn sm_transition_rejects_unlisted() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        // Terminal → anything is rejected.
+        assert!(!sm.transition_allowed(Some("done"), "active-development"));
+        // Skipping the gate is rejected.
+        assert!(!sm.transition_allowed(Some("queued"), "done"));
+        // Backwards is rejected.
+        assert!(!sm.transition_allowed(Some("approved"), "queued"));
+    }
+
+    #[test]
+    fn sm_allowed_targets_from() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        let mut from_active = sm.allowed_targets_from(Some("active-development"));
+        from_active.sort_unstable();
+        assert_eq!(from_active, vec!["blocked", "done", "failed", "paused"]);
+        assert!(sm.allowed_targets_from(Some("done")).is_empty());
+    }
+
+    #[test]
+    fn sm_resolve_one() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        let labels = vec!["unicorn".to_string(), "unicorn:approved".to_string()];
+        assert_eq!(
+            sm.resolve_current_state(&labels),
+            CurrentState::One("approved")
+        );
+    }
+
+    #[test]
+    fn sm_resolve_none() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        let labels = vec!["unicorn".to_string(), "blast:high".to_string()];
+        assert_eq!(sm.resolve_current_state(&labels), CurrentState::None);
+    }
+
+    #[test]
+    fn sm_resolve_many() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        let labels = vec!["unicorn:queued".to_string(), "unicorn:approved".to_string()];
+        match sm.resolve_current_state(&labels) {
+            CurrentState::Many(v) => {
+                assert!(v.contains(&"queued") && v.contains(&"approved"));
+            }
+            other => panic!("expected Many, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sm_assignee_unchanged() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        // Every non-initial factory state is `unchanged` → no mutation.
+        assert_eq!(sm.assignee_target_for("approved"), None);
+        assert_eq!(sm.assignee_target_for("done"), None);
+    }
+
+    #[test]
+    fn sm_assignee_template_is_noop() {
+        let m = model();
+        let sm = StateMachine::new(&m);
+        // `queued` carries a `{manifest...}` template — tm cannot resolve it,
+        // so it is a no-op rather than a guess.
+        assert_eq!(sm.assignee_target_for("queued"), None);
+    }
+
+    #[test]
+    fn sm_assignee_self_and_none() {
+        // Build a tiny synthetic model to exercise the non-factory rules.
+        let yaml = r#"
+version: 1
+label_config: { base: x, approved: x:a, blast_prefix: "b:", status_prefix: "x:" }
+states:
+  - { name: open, label: { name: "x:open", color: "AABBCC" } }
+  - { name: closed, label: { name: "x:closed", color: "AABBCC" }, terminal: true }
+transitions:
+  - { from: null, to: open, trigger: issue_created }
+  - { from: open, to: closed, trigger: human_label }
+assignee_model:
+  strategy: self
+  per_state:
+    open:
+      assignees: self
+    closed:
+      assignees: none
+"#;
+        let m: StateModel = serde_yaml::from_str(yaml).expect("synthetic parses");
+        let sm = StateMachine::new(&m);
+        assert_eq!(
+            sm.assignee_target_for("open"),
+            Some(AssigneeTarget::SelfUser)
+        );
+        assert_eq!(sm.assignee_target_for("closed"), Some(AssigneeTarget::None));
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/validate.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/validate.rs
@@ -1,0 +1,316 @@
+//! Load-time validation of the issue state model (#1246, RFC §4.1).
+//!
+//! Why: an invalid model must be rejected with a clear, actionable error
+//! *before* any `gh` mutation, so bad config never half-applies to GitHub. A
+//! structured [`ModelError`] (`thiserror`) gives each failure mode a precise
+//! message and keeps the checks testable in isolation.
+//! What: [`validate_model`] runs every load-time rule — known version, unique
+//! state names, transition refs resolve, 6-hex colors, generic terminal-edge
+//! check, and `bot` strategy requires an identity.
+//! Test: the `validate_*` tests in this file cover each rejection path.
+
+use std::collections::BTreeSet;
+
+use super::config::{SUPPORTED_VERSION, StateModel};
+
+/// Structured validation failures for the issue state model.
+///
+/// Why: distinct variants let callers (and tests) assert the exact failure, and
+/// `thiserror` renders user-facing messages without a manual `Display` impl.
+/// What: one variant per load-time rule in RFC §4.1.
+/// Test: each variant is produced by a `validate_*` test below.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum ModelError {
+    /// `version` is not the supported value.
+    #[error("unsupported schema version {found}; this build supports version {supported}")]
+    UnsupportedVersion {
+        /// The version found in the YAML.
+        found: u32,
+        /// The version this build supports.
+        supported: u32,
+    },
+
+    /// The model declares no states.
+    #[error("state model has no states; at least one state is required")]
+    NoStates,
+
+    /// A state name appears more than once.
+    #[error("duplicate state name `{0}`; state names must be unique")]
+    DuplicateState(String),
+
+    /// A transition references a state that does not exist.
+    #[error("transition {from} → `{to}` references unknown state `{missing}`")]
+    DanglingTransition {
+        /// Rendered source (`null` or the state name).
+        from: String,
+        /// The declared destination.
+        to: String,
+        /// The name that did not resolve.
+        missing: String,
+    },
+
+    /// A color is not a 6-hex-digit string.
+    #[error("label `{label}` has invalid color `{color}`; expected 6 hex digits with no `#`")]
+    BadColor {
+        /// The label whose color is invalid.
+        label: String,
+        /// The offending color value.
+        color: String,
+    },
+
+    /// A terminal state has an outbound transition.
+    #[error("terminal state `{0}` must have no outbound transitions")]
+    TerminalHasOutbound(String),
+
+    /// The `bot` strategy was selected without an identity.
+    #[error("assignee strategy `bot` requires an `identity_pattern` (or `identity_example`)")]
+    BotStrategyMissingIdentity,
+}
+
+/// Whether `s` is exactly six hexadecimal digits (no `#`).
+///
+/// Why: GitHub label colors are 6-hex with no leading `#`; centralising the
+/// check keeps state and extra labels consistent.
+/// What: returns `true` iff `s.len() == 6` and every char is an ASCII hex digit.
+/// Test: exercised via `validate_rejects_bad_hex` and `validate_default_ok`.
+fn is_six_hex(s: &str) -> bool {
+    s.len() == 6 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Validate the whole state model against the RFC §4.1 rules.
+///
+/// Why: the single gate every loader calls; returning `anyhow::Result` lets it
+/// compose with the binary's error flow while the structured [`ModelError`] is
+/// preserved as the source.
+/// What: checks version, non-empty + unique states, transition ref integrity,
+/// 6-hex colors (states + extra labels), terminal states have no outbound edge,
+/// and (for the `bot` strategy) an identity is present.
+/// Test: `validate_default_ok` and the `validate_rejects_*` tests.
+pub(crate) fn validate_model(model: &StateModel) -> anyhow::Result<()> {
+    validate_model_inner(model).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// The inner validator returning the structured error (testable directly).
+///
+/// Why: tests assert exact [`ModelError`] variants; keeping the structured
+/// return here while [`validate_model`] adapts to `anyhow` serves both callers.
+/// What: see [`validate_model`].
+/// Test: the `validate_*` tests call this directly.
+fn validate_model_inner(model: &StateModel) -> Result<(), ModelError> {
+    // 1. Version.
+    if model.version != SUPPORTED_VERSION {
+        return Err(ModelError::UnsupportedVersion {
+            found: model.version,
+            supported: SUPPORTED_VERSION,
+        });
+    }
+
+    // 2. Non-empty + unique state names.
+    if model.states.is_empty() {
+        return Err(ModelError::NoStates);
+    }
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for s in &model.states {
+        if !seen.insert(s.name.as_str()) {
+            return Err(ModelError::DuplicateState(s.name.clone()));
+        }
+    }
+
+    // 3. Transition refs resolve (null source is only allowed as the entry edge).
+    for t in &model.transitions {
+        if let Some(from) = &t.from
+            && !seen.contains(from.as_str())
+        {
+            return Err(ModelError::DanglingTransition {
+                from: format!("`{from}`"),
+                to: t.to.clone(),
+                missing: from.clone(),
+            });
+        }
+        if !seen.contains(t.to.as_str()) {
+            return Err(ModelError::DanglingTransition {
+                from: t
+                    .from
+                    .as_ref()
+                    .map(|f| format!("`{f}`"))
+                    .unwrap_or_else(|| "null".to_string()),
+                to: t.to.clone(),
+                missing: t.to.clone(),
+            });
+        }
+    }
+
+    // 4. Colors are 6-hex (states + extra labels).
+    for s in &model.states {
+        if !is_six_hex(&s.label.color) {
+            return Err(ModelError::BadColor {
+                label: s.label.name.clone(),
+                color: s.label.color.clone(),
+            });
+        }
+    }
+    for l in &model.extra_labels {
+        if !is_six_hex(&l.color) {
+            return Err(ModelError::BadColor {
+                label: l.name.clone(),
+                color: l.color.clone(),
+            });
+        }
+    }
+
+    // 5. Generic terminal check: NO transition may have `from == <terminal state>`
+    //    (for EVERY terminal state, not just hardcoded done/failed).
+    for s in &model.states {
+        if s.terminal
+            && model
+                .transitions
+                .iter()
+                .any(|t| t.from.as_deref() == Some(s.name.as_str()))
+        {
+            return Err(ModelError::TerminalHasOutbound(s.name.clone()));
+        }
+    }
+
+    // 6. `bot` strategy requires an identity.
+    if model.assignee_model.strategy == "bot"
+        && model.assignee_model.identity_pattern.is_none()
+        && model.assignee_model.identity_example.is_none()
+    {
+        return Err(ModelError::BotStrategyMissingIdentity);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::DEFAULT_MODEL_YAML;
+    use super::*;
+
+    fn default_model() -> StateModel {
+        serde_yaml::from_str(DEFAULT_MODEL_YAML).expect("default parses")
+    }
+
+    #[test]
+    fn validate_default_ok() {
+        assert!(validate_model_inner(&default_model()).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_version() {
+        let mut m = default_model();
+        m.version = 99;
+        assert_eq!(
+            validate_model_inner(&m),
+            Err(ModelError::UnsupportedVersion {
+                found: 99,
+                supported: SUPPORTED_VERSION
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_states() {
+        let mut m = default_model();
+        let dup = m.states[0].clone();
+        m.states.push(dup);
+        let name = m.states[0].name.clone();
+        assert_eq!(
+            validate_model_inner(&m),
+            Err(ModelError::DuplicateState(name))
+        );
+    }
+
+    #[test]
+    fn validate_rejects_dangling_transition_to() {
+        let mut m = default_model();
+        m.transitions[1].to = "nonexistent".to_string();
+        let err = validate_model_inner(&m).unwrap_err();
+        assert!(
+            matches!(err, ModelError::DanglingTransition { ref missing, .. } if missing == "nonexistent"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_dangling_transition_from() {
+        let mut m = default_model();
+        m.transitions[1].from = Some("ghost".to_string());
+        let err = validate_model_inner(&m).unwrap_err();
+        assert!(
+            matches!(err, ModelError::DanglingTransition { ref missing, .. } if missing == "ghost"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_bad_hex() {
+        let mut m = default_model();
+        m.states[0].label.color = "ZZZ".to_string();
+        let err = validate_model_inner(&m).unwrap_err();
+        assert!(matches!(err, ModelError::BadColor { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn validate_rejects_bad_hex_in_extra_label() {
+        let mut m = default_model();
+        m.extra_labels[0].color = "12345".to_string(); // 5 digits
+        let err = validate_model_inner(&m).unwrap_err();
+        assert!(matches!(err, ModelError::BadColor { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn validate_rejects_terminal_with_outbound_edge() {
+        // Add an edge OUT of the terminal `done` state — must be rejected
+        // generically (not via a hardcoded done/failed list).
+        let mut m = default_model();
+        m.transitions.push(super::super::config::Transition {
+            from: Some("done".to_string()),
+            to: "queued".to_string(),
+            trigger: super::super::config::Trigger::HumanLabel,
+            description: String::new(),
+        });
+        assert_eq!(
+            validate_model_inner(&m),
+            Err(ModelError::TerminalHasOutbound("done".to_string()))
+        );
+    }
+
+    #[test]
+    fn validate_rejects_terminal_with_outbound_edge_for_any_state() {
+        // Mark a non-default state terminal and give it an outbound edge to prove
+        // the check is generic across ALL terminal states.
+        let mut m = default_model();
+        // Make `approved` terminal; it has an outbound edge to active-development.
+        for s in &mut m.states {
+            if s.name == "approved" {
+                s.terminal = true;
+            }
+        }
+        assert_eq!(
+            validate_model_inner(&m),
+            Err(ModelError::TerminalHasOutbound("approved".to_string()))
+        );
+    }
+
+    #[test]
+    fn validate_rejects_bot_strategy_without_identity() {
+        let mut m = default_model();
+        m.assignee_model.strategy = "bot".to_string();
+        m.assignee_model.identity_pattern = None;
+        m.assignee_model.identity_example = None;
+        assert_eq!(
+            validate_model_inner(&m),
+            Err(ModelError::BotStrategyMissingIdentity)
+        );
+    }
+
+    #[test]
+    fn validate_accepts_bot_strategy_with_identity() {
+        let mut m = default_model();
+        m.assignee_model.strategy = "bot".to_string();
+        m.assignee_model.identity_pattern = Some("{user}-bot".to_string());
+        m.assignee_model.identity_example = None;
+        assert!(validate_model_inner(&m).is_ok());
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -10,6 +10,7 @@
 
 pub(crate) mod daemon;
 pub(crate) mod install;
+pub(crate) mod issue;
 pub(crate) mod launch;
 pub(crate) mod managed;
 pub(crate) mod misc;

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
@@ -1,0 +1,431 @@
+//! Repo-label and assignee value types plus the `gh`-backed primitives that the
+//! extended [`super::system::TicketSystem`] uses for the `tm issue` verbs.
+//!
+//! Why: #1246 extends the ticket backend with label seeding (list/create) and
+//! issue-level label/assignee mutation. Keeping the value types ([`RepoLabel`],
+//! [`AssigneeTarget`]) and the `gh`-invocation free functions here — rather than
+//! inflating `system.rs` past the 500-SLOC production cap — lets the
+//! `GhTicketSystem` trait impl stay a thin delegation while all the `gh` wiring
+//! (and its `FakeRunner` tests) live in one focused module.
+//! What: the [`RepoLabel`] (name/color/description) and [`AssigneeTarget`]
+//! (self/login/none) types, and the `gh_*` helpers (`gh_list_repo_labels`,
+//! `gh_create_label`, `gh_add_label`, `gh_remove_label`, `gh_swap_labels`,
+//! `gh_set_assignee`) that drive `gh` through the injected [`CommandRunner`].
+//! Test: the `gh_*` unit tests in this file drive a `FakeRunner` (no live `gh`).
+
+use serde::Deserialize;
+
+use super::runner::CommandRunner;
+
+/// A repository label as it exists (or should exist) on GitHub.
+///
+/// Why: seeding (`tm issue seed-labels`) is create-missing against the repo's
+/// label set, so both the "what the YAML wants" and "what the repo has" sides
+/// need the same name/color/description shape for a diff.
+/// What: the label `name`, its 6-hex `color` (no leading `#`), and an optional
+/// `description`.
+/// Test: round-tripped through `gh_list_repo_labels` parsing in
+/// `gh_list_repo_labels_parses`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct RepoLabel {
+    /// Label name (e.g. `unicorn:queued`).
+    pub(crate) name: String,
+    /// 6-hex color, no `#` (e.g. `BFD4F2`). `gh label list` returns it without `#`.
+    #[serde(default)]
+    pub(crate) color: String,
+    /// Optional human description shown in the GitHub label UI.
+    #[serde(default)]
+    pub(crate) description: String,
+}
+
+/// The effective assignee mutation a transition should apply.
+///
+/// Why: per-state assignee rules resolve to one of three generic GitHub
+/// operations; modelling them as an enum keeps `set_assignee` total and its
+/// `gh` mapping (§5.4 of the RFC) explicit and testable.
+/// What: `SelfUser` assigns the authenticated `gh` user; `Login(l)` assigns a
+/// named login; `None` clears all current assignees (read-then-remove).
+/// Test: `gh_set_assignee_self`, `gh_set_assignee_login`,
+/// `gh_set_assignee_none_*`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AssigneeTarget {
+    /// Assign the authenticated `gh` user (`gh api user` → `--add-assignee`).
+    SelfUser,
+    /// Assign a specific GitHub login.
+    Login(String),
+    /// Clear all assignees (read current set, then `--remove-assignee` each).
+    None,
+}
+
+/// `gh label list --json name,color,description` → existing repo labels.
+///
+/// Why: idempotent seeding needs the current label set so only missing labels
+/// are created (and present ones are left untouched).
+/// What: runs `gh label list` through `runner`, parses the JSON array into
+/// [`RepoLabel`]s; surfaces an actionable error on `gh` failure or bad JSON.
+/// Test: `gh_list_repo_labels_parses`, `gh_list_repo_labels_errors`.
+pub(crate) fn gh_list_repo_labels<R: CommandRunner>(runner: &R) -> anyhow::Result<Vec<RepoLabel>> {
+    let out = runner.run("gh", &["label", "list", "--json", "name,color,description"])?;
+    let json = out.ok_or_stderr("gh label list")?;
+    if json.is_empty() {
+        return Ok(Vec::new());
+    }
+    let labels: Vec<RepoLabel> = serde_json::from_str(&json)
+        .map_err(|e| anyhow::anyhow!("failed to parse `gh label list` JSON: {e}"))?;
+    Ok(labels)
+}
+
+/// `gh label create <name> --color <hex> --description <desc>`.
+///
+/// Why: the create-missing half of seeding; the caller decides *whether* to
+/// create (post-diff), this just performs one creation.
+/// What: invokes `gh label create` with the label's color/description (omitting
+/// the `--description` flag when empty); maps failure to an `anyhow` error.
+/// Test: `gh_create_label_invokes_create`,
+/// `gh_create_label_omits_empty_description`.
+pub(crate) fn gh_create_label<R: CommandRunner>(
+    runner: &R,
+    label: &RepoLabel,
+) -> anyhow::Result<()> {
+    let mut args: Vec<&str> = vec!["label", "create", &label.name];
+    if !label.color.is_empty() {
+        args.push("--color");
+        args.push(&label.color);
+    }
+    if !label.description.is_empty() {
+        args.push("--description");
+        args.push(&label.description);
+    }
+    runner.run("gh", &args)?.ok_or_stderr("gh label create")?;
+    Ok(())
+}
+
+/// `gh issue edit <n> --add-label <label>`.
+///
+/// Why: a transition-fallback primitive (the single-call swap is preferred;
+/// `add_label` is the degraded two-call path and a building block for other ops).
+/// What: adds one label to an issue via `gh issue edit`.
+/// Test: `gh_add_label_invokes_edit`.
+pub(crate) fn gh_add_label<R: CommandRunner>(
+    runner: &R,
+    issue: u64,
+    label: &str,
+) -> anyhow::Result<()> {
+    let n = issue.to_string();
+    runner
+        .run("gh", &["issue", "edit", &n, "--add-label", label])?
+        .ok_or_stderr("gh issue edit")?;
+    Ok(())
+}
+
+/// `gh issue edit <n> --remove-label <label>`.
+///
+/// Why: the remove half of the two-call fallback and the `repair` primitive for
+/// dropping a stale state label.
+/// What: removes one label from an issue via `gh issue edit`.
+/// Test: `gh_remove_label_invokes_edit`.
+pub(crate) fn gh_remove_label<R: CommandRunner>(
+    runner: &R,
+    issue: u64,
+    label: &str,
+) -> anyhow::Result<()> {
+    let n = issue.to_string();
+    runner
+        .run("gh", &["issue", "edit", &n, "--remove-label", label])?
+        .ok_or_stderr("gh issue edit")?;
+    Ok(())
+}
+
+/// Single-call atomic label swap (the transition default, RFC §5.2).
+///
+/// Why: `gh issue edit --add-label NEW --remove-label OLD` applies both in one
+/// invocation, so the issue is never observed carrying both labels or neither —
+/// the tightest atomicity `gh` offers and the form aligned with the visibility
+/// north star. Collapsing to one recorded call also simplifies the test.
+/// What: runs the combined add/remove `gh issue edit` in one call.
+/// Test: `gh_swap_labels_single_call`.
+pub(crate) fn gh_swap_labels<R: CommandRunner>(
+    runner: &R,
+    issue: u64,
+    add: &str,
+    remove: &str,
+) -> anyhow::Result<()> {
+    let n = issue.to_string();
+    runner
+        .run(
+            "gh",
+            &[
+                "issue",
+                "edit",
+                &n,
+                "--add-label",
+                add,
+                "--remove-label",
+                remove,
+            ],
+        )?
+        .ok_or_stderr("gh issue edit")?;
+    Ok(())
+}
+
+/// Apply an [`AssigneeTarget`] to an issue (RFC §5.4 exact `gh` semantics).
+///
+/// Why: per-state assignee rules must map to concrete, observable GitHub
+/// mutations. The subtlety is `None` (clear-all): `gh issue edit
+/// --remove-assignee` needs an explicit login, so clearing first reads the
+/// current assignee set and removes each by login.
+/// What: `SelfUser` → `gh api user --jq .login` then `--add-assignee <login>`;
+/// `Login` → `--add-assignee <login>`; `None` → for each of `current_assignees`,
+/// `--remove-assignee <login>` (a no-op `gh`-call-free when the set is empty).
+///
+/// TOCTOU NOTE: the `None` (clear-all) rule is read-then-remove and is therefore
+/// NOT atomic — an assignee added between the caller's read of `current_assignees`
+/// and these `--remove-assignee` calls will survive. This is inherent to `gh`'s
+/// lack of a "clear all assignees" primitive; the factory default never exercises
+/// this path (all per-state rules are `unchanged`), so the window is unreachable
+/// for the only current consumer.
+/// Test: `gh_set_assignee_self`, `gh_set_assignee_login`,
+/// `gh_set_assignee_none_removes_each`, `gh_set_assignee_none_empty_is_noop`.
+pub(crate) fn gh_set_assignee<R: CommandRunner>(
+    runner: &R,
+    issue: u64,
+    who: &AssigneeTarget,
+    current_assignees: &[String],
+) -> anyhow::Result<()> {
+    let n = issue.to_string();
+    match who {
+        AssigneeTarget::SelfUser => {
+            let login = runner
+                .run("gh", &["api", "user", "--jq", ".login"])?
+                .ok_or_stderr("gh api user")?;
+            if login.is_empty() {
+                anyhow::bail!("could not resolve the authenticated `gh` user for self-assignment");
+            }
+            runner
+                .run("gh", &["issue", "edit", &n, "--add-assignee", &login])?
+                .ok_or_stderr("gh issue edit")?;
+        }
+        AssigneeTarget::Login(login) => {
+            runner
+                .run("gh", &["issue", "edit", &n, "--add-assignee", login])?
+                .ok_or_stderr("gh issue edit")?;
+        }
+        AssigneeTarget::None => {
+            for login in current_assignees {
+                runner
+                    .run("gh", &["issue", "edit", &n, "--remove-assignee", login])?
+                    .ok_or_stderr("gh issue edit")?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::runner::{CommandOutput, CommandRunner};
+    use super::*;
+    use std::cell::RefCell;
+
+    /// Scripted [`CommandRunner`] recording `(program, args)` per call.
+    struct FakeRunner {
+        outputs: RefCell<Vec<CommandOutput>>,
+        calls: RefCell<Vec<(String, Vec<String>)>>,
+    }
+
+    impl FakeRunner {
+        fn new(outputs: Vec<CommandOutput>) -> Self {
+            Self {
+                outputs: RefCell::new(outputs),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+        fn calls(&self) -> Vec<(String, Vec<String>)> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, program: &str, args: &[&str]) -> anyhow::Result<CommandOutput> {
+            self.calls.borrow_mut().push((
+                program.to_string(),
+                args.iter().map(|a| a.to_string()).collect(),
+            ));
+            let mut outs = self.outputs.borrow_mut();
+            if outs.is_empty() {
+                anyhow::bail!("FakeRunner exhausted")
+            }
+            Ok(outs.remove(0))
+        }
+    }
+
+    fn ok_out(stdout: &str) -> CommandOutput {
+        CommandOutput {
+            success: true,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    fn fail_out(stderr: &str) -> CommandOutput {
+        CommandOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    #[test]
+    fn gh_list_repo_labels_parses() {
+        let json = r#"[{"name":"unicorn:queued","color":"BFD4F2","description":"Queued"}]"#;
+        let r = FakeRunner::new(vec![ok_out(json)]);
+        let labels = gh_list_repo_labels(&r).expect("parse");
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].name, "unicorn:queued");
+        assert_eq!(labels[0].color, "BFD4F2");
+        assert_eq!(labels[0].description, "Queued");
+        assert_eq!(
+            r.calls()[0].1,
+            vec!["label", "list", "--json", "name,color,description"]
+        );
+    }
+
+    #[test]
+    fn gh_list_repo_labels_empty_is_empty() {
+        let r = FakeRunner::new(vec![ok_out("")]);
+        assert!(gh_list_repo_labels(&r).expect("empty ok").is_empty());
+    }
+
+    #[test]
+    fn gh_list_repo_labels_errors() {
+        let r = FakeRunner::new(vec![fail_out("not a repo")]);
+        assert!(gh_list_repo_labels(&r).is_err());
+    }
+
+    #[test]
+    fn gh_create_label_invokes_create() {
+        let r = FakeRunner::new(vec![ok_out("")]);
+        let label = RepoLabel {
+            name: "unicorn:done".to_string(),
+            color: "0075CA".to_string(),
+            description: "Done".to_string(),
+        };
+        gh_create_label(&r, &label).expect("create");
+        assert_eq!(
+            r.calls()[0].1,
+            vec![
+                "label",
+                "create",
+                "unicorn:done",
+                "--color",
+                "0075CA",
+                "--description",
+                "Done"
+            ]
+        );
+    }
+
+    #[test]
+    fn gh_create_label_omits_empty_description() {
+        let r = FakeRunner::new(vec![ok_out("")]);
+        let label = RepoLabel {
+            name: "T4".to_string(),
+            color: "0075CA".to_string(),
+            description: String::new(),
+        };
+        gh_create_label(&r, &label).expect("create");
+        let args = &r.calls()[0].1;
+        assert!(!args.iter().any(|a| a == "--description"));
+        assert!(args.iter().any(|a| a == "--color"));
+    }
+
+    #[test]
+    fn gh_add_label_invokes_edit() {
+        let r = FakeRunner::new(vec![ok_out("")]);
+        gh_add_label(&r, 42, "unicorn:approved").expect("add");
+        assert_eq!(
+            r.calls()[0].1,
+            vec!["issue", "edit", "42", "--add-label", "unicorn:approved"]
+        );
+    }
+
+    #[test]
+    fn gh_remove_label_invokes_edit() {
+        let r = FakeRunner::new(vec![ok_out("")]);
+        gh_remove_label(&r, 42, "unicorn:queued").expect("remove");
+        assert_eq!(
+            r.calls()[0].1,
+            vec!["issue", "edit", "42", "--remove-label", "unicorn:queued"]
+        );
+    }
+
+    #[test]
+    fn gh_swap_labels_single_call() {
+        let r = FakeRunner::new(vec![ok_out("")]);
+        gh_swap_labels(&r, 7, "unicorn:approved", "unicorn:queued").expect("swap");
+        let calls = r.calls();
+        assert_eq!(calls.len(), 1, "swap must be a single gh call");
+        assert_eq!(
+            calls[0].1,
+            vec![
+                "issue",
+                "edit",
+                "7",
+                "--add-label",
+                "unicorn:approved",
+                "--remove-label",
+                "unicorn:queued"
+            ]
+        );
+    }
+
+    #[test]
+    fn gh_set_assignee_self() {
+        // First call resolves the login, second adds it.
+        let r = FakeRunner::new(vec![ok_out("octocat"), ok_out("")]);
+        gh_set_assignee(&r, 7, &AssigneeTarget::SelfUser, &[]).expect("self");
+        let calls = r.calls();
+        assert_eq!(calls[0].1, vec!["api", "user", "--jq", ".login"]);
+        assert_eq!(
+            calls[1].1,
+            vec!["issue", "edit", "7", "--add-assignee", "octocat"]
+        );
+    }
+
+    #[test]
+    fn gh_set_assignee_login() {
+        let r = FakeRunner::new(vec![ok_out("")]);
+        gh_set_assignee(&r, 7, &AssigneeTarget::Login("alice".to_string()), &[]).expect("login");
+        assert_eq!(
+            r.calls()[0].1,
+            vec!["issue", "edit", "7", "--add-assignee", "alice"]
+        );
+    }
+
+    #[test]
+    fn gh_set_assignee_none_removes_each() {
+        let r = FakeRunner::new(vec![ok_out(""), ok_out("")]);
+        let current = vec!["alice".to_string(), "bob".to_string()];
+        gh_set_assignee(&r, 7, &AssigneeTarget::None, &current).expect("none");
+        let calls = r.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(
+            calls[0].1,
+            vec!["issue", "edit", "7", "--remove-assignee", "alice"]
+        );
+        assert_eq!(
+            calls[1].1,
+            vec!["issue", "edit", "7", "--remove-assignee", "bob"]
+        );
+    }
+
+    #[test]
+    fn gh_set_assignee_none_empty_is_noop() {
+        let r = FakeRunner::new(vec![]);
+        gh_set_assignee(&r, 7, &AssigneeTarget::None, &[]).expect("noop");
+        assert!(
+            r.calls().is_empty(),
+            "empty assignee set must make zero gh calls"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
@@ -15,6 +15,7 @@
 //! sibling modules; CLI parsing in `tests.rs`.
 
 pub(crate) mod branch;
+pub(crate) mod labels;
 pub(crate) mod runner;
 pub(crate) mod system;
 
@@ -344,6 +345,7 @@ mod tests {
             title: "Add the thing".to_string(),
             body: "do the thing properly".to_string(),
             labels: vec!["enhancement".to_string()],
+            assignees: vec![],
             open: true,
         };
         let task = build_task(&issue, "feat/1232-add-the-thing", "main");
@@ -362,6 +364,7 @@ mod tests {
             title: "Fix it".to_string(),
             body: "   ".to_string(),
             labels: vec![],
+            assignees: vec![],
             open: true,
         };
         let task = build_task(&issue, "feat/7-fix-it", "main");
@@ -377,6 +380,7 @@ mod tests {
             title: "Do thing".to_string(),
             body: "body".to_string(),
             labels: vec![],
+            assignees: vec![],
             open: true,
         };
         let task = build_task(&issue, "feat/9-do-thing", "master");

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/system.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/system.rs
@@ -14,6 +14,10 @@ use clap::ValueEnum;
 use serde::Deserialize;
 
 use super::branch::derive_branch_name;
+use super::labels::{
+    AssigneeTarget, RepoLabel, gh_add_label, gh_create_label, gh_list_repo_labels, gh_remove_label,
+    gh_set_assignee, gh_swap_labels,
+};
 use super::runner::CommandRunner;
 
 /// Which ticketing backend `tm ticket` should use.
@@ -52,6 +56,9 @@ pub(crate) struct Issue {
     pub(crate) body: String,
     /// Label names (drive the conventional-commit branch type).
     pub(crate) labels: Vec<String>,
+    /// Current GitHub assignee logins (the read side of the assignee model;
+    /// needed by `set_assignee`'s `None` clear-all rule — RFC §5.4).
+    pub(crate) assignees: Vec<String>,
     /// Whether the issue is OPEN (closed issues are refused).
     pub(crate) open: bool,
 }
@@ -88,6 +95,49 @@ pub(crate) trait TicketSystem {
 
     /// Post a comment on the issue for the audit trail.
     fn comment(&self, issue_number: u64, body: &str) -> anyhow::Result<()>;
+
+    // --- NEW for #1246: label/assignee write side -----------------------------
+    //
+    // Each ships with a default body that ERRORS so the `Jira`/`Linear` stubs
+    // keep compiling unchanged; `GhTicketSystem` overrides all of them. A future
+    // `tm issue` run against a non-`gh` backend fails loudly and legibly rather
+    // than silently. (RFC §3.3.)
+
+    /// List labels that already exist in the repo (for idempotent seeding).
+    fn list_repo_labels(&self) -> anyhow::Result<Vec<RepoLabel>> {
+        anyhow::bail!("list_repo_labels not supported for this ticket system")
+    }
+
+    /// Create a label in the repo (create-missing half of seeding).
+    fn create_label(&self, _label: &RepoLabel) -> anyhow::Result<()> {
+        anyhow::bail!("create_label not supported for this ticket system")
+    }
+
+    /// Add one label to an issue (two-call transition fallback primitive).
+    fn add_label(&self, _issue: u64, _label: &str) -> anyhow::Result<()> {
+        anyhow::bail!("add_label not supported for this ticket system")
+    }
+
+    /// Remove one label from an issue (`repair`/fallback primitive).
+    fn remove_label(&self, _issue: u64, _label: &str) -> anyhow::Result<()> {
+        anyhow::bail!("remove_label not supported for this ticket system")
+    }
+
+    /// Atomic single-call label swap (the transition default — RFC §5.2).
+    fn swap_labels(&self, _issue: u64, _add: &str, _remove: &str) -> anyhow::Result<()> {
+        anyhow::bail!("swap_labels not supported for this ticket system")
+    }
+
+    /// Apply an assignee rule to an issue; `current` is the issue's existing
+    /// assignee set (needed for the `None` clear-all rule — RFC §5.4).
+    fn set_assignee(
+        &self,
+        _issue: u64,
+        _who: &AssigneeTarget,
+        _current: &[String],
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("set_assignee not supported for this ticket system")
+    }
 }
 
 /// GitHub-backed [`TicketSystem`] driving the `gh` CLI.
@@ -131,6 +181,20 @@ struct GhIssueJson {
     state: String,
     #[serde(default)]
     labels: Vec<GhLabel>,
+    #[serde(default)]
+    assignees: Vec<GhAssignee>,
+}
+
+/// A single assignee object in the gh issue JSON.
+///
+/// Why: gh returns assignees as objects with a `login` field; the `None`
+/// clear-all assignee rule (RFC §5.4) needs those logins.
+/// What: captures just the `login`.
+/// Test: parsed in `gh_validate_parses_assignees`.
+#[derive(Debug, Deserialize)]
+struct GhAssignee {
+    #[serde(default)]
+    login: String,
 }
 
 /// A single label object in the gh issue JSON.
@@ -158,7 +222,7 @@ impl<R: CommandRunner> TicketSystem for GhTicketSystem<R> {
                 "view",
                 &number,
                 "--json",
-                "number,title,body,state,labels",
+                "number,title,body,state,labels,assignees",
             ],
         )?;
         if !out.success {
@@ -192,6 +256,7 @@ impl<R: CommandRunner> TicketSystem for GhTicketSystem<R> {
             title: parsed.title,
             body: parsed.body,
             labels: parsed.labels.into_iter().map(|l| l.name).collect(),
+            assignees: parsed.assignees.into_iter().map(|a| a.login).collect(),
             open,
         })
     }
@@ -203,6 +268,37 @@ impl<R: CommandRunner> TicketSystem for GhTicketSystem<R> {
             .run("gh", &["issue", "comment", &number, "--body", body])?;
         out.ok_or_stderr("gh issue comment")?;
         Ok(())
+    }
+
+    // --- #1246 gh-backed overrides: thin delegation to the `labels` helpers ----
+
+    fn list_repo_labels(&self) -> anyhow::Result<Vec<RepoLabel>> {
+        gh_list_repo_labels(&self.runner)
+    }
+
+    fn create_label(&self, label: &RepoLabel) -> anyhow::Result<()> {
+        gh_create_label(&self.runner, label)
+    }
+
+    fn add_label(&self, issue: u64, label: &str) -> anyhow::Result<()> {
+        gh_add_label(&self.runner, issue, label)
+    }
+
+    fn remove_label(&self, issue: u64, label: &str) -> anyhow::Result<()> {
+        gh_remove_label(&self.runner, issue, label)
+    }
+
+    fn swap_labels(&self, issue: u64, add: &str, remove: &str) -> anyhow::Result<()> {
+        gh_swap_labels(&self.runner, issue, add, remove)
+    }
+
+    fn set_assignee(
+        &self,
+        issue: u64,
+        who: &AssigneeTarget,
+        current: &[String],
+    ) -> anyhow::Result<()> {
+        gh_set_assignee(&self.runner, issue, who, current)
     }
 }
 
@@ -287,6 +383,7 @@ mod tests {
             title: "Add the thing".to_string(),
             body: String::new(),
             labels: vec!["enhancement".to_string()],
+            assignees: vec![],
             open: true,
         };
         assert_eq!(issue.branch_name(), "feat/1232-add-the-thing");
@@ -302,8 +399,21 @@ mod tests {
         assert_eq!(issue.body, "do it");
         assert_eq!(issue.labels, vec!["bug".to_string()]);
         assert!(issue.open);
+        // Missing `assignees` defaults to empty.
+        assert!(issue.assignees.is_empty());
         // The derived branch uses the bug label → fix.
         assert_eq!(issue.branch_name(), "fix/1232-add-the-thing");
+    }
+
+    #[test]
+    fn gh_validate_parses_assignees() {
+        let json = r#"{"number":7,"title":"t","body":"","state":"OPEN","labels":[],"assignees":[{"login":"alice"},{"login":"bob"}]}"#;
+        let sys = GhTicketSystem::new(FakeRunner::new(vec![ok_out(json)]));
+        let issue = sys.validate(7).expect("should validate");
+        assert_eq!(
+            issue.assignees,
+            vec!["alice".to_string(), "bob".to_string()]
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -260,5 +260,6 @@ async fn main() -> anyhow::Result<()> {
             notes,
             runtime,
         } => commands::ticket::ticket(&client, &url, issue, system, notes, runtime).await,
+        Command::Issue { cmd, system } => commands::issue::issue(cmd, system),
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -928,3 +928,98 @@ fn cli_rejects_ticket_unknown_system() {
     let err = Cli::try_parse_from(["trusty-mpm", "ticket", "1", "bogus"]);
     assert!(err.is_err(), "expected unknown system to be rejected");
 }
+
+#[test]
+fn cli_parses_issue_seed_labels() {
+    // Why: `tm issue seed-labels [--dry-run]` must parse with the gh default
+    // and surface the dry-run flag (#1246).
+    use crate::cli::IssueCmd;
+    let cli = Cli::try_parse_from(["trusty-mpm", "issue", "seed-labels", "--dry-run"]).unwrap();
+    match cli.command {
+        Command::Issue { cmd, .. } => match cmd {
+            IssueCmd::SeedLabels { dry_run, config } => {
+                assert!(dry_run);
+                assert!(config.is_none());
+            }
+            other => panic!("expected seed-labels, got {other:?}"),
+        },
+        other => panic!("expected issue, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_issue_transition() {
+    // Why: `tm issue transition <issue#> <to-state> [--note]` must parse the
+    // numeric issue, the target state, and the optional note (#1246).
+    use crate::cli::IssueCmd;
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "issue",
+        "transition",
+        "1232",
+        "approved",
+        "--note",
+        "approved by reviewer",
+    ])
+    .unwrap();
+    match cli.command {
+        Command::Issue { cmd, .. } => match cmd {
+            IssueCmd::Transition {
+                issue,
+                to_state,
+                note,
+                ..
+            } => {
+                assert_eq!(issue, 1232);
+                assert_eq!(to_state, "approved");
+                assert_eq!(note.as_deref(), Some("approved by reviewer"));
+            }
+            other => panic!("expected transition, got {other:?}"),
+        },
+        other => panic!("expected issue, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_issue_current_and_states_and_repair() {
+    // Why: the read/introspection/recovery verbs must all parse (#1246).
+    use crate::cli::IssueCmd;
+    let current = Cli::try_parse_from(["trusty-mpm", "issue", "current", "7"]).unwrap();
+    assert!(matches!(
+        current.command,
+        Command::Issue {
+            cmd: IssueCmd::Current { issue: 7, .. },
+            ..
+        }
+    ));
+    let states = Cli::try_parse_from(["trusty-mpm", "issue", "states"]).unwrap();
+    assert!(matches!(
+        states.command,
+        Command::Issue {
+            cmd: IssueCmd::States { .. },
+            ..
+        }
+    ));
+    let repair = Cli::try_parse_from(["trusty-mpm", "issue", "repair", "9"]).unwrap();
+    assert!(matches!(
+        repair.command,
+        Command::Issue {
+            cmd: IssueCmd::Repair { issue: 9, .. },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn cli_parses_issue_seed_config_force() {
+    // Why: `tm issue seed-config --force` must parse the overwrite flag (#1246).
+    use crate::cli::IssueCmd;
+    let cli = Cli::try_parse_from(["trusty-mpm", "issue", "seed-config", "--force"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Command::Issue {
+            cmd: IssueCmd::SeedConfig { force: true },
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
## Summary

Implements the **accepted RFC** (PR #1248) for a YAML-configurable issue
state-management subsystem in **trusty-mpm**. Externalizes the Unicorn Factory's
formerly-hardcoded issue state machine — the **label set**, the **allowed
transitions**, and the **assignee/identity model** — out of the harness into a
YAML contract owned by trusty-mpm, surfaced as `tm issue …` CLI verbs built on
the #1237/#1244 `TicketSystem`/`CommandRunner` seam. The Python harness consumes
by shelling out to `tm`; the YAML is the portable shared contract. Every verb
maps to a concrete GitHub label/assignee/comment mutation, so issue state stays
reconstructable from GitHub artifacts alone (the visibility north star).

`Closes #1246`.

## `tm issue` verb surface (gh backend; jira/linear stubbed)

| Verb | Behavior |
|---|---|
| `tm issue seed-labels [--config <path>] [--dry-run]` | Idempotent create-missing of all state + family labels. `--dry-run` makes **zero** create calls. |
| `tm issue transition <issue#> <to-state> [--config] [--note <text>]` | Validates the `from→to` edge against the model **before any gh mutation**; performs the **single-call swap** `gh issue edit <n> --add-label <new> --remove-label <old>`; applies the per-state assignee rule (no-op for the factory `unchanged` rules); posts an audit comment. |
| `tm issue current <issue#> [--config]` | Reports the current state derived from the issue's labels. |
| `tm issue states [--config]` | Lists configured states + transitions (reads YAML only, no gh). |
| `tm issue seed-config [--force]` | Writes the embedded default YAML to `~/.trusty-tools/trusty-mpm/issue-state.yaml`. |
| `tm issue repair <issue#> [--config]` | Resolves a mid-transition issue carrying multiple state labels to a single state (keeps the highest-`order` state); clear error when zero. |

## How `TicketSystem` was extended (RFC §3.3)

Six new methods — `list_repo_labels`, `create_label`, `add_label`,
`remove_label`, `swap_labels`, `set_assignee` — ship with **default bodies that
error** (`"<op> not supported for this ticket system"`), so the `Jira`/`Linear`
stubs keep compiling unchanged. `GhTicketSystem<R>` **overrides all six** via the
`CommandRunner` seam (shelling `gh`), delegating to thin `gh_*` helpers in the
new `ticket/labels.rs` (keeps `system.rs` under the SLOC cap). The `Issue` struct
gains an `assignees: Vec<String>` field, populated from
`gh issue view --json …,assignees` (needed by the `none` clear-all assignee
rule; its read-then-remove TOCTOU is documented in `gh_set_assignee`).

## Embedded default config

Committed at **`crates/trusty-mpm/examples/issue-state/unicorn-factory.yaml`** and
embedded via `include_str!` as the built-in default. Reproduces the #1246
source-confirmed model **verbatim**: `queued → approved → active-development →
done` plus `paused`/`blocked` halt states and the terminal `failed`; the full
`unicorn` / `blast:*` / `T2`–`T4` / `approval:level-*` label families with exact
colors; the `null → queued` creation edge; and an attribution-only `bot_identity`
assignee model (every per-state rule `unchanged`). **No `in-review` state.**

## Config discovery precedence (RFC §6)

`--config <path>` > `./issue-state.yaml` > `~/.trusty-tools/trusty-mpm/issue-state.yaml` > embedded default.

## Validation (load-time, before any gh call)

A `thiserror` `ModelError` enforces: known version; unique state names; every
transition `from`/`to` references an existing state (or `null` for the entry
edge); 6-hex colors (states + extra labels); a **generic** terminal check (for
**every** state with `terminal: true`, no `transitions[].from == state.name`, not
just hardcoded done/failed); `bot` strategy requires an identity.

## Tests (behind FakeRunner / FakeSystem — no live gh)

Config load + precedence; validation rejections (duplicate states, dangling
transition refs, bad hex, a terminal state with an outbound edge for **any**
state, missing bot identity); seed-labels idempotency + `--dry-run` (zero create
calls); transition happy path records the **single-call** swap and **no**
assignee mutation for the factory `unchanged` rule; invalid transitions rejected
**before any gh mutation** (`done → active-development`, `queued → done`,
zero/multiple state labels); the factory default loads + round-trips; `repair`
resolves a two-label issue; plus the `gh_*` label/assignee primitives and CLI
parse tests.

## Quality bar

- `cargo fmt --check` ✅  `cargo clippy -p trusty-mpm --all-targets -- -D warnings` ✅
- `cargo test -p trusty-mpm` ✅ (994 + 243 + 34 + … all pass; ~64 new tests)
- `bash scripts/check_line_cap.sh` ✅ (all new production files < 500 SLOC)
- No `unwrap()` in the new logic; `thiserror` for validation, `anyhow` glue.

## Unblocks

bob-duetto/unicorn-factory **#100** (first consumer adopts the YAML model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)