### PR TITLE
feat(trusty-mpm): SM-2 multi-provider inference + per-task model tiers (#1285)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10953,6 +10953,9 @@ version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-bedrockruntime",
+ "aws-types",
  "axum",
  "chrono",
  "clap",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -31,14 +31,20 @@ daemon = ["mcp",
           "dep:utoipa-swagger-ui"]
 
 # `mcp` gates the MCP server library module.
-# `async-trait` is needed by the OrchestratorBackend trait definition.
-mcp = ["dep:async-trait"]
+# (`async-trait`, used by the OrchestratorBackend trait, is now an always-on
+# dependency because the SM providers' `LlmProvider` trait needs it too — SM-2.)
+mcp = []
 
 # `tui` gates the TUI library module (`tm tui`).
 tui = ["dep:ratatui", "dep:crossterm"]
 
 # `telegram` gates the Telegram bot library module (`tm telegram`).
 telegram = ["dep:teloxide", "dep:tokio-util"]
+
+# `bedrock` gates the Session Manager's AWS Bedrock provider (SM-2, DOC-14 §5.1).
+# NOT in `default`: it pulls the heavy `aws-sdk-bedrockruntime` stack, so the
+# Bedrock provider weight is strictly opt-in. Build/test with `--features bedrock`.
+bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-types"]
 
 # `gui` is intentionally a no-dep CLI-gating feature. The `tm gui` subcommand
 # is ALWAYS available; this flag exists only so the subcommand can optionally
@@ -120,6 +126,10 @@ jsonwebtoken.workspace = true
 utoipa.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 tokio.workspace = true
+# async-trait is needed by the SM providers' `LlmProvider` trait (SM-2), which is
+# compiled unconditionally in the `core` library. (The `mcp` feature also lists it
+# below for the OrchestratorBackend trait; declaring it here makes it always-on.)
+async-trait.workspace = true
 
 # Always-on CLI/binary support deps.
 # These are pulled in by the bin targets; having them always-on is acceptable
@@ -135,8 +145,11 @@ which.workspace = true
 
 # ── Optional dependencies (feature-gated) ────────────────────────────────────
 
-# mcp feature
-async-trait = { workspace = true, optional = true }
+# bedrock feature (SM-2): AWS Bedrock Converse provider for the Session Manager.
+# Opt-in only — keeps the heavy aws-sdk stack out of the default build.
+aws-config             = { workspace = true, optional = true }
+aws-sdk-bedrockruntime = { workspace = true, optional = true }
+aws-types              = { workspace = true, optional = true }
 
 # daemon feature
 axum = { workspace = true, optional = true }

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -6,13 +6,21 @@
 //! agent struct — that SM-2..SM-8 fill in (multi-provider inference, dedicated
 //! memory palace, rolling auto-compaction context, goal tracking, and the
 //! stdio/HTTP adapters).
-//! What: a thin facade that re-exports the SM config types and the agent
-//! skeleton from the `config` and `agent` submodules.
-//! Test: submodule `tests` modules (`config::tests`, `agent::tests`) plus the
-//! `MpmConfig`-level coverage in `core/config.rs::tests`.
+//! What: a thin facade that re-exports the SM config types, the agent
+//! skeleton, and (SM-2) the multi-provider inference abstraction from the
+//! `config`, `agent`, and `providers` submodules.
+//! Test: submodule `tests` modules (`config::tests`, `agent::tests`,
+//! `providers::*::tests`) plus the `MpmConfig`-level coverage in
+//! `core/config.rs::tests`.
 
 pub mod agent;
 pub mod config;
+pub mod providers;
 
 pub use agent::SessionManagerAgent;
 pub use config::{SessionManagerConfig, SmInferenceConfig, SmMemoryConfig, SmRoundsConfig};
+pub use providers::{
+    AnthropicProvider, LlmProvider, LlmRequest, LlmResponse, OpenRouterProvider, ProviderKind,
+    ProviderRegistry, ResolvedCall, SmLlmError, SmModelTier, resolve_provider_and_model,
+    resolve_tier_model,
+};

--- a/crates/trusty-mpm/src/core/sm/providers/anthropic.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/anthropic.rs
@@ -1,0 +1,288 @@
+//! Direct Anthropic `/v1/messages` provider for the SM (DOC-14 §5.1, D5.2).
+//!
+//! Why: the third SM provider talks to `api.anthropic.com` directly (lower
+//! latency, no OpenRouter markup), which requires Anthropic's NATIVE wire
+//! format: `system` is a top-level field, messages are role/content pairs, and
+//! the response is a flat `content[]` array of typed blocks with a
+//! `stop_reason` and a `usage` object — not OpenAI's nested `choices`. This is
+//! the third provider §5.2 D5.2 calls for, porting trusty-agents'
+//! `anthropic_native` request/response shape (without its async-openai tool
+//! coupling, which the SM does not need for plain reasoning calls).
+//! What: [`AnthropicProvider`] reads `ANTHROPIC_API_KEY`, a bare model id, and
+//! a configurable base URL (default `https://api.anthropic.com`, overridable
+//! via `ANTHROPIC_BASE_URL` and by tests). `complete` POSTs to `{base}/v1/messages`
+//! with `x-api-key` + `anthropic-version: 2023-06-01`, maps HTTP errors to
+//! [`SmLlmError`], and extracts text + token usage from the native response.
+//! Test: `complete_roundtrips_against_mock`, `complete_maps_http_errors`,
+//! `new_rejects_empty_key`, `build_body_places_system_top_level` in tests.
+
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError};
+
+/// Default Anthropic API base (no trailing `/v1/messages`).
+pub const DEFAULT_ANTHROPIC_BASE: &str = "https://api.anthropic.com";
+/// Env var overriding the Anthropic base URL (§5.1).
+pub const ENV_ANTHROPIC_BASE_URL: &str = "ANTHROPIC_BASE_URL";
+/// Anthropic API version header value (§5.1).
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const CONNECT_TIMEOUT_SECS: u64 = 10;
+const READ_TIMEOUT_SECS: u64 = 120;
+
+// ─── Pricing ──────────────────────────────────────────────────────────────────
+
+/// Approximate `(input, output)` USD cost per million tokens for the Anthropic
+/// model families the SM uses (Sonnet orchestration, Haiku summarization).
+///
+/// Why: per-call cost telemetry (§5.5). Unknown ids fall back to `(0.0, 0.0)`.
+/// What: matches on the model-family substring so version suffixes still price.
+/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
+fn cost_per_million(model: &str) -> (f64, f64) {
+    match model {
+        m if m.contains("sonnet") => (3.00, 15.00),
+        m if m.contains("haiku") => (0.80, 4.00),
+        m if m.contains("opus") => (15.00, 75.00),
+        _ => (0.0, 0.0),
+    }
+}
+
+/// Compute a USD cost estimate from token counts and the pricing table.
+///
+/// Why: lets the SM total session cost (§5.5).
+/// What: applies [`cost_per_million`]; `0.0` for unknown models.
+/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
+pub fn estimate_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
+    let (in_price, out_price) = cost_per_million(model);
+    (input_tokens as f64 / 1_000_000.0) * in_price
+        + (output_tokens as f64 / 1_000_000.0) * out_price
+}
+
+// ─── Request / response shaping (native Anthropic wire format) ─────────────────
+
+/// Build the native Anthropic `/v1/messages` request body from an SM request.
+///
+/// Why: Anthropic's format differs from OpenAI's enough that a serde round-trip
+/// is insufficient — `system` is top-level and messages omit the system turn
+/// (ported from trusty-agents `anthropic_native::build_anthropic_request`,
+/// minus the tool plumbing the SM does not use).
+/// What: lifts `req.system` to a top-level `system` field (when non-empty), and
+/// maps each `ChatMessage` to `{role, content}`. `model` is the already-bare id.
+/// Test: `build_body_places_system_top_level`.
+fn build_body(req: &LlmRequest) -> Value {
+    let messages: Vec<Value> = req
+        .messages
+        .iter()
+        .map(|m| {
+            let role = if m.role == "assistant" {
+                "assistant"
+            } else {
+                "user"
+            };
+            json!({ "role": role, "content": m.content })
+        })
+        .collect();
+
+    let mut body = json!({
+        "model": req.model,
+        "max_tokens": req.max_tokens,
+        "temperature": req.temperature,
+        "messages": messages,
+    });
+    if !req.system.is_empty() {
+        body["system"] = Value::String(req.system.clone());
+    }
+    body
+}
+
+/// Extract `(text, input_tokens, output_tokens)` from a native Anthropic
+/// `/v1/messages` response.
+///
+/// Why: the response is a flat `content[]` of typed blocks; we concatenate the
+/// `text` blocks and read `usage.input_tokens` / `usage.output_tokens` (ported
+/// from `anthropic_native::parse_anthropic_response`, text path only).
+/// What: joins all `type == "text"` blocks with newlines; reads usage,
+/// defaulting absent counts to `0`.
+/// Test: covered by `complete_roundtrips_against_mock`.
+fn parse_response(value: &Value) -> (String, u32, u32) {
+    let mut text = String::new();
+    if let Some(blocks) = value.get("content").and_then(|c| c.as_array()) {
+        for block in blocks {
+            if block.get("type").and_then(|t| t.as_str()) == Some("text")
+                && let Some(s) = block.get("text").and_then(|t| t.as_str())
+            {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(s);
+            }
+        }
+    }
+    let (input, output) = value
+        .get("usage")
+        .map(|u| {
+            (
+                u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+                u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+            )
+        })
+        .unwrap_or((0, 0));
+    (text, input, output)
+}
+
+// ─── Provider ──────────────────────────────────────────────────────────────────
+
+/// Direct Anthropic `/v1/messages` provider for the SM.
+///
+/// Why: satisfies [`LlmProvider`] against `api.anthropic.com`; the configurable
+/// `base` lets tests drive it against a local mock.
+/// What: holds the api key, bare model id, base URL, and a pooled
+/// `reqwest::Client`. `complete` POSTs the native body and maps the outcome to
+/// [`LlmResponse`] / [`SmLlmError`].
+/// Test: `complete_roundtrips_against_mock`, `complete_maps_http_errors`.
+#[derive(Debug)]
+pub struct AnthropicProvider {
+    api_key: String,
+    model: String,
+    base: String,
+    client: reqwest::Client,
+}
+
+impl AnthropicProvider {
+    /// Construct a provider for the given model + API key, resolving the base
+    /// URL from `ANTHROPIC_BASE_URL` or falling back to the default.
+    ///
+    /// Why: the resolver builds this from `ANTHROPIC_API_KEY` and the bare
+    /// model id; operators may point at a proxy via `ANTHROPIC_BASE_URL`.
+    /// What: reads the env override (when non-empty) and delegates to
+    /// [`Self::with_base_url`].
+    /// Test: `new_rejects_empty_key`.
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Result<Self, SmLlmError> {
+        let base = std::env::var(ENV_ANTHROPIC_BASE_URL)
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_ANTHROPIC_BASE.to_string());
+        Self::with_base_url(api_key, model, base)
+    }
+
+    /// Construct a provider with an explicit base URL (used by tests/mocks).
+    ///
+    /// Why: tests must point the provider at a local `TcpListener` mock.
+    /// What: validates the key is non-empty, builds a timed `reqwest::Client`,
+    /// stores the fields (trimming any trailing `/` on the base). Returns
+    /// [`SmLlmError::AccessDenied`] on an empty key.
+    /// Test: `new_rejects_empty_key`, `complete_roundtrips_against_mock`.
+    pub fn with_base_url(
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        base: impl Into<String>,
+    ) -> Result<Self, SmLlmError> {
+        let api_key = api_key.into();
+        if api_key.is_empty() {
+            return Err(SmLlmError::AccessDenied(
+                "ANTHROPIC_API_KEY is empty".to_string(),
+            ));
+        }
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(READ_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| SmLlmError::Transport(format!("build reqwest client: {e}")))?;
+        Ok(Self {
+            api_key,
+            model: model.into(),
+            base: base.into().trim_end_matches('/').to_string(),
+            client,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AnthropicProvider {
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+
+    /// Execute a direct Anthropic `/v1/messages` completion.
+    ///
+    /// Why: the SM needs full text + usage from the native endpoint (§5.5).
+    /// What: POSTs [`build_body`] to `{base}/v1/messages` with `x-api-key` and
+    /// `anthropic-version`, maps HTTP status to [`SmLlmError`], parses the
+    /// native response via [`parse_response`], and logs cost/usage to stderr.
+    /// Test: `complete_roundtrips_against_mock`, `complete_maps_http_errors`.
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError> {
+        let url = format!("{}/v1/messages", self.base);
+        let body = build_body(&req);
+
+        let start = Instant::now();
+        let http_resp = self
+            .client
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SmLlmError::Transport(e.to_string()))?;
+
+        let latency_ms = start.elapsed().as_millis() as u64;
+        let status = http_resp.status();
+
+        if !status.is_success() {
+            let text = http_resp.text().await.unwrap_or_default();
+            return Err(match status.as_u16() {
+                401 | 403 => SmLlmError::AccessDenied(text),
+                404 => SmLlmError::ModelNotFound(format!("model={}: {text}", self.model)),
+                400 | 422 => SmLlmError::Validation(text),
+                429 => SmLlmError::RateLimited,
+                code => SmLlmError::Upstream {
+                    status: code,
+                    body: text,
+                },
+            });
+        }
+
+        let value: Value = http_resp.json().await.map_err(|e| {
+            warn!("failed to parse Anthropic response: {e}");
+            SmLlmError::Upstream {
+                status: status.as_u16(),
+                body: e.to_string(),
+            }
+        })?;
+
+        let (text, input_tokens, output_tokens) = parse_response(&value);
+        let model_used = value
+            .get("model")
+            .and_then(|m| m.as_str())
+            .unwrap_or(&self.model)
+            .to_string();
+        let cost_usd = estimate_cost_usd(&model_used, input_tokens, output_tokens);
+
+        debug!(
+            provider = "anthropic",
+            model = %model_used,
+            input_tokens,
+            output_tokens,
+            latency_ms,
+            cost_usd,
+            "sm anthropic complete"
+        );
+
+        Ok(LlmResponse {
+            text,
+            model: model_used,
+            input_tokens,
+            output_tokens,
+            latency_ms,
+            cost_usd,
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "anthropic_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/sm/providers/anthropic.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/anthropic.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
-use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError};
+use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError, pricing};
 
 /// Default Anthropic API base (no trailing `/v1/messages`).
 pub const DEFAULT_ANTHROPIC_BASE: &str = "https://api.anthropic.com";
@@ -32,34 +32,6 @@ pub const ENV_ANTHROPIC_BASE_URL: &str = "ANTHROPIC_BASE_URL";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 const CONNECT_TIMEOUT_SECS: u64 = 10;
 const READ_TIMEOUT_SECS: u64 = 120;
-
-// ─── Pricing ──────────────────────────────────────────────────────────────────
-
-/// Approximate `(input, output)` USD cost per million tokens for the Anthropic
-/// model families the SM uses (Sonnet orchestration, Haiku summarization).
-///
-/// Why: per-call cost telemetry (§5.5). Unknown ids fall back to `(0.0, 0.0)`.
-/// What: matches on the model-family substring so version suffixes still price.
-/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
-fn cost_per_million(model: &str) -> (f64, f64) {
-    match model {
-        m if m.contains("sonnet") => (3.00, 15.00),
-        m if m.contains("haiku") => (0.80, 4.00),
-        m if m.contains("opus") => (15.00, 75.00),
-        _ => (0.0, 0.0),
-    }
-}
-
-/// Compute a USD cost estimate from token counts and the pricing table.
-///
-/// Why: lets the SM total session cost (§5.5).
-/// What: applies [`cost_per_million`]; `0.0` for unknown models.
-/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
-pub fn estimate_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
-    let (in_price, out_price) = cost_per_million(model);
-    (input_tokens as f64 / 1_000_000.0) * in_price
-        + (output_tokens as f64 / 1_000_000.0) * out_price
-}
 
 // ─── Request / response shaping (native Anthropic wire format) ─────────────────
 
@@ -260,7 +232,7 @@ impl LlmProvider for AnthropicProvider {
             .and_then(|m| m.as_str())
             .unwrap_or(&self.model)
             .to_string();
-        let cost_usd = estimate_cost_usd(&model_used, input_tokens, output_tokens);
+        let cost_usd = pricing::estimate_cost_usd(&model_used, input_tokens, output_tokens);
 
         debug!(
             provider = "anthropic",

--- a/crates/trusty-mpm/src/core/sm/providers/anthropic_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/anthropic_tests.rs
@@ -1,0 +1,167 @@
+//! Tests for the SM Anthropic native provider.
+//!
+//! Why: extracted from `anthropic.rs` to keep that file under the 500-SLOC cap
+//! while exercising the full `complete` path against a local mock (no real
+//! `api.anthropic.com` calls).
+//! What: construction validation, native-body shaping, a `complete` round-trip
+//! against a one-shot `TcpListener` mock returning a native `/v1/messages`
+//! response, and an error-mapping check for a 400 response.
+//! Test: included as `#[cfg(test)] mod tests` via `#[path]` from `anthropic.rs`.
+
+use super::*;
+use crate::core::sm::providers::ChatMessage;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Spawn a one-shot HTTP mock returning `status_line`/`body`; yields the base
+/// `http://127.0.0.1:PORT` URL.
+///
+/// Why: drive `complete` without touching the real Anthropic API.
+/// What: binds an ephemeral port, accepts one connection, replies, shuts down.
+/// Test: used by the `complete_*` tests.
+async fn spawn_mock(status_line: &'static str, body: String) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.expect("accept");
+        let mut buf = vec![0u8; 16384];
+        let _ = sock.read(&mut buf).await;
+        let resp = format!(
+            "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = sock.write_all(resp.as_bytes()).await;
+        let _ = sock.shutdown().await;
+    });
+    format!("http://{addr}")
+}
+
+#[test]
+fn new_rejects_empty_key() {
+    let result = AnthropicProvider::with_base_url("", "claude-sonnet-4-6", "http://unused");
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), SmLlmError::AccessDenied(_)));
+}
+
+#[test]
+fn provider_name_is_anthropic() {
+    let p =
+        AnthropicProvider::with_base_url("sk-ant", "claude-haiku", "http://unused").expect("ok");
+    assert_eq!(p.name(), "anthropic");
+}
+
+/// Why: Anthropic requires `system` at the TOP LEVEL, not as a message — a
+/// mis-shaped body silently drops the system prompt.
+/// What: builds the body from a request with a system prompt and asserts the
+/// top-level `system` field plus the user message shape.
+/// Test: this is the test.
+#[test]
+fn build_body_places_system_top_level() {
+    let req = LlmRequest {
+        model: "claude-sonnet-4-6".to_string(),
+        system: "You are the SM.".to_string(),
+        messages: vec![ChatMessage {
+            role: "user".to_string(),
+            content: "go".to_string(),
+        }],
+        temperature: 0.3,
+        max_tokens: 512,
+    };
+    let body = super::build_body(&req);
+    assert_eq!(body["system"], "You are the SM.");
+    assert_eq!(body["model"], "claude-sonnet-4-6");
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"], "go");
+    // The system prompt must NOT also appear as a message.
+    assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn cost_estimate_known() {
+    let cost = estimate_cost_usd("claude-haiku-4-5", 1_000_000, 1_000_000);
+    // (0.80, 4.00) → 0.80 + 4.00 = 4.80
+    assert!((cost - 4.80_f64).abs() < 1e-9, "expected $4.80, got {cost}");
+}
+
+#[test]
+fn cost_estimate_unknown() {
+    assert_eq!(estimate_cost_usd("gpt-self", 100, 100), 0.0);
+}
+
+/// Why: prove `complete` drives the native path — building the body, parsing a
+/// real `content[]` response, and reading `usage`.
+/// What: points the provider at a mock returning a native response and asserts
+/// the concatenated text + token counts + cost.
+/// Test: this is the test (no real network).
+#[tokio::test]
+async fn complete_roundtrips_against_mock() {
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "content": [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"}
+        ],
+        "usage": {"input_tokens": 2000, "output_tokens": 100}
+    })
+    .to_string();
+    let base = spawn_mock("HTTP/1.1 200 OK", body).await;
+
+    let provider =
+        AnthropicProvider::with_base_url("sk-ant", "claude-sonnet-4-6", base).expect("provider");
+
+    let resp = provider
+        .complete(LlmRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            system: "sys".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            temperature: 0.3,
+            max_tokens: 256,
+        })
+        .await
+        .expect("complete ok");
+
+    assert_eq!(resp.text, "first\nsecond");
+    assert_eq!(resp.input_tokens, 2000);
+    assert_eq!(resp.output_tokens, 100);
+    // 2000/1e6*3.00 + 100/1e6*15.00 = 0.006 + 0.0015 = 0.0075
+    assert!(
+        (resp.cost_usd - 0.0075_f64).abs() < 1e-9,
+        "expected $0.0075, got {}",
+        resp.cost_usd
+    );
+}
+
+/// Why: a 400 from Anthropic is deterministic (bad request) and must map to the
+/// non-retryable `Validation` alarm.
+/// What: mock returns HTTP 400; asserts the mapped error is an alarm, not
+/// retryable.
+/// Test: this is the test.
+#[tokio::test]
+async fn complete_maps_http_errors() {
+    let base = spawn_mock("HTTP/1.1 400 Bad Request", "bad model".to_string()).await;
+    let provider =
+        AnthropicProvider::with_base_url("sk-ant", "claude-haiku", base).expect("provider");
+
+    let err = provider
+        .complete(LlmRequest {
+            model: "claude-haiku".to_string(),
+            system: String::new(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "x".to_string(),
+            }],
+            temperature: 0.3,
+            max_tokens: 64,
+        })
+        .await
+        .expect_err("400 should error");
+
+    assert!(matches!(err, SmLlmError::Validation(_)));
+    assert!(err.is_alarm());
+    assert!(!err.is_retryable());
+}

