### PR TITLE
feat(trusty-mpm): SM-6 goal-tracking model + dual (palace + cache) persistence (#1289)

### DIFF
--- a/crates/trusty-mpm/src/core/sm/goals/cache.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/cache.rs
@@ -121,6 +121,14 @@ impl GoalCache {
             TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::write(&tmp, &json).map_err(|source| SmGoalError::Io { source })?;
+        // Atomicity relies on POSIX rename-replace semantics: on macOS/Linux (the
+        // supported targets) rename atomically replaces an existing `target` on the
+        // same filesystem, so a reader sees either the old or the new file, never a
+        // partial write. On platforms WITHOUT rename-replace (notably Windows,
+        // where rename-over-existing can fail), a failed rename may leave the
+        // `.tmp.*` file behind; the best-effort cleanup below removes it on the
+        // error path. trusty-mpm targets macOS/Linux, so this is documented, not a
+        // bug we guard against here.
         std::fs::rename(&tmp, &target).map_err(|source| {
             // Best-effort cleanup of the temp file on a failed rename.
             let _ = std::fs::remove_file(&tmp);

--- a/crates/trusty-mpm/src/core/sm/goals/cache.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/cache.rs
@@ -1,0 +1,167 @@
+//! Atomic `goals.json` hot-cache persistence for the SM goal store (§9.4).
+//!
+//! Why: §9.4 mirrors the active goal set in a daemon state file
+//! (`~/.trusty-mpm/sm/goals.json`) so the TUI can render goals without a memory
+//! round-trip on every poll. The palace is the source of truth; this file is a
+//! DERIVED cache, rebuilt from the palace on startup and re-written on every
+//! mutation. The write must be ATOMIC — a crash mid-write must never leave a
+//! truncated, unparseable cache — so we write to a sibling temp file and rename it
+//! over the target (atomic on the same filesystem), exactly mirroring SM-5's
+//! conversation-state store. The storage ROOT is injectable so tests use a
+//! `tempdir` instead of the real home directory.
+//! What: [`GoalCache`] owns the `<root>/sm/` directory and the `goals.json` path;
+//! [`GoalCache::save`] serialises the goal list via write-tmp-then-rename, and
+//! [`GoalCache::load`] reconstructs it (a missing file loads as an empty list, so
+//! first-touch is not an error). Errors map to the shared [`SmGoalError`].
+//! Test: `goals/cache_tests.rs` covers round-trip identity, atomic overwrite, the
+//! missing-file → empty path, and a malformed-file error.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::error::{SmGoalError, SmGoalResult};
+use super::model::Goal;
+
+/// Process-wide monotonic counter that uniquifies temp-file names per `save`.
+///
+/// Why: two `save` calls in the same nanosecond (coarse clock) would otherwise
+/// generate identical temp paths and race; a monotonic counter mixed with the
+/// wall-clock nanos guarantees a distinct temp path per call (same rationale as
+/// SM-5's conversation store).
+/// What: incremented once per `save`; mixed into the temp filename.
+/// Test: exercised indirectly by the cache round-trip tests.
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Subdirectory under the data root that holds SM state files.
+///
+/// Why: §9.4 nests `goals.json` under `~/.trusty-mpm/sm/`, alongside the SM
+/// conversation state files; isolating the segment keeps the layout consistent.
+/// What: the `"sm"` path segment joined under the injected root.
+/// Test: `cache_path_is_under_sm_subdir`.
+pub const SM_STATE_SUBDIR: &str = "sm";
+
+/// The cache filename under the `sm/` subdirectory.
+///
+/// Why: a single well-known name (`goals.json`, §9.4) the TUI and the store agree
+/// on.
+/// What: the basename joined under `<root>/sm/`.
+/// Test: `cache_path_is_under_sm_subdir`.
+pub const GOALS_CACHE_FILE: &str = "goals.json";
+
+/// Atomic, root-injectable store for the `goals.json` hot cache (§9.4).
+///
+/// Why: centralises the path layout and the write-tmp-then-rename atomicity in one
+/// tested type, and makes the storage root a constructor argument so tests never
+/// write to `~/.trusty-mpm`. The daemon (SM-7) builds it from the real data dir;
+/// tests build it from a `tempdir`.
+/// What: holds `<root>/sm/` and persists the goal list as `goals.json`.
+/// Test: `goals/cache_tests.rs`.
+#[derive(Debug, Clone)]
+pub struct GoalCache {
+    /// `<data_root>/sm/` — the directory holding the cache file.
+    dir: PathBuf,
+}
+
+impl GoalCache {
+    /// Build a cache rooted at `data_root` (the SM data directory).
+    ///
+    /// Why: the daemon passes the real `~/.trusty-mpm` while tests pass a
+    /// `tempdir`; the cache derives its `sm/` subdir from whichever root it is
+    /// given, so the same code path is exercised in both.
+    /// What: joins [`SM_STATE_SUBDIR`] under `data_root`. The directory is created
+    /// lazily on the first `save`, so merely constructing performs no I/O.
+    /// Test: `cache_path_is_under_sm_subdir`, `save_creates_sm_subdir`.
+    pub fn new(data_root: impl Into<PathBuf>) -> Self {
+        Self {
+            dir: data_root.into().join(SM_STATE_SUBDIR),
+        }
+    }
+
+    /// The on-disk path of the `goals.json` cache.
+    ///
+    /// Why: callers/tests need to assert/locate the exact file; it also drives
+    /// `save`/`load`.
+    /// What: returns `<root>/sm/goals.json`.
+    /// Test: `cache_path_is_under_sm_subdir`.
+    pub fn path(&self) -> PathBuf {
+        self.dir.join(GOALS_CACHE_FILE)
+    }
+
+    /// The directory holding the cache (read-only accessor).
+    ///
+    /// Why: tests assert the layout; diagnostics may want it.
+    /// What: returns `<root>/sm/`.
+    /// Test: `cache_path_is_under_sm_subdir`.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Atomically persist the goal list to `goals.json` (§9.4).
+    ///
+    /// Why: a daemon crash mid-write must never corrupt the cache; an atomic
+    /// rename guarantees readers see either the old or the new content, never a
+    /// partial write.
+    /// What: ensures the `sm/` directory exists, serialises `goals` to pretty JSON,
+    /// writes it to a sibling temp file whose name is unique per call, then renames
+    /// the temp file over the target. Failures map to [`SmGoalError`].
+    /// Test: `save_then_load_round_trips`, `save_is_atomic_overwrite`,
+    /// `save_creates_sm_subdir`.
+    pub fn save(&self, goals: &[Goal]) -> SmGoalResult<()> {
+        std::fs::create_dir_all(&self.dir).map_err(|source| SmGoalError::Io { source })?;
+
+        let json =
+            serde_json::to_vec_pretty(goals).map_err(|source| SmGoalError::Serde { source })?;
+
+        let target = self.path();
+        let tmp = self.dir.join(format!(
+            "{GOALS_CACHE_FILE}.tmp.{}.{}.{}",
+            std::process::id(),
+            unique_temp_token(),
+            TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&tmp, &json).map_err(|source| SmGoalError::Io { source })?;
+        std::fs::rename(&tmp, &target).map_err(|source| {
+            // Best-effort cleanup of the temp file on a failed rename.
+            let _ = std::fs::remove_file(&tmp);
+            SmGoalError::Io { source }
+        })?;
+        Ok(())
+    }
+
+    /// Load the goal list from `goals.json`, or an empty list if absent (§9.4).
+    ///
+    /// Why: on startup, before the palace rebuild runs (or as the fallback when the
+    /// palace is unavailable), the cache is read; a never-written cache must load
+    /// as empty rather than erroring.
+    /// What: returns `vec![]` when the file is absent. Otherwise reads and
+    /// deserialises it. A present but malformed file is a hard
+    /// [`SmGoalError::Serde`] (corruption the operator should see).
+    /// Test: `save_then_load_round_trips`, `load_missing_is_empty`,
+    /// `load_rejects_malformed_file`.
+    pub fn load(&self) -> SmGoalResult<Vec<Goal>> {
+        match std::fs::read(self.path()) {
+            Ok(bytes) => {
+                serde_json::from_slice(&bytes).map_err(|source| SmGoalError::Serde { source })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(source) => Err(SmGoalError::Io { source }),
+        }
+    }
+}
+
+/// Wall-clock nanoseconds since the Unix epoch, for temp-file uniqueness.
+///
+/// Why: combined with the pid and the monotonic counter, the nanosecond timestamp
+/// makes a temp filename overwhelmingly unlikely to collide (same approach as
+/// SM-5's conversation store).
+/// What: returns `SystemTime::now()` as nanos since the epoch, falling back to `0`
+/// if the clock predates the epoch (the counter still guarantees per-call
+/// uniqueness, so `0` is safe).
+/// Test: exercised indirectly by the cache round-trip tests.
+fn unique_temp_token() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}

--- a/crates/trusty-mpm/src/core/sm/goals/cache_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/cache_tests.rs
@@ -1,0 +1,125 @@
+//! Tests for the atomic `goals.json` hot cache (SM-6, DOC-14 §9.4).
+//!
+//! Why: prove the cache contract the store relies on — the file lives under
+//! `<root>/sm/goals.json`, save→load round-trips, save atomically overwrites, a
+//! missing file loads as empty (first-touch is not an error), and a malformed file
+//! is a hard error. All tests point at a `tempdir` so they never touch the real
+//! `~/.trusty-mpm`.
+
+use super::cache::{GOALS_CACHE_FILE, GoalCache, SM_STATE_SUBDIR};
+use super::error::SmGoalError;
+use super::model::{Goal, GoalStatus};
+use chrono::{TimeZone, Utc};
+use tempfile::TempDir;
+
+fn ts() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 16, 12, 0, 0).unwrap()
+}
+
+fn sample_goals() -> Vec<Goal> {
+    let mut a = Goal::new("g-aaaa1111", "first goal", vec!["t1".into()], ts());
+    a.status = GoalStatus::InProgress;
+    let b = Goal::new("g-bbbb2222", "second goal", vec![], ts());
+    vec![a, b]
+}
+
+/// Why: the cache path must be exactly `<root>/sm/goals.json` (§9.4) so the TUI
+/// and the store agree on where it lives.
+/// What: asserts `dir()` ends in `sm` and `path()` is the well-known file.
+/// Test: this is the test.
+#[test]
+fn cache_path_is_under_sm_subdir() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache = GoalCache::new(dir.path());
+    assert!(cache.dir().ends_with(SM_STATE_SUBDIR));
+    assert!(
+        cache
+            .path()
+            .ends_with(format!("{SM_STATE_SUBDIR}/{GOALS_CACHE_FILE}"))
+    );
+}
+
+/// Why: the core round-trip — saved goals must reload byte-identically.
+/// What: saves a goal list, loads it, asserts equality.
+/// Test: this is the test.
+#[test]
+fn save_then_load_round_trips() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache = GoalCache::new(dir.path());
+    let goals = sample_goals();
+
+    cache.save(&goals).expect("save");
+    let back = cache.load().expect("load");
+    assert_eq!(goals, back);
+}
+
+/// Why: a never-written cache must load as an empty list, not error — first-touch
+/// on a fresh daemon is normal.
+/// What: loads from a fresh root, asserts an empty vec.
+/// Test: this is the test.
+#[test]
+fn load_missing_is_empty() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache = GoalCache::new(dir.path());
+    assert!(cache.load().expect("load").is_empty());
+}
+
+/// Why: `save` must create the `sm/` subdir lazily (constructing the cache does no
+/// I/O), so the daemon need not pre-create it.
+/// What: saves into a fresh root and asserts the file now exists.
+/// Test: this is the test.
+#[test]
+fn save_creates_sm_subdir() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache = GoalCache::new(dir.path());
+    assert!(!cache.dir().exists(), "no I/O before save");
+    cache.save(&sample_goals()).expect("save");
+    assert!(cache.path().exists(), "save must create the cache file");
+}
+
+/// Why: re-saving must atomically REPLACE the file (write-tmp-then-rename), leaving
+/// exactly the new content and no stray temp files.
+/// What: saves twice with different content, asserts the second wins and only the
+/// cache file remains in the dir.
+/// Test: this is the test.
+#[test]
+fn save_is_atomic_overwrite() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache = GoalCache::new(dir.path());
+
+    cache.save(&sample_goals()).expect("first save");
+    let smaller = vec![Goal::new("g-cccc3333", "only goal", vec![], ts())];
+    cache.save(&smaller).expect("second save");
+
+    let back = cache.load().expect("load");
+    assert_eq!(back, smaller, "second save must fully replace the first");
+
+    let entries: Vec<_> = std::fs::read_dir(cache.dir())
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        entries,
+        vec![GOALS_CACHE_FILE.to_string()],
+        "only the cache file must remain — no leaked temp files; got {entries:?}"
+    );
+}
+
+/// Why: a present-but-corrupt cache is operator-visible corruption, not silently
+/// discarded — it must surface as a hard `Serde` error.
+/// What: writes garbage to the cache path then asserts `load` returns
+/// `SmGoalError::Serde`.
+/// Test: this is the test.
+#[test]
+fn load_rejects_malformed_file() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache = GoalCache::new(dir.path());
+    std::fs::create_dir_all(cache.dir()).expect("mkdir");
+    std::fs::write(cache.path(), b"{ this is not valid json").expect("write garbage");
+
+    match cache.load() {
+        Err(SmGoalError::Serde { .. }) => {}
+        other => panic!("malformed cache must be a Serde error, got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/goals/error.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/error.rs
@@ -1,0 +1,75 @@
+//! Structured errors for the SM goal store (DOC-14 §9).
+//!
+//! Why: SM-6 is library code in `trusty-mpm-core`; per the workspace convention
+//! library failures surface as typed, matchable `thiserror` enums rather than
+//! `unwrap()`/`panic!`. The two operator-facing failure modes — an unknown goal
+//! id and a verification-gate rejection (§3.5) — must be DISTINCT variants so the
+//! future endpoint/loop (SM-7/SM-8) can render a precise message; the I/O and
+//! palace surfaces degrade gracefully so a missing cache or unavailable palace
+//! never crashes the daemon.
+//! What: [`SmGoalError`] wraps not-found, the verification-gate rejection, cache
+//! I/O, JSON (de)serialisation, and palace-memory failures, preserving the source
+//! chain where one exists.
+//! Test: `goals/store_tests.rs` asserts the `NotFound` and `VerificationGate`
+//! variants on their respective paths; happy paths assert `Ok`.
+
+/// Structured errors for goal-store operations (library → `thiserror`).
+///
+/// Why: see the module docs — distinct, matchable variants for the gate and
+/// not-found cases, plus graceful wrappers for the persistence surfaces.
+/// What: the five failure modes of the goal store.
+/// Test: `close_without_all_verified_is_rejected` (gate),
+/// `link_unknown_goal_is_not_found` (not-found).
+#[derive(Debug, thiserror::Error)]
+pub enum SmGoalError {
+    /// No goal exists with the referenced id.
+    #[error("goal '{0}' not found")]
+    NotFound(String),
+
+    /// The verification gate (§3.5) refused a `Done` transition because not every
+    /// linked task is `Verified`. Carries the offending goal id plus the
+    /// verified/total counts so the caller can render an actionable message.
+    #[error(
+        "verification gate: goal '{goal_id}' cannot be marked Done — \
+         {verified}/{total} linked tasks verified (all must be Verified)"
+    )]
+    VerificationGate {
+        /// The goal that failed the gate.
+        goal_id: String,
+        /// How many linked tasks are `Verified`.
+        verified: usize,
+        /// Total linked tasks.
+        total: usize,
+    },
+
+    /// A cache filesystem operation (mkdir / write / rename / read) failed.
+    #[error("goal cache I/O failed: {source}")]
+    Io {
+        /// The underlying filesystem error.
+        source: std::io::Error,
+    },
+
+    /// Serialising or deserialising the goal cache JSON failed.
+    #[error("goal cache (de)serialisation failed: {source}")]
+    Serde {
+        /// The underlying serde_json error.
+        source: serde_json::Error,
+    },
+
+    /// A palace-memory operation (the source-of-truth write/enumerate) failed.
+    #[error("goal palace persistence failed: {message}")]
+    Palace {
+        /// The underlying memory error, as a string (the concrete `SmMemoryError`
+        /// lives behind the `sm-memory` feature, so it is captured as a message to
+        /// keep this error type feature-independent).
+        message: String,
+    },
+}
+
+/// Result alias for goal-store operations.
+///
+/// Why: keeps the public signatures terse and consistent with the rest of the
+/// `sm` module (mirrors `SmMemoryResult` / `ConversationStoreResult`).
+/// What: `Result<T, SmGoalError>`.
+/// Test: used throughout `goals/store_tests.rs`.
+pub type SmGoalResult<T> = std::result::Result<T, SmGoalError>;

