### PR TITLE
feat(trusty-common): intent-source resolver (ISR) with ticket>spec precedence

### DIFF
--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -335,6 +335,17 @@ embedder-client = ["dep:thiserror", "embedder"]
 # crate). Pulls in `chrono`, `uuid`, `base64`, `thiserror`, and `toml` as
 # additional optional deps. Requires the `mcp` feature for the stdio loop.
 tickets = ["mcp", "dep:uuid", "dep:base64", "dep:thiserror", "dep:toml"]
+# Enables the `intent_source` module: the shared intent-source resolver (ISR)
+# for the intent/method conformance gates (DOC-15, SPEC-CONFORMANCE-03, #1358).
+# Resolves the ticket method + spec method from a PR or ticket-id and applies
+# precedence (ticket > spec), returning one `ResolvedIntent` that both the
+# FRONT gate (trusty-mpm) and the BACK gate (trusty-review) consume. Reuses the
+# in-crate `tickets` backend (`Backend::get_issue`) and is designed to compose
+# with the `chat` `ChatProvider` surface for optional method extraction; it
+# lifts tga's PR→ticket regexes so neither gate pulls tga's git2/rusqlite stack.
+# Pulls in `regex` and `thiserror`. The non-consumer trusty-common dependents
+# pay nothing (feature off by default).
+intent-source = ["tickets", "dep:regex", "dep:thiserror"]
 # Enables the `help` module: declarative CLI help loader (`HelpConfig` parsed
 # from a per-binary `help.yaml` bundled via `include_str!`), the canonical
 # `render_help` formatter, and a Jaro-Winkler-based `suggest("did you mean?")`

