### PR TITLE
fix(trusty-controller): tctl Phase-1 review nits + wire trusty-controller into release allowlist (#1332)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,22 @@ jobs:
             AL2023_NO_DEFAULT="false"
             AL2023_FEATURES=""
 
+          elif [[ "$CRATE" == "trusty-controller" ]]; then
+            # Binaries: tctl
+            # Single [[bin]] `tctl` at src/main.rs confirmed in trusty-controller/Cargo.toml;
+            # no required-features on the bin target (edition 2021).
+            # No UI embedding, no ORT: no SKIP_UI_BUILD, no AL2023 variant.
+            # (#1316 / #1332): wired into the allowlist so tctl tags build + release
+            # instead of green-skipping as a library-only crate.
+            CARGO_PKG="trusty-controller"
+            BINARIES="tctl"
+            SKIP_UI_BUILD="false"
+            CARGO_FEATURES=""
+            NO_DEFAULT_FEATURES="false"
+            AL2023_VARIANT="false"
+            AL2023_NO_DEFAULT="false"
+            AL2023_FEATURES=""
+
           elif [[ "$CRATE" == "trusty-console" ]]; then
             # Binaries: trusty-console
             # As of #1318 (single-owner-per-binary) the standalone trusty-console
@@ -305,15 +321,14 @@ jobs:
           # CAVEAT — adding a NEW binary crate: because the default is skip, a brand
           # new *binary*-producing crate will ALSO green-skip until you add an
           # explicit config branch for it above. That is intentional (fail-safe, not
-          # fail-loud), but it means a missing binary release is silent. Known gap:
-          # `trusty-controller` (bin `tctl`, added in #1316) is a real binary crate
-          # that does NOT yet have a config branch above, so its tags currently
-          # green-skip. Wire it into the allowlist before relying on tctl releases.
+          # fail-loud), but it means a missing binary release is silent. (The former
+          # `trusty-controller` / bin `tctl` gap from #1316 was closed in #1332 — it
+          # now has a config branch above and builds + releases normally.)
           else
             echo "::notice title=Library-only crate — release skipped::Crate '$CRATE' is not in the binary-release allowlist; treating it as library-only and skipping the binary release gracefully (green, not an error)."
             echo "Binary-producing crates (built + released): trusty-search, trusty-memory,"
             echo "  trusty-analyze, trusty-review, trusty-mpm, trusty-git-analytics (tga),"
-            echo "  trusty-code, trusty-console."
+            echo "  trusty-code, trusty-console, trusty-controller (tctl)."
             echo "Library-only / internal crates (green-skip, no standalone binary):"
             echo "  trusty-common, trusty-bm25-daemon, trusty-embedderd, trusty-progress,"
             echo "  trusty-agents*, trusty-mpm-gui, tc-services, cto-assistant,"
@@ -941,6 +956,7 @@ jobs:
             trusty-console)  INSTALL_BINS="trusty-console" ;;
             trusty-git-analytics) INSTALL_BINS="tga" ;;
             trusty-code)     INSTALL_BINS="tcode" ;;
+            trusty-controller) INSTALL_BINS="tctl" ;;
             *)               INSTALL_BINS="${CRATE}" ;;
           esac
 

