### PR TITLE
feat(trusty-mpm): SM-8 SM↔session delegation loop with verification gate + prohibition enforcement (#1292)

### DIFF
--- a/crates/trusty-mpm/src/core/sm/agent/delegate/decision.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/decision.rs
@@ -1,0 +1,168 @@
+//! The SM decision protocol — structured-text (ReAct-style) action blocks (§3.4).
+//!
+//! Why: the SM's [`LlmProvider`](crate::core::sm::providers::LlmProvider) surface
+//! is non-streaming `complete()` returning TEXT only — it has NO tool/function
+//! calling (the provider trait deliberately omits the tool-call shape, see
+//! `providers/mod.rs::ChatMessage`). So the §3.4 delegation loop cannot rely on
+//! native tool calls; instead the SM emits a STRUCTURED-TEXT decision — a single
+//! JSON action block — which the delegation engine ([`super`]) parses and
+//! EXECUTES against the session-control + goal surfaces. This is the
+//! deterministic, provider-agnostic decision protocol the spec's "verbs the SM
+//! calls" (§4.2/SM_TOOLS) maps onto when the provider is text-only. Parsing is
+//! lenient (the model may wrap the JSON in prose or a ```json fence) but the
+//! resulting action is a strict, typed enum so the engine never interprets free
+//! text as an instruction.
+//! What: [`SmDecision`] — the closed set of actions the SM may emit at the
+//! DECOMPOSE step (`delegate` to launch session-sized tasks, `respond` to talk
+//! to the operator, or `do_work` — a PROHIBITION-violating direct-work attempt
+//! the engine refuses and redirects, §3.2 SP1–SP5); [`TaskSpec`] — one
+//! session-sized task; and [`parse_decision`] — the lenient JSON extractor.
+//! Test: `decision_tests.rs` covers fenced/bare/prose-wrapped JSON, each action
+//! variant, the empty-tasks guard, and the malformed-input fallback.
+
+use serde::{Deserialize, Serialize};
+
+/// One session-sized task the SM decomposed a goal into (§3.4 DECOMPOSE).
+///
+/// Why: DECOMPOSE splits a goal into one-or-many tasks, each of which becomes
+/// exactly ONE launched session (§3.4: "one task → one launched session"). A task
+/// carries everything LAUNCH needs: the working directory/repo, the prompt the
+/// session executes, and an optional model/runtime selector.
+/// What: `workdir` (required — the repo/dir the session runs against, mapped to
+/// the launch `workdir`), `prompt` (required — the task the session performs,
+/// DELIVERED to the session per #1299), and an optional `model` selector.
+/// Test: `decision_tests.rs::parse_delegate_with_tasks`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskSpec {
+    /// The working directory / repository the launched session runs against.
+    pub workdir: String,
+    /// The task prompt the session executes (delivered via `sessions.send`, #1299).
+    pub prompt: String,
+    /// Optional model / runtime selector for the launched session.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+impl TaskSpec {
+    /// Whether this task is well-formed enough to launch.
+    ///
+    /// Why: a task with a blank `workdir` or `prompt` cannot be launched
+    /// meaningfully (LAUNCH needs a target and a task), so the engine drops it
+    /// rather than spawning an idle/garbage session.
+    /// What: returns `true` iff both `workdir` and `prompt` are non-blank.
+    /// Test: `parse_delegate_drops_blank_tasks`.
+    pub fn is_launchable(&self) -> bool {
+        !self.workdir.trim().is_empty() && !self.prompt.trim().is_empty()
+    }
+}
+
+/// The closed set of decisions the SM may emit at the DECOMPOSE step (§3.4).
+///
+/// Why: the engine must NEVER interpret free model text as an instruction — that
+/// is how a prohibition (SP5: "answer a work question from your own knowledge")
+/// sneaks in. Constraining the SM's decision to this typed enum means the only
+/// thing it can ask the engine to do is delegate (launch sessions), talk to the
+/// operator, or — explicitly — attempt direct work, which the engine REFUSES and
+/// redirects (§3.2). Anything unparseable degrades to [`SmDecision::Respond`]
+/// (talk to the operator) — never to silently doing work.
+/// What: `Delegate { tasks }` launches one session per [`TaskSpec`];
+/// `Respond { message }` is an Allowlist-1 operator-facing reply (triage/status/
+/// clarification); `DoWork { summary }` is a flagged direct-work attempt the
+/// engine converts into a delegation refusal (the SP guard).
+/// Test: `decision_tests.rs` — every variant + the lenient/fallback parses.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum SmDecision {
+    /// Delegate the goal to one-or-many launched sessions (the normal path).
+    Delegate {
+        /// The session-sized tasks (one launched session each).
+        #[serde(default)]
+        tasks: Vec<TaskSpec>,
+    },
+    /// Talk to the operator directly (Allowlist 1) — triage, status, a question.
+    Respond {
+        /// The operator-facing message.
+        message: String,
+    },
+    /// A PROHIBITED direct-work attempt (SP1–SP5). The SM tried to do the work
+    /// itself instead of delegating; the engine refuses and redirects to launch.
+    DoWork {
+        /// The work the SM attempted to do directly (captured for the redirect).
+        #[serde(default)]
+        summary: String,
+    },
+}
+
+/// The opening fence/marker the SM may wrap its decision JSON in.
+const JSON_FENCE: &str = "```json";
+/// A generic code fence the SM may use instead of the `json`-tagged one.
+const BARE_FENCE: &str = "```";
+
+/// Parse the SM's reply text into a typed [`SmDecision`] (lenient extraction).
+///
+/// Why: the model returns TEXT (no tool calls), and may wrap its JSON action
+/// block in a ```json fence or surround it with prose. The engine must extract
+/// the action robustly but NEVER guess: if no valid action object is found, the
+/// safe fallback is to treat the whole reply as an operator-facing message
+/// ([`SmDecision::Respond`]) — the SM is talking, not delegating — rather than
+/// inventing a delegation or (worse) doing work. This keeps an unparseable reply
+/// on the always-safe Allowlist-1 path.
+/// What: (1) strips a leading ```json / ``` fence + trailing fence if present;
+/// (2) failing that, scans for the first `{`…matching `}` span; (3) attempts to
+/// deserialize that span as [`SmDecision`]; (4) on any failure returns
+/// `Respond { message: <trimmed original> }`.
+/// Test: `decision_tests.rs::parse_fenced_json`, `parse_bare_json`,
+/// `parse_prose_wrapped_json`, `parse_garbage_is_respond`,
+/// `parse_do_work_action`.
+pub fn parse_decision(reply: &str) -> SmDecision {
+    let trimmed = reply.trim();
+
+    // (1)/(2): find a candidate JSON object span.
+    if let Some(candidate) = extract_json_object(trimmed)
+        && let Ok(decision) = serde_json::from_str::<SmDecision>(&candidate)
+    {
+        return decision;
+    }
+
+    // (4): no valid action → the SM is talking to the operator (Allowlist 1).
+    SmDecision::Respond {
+        message: trimmed.to_string(),
+    }
+}
+
+/// Extract a candidate JSON-object substring from the SM's reply.
+///
+/// Why: keeps [`parse_decision`] readable by isolating the three extraction
+/// strategies (fenced → bare-fenced → first-brace-span). Returns the substring
+/// only; the caller decides whether it deserialises into a valid action.
+/// What: if the text contains a ```json (or ```) fence, returns the content up to
+/// the closing fence; otherwise returns the span from the first `{` to the last
+/// `}` (inclusive), or `None` when no brace pair exists.
+/// Test: exercised via `parse_decision` in `decision_tests.rs`.
+fn extract_json_object(text: &str) -> Option<String> {
+    // Strategy A: a ```json … ``` (or ``` … ```) fenced block.
+    for fence in [JSON_FENCE, BARE_FENCE] {
+        if let Some(after) = text.find(fence).map(|i| i + fence.len()) {
+            let rest = &text[after..];
+            if let Some(end) = rest.find(BARE_FENCE) {
+                let inner = rest[..end].trim();
+                if inner.starts_with('{') {
+                    return Some(inner.to_string());
+                }
+            }
+        }
+    }
+
+    // Strategy B: the first `{` … last `}` span (prose-wrapped or bare object).
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    if end > start {
+        Some(text[start..=end].to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+#[path = "decision_tests.rs"]
+mod decision_tests;

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/decision.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/decision.rs
@@ -107,21 +107,28 @@ const BARE_FENCE: &str = "```";
 /// ([`SmDecision::Respond`]) — the SM is talking, not delegating — rather than
 /// inventing a delegation or (worse) doing work. This keeps an unparseable reply
 /// on the always-safe Allowlist-1 path.
-/// What: (1) strips a leading ```json / ``` fence + trailing fence if present;
-/// (2) failing that, scans for the first `{`…matching `}` span; (3) attempts to
-/// deserialize that span as [`SmDecision`]; (4) on any failure returns
-/// `Respond { message: <trimmed original> }`.
+/// What: (1) if a ```json / ``` fenced block is present, extracts its inner
+/// content (matching opening→closing fence); (2) otherwise (or if the fenced inner
+/// is not an object) runs a BALANCED-BRACE scan from the first `{` that respects
+/// JSON string literals, yielding the first complete top-level object regardless of
+/// surrounding/trailing prose braces; (3) attempts to deserialize that candidate as
+/// [`SmDecision`]; (4) on any failure returns `Respond { message: <trimmed original> }`.
 /// Test: `decision_tests.rs::parse_fenced_json`, `parse_bare_json`,
-/// `parse_prose_wrapped_json`, `parse_garbage_is_respond`,
-/// `parse_do_work_action`.
+/// `parse_prose_wrapped_json`, `parse_garbage_is_respond`, `parse_do_work_action`,
+/// `parse_both_json_and_bare_fence`, `parse_prose_brace_after_json`,
+/// `parse_prose_brace_before_json`, `parse_brace_inside_string_value`.
 pub fn parse_decision(reply: &str) -> SmDecision {
     let trimmed = reply.trim();
 
-    // (1)/(2): find a candidate JSON object span.
-    if let Some(candidate) = extract_json_object(trimmed)
-        && let Ok(decision) = serde_json::from_str::<SmDecision>(&candidate)
-    {
-        return decision;
+    // (1)/(2)/(3): try each candidate object span in order — the first that
+    // deserializes into a valid action wins. Trying successive top-level objects
+    // (not just the first) is what lets a prose brace BEFORE the real action
+    // object — e.g. `{note}: {"action":...}` — still parse: `{note}` fails to
+    // deserialize and the scan moves on to the real object.
+    for candidate in candidate_objects(trimmed) {
+        if let Ok(decision) = serde_json::from_str::<SmDecision>(&candidate) {
+            return decision;
+        }
     }
 
     // (4): no valid action → the SM is talking to the operator (Allowlist 1).
@@ -130,37 +137,146 @@ pub fn parse_decision(reply: &str) -> SmDecision {
     }
 }
 
-/// Extract a candidate JSON-object substring from the SM's reply.
+/// Collect candidate JSON-object spans from the SM's reply, best-first.
 ///
-/// Why: keeps [`parse_decision`] readable by isolating the three extraction
-/// strategies (fenced → bare-fenced → first-brace-span). Returns the substring
-/// only; the caller decides whether it deserialises into a valid action.
-/// What: if the text contains a ```json (or ```) fence, returns the content up to
-/// the closing fence; otherwise returns the span from the first `{` to the last
-/// `}` (inclusive), or `None` when no brace pair exists.
-/// Test: exercised via `parse_decision` in `decision_tests.rs`.
-fn extract_json_object(text: &str) -> Option<String> {
-    // Strategy A: a ```json … ``` (or ``` … ```) fenced block.
-    for fence in [JSON_FENCE, BARE_FENCE] {
-        if let Some(after) = text.find(fence).map(|i| i + fence.len()) {
-            let rest = &text[after..];
-            if let Some(end) = rest.find(BARE_FENCE) {
-                let inner = rest[..end].trim();
-                if inner.starts_with('{') {
-                    return Some(inner.to_string());
-                }
-            }
-        }
+/// Why: the prior extractor was fragile in two ways the review flagged: (1) the
+/// `[JSON_FENCE, BARE_FENCE]` ordering made `BARE_FENCE` re-match a ```json
+/// opening as a bare fence and mishandled a reply with BOTH a ```json block AND a
+/// later ``` block; and (2) the `first '{' ..= last '}'` span grabbed a WRONG span
+/// whenever prose braces surrounded the JSON (e.g. `{...} see {docs}` →
+/// `rfind('}')` captured the prose brace → truncated JSON → a spurious `Respond`
+/// fallback that silently dropped an intended `Delegate`). Both are now robust.
+/// What: returns, in priority order, (1) the first balanced object found INSIDE a
+/// ```json (or bare ```) fenced block — the `json` tag is consumed as part of the
+/// opening fence so it is never re-read as a bare fence; then (2) successive
+/// complete top-level `{ … }` objects scanned over the whole text, each found by a
+/// BALANCED-BRACE walk that RESPECTS JSON string literals + escapes (so braces
+/// inside strings and prose braces before/after the object do not corrupt the
+/// span). The caller deserializes each in turn and keeps the first valid action.
+/// Test: exercised via `parse_decision` in `decision_tests.rs`
+/// (`parse_both_json_and_bare_fence`, `parse_prose_brace_after_json`,
+/// `parse_prose_brace_before_json`, `parse_brace_inside_string_value`, plus the
+/// existing fenced/bare/prose/garbage cases).
+fn candidate_objects(text: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+
+    // Strategy A: a fenced code block. Find the OPENING fence (prefer the explicit
+    // ```json tag; fall back to a bare ```), consume it, then take the first
+    // balanced object up to the matching CLOSING ``` fence. Consuming the ```json
+    // tag as part of the opening prevents re-matching the same opening as a bare
+    // fence (the BOTH-fences regression).
+    if let Some(inner) = fenced_inner(text)
+        && let Some(obj) = first_balanced_object(&inner)
+    {
+        candidates.push(obj);
     }
 
-    // Strategy B: the first `{` … last `}` span (prose-wrapped or bare object).
-    let start = text.find('{')?;
-    let end = text.rfind('}')?;
-    if end > start {
-        Some(text[start..=end].to_string())
-    } else {
-        None
+    // Strategy B: every complete top-level `{ … }` object in the whole text, in
+    // order. Prose braces before the real object yield candidates that fail to
+    // deserialize; the caller skips them and reaches the valid action.
+    let mut from = 0;
+    while let Some((obj, end)) = next_balanced_object(text, from) {
+        if !candidates.contains(&obj) {
+            candidates.push(obj);
+        }
+        from = end;
     }
+
+    candidates
+}
+
+/// Return the inner content of the first fenced code block, if any.
+///
+/// Why: isolates fence handling so [`candidate_objects`] stays readable, and so
+/// a ```json opening is matched exactly once (the `json` tag is part of the
+/// opening, never re-read as a separate bare fence).
+/// What: finds a ```json opening if present (else a bare ```), skips to the end of
+/// that line (so the opening fence + optional language tag is fully consumed), then
+/// returns the substring up to the next ``` closing fence (or end of text if the
+/// block is unterminated). Returns `None` when there is no opening fence.
+/// Test: exercised via `parse_decision` (`parse_fenced_json`, `parse_bare_json`,
+/// `parse_both_json_and_bare_fence`).
+fn fenced_inner(text: &str) -> Option<String> {
+    // Prefer the explicit ```json fence; fall back to a bare ``` fence.
+    let (open_at, fence_len) = match text.find(JSON_FENCE) {
+        Some(i) => (i, JSON_FENCE.len()),
+        None => (text.find(BARE_FENCE)?, BARE_FENCE.len()),
+    };
+    // Consume to the end of the opening-fence line so any trailing language tag on
+    // a bare ```json-equivalent (e.g. "```json5") does not leak into the inner.
+    let after_open = open_at + fence_len;
+    let body_start = match text[after_open..].find('\n') {
+        Some(nl) => after_open + nl + 1,
+        None => after_open,
+    };
+    let rest = &text[body_start..];
+    let inner = match rest.find(BARE_FENCE) {
+        Some(close) => &rest[..close],
+        None => rest,
+    };
+    Some(inner.to_string())
+}
+
+/// Return the first COMPLETE top-level JSON object in `text` (balanced scan).
+///
+/// Why: convenience wrapper for callers (the fenced-inner path) that only need the
+/// first object and not the continuation offset.
+/// What: returns the object span from [`next_balanced_object`] starting at 0.
+/// Test: exercised via `parse_decision` (`parse_fenced_json`, `parse_bare_json`).
+fn first_balanced_object(text: &str) -> Option<String> {
+    next_balanced_object(text, 0).map(|(obj, _)| obj)
+}
+
+/// Find the next COMPLETE top-level `{ … }` object at or after `from`.
+///
+/// Why: a naive `first '{' ..= last '}'` span breaks when prose braces appear
+/// before or after the JSON object, or when braces appear inside a JSON string
+/// value. A depth-tracking scan that honours JSON string literals + escapes finds
+/// each well-formed top-level object in turn, so the caller can try successive
+/// candidates (skipping a leading prose `{…}` that is not a valid action).
+/// What: from the first `{` at/after `from`, increments depth on `{` and
+/// decrements on `}`, but ONLY when NOT inside a string literal (a `"` toggles
+/// string mode; a `\` inside a string escapes the next char so an escaped quote
+/// does not end the string). Returns `(object_span, end_offset)` the moment depth
+/// returns to zero, where `end_offset` is the absolute index just past the closing
+/// `}` (so a follow-up call can resume there). Returns `None` if there is no `{`
+/// at/after `from` or the object never closes.
+/// Test: `parse_prose_brace_after_json`, `parse_prose_brace_before_json`,
+/// `parse_brace_inside_string_value`, `parse_escaped_quote_in_string`.
+fn next_balanced_object(text: &str, from: usize) -> Option<(String, usize)> {
+    if from >= text.len() {
+        return None;
+    }
+    let rel = text[from..].find('{')?;
+    let start = from + rel;
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (offset, ch) in text[start..].char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let end = start + offset + ch.len_utf8();
+                    return Some((text[start..end].to_string(), end));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/decision_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/decision_tests.rs
@@ -93,6 +93,99 @@ fn parse_garbage_is_respond() {
     );
 }
 
+/// Why: regression for the fence-ordering bug — a reply containing BOTH a ```json
+/// block AND a later bare ``` block must parse the JSON inside the ```json block,
+/// not mis-pair the ```json opening with the later bare closing fence (which would
+/// swallow prose between them and truncate the object).
+/// What: a reply with a ```json delegate block followed by a separate ``` snippet;
+/// asserts the delegate action is recovered intact.
+/// Test: this is the test.
+#[test]
+fn parse_both_json_and_bare_fence() {
+    let reply = "Plan:\n```json\n{\"action\":\"delegate\",\"tasks\":[\
+        {\"workdir\":\"/repo\",\"prompt\":\"add login\"}]}\n```\n\nAside:\n```\nsome shell\n```";
+    match parse_decision(reply) {
+        SmDecision::Delegate { tasks } => {
+            assert_eq!(tasks.len(), 1);
+            assert_eq!(tasks[0].workdir, "/repo");
+            assert_eq!(tasks[0].prompt, "add login");
+        }
+        other => panic!("expected Delegate from the json fence, got {other:?}"),
+    }
+}
+
+/// Why: regression for the `rfind('}')` bug — a prose brace AFTER the JSON object
+/// (e.g. `{...} see {docs}`) must NOT extend the captured span to the trailing
+/// prose brace (which truncated the JSON → a spurious `Respond` fallback that
+/// dropped an intended `Delegate`). The balanced scan stops at the FIRST complete
+/// object.
+/// What: a delegate object followed by a prose `{docs}`; asserts `Delegate`.
+/// Test: this is the test.
+#[test]
+fn parse_prose_brace_after_json() {
+    let reply =
+        "{\"action\":\"delegate\",\"tasks\":[{\"workdir\":\"/r\",\"prompt\":\"go\"}]} see {docs}";
+    match parse_decision(reply) {
+        SmDecision::Delegate { tasks } => {
+            assert_eq!(tasks.len(), 1);
+            assert_eq!(tasks[0].prompt, "go");
+        }
+        other => panic!("expected Delegate despite trailing prose brace, got {other:?}"),
+    }
+}
+
+/// Why: a prose brace BEFORE the JSON object must not derail the balanced scan —
+/// it begins its own (unbalanced) object that never closes, so the scan must move
+/// on and still recover the real action object.
+/// What: a leading prose `{note}` then a respond object; asserts `Respond`.
+/// Test: this is the test.
+#[test]
+fn parse_prose_brace_before_json() {
+    let reply = "Context {see notes}: {\"action\":\"respond\",\"message\":\"hi there\"}";
+    assert_eq!(
+        parse_decision(reply),
+        SmDecision::Respond {
+            message: "hi there".to_string()
+        }
+    );
+}
+
+/// Why: braces INSIDE a JSON string value (e.g. a prompt mentioning `{cfg}`) must
+/// NOT change brace depth — a naive depth counter that ignored string literals
+/// would close the object early and truncate it.
+/// What: a delegate task whose prompt contains literal braces; asserts the full
+/// prompt (with the inner braces) survives.
+/// Test: this is the test.
+#[test]
+fn parse_brace_inside_string_value() {
+    let reply = "{\"action\":\"delegate\",\"tasks\":[\
+        {\"workdir\":\"/r\",\"prompt\":\"render {a:{b:1}} and ship\"}]}";
+    match parse_decision(reply) {
+        SmDecision::Delegate { tasks } => {
+            assert_eq!(tasks.len(), 1);
+            assert_eq!(tasks[0].prompt, "render {a:{b:1}} and ship");
+        }
+        other => panic!("expected Delegate with braces inside string, got {other:?}"),
+    }
+}
+
+/// Why: an escaped quote inside a JSON string must not prematurely end string mode
+/// (which would expose an inner brace to the depth counter). Proves the escape
+/// handling in the balanced scan.
+/// What: a respond message containing an escaped quote then a brace; asserts the
+/// message round-trips with the literal quote and brace.
+/// Test: this is the test.
+#[test]
+fn parse_escaped_quote_in_string() {
+    let reply = r#"{"action":"respond","message":"say \"hi\" and {wave}"}"#;
+    assert_eq!(
+        parse_decision(reply),
+        SmDecision::Respond {
+            message: "say \"hi\" and {wave}".to_string()
+        }
+    );
+}
+
 /// Why: a delegate block may contain blank/garbage task entries; `is_launchable`
 /// lets the engine drop them rather than spawning idle sessions.
 /// What: asserts a blank-workdir task is not launchable and a full one is.

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/decision_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/decision_tests.rs
@@ -1,0 +1,114 @@
+//! Unit tests for the SM decision protocol parser (`parse_decision`).
+//!
+//! Why: the decision parser is the trust boundary between the model's free text
+//! and the engine's typed actions — it must extract a valid action from fenced,
+//! bare, or prose-wrapped JSON, and it must NEVER turn garbage into a delegation
+//! or a direct-work action (the safe fallback is "talk to the operator").
+//! What: drives `parse_decision` with each shape and asserts the typed result.
+//! Test: this is the test module.
+
+use super::{SmDecision, TaskSpec, parse_decision};
+
+/// Why: the normal model output is a ```json-fenced action block; the parser must
+/// strip the fence and yield a `Delegate` with the tasks.
+/// What: parses a fenced delegate block and asserts the two tasks survive.
+/// Test: this is the test.
+#[test]
+fn parse_fenced_json() {
+    let reply = "Here is my plan:\n```json\n{\"action\":\"delegate\",\"tasks\":[\
+        {\"workdir\":\"/repo\",\"prompt\":\"add login\"},\
+        {\"workdir\":\"/repo\",\"prompt\":\"write tests\",\"model\":\"sonnet\"}]}\n```\nDone.";
+    match parse_decision(reply) {
+        SmDecision::Delegate { tasks } => {
+            assert_eq!(tasks.len(), 2);
+            assert_eq!(tasks[0].workdir, "/repo");
+            assert_eq!(tasks[0].prompt, "add login");
+            assert_eq!(tasks[1].model.as_deref(), Some("sonnet"));
+        }
+        other => panic!("expected Delegate, got {other:?}"),
+    }
+}
+
+/// Why: a bare JSON object (no fence) is also valid model output.
+/// What: parses a bare delegate object and asserts the single task.
+/// Test: this is the test.
+#[test]
+fn parse_bare_json() {
+    let reply = "{\"action\":\"delegate\",\"tasks\":[{\"workdir\":\"/r\",\"prompt\":\"do it\"}]}";
+    assert_eq!(
+        parse_decision(reply),
+        SmDecision::Delegate {
+            tasks: vec![TaskSpec {
+                workdir: "/r".to_string(),
+                prompt: "do it".to_string(),
+                model: None,
+            }],
+        }
+    );
+}
+
+/// Why: the model often surrounds the JSON with prose; the first-`{`…last-`}`
+/// span extraction must still recover the action.
+/// What: parses a prose-wrapped respond action.
+/// Test: this is the test.
+#[test]
+fn parse_prose_wrapped_json() {
+    let reply = "I think we should ask first. {\"action\":\"respond\",\
+        \"message\":\"which repo?\"} Let me know.";
+    assert_eq!(
+        parse_decision(reply),
+        SmDecision::Respond {
+            message: "which repo?".to_string()
+        }
+    );
+}
+
+/// Why: a direct-work attempt must parse to the `DoWork` variant so the engine
+/// can refuse + redirect it (the SP guard).
+/// What: parses a `do_work` action and asserts the summary.
+/// Test: this is the test.
+#[test]
+fn parse_do_work_action() {
+    let reply = "{\"action\":\"do_work\",\"summary\":\"I edited main.rs to add the flag\"}";
+    assert_eq!(
+        parse_decision(reply),
+        SmDecision::DoWork {
+            summary: "I edited main.rs to add the flag".to_string()
+        }
+    );
+}
+
+/// Why: unparseable / non-JSON model output must fall back to `Respond` (the SM
+/// is talking to the operator) — NEVER to a delegation or to doing work.
+/// What: parses plain prose and asserts it becomes a `Respond` echoing the text.
+/// Test: this is the test.
+#[test]
+fn parse_garbage_is_respond() {
+    let reply = "I am not sure what you mean — can you clarify the goal?";
+    assert_eq!(
+        parse_decision(reply),
+        SmDecision::Respond {
+            message: "I am not sure what you mean — can you clarify the goal?".to_string()
+        }
+    );
+}
+
+/// Why: a delegate block may contain blank/garbage task entries; `is_launchable`
+/// lets the engine drop them rather than spawning idle sessions.
+/// What: asserts a blank-workdir task is not launchable and a full one is.
+/// Test: this is the test.
+#[test]
+fn task_launchable_predicate() {
+    let blank = TaskSpec {
+        workdir: "  ".to_string(),
+        prompt: "x".to_string(),
+        model: None,
+    };
+    let full = TaskSpec {
+        workdir: "/r".to_string(),
+        prompt: "x".to_string(),
+        model: None,
+    };
+    assert!(!blank.is_launchable());
+    assert!(full.is_launchable());
+}

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/delegate_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/delegate_tests.rs
@@ -1,0 +1,410 @@
+//! Acceptance tests for the SM-8 delegation loop (`delegate_goal`).
+//!
+//! Why: SM-8's acceptance criteria are the heart of the Session Manager — an
+//! operator goal must (a) create a tracked goal LINKED to ≥1 launched session;
+//! (b) observe sessions and update link state + goal progress; (c) be BLOCKED
+//! from `Done` without observed evidence, then close once evidence is present
+//! (the §3.5 gate); (d) REFUSE a direct-work attempt and redirect to launch (the
+//! §3.2 SP guard); and (e) DELIVER the task to the launched session (#1299).
+//! These tests pin every one of those deterministically with a mock provider
+//! (scripted decision JSON), a mock `SessionControl`, and an in-memory goal store
+//! — NO network, NO real spawn, NO ONNX.
+//! What: builds an agent over a [`MockResolver`] whose provider replies with a
+//! scripted decision, a [`MockSessionControl`], and an [`SmGoalStore`] over an
+//! in-memory [`GoalMemory`] mock, then drives `delegate_goal`.
+//! Test: this is the test module.
+
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+
+use super::mock_control::MockSessionControl;
+use crate::core::sm::agent::SessionManagerAgent;
+use crate::core::sm::agent::mock::{MockChatProvider, MockResolver};
+use crate::core::sm::config::SessionManagerConfig;
+use crate::core::sm::control::SessionControl;
+use crate::core::sm::goals::{GOAL_TAG, GoalMemory, GoalStatus, SmGoalStore};
+
+// ── In-memory goal palace (mock GoalMemory) ─────────────────────────────────────
+
+/// A minimal in-memory [`GoalMemory`] for the delegation tests.
+///
+/// Why: the goal store needs a palace seam; a tiny in-memory upsert-by-id mock
+/// keeps the loop tests free of the ONNX-backed palace while still exercising the
+/// real store lifecycle (create/link/update/close gate).
+/// What: upserts JSON by goal id; `list_goals` returns the current set.
+struct MemPalace {
+    entries: StdMutex<Vec<(String, String)>>,
+}
+
+impl MemPalace {
+    fn arc() -> Arc<Self> {
+        Arc::new(Self {
+            entries: StdMutex::new(Vec::new()),
+        })
+    }
+}
+
+#[async_trait]
+impl GoalMemory for MemPalace {
+    async fn remember_goal(&self, json: String, tag: &str) -> Result<(), String> {
+        assert_eq!(tag, GOAL_TAG);
+        let id = serde_json::from_str::<serde_json::Value>(&json)
+            .ok()
+            .and_then(|v| v.get("id").and_then(|x| x.as_str()).map(str::to_string))
+            .unwrap_or_default();
+        let mut e = self.entries.lock().expect("lock");
+        if let Some(slot) = e.iter_mut().find(|(eid, _)| *eid == id) {
+            slot.1 = json;
+        } else {
+            e.push((id, json));
+        }
+        Ok(())
+    }
+
+    async fn list_goals(&self, _tag: &str) -> Result<Vec<String>, String> {
+        Ok(self
+            .entries
+            .lock()
+            .expect("lock")
+            .iter()
+            .map(|(_, j)| j.clone())
+            .collect())
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────────
+
+/// Build an enabled SM config.
+fn enabled_config() -> SessionManagerConfig {
+    SessionManagerConfig {
+        enabled: true,
+        ..SessionManagerConfig::default()
+    }
+}
+
+/// Build an agent over a mock resolver whose provider replies with `decision_json`.
+///
+/// Why: the loop's only LLM call is DECOMPOSE; scripting the provider reply lets a
+/// test drive any decision path (delegate / respond / do_work) deterministically.
+/// What: builds an agent via the feature-aware `with_runtime` over a
+/// [`MockResolver`] returning a [`MockChatProvider`] that always replies with
+/// `decision_json`.
+fn agent_with(decision_json: &str, data_root: &std::path::Path) -> SessionManagerAgent {
+    let provider = MockChatProvider::new(decision_json, 0.0);
+    let resolver = Arc::new(MockResolver::with_provider(provider));
+    #[cfg(feature = "sm-memory")]
+    {
+        SessionManagerAgent::with_runtime(enabled_config(), resolver, data_root.to_path_buf(), None)
+    }
+    #[cfg(not(feature = "sm-memory"))]
+    {
+        SessionManagerAgent::with_runtime(enabled_config(), resolver, data_root.to_path_buf())
+    }
+}
+
+/// Build an in-memory goal store handle for the loop.
+fn goal_store(dir: &TempDir) -> Arc<Mutex<SmGoalStore>> {
+    let palace = MemPalace::arc();
+    Arc::new(Mutex::new(SmGoalStore::new(palace, dir.path())))
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────────
+
+/// Why: the headline acceptance — an operator goal results in ≥1 launched session
+/// LINKED to a `Goal` record. Proves INTAKE→DECOMPOSE→LAUNCH wired correctly.
+/// What: scripts a single-task delegate decision, runs the loop, and asserts a
+/// session launched, the goal carries the link, and the launch recorded the goal id.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_launches_and_links_session() {
+    let tmp = TempDir::new().unwrap();
+    let decision = r#"{"action":"delegate","tasks":[{"workdir":"/repo","prompt":"add login"}]}"#;
+    let agent = agent_with(decision, tmp.path());
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("build the login feature", &control, &goals)
+        .await
+        .expect("delegation loop runs");
+
+    // A session launched and is reported back.
+    assert_eq!(outcome.launched.len(), 1, "exactly one session launched");
+
+    // The launch recorded the goal id (so it links).
+    let launches = mock.launches();
+    assert_eq!(launches.len(), 1);
+    assert_eq!(
+        launches[0].1.goal_id.as_deref(),
+        Some(outcome.goal_id.as_str())
+    );
+
+    // The goal carries the session link.
+    let store = goals.lock().await;
+    let goal = store.get(&outcome.goal_id).expect("goal exists");
+    assert_eq!(goal.sessions.len(), 1, "session linked to goal");
+    assert_eq!(goal.sessions[0].session_id, outcome.launched[0]);
+    assert_eq!(goal.status, GoalStatus::InProgress);
+}
+
+/// Why: after LAUNCH the task must be DELIVERED to the session (#1299) — spawn
+/// does not auto-inject the prompt, so without delivery the session sits idle.
+/// What: runs the loop and asserts the mock session RECEIVED the task via `send`.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_delivers_task_to_session() {
+    let tmp = TempDir::new().unwrap();
+    let decision =
+        r#"{"action":"delegate","tasks":[{"workdir":"/r","prompt":"implement the parser"}]}"#;
+    let agent = agent_with(decision, tmp.path());
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("write a parser", &control, &goals)
+        .await
+        .expect("loop runs");
+
+    let sends = mock.sends();
+    assert_eq!(sends.len(), 1, "task delivered exactly once (#1299)");
+    assert_eq!(
+        sends[0].0, outcome.launched[0],
+        "delivered to launched session"
+    );
+    assert_eq!(
+        sends[0].1, "implement the parser",
+        "the task prompt was delivered"
+    );
+}
+
+/// Why: observation must update the link state and the goal progress. With a
+/// running session and NO evidence, the link is `Running` and progress stays 0%.
+/// What: default mock (running, no evidence); asserts link Running + progress 0
+/// + goal not done.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_observes_and_updates_progress() {
+    let tmp = TempDir::new().unwrap();
+    let decision = r#"{"action":"delegate","tasks":[{"workdir":"/r","prompt":"task"}]}"#;
+    let agent = agent_with(decision, tmp.path());
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("do the thing", &control, &goals)
+        .await
+        .expect("loop runs");
+
+    assert!(!outcome.goal_done, "no evidence ⇒ goal not done");
+    let store = goals.lock().await;
+    let goal = store.get(&outcome.goal_id).expect("goal");
+    use crate::core::sm::goals::SessionTaskState;
+    assert_eq!(goal.sessions[0].state, SessionTaskState::Running);
+    assert_eq!(goal.progress, 0, "no verified tasks ⇒ 0% progress");
+}
+
+/// Why: THE verification gate (§3.5) — a goal CANNOT reach `Done` without observed
+/// evidence. With a running, evidence-free session, the gated close must be refused
+/// and the goal left open.
+/// What: default mock (no evidence); asserts `goal_done == false` and the goal
+/// status is NOT `Done`.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_gate_blocks_without_evidence() {
+    let tmp = TempDir::new().unwrap();
+    let decision = r#"{"action":"delegate","tasks":[{"workdir":"/r","prompt":"task"}]}"#;
+    let agent = agent_with(decision, tmp.path());
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("ship it", &control, &goals)
+        .await
+        .expect("loop runs");
+
+    assert!(!outcome.goal_done, "gate blocks Done without evidence");
+    let store = goals.lock().await;
+    assert_ne!(
+        store.get(&outcome.goal_id).unwrap().status,
+        GoalStatus::Done,
+        "goal must not be Done"
+    );
+    // And the honest report says so (no forbidden 'should be done' phrasing).
+    let lower = outcome.reply.to_ascii_lowercase();
+    assert!(!lower.contains("should be done"));
+    assert!(!lower.contains("looks complete"));
+}
+
+/// Why: once observed evidence is present AND all tasks verified, the gated close
+/// SUCCEEDS — the goal reaches `Done`. This is the positive end of the gate.
+/// What: scripts a session whose pane carries a PR URL; asserts the link is
+/// `Verified` with that evidence, progress is 100, and the goal closed Done.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_verifies_and_closes_with_evidence() {
+    let tmp = TempDir::new().unwrap();
+    let decision = r#"{"action":"delegate","tasks":[{"workdir":"/r","prompt":"open a PR"}]}"#;
+    let agent = agent_with(decision, tmp.path());
+    let evidence = "Opened PR https://github.com/acme/repo/pull/9 ready";
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::with_evidence(evidence));
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("open the PR", &control, &goals)
+        .await
+        .expect("loop runs");
+
+    assert!(outcome.goal_done, "evidence present ⇒ gate passes ⇒ Done");
+    let store = goals.lock().await;
+    let goal = store.get(&outcome.goal_id).expect("goal");
+    use crate::core::sm::goals::SessionTaskState;
+    assert_eq!(goal.sessions[0].state, SessionTaskState::Verified);
+    assert!(
+        goal.sessions[0]
+            .evidence
+            .as_deref()
+            .unwrap()
+            .contains("pull/9"),
+        "evidence captured into the link"
+    );
+    assert_eq!(goal.progress, 100);
+    assert_eq!(goal.status, GoalStatus::Done);
+    assert!(outcome.reply.to_ascii_lowercase().contains("done"));
+}
+
+/// Why: the PROHIBITION guard (§3.2 SP1–SP5) — a direct-work attempt must be
+/// REFUSED and redirected to "launch a session", NOT performed. Proves the SM
+/// does not do work itself even when its decision says to.
+/// What: scripts a `do_work` decision; asserts NO session launched, the reply
+/// redirects to launching a session, and the goal is not done.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_refuses_direct_work_and_redirects() {
+    let tmp = TempDir::new().unwrap();
+    let decision = r#"{"action":"do_work","summary":"I will edit main.rs myself"}"#;
+    let agent = agent_with(decision, tmp.path());
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("just add the flag", &control, &goals)
+        .await
+        .expect("loop runs");
+
+    // No work was done directly — nothing launched, and the reply redirects.
+    assert!(
+        outcome.launched.is_empty(),
+        "direct work must NOT launch arbitrary work"
+    );
+    assert!(
+        mock.launches().is_empty(),
+        "control was never driven to do the work"
+    );
+    assert!(mock.sends().is_empty(), "no task delivered (no session)");
+    assert!(!outcome.goal_done);
+    let lower = outcome.reply.to_ascii_lowercase();
+    assert!(
+        lower.contains("launch a session"),
+        "reply redirects to launching a session: {}",
+        outcome.reply
+    );
+    assert!(lower.contains("sp1-sp5"), "reply names the prohibition");
+    // The refused goal is Blocked (awaiting operator re-issue), not an orphan Pending.
+    let store = goals.lock().await;
+    assert_eq!(
+        store.get(&outcome.goal_id).unwrap().status,
+        GoalStatus::Blocked,
+        "a refused direct-work goal is Blocked, not left Pending"
+    );
+}
+
+/// Why: a `respond` decision is an Allowlist-1 operator-facing reply (triage /
+/// clarification) — the SM talks, launches nothing, goal stays Pending.
+/// What: scripts a respond decision; asserts the message is returned and nothing
+/// launched.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_respond_talks_to_operator() {
+    let tmp = TempDir::new().unwrap();
+    let decision = r#"{"action":"respond","message":"Which repository should I target?"}"#;
+    let agent = agent_with(decision, tmp.path());
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("do something vague", &control, &goals)
+        .await
+        .expect("loop runs");
+
+    assert_eq!(outcome.reply, "Which repository should I target?");
+    assert!(outcome.launched.is_empty());
+    let store = goals.lock().await;
+    assert_eq!(
+        store.get(&outcome.goal_id).unwrap().status,
+        GoalStatus::Pending
+    );
+}
+
+/// Why: a goal may fan out to several sessions (§3.4); each must be launched,
+/// linked, and delivered.
+/// What: scripts a two-task delegate; asserts two sessions launched + two links +
+/// two deliveries.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_fans_out_to_multiple_sessions() {
+    let tmp = TempDir::new().unwrap();
+    let decision = r#"{"action":"delegate","tasks":[
+        {"workdir":"/r","prompt":"backend"},
+        {"workdir":"/r","prompt":"frontend"}]}"#;
+    let agent = agent_with(decision, tmp.path());
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+    let goals = goal_store(&tmp);
+
+    let outcome = agent
+        .delegate_goal("build the app", &control, &goals)
+        .await
+        .expect("loop runs");
+
+    assert_eq!(outcome.launched.len(), 2);
+    assert_eq!(mock.launches().len(), 2);
+    assert_eq!(mock.sends().len(), 2, "both tasks delivered");
+    let store = goals.lock().await;
+    assert_eq!(store.get(&outcome.goal_id).unwrap().sessions.len(), 2);
+}
+
+/// Why: with no inference provider the DECOMPOSE reasoning cannot run; the loop
+/// must degrade gracefully (a typed error), never panic.
+/// What: builds an agent over a degraded resolver and asserts `Degraded`.
+/// Test: this is the test.
+#[tokio::test]
+async fn delegate_degraded_without_provider() {
+    use crate::core::sm::agent::DelegationError;
+    let tmp = TempDir::new().unwrap();
+    let resolver = Arc::new(MockResolver::degraded());
+    #[cfg(feature = "sm-memory")]
+    let agent = SessionManagerAgent::with_runtime(
+        enabled_config(),
+        resolver,
+        tmp.path().to_path_buf(),
+        None,
+    );
+    #[cfg(not(feature = "sm-memory"))]
+    let agent =
+        SessionManagerAgent::with_runtime(enabled_config(), resolver, tmp.path().to_path_buf());
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let goals = goal_store(&tmp);
+
+    let err = agent
+        .delegate_goal("anything", &control, &goals)
+        .await
+        .expect_err("degraded loop errors gracefully");
+    assert!(matches!(err, DelegationError::Degraded(_)));
+}

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/delegate_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/delegate_tests.rs
@@ -202,6 +202,11 @@ async fn delegate_observes_and_updates_progress() {
         .expect("loop runs");
 
     assert!(!outcome.goal_done, "no evidence ⇒ goal not done");
+    // `goal_status` disambiguates the false `goal_done`: this goal is in flight.
+    assert_eq!(
+        outcome.goal_status, "InProgress",
+        "an observed-but-unverified goal is InProgress, not blocked/failed"
+    );
     let store = goals.lock().await;
     let goal = store.get(&outcome.goal_id).expect("goal");
     use crate::core::sm::goals::SessionTaskState;
@@ -275,6 +280,7 @@ async fn delegate_verifies_and_closes_with_evidence() {
     );
     assert_eq!(goal.progress, 100);
     assert_eq!(goal.status, GoalStatus::Done);
+    assert_eq!(outcome.goal_status, "Done", "closed goal reports Done");
     assert!(outcome.reply.to_ascii_lowercase().contains("done"));
 }
 
