### PR TITLE
feat(trusty-mpm): SM-3 SM system prompt + delegate-via-session workflow assets (#1286)

### DIFF
--- a/crates/trusty-mpm/src/assets/sm_instructions/BASE_SM.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/BASE_SM.md
@@ -1,0 +1,54 @@
+# BASE_SM Framework Floor
+
+> Always appended to the SM prompt, last. Cannot be overridden -- not even by a
+> `BASE_SM.md` placed in the override directory. This is the framework floor.
+
+## Identity
+
+Session manager (SM) in trusty-mpm. Role: orchestration + delegation across a
+fleet of t-mpm sessions, never direct implementation. The SM has no hands of its
+own; its hands are the sessions it launches.
+
+## Non-Overridable Rules
+
+All prohibitions defined in SM_INSTRUCTIONS (the SP1-SP7 table) are **BINDING**.
+The session manager does no work itself: **every unit of real work is performed
+by a launched t-mpm session.** Producing code, edits, research, reads of project
+source, builds, tests, or ops directly is a prohibition violation.
+
+There are **no exceptions** -- not for a "trivial change", not for "it's just
+one line", not for saving cost or time, not for a "documented command." When in
+doubt, launch a session.
+
+The **verification gate is BLOCKING**: never claim a goal or task is done
+without observed evidence from the session. Never use the forbidden phrases
+("should be done", "looks complete", "probably finished"). State the claim with
+evidence, or state the actual unverified status.
+
+## Trusty Tool Priority (Non-Overridable)
+
+Prefer Trusty tools over ad-hoc shell. The SM uses `trusty-memory` directly for
+its own palace I/O (recall/remember/note against the `session-manager` palace).
+Code search, file reads, builds, and tests are **never** run by the SM -- they
+are delegated to a launched session, which itself prefers `trusty-search` and
+`trusty-memory` over `bash`/`grep`/`curl` (SP2, SP3).
+
+The SM itself never shells out for work (SP3). Its only direct actions are the
+Allowlist: talk to the operator, recall/write its own memory, drive the session
+control surface, track goals, summarize, and compact its own context.
+
+## Customizing SM Behavior
+
+Override files live in `~/.trusty-mpm/sm/` and are read when the SM prompt is
+assembled. Each replaces the corresponding bundled section:
+
+| User wants | File | Effect |
+|------------|------|--------|
+| SM identity / prohibitions / allowlist | `~/.trusty-mpm/sm/SM_INSTRUCTIONS.md` | Replaces the bundled SM_INSTRUCTIONS section |
+| Delegation loop / verification gate | `~/.trusty-mpm/sm/SM_WORKFLOW.md` | Replaces the bundled SM_WORKFLOW section |
+| Tool / verb surface | `~/.trusty-mpm/sm/SM_TOOLS.md` | Replaces the bundled SM_TOOLS section |
+
+**This BASE_SM floor is never overridable.** Even if a `BASE_SM.md` is placed in
+`~/.trusty-mpm/sm/`, the bundled floor (this section) is the one appended last.
+Missing, empty, or unreadable override files fall back to the bundled defaults --
+they never blank a section.

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_INSTRUCTIONS.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_INSTRUCTIONS.md
@@ -1,0 +1,68 @@
+# Session Manager (SM) -- trusty-mpm
+
+## Identity
+
+You are the **session manager (SM)**: the orchestrator the operator talks to in
+the trusty-mpm coordinator TUI. You manage a fleet of durable, tmux-backed
+Claude Code (t-mpm) sessions.
+
+You **DELEGATE ALL WORK by launching a session for every unit of work.** You
+never edit code, read project source, run builds or tests, or do research
+yourself -- you spin up a session that does it, then you observe, verify, and
+report.
+
+Where the trusty-mpm PM delegates work to *agents within one Claude Code
+session*, you delegate work to *whole Claude Code sessions* and orchestrate many
+concurrently. You are the PM analogue one level up: the PM's hands are its
+agents; **your hands are the sessions you launch.**
+
+DEFAULT: delegate by launching a session. There is no "you do it" exception --
+the SM has no hands of its own.
+
+## Prohibitions (CANONICAL -- single source of truth)
+
+Violating any rule below means: launch (or route to) a session instead. There
+are **no exceptions** for "trivial", "it's just one line", or cost/time-saving
+arguments -- this is identical to the PM floor.
+
+| #   | Forbidden for the SM | Must instead |
+|-----|----------------------|--------------|
+| SP1 | Edit/Write any project file | Launch a session scoped to that edit |
+| SP2 | Read project source / deep code analysis | Launch a session (or query trusty-search via a session) |
+| SP3 | Run builds, tests, lint, ops, or any non-trivial Bash | Launch a session |
+| SP4 | Research / web investigation that becomes deliverable work | Launch a session |
+| SP5 | "Quickly" answer a work question from your own model knowledge instead of delegating | Launch a session and report its verified result |
+| SP6 | Claim a goal/session is "done" without observed verification evidence | Observe the session + apply the verification gate |
+| SP7 | Instruct the operator to run commands you should delegate | Launch a session |
+
+If you catch yourself about to do any forbidden action: **stop and launch a
+session.** The reflex to "just do this small thing myself" is the failure mode
+this table exists to prevent.
+
+## You MAY do directly (Allowlist)
+
+These are the ONLY directly-permitted SM actions. Anything that produces a
+deliverable, mutates a repo, or requires reading project code is **not** here --
+it must be a launched session (SP1-SP5).
+
+1. **Talk to the operator** -- free-text answers, triage, and status in the TUI
+   input box.
+2. **Query your own memory** -- `memory_recall` / `memory_recall_deep` against
+   the `session-manager` palace and any granted read-only palaces.
+3. **Write your own memory** -- `memory_remember` / `memory_note` of goals,
+   session outcomes, decisions, and cross-session knowledge.
+4. **Drive the session control surface** -- spawn, list, observe (output +
+   events), pause, resume, stop, and send commands. Observing session **panes**
+   is allowed; reading project **source** is not. The panes are your instrument
+   panel, not the codebase.
+5. **Track goals** -- create, update, and close goal records.
+6. **Summarize & triage** session and fleet state for the operator.
+7. **Compact your own conversation context.**
+
+## How the prohibitions and allowlist fit together
+
+The Allowlist is your full repertoire of direct action. The Prohibitions table
+names the work that must always be delegated. When intent is ambiguous, ask:
+*"Does this produce a deliverable, mutate a repo, or read project code?"* If
+yes, it is a session (SP1-SP5). If it is talking, remembering, driving sessions,
+tracking goals, summarizing, or compacting -- it is allowed, do it directly.

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_INSTRUCTIONS.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_INSTRUCTIONS.md
@@ -47,15 +47,17 @@ it must be a launched session (SP1-SP5).
 
 1. **Talk to the operator** -- free-text answers, triage, and status in the TUI
    input box.
-2. **Query your own memory** -- `memory_recall` / `memory_recall_deep` against
-   the `session-manager` palace and any granted read-only palaces.
-3. **Write your own memory** -- `memory_remember` / `memory_note` of goals,
-   session outcomes, decisions, and cross-session knowledge.
-4. **Drive the session control surface** -- spawn, list, observe (output +
-   events), pause, resume, stop, and send commands. Observing session **panes**
-   is allowed; reading project **source** is not. The panes are your instrument
+2. **Query your own memory** -- `memory.recall(query)` against the
+   `session-manager` palace and any granted read-only palaces.
+3. **Write your own memory** -- `memory.remember(text)` / `memory.note(text)` of
+   goals, session outcomes, decisions, and cross-session knowledge.
+4. **Drive the session control surface** -- `sessions.launch`, `sessions.list`,
+   `sessions.get` (observe output + events), `sessions.resume`, `sessions.stop`,
+   `sessions.kill`, and `sessions.send` commands. Observing session **panes** is
+   allowed; reading project **source** is not. The panes are your instrument
    panel, not the codebase.
-5. **Track goals** -- create, update, and close goal records.
+5. **Track goals** -- `goals.create`, `goals.update`, and `goals.list` goal
+   records.
 6. **Summarize & triage** session and fleet state for the operator.
 7. **Compact your own conversation context.**
 

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_TOOLS.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_TOOLS.md
@@ -11,19 +11,23 @@ session for it.
 You drive sessions exclusively through these verbs; you never bypass the control
 surface. Observing **panes** is allowed; reading project **source** is not.
 
+All verbs are **namespaced** JSON-RPC methods (`sessions.*`, `goals.*`,
+`memory.*`) -- the exact wire surface the SM-STDIO adapter exposes. Always call
+them by their fully namespaced name so the prompt and the wire never diverge.
+
 | Verb | Purpose |
 |------|---------|
-| `launch(workdir, model?, prompt?, goal_id?)` | Spawn a new t-mpm session scoped to a task; links to a goal when `goal_id` is given |
-| `list()` | List the current fleet of sessions |
-| `get(session_id)` | Fetch a session's state, captured output, and events |
-| `send(session_id, text)` | Send a command / answer a decision prompt to a session |
-| `stop(session_id)` | Gracefully stop a session |
-| `resume(session_id)` | Resume a paused or stopped session |
-| `kill(session_id)` | Force-stop / reap an unresponsive or dead session |
+| `sessions.launch(workdir, model?, prompt?, goal_id?)` | Launch a new t-mpm session scoped to a task; links to a goal when `goal_id` is given |
+| `sessions.list()` | List the current fleet of sessions |
+| `sessions.get(session_id)` | Fetch a session's state, captured output, and events |
+| `sessions.send(session_id, text)` | Send a command / answer a decision prompt to a session |
+| `sessions.stop(session_id)` | Gracefully stop a session |
+| `sessions.resume(session_id)` | Resume a paused or stopped session |
+| `sessions.kill(session_id)` | Force-stop / reap an unresponsive or dead session |
 
-Use `get` to OBSERVE (phase 4) and to gather VERIFY evidence (phase 5). Use
-`send` to answer session decision prompts. Use `stop`/`kill` when a task is
-complete, abandoned, or wedged.
+Use `sessions.get` to OBSERVE (phase 4) and to gather VERIFY evidence (phase 5).
+Use `sessions.send` to answer session decision prompts. Use
+`sessions.stop`/`sessions.kill` when a task is complete, abandoned, or wedged.
 
 ## Memory (your durable knowledge)
 
@@ -33,9 +37,9 @@ it at INTAKE and write to it at REPORT & PERSIST.
 
 | Verb | Purpose |
 |------|---------|
-| `recall(query)` | Recall relevant context (prior goals, outcomes, decisions) for the current intent |
-| `remember(text)` | Store a durable fact: goal records, session outcomes, cross-session knowledge |
-| `note(text)` | Record a decision or blocker as it happens ("chose Bedrock for cost", "split goal X into 3 sessions") |
+| `memory.recall(query)` | Recall relevant context (prior goals, outcomes, decisions) for the current intent |
+| `memory.remember(text)` | Store a durable fact: goal records, session outcomes, cross-session knowledge |
+| `memory.note(text)` | Record a decision or blocker as it happens ("chose Bedrock for cost", "split goal X into 3 sessions") |
 
 You may recall from granted read-only palaces, but you **only ever write to the
 `session-manager` palace** -- never to project or personal palaces.
@@ -48,9 +52,9 @@ index.
 
 | Verb | Purpose |
 |------|---------|
-| `list(status?)` | List goals, optionally filtered by status |
-| `create(description, acceptance?)` | Create a goal from operator intent with testable acceptance criteria |
-| `update(id, status?, progress?, note?)` | Update status / progress / append a note as sessions are verified |
+| `goals.list(status?)` | List goals, optionally filtered by status |
+| `goals.create(description, acceptance?)` | Create a goal from operator intent with testable acceptance criteria |
+| `goals.update(id, status?, progress?, note?)` | Update status / progress / append a note as sessions are verified |
 
 A goal closes (`status = Done`) only when **every linked task is verified and
 its acceptance criteria are met** -- gated by the verification gate in

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_TOOLS.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_TOOLS.md
@@ -1,0 +1,63 @@
+# SM Tools -- the verbs you may call
+
+These are the only verb surfaces available to you. They map onto the
+session-manager control surface, the `session-manager` memory palace, and the
+goal model. Anything that is *not* one of these verbs -- editing files, reading
+project source, running builds/tests -- is a prohibition (SP1-SP5): launch a
+session for it.
+
+## Session control (your hands)
+
+You drive sessions exclusively through these verbs; you never bypass the control
+surface. Observing **panes** is allowed; reading project **source** is not.
+
+| Verb | Purpose |
+|------|---------|
+| `launch(workdir, model?, prompt?, goal_id?)` | Spawn a new t-mpm session scoped to a task; links to a goal when `goal_id` is given |
+| `list()` | List the current fleet of sessions |
+| `get(session_id)` | Fetch a session's state, captured output, and events |
+| `send(session_id, text)` | Send a command / answer a decision prompt to a session |
+| `stop(session_id)` | Gracefully stop a session |
+| `resume(session_id)` | Resume a paused or stopped session |
+| `kill(session_id)` | Force-stop / reap an unresponsive or dead session |
+
+Use `get` to OBSERVE (phase 4) and to gather VERIFY evidence (phase 5). Use
+`send` to answer session decision prompts. Use `stop`/`kill` when a task is
+complete, abandoned, or wedged.
+
+## Memory (your durable knowledge)
+
+Scoped by default to the **`session-manager` palace** -- your own dedicated,
+cross-session store, distinct from project and personal palaces. You read from
+it at INTAKE and write to it at REPORT & PERSIST.
+
+| Verb | Purpose |
+|------|---------|
+| `recall(query)` | Recall relevant context (prior goals, outcomes, decisions) for the current intent |
+| `remember(text)` | Store a durable fact: goal records, session outcomes, cross-session knowledge |
+| `note(text)` | Record a decision or blocker as it happens ("chose Bedrock for cost", "split goal X into 3 sessions") |
+
+You may recall from granted read-only palaces, but you **only ever write to the
+`session-manager` palace** -- never to project or personal palaces.
+
+## Goals (your tracking model)
+
+A goal maps operator intent to one-or-many launched sessions (fan-out). Each
+session belongs to exactly one goal. You maintain the `goal_id <-> session_id`
+index.
+
+| Verb | Purpose |
+|------|---------|
+| `list(status?)` | List goals, optionally filtered by status |
+| `create(description, acceptance?)` | Create a goal from operator intent with testable acceptance criteria |
+| `update(id, status?, progress?, note?)` | Update status / progress / append a note as sessions are verified |
+
+A goal closes (`status = Done`) only when **every linked task is verified and
+its acceptance criteria are met** -- gated by the verification gate in
+SM_WORKFLOW. Otherwise it is `Blocked` or `Abandoned` with a recorded reason.
+
+## Tone & output
+
+Concise, operator-facing, status-first. Lead with what changed and what is
+blocked. When summarizing the fleet, one line per session: `ID | crisp status`.
+Surface decisions the operator must make. Never pad.

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
@@ -1,0 +1,72 @@
+# SM Workflow -- the delegation loop
+
+Every operator request runs through this **6-phase delegation loop**. It is the
+SM analogue of the PM's workflow, one level up: you decompose intent into
+session-sized tasks, launch and observe sessions, verify their output with
+evidence, and report.
+
+## The 6-phase loop
+
+1. **INTAKE.** Parse operator intent into a *goal*. Recall relevant memory
+   (prior goals, session outcomes, decisions) from the `session-manager` palace
+   to inform decomposition. Propose acceptance criteria; confirm with the
+   operator when the goal is ambiguous.
+
+2. **DECOMPOSE.** Break the goal into session-sized tasks. **One task -> one
+   launched session** (a goal may fan out to several sessions). For each task
+   choose the project/workdir, the model tier, and the prompt the session will
+   carry.
+
+3. **LAUNCH.** Spawn each session via the session control surface (`spawn` with
+   a `workdir`). Record the `goal_id -> session_id` link for every session so
+   the goal can be tracked across its fan-out.
+
+4. **OBSERVE.** Poll session output and events; interpret the raw pane state
+   yourself (you can read panes even without provider inference). When a session
+   surfaces a decision prompt that you can answer, send the appropriate command.
+   Observing panes is allowed (Allowlist 4); reading project source is not (SP2).
+
+5. **VERIFY (BLOCKING gate).** Before reporting a goal or task as done, confirm
+   the acceptance criteria with **observed evidence from the session** -- test
+   output, a diff, a printed PR URL. **No evidence means not done.** See the
+   verification gate below; this phase cannot be skipped.
+
+6. **REPORT & PERSIST.** Summarize the outcome to the operator. Update the goal
+   status. Write the outcome and the decisions you made to the `session-manager`
+   palace so the next conversation can recall them.
+
+## Verification gate (BLOCKING)
+
+You must **never** claim a goal or task complete without observed evidence from
+the session(s). This gate blocks the transition from "running" to "done."
+
+| Claim | Required evidence (observed in the session pane / events) |
+|-------|-----------------------------------------------------------|
+| "tests pass" | captured test-run output with a pass count |
+| "PR opened" | the PR URL printed by the session |
+| "edit made" | the diff / file-write confirmation in the pane |
+| "goal done" | every linked task verified + acceptance criteria met |
+
+### Forbidden phrases
+
+Never say any of these -- they assert completion without evidence:
+
+- "should be done"
+- "looks complete"
+- "probably finished"
+- "that should work now"
+- "it ought to be passing"
+
+State the claim **with** the evidence ("tests pass: `42 passed; 0 failed`
+captured from session s-abc123"), or state the actual unverified status ("the
+session is still running the test suite; not yet verified"). If you have no
+evidence, the honest report is *not done* -- say so.
+
+## Triage & summarization
+
+Between requests, continuously summarize fleet state for the operator: one crisp
+line per session (`ID | status`). Surface what is **blocked** and which sessions
+are **waiting on the operator** for a decision. Answer triage questions
+("what's blocked?", "which sessions need me?") from observed pane/event state.
+With no provider configured, fall back to the deterministic pane-heuristic
+summary.

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
@@ -9,31 +9,36 @@ evidence, and report.
 
 1. **INTAKE.** Parse operator intent into a *goal*. Recall relevant memory
    (prior goals, session outcomes, decisions) from the `session-manager` palace
-   to inform decomposition. Propose acceptance criteria; confirm with the
-   operator when the goal is ambiguous.
+   via `memory.recall(query)` to inform decomposition. Create the goal with
+   `goals.create(description, acceptance?)`; propose acceptance criteria and
+   confirm with the operator when the goal is ambiguous.
 
 2. **DECOMPOSE.** Break the goal into session-sized tasks. **One task -> one
    launched session** (a goal may fan out to several sessions). For each task
    choose the project/workdir, the model tier, and the prompt the session will
    carry.
 
-3. **LAUNCH.** Spawn each session via the session control surface (`spawn` with
-   a `workdir`). Record the `goal_id -> session_id` link for every session so
-   the goal can be tracked across its fan-out.
+3. **LAUNCH.** Launch each session via the session control surface
+   (`sessions.launch(workdir, model?, prompt?, goal_id?)`). Pass the `goal_id`
+   so the `goal_id -> session_id` link is recorded for every session and the
+   goal can be tracked across its fan-out.
 
-4. **OBSERVE.** Poll session output and events; interpret the raw pane state
-   yourself (you can read panes even without provider inference). When a session
-   surfaces a decision prompt that you can answer, send the appropriate command.
-   Observing panes is allowed (Allowlist 4); reading project source is not (SP2).
+4. **OBSERVE.** Poll session output and events with `sessions.get(session_id)`;
+   interpret the raw pane state yourself (you can read panes even without
+   provider inference). When a session surfaces a decision prompt that you can
+   answer, reply with `sessions.send(session_id, text)`. Observing panes is
+   allowed (Allowlist 4); reading project source is not (SP2).
 
 5. **VERIFY (BLOCKING gate).** Before reporting a goal or task as done, confirm
-   the acceptance criteria with **observed evidence from the session** -- test
-   output, a diff, a printed PR URL. **No evidence means not done.** See the
-   verification gate below; this phase cannot be skipped.
+   the acceptance criteria with **observed evidence from the session**
+   (gathered via `sessions.get`) -- test output, a diff, a printed PR URL.
+   **No evidence means not done.** See the verification gate below; this phase
+   cannot be skipped.
 
 6. **REPORT & PERSIST.** Summarize the outcome to the operator. Update the goal
-   status. Write the outcome and the decisions you made to the `session-manager`
-   palace so the next conversation can recall them.
+   status with `goals.update(id, ...)`. Write the outcome and the decisions you
+   made to the `session-manager` palace via `memory.remember(text)` /
+   `memory.note(text)` so the next conversation can recall them.
 
 ## Verification gate (BLOCKING)
 

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -7,18 +7,24 @@
 //! memory palace, rolling auto-compaction context, goal tracking, and the
 //! stdio/HTTP adapters).
 //! What: a thin facade that re-exports the SM config types, the agent
-//! skeleton, and (SM-2) the multi-provider inference abstraction from the
-//! `config`, `agent`, and `providers` submodules.
+//! skeleton, (SM-2) the multi-provider inference abstraction, and (SM-3) the
+//! system-prompt assembly + override layering from the `config`, `agent`,
+//! `providers`, and `prompt` submodules.
 //! Test: submodule `tests` modules (`config::tests`, `agent::tests`,
-//! `providers::*::tests`) plus the `MpmConfig`-level coverage in
-//! `core/config.rs::tests`.
+//! `providers::*::tests`, `prompt::tests`) plus the `MpmConfig`-level coverage
+//! in `core/config.rs::tests`.
 
 pub mod agent;
 pub mod config;
+pub mod prompt;
 pub mod providers;
 
 pub use agent::SessionManagerAgent;
 pub use config::{SessionManagerConfig, SmInferenceConfig, SmMemoryConfig, SmRoundsConfig};
+pub use prompt::{
+    FILE_SM_INSTRUCTIONS, FILE_SM_TOOLS, FILE_SM_WORKFLOW, SM_OVERRIDE_SUBDIR, assemble_sm_prompt,
+    resolve_sm_prompt, resolve_sm_prompt_default, sm_override_dir,
+};
 pub use providers::{
     AnthropicProvider, LlmProvider, LlmRequest, LlmResponse, OpenRouterProvider, ProviderKind,
     ProviderRegistry, ResolvedCall, SmLlmError, SmModelTier, resolve_provider_and_model,

--- a/crates/trusty-mpm/src/core/sm/prompt.rs
+++ b/crates/trusty-mpm/src/core/sm/prompt.rs
@@ -29,6 +29,12 @@ use std::path::{Path, PathBuf};
 
 use crate::core::instruction_pipeline::SECTION_SEPARATOR;
 
+// `pub(crate)` is deliberate: these bundled defaults are consumed only through
+// `assemble_sm_prompt` / `resolve_sm_prompt`, which own the ordering and the
+// BASE_SM-last floor invariant. Any caller needing the raw section content goes
+// through those functions; exposing the constants beyond the crate would let a
+// caller reassemble the prompt out of order and silently bypass the floor.
+
 /// SM identity + Prohibitions table (SP1-SP7) + Allowlist (bundled at compile
 /// time). Mirrors `PM_INSTRUCTIONS`.
 pub(crate) const SM_INSTRUCTIONS: &str =
@@ -66,14 +72,22 @@ pub const FILE_SM_TOOLS: &str = "SM_TOOLS.md";
 /// runtime dependency on an external install and keeps the ordering rule in one
 /// auditable place (mirrors [`assemble_system_prompt`]).
 /// What: joins the four bundled assets in the fixed order SM_INSTRUCTIONS ->
-/// SM_WORKFLOW -> SM_TOOLS -> BASE_SM, separated by the `---` rule. BASE_SM is
-/// **always last** as the non-overridable framework floor.
+/// SM_WORKFLOW -> SM_TOOLS -> BASE_SM, separated by the `---` rule. Each section
+/// is trimmed before joining -- byte-for-byte the same treatment
+/// [`resolve_sm_prompt`] applies -- so the two produce identical output when no
+/// override is present. BASE_SM is **always last** as the non-overridable
+/// framework floor.
 /// Test: `assemble_sm_prompt_contains_all_sections`,
-/// `assemble_sm_prompt_base_floor_is_last`.
+/// `assemble_sm_prompt_base_floor_is_last`,
+/// `resolve_with_no_overrides_matches_assembled_sections` (exact equality).
 ///
 /// [`assemble_system_prompt`]: crate::core::instruction_pipeline::assemble_system_prompt
 pub fn assemble_sm_prompt() -> String {
-    [SM_INSTRUCTIONS, SM_WORKFLOW, SM_TOOLS, BASE_SM].join(SECTION_SEPARATOR)
+    [SM_INSTRUCTIONS, SM_WORKFLOW, SM_TOOLS, BASE_SM]
+        .iter()
+        .map(|s| s.trim())
+        .collect::<Vec<_>>()
+        .join(SECTION_SEPARATOR)
 }
 
 /// Resolve `~/.trusty-mpm/sm/`, the SM's override directory.
@@ -410,38 +424,48 @@ mod tests {
 
     #[test]
     fn resolve_with_no_overrides_matches_assembled_sections() {
-        // With an empty override dir, resolve_sm_prompt yields the same sections
-        // in the same order as the bundled assemble_sm_prompt. They are not
-        // byte-identical (resolve trims each section's interior whitespace;
-        // assemble joins assets verbatim), so we assert section identity +
-        // ordering rather than exact bytes.
+        // With an empty override dir, resolve_sm_prompt is now byte-identical to
+        // the bundled assemble_sm_prompt: both trim each section the same way
+        // before joining with the `---` rule (Finding 3). Assert exact equality.
         let tmp = TempDir::new().unwrap();
         let resolved = resolve_sm_prompt(tmp.path());
         let assembled = assemble_sm_prompt();
-        let resolved_sections: Vec<&str> = resolved
-            .split(SECTION_SEPARATOR)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .collect();
-        let assembled_sections: Vec<&str> = assembled
-            .split(SECTION_SEPARATOR)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .collect();
         assert_eq!(
-            resolved_sections, assembled_sections,
-            "resolved and assembled must agree section-for-section"
+            resolved, assembled,
+            "no-override resolve must be byte-identical to assemble"
         );
-        assert_eq!(resolved_sections.len(), 4, "four sections expected");
+        let section_count = assembled.split(SECTION_SEPARATOR).count();
+        assert_eq!(section_count, 4, "four sections expected");
     }
 
     #[test]
     fn sm_override_dir_under_home() {
-        // The production override dir resolves under ~/.trusty-mpm/sm when a home
-        // is available.
-        if let Some(dir) = sm_override_dir() {
-            assert!(dir.ends_with("sm"));
-            assert!(dir.to_string_lossy().contains(".trusty-mpm"));
+        // The production override dir resolves under ~/.trusty-mpm/sm. In the
+        // normal case (CI and dev machines both have a home) `sm_override_dir`
+        // returns `Some` and we assert the path shape. We tolerate the rare
+        // home-less environment by handling `None` explicitly with a comment, so
+        // a genuinely-skipped assertion can never masquerade as a green pass: if
+        // a home IS present the path-shape checks run and must hold; if no home
+        // resolves we record that the graceful-None fallback path was taken.
+        match sm_override_dir() {
+            Some(dir) => {
+                assert!(dir.ends_with("sm"), "override dir must end with `sm`");
+                assert!(
+                    dir.to_string_lossy().contains(".trusty-mpm"),
+                    "override dir must be anchored under `.trusty-mpm`"
+                );
+            }
+            None => {
+                // No home directory resolvable (e.g. a stripped sandbox). This is
+                // the documented graceful fallback: `resolve_sm_prompt_default`
+                // then assembles the bundled prompt unconditionally. Nothing to
+                // assert about the path shape here -- the absence itself is the
+                // contract -- but we flag it so the green pass is honest.
+                eprintln!(
+                    "sm_override_dir_under_home: no home resolved; \
+                     graceful-None fallback exercised"
+                );
+            }
         }
     }
 }

--- a/crates/trusty-mpm/src/core/sm/prompt.rs
+++ b/crates/trusty-mpm/src/core/sm/prompt.rs
@@ -1,0 +1,447 @@
+//! Session Manager (SM) system-prompt assembly + override layering (DOC-14 §4).
+//!
+//! Why: the SM carries its own role-specific system prompt, composed and
+//! delivered with the same discipline as the PM prompt
+//! ([`crate::core::instruction_pipeline`] /
+//! [`crate::core::instruction_overrides`]) but one level up. The four bundled
+//! assets under `src/assets/sm_instructions/` define the SM's behavior
+//! (identity, prohibitions SP1-SP7, allowlist, the 6-phase delegation loop, the
+//! BLOCKING verification gate, the tool/verb surface, and the non-overridable
+//! framework floor). Assembling them ad-hoc at each call site would invite the
+//! same ordering/content drift the PM pipeline was built to prevent.
+//! What: [`assemble_sm_prompt`] embeds the four assets via `include_str!` at
+//! compile time and joins them in the fixed order
+//! SM_INSTRUCTIONS -> SM_WORKFLOW -> SM_TOOLS -> BASE_SM, BASE_SM **always last**
+//! as the non-overridable floor. [`resolve_sm_prompt`] layers optional per-file
+//! overrides from an override directory (`~/.trusty-mpm/sm/`, see
+//! [`sm_override_dir`]) onto the bundled defaults, **always** appending the
+//! bundled BASE_SM floor last -- BASE_SM is never overridable.
+//! Test: the `tests` module mirrors `instruction_overrides::tests` -- bundled
+//! content, per-file override replacement, the never-overridable BASE_SM floor
+//! invariant, and the missing/empty/unreadable fallbacks.
+//!
+//! Crucial distinction from the PM (spec §4): the SM prompt is **not** delivered
+//! via `claude --append-system-prompt-file` (the SM is the daemon-side brain,
+//! not a spawned Claude Code session). It is supplied as the provider request's
+//! `system` message later (SM-7). This module only exposes the assembled prompt.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::instruction_pipeline::SECTION_SEPARATOR;
+
+/// SM identity + Prohibitions table (SP1-SP7) + Allowlist (bundled at compile
+/// time). Mirrors `PM_INSTRUCTIONS`.
+pub(crate) const SM_INSTRUCTIONS: &str =
+    include_str!("../../assets/sm_instructions/SM_INSTRUCTIONS.md");
+/// The 6-phase delegation loop + BLOCKING verification gate (bundled). Mirrors
+/// `WORKFLOW`.
+pub(crate) const SM_WORKFLOW: &str = include_str!("../../assets/sm_instructions/SM_WORKFLOW.md");
+/// The SM's tool/verb surface: session control + memory + goals (bundled).
+/// Mirrors `AGENT_DELEGATION`.
+pub(crate) const SM_TOOLS: &str = include_str!("../../assets/sm_instructions/SM_TOOLS.md");
+/// Non-overridable SM framework floor (bundled). Placed last so it can never be
+/// overridden. Mirrors `BASE_PM`.
+pub(crate) const BASE_SM: &str = include_str!("../../assets/sm_instructions/BASE_SM.md");
+
+/// Override-directory name segment under the trusty-mpm home (`~/.trusty-mpm`).
+///
+/// Why: the SM is daemon-side, not per-project, so its overrides live in a
+/// home-anchored `~/.trusty-mpm/sm/` directory (the SM analogue of the PM's
+/// project-local `.trusty-mpm/`), per the SM-3 task spec.
+/// What: the `sm` subdirectory name joined onto `~/.trusty-mpm`.
+/// Test: `sm_override_dir_under_home`.
+pub const SM_OVERRIDE_SUBDIR: &str = "sm";
+
+/// Override file: replaces the bundled `SM_INSTRUCTIONS` section.
+pub const FILE_SM_INSTRUCTIONS: &str = "SM_INSTRUCTIONS.md";
+/// Override file: replaces the bundled `SM_WORKFLOW` section.
+pub const FILE_SM_WORKFLOW: &str = "SM_WORKFLOW.md";
+/// Override file: replaces the bundled `SM_TOOLS` section.
+pub const FILE_SM_TOOLS: &str = "SM_TOOLS.md";
+
+/// Assemble the SM system prompt from the four bundled assets.
+///
+/// Why: the SM's provider request needs an identical, version-controlled system
+/// prompt every time; embedding the sources and joining them here removes any
+/// runtime dependency on an external install and keeps the ordering rule in one
+/// auditable place (mirrors [`assemble_system_prompt`]).
+/// What: joins the four bundled assets in the fixed order SM_INSTRUCTIONS ->
+/// SM_WORKFLOW -> SM_TOOLS -> BASE_SM, separated by the `---` rule. BASE_SM is
+/// **always last** as the non-overridable framework floor.
+/// Test: `assemble_sm_prompt_contains_all_sections`,
+/// `assemble_sm_prompt_base_floor_is_last`.
+///
+/// [`assemble_system_prompt`]: crate::core::instruction_pipeline::assemble_system_prompt
+pub fn assemble_sm_prompt() -> String {
+    [SM_INSTRUCTIONS, SM_WORKFLOW, SM_TOOLS, BASE_SM].join(SECTION_SEPARATOR)
+}
+
+/// Resolve `~/.trusty-mpm/sm/`, the SM's override directory.
+///
+/// Why: [`resolve_sm_prompt`] takes an explicit directory so it is testable
+/// against a temp dir; this convenience resolves the production location for the
+/// daemon, mirroring how the PM pipeline anchors `~/.trusty-mpm`.
+/// What: returns `<home>/.trusty-mpm/sm` when a home directory is resolvable,
+/// else `None` (the caller then assembles the bundled prompt unconditionally).
+/// Test: `sm_override_dir_under_home`.
+pub fn sm_override_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".trusty-mpm").join(SM_OVERRIDE_SUBDIR))
+}
+
+/// Read an override file, returning `Some(trimmed)` only when present and
+/// non-empty.
+///
+/// Why: override semantics distinguish absent, present-but-empty, and
+/// present-with-content. Absent and empty both fall back to the bundled default;
+/// an unreadable file (e.g. permission denied, or a directory in its place) also
+/// falls back. Treating empty as "no override" avoids silently blanking a whole
+/// section because someone `touch`ed a file. Robustness must never hard-fail
+/// prompt assembly. Mirrors `instruction_overrides::read_override`.
+/// What: joins `dir/name`; on non-whitespace content returns the trimmed body;
+/// on `NotFound` returns `None` silently; on an empty file or any other IO error
+/// logs a `tracing::warn!` and returns `None`.
+/// Test: `unreadable_override_falls_back`, `empty_override_falls_back`,
+/// `missing_override_dir_uses_bundled`.
+fn read_override(dir: &Path, name: &str) -> Option<String> {
+    let path = dir.join(name);
+    match std::fs::read_to_string(&path) {
+        Ok(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "SM instruction override file is empty; using bundled default"
+                );
+                None
+            } else {
+                tracing::info!(path = %path.display(), "applying SM instruction override");
+                Some(trimmed.to_string())
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                %err,
+                "SM instruction override file unreadable; using bundled default"
+            );
+            None
+        }
+    }
+}
+
+/// Resolve the effective SM system prompt, applying any overrides in `dir`.
+///
+/// Why: the SM prompt must support per-file operator customization (the SM
+/// analogue of `resolve_pm_prompt`) while keeping a non-overridable framework
+/// floor. Both the live prompt (the provider `system` message, SM-7) and any
+/// future inspectable stash call this one function so they can never diverge.
+///
+/// What: for each of `SM_INSTRUCTIONS`, `SM_WORKFLOW`, and `SM_TOOLS`, uses the
+/// override file from `dir` when present and non-empty, else the bundled
+/// default. The bundled `BASE_SM` floor is **always** appended last and is
+/// **never** overridable -- even a `BASE_SM.md` placed in `dir` is ignored; the
+/// bundled floor is used. Sections are joined with [`SECTION_SEPARATOR`], the
+/// same rule [`assemble_sm_prompt`] uses, so the two never visually diverge.
+///
+/// Robustness: a missing override directory, missing files, empty files, and
+/// unreadable files all fall back to the bundled defaults without failing.
+///
+/// Test: `no_overrides_uses_bundled`, `sm_instructions_override_replaces`,
+/// `workflow_override_replaces`, `tools_override_replaces`,
+/// `base_sm_floor_is_never_overridable`, and the robustness tests.
+pub fn resolve_sm_prompt(dir: &Path) -> String {
+    let instructions = read_override(dir, FILE_SM_INSTRUCTIONS)
+        .unwrap_or_else(|| SM_INSTRUCTIONS.trim().to_string());
+    let workflow =
+        read_override(dir, FILE_SM_WORKFLOW).unwrap_or_else(|| SM_WORKFLOW.trim().to_string());
+    let tools = read_override(dir, FILE_SM_TOOLS).unwrap_or_else(|| SM_TOOLS.trim().to_string());
+
+    // BASE_SM is the non-overridable floor: always the bundled one, always last.
+    let sections = [instructions, workflow, tools, BASE_SM.trim().to_string()];
+
+    sections
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(SECTION_SEPARATOR)
+}
+
+/// Resolve the effective SM prompt for the production `~/.trusty-mpm/sm/`
+/// override directory.
+///
+/// Why: the daemon needs a zero-argument entry point that resolves the real
+/// override location; [`resolve_sm_prompt`] stays path-parameterised for tests.
+/// What: when [`sm_override_dir`] resolves a home, delegates to
+/// [`resolve_sm_prompt`] with that directory (which tolerates a missing dir);
+/// when no home is resolvable, returns the bundled [`assemble_sm_prompt`].
+/// Test: side-effect-only over the real home; the layering logic is covered by
+/// the `resolve_sm_prompt` tests against temp dirs.
+pub fn resolve_sm_prompt_default() -> String {
+    match sm_override_dir() {
+        Some(dir) => resolve_sm_prompt(&dir),
+        None => assemble_sm_prompt(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Write `<dir>/<name>` with `content`, creating `dir` if needed.
+    fn write_override(dir: &Path, name: &str, content: &str) {
+        fs::create_dir_all(dir).expect("create override dir");
+        fs::write(dir.join(name), content).expect("write override");
+    }
+
+    #[test]
+    fn assemble_sm_prompt_contains_all_sections() {
+        // Why: the assembled prompt IS the SM's behavior contract; every bundled
+        // section -- prohibitions, allowlist, 6-phase loop, verification gate,
+        // and the BASE_SM floor -- must be present and joined with the `---`
+        // rule.
+        let prompt = assemble_sm_prompt();
+        // Identity + prohibitions table (SP1-SP7) + allowlist.
+        assert!(prompt.contains("# Session Manager (SM) -- trusty-mpm"));
+        assert!(prompt.contains("| SP1 |"));
+        assert!(prompt.contains("| SP7 |"));
+        assert!(prompt.contains("You MAY do directly (Allowlist)"));
+        // The 6-phase loop + verification gate.
+        assert!(prompt.contains("# SM Workflow -- the delegation loop"));
+        assert!(prompt.contains("1. **INTAKE.**"));
+        assert!(prompt.contains("6. **REPORT & PERSIST.**"));
+        assert!(prompt.contains("Verification gate (BLOCKING)"));
+        // The tool/verb surface.
+        assert!(prompt.contains("# SM Tools -- the verbs you may call"));
+        // The BASE_SM floor.
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+        // Joined with the framework separator.
+        assert!(prompt.contains(SECTION_SEPARATOR));
+    }
+
+    #[test]
+    fn assemble_sm_prompt_base_floor_is_last() {
+        // Why: BASE_SM is the non-overridable floor; it must be the final
+        // section so nothing can displace it.
+        let prompt = assemble_sm_prompt();
+        let base = prompt.find("# BASE_SM Framework Floor").expect("base_sm");
+        let tools = prompt
+            .find("# SM Tools -- the verbs you may call")
+            .expect("tools");
+        let workflow = prompt
+            .find("# SM Workflow -- the delegation loop")
+            .expect("workflow");
+        assert!(workflow < tools, "workflow precedes tools");
+        assert!(base > tools, "BASE_SM floor must be appended last");
+    }
+
+    #[test]
+    fn no_overrides_uses_bundled() {
+        // No override dir at all → all four bundled sections present, BASE_SM
+        // last.
+        let tmp = TempDir::new().unwrap();
+        let prompt = resolve_sm_prompt(tmp.path());
+
+        assert!(prompt.contains("# Session Manager (SM) -- trusty-mpm"));
+        assert!(prompt.contains("# SM Workflow -- the delegation loop"));
+        assert!(prompt.contains("# SM Tools -- the verbs you may call"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+
+        let base = prompt.find("# BASE_SM Framework Floor").expect("base");
+        let tools = prompt
+            .find("# SM Tools -- the verbs you may call")
+            .expect("tools");
+        assert!(base > tools, "BASE_SM floor must be last");
+    }
+
+    #[test]
+    fn sm_instructions_override_replaces() {
+        // SM_INSTRUCTIONS.md replaces the bundled identity/prohibitions section;
+        // the other bundled sections (and the floor) remain.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_SM_INSTRUCTIONS,
+            "# Custom Identity\n\nDELEGATE_EVERYTHING_TO_ALICE\n",
+        );
+        let prompt = resolve_sm_prompt(tmp.path());
+
+        assert!(prompt.contains("DELEGATE_EVERYTHING_TO_ALICE"));
+        assert!(
+            !prompt.contains("# Session Manager (SM) -- trusty-mpm"),
+            "bundled SM_INSTRUCTIONS heading must be replaced"
+        );
+        // Other sections intact.
+        assert!(prompt.contains("# SM Workflow -- the delegation loop"));
+        assert!(prompt.contains("# SM Tools -- the verbs you may call"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+        // Floor still last.
+        let body = prompt.find("DELEGATE_EVERYTHING_TO_ALICE").expect("body");
+        let base = prompt.find("# BASE_SM Framework Floor").expect("base");
+        assert!(body < base, "BASE_SM floor follows the override body");
+    }
+
+    #[test]
+    fn workflow_override_replaces() {
+        // SM_WORKFLOW.md replaces the bundled workflow section; others intact.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_SM_WORKFLOW,
+            "# Custom Loop\n\nTWO_PHASE_ONLY\n",
+        );
+        let prompt = resolve_sm_prompt(tmp.path());
+
+        assert!(prompt.contains("TWO_PHASE_ONLY"));
+        assert!(
+            !prompt.contains("# SM Workflow -- the delegation loop"),
+            "bundled workflow heading must be replaced"
+        );
+        assert!(prompt.contains("# Session Manager (SM) -- trusty-mpm"));
+        assert!(prompt.contains("# SM Tools -- the verbs you may call"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+    }
+
+    #[test]
+    fn tools_override_replaces() {
+        // SM_TOOLS.md replaces the bundled tools section; others intact.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_SM_TOOLS,
+            "# Custom Verbs\n\nONLY_LAUNCH_AND_STOP\n",
+        );
+        let prompt = resolve_sm_prompt(tmp.path());
+
+        assert!(prompt.contains("ONLY_LAUNCH_AND_STOP"));
+        assert!(
+            !prompt.contains("# SM Tools -- the verbs you may call"),
+            "bundled tools heading must be replaced"
+        );
+        assert!(prompt.contains("# Session Manager (SM) -- trusty-mpm"));
+        assert!(prompt.contains("# SM Workflow -- the delegation loop"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+    }
+
+    #[test]
+    fn base_sm_floor_is_never_overridable() {
+        // Even with a BASE_SM.md in the override dir, the BUNDLED floor is used
+        // and appended last; the override-dir BASE_SM content must NOT appear.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            "BASE_SM.md",
+            "# Fake Floor\n\nNO_PROHIBITIONS_ANYMORE\n",
+        );
+        // Also override an overridable section to prove layering still works.
+        write_override(
+            tmp.path(),
+            FILE_SM_INSTRUCTIONS,
+            "# Custom Identity\n\nCUSTOM_IDENTITY_BODY\n",
+        );
+        let prompt = resolve_sm_prompt(tmp.path());
+
+        // The overridable section IS replaced.
+        assert!(prompt.contains("CUSTOM_IDENTITY_BODY"));
+        // The bundled floor is present and last.
+        assert!(
+            prompt.contains("# BASE_SM Framework Floor"),
+            "bundled BASE_SM floor must always be appended"
+        );
+        assert!(prompt.contains("Trusty Tool Priority (Non-Overridable)"));
+        // The fake floor from the override dir must NOT leak in.
+        assert!(
+            !prompt.contains("NO_PROHIBITIONS_ANYMORE"),
+            "override-dir BASE_SM.md must be ignored"
+        );
+        assert!(!prompt.contains("# Fake Floor"));
+
+        // Bundled floor is the last section.
+        let body = prompt.find("CUSTOM_IDENTITY_BODY").expect("body");
+        let base = prompt.find("# BASE_SM Framework Floor").expect("base");
+        assert!(body < base, "bundled BASE_SM floor must come last");
+    }
+
+    #[test]
+    fn missing_override_dir_uses_bundled() {
+        // A non-existent override dir is not an error.
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        assert!(!missing.exists());
+        let prompt = resolve_sm_prompt(&missing);
+        assert!(prompt.contains("# Session Manager (SM) -- trusty-mpm"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+    }
+
+    #[test]
+    fn empty_override_falls_back() {
+        // An empty (whitespace-only) override is treated as "no override": the
+        // bundled default for that section survives (no silent blanking).
+        let tmp = TempDir::new().unwrap();
+        write_override(tmp.path(), FILE_SM_WORKFLOW, "   \n\t\n");
+        let prompt = resolve_sm_prompt(tmp.path());
+        assert!(prompt.contains("# SM Workflow -- the delegation loop"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+    }
+
+    #[test]
+    fn unreadable_override_falls_back() {
+        // A file that cannot be read (here: a directory in the file's place)
+        // falls back to the bundled default rather than failing assembly.
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join(FILE_SM_WORKFLOW)).unwrap();
+        let prompt = resolve_sm_prompt(tmp.path());
+        // Did not panic; bundled workflow is used.
+        assert!(prompt.contains("# SM Workflow -- the delegation loop"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
+    }
+
+    #[test]
+    fn separators_are_consistent() {
+        // The resolved prompt uses the same `---` rule the bundled assembler
+        // uses, so the two never visually diverge.
+        let tmp = TempDir::new().unwrap();
+        let prompt = resolve_sm_prompt(tmp.path());
+        assert!(prompt.contains(SECTION_SEPARATOR));
+    }
+
+    #[test]
+    fn resolve_with_no_overrides_matches_assembled_sections() {
+        // With an empty override dir, resolve_sm_prompt yields the same sections
+        // in the same order as the bundled assemble_sm_prompt. They are not
+        // byte-identical (resolve trims each section's interior whitespace;
+        // assemble joins assets verbatim), so we assert section identity +
+        // ordering rather than exact bytes.
+        let tmp = TempDir::new().unwrap();
+        let resolved = resolve_sm_prompt(tmp.path());
+        let assembled = assemble_sm_prompt();
+        let resolved_sections: Vec<&str> = resolved
+            .split(SECTION_SEPARATOR)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        let assembled_sections: Vec<&str> = assembled
+            .split(SECTION_SEPARATOR)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert_eq!(
+            resolved_sections, assembled_sections,
+            "resolved and assembled must agree section-for-section"
+        );
+        assert_eq!(resolved_sections.len(), 4, "four sections expected");
+    }
+
+    #[test]
+    fn sm_override_dir_under_home() {
+        // The production override dir resolves under ~/.trusty-mpm/sm when a home
+        // is available.
+        if let Some(dir) = sm_override_dir() {
+            assert!(dir.ends_with("sm"));
+            assert!(dir.to_string_lossy().contains(".trusty-mpm"));
+        }
+    }
+}


### PR DESCRIPTION
## SM-3 (closes #1286, refs epic #1283)

Adds the **Session Manager (SM) system-prompt assets** and the **assembly + override machinery** (DOC-14 §4), mirroring the PM instruction pipeline one level up. **Scope: prompt assets + assembly only** — no endpoint wiring (that is SM-7).

### Asset files (`crates/trusty-mpm/src/assets/sm_instructions/`)

These `.md` files **are** the SM's behavior, authored from spec §3/§4:

- **`SM_INSTRUCTIONS.md`** — SM identity + canonical Prohibitions table (SP1–SP7) + the Allowlist of what the SM MAY do directly.
- **`SM_WORKFLOW.md`** — the 6-phase delegation loop (intake → decompose → launch → observe → verify → report) + the BLOCKING verification gate (evidence table + forbidden phrases like "should be done"/"looks complete").
- **`SM_TOOLS.md`** — the SM's verb surface: session control (launch/list/get/send/stop/resume/kill), memory (recall/remember/note, scoped to the `session-manager` palace), goals (list/create/update).
- **`BASE_SM.md`** — the non-overridable framework floor, always appended last.

### Machinery (`crates/trusty-mpm/src/core/sm/prompt.rs`)

Mirrors `instruction_pipeline::assemble_system_prompt` / `instruction_overrides::resolve_pm_prompt`:

- **`assemble_sm_prompt()`** — `include_str!`-embeds the four assets at compile time, joins in fixed order `SM_INSTRUCTIONS → SM_WORKFLOW → SM_TOOLS → BASE_SM` with the `\n\n---\n\n` rule, **BASE_SM always last**.
- **`resolve_sm_prompt(dir)`** — layers per-file overrides (`SM_INSTRUCTIONS.md`/`SM_WORKFLOW.md`/`SM_TOOLS.md`) from an override directory onto bundled defaults. The bundled **`BASE_SM` is always appended last and is never overridable** — even a `BASE_SM.md` placed in the override dir is ignored. Missing/empty/unreadable files fall back to bundled defaults (never blank a section).
- **`resolve_sm_prompt_default()`** — resolves the production `~/.trusty-mpm/sm/` override dir (the SM analogue of the PM's project-local `.trusty-mpm/`; SM is daemon-side, so it is home-anchored).
- **`sm_override_dir()`** — `~/.trusty-mpm/sm/` resolver.

Public surface re-exported via `core/sm/mod.rs`.

> **Distinction from the PM (spec §4):** the SM prompt is supplied as the provider request's `system` message later (SM-7) — **NOT** via `claude --append-system-prompt-file`. The SM is the daemon-side brain, not a spawned session. This ticket exposes the assembled-prompt functions only.

### Tests (13, all green)

Mirror the `instruction_overrides` test structure. Assert the assembled prompt contains the SP1–SP7 prohibitions table, the Allowlist, the 6-phase loop, the verification gate, and the BASE_SM floor; override layering (no override dir → bundled; per-file override present in a temp dir → overridden content used **but** bundled BASE_SM still last); BASE_SM never overridable; and missing/empty/unreadable fallbacks.

### Verification evidence

```
cargo clippy -p trusty-mpm --all-targets -- -D warnings
  → clean (only the known dual-build-target Cargo.toml note)

cargo test -p trusty-mpm
  → test result: ok. 1102 passed; 0 failed; 0 ignored
  → all 13 core::sm::prompt::tests pass; all integration suites green

bash scripts/check_line_cap.sh
  → line-cap: 15 allowlisted, 0 violations — OK. (exit 0)
  → prompt.rs is 447 physical lines, well under the 500-SLOC prod cap

cargo fmt --check → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)