### PR TITLE
refactor(trusty-review): is_high_severity predicate + 0.3.13 hardening follow-ups

### DIFF
--- a/crates/trusty-review/src/llm/bedrock/mod.rs
+++ b/crates/trusty-review/src/llm/bedrock/mod.rs
@@ -325,6 +325,11 @@ impl BedrockProvider {
         let (input_tokens, output_tokens) = extract_token_usage(&resp);
         let cost_usd = estimate_bedrock_cost_usd(&req.model, input_tokens, output_tokens);
 
+        // Bedrock Converse surfaces a stop reason (`end_turn`, `max_tokens`, …);
+        // thread it through as the PRIMARY truncation signal (#1357).  `max_tokens`
+        // is the truncation case the runner keys off.
+        let finish_reason = Some(resp.stop_reason().as_str().trim().to_ascii_lowercase());
+
         Ok(LlmResponse {
             text,
             model: req.model.clone(),
@@ -332,6 +337,7 @@ impl BedrockProvider {
             output_tokens,
             latency_ms,
             cost_usd,
+            finish_reason,
         })
     }
 }

--- a/crates/trusty-review/src/llm/mod.rs
+++ b/crates/trusty-review/src/llm/mod.rs
@@ -108,7 +108,9 @@ pub struct LlmRequest {
 /// What: `text` is the full response; `model` echoes the actual model id
 /// used (providers may normalise or alias the requested id); `input_tokens` /
 /// `output_tokens` come from the API usage field; `latency_ms` is wall-clock
-/// end-to-end; `cost_usd` is an estimate from a pricing table.
+/// end-to-end; `cost_usd` is an estimate from a pricing table; `finish_reason`
+/// is the provider's normalised completion reason (`"stop"` / `"length"` / …)
+/// when surfaced, used as the PRIMARY truncation signal (#1357).
 /// Test: `llm_response_serde_roundtrip` in this module.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmResponse {
@@ -124,6 +126,15 @@ pub struct LlmResponse {
     pub latency_ms: u64,
     /// Estimated USD cost for this call based on the model pricing table.
     pub cost_usd: f64,
+    /// Provider completion / stop reason, normalised to a lowercase token
+    /// (#1357).  `Some("stop")` / `Some("end_turn")` means the model finished
+    /// naturally; `Some("length")` / `Some("max_tokens")` means it was cut off
+    /// at the output-token ceiling (a genuine truncation).  `None` when the
+    /// provider did not surface a reason — callers fall back to the token-ratio
+    /// heuristic in that case.  Defaulted on deserialise so older serialised
+    /// `ReviewResult` logs (and test fakes) remain compatible.
+    #[serde(default)]
+    pub finish_reason: Option<String>,
 }
 
 // ─── Provider trait ───────────────────────────────────────────────────────────
@@ -256,6 +267,7 @@ mod tests {
             output_tokens: 64,
             latency_ms: 1234,
             cost_usd: 0.000123,
+            finish_reason: None,
         };
         let json = serde_json::to_string(&resp).expect("serialise");
         let back: LlmResponse = serde_json::from_str(&json).expect("deserialise");

--- a/crates/trusty-review/src/llm/openrouter.rs
+++ b/crates/trusty-review/src/llm/openrouter.rs
@@ -93,6 +93,11 @@ struct OrcResponse {
 #[derive(Debug, Deserialize)]
 struct OrcChoice {
     message: OrcChoiceMessage,
+    /// OpenAI-compatible completion reason: `"stop"` (natural end), `"length"`
+    /// (hit `max_tokens` → truncated), `"content_filter"`, etc.  Threaded into
+    /// `LlmResponse.finish_reason` as the PRIMARY truncation signal (#1357).
+    #[serde(default)]
+    finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -156,6 +161,16 @@ fn cost_per_million(model: &str) -> (f64, f64) {
 /// caller's unknown-model fallback is preserved.
 /// Test: `cost_estimate_gemini_pro_nonzero`, `cost_estimate_gemini_flash_nonzero`,
 /// `cost_estimate_unknown_model` (still zero).
+///
+/// PRICING PROVENANCE (#1357 item 4):
+///   Source:    OpenRouter model pricing — https://openrouter.ai/models?q=gemini
+///              (per-million input/output USD; cross-check against
+///              https://ai.google.dev/gemini-api/docs/pricing for Google direct).
+///   Reference date: 2026-06-17 (best-effort snapshot; family substring match,
+///              NOT per-slug exact pricing).
+///   TODO: refresh pricing — re-verify these tiers against the OpenRouter pricing
+///   page; if `compare`-mode cost ranking ever depends on exact per-slug Gemini
+///   pricing, replace these family-tier estimates with an exact-slug table.
 fn gemini_cost_per_million(model: &str) -> (f64, f64) {
     let m = model.to_ascii_lowercase();
     if !m.contains("gemini") {
@@ -163,6 +178,7 @@ fn gemini_cost_per_million(model: &str) -> (f64, f64) {
     }
     // Flash-Lite is cheapest; Flash mid; Pro top-tier.  Order matters: check the
     // more specific "flash-lite" before "flash".
+    // Values: USD per million (input, output); source/date in the doc comment above.
     if m.contains("flash-lite") {
         (0.10, 0.40)
     } else if m.contains("flash") {
@@ -343,10 +359,13 @@ impl LlmProvider for OpenRouterProvider {
             }
         })?;
 
-        let text = orc
-            .choices
-            .into_iter()
-            .next()
+        let first_choice = orc.choices.into_iter().next();
+        // Capture finish_reason BEFORE consuming the message content (#1357).
+        let finish_reason = first_choice
+            .as_ref()
+            .and_then(|c| c.finish_reason.clone())
+            .map(|r| r.trim().to_ascii_lowercase());
+        let text = first_choice
             .and_then(|c| c.message.content)
             .unwrap_or_default();
 
@@ -365,6 +384,7 @@ impl LlmProvider for OpenRouterProvider {
             output_tokens,
             latency_ms,
             cost_usd,
+            finish_reason,
         })
     }
 }

--- a/crates/trusty-review/src/mcp/console_metrics.rs
+++ b/crates/trusty-review/src/mcp/console_metrics.rs
@@ -192,6 +192,7 @@ mod tests {
                 output_tokens: 1,
                 latency_ms: 0,
                 cost_usd: 0.0,
+                finish_reason: None,
             })
         }
     }

--- a/crates/trusty-review/src/mcp/mcp_tests.rs
+++ b/crates/trusty-review/src/mcp/mcp_tests.rs
@@ -45,6 +45,7 @@ impl LlmProvider for FakeLlm {
             output_tokens: 1,
             latency_ms: 0,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -211,7 +211,7 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
         token,
     };
 
