### PR TITLE
feat(trusty-mpm): SM-1 — [session_manager] config + sm module skeleton (#1284)

### DIFF
--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::core::sm::config::SessionManagerConfig;
+
 // ──────────────────────────────────────────────
 // Top-level config sections
 // ──────────────────────────────────────────────
@@ -127,11 +129,17 @@ pub struct PmConfig {
 /// Why: a single top-level struct makes `toml::from_str` the only parsing
 /// call; every section has a `Default` impl so absent sections yield
 /// sensible values without errors.
-/// What: four optional sections (`[agents]`, `[models]`, `[skills]`,
-/// `[pm]`); absent sections produce their `Default`.
+/// What: five optional sections (`[agents]`, `[models]`, `[skills]`,
+/// `[pm]`, `[session_manager]`); absent sections produce their `Default`.
+/// The `[session_manager]` section (DOC-14 spec §10) defaults to disabled, so
+/// its mere presence in the struct never changes runtime behavior.
 /// Test: `config_absent_yields_defaults`, `config_valid_parsed`,
-/// `config_malformed_falls_back`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+/// `config_malformed_falls_back`, `config_session_manager_*`.
+///
+/// Note: `Eq` is intentionally NOT derived — [`SessionManagerConfig`] carries a
+/// floating-point `temperature`, and `f32` is not `Eq`. `PartialEq` is retained
+/// for the equality assertions in tests.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct MpmConfig {
     /// `[agents]` — agent discovery sources.
     #[serde(default)]
@@ -148,6 +156,13 @@ pub struct MpmConfig {
     /// `[pm]` — PM-layer feature toggles.
     #[serde(default)]
     pub pm: PmConfig,
+
+    /// `[session_manager]` — Session Manager agent config (DOC-14 §10).
+    ///
+    /// Defaults to `enabled = false`; absent or partial sections parse to spec
+    /// defaults and leave the legacy overseer path untouched.
+    #[serde(default)]
+    pub session_manager: SessionManagerConfig,
 }
 
 // ──────────────────────────────────────────────
@@ -328,6 +343,8 @@ mod tests {
         assert_eq!(cfg, MpmConfig::default());
         assert!(cfg.agents.sources.is_empty());
         assert!(cfg.models.agents.is_empty());
+        // SM-1 zero-regression: absent [session_manager] → disabled by default.
+        assert!(!cfg.session_manager.enabled);
     }
 
     #[test]
@@ -354,6 +371,21 @@ sources = ["bundled"]
 
 [pm]
 circuit_breaker = true
+
+[session_manager]
+enabled = true
+
+[session_manager.inference]
+provider = "anthropic"
+sm_model = "anthropic/claude-sonnet-4-6"
+temperature = 0.4
+
+[session_manager.memory]
+palace = "session-manager"
+recall_top_k = 8
+
+[session_manager.rounds]
+window = 12
 "#;
         let cfg = load_from_str(dir.path(), toml);
         assert_eq!(cfg.agents.sources, vec!["bundled", "user"]);
@@ -369,6 +401,47 @@ circuit_breaker = true
         assert_eq!(cfg.models.default.as_deref(), Some("sonnet"));
         assert_eq!(cfg.skills.sources, vec!["bundled"]);
         assert_eq!(cfg.pm.circuit_breaker, Some(true));
+        // [session_manager] parses through MpmConfig (DOC-14 §10).
+        assert!(cfg.session_manager.enabled);
+        assert_eq!(cfg.session_manager.inference.provider, "anthropic");
+        assert_eq!(cfg.session_manager.inference.temperature, 0.4);
+        assert_eq!(cfg.session_manager.memory.recall_top_k, 8);
+        assert_eq!(cfg.session_manager.rounds.window, 12);
+        // A field omitted from the partial inference block keeps its spec default.
+        assert_eq!(cfg.session_manager.inference.context_token_budget, 24_000);
+    }
+
+    #[test]
+    fn config_session_manager_partial_takes_defaults() {
+        // A [session_manager] section that sets only `enabled` must leave every
+        // nested subsection at its spec §10 default.
+        let dir = tempfile::TempDir::new().unwrap();
+        let toml = r#"
+[session_manager]
+enabled = true
+"#;
+        let cfg = load_from_str(dir.path(), toml);
+        assert!(cfg.session_manager.enabled);
+        assert_eq!(cfg.session_manager.inference.provider, "auto");
+        assert_eq!(cfg.session_manager.memory.palace, "session-manager");
+        assert_eq!(cfg.session_manager.rounds.window, 10);
+    }
+
+    #[test]
+    fn config_session_manager_absent_is_noop_default() {
+        // No [session_manager] section at all → the whole struct defaults and
+        // the SM is disabled (zero-regression proof for SM-1).
+        let dir = tempfile::TempDir::new().unwrap();
+        let toml = r#"
+[models.agents]
+engineer = "haiku"
+"#;
+        let cfg = load_from_str(dir.path(), toml);
+        assert_eq!(
+            cfg.session_manager,
+            crate::core::sm::config::SessionManagerConfig::default()
+        );
+        assert!(!cfg.session_manager.enabled);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -48,6 +48,7 @@ pub mod session_launch;
 pub mod session_store;
 pub mod skill_deployer;
 pub mod skill_manifest;
+pub mod sm;
 pub mod tmux;
 pub mod trusty_tools_config;
 pub mod workspace_scan;

--- a/crates/trusty-mpm/src/core/sm/agent.rs
+++ b/crates/trusty-mpm/src/core/sm/agent.rs
@@ -1,0 +1,94 @@
+//! Session Manager agent skeleton (DOC-14 spec §6.1, §1A.1).
+//!
+//! Why: the SM is a daemon-side, interface-agnostic orchestrator that — once
+//! complete — delegates ALL work by spawning t-mpm sessions, never implementing
+//! directly (spec §3 prohibitions). SM-1 lands only the skeleton: a struct that
+//! holds the SM config so later tickets can fill in the moving parts
+//! (`SmProviders` §5/SM-2, `SmMemory` §8/SM-4, `SmContextEngine` §7/SM-5,
+//! `SmGoals` §9/SM-6) and the JSON-RPC/HTTP adapters (SM-7/SM-STDIO). Crucially,
+//! constructing the agent is inert: with `enabled = false` (the default) nothing
+//! in this skeleton runs, so existing behavior is unchanged.
+//! What: [`SessionManagerAgent`] stores a clone of [`SessionManagerConfig`] and
+//! exposes `new`, `config`, and `is_enabled`. It has NO inference, NO memory, NO
+//! loop yet — those arrive in SM-2..SM-8.
+//! Test: `agent_new_is_inert`, `agent_default_is_disabled` below.
+
+use super::config::SessionManagerConfig;
+
+/// The Session Manager orchestrator (skeleton — SM-1).
+///
+/// Why: gives the SM build a stable type to grow into. Later tickets attach the
+/// provider abstraction, memory palace, rolling-context engine, and goal store
+/// as fields here, and the stdio/HTTP adapters call into it. Holding the config
+/// now means every later subsystem reads its settings from one place.
+/// What: a thin owner of [`SessionManagerConfig`]. Construction performs no I/O,
+/// spawns no sessions, and makes no inference calls — it is a pure value, so an
+/// SM with `enabled = false` is a guaranteed runtime no-op.
+/// Test: `agent_new_is_inert`, `agent_default_is_disabled`.
+#[derive(Debug, Clone)]
+pub struct SessionManagerAgent {
+    /// The SM configuration this agent was built from (spec §10).
+    config: SessionManagerConfig,
+}
+
+impl SessionManagerAgent {
+    /// Construct an SM agent from its configuration.
+    ///
+    /// Why: callers (the future stdio/HTTP adapters, SM-7/SM-STDIO) need one
+    /// entry point that takes the parsed `[session_manager]` config. SM-1 keeps
+    /// it side-effect-free so wiring it up early cannot regress anything.
+    /// What: stores `config` and returns the agent. No I/O, no inference, no
+    /// session spawning.
+    /// Test: `agent_new_is_inert`.
+    pub fn new(config: SessionManagerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Borrow the agent's configuration.
+    ///
+    /// Why: later subsystems (inference, memory, context, goals) read their
+    /// settings from the SM config; exposing it via an accessor keeps the field
+    /// private while letting collaborators read it.
+    /// What: returns a shared reference to the held [`SessionManagerConfig`].
+    /// Test: `agent_new_is_inert`.
+    pub fn config(&self) -> &SessionManagerConfig {
+        &self.config
+    }
+
+    /// Whether the SM is opted in.
+    ///
+    /// Why: the daemon's wiring (SM-7) will gate the SM path on this so the
+    /// default-disabled config stays a strict no-op against the legacy overseer.
+    /// What: returns `self.config.enabled`.
+    /// Test: `agent_default_is_disabled`.
+    pub fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: prove that constructing the skeleton from a default config succeeds
+    /// and is inert — it merely retains the config, performing no side effects.
+    /// What: builds an agent from `SessionManagerConfig::default()` and checks
+    /// the held config round-trips.
+    /// Test: this is the test.
+    #[test]
+    fn agent_new_is_inert() {
+        let cfg = SessionManagerConfig::default();
+        let agent = SessionManagerAgent::new(cfg.clone());
+        assert_eq!(agent.config(), &cfg);
+    }
+
+    /// Why: the default config disables the SM, so a default-built agent must
+    /// report `is_enabled() == false` — the runtime no-op guarantee.
+    /// What: builds an agent from the default config and asserts it is disabled.
+    /// Test: this is the test.
+    #[test]
+    fn agent_default_is_disabled() {
+        let agent = SessionManagerAgent::new(SessionManagerConfig::default());
+        assert!(!agent.is_enabled());
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/config.rs
+++ b/crates/trusty-mpm/src/core/sm/config.rs
@@ -1,0 +1,298 @@
+//! `[session_manager]` configuration schema (DOC-14 spec §10).
+//!
+//! Why: the Session Manager (SM) agent — the PM-like orchestrator that delegates
+//! all work by spawning t-mpm sessions — needs a single, opt-in config surface so
+//! operators can pick inference providers, model tiers, memory palace, and the
+//! rolling-context window without recompiling. SM-1 lays this foundation; later
+//! tickets (SM-2..SM-8) read these fields. The top-level `enabled` flag defaults
+//! to `false`, so an absent or partial `[session_manager]` section is a strict
+//! no-op that preserves the legacy `LlmOverseer`/coordinator behavior.
+//! What: [`SessionManagerConfig`] mirrors spec §10's TOML shape — a top-level
+//! `enabled` plus three nested subsections (`[session_manager.inference]`,
+//! `[session_manager.memory]`, `[session_manager.rounds]`). Every struct and
+//! field is `#[serde(default)]`, so partial and absent config both deserialize
+//! to sensible defaults.
+//! Test: `sm_config_full_parsed`, `sm_config_partial_takes_defaults`,
+//! `sm_config_absent_is_all_defaults`, `sm_config_enabled_default_false` in the
+//! `tests` module below; integration coverage via `MpmConfig` lives in
+//! `core/config.rs::tests`.
+
+use serde::{Deserialize, Serialize};
+
+/// `[session_manager]` — top-level Session Manager configuration (spec §10).
+///
+/// Why: gives the SM agent a typed, opt-in home in `~/.trusty-mpm/config.toml`.
+/// Disabled by default (`enabled = false`) so merely defining the struct never
+/// alters runtime behavior — the legacy overseer path stays untouched until an
+/// operator opts in and a later ticket (SM-7) wires the agent into an endpoint.
+/// What: an `enabled` toggle plus three subsections — `inference` (§5,
+/// provider and model tiers), `memory` (§8, palace and recall), and `rounds`
+/// (§7, rolling window). All fields are `#[serde(default)]` so partial config
+/// parses.
+/// Test: `sm_config_*` in the `tests` module.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct SessionManagerConfig {
+    /// Master opt-in switch. `false` (the default) → the SM is inert and the
+    /// legacy `LlmOverseer`/coordinator behavior is preserved unchanged.
+    pub enabled: bool,
+
+    /// `[session_manager.inference]` — provider selection + per-task model tiers.
+    pub inference: SmInferenceConfig,
+
+    /// `[session_manager.memory]` — dedicated SM palace + recall settings.
+    pub memory: SmMemoryConfig,
+
+    /// `[session_manager.rounds]` — rolling verbatim context window.
+    pub rounds: SmRoundsConfig,
+}
+
+/// `[session_manager.inference]` — provider + model-tier selection (spec §5).
+///
+/// Why: the SM is multi-provider (OpenRouter / Bedrock / Anthropic) and selects
+/// a model per task (orchestration vs. summarization vs. compaction, §5.4). This
+/// section captures that selection declaratively; SM-2 consumes it to build the
+/// provider abstraction. Auth is NOT stored here — it is resolved from env
+/// (`OPENROUTER_API_KEY`, AWS chain, `ANTHROPIC_API_KEY`) per spec §10.
+/// What: a `provider` selector, three model-tier ids (`sm_model`,
+/// `summary_model`, `compaction_model`) with an optional provider prefix, a
+/// deprecated `model` alias (interpreted as `sm_model` when that is unset), an
+/// ordered `fallback` provider list, sampling `temperature`, and two token
+/// budgets governing the compaction safety valve.
+/// Test: `sm_config_full_parsed`, `sm_config_partial_takes_defaults`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SmInferenceConfig {
+    /// Provider selector: `"auto"` | `"openrouter"` | `"bedrock"` | `"anthropic"`.
+    /// Default `"auto"` lets SM-2 pick the first provider with valid credentials.
+    pub provider: String,
+
+    /// SM chat/orchestration model — MEDIUM (Sonnet) tier. May carry an
+    /// `openrouter/` `bedrock/` or `anthropic/` prefix to pin a provider.
+    /// Empty → SM-2 uses the active provider's medium-tier default.
+    pub sm_model: String,
+
+    /// Session `last_summary` + compaction compression model — INEXPENSIVE
+    /// (Haiku) tier. Empty → SM-2 uses the active provider's cheap-tier default.
+    pub summary_model: String,
+
+    /// Deprecated back-compat alias for [`sm_model`](Self::sm_model). When
+    /// `sm_model` is empty, SM-2 interprets this field as the SM model. Empty by
+    /// default; new configs should set `sm_model` instead.
+    pub model: String,
+
+    /// Ordered provider-fallback chain, e.g. `["openrouter", "bedrock"]`.
+    /// Empty (the default) → no fallback.
+    pub fallback: Vec<String>,
+
+    /// Sampling temperature for SM orchestration calls. Default `0.3`.
+    pub temperature: f32,
+
+    /// Compaction safety-valve trigger: when assembled context exceeds this many
+    /// tokens, the rolling window is compacted (§7.2). Default `24000`.
+    pub context_token_budget: u32,
+
+    /// Explicit model for compaction only. Empty (the default) → reuse
+    /// `summary_model` (Haiku). A non-empty, optionally prefixed id overrides it.
+    pub compaction_model: String,
+
+    /// Hard cap on the compressed-context summary the compaction call may emit
+    /// (§7.3). Default `4000` tokens.
+    pub compressed_context_max_tokens: u32,
+}
+
+impl Default for SmInferenceConfig {
+    /// Why: serde `#[serde(default)]` on each field requires a `Default` whose
+    /// values match spec §10's documented defaults (not Rust's zero-values, which
+    /// would give `temperature = 0.0` and empty budgets).
+    /// What: returns the spec §10 defaults — `provider = "auto"`, the
+    /// Sonnet/Haiku tier ids, no fallback, `temperature = 0.3`, and the documented
+    /// token budgets.
+    /// Test: `sm_config_absent_is_all_defaults`, `sm_config_default_values`.
+    fn default() -> Self {
+        Self {
+            provider: "auto".to_string(),
+            sm_model: "anthropic/claude-sonnet-4-6".to_string(),
+            summary_model: "anthropic/claude-haiku".to_string(),
+            model: String::new(),
+            fallback: Vec::new(),
+            temperature: 0.3,
+            context_token_budget: 24_000,
+            compaction_model: String::new(),
+            compressed_context_max_tokens: 4_000,
+        }
+    }
+}
+
+/// `[session_manager.memory]` — dedicated SM palace + recall (spec §8).
+///
+/// Why: the SM keeps durable cross-session knowledge in its own memory palace,
+/// separate from per-project palaces, and injects the top-k recall hits into the
+/// working prompt. SM-4 creates the palace idempotently and reads these settings.
+/// What: the `palace` name and the number of recall hits (`recall_top_k`) to
+/// inject into the working context per request.
+/// Test: `sm_config_full_parsed`, `sm_config_default_values`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SmMemoryConfig {
+    /// Dedicated SM palace name. Default `"session-manager"`.
+    pub palace: String,
+
+    /// Number of recall hits injected into the working prompt. Default `6`.
+    pub recall_top_k: u32,
+}
+
+impl Default for SmMemoryConfig {
+    /// Why: spec §10 defaults are non-zero (`"session-manager"`, `6`), so the
+    /// derived zero-value `Default` would be wrong.
+    /// What: returns the spec §10 memory defaults.
+    /// Test: `sm_config_absent_is_all_defaults`, `sm_config_default_values`.
+    fn default() -> Self {
+        Self {
+            palace: "session-manager".to_string(),
+            recall_top_k: 6,
+        }
+    }
+}
+
+/// `[session_manager.rounds]` — rolling verbatim context window (spec §7).
+///
+/// Why: the SM keeps the most recent N conversation rounds verbatim and compacts
+/// everything older (§7.2). This section sizes that window. SM-5 reads it.
+/// What: the `window` size — how many recent rounds stay verbatim before older
+/// rounds are folded into the compressed context.
+/// Test: `sm_config_full_parsed`, `sm_config_default_values`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SmRoundsConfig {
+    /// Verbatim rolling-window size (number of recent rounds). Default `10`.
+    pub window: u32,
+}
+
+impl Default for SmRoundsConfig {
+    /// Why: spec §10 default is `10`, not the derived zero-value.
+    /// What: returns the spec §10 rounds default.
+    /// Test: `sm_config_absent_is_all_defaults`, `sm_config_default_values`.
+    fn default() -> Self {
+        Self { window: 10 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: prove a fully-specified `[session_manager]` block round-trips every
+    /// field to the value written (no silent default-clobbering).
+    /// What: parses a complete TOML section and asserts each nested field.
+    /// Test: this is the test.
+    #[test]
+    fn sm_config_full_parsed() {
+        let toml = r#"
+enabled = true
+
+[inference]
+provider = "openrouter"
+sm_model = "openrouter/anthropic/claude-sonnet-4-6"
+summary_model = "openrouter/anthropic/claude-haiku"
+model = "legacy/sonnet"
+fallback = ["openrouter", "bedrock"]
+temperature = 0.5
+context_token_budget = 32000
+compaction_model = "anthropic/claude-haiku"
+compressed_context_max_tokens = 6000
+
+[memory]
+palace = "sm-palace"
+recall_top_k = 9
+
+[rounds]
+window = 20
+"#;
+        let cfg: SessionManagerConfig = toml::from_str(toml).expect("full SM config parses");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.inference.provider, "openrouter");
+        assert_eq!(
+            cfg.inference.sm_model,
+            "openrouter/anthropic/claude-sonnet-4-6"
+        );
+        assert_eq!(
+            cfg.inference.summary_model,
+            "openrouter/anthropic/claude-haiku"
+        );
+        assert_eq!(cfg.inference.model, "legacy/sonnet");
+        assert_eq!(cfg.inference.fallback, vec!["openrouter", "bedrock"]);
+        assert_eq!(cfg.inference.temperature, 0.5);
+        assert_eq!(cfg.inference.context_token_budget, 32_000);
+        assert_eq!(cfg.inference.compaction_model, "anthropic/claude-haiku");
+        assert_eq!(cfg.inference.compressed_context_max_tokens, 6_000);
+        assert_eq!(cfg.memory.palace, "sm-palace");
+        assert_eq!(cfg.memory.recall_top_k, 9);
+        assert_eq!(cfg.rounds.window, 20);
+    }
+
+    /// Why: a partial `[session_manager]` (only a couple fields) must keep the
+    /// written values and fill every unspecified field from spec §10 defaults.
+    /// What: parses a sparse TOML section and asserts the set fields plus the
+    /// defaulted ones.
+    /// Test: this is the test.
+    #[test]
+    fn sm_config_partial_takes_defaults() {
+        let toml = r#"
+enabled = true
+
+[inference]
+temperature = 0.7
+"#;
+        let cfg: SessionManagerConfig = toml::from_str(toml).expect("partial SM config parses");
+        // Explicitly set:
+        assert!(cfg.enabled);
+        assert_eq!(cfg.inference.temperature, 0.7);
+        // Defaulted within an otherwise-touched subsection:
+        assert_eq!(cfg.inference.provider, "auto");
+        assert_eq!(cfg.inference.context_token_budget, 24_000);
+        // Entirely-absent subsections default whole:
+        assert_eq!(cfg.memory, SmMemoryConfig::default());
+        assert_eq!(cfg.rounds, SmRoundsConfig::default());
+    }
+
+    /// Why: an absent `[session_manager]` section (empty input) must yield the
+    /// full default struct — the zero-regression contract for SM-1.
+    /// What: parses empty TOML and asserts equality with `Default`.
+    /// Test: this is the test.
+    #[test]
+    fn sm_config_absent_is_all_defaults() {
+        let cfg: SessionManagerConfig = toml::from_str("").expect("empty input parses");
+        assert_eq!(cfg, SessionManagerConfig::default());
+    }
+
+    /// Why: the headline no-op guarantee — `enabled` defaults to `false` so
+    /// merely having the struct present changes nothing at runtime.
+    /// What: asserts the default `enabled` value.
+    /// Test: this is the test.
+    #[test]
+    fn sm_config_enabled_default_false() {
+        assert!(!SessionManagerConfig::default().enabled);
+    }
+
+    /// Why: pin spec §10's documented non-zero defaults so a future careless
+    /// `#[derive(Default)]` swap (which would zero them) fails loudly.
+    /// What: asserts each defaulted field value.
+    /// Test: this is the test.
+    #[test]
+    fn sm_config_default_values() {
+        let cfg = SessionManagerConfig::default();
+        assert_eq!(cfg.inference.provider, "auto");
+        assert_eq!(cfg.inference.sm_model, "anthropic/claude-sonnet-4-6");
+        assert_eq!(cfg.inference.summary_model, "anthropic/claude-haiku");
+        assert!(cfg.inference.model.is_empty());
+        assert!(cfg.inference.fallback.is_empty());
+        assert_eq!(cfg.inference.temperature, 0.3);
+        assert_eq!(cfg.inference.context_token_budget, 24_000);
+        assert!(cfg.inference.compaction_model.is_empty());
+        assert_eq!(cfg.inference.compressed_context_max_tokens, 4_000);
+        assert_eq!(cfg.memory.palace, "session-manager");
+        assert_eq!(cfg.memory.recall_top_k, 6);
+        assert_eq!(cfg.rounds.window, 10);
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -1,0 +1,18 @@
+//! Session Manager (SM) agent module (DOC-14 spec).
+//!
+//! Why: the SM is a PM-like, daemon-side orchestrator that delegates all work by
+//! spawning t-mpm sessions (spec §3 prime directive). This module is its home in
+//! trusty-mpm-core. SM-1 establishes the skeleton — config schema + an inert
+//! agent struct — that SM-2..SM-8 fill in (multi-provider inference, dedicated
+//! memory palace, rolling auto-compaction context, goal tracking, and the
+//! stdio/HTTP adapters).
+//! What: a thin facade that re-exports the SM config types and the agent
+//! skeleton from the `config` and `agent` submodules.
+//! Test: submodule `tests` modules (`config::tests`, `agent::tests`) plus the
+//! `MpmConfig`-level coverage in `core/config.rs::tests`.
+
+pub mod agent;
+pub mod config;
+
+pub use agent::SessionManagerAgent;
+pub use config::{SessionManagerConfig, SmInferenceConfig, SmMemoryConfig, SmRoundsConfig};


### PR DESCRIPTION
## SM-1 — Session Manager config + module skeleton

Closes #1284. Part of epic #1283 (DOC-14 Session Manager).

First ticket of the SM build: the **config substrate + module skeleton** that
SM-2..SM-8 fill in. No inference, memory, or loop logic — and **`enabled = false`
(the default) is a strict runtime no-op**, so the legacy `LlmOverseer`/coordinator
path is unchanged.

### Config shape (DOC-14 spec §10)

`SessionManagerConfig` (`core/sm/config.rs`), wired into `MpmConfig` as
`#[serde(default)] pub session_manager`. Every struct and field is
`#[serde(default)]`, so full, partial, and absent config all parse.

| Field | Type | Default |
|---|---|---|
| `enabled` | `bool` | `false` |
| `inference.provider` | `String` | `"auto"` |
| `inference.sm_model` | `String` | `"anthropic/claude-sonnet-4-6"` |
| `inference.summary_model` | `String` | `"anthropic/claude-haiku"` |
| `inference.model` (deprecated alias) | `String` | `""` |
| `inference.fallback` | `Vec<String>` | `[]` |
| `inference.temperature` | `f32` | `0.3` |
| `inference.context_token_budget` | `u32` | `24000` |
| `inference.compaction_model` | `String` | `""` (→ `summary_model`) |
| `inference.compressed_context_max_tokens` | `u32` | `4000` |
| `memory.palace` | `String` | `"session-manager"` |
| `memory.recall_top_k` | `u32` | `6` |
| `rounds.window` | `u32` | `10` |

Provider auth is resolved from env (not stored in config), per spec §10.

### Module skeleton

- `core/sm/mod.rs` — thin facade re-exporting the config types + agent.
- `core/sm/config.rs` — schema + unit tests.
- `core/sm/agent.rs` — inert `SessionManagerAgent` stub (`new`/`config`/`is_enabled`);
  no inference, memory, or loop yet. Documented as the SM orchestrator-to-be.
- Registered `pub mod sm;` in `core/mod.rs` (the `core` module is not feature-gated,
  matching its siblings).

### No-op proof

`SessionManagerAgent` has **zero references** outside its own module/tests, and
`MpmConfig.session_manager` is read only by tests. (The pre-existing
`state.session_manager()` *method* on `DaemonState` is the unrelated #1247 session
control surface, not this config field.)

### Notable decision

`Eq` was dropped from `MpmConfig` and the SM structs: `temperature: f32` is not
`Eq`. `PartialEq` is retained (covers all `assert_eq!` usage); nothing relied on
`MpmConfig: Eq`.

### Test evidence

11 new tests, all green; full `trusty-mpm` suite passes:

- Full `[session_manager]` parse → values as written (unit + via `MpmConfig` in
  extended `config_valid_parsed`).
- Partial `[session_manager]` → missing fields take spec defaults.
- Absent `[session_manager]` → entire struct defaults, `enabled == false`
  (extended `config_absent_yields_defaults` + dedicated tests).
- `SessionManagerAgent::new(default)` constructs and is inert/disabled.
- Default-value pinning test guards spec §10 non-zero defaults.

```
test result: ok. 1049 passed; 0 failed (lib)
test result: ok. 302 passed; 0 failed; 1 ignored (bin tm)
cargo clippy -p trusty-mpm --all-targets -- -D warnings  → clean
bash scripts/check_line_cap.sh  → exit 0 (15 allowlisted, 0 violations)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)