### PR TITLE
fix(tm): unattended spawn config — isolate from user settings, fix memory hook/MCP, inject trusty-search, suppress trust/permission dialogs, fix port (closes #1268, #1269, #1270)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10949,7 +10949,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tga = { path = "crates/trusty-git-analytics", version = "2.8.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
-trusty-mpm = { path = "crates/trusty-mpm", version = "0.8.0" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "0.8.1" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -10,8 +10,24 @@ use std::net::SocketAddr;
 
 use clap::{Parser, Subcommand};
 
-/// Default daemon address when `--url` / `TRUSTY_MPM_URL` is unset.
-pub(crate) const DEFAULT_URL: &str = "http://127.0.0.1:7880";
+/// Default daemon URL when `--url` / `TRUSTY_MPM_URL` is unset.
+///
+/// Why (issue #1268): this must be the *same* address the daemon binds to by
+/// default, or the client probes a port nothing is listening on and reports
+/// "daemon: unreachable". It is re-exported from the single source of truth in
+/// `core::discovery` (which also drives the daemon `--addr` default) so the two
+/// sides can never drift.
+/// What: alias of [`trusty_mpm::core::DEFAULT_DAEMON_URL`].
+/// Test: `core::discovery::default_url_matches_addr` proves URL and addr agree.
+pub(crate) const DEFAULT_URL: &str = trusty_mpm::core::DEFAULT_DAEMON_URL;
+
+/// Default daemon bind address for the `daemon --addr` flag (issue #1268).
+///
+/// Why: keeps the daemon's bind default tied to the same constant that drives
+/// the client's [`DEFAULT_URL`], so `tm start` and the thin CLI always agree.
+/// What: alias of [`trusty_mpm::core::DEFAULT_DAEMON_ADDR`].
+/// Test: `core::discovery::default_addr_parses`.
+pub(crate) const DEFAULT_ADDR: &str = trusty_mpm::core::DEFAULT_DAEMON_ADDR;
 
 /// trusty-mpm command-line interface.
 #[derive(Debug, Parser)]
@@ -117,7 +133,7 @@ pub(crate) enum Command {
     /// Run the trusty-mpm daemon.
     Daemon {
         /// Address the daemon HTTP API binds to.
-        #[arg(long, env = "TRUSTY_MPM_ADDR", default_value = "127.0.0.1:7880")]
+        #[arg(long, env = "TRUSTY_MPM_ADDR", default_value = DEFAULT_ADDR)]
         addr: SocketAddr,
         /// Also expose the daemon on the Tailscale interface for remote access.
         #[arg(long, env = "TRUSTY_MPM_TAILSCALE")]

--- a/crates/trusty-mpm/src/core/discovery.rs
+++ b/crates/trusty-mpm/src/core/discovery.rs
@@ -11,8 +11,46 @@ use std::path::PathBuf;
 
 use crate::core::paths::FRAMEWORK_DIR_NAME;
 
+/// Canonical loopback bind address the daemon listens on by default.
+///
+/// Why (issue #1268): the daemon's `--addr` default, the thin CLI's `--url`
+/// default, and [`DEFAULT_DAEMON_URL`] previously each hard-coded the
+/// `127.0.0.1:7880` literal independently. Any one of them drifting (or an
+/// operator carrying a stale `TRUSTY_MPM_URL=…:7881` in their environment)
+/// produced "daemon: unreachable" because the client probed a port the daemon
+/// never bound. Hoisting the port into a single constant — and deriving every
+/// other default address string from it — makes the bind side and the client
+/// side provably agree from one source of truth.
+/// What: the literal `"127.0.0.1:7880"`, parsed into a [`SocketAddr`] by
+/// [`default_daemon_addr`] and embedded into [`DEFAULT_DAEMON_URL`].
+/// Test: `default_url_matches_addr`, `default_addr_parses`.
+pub const DEFAULT_DAEMON_ADDR: &str = "127.0.0.1:7880";
+
 /// Default daemon URL when no override and no lock file is found.
+///
+/// Why: derived from [`DEFAULT_DAEMON_ADDR`] so the client default and the
+/// daemon bind default can never drift (issue #1268).
+/// What: `"http://127.0.0.1:7880"` — the `http://` scheme prepended to
+/// [`DEFAULT_DAEMON_ADDR`]. Kept as a `&'static str` literal (rather than a
+/// runtime `format!`) so it remains usable in `const`/`default_value` contexts;
+/// the [`default_url_matches_addr`] test guarantees the two stay in lockstep.
+/// Test: `default_url_matches_addr`.
 pub const DEFAULT_DAEMON_URL: &str = "http://127.0.0.1:7880";
+
+/// Parse [`DEFAULT_DAEMON_ADDR`] into a [`SocketAddr`].
+///
+/// Why: the daemon's clap `--addr` argument is typed as [`SocketAddr`]; this
+/// helper lets that default be derived from the shared [`DEFAULT_DAEMON_ADDR`]
+/// constant instead of repeating the literal (issue #1268).
+/// What: parses the constant; the parse is infallible for a well-formed
+/// literal, so a malformed constant is a programmer error caught by
+/// `default_addr_parses` at test time.
+/// Test: `default_addr_parses`.
+pub fn default_daemon_addr() -> std::net::SocketAddr {
+    DEFAULT_DAEMON_ADDR
+        .parse()
+        .expect("DEFAULT_DAEMON_ADDR is a valid SocketAddr literal")
+}
 
 /// Path to the daemon lock file.
 ///
@@ -119,6 +157,26 @@ mod tests {
         // We can't guarantee no lock file exists, so just check it's a valid URL.
         let result = resolve_daemon_url(None);
         assert!(result.starts_with("http"));
+    }
+
+    #[test]
+    fn default_url_matches_addr() {
+        // Why (issue #1268): the client default URL and the daemon bind default
+        // must agree. `DEFAULT_DAEMON_URL` is `http://` + `DEFAULT_DAEMON_ADDR`.
+        assert_eq!(
+            DEFAULT_DAEMON_URL,
+            format!("http://{DEFAULT_DAEMON_ADDR}"),
+            "client default URL and daemon bind addr drifted (issue #1268)"
+        );
+    }
+
+    #[test]
+    fn default_addr_parses() {
+        // The shared bind constant must parse into a SocketAddr so the daemon's
+        // clap `--addr` default can be derived from it.
+        let addr = default_daemon_addr();
+        assert_eq!(addr.to_string(), DEFAULT_DAEMON_ADDR);
+        assert_eq!(addr.port(), 7880);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -53,5 +53,8 @@ pub mod trusty_tools_config;
 pub mod workspace_scan;
 
 pub use connect::{ResolveResult, SessionSummary, resolve_target};
-pub use discovery::{DEFAULT_DAEMON_URL, lock_file_path, resolve_daemon_url};
+pub use discovery::{
+    DEFAULT_DAEMON_ADDR, DEFAULT_DAEMON_URL, default_daemon_addr, lock_file_path,
+    resolve_daemon_url,
+};
 pub use error::{Error, Result};

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -56,16 +56,46 @@ pub fn resolve_pm_model(config: &MpmConfig, explicit: Option<&str>) -> String {
     crate::core::config::resolve_agent_model(config, "pm", None, explicit)
 }
 
+/// The setting-sources flag every trusty-mpm-spawned `claude` carries.
+///
+/// Why (issue #1269 / step 4): the operator's global `~/.claude/settings.json`
+/// carries hooks (e.g. claude-mpm's) that bleed into — and interfere with —
+/// trusty-mpm sessions. `--setting-sources project,local` tells Claude Code to
+/// load ONLY the project (tm-owned workspace `.claude/settings.json`) and local
+/// settings sources, excluding `user`. This is the correct isolation lever: it
+/// does NOT touch `~/.claude.json`, so the ambient OAuth login tm relies on is
+/// preserved.
+/// What: the literal flag string appended to every launch command.
+/// Test: `claude_command_includes_setting_sources`.
+pub const SETTING_SOURCES_FLAG: &str = "--setting-sources project,local";
+
+/// The permission-mode flag every trusty-mpm-spawned `claude` carries.
+///
+/// Why (issue #1269): tm runs Claude Code in an interactive tmux pane; without
+/// a non-interactive permission mode, Claude blocks on per-tool permission
+/// prompts and the injected task stalls. `acceptEdits` lets the unattended
+/// session make edits without prompting while stopping short of the fully
+/// unguarded `bypassPermissions` (reserved for sandboxed/provisioned runs).
+/// What: the literal flag string appended to every launch command.
+/// Test: `claude_command_includes_permission_mode`.
+pub const PERMISSION_MODE_FLAG: &str = "--permission-mode acceptEdits";
+
 /// Build the full `claude` command string for `tmux send-keys`.
 ///
 /// Why: the command passed to `tmux send-keys` must be a single shell string;
 /// constructing it in one place keeps the CLI `launch`, `session start`, and
-/// future daemon-driven paths from drifting apart.
-/// What: always starts with `"claude"`; appends `--model <model>` when
-/// `model` is `Some`; appends `--append-system-prompt-file <path>` when
-/// `prompt_file` is `Some`. Returns the composed string.
+/// future daemon-driven paths from drifting apart. It is also the single place
+/// the session-isolation flag ([`SETTING_SOURCES_FLAG`]) and the
+/// unattended-permission flag ([`PERMISSION_MODE_FLAG`]) are applied so every
+/// spawn path stays unattended and isolated (issue #1269).
+/// What: always starts with `"claude"`; appends `--model <model>` when `model`
+/// is `Some`; appends `--append-system-prompt-file <path>` when `prompt_file` is
+/// `Some`; then ALWAYS appends [`SETTING_SOURCES_FLAG`] and
+/// [`PERMISSION_MODE_FLAG`]. Returns the composed string.
 /// Test: `claude_command_bare`, `claude_command_with_model`,
-/// `claude_command_with_prompt`, `claude_command_with_both`.
+/// `claude_command_with_prompt`, `claude_command_with_both`,
+/// `claude_command_includes_setting_sources`,
+/// `claude_command_includes_permission_mode`.
 pub fn build_claude_command(model: Option<&str>, prompt_file: Option<&Path>) -> String {
     let mut cmd = "claude".to_string();
     if let Some(m) = model {
@@ -76,6 +106,11 @@ pub fn build_claude_command(model: Option<&str>, prompt_file: Option<&Path>) -> 
         cmd.push_str(" --append-system-prompt-file ");
         cmd.push_str(&p.display().to_string());
     }
+    // Isolation + unattended flags, always applied (issue #1269 / step 4).
+    cmd.push(' ');
+    cmd.push_str(SETTING_SOURCES_FLAG);
+    cmd.push(' ');
+    cmd.push_str(PERMISSION_MODE_FLAG);
     cmd
 }
 
@@ -109,23 +144,29 @@ pub fn build_agent_command(
 mod tests {
     use super::*;
 
+    /// The isolation + unattended suffix every command now carries (#1269).
+    const FLAGS: &str = "--setting-sources project,local --permission-mode acceptEdits";
+
     #[test]
     fn claude_command_bare() {
-        // No model, no prompt file → plain "claude".
-        assert_eq!(build_claude_command(None, None), "claude");
+        // No model, no prompt file → "claude" + the always-on isolation flags.
+        assert_eq!(build_claude_command(None, None), format!("claude {FLAGS}"));
     }
 
     #[test]
     fn claude_command_with_model() {
         let cmd = build_claude_command(Some("claude-opus-4-5"), None);
-        assert_eq!(cmd, "claude --model claude-opus-4-5");
+        assert_eq!(cmd, format!("claude --model claude-opus-4-5 {FLAGS}"));
     }
 
     #[test]
     fn claude_command_with_prompt() {
         let path = Path::new("/tmp/prompt.txt");
         let cmd = build_claude_command(None, Some(path));
-        assert_eq!(cmd, "claude --append-system-prompt-file /tmp/prompt.txt");
+        assert_eq!(
+            cmd,
+            format!("claude --append-system-prompt-file /tmp/prompt.txt {FLAGS}")
+        );
     }
 
     #[test]
@@ -134,7 +175,35 @@ mod tests {
         let cmd = build_claude_command(Some("claude-haiku-4-5"), Some(path));
         assert_eq!(
             cmd,
-            "claude --model claude-haiku-4-5 --append-system-prompt-file /tmp/sys.txt"
+            format!(
+                "claude --model claude-haiku-4-5 --append-system-prompt-file /tmp/sys.txt {FLAGS}"
+            )
+        );
+    }
+
+    #[test]
+    fn claude_command_includes_setting_sources() {
+        // Why (#1269/step 4): every spawned session must EXCLUDE the user's
+        // global settings by loading only project,local sources.
+        let cmd = build_claude_command(None, None);
+        assert!(
+            cmd.contains("--setting-sources project,local"),
+            "missing setting-sources isolation flag: {cmd}"
+        );
+        // Must not load the `user` source.
+        assert!(
+            !cmd.contains("user"),
+            "should not reference the user source: {cmd}"
+        );
+    }
+
+    #[test]
+    fn claude_command_includes_permission_mode() {
+        // Why (#1269): unattended sessions must not block on permission prompts.
+        let cmd = build_claude_command(Some("sonnet"), None);
+        assert!(
+            cmd.contains("--permission-mode acceptEdits"),
+            "missing permission-mode flag: {cmd}"
         );
     }
 
@@ -176,6 +245,6 @@ mod tests {
 
         // Config per-agent override (haiku) wins over frontmatter (sonnet).
         let cmd = build_agent_command(&cfg, &agent, None, None);
-        assert_eq!(cmd, "claude --model claude-haiku-4-5");
+        assert_eq!(cmd, format!("claude --model claude-haiku-4-5 {FLAGS}"));
     }
 }

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -25,8 +25,9 @@ use crate::core::instruction_pipeline::{PipelineInput, PipelineOutput, build_ins
 use crate::core::paths::FrameworkPaths;
 use crate::core::skill_deployer::{DeployStats, deploy_skills};
 use settings::{
-    deploy_output_style, inject_trusty_memory_mcp, remove_global_trusty_memory_hooks,
-    write_output_style, write_project_hooks,
+    deploy_output_style, inject_trusty_memory_mcp, inject_trusty_search_mcp,
+    preseed_workspace_trust_home, remove_global_trusty_memory_hooks, write_output_style,
+    write_project_hooks,
 };
 
 /// Outcome of the pre-launch preparation for one session.
@@ -164,6 +165,23 @@ pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepRe
     // the memory tools.
     if let Err(err) = inject_trusty_memory_mcp(project_dir) {
         tracing::warn!("failed to inject trusty-memory MCP server: {err}");
+    }
+
+    // Inject the `trusty-search` MCP server too (issue #1270 / step 4) so the
+    // spawned session can reach the code-search tools (`search`, `grep`,
+    // `get_call_chain`, …) alongside the memory tools. Non-fatal: the session
+    // still launches without code search.
+    if let Err(err) = inject_trusty_search_mcp(project_dir) {
+        tracing::warn!("failed to inject trusty-search MCP server: {err}");
+    }
+
+    // Pre-seed per-directory trust for this workspace in `~/.claude.json`
+    // (issue #1269) so the interactive tmux Claude session does not stall on the
+    // "Do you trust this folder?" dialog and the injected task prompt is
+    // received. tm owns this workspace path, so marking it trusted is safe.
+    // Non-fatal: a trust-seed failure only means the operator may see the dialog.
+    if let Err(err) = preseed_workspace_trust_home(project_dir) {
+        tracing::warn!("failed to pre-seed workspace trust: {err}");
     }
 
     // Remove the now-redundant global `trusty-memory` hook entries so they no

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -40,46 +40,44 @@ pub(super) const SPINNER_TIPS: &[&str] = &[
 /// The `trusty-memory` hook block written into the project's
 /// `.claude/settings.json`.
 ///
-/// Why: these hooks must fire only for trusty-mpm-managed sessions, not for
-/// every Claude Code instance on the machine. Writing them at the project
-/// level (rather than `~/.claude/settings.json`) scopes them to projects
-/// prepared by trusty-mpm. The block covers the `PostToolUse`, `Stop`, and
-/// `UserPromptSubmit` events — the `trusty-memory` binary does not implement a
-/// `claude.pre-tool-use` handler, so a `PreToolUse` hook would only error on
-/// every tool call. These three events capture the session lifecycle for
-/// memory.
+/// Why (issue #1270): the previous block invoked `trusty-memory hooks fire
+/// <event>`, but the installed `trusty-memory` binary has **no `hooks`
+/// subcommand** — that invocation exits non-zero with "unrecognized subcommand
+/// 'hooks'". A non-zero `UserPromptSubmit` hook *hard-blocks the prompt*, so
+/// every trusty-mpm-spawned session was dead on arrival: the injected task was
+/// rejected before Claude ever saw it. This block now mirrors the canonical
+/// hooks that `trusty-memory setup` installs (see
+/// `crates/trusty-memory/src/commands/setup.rs`): `UserPromptSubmit` runs
+/// `trusty-memory prompt-context` (documented to always exit 0 so it can never
+/// block a prompt) and `SessionStart` runs `trusty-memory inbox-check` (also
+/// fail-silent). There is intentionally no `PostToolUse` or `Stop` hook because
+/// `trusty-memory` ships no corresponding CLI surface; memory writes during a
+/// session flow through the MCP tools instead.
+/// What: a `UserPromptSubmit` → `trusty-memory prompt-context` hook and a
+/// `SessionStart` → `trusty-memory inbox-check` hook, scoped to the project so
+/// they fire only for trusty-mpm sessions.
+/// Test: `write_project_hooks_uses_canonical_commands`,
+/// `write_project_hooks_writes_all_event_types`.
 pub(super) const TRUSTY_MEMORY_HOOKS: &str = r#"{
-  "PostToolUse": [
-    {
-      "matcher": "Write|Edit|Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "trusty-memory hooks fire claude.post-tool-use",
-          "timeout": 60
-        }
-      ]
-    }
-  ],
-  "Stop": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "trusty-memory hooks fire claude.stop",
-          "timeout": 60
-        }
-      ]
-    }
-  ],
   "UserPromptSubmit": [
     {
       "matcher": "",
       "hooks": [
         {
           "type": "command",
-          "command": "trusty-memory hooks fire claude.user-prompt",
+          "command": "trusty-memory prompt-context",
+          "timeout": 60
+        }
+      ]
+    }
+  ],
+  "SessionStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "trusty-memory inbox-check",
           "timeout": 60
         }
       ]