-    let deps = deps_from_state(state, &reviewer_model).await;
+    let (deps, reviewer_model_fallback) = deps_from_state(state, &reviewer_model).await;
     let input = ReviewInput {
         diff_source,
         reviewer_model: reviewer_model.clone(),
@@ -224,7 +224,7 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
 
     info!(owner, repo, pr, reviewer_model, "mcp: review_pr");
     let result = run_review(&state.config, input, deps).await;
-    Ok(wrap_result(&result))
+    Ok(wrap_result(&result, reviewer_model_fallback.as_deref()))
 }
 
 // ─── review_diff ─────────────────────────────────────────────────────────────
@@ -262,7 +262,7 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
     let path = tmp.path().to_path_buf();
     let diff_source = DiffSource::LocalFile { path };
 
-    let deps = deps_from_state(state, &reviewer_model).await;
+    let (deps, reviewer_model_fallback) = deps_from_state(state, &reviewer_model).await;
     let input = ReviewInput {
         diff_source,
         reviewer_model: reviewer_model.clone(),
@@ -276,7 +276,7 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
     info!(bytes = diff.len(), reviewer_model, "mcp: review_diff");
     let result = run_review(&state.config, input, deps).await;
     // `tmp` is dropped here — temp file cleaned up automatically.
-    Ok(wrap_result(&result))
+    Ok(wrap_result(&result, reviewer_model_fallback.as_deref()))
 }
 
 // ─── review_health ────────────────────────────────────────────────────────────
