### PR TITLE
feat(trusty-mpm): intent-conformance front gate (C3)

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -119,6 +119,7 @@ trusty-common = { workspace = true, features = [
     "bug-capture",
     "crate-config",
     "console-metrics",
+    "intent-source",
 ] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # `console-metrics` enables `trusty_common::console_metrics` (used unconditionally by

--- a/crates/trusty-mpm/src/daemon/managed_routes/front_gate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/front_gate.rs
@@ -316,28 +316,76 @@ pub fn front_gate_disposition(
     }
 }
 
-/// Compose two dispositions STRICTER-WINS (escalate beats auto-accept).
+/// Which input won the stricter-wins composition (the escalation source).
+///
+/// Why: the FRONT gate's `proposed_default` is only meaningful when the
+/// *conformance* path is what escalated — it names the conformant method to
+/// adopt. When the *autonomy* tier is the escalation source (e.g. a T4
+/// destructive task), surfacing the conformance-derived method is misleading: the
+/// reason reads "T4: destructive" while `proposed_default` says "use cursor
+/// pagination", which has nothing to do with why we stopped (#1360 review). The
+/// composition must therefore report which side won so the caller can scope
+/// `proposed_default` to the conformance case only.
+/// What: `Conformance` — the conformance disposition is the (sole) escalation
+/// source; `Autonomy` — the autonomy tier escalated (it wins outright when both
+/// escalate, since the tier engine is the authoritative safety floor); `Neither`
+/// — both auto-accepted, no escalation.
+/// Test: `tests::stricter_wins_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EscalationSource {
+    /// Both inputs auto-accepted; the composition did not escalate.
+    Neither,
+    /// The conformance disposition is the escalation source.
+    Conformance,
+    /// The autonomy tier is the escalation source (wins when both escalate).
+    Autonomy,
+}
+
+/// Compose two dispositions STRICTER-WINS, reporting the escalation source.
 ///
 /// Why: spec §5.1 / AC-16 — the conformance disposition is *combined* with the
 /// standard `evaluate_autonomy_tier` decision by taking the stricter outcome. The
 /// gate must NEVER *lower* a tier escalation to auto-accept (a T4/destructive
 /// action still escalates regardless of conformance). Equally, a conformance
 /// divergence must escalate even when the autonomy tier would auto-accept.
-/// What: returns `Escalate` if EITHER input escalates (preferring the autonomy
-/// reason when both escalate, since the tier engine is the established safety
-/// authority); returns `AutoAccept` only when BOTH auto-accept.
+/// Beyond the disposition, the caller needs to know WHICH side escalated so it can
+/// scope `proposed_default` to the conformance-only case (#1360 review): a
+/// `proposed_default` derived from conformance is meaningless when the autonomy
+/// tier is the reason we stopped.
+/// What: returns the stricter `Disposition` plus an [`EscalationSource`] tag —
+/// `Escalate` if EITHER input escalates (preferring the autonomy reason when both
+/// escalate, since the tier engine is the established safety authority, and
+/// tagging the source `Autonomy` in that case); `AutoAccept` (tagged `Neither`)
+/// only when BOTH auto-accept.
+/// Test: `tests::stricter_wins_*`, `tests::run_*_proposed_default_*`.
+#[must_use]
+pub fn stricter_of_with_source(
+    conformance: Disposition,
+    autonomy: Disposition,
+) -> (Disposition, EscalationSource) {
+    match (&conformance, &autonomy) {
+        // Both clear → auto-accept (cite conformance, the gate's own reason).
+        (Disposition::AutoAccept { .. }, Disposition::AutoAccept { .. }) => {
+            (conformance, EscalationSource::Neither)
+        }
+        // Autonomy escalates → autonomy wins (tier safety is authoritative; it
+        // must never be lowered by conformance). It wins even when conformance
+        // ALSO escalates, so the source is `Autonomy` in both sub-cases.
+        (_, Disposition::Escalate { .. }) => (autonomy, EscalationSource::Autonomy),
+        // Only conformance escalates → conformance wins.
+        (Disposition::Escalate { .. }, _) => (conformance, EscalationSource::Conformance),
+    }
+}
+
+/// Compose two dispositions STRICTER-WINS (escalate beats auto-accept).
+///
+/// Why: the disposition-only projection of [`stricter_of_with_source`], for call
+/// sites and tests that do not need the escalation-source tag.
+/// What: returns the stricter `Disposition`, discarding the source tag.
 /// Test: `tests::stricter_wins_*`.
 #[must_use]
 pub fn stricter_of(conformance: Disposition, autonomy: Disposition) -> Disposition {
-    match (&conformance, &autonomy) {
-        // Both clear → auto-accept (cite conformance, the gate's own reason).
-        (Disposition::AutoAccept { .. }, Disposition::AutoAccept { .. }) => conformance,
-        // Autonomy escalates → autonomy wins (tier safety is authoritative; it
-        // must never be lowered by conformance).
-        (_, Disposition::Escalate { .. }) => autonomy,
-        // Only conformance escalates → conformance wins.
-        (Disposition::Escalate { .. }, _) => conformance,
-    }
+    stricter_of_with_source(conformance, autonomy).0
 }
 
 /// Run the FRONT gate for a spawn, producing a [`FrontGateOutcome`].
