### PR TITLE
fix(trusty-review): 0.3.12 — retain High-effort findings in verdict floor regardless of confidence; document thresholds (refs #1343)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11023,7 +11023,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.9.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.3.11" }
+trusty-review = { path = "crates/trusty-review", version = "0.3.12" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.11"
+version     = "0.3.12"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -10,10 +10,14 @@
 //! The fix has these deterministic rules applied in `derive_verdict`:
 //!
 //! 0. SUBSTANTIVE-FINDING FILTER (#1343, applied first): findings that are
-//!    verifier-refuted (`Refuted` / `ErrorRefuted` / `TruncationRefuted`) OR carry
-//!    `confidence < 0.50` (`FLOOR_COUNT_MIN_CONFIDENCE`) are excluded from ALL
-//!    floor logic.  They are noise, never evidence — a `confidence:0.1` or refuted
-//!    finding must never harden the verdict.
+//!    verifier-refuted (`Refuted` / `ErrorRefuted` / `TruncationRefuted`) are always
+//!    excluded from ALL floor logic.  Otherwise a finding is excluded when it carries
+//!    `confidence < 0.50` (`FLOOR_COUNT_MIN_CONFIDENCE`) UNLESS it is `Effort::High`
+//!    — a non-refuted High-effort (critical/high severity) finding is retained even
+//!    at low confidence so it still drives the BLOCK floor (0.3.12 safety-net fix,
+//!    PR #1350).  A `confidence:0.1` Medium or a refuted finding is noise, never
+//!    evidence, and must never harden the verdict; an uncertain *critical* finding
+//!    keeps its place at the floor.
 //!
 //! 1. LOW-CONFIDENCE OVERRIDE: if ALL substantive findings have confidence
 //!    ≤ 0.65 AND none are `High`-effort, force APPROVE — overriding even a
@@ -85,7 +89,9 @@
 //! `approve_b_plus_survives_refuted_and_low_confidence_findings` (#1343),
 //! `approve_b_plus_two_high_conf_medium_caps_at_approve_star` (#1343),
 //! `model_request_changes_review_body_still_surfaces_request_changes` (#1343),
-//! `high_effort_finding_still_overrides_approve` (#1343).
+//! `high_effort_finding_still_overrides_approve` (#1343),
+//! `low_confidence_high_effort_finding_still_drives_floor` (PR #1350),
+//! `refuted_high_effort_finding_is_still_excluded` (PR #1350).
 
 use tracing::debug;
 
@@ -130,10 +136,18 @@ const FLOOR_MIN_CONFIDENCE: f32 = 0.80;
 /// driven by speculative findings carrying `confidence: 0.1` (and verifier-refuted
 /// findings, which are demoted to 0.10 by `VERIFY_REFUTED_CONFIDENCE`).  Such
 /// findings must never count toward any floor — they are noise, not evidence.
+/// The 0.50 value is the coin-flip line: below 0.50 a finding is more likely
+/// wrong than right, so it must not move the verdict floor.  (Contrast with
+/// `LOW_CONFIDENCE_THRESHOLD` = 0.65, the advisory-batch collapse line, and
+/// `FLOOR_MIN_CONFIDENCE` = 0.80, the Medium-counts-toward-the-floor line.)
 /// What: any finding with `confidence < FLOOR_COUNT_MIN_CONFIDENCE` is dropped
-/// from the severity-floor input set (alongside any verifier-refuted finding).
+/// from the severity-floor input set (alongside any verifier-refuted finding) —
+/// with ONE exception (0.3.12, PR #1350): a non-refuted `Effort::High` finding is
+/// retained even below 0.50, so an uncertain-but-critical concern keeps its safety
+/// net (see `is_substantive`).
 /// Test: `floor_excludes_refuted_and_low_confidence_findings`,
-/// `approve_b_plus_survives_refuted_and_low_confidence_findings`.
+/// `approve_b_plus_survives_refuted_and_low_confidence_findings`,
+/// `low_confidence_high_effort_finding_still_drives_floor`.
 const FLOOR_COUNT_MIN_CONFIDENCE: f32 = 0.50;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -211,6 +225,12 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
         );
         floor = Verdict::ApproveWithReservations;
     }
+    // Traceability (PR #1350): this cap only relaxes the *upward* direction
+    // (an APPROVE review_body must not be hardened to REQUEST_CHANGES by a Medium
+    // count).  The symmetric *downward* direction — a model-proposed BLOCK being
+    // relaxed below the floor — is intentionally NOT handled here; it is covered by
+    // `stricter_of` below, which takes max(model, floor), so a model BLOCK can never
+    // be softened by a weaker floor.  See `grade_model_block_kept_when_no_critical_finding`.
 
     let final_verdict = stricter_of(model_proposed.clone(), floor.clone());
 
@@ -225,16 +245,26 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
 }
 
 /// Return `true` if a finding is substantive enough to count toward the verdict