@@ -368,13 +368,22 @@ async fn call_review_health(state: &AppState) -> Value {
 /// build error it logs a `warn!` and falls back to the startup `state.llm` so a
 /// malformed override degrades gracefully rather than failing the whole review.
 /// The verifier / search / analyze / dedup handles are always cloned from state.
+///
+/// Returns the built `ReviewDeps` alongside an OPTIONAL `reviewer_model_fallback`
+/// reason (closes #1357 item 2): `Some(reason)` when an override provider failed to
+/// build and we silently fell back to the startup provider, so the caller can
+/// surface it in the tool response metadata instead of getting the wrong backend
+/// with no signal.  `None` on the happy path (override matched startup, or built
+/// successfully).
 /// Test: `deps_from_state_openrouter_override_switches_provider`,
-/// `deps_from_state_no_override_reuses_startup_provider` (in `tools_dispatch_tests.rs`).
-async fn deps_from_state(state: &AppState, reviewer_model: &str) -> ReviewDeps {
+/// `deps_from_state_no_override_reuses_startup_provider`,
+/// `deps_from_state_build_failure_reports_fallback` (in `tools_dispatch_tests.rs`).
+async fn deps_from_state(state: &AppState, reviewer_model: &str) -> (ReviewDeps, Option<String>) {
     let startup_provider = &state.config.role_models.reviewer.provider;
     let (override_provider, _bare) =
         crate::llm::resolve_provider_and_model(reviewer_model, startup_provider);
 
+    let mut fallback_reason: Option<String> = None;
     let llm = if &override_provider == startup_provider {
         // Same backend as startup — reuse the already-built provider (no alloc).
         Arc::clone(&state.llm)
@@ -389,24 +398,30 @@ async fn deps_from_state(state: &AppState, reviewer_model: &str) -> ReviewDeps {
         {
             Ok(p) => p,
             Err(e) => {
+                let reason = format!(
+                    "failed to build provider for reviewer_model override '{reviewer_model}' \
+                     ({e}); fell back to the startup '{startup_provider}' provider"
+                );
                 tracing::warn!(
                     reviewer_model,
                     error = %e,
                     "mcp: failed to build provider for reviewer_model override — \
                      falling back to startup provider"
                 );
+                fallback_reason = Some(reason);
                 Arc::clone(&state.llm)
             }
         }
     };
 
-    ReviewDeps {
+    let deps = ReviewDeps {
         llm,
         verifier: state.verifier.clone(),
         search: Arc::clone(&state.search),
         analyze: state.analyze.clone(),
         dedup: state.dedup.clone(),
-    }
+    };
+    (deps, fallback_reason)
 }
 
 /// Extract a required string field from the tool arguments.
@@ -420,20 +435,46 @@ fn require_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, ToolError> {
         .ok_or_else(|| ToolError::InvalidParams(format!("missing or non-string '{key}'")))
 }
 
-/// Wrap a `ReviewResult` in the MCP content envelope.
+/// Wrap a `ReviewResult` in the MCP content envelope, optionally surfacing a
+/// reviewer-model override-fallback reason (closes #1357 item 2).
 ///
 /// Why: MCP `tools/call` responses must carry results inside a `content[]` array
-/// (per MCP spec) so the LLM can render them correctly.
-/// What: serialises `ReviewResult` to a pretty JSON string, wraps it in a text
-/// content block.
-/// Test: result shape verified by `review_health_does_not_require_creds`.
-fn wrap_result(result: &ReviewResult) -> Value {
-    let text = serde_json::to_string_pretty(result)
-        .unwrap_or_else(|_| serde_json::to_string(result).unwrap_or_default());
-    serde_json::json!({
+/// (per MCP spec) so the LLM can render them correctly.  When a `reviewer_model`
+/// override failed to build and the pipeline silently fell back to the startup
+/// provider, the caller would otherwise get the WRONG backend with no signal.
+/// Surfacing the fallback in the response metadata (and inside the serialised
+/// payload the LLM reads) makes it DETECTABLE without breaking the non-error
+/// contract — the review still ran, just on a different model than requested.
+/// What: serialises `ReviewResult` to pretty JSON; when `fallback` is
+/// `Some(reason)` it injects a `reviewer_model_fallback` string into BOTH the
+/// serialised JSON object (so the LLM reading `content[0].text` sees it) and as a
+/// top-level envelope field (so programmatic callers can detect it without
+/// re-parsing the text).  `None` leaves the envelope unchanged (no extra field).
+/// Test: `wrap_result_surfaces_reviewer_model_fallback`,
+/// `wrap_result_no_fallback_omits_field` (in `tools_tests.rs`).
+fn wrap_result(result: &ReviewResult, fallback: Option<&str>) -> Value {
+    // Serialise to a JSON Value first so we can splice in the fallback marker.
+    let mut payload = serde_json::to_value(result).unwrap_or(Value::Null);
+    if let (Some(reason), Some(obj)) = (fallback, payload.as_object_mut()) {
+        obj.insert(
+            "reviewer_model_fallback".to_string(),
+            Value::String(reason.to_string()),
+        );
+    }
+    let text = serde_json::to_string_pretty(&payload)
+        .unwrap_or_else(|_| serde_json::to_string(&payload).unwrap_or_default());
+
+    let mut envelope = serde_json::json!({
         "content": [{ "type": "text", "text": text }],
         "isError": false,
-    })
+    });
+    if let (Some(reason), Some(obj)) = (fallback, envelope.as_object_mut()) {
+        obj.insert(
+            "reviewer_model_fallback".to_string(),
+            Value::String(reason.to_string()),
+        );
+    }
+    envelope
 }
 
 /// Wrap an arbitrary JSON value in the MCP content envelope.

--- a/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
@@ -59,6 +59,7 @@ impl LlmProvider for ApproveLlm {
             output_tokens: 5,
             latency_ms: 0,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }
@@ -292,11 +293,16 @@ async fn deps_from_state_openrouter_override_switches_provider() {
     // state must build a fresh OpenRouter provider, NOT silently reuse the startup
     // (Bedrock) provider.
     let state = bedrock_startup_state();
-    let deps = super::deps_from_state(&state, "openrouter/openai/gpt-5.4-mini-20260317").await;
+    let (deps, fallback) =
+        super::deps_from_state(&state, "openrouter/openai/gpt-5.4-mini-20260317").await;
     assert_eq!(
         deps.llm.name(),
         "openrouter",
         "an openrouter/ override must route to the OpenRouter backend (#1233)"
+    );
+    assert!(
+        fallback.is_none(),
+        "a successful override build must NOT report a fallback (#1357)"
     );
 }
 
@@ -305,10 +311,45 @@ async fn deps_from_state_no_override_reuses_startup_provider() {
     // Control: a bare model id (no routing prefix) keeps the startup provider —
     // the stub `ApproveLlm`, whose name() is NOT "openrouter".
     let state = bedrock_startup_state();
-    let deps = super::deps_from_state(&state, "us.anthropic.claude-sonnet-4-6").await;
+    let (deps, fallback) = super::deps_from_state(&state, "us.anthropic.claude-sonnet-4-6").await;
     assert_ne!(
         deps.llm.name(),
         "openrouter",
         "a bare model id must reuse the startup (Bedrock) provider, not switch"
+    );
+    assert!(
+        fallback.is_none(),
+        "the no-override path must NOT report a fallback (#1357)"
+    );
+}
+
+/// #1357 item 2: when an override provider fails to build, `deps_from_state` must
+/// report a `Some(reason)` fallback so the MCP caller can detect the wrong-backend
+/// silent fallback.
+///
+/// Why: previously the failed-override path only `warn!`d and silently reused the
+/// startup provider; an MCP caller had no way to know it got the wrong backend.
+/// What: an `openrouter/...` override against a Bedrock-startup state whose config
+/// has an EMPTY OpenRouter key makes `build_provider` fail the empty-key guard;
+/// the result must fall back to the startup provider AND carry a fallback reason.
+/// Test: this test itself.
+#[tokio::test]
+async fn deps_from_state_build_failure_reports_fallback() {
+    let mut state = bedrock_startup_state();
+    // Empty the key so OpenRouterProvider::new() fails its empty-key guard.
+    state.config.openrouter_api_key = String::new();
+
+    let (deps, fallback) =
+        super::deps_from_state(&state, "openrouter/openai/gpt-5.4-mini-20260317").await;
+    // Fell back to the startup (Bedrock) provider, not the requested OpenRouter one.
+    assert_ne!(
+        deps.llm.name(),
+        "openrouter",
+        "a failed override build must fall back to the startup provider"
+    );
+    let reason = fallback.expect("a failed override build must report a fallback reason (#1357)");
+    assert!(
+        reason.contains("reviewer_model") && reason.contains("fell back"),
+        "fallback reason must be actionable: {reason}"
     );
 }

--- a/crates/trusty-review/src/mcp/tools_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_tests.rs
@@ -26,7 +26,10 @@ use crate::{
     service::AppState,
 };
 
-use super::{ToolError, call_review_health, require_str, tool_descriptors, wrap_tool_error};
+use super::{
+    ToolError, call_review_health, require_str, tool_descriptors, wrap_result, wrap_tool_error,
+};
+use crate::models::ReviewResult;
 
 // ── Stub providers ────────────────────────────────────────────────────────────
 
@@ -46,6 +49,7 @@ impl LlmProvider for OkLlmTool {
             output_tokens: 1,
             latency_ms: 0,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }
@@ -286,5 +290,66 @@ async fn review_health_optional_dep_down_ok() {
     assert_eq!(
         health["deps"]["trusty_analyze"]["reachable"], false,
         "trusty_analyze.reachable must be false (no analyze configured)"
+    );
+}
+
+// ── reviewer_model override fallback surfacing (#1357 item 2) ───────────────────
+
+/// #1357: when an override provider build failed, `wrap_result` surfaces the
+/// fallback reason in BOTH the envelope and the serialised payload text.
+///
+/// Why: an MCP caller silently getting the wrong backend is the hazard #1357
+/// targets; the fallback must be DETECTABLE both programmatically (envelope) and
+/// by the LLM reading `content[0].text`.
+/// What: wraps a `ReviewResult` with `Some(reason)`; asserts the envelope-level
+/// `reviewer_model_fallback` field is present AND that the same key appears in the
+/// parsed payload JSON.
+/// Test: this test itself.
+#[test]
+fn wrap_result_surfaces_reviewer_model_fallback() {
+    let result = ReviewResult::new("acme", "backend", 7, "Add X", "https://example/pr/7");
+    let reason = "failed to build provider for reviewer_model override 'openrouter/x' \
+                  (key empty); fell back to the startup 'bedrock' provider";
+    let envelope = wrap_result(&result, Some(reason));
+
+    // Envelope-level metadata field for programmatic callers.
+    assert_eq!(
+        envelope["reviewer_model_fallback"], reason,
+        "envelope must carry reviewer_model_fallback for detection"
+    );
+    assert_eq!(
+        envelope["isError"], false,
+        "fallback is non-breaking, not an error"
+    );
+
+    // The same marker is spliced into the payload the LLM reads.
+    let text = envelope["content"][0]["text"].as_str().expect("text field");
+    let payload: Value = serde_json::from_str(text).expect("valid JSON payload");
+    assert_eq!(
+        payload["reviewer_model_fallback"], reason,
+        "payload JSON must also carry the fallback so the LLM sees it"
+    );
+}
+
+/// #1357: the happy path (no fallback) leaves the envelope clean — no extra field.
+///
+/// Why: only the failure path should advertise a fallback; a clean run must not
+/// emit a spurious marker that callers would misread as a degraded backend.
+/// What: wraps a `ReviewResult` with `None`; asserts the `reviewer_model_fallback`
+/// key is absent from both envelope and payload.
+/// Test: this test itself.
+#[test]
+fn wrap_result_no_fallback_omits_field() {
+    let result = ReviewResult::new("acme", "backend", 8, "Add Y", "https://example/pr/8");
+    let envelope = wrap_result(&result, None);
+    assert!(
+        envelope.get("reviewer_model_fallback").is_none(),
+        "no fallback → envelope must NOT carry the marker"
+    );
+    let text = envelope["content"][0]["text"].as_str().expect("text field");
+    let payload: Value = serde_json::from_str(text).expect("valid JSON payload");
+    assert!(
+        payload.get("reviewer_model_fallback").is_none(),
+        "no fallback → payload must NOT carry the marker"
     );
 }

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -60,6 +60,33 @@ pub enum Verdict {
     Unknown,
 }
 
+impl Verdict {
+    /// Ordinal severity for this verdict (higher = more severe).
+    ///
+    /// Why: the grade-derivation (`grade.rs`) and verification re-derivation
+    /// (`verify.rs`) paths both need a total order over verdicts to compute the
+    /// stricter-of / less-severe-of two verdicts.  Before #1357 each module
+    /// carried its OWN private `verdict_ord` with an identical mapping — two
+    /// copies of the same ordinal table is a maintenance hazard (drift between
+    /// them would silently corrupt the floor/ceiling logic).  Centralising the
+    /// mapping here makes `Verdict` the single source of truth.
+    /// What: returns `APPROVE=0 < APPROVE*=1 < REQUEST_CHANGES=2 < BLOCK=3`.
+    /// `Unknown=4` is a terminal state (the diff was unassessable); callers
+    /// short-circuit it before any ordinal comparison, so it never participates
+    /// in normal flow — the value is defined only so the match is exhaustive.
+    /// Test: `verdict_ordinal_is_monotonic` in this module; exercised
+    /// transitively by `grade.rs::stricter_of` and `verify.rs::verdict_min`.
+    pub fn ordinal(&self) -> u8 {
+        match self {
+            Verdict::Approve => 0,
+            Verdict::ApproveWithReservations => 1,
+            Verdict::RequestChanges => 2,
+            Verdict::Block => 3,
+            Verdict::Unknown => 4,
+        }
+    }
+}
+
 impl std::fmt::Display for Verdict {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -432,6 +459,25 @@ mod tests {
         assert_eq!(json, "\"UNKNOWN\"");
         let back: Verdict = serde_json::from_str(&json).unwrap();
         assert_eq!(back, Verdict::Unknown);
+    }
+
+    /// Verify the single-source-of-truth verdict ordinal is strictly monotonic.
+    ///
+    /// Why: #1357 collapsed two duplicate `verdict_ord` tables (grade.rs +
+    /// verify.rs) into `Verdict::ordinal`.  This test pins the ordering both
+    /// call sites depend on so a future reorder can't silently invert the
+    /// floor/ceiling comparisons.
+    /// What: asserts APPROVE < APPROVE* < REQUEST_CHANGES < BLOCK < UNKNOWN.
+    /// Test: this test itself.
+    #[test]
+    fn verdict_ordinal_is_monotonic() {
+        assert!(Verdict::Approve.ordinal() < Verdict::ApproveWithReservations.ordinal());
+        assert!(Verdict::ApproveWithReservations.ordinal() < Verdict::RequestChanges.ordinal());
+        assert!(Verdict::RequestChanges.ordinal() < Verdict::Block.ordinal());
+        assert!(Verdict::Block.ordinal() < Verdict::Unknown.ordinal());
+        // Pin the exact values the comparison logic relies on.
+        assert_eq!(Verdict::Approve.ordinal(), 0);
+        assert_eq!(Verdict::Block.ordinal(), 3);
     }
 
     #[test]

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -194,7 +194,7 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
     // Override the model down to APPROVE — this specifically prevents APPROVE*
     // over-fire (Fix 4).  High-effort findings escape this gate: a confirmed
     // bug with low confidence should still BLOCK, not disappear.
-    let has_high = substantive.iter().any(|f| f.effort == Effort::High);
+    let has_high = substantive.iter().any(|f| is_high_severity(f));
     let all_low_confidence = !substantive.is_empty()
         && substantive
             .iter()
@@ -272,11 +272,36 @@ fn is_substantive(f: &Finding) -> bool {
             | Some(VerifyOutcome::ErrorRefuted { .. })
             | Some(VerifyOutcome::TruncationRefuted)
     );
-    // A refuted finding is disproven evidence — always excluded, even High-effort.
-    // Otherwise retain it if it clears the confidence floor OR is a High-effort
-    // (critical/high severity) finding: a genuine critical concern must keep its
-    // place at the verdict floor even when the model is only uncertain about it.
-    !refuted && (f.confidence >= FLOOR_COUNT_MIN_CONFIDENCE || f.effort == Effort::High)
+    // A refuted finding is disproven evidence — always excluded, even high-severity.
+    // Otherwise retain it if it clears the confidence floor OR is a high-severity
+    // (critical or high) finding: a genuine critical or high-severity concern must
+    // keep its place at the verdict floor even when the model is only uncertain
+    // about it.
+    !refuted && (f.confidence >= FLOOR_COUNT_MIN_CONFIDENCE || is_high_severity(f))
+}
+
+/// Return `true` when a finding is critical- or high-severity (closes #1352).
+///
+/// Why: the verdict-floor guard must single out "a critical/high-severity finding
+/// that must never be silently dropped".  Before #1352 the call sites spelled this
+/// as the bare check `f.effort == Effort::High`, which made `Effort` do double duty
+/// as a severity proxy and left the *intent* (severity, not remediation cost)
+/// implicit.  Naming the predicate makes that intent unmistakable at every call
+/// site and gives a single place to evolve the severity definition if `Finding`
+/// ever grows a dedicated severity axis.
+/// What: returns `f.effort == Effort::High`.  In this domain model `Effort` IS the
+/// severity proxy — `Effort::High` is defined as "Critical or High severity"
+/// (see the module-level mapping and `models::Effort`), `Effort::Medium` as Medium
+/// severity, and `Effort::Low` as Low severity.  This is therefore behaviour-
+/// equivalent to the previous inline check (verified by the #1343 calibration
+/// regression tests, which are unchanged) while reading as the severity question
+/// it actually asks.  Should a separate `Severity::{Critical,High}` field land
+/// later, this is the one function to update.
+/// Test: `is_high_severity_matches_high_effort`,
+/// `low_confidence_high_effort_finding_still_drives_floor` (#1350),
+/// `floor_excludes_refuted_and_low_confidence_findings` (#1343).
+fn is_high_severity(f: &Finding) -> bool {
+    f.effort == Effort::High
 }
 
 // ─── Floor computation ────────────────────────────────────────────────────────
@@ -316,7 +341,7 @@ fn severity_floor(findings: &[&Finding]) -> Verdict {
     }
 
     // Partition findings by effort tier.
-    let has_high = findings.iter().any(|f| f.effort == Effort::High);
+    let has_high = findings.iter().any(|f| is_high_severity(f));
 
     // Only count Medium findings whose confidence clears the floor threshold
     // (#1015: advisory-tier Medium findings must not force REQUEST_CHANGES).
@@ -351,33 +376,13 @@ fn severity_floor(findings: &[&Finding]) -> Verdict {
 /// Why: the floor is a MINIMUM; we take `max(model, floor)` using verdict
 /// severity ordering so the model can escalate beyond the floor but cannot
 /// go below it.
-/// What: defines an ordinal ordering APPROVE(0) < APPROVE*(1) <
-/// REQUEST_CHANGES(2) < BLOCK(3).  Unknown(4) is a separate terminal case
-/// handled before `stricter_of` is called.
+/// What: compares via `Verdict::ordinal` (the single source of truth, #1357):
+/// APPROVE(0) < APPROVE*(1) < REQUEST_CHANGES(2) < BLOCK(3).  Unknown(4) is a
+/// separate terminal case handled before `stricter_of` is called.
 /// Test: `grade_floor_overrides_model_approve`,
 /// `grade_model_block_kept_when_no_critical_finding`.
 fn stricter_of(a: Verdict, b: Verdict) -> Verdict {
-    if verdict_ord(&b) > verdict_ord(&a) {
-        b
-    } else {
-        a
-    }
-}
-
-/// Ordinal severity for a verdict (higher = more severe).
-///
-/// Why: needed by `stricter_of` to compare two verdicts without a full match.
-/// What: APPROVE=0, APPROVE*=1, REQUEST_CHANGES=2, BLOCK=3.  UNKNOWN is never
-/// passed here (handled before the call site).
-/// Test: covered transitively by `stricter_of` tests.
-fn verdict_ord(v: &Verdict) -> u8 {
-    match v {
-        Verdict::Approve => 0,
-        Verdict::ApproveWithReservations => 1,
-        Verdict::RequestChanges => 2,
-        Verdict::Block => 3,
-        Verdict::Unknown => 4, // Should not reach this branch in normal flow.
-    }
+    if b.ordinal() > a.ordinal() { b } else { a }
 }
 
 // ─── Grade-aware entry point ──────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -637,6 +637,44 @@ fn refuted_high_effort_finding_is_still_excluded() {
     );
 }
 
+/// #1352: the explicit `is_high_severity` predicate identifies exactly the
+/// critical/high-severity tier and drives the verdict floor accordingly.
+///
+/// Why: #1352 replaced the bare `f.effort == Effort::High` check in the floor
+/// guard with a named `is_high_severity` predicate to make the *severity* intent
+/// explicit.  This test pins (a) the predicate's own truth table and (b) that it
+/// drives the floor for an uncertain (low-confidence) high-severity finding — the
+/// #1350 safety-net path that depends on it.  Behaviour must stay equivalent to
+/// the prior `Effort::High` check.
+/// What: asserts `is_high_severity` is true only for `Effort::High`, then asserts
+/// a low-confidence (0.30) High-effort finding still floors a model APPROVE to
+/// BLOCK (the safety net), while a low-confidence Medium does not.
+/// Test: this test itself.
+#[test]
+fn is_high_severity_matches_high_effort() {
+    // (a) Predicate truth table — High only.
+    assert!(is_high_severity(&finding(Effort::High, 0.5)));
+    assert!(!is_high_severity(&finding(Effort::Medium, 0.5)));
+    assert!(!is_high_severity(&finding(Effort::Low, 0.5)));
+
+    // (b) The predicate drives the floor: a low-confidence High-severity finding
+    // still escalates an APPROVE to BLOCK (the #1350 safety net the predicate gates).
+    let high_low_conf = vec![finding(Effort::High, 0.30)];
+    assert_eq!(
+        derive_verdict(Verdict::Approve, &high_low_conf),
+        Verdict::Block,
+        "a low-confidence high-severity finding must still drive the BLOCK floor"
+    );
+
+    // A low-confidence Medium (non-high-severity) is filtered out → no escalation.
+    let medium_low_conf = vec![finding(Effort::Medium, 0.30)];
+    assert_eq!(
+        derive_verdict(Verdict::Approve, &medium_low_conf),
+        Verdict::Approve,
+        "a low-confidence Medium is NOT high-severity and must not escalate"
+    );
+}
+
 /// A confirmed High finding still drives BLOCK even with a B+ grade (#1015 regression).
 ///
 /// Why: the fix must not soften correctness blockers.  High-effort findings are

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -338,7 +338,11 @@ pub async fn run_review(
     // very likely cut off mid-object.  Parsing such output and treating it as a
     // verdict risks a silent (and wrong) APPROVE.  Fail CLOSED to UNKNOWN instead
     // of parse-and-trust.
-    if is_truncated(llm_resp.output_tokens, requested_max_tokens) {
+    if is_truncated(
+        llm_resp.finish_reason.as_deref(),
+        llm_resp.output_tokens,
+        requested_max_tokens,
+    ) {
         warn!(
             output_tokens = llm_resp.output_tokens,
             max_tokens = requested_max_tokens,
@@ -409,36 +413,91 @@ pub async fn run_review(
     finalize_run(result, config, &input, deps.dedup.as_ref()).await
 }
 
-/// Fraction of the output-token ceiling at/above which a response is treated as
-/// truncated (closes #1241).
+/// Default fraction of the output-token ceiling at/above which a response is
+/// treated as truncated when no `finish_reason` is available (closes #1241).
 ///
-/// Why: providers stop generating exactly at `max_tokens` without always setting
-/// an explicit `finish_reason`.  When the completion lands at ≥95 % of the ceiling
-/// the structured JSON is very likely cut off mid-object, so trusting its parse
-/// risks a silent wrong-APPROVE.  95 % (not 100 %) leaves a small margin for
-/// provider-side token-count rounding so a genuinely-complete response that lands
-/// a few tokens under the ceiling is not mis-flagged.
-/// What: the multiplier applied to `max_tokens` in `is_truncated`.
-/// Test: `is_truncated_*` unit tests in `runner_tests.rs`.
-const TRUNCATION_TOKEN_RATIO: f64 = 0.95;
+/// Why: this is the FALLBACK heuristic.  Some providers stop generating exactly
+/// at `max_tokens` without surfacing a `finish_reason`; when the completion lands
+/// at ≥95 % of the ceiling the structured JSON is very likely cut off mid-object,
+/// so trusting its parse risks a silent wrong-APPROVE.  95 % (not 100 %) leaves a
+/// small margin for provider-side token-count rounding so a genuinely-complete
+/// response that lands a few tokens under the ceiling is not mis-flagged.  As of
+/// #1357 this ratio is only consulted when `finish_reason` is absent — a provider
+/// that reports `finish_reason: "stop"` at 99 % of the ceiling is NOT flagged.
+/// What: the default multiplier applied to `max_tokens`, overridable at runtime
+/// via `truncation_token_ratio` (env seam) so operators can retune without a
+/// rebuild.
+/// Test: `is_truncated_ratio_fallback_*` unit tests in `runner_tests.rs`.
+const DEFAULT_TRUNCATION_TOKEN_RATIO: f64 = 0.95;
+
+/// Environment variable that overrides [`DEFAULT_TRUNCATION_TOKEN_RATIO`].
+///
+/// Why: #1357 asked for the fallback ratio to be configurable.  A single env seam
+/// (rather than threading a config field through every call site) keeps the change
+/// small while still letting operators retune the fallback band without a rebuild.
+/// What: parsed as `f64` in `truncation_token_ratio`; ignored when unset, empty,
+/// unparseable, or outside `(0.0, 1.0]`.
+const TRUNCATION_TOKEN_RATIO_ENV: &str = "TRUSTY_REVIEW_TRUNCATION_TOKEN_RATIO";
+
+/// Resolve the effective truncation token ratio (env override, else default).
+///
+/// Why: centralises the configurable-ratio seam (#1357) so both the runner and its
+/// tests read the ratio through one place; an out-of-range or unparseable override
+/// falls back to the default rather than silently disabling the safety check.
+/// What: reads `TRUSTY_REVIEW_TRUNCATION_TOKEN_RATIO`; returns the parsed value when
+/// it is a finite `f64` in `(0.0, 1.0]`, else `DEFAULT_TRUNCATION_TOKEN_RATIO`.
+/// Test: `truncation_ratio_env_override_applies`, `truncation_ratio_env_invalid_falls_back`.
+fn truncation_token_ratio() -> f64 {
+    match std::env::var(TRUNCATION_TOKEN_RATIO_ENV) {
+        Ok(raw) => match raw.trim().parse::<f64>() {
+            Ok(v) if v.is_finite() && v > 0.0 && v <= 1.0 => v,
+            _ => DEFAULT_TRUNCATION_TOKEN_RATIO,
+        },
+        Err(_) => DEFAULT_TRUNCATION_TOKEN_RATIO,
+    }
+}
 
 /// Return `true` when an LLM completion appears truncated at the token ceiling.
 ///
 /// Why: a truncated reviewer response must fail CLOSED to UNKNOWN rather than be
-/// parsed into a (likely wrong) APPROVE — the #1241 safety fix.  Detection is
-/// purely arithmetic so it works across every provider regardless of whether the
-/// provider surfaces an explicit `finish_reason`.
-/// What: returns `true` when `max_tokens > 0` AND
-/// `output_tokens >= ceil(max_tokens * TRUNCATION_TOKEN_RATIO)`.  A `max_tokens`
-/// of 0 (unset / unknown ceiling) disables the check (returns `false`) so we never
-/// false-positive when the ceiling is unknown.
-/// Test: `is_truncated_at_ceiling_true`, `is_truncated_well_under_false`,
+/// parsed into a (likely wrong) APPROVE — the #1241 safety fix.  Before #1357 the
+/// detection was purely arithmetic (token-ratio), which FALSE-POSITIVED on large
+/// but complete responses that legitimately landed in the ≥95 % band.  The
+/// provider's own `finish_reason` is the authoritative truncation signal, so #1357
+/// makes it PRIMARY and keeps the token-ratio only as a fallback when the provider
+/// did not surface a reason.
+/// What:
+///   1. PRIMARY — when `finish_reason` is present: return `true` iff it is a
+///      length/truncation reason (`"length"` / `"max_tokens"` / `"max_token"`),
+///      and `false` for any natural-stop reason (`"stop"`, `"end_turn"`, …).  The
+///      token ratio is NOT consulted, so a complete response at 99 % of the ceiling
+///      is not mis-flagged.
+///   2. FALLBACK — when `finish_reason` is `None`: return `true` when `max_tokens > 0`
+///      AND `output_tokens >= ceil(max_tokens * truncation_token_ratio())`.  A
+///      `max_tokens` of 0 (unknown ceiling) disables the check (returns `false`).
+///
+/// `finish_reason` is matched case-insensitively (providers already lowercase it,
+/// but we trim/lowercase defensively).
+///
+/// Test: `is_truncated_finish_reason_length_true`,
+/// `is_truncated_finish_reason_stop_at_high_ratio_false`,
+/// `is_truncated_ratio_fallback_at_ceiling_true`,
+/// `is_truncated_ratio_fallback_well_under_false`,
 /// `is_truncated_unset_ceiling_false`.
-fn is_truncated(output_tokens: u32, max_tokens: u32) -> bool {
+fn is_truncated(finish_reason: Option<&str>, output_tokens: u32, max_tokens: u32) -> bool {
+    // PRIMARY: trust the provider's explicit completion reason when present.
+    if let Some(reason) = finish_reason {
+        let r = reason.trim().to_ascii_lowercase();
+        if !r.is_empty() {
+            return matches!(r.as_str(), "length" | "max_tokens" | "max_token");
+        }
+    }
+
+    // FALLBACK: no usable finish_reason — use the token-ratio heuristic.
     if max_tokens == 0 {
         return false;
     }
-    let threshold = (f64::from(max_tokens) * TRUNCATION_TOKEN_RATIO).ceil() as u32;
+    let threshold = (f64::from(max_tokens) * truncation_token_ratio()).ceil() as u32;
     output_tokens >= threshold
 }
 

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -302,6 +302,7 @@ mod tests {
                 output_tokens: 1,
                 latency_ms: 0,
                 cost_usd: 0.0,
+                finish_reason: None,
             })
         }
     }

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -102,6 +102,7 @@ impl LlmProvider for FakeLlm {
             output_tokens: self.output_tokens.unwrap_or(50),
             latency_ms: 42,
             cost_usd: 0.000042,
+            finish_reason: None,
         })
     }
 }
@@ -127,6 +128,7 @@ impl LlmProvider for FakeVerifier {
             output_tokens: 3,
             latency_ms: 1,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }
@@ -395,32 +397,157 @@ async fn run_review_truncated_output_is_unknown() {
     );
 }
 
+/// PRIMARY signal (#1357): a length/max_tokens finish_reason flags truncation
+/// regardless of the token count.
+///
+/// Why: the provider's own completion reason is authoritative; an explicit
+/// `length` means the model was cut off even if token accounting looks fine.
+/// What: asserts `length` / `max_tokens` → truncated even with low output tokens.
+/// Test: this test itself.
 #[test]
-fn is_truncated_at_ceiling_true() {
-    // 4096 ceiling: ceil(4096 * 0.95) = 3892; output >= that is truncated.
-    assert!(is_truncated(4096, 4096), "exactly at ceiling is truncated");
+fn is_truncated_finish_reason_length_true() {
     assert!(
-        is_truncated(3892, 4096),
-        "at the 95% threshold is truncated"
+        is_truncated(Some("length"), 10, 4096),
+        "finish_reason=length is truncated even well under the ceiling"
+    );
+    assert!(
+        is_truncated(Some("max_tokens"), 10, 4096),
+        "finish_reason=max_tokens (Bedrock) is truncated"
+    );
+    // Case-insensitive / padded.
+    assert!(is_truncated(Some(" LENGTH "), 10, 4096));
+}
+
+/// PRIMARY signal (#1357): a natural-stop finish_reason at a HIGH token ratio is
+/// NOT flagged — this is the false-positive the issue targets.
+///
+/// Why: before #1357 a complete response landing ≥95 % of the ceiling was
+/// mis-flagged UNKNOWN.  With finish_reason primary, `stop`/`end_turn` overrides
+/// the ratio heuristic entirely.
+/// What: asserts `stop` / `end_turn` at 99–100 % of the ceiling → NOT truncated.
+/// Test: this test itself.
+#[test]
+fn is_truncated_finish_reason_stop_at_high_ratio_false() {
+    assert!(
+        !is_truncated(Some("stop"), 4096, 4096),
+        "finish_reason=stop at 100% of ceiling is NOT truncated (#1357 false-positive fix)"
+    );
+    assert!(
+        !is_truncated(Some("end_turn"), 4090, 4096),
+        "finish_reason=end_turn (Bedrock natural stop) near the ceiling is NOT truncated"
+    );
+}
+
+/// FALLBACK heuristic (#1357): when finish_reason is absent, the token-ratio
+/// behaves exactly as the pre-#1357 #1241 logic.
+///
+/// Why: providers that don't surface a reason must still fail closed on a likely
+/// cut-off response.
+/// What: 4096 ceiling, ceil(4096*0.95)=3892; output >= that → truncated.
+/// Test: this test itself.
+#[test]
+fn is_truncated_ratio_fallback_at_ceiling_true() {
+    assert!(
+        is_truncated(None, 4096, 4096),
+        "no finish_reason, exactly at ceiling → truncated"
+    );
+    assert!(
+        is_truncated(None, 3892, 4096),
+        "no finish_reason, at the 95% threshold → truncated"
+    );
+    // An empty-string finish_reason is treated as "absent" → fall back to ratio.
+    assert!(
+        is_truncated(Some(""), 4096, 4096),
+        "empty reason falls back to ratio"
     );
 }
 
 #[test]
-fn is_truncated_well_under_false() {
+fn is_truncated_ratio_fallback_well_under_false() {
     assert!(
-        !is_truncated(3891, 4096),
-        "one below the 95% threshold is NOT truncated"
+        !is_truncated(None, 3891, 4096),
+        "no finish_reason, one below the 95% threshold → NOT truncated"
     );
-    assert!(!is_truncated(50, 4096), "a short response is NOT truncated");
+    assert!(
+        !is_truncated(None, 50, 4096),
+        "no finish_reason, a short response → NOT truncated"
+    );
 }
 
 #[test]
 fn is_truncated_unset_ceiling_false() {
-    // max_tokens == 0 means the ceiling is unknown — never false-positive.
+    // max_tokens == 0 means the ceiling is unknown — never false-positive on the
+    // fallback path.
     assert!(
-        !is_truncated(10_000, 0),
-        "unknown ceiling (0) disables the truncation check"
+        !is_truncated(None, 10_000, 0),
+        "unknown ceiling (0) disables the fallback truncation check"
     );
+}
+
+// ── Configurable fallback ratio (#1357) ───────────────────────────────────
+// These tests mutate a process-global env var, so they must not interleave with
+// each other.  A local mutex serialises them; each restores the prior value.
+
+/// Serialises env-mutating ratio tests so they don't race.
+static RATIO_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// #1357: a valid `TRUSTY_REVIEW_TRUNCATION_TOKEN_RATIO` override changes the
+/// fallback threshold.
+///
+/// Why: operators must be able to retune the fallback band without a rebuild.
+/// What: sets the env ratio to 0.50; asserts a 50 %-of-ceiling response (no
+/// finish_reason) is now flagged where the 0.95 default would not flag it.
+/// Test: this test itself (serialised via `RATIO_ENV_LOCK`).
+#[test]
+fn truncation_ratio_env_override_applies() {
+    let _guard = RATIO_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var(TRUNCATION_TOKEN_RATIO_ENV).ok();
+    // SAFETY: single-threaded within the lock; restored before unlock.
+    unsafe { std::env::set_var(TRUNCATION_TOKEN_RATIO_ENV, "0.50") };
+
+    assert!(
+        (truncation_token_ratio() - 0.50).abs() < f64::EPSILON,
+        "env override should set the ratio to 0.50"
+    );
+    // ceil(4096 * 0.50) = 2048 — a 2048-token response now flags (would not at 0.95).
+    assert!(
+        is_truncated(None, 2048, 4096),
+        "with ratio 0.50, 50% of ceiling is truncated on the fallback path"
+    );
+
+    match prev {
+        Some(v) => unsafe { std::env::set_var(TRUNCATION_TOKEN_RATIO_ENV, v) },
+        None => unsafe { std::env::remove_var(TRUNCATION_TOKEN_RATIO_ENV) },
+    }
+}
+
+/// #1357: an invalid / out-of-range override falls back to the default ratio.
+///
+/// Why: a typo (or a nonsensical value like `2.0`) must never silently disable
+/// the truncation safety check.
+/// What: sets the env ratio to an out-of-range value; asserts the default 0.95
+/// is used.
+/// Test: this test itself (serialised via `RATIO_ENV_LOCK`).
+#[test]
+fn truncation_ratio_env_invalid_falls_back() {
+    let _guard = RATIO_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var(TRUNCATION_TOKEN_RATIO_ENV).ok();
+    unsafe { std::env::set_var(TRUNCATION_TOKEN_RATIO_ENV, "2.0") };
+    assert!(
+        (truncation_token_ratio() - DEFAULT_TRUNCATION_TOKEN_RATIO).abs() < f64::EPSILON,
+        "out-of-range override (>1.0) must fall back to the default"
+    );
+
+    unsafe { std::env::set_var(TRUNCATION_TOKEN_RATIO_ENV, "not-a-number") };
+    assert!(
+        (truncation_token_ratio() - DEFAULT_TRUNCATION_TOKEN_RATIO).abs() < f64::EPSILON,
+        "unparseable override must fall back to the default"
+    );
+
+    match prev {
+        Some(v) => unsafe { std::env::set_var(TRUNCATION_TOKEN_RATIO_ENV, v) },
+        None => unsafe { std::env::remove_var(TRUNCATION_TOKEN_RATIO_ENV) },
+    }
 }
 
 /// REQUIRED-CONTEXT GATE (#590): when trusty-search is unreachable and required

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -298,28 +298,10 @@ fn rederive_verdict(
 /// Test: `rederive_confirmed_medium_caps_at_approve_star` (REQUEST_CHANGES→APPROVE*),
 /// `rederive_confirmed_praise_keeps_clean_approve` (APPROVE stays APPROVE — #1343).
 fn verdict_min(a: Verdict, b: Verdict) -> Verdict {
-    if verdict_ord(&a) <= verdict_ord(&b) {
-        a
-    } else {
-        b
-    }
-}
-
-/// Ordinal severity for a verdict (higher = more severe).
-///
-/// Why: `verdict_min` needs a total order over verdicts to pick the less-severe one.
-/// Mirrors the ordering in `grade.rs::verdict_ord` so the two modules agree.
-/// What: APPROVE=0, APPROVE*=1, REQUEST_CHANGES=2, BLOCK=3, UNKNOWN=4 (terminal,
-/// never compared in normal flow).
-/// Test: covered transitively by `verdict_min` callers in `verify_tests.rs`.
-fn verdict_ord(v: &Verdict) -> u8 {
-    match v {
-        Verdict::Approve => 0,
-        Verdict::ApproveWithReservations => 1,
-        Verdict::RequestChanges => 2,
-        Verdict::Block => 3,
-        Verdict::Unknown => 4,
-    }
+    // #1357: compare via `Verdict::ordinal` (the single source of truth) instead
+    // of a module-local copy of the ordinal table, so this module and `grade.rs`
+    // can never drift apart.
+    if a.ordinal() <= b.ordinal() { a } else { b }
 }
 
 // ─── Candidate selection ─────────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/verify_liveness.rs
+++ b/crates/trusty-review/src/pipeline/verify_liveness.rs
@@ -209,6 +209,7 @@ mod tests {
                 output_tokens: 1,
                 latency_ms: 1,
                 cost_usd: 0.0,
+                finish_reason: None,
             })
         }
     }

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -49,6 +49,7 @@ impl LlmProvider for FixedVerifier {
             output_tokens: 5,
             latency_ms: 1,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }
@@ -70,6 +71,7 @@ impl LlmProvider for TruncatedVerifier {
             output_tokens: 3,
             latency_ms: 1,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }

--- a/crates/trusty-review/src/profile/batch_reviewer_tests.rs
+++ b/crates/trusty-review/src/profile/batch_reviewer_tests.rs
@@ -41,6 +41,7 @@ impl LlmProvider for FakeLlm {
             output_tokens: 50,
             latency_ms: 10,
             cost_usd: 0.0001,
+            finish_reason: None,
         })
     }
 }