--- a/crates/trusty-mpm/src/core/sm/goals/memory.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/memory.rs
@@ -1,0 +1,91 @@
+//! Palace-memory seam for the SM goal store (DOC-14 §9.4).
+//!
+//! Why: the goal store treats the SM palace as its source of truth, but it must
+//! (a) be UNIT-TESTABLE without the heavy ONNX-backed Memory Palace, and (b)
+//! depend on an ABSTRACTION rather than the concrete `SmMemory` (which lives
+//! behind the `sm-memory` feature) so the store compiles and is testable on the
+//! default build. This module is that seam: a tiny async trait the store writes
+//! through, implemented by `SmMemory` under `--features sm-memory` and by an
+//! in-memory mock in tests. Per §9.4 the palace is durable truth and `goals.json`
+//! is a cache rebuilt from it, so the trait surfaces exactly two operations — a
+//! tagged write and a tag-scoped enumeration — and nothing else.
+//! What: defines [`GoalMemory`] (two async methods returning a `String` error so
+//! the trait stays feature-independent) and, behind `sm-memory`, implements it for
+//! [`super::super::memory::SmMemory`] by delegating to its `remember_tagged` /
+//! `list_tagged` scoped-write/enumerate methods.
+//! Test: the mock impl in `goals/store_tests.rs` exercises the store; the real
+//! `SmMemory` impl is covered by the `#[ignore]`-free seam delegation plus the
+//! SM-4 scope tests it reuses.
+
+use async_trait::async_trait;
+
+/// The stable palace tag every SM goal entry carries (DOC-14 §9.4).
+///
+/// Why: rebuilding the cache enumerates goal entries by an exact tag (not fuzzy
+/// recall), so the write and the enumerate must agree on one constant. Isolating
+/// it here makes the contract auditable and impossible to typo apart.
+/// What: the `"sm-goal"` tag attached to every persisted goal drawer and used as
+/// the [`GoalMemory::list_goals`] filter.
+/// Test: `goals/store_tests.rs` round-trips writes and reads through this tag via
+/// the mock; the production path reuses the same constant.
+pub const GOAL_TAG: &str = "sm-goal";
+
+/// Abstraction over the SM palace for goal persistence (the source of truth).
+///
+/// Why: decouples [`super::store::SmGoalStore`] from the concrete, feature-gated
+/// `SmMemory` (Dependency Inversion) so the store is testable with a mock and
+/// builds without the `sm-memory` feature. The two methods are the complete set
+/// the store needs: persist a serialised goal (tagged for later enumeration) and
+/// enumerate every persisted goal deterministically on startup.
+/// What: an async trait with `remember_goal` (write one tagged JSON entry) and
+/// `list_goals` (return every entry's raw JSON for `tag`). Errors are `String`s so
+/// the trait carries no dependency on the feature-gated `SmMemoryError`.
+/// Test: the mock in `goals/store_tests.rs`; the `SmMemory` impl below.
+#[async_trait]
+pub trait GoalMemory: Send + Sync {
+    /// Persist a serialised goal as a tagged palace entry (source of truth).
+    ///
+    /// Why: every goal mutation re-writes the goal's current JSON to the palace so
+    /// the palace always holds the latest state — the cache is derived from it.
+    /// What: writes `json` to the SM palace tagged with `tag` (always
+    /// [`GOAL_TAG`]); returns `Ok(())` on success or a message on failure.
+    /// Test: mock asserts the entry is stored; `SmMemory` impl delegates to
+    /// `remember_tagged`.
+    async fn remember_goal(&self, json: String, tag: &str) -> Result<(), String>;
+
+    /// Enumerate the raw JSON of every persisted goal entry carrying `tag`.
+    ///
+    /// Why: startup rebuilds the hot cache from the palace — it must see EVERY
+    /// goal, deterministically, not an embedding-ranked subset.
+    /// What: returns each matching entry's stored JSON string; `Ok(vec![])` when
+    /// none exist.
+    /// Test: mock returns the stored set; `SmMemory` impl delegates to
+    /// `list_tagged`.
+    async fn list_goals(&self, tag: &str) -> Result<Vec<String>, String>;
+}
+
+/// `SmMemory` is the production [`GoalMemory`]: the dedicated SM palace.
+///
+/// Why: in the daemon the goal store's source of truth is the real SM palace
+/// (§9.4). Implementing the seam directly on `SmMemory` keeps writes scoped to the
+/// SM palace by construction (SM-4 guarantees) while the store stays
+/// palace-agnostic.
+/// What: delegates `remember_goal` → `SmMemory::remember_tagged` and `list_goals`
+/// → `SmMemory::list_tagged`, mapping the structured `SmMemoryError` to a message.
+/// Gated behind `sm-memory` because `SmMemory` (and its heavy memory-core dep) is.
+/// Test: exercised whenever the store is built over a real `SmMemory` (the
+/// `sm-memory` feature build); the SM-4 scope tests cover the underlying writes.
+#[cfg(feature = "sm-memory")]
+#[async_trait]
+impl GoalMemory for super::super::memory::SmMemory {
+    async fn remember_goal(&self, json: String, tag: &str) -> Result<(), String> {
+        self.remember_tagged(json, vec![tag.to_string()])
+            .await
+            .map(|_id| ())
+            .map_err(|e| e.to_string())
+    }
+
+    async fn list_goals(&self, tag: &str) -> Result<Vec<String>, String> {
+        self.list_tagged(tag).map_err(|e| e.to_string())
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/goals/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/mod.rs
@@ -1,0 +1,44 @@
+//! Goal-tracking model + dual persistence for the Session Manager (DOC-14 §9).
+//!
+//! Why: the SM tracks operator intent as durable [`Goal`]s, each fanned out to
+//! one-or-many delegated t-mpm sessions, with progress and a BLOCKING
+//! verification gate (§3.5) DERIVED from per-session verification state. Goals are
+//! the central SM artifact and must outlive daemon restarts, so they use a DUAL
+//! persistence design (§9.4): the dedicated SM palace (SM-4) is the source of
+//! truth, and `~/.trusty-mpm/sm/goals.json` is a hot cache rebuilt from the palace
+//! on startup. SM-6 delivers the model + store in ISOLATION; it deliberately does
+//! NOT wire into any endpoint or the agent loop (those are SM-7 / SM-8). The
+//! palace seam and the data root are injectable, so the whole feature is
+//! unit-testable with a mock palace + a tempdir (no ONNX).
+//! What: a thin facade re-exporting the four concerns — [`model`] (§9.1 data
+//! types + derived progress + the gate predicate), [`error`] (the typed errors),
+//! [`memory`] (the [`GoalMemory`] palace seam + the `SmMemory` impl, gated), and
+//! [`cache`] (the atomic `goals.json` store) — plus [`store::SmGoalStore`], the
+//! lifecycle + dual-persistence owner.
+//! Test: each submodule carries its own `*_tests.rs`; together they cover id
+//! stability, progress recompute, the verification gate, palace→cache rebuild
+//! equality, and palace-unavailable fallback.
+
+pub mod cache;
+pub mod error;
+pub mod memory;
+pub mod model;
+pub mod store;
+
+pub use cache::{GOALS_CACHE_FILE, GoalCache};
+pub use error::{SmGoalError, SmGoalResult};
+pub use memory::{GOAL_TAG, GoalMemory};
+pub use model::{Goal, GoalStatus, SessionLink, SessionTaskState};
+pub use store::{SessionUpdate, SmGoalStore};
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod model_tests;
+
+#[cfg(test)]
+#[path = "cache_tests.rs"]
+mod cache_tests;
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod store_tests;

--- a/crates/trusty-mpm/src/core/sm/goals/model.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/model.rs
@@ -1,0 +1,235 @@
+//! Goal-tracking data model for the Session Manager (DOC-14 §9.1).
+//!
+//! Why: the SM tracks operator intent as durable, queryable [`Goal`]s, each
+//! fanned out to one-or-many delegated t-mpm sessions (§9.3). Progress and the
+//! BLOCKING verification gate (§3.5) are *derived* from the per-session
+//! verification state, so the data model must capture that state precisely and
+//! serialisably — it is the source-of-truth payload written to the SM palace and
+//! mirrored in the `goals.json` hot cache (§9.4). Pulling the pure types into
+//! their own file keeps the store (`store.rs`) focused and under the SLOC cap and
+//! keeps timestamps injectable so tests stay deterministic.
+//! What: defines [`GoalStatus`], [`SessionTaskState`], [`SessionLink`], and
+//! [`Goal`] — all `serde`-serialisable — plus the derived [`Goal::progress`]
+//! recompute and the [`Goal::all_verified`] verification-gate predicate. No I/O,
+//! no clock reads here: every timestamp is passed IN.
+//! Test: `goals/model_tests.rs` covers id stability, progress recompute, the
+//! all-verified predicate, status transitions, and serde round-trips.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Lifecycle status of a [`Goal`] (DOC-14 §9.1).
+///
+/// Why: the operator and the SM need a single, explicit state for each goal that
+/// drives surfacing (§9.2) and the close decision. The spec enumerates exactly
+/// these five variants — `Done` is reachable ONLY through the verification gate
+/// (§3.5), enforced in [`super::store::SmGoalStore`].
+/// What: a closed enum, serialised in lowerCamelCase to keep the palace/cache
+/// JSON stable and human-readable. `Pending` is the `Default` (a freshly created
+/// goal with no linked work yet).
+/// Test: `status_default_is_pending`, `goal_status_serde_roundtrip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum GoalStatus {
+    /// Created from operator intent; no linked work has started.
+    #[default]
+    Pending,
+    /// At least one linked session is in flight.
+    InProgress,
+    /// Progress is stalled awaiting an operator decision or an external blocker.
+    Blocked,
+    /// Verification gate passed — every linked task verified and acceptance met.
+    Done,
+    /// Closed without completion (cancelled / superseded), with a reason note.
+    Abandoned,
+}
+
+/// Verification state of a single linked session task (DOC-14 §9.1 / §3.5).
+///
+/// Why: `Goal` progress and the close gate are derived purely from how many
+/// linked tasks have reached `Verified` (observed evidence, §3.5). A precise
+/// per-task state machine is therefore the foundation of the whole feature: a
+/// goal cannot be `Done` unless EVERY link is `Verified`.
+/// What: a closed enum mirroring the §3.4 delegation loop — `Launched` (spawned)
+/// → `Running` (observed working) → `Verified` (evidence captured) or `Failed`.
+/// `Launched` is the `Default` (the state a link is created in when a session is
+/// first spawned). Serialised in lowerCamelCase for stable JSON.
+/// Test: `session_state_default_is_launched`, `session_state_serde_roundtrip`,
+/// and the progress/gate tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionTaskState {
+    /// The session was spawned for this task; no progress observed yet.
+    #[default]
+    Launched,
+    /// The session is observed actively working the task.
+    Running,
+    /// The task is complete WITH observed evidence (gate-satisfying, §3.5).
+    Verified,
+    /// The session failed or was abandoned for this task.
+    Failed,
+}
+
+impl SessionTaskState {
+    /// Whether this state counts as gate-satisfying completion.
+    ///
+    /// Why: the verification gate (§3.5) and the [`Goal::progress`] numerator both
+    /// ask the same question — "is this link done WITH evidence?" — so centralising
+    /// it avoids the two drifting apart.
+    /// What: returns `true` only for [`SessionTaskState::Verified`].
+    /// Test: `verified_is_the_only_gate_satisfying_state`.
+    pub fn is_verified(self) -> bool {
+        matches!(self, SessionTaskState::Verified)
+    }
+}
+
+/// A link from a [`Goal`] to one delegated t-mpm session task (DOC-14 §9.1).
+///
+/// Why: a goal fans out to one-or-many sessions (§9.3); each launched
+/// session-sized task is recorded here with its current verification `state` and
+/// any captured `evidence` (the PR URL / test-pass output the gate requires,
+/// §3.5). The `session_id` is the join key returned by `POST /sessions`.
+/// What: the `session_id`, the `task` description it was launched for, its
+/// [`SessionTaskState`], and `evidence` (`None` until observed). Serialisable for
+/// the palace/cache payload.
+/// Test: `session_link_serde_roundtrip`, and the progress/gate tests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionLink {
+    /// The control-surface session id (`POST /sessions`) — the goal↔session join.
+    pub session_id: String,
+    /// The session-sized task this session was launched to complete.
+    pub task: String,
+    /// Current verification state of the linked task.
+    pub state: SessionTaskState,
+    /// Observed evidence (PR URL, captured test output, …); `None` until seen.
+    #[serde(default)]
+    pub evidence: Option<String>,
+}
+
+impl SessionLink {
+    /// Construct a freshly launched link (state `Launched`, no evidence yet).
+    ///
+    /// Why: linking a session at spawn time (§9.2 decompose) is the common case;
+    /// a terse constructor keeps the store and tests readable.
+    /// What: builds a link with the given `session_id`/`task`,
+    /// [`SessionTaskState::Launched`], and `evidence = None`.
+    /// Test: `launched_link_has_no_evidence`.
+    pub fn launched(session_id: impl Into<String>, task: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            task: task.into(),
+            state: SessionTaskState::Launched,
+            evidence: None,
+        }
+    }
+}
+
+/// A tracked operator goal with its linked sessions and derived progress (§9.1).
+///
+/// Why: the central SM artifact — operator intent normalised into a stable,
+/// durable record the SM reasons over, surfaces, and closes through the
+/// verification gate. It is the exact payload persisted to the palace
+/// (source-of-truth) and mirrored in `goals.json` (§9.4), so it must be fully
+/// `serde`-serialisable and carry a STABLE `id` that survives restarts.
+/// What: an `id` (`g-<short-uuid>`, assigned once at create), the normalised
+/// `description`, the [`GoalStatus`], testable `acceptance` criteria, the
+/// `sessions` fan-out, a derived `progress` percentage `0..=100`, `created` /
+/// `updated` timestamps, and free-form `notes` (decisions / blockers). Timestamps
+/// are passed in by the store so tests stay deterministic.
+/// Test: `goals/model_tests.rs` (progress recompute, gate predicate, serde) and
+/// `goals/store_tests.rs` (id stability, lifecycle).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Goal {
+    /// Stable goal id, e.g. `"g-1a2b3c4d"`. Assigned once; never changes.
+    pub id: String,
+    /// Operator intent, normalised to a single-line description.
+    pub description: String,
+    /// Lifecycle status. `Done` is reachable only through the verification gate.
+    pub status: GoalStatus,
+    /// Testable acceptance criteria proposed at intake (§9.2).
+    #[serde(default)]
+    pub acceptance: Vec<String>,
+    /// Linked delegated sessions (the one-or-many fan-out, §9.3).
+    #[serde(default)]
+    pub sessions: Vec<SessionLink>,
+    /// Derived completion percentage `0..=100` (fraction of links `Verified`).
+    pub progress: u8,
+    /// Creation timestamp (UTC), passed in by the store.
+    pub created: DateTime<Utc>,
+    /// Last-mutation timestamp (UTC), bumped on every change.
+    pub updated: DateTime<Utc>,
+    /// Free-form decisions / blockers / closing-outcome notes (§9.2).
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+impl Goal {
+    /// Construct a fresh goal with a caller-supplied stable id and timestamp.
+    ///
+    /// Why: the store owns id generation (deterministic `g-<uuid>`) and the clock,
+    /// so the model takes both as arguments — keeping this constructor pure and
+    /// the tests deterministic. A new goal starts `Pending` with `0%` progress and
+    /// no links.
+    /// What: builds a [`Goal`] with the given `id`, normalised `description`,
+    /// `acceptance`, `status = Pending`, empty `sessions`/`notes`, `progress = 0`,
+    /// and `created == updated == now`.
+    /// Test: `new_goal_is_pending_zero_progress`, `goal_serde_roundtrip`.
+    pub fn new(
+        id: impl Into<String>,
+        description: impl Into<String>,
+        acceptance: Vec<String>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            description: description.into(),
+            status: GoalStatus::Pending,
+            acceptance,
+            sessions: Vec::new(),
+            progress: 0,
+            created: now,
+            updated: now,
+            notes: Vec::new(),
+        }
+    }
+
+    /// Recompute `progress` from the fraction of linked tasks that are `Verified`.
+    ///
+    /// Why: progress is DERIVED state (§9.2) — never set directly — so a single
+    /// recompute keeps it consistent with the links after any mutation
+    /// (link/update). With no links progress is `0` (nothing verified yet).
+    /// What: sets `progress` to `round(100 * verified / total)` as a `u8`, or `0`
+    /// when `sessions` is empty. Uses integer rounding via `+ total/2` to avoid
+    /// floating-point drift in the persisted value.
+    /// Test: `progress_one_of_three_verified_is_33`,
+    /// `progress_all_verified_is_100`, `progress_no_links_is_zero`.
+    pub fn recompute_progress(&mut self) {
+        let total = self.sessions.len();
+        if total == 0 {
+            self.progress = 0;
+            return;
+        }
+        let verified = self
+            .sessions
+            .iter()
+            .filter(|s| s.state.is_verified())
+            .count();
+        // Integer rounding to nearest percent: (100*v + total/2) / total.
+        self.progress = ((100 * verified + total / 2) / total) as u8;
+    }
+
+    /// Whether EVERY linked task is `Verified` (the §3.5 close precondition).
+    ///
+    /// Why: the verification gate forbids `Done` unless all linked work carries
+    /// observed evidence. Expressing it as one predicate over the links keeps the
+    /// gate logic in [`super::store::SmGoalStore::close`] a single readable check.
+    /// A goal with NO links cannot be verified-done (there is no observed evidence
+    /// of anything), so this returns `false` for an empty fan-out.
+    /// What: returns `true` iff `sessions` is non-empty and every link
+    /// `is_verified()`.
+    /// Test: `all_verified_false_when_any_unverified`,
+    /// `all_verified_false_when_no_links`, `all_verified_true_when_every_link_verified`.
+    pub fn all_verified(&self) -> bool {
+        !self.sessions.is_empty() && self.sessions.iter().all(|s| s.state.is_verified())
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/goals/model_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/model_tests.rs
@@ -1,0 +1,164 @@
+//! Tests for the SM goal-tracking data model (SM-6, DOC-14 §9.1).
+//!
+//! Why: prove the pure model contracts the store relies on — default states,
+//! derived progress (the 1-of-3 → 33% case the acceptance calls out), the
+//! all-verified gate predicate, and serde round-trips for the palace/cache
+//! payload. No I/O, no clock reads: timestamps are passed in, so these are fully
+//! deterministic and need no ONNX.
+
+use super::model::{Goal, GoalStatus, SessionLink, SessionTaskState};
+use chrono::{TimeZone, Utc};
+
+/// A fixed timestamp for deterministic construction.
+fn ts() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 16, 12, 0, 0).unwrap()
+}
+
+/// Build a goal with `total` links, the first `verified` of which are `Verified`.
+fn goal_with_links(total: usize, verified: usize) -> Goal {
+    let mut g = Goal::new("g-test1234", "ship the thing", vec![], ts());
+    for i in 0..total {
+        let mut link = SessionLink::launched(format!("s-{i}"), format!("task {i}"));
+        if i < verified {
+            link.state = SessionTaskState::Verified;
+        }
+        g.sessions.push(link);
+    }
+    g.recompute_progress();
+    g
+}
+
+/// Why: a freshly created goal must start `Pending` with `0%` progress and no
+/// links — the intake baseline (§9.2).
+/// What: constructs a goal and asserts the initial field values.
+/// Test: this is the test.
+#[test]
+fn new_goal_is_pending_zero_progress() {
+    let g = Goal::new("g-abc", "do work", vec!["passes".into()], ts());
+    assert_eq!(g.status, GoalStatus::Pending);
+    assert_eq!(g.progress, 0);
+    assert!(g.sessions.is_empty());
+    assert_eq!(g.created, g.updated);
+    assert_eq!(g.acceptance, vec!["passes".to_string()]);
+}
+
+/// Why: `GoalStatus` and `SessionTaskState` defaults anchor the lifecycle —
+/// `Pending` goal, `Launched` link.
+/// What: asserts both `Default`s.
+/// Test: this is the test.
+#[test]
+fn status_and_state_defaults() {
+    assert_eq!(GoalStatus::default(), GoalStatus::Pending);
+    assert_eq!(SessionTaskState::default(), SessionTaskState::Launched);
+}
+
+/// Why: only `Verified` satisfies the gate / progress numerator (§3.5).
+/// What: asserts `is_verified()` for every variant.
+/// Test: this is the test.
+#[test]
+fn verified_is_the_only_gate_satisfying_state() {
+    assert!(SessionTaskState::Verified.is_verified());
+    assert!(!SessionTaskState::Launched.is_verified());
+    assert!(!SessionTaskState::Running.is_verified());
+    assert!(!SessionTaskState::Failed.is_verified());
+}
+
+/// Why: the acceptance criterion — linking sessions, 1 of 3 verified, yields ~33%
+/// progress (derived, integer-rounded).
+/// What: builds a 3-link goal with 1 verified and asserts `progress == 33`.
+/// Test: this is the test.
+#[test]
+fn progress_one_of_three_verified_is_33() {
+    let g = goal_with_links(3, 1);
+    assert_eq!(g.progress, 33, "1/3 verified must round to 33%");
+}
+
+/// Why: every link verified → 100%; the close-gate precondition is reflected in
+/// progress too.
+/// What: 3/3 verified asserts `progress == 100`.
+/// Test: this is the test.
+#[test]
+fn progress_all_verified_is_100() {
+    let g = goal_with_links(3, 3);
+    assert_eq!(g.progress, 100);
+}
+
+/// Why: a goal with no links has nothing verified → 0% (and cannot be done).
+/// What: 0 links asserts `progress == 0` and `!all_verified`.
+/// Test: this is the test.
+#[test]
+fn progress_no_links_is_zero() {
+    let g = goal_with_links(0, 0);
+    assert_eq!(g.progress, 0);
+    assert!(!g.all_verified());
+}
+
+/// Why: 2 of 4 verified must round to 50% (exercises the integer rounding path).
+/// What: asserts `progress == 50`.
+/// Test: this is the test.
+#[test]
+fn progress_two_of_four_is_50() {
+    let g = goal_with_links(4, 2);
+    assert_eq!(g.progress, 50);
+}
+
+/// Why: the verification-gate predicate must be `false` if ANY link is
+/// unverified, and `false` with no links (no observed evidence of anything).
+/// What: asserts `all_verified` across mixed/empty/full link sets.
+/// Test: this is the test.
+#[test]
+fn all_verified_predicate() {
+    assert!(
+        !goal_with_links(3, 2).all_verified(),
+        "any unverified → false"
+    );
+    assert!(!goal_with_links(0, 0).all_verified(), "no links → false");
+    assert!(
+        goal_with_links(2, 2).all_verified(),
+        "every link verified → true"
+    );
+}
+
+/// Why: a launched link starts with no evidence (evidence is captured later on
+/// observation, §3.5).
+/// What: asserts the constructor's defaults.
+/// Test: this is the test.
+#[test]
+fn launched_link_has_no_evidence() {
+    let link = SessionLink::launched("s-1", "do x");
+    assert_eq!(link.state, SessionTaskState::Launched);
+    assert!(link.evidence.is_none());
+}
+
+/// Why: goals (and their links) are the palace/cache payload — they must survive a
+/// JSON round-trip byte-for-byte (the dual-persistence contract).
+/// What: builds a fully-populated goal, serialises + deserialises it, asserts
+/// equality.
+/// Test: this is the test.
+#[test]
+fn goal_serde_roundtrip() {
+    let mut g = goal_with_links(2, 1);
+    g.status = GoalStatus::InProgress;
+    g.sessions[0].evidence = Some("https://example.com/pr/1".into());
+    g.notes.push("blocked on review".into());
+
+    let json = serde_json::to_string(&g).expect("serialise");
+    let back: Goal = serde_json::from_str(&json).expect("deserialise");
+    assert_eq!(g, back, "goal must round-trip through JSON unchanged");
+}
+
+/// Why: the camelCase serde renames keep the on-disk JSON stable and readable; a
+/// drift would break previously-written palace/cache entries.
+/// What: asserts the wire forms of the enums.
+/// Test: this is the test.
+#[test]
+fn enum_wire_forms_are_camel_case() {
+    assert_eq!(
+        serde_json::to_string(&GoalStatus::InProgress).unwrap(),
+        "\"inProgress\""
+    );
+    assert_eq!(
+        serde_json::to_string(&SessionTaskState::Verified).unwrap(),
+        "\"verified\""
+    );
+}

