### PR TITLE
chore(release): publish trusty-progress + bump trusty-controller to 0.2.0 (#1332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10837,7 +10837,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-controller"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-controller/Cargo.toml
+++ b/crates/trusty-controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-controller"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-progress/Cargo.toml
+++ b/crates/trusty-progress/Cargo.toml
@@ -7,9 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-# Not published yet (#1315): consumed first in-tree by trusty-controller's
-# Phase-1 install/upgrade flows. Flip `publish` once the API stabilises.
-publish = false
+# Published to crates.io as of #1332: required as a real registry dependency of
+# trusty-controller 0.2.0 (Phase-2 publish). The API has stabilised enough to
+# ship; the in-tree path dep still resolves locally via [workspace.dependencies].
 
 [dependencies]
 indicatif = { workspace = true }


### PR DESCRIPTION
Release-prep for the tctl Phase-2 crates.io publish (#1332).

## What
- Makes `trusty-progress` publishable (removes `publish = false`). It must exist on crates.io as a real registry dependency of `trusty-controller` — `cargo publish` resolves deps against crates.io, not the in-tree path table.
- Bumps `trusty-controller` 0.1.0 → 0.2.0. 0.1.0 is already published (immutable), so the merged Phase-2 verbs ship as a new minor.

## Why
Unblocks publishing `trusty-controller` 0.2.0 (the 8 Phase-2 verbs already merged in #1339), which in turn unblocks the curl|sh installer (#1330).

## Follow-up after merge
Publish `trusty-progress` 0.1.0, then `trusty-controller` 0.2.0, then tag `trusty-controller-v0.2.0` (release.yml allowlist branch is ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)