@@ -316,6 +322,10 @@ async fn delegate_refuses_direct_work_and_redirects() {
         outcome.reply
     );
     assert!(lower.contains("sp1-sp5"), "reply names the prohibition");
+    assert_eq!(
+        outcome.goal_status, "Blocked",
+        "a refused direct-work goal reports Blocked in goal_status"
+    );
     // The refused goal is Blocked (awaiting operator re-issue), not an orphan Pending.
     let store = goals.lock().await;
     assert_eq!(

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/mock_control.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/mock_control.rs
@@ -1,0 +1,121 @@
+//! A scriptable mock [`SessionControl`] for the SM-8 delegation-loop tests.
+//!
+//! Why: the delegation loop must be exercised HERMETICALLY — no tmux, no real
+//! spawn, no network. The loop depends on `SessionControl` (Dependency Inversion)
+//! exactly so a test can inject a deterministic mock that (a) records every
+//! `launch`/`send` so the test can assert the loop launched + LINKED + DELIVERED
+//! the task (#1299), and (b) returns a SCRIPTED `get` response so OBSERVE/VERIFY
+//! see a controlled pane (with or without evidence). This is that mock.
+//! What: [`MockSessionControl`] hands out incrementing session ids on `launch`,
+//! records `(session_id, params)` launches and `(session_id, text)` sends in a
+//! shared log the test reads, and returns a configurable `get` body (default: a
+//! `running` pane with no evidence; settable to a pane carrying evidence). All
+//! verbs are deterministic and panic-free.
+//! Test: drives `delegate_tests.rs`.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::core::sm::control::{LaunchParams, SessionControl, SessionControlError};
+
+/// A scriptable, recording mock [`SessionControl`] (test-only).
+///
+/// Why: see the module docs — records launches/sends and returns a scripted
+/// `get` so the loop is fully assertable with no real session.
+/// What: a launch counter (for deterministic ids), a shared launch log, a shared
+/// send log, and the JSON the next `get` returns (the observed pane).
+/// Test: `delegate_tests.rs`.
+pub struct MockSessionControl {
+    /// Monotonic counter minting `s-1`, `s-2`, … session ids on launch.
+    next_id: AtomicUsize,
+    /// Recorded launches: `(session_id, LaunchParams)`.
+    launches: Mutex<Vec<(String, LaunchParams)>>,
+    /// Recorded task deliveries: `(session_id, text)` from `send` (#1299).
+    sends: Mutex<Vec<(String, String)>>,
+    /// The pane/record JSON each `get` returns (the OBSERVE input). Shared so a
+    /// test can script evidence (or none).
+    get_body: Mutex<Value>,
+}
+
+impl Default for MockSessionControl {
+    fn default() -> Self {
+        Self {
+            next_id: AtomicUsize::new(0),
+            launches: Mutex::new(Vec::new()),
+            sends: Mutex::new(Vec::new()),
+            // Default observation: a running session with NO evidence — the gate
+            // stays closed unless a test scripts evidence.
+            get_body: Mutex::new(json!({ "session": { "state": "running" } })),
+        }
+    }
+}
+
+impl MockSessionControl {
+    /// A mock whose `get` returns a pane CARRYING the given evidence text.
+    ///
+    /// Why: the verification-gate tests need a session that observes as `Verified`
+    /// (a PR URL / test-pass output in the pane). This builds a mock that scripts
+    /// that evidence so OBSERVE captures it.
+    /// What: returns a mock whose `get` body embeds `evidence` in a pane field.
+    /// Test: `delegate_tests.rs::delegate_verifies_and_closes_with_evidence`.
+    pub fn with_evidence(evidence: &str) -> Self {
+        let mock = Self::default();
+        *mock.get_body.lock().expect("lock") =
+            json!({ "session": { "state": "running", "pane": evidence } });
+        mock
+    }
+
+    /// The recorded launches `(session_id, params)` (test read).
+    pub fn launches(&self) -> Vec<(String, LaunchParams)> {
+        self.launches.lock().expect("lock").clone()
+    }
+
+    /// The recorded task deliveries `(session_id, text)` (test read, #1299).
+    pub fn sends(&self) -> Vec<(String, String)> {
+        self.sends.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl SessionControl for MockSessionControl {
+    async fn launch(&self, params: LaunchParams) -> Result<Value, SessionControlError> {
+        let n = self.next_id.fetch_add(1, Ordering::SeqCst) + 1;
+        let session_id = format!("s-{n}");
+        self.launches
+            .lock()
+            .expect("lock")
+            .push((session_id.clone(), params));
+        Ok(json!({ "session_id": session_id }))
+    }
+
+    async fn list(&self) -> Result<Value, SessionControlError> {
+        Ok(json!({ "sessions": [] }))
+    }
+
+    async fn get(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(self.get_body.lock().expect("lock").clone())
+    }
+
+    async fn send(&self, session_id: &str, text: &str) -> Result<Value, SessionControlError> {
+        self.sends
+            .lock()
+            .expect("lock")
+            .push((session_id.to_string(), text.to_string()));
+        Ok(json!({ "ok": true }))
+    }
+
+    async fn stop(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+
+    async fn resume(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+
+    async fn kill(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
@@ -1,0 +1,560 @@
+//! The 6-phase SM↔session delegation loop (DOC-14 §3.4) — SM-8 capstone.
+//!
+//! Why: this is the mechanism that brings the Session Manager to life. SM-1..SM-7
+//! built the parts (config, multi-provider inference, system prompt, memory,
+//! rolling context, goal store, chat turn, stdio surface); SM-8 wires them into
+//! the spec's prime directive (§3.1): the SM does NO work itself — it turns an
+//! operator goal into a tracked [`Goal`](crate::core::sm::Goal), DECOMPOSEs it
+//! into session-sized tasks, LAUNCHes one session per task, OBSERVEs them,
+//! VERIFIes with observed evidence (the §3.5 BLOCKING gate), and REPORTs +
+//! PERSISTs. The only action surfaces the loop touches are session control
+//! ([`SessionControl`]), goals ([`SmGoalStore`]), and memory — there are NO
+//! edit/read-source/build/test tools, so the prohibitions (§3.2 SP1–SP7) are
+//! enforced STRUCTURALLY; on top of that, a direct-work *attempt* by the model is
+//! refused and redirected (the SP guard, [`verify::redirect_direct_work`]).
+//!
+//! DECISION PROTOCOL (NORMATIVE for this impl): the SM provider is text-only
+//! (`complete()`, no tool/function calls — see `providers/mod.rs`), so the loop
+//! uses a STRUCTURED-TEXT (ReAct-style) protocol: the SM emits ONE JSON action
+//! block at DECOMPOSE which [`decision::parse_decision`] turns into a typed
+//! [`SmDecision`]; the engine then mechanically executes launch→observe→verify.
+//! Observation/verification need NO LLM (deterministic pane heuristics, §3.4),
+//! keeping the whole loop unit-testable with a mock provider + mock control.
+//!
+//! CONCURRENCY (#1309): this loop drives the first code that fans out to multiple
+//! sessions and makes repeated goal-store writes. Goal-store mutations are already
+//! ATOMIC and serialized — every mutator goes through the single
+//! `Arc<Mutex<SmGoalStore>>` and SM-6 snapshots+rolls-back on a failed persist —
+//! so the loop introduces NO new last-write-wins race in the goal store. The loop
+//! does NOT touch the per-`conv_id` rolling-context engine (that path stays in
+//! `chat`), so it does not widen the #1309 context-engine race either. TODO(#1309):
+//! if `delegate_goal` ever becomes reachable concurrently for the SAME goal (e.g.
+//! re-driven by two operator turns), add a per-goal serialization seam here; today
+//! each call creates a fresh goal at INTAKE, so concurrent calls operate on
+//! disjoint goals and cannot interleave.
+//!
+//! What: [`DelegationOutcome`] (the loop result), [`DelegationError`] (typed
+//! failures), and the `impl` block adding
+//! [`SessionManagerAgent::delegate_goal`]. Split into `decision` (the action
+//! protocol), `observe` (pane interpretation + evidence), and `verify` (the gate
+//! plus the SP guard) to respect the 500-SLOC cap.
+//! Test: `delegate_tests.rs` — launch+link, observe→progress, the verification
+//! gate (no Done without evidence), the prohibition redirect, and task delivery
+//! (#1299).
+
+mod decision;
+mod observe;
+mod verify;
+
+#[cfg(test)]
+pub mod mock_control;
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::core::sm::control::{LaunchParams, SessionControl};
+use crate::core::sm::goals::{GoalStatus, SessionLink, SessionUpdate, SmGoalError, SmGoalStore};
+use crate::core::sm::providers::{LlmRequest, SmModelTier};
+
+use super::SessionManagerAgent;
+
+pub use decision::{SmDecision, TaskSpec, parse_decision};
+use observe::interpret_session;
+use verify::redirect_direct_work;
+
+/// Generation cap for the SM's DECOMPOSE decision reply.
+///
+/// Why: the decompose step emits a compact JSON action block, not prose; a tight
+/// ceiling keeps the turn cheap and predictable (§5.4).
+/// What: passed as [`LlmRequest::max_tokens`] for the decompose call.
+/// Test: `delegate_tests.rs` asserts the mock saw a bounded request.
+const DECOMPOSE_MAX_TOKENS: u32 = 2_048;
+
+/// The result of running the delegation loop for one operator goal (§3.4).
+///
+/// Why: the caller (the stdio/chat surface) needs the operator-facing reply, the
+/// tracked goal id (so follow-ups can reference it), and an auditable record of
+/// what the loop did — which sessions launched, and whether the goal closed
+/// through the verification gate. Returning all of it as one value keeps the call
+/// site terse and the behaviour assertable.
+/// What: `reply` is the status-first operator message; `goal_id` is the tracked
+/// goal; `launched` are the session ids spawned; `goal_done` is whether the
+/// verification gate passed and the goal closed.
+/// Test: `delegate_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegationOutcome {
+    /// The operator-facing, status-first reply (§3.6).
+    pub reply: String,
+    /// The tracked goal this loop created/advanced.
+    pub goal_id: String,
+    /// The session ids launched for this goal (one per decomposed task).
+    pub launched: Vec<String>,
+    /// Whether the verification gate passed and the goal reached `Done` (§3.5).
+    pub goal_done: bool,
+}
+
+/// A failure surfaced by [`SessionManagerAgent::delegate_goal`].
+///
+/// Why: the caller must distinguish a graceful *degraded* state (no provider for
+/// the decompose reasoning — §5.3) from a goal-store failure or a session-control
+/// failure, so it can render each appropriately and stay panic-free.
+/// What: [`Degraded`](DelegationError::Degraded) — no inference for decompose;
+/// [`Goal`](DelegationError::Goal) — a goal-store error (create/link/update/gate);
+/// [`Control`](DelegationError::Control) — a session-control error during launch.
+/// Test: `delegate_tests.rs::delegate_degraded_without_provider`.
+#[derive(Debug, thiserror::Error)]
+pub enum DelegationError {
+    /// No inference provider resolved for the DECOMPOSE reasoning (graceful).
+    #[error("{0}")]
+    Degraded(String),
+
+    /// A goal-store operation failed (create/link/update/close gate). This is the
+    /// only fatal class: the goal store is the SM's source of truth, so a create
+    /// failure (no tracked goal) cannot be recovered. Session-control failures, by
+    /// contrast, are best-effort per task (a launch/deliver failure for one task is
+    /// noted and the fan-out continues — see [`SessionManagerAgent::launch_tasks`]).
+    #[error("session-manager goal store failed: {0}")]
+    Goal(#[from] SmGoalError),
+}
+
+impl SessionManagerAgent {
+    /// Run the 6-phase delegation loop for one operator goal (§3.4) — SM-8.
+    ///
+    /// Why: the capstone — the single entry the stdio/chat surface calls to turn
+    /// operator intent into delegated, verified work. It enforces the prime
+    /// directive (§3.1): the SM delegates everything; the only side effects are
+    /// launching sessions, tracking goals, and writing memory. The verification
+    /// gate (§3.5) and the prohibition guard (§3.2) are applied here.
+    /// What: (1) INTAKE — create a tracked goal from `message` (recall is folded
+    /// into the decompose prompt, best-effort); (2) DECOMPOSE — assemble the SM
+    /// system prompt + the decision instructions + the goal, call the
+    /// orchestration-tier provider, and parse a typed [`SmDecision`]; a
+    /// [`SmDecision::DoWork`] is REFUSED and redirected (the SP guard), a
+    /// [`SmDecision::Respond`] returns the operator message with the goal still
+    /// `Pending`; (3) LAUNCH — for each launchable [`TaskSpec`] spawn a session via
+    /// `control`, link it to the goal, and DELIVER the task prompt via
+    /// `control.send` (#1299); (4) OBSERVE — poll each session and update its link
+    /// state + the goal progress; (5) VERIFY — mark a link `Verified` ONLY with
+    /// observed evidence, then attempt the gated close (§3.5); (6) REPORT —
+    /// summarize, status-first. A no-provider decompose returns
+    /// [`DelegationError::Degraded`].
+    ///
+    /// SCOPE NOTE (single-pass observation): SM-8 delivers the loop MECHANISM with
+    /// ONE observation pass — it polls each launched session once (phase 4) and
+    /// applies the gate (phase 5) synchronously. A goal therefore reaches `Done` in
+    /// this call only if its session(s) already carry evidence at observe time
+    /// (e.g. a fast/mocked session, or a re-driven goal). Long-running sessions
+    /// stay `InProgress` and are re-observed on a later drive. A continuous
+    /// poll-until-terminal observer (and a resume path that re-attaches to an open
+    /// goal instead of creating a new one) is deliberate follow-up — the gate and
+    /// evidence wiring here are what make that future loop correct.
+    /// Test: `delegate_tests.rs` — the full loop, the gate, the SP redirect, and
+    /// task delivery.
+    pub async fn delegate_goal(
+        &self,
+        message: &str,
+        control: &Arc<dyn SessionControl>,
+        goals: &Arc<Mutex<SmGoalStore>>,
+    ) -> Result<DelegationOutcome, DelegationError> {
+        // ── (1) INTAKE — create the tracked goal. ───────────────────────────────
+        let goal_id = {
+            let mut store = goals.lock().await;
+            store.create(message.to_string(), Vec::new()).await?.id
+        };
+
+        // ── (2) DECOMPOSE — ask the SM for a typed decision. ────────────────────
+        let decision = self.decompose(message, &goal_id, goals).await?;
+        let tasks = match decision {
+            SmDecision::Delegate { tasks } => tasks,
+            SmDecision::Respond { message } => {
+                // Allowlist 1: the SM is talking to the operator; the goal stays
+                // Pending with no fan-out (nothing delegated this turn).
+                return Ok(DelegationOutcome {
+                    reply: message,
+                    goal_id,
+                    launched: Vec::new(),
+                    goal_done: false,
+                });
+            }
+            SmDecision::DoWork { summary } => {
+                // §3.2 SP guard: a direct-work attempt is REFUSED and redirected
+                // to "launch a session". Record the refusal as a goal note so the
+                // attempt is auditable, mark the goal Blocked (awaiting the operator
+                // to re-issue it as a delegation — it is NOT progressing on its own,
+                // so leaving it Pending forever would orphan it), then return the
+                // redirect message.
+                let reply = redirect_direct_work(&summary);
+                let mut store = goals.lock().await;
+                let _ = store.note(&goal_id, reply.clone()).await;
+                let _ = store.set_status(&goal_id, GoalStatus::Blocked).await;
+                return Ok(DelegationOutcome {
+                    reply,
+                    goal_id,
+                    launched: Vec::new(),
+                    goal_done: false,
+                });
+            }
+        };
+
+        // ── (3) LAUNCH — one session per launchable task; link + DELIVER (#1299).
+        let launched = self.launch_tasks(&tasks, &goal_id, control, goals).await;
+        if launched.is_empty() {
+            let mut store = goals.lock().await;
+            let _ = store
+                .note(
+                    &goal_id,
+                    "decompose produced no launchable task".to_string(),
+                )
+                .await;
+            return Ok(DelegationOutcome {
+                reply: "No launchable task was produced for this goal; nothing delegated."
+                    .to_string(),
+                goal_id,
+                launched,
+                goal_done: false,
+            });
+        }
+
+        // ── (4)+(5) OBSERVE + VERIFY — poll, update progress, apply the gate. ───
+        self.observe_and_verify(&launched, &goal_id, control, goals)
+            .await?;
+
+        // Attempt the BLOCKING gated close (§3.5): succeeds ONLY when every linked
+        // task is Verified (with evidence). A VerificationGate rejection is NOT an
+        // error — the goal simply stays open and the report says so. But a real
+        // persistence failure (palace/cache) must NOT be silently conflated with a
+        // benign gate rejection: it is logged so the infra failure is visible, while
+        // the loop still reports the goal as not-done (it could not be durably closed).
+        let goal_done = {
+            let mut store = goals.lock().await;
+            match store.close(&goal_id).await {
+                Ok(_) => true,
+                Err(SmGoalError::VerificationGate { .. }) => false,
+                Err(e) => {
+                    tracing::warn!(%goal_id, "delegate: gated close failed (not a gate rejection): {e}");
+                    false
+                }
+            }
+        };
+
+        // ── (6) REPORT — status-first summary for the operator. ─────────────────
+        let reply = self.report(&goal_id, &launched, goal_done, goals).await;
+        Ok(DelegationOutcome {
+            reply,
+            goal_id,
+            launched,
+            goal_done,
+        })
+    }
+
+    /// DECOMPOSE: assemble the decision prompt, call the provider, parse a decision.
+    ///
+    /// Why: phase 2 is the only LLM call in the loop; isolating it keeps
+    /// `delegate_goal` readable and the prompt assembly auditable. The SM is
+    /// instructed to emit ONE JSON action block (the structured-text protocol);
+    /// recall (SM-4) is folded in best-effort to inform decomposition.
+    /// What: resolves the orchestration tier (degraded → [`DelegationError::Degraded`]),
+    /// builds the system prompt + decision instructions + recall + the goal, calls
+    /// `complete`, and returns the parsed [`SmDecision`]. The decompose round is
+    /// NOT recorded into the rolling-context engine here (the loop is a single
+    /// goal-scoped action, not a conversational turn — context recording stays in
+    /// `chat`).
+    /// Test: `delegate_tests.rs` (every decision path), `delegate_degraded_*`.
+    async fn decompose(
+        &self,
+        message: &str,
+        goal_id: &str,
+        goals: &Arc<Mutex<SmGoalStore>>,
+    ) -> Result<SmDecision, DelegationError> {
+        let runtime = self
+            .runtime_ref()
+            .ok_or_else(|| DelegationError::Degraded(super::chat::degraded_notice()))?;
+
+        let resolved = runtime
+            .resolver
+            .resolve(&self.config.inference, SmModelTier::Orchestration)
+            .await
+            .map_err(|e| {
+                if e.is_degraded() {
+                    DelegationError::Degraded(super::chat::degraded_notice())
+                } else {
+                    DelegationError::Degraded(e.to_string())
+                }
+            })?;
+
+        let recall = self.delegate_recall(runtime, message).await;
+        let system = decision_system_prompt();
+        let user = decision_user_prompt(message, goal_id, recall.as_deref());
+
+        let req = LlmRequest {
+            model: resolved.model.clone(),
+            system,
+            messages: vec![crate::core::sm::providers::ChatMessage {
+                role: "user".to_string(),
+                content: user,
+            }],
+            temperature: self.config.inference.temperature,
+            max_tokens: DECOMPOSE_MAX_TOKENS,
+        };
+        let response = resolved
+            .provider
+            .complete(req)
+            .await
+            .map_err(|e| DelegationError::Degraded(e.to_string()))?;
+
+        let decision = parse_decision(&response.text);
+        // Record the decision as a goal note for auditability (best-effort).
+        {
+            let mut store = goals.lock().await;
+            let _ = store
+                .note(goal_id, format!("decompose decision: {decision:?}"))
+                .await;
+        }
+        Ok(decision)
+    }
+
+    /// LAUNCH: spawn one session per launchable task, link it, and DELIVER it.
+    ///
+    /// Why: phase 3 turns each [`TaskSpec`] into exactly one launched, linked,
+    /// and TASK-DELIVERED session. Delivery (#1299) is explicit: `tm ticket`
+    /// spawn does NOT auto-inject the prompt into the pane, so the SM must
+    /// `sessions.send` the task after launch or the session sits idle. We do that
+    /// here so a launched session actually receives its work.
+    /// What: for each launchable task, calls `control.launch`; a launch FAILURE is
+    /// best-effort (noted on the goal, the fan-out continues with the remaining
+    /// tasks — aborting would orphan sessions already launched). On success it
+    /// extracts the `session_id` (skipping with a note + warning if the control
+    /// surface returned no id), links it to the goal via `store.link` (best-effort —
+    /// a link failure is noted, never fatal), then `control.send`s the task prompt
+    /// to the session (best-effort delivery — a send failure is noted). Returns the
+    /// successfully launched session ids (infallible — no fatal control error).
+    /// Test: `delegate_tests.rs::delegate_launches_and_links`,
+    /// `delegate_delivers_task_to_session`.
+    async fn launch_tasks(
+        &self,
+        tasks: &[TaskSpec],
+        goal_id: &str,
+        control: &Arc<dyn SessionControl>,
+        goals: &Arc<Mutex<SmGoalStore>>,
+    ) -> Vec<String> {
+        let mut launched = Vec::new();
+        for task in tasks.iter().filter(|t| t.is_launchable()) {
+            let params = LaunchParams {
+                workdir: task.workdir.clone(),
+                model: task.model.clone(),
+                prompt: Some(task.prompt.clone()),
+                goal_id: Some(goal_id.to_string()),
+            };
+            // Per-task best-effort: a single launch failure must NOT abort the whole
+            // fan-out (which would orphan sessions already launched for earlier
+            // tasks). Record it as a goal note and continue with the remaining tasks.
+            let result = match control.launch(params).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(%goal_id, "delegate: launch failed for a task: {e}");
+                    let mut store = goals.lock().await;
+                    let _ = store
+                        .note(goal_id, format!("launch failed for a task: {e}"))
+                        .await;
+                    continue;
+                }
+            };
+            let session_id = result
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if session_id.is_empty() {
+                // The control surface returned Ok but no string session id. We cannot
+                // link/deliver/track without one; warn so an out-of-contract impl
+                // (or a spawned-but-unidentified session) is visible rather than
+                // silently dropped.
+                tracing::warn!(
+                    %goal_id,
+                    "delegate: launch returned no session_id; skipping link+delivery for this task"
+                );
+                let mut store = goals.lock().await;
+                let _ = store
+                    .note(goal_id, "launch returned no session_id".to_string())
+                    .await;
+                continue;
+            }
+
+            // Link the session to the goal (§9.3). Best-effort: a link failure must
+            // not undo a successful launch (it is recorded as a note instead).
+            {
+                let mut store = goals.lock().await;
+                if let Err(e) = store
+                    .link(goal_id, SessionLink::launched(&session_id, &task.prompt))
+                    .await
+                {
+                    tracing::warn!(%session_id, %goal_id, "delegate: goal link failed: {e}");
+                }
+            }
+
+            // DELIVER the task to the session pane (#1299). Spawn does not
+            // auto-inject the prompt, so without this the session sits idle.
+            if let Err(e) = control.send(&session_id, &task.prompt).await {
+                tracing::warn!(%session_id, "delegate: task delivery failed: {e}");
+                let mut store = goals.lock().await;
+                let _ = store
+                    .note(
+                        goal_id,
+                        format!("task delivery to {session_id} failed: {e}"),
+                    )
+                    .await;
+            }
+
+            launched.push(session_id);
+        }
+        launched
+    }
+
+    /// OBSERVE + VERIFY: poll each session, update its link state + goal progress.
+    ///
+    /// Why: phases 4–5 interpret each launched session's pane (deterministically,
+    /// no LLM) and fold the result into the goal store so progress is DERIVED from
+    /// observed state and a link reaches `Verified` ONLY with evidence (§3.5).
+    /// What: for each session id, calls `control.get`, interprets it via
+    /// [`interpret_session`], and applies a [`SessionUpdate`] (state + evidence)
+    /// through `store.update` — which recomputes goal progress. A `get` failure or
+    /// an update failure is noted (best-effort) but does not abort the whole sweep.
+    /// Test: `delegate_tests.rs::delegate_observes_and_updates_progress`,
+    /// `delegate_gate_blocks_without_evidence`.
+    async fn observe_and_verify(
+        &self,
+        launched: &[String],
+        goal_id: &str,
+        control: &Arc<dyn SessionControl>,
+        goals: &Arc<Mutex<SmGoalStore>>,
+    ) -> Result<(), DelegationError> {
+        for session_id in launched {
+            let observed = match control.get(session_id).await {
+                Ok(json) => interpret_session(&json),
+                Err(e) => {
+                    let mut store = goals.lock().await;
+                    let _ = store
+                        .note(goal_id, format!("observe {session_id} failed: {e}"))
+                        .await;
+                    continue;
+                }
+            };
+            let update = SessionUpdate {
+                session_id: session_id.clone(),
+                state: Some(observed.state),
+                evidence: observed.evidence.clone(),
+                note: observed
+                    .evidence
+                    .as_ref()
+                    .map(|e| format!("verified {session_id}: {e}")),
+            };
+            let mut store = goals.lock().await;
+            if let Err(e) = store.update(goal_id, update).await {
+                tracing::warn!(%session_id, %goal_id, "delegate: goal update failed: {e}");
+            }
+        }
+        Ok(())
+    }
+
+    /// REPORT: build the status-first operator summary for the goal (§3.6).
+    ///
+    /// Why: phase 6 reports the verified outcome to the operator — status-first,
+    /// no forbidden "should be done" phrasing (§3.5). The summary states the goal,
+    /// the launched session count, and whether the gate passed WITH the count of
+    /// verified links, so the operator sees evidence-backed status, not optimism.
+    /// What: reads the goal back from the store and formats a one-paragraph,
+    /// status-first summary; on a missing goal (should not happen) returns a terse
+    /// fallback.
+    /// Test: `delegate_tests.rs` asserts the report mentions the goal + status.
+    async fn report(
+        &self,
+        goal_id: &str,
+        launched: &[String],
+        goal_done: bool,
+        goals: &Arc<Mutex<SmGoalStore>>,
+    ) -> String {
+        let store = goals.lock().await;
+        let Some(goal) = store.get(goal_id) else {
+            return format!("Goal {goal_id}: launched {} session(s).", launched.len());
+        };
+        let verified = goal
+            .sessions
+            .iter()
+            .filter(|s| s.state.is_verified())
+            .count();
+        let total = goal.sessions.len();
+        if goal_done {
+            format!(
+                "Goal {goal_id} DONE: {verified}/{total} task(s) verified with observed evidence. \
+                 Launched {} session(s).",
+                launched.len()
+            )
+        } else {
+            format!(
+                "Goal {goal_id} in progress: {verified}/{total} task(s) verified \
+                 (not yet done — verification evidence required for the rest). \
+                 Launched {} session(s).",
+                launched.len()
+            )
+        }
+    }
+}
+
+/// The SM system prompt fragment that constrains the decompose DECISION.
+///
+/// Why: the structured-text protocol needs the model to emit EXACTLY one JSON
+/// action block. This fragment (appended to the SM identity/prohibitions prompt)
+/// pins the action schema so [`parse_decision`] can rely on it, and reiterates the
+/// prohibition (do NOT do the work — delegate) so the model picks `delegate`, not
+/// `do_work`, for real work.
+/// What: returns the SM identity/prohibitions/workflow prompt
+/// ([`resolve_sm_prompt_default`](crate::core::sm::prompt::resolve_sm_prompt_default))
+/// followed by the decision-schema instructions.
+/// Test: `delegate_tests.rs` asserts the mock saw the schema instructions.
+fn decision_system_prompt() -> String {
+    let base = crate::core::sm::prompt::resolve_sm_prompt_default();
+    format!("{base}\n\n---\n\n{DECISION_INSTRUCTIONS}")
+}
+
+/// The decision-schema instructions appended to the SM system prompt.
+const DECISION_INSTRUCTIONS: &str = "\
+# DECISION (machine-read)
+
+Reply with EXACTLY ONE JSON object (optionally inside a ```json fence) and no
+other commands. Choose ONE action:
+
+- To delegate real work (the default — you have no hands of your own):
+  {\"action\":\"delegate\",\"tasks\":[{\"workdir\":\"<repo-or-dir>\",\"prompt\":\"<task>\",\"model\":\"<optional>\"}]}
+  One task = one launched session. Split a goal into session-sized tasks.
+
+- To talk to the operator (ask a question / give status — Allowlist 1):
+  {\"action\":\"respond\",\"message\":\"<operator-facing text>\"}
+
+You MUST NOT do the work yourself (SP1-SP5): never edit files, read project
+source, run builds/tests, or answer a work request from your own knowledge.
+If you are tempted to do the work directly, emit a delegate action instead.";
+
+/// Build the decompose USER prompt: the goal + recall, asking for a decision.
+///
+/// Why: the user turn carries the operator's goal, its tracked id, and any
+/// recalled SM-palace context, and asks the SM to DECOMPOSE into session-sized
+/// tasks. Keeping it a free function keeps `decompose` terse and the prompt
+/// auditable.
+/// What: formats the goal id + message and (when present) a recall block, then the
+/// explicit decompose ask.
+/// Test: `delegate_tests.rs` asserts the mock saw the goal text.
+fn decision_user_prompt(message: &str, goal_id: &str, recall: Option<&str>) -> String {
+    let recall_block = match recall {
+        Some(r) if !r.trim().is_empty() => format!("\n\nRelevant prior context:\n{r}"),
+        _ => String::new(),
+    };
+    format!(
+        "Operator goal ({goal_id}): {message}{recall_block}\n\n\
+         Decompose this goal into session-sized tasks and reply with your decision."
+    )
+}
+
+#[cfg(test)]
+#[path = "delegate_tests.rs"]
+mod delegate_tests;

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
@@ -80,7 +80,8 @@ const DECOMPOSE_MAX_TOKENS: u32 = 2_048;
 /// site terse and the behaviour assertable.
 /// What: `reply` is the status-first operator message; `goal_id` is the tracked
 /// goal; `launched` are the session ids spawned; `goal_done` is whether the
-/// verification gate passed and the goal closed.
+/// verification gate passed and the goal closed; `goal_status` is the goal's actual
+/// lifecycle label (`Pending`/`InProgress`/`Blocked`/`Done`/`Abandoned`).
 /// Test: `delegate_tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DelegationOutcome {
@@ -92,6 +93,17 @@ pub struct DelegationOutcome {
     pub launched: Vec<String>,
     /// Whether the verification gate passed and the goal reached `Done` (§3.5).
     pub goal_done: bool,
+    /// The goal's actual lifecycle status label (§9.1).
+    ///
+    /// Why: `goal_done` alone is AMBIGUOUS — a caller can misread
+    /// `goal_done == false` as "failed" when it really means "still in progress"
+    /// (or "blocked", awaiting an operator decision). Carrying the real status
+    /// label lets the caller distinguish these WITHOUT a follow-up `sm.goals.list`.
+    /// It is additive: `goal_done` stays for back-compat.
+    /// What: the PascalCase label from
+    /// [`GoalStatus::label`](crate::core::sm::GoalStatus::label) read back from the
+    /// store after the loop (falling back to `"Pending"` only if the goal vanished).
+    pub goal_status: String,
 }
 
 /// A failure surfaced by [`SessionManagerAgent::delegate_goal`].
@@ -170,11 +182,13 @@ impl SessionManagerAgent {
             SmDecision::Respond { message } => {
                 // Allowlist 1: the SM is talking to the operator; the goal stays
                 // Pending with no fan-out (nothing delegated this turn).
+                let goal_status = self.goal_status_label(&goal_id, goals).await;
                 return Ok(DelegationOutcome {
                     reply: message,
                     goal_id,
                     launched: Vec::new(),
                     goal_done: false,
+                    goal_status,
                 });
             }
             SmDecision::DoWork { summary } => {
@@ -185,14 +199,21 @@ impl SessionManagerAgent {
                 // so leaving it Pending forever would orphan it), then return the
                 // redirect message.
                 let reply = redirect_direct_work(&summary);
-                let mut store = goals.lock().await;
-                let _ = store.note(&goal_id, reply.clone()).await;
-                let _ = store.set_status(&goal_id, GoalStatus::Blocked).await;
+                let goal_status = {
+                    let mut store = goals.lock().await;
+                    let _ = store.note(&goal_id, reply.clone()).await;
+                    let _ = store.set_status(&goal_id, GoalStatus::Blocked).await;
+                    store
+                        .get(&goal_id)
+                        .map(|g| g.status.label().to_string())
+                        .unwrap_or_else(|| GoalStatus::Blocked.label().to_string())
+                };
                 return Ok(DelegationOutcome {
                     reply,
                     goal_id,
                     launched: Vec::new(),
                     goal_done: false,
+                    goal_status,
                 });
             }
         };
@@ -200,19 +221,26 @@ impl SessionManagerAgent {
         // ── (3) LAUNCH — one session per launchable task; link + DELIVER (#1299).
         let launched = self.launch_tasks(&tasks, &goal_id, control, goals).await;
         if launched.is_empty() {
-            let mut store = goals.lock().await;
-            let _ = store
-                .note(
-                    &goal_id,
-                    "decompose produced no launchable task".to_string(),
-                )
-                .await;
+            let goal_status = {
+                let mut store = goals.lock().await;
+                let _ = store
+                    .note(
+                        &goal_id,
+                        "decompose produced no launchable task".to_string(),
+                    )
+                    .await;
+                store
+                    .get(&goal_id)
+                    .map(|g| g.status.label().to_string())
+                    .unwrap_or_else(|| GoalStatus::Pending.label().to_string())
+            };
             return Ok(DelegationOutcome {
                 reply: "No launchable task was produced for this goal; nothing delegated."
                     .to_string(),
                 goal_id,
                 launched,
                 goal_done: false,
+                goal_status,
             });
         }
 
@@ -240,11 +268,13 @@ impl SessionManagerAgent {
 
         // ── (6) REPORT — status-first summary for the operator. ─────────────────
         let reply = self.report(&goal_id, &launched, goal_done, goals).await;
+        let goal_status = self.goal_status_label(&goal_id, goals).await;
         Ok(DelegationOutcome {
             reply,
             goal_id,
             launched,
             goal_done,
+            goal_status,
         })
     }
 
@@ -339,6 +369,12 @@ impl SessionManagerAgent {
         goals: &Arc<Mutex<SmGoalStore>>,
     ) -> Vec<String> {
         let mut launched = Vec::new();
+        // WARNING (future editors): the goal-store lock (`goals.lock().await`) MUST
+        // be DROPPED before any `control.*` await below. Every store access in this
+        // loop is taken in its OWN tight scope so the `MutexGuard` is released before
+        // the next `control.launch`/`control.send` await — holding it across that
+        // async I/O would serialize the whole fan-out and risks a deadlock if the
+        // control surface ever re-enters the goal store. Keep the guards scoped.
         for task in tasks.iter().filter(|t| t.is_launchable()) {
             let params = LaunchParams {
                 workdir: task.workdir.clone(),
@@ -455,6 +491,25 @@ impl SessionManagerAgent {
             }
         }
         Ok(())
+    }
+
+    /// Read the goal's current lifecycle status label from the store.
+    ///
+    /// Why: every [`DelegationOutcome`] carries the goal's REAL status (§9.1) so a
+    /// caller never has to disambiguate `goal_done == false` between "in progress"
+    /// and "blocked"/"failed" with a follow-up call. This reads it back at the
+    /// moment of return.
+    /// What: locks the store, returns
+    /// [`GoalStatus::label`](crate::core::sm::GoalStatus::label) for the goal, or
+    /// `"Pending"` if the goal is (unexpectedly) absent.
+    /// Test: `delegate_tests.rs` asserts the label for the in-progress and done
+    /// paths.
+    async fn goal_status_label(&self, goal_id: &str, goals: &Arc<Mutex<SmGoalStore>>) -> String {
+        let store = goals.lock().await;
+        store
+            .get(goal_id)
+            .map(|g| g.status.label().to_string())
+            .unwrap_or_else(|| GoalStatus::Pending.label().to_string())
     }
 
     /// REPORT: build the status-first operator summary for the goal (§3.6).

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/observe.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/observe.rs
@@ -1,0 +1,218 @@
+//! OBSERVE + VERIFY interpretation of a session's pane state (§3.4 phases 4–5).
+//!
+//! Why: phases 4 (OBSERVE) and 5 (VERIFY) read a session's pane/record state and
+//! decide (a) its current verification [`SessionTaskState`] and (b) whether the
+//! pane carries gate-satisfying EVIDENCE (a PR URL, captured test output, a
+//! diff/write confirmation — §3.5). The spec says the SM can interpret raw panes
+//! WITHOUT provider inference ("the session-manager-driver skill's inference
+//! applies"), so this interpretation is DETERMINISTIC heuristics over the session
+//! JSON — no LLM call, fully unit-testable. Keeping it here (separate from the
+//! orchestrator) keeps each file under the SLOC cap and makes the gate logic
+//! auditable in one place.
+//! What: [`ObservedState`] (the interpreted state + optional captured evidence),
+//! [`interpret_session`] (session JSON → `ObservedState`), and the evidence
+//! scanner [`scan_evidence`]. The orchestrator turns an [`ObservedState`] into a
+//! goal-store [`SessionUpdate`](crate::core::sm::SessionUpdate).
+//! Test: `observe_tests.rs` covers running/failed/verified interpretation and
+//! evidence extraction (PR URL, test-pass output) vs. no-evidence.
+
+use serde_json::Value;
+
+use crate::core::sm::goals::SessionTaskState;
+
+/// The interpreted outcome of observing one session (§3.4 phases 4–5).
+///
+/// Why: OBSERVE/VERIFY need to convey BOTH the interpreted verification state and
+/// any captured evidence in one value so the orchestrator can build a single
+/// goal-store update. Crucially, `Verified` is only ever reached WITH evidence —
+/// the verification gate (§3.5) — so this type couples them: a `Verified` state
+/// always carries `Some(evidence)`.
+/// What: `state` is the interpreted [`SessionTaskState`]; `evidence` is the
+/// gate-satisfying snippet (PR URL / test output / diff) when one was observed,
+/// else `None`.
+/// Test: `observe_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedState {
+    /// The interpreted verification state of the linked task.
+    pub state: SessionTaskState,
+    /// Gate-satisfying evidence captured from the pane, if any (§3.5).
+    pub evidence: Option<String>,
+}
+
+/// Interpret a session's record/pane JSON into an [`ObservedState`] (deterministic).
+///
+/// Why: phase 4 turns the raw session JSON (the `SessionControl::get` body) into a
+/// verification state WITHOUT an LLM (§3.4 — the pane heuristic applies). The
+/// interpretation is conservative: a session is only `Verified` when the pane
+/// carries observed EVIDENCE (§3.5), never merely because it reports "done".
+/// What: reads the nested `session` object (the control surface wraps the record
+/// as `{ "session": { … } }`); scans the WHOLE JSON text for evidence via
+/// [`scan_evidence`]. If evidence is present → `Verified` + that evidence. Else
+/// if the record `state` indicates a terminal failure (`errored`/`dead`/`failed`)
+/// → `Failed`. Else if it indicates the session is gone/stopped with no evidence,
+/// or still active → `Running` (in flight, not yet verified). A brand-new record
+/// with no activity stays `Launched`.
+/// Test: `observe_tests.rs::interpret_running`, `interpret_failed`,
+/// `interpret_verified_with_pr_url`, `interpret_no_evidence_stays_running`.
+pub fn interpret_session(session_json: &Value) -> ObservedState {
+    // The control surface returns `{ "session": { … } }`; tolerate both shapes.
+    let record = session_json.get("session").unwrap_or(session_json);
+
+    // Evidence is searched across the full JSON text (record fields + any
+    // captured pane output the control surface includes), so a PR URL or test
+    // output anywhere in the observed payload is captured.
+    let haystack = session_json.to_string();
+    if let Some(evidence) = scan_evidence(&haystack) {
+        return ObservedState {
+            state: SessionTaskState::Verified,
+            evidence: Some(evidence),
+        };
+    }
+
+    let state_str = record
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    let interpreted = if is_failed_state(&state_str) {
+        SessionTaskState::Failed
+    } else if state_str.is_empty() || state_str == "created" || state_str == "provisioning" {
+        // No activity yet observed.
+        SessionTaskState::Launched
+    } else {
+        // Active / running / stopped-without-evidence: in flight, not verified.
+        SessionTaskState::Running
+    };
+
+    ObservedState {
+        state: interpreted,
+        evidence: None,
+    }
+}
+
+/// Whether a record `state` string indicates a terminal FAILURE.
+///
+/// Why: a session that errored/died is a `Failed` task — the goal cannot close on
+/// it, and the operator must be told. Centralising the terminal-failure vocabulary
+/// keeps `interpret_session` readable.
+/// What: returns `true` for `errored`/`dead`/`failed`/`killed` (case already
+/// lowered by the caller).
+/// Test: `observe_tests.rs::interpret_failed`.
+fn is_failed_state(state: &str) -> bool {
+    matches!(state, "errored" | "dead" | "failed" | "killed")
+}
+
+/// Scan observed pane/record text for gate-satisfying evidence (§3.5).
+///
+/// Why: the verification gate forbids `Verified` without OBSERVED evidence (a PR
+/// URL, a captured test-pass count, a diff/write confirmation). A deterministic
+/// scanner means a test can pin exactly what counts as evidence, and the SM can
+/// never "claim done" without it.
+/// What: returns the FIRST matching evidence snippet found, in priority order:
+/// (1) a GitHub/GitLab PR/MR URL; (2) a test-pass summary (`N passed`, `N tests
+/// passed`, `test result: ok`); (3) a diff/write confirmation marker. Returns
+/// `None` when no evidence pattern matches.
+/// Test: `observe_tests.rs::scan_finds_pr_url`, `scan_finds_test_pass`,
+/// `scan_finds_diff`, `scan_finds_nothing`.
+pub fn scan_evidence(text: &str) -> Option<String> {
+    if let Some(url) = find_pr_url(text) {
+        return Some(format!("PR opened: {url}"));
+    }
+    if let Some(pass) = find_test_pass(text) {
+        return Some(format!("tests pass: {pass}"));
+    }
+    if let Some(diff) = find_diff_marker(text) {
+        return Some(format!("edit made: {diff}"));
+    }
+    None
+}
+
+/// Find a GitHub/GitLab pull/merge-request URL in `text`.
+///
+/// Why: "PR opened" evidence is a printed PR URL (§3.5). A token scan keeps this
+/// dependency-free (no regex crate) and predictable. Because evidence is scanned
+/// over the JSON-serialized session payload, a URL at the END of a JSON string
+/// value is followed by `"`/`}`/`]` framing punctuation; the trim must strip ALL
+/// of that so the captured URL is clean (not e.g. `…/pull/9"}}`).
+/// What: finds the first `http`-scheme span (scanning char-by-char so it works
+/// even when the URL has NO surrounding whitespace — e.g. embedded in compact
+/// JSON like `"pane":"…/pull/9","state":…`), bounding the URL at the first
+/// non-URL character (whitespace OR JSON/sentence framing: quotes, braces,
+/// brackets, parens, comma, trailing dot), then returns it iff it carries a
+/// `github.com /pull/` or `gitlab /merge_requests/` PR path.
+/// Test: `observe_tests.rs::scan_finds_pr_url`, `scan_pr_url_strips_json_framing`.
+fn find_pr_url(text: &str) -> Option<String> {
+    // A URL boundary: whitespace or framing punctuation that cannot be inside a
+    // URL we care about. (A trailing `.` ends a sentence; mid-URL dots are fine
+    // because the boundary only fires at the END once a delimiter is hit.)
+    let is_boundary = |c: char| {
+        c.is_whitespace() || matches!(c, '"' | '\'' | '}' | '{' | ']' | '[' | '(' | ')' | ',')
+    };
+
+    let mut search_from = 0;
+    while let Some(rel) = text[search_from..].find("http") {
+        let start = search_from + rel;
+        // The URL runs from `start` to the first boundary char (or end of text).
+        let len = text[start..]
+            .find(is_boundary)
+            .unwrap_or(text.len() - start);
+        let end = start + len;
+        // Strip a single trailing sentence period (mid-URL dots are kept because
+        // the boundary scan already stopped at the first framing char).
+        let candidate = text[start..end].trim_end_matches('.');
+        if (candidate.contains("github.com") && candidate.contains("/pull/"))
+            || (candidate.contains("gitlab") && candidate.contains("/merge_requests/"))
+        {
+            return Some(candidate.to_string());
+        }
+        search_from = end.max(start + 1);
+    }
+    None
+}
+
+/// Find a test-pass summary in `text`.
+///
+/// Why: "tests pass" evidence is a captured run with a pass count (§3.5).
+/// What: scans for the cargo `test result: ok.` marker (returning the line) or a
+/// `N passed` / `N tests passed` phrase; returns the matched snippet.
+/// Test: `observe_tests.rs::scan_finds_test_pass`.
+fn find_test_pass(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let lower = line.to_ascii_lowercase();
+        if lower.contains("test result: ok") {
+            return Some(line.trim().to_string());
+        }
+        if (lower.contains(" passed") || lower.contains("passed;"))
+            && lower.chars().any(|c| c.is_ascii_digit())
+        {
+            return Some(line.trim().to_string());
+        }
+    }
+    None
+}
+
+/// Find a diff / file-write confirmation marker in `text`.
+///
+/// Why: "edit made" evidence is a diff or write confirmation in the pane (§3.5).
+/// What: returns the first line containing a unified-diff header (`diff --git`),
+/// or a write-confirmation phrase (`wrote `/`updated `/`created file`); else
+/// `None`.
+/// Test: `observe_tests.rs::scan_finds_diff`.
+fn find_diff_marker(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let lower = line.to_ascii_lowercase();
+        if lower.contains("diff --git")
+            || lower.contains("wrote ")
+            || lower.contains("updated file")
+            || lower.contains("created file")
+        {
+            return Some(line.trim().to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "observe_tests.rs"]
+mod observe_tests;

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/observe.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/observe.rs
@@ -46,22 +46,30 @@ pub struct ObservedState {
 /// interpretation is conservative: a session is only `Verified` when the pane
 /// carries observed EVIDENCE (§3.5), never merely because it reports "done".
 /// What: reads the nested `session` object (the control surface wraps the record
-/// as `{ "session": { … } }`); scans the WHOLE JSON text for evidence via
-/// [`scan_evidence`]. If evidence is present → `Verified` + that evidence. Else
-/// if the record `state` indicates a terminal failure (`errored`/`dead`/`failed`)
-/// → `Failed`. Else if it indicates the session is gone/stopped with no evidence,
-/// or still active → `Running` (in flight, not yet verified). A brand-new record
-/// with no activity stays `Launched`.
+/// as `{ "session": { … } }`); FIRST scans the RAW pane/output string value for
+/// evidence (so JSON escaping never garbles a captured PR URL or test line), and
+/// only falls back to scanning the whole compact JSON when no pane/output field is
+/// present. If evidence is present → `Verified` + that evidence. Else if the record
+/// `state` indicates a terminal failure (`errored`/`dead`/`failed`) → `Failed`.
+/// Else if it indicates the session is gone/stopped with no evidence, or still
+/// active → `Running` (in flight, not yet verified). A brand-new record with no
+/// activity stays `Launched`.
 /// Test: `observe_tests.rs::interpret_running`, `interpret_failed`,
-/// `interpret_verified_with_pr_url`, `interpret_no_evidence_stays_running`.
+/// `interpret_verified_with_pr_url`, `interpret_no_evidence_stays_unverified`,
+/// `interpret_evidence_from_raw_pane`.
 pub fn interpret_session(session_json: &Value) -> ObservedState {
     // The control surface returns `{ "session": { … } }`; tolerate both shapes.
     let record = session_json.get("session").unwrap_or(session_json);
 
-    // Evidence is searched across the full JSON text (record fields + any
-    // captured pane output the control surface includes), so a PR URL or test
-    // output anywhere in the observed payload is captured.
-    let haystack = session_json.to_string();
+    // Evidence is scanned over the RAW pane/output string FIRST (issue #1311 review):
+    // running the scanner on the escaped compact JSON (`session_json.to_string()`)
+    // can garble evidence — e.g. a PR URL whose surrounding JSON adds `\"` / `}}`
+    // framing, or a test line with escaped newlines. Pulling the raw string value
+    // out of the record and scanning THAT keeps the captured evidence clean. We fall
+    // back to the whole compact JSON only when no pane/output field is present, so
+    // evidence anywhere in the payload is still found.
+    let raw_pane = extract_pane_text(record);
+    let haystack = raw_pane.unwrap_or_else(|| session_json.to_string());
     if let Some(evidence) = scan_evidence(&haystack) {
         return ObservedState {
             state: SessionTaskState::Verified,
@@ -89,6 +97,36 @@ pub fn interpret_session(session_json: &Value) -> ObservedState {
         state: interpreted,
         evidence: None,
     }
+}
+
+/// The ordered field names that may hold a session's raw pane / captured output.
+///
+/// Why: different control surfaces (the tmux-backed session manager, the test mock)
+/// name the captured pane text differently; checking a small ordered set finds the
+/// raw string regardless of which the surface used, most-specific first.
+const PANE_FIELDS: &[&str] = &["pane", "output", "pane_text", "tail", "stdout"];
+
+/// Extract the RAW pane/output string from a session record, if present.
+///
+/// Why: the evidence scanner must run over the UNESCAPED pane text, not the
+/// compact JSON serialization (which adds `\"`/`}}` framing and escapes newlines,
+/// garbling a captured PR URL or test line — issue #1311 review). Pulling the raw
+/// string value out lets the scanner see exactly what the session printed.
+/// What: returns the first present, non-empty string value among [`PANE_FIELDS`]
+/// on the record; `None` when the record carries no recognised pane field (the
+/// caller then falls back to the whole compact JSON so evidence elsewhere in the
+/// payload is still found).
+/// Test: `observe_tests.rs::interpret_evidence_from_raw_pane`,
+/// `scan_pr_url_strips_json_framing` (the fallback path stays green).
+fn extract_pane_text(record: &Value) -> Option<String> {
+    for field in PANE_FIELDS {
+        if let Some(s) = record.get(*field).and_then(Value::as_str)
+            && !s.is_empty()
+        {
+            return Some(s.to_string());
+        }
+    }
+    None
 }
 
 /// Whether a record `state` string indicates a terminal FAILURE.

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/observe_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/observe_tests.rs
@@ -105,6 +105,46 @@ fn scan_pr_url_strips_json_framing() {
     );
 }
 
+/// Why: the evidence scanner must run over the RAW pane string, not the escaped
+/// compact JSON (issue #1311 review). A pane value containing characters JSON would
+/// escape (quotes, newlines) must still yield CLEAN evidence — proving the scan
+/// reads the unescaped value, not `session_json.to_string()`.
+/// What: a pane whose text embeds a quoted phrase + newline THEN a PR URL on its
+/// own line; asserts the captured URL is clean (no JSON framing, no escape gunk).
+/// Test: this is the test.
+#[test]
+fn interpret_evidence_from_raw_pane() {
+    let pane =
+        "Ran the job: \"build\" finished.\nOpened PR https://github.com/acme/repo/pull/13\nDone.";
+    let obs = interpret_session(&json!({
+        "session": { "state": "running", "pane": pane }
+    }));
+    assert_eq!(obs.state, SessionTaskState::Verified);
+    assert_eq!(
+        obs.evidence.as_deref(),
+        Some("PR opened: https://github.com/acme/repo/pull/13"),
+        "evidence is scanned from the raw pane value, clean of JSON escaping"
+    );
+}
+
+/// Why: when NO pane/output field is present, the scanner must FALL BACK to the
+/// whole compact JSON so evidence in another record field is still found.
+/// What: a record with a PR URL in a non-pane field and no pane field; asserts the
+/// URL is still captured via the JSON fallback.
+/// Test: this is the test.
+#[test]
+fn interpret_evidence_fallback_to_json_when_no_pane() {
+    let obs = interpret_session(&json!({
+        "session": { "state": "running", "result_url": "https://github.com/o/r/pull/5" }
+    }));
+    assert_eq!(obs.state, SessionTaskState::Verified);
+    assert_eq!(
+        obs.evidence.as_deref(),
+        Some("PR opened: https://github.com/o/r/pull/5"),
+        "no pane field ⇒ fall back to scanning the whole JSON"
+    );
+}
+
 /// Why: captured cargo/test output with a pass count is gate-satisfying evidence.
 /// What: scans a `test result: ok` line.
 /// Test: this is the test.

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/observe_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/observe_tests.rs
@@ -1,0 +1,134 @@
+//! Unit tests for the deterministic OBSERVE/VERIFY interpretation.
+//!
+//! Why: phases 4–5 interpret raw session JSON with NO LLM (§3.4 pane heuristic);
+//! these tests pin the verification-state interpretation and — critically — that
+//! `Verified` is ONLY ever reached when gate-satisfying evidence is observed
+//! (§3.5). The evidence scanner is the trust boundary of the whole gate.
+//! What: drives `interpret_session` + `scan_evidence` over representative pane
+//! payloads.
+//! Test: this is the test module.
+
+use serde_json::json;
+
+use super::{interpret_session, scan_evidence};
+use crate::core::sm::goals::SessionTaskState;
+
+/// Why: an active/running session with no evidence is `Running` — in flight, not
+/// yet verified (the gate is not satisfied).
+/// What: interprets a `running` record and asserts `Running` + no evidence.
+/// Test: this is the test.
+#[test]
+fn interpret_running() {
+    let obs = interpret_session(&json!({ "session": { "state": "running" } }));
+    assert_eq!(obs.state, SessionTaskState::Running);
+    assert!(obs.evidence.is_none());
+}
+
+/// Why: a terminal-failure record must interpret as `Failed` so the goal cannot
+/// close on it and the operator is told.
+/// What: interprets an `errored` record and asserts `Failed`.
+/// Test: this is the test.
+#[test]
+fn interpret_failed() {
+    let obs = interpret_session(&json!({ "session": { "state": "errored" } }));
+    assert_eq!(obs.state, SessionTaskState::Failed);
+    assert!(obs.evidence.is_none());
+}
+
+/// Why: a brand-new record with no activity stays `Launched` (nothing observed).
+/// What: interprets a `created` record and asserts `Launched`.
+/// Test: this is the test.
+#[test]
+fn interpret_launched() {
+    let obs = interpret_session(&json!({ "session": { "state": "created" } }));
+    assert_eq!(obs.state, SessionTaskState::Launched);
+}
+
+/// Why: the verification gate — a pane carrying a printed PR URL is gate-satisfying
+/// EVIDENCE, so the task interprets as `Verified` WITH that evidence captured.
+/// What: interprets a record whose pane output contains a PR URL.
+/// Test: this is the test.
+#[test]
+fn interpret_verified_with_pr_url() {
+    let obs = interpret_session(&json!({
+        "session": {
+            "state": "running",
+            "pane": "Opened PR https://github.com/acme/repo/pull/42 ready for review"
+        }
+    }));
+    assert_eq!(obs.state, SessionTaskState::Verified);
+    assert_eq!(
+        obs.evidence.as_deref(),
+        Some("PR opened: https://github.com/acme/repo/pull/42")
+    );
+}
+
+/// Why: without evidence, even a "done"-looking running session is NOT verified —
+/// the gate blocks. Proves the SM cannot reach `Verified` on a bare state.
+/// What: interprets a `stopped` record with no evidence; asserts `Running` (in
+/// flight / not verified), evidence none.
+/// Test: this is the test.
+#[test]
+fn interpret_no_evidence_stays_unverified() {
+    let obs = interpret_session(&json!({ "session": { "state": "stopped" } }));
+    assert_ne!(obs.state, SessionTaskState::Verified);
+    assert!(obs.evidence.is_none());
+}
+
+/// Why: the PR-URL scanner is the most common evidence path; it must find a URL
+/// even surrounded by prose/punctuation.
+/// What: scans a sentence with a trailing-punctuation PR URL.
+/// Test: this is the test.
+#[test]
+fn scan_finds_pr_url() {
+    let ev = scan_evidence("All set. See https://github.com/o/r/pull/7).").unwrap();
+    assert_eq!(ev, "PR opened: https://github.com/o/r/pull/7");
+}
+
+/// Why: regression for the trim bug — evidence is scanned over the JSON-serialized
+/// payload, so a PR URL at the END of a string value is wrapped in `"}}` framing;
+/// the captured URL must be CLEAN (no trailing JSON punctuation), or the recorded
+/// evidence would hold a garbled, unopenable URL.
+/// What: interprets a record whose pane field ENDS with the PR URL (so the
+/// serialized form is `…pull/9"}}`) and asserts the captured evidence URL has no
+/// trailing framing characters.
+/// Test: this is the test.
+#[test]
+fn scan_pr_url_strips_json_framing() {
+    let obs = interpret_session(&json!({
+        "session": { "state": "running", "pane": "https://github.com/o/r/pull/9" }
+    }));
+    assert_eq!(
+        obs.evidence.as_deref(),
+        Some("PR opened: https://github.com/o/r/pull/9"),
+        "captured URL must not carry trailing JSON framing"
+    );
+}
+
+/// Why: captured cargo/test output with a pass count is gate-satisfying evidence.
+/// What: scans a `test result: ok` line.
+/// Test: this is the test.
+#[test]
+fn scan_finds_test_pass() {
+    let ev = scan_evidence("running 12 tests\ntest result: ok. 12 passed; 0 failed").unwrap();
+    assert!(ev.starts_with("tests pass:"));
+    assert!(ev.contains("ok"));
+}
+
+/// Why: a diff / write confirmation is gate-satisfying "edit made" evidence.
+/// What: scans a `diff --git` line.
+/// Test: this is the test.
+#[test]
+fn scan_finds_diff() {
+    let ev = scan_evidence("diff --git a/src/main.rs b/src/main.rs\n+ added").unwrap();
+    assert!(ev.starts_with("edit made:"));
+}
+
+/// Why: a pane with no evidence pattern must yield NO evidence — the gate stays
+/// closed. This is the single most important negative case.
+/// What: scans plain prose with no PR/test/diff markers.
+/// Test: this is the test.
+#[test]
+fn scan_finds_nothing() {
+    assert!(scan_evidence("still working on the feature, no results yet").is_none());
+}

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/verify.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/verify.rs
@@ -1,0 +1,52 @@
+//! The verification gate helpers + the prohibition (SP1–SP7) guard (§3.2, §3.5).
+//!
+//! Why: two SM invariants live here so they are auditable in one place. (1) The
+//! VERIFICATION GATE (§3.5): a goal cannot be claimed `Done` without observed
+//! evidence on every linked task — this is enforced in the goal store
+//! ([`SmGoalStore::close`](crate::core::sm::SmGoalStore)), and the loop feeds it
+//! evidence captured by [`super::observe`]; this module documents that wiring and
+//! provides the redirect text. (2) The PROHIBITION GUARD (§3.2): the SM must never
+//! do real work itself. Structurally the loop has NO edit/read/build/test tools —
+//! the only actions are session control + goals + memory — so SP1–SP5 are enforced
+//! by CONSTRUCTION. On top of that, if the model's decision is a direct-work
+//! ATTEMPT ([`SmDecision::DoWork`](super::SmDecision)), the engine refuses it and
+//! redirects to "launch a session" via [`redirect_direct_work`].
+//! What: [`DIRECT_WORK_REDIRECT`] (the canonical redirect preamble) and
+//! [`redirect_direct_work`] (build the operator-facing refusal + redirect).
+//! Test: `verify_tests.rs` covers the redirect text; the gate itself is covered
+//! by the goal-store tests + `delegate_tests.rs::delegate_gate_blocks_without_evidence`.
+
+/// The canonical preamble for refusing a direct-work attempt (§3.2 SP1–SP5).
+///
+/// Why: the SM has "no hands of its own"; when it attempts to do work directly the
+/// engine must give a CONSISTENT, operator-facing refusal that names the rule and
+/// the required behaviour (launch a session). A single constant keeps that wording
+/// stable across call sites and tests.
+/// What: the fixed refusal/redirect preamble string.
+/// Test: `verify_tests.rs::redirect_mentions_prohibition_and_launch`.
+pub const DIRECT_WORK_REDIRECT: &str = "The session manager does not do work itself (prohibitions SP1-SP5): it \
+     delegates every unit of work to a launched session. Rather than doing this \
+     directly, launch a session scoped to the task";
+
+/// Build the operator-facing refusal + redirect for a direct-work attempt.
+///
+/// Why: the SP guard — when the model decides to do the work itself instead of
+/// delegating, the loop REFUSES and redirects. Surfacing the attempted work in the
+/// message makes the redirect actionable ("you tried to X; instead launch a
+/// session to X") and auditable (it is also recorded as a goal note by the caller).
+/// What: returns [`DIRECT_WORK_REDIRECT`] followed by the attempted-work `summary`
+/// (when non-blank), as a single operator-facing sentence.
+/// Test: `verify_tests.rs::redirect_includes_attempted_work`,
+/// `redirect_handles_empty_summary`.
+pub fn redirect_direct_work(summary: &str) -> String {
+    let summary = summary.trim();
+    if summary.is_empty() {
+        format!("{DIRECT_WORK_REDIRECT}.")
+    } else {
+        format!("{DIRECT_WORK_REDIRECT}: {summary}.")
+    }
+}
+
+#[cfg(test)]
+#[path = "verify_tests.rs"]
+mod verify_tests;

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/verify_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/verify_tests.rs
@@ -1,0 +1,45 @@
+//! Unit tests for the prohibition-redirect helper (the SP guard text).
+//!
+//! Why: the redirect is the operator-facing proof that the SM refuses direct work
+//! and points to delegation (§3.2). The wording must name the prohibition and the
+//! corrective action so a driver/operator understands WHY the SM did not just do
+//! it.
+//! What: drives `redirect_direct_work` with present/empty summaries.
+//! Test: this is the test module.
+
+use super::{DIRECT_WORK_REDIRECT, redirect_direct_work};
+
+/// Why: the redirect must name the prohibition (SP1-SP5) and the corrective action
+/// (launch a session) so the refusal is self-explanatory.
+/// What: asserts the constant mentions both.
+/// Test: this is the test.
+#[test]
+fn redirect_mentions_prohibition_and_launch() {
+    assert!(DIRECT_WORK_REDIRECT.contains("SP1-SP5"));
+    assert!(
+        DIRECT_WORK_REDIRECT
+            .to_ascii_lowercase()
+            .contains("launch a session")
+    );
+}
+
+/// Why: surfacing the attempted work makes the redirect actionable + auditable.
+/// What: asserts the summary text rides back in the redirect.
+/// Test: this is the test.
+#[test]
+fn redirect_includes_attempted_work() {
+    let msg = redirect_direct_work("edit main.rs to add a flag");
+    assert!(msg.contains("edit main.rs to add a flag"));
+    assert!(msg.starts_with(DIRECT_WORK_REDIRECT));
+}
+
+/// Why: a blank summary must still produce a clean, grammatical redirect (no
+/// dangling colon).
+/// What: asserts the empty-summary redirect ends with a period and no trailing colon.
+/// Test: this is the test.
+#[test]
+fn redirect_handles_empty_summary() {
+    let msg = redirect_direct_work("   ");
+    assert!(msg.ends_with('.'));
+    assert!(!msg.contains(": ."));
+}

--- a/crates/trusty-mpm/src/core/sm/agent/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/mod.rs
@@ -24,10 +24,13 @@
 //! `agent/chat_tests.rs` covers the composed turn, degraded mode, and recall.
 
 mod chat;
+mod delegate;
 mod health;
 
 #[cfg(test)]
 pub mod mock;
+
+pub use delegate::{DelegationError, DelegationOutcome, SmDecision, TaskSpec};
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -226,6 +229,59 @@ impl SessionManagerAgent {
     /// Test: `agent_new_has_no_runtime`, `chat_tests.rs`.
     pub fn has_runtime(&self) -> bool {
         self.runtime.is_some()
+    }
+
+    /// Borrow the inference runtime for the delegation loop (SM-8 seam).
+    ///
+    /// Why: the SM-8 delegation loop (in the [`delegate`] submodule) needs the same
+    /// runtime handles `chat` uses — the tier resolver for the DECOMPOSE call and,
+    /// under `sm-memory`, the palace for recall. Exposing a `pub(super)` accessor
+    /// lets the submodule reach the (parent-private) runtime without widening its
+    /// visibility beyond the agent module tree.
+    /// What: returns `Some(&AgentRuntime)` when inference is wired, else `None`
+    /// (the inert agent — the loop then reports degraded).
+    /// Test: `delegate_tests.rs` (with a mock resolver), `delegate_degraded_*`.
+    fn runtime_ref(&self) -> Option<&AgentRuntime> {
+        self.runtime.as_ref()
+    }
+
+    /// Recall SM-palace context for the delegation loop's DECOMPOSE prompt (SM-4).
+    ///
+    /// Why: INTAKE recalls relevant prior goals/outcomes/decisions to inform
+    /// DECOMPOSE (§3.4 phase 1). This mirrors the chat turn's best-effort recall
+    /// but is exposed to the [`delegate`] submodule. Recall is always best-effort:
+    /// a missing palace, the feature being off, or a recall error degrades to "no
+    /// recall" rather than failing the loop.
+    /// What: under `sm-memory`, runs the palace recall and joins hit contents;
+    /// returns `None` on no-hits/error/unavailable. Without the feature, `None`.
+    /// Test: `delegate_tests.rs` (no-palace path returns a usable decision).
+    #[cfg(feature = "sm-memory")]
+    async fn delegate_recall(&self, runtime: &AgentRuntime, message: &str) -> Option<String> {
+        let memory = runtime.memory.as_ref()?;
+        match memory.recall(message).await {
+            Ok(hits) if !hits.is_empty() => {
+                let joined = hits
+                    .iter()
+                    .map(|h| h.drawer.content.trim())
+                    .filter(|c| !c.is_empty())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                (!joined.trim().is_empty()).then_some(joined)
+            }
+            _ => None,
+        }
+    }
+
+    /// No-memory build: delegation recall is always absent.
+    ///
+    /// Why: without the `sm-memory` feature the palace is not compiled in, so the
+    /// delegation loop composes its DECOMPOSE prompt with no recall — and must
+    /// still work.
+    /// What: always returns `None`.
+    /// Test: `delegate_tests.rs` (default build).
+    #[cfg(not(feature = "sm-memory"))]
+    async fn delegate_recall(&self, _runtime: &AgentRuntime, _message: &str) -> Option<String> {
+        None
     }
 }
 

--- a/crates/trusty-mpm/src/core/sm/control.rs
+++ b/crates/trusty-mpm/src/core/sm/control.rs
@@ -1,0 +1,111 @@
+//! The session-control seam the SM drives its fleet through (DOC-14 §2.6).
+//!
+//! Why: SM-8's delegation loop (§3.4) and the SM-STDIO adapter (§1A.1) both need
+//! to drive managed sessions — launch, observe, send, stop — WITHOUT carrying
+//! session-lifecycle business logic and WITHOUT a real tmux/workspace in tests.
+//! Hiding that surface behind a narrow trait (Dependency Inversion) lets the
+//! delegation loop and the dispatcher depend on the trait while production wires
+//! the real `DaemonSessionControl` (in `daemon::sm_stdio`) and tests inject a
+//! deterministic mock. SM-STDIO originally defined this trait under
+//! `daemon::sm_stdio`; SM-8 RELOCATES it here (a feature-independent core
+//! location) so the agent-side delegation loop can depend on it too, with
+//! `sm_stdio` re-exporting it so its public surface is unchanged.
+//! What: [`LaunchParams`] (the launch inputs), [`SessionControlError`] (the typed
+//! failure), and [`SessionControl`] — the seven async verbs the spec's session
+//! methods need, each returning a plain `serde_json::Value` (the wire result
+//! body) or a [`SessionControlError`]. The production `DaemonSessionControl`
+//! impl lives in `daemon::sm_stdio::control` (it needs daemon-internal handles);
+//! the agent-side mock lives in `agent/delegate/mock_control.rs`.
+//! Test: the dispatcher's `sm.sessions.*` round-trips and the SM-8 delegation
+//! tests both inject mock impls of this trait.
+
+use async_trait::async_trait;
+
+/// Inputs for `sessions.launch` (§1A.1: `{ workdir, model?, prompt?, goal_id? }`).
+///
+/// Why: the spec's launch params differ from the managed-session `SpawnParams`
+/// shape (`{ repo_url, ref, task }`); keeping the adapter's own owned input
+/// struct lets callers (the dispatcher AND the SM-8 delegation loop) parse the
+/// spec params once and hand them to ANY [`SessionControl`] impl (real or mock)
+/// without re-deriving the mapping at the call site.
+/// What: `workdir` (the directory/repo the session launches against, mapped to
+/// the managed `repo_url`), an optional `model` (runtime selector), an optional
+/// `prompt` (the task/intent, mapped to the managed `task`), and an optional
+/// `goal_id` the caller wants the new session linked to (§9.3).
+/// Test: `tests.rs::launch_round_trips` and `delegate` tests construct this.
+#[derive(Debug, Clone)]
+pub struct LaunchParams {
+    /// Working directory / repository the session launches against.
+    pub workdir: String,
+    /// Optional model / runtime selector (mapped to the managed `runtime`).
+    pub model: Option<String>,
+    /// Optional initial prompt / task description (mapped to the managed `task`).
+    pub prompt: Option<String>,
+    /// Optional goal id to link the launched session to (§9.3).
+    pub goal_id: Option<String>,
+}
+
+/// A failure surfaced by a [`SessionControl`] operation.
+///
+/// Why: callers map these onto JSON-RPC error responses (the dispatcher) or onto
+/// goal-link failures (the SM-8 loop); a typed enum lets them choose
+/// `INVALID_PARAMS` (bad id) vs `INTERNAL_ERROR` (control failure) by VARIANT
+/// rather than string-matching, and keeps the adapter panic-free per the
+/// workspace convention.
+/// What: [`NotFound`](SessionControlError::NotFound) is reserved for a malformed
+/// session id (UUID parse failure) OR a genuinely-absent session
+/// (`ManagedError::SessionNotFound`); [`Backend`](SessionControlError::Backend)
+/// for any other control-surface failure (provision/tmux/store/invalid-state).
+/// Test: `sm_stdio::tests` mock returns both variants; the dispatcher asserts the
+/// mapped JSON-RPC code.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionControlError {
+    /// The session id was invalid or not present.
+    #[error("session not found: {0}")]
+    NotFound(String),
+
+    /// Any backend control failure (provisioning, tmux, store, resume).
+    #[error("{0}")]
+    Backend(String),
+}
+
+/// The narrow session-control surface the SM drives its fleet through (§2.6).
+///
+/// Why: keeps both `sm.sessions.*` (a thin translation) AND the SM-8 delegation
+/// loop decoupled from the concrete managed-session surface. Callers depend on
+/// this trait (Dependency Inversion) so production wires `DaemonSessionControl`
+/// (the real managed-session surface) while tests wire a deterministic mock with
+/// NO tmux/workspace. Every method returns the wire `result` body directly so the
+/// dispatcher does no shaping.
+/// What: `launch` → `{ session_id }`; `list` → `{ sessions: [...] }`; `get` →
+/// the full record JSON; `send` → `{ ok }`; `stop`/`resume`/`kill` → `{ ok }`.
+/// All are `Send + Sync` to live behind `Arc<dyn SessionControl>`.
+/// Test: `sm_stdio::tests` mock; the SM-8 `delegate` tests mock; the real
+/// `DaemonSessionControl` via the managed integration tests.
+#[async_trait]
+pub trait SessionControl: Send + Sync {
+    /// Launch a managed session (`POST /sessions`, §2.6) and return its id.
+    async fn launch(&self, params: LaunchParams) -> Result<serde_json::Value, SessionControlError>;
+
+    /// List all managed sessions (`GET /sessions`, §2.6).
+    async fn list(&self) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Get one session record (`GET /sessions/{id}`, §2.6).
+    async fn get(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Send text into a session's pane (`POST /sessions/{id}/command`, §2.6).
+    async fn send(
+        &self,
+        session_id: &str,
+        text: &str,
+    ) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Stop a session's runtime, keeping the workspace (`DELETE /sessions/{id}`).
+    async fn stop(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Resume a stopped session (`POST /sessions/{id}/resume`, §2.6).
+    async fn resume(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Force-stop / reap a session (`DELETE /sessions/{id}`, §2.6).
+    async fn kill(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+}

--- a/crates/trusty-mpm/src/core/sm/goals/model.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/model.rs
@@ -44,6 +44,28 @@ pub enum GoalStatus {
     Abandoned,
 }
 
+impl GoalStatus {
+    /// The stable, human-readable label for this status.
+    ///
+    /// Why: callers (the delegation wire response, logs, operator surfaces) need a
+    /// single canonical status string so they can DISTINGUISH "in progress" from
+    /// "blocked"/"done" without re-deriving it or misreading a boolean
+    /// `goal_done == false` (which is ambiguous between "still running" and
+    /// "failed"). Centralising the label keeps every surface consistent.
+    /// What: returns the PascalCase variant name (`"Pending"`, `"InProgress"`,
+    /// `"Blocked"`, `"Done"`, `"Abandoned"`).
+    /// Test: `goal_status_label_matches_variants`.
+    pub fn label(self) -> &'static str {
+        match self {
+            GoalStatus::Pending => "Pending",
+            GoalStatus::InProgress => "InProgress",
+            GoalStatus::Blocked => "Blocked",
+            GoalStatus::Done => "Done",
+            GoalStatus::Abandoned => "Abandoned",
+        }
+    }
+}
+
 /// Verification state of a single linked session task (DOC-14 §9.1 / §3.5).
 ///
 /// Why: `Goal` progress and the close gate are derived purely from how many

--- a/crates/trusty-mpm/src/core/sm/goals/model_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/model_tests.rs
@@ -52,6 +52,20 @@ fn status_and_state_defaults() {
     assert_eq!(SessionTaskState::default(), SessionTaskState::Launched);
 }
 
+/// Why: the delegation wire response carries `goal_status` from
+/// [`GoalStatus::label`] so callers can distinguish "in progress" from
+/// "blocked"/"done"; the label must be the canonical PascalCase per variant.
+/// What: asserts the label string for every variant.
+/// Test: this is the test.
+#[test]
+fn goal_status_label_matches_variants() {
+    assert_eq!(GoalStatus::Pending.label(), "Pending");
+    assert_eq!(GoalStatus::InProgress.label(), "InProgress");
+    assert_eq!(GoalStatus::Blocked.label(), "Blocked");
+    assert_eq!(GoalStatus::Done.label(), "Done");
+    assert_eq!(GoalStatus::Abandoned.label(), "Abandoned");
+}
+
 /// Why: only `Verified` satisfies the gate / progress numerator (§3.5).
 /// What: asserts `is_verified()` for every variant.
 /// Test: this is the test.

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -27,6 +27,15 @@ pub mod config;
 /// + the SM-2 provider trait).
 /// Test: `context::*::tests`.
 pub mod context;
+/// The session-control seam the SM drives its fleet through (SM-8, DOC-14 §2.6).
+///
+/// Why: both the SM-8 delegation loop and the SM-STDIO adapter must drive managed
+/// sessions through one narrow, mockable trait. Relocating it here (from
+/// `daemon::sm_stdio`) lets the agent-side loop depend on it while `sm_stdio`
+/// re-exports it unchanged.
+/// What: re-compiled in every build (pure trait + serde value shapes).
+/// Test: `agent::delegate` tests + `daemon::sm_stdio::tests`.
+pub mod control;
 /// Goal-tracking model + dual (palace + cache) persistence (SM-6, DOC-14 §9).
 ///
 /// Why: the SM tracks operator intent as durable goals fanned out to delegated
@@ -60,6 +69,7 @@ pub use context::{
     ConversationStore, ConversationStoreError, Round, SmContextEngine, SmContextError,
     SmConversation, ToolTrace,
 };
+pub use control::{LaunchParams, SessionControl, SessionControlError};
 pub use goals::{
     GOAL_TAG, Goal, GoalCache, GoalMemory, GoalStatus, SessionLink, SessionTaskState,
     SessionUpdate, SmGoalError, SmGoalResult, SmGoalStore,

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -1,18 +1,18 @@
-//! The session-control seam the SM stdio adapter maps `sm.sessions.*` onto.
+//! The production [`SessionControl`] impl over the daemon's managed surface.
 //!
-//! Why: the SM-STDIO adapter (DOC-14 §1A.1) is a THIN mapping — it must not
-//! carry session-lifecycle business logic. The `sm.sessions.launch/list/get/
-//! send/stop/resume/kill` methods map onto the daemon's existing managed-session
-//! control surface (§2.6) — the SAME code `tm ticket`/the HTTP `…/managed/*`
-//! routes use. Hiding that surface behind a narrow trait keeps the dispatcher
-//! (a) transport-neutral and (b) HERMETICALLY testable: the round-trip tests
-//! inject a deterministic mock instead of provisioning a real tmux/workspace.
-//! What: [`SessionControl`] — the seven async verbs the spec's session methods
-//! need, each returning a plain `serde_json::Value` (the wire result body) or a
-//! [`SessionControlError`]. [`DaemonSessionControl`] is the production impl that
-//! delegates to the in-process [`crate::session_manager::SessionManager`] +
-//! [`spawn_managed`]/[`resume_managed`] (so the stdio path and the HTTP path
-//! cannot diverge). The mock impl lives in `tests.rs`.
+//! Why: the SM-STDIO adapter (DOC-14 §1A.1) and the SM-8 delegation loop both
+//! drive sessions through the narrow [`SessionControl`] trait (now defined in
+//! `core::sm::control` so the agent-side loop can depend on it too). This file
+//! holds the PRODUCTION impl: an in-process bridge onto the daemon's existing
+//! managed-session control surface (§2.6) — the SAME code `tm ticket`/the HTTP
+//! `…/managed/*` routes use. Keeping it here (not in core) is deliberate: it
+//! needs daemon-internal handles (`DaemonState`, `spawn_managed`, …) that core
+//! must not depend on. The trait + input/error types are re-exported from this
+//! module so `sm_stdio`'s public surface (`pub use control::{…}`) is unchanged.
+//! What: [`DaemonSessionControl`] delegates each verb to the in-process
+//! [`crate::session_manager::SessionManager`] + [`spawn_managed`]/[`resume_managed`]
+//! (so the stdio path and the HTTP path cannot diverge). The trait, [`LaunchParams`],
+//! and [`SessionControlError`] are re-exported from [`crate::core::sm::control`].
 //! Test: `DaemonSessionControl` is exercised by the daemon's managed-session
 //! integration tests (it forwards to the same helpers those cover); the
 //! dispatcher's `sm.sessions.*` round-trips use the `tests.rs` mock.
@@ -21,95 +21,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+// Re-export the relocated trait + types so `sm_stdio`'s public surface
+// (`pub use control::{DaemonSessionControl, LaunchParams, SessionControl,
+// SessionControlError}`) is unchanged after the SM-8 move to core.
+pub use crate::core::sm::control::{LaunchParams, SessionControl, SessionControlError};
+
 use crate::daemon::managed_routes::{SpawnParams, record_to_json, resume_managed, spawn_managed};
 use crate::daemon::state::DaemonState;
 use crate::session_manager::{ManagedError, ManagedSessionId};
-
-/// Inputs for `sm.sessions.launch` (§1A.1: `{ workdir, model?, prompt?, goal_id? }`).
-///
-/// Why: the spec's launch params differ from the managed-session `SpawnParams`
-/// shape (`{ repo_url, ref, task }`); keeping the adapter's own owned input
-/// struct lets the dispatcher parse the spec params once and hand them to ANY
-/// [`SessionControl`] impl (real or mock) without re-deriving the mapping at the
-/// call site.
-/// What: `workdir` (the directory/repo the session launches against, mapped to
-/// the managed `repo_url`), an optional `model` (runtime selector), an optional
-/// `prompt` (the task/intent, mapped to the managed `task`), and an optional
-/// `goal_id` the caller wants the new session linked to (§9.3).
-/// Test: `tests.rs::launch_round_trips` constructs this from JSON params.
-#[derive(Debug, Clone)]
-pub struct LaunchParams {
-    /// Working directory / repository the session launches against.
-    pub workdir: String,
-    /// Optional model / runtime selector (mapped to the managed `runtime`).
-    pub model: Option<String>,
-    /// Optional initial prompt / task description (mapped to the managed `task`).
-    pub prompt: Option<String>,
-    /// Optional goal id to link the launched session to (§9.3).
-    pub goal_id: Option<String>,
-}
-
-/// A failure surfaced by a [`SessionControl`] operation.
-///
-/// Why: the dispatcher maps these onto JSON-RPC error responses; a typed enum
-/// lets it choose `INVALID_PARAMS` (bad id) vs `INTERNAL_ERROR` (control
-/// failure) by VARIANT rather than string-matching, and keeps the adapter
-/// panic-free per the workspace convention.
-/// What: [`NotFound`](SessionControlError::NotFound) is reserved for a malformed
-/// session id (UUID parse failure) OR a genuinely-absent session
-/// (`ManagedError::SessionNotFound`); [`Backend`](SessionControlError::Backend)
-/// for any other control-surface failure (provision/tmux/store/invalid-state).
-/// Test: `tests.rs` mock returns both variants; the dispatcher asserts the
-/// mapped JSON-RPC code.
-#[derive(Debug, thiserror::Error)]
-pub enum SessionControlError {
-    /// The session id was invalid or not present.
-    #[error("session not found: {0}")]
-    NotFound(String),
-
-    /// Any backend control failure (provisioning, tmux, store, resume).
-    #[error("{0}")]
-    Backend(String),
-}
-
-/// The narrow session-control surface the SM stdio adapter maps onto (§2.6).
-///
-/// Why: keeps `sm.sessions.*` a thin translation. The dispatcher depends on this
-/// trait (Dependency Inversion) so production wires [`DaemonSessionControl`]
-/// (the real managed-session surface) while tests wire a deterministic mock with
-/// NO tmux/workspace. Every method returns the wire `result` body directly so
-/// the dispatcher does no shaping.
-/// What: `launch` → `{ session_id }`; `list` → `{ sessions: [...] }`; `get` →
-/// the full record JSON; `send` → `{ ok }`; `stop`/`resume`/`kill` → `{ ok }`.
-/// All are `Send + Sync` to live behind `Arc<dyn SessionControl>`.
-/// Test: `tests.rs` mock; `DaemonSessionControl` via the managed integration tests.
-#[async_trait]
-pub trait SessionControl: Send + Sync {
-    /// Launch a managed session (`POST /sessions`, §2.6) and return its id.
-    async fn launch(&self, params: LaunchParams) -> Result<serde_json::Value, SessionControlError>;
-
-    /// List all managed sessions (`GET /sessions`, §2.6).
-    async fn list(&self) -> Result<serde_json::Value, SessionControlError>;
-
-    /// Get one session record (`GET /sessions/{id}`, §2.6).
-    async fn get(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
-
-    /// Send text into a session's pane (`POST /sessions/{id}/command`, §2.6).
-    async fn send(
-        &self,
-        session_id: &str,
-        text: &str,
-    ) -> Result<serde_json::Value, SessionControlError>;
-
-    /// Stop a session's runtime, keeping the workspace (`DELETE /sessions/{id}`).
-    async fn stop(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
-
-    /// Resume a stopped session (`POST /sessions/{id}/resume`, §2.6).
-    async fn resume(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
-
-    /// Force-stop / reap a session (`DELETE /sessions/{id}`, §2.6).
-    async fn kill(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
-}
 
 /// Production [`SessionControl`] over the in-process managed-session surface.
 ///
@@ -185,7 +104,7 @@ impl SessionControl for DaemonSessionControl {
     /// mapping with zero provisioning logic of its own.
     /// What: maps `workdir → repo_url`, `prompt → task` (defaulting to a generic
     /// description when absent), and `model → runtime`, then returns
-    /// `{ session_id }`. The `goal_id` link is recorded by the dispatcher via the
+    /// `{ session_id }`. The `goal_id` link is recorded by the caller via the
     /// goal store (§9.3), not here, so this stays purely session-control.
     /// Test: forwards to `spawn_managed` (managed integration tests).
     async fn launch(&self, params: LaunchParams) -> Result<serde_json::Value, SessionControlError> {

--- a/crates/trusty-mpm/src/daemon/sm_stdio/dispatch.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/dispatch.rs
@@ -8,7 +8,7 @@
 //! `METHOD_NOT_FOUND`; bad params become `INVALID_PARAMS`; a notification (no id)
 //! is suppressed — never a panic.
 //! What: [`dispatch`] — `(&SmDispatcher, Request) -> Response`. It returns the
-//! suppressed sentinel for id-less notifications, routes the 13 `sm.*` methods,
+//! suppressed sentinel for id-less notifications, routes the 14 `sm.*` methods,
 //! and folds every other method into a method-not-found error.
 //! Test: `tests.rs` round-trips every method + the parse/unknown/notification
 //! paths.
@@ -27,10 +27,10 @@ use trusty_common::mcp::Request;
 /// the method to its handler, and maps the handler's `Result<Value, MethodError>`
 /// onto a `result`/`error` response. No panics: a missing handler →
 /// method-not-found, a handler error → its mapped code.
-/// What: matches `req.method` against the 13 `sm.*` names; on a hit awaits the
+/// What: matches `req.method` against the 14 `sm.*` names; on a hit awaits the
 /// handler and builds `Response::ok` / the mapped error; on a miss builds
 /// `Response::err(METHOD_NOT_FOUND)`.
-/// Test: `tests.rs` — all 13 methods, unknown method, notification suppression.
+/// Test: `tests.rs` — all 14 methods, unknown method, notification suppression.
 pub async fn dispatch(d: &SmDispatcher, req: Request) -> Response {
     // JSON-RPC notifications (no id) must not produce a reply.
     if req.id.is_none() {
@@ -41,6 +41,7 @@ pub async fn dispatch(d: &SmDispatcher, req: Request) -> Response {
 
     let result: Result<Value, MethodError> = match req.method.as_str() {
         "sm.chat" => methods::sm_chat(d, &params).await,
+        "sm.delegate" => methods::sm_delegate(d, &params).await,
         "sm.health" => methods::sm_health(d, &params).await,
         "sm.goals.list" => methods::sm_goals_list(d, &params).await,
         "sm.goals.create" => methods::sm_goals_create(d, &params).await,

--- a/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
@@ -133,6 +133,53 @@ pub async fn sm_chat(d: &SmDispatcher, params: &Value) -> Result<Value, MethodEr
     }
 }
 
+/// `sm.delegate { message }` → the delegation-loop outcome (SM-8, §3.4).
+///
+/// Why: the capstone method — drives the FULL 6-phase delegation loop
+/// ([`SessionManagerAgent::delegate_goal`]) over the dispatcher's session-control
+/// and goal-store surfaces. This is the §1A.2 step-1 flow `claude-mpm ⟷ SM ⟷ t-mpm`:
+/// a driver sends a goal, the SM creates a tracked goal, launches and delivers
+/// session(s), observes, verifies with evidence (the §3.5 gate), and reports.
+/// Unlike `sm.chat` (a conversational turn), this runs the launch/observe/verify
+/// mechanism end-to-end.
+/// What: under `sm-memory`, parses `message` (required), calls `delegate_goal`
+/// with the dispatcher's `sessions` + `goals`, and returns
+/// `{ reply, goal_id, launched, goal_done }`. A degraded SM (no provider) maps to
+/// [`MethodError::Unavailable`]; any other failure → [`MethodError::Internal`].
+/// Without `sm-memory` (no goal store) it returns a graceful unavailable error.
+/// Test: `tests.rs::delegate_end_to_end_launch_observe_verify_close`,
+/// `delegate_gate_blocks_without_evidence`, `delegate_unavailable_without_feature`.
+#[cfg(feature = "sm-memory")]
+pub async fn sm_delegate(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
+    let message = req_str(params, "message")?;
+    match d.agent.delegate_goal(&message, &d.sessions, &d.goals).await {
+        Ok(outcome) => Ok(json!({
+            "reply": outcome.reply,
+            "goal_id": outcome.goal_id,
+            "launched": outcome.launched,
+            "goal_done": outcome.goal_done,
+        })),
+        Err(crate::core::sm::agent::DelegationError::Degraded(notice)) => {
+            Err(MethodError::Unavailable(notice))
+        }
+        Err(e) => Err(MethodError::Internal(e.to_string())),
+    }
+}
+
+/// `sm.delegate` is unavailable without the `sm-memory` feature.
+///
+/// Why: the delegation loop persists goals through the SM-6 store, which is backed
+/// by the SM palace (memory-core); the no-memory build returns a graceful JSON-RPC
+/// error rather than failing to compile.
+/// What: always returns [`MethodError::Unavailable`].
+/// Test: `tests.rs::delegate_unavailable_without_feature`.
+#[cfg(not(feature = "sm-memory"))]
+pub async fn sm_delegate(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
+    Err(MethodError::Unavailable(
+        "sm.delegate is not available without the sm-memory feature".to_string(),
+    ))
+}
+
 /// `sm.health {}` → `{ ok, provider, degraded, model_tiers }` (§5.3).
 ///
 /// Why: a parent driver probes SM readiness before driving turns. Maps directly

--- a/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
@@ -144,9 +144,13 @@ pub async fn sm_chat(d: &SmDispatcher, params: &Value) -> Result<Value, MethodEr
 /// mechanism end-to-end.
 /// What: under `sm-memory`, parses `message` (required), calls `delegate_goal`
 /// with the dispatcher's `sessions` + `goals`, and returns
-/// `{ reply, goal_id, launched, goal_done }`. A degraded SM (no provider) maps to
-/// [`MethodError::Unavailable`]; any other failure → [`MethodError::Internal`].
-/// Without `sm-memory` (no goal store) it returns a graceful unavailable error.
+/// `{ reply, goal_id, launched, goal_done, goal_status }`. `goal_status` carries the
+/// goal's actual lifecycle label (`Pending`/`InProgress`/`Blocked`/`Done`/
+/// `Abandoned`) so a caller can distinguish in-progress from blocked/failed WITHOUT
+/// a follow-up `sm.goals.list`; `goal_done` is kept additively for back-compat. A
+/// degraded SM (no provider) maps to [`MethodError::Unavailable`]; any other failure
+/// → [`MethodError::Internal`]. Without `sm-memory` (no goal store) it returns a
+/// graceful unavailable error.
 /// Test: `tests.rs::delegate_end_to_end_launch_observe_verify_close`,
 /// `delegate_gate_blocks_without_evidence`, `delegate_unavailable_without_feature`.
 #[cfg(feature = "sm-memory")]
@@ -158,6 +162,7 @@ pub async fn sm_delegate(d: &SmDispatcher, params: &Value) -> Result<Value, Meth
             "goal_id": outcome.goal_id,
             "launched": outcome.launched,
             "goal_done": outcome.goal_done,
+            "goal_status": outcome.goal_status,
         })),
         Err(crate::core::sm::agent::DelegationError::Degraded(notice)) => {
             Err(MethodError::Unavailable(notice))

--- a/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
@@ -21,7 +21,7 @@
 //! dispatcher from the daemon state and drives the shared
 //! [`trusty_common::mcp::run_stdio_loop`] (line framing + stderr-only logging),
 //! so the wire framing is the SAME proven loop trusty-memory/trusty-search use.
-//! Test: `tests.rs` — each of the 13 methods round-trips with correct JSON-RPC
+//! Test: `tests.rs` — each of the 14 methods round-trips with correct JSON-RPC
 //! framing, plus parse-error / method-not-found / stdout-cleanliness / scripted
 //! sequence coverage.
 
@@ -73,7 +73,7 @@ pub type SmGoalHandle = std::convert::Infallible;
 
 /// The transport-neutral SM dispatcher the stdio adapter drives (§1A.1).
 ///
-/// Why: separating the dispatcher from the stdio loop is what makes the 13
+/// Why: separating the dispatcher from the stdio loop is what makes the 14
 /// methods HERMETICALLY testable — the round-trip tests construct an
 /// `SmDispatcher` over mocks and call [`SmDispatcher::dispatch`] with constructed
 /// JSON requests, with no real stdin/stdout, no network, and no tmux. The
@@ -161,7 +161,7 @@ impl SmDispatcher {
     /// methods → method-not-found; bad params → invalid-params; surface failures →
     /// a structured error — never a panic.
     /// What: delegates to [`dispatch::dispatch`].
-    /// Test: `tests.rs` — all 13 methods + error paths.
+    /// Test: `tests.rs` — all 14 methods + error paths.
     pub async fn dispatch(&self, req: Request) -> Response {
         dispatch::dispatch(self, req).await
     }

--- a/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
@@ -1,6 +1,6 @@
 //! Round-trip + framing tests for the SM stdio adapter (SM-STDIO #1291).
 //!
-//! Why: the acceptance bar is that EVERY one of the 13 `sm.*` methods round-trips
+//! Why: the acceptance bar is that EVERY one of the 14 `sm.*` methods round-trips
 //! over the dispatcher with correct JSON-RPC 2.0 framing (id echoed, result shape
 //! correct), that malformed/unknown requests produce proper JSON-RPC errors (no
 //! panic), that `sm.chat` drives a full SM turn and `sm.health` reports provider
@@ -842,6 +842,253 @@ async fn context_get_feature_branches() {
             .await;
         err_code(&ctx, 62, CODE_UNAVAILABLE);
     }
+}
+
+// ── sm.delegate (SM-8 delegation loop) — §1A.2 step-1 e2e ───────────────────────
+
+/// Build an SM agent whose (mock) provider replies with a scripted decision JSON.
+///
+/// Why: the `sm.delegate` e2e drives the FULL delegation loop; the loop's only
+/// LLM call is DECOMPOSE, so scripting the provider reply with a delegate/respond/
+/// do_work JSON lets the dispatcher test drive any path deterministically.
+/// What: builds an agent (feature-aware) over a [`MockResolver`] returning a
+/// provider that always replies with `decision_json`.
+#[cfg(feature = "sm-memory")]
+fn agent_with_decision(
+    cfg: SessionManagerConfig,
+    data_root: &std::path::Path,
+    decision_json: &str,
+) -> Arc<SessionManagerAgent> {
+    let provider = MockChatProvider::new(decision_json, 0.0);
+    let resolver = Arc::new(MockResolver::with_provider(provider));
+    Arc::new(SessionManagerAgent::for_test(
+        cfg,
+        resolver,
+        data_root.to_path_buf(),
+    ))
+}
+
+/// A session-control mock whose `get` returns a pane carrying `evidence` text.
+///
+/// Why: the verification-gate close path needs a session that OBSERVES as
+/// `Verified` (a PR URL in the pane); this mock scripts that evidence so the
+/// dispatcher-level e2e exercises the gate passing, not just the agent-level test.
+/// What: `launch` mints an id and records params (so the goal links); `get`
+/// returns the evidence pane; `send` records the delivery.
+#[cfg(feature = "sm-memory")]
+#[derive(Default)]
+struct EvidenceControl {
+    evidence: String,
+    sends: std::sync::Mutex<Vec<(String, String)>>,
+    next: std::sync::atomic::AtomicUsize,
+}
+
+#[cfg(feature = "sm-memory")]
+#[async_trait]
+impl SessionControl for EvidenceControl {
+    async fn launch(&self, _params: LaunchParams) -> Result<Value, SessionControlError> {
+        let n = self.next.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        Ok(json!({ "session_id": format!("s-{n}") }))
+    }
+    async fn list(&self) -> Result<Value, SessionControlError> {
+        Ok(json!({ "sessions": [] }))
+    }
+    async fn get(&self, _id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "session": { "state": "running", "pane": self.evidence } }))
+    }
+    async fn send(&self, id: &str, text: &str) -> Result<Value, SessionControlError> {
+        self.sends
+            .lock()
+            .expect("lock")
+            .push((id.to_string(), text.to_string()));
+        Ok(json!({ "ok": true }))
+    }
+    async fn stop(&self, _id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn resume(&self, _id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn kill(&self, _id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+}
+
+/// Build a dispatcher over an explicit `Arc<dyn SessionControl>` (e2e helper).
+#[cfg(feature = "sm-memory")]
+fn dispatcher_with_dyn_control(
+    agent: Arc<SessionManagerAgent>,
+    cfg: SessionManagerConfig,
+    data_root: &std::path::Path,
+    sessions: Arc<dyn SessionControl>,
+) -> SmDispatcher {
+    let goals = Some(test_goal_store(data_root));
+    SmDispatcher::new(agent, cfg, data_root.to_path_buf(), sessions, goals)
+}
+
+/// Why: THE SM-8 capstone e2e (§1A.2 step-1, `claude-mpm ⟷ SM ⟷ t-mpm`) — a
+/// driver `sm.delegate`s a goal, the SM launches a session (mocked) + delivers
+/// the task + observes evidence + verifies, and the goal CLOSES through the gate.
+/// What: scripts a delegate decision + an evidence-bearing control, dispatches
+/// `sm.delegate`, and asserts the launched session, task delivery (#1299), and
+/// `goal_done == true`; then `sm.goals.list` shows the goal as `done`.
+/// Test: this is the test.
+#[cfg(feature = "sm-memory")]
+#[tokio::test]
+async fn delegate_end_to_end_launch_observe_verify_close() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let decision = r#"{"action":"delegate","tasks":[{"workdir":"/repo","prompt":"open a PR"}]}"#;
+    let agent = agent_with_decision(cfg.clone(), tmp.path(), decision);
+    let control = Arc::new(EvidenceControl {
+        evidence: "Opened PR https://github.com/acme/repo/pull/7".to_string(),
+        ..EvidenceControl::default()
+    });
+    let sessions: Arc<dyn SessionControl> = control.clone();
+    let d = dispatcher_with_dyn_control(agent, cfg, tmp.path(), sessions);
+
+    let resp = d
+        .dispatch(req(
+            70,
+            "sm.delegate",
+            json!({ "message": "open the PR for me" }),
+        ))
+        .await;
+    let result = ok_result(&resp, 70);
+
+    let launched = result["launched"].as_array().expect("launched array");
+    assert_eq!(launched.len(), 1, "one session launched");
+    assert_eq!(
+        result["goal_done"], true,
+        "gate passed with evidence ⇒ Done"
+    );
+
+    // #1299: the task was delivered to the launched session. Snapshot the sends
+    // out of the guard in a tight scope so no MutexGuard is held across the await.
+    let sends: Vec<(String, String)> = { control.sends.lock().expect("lock").clone() };
+    assert_eq!(sends.len(), 1, "task delivered to the session");
+    assert_eq!(sends[0].1, "open a PR");
+
+    // The goal is visible as `done` via the goals surface.
+    let goal_id = result["goal_id"].as_str().expect("goal_id").to_string();
+    let list = d.dispatch(req(71, "sm.goals.list", json!({}))).await;
+    let goals = ok_result(&list, 71);
+    let found = goals["goals"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|g| g["id"] == goal_id)
+        .expect("goal present");
+    assert_eq!(found["status"], "done");
+}
+
+/// Why: the BLOCKING gate at the dispatcher level — without observed evidence,
+/// `sm.delegate` launches + observes but the goal CANNOT close (`goal_done`
+/// false). Proves the gate is enforced through the wire surface, not just in the
+/// agent unit test.
+/// What: scripts a delegate decision + the default (no-evidence) control;
+/// dispatches `sm.delegate` and asserts a launch happened but `goal_done` is false.
+/// Test: this is the test.
+#[cfg(feature = "sm-memory")]
+#[tokio::test]
+async fn delegate_gate_blocks_without_evidence_over_wire() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let decision = r#"{"action":"delegate","tasks":[{"workdir":"/r","prompt":"do work"}]}"#;
+    let agent = agent_with_decision(cfg.clone(), tmp.path(), decision);
+    // Default mock control: `get` returns `state: active` with NO evidence.
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d
+        .dispatch(req(
+            72,
+            "sm.delegate",
+            json!({ "message": "ship the feature" }),
+        ))
+        .await;
+    let result = ok_result(&resp, 72);
+    assert_eq!(result["launched"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        result["goal_done"], false,
+        "no evidence ⇒ gate blocks Done over the wire"
+    );
+}
+
+/// Why: the PROHIBITION guard over the wire — a `do_work` decision must be REFUSED
+/// and redirected, never executed. Proves SP1–SP5 enforcement reaches the surface.
+/// What: scripts a `do_work` decision; dispatches `sm.delegate`; asserts nothing
+/// launched and the reply redirects to launching a session.
+/// Test: this is the test.
+#[cfg(feature = "sm-memory")]
+#[tokio::test]
+async fn delegate_refuses_direct_work_over_wire() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let decision = r#"{"action":"do_work","summary":"I'll just edit the file"}"#;
+    let agent = agent_with_decision(cfg.clone(), tmp.path(), decision);
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+
+    let resp = d
+        .dispatch(req(73, "sm.delegate", json!({ "message": "add a flag" })))
+        .await;
+    let result = ok_result(&resp, 73);
+    assert!(result["launched"].as_array().unwrap().is_empty());
+    let reply = result["reply"].as_str().unwrap().to_ascii_lowercase();
+    assert!(reply.contains("launch a session"), "redirects to launch");
+}
+
+/// Why: a degraded SM (no provider) must surface `sm.delegate` as a graceful
+/// JSON-RPC unavailable error (the DECOMPOSE reasoning cannot run), never a panic.
+/// What: builds a degraded agent and asserts `sm.delegate` → CODE_UNAVAILABLE.
+/// Test: this is the test.
+#[cfg(feature = "sm-memory")]
+#[tokio::test]
+async fn delegate_degraded_is_unavailable() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_degraded(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+    let resp = d
+        .dispatch(req(74, "sm.delegate", json!({ "message": "anything" })))
+        .await;
+    err_code(&resp, 74, CODE_UNAVAILABLE);
+}
+
+/// Why: in the no-memory build `sm.delegate` (which persists goals) is gracefully
+/// unavailable, not a compile/runtime failure.
+/// What: dispatches `sm.delegate` and asserts CODE_UNAVAILABLE.
+/// Test: this is the test.
+#[cfg(not(feature = "sm-memory"))]
+#[tokio::test]
+async fn delegate_unavailable_without_feature() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = enabled_config();
+    let agent = agent_with_provider(cfg.clone(), tmp.path());
+    let d = dispatcher_with(
+        agent,
+        cfg,
+        tmp.path(),
+        Arc::new(MockSessionControl::default()),
+    );
+    let resp = d
+        .dispatch(req(75, "sm.delegate", json!({ "message": "anything" })))
+        .await;
+    err_code(&resp, 75, CODE_UNAVAILABLE);
 }
 
 // ── stdout cleanliness guard ────────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
@@ -962,6 +962,12 @@ async fn delegate_end_to_end_launch_observe_verify_close() {
         result["goal_done"], true,
         "gate passed with evidence ⇒ Done"
     );
+    // The companion `goal_status` carries the real lifecycle label (#1311 review):
+    // a Done goal reports "Done", not just `goal_done == true`.
+    assert_eq!(
+        result["goal_status"], "Done",
+        "goal_status reflects the closed goal"
+    );
 
     // #1299: the task was delivered to the launched session. Snapshot the sends
     // out of the guard in a tight scope so no MutexGuard is held across the await.
@@ -1016,6 +1022,12 @@ async fn delegate_gate_blocks_without_evidence_over_wire() {
     assert_eq!(
         result["goal_done"], false,
         "no evidence ⇒ gate blocks Done over the wire"
+    );
+    // `goal_done == false` is ambiguous on its own; `goal_status` disambiguates —
+    // a launched-but-unverified goal is "InProgress", NOT failed/blocked (#1311).
+    assert_eq!(
+        result["goal_status"], "InProgress",
+        "an in-flight goal reports InProgress, distinguishing it from blocked/failed"
     );
 }
 


### PR DESCRIPTION
Closes #1292. Capstone of the Session Manager epic (#1283): SM-1..SM-7 + SM-STDIO built the parts; this wires them into the **6-phase SM↔session delegation loop** (DOC-14 §3.4) and brings the SM to life.

## What this does (§3.4 loop)
`sm.delegate { message }` (and `SessionManagerAgent::delegate_goal`) drives:
1. **INTAKE** — operator goal → a tracked `Goal` (SM-6), with SM-palace recall (SM-4) folded into the decompose prompt.
2. **DECOMPOSE** — the SM emits ONE JSON action block (decision protocol below) → parsed into a typed `SmDecision`.
3. **LAUNCH** — one session per task via `SessionControl`; records the `goal_id ↔ session_id` link (§9.3); then **delivers** the task via `sessions.send` (#1299).
4. **OBSERVE** — polls each session via `SessionControl::get`, interprets the pane deterministically (no LLM), updates `SessionLink.state` + derived `Goal.progress`.
5. **VERIFY (BLOCKING gate, §3.5)** — a link reaches `Verified` ONLY with observed evidence captured into `SessionLink.evidence`; the goal closes only when SM-6's gate confirms every linked task is `Verified`.
6. **REPORT + PERSIST** — status-first operator summary (no forbidden "should be done" phrasing).

## Decision protocol: structured-text (ReAct), not tool-calling
The SM `LlmProvider` is **text-only** (`complete()` → text; `ChatMessage` is role+content; no tool/function-call shape). So the loop uses a structured-text protocol: the SM emits a single JSON action block — `{"action":"delegate"|"respond"|"do_work", …}` — which `decision::parse_decision` turns into a typed `SmDecision`. Parsing is lenient (fenced / bare / prose-wrapped JSON) but **garbage falls back to `Respond` (talk to operator)** — never a spurious delegate or do_work. Observation/verification need NO LLM (deterministic pane heuristics, §3.4), keeping the whole loop hermetically testable.

## Verification gate (§3.5) + prohibitions (§3.2 SP1–SP7)
- **Gate:** `observe::scan_evidence` recognizes a PR URL / test-pass output / diff as gate-satisfying evidence; only then is a link `Verified`. The goal-store close (SM-6) is the single enforcement point — no path reaches `Done` without evidence on every link.
- **Prohibitions:** enforced **structurally** — the loop's only action surfaces are session control + goals + memory (no edit/read-source/build/test tools). On top of that, a direct-work `do_work` decision is **refused and redirected** to "launch a session" (and the goal is marked `Blocked`, not left an orphan).

## Reachability (§1A.2 step-1)
New `sm.delegate` JSON-RPC method wires the loop into the SM-STDIO dispatcher (`claude-mpm ⟷ SM ⟷ t-mpm`), feature-gated like `sm.goals.*`.

## Notable structural change
Relocated the `SessionControl` trait (+ `LaunchParams`/`SessionControlError`) from `daemon::sm_stdio` to a shared `core::sm::control` so the agent-side loop can depend on it; `sm_stdio` re-exports them unchanged and keeps the production `DaemonSessionControl`.

## Concurrency (#1309)
Goal-store mutations stay atomic/serialized (single `Arc<Mutex<SmGoalStore>>`; SM-6 snapshots+rolls-back) — the loop adds **no new last-write-wins race** and does not touch the per-`conv_id` context engine. A `TODO(#1309)` per-goal seam is documented for any future concurrent re-drive.

## Scope note
SM-8 delivers the loop **mechanism** with one synchronous observation pass; a continuous poll-until-terminal observer + a resume-into-open-goal path are deliberate follow-ups (the gate + evidence wiring here are what make that correct). Documented inline.

## Tests (hermetic — mock provider + mock `SessionControl` + in-memory goal store; NO network/spawn/ONNX)
- decision-parser: fenced/bare/prose-wrapped/garbage/do_work
- deterministic observe + evidence scanner (incl. a regression test for JSON-framed PR URLs)
- launch+link, **task delivery (#1299)**, observe→progress, multi-session fan-out
- **verification gate**: blocks `Done` without evidence; closes with evidence + all-verified
- **prohibition**: a `do_work` attempt is refused/redirected (nothing launched), goal Blocked
- degraded mode (no provider) → graceful typed error
- **end-to-end over the dispatcher** (`sm.delegate`): launch → observe → verify → goal close; plus gate-blocks / direct-work-refused / degraded / no-feature variants

## Quality bar (raw)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean (default **and** `--features sm-memory`); only the known dual-build-target note.
- `cargo test -p trusty-mpm` — **1244 passed**; `--features sm-memory` — **1257 passed**; 0 failed.
- `cargo build -p trusty-mpm` and `--features sm-memory` — both compile.
- `cargo fmt --check` — clean. `bash scripts/check_line_cap.sh` — **0 violations**.

A code-critic review pass was applied: fixed the PR-URL evidence scanner (was leaving JSON framing on the captured URL), made the gated close distinguish a benign verification-gate rejection from a real persistence failure (now logged), made launch best-effort per task (a single launch failure no longer aborts the fan-out / orphans earlier sessions), and marked refused/idle goals `Blocked` instead of leaving them orphaned `Pending`.

Refs epic #1283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)