### PR TITLE
fix(trusty-search): cursor-based deep pagination + timeout relief for get_chunks (closes #1325)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11062,7 +11062,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.24.8"
+version = "0.24.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11062,7 +11062,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,33 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.24.8] — 2026-06-16
+
+### Fixed (closes #1325)
+
+- **Deep `GET /indexes/{id}/chunks` pagination no longer times out / 502s on
+  large indexes.** The endpoint's offset path materialized the entire corpus
+  and re-sorted it on every page request (O(N log N) per page), so a deep
+  offset (`offset=304000` on a 300k-chunk index) blew past the client / proxy
+  timeout and surfaced as a 502 Bad Gateway after ~120 s. Chat / search were
+  unaffected.
+
+### Added (closes #1325)
+
+- **Cursor-based pagination for `GET /indexes/{id}/chunks` and the
+  `list_chunks` MCP tool.** A new, additive, non-breaking `after` query param
+  (the `list_chunks` tool gains a matching `after` arg) pages by chunk `id`
+  using an indexed redb B-tree seek (`CorpusStore::chunks_after`) instead of an
+  O(offset) scan — each page is O(page) regardless of depth. Send `after=`
+  (empty) to start from the first chunk and pass the response's `next_cursor`
+  back as `after` to walk forward; `next_cursor` is `null` once the corpus is
+  exhausted. The legacy `offset`/`limit` mode is unchanged for back-compat
+  (its `next_cursor` is always `null`, since offset ordering — by
+  `(file, start_line)` — differs from cursor ordering — by `id`; a cursor walk
+  must not be seeded from an offset page). Consumers doing bulk enumeration
+  (e.g. trusty-analyze's PR-review static-analysis context) should switch to
+  the cursor mode.
+
 ## [0.24.7] — 2026-06-16
 
 ### Changed (closes part of #1318)

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -305,13 +305,28 @@ live updates, so a subscriber that connects after `start` still sees it.
 
 - **Response 404**: no reindex has been queued for this index.
 
-##### `GET /indexes/:id/chunks?offset=&limit=`
+##### `GET /indexes/:id/chunks?offset=&limit=&after=`
 
-Paginated enumeration of all chunks in stable `(file, start_line)` order.
+Paginated enumeration of all chunks. Two modes:
+
+- **Offset mode** (default, issue #54): stable `(file, start_line)` order; the
+  slice `[offset .. offset+limit]`. Simple but O(N log N) per page — it
+  materialises and sorts the whole corpus each call, so deep offsets on large
+  indexes are slow (and previously 502'd, issue #1325). `next_cursor` is always
+  `null` in this mode.
+- **Cursor mode** (issue #1325, preferred for deep / bulk enumeration): opt in
+  by sending the `after` param. Pages by chunk `id` via an indexed redb B-tree
+  seek — O(page) regardless of depth. Send `after=` (empty) to start from the
+  first chunk; pass the response's `next_cursor` back as `after` to walk
+  forward. `next_cursor` is `null` once the corpus is exhausted. `offset` is
+  ignored. Cursor order (by `id`) differs from offset order — pick one mode and
+  page consistently; do not seed a cursor walk from an offset page.
 
 - **Query params**:
-  - `offset` (optional, default `0`).
+  - `offset` (optional, default `0`) — offset mode only.
   - `limit` (optional, default `100`, clamped to `1000`).
+  - `after` (optional) — cursor mode. Empty string = from the first chunk;
+    otherwise the opaque cursor (a chunk `id`) from a prior `next_cursor`.
 - **Response 200**:
   ```json
   {
@@ -319,9 +334,12 @@ Paginated enumeration of all chunks in stable `(file, start_line)` order.
     "total": 14823,
     "offset": 0,
     "limit": 100,
-    "chunks": [/* CodeChunk[] */]
+    "chunks": [/* CodeChunk[] */],
+    "next_cursor": "src/zzz.rs:10:42"
   }
   ```
+  `next_cursor` is the chunk `id` to pass as the next `after`, or `null` when
+  the page was the last one (cursor mode) / always `null` (offset mode).
 
 ##### Complexity / smells / quality endpoints
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.24.7"
+version = "0.24.8"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/core/corpus/corpus_ops.rs
+++ b/crates/trusty-search/src/core/corpus/corpus_ops.rs
@@ -303,6 +303,64 @@ impl CorpusStore {
         Ok(out)
     }
 
+    /// Cursor-paginate the chunk corpus in ascending `chunk_id` key order
+    /// (issue #1325).
+    ///
+    /// Why: deep offset pagination (`GET /indexes/{id}/chunks?offset=304000`)
+    /// previously loaded the *entire* corpus into memory and re-sorted it on
+    /// every page request — O(N log N) per page, which times out (and 502s
+    /// behind a proxy) on large indexes. redb's `CHUNKS_TABLE` is a B-tree
+    /// keyed by `chunk_id`, so a `range(after..)` is an indexed seek: O(log N)
+    /// to position the cursor plus O(page) to read. Paging forward by passing
+    /// the previous page's last id as `after` is therefore O(page) per call
+    /// instead of O(offset).
+    /// What: opens a read transaction and walks `CHUNKS_TABLE` starting
+    /// *strictly after* `after` (when `Some`) or from the first key (when
+    /// `None`), deserialising up to `limit` rows. The cursor is exclusive and
+    /// need not be an exact stored key — redb seeks to the next-greater key, so
+    /// a client may pass back any opaque string and still resume correctly.
+    /// Corrupt rows are skipped with a `warn`, matching `load_all_chunks`.
+    /// `limit == 0` returns an empty `Vec` without opening the table iterator.
+    /// Test: `chunks_after_cursor_seeks_and_pages_in_key_order`.
+    pub fn chunks_after(&self, after: Option<&str>, limit: usize) -> Result<Vec<RawChunk>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        use std::ops::Bound;
+        let txn = self
+            .db
+            .begin_read()
+            .context("begin chunk cursor read txn")?;
+        let table = txn.open_table(CHUNKS_TABLE)?;
+        // Exclusive lower bound on the cursor id; unbounded upper end. redb
+        // walks the B-tree from the seek point, so we never touch the rows
+        // before `after`.
+        let lower = match after {
+            Some(cursor) => Bound::Excluded(cursor),
+            None => Bound::Unbounded,
+        };
+        let mut out = Vec::with_capacity(limit);
+        let range = table
+            .range::<&str>((lower, Bound::Unbounded))
+            .context("range chunks table by cursor")?;
+        for entry in range {
+            let (key, value) = entry.context("read chunk row in cursor page")?;
+            match serde_json::from_slice::<RawChunk>(value.value()) {
+                Ok(chunk) => out.push(chunk),
+                Err(e) => {
+                    tracing::warn!(
+                        "corpus: skipping corrupt chunk row '{}' in cursor page ({e})",
+                        key.value()
+                    )
+                }
+            }
+            if out.len() >= limit {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
     /// Load every per-file entity list.
     ///
     /// Why: counterpart of [`Self::load_all_chunks`] for the entities table;

--- a/crates/trusty-search/src/core/corpus/tests.rs
+++ b/crates/trusty-search/src/core/corpus/tests.rs
@@ -177,6 +177,55 @@ fn get_chunks_batch_reads_subset() {
 }
 
 #[test]
+fn chunks_after_cursor_seeks_and_pages_in_key_order() {
+    // Issue #1325: deep pagination must be a B-tree seek, not a full scan.
+    // `chunks_after(cursor, limit)` returns up to `limit` rows whose id is
+    // strictly greater than `cursor`, in redb key (ascending id) order, so a
+    // client can page forward in O(page) without re-reading earlier rows.
+    let dir = tempfile::tempdir().unwrap();
+    let store = CorpusStore::open(&dir.path().join("index.redb")).unwrap();
+    // Insert out of order to prove the read order is the table's key order,
+    // not insertion order.
+    store
+        .upsert_chunks(&[
+            raw("c:1:1", "fn c() {}"),
+            raw("a:1:1", "fn a() {}"),
+            raw("e:1:1", "fn e() {}"),
+            raw("b:1:1", "fn b() {}"),
+            raw("d:1:1", "fn d() {}"),
+        ])
+        .unwrap();
+
+    // First page (no cursor): the two lowest ids in key order.
+    let page1 = store.chunks_after(None, 2).unwrap();
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1[0].id, "a:1:1");
+    assert_eq!(page1[1].id, "b:1:1");
+
+    // Second page: cursor = last id of page1, exclusive.
+    let page2 = store.chunks_after(Some("b:1:1"), 2).unwrap();
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2[0].id, "c:1:1");
+    assert_eq!(page2[1].id, "d:1:1");
+
+    // Final partial page.
+    let page3 = store.chunks_after(Some("d:1:1"), 2).unwrap();
+    assert_eq!(page3.len(), 1);
+    assert_eq!(page3[0].id, "e:1:1");
+
+    // Past the end → empty, never an error.
+    assert!(store.chunks_after(Some("e:1:1"), 2).unwrap().is_empty());
+
+    // A cursor that is not itself a stored id still seeks to the next-greater
+    // row (clients pass back an opaque cursor; it need not be an exact key).
+    let after_gap = store.chunks_after(Some("a:9:9"), 10).unwrap();
+    assert_eq!(after_gap[0].id, "b:1:1", "seek lands on next-greater id");
+
+    // limit == 0 → empty page.
+    assert!(store.chunks_after(None, 0).unwrap().is_empty());
+}
+
+#[test]
 fn missing_db_is_empty() {
     // A brand-new database (post-upgrade / first-run) must open cleanly
     // and report an empty corpus rather than erroring.

--- a/crates/trusty-search/src/core/indexer/files.rs
+++ b/crates/trusty-search/src/core/indexer/files.rs
@@ -104,6 +104,101 @@ impl CodeIndexer {
         (total, page)
     }
 
+    /// Cursor-paginate the chunk corpus in ascending `chunk_id` order, doing an
+    /// indexed B-tree seek instead of a full-corpus scan (issue #1325).
+    ///
+    /// Why: [`Self::enumerate_chunks`] loads every chunk and re-sorts the whole
+    /// corpus on every page request — O(N log N) per page — which times out
+    /// (and 502s behind a proxy) at deep offsets on large indexes
+    /// (`offset=304000`). When a durable [`CorpusStore`] is wired, this method
+    /// instead seeks straight to the cursor in redb's `chunk_id`-keyed B-tree
+    /// and reads one page: O(log N) + O(page) per call, so a forward scan over
+    /// the whole corpus is O(N) total rather than O(N²/page). Indexers without
+    /// a durable corpus (BM25-only / tests) fall back to the in-memory map,
+    /// reproducing the cursor (exclusive `after`, ascending id) semantics over
+    /// the same `(file, start_line, end_line)` ordering used elsewhere — note
+    /// this differs from the redb path's pure `id` ordering, but both are
+    /// stable total orders, which is all a cursor requires.
+    /// What: returns `(total, page, next_cursor)`. `total` is the corpus chunk
+    /// count (cheap `CorpusStore::chunk_count`, or the in-memory length).
+    /// `page` is up to `limit` materialized [`CodeChunk`]s strictly after
+    /// `after`. `next_cursor` is `Some(last_id)` when a full `limit`-sized page
+    /// was returned (more rows may follow) and `None` once the page is short
+    /// (end reached) — so a client loops until `next_cursor` is `None`.
+    /// Test: `test_enumerate_chunks_after_cursor_pages_via_redb` and
+    /// `test_enumerate_chunks_after_cursor_in_memory_fallback`.
+    pub async fn enumerate_chunks_after(
+        &self,
+        after: Option<&str>,
+        limit: usize,
+    ) -> (usize, Vec<CodeChunk>, Option<String>) {
+        let root = self.root_path.clone();
+        // Durable path: indexed seek over redb, no full-corpus materialization.
+        if let Some(corpus) = self.corpus.clone() {
+            let total = corpus.chunk_count().unwrap_or(0);
+            if limit == 0 || total == 0 {
+                return (total, Vec::new(), None);
+            }
+            let after_owned = after.map(str::to_string);
+            let raws = tokio::task::spawn_blocking(move || {
+                corpus.chunks_after(after_owned.as_deref(), limit)
+            })
+            .await;
+            let raws = match raws {
+                Ok(Ok(raws)) => raws,
+                Ok(Err(e)) => {
+                    tracing::warn!("index '{}': cursor page read failed ({e})", self.index_id);
+                    return (total, Vec::new(), None);
+                }
+                Err(e) => {
+                    tracing::warn!("index '{}': cursor page task panicked ({e})", self.index_id);
+                    return (total, Vec::new(), None);
+                }
+            };
+            let next_cursor = if raws.len() == limit {
+                raws.last().map(|r| r.id.clone())
+            } else {
+                None
+            };
+            let page: Vec<CodeChunk> = raws
+                .iter()
+                .map(|raw| raw_to_code_chunk(raw, 0.0, "enumerate", None, &root))
+                .collect();
+            return (total, page, next_cursor);
+        }
+
+        // In-memory fallback (no durable corpus): reproduce the redb path's
+        // cursor semantics by ordering on `chunk_id` alone, so the exclusive
+        // `after` cursor is monotonic with the sort and `partition_point` finds
+        // the resume point correctly. This is a different (but equally stable)
+        // total order from `enumerate_chunks`'s (file, start_line) ordering —
+        // the cursor path only requires internal consistency.
+        self.ensure_chunks_loaded().await;
+        let chunks = self.chunks.read().await;
+        let total = chunks.len();
+        if limit == 0 || total == 0 {
+            return (total, Vec::new(), None);
+        }
+        let mut ordered: Vec<&RawChunk> = chunks.values().collect();
+        ordered.sort_by(|a, b| a.id.cmp(&b.id));
+        let start = match after {
+            Some(cursor) => ordered.partition_point(|r| r.id.as_str() <= cursor),
+            None => 0,
+        };
+        let end = (start + limit).min(ordered.len());
+        let slice = &ordered[start..end];
+        let next_cursor = if slice.len() == limit {
+            slice.last().map(|r| r.id.clone())
+        } else {
+            None
+        };
+        let page: Vec<CodeChunk> = slice
+            .iter()
+            .map(|raw| raw_to_code_chunk(raw, 0.0, "enumerate", None, &root))
+            .collect();
+        (total, page, next_cursor)
+    }
+
     /// Run an HNSW-only similarity search against a precomputed embedding,
     /// excluding `exclude_id` (typically the seed chunk). Returns up to
     /// `top_k` `CodeChunk`s with `match_reason = "vector"`.

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -51,6 +51,8 @@ pub(crate) use ingest::PROGRESS_CHUNK_INTERVAL;
 pub(crate) use search::KG_REFINE_THRESHOLD;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_cursor;
 
 // Re-export helpers so sibling modules can use the crate-internal API.
 pub(crate) use helpers::{

--- a/crates/trusty-search/src/core/indexer/tests_cursor.rs
+++ b/crates/trusty-search/src/core/indexer/tests_cursor.rs
@@ -1,0 +1,127 @@
+//! Cursor-pagination tests for [`CodeIndexer::enumerate_chunks_after`]
+//! (issue #1325).
+//!
+//! Why: deep offset pagination over `GET /indexes/{id}/chunks` timed out on
+//! large indexes because every page re-sorted the whole corpus. The cursor
+//! path does an indexed redb B-tree seek instead. These tests pin both the
+//! durable (redb-backed) and in-memory fallback code paths.
+//! What: page through a corpus by following `next_cursor`, asserting full
+//! coverage, no duplicates, ascending `id` order, and termination.
+//! Test: this module (lives in its own file to keep `tests.rs` under the
+//! 1500-SLOC test cap).
+use super::CodeIndexer;
+use crate::core::chunker::{ChunkType, RawChunk};
+use crate::core::corpus::CorpusStore;
+use std::sync::Arc;
+
+/// Minimal in-memory `RawChunk` builder.
+fn raw(id: &str) -> RawChunk {
+    RawChunk {
+        id: id.to_string(),
+        file: "f.rs".to_string(),
+        start_line: 1,
+        end_line: 1,
+        content: "fn x() {}".to_string(),
+        function_name: None,
+        language: Some("rust".to_string()),
+        chunk_type: ChunkType::Code,
+        calls: Vec::new(),
+        inherits_from: Vec::new(),
+        chunk_depth: 0,
+        parent_chunk_id: None,
+        child_chunk_ids: Vec::new(),
+        nlp_keywords: Vec::new(),
+        nlp_code_refs: Vec::new(),
+        virtual_terms: Vec::new(),
+    }
+}
+
+/// In-memory fallback path: no durable corpus. Paging forward by `next_cursor`
+/// must cover every chunk exactly once, in ascending id order, and terminate.
+#[tokio::test]
+async fn test_enumerate_chunks_after_cursor_in_memory_fallback() {
+    let idx = CodeIndexer::new("cursor-mem", "/tmp/cursor-mem");
+    for id in ["a:1:1", "b:1:1", "c:1:1", "d:1:1", "e:1:1"] {
+        idx.add_chunk(raw(id)).await.unwrap();
+    }
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut pages = 0;
+    loop {
+        let (total, page, next) = idx.enumerate_chunks_after(cursor.as_deref(), 2).await;
+        assert_eq!(total, 5, "total chunk count is stable across pages");
+        for c in &page {
+            seen.push(c.id.clone());
+        }
+        pages += 1;
+        match next {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+        assert!(pages < 10, "pagination must terminate");
+    }
+    assert_eq!(seen, vec!["a:1:1", "b:1:1", "c:1:1", "d:1:1", "e:1:1"]);
+
+    // limit == 0 → empty page, no cursor.
+    let (total_z, z, next_z) = idx.enumerate_chunks_after(None, 0).await;
+    assert_eq!(total_z, 5);
+    assert!(z.is_empty());
+    assert!(next_z.is_none());
+}
+
+/// Durable path: cursor pagination over a redb corpus does an indexed seek.
+/// Verifies full coverage, termination, ascending `chunk_id` key order, and no
+/// duplicates.
+#[tokio::test]
+async fn test_enumerate_chunks_after_cursor_pages_via_redb() {
+    let dir = tempfile::tempdir().unwrap();
+    let redb_path = dir.path().join("index.redb");
+    let mut idx = CodeIndexer::new("cursor-redb", "/tmp/cursor-redb");
+    idx.set_corpus_store(Arc::new(
+        CorpusStore::open(&redb_path).expect("open corpus"),
+    ));
+
+    // index_files_batch persists chunks into redb (unlike add_chunk, which is
+    // in-memory only) so the cursor path reads them back via the B-tree.
+    idx.index_files_batch(&[
+        ("src/a.rs".into(), "fn a_one() {}\nfn a_two() {}".into()),
+        ("src/b.rs".into(), "fn b_one() {}".into()),
+        ("src/c.rs".into(), "fn c_one() {}".into()),
+    ])
+    .await
+    .expect("index batch");
+
+    let total_chunks = idx.chunk_count();
+    assert!(
+        total_chunks >= 3,
+        "expected >= 3 chunks, got {total_chunks}"
+    );
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut pages = 0;
+    loop {
+        let (total, page, next) = idx.enumerate_chunks_after(cursor.as_deref(), 2).await;
+        assert_eq!(total, total_chunks, "total is the redb chunk_count");
+        for c in &page {
+            seen.push(c.id.clone());
+        }
+        pages += 1;
+        match next {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+        assert!(pages < 1000, "pagination must terminate");
+    }
+    assert_eq!(
+        seen.len(),
+        total_chunks,
+        "every chunk returned exactly once"
+    );
+    let mut sorted = seen.clone();
+    sorted.sort();
+    assert_eq!(seen, sorted, "redb cursor pages in ascending id order");
+    sorted.dedup();
+    assert_eq!(sorted.len(), seen.len(), "no chunk returned twice");
+}

--- a/crates/trusty-search/src/mcp/tools/descriptors.rs
+++ b/crates/trusty-search/src/mcp/tools/descriptors.rs
@@ -245,14 +245,21 @@ pub fn tool_descriptors() -> Value {
         },
         {
             "name": "list_chunks",
-            "description": "Paginated enumeration of every chunk in an index (issue #54). Stable order by (file, start_line).",
+            "description": "Paginated enumeration of every chunk in an index (issue #54). \
+                            Two modes: offset/limit (stable order by file, start_line) for \
+                            shallow paging, or cursor paging via `after` (issue #1325) for \
+                            deep/bulk enumeration. Pass the response's `next_cursor` back as \
+                            `after` to fetch the next page in O(page) time (an indexed seek) \
+                            instead of the O(offset) scan that times out on large indexes. \
+                            `next_cursor` is null once the corpus is exhausted.",
             "inputSchema": {
                 "type": "object",
                 "required": ["index_id"],
                 "properties": {
                     "index_id": { "type": "string" },
                     "offset":   { "type": "integer", "default": 0 },
-                    "limit":    { "type": "integer", "default": 100 }
+                    "limit":    { "type": "integer", "default": 100 },
+                    "after":    { "type": "string", "description": "Forward cursor (a chunk id, typically the previous page's next_cursor). When set, offset is ignored." }
                 }
             }
         },

--- a/crates/trusty-search/src/mcp/tools/http.rs
+++ b/crates/trusty-search/src/mcp/tools/http.rs
@@ -49,6 +49,44 @@ impl McpServer {
         Ok(body)
     }
 
+    /// GET a JSON endpoint with query parameters that need URL-encoding.
+    ///
+    /// Why: `list_chunks`'s cursor (`after`, issue #1325) is a chunk `id` of the
+    /// form `path:start:end` — it contains `:` and may contain path separators
+    /// and other reserved characters that must be percent-encoded or the query
+    /// string breaks. Building the query with `reqwest::RequestBuilder::query`
+    /// encodes each pair correctly, unlike hand-formatting into the path.
+    /// What: GETs `{base_url}{path}` with `query` appended as a properly-encoded
+    /// query string, then mirrors [`Self::get`]'s status-then-decode handling.
+    /// Test: `list_chunks` cursor arm exercises this via the dispatch tests.
+    pub(super) async fn get_query(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<Value, DispatchError> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .http
+            .get(&url)
+            .query(query)
+            .send()
+            .await
+            .map_err(|e| DispatchError::Transport(format!("GET {url}: {e}")))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| DispatchError::Transport(format!("read {url}: {e}")))?;
+        if !status.is_success() {
+            return Err(DispatchError::Transport(format!(
+                "GET {url} returned {status}: {text}"
+            )));
+        }
+        let body: Value = serde_json::from_str(&text)
+            .map_err(|e| DispatchError::Transport(format!("decode {url}: {e}")))?;
+        Ok(body)
+    }
+
     /// GET an endpoint that returns `text/plain`.
     ///
     /// Why: `get_call_chain` (issue #76) returns prose intended for direct LLM

--- a/crates/trusty-search/src/mcp/tools/index.rs
+++ b/crates/trusty-search/src/mcp/tools/index.rs
@@ -126,18 +126,27 @@ pub(super) async fn dispatch_index_tool(
         }
         "list_chunks" => {
             // Issue #54 — paginated enumeration of an index's corpus.
-            // Mirrors `GET /indexes/:id/chunks?offset=&limit=`.
+            // Mirrors `GET /indexes/:id/chunks?offset=&limit=&after=`.
+            // Issue #1325: an optional `after` cursor switches to an indexed
+            // redb seek (O(page) at any depth) instead of the O(offset) scan;
+            // the daemon echoes `next_cursor` for the next call.
             let index_id = match require_str(args, "index_id") {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
             let offset = args.get("offset").and_then(Value::as_u64).unwrap_or(0);
             let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100);
+            let mut query: Vec<(&str, String)> =
+                vec![("offset", offset.to_string()), ("limit", limit.to_string())];
+            if let Some(after) = args.get("after").and_then(Value::as_str) {
+                // The cursor is a chunk id (`path:start:end`) — reqwest's
+                // `.query()` percent-encodes it so reserved chars don't break
+                // the query string.
+                query.push(("after", after.to_string()));
+            }
             Some(
                 server
-                    .get(&format!(
-                        "/indexes/{index_id}/chunks?offset={offset}&limit={limit}"
-                    ))
+                    .get_query(&format!("/indexes/{index_id}/chunks"), &query)
                     .await,
             )
         }

--- a/crates/trusty-search/src/service/server/files.rs
+++ b/crates/trusty-search/src/service/server/files.rs
@@ -61,13 +61,28 @@ pub(super) async fn remove_file_handler(
     })))
 }
 
-/// Query params for `GET /indexes/:id/chunks` (issue #54).
+/// Query params for `GET /indexes/:id/chunks` (issue #54, #1325).
+///
+/// Why: the original `offset`/`limit` pair forced an O(N log N) full-corpus
+/// scan-and-sort per page, which 502'd at deep offsets (`offset=304000`) on
+/// large indexes (issue #1325). `after` adds opt-in cursor pagination keyed on
+/// the chunk's stable `id`, served by an indexed redb B-tree seek — O(page)
+/// per call. `offset` is retained verbatim for back-compat.
+/// What: `offset` (default 0), `limit` (default 100, clamped to 1000), and the
+/// optional `after` cursor. When `after` is present it takes precedence and
+/// `offset` is ignored.
+/// Test: `test_get_index_chunks_paginates` (offset) and
+/// `chunks_endpoint_cursor_*` server tests (cursor).
 #[derive(Deserialize)]
 pub struct ChunksParams {
     #[serde(default)]
     pub offset: usize,
     #[serde(default = "default_chunks_limit")]
     pub limit: usize,
+    /// Opaque forward cursor (a chunk `id`). When set, the page is the rows
+    /// strictly after this id in ascending key order; `offset` is ignored.
+    #[serde(default)]
+    pub after: Option<String>,
 }
 
 fn default_chunks_limit() -> usize {
@@ -85,12 +100,27 @@ const MAX_CHUNKS_LIMIT: usize = 1_000;
 /// Issue #54 introduces stable-order pagination on top of the existing bulk
 /// export.
 /// What: Returns
-/// `{ index_id, total, offset, limit, chunks: [...] }`. `chunks` is the slice
-/// `[offset .. offset+limit]` of the corpus sorted by `(file, start_line)`.
-/// `limit` is clamped to `MAX_CHUNKS_LIMIT` (1000); the value echoed back in
-/// the response is the post-clamp value so clients can detect the clamp.
-/// Test: `test_get_index_chunks_paginates` registers an index, indexes a few
-/// files, asserts page1 + page2 cover all chunks without overlap.
+/// `{ index_id, total, offset, limit, chunks: [...], next_cursor }`.
+///
+/// Two pagination modes, selected by the presence of the `after` query param:
+/// - **Cursor (issue #1325, preferred for deep / bulk pagination):** when
+///   `after` is present (including an empty string, meaning "from the start"),
+///   the page is the rows strictly after that chunk `id` in ascending key
+///   order, served by an indexed redb B-tree seek — O(page) regardless of
+///   depth. `next_cursor` carries the id to pass as the next `after`, or is
+///   `null` once the corpus is exhausted. `offset` is ignored in this mode.
+/// - **Offset (issue #54, back-compat):** when `after` is absent, `chunks` is
+///   the slice `[offset .. offset+limit]` of the corpus ordered by
+///   `(file, start_line)`. `next_cursor` is always `null` in this mode (offset
+///   order differs from cursor order, so a cursor walk must not be seeded from
+///   an offset page). Offset pagination still scans/sorts the whole corpus per
+///   page and can be slow at deep offsets on large indexes — prefer `after` for
+///   bulk enumeration.
+///
+/// `limit` is clamped to `MAX_CHUNKS_LIMIT` (1000); the echoed value is the
+/// post-clamp value so clients can detect the clamp.
+/// Test: `test_get_index_chunks_paginates` (offset) and the
+/// `chunks_endpoint_cursor_*` server tests (cursor + next_cursor).
 pub(super) async fn get_index_chunks_handler(
     State(state): State<Arc<SearchAppState>>,
     Path(id): Path<String>,
@@ -100,6 +130,37 @@ pub(super) async fn get_index_chunks_handler(
     let handle = state.registry.get(&index_id).ok_or(StatusCode::NOT_FOUND)?;
     let limit = params.limit.min(MAX_CHUNKS_LIMIT);
     let indexer = handle.indexer.read().await;
+
+    // Cursor mode (issue #1325): opt-in by sending the `after` param at all —
+    // even an empty string, which means "start from the first chunk". The
+    // cursor path orders strictly by `chunk_id` (the redb B-tree key) and does
+    // an indexed seek, so it is O(page) at any depth. An empty cursor is
+    // treated as "no cursor" (first page); a non-empty cursor resumes strictly
+    // after that id. NOTE: cursor order (by id) differs from offset order (by
+    // file, start_line), so a client must pick ONE mode and page consistently;
+    // do not seed a cursor walk from an offset response.
+    if let Some(cursor) = params.after.as_deref() {
+        let after = if cursor.is_empty() {
+            None
+        } else {
+            Some(cursor)
+        };
+        let (total, chunks, next_cursor) = indexer.enumerate_chunks_after(after, limit).await;
+        return Ok(Json(serde_json::json!({
+            "index_id": index_id.0,
+            "total": total,
+            "offset": params.offset,
+            "limit": limit,
+            "chunks": chunks,
+            "next_cursor": next_cursor,
+        })));
+    }
+
+    // Offset mode (issue #54): retained verbatim for back-compat. `next_cursor`
+    // is always null here — offset and cursor use different orderings, so we do
+    // not imply that a cursor walk can continue from an offset page (that would
+    // drop or duplicate rows). Clients wanting fast deep pagination should use
+    // the cursor mode from the start (`after=`).
     let (total, chunks) = indexer.enumerate_chunks(params.offset, limit).await;
     Ok(Json(serde_json::json!({
         "index_id": index_id.0,
@@ -107,6 +168,7 @@ pub(super) async fn get_index_chunks_handler(
         "offset": params.offset,
         "limit": limit,
         "chunks": chunks,
+        "next_cursor": serde_json::Value::Null,
     })))
 }
 

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -34,6 +34,8 @@ mod tests_1073;
 #[cfg(test)]
 mod tests_829;
 #[cfg(test)]
+mod tests_chunks;
+#[cfg(test)]
 mod tests_contrib_graph;
 #[cfg(test)]
 mod tests_denylist;

--- a/crates/trusty-search/src/service/server/tests_chunks.rs
+++ b/crates/trusty-search/src/service/server/tests_chunks.rs
@@ -1,0 +1,164 @@
+//! Tests for `GET /indexes/:id/chunks` pagination (issues #54, #1325).
+//!
+//! Why: deep offset pagination 502'd on large indexes (#1325). The handler now
+//! supports an additive `after` cursor (indexed seek, O(page)) alongside the
+//! legacy `offset`/`limit` (O(offset) scan, retained for back-compat). These
+//! tests pin both modes and the `next_cursor` contract.
+//! What: register an in-memory index, plant chunks, drive
+//! `get_index_chunks_handler` directly, and assert page coverage / ordering /
+//! cursor semantics.
+//! Test: this module.
+use super::*;
+use crate::core::chunker::{ChunkType, RawChunk};
+use crate::core::indexer::CodeIndexer;
+use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+use axum::extract::{Path, Query, State};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Minimal `RawChunk` for the in-memory fallback path (no durable corpus).
+fn raw(id: &str) -> RawChunk {
+    RawChunk {
+        id: id.to_string(),
+        file: "src/lib.rs".to_string(),
+        start_line: 1,
+        end_line: 1,
+        content: "fn x() {}".to_string(),
+        function_name: None,
+        language: Some("rust".to_string()),
+        chunk_type: ChunkType::Code,
+        calls: Vec::new(),
+        inherits_from: Vec::new(),
+        chunk_depth: 0,
+        parent_chunk_id: None,
+        child_chunk_ids: Vec::new(),
+        nlp_keywords: Vec::new(),
+        nlp_code_refs: Vec::new(),
+        virtual_terms: Vec::new(),
+    }
+}
+
+/// Build a one-index state with the given chunk ids planted in memory.
+async fn state_with_chunks(ids: &[&str]) -> (Arc<SearchAppState>, String) {
+    let registry = IndexRegistry::new();
+    let name = "chunks-test";
+    let id = IndexId::new(name);
+    let indexer = CodeIndexer::new(name, "/tmp/chunks-test");
+    for cid in ids {
+        indexer.add_chunk(raw(cid)).await.unwrap();
+    }
+    registry.register(IndexHandle::bare(
+        id,
+        Arc::new(RwLock::new(indexer)),
+        "/tmp/chunks-test".into(),
+    ));
+    (Arc::new(SearchAppState::new(registry)), name.to_string())
+}
+
+async fn call_chunks(
+    state: &Arc<SearchAppState>,
+    name: &str,
+    params: ChunksParams,
+) -> serde_json::Value {
+    let resp = get_index_chunks_handler(
+        State(Arc::clone(state)),
+        Path(name.to_string()),
+        Query(params),
+    )
+    .await
+    .expect("handler ok");
+    resp.0
+}
+
+/// Cursor mode: paging forward by `next_cursor` covers every chunk exactly
+/// once, in ascending id order, and terminates with `next_cursor = null`.
+#[tokio::test]
+async fn chunks_endpoint_cursor_pages_full_coverage() {
+    let (state, name) = state_with_chunks(&["a:1:1", "b:1:1", "c:1:1", "d:1:1", "e:1:1"]).await;
+
+    let mut seen: Vec<String> = Vec::new();
+    // Start cursor paging with an empty `after` ("from the first chunk").
+    let mut after: Option<String> = Some(String::new());
+    let mut pages = 0;
+    loop {
+        let body = call_chunks(
+            &state,
+            &name,
+            ChunksParams {
+                offset: 0,
+                limit: 2,
+                after: after.clone(),
+            },
+        )
+        .await;
+        assert_eq!(body["total"], 5);
+        for c in body["chunks"].as_array().unwrap() {
+            seen.push(c["id"].as_str().unwrap().to_string());
+        }
+        pages += 1;
+        match body["next_cursor"].as_str() {
+            Some(c) => after = Some(c.to_string()),
+            None => break,
+        }
+        assert!(pages < 10, "must terminate");
+    }
+    assert_eq!(seen, vec!["a:1:1", "b:1:1", "c:1:1", "d:1:1", "e:1:1"]);
+}
+
+/// Offset mode (back-compat): the legacy `offset`/`limit` slice still works
+/// unchanged, total is preserved, and `next_cursor` is always null (offset
+/// order differs from cursor order, so it must not seed a cursor walk).
+#[tokio::test]
+async fn chunks_endpoint_offset_back_compat() {
+    let (state, name) = state_with_chunks(&["a:1:1", "b:1:1", "c:1:1"]).await;
+
+    let p1 = call_chunks(
+        &state,
+        &name,
+        ChunksParams {
+            offset: 0,
+            limit: 2,
+            after: None,
+        },
+    )
+    .await;
+    assert_eq!(p1["total"], 3);
+    assert_eq!(p1["offset"], 0);
+    assert_eq!(p1["chunks"].as_array().unwrap().len(), 2);
+    assert!(
+        p1["next_cursor"].is_null(),
+        "offset mode never surfaces a cursor (different ordering)"
+    );
+
+    // Second offset page covers the remainder.
+    let p2 = call_chunks(
+        &state,
+        &name,
+        ChunksParams {
+            offset: 2,
+            limit: 2,
+            after: None,
+        },
+    )
+    .await;
+    assert_eq!(p2["chunks"].as_array().unwrap().len(), 1);
+    assert!(p2["next_cursor"].is_null());
+}
+
+/// An unknown index id is a 404, in both modes.
+#[tokio::test]
+async fn chunks_endpoint_unknown_index_is_404() {
+    let (state, _name) = state_with_chunks(&["a:1:1"]).await;
+    let err = get_index_chunks_handler(
+        State(state),
+        Path("does-not-exist".to_string()),
+        Query(ChunksParams {
+            offset: 0,
+            limit: 10,
+            after: Some("a:1:1".to_string()),
+        }),
+    )
+    .await
+    .expect_err("unknown index must 404");
+    assert_eq!(err, axum::http::StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Implements #1325. `GET /indexes/{id}/chunks?offset=304000` was timing out → 502 (~120s) on large indexes.

Root cause: the offset path was O(N log N) per page — it rehydrated the entire corpus from redb and re-sorted all chunks on every page request.

Fix (structural): cursor-based pagination using the redb `CHUNKS_TABLE` B-tree (ordered by chunk id), O(log N) + O(page):
- New opt-in, non-breaking query param `after` (opaque cursor = chunk id) + response field `next_cursor` (null when exhausted).
- Legacy `offset`/`limit` retained verbatim (its `next_cursor` is always null; the two orderings differ, so don't seed a cursor walk from an offset page).
- `CorpusStore::chunks_after`, `CodeIndexer::enumerate_chunks_after`, matching `after` arg on the `list_chunks` MCP tool.
- Timeout relief: each cursor page is O(page) regardless of depth, so the 502s stop; route left on the unbounded bulk lane (no 30s interactive cutoff for legitimate large pages).

Version: trusty-search 0.24.7 → 0.24.9 (0.24.8 was taken by #1326; reconciled against main — CHANGELOG has both 0.24.8 and 0.24.9 sections).

Verification: `cargo build -p trusty-search` green; `cargo test -p trusty-search` 903 passed/0 failed (+ new cursor/offset/404 tests); clippy -D warnings clean; fmt clean; line-cap exit 0.

Closes #1325.