--- a/crates/trusty-controller/src/commands/install.rs
+++ b/crates/trusty-controller/src/commands/install.rs
@@ -219,12 +219,25 @@ fn binary_size(binary: &str) -> u64 {
 ///
 /// Why: `cargo install` honours `CARGO_HOME`; hardcoding `~/.cargo/bin` would
 /// mis-resolve installed-binary sizes under a custom `CARGO_HOME` (e.g. CI).
-/// What: Returns `$CARGO_HOME/bin` when `CARGO_HOME` is set and non-empty,
-/// otherwise `~/.cargo/bin` (or `None` if the home dir cannot be resolved).
-/// Test: `tests::cargo_bin_dir_honours_cargo_home`.
+/// What: Reads `CARGO_HOME` from the process environment and delegates to the
+/// pure [`cargo_bin_dir_from_env`] (which holds the testable resolution rule).
+/// Test: `cargo_bin_dir_from_env` is unit-tested directly in
+/// `tests::cargo_bin_dir_from_env_*`; this wrapper is the side-effecting shell.
 fn cargo_bin_dir() -> Option<std::path::PathBuf> {
-    match std::env::var("CARGO_HOME") {
-        Ok(home) if !home.is_empty() => Some(std::path::PathBuf::from(home).join("bin")),
+    cargo_bin_dir_from_env(std::env::var("CARGO_HOME").ok().as_deref())
+}
+
+/// Pure resolution of the cargo bin directory from a `CARGO_HOME` value.
+///
+/// Why: Extracting the rule from the env read makes it testable WITHOUT mutating
+/// the process-global environment, so the test is safe under parallel execution.
+/// What: Returns `<cargo_home>/bin` when `cargo_home` is `Some` and non-empty,
+/// otherwise `~/.cargo/bin` (or `None` when the home dir cannot be resolved).
+/// Test: `tests::cargo_bin_dir_from_env_honours_value`,
+/// `tests::cargo_bin_dir_from_env_falls_back`.
+fn cargo_bin_dir_from_env(cargo_home: Option<&str>) -> Option<std::path::PathBuf> {
+    match cargo_home {
+        Some(home) if !home.is_empty() => Some(std::path::PathBuf::from(home).join("bin")),
         _ => dirs::home_dir().map(|h| h.join(".cargo").join("bin")),
     }
 }
@@ -304,35 +317,28 @@ mod tests {
     }
 
     /// Why: Re-review fix — `binary_size` must resolve under a non-default
-    /// `CARGO_HOME` (CI installs there), so `cargo_bin_dir` must honour the env
-    /// var rather than hardcoding `~/.cargo/bin`.
-    /// What: Sets `CARGO_HOME` to a temp path, asserts `cargo_bin_dir` returns
-    /// `<that>/bin`; clears it and asserts the fallback ends in `.cargo/bin`.
-    /// Restores the prior value so the process-global env is left untouched.
+    /// `CARGO_HOME` (CI installs there). The rule lives in the pure
+    /// `cargo_bin_dir_from_env`, exercised here WITHOUT mutating the process
+    /// environment so the test is safe to run in parallel with any other test.
+    /// What: A non-empty value yields `<that>/bin`.
     /// Test: This is the test.
     #[test]
-    fn cargo_bin_dir_honours_cargo_home() {
-        let prior = std::env::var_os("CARGO_HOME");
-
-        // This test is the sole mutator of CARGO_HOME and restores it before
-        // returning; the controller crate runs no other env-racing tests.
-        std::env::set_var("CARGO_HOME", "/tmp/fake-cargo-home");
+    fn cargo_bin_dir_from_env_honours_value() {
         assert_eq!(
-            cargo_bin_dir(),
+            cargo_bin_dir_from_env(Some("/tmp/fake-cargo-home")),
             Some(std::path::PathBuf::from("/tmp/fake-cargo-home").join("bin"))
         );
+    }
 
-        // Empty CARGO_HOME falls back to ~/.cargo/bin.
-        std::env::set_var("CARGO_HOME", "");
-        let fallback = cargo_bin_dir();
-        if let Some(p) = &fallback {
-            assert!(p.ends_with(std::path::Path::new(".cargo").join("bin")));
-        }
-
-        // Restore the prior environment.
-        match prior {
-            Some(v) => std::env::set_var("CARGO_HOME", v),
-            None => std::env::remove_var("CARGO_HOME"),
+    /// Why: An empty or absent `CARGO_HOME` must fall back to `~/.cargo/bin`.
+    /// What: Both `Some("")` and `None` resolve to a path ending in `.cargo/bin`.
+    /// Test: This is the test.
+    #[test]
+    fn cargo_bin_dir_from_env_falls_back() {
+        for value in [Some(""), None] {
+            if let Some(p) = cargo_bin_dir_from_env(value) {
+                assert!(p.ends_with(std::path::Path::new(".cargo").join("bin")));
+            }
         }
     }
 

--- a/crates/trusty-controller/src/commands/ui.rs
+++ b/crates/trusty-controller/src/commands/ui.rs
@@ -173,10 +173,12 @@ fn spawn_detached_console() -> std::io::Result<()> {
         // affects the calling (child) process between fork and exec.
         unsafe {
             cmd.pre_exec(|| {
-                // Detach from the parent's process group/session. A non-fatal
-                // failure (already a session leader) is ignored — the redirected
-                // std streams alone still prevent terminal coupling.
-                libc::setsid();
+                // Detach from the parent's process group/session. The return
+                // value is deliberately discarded: the only documented failure
+                // is `EPERM` when the caller is already a session/process-group
+                // leader, which is benign here — the redirected std streams alone
+                // still prevent terminal coupling, so there is nothing to recover.
+                let _ = libc::setsid();
                 Ok(())
             });
         }
@@ -185,6 +187,10 @@ fn spawn_detached_console() -> std::io::Result<()> {
     let child = cmd.spawn()?;
     // Intentional detach: the console outlives `tctl`. We never wait on it, so we
     // forget the handle rather than let `Drop` (which does not reap) run.
+    // Trade-off vs `drop(child)`: `Child::drop` does NOT kill or reap the child
+    // either, so behaviourally the two are equivalent here — but `forget` signals
+    // the intent ("we are deliberately abandoning a daemon we do not own") so a
+    // future reader does not mistake a dropped handle for an oversight.
     std::mem::forget(child);
     Ok(())
 }

--- a/crates/trusty-controller/src/commands/update_engine.rs
+++ b/crates/trusty-controller/src/commands/update_engine.rs
@@ -46,6 +46,8 @@ pub struct UpdateCandidate {
     pub latest: String,
     /// Whether this member is a supervised daemon (drives restart-on-upgrade).
     pub daemon: bool,
+    /// true when the binary is absent — install-candidate vs upgrade-candidate.
+    pub is_install: bool,
 }
 
 /// The outcome of the confirm-then-apply gate.
@@ -157,12 +159,18 @@ pub fn installed_version(binary: &str) -> Option<String> {
 /// isolating the token extraction makes it unit-testable without a subprocess.
 ///
 /// What: Returns the first whitespace-delimited token that contains a `.` and a
-/// leading digit, stripping a leading `v`. Returns `None` when no token matches.
+/// leading digit, stripping a leading `v` and any trailing non-alphanumeric
+/// punctuation (e.g. a trailing comma or period). Returns `None` when no token
+/// matches.
 ///
 /// Test: `tests::extract_version_from_line`.
 pub fn extract_version_from_line(line: &str) -> Option<String> {
     line.split_whitespace()
         .map(|t| t.trim_start_matches('v'))
+        // Strip trailing non-alphanumeric punctuation so `tctl 1.2.3,` and
+        // `tctl 1.2.3.` both yield `1.2.3`. A pre-release token like `1.2.3-rc1`
+        // ends in an alphanumeric, so nothing is trimmed from it.
+        .map(|t| t.trim_end_matches(|c: char| !c.is_ascii_alphanumeric()))
         .find(|t| t.contains('.') && t.chars().next().is_some_and(|c| c.is_ascii_digit()))
         .map(|t| t.to_owned())
 }
@@ -190,6 +198,7 @@ pub async fn gather_candidates(members: &[StableMember]) -> Vec<UpdateCandidate>
             candidates.push(UpdateCandidate {
                 crate_name: m.crate_name.clone(),
                 binary: m.binary.clone(),
+                is_install: installed.is_none(),
                 installed,
                 latest: info.latest,
                 daemon: m.daemon,
@@ -291,6 +300,15 @@ mod tests {
         assert_eq!(
             super::extract_version_from_line("mytool v2.8.0"),
             Some("2.8.0".to_owned())
+        );
+        // Trailing punctuation (comma, period) is stripped.
+        assert_eq!(
+            super::extract_version_from_line("tctl 1.2.3,"),
+            Some("1.2.3".to_owned())
+        );
+        assert_eq!(
+            super::extract_version_from_line("tctl 1.2.3."),
+            Some("1.2.3".to_owned())
         );
         assert_eq!(super::extract_version_from_line("no version here"), None);
     }

--- a/crates/trusty-controller/src/commands/updates.rs
+++ b/crates/trusty-controller/src/commands/updates.rs
@@ -125,6 +125,7 @@ mod tests {
             installed: Some("0.19.0".to_owned()),
             latest: "0.20.0".to_owned(),
             daemon: true,
+            is_install: false,
         }]);
         let v = serde_json::to_value(&report).expect("serialises");
         assert_eq!(v["command"], "updates");

--- a/crates/trusty-controller/src/commands/upgrade.rs
+++ b/crates/trusty-controller/src/commands/upgrade.rs
@@ -363,6 +363,7 @@ mod tests {
             installed: Some("0.19.0".to_owned()),
             latest: "0.20.0".to_owned(),
             daemon: true,
+            is_install: false,
         }
     }
 

--- a/crates/trusty-progress/src/progress.rs
+++ b/crates/trusty-progress/src/progress.rs
@@ -41,12 +41,13 @@ impl ProgressHandle {
     pub fn spinner(output: &Output, message: impl Into<String>) -> Self {
         let bar = ProgressBar::new_spinner();
         bar.set_draw_target(output.draw_target());
-        // `ProgressStyle::with_template` only fails on a malformed template, and
-        // `SPINNER_TEMPLATE` is a compile-time `const` literal we control — a
-        // parse failure here is a programmer error (a bad edit to the constant),
-        // never a runtime condition, so `expect` is the correct response: it
-        // surfaces the mistake loudly in dev/test rather than silently rendering
-        // an unstyled spinner. This is the one sanctioned `expect` in the crate.
+        // SAFETY: const template string, validated at construction; runtime
+        // failure is impossible. `ProgressStyle::with_template` only fails on a
+        // malformed template, and `SPINNER_TEMPLATE` is a compile-time `const`
+        // literal we control — a parse failure here is a programmer error (a bad
+        // edit to the constant), never a runtime condition, so `expect` is the
+        // correct response: it surfaces the mistake loudly in dev/test rather than
+        // silently rendering an unstyled spinner. This is a sanctioned `expect`.
         let style = ProgressStyle::with_template(SPINNER_TEMPLATE).expect("const template valid");
         bar.set_style(style);
         bar.set_message(message.into());
@@ -62,8 +63,10 @@ impl ProgressHandle {
     pub fn bar(output: &Output, total: u64, message: impl Into<String>) -> Self {
         let bar = ProgressBar::new(total);
         bar.set_draw_target(output.draw_target());
-        // See `spinner` above: `BAR_TEMPLATE` is a `const` literal, so a parse
-        // failure is a programmer error and `expect` is the correct response.
+        // SAFETY: const template string, validated at construction; runtime
+        // failure is impossible. See `spinner` above: `BAR_TEMPLATE` is a `const`
+        // literal, so a parse failure is a programmer error and `expect` is the
+        // correct response.
         let style = ProgressStyle::with_template(BAR_TEMPLATE).expect("const template valid");
         bar.set_style(style);
         bar.set_message(message.into());


### PR DESCRIPTION
Mechanical/advisory follow-ups from the #1316 tctl Phase-1 review (the no-design-decisions track). The deferred Phase-2 verbs (ensure/start/stop/restart/stack/doctor/config/port) are explicitly **out of scope** here.

Closes the review nits in #1332 and wires `trusty-controller` into the release allowlist.

## The 5 nits

1. **`ui.rs` — `setsid` return + `mem::forget` intent.** The discarded `libc::setsid()` is now `let _ = libc::setsid();` with a comment noting the only documented failure (`EPERM`, already a session/group leader) is benign. Added a comment on `std::mem::forget(child)` documenting the trade-off vs `drop(child)` — neither reaps, but `forget` signals deliberate abandonment of a daemon `tctl` does not own. No behavioural change.

2. **`install.rs` — `CARGO_HOME` test parallel-safety.** Extracted a pure `cargo_bin_dir_from_env(Option<&str>) -> Option<PathBuf>`; `cargo_bin_dir()` now calls it with `std::env::var("CARGO_HOME").ok()`. The test exercises `Some("/tmp/fake-cargo-home")`, `Some("")`, and `None` with **no** `set_var`/`remove_var` — safe under parallel execution. Behaviour preserved exactly.

3. **`update_engine.rs` — `extract_version_from_line` trailing punctuation.** Added `.trim_end_matches(|c: char| !c.is_ascii_alphanumeric())` so `"tctl 1.2.3,"` and `"tctl 1.2.3."` both yield `Some("1.2.3")`. Pre-release tokens (`1.2.3-rc1`) end alphanumeric, so they're untouched. Added unit tests for the trailing comma and period.

4. **`update_engine.rs` — `is_install` flag.** Added `pub is_install: bool` to `UpdateCandidate` ("true when the binary is absent — install-candidate vs upgrade-candidate"), set from `installed.is_none()` in `gather_candidates`. Updated the `upgrade.rs` `candidate()` fixture and the `updates.rs` test literal. The field flows into the existing `UpdatesReport`/`UpgradeReport` JSON via serde (no mirror struct to update).

5. **`trusty-progress/progress.rs` — const-template `expect`.** Documented both `ProgressStyle::with_template(...).expect(...)` calls with a `// SAFETY: const template string, validated at construction; runtime failure is impossible` marker. **Chosen resolution: the comment, not a runtime fallback** — the templates (`SPINNER_TEMPLATE`, `BAR_TEMPLATE`) are genuine compile-time `const` literals, not runtime-derived, so a parse failure is strictly a programmer error and `expect` is correct. No behavioural complexity added.

## release.yml allowlist
Added a `trusty-controller` config branch (bin-only `tctl`, **no** UI embedding, **no** ORT, edition 2021) mirroring the simplest existing binary crate so tctl tags build + release instead of green-skipping as library-only. Also: added `trusty-controller) INSTALL_BINS="tctl"` to the homebrew map, added `trusty-controller (tctl)` to the distributable-crates help message, and retired the now-resolved "known gap" caveat. YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

## Verification
- `cargo test -p trusty-controller`: 145 passed, 0 failed (incl. the 3 new/changed tests).
- `cargo test -p trusty-progress`: 23 passed, 0 failed.
- `cargo clippy -p trusty-controller -p trusty-progress --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `bash scripts/check_line_cap.sh`: 15 allowlisted, 0 violations.
- release.yml YAML: parses OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)