### PR TITLE
feat(trusty-progress): rustup/cargo-style shared progress crate (#1315)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11015,6 +11015,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "trusty-progress"
+version = "0.1.0"
+dependencies = [
+ "indicatif 0.17.11",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "trusty-review"
 version = "0.3.9"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,11 @@ libc = "0.2"
 ratatui = "0.29"
 crossterm = "0.28"
 teloxide = { version = "0.13", features = ["macros"] }
+# Progress bars / spinners. Shared rustup/cargo-style progress display lives in
+# the `trusty-progress` crate (#1315). Pinned to 0.17 to match the existing
+# local pins in trusty-search and tga; migrating those two crates to this
+# workspace dep is a tracked follow-up (do NOT churn them here, see #1315).
+indicatif = "0.17"
 
 # Misc utilities used across crates.
 dashmap = "6"

--- a/crates/trusty-progress/Cargo.toml
+++ b/crates/trusty-progress/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "trusty-progress"
+description = "Shared rustup/cargo-style progress + status display for the trusty-* tooling ecosystem"
+version = "0.1.0"
+edition = "2021"
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+# Not published yet (#1315): consumed first in-tree by trusty-controller's
+# Phase-1 install/upgrade flows. Flip `publish` once the API stabilises.
+publish = false
+
+[dependencies]
+indicatif = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/trusty-progress/examples/rustup_style.rs
+++ b/crates/trusty-progress/examples/rustup_style.rs
@@ -1,0 +1,48 @@
+//! Demonstrates the rustup-style progress + status display.
+//!
+//! Run with:
+//! ```text
+//! cargo run -p trusty-progress --example rustup_style
+//! ```
+//!
+//! When stderr is a terminal you get animated spinners; piped or in CI the
+//! output degrades to plain append-only lines (try `… 2>&1 | cat`).
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use trusty_progress::{Component, ComponentTracker, Narrator, Output, ProgressHandle};
+
+fn main() -> Result<(), trusty_progress::ProgressError> {
+    // Autodetect the terminal: animated interactively, plain when piped/CI.
+    let output = Output::to_stderr();
+    let narrator = Narrator::new(output.clone());
+
+    narrator.info("downloading 6 components")?;
+
+    // Indeterminate phase: a spinner while we "resolve" the toolchain.
+    let spinner = ProgressHandle::spinner(&output, "resolving stable-aarch64-apple-darwin");
+    sleep(Duration::from_millis(400));
+    spinner.finish_and_clear();
+
+    // Determinate phase: a bar over the known component count.
+    let components = [
+        Component::new("cargo", 8_870_953),
+        Component::new("clippy", 3_030_384),
+        Component::new("rust-std", 27_472_691),
+    ];
+    let bar = ProgressHandle::bar(&output, components.len() as u64, "installing");
+    let mut table = ComponentTracker::new(output.clone());
+    for component in components {
+        sleep(Duration::from_millis(200));
+        bar.inc(1);
+        table.add(component);
+    }
+    bar.finish_and_clear();
+
+    // The aligned "name installed size" table, rustup-style.
+    table.print()?;
+
+    narrator.info("default toolchain set to stable-aarch64-apple-darwin")?;
+    Ok(())
+}

--- a/crates/trusty-progress/src/components.rs
+++ b/crates/trusty-progress/src/components.rs
@@ -1,0 +1,258 @@
+//! Right-aligned "component installed" table, rustup-style.
+//!
+//! Renders rows like:
+//! ```text
+//!         cargo installed                        8.46 MiB
+//!        clippy installed                        2.89 MiB
+//!      rust-std installed                       26.20 MiB
+//! ```
+//! The component name is right-aligned in a name column, followed by a fixed
+//! verb (` installed`), then the human-readable size right-aligned in a size
+//! column. Centralising the layout keeps every caller's table byte-identical.
+
+use crate::error::Result;
+use crate::output::Output;
+use crate::size::format_mib;
+
+/// Leading indent so the table sits in from the margin (matches rustup).
+const INDENT: usize = 8;
+/// Total width reserved for the right-aligned size column (after the verb).
+const SIZE_COLUMN_WIDTH: usize = 16;
+/// The action verb printed between the name and the size.
+const VERB_INSTALLED: &str = "installed";
+
+/// Why: A row needs both the component name and its byte size together so the
+/// tracker can right-align names against each other (the longest name sets the
+/// column width) — passing them separately would lose that grouping.
+/// What: One component's name + size, as supplied by the caller.
+/// Test: `components::tests::*` build these and assert the rendered table.
+#[derive(Debug, Clone)]
+pub struct Component {
+    /// Display name, e.g. `cargo`, `rust-std`.
+    pub name: String,
+    /// Size in bytes; rendered via [`format_mib`].
+    pub size_bytes: u64,
+}
+
+impl Component {
+    /// Why: Ergonomic constructor so callers write
+    /// `Component::new("cargo", 8_870_953)` instead of a struct literal.
+    /// What: Builds a [`Component`] from any string-like name and a byte count.
+    /// Test: Used throughout `components::tests`.
+    pub fn new(name: impl Into<String>, size_bytes: u64) -> Self {
+        Self {
+            name: name.into(),
+            size_bytes,
+        }
+    }
+}
+
+/// Why: The whole point of the rustup style is that the *set* of rows aligns as
+/// a block (names right-aligned to the longest, sizes right-aligned in a fixed
+/// column). That alignment can only be computed once all rows are known, so the
+/// tracker accumulates components and renders them together.
+/// What: Collects [`Component`]s and renders the aligned table through a shared
+/// [`Output`], honouring its TTY/quiet/silent mode.
+/// Test: `components::tests` assert the exact byte layout and the fallback.
+#[derive(Debug, Clone)]
+pub struct ComponentTracker {
+    output: Output,
+    components: Vec<Component>,
+}
+
+impl ComponentTracker {
+    /// Why: Lets the tracker share a sink with a [`crate::Narrator`] so the
+    /// `info:` lines and the table interleave correctly.
+    /// What: Builds an empty tracker over the given [`Output`].
+    /// Test: `components::tests::renders_rustup_table`.
+    pub fn new(output: Output) -> Self {
+        Self {
+            output,
+            components: Vec::new(),
+        }
+    }
+
+    /// Why: Convenience for the standalone "just print a table on stderr" case.
+    /// What: Builds an empty tracker over an autodetected stderr [`Output`].
+    /// Test: Side-effect-only (ambient TTY); delegates to tested `Output`.
+    pub fn to_stderr() -> Self {
+        Self::new(Output::to_stderr())
+    }
+
+    /// Why: Callers discover component sizes incrementally (e.g. after each
+    /// download finishes); buffering them lets the final render align as a block.
+    /// What: Appends one component to the table, returning `&mut self` for
+    /// chaining.
+    /// Test: `components::tests::renders_rustup_table`.
+    pub fn add(&mut self, component: Component) -> &mut Self {
+        self.components.push(component);
+        self
+    }
+
+    /// Why: Some callers already have a `Vec`; avoid forcing a manual loop.
+    /// What: Extends the table with all supplied components.
+    /// Test: `components::tests::renders_rustup_table`.
+    pub fn extend(&mut self, components: impl IntoIterator<Item = Component>) -> &mut Self {
+        self.components.extend(components);
+        self
+    }
+
+    /// Why: Tests (and any non-TTY caller) need the exact text without writing
+    /// to a sink; rendering to a string keeps the layout logic pure and
+    /// testable, separate from I/O.
+    /// What: Produces the fully aligned, multi-line table as a `String`
+    /// (no trailing newline). Returns an empty string when there are no rows.
+    /// Test: `components::tests::renders_rustup_table` /
+    /// `right_aligns_names_to_longest`.
+    pub fn render(&self) -> String {
+        if self.components.is_empty() {
+            return String::new();
+        }
+        let name_width = self
+            .components
+            .iter()
+            .map(|c| c.name.len())
+            .max()
+            .unwrap_or(0);
+
+        let mut lines = Vec::with_capacity(self.components.len());
+        for c in &self.components {
+            let size = format_mib(c.size_bytes);
+            // Indent + right-aligned name + " installed" + right-aligned size.
+            lines.push(format!(
+                "{indent}{name:>name_width$} {verb}{size:>size_width$}",
+                indent = " ".repeat(INDENT),
+                name = c.name,
+                name_width = name_width,
+                verb = VERB_INSTALLED,
+                size = size,
+                size_width = SIZE_COLUMN_WIDTH,
+            ));
+        }
+        lines.join("\n")
+    }
+
+    /// Why: The terminal verb — actually emit the rendered table through the
+    /// shared output, honouring silent mode.
+    /// What: Renders the table and writes it (line-buffered) to the sink; a
+    /// no-op when there are no rows or in silent mode.
+    /// Test: `components::tests::print_writes_through_output`.
+    pub fn print(&self) -> Result<()> {
+        if self.components.is_empty() || !self.output.is_visible() {
+            return Ok(());
+        }
+        self.output.writeln(&self.render())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::Mode;
+
+    fn sample() -> ComponentTracker {
+        let (out, _cap) = Output::for_capture(Mode::Plain);
+        let mut t = ComponentTracker::new(out);
+        t.add(Component::new("cargo", 8_870_953))
+            .add(Component::new("clippy", 3_030_384))
+            .add(Component::new("rust-std", 27_472_691));
+        t
+    }
+
+    /// Why: The whole feature is this exact layout; pin it byte-for-byte so a
+    /// refactor cannot drift the column math.
+    /// What: Asserts each rendered row equals `INDENT spaces + right-aligned
+    /// name (width 8) + " installed" + size right-aligned in width 16`.
+    /// Test: This is the test.
+    #[test]
+    fn renders_rustup_table() {
+        let table = sample().render();
+        let lines: Vec<&str> = table.lines().collect();
+        assert_eq!(lines.len(), 3);
+        // Longest name is "rust-std" (8 chars); names right-align to width 8.
+        let expect = |name_field: &str, size: &str| {
+            format!(
+                "{indent}{name_field} installed{size:>width$}",
+                indent = " ".repeat(INDENT),
+                width = SIZE_COLUMN_WIDTH,
+            )
+        };
+        assert_eq!(lines[0], expect("   cargo", "8.46 MiB"));
+        assert_eq!(lines[1], expect("  clippy", "2.89 MiB"));
+        assert_eq!(lines[2], expect("rust-std", "26.20 MiB"));
+    }
+
+    /// Why: Right-alignment of names is what makes the block read cleanly;
+    /// verify the column equals the longest name regardless of insertion order.
+    /// What: Asserts the name field width matches the longest name across rows.
+    /// Test: This is the test.
+    #[test]
+    fn right_aligns_names_to_longest() {
+        let (out, _cap) = Output::for_capture(Mode::Plain);
+        let mut t = ComponentTracker::new(out);
+        t.add(Component::new("a", 0))
+            .add(Component::new("longest-name", 0));
+        let lines: Vec<String> = t.render().lines().map(str::to_owned).collect();
+        // Both name fields occupy the same right-aligned column → the byte
+        // offset of " installed" must be identical on both rows.
+        let off0 = lines[0].find(" installed").expect("verb on row 0");
+        let off1 = lines[1].find(" installed").expect("verb on row 1");
+        assert_eq!(off0, off1);
+    }
+
+    /// Why: An empty tracker must render nothing (no stray blank line) and
+    /// `print` must be a clean no-op.
+    /// What: Asserts empty render + empty capture.
+    /// Test: This is the test.
+    #[test]
+    fn empty_tracker_renders_nothing() {
+        let (out, cap) = Output::for_capture(Mode::Plain);
+        let t = ComponentTracker::new(out);
+        assert_eq!(t.render(), "");
+        t.print().expect("print");
+        assert_eq!(cap.contents(), "");
+    }
+
+    /// Why: `print` is the production path; confirm it writes the table plus a
+    /// single trailing newline to the sink.
+    /// What: Builds a captured tracker, prints, and asserts the bytes.
+    /// Test: This is the test.
+    #[test]
+    fn print_writes_through_output() {
+        let (out, cap) = Output::for_capture(Mode::Plain);
+        let mut t = ComponentTracker::new(out);
+        t.add(Component::new("cargo", 8_870_953));
+        t.print().expect("print");
+        // Single component → name column width == len("cargo") == 5, so no
+        // intra-name padding; just INDENT + name + verb + right-aligned size.
+        let expected = format!(
+            "{indent}cargo installed{size:>width$}\n",
+            indent = " ".repeat(INDENT),
+            size = "8.46 MiB",
+            width = SIZE_COLUMN_WIDTH,
+        );
+        assert_eq!(cap.contents(), expected);
+    }
+
+    /// Why: The non-TTY fallback must be plain text with zero ANSI escapes so
+    /// piped/CI/`--json` consumers stay clean.
+    /// What: Asserts the rendered plain table contains no ESC byte.
+    /// Test: This is the test.
+    #[test]
+    fn plain_table_has_no_ansi_escapes() {
+        let table = sample().render();
+        assert!(!table.contains('\u{1b}'));
+    }
+
+    /// Why: Silent mode must suppress the table even when rows are present.
+    /// What: Asserts nothing is written in silent mode.
+    /// Test: This is the test.
+    #[test]
+    fn silent_mode_prints_nothing() {
+        let (out, cap) = Output::for_capture(Mode::Silent);
+        let mut t = ComponentTracker::new(out);
+        t.add(Component::new("cargo", 8_870_953));
+        t.print().expect("print");
+        assert_eq!(cap.contents(), "");
+    }
+}

--- a/crates/trusty-progress/src/error.rs
+++ b/crates/trusty-progress/src/error.rs
@@ -1,0 +1,49 @@
+//! Error type for the `trusty-progress` crate.
+
+use std::io;
+
+/// Why: Library crates in this workspace must surface structured errors via
+/// `thiserror` (never `anyhow`, never `unwrap`) so callers can match on the
+/// failure mode. The only fallible path in this crate is writing rendered
+/// output to the underlying sink, so we model that single failure.
+/// What: Enumerates the error conditions a progress sink can raise.
+/// Test: Exercised indirectly by `output` tests that write to an in-memory
+/// sink (which never errors) and by the `Display`/`From` derives below; the
+/// `io::Error` arm is covered by the `From<io::Error>` conversion test in
+/// `error::tests`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ProgressError {
+    /// Why: Writing a narrator line or a component row to the configured sink
+    /// (stderr, a file, or a captured buffer) can fail with an I/O error; the
+    /// caller needs that surfaced rather than silently dropped.
+    /// What: Wraps the underlying [`std::io::Error`] from a failed write/flush.
+    /// Test: `error::tests::io_error_converts_and_displays`.
+    #[error("failed to write progress output: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Why: Saves every public function from repeating the full `Result<T,
+/// ProgressError>` spelling and gives callers a single canonical alias.
+/// What: Crate-local `Result` specialised to [`ProgressError`].
+/// Test: Used as the return type throughout the crate; compilation is the test.
+pub type Result<T> = std::result::Result<T, ProgressError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: Guards the `#[from]` conversion and the `Display` message so a
+    /// future refactor cannot silently change the public error surface.
+    /// What: Builds a `ProgressError` from an `io::Error` and asserts the
+    /// rendered message contains the wrapped cause.
+    /// Test: This is the test.
+    #[test]
+    fn io_error_converts_and_displays() {
+        let io_err = io::Error::new(io::ErrorKind::BrokenPipe, "pipe gone");
+        let err: ProgressError = io_err.into();
+        let rendered = err.to_string();
+        assert!(rendered.contains("failed to write progress output"));
+        assert!(rendered.contains("pipe gone"));
+    }
+}

--- a/crates/trusty-progress/src/lib.rs
+++ b/crates/trusty-progress/src/lib.rs
@@ -1,0 +1,79 @@
+//! # trusty-progress
+//!
+//! Shared rustup/cargo-style progress + status display for the trusty-* tooling
+//! ecosystem. Today `trusty-search` and `tga` each pin `indicatif` locally and
+//! hand-roll their own bars; this crate (issue #1315) consolidates the *style*
+//! behind one small, dependency-light API so every tool renders progress the
+//! same way.
+//!
+//! ## Why this crate exists
+//!
+//! - **One look.** A single right-aligned component table and `info:` narrator
+//!   format, matching rustup, used everywhere.
+//! - **Centralised terminal handling.** TTY detection, the quiet/non-TTY/`--json`
+//!   fallback, and indicatif draw-target selection live in [`Output`] alone, so
+//!   call sites never re-derive them.
+//! - **Library-grade errors.** Fallible writes surface as [`ProgressError`]
+//!   (via `thiserror`); there is no `unwrap()` in the library path.
+//!
+//! ## Building blocks
+//!
+//! - [`Output`] / [`Mode`] — pick where text goes and how animated it should be.
+//! - [`Narrator`] — `info:` / `warning:` / `error:` status lines.
+//! - [`ComponentTracker`] / [`Component`] — the right-aligned "name installed
+//!   size" table.
+//! - [`ProgressHandle`] — a spinner (indeterminate) or bar (determinate) over
+//!   `indicatif`.
+//! - [`format_mib`] / [`format_bytes`] — human-readable size columns.
+//!
+//! ## Rustup-style component table
+//!
+//! Render the exact layout from the issue — `info:` lines bracketing a
+//! right-aligned component table. Here we capture the output to a buffer (as the
+//! tests do) so the example is deterministic; in a real CLI you would use
+//! [`Output::to_stderr`] and let terminal detection choose the mode.
+//!
+//! ```rust
+//! use trusty_progress::{Component, ComponentTracker, Mode, Narrator, Output};
+//!
+//! // In production: `Output::to_stderr()` autodetects the terminal.
+//! let (output, capture) = Output::for_capture(Mode::Plain);
+//! let narrator = Narrator::new(output.clone());
+//!
+//! narrator.info("downloading 6 components")?;
+//!
+//! let mut table = ComponentTracker::new(output.clone());
+//! table
+//!     .add(Component::new("cargo", 8_870_953))
+//!     .add(Component::new("clippy", 3_030_384))
+//!     .add(Component::new("rust-std", 27_472_691));
+//! table.print()?;
+//!
+//! narrator.info("default toolchain set to stable-aarch64-apple-darwin")?;
+//!
+//! let rendered = capture.contents();
+//! // The narrator lines bracket the right-aligned table:
+//! assert!(rendered.starts_with("info: downloading 6 components\n"));
+//! assert!(rendered.contains("cargo installed"));
+//! assert!(rendered.contains("8.46 MiB"));
+//! assert!(rendered.trim_end().ends_with(
+//!     "info: default toolchain set to stable-aarch64-apple-darwin"
+//! ));
+//! // Plain/non-TTY output never contains ANSI escape sequences.
+//! assert!(!rendered.contains('\u{1b}'));
+//! # Ok::<(), trusty_progress::ProgressError>(())
+//! ```
+
+mod components;
+mod error;
+mod narrator;
+mod output;
+mod progress;
+mod size;
+
+pub use components::{Component, ComponentTracker};
+pub use error::{ProgressError, Result};
+pub use narrator::Narrator;
+pub use output::{Capture, Mode, Output};
+pub use progress::ProgressHandle;
+pub use size::{format_bytes, format_mib};

--- a/crates/trusty-progress/src/narrator.rs
+++ b/crates/trusty-progress/src/narrator.rs
@@ -1,0 +1,144 @@
+//! Rustup-style `info:` narrator lines.
+
+use crate::error::Result;
+use crate::output::Output;
+
+/// Prefix rustup uses for informational narration.
+const INFO_PREFIX: &str = "info:";
+/// Prefix for warnings (rustup uses `warning:`).
+const WARN_PREFIX: &str = "warning:";
+/// Prefix for errors (rustup uses `error:`).
+const ERROR_PREFIX: &str = "error:";
+
+/// Why: The rustup output Bob wants is framed by `info: …` narration lines
+/// (`info: downloading 6 components`, `info: default toolchain set to …`).
+/// Centralising the prefix + sink avoids every call site re-spelling the
+/// format and routing decision.
+/// What: A thin printer that emits prefixed status lines through a shared
+/// [`Output`], honouring its TTY/quiet/silent mode.
+/// Test: `narrator::tests` assert exact line text and the silent/plain paths.
+#[derive(Debug, Clone)]
+pub struct Narrator {
+    output: Output,
+}
+
+impl Narrator {
+    /// Why: Callers that already hold an [`Output`] (e.g. alongside a component
+    /// tracker) should share the same mode/sink rather than constructing a new
+    /// one with possibly divergent terminal detection.
+    /// What: Wraps an existing `Output` in a `Narrator`.
+    /// Test: `narrator::tests::info_line_matches_rustup`.
+    pub fn new(output: Output) -> Self {
+        Self { output }
+    }
+
+    /// Why: Convenience for the common "I just want narration on stderr" case
+    /// so a CLI need not touch the `Output` type at all.
+    /// What: Builds a `Narrator` over an autodetected stderr [`Output`].
+    /// Test: Side-effect-only (ambient TTY); delegates to tested `Output`.
+    pub fn to_stderr() -> Self {
+        Self::new(Output::to_stderr())
+    }
+
+    /// Why: The primary verb — print an `info:`-prefixed status line exactly as
+    /// rustup does.
+    /// What: Emits `info: <msg>` (or nothing in silent mode).
+    /// Test: `narrator::tests::info_line_matches_rustup`.
+    pub fn info(&self, msg: &str) -> Result<()> {
+        self.output.writeln(&format!("{INFO_PREFIX} {msg}"))
+    }
+
+    /// Why: Some flows need to flag a recoverable problem in the same visual
+    /// register as the narration.
+    /// What: Emits `warning: <msg>`.
+    /// Test: `narrator::tests::warn_and_error_prefixes`.
+    pub fn warn(&self, msg: &str) -> Result<()> {
+        self.output.writeln(&format!("{WARN_PREFIX} {msg}"))
+    }
+
+    /// Why: Lets a flow report a hard failure line consistently with the rest
+    /// of the progress output (the caller still returns its own error type).
+    /// What: Emits `error: <msg>`.
+    /// Test: `narrator::tests::warn_and_error_prefixes`.
+    pub fn error(&self, msg: &str) -> Result<()> {
+        self.output.writeln(&format!("{ERROR_PREFIX} {msg}"))
+    }
+
+    /// Why: A component tracker and its surrounding narration must share one
+    /// sink so lines interleave in order; expose the inner `Output` for that.
+    /// What: Returns a clone of the underlying [`Output`].
+    /// Test: `narrator::tests::shares_output_clone`.
+    pub fn output(&self) -> Output {
+        self.output.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::Mode;
+
+    /// Why: The exact `info: ` prefix (lowercase, single space) is the
+    /// load-bearing visual contract with the rustup style.
+    /// What: Asserts a single `info` call renders `info: downloading 6 components\n`.
+    /// Test: This is the test.
+    #[test]
+    fn info_line_matches_rustup() {
+        let (out, cap) = Output::for_capture(Mode::Plain);
+        let narrator = Narrator::new(out);
+        narrator.info("downloading 6 components").expect("info");
+        assert_eq!(cap.contents(), "info: downloading 6 components\n");
+    }
+
+    /// Why: Guard the warn/error prefixes too so they stay rustup-faithful.
+    /// What: Asserts both prefixes render verbatim.
+    /// Test: This is the test.
+    #[test]
+    fn warn_and_error_prefixes() {
+        let (out, cap) = Output::for_capture(Mode::Plain);
+        let narrator = Narrator::new(out);
+        narrator.warn("disk almost full").expect("warn");
+        narrator.error("download failed").expect("error");
+        assert_eq!(
+            cap.contents(),
+            "warning: disk almost full\nerror: download failed\n"
+        );
+    }
+
+    /// Why: Silent mode must drop narration entirely (e.g. scripted use).
+    /// What: Asserts no bytes are emitted in silent mode.
+    /// Test: This is the test.
+    #[test]
+    fn silent_mode_emits_nothing() {
+        let (out, cap) = Output::for_capture(Mode::Silent);
+        let narrator = Narrator::new(out);
+        narrator.info("hidden").expect("info");
+        assert_eq!(cap.contents(), "");
+    }
+
+    /// Why: Narration lines must never contain ANSI escape sequences in the
+    /// non-TTY/plain fallback, or piped logs and `--json` consumers break.
+    /// What: Asserts the rendered plain output has no ESC (`0x1b`) byte.
+    /// Test: This is the test.
+    #[test]
+    fn plain_output_has_no_ansi_escapes() {
+        let (out, cap) = Output::for_capture(Mode::Plain);
+        let narrator = Narrator::new(out);
+        narrator.info("downloading 6 components").expect("info");
+        assert!(!cap.contents().contains('\u{1b}'));
+    }
+
+    /// Why: A component tracker shares the narrator's sink; verify the clone
+    /// writes to the same buffer.
+    /// What: Writes through both the narrator and its cloned output and asserts
+    /// both lines land in order.
+    /// Test: This is the test.
+    #[test]
+    fn shares_output_clone() {
+        let (out, cap) = Output::for_capture(Mode::Plain);
+        let narrator = Narrator::new(out);
+        narrator.info("first").expect("info");
+        narrator.output().writeln("second").expect("write");
+        assert_eq!(cap.contents(), "info: first\nsecond\n");
+    }
+}

--- a/crates/trusty-progress/src/output.rs
+++ b/crates/trusty-progress/src/output.rs
@@ -1,0 +1,262 @@
+//! Centralised output mode + sink.
+//!
+//! Every renderer in this crate routes through [`Output`] so terminal
+//! detection, the quiet/non-TTY fallback, and the write sink are decided in
+//! exactly one place.
+
+use std::io::{self, IsTerminal, Write};
+use std::sync::{Arc, Mutex};
+
+use indicatif::ProgressDrawTarget;
+
+use crate::error::Result;
+
+/// Why: A progress display behaves very differently in an interactive terminal
+/// (live spinners, in-place redraws, colour) versus a pipe / CI log / `--json`
+/// run (plain, append-only lines). Centralising the choice in one enum stops
+/// every call site from re-deriving it and keeps the fallback consistent.
+/// What: The three rendering modes the crate supports.
+/// Test: `output::tests::mode_selects_draw_target` and the renderer tests in
+/// `narrator`/`components` assert plain output in the non-interactive modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Interactive terminal: animated indicatif draw targets are used.
+    Interactive,
+    /// Not a terminal (pipe, file, CI) or `--json`/quiet requested: emit plain
+    /// append-only lines and hide indicatif animations.
+    Plain,
+    /// Fully silent: suppress all output (used for `--quiet` where even plain
+    /// lines are unwanted). Renderers become no-ops.
+    Silent,
+}
+
+/// Why: Tests must assert on rendered bytes (e.g. "no ANSI escapes when not a
+/// TTY") without touching the real stderr, and production callers want output
+/// on stderr so stdout stays clean for JSON-RPC framing. A trait object behind
+/// an `Arc<Mutex<…>>` lets us swap stderr for an in-memory buffer.
+/// What: The shared, thread-safe write target for rendered lines.
+type SharedSink = Arc<Mutex<dyn Write + Send>>;
+
+/// Why: Bundles the rendering [`Mode`] with the line sink so the narrator,
+/// component tracker, and progress handles all share one source of truth for
+/// "where does text go and how animated should it be".
+/// What: The handle every renderer holds; cheap to clone (`Arc` inside).
+/// Test: `output::tests::*` plus the renderer modules construct `Output` via
+/// [`Output::for_capture`] and assert on the captured buffer.
+#[derive(Clone)]
+pub struct Output {
+    mode: Mode,
+    sink: SharedSink,
+}
+
+impl Output {
+    /// Why: The common production constructor — autodetect the terminal so
+    /// callers get animations interactively and plain lines in CI/pipes for
+    /// free, writing to stderr (stdout stays clean for protocol framing).
+    /// What: Builds an `Output` writing to stderr, choosing [`Mode::Interactive`]
+    /// when stderr is a terminal and [`Mode::Plain`] otherwise.
+    /// Test: Side-effect-only (depends on the ambient TTY); the mode-selection
+    /// logic it delegates to is covered by `mode_selects_draw_target`.
+    pub fn to_stderr() -> Self {
+        let mode = if is_stderr_terminal() {
+            Mode::Interactive
+        } else {
+            Mode::Plain
+        };
+        Self {
+            mode,
+            sink: Arc::new(Mutex::new(io::stderr())),
+        }
+    }
+
+    /// Why: Lets a CLI honour an explicit `--quiet` / `--json` flag, overriding
+    /// autodetection (e.g. force plain output even on a TTY for `--json`).
+    /// What: Builds an stderr-backed `Output` with the caller-chosen mode.
+    /// Test: Side-effect-only; mode handling is covered via `for_capture`.
+    pub fn to_stderr_with_mode(mode: Mode) -> Self {
+        Self {
+            mode,
+            sink: Arc::new(Mutex::new(io::stderr())),
+        }
+    }
+
+    /// Why: Enables deterministic unit tests — render into an owned buffer and
+    /// assert on the exact bytes, including the "no ANSI escapes" guarantee of
+    /// the plain fallback.
+    /// What: Builds an `Output` with the given mode whose sink is a shared
+    /// in-memory buffer; the returned [`Capture`] reads the accumulated bytes.
+    /// Test: `output::tests::capture_roundtrips_written_bytes`.
+    pub fn for_capture(mode: Mode) -> (Self, Capture) {
+        let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let output = Self {
+            mode,
+            sink: Arc::new(Mutex::new(SharedBuf(buf.clone()))),
+        };
+        (output, Capture(buf))
+    }
+
+    /// Why: Renderers branch on the mode to decide between animated and plain
+    /// rendering; exposing it keeps that branching out of the sink internals.
+    /// What: Returns the current [`Mode`].
+    /// Test: `output::tests::mode_selects_draw_target`.
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    /// Why: `true` in any mode that should emit text at all; lets renderers
+    /// short-circuit cleanly in [`Mode::Silent`] without duplicating the check.
+    /// What: Returns whether plain/animated line output is enabled.
+    /// Test: `output::tests::visible_reflects_mode`.
+    pub fn is_visible(&self) -> bool {
+        self.mode != Mode::Silent
+    }
+
+    /// Why: indicatif needs a [`ProgressDrawTarget`]; in non-interactive modes
+    /// we must hand it a hidden target so spinners don't spam plain logs with
+    /// control characters. One place decides this for all progress handles.
+    /// What: Returns the indicatif draw target appropriate for the mode —
+    /// stderr for [`Mode::Interactive`], hidden otherwise.
+    /// Test: `output::tests::mode_selects_draw_target`.
+    pub fn draw_target(&self) -> ProgressDrawTarget {
+        match self.mode {
+            Mode::Interactive => ProgressDrawTarget::stderr(),
+            Mode::Plain | Mode::Silent => ProgressDrawTarget::hidden(),
+        }
+    }
+
+    /// Why: The narrator and component tracker emit whole lines; funnelling
+    /// them through one method guarantees consistent newline handling, the
+    /// silent-mode short-circuit, and a single I/O error surface.
+    /// What: Writes `line` followed by `\n` to the sink unless silent; flushes
+    /// so piped consumers see output promptly.
+    /// Test: `narrator::tests` and `components::tests` assert on the bytes this
+    /// writes; the silent short-circuit is covered by
+    /// `output::tests::silent_writes_nothing`.
+    pub(crate) fn writeln(&self, line: &str) -> Result<()> {
+        if self.mode == Mode::Silent {
+            return Ok(());
+        }
+        let mut sink = self
+            .sink
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        sink.write_all(line.as_bytes())?;
+        sink.write_all(b"\n")?;
+        sink.flush()?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Output")
+            .field("mode", &self.mode)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Why: Tests need to read back exactly what was rendered to assert on layout
+/// and the absence of ANSI escapes; this is the read side of [`Output::for_capture`].
+/// What: A cloneable handle over the same in-memory buffer the `Output` writes.
+/// Test: `output::tests::capture_roundtrips_written_bytes`.
+#[derive(Clone)]
+pub struct Capture(Arc<Mutex<Vec<u8>>>);
+
+impl Capture {
+    /// Why: Assertions want a `String`, and the renderers only ever write UTF-8.
+    /// What: Returns the accumulated output as a lossy UTF-8 string.
+    /// Test: `output::tests::capture_roundtrips_written_bytes`.
+    pub fn contents(&self) -> String {
+        let buf = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        String::from_utf8_lossy(&buf).into_owned()
+    }
+}
+
+/// Internal newtype so the shared `Vec<u8>` can implement `Write` behind the
+/// `dyn Write + Send` sink object.
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedBuf {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        let mut buf = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        buf.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Why: Terminal detection is the one piece of environment-coupled logic; we
+/// use std's `IsTerminal` (stable, well below the 1.91 MSRV) rather than adding
+/// an `is-terminal`/`atty` crate, keeping the dep tree to just `indicatif` +
+/// `thiserror`.
+/// What: Returns whether stderr is an interactive terminal.
+/// Test: Side-effect-only (ambient FD state); not unit-tested directly.
+fn is_stderr_terminal() -> bool {
+    io::stderr().is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: The draw-target choice is what suppresses spinner control codes in
+    /// non-interactive contexts; a regression here would corrupt plain logs.
+    /// The crucial, environment-independent invariant is that Plain and Silent
+    /// are *always* hidden. (Interactive delegates to
+    /// `ProgressDrawTarget::stderr()`, which is itself hidden when stderr is not
+    /// a TTY — as under the test harness — so we cannot assert it is visible in
+    /// a deterministic way; we assert it matches stderr's own report instead.)
+    /// What: Asserts Plain/Silent are unconditionally hidden, and Interactive
+    /// tracks the real stderr terminal state.
+    /// Test: This is the test.
+    #[test]
+    fn mode_selects_draw_target() {
+        for mode in [Mode::Plain, Mode::Silent] {
+            let (out, _) = Output::for_capture(mode);
+            assert!(out.draw_target().is_hidden());
+        }
+
+        let (interactive, _) = Output::for_capture(Mode::Interactive);
+        assert_eq!(
+            interactive.draw_target().is_hidden(),
+            ProgressDrawTarget::stderr().is_hidden()
+        );
+    }
+
+    /// Why: Renderers rely on `is_visible` to gate output; verify the mapping.
+    /// What: Asserts only `Silent` is invisible.
+    /// Test: This is the test.
+    #[test]
+    fn visible_reflects_mode() {
+        let (i, _) = Output::for_capture(Mode::Interactive);
+        let (p, _) = Output::for_capture(Mode::Plain);
+        let (s, _) = Output::for_capture(Mode::Silent);
+        assert!(i.is_visible());
+        assert!(p.is_visible());
+        assert!(!s.is_visible());
+    }
+
+    /// Why: The capture sink is the foundation of every other test; confirm it
+    /// faithfully records writes.
+    /// What: Writes a line and reads it back via `Capture`.
+    /// Test: This is the test.
+    #[test]
+    fn capture_roundtrips_written_bytes() {
+        let (out, cap) = Output::for_capture(Mode::Plain);
+        out.writeln("hello").expect("write");
+        assert_eq!(cap.contents(), "hello\n");
+    }
+
+    /// Why: Silent mode must emit absolutely nothing, even when asked to write.
+    /// What: Writes in silent mode and asserts the buffer stays empty.
+    /// Test: This is the test.
+    #[test]
+    fn silent_writes_nothing() {
+        let (out, cap) = Output::for_capture(Mode::Silent);
+        out.writeln("should not appear").expect("write");
+        assert_eq!(cap.contents(), "");
+    }
+}

--- a/crates/trusty-progress/src/progress.rs
+++ b/crates/trusty-progress/src/progress.rs
@@ -1,0 +1,171 @@
+//! Spinner / progress-bar handle — a thin wrapper over `indicatif`.
+//!
+//! Provides one type, [`ProgressHandle`], for both indeterminate steps
+//! (spinner) and determinate steps (a bar with a known total). The handle
+//! respects the shared [`Output`] mode: in plain/silent/non-TTY modes the
+//! indicatif draw target is hidden, so no control characters leak into logs.
+
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::output::Output;
+
+/// How often the spinner animation ticks while active.
+const SPINNER_TICK: Duration = Duration::from_millis(80);
+/// Template for an indeterminate spinner (`⠋ message`).
+const SPINNER_TEMPLATE: &str = "{spinner:.cyan} {msg}";
+/// Template for a determinate bar (`[#####>----] 12/40 message`).
+const BAR_TEMPLATE: &str = "{bar:40.cyan/blue} {pos}/{len} {msg}";
+
+/// Why: Callers want a single ergonomic handle that hides indicatif's setup
+/// (styles, tick intervals, draw targets) and automatically degrades to no
+/// animation in non-TTY/quiet contexts — without each call site re-deriving
+/// terminal state. This wrapper owns that policy.
+/// What: Wraps an `indicatif::ProgressBar` whose draw target was chosen from
+/// the shared [`Output`] mode. Supports indeterminate (spinner) and
+/// determinate (bar) progress; methods are no-ops when the target is hidden.
+/// Test: `progress::tests` construct hidden handles (`Mode::Plain`) and drive
+/// the API to confirm it does not panic and tracks position.
+#[derive(Debug, Clone)]
+pub struct ProgressHandle {
+    bar: ProgressBar,
+}
+
+impl ProgressHandle {
+    /// Why: Indeterminate work (connecting, resolving, "downloading…") has no
+    /// known total, so a spinner is the right affordance.
+    /// What: Starts a spinner with `message`, ticking on a timer in interactive
+    /// mode and hidden otherwise.
+    /// Test: `progress::tests::spinner_is_hidden_in_plain_mode`.
+    pub fn spinner(output: &Output, message: impl Into<String>) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_draw_target(output.draw_target());
+        // ProgressStyle::with_template only fails on a malformed template; ours
+        // is a const literal, so fall back to the default style if it ever does
+        // rather than unwrapping in library code.
+        if let Ok(style) = ProgressStyle::with_template(SPINNER_TEMPLATE) {
+            bar.set_style(style);
+        }
+        bar.set_message(message.into());
+        bar.enable_steady_tick(SPINNER_TICK);
+        Self { bar }
+    }
+
+    /// Why: Determinate work (N components, N files) should show a filling bar
+    /// and a position/total readout.
+    /// What: Starts a bar with the given `total` and `message`; hidden in
+    /// non-interactive modes.
+    /// Test: `progress::tests::bar_tracks_position`.
+    pub fn bar(output: &Output, total: u64, message: impl Into<String>) -> Self {
+        let bar = ProgressBar::new(total);
+        bar.set_draw_target(output.draw_target());
+        if let Ok(style) = ProgressStyle::with_template(BAR_TEMPLATE) {
+            bar.set_style(style);
+        }
+        bar.set_message(message.into());
+        Self { bar }
+    }
+
+    /// Why: Long-running steps update their label as they progress (e.g.
+    /// switch from "resolving" to the current filename).
+    /// What: Replaces the handle's message text.
+    /// Test: `progress::tests::bar_tracks_position` (exercises set_message path).
+    pub fn set_message(&self, message: impl Into<String>) {
+        self.bar.set_message(message.into());
+    }
+
+    /// Why: Determinate callers report units of work completed; advancing the
+    /// bar is the core determinate verb.
+    /// What: Advances the bar position by `delta`.
+    /// Test: `progress::tests::bar_tracks_position`.
+    pub fn inc(&self, delta: u64) {
+        self.bar.inc(delta);
+    }
+
+    /// Why: Some callers know the absolute position rather than a delta.
+    /// What: Sets the bar position to `pos`.
+    /// Test: `progress::tests::bar_tracks_position`.
+    pub fn set_position(&self, pos: u64) {
+        self.bar.set_position(pos);
+    }
+
+    /// Why: The current position is occasionally needed for assertions and for
+    /// callers that mix `inc`/`set_position`.
+    /// What: Returns the bar's current position.
+    /// Test: `progress::tests::bar_tracks_position`.
+    pub fn position(&self) -> u64 {
+        self.bar.position()
+    }
+
+    /// Why: A finished step should clear its spinner/bar line (interactive) so
+    /// the narrator's `info:` summary line reads cleanly afterwards.
+    /// What: Stops the animation and removes the line from the terminal.
+    /// Test: `progress::tests::finish_and_clear_is_safe`.
+    pub fn finish_and_clear(self) {
+        self.bar.finish_and_clear();
+    }
+
+    /// Why: Some flows want the final state to stay on screen with a closing
+    /// message (e.g. "done").
+    /// What: Stops the animation, leaving the line with `message`.
+    /// Test: `progress::tests::finish_with_message_is_safe`.
+    pub fn finish_with_message(self, message: impl Into<String>) {
+        self.bar.finish_with_message(message.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::Mode;
+
+    /// Why: In non-TTY/plain mode the spinner must use a hidden draw target so
+    /// no control characters reach piped logs; the handle must still be usable.
+    /// What: Creates a spinner in plain mode and confirms it is hidden.
+    /// Test: This is the test.
+    #[test]
+    fn spinner_is_hidden_in_plain_mode() {
+        let (out, _cap) = Output::for_capture(Mode::Plain);
+        let handle = ProgressHandle::spinner(&out, "downloading");
+        assert!(handle.bar.is_hidden());
+        handle.finish_and_clear();
+    }
+
+    /// Why: The determinate API must accurately track position regardless of
+    /// draw target (logic is independent of rendering).
+    /// What: Advances a bar via `inc`/`set_position`/`set_message` and asserts
+    /// the position.
+    /// Test: This is the test.
+    #[test]
+    fn bar_tracks_position() {
+        let (out, _cap) = Output::for_capture(Mode::Plain);
+        let handle = ProgressHandle::bar(&out, 10, "installing");
+        handle.inc(3);
+        assert_eq!(handle.position(), 3);
+        handle.set_position(7);
+        handle.set_message("almost there");
+        assert_eq!(handle.position(), 7);
+        handle.finish_and_clear();
+    }
+
+    /// Why: `finish_and_clear` consumes the handle; verify it does not panic
+    /// even with a hidden target.
+    /// What: Finishes a hidden spinner.
+    /// Test: This is the test.
+    #[test]
+    fn finish_and_clear_is_safe() {
+        let (out, _cap) = Output::for_capture(Mode::Plain);
+        ProgressHandle::spinner(&out, "x").finish_and_clear();
+    }
+
+    /// Why: `finish_with_message` is the alternate terminal verb; verify it is
+    /// panic-free in plain mode.
+    /// What: Finishes a hidden bar with a message.
+    /// Test: This is the test.
+    #[test]
+    fn finish_with_message_is_safe() {
+        let (out, _cap) = Output::for_capture(Mode::Plain);
+        ProgressHandle::bar(&out, 5, "x").finish_with_message("done");
+    }
+}

--- a/crates/trusty-progress/src/size.rs
+++ b/crates/trusty-progress/src/size.rs
@@ -1,0 +1,94 @@
+//! Human-readable byte-size formatting.
+//!
+//! Centralises the rustup-style size column (`8.46 MiB`) so every caller
+//! renders sizes identically.
+
+/// Bytes in one binary kibibyte.
+const KIB: u64 = 1024;
+/// Bytes in one binary mebibyte.
+const MIB: u64 = KIB * 1024;
+/// Bytes in one binary gibibyte.
+const GIB: u64 = MIB * 1024;
+/// Bytes in one binary tebibyte.
+const TIB: u64 = GIB * 1024;
+
+/// Why: The rustup component table shows every size with two decimal places in
+/// MiB (`8.46 MiB`); reproducing that exactly keeps the shared style faithful
+/// to the target output Bob specified in #1315.
+/// What: Formats a raw byte count as a fixed two-decimal mebibyte string,
+/// e.g. `8_870_000` → `"8.46 MiB"`. Always uses MiB regardless of magnitude so
+/// the component column stays aligned (matching rustup's behaviour).
+/// Test: `size::tests::mib_matches_rustup_samples` pins the exact strings from
+/// the issue (`8.46 MiB`, `2.89 MiB`, `26.20 MiB`).
+pub fn format_mib(bytes: u64) -> String {
+    let mib = bytes as f64 / MIB as f64;
+    format!("{mib:.2} MiB")
+}
+
+/// Why: For general-purpose progress (downloads, indexing) a fixed-MiB column
+/// reads poorly across many orders of magnitude; callers that are not
+/// rendering the rustup component table want an auto-scaled unit instead.
+/// What: Formats a byte count with the largest binary unit that keeps the
+/// mantissa below 1024, with two decimals for KiB and up (whole bytes for
+/// `< 1 KiB`). e.g. `512` → `"512 B"`, `1536` → `"1.50 KiB"`,
+/// `1_572_864` → `"1.50 MiB"`.
+/// Test: `size::tests::auto_scales_across_units` covers each unit boundary.
+pub fn format_bytes(bytes: u64) -> String {
+    if bytes < KIB {
+        return format!("{bytes} B");
+    }
+    let (value, unit) = if bytes < MIB {
+        (bytes as f64 / KIB as f64, "KiB")
+    } else if bytes < GIB {
+        (bytes as f64 / MIB as f64, "MiB")
+    } else if bytes < TIB {
+        (bytes as f64 / GIB as f64, "GiB")
+    } else {
+        (bytes as f64 / TIB as f64, "TiB")
+    };
+    format!("{value:.2} {unit}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: The two-decimal MiB column is the load-bearing visual detail of the
+    /// rustup style; these exact strings appear in the issue's target output.
+    /// What: Asserts `format_mib` reproduces the three sample sizes.
+    /// Test: This is the test.
+    #[test]
+    fn mib_matches_rustup_samples() {
+        // 8.46 MiB ≈ 8.46 * 1048576 = 8_870_953 bytes (rounds to 8.46).
+        assert_eq!(format_mib(8_870_953), "8.46 MiB");
+        // 2.89 MiB ≈ 3_030_384 bytes.
+        assert_eq!(format_mib(3_030_384), "2.89 MiB");
+        // 26.20 MiB ≈ 27_472_691 bytes.
+        assert_eq!(format_mib(27_472_691), "26.20 MiB");
+    }
+
+    /// Why: Zero and sub-MiB inputs must not panic or render `NaN`; the column
+    /// should still show two decimals so it stays aligned.
+    /// What: Asserts edge values format predictably.
+    /// Test: This is the test.
+    #[test]
+    fn mib_handles_small_values() {
+        assert_eq!(format_mib(0), "0.00 MiB");
+        assert_eq!(format_mib(MIB), "1.00 MiB");
+        assert_eq!(format_mib(MIB / 2), "0.50 MiB");
+    }
+
+    /// Why: The auto-scaling helper must pick the right unit at each binary
+    /// boundary so general progress readouts are legible.
+    /// What: Checks every unit tier and the whole-byte path.
+    /// Test: This is the test.
+    #[test]
+    fn auto_scales_across_units() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(KIB + KIB / 2), "1.50 KiB");
+        assert_eq!(format_bytes(MIB + MIB / 2), "1.50 MiB");
+        assert_eq!(format_bytes(GIB + GIB / 2), "1.50 GiB");
+        assert_eq!(format_bytes(TIB + TIB / 2), "1.50 TiB");
+    }
+}


### PR DESCRIPTION
Implements #1315. New dependency-light shared crate `crates/trusty-progress` (edition 2021, publish=false) providing the canonical rustup/cargo-style progress + status display, reusable across all trusty tools.

Public API: `Output`/`Mode` (centralized TTY detection + quiet/non-TTY/silent fallback), `Narrator` (`info:`/`warning:`/`error:` lines), `ComponentTracker`/`Component` (right-aligned `name installed   size` table), `ProgressHandle` (indicatif spinner/bar wrapper), `format_mib`/`format_bytes`. Built on `indicatif` (added to `[workspace.dependencies]`, pinned 0.17). TTY detection via `std::io::IsTerminal` (no extra dep).

Verification: `cargo test -p trusty-progress` 23 tests + 1 doctest green; clippy -D warnings clean; fmt clean; `cargo build` workspace green; line-cap exit 0 (largest new file 262 raw lines).

Follow-up (separate): migrate trusty-search & tga from local `indicatif="0.17"` pins to the workspace dep. First consumer will be tctl Phase-1 (#1316).

Closes #1315.