--- a/crates/trusty-mpm/src/core/sm/goals/store.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/store.rs
@@ -1,0 +1,380 @@
+//! The SM goal store: lifecycle + dual (palace + cache) persistence (§9).
+//!
+//! Why: SM-6 owns the goal lifecycle (§9.2) — create, link a session, update a
+//! session's verification state/evidence, append notes, and close through the
+//! BLOCKING verification gate (§3.5) — over a DUAL persistence design (§9.4): the
+//! SM palace is the source of truth (every mutation writes the goal's JSON there
+//! through the [`GoalMemory`] seam), and `goals.json` is a hot cache mirrored on
+//! every mutation and REBUILT from the palace on startup. This file is the store;
+//! it deliberately does NOT wire into any endpoint or the agent loop (SM-7/SM-8).
+//! Both the memory seam and the data root are injectable, so the whole store is
+//! unit-testable with a mock palace + a tempdir (no ONNX).
+//! What: [`SmGoalStore`] holds an in-memory goal map, a [`GoalMemory`] (palace),
+//! and a [`GoalCache`] (file). [`SmGoalStore::load`] rebuilds the map from the
+//! palace (falling back to the cache when the palace is unavailable). `create` /
+//! `link` / `update` / `close` mutate, recompute derived progress, then dual-write
+//! (palace first as truth, then cache). A monotonic clock is injectable for
+//! deterministic timestamps in tests.
+//! Test: `goals/store_tests.rs` — id stability across reload, progress on link,
+//! the verification gate, palace→cache rebuild equality, and palace-unavailable
+//! fallback.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use super::cache::GoalCache;
+use super::error::{SmGoalError, SmGoalResult};
+use super::memory::{GOAL_TAG, GoalMemory};
+use super::model::{Goal, GoalStatus, SessionLink, SessionTaskState};
+
+/// A mutation applied to a linked session via [`SmGoalStore::update`] (§9.2).
+///
+/// Why: as sessions are observed/verified (§3.4 phases 4-5) the SM updates the
+/// matching [`SessionLink`]'s state and captures evidence, and may append a
+/// decision/blocker note. Bundling those into one optional-field struct keeps the
+/// update API a single call (and a single dual-write) rather than several.
+/// What: a `session_id` selecting the link, plus optional `state` / `evidence` /
+/// `note`. `None` fields are left unchanged; a `note` is appended to the goal.
+/// Test: `update_sets_state_and_evidence`, `update_appends_note`.
+#[derive(Debug, Clone, Default)]
+pub struct SessionUpdate {
+    /// The linked session to mutate (must already be linked to the goal).
+    pub session_id: String,
+    /// New verification state, if changing.
+    pub state: Option<SessionTaskState>,
+    /// Evidence to record (PR URL, captured test output, …), if any.
+    pub evidence: Option<String>,
+    /// A decision/blocker note to append to the goal, if any.
+    pub note: Option<String>,
+}
+
+/// In-memory goal map backed by the SM palace (truth) + `goals.json` (cache).
+///
+/// Why: the single owner of the goal lifecycle and its dual persistence. Keeping
+/// the goals in a `BTreeMap` keyed by id gives stable iteration order (so the
+/// cache file is deterministic) and O(log n) lookup for link/update/close.
+/// What: holds the goal map, the [`GoalMemory`] palace seam (`Arc<dyn …>` for
+/// injection), the [`GoalCache`], and an injectable clock. Built via
+/// [`SmGoalStore::load`] (rebuild-from-palace) for production or
+/// [`SmGoalStore::with_clock`] for deterministic tests.
+/// Test: `goals/store_tests.rs`.
+pub struct SmGoalStore {
+    /// Live goals keyed by stable id (sorted iteration → deterministic cache).
+    goals: BTreeMap<String, Goal>,
+    /// Source-of-truth palace seam (mocked in tests, `SmMemory` in production).
+    memory: Arc<dyn GoalMemory>,
+    /// Hot-cache file store (`goals.json`).
+    cache: GoalCache,
+    /// Injectable clock for `created`/`updated`; defaults to `Utc::now`.
+    clock: fn() -> DateTime<Utc>,
+}
+
+impl SmGoalStore {
+    /// Build an empty store over the given palace seam and data root.
+    ///
+    /// Why: the lowest-level constructor — no rebuild, real clock. Used internally
+    /// by [`SmGoalStore::load`] and directly when an empty start is wanted.
+    /// What: constructs the store with an empty goal map, a [`GoalCache`] rooted at
+    /// `data_root`, and `Utc::now` as the clock.
+    /// Test: indirectly via every other constructor.
+    pub fn new(memory: Arc<dyn GoalMemory>, data_root: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            goals: BTreeMap::new(),
+            memory,
+            cache: GoalCache::new(data_root),
+            clock: Utc::now,
+        }
+    }
+
+    /// Build an empty store with an injected clock (deterministic tests).
+    ///
+    /// Why: tests need reproducible `created`/`updated` timestamps; production uses
+    /// the wall clock. Injecting the clock keeps the model pure.
+    /// What: like [`SmGoalStore::new`] but stores the supplied `clock` fn.
+    /// Test: used throughout `goals/store_tests.rs`.
+    pub fn with_clock(
+        memory: Arc<dyn GoalMemory>,
+        data_root: impl Into<std::path::PathBuf>,
+        clock: fn() -> DateTime<Utc>,
+    ) -> Self {
+        Self {
+            goals: BTreeMap::new(),
+            memory,
+            cache: GoalCache::new(data_root),
+            clock,
+        }
+    }
+
+    /// Load the store, rebuilding the goal map from the palace (§9.4).
+    ///
+    /// Why: the palace is the source of truth, so on startup the hot map (and the
+    /// `goals.json` cache) is DERIVED by enumerating every persisted goal entry. If
+    /// the palace is unavailable (degraded backend), the store falls back to the
+    /// last-written cache so the SM still surfaces the goals it knew about — never
+    /// panicking. After a successful palace rebuild the cache is re-written so it
+    /// matches the palace-derived state.
+    /// What: enumerates `GOAL_TAG` entries via [`GoalMemory::list_goals`],
+    /// deserialises each into a [`Goal`], and indexes them by id. On enumeration
+    /// success the cache is overwritten to match; on enumeration failure the store
+    /// loads from the cache instead. Per-entry JSON that fails to parse is skipped
+    /// (one corrupt drawer must not sink the whole rebuild).
+    /// Test: `rebuild_from_palace_matches_cache`,
+    /// `palace_unavailable_falls_back_to_cache`.
+    pub async fn load(
+        memory: Arc<dyn GoalMemory>,
+        data_root: impl Into<std::path::PathBuf>,
+    ) -> SmGoalResult<Self> {
+        let mut store = Self::new(memory, data_root);
+        match store.memory.list_goals(GOAL_TAG).await {
+            Ok(entries) => {
+                for json in entries {
+                    // Skip an individual unparseable entry rather than failing the
+                    // whole rebuild — one corrupt drawer must not hide every goal.
+                    if let Ok(goal) = serde_json::from_str::<Goal>(&json) {
+                        store.goals.insert(goal.id.clone(), goal);
+                    }
+                }
+                // Re-derive the cache so it matches the palace-derived truth.
+                store.persist_cache()?;
+            }
+            Err(_palace_err) => {
+                // Palace unavailable → fall back to the last-written cache. This is
+                // graceful degradation: the SM keeps the goals it last cached.
+                for goal in store.cache.load()? {
+                    store.goals.insert(goal.id.clone(), goal);
+                }
+            }
+        }
+        Ok(store)
+    }
+
+    /// Create a goal from operator intent and dual-persist it (§9.2 create).
+    ///
+    /// Why: intake (§3.4 phase 1) turns operator intent into a tracked goal with a
+    /// STABLE id that survives restarts. The id is generated once here and is the
+    /// join key the palace and cache key on.
+    /// What: mints `g-<short-uuid>`, builds a `Pending` [`Goal`] with the injected
+    /// clock, inserts it, then dual-writes (palace truth first, then cache).
+    /// Returns the created goal.
+    /// Test: `create_assigns_stable_id`, `create_dual_persists`.
+    pub async fn create(
+        &mut self,
+        description: impl Into<String>,
+        acceptance: Vec<String>,
+    ) -> SmGoalResult<Goal> {
+        let id = new_goal_id();
+        let goal = Goal::new(id.clone(), description, acceptance, (self.clock)());
+        self.goals.insert(id.clone(), goal);
+        self.persist(&id).await?;
+        Ok(self.goals.get(&id).cloned().expect("just inserted"))
+    }
+
+    /// Link a launched session to a goal and recompute progress (§9.2 decompose).
+    ///
+    /// Why: each session-sized task launched for a goal is recorded so progress and
+    /// the close gate can derive from the per-session verification state. Linking
+    /// must recompute the derived `progress` and dual-persist.
+    /// What: appends `link` to the goal's `sessions`, moves a `Pending` goal to
+    /// `InProgress`, recomputes `progress`, bumps `updated`, then dual-writes.
+    /// Returns the updated goal. Unknown id → [`SmGoalError::NotFound`].
+    /// Test: `link_updates_progress`, `link_unknown_goal_is_not_found`.
+    pub async fn link(&mut self, goal_id: &str, link: SessionLink) -> SmGoalResult<Goal> {
+        {
+            let goal = self
+                .goals
+                .get_mut(goal_id)
+                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            goal.sessions.push(link);
+            if goal.status == GoalStatus::Pending {
+                goal.status = GoalStatus::InProgress;
+            }
+            goal.recompute_progress();
+            goal.updated = (self.clock)();
+        }
+        self.persist(goal_id).await?;
+        Ok(self.goals.get(goal_id).cloned().expect("present"))
+    }
+
+    /// Apply a session update (state / evidence / note) and recompute (§9.2 update).
+    ///
+    /// Why: as the SM observes and verifies sessions (§3.4 phases 4-5) it records
+    /// the new verification state and the captured evidence, and may append a
+    /// decision/blocker note; progress is re-derived from the updated states.
+    /// What: finds the [`SessionLink`] by `session_id`, applies the supplied
+    /// non-`None` fields, appends any `note` to the goal, recomputes `progress`,
+    /// bumps `updated`, then dual-writes. Returns the updated goal. Unknown goal or
+    /// session → [`SmGoalError::NotFound`].
+    /// Test: `update_sets_state_and_evidence`, `update_appends_note`,
+    /// `update_unknown_session_is_not_found`.
+    pub async fn update(&mut self, goal_id: &str, upd: SessionUpdate) -> SmGoalResult<Goal> {
+        {
+            let goal = self
+                .goals
+                .get_mut(goal_id)
+                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            let link = goal
+                .sessions
+                .iter_mut()
+                .find(|s| s.session_id == upd.session_id)
+                .ok_or_else(|| SmGoalError::NotFound(upd.session_id.clone()))?;
+            if let Some(state) = upd.state {
+                link.state = state;
+            }
+            if let Some(evidence) = upd.evidence {
+                link.evidence = Some(evidence);
+            }
+            if let Some(note) = upd.note {
+                goal.notes.push(note);
+            }
+            goal.recompute_progress();
+            goal.updated = (self.clock)();
+        }
+        self.persist(goal_id).await?;
+        Ok(self.goals.get(goal_id).cloned().expect("present"))
+    }
+
+    /// Append a free-form note to a goal and dual-persist (§9.2 decisions/blockers).
+    ///
+    /// Why: the SM records decisions and blockers against a goal independently of
+    /// any session update; a dedicated path keeps that intent explicit.
+    /// What: pushes `note`, bumps `updated`, dual-writes. Unknown id →
+    /// [`SmGoalError::NotFound`].
+    /// Test: `note_appends_and_persists`.
+    pub async fn note(&mut self, goal_id: &str, note: impl Into<String>) -> SmGoalResult<Goal> {
+        {
+            let goal = self
+                .goals
+                .get_mut(goal_id)
+                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            goal.notes.push(note.into());
+            goal.updated = (self.clock)();
+        }
+        self.persist(goal_id).await?;
+        Ok(self.goals.get(goal_id).cloned().expect("present"))
+    }
+
+    /// Set a goal's status, enforcing the verification gate on `Done` (§3.5).
+    ///
+    /// Why: §3.5 forbids claiming a goal `Done` without observed evidence — every
+    /// linked task must be `Verified`. The gate lives HERE so no caller can bypass
+    /// it; a `Done` request that fails the gate is REJECTED with a structured
+    /// error (not a panic), and the goal is left unchanged. Other statuses
+    /// (`Blocked`, `Abandoned`, …) carry no gate.
+    /// What: if `status == Done` and not [`Goal::all_verified`], returns
+    /// [`SmGoalError::VerificationGate`] with the verified/total counts and does
+    /// NOT mutate or persist. Otherwise sets the status, bumps `updated`, and
+    /// dual-writes. Returns the updated goal. Unknown id →
+    /// [`SmGoalError::NotFound`].
+    /// Test: `close_without_all_verified_is_rejected`,
+    /// `close_with_all_verified_succeeds`, `set_blocked_has_no_gate`.
+    pub async fn set_status(&mut self, goal_id: &str, status: GoalStatus) -> SmGoalResult<Goal> {
+        {
+            let goal = self
+                .goals
+                .get_mut(goal_id)
+                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            if status == GoalStatus::Done && !goal.all_verified() {
+                let total = goal.sessions.len();
+                let verified = goal
+                    .sessions
+                    .iter()
+                    .filter(|s| s.state.is_verified())
+                    .count();
+                return Err(SmGoalError::VerificationGate {
+                    goal_id: goal_id.to_string(),
+                    verified,
+                    total,
+                });
+            }
+            goal.status = status;
+            goal.updated = (self.clock)();
+        }
+        self.persist(goal_id).await?;
+        Ok(self.goals.get(goal_id).cloned().expect("present"))
+    }
+
+    /// Close a goal as `Done`, applying the verification gate (§9.2 close).
+    ///
+    /// Why: the canonical close path — a thin, intent-revealing alias over
+    /// [`SmGoalStore::set_status`]`(Done)` so call sites read as "close this goal"
+    /// while still going through the single gated transition.
+    /// What: delegates to `set_status(goal_id, GoalStatus::Done)`.
+    /// Test: `close_without_all_verified_is_rejected`,
+    /// `close_with_all_verified_succeeds`.
+    pub async fn close(&mut self, goal_id: &str) -> SmGoalResult<Goal> {
+        self.set_status(goal_id, GoalStatus::Done).await
+    }
+
+    /// Fetch a goal by id (read-only).
+    ///
+    /// Why: callers (and the future TUI/endpoint) read individual goals; tests
+    /// assert state without reaching into the private map.
+    /// What: returns a reference to the goal, or `None` if absent.
+    /// Test: used throughout `goals/store_tests.rs`.
+    pub fn get(&self, goal_id: &str) -> Option<&Goal> {
+        self.goals.get(goal_id)
+    }
+
+    /// All goals in stable (id-sorted) order (read-only).
+    ///
+    /// Why: the TUI lists goals; the cache writes them in this order. Sorted
+    /// iteration makes both deterministic.
+    /// What: returns the goals as a `Vec` in `BTreeMap` key order.
+    /// Test: `rebuild_from_palace_matches_cache`.
+    pub fn all(&self) -> Vec<Goal> {
+        self.goals.values().cloned().collect()
+    }
+
+    /// Dual-write one goal: palace (truth) first, then the cache (§9.4).
+    ///
+    /// Why: the palace is the source of truth, so it is written FIRST — if the
+    /// palace write fails the operation fails before the cache diverges from truth.
+    /// The cache is then re-derived from the full in-memory map (which already
+    /// reflects this goal's mutation).
+    /// What: serialises the goal to JSON, writes it tagged to the palace via
+    /// [`GoalMemory::remember_goal`] (mapping the `String` error to
+    /// [`SmGoalError::Palace`]), then calls [`SmGoalStore::persist_cache`].
+    /// Test: `create_dual_persists`, `palace_write_failure_propagates`.
+    async fn persist(&self, goal_id: &str) -> SmGoalResult<()> {
+        let goal = self
+            .goals
+            .get(goal_id)
+            .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+        let json = serde_json::to_string(goal).map_err(|source| SmGoalError::Serde { source })?;
+        self.memory
+            .remember_goal(json, GOAL_TAG)
+            .await
+            .map_err(|message| SmGoalError::Palace { message })?;
+        self.persist_cache()
+    }
+
+    /// Re-write the `goals.json` cache from the full in-memory map (§9.4).
+    ///
+    /// Why: the cache is a faithful mirror of the live goal set; re-writing the
+    /// whole list (rather than patching) keeps it trivially consistent and
+    /// deterministic.
+    /// What: snapshots all goals (sorted) and atomically saves them via
+    /// [`GoalCache::save`].
+    /// Test: `create_dual_persists`, `rebuild_from_palace_matches_cache`.
+    fn persist_cache(&self) -> SmGoalResult<()> {
+        let goals = self.all();
+        self.cache.save(&goals)
+    }
+}
+
+/// Mint a fresh stable goal id of the form `g-<short-uuid>` (§9.1).
+///
+/// Why: each goal needs an id that is unique and STABLE for its lifetime (the
+/// palace/cache join key). A v4 UUID gives collision-resistance; the `g-` prefix
+/// and the 8-char short form match the spec's `"g-<short-uuid>"` example and keep
+/// the id readable in logs/TUI.
+/// What: returns `"g-"` followed by the first 8 hex chars of a fresh v4 UUID's
+/// simple (dash-free) form.
+/// Test: `create_assigns_stable_id` (stability across reload), `goal_id_is_prefixed`.
+fn new_goal_id() -> String {
+    let uuid = Uuid::new_v4().simple().to_string();
+    format!("g-{}", &uuid[..8])
+}