@@ -90,18 +88,53 @@ pub(super) const TRUSTY_MEMORY_HOOKS: &str = r#"{
 /// The `trusty-memory` MCP server definition injected into a project's
 /// `.mcp.json`.
 ///
-/// Why: Claude Code reads MCP servers from `<project>/.mcp.json`; a launched
-/// trusty-mpm session needs the `trusty-memory` server registered there so the
-/// memory tools (`memory_recall`, `memory_store`, …) are available.
+/// Why (issue #1270): Claude Code reads MCP servers from `<project>/.mcp.json`;
+/// a launched trusty-mpm session needs the `trusty-memory` server registered
+/// there so the memory tools (`memory_recall`, `memory_remember`, …) are
+/// available. The previous definition used `args: ["mcp", "serve"]`, but
+/// `trusty-memory` has **no `mcp` subcommand** — the server would have failed
+/// to start. The canonical stdio MCP invocation (per `trusty-memory setup`) is
+/// `serve --stdio`.
+/// What: a stdio MCP server entry running `trusty-memory serve --stdio`.
+/// Test: `inject_trusty_memory_mcp_uses_serve_stdio`.
 pub(super) const TRUSTY_MEMORY_MCP_SERVER: &str = r#"{
   "type": "stdio",
   "command": "trusty-memory",
