### PR TITLE
feat(trusty-mpm): SM-4 dedicated session-manager palace + memory recall/remember (#1287)

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -46,6 +46,20 @@ telegram = ["dep:teloxide", "dep:tokio-util"]
 # Bedrock provider weight is strictly opt-in. Build/test with `--features bedrock`.
 bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-types"]
 
+# `sm-memory` gates the Session Manager's dedicated memory palace (SM-4, DOC-14
+# §8). NOT in `default`: it turns on `trusty-common/memory-core`, which pulls the
+# heavy Memory Palace storage engine (usearch/hnsw_rs HNSW vector index, redb +
+# postcard stores, git2, and the bundled-ORT FastEmbedder). Keeping it opt-in
+# means a `--no-default-features` build — and even the default daemon build —
+# does NOT pay the ONNX/usearch compile or runtime cost unless the operator
+# explicitly opts the SM memory subsystem in. Build/test with `--features
+# sm-memory`. The `core::sm::memory` module is compiled only under this flag.
+# `embedder-test-support` is included so the SM-4 unit tests can seed the MOCK
+# embedder (`seed_shared_embedder_with_mock`) and run without the ONNX model;
+# it only exposes a test double and pulls no extra runtime weight beyond the
+# embedder that `memory-core` already requires.
+sm-memory = ["trusty-common/memory-core", "trusty-common/embedder-test-support"]
+
 # `gui` is intentionally a no-dep CLI-gating feature. The `tm gui` subcommand
 # is ALWAYS available; this flag exists only so the subcommand can optionally
 # advertise itself. The Tauri GUI lives in the separate, publish=false

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -54,11 +54,16 @@ bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-types"]
 # does NOT pay the ONNX/usearch compile or runtime cost unless the operator
 # explicitly opts the SM memory subsystem in. Build/test with `--features
 # sm-memory`. The `core::sm::memory` module is compiled only under this flag.
-# `embedder-test-support` is included so the SM-4 unit tests can seed the MOCK
-# embedder (`seed_shared_embedder_with_mock`) and run without the ONNX model;
-# it only exposes a test double and pulls no extra runtime weight beyond the
-# embedder that `memory-core` already requires.
-sm-memory = ["trusty-common/memory-core", "trusty-common/embedder-test-support"]
+#
+# Production hygiene (SM-4 review): this feature deliberately does NOT enable
+# `trusty-common/embedder-test-support`. That test double (and its
+# `seed_shared_embedder_with_mock` seam) must never link into a production
+# `--features sm-memory` build. The SM-4 unit tests still need the mock
+# embedder to run without the ONNX model, so the test-support feature is wired
+# in via `[dev-dependencies]` below — Cargo unifies dev-dependency features only
+# for test/bench/example builds, so `cargo test` gets the mock while a plain
+# `cargo build --features sm-memory` does not.
+sm-memory = ["trusty-common/memory-core"]
 
 # `gui` is intentionally a no-dep CLI-gating feature. The `tm gui` subcommand
 # is ALWAYS available; this flag exists only so the subcommand can optionally
@@ -197,6 +202,13 @@ nix = { version = "0.29", features = ["signal"] }
 
 # ── Dev dependencies ───────────────────────────────────────────────────────────
 [dev-dependencies]
+# Re-declare trusty-common with `embedder-test-support` (SM-4 review): Cargo
+# merges dev-dependency features ONLY for test/bench/example builds, so this
+# turns on the mock-embedder seam (`seed_shared_embedder_with_mock`) for
+# `cargo test --features sm-memory` WITHOUT leaking it into a production
+# `cargo build --features sm-memory`. `memory-core` is repeated so the unified
+# feature set still includes the palace storage engine the SM-4 tests exercise.
+trusty-common = { workspace = true, features = ["memory-core", "embedder-test-support"] }
 tempfile.workspace = true
 axum.workspace = true
 http-body-util.workspace = true

--- a/crates/trusty-mpm/src/core/sm/memory.rs
+++ b/crates/trusty-mpm/src/core/sm/memory.rs
@@ -161,39 +161,54 @@ impl SmMemory {
     /// Open-or-create the bound palace, returning a live handle.
     ///
     /// Why: every operation needs a handle; centralising the idempotent
-    /// open-from-disk-else-create here means a single, well-tested code path
-    /// enforces "exactly one palace" for both construction and every later call.
-    /// What: returns the cached handle if registered; else opens from disk when
-    /// `palace.json` exists, otherwise creates and persists a new palace. Scoped
-    /// entirely to `self.palace_id` — no other id is reachable.
-    /// Test: `palace_create_is_idempotent`, `writes_target_only_the_sm_palace`.
+    /// open-or-create here means a single, well-tested code path enforces
+    /// "exactly one palace" for both construction and every later call. The
+    /// open-or-create must also be RACE-SAFE: two concurrent first-starts
+    /// against the same data root (e.g. two SM processes, or two threads) must
+    /// converge on ONE palace without either erroring. The previous
+    /// `exists()`-then-branch form had a TOCTOU window where both callers could
+    /// observe "missing" and both take the create branch; this form closes it.
+    /// What: returns the cached handle if registered (fast path). Otherwise
+    /// tries `open_palace` first — which succeeds whenever `palace.json` is
+    /// already on disk, including the case where a concurrent creator just
+    /// finished writing it. If the open fails (the normal first-run case: no
+    /// metadata yet), it falls back to `create_palace`, which is itself
+    /// idempotent (`create_dir_all` + an atomic `palace.json` rename), so two
+    /// racing creators both succeed and the registry de-duplicates by id. Both
+    /// branches are scoped entirely to `self.palace_id` — no other id is
+    /// reachable. Any final failure is wrapped in [`SmMemoryError::Palace`].
+    /// Test: `palace_create_is_idempotent`, `writes_target_only_the_sm_palace`,
+    /// `ensure_palace_falls_back_to_open_when_palace_already_exists`.
     fn ensure_palace(&self) -> SmMemoryResult<Arc<PalaceHandle>> {
         if let Some(handle) = self.registry.get(&self.palace_id) {
             return Ok(handle);
         }
 
-        let palace_dir = self.data_root.join(self.palace_id.as_str());
-        let result = if palace_dir.join("palace.json").exists() {
-            self.registry.open_palace(&self.data_root, &self.palace_id)
-        } else {
-            let palace = Palace {
-                id: self.palace_id.clone(),
-                name: "Session Manager".to_string(),
-                description: Some(
-                    "Dedicated Session-Manager memory palace (DOC-14 §8): goals, \
-                     outcomes, and decisions across sessions."
-                        .to_string(),
-                ),
-                created_at: Utc::now(),
-                data_dir: palace_dir,
-            };
-            self.registry.create_palace(&self.data_root, palace)
-        };
+        // Open-first, create-on-failure: no `exists()` pre-check, so there is no
+        // TOCTOU window. `open_palace` resolves the common "already on disk"
+        // case (including a concurrent creator that has finished); only when it
+        // fails do we attempt the idempotent create.
+        if let Ok(handle) = self.registry.open_palace(&self.data_root, &self.palace_id) {
+            return Ok(handle);
+        }
 
-        result.map_err(|source| SmMemoryError::Palace {
-            palace: self.palace_id.to_string(),
-            source,
-        })
+        let palace = Palace {
+            id: self.palace_id.clone(),
+            name: "Session Manager".to_string(),
+            description: Some(
+                "Dedicated Session-Manager memory palace (DOC-14 §8): goals, \
+                 outcomes, and decisions across sessions."
+                    .to_string(),
+            ),
+            created_at: Utc::now(),
+            data_dir: self.data_root.join(self.palace_id.as_str()),
+        };
+        self.registry
+            .create_palace(&self.data_root, palace)
+            .map_err(|source| SmMemoryError::Palace {
+                palace: self.palace_id.to_string(),
+                source,
+            })
     }
 
     /// Recall the top-k SM memories matching `query` (standard L0+L1+L2 path).
@@ -296,14 +311,16 @@ impl SmMemory {
         Self::count_persisted(&self.data_root, &self.palace_id)
     }
 
-    /// Count persisted palaces under `data_root` (free helper for tests/callers).
+    /// Count persisted palaces under `data_root` (internal helper).
     ///
-    /// Why: lets a test count palaces from a path without first building an
-    /// `SmMemory`, keeping the idempotency assertions independent of the very
-    /// object under test where useful.
+    /// Why: factors the registry-listing + error-mapping out of
+    /// [`SmMemory::persisted_palace_count`] so the public accessor stays a thin
+    /// one-liner. Private by design — the only caller is `persisted_palace_count`
+    /// (which the idempotency tests drive); it takes the path/id as arguments
+    /// purely to avoid borrowing `self` twice, not to expose a standalone API.
     /// What: delegates to [`PalaceRegistry::list_palaces`]; maps failure to
     /// [`SmMemoryError::Palace`] tagged with `palace_id`.
-    /// Test: `palace_create_is_idempotent`.
+    /// Test: `palace_create_is_idempotent` (via `persisted_palace_count`).
     fn count_persisted(data_root: &Path, palace_id: &PalaceId) -> SmMemoryResult<usize> {
         PalaceRegistry::list_palaces(data_root)
             .map(|palaces| palaces.len())

--- a/crates/trusty-mpm/src/core/sm/memory.rs
+++ b/crates/trusty-mpm/src/core/sm/memory.rs
@@ -1,0 +1,319 @@
+//! Session Manager dedicated memory palace + recall/remember wiring (DOC-14 §8).
+//!
+//! Why: the SM keeps durable, cross-session knowledge — goals, outcomes,
+//! decisions — in its OWN memory palace (default `"session-manager"`), strictly
+//! separate from per-project palaces. Per spec ref D8.3a the SM must call the
+//! memory engine as a DIRECT LIBRARY call (not over MCP) to avoid a network hop
+//! and an extra daemon dependency; this module is that direct binding. SM-4
+//! lands the palace lifecycle + the four scoped operations (recall, recall_deep,
+//! remember, note); SM-7/SM-8 (the endpoint + agent loop) consume them — this
+//! ticket deliberately does NOT wire them into any endpoint yet. The §7.5
+//! step-3 recall-injection point lives in the future context engine.
+//! What: [`SmMemory`] owns a [`PalaceRegistry`] rooted at a data dir and a single
+//! [`PalaceId`] (from [`SmMemoryConfig::palace`]). Construction IDEMPOTENTLY
+//! ensures that one palace exists (open-from-disk, else create — creating twice
+//! yields exactly one palace). Every read/write is scoped to that single palace
+//! id, so the SM can never touch another namespace. A backend failure surfaces
+//! as a structured [`SmMemoryError`] (no panics, graceful degradation).
+//! Test: `#[path = "memory_tests.rs"] mod tests` — palace idempotency, scoped
+//! remember→recall round-trip, scope isolation, restart survival, and the
+//! "never writes to a non-SM palace" guard.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::Utc;
+use trusty_common::memory_core::palace::{Palace, PalaceId, RoomType};
+use trusty_common::memory_core::registry::PalaceRegistry;
+use trusty_common::memory_core::retrieval::{
+    PalaceHandle, RecallResult, RememberOptions, recall_deep_with_default_embedder,
+    recall_with_default_embedder,
+};
+
+use super::config::SmMemoryConfig;
+
+/// Default importance assigned to SM-remembered drawers.
+///
+/// Why: SM memories (goals/outcomes/decisions) are curated, high-signal facts —
+/// they should rank above incidental auto-capture but need not be pinned at the
+/// ceiling. `0.7` matches the importance the agents adapter and the memory-core
+/// restart test use for canonical curated content.
+/// What: a `0.0..=1.0` weight passed to the memory-core write path; the engine
+/// re-clamps defensively.
+/// Test: exercised indirectly by every `remember`/`note` test in `memory_tests`.
+const SM_DEFAULT_IMPORTANCE: f32 = 0.7;
+
+/// Structured errors for the SM memory subsystem (library code → `thiserror`).
+///
+/// Why: SM-4 is library code in `trusty-mpm-core`; per the workspace convention
+/// library errors are typed `thiserror` enums, never `unwrap()`/`panic!`. A
+/// memory backend that is unavailable (corrupt store, missing model, locked
+/// palace) must degrade into a clear, matchable error the caller can log and
+/// proceed past — not crash the daemon.
+/// What: wraps the two failure surfaces — palace lifecycle (`anyhow` from the
+/// registry) and recall/remember/note operations — preserving the source chain.
+/// Test: `construct_on_unwritable_root_is_error` asserts the `Palace` variant;
+/// the happy-path tests assert `Ok`.
+#[derive(Debug, thiserror::Error)]
+pub enum SmMemoryError {
+    /// Ensuring the dedicated palace exists (open-or-create) failed.
+    #[error("session-manager palace '{palace}' unavailable: {source}")]
+    Palace {
+        /// The SM palace id the operation targeted.
+        palace: String,
+        /// The underlying registry/store error.
+        source: anyhow::Error,
+    },
+
+    /// A recall / remember / note operation against the SM palace failed.
+    #[error("session-manager memory operation '{op}' failed: {source}")]
+    Operation {
+        /// Short operation tag (`"recall"`, `"recall_deep"`, `"remember"`,
+        /// `"note"`) for actionable logs.
+        op: &'static str,
+        /// The underlying engine error.
+        source: anyhow::Error,
+    },
+}
+
+/// Result alias for SM memory operations.
+///
+/// Why: keeps the public signatures terse and consistent with the rest of the
+/// `sm` module.
+/// What: `Result<T, SmMemoryError>`.
+/// Test: used throughout `memory_tests`.
+pub type SmMemoryResult<T> = std::result::Result<T, SmMemoryError>;
+
+/// Dedicated Session-Manager memory palace, scoped to a single palace id.
+///
+/// Why: the SM needs durable cross-session memory it fully owns. Binding ONE
+/// [`PalaceId`] for the lifetime of the struct makes "SM only ever reads/writes
+/// its own palace" a structural invariant rather than a caller discipline —
+/// there is no API surface here that accepts a different palace id, so scope
+/// leakage is impossible by construction (the headline §8 guarantee).
+/// What: holds the open-handle [`PalaceRegistry`], the on-disk `data_root`, the
+/// bound `palace_id`, and the configured `recall_top_k`. Built via
+/// [`SmMemory::open`], which idempotently ensures the palace exists.
+/// Test: `palace_create_is_idempotent`, `remember_then_recall_round_trips`,
+/// `recall_is_scoped_to_sm_palace`, `data_survives_fresh_construction`,
+/// `writes_target_only_the_sm_palace` in `memory_tests`.
+#[derive(Clone)]
+pub struct SmMemory {
+    /// Open-handle registry (LRU-bounded). Cheap to clone — state is behind `Arc`.
+    registry: PalaceRegistry,
+    /// Directory under which the SM palace's `<id>/` subtree lives on disk.
+    data_root: PathBuf,
+    /// The single palace this SM instance is bound to. Never changes.
+    palace_id: PalaceId,
+    /// Number of recall hits to return (from [`SmMemoryConfig::recall_top_k`]).
+    recall_top_k: usize,
+}
+
+impl SmMemory {
+    /// Open the SM memory subsystem, idempotently ensuring its palace exists.
+    ///
+    /// Why: startup must guarantee the dedicated palace is present without
+    /// erroring when it already exists (the SM may restart against a populated
+    /// store). Calling this twice — in one process or across restarts — must
+    /// leave EXACTLY ONE palace on disk, never duplicate or wipe it.
+    /// What: derives `palace_id` from `cfg.palace`, then: if
+    /// `<data_root>/<id>/palace.json` already exists, opens it from disk;
+    /// otherwise creates and persists a fresh palace. Both paths register the
+    /// handle in the registry. Any failure is wrapped in
+    /// [`SmMemoryError::Palace`].
+    /// Test: `palace_create_is_idempotent` (two `open` calls → one palace),
+    /// `data_survives_fresh_construction` (restart survival).
+    pub fn open(data_root: impl Into<PathBuf>, cfg: &SmMemoryConfig) -> SmMemoryResult<Self> {
+        let data_root = data_root.into();
+        let palace_id = PalaceId::new(cfg.palace.clone());
+        let recall_top_k = cfg.recall_top_k as usize;
+
+        let registry =
+            PalaceRegistry::open(&data_root).map_err(|source| SmMemoryError::Palace {
+                palace: palace_id.to_string(),
+                source,
+            })?;
+
+        let me = Self {
+            registry,
+            data_root,
+            palace_id,
+            recall_top_k,
+        };
+        // Eagerly materialise the palace so the first recall/remember cannot race
+        // creation and so idempotency is observable immediately after `open`.
+        me.ensure_palace()?;
+        Ok(me)
+    }
+
+    /// The palace id this instance is bound to (read-only accessor).
+    ///
+    /// Why: tests and callers (and the future §7.5 injection point) need to
+    /// confirm which namespace the SM is scoped to without reaching into private
+    /// state; exposing the bound id makes the "SM-only" contract auditable.
+    /// What: returns the bound [`PalaceId`].
+    /// Test: `writes_target_only_the_sm_palace` asserts this equals the
+    /// configured name.
+    pub fn palace_id(&self) -> &PalaceId {
+        &self.palace_id
+    }
+
+    /// Open-or-create the bound palace, returning a live handle.
+    ///
+    /// Why: every operation needs a handle; centralising the idempotent
+    /// open-from-disk-else-create here means a single, well-tested code path
+    /// enforces "exactly one palace" for both construction and every later call.
+    /// What: returns the cached handle if registered; else opens from disk when
+    /// `palace.json` exists, otherwise creates and persists a new palace. Scoped
+    /// entirely to `self.palace_id` — no other id is reachable.
+    /// Test: `palace_create_is_idempotent`, `writes_target_only_the_sm_palace`.
+    fn ensure_palace(&self) -> SmMemoryResult<Arc<PalaceHandle>> {
+        if let Some(handle) = self.registry.get(&self.palace_id) {
+            return Ok(handle);
+        }
+
+        let palace_dir = self.data_root.join(self.palace_id.as_str());
+        let result = if palace_dir.join("palace.json").exists() {
+            self.registry.open_palace(&self.data_root, &self.palace_id)
+        } else {
+            let palace = Palace {
+                id: self.palace_id.clone(),
+                name: "Session Manager".to_string(),
+                description: Some(
+                    "Dedicated Session-Manager memory palace (DOC-14 §8): goals, \
+                     outcomes, and decisions across sessions."
+                        .to_string(),
+                ),
+                created_at: Utc::now(),
+                data_dir: palace_dir,
+            };
+            self.registry.create_palace(&self.data_root, palace)
+        };
+
+        result.map_err(|source| SmMemoryError::Palace {
+            palace: self.palace_id.to_string(),
+            source,
+        })
+    }
+
+    /// Recall the top-k SM memories matching `query` (standard L0+L1+L2 path).
+    ///
+    /// Why: feeds the SM's working context with its most relevant durable
+    /// knowledge (§8 / the future §7.5 step-3 injection). Scoped to the SM
+    /// palace only, so recall can never surface another namespace's facts.
+    /// What: ensures the palace, then runs memory-core's
+    /// `recall_with_default_embedder` against the bound handle with the
+    /// configured `recall_top_k`. Returns the ranked [`RecallResult`]s.
+    /// Test: `remember_then_recall_round_trips`, `recall_is_scoped_to_sm_palace`.
+    pub async fn recall(&self, query: &str) -> SmMemoryResult<Vec<RecallResult>> {
+        let handle = self.ensure_palace()?;
+        recall_with_default_embedder(&handle, query, self.recall_top_k)
+            .await
+            .map_err(|source| SmMemoryError::Operation {
+                op: "recall",
+                source,
+            })
+    }
+
+    /// Deep recall of the top-k SM memories (L0+L1+L3 path).
+    ///
+    /// Why: when the SM explicitly wants a heavier, full-corpus search (not the
+    /// metadata-filtered L2), this exposes the engine's deep path — still scoped
+    /// strictly to the SM palace.
+    /// What: ensures the palace, then delegates to
+    /// `recall_deep_with_default_embedder` with the configured `recall_top_k`.
+    /// Test: `recall_deep_round_trips`.
+    pub async fn recall_deep(&self, query: &str) -> SmMemoryResult<Vec<RecallResult>> {
+        let handle = self.ensure_palace()?;
+        recall_deep_with_default_embedder(&handle, query, self.recall_top_k)
+            .await
+            .map_err(|source| SmMemoryError::Operation {
+                op: "recall_deep",
+                source,
+            })
+    }
+
+    /// Remember a piece of prose (goal / outcome / decision) into the SM palace.
+    ///
+    /// Why: the SM persists durable cross-session knowledge through this single
+    /// write path. Routing every write through the bound palace id guarantees
+    /// the SM never writes elsewhere.
+    /// What: ensures the palace, then calls `PalaceHandle::remember` in the
+    /// `General` room at [`SM_DEFAULT_IMPORTANCE`] with no extra tags. Returns
+    /// the new drawer's UUID as a string.
+    /// Test: `remember_then_recall_round_trips`, `writes_target_only_the_sm_palace`.
+    pub async fn remember(&self, text: impl Into<String>) -> SmMemoryResult<String> {
+        let handle = self.ensure_palace()?;
+        handle
+            .remember(
+                text.into(),
+                RoomType::General,
+                Vec::new(),
+                SM_DEFAULT_IMPORTANCE,
+            )
+            .await
+            .map(|id| id.to_string())
+            .map_err(|source| SmMemoryError::Operation {
+                op: "remember",
+                source,
+            })
+    }
+
+    /// Note a short, curated SM fact, bypassing only the min-token gate.
+    ///
+    /// Why: SM decisions are sometimes terse ("Chose worktree-per-ticket") and
+    /// would trip the engine's token-length filter under the normal `remember`
+    /// path; `note` uses the curated-fact preset so short high-signal facts land
+    /// while noise patterns are still rejected. Scoped to the SM palace only.
+    /// What: ensures the palace, then calls `remember_with_options` with
+    /// [`RememberOptions::note`] (pins `UserFact`, skips the token check). Returns
+    /// the new drawer's UUID as a string.
+    /// Test: `note_stores_short_fact`, `writes_target_only_the_sm_palace`.
+    pub async fn note(&self, text: impl Into<String>) -> SmMemoryResult<String> {
+        let handle = self.ensure_palace()?;
+        handle
+            .remember_with_options(
+                text.into(),
+                RoomType::General,
+                Vec::new(),
+                SM_DEFAULT_IMPORTANCE,
+                RememberOptions::note(),
+            )
+            .await
+            .map(|id| id.to_string())
+            .map_err(|source| SmMemoryError::Operation { op: "note", source })
+    }
+
+    /// Number of palaces currently persisted under the SM data root.
+    ///
+    /// Why: the idempotency contract ("create twice → one palace") is most
+    /// directly asserted by counting palaces on disk; exposing this keeps the
+    /// test honest without reaching into registry internals.
+    /// What: lists persisted palaces via [`PalaceRegistry::list_palaces`] and
+    /// returns the count. Wrapped errors use [`SmMemoryError::Palace`].
+    /// Test: `palace_create_is_idempotent`, `writes_target_only_the_sm_palace`.
+    pub fn persisted_palace_count(&self) -> SmMemoryResult<usize> {
+        Self::count_persisted(&self.data_root, &self.palace_id)
+    }
+
+    /// Count persisted palaces under `data_root` (free helper for tests/callers).
+    ///
+    /// Why: lets a test count palaces from a path without first building an
+    /// `SmMemory`, keeping the idempotency assertions independent of the very
+    /// object under test where useful.
+    /// What: delegates to [`PalaceRegistry::list_palaces`]; maps failure to
+    /// [`SmMemoryError::Palace`] tagged with `palace_id`.
+    /// Test: `palace_create_is_idempotent`.
+    fn count_persisted(data_root: &Path, palace_id: &PalaceId) -> SmMemoryResult<usize> {
+        PalaceRegistry::list_palaces(data_root)
+            .map(|palaces| palaces.len())
+            .map_err(|source| SmMemoryError::Palace {
+                palace: palace_id.to_string(),
+                source,
+            })
+    }
+}
+
+#[cfg(test)]
+#[path = "memory_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/sm/memory_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/memory_tests.rs
@@ -1,0 +1,269 @@
+//! Tests for the SM dedicated memory palace + recall/remember wiring (SM-4).
+//!
+//! Why: prove the §8 contract — idempotent palace creation, scoped
+//! remember→recall, strict SM-only scope, restart survival, and that writes
+//! never target a non-SM palace. All tests point the engine at a `tempdir` so
+//! they never touch the real `~/.trusty-mpm` data, and seed the MOCK embedder so
+//! they run without the ONNX model (no `#[ignore]` needed — the lexical/L2 path
+//! with a deterministic mock embedding is sufficient).
+//! What: a `tempfile::TempDir` per test plus `seed_shared_embedder_with_mock()`
+//! to avoid any HuggingFace download.
+
+use super::*;
+use tempfile::TempDir;
+use trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock;
+
+use crate::core::sm::config::SmMemoryConfig;
+
+/// Build an `SmMemory` rooted at a fresh tempdir with the default SM palace
+/// name, seeding the mock embedder first.
+///
+/// Why: every test needs an isolated store + a deterministic embedder; this
+/// keeps each test focused on the behaviour it asserts.
+/// What: seeds the mock embedder, returns `(SmMemory, TempDir)` — the caller
+/// holds the `TempDir` so it isn't dropped (which would delete the store).
+/// Test: used by every test below.
+fn sm_memory() -> (SmMemory, TempDir) {
+    seed_shared_embedder_with_mock();
+    let dir = TempDir::new().expect("tempdir");
+    let cfg = SmMemoryConfig::default();
+    let mem = SmMemory::open(dir.path(), &cfg).expect("open SM memory");
+    (mem, dir)
+}
+
+/// Why: idempotency is the headline SM-4 guarantee — ensuring the palace twice
+/// (here: a second `SmMemory::open` against the same root) must NOT create a
+/// duplicate or wipe the first; exactly one palace must persist.
+/// What: opens SM memory twice against the same data root, then asserts exactly
+/// one persisted palace named `"session-manager"`.
+/// Test: this is the test.
+#[test]
+fn palace_create_is_idempotent() {
+    seed_shared_embedder_with_mock();
+    let dir = TempDir::new().expect("tempdir");
+    let cfg = SmMemoryConfig::default();
+
+    let first = SmMemory::open(dir.path(), &cfg).expect("first open");
+    assert_eq!(first.persisted_palace_count().expect("count"), 1);
+
+    // Second construction against the same root must be a no-op create.
+    let second = SmMemory::open(dir.path(), &cfg).expect("second open");
+    assert_eq!(
+        second.persisted_palace_count().expect("count"),
+        1,
+        "creating the SM palace twice must yield exactly ONE palace"
+    );
+    assert_eq!(second.palace_id().as_str(), "session-manager");
+}
+
+/// Why: the core round-trip — a remembered fact must be retrievable via recall
+/// from the SM palace.
+/// What: remembers a distinctive sentence, recalls a related query, asserts the
+/// remembered content appears among the hits.
+/// Test: this is the test.
+#[tokio::test]
+async fn remember_then_recall_round_trips() {
+    let (mem, _dir) = sm_memory();
+
+    mem.remember("The session manager delegates all engineering work to t-mpm sessions")
+        .await
+        .expect("remember");
+
+    let hits = mem
+        .recall("who does the session manager delegate work to")
+        .await
+        .expect("recall");
+
+    assert!(
+        hits.iter()
+            .any(|h| h.drawer.content.contains("delegates all engineering work")),
+        "recall must surface the remembered SM fact; got {hits:?}"
+    );
+}
+
+/// Why: deep recall (L0+L1+L3) must also return SM facts, proving the deep path
+/// is wired and scoped.
+/// What: remembers a fact, runs `recall_deep`, asserts the fact is present.
+/// Test: this is the test.
+#[tokio::test]
+async fn recall_deep_round_trips() {
+    let (mem, _dir) = sm_memory();
+
+    mem.remember("Decision: adopt worktree-per-ticket discipline for all SM work")
+        .await
+        .expect("remember");
+
+    let hits = mem
+        .recall_deep("what discipline did we adopt for tickets")
+        .await
+        .expect("recall_deep");
+
+    assert!(
+        hits.iter()
+            .any(|h| h.drawer.content.contains("worktree-per-ticket")),
+        "recall_deep must surface the remembered SM fact; got {hits:?}"
+    );
+}
+
+/// Why: `note` stores short curated facts that the normal `remember` token gate
+/// would reject — proving the curated-fact path works end to end.
+/// What: notes a terse decision, recalls it, asserts it is retrievable.
+/// Test: this is the test.
+#[tokio::test]
+async fn note_stores_short_fact() {
+    let (mem, _dir) = sm_memory();
+
+    // Short enough to trip the min-token gate on the plain `remember` path.
+    mem.note("Goal: ship SM-4").await.expect("note short fact");
+
+    let hits = mem.recall("what is the goal").await.expect("recall");
+    assert!(
+        hits.iter().any(|h| h.drawer.content.contains("ship SM-4")),
+        "note must store a short curated fact retrievable via recall; got {hits:?}"
+    );
+}
+
+/// Why: scope isolation — facts written to the SM palace must surface ONLY when
+/// recalling the SM palace; a sibling palace under the same data root must not
+/// leak its content into SM recall (and vice versa).
+/// What: writes a distinctive fact to the SM palace, then builds a SECOND
+/// `SmMemory` bound to a different palace name under the SAME root, writes a
+/// different fact there, and asserts each recall sees only its own palace's fact.
+/// Test: this is the test.
+#[tokio::test]
+async fn recall_is_scoped_to_sm_palace() {
+    seed_shared_embedder_with_mock();
+    let dir = TempDir::new().expect("tempdir");
+
+    let sm_cfg = SmMemoryConfig::default(); // "session-manager"
+    let sm = SmMemory::open(dir.path(), &sm_cfg).expect("open SM");
+    sm.remember("SM_PALACE_SECRET zebra orchestration delegation marker")
+        .await
+        .expect("remember in SM palace");
+
+    let other_cfg = SmMemoryConfig {
+        palace: "some-other-project".to_string(),
+        recall_top_k: 6,
+    };
+    let other = SmMemory::open(dir.path(), &other_cfg).expect("open other");
+    other
+        .remember("OTHER_PALACE_SECRET giraffe unrelated project marker")
+        .await
+        .expect("remember in other palace");
+
+    // SM recall must NOT see the other palace's marker.
+    let sm_hits = sm.recall("secret marker").await.expect("sm recall");
+    assert!(
+        sm_hits
+            .iter()
+            .all(|h| !h.drawer.content.contains("OTHER_PALACE_SECRET")),
+        "SM recall must never surface another palace's content; got {sm_hits:?}"
+    );
+
+    // The other palace's recall must NOT see the SM marker.
+    let other_hits = other.recall("secret marker").await.expect("other recall");
+    assert!(
+        other_hits
+            .iter()
+            .all(|h| !h.drawer.content.contains("SM_PALACE_SECRET")),
+        "non-SM recall must never surface SM content; got {other_hits:?}"
+    );
+}
+
+/// Why: restart survival — remembered SM data must persist across a FRESH
+/// `SmMemory` construction pointing at the same storage (process restart).
+/// What: remembers a fact, drops the first `SmMemory`, builds a new one against
+/// the same root, and recalls the fact successfully.
+/// Test: this is the test.
+#[tokio::test]
+async fn data_survives_fresh_construction() {
+    seed_shared_embedder_with_mock();
+    let dir = TempDir::new().expect("tempdir");
+    let cfg = SmMemoryConfig::default();
+
+    {
+        let mem = SmMemory::open(dir.path(), &cfg).expect("first open");
+        mem.remember("Persistent SM outcome: SM-3 merged to main successfully")
+            .await
+            .expect("remember");
+        // `mem` drops here, simulating a process restart.
+    }
+
+    // Fresh construction against the same storage.
+    let reopened = SmMemory::open(dir.path(), &cfg).expect("reopen");
+    assert_eq!(
+        reopened.persisted_palace_count().expect("count"),
+        1,
+        "reopen must reuse the existing palace, not create a second"
+    );
+
+    let hits = reopened
+        .recall("which SM ticket merged to main")
+        .await
+        .expect("recall after restart");
+    assert!(
+        hits.iter()
+            .any(|h| h.drawer.content.contains("SM-3 merged to main")),
+        "remembered data must survive a fresh SmMemory construction; got {hits:?}"
+    );
+}
+
+/// Why: the structural "SM never writes to a non-SM palace" guarantee — every
+/// write goes to the bound palace id and to no other namespace, regardless of
+/// how many writes occur.
+/// What: performs `remember`, `note`, and another `remember`, then asserts the
+/// bound `palace_id` is the configured SM name and that exactly ONE palace
+/// exists on disk (so no stray palace was created by any write).
+/// Test: this is the test.
+#[tokio::test]
+async fn writes_target_only_the_sm_palace() {
+    let (mem, _dir) = sm_memory();
+
+    assert_eq!(
+        mem.palace_id().as_str(),
+        "session-manager",
+        "SM must be bound to the configured palace name"
+    );
+
+    mem.remember("first SM write — a goal for the milestone")
+        .await
+        .expect("remember 1");
+    mem.note("terse SM decision").await.expect("note");
+    mem.remember("third SM write — an outcome record for the milestone")
+        .await
+        .expect("remember 2");
+
+    assert_eq!(
+        mem.persisted_palace_count().expect("count"),
+        1,
+        "no write may create or touch a palace other than the bound SM palace"
+    );
+}
+
+/// Why: graceful degradation — when the palace cannot be ensured (here: a data
+/// root that cannot be created because a FILE exists at that path), `open` must
+/// return a structured `SmMemoryError::Palace`, not panic.
+/// What: creates a regular file, then tries to root `SmMemory` at a path BELOW
+/// that file (so `create_dir_all` fails), and asserts the `Palace` error variant.
+/// Test: this is the test.
+#[test]
+fn construct_on_unwritable_root_is_error() {
+    seed_shared_embedder_with_mock();
+    let dir = TempDir::new().expect("tempdir");
+    let file_path = dir.path().join("not-a-dir");
+    std::fs::write(&file_path, b"x").expect("write blocking file");
+
+    // Rooting under a path whose parent is a file makes create_dir_all fail.
+    let bad_root = file_path.join("child");
+    let cfg = SmMemoryConfig::default();
+
+    // `SmMemory` is not `Debug` (it owns a non-`Debug` registry), so match on the
+    // error directly rather than via `expect_err`.
+    match SmMemory::open(&bad_root, &cfg) {
+        Ok(_) => panic!("must fail to create store under a file"),
+        Err(err) => assert!(
+            matches!(err, SmMemoryError::Palace { .. }),
+            "unavailable backend must degrade to SmMemoryError::Palace, got {err:?}"
+        ),
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/memory_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/memory_tests.rs
@@ -56,6 +56,57 @@ fn palace_create_is_idempotent() {
     assert_eq!(second.palace_id().as_str(), "session-manager");
 }
 
+/// Why: the TOCTOU-race fix in `ensure_palace` must take the OPEN branch (not
+/// re-create) when the palace already exists on disk but is absent from THIS
+/// instance's registry cache — the exact situation a second concurrent or
+/// restarted SM faces after another process has already created the palace.
+/// This guards against the create-when-exists fallback wiping or duplicating an
+/// existing palace.
+/// What: builds a first `SmMemory`, writes a distinctive fact (forcing the
+/// palace + content onto disk), drops it, then builds a SECOND `SmMemory` with a
+/// FRESH registry against the same root. The second instance must converge on
+/// the existing palace (exactly one persisted) AND surface the first instance's
+/// already-written fact via recall — proving it opened the existing palace
+/// rather than creating a fresh empty one.
+/// Test: this is the test.
+#[tokio::test]
+async fn ensure_palace_falls_back_to_open_when_palace_already_exists() {
+    seed_shared_embedder_with_mock();
+    let dir = TempDir::new().expect("tempdir");
+    let cfg = SmMemoryConfig::default();
+
+    // First instance materialises the palace and writes a marker fact.
+    {
+        let first = SmMemory::open(dir.path(), &cfg).expect("first open");
+        assert_eq!(first.persisted_palace_count().expect("count"), 1);
+        first
+            .remember("TOCTOU_MARKER existing palace content written by first SM")
+            .await
+            .expect("remember in first instance");
+        // `first` (and its registry cache) drops here — the palace now lives
+        // ONLY on disk, exactly as a second process would observe it.
+    }
+
+    // Second instance has a brand-new registry, so `ensure_palace` cannot hit
+    // the cached fast path — it must take the open-first branch against disk.
+    let second = SmMemory::open(dir.path(), &cfg).expect("second open");
+    assert_eq!(
+        second.persisted_palace_count().expect("count"),
+        1,
+        "create-when-exists fallback must open the existing palace, not add a second"
+    );
+
+    let hits = second
+        .recall("what marker did the first SM write")
+        .await
+        .expect("recall from second instance");
+    assert!(
+        hits.iter()
+            .any(|h| h.drawer.content.contains("TOCTOU_MARKER")),
+        "second SM must open the EXISTING palace (seeing prior content), not a fresh one; got {hits:?}"
+    );
+}
+
 /// Why: the core round-trip — a remembered fact must be retrievable via recall
 /// from the SM palace.
 /// What: remembers a distinctive sentence, recalls a related query, asserts the

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -16,11 +16,24 @@
 
 pub mod agent;
 pub mod config;
+/// Dedicated SM memory palace + recall/remember wiring (SM-4, DOC-14 §8).
+///
+/// Why: gated behind the `sm-memory` feature because it turns on
+/// `trusty-common/memory-core` — the heavy Memory Palace storage engine
+/// (usearch HNSW, redb, bundled-ORT FastEmbedder). Default and
+/// `--no-default-features` builds must not pay that cost, so the module (and its
+/// dependency) are strictly opt-in.
+/// What: re-compiled only under `--features sm-memory`.
+/// Test: `memory::tests` (run with `--features sm-memory`).
+#[cfg(feature = "sm-memory")]
+pub mod memory;
 pub mod prompt;
 pub mod providers;
 
 pub use agent::SessionManagerAgent;
 pub use config::{SessionManagerConfig, SmInferenceConfig, SmMemoryConfig, SmRoundsConfig};
+#[cfg(feature = "sm-memory")]
+pub use memory::{SmMemory, SmMemoryError, SmMemoryResult};
 pub use prompt::{
     FILE_SM_INSTRUCTIONS, FILE_SM_TOOLS, FILE_SM_WORKFLOW, SM_OVERRIDE_SUBDIR, assemble_sm_prompt,
     resolve_sm_prompt, resolve_sm_prompt_default, sm_override_dir,


### PR DESCRIPTION
Closes #1287. Part of epic #1283 (Session Manager / DOC-14). Builds on SM-1/SM-2/SM-3.

## Scope (SM-4)

Lands the SM's **dedicated memory palace + recall/remember wiring** (DOC-14 §8). Per spec ref **D8.3a** the SM calls the memory engine as a **DIRECT LIBRARY call** (`trusty-common` `memory_core`), not over MCP. This ticket is **palace + memory wiring ONLY** — it does NOT wire into any endpoint or the agent loop (that is SM-7/SM-8; the §7.5 step-3 recall-injection point lives in the future context engine).

## What changed

- **`crates/trusty-mpm/Cargo.toml`** — new `sm-memory` feature enabling `trusty-common/memory-core` (+ `embedder-test-support` for the mock embedder). **NOT in `default`** and **NOT in `--no-default-features`**, mirroring the existing opt-in `bedrock` pattern, so neither the default daemon build nor a no-default build pulls the heavy Memory Palace engine (usearch HNSW, redb, bundled-ORT FastEmbedder).
- **`crates/trusty-mpm/src/core/sm/memory.rs`** (new, 319 lines) — `SmMemory` wrapper:
  - Bound to **ONE** `PalaceId` (default `"session-manager"`) for its whole lifetime — there is no API that accepts a different palace id, so **SM-only scope is structural**, not caller discipline.
  - **Idempotent** open-or-create (open-from-disk if `palace.json` exists, else create+persist). Creating twice yields exactly one palace.
  - Scoped `recall(query)`, `recall_deep(query)`, `remember(text)`, `note(text)` — all against the bound palace.
  - Structured `SmMemoryError` (thiserror, no `unwrap`) → an unavailable backend degrades to a clear error, never a panic.
- **`crates/trusty-mpm/src/core/sm/mod.rs`** — re-exports `SmMemory` / `SmMemoryError` / `SmMemoryResult`, feature-gated.
- **`crates/trusty-mpm/src/core/sm/memory_tests.rs`** (new, test file).

## memory-core dependency / feature impact

- **No circular dependency**: `trusty-common` does not depend on `trusty-mpm`; this is a normal downstream lib dep.
- **Opt-in only**: gated behind `sm-memory` so default + `--no-default-features` builds are unaffected (verified — see below).

## Test evidence

8/8 SM-4 tests pass (`--features sm-memory`), all temp-dir isolated + mock-embedder (no ONNX, no `#[ignore]`):

\`\`\`
test core::sm::memory::tests::palace_create_is_idempotent ... ok
test core::sm::memory::tests::remember_then_recall_round_trips ... ok
test core::sm::memory::tests::recall_deep_round_trips ... ok
test core::sm::memory::tests::note_stores_short_fact ... ok
test core::sm::memory::tests::recall_is_scoped_to_sm_palace ... ok
test core::sm::memory::tests::data_survives_fresh_construction ... ok
test core::sm::memory::tests::writes_target_only_the_sm_palace ... ok
test core::sm::memory::tests::construct_on_unwritable_root_is_error ... ok
test result: ok. 8 passed; 0 failed; 0 ignored
\`\`\`

- `cargo clippy -p trusty-mpm --features sm-memory --all-targets -- -D warnings` — clean (only the known dual-build-target Cargo.toml note).
- `cargo test -p trusty-mpm` (default) — 1102 + 302 + … all green, no regressions.
- `cargo check -p trusty-mpm --no-default-features` — builds (pre-existing unrelated `supervisor` unused-import warnings only).
- `cargo check -p trusty-mpm --features daemon` — clean.
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)