--- a/crates/trusty-review/src/profile/synthesizer_tests.rs
+++ b/crates/trusty-review/src/profile/synthesizer_tests.rs
@@ -42,6 +42,7 @@ impl LlmProvider for FakeLlm {
             output_tokens: 100,
             latency_ms: 50,
             cost_usd: 0.0002,
+            finish_reason: None,
         })
     }
 }

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -52,6 +52,7 @@ impl LlmProvider for FakeLlm {
             output_tokens: 5,
             latency_ms: 1,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }

--- a/crates/trusty-review/src/service/inference_probe_tests.rs
+++ b/crates/trusty-review/src/service/inference_probe_tests.rs
@@ -29,6 +29,7 @@ impl LlmProvider for OkLlm {
             output_tokens: 1,
             latency_ms: 0,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }
@@ -94,6 +95,7 @@ impl LlmProvider for CountingLlm {
             output_tokens: 1,
             latency_ms: 0,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }

--- a/crates/trusty-review/src/service/webhook_tests.rs
+++ b/crates/trusty-review/src/service/webhook_tests.rs
@@ -45,6 +45,7 @@ impl LlmProvider for FakeLlm {
             output_tokens: 5,
             latency_ms: 1,
             cost_usd: 0.0,
+            finish_reason: None,
         })
     }
 }