-  "args": ["mcp", "serve"]
+  "args": ["serve", "--stdio"]
 }"#;
 
-/// Hook event types the global `trusty-memory` entries were registered under.
+/// The `trusty-search` MCP server definition injected into a project's
+/// `.mcp.json`.
+///
+/// Why (issue #1270 / step 4): trusty-mpm-spawned sessions are expected to have
+/// both the memory *and* the code-search tools, but `trusty-search` was never
+/// registered in the workspace `.mcp.json` — only `trusty-memory` was. Without
+/// it the spawned PM cannot run `search`, `grep`, `get_call_chain`, etc. The
+/// canonical stdio MCP invocation (per `trusty-search setup`) is bare `serve`
+/// (stdio is the default transport; HTTP is off unless `--with-http`).
+/// What: a stdio MCP server entry running `trusty-search serve`. This wires the
+/// tools only — index creation is a separate concern handled elsewhere.
+/// Test: `inject_trusty_search_mcp_adds_server`,
+/// `inject_trusty_search_mcp_preserves_existing`,
+/// `inject_trusty_search_mcp_is_idempotent`.
+pub(super) const TRUSTY_SEARCH_MCP_SERVER: &str = r#"{
+  "type": "stdio",
+  "command": "trusty-search",
+  "args": ["serve"]
+}"#;
+
+/// Hook event types the global `trusty-memory` entries may have been registered
+/// under (across current and legacy trusty-mpm builds).
+///
+/// Why: [`clean_global_trusty_memory_hooks`] strips trusty-mpm's
+/// `trusty-memory` hook entries from `~/.claude/settings.json` so they stop
+/// firing for unrelated sessions. It must cover every event trusty-mpm has ever
+/// written globally: the new canonical pair (`UserPromptSubmit`, `SessionStart`)
+/// AND the legacy `hooks fire` events (`PostToolUse`, `Stop`) so an upgrade
+/// cleans up the old entries too.
+/// What: the union of current and legacy global hook event keys.
 pub(super) const GLOBAL_TRUSTY_MEMORY_EVENTS: &[&str] =
