### PR TITLE
docs: repo hygiene — MIT license cleanup, README accuracy, CONTRIBUTING/SECURITY, .github templates (#1317)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: bug
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+Steps to reproduce the behavior:
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- **OS:** (macOS / Linux / Windows)
+- **Rust Version:** (output of `rustc --version`)
+- **Crate(s) Affected:** (e.g., `trusty-search`, `trusty-memory`)
+- **Version(s):** (crate version or git commit)
+
+## Logs or Error Messages
+
+If applicable, include relevant error output:
+
+```
+paste error logs here
+```
+
+## Additional Context
+
+Any other context about the problem (e.g., system configuration, recent changes, workarounds).
+
+---
+
+**Labels:** Add `P0`, `P1`, or `P2` priority and the affected crate label (e.g., `trusty-search`).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature Request
+about: Suggest an idea or enhancement
+title: "[FEATURE] "
+labels: enhancement
+---
+
+## Describe the Feature
+
+A clear and concise description of what you want to happen.
+
+## Problem Statement
+
+What problem or limitation does this feature address? Why is it needed?
+
+## Proposed Solution
+
+How should the feature work? Include any relevant examples or use cases.
+
+## Alternatives Considered
+
+Have you considered any alternative approaches?
+
+## Crate(s) Affected
+
+Which crate or crates does this feature relate to? (e.g., `trusty-search`, `trusty-memory`, `trusty-agents`)
+
+## Additional Context
+
+Any other relevant information, such as:
+- Links to related issues or discussions
+- Design mockups or diagrams
+- Performance implications
+- Backward compatibility concerns
+
+---
+
+**Labels:** Add `P0`, `P1`, or `P2` priority and the affected crate label.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+## Summary
+
+Briefly describe the changes in this PR.
+
+## Related Issue(s)
+
+Closes #<issue-number>
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring
+- [ ] Performance improvement
+- [ ] Documentation update
+- [ ] Dependency update
+- [ ] CI/infrastructure change
+
+## Crate(s) Affected
+
+List the crate(s) modified by this PR:
+- `crate-name`
+
+## Testing
+
+Describe how you tested these changes:
+
+- [ ] Added or updated tests
+- [ ] Ran `cargo test -p <crate>` locally
+- [ ] Ran full workspace tests: `cargo test --workspace`
+- [ ] Manual testing (describe):
+
+## Checklist
+
+- [ ] Code follows the project's style guidelines
+- [ ] `cargo fmt` has been run
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `bash scripts/check_line_cap.sh` returns exit code 0
+- [ ] Documentation is updated (if applicable)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No breaking changes, or breaking changes are documented
+
+## Notes
+
+Any additional context or notes for reviewers.
+
+---
+
+🤖 This PR will be reviewed by `trusty-review` and merged once all checks pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,56 @@
-# Changelog
+# trusty-tools Changelog Index
 
-All notable changes to trusty-tools are documented in this file.
+This workspace is a monorepo consolidating 20 independent Rust crates. Each crate maintains its own **authoritative** changelog in its directory.
 
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-Crate versions are tagged independently (`<crate-name>-v<version>`); this file
-records changes in chronological order grouped by release date.
+## Per-Crate Changelogs
 
-## [Unreleased] — 2026-05-26
+The source of truth for changes to any crate is its own CHANGELOG:
 
-### Fixed
-- **trusty-memory**: `open_activity_log_with_fallback` no longer panics on restricted filesystems — returns a `Discard` no-op log variant (#225)
-- **trusty-memory**: `AppState::emit` no longer blocks the tokio runtime — activity log writes offloaded to `spawn_blocking` (#232)
-- **trusty-memory**: `prompt_context_cache` uses `tokio::sync::RwLock` — KG cache rebuilds no longer stall async worker threads (#229)
-- **trusty-memory**: Per-palace write mutex eliminates TOCTOU race in `dedup_gate` — concurrent identical writes now correctly deduplicate (#230)
-- **trusty-mpm-tui**: Drawer detail pane and help overlay text now visible on light terminal themes — replaced `Color::White` with `Color::Reset` (#244)
+| Crate | Changelog |
+|---|---|
+| **trusty-search** | [crates/trusty-search/CHANGELOG.md](crates/trusty-search/CHANGELOG.md) |
+| **trusty-memory** | [crates/trusty-memory/CHANGELOG.md](crates/trusty-memory/CHANGELOG.md) |
+| **trusty-analyze** | [crates/trusty-analyze/CHANGELOG.md](crates/trusty-analyze/CHANGELOG.md) |
+| **trusty-mpm** | [crates/trusty-mpm/CHANGELOG.md](crates/trusty-mpm/CHANGELOG.md) |
+| **trusty-agents** | [crates/trusty-agents/CHANGELOG.md](crates/trusty-agents/CHANGELOG.md) |
+| **trusty-git-analytics** | [crates/trusty-git-analytics/CHANGELOG.md](crates/trusty-git-analytics/CHANGELOG.md) |
+| **trusty-review** | [crates/trusty-review/CHANGELOG.md](crates/trusty-review/CHANGELOG.md) |
+| **trusty-common** | [crates/trusty-common/CHANGELOG.md](crates/trusty-common/CHANGELOG.md) |
+| **trusty-embedderd** | [crates/trusty-embedderd/CHANGELOG.md](crates/trusty-embedderd/CHANGELOG.md) |
+| **trusty-mpm-gui** | [crates/trusty-mpm-gui/CHANGELOG.md](crates/trusty-mpm-gui/CHANGELOG.md) |
 
-### Changed
-- **trusty-memory**: `axum` and `tower-http` gated behind `axum-server` feature flag — consumers can link the rlib without the HTTP stack (`default-features = false`) (#226)
-- **trusty-memory**: `dispatch_tool` refactored from 957-line monolith to 28-line router + 23 per-tool handler functions (#227)
-- **trusty-memory**: Write hot path no longer triggers O(N) palace disk walks — palace name lookup uses in-memory cache; status aggregation moved to 30s background ticker (#228)
-- **trusty-memory**: BM25 indexing uses bounded `mpsc::channel(256)` — burst writes no longer accumulate unbounded background tasks; queue-full events are logged and skipped (#231)
+Other crates (libraries, internal tools) may not maintain per-release changelogs. Consult their git history via `git log crates/<name>/` for changes.
 
-### Internal
-- **trusty-memory**: `run_serve` startup hydration deduplicated into `spawn_startup_tasks` helper (#233)
-- **trusty-memory**: Test helper `test_state()` returns `(AppState, TempDir)` — eliminates `mem::forget` temp directory leaks across 262 tests (#234)
+## Versioning
+
+Each crate manages its own independent semantic version. When publishing, only the crates with user-facing changes are released with new versions. See [CONTRIBUTING.md](CONTRIBUTING.md) for the per-crate release convention.
+
+## Release Tags
+
+Releases are tagged as `<crate-name>-v<version>`. Example: `trusty-search-v0.8.0`.
+
+To see all release tags:
+```bash
+git tag -l
+```
+
+To see commits for a specific crate:
+```bash
+git log crates/<crate-name>/
+```
+
+## Finding Changes
+
+To see all changes across the workspace since a date:
+```bash
+git log --since="2026-01-01" --oneline
+```
+
+To see changes affecting a specific crate:
+```bash
+git log crates/<crate-name>/ --oneline
+```
+
+---
+
+**For detailed development and release information**, see [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/reference/release-workflow.md](docs/reference/release-workflow.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,26 @@ git log crates/<crate-name>/ --oneline
 ---
 
 **For detailed development and release information**, see [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/reference/release-workflow.md](docs/reference/release-workflow.md).
+
+## Legacy (pre per-crate-changelog split)
+
+The following entries document changes made before each crate adopted independent changelogs.
+
+### [Unreleased] — 2026-05-26
+
+#### Fixed
+- **trusty-memory**: `open_activity_log_with_fallback` no longer panics on restricted filesystems — returns a `Discard` no-op log variant (#225)
+- **trusty-memory**: `AppState::emit` no longer blocks the tokio runtime — activity log writes offloaded to `spawn_blocking` (#232)
+- **trusty-memory**: `prompt_context_cache` uses `tokio::sync::RwLock` — KG cache rebuilds no longer stall async worker threads (#229)
+- **trusty-memory**: Per-palace write mutex eliminates TOCTOU race in `dedup_gate` — concurrent identical writes now correctly deduplicate (#230)
+- **trusty-mpm-tui**: Drawer detail pane and help overlay text now visible on light terminal themes — replaced `Color::White` with `Color::Reset` (#244)
+
+#### Changed
+- **trusty-memory**: `axum` and `tower-http` gated behind `axum-server` feature flag — consumers can link the rlib without the HTTP stack (`default-features = false`) (#226)
+- **trusty-memory**: `dispatch_tool` refactored from 957-line monolith to 28-line router + 23 per-tool handler functions (#227)
+- **trusty-memory**: Write hot path no longer triggers O(N) palace disk walks — palace name lookup uses in-memory cache; status aggregation moved to 30s background ticker (#228)
+- **trusty-memory**: BM25 indexing uses bounded `mpsc::channel(256)` — burst writes no longer accumulate unbounded background tasks; queue-full events are logged and skipped (#231)
+
+#### Internal
+- **trusty-memory**: `run_serve` startup hydration deduplicated into `spawn_startup_tasks` helper (#233)
+- **trusty-memory**: Test helper `test_state()` returns `(AppState, TempDir)` — eliminates `mem::forget` temp directory leaks across 262 tests (#234)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,7 @@ control plane, and an orchestrator — all co-located under one Cargo workspace.
 ## Project Overview
 
 This is a **Rust workspace** (Cargo workspace, resolver v2, glob members
-`crates/*`) under the Elastic License 2.0 (per-crate; a few crates are MIT —
-see each `Cargo.toml`). Every crate manages its own `version` field independently;
+`crates/*`) under the MIT License. Every crate manages its own `version` field independently;
 `[workspace.package]` shares `rust-version`, `edition`, `license`, `repository`,
 and `authors` but no longer carries a version field (see #343).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # trusty-tools — Claude Code Instructions
 
 Unified Rust workspace consolidating the entire trusty-* AI tooling ecosystem.
-20 crates — shared libraries, daemon/MCP servers, the MPM platform, the
+21 crates — shared libraries, daemon/MCP servers, the MPM platform, the
 control plane, and an orchestrator — all co-located under one Cargo workspace.
 
 ## Project Overview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,156 @@
+# Contributing to trusty-tools
+
+Thank you for your interest in contributing to trusty-tools! This document provides guidelines for development and contributing code back to the project.
+
+## Getting Started
+
+**Before contributing, read [CLAUDE.md](CLAUDE.md)** — it is the authoritative reference for development workflows, conventions, and internal tooling patterns.
+
+### Prerequisites
+
+- Rust 1.91+ (enforced by MSRV in the workspace)
+- Git
+- Node.js + pnpm (only if working on embedded Svelte UIs)
+
+### Build and Test
+
+```bash
+# Build all crates (debug)
+cargo build
+
+# Build release (optimized)
+cargo build --release
+
+# Run all tests
+cargo test
+
+# Check without codegen (fast)
+cargo check
+
+# Lint everything
+cargo clippy --workspace --all-targets -- -D warnings
+
+# Format check
+cargo fmt --check
+
+# Format and fix
+cargo fmt
+```
+
+For single-crate workflows, use `-p <crate-name>` to scope commands. See CLAUDE.md for the full command reference.
+
+## Worktree Discipline
+
+All code changes happen in **dedicated git worktrees** branched off `origin/main`. This protects the main checkout from mutation and allows safe parallel work.
+
+```bash
+# Create a worktree for your feature/fix
+git fetch origin main
+git worktree add -b <feature-branch> .claude/worktrees/<dirname> origin/main
+cd .claude/worktrees/<dirname>
+
+# … edit, build, test, commit from here …
+
+# After PR merge, clean up
+git worktree remove --force <path>
+git push origin --delete <feature-branch>
+```
+
+**Important:** Never use `git reset --hard`, `git checkout .`, or `git stash` against the main checkout. The main repo is inspection-only.
+
+## Code Conventions
+
+### SLOC File Size Limits
+
+Enforced per-crate, dual-cap (production vs. test):
+
+| File Type | Cap | Enforcement |
+|---|---|---|
+| Production source (`.rs` in `src/`) | **500 SLOC** | Mechanical gate in CI + pre-commit hook |
+| Test / benchmark files | **1500 SLOC** | Mechanical gate in CI |
+
+When a file approaches its limit, split it into focused submodules before adding more features. Run:
+
+```bash
+bash scripts/check_line_cap.sh        # Check current status
+bash scripts/check_line_cap.sh --update  # Ratchet down after intentional splits
+```
+
+### Error Handling
+
+- **Library crates:** Use `thiserror::Error` for structured error enums
+- **Application/binary crates:** Use `anyhow::Result` for ergonomic error handling
+- **Never** use `unwrap()` in library code; reserve `expect()` for genuine invariants only
+
+### Logging
+
+- Log to **stderr only** via `tracing` macros — stdout must stay clean for MCP JSON-RPC framing
+- Never log to stdout in daemons or MCP servers
+
+### Documentation
+
+Every public item (function, struct, trait, module) must carry three comment sections:
+
+```rust
+/// Why: <motivation — the problem this solves>
+/// What: <mechanical description of what it does>
+/// Test: <where coverage lives, or why untestable>
+pub fn my_function() { … }
+```
+
+## Commit Message Format
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+Closes #<issue>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `perf`, `test`, `chore`, `docs`
+
+**Examples:**
+- `feat(trusty-search): add branch-aware query routing (#456)`
+- `fix(trusty-memory): resolve race condition in concurrent writes`
+- `refactor(trusty-agents): extract validation logic to separate module`
+- `perf(trusty-analyze): optimize KG expansion with caching`
+
+## Per-Crate Versioning & Release
+
+Each crate independently manages its version in its `Cargo.toml`. There is no workspace-level version.
+
+**Release workflow:**
+
+1. Bump `version` in `crates/<name>/Cargo.toml`
+2. Run `cargo test -p <name>` and `cargo clippy --workspace -- -D warnings`
+3. Commit: `version: bump <name> to <version>`
+4. Create git tag: `git tag <crate-name>-v<version>`
+5. Push tag: `git push origin <crate-name>-v<version>`
+6. Publish: `cargo publish -p <crate-name>`
+
+For UI-embedding crates, use `SKIP_UI_BUILD=1 cargo publish`.
+
+See [docs/reference/release-workflow.md](docs/reference/release-workflow.md) for macOS-specific notes and the full convention.
+
+## Pull Request Process
+
+1. **Create a worktree and feature branch** (see Worktree Discipline above)
+2. **Make your changes** following the conventions above
+3. **Test locally:** `cargo test --workspace`
+4. **Lint:** `cargo clippy --workspace --all-targets -- -D warnings && cargo fmt`
+5. **Check line caps:** `bash scripts/check_line_cap.sh` (exit 0 = clean)
+6. **Commit with a conventional message** (see Commit Message Format)
+7. **Push to origin:** `git push -u origin <feature-branch>`
+8. **Open a PR** linking any related issues
+9. **Wait for trusty-review + CI** (all checks must pass)
+
+## License
+
+All contributions are licensed under the MIT License. By contributing, you agree to license your work under MIT.
+
+---
+
+For detailed development information, references, and troubleshooting, consult [CLAUDE.md](CLAUDE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ git worktree remove --force <path>
 git push origin --delete <feature-branch>
 ```
 
+**Note on worktree paths:** The `.claude/worktrees/<dirname>` path is an internal convention used by Claude Code and automated tooling. External contributors may use any worktree location they prefer (e.g., `../trusty-tools-worktrees/<dirname>` or a sibling directory).
+
 **Important:** Never use `git reset --hard`, `git checkout .`, or `git stash` against the main checkout. The main repo is inspection-only.
 
 ## Code Conventions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,7 @@ rust-version = "1.91"
 # version = "0.4.0" — REMOVED. Every crate manages its own version independently
 # in its own Cargo.toml. See issue #343 and CLAUDE.md "Git Tag / Release Convention".
 # When publishing, bump only the crates that actually changed.
-# NOTE: workspace-level license is MIT. All crates that do not declare an
-# explicit license field inherit this via `license.workspace = true`.
-# trusty-search uses `license-file` (excluded from relicense, see #893).
-# trusty-memory declares `license = "MIT"` directly (unchanged).
+# NOTE: workspace-level license is MIT. All crates inherit this via `license.workspace = true`.
 license = "MIT"
 repository = "https://github.com/bobmatnyc/trusty-tools"
 authors = ["Bob Matsuoka <bob@matsuoka.com>"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # trusty-tools
 
 Unified Rust workspace consolidating the entire trusty-* AI tooling ecosystem.
-Unified Rust workspace consolidating 25 crates of AI development tooling,
-with three flagship MCP servers for code search, memory management, and analysis.
+20 crates of AI development tooling with three flagship MCP servers for code search, memory management, and analysis.
 
 ## Three Flagship MCP Servers
 
@@ -56,7 +55,7 @@ cargo run -p trusty-memory -- serve
 # }
 ```
 
-**MCP tools:** `store_memory`, `search_memories`, `update_memory`, `list_collections`, `create_collection`, `get_memory`, `delete_memory`
+**MCP tools:** `memory_remember`, `memory_recall`, `memory_recall_deep`, `memory_recall_all`, `memory_note`, `memory_list`, `memory_forget`, `list_prompt_facts`, `remove_prompt_fact`, `get_prompt_context`
 
 See [crates/trusty-memory/README.md](crates/trusty-memory/README.md) for full documentation.
 
@@ -104,13 +103,13 @@ documentation.
 
 ---
 
-## Full Crate Index (All 25 Crates)
+## Full Crate Index (All 20 Crates)
 
 ### Core Daemons / MCP Servers
 
 | Crate | Description | License |
 |---|---|---|
-| `trusty-search` | Hybrid code search (BM25 + vector + KG) + MCP server | Elastic-2.0 |
+| `trusty-search` | Hybrid code search (BM25 + vector + KG) + MCP server | MIT |
 | `trusty-memory` | Memory palace UI + MCP frontend (storage engine lives in `trusty-common`'s `memory-core` feature) | MIT |
 | `trusty-analyze` | Code-analysis sidecar daemon (complexity, smells, facts) + MCP server | MIT |
 
@@ -132,21 +131,28 @@ documentation.
 
 | Crate | Description |
 |---|---|
-| `trusty-mpm-core` | Core domain types and traits |
-| `trusty-mpm-mcp` | MCP server for MPM (OpenAPI / Swagger) |
-| `trusty-mpm-daemon` | Background daemon service |
-| `trusty-mpm-client` | API client library |
-| `trusty-mpm-cli` | CLI binary — `trusty-mpm` / `tm` |
-| `trusty-mpm-tui` | Terminal UI (ratatui + crossterm) |
-| `trusty-mpm-telegram` | Telegram bot integration |
+| `trusty-mpm` | Core platform with embedded CLI, daemon, and MCP server |
 | `trusty-mpm-gui` | Desktop GUI (Tauri) |
+
+### Supporting Tools & Agents
+
+| Crate | Description |
+|---|---|
+| `trusty-bm25-daemon` | Standalone BM25 full-text search daemon |
+| `trusty-code` | Code generation and analysis utilities |
+| `trusty-console` | Terminal UI for system monitoring |
+| `trusty-controller` | Infrastructure controller |
+| `trusty-progress` | Progress tracking and reporting |
+| `trusty-review` | Code review automation and analysis |
 
 ### Analytics & Orchestration
 
 | Crate | Description |
 |---|---|
 | `trusty-git-analytics` | Developer productivity analytics from git history |
-| `trusty-agents` | agent orchestration platform |
+| `trusty-agents` | Agent orchestration platform |
+| `trusty-agents-common` | Shared types and utilities for agent framework |
+| `trusty-agents-local` | Local agent runtime implementation |
 | `cto-assistant` | CTO domain assistant |
 
 ## Architecture
@@ -226,23 +232,6 @@ cargo install --path crates/trusty-search --locked
 # More tools available via: cargo install --path crates/<crate>
 ```
 
-## Quick Start — All Crates (Source Build)
-
-```bash
-git clone https://github.com/bobmatnyc/trusty-tools
-cd trusty-tools
-
-# Build all crates
-cargo build --release
-
-# Run all tests
-cargo test
-
-# Install the CLI tools
-cargo install --path crates/trusty-search --locked
-# More tools available via: cargo install --path crates/<crate>
-```
-
 ## Build & Test Commands
 
 ```bash
@@ -258,14 +247,14 @@ cargo fmt
 
 ## Workspace Info
 
-**Single source of truth:** This monorepo consolidates seven formerly separate repos. All 24 crates are co-located under `crates/` with one workspace root and one `Cargo.lock` — no more `[patch.crates-io]` dances during active development.
+**Single source of truth:** This monorepo consolidates seven formerly separate repos. All 20 crates are co-located under `crates/` with one workspace root and one `Cargo.lock` — no more `[patch.crates-io]` dances during active development.
 
-**MSRV:** Rust 1.88+ (required for `let-chains` used by `trusty-mpm-*` and `trusty-agents` in edition 2024)
+**MSRV:** Rust 1.91+ (required by indirect `aws-smithy-*` dependencies)
 
-**License:** Elastic License 2.0 (most crates), MIT (trusty-memory, trusty-analyze). See each crate's `Cargo.toml` for the authoritative license field.
+**License:** MIT for all crates. See each crate's `Cargo.toml` for the authoritative license field.
 
 **Where to start:**
 - **I want to search code:** Read [crates/trusty-search/README.md](crates/trusty-search/README.md)
 - **I want persistent memory:** Read [crates/trusty-memory/README.md](crates/trusty-memory/README.md)
-- **I want the full platform: Read [crates/trusty-agents/README.md](crates/trusty-agents/README.md)
+- **I want the full platform:** Read [crates/trusty-agents/README.md](crates/trusty-agents/README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # trusty-tools
 
 Unified Rust workspace consolidating the entire trusty-* AI tooling ecosystem.
-20 crates of AI development tooling with three flagship MCP servers for code search, memory management, and analysis.
+21 crates of AI development tooling with three flagship MCP servers for code search, memory management, and analysis.
 
 ## Three Flagship MCP Servers
 
@@ -103,7 +103,7 @@ documentation.
 
 ---
 
-## Full Crate Index (All 20 Crates)
+## Full Crate Index (All 21 Crates)
 
 ### Core Daemons / MCP Servers
 
@@ -247,7 +247,7 @@ cargo fmt
 
 ## Workspace Info
 
-**Single source of truth:** This monorepo consolidates seven formerly separate repos. All 20 crates are co-located under `crates/` with one workspace root and one `Cargo.lock` — no more `[patch.crates-io]` dances during active development.
+**Single source of truth:** This monorepo consolidates seven formerly separate repos. All 21 crates are co-located under `crates/` with one workspace root and one `Cargo.lock` — no more `[patch.crates-io]` dances during active development.
 
 **MSRV:** Rust 1.91+ (required by indirect `aws-smithy-*` dependencies)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported Versions
+
+We maintain security updates for recent releases. The exact version support matrix is maintained in the individual crate CHANGELOG files (located in `crates/*/CHANGELOG.md`).
+
+General guidance:
+- Always upgrade to the latest version for security fixes
+- Per-crate versioning means updates can be released independently
+- Subscribe to [GitHub Security Advisories](https://github.com/bobmatnyc/trusty-tools/security/advisories) to be notified of published vulnerabilities
+
+## Reporting Security Vulnerabilities
+
+We take security seriously. If you discover a security vulnerability, **do not open a public issue**. Instead, please report it privately:
+
+**Email:** r@1mc.io
+
+**Include in your report:**
+- A clear description of the vulnerability
+- Steps to reproduce (if applicable)
+- Affected crate(s) and version(s)
+- Potential impact and severity
+- Any known mitigations
+
+## Response and Disclosure
+
+- **Acknowledgment:** We will acknowledge receipt within 48 hours
+- **Triage:** We will assess severity and begin work on a fix
+- **Fix timeline:** Critical vulnerabilities are addressed within 7 days; others within 30 days
+- **Disclosure:** We will coordinate a responsible disclosure timeline with you before publishing a fix
+
+## Dependency Security
+
+The project uses `cargo audit` to scan for known vulnerabilities in dependencies:
+
+```bash
+cargo audit
+```
+
+This is run in CI on every commit. Dependencies are kept up-to-date as part of regular maintenance.
+
+## Secure Coding Practices
+
+See [CLAUDE.md](CLAUDE.md) for the project's development conventions, including:
+- Error handling best practices
+- No use of `unsafe` except in carefully justified library code
+- No global state or unsynchronized access patterns
+- Logging to stderr only (no secrets leak to stdout)
+
+## Questions
+
+For security-related questions or concerns, email r@1mc.io.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,11 @@ General guidance:
 
 ## Reporting Security Vulnerabilities
 
-We take security seriously. If you discover a security vulnerability, **do not open a public issue**. Instead, please report it privately:
+We take security seriously. If you discover a security vulnerability, **do not open a public issue**. Instead, please report it privately using one of the following channels:
 
-**Email:** r@1mc.io
+**Primary (Recommended):** [GitHub Security Advisories](https://github.com/bobmatnyc/trusty-tools/security/advisories/new)
+
+**Secondary:** r@1mc.io
 
 **Include in your report:**
 - A clear description of the vulnerability
@@ -49,4 +51,4 @@ See [CLAUDE.md](CLAUDE.md) for the project's development conventions, including:
 
 ## Questions
 
-For security-related questions or concerns, email r@1mc.io.
+For security-related questions or concerns, please use the reporting channels above.

--- a/crates/cto-assistant/LICENSE
+++ b/crates/cto-assistant/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bob Matsuoka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/tc-services/LICENSE
+++ b/crates/tc-services/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bob Matsuoka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/trusty-common/LICENSE
+++ b/crates/trusty-common/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bob Matsuoka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/trusty-console/LICENSE
+++ b/crates/trusty-console/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bob Matsuoka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/trusty-cto-db/LICENSE
+++ b/crates/trusty-cto-db/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bob Matsuoka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Implements Work Area A (repo files) of #1317. Decisions locked: MIT everywhere (scrub Elastic-2.0); per-crate CHANGELOGs (root = index); P0/P1/P2 priorities (label side done separately).

Changes (14 files):
- **README.md**: crate count 25→20; replaced fabricated MPM sub-crate list with real crates (trusty-mpm, trusty-mpm-gui); added 7 missing crates to index; MSRV 1.88→1.91; corrected trusty-memory MCP tool names (memory_remember/recall/note…); removed duplicate quick-start; fixed broken markdown; Elastic-2.0 → MIT.
- **CLAUDE.md**: scrubbed Elastic-2.0 claim → MIT.
- **Cargo.toml**: removed stale license-file/#893 comment.
- **CHANGELOG.md**: converted to a per-crate index.
- **New**: CONTRIBUTING.md, SECURITY.md, .github/ISSUE_TEMPLATE/{bug_report,feature_request}.md, .github/PULL_REQUEST_TEMPLATE.md.
- **New LICENSE (MIT)** for the 5 publishable crates missing one: trusty-common, trusty-console, cto-assistant, tc-services, trusty-cto-db.

Verification: \`grep -rni elastic README.md CLAUDE.md Cargo.toml\` clean; \`cargo metadata\` confirms root manifest valid. Docs/manifest-comment/LICENSE only — no code logic changes.

Note: GitHub repo description still needs an admin-token update (separate, flagged to maintainer).

Closes #1317.