--- a/crates/trusty-mpm/src/core/sm/goals/store.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/store.rs
@@ -156,10 +156,14 @@ impl SmGoalStore {
     /// Why: intake (§3.4 phase 1) turns operator intent into a tracked goal with a
     /// STABLE id that survives restarts. The id is generated once here and is the
     /// join key the palace and cache key on.
-    /// What: mints `g-<short-uuid>`, builds a `Pending` [`Goal`] with the injected
-    /// clock, inserts it, then dual-writes (palace truth first, then cache).
-    /// Returns the created goal.
-    /// Test: `create_assigns_stable_id`, `create_dual_persists`.
+    /// What: mints `g-<uuid-prefix>`, builds a `Pending` [`Goal`] with the injected
+    /// clock, inserts it, then dual-writes (palace truth first, then cache). If the
+    /// persist fails the freshly-inserted goal is REMOVED from the in-memory map so
+    /// a failed create leaves the store byte-identical to before the call (no
+    /// phantom goal visible to `all()`/`get()`). Returns the created goal.
+    /// Test: `create_assigns_stable_id_that_survives_reload`,
+    /// `mutations_dual_persist_palace_and_cache`,
+    /// `failed_create_leaves_no_phantom_goal`.
     pub async fn create(
         &mut self,
         description: impl Into<String>,
@@ -168,7 +172,12 @@ impl SmGoalStore {
         let id = new_goal_id();
         let goal = Goal::new(id.clone(), description, acceptance, (self.clock)());
         self.goals.insert(id.clone(), goal);
-        self.persist(&id).await?;
+        // Atomic w.r.t. the in-memory map: a persist failure must not leave a
+        // phantom goal that was never durably written. Roll the insert back.
+        if let Err(e) = self.persist(&id).await {
+            self.goals.remove(&id);
+            return Err(e);
+        }
         Ok(self.goals.get(&id).cloned().expect("just inserted"))
     }
 
@@ -178,15 +187,20 @@ impl SmGoalStore {
     /// the close gate can derive from the per-session verification state. Linking
     /// must recompute the derived `progress` and dual-persist.
     /// What: appends `link` to the goal's `sessions`, moves a `Pending` goal to
-    /// `InProgress`, recomputes `progress`, bumps `updated`, then dual-writes.
+    /// `InProgress`, recomputes `progress`, bumps `updated`, then dual-writes. The
+    /// prior goal is snapshotted first; on persist failure it is RESTORED so a
+    /// failed link leaves the goal byte-identical to before the call.
     /// Returns the updated goal. Unknown id → [`SmGoalError::NotFound`].
-    /// Test: `link_updates_progress`, `link_unknown_goal_is_not_found`.
+    /// Test: `link_updates_progress`, `link_unknown_goal_is_not_found`,
+    /// `failed_mutation_leaves_existing_goal_unchanged`.
     pub async fn link(&mut self, goal_id: &str, link: SessionLink) -> SmGoalResult<Goal> {
+        let prior = self
+            .goals
+            .get(goal_id)
+            .cloned()
+            .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
         {
-            let goal = self
-                .goals
-                .get_mut(goal_id)
-                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            let goal = self.goals.get_mut(goal_id).expect("present");
             goal.sessions.push(link);
             if goal.status == GoalStatus::Pending {
                 goal.status = GoalStatus::InProgress;
@@ -194,7 +208,7 @@ impl SmGoalStore {
             goal.recompute_progress();
             goal.updated = (self.clock)();
         }
-        self.persist(goal_id).await?;
+        self.persist_or_restore(goal_id, prior).await?;
         Ok(self.goals.get(goal_id).cloned().expect("present"))
     }
 
@@ -205,21 +219,34 @@ impl SmGoalStore {
     /// decision/blocker note; progress is re-derived from the updated states.
     /// What: finds the [`SessionLink`] by `session_id`, applies the supplied
     /// non-`None` fields, appends any `note` to the goal, recomputes `progress`,
-    /// bumps `updated`, then dual-writes. Returns the updated goal. Unknown goal or
-    /// session → [`SmGoalError::NotFound`].
-    /// Test: `update_sets_state_and_evidence`, `update_appends_note`,
-    /// `update_unknown_session_is_not_found`.
+    /// bumps `updated`, then dual-writes. The prior goal is snapshotted first; on
+    /// persist failure it is RESTORED so a failed update leaves the goal
+    /// byte-identical to before the call. Returns the updated goal. Unknown goal or
+    /// session → [`SmGoalError::NotFound`] (and the goal is left unchanged).
+    /// Test: `update_sets_state_evidence_and_note`,
+    /// `update_unknown_session_is_not_found`,
+    /// `failed_mutation_leaves_existing_goal_unchanged`.
     pub async fn update(&mut self, goal_id: &str, upd: SessionUpdate) -> SmGoalResult<Goal> {
+        let prior = self
+            .goals
+            .get(goal_id)
+            .cloned()
+            .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
         {
-            let goal = self
-                .goals
-                .get_mut(goal_id)
-                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            let goal = self.goals.get_mut(goal_id).expect("present");
             let link = goal
                 .sessions
                 .iter_mut()
-                .find(|s| s.session_id == upd.session_id)
-                .ok_or_else(|| SmGoalError::NotFound(upd.session_id.clone()))?;
+                .find(|s| s.session_id == upd.session_id);
+            let link = match link {
+                Some(link) => link,
+                None => {
+                    // Unknown session: nothing mutated yet, but restore the prior
+                    // snapshot defensively so the goal is provably unchanged.
+                    self.goals.insert(goal_id.to_string(), prior);
+                    return Err(SmGoalError::NotFound(upd.session_id));
+                }
+            };
             if let Some(state) = upd.state {
                 link.state = state;
             }
@@ -232,7 +259,7 @@ impl SmGoalStore {
             goal.recompute_progress();
             goal.updated = (self.clock)();
         }
-        self.persist(goal_id).await?;
+        self.persist_or_restore(goal_id, prior).await?;
         Ok(self.goals.get(goal_id).cloned().expect("present"))
     }
 
@@ -240,19 +267,24 @@ impl SmGoalStore {
     ///
     /// Why: the SM records decisions and blockers against a goal independently of
     /// any session update; a dedicated path keeps that intent explicit.
-    /// What: pushes `note`, bumps `updated`, dual-writes. Unknown id →
+    /// What: pushes `note`, bumps `updated`, dual-writes. The prior goal is
+    /// snapshotted first; on persist failure it is RESTORED so a failed note leaves
+    /// the goal byte-identical to before the call. Unknown id →
     /// [`SmGoalError::NotFound`].
-    /// Test: `note_appends_and_persists`.
+    /// Test: `note_appends_and_persists`,
+    /// `failed_mutation_leaves_existing_goal_unchanged`.
     pub async fn note(&mut self, goal_id: &str, note: impl Into<String>) -> SmGoalResult<Goal> {
+        let prior = self
+            .goals
+            .get(goal_id)
+            .cloned()
+            .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
         {
-            let goal = self
-                .goals
-                .get_mut(goal_id)
-                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            let goal = self.goals.get_mut(goal_id).expect("present");
             goal.notes.push(note.into());
             goal.updated = (self.clock)();
         }
-        self.persist(goal_id).await?;
+        self.persist_or_restore(goal_id, prior).await?;
         Ok(self.goals.get(goal_id).cloned().expect("present"))
     }
 
@@ -266,16 +298,20 @@ impl SmGoalStore {
     /// What: if `status == Done` and not [`Goal::all_verified`], returns
     /// [`SmGoalError::VerificationGate`] with the verified/total counts and does
     /// NOT mutate or persist. Otherwise sets the status, bumps `updated`, and
-    /// dual-writes. Returns the updated goal. Unknown id →
-    /// [`SmGoalError::NotFound`].
+    /// dual-writes. The prior goal is snapshotted first; on persist failure it is
+    /// RESTORED so a failed status change leaves the goal byte-identical to before
+    /// the call. Returns the updated goal. Unknown id → [`SmGoalError::NotFound`].
     /// Test: `close_without_all_verified_is_rejected`,
-    /// `close_with_all_verified_succeeds`, `set_blocked_has_no_gate`.
+    /// `close_with_all_verified_succeeds`, `set_blocked_has_no_gate`,
+    /// `failed_mutation_leaves_existing_goal_unchanged`.
     pub async fn set_status(&mut self, goal_id: &str, status: GoalStatus) -> SmGoalResult<Goal> {
+        let prior = self
+            .goals
+            .get(goal_id)
+            .cloned()
+            .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
         {
-            let goal = self
-                .goals
-                .get_mut(goal_id)
-                .ok_or_else(|| SmGoalError::NotFound(goal_id.to_string()))?;
+            let goal = self.goals.get_mut(goal_id).expect("present");
             if status == GoalStatus::Done && !goal.all_verified() {
                 let total = goal.sessions.len();
                 let verified = goal
@@ -283,6 +319,8 @@ impl SmGoalStore {
                     .iter()
                     .filter(|s| s.state.is_verified())
                     .count();
+                // Gate failure happens BEFORE any mutation, so the goal is already
+                // unchanged; just reject.
                 return Err(SmGoalError::VerificationGate {
                     goal_id: goal_id.to_string(),
                     verified,
@@ -292,7 +330,7 @@ impl SmGoalStore {
             goal.status = status;
             goal.updated = (self.clock)();
         }
-        self.persist(goal_id).await?;
+        self.persist_or_restore(goal_id, prior).await?;
         Ok(self.goals.get(goal_id).cloned().expect("present"))
     }
 
@@ -351,6 +389,26 @@ impl SmGoalStore {
         self.persist_cache()
     }
 
+    /// Dual-write a mutated goal, RESTORING its prior value if the write fails.
+    ///
+    /// Why: every existing-goal mutator (`link`/`update`/`note`/`set_status`)
+    /// mutates the in-memory map BEFORE the durable write. If the palace write (or
+    /// the cache re-derive) fails, the map would otherwise be left holding a
+    /// mutation that was never durably persisted — a phantom diverging from truth.
+    /// Centralising the rollback here keeps every mutator ATOMIC w.r.t. the map and
+    /// avoids repeating the snapshot/restore dance at each call site.
+    /// What: calls [`SmGoalStore::persist`]; on `Err`, re-inserts `prior` (the
+    /// pre-mutation snapshot) under `goal_id` so the observed goal is byte-identical
+    /// to before the call, then propagates the error.
+    /// Test: `failed_mutation_leaves_existing_goal_unchanged`.
+    async fn persist_or_restore(&mut self, goal_id: &str, prior: Goal) -> SmGoalResult<()> {
+        if let Err(e) = self.persist(goal_id).await {
+            self.goals.insert(goal_id.to_string(), prior);
+            return Err(e);
+        }
+        Ok(())
+    }
+
     /// Re-write the `goals.json` cache from the full in-memory map (§9.4).
     ///
     /// Why: the cache is a faithful mirror of the live goal set; re-writing the
@@ -365,16 +423,29 @@ impl SmGoalStore {
     }
 }
 
-/// Mint a fresh stable goal id of the form `g-<short-uuid>` (§9.1).
+/// Number of hex chars of the v4 UUID kept in a goal id (§9.1).
+///
+/// Why: the palace/cache upsert KEYS on the goal id, so a collision silently
+/// overwrites an existing goal. An 8-char (32-bit) prefix has a ~50% birthday
+/// collision at only ~65k goals — far too small for a durable join key. Keeping
+/// 16 hex chars (64-bit) pushes the 50% birthday point to ~5 billion goals while
+/// still reading cleanly in logs/TUI.
+/// What: the slice width taken from the UUID's simple (dash-free) form.
+/// Test: `goal_id_has_64bit_width`.
+const GOAL_ID_HEX_WIDTH: usize = 16;
+
+/// Mint a fresh stable goal id of the form `g-<uuid-prefix>` (§9.1).
 ///
 /// Why: each goal needs an id that is unique and STABLE for its lifetime (the
-/// palace/cache join key). A v4 UUID gives collision-resistance; the `g-` prefix
-/// and the 8-char short form match the spec's `"g-<short-uuid>"` example and keep
+/// palace/cache join key). A v4 UUID gives collision-resistance; because the
+/// palace upserts by id, the prefix must be WIDE enough that birthday collisions
+/// are not a practical concern (see [`GOAL_ID_HEX_WIDTH`]). The `g-` prefix keeps
 /// the id readable in logs/TUI.
-/// What: returns `"g-"` followed by the first 8 hex chars of a fresh v4 UUID's
-/// simple (dash-free) form.
-/// Test: `create_assigns_stable_id` (stability across reload), `goal_id_is_prefixed`.
+/// What: returns `"g-"` followed by the first [`GOAL_ID_HEX_WIDTH`] hex chars of a
+/// fresh v4 UUID's simple (dash-free) form (64 bits of entropy).
+/// Test: `create_assigns_stable_id_that_survives_reload` (stability across reload),
+/// `goal_id_has_64bit_width` (prefix + width).
 fn new_goal_id() -> String {
     let uuid = Uuid::new_v4().simple().to_string();
-    format!("g-{}", &uuid[..8])
+    format!("g-{}", &uuid[..GOAL_ID_HEX_WIDTH])
 }

--- a/crates/trusty-mpm/src/core/sm/goals/store_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/store_tests.rs
@@ -516,3 +516,134 @@ async fn palace_write_failure_propagates() {
         other => panic!("palace write failure must surface as Palace error, got {other:?}"),
     }
 }
+
+/// Why: goal ids are the palace/cache upsert key, so a too-narrow id space risks
+/// silent overwrites via birthday collisions. The id must carry 64 bits of entropy
+/// (16 hex chars) behind the `g-` prefix, not the old 32-bit (8-char) prefix.
+/// What: creates a goal and asserts its id is `g-` + 16 lowercase hex chars.
+/// Test: this is the test.
+#[tokio::test]
+async fn goal_id_has_64bit_width() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    let id = store.create("widen me", vec![]).await.expect("create").id;
+    let hex = id.strip_prefix("g-").expect("id must be g-prefixed");
+    assert_eq!(
+        hex.len(),
+        16,
+        "id must carry 16 hex chars (64-bit) for collision resistance; got {id}"
+    );
+    assert!(
+        hex.chars().all(|c| c.is_ascii_hexdigit()),
+        "id body must be hex; got {id}"
+    );
+}
+
+/// Why: `create` must be ATOMIC w.r.t. the in-memory map — if the palace write
+/// fails, the freshly-inserted goal must NOT linger as a phantom visible to
+/// `all()`/`get()` (it was never durably written). The store must be clean.
+/// What: forces the palace to fail, attempts a create, asserts the `Palace` error
+/// AND that `all()` is empty and the would-be goal is absent.
+/// Test: this is the test.
+#[tokio::test]
+async fn failed_create_leaves_no_phantom_goal() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace.clone(), &dir);
+
+    palace.set_fail(true);
+    match store.create("phantom", vec![]).await {
+        Err(SmGoalError::Palace { .. }) => {}
+        other => panic!("expected Palace error on failed create, got {other:?}"),
+    }
+
+    assert!(
+        store.all().is_empty(),
+        "a failed create must leave NO phantom goal in the in-memory map"
+    );
+    assert_eq!(
+        palace.entry_count(),
+        0,
+        "nothing was durably written, so the palace must hold nothing"
+    );
+}
+
+/// Why: every existing-goal mutator (`link`/`update`/`note`/`set_status`) must be
+/// ATOMIC w.r.t. the map — if the palace write fails mid-mutation, the goal
+/// observed afterward must be byte-identical to before the call (no half-applied
+/// mutation lingering). This proves the snapshot/restore rollback.
+/// What: creates + links a goal (succeeds), snapshots it, then forces the palace to
+/// fail and drives each mutator in turn; after each failure asserts the `Palace`
+/// error AND that `get()` returns the UNCHANGED prior goal.
+/// Test: this is the test.
+#[tokio::test]
+async fn failed_mutation_leaves_existing_goal_unchanged() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace.clone(), &dir);
+
+    let id = store.create("durable", vec![]).await.expect("create").id;
+    store
+        .link(&id, SessionLink::launched("s-0", "task"))
+        .await
+        .expect("link");
+
+    // Snapshot the goal in its committed state.
+    let before = store.get(&id).expect("present").clone();
+
+    // From now on every palace write fails — each mutator must roll its map change
+    // back so the goal stays byte-identical to `before`.
+    palace.set_fail(true);
+
+    let assert_unchanged = |store: &SmGoalStore, ctx: &str| {
+        let after = store.get(&id).expect("goal must still be present");
+        assert_eq!(
+            after, &before,
+            "after a failed {ctx} the goal must be UNCHANGED"
+        );
+    };
+
+    // link
+    match store
+        .link(&id, SessionLink::launched("s-1", "second"))
+        .await
+    {
+        Err(SmGoalError::Palace { .. }) => {}
+        other => panic!("failed link must surface Palace error, got {other:?}"),
+    }
+    assert_unchanged(&store, "link");
+
+    // update (existing session s-0)
+    match store
+        .update(
+            &id,
+            SessionUpdate {
+                session_id: "s-0".into(),
+                state: Some(SessionTaskState::Verified),
+                evidence: Some("ev".into()),
+                note: Some("note".into()),
+            },
+        )
+        .await
+    {
+        Err(SmGoalError::Palace { .. }) => {}
+        other => panic!("failed update must surface Palace error, got {other:?}"),
+    }
+    assert_unchanged(&store, "update");
+
+    // note
+    match store.note(&id, "blocker noted").await {
+        Err(SmGoalError::Palace { .. }) => {}
+        other => panic!("failed note must surface Palace error, got {other:?}"),
+    }
+    assert_unchanged(&store, "note");
+
+    // set_status (Blocked is ungated, so it reaches the persist)
+    match store.set_status(&id, GoalStatus::Blocked).await {
+        Err(SmGoalError::Palace { .. }) => {}
+        other => panic!("failed set_status must surface Palace error, got {other:?}"),
+    }
+    assert_unchanged(&store, "set_status");
+}

--- a/crates/trusty-mpm/src/core/sm/goals/store_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/store_tests.rs
@@ -1,0 +1,518 @@
+//! Tests for the SM goal store: lifecycle + dual persistence (SM-6, DOC-14 §9).
+//!
+//! Why: prove the acceptance contracts — a created goal has a STABLE id that
+//! survives reload; linking a session recomputes progress (1/3 → 33%); the
+//! verification gate REJECTS `Done` unless every linked task is `Verified`; goals
+//! REBUILD from the palace on startup with the `goals.json` cache matching the
+//! palace-derived state; and a palace-unavailable startup falls back to the cache
+//! without panicking. The palace is mocked in-memory (a `GoalMemory` impl), so
+//! these run without ONNX and need no `#[ignore]`. Each test uses a fresh
+//! `tempdir` for the cache.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+use tempfile::TempDir;
+
+use super::cache::GoalCache;
+use super::error::SmGoalError;
+use super::memory::{GOAL_TAG, GoalMemory};
+use super::model::{GoalStatus, SessionLink, SessionTaskState};
+use super::store::{SessionUpdate, SmGoalStore};
+
+/// A deterministic clock for reproducible timestamps.
+fn fixed_clock() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 16, 12, 0, 0).unwrap()
+}
+
+/// In-memory mock of the SM palace implementing [`GoalMemory`].
+///
+/// Why: the store's source of truth is the palace; a deterministic in-memory mock
+/// lets us assert dual-persistence behaviour (writes land in the palace; rebuild
+/// enumerates them) and inject an "unavailable" failure — all without the heavy
+/// ONNX-backed Memory Palace.
+/// What: stores tagged JSON entries newest-last; `remember_goal` upserts by the
+/// goal's `id` (so re-writing a mutated goal replaces, not duplicates — mirroring
+/// how a real rebuild keys by id), `list_goals` returns the current set. A
+/// `fail` flag forces both methods to error (the palace-unavailable case).
+#[derive(Default)]
+struct MockPalace {
+    inner: Mutex<MockState>,
+}
+
+#[derive(Default)]
+struct MockState {
+    /// (goal_id, json) entries, in insertion/upsert order.
+    entries: Vec<(String, String)>,
+    /// When true, every operation reports the palace as unavailable.
+    fail: bool,
+    /// Count of `remember_goal` calls (asserts dual-write happened).
+    writes: usize,
+}
+
+impl MockPalace {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn set_fail(&self, fail: bool) {
+        self.inner.lock().expect("lock").fail = fail;
+    }
+
+    fn write_count(&self) -> usize {
+        self.inner.lock().expect("lock").writes
+    }
+
+    fn entry_count(&self) -> usize {
+        self.inner.lock().expect("lock").entries.len()
+    }
+}
+
+#[async_trait]
+impl GoalMemory for MockPalace {
+    async fn remember_goal(&self, json: String, tag: &str) -> Result<(), String> {
+        assert_eq!(tag, GOAL_TAG, "store must always tag goals with GOAL_TAG");
+        let mut st = self.inner.lock().expect("lock");
+        if st.fail {
+            return Err("mock palace unavailable".to_string());
+        }
+        st.writes += 1;
+        // Upsert by id so a re-written goal replaces its prior entry, exactly as a
+        // real id-keyed rebuild would collapse them.
+        let id = extract_id(&json);
+        if let Some(slot) = st.entries.iter_mut().find(|(eid, _)| *eid == id) {
+            slot.1 = json;
+        } else {
+            st.entries.push((id, json));
+        }
+        Ok(())
+    }
+
+    async fn list_goals(&self, tag: &str) -> Result<Vec<String>, String> {
+        assert_eq!(tag, GOAL_TAG);
+        let st = self.inner.lock().expect("lock");
+        if st.fail {
+            return Err("mock palace unavailable".to_string());
+        }
+        Ok(st.entries.iter().map(|(_, j)| j.clone()).collect())
+    }
+}
+
+/// Pull the `id` field out of a serialised goal (test helper).
+fn extract_id(json: &str) -> String {
+    let v: serde_json::Value = serde_json::from_str(json).expect("valid goal json");
+    v.get("id")
+        .and_then(|x| x.as_str())
+        .expect("goal has id")
+        .to_string()
+}
+
+/// Build a store with the mock palace + a tempdir cache + a fixed clock.
+fn store_with(palace: Arc<MockPalace>, dir: &TempDir) -> SmGoalStore {
+    SmGoalStore::with_clock(palace, dir.path(), fixed_clock)
+}
+
+/// Why: every created goal must carry a stable `g-…` id, and that id must survive
+/// a reload (rebuild from the palace) — the join-key invariant of dual persistence.
+/// What: creates a goal, records its id, rebuilds a fresh store from the SAME
+/// palace, asserts the same id (and content) is present.
+/// Test: this is the test.
+#[tokio::test]
+async fn create_assigns_stable_id_that_survives_reload() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+
+    let id = {
+        let mut store = store_with(palace.clone(), &dir);
+        let g = store
+            .create("ship SM-6", vec!["tests pass".into()])
+            .await
+            .expect("create");
+        assert!(
+            g.id.starts_with("g-"),
+            "id must be g-prefixed; got {}",
+            g.id
+        );
+        assert_eq!(g.status, GoalStatus::Pending);
+        g.id
+    };
+
+    // Fresh store over the same palace → rebuild from truth.
+    let reloaded = SmGoalStore::load(palace.clone(), dir.path())
+        .await
+        .expect("reload");
+    let g = reloaded
+        .get(&id)
+        .expect("goal survives reload by stable id");
+    assert_eq!(g.description, "ship SM-6");
+}
+
+/// Why: the acceptance criterion — linking sessions and verifying 1 of 3 yields
+/// ~33% progress, derived from the link states.
+/// What: creates a goal, links 3 sessions, verifies one, asserts `progress == 33`
+/// and the goal moved to `InProgress`.
+/// Test: this is the test.
+#[tokio::test]
+async fn link_updates_progress() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    let g = store
+        .create("multi-session goal", vec![])
+        .await
+        .expect("create");
+    let id = g.id.clone();
+
+    for i in 0..3 {
+        store
+            .link(
+                &id,
+                SessionLink::launched(format!("s-{i}"), format!("task {i}")),
+            )
+            .await
+            .expect("link");
+    }
+    assert_eq!(store.get(&id).unwrap().status, GoalStatus::InProgress);
+    assert_eq!(store.get(&id).unwrap().progress, 0, "no links verified yet");
+
+    store
+        .update(
+            &id,
+            SessionUpdate {
+                session_id: "s-0".into(),
+                state: Some(SessionTaskState::Verified),
+                evidence: Some("https://example.com/pr/1".into()),
+                note: None,
+            },
+        )
+        .await
+        .expect("update");
+
+    assert_eq!(
+        store.get(&id).unwrap().progress,
+        33,
+        "1 of 3 verified must derive 33% progress"
+    );
+}
+
+/// Why: linking an unknown goal must be a clean `NotFound`, not a panic.
+/// What: links to a bogus id, asserts the error variant.
+/// Test: this is the test.
+#[tokio::test]
+async fn link_unknown_goal_is_not_found() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    match store
+        .link("g-nope", SessionLink::launched("s-1", "x"))
+        .await
+    {
+        Err(SmGoalError::NotFound(id)) => assert_eq!(id, "g-nope"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+/// Why: THE verification gate (§3.5) — `Done` must be REJECTED while any linked
+/// task is unverified, and the goal must be left unchanged (still `InProgress`).
+/// What: creates a goal with 2 links, verifies only one, asserts `close` returns
+/// `VerificationGate` with the right counts and does not mutate the status.
+/// Test: this is the test.
+#[tokio::test]
+async fn close_without_all_verified_is_rejected() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    let id = store.create("gated goal", vec![]).await.expect("create").id;
+    store
+        .link(&id, SessionLink::launched("s-0", "a"))
+        .await
+        .expect("link a");
+    store
+        .link(&id, SessionLink::launched("s-1", "b"))
+        .await
+        .expect("link b");
+    store
+        .update(
+            &id,
+            SessionUpdate {
+                session_id: "s-0".into(),
+                state: Some(SessionTaskState::Verified),
+                evidence: Some("ev".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("verify one");
+
+    match store.close(&id).await {
+        Err(SmGoalError::VerificationGate {
+            goal_id,
+            verified,
+            total,
+        }) => {
+            assert_eq!(goal_id, id);
+            assert_eq!(verified, 1);
+            assert_eq!(total, 2);
+        }
+        other => panic!("gate must reject Done with 1/2 verified, got {other:?}"),
+    }
+    assert_eq!(
+        store.get(&id).unwrap().status,
+        GoalStatus::InProgress,
+        "a rejected close must leave the goal unchanged"
+    );
+}
+
+/// Why: once every linked task is `Verified`, the gate ALLOWS `Done` — the
+/// positive half of §3.5.
+/// What: verifies all links, closes, asserts `Done` and `progress == 100`.
+/// Test: this is the test.
+#[tokio::test]
+async fn close_with_all_verified_succeeds() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    let id = store
+        .create("completable goal", vec![])
+        .await
+        .expect("create")
+        .id;
+    for i in 0..2 {
+        let sid = format!("s-{i}");
+        store
+            .link(&id, SessionLink::launched(&sid, "task"))
+            .await
+            .expect("link");
+        store
+            .update(
+                &id,
+                SessionUpdate {
+                    session_id: sid,
+                    state: Some(SessionTaskState::Verified),
+                    evidence: Some("ev".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("verify");
+    }
+
+    let done = store
+        .close(&id)
+        .await
+        .expect("close must succeed when all verified");
+    assert_eq!(done.status, GoalStatus::Done);
+    assert_eq!(done.progress, 100);
+}
+
+/// Why: non-`Done` statuses carry NO gate — `Blocked`/`Abandoned` are always
+/// allowed (the SM marks a stalled goal blocked regardless of verification).
+/// What: sets `Blocked` on an unverified goal, asserts success.
+/// Test: this is the test.
+#[tokio::test]
+async fn set_blocked_has_no_gate() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    let id = store.create("stuck goal", vec![]).await.expect("create").id;
+    store
+        .link(&id, SessionLink::launched("s-0", "a"))
+        .await
+        .expect("link");
+    let g = store
+        .set_status(&id, GoalStatus::Blocked)
+        .await
+        .expect("blocked is ungated");
+    assert_eq!(g.status, GoalStatus::Blocked);
+}
+
+/// Why: an update must mutate the link's state + evidence, and a supplied note
+/// must be appended to the goal.
+/// What: links one session, updates state+evidence+note, asserts all three landed.
+/// Test: this is the test.
+#[tokio::test]
+async fn update_sets_state_evidence_and_note() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    let id = store.create("g", vec![]).await.expect("create").id;
+    store
+        .link(&id, SessionLink::launched("s-0", "a"))
+        .await
+        .expect("link");
+    let g = store
+        .update(
+            &id,
+            SessionUpdate {
+                session_id: "s-0".into(),
+                state: Some(SessionTaskState::Running),
+                evidence: Some("partial output".into()),
+                note: Some("operator asked to continue".into()),
+            },
+        )
+        .await
+        .expect("update");
+
+    assert_eq!(g.sessions[0].state, SessionTaskState::Running);
+    assert_eq!(g.sessions[0].evidence.as_deref(), Some("partial output"));
+    assert_eq!(g.notes, vec!["operator asked to continue".to_string()]);
+}
+
+/// Why: updating an unlinked session id must be a clean `NotFound`.
+/// What: updates a session not linked to the goal, asserts the error.
+/// Test: this is the test.
+#[tokio::test]
+async fn update_unknown_session_is_not_found() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace, &dir);
+
+    let id = store.create("g", vec![]).await.expect("create").id;
+    match store
+        .update(
+            &id,
+            SessionUpdate {
+                session_id: "s-missing".into(),
+                ..Default::default()
+            },
+        )
+        .await
+    {
+        Err(SmGoalError::NotFound(s)) => assert_eq!(s, "s-missing"),
+        other => panic!("expected NotFound for unlinked session, got {other:?}"),
+    }
+}
+
+/// Why: every mutation must DUAL-write — the palace (truth) AND the `goals.json`
+/// cache — so both stores stay consistent (§9.4).
+/// What: creates + links a goal, asserts the palace recorded writes and the cache
+/// file on disk now holds the same goal.
+/// Test: this is the test.
+#[tokio::test]
+async fn mutations_dual_persist_palace_and_cache() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace.clone(), &dir);
+
+    let id = store.create("dual goal", vec![]).await.expect("create").id;
+    store
+        .link(&id, SessionLink::launched("s-0", "a"))
+        .await
+        .expect("link");
+
+    assert!(
+        palace.write_count() >= 2,
+        "create + link must each write the palace"
+    );
+    assert_eq!(
+        palace.entry_count(),
+        1,
+        "the same goal must upsert, not duplicate"
+    );
+
+    // Cache on disk must reflect the goal.
+    let cached = GoalCache::new(dir.path()).load().expect("load cache");
+    assert_eq!(cached.len(), 1);
+    assert_eq!(cached[0].id, id);
+    assert_eq!(cached[0].sessions.len(), 1);
+}
+
+/// Why: the rebuild contract (§9.4) — on startup the store rebuilds its map from
+/// the PALACE (source of truth), and the re-derived `goals.json` cache must match
+/// that palace-derived state exactly.
+/// What: writes several goals via one store, drops it, rebuilds a fresh store from
+/// the same palace, then asserts the rebuilt set equals what the cache holds.
+/// Test: this is the test.
+#[tokio::test]
+async fn rebuild_from_palace_matches_cache() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+
+    {
+        let mut store = store_with(palace.clone(), &dir);
+        let a = store
+            .create("goal A", vec!["x".into()])
+            .await
+            .expect("create A")
+            .id;
+        store.create("goal B", vec![]).await.expect("create B");
+        store
+            .link(&a, SessionLink::launched("s-0", "t"))
+            .await
+            .expect("link A");
+        // store drops — palace + cache persist independently.
+    }
+
+    // Wipe the cache file to PROVE the rebuild comes from the palace, then reload.
+    std::fs::remove_file(GoalCache::new(dir.path()).path()).expect("rm cache");
+
+    let reloaded = SmGoalStore::load(palace.clone(), dir.path())
+        .await
+        .expect("reload");
+    let rebuilt = reloaded.all();
+    assert_eq!(rebuilt.len(), 2, "both goals rebuild from the palace");
+
+    // The reload re-wrote the cache from palace truth; it must match the map.
+    let cached = GoalCache::new(dir.path())
+        .load()
+        .expect("load rebuilt cache");
+    assert_eq!(
+        cached, rebuilt,
+        "rebuilt cache must equal palace-derived state"
+    );
+}
+
+/// Why: graceful degradation (§9.4) — when the palace is unavailable on startup,
+/// the store must fall back to the last-written `goals.json` cache and NOT panic.
+/// What: populates the palace + cache via a working store, then reloads with the
+/// palace forced into failure; asserts the goals still load (from cache).
+/// Test: this is the test.
+#[tokio::test]
+async fn palace_unavailable_falls_back_to_cache() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+
+    let id = {
+        let mut store = store_with(palace.clone(), &dir);
+        store
+            .create("cached goal", vec![])
+            .await
+            .expect("create")
+            .id
+    };
+
+    // Palace now reports unavailable; startup must use the cache instead.
+    palace.set_fail(true);
+    let reloaded = SmGoalStore::load(palace.clone(), dir.path())
+        .await
+        .expect("reload must not panic when palace is down");
+    assert!(
+        reloaded.get(&id).is_some(),
+        "goal must rebuild from the cache when the palace is unavailable"
+    );
+}
+
+/// Why: a palace WRITE failure mid-mutation must propagate as a structured
+/// `Palace` error (the truth-first dual-write fails closed), not silently succeed.
+/// What: forces the palace to fail, then attempts a create; asserts the `Palace`
+/// error variant.
+/// Test: this is the test.
+#[tokio::test]
+async fn palace_write_failure_propagates() {
+    let palace = MockPalace::new();
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = store_with(palace.clone(), &dir);
+
+    palace.set_fail(true);
+    match store.create("doomed", vec![]).await {
+        Err(SmGoalError::Palace { message }) => assert!(message.contains("unavailable")),
+        other => panic!("palace write failure must surface as Palace error, got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/memory.rs
+++ b/crates/trusty-mpm/src/core/sm/memory.rs
@@ -299,6 +299,68 @@ impl SmMemory {
             .map_err(|source| SmMemoryError::Operation { op: "note", source })
     }
 
+    /// Remember a tagged, short-fact-tolerant entry into the SM palace.
+    ///
+    /// Why: SM-6 persists each goal as a STRUCTURED palace entry it must later
+    /// enumerate deterministically (not via fuzzy recall) to rebuild the hot
+    /// cache on startup. Enumeration keys on a stable tag, so the write path must
+    /// accept explicit tags; and a serialised goal can be short (a one-line
+    /// description), so — like [`SmMemory::note`] — it must bypass the
+    /// min-token gate. Routing through the bound palace id keeps the SM-only
+    /// scope invariant intact.
+    /// What: ensures the palace, then calls `remember_with_options` in the
+    /// `General` room at [`SM_DEFAULT_IMPORTANCE`] with the supplied `tags` and
+    /// the curated-fact preset ([`RememberOptions::note`], which pins `UserFact`
+    /// and skips the token check). Returns the new drawer's UUID as a string.
+    /// Test: `goals` module rebuild/dual-persistence tests drive this via the
+    /// `GoalMemory` seam; `writes_target_only_the_sm_palace` covers scope.
+    pub async fn remember_tagged(
+        &self,
+        text: impl Into<String>,
+        tags: Vec<String>,
+    ) -> SmMemoryResult<String> {
+        let handle = self.ensure_palace()?;
+        handle
+            .remember_with_options(
+                text.into(),
+                RoomType::General,
+                tags,
+                SM_DEFAULT_IMPORTANCE,
+                RememberOptions::note(),
+            )
+            .await
+            .map(|id| id.to_string())
+            .map_err(|source| SmMemoryError::Operation {
+                op: "remember_tagged",
+                source,
+            })
+    }
+
+    /// Enumerate the content of every SM-palace entry carrying `tag`.
+    ///
+    /// Why: rebuilding the SM goal cache on startup (§9.4) must be DETERMINISTIC
+    /// and COMPLETE — every persisted goal, not the embedding-ranked top-k a
+    /// `recall` would return. `list_drawers` is the exact-match, non-fuzzy
+    /// enumeration that gives that guarantee, scoped strictly to the bound SM
+    /// palace.
+    /// What: ensures the palace, then lists drawers filtered to `tag` (no room
+    /// filter, a generous cap), returning each matching drawer's raw `content`
+    /// string. The goal store deserialises these back into `Goal`s. No fuzzy
+    /// scoring is involved.
+    /// Test: `goals` module rebuild tests (`rebuild_*`) assert the full set
+    /// round-trips through this enumeration.
+    pub fn list_tagged(&self, tag: &str) -> SmMemoryResult<Vec<String>> {
+        let handle = self.ensure_palace()?;
+        // A cap far above any realistic live-goal count; `list_drawers` returns
+        // up to this many, sorted by importance (irrelevant here — we take all).
+        const LIST_CAP: usize = 100_000;
+        Ok(handle
+            .list_drawers(None, Some(tag.to_string()), LIST_CAP)
+            .into_iter()
+            .map(|d| d.content)
+            .collect())
+    }
+
     /// Number of palaces currently persisted under the SM data root.
     ///
     /// Why: the idempotency contract ("create twice → one palace") is most

--- a/crates/trusty-mpm/src/core/sm/memory.rs
+++ b/crates/trusty-mpm/src/core/sm/memory.rs
@@ -346,7 +346,10 @@ impl SmMemory {
     /// What: ensures the palace, then lists drawers filtered to `tag` (no room
     /// filter, a generous cap), returning each matching drawer's raw `content`
     /// string. The goal store deserialises these back into `Goal`s. No fuzzy
-    /// scoring is involved.
+    /// scoring is involved. When the returned count approaches the cap (≥90%) a
+    /// `tracing::warn!` fires so a silent truncation of the rebuild becomes
+    /// OBSERVABLE — the cap should then be revisited rather than quietly dropping
+    /// goals.
     /// Test: `goals` module rebuild tests (`rebuild_*`) assert the full set
     /// round-trips through this enumeration.
     pub fn list_tagged(&self, tag: &str) -> SmMemoryResult<Vec<String>> {
@@ -354,11 +357,21 @@ impl SmMemory {
         // A cap far above any realistic live-goal count; `list_drawers` returns
         // up to this many, sorted by importance (irrelevant here — we take all).
         const LIST_CAP: usize = 100_000;
-        Ok(handle
-            .list_drawers(None, Some(tag.to_string()), LIST_CAP)
-            .into_iter()
-            .map(|d| d.content)
-            .collect())
+        // Warn before the cap silently truncates the enumeration. list_drawers
+        // caps at LIST_CAP, so a returned count at/near it means entries may have
+        // been dropped from the rebuild and the cap must be revisited.
+        const LIST_WARN_THRESHOLD: usize = LIST_CAP / 10 * 9; // 90% of the cap.
+        let drawers = handle.list_drawers(None, Some(tag.to_string()), LIST_CAP);
+        if drawers.len() >= LIST_WARN_THRESHOLD {
+            tracing::warn!(
+                tag,
+                returned = drawers.len(),
+                cap = LIST_CAP,
+                "SM palace enumeration is approaching LIST_CAP; goal entries may be \
+                 truncated on rebuild — revisit the cap"
+            );
+        }
+        Ok(drawers.into_iter().map(|d| d.content).collect())
     }
 
     /// Number of palaces currently persisted under the SM data root.

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -27,6 +27,19 @@ pub mod config;
 /// + the SM-2 provider trait).
 /// Test: `context::*::tests`.
 pub mod context;
+/// Goal-tracking model + dual (palace + cache) persistence (SM-6, DOC-14 §9).
+///
+/// Why: the SM tracks operator intent as durable goals fanned out to delegated
+/// sessions, with progress and a BLOCKING verification gate (§3.5) derived from
+/// per-session verification state. Goals persist with a dual design (§9.4): the
+/// SM palace (SM-4) is the source of truth, `goals.json` is a hot cache rebuilt
+/// from it on startup. The module is feature-INDEPENDENT (always compiled): the
+/// store depends on the `GoalMemory` abstraction, and only the production
+/// `SmMemory` impl of that trait is gated behind `sm-memory` (internally). SM-6 is
+/// the store only — not yet wired into any endpoint/loop (SM-7 / SM-8).
+/// What: re-compiled in every build (pure logic + serde + uuid/chrono).
+/// Test: `goals::{model_tests, cache_tests, store_tests}`.
+pub mod goals;
 /// Dedicated SM memory palace + recall/remember wiring (SM-4, DOC-14 §8).
 ///
 /// Why: gated behind the `sm-memory` feature because it turns on
@@ -46,6 +59,10 @@ pub use config::{SessionManagerConfig, SmInferenceConfig, SmMemoryConfig, SmRoun
 pub use context::{
     ConversationStore, ConversationStoreError, Round, SmContextEngine, SmContextError,
     SmConversation, ToolTrace,
+};
+pub use goals::{
+    GOAL_TAG, Goal, GoalCache, GoalMemory, GoalStatus, SessionLink, SessionTaskState,
+    SessionUpdate, SmGoalError, SmGoalResult, SmGoalStore,
 };
 #[cfg(feature = "sm-memory")]
 pub use memory::{SmMemory, SmMemoryError, SmMemoryResult};


### PR DESCRIPTION
Implements **SM-6** (#1289, part of epic #1283) — DOC-14 §9 goal tracking + dual persistence for the Session Manager.

**Scope is the goal store ONLY.** It is deliberately NOT wired into any endpoint or the agent loop (those are SM-7 #1290 / SM-8 #1292).

## What landed

`crates/trusty-mpm/src/core/sm/goals/` (new submodule):
- **`model.rs`** — `Goal { id, description, status, acceptance, sessions, progress, created, updated, notes }`, `SessionLink { session_id, task, state, evidence }`, `GoalStatus` (Pending/InProgress/Blocked/Done/Abandoned), `SessionTaskState` (Launched/Running/Verified/Failed). Derived `recompute_progress()` (fraction of links `Verified`, integer-rounded) + `all_verified()` gate predicate.
- **`store.rs`** — `SmGoalStore`: stable `g-<short-uuid>` ids; `create`/`link`/`update`/`note`/`set_status`/`close`. `set_status(Done)`/`close` enforce the **§3.5 verification gate** — `Done` is rejected with a structured `VerificationGate` error unless every linked task is `Verified` (the goal is left unchanged). Truth-first dual-write; `load()` rebuilds from the palace and re-derives the cache, falling back to the cache when the palace is unavailable.
- **`memory.rs`** — `GoalMemory` trait seam (Dependency Inversion) abstracting the SM palace; `SmMemory` impl gated behind `sm-memory`. The goals module itself is **feature-independent** (compiles + is tested on the default/no-default build).
- **`cache.rs`** — atomic write-tmp-then-rename `~/.trusty-mpm/sm/goals.json` cache (mirrors SM-5's persist).
- **`error.rs`** — typed `thiserror` enum (`NotFound`, `VerificationGate`, `Io`, `Serde`, `Palace`).

`core/sm/memory.rs` — added scope-isolated `remember_tagged` + `list_tagged` so the store can persist goals and **deterministically enumerate** them by tag (`list_drawers`, not fuzzy recall) for the startup rebuild.

## Verification gate + dual persistence

- **Gate (§3.5):** lives in `set_status`, so no caller can bypass it. A goal with no links can never be `Done` (no observed evidence).
- **Dual persistence (§9.4):** palace = source of truth (written first; failure fails closed). `goals.json` = derived hot cache, re-written on every mutation and rebuilt from the palace on startup. Both the memory seam and data root are injectable.

## Test evidence (no ONNX — mock `GoalMemory` + tempdir)

`cargo test -p trusty-mpm --features sm-memory` → **1182 lib + all integration green**; the 29 new `goals::*` tests cover: stable id across reload, 1/3 verified → 33% progress, verification-gate reject/allow, palace→cache rebuild equality, palace-unavailable cache fallback, dual-write + scope assertions, atomic cache overwrite, serde round-trips.

- `cargo clippy -p trusty-mpm --all-targets --features sm-memory -- -D warnings` — clean
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean (non-palace path)
- `cargo check -p trusty-mpm --no-default-features` — builds (feature-gating correct)
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations (largest prod file `store.rs` ≈380 raw lines)

## Spec assumption

The spec writes `acceptance: Vec<String>` and lists the example `Pending | InProgress | Blocked | Done | Abandoned`; both are used verbatim. Session task states (`Launched/Running/Verified/Failed`) follow the §3.4 loop wording. Progress is integer percent `0..=100` per §9.1 `progress: u8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)