@@ -383,15 +431,22 @@ pub async fn run_front_gate(
     // (3) Derive the planned method from the task prose (heuristic, offline).
     let planned = heuristic_method(task);
 
-    // (4) Map to a conformance disposition; (5) compose stricter-wins.
+    // (4) Map to a conformance disposition; (5) compose stricter-wins, keeping the
+    // escalation source so we can scope `proposed_default` correctly.
     let conformance = front_gate_disposition(&intent, planned.as_ref());
     let prescribed = prescribed_method(&intent).map(|m| m.text.trim().to_string());
-    let disposition = stricter_of(conformance, autonomy);
+    let (disposition, source) = stricter_of_with_source(conformance, autonomy);
 
-    // Only surface a proposed default when we actually escalate.
-    let proposed_default = match &disposition {
-        Disposition::Escalate { .. } => prescribed,
-        Disposition::AutoAccept { .. } => None,
+    // `proposed_default` carries the conformant method to adopt — it is ONLY
+    // meaningful when the CONFORMANCE path is the escalation source. When the
+    // autonomy tier escalates (e.g. T4 destructive), the conformance-derived
+    // method is unrelated to why we stopped, so surfacing it would mislead the
+    // human (the reason would say "T4: destructive" while the default says "use
+    // cursor pagination"). Scope it to `Conformance` only; `None` otherwise
+    // (#1360 review).
+    let proposed_default = match source {
+        EscalationSource::Conformance => prescribed,
+        EscalationSource::Autonomy | EscalationSource::Neither => None,
     };
 
     FrontGateOutcome {
@@ -443,13 +498,28 @@ pub fn autonomy_disposition(ctx: &ActionContext, signals: &GuardrailSignals) -> 
 /// the destructive-keyword scan reads) under `ChangeClass::StyleOnly`, plus a
 /// neutral pre-work [`GuardrailSignals`], and runs `evaluate_autonomy_tier`. Maps
 /// the empty-task error to a fail-open `AutoAccept`.
-/// Test: `tests::prework_autonomy_*`.
+///
+/// Why `ChangeClass::StyleOnly` is the safe pre-work default: the destructive
+/// scan is NOT gated by the change class. `classify_tier` first derives a base
+/// tier from the class (StyleOnly → T1) and then *unconditionally* bumps to T4 if
+/// `ActionContext::mentions_destructive_op()` matches a destructive keyword —
+/// `if ctx.mentions_destructive_op() { base.max(T4) }` runs independently of
+/// `change_class`. So picking the *lowest* base tier (StyleOnly/T1) cannot
+/// suppress a destructive escalation: a "drop table" task is forced to T4
+/// regardless. This is exactly the pre-work intent — ordinary work auto-accepts
+/// (T1), destructive text escalates (T4). The passing test
+/// `tests::prework_autonomy_destructive_task_escalates` ("drop table sessions …")
+/// pins this behaviour; if the keyword scan were ever gated on `change_class`,
+/// switch this default to `ChangeClass::Standard` as the conservative floor.
+/// Test: `tests::prework_autonomy_*` (esp. `prework_autonomy_destructive_task_escalates`).
 #[must_use]
 pub fn prework_autonomy_disposition(task: &str) -> Disposition {
     let ctx = ActionContext {
         pending_decision: task.to_string(),
         // Pre-spawn we cannot classify the diff; the destructive-keyword scan in
-        // `evaluate_autonomy_tier` still forces T4 on irreversible task text.
+        // `evaluate_autonomy_tier` (`classify_tier`) forces T4 on irreversible
+        // task text INDEPENDENT of this class, so StyleOnly is the safe default —
+        // it sets the lowest base tier without suppressing destructive escalation.
         change_class: ChangeClass::StyleOnly,
         correlation: SessionCorrelation::new(),
         prior_rejections: 0,

--- a/crates/trusty-mpm/src/daemon/managed_routes/front_gate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/front_gate.rs
@@ -1,0 +1,482 @@
+//! Pre-spawn intent/method-conformance FRONT gate (DOC-15 C3, #1360).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CONFORMANCE-02~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-02~draft) (§5.1 FRONT gate)
+//! - [`SPEC-CONFORMANCE-01~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-01~draft) (§4 decision matrix)
+//!
+//! Why: a managed session begins *coding a ticket* the moment
+//! [`crate::daemon::managed_routes::spawn_managed`] calls `adapter.spawn`. The
+//! FRONT gate is the only seam that owns BOTH the task text (the intent) and the
+//! spawn trigger, so it is where we can check the planned method against the
+//! ticket+spec intent *before* any code is written — when redirection is
+//! cheapest (spec §5.1 Rationale). The gate realises the ~80% auto / ~20%
+//! escalate operating model: the default is auto-proceed; escalation is the
+//! exception, reserved for a genuine method divergence (spec G2).
+//!
+//! What: this module is the pure, testable core of the gate. It exposes
+//! - [`ConformanceGate`] — the seam over the shared ISR
+//!   (`trusty_common::intent_source`), so the spawn path can resolve a
+//!   `ResolvedIntent` without coupling to a live GitHub client (mocked in tests);
+//! - [`HeadlessApproval`] — the #1269 capability flag that selects the headless
+//!   auto-spawn path vs. the degraded operator-confirm path;
+//! - [`front_gate_disposition`] — the pure matrix→`Disposition` mapping, composed
+//!   STRICTER-WINS with `evaluate_autonomy_tier` so conformance can never *lower*
+//!   a tier escalation (spec §5.1, AC-16);
+//! - [`run_front_gate`] — the async orchestration the spawn path calls.
+//!
+//! Fail-open everywhere (spec §4.2, AC-17): non-ticketed work, an unresolved
+//! ISR, or an empty planned/prescribed method all yield `AutoAccept` — the gate
+//! must NEVER be the reason work stalls.
+//!
+//! Test: `super::front_gate::tests` covers the matrix rows (agree/gap/divergence),
+//! fail-open (non-ticketed + ISR failure), the stricter-wins composition, and the
+//! #1269 degraded branch — all without network access (AC-13..AC-17).
+
+use async_trait::async_trait;
+
+use trusty_common::intent_source::backend_fetcher::{BackendTicketFetcher, FsSpecLookup};
+use trusty_common::intent_source::{
+    EnvTokenResolver, IntentQuery, Method, Precedence, ResolvedIntent, extract_ticket_id,
+    heuristic_method,
+};
+
+use crate::driver::correlation::{ScopeCheck, SessionCorrelation};
+use crate::driver::policy::{
+    ActionContext, AutonomyDecision, ChangeClass, CiStatus, Disposition, GuardrailSignals,
+    ReviewVerdict, evaluate_autonomy_tier,
+};
+
+/// The fail-open reason used when the gate has no intent to conform to.
+///
+/// Why: non-ticketed work, an unresolved ISR, and a clean gap all collapse to
+/// the same outcome — auto-proceed — and the spec fixes the reason text
+/// ("no intent source", §5.1). Centralising the literal keeps every call site
+/// and every test asserting on one string.
+/// What: the canonical `AutoAccept` reason for the fail-open / no-intent path.
+/// Test: `tests::non_ticketed_auto_accepts`, `tests::isr_failure_auto_accepts`.
+pub const NO_INTENT_SOURCE: &str = "no intent source";
+
+/// Whether the fully-headless auto-spawn approval path is available (#1269).
+///
+/// Why: spec §5.1 — the fully-headless auto-spawn path is **soft-blocked by
+/// #1269**. The gate must still land and function: on an escalation it degrades
+/// to the CLI-owned launch / operator-confirm path rather than blocking the
+/// whole gate on #1269. Modelling the capability as an explicit two-state value
+/// (rather than a bare `bool`) keeps the degradation branch self-documenting at
+/// every call site.
+/// What: `Headless` — the headless approval channel is live (post-#1269);
+/// `OperatorConfirm` — degrade an escalation to operator confirmation (the
+/// `pending_decision` is written and surfaced through the CLI/activity channels,
+/// and a human resolves it via `POST …/answer`).
+/// Test: `tests::degraded_branch_marks_operator_confirm`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeadlessApproval {
+    /// The headless auto-spawn approval path is available (post-#1269).
+    Headless,
+    /// Degraded path: escalation requires operator confirmation (pre-#1269).
+    OperatorConfirm,
+}
+
+impl HeadlessApproval {
+    /// The capability the gate runs under until #1269 lands.
+    ///
+    /// Why: #1269 soft-blocks the headless auto-spawn path; until it merges, the
+    /// production spawn path must use the degraded operator-confirm branch so the
+    /// gate lands and functions today (spec §5.1 Rationale, scope item 6).
+    /// What: returns [`HeadlessApproval::OperatorConfirm`].
+    /// Test: `tests::current_capability_is_degraded`.
+    #[must_use]
+    pub fn current() -> Self {
+        // #1269 not yet landed: degrade to operator-confirm.
+        HeadlessApproval::OperatorConfirm
+    }
+}
+
+/// The outcome of running the FRONT gate against a spawn.
+///
+/// Why: the spawn path needs more than a yes/no — on an escalation it must write
+/// the `pending_decision`/`proposed_default` and withhold the spawn, and it must
+/// know whether it is on the headless or the degraded operator-confirm path so it
+/// can log/surface accordingly (spec §5.1).
+/// What: carries the composed [`Disposition`], plus — when the disposition is
+/// `Escalate` — the `proposed_default` (the conformant method to surface to the
+/// human) and the approval mode in force.
+/// Test: `tests::*` assert on the disposition and the escalation fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrontGateOutcome {
+    /// The composed disposition (stricter of conformance vs. autonomy).
+    pub disposition: Disposition,
+    /// The conformant method to propose to the human, when escalating.
+    pub proposed_default: Option<String>,
+    /// Which approval path is in force (headless vs. degraded operator-confirm).
+    pub approval: HeadlessApproval,
+}
+
+impl FrontGateOutcome {
+    /// Whether the gate cleared and the spawn may proceed.
+    ///
+    /// Why: the spawn path branches on this to call `adapter.spawn` or withhold
+    /// it; a helper keeps the call site declarative.
+    /// What: returns `true` when the composed disposition is `AutoAccept`.
+    /// Test: asserted across `tests::*`.
+    #[must_use]
+    pub fn may_spawn(&self) -> bool {
+        self.disposition.is_auto_accept()
+    }
+
+    /// The escalation reason text, when the gate escalated.
+    ///
+    /// Why: the spawn path writes this into `SessionRecord.pending_decision` so it
+    /// surfaces through every existing channel (activity API, CLI, supervisor).
+    /// What: returns the `Escalate` reason, or `None` on auto-accept.
+    /// Test: `tests::divergence_escalates`.
+    #[must_use]
+    pub fn escalation_reason(&self) -> Option<&str> {
+        match &self.disposition {
+            Disposition::Escalate { reason } => Some(reason),
+            Disposition::AutoAccept { .. } => None,
+        }
+    }
+}
+
+/// Seam over the shared intent-source resolver (ISR).
+///
+/// Why: `run_front_gate` must resolve a `ResolvedIntent` from a ticket-id, but
+/// the production resolver fetches a GitHub issue over the network. Modelling the
+/// resolution as a trait lets the spawn path run the real ISR while unit tests
+/// inject a deterministic mock — no network, fully offline (spec §5.1 inputs,
+/// CLAUDE.md no-network-in-tests).
+/// What: one async method mapping `(ticket_id, owner, repo, task)` to a
+/// `ResolvedIntent`. Implementors MUST be fail-open: any failure resolves to
+/// [`ResolvedIntent::unresolved`], never an `Err` (the trait is infallible by
+/// design so the gate can never block on resolver failure — spec §4.2).
+/// Test: `tests` use a `MockGate`; the production impl is [`IsrConformanceGate`].
+#[async_trait]
+pub trait ConformanceGate: Send + Sync {
+    /// Resolve the intent for a ticketed task.
+    ///
+    /// Why: the FRONT gate compares the *planned method* (derived from `task`)
+    /// against the ticket/spec method the ISR resolves (spec §5.1).
+    /// What: returns a `ResolvedIntent`; fail-open (`unresolved`) on any failure.
+    /// Test: `tests` via `MockGate`.
+    async fn resolve(&self, ticket_id: &str, owner: &str, repo: &str, task: &str)
+    -> ResolvedIntent;
+}
+
+/// Production [`ConformanceGate`] backed by the shared ISR.
+///
+/// Why: the real gate must reuse `trusty_common::intent_source` — the single
+/// shared resolver both conformance gates call (spec G4) — rather than
+/// re-implement ticket fetch + precedence. This wraps it behind the
+/// `BackendTicketFetcher` (PAT/App-token via the pluggable resolver) and a
+/// filesystem spec lookup rooted at the session's workspace.
+/// What: holds the repo root used for SLD spec resolution; `resolve` builds an
+/// `IntentQuery::Ticket` (pre-work `changed_files` is empty, so the spec axis is
+/// keyed off the ticket body's links only — spec §6.1) and calls
+/// `resolve_default`, which is itself fail-open.
+/// Test: covered by `tests::production_gate_*` (offline: a non-fetchable ticket
+/// resolves to `unresolved`, the fail-open contract — no network is exercised).
+pub struct IsrConformanceGate {
+    repo_root: std::path::PathBuf,
+}
+
+impl IsrConformanceGate {
+    /// Construct a production gate rooted at `repo_root` for spec resolution.
+    ///
+    /// Why: SLD spec refs are repo-relative (`docs/specs/…`); the loader needs
+    /// the checkout root to resolve them (spec §6.4).
+    /// What: stores the root used to build the `FsSpecLookup`.
+    /// Test: `tests::production_gate_*`.
+    #[must_use]
+    pub fn new(repo_root: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            repo_root: repo_root.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ConformanceGate for IsrConformanceGate {
+    async fn resolve(
+        &self,
+        ticket_id: &str,
+        owner: &str,
+        repo: &str,
+        _task: &str,
+    ) -> ResolvedIntent {
+        let fetcher: BackendTicketFetcher = BackendTicketFetcher::new(Box::new(EnvTokenResolver));
+        let spec_lookup = FsSpecLookup::new(self.repo_root.clone());
+        let query = IntentQuery::Ticket {
+            ticket_id: ticket_id.to_string(),
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            changed_files: Vec::new(),
+        };
+        // `resolve_default` is itself fail-open — it returns `unresolved` on any
+        // fetch/parse failure and never `Err`s (spec §4.2).
+        trusty_common::intent_source::resolve_default(query, &fetcher, &spec_lookup).await
+    }
+}
+
+/// The method the resolved intent prescribes, under precedence (ticket > spec).
+///
+/// Why: the FRONT gate compares the planned method against the *winning* method,
+/// not against both axes — precedence has already been applied centrally by the
+/// ISR (spec §6.1). A small accessor keeps [`front_gate_disposition`] declarative.
+/// What: returns the ticket method when the ticket won, the spec method when the
+/// spec won, and `None` for a gap.
+/// Test: `tests::prescribed_method_follows_precedence`.
+fn prescribed_method(intent: &ResolvedIntent) -> Option<&Method> {
+    match intent.precedence_winner {
+        Precedence::Ticket => intent.ticket_method.as_ref(),
+        Precedence::Spec => intent.spec_method.as_ref(),
+        Precedence::None => None,
+    }
+}
+
+/// Lowercase + collapse whitespace, for method-text comparison.
+///
+/// Why: trivial formatting differences between the planned method (from the task
+/// prose) and the prescribed method (from the ticket/spec) must not register as a
+/// divergence — that would manufacture a false escalation (spec §4.3 fail-open
+/// bias). Mirrors the ISR's own `normalise` so FRONT and the resolver agree on
+/// what "the same method" means.
+/// What: lowercases, splits on whitespace, and rejoins single-spaced.
+/// Test: `tests::planned_matching_prescribed_auto_accepts`.
+fn normalise(s: &str) -> String {
+    s.to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Map the resolved intent + planned method onto a conformance `Disposition`.
+///
+/// Why: this is the FRONT half of the normative decision matrix (spec §4.1),
+/// pre-work. It is a pure function of `(intent, planned_method)` so it is fully
+/// unit-testable offline.
+/// What: implements the matrix rows for FRONT —
+/// - `unresolved` / non-ticketed / gap (no prescribed method) → `AutoAccept`
+///   (M3, fail-open §4.2);
+/// - a prescribed method exists and the planned method is absent OR agrees with
+///   it → `AutoAccept` (M1/M2 agree). Pre-work the plan is implicit, so an absent
+///   planned method is treated as conformant (escalate-only-on-divergence, §5.1);
+/// - a prescribed method exists and the planned method *diverges* from it →
+///   `Escalate` (M1/M2/M5 divergence). The reason names both methods so a human
+///   can triage instantly (`first_failing_signal` style, §5.1).
+///
+/// Note (M4): a ticket/spec **conflict** is NOT an escalation here — the ISR has
+/// already applied ticket > spec, so the prescribed method is the *ticket*
+/// method and the gate conforms to it; the stale spec is advisory only (spec
+/// §4.1 M4, §5.1). The conflict therefore only matters insofar as the planned
+/// method diverges from the *ticket* method.
+/// Test: `tests::gap_auto_accepts`, `tests::planned_matching_prescribed_auto_accepts`,
+/// `tests::divergence_escalates`, `tests::conflict_follows_ticket`.
+#[must_use]
+pub fn front_gate_disposition(
+    intent: &ResolvedIntent,
+    planned_method: Option<&Method>,
+) -> Disposition {
+    // Fail-open: ISR could not resolve → no intent to conform to (spec §4.2).
+    if let Some(reason) = &intent.unresolved {
+        return Disposition::AutoAccept {
+            reason: format!("{NO_INTENT_SOURCE} (unresolved: {reason})"),
+        };
+    }
+
+    let Some(prescribed) = prescribed_method(intent) else {
+        // M3 gap: neither ticket nor spec prescribes a method — nothing to
+        // conform to.
+        return Disposition::AutoAccept {
+            reason: format!("{NO_INTENT_SOURCE} (no prescribed method; gap)"),
+        };
+    };
+
+    match planned_method {
+        // M1/M2 agree (or no explicit plan pre-work → treat as conformant): the
+        // planned approach matches the prescribed method.
+        None => Disposition::AutoAccept {
+            reason: "conformance: no divergent plan; ticket/spec method honoured".to_string(),
+        },
+        Some(planned) if normalise(&planned.text) == normalise(&prescribed.text) => {
+            Disposition::AutoAccept {
+                reason: "conformance: planned method matches the ticket/spec method".to_string(),
+            }
+        }
+        // M1/M2/M5 divergence: the planned method contradicts an explicit
+        // ticket/spec method — escalate before any code is written (spec §5.1).
+        Some(planned) => Disposition::Escalate {
+            reason: format!(
+                "conformance divergence: ticket/spec specifies \"{}\"; plan uses \"{}\"",
+                prescribed.text.trim(),
+                planned.text.trim()
+            ),
+        },
+    }
+}
+
+/// Compose two dispositions STRICTER-WINS (escalate beats auto-accept).
+///
+/// Why: spec §5.1 / AC-16 — the conformance disposition is *combined* with the
+/// standard `evaluate_autonomy_tier` decision by taking the stricter outcome. The
+/// gate must NEVER *lower* a tier escalation to auto-accept (a T4/destructive
+/// action still escalates regardless of conformance). Equally, a conformance
+/// divergence must escalate even when the autonomy tier would auto-accept.
+/// What: returns `Escalate` if EITHER input escalates (preferring the autonomy
+/// reason when both escalate, since the tier engine is the established safety
+/// authority); returns `AutoAccept` only when BOTH auto-accept.
+/// Test: `tests::stricter_wins_*`.
+#[must_use]
+pub fn stricter_of(conformance: Disposition, autonomy: Disposition) -> Disposition {
+    match (&conformance, &autonomy) {
+        // Both clear → auto-accept (cite conformance, the gate's own reason).
+        (Disposition::AutoAccept { .. }, Disposition::AutoAccept { .. }) => conformance,
+        // Autonomy escalates → autonomy wins (tier safety is authoritative; it
+        // must never be lowered by conformance).
+        (_, Disposition::Escalate { .. }) => autonomy,
+        // Only conformance escalates → conformance wins.
+        (Disposition::Escalate { .. }, _) => conformance,
+    }
+}
+
+/// Run the FRONT gate for a spawn, producing a [`FrontGateOutcome`].
+///
+/// Why: the single entry point [`crate::daemon::managed_routes::spawn_managed`]
+/// calls between record-creation and `adapter.spawn`. It ties together ticket
+/// extraction, ISR resolution, the conformance disposition, and the stricter-wins
+/// composition with autonomy — and selects the headless vs. degraded path.
+/// What: in order — (1) extract a ticket-id from `task`; non-ticketed →
+/// `AutoAccept` fail-open (AC-17); (2) resolve the intent via `gate` (fail-open);
+/// (3) derive the planned method from `task` (heuristic, no network); (4) map to a
+/// conformance `Disposition` ([`front_gate_disposition`]); (5) compose
+/// stricter-wins with `autonomy` ([`stricter_of`]); (6) wrap with the
+/// `proposed_default` (the prescribed method) and the `approval` mode. The gate
+/// is infallible by design (every failure is fail-open) so it can never block.
+/// Test: `tests::run_*` (AC-13, AC-14, AC-16, AC-17).
+pub async fn run_front_gate(
+    gate: &dyn ConformanceGate,
+    owner: &str,
+    repo: &str,
+    task: &str,
+    autonomy: Disposition,
+    approval: HeadlessApproval,
+) -> FrontGateOutcome {
+    // (1) Extract a ticket-id from the task prose. Non-ticketed → fail-open.
+    let Some(ticket_id) = extract_ticket_id(task) else {
+        let disposition = stricter_of(
+            Disposition::AutoAccept {
+                reason: format!("{NO_INTENT_SOURCE} (non-ticketed work)"),
+            },
+            autonomy,
+        );
+        return FrontGateOutcome {
+            disposition,
+            proposed_default: None,
+            approval,
+        };
+    };
+
+    // (2) Resolve intent (fail-open by the trait contract).
+    let intent = gate.resolve(&ticket_id, owner, repo, task).await;
+
+    // (3) Derive the planned method from the task prose (heuristic, offline).
+    let planned = heuristic_method(task);
+
+    // (4) Map to a conformance disposition; (5) compose stricter-wins.
+    let conformance = front_gate_disposition(&intent, planned.as_ref());
+    let prescribed = prescribed_method(&intent).map(|m| m.text.trim().to_string());
+    let disposition = stricter_of(conformance, autonomy);
+
+    // Only surface a proposed default when we actually escalate.
+    let proposed_default = match &disposition {
+        Disposition::Escalate { .. } => prescribed,
+        Disposition::AutoAccept { .. } => None,
+    };
+
+    FrontGateOutcome {
+        disposition,
+        proposed_default,
+        approval,
+    }
+}
+
+/// Build the autonomy [`Disposition`] the FRONT gate composes against.
+///
+/// Why: the gate must compose with `evaluate_autonomy_tier` (spec §5.1), but
+/// pre-work most guardrail signals (review, CI) are not yet available — the work
+/// has not been done. The honest pre-work signal set is "unknown", which the
+/// autonomy engine already treats conservatively. This helper builds an
+/// `ActionContext`/`GuardrailSignals` pair from what IS known pre-work (the task
+/// text as the decision, the caller-supplied change class) and runs the engine,
+/// so the FRONT gate gives `evaluate_autonomy_tier` its FIRST production caller
+/// (spec §2.2 — the engine was built+tested with zero callers).
+/// What: runs `evaluate_autonomy_tier` with an unavailable/unknown guardrail set
+/// and the supplied [`ActionContext`]; maps the inevitable `EmptyDecision` error
+/// (empty task) to a fail-open `AutoAccept` so the gate never blocks on its own
+/// composition step.
+/// Test: `tests::autonomy_disposition_*`.
+#[must_use]
+pub fn autonomy_disposition(ctx: &ActionContext, signals: &GuardrailSignals) -> Disposition {
+    match evaluate_autonomy_tier(ctx, signals) {
+        Ok(decision) => decision_into_disposition(decision),
+        // An empty decision text cannot be classified; fail open rather than
+        // block the gate on its own composition input (spec §4.2).
+        Err(_) => Disposition::AutoAccept {
+            reason: format!("{NO_INTENT_SOURCE} (autonomy input empty)"),
+        },
+    }
+}
+
+/// Build the PRE-WORK autonomy disposition for a task about to be spawned.
+///
+/// Why: the FRONT gate runs *before* any code exists, so the post-work guardrails
+/// (`review`, `ci`) are not yet meaningful — the work has not been done. The only
+/// autonomy dimension that applies pre-spawn is the tier/destructive classifier:
+/// a task that names an irreversible operation (`delete`, `drop table`,
+/// `decommission`, …) must escalate before the agent is even launched (T4),
+/// while ordinary work proceeds. Feeding the engine `StyleOnly` + a pre-work
+/// signal set (review `Unavailable`, CI `Unknown` — NOT `Reject`/`Red`) yields
+/// exactly that: auto-accept normally, escalate on destructive text. This is the
+/// engine's FIRST production caller (spec §2.2).
+/// What: constructs an [`ActionContext`] from the task text (the `pending_decision`
+/// the destructive-keyword scan reads) under `ChangeClass::StyleOnly`, plus a
+/// neutral pre-work [`GuardrailSignals`], and runs `evaluate_autonomy_tier`. Maps
+/// the empty-task error to a fail-open `AutoAccept`.
+/// Test: `tests::prework_autonomy_*`.
+#[must_use]
+pub fn prework_autonomy_disposition(task: &str) -> Disposition {
+    let ctx = ActionContext {
+        pending_decision: task.to_string(),
+        // Pre-spawn we cannot classify the diff; the destructive-keyword scan in
+        // `evaluate_autonomy_tier` still forces T4 on irreversible task text.
+        change_class: ChangeClass::StyleOnly,
+        correlation: SessionCorrelation::new(),
+        prior_rejections: 0,
+    };
+    let signals = GuardrailSignals {
+        // Pre-work: not yet reviewed / no CI run. `Unavailable`/`Unknown` are NOT
+        // `Reject`/`Red`, so a T1 task auto-accepts; a destructive task is forced
+        // to T4 and escalates regardless.
+        review: ReviewVerdict::Unavailable,
+        ci: CiStatus::Unknown,
+        search_consistent: true,
+        memory_consistent: true,
+        scope: ScopeCheck::InScope,
+    };
+    autonomy_disposition(&ctx, &signals)
+}
+
+/// Project an [`AutonomyDecision`] onto its [`Disposition`].
+///
+/// Why: [`stricter_of`] composes two `Disposition`s; the autonomy engine returns
+/// the richer `AutonomyDecision` (tier + disposition). This narrows it to the
+/// disposition the composition needs.
+/// What: returns `decision.disposition`.
+/// Test: `tests::autonomy_disposition_*`.
+fn decision_into_disposition(decision: AutonomyDecision) -> Disposition {
+    decision.disposition
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/front_gate/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/front_gate/tests.rs
@@ -207,6 +207,38 @@ fn stricter_wins_both_escalate_prefers_autonomy() {
     );
 }
 
+// ── stricter_of_with_source: escalation-source tagging (#1360 review) ────────────
+
+#[test]
+fn source_both_clear_is_neither() {
+    let (d, src) = stricter_of_with_source(auto("conformance ok"), auto("autonomy ok"));
+    assert!(d.is_auto_accept());
+    assert_eq!(src, EscalationSource::Neither);
+}
+
+#[test]
+fn source_conformance_only_is_conformance() {
+    let (d, src) = stricter_of_with_source(esc("conformance divergence"), auto("autonomy ok"));
+    assert_eq!(d, esc("conformance divergence"));
+    assert_eq!(src, EscalationSource::Conformance);
+}
+
+#[test]
+fn source_autonomy_only_is_autonomy() {
+    let (d, src) = stricter_of_with_source(auto("conformance ok"), esc("T4: destructive"));
+    assert_eq!(d, esc("T4: destructive"));
+    assert_eq!(src, EscalationSource::Autonomy);
+}
+
+#[test]
+fn source_both_escalate_is_autonomy() {
+    // Autonomy wins outright when both escalate; the source is Autonomy so the
+    // (possibly irrelevant) conformance-derived proposed_default is suppressed.
+    let (d, src) = stricter_of_with_source(esc("conformance divergence"), esc("T4"));
+    assert_eq!(d, esc("T4"), "tier authority wins");
+    assert_eq!(src, EscalationSource::Autonomy);
+}
+
 // ── run_front_gate: orchestration (AC-13, AC-14, AC-16, AC-17) ──────────────────
 
 fn gate_with(intent: ResolvedIntent) -> MockGate {
@@ -282,6 +314,67 @@ async fn run_divergence_escalates_and_proposes_default() {
         out.proposed_default.as_deref(),
         Some("use cursor-based pagination"),
         "proposed_default is the conformant ticket method"
+    );
+}
+
+#[tokio::test]
+async fn run_autonomy_only_escalation_has_no_proposed_default() {
+    // #1360 review: conformance is CLEAN (plan matches ticket method) but the
+    // autonomy tier escalates (T4). proposed_default must be None — surfacing the
+    // conformance method here would mislead the human (reason says "T4", default
+    // would say "use cursor pagination", which is unrelated to why we stopped).
+    let gate = gate_with(ticket_intent("use cursor pagination"));
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        // Plan agrees with the ticket method, so conformance auto-accepts; the
+        // autonomy disposition supplied below is the lone escalation source.
+        "Closes #1360: implement listing.\nuse cursor pagination",
+        esc("T4: irreversible or security-sensitive operation; human confirmation required"),
+        HeadlessApproval::OperatorConfirm,
+    )
+    .await;
+    assert!(!out.may_spawn(), "autonomy T4 escalates");
+    assert!(
+        out.escalation_reason().unwrap().contains("T4"),
+        "reason is the autonomy tier reason"
+    );
+    assert!(
+        out.proposed_default.is_none(),
+        "autonomy-only escalation must not surface a conformance proposed_default"
+    );
+}
+
+#[tokio::test]
+async fn run_both_escalate_reason_is_autonomy_and_default_not_conformance() {
+    // #1360 review: BOTH paths escalate — conformance diverges AND autonomy is T4.
+    // The autonomy tier wins (safety authority), so the reason is the autonomy
+    // reason and proposed_default is NOT the (now-irrelevant) conformance method.
+    let gate = gate_with(ticket_intent("use cursor-based pagination"));
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        // Plan diverges from the ticket method → conformance escalates too.
+        "Fixes #1360: implement listing.\nuse offset pagination for the endpoint",
+        esc("T4: irreversible or security-sensitive operation; human confirmation required"),
+        HeadlessApproval::OperatorConfirm,
+    )
+    .await;
+    assert!(!out.may_spawn(), "both escalate");
+    assert!(
+        out.escalation_reason().unwrap().contains("T4"),
+        "autonomy reason wins when both escalate"
+    );
+    assert_ne!(
+        out.proposed_default.as_deref(),
+        Some("use cursor-based pagination"),
+        "must not surface the conformance method when autonomy is the escalation source"
+    );
+    assert!(
+        out.proposed_default.is_none(),
+        "autonomy-sourced escalation carries no proposed_default"
     );
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/front_gate/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/front_gate/tests.rs
@@ -1,0 +1,431 @@
+//! Unit tests for the pre-spawn conformance FRONT gate (AC-13..AC-17).
+//!
+//! Why: the gate's correctness is safety-critical (it decides whether a session
+//! auto-spawns or escalates) and must be verifiable offline — no GitHub, no
+//! network. These tests mock the ISR seam and assert every matrix row, the
+//! fail-open paths, the stricter-wins composition, and the #1269 degraded branch.
+//! What: a `MockGate` returning a fixed `ResolvedIntent`, plus pure-function
+//! assertions over `front_gate_disposition` / `stricter_of` / `run_front_gate`.
+//! Test: this IS the test module.
+
+use super::*;
+
+use async_trait::async_trait;
+use trusty_common::intent_source::{Method, MethodKind, Precedence, ResolvedIntent, TicketRef};
+
+use crate::driver::correlation::{ScopeCheck, SessionCorrelation};
+use crate::driver::policy::{
+    ActionContext, ChangeClass, CiStatus, Disposition, GuardrailSignals, ReviewVerdict,
+};
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/// A `ConformanceGate` that returns a pre-baked `ResolvedIntent` (no network).
+struct MockGate(ResolvedIntent);
+
+#[async_trait]
+impl ConformanceGate for MockGate {
+    async fn resolve(
+        &self,
+        _ticket_id: &str,
+        _owner: &str,
+        _repo: &str,
+        _task: &str,
+    ) -> ResolvedIntent {
+        self.0.clone()
+    }
+}
+
+fn method(text: &str) -> Method {
+    Method {
+        text: text.to_string(),
+        kind: MethodKind::Approach,
+        source_excerpt: text.to_string(),
+    }
+}
+
+fn ticket_ref() -> TicketRef {
+    TicketRef {
+        id: "#1360".to_string(),
+        title: "front gate".to_string(),
+        url: None,
+        backend: "github".to_string(),
+    }
+}
+
+/// A resolved intent where the TICKET prescribes `m` (precedence: Ticket).
+fn ticket_intent(m: &str) -> ResolvedIntent {
+    ResolvedIntent {
+        ticket: Some(ticket_ref()),
+        ticket_method: Some(method(m)),
+        spec_section: None,
+        spec_method: None,
+        precedence_winner: Precedence::Ticket,
+        conflict: false,
+        stale_spec: false,
+        unresolved: None,
+    }
+}
+
+fn auto(reason: &str) -> Disposition {
+    Disposition::AutoAccept {
+        reason: reason.to_string(),
+    }
+}
+
+fn esc(reason: &str) -> Disposition {
+    Disposition::Escalate {
+        reason: reason.to_string(),
+    }
+}
+
+// ── front_gate_disposition: matrix rows ─────────────────────────────────────────
+
+#[test]
+fn gap_auto_accepts() {
+    // M3: neither ticket nor spec prescribes a method.
+    let intent = ResolvedIntent::none();
+    let d = front_gate_disposition(&intent, None);
+    assert!(d.is_auto_accept(), "gap must auto-accept (M3)");
+}
+
+#[test]
+fn unresolved_auto_accepts() {
+    // Fail-open (AC-17): ISR could not resolve.
+    let intent = ResolvedIntent::unresolved("ticket fetch failed: 404");
+    let d = front_gate_disposition(&intent, Some(&method("use cursor pagination")));
+    assert!(
+        d.is_auto_accept(),
+        "unresolved must auto-accept (fail-open)"
+    );
+    let reason = match d {
+        Disposition::AutoAccept { reason } => reason,
+        Disposition::Escalate { .. } => unreachable!(),
+    };
+    assert!(reason.contains(NO_INTENT_SOURCE));
+}
+
+#[test]
+fn planned_matching_prescribed_auto_accepts() {
+    // M1 agree: planned method matches the ticket method (whitespace/case-insensitive).
+    let intent = ticket_intent("use cursor pagination");
+    let d = front_gate_disposition(&intent, Some(&method("Use   Cursor  Pagination")));
+    assert!(d.is_auto_accept(), "matching method must auto-accept");
+}
+
+#[test]
+fn absent_plan_auto_accepts() {
+    // Pre-work the plan is implicit; an absent planned method is conformant
+    // (escalate-only-on-divergence, §5.1).
+    let intent = ticket_intent("use cursor pagination");
+    let d = front_gate_disposition(&intent, None);
+    assert!(d.is_auto_accept(), "absent plan must auto-accept");
+}
+
+#[test]
+fn divergence_escalates() {
+    // M5: planned method contradicts the explicit ticket method.
+    let intent = ticket_intent("use cursor-based pagination");
+    let d = front_gate_disposition(&intent, Some(&method("use offset pagination")));
+    assert!(!d.is_auto_accept(), "divergence must escalate (M5)");
+    let reason = match d {
+        Disposition::Escalate { reason } => reason,
+        Disposition::AutoAccept { .. } => unreachable!(),
+    };
+    assert!(
+        reason.contains("cursor"),
+        "reason names the prescribed method"
+    );
+    assert!(reason.contains("offset"), "reason names the planned method");
+}
+
+#[test]
+fn conflict_follows_ticket() {
+    // M4: ticket and spec conflict → ticket wins (precedence applied by ISR).
+    // A plan matching the TICKET method auto-accepts; the stale spec is advisory.
+    let mut intent = ticket_intent("use cursor pagination");
+    intent.spec_section = None;
+    intent.spec_method = Some(method("use offset pagination"));
+    intent.conflict = true;
+    intent.stale_spec = true;
+    // precedence_winner stays Ticket (the ISR sets this); prescribed = ticket method.
+    let d = front_gate_disposition(&intent, Some(&method("use cursor pagination")));
+    assert!(
+        d.is_auto_accept(),
+        "M4 conforms to the ticket; stale spec advisory"
+    );
+}
+
+#[test]
+fn spec_only_divergence_escalates() {
+    // M2/M5: ticket silent, spec prescribes; plan diverges from the spec method.
+    let intent = ResolvedIntent {
+        ticket: Some(ticket_ref()),
+        ticket_method: None,
+        spec_section: None,
+        spec_method: Some(method("use cursor pagination")),
+        precedence_winner: Precedence::Spec,
+        conflict: false,
+        stale_spec: false,
+        unresolved: None,
+    };
+    let d = front_gate_disposition(&intent, Some(&method("use offset pagination")));
+    assert!(!d.is_auto_accept(), "spec divergence must escalate (M2/M5)");
+}
+
+// ── stricter_of: composition (AC-16) ────────────────────────────────────────────
+
+#[test]
+fn stricter_wins_both_clear() {
+    let d = stricter_of(auto("conformance ok"), auto("autonomy ok"));
+    assert!(d.is_auto_accept());
+}
+
+#[test]
+fn stricter_wins_autonomy_escalates() {
+    // Conformance would auto-accept, but a T4/destructive autonomy escalation
+    // must NOT be lowered (AC-16).
+    let d = stricter_of(auto("conformance ok"), esc("T4: destructive"));
+    assert!(!d.is_auto_accept(), "tier escalation must not be lowered");
+    assert_eq!(d, esc("T4: destructive"));
+}
+
+#[test]
+fn stricter_wins_conformance_escalates() {
+    let d = stricter_of(esc("conformance divergence"), auto("autonomy ok"));
+    assert!(!d.is_auto_accept());
+    assert_eq!(d, esc("conformance divergence"));
+}
+
+#[test]
+fn stricter_wins_both_escalate_prefers_autonomy() {
+    let d = stricter_of(esc("conformance"), esc("T4"));
+    assert_eq!(
+        d,
+        esc("T4"),
+        "tier safety authority cited when both escalate"
+    );
+}
+
+// ── run_front_gate: orchestration (AC-13, AC-14, AC-16, AC-17) ──────────────────
+
+fn gate_with(intent: ResolvedIntent) -> MockGate {
+    MockGate(intent)
+}
+
+#[tokio::test]
+async fn run_non_ticketed_auto_accepts() {
+    // AC-17: non-ticketed work → AutoAccept (fail-open), gate never runs ISR.
+    let gate = gate_with(ResolvedIntent::none());
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        "implement the parser with no ticket reference",
+        auto("autonomy ok"),
+        HeadlessApproval::Headless,
+    )
+    .await;
+    assert!(out.may_spawn(), "non-ticketed work auto-accepts");
+    assert!(out.proposed_default.is_none());
+}
+
+#[tokio::test]
+async fn run_isr_failure_auto_accepts() {
+    // AC-17: ISR failure → AutoAccept (fail-open). Task IS ticketed.
+    let gate = gate_with(ResolvedIntent::unresolved("ticket fetch failed"));
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        "Closes #1360 — use offset pagination",
+        auto("autonomy ok"),
+        HeadlessApproval::Headless,
+    )
+    .await;
+    assert!(out.may_spawn(), "ISR failure auto-accepts (fail-open)");
+}
+
+#[tokio::test]
+async fn run_clean_match_auto_accepts() {
+    // AC-13: ticket method honoured (no divergent plan) → AutoAccept → spawn.
+    let gate = gate_with(ticket_intent("use cursor pagination"));
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        "Closes #1360: implement the feature",
+        auto("autonomy ok"),
+        HeadlessApproval::Headless,
+    )
+    .await;
+    assert!(out.may_spawn(), "clean match auto-accepts (AC-13)");
+    assert!(out.escalation_reason().is_none());
+}
+
+#[tokio::test]
+async fn run_divergence_escalates_and_proposes_default() {
+    // AC-14: planned method diverges → Escalate, proposed_default = ticket method.
+    let gate = gate_with(ticket_intent("use cursor-based pagination"));
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        "Fixes #1360: implement listing.\nuse offset pagination for the listing endpoint",
+        auto("autonomy ok"),
+        HeadlessApproval::OperatorConfirm,
+    )
+    .await;
+    assert!(!out.may_spawn(), "divergence escalates (AC-14)");
+    assert!(out.escalation_reason().is_some());
+    assert_eq!(
+        out.proposed_default.as_deref(),
+        Some("use cursor-based pagination"),
+        "proposed_default is the conformant ticket method"
+    );
+}
+
+#[tokio::test]
+async fn run_stricter_wins_autonomy_escalation_survives_conformance_auto_accept() {
+    // AC-16: conformance would auto-accept (clean match) but autonomy escalates
+    // (T4); the composed outcome must escalate.
+    let gate = gate_with(ticket_intent("use cursor pagination"));
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        "Closes #1360: implement the feature",
+        esc("T4: irreversible or security-sensitive operation"),
+        HeadlessApproval::Headless,
+    )
+    .await;
+    assert!(
+        !out.may_spawn(),
+        "tier escalation survives conformance auto-accept"
+    );
+    assert!(out.escalation_reason().unwrap().contains("T4"));
+}
+
+#[tokio::test]
+async fn degraded_branch_marks_operator_confirm() {
+    // #1269 degraded path: the outcome carries the operator-confirm approval mode
+    // so the spawn path withholds the spawn and surfaces pending_decision via CLI.
+    let gate = gate_with(ticket_intent("use cursor-based pagination"));
+    let out = run_front_gate(
+        &gate,
+        "owner",
+        "repo",
+        "Fixes #1360: implement listing.\nuse offset pagination",
+        auto("autonomy ok"),
+        HeadlessApproval::OperatorConfirm,
+    )
+    .await;
+    assert_eq!(out.approval, HeadlessApproval::OperatorConfirm);
+    assert!(
+        !out.may_spawn(),
+        "escalation in degraded mode still withholds spawn"
+    );
+}
+
+#[test]
+fn current_capability_is_degraded() {
+    // Until #1269 lands, the production path runs operator-confirm.
+    assert_eq!(
+        HeadlessApproval::current(),
+        HeadlessApproval::OperatorConfirm
+    );
+}
+
+// ── autonomy_disposition: first production caller of evaluate_autonomy_tier ──────
+
+fn correlated() -> SessionCorrelation {
+    SessionCorrelation::new()
+        .with_worktree("/repo/wt")
+        .with_issue_id(1360)
+}
+
+fn ctx(decision: &str, class: ChangeClass) -> ActionContext {
+    ActionContext {
+        pending_decision: decision.to_string(),
+        change_class: class,
+        correlation: correlated(),
+        prior_rejections: 0,
+    }
+}
+
+/// Pre-work guardrails are unknown/unavailable (the work isn't done yet).
+fn prework_signals() -> GuardrailSignals {
+    GuardrailSignals {
+        review: ReviewVerdict::Unavailable,
+        ci: CiStatus::Unknown,
+        search_consistent: true,
+        memory_consistent: true,
+        scope: ScopeCheck::InScope,
+    }
+}
+
+#[test]
+fn autonomy_disposition_destructive_escalates() {
+    // The engine's FIRST production caller: a destructive task escalates (T4).
+    let c = ctx(
+        "decommission the production index",
+        ChangeClass::Destructive,
+    );
+    let d = autonomy_disposition(&c, &prework_signals());
+    assert!(
+        !d.is_auto_accept(),
+        "destructive work escalates via the tier engine"
+    );
+}
+
+#[test]
+fn autonomy_disposition_style_only_auto_accepts() {
+    // A T1 style-only change with no objecting guardrail auto-accepts.
+    let c = ctx("apply rustfmt", ChangeClass::StyleOnly);
+    let d = autonomy_disposition(&c, &prework_signals());
+    assert!(d.is_auto_accept(), "T1 style-only auto-accepts pre-work");
+}
+
+#[test]
+fn autonomy_disposition_empty_decision_fails_open() {
+    // An empty decision cannot be classified → fail-open AutoAccept (never block
+    // the gate on its own composition input).
+    let c = ctx("   ", ChangeClass::Standard);
+    let d = autonomy_disposition(&c, &prework_signals());
+    assert!(d.is_auto_accept(), "empty decision fails open");
+}
+
+#[test]
+fn prework_autonomy_ordinary_task_auto_accepts() {
+    // An ordinary ticketed task auto-accepts pre-work (no destructive op).
+    let d = prework_autonomy_disposition("Closes #1360: implement the listing endpoint");
+    assert!(d.is_auto_accept(), "ordinary pre-work task auto-accepts");
+}
+
+#[test]
+fn prework_autonomy_destructive_task_escalates() {
+    // A destructive task escalates pre-spawn (T4), independent of conformance.
+    let d = prework_autonomy_disposition("Closes #1360: drop table sessions to reset state");
+    assert!(
+        !d.is_auto_accept(),
+        "destructive pre-work task escalates (T4)"
+    );
+}
+
+#[test]
+fn prework_autonomy_empty_task_fails_open() {
+    let d = prework_autonomy_disposition("   ");
+    assert!(d.is_auto_accept(), "empty task fails open");
+}
+
+#[test]
+fn prescribed_method_follows_precedence() {
+    let mut intent = ticket_intent("use cursor pagination");
+    intent.spec_method = Some(method("use offset pagination"));
+    // Ticket wins → prescribed is the ticket method.
+    let d = front_gate_disposition(&intent, Some(&method("use offset pagination")));
+    assert!(
+        !d.is_auto_accept(),
+        "diverges from ticket (the precedence winner)"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -134,6 +134,21 @@ pub async fn spawn_managed(
             e.to_string()
         })?;
 
+    // Step 2.5 — INTENT-CONFORMANCE FRONT GATE (#1360, spec §5.1).
+    //
+    // Between record-creation and `adapter.spawn`, resolve the ticket+spec intent
+    // for this task and decide whether to auto-proceed or escalate BEFORE any code
+    // is written. The gate is fail-open (non-ticketed work, an unresolved ISR, or
+    // a gap all auto-proceed) so it can never be the reason a spawn stalls. On an
+    // escalation it withholds the spawn, writes `pending_decision`/`proposed_default`
+    // (surfaced through every existing channel), and leaves the session in its
+    // pre-spawn `Provisioning` state until a human resolves it via `POST …/answer`.
+    if let Some(record) =
+        front_gate_or_escalate(&mgr, &record, &params.repo_url, &params.task).await?
+    {
+        return Ok(record);
+    }
+
     if let Err(e) = mgr
         .set_workspace(
             &record.id,
@@ -170,6 +185,140 @@ pub async fn spawn_managed(
     }
 
     Ok(mgr.get(&record.id).await.unwrap_or(record))
+}
+
+/// Perform the withheld spawn (Step 3) for a FRONT-gate-escalated session.
+///
+/// Why: when the FRONT gate escalates (#1360), the spawn is WITHHELD and the
+/// session sits in `Provisioning` with a `pending_decision`. After a human
+/// resolves it via `POST …/answer`, the runtime must actually start — otherwise
+/// the answer clears the decision but the agent never launches (AC-15). This is
+/// the exact Step 3 from [`spawn_managed`], lifted so the answer path can invoke
+/// it on demand.
+/// What: transitions the record to `Active` (persisting the workspace), builds
+/// the runtime adapter, and spawns the harness in the pane — marking the record
+/// errored on spawn failure (non-fatal, mirroring `spawn_managed`). Idempotent
+/// guard: callers should only invoke this for a session still in `Provisioning`
+/// (never spawned), so an already-live session is not double-spawned.
+/// Test: `front_gate_answer_unblocks_spawn` in tests/session_manager_mvp.rs.
+pub async fn spawn_runtime_for(
+    state: &Arc<DaemonState>,
+    record: &SessionRecord,
+) -> Result<(), String> {
+    let mgr = state.session_manager().await;
+    let workspace = record
+        .workspace_path
+        .clone()
+        .unwrap_or_else(|| record.cwd.clone());
+
+    if let Err(e) = mgr
+        .set_workspace(&record.id, workspace.clone(), ManagedSessionState::Active)
+        .await
+    {
+        warn!(id = %record.id, "spawn_runtime_for: set_workspace failed: {e}");
+    }
+
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = build_adapter(record.runtime, tmux_arc);
+    if let Err(e) = adapter.spawn(&record.tmux_name, &workspace, &record.task) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            "spawn_runtime_for: runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("spawn failed: {e}"))
+            .await;
+        return Err(e.to_string());
+    }
+    info!(
+        id = %record.id,
+        name = %record.tmux_name,
+        "FRONT-gate-escalated session spawned after human approval"
+    );
+    Ok(())
+}
+
+/// Run the intent-conformance FRONT gate for a freshly-created session record.
+///
+/// Why: factored out of [`spawn_managed`] so the gate's escalate-vs-proceed
+/// decision (and the #1269 degraded operator-confirm branch) is a single, named,
+/// testable step rather than inlined in the spawn ritual (spec §5.1, #1360). It
+/// keeps `spawn_managed` linear and under the 500-SLOC production cap.
+/// What: derives owner/repo from the repo URL, builds the production
+/// [`IsrConformanceGate`] rooted at the provisioned workspace, composes the
+/// conformance disposition with the pre-work autonomy disposition (stricter-wins,
+/// via [`run_front_gate`]), and —
+/// - on **auto-accept** → returns `Ok(None)`; the caller proceeds to spawn;
+/// - on **escalate** → writes `pending_decision`/`proposed_default` (so the
+///   escalation surfaces through `…/activity`, MCP `session_status`, the
+///   supervisor, and the `tm` CLI), withholds the spawn, logs the divergence,
+///   and returns `Ok(Some(record))` so the caller returns early WITHOUT spawning.
+///
+/// #1269 degradation: until the headless auto-spawn approval path lands
+/// ([`HeadlessApproval::current`] returns `OperatorConfirm`), an escalation
+/// degrades to the operator-confirm path — the pending decision is recorded and a
+/// human resolves it via `POST …/answer` (which then unblocks the spawn). The
+/// gate itself always functions; only the *resolution channel* is degraded.
+///
+/// Fail-open: the gate never `Err`s on its own resolution failures (it returns an
+/// `AutoAccept`); this function only returns `Err` if persisting the escalation
+/// fails — in which case the caller surfaces the store error rather than silently
+/// spawning.
+/// Test: `front_gate_escalation_sets_pending_decision` /
+/// `front_gate_clean_match_spawns` in tests/session_manager_mvp.rs, plus the unit
+/// matrix in `managed_routes::front_gate::tests`.
+async fn front_gate_or_escalate(
+    mgr: &Arc<crate::session_manager::SessionManager>,
+    record: &SessionRecord,
+    repo_url: &str,
+    task: &str,
+) -> Result<Option<SessionRecord>, String> {
+    use super::front_gate::{
+        HeadlessApproval, IsrConformanceGate, prework_autonomy_disposition, run_front_gate,
+    };
+
+    let (owner, repo) = match trusty_common::github_path::parse_github_path(repo_url) {
+        Some(gh) => (gh.owner, gh.repo),
+        // No GitHub identity → no ticket backend to resolve against; fail-open.
+        None => return Ok(None),
+    };
+
+    let repo_root = record
+        .workspace_path
+        .clone()
+        .unwrap_or_else(|| record.cwd.clone());
+    let gate = IsrConformanceGate::new(repo_root);
+    let autonomy = prework_autonomy_disposition(task);
+    let approval = HeadlessApproval::current();
+
+    let outcome = run_front_gate(&gate, &owner, &repo, task, autonomy, approval).await;
+
+    if outcome.may_spawn() {
+        return Ok(None);
+    }
+
+    let reason = outcome
+        .escalation_reason()
+        .unwrap_or("conformance escalation")
+        .to_string();
+    warn!(
+        id = %record.id,
+        approval = ?outcome.approval,
+        "spawn_managed: FRONT gate escalated; withholding spawn: {reason}"
+    );
+    mgr.set_pending_decision(&record.id, &reason, outcome.proposed_default.as_deref())
+        .await
+        .map_err(|e| {
+            warn!(id = %record.id, "spawn_managed: set_pending_decision failed: {e}");
+            e.to_string()
+        })?;
+
+    // Return the updated record (now carrying the pending decision), withholding
+    // the spawn. The session stays in `Provisioning` until a human answers.
+    Ok(Some(
+        mgr.get(&record.id).await.unwrap_or_else(|_| record.clone()),
+    ))
 }
 
 /// Typed failure modes for [`resume_managed`], shared across transports.

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -488,7 +488,18 @@ pub async fn answer_session_decision(
         if let Err(e) = mgr.clear_pending_decision(&id).await {
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
-        match spawn_runtime_for(&state, &record).await {
+        // Re-fetch AFTER clearing: `clear_pending_decision` upserts a new record
+        // version, so the `record` captured above is now stale (it still carries
+        // the pending decision). Spawn the runtime from the fresh snapshot so the
+        // withheld harness launches against the post-clear state (#1360 review).
+        let fresh = match mgr.get(&id).await {
+            Ok(r) => r,
+            Err(_) => {
+                return (StatusCode::NOT_FOUND, format!("session {id_str} not found"))
+                    .into_response();
+            }
+        };
+        match spawn_runtime_for(&state, &fresh).await {
             Ok(()) => Json(AnswerResponse {
                 injected: true,
                 tmux_name,

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -26,8 +26,14 @@ use crate::daemon::state::DaemonState;
 use crate::runtime::RuntimeKind;
 use crate::session_manager::{ManagedSessionId, SessionRecord};
 
+pub mod front_gate;
 mod lifecycle;
-pub use lifecycle::{ResumeManagedError, SpawnParams, resume_managed, spawn_managed};
+pub use front_gate::{
+    ConformanceGate, FrontGateOutcome, HeadlessApproval, IsrConformanceGate, run_front_gate,
+};
+pub use lifecycle::{
+    ResumeManagedError, SpawnParams, resume_managed, spawn_managed, spawn_runtime_for,
+};
 
 // ── Request / Response shapes ─────────────────────────────────────────────────
 
@@ -461,19 +467,44 @@ pub async fn answer_session_decision(
         Err((code, msg)) => return (code, msg).into_response(),
     };
     let mgr = state.session_manager().await;
-    let tmux_name = match mgr.get(&id).await {
-        Ok(r) => r.tmux_name,
+    let record = match mgr.get(&id).await {
+        Ok(r) => r,
         Err(_) => {
             return (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response();
         }
     };
-    match mgr.answer_decision(&id, &req.answer).await {
-        Ok(()) => Json(AnswerResponse {
-            injected: true,
-            tmux_name,
-        })
-        .into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    let tmux_name = record.tmux_name.clone();
+
+    // FRONT-gate (#1360) path: a session escalated *before* spawn sits in
+    // `Provisioning` with a `pending_decision` and NO running harness. Answering
+    // it must clear the decision AND launch the withheld runtime (AC-15) — not
+    // inject the answer into a bare pane. Any other state is the ordinary
+    // harness-question path (`answer_decision`, which injects into the live pane).
+    let is_front_gate_escalation = record.state
+        == crate::session_manager::ManagedSessionState::Provisioning
+        && record.pending_decision.is_some();
+
+    if is_front_gate_escalation {
+        if let Err(e) = mgr.clear_pending_decision(&id).await {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+        match spawn_runtime_for(&state, &record).await {
+            Ok(()) => Json(AnswerResponse {
+                injected: true,
+                tmux_name,
+            })
+            .into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+        }
+    } else {
+        match mgr.answer_decision(&id, &req.answer).await {
+            Ok(()) => Json(AnswerResponse {
+                injected: true,
+                tmux_name,
+            })
+            .into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -684,4 +684,53 @@ impl SessionManager {
         self.store.write().await.upsert(record).await?;
         Ok(())
     }
+
+    /// Record a pending decision (an escalation) on a session, awaiting a human.
+    ///
+    /// Why: the intent-conformance FRONT gate (#1360) escalates *before* the
+    /// runtime is spawned. It must surface the divergence reason + the conformant
+    /// default through the SAME channel the harness uses (`pending_decision` /
+    /// `proposed_default`), so it appears in `GET …/activity`, MCP
+    /// `session_status`, the supervisor, and the `tm` CLI with zero new UI. The
+    /// session is left NOT `Active` (the runtime never started) so it reads as
+    /// awaiting approval until a human resolves it via `POST …/answer`.
+    /// What: looks up the record, sets `pending_decision`/`proposed_default`,
+    /// leaves the lifecycle state untouched (it stays `Provisioning` — the
+    /// runtime was withheld), and persists. No tmux input is sent (unlike
+    /// `answer_decision`): the pane has no running harness to receive it yet.
+    /// Test: `front_gate_escalation_sets_pending_decision` in
+    /// tests/session_manager_mvp.rs.
+    pub async fn set_pending_decision(
+        &self,
+        id: &ManagedSessionId,
+        decision: &str,
+        proposed_default: Option<&str>,
+    ) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.pending_decision = Some(decision.to_string());
+        record.proposed_default = proposed_default.map(str::to_string);
+        record.last_activity_at = Some(Utc::now());
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+
+    /// Clear a pending decision WITHOUT injecting any text into the pane.
+    ///
+    /// Why: a FRONT-gate (#1360) escalation is resolved *before* a harness exists
+    /// — the session is still `Provisioning` with no runtime in the pane. Unlike
+    /// [`answer_decision`](Self::answer_decision) (which sends the answer to a
+    /// LIVE harness), the FRONT-gate answer path must clear the decision and then
+    /// LAUNCH the withheld runtime; sending the answer to a bare shell would be
+    /// meaningless. This method does the clear half only.
+    /// What: looks up the record, clears `pending_decision`/`proposed_default`,
+    /// updates `last_activity_at`, and persists. No tmux I/O.
+    /// Test: `front_gate_answer_unblocks_spawn` in tests/session_manager_mvp.rs.
+    pub async fn clear_pending_decision(&self, id: &ManagedSessionId) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.pending_decision = None;
+        record.proposed_default = None;
+        record.last_activity_at = Some(Utc::now());
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
 }

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -845,15 +845,53 @@ async fn front_gate_answer_unblocks_spawn() {
 
     // Human approves → clear decision + launch the withheld runtime.
     mgr.clear_pending_decision(&record.id).await.expect("clear");
-    let _ = spawn_runtime_for(&state, &record).await;
+    // Re-fetch after clearing so we spawn from the fresh, post-clear snapshot
+    // (mirrors the answer-route fix; #1360 review).
+    let fresh = mgr.get(&record.id).await.expect("get fresh");
+    let spawn_result = spawn_runtime_for(&state, &fresh).await;
 
     let after = mgr.get(&record.id).await.expect("get");
+    // The withheld spawn must ALWAYS leave Provisioning (AC-15).
     assert_ne!(
         after.state,
         ManagedSessionState::Provisioning,
         "the withheld spawn must advance the session out of Provisioning (AC-15)"
     );
     assert!(after.pending_decision.is_none());
+
+    // Fail LOUDLY on an unexpected terminal state. Two outcomes are legitimate:
+    //   - `Active`  → the runtime actually spawned (`spawn_runtime_for` => Ok);
+    //   - `Errored` → CI-without-tmux: no tmux/runtime binary is present, so
+    //     `adapter.spawn` fails and `spawn_runtime_for` returns Err, which
+    //     `mark_errored` records as a spawn failure on the record's task field.
+    // We tie the assertion to the spawn RESULT (not a blanket "any non-Provisioning
+    // state") so a genuinely wrong transition can never pass silently. The benign
+    // CI case is distinguished by asserting on the recorded error reason, not by
+    // blindly accepting any Errored state.
+    match spawn_result {
+        Ok(()) => assert_eq!(
+            after.state,
+            ManagedSessionState::Active,
+            "successful spawn must leave the session Active"
+        ),
+        Err(_) => {
+            assert_eq!(
+                after.state,
+                ManagedSessionState::Errored,
+                "a failed spawn must mark the session Errored, not any other state"
+            );
+            // `mark_errored` appends `[error: spawn failed: …]` to the task field;
+            // asserting on it confirms this is the benign runtime/tmux-unavailable
+            // case (the only way spawn legitimately fails in CI) rather than an
+            // unrelated failure that happens to land in Errored.
+            assert!(
+                after.task.contains("[error: spawn failed:"),
+                "Errored state must carry the runtime/tmux-unavailable spawn-failure \
+                 reason (CI-without-tmux); got task: {:?}",
+                after.task
+            );
+        }
+    }
 }
 
 /// Why: issue #1313 review nitpick #7 — assert the SM-unavailable → exit-code-75

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -180,6 +180,103 @@ async fn session_manager_answer_clears_pending_and_injects() {
     assert!(after.proposed_default.is_none());
 }
 
+/// FRONT gate (#1360): an escalation records a pending decision + proposed default.
+///
+/// Why: when the conformance FRONT gate escalates, the spawn is withheld and the
+/// divergence must surface through the SAME `pending_decision`/`proposed_default`
+/// channel the harness uses, leaving the session in its pre-spawn `Provisioning`
+/// state (AC-14). This asserts the manager primitive that does it.
+/// What: creates a session, calls `set_pending_decision`, and asserts the fields
+/// and that the lifecycle state was NOT advanced past `Provisioning`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn front_gate_escalation_sets_pending_decision() {
+    use trusty_mpm::session_manager::ManagedSessionState;
+
+    let dir = TempDir::new().unwrap();
+    let tmux = RecordingTmux::new();
+    let mgr = SessionManager::new(dir.path(), tmux.clone())
+        .await
+        .expect("manager");
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/ws")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    mgr.set_pending_decision(
+        &record.id,
+        "conformance divergence: ticket specifies cursor; plan uses offset",
+        Some("use cursor-based pagination"),
+    )
+    .await
+    .expect("set_pending_decision");
+
+    let after = mgr.get(&record.id).await.expect("get");
+    assert!(after.pending_decision.unwrap().contains("divergence"));
+    assert_eq!(
+        after.proposed_default.as_deref(),
+        Some("use cursor-based pagination")
+    );
+    // Spawn was withheld: state stays Provisioning, and no harness was injected.
+    assert_eq!(after.state, ManagedSessionState::Provisioning);
+    let injected = {
+        let sends = tmux.sends.lock().unwrap();
+        sends.iter().any(|(_, text)| text.contains("cursor"))
+    };
+    assert!(
+        !injected,
+        "set_pending_decision must not inject into the pane"
+    );
+}
+
+/// FRONT gate (#1360): clearing a pending decision performs no pane injection.
+///
+/// Why: a FRONT-gate escalation is answered BEFORE a harness exists; clearing the
+/// decision must not send text to the bare pane — the spawn happens separately
+/// (AC-15). This isolates the clear half.
+/// What: sets then clears a pending decision; asserts both fields are `None` and
+/// nothing was sent to tmux.
+/// Test: this IS the test.
+#[tokio::test]
+async fn front_gate_clear_pending_decision_no_injection() {
+    let dir = TempDir::new().unwrap();
+    let tmux = RecordingTmux::new();
+    let mgr = SessionManager::new(dir.path(), tmux.clone())
+        .await
+        .expect("manager");
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/ws")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    mgr.set_pending_decision(&record.id, "divergence", Some("use cursor"))
+        .await
+        .expect("set");
+    mgr.clear_pending_decision(&record.id).await.expect("clear");
+
+    let after = mgr.get(&record.id).await.expect("get");
+    assert!(after.pending_decision.is_none());
+    assert!(after.proposed_default.is_none());
+    let sends = tmux.sends.lock().unwrap();
+    assert!(sends.is_empty(), "clear must not inject any text");
+}
+
 // ── Handler-level anti-stub tests ────────────────────────────────────────────
 //
 // These tests call the critical path that the `spawn_session` HTTP handler
@@ -700,6 +797,63 @@ async fn resume_managed_typed_invalid_state_is_conflict() {
         matches!(err, ResumeManagedError::InvalidState(_)),
         "non-resumable state must map to the typed InvalidState variant (→ 409), got {err:?}"
     );
+}
+
+/// FRONT gate (#1360, AC-15): the withheld spawn launches after human approval.
+///
+/// Why: a session escalated by the FRONT gate sits in `Provisioning` with no
+/// runtime. Resolving its decision must actually LAUNCH the runtime (not just
+/// clear the flag) — `spawn_runtime_for` is the lifted Step 3 the answer path
+/// invokes. This asserts the runtime is spawned and the session leaves
+/// `Provisioning`.
+/// What: seeds a `Provisioning` session with a pending decision via the daemon's
+/// manager, calls `spawn_runtime_for`, and asserts the session is no longer
+/// `Provisioning` (the spawn was performed — `Active` on success, `Errored` only
+/// if the runtime binary is absent).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn front_gate_answer_unblocks_spawn() {
+    use trusty_mpm::daemon::managed_routes::spawn_runtime_for;
+    use trusty_mpm::session_manager::ManagedSessionState;
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(root.path().to_path_buf()));
+    let mgr = state.session_manager().await;
+
+    let id = ResumeSessionId::new();
+    let ws = root.path().join(format!("{id}-frontgate-ws"));
+    let record = mgr
+        .create_with_id(
+            id,
+            "Closes #1360: implement listing".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws),
+            Some("https://github.com/owner/repo".to_string()),
+            Some("main".to_string()),
+            ResumeRuntimeKind::default(),
+        )
+        .await
+        .expect("seed session");
+
+    // Simulate a FRONT-gate escalation: pending decision, still Provisioning.
+    mgr.set_pending_decision(&record.id, "conformance divergence", Some("use cursor"))
+        .await
+        .expect("set_pending_decision");
+    let before = mgr.get(&record.id).await.expect("get");
+    assert_eq!(before.state, ManagedSessionState::Provisioning);
+
+    // Human approves → clear decision + launch the withheld runtime.
+    mgr.clear_pending_decision(&record.id).await.expect("clear");
+    let _ = spawn_runtime_for(&state, &record).await;
+
+    let after = mgr.get(&record.id).await.expect("get");
+    assert_ne!(
+        after.state,
+        ManagedSessionState::Provisioning,
+        "the withheld spawn must advance the session out of Provisioning (AC-15)"
+    );
+    assert!(after.pending_decision.is_none());
 }
 
 /// Why: issue #1313 review nitpick #7 — assert the SM-unavailable → exit-code-75


### PR DESCRIPTION
Closes #1360
Part of #1354

## Scope (SPEC-CONFORMANCE-02 §5.1 / §7.2)

The FRONT gate of the intent/method-conformance system, in `trusty-mpm`. Inserted in `spawn_managed` between record creation (Step 2) and `adapter.spawn` (Step 3): resolves the ticket+spec intent via the shared C1 ISR (`trusty_common::intent_source`, `intent-source` feature) and decides auto-proceed vs. escalate **before any code is written**.

### What landed
- **`daemon::managed_routes::front_gate`** (new module):
  - `ConformanceGate` trait — the seam over the ISR (`resolve(IntentQuery::Ticket{..})`), mocked in tests so the gate is verified fully offline; production impl `IsrConformanceGate` wraps `resolve_default` + `BackendTicketFetcher` + `FsSpecLookup`.
  - `front_gate_disposition` — pure matrix→`Disposition` mapping (M1/M2 agree, M3 gap, M4 ticket-wins → AutoAccept; M1/M2/M5 divergence → Escalate). Pre-work, the "planned method" is derived from the task prose via the ISR's `heuristic_method`; divergence from the precedence-winning method escalates.
  - `stricter_of` — **stricter-wins** composition with the autonomy decision.
  - `prework_autonomy_disposition` / `run_front_gate` — orchestration.
- **`spawn_managed`** wiring: `front_gate_or_escalate` runs the gate; on escalate it writes `pending_decision`/`proposed_default`, **withholds `adapter.spawn`**, leaves the session `Provisioning`.
- **Human resolution path (AC-15):** `POST …/answer` on a FRONT-gate-escalated session clears the decision and **launches the withheld runtime** (`spawn_runtime_for`). New manager primitives `set_pending_decision` / `clear_pending_decision`.

### AC-13..AC-17 coverage
- **AC-13** clean match (M3-agree/AutoAccept) → spawns — `run_clean_match_auto_accepts`.
- **AC-14** divergence (M5) → `pending_decision` set, spawn withheld, session `Provisioning` — `run_divergence_escalates_and_proposes_default`, `front_gate_escalation_sets_pending_decision`.
- **AC-15** human answer unblocks the spawn — `front_gate_answer_unblocks_spawn`.
- **AC-16** stricter-wins: a T4/destructive autonomy escalation survives a conformance auto-accept; conformance never lowers a tier escalation — `run_stricter_wins_*`, `stricter_wins_*`.
- **AC-17** non-ticketed work → AutoAccept; ISR failure → AutoAccept — `run_non_ticketed_auto_accepts`, `run_isr_failure_auto_accepts`.

### Fail-open behavior
Non-ticketed work, an unresolved ISR, a gap, or an empty autonomy input all yield `AutoAccept`. The gate is infallible by design — it can never be the reason a spawn stalls (§4.2).

### Stricter-wins composition
`run_front_gate` composes the conformance `Disposition` with `evaluate_autonomy_tier` via `stricter_of` (escalate beats auto-accept; when both escalate the tier reason is cited as the safety authority). This is the **first production caller** of `evaluate_autonomy_tier`, which was built+tested with zero callers.

### #1269 degraded path
`HeadlessApproval::current()` returns `OperatorConfirm` until #1269 lands. An escalation degrades to the operator-confirm path: the `pending_decision` is recorded and surfaced through `…/activity`, MCP `session_status`, the supervisor, and the `tm` CLI; a human resolves it via `POST …/answer`. The gate itself always functions — only the resolution channel is degraded. No hard dependency on #1269.

### Notes
- **No version bump.**
- Existing trusty-mpm tests remain green (1290 lib + 316 mvp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)