### PR TITLE
feat(trusty-mpm): SM-STDIO JSON-RPC stdio adapter (tm sm serve --stdio) (#1291)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -223,14 +223,23 @@ pub(crate) enum Command {
     ///
     /// DOC-14 D0.2: `tm sm` and `tm session-manager` are visible aliases for
     /// `tm coordinator` — all reach the same code path. `coord` is a hidden alias.
+    ///
+    /// DOC-14 SM-STDIO (#1291): `tm sm serve --stdio` runs the SM JSON-RPC 2.0
+    /// over STDIO adapter — the primary, API-first headless drive surface
+    /// (`sm.chat`/`sm.goals.*`/`sm.sessions.*`/`sm.context.get`/`sm.health`). A
+    /// plain `tm sm <message>` still chats; the `serve` subcommand is the adapter.
     #[command(
         visible_alias = "sm",
         visible_alias = "session-manager",
         alias = "coord"
     )]
     Coordinator {
-        /// The message to send to the coordinator / session manager.
-        message: String,
+        /// The message to send to the coordinator / session manager (omit when
+        /// using the `serve` subcommand).
+        message: Option<String>,
+        /// Optional subcommand: `serve --stdio` runs the SM JSON-RPC stdio adapter.
+        #[command(subcommand)]
+        action: Option<CoordinatorAction>,
     },
 
     /// Inspect and probe workspace service daemons.
@@ -367,6 +376,30 @@ pub(crate) enum Command {
 /// What: `Poll` (discover + dispatch once, then exit) and `Listen` (repeatedly
 /// poll on an interval, processing newly-matched issues, until Ctrl-C).
 /// Test: `cli_parses_watch_poll`, `cli_parses_watch_listen` in `tests.rs`.
+/// Subcommands for `tm coordinator` / `tm sm` (DOC-14 SM-STDIO #1291).
+///
+/// Why: `tm sm` chats by default (a plain message), but the SM's PRIMARY,
+/// API-first interface is the JSON-RPC over STDIO adapter (§1A.1). Exposing it as
+/// a `serve` subcommand under the `sm` alias matches the trusty-* `serve --stdio`
+/// convention while leaving `tm sm <message>` for ad-hoc chat.
+/// What: one variant, `Serve { stdio }`, mirroring the daemon's `serve --stdio`
+/// flag shape. `--stdio` selects the newline-delimited JSON-RPC adapter; without
+/// it the subcommand prints guidance (the HTTP/TUI surfaces are separate).
+/// Test: `cli_parses_sm_serve_stdio` in `tests.rs`.
+#[derive(Debug, Subcommand)]
+pub(crate) enum CoordinatorAction {
+    /// Run the SM JSON-RPC 2.0 over STDIO adapter (the headless drive surface).
+    Serve {
+        /// Speak newline-delimited JSON-RPC 2.0 on stdin/stdout (logs to stderr).
+        ///
+        /// Why: the SM's API-first surface — a parent `claude-mpm`/PM drives every
+        /// `sm.*` method headlessly over stdio (§1A.2). Without this flag there is
+        /// no other `serve` mode yet, so it is effectively required.
+        #[arg(long)]
+        stdio: bool,
+    },
+}
+
 #[derive(Debug, Subcommand)]
 pub(crate) enum WatchCmd {
     /// One-shot: list label-matched issues, dispatch each, then exit.

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod repair;
 pub(crate) mod serve_stdio;
 pub(crate) mod services;
 pub(crate) mod session;
+pub(crate) mod sm_serve;
 pub(crate) mod supervisor;
 pub(crate) mod telegram;
 pub(crate) mod ticket;

--- a/crates/trusty-mpm/src/bin/tm/commands/sm_serve.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/sm_serve.rs
@@ -1,0 +1,48 @@
+//! `tm sm serve --stdio` — launch the SM JSON-RPC over STDIO adapter (#1291).
+//!
+//! Why: the SM's PRIMARY, API-first interface (DOC-14 §1A.1). A parent
+//! `claude-mpm`/PM drives every `sm.*` method headlessly over newline-delimited
+//! JSON-RPC to validate ALL SM functionality before any UI exists (§1A.2). Unlike
+//! the generic `tm serve --stdio` MCP bridge (which PROXIES to the HTTP daemon's
+//! `/rpc`), the SM adapter runs IN-PROCESS: it builds the SM core + the managed
+//! session-manager surface directly (the same handles the daemon wires) so the
+//! 13 `sm.*` methods map straight onto them with no extra hop.
+//! What: [`run_sm_serve`] initialises a STDERR-ONLY tracing subscriber (so stdout
+//! stays a clean JSON-RPC channel), builds an in-process
+//! [`DaemonState`](trusty_mpm::daemon::state::DaemonState), and runs
+//! [`run_sm_stdio`](trusty_mpm::daemon::sm_stdio::run_sm_stdio) to EOF.
+//! Test: dispatch behaviour is covered by `daemon::sm_stdio::tests`; this thin
+//! wiring is exercised at runtime via `tm sm serve --stdio`.
+
+use anyhow::{Result, bail};
+
+use crate::cli::CoordinatorAction;
+
+/// Run the `tm sm serve` subcommand.
+///
+/// Why: dispatch entry for the SM stdio adapter. Only `--stdio` is a real mode
+/// today; any other invocation is a usage error (the HTTP/TUI surfaces are
+/// separate tickets), so we fail loudly rather than silently no-op.
+/// What: for `Serve { stdio: true }`, inits stderr-only tracing and runs the
+/// adapter; for `Serve { stdio: false }`, returns an actionable error.
+/// Test: runtime; the adapter dispatch is unit-tested in `daemon::sm_stdio`.
+pub(crate) async fn run_sm_serve(action: CoordinatorAction) -> Result<()> {
+    let CoordinatorAction::Serve { stdio } = action;
+    if !stdio {
+        bail!("`tm sm serve` currently requires --stdio (the JSON-RPC over STDIO adapter)");
+    }
+
+    // STDOUT is the JSON-RPC channel — route ALL tracing to stderr. `try_init` is
+    // idempotent across test binaries and a no-op if a subscriber already exists.
+    use tracing_subscriber::util::SubscriberInitExt as _;
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .with_writer(std::io::stderr)
+        .finish()
+        .try_init();
+
+    let state = trusty_mpm::daemon::state::DaemonState::shared();
+    trusty_mpm::daemon::sm_stdio::run_sm_stdio(state).await
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -234,7 +234,20 @@ async fn main() -> anyhow::Result<()> {
         Command::Attach { target, json } => attach_cmd(&client, &url, &target, json).await,
         Command::Optimizer { action } => optimizer(&client, &url, action).await,
         Command::Overseer { action } => overseer(&client, &url, action).await,
-        Command::Coordinator { message } => coordinator(&url, message).await,
+        Command::Coordinator { message, action } => {
+            // DOC-14 SM-STDIO (#1291): `tm sm serve --stdio` runs the JSON-RPC
+            // over STDIO adapter; a plain `tm sm <message>` chats as before.
+            match action {
+                Some(action) => commands::sm_serve::run_sm_serve(action).await,
+                None => match message {
+                    Some(message) => coordinator(&url, message).await,
+                    None => Err(anyhow::anyhow!(
+                        "provide a message (`tm sm <message>`) or a subcommand \
+                         (`tm sm serve --stdio`)"
+                    )),
+                },
+            }
+        }
         Command::Services { action } => services(action),
         Command::Repair { action } => {
             use cli::RepairAction;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b.rs
@@ -73,10 +73,39 @@ fn cli_sm_aliases_reach_coordinator() {
         let cli = Cli::try_parse_from(["trusty-mpm", name, "hello there"])
             .unwrap_or_else(|e| panic!("`tm {name}` must parse: {e}"));
         match cli.command {
-            Command::Coordinator { message } => {
-                assert_eq!(message, "hello there", "`tm {name}` carries the message");
+            Command::Coordinator { message, action } => {
+                assert_eq!(
+                    message.as_deref(),
+                    Some("hello there"),
+                    "`tm {name}` carries the message"
+                );
+                assert!(action.is_none(), "a plain message has no subcommand");
             }
             other => panic!("`tm {name}` must be Command::Coordinator, got {other:?}"),
+        }
+    }
+}
+
+/// DOC-14 SM-STDIO (#1291): `tm sm serve --stdio` (and via every coordinator
+/// alias) must parse to `Command::Coordinator` with the `Serve { stdio: true }`
+/// subcommand — the JSON-RPC over STDIO adapter entry point.
+#[test]
+fn cli_parses_sm_serve_stdio() {
+    use crate::cli::CoordinatorAction;
+    for name in ["coordinator", "sm", "session-manager", "coord"] {
+        let cli = Cli::try_parse_from(["trusty-mpm", name, "serve", "--stdio"])
+            .unwrap_or_else(|e| panic!("`tm {name} serve --stdio` must parse: {e}"));
+        match cli.command {
+            Command::Coordinator { message, action } => {
+                assert!(message.is_none(), "the serve subcommand carries no message");
+                match action {
+                    Some(CoordinatorAction::Serve { stdio }) => {
+                        assert!(stdio, "--stdio sets the stdio flag");
+                    }
+                    other => panic!("`tm {name} serve` must be Serve, got {other:?}"),
+                }
+            }
+            other => panic!("`tm {name} serve` must be Command::Coordinator, got {other:?}"),
         }
     }
 }

--- a/crates/trusty-mpm/src/core/sm/agent/health.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/health.rs
@@ -1,0 +1,126 @@
+//! SM provider/health status for `sm.health` (DOC-14 §5.3, §1A.1).
+//!
+//! Why: the SM-STDIO `sm.health` method must report whether the SM can actually
+//! run a turn — is a provider resolvable, is it degraded, and which model tiers
+//! are configured — WITHOUT making a network call. That status logic is SM core,
+//! not transport, so it lives on [`SessionManagerAgent`] (the stdio adapter just
+//! forwards it). Reusing the SM-2 [`TierResolver`] seam means `resolve` only
+//! checks credentials + constructs a provider handle; it does not call the model,
+//! so health is cheap and deterministic-to-test with the mock resolver.
+//! What: [`SmHealth`] (`{ ok, provider, degraded, model_tiers }`) and
+//! [`SessionManagerAgent::health`], which resolves the orchestration tier to
+//! determine `provider`/`degraded`/`ok` and reads the three tier model ids from
+//! config.
+//! Test: `agent/health_tests.rs` — degraded (no runtime / degraded resolver),
+//! healthy (mock provider), and the model-tier reporting.
+
+use super::SessionManagerAgent;
+use crate::core::sm::providers::SmModelTier;
+
+/// The SM health snapshot returned by `sm.health` (§1A.1).
+///
+/// Why: a parent driver (`claude-mpm`) probes this before driving a turn to know
+/// whether inference is available and, if not, that the SM is in graceful
+/// degraded mode rather than broken. Bundling the four spec fields into one
+/// serializable struct keeps the adapter mapping a single `serde_json::to_value`.
+/// What: `ok` is true when a non-degraded provider resolved for orchestration;
+/// `provider` is the resolved provider's name (or `"none"` when degraded);
+/// `degraded` is `!ok`; `model_tiers` lists the configured tier model ids.
+/// Test: `agent/health_tests.rs`.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct SmHealth {
+    /// True when a provider with credentials resolved for the orchestration tier.
+    pub ok: bool,
+    /// The resolved provider name (`"anthropic"`/`"bedrock"`/`"openrouter"`), or
+    /// `"none"` when no provider is available (degraded).
+    pub provider: String,
+    /// Graceful degraded mode (no inference provider configured), the inverse of
+    /// `ok`.
+    pub degraded: bool,
+    /// The configured per-tier model ids (orchestration / summary / compaction).
+    pub model_tiers: SmModelTiers,
+}
+
+/// The configured model id for each SM task tier (§5.4).
+///
+/// Why: `sm.health` surfaces what models the SM is configured to use per tier so
+/// an operator can confirm the deployment is wired as intended.
+/// What: the orchestration (Sonnet), summary (Haiku), and compaction model ids,
+/// each as the raw (possibly provider-prefixed) config string.
+/// Test: `agent/health_tests.rs::health_reports_model_tiers`.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct SmModelTiers {
+    /// Orchestration-tier model (`sm_model`, with the deprecated-alias fallback).
+    pub orchestration: String,
+    /// Summarization-tier model (`summary_model`).
+    pub summary: String,
+    /// Compaction-tier model (`compaction_model`, falling back to `summary_model`).
+    pub compaction: String,
+}
+
+impl SessionManagerAgent {
+    /// Report the SM's provider/health status without a network call (§5.3).
+    ///
+    /// Why: `sm.health` (SM-STDIO) needs `{ ok, provider, degraded, model_tiers }`
+    /// to tell a parent driver whether the SM can run a turn. Resolving the
+    /// orchestration tier through the [`TierResolver`](crate::core::sm::providers::TierResolver)
+    /// checks credentials + builds a provider handle but does NOT call the model,
+    /// so this is cheap and testable with the mock resolver.
+    /// What: with no runtime (inert agent) → degraded with `provider = "none"`.
+    /// With a runtime, resolves the orchestration tier: a [`SmLlmError::Degraded`]
+    /// (or any resolution error) → degraded; success → `ok = true` and the
+    /// resolved provider name. Always fills `model_tiers` from config.
+    /// Test: `agent/health_tests.rs`.
+    pub async fn health(&self) -> SmHealth {
+        let model_tiers = self.model_tiers();
+        let Some(runtime) = self.runtime.as_ref() else {
+            return SmHealth {
+                ok: false,
+                provider: "none".to_string(),
+                degraded: true,
+                model_tiers,
+            };
+        };
+        match runtime
+            .resolver
+            .resolve(&self.config.inference, SmModelTier::Orchestration)
+            .await
+        {
+            Ok(call) => SmHealth {
+                ok: true,
+                provider: call.kind.name().to_string(),
+                degraded: false,
+                model_tiers,
+            },
+            Err(_) => SmHealth {
+                ok: false,
+                provider: "none".to_string(),
+                degraded: true,
+                model_tiers,
+            },
+        }
+    }
+
+    /// Read the configured per-tier model ids from config (§5.4).
+    ///
+    /// Why: health reports what each tier is configured to use; resolving the
+    /// tier model strings via the same SM-2 selection logic keeps health and the
+    /// real chat/compaction calls reporting identical ids.
+    /// What: returns the orchestration/summary/compaction model strings via
+    /// [`resolve_tier_model`](crate::core::sm::providers::resolve_tier_model),
+    /// substituting an empty string when a tier has no model configured.
+    /// Test: `agent/health_tests.rs::health_reports_model_tiers`.
+    fn model_tiers(&self) -> SmModelTiers {
+        use crate::core::sm::providers::resolve_tier_model;
+        let tier = |t| resolve_tier_model(&self.config.inference, t).unwrap_or_default();
+        SmModelTiers {
+            orchestration: tier(SmModelTier::Orchestration),
+            summary: tier(SmModelTier::Summary),
+            compaction: tier(SmModelTier::Compaction),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "health_tests.rs"]
+mod health_tests;

--- a/crates/trusty-mpm/src/core/sm/agent/health_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/health_tests.rs
@@ -1,0 +1,98 @@
+//! Tests for [`SessionManagerAgent::health`] (SM-STDIO `sm.health` source).
+//!
+//! Why: `sm.health` must report `{ ok, provider, degraded, model_tiers }` without
+//! a network call. These tests pin the three states — no runtime (inert),
+//! degraded resolver, and a healthy mock provider — plus the tier reporting,
+//! deterministically with the mock resolver.
+//! What: builds the agent feature-aware over a [`MockResolver`] and asserts the
+//! [`SmHealth`] shape.
+//! Test: this is the test module.
+
+use std::sync::Arc;
+
+use super::super::mock::{MockChatProvider, MockResolver};
+use crate::core::sm::agent::SessionManagerAgent;
+use crate::core::sm::config::SessionManagerConfig;
+
+/// An enabled SM config (health does not require enablement, but mirrors prod).
+fn enabled_config() -> SessionManagerConfig {
+    SessionManagerConfig {
+        enabled: true,
+        ..SessionManagerConfig::default()
+    }
+}
+
+/// Build an agent over the mock resolver, feature-aware (no memory in tests).
+fn agent_with(cfg: SessionManagerConfig, resolver: Arc<MockResolver>) -> SessionManagerAgent {
+    let data_root = std::env::temp_dir();
+    #[cfg(feature = "sm-memory")]
+    {
+        SessionManagerAgent::with_runtime(cfg, resolver, data_root, None)
+    }
+    #[cfg(not(feature = "sm-memory"))]
+    {
+        SessionManagerAgent::with_runtime(cfg, resolver, data_root)
+    }
+}
+
+/// Why: an inert agent (built via `new`, no runtime) has no provider, so health
+/// must report degraded with `provider = "none"` and `ok = false`.
+/// What: builds a `new()` agent and asserts the degraded health shape.
+/// Test: this is the test.
+#[tokio::test]
+async fn health_no_runtime_is_degraded() {
+    let agent = SessionManagerAgent::new(enabled_config());
+    let health = agent.health().await;
+    assert!(!health.ok);
+    assert!(health.degraded);
+    assert_eq!(health.provider, "none");
+}
+
+/// Why: when the resolver reports degraded (no credentials), health must surface
+/// graceful degraded mode rather than ok.
+/// What: builds an agent over a degraded resolver and asserts degraded health.
+/// Test: this is the test.
+#[tokio::test]
+async fn health_degraded_resolver_is_degraded() {
+    let agent = agent_with(enabled_config(), Arc::new(MockResolver::degraded()));
+    let health = agent.health().await;
+    assert!(!health.ok);
+    assert!(health.degraded);
+    assert_eq!(health.provider, "none");
+}
+
+/// Why: with a resolvable provider, health must report ok + the resolved
+/// provider name and NOT degraded.
+/// What: builds an agent over a provider resolver; asserts `ok` + provider name.
+/// Test: this is the test.
+#[tokio::test]
+async fn health_with_provider_is_ok() {
+    let provider = MockChatProvider::new("unused", 0.0);
+    let resolver = Arc::new(MockResolver::with_provider(provider));
+    let agent = agent_with(enabled_config(), resolver);
+    let health = agent.health().await;
+    assert!(health.ok);
+    assert!(!health.degraded);
+    // The mock resolver tags resolved calls as Anthropic.
+    assert_eq!(health.provider, "anthropic");
+}
+
+/// Why: health must surface the configured per-tier model ids so an operator can
+/// confirm the deployment is wired as intended.
+/// What: asserts the orchestration/summary/compaction model ids match the
+/// default config tiers.
+/// Test: this is the test.
+#[tokio::test]
+async fn health_reports_model_tiers() {
+    let provider = MockChatProvider::new("unused", 0.0);
+    let resolver = Arc::new(MockResolver::with_provider(provider));
+    let agent = agent_with(enabled_config(), resolver);
+    let health = agent.health().await;
+    assert_eq!(
+        health.model_tiers.orchestration,
+        "anthropic/claude-sonnet-4-6"
+    );
+    assert_eq!(health.model_tiers.summary, "anthropic/claude-haiku");
+    // Compaction falls back to summary when unset.
+    assert_eq!(health.model_tiers.compaction, "anthropic/claude-haiku");
+}

--- a/crates/trusty-mpm/src/core/sm/agent/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/mod.rs
@@ -24,6 +24,7 @@
 //! `agent/chat_tests.rs` covers the composed turn, degraded mode, and recall.
 
 mod chat;
+mod health;
 
 #[cfg(test)]
 pub mod mock;
@@ -38,6 +39,7 @@ use super::providers::TierResolver;
 use super::memory::SmMemory;
 
 pub use chat::{SmAgentError, SmChatOutcome};
+pub use health::{SmHealth, SmModelTiers};
 
 /// The Session Manager orchestrator (SM-7: real conversational chat turn).
 ///

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -54,7 +54,7 @@ pub mod memory;
 pub mod prompt;
 pub mod providers;
 
-pub use agent::{SessionManagerAgent, SmAgentError, SmChatOutcome};
+pub use agent::{SessionManagerAgent, SmAgentError, SmChatOutcome, SmHealth, SmModelTiers};
 pub use config::{SessionManagerConfig, SmInferenceConfig, SmMemoryConfig, SmRoundsConfig};
 pub use context::{
     ConversationStore, ConversationStoreError, Round, SmContextEngine, SmContextError,

--- a/crates/trusty-mpm/src/core/sm/providers/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/mod.rs
@@ -108,6 +108,22 @@ impl ProviderKind {
             ))),
         }
     }
+
+    /// The stable lowercase name of this provider kind.
+    ///
+    /// Why: `sm.health` (SM-STDIO) reports which concrete provider resolved for
+    /// the orchestration tier; a stable string keeps the wire payload and any
+    /// operator-facing status consistent with the `provider` config values.
+    /// What: returns `"auto"`/`"anthropic"`/`"bedrock"`/`"openrouter"`.
+    /// Test: `provider_kind_name_round_trips` (this module's tests).
+    pub fn name(self) -> &'static str {
+        match self {
+            ProviderKind::Auto => "auto",
+            ProviderKind::Anthropic => "anthropic",
+            ProviderKind::Bedrock => "bedrock",
+            ProviderKind::OpenRouter => "openrouter",
+        }
+    }
 }
 
 // ─── Chat / request / response shapes ──────────────────────────────────────────
