### PR TITLE
chore(release): fix trusty-mpm console-metrics build break + bump mpm 0.9.0 + trusty-memory repository (release prep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10947,7 +10947,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tga = { path = "crates/trusty-git-analytics", version = "2.8.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
-trusty-mpm = { path = "crates/trusty-mpm", version = "0.8.2" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "0.9.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.15.5"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true
+repository.workspace = true
 readme = "README.md"
 
 exclude = [".fastembed_cache/", "ui/node_modules/**"]
@@ -79,7 +80,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.15.1", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics"] }
+trusty-common = { path = "../trusty-common", version = "0.15.3", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — trusty-mpm
 
+## [0.9.0] — 2026-06-16
+
+### Release
+
+- **First monorepo publish.** This is the first `trusty-mpm` release published
+  from the unified `trusty-tools` workspace. It supersedes the stale `0.8.1`
+  on crates.io, which was published from the now-archived standalone repo.
+
+### Fixed
+
+- **Standalone build break:** `daemon/mcp_console.rs` imports
+  `trusty_common::console_metrics` unconditionally, but that module is gated
+  behind trusty-common's `console-metrics` feature. trusty-mpm's main
+  `trusty-common` dependency now enables `console-metrics`, so
+  `cargo check -p trusty-mpm` and `cargo publish` no longer fail to resolve
+  the module. (Workspace feature-unification previously masked this under
+  `cargo test`.)
+
 ## [0.8.2] — 2026-06-16
 
 ### Changed (closes part of #1318)

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.8.2"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -118,8 +118,12 @@ trusty-common = { workspace = true, features = [
     "cli-help",
     "bug-capture",
     "crate-config",
+    "console-metrics",
 ] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
+# `console-metrics` enables `trusty_common::console_metrics` (used unconditionally by
+# `daemon/mcp_console.rs`). Without it, `cargo check -p trusty-mpm` and `cargo publish`
+# fail to resolve the module — workspace feature-unification masks this under `cargo test`.
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console is
 # no longer bundled into trusty-mpm (single-owner-per-binary); the standalone
 # `trusty-console` crate is its sole producer.


### PR DESCRIPTION
Release-prep fixes the blockers the publish dry-run surfaced for the full-platform crates.io campaign (#1322).

- **trusty-mpm standalone build break (BLOCKER) fixed**: `daemon/mcp_console.rs` imports `trusty_common::console_metrics` unconditionally, but the feature wasn't enabled on trusty-mpm's main trusty-common dependency (workspace feature-unification hid it under `cargo test`; `cargo publish`/`cargo check -p` exposed it). Added `"console-metrics"` to the features list. Proven: `cargo publish -p trusty-mpm --dry-run` now gets past packaging/compile (only fails on the expected unpublished trusty-common 0.15.3 dep, which the campaign publishes first); `cargo check -p trusty-mpm` green.
- **trusty-mpm 0.8.2 → 0.9.0**: first monorepo publish, supersedes the stale archived-repo 0.8.1 on crates.io. publish=true (default) intact. CHANGELOG [0.9.0] added.
- **trusty-memory**: added `repository.workspace = true` (clears the cargo packaging warning). Version unchanged (0.15.5).
- trusty-memory's explicit trusty-common pin 0.15.1 → 0.15.3 (hygiene). trusty-search manifest untouched.

Verification: `cargo check -p trusty-mpm` green; `SKIP_UI_BUILD=1 cargo build --workspace` green; `cargo test -p trusty-mpm` 1265+316+... all pass; clippy -D warnings clean; fmt clean; line-cap exit 0.

Refs #1322. Enables the publish campaign (common 0.15.3 → … → mpm 0.9.0).