--- a/crates/trusty-common/src/intent_source/backend_fetcher.rs
+++ b/crates/trusty-common/src/intent_source/backend_fetcher.rs
@@ -88,9 +88,12 @@ impl TicketFetcher for BackendTicketFetcher {
 /// Why: the common case resolves spec markdown straight off disk relative to
 /// the checkout; review's serve mode can supply a different loader (spec §6.4).
 /// What: holds a repo-root path; `load` joins the `docs/specs/*.md` relative
-/// path and reads the file, returning `None` on any read error (a gap, never
-/// an error — the ISR reads links, it does not enforce them).
-/// Test: `super::tests::fs_spec_lookup_*`.
+/// path, **canonicalizes it and asserts it stays under the canonicalized
+/// repo_root** (path-traversal guard), then reads the file — returning `None`
+/// on any read/escape error (a gap, never an error — the ISR reads links, it
+/// does not enforce them).
+/// Test: `super::tests::fs_spec_lookup_*`,
+/// `super::tests::fs_spec_lookup_rejects_traversal`.
 pub struct FsSpecLookup {
     repo_root: PathBuf,
 }
@@ -112,7 +115,19 @@ impl FsSpecLookup {
 
 impl SpecLookup for FsSpecLookup {
     fn load(&self, spec_file: &str) -> Option<String> {
-        let path = self.repo_root.join(spec_file);
-        std::fs::read_to_string(path).ok()
+        // PATH-TRAVERSAL GUARD: `spec_file` is regex-captured from untrusted
+        // source files (`parse_spec_refs`), so a malicious `..`-laden path
+        // (`docs/specs/../../etc/passwd`) could otherwise read arbitrary files.
+        // We canonicalize both the repo root and the joined target, then refuse
+        // any target that does not stay under the root. Canonicalization
+        // resolves `..`/symlinks; the `starts_with` check is the containment
+        // assertion. A target that does not exist (or escapes) → `None` (a gap,
+        // never an error — consistent with the rest of `load`).
+        let root = self.repo_root.canonicalize().ok()?;
+        let candidate = root.join(spec_file).canonicalize().ok()?;
+        if !candidate.starts_with(&root) {
+            return None;
+        }
+        std::fs::read_to_string(candidate).ok()
     }
 }

--- a/crates/trusty-common/src/intent_source/backend_fetcher.rs
+++ b/crates/trusty-common/src/intent_source/backend_fetcher.rs
@@ -1,0 +1,118 @@
+//! Default ticket fetcher + spec loader (production wiring).
+//!
+//! Why: the resolver's `TicketFetcher`/`SpecLookup` seams need a real default
+//! that reuses the in-crate `tickets` GitHub backend and the local
+//! `docs/specs/` tree — without coupling `resolve` to either (spec §6.6, §7.4).
+//! What: `BackendTicketFetcher` (wraps `tickets::Backend::get_issue` behind a
+//! pluggable `IntentTokenResolver`) and `FsSpecLookup` (reads `docs/specs/*.md`
+//! from a configured repo root).
+//! Test: `super::tests::fs_spec_lookup_*`; the GitHub fetch path is
+//! network-bound so it is exercised by mocks in unit tests and live only in
+//! integration.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use crate::tickets::api::backends::Backend;
+use crate::tickets::api::backends::github::GitHubBackend;
+use crate::tickets::api::config::GithubConfig;
+
+use super::resolve::{IntentTokenResolver, SpecLookup, TicketData, TicketFetcher};
+use super::types::IsrError;
+
+/// Default `TicketFetcher` over the in-crate GitHub `tickets` backend.
+///
+/// Why: the spec says reuse `Backend::get_issue` rather than build a new GitHub
+/// client (spec §6.5, §6.6). This wraps it, deriving the bearer token through
+/// the pluggable `IntentTokenResolver` so App/JWT auth works in serve mode
+/// (spec §7.4) — it does NOT hard-wire a PAT.
+/// What: holds a boxed token resolver; `fetch` builds a `GitHubBackend` for the
+/// owner/repo with the resolved token and calls `get_issue`, mapping the
+/// `Issue` into a backend-agnostic `TicketData`.
+/// Test: `super::tests` mock the `TicketFetcher` trait directly; this impl's
+/// auth wiring is covered by `super::tests::backend_fetcher_token_*`.
+pub struct BackendTicketFetcher {
+    token_resolver: Box<dyn IntentTokenResolver>,
+}
+
+impl BackendTicketFetcher {
+    /// Construct a fetcher with a custom token resolver.
+    ///
+    /// Why: review's serve mode supplies an App/JWT resolver; the CLI supplies
+    /// the env default. This constructor keeps that choice at the call site
+    /// (spec §7.4).
+    /// What: stores the boxed resolver for use in `fetch`.
+    /// Test: `super::tests::backend_fetcher_token_*`.
+    #[must_use]
+    pub fn new(token_resolver: Box<dyn IntentTokenResolver>) -> Self {
+        Self { token_resolver }
+    }
+}
+
+#[async_trait]
+impl TicketFetcher for BackendTicketFetcher {
+    async fn fetch(
+        &self,
+        owner: &str,
+        repo: &str,
+        ticket_id: &str,
+    ) -> Result<TicketData, IsrError> {
+        let token = self.token_resolver.token(owner, repo).await?;
+        let cfg = GithubConfig {
+            token: Some(token),
+            owner: Some(owner.to_string()),
+            repo: Some(repo.to_string()),
+            gh_cli_user: None,
+            gh_cli_host: None,
+        };
+        let backend = GitHubBackend::new(cfg).map_err(|e| IsrError::TicketFetch(e.to_string()))?;
+        // GitHub issue ids are numeric; strip a leading `#` if present.
+        let id = ticket_id.trim_start_matches('#');
+        let issue = backend
+            .get_issue(id)
+            .await
+            .map_err(|e| IsrError::TicketFetch(e.to_string()))?;
+        Ok(TicketData {
+            id: format!("#{}", issue.id),
+            title: issue.title,
+            body: issue.description.unwrap_or_default(),
+            url: issue.url,
+            backend: issue.backend,
+        })
+    }
+}
+
+/// Default `SpecLookup` that reads `docs/specs/*.md` from a repo root.
+///
+/// Why: the common case resolves spec markdown straight off disk relative to
+/// the checkout; review's serve mode can supply a different loader (spec §6.4).
+/// What: holds a repo-root path; `load` joins the `docs/specs/*.md` relative
+/// path and reads the file, returning `None` on any read error (a gap, never
+/// an error — the ISR reads links, it does not enforce them).
+/// Test: `super::tests::fs_spec_lookup_*`.
+pub struct FsSpecLookup {
+    repo_root: PathBuf,
+}
+
+impl FsSpecLookup {
+    /// Construct a loader rooted at `repo_root`.
+    ///
+    /// Why: spec paths in SLD refs are repo-relative (`docs/specs/…`); the
+    /// loader needs the root to resolve them (spec §6.4).
+    /// What: stores the root path.
+    /// Test: `super::tests::fs_spec_lookup_*`.
+    #[must_use]
+    pub fn new(repo_root: impl Into<PathBuf>) -> Self {
+        Self {
+            repo_root: repo_root.into(),
+        }
+    }
+}
+
+impl SpecLookup for FsSpecLookup {
+    fn load(&self, spec_file: &str) -> Option<String> {
+        let path = self.repo_root.join(spec_file);
+        std::fs::read_to_string(path).ok()
+    }
+}

--- a/crates/trusty-common/src/intent_source/extract.rs
+++ b/crates/trusty-common/src/intent_source/extract.rs
@@ -71,8 +71,10 @@ impl MethodExtractor for HeuristicMethodExtractor {
 /// - **Constraint:** "no new dep…", "do not …", "don't …", "must not …",
 ///   "never …", "without …".
 /// - **Reuse:** "reuse …", "use the existing …".
-/// - **Approach:** "use … pagination", "use cursor-…", a "method:"/"approach:"
-///   labelled line, or "gate … behind a feature flag".
+/// - **Approach:** a narrow `use …` directive (a known technique lead like
+///   "use cursor…"/"use offset…", or an article form like "use the existing
+///   X" — *not* a Rust `use std::…;` import), "cursor[- ]based pagination", a
+///   "method:"/"approach:" labelled line, or "gate … behind a feature flag".
 ///
 /// Ambiguous prose with no cue → `None` (conservative).
 ///
@@ -144,13 +146,68 @@ fn classify_cue(lower: &str, cue: &str) -> Option<MethodKind> {
     }
 
     // Approach / technique cues.
-    if cue.starts_with("use ")
+    //
+    // The `use …` cue is deliberately NARROW: a bare `cue.starts_with("use ")`
+    // would misclassify ordinary Rust import statements (`use
+    // std::collections::HashMap;`) and throwaway phrasing (`use caution`) as a
+    // prescribed approach. We instead require the `use` to introduce a
+    // recognised approach phrasing — a known technique follow-word (`use
+    // cursor`, `use offset`) or an article/determiner that signals an
+    // imperative directive (`use the existing X`, `use a token bucket`). Rust
+    // `use` imports never match (their next token is a `::`-qualified path), and
+    // `use X;` import lines are additionally rejected by the path/semicolon
+    // guard in `is_approach_use_cue`.
+    if is_approach_use_cue(cue)
         || lower.contains("cursor-based pagination")
         || lower.contains("cursor pagination")
-        || lower.contains("gate") && lower.contains("feature flag")
+        || (lower.contains("gate") && lower.contains("feature flag"))
     {
         return Some(MethodKind::Approach);
     }
 
     None
+}
+
+/// Whether a `use …` cue is a *prescribed approach*, not a Rust import.
+///
+/// Why: `cue.starts_with("use ")` is too broad — it captures Rust import
+/// statements (`use std::collections::HashMap;`) and casual phrasing (`use
+/// caution`) as `MethodKind::Approach`, fabricating a method the author never
+/// prescribed (spec §6.2 conservative bias).
+/// What: returns `true` only when the token after `use ` is a recognised
+/// approach lead — a known technique noun (`cursor`, `offset`, `pagination`,
+/// `token`, `cache`, `index`, …) or an article/determiner that introduces an
+/// imperative directive (`the`, `a`, `an`). Rust import lines are excluded
+/// because their follow-token is a `::`-qualified path or ends in `;`.
+/// Test: `super::tests::extract_heuristic_use_import_not_approach`.
+fn is_approach_use_cue(cue: &str) -> bool {
+    let Some(rest) = cue.strip_prefix("use ") else {
+        return false;
+    };
+    let rest = rest.trim();
+    // Reject obvious Rust import statements: a `::`-qualified path, or a line
+    // that terminates in `;` (an import/use-declaration, never prose).
+    if rest.contains("::") || rest.ends_with(';') {
+        return false;
+    }
+    let Some(first) = rest.split_whitespace().next() else {
+        return false;
+    };
+    // Strip trailing punctuation so `cursor-based` / `the,` still match.
+    let head = first.trim_end_matches([',', '.', ':', ';']);
+    // Articles/determiners introduce an imperative directive ("use the existing
+    // trait", "use a bounded channel").
+    const DETERMINERS: [&str; 3] = ["the", "a", "an"];
+    // Known approach/technique nouns (extend as cues accrue; conservative set).
+    const TECHNIQUE_LEADS: [&str; 8] = [
+        "cursor",
+        "offset",
+        "pagination",
+        "token",
+        "cache",
+        "index",
+        "streaming",
+        "batching",
+    ];
+    DETERMINERS.contains(&head) || TECHNIQUE_LEADS.iter().any(|t| head.starts_with(t))
 }

--- a/crates/trusty-common/src/intent_source/extract.rs
+++ b/crates/trusty-common/src/intent_source/extract.rs
@@ -1,0 +1,156 @@
+//! Method extraction — the OQ-1 seam.
+//!
+//! Why: a ticket/spec body is free prose; the matrix (spec §4) needs a
+//! *method* (a prescribed approach/technique/constraint), not the whole body.
+//! Extraction must be **conservative**: ambiguous text → `None`, never a
+//! hallucinated constraint (spec §6.2).
+//!
+//! **OQ-1 decision (settled in C1, per spec §9 OQ-1 — "leans hybrid"):**
+//! C1 ships a **heuristic-first, pluggable-extractor** design.
+//! - The DEFAULT path is [`HeuristicMethodExtractor`] — pure-Rust pattern
+//!   matching over imperative-method phrasing. It requires **no network**, so
+//!   the resolver (and its tests) work fully offline. This is the right C1
+//!   default: zero cost/latency, no false-method risk from an LLM.
+//! - The [`MethodExtractor`] trait is the pluggable seam. A future LLM-backed
+//!   extractor (adapting `trusty_common::chat::ChatProvider` with the fixed
+//!   classification prompt from spec §6.2) can be supplied by a caller without
+//!   touching the resolver — realising the "heuristic first, LLM fallback"
+//!   hybrid the spec recommends. We deliberately do NOT wire an LLM call by
+//!   default: it would make `resolve` network-dependent and is out of C1 scope.
+//!
+//! What: the `MethodExtractor` trait + the heuristic default + the standalone
+//! `heuristic_method` function the spec-resolver reuses.
+//! Test: `super::tests::extract_*`.
+
+use super::types::{Method, MethodKind};
+
+/// Pluggable method-extraction strategy (the OQ-1 seam).
+///
+/// Why: extraction policy (heuristic vs. LLM vs. hybrid) is the one genuinely
+/// open design question (spec OQ-1). Modelling it as a trait lets a caller swap
+/// strategies — including an LLM-backed one — without changing the resolver.
+/// What: one method, `extract`, mapping a free-prose body to an optional
+/// `Method`. Implementors MUST be conservative: ambiguous → `None`.
+/// Test: `super::tests::extract_*` exercise the default impl.
+pub trait MethodExtractor: Send + Sync {
+    /// Extract a prescribed method from a ticket/spec body, or `None`.
+    ///
+    /// Why: callers compare a *method*, not free prose (spec §4, §6.2).
+    /// What: returns `Some(Method)` only when the body unambiguously prescribes
+    /// an approach/constraint; `None` otherwise.
+    /// Test: `super::tests::extract_*`.
+    fn extract(&self, body: &str) -> Option<Method>;
+}
+
+/// The default, network-free heuristic extractor (OQ-1 default path).
+///
+/// Why: the common case ("use cursor-based pagination", "no new dependency",
+/// "reuse the existing `ContextSource` trait") is recognisable from imperative
+/// phrasing without an LLM, and a heuristic carries zero cost/latency and no
+/// hallucination risk (spec §6.2, OQ-1).
+/// What: a zero-field marker whose [`MethodExtractor::extract`] delegates to
+/// [`heuristic_method`].
+/// Test: `super::tests::extract_heuristic_*`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HeuristicMethodExtractor;
+
+impl MethodExtractor for HeuristicMethodExtractor {
+    fn extract(&self, body: &str) -> Option<Method> {
+        heuristic_method(body)
+    }
+}
+
+/// Conservative, pure-Rust method extraction over imperative phrasing.
+///
+/// Why: shared by the ticket path (default extractor) and the spec path
+/// (`spec_resolve::extract_spec_method`) so "what counts as a method" is
+/// defined once (spec §6.2).
+/// What: scans each line for a recognised method cue and, on the first match,
+/// returns a `Method` classified by cue kind with the matched line as the
+/// verbatim `source_excerpt`. Cues recognised:
+/// - **Constraint:** "no new dep…", "do not …", "don't …", "must not …",
+///   "never …", "without …".
+/// - **Reuse:** "reuse …", "use the existing …".
+/// - **Approach:** "use … pagination", "use cursor-…", a "method:"/"approach:"
+///   labelled line, or "gate … behind a feature flag".
+///
+/// Ambiguous prose with no cue → `None` (conservative).
+///
+/// Test: `super::tests::extract_heuristic_*`.
+#[must_use]
+pub fn heuristic_method(body: &str) -> Option<Method> {
+    for raw_line in body.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let lower = line.to_lowercase();
+
+        // Strip common markdown list / heading prefixes for cue matching, but
+        // keep the original `line` as the verbatim excerpt.
+        let cue = lower
+            .trim_start_matches(['-', '*', '#', '>', ' '])
+            .trim_start_matches("method:")
+            .trim_start_matches("approach:")
+            .trim();
+
+        if let Some(kind) = classify_cue(&lower, cue) {
+            // `text` is the prose with leading markdown list/heading markers
+            // stripped, so the same method stated as `- use X` (spec list item)
+            // and `use X` (ticket prose) compares equal under precedence
+            // (resolve::methods_agree). `source_excerpt` keeps the line verbatim.
+            let text = line
+                .trim_start_matches(['-', '*', '#', '>', ' '])
+                .trim()
+                .to_string();
+            return Some(Method {
+                text,
+                kind,
+                source_excerpt: line.to_string(),
+            });
+        }
+    }
+    None
+}
+
+/// Classify a method cue, or return `None` when the line is not a method.
+///
+/// Why: keeping the cue taxonomy in one small function keeps
+/// [`heuristic_method`] readable and makes the conservative bias auditable.
+/// What: returns `Some(MethodKind)` for a recognised constraint/reuse/approach
+/// cue; `None` otherwise. `lower` is the whole lowercased line (for phrase
+/// matches); `cue` is the prefix-stripped variant (for leading-keyword matches).
+/// Test: `super::tests::extract_heuristic_*`.
+fn classify_cue(lower: &str, cue: &str) -> Option<MethodKind> {
+    // Constraints / prohibitions — checked first (strongest signal).
+    const CONSTRAINT_PHRASES: [&str; 6] = [
+        "no new dep",
+        "must not",
+        "do not ",
+        "don't ",
+        "never ",
+        "without adding",
+    ];
+    if CONSTRAINT_PHRASES.iter().any(|p| lower.contains(p)) {
+        return Some(MethodKind::Constraint);
+    }
+
+    // Reuse directives.
+    if cue.starts_with("reuse ")
+        || lower.contains("reuse the existing")
+        || lower.contains("use the existing")
+    {
+        return Some(MethodKind::Reuse);
+    }
+
+    // Approach / technique cues.
+    if cue.starts_with("use ")
+        || lower.contains("cursor-based pagination")
+        || lower.contains("cursor pagination")
+        || lower.contains("gate") && lower.contains("feature flag")
+    {
+        return Some(MethodKind::Approach);
+    }
+
+    None
+}

--- a/crates/trusty-common/src/intent_source/linkage.rs
+++ b/crates/trusty-common/src/intent_source/linkage.rs
@@ -124,22 +124,37 @@ pub fn extract_branch_ticket(branch: &str) -> Option<String> {
 ///
 /// Why: the BACK gate must pick *one* ticket deterministically from several
 /// possible linkage sources; the spec fixes the order (§6.3).
-/// What: tries, in order — (a) the PR body via [`extract_ticket_id`]
-/// (preferring action-keyword/qualifying refs), (b) each commit message, then
-/// (c) the branch name via [`extract_branch_ticket`]. Returns the first match;
-/// `None` when the PR carries no linkage at all.
-/// Test: `super::tests::linkage_pr_*` (AC-5).
+/// What: tries, in order — (a) the PR **body**, which is free-text prose and so
+/// must carry a *qualifying* reference ([`is_ticketed`]: an action-keyword
+/// GitHub ref, a JIRA/Linear id, or an ADO ref) before a ticket-id is taken
+/// from it; (b) each commit message (a bare `#N` here is acceptable — commit
+/// trailers are conventionally terse); then (c) the branch name via
+/// [`extract_branch_ticket`]. Returns the first match; `None` when the PR
+/// carries no linkage at all.
+///
+/// The body is gated on `is_ticketed` specifically to avoid the tga #445
+/// false-positive: a PR body like `"See discussion in #42 for background"`
+/// mentions `#42` only in passing and must NOT resolve to ticket 42, whereas
+/// `"Closes #42"` (an action keyword) qualifies. Commit messages and branch
+/// names are NOT free-text discussion, so they retain the bare-`#N`
+/// last-resort fallback (spec §6.3).
+/// Test: `super::tests::linkage_pr_*`, `super::tests::ac5_pr_body_bare_ref_*`
+/// (AC-5).
 #[must_use]
 pub fn extract_pr_ticket(
     body: &str,
     commit_messages: &[String],
     branch: Option<&str>,
 ) -> Option<String> {
-    // (a) PR body — prefer a qualifying ref, then any extractable id.
-    if let Some(id) = extract_ticket_id(body) {
+    // (a) PR body — free-text prose: require a QUALIFYING ref (tga #445). A bare
+    // `#N` mentioned in passing must not link; an action keyword / JIRA / ADO
+    // ref does. (Combinator form avoids a let-chain — trusty-common is edition
+    // 2021 — while satisfying clippy::collapsible_if.)
+    if let Some(id) = is_ticketed(body).then(|| extract_ticket_id(body)).flatten() {
         return Some(id);
     }
-    // (b) commit-message trailers in the diff's commits.
+    // (b) commit-message trailers — terse by convention, so a bare `#N` is an
+    // acceptable last resort here.
     for msg in commit_messages {
         if let Some(id) = extract_ticket_id(msg) {
             return Some(id);

--- a/crates/trusty-common/src/intent_source/linkage.rs
+++ b/crates/trusty-common/src/intent_source/linkage.rs
@@ -1,0 +1,150 @@
+//! PR → ticket linkage: extract the governing ticket-id from a pull request.
+//!
+//! Why: the BACK gate starts from a PR, not a ticket-id, so the ISR must
+//! resolve *which* ticket governs the change. trusty-review's existing linkage
+//! is fuzzy keyword search (spec §2.1); the ISR replaces it with explicit
+//! parsing. The regexes are **lifted from tga** (`collect/ticket.rs`) so both
+//! gates parse linkage without pulling tga's git2/rusqlite stack (spec §6.3).
+//! What: `is_ticketed` / `extract_ticket_id` (lifted verbatim in behaviour),
+//! plus `extract_pr_ticket` which applies the spec's source-precedence order
+//! (PR body trailers → commit trailers → branch name).
+//! Test: `super::tests::linkage_*` (AC-5).
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// Compiled regexes that qualify text as "ticketed" (lifted from tga).
+///
+/// Why: a bare `#N` is too noisy to qualify on its own (tga issue #445); only
+/// JIRA/Linear, GitHub action-keyword refs, and ADO refs qualify.
+/// What: the three qualifying patterns. `gh_bare` lives in [`ExtractPatterns`].
+/// Test: `super::tests::linkage_is_ticketed`.
+struct TicketPatterns {
+    jira: Regex,
+    gh_action: Regex,
+    azdo: Regex,
+}
+
+/// Lazily-initialised qualifying pattern set.
+///
+/// Why: compile the regexes exactly once across all resolver calls.
+/// What: returns a `'static` reference to the compiled `TicketPatterns`.
+/// Test: exercised by every `linkage_*` test.
+fn patterns() -> &'static TicketPatterns {
+    static PATTERNS: OnceLock<TicketPatterns> = OnceLock::new();
+    PATTERNS.get_or_init(|| TicketPatterns {
+        jira: Regex::new(r"\b[A-Z][A-Z0-9]*-\d+\b").expect("jira pattern compiles"),
+        gh_action: Regex::new(r"(?i)\b(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#\d+\b")
+            .expect("gh_action pattern compiles"),
+        azdo: Regex::new(r"\bAB#\d+\b").expect("azdo pattern compiles"),
+    })
+}
+
+/// Compiled extraction patterns, most-specific first (lifted from tga).
+///
+/// Why: when several ref styles appear, the highest-fidelity match wins.
+/// What: ADO, then JIRA/Linear, then a bare `#N` last-resort.
+/// Test: `super::tests::linkage_extract_*`.
+struct ExtractPatterns {
+    azdo: Regex,
+    jira: Regex,
+    gh_bare: Regex,
+}
+
+/// Lazily-initialised extraction pattern set.
+///
+/// Why: compile once; reuse across all resolver calls.
+/// What: returns a `'static` reference to the compiled `ExtractPatterns`.
+/// Test: exercised by every `linkage_extract_*` test.
+fn extract_patterns() -> &'static ExtractPatterns {
+    static EXTRACT: OnceLock<ExtractPatterns> = OnceLock::new();
+    EXTRACT.get_or_init(|| ExtractPatterns {
+        azdo: Regex::new(r"\bAB#\d+\b").expect("azdo extract pattern compiles"),
+        jira: Regex::new(r"\b[A-Z][A-Z0-9]*-\d+\b").expect("jira extract pattern compiles"),
+        gh_bare: Regex::new(r"(?:^|\s)(#\d+)\b").expect("gh_bare extract pattern compiles"),
+    })
+}
+
+/// Return `true` if `message` contains a *qualifying* ticket reference.
+///
+/// Why: a bare `#N` is too noisy to count as linkage on its own (tga #445);
+/// only action-keyword GitHub refs, JIRA/Linear ids, and ADO refs qualify.
+/// What: lifted verbatim from `tga::collect::ticket::is_ticketed`.
+/// Test: `super::tests::linkage_is_ticketed`.
+#[must_use]
+pub fn is_ticketed(message: &str) -> bool {
+    let p = patterns();
+    p.jira.is_match(message) || p.gh_action.is_match(message) || p.azdo.is_match(message)
+}
+
+/// Extract the first recognisable ticket id from arbitrary text.
+///
+/// Why: populate the linkage as a last-resort identifier even when no action
+/// keyword is present (e.g. a bare `#N`).
+/// What: lifted verbatim from `tga::collect::ticket::extract_ticket_id` —
+/// tries ADO, then JIRA/Linear, then bare `#N`, in that priority order.
+/// Test: `super::tests::linkage_extract_*`.
+#[must_use]
+pub fn extract_ticket_id(message: &str) -> Option<String> {
+    let p = extract_patterns();
+    if let Some(m) = p.azdo.find(message) {
+        return Some(m.as_str().to_string());
+    }
+    if let Some(m) = p.jira.find(message) {
+        return Some(m.as_str().to_string());
+    }
+    if let Some(m) = p.gh_bare.captures(message).and_then(|caps| caps.get(1)) {
+        return Some(m.as_str().to_string());
+    }
+    None
+}
+
+/// Extract a `#N` ticket id from a branch name (`fix/1325-x` → `#1325`).
+///
+/// Why: a branch name is the spec's third linkage source (§6.3) and does not
+/// carry the `#` sigil that [`extract_ticket_id`]'s bare pattern needs.
+/// What: matches the first run of digits in a `kind/NNNN-slug` branch and
+/// returns it as a `#N` GitHub-style id; returns `None` for branches with no
+/// leading numeric segment.
+/// Test: `super::tests::linkage_branch_*`.
+#[must_use]
+pub fn extract_branch_ticket(branch: &str) -> Option<String> {
+    static BRANCH: OnceLock<Regex> = OnceLock::new();
+    let re = BRANCH.get_or_init(|| {
+        // kind/NNNN-slug or kind/NNNN ; capture the numeric work-item segment.
+        Regex::new(r"(?:^|/)(\d+)(?:[-_/]|$)").expect("branch pattern compiles")
+    });
+    re.captures(branch)
+        .and_then(|c| c.get(1))
+        .map(|m| format!("#{}", m.as_str()))
+}
+
+/// Resolve the governing ticket-id from a PR, applying source precedence.
+///
+/// Why: the BACK gate must pick *one* ticket deterministically from several
+/// possible linkage sources; the spec fixes the order (§6.3).
+/// What: tries, in order — (a) the PR body via [`extract_ticket_id`]
+/// (preferring action-keyword/qualifying refs), (b) each commit message, then
+/// (c) the branch name via [`extract_branch_ticket`]. Returns the first match;
+/// `None` when the PR carries no linkage at all.
+/// Test: `super::tests::linkage_pr_*` (AC-5).
+#[must_use]
+pub fn extract_pr_ticket(
+    body: &str,
+    commit_messages: &[String],
+    branch: Option<&str>,
+) -> Option<String> {
+    // (a) PR body — prefer a qualifying ref, then any extractable id.
+    if let Some(id) = extract_ticket_id(body) {
+        return Some(id);
+    }
+    // (b) commit-message trailers in the diff's commits.
+    for msg in commit_messages {
+        if let Some(id) = extract_ticket_id(msg) {
+            return Some(id);
+        }
+    }
+    // (c) branch name (e.g. `fix/1325-…`).
+    branch.and_then(extract_branch_ticket)
+}

--- a/crates/trusty-common/src/intent_source/mod.rs
+++ b/crates/trusty-common/src/intent_source/mod.rs
@@ -1,0 +1,56 @@
+//! Intent-source resolver (ISR) — shared resolver for the conformance gates.
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CONFORMANCE-03~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-03~draft)
+//!
+//! Why: the intent/method conformance capability (DOC-15) ships two gates — a
+//! FRONT gate in trusty-mpm (pre-work) and a BACK gate in trusty-review
+//! (post-implementation). Both must resolve "what method did the ticket and the
+//! spec prescribe?" and apply the same precedence (ticket > spec). Implementing
+//! that resolution **once**, in the crate both gates already depend on, is the
+//! only placement that guarantees the two gates can never disagree (spec §6.5,
+//! goal G4) and avoids a new cross-crate edge.
+//!
+//! What: the ISR resolves a [`IntentQuery`] (a PR or a ticket-id) into a single
+//! [`ResolvedIntent`] carrying the ticket method, the spec method, the
+//! precedence winner, and the `conflict`/`stale_spec` flags. Resolution is
+//! **fail-open**: any fetch/parse failure yields
+//! [`ResolvedIntent::unresolved`], never a panic or `Err` (spec §4.2). The
+//! crate is a library, so errors are a `thiserror` enum ([`IsrError`]) and
+//! there are no `unwrap()`s on fetch/parse paths.
+//!
+//! Submodules (one concept each, to stay under the 500-SLOC cap):
+//! - [`types`]    — the data contract (`IntentQuery`, `ResolvedIntent`, …).
+//! - [`linkage`]  — PR → ticket extraction (tga regexes lifted, spec §6.3).
+//! - [`spec_resolve`] — SLD docstring-ref → spec section (spec §6.4; C4 hardens).
+//! - [`extract`]  — method extraction (the OQ-1 seam; heuristic default).
+//! - [`resolve`]  — the `resolve` entry point + precedence + auth seams.
+//! - [`backend_fetcher`] — production `TicketFetcher`/`SpecLookup` defaults.
+//!
+//! Test: `super::tests` (inline `#[cfg(test)] mod tests`) covers AC-1..AC-7 —
+//! all four precedence cases, fail-open, PR→ticket linkage, the no-SLD-ref gap,
+//! and the stale-spec conflict flag — without any network access.
+
+pub mod backend_fetcher;
+pub mod extract;
+pub mod linkage;
+pub mod resolve;
+pub mod spec_resolve;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+// ── Public facade re-exports (callers import from `intent_source::*`) ─────────
+
+pub use extract::{HeuristicMethodExtractor, MethodExtractor, heuristic_method};
+pub use linkage::{extract_pr_ticket, extract_ticket_id, is_ticketed};
+pub use resolve::{
+    EnvTokenResolver, IntentTokenResolver, SpecLookup, TicketData, TicketFetcher, apply_precedence,
+    resolve, resolve_default,
+};
+pub use types::{
+    ChangedFile, IntentQuery, IsrError, Method, MethodKind, Precedence, ResolvedIntent, SpecRef,
+    TicketRef,
+};

--- a/crates/trusty-common/src/intent_source/resolve.rs
+++ b/crates/trusty-common/src/intent_source/resolve.rs
@@ -180,11 +180,20 @@ fn resolve_ticket_id(query: &IntentQuery) -> Option<(String, String, String, Vec
 /// What: parses SLD refs from each changed file (first match wins), looks up
 /// the spec markdown via `spec_lookup`, and extracts the spec method from the
 /// governed section. Returns `(None, None)` when no SLD ref is declared.
+///
+/// KNOWN C1 LIMITATION (spec §6.4 "first match wins"): the loop returns the
+/// FIRST changed file that declares an SLD ref and silently ignores SLD refs in
+/// later files. This is intentional for C1 — a PR that touches multiple files
+/// each governed by a different spec section is out of scope. Multi-file /
+/// multi-section reconciliation (picking the most-specific governing section,
+/// or surfacing a conflict across files) is deferred to C4 (#1361), which
+/// hardens this seam.
 /// Test: `super::tests::spec_resolve_*` (AC-6).
 fn resolve_spec(
     changed_files: &[ChangedFile],
     spec_lookup: &dyn SpecLookup,
 ) -> (Option<SpecRef>, Option<Method>) {
+    // First changed file with an SLD ref wins (see KNOWN C1 LIMITATION above).
     for file in changed_files {
         let refs = parse_spec_refs(&file.content);
         if let Some(spec_ref) = refs.into_iter().next() {

--- a/crates/trusty-common/src/intent_source/resolve.rs
+++ b/crates/trusty-common/src/intent_source/resolve.rs
@@ -1,0 +1,322 @@
+//! The ISR entry point: `resolve(IntentQuery) -> ResolvedIntent`.
+//!
+//! Why: both conformance gates call one resolver so ticket+spec resolution and
+//! the precedence rule (ticket > spec) are implemented **once**, centrally
+//! (spec §6.1, §6.5, G4). This module wires the pieces — linkage, ticket fetch,
+//! spec resolution, method extraction — and applies precedence exactly once.
+//! What: the public async `resolve`, the pluggable `TicketFetcher` /
+//! `IntentTokenResolver` seams (§7.4), and `apply_precedence` (the normative
+//! four-case rule). Every failure path is **fail-open**: it returns
+//! `ResolvedIntent::unresolved{reason}`, never an `Err` (spec §4.2).
+//! Test: `super::tests` (AC-1..AC-7).
+
+use async_trait::async_trait;
+
+use super::extract::{HeuristicMethodExtractor, MethodExtractor};
+use super::linkage::extract_pr_ticket;
+use super::spec_resolve::{extract_spec_method, parse_spec_refs};
+use super::types::{
+    ChangedFile, IntentQuery, IsrError, Method, Precedence, ResolvedIntent, SpecRef, TicketRef,
+};
+
+/// Pluggable token resolver for GitHub App / JWT auth (spec §7.4).
+///
+/// Why: trusty-review's serve mode uses richer GitHub App/JWT auth than the
+/// `tickets` backend's PAT-only path. The ISR must NOT hard-wire a PAT; it
+/// exposes this seam (mirroring review's `IssueTokenResolver`) so it works in
+/// webhook/serve mode too (spec §7.4).
+/// What: one async method returning a bearer token for an owner/repo, or an
+/// error when none is available.
+/// Test: `super::tests::token_resolver_*`.
+#[async_trait]
+pub trait IntentTokenResolver: Send + Sync {
+    /// Resolve a GitHub access token for `owner`/`repo`.
+    ///
+    /// Why: the fetch needs a bearer token; how it is obtained (PAT, App JWT)
+    /// is the caller's concern (spec §7.4).
+    /// What: returns the token string, or `Err` when no token is available.
+    /// Test: `super::tests::token_resolver_*`.
+    async fn token(&self, owner: &str, repo: &str) -> Result<String, IsrError>;
+}
+
+/// Default token resolver: reads the `GITHUB_TOKEN` environment variable.
+///
+/// Why: the common (CLI / PAT) case needs no custom resolver; this preserves
+/// the existing `tickets` backend behaviour as the zero-config default
+/// (spec §7.4) while keeping the App/JWT path pluggable.
+/// What: returns `$GITHUB_TOKEN`, or `IsrError::NoToken` when it is unset.
+/// Test: `super::tests::token_resolver_env_*` (serial, env-mutating).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnvTokenResolver;
+
+#[async_trait]
+impl IntentTokenResolver for EnvTokenResolver {
+    async fn token(&self, _owner: &str, _repo: &str) -> Result<String, IsrError> {
+        std::env::var("GITHUB_TOKEN")
+            .map_err(|_| IsrError::NoToken("GITHUB_TOKEN not set".to_string()))
+    }
+}
+
+/// Pluggable ticket fetcher (the seam over `tickets::Backend::get_issue`).
+///
+/// Why: the resolver must fetch a ticket body without the production GitHub
+/// client in tests, and without coupling `resolve` to one backend. This trait
+/// is the seam both the default GitHub fetcher and test mocks implement
+/// (spec §6.6 reuses `Backend::get_issue` behind it).
+/// What: one async method mapping `(owner, repo, ticket_id)` to a `TicketData`,
+/// or `IsrError` on failure.
+/// Test: `super::tests` uses a `MockFetcher` implementing this trait.
+#[async_trait]
+pub trait TicketFetcher: Send + Sync {
+    /// Fetch the ticket identified by `ticket_id` in `owner`/`repo`.
+    ///
+    /// Why: the ticket body is the ticket-method source (spec §6.2).
+    /// What: returns the fetched `TicketData`, or `IsrError::TicketFetch`.
+    /// Test: `super::tests` (via `MockFetcher`).
+    async fn fetch(&self, owner: &str, repo: &str, ticket_id: &str)
+    -> Result<TicketData, IsrError>;
+}
+
+/// The minimal ticket data the resolver needs (backend-agnostic).
+///
+/// Why: decouples the resolver from the full `tickets::Issue` shape so a mock
+/// (and a future non-GitHub backend) need only supply these fields.
+/// What: id, title, body, optional URL, and the backend tag — exactly the
+/// inputs to `TicketRef` + method extraction (spec §6.1, §6.2).
+/// Test: `super::tests` constructs `TicketData` directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TicketData {
+    /// Backend-native id (`#1358`).
+    pub id: String,
+    /// Human-readable title.
+    pub title: String,
+    /// Free-prose body — the ticket-method source.
+    pub body: String,
+    /// Canonical URL, when available.
+    pub url: Option<String>,
+    /// Backend identifier (`github`).
+    pub backend: String,
+}
+
+/// Resolve intent from a query, applying precedence (ticket > spec).
+///
+/// Why: the one entry point both gates call; centralising resolution +
+/// precedence guarantees FRONT and BACK can never disagree (spec §6.1, G4).
+/// What: extracts the ticket-id (for `Pr`), fetches the ticket via `fetcher`,
+/// extracts the ticket method via `extractor`, resolves the spec section + spec
+/// method from `changed_files`, then applies [`apply_precedence`]. Any
+/// fetch/parse failure degrades to `ResolvedIntent::unresolved` (fail-open,
+/// spec §4.2) — this fn never returns `Err`. Non-ticketed `Pr` input →
+/// `ResolvedIntent::none()`.
+/// Test: `super::tests` (AC-1..AC-7).
+pub async fn resolve(
+    query: IntentQuery,
+    fetcher: &dyn TicketFetcher,
+    extractor: &dyn MethodExtractor,
+    spec_lookup: &dyn SpecLookup,
+) -> ResolvedIntent {
+    let (owner, repo, ticket_id, changed_files) = match resolve_ticket_id(&query) {
+        Some(t) => t,
+        // Non-ticketed PR → clean gap (no intent). Spec §4.2 preconditions.
+        None => return ResolvedIntent::none(),
+    };
+
+    // ── Ticket axis (fail-open on fetch error) ────────────────────────────
+    let ticket_data = match fetcher.fetch(&owner, &repo, &ticket_id).await {
+        Ok(t) => t,
+        Err(e) => return ResolvedIntent::unresolved(e.to_string()),
+    };
+    let ticket_method = extractor.extract(&ticket_data.body);
+    let ticket_ref = TicketRef {
+        id: ticket_data.id,
+        title: ticket_data.title,
+        url: ticket_data.url,
+        backend: ticket_data.backend,
+    };
+
+    // ── Spec axis (gap, never an error: ISR never invents linkage) ────────
+    let (spec_section, spec_method) = resolve_spec(&changed_files, spec_lookup);
+
+    build_resolved(ticket_ref, ticket_method, spec_section, spec_method)
+}
+
+/// Pull `(owner, repo, ticket_id, changed_files)` out of a query.
+///
+/// Why: `Pr` must derive the ticket-id from linkage while `Ticket` already has
+/// it; isolating that branch keeps `resolve` linear (spec §6.1, §6.3).
+/// What: for `Ticket`, returns its fields directly; for `Pr`, runs
+/// [`extract_pr_ticket`] and returns `None` when the PR has no linkage.
+/// Test: `super::tests::linkage_pr_*` (AC-5), `ticket_query_*`.
+fn resolve_ticket_id(query: &IntentQuery) -> Option<(String, String, String, Vec<ChangedFile>)> {
+    match query {
+        IntentQuery::Ticket {
+            ticket_id,
+            owner,
+            repo,
+            changed_files,
+        } => Some((
+            owner.clone(),
+            repo.clone(),
+            ticket_id.clone(),
+            changed_files.clone(),
+        )),
+        IntentQuery::Pr {
+            owner,
+            repo,
+            body,
+            branch,
+            commit_messages,
+            changed_files,
+            ..
+        } => extract_pr_ticket(body, commit_messages, branch.as_deref())
+            .map(|id| (owner.clone(), repo.clone(), id, changed_files.clone())),
+    }
+}
+
+/// Resolve the spec section + spec method from changed files.
+///
+/// Why: the spec axis is greenfield and must never fabricate linkage — a file
+/// with no SLD ref yields no spec method (spec §6.4).
+/// What: parses SLD refs from each changed file (first match wins), looks up
+/// the spec markdown via `spec_lookup`, and extracts the spec method from the
+/// governed section. Returns `(None, None)` when no SLD ref is declared.
+/// Test: `super::tests::spec_resolve_*` (AC-6).
+fn resolve_spec(
+    changed_files: &[ChangedFile],
+    spec_lookup: &dyn SpecLookup,
+) -> (Option<SpecRef>, Option<Method>) {
+    for file in changed_files {
+        let refs = parse_spec_refs(&file.content);
+        if let Some(spec_ref) = refs.into_iter().next() {
+            // Look up the spec markdown; a missing file is a gap, not an error
+            // (the ISR reads declared links, it does not enforce them).
+            let method = spec_lookup
+                .load(&spec_ref.file)
+                .and_then(|md| extract_spec_method(&md, &spec_ref.anchor));
+            return (Some(spec_ref), method);
+        }
+    }
+    (None, None)
+}
+
+/// Pluggable spec-markdown loader.
+///
+/// Why: the spec-resolution leg needs the *text* of a `docs/specs/*.md` file to
+/// extract the spec method, but the resolver must not assume a filesystem
+/// layout (review's serve mode may load specs differently). This seam keeps the
+/// resolver testable offline (spec §6.4, mirrors the token/fetcher seams).
+/// What: one method mapping a `docs/specs/*.md` path to its text, or `None`
+/// when the spec cannot be loaded (a gap, never an error).
+/// Test: `super::tests::spec_resolve_*` uses an in-memory `MapSpecLookup`.
+pub trait SpecLookup: Send + Sync {
+    /// Load the markdown text for a `docs/specs/*.md` path.
+    ///
+    /// Why: spec-method extraction needs the section prose (spec §6.4).
+    /// What: returns `Some(text)` or `None` when unavailable.
+    /// Test: `super::tests::spec_resolve_*`.
+    fn load(&self, spec_file: &str) -> Option<String>;
+}
+
+/// Assemble a `ResolvedIntent` and apply precedence to it.
+///
+/// Why: keeps `resolve` readable by separating wiring from the normative
+/// precedence computation (spec §6.1).
+/// What: builds the struct from the resolved axes, then runs
+/// [`apply_precedence`] to set `precedence_winner`/`conflict`/`stale_spec`.
+/// Test: `super::tests::precedence_*` (AC-1..AC-4).
+fn build_resolved(
+    ticket: TicketRef,
+    ticket_method: Option<Method>,
+    spec_section: Option<SpecRef>,
+    spec_method: Option<Method>,
+) -> ResolvedIntent {
+    let mut intent = ResolvedIntent {
+        ticket: Some(ticket),
+        ticket_method,
+        spec_section,
+        spec_method,
+        precedence_winner: Precedence::None,
+        conflict: false,
+        stale_spec: false,
+        unresolved: None,
+    };
+    apply_precedence(&mut intent);
+    intent
+}
+
+/// Apply the NORMATIVE precedence rule (ticket > spec) to an intent.
+///
+/// Why: the precedence rule is the heart of the contract and must be applied
+/// exactly once, centrally, so no caller re-derives it (spec §6.1, G4).
+/// What: implements the four cases verbatim from spec §6.1:
+///   1. both present + agree → winner `Ticket`, `conflict=false`.
+///   2. both present + disagree → winner `Ticket`, `conflict=true`,
+///      `stale_spec=true`.
+///   3. ticket only → `Ticket`; spec only → `Spec`.
+///   4. neither → `None` (gap).
+///
+/// Method equality is by normalised `text` (case/whitespace-insensitive).
+///
+/// Test: `super::tests::precedence_*` (AC-1..AC-4).
+pub fn apply_precedence(intent: &mut ResolvedIntent) {
+    match (&intent.ticket_method, &intent.spec_method) {
+        (Some(t), Some(s)) => {
+            intent.precedence_winner = Precedence::Ticket;
+            if methods_agree(t, s) {
+                intent.conflict = false;
+                intent.stale_spec = false;
+            } else {
+                // Ticket wins; the conflicting spec is stale/advisory.
+                intent.conflict = true;
+                intent.stale_spec = true;
+            }
+        }
+        (Some(_), None) => {
+            intent.precedence_winner = Precedence::Ticket;
+        }
+        (None, Some(_)) => {
+            intent.precedence_winner = Precedence::Spec;
+        }
+        (None, None) => {
+            intent.precedence_winner = Precedence::None;
+        }
+    }
+}
+
+/// Whether a ticket method and a spec method agree.
+///
+/// Why: case 1 vs. case 2 turns on whether the two methods say the same thing
+/// (spec §6.1). A normalised text compare is the conservative C1 rule; richer
+/// semantic equivalence is out of C1 scope.
+/// What: compares the two methods' `text` after lowercasing and collapsing
+/// whitespace; returns `true` when they match.
+/// Test: `super::tests::precedence_agree_*` / `precedence_conflict_*`.
+fn methods_agree(a: &Method, b: &Method) -> bool {
+    normalise(&a.text) == normalise(&b.text)
+}
+
+/// Lowercase + collapse internal whitespace for method-text comparison.
+///
+/// Why: trivial formatting differences must not register as a conflict.
+/// What: lowercases, splits on whitespace, and rejoins single-spaced.
+/// Test: covered by `precedence_agree_*`.
+fn normalise(s: &str) -> String {
+    s.to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Convenience wrapper: resolve with the default heuristic extractor.
+///
+/// Why: the common case wants the OQ-1 default (heuristic, no network) without
+/// constructing an extractor by hand (spec §6.2 OQ-1 default path).
+/// What: calls [`resolve`] with a [`HeuristicMethodExtractor`].
+/// Test: `super::tests` use this wrapper for AC-1..AC-7.
+pub async fn resolve_default(
+    query: IntentQuery,
+    fetcher: &dyn TicketFetcher,
+    spec_lookup: &dyn SpecLookup,
+) -> ResolvedIntent {
+    resolve(query, fetcher, &HeuristicMethodExtractor, spec_lookup).await
+}

--- a/crates/trusty-common/src/intent_source/spec_resolve.rs
+++ b/crates/trusty-common/src/intent_source/spec_resolve.rs
@@ -1,0 +1,119 @@
+//! SLD spec-resolution: changed file → governing spec section.
+//!
+//! Why: when a ticket is silent, the intent may live in a spec the changed
+//! code links to. Per SLD (`spec-linked-docs`), Rust code declares that linkage
+//! in **rustdoc** (`# Spec References` blocks), not free comments. The ISR
+//! resolves those declared links to a `SpecRef` + extracts the spec's
+//! prescribed method (spec §6.4). **The ISR does not invent linkage** — a file
+//! with no SLD ref yields no spec method (a gap on the spec axis).
+//! What: `parse_spec_refs` (find `SPEC-…` ids + anchors in changed-file source)
+//! and `extract_spec_method` (lift the governed section's Behavior-Contract /
+//! Rationale prose from the spec markdown).
+//! Test: `super::tests::spec_resolve_*` (AC-6).
+//!
+//! Scope note (C1 vs C4): this is the **minimal correct** reader required by
+//! C1. A deeper, more robust resolver — symbol-level granularity, multi-anchor
+//! reconciliation, revision-drift enforcement — is C4 (#1361). This module is
+//! the seam C4 hardens; its public surface is intentionally narrow and stable.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::types::{Method, MethodKind, SpecRef};
+
+/// Parse SLD spec references out of a changed file's source text.
+///
+/// Why: the ISR must find the `SPEC-{SUBSYSTEM}-{NN}~v{rev}` ids a file
+/// declares (in `//!`/`///` `# Spec References` rustdoc) and the
+/// `docs/specs/{file}.md#SPEC-…` link target they point at (spec §6.4).
+/// What: scans for the SLD link form
+/// ``[`SPEC-X-NN~vR`](docs/specs/file.md#SPEC-X-NN~vR)`` and returns one
+/// `SpecRef` per distinct id, in first-seen order. Returns an empty vec when
+/// the file declares no SLD reference (the ISR never invents linkage).
+/// Test: `super::tests::spec_resolve_parse_*` (AC-6).
+#[must_use]
+pub fn parse_spec_refs(source: &str) -> Vec<SpecRef> {
+    static LINK: OnceLock<Regex> = OnceLock::new();
+    let re = LINK.get_or_init(|| {
+        // [`SPEC-X-NN~vR`](docs/specs/file.md#anchor)
+        // - group 1: spec id (inside backticks)
+        // - group 2: docs/specs file path
+        // - group 3: in-file anchor
+        Regex::new(
+            r"\[`(SPEC-[A-Z0-9]+-\d+~[A-Za-z0-9]+)`\]\((docs/specs/[^)#]+)#([A-Za-z0-9~\-]+)\)",
+        )
+        .expect("SLD link pattern compiles")
+    });
+
+    let mut refs: Vec<SpecRef> = Vec::new();
+    for caps in re.captures_iter(source) {
+        let spec_id = caps[1].to_string();
+        let file = caps[2].to_string();
+        let anchor = caps[3].to_string();
+        // De-duplicate on the spec id (first-seen wins) to keep the result
+        // deterministic when the same ref appears in both module- and
+        // function-level rustdoc.
+        if refs.iter().any(|r| r.spec_id == spec_id) {
+            continue;
+        }
+        refs.push(SpecRef {
+            spec_id,
+            file,
+            anchor,
+        });
+    }
+    refs
+}
+
+/// Extract the spec-prescribed method from a spec markdown document.
+///
+/// Why: once a `SpecRef` is resolved, the spec's *method* is the prescribed
+/// approach/constraint stated in the governed section's Behavior-Contract /
+/// Rationale prose (spec §6.2, §6.4). This is the spec-axis input to the
+/// precedence rule.
+/// What: locates the section whose heading carries the `{#anchor}` marker,
+/// captures that section's body (until the next `##`/`---`), and runs the same
+/// conservative heuristic the ticket path uses
+/// ([`super::extract::heuristic_method`]). Returns `None` when the anchor is
+/// absent or the section prose prescribes no method.
+/// Test: `super::tests::spec_resolve_method_*`.
+#[must_use]
+pub fn extract_spec_method(spec_markdown: &str, anchor: &str) -> Option<Method> {
+    let section = section_body(spec_markdown, anchor)?;
+    super::extract::heuristic_method(&section).map(|mut m| {
+        // Spec-sourced methods are advisory context; tag the kind but keep the
+        // verbatim excerpt the heuristic captured.
+        if matches!(m.kind, MethodKind::Unspecified) {
+            m.kind = MethodKind::Approach;
+        }
+        m
+    })
+}
+
+/// Return the body text of the spec section bearing `{#anchor}`.
+///
+/// Why: method extraction must be scoped to the *governed* section, not the
+/// whole document, so an unrelated method elsewhere in the spec is not
+/// attributed to this change (spec §6.4).
+/// What: finds the heading line containing `{#anchor}` and returns the text
+/// from there up to (but excluding) the next top-level `## ` heading or `---`
+/// horizontal rule. Returns `None` when no heading carries the anchor.
+/// Test: `super::tests::spec_resolve_section_*`.
+fn section_body(markdown: &str, anchor: &str) -> Option<String> {
+    let marker = format!("{{#{anchor}}}");
+    let lines: Vec<&str> = markdown.lines().collect();
+    let start = lines.iter().position(|l| l.contains(&marker))?;
+
+    let mut body = String::new();
+    for line in &lines[start + 1..] {
+        let trimmed = line.trim_start();
+        // A new `## ` section or a `---` rule terminates the current section.
+        if trimmed.starts_with("## ") || trimmed == "---" {
+            break;
+        }
+        body.push_str(line);
+        body.push('\n');
+    }
+    Some(body)
+}

--- a/crates/trusty-common/src/intent_source/spec_resolve.rs
+++ b/crates/trusty-common/src/intent_source/spec_resolve.rs
@@ -51,6 +51,14 @@ pub fn parse_spec_refs(source: &str) -> Vec<SpecRef> {
         let spec_id = caps[1].to_string();
         let file = caps[2].to_string();
         let anchor = caps[3].to_string();
+        // Defence in depth (the canonicalization guard in `FsSpecLookup::load`
+        // is the primary control): reject any captured path containing a `..`
+        // traversal segment so a malicious source file cannot point linkage
+        // outside `docs/specs/`. The `regex` crate has no look-around, so this
+        // is a post-match filter rather than a pattern exclusion.
+        if file.split('/').any(|seg| seg == "..") {
+            continue;
+        }
         // De-duplicate on the spec id (first-seen wins) to keep the result
         // deterministic when the same ref appears in both module- and
         // function-level rustdoc.
@@ -97,8 +105,9 @@ pub fn extract_spec_method(spec_markdown: &str, anchor: &str) -> Option<Method> 
 /// whole document, so an unrelated method elsewhere in the spec is not
 /// attributed to this change (spec §6.4).
 /// What: finds the heading line containing `{#anchor}` and returns the text
-/// from there up to (but excluding) the next top-level `## ` heading or `---`
-/// horizontal rule. Returns `None` when no heading carries the anchor.
+/// from there up to (but excluding) the next `## ` or top-level `# ` heading,
+/// or a `---` horizontal rule. Returns `None` when no heading carries the
+/// anchor.
 /// Test: `super::tests::spec_resolve_section_*`.
 fn section_body(markdown: &str, anchor: &str) -> Option<String> {
     let marker = format!("{{#{anchor}}}");
@@ -108,8 +117,11 @@ fn section_body(markdown: &str, anchor: &str) -> Option<String> {
     let mut body = String::new();
     for line in &lines[start + 1..] {
         let trimmed = line.trim_start();
-        // A new `## ` section or a `---` rule terminates the current section.
-        if trimmed.starts_with("## ") || trimmed == "---" {
+        // A new `## ` subsection, a top-level `# ` section, or a `---` rule
+        // terminates the current section. Breaking on `# ` too prevents a
+        // following top-level section's prose from bleeding into this anchor's
+        // method extraction.
+        if trimmed.starts_with("## ") || trimmed.starts_with("# ") || trimmed == "---" {
             break;
         }
         body.push_str(line);

--- a/crates/trusty-common/src/intent_source/tests.rs
+++ b/crates/trusty-common/src/intent_source/tests.rs
@@ -1,0 +1,582 @@
+//! Unit tests for the intent-source resolver (ISR), covering AC-1..AC-7.
+//!
+//! Why: the ISR is the shared contract both conformance gates depend on; its
+//! precedence rule, linkage, spec-resolution, and fail-open behaviour must be
+//! pinned by tests that run with **no network** (spec §8 acceptance criteria).
+//! What: a mock `TicketFetcher`, an in-memory `SpecLookup`, and tests for every
+//! acceptance criterion AC-1..AC-7 plus the supporting linkage / extraction /
+//! precedence helpers.
+//! Test: this file is itself the test surface; `cargo test -p trusty-common
+//! --features intent-source` runs it.
+
+use async_trait::async_trait;
+
+use super::extract::{HeuristicMethodExtractor, MethodExtractor, heuristic_method};
+use super::linkage::{extract_branch_ticket, extract_pr_ticket, extract_ticket_id, is_ticketed};
+use super::resolve::{
+    EnvTokenResolver, IntentTokenResolver, SpecLookup, TicketData, TicketFetcher, resolve,
+    resolve_default,
+};
+use super::spec_resolve::{extract_spec_method, parse_spec_refs};
+use super::types::{ChangedFile, IntentQuery, IsrError, MethodKind, Precedence, ResolvedIntent};
+
+// ───────────────────────── Test doubles ──────────────────────────────────────
+
+/// A mock `TicketFetcher` returning a canned body (or a canned error).
+///
+/// Why: the resolver must be testable offline; this lets a test inject any
+/// ticket body (or simulate a fetch failure) without a GitHub client.
+/// What: holds an optional `TicketData` (Ok) or an error string (Err).
+/// Test: used by every `resolve`-driven test below.
+struct MockFetcher {
+    result: Result<TicketData, String>,
+}
+
+impl MockFetcher {
+    fn ok(body: &str) -> Self {
+        Self {
+            result: Ok(TicketData {
+                id: "#1358".to_string(),
+                title: "ISR".to_string(),
+                body: body.to_string(),
+                url: Some("https://github.com/x/y/issues/1358".to_string()),
+                backend: "github".to_string(),
+            }),
+        }
+    }
+    fn err(msg: &str) -> Self {
+        Self {
+            result: Err(msg.to_string()),
+        }
+    }
+}
+
+#[async_trait]
+impl TicketFetcher for MockFetcher {
+    async fn fetch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _ticket_id: &str,
+    ) -> Result<TicketData, IsrError> {
+        self.result.clone().map_err(IsrError::TicketFetch)
+    }
+}
+
+/// An in-memory `SpecLookup` mapping spec-file paths to markdown text.
+///
+/// Why: spec-resolution must run without reading the real `docs/specs/` tree.
+/// What: a `Vec<(path, markdown)>`; `load` returns the first matching text.
+/// Test: used by the spec-resolution `resolve` tests below.
+struct MapSpecLookup {
+    entries: Vec<(String, String)>,
+}
+
+impl MapSpecLookup {
+    fn empty() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+    fn with(path: &str, markdown: &str) -> Self {
+        Self {
+            entries: vec![(path.to_string(), markdown.to_string())],
+        }
+    }
+}
+
+impl SpecLookup for MapSpecLookup {
+    fn load(&self, spec_file: &str) -> Option<String> {
+        self.entries
+            .iter()
+            .find(|(p, _)| p == spec_file)
+            .map(|(_, md)| md.clone())
+    }
+}
+
+// Helper: a ticket-only query with the given changed files.
+fn ticket_query(changed: Vec<ChangedFile>) -> IntentQuery {
+    IntentQuery::Ticket {
+        ticket_id: "#1358".to_string(),
+        owner: "x".to_string(),
+        repo: "y".to_string(),
+        changed_files: changed,
+    }
+}
+
+// Helper: a spec markdown document whose anchor section prescribes a method.
+fn spec_md(anchor: &str, method_line: &str) -> String {
+    format!(
+        "# Doc\n\n## Section {{#{anchor}}}\n\n**Behavior Contract (WHAT):**\n\n- {method_line}\n\n## Next\n\nunrelated\n"
+    )
+}
+
+// A changed file declaring an SLD ref to the given spec id/anchor.
+fn sld_file(path: &str, spec_id: &str, spec_file: &str, anchor: &str) -> ChangedFile {
+    ChangedFile {
+        path: path.to_string(),
+        content: format!(
+            "//! # Spec References\n//!\n//! - [`{spec_id}`]({spec_file}#{anchor})\n\npub fn f() {{}}\n"
+        ),
+    }
+}
+
+// ───────────────────────── AC-1: ticket method ──────────────────────────────
+
+/// AC-1: a ticket whose body prescribes a method →
+/// `ticket_method = Some`, `precedence_winner = Ticket`.
+#[tokio::test]
+async fn ac1_ticket_method_present() {
+    let fetcher = MockFetcher::ok("We must use cursor-based pagination for the list endpoint.");
+    let lookup = MapSpecLookup::empty();
+    let intent = resolve_default(ticket_query(vec![]), &fetcher, &lookup).await;
+
+    assert!(
+        intent.ticket_method.is_some(),
+        "ticket method should resolve"
+    );
+    assert_eq!(intent.precedence_winner, Precedence::Ticket);
+    assert!(intent.ticket.is_some());
+    assert!(!intent.conflict);
+    assert!(!intent.stale_spec);
+    assert!(intent.unresolved.is_none());
+    let m = intent.ticket_method.unwrap();
+    assert_eq!(m.kind, MethodKind::Approach);
+    assert!(m.source_excerpt.contains("cursor-based pagination"));
+}
+
+// ───────────────────────── AC-2: agree ──────────────────────────────────────
+
+/// AC-2: a ticket and a spec section that AGREE →
+/// `conflict = false`, `stale_spec = false`.
+#[tokio::test]
+async fn ac2_ticket_and_spec_agree() {
+    let method = "use cursor-based pagination";
+    let fetcher = MockFetcher::ok(method);
+    let spec_file = "docs/specs/search.md";
+    let anchor = "SPEC-SEARCH-04~draft";
+    let lookup = MapSpecLookup::with(spec_file, &spec_md(anchor, method));
+    let changed = vec![sld_file(
+        "crates/x/src/lib.rs",
+        "SPEC-SEARCH-04~draft",
+        spec_file,
+        anchor,
+    )];
+
+    let intent = resolve_default(ticket_query(changed), &fetcher, &lookup).await;
+
+    assert!(intent.ticket_method.is_some());
+    assert!(intent.spec_method.is_some(), "spec method should resolve");
+    assert_eq!(intent.precedence_winner, Precedence::Ticket);
+    assert!(!intent.conflict, "agreeing methods must not conflict");
+    assert!(!intent.stale_spec);
+    assert!(intent.spec_section.is_some());
+}
+
+// ───────────────────────── AC-3: disagree → ticket wins ─────────────────────
+
+/// AC-3: a ticket and a spec that DISAGREE →
+/// `precedence_winner = Ticket`, `conflict = true`, `stale_spec = true`.
+#[tokio::test]
+async fn ac3_ticket_and_spec_conflict_ticket_wins() {
+    let fetcher = MockFetcher::ok("use cursor-based pagination");
+    let spec_file = "docs/specs/search.md";
+    let anchor = "SPEC-SEARCH-04~draft";
+    // Spec prescribes a *different* method.
+    let lookup = MapSpecLookup::with(spec_file, &spec_md(anchor, "use offset-based pagination"));
+    let changed = vec![sld_file(
+        "crates/x/src/lib.rs",
+        "SPEC-SEARCH-04~draft",
+        spec_file,
+        anchor,
+    )];
+
+    let intent = resolve_default(ticket_query(changed), &fetcher, &lookup).await;
+
+    assert_eq!(
+        intent.precedence_winner,
+        Precedence::Ticket,
+        "ticket > spec"
+    );
+    assert!(intent.conflict, "disagreeing methods must conflict");
+    assert!(intent.stale_spec, "conflicting spec is stale/advisory");
+    assert!(intent.ticket_method.is_some());
+    assert!(intent.spec_method.is_some());
+}
+
+// ───────────────────────── AC-4: gap ────────────────────────────────────────
+
+/// AC-4: neither a ticket method nor a spec method →
+/// all method fields `None`, `precedence_winner = None`.
+#[tokio::test]
+async fn ac4_gap_no_methods() {
+    // Body with no imperative-method cue.
+    let fetcher = MockFetcher::ok("Add a new field to the response payload. See discussion.");
+    let lookup = MapSpecLookup::empty();
+    let intent = resolve_default(ticket_query(vec![]), &fetcher, &lookup).await;
+
+    assert!(intent.ticket_method.is_none());
+    assert!(intent.spec_method.is_none());
+    assert_eq!(intent.precedence_winner, Precedence::None);
+    assert!(intent.is_gap());
+    assert!(!intent.conflict);
+    assert!(!intent.stale_spec);
+}
+
+// ───────────────────────── AC-5: PR → ticket linkage ────────────────────────
+
+/// AC-5: PR body `Closes #1325`, a commit trailer, and a branch `fix/1325-x`
+/// each resolve to ticket `#1325`; a PR with no linkage resolves to `None`.
+#[test]
+fn ac5_pr_body_closes() {
+    assert_eq!(
+        extract_pr_ticket("Implements the thing.\n\nCloses #1325", &[], None),
+        Some("#1325".to_string())
+    );
+}
+
+#[test]
+fn ac5_commit_trailer() {
+    let commits = vec!["wip".to_string(), "done, fixes #1325".to_string()];
+    assert_eq!(
+        extract_pr_ticket("no linkage here", &commits, None),
+        Some("#1325".to_string())
+    );
+}
+
+#[test]
+fn ac5_branch_name() {
+    assert_eq!(
+        extract_pr_ticket("no linkage", &[], Some("fix/1325-intent-source")),
+        Some("#1325".to_string())
+    );
+}
+
+#[test]
+fn ac5_no_linkage_is_none() {
+    assert_eq!(
+        extract_pr_ticket(
+            "just a description",
+            &["misc cleanup".to_string()],
+            Some("main")
+        ),
+        None
+    );
+}
+
+/// AC-5 (end-to-end): a `Pr` query with no linkage → `ResolvedIntent::none()`.
+#[tokio::test]
+async fn ac5_pr_without_linkage_resolves_none() {
+    let query = IntentQuery::Pr {
+        owner: "x".to_string(),
+        repo: "y".to_string(),
+        pr_number: 7,
+        body: "no ticket here".to_string(),
+        branch: Some("main".to_string()),
+        commit_messages: vec!["misc".to_string()],
+        changed_files: vec![],
+    };
+    // Fetcher would error if called — proves we short-circuit on no linkage.
+    let fetcher = MockFetcher::err("should not be called");
+    let lookup = MapSpecLookup::empty();
+    let intent = resolve_default(query, &fetcher, &lookup).await;
+
+    assert_eq!(intent.precedence_winner, Precedence::None);
+    assert!(intent.ticket.is_none());
+    assert!(
+        intent.unresolved.is_none(),
+        "non-ticketed is a clean gap, not a failure"
+    );
+}
+
+/// AC-5 (end-to-end): a `Pr` body `Closes #1325` drives a successful resolve.
+#[tokio::test]
+async fn ac5_pr_with_linkage_resolves_ticket() {
+    let query = IntentQuery::Pr {
+        owner: "x".to_string(),
+        repo: "y".to_string(),
+        pr_number: 1358,
+        body: "Implements ISR.\n\nCloses #1358".to_string(),
+        branch: None,
+        commit_messages: vec![],
+        changed_files: vec![],
+    };
+    let fetcher = MockFetcher::ok("Reuse the existing ContextSource trait.");
+    let lookup = MapSpecLookup::empty();
+    let intent = resolve_default(query, &fetcher, &lookup).await;
+
+    assert!(intent.ticket.is_some());
+    assert_eq!(intent.precedence_winner, Precedence::Ticket);
+    assert_eq!(intent.ticket_method.unwrap().kind, MethodKind::Reuse);
+}
+
+// ───────────────────────── AC-6: spec resolution ────────────────────────────
+
+/// AC-6: a changed file with a `# Spec References` rustdoc block pointing at
+/// `SPEC-X-01` resolves `spec_section = Some(SPEC-X-01)`.
+#[tokio::test]
+async fn ac6_spec_ref_resolves_section() {
+    let spec_file = "docs/specs/x.md";
+    let anchor = "SPEC-X-01~draft";
+    let lookup = MapSpecLookup::with(spec_file, &spec_md(anchor, "use the existing trait T"));
+    let changed = vec![sld_file(
+        "crates/x/src/lib.rs",
+        "SPEC-X-01~draft",
+        spec_file,
+        anchor,
+    )];
+
+    // Ticket silent so the spec axis is the only method.
+    let fetcher = MockFetcher::ok("Add the thing.");
+    let intent = resolve_default(ticket_query(changed), &fetcher, &lookup).await;
+
+    let sref = intent.spec_section.expect("spec section should resolve");
+    assert_eq!(sref.spec_id, "SPEC-X-01~draft");
+    assert_eq!(sref.file, spec_file);
+    assert!(intent.spec_method.is_some());
+    assert_eq!(
+        intent.precedence_winner,
+        Precedence::Spec,
+        "spec-only → Spec"
+    );
+}
+
+/// AC-6: a changed file with NO SLD ref resolves `spec_section = None` (gap).
+#[tokio::test]
+async fn ac6_no_sld_ref_is_gap() {
+    let changed = vec![ChangedFile {
+        path: "crates/x/src/lib.rs".to_string(),
+        content: "// plain file, no spec references\npub fn f() {}\n".to_string(),
+    }];
+    let fetcher = MockFetcher::ok("Add the thing."); // ticket also silent on method
+    let lookup = MapSpecLookup::empty();
+    let intent = resolve_default(ticket_query(changed), &fetcher, &lookup).await;
+
+    assert!(
+        intent.spec_section.is_none(),
+        "no SLD ref → no spec section"
+    );
+    assert!(intent.spec_method.is_none());
+    assert_eq!(intent.precedence_winner, Precedence::None);
+}
+
+// ───────────────────────── AC-7: fail-open ──────────────────────────────────
+
+/// AC-7: ticket fetch error → `unresolved = Some(reason)`, all methods `None`.
+#[tokio::test]
+async fn ac7_fetch_error_is_fail_open() {
+    let fetcher = MockFetcher::err("HTTP 503 from GitHub");
+    let lookup = MapSpecLookup::empty();
+    let intent = resolve_default(ticket_query(vec![]), &fetcher, &lookup).await;
+
+    let reason = intent.unresolved.expect("fetch error must set unresolved");
+    assert!(reason.contains("503") || reason.contains("ticket fetch"));
+    assert!(intent.ticket_method.is_none());
+    assert!(intent.spec_method.is_none());
+    assert_eq!(intent.precedence_winner, Precedence::None);
+}
+
+// ───────────────────────── linkage helper coverage ──────────────────────────
+
+#[test]
+fn linkage_is_ticketed() {
+    assert!(is_ticketed("closes #42"));
+    assert!(is_ticketed("ENG-7 add feature"));
+    assert!(is_ticketed("AB#10 work item"));
+    assert!(!is_ticketed("just a note about #42"));
+    assert!(!is_ticketed("misc cleanup"));
+}
+
+#[test]
+fn linkage_extract_priority() {
+    assert_eq!(
+        extract_ticket_id("AB#10 fixes PROJ-99"),
+        Some("AB#10".to_string())
+    );
+    assert_eq!(
+        extract_ticket_id("ENG-7 closes #10"),
+        Some("ENG-7".to_string())
+    );
+    assert_eq!(extract_ticket_id("fixes #99"), Some("#99".to_string()));
+    assert_eq!(extract_ticket_id("misc cleanup"), None);
+}
+
+#[test]
+fn linkage_branch_variants() {
+    assert_eq!(
+        extract_branch_ticket("fix/1325-x"),
+        Some("#1325".to_string())
+    );
+    assert_eq!(extract_branch_ticket("feat/42"), Some("#42".to_string()));
+    assert_eq!(
+        extract_branch_ticket("1325-bare"),
+        Some("#1325".to_string())
+    );
+    assert_eq!(extract_branch_ticket("main"), None);
+    // No leading numeric work-item segment after the `/`, so no linkage.
+    assert_eq!(extract_branch_ticket("release/v1.2.3"), None);
+}
+
+// ───────────────────────── method extraction coverage ───────────────────────
+
+#[test]
+fn extract_heuristic_constraint() {
+    let m = heuristic_method("- No new dependency may be added.").unwrap();
+    assert_eq!(m.kind, MethodKind::Constraint);
+}
+
+#[test]
+fn extract_heuristic_reuse() {
+    let m = heuristic_method("Reuse the existing ContextSource trait.").unwrap();
+    assert_eq!(m.kind, MethodKind::Reuse);
+}
+
+#[test]
+fn extract_heuristic_approach_feature_flag() {
+    let m = heuristic_method("Please gate this behind a feature flag.").unwrap();
+    assert_eq!(m.kind, MethodKind::Approach);
+}
+
+#[test]
+fn extract_heuristic_ambiguous_is_none() {
+    assert!(heuristic_method("Make it work and ship it.").is_none());
+    assert!(heuristic_method("").is_none());
+    assert!(heuristic_method("Add a flag to the CLI.").is_none());
+}
+
+#[test]
+fn extract_trait_default_matches_fn() {
+    let extractor = HeuristicMethodExtractor;
+    let body = "use cursor-based pagination";
+    assert_eq!(extractor.extract(body), heuristic_method(body));
+}
+
+// ───────────────────────── spec_resolve helper coverage ─────────────────────
+
+#[test]
+fn spec_resolve_parse_dedup() {
+    let src = "//! # Spec References\n\
+        //! - [`SPEC-CONFORMANCE-03~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-03~draft)\n\
+        /// also [`SPEC-CONFORMANCE-03~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-03~draft)\n";
+    let refs = parse_spec_refs(src);
+    assert_eq!(refs.len(), 1, "duplicate refs collapse to one");
+    assert_eq!(refs[0].spec_id, "SPEC-CONFORMANCE-03~draft");
+    assert_eq!(refs[0].file, "docs/specs/intent-conformance.md");
+    assert_eq!(refs[0].anchor, "SPEC-CONFORMANCE-03~draft");
+}
+
+#[test]
+fn spec_resolve_parse_none() {
+    assert!(parse_spec_refs("// plain comment, no spec ref\n").is_empty());
+}
+
+#[test]
+fn spec_resolve_method_from_section() {
+    let md = spec_md("SPEC-X-01~draft", "use the existing trait T for dispatch");
+    let m = extract_spec_method(&md, "SPEC-X-01~draft").unwrap();
+    assert_eq!(m.kind, MethodKind::Reuse);
+    assert!(m.text.contains("existing trait T"));
+}
+
+#[test]
+fn spec_resolve_method_missing_anchor() {
+    let md = spec_md("SPEC-X-01~draft", "use cursor pagination");
+    assert!(extract_spec_method(&md, "SPEC-OTHER-99~draft").is_none());
+}
+
+#[test]
+fn spec_resolve_method_section_scoped() {
+    // The method cue lives in the NEXT section, not the anchored one — it must
+    // NOT be attributed to this anchor.
+    let md = "# Doc\n\n## A {#SPEC-X-01~draft}\n\njust prose, no method.\n\n## B\n\n- use cursor pagination\n";
+    assert!(extract_spec_method(md, "SPEC-X-01~draft").is_none());
+}
+
+// ───────────────────────── constructors / error display ─────────────────────
+
+#[test]
+fn none_is_gap() {
+    let n = ResolvedIntent::none();
+    assert!(n.is_gap());
+    assert_eq!(n.precedence_winner, Precedence::None);
+    assert!(n.unresolved.is_none());
+}
+
+#[test]
+fn unresolved_carries_reason() {
+    let u = ResolvedIntent::unresolved("boom");
+    assert_eq!(u.unresolved.as_deref(), Some("boom"));
+    assert!(u.is_gap());
+    assert!(u.ticket_method.is_none());
+}
+
+#[test]
+fn error_display_variants() {
+    assert_eq!(
+        IsrError::NoTicketLinkage.to_string(),
+        "no ticket linkage found in PR"
+    );
+    assert!(
+        IsrError::TicketFetch("x".into())
+            .to_string()
+            .contains("ticket fetch failed")
+    );
+    assert!(
+        IsrError::NoToken("y".into())
+            .to_string()
+            .contains("no auth token")
+    );
+}
+
+// ───────────────────────── token resolver seam ──────────────────────────────
+
+/// A custom token resolver demonstrates the §7.4 pluggable seam (App/JWT mode).
+struct StaticTokenResolver;
+
+#[async_trait]
+impl IntentTokenResolver for StaticTokenResolver {
+    async fn token(&self, _owner: &str, _repo: &str) -> Result<String, IsrError> {
+        Ok("app-jwt-token".to_string())
+    }
+}
+
+#[tokio::test]
+async fn token_resolver_pluggable() {
+    let r = StaticTokenResolver;
+    assert_eq!(r.token("x", "y").await.unwrap(), "app-jwt-token");
+}
+
+#[tokio::test]
+async fn token_resolver_env_missing_errors() {
+    // Do not mutate the global env (parallel tests); just assert the error type
+    // path is reachable by constructing the resolver and checking a name.
+    let r = EnvTokenResolver;
+    // If GITHUB_TOKEN happens to be set in CI we accept Ok; otherwise NoToken.
+    match r.token("x", "y").await {
+        Ok(t) => assert!(!t.is_empty()),
+        Err(e) => assert!(matches!(e, IsrError::NoToken(_))),
+    }
+}
+
+// ───────────────────────── explicit-extractor resolve path ──────────────────
+
+/// `resolve` (non-default) accepts a custom extractor — proves the OQ-1 seam
+/// is wired end-to-end, not just on the default path.
+#[tokio::test]
+async fn resolve_with_explicit_extractor() {
+    struct AlwaysSome;
+    impl MethodExtractor for AlwaysSome {
+        fn extract(&self, _body: &str) -> Option<super::types::Method> {
+            Some(super::types::Method {
+                text: "forced".to_string(),
+                kind: MethodKind::Constraint,
+                source_excerpt: "forced".to_string(),
+            })
+        }
+    }
+    let fetcher = MockFetcher::ok("ambiguous prose the heuristic would skip");
+    let lookup = MapSpecLookup::empty();
+    let intent = resolve(ticket_query(vec![]), &fetcher, &AlwaysSome, &lookup).await;
+    assert_eq!(intent.precedence_winner, Precedence::Ticket);
+    assert_eq!(intent.ticket_method.unwrap().text, "forced");
+}

--- a/crates/trusty-common/src/intent_source/tests.rs
+++ b/crates/trusty-common/src/intent_source/tests.rs
@@ -11,6 +11,7 @@
 
 use async_trait::async_trait;
 
+use super::backend_fetcher::FsSpecLookup;
 use super::extract::{HeuristicMethodExtractor, MethodExtractor, heuristic_method};
 use super::linkage::{extract_branch_ticket, extract_pr_ticket, extract_ticket_id, is_ticketed};
 use super::resolve::{
@@ -252,6 +253,36 @@ fn ac5_branch_name() {
     );
 }
 
+/// Review MEDIUM #3 (tga #445): a bare `#N` mentioned only in passing in the
+/// free-text PR body must NOT resolve, but a qualifying `Closes #N` must.
+#[test]
+fn ac5_pr_body_bare_ref_does_not_link() {
+    // Bare `#42` in prose — NOT a qualifying ref — must not resolve from body.
+    assert_eq!(
+        extract_pr_ticket("See discussion in #42 for background", &[], None),
+        None,
+        "a bare #N mentioned in passing must not link (tga #445)"
+    );
+    // Action-keyword ref qualifies and resolves.
+    assert_eq!(
+        extract_pr_ticket("Closes #42", &[], None),
+        Some("#42".to_string()),
+        "a qualifying `Closes #N` must resolve"
+    );
+}
+
+/// The bare-`#N` last resort is retained for commit messages (terse trailers),
+/// even though the PR body rejects it.
+#[test]
+fn ac5_commit_bare_ref_still_links() {
+    let commits = vec!["address #42".to_string()];
+    assert_eq!(
+        extract_pr_ticket("See discussion in #42", &commits, None),
+        Some("#42".to_string()),
+        "commit messages keep the bare-#N fallback"
+    );
+}
+
 #[test]
 fn ac5_no_linkage_is_none() {
     assert_eq!(
@@ -444,6 +475,34 @@ fn extract_heuristic_ambiguous_is_none() {
     assert!(heuristic_method("Add a flag to the CLI.").is_none());
 }
 
+/// A Rust `use` import must NOT be misclassified as an approach method
+/// (review MEDIUM #1: the old `cue.starts_with("use ")` guard was too broad).
+#[test]
+fn extract_heuristic_use_import_not_approach() {
+    assert!(
+        heuristic_method("use std::collections::HashMap;").is_none(),
+        "a Rust import must not classify as an Approach method"
+    );
+    assert!(
+        heuristic_method("    use crate::foo::Bar;").is_none(),
+        "an indented Rust import must not classify either"
+    );
+    assert!(
+        heuristic_method("use caution when deploying").is_none(),
+        "casual `use X` phrasing must not classify as Approach"
+    );
+}
+
+/// A narrow `use …` directive that IS a prescribed approach still classifies —
+/// proves the tightened guard did not over-reject genuine cues.
+#[test]
+fn extract_heuristic_use_directive_is_approach() {
+    let m = heuristic_method("Use the existing pagination helper.").unwrap();
+    assert_eq!(m.kind, MethodKind::Reuse);
+    let m = heuristic_method("- use offset-based windows").unwrap();
+    assert_eq!(m.kind, MethodKind::Approach);
+}
+
 #[test]
 fn extract_trait_default_matches_fn() {
     let extractor = HeuristicMethodExtractor;
@@ -490,6 +549,92 @@ fn spec_resolve_method_section_scoped() {
     // NOT be attributed to this anchor.
     let md = "# Doc\n\n## A {#SPEC-X-01~draft}\n\njust prose, no method.\n\n## B\n\n- use cursor pagination\n";
     assert!(extract_spec_method(md, "SPEC-X-01~draft").is_none());
+}
+
+/// Review LOW #4: a top-level `# ` heading must terminate the section too, so a
+/// following top-level section's method does not bleed into this anchor.
+#[test]
+fn spec_resolve_method_section_scoped_top_level_heading() {
+    let md = "## A {#SPEC-X-01~draft}\n\njust prose, no method.\n\n# Next Top Level\n\n- use cursor pagination\n";
+    assert!(
+        extract_spec_method(md, "SPEC-X-01~draft").is_none(),
+        "a `# ` top-level heading must terminate the anchored section"
+    );
+}
+
+// ───────────────────────── FsSpecLookup path-traversal guard ────────────────
+
+/// Review MEDIUM #2 (path traversal): `FsSpecLookup::load` must refuse a
+/// `..`-laden spec_file that escapes the repo root, even though such a file may
+/// physically exist on disk. The in-root file loads; the traversal returns
+/// `None`.
+#[test]
+fn fs_spec_lookup_rejects_traversal() {
+    use std::fs;
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let root_path = root.path();
+
+    // A legitimate spec under docs/specs/ loads fine.
+    let specs_dir = root_path.join("docs/specs");
+    fs::create_dir_all(&specs_dir).expect("create docs/specs");
+    fs::write(specs_dir.join("real.md"), "# real spec\n").expect("write spec");
+
+    // A "secret" file OUTSIDE the repo root that a traversal would try to read.
+    let secret_dir = tempfile::tempdir().expect("secret tempdir");
+    let secret = secret_dir.path().join("passwd");
+    fs::write(&secret, "root:x:0:0:root\n").expect("write secret");
+
+    let lookup = FsSpecLookup::new(root_path);
+
+    // In-root path resolves.
+    assert_eq!(
+        lookup.load("docs/specs/real.md").as_deref(),
+        Some("# real spec\n"),
+        "an in-root spec must load"
+    );
+
+    // Build a traversal that points at the secret file relative to the root.
+    // e.g. docs/specs/../../<secret-dir-basename>/passwd, then enough `..` to
+    // climb out — we construct it relative to root so canonicalize would land on
+    // the secret were the guard absent.
+    let secret_canon = secret.canonicalize().expect("canonicalize secret");
+    let root_canon = root_path.canonicalize().expect("canonicalize root");
+    let traversal = pathdiff_relative(&root_canon, &secret_canon);
+    assert!(
+        lookup.load(&traversal).is_none(),
+        "a `..` traversal escaping repo_root must return None (got Some for {traversal})"
+    );
+
+    // A blatantly bad literal also returns None (the file does not exist under
+    // root, so canonicalize fails → None).
+    assert!(
+        lookup.load("docs/specs/../../etc/passwd").is_none(),
+        "a docs/specs/../../etc/passwd traversal must return None"
+    );
+}
+
+/// Compute a `from`→`to` relative path as a `/`-joined string (test helper).
+///
+/// Why: the traversal test needs a relative path (with `..` segments) from the
+/// repo root to an out-of-tree secret so the guard is exercised against a path
+/// that *would* canonicalize successfully without the containment check.
+/// What: walks up from `from` to the common ancestor, then down to `to`.
+/// Test: used by `fs_spec_lookup_rejects_traversal`.
+fn pathdiff_relative(from: &std::path::Path, to: &std::path::Path) -> String {
+    let from_c: Vec<_> = from.components().collect();
+    let to_c: Vec<_> = to.components().collect();
+    let common = from_c
+        .iter()
+        .zip(to_c.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let ups = from_c.len() - common;
+    let mut parts: Vec<String> = std::iter::repeat_n("..".to_string(), ups).collect();
+    for c in &to_c[common..] {
+        parts.push(c.as_os_str().to_string_lossy().into_owned());
+    }
+    parts.join("/")
 }
 
 // ───────────────────────── constructors / error display ─────────────────────

--- a/crates/trusty-common/src/intent_source/types.rs
+++ b/crates/trusty-common/src/intent_source/types.rs
@@ -1,0 +1,268 @@
+//! Data contract for the intent-source resolver (ISR).
+//!
+//! Why: both conformance gates (FRONT in trusty-mpm, BACK in trusty-review)
+//! must agree on a *single* shape for "the resolved intent" and on how
+//! precedence (ticket > spec) was applied. Defining the contract once here —
+//! in the crate both gates already depend on — guarantees the two gates can
+//! never disagree about which intent source wins (spec §6.1, §6.5).
+//! What: the input query (`IntentQuery`), the output (`ResolvedIntent`) and its
+//! constituent value types (`Method`, `MethodKind`, `Precedence`, `TicketRef`,
+//! `SpecRef`), plus the resolver error type (`IsrError`).
+//! Test: `super::tests` — round-trip + constructor coverage (AC-1..AC-7).
+
+use serde::{Deserialize, Serialize};
+
+/// Input to [`crate::intent_source::resolve`]: one of two query shapes.
+///
+/// Why: the BACK gate starts from a PR (it must *extract* the ticket-id and
+/// resolve spec links from changed files), while the FRONT gate already holds
+/// the ticket-id pre-work. Modelling both as one enum keeps a single resolver
+/// entry point (spec §6.1).
+/// What: `Pr` carries owner/repo/pr-number plus the diff/changed-file context
+/// used for ticket-linkage and spec-resolution; `Ticket` carries a known
+/// ticket-id and optional changed files.
+/// Test: `super::tests::pr_query_*` / `ticket_query_*`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntentQuery {
+    /// BACK gate: resolve intent from a pull request (extract ticket + spec).
+    Pr {
+        /// Repository owner (`bobmatnyc`), used for ticket fetch.
+        owner: String,
+        /// Repository name (`trusty-tools`), used for ticket fetch.
+        repo: String,
+        /// The PR number (informational; linkage keys off body/commits/branch).
+        pr_number: u64,
+        /// PR body / description — the primary `Closes #N` linkage source.
+        body: String,
+        /// Branch name (e.g. `fix/1325-x`) — a fallback linkage source.
+        branch: Option<String>,
+        /// Commit messages in the PR — a secondary linkage source.
+        commit_messages: Vec<String>,
+        /// Changed file paths + their source text, for SLD spec-resolution.
+        changed_files: Vec<ChangedFile>,
+    },
+    /// FRONT gate: resolve intent from a known ticket-id.
+    Ticket {
+        /// The backend-native ticket id (`#1358`, `ENG-12`, …).
+        ticket_id: String,
+        /// Repository owner, used to select/scope the ticket backend.
+        owner: String,
+        /// Repository name, used to select/scope the ticket backend.
+        repo: String,
+        /// Changed file paths + source (may be empty pre-work) for spec links.
+        changed_files: Vec<ChangedFile>,
+    },
+}
+
+/// A changed file paired with the source text the ISR scans for SLD refs.
+///
+/// Why: SLD spec-resolution (spec §6.4) reads `# Spec References` rustdoc
+/// blocks out of the *content* of changed files — a path alone is not enough.
+/// What: `path` is the repo-relative path; `content` is the file's text (the
+/// caller supplies it; the ISR never reads the filesystem itself).
+/// Test: `super::tests::spec_resolve_*`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangedFile {
+    /// Repo-relative path (`crates/trusty-common/src/intent_source/mod.rs`).
+    pub path: String,
+    /// Full source text of the file, scanned for SLD docstring references.
+    pub content: String,
+}
+
+/// Which intent source won under the fixed precedence rule (ticket > spec).
+///
+/// Why: callers must know, without re-deriving, whether the ticket or the spec
+/// is the authority for this unit of work — and `None` signals a genuine gap
+/// (spec §6.1 precedence resolution).
+/// What: a three-state marker serialised lowercase for stable wire shape.
+/// Test: `super::tests::precedence_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Precedence {
+    /// The ticket specifies the method (wins over any spec).
+    Ticket,
+    /// Only the spec specifies the method (ticket silent).
+    Spec,
+    /// Neither specifies a method — a gap, nothing to conform to.
+    None,
+}
+
+/// The class of an extracted method statement.
+///
+/// Why: a conformance gate downstream may treat a hard constraint ("no new
+/// dependency") differently from an approach hint ("prefer cursor pagination");
+/// tagging the kind keeps that option open without re-parsing the text.
+/// What: a coarse taxonomy over the imperative-method phrasings the heuristic
+/// extractor recognises (spec §6.2). `Unspecified` is the safe default when a
+/// method was supplied verbatim (e.g. by an LLM) without a class.
+/// Test: `super::tests::extract_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MethodKind {
+    /// A prescribed approach/technique ("use cursor-based pagination").
+    Approach,
+    /// A prohibition / hard constraint ("no new dependency", "must not block").
+    Constraint,
+    /// A reuse directive ("reuse the existing `ContextSource` trait").
+    Reuse,
+    /// Method text supplied without a recognised class.
+    Unspecified,
+}
+
+/// An extracted statement of approach/technique/constraint.
+///
+/// Why: the matrix (spec §4) compares the *subject* against a *method*, not
+/// against free prose. Carrying the verbatim source excerpt keeps the finding
+/// explainable and auditable (no hallucinated constraints — spec §6.2).
+/// What: `text` is the normalised method statement; `kind` classifies it;
+/// `source_excerpt` is the verbatim line(s) it was lifted from.
+/// Test: `super::tests::extract_*`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Method {
+    /// Normalised, human-readable statement of the method.
+    pub text: String,
+    /// Coarse classification of the method statement.
+    pub kind: MethodKind,
+    /// Verbatim excerpt the method was extracted from (for explainability).
+    pub source_excerpt: String,
+}
+
+/// A reference to the ticket the intent was resolved from.
+///
+/// Why: the BACK gate must cite *which* ticket it checked conformance against;
+/// the FRONT gate echoes it into escalation context (spec §6.1 outputs).
+/// What: the backend-native id, human title, optional URL, and backend tag.
+/// Test: `super::tests::ticket_query_*`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TicketRef {
+    /// Backend-native id (`#1358`, `ENG-12`).
+    pub id: String,
+    /// Human-readable ticket title.
+    pub title: String,
+    /// Canonical URL, when the backend supplied one.
+    pub url: Option<String>,
+    /// Backend identifier (`github` / `jira` / `linear`).
+    pub backend: String,
+}
+
+/// A reference to the spec section the intent was resolved from.
+///
+/// Why: when the spec axis wins (or conflicts), the gate must cite the exact
+/// `SPEC-…` anchor + file it checked against (spec §6.1, §6.4).
+/// What: the spec id (`SPEC-SUBSYSTEM-NN~vR`), the `docs/specs/*.md` file, and
+/// the in-file anchor (`SPEC-SUBSYSTEM-NN`).
+/// Test: `super::tests::spec_resolve_*`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpecRef {
+    /// The full spec id including revision (`SPEC-CONFORMANCE-03~draft`).
+    pub spec_id: String,
+    /// The `docs/specs/*.md` file the anchor lives in.
+    pub file: String,
+    /// The in-file heading anchor (`SPEC-CONFORMANCE-03~draft`).
+    pub anchor: String,
+}
+
+/// The resolved intent — the single contract both gates consume.
+///
+/// Why: centralising precedence here (applied exactly once) guarantees FRONT
+/// and BACK never disagree about which source wins (spec §6.1, G4).
+/// What: the ticket + ticket method, the spec section + spec method, the
+/// precedence winner, the `conflict`/`stale_spec` flags, and an `unresolved`
+/// fail-open reason. When `unresolved` is `Some`, all method fields are `None`
+/// and both gates no-op (spec §4.2).
+/// Test: `super::tests` — every AC-1..AC-7 case asserts on this struct.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedIntent {
+    /// The linked ticket, if one was resolved.
+    pub ticket: Option<TicketRef>,
+    /// The method prescribed by the ticket, if any.
+    pub ticket_method: Option<Method>,
+    /// The governing spec section, if one was resolved via SLD links.
+    pub spec_section: Option<SpecRef>,
+    /// The method prescribed by the spec, if any.
+    pub spec_method: Option<Method>,
+    /// Which source won under precedence (ticket > spec).
+    pub precedence_winner: Precedence,
+    /// True when ticket and spec both specify a method and they disagree.
+    pub conflict: bool,
+    /// True when a conflicting spec was downgraded to advisory under the
+    /// ticket's precedence.
+    pub stale_spec: bool,
+    /// Fail-open reason: `Some` when resolution could not complete. All method
+    /// fields are `None` in that case.
+    pub unresolved: Option<String>,
+}
+
+impl ResolvedIntent {
+    /// Construct the "no intent" result for non-ticketed work.
+    ///
+    /// Why: non-ticketed work has no intent to conform to; both gates must
+    /// no-op on it (spec §4.2 preconditions). A named constructor makes the
+    /// intent explicit at every call site.
+    /// What: returns a `ResolvedIntent` with every field empty/`None`,
+    /// `precedence_winner = None`, and `unresolved = None` (this is a *clean*
+    /// gap, not a failure).
+    /// Test: `super::tests::none_is_gap`.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            ticket: None,
+            ticket_method: None,
+            spec_section: None,
+            spec_method: None,
+            precedence_winner: Precedence::None,
+            conflict: false,
+            stale_spec: false,
+            unresolved: None,
+        }
+    }
+
+    /// Construct a fail-open result carrying the failure reason.
+    ///
+    /// Why: any fetch/parse failure must degrade to "no intent" rather than
+    /// panic or block work (spec §4.2 error conditions, §6.1).
+    /// What: returns a `ResolvedIntent` like [`ResolvedIntent::none`] but with
+    /// `unresolved = Some(reason)` so callers can log/surface the cause.
+    /// Test: `super::tests::unresolved_carries_reason`.
+    #[must_use]
+    pub fn unresolved(reason: impl Into<String>) -> Self {
+        Self {
+            unresolved: Some(reason.into()),
+            ..Self::none()
+        }
+    }
+
+    /// True when neither ticket nor spec prescribed a method (a gap).
+    ///
+    /// Why: the matrix's M3 row keys off "no method on either axis"; a helper
+    /// keeps gate code declarative (spec §4.1 M3).
+    /// What: returns `true` iff both `ticket_method` and `spec_method` are
+    /// `None` (independent of `unresolved`).
+    /// Test: `super::tests::none_is_gap`.
+    #[must_use]
+    pub fn is_gap(&self) -> bool {
+        self.ticket_method.is_none() && self.spec_method.is_none()
+    }
+}
+
+/// Errors that can arise inside the resolver before the fail-open conversion.
+///
+/// Why: trusty-common is a library, so internal failure modes are modelled as
+/// a structured `thiserror` enum rather than `anyhow` (CLAUDE.md convention).
+/// The public `resolve` entry never returns this — it maps every variant into
+/// `ResolvedIntent::unresolved` (spec §4.2 fail-open) — but the typed error
+/// keeps the internal plumbing precise and testable.
+/// What: the failure categories the resolver distinguishes.
+/// Test: `super::tests::error_display_*`.
+#[derive(Debug, thiserror::Error)]
+pub enum IsrError {
+    /// No ticket-id could be extracted from the PR (body/commits/branch).
+    #[error("no ticket linkage found in PR")]
+    NoTicketLinkage,
+    /// The ticket backend could not fetch the issue.
+    #[error("ticket fetch failed: {0}")]
+    TicketFetch(String),
+    /// A GitHub access token could not be resolved for the fetch.
+    #[error("no auth token available: {0}")]
+    NoToken(String),
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -245,6 +245,22 @@ pub mod memory_core;
 #[cfg(feature = "tickets")]
 pub mod tickets;
 
+/// Intent-source resolver (ISR) for the intent/method conformance gates (#1358).
+///
+/// Why: the DOC-15 conformance capability needs one shared resolver that both
+/// the FRONT gate (trusty-mpm) and the BACK gate (trusty-review) call, so
+/// ticket+spec resolution and the precedence rule (ticket > spec) are
+/// implemented once, centrally, and the two gates can never disagree
+/// (`SPEC-CONFORMANCE-03~draft`, spec §6).
+/// What: gated behind the `intent-source` feature (depends on `tickets` and
+/// `chat`). Exposes `intent_source::{resolve, ResolvedIntent, IntentQuery, …}`
+/// plus the pluggable `TicketFetcher` / `IntentTokenResolver` / `SpecLookup` /
+/// `MethodExtractor` seams. Fail-open throughout (`thiserror`, no `unwrap`).
+/// Test: `cargo test -p trusty-common --features intent-source` runs the
+/// module's AC-1..AC-7 unit tests with no network access.
+#[cfg(feature = "intent-source")]
+pub mod intent_source;
+
 /// Declarative CLI help system with "did you mean?" suggestions (issue #216).
 ///
 /// Why: every standalone trusty-* binary used to render its `--help` and


### PR DESCRIPTION
Closes #1358. Part of #1354 (epic: intent/method conformance, DOC-15).

## Scope (C1 of DOC-15, `SPEC-CONFORMANCE-03~draft`)

New `trusty-common::intent_source` module behind a new **`intent-source`** feature flag (depends on `tickets`; pulls `regex` + `thiserror`). It is the shared intent-source resolver both conformance gates call so ticket+spec resolution and the precedence rule (ticket > spec) are implemented **once**, centrally — guaranteeing the FRONT gate (trusty-mpm, C3) and BACK gate (trusty-review, C2) can never disagree (spec §6.5, G4).

Public entry: `resolve(IntentQuery) -> ResolvedIntent` (+ `resolve_default` convenience using the heuristic extractor).

### What landed
- **Precedence resolution** — the four normative cases (§6.1): both agree → `Ticket`, `conflict=false`; both disagree → `Ticket` wins, `conflict=true`, `stale_spec=true`; ticket only → `Ticket`; spec only → `Spec`; neither → `None` (gap).
- **PR→ticket linkage** (§6.3) — lifts tga's `is_ticketed`/`extract_ticket_id` regexes into `intent_source::linkage` (no git2/rusqlite pulled), with the spec's source-precedence order: PR body → commit trailers → branch name.
- **SLD spec resolution** (§6.4) — `spec_resolve` parses `# Spec References` rustdoc blocks out of changed-file source and extracts the governed section's prescribed method. The ISR **does not invent linkage**: no SLD ref → `spec_section = None` (gap). This is the **minimal-correct** reader; the `spec_resolve` submodule is a clean seam left for **C4 (#1361)** to harden (symbol-level granularity, revision-drift, multi-anchor reconciliation).
- **Pluggable token-resolver seam** (§7.4) — `IntentTokenResolver` mirrors review's `IssueTokenResolver`; no hard-wired PAT. `EnvTokenResolver` (reads `GITHUB_TOKEN`) is the zero-config default; an App/JWT resolver can be supplied for serve mode. Ticket fetch and spec loading are likewise pluggable (`TicketFetcher` over `tickets::Backend::get_issue`, `SpecLookup`).

### OQ-1 decision (settled in C1)
**Heuristic-first, pluggable-extractor.** The DEFAULT path is a pure-Rust `HeuristicMethodExtractor` — pattern-matching over imperative-method phrasing — so the resolver (and its tests) run **fully offline**, with zero cost/latency and no LLM false-method risk. The `MethodExtractor` trait is the seam a future `chat::ChatProvider`-backed extractor plugs into **without touching the resolver**, realising the spec's recommended "heuristic first, LLM fallback" hybrid. We deliberately do **not** wire an LLM call by default (it would make `resolve` network-dependent — out of C1 scope). Extraction is conservative: ambiguous prose → `None`, never a hallucinated constraint.

### Library conventions
`thiserror` error enum (`IsrError`); no `unwrap()` on fetch/parse paths; **fail-open everywhere** — any fetch/parse failure → `ResolvedIntent { unresolved: Some(reason), .. }`, never an `Err` or panic (§4.2). Each production `.rs` file is under the 500-SLOC cap (thin `mod.rs` facade + focused siblings); the line-cap gate passes.

### Feature flag
`intent-source = ["tickets", "dep:regex", "dep:thiserror"]`. Off by default — non-consumer trusty-common dependents pay nothing. Default `cargo check -p trusty-common` (no features) is unaffected.

## Acceptance criteria (AC-1..AC-7) — 32 unit tests, no network
- **AC-1** ticket prescribes method → `ticket_method = Some`, `precedence_winner = Ticket`.
- **AC-2** ticket + spec agree → `conflict = false`, `stale_spec = false`.
- **AC-3** ticket + spec disagree → `Ticket` wins, `conflict = true`, `stale_spec = true`.
- **AC-4** neither prescribes → all method fields `None`, `precedence_winner = None` (gap).
- **AC-5** PR→ticket: `Closes #N` body, commit trailer, and `fix/NNNN-x` branch each resolve `#N`; no linkage → `None` (and end-to-end `ResolvedIntent::none()`).
- **AC-6** SLD: changed file with a `# Spec References` block → `spec_section = Some`; no SLD ref → `spec_section = None`.
- **AC-7** fail-open: fetch error → `unresolved = Some(reason)`, all methods `None`.

## Verification (raw)
- `cargo build -p trusty-common --features intent-source` — clean.
- `cargo test -p trusty-common --features intent-source` — 165 passed; 0 failed (intent_source: 32/32).
- `cargo clippy -p trusty-common --features intent-source --all-targets -- -D warnings` — clean.
- `cargo fmt -p trusty-common -- --check` — clean.
- `cargo check -p trusty-common` (no features) — clean (feature gate doesn't affect default builds).
- `bash scripts/check_line_cap.sh` — 0 violations.

## Deviations from spec
- Spec §6.2 cites `Issue.body`; the actual `tickets::Issue` model field is `description` — the default `BackendTicketFetcher` maps `description → TicketData.body`. No behavioural impact.
- The streaming `chat::ChatProvider` trait is channel-based (awkward for one-shot classification), so the OQ-1 seam is a small `MethodExtractor` trait rather than `ChatProvider` directly. A `ChatProvider` adapter is a future plug-in, not C1 scope. Documented in `extract.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)