### PR TITLE
fix(release): add actions/checkout to release job so git-cliff finds repo + cliff.toml (#1322 regression)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -739,6 +739,21 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # ── Checkout the repository (required by git-cliff) ──────────────────────
+      # Why: the git-cliff step below (orhun/git-cliff-action@v4) reads cliff.toml
+      # from the repo root and walks the git history/tags to render RELEASE_NOTES.md.
+      # Without a checkout this job runs in an empty working dir: git-cliff cannot
+      # find cliff.toml (falls back to the default config) NOR the git repository
+      # ("could not find repository at '/home/runner/work/trusty-tools/trusty-tools'"),
+      # so it errors out, RELEASE_NOTES.md is never written, and softprops fails to
+      # read body_path → no GitHub Release is created (regression from #1322 / PR #1346).
+      # fetch-depth: 0 fetches the FULL history and all tags, which git-cliff needs
+      # for its --latest / --tag-pattern tag-range walking.
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Download all build artifacts
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
## Root cause

The `release` job in `.github/workflows/release.yml` (the GitHub-Release-creation job) runs `orhun/git-cliff-action@v4` to render `RELEASE_NOTES.md`, then `softprops/action-gh-release` with `body_path: RELEASE_NOTES.md`. **But the job had no `actions/checkout` step** — it only downloaded build artifacts into a `release-assets/` subdir.

With no checkout, git-cliff ran in an empty working directory: no git repo, no `cliff.toml`. Confirmed from release run `27651766100` (tag `trusty-review-v0.3.12`):

```
cliff.toml is not found, using the default configuration
Error: GitError ... "could not find repository at '/home/runner/work/trusty-tools/trusty-tools'"
stat: cannot statx 'RELEASE_NOTES.md': No such file or directory
```

The chain of failure:

> missing checkout → git-cliff `GitError` (no repo, no `cliff.toml`) → `RELEASE_NOTES.md` never written → softprops can't read `body_path` → **no GitHub Release created**

This broke GitHub Releases and the downstream `homebrew-bump` job for **every binary crate**. The git-cliff wiring introduced in PR #1346 / issue #1322 has therefore never actually worked since it landed.

## Fix

Add `actions/checkout@v5` (matching the version already used by the `build` and `homebrew-bump` jobs) as the **first** step of the `release` job, with `fetch-depth: 0` so git-cliff has the full history + all tags for its `--latest` / `--tag-pattern` tag-range walking.

Resulting step order:

```
checkout (fetch-depth: 0)
  → download artifacts (into release-assets/)
  → detect prerelease
  → git-cliff → RELEASE_NOTES.md   (reads cliff.toml from repo root)
  → softprops/action-gh-release    (reads body_path: RELEASE_NOTES.md)
```

The artifact download targets the `release-assets/` subdir, so the checkout and the artifacts don't collide. **No changes** to `cliff.toml` or the `body_path` / `RELEASE_NOTES.md` wiring — minimal, surgical fix.

## Other jobs — no same risk

- `setup` — pure tag parse / config table, no git ops. No checkout needed.
- `build` — already has `actions/checkout@v5`.
- `homebrew-bump` — already has `actions/checkout@v5` (checks out the *tap* repo); its git ops run under `working-directory: tap`. No repo-root git ops, no git-cliff.

Only the `release` job was missing a checkout.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → parses cleanly.
- `actionlint .github/workflows/release.yml` → OK.
- pre-commit `check yaml` hook → Passed.

Will be verified on the next binary-crate release tag (the GitHub Release should now be created with git-cliff-generated notes).

Refs #1322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)