@@ -229,6 +245,24 @@ mod tests {
             ProviderKind::parse("openrouter").unwrap(),
             ProviderKind::OpenRouter
         );
+    }
+
+    /// Why: `sm.health` reports the resolved provider by name; the name must be
+    /// the stable lowercase string that also round-trips back through `parse`.
+    /// What: asserts `name()` for each kind and that `parse(name())` recovers it
+    /// (modulo `Auto`, whose name `"auto"` parses back to `Auto`).
+    /// Test: this is the test.
+    #[test]
+    fn provider_kind_name_round_trips() {
+        for kind in [
+            ProviderKind::Auto,
+            ProviderKind::Anthropic,
+            ProviderKind::Bedrock,
+            ProviderKind::OpenRouter,
+        ] {
+            assert_eq!(ProviderKind::parse(kind.name()).unwrap(), kind);
+        }
+        assert_eq!(ProviderKind::Anthropic.name(), "anthropic");
     }
 
     /// Why: SM-1 review carry-forward — an unknown `provider` string must be a

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -29,6 +29,7 @@ pub mod optimizer;
 pub mod overseer_compose;
 pub mod pairing_store;
 pub mod services;
+pub mod sm_stdio;
 pub mod state;
 pub mod tmux;
 pub mod watcher;

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -1,0 +1,255 @@
+//! The session-control seam the SM stdio adapter maps `sm.sessions.*` onto.
+//!
+//! Why: the SM-STDIO adapter (DOC-14 §1A.1) is a THIN mapping — it must not
+//! carry session-lifecycle business logic. The `sm.sessions.launch/list/get/
+//! send/stop/resume/kill` methods map onto the daemon's existing managed-session
+//! control surface (§2.6) — the SAME code `tm ticket`/the HTTP `…/managed/*`
+//! routes use. Hiding that surface behind a narrow trait keeps the dispatcher
+//! (a) transport-neutral and (b) HERMETICALLY testable: the round-trip tests
+//! inject a deterministic mock instead of provisioning a real tmux/workspace.
+//! What: [`SessionControl`] — the seven async verbs the spec's session methods
+//! need, each returning a plain `serde_json::Value` (the wire result body) or a
+//! [`SessionControlError`]. [`DaemonSessionControl`] is the production impl that
+//! delegates to the in-process [`crate::session_manager::SessionManager`] +
+//! [`spawn_managed`]/[`resume_managed`] (so the stdio path and the HTTP path
+//! cannot diverge). The mock impl lives in `tests.rs`.
+//! Test: `DaemonSessionControl` is exercised by the daemon's managed-session
+//! integration tests (it forwards to the same helpers those cover); the
+//! dispatcher's `sm.sessions.*` round-trips use the `tests.rs` mock.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::daemon::managed_routes::{SpawnParams, record_to_json, resume_managed, spawn_managed};
+use crate::daemon::state::DaemonState;
+use crate::session_manager::ManagedSessionId;
+
+/// Inputs for `sm.sessions.launch` (§1A.1: `{ workdir, model?, prompt?, goal_id? }`).
+///
+/// Why: the spec's launch params differ from the managed-session `SpawnParams`
+/// shape (`{ repo_url, ref, task }`); keeping the adapter's own owned input
+/// struct lets the dispatcher parse the spec params once and hand them to ANY
+/// [`SessionControl`] impl (real or mock) without re-deriving the mapping at the
+/// call site.
+/// What: `workdir` (the directory/repo the session launches against, mapped to
+/// the managed `repo_url`), an optional `model` (runtime selector), an optional
+/// `prompt` (the task/intent, mapped to the managed `task`), and an optional
+/// `goal_id` the caller wants the new session linked to (§9.3).
+/// Test: `tests.rs::launch_round_trips` constructs this from JSON params.
+#[derive(Debug, Clone)]
+pub struct LaunchParams {
+    /// Working directory / repository the session launches against.
+    pub workdir: String,
+    /// Optional model / runtime selector (mapped to the managed `runtime`).
+    pub model: Option<String>,
+    /// Optional initial prompt / task description (mapped to the managed `task`).
+    pub prompt: Option<String>,
+    /// Optional goal id to link the launched session to (§9.3).
+    pub goal_id: Option<String>,
+}
+
+/// A failure surfaced by a [`SessionControl`] operation.
+///
+/// Why: the dispatcher maps these onto JSON-RPC error responses; a typed enum
+/// lets it choose `INVALID_PARAMS` (bad id) vs `INTERNAL_ERROR` (control
+/// failure) by VARIANT rather than string-matching, and keeps the adapter
+/// panic-free per the workspace convention.
+/// What: [`NotFound`](SessionControlError::NotFound) for an absent/invalid
+/// session id; [`Backend`](SessionControlError::Backend) for any control-surface
+/// failure (provision/tmux/store).
+/// Test: `tests.rs` mock returns both variants; the dispatcher asserts the
+/// mapped JSON-RPC code.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionControlError {
+    /// The session id was invalid or not present.
+    #[error("session not found: {0}")]
+    NotFound(String),
+
+    /// Any backend control failure (provisioning, tmux, store, resume).
+    #[error("{0}")]
+    Backend(String),
+}
+
+/// The narrow session-control surface the SM stdio adapter maps onto (§2.6).
+///
+/// Why: keeps `sm.sessions.*` a thin translation. The dispatcher depends on this
+/// trait (Dependency Inversion) so production wires [`DaemonSessionControl`]
+/// (the real managed-session surface) while tests wire a deterministic mock with
+/// NO tmux/workspace. Every method returns the wire `result` body directly so
+/// the dispatcher does no shaping.
+/// What: `launch` → `{ session_id }`; `list` → `{ sessions: [...] }`; `get` →
+/// the full record JSON; `send` → `{ ok }`; `stop`/`resume`/`kill` → `{ ok }`.
+/// All are `Send + Sync` to live behind `Arc<dyn SessionControl>`.
+/// Test: `tests.rs` mock; `DaemonSessionControl` via the managed integration tests.
+#[async_trait]
+pub trait SessionControl: Send + Sync {
+    /// Launch a managed session (`POST /sessions`, §2.6) and return its id.
+    async fn launch(&self, params: LaunchParams) -> Result<serde_json::Value, SessionControlError>;
+
+    /// List all managed sessions (`GET /sessions`, §2.6).
+    async fn list(&self) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Get one session record (`GET /sessions/{id}`, §2.6).
+    async fn get(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Send text into a session's pane (`POST /sessions/{id}/command`, §2.6).
+    async fn send(
+        &self,
+        session_id: &str,
+        text: &str,
+    ) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Stop a session's runtime, keeping the workspace (`DELETE /sessions/{id}`).
+    async fn stop(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Resume a stopped session (`POST /sessions/{id}/resume`, §2.6).
+    async fn resume(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Force-stop / reap a session (`DELETE /sessions/{id}`, §2.6).
+    async fn kill(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+}
+
+/// Production [`SessionControl`] over the in-process managed-session surface.
+///
+/// Why: the SM runs IN the daemon, so the spec's "delegate to t-mpm's
+/// session-manager" is a direct in-process call to the SAME helpers the HTTP
+/// `…/managed/*` routes use ([`spawn_managed`]/[`resume_managed`] +
+/// [`crate::session_manager::SessionManager`]). Calling them directly (rather
+/// than looping back over HTTP) keeps one code path and means the stdio surface
+/// inherits every fix to the managed surface for free.
+/// What: holds the shared `Arc<DaemonState>` and forwards each verb to its
+/// managed-surface counterpart, returning the same flat JSON the HTTP routes do
+/// (via [`record_to_json`]).
+/// Test: forwards to helpers covered by the managed integration tests; the
+/// dispatcher round-trips use the `tests.rs` mock instead.
+pub struct DaemonSessionControl {
+    /// Shared daemon state holding the managed [`crate::session_manager::SessionManager`].
+    state: Arc<DaemonState>,
+}
+
+impl DaemonSessionControl {
+    /// Build the production control over the daemon's shared state.
+    ///
+    /// Why: the stdio entry point constructs this once from the daemon state so
+    /// every `sm.sessions.*` call reuses the one live session manager.
+    /// What: stores the `Arc<DaemonState>`.
+    /// Test: construction is trivial; behaviour is covered by the managed tests.
+    pub fn new(state: Arc<DaemonState>) -> Self {
+        Self { state }
+    }
+
+    /// Parse + validate a managed session id string.
+    ///
+    /// Why: an invalid UUID must become a graceful `NotFound` (→ JSON-RPC error)
+    /// rather than a panic, mirroring the HTTP route's 400/404 handling.
+    /// What: parses the string into a [`ManagedSessionId`], mapping failure to
+    /// [`SessionControlError::NotFound`].
+    /// Test: covered by the managed integration tests.
+    fn parse_id(session_id: &str) -> Result<ManagedSessionId, SessionControlError> {
+        session_id
+            .parse::<uuid::Uuid>()
+            .map(ManagedSessionId::from)
+            .map_err(|_| SessionControlError::NotFound(session_id.to_string()))
+    }
+}
+
+#[async_trait]
+impl SessionControl for DaemonSessionControl {
+    /// Launch via the shared [`spawn_managed`] flow (provision → tmux → harness).
+    ///
+    /// Why: the spec maps `sm.sessions.launch` onto `POST /sessions`, whose
+    /// engine is [`spawn_managed`]. Forwarding here keeps the adapter a thin
+    /// mapping with zero provisioning logic of its own.
+    /// What: maps `workdir → repo_url`, `prompt → task` (defaulting to a generic
+    /// description when absent), and `model → runtime`, then returns
+    /// `{ session_id }`. The `goal_id` link is recorded by the dispatcher via the
+    /// goal store (§9.3), not here, so this stays purely session-control.
+    /// Test: forwards to `spawn_managed` (managed integration tests).
+    async fn launch(&self, params: LaunchParams) -> Result<serde_json::Value, SessionControlError> {
+        let task = params
+            .prompt
+            .filter(|p| !p.trim().is_empty())
+            .unwrap_or_else(|| "session-manager launched task".to_string());
+        let spawn = SpawnParams {
+            repo_url: params.workdir,
+            git_ref: String::new(),
+            task,
+            name_hint: None,
+            runtime: params.model,
+        };
+        let record = spawn_managed(&self.state, spawn)
+            .await
+            .map_err(SessionControlError::Backend)?;
+        Ok(serde_json::json!({ "session_id": record.id.to_string() }))
+    }
+
+    /// List all managed sessions as `{ sessions: [record, …] }`.
+    async fn list(&self) -> Result<serde_json::Value, SessionControlError> {
+        let mgr = self.state.session_manager().await;
+        let sessions: Vec<serde_json::Value> =
+            mgr.list().await.iter().map(record_to_json).collect();
+        Ok(serde_json::json!({ "sessions": sessions }))
+    }
+
+    /// Get one session record (the flat managed JSON).
+    async fn get(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        let mgr = self.state.session_manager().await;
+        let record = mgr
+            .get(&id)
+            .await
+            .map_err(|_| SessionControlError::NotFound(session_id.to_string()))?;
+        Ok(serde_json::json!({ "session": record_to_json(&record) }))
+    }
+
+    /// Inject text into the session pane; returns `{ ok: true }`.
+    async fn send(
+        &self,
+        session_id: &str,
+        text: &str,
+    ) -> Result<serde_json::Value, SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        let mgr = self.state.session_manager().await;
+        mgr.send_input(&id, text)
+            .await
+            .map_err(|e| SessionControlError::Backend(e.to_string()))?;
+        Ok(serde_json::json!({ "ok": true }))
+    }
+
+    /// Stop the runtime, keeping the workspace; returns `{ ok: true }`.
+    async fn stop(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        let mgr = self.state.session_manager().await;
+        mgr.stop(&id)
+            .await
+            .map_err(|_| SessionControlError::NotFound(session_id.to_string()))?;
+        Ok(serde_json::json!({ "ok": true }))
+    }
+
+    /// Resume a stopped session and re-spawn its runtime; returns `{ ok: true }`.
+    async fn resume(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        resume_managed(&self.state, &id)
+            .await
+            .map_err(|e| SessionControlError::Backend(e.to_string()))?;
+        Ok(serde_json::json!({ "ok": true }))
+    }
+
+    /// Force-stop / reap a session (decommission — terminal teardown).
+    ///
+    /// Why: `sm.sessions.kill` is the force-stop/reap verb (§1A.1 maps it to the
+    /// `DELETE /sessions/{id}` + `/sessions/dead` reap path). The strongest
+    /// in-process equivalent is `decommission` (kills runtime + tombstones the
+    /// record); a plain `stop` would leave a resumable session, not a reaped one.
+    /// What: forwards to `SessionManager::decommission`; returns `{ ok: true }`.
+    /// Test: forwards to `decommission` (managed integration tests).
+    async fn kill(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        let mgr = self.state.session_manager().await;
+        mgr.decommission(&id)
+            .await
+            .map_err(|_| SessionControlError::NotFound(session_id.to_string()))?;
+        Ok(serde_json::json!({ "ok": true }))
+    }
+}

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 
 use crate::daemon::managed_routes::{SpawnParams, record_to_json, resume_managed, spawn_managed};
 use crate::daemon::state::DaemonState;
-use crate::session_manager::ManagedSessionId;
+use crate::session_manager::{ManagedError, ManagedSessionId};
 
 /// Inputs for `sm.sessions.launch` (§1A.1: `{ workdir, model?, prompt?, goal_id? }`).
 ///
@@ -55,9 +55,10 @@ pub struct LaunchParams {
 /// lets it choose `INVALID_PARAMS` (bad id) vs `INTERNAL_ERROR` (control
 /// failure) by VARIANT rather than string-matching, and keeps the adapter
 /// panic-free per the workspace convention.
-/// What: [`NotFound`](SessionControlError::NotFound) for an absent/invalid
-/// session id; [`Backend`](SessionControlError::Backend) for any control-surface
-/// failure (provision/tmux/store).
+/// What: [`NotFound`](SessionControlError::NotFound) is reserved for a malformed
+/// session id (UUID parse failure) OR a genuinely-absent session
+/// (`ManagedError::SessionNotFound`); [`Backend`](SessionControlError::Backend)
+/// for any other control-surface failure (provision/tmux/store/invalid-state).
 /// Test: `tests.rs` mock returns both variants; the dispatcher asserts the
 /// mapped JSON-RPC code.
 #[derive(Debug, thiserror::Error)]
@@ -152,6 +153,27 @@ impl DaemonSessionControl {
             .map(ManagedSessionId::from)
             .map_err(|_| SessionControlError::NotFound(session_id.to_string()))
     }
+
+    /// Map a manager [`ManagedError`] onto the control error class.
+    ///
+    /// Why: a post-parse operation failure must preserve the not-found-vs-backend
+    /// distinction so the dispatcher picks the right JSON-RPC code. Reserving
+    /// [`SessionControlError::NotFound`] for the genuinely-absent session (and the
+    /// UUID-parse failure in [`Self::parse_id`]) — and routing every OTHER manager
+    /// failure (tmux, store, invalid-state, I/O) to
+    /// [`SessionControlError::Backend`] (`-32603`) — keeps `get`/`stop`/`kill`
+    /// consistent with `send`/`resume`, which already surface backend failures as
+    /// `Backend`.
+    /// What: `ManagedError::SessionNotFound` → `NotFound`; every other variant →
+    /// `Backend(e.to_string())`.
+    /// Test: `tests.rs::stop_backend_failure_is_backend_not_found` and
+    /// `kill_backend_failure_is_backend_not_found`.
+    fn map_managed_err(e: ManagedError) -> SessionControlError {
+        match e {
+            ManagedError::SessionNotFound(msg) => SessionControlError::NotFound(msg),
+            other => SessionControlError::Backend(other.to_string()),
+        }
+    }
 }
 
 #[async_trait]
@@ -196,10 +218,7 @@ impl SessionControl for DaemonSessionControl {
     async fn get(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError> {
         let id = Self::parse_id(session_id)?;
         let mgr = self.state.session_manager().await;
-        let record = mgr
-            .get(&id)
-            .await
-            .map_err(|_| SessionControlError::NotFound(session_id.to_string()))?;
+        let record = mgr.get(&id).await.map_err(Self::map_managed_err)?;
         Ok(serde_json::json!({ "session": record_to_json(&record) }))
     }
 
@@ -221,9 +240,7 @@ impl SessionControl for DaemonSessionControl {
     async fn stop(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError> {
         let id = Self::parse_id(session_id)?;
         let mgr = self.state.session_manager().await;
-        mgr.stop(&id)
-            .await
-            .map_err(|_| SessionControlError::NotFound(session_id.to_string()))?;
+        mgr.stop(&id).await.map_err(Self::map_managed_err)?;
         Ok(serde_json::json!({ "ok": true }))
     }
 
@@ -247,9 +264,7 @@ impl SessionControl for DaemonSessionControl {
     async fn kill(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError> {
         let id = Self::parse_id(session_id)?;
         let mgr = self.state.session_manager().await;
-        mgr.decommission(&id)
-            .await
-            .map_err(|_| SessionControlError::NotFound(session_id.to_string()))?;
+        mgr.decommission(&id).await.map_err(Self::map_managed_err)?;
         Ok(serde_json::json!({ "ok": true }))
     }
 }

--- a/crates/trusty-mpm/src/daemon/sm_stdio/dispatch.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/dispatch.rs
@@ -1,0 +1,85 @@
+//! The JSON-RPC 2.0 router for the SM stdio adapter (§1A.1 / §1A.2).
+//!
+//! Why: one place that turns a parsed [`Request`] into a JSON-RPC 2.0
+//! [`Response`] — echoing the `id`, routing the method name to its handler in
+//! [`super::methods`], and mapping a handler's typed [`MethodError`] onto the
+//! correct JSON-RPC error code. Keeping the router separate from the handlers
+//! keeps both legible and under the SLOC cap. Unknown methods become
+//! `METHOD_NOT_FOUND`; bad params become `INVALID_PARAMS`; a notification (no id)
+//! is suppressed — never a panic.
+//! What: [`dispatch`] — `(&SmDispatcher, Request) -> Response`. It returns the
+//! suppressed sentinel for id-less notifications, routes the 13 `sm.*` methods,
+//! and folds every other method into a method-not-found error.
+//! Test: `tests.rs` round-trips every method + the parse/unknown/notification
+//! paths.
+
+use serde_json::Value;
+use trusty_common::mcp::{Response, error_codes};
+
+use super::SmDispatcher;
+use super::methods::{self, CODE_NOT_FOUND, CODE_UNAVAILABLE, MethodError};
+use trusty_common::mcp::Request;
+
+/// Route one request to its mapped SM surface and shape the JSON-RPC response.
+///
+/// Why: the single dispatch seam the stdio loop and every test drive. It echoes
+/// the request `id`, suppresses id-less notifications (per JSON-RPC 2.0), routes
+/// the method to its handler, and maps the handler's `Result<Value, MethodError>`
+/// onto a `result`/`error` response. No panics: a missing handler →
+/// method-not-found, a handler error → its mapped code.
+/// What: matches `req.method` against the 13 `sm.*` names; on a hit awaits the
+/// handler and builds `Response::ok` / the mapped error; on a miss builds
+/// `Response::err(METHOD_NOT_FOUND)`.
+/// Test: `tests.rs` — all 13 methods, unknown method, notification suppression.
+pub async fn dispatch(d: &SmDispatcher, req: Request) -> Response {
+    // JSON-RPC notifications (no id) must not produce a reply.
+    if req.id.is_none() {
+        return Response::suppressed();
+    }
+    let id = req.id.clone();
+    let params = req.params.clone().unwrap_or(Value::Null);
+
+    let result: Result<Value, MethodError> = match req.method.as_str() {
+        "sm.chat" => methods::sm_chat(d, &params).await,
+        "sm.health" => methods::sm_health(d, &params).await,
+        "sm.goals.list" => methods::sm_goals_list(d, &params).await,
+        "sm.goals.create" => methods::sm_goals_create(d, &params).await,
+        "sm.goals.update" => methods::sm_goals_update(d, &params).await,
+        "sm.sessions.launch" => methods::sm_sessions_launch(d, &params).await,
+        "sm.sessions.list" => methods::sm_sessions_list(d, &params).await,
+        "sm.sessions.get" => methods::sm_sessions_get(d, &params).await,
+        "sm.sessions.send" => methods::sm_sessions_send(d, &params).await,
+        "sm.sessions.stop" => methods::sm_sessions_stop(d, &params).await,
+        "sm.sessions.resume" => methods::sm_sessions_resume(d, &params).await,
+        "sm.sessions.kill" => methods::sm_sessions_kill(d, &params).await,
+        "sm.context.get" => methods::sm_context_get(d, &params).await,
+        other => {
+            return Response::err(
+                id,
+                error_codes::METHOD_NOT_FOUND,
+                format!("unknown SM method: {other}"),
+            );
+        }
+    };
+
+    match result {
+        Ok(value) => Response::ok(id, value),
+        Err(e) => Response::err(id, error_code_for(&e), e.to_string()),
+    }
+}
+
+/// Map a [`MethodError`] class onto its JSON-RPC error code.
+///
+/// Why: the router must report the right code per failure class so a driver can
+/// distinguish bad input (`-32602`) from a missing entity (`-32001`), an
+/// unavailable surface (`-32002`), and a backend failure (`-32603`).
+/// What: matches the variant to its code.
+/// Test: `tests.rs` asserts the code for each error path.
+fn error_code_for(e: &MethodError) -> i32 {
+    match e {
+        MethodError::InvalidParams(_) => error_codes::INVALID_PARAMS,
+        MethodError::NotFound(_) => CODE_NOT_FOUND,
+        MethodError::Unavailable(_) => CODE_UNAVAILABLE,
+        MethodError::Internal(_) => error_codes::INTERNAL_ERROR,
+    }
+}

--- a/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
@@ -69,23 +69,31 @@ fn ensure_obj(params: &Value) -> Result<(), MethodError> {
     }
 }
 
-/// Extract a REQUIRED string field from params.
+/// Extract a REQUIRED, non-blank string field from params.
 ///
 /// Why: several methods require a string (`message`, `description`, `session_id`,
-/// `text`, `id`, `workdir`); a missing/non-string value must be a clean
-/// invalid-params error, not a panic.
-/// What: returns the trimmed-non-empty string, or [`MethodError::InvalidParams`].
-/// Test: `tests.rs::*_missing_required_param_is_invalid_params`.
+/// `text`, `id`, `workdir`); a missing/non-string/blank value must be a clean
+/// invalid-params error, not a panic. Distinguishing "absent" from
+/// "present-but-blank" gives a caller an actionable message instead of a
+/// misleading "missing" when they DID supply the key (just whitespace).
+/// What: returns the original (untrimmed) string when present and non-blank;
+/// otherwise [`MethodError::InvalidParams`] — with a "missing/not a string"
+/// message when the field is absent or non-string, and a distinct "must not be
+/// blank" message when it is present but trims to empty. Blank strings are still
+/// rejected.
+/// Test: `tests.rs::*_missing_required_param_is_invalid_params`,
+/// `blank_required_param_is_distinct_invalid_params`.
 fn req_str(params: &Value, field: &str) -> Result<String, MethodError> {
     ensure_obj(params)?;
-    params
-        .get(field)
-        .and_then(Value::as_str)
-        .filter(|s| !s.trim().is_empty())
-        .map(str::to_string)
-        .ok_or_else(|| {
-            MethodError::InvalidParams(format!("missing required string param `{field}`"))
-        })
+    match params.get(field).and_then(Value::as_str) {
+        Some(s) if !s.trim().is_empty() => Ok(s.to_string()),
+        Some(_) => Err(MethodError::InvalidParams(format!(
+            "param `{field}` must not be blank"
+        ))),
+        None => Err(MethodError::InvalidParams(format!(
+            "missing required string param `{field}`"
+        ))),
+    }
 }
 
 /// Extract an OPTIONAL string field from params (absent/null/empty → `None`).
@@ -169,6 +177,16 @@ pub async fn sm_sessions_launch(d: &SmDispatcher, params: &Value) -> Result<Valu
             .unwrap_or_default()
             .to_string();
         let linked = link_session_to_goal(d, &goal_id, &session_id).await;
+        if !linked {
+            // Best-effort link (§9.3): an unknown goal or a persist failure must
+            // NOT undo a successful launch, but it must be observable rather than
+            // silently swallowed — `linked: false` rides back in the response too.
+            tracing::warn!(
+                session_id = %session_id,
+                goal_id = %goal_id,
+                "sm.sessions.launch: goal↔session link failed (best-effort); session launched but not linked"
+            );
+        }
         let mut out = result;
         if let Some(obj) = out.as_object_mut() {
             obj.insert("goal_id".to_string(), json!(goal_id));
@@ -346,8 +364,6 @@ pub async fn sm_goals_create(d: &SmDispatcher, params: &Value) -> Result<Value, 
 /// Test: `tests.rs::goals_update_round_trips`.
 #[cfg(feature = "sm-memory")]
 pub async fn sm_goals_update(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
-    use crate::core::sm::GoalStatus;
-
     let id = req_str(params, "id")?;
     let note = opt_str(params, "note");
     let status = opt_str(params, "status");
@@ -364,7 +380,6 @@ pub async fn sm_goals_update(d: &SmDispatcher, params: &Value) -> Result<Value, 
         .get(&id)
         .cloned()
         .ok_or_else(|| MethodError::NotFound(format!("goal not found: {id}")))?;
-    let _ = GoalStatus::default(); // keep the import meaningful across cfgs
     serde_json::to_value(json!({ "goal": goal })).map_err(|e| MethodError::Internal(e.to_string()))
 }
 

--- a/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
@@ -1,0 +1,490 @@
+//! The 13 SM method handlers — thin mappings onto existing surfaces (§1A.1).
+//!
+//! Why: each `sm.*` method maps onto exactly one existing SM surface; keeping the
+//! handlers here (separate from the router) makes the "method → surface" table
+//! the spec mandates legible at a glance, and keeps every file under the SLOC
+//! cap. NO business logic lives here — each handler parses its params, calls the
+//! mapped surface, and shapes the result. All errors are typed
+//! ([`MethodError`]) so the router maps them to JSON-RPC codes by variant.
+//! What: `sm_chat`/`sm_health` → [`SessionManagerAgent`]; `sm_goals_*` →
+//! [`SmGoalStore`] (feature-gated); `sm_sessions_*` → [`SessionControl`];
+//! `sm_context_get` → the SM-5 context engine (feature-gated on the goal/context
+//! availability decision).
+//! Test: `tests.rs` round-trips every handler through the router.
+
+use serde_json::{Value, json};
+
+use super::SmDispatcher;
+use super::control::{LaunchParams, SessionControlError};
+
+/// A typed handler failure the router maps to a JSON-RPC error (§1A.2).
+///
+/// Why: the router needs to choose the right JSON-RPC error code per failure
+/// class WITHOUT string-matching, and every handler must stay panic-free. A
+/// typed enum carries the class + a human message + optional structured data.
+/// What: [`InvalidParams`](MethodError::InvalidParams) (bad/missing params →
+/// `-32602`), [`NotFound`](MethodError::NotFound) (absent goal/session → a
+/// server-defined `-32001`), [`Unavailable`](MethodError::Unavailable) (a surface
+/// gated off, e.g. goals without `sm-memory` → `-32002`), and
+/// [`Internal`](MethodError::Internal) (any backend failure → `-32603`).
+/// Test: `tests.rs` asserts the mapped code for each path.
+#[derive(Debug, thiserror::Error)]
+pub enum MethodError {
+    /// Missing or malformed params → JSON-RPC `INVALID_PARAMS` (-32602).
+    #[error("{0}")]
+    InvalidParams(String),
+
+    /// A referenced goal/session was not found → server error -32001.
+    #[error("{0}")]
+    NotFound(String),
+
+    /// A surface is unavailable in this build (feature gated) → server -32002.
+    #[error("{0}")]
+    Unavailable(String),
+
+    /// Any backend failure → JSON-RPC `INTERNAL_ERROR` (-32603).
+    #[error("{0}")]
+    Internal(String),
+}
+
+/// Server-defined JSON-RPC error code for "referenced entity not found".
+pub const CODE_NOT_FOUND: i32 = -32001;
+/// Server-defined JSON-RPC error code for "surface unavailable in this build".
+pub const CODE_UNAVAILABLE: i32 = -32002;
+
+/// Validate that params is an object or absent/null (else invalid-params).
+///
+/// Why: `sm.*` methods accept an optional params OBJECT; an array or scalar
+/// `params` is malformed and must be a clean invalid-params error rather than a
+/// silent miss. Absent/null is allowed (methods with no required fields).
+/// What: returns `Ok(())` for `Null`/object params; [`MethodError::InvalidParams`]
+/// otherwise.
+/// Test: `tests.rs` drives both present and absent params.
+fn ensure_obj(params: &Value) -> Result<(), MethodError> {
+    match params {
+        Value::Null | Value::Object(_) => Ok(()),
+        other => Err(MethodError::InvalidParams(format!(
+            "params must be a JSON object, got {other}"
+        ))),
+    }
+}
+
+/// Extract a REQUIRED string field from params.
+///
+/// Why: several methods require a string (`message`, `description`, `session_id`,
+/// `text`, `id`, `workdir`); a missing/non-string value must be a clean
+/// invalid-params error, not a panic.
+/// What: returns the trimmed-non-empty string, or [`MethodError::InvalidParams`].
+/// Test: `tests.rs::*_missing_required_param_is_invalid_params`.
+fn req_str(params: &Value, field: &str) -> Result<String, MethodError> {
+    ensure_obj(params)?;
+    params
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            MethodError::InvalidParams(format!("missing required string param `{field}`"))
+        })
+}
+
+/// Extract an OPTIONAL string field from params (absent/null/empty → `None`).
+fn opt_str(params: &Value, field: &str) -> Option<String> {
+    params
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+}
+
+// ── sm.chat / sm.health (SessionManagerAgent: SM-7 / §5.3) ──────────────────────
+
+/// `sm.chat { message, conv_id? }` → `{ reply, conv_id, cost? }` (SM-7).
+///
+/// Why: the headline method — drives one full SM conversational turn via
+/// [`SessionManagerAgent::chat`]. The adapter only parses params and shapes the
+/// outcome; the §7.5 assembly + provider call live in SM-7.
+/// What: parses `message` (required) + `conv_id` (optional), calls `chat`, and
+/// returns `{ reply, conv_id, cost }`. A degraded SM (no provider) maps to a
+/// graceful [`MethodError::Unavailable`]; any other chat failure →
+/// [`MethodError::Internal`].
+/// Test: `tests.rs::chat_round_trips`, `chat_degraded_is_unavailable`.
+pub async fn sm_chat(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let message = req_str(params, "message")?;
+    let conv_id = opt_str(params, "conv_id");
+    match d.agent.chat(&message, conv_id.as_deref()).await {
+        Ok(outcome) => Ok(json!({
+            "reply": outcome.reply,
+            "conv_id": outcome.conv_id,
+            "cost": outcome.cost_usd,
+        })),
+        Err(crate::core::sm::SmAgentError::Degraded(notice)) => {
+            Err(MethodError::Unavailable(notice))
+        }
+        Err(e) => Err(MethodError::Internal(e.to_string())),
+    }
+}
+
+/// `sm.health {}` → `{ ok, provider, degraded, model_tiers }` (§5.3).
+///
+/// Why: a parent driver probes SM readiness before driving turns. Maps directly
+/// onto [`SessionManagerAgent::health`] (no network call).
+/// What: calls `health` and serializes the [`SmHealth`](crate::core::sm::SmHealth).
+/// Test: `tests.rs::health_round_trips`.
+pub async fn sm_health(d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
+    let health = d.agent.health().await;
+    serde_json::to_value(health).map_err(|e| MethodError::Internal(e.to_string()))
+}
+
+// ── sm.sessions.* (SessionControl: §2.6) ────────────────────────────────────────
+
+/// `sm.sessions.launch { workdir, model?, prompt?, goal_id? }` → `{ session_id }`.
+///
+/// Why: maps onto the managed-session spawn surface (§2.6) via [`SessionControl`].
+/// When a `goal_id` is supplied the launched session is LINKED to that goal (§9.3)
+/// through the goal store — the one place the adapter touches two surfaces, and
+/// only to record the spec-mandated link, not to add logic.
+/// What: builds [`LaunchParams`] from params, calls `sessions.launch`, then (when
+/// `goal_id` is present and the goal store is available) links the new
+/// `session_id` to the goal. Returns `{ session_id }` (link failures are reported
+/// as a `linked: false` note, never failing an otherwise-successful launch).
+/// Test: `tests.rs::launch_round_trips`, `launch_with_goal_links_session`.
+pub async fn sm_sessions_launch(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let workdir = req_str(params, "workdir")?;
+    let goal_id = opt_str(params, "goal_id");
+    let launch = LaunchParams {
+        workdir,
+        model: opt_str(params, "model"),
+        prompt: opt_str(params, "prompt"),
+        goal_id: goal_id.clone(),
+    };
+    let result = d.sessions.launch(launch).await.map_err(map_control_err)?;
+
+    // §9.3: record the goal↔session link when requested. Best-effort: a link
+    // failure must not undo a successful launch.
+    if let Some(goal_id) = goal_id {
+        let session_id = result
+            .get("session_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let linked = link_session_to_goal(d, &goal_id, &session_id).await;
+        let mut out = result;
+        if let Some(obj) = out.as_object_mut() {
+            obj.insert("goal_id".to_string(), json!(goal_id));
+            obj.insert("linked".to_string(), json!(linked));
+        }
+        return Ok(out);
+    }
+    Ok(result)
+}
+
+/// `sm.sessions.list {}` → `{ sessions: [...] }` (§2.6).
+pub async fn sm_sessions_list(d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
+    d.sessions.list().await.map_err(map_control_err)
+}
+
+/// `sm.sessions.get { session_id }` → `{ session, ... }` (§2.6).
+pub async fn sm_sessions_get(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let session_id = req_str(params, "session_id")?;
+    d.sessions.get(&session_id).await.map_err(map_control_err)
+}
+
+/// `sm.sessions.send { session_id, text }` → `{ ok }` (§2.6).
+pub async fn sm_sessions_send(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let session_id = req_str(params, "session_id")?;
+    let text = req_str(params, "text")?;
+    d.sessions
+        .send(&session_id, &text)
+        .await
+        .map_err(map_control_err)
+}
+
+/// `sm.sessions.stop { session_id }` → `{ ok }` (§2.6).
+pub async fn sm_sessions_stop(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let session_id = req_str(params, "session_id")?;
+    d.sessions.stop(&session_id).await.map_err(map_control_err)
+}
+
+/// `sm.sessions.resume { session_id }` → `{ ok }` (§2.6).
+pub async fn sm_sessions_resume(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let session_id = req_str(params, "session_id")?;
+    d.sessions
+        .resume(&session_id)
+        .await
+        .map_err(map_control_err)
+}
+
+/// `sm.sessions.kill { session_id }` → `{ ok }` (§2.6 force-stop/reap).
+pub async fn sm_sessions_kill(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let session_id = req_str(params, "session_id")?;
+    d.sessions.kill(&session_id).await.map_err(map_control_err)
+}
+
+/// Map a [`SessionControlError`] onto the handler error class.
+///
+/// Why: the session control surface distinguishes not-found from backend
+/// failures; preserving that distinction lets the router pick the right JSON-RPC
+/// code.
+/// What: `NotFound` → [`MethodError::NotFound`]; `Backend` → [`MethodError::Internal`].
+/// Test: `tests.rs::get_unknown_session_is_not_found`.
+fn map_control_err(e: SessionControlError) -> MethodError {
+    match e {
+        SessionControlError::NotFound(msg) => MethodError::NotFound(msg),
+        SessionControlError::Backend(msg) => MethodError::Internal(msg),
+    }
+}
+
+// ── sm.context.get (SM-5 context engine — feature-gated) ────────────────────────
+
+/// `sm.context.get { conv_id? }` → context state (§7.1/§7.5).
+///
+/// Why: surfaces the rolling-context engine's state — the compressed block, the
+/// recent verbatim rounds, the total round count, and the token estimate — so a
+/// driver can inspect what context the SM is carrying for a conversation.
+/// What: under `sm-memory`, opens the per-`conv_id` engine under the SM data root
+/// and returns `{ compressed_context, recent_rounds, total_rounds, token_estimate }`.
+/// Without `sm-memory` (or when no `conv_id` is supplied to identify a stored
+/// conversation), returns the appropriate graceful error.
+/// Test: `tests.rs::context_get_round_trips` (feature),
+/// `context_get_unavailable_without_feature` (no feature).
+#[cfg(feature = "sm-memory")]
+pub async fn sm_context_get(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    use crate::core::sm::SmContextEngine;
+
+    let conv_id = req_str(params, "conv_id")?;
+    let engine = SmContextEngine::open(
+        &conv_id,
+        &d.data_root,
+        &d.config.inference,
+        &d.config.rounds,
+    )
+    .map_err(|e| MethodError::Internal(e.to_string()))?;
+    let conv = engine.conversation();
+    let recent: Vec<Value> = conv
+        .recent_rounds
+        .iter()
+        .map(|r| json!({ "user": r.user, "assistant": r.assistant }))
+        .collect();
+    Ok(json!({
+        "compressed_context": conv.compressed_context,
+        "recent_rounds": recent,
+        "total_rounds": conv.total_rounds,
+        "token_estimate": conv.token_estimate,
+    }))
+}
+
+/// `sm.context.get` is unavailable without the `sm-memory` feature.
+///
+/// Why: the context engine state lives alongside the SM palace; the no-memory
+/// build returns a graceful JSON-RPC error rather than failing to compile.
+/// What: always returns [`MethodError::Unavailable`].
+/// Test: `tests.rs::context_get_unavailable_without_feature`.
+#[cfg(not(feature = "sm-memory"))]
+pub async fn sm_context_get(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
+    Err(MethodError::Unavailable(
+        "sm.context.get is not available without the sm-memory feature".to_string(),
+    ))
+}
+
+// ── sm.goals.* (SmGoalStore — feature-gated) ────────────────────────────────────
+
+/// `sm.goals.list { status? }` → `{ goals: [Goal] }` (SM-6).
+///
+/// Why: lists tracked operator goals, optionally filtered by status. Maps onto the
+/// SM-6 goal store.
+/// What: under `sm-memory`, reads `store.all()` and (when `status` is supplied)
+/// filters by it; returns `{ goals }`. Without the feature → unavailable error.
+/// Test: `tests.rs::goals_list_round_trips`, `goals_unavailable_without_feature`.
+#[cfg(feature = "sm-memory")]
+pub async fn sm_goals_list(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let status = opt_str(params, "status");
+    let store = d.goals.lock().await;
+    let goals: Vec<_> = store
+        .all()
+        .into_iter()
+        .filter(|g| match &status {
+            Some(s) => goal_status_str(g) == s.to_ascii_lowercase(),
+            None => true,
+        })
+        .collect();
+    serde_json::to_value(json!({ "goals": goals }))
+        .map_err(|e| MethodError::Internal(e.to_string()))
+}
+
+/// `sm.goals.create { description, acceptance? }` → `{ goal: Goal }` (SM-6).
+#[cfg(feature = "sm-memory")]
+pub async fn sm_goals_create(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let description = req_str(params, "description")?;
+    let acceptance = params
+        .get("acceptance")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mut store = d.goals.lock().await;
+    let goal = store
+        .create(description, acceptance)
+        .await
+        .map_err(|e| MethodError::Internal(e.to_string()))?;
+    serde_json::to_value(json!({ "goal": goal })).map_err(|e| MethodError::Internal(e.to_string()))
+}
+
+/// `sm.goals.update { id, status?, progress?, note? }` → `{ goal: Goal }` (SM-6).
+///
+/// Why: maps onto the SM-6 goal update path. `note` appends a free-form note;
+/// `status` transitions the goal (the verification gate applies to `done`).
+/// What: under `sm-memory`, applies a `note` (if present) then a `status` change
+/// (if present), returning the final goal. A `done` request that fails the
+/// verification gate maps to [`MethodError::Internal`] (the gate message). The
+/// spec's `progress` field is DERIVED by the store from session states (§9.1) and
+/// is not directly settable, so it is accepted-but-ignored with a note.
+/// Test: `tests.rs::goals_update_round_trips`.
+#[cfg(feature = "sm-memory")]
+pub async fn sm_goals_update(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    use crate::core::sm::GoalStatus;
+
+    let id = req_str(params, "id")?;
+    let note = opt_str(params, "note");
+    let status = opt_str(params, "status");
+    let mut store = d.goals.lock().await;
+
+    if let Some(note) = note {
+        store.note(&id, note).await.map_err(map_goal_err)?;
+    }
+    if let Some(status) = status {
+        let parsed = parse_goal_status(&status)?;
+        store.set_status(&id, parsed).await.map_err(map_goal_err)?;
+    }
+    let goal = store
+        .get(&id)
+        .cloned()
+        .ok_or_else(|| MethodError::NotFound(format!("goal not found: {id}")))?;
+    let _ = GoalStatus::default(); // keep the import meaningful across cfgs
+    serde_json::to_value(json!({ "goal": goal })).map_err(|e| MethodError::Internal(e.to_string()))
+}
+
+/// The lowercase wire status string for a goal (matches the camelCase serde).
+#[cfg(feature = "sm-memory")]
+fn goal_status_str(goal: &crate::core::sm::Goal) -> String {
+    use crate::core::sm::GoalStatus;
+    match goal.status {
+        GoalStatus::Pending => "pending",
+        GoalStatus::InProgress => "inprogress",
+        GoalStatus::Blocked => "blocked",
+        GoalStatus::Done => "done",
+        GoalStatus::Abandoned => "abandoned",
+    }
+    .to_string()
+}
+
+/// Parse a wire status string into a [`GoalStatus`].
+///
+/// Why: `sm.goals.update` accepts a status string; an unknown value must be a
+/// clean invalid-params error, not a panic.
+/// What: case-insensitively matches the five statuses (accepting both
+/// `inprogress` and `in_progress`).
+/// Test: `tests.rs::goals_update_round_trips`.
+#[cfg(feature = "sm-memory")]
+fn parse_goal_status(s: &str) -> Result<crate::core::sm::GoalStatus, MethodError> {
+    use crate::core::sm::GoalStatus;
+    match s
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['_', '-'], "")
+        .as_str()
+    {
+        "pending" => Ok(GoalStatus::Pending),
+        "inprogress" => Ok(GoalStatus::InProgress),
+        "blocked" => Ok(GoalStatus::Blocked),
+        "done" => Ok(GoalStatus::Done),
+        "abandoned" => Ok(GoalStatus::Abandoned),
+        other => Err(MethodError::InvalidParams(format!(
+            "unknown goal status {other:?}; expected one of: \
+             pending, inProgress, blocked, done, abandoned"
+        ))),
+    }
+}
+
+/// Map an [`SmGoalError`](crate::core::sm::SmGoalError) onto a handler error.
+///
+/// Why: the goal store distinguishes not-found from other failures; preserving it
+/// lets the router pick the right JSON-RPC code.
+/// What: `NotFound` → [`MethodError::NotFound`]; everything else (palace/cache/
+/// gate) → [`MethodError::Internal`].
+/// Test: `tests.rs::goals_update_unknown_is_not_found`.
+#[cfg(feature = "sm-memory")]
+fn map_goal_err(e: crate::core::sm::SmGoalError) -> MethodError {
+    match e {
+        crate::core::sm::SmGoalError::NotFound(msg) => {
+            MethodError::NotFound(format!("not found: {msg}"))
+        }
+        other => MethodError::Internal(other.to_string()),
+    }
+}
+
+/// Link a launched session to a goal (best-effort, §9.3).
+///
+/// Why: `sm.sessions.launch` with a `goal_id` must record the goal↔session link;
+/// doing it here keeps the launch handler's two-surface touch minimal. A link
+/// failure (unknown goal / persist error) is reported, never fatal to the launch.
+/// What: under `sm-memory`, calls `store.link`; returns whether it succeeded.
+/// Test: `tests.rs::launch_with_goal_links_session`.
+#[cfg(feature = "sm-memory")]
+async fn link_session_to_goal(d: &SmDispatcher, goal_id: &str, session_id: &str) -> bool {
+    use crate::core::sm::SessionLink;
+    let mut store = d.goals.lock().await;
+    store
+        .link(
+            goal_id,
+            SessionLink::launched(session_id, "session-manager launched task"),
+        )
+        .await
+        .is_ok()
+}
+
+/// No-memory build: there is no goal store, so a launch link is a no-op.
+///
+/// Why: keeps `sm.sessions.launch` compiling without `sm-memory`; the goal link
+/// is simply not recorded (goals are unavailable in that build).
+/// What: always returns `false`.
+/// Test: `tests.rs` (no-feature build) covers launch without a goal.
+#[cfg(not(feature = "sm-memory"))]
+async fn link_session_to_goal(_d: &SmDispatcher, _goal_id: &str, _session_id: &str) -> bool {
+    false
+}
+
+/// `sm.goals.*` are unavailable without the `sm-memory` feature.
+///
+/// Why: the goal store is backed by the SM palace (memory-core); the no-memory
+/// build returns a graceful JSON-RPC error rather than failing to compile.
+/// What: always returns [`MethodError::Unavailable`].
+/// Test: `tests.rs::goals_unavailable_without_feature`.
+#[cfg(not(feature = "sm-memory"))]
+pub async fn sm_goals_list(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
+    goals_unavailable()
+}
+
+/// See [`sm_goals_list`] (no-memory build).
+#[cfg(not(feature = "sm-memory"))]
+pub async fn sm_goals_create(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
+    goals_unavailable()
+}
+
+/// See [`sm_goals_list`] (no-memory build).
+#[cfg(not(feature = "sm-memory"))]
+pub async fn sm_goals_update(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
+    goals_unavailable()
+}
+
+/// The graceful "goals unavailable" error for the no-memory build.
+#[cfg(not(feature = "sm-memory"))]
+fn goals_unavailable() -> Result<Value, MethodError> {
+    Err(MethodError::Unavailable(
+        "sm.goals.* are not available without the sm-memory feature".to_string(),
+    ))
+}

--- a/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
@@ -1,0 +1,267 @@
+//! `tm sm serve --stdio` — the SM JSON-RPC 2.0 over STDIO adapter (DOC-14 §1A.1).
+//!
+//! Why: the SM's PRIMARY, API-first interface (epic #1283, SM-STDIO #1291). A
+//! parent `claude-mpm`/PM drives the SM headlessly over newline-delimited JSON-RPC
+//! to exercise EVERY capability — chat, goals, session launch/observe/verify,
+//! context, health — with no UI (the §1A.2 test topology
+//! `claude-mpm ⟷ SM ⟷ t-mpm`). The adapter is a THIN mapping: each method maps
+//! onto an existing surface — `SessionManagerAgent::chat` (SM-7), the goal store
+//! (SM-6), the rolling-context engine (SM-5), the provider/health surface
+//! (SM-2/§5.3), and the managed-session control surface (§2.6). No business logic
+//! lives in the transport.
+//!
+//! STDOUT DISCIPLINE (CRITICAL): stdout is reserved EXCLUSIVELY for JSON-RPC
+//! framing (one response object per line). EVERY diagnostic goes to stderr via
+//! `tracing`. There is ZERO `println!`/`print!` in this module tree or the SM
+//! code path it touches — `tests::no_stdout_writes_in_sm_paths` greps the source
+//! and asserts that mechanically.
+//!
+//! What: [`SmDispatcher`] owns the SM surfaces and exposes the transport-neutral
+//! [`SmDispatcher::dispatch`] (request → response). [`run_sm_stdio`] builds the
+//! dispatcher from the daemon state and drives the shared
+//! [`trusty_common::mcp::run_stdio_loop`] (line framing + stderr-only logging),
+//! so the wire framing is the SAME proven loop trusty-memory/trusty-search use.
+//! Test: `tests.rs` — each of the 13 methods round-trips with correct JSON-RPC
+//! framing, plus parse-error / method-not-found / stdout-cleanliness / scripted
+//! sequence coverage.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use trusty_common::mcp::{Request, Response, run_stdio_loop};
+
+use crate::core::sm::{SessionManagerAgent, SessionManagerConfig};
+
+mod control;
+mod dispatch;
+mod methods;
+
+pub use control::{DaemonSessionControl, LaunchParams, SessionControl, SessionControlError};
+
+#[cfg(feature = "sm-memory")]
+use std::sync::Arc as StdArc;
+#[cfg(feature = "sm-memory")]
+use tokio::sync::Mutex;
+
+#[cfg(feature = "sm-memory")]
+use crate::core::sm::SmGoalStore;
+
+/// The transport-neutral SM dispatcher the stdio adapter drives (§1A.1).
+///
+/// Why: separating the dispatcher from the stdio loop is what makes the 13
+/// methods HERMETICALLY testable — the round-trip tests construct an
+/// `SmDispatcher` over mocks and call [`SmDispatcher::dispatch`] with constructed
+/// JSON requests, with no real stdin/stdout, no network, and no tmux. The
+/// dispatcher owns one handle per SM surface and does pure translation.
+/// What: the SM [`SessionManagerAgent`] (chat + health), a config snapshot + the
+/// `data_root` for opening the per-`conv_id` context engine (`sm.context.get`),
+/// the [`SessionControl`] seam for `sm.sessions.*`, and — under `sm-memory` — the
+/// shared [`SmGoalStore`] for `sm.goals.*`. Without the feature the goal store is
+/// absent and `sm.goals.*`/`sm.context.get` return a graceful JSON-RPC error.
+/// Test: `tests.rs` builds this over the mock resolver + mock session control.
+pub struct SmDispatcher {
+    /// The SM agent (SM-7 chat + SM-2/§5.3 health). Shared, cheap to clone.
+    agent: Arc<SessionManagerAgent>,
+    /// Config snapshot used to open the context engine for `sm.context.get`
+    /// (inference + rounds) — read-only, never mutated here. Only consulted under
+    /// `sm-memory` (the no-memory build returns the unavailable error before
+    /// touching it).
+    #[cfg_attr(not(feature = "sm-memory"), allow(dead_code))]
+    config: SessionManagerConfig,
+    /// Storage root under which per-`conv_id` context-engine state lives (SM-5).
+    /// Only consulted under `sm-memory` (see `config`).
+    #[cfg_attr(not(feature = "sm-memory"), allow(dead_code))]
+    data_root: PathBuf,
+    /// The managed-session control surface for `sm.sessions.*` (§2.6).
+    sessions: Arc<dyn SessionControl>,
+    /// The SM goal store for `sm.goals.*` (SM-6), behind a mutex for the
+    /// `&mut self` mutators. Only present under `sm-memory`.
+    #[cfg(feature = "sm-memory")]
+    goals: StdArc<Mutex<SmGoalStore>>,
+}
+
+impl SmDispatcher {
+    /// Build a dispatcher over the SM surfaces (production: `sm-memory`).
+    ///
+    /// Why: the stdio entry point wires the real agent, control, and goal store
+    /// once; tests wire mocks through this same constructor.
+    /// What: stores the four/five handles. No I/O.
+    /// Test: `tests.rs` uses the no-memory constructor; the daemon entry point
+    /// uses this one.
+    #[cfg(feature = "sm-memory")]
+    pub fn new(
+        agent: Arc<SessionManagerAgent>,
+        config: SessionManagerConfig,
+        data_root: impl Into<PathBuf>,
+        sessions: Arc<dyn SessionControl>,
+        goals: StdArc<Mutex<SmGoalStore>>,
+    ) -> Self {
+        Self {
+            agent,
+            config,
+            data_root: data_root.into(),
+            sessions,
+            goals,
+        }
+    }
+
+    /// Build a dispatcher over the SM surfaces (no-memory build).
+    ///
+    /// Why: builds without the heavy memory-core feature; `sm.goals.*` and
+    /// `sm.context.get` then return a graceful "not available without sm-memory"
+    /// JSON-RPC error instead of failing to compile.
+    /// What: stores agent/config/data_root/sessions (no goal store).
+    /// Test: `tests.rs` builds this over the mock resolver + mock control.
+    #[cfg(not(feature = "sm-memory"))]
+    pub fn new(
+        agent: Arc<SessionManagerAgent>,
+        config: SessionManagerConfig,
+        data_root: impl Into<PathBuf>,
+        sessions: Arc<dyn SessionControl>,
+    ) -> Self {
+        Self {
+            agent,
+            config,
+            data_root: data_root.into(),
+            sessions,
+        }
+    }
+
+    /// Dispatch one JSON-RPC request to its mapped SM surface (transport-neutral).
+    ///
+    /// Why: the single seam the stdio loop and every round-trip test drive. It
+    /// routes the method name, parses params, calls the mapped surface, and shapes
+    /// the result/error into a JSON-RPC 2.0 [`Response`] (id echoed). Unknown
+    /// methods → method-not-found; bad params → invalid-params; surface failures →
+    /// a structured error — never a panic.
+    /// What: delegates to [`dispatch::dispatch`].
+    /// Test: `tests.rs` — all 13 methods + error paths.
+    pub async fn dispatch(&self, req: Request) -> Response {
+        dispatch::dispatch(self, req).await
+    }
+}
+
+/// Run the SM JSON-RPC stdio adapter to EOF (the `tm sm serve --stdio` entry).
+///
+/// Why: the process entry point. It builds the [`SmDispatcher`] from the daemon
+/// state (reusing the SM-7 agent construction and the managed-session surface),
+/// then drives the shared newline-delimited JSON-RPC loop on stdin/stdout. Logs
+/// go to stderr only (the loop never writes anything but framed responses to
+/// stdout), so a parent driver gets a clean channel.
+/// What: constructs the agent + control + (feature-gated) goal store rooted under
+/// the daemon's SM data root, then runs [`run_stdio_loop`] forwarding each request
+/// to [`SmDispatcher::dispatch`]. Returns `Ok(())` on stdin EOF.
+/// Test: the dispatch logic is covered by `tests.rs`; this thin wiring is
+/// exercised at runtime via `tm sm serve --stdio`.
+pub async fn run_sm_stdio(state: Arc<crate::daemon::state::DaemonState>) -> anyhow::Result<()> {
+    let dispatcher = Arc::new(build_dispatcher(state).await?);
+    run_stdio_loop(move |req| {
+        let dispatcher = dispatcher.clone();
+        async move { dispatcher.dispatch(req).await }
+    })
+    .await
+}
+
+/// Build the production [`SmDispatcher`] from the daemon state.
+///
+/// Why: isolates the wiring (which differs by the `sm-memory` feature) from the
+/// loop so [`run_sm_stdio`] stays readable. The agent and control reuse the
+/// daemon's already-constructed handles so the stdio surface and the HTTP/chat
+/// surfaces share one core.
+/// What: clones the daemon's SM agent, reads the SM config + data root, builds a
+/// [`DaemonSessionControl`], and — under `sm-memory` — loads the goal store from
+/// the dedicated SM palace (falling back gracefully on a palace-open failure).
+/// Test: covered indirectly; the dispatch behaviour is unit-tested in `tests.rs`.
+async fn build_dispatcher(
+    state: Arc<crate::daemon::state::DaemonState>,
+) -> anyhow::Result<SmDispatcher> {
+    let agent = state.session_manager_agent();
+    let config = agent.config().clone();
+    let data_root = state.sm_data_root();
+    let sessions: Arc<dyn SessionControl> = Arc::new(DaemonSessionControl::new(state.clone()));
+
+    #[cfg(feature = "sm-memory")]
+    {
+        let goals = build_goal_store(&data_root, &config).await;
+        Ok(SmDispatcher::new(agent, config, data_root, sessions, goals))
+    }
+    #[cfg(not(feature = "sm-memory"))]
+    {
+        Ok(SmDispatcher::new(agent, config, data_root, sessions))
+    }
+}
+
+/// Load the SM goal store from the dedicated SM palace (`sm-memory` build).
+///
+/// Why: `sm.goals.*` are backed by the SM-6 dual-persistence store over the SM
+/// palace. Loading rebuilds the goal map from the palace (truth) with a cache
+/// fallback, so the stdio surface sees the same goals the chat surface does.
+/// What: opens the SM palace under `<data_root>/palace`, wraps it as the goal
+/// store's [`GoalMemory`], and `SmGoalStore::load`s it. A palace-open or load
+/// failure degrades to an empty in-memory store (logged to stderr) rather than
+/// failing the whole stdio surface.
+/// Test: covered by the SM-6 store tests; this wiring is runtime-only.
+#[cfg(feature = "sm-memory")]
+async fn build_goal_store(
+    data_root: &std::path::Path,
+    config: &SessionManagerConfig,
+) -> StdArc<Mutex<SmGoalStore>> {
+    use crate::core::sm::memory::SmMemory;
+
+    let store = match SmMemory::open(data_root.join("palace"), &config.memory) {
+        Ok(mem) => {
+            let mem: StdArc<dyn crate::core::sm::GoalMemory> = StdArc::new(mem);
+            match SmGoalStore::load(mem, data_root.to_path_buf()).await {
+                Ok(store) => store,
+                Err(e) => {
+                    tracing::warn!(
+                        "sm stdio: goal store load failed ({e}); starting empty in-memory store"
+                    );
+                    empty_goal_store(data_root)
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("sm stdio: SM palace unavailable ({e}); goals start empty in-memory");
+            empty_goal_store(data_root)
+        }
+    };
+    StdArc::new(Mutex::new(store))
+}
+
+/// Build an empty goal store over a no-op palace seam (degraded fallback).
+///
+/// Why: when the real palace is unavailable, `sm.goals.*` must still answer
+/// (returning an empty list / accepting creates that simply do not durably
+/// persist) rather than the whole stdio surface failing. A no-op [`GoalMemory`]
+/// gives the store a seam that always succeeds with no entries.
+/// What: constructs an [`SmGoalStore::new`] over a [`NoopGoalMemory`].
+/// Test: runtime fallback; the store behaviour is covered by SM-6 tests.
+#[cfg(feature = "sm-memory")]
+fn empty_goal_store(data_root: &std::path::Path) -> SmGoalStore {
+    SmGoalStore::new(StdArc::new(NoopGoalMemory), data_root.to_path_buf())
+}
+
+/// A [`GoalMemory`] that persists nothing and lists nothing (degraded seam).
+///
+/// Why: lets the goal store operate (in-memory only) when the real SM palace is
+/// unavailable, so `sm.goals.*` degrade gracefully instead of erroring out.
+/// What: `remember_goal` is a no-op success; `list_goals` returns an empty vec.
+/// Test: runtime fallback only.
+#[cfg(feature = "sm-memory")]
+struct NoopGoalMemory;
+
+#[cfg(feature = "sm-memory")]
+#[async_trait::async_trait]
+impl crate::core::sm::GoalMemory for NoopGoalMemory {
+    async fn remember_goal(&self, _json: String, _tag: &str) -> Result<(), String> {
+        Ok(())
+    }
+    async fn list_goals(&self, _tag: &str) -> Result<Vec<String>, String> {
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
@@ -46,6 +46,31 @@ use tokio::sync::Mutex;
 #[cfg(feature = "sm-memory")]
 use crate::core::sm::SmGoalStore;
 
+/// The shared goal-store handle `sm.goals.*` operate over (feature-gated type).
+///
+/// Why: [`SmDispatcher::new`] takes ONE signature across both `sm-memory` and
+/// the default build (a fragile dual-arity API was the prior shape). The goal
+/// store only exists under `sm-memory`, so the constructor accepts this handle
+/// as an `Option` that is simply always `None` in the no-memory build — gating
+/// the TYPE, never the arity. Under `sm-memory` it is the live store behind a
+/// mutex (the `&mut self` goal mutators serialise through it).
+/// What: an `Arc<Mutex<SmGoalStore>>` under the feature; an uninhabited
+/// `std::convert::Infallible` placeholder without it (never constructed —
+/// callers pass `None`).
+/// Test: `tests.rs::dispatcher_with` constructs `Some(..)`/`None` via this alias.
+#[cfg(feature = "sm-memory")]
+pub type SmGoalHandle = StdArc<Mutex<SmGoalStore>>;
+
+/// Placeholder goal-store handle for the no-memory build (never constructed).
+///
+/// Why: lets [`SmDispatcher::new`] keep ONE signature without referencing the
+/// `sm-memory`-only [`SmGoalStore`]. Callers in the default build always pass
+/// `None`, so no value of this type is ever created.
+/// What: a zero-sized uninhabitable-by-convention marker.
+/// Test: compile-only; the no-memory `new` ignores its `Option<SmGoalHandle>`.
+#[cfg(not(feature = "sm-memory"))]
+pub type SmGoalHandle = std::convert::Infallible;
+
 /// The transport-neutral SM dispatcher the stdio adapter drives (§1A.1).
 ///
 /// Why: separating the dispatcher from the stdio loop is what makes the 13
@@ -81,49 +106,50 @@ pub struct SmDispatcher {
 }
 
 impl SmDispatcher {
-    /// Build a dispatcher over the SM surfaces (production: `sm-memory`).
+    /// Build a dispatcher over the SM surfaces (ONE signature, both builds).
     ///
-    /// Why: the stdio entry point wires the real agent, control, and goal store
-    /// once; tests wire mocks through this same constructor.
-    /// What: stores the four/five handles. No I/O.
-    /// Test: `tests.rs` uses the no-memory constructor; the daemon entry point
-    /// uses this one.
-    #[cfg(feature = "sm-memory")]
+    /// Why: a single constructor across `sm-memory` and the default build keeps
+    /// the public API stable for callers and tests — they wire the SAME five
+    /// arguments regardless of feature. The goal store is an [`Option`]: `Some`
+    /// under `sm-memory` (the live store), always `None` in the no-memory build
+    /// (where `sm.goals.*`/`sm.context.get` return the graceful unavailable
+    /// error). Only the goal-handle TYPE is feature-gated (via [`SmGoalHandle`]),
+    /// never the arity.
+    /// What: stores agent/config/data_root/sessions; under `sm-memory` also stores
+    /// the unwrapped goal store (defaulting to an empty no-op store if `None`).
+    /// No I/O.
+    /// Test: `tests.rs::dispatcher_with` builds this with `Some`/`None` per build.
     pub fn new(
         agent: Arc<SessionManagerAgent>,
         config: SessionManagerConfig,
         data_root: impl Into<PathBuf>,
         sessions: Arc<dyn SessionControl>,
-        goals: StdArc<Mutex<SmGoalStore>>,
+        goals: Option<SmGoalHandle>,
     ) -> Self {
-        Self {
-            agent,
-            config,
-            data_root: data_root.into(),
-            sessions,
-            goals,
+        let data_root = data_root.into();
+        #[cfg(feature = "sm-memory")]
+        {
+            let goals =
+                goals.unwrap_or_else(|| StdArc::new(Mutex::new(empty_goal_store(&data_root))));
+            Self {
+                agent,
+                config,
+                data_root,
+                sessions,
+                goals,
+            }
         }
-    }
-
-    /// Build a dispatcher over the SM surfaces (no-memory build).
-    ///
-    /// Why: builds without the heavy memory-core feature; `sm.goals.*` and
-    /// `sm.context.get` then return a graceful "not available without sm-memory"
-    /// JSON-RPC error instead of failing to compile.
-    /// What: stores agent/config/data_root/sessions (no goal store).
-    /// Test: `tests.rs` builds this over the mock resolver + mock control.
-    #[cfg(not(feature = "sm-memory"))]
-    pub fn new(
-        agent: Arc<SessionManagerAgent>,
-        config: SessionManagerConfig,
-        data_root: impl Into<PathBuf>,
-        sessions: Arc<dyn SessionControl>,
-    ) -> Self {
-        Self {
-            agent,
-            config,
-            data_root: data_root.into(),
-            sessions,
+        #[cfg(not(feature = "sm-memory"))]
+        {
+            // No-memory build: there is no goal store; the handle is never
+            // constructed (callers always pass `None`).
+            let _ = goals;
+            Self {
+                agent,
+                config,
+                data_root,
+                sessions,
+            }
         }
     }
 
@@ -183,11 +209,17 @@ async fn build_dispatcher(
     #[cfg(feature = "sm-memory")]
     {
         let goals = build_goal_store(&data_root, &config).await;
-        Ok(SmDispatcher::new(agent, config, data_root, sessions, goals))
+        Ok(SmDispatcher::new(
+            agent,
+            config,
+            data_root,
+            sessions,
+            Some(goals),
+        ))
     }
     #[cfg(not(feature = "sm-memory"))]
     {
-        Ok(SmDispatcher::new(agent, config, data_root, sessions))
+        Ok(SmDispatcher::new(agent, config, data_root, sessions, None))
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
@@ -1,0 +1,887 @@
+//! Round-trip + framing tests for the SM stdio adapter (SM-STDIO #1291).
+//!
+//! Why: the acceptance bar is that EVERY one of the 13 `sm.*` methods round-trips
+//! over the dispatcher with correct JSON-RPC 2.0 framing (id echoed, result shape
+//! correct), that malformed/unknown requests produce proper JSON-RPC errors (no
+//! panic), that `sm.chat` drives a full SM turn and `sm.health` reports provider
+//! status, and that stdout stays clean (no `println!` in the SM paths). These
+//! tests pin all of that deterministically with a mock resolver + mock session
+//! control + a tempdir — NO network, NO tmux, NO real LLM.
+//! What: builds an [`SmDispatcher`] over mocks, drives [`SmDispatcher::dispatch`]
+//! with constructed [`Request`]s, and asserts the [`Response`] envelope. Also
+//! exercises the shared line-framing loop and greps the source for stdout writes.
+//! Test: this is the test module.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use trusty_common::mcp::{Request, Response, error_codes};
+
+use super::SmDispatcher;
+use super::control::{LaunchParams, SessionControl, SessionControlError};
+use super::methods::{CODE_NOT_FOUND, CODE_UNAVAILABLE};
+use crate::core::sm::SessionManagerConfig;
+use crate::core::sm::agent::SessionManagerAgent;
+use crate::core::sm::agent::mock::{MockChatProvider, MockResolver};
+
+// ── Mock session control ────────────────────────────────────────────────────────
+
+/// A deterministic [`SessionControl`] mock for the `sm.sessions.*` round-trips.
+///
+/// Why: the dispatcher's session methods must be testable with NO tmux/workspace.
+/// This mock records the last call and returns canned, well-formed JSON so the
+/// tests assert the dispatcher's mapping (id echo, result shape) in isolation.
+/// What: `launch` returns a fixed `session_id`; `list`/`get`/`send`/`stop`/
+/// `resume`/`kill` return canned bodies. A `fail_get_not_found` flag makes `get`
+/// return [`SessionControlError::NotFound`] so the not-found mapping is covered.
+/// Test: drives `sm.sessions.*` tests below.
+#[derive(Default)]
+struct MockSessionControl {
+    /// When true, `get` returns NotFound (to cover the not-found JSON-RPC mapping).
+    fail_get_not_found: bool,
+    /// The last launch params seen (so a test can assert the mapping).
+    last_launch: std::sync::Mutex<Option<LaunchParams>>,
+}
+
+#[async_trait]
+impl SessionControl for MockSessionControl {
+    async fn launch(&self, params: LaunchParams) -> Result<Value, SessionControlError> {
+        *self.last_launch.lock().expect("lock") = Some(params);
+        Ok(json!({ "session_id": "11111111-1111-1111-1111-111111111111" }))
+    }
+    async fn list(&self) -> Result<Value, SessionControlError> {
+        Ok(json!({ "sessions": [] }))
+    }
+    async fn get(&self, session_id: &str) -> Result<Value, SessionControlError> {
+        if self.fail_get_not_found {
+            return Err(SessionControlError::NotFound(session_id.to_string()));
+        }
+        Ok(json!({ "session": { "id": session_id, "state": "active" } }))
+    }
+    async fn send(&self, _id: &str, _text: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn stop(&self, _id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn resume(&self, _id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn kill(&self, _id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+}
+
+// ── Dispatcher builders (feature-aware) ─────────────────────────────────────────
+
+/// An enabled SM config (default tiers) for the dispatcher tests.
+fn enabled_config() -> SessionManagerConfig {
+    SessionManagerConfig {
+        enabled: true,
+        ..SessionManagerConfig::default()
+    }
+}
+
+/// Build an SM agent over a (mock) provider resolver, feature-aware.
+fn agent_with_provider(
+    cfg: SessionManagerConfig,
+    data_root: &std::path::Path,
+) -> Arc<SessionManagerAgent> {
+    let provider = MockChatProvider::new("SM plan: delegate to a session", 0.0021);
+    let resolver = Arc::new(MockResolver::with_provider(provider));
+    Arc::new(SessionManagerAgent::for_test(
+        cfg,
+        resolver,
+        data_root.to_path_buf(),
+    ))
+}
+
+/// Build a degraded SM agent (no provider), feature-aware.
+fn agent_degraded(
+    cfg: SessionManagerConfig,
+    data_root: &std::path::Path,
+) -> Arc<SessionManagerAgent> {
+    let resolver = Arc::new(MockResolver::degraded());
+    Arc::new(SessionManagerAgent::for_test(
+        cfg,
+        resolver,
+        data_root.to_path_buf(),
+    ))
+}
+
+/// Build a dispatcher over the given agent + a fresh mock session control.
+///
+/// Why: the feature-gated goal-store field makes construction differ by build;
+/// this helper hides that so the tests read identically. Under `sm-memory` it
+/// loads an empty goal store over a no-op palace + the tempdir.
+fn dispatcher_with(
+    agent: Arc<SessionManagerAgent>,
+    cfg: SessionManagerConfig,
+    data_root: &std::path::Path,
+    control: Arc<MockSessionControl>,
+) -> SmDispatcher {
+    let sessions: Arc<dyn SessionControl> = control;
+    #[cfg(feature = "sm-memory")]
+    {
+        let goals = test_goal_store(data_root);
+        SmDispatcher::new(agent, cfg, data_root.to_path_buf(), sessions, goals)
+    }
+    #[cfg(not(feature = "sm-memory"))]
+    {
+        SmDispatcher::new(agent, cfg, data_root.to_path_buf(), sessions)
+    }
+}
+
+/// Build an in-memory goal store over a no-op palace for `sm.goals.*` tests.
+///
+/// Why: the goal-store methods must round-trip without a real palace (no ONNX);
+/// a no-op [`GoalMemory`] gives the SM-6 store a seam that always succeeds with no
+/// durable entries, so creates/updates are visible in-memory within one test.
+#[cfg(feature = "sm-memory")]
+fn test_goal_store(
+    data_root: &std::path::Path,
+) -> std::sync::Arc<tokio::sync::Mutex<crate::core::sm::SmGoalStore>> {
+    use crate::core::sm::{GoalMemory, SmGoalStore};
+
+    struct NoopMem;
+    #[async_trait]
+    impl GoalMemory for NoopMem {
+        async fn remember_goal(&self, _json: String, _tag: &str) -> Result<(), String> {
+            Ok(())
+        }
+        async fn list_goals(&self, _tag: &str) -> Result<Vec<String>, String> {
+            Ok(Vec::new())
+        }
+    }
+    let store = SmGoalStore::new(Arc::new(NoopMem), data_root.to_path_buf());
+    std::sync::Arc::new(tokio::sync::Mutex::new(store))
+}
+
+/// Build a request envelope with an integer id.
+fn req(id: i64, method: &str, params: Value) -> Request {
+    Request {
+        jsonrpc: Some("2.0".into()),
+        id: Some(json!(id)),
+        method: method.into(),
+        params: Some(params),
+    }
+}
+
+/// Assert the response echoed `id` and carries a `result` (not an error); return it.
+fn ok_result(resp: &Response, id: i64) -> Value {
+    assert_eq!(resp.jsonrpc, "2.0", "framing: jsonrpc 2.0");
+    assert_eq!(resp.id, Some(json!(id)), "framing: id echoed");
+    assert!(
+        resp.error.is_none(),
+        "expected result, got error: {:?}",
+        resp.error
+    );
+    resp.result.clone().expect("result present")
+}
+
+/// Assert the response is an error with the given code; return the message.
+fn err_code(resp: &Response, id: i64, code: i32) -> String {
+    assert_eq!(resp.id, Some(json!(id)), "framing: id echoed on error");
+    let e = resp.error.as_ref().expect("error present");
+    assert_eq!(e.code, code, "error code");
+    e.message.clone()
+}
+
+// ── sm.chat / sm.health ─────────────────────────────────────────────────────────
+
+/// Why: the headline acceptance — `sm.chat` drives a full SM turn through the
+/// mock provider and returns `{ reply, conv_id, cost }` with correct framing.
+/// What: dispatches `sm.chat` and asserts the reply, an echoed conv_id, and the
+/// per-call cost (epsilon compare).
+/// Test: this is the test.
+#[tokio::test]
+async fn chat_round_trips() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d
+        .dispatch(req(
+            1,
+            "sm.chat",
+            json!({ "message": "decompose login", "conv_id": "c-1" }),
+        ))
+        .await;
+    let result = ok_result(&resp, 1);
+    assert_eq!(result["reply"], "SM plan: delegate to a session");
+    assert_eq!(result["conv_id"], "c-1");
+    let cost = result["cost"].as_f64().expect("cost is a number");
+    assert!((cost - 0.0021).abs() < 1e-9, "per-call cost returned");
+}
+
+/// Why: a degraded SM (no provider) must map to a graceful JSON-RPC error
+/// (CODE_UNAVAILABLE), NOT a panic and NOT a success.
+/// What: dispatches `sm.chat` against a degraded agent; asserts the unavailable code.
+/// Test: this is the test.
+#[tokio::test]
+async fn chat_degraded_is_unavailable() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_degraded(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d
+        .dispatch(req(2, "sm.chat", json!({ "message": "hi" })))
+        .await;
+    err_code(&resp, 2, CODE_UNAVAILABLE);
+}
+
+/// Why: `sm.chat` with no `message` is malformed and must be an invalid-params
+/// error, not a panic.
+/// What: dispatches `sm.chat` with empty params; asserts INVALID_PARAMS.
+/// Test: this is the test.
+#[tokio::test]
+async fn chat_missing_message_is_invalid_params() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d.dispatch(req(3, "sm.chat", json!({}))).await;
+    err_code(&resp, 3, error_codes::INVALID_PARAMS);
+}
+
+/// Why: `sm.health` must report provider status + degraded + model tiers with
+/// correct framing.
+/// What: dispatches `sm.health` against a provider-backed agent; asserts ok +
+/// provider + the model-tier fields.
+/// Test: this is the test.
+#[tokio::test]
+async fn health_round_trips() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d.dispatch(req(4, "sm.health", json!({}))).await;
+    let result = ok_result(&resp, 4);
+    assert_eq!(result["ok"], true);
+    assert_eq!(result["degraded"], false);
+    assert_eq!(result["provider"], "anthropic");
+    assert_eq!(
+        result["model_tiers"]["orchestration"],
+        "anthropic/claude-sonnet-4-6"
+    );
+}
+
+/// Why: a degraded SM's health must report degraded + provider "none".
+/// What: dispatches `sm.health` against a degraded agent.
+/// Test: this is the test.
+#[tokio::test]
+async fn health_degraded_reports_degraded() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_degraded(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d.dispatch(req(5, "sm.health", json!({}))).await;
+    let result = ok_result(&resp, 5);
+    assert_eq!(result["ok"], false);
+    assert_eq!(result["degraded"], true);
+    assert_eq!(result["provider"], "none");
+}
+
+// ── sm.sessions.* ───────────────────────────────────────────────────────────────
+
+/// Why: `sm.sessions.launch` maps onto the control surface and returns
+/// `{ session_id }` with the launch params forwarded.
+/// What: dispatches launch; asserts the session_id result and that the mock saw
+/// the workdir/prompt mapping.
+/// Test: this is the test.
+#[tokio::test]
+async fn launch_round_trips() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let control = Arc::new(MockSessionControl::default());
+    let d = dispatcher_with(agent, cfg, tmp.path(), control.clone());
+
+    let resp = d
+        .dispatch(req(
+            6,
+            "sm.sessions.launch",
+            json!({ "workdir": "/repo", "prompt": "fix bug", "model": "tcode" }),
+        ))
+        .await;
+    let result = ok_result(&resp, 6);
+    assert_eq!(result["session_id"], "11111111-1111-1111-1111-111111111111");
+
+    let seen = control
+        .last_launch
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("launch seen");
+    assert_eq!(seen.workdir, "/repo");
+    assert_eq!(seen.prompt.as_deref(), Some("fix bug"));
+    assert_eq!(seen.model.as_deref(), Some("tcode"));
+}
+
+/// Why: each remaining session verb (list/get/send/stop/resume/kill) must
+/// round-trip with correct framing through its control mapping.
+/// What: dispatches each and asserts an ok result.
+/// Test: this is the test.
+#[tokio::test]
+async fn session_verbs_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+    let sid = "22222222-2222-2222-2222-222222222222";
+
+    let list = d.dispatch(req(10, "sm.sessions.list", json!({}))).await;
+    assert!(ok_result(&list, 10)["sessions"].is_array());
+
+    let get = d
+        .dispatch(req(11, "sm.sessions.get", json!({ "session_id": sid })))
+        .await;
+    assert!(ok_result(&get, 11)["session"].is_object());
+
+    let send = d
+        .dispatch(req(
+            12,
+            "sm.sessions.send",
+            json!({ "session_id": sid, "text": "y" }),
+        ))
+        .await;
+    assert_eq!(ok_result(&send, 12)["ok"], true);
+
+    let stop = d
+        .dispatch(req(13, "sm.sessions.stop", json!({ "session_id": sid })))
+        .await;
+    assert_eq!(ok_result(&stop, 13)["ok"], true);
+
+    let resume = d
+        .dispatch(req(14, "sm.sessions.resume", json!({ "session_id": sid })))
+        .await;
+    assert_eq!(ok_result(&resume, 14)["ok"], true);
+
+    let kill = d
+        .dispatch(req(15, "sm.sessions.kill", json!({ "session_id": sid })))
+        .await;
+    assert_eq!(ok_result(&kill, 15)["ok"], true);
+}
+
+/// Why: a not-found session must map to the server-defined NOT_FOUND code (not a
+/// success, not a panic).
+/// What: dispatches `sm.sessions.get` against a control that returns NotFound.
+/// Test: this is the test.
+#[tokio::test]
+async fn get_unknown_session_is_not_found() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let control = Arc::new(MockSessionControl {
+        fail_get_not_found: true,
+        ..MockSessionControl::default()
+    });
+    let d = dispatcher_with(agent, cfg, tmp.path(), control);
+
+    let resp = d
+        .dispatch(req(
+            16,
+            "sm.sessions.get",
+            json!({ "session_id": "33333333-3333-3333-3333-333333333333" }),
+        ))
+        .await;
+    err_code(&resp, 16, CODE_NOT_FOUND);
+}
+
+// ── Framing: parse error / unknown method / notification ────────────────────────
+
+/// Why: a malformed JSON request line must produce a JSON-RPC parse-error
+/// response, not a panic. The shared line loop builds the parse error; this test
+/// asserts that contract directly via the same path.
+/// What: parses an invalid JSON line the way the loop does and asserts the
+/// PARSE_ERROR response with a null id.
+/// Test: this is the test.
+#[test]
+fn malformed_json_is_parse_error() {
+    let line = "{ this is not json ";
+    let resp = match serde_json::from_str::<Request>(line) {
+        Ok(_) => panic!("should not parse"),
+        Err(e) => Response::err(
+            None,
+            error_codes::PARSE_ERROR,
+            format!("invalid JSON-RPC: {e}"),
+        ),
+    };
+    assert_eq!(resp.error.as_ref().unwrap().code, error_codes::PARSE_ERROR);
+    assert!(resp.id.is_none(), "parse error has null id");
+}
+
+/// Why: an unknown method must map to METHOD_NOT_FOUND with the id echoed.
+/// What: dispatches a bogus method; asserts the code.
+/// Test: this is the test.
+#[tokio::test]
+async fn unknown_method_is_method_not_found() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d.dispatch(req(20, "sm.bogus", json!({}))).await;
+    err_code(&resp, 20, error_codes::METHOD_NOT_FOUND);
+}
+
+/// Why: a JSON-RPC notification (no id) must be SUPPRESSED — the adapter must not
+/// emit a reply for it (the line loop drops suppressed responses).
+/// What: dispatches an id-less request and asserts the suppress flag.
+/// Test: this is the test.
+#[tokio::test]
+async fn notification_is_suppressed() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let notif = Request {
+        jsonrpc: Some("2.0".into()),
+        id: None,
+        method: "sm.health".into(),
+        params: None,
+    };
+    let resp = d.dispatch(notif).await;
+    assert!(resp.suppress, "notification must be suppressed");
+}
+
+// ── Line framing read/write helper ──────────────────────────────────────────────
+
+/// Why: the adapter relies on `run_stdio_loop`'s newline-delimited read/write
+/// framing; this test drives that helper through an in-memory pipe with the SM
+/// dispatch as the handler, asserting a request produces exactly one JSON line
+/// on stdout (clean framing, id echoed).
+/// What: pipes one `sm.health` request line into `run_stdio_loop` (over injected
+/// I/O) and parses the single response line back.
+/// Test: this is the test.
+#[tokio::test]
+async fn line_framing_round_trips_one_response() {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = Arc::new(dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    ));
+
+    // Build one request line, run it through the dispatcher, and serialize the
+    // response the way the loop does — asserting exactly one clean JSON line.
+    let request_line = serde_json::to_string(&req(99, "sm.health", json!({}))).unwrap();
+    let (mut client_tx, server_rx) = tokio::io::duplex(8192);
+    let (server_tx, client_rx) = tokio::io::duplex(8192);
+
+    let dispatcher = d.clone();
+    let loop_fut = run_stdio_loop_over(
+        move |r| {
+            let dispatcher = dispatcher.clone();
+            async move { dispatcher.dispatch(r).await }
+        },
+        server_rx,
+        server_tx,
+    );
+
+    client_tx
+        .write_all(format!("{request_line}\n").as_bytes())
+        .await
+        .unwrap();
+    drop(client_tx); // EOF so the loop returns
+
+    loop_fut.await.expect("loop returns Ok on EOF");
+
+    let mut lines = BufReader::new(client_rx).lines();
+    let first = lines.next_line().await.unwrap().expect("one response line");
+    let parsed: Value = serde_json::from_str(&first).expect("response is valid JSON");
+    assert_eq!(parsed["jsonrpc"], "2.0");
+    assert_eq!(parsed["id"], 99);
+    assert_eq!(parsed["result"]["ok"], true);
+    // Exactly one line — no stray output.
+    assert!(
+        lines.next_line().await.unwrap().is_none(),
+        "exactly one response line"
+    );
+}
+
+/// Minimal copy of the shared stdio loop parameterised over injected I/O.
+///
+/// Why: `trusty_common::mcp::run_stdio_loop` only accepts the real stdin/stdout;
+/// to test the dispatcher over the SAME framing rules without touching the real
+/// process streams, this mirrors the loop body over an injected reader/writer.
+/// What: reads newline-delimited requests, dispatches, writes one JSON line per
+/// non-suppressed response. Identical framing to the shared loop.
+/// Test: used by `line_framing_round_trips_one_response`.
+async fn run_stdio_loop_over<F, Fut, R, W>(
+    dispatcher: F,
+    reader: R,
+    mut writer: W,
+) -> anyhow::Result<()>
+where
+    F: Fn(Request) -> Fut,
+    Fut: std::future::Future<Output = Response>,
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    let mut lines = BufReader::new(reader).lines();
+    while let Some(line) = lines.next_line().await? {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<Request>(trimmed) {
+            Ok(r) => dispatcher(r).await,
+            Err(e) => Response::err(None, error_codes::PARSE_ERROR, format!("{e}")),
+        };
+        if response.suppress {
+            continue;
+        }
+        let serialised = serde_json::to_string(&response)?;
+        writer.write_all(serialised.as_bytes()).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+    }
+    Ok(())
+}
+
+// ── Scripted §1A.2 step-1 sequence ──────────────────────────────────────────────
+
+/// Why: the §1A.2 acceptance is a scripted parent-driver flow over stdio:
+/// chat → launch → get → stop → goal-update. This drives that exact sequence
+/// through the dispatcher (mocks for control + provider) and asserts each step
+/// round-trips, proving the whole surface is exercisable headlessly.
+/// What: runs chat, launch, get, stop in order; under `sm-memory` also creates a
+/// goal and updates it; asserts each response is a non-error result.
+/// Test: this is the test.
+#[tokio::test]
+async fn scripted_chat_launch_get_stop_sequence() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    // 1) chat
+    let chat = d
+        .dispatch(req(40, "sm.chat", json!({ "message": "ship feature X" })))
+        .await;
+    let chat_result = ok_result(&chat, 40);
+    let conv_id = chat_result["conv_id"]
+        .as_str()
+        .expect("conv_id")
+        .to_string();
+    assert!(!conv_id.is_empty());
+
+    // 2) launch
+    let launch = d
+        .dispatch(req(
+            41,
+            "sm.sessions.launch",
+            json!({ "workdir": "/repo", "prompt": "X" }),
+        ))
+        .await;
+    let session_id = ok_result(&launch, 41)["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // 3) get
+    let get = d
+        .dispatch(req(
+            42,
+            "sm.sessions.get",
+            json!({ "session_id": session_id }),
+        ))
+        .await;
+    assert!(ok_result(&get, 42)["session"].is_object());
+
+    // 4) stop
+    let stop = d
+        .dispatch(req(
+            43,
+            "sm.sessions.stop",
+            json!({ "session_id": session_id }),
+        ))
+        .await;
+    assert_eq!(ok_result(&stop, 43)["ok"], true);
+
+    // 5) goal-update (only meaningful under sm-memory; otherwise it returns the
+    //    graceful unavailable error, which is itself a valid framed response).
+    let create = d
+        .dispatch(req(
+            44,
+            "sm.goals.create",
+            json!({ "description": "ship X" }),
+        ))
+        .await;
+    #[cfg(feature = "sm-memory")]
+    {
+        let goal = ok_result(&create, 44);
+        let goal_id = goal["goal"]["id"].as_str().unwrap().to_string();
+        let upd = d
+            .dispatch(req(
+                45,
+                "sm.goals.update",
+                json!({ "id": goal_id, "note": "kicked off" }),
+            ))
+            .await;
+        assert!(
+            !ok_result(&upd, 45)["goal"]["notes"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+    }
+    #[cfg(not(feature = "sm-memory"))]
+    {
+        err_code(&create, 44, CODE_UNAVAILABLE);
+    }
+}
+
+// ── Feature-gated goals / context ───────────────────────────────────────────────
+
+/// Why: `sm.goals.*` round-trip under `sm-memory` (create then list) and degrade
+/// to a graceful unavailable error without it. This pins both branches.
+/// What: under the feature, creates a goal and lists it; without it, asserts the
+/// unavailable code on `sm.goals.list`.
+/// Test: this is the test.
+#[tokio::test]
+async fn goals_feature_branches() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    #[cfg(feature = "sm-memory")]
+    {
+        let create = d
+            .dispatch(req(
+                50,
+                "sm.goals.create",
+                json!({ "description": "g1", "acceptance": ["pr merged"] }),
+            ))
+            .await;
+        assert_eq!(ok_result(&create, 50)["goal"]["description"], "g1");
+
+        let list = d.dispatch(req(51, "sm.goals.list", json!({}))).await;
+        let goals = ok_result(&list, 51)["goals"].as_array().unwrap().clone();
+        assert_eq!(goals.len(), 1, "the created goal is listed");
+    }
+    #[cfg(not(feature = "sm-memory"))]
+    {
+        let list = d.dispatch(req(52, "sm.goals.list", json!({}))).await;
+        err_code(&list, 52, CODE_UNAVAILABLE);
+    }
+}
+
+/// Why: `sm.context.get` returns the rolling context state under `sm-memory`
+/// (after a chat populates it) and degrades to unavailable without the feature.
+/// What: under the feature, runs a chat then `sm.context.get` for the same
+/// conv_id and asserts the four context fields; without it, asserts unavailable.
+/// Test: this is the test.
+#[tokio::test]
+async fn context_get_feature_branches() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    #[cfg(feature = "sm-memory")]
+    {
+        // Populate a conversation first so the context engine has a round.
+        let _ = d
+            .dispatch(req(
+                60,
+                "sm.chat",
+                json!({ "message": "hi", "conv_id": "ctx-1" }),
+            ))
+            .await;
+        let ctx = d
+            .dispatch(req(61, "sm.context.get", json!({ "conv_id": "ctx-1" })))
+            .await;
+        let result = ok_result(&ctx, 61);
+        assert!(result["recent_rounds"].is_array());
+        assert!(result["total_rounds"].as_u64().unwrap() >= 1);
+        assert!(result["token_estimate"].is_number());
+        assert!(result.get("compressed_context").is_some());
+    }
+    #[cfg(not(feature = "sm-memory"))]
+    {
+        let ctx = d
+            .dispatch(req(62, "sm.context.get", json!({ "conv_id": "ctx-1" })))
+            .await;
+        err_code(&ctx, 62, CODE_UNAVAILABLE);
+    }
+}
+
+// ── stdout cleanliness guard ────────────────────────────────────────────────────
+
+/// Why: stdout is reserved EXCLUSIVELY for JSON-RPC framing. A stray `println!`/
+/// `print!` anywhere in the SM stdio adapter OR the SM core it drives would
+/// corrupt the channel. This test mechanically greps those source trees and
+/// asserts NONE contain a `print!`/`println!` macro call, so a future edit that
+/// adds one fails loudly.
+/// What: scans every `.rs` file under `src/daemon/sm_stdio/` and `src/core/sm/`
+/// for the `println!`/`print!` macro tokens (ignoring this test file and doc
+/// comments), asserting zero hits.
+/// Test: this is the test.
+#[test]
+fn no_stdout_writes_in_sm_paths() {
+    use std::fs;
+    use std::path::Path;
+
+    // CARGO_MANIFEST_DIR is the crate root; the SM paths live under src/.
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let roots = [
+        crate_root.join("src/daemon/sm_stdio"),
+        crate_root.join("src/core/sm"),
+    ];
+
+    /// Recursively collect every `.rs` file under `dir`.
+    fn collect_rs(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rs(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    for root in &roots {
+        collect_rs(root, &mut files);
+    }
+    assert!(
+        !files.is_empty(),
+        "expected to find SM source files to scan"
+    );
+
+    let mut offenders = Vec::new();
+    for path in &files {
+        // This test file itself names the macros in comments/strings — skip it.
+        if path.ends_with("daemon/sm_stdio/tests.rs") {
+            continue;
+        }
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
+        };
+        for (lineno, line) in src.lines().enumerate() {
+            let code = line.trim_start();
+            // Ignore doc/line comments — they cannot write to stdout.
+            if code.starts_with("//") || code.starts_with("*") {
+                continue;
+            }
+            // `print!`/`println!` write to stdout (forbidden). `eprint!`/
+            // `eprintln!` write to stderr (allowed) — and contain the substring
+            // `print!`/`println!`, so we must check the preceding char is not an
+            // identifier char (the `e` in `eprintln!`) before flagging.
+            if contains_macro(line, b"println!") || contains_macro(line, b"print!") {
+                offenders.push(format!("{}:{}", path.display(), lineno + 1));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "stdout-write macro found in SM paths (stdout must stay JSON-RPC-only): {offenders:?}"
+    );
+}
+
+/// Detect a `needle` macro token NOT preceded by an identifier char.
+///
+/// Why: distinguishing the stdout writers `print!`/`println!` from the stderr
+/// writers `eprint!`/`eprintln!` (which contain them as a substring) needs a
+/// boundary check — the macro must not be immediately preceded by an
+/// alphanumeric/`_` char (the `e` in `eprintln!`, or any identifier prefix).
+/// What: returns true when `needle` occurs in `line` with a non-identifier char
+/// (or start-of-line) immediately before it.
+/// Test: exercised by `no_stdout_writes_in_sm_paths` (the `eprintln!` in
+/// `prompt.rs` must NOT be flagged).
+fn contains_macro(line: &str, needle: &[u8]) -> bool {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while let Some(pos) = find_subslice(&bytes[i..], needle) {
+        let abs = i + pos;
+        let prev_ok =
+            abs == 0 || !(bytes[abs - 1].is_ascii_alphanumeric() || bytes[abs - 1] == b'_');
+        if prev_ok {
+            return true;
+        }
+        i = abs + 1;
+    }
+    false
+}
+
+/// Find the first index of `needle` in `haystack`, or `None`.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}

--- a/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
@@ -41,6 +41,10 @@ use crate::core::sm::agent::mock::{MockChatProvider, MockResolver};
 struct MockSessionControl {
     /// When true, `get` returns NotFound (to cover the not-found JSON-RPC mapping).
     fail_get_not_found: bool,
+    /// When true, `stop`/`kill` return [`SessionControlError::Backend`] (to cover
+    /// the backend-failure JSON-RPC mapping — a tmux/store failure on a session
+    /// that DOES exist must NOT be reported as not-found).
+    fail_stop_kill_backend: bool,
     /// The last launch params seen (so a test can assert the mapping).
     last_launch: std::sync::Mutex<Option<LaunchParams>>,
 }
@@ -64,12 +68,20 @@ impl SessionControl for MockSessionControl {
         Ok(json!({ "ok": true }))
     }
     async fn stop(&self, _id: &str) -> Result<Value, SessionControlError> {
+        if self.fail_stop_kill_backend {
+            return Err(SessionControlError::Backend("tmux kill failed".into()));
+        }
         Ok(json!({ "ok": true }))
     }
     async fn resume(&self, _id: &str) -> Result<Value, SessionControlError> {
         Ok(json!({ "ok": true }))
     }
     async fn kill(&self, _id: &str) -> Result<Value, SessionControlError> {
+        if self.fail_stop_kill_backend {
+            return Err(SessionControlError::Backend(
+                "decommission tmux failed".into(),
+            ));
+        }
         Ok(json!({ "ok": true }))
     }
 }
@@ -124,14 +136,10 @@ fn dispatcher_with(
 ) -> SmDispatcher {
     let sessions: Arc<dyn SessionControl> = control;
     #[cfg(feature = "sm-memory")]
-    {
-        let goals = test_goal_store(data_root);
-        SmDispatcher::new(agent, cfg, data_root.to_path_buf(), sessions, goals)
-    }
+    let goals = Some(test_goal_store(data_root));
     #[cfg(not(feature = "sm-memory"))]
-    {
-        SmDispatcher::new(agent, cfg, data_root.to_path_buf(), sessions)
-    }
+    let goals = None;
+    SmDispatcher::new(agent, cfg, data_root.to_path_buf(), sessions, goals)
 }
 
 /// Build an in-memory goal store over a no-op palace for `sm.goals.*` tests.
@@ -262,6 +270,34 @@ async fn chat_missing_message_is_invalid_params() {
 
     let resp = d.dispatch(req(3, "sm.chat", json!({}))).await;
     err_code(&resp, 3, error_codes::INVALID_PARAMS);
+}
+
+/// Why: a PRESENT-but-blank required string must still be rejected (INVALID_PARAMS)
+/// but with a DISTINCT "must not be blank" message — not the misleading "missing"
+/// wording — so a caller who supplied a whitespace value gets an actionable error.
+/// What: dispatches `sm.chat` with a whitespace `message`; asserts INVALID_PARAMS
+/// and that the message distinguishes blank from missing.
+/// Test: this is the test.
+#[tokio::test]
+async fn blank_required_param_is_distinct_invalid_params() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d
+        .dispatch(req(7, "sm.chat", json!({ "message": "   " })))
+        .await;
+    let msg = err_code(&resp, 7, error_codes::INVALID_PARAMS);
+    assert!(
+        msg.contains("must not be blank"),
+        "blank value gets a distinct message, got: {msg}"
+    );
 }
 
 /// Why: `sm.health` must report provider status + degraded + model tiers with
@@ -423,6 +459,36 @@ async fn get_unknown_session_is_not_found() {
         ))
         .await;
     err_code(&resp, 16, CODE_NOT_FOUND);
+}
+
+/// Why: a BACKEND failure of `stop`/`kill` on a session that exists (tmux/store
+/// error, not a missing id) must map to INTERNAL_ERROR (-32603), NOT the
+/// not-found code — consistent with `send`/`resume`. This guards the regression
+/// where any `stop`/`decommission` error was reported as not-found.
+/// What: dispatches `sm.sessions.stop` and `sm.sessions.kill` against a control
+/// that returns [`SessionControlError::Backend`]; asserts INTERNAL_ERROR on both.
+/// Test: this is the test.
+#[tokio::test]
+async fn stop_kill_backend_failure_is_internal_not_found() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let control = Arc::new(MockSessionControl {
+        fail_stop_kill_backend: true,
+        ..MockSessionControl::default()
+    });
+    let d = dispatcher_with(agent, cfg, tmp.path(), control);
+    let sid = "44444444-4444-4444-4444-444444444444";
+
+    let stop = d
+        .dispatch(req(17, "sm.sessions.stop", json!({ "session_id": sid })))
+        .await;
+    err_code(&stop, 17, error_codes::INTERNAL_ERROR);
+
+    let kill = d
+        .dispatch(req(18, "sm.sessions.kill", json!({ "session_id": sid })))
+        .await;
+    err_code(&kill, 18, error_codes::INTERNAL_ERROR);
 }
 
 // ── Framing: parse error / unknown method / notification ────────────────────────

--- a/crates/trusty-mpm/src/daemon/state/resources.rs
+++ b/crates/trusty-mpm/src/daemon/state/resources.rs
@@ -201,6 +201,20 @@ impl DaemonState {
         Arc::clone(&self.session_manager_agent)
     }
 
+    /// The SM runtime data root (`<framework_root>/sm`), DOC-14 SM-STDIO.
+    ///
+    /// Why: the SM-STDIO adapter (`tm sm serve --stdio`) opens the per-`conv_id`
+    /// rolling-context engine state and the SM goal palace under the SAME root the
+    /// SM agent was built against (`state::sm::SM_DATA_SUBDIR`). Exposing it as one
+    /// accessor keeps the stdio wiring from re-deriving the path (and possibly
+    /// drifting from the agent's storage root).
+    /// What: returns `<framework_root>/sm`.
+    /// Test: covered by the SM-STDIO dispatch wiring; the path convention matches
+    /// `state::sm::build_session_manager_agent`.
+    pub fn sm_data_root(&self) -> std::path::PathBuf {
+        self.framework_root.join("sm")
+    }
+
     // ---- hook events ----------------------------------------------------
 
     /// Append a hook event to the bounded history ring buffer and broadcast it.


### PR DESCRIPTION
## SM-STDIO (#1291) — SM JSON-RPC 2.0 over STDIO adapter

Implements the SM's **PRIMARY, API-first interface** (DOC-14 §1A.1): a JSON-RPC 2.0 over STDIO adapter so a parent `claude-mpm`/PM can drive **every** SM capability headlessly (the §1A.2 topology `claude-mpm ⟷ SM ⟷ t-mpm`). The adapter is a **thin mapping** — no business logic; each of the 13 `sm.*` methods maps onto an existing surface.

Part of epic #1283. Depends on SM-2/#1285, SM-3/#1286, SM-7/#1290 (all merged).

### Method → surface table (13 methods)

| Method | Maps onto |
|---|---|
| `sm.chat` | `SessionManagerAgent::chat` (SM-7) |
| `sm.health` | new `SessionManagerAgent::health()` (SM-2/§5.3, no network) |
| `sm.goals.list/create/update` | `SmGoalStore` (SM-6, behind `sm-memory`) |
| `sm.context.get` | SM-5 rolling-context engine (behind `sm-memory`) |
| `sm.sessions.launch/list/get/send/stop/resume/kill` | managed-session control surface (§2.6), in-process via a `SessionControl` seam over `SessionManager` + `spawn_managed`/`resume_managed` |

### Architecture

**In-process** (not an HTTP client): the SM runs in the daemon, so the adapter builds the SM core + managed session-manager surface directly — the same handles the daemon wires. This is the spec-faithful choice (the goal store & context engine are not exposed over HTTP) and makes the 13 methods hermetically testable.

`crates/trusty-mpm/src/daemon/sm_stdio/`:
- `mod.rs` — `SmDispatcher` + `run_sm_stdio` entry (drives the shared `trusty_common::mcp::run_stdio_loop` newline framing + stderr-only logging)
- `dispatch.rs` — JSON-RPC 2.0 router: id echoed, result/error shaping, method-not-found / parse-error / invalid-params / **notification suppression** — never a panic
- `methods.rs` — the 13 thin handlers (typed `MethodError` → JSON-RPC codes)
- `control.rs` — `SessionControl` trait + `DaemonSessionControl` (in-process)
- `tests.rs` — 16 hermetic round-trips (mock resolver + mock control + tempdir; **no network, no tmux, no real LLM**)

### stdout cleanliness (guaranteed)

stdout is reserved exclusively for JSON-RPC framing; **all** logs go to stderr via `tracing`. The `no_stdout_writes_in_sm_paths` test greps `src/daemon/sm_stdio` + `src/core/sm` and asserts **zero** `println!`/`print!` (`eprintln!`/`eprint!` to stderr are correctly allowed via a boundary check).

### Entry point

`tm sm serve --stdio` — a new `Serve` subcommand under `coordinator`/`sm`. A plain `tm sm <message>` **still chats** (non-breaking; covered by `cli_sm_aliases_reach_coordinator` + `cli_parses_sm_serve_stdio`).

### Feature gating

`sm.goals.*` and `sm.context.get` are gated behind `sm-memory`; when the feature is off they return a graceful JSON-RPC error (`-32002`) rather than failing to compile.

## Test evidence

- `cargo test -p trusty-mpm` — all green (0 failed across all suites)
- `cargo test -p trusty-mpm --features sm-memory` — **1876 passed, 0 failed**
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean (exit 0)
- `cargo clippy -p trusty-mpm --all-targets --features sm-memory -- -D warnings` — clean (exit 0)
- `cargo fmt --check` — clean
- `cargo build -p trusty-mpm` and `--features sm-memory` — both compile
- `bash scripts/check_line_cap.sh` — `15 allowlisted, 0 violations — OK` (exit 0)

### Runtime smoke (real stdin/stdout pipe)

```
$ printf '{"jsonrpc":"2.0","id":1,"method":"sm.health","params":{}}\n{"jsonrpc":"2.0","method":"sm.health"}\nnot json\n{"jsonrpc":"2.0","id":2,"method":"sm.bogus"}\n' | tm sm serve --stdio
{"jsonrpc":"2.0","id":1,"result":{"degraded":true,"model_tiers":{...},"ok":false,"provider":"none"}}
{"jsonrpc":"2.0","error":{"code":-32700,"message":"invalid JSON-RPC: ..."}}
{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"unknown SM method: sm.bogus"}}
```
The notification (no id) produced **no output line** (suppressed); stdout carried only framed JSON; stderr held logs.

## Notes / assumptions

- **In-process vs HTTP client:** chose in-process — the SM core, goal store, and context engine live in the daemon and are not all exposed over HTTP. `sm.sessions.*` call the same `SessionManager`/`spawn_managed` helpers `tm ticket`/the HTTP `…/managed/*` routes use, so the surfaces cannot diverge.
- `sm.sessions.launch {workdir,...}` maps `workdir → repo_url`, `prompt → task`, `model → runtime`; a supplied `goal_id` records the §9.3 goal↔session link (best-effort, never fails the launch).
- `sm.sessions.kill` maps to `decommission` (force-stop + tombstone) — the strongest in-process equivalent of the spec's force-stop/reap.
- `sm.goals.update`'s `progress` field is **derived** by the store from session states (§9.1), so it is accepted-but-not-directly-settable; `status`/`note` are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)