### PR TITLE
chore(release): trusty-search v0.24.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11064,7 +11064,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.24.9"
+version = "0.24.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.24.9"
+version = "0.24.10"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bumps `trusty-search` from `0.24.9` → `0.24.10` (patch release)
- Ships the `status [INDEX] --watch` fix from #1365 (commit dc9e4fa6)
- No code changes — version bump only; all pre-flight checks pass

## Pre-flight

- `cargo fmt --check` ✓
- `cargo clippy -p trusty-search --all-targets -- -D warnings` ✓ (no warnings)
- `cargo test -p trusty-search` ✓ (all tests pass)
- `cargo publish --dry-run -p trusty-search` ✓ (packaged 291 files, 3.7 MiB)

## References

- Fixes: #1365
- Fix commit: dc9e4fa6