### PR TITLE
feat(tm): add watch poll|listen <project> command for label-routed autonomous ticket execution (trusty-mpm 0.7.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10949,7 +10949,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tga = { path = "crates/trusty-git-analytics", version = "2.8.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
-trusty-mpm = { path = "crates/trusty-mpm", version = "0.6.2" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "0.7.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.6.2"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -314,6 +314,97 @@ pub(crate) enum Command {
         #[arg(long, default_value = "gh", value_enum, global = true)]
         system: crate::commands::ticket::system::TicketSystemKind,
     },
+
+    /// Watch a board for label-routed issues and dispatch them autonomously.
+    ///
+    /// Why: `tm ticket <issue#>` executes ONE hand-named issue. `tm watch`
+    /// complements it with a board-watch mode: discover every issue carrying a
+    /// routing label (default `tm-agent`) and dispatch each into the SAME
+    /// managed-session execution path so a team can drop the label on an issue
+    /// and have it picked up. Routing is by LABEL, not assignee (no bot account
+    /// exists). `poll` runs once (cron-friendly); `listen` polls on an interval
+    /// until Ctrl-C.
+    /// What: a `poll`/`listen` sub-subcommand group. Both default to DRY-RUN —
+    /// they only spawn real work with the explicit `--execute` flag. `<project>`
+    /// is an `owner/repo` or a name resolved via the `watch:` config section.
+    /// Test: `cli_parses_watch_*` in `tests.rs`; logic in `commands::watch`.
+    Watch {
+        /// Watch mode to run (`poll` one-shot or `listen` loop).
+        #[command(subcommand)]
+        cmd: WatchCmd,
+    },
+}
+
+/// Modes for the `tm watch` command group.
+///
+/// Why: `poll` and `listen` share every flag but differ in lifecycle (one-shot
+/// vs loop); a sub-subcommand enum keeps them discoverable and individually
+/// parseable while reusing one flag set via the flattened [`WatchArgs`].
+/// What: `Poll` (discover + dispatch once, then exit) and `Listen` (repeatedly
+/// poll on an interval, processing newly-matched issues, until Ctrl-C).
+/// Test: `cli_parses_watch_poll`, `cli_parses_watch_listen` in `tests.rs`.
+#[derive(Debug, Subcommand)]
+pub(crate) enum WatchCmd {
+    /// One-shot: list label-matched issues, dispatch each, then exit.
+    Poll {
+        /// Shared watch flags (project + label/state/safety/runtime).
+        #[command(flatten)]
+        args: WatchArgs,
+    },
+    /// Long-running: poll on `--interval-secs`, dispatching new issues each cycle.
+    Listen {
+        /// Shared watch flags (project + label/interval/state/safety/runtime).
+        #[command(flatten)]
+        args: WatchArgs,
+    },
+}
+
+/// The shared flag set for both `tm watch poll` and `tm watch listen`.
+///
+/// Why: poll and listen take the same inputs (board, routing label, issue state,
+/// the dry-run/execute safety gate, and the spawn runtime), plus listen's poll
+/// interval. Flattening one struct into both keeps the surface identical and the
+/// dispatch wiring DRY.
+/// What: the `<project>` positional (`owner/repo` or a configured name) and the
+/// `--label` / `--interval-secs` / `--state` / `--dry-run` / `--execute` /
+/// `--runtime` flags. Safety: default is dry-run; `--execute` is required to
+/// actually spawn work, and `--dry-run` (the default) always wins if both appear.
+/// Test: `cli_parses_watch_*` assert the parsed fields.
+#[derive(Debug, clap::Args)]
+pub(crate) struct WatchArgs {
+    /// Board to watch: an `owner/repo` (e.g. `bobmatnyc/trusty-tools`) OR a
+    /// registered project name resolved via the `watch:` config section.
+    pub(crate) project: String,
+
+    /// Routing label; only issues carrying it are picked up (default `tm-agent`).
+    #[arg(long)]
+    pub(crate) label: Option<String>,
+
+    /// `listen`-mode poll interval in seconds (default 60).
+    #[arg(long = "interval-secs")]
+    pub(crate) interval_secs: Option<u64>,
+
+    /// Which issues to consider: `open` (default) or `all`.
+    #[arg(long, value_enum)]
+    pub(crate) state: Option<crate::commands::watch::github::IssueState>,
+
+    /// List matched issues and what WOULD run without spawning anything.
+    ///
+    /// This is the DEFAULT behaviour; the flag exists to make the safe intent
+    /// explicit and, if both `--dry-run` and `--execute` are passed, dry-run wins.
+    #[arg(long)]
+    pub(crate) dry_run: bool,
+
+    /// Actually spawn a managed session per matched issue (the explicit opt-in).
+    ///
+    /// Without this flag, `tm watch` only describes what it would do. This guard
+    /// makes accidental mass-execution against real repos impossible.
+    #[arg(long)]
+    pub(crate) execute: bool,
+
+    /// Runtime backend for spawned sessions: `claude-code` (default) or `tcode`.
+    #[arg(long, default_value = "claude-code", value_enum)]
+    pub(crate) runtime: trusty_mpm::runtime::RuntimeKind,
 }
 
 /// Verbs for the `tm issue` state-management command group (#1246).

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -381,7 +381,10 @@ pub(crate) struct WatchArgs {
     pub(crate) label: Option<String>,
 
     /// `listen`-mode poll interval in seconds (default 60).
-    #[arg(long = "interval-secs")]
+    #[arg(
+        long = "interval-secs",
+        help = "Poll interval in seconds (listen mode only; ignored by poll)"
+    )]
     pub(crate) interval_secs: Option<u64>,
 
     /// Which issues to consider: `open` (default) or `all`.

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -22,3 +22,4 @@ pub(crate) mod session;
 pub(crate) mod supervisor;
 pub(crate) mod telegram;
 pub(crate) mod ticket;
+pub(crate) mod watch;

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/args.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/args.rs
@@ -1,0 +1,180 @@
+//! Effective-settings resolution for `tm watch` — CLI flags over config defaults.
+//!
+//! Why: `tm watch poll|listen <project>` takes several settings (the routing
+//! label, the poll interval, the issue state) that may come from a CLI flag OR
+//! the `watch:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#1220). The
+//! precedence must be applied in exactly one tested place so `poll` and `listen`
+//! cannot diverge, and so "CLI flag overrides config" is an asserted invariant
+//! rather than scattered `unwrap_or` calls.
+//! What: [`RawWatchArgs`] is the parsed CLI surface (all overrides optional);
+//! [`ResolvedWatch`] is the fully-resolved settings the loops consume;
+//! [`resolve`] merges a `RawWatchArgs` with a [`WatchConfig`] applying the
+//! precedence **CLI flag > config value > built-in default** and resolves the
+//! `<project>` token (either a direct `owner/repo` or a name falling back to the
+//! configured `repo`). [`DEFAULT_LABEL`] / [`DEFAULT_INTERVAL_SECS`] name the
+//! built-in defaults.
+//! Test: `resolve_*` in the sibling `tests.rs`.
+
+use trusty_common::github_path::parse_github_path;
+
+use trusty_mpm::core::trusty_tools_config::WatchConfig;
+
+use super::github::IssueState;
+
+/// Built-in default routing label.
+///
+/// Why: the design fixes `tm-agent` as the default routing label (issues carrying
+/// it are picked up); naming it once keeps the CLI default and the docs aligned.
+/// What: `"tm-agent"`.
+/// Test: `resolve_uses_default_label_when_unset`.
+pub(crate) const DEFAULT_LABEL: &str = "tm-agent";
+
+/// Built-in default `listen` poll interval, in seconds.
+///
+/// Why: a sensible cadence that is gentle on the GitHub API yet responsive; the
+/// design fixes it at 60s. Named once so the CLI default and config fallback agree.
+/// What: `60`.
+/// Test: `resolve_uses_default_interval_when_unset`.
+pub(crate) const DEFAULT_INTERVAL_SECS: u64 = 60;
+
+/// The parsed `tm watch` CLI surface before config merging.
+///
+/// Why: separating the raw (all-optional) CLI overrides from the resolved
+/// settings keeps the precedence logic in [`resolve`] and makes the merge
+/// unit-testable without clap.
+/// What: the `<project>` token plus the optional `--label` / `--interval-secs` /
+/// `--state` overrides. `project` is the verbatim positional (`owner/repo` or a
+/// name); `None` overrides mean "fall back to config then default".
+/// Test: drives every `resolve_*` test.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RawWatchArgs {
+    /// The verbatim `<project>` positional (`owner/repo` or a registered name).
+    pub(crate) project: String,
+    /// `--label` override; `None` → config then [`DEFAULT_LABEL`].
+    pub(crate) label: Option<String>,
+    /// `--interval-secs` override; `None` → config then [`DEFAULT_INTERVAL_SECS`].
+    pub(crate) interval_secs: Option<u64>,
+    /// `--state` override; `None` → [`IssueState::Open`].
+    pub(crate) state: Option<IssueState>,
+}
+
+/// Fully-resolved `tm watch` settings consumed by the poll/listen loops.
+///
+/// Why: once precedence is applied the loops want concrete, non-optional values
+/// (a resolved `owner/repo`, a label, an interval, a state) so they never re-run
+/// the merge or re-resolve the project.
+/// What: the resolved `repo` (`owner/repo`), the routing `label`, the listen
+/// `interval_secs`, and the `state` selection.
+/// Test: produced and asserted by every `resolve_*` test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedWatch {
+    /// The resolved board repository as `owner/repo`.
+    pub(crate) repo: String,
+    /// The routing label; only issues carrying it are picked up.
+    pub(crate) label: String,
+    /// The `listen`-mode poll interval, in seconds.
+    pub(crate) interval_secs: u64,
+    /// Which issues to consider (open vs all).
+    pub(crate) state: IssueState,
+}
+
+/// Resolve the `<project>` token into an `owner/repo` board repository.
+///
+/// Why: the spec lets `<project>` be a direct `owner/repo` OR a registered
+/// project name resolved via config. A direct `owner/repo` must win as-is; any
+/// other token (a bare name, or anything that does not parse to two segments)
+/// falls back to the configured `watch.repo`. Surfacing a clear error when
+/// neither yields a repo stops the loop from running against a guessed board.
+/// What: returns the trimmed `project` when it parses to a clean `owner/repo`
+/// (two non-empty segments and no extra path noise); otherwise returns the
+/// configured `repo`; otherwise an actionable error.
+/// Test: `resolve_project_direct_owner_repo`, `resolve_project_name_uses_config`,
+/// `resolve_project_unresolvable_errors`.
+fn resolve_project(project: &str, config: &WatchConfig) -> anyhow::Result<String> {
+    let token = project.trim();
+    if looks_like_owner_repo(token) {
+        return Ok(token.to_string());
+    }
+    if let Some(repo) = config
+        .repo
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return Ok(repo.to_string());
+    }
+    anyhow::bail!(
+        "could not resolve project `{project}` — pass an `owner/repo` (e.g. \
+         `bobmatnyc/trusty-tools`) or set `watch.repo` in \
+         ~/.trusty-tools/trusty-mpm/config.yaml"
+    )
+}
+
+/// Decide whether a token is a direct `owner/repo` reference.
+///
+/// Why: `resolve_project` must distinguish a literal `owner/repo` from a bare
+/// registered-project name so the former is used verbatim and the latter falls
+/// back to config. A `<owner>/<repo>` has exactly two non-empty, slash-separated
+/// segments with no host/scheme noise.
+/// What: returns true when `parse_github_path` yields a path whose rendered
+/// `owner/repo` equals the lower-cased input — i.e. the token is already a clean
+/// two-segment identity, not a URL or a single bare name.
+/// Test: `looks_like_owner_repo_*`.
+fn looks_like_owner_repo(token: &str) -> bool {
+    if !token.contains('/') || token.contains("://") || token.contains(':') {
+        return false;
+    }
+    // Exactly two non-empty segments.
+    let segments: Vec<&str> = token.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() != 2 {
+        return false;
+    }
+    // And it must round-trip through the canonical parser (rejects empty/odd).
+    parse_github_path(token).is_some()
+}
+
+/// Merge raw CLI args with config defaults into [`ResolvedWatch`].
+///
+/// Why: the single place the precedence **CLI flag > config value > built-in
+/// default** is applied, so `poll` and `listen` share identical resolution and
+/// the rule is asserted once.
+/// What: resolves the project to an `owner/repo`, then for each setting takes the
+/// CLI override if present, else the config value, else the built-in default.
+/// `state` has no config field (it is a per-run choice) so it falls straight
+/// through to [`IssueState::Open`].
+/// Test: `resolve_cli_overrides_config`, `resolve_config_used_when_no_cli`,
+/// `resolve_uses_default_label_when_unset`, `resolve_uses_default_interval_when_unset`.
+pub(crate) fn resolve(raw: &RawWatchArgs, config: &WatchConfig) -> anyhow::Result<ResolvedWatch> {
+    let repo = resolve_project(&raw.project, config)?;
+
+    let label = raw
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            config
+                .label
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| DEFAULT_LABEL.to_string());
+
+    let interval_secs = raw
+        .interval_secs
+        .or(config.interval_secs)
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_INTERVAL_SECS);
+
+    let state = raw.state.unwrap_or_default();
+
+    Ok(ResolvedWatch {
+        repo,
+        label,
+        interval_secs,
+        state,
+    })
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/args.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/args.rs
@@ -83,11 +83,16 @@ pub(crate) struct ResolvedWatch {
 /// Why: the spec lets `<project>` be a direct `owner/repo` OR a registered
 /// project name resolved via config. A direct `owner/repo` must win as-is; any
 /// other token (a bare name, or anything that does not parse to two segments)
-/// falls back to the configured `watch.repo`. Surfacing a clear error when
-/// neither yields a repo stops the loop from running against a guessed board.
+/// falls back to the configured `watch.repo`. That fallback must NEVER be silent:
+/// a typo in the `<project>` token would otherwise quietly target the configured
+/// board, so we emit a clear stderr notice naming both the offending token and
+/// the repo we are substituting. Surfacing a clear error when neither yields a
+/// repo stops the loop from running against a guessed board.
 /// What: returns the trimmed `project` when it parses to a clean `owner/repo`
-/// (two non-empty segments and no extra path noise); otherwise returns the
-/// configured `repo`; otherwise an actionable error.
+/// (two non-empty segments and no extra path noise); otherwise, when a non-empty
+/// `config.repo` exists, prints `note: project token '<tok>' is not 'owner/repo';
+/// using configured repo '<config.repo>'` to stderr and returns that repo;
+/// otherwise an actionable error (never a guess).
 /// Test: `resolve_project_direct_owner_repo`, `resolve_project_name_uses_config`,
 /// `resolve_project_unresolvable_errors`.
 fn resolve_project(project: &str, config: &WatchConfig) -> anyhow::Result<String> {
@@ -101,6 +106,11 @@ fn resolve_project(project: &str, config: &WatchConfig) -> anyhow::Result<String
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
+        // Never substitute silently: a typo in `<project>` must not quietly
+        // target the wrong board. Name both the token and the repo we use.
+        eprintln!(
+            "note: project token '{token}' is not 'owner/repo'; using configured repo '{repo}'"
+        );
         return Ok(repo.to_string());
     }
     anyhow::bail!(

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/dispatch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/dispatch.rs
@@ -1,0 +1,180 @@
+//! Per-issue dispatch for `tm watch` — build the task, then dry-run or spawn.
+//!
+//! Why: once an issue is matched by the routing label, watch must turn it into
+//! the SAME managed-session execution `tm ticket` performs: a Claude Code session
+//! spawned via `POST /api/v1/sessions/managed` whose task instructs the driver
+//! agent to implement the issue and open a PR. Factoring the per-issue step out
+//! of the loops keeps the safety gate (dry-run vs execute) and the task wording
+//! in one tested place that both `poll` and `listen` share.
+//! What: [`build_watch_task`] builds the agent prompt for a matched issue (pure,
+//! tested); [`DispatchMode`] is the dry-run/execute selector; [`dispatch_issue`]
+//! either prints the would-execute plan (dry-run) or POSTs the managed-spawn
+//! request (execute), reusing the exact request shape `tm ticket` uses. The
+//! branch ref is the repo's resolved default branch; the agent creates the ticket
+//! branch from there.
+//! Test: `build_watch_task_*` in the sibling `tests.rs`; the HTTP spawn mirrors
+//! `tm ticket::spawn_managed` (covered by the managed MVP integration test) and
+//! is exercised end-to-end manually.
+
+use serde::Deserialize;
+
+use trusty_mpm::runtime::RuntimeKind;
+
+use super::github::MatchedIssue;
+
+/// Whether `dispatch_issue` should actually spawn work or only describe it.
+///
+/// Why: `tm watch` drives real execution against real repos, so the default must
+/// be safe — describe, do not execute — unless the operator explicitly opts in.
+/// A two-variant selector makes the gate explicit and impossible to fat-finger
+/// into mass execution.
+/// What: `DryRun` (list what WOULD run, spawn nothing) or `Execute` (POST the
+/// managed-spawn request).
+/// Test: `dispatch_dry_run_spawns_nothing` (dry-run path), and the execute path
+/// via the manual e2e + the shared `spawn_managed` shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DispatchMode {
+    /// Describe what would run; spawn nothing (the safe default).
+    DryRun,
+    /// Actually POST the managed-session spawn request.
+    Execute,
+}
+
+/// Build the agent task prompt for a watch-matched issue.
+///
+/// Why: the spawned managed session needs a self-contained instruction naming
+/// the issue, the branch to create, the base branch to create it from, and the
+/// close-on-merge convention — identical in spirit to `tm ticket`'s task so a
+/// watched issue is resolved the same way a hand-run ticket is. Building it as a
+/// pure function keeps the wording asserted in a test.
+/// What: returns a multi-line task string embedding the issue number/title/body,
+/// the derived `branch`, the `base_branch` to branch from, and the close-on-merge
+/// (`Closes #<n>`) and pull-request requirements.
+/// Test: `build_watch_task_includes_branch_and_close` and
+/// `build_watch_task_handles_empty_body`.
+pub(crate) fn build_watch_task(issue: &MatchedIssue, branch: &str, base_branch: &str) -> String {
+    format!(
+        "Address issue #{number}: {title}\n\n\
+         Issue body:\n{body}\n\n\
+         Workflow requirements:\n\
+         - Work on branch `{branch}` (create it off the default branch `{base_branch}`).\n\
+         - Implement the change described in the issue.\n\
+         - Commit with a message referencing the issue and ending in `Closes #{number}`.\n\
+         - Open a pull request linking the issue so a squash-merge closes it.\n",
+        number = issue.number,
+        title = issue.title,
+        body = if issue.body.trim().is_empty() {
+            "(no body provided)"
+        } else {
+            issue.body.trim()
+        },
+        branch = branch,
+        base_branch = base_branch,
+    )
+}
+
+/// Derive the per-issue working branch name for a watched issue.
+///
+/// Why: every matched issue needs a stable, unique branch so concurrent watch
+/// dispatches do not collide; deriving it from the issue number keeps it
+/// deterministic and re-runnable.
+/// What: returns `tm-watch/<number>` — a namespaced branch that groups all
+/// watch-driven work and never clashes across issues.
+/// Test: `watch_branch_name_is_namespaced`.
+pub(crate) fn watch_branch_name(issue: &MatchedIssue) -> String {
+    format!("tm-watch/{}", issue.number)
+}
+
+/// Dispatch one matched issue: dry-run describes it, execute spawns it.
+///
+/// Why: the single per-issue action both loops call; centralising the safety
+/// gate and the managed-spawn shape means dry-run can never accidentally spawn
+/// and the execute path can never diverge from `tm ticket`.
+/// What: in [`DispatchMode::DryRun`] prints the issue, derived branch, and target
+/// repo/ref WITHOUT any HTTP call; in [`DispatchMode::Execute`] POSTs
+/// `{repo_url, ref, task, name_hint, runtime}` to `/api/v1/sessions/managed` and
+/// prints the new session id/state/attach command. Returns `Ok(true)` when the
+/// issue was actually spawned (execute path succeeded) and `Ok(false)` for a
+/// dry-run, so the caller's dedup set only records genuinely-dispatched issues.
+/// Test: dry-run via `dispatch_dry_run_spawns_nothing`; execute via the manual
+/// e2e (mirrors `tm ticket::spawn_managed`).
+pub(crate) async fn dispatch_issue(
+    client: &reqwest::Client,
+    url: &str,
+    repo_url: &str,
+    base_ref: &str,
+    issue: &MatchedIssue,
+    mode: DispatchMode,
+    runtime: RuntimeKind,
+) -> anyhow::Result<bool> {
+    let branch = watch_branch_name(issue);
+    match mode {
+        DispatchMode::DryRun => {
+            println!(
+                "[dry-run] would dispatch #{} ({}) → branch `{branch}` off `{base_ref}` of {repo_url}",
+                issue.number, issue.url
+            );
+            println!("           title: {}", issue.title);
+            Ok(false)
+        }
+        DispatchMode::Execute => {
+            let task = build_watch_task(issue, &branch, base_ref);
+            spawn_managed(client, url, repo_url, base_ref, &branch, &task, runtime).await?;
+            Ok(true)
+        }
+    }
+}
+
+/// POST the managed-session spawn request that drives the issue implementation.
+///
+/// Why: reuses the exact session-manager spawn path (`POST
+/// /api/v1/sessions/managed`) that `tm ticket` / `tm session new` use, so
+/// `tm watch` plugs into the existing isolated-workspace + runtime-adapter
+/// machinery (the P4 workspace root `~/trusty-mpm-projects/<owner>/<repo>/…`)
+/// rather than re-implementing it. The provisioner clones the repo and the driver
+/// agent creates `branch` off `base_ref` per the task.
+/// What: posts repo_url/ref/task/name_hint/runtime and prints the new session id,
+/// state, runtime, and attach command.
+/// Test: mirrors `tm ticket::spawn_managed`; HTTP path covered by the managed MVP
+/// integration test.
+#[allow(clippy::too_many_arguments)]
+async fn spawn_managed(
+    client: &reqwest::Client,
+    url: &str,
+    repo_url: &str,
+    base_ref: &str,
+    branch: &str,
+    task: &str,
+    runtime: RuntimeKind,
+) -> anyhow::Result<()> {
+    #[derive(Deserialize)]
+    struct SpawnResp {
+        id: String,
+        name: String,
+        state: String,
+        attach_cmd: String,
+        #[serde(default)]
+        runtime: String,
+    }
+    let resp: SpawnResp = client
+        .post(format!("{url}/api/v1/sessions/managed"))
+        .json(&serde_json::json!({
+            "repo_url": repo_url,
+            "ref": base_ref,
+            "task": task,
+            "name_hint": branch,
+            "runtime": runtime.as_str(),
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    println!(
+        "spawned {} ({}) [{}] runtime={}",
+        resp.name, resp.id, resp.state, resp.runtime
+    );
+    println!("  task drives branch `{branch}` → PR (Closes the issue on merge)");
+    println!("  attach: {}", resp.attach_cmd);
+    Ok(())
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/github.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/github.rs
@@ -93,8 +93,9 @@ pub(crate) trait IssueLister {
 /// behind a [`CommandRunner`] keeps the discovery path unit-testable and reuses
 /// the exact process seam `tm ticket` uses.
 /// What: `list` runs `gh issue list -R <repo> --label <l> --state <s> --json
-/// number,title,body,labels,assignees,url`, parses the JSON, and applies the
-/// defensive label re-filter.
+/// number,title,body,labels,url`, parses the JSON, and applies the defensive
+/// label re-filter. (Assignees are intentionally not requested: routing is by
+/// LABEL, so the field was never deserialised.)
 /// Test: `gh_list_parses_and_filters`, `gh_list_surfaces_gh_failure`.
 pub(crate) struct GhIssueLister<R: CommandRunner> {
     runner: R,
@@ -130,7 +131,7 @@ impl<R: CommandRunner> IssueLister for GhIssueLister<R> {
                 "--state",
                 state.as_gh(),
                 "--json",
-                "number,title,body,labels,assignees,url",
+                "number,title,body,labels,url",
             ],
         )?;
         if !out.success {

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/github.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/github.rs
@@ -1,0 +1,224 @@
+//! GitHub issue discovery for `tm watch` — list + label-filter via `gh`.
+//!
+//! Why: `tm watch` routes work by LABEL (no bot account exists, so we do NOT
+//! filter by assignee). It must enumerate a repo's issues carrying the routing
+//! label and turn them into a small, backend-independent value the dispatch and
+//! listen loops can act on. Hiding the `gh issue list` call behind a trait seam
+//! ([`IssueLister`]) lets the loops be unit-tested with a scripted fake instead
+//! of hitting GitHub over the network.
+//! What: [`MatchedIssue`] is the normalised issue view; [`IssueState`] selects
+//! open/all; [`IssueLister`] is the one-method seam; [`GhIssueLister`] is the
+//! `gh`-backed production impl over the shared [`CommandRunner`]; [`parse_issues`]
+//! turns `gh issue list --json …` output into `MatchedIssue`s and
+//! [`filter_by_label`] applies the routing-label predicate defensively (gh's
+//! `--label` already filters server-side, but we re-check so the predicate is
+//! tested and a fake/loose backend cannot leak unmatched issues).
+//! Test: `parse_issues_*`, `filter_by_label_*`, `gh_list_*` in the sibling
+//! `tests.rs`.
+
+use serde::Deserialize;
+
+use crate::commands::ticket::runner::CommandRunner;
+
+/// Which issues `tm watch` should consider.
+///
+/// Why: a one-shot `poll` against a busy board may want only `open` issues
+/// (the common, safe case) but an operator backfilling may want `all`. Typing
+/// it as a clap `ValueEnum` rejects bad values at parse time.
+/// What: `Open` (default — the routable working set) or `All` (open + closed).
+/// Maps to the `gh issue list --state` value via [`IssueState::as_gh`].
+/// Test: `issue_state_default_is_open`, `issue_state_as_gh`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub(crate) enum IssueState {
+    /// Only open issues (default — the routable working set).
+    #[default]
+    Open,
+    /// Both open and closed issues.
+    All,
+}
+
+impl IssueState {
+    /// Return the `gh issue list --state` value for this selection.
+    ///
+    /// Why: `gh` expects the lowercase string; keeping the mapping in one place
+    /// stops the CLI and the gh invocation from drifting.
+    /// What: `"open"` or `"all"`.
+    /// Test: `issue_state_as_gh`.
+    pub(crate) fn as_gh(self) -> &'static str {
+        match self {
+            IssueState::Open => "open",
+            IssueState::All => "all",
+        }
+    }
+}
+
+/// A normalised issue matched by the routing label.
+///
+/// Why: the dispatch and listen loops need a backend-independent, hashable-by-
+/// number view of an issue — number (the dedup key), title/body (seed the agent
+/// task), labels (for the defensive re-filter), and url (operator-facing log).
+/// What: the issue number, title, body, label names, and html url.
+/// Test: built from `gh` JSON in `parse_issues_basic`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MatchedIssue {
+    /// Numeric issue identifier (the dedup key for listen mode).
+    pub(crate) number: u64,
+    /// Issue title (used for the spawned session name hint + task).
+    pub(crate) title: String,
+    /// Issue body (seeds the agent task description).
+    pub(crate) body: String,
+    /// Label names carried by the issue (drives the defensive re-filter).
+    pub(crate) labels: Vec<String>,
+    /// Web URL for the issue (operator-facing log line).
+    pub(crate) url: String,
+}
+
+/// A seam for listing a repo's issues filtered by label.
+///
+/// Why: decouples the watch loops from a live `gh` + GitHub so the discovery →
+/// filter → dispatch flow is unit-testable with a scripted fake, mirroring the
+/// `TicketSystem`/`CommandRunner` seams `tm ticket` already uses.
+/// What: one `list` method taking the `owner/repo`, routing label, and state,
+/// returning the matched issues.
+/// Test: `GhIssueLister` via `FakeRunner`; the loops via a `FakeLister`.
+pub(crate) trait IssueLister {
+    /// List `repo`'s issues carrying `label` in `state`.
+    fn list(&self, repo: &str, label: &str, state: IssueState)
+    -> anyhow::Result<Vec<MatchedIssue>>;
+}
+
+/// GitHub-backed [`IssueLister`] driving the `gh` CLI.
+///
+/// Why: GitHub is the only supported board today; wrapping `gh issue list`
+/// behind a [`CommandRunner`] keeps the discovery path unit-testable and reuses
+/// the exact process seam `tm ticket` uses.
+/// What: `list` runs `gh issue list -R <repo> --label <l> --state <s> --json
+/// number,title,body,labels,assignees,url`, parses the JSON, and applies the
+/// defensive label re-filter.
+/// Test: `gh_list_parses_and_filters`, `gh_list_surfaces_gh_failure`.
+pub(crate) struct GhIssueLister<R: CommandRunner> {
+    runner: R,
+}
+
+impl<R: CommandRunner> GhIssueLister<R> {
+    /// Construct a gh-backed lister over the given runner.
+    ///
+    /// Why: dependency injection of the runner is what makes the type testable.
+    /// What: stores the runner for later `gh` invocations.
+    /// Test: used by every `gh_list_*` test.
+    pub(crate) fn new(runner: R) -> Self {
+        Self { runner }
+    }
+}
+
+impl<R: CommandRunner> IssueLister for GhIssueLister<R> {
+    fn list(
+        &self,
+        repo: &str,
+        label: &str,
+        state: IssueState,
+    ) -> anyhow::Result<Vec<MatchedIssue>> {
+        let out = self.runner.run(
+            "gh",
+            &[
+                "issue",
+                "list",
+                "-R",
+                repo,
+                "--label",
+                label,
+                "--state",
+                state.as_gh(),
+                "--json",
+                "number,title,body,labels,assignees,url",
+            ],
+        )?;
+        if !out.success {
+            let detail = out.stderr.trim();
+            anyhow::bail!(
+                "`gh issue list -R {repo}` failed{} — check the repo, the `gh` \
+                 install, and that `gh auth status` is logged in",
+                if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({detail})")
+                }
+            );
+        }
+        let issues = parse_issues(out.stdout.trim())?;
+        Ok(filter_by_label(issues, label))
+    }
+}
+
+/// Shape of a single `gh issue list --json …` array element.
+///
+/// Why: decouples our [`MatchedIssue`] from gh's wire shape so a field rename
+/// only touches this struct.
+/// What: deserialises the subset of fields we request.
+/// Test: parsed in `parse_issues_basic`.
+#[derive(Debug, Deserialize)]
+struct GhIssueJson {
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
+    #[serde(default)]
+    url: String,
+}
+
+/// A single label object in the gh issue JSON.
+///
+/// Why: gh returns labels as objects with a `name` field, not bare strings.
+/// What: captures just the `name`.
+/// Test: parsed alongside `GhIssueJson`.
+#[derive(Debug, Deserialize)]
+struct GhLabel {
+    #[serde(default)]
+    name: String,
+}
+
+/// Parse `gh issue list --json …` output into [`MatchedIssue`]s.
+///
+/// Why: keeping the JSON→value mapping a pure function makes every parse branch
+/// (empty array, missing optional fields) deterministically unit-testable.
+/// What: deserialises the gh array, flattening each label object to its name.
+/// An empty input string is treated as an empty array (gh prints nothing when
+/// there are no matches under some configurations).
+/// Test: `parse_issues_basic`, `parse_issues_empty`.
+pub(crate) fn parse_issues(stdout: &str) -> anyhow::Result<Vec<MatchedIssue>> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let parsed: Vec<GhIssueJson> = serde_json::from_str(trimmed)
+        .map_err(|e| anyhow::anyhow!("failed to parse `gh issue list` JSON: {e}"))?;
+    Ok(parsed
+        .into_iter()
+        .map(|i| MatchedIssue {
+            number: i.number,
+            title: i.title,
+            body: i.body,
+            labels: i.labels.into_iter().map(|l| l.name).collect(),
+            url: i.url,
+        })
+        .collect())
+}
+
+/// Keep only issues that actually carry `label` (defensive re-filter).
+///
+/// Why: `gh issue list --label` filters server-side, but the routing contract is
+/// "only issues carrying the label are picked up". Re-applying the predicate
+/// here makes that contract a tested invariant and means a fake/loose backend
+/// (or a future HTTP path) can never leak an unmatched issue into execution.
+/// The match is case-insensitive because GitHub label names are not.
+/// What: returns the issues whose `labels` contain `label` (ASCII-case-insensitive).
+/// Test: `filter_by_label_keeps_only_matching`, `filter_by_label_case_insensitive`.
+pub(crate) fn filter_by_label(issues: Vec<MatchedIssue>, label: &str) -> Vec<MatchedIssue> {
+    issues
+        .into_iter()
+        .filter(|i| i.labels.iter().any(|l| l.eq_ignore_ascii_case(label)))
+        .collect()
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/listen.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/listen.rs
@@ -49,6 +49,20 @@ pub(crate) fn select_new_issues(
     fresh
 }
 
+/// Decide whether the in-memory-dedup restart warning should be emitted.
+///
+/// Why: the `seen` set lives only for the process lifetime, so a restart loses
+/// it and `--execute` would re-dispatch every currently-open matching issue. That
+/// risk only exists when we are actually spawning work, so the warning must fire
+/// for `Execute` and stay silent for `DryRun` (where re-listing is harmless).
+/// Pulling the predicate out of the loop body makes the "warn iff Execute"
+/// invariant directly unit-testable without driving the sleeping loop.
+/// What: returns `true` only for [`DispatchMode::Execute`].
+/// Test: `should_warn_only_for_execute`.
+pub(crate) fn should_warn(mode: DispatchMode) -> bool {
+    matches!(mode, DispatchMode::Execute)
+}
+
 /// Drive the `tm watch listen` poll loop until Ctrl-C.
 ///
 /// Why: the long-running entry point. Polling on an interval (rather than a
@@ -87,6 +101,14 @@ pub(crate) async fn run_listen_loop<L: IssueLister>(
             DispatchMode::Execute => "EXECUTE",
         }
     );
+    // The dedup set is process-local (a persistent state file is a documented
+    // future enhancement). In execute mode a restart therefore re-dispatches
+    // every currently-open matching issue, which is destructive — warn loudly.
+    if should_warn(mode) {
+        eprintln!(
+            "warn: dedup set is in-memory; a restart will re-dispatch all currently-open matching issues"
+        );
+    }
 
     loop {
         match lister.list(&settings.repo, &settings.label, settings.state) {

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/listen.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/listen.rs
@@ -1,0 +1,132 @@
+//! The long-running `tm watch listen` poll loop with dedup + graceful SIGINT.
+//!
+//! Why: `listen` is the pragmatic, locally-testable form of "watch a board":
+//! repeatedly poll for label-matched issues, dispatch any not seen before, and
+//! sleep until the next cycle — running until Ctrl-C. Tracking already-processed
+//! issue numbers in-memory prevents re-dispatching the same issue every cycle.
+//! Webhook-based listen is a future enhancement (#follow-up: replace this poll
+//! loop with a GitHub webhook receiver so dispatch is event-driven rather than
+//! polled).
+//! What: [`select_new_issues`] is the pure dedup step (returns the issues whose
+//! numbers are not yet in the seen-set and records them); [`run_listen_loop`]
+//! drives poll → select-new → dispatch → sleep over an [`IssueLister`], cancelling
+//! cleanly on `Ctrl-C`. The seen-set lives in-memory for the process lifetime
+//! (a persistent state file is a documented future enhancement).
+//! Test: `select_new_issues_*` cover the dedup invariants; the loop's wiring is
+//! exercised via the manual e2e (it sleeps + traps signals).
+
+use std::collections::HashSet;
+
+use trusty_mpm::runtime::RuntimeKind;
+
+use super::args::ResolvedWatch;
+use super::dispatch::{DispatchMode, dispatch_issue};
+use super::github::{IssueLister, MatchedIssue};
+
+/// Select the issues not yet seen, recording them in `seen`.
+///
+/// Why: the core of listen-mode dedup — each poll re-returns every matching
+/// issue, but only issues whose numbers are new this process should be
+/// dispatched, or the loop would re-run the same work every cycle. Keeping this
+/// a pure function over an explicit set makes the invariant ("an issue is
+/// dispatched at most once per process") directly testable.
+/// What: returns the subset of `issues` whose `number` is absent from `seen`,
+/// inserting each returned number into `seen` as it goes. Input order is
+/// preserved. Dry-run callers pass a set they DON'T want mutated by using a
+/// throwaway clone; execute callers pass the persistent set.
+/// Test: `select_new_issues_filters_seen`, `select_new_issues_records_new`,
+/// `select_new_issues_dedups_within_batch`.
+pub(crate) fn select_new_issues(
+    issues: &[MatchedIssue],
+    seen: &mut HashSet<u64>,
+) -> Vec<MatchedIssue> {
+    let mut fresh = Vec::new();
+    for issue in issues {
+        if seen.insert(issue.number) {
+            fresh.push(issue.clone());
+        }
+    }
+    fresh
+}
+
+/// Drive the `tm watch listen` poll loop until Ctrl-C.
+///
+/// Why: the long-running entry point. Polling on an interval (rather than a
+/// webhook) keeps it dependency-free and locally testable while still achieving
+/// "process newly-matched issues each cycle". Trapping SIGINT lets an operator
+/// stop it cleanly without orphaning the current cycle.
+/// What: loops forever: list label-matched issues via `lister`, [`select_new_issues`]
+/// to drop already-seen numbers, [`dispatch_issue`] each new one (honouring the
+/// dry-run/execute `mode`), then `tokio::select!` a `sleep(interval)` against
+/// `ctrl_c()` so a signal during the sleep breaks out immediately. A failed poll
+/// is logged to stderr and retried next cycle rather than aborting the loop.
+/// `repo_url`/`base_ref` are the resolved clone URL + default branch threaded
+/// into each dispatch.
+/// Test: the pure dedup step is unit-tested; the loop wiring (sleep + signal) is
+/// exercised manually (it would otherwise block tests).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_listen_loop<L: IssueLister>(
+    client: &reqwest::Client,
+    url: &str,
+    lister: &L,
+    settings: &ResolvedWatch,
+    repo_url: &str,
+    base_ref: &str,
+    mode: DispatchMode,
+    runtime: RuntimeKind,
+) -> anyhow::Result<()> {
+    let mut seen: HashSet<u64> = HashSet::new();
+    let interval = std::time::Duration::from_secs(settings.interval_secs);
+    eprintln!(
+        "tm watch listen: polling {} for label `{}` every {}s ({}); Ctrl-C to stop",
+        settings.repo,
+        settings.label,
+        settings.interval_secs,
+        match mode {
+            DispatchMode::DryRun => "dry-run",
+            DispatchMode::Execute => "EXECUTE",
+        }
+    );
+
+    loop {
+        match lister.list(&settings.repo, &settings.label, settings.state) {
+            Ok(issues) => {
+                let fresh = select_new_issues(&issues, &mut seen);
+                if fresh.is_empty() {
+                    eprintln!(
+                        "tm watch listen: no new matched issues (seen {} total)",
+                        seen.len()
+                    );
+                } else {
+                    for issue in &fresh {
+                        if let Err(e) =
+                            dispatch_issue(client, url, repo_url, base_ref, issue, mode, runtime)
+                                .await
+                        {
+                            // A dispatch failure for one issue must not kill the
+                            // loop or poison the seen-set permanently: drop it
+                            // from `seen` so a later cycle can retry it.
+                            seen.remove(&issue.number);
+                            eprintln!("tm watch listen: dispatch of #{} failed: {e}", issue.number);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("tm watch listen: poll failed (will retry): {e}");
+            }
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            r = tokio::signal::ctrl_c() => {
+                match r {
+                    Ok(()) => eprintln!("\ntm watch listen: received Ctrl-C, stopping"),
+                    Err(e) => eprintln!("\ntm watch listen: signal error ({e}), stopping"),
+                }
+                break;
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/mod.rs
@@ -92,6 +92,7 @@ pub(crate) fn resolve_board_repo<R: CommandRunner>(
     runner: &R,
     repo: &str,
 ) -> anyhow::Result<BoardRepo> {
+    // TODO: support configurable GitHub host (GHE)
     let clone_url = format!("https://github.com/{repo}");
     let out = runner.run(
         "gh",

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/mod.rs
@@ -1,0 +1,239 @@
+//! `tm watch poll|listen <project>` — autonomous label-routed ticket execution.
+//!
+//! Why: the existing `tm ticket <issue#>` model executes ONE hand-named issue. A
+//! board-watch mode complements it: discover every issue carrying a routing label
+//! and dispatch each into the SAME managed-session execution path, so a team can
+//! drop the label on an issue and have it picked up autonomously. Routing is by
+//! LABEL (default `tm-agent`), not assignee — no bot account exists. `poll` is the
+//! one-shot, cron-friendly form; `listen` is a long-running poll loop.
+//! What: this module owns the two operator entry points — [`poll`] (discover +
+//! dispatch once, then exit) and [`listen`] (poll-loop until Ctrl-C) — plus the
+//! repo-coordinate resolver ([`resolve_board_repo`]) and the safety-gate mapping
+//! ([`dispatch_mode`]). Discovery lives in `github`, settings precedence in
+//! `args`, per-issue dispatch in `dispatch`, and the loop in `listen`.
+//!
+//! SAFETY: both entry points default to DRY-RUN. They only spawn real work when
+//! the operator passes `--execute`. `--dry-run` is also accepted (and is the
+//! default), so the safe path is the one you get by doing nothing special; mass
+//! execution requires the explicit, hard-to-fat-finger `--execute` opt-in.
+//!
+//! Test: `resolve_board_repo_*`, `dispatch_mode_*`, and the args/github/dispatch/
+//! listen unit tests in `tests.rs`.
+
+pub(crate) mod args;
+pub(crate) mod dispatch;
+pub(crate) mod github;
+pub(crate) mod listen;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+use trusty_mpm::runtime::RuntimeKind;
+
+use crate::commands::ticket::runner::{CommandRunner, RealCommandRunner};
+use trusty_mpm::core::trusty_tools_config::TrustyToolsConfig;
+
+use args::{RawWatchArgs, ResolvedWatch, resolve};
+use dispatch::{DispatchMode, dispatch_issue};
+use github::{GhIssueLister, IssueLister};
+use listen::run_listen_loop;
+
+/// Resolved clone URL + base ref for a board repository.
+///
+/// Why: the managed-spawn endpoint needs a clone URL AND a base ref to branch
+/// from. For watch the board is named as `owner/repo` (possibly remote, not the
+/// current checkout), so the clone URL is synthesised and the default branch is
+/// asked of `gh` for that specific repo — hard-coding `main` would be wrong for
+/// `master`/`trunk` boards.
+/// What: the `https://github.com/<owner>/<repo>` clone URL and the repo's actual
+/// default branch name.
+/// Test: `resolve_board_repo_threads_default_branch`,
+/// `resolve_board_repo_falls_back_to_main`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoardRepo {
+    /// HTTPS clone URL for the board repository.
+    pub(crate) clone_url: String,
+    /// The board repository's default branch (base ref for new branches).
+    pub(crate) default_branch: String,
+}
+
+/// Map the CLI safety flags to a [`DispatchMode`], defaulting to dry-run.
+///
+/// Why: the safety model must be "safe unless explicitly told otherwise". This
+/// folds the two flags into one decision in a tested place so neither entry point
+/// can accidentally execute: `--execute` is required to spawn; absence of it (or
+/// an explicit `--dry-run`) is dry-run. `--dry-run` always wins over `--execute`
+/// if both are somehow passed, biasing toward safety.
+/// What: returns [`DispatchMode::Execute`] only when `execute && !dry_run`;
+/// otherwise [`DispatchMode::DryRun`].
+/// Test: `dispatch_mode_defaults_to_dry_run`, `dispatch_mode_execute_opts_in`,
+/// `dispatch_mode_dry_run_wins_over_execute`.
+pub(crate) fn dispatch_mode(execute: bool, dry_run: bool) -> DispatchMode {
+    if execute && !dry_run {
+        DispatchMode::Execute
+    } else {
+        DispatchMode::DryRun
+    }
+}
+
+/// Resolve a board repo's clone URL + default branch via `gh`.
+///
+/// Why: watch dispatches into the managed-spawn path, which clones a URL and
+/// branches off a base ref. The board may be a different repo than the current
+/// checkout, so we synthesise the HTTPS clone URL from `owner/repo` and ask `gh`
+/// for THAT repo's default branch (so `master`/`trunk` boards branch correctly).
+/// What: builds `https://github.com/<repo>` and runs
+/// `gh repo view <repo> --json defaultBranchRef --jq …` through the injected
+/// [`CommandRunner`]; falls back to `main` only when gh returns an empty branch.
+/// Test: `resolve_board_repo_threads_default_branch`,
+/// `resolve_board_repo_falls_back_to_main`.
+pub(crate) fn resolve_board_repo<R: CommandRunner>(
+    runner: &R,
+    repo: &str,
+) -> anyhow::Result<BoardRepo> {
+    let clone_url = format!("https://github.com/{repo}");
+    let out = runner.run(
+        "gh",
+        &[
+            "repo",
+            "view",
+            repo,
+            "--json",
+            "defaultBranchRef",
+            "--jq",
+            ".defaultBranchRef.name",
+        ],
+    )?;
+    let default_branch = out.ok_or_stderr("gh repo view")?;
+    let default_branch = if default_branch.is_empty() {
+        "main".to_string()
+    } else {
+        default_branch
+    };
+    Ok(BoardRepo {
+        clone_url,
+        default_branch,
+    })
+}
+
+/// `tm watch poll <project>` — discover label-matched issues and dispatch once.
+///
+/// Why: the one-shot, stateless, cron-friendly entry point: list every issue
+/// carrying the routing label, dispatch each (dry-run by default, execute only
+/// with `--execute`), then exit. No loop, no state — a scheduler re-runs it.
+/// What: loads config, resolves settings (CLI > config > defaults), resolves the
+/// board repo coords, lists matched issues via `gh`, and dispatches each through
+/// the shared [`dispatch_issue`]. Prints a summary and returns.
+/// Test: settings/repo/mode resolution are unit-tested; the gh + HTTP path is
+/// exercised manually (and mirrors `tm ticket`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn poll(
+    client: &reqwest::Client,
+    url: &str,
+    raw: RawWatchArgs,
+    execute: bool,
+    dry_run: bool,
+    runtime: RuntimeKind,
+) -> anyhow::Result<()> {
+    let config = TrustyToolsConfig::load();
+    let settings = resolve(&raw, &config.watch.unwrap_or_default())?;
+    let mode = dispatch_mode(execute, dry_run);
+
+    let runner = RealCommandRunner;
+    let lister = GhIssueLister::new(RealCommandRunner);
+    run_poll_once(client, url, &runner, &lister, &settings, mode, runtime).await
+}
+
+/// One-shot poll body, generic over the runner + lister seams for testing.
+///
+/// Why: factoring the body out from [`poll`] (which constructs the real `gh`
+/// seams) lets the discover→dispatch flow be driven by fakes in tests without a
+/// live `gh`, while the public entry point stays a thin wiring shim.
+/// What: resolves the board repo, lists matched issues, dispatches each via
+/// [`dispatch_issue`], and prints a count summary.
+/// Test: covered indirectly via the dispatch/github unit tests; the dry-run no-op
+/// invariant is asserted on the underlying `dispatch_issue`.
+async fn run_poll_once<R: CommandRunner, L: IssueLister>(
+    client: &reqwest::Client,
+    url: &str,
+    runner: &R,
+    lister: &L,
+    settings: &ResolvedWatch,
+    mode: DispatchMode,
+    runtime: RuntimeKind,
+) -> anyhow::Result<()> {
+    let board = resolve_board_repo(runner, &settings.repo)?;
+    let issues = lister.list(&settings.repo, &settings.label, settings.state)?;
+    eprintln!(
+        "tm watch poll: {} issue(s) on {} carry label `{}` ({})",
+        issues.len(),
+        settings.repo,
+        settings.label,
+        match mode {
+            DispatchMode::DryRun => "dry-run",
+            DispatchMode::Execute => "EXECUTE",
+        }
+    );
+    let mut dispatched = 0usize;
+    for issue in &issues {
+        if dispatch_issue(
+            client,
+            url,
+            &board.clone_url,
+            &board.default_branch,
+            issue,
+            mode,
+            runtime,
+        )
+        .await?
+        {
+            dispatched += 1;
+        }
+    }
+    eprintln!(
+        "tm watch poll: done — {dispatched} dispatched, {} considered",
+        issues.len()
+    );
+    Ok(())
+}
+
+/// `tm watch listen <project>` — poll the board on an interval until Ctrl-C.
+///
+/// Why: the long-running entry point that processes newly-matched issues each
+/// cycle, de-duplicating already-seen issue numbers so the same issue is not
+/// re-dispatched every poll. Defaults to dry-run; `--execute` opts into real
+/// spawning.
+/// What: loads config, resolves settings, resolves the board repo coords, then
+/// hands off to [`run_listen_loop`] (poll → dedup → dispatch → sleep), which
+/// traps SIGINT for a clean stop.
+/// Test: the dedup core ([`select_new_issues`]) is unit-tested; the loop is
+/// exercised manually (it sleeps + traps signals).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn listen(
+    client: &reqwest::Client,
+    url: &str,
+    raw: RawWatchArgs,
+    execute: bool,
+    dry_run: bool,
+    runtime: RuntimeKind,
+) -> anyhow::Result<()> {
+    let config = TrustyToolsConfig::load();
+    let settings = resolve(&raw, &config.watch.unwrap_or_default())?;
+    let mode = dispatch_mode(execute, dry_run);
+
+    let runner = RealCommandRunner;
+    let board = resolve_board_repo(&runner, &settings.repo)?;
+    let lister = GhIssueLister::new(RealCommandRunner);
+    run_listen_loop(
+        client,
+        url,
+        &lister,
+        &settings,
+        &board.clone_url,
+        &board.default_branch,
+        mode,
+        runtime,
+    )
+    .await
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/tests.rs
@@ -21,7 +21,7 @@ use super::dispatch::{DispatchMode, build_watch_task, dispatch_issue, watch_bran
 use super::github::{
     GhIssueLister, IssueLister, IssueState, MatchedIssue, filter_by_label, parse_issues,
 };
-use super::listen::select_new_issues;
+use super::listen::{select_new_issues, should_warn};
 use super::{BoardRepo, dispatch_mode, resolve_board_repo};
 
 use crate::commands::ticket::runner::{CommandOutput, CommandRunner};
@@ -494,4 +494,12 @@ fn select_new_issues_second_poll_is_empty() {
     assert_eq!(first.len(), 2);
     let second = select_new_issues(&batch, &mut seen);
     assert!(second.is_empty(), "re-poll of same issues must be empty");
+}
+
+#[test]
+fn should_warn_only_for_execute() {
+    // The in-memory-dedup restart warning must fire only when we actually spawn
+    // work (Execute); dry-run re-listing is harmless and must stay quiet.
+    assert!(should_warn(DispatchMode::Execute));
+    assert!(!should_warn(DispatchMode::DryRun));
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/tests.rs
@@ -1,0 +1,497 @@
+//! Unit tests for the `tm watch` module (label filtering, project/owner-repo
+//! parsing, dry-run no-op, listen dedup, config-default + flag-override
+//! precedence, and the gh discovery seam).
+//!
+//! Why: `tm watch` drives real execution against real repos, so its decision
+//! logic — which issues match, how settings resolve, whether dry-run spawns
+//! anything, and how listen de-duplicates — must be pinned by fast, network-free
+//! tests using the `CommandRunner`/`IssueLister` seams.
+//! What: groups tests by concern: github parsing/filtering + the gh-backed
+//! lister, args precedence + project resolution, the dispatch task/branch/dry-run
+//! invariants, the safety-gate mapping, the board-repo resolver, and the listen
+//! dedup core.
+//! Test: this file IS the test surface; run via `cargo test -p trusty-mpm`.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use super::args::{DEFAULT_INTERVAL_SECS, DEFAULT_LABEL, RawWatchArgs, resolve};
+use super::dispatch::{DispatchMode, build_watch_task, dispatch_issue, watch_branch_name};
+use super::github::{
+    GhIssueLister, IssueLister, IssueState, MatchedIssue, filter_by_label, parse_issues,
+};
+use super::listen::select_new_issues;
+use super::{BoardRepo, dispatch_mode, resolve_board_repo};
+
+use crate::commands::ticket::runner::{CommandOutput, CommandRunner};
+use trusty_mpm::core::trusty_tools_config::WatchConfig;
+
+use trusty_mpm::runtime::RuntimeKind;
+
+// --- shared fakes ----------------------------------------------------------
+
+/// Recorded `(program, args)` invocations, shared across a move into a lister.
+///
+/// Why: a named alias keeps the `Rc<RefCell<…>>` handle off the `type_complexity`
+/// lint while documenting that it is a shared, mutable call log.
+/// What: a reference-counted, interior-mutable vector of `(program, args)` pairs.
+/// Test: used by `FakeRunner` and `gh_list_passes_label_and_state_flags`.
+type CallLog = Rc<RefCell<Vec<(String, Vec<String>)>>>;
+
+/// A scripted [`CommandRunner`] returning queued outputs and recording calls.
+///
+/// Why: drives the gh-backed lister + board resolver without spawning processes.
+/// What: pops queued [`CommandOutput`]s FIFO; records `(program, args)` per call.
+/// Test: used by `gh_list_*` and `resolve_board_repo_*`.
+struct FakeRunner {
+    outputs: RefCell<Vec<CommandOutput>>,
+    /// Shared so a test can keep a handle after the runner is moved into a lister.
+    calls: CallLog,
+}
+
+impl FakeRunner {
+    fn new(outputs: Vec<CommandOutput>) -> Self {
+        Self {
+            outputs: RefCell::new(outputs),
+            calls: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    /// A cloneable handle to the recorded calls (read after a move).
+    fn calls_handle(&self) -> CallLog {
+        Rc::clone(&self.calls)
+    }
+}
+
+impl CommandRunner for FakeRunner {
+    fn run(&self, program: &str, args: &[&str]) -> anyhow::Result<CommandOutput> {
+        self.calls.borrow_mut().push((
+            program.to_string(),
+            args.iter().map(|a| a.to_string()).collect(),
+        ));
+        let mut outs = self.outputs.borrow_mut();
+        if outs.is_empty() {
+            anyhow::bail!("FakeRunner exhausted")
+        }
+        Ok(outs.remove(0))
+    }
+}
+
+fn ok_out(stdout: &str) -> CommandOutput {
+    CommandOutput {
+        success: true,
+        stdout: stdout.to_string(),
+        stderr: String::new(),
+    }
+}
+
+fn fail_out(stderr: &str) -> CommandOutput {
+    CommandOutput {
+        success: false,
+        stdout: String::new(),
+        stderr: stderr.to_string(),
+    }
+}
+
+fn issue(number: u64, labels: &[&str]) -> MatchedIssue {
+    MatchedIssue {
+        number,
+        title: format!("Issue {number}"),
+        body: "body".to_string(),
+        labels: labels.iter().map(|s| s.to_string()).collect(),
+        url: format!("https://github.com/o/r/issues/{number}"),
+    }
+}
+
+// --- github: parsing + filtering ------------------------------------------
+
+#[test]
+fn issue_state_default_is_open() {
+    assert_eq!(IssueState::default(), IssueState::Open);
+}
+
+#[test]
+fn issue_state_as_gh() {
+    assert_eq!(IssueState::Open.as_gh(), "open");
+    assert_eq!(IssueState::All.as_gh(), "all");
+}
+
+#[test]
+fn parse_issues_basic() {
+    let json = r#"[
+        {"number":1,"title":"A","body":"do a","labels":[{"name":"tm-agent"}],"url":"https://x/1"},
+        {"number":2,"title":"B","body":"","labels":[{"name":"bug"},{"name":"tm-agent"}],"url":"https://x/2"}
+    ]"#;
+    let issues = parse_issues(json).expect("parse");
+    assert_eq!(issues.len(), 2);
+    assert_eq!(issues[0].number, 1);
+    assert_eq!(issues[0].title, "A");
+    assert_eq!(issues[0].body, "do a");
+    assert_eq!(issues[0].labels, vec!["tm-agent".to_string()]);
+    assert_eq!(issues[0].url, "https://x/1");
+    assert_eq!(
+        issues[1].labels,
+        vec!["bug".to_string(), "tm-agent".to_string()]
+    );
+}
+
+#[test]
+fn parse_issues_empty() {
+    assert!(parse_issues("[]").unwrap().is_empty());
+    assert!(parse_issues("   ").unwrap().is_empty());
+    assert!(parse_issues("").unwrap().is_empty());
+}
+
+#[test]
+fn parse_issues_rejects_garbage() {
+    assert!(parse_issues("not json").is_err());
+}
+
+#[test]
+fn filter_by_label_keeps_only_matching() {
+    let issues = vec![
+        issue(1, &["tm-agent"]),
+        issue(2, &["bug"]),
+        issue(3, &["enhancement", "tm-agent"]),
+    ];
+    let kept = filter_by_label(issues, "tm-agent");
+    let nums: Vec<u64> = kept.iter().map(|i| i.number).collect();
+    assert_eq!(nums, vec![1, 3]);
+}
+
+#[test]
+fn filter_by_label_case_insensitive() {
+    let issues = vec![issue(1, &["TM-Agent"]), issue(2, &["bug"])];
+    let kept = filter_by_label(issues, "tm-agent");
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].number, 1);
+}
+
+#[test]
+fn filter_by_label_empty_when_none_match() {
+    let issues = vec![issue(1, &["bug"]), issue(2, &["chore"])];
+    assert!(filter_by_label(issues, "tm-agent").is_empty());
+}
+
+// --- github: gh-backed lister ---------------------------------------------
+
+#[test]
+fn gh_list_parses_and_filters() {
+    // gh returns two issues; both carry the label server-side, so both survive
+    // the defensive re-filter.
+    let json = r#"[
+        {"number":10,"title":"X","body":"b","labels":[{"name":"tm-agent"}],"url":"https://x/10"},
+        {"number":11,"title":"Y","body":"b","labels":[{"name":"tm-agent"}],"url":"https://x/11"}
+    ]"#;
+    let lister = GhIssueLister::new(FakeRunner::new(vec![ok_out(json)]));
+    let got = lister
+        .list("o/r", "tm-agent", IssueState::Open)
+        .expect("list");
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].number, 10);
+}
+
+#[test]
+fn gh_list_defensive_filter_drops_unmatched() {
+    // A loose backend returns an issue WITHOUT the label; the defensive filter
+    // must drop it so only labelled issues ever reach dispatch.
+    let json = r#"[
+        {"number":10,"title":"X","body":"b","labels":[{"name":"tm-agent"}],"url":"https://x/10"},
+        {"number":12,"title":"Z","body":"b","labels":[{"name":"unrelated"}],"url":"https://x/12"}
+    ]"#;
+    let lister = GhIssueLister::new(FakeRunner::new(vec![ok_out(json)]));
+    let got = lister
+        .list("o/r", "tm-agent", IssueState::Open)
+        .expect("list");
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].number, 10);
+}
+
+#[test]
+fn gh_list_surfaces_gh_failure() {
+    let lister = GhIssueLister::new(FakeRunner::new(vec![fail_out("not logged in")]));
+    let err = lister
+        .list("o/r", "tm-agent", IssueState::Open)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("gh issue list"), "got: {err}");
+    assert!(err.contains("not logged in"), "got: {err}");
+}
+
+#[test]
+fn gh_list_passes_label_and_state_flags() {
+    let runner = FakeRunner::new(vec![ok_out("[]")]);
+    let calls = runner.calls_handle();
+    let lister = GhIssueLister::new(runner);
+    let _ = lister.list("acme/widget", "ship-it", IssueState::All);
+    let recorded = calls.borrow();
+    let args = &recorded[0].1;
+    assert!(args.contains(&"-R".to_string()));
+    assert!(args.contains(&"acme/widget".to_string()));
+    assert!(args.contains(&"--label".to_string()));
+    assert!(args.contains(&"ship-it".to_string()));
+    assert!(args.contains(&"--state".to_string()));
+    assert!(args.contains(&"all".to_string()));
+}
+
+// --- args: project resolution + precedence --------------------------------
+
+#[test]
+fn resolve_project_direct_owner_repo() {
+    let raw = RawWatchArgs {
+        project: "bobmatnyc/trusty-tools".into(),
+        ..Default::default()
+    };
+    let cfg = WatchConfig::default();
+    let r = resolve(&raw, &cfg).expect("resolve");
+    assert_eq!(r.repo, "bobmatnyc/trusty-tools");
+}
+
+#[test]
+fn resolve_project_name_uses_config() {
+    // A bare name (not owner/repo) falls back to the configured repo.
+    let raw = RawWatchArgs {
+        project: "myboard".into(),
+        ..Default::default()
+    };
+    let cfg = WatchConfig {
+        repo: Some("acme/widget".into()),
+        ..Default::default()
+    };
+    let r = resolve(&raw, &cfg).expect("resolve");
+    assert_eq!(r.repo, "acme/widget");
+}
+
+#[test]
+fn resolve_project_unresolvable_errors() {
+    let raw = RawWatchArgs {
+        project: "justaname".into(),
+        ..Default::default()
+    };
+    let cfg = WatchConfig::default();
+    let err = resolve(&raw, &cfg).unwrap_err().to_string();
+    assert!(err.contains("could not resolve project"), "got: {err}");
+    assert!(err.contains("owner/repo"), "got: {err}");
+}
+
+#[test]
+fn resolve_cli_overrides_config() {
+    let raw = RawWatchArgs {
+        project: "o/r".into(),
+        label: Some("cli-label".into()),
+        interval_secs: Some(5),
+        state: Some(IssueState::All),
+    };
+    let cfg = WatchConfig {
+        repo: None,
+        label: Some("config-label".into()),
+        interval_secs: Some(999),
+    };
+    let r = resolve(&raw, &cfg).expect("resolve");
+    assert_eq!(r.label, "cli-label");
+    assert_eq!(r.interval_secs, 5);
+    assert_eq!(r.state, IssueState::All);
+}
+
+#[test]
+fn resolve_config_used_when_no_cli() {
+    let raw = RawWatchArgs {
+        project: "o/r".into(),
+        ..Default::default()
+    };
+    let cfg = WatchConfig {
+        repo: None,
+        label: Some("config-label".into()),
+        interval_secs: Some(120),
+    };
+    let r = resolve(&raw, &cfg).expect("resolve");
+    assert_eq!(r.label, "config-label");
+    assert_eq!(r.interval_secs, 120);
+}
+
+#[test]
+fn resolve_uses_default_label_when_unset() {
+    let raw = RawWatchArgs {
+        project: "o/r".into(),
+        ..Default::default()
+    };
+    let r = resolve(&raw, &WatchConfig::default()).expect("resolve");
+    assert_eq!(r.label, DEFAULT_LABEL);
+}
+
+#[test]
+fn resolve_uses_default_interval_when_unset() {
+    let raw = RawWatchArgs {
+        project: "o/r".into(),
+        ..Default::default()
+    };
+    let r = resolve(&raw, &WatchConfig::default()).expect("resolve");
+    assert_eq!(r.interval_secs, DEFAULT_INTERVAL_SECS);
+}
+
+#[test]
+fn resolve_zero_interval_falls_back_to_default() {
+    // A zero interval (CLI or config) is nonsense; it must fall back to default.
+    let raw = RawWatchArgs {
+        project: "o/r".into(),
+        interval_secs: Some(0),
+        ..Default::default()
+    };
+    let r = resolve(&raw, &WatchConfig::default()).expect("resolve");
+    assert_eq!(r.interval_secs, DEFAULT_INTERVAL_SECS);
+}
+
+#[test]
+fn resolve_state_defaults_to_open() {
+    let raw = RawWatchArgs {
+        project: "o/r".into(),
+        ..Default::default()
+    };
+    let r = resolve(&raw, &WatchConfig::default()).expect("resolve");
+    assert_eq!(r.state, IssueState::Open);
+}
+
+// --- dispatch: task / branch / dry-run ------------------------------------
+
+#[test]
+fn watch_branch_name_is_namespaced() {
+    assert_eq!(watch_branch_name(&issue(42, &["tm-agent"])), "tm-watch/42");
+}
+
+#[test]
+fn build_watch_task_includes_branch_and_close() {
+    let task = build_watch_task(&issue(7, &["tm-agent"]), "tm-watch/7", "main");
+    assert!(task.contains("issue #7"));
+    assert!(task.contains("tm-watch/7"));
+    assert!(task.contains("default branch `main`"));
+    assert!(task.contains("Closes #7"));
+    assert!(task.contains("pull request"));
+}
+
+#[test]
+fn build_watch_task_handles_empty_body() {
+    let mut i = issue(8, &["tm-agent"]);
+    i.body = "   ".into();
+    let task = build_watch_task(&i, "tm-watch/8", "master");
+    assert!(task.contains("(no body provided)"));
+    assert!(task.contains("default branch `master`"));
+}
+
+#[tokio::test]
+async fn dispatch_dry_run_spawns_nothing() {
+    // The daemon URL is deliberately unroutable; a dry-run must NOT make any HTTP
+    // call, so this returns Ok(false) without erroring on the bad URL.
+    let client = reqwest::Client::new();
+    let i = issue(99, &["tm-agent"]);
+    let spawned = dispatch_issue(
+        &client,
+        "http://127.0.0.1:1", // would fail if contacted
+        "https://github.com/o/r",
+        "main",
+        &i,
+        DispatchMode::DryRun,
+        RuntimeKind::ClaudeCode,
+    )
+    .await
+    .expect("dry-run must not error");
+    assert!(!spawned, "dry-run must report nothing spawned");
+}
+
+// --- safety gate -----------------------------------------------------------
+
+#[test]
+fn dispatch_mode_defaults_to_dry_run() {
+    // Neither flag set → dry-run (the safe default).
+    assert_eq!(dispatch_mode(false, false), DispatchMode::DryRun);
+}
+
+#[test]
+fn dispatch_mode_execute_opts_in() {
+    assert_eq!(dispatch_mode(true, false), DispatchMode::Execute);
+}
+
+#[test]
+fn dispatch_mode_dry_run_wins_over_execute() {
+    // If both are passed, safety wins.
+    assert_eq!(dispatch_mode(true, true), DispatchMode::DryRun);
+}
+
+#[test]
+fn dispatch_mode_explicit_dry_run() {
+    assert_eq!(dispatch_mode(false, true), DispatchMode::DryRun);
+}
+
+// --- board-repo resolver ---------------------------------------------------
+
+#[test]
+fn resolve_board_repo_threads_default_branch() {
+    let runner = FakeRunner::new(vec![ok_out("trunk")]);
+    let board = resolve_board_repo(&runner, "acme/widget").expect("resolve");
+    assert_eq!(
+        board,
+        BoardRepo {
+            clone_url: "https://github.com/acme/widget".into(),
+            default_branch: "trunk".into(),
+        }
+    );
+}
+
+#[test]
+fn resolve_board_repo_falls_back_to_main() {
+    let runner = FakeRunner::new(vec![ok_out("")]);
+    let board = resolve_board_repo(&runner, "acme/widget").expect("resolve");
+    assert_eq!(board.default_branch, "main");
+}
+
+#[test]
+fn resolve_board_repo_surfaces_failure() {
+    let runner = FakeRunner::new(vec![fail_out("no such repo")]);
+    let err = resolve_board_repo(&runner, "acme/widget")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no such repo"), "got: {err}");
+}
+
+// --- listen: dedup core ----------------------------------------------------
+
+#[test]
+fn select_new_issues_records_new() {
+    let mut seen = HashSet::new();
+    let batch = vec![issue(1, &["tm-agent"]), issue(2, &["tm-agent"])];
+    let fresh = select_new_issues(&batch, &mut seen);
+    assert_eq!(fresh.len(), 2);
+    assert!(seen.contains(&1));
+    assert!(seen.contains(&2));
+}
+
+#[test]
+fn select_new_issues_filters_seen() {
+    let mut seen = HashSet::new();
+    seen.insert(1);
+    let batch = vec![issue(1, &["tm-agent"]), issue(2, &["tm-agent"])];
+    let fresh = select_new_issues(&batch, &mut seen);
+    // Only #2 is new; #1 was already seen.
+    let nums: Vec<u64> = fresh.iter().map(|i| i.number).collect();
+    assert_eq!(nums, vec![2]);
+}
+
+#[test]
+fn select_new_issues_dedups_within_batch() {
+    // A duplicate number within a single batch must only be returned once.
+    let mut seen = HashSet::new();
+    let batch = vec![issue(3, &["tm-agent"]), issue(3, &["tm-agent"])];
+    let fresh = select_new_issues(&batch, &mut seen);
+    assert_eq!(fresh.len(), 1);
+}
+
+#[test]
+fn select_new_issues_second_poll_is_empty() {
+    // Simulate two polls returning the same issues: the second yields nothing.
+    let mut seen = HashSet::new();
+    let batch = vec![issue(1, &["tm-agent"]), issue(2, &["tm-agent"])];
+    let first = select_new_issues(&batch, &mut seen);
+    assert_eq!(first.len(), 2);
+    let second = select_new_issues(&batch, &mut seen);
+    assert!(second.is_empty(), "re-poll of same issues must be empty");
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -249,6 +249,60 @@ async fn main() -> anyhow::Result<()> {
             runtime,
         } => commands::ticket::ticket(&client, &url, issue, system, notes, runtime).await,
         Command::Issue { cmd, system } => commands::issue::issue(cmd, system),
+        Command::Watch { cmd } => dispatch_watch(&client, &url, cmd).await,
+    }
+}
+
+/// Dispatch a `tm watch poll|listen` invocation to its handler.
+///
+/// Why: keeps `main`'s match arm thin by folding the flattened [`WatchArgs`] into
+/// the [`commands::watch`] entry points in one place, mapping the shared CLI flags
+/// onto the module's `RawWatchArgs` and the safety-gate booleans.
+/// What: builds a `RawWatchArgs` from the parsed flags and calls
+/// [`commands::watch::poll`] or [`commands::watch::listen`] accordingly, threading
+/// the `--execute`/`--dry-run` safety flags and the spawn runtime through.
+/// Test: the resolution/safety logic is unit-tested in `commands::watch::tests`;
+/// CLI parsing in `tests.rs` (`cli_parses_watch_*`).
+async fn dispatch_watch(
+    client: &reqwest::Client,
+    url: &str,
+    cmd: cli::WatchCmd,
+) -> anyhow::Result<()> {
+    use cli::{WatchArgs, WatchCmd};
+    use commands::watch::args::RawWatchArgs;
+
+    fn raw(args: &WatchArgs) -> RawWatchArgs {
+        RawWatchArgs {
+            project: args.project.clone(),
+            label: args.label.clone(),
+            interval_secs: args.interval_secs,
+            state: args.state,
+        }
+    }
+
+    match cmd {
+        WatchCmd::Poll { args } => {
+            commands::watch::poll(
+                client,
+                url,
+                raw(&args),
+                args.execute,
+                args.dry_run,
+                args.runtime,
+            )
+            .await
+        }
+        WatchCmd::Listen { args } => {
+            commands::watch::listen(
+                client,
+                url,
+                raw(&args),
+                args.execute,
+                args.dry_run,
+                args.runtime,
+            )
+            .await
+        }
     }
 }
 
@@ -306,7 +360,9 @@ fn resolve_gui_binary() -> std::path::PathBuf {
     if let Ok(exe) = std::env::current_exe()
         && let Some(dir) = exe.parent()
     {
-        let sibling = dir.join(GUI_BIN);
+        // Include the platform executable suffix (`.exe` on Windows; "" on
+        // macOS/Linux) so the sibling lookup finds the GUI binary on every OS.
+        let sibling = dir.join(format!("{GUI_BIN}{}", std::env::consts::EXE_SUFFIX));
         if sibling.is_file() {
             return sibling;
         }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1058,3 +1058,82 @@ fn cli_parses_issue_seed_config_force() {
         }
     ));
 }
+
+#[test]
+fn cli_parses_watch_poll_minimal() {
+    // Why: the minimal `tm watch poll <project>` must parse with safety defaults
+    // (dry-run off but execute also off → dry-run behaviour) and claude-code.
+    use crate::cli::WatchCmd;
+    let cli = Cli::try_parse_from(["trusty-mpm", "watch", "poll", "owner/repo"]).unwrap();
+    match cli.command {
+        Command::Watch {
+            cmd: WatchCmd::Poll { args },
+        } => {
+            assert_eq!(args.project, "owner/repo");
+            assert!(args.label.is_none());
+            assert!(!args.dry_run);
+            assert!(!args.execute, "execute must default off (safe)");
+            assert!(args.interval_secs.is_none());
+            assert!(args.state.is_none());
+            assert_eq!(args.runtime, trusty_mpm::runtime::RuntimeKind::ClaudeCode);
+        }
+        other => panic!("expected watch poll, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_watch_poll_with_flags() {
+    // Why: `--label`, `--state`, and `--execute` must all parse on poll.
+    use crate::cli::WatchCmd;
+    use crate::commands::watch::github::IssueState;
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "watch",
+        "poll",
+        "acme/widget",
+        "--label",
+        "ship-it",
+        "--state",
+        "all",
+        "--execute",
+    ])
+    .unwrap();
+    match cli.command {
+        Command::Watch {
+            cmd: WatchCmd::Poll { args },
+        } => {
+            assert_eq!(args.project, "acme/widget");
+            assert_eq!(args.label.as_deref(), Some("ship-it"));
+            assert_eq!(args.state, Some(IssueState::All));
+            assert!(args.execute);
+        }
+        other => panic!("expected watch poll, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_watch_listen_with_interval() {
+    // Why: `tm watch listen <project> --interval-secs N --dry-run` must parse the
+    // listen-specific interval and the explicit safe flag.
+    use crate::cli::WatchCmd;
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "watch",
+        "listen",
+        "owner/repo",
+        "--interval-secs",
+        "30",
+        "--dry-run",
+    ])
+    .unwrap();
+    match cli.command {
+        Command::Watch {
+            cmd: WatchCmd::Listen { args },
+        } => {
+            assert_eq!(args.project, "owner/repo");
+            assert_eq!(args.interval_secs, Some(30));
+            assert!(args.dry_run);
+        }
+        other => panic!("expected watch listen, got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -86,6 +86,40 @@ pub struct TrustyToolsConfig {
     /// #1220 convention without touching the legacy TOML.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_model: Option<String>,
+
+    /// `tm watch` defaults (the `watch:` YAML section).
+    ///
+    /// `None` → no configured defaults; the watch CLI flags supply their own
+    /// built-in defaults. Present so an operator can pin a board's repo, routing
+    /// label, and poll interval declaratively instead of typing them every run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub watch: Option<WatchConfig>,
+}
+
+/// The `watch:` section of `~/.trusty-tools/trusty-mpm/config.yaml`.
+///
+/// Why: `tm watch poll|listen` routes board issues to managed sessions; an
+/// operator running it repeatedly (or from cron) wants to pin the board repo,
+/// the routing label, and the poll interval once rather than passing them on
+/// every invocation. Every field is optional so an absent section or key falls
+/// back to the CLI flag's built-in default; CLI flags always override config.
+/// What: optional `repo` (`owner/repo`), `label` (routing label), and
+/// `interval_secs` (listen-mode poll cadence). Resolution precedence lives in
+/// the `watch::args` module, not here — this is purely the on-disk shape.
+/// Test: round-trips via the `crate_config` tests; precedence in `watch::args`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatchConfig {
+    /// Default board repository as `owner/repo` (e.g. `bobmatnyc/trusty-tools`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+
+    /// Default routing label; only issues carrying it are picked up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+
+    /// Default poll interval (seconds) for `listen` mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval_secs: Option<u64>,
 }
 
 impl TrustyToolsConfig {


### PR DESCRIPTION
## Summary

Adds `tm watch poll|listen <project>` to the `tm` binary — an autonomous **board-watch** mode that complements the existing single-ticket `tm ticket <issue#>` model. It discovers GitHub issues carrying a routing **label** and dispatches each into the *same* managed-session execution path `tm ticket` already uses.

Closes the "watch a board for issues assigned to it" capability gap (label-routed, since no bot account exists).

---

## STEP 1 — Existing ticket-execution model (investigation findings)

`tm ticket <issue#> [system]` (issues #1244/#1237, commit `6eada1af`) is the canonical **execute-a-ticket** path, and it **does** execute (option (b), not just CRUD):

1. Validates the issue is **OPEN** via `gh issue view … --json …` (`commands/ticket/system.rs`, `GhTicketSystem`).
2. Posts any `--note` text as audit comments.
3. Derives a `<type>/<n>-<slug>` branch from the issue title/labels.
4. Resolves repo coords (`gh repo view` → clone URL + default branch).
5. **Spawns a managed Claude Code session** via `POST /api/v1/sessions/managed` (the P1 session-manager service, #1247/#1221) with a task prompt. The provisioner clones the repo into the P4 workspace root (`~/trusty-mpm-projects/<owner>/<repo>/<id>/`, #1220) and the #842 driver agent implements the change + opens the PR.

So a full autonomous execution path **already exists**. `tm watch` therefore does **not** re-build an execution engine — it discovers label-matched issues and **dispatches each into that exact managed-spawn path**, reusing these seams verbatim:

- `CommandRunner` / `RealCommandRunner` (process seam) — `commands/ticket/runner.rs`
- `parse_github_path` / `GithubPath` (owner/repo parsing) — `trusty-common`
- `TrustyToolsConfig` / `workspace_root` (P4 config + workspace root) — `trusty-mpm::core`
- `RuntimeKind` (`--runtime claude-code|tcode`)
- the `POST /api/v1/sessions/managed` request shape (mirrors `ticket::spawn_managed`)

**Gap / honesty note:** watch *dispatches* issues into the managed-spawn path; whether each dispatched session *completes* end-to-end (implements + opens a mergeable PR) depends on the existing driver agent + daemon, which this PR does not change. I am **not** claiming verified end-to-end autonomous completion — only that watch wires discovery into the same execution mechanism `tm ticket` uses.

---

## STEP 2 — CLI surface

```
tm watch poll   <project> [flags]   # one-shot: discover + dispatch, then exit (cron-friendly)
tm watch listen <project> [flags]   # long-running: poll on an interval until Ctrl-C
```

`<project>` = a direct `owner/repo` **or** a name resolved via the `watch:` config section.

| Flag | Default | Meaning |
|---|---|---|
| `--label <L>` | `tm-agent` | Routing label; only issues carrying it are picked up (routing is by **label**, not assignee). |
| `--interval-secs <N>` | `60` | `listen`-mode poll cadence. |
| `--state <open\|all>` | `open` | Which issues to consider. |
| `--dry-run` | (default behaviour) | List matched issues + what *would* run; spawn nothing. |
| `--execute` | off | **Required** to actually spawn managed sessions. |
| `--runtime <claude-code\|tcode>` | `claude-code` | Runtime for spawned sessions. |

**Auth:** shells out to `gh issue list -R <owner/repo> --label <L> --state <s> --json number,title,body,labels,assignees,url` (and `gh repo view` for the base ref). `gh`-absent / not-logged-in surfaces an actionable error.

**Config (`watch:` section of `~/.trusty-tools/trusty-mpm/config.yaml`, #1220):**
```yaml
watch:
  repo: bobmatnyc/trusty-tools
  label: tm-agent
  interval_secs: 120
```
Precedence: **CLI flag > config value > built-in default** (one tested resolver shared by both modes). Reuses the existing `crate-config` plumbing — no duplicate config loading.

**`listen` dedup + signals:** tracks already-processed issue numbers in-memory so the same issue is not re-dispatched every cycle; a per-issue dispatch failure drops it from the seen-set for retry. Stops cleanly on SIGINT (`tokio::signal::ctrl_c` raced against the sleep). Webhook-based listen is documented in-code as a future enhancement (#follow-up).

---

## STEP 3 — SAFETY model (default-safe)

Default behaviour is **DRY-RUN**. Real work is only spawned when the operator passes the explicit **`--execute`** flag, and `--dry-run` **always wins** if both are passed (`dispatch_mode(execute, dry_run)` biases toward safety). Accidental mass-execution against real repos is impossible. The dry-run path is well-tested and asserted to make **zero** HTTP calls.

---

## Module layout (all ≤500 SLOC, line-cap passes)

```
src/bin/tm/commands/watch/
  mod.rs       # poll/listen entry points, board-repo resolver, safety gate
  args.rs      # CLI→effective settings precedence + project resolution
  github.rs    # IssueLister seam + gh-backed impl + parse/filter
  dispatch.rs  # per-issue dispatch (dry-run vs managed spawn), task builder
  listen.rs    # poll loop + dedup core + SIGINT
  tests.rs     # unit tests (test file)
```

## STEP 3 (bonus) — PR #1259 review fix folded in

`resolve_gui_binary` in `main.rs` now builds the sibling path with `std::env::consts::EXE_SUFFIX` so the GUI lookup finds `trusty-mpm-gui.exe` on Windows (identical behaviour on macOS/Linux where the suffix is `""`).

## STEP 4 — Version

`trusty-mpm` 0.6.2 → **0.7.0** (new feature); root `[workspace.dependencies]` pin updated to 0.7.0 in sync.

---

## Tests (39 watch unit tests + 3 CLI parse tests, all passing)

- **label filtering**: `filter_by_label_keeps_only_matching`, `_case_insensitive`, `_empty_when_none_match`, `gh_list_defensive_filter_drops_unmatched`
- **gh discovery seam**: `gh_list_parses_and_filters`, `_surfaces_gh_failure`, `_passes_label_and_state_flags`, `parse_issues_basic/_empty/_rejects_garbage`
- **project / owner-repo parsing**: `resolve_project_direct_owner_repo`, `_name_uses_config`, `_unresolvable_errors`; board resolver `resolve_board_repo_threads_default_branch` / `_falls_back_to_main` / `_surfaces_failure`
- **config-default + flag-override precedence**: `resolve_cli_overrides_config`, `_config_used_when_no_cli`, `_uses_default_label/interval_when_unset`, `_zero_interval_falls_back_to_default`, `_state_defaults_to_open`
- **dry-run produces no execution**: `dispatch_dry_run_spawns_nothing` (unroutable URL, must not be contacted)
- **safety gate**: `dispatch_mode_defaults_to_dry_run`, `_execute_opts_in`, `_dry_run_wins_over_execute`, `_explicit_dry_run`
- **listen dedup of already-processed issues**: `select_new_issues_records_new`, `_filters_seen`, `_dedups_within_batch`, `_second_poll_is_empty`
- **task/branch**: `build_watch_task_includes_branch_and_close`, `_handles_empty_body`, `watch_branch_name_is_namespaced`
- **CLI parsing**: `cli_parses_watch_poll_minimal`, `_poll_with_flags`, `_listen_with_interval`

The `gh` call is mocked via the `CommandRunner`/`IssueLister` trait seams — no test hits the network.

Validation (raw): `cargo fmt --check` ✅ · `cargo clippy --workspace --all-targets -- -D warnings` ✅ (exit 0) · `cargo test -p trusty-mpm` ✅ (1018 + 284 pass, 0 fail) · `bash scripts/check_line_cap.sh` ✅ (`15 allowlisted, 0 violations — OK`).

## Dry-run publish

`SKIP_UI_BUILD=1 cargo publish --dry-run -p trusty-mpm` packages `trusty-mpm v0.7.0` cleanly and fails **only** at dependency resolution for the unpublished sibling `trusty-common ^0.15.2` (candidates on crates.io top out at 0.15.1) — the documented acceptable not-yet-on-crates.io case. No other errors.

## Follow-ups / gaps

- Webhook-based `listen` (event-driven instead of polled) — documented in-code.
- Optional persistent dedup state file under the P4 config dir (currently in-memory per process).
- End-to-end completion of dispatched sessions relies on the existing driver agent + daemon; not changed/verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)