### PR TITLE
fix(trusty-mpm): export full PATH in generated launchd plist so daemon spawns find tmux+claude (closes #1298)

### DIFF
--- a/crates/trusty-common/src/bin_resolve.rs
+++ b/crates/trusty-common/src/bin_resolve.rs
@@ -1,0 +1,282 @@
+//! Robust executable discovery and daemon `PATH` composition.
+//!
+//! Why: macOS launchd relaunches LaunchAgents with a deliberately minimal
+//! `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`). Daemons that shell out to tools
+//! installed by Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) or into the
+//! user's home (`~/.local/bin`, `~/.cargo/bin`) therefore fail *before*
+//! reaching application logic — e.g. the trusty-mpm session manager could not
+//! find `tmux` or `claude` after every daemon restart (#1298). Two daemons
+//! independently hand-rolled `which`-style lookups and would each have to
+//! re-derive the same well-known-dir list; this module is the single shared
+//! answer.
+//!
+//! What: [`daemon_path_dirs`] returns the ordered, de-duplicated list of bin
+//! directories a trusty-* daemon should be able to see (Homebrew + user bins
+//! before the standard system dirs, with `~` expanded to the real home).
+//! [`daemon_path_env`] joins them into a `PATH` string suitable for a launchd
+//! `EnvironmentVariables` dict. [`resolve_binary`] finds an executable by
+//! consulting the live `PATH` first and falling back to those well-known dirs,
+//! so a daemon spawned with a minimal `PATH` still locates `tmux`/`claude`.
+//!
+//! Test: `daemon_path_*` and `resolve_binary_*` unit tests below. The module is
+//! cross-platform (the well-known dirs are macOS/Linux-oriented but harmless
+//! elsewhere) so it is not gated behind `#[cfg(target_os = "macos")]`.
+
+use std::path::{Path, PathBuf};
+
+/// Standard system bin directories present even under launchd's minimal `PATH`.
+///
+/// Why: these must always be in the composed `PATH` so core utilities
+/// (`/bin/sh`, `/usr/bin/env`, …) resolve. They go *after* the user/Homebrew
+/// dirs so a Homebrew tool shadows an older system copy when both exist.
+const SYSTEM_BIN_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+/// Absolute (non-home) bin directories that hold operator-installed tools.
+///
+/// Why: Homebrew installs to `/opt/homebrew/bin` (Apple silicon) or
+/// `/usr/local/bin` (Intel); both must be visible to the daemon. Listed before
+/// the home-relative dirs only for readability — final ordering is
+/// user/Homebrew first, then system, enforced in [`daemon_path_dirs`].
+const ABSOLUTE_TOOL_DIRS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin"];
+
+/// Home-relative bin directories (expanded against the real home dir).
+///
+/// Why: `claude` ships to `~/.local/bin` and cargo-installed binaries land in
+/// `~/.cargo/bin`; launchd never expands `~`, so the daemon must carry the
+/// expanded absolute paths.
+const HOME_RELATIVE_BIN_DIRS: &[&str] = &[".local/bin", ".cargo/bin"];
+
+/// Compose the ordered, de-duplicated list of bin directories a trusty-*
+/// daemon should be able to see, with `~` expanded to the real home.
+///
+/// Why: launchd's minimal `PATH` omits Homebrew and user bin dirs, breaking
+/// daemon spawns of `tmux`/`claude` (#1298). A single canonical ordering keeps
+/// the generated plist `PATH` and the runtime [`resolve_binary`] fallback in
+/// agreement.
+/// What: returns Homebrew/absolute tool dirs, then the home-relative dirs
+/// (`~/.local/bin`, `~/.cargo/bin`) expanded against [`dirs::home_dir`], then
+/// the standard system dirs — de-duplicated, preserving first-seen order.
+/// Existing entries from the live `PATH` are intentionally *not* merged here;
+/// callers that want the inherited `PATH` too should prepend it.
+/// Test: `daemon_path_dirs_orders_user_before_system`,
+/// `daemon_path_dirs_expands_home`, `daemon_path_dirs_dedupes`.
+pub fn daemon_path_dirs() -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let push = |p: PathBuf, acc: &mut Vec<PathBuf>| {
+        if !acc.contains(&p) {
+            acc.push(p);
+        }
+    };
+
+    for d in ABSOLUTE_TOOL_DIRS {
+        push(PathBuf::from(d), &mut dirs);
+    }
+    if let Some(home) = dirs::home_dir() {
+        for rel in HOME_RELATIVE_BIN_DIRS {
+            push(home.join(rel), &mut dirs);
+        }
+    }
+    for d in SYSTEM_BIN_DIRS {
+        push(PathBuf::from(d), &mut dirs);
+    }
+    dirs
+}
+
+/// Render [`daemon_path_dirs`] as a colon-joined `PATH` string.
+///
+/// Why: a launchd `EnvironmentVariables` dict needs `PATH` as a single string;
+/// generating it from the same source as the runtime fallback guarantees the
+/// installed daemon and the live resolver look in identical places.
+/// What: joins [`daemon_path_dirs`] with `:`, skipping any path that is not
+/// valid UTF-8 (launchd plist values are UTF-8 strings).
+/// Test: `daemon_path_env_contains_expected_dirs`.
+pub fn daemon_path_env() -> String {
+    daemon_path_dirs()
+        .into_iter()
+        .filter_map(|p| p.to_str().map(str::to_owned))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Resolve an executable by name, trusting the live `PATH` first and falling
+/// back to the well-known [`daemon_path_dirs`].
+///
+/// Why: a daemon relaunched by launchd with a minimal `PATH` cannot find
+/// `tmux`/`claude` via a bare `PATH` lookup, yet the binaries exist at known
+/// locations. Checking those locations after the `PATH` lookup makes spawning
+/// resilient to the inherited environment without trusting it.
+/// What: if `name` contains a path separator it is treated as a literal path
+/// and returned when it is an existing file. Otherwise each entry of the
+/// current process `PATH` is checked, then each [`daemon_path_dirs`] entry, for
+/// an existing `dir/name`; the first hit is returned. Returns `None` if nothing
+/// matches.
+/// Test: `resolve_binary_finds_in_well_known_dir`,
+/// `resolve_binary_returns_none_for_missing`,
+/// `resolve_binary_accepts_absolute_path`.
+pub fn resolve_binary(name: &str) -> Option<PathBuf> {
+    // An explicit path (absolute or relative with a separator) is used verbatim.
+    if name.contains(std::path::MAIN_SEPARATOR) {
+        let p = PathBuf::from(name);
+        return p.is_file().then_some(p);
+    }
+
+    // 1) Honour the live PATH (covers interactive/login invocations).
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            if let Some(hit) = candidate(&dir, name) {
+                return Some(hit);
+            }
+        }
+    }
+
+    // 2) Fall back to the well-known daemon dirs (covers launchd's minimal PATH).
+    for dir in daemon_path_dirs() {
+        if let Some(hit) = candidate(&dir, name) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
+/// Return `dir/name` when it is an existing file, else `None`.
+///
+/// Why: factoring the join+exists check keeps [`resolve_binary`] readable and
+/// the "is this a runnable file" predicate in one place.
+/// What: joins `dir` and `name` and returns the path when [`Path::is_file`]
+/// holds (a symlink to a file also satisfies `is_file`).
+/// Test: exercised via the `resolve_binary_*` tests.
+fn candidate(dir: &Path, name: &str) -> Option<PathBuf> {
+    let p = dir.join(name);
+    p.is_file().then_some(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_path_dirs_orders_user_before_system() {
+        let dirs = daemon_path_dirs();
+        let pos = |needle: &str| dirs.iter().position(|p| p == &PathBuf::from(needle));
+        let homebrew = pos("/opt/homebrew/bin").expect("homebrew dir present");
+        let usr_bin = pos("/usr/bin").expect("/usr/bin present");
+        assert!(
+            homebrew < usr_bin,
+            "Homebrew must precede /usr/bin so it shadows older system copies"
+        );
+    }
+
+    #[test]
+    fn daemon_path_dirs_expands_home() {
+        let home = dirs::home_dir().expect("home dir resolvable in test env");
+        let dirs = daemon_path_dirs();
+        assert!(
+            dirs.contains(&home.join(".local/bin")),
+            "~/.local/bin must be expanded to the real home"
+        );
+        assert!(
+            dirs.contains(&home.join(".cargo/bin")),
+            "~/.cargo/bin must be expanded to the real home"
+        );
+        // No literal tilde should survive expansion.
+        assert!(
+            dirs.iter().all(|p| !p.starts_with("~")),
+            "launchd does not expand ~; paths must be absolute"
+        );
+    }
+
+    #[test]
+    fn daemon_path_dirs_dedupes() {
+        let dirs = daemon_path_dirs();
+        let mut sorted = dirs.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            dirs.len(),
+            "daemon_path_dirs must not contain duplicates"
+        );
+    }
+
+    #[test]
+    fn daemon_path_env_contains_expected_dirs() {
+        let env = daemon_path_env();
+        let home = dirs::home_dir().expect("home dir resolvable in test env");
+        assert!(env.contains("/opt/homebrew/bin"), "PATH missing Homebrew");
+        assert!(
+            env.contains("/usr/local/bin"),
+            "PATH missing /usr/local/bin"
+        );
+        assert!(
+            env.contains(home.join(".local/bin").to_str().unwrap()),
+            "PATH missing expanded ~/.local/bin"
+        );
+        assert!(
+            env.contains(home.join(".cargo/bin").to_str().unwrap()),
+            "PATH missing expanded ~/.cargo/bin"
+        );
+        for sys in SYSTEM_BIN_DIRS {
+            assert!(env.contains(sys), "PATH missing system dir {sys}");
+        }
+    }
+
+    #[test]
+    fn resolve_binary_finds_in_well_known_dir() {
+        // Create a fake "binary" inside a temp dir, then point one of the
+        // well-known dirs at it via a symlink-free approach: we cannot inject
+        // into daemon_path_dirs, so instead verify resolution through PATH and
+        // through an explicit directory join using candidate().
+        let tmp = std::env::temp_dir().join(format!("bin_resolve_test_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let bin = tmp.join("fake-tool-xyz");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+
+        // candidate() must find it given the directory.
+        let hit = candidate(&tmp, "fake-tool-xyz");
+        assert_eq!(hit.as_deref(), Some(bin.as_path()));
+
+        // resolve_binary honours PATH: prepend tmp to PATH and resolve.
+        let orig = std::env::var_os("PATH");
+        let mut paths = vec![tmp.clone()];
+        if let Some(ref p) = orig {
+            paths.extend(std::env::split_paths(p));
+        }
+        let joined = std::env::join_paths(paths).unwrap();
+        // SAFETY: single-threaded test; restored immediately after.
+        unsafe {
+            std::env::set_var("PATH", &joined);
+        }
+        let resolved = resolve_binary("fake-tool-xyz");
+        // SAFETY: restore original PATH before any assertion can unwind.
+        unsafe {
+            match orig {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        assert_eq!(resolved.as_deref(), Some(bin.as_path()));
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn resolve_binary_returns_none_for_missing() {
+        assert!(
+            resolve_binary("definitely-not-a-real-binary-zzz-1298").is_none(),
+            "a nonexistent binary must resolve to None"
+        );
+    }
+
+    #[test]
+    fn resolve_binary_accepts_absolute_path() {
+        // /bin/sh exists on every supported unix.
+        let sh = PathBuf::from("/bin/sh");
+        if sh.is_file() {
+            assert_eq!(resolve_binary("/bin/sh"), Some(sh));
+        }
+        assert!(
+            resolve_binary("/no/such/path/here-1298").is_none(),
+            "a non-existent explicit path must resolve to None"
+        );
+    }
+}

--- a/crates/trusty-common/src/bin_resolve.rs
+++ b/crates/trusty-common/src/bin_resolve.rs
@@ -138,16 +138,40 @@ pub fn resolve_binary(name: &str) -> Option<PathBuf> {
     None
 }
 
-/// Return `dir/name` when it is an existing file, else `None`.
+/// Return `dir/name` when it is an existing, runnable file, else `None`.
 ///
 /// Why: factoring the join+exists check keeps [`resolve_binary`] readable and
-/// the "is this a runnable file" predicate in one place.
-/// What: joins `dir` and `name` and returns the path when [`Path::is_file`]
-/// holds (a symlink to a file also satisfies `is_file`).
-/// Test: exercised via the `resolve_binary_*` tests.
+/// the "is this a runnable file" predicate in one place. A bare `is_file` check
+/// is too loose: a non-executable regular file (e.g. a stray `claude.json` or a
+/// data file that happens to share a name) would be returned and then fail at
+/// spawn time. Requiring the execute bit on Unix means resolution only yields
+/// paths the daemon can actually `exec`.
+/// What: joins `dir` and `name`. On Unix the result is returned only when it is
+/// a file *and* at least one execute bit (`0o111`) is set in its permissions; a
+/// symlink to an executable file also satisfies this (metadata follows the
+/// link). On non-Unix targets the historical [`Path::is_file`] behaviour is
+/// preserved (no portable execute concept).
+/// Test: `candidate_requires_execute_bit_on_unix`, plus the `resolve_binary_*`
+/// tests.
 fn candidate(dir: &Path, name: &str) -> Option<PathBuf> {
     let p = dir.join(name);
-    p.is_file().then_some(p)
+    if !p.is_file() {
+        return None;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // `metadata` follows symlinks, so a symlink to an executable resolves
+        // correctly. A file with no execute bit is not a runnable binary.
+        match std::fs::metadata(&p) {
+            Ok(meta) if meta.permissions().mode() & 0o111 != 0 => Some(p),
+            _ => None,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        Some(p)
+    }
 }
 
 #[cfg(test)]
@@ -220,41 +244,89 @@ mod tests {
         }
     }
 
+    /// Create a unique temp directory for a test, returning its path.
+    ///
+    /// Why: each test needs an isolated scratch dir; keying it on the test name
+    /// plus the process id avoids collisions under the parallel harness without
+    /// pulling in an extra dev-dependency.
+    /// What: joins the system temp dir with `bin_resolve_<tag>_<pid>` and
+    /// `create_dir_all`s it.
+    /// Test: exercised by every test that calls it.
+    fn make_temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("bin_resolve_{tag}_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// Write a file and, on Unix, mark it executable.
+    ///
+    /// Why: [`candidate`] now requires the execute bit on Unix, so test fixtures
+    /// that stand in for binaries must be chmod'd `0o755` to be discoverable.
+    /// What: writes a tiny shebang stub at `path` and sets mode `0o755` on Unix.
+    /// Test: exercised by `candidate_*` and `resolve_binary_*` tests.
+    fn write_executable(path: &Path) {
+        std::fs::write(path, b"#!/bin/sh\n").expect("write fixture");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path).expect("stat fixture").permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).expect("chmod fixture");
+        }
+    }
+
     #[test]
     fn resolve_binary_finds_in_well_known_dir() {
-        // Create a fake "binary" inside a temp dir, then point one of the
-        // well-known dirs at it via a symlink-free approach: we cannot inject
-        // into daemon_path_dirs, so instead verify resolution through PATH and
-        // through an explicit directory join using candidate().
-        let tmp = std::env::temp_dir().join(format!("bin_resolve_test_{}", std::process::id()));
-        std::fs::create_dir_all(&tmp).unwrap();
+        // Verify the "found in a directory" branch WITHOUT mutating the
+        // process-global PATH (which races the parallel test harness). We
+        // exercise candidate() directly against an explicit temp dir — the same
+        // per-directory predicate resolve_binary() applies to each PATH and
+        // well-known-dir entry — and confirm resolve_binary() accepts the
+        // resulting explicit path verbatim.
+        let tmp = make_temp_dir("well_known");
         let bin = tmp.join("fake-tool-xyz");
-        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        write_executable(&bin);
 
-        // candidate() must find it given the directory.
+        // candidate() finds the executable given its directory.
         let hit = candidate(&tmp, "fake-tool-xyz");
         assert_eq!(hit.as_deref(), Some(bin.as_path()));
 
-        // resolve_binary honours PATH: prepend tmp to PATH and resolve.
-        let orig = std::env::var_os("PATH");
-        let mut paths = vec![tmp.clone()];
-        if let Some(ref p) = orig {
-            paths.extend(std::env::split_paths(p));
-        }
-        let joined = std::env::join_paths(paths).unwrap();
-        // SAFETY: single-threaded test; restored immediately after.
-        unsafe {
-            std::env::set_var("PATH", &joined);
-        }
-        let resolved = resolve_binary("fake-tool-xyz");
-        // SAFETY: restore original PATH before any assertion can unwind.
-        unsafe {
-            match orig {
-                Some(p) => std::env::set_var("PATH", p),
-                None => std::env::remove_var("PATH"),
-            }
-        }
-        assert_eq!(resolved.as_deref(), Some(bin.as_path()));
+        // resolve_binary() accepts the discovered path as an explicit path,
+        // closing the loop from "found in a dir" to "usable result" — no PATH
+        // mutation required.
+        let explicit = bin.to_str().expect("utf8 temp path");
+        assert_eq!(resolve_binary(explicit).as_deref(), Some(bin.as_path()));
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn candidate_requires_execute_bit_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = make_temp_dir("exec_bit");
+
+        // A non-executable regular file must NOT be returned.
+        let data = tmp.join("not-a-binary");
+        std::fs::write(&data, b"plain data\n").expect("write data file");
+        let mut perms = std::fs::metadata(&data).expect("stat data").permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&data, perms).expect("chmod data");
+        assert_eq!(
+            candidate(&tmp, "not-a-binary"),
+            None,
+            "a non-executable regular file must not resolve as a runnable binary"
+        );
+
+        // An executable file with the same parent dir IS returned.
+        let exe = tmp.join("a-binary");
+        write_executable(&exe);
+        assert_eq!(
+            candidate(&tmp, "a-binary").as_deref(),
+            Some(exe.as_path()),
+            "an executable file must resolve"
+        );
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/trusty-common/src/launchd.rs
+++ b/crates/trusty-common/src/launchd.rs
@@ -97,6 +97,30 @@ pub struct LaunchdConfig {
 }
 
 impl LaunchdConfig {
+    /// Ensure the agent's environment exports a full `PATH` covering Homebrew
+    /// and user bin dirs, returning `self` for builder-style chaining.
+    ///
+    /// Why: macOS launchd relaunches LaunchAgents with a minimal `PATH`
+    /// (`/usr/bin:/bin:/usr/sbin:/sbin`). Daemons that shell out to Homebrew or
+    /// user-installed tools (`tmux` at `/opt/homebrew/bin`, `claude` at
+    /// `~/.local/bin`) then fail before reaching application logic, and every
+    /// daemon restart re-breaks them until the plist is hand-patched (#1298).
+    /// Seeding `PATH` into the generated plist makes the fix survive restarts.
+    /// What: if the caller has not already supplied a `PATH` env var, pushes a
+    /// `("PATH", `[`crate::bin_resolve::daemon_path_env`]`())` entry. A
+    /// caller-provided `PATH` is left untouched so explicit overrides win.
+    /// Test: `with_daemon_path_seeds_full_path`,
+    /// `with_daemon_path_preserves_explicit_path`.
+    #[must_use]
+    pub fn with_daemon_path(mut self) -> Self {
+        let has_path = self.env_vars.iter().any(|(k, _)| k == "PATH");
+        if !has_path {
+            self.env_vars
+                .push(("PATH".to_string(), crate::bin_resolve::daemon_path_env()));
+        }
+        self
+    }
+
     /// Render the launchd plist XML for this agent.
     ///
     /// Why: launchd consumes a property-list XML document; generating it in one
@@ -393,6 +417,48 @@ mod tests {
         assert!(xml.contains("<key>EnvironmentVariables</key>"));
         assert!(xml.contains("<key>RUST_LOG</key>"));
         assert!(xml.contains("<string>info</string>"));
+    }
+
+    /// Why: #1298 — every generated launchd plist for a daemon that spawns
+    /// `tmux`/`claude` must export a `PATH` covering Homebrew and the expanded
+    /// user bin dirs, or the daemon fails after each restart under launchd's
+    /// minimal `PATH`. This asserts the rendered plist carries that `PATH`.
+    /// What: builds a config with `with_daemon_path`, renders, and checks the
+    /// `EnvironmentVariables` `PATH` string contains `/opt/homebrew/bin`, the
+    /// expanded `~/.local/bin`, and the expanded `~/.cargo/bin`.
+    /// Test: itself.
+    #[test]
+    fn with_daemon_path_seeds_full_path() {
+        let home = dirs::home_dir().expect("home dir resolvable in test env");
+        let xml = sample(KeepAlive::Always)
+            .with_daemon_path()
+            .render_plist()
+            .unwrap();
+        assert!(xml.contains("<key>EnvironmentVariables</key>"));
+        assert!(xml.contains("<key>PATH</key>"));
+        assert!(
+            xml.contains("/opt/homebrew/bin"),
+            "plist PATH must include Homebrew bin dir"
+        );
+        assert!(
+            xml.contains(home.join(".local/bin").to_str().unwrap()),
+            "plist PATH must include expanded ~/.local/bin"
+        );
+        assert!(
+            xml.contains(home.join(".cargo/bin").to_str().unwrap()),
+            "plist PATH must include expanded ~/.cargo/bin"
+        );
+    }
+
+    #[test]
+    fn with_daemon_path_preserves_explicit_path() {
+        let mut cfg = sample(KeepAlive::Always);
+        cfg.env_vars = vec![("PATH".to_string(), "/custom/only".to_string())];
+        let cfg = cfg.with_daemon_path();
+        let path_entries: Vec<&(String, String)> =
+            cfg.env_vars.iter().filter(|(k, _)| k == "PATH").collect();
+        assert_eq!(path_entries.len(), 1, "must not duplicate an explicit PATH");
+        assert_eq!(path_entries[0].1, "/custom/only");
     }
 
     #[test]

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -64,6 +64,17 @@ pub mod log_buffer;
 /// Test: `cargo test -p trusty-common sys_metrics`.
 pub mod sys_metrics;
 
+/// Robust executable discovery and daemon `PATH` composition.
+///
+/// Why: launchd relaunches daemons with a minimal `PATH`, breaking spawns of
+/// Homebrew/user-installed tools (`tmux`, `claude`) until the inherited `PATH`
+/// is patched (#1298). This module composes the full set of well-known bin
+/// dirs for a generated launchd plist and provides a `PATH`-then-well-known
+/// binary resolver so the daemon spawns survive a minimal inherited `PATH`.
+/// What: `daemon_path_dirs`, `daemon_path_env`, `resolve_binary`.
+/// Test: `cargo test -p trusty-common bin_resolve`.
+pub mod bin_resolve;
+
 /// macOS LaunchAgent generation and lifecycle management. macOS-only —
 /// the module compiles to nothing on every other platform.
 #[cfg(target_os = "macos")]

--- a/crates/trusty-mpm/deploy/supervisor/README.md
+++ b/crates/trusty-mpm/deploy/supervisor/README.md
@@ -62,13 +62,14 @@ resumes sessions until you opt in. To enable it, do **one** of:
 ## Persistence — macOS (launchd)
 
 ```bash
-# 1. Find your tm binary and username:
+# 1. Find your tm binary and home directory:
 which tm          # e.g. /Users/you/.cargo/bin/tm
-whoami            # e.g. you
+echo "$HOME"      # e.g. /Users/you  (use the REAL $HOME, not an assumed /Users/<user>)
 
-# 2. Copy the plist and substitute the placeholders:
+# 2. Copy the plist and substitute the placeholders. __HOME__ expands to the
+#    real $HOME so non-default home prefixes (not just /Users/<user>) work:
 mkdir -p ~/Library/LaunchAgents ~/.trusty-mpm/logs
-sed -e "s|__USER__|$(whoami)|g" \
+sed -e "s|__HOME__|$HOME|g" \
     -e "s|__TM_BINARY_PATH__|$(which tm)|g" \
     crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist \
     > ~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist
@@ -84,8 +85,10 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.superviso
 `RunAtLoad` + `KeepAlive` make it survive reboots and restart on crash.
 
 The plist's `EnvironmentVariables` block sets a full `PATH`
-(`/opt/homebrew/bin:/usr/local/bin:~/.local/bin:~/.cargo/bin:` + system dirs,
-with `~` expanded by the `__USER__` substitution above). launchd otherwise
+(`/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.cargo/bin:` + system
+dirs, with `$HOME` substituted in for the `__HOME__` placeholder by the `sed`
+recipe above — launchd does NOT expand `~`, so the value must be the literal
+absolute home path). launchd otherwise
 relaunches the agent with a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`)
 that omits Homebrew (`tmux`) and `~/.local/bin` (`claude`), which 500s
 managed-session spawns after every restart (#1298). The daemon also resolves

--- a/crates/trusty-mpm/deploy/supervisor/README.md
+++ b/crates/trusty-mpm/deploy/supervisor/README.md
@@ -83,6 +83,15 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.superviso
 
 `RunAtLoad` + `KeepAlive` make it survive reboots and restart on crash.
 
+The plist's `EnvironmentVariables` block sets a full `PATH`
+(`/opt/homebrew/bin:/usr/local/bin:~/.local/bin:~/.cargo/bin:` + system dirs,
+with `~` expanded by the `__USER__` substitution above). launchd otherwise
+relaunches the agent with a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`)
+that omits Homebrew (`tmux`) and `~/.local/bin` (`claude`), which 500s
+managed-session spawns after every restart (#1298). The daemon also resolves
+`tmux`/`claude` via well-known dirs at runtime as a belt-and-braces fallback,
+so spawns survive even a minimal inherited `PATH`.
+
 ## Persistence — Linux (systemd user service)
 
 ```bash

--- a/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
+++ b/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
@@ -11,9 +11,12 @@
   Edit the env block to taste, then load it (see deploy/supervisor/README.md).
 
   IMPORTANT — replace the placeholders before loading:
-    * __USER__              your macOS short username (e.g. `masa`)
+    * __HOME__              your home directory (e.g. `/Users/masa`); do NOT
+                            assume `/Users/<user>` — use the real $HOME so
+                            non-default home prefixes work. (run `echo $HOME`)
     * __TM_BINARY_PATH__    absolute path to the `tm` binary, e.g.
-                            /Users/__USER__/.cargo/bin/tm  (run `which tm`)
+                            $HOME/.cargo/bin/tm  (run `which tm`)
+  The deploy/supervisor/README.md sed recipe substitutes these for you.
 -->
 <plist version="1.0">
 <dict>
@@ -37,10 +40,11 @@
              agent with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that omits
              both, which 500s managed-session spawns after every restart (#1298).
              launchd does NOT expand ~, so the home-relative dirs are written out
-             with the __USER__ placeholder. Keep user/Homebrew dirs before the
-             system dirs. -->
+             with the __HOME__ placeholder, which the README sed recipe replaces
+             with the real $HOME (NOT an assumed /Users/<user> prefix). Keep
+             user/Homebrew dirs before the system dirs. -->
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/Users/__USER__/.local/bin:/Users/__USER__/.cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:__HOME__/.local/bin:__HOME__/.cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <!-- ENABLE AUTO-RESUME: uncomment the two lines below to set it to 1.
         <key>TRUSTY_MPM_AUTO_RESUME</key>
         <string>1</string>
@@ -65,9 +69,9 @@
 
     <!-- Logs land next to the daemon's own logs. -->
     <key>StandardOutPath</key>
-    <string>/Users/__USER__/.trusty-mpm/logs/supervisor.out.log</string>
+    <string>__HOME__/.trusty-mpm/logs/supervisor.out.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/__USER__/.trusty-mpm/logs/supervisor.err.log</string>
+    <string>__HOME__/.trusty-mpm/logs/supervisor.err.log</string>
 
     <key>ProcessType</key>
     <string>Background</string>

--- a/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
+++ b/crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist
@@ -32,6 +32,15 @@
          TRUSTY_MPM_AUTO_RESUME block below (or pass `tm supervisor --auto-resume`). -->
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- Full PATH so the supervisor (and the sessions it spawns) can find
+             tmux (Homebrew) and claude (~/.local/bin). launchd relaunches this
+             agent with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that omits
+             both, which 500s managed-session spawns after every restart (#1298).
+             launchd does NOT expand ~, so the home-relative dirs are written out
+             with the __USER__ placeholder. Keep user/Homebrew dirs before the
+             system dirs. -->
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/Users/__USER__/.local/bin:/Users/__USER__/.cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <!-- ENABLE AUTO-RESUME: uncomment the two lines below to set it to 1.
         <key>TRUSTY_MPM_AUTO_RESUME</key>
         <string>1</string>

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -81,25 +81,32 @@ pub struct TmuxDriver {
 }
 
 impl TmuxDriver {
-    /// Resolve the `tmux` binary, or fail if it is not on `PATH`.
+    /// Resolve the `tmux` binary, or fail if it cannot be found.
     ///
     /// Why: the daemon should refuse the tmux control model up front rather
-    /// than fail on the first session start.
-    /// What: runs `which tmux`; errors with a clear message if absent.
+    /// than fail on the first session start. Under launchd the daemon inherits
+    /// a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) that omits Homebrew,
+    /// so a bare `PATH` lookup of `tmux` (which lives at `/opt/homebrew/bin`)
+    /// returns nothing and every managed-session spawn 500s after a restart
+    /// (#1298). Resolving via the well-known dirs makes discovery survive the
+    /// minimal inherited `PATH`.
+    /// What: delegates to [`trusty_common::bin_resolve::resolve_binary`], which
+    /// consults the live `PATH` first and then falls back to the well-known
+    /// daemon dirs (Homebrew + user bins). Errors with a clear message if no
+    /// `tmux` is found anywhere.
     /// Test: `driver_reports_availability` (skips assertion when tmux missing).
     pub fn discover() -> Result<Self> {
-        let output = Command::new("which").arg("tmux").output()?;
-        if !output.status.success() {
-            return Err(Error::Protocol(
-                "tmux not found on PATH; use the PTY or SDK control model".into(),
-            ));
-        }
-        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if path.is_empty() {
-            return Err(Error::Protocol(
-                "`which tmux` returned an empty path".into(),
-            ));
-        }
+        let path = trusty_common::bin_resolve::resolve_binary("tmux").ok_or_else(|| {
+            Error::Protocol(
+                "tmux not found on PATH or in well-known dirs (e.g. /opt/homebrew/bin); \
+                 use the PTY or SDK control model"
+                    .into(),
+            )
+        })?;
+        let path = path
+            .to_str()
+            .ok_or_else(|| Error::Protocol("resolved tmux path is not valid UTF-8".into()))?
+            .to_string();
         Ok(Self { tmux_path: path })
     }
 

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -10,7 +10,6 @@
 //! `claude_code_adapter_identifies`.
 
 use std::path::Path;
-use std::process::Command;
 use std::sync::Arc;
 
 use tracing::debug;
@@ -33,13 +32,17 @@ use super::RuntimeError;
 /// shared [`crate::core::model_inject::SETTING_SOURCES_FLAG`] /
 /// [`crate::core::model_inject::PERMISSION_MODE_FLAG`] constants so this spawn
 /// path and the CLI launch path can never drift.
-/// What: built once at first use from `env -u ANTHROPIC_API_KEY claude` plus the
-/// two shared flag constants; piped to `tmux send-keys … Enter`.
+/// What: built from `env -u ANTHROPIC_API_KEY <claude_bin>` plus the two shared
+/// flag constants; piped to `tmux send-keys … Enter`. `claude_bin` is the
+/// resolved binary — an absolute path under launchd so the pane (which inherits
+/// the daemon's minimal `PATH`) does not need `claude` on its own `PATH` (#1298).
 /// Test: `spawn_command_contains_env_scrub`,
-/// `spawn_command_contains_isolation_flags`.
-fn spawn_command() -> String {
+/// `spawn_command_contains_isolation_flags`,
+/// `spawn_command_uses_resolved_binary`.
+fn spawn_command(claude_bin: &str) -> String {
     format!(
-        "env -u ANTHROPIC_API_KEY claude {} {}",
+        "env -u ANTHROPIC_API_KEY {} {} {}",
+        claude_bin,
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
     )
@@ -69,18 +72,20 @@ impl ClaudeCodeAdapter {
         Self { tmux }
     }
 
-    /// Return `true` if the `claude` binary can be found on `PATH`.
+    /// Resolve the `claude` binary to an absolute path, or `None` if missing.
     ///
-    /// Why: `spawn` must return `RuntimeError::BinaryNotFound` rather than
-    /// sending a command that silently fails inside the pane.
-    /// What: runs `which claude` and checks the exit status.
-    /// Test: `claude_code_adapter_binary_check`.
-    fn claude_available() -> bool {
-        Command::new("which")
-            .arg("claude")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+    /// Why: under launchd the daemon (and the tmux pane it spawns) inherits a
+    /// minimal `PATH` that omits `~/.local/bin` where Claude Code installs, so a
+    /// bare `claude` on the pane would fail to launch (spawn `[errored]`, #1298).
+    /// Resolving to an absolute path here lets the spawn command invoke claude
+    /// by full path, independent of the pane's `PATH`.
+    /// What: delegates to [`trusty_common::bin_resolve::resolve_binary`] which
+    /// checks the live `PATH` first then the well-known daemon dirs (Homebrew +
+    /// `~/.local/bin` + `~/.cargo/bin`); returns the resolved path as a `String`.
+    /// Test: `claude_code_adapter_binary_check_returns_option`.
+    fn resolve_claude() -> Option<String> {
+        trusty_common::bin_resolve::resolve_binary("claude")
+            .and_then(|p| p.to_str().map(str::to_owned))
     }
 }
 
@@ -89,26 +94,30 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     ///
     /// Why: the session manager calls this after creating the tmux pane so the
     /// actual agent process starts inside it.
-    /// What: checks that `claude` is on PATH (returns `BinaryNotFound` if not),
-    /// then sends [`spawn_command`] (`env -u ANTHROPIC_API_KEY claude` plus the
+    /// What: resolves `claude` to an absolute path (returns `BinaryNotFound`
+    /// if it cannot be found on `PATH` or in the well-known daemon dirs), then
+    /// sends [`spawn_command`] (`env -u ANTHROPIC_API_KEY <abs-claude>` plus the
     /// isolation/permission flags) to the pane; the task is logged for
     /// observability but not passed to the command (Claude Code reads
     /// instructions from CLAUDE.md or an interactive prompt).
     /// Test: `spawn_sends_env_scrub_when_binary_available`.
     fn spawn(&self, tmux_name: &str, cwd: &Path, task: &str) -> Result<(), RuntimeError> {
-        if !Self::claude_available() {
-            return Err(RuntimeError::BinaryNotFound(
-                "claude binary not found on PATH — install Claude Code first".into(),
-            ));
-        }
+        let claude_bin = Self::resolve_claude().ok_or_else(|| {
+            RuntimeError::BinaryNotFound(
+                "claude binary not found on PATH or in well-known dirs \
+                 (e.g. ~/.local/bin) — install Claude Code first"
+                    .into(),
+            )
+        })?;
         debug!(
             session = %tmux_name,
             cwd = %cwd.display(),
             task = %task,
+            claude = %claude_bin,
             "spawning claude-code in tmux pane"
         );
         self.tmux
-            .send_line(tmux_name, &spawn_command())
+            .send_line(tmux_name, &spawn_command(&claude_bin))
             .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
     }
 
@@ -139,7 +148,7 @@ mod tests {
     fn spawn_command_contains_env_scrub() {
         // The spawn command must always strip the API key from the environment
         // so the session falls back to OAuth in ~/.claude.json.
-        let cmd = spawn_command();
+        let cmd = spawn_command("claude");
         assert!(
             cmd.contains("env -u ANTHROPIC_API_KEY"),
             "spawn command must contain env scrub: {cmd}"
@@ -154,7 +163,7 @@ mod tests {
     fn spawn_command_contains_isolation_flags() {
         // Why (#1269): the session_manager spawn path must isolate from the
         // user's global settings and run unattended, exactly like the CLI path.
-        let cmd = spawn_command();
+        let cmd = spawn_command("claude");
         assert!(
             cmd.contains("--setting-sources project,local"),
             "spawn command must isolate settings: {cmd}"
@@ -166,19 +175,33 @@ mod tests {
     }
 
     #[test]
-    fn claude_code_adapter_binary_check_returns_bool() {
-        // Just assert the function returns without panicking; we don't assert
-        // the result because `claude` may or may not be on PATH in CI.
-        let _ = ClaudeCodeAdapter::claude_available();
+    fn spawn_command_uses_resolved_binary() {
+        // Why (#1298): under launchd the pane inherits a minimal PATH, so the
+        // spawn command must invoke claude by the resolved (absolute) path
+        // rather than a bare `claude` that the pane's PATH cannot find.
+        let cmd = spawn_command("/Users/me/.local/bin/claude");
+        assert!(
+            cmd.contains("env -u ANTHROPIC_API_KEY /Users/me/.local/bin/claude "),
+            "spawn command must invoke the resolved absolute claude path: {cmd}"
+        );
+    }
+
+    #[test]
+    fn claude_code_adapter_binary_check_returns_option() {
+        // resolve_claude returns Some(path) or None without panicking; when it
+        // resolves, the path must be a non-empty absolute-ish string.
+        if let Some(p) = ClaudeCodeAdapter::resolve_claude() {
+            assert!(!p.is_empty(), "resolved claude path must be non-empty");
+        }
     }
 
     #[test]
     fn spawn_sends_env_scrub_when_binary_available() {
         // Patch: if claude is not available this test is a no-op (we cannot
         // install it in CI). We only assert the send when the binary exists.
-        if !ClaudeCodeAdapter::claude_available() {
+        let Some(claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
             return;
-        }
+        };
         let fake = FakeTmux::new();
         let adapter = ClaudeCodeAdapter::new(fake.clone());
         adapter
@@ -187,6 +210,6 @@ mod tests {
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1);
         assert_eq!(sends[0].0, "tmpm-test");
-        assert_eq!(sends[0].1, spawn_command());
+        assert_eq!(sends[0].1, spawn_command(&claude_bin));
     }
 }


### PR DESCRIPTION
## Summary

Closes #1298. The `com.trusty.mpm` launchd daemon/supervisor is relaunched by launchd with a **minimal PATH** (`/usr/bin:/bin:/usr/sbin:/sbin`) that omits Homebrew (`/opt/homebrew/bin` → `tmux`) and `~/.local/bin` (`claude`). The managed-session spawn path therefore failed **before** reaching app logic:

- `tmux not found on PATH` → HTTP 500 on `POST /api/v1/sessions/managed`
- `claude binary not found on PATH` → spawn `[errored]`

Every daemon restart (including after every `cargo install`) re-broke session spawning until the plist was hand-patched. This PR fixes it two ways.

### (a) Full PATH in the generated/shipped plist
- **New `trusty-common::bin_resolve` module**: `daemon_path_dirs()` / `daemon_path_env()` compose the ordered, de-duplicated set of well-known bin dirs — Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`), user bins (`~/.local/bin`, `~/.cargo/bin`, **`~` expanded to the real home** since launchd does not expand it), then system dirs.
- **`LaunchdConfig::with_daemon_path()`** seeds that PATH into the plist `EnvironmentVariables` dict (idempotent; an explicit caller-provided `PATH` wins). Available to every trusty-* daemon that generates a plist via `LaunchdConfig`.
- **`deploy/supervisor/com.trusty.mpm.supervisor.plist`** + its README now ship a full `PATH` (`/opt/homebrew/bin:/usr/local/bin:/Users/__USER__/.local/bin:/Users/__USER__/.cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin`).

The resulting PATH value:
```
/opt/homebrew/bin:/usr/local/bin:<HOME>/.local/bin:<HOME>/.cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

### (b) Defense-in-depth runtime resolution (survives a minimal inherited PATH)
- **`TmuxDriver::discover()`** now resolves `tmux` via `bin_resolve::resolve_binary` (live `PATH` first, then well-known dirs) instead of a bare `which tmux`.
- **`ClaudeCodeAdapter`** resolves `claude` to an **absolute path** and sends *that* into the tmux pane — the pane inherits the daemon's minimal PATH, so a bare `claude` would still fail; an absolute path launches regardless of the pane's PATH.

## Test evidence

```
# trusty-common (new + plist tests)
bin_resolve::tests::daemon_path_dirs_orders_user_before_system ... ok
bin_resolve::tests::daemon_path_dirs_expands_home ... ok
bin_resolve::tests::daemon_path_dirs_dedupes ... ok
bin_resolve::tests::daemon_path_env_contains_expected_dirs ... ok
bin_resolve::tests::resolve_binary_finds_in_well_known_dir ... ok
bin_resolve::tests::resolve_binary_returns_none_for_missing ... ok
bin_resolve::tests::resolve_binary_accepts_absolute_path ... ok
launchd::tests::with_daemon_path_seeds_full_path ... ok
launchd::tests::with_daemon_path_preserves_explicit_path ... ok
test result: ok. 86 passed; 0 failed; 6 ignored

# trusty-mpm
runtime::claude_code::tests::spawn_command_uses_resolved_binary ... ok
runtime::claude_code::tests::claude_code_adapter_binary_check_returns_option ... ok
daemon::tmux::tests::driver_reports_availability ... ok
test result: ok. 1040 passed; 0 failed   (lib)
test result: ok. 302 passed; 0 failed    (tm bin)
test result: ok. 34 + 10 + 1 passed; 0 failed  (integration)
```

- `cargo clippy -p trusty-common --all-targets -- -D warnings` — clean
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` → `15 allowlisted, 0 violations — OK.` (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)