-/// floor (closes #1343).
+/// floor (closes #1343; High-effort safety net restored in 0.3.12 per PR #1350).
 ///
 /// Why: refuted findings and very-low-confidence speculation must never harden
 /// the verdict.  The #1343 calibration bug surfaced REQUEST_CHANGES/D+ on PRs the
 /// model graded APPROVE/B+ partly because `verified:"refuted"` findings (demoted to
 /// 0.10) and raw `confidence:0.1` findings were still fed into the severity floor.
+/// BUT the original #1343 predicate dropped EVERY finding below 0.50 confidence —
+/// including genuine High-effort (critical/high severity) findings.  That removed
+/// the safety net: a real critical bug the model was merely uncertain about (e.g.
+/// `confidence:0.45`, `effort:High`) would be excluded from the floor and silently
+/// soften to APPROVE.  PR #1350's review flagged this; we restore the net here.
 /// What: returns `false` when the finding is any refutation variant
-/// (`Refuted` / `ErrorRefuted` / `TruncationRefuted`) OR its confidence is below
-/// `FLOOR_COUNT_MIN_CONFIDENCE` (0.50); `true` otherwise.
-/// Test: `floor_excludes_refuted_and_low_confidence_findings`.
+/// (`Refuted` / `ErrorRefuted` / `TruncationRefuted`) — a verifier-refuted finding
+/// is disproven evidence and is excluded REGARDLESS of effort.  Otherwise returns
+/// `true` when EITHER its `confidence >= FLOOR_COUNT_MIN_CONFIDENCE` (0.50) OR it is
+/// `Effort::High` — a non-refuted High-effort finding is retained even at low
+/// confidence so it still drives the BLOCK floor / `has_high` path.
+/// Test: `floor_excludes_refuted_and_low_confidence_findings`,
+/// `low_confidence_high_effort_finding_still_drives_floor`,
+/// `refuted_high_effort_finding_is_still_excluded`.
 fn is_substantive(f: &Finding) -> bool {
     let refuted = matches!(
         f.verified,
@@ -242,7 +272,11 @@ fn is_substantive(f: &Finding) -> bool {
             | Some(VerifyOutcome::ErrorRefuted { .. })
             | Some(VerifyOutcome::TruncationRefuted)
     );
-    !refuted && f.confidence >= FLOOR_COUNT_MIN_CONFIDENCE
+    // A refuted finding is disproven evidence — always excluded, even High-effort.
+    // Otherwise retain it if it clears the confidence floor OR is a High-effort
+    // (critical/high severity) finding: a genuine critical concern must keep its
+    // place at the verdict floor even when the model is only uncertain about it.
+    !refuted && (f.confidence >= FLOOR_COUNT_MIN_CONFIDENCE || f.effort == Effort::High)
 }
 
 // ─── Floor computation ────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -572,6 +572,71 @@ fn high_effort_finding_still_overrides_approve() {
     assert_eq!(g, Grade::F);
 }
 
