### PR TITLE
docs(install): document curl|sh installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,40 @@ documentation.
 
 ## Installation
 
-### With Homebrew (recommended for end users)
+### One-liner: `curl | sh` Bootstrap Installer
 
-The easiest way to install any trusty-* binary. First, add the tap:
+Install the full trusty-tools platform with one command (no Rust toolchain required):
+
+```bash
+curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh
+```
+
+This downloads the prebuilt `tctl` controller binary (SHA-256 verified), installs it to `~/.local/bin`, and runs `tctl install` to set up the rest of the platform (search, memory, analyze, review, console).
+
+**Non-interactive** (CI / scripted):
+```bash
+curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh -s -- -y
+```
+
+**Options** (environment variables):
+
+| Variable | Effect |
+|---|---|
+| `TRUSTY_VERSION` | Pin a specific version (e.g. `0.2.0`) |
+| `TRUSTY_INSTALL_DIR` | Override the install directory (default `~/.local/bin`) |
+| `TRUSTY_YES=1` | Skip all prompts (same as `-y`) |
+| `TRUSTY_FORCE=1` | Re-download even if already installed (same as `--force`) |
+| `TRUSTY_NO_MODIFY_PATH=1` | Don't modify your shell PATH |
+
+**Supported platforms:** macOS (Apple Silicon) and Linux (x86_64). For other platforms, build from source with `cargo install trusty-controller`.
+
+**Security:** The installer is served over HTTPS and every downloaded binary is SHA-256 verified against its published checksum. The installer script itself is not signed — review it before running if you require higher assurance: https://github.com/bobmatnyc/trusty-tools/blob/main/install.sh
+
+---
+
+### With Homebrew
+
+The easiest way to install individual trusty-* binaries via package manager. First, add the tap:
 
 ```bash
 brew tap bobmatnyc/trusty

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,21 @@
 # Security Policy
 
+## Installer trust model
+
+The `curl | sh` bootstrap installer (`install.sh`) follows the same trust model as rustup:
+
+- **Transport integrity:** the script and all assets are fetched over HTTPS only. The installer aborts on any non-HTTPS URL or HTTP error.
+- **Binary integrity:** every downloaded binary tarball is verified against its published `.sha256` checksum before installation. A checksum mismatch aborts the install.
+- **Installer integrity:** the `install.sh` script itself is **not** cryptographically signed. HTTPS is the only integrity guarantee for the script. If you require higher assurance, download and review the script before executing it:
+  ```bash
+  curl -sSfO https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh
+  less install.sh   # review
+  sh install.sh
+  ```
+- **Idempotent re-runs:** when a matching version is already installed, the installer skips re-download and therefore skips checksum re-verification of the existing binary. Run with `--force` (or `TRUSTY_FORCE=1`) to always re-download and re-verify.
+
+---
+
 ## Supported Versions
 
 We maintain security updates for recent releases. The exact version support matrix is maintained in the individual crate CHANGELOG files (located in `crates/*/CHANGELOG.md`).


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the `install.sh` bootstrap installer merged in #1330:

- **README.md**: New primary installation section with `curl | sh` one-liner, environment variable options, and platform support details
- **SECURITY.md**: New "Installer trust model" section documenting HTTPS transport integrity, binary SHA-256 verification, and idempotent re-run behavior

The installer is now the first recommended installation method (no Rust toolchain required), with Homebrew and source build options following as alternatives.

## Test plan

- [x] README renders correctly with new Installation section
- [x] Links to install.sh script are valid and point to main branch
- [x] SECURITY.md explains trust model clearly for users concerned about `curl | sh`
- [x] Environment variable table is accurate per the install.sh implementation
- [x] No markup or formatting errors

Follow-up to #1330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)