### PR DESCRIPTION
Closes #1352
Closes #1357

Two advisory refinement issues in `trusty-review`, batched in one PR (overlapping files; separate PRs would conflict on the version pin). Existing 0.3.13 behavior is preserved — the #1343 calibration regression tests are unchanged and still pass.

## #1352 — explicit `is_high_severity` predicate in the verdict floor

**Investigation finding:** `Finding` has **no `severity` field**. The domain model uses `Effort` (Low/Medium/High) as the documented severity proxy: `Effort::High` ⇔ "Critical or High severity", `Medium` ⇔ Medium, `Low` ⇔ Low (see `models::Effort` and the `grade.rs` module doc). There is therefore no `Severity::{Critical,High}` to switch to, and `Effort::High` already *is* the canonical critical/high axis.

**Decision:** introduce a named `is_high_severity(f) -> bool` helper (returns `f.effort == Effort::High`) and use it at all three floor call sites (`is_substantive`, the `has_high` ceiling check, and `severity_floor`). This makes the *severity* intent explicit and gives a single seam to evolve if a dedicated `Severity` field ever lands — while remaining **behaviour-equivalent** to the previous inline `Effort::High` check. The #1343 calibration tests pass unchanged (no fixture edits needed). Comment wording fixed: "a genuine critical concern" → "a genuine critical or high-severity concern".