+// ── PR #1350 advisory fix A: High-effort findings keep their floor seat ──────
+
+/// A High-effort finding with confidence < 0.50 (and NOT refuted) must STILL drive
+/// the verdict floor (PR #1350 safety-net restoration).
+///
+/// Why: the original #1343 `is_substantive` predicate dropped EVERY finding below
+/// 0.50 confidence, including genuine High-effort criticals.  That silently
+/// softened an uncertain-but-critical finding to APPROVE — exactly the safety net
+/// PR #1350's review flagged.  A non-refuted High-effort finding must keep its seat
+/// at the floor regardless of confidence, so it still escalates to BLOCK.
+/// What: model APPROVE + one High@0.45 (non-refuted, below FLOOR_COUNT_MIN_CONFIDENCE)
+/// → BLOCK (has_high path is reached, severity_floor returns BLOCK).
+/// Test: this test itself.
+#[test]
+fn low_confidence_high_effort_finding_still_drives_floor() {
+    let findings = vec![finding(Effort::High, 0.45)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a non-refuted High-effort finding below 0.50 confidence must still BLOCK (PR #1350)"
+    );
+}
+
+/// End-to-end form: a low-confidence non-refuted High-effort finding clamps a clean
+/// APPROVE/B+ down to BLOCK/F via the grade-aware entry point (PR #1350).
+///
+/// Why: confirms the restored safety net flows through `derive_verdict_with_grade`,
+/// not just the bare `derive_verdict` — the uncertain critical hardens both verdict
+/// and grade.
+/// What: model APPROVE, grade B+, one High@0.40 → (BLOCK, F).
+/// Test: this test itself.
+#[test]
+fn low_confidence_high_effort_clamps_grade_to_block() {
+    let findings = vec![finding(Effort::High, 0.40)];
+    let (v, g) = derive_verdict_with_grade(Verdict::Approve, Grade::BPlus, &findings);
+    assert_eq!(
+        v,
+        Verdict::Block,
+        "uncertain critical (High@0.40) must still BLOCK through the grade pipeline (PR #1350)"
+    );
+    assert_eq!(g, Grade::F, "grade must clamp to F when verdict=BLOCK");
+}
+
+/// A REFUTED High-effort finding (even at high confidence) must STILL be excluded —
+/// the safety-net fix retains uncertain criticals but never disproven ones (PR #1350).
+///
+/// Why: advisory fix A widens the floor net for *uncertain* High-effort findings,
+/// but a verifier-`Refuted` finding is disproven evidence and must never harden the
+/// verdict — even when its effort is High.  This guards against the fix being
+/// mis-read as "all High-effort findings always count".
+/// What: model APPROVE + one refuted High@0.95 → APPROVE (the refuted critical is
+/// excluded; no other substantive finding remains).
+/// Test: this test itself.
+#[test]
+fn refuted_high_effort_finding_is_still_excluded() {
+    let findings = vec![verified_finding(Effort::High, 0.95, VerifyOutcome::Refuted)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "a REFUTED High-effort finding must not harden the verdict, even high-confidence (PR #1350)"
+    );
+}
+
 /// A confirmed High finding still drives BLOCK even with a B+ grade (#1015 regression).
 ///
 /// Why: the fix must not soften correctness blockers.  High-effort findings are


### PR DESCRIPTION
## Summary

Cuts **trusty-review 0.3.11 → 0.3.12** to (a) restore a taggable release — the
`0.3.11` git tag was burned after the #1343 verdict-calibration fix was published
to crates.io — and (b) fold in the two advisory findings raised in the **PR #1350**
review.

## Advisory Fix A — High-effort/low-confidence safety net (substantive)

The #1343 `is_substantive` predicate (`grade.rs`) dropped **every** finding with
`confidence < FLOOR_COUNT_MIN_CONFIDENCE` (0.50), *including* genuine `Effort::High`
criticals. That silently removed the safety net: a real critical finding the model
was merely uncertain about (e.g. `confidence:0.45`, `effort:High`) was excluded from
the verdict floor and softened to APPROVE.

New semantics:
- **Always** exclude verifier-refuted findings (`Refuted` / `ErrorRefuted` /
  `TruncationRefuted`) — unchanged, applies even to High-effort.
- Otherwise **retain** a finding when `confidence >= 0.50 OR effort == Effort::High`.

A non-refuted High-effort finding therefore keeps its seat at the floor and still
drives the `has_high` / BLOCK path, while a **refuted** High-effort finding does NOT
harden the verdict. The #1343 fix is preserved: a clean model APPROVE carrying only
low-confidence / refuted noise still does **not** harden to REQUEST_CHANGES.

## Advisory Fix B — threshold documentation + traceability (docs)

- Documented the magic `FLOOR_COUNT_MIN_CONFIDENCE = 0.50` constant in the same
  Why/What/Test style as `FLOOR_MIN_CONFIDENCE` (0.80) and `LOW_CONFIDENCE_THRESHOLD`
  (0.65): *below 0.50 a finding is more likely wrong than right, so it must not move
  the verdict floor* (the coin-flip line), plus the new High-effort exception.
- Added a traceability comment at the source-of-truth reconciliation cap noting that
  the symmetric **BLOCK-downgrade** direction is intentionally handled by
  `stricter_of` (`max(model, floor)`), so a model-proposed BLOCK is never relaxed —
  addressing the reviewer's traceability concern.

## Tests

New regression tests in `grade_tests.rs`:
- `low_confidence_high_effort_finding_still_drives_floor` — a non-refuted High@0.45
  still floors to BLOCK (the safety net Fix A restores).
- `low_confidence_high_effort_clamps_grade_to_block` — same through the grade-aware
  `derive_verdict_with_grade` entry point (BLOCK/F).
- `refuted_high_effort_finding_is_still_excluded` — a refuted High@0.95 is still
  excluded and does not harden an APPROVE.

All existing #1343/#1015 tests remain green (`high_effort_finding_still_overrides_approve`,
`floor_excludes_refuted_and_low_confidence_findings`,
`approve_b_plus_survives_refuted_and_low_confidence_findings`, etc.).

## Version / dependency plumbing

- `crates/trusty-review/Cargo.toml`: `0.3.11` → `0.3.12`.
- Root `Cargo.toml` `[workspace.dependencies]` pin updated to `0.3.12` (single pin
  point per CLAUDE.md); `Cargo.lock` regenerated. trusty-analyze consumes
  trusty-review via `workspace = true` (caret-compatible) and resolves to 0.3.12.

## Verification

| Check | Result |
|---|---|
| `cargo check` (workspace) | EXIT=0 |
| `cargo test -p trusty-review` | EXIT=0 — 820 lib + 19 bin, 0 failed |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | EXIT=0 |
| `cargo fmt --check` | EXIT=0 |
| `bash scripts/check_line_cap.sh` | EXIT=0 (grade.rs under the 500-SLOC prod cap) |

Refs #1343. Restores a taggable trusty-review release after the 0.3.11 tag was burned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)