-    &["PostToolUse", "Stop", "UserPromptSubmit"];
+    &["UserPromptSubmit", "SessionStart", "PostToolUse", "Stop"];
 
 /// Deploy the bundled `trusty-mpm` output style under `<home>/.claude/output-styles/`.
 ///
@@ -225,20 +258,20 @@ pub(super) fn write_project_hooks(project_dir: &Path) -> Result<(), PrepError> {
     Ok(())
 }
 
-/// Inject the `trusty-memory` MCP server into the project's `.mcp.json`.
+/// Inject (or update) a named stdio MCP server into the project's `.mcp.json`.
 ///
-/// Why: `prepare_session` configures hooks and instructions but, without this,
-/// the launched `claude` process has no access to the memory tools because the
-/// `trusty-memory` MCP server is never registered in `<project>/.mcp.json`.
+/// Why: trusty-mpm needs to register multiple MCP servers (`trusty-memory`,
+/// `trusty-search`) into the workspace `.mcp.json` with identical merge/idempotency
+/// semantics. Factoring the read-merge-write logic into one helper keeps the two
+/// public wrappers thin and guarantees they behave consistently (issue #1270).
 /// What: reads an existing `<project_path>/.mcp.json` (starting from `{}` when
-/// absent or malformed), adds/updates the `trusty-memory` entry under
-/// `mcpServers` with [`TRUSTY_MEMORY_MCP_SERVER`], and writes the merged JSON
-/// back pretty-printed — preserving all other MCP servers. Idempotent: if the
-/// entry already matches, the file is left untouched.
-/// Test: `inject_trusty_memory_mcp_adds_server`,
-/// `inject_trusty_memory_mcp_preserves_existing`,
-/// `inject_trusty_memory_mcp_is_idempotent`.
-pub(super) fn inject_trusty_memory_mcp(project_path: &Path) -> Result<(), PrepError> {
+/// absent or malformed), adds/updates `mcpServers.<name>` to the parsed
+/// `server_json`, and writes the merged JSON back pretty-printed — preserving all
+/// other MCP servers. Idempotent: if the entry already matches, the file is left
+/// untouched and no write occurs. `server_json` MUST be a valid JSON object
+/// (callers pass compile-time constants).
+/// Test: exercised via `inject_trusty_memory_mcp_*` and `inject_trusty_search_mcp_*`.
+fn inject_mcp_server(project_path: &Path, name: &str, server_json: &str) -> Result<(), PrepError> {
     let mcp_path = project_path.join(".mcp.json");
 
     // Load existing config to preserve unrelated servers; tolerate a missing or
@@ -252,8 +285,8 @@ pub(super) fn inject_trusty_memory_mcp(project_path: &Path) -> Result<(), PrepEr
     };
 
     // The bundled server block is a constant and is guaranteed to parse.
-    let server: serde_json::Value = serde_json::from_str(TRUSTY_MEMORY_MCP_SERVER)
-        .expect("bundled trusty-memory MCP server block is valid JSON");
+    let server: serde_json::Value =
+        serde_json::from_str(server_json).expect("bundled MCP server block is valid JSON");
 
     // Ensure `mcpServers` is an object we can insert into.
     let servers = config
@@ -269,10 +302,10 @@ pub(super) fn inject_trusty_memory_mcp(project_path: &Path) -> Result<(), PrepEr
         .expect("mcpServers normalized to an object");
 
     // Idempotent: skip the write when the entry already matches.
-    if servers.get("trusty-memory") == Some(&server) {
+    if servers.get(name) == Some(&server) {
         return Ok(());
     }
-    servers.insert("trusty-memory".to_string(), server);
+    servers.insert(name.to_string(), server);
 
     let serialized =
         serde_json::to_string_pretty(&config).map_err(|err| PrepError::Deploy(err.to_string()))?;
@@ -281,6 +314,152 @@ pub(super) fn inject_trusty_memory_mcp(project_path: &Path) -> Result<(), PrepEr
         source,
     })?;
     Ok(())
