### PR TITLE
feat(trusty-controller): tctl Phase-1 — install/upgrade/ui/status + confirm-then-apply auto-update on trusty-progress (#1316)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10851,6 +10851,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trusty-common",
+ "trusty-progress",
  "which 6.0.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ trusty-review = { path = "crates/trusty-review", version = "0.3.10" }
 # published library crate; the path entry remains so any local lib consumers
 # resolve in-tree.
 trusty-console = { path = "crates/trusty-console", version = "0.3.0" }
+# trusty-progress: shared rustup/cargo-style progress + status display (#1315).
+# Consumed by tctl for install/upgrade component rows; published library crate.
+trusty-progress = { path = "crates/trusty-progress", version = "0.1.0" }
 
 # ── Async runtime / HTTP ────────────────────────────────────────────────────
 anyhow = "1"

--- a/crates/trusty-controller/Cargo.toml
+++ b/crates/trusty-controller/Cargo.toml
@@ -43,7 +43,13 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 # Shared update primitives (check_crates_io, perform_upgrade, verify_installed_binary,
 # is_launchd_supervised, upgrade_and_restart) reused by tctl updates/upgrade.
-trusty-common = { workspace = true }
+# The `update-check` feature gates the `trusty_common::update` module exposing
+# those primitives (it adds zero new transitive deps; the flag controls module
+# compilation only).
+trusty-common = { workspace = true, features = ["update-check"] }
+# Rustup/cargo-style progress display (#1315): Narrator `info:` lines + the
+# right-aligned ComponentTracker table for install/upgrade rows.
+trusty-progress = { workspace = true }
 
 [dev-dependencies]
 # Temporary directory helpers for integration test isolation

--- a/crates/trusty-controller/src/commands/auto_update.rs
+++ b/crates/trusty-controller/src/commands/auto_update.rs
@@ -1,0 +1,115 @@
+//! Opt-in automatic update CHECK that notifies — never auto-applies (#1316).
+//!
+//! Why: The #1316 added requirement asks for an opt-in periodic/background check
+//! that *notifies* the operator that updates are available but **never** mutates
+//! installed binaries without confirmation. This module is the notify-only half:
+//! it is gated behind `[controller] auto_update_check` in the config and, when
+//! enabled, surfaces a short "updates available — run `tctl upgrade`" notice. It
+//! never calls any apply primitive; applying always goes through the explicit
+//! `tctl upgrade` confirm-then-apply gate.
+//!
+//! What: [`auto_update_enabled`] reads the config flag (off by default — the
+//! safe posture). [`notice_for`] formats the notification line from a candidate
+//! count (a pure function). [`maybe_notify`] is the side-effecting entry point:
+//! when enabled, it probes the stable set and, when updates exist, prints the
+//! notice to stderr — and returns whether it notified.
+//!
+//! Test: `tests` covers the pure `notice_for` formatting and the disabled-by-
+//! default `auto_update_enabled` path against a default config.
+
+use super::runtime::block_on;
+use super::stable_set::stable_set;
+use super::up::config::{load_boot_config, BootConfig};
+use super::update_engine::gather_candidates;
+
+/// Whether the opt-in auto-update check is enabled in `config`.
+///
+/// Why: The default posture is OFF — tctl must not even *probe* crates.io in the
+/// background unless the operator opted in via `[controller] auto_update_check`.
+///
+/// What: Returns `config.controller.auto_update_check`.
+///
+/// Test: `tests::disabled_by_default`.
+pub fn auto_update_enabled(config: &BootConfig) -> bool {
+    config.controller.auto_update_check
+}
+
+/// Format the notify-only notification line for `count` available updates.
+///
+/// Why: A pure formatter keeps the wording consistent and testable, and makes
+/// explicit that the notice only *points at* the confirm-then-apply command —
+/// it never implies anything was applied.
+///
+/// What: Returns `None` when `count == 0` (nothing to say); otherwise a line
+/// like `"N update(s) available — run `tctl upgrade` to review and apply."`.
+///
+/// Test: `tests::notice_for_zero_is_none`, `tests::notice_for_some`.
+pub fn notice_for(count: usize) -> Option<String> {
+    if count == 0 {
+        return None;
+    }
+    Some(format!(
+        "{count} trusty update(s) available — run `tctl upgrade` to review and apply (nothing is changed without your confirmation)."
+    ))
+}
+
+/// Run the opt-in background update check, notifying when updates exist.
+///
+/// Why: The single side-effecting entry point a caller (e.g. `tctl up` or a
+/// scheduled invocation) uses to surface available updates without ever applying
+/// them.
+///
+/// What: Loads the controller config; if the check is disabled, returns `false`
+/// immediately (no network). When enabled, probes the stable set via
+/// `gather_candidates` (which is itself throttled to once/24h by
+/// `trusty_common::update`), prints [`notice_for`] to stderr when there are
+/// candidates, and returns whether it notified. Never mutates binaries.
+///
+/// Test: Side-effecting (network/config); the pure pieces are unit-tested.
+pub fn maybe_notify() -> bool {
+    let config = load_boot_config().unwrap_or_default();
+    if !auto_update_enabled(&config) {
+        return false;
+    }
+    let candidates = block_on(gather_candidates(&stable_set()));
+    match notice_for(candidates.len()) {
+        Some(line) => {
+            eprintln!("{line}");
+            true
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: The default posture must be OFF — no opt-in, no background probing.
+    /// What: Asserts `auto_update_enabled` is false for a default config.
+    /// Test: This is the test.
+    #[test]
+    fn disabled_by_default() {
+        assert!(!auto_update_enabled(&BootConfig::default()));
+    }
+
+    /// Why: Zero updates must produce no notice (silence when current).
+    /// What: Asserts `notice_for(0)` is `None`.
+    /// Test: This is the test.
+    #[test]
+    fn notice_for_zero_is_none() {
+        assert_eq!(notice_for(0), None);
+    }
+
+    /// Why: A non-zero count must point at the confirm-then-apply command and
+    /// never claim anything was applied.
+    /// What: Asserts the notice mentions the count and `tctl upgrade`.
+    /// Test: This is the test.
+    #[test]
+    fn notice_for_some() {
+        let n = notice_for(3).expect("some");
+        assert!(n.contains('3'));
+        assert!(n.contains("tctl upgrade"));
+        assert!(n.contains("confirmation"));
+    }
+}

--- a/crates/trusty-controller/src/commands/install.rs
+++ b/crates/trusty-controller/src/commands/install.rs
@@ -1,48 +1,287 @@
-//! `tctl install` — zero-knowledge system install (UUC2, DOC-8).
+//! `tctl install` — install the agreed STABLE trusty tool set (#1316, DOC-8).
 //!
-//! Why: The one-time entry point that brings a vanilla machine to a fully
-//! installed and verified stack. Idempotent: already-installed members are
-//! reported no-ops (DOC-3 §4 / DOC-8 §1.5).
+//! Why: The one-time entry point that brings a machine to a fully-installed
+//! stack. Installs the canonical, topologically-ordered stable set as a unit so
+//! the platform comes up coherent rather than drifting member-by-member.
+//! Idempotent: an already-installed member is re-run through `cargo install`
+//! (cheap no-op when current) and reported.
 //!
-//! What: Phase-0 stub. Phase-1 will implement the DOC-8 §1 flow:
-//! preflight → manifest → topological install → supervise daemons →
-//! contract verify → rollup. Each cargo member uses
-//! `trusty_common::update::perform_upgrade` (= `cargo install <crate> --locked`
-//! with `SKIP_UI_BUILD=1` for UI-embedding members). The orchestrator uses
-//! `uv tool install claude-mpm`.
+//! What: Resolves the requested members against [`super::stable_set`], installs
+//! each in order via `trusty_common::update::perform_upgrade` (= `cargo install
+//! <crate> --locked`), health-gates each freshly-installed binary with
+//! `verify_installed_binary`, and renders rustup-style per-tool component rows
+//! via `trusty-progress`. Honours `--yes` (non-interactive) and `--json`
+//! (machine output). Returns a process exit code: 0 all installed, 2 one or more
+//! failed.
 //!
-//! Test: `run(&[], false, false)` does not panic.
+//! Test: `tests` covers the JSON envelope shaping (`build_report`) and the
+//! unknown-member handling; the network/`cargo install` path is side-effecting
+//! and validated manually.
 
-use crate::output;
+use serde::Serialize;
+use trusty_progress::{Component, ComponentTracker};
+
+use super::progress_ui::{narrator, prompt_yes_no};
+use super::runtime::block_on;
+use super::stable_set::{select_members, StableMember};
+use crate::output::render_json;
+
+/// One member's install outcome for the `--json` report.
+///
+/// Why: A typed per-member result keeps the machine output stable and testable.
+/// What: `member` is the crate name; `ok` whether it installed + health-gated;
+/// `detail` a human note (e.g. the error on failure).
+/// Test: `tests::report_serialises`.
+#[derive(Clone, Debug, Serialize)]
+pub struct InstallOutcome {
+    /// Crate name installed.
+    pub member: String,
+    /// Whether install + health-gate succeeded.
+    pub ok: bool,
+    /// Human detail / error message.
+    pub detail: String,
+}
+
+/// The aggregate install report.
+///
+/// Why: `--json` consumers want the whole rollup in one object with an overall
+/// verdict; the human path renders the same data as a component table.
+/// What: Holds per-member outcomes and the computed `all_ok`.
+/// Test: `tests::report_serialises`, `tests::report_all_ok`.
+#[derive(Clone, Debug, Serialize)]
+pub struct InstallReport {
+    /// Fixed command tag for JSON consumers.
+    pub command: &'static str,
+    /// Per-member install outcomes in install order.
+    pub members: Vec<InstallOutcome>,
+    /// Whether every member installed successfully.
+    pub all_ok: bool,
+}
+
+impl InstallReport {
+    /// Build a report from per-member outcomes.
+    ///
+    /// Why: Centralises the `all_ok` derivation so the exit code and JSON agree.
+    /// What: Sets `command = "install"` and `all_ok = every outcome ok`.
+    /// Test: `tests::report_all_ok`.
+    fn build(members: Vec<InstallOutcome>) -> Self {
+        let all_ok = members.iter().all(|m| m.ok);
+        Self {
+            command: "install",
+            members,
+            all_ok,
+        }
+    }
+
+    /// Process exit code: 0 when all installed, 2 when any failed.
+    ///
+    /// Why: A boot/automation script branches on this.
+    /// What: `0` if `all_ok`, else `2` (partial/total failure — stack degraded).
+    /// Test: `tests::exit_code_reflects_all_ok`.
+    fn exit_code(&self) -> i32 {
+        if self.all_ok {
+            0
+        } else {
+            2
+        }
+    }
+}
 
 /// Handle `tctl install [<members>…]`.
 ///
-/// Why: Phase-0 entry point for the system install flow.
+/// Why: Phase-1 entry point for the system install flow (#1316 priority 1).
 ///
-/// What: `members` names specific members to install; empty = all enabled
-/// members. `yes` bypasses the blast-radius confirmation (DOC-3 §5). `json`
-/// selects machine output.
+/// What: Resolves `members` against the stable set (empty = all). On a TTY
+/// without `--yes`, confirms the blast radius before installing. Installs each
+/// member in topological order, rendering progress rows; emits either the human
+/// component table + summary or the `--json` [`InstallReport`]. Returns the
+/// process exit code.
 ///
-/// Test: Call with an empty slice and both `json` values; neither should panic.
-pub fn run(members: &[String], yes: bool, json: bool) {
-    let mut label = "install".to_owned();
-    if yes {
-        label.push_str(" --yes");
+/// Test: `tests::run_unknown_member_is_error`; the install path itself is
+/// side-effecting (`cargo install`) and validated manually.
+pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
+    let (selected, unknown) = select_members(members);
+
+    if !unknown.is_empty() {
+        let msg = format!("unknown member(s): {}", unknown.join(", "));
+        if json {
+            let _ = render_json(&serde_json::json!({
+                "command": "install",
+                "error": msg,
+            }));
+        } else {
+            eprintln!("tctl install: {msg}");
+        }
+        return 3;
     }
-    if !members.is_empty() {
-        label.push(' ');
-        label.push_str(&members.join(" "));
+
+    // Confirm the blast radius unless --yes or non-interactive (#1316 default-safe).
+    if !yes && super::progress_ui::is_tty() && !json {
+        let names: Vec<&str> = selected.iter().map(|m| m.crate_name.as_str()).collect();
+        let q = format!("Install {} tool(s): {}? ", selected.len(), names.join(", "));
+        if !prompt_yes_no(&q) {
+            eprintln!("tctl install: aborted (no confirmation).");
+            return 3;
+        }
     }
-    output::print_not_yet_implemented(&label, json);
+
+    let report = block_on(install_all(&selected, json));
+    if json {
+        let _ = render_json(&report);
+    } else {
+        print_human_summary(&report);
+    }
+    report.exit_code()
+}
+
+/// Install every selected member in order, returning the aggregate report.
+///
+/// Why: The async core, separated from the sync CLI shell so the runtime is
+/// owned in exactly one place (`run`).
+/// What: For each member, runs `perform_upgrade` then `verify_installed_binary`,
+/// rendering a `trusty-progress` narration line per member and a final component
+/// table of the installed binaries (with on-disk sizes when resolvable).
+/// Test: Side-effecting; the report shaping is tested via `InstallReport`.
+async fn install_all(selected: &[StableMember], json: bool) -> InstallReport {
+    let narr = narrator(json);
+    let _ = narr.info(&format!("installing {} component(s)", selected.len()));
+
+    let mut outcomes = Vec::with_capacity(selected.len());
+    let mut tracker = ComponentTracker::new(narr.output());
+
+    for m in selected {
+        let _ = narr.info(&format!("installing {}", m.crate_name));
+        match install_one(m).await {
+            Ok(()) => {
+                outcomes.push(InstallOutcome {
+                    member: m.crate_name.clone(),
+                    ok: true,
+                    detail: "installed".to_owned(),
+                });
+                tracker.add(Component::new(m.binary.clone(), binary_size(&m.binary)));
+            }
+            Err(e) => {
+                let _ = narr.error(&format!("{}: {e}", m.crate_name));
+                outcomes.push(InstallOutcome {
+                    member: m.crate_name.clone(),
+                    ok: false,
+                    detail: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // The component table (rustup-style) summarising what landed.
+    if !json {
+        let _ = tracker.print();
+    }
+    InstallReport::build(outcomes)
+}
+
+/// Install + health-gate a single member.
+///
+/// Why: One member's full install step, composed from the shared primitives.
+/// What: `perform_upgrade(crate)` then `verify_installed_binary(binary)`.
+/// Test: Side-effecting; covered indirectly.
+async fn install_one(m: &StableMember) -> anyhow::Result<()> {
+    trusty_common::update::perform_upgrade(&m.crate_name).await?;
+    trusty_common::update::verify_installed_binary(&m.binary).await
+}
+
+/// Best-effort on-disk size of an installed binary (for the component row).
+///
+/// Why: The rustup-style table shows a size column; we look up the installed
+/// file's size, defaulting to 0 when it cannot be resolved (the row still renders).
+/// What: Checks `~/.cargo/bin/<binary>`; returns its byte length or 0.
+/// Test: Side-effect-only (filesystem); the table layout is tested in trusty-progress.
+fn binary_size(binary: &str) -> u64 {
+    dirs::home_dir()
+        .map(|h| h.join(".cargo").join("bin").join(binary))
+        .and_then(|p| std::fs::metadata(p).ok())
+        .map(|md| md.len())
+        .unwrap_or(0)
+}
+
+/// Print the human-readable install summary footer.
+///
+/// Why: After the component table, a one-line verdict tells the operator whether
+/// everything landed.
+/// What: Prints `installed N/M` and lists any failures to stderr.
+/// Test: Side-effect-only; the data it reads is tested via `InstallReport`.
+fn print_human_summary(report: &InstallReport) {
+    let ok = report.members.iter().filter(|m| m.ok).count();
+    let narr = narrator(false);
+    let _ = narr.info(&format!("installed {}/{}", ok, report.members.len()));
+    for m in report.members.iter().filter(|m| !m.ok) {
+        let _ = narr.error(&format!("{}: {}", m.member, m.detail));
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Why: The JSON envelope is a public contract; pin its shape.
+    /// What: Builds a report and asserts the serialised keys/values.
+    /// Test: This is the test.
     #[test]
-    fn does_not_panic() {
-        run(&[], false, false);
-        run(&["trusty-search".to_owned()], true, true);
+    fn report_serialises() {
+        let report = InstallReport::build(vec![InstallOutcome {
+            member: "trusty-search".to_owned(),
+            ok: true,
+            detail: "installed".to_owned(),
+        }]);
+        let v = serde_json::to_value(&report).expect("serialises");
+        assert_eq!(v["command"], "install");
+        assert_eq!(v["all_ok"], true);
+        assert_eq!(v["members"][0]["member"], "trusty-search");
+    }
+
+    /// Why: `all_ok` must be false if any member failed.
+    /// What: Mixes an ok and a failed outcome; asserts `all_ok = false`.
+    /// Test: This is the test.
+    #[test]
+    fn report_all_ok() {
+        let report = InstallReport::build(vec![
+            InstallOutcome {
+                member: "a".to_owned(),
+                ok: true,
+                detail: String::new(),
+            },
+            InstallOutcome {
+                member: "b".to_owned(),
+                ok: false,
+                detail: "boom".to_owned(),
+            },
+        ]);
+        assert!(!report.all_ok);
+    }
+
+    /// Why: The exit code must track the verdict for automation.
+    /// What: Asserts 0 for all-ok and 2 for a failure.
+    /// Test: This is the test.
+    #[test]
+    fn exit_code_reflects_all_ok() {
+        let ok = InstallReport::build(vec![InstallOutcome {
+            member: "a".to_owned(),
+            ok: true,
+            detail: String::new(),
+        }]);
+        assert_eq!(ok.exit_code(), 0);
+        let bad = InstallReport::build(vec![InstallOutcome {
+            member: "a".to_owned(),
+            ok: false,
+            detail: "x".to_owned(),
+        }]);
+        assert_eq!(bad.exit_code(), 2);
+    }
+
+    /// Why: An unknown member must be a clean error (exit 3), not a silent skip.
+    /// What: Calls `run` with a bogus member in `--json` mode; asserts exit 3.
+    /// Test: This is the test.
+    #[test]
+    fn run_unknown_member_is_error() {
+        let code = run(&["not-a-real-tool".to_owned()], true, true);
+        assert_eq!(code, 3);
     }
 }

--- a/crates/trusty-controller/src/commands/install.rs
+++ b/crates/trusty-controller/src/commands/install.rs
@@ -202,14 +202,31 @@ async fn install_one(m: &StableMember) -> anyhow::Result<()> {
 ///
 /// Why: The rustup-style table shows a size column; we look up the installed
 /// file's size, defaulting to 0 when it cannot be resolved (the row still renders).
-/// What: Checks `~/.cargo/bin/<binary>`; returns its byte length or 0.
-/// Test: Side-effect-only (filesystem); the table layout is tested in trusty-progress.
+/// What: Resolves the cargo bin directory (`$CARGO_HOME/bin`, falling back to
+/// `~/.cargo/bin`) so the size resolves under a non-default `CARGO_HOME` (CI),
+/// then returns `<bin>/<binary>`'s byte length or 0.
+/// Test: Side-effect-only (filesystem); `cargo_bin_dir` is unit-tested in
+/// `tests::cargo_bin_dir_honours_cargo_home`.
 fn binary_size(binary: &str) -> u64 {
-    dirs::home_dir()
-        .map(|h| h.join(".cargo").join("bin").join(binary))
+    cargo_bin_dir()
+        .map(|d| d.join(binary))
         .and_then(|p| std::fs::metadata(p).ok())
         .map(|md| md.len())
         .unwrap_or(0)
+}
+
+/// Resolve the cargo binary install directory.
+///
+/// Why: `cargo install` honours `CARGO_HOME`; hardcoding `~/.cargo/bin` would
+/// mis-resolve installed-binary sizes under a custom `CARGO_HOME` (e.g. CI).
+/// What: Returns `$CARGO_HOME/bin` when `CARGO_HOME` is set and non-empty,
+/// otherwise `~/.cargo/bin` (or `None` if the home dir cannot be resolved).
+/// Test: `tests::cargo_bin_dir_honours_cargo_home`.
+fn cargo_bin_dir() -> Option<std::path::PathBuf> {
+    match std::env::var("CARGO_HOME") {
+        Ok(home) if !home.is_empty() => Some(std::path::PathBuf::from(home).join("bin")),
+        _ => dirs::home_dir().map(|h| h.join(".cargo").join("bin")),
+    }
 }
 
 /// Print the human-readable install summary footer.
@@ -284,6 +301,39 @@ mod tests {
             detail: "x".to_owned(),
         }]);
         assert_eq!(bad.exit_code(), 2);
+    }
+
+    /// Why: Re-review fix — `binary_size` must resolve under a non-default
+    /// `CARGO_HOME` (CI installs there), so `cargo_bin_dir` must honour the env
+    /// var rather than hardcoding `~/.cargo/bin`.
+    /// What: Sets `CARGO_HOME` to a temp path, asserts `cargo_bin_dir` returns
+    /// `<that>/bin`; clears it and asserts the fallback ends in `.cargo/bin`.
+    /// Restores the prior value so the process-global env is left untouched.
+    /// Test: This is the test.
+    #[test]
+    fn cargo_bin_dir_honours_cargo_home() {
+        let prior = std::env::var_os("CARGO_HOME");
+
+        // This test is the sole mutator of CARGO_HOME and restores it before
+        // returning; the controller crate runs no other env-racing tests.
+        std::env::set_var("CARGO_HOME", "/tmp/fake-cargo-home");
+        assert_eq!(
+            cargo_bin_dir(),
+            Some(std::path::PathBuf::from("/tmp/fake-cargo-home").join("bin"))
+        );
+
+        // Empty CARGO_HOME falls back to ~/.cargo/bin.
+        std::env::set_var("CARGO_HOME", "");
+        let fallback = cargo_bin_dir();
+        if let Some(p) = &fallback {
+            assert!(p.ends_with(std::path::Path::new(".cargo").join("bin")));
+        }
+
+        // Restore the prior environment.
+        match prior {
+            Some(v) => std::env::set_var("CARGO_HOME", v),
+            None => std::env::remove_var("CARGO_HOME"),
+        }
     }
 
     /// Why: An unknown member must be a clean error (exit 3), not a silent skip.

--- a/crates/trusty-controller/src/commands/install.rs
+++ b/crates/trusty-controller/src/commands/install.rs
@@ -105,10 +105,15 @@ pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
     if !unknown.is_empty() {
         let msg = format!("unknown member(s): {}", unknown.join(", "));
         if json {
-            let _ = render_json(&serde_json::json!({
+            if render_json(&serde_json::json!({
                 "command": "install",
                 "error": msg,
-            }));
+            }))
+            .is_err()
+            {
+                eprintln!("tctl install: failed to write JSON output");
+                return 1;
+            }
         } else {
             eprintln!("tctl install: {msg}");
         }
@@ -127,7 +132,12 @@ pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
 
     let report = block_on(install_all(&selected, json));
     if json {
-        let _ = render_json(&report);
+        // A failed machine-readable write must not exit 0: automation would
+        // read success from the exit code while the JSON never arrived.
+        if render_json(&report).is_err() {
+            eprintln!("tctl install: failed to write JSON output");
+            return 1;
+        }
     } else {
         print_human_summary(&report);
     }

--- a/crates/trusty-controller/src/commands/mod.rs
+++ b/crates/trusty-controller/src/commands/mod.rs
@@ -12,6 +12,7 @@
 //! Test: Each module has its own test section; `cargo test -p trusty-controller`
 //! runs them all.
 
+pub mod auto_update;
 pub mod config;
 pub mod doctor;
 pub mod ensure;
@@ -19,10 +20,14 @@ pub mod install;
 pub mod lifecycle;
 pub mod passthrough;
 pub mod port;
+pub mod progress_ui;
+pub mod runtime;
+pub mod stable_set;
 pub mod stack;
 pub mod status;
 pub mod ui;
 pub mod up;
+pub mod update_engine;
 pub mod updates;
 pub mod upgrade;
 pub mod version;

--- a/crates/trusty-controller/src/commands/progress_ui.rs
+++ b/crates/trusty-controller/src/commands/progress_ui.rs
@@ -1,0 +1,112 @@
+//! Shared `trusty-progress` wiring + interactive consent for install/upgrade.
+//!
+//! Why: The install and upgrade handlers both render rustup-style component rows
+//! and both need a confirm prompt. Centralising the [`trusty_progress::Output`]
+//! mode selection (honouring `--json`/TTY) and the stdin yes/no prompt keeps the
+//! two handlers thin and consistent, and keeps all interactive I/O in one place.
+//!
+//! What: [`progress_mode`] picks the `trusty-progress` [`Mode`] from the `--json`
+//! flag and the ambient stderr TTY; [`narrator`] builds a stderr [`Narrator`];
+//! [`prompt_yes_no`] reads a yes/no answer from stdin (stderr prompt, stdout
+//! reserved for data); [`is_tty`] reports whether stdin is interactive.
+//!
+//! Test: `tests` covers `progress_mode`'s json→Plain rule and `is_tty`'s
+//! type; the stdin prompt is side-effect-only.
+
+use trusty_progress::{Mode, Narrator, Output};
+
+/// Pick the `trusty-progress` rendering mode for a command.
+///
+/// Why: Under `--json` (machine output) or a non-TTY (pipe/CI) we must not emit
+/// animated spinners or interleave human progress with the JSON on stdout;
+/// progress goes to stderr as plain lines. Interactive terminals get the full
+/// rustup-style animated display.
+///
+/// What: Returns [`Mode::Plain`] when `json` is set OR stderr is not a terminal;
+/// [`Mode::Interactive`] otherwise. (`Output::to_stderr` already autodetects the
+/// TTY, but threading `json` through lets `--json` force plain even on a TTY.)
+///
+/// Test: `tests::progress_mode_json_is_plain`.
+pub fn progress_mode(json: bool) -> Mode {
+    if json {
+        Mode::Plain
+    } else if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        Mode::Interactive
+    } else {
+        Mode::Plain
+    }
+}
+
+/// Build a stderr [`Narrator`] in the mode appropriate for the command.
+///
+/// Why: Progress narration (`info:` lines) must land on stderr so stdout stays
+/// clean for `--json` framing (CLAUDE.md). One helper keeps every call site from
+/// re-deriving the mode + sink.
+///
+/// What: Constructs an [`Output::to_stderr_with_mode`] using [`progress_mode`]
+/// and wraps it in a [`Narrator`]. The returned narrator's `output()` can be
+/// shared with a `ComponentTracker` so rows interleave correctly.
+///
+/// Test: Side-effect-only (writes to stderr); the mode logic is tested via
+/// `progress_mode`.
+pub fn narrator(json: bool) -> Narrator {
+    Narrator::new(Output::to_stderr_with_mode(progress_mode(json)))
+}
+
+/// Whether stdin is an interactive terminal we can prompt on.
+///
+/// Why: The confirm-then-apply gate (#1316) only prompts when it can actually
+/// read a human answer; on a pipe/CI it must fall back to the refuse-without-
+/// `--yes` posture.
+///
+/// What: Returns `true` when stdin is a TTY.
+///
+/// Test: `tests::is_tty_returns_bool` (the value depends on the harness's fds,
+/// so we assert only that it is callable and boolean).
+pub fn is_tty() -> bool {
+    std::io::IsTerminal::is_terminal(&std::io::stdin())
+}
+
+/// Prompt the operator with a yes/no question on stderr and read the answer.
+///
+/// Why: The confirm-then-apply gate needs interactive consent; centralising the
+/// prompt keeps the wording and the stderr-not-stdout discipline consistent.
+///
+/// What: Prints `{question} [y/N] ` to stderr (stdout is reserved for data),
+/// reads a line from stdin, and returns `true` only on an explicit `y`/`yes`
+/// (default No on empty input or read error — the safe default).
+///
+/// Test: Side-effect-only (stdin); the decision logic that consumes its result
+/// is unit-tested via `update_engine::decide_apply`.
+pub fn prompt_yes_no(question: &str) -> bool {
+    use std::io::Write;
+    eprint!("{question} [y/N] ");
+    let _ = std::io::stderr().flush();
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return false;
+    }
+    let ans = line.trim().to_ascii_lowercase();
+    ans == "y" || ans == "yes"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `--json` must always force plain (no animation, no stdout noise).
+    /// What: Asserts `progress_mode(true) == Mode::Plain`.
+    /// Test: This is the test.
+    #[test]
+    fn progress_mode_json_is_plain() {
+        assert_eq!(progress_mode(true), Mode::Plain);
+    }
+
+    /// Why: `is_tty` must be callable and return a bool regardless of harness fds.
+    /// What: Calls it and binds the result (the value is environment-dependent).
+    /// Test: This is the test.
+    #[test]
+    fn is_tty_returns_bool() {
+        let _v: bool = is_tty();
+    }
+}

--- a/crates/trusty-controller/src/commands/runtime.rs
+++ b/crates/trusty-controller/src/commands/runtime.rs
@@ -5,46 +5,105 @@
 //! `trusty_common::update` (network probes, `cargo install`). Rather than make
 //! the whole binary `#[tokio::main]` — which would change every handler's
 //! signature and complicate the `up` path's direct `process::exit` — we provide
-//! one helper that runs a future to completion on a small runtime, used only by
-//! the async handlers.
+//! helpers that build ONE runtime per command and drive futures on it.
 //!
-//! What: [`block_on`] builds a multi-thread tokio runtime (the workspace pins
-//! `tokio` with `features = ["full"]`) and drives `fut` to completion.
+//! What:
+//! - [`with_runtime`] builds a single multi-thread tokio runtime, hands the
+//!   caller its [`Handle`], and tears it down when the closure returns. A
+//!   command that needs to await several futures (e.g. `upgrade` gathers
+//!   candidates *then* applies them) builds the runtime exactly once and reuses
+//!   the handle, avoiding both the per-call construction cost and the
+//!   nested-runtime panic risk of constructing a second runtime while the first
+//!   is still live.
+//! - [`block_on`] is the single-future convenience wrapper over [`with_runtime`]
+//!   for commands that await exactly one future (`install`, `updates`,
+//!   `auto_update`).
 //!
-//! Test: `tests::block_on_runs_future` runs a trivial async block and asserts
-//! the result.
+//! Test: `tests::block_on_runs_future` and `tests::with_runtime_reuses_handle`.
 
 use std::future::Future;
 
-/// Run an async future to completion on a fresh tokio runtime.
+use tokio::runtime::{Builder, Handle, Runtime};
+
+/// Build the one multi-thread tokio runtime used for a command's async work.
 ///
-/// Why: The sync dispatcher needs to call async update primitives; one helper
-/// keeps the runtime construction in a single audited place.
+/// Why: Centralising construction in a single audited place keeps the `expect`
+/// rationale in one spot and lets every caller reuse the same runtime config.
 ///
-/// What: Builds a multi-threaded tokio runtime and blocks on `fut`, returning
-/// its output. Builds with `expect` because a runtime-construction failure is a
-/// fatal environment problem (no usable async executor) at a binary entry point,
-/// not a recoverable condition — there is nothing sensible to fall back to.
+/// What: Builds a multi-threaded tokio runtime (the workspace pins `tokio` with
+/// `features = ["full"]`). Uses `expect` because a runtime-construction failure
+/// is a fatal environment problem (no usable async executor) at a binary entry
+/// point, not a recoverable condition — there is nothing sensible to fall back
+/// to.
 ///
-/// Test: `tests::block_on_runs_future`.
-pub fn block_on<F: Future>(fut: F) -> F::Output {
-    tokio::runtime::Builder::new_multi_thread()
+/// Test: Exercised via [`with_runtime`] / [`block_on`] in `tests`.
+fn build_runtime() -> Runtime {
+    Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("failed to build tokio runtime")
-        .block_on(fut)
+}
+
+/// Build one runtime, run `f` with its [`Handle`], then drop the runtime.
+///
+/// Why: A command that awaits more than one future (e.g. `upgrade` gathers
+/// candidates and *then* applies them) must build the runtime ONCE and reuse it
+/// for every `handle.block_on(...)` call — constructing a fresh runtime per
+/// future is wasteful and risks a nested-runtime panic. This helper makes the
+/// single-runtime lifetime explicit and scoped.
+///
+/// What: Builds the runtime via [`build_runtime`], invokes `f` with a borrowed
+/// [`Handle`], and returns `f`'s result. The runtime is dropped when this
+/// function returns.
+///
+/// Test: `tests::with_runtime_reuses_handle`.
+pub fn with_runtime<T>(f: impl FnOnce(&Handle) -> T) -> T {
+    let rt = build_runtime();
+    f(rt.handle())
+}
+
+/// Run a single async future to completion on a freshly-built tokio runtime.
+///
+/// Why: Commands that await exactly one future want a one-liner; this keeps the
+/// runtime construction in [`with_runtime`] so there is still a single place
+/// runtimes are built.
+///
+/// What: Builds one runtime via [`with_runtime`] and blocks on `fut`, returning
+/// its output.
+///
+/// Test: `tests::block_on_runs_future`.
+pub fn block_on<F: Future>(fut: F) -> F::Output {
+    with_runtime(|handle| handle.block_on(fut))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Why: Confirm the bridge actually drives a future to completion.
+    /// Why: Confirm the single-future bridge actually drives a future to
+    /// completion.
     /// What: Runs `async { 21 + 21 }` and asserts the result.
     /// Test: This is the test.
     #[test]
     fn block_on_runs_future() {
         let v = block_on(async { 21 + 21 });
         assert_eq!(v, 42);
+    }
+
+    /// Why: The whole point of `with_runtime` is that ONE runtime drives several
+    /// futures; prove the same handle services two sequential `block_on`s
+    /// without panicking (a second runtime built while the first is live would
+    /// panic on a nested `block_on`).
+    /// What: Builds one runtime and awaits two futures on its handle, asserting
+    /// both results.
+    /// Test: This is the test.
+    #[test]
+    fn with_runtime_reuses_handle() {
+        let (a, b) = with_runtime(|handle| {
+            let a = handle.block_on(async { 1 + 1 });
+            let b = handle.block_on(async { 2 + 2 });
+            (a, b)
+        });
+        assert_eq!((a, b), (2, 4));
     }
 }

--- a/crates/trusty-controller/src/commands/runtime.rs
+++ b/crates/trusty-controller/src/commands/runtime.rs
@@ -1,0 +1,50 @@
+//! Tiny async-runtime bridge for the otherwise-synchronous command dispatch.
+//!
+//! Why: `tctl`'s dispatcher (`main.rs`) is synchronous, but several Phase-1
+//! commands (`install`, `upgrade`, `updates`) call async primitives in
+//! `trusty_common::update` (network probes, `cargo install`). Rather than make
+//! the whole binary `#[tokio::main]` — which would change every handler's
+//! signature and complicate the `up` path's direct `process::exit` — we provide
+//! one helper that runs a future to completion on a small runtime, used only by
+//! the async handlers.
+//!
+//! What: [`block_on`] builds a multi-thread tokio runtime (the workspace pins
+//! `tokio` with `features = ["full"]`) and drives `fut` to completion.
+//!
+//! Test: `tests::block_on_runs_future` runs a trivial async block and asserts
+//! the result.
+
+use std::future::Future;
+
+/// Run an async future to completion on a fresh tokio runtime.
+///
+/// Why: The sync dispatcher needs to call async update primitives; one helper
+/// keeps the runtime construction in a single audited place.
+///
+/// What: Builds a multi-threaded tokio runtime and blocks on `fut`, returning
+/// its output. Builds with `expect` because a runtime-construction failure is a
+/// fatal environment problem (no usable async executor) at a binary entry point,
+/// not a recoverable condition — there is nothing sensible to fall back to.
+///
+/// Test: `tests::block_on_runs_future`.
+pub fn block_on<F: Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime")
+        .block_on(fut)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: Confirm the bridge actually drives a future to completion.
+    /// What: Runs `async { 21 + 21 }` and asserts the result.
+    /// Test: This is the test.
+    #[test]
+    fn block_on_runs_future() {
+        let v = block_on(async { 21 + 21 });
+        assert_eq!(v, 42);
+    }
+}

--- a/crates/trusty-controller/src/commands/stable_set.rs
+++ b/crates/trusty-controller/src/commands/stable_set.rs
@@ -71,7 +71,7 @@ impl StableMember {
 /// non-daemon), and trusty-console (daemon). Library crates resolve as cargo
 /// dependencies and are not listed.
 ///
-/// Test: `tests::stable_set_is_pinned`, `tests::tga_crate_and_binary_differ`,
+/// Test: `tests::stable_set_is_pinned`, `tests::tga_crate_and_binary_names`,
 /// `tests::daemon_flags_match_spec`.
 pub fn stable_set() -> Vec<StableMember> {
     vec![
@@ -137,13 +137,15 @@ mod tests {
         );
     }
 
-    /// Why: `tga`'s crate name differs from most; the install command must use
-    /// the crate name for `cargo install` and the binary for probes.
-    /// What: Asserts tga's crate_name == binary == "tga" (both happen to match
-    /// here, but the field separation is what the install path depends on).
+    /// Why: The install command must use the crate name for `cargo install` and
+    /// the binary name for presence/health probes — they are read from separate
+    /// fields. For `tga` both fields happen to equal "tga", so this pins the
+    /// field *separation* (each field is independently populated and correct),
+    /// not that the two values differ.
+    /// What: Asserts tga's `binary` is "tga" and it is a non-daemon.
     /// Test: This is the test.
     #[test]
-    fn tga_crate_and_binary_differ() {
+    fn tga_crate_and_binary_names() {
         let tga = stable_set()
             .into_iter()
             .find(|m| m.crate_name == "tga")

--- a/crates/trusty-controller/src/commands/stable_set.rs
+++ b/crates/trusty-controller/src/commands/stable_set.rs
@@ -1,0 +1,207 @@
+//! The agreed STABLE trusty tool set — the coherent platform `tctl` installs and
+//! upgrades as a unit (#1316).
+//!
+//! Why: `tctl install` / `tctl upgrade` must operate on one canonical,
+//! topologically-ordered set so the whole platform moves together rather than
+//! drifting member-by-member. Encoding the set (and its install order) as data
+//! in one place means adding/removing a member is a data edit, never scattered
+//! branching, and keeps the install/upgrade/updates handlers agreeing on exactly
+//! which crates are in scope.
+//!
+//! What: Defines [`StableMember`] (crate name + binary name + whether it is a
+//! supervised daemon) and [`stable_set`] — the ordered member list:
+//! trusty-search, trusty-memory, trusty-analyze, trusty-review, tga, and
+//! trusty-console. Library crates (trusty-common, trusty-embedderd,
+//! trusty-bm25-daemon, …) are pulled in automatically as cargo dependencies of
+//! these binaries, so they are intentionally *not* listed here.
+//!
+//! Test: `tests` pins the ordered set, asserts every member's crate/binary
+//! names, and asserts the daemon flags.
+
+use serde::Serialize;
+
+/// One member of the stable trusty tool set.
+///
+/// Why: `tctl` keys three things off a member — the crates.io package name (for
+/// `cargo install` / `check_crates_io`), the installed binary name (for presence
+/// and health probes), and whether it is a launchd-supervised daemon (so upgrade
+/// can restart it cleanly). Bundling them keeps every handler consistent.
+///
+/// What: `crate_name` is the cargo package; `binary` is the installed binary
+/// (often equal, but `tga` differs); `daemon` marks members that run as a
+/// long-lived HTTP daemon and therefore need a connection-safe restart after an
+/// upgrade (`upgrade_and_restart`).
+///
+/// Test: `tests::stable_set_is_pinned`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct StableMember {
+    /// The crates.io package name (`cargo install <crate_name> --locked`).
+    pub crate_name: String,
+    /// The installed binary name probed on PATH (`which <binary>`).
+    pub binary: String,
+    /// Whether this member runs as a supervised daemon (needs restart on upgrade).
+    pub daemon: bool,
+}
+
+impl StableMember {
+    /// Construct a stable-set member.
+    ///
+    /// Why: Terse constructor keeps the [`stable_set`] table readable.
+    /// What: Builds a [`StableMember`] from borrowed parts.
+    /// Test: Exercised by [`stable_set`] and its tests.
+    fn new(crate_name: &str, binary: &str, daemon: bool) -> Self {
+        Self {
+            crate_name: crate_name.to_owned(),
+            binary: binary.to_owned(),
+            daemon,
+        }
+    }
+}
+
+/// The ordered, agreed STABLE trusty tool set (#1316).
+///
+/// Why: This is the single source of truth for what `tctl install` brings up and
+/// `tctl upgrade` moves forward. The order is the topological install order:
+/// the shared daemons (search/memory/analyze) first, then the review service and
+/// git-analytics it composes with, then the console (the HTTP front door that
+/// proxies the others) last so it discovers already-running members.
+///
+/// What: Returns the member list in install order — trusty-search,
+/// trusty-memory, trusty-analyze, trusty-review, tga (binary `tga`,
+/// non-daemon), and trusty-console (daemon). Library crates resolve as cargo
+/// dependencies and are not listed.
+///
+/// Test: `tests::stable_set_is_pinned`, `tests::tga_crate_and_binary_differ`,
+/// `tests::daemon_flags_match_spec`.
+pub fn stable_set() -> Vec<StableMember> {
+    vec![
+        StableMember::new("trusty-search", "trusty-search", true),
+        StableMember::new("trusty-memory", "trusty-memory", true),
+        StableMember::new("trusty-analyze", "trusty-analyze", true),
+        StableMember::new("trusty-review", "trusty-review", true),
+        StableMember::new("tga", "tga", false),
+        StableMember::new("trusty-console", "trusty-console", true),
+    ]
+}
+
+/// Filter the stable set to a caller-named subset, preserving install order.
+///
+/// Why: `tctl install <members…>` / `tctl upgrade <members…>` let the operator
+/// name a subset; resolving names against the canonical set (rather than the raw
+/// strings) validates them and keeps the topological order intact.
+///
+/// What: When `names` is empty, returns the full [`stable_set`]. Otherwise
+/// returns the members whose `crate_name` OR `binary` matches a requested name,
+/// in stable-set order, plus the list of unrecognised names.
+///
+/// Test: `tests::select_empty_returns_all`, `tests::select_subset_preserves_order`,
+/// `tests::select_reports_unknown`.
+pub fn select_members(names: &[String]) -> (Vec<StableMember>, Vec<String>) {
+    let all = stable_set();
+    if names.is_empty() {
+        return (all, Vec::new());
+    }
+    let selected: Vec<StableMember> = all
+        .iter()
+        .filter(|m| names.iter().any(|n| n == &m.crate_name || n == &m.binary))
+        .cloned()
+        .collect();
+    let unknown: Vec<String> = names
+        .iter()
+        .filter(|n| !all.iter().any(|m| *n == &m.crate_name || *n == &m.binary))
+        .cloned()
+        .collect();
+    (selected, unknown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: The set + its order is the load-bearing contract for install; pin it.
+    /// What: Asserts the exact ordered crate-name sequence.
+    /// Test: This is the test.
+    #[test]
+    fn stable_set_is_pinned() {
+        let names: Vec<String> = stable_set().into_iter().map(|m| m.crate_name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "trusty-search",
+                "trusty-memory",
+                "trusty-analyze",
+                "trusty-review",
+                "tga",
+                "trusty-console",
+            ]
+        );
+    }
+
+    /// Why: `tga`'s crate name differs from most; the install command must use
+    /// the crate name for `cargo install` and the binary for probes.
+    /// What: Asserts tga's crate_name == binary == "tga" (both happen to match
+    /// here, but the field separation is what the install path depends on).
+    /// Test: This is the test.
+    #[test]
+    fn tga_crate_and_binary_differ() {
+        let tga = stable_set()
+            .into_iter()
+            .find(|m| m.crate_name == "tga")
+            .expect("tga in set");
+        assert_eq!(tga.binary, "tga");
+        assert!(!tga.daemon);
+    }
+
+    /// Why: Upgrade restarts only daemons; the daemon flags drive that.
+    /// What: Asserts the console + the three core daemons + review are daemons
+    /// and tga is not.
+    /// Test: This is the test.
+    #[test]
+    fn daemon_flags_match_spec() {
+        let set = stable_set();
+        let daemon = |c: &str| {
+            set.iter()
+                .find(|m| m.crate_name == c)
+                .expect("present")
+                .daemon
+        };
+        assert!(daemon("trusty-search"));
+        assert!(daemon("trusty-memory"));
+        assert!(daemon("trusty-analyze"));
+        assert!(daemon("trusty-review"));
+        assert!(daemon("trusty-console"));
+        assert!(!daemon("tga"));
+    }
+
+    /// Why: An empty selection means "the whole platform".
+    /// What: Asserts `select_members(&[])` returns the full set, no unknowns.
+    /// Test: This is the test.
+    #[test]
+    fn select_empty_returns_all() {
+        let (sel, unknown) = select_members(&[]);
+        assert_eq!(sel.len(), stable_set().len());
+        assert!(unknown.is_empty());
+    }
+
+    /// Why: A named subset must keep install order regardless of arg order.
+    /// What: Requests console then search; asserts search comes first (set order).
+    /// Test: This is the test.
+    #[test]
+    fn select_subset_preserves_order() {
+        let (sel, unknown) =
+            select_members(&["trusty-console".to_owned(), "trusty-search".to_owned()]);
+        let names: Vec<String> = sel.into_iter().map(|m| m.crate_name).collect();
+        assert_eq!(names, vec!["trusty-search", "trusty-console"]);
+        assert!(unknown.is_empty());
+    }
+
+    /// Why: Unknown names must be surfaced, not silently dropped.
+    /// What: Requests a bogus name; asserts it lands in the unknown list.
+    /// Test: This is the test.
+    #[test]
+    fn select_reports_unknown() {
+        let (sel, unknown) = select_members(&["not-a-tool".to_owned()]);
+        assert!(sel.is_empty());
+        assert_eq!(unknown, vec!["not-a-tool".to_owned()]);
+    }
+}

--- a/crates/trusty-controller/src/commands/status.rs
+++ b/crates/trusty-controller/src/commands/status.rs
@@ -114,12 +114,26 @@ fn probe_daemon_health(binary: &str) -> MemberHealth {
     if !out.status.success() {
         return MemberHealth::Down;
     }
-    match serde_json::from_slice::<serde_json::Value>(&out.stdout) {
+    classify_health_json(&out.stdout)
+}
+
+/// Classify a daemon's `health --json` stdout bytes into a [`MemberHealth`].
+///
+/// Why: Isolating the parse + classification as a pure function makes the
+/// fallback policy testable without spawning a subprocess. The re-review fix
+/// lives here: unparseable output is `Down`, not `HealthyStale`.
+/// What: Parses `bytes` as JSON; on success maps the `status` field via
+/// `classify_status` (defaulting to `down` when the field is absent). On a parse
+/// failure returns `Down` — garbage output means the daemon is broken, not
+/// merely stale ("if in doubt, degraded").
+/// Test: `tests::unparseable_health_is_down`, `tests::parsed_status_classifies`.
+fn classify_health_json(bytes: &[u8]) -> MemberHealth {
+    match serde_json::from_slice::<serde_json::Value>(bytes) {
         Ok(v) => {
             let status = v.get("status").and_then(|s| s.as_str()).unwrap_or("down");
             classify_status(status)
         }
-        Err(_) => MemberHealth::HealthyStale,
+        Err(_) => MemberHealth::Down,
     }
 }
 
@@ -256,6 +270,35 @@ mod tests {
         assert_eq!(ready.exit_code(), 0);
         let incomplete = StatusReport::build(vec![ms("tga", None, "not_installed", false)]);
         assert_eq!(incomplete.exit_code(), 0);
+    }
+
+    /// Why: Re-review fix — a daemon that emits unparseable `health --json`
+    /// output is BROKEN, not merely stale, so the fallback must be `Down`
+    /// ("if in doubt, degraded"). Pin this so it cannot regress to `HealthyStale`.
+    /// What: Feeds non-JSON bytes to `classify_health_json`; asserts `Down`.
+    /// Test: This is the test.
+    #[test]
+    fn unparseable_health_is_down() {
+        assert_eq!(classify_health_json(b"not json at all"), MemberHealth::Down);
+        assert_eq!(classify_health_json(b""), MemberHealth::Down);
+    }
+
+    /// Why: Valid JSON must still classify via the shared `classify_status`
+    /// vocabulary, and an absent `status` field defaults to `down`.
+    /// What: Feeds healthy / stale / field-less JSON; asserts each mapping.
+    /// Test: This is the test.
+    #[test]
+    fn parsed_status_classifies() {
+        assert_eq!(
+            classify_health_json(br#"{"status":"healthy"}"#),
+            MemberHealth::HealthyVersionOk
+        );
+        assert_eq!(
+            classify_health_json(br#"{"status":"stale"}"#),
+            MemberHealth::HealthyStale
+        );
+        // Parseable JSON without a `status` field → defaults to `down`.
+        assert_eq!(classify_health_json(br#"{"other":1}"#), MemberHealth::Down);
     }
 
     /// Why: The health-string mapping is the report's vocabulary; pin it.

--- a/crates/trusty-controller/src/commands/status.rs
+++ b/crates/trusty-controller/src/commands/status.rs
@@ -1,33 +1,266 @@
-//! `tctl status` — one-line stack summary (verdict + stack version).
+//! `tctl status` — stack summary: installed versions + daemon health (#1316).
 //!
-//! Why: A quick "is the stack healthy?" command that renders a single verdict
-//! line, sugar over `stack health` (DOC-4).
+//! Why: A quick "what's installed and is it healthy?" command over the whole
+//! stable set, sugar over a full `stack health`. It is the operator's at-a-glance
+//! view and the data the console / scripts consume via `--json`.
 //!
-//! What: Phase-0 stub. Phase-1 will probe all members and render a one-liner
-//! such as `stack 2026.06-1 — verdict: ready`.
+//! What: For each stable-set member, reports the installed version (via
+//! `<binary> --version`) and — for daemons — a coarse health verdict (via
+//! `<binary> health --json`, reusing the `up::system_runner::classify_status`
+//! mapping). Renders a human table or a `--json` envelope. Returns exit 0 when
+//! every daemon is healthy (or absent-but-reported), 2 when a daemon is down.
 //!
-//! Test: `run(false)` does not panic; `run(true)` outputs parseable JSON.
+//! Test: `tests` covers the report shaping + the overall verdict derivation; the
+//! probes are side-effecting.
 
-use crate::output;
+use std::process::Command;
+
+use serde::Serialize;
+
+use super::stable_set::stable_set;
+use super::up::member::MemberHealth;
+use super::up::system_runner::classify_status;
+use super::update_engine::installed_version;
+use crate::output::render_json;
+
+/// One member's status line.
+///
+/// Why: Typed per-member status keeps machine output stable + testable.
+/// What: `member` crate name; `installed` version or `None`; `health` a coarse
+/// verdict string (`healthy`/`stale`/`down`/`not_installed`/`n/a` for non-daemons).
+/// Test: `tests::report_serialises`.
+#[derive(Clone, Debug, Serialize)]
+pub struct MemberStatus {
+    /// Crate name.
+    pub member: String,
+    /// Installed version, or `None` when the binary is absent.
+    pub installed: Option<String>,
+    /// Coarse health verdict.
+    pub health: String,
+    /// Whether this member is a daemon (health is `n/a` otherwise).
+    pub daemon: bool,
+}
+
+/// The aggregate status report.
+///
+/// Why: `--json` consumers want the rollup + an overall verdict in one object.
+/// What: Holds per-member statuses and the overall verdict string.
+/// Test: `tests::report_serialises`, `tests::verdict_*`.
+#[derive(Clone, Debug, Serialize)]
+pub struct StatusReport {
+    /// Fixed command tag.
+    pub command: &'static str,
+    /// Per-member statuses in stable-set order.
+    pub members: Vec<MemberStatus>,
+    /// Overall verdict: `ready` | `degraded` | `incomplete`.
+    pub verdict: &'static str,
+}
+
+impl StatusReport {
+    /// Build a report and compute the overall verdict.
+    ///
+    /// Why: One place derives the verdict so the exit code + JSON agree.
+    /// What: `degraded` if any daemon is `down`; else `incomplete` if any member
+    /// is not installed; else `ready`.
+    /// Test: `tests::verdict_down_is_degraded`, `tests::verdict_missing_is_incomplete`.
+    fn build(members: Vec<MemberStatus>) -> Self {
+        let any_down = members.iter().any(|m| m.daemon && m.health == "down");
+        let any_missing = members.iter().any(|m| m.installed.is_none());
+        let verdict = if any_down {
+            "degraded"
+        } else if any_missing {
+            "incomplete"
+        } else {
+            "ready"
+        };
+        Self {
+            command: "status",
+            members,
+            verdict,
+        }
+    }
+
+    /// Process exit code: 0 ready/incomplete, 2 degraded.
+    ///
+    /// Why: A monitoring script branches on this; a down daemon is the failure.
+    /// What: `2` when `degraded`, else `0` (an incomplete install is not a
+    /// runtime failure — `tctl install` is the remedy, not an error here).
+    /// Test: `tests::exit_code_reflects_verdict`.
+    fn exit_code(&self) -> i32 {
+        if self.verdict == "degraded" {
+            2
+        } else {
+            0
+        }
+    }
+}
+
+/// Coarse health probe for a daemon member (`<binary> health --json`).
+///
+/// Why: `status` reports a one-word health per daemon; reuse the same
+/// classification the boot path uses so the vocabulary is consistent.
+/// What: Spawns `<binary> health --json`; maps the `status` field via
+/// `classify_status`. Returns `NotInstalled` when the binary is absent, `Down`
+/// on spawn/parse failure.
+/// Test: Side-effect-only (subprocess); `classify_status` is unit-tested in `up`.
+fn probe_daemon_health(binary: &str) -> MemberHealth {
+    if which::which(binary).is_err() {
+        return MemberHealth::NotInstalled;
+    }
+    let out = Command::new(binary).args(["health", "--json"]).output();
+    let Ok(out) = out else {
+        return MemberHealth::Down;
+    };
+    if !out.status.success() {
+        return MemberHealth::Down;
+    }
+    match serde_json::from_slice::<serde_json::Value>(&out.stdout) {
+        Ok(v) => {
+            let status = v.get("status").and_then(|s| s.as_str()).unwrap_or("down");
+            classify_status(status)
+        }
+        Err(_) => MemberHealth::HealthyStale,
+    }
+}
+
+/// Map a [`MemberHealth`] to the status report's coarse string.
+///
+/// Why: The report uses a flat string vocabulary; centralise the mapping.
+/// What: `HealthyVersionOk` → `healthy`, `HealthyStale` → `stale`, `Down` →
+/// `down`, `NotInstalled` → `not_installed`.
+/// Test: `tests::health_string_mapping`.
+fn health_string(h: MemberHealth) -> &'static str {
+    match h {
+        MemberHealth::HealthyVersionOk => "healthy",
+        MemberHealth::HealthyStale => "stale",
+        MemberHealth::Down => "down",
+        MemberHealth::NotInstalled => "not_installed",
+    }
+}
 
 /// Handle `tctl status`.
 ///
-/// Why: Phase-0 entry point confirming the command is wired.
+/// Why: Phase-1 stack summary (#1316 priority 5).
 ///
-/// What: Prints a structured stub result.
+/// What: Probes each stable-set member's installed version and (for daemons)
+/// health, builds the report, and renders human or `--json`. Returns the exit code.
 ///
-/// Test: Call `run(false)` and `run(true)`; neither should panic.
-pub fn run(json: bool) {
-    output::print_not_yet_implemented("status", json);
+/// Test: Side-effecting (probes); the report logic is tested via `StatusReport`.
+pub fn run(json: bool) -> i32 {
+    let mut members = Vec::new();
+    for m in stable_set() {
+        let installed = installed_version(&m.binary);
+        let (health, daemon) = if m.daemon {
+            (
+                health_string(probe_daemon_health(&m.binary)).to_owned(),
+                true,
+            )
+        } else {
+            (
+                if installed.is_some() {
+                    "n/a"
+                } else {
+                    "not_installed"
+                }
+                .to_owned(),
+                false,
+            )
+        };
+        members.push(MemberStatus {
+            member: m.crate_name,
+            installed,
+            health,
+            daemon,
+        });
+    }
+    let report = StatusReport::build(members);
+    if json {
+        let _ = render_json(&report);
+    } else {
+        print_human(&report);
+    }
+    report.exit_code()
+}
+
+/// Render the human-readable status table to stdout.
+///
+/// Why: Operators want an at-a-glance table.
+/// What: Prints one aligned row per member + the verdict footer.
+/// Test: Side-effect-only; the data is tested via `StatusReport`.
+fn print_human(report: &StatusReport) {
+    println!("tctl status — stack summary");
+    for m in &report.members {
+        let ver = m.installed.as_deref().unwrap_or("(absent)");
+        println!("  {:<18} {:<12} {}", m.member, ver, m.health);
+    }
+    println!("verdict: {} (exit {})", report.verdict, report.exit_code());
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn ms(member: &str, installed: Option<&str>, health: &str, daemon: bool) -> MemberStatus {
+        MemberStatus {
+            member: member.to_owned(),
+            installed: installed.map(str::to_owned),
+            health: health.to_owned(),
+            daemon,
+        }
+    }
+
+    /// Why: The JSON envelope is a public contract; pin its shape.
+    /// What: Builds a report and asserts the keys.
+    /// Test: This is the test.
     #[test]
-    fn does_not_panic() {
-        run(false);
-        run(true);
+    fn report_serialises() {
+        let report =
+            StatusReport::build(vec![ms("trusty-search", Some("0.20.0"), "healthy", true)]);
+        let v = serde_json::to_value(&report).expect("serialises");
+        assert_eq!(v["command"], "status");
+        assert_eq!(v["verdict"], "ready");
+        assert_eq!(v["members"][0]["health"], "healthy");
+    }
+
+    /// Why: A down daemon must degrade the whole verdict.
+    /// What: Builds a report with one down daemon; asserts `degraded`.
+    /// Test: This is the test.
+    #[test]
+    fn verdict_down_is_degraded() {
+        let report = StatusReport::build(vec![ms("trusty-search", Some("0.20.0"), "down", true)]);
+        assert_eq!(report.verdict, "degraded");
+    }
+
+    /// Why: A missing member (but no down daemon) is `incomplete`, not failure.
+    /// What: Builds a report with one absent member; asserts `incomplete`.
+    /// Test: This is the test.
+    #[test]
+    fn verdict_missing_is_incomplete() {
+        let report = StatusReport::build(vec![ms("tga", None, "not_installed", false)]);
+        assert_eq!(report.verdict, "incomplete");
+    }
+
+    /// Why: The exit code must track the verdict for monitoring.
+    /// What: Asserts 2 for degraded, 0 for ready and incomplete.
+    /// Test: This is the test.
+    #[test]
+    fn exit_code_reflects_verdict() {
+        let degraded = StatusReport::build(vec![ms("trusty-search", Some("1.0.0"), "down", true)]);
+        assert_eq!(degraded.exit_code(), 2);
+        let ready = StatusReport::build(vec![ms("trusty-search", Some("1.0.0"), "healthy", true)]);
+        assert_eq!(ready.exit_code(), 0);
+        let incomplete = StatusReport::build(vec![ms("tga", None, "not_installed", false)]);
+        assert_eq!(incomplete.exit_code(), 0);
+    }
+
+    /// Why: The health-string mapping is the report's vocabulary; pin it.
+    /// What: Asserts each `MemberHealth` → string.
+    /// Test: This is the test.
+    #[test]
+    fn health_string_mapping() {
+        assert_eq!(health_string(MemberHealth::HealthyVersionOk), "healthy");
+        assert_eq!(health_string(MemberHealth::HealthyStale), "stale");
+        assert_eq!(health_string(MemberHealth::Down), "down");
+        assert_eq!(health_string(MemberHealth::NotInstalled), "not_installed");
     }
 }

--- a/crates/trusty-controller/src/commands/status.rs
+++ b/crates/trusty-controller/src/commands/status.rs
@@ -175,7 +175,12 @@ pub fn run(json: bool) -> i32 {
     }
     let report = StatusReport::build(members);
     if json {
-        let _ = render_json(&report);
+        // A failed machine-readable write must not exit 0: a monitoring script
+        // would read health from the exit code while the JSON never arrived.
+        if render_json(&report).is_err() {
+            eprintln!("tctl status: failed to write JSON output");
+            return 1;
+        }
     } else {
         print_human(&report);
     }

--- a/crates/trusty-controller/src/commands/ui.rs
+++ b/crates/trusty-controller/src/commands/ui.rs
@@ -1,37 +1,177 @@
-//! `tctl ui` — print or open the controller web-UI URL.
+//! `tctl ui` — launch trusty-console or print its URL (#1316, DOC-7).
 //!
-//! Why: Provides a clean entry point for the DOC-7 web UI (DOC-5 §1.2). The
-//! URL is derived from `tctl port`; this command either prints it or launches
-//! the user's default browser.
+//! Why: The "option to launch the console" — the single HTTP front door for the
+//! stack. Post-de-bundle (#1318) `trusty-console` is a standalone binary on
+//! PATH; `tctl ui` discovers a running console (or starts one) and either opens
+//! the URL or, with `--print`, just emits it.
 //!
-//! What: Phase-0 stub. Phase-1 will read the port from the state dir and
-//! either print `http://127.0.0.1:<port>` or call `open::that` (the `open`
-//! crate already in the workspace) unless `--print` is set.
+//! What: Resolves the console URL via the console's own `port --json` contract
+//! (reusing [`super::up::os_env::parse_console_port`]). With `--print`, prints
+//! the resolved URL (or the default) and exits. Otherwise spawns
+//! `trusty-console serve` detached and prints the URL it will serve on. Returns
+//! a non-zero exit when the console binary is absent.
 //!
-//! Test: `run(false, false)` does not panic.
+//! Test: `tests` covers the URL resolution (`resolve_url`) against canned
+//! `port --json` bytes and the absent-binary path indirectly.
 
-use crate::output;
+use std::process::Command;
+
+use super::up::os_env::parse_console_port;
+use crate::output::render_json;
+
+/// The console's default URL when no running instance reports a port.
+///
+/// Why: A sane fallback so `--print` always yields a usable URL even before the
+/// console has started (it binds `127.0.0.1:7788` by default — see
+/// `trusty_console::DEFAULT_HTTP`).
+const DEFAULT_CONSOLE_URL: &str = "http://127.0.0.1:7788";
+
+/// Resolve the console URL from a `trusty-console port --json` invocation.
+///
+/// Why: Isolating the resolution (spawn + parse + fallback) from the command
+/// flow keeps the URL logic testable via canned JSON.
+///
+/// What: Returns the parsed `http://addr:port` URL, or `None` when the console
+/// binary is absent / errors / emits unparseable output (caller applies the
+/// default).
+///
+/// Test: `resolve_url_from_bytes` covers the parse; the spawn is side-effecting.
+fn query_console_url() -> Option<String> {
+    let out = Command::new("trusty-console")
+        .args(["port", "--json"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_console_port(&out.stdout)
+}
+
+/// Whether the `trusty-console` binary is resolvable on PATH.
+///
+/// Why: `tctl ui` (launch mode) must fail clearly when the console is not
+/// installed rather than silently doing nothing.
+/// What: `which trusty-console`.
+/// Test: Side-effect-only (PATH); the absent path is reported as exit 4.
+fn console_present() -> bool {
+    which::which("trusty-console").is_ok()
+}
 
 /// Handle `tctl ui [--print]`.
 ///
-/// Why: Phase-0 entry point for the web-UI URL command.
+/// Why: Phase-1 entry point for the console launch/URL command (#1316 priority 4).
 ///
-/// What: `print` = skip browser launch, just print the URL. `json` = machine
-/// output. Both are stubs in Phase 0.
+/// What:
+/// - `--print`: resolve and print the URL (live port if a console is running,
+///   else the default), in human or `--json` form. Exit 0.
+/// - default: require the console binary; spawn `trusty-console serve` detached,
+///   print the URL it will serve on, and exit 0. If the binary is absent, print
+///   an install hint and exit 4.
 ///
-/// Test: Call with both `print` values; neither should panic.
-pub fn run(print: bool, json: bool) {
-    let cmd = if print { "ui --print" } else { "ui" };
-    output::print_not_yet_implemented(cmd, json);
+/// Test: `tests::resolve_url_from_bytes`; the spawn path is side-effecting.
+pub fn run(print: bool, json: bool) -> i32 {
+    let live_url = query_console_url();
+    let url = live_url
+        .clone()
+        .unwrap_or_else(|| DEFAULT_CONSOLE_URL.to_owned());
+
+    if print {
+        if json {
+            let _ = render_json(&serde_json::json!({
+                "command": "ui",
+                "url": url,
+                "running": live_url.is_some(),
+            }));
+        } else {
+            println!("{url}");
+        }
+        return 0;
+    }
+
+    // Launch mode: the console binary must be present.
+    if !console_present() {
+        let hint = "trusty-console not found on PATH — install it with `tctl install trusty-console` or `cargo install trusty-console`.";
+        if json {
+            let _ = render_json(&serde_json::json!({"command":"ui","error":hint}));
+        } else {
+            eprintln!("tctl ui: {hint}");
+        }
+        return 4;
+    }
+
+    // If a console is already running, do not spawn a second one — just report.
+    if live_url.is_some() {
+        report_launch(&url, true, json);
+        return 0;
+    }
+
+    match Command::new("trusty-console").arg("serve").spawn() {
+        Ok(_child) => {
+            report_launch(&url, false, json);
+            0
+        }
+        Err(e) => {
+            let msg = format!("failed to launch trusty-console serve: {e}");
+            if json {
+                let _ = render_json(&serde_json::json!({"command":"ui","error":msg}));
+            } else {
+                eprintln!("tctl ui: {msg}");
+            }
+            4
+        }
+    }
+}
+
+/// Report a console launch (or already-running) result.
+///
+/// Why: Both the "already running" and "just spawned" paths emit the same shape.
+/// What: Prints the URL (human) or a `{command,url,already_running}` JSON object.
+/// Test: Side-effect-only.
+fn report_launch(url: &str, already_running: bool, json: bool) {
+    if json {
+        let _ = render_json(&serde_json::json!({
+            "command": "ui",
+            "url": url,
+            "already_running": already_running,
+        }));
+    } else if already_running {
+        println!("trusty-console already running at {url}");
+    } else {
+        println!("trusty-console starting at {url}");
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Why: The URL resolution from the console's `port --json` contract is the
+    /// load-bearing piece of `tctl ui`; verify it against canned bytes.
+    /// What: Parses a `{addr,port}` envelope and asserts the composed URL.
+    /// Test: This is the test.
     #[test]
-    fn does_not_panic() {
-        run(false, false);
-        run(true, true);
+    fn resolve_url_from_bytes() {
+        let json = br#"{"addr":"127.0.0.1","port":7788}"#;
+        assert_eq!(
+            parse_console_port(json),
+            Some("http://127.0.0.1:7788".to_owned())
+        );
+    }
+
+    /// Why: A missing `port` field must yield `None` so the default applies.
+    /// What: Parses an envelope without `port`; asserts `None`.
+    /// Test: This is the test.
+    #[test]
+    fn resolve_url_missing_port_is_none() {
+        let json = br#"{"addr":"127.0.0.1"}"#;
+        assert_eq!(parse_console_port(json), None);
+    }
+
+    /// Why: The default URL is the fallback contract; pin it.
+    /// What: Asserts the default constant shape.
+    /// Test: This is the test.
+    #[test]
+    fn default_url_is_localhost_7788() {
+        assert_eq!(DEFAULT_CONSOLE_URL, "http://127.0.0.1:7788");
     }
 }

--- a/crates/trusty-controller/src/commands/ui.rs
+++ b/crates/trusty-controller/src/commands/ui.rs
@@ -8,13 +8,15 @@
 //! What: Resolves the console URL via the console's own `port --json` contract
 //! (reusing [`super::up::os_env::parse_console_port`]). With `--print`, prints
 //! the resolved URL (or the default) and exits. Otherwise spawns
-//! `trusty-console serve` detached and prints the URL it will serve on. Returns
-//! a non-zero exit when the console binary is absent.
+//! `trusty-console serve` *genuinely detached* (new session via `setsid` +
+//! null std streams, see [`spawn_detached_console`]) so the console survives
+//! `tctl` exiting, then prints the URL it will serve on and returns promptly.
+//! Returns a non-zero exit when the console binary is absent.
 //!
 //! Test: `tests` covers the URL resolution (`resolve_url`) against canned
 //! `port --json` bytes and the absent-binary path indirectly.
 
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use super::up::os_env::parse_console_port;
 use crate::output::render_json;
@@ -64,9 +66,13 @@ fn console_present() -> bool {
 /// What:
 /// - `--print`: resolve and print the URL (live port if a console is running,
 ///   else the default), in human or `--json` form. Exit 0.
-/// - default: require the console binary; spawn `trusty-console serve` detached,
-///   print the URL it will serve on, and exit 0. If the binary is absent, print
-///   an install hint and exit 4.
+/// - default: require the console binary; spawn `trusty-console serve` *genuinely
+///   detached* (see [`spawn_detached_console`]), print the URL it will serve on,
+///   and return promptly with exit 0. If the binary is absent, print an install
+///   hint and exit 4.
+///
+/// A `--json` write that fails to reach stdout returns exit 1 (never a false 0)
+/// so automation does not read success from a dropped JSON payload.
 ///
 /// Test: `tests::resolve_url_from_bytes`; the spawn path is side-effecting.
 pub fn run(print: bool, json: bool) -> i32 {
@@ -77,11 +83,16 @@ pub fn run(print: bool, json: bool) -> i32 {
 
     if print {
         if json {
-            let _ = render_json(&serde_json::json!({
+            if render_json(&serde_json::json!({
                 "command": "ui",
                 "url": url,
                 "running": live_url.is_some(),
-            }));
+            }))
+            .is_err()
+            {
+                eprintln!("tctl ui: failed to write JSON output");
+                return 1;
+            }
         } else {
             println!("{url}");
         }
@@ -92,7 +103,10 @@ pub fn run(print: bool, json: bool) -> i32 {
     if !console_present() {
         let hint = "trusty-console not found on PATH — install it with `tctl install trusty-console` or `cargo install trusty-console`.";
         if json {
-            let _ = render_json(&serde_json::json!({"command":"ui","error":hint}));
+            if render_json(&serde_json::json!({"command":"ui","error":hint})).is_err() {
+                eprintln!("tctl ui: failed to write JSON output");
+                return 1;
+            }
         } else {
             eprintln!("tctl ui: {hint}");
         }
@@ -101,19 +115,18 @@ pub fn run(print: bool, json: bool) -> i32 {
 
     // If a console is already running, do not spawn a second one — just report.
     if live_url.is_some() {
-        report_launch(&url, true, json);
-        return 0;
+        return report_launch(&url, true, json);
     }
 
-    match Command::new("trusty-console").arg("serve").spawn() {
-        Ok(_child) => {
-            report_launch(&url, false, json);
-            0
-        }
+    match spawn_detached_console() {
+        Ok(()) => report_launch(&url, false, json),
         Err(e) => {
             let msg = format!("failed to launch trusty-console serve: {e}");
             if json {
-                let _ = render_json(&serde_json::json!({"command":"ui","error":msg}));
+                if render_json(&serde_json::json!({"command":"ui","error":msg})).is_err() {
+                    eprintln!("tctl ui: failed to write JSON output");
+                    return 1;
+                }
             } else {
                 eprintln!("tctl ui: {msg}");
             }
@@ -122,23 +135,86 @@ pub fn run(print: bool, json: bool) -> i32 {
     }
 }
 
-/// Report a console launch (or already-running) result.
+/// Spawn `trusty-console serve` as a genuinely-detached background process.
+///
+/// Why: `tctl ui` must launch the console and return immediately, leaving a
+/// long-lived daemon behind that *survives `tctl` exiting*. A naive
+/// `Command::spawn()` whose child handle is dropped is wrong on two counts: the
+/// child stays in the parent's process group/session, so it receives `SIGHUP`
+/// when the controlling terminal (or `tctl`) goes away; and on Unix dropping the
+/// handle without reaping leaves a zombie if the child exits. We fully detach.
+///
+/// What: Redirects the child's stdin/stdout/stderr to `/dev/null` (so it is not
+/// tied to `tctl`'s terminal and cannot block on a pipe), and on Unix calls
+/// `setsid(2)` in the child via `pre_exec` to start a new session — detaching it
+/// from `tctl`'s process group so a terminal `SIGHUP` never reaches it. The
+/// returned [`Child`] handle is intentionally leaked with [`std::mem::forget`]:
+/// the console is a daemon `tctl` does not own, so we must NOT drop the handle
+/// (dropping does not wait, but forgetting documents that we will never reap it —
+/// `setsid` + closed std streams make it a clean orphan adopted by `init`/PID 1).
+///
+/// Test: Side-effecting (spawns a real process); the detach mechanism is
+/// documented here and validated manually (`tctl ui` returns immediately and the
+/// console keeps serving after `tctl` exits).
+fn spawn_detached_console() -> std::io::Result<()> {
+    let mut cmd = Command::new("trusty-console");
+    cmd.arg("serve")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    // On Unix, start a new session so a terminal SIGHUP cannot reach the console
+    // when `tctl` (and its controlling terminal) goes away.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Safety: `setsid` is async-signal-safe and is the canonical way to
+        // detach a child into its own session. It takes no arguments and only
+        // affects the calling (child) process between fork and exec.
+        unsafe {
+            cmd.pre_exec(|| {
+                // Detach from the parent's process group/session. A non-fatal
+                // failure (already a session leader) is ignored — the redirected
+                // std streams alone still prevent terminal coupling.
+                libc::setsid();
+                Ok(())
+            });
+        }
+    }
+
+    let child = cmd.spawn()?;
+    // Intentional detach: the console outlives `tctl`. We never wait on it, so we
+    // forget the handle rather than let `Drop` (which does not reap) run.
+    std::mem::forget(child);
+    Ok(())
+}
+
+/// Report a console launch (or already-running) result; return the exit code.
 ///
 /// Why: Both the "already running" and "just spawned" paths emit the same shape.
-/// What: Prints the URL (human) or a `{command,url,already_running}` JSON object.
+/// A `--json` write that fails must surface as exit 1 (not a false 0) so
+/// automation never reads success from a dropped payload.
+/// What: Prints the URL (human, exit 0) or a `{command,url,already_running}` JSON
+/// object (exit 0 on success, 1 if the write fails).
 /// Test: Side-effect-only.
-fn report_launch(url: &str, already_running: bool, json: bool) {
+fn report_launch(url: &str, already_running: bool, json: bool) -> i32 {
     if json {
-        let _ = render_json(&serde_json::json!({
+        if render_json(&serde_json::json!({
             "command": "ui",
             "url": url,
             "already_running": already_running,
-        }));
+        }))
+        .is_err()
+        {
+            eprintln!("tctl ui: failed to write JSON output");
+            return 1;
+        }
     } else if already_running {
         println!("trusty-console already running at {url}");
     } else {
         println!("trusty-console starting at {url}");
     }
+    0
 }
 
 #[cfg(test)]

--- a/crates/trusty-controller/src/commands/up/config.rs
+++ b/crates/trusty-controller/src/commands/up/config.rs
@@ -118,15 +118,35 @@ impl Default for BootSection {
     }
 }
 
-/// The controller's on-disk config (DOC-12 §8 / #1220).
+/// The `[controller]` config section (#1316).
+///
+/// Why: The #1316 opt-in auto-update CHECK is gated by a config flag distinct
+/// from boot policy, so it lives in its own `controller` namespace. The default
+/// is OFF — tctl must never probe crates.io in the background, let alone apply
+/// anything, unless the operator opts in.
+///
+/// What: `auto_update_check` enables the notify-only background update check
+/// (see `commands::auto_update`). It only *notifies*; applying always requires
+/// explicit confirmation via `tctl upgrade`.
+///
+/// Test: `super::tests::config_parses_controller`, `super::tests::controller_default_off`.
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize)]
+#[serde(default)]
+pub struct ControllerSection {
+    /// Enable the opt-in notify-only update check (default `false`).
+    pub auto_update_check: bool,
+}
+
+/// The controller's on-disk config (DOC-12 §8 / #1220 / #1316).
 ///
 /// Why: The deserialisation root for
 /// `~/.trusty-tools/trusty-controller/config.yaml`.
 ///
-/// What: Holds the `boot` section plus the optional `analyze_core_targets`
-/// override (empty = use the §3.3 default set).
+/// What: Holds the `boot` section, the optional `analyze_core_targets` override
+/// (empty = use the §3.3 default set), and the `controller` section (#1316
+/// auto-update opt-in).
 ///
-/// Test: `super::tests::config_parses_full`.
+/// Test: `super::tests::config_parses_full`, `super::tests::config_parses_controller`.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize)]
 #[serde(default)]
 pub struct BootConfig {
@@ -134,6 +154,8 @@ pub struct BootConfig {
     pub boot: BootSection,
     /// Override of the §3.3 core-analysis target set (empty = default).
     pub analyze_core_targets: Vec<String>,
+    /// Controller-level settings (#1316 auto-update opt-in).
+    pub controller: ControllerSection,
 }
 
 /// Compute the #1220 controller config path: `~/.trusty-tools/trusty-controller/config.yaml`.

--- a/crates/trusty-controller/src/commands/up/tests.rs
+++ b/crates/trusty-controller/src/commands/up/tests.rs
@@ -147,6 +147,28 @@ fn load_empty_file_is_default() {
     assert_eq!(cfg, BootConfig::default());
 }
 
+/// Why: The #1316 `[controller] auto_update_check` flag must parse from the
+/// config file so operators can opt into the notify-only update check.
+/// What: Writes a config with `controller.auto_update_check: true` and asserts
+/// it round-trips.
+/// Test: This is the test.
+#[test]
+fn config_parses_controller() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, "controller:\n  auto_update_check: true\n").unwrap();
+    let cfg = load_boot_config_from(&path).unwrap();
+    assert!(cfg.controller.auto_update_check);
+}
+
+/// Why: The default posture is OFF — no opt-in, no background probing.
+/// What: Asserts the default config disables the auto-update check.
+/// Test: This is the test.
+#[test]
+fn controller_default_off() {
+    assert!(!BootConfig::default().controller.auto_update_check);
+}
+
 // ── §4/§8 policy precedence ─────────────────────────────────────────────────────
 
 fn flags(with: bool, no: bool, tty: bool, yes: bool) -> UpFlags {

--- a/crates/trusty-controller/src/commands/update_engine.rs
+++ b/crates/trusty-controller/src/commands/update_engine.rs
@@ -137,8 +137,8 @@ pub fn decide_apply(inputs: ApplyInputs) -> ApplyDecision {
 /// it via `--version`.
 ///
 /// What: Spawns `<binary> --version`, returns the first whitespace-delimited
-/// token that looks like a version (the last token containing a digit and a
-/// dot), or `None` if the binary is absent / does not respond.
+/// token that looks like a version (the first token containing a leading digit
+/// and a dot), or `None` if the binary is absent / does not respond.
 ///
 /// Test: `tests::extract_version_from_line` covers the parsing; the spawn is
 /// side-effect-only.

--- a/crates/trusty-controller/src/commands/update_engine.rs
+++ b/crates/trusty-controller/src/commands/update_engine.rs
@@ -1,0 +1,297 @@
+//! Update detection + the confirm-then-apply decision logic (#1316).
+//!
+//! Why: The added #1316 requirement is that `tctl` *never mutates installed
+//! binaries without confirmation*. That safety property is a pure decision —
+//! "given the candidates, whether we are on a TTY, and the `--yes` flag, do we
+//! apply?" — and it must be unit-testable in isolation from any network or
+//! process side effects. This module holds (a) the network listing of available
+//! updates and (b) the pure [`decide_apply`] gate that the upgrade command and
+//! the opt-in auto-update check both route through.
+//!
+//! What:
+//! - [`UpdateCandidate`] — one member with an available newer version.
+//! - [`gather_candidates`] — async; probes crates.io for each stable member's
+//!   currently-installed version and returns those with a newer release.
+//! - [`ApplyDecision`] / [`decide_apply`] — the pure confirm-then-apply gate.
+//!
+//! Test: `tests` exhaustively covers `decide_apply` (the load-bearing safety
+//! gate) and the installed-version parsing; the network path is side-effecting
+//! and validated manually / via `trusty_common::update` tests.
+
+use std::process::Command;
+
+use serde::Serialize;
+
+use super::stable_set::StableMember;
+
+/// A stable-set member that has a newer version available.
+///
+/// Why: `tctl updates` lists these and `tctl upgrade` applies them; a typed
+/// record keeps the installed→latest diff explicit and JSON-serialisable.
+///
+/// What: Carries the crate/binary names plus the installed and latest version
+/// strings. `installed` is `None` when the binary is not present on PATH (a
+/// candidate for install rather than upgrade).
+///
+/// Test: `tests::decide_*` build these; `gather_candidates` populates them.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct UpdateCandidate {
+    /// crates.io package name.
+    pub crate_name: String,
+    /// Installed binary name.
+    pub binary: String,
+    /// Currently-installed version (`None` if the binary is absent).
+    pub installed: Option<String>,
+    /// The latest version available on crates.io.
+    pub latest: String,
+    /// Whether this member is a supervised daemon (drives restart-on-upgrade).
+    pub daemon: bool,
+}
+
+/// The outcome of the confirm-then-apply gate.
+///
+/// Why: Separating the *decision* from the *action* lets the upgrade command be
+/// tested without spawning `cargo install`; the command pattern-matches on this.
+///
+/// What: `Apply` — proceed (confirmed via `--yes` or an interactive yes);
+/// `Decline` — the user said no at the prompt; `NothingToDo` — there were no
+/// candidates; `NeedsConfirmation` — there are candidates but we are
+/// non-interactive without `--yes`, so applying is forbidden (the default-safe
+/// posture: never mutate without confirmation).
+///
+/// Test: `tests::decide_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApplyDecision {
+    /// Confirmed — proceed to apply the upgrades.
+    Apply,
+    /// The user explicitly declined at the interactive prompt.
+    Decline,
+    /// No candidates — nothing to apply.
+    NothingToDo,
+    /// Candidates exist but no confirmation is possible (non-TTY, no `--yes`).
+    /// Applying is refused; the caller must report the candidates and exit
+    /// non-zero so automation does not silently skip an intended upgrade.
+    NeedsConfirmation,
+}
+
+/// Inputs to the pure confirm-then-apply gate.
+///
+/// Why: Bundling the inputs keeps [`decide_apply`] a single-argument pure
+/// function that is trivial to exhaustively test across the decision matrix.
+///
+/// What: `has_candidates` — are there any updates to apply; `yes` — the global
+/// `--yes` flag (non-interactive auto-confirm); `is_tty` — whether we can prompt;
+/// `interactive_consent` — the result of an interactive prompt (only consulted
+/// when `yes` is false and `is_tty` is true).
+///
+/// Test: `tests::decide_*`.
+#[derive(Clone, Copy, Debug)]
+pub struct ApplyInputs {
+    /// Whether any upgrade candidates exist.
+    pub has_candidates: bool,
+    /// The `--yes` flag (skip the prompt, auto-confirm).
+    pub yes: bool,
+    /// Whether stdin is an interactive terminal we can prompt on.
+    pub is_tty: bool,
+    /// The interactive prompt result (consulted only on the TTY, no-`--yes` path).
+    pub interactive_consent: bool,
+}
+
+/// The pure confirm-then-apply gate (#1316 default-safe posture).
+///
+/// Why: This is THE safety property of #1316: tctl must never apply an upgrade
+/// without confirmation. Encoding the rule as one pure function makes it
+/// auditable and exhaustively testable, decoupled from prompts and processes.
+///
+/// What:
+/// 1. No candidates → [`ApplyDecision::NothingToDo`].
+/// 2. `--yes` → [`ApplyDecision::Apply`] (explicit non-interactive consent).
+/// 3. Not a TTY (and not `--yes`) → [`ApplyDecision::NeedsConfirmation`]
+///    (refuse to mutate; cannot obtain consent).
+/// 4. TTY → reflect `interactive_consent`: yes → `Apply`, no → `Decline`.
+///
+/// Test: `tests::decide_nothing_to_do`, `decide_yes_applies`,
+/// `decide_non_tty_needs_confirmation`, `decide_tty_yes_applies`,
+/// `decide_tty_no_declines`.
+pub fn decide_apply(inputs: ApplyInputs) -> ApplyDecision {
+    if !inputs.has_candidates {
+        return ApplyDecision::NothingToDo;
+    }
+    if inputs.yes {
+        return ApplyDecision::Apply;
+    }
+    if !inputs.is_tty {
+        return ApplyDecision::NeedsConfirmation;
+    }
+    if inputs.interactive_consent {
+        ApplyDecision::Apply
+    } else {
+        ApplyDecision::Decline
+    }
+}
+
+/// Probe the installed version of a binary via `<binary> --version`.
+///
+/// Why: To compute the installed→latest diff we need the version of the
+/// currently-installed binary; the trusty-* CLIs (and most cargo binaries) print
+/// it via `--version`.
+///
+/// What: Spawns `<binary> --version`, returns the first whitespace-delimited
+/// token that looks like a version (the last token containing a digit and a
+/// dot), or `None` if the binary is absent / does not respond.
+///
+/// Test: `tests::extract_version_from_line` covers the parsing; the spawn is
+/// side-effect-only.
+pub fn installed_version(binary: &str) -> Option<String> {
+    let out = Command::new(binary).arg("--version").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&out.stdout);
+    extract_version_from_line(&line)
+}
+
+/// Extract a `MAJOR.MINOR…` version token from a `--version` output line.
+///
+/// Why: `--version` output varies (`tctl 0.1.0`, `trusty-search 0.20.0 (abc)`);
+/// isolating the token extraction makes it unit-testable without a subprocess.
+///
+/// What: Returns the first whitespace-delimited token that contains a `.` and a
+/// leading digit, stripping a leading `v`. Returns `None` when no token matches.
+///
+/// Test: `tests::extract_version_from_line`.
+pub fn extract_version_from_line(line: &str) -> Option<String> {
+    line.split_whitespace()
+        .map(|t| t.trim_start_matches('v'))
+        .find(|t| t.contains('.') && t.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        .map(|t| t.to_owned())
+}
+
+/// Probe crates.io for newer versions of each stable-set member (async).
+///
+/// Why: `tctl updates` and `tctl upgrade` both need the current set of upgrade
+/// candidates; centralising the probe keeps them consistent and reuses the
+/// shared `trusty_common::update::check_crates_io` primitive.
+///
+/// What: For each member, reads the installed version via [`installed_version`]
+/// then calls `check_crates_io`. A member with no installed binary uses a `0.0.0`
+/// baseline so any published version registers as an available update (install
+/// candidate). Returns the members that have a strictly-newer release.
+///
+/// Test: Side-effecting (network + subprocess); the pure pieces it composes
+/// (`decide_apply`, `extract_version_from_line`, `check_crates_io`) are tested
+/// independently.
+pub async fn gather_candidates(members: &[StableMember]) -> Vec<UpdateCandidate> {
+    let mut candidates = Vec::new();
+    for m in members {
+        let installed = installed_version(&m.binary);
+        let baseline = installed.clone().unwrap_or_else(|| "0.0.0".to_owned());
+        if let Some(info) = trusty_common::update::check_crates_io(&m.crate_name, &baseline).await {
+            candidates.push(UpdateCandidate {
+                crate_name: m.crate_name.clone(),
+                binary: m.binary.clone(),
+                installed,
+                latest: info.latest,
+                daemon: m.daemon,
+            });
+        }
+    }
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: No candidates must never be reported as "apply".
+    /// What: Asserts `NothingToDo` when `has_candidates = false`, regardless of flags.
+    /// Test: This is the test.
+    #[test]
+    fn decide_nothing_to_do() {
+        let d = decide_apply(ApplyInputs {
+            has_candidates: false,
+            yes: true,
+            is_tty: true,
+            interactive_consent: true,
+        });
+        assert_eq!(d, ApplyDecision::NothingToDo);
+    }
+
+    /// Why: `--yes` is the sanctioned non-interactive auto-confirm.
+    /// What: Asserts `Apply` when candidates exist and `yes = true`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_yes_applies() {
+        let d = decide_apply(ApplyInputs {
+            has_candidates: true,
+            yes: true,
+            is_tty: false,
+            interactive_consent: false,
+        });
+        assert_eq!(d, ApplyDecision::Apply);
+    }
+
+    /// Why: THE safety property — never mutate without confirmation when we
+    /// cannot prompt and `--yes` was not given.
+    /// What: Asserts `NeedsConfirmation` on a non-TTY without `--yes`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_non_tty_needs_confirmation() {
+        let d = decide_apply(ApplyInputs {
+            has_candidates: true,
+            yes: false,
+            is_tty: false,
+            interactive_consent: true, // ignored — cannot actually prompt
+        });
+        assert_eq!(d, ApplyDecision::NeedsConfirmation);
+    }
+
+    /// Why: An interactive yes is confirmation.
+    /// What: Asserts `Apply` when TTY + consent.
+    /// Test: This is the test.
+    #[test]
+    fn decide_tty_yes_applies() {
+        let d = decide_apply(ApplyInputs {
+            has_candidates: true,
+            yes: false,
+            is_tty: true,
+            interactive_consent: true,
+        });
+        assert_eq!(d, ApplyDecision::Apply);
+    }
+
+    /// Why: An interactive no must abort the mutation.
+    /// What: Asserts `Decline` when TTY + refusal.
+    /// Test: This is the test.
+    #[test]
+    fn decide_tty_no_declines() {
+        let d = decide_apply(ApplyInputs {
+            has_candidates: true,
+            yes: false,
+            is_tty: true,
+            interactive_consent: false,
+        });
+        assert_eq!(d, ApplyDecision::Decline);
+    }
+
+    /// Why: The version extractor must cope with the varied `--version` shapes.
+    /// What: Covers `tctl 0.1.0`, a trailing-paren shape, a leading `v`, and a
+    /// line with no version.
+    /// Test: This is the test.
+    #[test]
+    fn extract_version_from_line() {
+        assert_eq!(
+            super::extract_version_from_line("tctl 0.1.0"),
+            Some("0.1.0".to_owned())
+        );
+        assert_eq!(
+            super::extract_version_from_line("trusty-search 0.20.0 (abcdef)"),
+            Some("0.20.0".to_owned())
+        );
+        assert_eq!(
+            super::extract_version_from_line("mytool v2.8.0"),
+            Some("2.8.0".to_owned())
+        );
+        assert_eq!(super::extract_version_from_line("no version here"), None);
+    }
+}

--- a/crates/trusty-controller/src/commands/updates.rs
+++ b/crates/trusty-controller/src/commands/updates.rs
@@ -1,43 +1,136 @@
-//! `tctl updates` — read-only listing of available updates + changelog headlines.
+//! `tctl updates` — read-only listing of available updates (#1316, DOC-9 §1).
 //!
-//! Why: The read-only companion to `tctl upgrade` (DOC-5 §1.3 / DOC-9 §1).
-//! It surfaces which members have a newer pinned or published version without
-//! performing any mutation.
+//! Why: The read-only companion to `tctl upgrade`. It surfaces which stable-set
+//! members have a newer published version *without performing any mutation* —
+//! the safe "what would change?" view, and the data the opt-in auto-update check
+//! reuses.
 //!
-//! What: Phase-0 stub. Phase-1 will walk the manifest, call
-//! `trusty_common::update::check_crates_io` for each cargo member (or the uv
-//! probe for the orchestrator), and render the per-member installed→available
-//! diff table plus changelog headlines (DOC-9 §2).
+//! What: Probes crates.io for each stable-set member via
+//! `update_engine::gather_candidates`, then renders the installed→latest diff —
+//! either a human table (rustup-style narration) or a `--json` envelope. Never
+//! mutates anything. Returns exit 0 always (read-only).
 //!
-//! Test: `run(false, false)` and `run(true, false)` do not panic.
+//! Test: `tests::report_serialises` covers the JSON shape; the network probe is
+//! side-effecting.
 
-use crate::output;
+use serde::Serialize;
+
+use super::runtime::block_on;
+use super::stable_set::stable_set;
+use super::update_engine::{gather_candidates, UpdateCandidate};
+use crate::output::render_json;
+
+/// The `tctl updates` report.
+///
+/// Why: A typed rollup keeps the machine output stable; the human path renders
+/// the same data.
+/// What: Holds the upgrade candidates and the total count.
+/// Test: `tests::report_serialises`.
+#[derive(Clone, Debug, Serialize)]
+pub struct UpdatesReport {
+    /// Fixed command tag for JSON consumers.
+    pub command: &'static str,
+    /// Members with a newer version available.
+    pub candidates: Vec<UpdateCandidate>,
+    /// Number of candidates (sugar for consumers).
+    pub count: usize,
+}
+
+impl UpdatesReport {
+    /// Build a report from gathered candidates.
+    ///
+    /// Why: Centralises the `count` derivation.
+    /// What: Sets `command = "updates"` and `count = candidates.len()`.
+    /// Test: `tests::report_serialises`.
+    fn build(candidates: Vec<UpdateCandidate>) -> Self {
+        Self {
+            command: "updates",
+            count: candidates.len(),
+            candidates,
+        }
+    }
+}
 
 /// Handle `tctl updates [--latest]`.
 ///
-/// Why: Phase-0 entry point confirming the read-only update listing is wired.
+/// Why: Phase-1 read-only update listing (#1316 priority 2).
 ///
-/// What: `latest` selects crates.io HEAD over the BOM pin (DOC-9 §1.2). Both
-/// paths are stubs in Phase 0.
+/// What: Gathers candidates across the stable set and renders them. `latest` is
+/// accepted for surface compatibility; the listing always reports the latest
+/// crates.io release (there is no separate BOM pin in Phase 1, so `--latest` and
+/// the default are equivalent today). Returns 0 (read-only, never fails the
+/// process on "updates available").
 ///
-/// Test: Call with `latest = false` and `latest = true`; neither should panic.
-pub fn run(latest: bool, json: bool) {
-    let cmd = if latest {
-        "updates --latest"
+/// Test: Side-effecting (network); the report shaping is tested via `UpdatesReport`.
+pub fn run(latest: bool, json: bool) -> i32 {
+    let _ = latest; // Phase 1: latest == default (no BOM pin yet).
+    let report = block_on(gather());
+    if json {
+        let _ = render_json(&report);
     } else {
-        "updates"
-    };
-    output::print_not_yet_implemented(cmd, json);
+        print_human(&report);
+    }
+    0
+}
+
+/// Probe the stable set for candidates and build the report.
+///
+/// Why: The async core, isolated from the sync CLI shell.
+/// What: Calls `gather_candidates(stable_set())`.
+/// Test: Side-effecting; covered indirectly.
+async fn gather() -> UpdatesReport {
+    let candidates = gather_candidates(&stable_set()).await;
+    UpdatesReport::build(candidates)
+}
+
+/// Render the human-readable updates listing to stdout.
+///
+/// Why: Operators want a quick scan of what is stale.
+/// What: Prints one line per candidate (`name installed → latest`), or a
+/// "everything up to date" line when there are none.
+/// Test: Side-effect-only; the data is tested via `UpdatesReport`.
+fn print_human(report: &UpdatesReport) {
+    if report.candidates.is_empty() {
+        println!("All stable-set tools are up to date.");
+        return;
+    }
+    println!("{} update(s) available:", report.count);
+    for c in &report.candidates {
+        let installed = c.installed.as_deref().unwrap_or("(not installed)");
+        println!("  {}  {} → {}", c.crate_name, installed, c.latest);
+    }
+    println!("Run `tctl upgrade` to apply (you will be asked to confirm).");
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::update_engine::UpdateCandidate;
 
+    /// Why: The JSON envelope is a public contract; pin its shape and count.
+    /// What: Builds a report with one candidate and asserts the keys.
+    /// Test: This is the test.
     #[test]
-    fn does_not_panic() {
-        run(false, false);
-        run(true, false);
-        run(false, true);
+    fn report_serialises() {
+        let report = UpdatesReport::build(vec![UpdateCandidate {
+            crate_name: "trusty-search".to_owned(),
+            binary: "trusty-search".to_owned(),
+            installed: Some("0.19.0".to_owned()),
+            latest: "0.20.0".to_owned(),
+            daemon: true,
+        }]);
+        let v = serde_json::to_value(&report).expect("serialises");
+        assert_eq!(v["command"], "updates");
+        assert_eq!(v["count"], 1);
+        assert_eq!(v["candidates"][0]["latest"], "0.20.0");
+    }
+
+    /// Why: An empty candidate list must report count 0 cleanly.
+    /// What: Builds an empty report; asserts count 0.
+    /// Test: This is the test.
+    #[test]
+    fn empty_report_count_zero() {
+        let report = UpdatesReport::build(vec![]);
+        assert_eq!(report.count, 0);
     }
 }

--- a/crates/trusty-controller/src/commands/updates.rs
+++ b/crates/trusty-controller/src/commands/updates.rs
@@ -59,14 +59,20 @@ impl UpdatesReport {
 /// accepted for surface compatibility; the listing always reports the latest
 /// crates.io release (there is no separate BOM pin in Phase 1, so `--latest` and
 /// the default are equivalent today). Returns 0 (read-only, never fails the
-/// process on "updates available").
+/// process on "updates available") — except exit 1 if a `--json` write to stdout
+/// fails, so automation never reads false success from a dropped JSON payload.
 ///
 /// Test: Side-effecting (network); the report shaping is tested via `UpdatesReport`.
 pub fn run(latest: bool, json: bool) -> i32 {
     let _ = latest; // Phase 1: latest == default (no BOM pin yet).
     let report = block_on(gather());
     if json {
-        let _ = render_json(&report);
+        // A failed machine-readable write must not exit 0: automation would
+        // read success from the exit code while the JSON never arrived.
+        if render_json(&report).is_err() {
+            eprintln!("tctl updates: failed to write JSON output");
+            return 1;
+        }
     } else {
         print_human(&report);
     }

--- a/crates/trusty-controller/src/commands/updates.rs
+++ b/crates/trusty-controller/src/commands/updates.rs
@@ -64,6 +64,7 @@ impl UpdatesReport {
 ///
 /// Test: Side-effecting (network); the report shaping is tested via `UpdatesReport`.
 pub fn run(latest: bool, json: bool) -> i32 {
+    // TODO(#1316): honour --latest once BOM/version pinning lands
     let _ = latest; // Phase 1: latest == default (no BOM pin yet).
     let report = block_on(gather());
     if json {

--- a/crates/trusty-controller/src/commands/upgrade.rs
+++ b/crates/trusty-controller/src/commands/upgrade.rs
@@ -1,34 +1,134 @@
-//! `tctl upgrade` — move members to BOM-pinned versions and restart.
+//! `tctl upgrade` — confirm-then-apply upgrades, then restart daemons (#1316).
 //!
-//! Why: The mutating half of the UUC3 flow (DOC-9 §3). After install, upgrade
-//! is the primary mechanism for moving the stack to a new known-good tuple.
+//! Why: The mutating half of the update flow. The #1316 added requirement makes
+//! the safety property explicit: present the available updates and apply them
+//! ONLY after confirmation (`--yes` skips the prompt for automation). Daemons
+//! are restarted cleanly after upgrade via `upgrade_and_restart` so launchd-
+//! supervised members come back on the new binary.
 //!
-//! What: Phase-0 stub. Phase-1 will implement the full DOC-9 flow:
-//! detect → changelog + blast-radius warn → per-member `cargo install --locked`
-//! / `uv tool upgrade` → health-gate → connection-safe restart → verify-after.
+//! What: Gathers candidates (`update_engine`), runs the pure confirm-then-apply
+//! gate (`decide_apply`), and — only on `Apply` — upgrades each member. Daemons
+//! go through `upgrade_and_restart` (cargo install + health-gate + connection-
+//! safe restart); non-daemons go through `perform_upgrade` + `verify_installed_
+//! binary`. Progress rows render via `trusty-progress`. `--check` is a read-only
+//! alias for `tctl updates`.
 //!
-//! The backing primitives in `trusty_common::update` (`perform_upgrade`,
-//! `verify_installed_binary`, `upgrade_and_restart`, `is_launchd_supervised`)
-//! are already available and will be composed here.
-//!
-//! Test: `run(false, false, false, false, &[], false)` does not panic.
+//! Test: `tests` covers the decision routing and the JSON report shaping; the
+//! actual `cargo install` + restart path is side-effecting.
 
-use crate::output;
+use serde::Serialize;
+use trusty_progress::{Component, ComponentTracker};
+
+use super::progress_ui::{is_tty, narrator, prompt_yes_no};
+use super::runtime::block_on;
+use super::stable_set::select_members;
+use super::update_engine::{
+    decide_apply, gather_candidates, ApplyDecision, ApplyInputs, UpdateCandidate,
+};
+use crate::output::render_json;
+
+/// One member's upgrade outcome for the report.
+///
+/// Why: Typed per-member result keeps machine output stable + testable.
+/// What: `member` crate name; `ok` success; `detail` human note / error / hint.
+/// Test: `tests::report_serialises`.
+#[derive(Clone, Debug, Serialize)]
+pub struct UpgradeOutcome {
+    /// Crate name upgraded.
+    pub member: String,
+    /// Whether the upgrade (+ restart for daemons) succeeded.
+    pub ok: bool,
+    /// Human detail: applied version, restart hint, or error.
+    pub detail: String,
+}
+
+/// The aggregate upgrade report.
+///
+/// Why: `--json` consumers want the whole rollup + a `status` discriminator that
+/// distinguishes "applied", "declined", "needs-confirmation", and "nothing".
+/// What: Holds the status string, the candidates considered, the per-member
+/// outcomes, and `all_ok`.
+/// Test: `tests::report_serialises`.
+#[derive(Clone, Debug, Serialize)]
+pub struct UpgradeReport {
+    /// Fixed command tag.
+    pub command: &'static str,
+    /// `applied` | `declined` | `needs_confirmation` | `nothing_to_do`.
+    pub status: &'static str,
+    /// The candidates considered (always populated for transparency).
+    pub candidates: Vec<UpdateCandidate>,
+    /// Per-member outcomes (only populated when `status == "applied"`).
+    pub members: Vec<UpgradeOutcome>,
+    /// Whether every applied member succeeded (true when nothing was applied).
+    pub all_ok: bool,
+}
+
+impl UpgradeReport {
+    /// Build a non-applying report (declined / needs-confirmation / nothing).
+    ///
+    /// Why: The three non-mutating outcomes share a shape (no member outcomes).
+    /// What: Sets `members = []`, `all_ok = true`.
+    /// Test: `tests::report_serialises`.
+    fn non_applying(status: &'static str, candidates: Vec<UpdateCandidate>) -> Self {
+        Self {
+            command: "upgrade",
+            status,
+            candidates,
+            members: Vec::new(),
+            all_ok: true,
+        }
+    }
+
+    /// Build an applied report from per-member outcomes.
+    ///
+    /// Why: Centralises the `all_ok` derivation for the applied path.
+    /// What: Sets `status = "applied"`, `all_ok = every outcome ok`.
+    /// Test: `tests::applied_report_all_ok`.
+    fn applied(candidates: Vec<UpdateCandidate>, members: Vec<UpgradeOutcome>) -> Self {
+        let all_ok = members.iter().all(|m| m.ok);
+        Self {
+            command: "upgrade",
+            status: "applied",
+            candidates,
+            members,
+            all_ok,
+        }
+    }
+
+    /// Process exit code per status.
+    ///
+    /// Why: Automation branches on this.
+    /// What: `applied` → 0 if all_ok else 2; `needs_confirmation` → 3 (could not
+    /// confirm — automation should pass `--yes`); `declined` → 4 (user said no);
+    /// `nothing_to_do` → 0.
+    /// Test: `tests::exit_codes_per_status`.
+    fn exit_code(&self) -> i32 {
+        match self.status {
+            "applied" => {
+                if self.all_ok {
+                    0
+                } else {
+                    2
+                }
+            }
+            "needs_confirmation" => 3,
+            "declined" => 4,
+            _ => 0,
+        }
+    }
+}
 
 /// Handle `tctl upgrade [<members>…] [--check] [--latest] [--exclude-self]`.
 ///
-/// Why: Phase-0 entry point for the upgrade action (DOC-9 §3).
+/// Why: Phase-1 confirm-then-apply upgrade (#1316 priority 2 + 3).
 ///
-/// What: All parameters are accepted and validated by clap; the underlying
-/// implementation is a Phase-0 stub.
+/// What: With `--check`, delegates to the read-only `updates` listing. Otherwise
+/// gathers candidates, presents them, runs the pure confirm-then-apply gate, and
+/// applies only on `Apply`. `exclude_self` drops `trusty-controller`/`tctl` from
+/// the set (avoids upgrading the running binary mid-flight). Returns the exit code.
 ///
-/// - `check`: dry-run mode (equivalent to `tctl updates`).
-/// - `latest`: target crates.io HEAD rather than the BOM pin.
-/// - `exclude_self`: skip self-upgrade of `tctl` itself (DOC-9 §8).
-/// - `members`: named subset; empty = all enabled members.
-/// - `yes`: bypass blast-radius confirmation (DOC-3 §5 / DOC-5 §3.3).
-///
-/// Test: Call with various combinations; none should panic.
+/// Test: `tests::run_check_is_readonly` (delegation); the apply path is
+/// side-effecting and validated manually.
 pub fn run(
     check: bool,
     latest: bool,
@@ -36,43 +136,261 @@ pub fn run(
     yes: bool,
     members: &[String],
     json: bool,
-) {
-    let mut label = "upgrade".to_owned();
+) -> i32 {
+    // --check is a read-only alias for `tctl updates`.
     if check {
-        label.push_str(" --check");
+        return super::updates::run(latest, json);
     }
-    if latest {
-        label.push_str(" --latest");
+
+    let (mut selected, unknown) = select_members(members);
+    if !unknown.is_empty() {
+        let msg = format!("unknown member(s): {}", unknown.join(", "));
+        if json {
+            let _ = render_json(&serde_json::json!({"command":"upgrade","error":msg}));
+        } else {
+            eprintln!("tctl upgrade: {msg}");
+        }
+        return 3;
     }
     if exclude_self {
-        label.push_str(" --exclude-self");
+        selected.retain(|m| m.crate_name != "trusty-controller" && m.binary != "tctl");
     }
-    if yes {
-        label.push_str(" --yes");
+
+    let candidates = block_on(gather_candidates(&selected));
+    let report = resolve_and_apply(candidates, yes, json);
+    if json {
+        let _ = render_json(&report);
+    } else {
+        print_human(&report);
     }
-    if !members.is_empty() {
-        label.push(' ');
-        label.push_str(&members.join(" "));
+    report.exit_code()
+}
+
+/// Present candidates, run the confirm-then-apply gate, and apply on `Apply`.
+///
+/// Why: The single place the #1316 safety property is enforced at the command
+/// layer — it threads `decide_apply` between "what's available" and "do it".
+///
+/// What: Lists candidates (human/stderr), computes the [`ApplyInputs`] from
+/// `--yes` + the TTY + (when prompting) an interactive yes/no, and matches the
+/// resulting [`ApplyDecision`] into an [`UpgradeReport`]. Only `Apply` mutates.
+///
+/// Test: `tests::run_check_is_readonly`; the apply branch is side-effecting.
+fn resolve_and_apply(candidates: Vec<UpdateCandidate>, yes: bool, json: bool) -> UpgradeReport {
+    let has_candidates = !candidates.is_empty();
+
+    if has_candidates && !json {
+        let narr = narrator(json);
+        let _ = narr.info(&format!("{} update(s) available:", candidates.len()));
+        for c in &candidates {
+            let installed = c.installed.as_deref().unwrap_or("(absent)");
+            let _ = narr.info(&format!("  {} {} → {}", c.crate_name, installed, c.latest));
+        }
     }
-    output::print_not_yet_implemented(&label, json);
+
+    // Only prompt when we actually need to (candidates, no --yes, on a TTY).
+    let interactive_consent = if has_candidates && !yes && is_tty() && !json {
+        prompt_yes_no("Apply these upgrades now?")
+    } else {
+        false
+    };
+
+    let decision = decide_apply(ApplyInputs {
+        has_candidates,
+        yes,
+        is_tty: is_tty(),
+        interactive_consent,
+    });
+
+    match decision {
+        ApplyDecision::NothingToDo => UpgradeReport::non_applying("nothing_to_do", candidates),
+        ApplyDecision::NeedsConfirmation => {
+            UpgradeReport::non_applying("needs_confirmation", candidates)
+        }
+        ApplyDecision::Decline => UpgradeReport::non_applying("declined", candidates),
+        ApplyDecision::Apply => {
+            let outcomes = block_on(apply_all(&candidates, json));
+            UpgradeReport::applied(candidates, outcomes)
+        }
+    }
+}
+
+/// Apply every candidate upgrade, restarting daemons cleanly.
+///
+/// Why: The async apply core; daemons must restart via the connection-safe path.
+/// What: For each candidate, daemons go through `upgrade_and_restart` (which may
+/// self-restart under launchd — but tctl is not itself launchd-supervised, so it
+/// returns the restart hint); non-daemons through `perform_upgrade` +
+/// `verify_installed_binary`. Renders a per-member narration line + a final
+/// component table.
+/// Test: Side-effecting; the report shaping is tested via `UpgradeReport`.
+async fn apply_all(candidates: &[UpdateCandidate], json: bool) -> Vec<UpgradeOutcome> {
+    let narr = narrator(json);
+    let mut tracker = ComponentTracker::new(narr.output());
+    let mut outcomes = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        let _ = narr.info(&format!("upgrading {} → {}", c.crate_name, c.latest));
+        let result = if c.daemon {
+            trusty_common::update::upgrade_and_restart(&c.crate_name, &c.binary)
+                .await
+                .map(|hint| hint.unwrap_or_else(|| "restarted".to_owned()))
+        } else {
+            match trusty_common::update::perform_upgrade(&c.crate_name).await {
+                Ok(()) => trusty_common::update::verify_installed_binary(&c.binary)
+                    .await
+                    .map(|()| format!("upgraded to {}", c.latest)),
+                Err(e) => Err(e),
+            }
+        };
+
+        match result {
+            Ok(detail) => {
+                outcomes.push(UpgradeOutcome {
+                    member: c.crate_name.clone(),
+                    ok: true,
+                    detail,
+                });
+                tracker.add(Component::new(c.binary.clone(), 0));
+            }
+            Err(e) => {
+                let _ = narr.error(&format!("{}: {e}", c.crate_name));
+                outcomes.push(UpgradeOutcome {
+                    member: c.crate_name.clone(),
+                    ok: false,
+                    detail: e.to_string(),
+                });
+            }
+        }
+    }
+    if !json {
+        let _ = tracker.print();
+    }
+    outcomes
+}
+
+/// Render the human-readable upgrade summary footer.
+///
+/// Why: Operators want a clear verdict after the confirm-then-apply flow.
+/// What: Branches on the report status to print the right one-liner.
+/// Test: Side-effect-only; the data is tested via `UpgradeReport`.
+fn print_human(report: &UpgradeReport) {
+    match report.status {
+        "nothing_to_do" => println!("All stable-set tools are up to date."),
+        "needs_confirmation" => eprintln!(
+            "tctl upgrade: {} update(s) available but not applied — re-run on a terminal or pass --yes to confirm.",
+            report.candidates.len()
+        ),
+        "declined" => eprintln!("tctl upgrade: aborted (no confirmation)."),
+        "applied" => {
+            let ok = report.members.iter().filter(|m| m.ok).count();
+            println!("upgraded {}/{}", ok, report.members.len());
+            for m in report.members.iter().filter(|m| !m.ok) {
+                eprintln!("  failed: {} — {}", m.member, m.detail);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn candidate() -> UpdateCandidate {
+        UpdateCandidate {
+            crate_name: "trusty-search".to_owned(),
+            binary: "trusty-search".to_owned(),
+            installed: Some("0.19.0".to_owned()),
+            latest: "0.20.0".to_owned(),
+            daemon: true,
+        }
+    }
+
+    /// Why: The non-applying envelope is a public contract; pin its shape.
+    /// What: Builds a needs-confirmation report; asserts keys.
+    /// Test: This is the test.
     #[test]
-    fn does_not_panic() {
-        run(false, false, false, false, &[], false);
-        run(true, false, false, false, &[], false);
-        run(false, true, false, false, &[], true);
-        run(
-            false,
-            false,
-            false,
-            true,
-            &["trusty-search".to_owned()],
-            false,
+    fn report_serialises() {
+        let report = UpgradeReport::non_applying("needs_confirmation", vec![candidate()]);
+        let v = serde_json::to_value(&report).expect("serialises");
+        assert_eq!(v["command"], "upgrade");
+        assert_eq!(v["status"], "needs_confirmation");
+        assert_eq!(v["candidates"][0]["crate_name"], "trusty-search");
+        assert_eq!(v["members"].as_array().expect("array").len(), 0);
+    }
+
+    /// Why: An applied report's `all_ok` must reflect member outcomes.
+    /// What: Mixes ok + failed; asserts all_ok false and status "applied".
+    /// Test: This is the test.
+    #[test]
+    fn applied_report_all_ok() {
+        let report = UpgradeReport::applied(
+            vec![candidate()],
+            vec![
+                UpgradeOutcome {
+                    member: "a".to_owned(),
+                    ok: true,
+                    detail: String::new(),
+                },
+                UpgradeOutcome {
+                    member: "b".to_owned(),
+                    ok: false,
+                    detail: "boom".to_owned(),
+                },
+            ],
         );
+        assert!(!report.all_ok);
+        assert_eq!(report.status, "applied");
+    }
+
+    /// Why: Exit codes are the automation contract; pin each status mapping.
+    /// What: Asserts the four status → exit-code mappings.
+    /// Test: This is the test.
+    #[test]
+    fn exit_codes_per_status() {
+        assert_eq!(
+            UpgradeReport::non_applying("nothing_to_do", vec![]).exit_code(),
+            0
+        );
+        assert_eq!(
+            UpgradeReport::non_applying("needs_confirmation", vec![candidate()]).exit_code(),
+            3
+        );
+        assert_eq!(
+            UpgradeReport::non_applying("declined", vec![candidate()]).exit_code(),
+            4
+        );
+        let applied_ok = UpgradeReport::applied(
+            vec![candidate()],
+            vec![UpgradeOutcome {
+                member: "a".to_owned(),
+                ok: true,
+                detail: String::new(),
+            }],
+        );
+        assert_eq!(applied_ok.exit_code(), 0);
+    }
+
+    /// Why: An unknown member must fail fast at selection (exit 3) and never
+    /// reach the network/apply path — a pure, offline-safe guard test.
+    /// What: Calls `run` with a bogus member in `--json` mode; asserts exit 3.
+    /// Test: This is the test.
+    #[test]
+    fn run_unknown_member_is_error() {
+        let code = run(false, false, false, true, &["not-a-tool".to_owned()], true);
+        assert_eq!(code, 3);
+    }
+
+    /// Why: `--check` must be read-only (delegates to `updates`) and never reach
+    /// the apply path. This performs a live crates.io probe, so it is
+    /// `#[ignore]`-tagged to keep CI fast and offline-deterministic.
+    /// What: Calls `run` with `check = true`; asserts exit 0 (read-only).
+    /// Test: `cargo test -p trusty-controller -- --include-ignored`.
+    #[test]
+    #[ignore = "performs a live crates.io probe; run with --include-ignored"]
+    fn run_check_is_readonly() {
+        let code = run(true, false, false, false, &["tga".to_owned()], true);
+        assert_eq!(code, 0);
     }
 }

--- a/crates/trusty-controller/src/commands/upgrade.rs
+++ b/crates/trusty-controller/src/commands/upgrade.rs
@@ -17,10 +17,11 @@
 //! actual `cargo install` + restart path is side-effecting.
 
 use serde::Serialize;
+use tokio::runtime::Handle;
 use trusty_progress::{Component, ComponentTracker};
 
 use super::progress_ui::{is_tty, narrator, prompt_yes_no};
-use super::runtime::block_on;
+use super::runtime::with_runtime;
 use super::stable_set::select_members;
 use super::update_engine::{
     decide_apply, gather_candidates, ApplyDecision, ApplyInputs, UpdateCandidate,
@@ -146,7 +147,10 @@ pub fn run(
     if !unknown.is_empty() {
         let msg = format!("unknown member(s): {}", unknown.join(", "));
         if json {
-            let _ = render_json(&serde_json::json!({"command":"upgrade","error":msg}));
+            if render_json(&serde_json::json!({"command":"upgrade","error":msg})).is_err() {
+                eprintln!("tctl upgrade: failed to write JSON output");
+                return 1;
+            }
         } else {
             eprintln!("tctl upgrade: {msg}");
         }
@@ -156,10 +160,20 @@ pub fn run(
         selected.retain(|m| m.crate_name != "trusty-controller" && m.binary != "tctl");
     }
 
-    let candidates = block_on(gather_candidates(&selected));
-    let report = resolve_and_apply(candidates, yes, json);
+    // Build ONE runtime for the whole command: candidate gathering and applying
+    // share the same handle (no per-future runtime construction, no nested
+    // runtime panic risk).
+    let report = with_runtime(|handle| {
+        let candidates = handle.block_on(gather_candidates(&selected));
+        resolve_and_apply(handle, candidates, yes, json)
+    });
     if json {
-        let _ = render_json(&report);
+        // A failed machine-readable write must not exit 0: automation would
+        // read success from the exit code while the JSON never arrived.
+        if render_json(&report).is_err() {
+            eprintln!("tctl upgrade: failed to write JSON output");
+            return 1;
+        }
     } else {
         print_human(&report);
     }
@@ -176,7 +190,12 @@ pub fn run(
 /// resulting [`ApplyDecision`] into an [`UpgradeReport`]. Only `Apply` mutates.
 ///
 /// Test: `tests::run_check_is_readonly`; the apply branch is side-effecting.
-fn resolve_and_apply(candidates: Vec<UpdateCandidate>, yes: bool, json: bool) -> UpgradeReport {
+fn resolve_and_apply(
+    handle: &Handle,
+    candidates: Vec<UpdateCandidate>,
+    yes: bool,
+    json: bool,
+) -> UpgradeReport {
     let has_candidates = !candidates.is_empty();
 
     if has_candidates && !json {
@@ -209,7 +228,7 @@ fn resolve_and_apply(candidates: Vec<UpdateCandidate>, yes: bool, json: bool) ->
         }
         ApplyDecision::Decline => UpgradeReport::non_applying("declined", candidates),
         ApplyDecision::Apply => {
-            let outcomes = block_on(apply_all(&candidates, json));
+            let outcomes = handle.block_on(apply_all(&candidates, json));
             UpgradeReport::applied(candidates, outcomes)
         }
     }

--- a/crates/trusty-controller/src/commands/upgrade.rs
+++ b/crates/trusty-controller/src/commands/upgrade.rs
@@ -207,19 +207,25 @@ fn resolve_and_apply(
         }
     }
 
+    // Probe the TTY exactly once and reuse the single binding for both the
+    // prompt gate and `decide_apply`. If these ever disagreed (two separate
+    // `is_tty()` calls), the user could answer "yes" yet `decide_apply` see
+    // `is_tty=false` → NeedsConfirmation (silent refusal), or vice versa.
+    let tty = is_tty();
+
     // Only prompt when we actually need to (candidates, no --yes, on a TTY).
-    let interactive_consent = if has_candidates && !yes && is_tty() && !json {
+    let interactive_consent = if should_prompt(has_candidates, yes, tty, json) {
         prompt_yes_no("Apply these upgrades now?")
     } else {
         false
     };
 
-    let decision = decide_apply(ApplyInputs {
+    let decision = decide_apply(build_apply_inputs(
         has_candidates,
         yes,
-        is_tty: is_tty(),
+        tty,
         interactive_consent,
-    });
+    ));
 
     match decision {
         ApplyDecision::NothingToDo => UpgradeReport::non_applying("nothing_to_do", candidates),
@@ -231,6 +237,40 @@ fn resolve_and_apply(
             let outcomes = handle.block_on(apply_all(&candidates, json));
             UpgradeReport::applied(candidates, outcomes)
         }
+    }
+}
+
+/// Decide whether to show the interactive confirmation prompt.
+///
+/// Why: Extracted as a pure predicate so the prompt gate and the
+/// [`ApplyInputs`] fed to `decide_apply` are guaranteed to read the *same*
+/// `tty` value (see `resolve_and_apply`). A divergence here would let the user
+/// consent on a prompt that `decide_apply` then treats as non-interactive.
+/// What: Prompt only when there are candidates, `--yes` was not passed, we are
+/// on a TTY, and we are not in `--json` mode.
+/// Test: `tests::prompt_gate_matches_apply_inputs`.
+fn should_prompt(has_candidates: bool, yes: bool, tty: bool, json: bool) -> bool {
+    has_candidates && !yes && tty && !json
+}
+
+/// Build the [`ApplyInputs`] for the gate from a single `tty` probe.
+///
+/// Why: Centralising construction guarantees the `is_tty` field carries the
+/// exact `tty` binding used by `should_prompt` — the consent and TTY values fed
+/// to `decide_apply` can never disagree.
+/// What: Threads the four decision inputs into an [`ApplyInputs`].
+/// Test: `tests::prompt_gate_matches_apply_inputs`.
+fn build_apply_inputs(
+    has_candidates: bool,
+    yes: bool,
+    tty: bool,
+    interactive_consent: bool,
+) -> ApplyInputs {
+    ApplyInputs {
+        has_candidates,
+        yes,
+        is_tty: tty,
+        interactive_consent,
     }
 }
 
@@ -389,6 +429,38 @@ mod tests {
             }],
         );
         assert_eq!(applied_ok.exit_code(), 0);
+    }
+
+    /// Why: The load-bearing safety invariant from re-review: the `tty` value
+    /// that gates the interactive prompt MUST be the same value fed to
+    /// `decide_apply` as `is_tty`. A divergence would let a user answer "yes"
+    /// while the gate silently treats the session as non-interactive (or the
+    /// reverse). This pins the single-source-of-truth `tty` binding.
+    /// What: For every (has_candidates, yes, tty, json) combination, asserts
+    /// (a) `build_apply_inputs.is_tty` equals the probed `tty`, and (b) whenever
+    /// `should_prompt` is true the same `tty` was true — so the consent path and
+    /// the gate's TTY view are always consistent.
+    /// Test: This is the test.
+    #[test]
+    fn prompt_gate_matches_apply_inputs() {
+        for &has_candidates in &[true, false] {
+            for &yes in &[true, false] {
+                for &tty in &[true, false] {
+                    for &json in &[true, false] {
+                        let prompt = should_prompt(has_candidates, yes, tty, json);
+                        // The consent the prompt would yield is irrelevant to
+                        // the invariant; what matters is the TTY value is shared.
+                        let inputs = build_apply_inputs(has_candidates, yes, tty, prompt);
+                        // (a) the gate sees exactly the probed tty.
+                        assert_eq!(inputs.is_tty, tty);
+                        // (b) we only ever prompt when that same tty is true.
+                        if prompt {
+                            assert!(tty, "prompted without a TTY the gate also sees");
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Why: An unknown member must fail fast at selection (exit 3) and never

--- a/crates/trusty-controller/src/main.rs
+++ b/crates/trusty-controller/src/main.rs
@@ -98,11 +98,11 @@ fn dispatch(cli: Cli) {
         }
 
         Commands::Status => {
-            status::run(json);
+            std::process::exit(status::run(json));
         }
 
         Commands::Updates { latest } => {
-            updates::run(latest, json);
+            std::process::exit(updates::run(latest, json));
         }
 
         Commands::Upgrade {
@@ -111,11 +111,18 @@ fn dispatch(cli: Cli) {
             latest,
             exclude_self,
         } => {
-            upgrade::run(check, latest, exclude_self, yes, &members, json);
+            std::process::exit(upgrade::run(
+                check,
+                latest,
+                exclude_self,
+                yes,
+                &members,
+                json,
+            ));
         }
 
         Commands::Install { members } => {
-            install::run(&members, yes, json);
+            std::process::exit(install::run(&members, yes, json));
         }
 
         Commands::Ensure { wait } => {
@@ -147,7 +154,7 @@ fn dispatch(cli: Cli) {
         }
 
         Commands::Ui { print } => {
-            ui::run(print, json);
+            std::process::exit(ui::run(print, json));
         }
 
         Commands::Passthrough(args) => {

--- a/crates/trusty-progress/src/output.rs
+++ b/crates/trusty-progress/src/output.rs
@@ -35,6 +35,19 @@ pub enum Mode {
 /// on stderr so stdout stays clean for JSON-RPC framing. A trait object behind
 /// an `Arc<Mutex<…>>` lets us swap stderr for an in-memory buffer.
 /// What: The shared, thread-safe write target for rendered lines.
+///
+/// ## Mutex poison recovery
+///
+/// Every `.lock()` on this sink (and on the [`Capture`] / [`SharedBuf`] buffers
+/// that back it) recovers from poisoning with
+/// `.unwrap_or_else(|poisoned| poisoned.into_inner())` rather than `.unwrap()`.
+/// A progress display is *purely cosmetic*: if one thread panicked mid-write and
+/// poisoned the mutex, the worst case is a single partially-written line — never
+/// corrupt program state. Recovering the guard lets the surviving threads keep
+/// rendering progress instead of cascading the panic into otherwise-healthy work
+/// (and, in a library, into the caller). This is the deliberate, crate-wide
+/// policy for the output sink; see the `writeln` / `Capture::contents` /
+/// `SharedBuf::write` lock sites below.
 type SharedSink = Arc<Mutex<dyn Write + Send>>;
 
 /// Why: Bundles the rendering [`Mode`] with the line sink so the narrator,

--- a/crates/trusty-progress/src/progress.rs
+++ b/crates/trusty-progress/src/progress.rs
@@ -41,12 +41,14 @@ impl ProgressHandle {
     pub fn spinner(output: &Output, message: impl Into<String>) -> Self {
         let bar = ProgressBar::new_spinner();
         bar.set_draw_target(output.draw_target());
-        // ProgressStyle::with_template only fails on a malformed template; ours
-        // is a const literal, so fall back to the default style if it ever does
-        // rather than unwrapping in library code.
-        if let Ok(style) = ProgressStyle::with_template(SPINNER_TEMPLATE) {
-            bar.set_style(style);
-        }
+        // `ProgressStyle::with_template` only fails on a malformed template, and
+        // `SPINNER_TEMPLATE` is a compile-time `const` literal we control — a
+        // parse failure here is a programmer error (a bad edit to the constant),
+        // never a runtime condition, so `expect` is the correct response: it
+        // surfaces the mistake loudly in dev/test rather than silently rendering
+        // an unstyled spinner. This is the one sanctioned `expect` in the crate.
+        let style = ProgressStyle::with_template(SPINNER_TEMPLATE).expect("const template valid");
+        bar.set_style(style);
         bar.set_message(message.into());
         bar.enable_steady_tick(SPINNER_TICK);
         Self { bar }
@@ -60,9 +62,10 @@ impl ProgressHandle {
     pub fn bar(output: &Output, total: u64, message: impl Into<String>) -> Self {
         let bar = ProgressBar::new(total);
         bar.set_draw_target(output.draw_target());
-        if let Ok(style) = ProgressStyle::with_template(BAR_TEMPLATE) {
-            bar.set_style(style);
-        }
+        // See `spinner` above: `BAR_TEMPLATE` is a `const` literal, so a parse
+        // failure is a programmer error and `expect` is the correct response.
+        let style = ProgressStyle::with_template(BAR_TEMPLATE).expect("const template valid");
+        bar.set_style(style);
         bar.set_message(message.into());
         Self { bar }
     }


### PR DESCRIPTION
Implements #1316 (Phase-1 must-haves). Builds on the post-de-bundle layout (#1318) and the trusty-progress crate (#1315).

Implemented:
- **install** — installs the stable set (search/memory/analyze/review/tga/console) in topological order via `trusty_common::update::{perform_upgrade,verify_installed_binary}`; rustup-style per-tool progress rows (trusty-progress); `--yes` + `--json`; clean non-zero exits.
- **updates / upgrade** — `updates [--latest]` lists upgradable crates (`check_crates_io`); `upgrade` = confirm-then-apply (applies ONLY after confirmation; `--yes` skips; non-TTY w/o --yes → NeedsConfirmation exit 3). Daemons restart via `upgrade_and_restart`. Decision logic is a pure, exhaustively-tested fn (`update_engine::decide_apply`).
- **Auto update CHECK (opt-in, notify-only)** — gated by new `[controller] auto_update_check` (default OFF); never applies without the explicit upgrade confirm gate.
- **ui** — spawns `trusty-console serve` (PATH); `--print` resolves URL via `trusty-console port --json`; exit 4 if console absent.
- **status** — installed versions + per-daemon health; `--json`; ready/degraded/incomplete.
- Folded in the trusty-progress review nits (const ProgressStyle `expect`, Mutex-poison doc).

Deferred (honest "not yet implemented" stubs, no silent success): ensure, start/stop/restart, stack health/doctor, doctor --self-check, config, port.

Verification: `cargo build -p trusty-controller` + workspace build (SKIP_UI_BUILD=1) green; `cargo test -p trusty-controller` 139 passed/0 failed; `cargo clippy --workspace --all-targets -- -D warnings` exit 0; `cargo fmt --check` clean; line-cap exit 0 (handlers split into focused modules, all <500 SLOC).

Note: adds trusty-progress to [workspace.dependencies] + enables trusty-common `update-check` feature for the controller.

Closes #1316.