### PR TITLE
chore(trusty-search): down-level benign timed_out_id=None embedder-stall WARN to debug (closes #1326)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,7 +6247,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10740,7 +10740,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11062,7 +11062,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
-trusty-common = { path = "crates/trusty-common", version = "0.15.2" }
+trusty-common = { path = "crates/trusty-common", version = "0.15.3" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.4" }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — trusty-common
 
+## [0.15.3] — 2026-06-16
+
+### Changed (closes #1326)
+
+- **`StdioEmbedderClient` reader: down-level benign `timed_out_id=None` timeout to `debug!`** — when the timeout fires with no in-flight request (empty pending map, a periodic idle re-arm while the embedder is healthy), the log is now `debug!` instead of `warn!`. The `warn!` path is preserved for `timed_out_id=Some(id)`, where a real in-flight request actually stalled. Eliminates ~2,800 spurious WARN lines/day during normal operation.
+
 ## [0.14.0] — 2026-06-04
 
 ### Changed (closes #753)

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.15.2"
+version = "0.15.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/src/embedder_client/stdio.rs
+++ b/crates/trusty-common/src/embedder_client/stdio.rs
@@ -245,16 +245,38 @@ async fn reader_task<R: AsyncBufRead + Unpin>(
                 // entry (not all) so other in-flight requests stay valid. The stale
                 // frame is discarded by the id-lookup when it eventually arrives.
                 // Issue #857: provider-aware hint so macOS operators are not misled.
+                //
+                // Why (log-level split, closes #1326): when `oldest_id` is None the
+                // pending map was empty — no in-flight request to blame, just a
+                // periodic re-arm while the embedder is idle and healthy. Emitting
+                // WARN there produces ~2,800 benign lines/day. When `oldest_id` is
+                // Some(id) a real in-flight request timed out — that is a genuine
+                // stall signal worth WARN.
+                // What: branches on the Option to select DEBUG (benign) vs WARN (real).
+                // Test: existing `reader_task_survives_timeout_and_serves_next_request`
+                // unit test covers the Some-id path; the None path is exercised by
+                // running with RUST_LOG=debug and verifying no WARN during idle periods.
                 let stall_hint = timeout_stall_hint(resolve_expected_provider());
-                tracing::warn!(
-                    timeout_secs = timeout.as_secs(),
-                    timed_out_id = ?oldest_id,
-                    "StdioEmbedderClient reader: timed out waiting for response \
-                     ({}s — {}) — removing stalled entry, \
-                     re-arming; task STAYS ALIVE",
-                    timeout.as_secs(),
-                    stall_hint,
-                );
+                if let Some(id) = oldest_id {
+                    tracing::warn!(
+                        timeout_secs = timeout.as_secs(),
+                        timed_out_id = id,
+                        "StdioEmbedderClient reader: timed out waiting for response \
+                         ({}s — {}) — removing stalled entry, \
+                         re-arming; task STAYS ALIVE",
+                        timeout.as_secs(),
+                        stall_hint,
+                    );
+                } else {
+                    tracing::debug!(
+                        timeout_secs = timeout.as_secs(),
+                        timed_out_id = ?oldest_id,
+                        "StdioEmbedderClient reader: timeout fired with no in-flight \
+                         request (idle re-arm, {}s — embedder healthy) — re-arming; \
+                         task STAYS ALIVE",
+                        timeout.as_secs(),
+                    );
+                }
                 if let Some(id) = oldest_id {
                     let req = {
                         let mut guard = pending.lock().await;

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,12 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.24.8] — 2026-06-16
+
+### Changed (closes #1326)
+
+- **Bumps `trusty-common` to 0.15.3**, which down-levels the benign `timed_out_id=None` embedder-stall WARN to `debug!`, eliminating ~2,800 spurious log lines/day during normal operation.
+
 ## [0.24.7] — 2026-06-16
 
 ### Changed (closes part of #1318)

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.24.7"
+version = "0.24.8"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.15.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.15.3", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
Implements #1326. The StdioEmbedderClient reader (in `crates/trusty-common/src/embedder_client/stdio.rs`) emitted a WARN every ~30s with `timed_out_id=None` while the embedder was healthy (~2,800 lines/day of noise).

Fix: branch on the `Option`:
- `timed_out_id=Some(id)` (a real in-flight request stalled) → keep `warn!` (genuine signal).
- `timed_out_id=None` (idle re-arm while healthy) → `debug!` (benign; suppressed from normal logs).
Re-arm / stalled-entry-removal behavior unchanged. Why/What/Test comment added.

Version bumps: trusty-common 0.15.2→0.15.3, trusty-search 0.24.7→0.24.8 (CHANGELOG updated).

Verification: `cargo check -p trusty-search` + `cargo clippy -p trusty-search --all-targets -- -D warnings` clean; `cargo test -p trusty-search` all pass; `cargo fmt --check` clean; line-cap exit 0.

Note: #1325 (also trusty-search) will take version 0.24.9 to avoid collision with this PR's 0.24.8.

Closes #1326.