+}
+
+/// Inject the `trusty-memory` MCP server into the project's `.mcp.json`.
+///
+/// Why: `prepare_session` configures hooks and instructions but, without this,
+/// the launched `claude` process has no access to the memory tools because the
+/// `trusty-memory` MCP server is never registered in `<project>/.mcp.json`.
+/// What: thin wrapper over [`inject_mcp_server`] registering the
+/// [`TRUSTY_MEMORY_MCP_SERVER`] entry under the key `trusty-memory`.
+/// Test: `inject_trusty_memory_mcp_adds_server`,
+/// `inject_trusty_memory_mcp_preserves_existing`,
+/// `inject_trusty_memory_mcp_is_idempotent`,
+/// `inject_trusty_memory_mcp_uses_serve_stdio`.
+pub(super) fn inject_trusty_memory_mcp(project_path: &Path) -> Result<(), PrepError> {
+    inject_mcp_server(project_path, "trusty-memory", TRUSTY_MEMORY_MCP_SERVER)
+}
+
+/// Inject the `trusty-search` MCP server into the project's `.mcp.json`.
+///
+/// Why (issue #1270 / step 4): spawned sessions must reach the code-search
+/// tools, but `trusty-search` was never registered alongside `trusty-memory`.
+/// This wires the MCP server so `search`, `grep`, `get_call_chain`, etc. are
+/// available. Index creation is out of scope here.
+/// What: thin wrapper over [`inject_mcp_server`] registering the
+/// [`TRUSTY_SEARCH_MCP_SERVER`] entry under the key `trusty-search`.
+/// Test: `inject_trusty_search_mcp_adds_server`,
+/// `inject_trusty_search_mcp_preserves_existing`,
+/// `inject_trusty_search_mcp_is_idempotent`,
+/// `inject_both_mcp_servers_coexist`.
+pub(super) fn inject_trusty_search_mcp(project_path: &Path) -> Result<(), PrepError> {
+    inject_mcp_server(project_path, "trusty-search", TRUSTY_SEARCH_MCP_SERVER)
+}
+
+/// Pre-seed per-directory trust acceptance for `workspace` in `~/.claude.json`.
+///
+/// Why (issue #1269): trusty-mpm launches Claude Code inside an *interactive*
+/// tmux pane (so the session can be observed and driven). For a directory it has
+/// never trusted, Claude Code blocks on the "Do you trust the files in this
+/// folder?" dialog before it will accept any input — so the task prompt that tm
+/// injects via `send-keys` is swallowed and the session stalls. Trust is keyed
+/// by absolute directory path in the config dir (`~/.claude.json`), which
+/// `--setting-sources` does NOT govern, so we must seed it directly. Because tm
+/// clones each repo into its OWN throwaway workspace under
+/// `~/trusty-mpm-projects/<owner>/<repo>/<id>/`, marking that path trusted is
+/// safe — no real user project is affected.
+/// What: reads `~/.claude.json` (the JSON config; starts from `{}` when absent
+/// or malformed — but a malformed *existing* file is left untouched to avoid
+/// clobbering the operator's OAuth/login data), ensures
+/// `projects.<workspace>` carries `hasTrustDialogAccepted: true`,
+/// `hasCompletedProjectOnboarding: true`, and `projectOnboardingSeenCount >= 1`,
+/// then writes it back pretty-printed preserving every other key. Idempotent.
+/// The OAuth fields elsewhere in the file are never touched.
+/// Test: `preseed_trust_marks_directory`, `preseed_trust_preserves_other_keys`,
+/// `preseed_trust_is_idempotent`, `preseed_trust_leaves_malformed_file`.
+pub(super) fn preseed_workspace_trust(
+    claude_json: &Path,
+    workspace: &Path,
+) -> Result<(), PrepError> {
+    use serde_json::Value;
+
+    // Read the existing config. If the file exists but is malformed JSON we must
+    // NOT overwrite it — it likely holds the operator's OAuth credentials, and
+    // clobbering it would force a re-login. Treat that as a soft failure.
+    let mut config: Value = match std::fs::read_to_string(claude_json) {
+        Ok(text) => match serde_json::from_str::<Value>(&text) {
+            Ok(value) if value.is_object() => value,
+            Ok(_) => {
+                tracing::warn!(
+                    "skipping trust pre-seed: {} is valid JSON but not an object",
+                    claude_json.display()
+                );
+                return Ok(());
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "skipping trust pre-seed: {} is not valid JSON ({err}); \
+                     leaving it untouched to protect OAuth state",
+                    claude_json.display()
+                );
+                return Ok(());
+            }
+        },
+        // Missing file: start fresh. (Rare — claude writes it on first run.)
+        Err(_) => Value::Object(serde_json::Map::new()),
+    };
+
+    let key = workspace.to_string_lossy().to_string();
+
+    let projects = config
+        .as_object_mut()
+        .expect("config is an object")
+        .entry("projects")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if !projects.is_object() {
+        *projects = Value::Object(serde_json::Map::new());
+    }
+    let projects = projects.as_object_mut().expect("projects is an object");
+
+    let entry = projects
+        .entry(key)
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if !entry.is_object() {
+        *entry = Value::Object(serde_json::Map::new());
+    }
+    let entry = entry.as_object_mut().expect("project entry is an object");
+
+    // Idempotent: skip the write when trust is already fully accepted.
+    let already_trusted = entry.get("hasTrustDialogAccepted") == Some(&Value::Bool(true))
+        && entry.get("hasCompletedProjectOnboarding") == Some(&Value::Bool(true));
+    if already_trusted {
+        return Ok(());
+    }
+
+    entry.insert("hasTrustDialogAccepted".to_string(), Value::Bool(true));
+    entry.insert(
+        "hasCompletedProjectOnboarding".to_string(),
+        Value::Bool(true),
+    );
+    // Claude Code shows the onboarding flow until this counter is >= 1.
+    entry
+        .entry("projectOnboardingSeenCount")
+        .or_insert_with(|| Value::from(1));
+
+    let serialized =
+        serde_json::to_string_pretty(&config).map_err(|err| PrepError::Deploy(err.to_string()))?;
+    std::fs::write(claude_json, serialized).map_err(|source| PrepError::Io {
+        path: claude_json.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+/// Pre-seed workspace trust in the operator's real `~/.claude.json`.
+///
+/// Why: thin home-resolving wrapper over [`preseed_workspace_trust`] so
+/// `prepare_session` can call it without knowing the config-dir layout; tests
+/// target a temp file via the inner function directly.
+/// What: resolves `~/.claude.json` and delegates. A missing home directory is a
+/// soft failure (logged, non-fatal) so launch still proceeds.
+/// Test: covered by the inner `preseed_trust_*` tests.
+pub(super) fn preseed_workspace_trust_home(workspace: &Path) -> Result<(), PrepError> {
+    let Some(home) = dirs::home_dir() else {
+        tracing::warn!("skipping trust pre-seed: home directory unresolved");
+        return Ok(());
+    };
+    preseed_workspace_trust(&home.join(".claude.json"), workspace)
 }
 
 /// Remove the `trusty-memory` hook entries from `~/.claude/settings.json`.
@@ -352,8 +531,13 @@ pub(super) fn clean_global_trusty_memory_hooks(settings_path: &Path) -> Result<(
 /// Whether a hook handler group is a `trusty-memory` entry.
 ///
 /// Why: identifies the groups [`clean_global_trusty_memory_hooks`] must drop.
-/// What: returns `true` when any command in the group's `hooks` array contains
-/// the substring `trusty-memory hooks fire`.
+/// Matching on the broad `trusty-memory` prefix (rather than the old, narrow
+/// `trusty-memory hooks fire` substring) cleans up BOTH the legacy global
+/// entries and the canonical `prompt-context` / `inbox-check` entries should
+/// either ever have been written globally (issue #1270).
+/// What: returns `true` when any command in the group's `hooks` array invokes
+/// the `trusty-memory` binary (the command string starts with `trusty-memory `
+/// or is exactly `trusty-memory`).
 /// Test: covered indirectly by `remove_global_hooks_removes_trusty_memory_entries`.
 pub(super) fn group_is_trusty_memory(group: &serde_json::Value) -> bool {
     group
@@ -364,7 +548,7 @@ pub(super) fn group_is_trusty_memory(group: &serde_json::Value) -> bool {
                 handler
                     .get("command")
                     .and_then(|c| c.as_str())
-                    .is_some_and(|cmd| cmd.contains("trusty-memory hooks fire"))
+                    .is_some_and(|cmd| cmd == "trusty-memory" || cmd.starts_with("trusty-memory "))
             })
         })
 }

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1,6 +1,6 @@
 use super::settings::{
     clean_global_trusty_memory_hooks, deploy_output_style, inject_trusty_memory_mcp,
-    write_output_style, write_project_hooks,
+    inject_trusty_search_mcp, preseed_workspace_trust, write_output_style, write_project_hooks,
 };
 use super::*;
 use tempfile::tempdir;