--- a/crates/trusty-mpm/src/core/sm/providers/anthropic_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/anthropic_tests.rs
@@ -10,22 +10,24 @@
 
 use super::*;
 use crate::core::sm::providers::ChatMessage;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use crate::core::sm::providers::test_support::read_full_request;
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 
 /// Spawn a one-shot HTTP mock returning `status_line`/`body`; yields the base
 /// `http://127.0.0.1:PORT` URL.
 ///
 /// Why: drive `complete` without touching the real Anthropic API.
-/// What: binds an ephemeral port, accepts one connection, replies, shuts down.
+/// What: binds an ephemeral port, accepts one connection, drains the full
+/// request via [`read_full_request`] (so the reply never races ahead of the
+/// client's `write`), replies, and shuts down.
 /// Test: used by the `complete_*` tests.
 async fn spawn_mock(status_line: &'static str, body: String) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("addr");
     tokio::spawn(async move {
         let (mut sock, _) = listener.accept().await.expect("accept");
-        let mut buf = vec![0u8; 16384];
-        let _ = sock.read(&mut buf).await;
+        read_full_request(&mut sock).await;
         let resp = format!(
             "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
@@ -75,18 +77,6 @@ fn build_body_places_system_top_level() {
     assert_eq!(body["messages"][0]["content"], "go");
     // The system prompt must NOT also appear as a message.
     assert_eq!(body["messages"].as_array().unwrap().len(), 1);
-}
-
-#[test]
-fn cost_estimate_known() {
-    let cost = estimate_cost_usd("claude-haiku-4-5", 1_000_000, 1_000_000);
-    // (0.80, 4.00) → 0.80 + 4.00 = 4.80
-    assert!((cost - 4.80_f64).abs() < 1e-9, "expected $4.80, got {cost}");
-}
-
-#[test]
-fn cost_estimate_unknown() {
-    assert_eq!(estimate_cost_usd("gpt-self", 100, 100), 0.0);
 }
 
 /// Why: prove `complete` drives the native path — building the body, parsing a

--- a/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
@@ -189,7 +189,11 @@ impl BedrockProvider {
         }
 
         let inference = InferenceConfiguration::builder()
-            .max_tokens(req.max_tokens as i32)
+            // Saturating, sound conversion: `req.max_tokens` is a `u32`, but the
+            // Bedrock SDK wants an `i32`. A naive `as i32` would wrap any value
+            // above `i32::MAX` into a negative token budget; clamp to `i32::MAX`
+            // instead (`unwrap_or` here cannot panic).
+            .max_tokens(i32::try_from(req.max_tokens).unwrap_or(i32::MAX))
             .temperature(req.temperature)
             .build();
 

--- a/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
@@ -1,0 +1,385 @@
+//! AWS Bedrock Converse provider for the SM (DOC-14 §5.1; `bedrock` feature).
+//!
+//! Why: AWS-resident operators can use Bedrock-hosted models (IAM auth, private
+//! VPC, no third-party SaaS egress) without an OpenRouter or Anthropic key.
+//! This is the SM's third provider, ported from trusty-review's
+//! `llm/bedrock/mod.rs` (text path only — the SM does not need the tool-use
+//! plumbing). It lives behind the `bedrock` cargo feature so the heavy
+//! `aws-sdk-bedrockruntime` dependency is opt-in (§5.1).
+//! What: [`BedrockProvider`] calls `Converse` (non-streaming), maps
+//! [`LlmRequest`] → Bedrock request, extracts text + usage, measures latency,
+//! computes cost, and retries bounded times on transient errors. Config errors
+//! (ModelNotFound/AccessDenied/Validation) never retry and always alarm. The
+//! `us.`/`eu.`/… cross-region inference-profile prefix is required and validated
+//! up front so a bare foundation-model id fails early as [`SmLlmError::Validation`].
+//! Test: `bedrock_region_resolution`, `bedrock_prefix_validation`,
+//! `bedrock_cost_estimate_*`, `bedrock_provider_stores_model_and_region`,
+//! `bedrock_no_credentials_returns_error`,
+//! `bedrock_empty_messages_is_validation_error` in tests.
+
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::Client as BedrockClient;
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock, ConversationRole, InferenceConfiguration, Message, SystemContentBlock,
+};
+use tracing::{debug, warn};
+
+use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError};
+
+/// Region env var: trusty-specific override (highest precedence).
+const ENV_REGION_TRUSTY: &str = "TRUSTY_AWS_REGION";
+/// Region env var: standard AWS fallback.
+const ENV_REGION_AWS: &str = "AWS_REGION";
+/// Default AWS region when neither env var is set.
+const DEFAULT_REGION: &str = "us-east-1";
+/// Required cross-region inference-profile prefixes (§5.1).
+const INFERENCE_PROFILE_PREFIXES: &[&str] = &["us.", "eu.", "ap.", "jp.", "global."];
+/// Retry attempts for transient errors.
+const MAX_RETRIES: u32 = 3;
+
+// ─── Region & validation ───────────────────────────────────────────────────────
+
+/// Resolve the AWS region: `explicit` > `TRUSTY_AWS_REGION` > `AWS_REGION` >
+/// `us-east-1`.
+///
+/// Why: operators may set either env var; the trusty-specific one wins (§5.1).
+/// What: returns the first non-empty value in precedence order.
+/// Test: `bedrock_region_resolution`.
+pub fn resolve_bedrock_region(explicit: Option<&str>) -> String {
+    if let Some(r) = explicit.filter(|s| !s.is_empty()) {
+        return r.to_string();
+    }
+    for var in [ENV_REGION_TRUSTY, ENV_REGION_AWS] {
+        if let Ok(val) = std::env::var(var) {
+            let val = val.trim().to_string();
+            if !val.is_empty() {
+                return val;
+            }
+        }
+    }
+    DEFAULT_REGION.to_string()
+}
+
+/// Validate that `model_id` carries a cross-region inference-profile prefix.
+///
+/// Why: Bedrock rejects bare foundation-model ids at runtime; we surface that
+/// at construction so operators see it immediately (§5.1).
+/// What: `Ok(())` if any [`INFERENCE_PROFILE_PREFIXES`] matches; else
+/// [`SmLlmError::Validation`].
+/// Test: `bedrock_prefix_validation`.
+fn validate_model_id(model_id: &str) -> Result<(), SmLlmError> {
+    if INFERENCE_PROFILE_PREFIXES
+        .iter()
+        .any(|p| model_id.starts_with(p))
+    {
+        return Ok(());
+    }
+    Err(SmLlmError::Validation(format!(
+        "Bedrock model id {model_id:?} must start with a cross-region inference-profile \
+         prefix (us., eu., ap., jp., or global.). Example: \"us.anthropic.claude-sonnet-4-6\"."
+    )))
+}
+
+// ─── Pricing ──────────────────────────────────────────────────────────────────
+
+/// Approximate `(input, output)` USD cost per million tokens for the Anthropic
+/// families served on Bedrock.
+///
+/// Why: per-call cost telemetry (§5.5).
+/// What: family-substring match; unknown → `(0.0, 0.0)`.
+/// Test: `bedrock_cost_estimate_sonnet`, `bedrock_cost_estimate_unknown`.
+fn cost_per_million(model: &str) -> (f64, f64) {
+    match model {
+        m if m.contains("sonnet") => (3.00, 15.00),
+        m if m.contains("haiku") => (0.80, 4.00),
+        m if m.contains("opus") => (15.00, 75.00),
+        _ => (0.0, 0.0),
+    }
+}
+
+/// Compute a USD cost estimate from token counts and the pricing table.
+///
+/// Why: lets the SM total session cost (§5.5).
+/// What: applies [`cost_per_million`]; `0.0` for unknown models.
+/// Test: `bedrock_cost_estimate_sonnet`, `bedrock_cost_estimate_unknown`.
+pub fn estimate_bedrock_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
+    let (in_price, out_price) = cost_per_million(model);
+    (input_tokens as f64 / 1_000_000.0) * in_price
+        + (output_tokens as f64 / 1_000_000.0) * out_price
+}
+
+// ─── Provider ──────────────────────────────────────────────────────────────────
+
+/// AWS Bedrock Converse provider for the SM.
+///
+/// Why: satisfies [`LlmProvider`] over Bedrock so the SM works with IAM-based
+/// auth and no SaaS API key (§5.1).
+/// What: holds a `BedrockClient`, the bare model id, and the resolved region.
+/// `complete` calls `Converse`, extracts text + usage, retries transient
+/// errors up to [`MAX_RETRIES`].
+/// Test: `bedrock_no_credentials_returns_error`,
+/// `bedrock_no_credentials_returns_error`.
+pub struct BedrockProvider {
+    client: BedrockClient,
+    /// The bare (validated) model id, e.g. `us.anthropic.claude-sonnet-4-6`.
+    pub model: String,
+    region: String,
+}
+
+impl BedrockProvider {
+    /// Construct using the standard AWS credential chain.
+    ///
+    /// Why: the SDK default chain covers env vars, `~/.aws/credentials`, IMDS,
+    /// and SSO without code changes.
+    /// What: validates the model id, resolves the region, loads AWS config, and
+    /// builds the client. Returns [`SmLlmError::Validation`] on a bad model id.
+    /// Async because credential loading may touch the filesystem / IMDS.
+    /// Test: `bedrock_prefix_validation` (validation path; no network).
+    pub async fn new(model: impl Into<String>, region: Option<&str>) -> Result<Self, SmLlmError> {
+        let model = model.into();
+        validate_model_id(&model)?;
+        let region_str = resolve_bedrock_region(region);
+        let config = aws_config::defaults(BehaviorVersion::latest())
+            .region(aws_config::meta::region::RegionProviderChain::first_try(
+                aws_types::region::Region::new(region_str.clone()),
+            ))
+            .load()
+            .await;
+        let client = BedrockClient::new(&config);
+        Ok(Self {
+            client,
+            model,
+            region: region_str,
+        })
+    }
+
+    /// Construct from a pre-built client (testing only; skips validation).
+    ///
+    /// Why: tests inject a `no_credentials()` client to drive provider logic
+    /// without AWS.
+    /// What: stores the client verbatim.
+    /// Test: `bedrock_no_credentials_returns_error`,
+    /// `bedrock_no_credentials_returns_error`.
+    #[cfg(test)]
+    pub fn from_client(
+        client: BedrockClient,
+        model: impl Into<String>,
+        region: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            model: model.into(),
+            region: region.into(),
+        }
+    }
+
+    /// The AWS region the client is configured for.
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    /// Execute a single Converse call.
+    ///
+    /// Why: extracted so retry logic in `complete` is visible/testable.
+    /// What: builds a `Converse` request from `req`, sends it, and maps SDK
+    /// errors to [`SmLlmError`] by inspecting the message text.
+    /// Test: error-mapping exercised via `bedrock_no_credentials_returns_error`.
+    async fn call_once(&self, req: &LlmRequest) -> Result<LlmResponse, SmLlmError> {
+        let start = Instant::now();
+
+        let mut system_blocks: Vec<SystemContentBlock> = Vec::new();
+        if !req.system.is_empty() {
+            system_blocks.push(SystemContentBlock::Text(req.system.clone()));
+        }
+
+        let mut messages: Vec<Message> = Vec::new();
+        for m in &req.messages {
+            let role = if m.role == "assistant" {
+                ConversationRole::Assistant
+            } else {
+                ConversationRole::User
+            };
+            let msg = Message::builder()
+                .role(role)
+                .content(ContentBlock::Text(m.content.clone()))
+                .build()
+                .map_err(|e| SmLlmError::Validation(format!("build Bedrock Message: {e}")))?;
+            messages.push(msg);
+        }
+        if messages.is_empty() {
+            return Err(SmLlmError::Validation(
+                "LlmRequest contains no user/assistant messages".to_string(),
+            ));
+        }
+
+        let inference = InferenceConfiguration::builder()
+            .max_tokens(req.max_tokens as i32)
+            .temperature(req.temperature)
+            .build();
+
+        let mut sdk_req = self
+            .client
+            .converse()
+            .model_id(&req.model)
+            .inference_config(inference)
+            .set_messages(Some(messages));
+        if !system_blocks.is_empty() {
+            sdk_req = sdk_req.set_system(Some(system_blocks));
+        }
+
+        let resp = sdk_req
+            .send()
+            .await
+            .map_err(|e| map_sdk_error(e.to_string(), &req.model, &self.region))?;
+
+        let latency_ms = start.elapsed().as_millis() as u64;
+        let text = extract_converse_text(&resp).unwrap_or_default();
+        let (input_tokens, output_tokens) = extract_token_usage(&resp);
+        let cost_usd = estimate_bedrock_cost_usd(&req.model, input_tokens, output_tokens);
+
+        Ok(LlmResponse {
+            text,
+            model: req.model.clone(),
+            input_tokens,
+            output_tokens,
+            latency_ms,
+            cost_usd,
+        })
+    }
+}
+
+/// Map a Bedrock SDK error string to the right [`SmLlmError`] variant.
+///
+/// Why: the AWS SDK surfaces typed errors as strings here; classifying them
+/// keeps retry/alarm policy correct (§5.3).
+/// What: substring-matches the lowercased message to the matching variant,
+/// defaulting unknown errors to retryable `Transport`.
+/// Test: exercised by `bedrock_no_credentials_returns_error`.
+fn map_sdk_error(msg: String, model: &str, region: &str) -> SmLlmError {
+    let lower = msg.to_lowercase();
+    if lower.contains("resourcenotfound") || lower.contains("no such model") {
+        SmLlmError::ModelNotFound(format!("model={model}: {msg}"))
+    } else if lower.contains("accessdenied")
+        || lower.contains("unauthorized")
+        || lower.contains("credential")
+        || lower.contains("not authorized")
+        || lower.contains("no credentials")
+    {
+        SmLlmError::AccessDenied(format!(
+            "AWS Bedrock access denied (model={model}, region={region}): {msg}"
+        ))
+    } else if lower.contains("validationexception") || lower.contains("validation") {
+        SmLlmError::Validation(msg)
+    } else if lower.contains("throttling") || lower.contains("throttled") || lower.contains("rate")
+    {
+        SmLlmError::RateLimited
+    } else if lower.contains("serviceunavailable") || lower.contains("internalserver") {
+        SmLlmError::Upstream {
+            status: 503,
+            body: msg,
+        }
+    } else if lower.contains("modelnotready") || lower.contains("not in active") {
+        SmLlmError::ModelNotReady(msg)
+    } else {
+        SmLlmError::Transport(format!(
+            "Bedrock Converse SDK error (model={model}, region={region}): {msg}"
+        ))
+    }
+}
+
+#[async_trait]
+impl LlmProvider for BedrockProvider {
+    fn name(&self) -> &str {
+        "bedrock"
+    }
+
+    /// Execute a Converse call with bounded retry for transient errors.
+    ///
+    /// Why: Bedrock returns transient 5xx/throttling; bounded exponential
+    /// backoff recovers most without hiding config errors (§5.3).
+    /// What: calls `call_once`; retries up to [`MAX_RETRIES`] while
+    /// `is_retryable()`; returns other errors immediately. Logs cost/usage to
+    /// stderr.
+    /// Test: `bedrock_no_credentials_returns_error`,
+    /// `bedrock_no_credentials_returns_error`.
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError> {
+        debug!(
+            provider = "bedrock",
+            model = %req.model,
+            region = %self.region,
+            "sm bedrock complete request"
+        );
+        let mut attempt = 0u32;
+        loop {
+            match self.call_once(&req).await {
+                Ok(resp) => {
+                    debug!(
+                        provider = "bedrock",
+                        model = %resp.model,
+                        input_tokens = resp.input_tokens,
+                        output_tokens = resp.output_tokens,
+                        latency_ms = resp.latency_ms,
+                        cost_usd = resp.cost_usd,
+                        "sm bedrock complete response"
+                    );
+                    return Ok(resp);
+                }
+                Err(err) if err.is_retryable() && attempt < MAX_RETRIES => {
+                    attempt += 1;
+                    let backoff_ms = 500u64 * (1u64 << attempt.min(6));
+                    warn!(attempt, backoff_ms, model = %req.model, "sm bedrock retry: {err}");
+                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+}
+
+// ─── Response helpers ───────────────────────────────────────────────────────────
+
+/// Join the `Text` content blocks of a Converse response.
+///
+/// Why: Converse wraps content in typed blocks; the SM only needs the text.
+/// What: joins `Text` blocks with newlines; `None` when empty.
+/// Test: covered by `bedrock_no_credentials_returns_error`.
+fn extract_converse_text(
+    resp: &aws_sdk_bedrockruntime::operation::converse::ConverseOutput,
+) -> Option<String> {
+    let msg = resp.output()?.as_message().ok()?;
+    let mut out = String::new();
+    for block in msg.content() {
+        if let ContentBlock::Text(t) = block {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(t);
+        }
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+/// Extract `(input_tokens, output_tokens)` from the Converse usage.
+///
+/// Why: needed for cost estimation and telemetry (§5.5).
+/// What: reads `usage.inputTokens`/`outputTokens`; `(0, 0)` when absent.
+/// Test: covered by `bedrock_no_credentials_returns_error`.
+fn extract_token_usage(
+    resp: &aws_sdk_bedrockruntime::operation::converse::ConverseOutput,
+) -> (u32, u32) {
+    resp.usage()
+        .map(|u| {
+            (
+                u.input_tokens().max(0) as u32,
+                u.output_tokens().max(0) as u32,
+            )
+        })
+        .unwrap_or((0, 0))
+}
+
+#[cfg(test)]
+#[path = "bedrock_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
@@ -13,9 +13,10 @@
 //! `us.`/`eu.`/… cross-region inference-profile prefix is required and validated
 //! up front so a bare foundation-model id fails early as [`SmLlmError::Validation`].
 //! Test: `bedrock_region_resolution`, `bedrock_prefix_validation`,
-//! `bedrock_cost_estimate_*`, `bedrock_provider_stores_model_and_region`,
+//! `bedrock_provider_stores_model_and_region`,
 //! `bedrock_no_credentials_returns_error`,
-//! `bedrock_empty_messages_is_validation_error` in tests.
+//! `bedrock_empty_messages_is_validation_error` in tests; cost estimation is
+//! covered centrally in `pricing_tests.rs`.
 
 use std::time::{Duration, Instant};
 
@@ -27,7 +28,7 @@ use aws_sdk_bedrockruntime::types::{
 };
 use tracing::{debug, warn};
 
-use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError};
+use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError, pricing};
 
 /// Region env var: trusty-specific override (highest precedence).
 const ENV_REGION_TRUSTY: &str = "TRUSTY_AWS_REGION";
@@ -83,34 +84,6 @@ fn validate_model_id(model_id: &str) -> Result<(), SmLlmError> {
     )))
 }
 
-// ─── Pricing ──────────────────────────────────────────────────────────────────
-
-/// Approximate `(input, output)` USD cost per million tokens for the Anthropic
-/// families served on Bedrock.
-///
-/// Why: per-call cost telemetry (§5.5).
-/// What: family-substring match; unknown → `(0.0, 0.0)`.
-/// Test: `bedrock_cost_estimate_sonnet`, `bedrock_cost_estimate_unknown`.
-fn cost_per_million(model: &str) -> (f64, f64) {
-    match model {
-        m if m.contains("sonnet") => (3.00, 15.00),
-        m if m.contains("haiku") => (0.80, 4.00),
-        m if m.contains("opus") => (15.00, 75.00),
-        _ => (0.0, 0.0),
-    }
-}
-
-/// Compute a USD cost estimate from token counts and the pricing table.
-///
-/// Why: lets the SM total session cost (§5.5).
-/// What: applies [`cost_per_million`]; `0.0` for unknown models.
-/// Test: `bedrock_cost_estimate_sonnet`, `bedrock_cost_estimate_unknown`.
-pub fn estimate_bedrock_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
-    let (in_price, out_price) = cost_per_million(model);
-    (input_tokens as f64 / 1_000_000.0) * in_price
-        + (output_tokens as f64 / 1_000_000.0) * out_price
-}
-
 // ─── Provider ──────────────────────────────────────────────────────────────────
 
 /// AWS Bedrock Converse provider for the SM.
