### PR TITLE
fix(tga): backfill ai-detection also repairs agentic_mode for historical commits (closes #1334)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9694,7 +9694,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to trusty-git-analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2026-06-16
+
+### Fixed
+
+- **`tga backfill ai-detection-commits` now also repairs `agentic_mode` (#1334)**
+  — the repair path previously updated only `is_ai_assisted` and `ai_tool`,
+  leaving historical commits' `agentic_mode` stuck at its `'none'` default. As a
+  result, Claude Code commits backfilled after migration v21 were never
+  queryable as `agentic_mode = 'full_agentic'`, and downstream consumers
+  (e.g. cto-reports' agentic-% analytics) under-counted agentic activity. The
+  backfill now recomputes `agentic_mode` via the same `detect_agentic_mode()`
+  logic used by the forward `tga collect` INSERT path and writes it alongside
+  `is_ai_assisted` / `ai_tool`. **Operators should re-run
+  `tga backfill ai-detection-commits` to repair existing history.**
+
 ## [2.7.1] - 2026-06-07
 
 ### Changed

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.8.0"
+version = "2.8.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.91) per #254. Required for

--- a/crates/trusty-git-analytics/src/commands/backfill/flags.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/flags.rs
@@ -6,7 +6,7 @@
 //! makes the shared `build_commits_filter_sql` helper easy to find.
 
 use rusqlite::params;
-use tga::collect::ai_attribution::detect_ai_tool;
+use tga::collect::ai_attribution::{detect_agentic_mode, detect_ai_tool};
 use tga::collect::ticket::{extract_ticket_id, is_ticketed};
 use tga::core::db::Database;
 
@@ -337,14 +337,21 @@ pub(super) fn backfill_ai_detection(db: &mut Database, dry_run: bool) -> anyhow:
 
 /// Scan existing `commits.message` for AI co-authorship trailers.
 ///
-/// Why: `is_ai_assisted` and `ai_tool` columns were added in migration v17;
-/// existing rows have `is_ai_assisted = 0` and `ai_tool = NULL` regardless of
-/// their actual history. This backfill retroactively detects Claude,
-/// GitHub Copilot, and Cursor via `Co-Authored-By:` trailers.
+/// Why: `is_ai_assisted` and `ai_tool` columns were added in migration v17 and
+/// the canonical `agentic_mode` column in v21 (issue #1113); existing rows have
+/// `is_ai_assisted = 0`, `ai_tool = NULL`, and `agentic_mode = 'none'`
+/// regardless of their actual history. Before issue #1334 this repair path only
+/// rewrote `is_ai_assisted` / `ai_tool`, leaving historical `agentic_mode` stuck
+/// at `'none'` — so downstream consumers querying `agentic_mode = 'full_agentic'`
+/// missed every backfilled Claude Code commit. This backfill now retroactively
+/// detects Claude, GitHub Copilot, and Cursor via `Co-Authored-By:` trailers AND
+/// recomputes `agentic_mode`, exactly as the forward `tga collect` path does.
 /// What: loads every commit (filtered by repos/since/until), runs
-/// [`detect_ai_tool`] on the message, and updates rows where `ai_tool`
-/// differs from the stored value. No LLM required — pure string matching.
-/// Test: `tests::backfill_ai_detection_commits_detects_claude`.
+/// [`detect_ai_tool`] and [`detect_agentic_mode`] on the message, and updates
+/// rows where `ai_tool` OR `agentic_mode` differs from the stored value. No LLM
+/// required — pure string matching, identical to the extractor's INSERT path.
+/// Test: `tests::backfill_ai_detection_commits_detects_claude` (ai_tool) and
+/// `tests::backfill_ai_detection_commits_repairs_agentic_mode` (agentic_mode).
 ///
 /// # Errors
 ///
@@ -356,37 +363,44 @@ pub(super) fn backfill_ai_detection_commits(
     since: Option<&str>,
     until: Option<&str>,
 ) -> anyhow::Result<()> {
-    let mut to_update: Vec<(i64, i64, Option<&'static str>)> = Vec::new();
+    // (id, is_ai, ai_tool, agentic_mode) — agentic_mode is the forward-path
+    // string ("none" | "ide_assisted" | "full_agentic") via `AgenticMode::as_str`.
+    let mut to_update: Vec<(i64, i64, Option<&'static str>, &'static str)> = Vec::new();
     {
         let conn = db.connection();
         let (sql, params) = build_commits_filter_sql(
-            "SELECT id, message, ai_tool FROM commits",
+            "SELECT id, message, ai_tool, agentic_mode FROM commits",
             repos_filter,
             since,
             until,
         );
         let mut stmt = conn.prepare(&sql)?;
-        let rows: Vec<(i64, String, Option<String>)> = stmt
+        let rows: Vec<(i64, String, Option<String>, String)> = stmt
             .query_map(rusqlite::params_from_iter(params.iter()), |row| {
                 Ok((
                     row.get::<_, i64>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, Option<String>>(2)?,
+                    // Pre-v21 rows default to 'none'; COALESCE guards any NULLs.
+                    row.get::<_, Option<String>>(3)?
+                        .unwrap_or_else(|| "none".to_string()),
                 ))
             })?
             .collect::<Result<_, _>>()?;
 
-        for (id, message, current_tool) in rows {
+        for (id, message, current_tool, current_mode) in rows {
             let detected = detect_ai_tool(&message);
-            let current_str = current_tool.as_deref();
-            if detected != current_str {
+            let mode = detect_agentic_mode(&message).as_str();
+            let tool_changed = detected != current_tool.as_deref();
+            let mode_changed = mode != current_mode;
+            if tool_changed || mode_changed {
                 let is_ai = if detected.is_some() { 1_i64 } else { 0_i64 };
-                to_update.push((id, is_ai, detected));
+                to_update.push((id, is_ai, detected, mode));
             }
         }
     }
 
-    let with_tool = to_update.iter().filter(|(_, _, t)| t.is_some()).count();
+    let with_tool = to_update.iter().filter(|(_, _, t, _)| t.is_some()).count();
 
     if dry_run {
         println!(
@@ -400,10 +414,12 @@ pub(super) fn backfill_ai_detection_commits(
     let conn = db.connection_mut();
     let tx = conn.transaction()?;
     {
-        let mut up =
-            tx.prepare("UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2 WHERE id = ?3")?;
-        for (id, is_ai, tool) in &to_update {
-            up.execute(params![is_ai, tool, id])?;
+        let mut up = tx.prepare(
+            "UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2, agentic_mode = ?3 \
+             WHERE id = ?4",
+        )?;
+        for (id, is_ai, tool, mode) in &to_update {
+            up.execute(params![is_ai, tool, mode, id])?;
         }
     }
     tx.commit()?;

--- a/crates/trusty-git-analytics/src/commands/backfill/tests.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/tests.rs
@@ -790,6 +790,84 @@ fn backfill_ai_detection_commits_detects_claude() {
     assert!(human_tool.is_none(), "human commit must have ai_tool=NULL");
 }
 
+/// Why: issue #1334 — the repair path left historical `agentic_mode` stuck at
+/// its `'none'` default, so a Claude-co-authored commit backfilled after
+/// migration v21 never became queryable as `agentic_mode = 'full_agentic'`.
+/// What: seeds a Claude-trailer commit (defaulting to `agentic_mode = 'none'`),
+/// a Cursor-trailer commit, and a plain human commit; runs the backfill; asserts
+/// the Claude commit is now `'full_agentic'`, the Cursor commit `'ide_assisted'`,
+/// and the human commit remains `'none'` — matching the forward `tga collect`
+/// path.
+/// Test: this test itself.
+#[test]
+fn backfill_ai_detection_commits_repairs_agentic_mode() {
+    let mut db = Database::open_in_memory().expect("open");
+
+    // Claude Code commit — must become full_agentic (the #1334 regression).
+    let claude_msg = "feat: add auth\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>";
+    seed(&db, "claude1", claude_msg);
+    // Cursor IDE commit — must become ide_assisted.
+    let cursor_msg = "fix: npe\n\nCo-Authored-By: Cursor <noreply@cursor.sh>";
+    seed(&db, "cursor1", cursor_msg);
+    // Human-only commit — must remain none.
+    seed(&db, "human1", "chore: bump dep");
+
+    // Sanity: all rows start at the migration default 'none' before the repair.
+    let pre: String = db
+        .connection()
+        .query_row(
+            "SELECT agentic_mode FROM commits WHERE sha = 'claude1'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read pre claude1");
+    assert_eq!(
+        pre, "none",
+        "pre-backfill agentic_mode must default to 'none'"
+    );
+
+    backfill_ai_detection_commits(&mut db, false, &[], None, None).expect("backfill ai-detection");
+
+    let claude_mode: String = db
+        .connection()
+        .query_row(
+            "SELECT agentic_mode FROM commits WHERE sha = 'claude1'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read claude1 mode");
+    assert_eq!(
+        claude_mode, "full_agentic",
+        "Claude commit must be repaired to agentic_mode='full_agentic' (#1334)"
+    );
+
+    let cursor_mode: String = db
+        .connection()
+        .query_row(
+            "SELECT agentic_mode FROM commits WHERE sha = 'cursor1'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read cursor1 mode");
+    assert_eq!(
+        cursor_mode, "ide_assisted",
+        "Cursor commit must be repaired to agentic_mode='ide_assisted'"
+    );
+
+    let human_mode: String = db
+        .connection()
+        .query_row(
+            "SELECT agentic_mode FROM commits WHERE sha = 'human1'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read human1 mode");
+    assert_eq!(
+        human_mode, "none",
+        "human commit must remain agentic_mode='none'"
+    );
+}
+
 /// Why: `backfill_top_level` must fill `top_level_category` for existing
 /// classifications where it is NULL, using the built-in taxonomy.
 /// What: seeds a classification with subcategory='bugfix' and


### PR DESCRIPTION
## Summary

Fixes #1334. `tga backfill ai-detection-commits` repaired only `is_ai_assisted` and `ai_tool`, leaving each historical commit's `agentic_mode` column stuck at its migration-v21 default of `'none'`. As a result, commits processed by the backfill never became queryable as `agentic_mode = 'full_agentic'`, even with a `Co-Authored-By: Claude` trailer present.

The forward `tga collect` INSERT path was already correct (`detect_agentic_mode(&message).as_str()`); only the backfill repair path was wrong. This PR makes the backfill recompute `agentic_mode` from the same detection helper.

## Before / After

`backfill_ai_detection_commits()` UPDATE:

```diff
-UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2 WHERE id = ?3
+UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2, agentic_mode = ?3 WHERE id = ?4
```

- **Before:** a backfilled `Co-Authored-By: Claude` commit → `is_ai_assisted=1`, `ai_tool='claude'`, **`agentic_mode='none'`** (wrong).
- **After:** same commit → `is_ai_assisted=1`, `ai_tool='claude'`, **`agentic_mode='full_agentic'`** (matches the forward `tga collect` path).

The row scan now also fetches the stored `agentic_mode` and triggers an update when **either** `ai_tool` OR `agentic_mode` differs, so rows whose `ai_tool` already matched but whose `agentic_mode` was wrong are still repaired. `agentic_mode` is computed via the existing `detect_agentic_mode()` helper — no logic is duplicated, and `detect_agentic_mode()` itself is unchanged.

## Downstream impact

Consumers that compute agentic-% analytics off `agentic_mode = 'full_agentic'` (e.g. cto-reports) under-counted agentic activity across all backfilled history. **After this lands, operators should re-run `tga backfill ai-detection-commits` to repair existing rows.**

## Test

Adds `backfill_ai_detection_commits_repairs_agentic_mode`: seeds a Claude-trailer, a Cursor-trailer, and a plain human commit (all defaulting to `agentic_mode = 'none'`), runs the backfill, and asserts they become `'full_agentic'`, `'ide_assisted'`, and remain `'none'` respectively. Verified the test **fails** against the pre-fix UPDATE (`left: "none"`, `right: "full_agentic"`) and passes with the fix.

- `cargo test -p tga` — 112 unit + 2 integration + 5 doctests pass
- `cargo clippy -p tga --all-targets -- -D warnings` — no code warnings
- `cargo fmt -p tga --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations

## Version

Bumps `tga` 2.8.0 → 2.8.1 (patch) + CHANGELOG entry. Not yet published to crates.io — publishing happens after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)