## #1357 — four hardening follow-ups

1. **Truncation via `finish_reason` (primary), token-ratio (fallback).** Added `finish_reason: Option<String>` to `LlmResponse`, threaded from both providers (OpenRouter `choices[].finish_reason`; Bedrock `ConverseOutput::stop_reason()`, normalised lowercase). `is_truncated` now trusts `finish_reason` first — `length`/`max_tokens` ⇒ truncated, `stop`/`end_turn` ⇒ NOT truncated even at ≥95 % of the ceiling (fixes the false-positive UNKNOWN). The token-ratio is used only when `finish_reason` is absent. The fallback ratio is configurable via the `TRUSTY_REVIEW_TRUNCATION_TOKEN_RATIO` env seam (centralised in `truncation_token_ratio()`, default 0.95, invalid/out-of-range values fall back to the default rather than disabling the safety check).
2. **Surface the reviewer_model override-fallback.** `deps_from_state` now returns `(ReviewDeps, Option<String>)`; when an override provider fails to build and the pipeline falls back to the startup provider, the reason is surfaced in the `review_pr`/`review_diff` MCP response as **`reviewer_model_fallback`** — both as a top-level envelope field (programmatic detection) and spliced into the serialised payload JSON the LLM reads. Non-breaking (`isError` stays false); the review still runs.
3. **Single `Verdict` ordinal.** Extracted the duplicated `verdict_ord` from `grade.rs` and `verify.rs` into one `Verdict::ordinal()` method in `models/`; both call sites now use it. Removed both duplicates.
4. **Gemini pricing provenance.** Added a source URL (OpenRouter pricing page), reference date (2026-06-17), and a `// TODO: refresh pricing` marker near `gemini_cost_per_million`. No value changes.

## Tests
- New: `is_high_severity_matches_high_effort`, `verdict_ordinal_is_monotonic`, `is_truncated_finish_reason_length_true`, `is_truncated_finish_reason_stop_at_high_ratio_false`, `is_truncated_ratio_fallback_*`, `truncation_ratio_env_override_applies`/`_invalid_falls_back`, `deps_from_state_build_failure_reports_fallback`, `wrap_result_surfaces_reviewer_model_fallback`/`_no_fallback_omits_field`.
- `cargo test -p trusty-review`: **843 + 19 passed, 0 failed** (incl. all #1343 calibration + #1350 safety-net tests). Clippy clean (`-D warnings`), `cargo fmt --check` clean, line-cap gate passes.

## Notes
- **NO version bump** — release deferred (still 0.3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)