### PR TITLE
chore(release): publish-prep for trusty-common, trusty-console, trusty-controller, trusty-mpm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,7 +6247,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10741,7 +10741,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10813,7 +10813,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -10991,7 +10991,6 @@ dependencies = [
  "tracing-subscriber",
  "trusty-common",
  "trusty-console",
- "trusty-mpm-gui",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
-trusty-common = { path = "crates/trusty-common", version = "0.15.1" }
+trusty-common = { path = "crates/trusty-common", version = "0.15.2" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.3" }
@@ -40,11 +40,11 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.3" }
 trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.1" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
-tga = { path = "crates/trusty-git-analytics", version = "2.7.1" }
+tga = { path = "crates/trusty-git-analytics", version = "2.8.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
-trusty-mpm = { path = "crates/trusty-mpm", version = "0.5.0" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "0.6.2" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
@@ -53,7 +53,7 @@ trusty-review = { path = "crates/trusty-review", version = "0.3.9" }
 # daemon crates + trusty-mpm so `cargo install <any-daemon>` also installs
 # trusty-console (Single-Install Convention, epic #943). Mirrors the pattern
 # of trusty-embedderd (issue #187) and trusty-bm25-daemon (PR #190).
-trusty-console = { path = "crates/trusty-console", version = "0.2.0" }
+trusty-console = { path = "crates/trusty-console", version = "0.2.1" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.15.1"
+version = "0.15.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-console"
-version     = "0.2.0"
+version     = "0.2.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-controller/Cargo.toml
+++ b/crates/trusty-controller/Cargo.toml
@@ -11,8 +11,6 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 authors.workspace = true
-# Phase-0 scaffold — not ready to publish yet.
-publish = false
 
 [lib]
 name = "trusty_controller"

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "trusty-mpm"
 version = "0.6.2"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,10 +40,16 @@ tui = ["dep:ratatui", "dep:crossterm"]
 # `telegram` gates the Telegram bot library module (`tm telegram`).
 telegram = ["dep:teloxide", "dep:tokio-util"]
 
-# `gui` gates the `tm gui` subcommand (non-default: pulls in Tauri/WebKit).
-# The Tauri GUI lives in the separate `trusty-mpm-gui` crate (it owns
-# `build.rs` + `tauri.conf.json` which cannot be merged into a generic crate).
-gui = ["dep:trusty-mpm-gui"]
+# `gui` is intentionally a no-dep CLI-gating feature. The `tm gui` subcommand
+# is ALWAYS available; this flag exists only so the subcommand can optionally
+# advertise itself. The Tauri GUI lives in the separate, publish=false
+# `trusty-mpm-gui` crate (it owns `build.rs` + `tauri.conf.json` which cannot be
+# published cleanly to crates.io). Rather than pull that unpublishable crate in
+# as an optional Cargo dependency — which blocks `cargo publish` for trusty-mpm,
+# because cargo requires even optional deps to resolve on crates.io — `tm gui`
+# shells out to a separately-installed `trusty-mpm-gui` binary (Single-Install
+# convention: `cargo install trusty-mpm-gui`). See src/bin/tm/main.rs.
+gui = []
 
 # ── Library ────────────────────────────────────────────────────────────────────
 [lib]
@@ -153,8 +158,11 @@ crossterm = { workspace = true, optional = true }
 teloxide = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 
-# gui feature — separate crate due to Tauri build system
-trusty-mpm-gui = { path = "../trusty-mpm-gui", version = "0.2.12", optional = true }
+# NOTE: trusty-mpm-gui is deliberately NOT a Cargo dependency. It is a
+# publish=false Tauri crate that cannot resolve on crates.io, so declaring it
+# (even as an optional dep) blocks `cargo publish` for trusty-mpm. The `tm gui`
+# subcommand shells out to a separately-installed `trusty-mpm-gui` binary
+# instead — see the `gui` feature comment above and src/bin/tm/main.rs.
 
 # ── Platform-specific always-on deps ─────────────────────────────────────────
 [target.'cfg(unix)'.dependencies]

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -213,19 +213,7 @@ async fn main() -> anyhow::Result<()> {
             let resolved = trusty_mpm::core::resolve_daemon_url(Some(&tui_url));
             trusty_mpm::tui::run(resolved, interval_ms).await
         }
-        Command::Gui => {
-            #[cfg(feature = "gui")]
-            {
-                trusty_mpm_gui::run();
-                Ok(())
-            }
-            #[cfg(not(feature = "gui"))]
-            {
-                anyhow::bail!(
-                    "this build was compiled without GUI support (the `gui` feature is disabled)"
-                )
-            }
-        }
+        Command::Gui => launch_gui(),
         Command::Telegram { cmd } => telegram(&url, cmd).await,
         Command::Install { force } => install(force),
         Command::Hook => hook(&client, &url).await,
@@ -262,4 +250,66 @@ async fn main() -> anyhow::Result<()> {
         } => commands::ticket::ticket(&client, &url, issue, system, notes, runtime).await,
         Command::Issue { cmd, system } => commands::issue::issue(cmd, system),
     }
+}
+
+/// Launch the Tauri desktop GUI by shelling out to the `trusty-mpm-gui` binary.
+///
+/// Why: the GUI lives in the separate, publish=false `trusty-mpm-gui` crate
+/// (it owns Tauri's `build.rs` + `tauri.conf.json`, which cannot be published
+/// cleanly to crates.io). Declaring it as an optional Cargo dependency blocks
+/// `cargo publish` for trusty-mpm, so `tm gui` instead launches a separately
+/// installed `trusty-mpm-gui` binary — matching the Single-Install convention.
+/// What: resolves the `trusty-mpm-gui` executable next to the running `tm`
+/// binary (via `current_exe().parent()`), falling back to a bare `trusty-mpm-gui`
+/// name so the OS resolves it on `PATH`. Spawns it and waits for it to exit,
+/// returning an actionable error if the binary is not installed.
+/// Test: the not-found → install-hint mapping is covered by `tests.rs`
+/// (`gui_not_found_error_has_install_hint`), which exercises `gui_status_to_result`
+/// directly with a synthetic `NotFound` error.
+fn launch_gui() -> anyhow::Result<()> {
+    let program = resolve_gui_binary();
+    gui_status_to_result(std::process::Command::new(&program).status())
+}
+
+/// Map the outcome of spawning `trusty-mpm-gui` to a CLI-friendly result.
+///
+/// Why: factoring the result mapping out of `launch_gui` keeps the actionable
+/// "not installed" hint unit-testable without actually spawning a GUI process.
+/// What: success → `Ok`; non-zero exit → error with the status; `NotFound`
+/// spawn error → the install hint; any other spawn error → a context error.
+/// Test: `tests.rs::gui_not_found_error_has_install_hint`.
+fn gui_status_to_result(status: std::io::Result<std::process::ExitStatus>) -> anyhow::Result<()> {
+    match status {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => anyhow::bail!("trusty-mpm-gui exited with status: {status}"),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => anyhow::bail!(
+            "trusty-mpm-gui is not installed.\n\
+             Install it with: cargo install trusty-mpm-gui\n\
+             (the desktop GUI ships as a separate Tauri crate; `tm gui` launches it)"
+        ),
+        Err(err) => Err(anyhow::Error::new(err).context("failed to launch trusty-mpm-gui")),
+    }
+}
+
+/// Resolve the path to the `trusty-mpm-gui` executable.
+///
+/// Why: a `cargo install`-based deployment lands every trusty-* binary in the
+/// same directory (`~/.cargo/bin`), so the sibling-of-`tm` lookup is the most
+/// reliable. We fall back to the bare binary name so a `PATH`-installed GUI is
+/// still found when `current_exe()` is unavailable or the sibling is missing.
+/// What: returns `<dir-of-current-exe>/trusty-mpm-gui` when that file exists,
+/// otherwise the bare `trusty-mpm-gui` name (resolved by the OS via `PATH`).
+/// Test: indirectly exercised by `launch_gui`'s missing-binary test; the
+/// sibling-exists branch is environment-dependent and not unit-tested.
+fn resolve_gui_binary() -> std::path::PathBuf {
+    const GUI_BIN: &str = "trusty-mpm-gui";
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        let sibling = dir.join(GUI_BIN);
+        if sibling.is_file() {
+            return sibling;
+        }
+    }
+    std::path::PathBuf::from(GUI_BIN)
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1011,6 +1011,41 @@ fn cli_parses_issue_current_and_states_and_repair() {
 }
 
 #[test]
+fn gui_not_found_error_has_install_hint() {
+    // Why: when `trusty-mpm-gui` is not installed, `tm gui` must fail with an
+    // actionable message telling the user how to install it (gui decoupling,
+    // publish-prep). A bare "No such file" from the OS is not acceptable.
+    // What: feeds a synthetic `NotFound` spawn error into the result mapper and
+    // asserts the error string carries the `cargo install trusty-mpm-gui` hint.
+    let not_found = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
+    let err = crate::gui_status_to_result(Err(not_found))
+        .expect_err("NotFound spawn error must map to an Err");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cargo install trusty-mpm-gui"),
+        "expected install hint, got: {msg}"
+    );
+    assert!(
+        msg.contains("not installed"),
+        "expected 'not installed' phrasing, got: {msg}"
+    );
+}
+
+#[test]
+fn gui_binary_resolution_falls_back_to_bare_name() {
+    // Why: when no `trusty-mpm-gui` sibling exists next to the running binary,
+    // the resolver must fall back to the bare name so the OS resolves it on PATH
+    // (Single-Install convention). The test binary's dir has no such sibling.
+    // What: asserts the resolved path's file name is exactly `trusty-mpm-gui`.
+    let resolved = crate::resolve_gui_binary();
+    assert_eq!(
+        resolved.file_name().and_then(|n| n.to_str()),
+        Some("trusty-mpm-gui"),
+        "resolver must yield a trusty-mpm-gui path, got: {resolved:?}"
+    );
+}
+
+#[test]
 fn cli_parses_issue_seed_config_force() {
     // Why: `tm issue seed-config --force` must parse the overwrite flag (#1246).
     use crate::cli::IssueCmd;


### PR DESCRIPTION
## Summary

Publish-prep (manifest + code) to enable crates.io release of **trusty-common**, **trusty-console**, **trusty-controller (tctl)**, and **trusty-mpm (tm)**. This unblocks publishing the session-manager + tctl features so they can be `cargo install`-ed for end-to-end testing.

Validated entirely with `cargo publish --dry-run`. **No `cargo publish` was run and no git tags were created** in this PR — those happen during the actual release.

## GUI decoupling approach (the trusty-mpm publish blocker)

`trusty-mpm` declared an **optional** Cargo dependency on `trusty-mpm-gui`, a `publish=false` Tauri crate (it owns `build.rs` + `tauri.conf.json` and cannot resolve on crates.io). Cargo requires even *optional* deps to resolve on crates.io at publish time, so this blocked `cargo publish -p trusty-mpm`.

Fix (Single-Install / shell-out convention used elsewhere in the workspace):

- **Removed** the `trusty-mpm-gui = { path = ..., optional = true }` dependency entirely.
- The `gui` feature is now a **no-dep CLI-gating flag** (`gui = []`), documented in `Cargo.toml`.
- `tm gui` now **shells out** to a separately-installed `trusty-mpm-gui` binary via `std::process::Command`, resolved next to the running `tm` exe (`current_exe().parent().join("trusty-mpm-gui")`) with a bare-name **PATH fallback**.
- If the binary is absent, it prints an **actionable error**: `trusty-mpm-gui is not installed. Install it with: cargo install trusty-mpm-gui`.
- The result-mapping helper (`gui_status_to_result`) and the binary resolver (`resolve_gui_binary`) are **unit-tested** (`gui_not_found_error_has_install_hint`, `gui_binary_resolution_falls_back_to_bare_name`).
- `crates/trusty-mpm-gui/` itself is **untouched** (remains `publish=false`).

Also lifted `publish = false` from `trusty-controller` and `trusty-mpm`.

## Per-crate version table

| Crate | Old | New | Note |
|---|---|---|---|
| trusty-common | 0.15.1 | **0.15.2** | patch (refactor/SLOC-split since tag) |
| trusty-console | 0.2.0 | **0.2.1** | patch (#1164 lock-ordering fix) |
| trusty-controller | 0.1.0 | **0.1.0** | first publish (removed `publish=false`) |
| trusty-mpm | 0.6.2 | **0.6.2** | first publish (removed `publish=false`, gui decoupled) |

### Workspace dependency fixes (`[workspace.dependencies]`)

| Dep | Old version pin | New version pin |
|---|---|---|
| trusty-common | 0.15.1 | 0.15.2 |
| trusty-console | 0.2.0 | 0.2.1 |
| trusty-mpm | 0.5.0 (stale) | 0.6.2 |
| tga | 2.7.1 (stale) | 2.8.0 (matches crate) |

## Validation

- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — **exit 0, zero lint warnings**
- `cargo test -p trusty-mpm` — **1018 + 245 + ... passed, 0 failed** (incl. both new gui tests)
- `cargo test -p trusty-controller` — **106 passed, 0 failed**
- `cargo check --workspace` — **exit 0**
- `bash scripts/check_line_cap.sh` — **0 violations**

### Dry-run results

| Crate | Command | Outcome |
|---|---|---|
| trusty-common | `cargo publish --dry-run -p trusty-common` | ✅ **PASS** (full) |
| trusty-console | `SKIP_UI_BUILD=1 cargo publish --dry-run -p trusty-console` | ⏳ **expected-unpublished-sibling** (`trusty-common ^0.15.2` not yet on crates.io) |
| trusty-controller | `cargo publish --dry-run -p trusty-controller` | ⏳ **expected-unpublished-sibling** (`trusty-common ^0.15.2`) |
| trusty-mpm | `SKIP_UI_BUILD=1 cargo publish --dry-run -p trusty-mpm` | ⏳ **expected-unpublished-sibling** (`trusty-common ^0.15.2`) — **NO trusty-mpm-gui resolution error: gui decoupling confirmed clean** |

The three "expected-unpublished-sibling" results are the documented, non-blocking case: crates.io has trusty-common 0.15.1 but not 0.15.2 yet. They resolve at real-publish time once crates are published in dependency order: **trusty-common → trusty-console → {trusty-controller, trusty-mpm}**.

For trusty-mpm specifically, the dry-run got past packaging and *all* dependency resolution except the unpublished `trusty-common`; there is **no mention of trusty-mpm-gui / Tauri / WebKit anywhere** — proving the gui decoupling fully cleared the publish path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)