@@ -120,7 +93,7 @@ pub fn estimate_bedrock_cost_usd(model: &str, input_tokens: u32, output_tokens: 
 /// What: holds a `BedrockClient`, the bare model id, and the resolved region.
 /// `complete` calls `Converse`, extracts text + usage, retries transient
 /// errors up to [`MAX_RETRIES`].
-/// Test: `bedrock_no_credentials_returns_error`,
+/// Test: `bedrock_provider_stores_model_and_region`,
 /// `bedrock_no_credentials_returns_error`.
 pub struct BedrockProvider {
     client: BedrockClient,
@@ -161,7 +134,7 @@ impl BedrockProvider {
     /// Why: tests inject a `no_credentials()` client to drive provider logic
     /// without AWS.
     /// What: stores the client verbatim.
-    /// Test: `bedrock_no_credentials_returns_error`,
+    /// Test: `bedrock_provider_stores_model_and_region`,
     /// `bedrock_no_credentials_returns_error`.
     #[cfg(test)]
     pub fn from_client(
@@ -238,7 +211,7 @@ impl BedrockProvider {
         let latency_ms = start.elapsed().as_millis() as u64;
         let text = extract_converse_text(&resp).unwrap_or_default();
         let (input_tokens, output_tokens) = extract_token_usage(&resp);
-        let cost_usd = estimate_bedrock_cost_usd(&req.model, input_tokens, output_tokens);
+        let cost_usd = pricing::estimate_cost_usd(&req.model, input_tokens, output_tokens);
 
         Ok(LlmResponse {
             text,
@@ -303,8 +276,8 @@ impl LlmProvider for BedrockProvider {
     /// What: calls `call_once`; retries up to [`MAX_RETRIES`] while
     /// `is_retryable()`; returns other errors immediately. Logs cost/usage to
     /// stderr.
-    /// Test: `bedrock_no_credentials_returns_error`,
-    /// `bedrock_no_credentials_returns_error`.
+    /// Test: `bedrock_no_credentials_returns_error` (error path),
+    /// `bedrock_empty_messages_is_validation_error` (validation path).
     async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError> {
         debug!(
             provider = "bedrock",

--- a/crates/trusty-mpm/src/core/sm/providers/bedrock_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/bedrock_tests.rs
@@ -1,0 +1,143 @@
+//! Unit tests for the SM Bedrock provider (`bedrock` feature only).
+//!
+//! Why: extracted from `bedrock.rs` to keep that file under the 500-SLOC cap.
+//! All tests are unit-level — no real AWS calls. The `complete`/`call_once`
+//! path is exercised with a `no_credentials()` client, which errors inside the
+//! SDK before any TCP connection, proving the error-mapping wiring.
+//! What: region resolution, model-id validation, cost estimation, construction,
+//! and the no-credentials `complete` error path.
+//! Test: included as `#[cfg(test)] mod tests` via `#[path]` from `bedrock.rs`.
+
+use super::{
+    BedrockProvider, LlmProvider, LlmRequest, estimate_bedrock_cost_usd, resolve_bedrock_region,
+    validate_model_id,
+};
+use crate::core::sm::providers::{ChatMessage, SmLlmError};
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::Client as BedrockClient;
+
+/// Build a `no_credentials()` Bedrock client for offline tests.
+///
+/// Why: `complete`/`call_once` need a client, but tests must not touch AWS; a
+/// no-credentials client fails in the SDK before any network I/O.
+/// What: loads a default config with a fixed region and no credentials.
+/// Test: used by `bedrock_*` tests below.
+async fn no_creds_client() -> BedrockClient {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .region(aws_types::region::Region::new("us-east-1"))
+        .no_credentials()
+        .load()
+        .await;
+    BedrockClient::new(&config)
+}
+
+#[test]
+fn bedrock_region_resolution() {
+    assert_eq!(resolve_bedrock_region(Some("eu-west-1")), "eu-west-1");
+    assert_eq!(resolve_bedrock_region(Some("")), "us-east-1");
+    assert_eq!(resolve_bedrock_region(None), "us-east-1");
+}
+
+#[test]
+fn bedrock_prefix_validation() {
+    for id in [
+        "us.anthropic.claude-sonnet-4-6",
+        "eu.anthropic.claude-sonnet-4-6",
+        "ap.anthropic.claude-haiku",
+        "jp.anthropic.claude-haiku",
+        "global.anthropic.claude-opus",
+    ] {
+        assert!(validate_model_id(id).is_ok(), "{id} should validate");
+    }
+    let err = validate_model_id("anthropic.claude-sonnet-4-6").unwrap_err();
+    assert!(matches!(err, SmLlmError::Validation(_)));
+    assert!(err.is_alarm());
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn bedrock_cost_estimate_sonnet() {
+    let cost = estimate_bedrock_cost_usd("us.anthropic.claude-sonnet-4-6", 1_000_000, 1_000_000);
+    assert!(
+        (cost - 18.0_f64).abs() < 1e-9,
+        "expected $18.00, got {cost}"
+    );
+}
+
+#[test]
+fn bedrock_cost_estimate_haiku() {
+    let cost = estimate_bedrock_cost_usd("us.anthropic.claude-haiku-4-5", 1_000_000, 1_000_000);
+    assert!((cost - 4.8_f64).abs() < 1e-9, "expected $4.80, got {cost}");
+}
+
+#[test]
+fn bedrock_cost_estimate_unknown() {
+    assert_eq!(estimate_bedrock_cost_usd("us.mystery.model", 100, 100), 0.0);
+}
+
+/// Why: the `from_client` accessors must report name/region without AWS calls.
+/// What: builds a no-creds client and checks `name()`/`region()`.
+/// Test: no network.
+#[tokio::test]
+async fn bedrock_provider_stores_model_and_region() {
+    let provider = BedrockProvider::from_client(
+        no_creds_client().await,
+        "us.anthropic.claude-haiku",
+        "us-east-1",
+    );
+    assert_eq!(provider.name(), "bedrock");
+    assert_eq!(provider.region(), "us-east-1");
+    assert_eq!(provider.model, "us.anthropic.claude-haiku");
+}
+
+/// Why: a misconfigured AWS environment must yield a typed [`SmLlmError`] (the
+/// error-mapping path in `map_sdk_error`), never a panic.
+/// What: calls `complete` on a no-credentials client and asserts it returns an
+/// error mentioning credentials/Bedrock.
+/// Test: the SDK errors before any TCP connection — no real network.
+#[tokio::test]
+async fn bedrock_no_credentials_returns_error() {
+    let provider = BedrockProvider::from_client(
+        no_creds_client().await,
+        "us.anthropic.claude-sonnet-4-6",
+        "us-east-1",
+    );
+    let req = LlmRequest {
+        model: "us.anthropic.claude-sonnet-4-6".to_string(),
+        system: "sys".to_string(),
+        messages: vec![ChatMessage {
+            role: "user".to_string(),
+            content: "go".to_string(),
+        }],
+        temperature: 0.3,
+        max_tokens: 256,
+    };
+    let err = provider.complete(req).await.expect_err("must fail offline");
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("bedrock") || msg.contains("credential") || msg.contains("access"),
+        "error should mention bedrock/credentials, got: {msg}"
+    );
+}
+
+/// Why: an empty message list is a deterministic client-side validation error,
+/// not something to send upstream.
+/// What: calls `complete` with no messages and asserts a `Validation` error.
+/// Test: no network.
+#[tokio::test]
+async fn bedrock_empty_messages_is_validation_error() {
+    let provider = BedrockProvider::from_client(
+        no_creds_client().await,
+        "us.anthropic.claude-sonnet-4-6",
+        "us-east-1",
+    );
+    let req = LlmRequest {
+        model: "us.anthropic.claude-sonnet-4-6".to_string(),
+        system: "sys".to_string(),
+        messages: vec![],
+        temperature: 0.3,
+        max_tokens: 256,
+    };
+    let err = provider.complete(req).await.expect_err("empty must fail");
+    assert!(matches!(err, SmLlmError::Validation(_)));
+}

--- a/crates/trusty-mpm/src/core/sm/providers/bedrock_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/bedrock_tests.rs
@@ -4,14 +4,12 @@
 //! All tests are unit-level — no real AWS calls. The `complete`/`call_once`
 //! path is exercised with a `no_credentials()` client, which errors inside the
 //! SDK before any TCP connection, proving the error-mapping wiring.
-//! What: region resolution, model-id validation, cost estimation, construction,
-//! and the no-credentials `complete` error path.
+//! What: region resolution, model-id validation, construction, and the
+//! no-credentials `complete` error path. Cost estimation is covered centrally
+//! in `pricing_tests.rs`.
 //! Test: included as `#[cfg(test)] mod tests` via `#[path]` from `bedrock.rs`.
 
-use super::{
-    BedrockProvider, LlmProvider, LlmRequest, estimate_bedrock_cost_usd, resolve_bedrock_region,
-    validate_model_id,
-};
+use super::{BedrockProvider, LlmProvider, LlmRequest, resolve_bedrock_region, validate_model_id};
 use crate::core::sm::providers::{ChatMessage, SmLlmError};
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::Client as BedrockClient;
@@ -53,26 +51,6 @@ fn bedrock_prefix_validation() {
     assert!(matches!(err, SmLlmError::Validation(_)));
     assert!(err.is_alarm());
     assert!(!err.is_retryable());
-}
-
-#[test]
-fn bedrock_cost_estimate_sonnet() {
-    let cost = estimate_bedrock_cost_usd("us.anthropic.claude-sonnet-4-6", 1_000_000, 1_000_000);
-    assert!(
-        (cost - 18.0_f64).abs() < 1e-9,
-        "expected $18.00, got {cost}"
-    );
-}
-
-#[test]
-fn bedrock_cost_estimate_haiku() {
-    let cost = estimate_bedrock_cost_usd("us.anthropic.claude-haiku-4-5", 1_000_000, 1_000_000);
-    assert!((cost - 4.8_f64).abs() < 1e-9, "expected $4.80, got {cost}");
-}
-
-#[test]
-fn bedrock_cost_estimate_unknown() {
-    assert_eq!(estimate_bedrock_cost_usd("us.mystery.model", 100, 100), 0.0);
 }
 
 /// Why: the `from_client` accessors must report name/region without AWS calls.

--- a/crates/trusty-mpm/src/core/sm/providers/error.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/error.rs
@@ -1,0 +1,192 @@
+//! SM LLM provider error type (DOC-14 spec §5.3).
+//!
+//! Why: the SM must distinguish *config/lifecycle* errors (wrong model id,
+//! missing credentials — deterministic, must NOT be retried, must surface
+//! loudly) from *transient* errors (network blips, 429, 5xx — may be retried
+//! with backoff and may trigger the optional provider fallback chain, §5.3).
+//! A typed enum lets the resolver and the fallback loop apply the correct
+//! policy without inspecting human-readable error strings.
+//! What: [`SmLlmError`] mirrors trusty-review's `LlmError` classification
+//! (this is the VENDORED copy per the SM-2 PM decision — see the module-level
+//! TODO in `mod.rs`). `is_retryable` / `is_alarm` encode the policy so callers
+//! never pattern-match on variants.
+//! Test: `sm_llm_error_classification`, `sm_llm_error_messages` below.
+
+use thiserror::Error;
+
+/// Errors produced by [`super::LlmProvider::complete`] and by provider
+/// construction / resolution.
+///
+/// Why: typed variants let the SM fallback loop (§5.3) retry only transient
+/// failures and alarm on deterministic config errors, matching trusty-review's
+/// retry/alarm policy (`llm/error.rs`).
+/// What: config/lifecycle variants classify as `is_alarm = true`,
+/// `is_retryable = false`; transient variants as `is_alarm = false`,
+/// `is_retryable = true`. The extra [`SmLlmError::Degraded`] variant (no
+/// provider credentials available, §5.3 / G6) is neither retryable nor an
+/// alarm — it is a graceful, reportable "no inference configured" state.
+/// Test: `sm_llm_error_classification`.
+#[derive(Debug, Error)]
+pub enum SmLlmError {
+    // ── Config / lifecycle errors (ALARM, no retry) ───────────────────────
+    /// The requested model id does not exist or is not available on the
+    /// provider (Bedrock `ResourceNotFoundException` / OpenRouter 404 /
+    /// Anthropic 404). Deterministic — retry will not help.
+    #[error("model not found: {0}")]
+    ModelNotFound(String),
+
+    /// The model exists but is not in an ACTIVE lifecycle state (e.g. Bedrock
+    /// provisioned throughput in CREATING/FAILED). Deterministic.
+    #[error("model not ready: {0}")]
+    ModelNotReady(String),
+
+    /// Malformed request (missing field, bad JSON, Bedrock ValidationException
+    /// on a missing `us.` prefix, or an unknown `provider` config string).
+    /// Deterministic.
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    /// Authentication / authorisation failure (invalid API key, missing IAM
+    /// permissions). Deterministic.
+    #[error("access denied: {0}")]
+    AccessDenied(String),
+
+    // ── Transient errors (may retry with backoff / trigger fallback) ──────
+    /// Network-level failure: DNS, TCP connect, TLS handshake, or read
+    /// timeout. May resolve on retry.
+    #[error("transport error: {0}")]
+    Transport(String),
+
+    /// Provider returned HTTP 429 (rate-limited / quota exceeded). Retry after
+    /// back-off, or fall back to the next provider.
+    #[error("rate limited")]
+    RateLimited,
+
+    /// Provider returned an HTTP 5xx or an unexpected non-success status.
+    #[error("upstream error (HTTP {status}): {body}")]
+    Upstream {
+        /// HTTP status code.
+        status: u16,
+        /// Response body text.
+        body: String,
+    },
+
+    // ── Degraded mode (no provider credentials — graceful, §5.3 / G6) ─────
+    /// No provider has resolvable credentials, so free-text reasoning is
+    /// unavailable. NOT an alarm and NOT retryable — the SM serves its
+    /// deterministic surface (routed commands, session/goal management) and
+    /// reports this as a graceful notice rather than a hard failure.
+    #[error("degraded: no inference provider configured ({0})")]
+    Degraded(String),
+}
+
+impl SmLlmError {
+    /// Returns `true` if this error should trigger an operational alarm.
+    ///
+    /// Why: config/lifecycle errors indicate a broken deployment (wrong model
+    /// id, missing credentials) and must be surfaced loudly, not swallowed.
+    /// What: `ModelNotFound`, `ModelNotReady`, `Validation`, `AccessDenied`
+    /// return `true`; transient errors and `Degraded` return `false`.
+    /// Test: `sm_llm_error_classification`.
+    pub fn is_alarm(&self) -> bool {
+        matches!(
+            self,
+            SmLlmError::ModelNotFound(_)
+                | SmLlmError::ModelNotReady(_)
+                | SmLlmError::Validation(_)
+                | SmLlmError::AccessDenied(_)
+        )
+    }
+
+    /// Returns `true` if this error is safe to retry / fall back on.
+    ///
+    /// Why: retrying config/lifecycle errors wastes time and hides root
+    /// causes; the SM fallback chain (§5.3) advances only on retryable errors.
+    /// What: only `Transport`, `RateLimited`, and `Upstream` return `true`.
+    /// Test: `sm_llm_error_classification`.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            SmLlmError::Transport(_) | SmLlmError::RateLimited | SmLlmError::Upstream { .. }
+        )
+    }
+
+    /// Returns `true` when the SM is in degraded (no-provider) mode.
+    ///
+    /// Why: the SM-7 endpoint / SM-STDIO adapter renders a graceful notice for
+    /// this case instead of an error, per §5.3.
+    /// What: `true` only for the `Degraded` variant.
+    /// Test: `sm_llm_error_classification`.
+    pub fn is_degraded(&self) -> bool {
+        matches!(self, SmLlmError::Degraded(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: pin the retry/alarm/degraded classification so a future variant
+    /// addition can't silently mis-route the fallback loop.
+    /// What: asserts each variant's `is_alarm`/`is_retryable`/`is_degraded`.
+    /// Test: this is the test.
+    #[test]
+    fn sm_llm_error_classification() {
+        let alarm: Vec<SmLlmError> = vec![
+            SmLlmError::ModelNotFound("x".into()),
+            SmLlmError::ModelNotReady("x".into()),
+            SmLlmError::Validation("x".into()),
+            SmLlmError::AccessDenied("x".into()),
+        ];
+        for e in &alarm {
+            assert!(e.is_alarm(), "{e:?} should alarm");
+            assert!(!e.is_retryable(), "{e:?} should not retry");
+            assert!(!e.is_degraded(), "{e:?} is not degraded");
+        }
+
+        let transient: Vec<SmLlmError> = vec![
+            SmLlmError::Transport("x".into()),
+            SmLlmError::RateLimited,
+            SmLlmError::Upstream {
+                status: 503,
+                body: "x".into(),
+            },
+        ];
+        for e in &transient {
+            assert!(!e.is_alarm(), "{e:?} should not alarm");
+            assert!(e.is_retryable(), "{e:?} should retry");
+            assert!(!e.is_degraded(), "{e:?} is not degraded");
+        }
+
+        let degraded = SmLlmError::Degraded("no keys".into());
+        assert!(!degraded.is_alarm());
+        assert!(!degraded.is_retryable());
+        assert!(degraded.is_degraded());
+    }
+
+    /// Why: error messages feed operator-facing logs / notices; keep them
+    /// informative and stable.
+    /// What: asserts the `Display` output of representative variants.
+    /// Test: this is the test.
+    #[test]
+    fn sm_llm_error_messages() {
+        assert_eq!(
+            SmLlmError::ModelNotFound("anthropic/claude-x".into()).to_string(),
+            "model not found: anthropic/claude-x"
+        );
+        assert_eq!(SmLlmError::RateLimited.to_string(), "rate limited");
+        assert_eq!(
+            SmLlmError::Upstream {
+                status: 503,
+                body: "overloaded".into()
+            }
+            .to_string(),
+            "upstream error (HTTP 503): overloaded"
+        );
+        assert_eq!(
+            SmLlmError::Degraded("no ANTHROPIC_API_KEY / AWS / OPENROUTER_API_KEY".into())
+                .to_string(),
+            "degraded: no inference provider configured (no ANTHROPIC_API_KEY / AWS / OPENROUTER_API_KEY)"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/providers/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/mod.rs
@@ -1,0 +1,270 @@
+//! Vendored multi-provider LLM abstraction for the Session Manager (DOC-14 §5).
+//!
+//! Why: the SM is multi-provider (OpenRouter / AWS Bedrock / direct Anthropic,
+//! §5.1) and selects a model per task (orchestration vs. summarization vs.
+//! compaction, §5.4). It needs a single, prefix-routed, non-streaming,
+//! cost/latency-aware `complete()`-style provider trait — the request/response
+//! shape (not token-streamed to a UI) that trusty-review's `llm` module already
+//! offers. Per the SM-2 PM decision we VENDOR a focused copy of that abstraction
+//! here rather than extracting trusty-review's module into a shared crate now
+//! (the cross-crate extraction is too high blast-radius for SM-2).
+//!
+//! TODO(follow-up #1302): extract this shared `LlmProvider` abstraction into a
+//! common crate (`trusty-common::llm` or a new `trusty-llm`) so trusty-review
+//! and the SM consume one copy instead of two. SM-2 deliberately vendored this
+//! copy (DOC-14 §5.2 D5.1, §13 open-question 1); #1302 tracks the dedup.
+//!
+//! What: defines the [`LlmProvider`] trait (one non-streaming `complete` call
+//! returning text + token usage + estimated cost), the [`LlmRequest`] /
+//! [`LlmResponse`] / [`ChatMessage`] data shapes, the [`ProviderKind`] enum
+//! (parsed from the SM config `provider` string with validation), and the
+//! prefix-routing [`resolve`] submodule that maps a (possibly-prefixed) model
+//! id + SM config into a concrete provider + bare model id + per-task tiers.
+//! The three concrete providers live in `openrouter`, `anthropic`, and (behind
+//! the `bedrock` cargo feature) `bedrock`.
+//! Test: each submodule carries unit tests; `provider_kind_*` and the
+//! `resolve::tests` module cover routing, tiers, alias-fallback, precedence,
+//! degraded mode, and provider validation.
+
+pub mod anthropic;
+pub mod error;
+pub mod openrouter;
+pub mod resolve;
+
+#[cfg(feature = "bedrock")]
+pub mod bedrock;
+
+pub use anthropic::AnthropicProvider;
+pub use error::SmLlmError;
+pub use openrouter::OpenRouterProvider;
+pub use resolve::{
+    ProviderRegistry, ResolvedCall, SmModelTier, resolve_provider_and_model, resolve_tier_model,
+};
+
+#[cfg(feature = "bedrock")]
+pub use bedrock::BedrockProvider;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// ─── Provider-id prefixes (DOC-14 §5.2 D5.3) ───────────────────────────────────
+
+/// `anthropic/` model-id prefix: pin the direct Anthropic provider for a call.
+pub const ANTHROPIC_MODEL_PREFIX: &str = "anthropic/";
+/// `bedrock/` model-id prefix: pin the AWS Bedrock provider for a call.
+pub const BEDROCK_MODEL_PREFIX: &str = "bedrock/";
+/// `openrouter/` model-id prefix: pin the OpenRouter provider for a call.
+pub const OPENROUTER_MODEL_PREFIX: &str = "openrouter/";
+
+// ─── Provider kind (validated `provider` config value) ─────────────────────────
+
+/// The four legal values of `[session_manager.inference].provider` (§5.3).
+///
+/// Why: SM-1 stored `provider` as a free-form `String`; SM-1 review flagged
+/// that a bare/unknown value must be *rejected as a config error* rather than
+/// silently failing at the first inference call. Parsing into this enum at
+/// resolution time gives that ergonomic, early validation.
+/// What: `Auto` triggers the precedence chain (§5.3); the other three pin a
+/// single default provider. [`ProviderKind::parse`] normalises case and
+/// trims, and returns [`SmLlmError::Validation`] for anything else.
+/// Test: `provider_kind_parse_ok`, `provider_kind_parse_rejects_unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    /// `provider = "auto"` — pick the first provider with valid credentials
+    /// (Anthropic → Bedrock → OpenRouter → degraded).
+    Auto,
+    /// `provider = "anthropic"` — direct `api.anthropic.com` `/v1/messages`.
+    Anthropic,
+    /// `provider = "bedrock"` — AWS Bedrock Converse.
+    Bedrock,
+    /// `provider = "openrouter"` — OpenRouter OpenAI-compatible endpoint.
+    OpenRouter,
+}
+
+impl ProviderKind {
+    /// Parse a `provider` config string into a validated [`ProviderKind`].
+    ///
+    /// Why: reject unknown provider strings at the config boundary (SM-1 review
+    /// carry-forward) so operators get a clear error instead of a late,
+    /// confusing inference failure.
+    /// What: trims + lowercases `s`, then matches `auto`/`anthropic`/`bedrock`/
+    /// `openrouter`. An empty string is treated as `auto` (the §10 default).
+    /// Anything else returns [`SmLlmError::Validation`].
+    /// Test: `provider_kind_parse_ok`, `provider_kind_parse_rejects_unknown`.
+    pub fn parse(s: &str) -> Result<Self, SmLlmError> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "" | "auto" => Ok(ProviderKind::Auto),
+            "anthropic" => Ok(ProviderKind::Anthropic),
+            "bedrock" => Ok(ProviderKind::Bedrock),
+            "openrouter" => Ok(ProviderKind::OpenRouter),
+            other => Err(SmLlmError::Validation(format!(
+                "unknown [session_manager.inference] provider {other:?}; \
+                 expected one of: auto, anthropic, bedrock, openrouter"
+            ))),
+        }
+    }
+}
+
+// ─── Chat / request / response shapes ──────────────────────────────────────────
+
+/// A single chat message for an SM completion request.
+///
+/// Why: the SM sends system + user/assistant turns; it does not need the full
+/// tool-call shape for its reasoning calls (§5.5).
+/// What: a minimal `role` (`"system"` | `"user"` | `"assistant"`) + `content`.
+/// Test: covered transitively by provider round-trip tests.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatMessage {
+    /// Role: `"system"`, `"user"`, or `"assistant"`.
+    pub role: String,
+    /// Message text content.
+    pub content: String,
+}
+
+/// Input to [`LlmProvider::complete`].
+///
+/// Why: carries every per-call parameter so each task tier (orchestration,
+/// summarization, compaction) can vary `model`, `temperature`, and
+/// `max_tokens` independently (§5.4).
+/// What: `model` is the fully-resolved bare model id for THIS call (the routing
+/// prefix has already been stripped by [`resolve`]); `system` is the system
+/// prompt; `messages` are the conversation turns.
+/// Test: provider round-trip tests construct these.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmRequest {
+    /// Fully-resolved bare model id for this call (no routing prefix).
+    pub model: String,
+    /// System prompt (empty string = no system message).
+    pub system: String,
+    /// Conversation turns.
+    pub messages: Vec<ChatMessage>,
+    /// Sampling temperature (typically the SM default `0.3`, §5.5).
+    pub temperature: f32,
+    /// Maximum tokens to generate.
+    pub max_tokens: u32,
+}
+
+/// Output from [`LlmProvider::complete`].
+///
+/// Why: captures the response text plus the telemetry the SM logs per call and
+/// totals per session (§5.5): tokens, latency, and estimated USD cost.
+/// What: `text` is the full response; `model` echoes the model id used;
+/// `input_tokens`/`output_tokens` come from the API usage; `latency_ms` is
+/// wall-clock; `cost_usd` is an estimate from a per-provider pricing table.
+/// Test: `llm_response_serde_roundtrip` below.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponse {
+    /// Full response text.
+    pub text: String,
+    /// Model id actually used by the provider.
+    pub model: String,
+    /// Input (prompt) tokens consumed.
+    pub input_tokens: u32,
+    /// Output (completion) tokens generated.
+    pub output_tokens: u32,
+    /// Wall-clock latency in milliseconds.
+    pub latency_ms: u64,
+    /// Estimated USD cost for this call.
+    pub cost_usd: f64,
+}
+
+// ─── Provider trait ─────────────────────────────────────────────────────────────
+
+/// A non-streaming LLM completion provider (DOC-14 §5.2).
+///
+/// Why: the SM and the resolver depend on this trait rather than concrete
+/// types so the active provider is an implementation detail, and so tests can
+/// inject mocks. Implementors are `Send + Sync` to live behind
+/// `Arc<dyn LlmProvider>`.
+/// What: one `complete` method (request → response or [`SmLlmError`]) plus a
+/// `name` tag for logs/metrics.
+/// Test: `provider_trait_object_compiles`; each provider has mock-server tests.
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    /// Human-readable provider name, e.g. `"anthropic"`, `"bedrock"`,
+    /// `"openrouter"`.
+    ///
+    /// Why: per-call cost/usage logs (§5.5) tag the provider.
+    /// What: a static string slice; no allocation.
+    /// Test: each implementation asserts its own name.
+    fn name(&self) -> &str;
+
+    /// Execute a non-streaming completion and return the full response.
+    ///
+    /// Why: the SM needs the full text plus token/latency/cost telemetry in one
+    /// call; streaming complicates usage capture (§5.5).
+    /// What: sends `req` upstream, waits for the full response, and returns
+    /// [`LlmResponse`]. Transient errors may be retried / fell-back by the
+    /// caller based on [`SmLlmError::is_retryable`].
+    /// Test: each provider implements mock-server tests.
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `provider` config values must parse to the right kind; `auto`/empty
+    /// both mean "use the precedence chain".
+    /// What: asserts each legal value (case-insensitive, trimmed).
+    /// Test: this is the test.
+    #[test]
+    fn provider_kind_parse_ok() {
+        assert_eq!(ProviderKind::parse("auto").unwrap(), ProviderKind::Auto);
+        assert_eq!(ProviderKind::parse("").unwrap(), ProviderKind::Auto);
+        assert_eq!(
+            ProviderKind::parse("  Anthropic ").unwrap(),
+            ProviderKind::Anthropic
+        );
+        assert_eq!(
+            ProviderKind::parse("BEDROCK").unwrap(),
+            ProviderKind::Bedrock
+        );
+        assert_eq!(
+            ProviderKind::parse("openrouter").unwrap(),
+            ProviderKind::OpenRouter
+        );
+    }
+
+    /// Why: SM-1 review carry-forward — an unknown `provider` string must be a
+    /// config error, not a silent late failure.
+    /// What: asserts `parse` returns a `Validation` error for a bogus value.
+    /// Test: this is the test.
+    #[test]
+    fn provider_kind_parse_rejects_unknown() {
+        let err = ProviderKind::parse("gpt-self-host").unwrap_err();
+        assert!(matches!(err, SmLlmError::Validation(_)));
+        assert!(err.is_alarm(), "unknown provider is a config alarm");
+    }
+
+    /// Why: telemetry fields must survive serde so the SM can persist/forward
+    /// per-call cost.
+    /// What: round-trips an [`LlmResponse`] through JSON.
+    /// Test: this is the test.
+    #[test]
+    fn llm_response_serde_roundtrip() {
+        let resp = LlmResponse {
+            text: "ok".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            input_tokens: 100,
+            output_tokens: 20,
+            latency_ms: 42,
+            cost_usd: 0.000_5,
+        };
+        let json = serde_json::to_string(&resp).expect("serialise");
+        let back: LlmResponse = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.text, "ok");
+        assert_eq!(back.input_tokens, 100);
+        assert!((back.cost_usd - 0.000_5_f64).abs() < 1e-12);
+    }
+
+    /// Object-safety smoke-test: [`LlmProvider`] must be usable as `dyn`.
+    ///
+    /// Why: the resolver hands back `Arc<dyn LlmProvider>`.
+    /// What: a coercion that only needs to compile.
+    /// Test: compilation is the assertion.
+    #[test]
+    fn provider_trait_object_compiles() {
+        fn _accepts(_p: &dyn LlmProvider) {}
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/providers/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/mod.rs
@@ -29,10 +29,14 @@
 pub mod anthropic;
 pub mod error;
 pub mod openrouter;
+pub mod pricing;
 pub mod resolve;
 
 #[cfg(feature = "bedrock")]
 pub mod bedrock;
+
+#[cfg(test)]
+pub(crate) mod test_support;
 
 pub use anthropic::AnthropicProvider;
 pub use error::SmLlmError;

--- a/crates/trusty-mpm/src/core/sm/providers/openrouter.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/openrouter.rs
@@ -190,6 +190,11 @@ impl LlmProvider for OpenRouterProvider {
         if !status.is_success() {
             let text = http_resp.text().await.unwrap_or_default();
             return Err(match status.as_u16() {
+                // A 400 is a malformed request (bad params / body). It is a
+                // non-retryable client alarm — retrying an identical request
+                // just wastes calls — so map it to a non-retryable Validation
+                // error, consistent with the Anthropic provider.
+                400 => SmLlmError::Validation(text),
                 401 | 403 => SmLlmError::AccessDenied(text),
                 404 => SmLlmError::ModelNotFound(format!("model={}: {text}", self.model)),
                 422 => SmLlmError::Validation(text),

--- a/crates/trusty-mpm/src/core/sm/providers/openrouter.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/openrouter.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError};
+use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError, pricing};
 
 /// Default OpenRouter chat-completions endpoint.
 pub const DEFAULT_OPENROUTER_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
@@ -69,40 +69,6 @@ struct OrcChoiceMessage {
 struct OrcUsage {
     prompt_tokens: u32,
     completion_tokens: u32,
-}
-
-// ─── Pricing ──────────────────────────────────────────────────────────────────
-
-/// Approximate `(input, output)` USD cost per million tokens for the model ids
-/// the SM commonly routes through OpenRouter.
-///
-/// Why: surfaces a per-call cost estimate in [`LlmResponse`] (§5.5). Unknown
-/// ids fall back to `(0.0, 0.0)` — a missing estimate, not an error.
-/// What: covers the Anthropic Sonnet/Haiku tiers (the SM defaults) as billed
-/// through OpenRouter, plus a couple of common OpenAI ids.
-/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
-fn cost_per_million(model: &str) -> (f64, f64) {
-    match model {
-        // Anthropic via OpenRouter (SM default tiers).
-        m if m.contains("claude-sonnet") => (3.00, 15.00),
-        m if m.contains("claude-haiku") => (0.80, 4.00),
-        m if m.contains("claude-opus") => (15.00, 75.00),
-        // Common OpenAI ids.
-        "openai/gpt-5.4-mini-20260317" => (0.75, 4.50),
-        "openai/gpt-5.4-nano-20260317" => (0.20, 1.25),
-        _ => (0.0, 0.0),
-    }
-}
-
-/// Compute a USD cost estimate from token counts and the pricing table.
-///
-/// Why: lets the SM total session cost and rank tiers by cost (§5.5).
-/// What: applies [`cost_per_million`]; returns `0.0` for unknown models.
-/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
-pub fn estimate_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
-    let (in_price, out_price) = cost_per_million(model);
-    (input_tokens as f64 / 1_000_000.0) * in_price
-        + (output_tokens as f64 / 1_000_000.0) * out_price
 }
 
 // ─── Provider ──────────────────────────────────────────────────────────────────
@@ -254,7 +220,7 @@ impl LlmProvider for OpenRouterProvider {
             .map(|u| (u.prompt_tokens, u.completion_tokens))
             .unwrap_or((0, 0));
         let model_used = orc.model.unwrap_or_else(|| self.model.clone());
-        let cost_usd = estimate_cost_usd(&model_used, input_tokens, output_tokens);
+        let cost_usd = pricing::estimate_cost_usd(&model_used, input_tokens, output_tokens);
 
         debug!(
             provider = "openrouter",

--- a/crates/trusty-mpm/src/core/sm/providers/openrouter.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/openrouter.rs
@@ -1,0 +1,282 @@
+//! OpenRouter LLM provider for the SM (vendored, DOC-14 §5.1).
+//!
+//! Why: OpenRouter is one of the SM's three providers; it speaks the
+//! OpenAI-compatible `/v1/chat/completions` endpoint with bearer auth. We
+//! vendor a focused, non-streaming implementation (ported from trusty-review's
+//! `llm/openrouter.rs`) so the SM's `complete()` call reliably captures token
+//! usage from the non-streaming response body.
+//! What: [`OpenRouterProvider`] reads an API key + bare model id, and a
+//! configurable base URL (so tests can point it at a local mock). `complete`
+//! POSTs `stream: false`, maps HTTP errors to [`SmLlmError`], and returns
+//! [`LlmResponse`] with token usage, wall-clock latency, and an estimated cost.
+//! Test: `complete_roundtrips_against_mock`, `complete_maps_http_errors`,
+//! `new_rejects_empty_key` in the test module.
+
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError};
+
+/// Default OpenRouter chat-completions endpoint.
+pub const DEFAULT_OPENROUTER_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
+const CONNECT_TIMEOUT_SECS: u64 = 10;
+const READ_TIMEOUT_SECS: u64 = 120;
+const HTTP_REFERER: &str = "https://github.com/bobmatnyc/trusty-tools";
+const X_TITLE: &str = "trusty-mpm-session-manager";
+
+// ─── Wire types (non-streaming) ───────────────────────────────────────────────
+
+/// OpenRouter non-streaming request body.
+#[derive(Debug, Serialize)]
+struct OrcRequest<'a> {
+    model: &'a str,
+    messages: &'a [OrcMessage],
+    stream: bool,
+    temperature: f32,
+    max_tokens: u32,
+}
+
+/// Single message in the OpenRouter request.
+#[derive(Debug, Serialize)]
+struct OrcMessage {
+    role: String,
+    content: String,
+}
+
+/// OpenRouter non-streaming response body (only fields we use).
+#[derive(Debug, Deserialize)]
+struct OrcResponse {
+    choices: Vec<OrcChoice>,
+    #[serde(default)]
+    usage: Option<OrcUsage>,
+    model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OrcChoice {
+    message: OrcChoiceMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OrcChoiceMessage {
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OrcUsage {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+}
+
+// ─── Pricing ──────────────────────────────────────────────────────────────────
+
+/// Approximate `(input, output)` USD cost per million tokens for the model ids
+/// the SM commonly routes through OpenRouter.
+///
+/// Why: surfaces a per-call cost estimate in [`LlmResponse`] (§5.5). Unknown
+/// ids fall back to `(0.0, 0.0)` — a missing estimate, not an error.
+/// What: covers the Anthropic Sonnet/Haiku tiers (the SM defaults) as billed
+/// through OpenRouter, plus a couple of common OpenAI ids.
+/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
+fn cost_per_million(model: &str) -> (f64, f64) {
+    match model {
+        // Anthropic via OpenRouter (SM default tiers).
+        m if m.contains("claude-sonnet") => (3.00, 15.00),
+        m if m.contains("claude-haiku") => (0.80, 4.00),
+        m if m.contains("claude-opus") => (15.00, 75.00),
+        // Common OpenAI ids.
+        "openai/gpt-5.4-mini-20260317" => (0.75, 4.50),
+        "openai/gpt-5.4-nano-20260317" => (0.20, 1.25),
+        _ => (0.0, 0.0),
+    }
+}
+
+/// Compute a USD cost estimate from token counts and the pricing table.
+///
+/// Why: lets the SM total session cost and rank tiers by cost (§5.5).
+/// What: applies [`cost_per_million`]; returns `0.0` for unknown models.
+/// Test: `cost_estimate_known`, `cost_estimate_unknown`.
+pub fn estimate_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
+    let (in_price, out_price) = cost_per_million(model);
+    (input_tokens as f64 / 1_000_000.0) * in_price
+        + (output_tokens as f64 / 1_000_000.0) * out_price
+}
+
+// ─── Provider ──────────────────────────────────────────────────────────────────
+
+/// OpenRouter provider for the SM.
+///
+/// Why: satisfies [`LlmProvider`] over the OpenRouter API; the configurable
+/// `base_url` lets unit tests drive it against a local mock without real
+/// network calls.
+/// What: holds the api key, bare model id, base URL, and a pooled
+/// `reqwest::Client`. `complete` POSTs a non-streaming request and maps the
+/// outcome to [`LlmResponse`] / [`SmLlmError`].
+/// Test: `complete_roundtrips_against_mock`, `complete_maps_http_errors`.
+#[derive(Debug)]
+pub struct OpenRouterProvider {
+    api_key: String,
+    model: String,
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl OpenRouterProvider {
+    /// Construct a provider for the given model + API key (default endpoint).
+    ///
+    /// Why: the resolver builds this from `OPENROUTER_API_KEY` and the bare
+    /// model id once the routing prefix is stripped.
+    /// What: delegates to [`Self::with_base_url`] using
+    /// [`DEFAULT_OPENROUTER_URL`].
+    /// Test: `new_rejects_empty_key`.
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Result<Self, SmLlmError> {
+        Self::with_base_url(api_key, model, DEFAULT_OPENROUTER_URL)
+    }
+
+    /// Construct a provider with an explicit base URL (used by tests/mocks).
+    ///
+    /// Why: tests must point the provider at a local `TcpListener` mock; the
+    /// default endpoint is not reachable (and must not be hit) in unit tests.
+    /// What: validates the key is non-empty, builds a `reqwest::Client` with
+    /// connect/read timeouts, and stores the fields. Returns
+    /// [`SmLlmError::AccessDenied`] on an empty key.
+    /// Test: `new_rejects_empty_key`, `complete_roundtrips_against_mock`.
+    pub fn with_base_url(
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        base_url: impl Into<String>,
+    ) -> Result<Self, SmLlmError> {
+        let api_key = api_key.into();
+        if api_key.is_empty() {
+            return Err(SmLlmError::AccessDenied(
+                "OPENROUTER_API_KEY is empty".to_string(),
+            ));
+        }
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(READ_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| SmLlmError::Transport(format!("build reqwest client: {e}")))?;
+        Ok(Self {
+            api_key,
+            model: model.into(),
+            base_url: base_url.into(),
+            client,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenRouterProvider {
+    fn name(&self) -> &str {
+        "openrouter"
+    }
+
+    /// Execute a non-streaming OpenRouter completion.
+    ///
+    /// Why: the SM needs full text + usage in one call (§5.5).
+    /// What: builds the message list (optional system + turns), POSTs with
+    /// `stream: false`, maps HTTP status codes to [`SmLlmError`] variants,
+    /// extracts text + token counts, measures latency, and computes cost. Logs
+    /// per-call cost/usage to stderr via `tracing` (§5.5; never stdout).
+    /// Test: `complete_roundtrips_against_mock`, `complete_maps_http_errors`.
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError> {
+        let mut messages = Vec::with_capacity(req.messages.len() + 1);
+        if !req.system.is_empty() {
+            messages.push(OrcMessage {
+                role: "system".to_string(),
+                content: req.system.clone(),
+            });
+        }
+        for m in &req.messages {
+            messages.push(OrcMessage {
+                role: m.role.clone(),
+                content: m.content.clone(),
+            });
+        }
+
+        let body = OrcRequest {
+            model: &self.model,
+            messages: &messages,
+            stream: false,
+            temperature: req.temperature,
+            max_tokens: req.max_tokens,
+        };
+
+        let start = Instant::now();
+        let http_resp = self
+            .client
+            .post(&self.base_url)
+            .bearer_auth(&self.api_key)
+            .header("HTTP-Referer", HTTP_REFERER)
+            .header("X-Title", X_TITLE)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SmLlmError::Transport(e.to_string()))?;
+
+        let latency_ms = start.elapsed().as_millis() as u64;
+        let status = http_resp.status();
+
+        if !status.is_success() {
+            let text = http_resp.text().await.unwrap_or_default();
+            return Err(match status.as_u16() {
+                401 | 403 => SmLlmError::AccessDenied(text),
+                404 => SmLlmError::ModelNotFound(format!("model={}: {text}", self.model)),
+                422 => SmLlmError::Validation(text),
+                429 => SmLlmError::RateLimited,
+                code => SmLlmError::Upstream {
+                    status: code,
+                    body: text,
+                },
+            });
+        }
+
+        let orc: OrcResponse = http_resp.json().await.map_err(|e| {
+            warn!("failed to parse OpenRouter response: {e}");
+            SmLlmError::Upstream {
+                status: status.as_u16(),
+                body: e.to_string(),
+            }
+        })?;
+
+        let text = orc
+            .choices
+            .into_iter()
+            .next()
+            .and_then(|c| c.message.content)
+            .unwrap_or_default();
+        let (input_tokens, output_tokens) = orc
+            .usage
+            .map(|u| (u.prompt_tokens, u.completion_tokens))
+            .unwrap_or((0, 0));
+        let model_used = orc.model.unwrap_or_else(|| self.model.clone());
+        let cost_usd = estimate_cost_usd(&model_used, input_tokens, output_tokens);
+
+        debug!(
+            provider = "openrouter",
+            model = %model_used,
+            input_tokens,
+            output_tokens,
+            latency_ms,
+            cost_usd,
+            "sm openrouter complete"
+        );
+
+        Ok(LlmResponse {
+            text,
+            model: model_used,
+            input_tokens,
+            output_tokens,
+            latency_ms,
+            cost_usd,
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "openrouter_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/sm/providers/openrouter_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/openrouter_tests.rs
@@ -130,3 +130,34 @@ async fn complete_maps_http_errors() {
     assert!(err.is_retryable());
     assert!(!err.is_alarm());
 }
+
+/// Why: a 400 from OpenRouter is a malformed request (bad params/body), not a
+/// transient failure — retrying it is pointless. It must map to the
+/// non-retryable `Validation` variant, consistent with the Anthropic provider,
+/// so the fallback chain treats it as a config alarm rather than retrying.
+/// What: points the provider at a mock returning HTTP 400 and asserts the
+/// mapped error is `Validation` and classifies as non-retryable.
+/// Test: this is the test.
+#[tokio::test]
+async fn complete_maps_400_to_non_retryable_validation() {
+    let base = spawn_mock("HTTP/1.1 400 Bad Request", "bad request body".to_string()).await;
+    let provider = OpenRouterProvider::with_base_url("sk-test", "anthropic/claude-haiku", base)
+        .expect("provider");
+
+    let err = provider
+        .complete(LlmRequest {
+            model: "anthropic/claude-haiku".to_string(),
+            system: String::new(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "summarize".to_string(),
+            }],
+            temperature: 0.3,
+            max_tokens: 256,
+        })
+        .await
+        .expect_err("400 should error");
+
+    assert!(matches!(err, SmLlmError::Validation(_)));
+    assert!(!err.is_retryable());
+}

--- a/crates/trusty-mpm/src/core/sm/providers/openrouter_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/openrouter_tests.rs
@@ -1,0 +1,146 @@
+//! Tests for the SM OpenRouter provider.
+//!
+//! Why: extracted from `openrouter.rs` to keep that file under the 500-SLOC
+//! cap while exercising the full `complete` path against a local mock server
+//! (no real OpenRouter calls).
+//! What: construction validation, cost estimation, and a round-trip of
+//! `complete` against a one-shot `TcpListener` mock that returns a canned
+//! chat-completions body, plus an error-mapping check for a 429 response.
+//! Test: included as `#[cfg(test)] mod tests` via `#[path]` from `openrouter.rs`.
+
+use super::*;
+use crate::core::sm::providers::ChatMessage;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Spawn a one-shot HTTP mock that replies with `status`/`body` and returns the
+/// bound `http://127.0.0.1:PORT` base URL.
+///
+/// Why: the providers must be tested without touching the real OpenRouter API;
+/// a raw `TcpListener` (matching the trusty-review test pattern) is the
+/// lightest dependency-free mock.
+/// What: binds an ephemeral port, accepts ONE connection, reads the request,
+/// writes a fixed HTTP response, and shuts down.
+/// Test: used by `complete_roundtrips_against_mock` / `complete_maps_http_errors`.
+async fn spawn_mock(status_line: &'static str, body: String) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.expect("accept");
+        let mut buf = vec![0u8; 16384];
+        let _ = sock.read(&mut buf).await;
+        let resp = format!(
+            "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = sock.write_all(resp.as_bytes()).await;
+        let _ = sock.shutdown().await;
+    });
+    format!("http://{addr}")
+}
+
+#[test]
+fn new_rejects_empty_key() {
+    let result = OpenRouterProvider::new("", "anthropic/claude-sonnet-4-6");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, SmLlmError::AccessDenied(_)));
+    assert!(err.is_alarm());
+}
+
+#[test]
+fn new_succeeds_with_valid_key() {
+    let p = OpenRouterProvider::new("sk-test", "anthropic/claude-haiku").expect("ok");
+    assert_eq!(p.name(), "openrouter");
+}
+
+#[test]
+fn cost_estimate_known() {
+    // Sonnet tier billed at (3.00, 15.00) per million.
+    let cost = estimate_cost_usd("anthropic/claude-sonnet-4-6", 1_000_000, 1_000_000);
+    assert!(
+        (cost - 18.0_f64).abs() < 1e-9,
+        "expected $18.00, got {cost}"
+    );
+}
+
+#[test]
+fn cost_estimate_unknown() {
+    assert_eq!(estimate_cost_usd("mystery/model", 100, 100), 0.0);
+}
+
+/// Why: prove `complete` actually drives the HTTP path — building the request,
+/// parsing a real chat-completions response, and computing usage/cost — not
+/// just constructing the type.
+/// What: points the provider at a local mock returning a canned body and
+/// asserts the parsed text + token counts + cost.
+/// Test: this is the test (no real network).
+#[tokio::test]
+async fn complete_roundtrips_against_mock() {
+    let body = serde_json::json!({
+        "choices": [{"message": {"content": "delegated to engineer session"}}],
+        "usage": {"prompt_tokens": 1000, "completion_tokens": 500},
+        "model": "anthropic/claude-sonnet-4-6"
+    })
+    .to_string();
+    let base = spawn_mock("HTTP/1.1 200 OK", body).await;
+
+    let provider =
+        OpenRouterProvider::with_base_url("sk-test", "anthropic/claude-sonnet-4-6", base)
+            .expect("provider");
+
+    let resp = provider
+        .complete(LlmRequest {
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+            system: "You are the SM.".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "plan this goal".to_string(),
+            }],
+            temperature: 0.3,
+            max_tokens: 1024,
+        })
+        .await
+        .expect("complete ok");
+
+    assert_eq!(resp.text, "delegated to engineer session");
+    assert_eq!(resp.input_tokens, 1000);
+    assert_eq!(resp.output_tokens, 500);
+    // 1000/1e6*3.00 + 500/1e6*15.00 = 0.003 + 0.0075 = 0.0105
+    assert!(
+        (resp.cost_usd - 0.0105_f64).abs() < 1e-9,
+        "expected $0.0105, got {}",
+        resp.cost_usd
+    );
+}
+
+/// Why: a 429 from OpenRouter must map to the retryable `RateLimited` variant
+/// so the fallback chain (§5.3) can advance.
+/// What: points the provider at a mock returning HTTP 429 and asserts the
+/// mapped error classifies as retryable, not an alarm.
+/// Test: this is the test.
+#[tokio::test]
+async fn complete_maps_http_errors() {
+    let base = spawn_mock("HTTP/1.1 429 Too Many Requests", "rate limited".to_string()).await;
+    let provider = OpenRouterProvider::with_base_url("sk-test", "anthropic/claude-haiku", base)
+        .expect("provider");
+
+    let err = provider
+        .complete(LlmRequest {
+            model: "anthropic/claude-haiku".to_string(),
+            system: String::new(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "summarize".to_string(),
+            }],
+            temperature: 0.3,
+            max_tokens: 256,
+        })
+        .await
+        .expect_err("429 should error");
+
+    assert!(matches!(err, SmLlmError::RateLimited));
+    assert!(err.is_retryable());
+    assert!(!err.is_alarm());
+}

--- a/crates/trusty-mpm/src/core/sm/providers/openrouter_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/openrouter_tests.rs
@@ -10,7 +10,8 @@
 
 use super::*;
 use crate::core::sm::providers::ChatMessage;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use crate::core::sm::providers::test_support::read_full_request;
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 
 /// Spawn a one-shot HTTP mock that replies with `status`/`body` and returns the
@@ -19,16 +20,16 @@ use tokio::net::TcpListener;
 /// Why: the providers must be tested without touching the real OpenRouter API;
 /// a raw `TcpListener` (matching the trusty-review test pattern) is the
 /// lightest dependency-free mock.
-/// What: binds an ephemeral port, accepts ONE connection, reads the request,
-/// writes a fixed HTTP response, and shuts down.
+/// What: binds an ephemeral port, accepts ONE connection, drains the FULL
+/// request via [`read_full_request`] (headers + body) so the reply never races
+/// ahead of the client's `write`, writes a fixed HTTP response, and shuts down.
 /// Test: used by `complete_roundtrips_against_mock` / `complete_maps_http_errors`.
 async fn spawn_mock(status_line: &'static str, body: String) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("addr");
     tokio::spawn(async move {
         let (mut sock, _) = listener.accept().await.expect("accept");
-        let mut buf = vec![0u8; 16384];
-        let _ = sock.read(&mut buf).await;
+        read_full_request(&mut sock).await;
         let resp = format!(
             "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
@@ -53,21 +54,6 @@ fn new_rejects_empty_key() {
 fn new_succeeds_with_valid_key() {
     let p = OpenRouterProvider::new("sk-test", "anthropic/claude-haiku").expect("ok");
     assert_eq!(p.name(), "openrouter");
-}
-
-#[test]
-fn cost_estimate_known() {
-    // Sonnet tier billed at (3.00, 15.00) per million.
-    let cost = estimate_cost_usd("anthropic/claude-sonnet-4-6", 1_000_000, 1_000_000);
-    assert!(
-        (cost - 18.0_f64).abs() < 1e-9,
-        "expected $18.00, got {cost}"
-    );
-}
-
-#[test]
-fn cost_estimate_unknown() {
-    assert_eq!(estimate_cost_usd("mystery/model", 100, 100), 0.0);
 }
 
 /// Why: prove `complete` actually drives the HTTP path — building the request,

--- a/crates/trusty-mpm/src/core/sm/providers/pricing.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/pricing.rs
@@ -1,0 +1,67 @@
+//! Single source of truth for SM per-call USD cost estimation (DOC-14 §5.5).
+//!
+//! Why: the three SM providers (Anthropic, Bedrock, OpenRouter) all bill the
+//! same Anthropic model FAMILIES (Sonnet / Haiku / Opus) at the same public
+//! per-million-token rates, plus a couple of common OpenAI ids routed through
+//! OpenRouter. SM-2 review flagged that copy-pasting that pricing table into
+//! every provider file means the numbers silently drift out of sync the moment
+//! one vendor changes a price. Centralising the table in one dated module gives
+//! a single place to audit and update, and keeps every provider's cost
+//! telemetry consistent.
+//! What: exposes [`cost_per_million`] (family-substring → `(input, output)` USD
+//! per million tokens) and [`estimate_cost_usd`] (token counts → USD). Both use
+//! the same substring matching the per-provider copies used before, so behaviour
+//! is identical for every previously-priced model.
+//! Test: `pricing_tests.rs` (substring matching, known/unknown estimates, the
+//! OpenRouter-routed OpenAI ids); per-provider tests still assert that their
+//! `complete` round-trips compute the expected cost via this module.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// Pricing as of 2026-06 — update when Anthropic/AWS/OpenRouter publish changes.
+//   - Anthropic:  https://www.anthropic.com/pricing
+//   - AWS Bedrock: https://aws.amazon.com/bedrock/pricing/
+//   - OpenRouter: https://openrouter.ai/models
+// All rates are USD per 1,000,000 tokens, expressed as (input, output).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Approximate `(input, output)` USD cost per million tokens for the model
+/// families the SM routes through any of its three providers.
+///
+/// Why: the SM logs a per-call cost estimate in `LlmResponse` (§5.5); all three
+/// providers need the SAME table so their telemetry agrees and updates land in
+/// one place. Unknown ids fall back to `(0.0, 0.0)` — a missing estimate, not
+/// an error.
+/// What: matches on the model-family substring (so version suffixes such as
+/// `-4-6` still price) for the Anthropic Sonnet/Haiku/Opus tiers, accepting both
+/// the bare `sonnet`/`haiku`/`opus` ids (direct Anthropic + Bedrock) and the
+/// `claude-sonnet`/… ids OpenRouter uses; plus a couple of common OpenAI ids
+/// routed through OpenRouter.
+/// Test: `pricing::tests::cost_per_million_*`.
+pub fn cost_per_million(model: &str) -> (f64, f64) {
+    match model {
+        // Anthropic families (direct, Bedrock, and OpenRouter `claude-*` ids).
+        m if m.contains("sonnet") => (3.00, 15.00),
+        m if m.contains("haiku") => (0.80, 4.00),
+        m if m.contains("opus") => (15.00, 75.00),
+        // Common OpenAI ids routed through OpenRouter.
+        "openai/gpt-5.4-mini-20260317" => (0.75, 4.50),
+        "openai/gpt-5.4-nano-20260317" => (0.20, 1.25),
+        _ => (0.0, 0.0),
+    }
+}
+
+/// Compute a USD cost estimate from token counts and the pricing table.
+///
+/// Why: lets the SM total session cost and rank tiers by cost (§5.5) using one
+/// shared formula across every provider.
+/// What: applies [`cost_per_million`]; returns `0.0` for unknown models.
+/// Test: `pricing::tests::estimate_cost_usd_*`.
+pub fn estimate_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
+    let (in_price, out_price) = cost_per_million(model);
+    (input_tokens as f64 / 1_000_000.0) * in_price
+        + (output_tokens as f64 / 1_000_000.0) * out_price
+}
+
+#[cfg(test)]
+#[path = "pricing_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/sm/providers/pricing.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/pricing.rs
@@ -38,6 +38,12 @@
 /// routed through OpenRouter.
 /// Test: `pricing::tests::cost_per_million_*`.
 pub fn cost_per_million(model: &str) -> (f64, f64) {
+    // NOTE: the family arms below are SUBSTRING matches and are ORDER-SENSITIVE
+    // — the first `contains(...)` that hits wins. We check `sonnet` before
+    // `haiku`/`opus`, which is safe only because we assume Anthropic model ids
+    // name exactly one family (no id contains two of "sonnet"/"haiku"/"opus").
+    // If a future id ever combined family words, the earliest arm here would
+    // mis-price it; reorder/disambiguate before adding such an id.
     match model {
         // Anthropic families (direct, Bedrock, and OpenRouter `claude-*` ids).
         m if m.contains("sonnet") => (3.00, 15.00),

--- a/crates/trusty-mpm/src/core/sm/providers/pricing_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/pricing_tests.rs
@@ -1,0 +1,80 @@
+//! Tests for the centralised SM pricing table (DOC-14 §5.5).
+//!
+//! Why: the pricing table is the single source of truth for per-call cost
+//! across all three providers; these tests pin the family-substring matching
+//! and the estimate arithmetic so a vendor price edit is a deliberate, reviewed
+//! change (the numbers can no longer drift per-provider).
+//! What: substring matching for the Anthropic Sonnet/Haiku/Opus families (bare
+//! and `claude-*` ids), the OpenRouter-routed OpenAI ids, the unknown fallback,
+//! and the `estimate_cost_usd` arithmetic. Float comparisons use an epsilon,
+//! never exact `==`.
+//! Test: included as `#[cfg(test)] mod tests` via `#[path]` from `pricing.rs`.
+
+use super::{cost_per_million, estimate_cost_usd};
+
+const EPS: f64 = 1e-9;
+
+#[test]
+fn cost_per_million_matches_anthropic_families() {
+    // Bare ids (direct Anthropic + Bedrock) and `claude-*` ids (OpenRouter)
+    // must price identically via substring matching.
+    for sonnet in ["claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-6"] {
+        let (i, o) = cost_per_million(sonnet);
+        assert!((i - 3.00).abs() < EPS, "{sonnet} input");
+        assert!((o - 15.00).abs() < EPS, "{sonnet} output");
+    }
+    for haiku in ["claude-haiku-4-5", "us.anthropic.claude-haiku-4-5"] {
+        let (i, o) = cost_per_million(haiku);
+        assert!((i - 0.80).abs() < EPS, "{haiku} input");
+        assert!((o - 4.00).abs() < EPS, "{haiku} output");
+    }
+    for opus in ["claude-opus-4-1", "global.anthropic.claude-opus"] {
+        let (i, o) = cost_per_million(opus);
+        assert!((i - 15.00).abs() < EPS, "{opus} input");
+        assert!((o - 75.00).abs() < EPS, "{opus} output");
+    }
+}
+
+#[test]
+fn cost_per_million_matches_openrouter_openai_ids() {
+    let (i, o) = cost_per_million("openai/gpt-5.4-mini-20260317");
+    assert!((i - 0.75).abs() < EPS);
+    assert!((o - 4.50).abs() < EPS);
+    let (i, o) = cost_per_million("openai/gpt-5.4-nano-20260317");
+    assert!((i - 0.20).abs() < EPS);
+    assert!((o - 1.25).abs() < EPS);
+}
+
+#[test]
+fn cost_per_million_unknown_is_zero() {
+    let (i, o) = cost_per_million("mystery/model");
+    assert!(i.abs() < EPS);
+    assert!(o.abs() < EPS);
+}
+
+#[test]
+fn estimate_cost_usd_known_sonnet() {
+    // 1e6 input @ 3.00 + 1e6 output @ 15.00 = 18.00
+    let cost = estimate_cost_usd("claude-sonnet-4-6", 1_000_000, 1_000_000);
+    assert!((cost - 18.0).abs() < EPS, "expected $18.00, got {cost}");
+}
+
+#[test]
+fn estimate_cost_usd_known_haiku() {
+    // 1e6 input @ 0.80 + 1e6 output @ 4.00 = 4.80
+    let cost = estimate_cost_usd("claude-haiku-4-5", 1_000_000, 1_000_000);
+    assert!((cost - 4.80).abs() < EPS, "expected $4.80, got {cost}");
+}
+
+#[test]
+fn estimate_cost_usd_partial_tokens() {
+    // 2000/1e6*3.00 + 100/1e6*15.00 = 0.006 + 0.0015 = 0.0075
+    let cost = estimate_cost_usd("claude-sonnet-4-6", 2000, 100);
+    assert!((cost - 0.0075).abs() < EPS, "expected $0.0075, got {cost}");
+}
+
+#[test]
+fn estimate_cost_usd_unknown_is_zero() {
+    let cost = estimate_cost_usd("gpt-self-host", 100, 100);
+    assert!(cost.abs() < EPS, "unknown model should cost 0, got {cost}");
+}

--- a/crates/trusty-mpm/src/core/sm/providers/resolve.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve.rs
@@ -195,7 +195,11 @@ pub struct ProviderRegistry {
     /// `ANTHROPIC_API_KEY` value, if present and non-empty.
     pub anthropic_api_key: Option<String>,
     /// Whether AWS credentials are resolvable (the daemon probes this; tests
-    /// set it directly). Only consulted when the `bedrock` feature is enabled.
+    /// set it directly). Only consulted by the `auto` precedence chain when the
+    /// `bedrock` feature is enabled. NOTE: [`Self::from_env`] sets this from a
+    /// conservative env-marker heuristic that cannot see `~/.aws/credentials`,
+    /// ECS/EKS/IMDS sources — set `provider = "bedrock"` explicitly in those
+    /// deployments (see [`Self::from_env`]).
     pub aws_credentials_available: bool,
     /// `OPENROUTER_API_KEY` value, if present and non-empty.
     pub openrouter_api_key: Option<String>,
@@ -210,6 +214,17 @@ impl ProviderRegistry {
     /// as absent) and probes AWS credential presence via `AWS_ACCESS_KEY_ID` /
     /// `AWS_PROFILE` / `AWS_ROLE_ARN` env markers (a cheap, non-async heuristic;
     /// the real SDK chain is the final authority at call time).
+    ///
+    /// This env-marker probe is **intentionally conservative**: it only sees
+    /// credentials advertised through those three env vars. It deliberately
+    /// does NOT detect AWS-native credential sources that the SDK chain resolves
+    /// at call time — the shared-credentials file (`~/.aws/credentials`), an ECS
+    /// task role, EKS IRSA, or EC2 IMDS. In those AWS-native deployments the
+    /// `auto` precedence chain may therefore skip Bedrock even though Bedrock is
+    /// in fact reachable. Operators running in such environments should set
+    /// `[session_manager.inference].provider = "bedrock"` EXPLICITLY to bypass
+    /// the `auto` heuristic and pin Bedrock; the explicit provider path does not
+    /// consult this flag.
     /// Test: side-effect-only env read; logic covered via the explicit-field
     /// constructor used by `registry_*` tests.
     pub fn from_env() -> Self {
@@ -242,6 +257,34 @@ impl ProviderRegistry {
         cfg: &SmInferenceConfig,
         tier: SmModelTier,
     ) -> Result<ResolvedCall, SmLlmError> {
+        let (effective_kind, bare_model) = self.resolve_kind_and_model(cfg, tier)?;
+        let provider = self.construct(effective_kind, &bare_model).await?;
+        Ok(ResolvedCall {
+            provider,
+            model: bare_model,
+            kind: effective_kind,
+        })
+    }
+
+    /// Resolve a tier into its `(effective_kind, bare_model)` WITHOUT building
+    /// the concrete provider.
+    ///
+    /// Why: this is the pure, network-free decision half of [`Self::build`] —
+    /// parsing/validating `provider`, selecting the tier model, applying prefix
+    /// routing, and running the `auto` precedence chain. Splitting it out keeps
+    /// `build` thin and lets tests assert the routing decision (including the
+    /// Bedrock-preference precedence) without `construct`'s real AWS SDK config
+    /// load (which can probe IMDS/network).
+    /// What: (1) parses `cfg.provider`; (2) selects the tier model via
+    /// [`resolve_tier_model`]; (3) routes via [`resolve_provider_and_model`];
+    /// (4) resolves an `Auto` routed kind through [`Self::auto_precedence`].
+    /// Test: `registry_auto_precedence`, `registry_degraded_without_creds`,
+    /// `registry_auto_prefers_bedrock_when_available` (feature-gated).
+    fn resolve_kind_and_model(
+        &self,
+        cfg: &SmInferenceConfig,
+        tier: SmModelTier,
+    ) -> Result<(ProviderKind, String), SmLlmError> {
         let default_provider = ProviderKind::parse(&cfg.provider)?;
         let tier_model = resolve_tier_model(cfg, tier)?;
         let (routed_kind, bare_model) = resolve_provider_and_model(&tier_model, default_provider);
@@ -258,13 +301,7 @@ impl ProviderRegistry {
             bare_model = %bare_model,
             "sm resolve provider+model"
         );
-
-        let provider = self.construct(effective_kind, &bare_model).await?;
-        Ok(ResolvedCall {
-            provider,
-            model: bare_model,
-            kind: effective_kind,
-        })
+        Ok((effective_kind, bare_model))
     }
 
     /// Pick the first provider with credentials in §5.3 precedence order.

--- a/crates/trusty-mpm/src/core/sm/providers/resolve.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve.rs
@@ -232,6 +232,32 @@ impl ProviderRegistry {
         let aws_credentials_available = ["AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_ROLE_ARN"]
             .iter()
             .any(|k| non_empty(k).is_some());
+
+        // Operator hint: the env-marker heuristic missed AWS credentials, but
+        // the process looks AWS-hosted (these markers are set by ECS/EKS/Lambda
+        // and `aws-sdk` web-identity flows whose creds the SDK chain resolves at
+        // call time but this cheap probe cannot see). Nudge the operator to pin
+        // Bedrock explicitly so the `auto` chain doesn't skip it. stderr-only.
+        if !aws_credentials_available {
+            let aws_hosted_markers = [
+                "AWS_EXECUTION_ENV",
+                "ECS_CONTAINER_METADATA_URI",
+                "ECS_CONTAINER_METADATA_URI_V4",
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "AWS_WEB_IDENTITY_TOKEN_FILE",
+            ];
+            if aws_hosted_markers
+                .iter()
+                .any(|k| std::env::var_os(k).is_some())
+            {
+                debug!(
+                    "AWS-hosted environment detected but no file/role-based AWS credentials \
+                     visible to the env heuristic; set [session_manager.inference].provider = \
+                     \"bedrock\" explicitly to pin Bedrock"
+                );
+            }
+        }
+
         Self {
             anthropic_api_key: non_empty("ANTHROPIC_API_KEY"),
             aws_credentials_available,

--- a/crates/trusty-mpm/src/core/sm/providers/resolve.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve.rs
@@ -1,0 +1,381 @@
+//! Provider + model resolution for the SM (DOC-14 §5.2–§5.4).
+//!
+//! Why: SM-2's job is to turn the declarative `[session_manager.inference]`
+//! config (provider selector + per-task model tiers, with optional routing
+//! prefixes and a deprecated `model` alias) into a concrete provider instance
+//! and bare model id for each call — orchestration, summarization, or
+//! compaction. Centralising that logic here keeps later tickets (SM-5
+//! compaction, SM-7 endpoint) from re-deriving the rules.
+//! What: this module exposes (1) [`resolve_provider_and_model`] — pure
+//! prefix-routing of a model string against the config provider; (2)
+//! [`resolve_tier_model`] — per-task tier selection (sm/summary/compaction)
+//! including the deprecated-`model` alias fallback; and (3) [`ProviderRegistry`]
+//! — the credential-aware entry point that builds an `Arc<dyn LlmProvider>` for
+//! a resolved call, applying the `auto` precedence chain (Anthropic → Bedrock →
+//! OpenRouter → degraded) and surfacing degraded mode as a graceful
+//! [`SmLlmError::Degraded`] rather than a panic.
+//! Test: the `tests` module covers all three prefixes + bare routing, tier
+//! defaults, alias fallback, compaction override, provider validation,
+//! precedence, and degraded mode.
+
+use std::sync::Arc;
+
+use tracing::debug;
+#[cfg(not(feature = "bedrock"))]
+use tracing::info;
+#[cfg(feature = "bedrock")]
+use tracing::warn;
+
+use super::{
+    ANTHROPIC_MODEL_PREFIX, AnthropicProvider, BEDROCK_MODEL_PREFIX, LlmProvider,
+    OPENROUTER_MODEL_PREFIX, OpenRouterProvider, ProviderKind, SmLlmError,
+};
+use crate::core::sm::config::SmInferenceConfig;
+
+#[cfg(feature = "bedrock")]
+use super::BedrockProvider;
+
+// ─── Per-task tiers ─────────────────────────────────────────────────────────────
+
+/// The SM's per-task model tiers (DOC-14 §5.4).
+///
+/// Why: the SM runs two classes of call with different cost/quality profiles —
+/// orchestration (Sonnet tier) and summarization/compaction (Haiku tier) — and
+/// must select the right model id per task.
+/// What: identifies which tier a call belongs to so [`resolve_tier_model`] can
+/// pick the matching config field (`sm_model` / `summary_model` /
+/// `compaction_model`).
+/// Test: `tier_*` tests in this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmModelTier {
+    /// SM chat / orchestration — MEDIUM (Sonnet) tier (`sm_model`).
+    Orchestration,
+    /// Session summarization (`last_summary`) — INEXPENSIVE (Haiku) tier
+    /// (`summary_model`).
+    Summary,
+    /// Rolling auto-compaction compression — Haiku tier; uses
+    /// `compaction_model` when set, else falls back to `summary_model`.
+    Compaction,
+}
+
+// ─── Pure prefix routing (DOC-14 §5.2 D5.3) ────────────────────────────────────
+
+/// Resolve `(ProviderKind, bare_model_id)` from a possibly-prefixed model
+/// string and the config provider.
+///
+/// Why: a model id may carry an `anthropic/`, `bedrock/`, or `openrouter/`
+/// prefix to pin a provider for that call, overriding the active `provider`
+/// (D5.3); a bare id routes to `default_provider`. This is the single source of
+/// truth for that rule.
+/// What: strips a known prefix (returning the matching kind + bare id) or
+/// returns `(default_provider, model)` unchanged for a bare id. Note: when
+/// `default_provider` is [`ProviderKind::Auto`], the *kind* stays `Auto` here —
+/// the credential-aware precedence chain is applied later by
+/// [`ProviderRegistry::build`].
+/// Test: `route_anthropic_prefix`, `route_bedrock_prefix`,
+/// `route_openrouter_prefix`, `route_bare_uses_default`.
+pub fn resolve_provider_and_model(
+    model: &str,
+    default_provider: ProviderKind,
+) -> (ProviderKind, String) {
+    if let Some(bare) = model.strip_prefix(ANTHROPIC_MODEL_PREFIX) {
+        return (ProviderKind::Anthropic, bare.to_string());
+    }
+    if let Some(bare) = model.strip_prefix(BEDROCK_MODEL_PREFIX) {
+        return (ProviderKind::Bedrock, bare.to_string());
+    }
+    if let Some(bare) = model.strip_prefix(OPENROUTER_MODEL_PREFIX) {
+        return (ProviderKind::OpenRouter, bare.to_string());
+    }
+    (default_provider, model.to_string())
+}
+
+// ─── Per-task tier selection (DOC-14 §5.4) ──────────────────────────────────────
+
+/// Select the configured model string for a task tier, applying the deprecated
+/// `model` alias and the compaction → summary fallback.
+///
+/// Why: §5.4 specifies exact precedence per tier, plus SM-1's carry-forward
+/// obligation that an empty `sm_model` falls back to the deprecated `model`
+/// alias. Encoding it once avoids drift across call sites.
+/// What: for [`SmModelTier::Orchestration`] returns `sm_model`, or `model`
+/// (deprecated alias) when `sm_model` is empty. For [`SmModelTier::Summary`]
+/// returns `summary_model`. For [`SmModelTier::Compaction`] returns
+/// `compaction_model` when non-empty, else `summary_model`. Returns the
+/// (possibly still prefixed) tier model string; callers pass it to
+/// [`resolve_provider_and_model`]. An empty result means "no model configured
+/// for this tier" and is surfaced as [`SmLlmError::Validation`].
+/// Test: `tier_orchestration_uses_sm_model`,
+/// `tier_orchestration_alias_fallback`, `tier_summary_default`,
+/// `tier_compaction_override`, `tier_compaction_falls_back_to_summary`,
+/// `tier_empty_is_validation_error`.
+pub fn resolve_tier_model(
+    cfg: &SmInferenceConfig,
+    tier: SmModelTier,
+) -> Result<String, SmLlmError> {
+    let chosen = match tier {
+        SmModelTier::Orchestration => {
+            if !cfg.sm_model.trim().is_empty() {
+                cfg.sm_model.clone()
+            } else {
+                // Deprecated `model` alias carry-forward (SM-1 review).
+                cfg.model.clone()
+            }
+        }
+        SmModelTier::Summary => cfg.summary_model.clone(),
+        SmModelTier::Compaction => {
+            if !cfg.compaction_model.trim().is_empty() {
+                cfg.compaction_model.clone()
+            } else {
+                cfg.summary_model.clone()
+            }
+        }
+    };
+    if chosen.trim().is_empty() {
+        return Err(SmLlmError::Validation(format!(
+            "no model configured for the {tier:?} tier \
+             (set sm_model/summary_model/compaction_model in [session_manager.inference])"
+        )));
+    }
+    Ok(chosen)
+}
+
+// ─── A fully-resolved call ─────────────────────────────────────────────────────
+
+/// The outcome of resolving a tier into a concrete provider + bare model id.
+///
+/// Why: SM-5/SM-7 need both the provider handle (to call `complete`) and the
+/// resolved model metadata (for logging the per-call cost/usage with the right
+/// model id) in one value.
+/// What: holds the built `Arc<dyn LlmProvider>`, the bare model id sent
+/// upstream, and the [`ProviderKind`] actually selected (after the `auto`
+/// precedence chain).
+/// Test: `registry_*` tests assert these fields.
+pub struct ResolvedCall {
+    /// The provider to invoke `complete` on.
+    pub provider: Arc<dyn LlmProvider>,
+    /// The bare model id (routing prefix stripped) for this call.
+    pub model: String,
+    /// The provider kind actually selected.
+    pub kind: ProviderKind,
+}
+
+impl std::fmt::Debug for ResolvedCall {
+    /// Why: `Arc<dyn LlmProvider>` is not `Debug`, but call sites (and tests
+    /// via `expect_err`) need a `Debug` `ResolvedCall`. We print the provider's
+    /// `name()` instead of the opaque trait object.
+    /// What: formats `kind`, `model`, and the provider name.
+    /// Test: exercised by `resolve_tests` `expect_err` call sites.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedCall")
+            .field("kind", &self.kind)
+            .field("model", &self.model)
+            .field("provider", &self.provider.name())
+            .finish()
+    }
+}
+
+// ─── Credential-aware registry ─────────────────────────────────────────────────
+
+/// Builds providers for resolved calls, applying credential precedence (§5.3).
+///
+/// Why: turning a resolved `(kind, model)` into a live provider needs
+/// credentials (`ANTHROPIC_API_KEY`, AWS chain, `OPENROUTER_API_KEY`) and the
+/// `auto` precedence chain. Keeping that in one credential-aware type lets SM-7
+/// build it once from the environment and reuse it per request, and lets tests
+/// inject explicit keys instead of reading the real environment.
+/// What: holds the optional provider credentials and the parsed config
+/// `provider`. [`Self::build`] resolves a tier model into a [`ResolvedCall`],
+/// applying the `auto` precedence chain (Anthropic → Bedrock → OpenRouter →
+/// degraded) when neither a prefix nor an explicit `provider` pins one.
+/// Test: `registry_routes_explicit_prefix`, `registry_auto_precedence`,
+/// `registry_degraded_without_creds`, `registry_rejects_unknown_provider`.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderRegistry {
+    /// `ANTHROPIC_API_KEY` value, if present and non-empty.
+    pub anthropic_api_key: Option<String>,
+    /// Whether AWS credentials are resolvable (the daemon probes this; tests
+    /// set it directly). Only consulted when the `bedrock` feature is enabled.
+    pub aws_credentials_available: bool,
+    /// `OPENROUTER_API_KEY` value, if present and non-empty.
+    pub openrouter_api_key: Option<String>,
+}
+
+impl ProviderRegistry {
+    /// Build a registry by reading provider credentials from the environment.
+    ///
+    /// Why: the daemon (SM-7) constructs the registry once from the process
+    /// environment; this keeps that single, documented place.
+    /// What: reads `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` (treating empty
+    /// as absent) and probes AWS credential presence via `AWS_ACCESS_KEY_ID` /
+    /// `AWS_PROFILE` / `AWS_ROLE_ARN` env markers (a cheap, non-async heuristic;
+    /// the real SDK chain is the final authority at call time).
+    /// Test: side-effect-only env read; logic covered via the explicit-field
+    /// constructor used by `registry_*` tests.
+    pub fn from_env() -> Self {
+        let non_empty = |k: &str| std::env::var(k).ok().filter(|v| !v.trim().is_empty());
+        let aws_credentials_available = ["AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_ROLE_ARN"]
+            .iter()
+            .any(|k| non_empty(k).is_some());
+        Self {
+            anthropic_api_key: non_empty("ANTHROPIC_API_KEY"),
+            aws_credentials_available,
+            openrouter_api_key: non_empty("OPENROUTER_API_KEY"),
+        }
+    }
+
+    /// Resolve a tier into a concrete [`ResolvedCall`] (provider + bare model).
+    ///
+    /// Why: this is the API SM-5/SM-7 call per request: "give me the provider
+    /// and model for the orchestration/summary/compaction tier", honouring
+    /// prefixes, the deprecated alias, the `auto` precedence chain, and
+    /// degraded mode.
+    /// What: (1) parses `cfg.provider` (rejecting unknown values); (2) selects
+    /// the tier model via [`resolve_tier_model`]; (3) routes it via
+    /// [`resolve_provider_and_model`]; (4) when the routed kind is `Auto`,
+    /// applies the credential precedence chain; (5) constructs the concrete
+    /// provider, or returns [`SmLlmError::Degraded`] when no credentials exist.
+    /// Test: `registry_routes_explicit_prefix`, `registry_auto_precedence`,
+    /// `registry_degraded_without_creds`, `registry_rejects_unknown_provider`.
+    pub async fn build(
+        &self,
+        cfg: &SmInferenceConfig,
+        tier: SmModelTier,
+    ) -> Result<ResolvedCall, SmLlmError> {
+        let default_provider = ProviderKind::parse(&cfg.provider)?;
+        let tier_model = resolve_tier_model(cfg, tier)?;
+        let (routed_kind, bare_model) = resolve_provider_and_model(&tier_model, default_provider);
+
+        let effective_kind = match routed_kind {
+            ProviderKind::Auto => self.auto_precedence()?,
+            explicit => explicit,
+        };
+
+        debug!(
+            ?tier,
+            requested = %tier_model,
+            ?effective_kind,
+            bare_model = %bare_model,
+            "sm resolve provider+model"
+        );
+
+        let provider = self.construct(effective_kind, &bare_model).await?;
+        Ok(ResolvedCall {
+            provider,
+            model: bare_model,
+            kind: effective_kind,
+        })
+    }
+
+    /// Pick the first provider with credentials in §5.3 precedence order.
+    ///
+    /// Why: `provider = "auto"` (the default) must deterministically prefer
+    /// Anthropic → Bedrock → OpenRouter, then degrade gracefully.
+    /// What: returns the first available kind; [`SmLlmError::Degraded`] when
+    /// none are available. Bedrock is only considered when the `bedrock`
+    /// feature is compiled in.
+    /// Test: `registry_auto_precedence`, `registry_degraded_without_creds`.
+    fn auto_precedence(&self) -> Result<ProviderKind, SmLlmError> {
+        if self.anthropic_api_key.is_some() {
+            return Ok(ProviderKind::Anthropic);
+        }
+        #[cfg(feature = "bedrock")]
+        if self.aws_credentials_available {
+            return Ok(ProviderKind::Bedrock);
+        }
+        if self.openrouter_api_key.is_some() {
+            return Ok(ProviderKind::OpenRouter);
+        }
+        Err(SmLlmError::Degraded(
+            "no ANTHROPIC_API_KEY, AWS credentials, or OPENROUTER_API_KEY available".to_string(),
+        ))
+    }
+
+    /// Construct the concrete provider for an explicit kind + bare model.
+    ///
+    /// Why: separates credential lookup/error-mapping from the precedence
+    /// logic; returns a clear degraded/validation error when the required
+    /// credential is missing or the `bedrock` feature is absent.
+    /// What: builds [`AnthropicProvider`] / [`OpenRouterProvider`] from the
+    /// matching key, or [`BedrockProvider`] (feature-gated). `Auto` cannot
+    /// reach here (it is resolved earlier) and is treated as an internal error.
+    /// Test: `registry_routes_explicit_prefix`,
+    /// `registry_bedrock_prefix_without_feature` (cfg-gated).
+    async fn construct(
+        &self,
+        kind: ProviderKind,
+        bare_model: &str,
+    ) -> Result<Arc<dyn LlmProvider>, SmLlmError> {
+        match kind {
+            ProviderKind::Anthropic => {
+                let key = self.anthropic_api_key.clone().ok_or_else(|| {
+                    SmLlmError::Degraded(
+                        "anthropic provider selected but ANTHROPIC_API_KEY is not set".to_string(),
+                    )
+                })?;
+                Ok(Arc::new(AnthropicProvider::new(
+                    key,
+                    bare_model.to_string(),
+                )?))
+            }
+            ProviderKind::OpenRouter => {
+                let key = self.openrouter_api_key.clone().ok_or_else(|| {
+                    SmLlmError::Degraded(
+                        "openrouter provider selected but OPENROUTER_API_KEY is not set"
+                            .to_string(),
+                    )
+                })?;
+                Ok(Arc::new(OpenRouterProvider::new(
+                    key,
+                    bare_model.to_string(),
+                )?))
+            }
+            ProviderKind::Bedrock => self.construct_bedrock(bare_model).await,
+            ProviderKind::Auto => Err(SmLlmError::Validation(
+                "internal: ProviderKind::Auto must be resolved before construction".to_string(),
+            )),
+        }
+    }
+
+    /// Construct a Bedrock provider (only when the `bedrock` feature is on).
+    ///
+    /// Why: isolates the feature gate so `construct` stays readable, and gives a
+    /// clear error when an operator pins `bedrock/` in a build that lacks the
+    /// feature.
+    /// What: with the feature, awaits [`BedrockProvider::new`] (credential +
+    /// region resolution); without it, returns a [`SmLlmError::Validation`]
+    /// telling the operator to rebuild with `--features bedrock`.
+    /// Test: `registry_bedrock_prefix_without_feature` (no-feature build).
+    #[cfg(feature = "bedrock")]
+    async fn construct_bedrock(
+        &self,
+        bare_model: &str,
+    ) -> Result<Arc<dyn LlmProvider>, SmLlmError> {
+        if !self.aws_credentials_available {
+            warn!("bedrock selected but no AWS credentials detected; attempting SDK chain anyway");
+        }
+        let provider = BedrockProvider::new(bare_model.to_string(), None).await?;
+        Ok(Arc::new(provider))
+    }
+
+    /// No-feature stub: report that Bedrock requires the `bedrock` feature.
+    ///
+    /// Why: an operator who pins a `bedrock/` model in a default build must get
+    /// a clear, actionable error rather than a confusing degraded state.
+    /// What: always returns [`SmLlmError::Validation`].
+    /// Test: `registry_bedrock_prefix_without_feature`.
+    #[cfg(not(feature = "bedrock"))]
+    async fn construct_bedrock(
+        &self,
+        _bare_model: &str,
+    ) -> Result<Arc<dyn LlmProvider>, SmLlmError> {
+        info!("bedrock model selected but the `bedrock` cargo feature is not enabled");
+        Err(SmLlmError::Validation(
+            "bedrock provider requires building trusty-mpm with `--features bedrock`".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+#[path = "resolve_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
@@ -1,0 +1,345 @@
+//! Tests for SM provider/model resolution (DOC-14 §5.2–§5.4).
+//!
+//! Why: resolution is the core of SM-2 — these tests pin every routing,
+//! tier, alias-fallback, precedence, validation, and degraded-mode rule the
+//! spec requires, with no real API calls.
+//! What: prefix routing (all three + bare), tier defaults (Sonnet/Haiku),
+//! deprecated `model` alias fallback, compaction override + fallback, unknown
+//! provider rejection, `auto` precedence ordering, and degraded mode.
+//! Test: included as `#[cfg(test)] mod tests` via `#[path]` from `resolve.rs`.
+
+use super::*;
+use crate::core::sm::config::SmInferenceConfig;
+
+/// A minimal inference config with all tier fields empty, for targeted tests.
+///
+/// Why: most tests want to set exactly one or two fields without inheriting the
+/// §10 defaults (which would mask the behavior under test).
+/// What: returns an `SmInferenceConfig` with empty tier strings and `auto`.
+/// Test: helper for the tests below.
+fn empty_cfg() -> SmInferenceConfig {
+    SmInferenceConfig {
+        provider: "auto".to_string(),
+        sm_model: String::new(),
+        summary_model: String::new(),
+        model: String::new(),
+        fallback: Vec::new(),
+        temperature: 0.3,
+        context_token_budget: 24_000,
+        compaction_model: String::new(),
+        compressed_context_max_tokens: 4_000,
+    }
+}
+
+// ── Prefix routing (D5.3) ──────────────────────────────────────────────────
+
+#[test]
+fn route_anthropic_prefix() {
+    let (kind, model) =
+        resolve_provider_and_model("anthropic/claude-sonnet-4-6", ProviderKind::OpenRouter);
+    assert_eq!(kind, ProviderKind::Anthropic);
+    assert_eq!(model, "claude-sonnet-4-6");
+}
+
+#[test]
+fn route_bedrock_prefix() {
+    let (kind, model) = resolve_provider_and_model(
+        "bedrock/us.anthropic.claude-sonnet-4-6",
+        ProviderKind::Anthropic,
+    );
+    assert_eq!(kind, ProviderKind::Bedrock);
+    assert_eq!(model, "us.anthropic.claude-sonnet-4-6");
+}
+
+#[test]
+fn route_openrouter_prefix() {
+    let (kind, model) =
+        resolve_provider_and_model("openrouter/anthropic/claude-haiku", ProviderKind::Bedrock);
+    assert_eq!(kind, ProviderKind::OpenRouter);
+    assert_eq!(model, "anthropic/claude-haiku");
+}
+
+#[test]
+fn route_bare_uses_default() {
+    // Bare id keeps the supplied default provider verbatim.
+    let (kind, model) = resolve_provider_and_model("claude-sonnet-4-6", ProviderKind::OpenRouter);
+    assert_eq!(kind, ProviderKind::OpenRouter);
+    assert_eq!(model, "claude-sonnet-4-6");
+
+    // Bare id with Auto default stays Auto (precedence applied later).
+    let (kind, _) = resolve_provider_and_model("claude-haiku", ProviderKind::Auto);
+    assert_eq!(kind, ProviderKind::Auto);
+}
+
+// ── Tier selection + alias fallback (§5.4) ─────────────────────────────────
+
+#[test]
+fn tier_orchestration_uses_sm_model() {
+    let mut cfg = empty_cfg();
+    cfg.sm_model = "anthropic/claude-sonnet-4-6".to_string();
+    let m = resolve_tier_model(&cfg, SmModelTier::Orchestration).unwrap();
+    assert_eq!(m, "anthropic/claude-sonnet-4-6");
+}
+
+/// Why: SM-1 review carry-forward — empty `sm_model` must fall back to the
+/// deprecated `model` alias for the orchestration tier.
+/// What: leaves `sm_model` empty, sets `model`, asserts the alias is used.
+/// Test: this is the test.
+#[test]
+fn tier_orchestration_alias_fallback() {
+    let mut cfg = empty_cfg();
+    cfg.sm_model = String::new();
+    cfg.model = "legacy/sonnet".to_string();
+    let m = resolve_tier_model(&cfg, SmModelTier::Orchestration).unwrap();
+    assert_eq!(m, "legacy/sonnet");
+}
+
+/// Why: the §10 defaults must keep working through resolution — `sm_model`
+/// defaults to a Sonnet tier and `summary_model` to a Haiku tier.
+/// What: uses `SmInferenceConfig::default()` and asserts the tier strings carry
+/// the documented Sonnet/Haiku ids.
+/// Test: this is the test.
+#[test]
+fn tier_defaults_are_sonnet_and_haiku() {
+    let cfg = SmInferenceConfig::default();
+    let orch = resolve_tier_model(&cfg, SmModelTier::Orchestration).unwrap();
+    let summ = resolve_tier_model(&cfg, SmModelTier::Summary).unwrap();
+    assert!(
+        orch.contains("sonnet"),
+        "orchestration default is Sonnet: {orch}"
+    );
+    assert!(summ.contains("haiku"), "summary default is Haiku: {summ}");
+}
+
+#[test]
+fn tier_summary_default() {
+    let mut cfg = empty_cfg();
+    cfg.summary_model = "anthropic/claude-haiku".to_string();
+    let m = resolve_tier_model(&cfg, SmModelTier::Summary).unwrap();
+    assert_eq!(m, "anthropic/claude-haiku");
+}
+
+/// Why: a non-empty `compaction_model` must override `summary_model` for the
+/// compaction tier only (§7.3 / §5.4).
+/// What: sets distinct summary + compaction models, asserts compaction wins.
+/// Test: this is the test.
+#[test]
+fn tier_compaction_override() {
+    let mut cfg = empty_cfg();
+    cfg.summary_model = "anthropic/claude-haiku".to_string();
+    cfg.compaction_model = "bedrock/us.anthropic.claude-haiku".to_string();
+    let m = resolve_tier_model(&cfg, SmModelTier::Compaction).unwrap();
+    assert_eq!(m, "bedrock/us.anthropic.claude-haiku");
+}
+
+/// Why: an empty `compaction_model` must fall back to `summary_model`.
+/// What: leaves compaction empty, sets summary, asserts the fallback.
+/// Test: this is the test.
+#[test]
+fn tier_compaction_falls_back_to_summary() {
+    let mut cfg = empty_cfg();
+    cfg.summary_model = "anthropic/claude-haiku".to_string();
+    cfg.compaction_model = String::new();
+    let m = resolve_tier_model(&cfg, SmModelTier::Compaction).unwrap();
+    assert_eq!(m, "anthropic/claude-haiku");
+}
+
+/// Why: a tier with no configured model (and no alias) is a config error, not a
+/// silent empty request.
+/// What: leaves every tier field empty and asserts a `Validation` error.
+/// Test: this is the test.
+#[test]
+fn tier_empty_is_validation_error() {
+    let cfg = empty_cfg();
+    let err = resolve_tier_model(&cfg, SmModelTier::Orchestration).unwrap_err();
+    assert!(matches!(err, SmLlmError::Validation(_)));
+}
+
+// ── Provider validation ────────────────────────────────────────────────────
+
+/// Why: an unknown `provider` string must be rejected as a config error during
+/// `build`, not silently ignored (SM-1 review carry-forward).
+/// What: sets a bogus provider, asserts `build` returns a `Validation` alarm.
+/// Test: this is the test.
+#[tokio::test]
+async fn registry_rejects_unknown_provider() {
+    let cfg = SmInferenceConfig {
+        provider: "totally-bogus".to_string(),
+        ..SmInferenceConfig::default()
+    };
+    let registry = ProviderRegistry {
+        anthropic_api_key: Some("sk-ant".to_string()),
+        aws_credentials_available: false,
+        openrouter_api_key: None,
+    };
+    let err = registry
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect_err("unknown provider rejected");
+    assert!(matches!(err, SmLlmError::Validation(_)));
+    assert!(err.is_alarm());
+}
+
+// ── Registry: explicit prefix routing ──────────────────────────────────────
+
+/// Why: an `anthropic/` prefix must build the Anthropic provider regardless of
+/// the config `provider` and even when an OpenRouter key is also present.
+/// What: routes an explicit `anthropic/` orchestration model and asserts the
+/// resolved kind + bare model + provider name.
+/// Test: this is the test (provider construction only; no API call).
+#[tokio::test]
+async fn registry_routes_explicit_prefix() {
+    let mut cfg = empty_cfg();
+    cfg.provider = "openrouter".to_string();
+    cfg.sm_model = "anthropic/claude-sonnet-4-6".to_string();
+    let registry = ProviderRegistry {
+        anthropic_api_key: Some("sk-ant".to_string()),
+        aws_credentials_available: false,
+        openrouter_api_key: Some("sk-or".to_string()),
+    };
+    let resolved = registry
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect("anthropic prefix builds");
+    assert_eq!(resolved.kind, ProviderKind::Anthropic);
+    assert_eq!(resolved.model, "claude-sonnet-4-6");
+    assert_eq!(resolved.provider.name(), "anthropic");
+}
+
+// ── Registry: auto precedence + degraded ───────────────────────────────────
+
+/// Why: `provider = "auto"` must prefer Anthropic → (Bedrock) → OpenRouter.
+/// What: with only an OpenRouter key present, a bare-model auto config must
+/// resolve to OpenRouter (Anthropic/Bedrock unavailable).
+/// Test: this is the test.
+#[tokio::test]
+async fn registry_auto_precedence() {
+    let mut cfg = empty_cfg();
+    cfg.provider = "auto".to_string();
+    cfg.sm_model = "claude-sonnet-4-6".to_string(); // bare → routes via precedence
+
+    // Only OpenRouter available → OpenRouter selected.
+    let or_only = ProviderRegistry {
+        anthropic_api_key: None,
+        aws_credentials_available: false,
+        openrouter_api_key: Some("sk-or".to_string()),
+    };
+    let resolved = or_only
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect("openrouter selected");
+    assert_eq!(resolved.kind, ProviderKind::OpenRouter);
+    assert_eq!(resolved.provider.name(), "openrouter");
+
+    // Anthropic present → Anthropic wins over OpenRouter.
+    let both = ProviderRegistry {
+        anthropic_api_key: Some("sk-ant".to_string()),
+        aws_credentials_available: false,
+        openrouter_api_key: Some("sk-or".to_string()),
+    };
+    let resolved = both
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect("anthropic wins");
+    assert_eq!(resolved.kind, ProviderKind::Anthropic);
+}
+
+/// Why: with NO provider credentials, `auto` must degrade gracefully — a
+/// reportable `Degraded` error, never a panic (§5.3 / G6).
+/// What: builds against an empty registry and asserts `is_degraded()`.
+/// Test: this is the test.
+#[tokio::test]
+async fn registry_degraded_without_creds() {
+    let mut cfg = empty_cfg();
+    cfg.provider = "auto".to_string();
+    cfg.sm_model = "claude-sonnet-4-6".to_string();
+    let registry = ProviderRegistry::default(); // no creds
+    let err = registry
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect_err("no creds → degraded");
+    assert!(err.is_degraded(), "expected degraded, got: {err}");
+    assert!(!err.is_alarm());
+    assert!(!err.is_retryable());
+}
+
+/// Why: explicitly selecting `anthropic` without the key must degrade (not
+/// silently fall through to another provider).
+/// What: sets `provider = "anthropic"` with no key; asserts `Degraded`.
+/// Test: this is the test.
+#[tokio::test]
+async fn registry_explicit_anthropic_without_key_degrades() {
+    let mut cfg = empty_cfg();
+    cfg.provider = "anthropic".to_string();
+    cfg.sm_model = "claude-sonnet-4-6".to_string();
+    let registry = ProviderRegistry {
+        anthropic_api_key: None,
+        aws_credentials_available: false,
+        openrouter_api_key: Some("sk-or".to_string()),
+    };
+    let err = registry
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect_err("anthropic without key degrades");
+    assert!(err.is_degraded(), "expected degraded, got: {err}");
+}
+
+// ── Bedrock feature gating ─────────────────────────────────────────────────
+
+/// Why: when built WITHOUT the `bedrock` feature, pinning a `bedrock/` model
+/// must produce a clear, actionable validation error (rebuild with the
+/// feature), not a confusing degraded/transport failure.
+/// What: routes a `bedrock/` model and asserts a `Validation` error mentioning
+/// the feature flag.
+/// Test: only compiled in the default (no-bedrock) build.
+#[cfg(not(feature = "bedrock"))]
+#[tokio::test]
+async fn registry_bedrock_prefix_without_feature() {
+    let mut cfg = empty_cfg();
+    cfg.provider = "auto".to_string();
+    cfg.sm_model = "bedrock/us.anthropic.claude-sonnet-4-6".to_string();
+    let registry = ProviderRegistry {
+        anthropic_api_key: None,
+        aws_credentials_available: true,
+        openrouter_api_key: None,
+    };
+    let err = registry
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect_err("bedrock without feature errors");
+    match err {
+        SmLlmError::Validation(msg) => {
+            assert!(msg.contains("bedrock"), "msg should mention bedrock: {msg}");
+            assert!(msg.contains("feature"), "msg should mention feature: {msg}");
+        }
+        other => panic!("expected Validation, got {other:?}"),
+    }
+}
+
+/// Why: when built WITH the `bedrock` feature, `auto` precedence must prefer
+/// Bedrock over OpenRouter when AWS creds are available and Anthropic is not.
+/// What: routes a bare-model auto config with only AWS creds + an OpenRouter
+/// key, asserts Bedrock is selected. (Construction attempts the SDK chain; we
+/// only assert the *kind*, so this stays offline-safe via the resolution path —
+/// the actual client build uses the default chain which succeeds at config
+/// load without network.)
+/// Test: only compiled in the `--features bedrock` build.
+#[cfg(feature = "bedrock")]
+#[tokio::test]
+async fn registry_auto_prefers_bedrock_when_available() {
+    let mut cfg = empty_cfg();
+    cfg.provider = "auto".to_string();
+    cfg.sm_model = "bedrock/us.anthropic.claude-sonnet-4-6".to_string();
+    let registry = ProviderRegistry {
+        anthropic_api_key: None,
+        aws_credentials_available: true,
+        openrouter_api_key: Some("sk-or".to_string()),
+    };
+    let resolved = registry
+        .build(&cfg, SmModelTier::Orchestration)
+        .await
+        .expect("bedrock builds via SDK config load");
+    assert_eq!(resolved.kind, ProviderKind::Bedrock);
+    assert_eq!(resolved.model, "us.anthropic.claude-sonnet-4-6");
+    assert_eq!(resolved.provider.name(), "bedrock");
+}

--- a/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
@@ -319,14 +319,14 @@ async fn registry_bedrock_prefix_without_feature() {
 /// Why: when built WITH the `bedrock` feature, `auto` precedence must prefer
 /// Bedrock over OpenRouter when AWS creds are available and Anthropic is not.
 /// What: routes a bare-model auto config with only AWS creds + an OpenRouter
-/// key, asserts Bedrock is selected. (Construction attempts the SDK chain; we
-/// only assert the *kind*, so this stays offline-safe via the resolution path —
-/// the actual client build uses the default chain which succeeds at config
-/// load without network.)
+/// key and asserts the resolved *kind* + bare model are Bedrock. Uses
+/// `resolve_kind_and_model` (the pure decision half of `build`) so the test
+/// makes ZERO network calls — it never reaches `construct`, which would load
+/// the real AWS SDK config chain (potentially probing IMDS/network in CI).
 /// Test: only compiled in the `--features bedrock` build.
 #[cfg(feature = "bedrock")]
-#[tokio::test]
-async fn registry_auto_prefers_bedrock_when_available() {
+#[test]
+fn registry_auto_prefers_bedrock_when_available() {
     let mut cfg = empty_cfg();
     cfg.provider = "auto".to_string();
     cfg.sm_model = "bedrock/us.anthropic.claude-sonnet-4-6".to_string();
@@ -335,11 +335,9 @@ async fn registry_auto_prefers_bedrock_when_available() {
         aws_credentials_available: true,
         openrouter_api_key: Some("sk-or".to_string()),
     };
-    let resolved = registry
-        .build(&cfg, SmModelTier::Orchestration)
-        .await
-        .expect("bedrock builds via SDK config load");
-    assert_eq!(resolved.kind, ProviderKind::Bedrock);
-    assert_eq!(resolved.model, "us.anthropic.claude-sonnet-4-6");
-    assert_eq!(resolved.provider.name(), "bedrock");
+    let (kind, model) = registry
+        .resolve_kind_and_model(&cfg, SmModelTier::Orchestration)
+        .expect("auto precedence resolves to bedrock");
+    assert_eq!(kind, ProviderKind::Bedrock);
+    assert_eq!(model, "us.anthropic.claude-sonnet-4-6");
 }

--- a/crates/trusty-mpm/src/core/sm/providers/test_support.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/test_support.rs
@@ -1,0 +1,84 @@
+//! Shared test-only helpers for the SM provider mock servers.
+//!
+//! Why: the Anthropic and OpenRouter provider tests both drive `complete`
+//! against a raw `TcpListener` HTTP mock. A naive mock that does a single
+//! `read` may reply before the client has finished writing the request
+//! (headers + body), which surfaces as intermittent connection-reset flakiness.
+//! Centralising a robust "read the whole request first" helper keeps both mocks
+//! deterministic without pulling in an external mock-server crate.
+//! What: [`read_full_request`] loops reading from the socket until the HTTP
+//! header terminator (`\r\n\r\n`) is seen, then drains any declared
+//! `Content-Length` body bytes, so the server only replies once the full
+//! request has arrived.
+//! Test: exercised transitively by every `complete_*` provider round-trip test.
+
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpStream;
+
+/// Read an entire HTTP/1.1 request (headers + any `Content-Length` body) from
+/// `sock` before the caller writes a response.
+///
+/// Why: a single `sock.read()` can return before the client has flushed the
+/// full request, letting the mock reply early and reset the connection — the
+/// source of the flaky-mock finding. Reading to the header terminator (and then
+/// the declared body) makes the mock wait for the complete request.
+/// What: appends reads into a buffer until `\r\n\r\n` appears, parses an
+/// optional case-insensitive `Content-Length`, then keeps reading until the
+/// buffer holds the full header + body (or the peer closes / errors). All I/O
+/// errors are swallowed: this is a best-effort test mock, and the assertions
+/// live in the response path.
+/// Test: used by the Anthropic + OpenRouter `complete_*` tests.
+pub async fn read_full_request(sock: &mut TcpStream) {
+    let mut buf: Vec<u8> = Vec::with_capacity(8192);
+    let mut chunk = [0u8; 4096];
+
+    // Phase 1: read until the end of the request headers (`\r\n\r\n`).
+    let header_end = loop {
+        if let Some(pos) = find_header_end(&buf) {
+            break pos;
+        }
+        match sock.read(&mut chunk).await {
+            Ok(0) => return, // peer closed before completing headers
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(_) => return,
+        }
+    };
+
+    // Phase 2: if a Content-Length is present, drain that many body bytes.
+    let content_len = parse_content_length(&buf[..header_end]);
+    let want_total = header_end + content_len;
+    while buf.len() < want_total {
+        match sock.read(&mut chunk).await {
+            Ok(0) => return, // peer closed; reply with what we have
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(_) => return,
+        }
+    }
+}
+
+/// Return the byte offset just past the `\r\n\r\n` header terminator, if present.
+///
+/// Why: marks where headers end and the body begins.
+/// What: scans for the 4-byte CRLFCRLF sequence; returns `Some(end)` past it.
+/// Test: exercised via [`read_full_request`].
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4)
+}
+
+/// Parse a case-insensitive `Content-Length` header value from header bytes.
+///
+/// Why: lets the mock drain the full request body before replying.
+/// What: scans CRLF-delimited header lines for `content-length:` and parses the
+/// decimal value; returns `0` when absent or unparseable.
+/// Test: exercised via [`read_full_request`].
+fn parse_content_length(header_bytes: &[u8]) -> usize {
+    let headers = String::from_utf8_lossy(header_bytes);
+    for line in headers.split("\r\n") {
+        if let Some((name, value)) = line.split_once(':')
+            && name.trim().eq_ignore_ascii_case("content-length")
+        {
+            return value.trim().parse().unwrap_or(0);
+        }
+    }
+    0
+}


### PR DESCRIPTION
## Summary

Implements **SM-2** (#1285, part of epic #1283): the Session Manager's multi-provider inference layer with per-task model tiers (DOC-14 §5). New module: `crates/trusty-mpm/src/core/sm/providers/`.

Per the SM-2 PM decision, this **vendors a focused copy** of the `LlmProvider` abstraction (trait + request/response + retryable/alarm error classification, ported from `trusty-review/src/llm/`) instead of extracting trusty-review's module into a shared crate now (too high blast-radius for SM-2). The shared-crate extraction dedup is filed as a follow-up: **#1302** (a `// TODO(follow-up #1302)` marks the vendored module).

## What's included

- **`error.rs`** — `SmLlmError` (thiserror) with trusty-review's retryable-vs-alarm classification, plus a graceful `Degraded` variant for the no-credentials path.
- **`mod.rs`** — the async `LlmProvider` trait (`complete()` → text + token usage + latency + cost), `LlmRequest`/`LlmResponse`/`ChatMessage` shapes, and `ProviderKind` (validated `provider` config string).
- **`openrouter.rs`** — `OpenRouterProvider` (OpenAI-compatible, configurable base URL for mocks).
- **`anthropic.rs`** — **NEW** `AnthropicProvider`: native `/v1/messages` (`x-api-key` + `anthropic-version: 2023-06-01`, `ANTHROPIC_BASE_URL` override), porting the trusty-agents `anthropic_native` request/response shape.
- **`bedrock.rs`** — `BedrockProvider` (AWS Converse) behind a **new opt-in `bedrock` cargo feature** so `aws-sdk-bedrockruntime` weight stays out of `default`.
- **`resolve.rs`** — the resolution core + `ProviderRegistry`.

## Provider / resolution API (for SM-5 / SM-7)

- `resolve_provider_and_model(model, default_provider) -> (ProviderKind, bare_model)` — pure prefix routing.
- `resolve_tier_model(cfg, tier) -> Result<String>` — per-task tier + alias/compaction fallback.
- `ProviderRegistry::from_env()` / `.build(cfg, tier) -> Result<ResolvedCall>` — credential-aware construction with auto-precedence + degraded mode.

### How the rules work
- **Prefix routing (§5.2 D5.3):** `anthropic/…`→Anthropic, `bedrock/…`→Bedrock, `openrouter/…`→OpenRouter; a **bare** model routes to the config `provider`.
- **Tiers (§5.4):** `sm_model` (Sonnet) for orchestration, `summary_model` (Haiku) for summarization, `compaction_model` overrides compaction only when non-empty (else falls back to `summary_model`).
- **Deprecated `model` alias:** when `sm_model` is empty, the orchestration tier falls back to `model` (SM-1 review carry-forward).
- **Provider validation:** an unknown `provider` string is rejected as a `Validation` config error via `ProviderKind::parse` (SM-1 review carry-forward).
- **`auto` precedence (§5.3):** Anthropic (`ANTHROPIC_API_KEY`) → Bedrock (AWS creds, feature-gated) → OpenRouter (`OPENROUTER_API_KEY`) → **degraded** (`SmLlmError::Degraded`, never a panic).
- **Cost/usage** logged per call to **stderr** via `tracing` (daemon-side; stdout stays clean).

No endpoint wiring yet — that's SM-7 (#1290).

## Test evidence (raw)

```
$ cargo clippy -p trusty-mpm --all-targets -- -D warnings
    Finished `dev` profile  (only the known dual-build-target Cargo.toml note)

$ cargo clippy -p trusty-mpm --all-targets --features bedrock -- -D warnings
    Finished `dev` profile  (only the known dual-build-target Cargo.toml note)

$ cargo test -p trusty-mpm sm::providers
running 36 tests
test result: ok. 36 passed; 0 failed; 0 ignored

$ cargo test -p trusty-mpm --features bedrock sm::providers
running 44 tests
test result: ok. 44 passed; 0 failed; 0 ignored

$ cargo test -p trusty-mpm --lib
test result: ok. 1085 passed; 0 failed; 0 ignored

$ cargo build -p trusty-mpm --features bedrock
    Finished `dev` profile

$ bash scripts/check_line_cap.sh
line-cap: 15 allowlisted, 0 violations — OK.   (exit 0)
```

## Follow-up filed
- #1302 — Extract shared LlmProvider abstraction into a common crate (SM-2 vendored a copy).

## Notes / assumptions
- **Mock testing:** no mock-server crate is in the workspace, so providers take a configurable base URL and tests drive them against a one-shot `tokio::net::TcpListener` (the trusty-review pattern). Bedrock's offline path is exercised with a `no_credentials()` SDK client (errors before any TCP I/O); a full Converse replay would need an SDK replay client, deferred.
- **AWS-creds probe** in `ProviderRegistry::from_env()` is a cheap env-marker heuristic (`AWS_ACCESS_KEY_ID`/`AWS_PROFILE`/`AWS_ROLE_ARN`); the real SDK chain remains the authority at call time.
- Pricing tables are family-substring estimates (Sonnet/Haiku/Opus) for telemetry only.

Closes #1285. Refs #1283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)