@@ -187,10 +187,10 @@ fn write_output_style_sets_spinner_tips() {
 
 #[test]
 fn write_project_hooks_writes_all_event_types() {
-    // Why: the trusty-memory hooks must be scoped to the project and cover
-    // the session lifecycle — PostToolUse, Stop, and UserPromptSubmit.
-    // PreToolUse is intentionally absent: trusty-memory has no
-    // `claude.pre-tool-use` handler.
+    // Why (#1270): the trusty-memory hooks must be scoped to the project and use
+    // the canonical, real CLI surface — `UserPromptSubmit` → prompt-context and
+    // `SessionStart` → inbox-check. The old `PostToolUse`/`Stop` events invoked
+    // the nonexistent `hooks fire` subcommand and are gone.
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
@@ -201,7 +201,7 @@ fn write_project_hooks_writes_all_event_types() {
     )
     .unwrap();
     let hooks = value["hooks"].as_object().expect("hooks must be an object");
-    for event in ["PostToolUse", "Stop", "UserPromptSubmit"] {
+    for event in ["UserPromptSubmit", "SessionStart"] {
         let groups = hooks[event]
             .as_array()
             .unwrap_or_else(|| panic!("{event} must be an array"));
@@ -210,17 +210,17 @@ fn write_project_hooks_writes_all_event_types() {
             .as_str()
             .expect("command must be a string");
         assert!(
-            cmd.contains("trusty-memory hooks fire"),
-            "{event} command must invoke trusty-memory"
+            cmd.starts_with("trusty-memory "),
+            "{event} command must invoke trusty-memory: {cmd}"
         );
     }
 }
 
 #[test]
-fn write_project_hooks_omits_pre_tool_use() {
-    // Why: trusty-memory has no `claude.pre-tool-use` handler, so a
-    // PreToolUse hook would error on every tool call. The written hooks
-    // block must not register one.
+fn write_project_hooks_uses_canonical_commands() {
+    // Why (#1270): the hook commands MUST match the real trusty-memory CLI
+    // (`prompt-context`, `inbox-check`) — never the bogus `hooks fire` form that
+    // hard-blocked prompts with "unrecognized subcommand 'hooks'".
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
@@ -230,10 +230,41 @@ fn write_project_hooks_omits_pre_tool_use() {
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
     )
     .unwrap();
+    let raw = serde_json::to_string(&value).unwrap();
     assert!(
-        value["hooks"].get("PreToolUse").is_none(),
-        "PreToolUse hook must not be registered"
+        !raw.contains("hooks fire"),
+        "the broken `hooks fire` command must never be written: {raw}"
     );
+    assert_eq!(
+        value["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
+        serde_json::json!("trusty-memory prompt-context")
+    );
+    assert_eq!(
+        value["hooks"]["SessionStart"][0]["hooks"][0]["command"],
+        serde_json::json!("trusty-memory inbox-check")
+    );
+}
+
+#[test]
+fn write_project_hooks_omits_post_tool_use_and_stop() {
+    // Why (#1270): trusty-memory has no PostToolUse/Stop CLI hook surface, so
+    // those events must not be registered (they previously invoked `hooks fire`,
+    // which fails). Memory writes during a session flow through MCP tools.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    write_project_hooks(project).expect("write succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    for absent in ["PreToolUse", "PostToolUse", "Stop"] {
+        assert!(
+            value["hooks"].get(absent).is_none(),
+            "{absent} hook must not be registered"
+        );
+    }
 }
 
 #[test]
@@ -250,11 +281,11 @@ fn write_project_hooks_replaces_existing() {
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
     )
     .unwrap();
-    let post = value["hooks"]["PostToolUse"]
+    let ss = value["hooks"]["SessionStart"]
         .as_array()
-        .expect("PostToolUse must be an array");
+        .expect("SessionStart must be an array");
     assert_eq!(
-        post.len(),
+        ss.len(),
         1,
         "re-running must replace, not append, handler groups"
     );
@@ -287,7 +318,31 @@ fn inject_trusty_memory_mcp_adds_server() {
     let server = &value["mcpServers"]["trusty-memory"];
     assert_eq!(server["type"], serde_json::json!("stdio"));
     assert_eq!(server["command"], serde_json::json!("trusty-memory"));
-    assert_eq!(server["args"], serde_json::json!(["mcp", "serve"]));
+    assert_eq!(server["args"], serde_json::json!(["serve", "--stdio"]));
+}
+
+#[test]
+fn inject_trusty_memory_mcp_uses_serve_stdio() {
+    // Why (#1270): the previous args `["mcp","serve"]` were invalid (no `mcp`
+    // subcommand). The canonical stdio MCP invocation is `serve --stdio`.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    inject_trusty_memory_mcp(project).expect("injection succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
+    let args = value["mcpServers"]["trusty-memory"]["args"]
+        .as_array()
+        .expect("args is an array");
+    assert_eq!(
+        args,
+        &vec![serde_json::json!("serve"), serde_json::json!("--stdio")]
+    );
+    assert!(
+        !args.contains(&serde_json::json!("mcp")),
+        "must not use the nonexistent `mcp` subcommand"
+    );
 }
 
 #[test]
@@ -432,6 +487,201 @@ fn remove_global_hooks_tolerates_missing_file() {
     let tmp = tempdir().unwrap();
     let missing = tmp.path().join("nope.json");
     clean_global_trusty_memory_hooks(&missing).expect("missing file is a no-op");
+}
+
+// ──────────────────────────────────────────────
+// trusty-search MCP injection (#1270 / step 4)
+// ──────────────────────────────────────────────
+
+#[test]
+fn inject_trusty_search_mcp_adds_server() {
+    // Why (#1270/step 4): spawned sessions need the code-search tools; the
+    // server must be registered as `trusty-search serve` (stdio default).
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    inject_trusty_search_mcp(project).expect("injection succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
+    let server = &value["mcpServers"]["trusty-search"];
+    assert_eq!(server["type"], serde_json::json!("stdio"));
+    assert_eq!(server["command"], serde_json::json!("trusty-search"));
+    assert_eq!(server["args"], serde_json::json!(["serve"]));
+}
+
+#[test]
+fn inject_trusty_search_mcp_preserves_existing() {
+    // Why: injecting trusty-search must not clobber an existing trusty-memory.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    inject_trusty_memory_mcp(project).expect("memory injection succeeds");
+
+    inject_trusty_search_mcp(project).expect("search injection succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
+    let servers = value["mcpServers"].as_object().expect("object");
+    assert!(servers.contains_key("trusty-memory"), "memory must survive");
+    assert!(
+        servers.contains_key("trusty-search"),
+        "search must be added"
+    );
+}
+
+#[test]
+fn inject_trusty_search_mcp_is_idempotent() {
+    // Why: prep may run repeatedly; re-injecting must not change the file.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    inject_trusty_search_mcp(project).expect("first injection succeeds");
+    let first = std::fs::read_to_string(project.join(".mcp.json")).unwrap();
+    inject_trusty_search_mcp(project).expect("second injection succeeds");
+    let second = std::fs::read_to_string(project.join(".mcp.json")).unwrap();
+
+    assert_eq!(first, second, "re-injecting must leave the file unchanged");
+}
+
+#[test]
+fn inject_both_mcp_servers_coexist() {
+    // Why (#1270/step 4): the end state must have BOTH servers so the spawned
+    // session gets memory AND code search.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    inject_trusty_memory_mcp(project).expect("memory injection succeeds");
+    inject_trusty_search_mcp(project).expect("search injection succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
+    let servers = value["mcpServers"].as_object().expect("object");
+    assert_eq!(servers.len(), 2, "exactly memory + search");
+    assert_eq!(
+        servers["trusty-memory"]["args"],
+        serde_json::json!(["serve", "--stdio"])
+    );
+    assert_eq!(
+        servers["trusty-search"]["args"],
+        serde_json::json!(["serve"])
+    );
+}
+
+#[test]
+fn prepare_session_injects_both_mcp_servers() {
+    // Why (#1270/step 4): the single launch-prep entry point must wire BOTH the
+    // memory and the search MCP servers.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    prepare_session(&fw, project).expect("prep succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
+    assert_eq!(
+        value["mcpServers"]["trusty-memory"]["command"],
+        serde_json::json!("trusty-memory")
+    );
+    assert_eq!(
+        value["mcpServers"]["trusty-search"]["command"],
+        serde_json::json!("trusty-search")
+    );
+}
+
+// ──────────────────────────────────────────────
+// Workspace trust pre-seed (#1269)
+// ──────────────────────────────────────────────
+
+#[test]
+fn preseed_trust_marks_directory() {
+    // Why (#1269): the interactive session must not stall on the trust dialog;
+    // seeding the per-dir entry in ~/.claude.json suppresses it.
+    let tmp = tempdir().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+    let workspace = tmp.path().join("ws");
+
+    preseed_workspace_trust(&claude_json, &workspace).expect("seed succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&claude_json).unwrap()).unwrap();
+    let key = workspace.to_string_lossy().to_string();
+    let entry = &value["projects"][&key];
+    assert_eq!(entry["hasTrustDialogAccepted"], serde_json::json!(true));
+    assert_eq!(
+        entry["hasCompletedProjectOnboarding"],
+        serde_json::json!(true)
+    );
+    assert!(
+        entry["projectOnboardingSeenCount"].as_u64().unwrap() >= 1,
+        "onboarding counter must be >= 1"
+    );
+}
+
+#[test]
+fn preseed_trust_preserves_other_keys() {
+    // Why: the file holds OAuth/login data; seeding trust must not drop it.
+    let tmp = tempdir().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+    let workspace = tmp.path().join("ws");
+    std::fs::write(
+        &claude_json,
+        r#"{"oauthAccount":{"emailAddress":"r@1mc.io"},"projects":{"/other":{"hasTrustDialogAccepted":true}}}"#,
+    )
+    .unwrap();
+
+    preseed_workspace_trust(&claude_json, &workspace).expect("seed succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&claude_json).unwrap()).unwrap();
+    // OAuth survives untouched (issue #1269: OAuth must be preserved).
+    assert_eq!(
+        value["oauthAccount"]["emailAddress"],
+        serde_json::json!("r@1mc.io")
+    );
+    // Pre-existing project survives.
+    assert_eq!(
+        value["projects"]["/other"]["hasTrustDialogAccepted"],
+        serde_json::json!(true)
+    );
+    // New workspace is trusted.
+    let key = workspace.to_string_lossy().to_string();
+    assert_eq!(
+        value["projects"][&key]["hasTrustDialogAccepted"],
+        serde_json::json!(true)
+    );
+}
+
+#[test]
+fn preseed_trust_is_idempotent() {
+    // Why: prep may run repeatedly; a second seed must not change the file.
+    let tmp = tempdir().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+    let workspace = tmp.path().join("ws");
+
+    preseed_workspace_trust(&claude_json, &workspace).expect("first seed");
+    let first = std::fs::read_to_string(&claude_json).unwrap();
+    preseed_workspace_trust(&claude_json, &workspace).expect("second seed");
+    let second = std::fs::read_to_string(&claude_json).unwrap();
+
+    assert_eq!(first, second, "re-seeding must leave the file unchanged");
+}
+
+#[test]
+fn preseed_trust_leaves_malformed_file() {
+    // Why (#1269): a malformed ~/.claude.json likely still holds OAuth state;
+    // clobbering it would force a re-login. Seeding must bail out untouched.
+    let tmp = tempdir().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+    let workspace = tmp.path().join("ws");
+    let garbage = "{ this is not valid json ";
+    std::fs::write(&claude_json, garbage).unwrap();
+
+    preseed_workspace_trust(&claude_json, &workspace).expect("soft-fails to Ok");
+
+    let after = std::fs::read_to_string(&claude_json).unwrap();
+    assert_eq!(after, garbage, "malformed file must be left untouched");
 }
 
 #[test]

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -23,11 +23,27 @@ use super::RuntimeError;
 /// The shell command sent to the tmux pane to start Claude Code.
 ///
 /// Why: the `env -u ANTHROPIC_API_KEY` prefix strips the API key from the
-/// child environment so Claude Code falls back to its own credential store or
-/// prompts the user, preventing accidental key leakage through pane history.
-/// What: literal string piped to `tmux send-keys … Enter`.
-/// Test: `claude_code_adapter_spawn_sends_env_scrub_command`.
-const SPAWN_COMMAND: &str = "env -u ANTHROPIC_API_KEY claude";
+/// child environment so Claude Code falls back to its OAuth login in
+/// `~/.claude.json`, preventing accidental key leakage through pane history.
+/// The `--setting-sources project,local` flag isolates the session from the
+/// operator's interfering global `~/.claude/settings.json` hooks (issue #1269 /
+/// step 4) without touching `~/.claude.json` (so OAuth is preserved), and
+/// `--permission-mode acceptEdits` keeps the unattended session from blocking on
+/// per-tool permission prompts (issue #1269). The isolation flags reuse the
+/// shared [`crate::core::model_inject::SETTING_SOURCES_FLAG`] /
+/// [`crate::core::model_inject::PERMISSION_MODE_FLAG`] constants so this spawn
+/// path and the CLI launch path can never drift.
+/// What: built once at first use from `env -u ANTHROPIC_API_KEY claude` plus the
+/// two shared flag constants; piped to `tmux send-keys … Enter`.
+/// Test: `spawn_command_contains_env_scrub`,
+/// `spawn_command_contains_isolation_flags`.
+fn spawn_command() -> String {
+    format!(
+        "env -u ANTHROPIC_API_KEY claude {} {}",
+        crate::core::model_inject::SETTING_SOURCES_FLAG,
+        crate::core::model_inject::PERMISSION_MODE_FLAG,
+    )
+}
 
 /// Runtime adapter that launches Claude Code CLI inside a tmux session.
 ///
@@ -74,10 +90,11 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// Why: the session manager calls this after creating the tmux pane so the
     /// actual agent process starts inside it.
     /// What: checks that `claude` is on PATH (returns `BinaryNotFound` if not),
-    /// then sends `env -u ANTHROPIC_API_KEY claude` to the pane; the task is
-    /// logged for observability but not passed to the command (Claude Code reads
+    /// then sends [`spawn_command`] (`env -u ANTHROPIC_API_KEY claude` plus the
+    /// isolation/permission flags) to the pane; the task is logged for
+    /// observability but not passed to the command (Claude Code reads
     /// instructions from CLAUDE.md or an interactive prompt).
-    /// Test: `claude_code_adapter_spawn_sends_env_scrub_command`.
+    /// Test: `spawn_sends_env_scrub_when_binary_available`.
     fn spawn(&self, tmux_name: &str, cwd: &Path, task: &str) -> Result<(), RuntimeError> {
         if !Self::claude_available() {
             return Err(RuntimeError::BinaryNotFound(
@@ -91,7 +108,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             "spawning claude-code in tmux pane"
         );
         self.tmux
-            .send_line(tmux_name, SPAWN_COMMAND)
+            .send_line(tmux_name, &spawn_command())
             .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
     }
 
@@ -119,15 +136,32 @@ mod tests {
     }
 
     #[test]
-    fn spawn_command_constant_contains_env_scrub() {
-        // The spawn command must always strip the API key from the environment.
+    fn spawn_command_contains_env_scrub() {
+        // The spawn command must always strip the API key from the environment
+        // so the session falls back to OAuth in ~/.claude.json.
+        let cmd = spawn_command();
         assert!(
-            SPAWN_COMMAND.contains("env -u ANTHROPIC_API_KEY"),
-            "SPAWN_COMMAND must contain env scrub: {SPAWN_COMMAND}"
+            cmd.contains("env -u ANTHROPIC_API_KEY"),
+            "spawn command must contain env scrub: {cmd}"
         );
         assert!(
-            SPAWN_COMMAND.ends_with("claude"),
-            "SPAWN_COMMAND must end with claude: {SPAWN_COMMAND}"
+            cmd.contains(" claude "),
+            "spawn command must invoke claude: {cmd}"
+        );
+    }
+
+    #[test]
+    fn spawn_command_contains_isolation_flags() {
+        // Why (#1269): the session_manager spawn path must isolate from the
+        // user's global settings and run unattended, exactly like the CLI path.
+        let cmd = spawn_command();
+        assert!(
+            cmd.contains("--setting-sources project,local"),
+            "spawn command must isolate settings: {cmd}"
+        );
+        assert!(
+            cmd.contains("--permission-mode acceptEdits"),
+            "spawn command must set unattended permission mode: {cmd}"
         );
     }
 
@@ -153,6 +187,6 @@ mod tests {
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1);
         assert_eq!(sends[0].0, "tmpm-test");
-        assert_eq!(sends[0].1, SPAWN_COMMAND);
+        assert_eq!(sends[0].1, spawn_command());
     }
 }


### PR DESCRIPTION
## Summary

Configuration-only fixes so `tm`-spawned Claude Code sessions actually run **unattended**. Addresses e2e blockers #1268, #1269, #1270. No search-indexing / palace-creation features (that is a separate next change) — this PR is pure spawn configuration.

## BEFORE / AFTER `claude` argv

**Session-manager runtime adapter** (`runtime/claude_code.rs`, the `env -u ANTHROPIC_API_KEY claude` path):
- BEFORE: `env -u ANTHROPIC_API_KEY claude`
- AFTER:  `env -u ANTHROPIC_API_KEY claude --setting-sources project,local --permission-mode acceptEdits`

**CLI launch builder** (`core/model_inject.rs::build_claude_command`, used by `tm launch` / `tm session start`):
- BEFORE: `claude [--model <m>] [--append-system-prompt-file <p>]`
- AFTER:  `claude [--model <m>] [--append-system-prompt-file <p>] --setting-sources project,local --permission-mode acceptEdits`

The `env -u ANTHROPIC_API_KEY` env-scrub is **preserved** (OAuth path). `--setting-sources` does **not** touch `~/.claude.json`, so the ambient OAuth login tm relies on keeps working. Verified empirically: `env -u ANTHROPIC_API_KEY claude -p ... --setting-sources project,local --permission-mode acceptEdits` returns a successful result over OAuth.

## #1270 — broken memory hook + wrong MCP args

The deployed project hooks called `trusty-memory hooks fire <event>`, which **does not exist**. A non-zero `UserPromptSubmit` hook hard-blocks the prompt, so spawned sessions were dead on arrival.

**Evidence (`trusty-memory --help` has no `hooks` subcommand):**
```
$ trusty-memory hooks fire claude.user-prompt ; echo $?
error: unrecognized subcommand 'hooks'
2                       # <- nonzero => blocked every UserPromptSubmit
$ trusty-memory prompt-context ; echo $?
0                       # <- corrected hook, never blocks
```

Corrected to the canonical hooks `trusty-memory setup` installs (`crates/trusty-memory/src/commands/setup.rs`):
- `UserPromptSubmit` → `trusty-memory prompt-context` (documented to always exit 0)
- `SessionStart` → `trusty-memory inbox-check`
- Dropped `PostToolUse` / `Stop` — trusty-memory ships no such CLI surface; in-session memory writes flow through MCP tools.

Also fixed the **trusty-memory MCP args**: were `["mcp","serve"]` (no `mcp` subcommand) → now `["serve","--stdio"]` (the canonical stdio MCP invocation).

## #1269 — trust + permission dialogs swallow the injected task

tm uses an **interactive** tmux session, where the trust dialog ("Do you trust this folder?") and per-tool permission prompts appear and swallow the `send-keys` task. Chose **(a)+(b)** to keep the interactive tmux/observe model (vs headless `-p`):

- **(a) Trust pre-seed:** `preseed_workspace_trust` writes the per-dir entry into `~/.claude.json` (`hasTrustDialogAccepted: true`, `hasCompletedProjectOnboarding: true`, `projectOnboardingSeenCount >= 1`) for the tm-owned workspace. Trust lives in the config dir (`~/.claude.json`), which `--setting-sources` does not govern, so it must be seeded directly. tm owns the workspace path (`~/trusty-mpm-projects/<owner>/<repo>/<id>/`), so marking it trusted is safe. The format matches real `~/.claude.json` `projects.<abs-path>` entries. A malformed/OAuth-bearing file is **left untouched** (never clobbered — would force a re-login).
- **(b) `--permission-mode acceptEdits`** on the argv so the unattended session does not block on per-tool permission prompts (kept short of `bypassPermissions`, which is reserved for fully-sandboxed provisioned runs).

## Step 4 — isolate from USER settings + ensure both MCP servers

- `--setting-sources project,local` excludes the `user` source so the operator's global `~/.claude/settings.json` hooks (e.g. claude-mpm's) no longer bleed into tm sessions. Applied in **both** spawn paths via shared constants so they cannot drift.
- **trusty-search MCP injected** alongside trusty-memory (it was never wired before). Entry: `{ "command": "trusty-search", "args": ["serve"] }` (stdio default). `prepare_session` now writes both servers into the workspace `.mcp.json`. MCP wiring only — index creation is the next change.

## #1268 — port mismatch ("daemon: unreachable")

The daemon bind default, the client `--url` default, and `DEFAULT_DAEMON_URL` each hard-coded `127.0.0.1:7880` independently (and `7881` is actually the *supervisor metrics* port, a likely source of confusion). Hoisted the address into a **single source of truth** in `core::discovery`:
- `DEFAULT_DAEMON_ADDR` + `default_daemon_addr()` — the daemon `--addr` default derives from it; the client `--url` default (`DEFAULT_URL`) and `DEFAULT_DAEMON_URL` derive from it too.
- New test `default_url_matches_addr` proves `DEFAULT_DAEMON_URL == "http://" + DEFAULT_DAEMON_ADDR`, so the two sides can never drift again. The existing lock-file discovery (ephemeral-port fallback) is unchanged and still wins when present.

## Version

trusty-mpm `0.8.0 → 0.8.1` (crate `Cargo.toml` + root `[workspace.dependencies]` pin).

## Validation (all green)

- `cargo fmt --check -p trusty-mpm` → clean
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo test -p trusty-mpm` → 34 lib + integration suites pass, 0 failed
- `bash scripts/check_line_cap.sh` → 15 allowlisted, 0 violations
- `SKIP_UI_BUILD=1 cargo publish --dry-run -p trusty-mpm` → packaged + verified (upload aborted by dry-run)

New unit tests cover: argv carries `--setting-sources project,local` + `--permission-mode acceptEdits` (both builders); the `.mcp.json` gets both trusty-memory (`serve --stdio`) and trusty-search (`serve`); the corrected memory hook commands (and that `hooks fire` is never written); trust pre-seed (marks dir / preserves OAuth & other keys / idempotent / leaves malformed file untouched); daemon/client port agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)