### PR TITLE
feat(trusty-review): intent-conformance back gate (C2)

### DIFF
--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -79,7 +79,12 @@ clap         = { workspace = true }
 # flag needed for the chat module itself, which is compiled unconditionally).
 # The `mcp` feature is enabled only under the `mcp` cargo feature of this crate
 # (which is on by default) to pull in the JSON-RPC 2.0 stdio loop primitives.
-trusty-common = { workspace = true }
+# The `intent-source` feature pulls in the shared intent-source resolver (ISR,
+# C1 / #1363): `trusty_common::intent_source::resolve` — the back gate (C2,
+# #1359) calls it to surface the resolved ticket/spec intent as a review context
+# source.  The ISR is feature-gated in trusty-common so the 11 non-consumer
+# dependents pay nothing; trusty-review opts in here.
+trusty-common = { workspace = true, features = ["intent-source"] }
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console is
 # no longer bundled into trusty-review (single-owner-per-binary); the standalone
 # `trusty-console` crate is its sole producer.

--- a/crates/trusty-review/src/integrations/context/config.rs
+++ b/crates/trusty-review/src/integrations/context/config.rs
@@ -79,6 +79,9 @@ pub struct ContextSourcesConfig {
     pub confluence: SourceConfig,
     /// GitHub Issues live source.
     pub github_issues: SourceConfig,
+    /// Intent/method-conformance back gate (#1359).  Default DISABLED: it calls
+    /// the ISR (GitHub ticket fetch) so it must be explicitly opted in.
+    pub conformance: SourceConfig,
 }
 
 impl ContextSourcesConfig {
@@ -95,6 +98,7 @@ impl ContextSourcesConfig {
             jira: resolve_source("JIRA", file.map(|f| &f.jira)),
             confluence: resolve_source("CONFLUENCE", file.map(|f| &f.confluence)),
             github_issues: resolve_source("GITHUB_ISSUES", file.map(|f| &f.github_issues)),
+            conformance: resolve_source("CONFORMANCE", file.map(|f| &f.conformance)),
         }
     }
 }
@@ -141,6 +145,9 @@ pub struct ContextSourcesFileConfig {
     /// `[context.sources.github_issues]`.
     #[serde(default)]
     pub github_issues: SourceFileConfig,
+    /// `[context.sources.conformance]` — the intent/method-conformance back gate.
+    #[serde(default)]
+    pub conformance: SourceFileConfig,
 }
 
 /// TOML-deserialisable single-source table (all fields optional).

--- a/crates/trusty-review/src/integrations/context/conformance.rs
+++ b/crates/trusty-review/src/integrations/context/conformance.rs
@@ -86,29 +86,50 @@ pub trait ConformanceTokenResolver: Send + Sync {
 pub struct DualModeConformanceToken {
     run_mode: RunMode,
     config: ReviewConfig,
+    /// HTTP client built ONCE at construction (mirrors sibling sources, which
+    /// build their `GithubClient` once rather than per call).
+    ///
+    /// `GithubClient::new()` can fail only on TLS-backend init; that failure is
+    /// captured here as the `Err` string so `resolve` surfaces the same fail-open
+    /// `NotConfigured` skip it did when it built the client per call — without
+    /// reconstructing the client (and its connection pool) on every `resolve`.
+    client: Result<GithubClient, String>,
 }
 
 impl DualModeConformanceToken {
     /// Construct from the run mode and a config snapshot.
     ///
-    /// Why: the resolver needs the same config the rest of the GitHub path uses.
-    /// What: stores `run_mode` and a clone of `config`.
+    /// Why: the resolver needs the same config the rest of the GitHub path uses,
+    /// and should reuse ONE `GithubClient` (connection pool) across calls instead
+    /// of rebuilding it on every `resolve` — matching the sibling sources.
+    /// What: stores `run_mode`, a clone of `config`, and a `GithubClient` built
+    /// once (its rare TLS-init failure is captured as an `Err` string so the
+    /// infallible `from_config` path stays infallible and `resolve` reports the
+    /// failure as a fail-open skip).
     /// Test: covered transitively by `ConformanceSource::from_config`.
     #[must_use]
     pub fn new(run_mode: RunMode, config: ReviewConfig) -> Self {
-        Self { run_mode, config }
+        let client = GithubClient::new().map_err(|e| format!("failed to build HTTP client: {e}"));
+        Self {
+            run_mode,
+            config,
+            client,
+        }
     }
 }
 
 #[async_trait]
 impl ConformanceTokenResolver for DualModeConformanceToken {
     async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError> {
-        let client = GithubClient::new().map_err(|e| ContextSourceError::NotConfigured {
-            src: SOURCE_NAME,
-            reason: format!("failed to build HTTP client: {e}"),
-        })?;
+        let client = self
+            .client
+            .as_ref()
+            .map_err(|reason| ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: reason.clone(),
+            })?;
         AuthStrategy::select(self.run_mode, None)
-            .resolve_token(&client, &self.config, owner)
+            .resolve_token(client, &self.config, owner)
             .await
             .map_err(|e| ContextSourceError::NotConfigured {
                 src: SOURCE_NAME,
@@ -212,15 +233,17 @@ impl ConformanceSource {
     ///
     /// Why: the ISR's `IntentQuery::Pr` keys ticket linkage off the PR body and
     /// (forward-looking) spec resolution off changed-file content.  The
-    /// `ReviewSubject` carries the owner/repo/body/changed-file *paths*; file
-    /// *content* is not available at this seam, so spec-link resolution is a gap
-    /// for C2 (documented; C4/#1361 hardens the spec axis).  The ticket-method
+    /// `ReviewSubject` carries the owner/repo/body/PR-number/changed-file *paths*;
+    /// file *content* is not available at this seam, so spec-link resolution is a
+    /// gap for C2 (documented; C4/#1361 hardens the spec axis).  The ticket-method
     /// axis — the primary C2 path — works from the PR body.
-    /// What: maps the subject into an `IntentQuery::Pr` with empty branch /
-    /// commit-message linkage sources (body-only) and changed files carrying
+    /// What: maps the subject into an `IntentQuery::Pr` with the real PR number
+    /// (threaded from the runner; `0` only in local-diff mode), empty branch /
+    /// commit-message linkage sources (body-only), and changed files carrying
     /// paths but empty content.  Returns `None` when there is no owner/repo (e.g.
     /// local-diff mode) so `gather` skips with an empty section.
-    /// Test: `query_none_without_owner_repo`, `gather_renders_ticket_method`.
+    /// Test: `query_none_without_owner_repo`, `query_carries_pr_number`,
+    /// `gather_renders_ticket_method`.
     fn build_query(subject: &ReviewSubject) -> Option<IntentQuery> {
         if subject.owner.is_empty() || subject.repo.is_empty() {
             return None;
@@ -229,6 +252,10 @@ impl ConformanceSource {
             .changed_files
             .iter()
             .map(|p| ChangedFile {
+                // FIXME(C4/#1361): changed-file *content* is not available at this
+                // seam, so the spec axis cannot resolve declared spec links yet;
+                // PR-body → ticket linkage is the primary C2 path. C4 plumbs file
+                // content (and any remaining spec-axis hardening) through here.
                 path: p.clone(),
                 content: String::new(),
             })
@@ -236,7 +263,10 @@ impl ConformanceSource {
         Some(IntentQuery::Pr {
             owner: subject.owner.clone(),
             repo: subject.repo.clone(),
-            pr_number: 0,
+            // Threaded from the runner (#1359); `0` only in local-diff mode where
+            // no PR exists. `build_query` already returns `None` for local diffs
+            // (empty owner/repo), so a live query always carries the real number.
+            pr_number: subject.pr_number,
             body: subject.body.clone(),
             branch: None,
             commit_messages: Vec::new(),

--- a/crates/trusty-review/src/integrations/context/conformance.rs
+++ b/crates/trusty-review/src/integrations/context/conformance.rs
@@ -1,0 +1,380 @@
+//! Intent/method-conformance context source — the BACK gate (C2, #1359).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CONFORMANCE-02~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-02~draft)
+//!
+//! Why: the intent/method-conformance capability (DOC-15) ships a BACK gate in
+//! trusty-review that, during PR review, surfaces "what method did the ticket /
+//! spec prescribe?" so the reviewer LLM can flag a diff that **explicitly
+//! contradicts** that method (matrix M5).  Modelling the gate as a
+//! `ContextSource` reuses the entire existing pipeline (gather → prompt → parse →
+//! grade) with the documented one-line registration seam (spec §5.2, §7.1) — the
+//! source renders the resolved intent as review context; the LLM emits the
+//! `method-conformance` finding; the verdict floor caps it at REQUEST_CHANGES.
+//!
+//! What: `ConformanceSource` implements `ContextSource` by calling the shared ISR
+//! ([`trusty_common::intent_source::resolve`], C1 / #1363) with an
+//! `IntentQuery::Pr` built from the `ReviewSubject`, then renders the resulting
+//! `ResolvedIntent` into a `## Intended method (ticket/spec)` section.  The ISR
+//! seams (`TicketFetcher` / `SpecLookup`) are injected so the source is testable
+//! offline; the production constructor wires a `BackendTicketFetcher` behind a
+//! pluggable token resolver (spec §7.4 — NO hard-wired PAT) and an `FsSpecLookup`.
+//!
+//! ## Fail-open (AC-11)
+//! If the ISR returns `unresolved` (ticket fetch failed) or `none` (no ticket
+//! linkage / no intent), `gather` returns an EMPTY section and manufactures NO
+//! finding — exactly like every sibling source (spec §5.2, §4.2).  A missing
+//! intent source never produces a false-positive conformance finding.
+//!
+//! ## Auth (spec §7.4)
+//! The ISR is reached through a pluggable [`ConformanceTokenResolver`] mirroring
+//! `github_issues::IssueTokenResolver`, so it works under review's App/JWT serve
+//! mode, not just a `GITHUB_TOKEN` PAT.
+//!
+//! Test: `conformance_tests.rs` — gather renders the ticket method, fail-open on
+//! unresolved/none yields an empty section, semantic-mode errors, disabled-source
+//! skip.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use trusty_common::intent_source::backend_fetcher::{BackendTicketFetcher, FsSpecLookup};
+use trusty_common::intent_source::{
+    ChangedFile, IntentQuery, IntentTokenResolver, IsrError, Method, Precedence, ResolvedIntent,
+    SpecLookup, TicketFetcher, resolve_default,
+};
+
+use super::{
+    ContextSection, ContextSnippet, ContextSource, ContextSourceError, RetrievalMode,
+    ReviewSubject, SNIPPET_BODY_CHARS, truncate_on_char_boundary,
+};
+use crate::config::ReviewConfig;
+use crate::integrations::github::{AuthStrategy, GithubClient, RunMode};
+
+/// Source identifier used in logs, config keys, and error messages.
+const SOURCE_NAME: &str = "conformance";
+
+/// Heading rendered for the resolved-intent section in the reviewer prompt.
+const SECTION_HEADING: &str = "Intended method (ticket/spec)";
+
+// ─── Auth seam (mirrors github_issues::IssueTokenResolver, spec §7.4) ─────────
+
+/// Resolves a GitHub bearer token for the ISR's ticket fetch.
+///
+/// Why: the ISR must NOT hard-wire a PAT (spec §7.4).  This seam mirrors
+/// `github_issues::IssueTokenResolver` so the conformance source reuses review's
+/// dual-mode auth (CLI → PAT/`gh`, serve → App) and tests can inject a fixed
+/// token without `gh`/network.
+/// What: one async method returning a token for `owner`, or an error (treated as
+/// fail-open skip by `gather`).
+/// Test: `DualModeConformanceToken` (prod) + a fake in `conformance_tests`.
+#[async_trait]
+pub trait ConformanceTokenResolver: Send + Sync {
+    /// Resolve a GitHub token for `owner`, or an error (treated as skip).
+    async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError>;
+}
+
+/// Production resolver delegating to review's #582 dual-mode `AuthStrategy`.
+///
+/// Why: keeps the single dual-mode auth funnel — the conformance source adds NO
+/// new credential path (spec §7.4).
+/// What: holds the run mode + a `ReviewConfig` snapshot; `resolve` selects the
+/// strategy and resolves a token, mapping any error to `NotConfigured` (skip).
+/// Test: not unit-tested directly (needs real auth); the seam is exercised via a
+/// fake resolver in `conformance_tests`.
+pub struct DualModeConformanceToken {
+    run_mode: RunMode,
+    config: ReviewConfig,
+}
+
+impl DualModeConformanceToken {
+    /// Construct from the run mode and a config snapshot.
+    ///
+    /// Why: the resolver needs the same config the rest of the GitHub path uses.
+    /// What: stores `run_mode` and a clone of `config`.
+    /// Test: covered transitively by `ConformanceSource::from_config`.
+    #[must_use]
+    pub fn new(run_mode: RunMode, config: ReviewConfig) -> Self {
+        Self { run_mode, config }
+    }
+}
+
+#[async_trait]
+impl ConformanceTokenResolver for DualModeConformanceToken {
+    async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError> {
+        let client = GithubClient::new().map_err(|e| ContextSourceError::NotConfigured {
+            src: SOURCE_NAME,
+            reason: format!("failed to build HTTP client: {e}"),
+        })?;
+        AuthStrategy::select(self.run_mode, None)
+            .resolve_token(&client, &self.config, owner)
+            .await
+            .map_err(|e| ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: format!("GitHub token unavailable: {e}"),
+            })
+    }
+}
+
+/// Adapter bridging a [`ConformanceTokenResolver`] into the ISR's
+/// [`IntentTokenResolver`] seam.
+///
+/// Why: the ISR's `BackendTicketFetcher` consumes an `IntentTokenResolver`; this
+/// adapter lets review's dual-mode resolver feed the ISR without the ISR
+/// depending on review's auth types (the dependency only points one way).
+/// What: wraps an `Arc<dyn ConformanceTokenResolver>` and implements
+/// `IntentTokenResolver::token` by delegating to `resolve`, mapping the
+/// review-side error into the ISR's `IsrError::NoToken`.
+/// Test: covered transitively by `ConformanceSource::from_config` wiring.
+struct IsrTokenBridge {
+    inner: Arc<dyn ConformanceTokenResolver>,
+}
+
+#[async_trait]
+impl IntentTokenResolver for IsrTokenBridge {
+    async fn token(&self, owner: &str, _repo: &str) -> Result<String, IsrError> {
+        self.inner
+            .resolve(owner)
+            .await
+            .map_err(|e| IsrError::NoToken(e.to_string()))
+    }
+}
+
+// ─── The source ──────────────────────────────────────────────────────────────
+
+/// BACK-gate context source: surfaces the resolved ticket/spec intent.
+///
+/// Why: the back gate (#1359) is modelled as a `ContextSource` so it reuses the
+/// existing review pipeline (spec §5.2).  It renders the resolved intent for the
+/// reviewer LLM; the LLM emits the `method-conformance` finding; `grade.rs` caps
+/// it at REQUEST_CHANGES.
+/// What: holds `enabled`, `mode`, a boxed `TicketFetcher`, and a `SpecLookup`
+/// (both ISR seams, injected for testability).  `gather` builds an
+/// `IntentQuery::Pr` from the subject, calls the ISR, and renders the result.
+/// Test: `conformance_tests.rs`.
+pub struct ConformanceSource {
+    enabled: bool,
+    mode: RetrievalMode,
+    fetcher: Box<dyn TicketFetcher>,
+    spec_lookup: Box<dyn SpecLookup>,
+}
+
+impl ConformanceSource {
+    /// Build from resolved config + run mode, wiring the ISR production seams.
+    ///
+    /// Why: the runner constructs the source set from config; the conformance
+    /// source must wire the ISR's `BackendTicketFetcher` (behind review's
+    /// dual-mode token resolver, spec §7.4) and an `FsSpecLookup` rooted at the
+    /// process CWD's git root for declared spec-link resolution.
+    /// What: computes `effective_enabled(false)` (default DISABLED unless
+    /// explicitly enabled — the ISR needs GitHub auth, so we do not auto-enable
+    /// on mere credential *presence* the way `github_issues` does), and attaches
+    /// the production fetcher + spec lookup.
+    /// Test: `from_config_respects_explicit_disable` in `conformance_tests`.
+    pub fn from_config(cfg: &super::SourceConfig, run_mode: RunMode, config: ReviewConfig) -> Self {
+        let token: Arc<dyn ConformanceTokenResolver> =
+            Arc::new(DualModeConformanceToken::new(run_mode, config));
+        let bridge = IsrTokenBridge { inner: token };
+        let fetcher = Box::new(BackendTicketFetcher::new(Box::new(bridge)));
+        let repo_root = crate::config::index_resolver::repo_root_from_cwd();
+        let spec_lookup = Box::new(FsSpecLookup::new(repo_root));
+        Self {
+            // Default DISABLED (conformance needs explicit opt-in + GitHub auth).
+            enabled: cfg.effective_enabled(false),
+            mode: cfg.mode,
+            fetcher,
+            spec_lookup,
+        }
+    }
+
+    /// Construct directly (tests inject ISR seam fakes).
+    ///
+    /// Why: drive `gather` against mock ISR seams without auth or network.
+    /// What: stores the provided fields verbatim.
+    /// Test: `gather_renders_ticket_method`, `gather_fail_open_on_unresolved`.
+    #[must_use]
+    pub fn new(
+        enabled: bool,
+        mode: RetrievalMode,
+        fetcher: Box<dyn TicketFetcher>,
+        spec_lookup: Box<dyn SpecLookup>,
+    ) -> Self {
+        Self {
+            enabled,
+            mode,
+            fetcher,
+            spec_lookup,
+        }
+    }
+
+    /// Build the ISR query from the review subject.
+    ///
+    /// Why: the ISR's `IntentQuery::Pr` keys ticket linkage off the PR body and
+    /// (forward-looking) spec resolution off changed-file content.  The
+    /// `ReviewSubject` carries the owner/repo/body/changed-file *paths*; file
+    /// *content* is not available at this seam, so spec-link resolution is a gap
+    /// for C2 (documented; C4/#1361 hardens the spec axis).  The ticket-method
+    /// axis — the primary C2 path — works from the PR body.
+    /// What: maps the subject into an `IntentQuery::Pr` with empty branch /
+    /// commit-message linkage sources (body-only) and changed files carrying
+    /// paths but empty content.  Returns `None` when there is no owner/repo (e.g.
+    /// local-diff mode) so `gather` skips with an empty section.
+    /// Test: `query_none_without_owner_repo`, `gather_renders_ticket_method`.
+    fn build_query(subject: &ReviewSubject) -> Option<IntentQuery> {
+        if subject.owner.is_empty() || subject.repo.is_empty() {
+            return None;
+        }
+        let changed_files = subject
+            .changed_files
+            .iter()
+            .map(|p| ChangedFile {
+                path: p.clone(),
+                content: String::new(),
+            })
+            .collect();
+        Some(IntentQuery::Pr {
+            owner: subject.owner.clone(),
+            repo: subject.repo.clone(),
+            pr_number: 0,
+            body: subject.body.clone(),
+            branch: None,
+            commit_messages: Vec::new(),
+            changed_files,
+        })
+    }
+
+    /// Render a `ResolvedIntent` into a context section (empty when no intent).
+    ///
+    /// Why: the reviewer LLM needs the resolved method (and which source won,
+    /// plus any stale-spec advisory) to judge conformance; an empty section
+    /// (dropped by the orchestrator) is the fail-open / gap signal (AC-9, AC-11).
+    /// What: returns an empty-snippet section when the intent is `unresolved`, a
+    /// gap, or has no method on either axis (M3 — nothing to conform to).
+    /// Otherwise renders one snippet for the precedence-winning method and, when
+    /// a stale-spec conflict exists (M4), an advisory snippet noting it.
+    /// Test: `gather_renders_ticket_method`, `gather_fail_open_on_unresolved`,
+    /// `gather_gap_renders_empty`, `render_stale_spec_advisory`.
+    fn render_section(intent: &ResolvedIntent) -> ContextSection {
+        // Fail-open / gap: unresolved or no method on either axis → empty section.
+        if intent.unresolved.is_some() || intent.is_gap() {
+            return Self::empty_section();
+        }
+
+        let mut snippets: Vec<ContextSnippet> = Vec::new();
+
+        // The precedence-winning method is the thing to check conformance against.
+        if let Some(method) = Self::winning_method(intent) {
+            let ticket_label = intent
+                .ticket
+                .as_ref()
+                .map(|t| format!("ticket {}", t.id))
+                .unwrap_or_else(|| "ticket".to_string());
+            let source_label = match intent.precedence_winner {
+                Precedence::Ticket => ticket_label,
+                Precedence::Spec => intent
+                    .spec_section
+                    .as_ref()
+                    .map(|s| format!("spec {}", s.spec_id))
+                    .unwrap_or_else(|| "spec".to_string()),
+                Precedence::None => "intent".to_string(),
+            };
+            let body =
+                truncate_on_char_boundary(method.text.trim(), SNIPPET_BODY_CHARS).to_string();
+            snippets.push(ContextSnippet {
+                title: format!("Prescribed method (from {source_label})"),
+                subtitle: Some(
+                    "Flag the diff ONLY if it explicitly contradicts this method.".to_string(),
+                ),
+                body: (!body.is_empty()).then_some(body),
+                link: intent.ticket.as_ref().and_then(|t| t.url.clone()),
+            });
+        }
+
+        // M4: a stale-spec conflict is ADVISORY context, never the thing to fail
+        // against — the ticket already won precedence (spec §5.2 precedence wiring).
+        if intent.stale_spec
+            && let Some(spec_method) = &intent.spec_method
+        {
+            let body =
+                truncate_on_char_boundary(spec_method.text.trim(), SNIPPET_BODY_CHARS).to_string();
+            snippets.push(ContextSnippet {
+                title: "Conflicting spec method (stale — advisory only)".to_string(),
+                subtitle: Some(
+                    "The ticket overrides this; do NOT flag the diff for matching the ticket."
+                        .to_string(),
+                ),
+                body: (!body.is_empty()).then_some(body),
+                link: None,
+            });
+        }
+
+        ContextSection {
+            heading: SECTION_HEADING.to_string(),
+            snippets,
+        }
+    }
+
+    /// The method to check conformance against, under precedence (ticket > spec).
+    ///
+    /// Why: the matrix compares the diff against the precedence-winning method
+    /// (M1/M2); the renderer must pick the right one.
+    /// What: returns the ticket method when the ticket won, the spec method when
+    /// the spec won, else `None`.
+    /// Test: covered by `gather_renders_ticket_method` / spec-win tests.
+    fn winning_method(intent: &ResolvedIntent) -> Option<&Method> {
+        match intent.precedence_winner {
+            Precedence::Ticket => intent.ticket_method.as_ref(),
+            Precedence::Spec => intent.spec_method.as_ref(),
+            Precedence::None => None,
+        }
+    }
+
+    /// An empty section (no snippets) — the fail-open / gap signal.
+    ///
+    /// Why: the orchestrator drops empty sections, so an empty section is exactly
+    /// "no conformance context, manufacture nothing" (AC-9, AC-11).
+    /// What: a `ContextSection` with the standard heading and zero snippets.
+    /// Test: `gather_fail_open_on_unresolved`, `gather_gap_renders_empty`.
+    fn empty_section() -> ContextSection {
+        ContextSection {
+            heading: SECTION_HEADING.to_string(),
+            snippets: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ContextSource for ConformanceSource {
+    fn name(&self) -> &'static str {
+        SOURCE_NAME
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn mode(&self) -> RetrievalMode {
+        self.mode
+    }
+
+    async fn gather(&self, subject: &ReviewSubject) -> Result<ContextSection, ContextSourceError> {
+        if self.mode == RetrievalMode::Semantic {
+            return Err(ContextSourceError::SemanticNotImplemented { src: SOURCE_NAME });
+        }
+        let Some(query) = Self::build_query(subject) else {
+            // No owner/repo (local-diff) — nothing to resolve; empty, not error.
+            return Ok(Self::empty_section());
+        };
+        // The ISR is itself FAIL-OPEN: a fetch/parse failure yields
+        // `ResolvedIntent::unresolved` (never an Err), which `render_section`
+        // turns into an empty section.  No conformance finding is manufactured
+        // (AC-11).
+        let intent = resolve_default(query, self.fetcher.as_ref(), self.spec_lookup.as_ref()).await;
+        Ok(Self::render_section(&intent))
+    }
+}
+
+#[cfg(test)]
+#[path = "conformance_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/integrations/context/conformance_tests.rs
+++ b/crates/trusty-review/src/integrations/context/conformance_tests.rs
@@ -1,0 +1,324 @@
+//! Tests for the intent/method-conformance back-gate context source (#1359).
+//!
+//! Why: extracted to a sibling file to keep `conformance.rs` under the 500-line
+//! cap while covering the AC-8..AC-12 back-gate behaviours that live in the
+//! source (the verdict-floor cap is tested in `grade_tests.rs`; the
+//! finding-category parse in `parser_tests.rs`).
+//! What: drives `gather` against MOCK ISR seams (`TicketFetcher` / `SpecLookup`)
+//! so no network or GitHub auth is touched — a ticket-method contradiction
+//! renders a section; an unresolved/gap intent fails open to an empty section;
+//! semantic mode errors; a disabled source skips.
+//! Test: this file is the test module included from `conformance.rs`.
+
+use super::*;
+use trusty_common::intent_source::{
+    Method, MethodKind, Precedence, ResolvedIntent, TicketData, TicketRef,
+};
+
+// ─── Mock ISR seams (no network) ──────────────────────────────────────────────
+
+/// A `TicketFetcher` that returns a fixed body (or a failure) for any id.
+struct MockFetcher {
+    body: String,
+    fail: bool,
+}
+
+#[async_trait]
+impl TicketFetcher for MockFetcher {
+    async fn fetch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        ticket_id: &str,
+    ) -> Result<TicketData, IsrError> {
+        if self.fail {
+            return Err(IsrError::TicketFetch("mock fetch failure".to_string()));
+        }
+        Ok(TicketData {
+            id: ticket_id.to_string(),
+            title: "Mock ticket".to_string(),
+            body: self.body.clone(),
+            url: Some("https://example/issues/1325".to_string()),
+            backend: "github".to_string(),
+        })
+    }
+}
+
+/// A `SpecLookup` that never resolves a spec (spec axis is a gap in these tests).
+struct NoSpecLookup;
+impl SpecLookup for NoSpecLookup {
+    fn load(&self, _spec_file: &str) -> Option<String> {
+        None
+    }
+}
+
+/// Build a subject whose PR body links a ticket via `Closes #N`.
+fn subject_with_body(body: &str) -> ReviewSubject {
+    ReviewSubject {
+        owner: "bobmatnyc".to_string(),
+        repo: "trusty-tools".to_string(),
+        title: "Add pagination".to_string(),
+        body: body.to_string(),
+        changed_files: vec!["src/page.rs".to_string()],
+        identifiers: vec![],
+    }
+}
+
+fn source_with_fetcher(fetcher: MockFetcher) -> ConformanceSource {
+    ConformanceSource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(fetcher),
+        Box::new(NoSpecLookup),
+    )
+}
+
+// ─── gather: happy path (ticket method rendered) ──────────────────────────────
+
+/// A ticket whose body prescribes a method renders a non-empty section naming
+/// the prescribed method (the thing to check conformance against).
+///
+/// Why: the back gate must surface the resolved ticket method to the reviewer
+/// LLM so it can flag a contradicting diff (M1).  AC-8's finding emission is the
+/// LLM's job; the source's job is to render the intent.
+/// What: a `Closes #1325` body + a ticket body prescribing "use cursor-based
+/// pagination" → a section with a snippet whose body carries the method text.
+/// Test: this test; no network.
+#[tokio::test]
+async fn gather_renders_ticket_method() {
+    let fetcher = MockFetcher {
+        body: "Implement listing. Method: use cursor-based pagination, not offset.".to_string(),
+        fail: false,
+    };
+    let src = source_with_fetcher(fetcher);
+    let subject = subject_with_body("Closes #1325 — add the listing endpoint.");
+    let section = src.gather(&subject).await.expect("gather must not error");
+    assert_eq!(section.heading, "Intended method (ticket/spec)");
+    assert!(
+        !section.snippets.is_empty(),
+        "a ticket with a prescribed method must render a non-empty section"
+    );
+    let rendered = section
+        .snippets
+        .iter()
+        .filter_map(|s| s.body.clone())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        rendered.to_lowercase().contains("cursor"),
+        "the prescribed method text must be surfaced: {rendered}"
+    );
+}
+
+// ─── gather: fail-open (AC-11) ────────────────────────────────────────────────
+
+/// A ticket-fetch failure (ISR unresolved) yields an EMPTY section and NO
+/// conformance content (AC-11 fail-open).
+///
+/// Why: a missing/unfetchable intent source must never manufacture a finding;
+/// the source returns an empty section the orchestrator drops.
+/// What: a failing `MockFetcher` → empty section, gather returns Ok.
+/// Test: this test; no network.
+#[tokio::test]
+async fn gather_fail_open_on_unresolved() {
+    let src = source_with_fetcher(MockFetcher {
+        body: String::new(),
+        fail: true,
+    });
+    let subject = subject_with_body("Closes #1325");
+    let section = src.gather(&subject).await.expect("fail-open: Ok, not Err");
+    assert!(
+        section.snippets.is_empty(),
+        "an unresolved ISR must render an EMPTY section (AC-11 fail-open)"
+    );
+}
+
+/// A PR with NO ticket linkage resolves to no intent → empty section (AC-11).
+///
+/// Why: non-ticketed work has no intent to conform to; the gate no-ops.
+/// What: a body with no `Closes #N` → ISR `none()` → empty section.
+/// Test: this test; no network.
+#[tokio::test]
+async fn gather_no_linkage_renders_empty() {
+    let src = source_with_fetcher(MockFetcher {
+        body: "use cursor pagination".to_string(),
+        fail: false,
+    });
+    let subject = subject_with_body("A PR with no ticket reference at all.");
+    let section = src.gather(&subject).await.expect("Ok");
+    assert!(
+        section.snippets.is_empty(),
+        "no ticket linkage → empty section (no intent to conform to)"
+    );
+}
+
+/// A ticket with NO prescribed method (a gap, M3) renders an empty section.
+///
+/// Why: a gap is advisory/none — never a blocking finding (AC-9 / M3); the
+/// source surfaces nothing to flag against.
+/// What: a fetched ticket whose body prescribes no method → empty section.
+/// Test: this test; no network.
+#[tokio::test]
+async fn gather_gap_renders_empty() {
+    let src = source_with_fetcher(MockFetcher {
+        body: "Please add a feature flag. Thanks!".to_string(),
+        fail: false,
+    });
+    let subject = subject_with_body("Closes #1325");
+    let section = src.gather(&subject).await.expect("Ok");
+    assert!(
+        section.snippets.is_empty(),
+        "a ticket with no prescribed method is a gap (M3) → empty section (AC-9)"
+    );
+}
+
+// ─── render_section: stale-spec advisory (M4) ─────────────────────────────────
+
+/// A stale-spec conflict (M4) renders the ticket method PLUS an advisory snippet
+/// for the conflicting spec — never as the thing to fail against.
+///
+/// Why: under precedence the ticket wins; the conflicting spec is downgraded to
+/// advisory context (spec §5.2 precedence wiring, M4 → ADVISORY).
+/// What: a `ResolvedIntent` with ticket+spec methods, `stale_spec = true`, and
+/// `precedence_winner = Ticket` → two snippets, one flagged advisory/stale.
+/// Test: this test; constructs the intent directly (renderer is pure).
+#[test]
+fn render_stale_spec_advisory() {
+    let intent = ResolvedIntent {
+        ticket: Some(TicketRef {
+            id: "#1325".to_string(),
+            title: "t".to_string(),
+            url: None,
+            backend: "github".to_string(),
+        }),
+        ticket_method: Some(Method {
+            text: "add dependency X".to_string(),
+            kind: MethodKind::Approach,
+            source_excerpt: "add dependency X".to_string(),
+        }),
+        spec_section: None,
+        spec_method: Some(Method {
+            text: "no new dependencies".to_string(),
+            kind: MethodKind::Constraint,
+            source_excerpt: "no new dependencies".to_string(),
+        }),
+        precedence_winner: Precedence::Ticket,
+        conflict: true,
+        stale_spec: true,
+        unresolved: None,
+    };
+    let section = ConformanceSource::render_section(&intent);
+    assert_eq!(
+        section.snippets.len(),
+        2,
+        "ticket method + stale-spec advisory"
+    );
+    let advisory = section
+        .snippets
+        .iter()
+        .any(|s| s.title.to_lowercase().contains("stale"));
+    assert!(
+        advisory,
+        "the conflicting spec must be rendered as a stale advisory (M4)"
+    );
+}
+
+/// An `unresolved` intent renders an empty section (renderer-level AC-11).
+///
+/// Why: pin the renderer's fail-open behaviour independently of `gather`.
+/// What: `ResolvedIntent::unresolved(..)` → empty section.
+/// Test: this test; pure.
+#[test]
+fn render_unresolved_is_empty() {
+    let intent = ResolvedIntent::unresolved("ticket fetch failed");
+    let section = ConformanceSource::render_section(&intent);
+    assert!(section.snippets.is_empty());
+}
+
+// ─── gather: mode + enabled ───────────────────────────────────────────────────
+
+/// Semantic mode is not implemented (PR-B parity) → error (logged, fail-open by
+/// the orchestrator).
+///
+/// Why: like every live source, conformance only supports `Live` retrieval in
+/// C2; a `Semantic` config surfaces a clear not-implemented error.
+/// What: a `Semantic`-mode source → `SemanticNotImplemented`.
+/// Test: this test; no network.
+#[tokio::test]
+async fn semantic_mode_errors() {
+    let src = ConformanceSource::new(
+        true,
+        RetrievalMode::Semantic,
+        Box::new(MockFetcher {
+            body: String::new(),
+            fail: false,
+        }),
+        Box::new(NoSpecLookup),
+    );
+    let subject = subject_with_body("Closes #1325");
+    let err = src.gather(&subject).await.unwrap_err();
+    assert!(matches!(
+        err,
+        ContextSourceError::SemanticNotImplemented { .. }
+    ));
+}
+
+/// A subject with no owner/repo (local-diff mode) renders an empty section.
+///
+/// Why: no repo scope → nothing to resolve; skip with an empty section, not an
+/// error.
+/// What: an empty-owner subject → empty section.
+/// Test: this test; no network.
+#[tokio::test]
+async fn gather_local_diff_renders_empty() {
+    let src = source_with_fetcher(MockFetcher {
+        body: "use cursor pagination".to_string(),
+        fail: false,
+    });
+    let subject = ReviewSubject::default(); // empty owner/repo
+    let section = src.gather(&subject).await.expect("Ok");
+    assert!(section.snippets.is_empty());
+}
+
+/// `from_config` honours an explicit `enabled = false` (default-disabled source).
+///
+/// Why: the conformance source is opt-in (it needs GitHub auth); an explicit
+/// disable must keep it off, and the default (no creds auto-enable) is off.
+/// What: a `SourceConfig { enabled: Some(false), .. }` → `is_enabled() == false`;
+/// a default `SourceConfig` → also `false` (no auto-enable on cred presence).
+/// Test: this test; no network.
+#[test]
+fn from_config_respects_explicit_disable() {
+    let cfg_off = crate::integrations::context::SourceConfig {
+        enabled: Some(false),
+        mode: RetrievalMode::Live,
+    };
+    let src = ConformanceSource::from_config(&cfg_off, RunMode::Cli, ReviewConfig::load(None));
+    assert!(
+        !src.is_enabled(),
+        "explicit disable must keep the source off"
+    );
+
+    let cfg_default = crate::integrations::context::SourceConfig::default();
+    let src2 = ConformanceSource::from_config(&cfg_default, RunMode::Cli, ReviewConfig::load(None));
+    assert!(
+        !src2.is_enabled(),
+        "default conformance source is DISABLED (no auto-enable)"
+    );
+}
+
+/// `from_config` honours an explicit `enabled = true`.
+///
+/// Why: an operator opting in must turn the source on.
+/// What: `SourceConfig { enabled: Some(true), .. }` → `is_enabled() == true`.
+/// Test: this test; no network.
+#[test]
+fn from_config_respects_explicit_enable() {
+    let cfg_on = crate::integrations::context::SourceConfig {
+        enabled: Some(true),
+        mode: RetrievalMode::Live,
+    };
+    let src = ConformanceSource::from_config(&cfg_on, RunMode::Cli, ReviewConfig::load(None));
+    assert!(src.is_enabled(), "explicit enable must turn the source on");
+    assert_eq!(src.name(), "conformance");
+}

--- a/crates/trusty-review/src/integrations/context/conformance_tests.rs
+++ b/crates/trusty-review/src/integrations/context/conformance_tests.rs
@@ -52,6 +52,10 @@ impl SpecLookup for NoSpecLookup {
     }
 }
 
+/// PR number used by the test subject; lets `query_carries_pr_number` assert the
+/// real number is threaded into the ISR query rather than the old hard-coded `0`.
+const TEST_PR_NUMBER: u64 = 1359;
+
 /// Build a subject whose PR body links a ticket via `Closes #N`.
 fn subject_with_body(body: &str) -> ReviewSubject {
     ReviewSubject {
@@ -61,6 +65,7 @@ fn subject_with_body(body: &str) -> ReviewSubject {
         body: body.to_string(),
         changed_files: vec!["src/page.rs".to_string()],
         identifiers: vec![],
+        pr_number: TEST_PR_NUMBER,
     }
 }
 
@@ -321,4 +326,48 @@ fn from_config_respects_explicit_enable() {
     let src = ConformanceSource::from_config(&cfg_on, RunMode::Cli, ReviewConfig::load(None));
     assert!(src.is_enabled(), "explicit enable must turn the source on");
     assert_eq!(src.name(), "conformance");
+}
+
+// ─── build_query: PR-number threading (#1359) ─────────────────────────────────
+
+/// `build_query` threads the real PR number into the ISR query (no hard-coded 0).
+///
+/// Why: the ISR's `IntentQuery::Pr` keys ticket linkage off the PR (body +
+/// number); the source previously hard-coded `pr_number: 0`, losing the real
+/// number.  This pins the threading so a regression to `0` is caught.
+/// What: builds a query from a subject carrying `TEST_PR_NUMBER` and asserts the
+/// resulting `IntentQuery::Pr.pr_number` matches.
+/// Test: this test; no network.
+#[test]
+fn query_carries_pr_number() {
+    let subject = subject_with_body("Closes #1325");
+    let query = ConformanceSource::build_query(&subject).expect("owner/repo present → Some");
+    match query {
+        IntentQuery::Pr { pr_number, .. } => {
+            assert_eq!(
+                pr_number, TEST_PR_NUMBER,
+                "the real PR number must be threaded, not hard-coded 0"
+            );
+        }
+        other => panic!("build_query must produce IntentQuery::Pr, got {other:?}"),
+    }
+}
+
+/// `build_query` returns `None` when there is no owner/repo (local-diff mode).
+///
+/// Why: a local diff has no PR to resolve intent against; `gather` must skip with
+/// an empty section rather than issue a meaningless ISR query.
+/// What: a subject with empty owner/repo → `build_query` returns `None`.
+/// Test: this test; no network.
+#[test]
+fn query_none_without_owner_repo() {
+    let subject = ReviewSubject {
+        owner: String::new(),
+        repo: String::new(),
+        ..subject_with_body("Closes #1325")
+    };
+    assert!(
+        ConformanceSource::build_query(&subject).is_none(),
+        "no owner/repo (local-diff) must yield None"
+    );
 }

--- a/crates/trusty-review/src/integrations/context/mod.rs
+++ b/crates/trusty-review/src/integrations/context/mod.rs
@@ -114,6 +114,15 @@ pub struct ReviewSubject {
     pub changed_files: Vec<String>,
     /// Identifiers extracted from the diff (function/type/symbol names).
     pub identifiers: Vec<String>,
+    /// PR number (`0` in local-diff mode or when not yet known).
+    ///
+    /// Why: the conformance BACK gate (#1359) builds an `IntentQuery::Pr` for the
+    /// ISR, which keys ticket linkage off the PR (body + number).  Carrying the
+    /// real PR number here lets the source pass it through instead of hard-coding
+    /// `0`; `0` remains the sentinel for local-diff mode where no PR exists.
+    /// What: the GitHub PR number, or `0` when reviewing a local diff.
+    /// Test: `query_carries_pr_number` (conformance_tests.rs).
+    pub pr_number: u64,
 }
 
 impl ReviewSubject {

--- a/crates/trusty-review/src/integrations/context/mod.rs
+++ b/crates/trusty-review/src/integrations/context/mod.rs
@@ -33,6 +33,7 @@ pub mod atlassian;
 pub mod config;
 pub mod confluence;
 pub mod confluence_parse;
+pub mod conformance;
 pub mod github_issues;
 pub mod jira;
 pub mod jira_parse;
@@ -40,6 +41,7 @@ pub mod orchestrator;
 
 pub use config::{ContextSourcesConfig, ContextSourcesFileConfig, SourceConfig, SourceFileConfig};
 pub use confluence::ConfluenceSource;
+pub use conformance::ConformanceSource;
 pub use github_issues::GithubIssuesSource;
 pub use jira::JiraSource;
 pub use orchestrator::{gather_external_context, render_sections};

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -170,6 +170,38 @@ pub enum VerifyOutcome {
     Skipped,
 }
 
+// ─── Finding category ──────────────────────────────────────────────────────────
+
+/// The axis a finding speaks to: code correctness vs. intent/method conformance.
+///
+/// Why: the intent/method-conformance back gate (DOC-15, `SPEC-CONFORMANCE-02`,
+/// #1359) adds a second, distinct *kind* of finding — one that flags a diff
+/// **contradicting an explicit method the ticket/spec stated**, separate from a
+/// correctness bug.  The two must be distinguishable so the verdict floor can
+/// treat them differently: a conformance divergence caps at `REQUEST_CHANGES`
+/// and NEVER drives `BLOCK` (BLOCK is reserved for correctness/safety), whereas a
+/// correctness finding floors normally.  Threading a category through the finding
+/// model is the minimal way to carry that distinction from the LLM JSON all the
+/// way to `grade::severity_floor`.
+/// What: a two-variant enum serialised kebab-case (`"correctness"` /
+/// `"method-conformance"`).  It is `#[serde(default)]` (→ `Correctness`) wherever
+/// it appears so pre-#1359 fixtures and LLM responses that omit `category` still
+/// deserialise unchanged (back-compat — every legacy finding is a correctness
+/// finding).
+/// Test: `finding_category_serde_roundtrip`,
+/// `finding_defaults_category_correctness`, and the parser/grade tests that
+/// assert the conformance cap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingCategory {
+    /// A correctness / logic / safety finding (the default, legacy behaviour).
+    #[default]
+    Correctness,
+    /// An intent/method-conformance divergence: the diff contradicts an explicit
+    /// method the ticket or spec prescribed (`SPEC-CONFORMANCE-02`, M5).
+    MethodConformance,
+}
+
 // ─── Finding ──────────────────────────────────────────────────────────────────
 
 /// A single code-review finding / fix suggestion.
@@ -198,6 +230,13 @@ pub struct Finding {
     pub confidence: f32,
     /// Estimated remediation effort.
     pub effort: Effort,
+    /// Which axis this finding speaks to (correctness vs. method-conformance).
+    ///
+    /// Why: the back gate (#1359) caps `MethodConformance` findings at
+    /// `REQUEST_CHANGES` in the verdict floor.  `#[serde(default)]` keeps every
+    /// pre-#1359 serialised finding deserialising as `Correctness`.
+    #[serde(default)]
+    pub category: FindingCategory,
     // ── Transient pipeline state ──────────────────────────────────────────
     /// Verification outcome; `None` before the verification round.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -230,9 +269,24 @@ impl Finding {
             suggestion: suggestion.into(),
             confidence: confidence.clamp(0.0, 1.0),
             effort,
+            category: FindingCategory::Correctness,
             verified: None,
             issue_eligible: false,
         }
+    }
+
+    /// Set this finding's category, returning the finding for chaining.
+    ///
+    /// Why: `Finding::new` defaults to `Correctness` so every existing call site
+    /// is unchanged; the back-gate parser (#1359) needs to override the category
+    /// for an LLM-emitted `method-conformance` finding without a new constructor
+    /// arity.  A small builder keeps construction ergonomic and the default safe.
+    /// What: overwrites `self.category` and returns `self`.
+    /// Test: `finding_with_category_sets_method_conformance`.
+    #[must_use]
+    pub fn with_category(mut self, category: FindingCategory) -> Self {
+        self.category = category;
+        self
     }
 }
 
@@ -511,6 +565,75 @@ mod tests {
 
         let f_mid = Finding::new("src/lib.rs", "bug", "desc", "fix", 0.85, Effort::Medium);
         assert!((f_mid.confidence - 0.85_f32).abs() < f32::EPSILON);
+    }
+
+    /// `FindingCategory` round-trips via its kebab-case wire form.
+    ///
+    /// Why: the LLM emits and the review log persists the category as a string;
+    /// the back gate (#1359) keys verdict-floor behaviour off it, so the wire
+    /// shape must be stable.
+    /// What: serialises both variants, asserts the exact tokens, deserialises back.
+    /// Test: this test itself.
+    #[test]
+    fn finding_category_serde_roundtrip() {
+        assert_eq!(
+            serde_json::to_string(&FindingCategory::Correctness).unwrap(),
+            "\"correctness\""
+        );
+        assert_eq!(
+            serde_json::to_string(&FindingCategory::MethodConformance).unwrap(),
+            "\"method-conformance\""
+        );
+        let back: FindingCategory = serde_json::from_str("\"method-conformance\"").unwrap();
+        assert_eq!(back, FindingCategory::MethodConformance);
+        assert_eq!(FindingCategory::default(), FindingCategory::Correctness);
+    }
+
+    /// A `Finding` constructed via `new` defaults to the `Correctness` category.
+    ///
+    /// Why: every existing call site must keep producing correctness findings
+    /// (back-compat); only the back-gate parser opts into `MethodConformance`.
+    /// What: builds a finding via `new`, asserts the category.
+    /// Test: this test itself.
+    #[test]
+    fn finding_defaults_category_correctness() {
+        let f = Finding::new("src/lib.rs", "bug", "desc", "fix", 0.9, Effort::Low);
+        assert_eq!(f.category, FindingCategory::Correctness);
+    }
+
+    /// `with_category` overrides the default category.
+    ///
+    /// Why: the back-gate parser threads `MethodConformance` onto an LLM finding
+    /// via this builder.
+    /// What: chains `with_category`, asserts the override took effect.
+    /// Test: this test itself.
+    #[test]
+    fn finding_with_category_sets_method_conformance() {
+        let f = Finding::new("src/lib.rs", "bug", "desc", "fix", 0.9, Effort::Medium)
+            .with_category(FindingCategory::MethodConformance);
+        assert_eq!(f.category, FindingCategory::MethodConformance);
+    }
+
+    /// A serialised finding WITHOUT a `category` field still deserialises (the
+    /// `#[serde(default)]` back-compat guarantee for pre-#1359 fixtures).
+    ///
+    /// Why: AC requires existing finding fixtures (no `category` key) to keep
+    /// deserialising, defaulting to `Correctness`.
+    /// What: deserialises a category-less JSON object, asserts the default.
+    /// Test: this test itself.
+    #[test]
+    fn finding_without_category_field_defaults_correctness() {
+        let json = r#"{
+            "file": "src/main.rs",
+            "kind": "logic-error",
+            "description": "off-by-one",
+            "suggestion": "use <=",
+            "confidence": 0.7,
+            "effort": "medium"
+        }"#;
+        let f: Finding = serde_json::from_str(json).expect("legacy finding must deserialise");
+        assert_eq!(f.category, FindingCategory::Correctness);
+        assert_eq!(f.kind, "logic-error");
     }
 
     #[test]

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -439,6 +439,7 @@ fn correctness_floor(findings: &[&&Finding]) -> Verdict {
 /// `conformance_high_effort_never_blocks`,
 /// `conformance_below_floor_confidence_is_advisory`.
 fn conformance_floor(findings: &[&&Finding]) -> Verdict {
+    // Effort is intentionally ignored: the conformance cap is confidence-only (never BLOCK).
     let any_confident = findings
         .iter()
         .any(|f| f.confidence >= FLOOR_MIN_CONFIDENCE);

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -95,7 +95,7 @@
 
 use tracing::debug;
 
-use crate::models::{Effort, Finding, Verdict, VerifyOutcome};
+use crate::models::{Effort, Finding, FindingCategory, Verdict, VerifyOutcome};
 use crate::pipeline::letter_grade::{Grade, clamp_grade_to_verdict, verdict_for_grade};
 
 // ─── Confidence thresholds ────────────────────────────────────────────────────
@@ -218,7 +218,22 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
     // count-based floor at APPROVE* (advisory) in that case.  High-effort findings
     // are unaffected: a genuine critical (BLOCK floor) still escalates an APPROVE,
     // because BLOCK is grounded critical evidence, not a count heuristic.
-    if model_proposed == Verdict::Approve && floor == Verdict::RequestChanges {
+    //
+    // #1359: a CONFIRMED method-conformance divergence (a conformance finding that
+    // clears FLOOR_MIN_CONFIDENCE = 0.80) is grounded explicit evidence — the diff
+    // contradicts a method the ticket/spec stated — NOT a Medium-count heuristic.
+    // Like the High-effort exemption, it is exempt from this cap so AC-8 holds: a
+    // model APPROVE + a confident conformance divergence still floors to
+    // REQUEST_CHANGES.  (A sub-0.80 conformance finding never reaches the
+    // RequestChanges floor in the first place — see `conformance_floor` — so the
+    // cap correctly still applies to advisory-only conformance, honouring AC-12.)
+    let has_confident_conformance = substantive.iter().any(|f| {
+        f.category == FindingCategory::MethodConformance && f.confidence >= FLOOR_MIN_CONFIDENCE
+    });
+    if model_proposed == Verdict::Approve
+        && floor == Verdict::RequestChanges
+        && !has_confident_conformance
+    {
         debug!(
             "source-of-truth reconciliation: model APPROVE + count-based REQUEST_CHANGES floor \
              → capping floor at APPROVE* (no Medium-count override of an APPROVE review_body)"
@@ -335,7 +350,44 @@ fn is_high_severity(f: &Finding) -> bool {
 ///
 /// As of #1343 the caller pre-filters refuted / sub-0.50-confidence findings via
 /// `is_substantive`, so this function only ever sees substantive findings.
+///
+/// As of #1359 the floor is split by `FindingCategory`: correctness findings run
+/// the four-tier rule unchanged, while method-conformance findings run a separate,
+/// strictly-weaker rule (see [`conformance_floor`]) that caps at `REQUEST_CHANGES`
+/// and never contributes `BLOCK`.  The combined floor is the stricter of the two.
 fn severity_floor(findings: &[&Finding]) -> Verdict {
+    if findings.is_empty() {
+        return Verdict::Approve;
+    }
+
+    // #1359: a method-conformance divergence is an *intent overlay*, capped at
+    // REQUEST_CHANGES — it must never drive BLOCK (reserved for correctness /
+    // safety).  Run the standard floor over the CORRECTNESS findings only, then
+    // combine with the conformance floor via `stricter_of`.
+    let (conformance, correctness): (Vec<&&Finding>, Vec<&&Finding>) = findings
+        .iter()
+        .partition(|f| f.category == FindingCategory::MethodConformance);
+
+    let correctness_floor = correctness_floor(&correctness);
+    let conformance_floor = conformance_floor(&conformance);
+    stricter_of(correctness_floor, conformance_floor)
+}
+
+/// The four-tier correctness floor (the pre-#1359 `severity_floor` body).
+///
+/// Why: separating the correctness rule from the conformance rule (#1359) keeps
+/// each rule readable and lets the conformance rule be strictly weaker (capped at
+/// REQUEST_CHANGES) without touching the proven correctness tiers.
+/// What: applies the unchanged four-tier rule set over correctness findings:
+///   1. Any `High`-effort finding → BLOCK
+///   2. ≥2 high-confidence Medium-effort findings → REQUEST_CHANGES
+///   3. Exactly 1 high-confidence Medium-effort finding → APPROVE*
+///   4. Only `Low` / no floor-counting findings → APPROVE
+///
+/// Test: `grade_two_medium_yields_request_changes`,
+///       `grade_one_medium_yields_approve_star`,
+///       `grade_advisory_medium_below_floor_threshold_does_not_escalate`.
+fn correctness_floor(findings: &[&&Finding]) -> Verdict {
     if findings.is_empty() {
         return Verdict::Approve;
     }
@@ -367,6 +419,36 @@ fn severity_floor(findings: &[&Finding]) -> Verdict {
 
     // Tier 4: only Low-effort, no findings, or all-advisory Medium findings.
     Verdict::Approve
+}
+
+/// The method-conformance floor (#1359, `SPEC-CONFORMANCE-02` §5.2; AC-8/AC-12).
+///
+/// Why: a method-conformance divergence is an advisory overlay on top of the
+/// correctness review — it must be conservative and bounded.  The spec is
+/// explicit: a conformance finding caps the verdict at `REQUEST_CHANGES` and
+/// NEVER drives `BLOCK` (BLOCK is reserved for correctness/safety, OQ-5), and a
+/// conformance finding must clear `FLOOR_MIN_CONFIDENCE` (0.80) to affect the
+/// verdict at all — below that it is advisory only and does NOT raise the floor
+/// (the primary false-positive guard, G3).
+/// What: returns `REQUEST_CHANGES` when ANY conformance finding clears 0.80
+/// confidence (regardless of its `Effort` — even a `High`-effort conformance
+/// finding is capped here, never BLOCK); otherwise `APPROVE` (advisory only).
+/// Note the caller's `is_substantive` pre-filter has already dropped refuted /
+/// sub-0.50 findings, but the 0.80 gate here is stricter and is what AC-12 pins.
+/// Test: `conformance_finding_caps_at_request_changes`,
+/// `conformance_high_effort_never_blocks`,
+/// `conformance_below_floor_confidence_is_advisory`.
+fn conformance_floor(findings: &[&&Finding]) -> Verdict {
+    let any_confident = findings
+        .iter()
+        .any(|f| f.confidence >= FLOOR_MIN_CONFIDENCE);
+    if any_confident {
+        // Capped at REQUEST_CHANGES — conformance NEVER drives BLOCK.
+        Verdict::RequestChanges
+    } else {
+        // Below the confidence floor → advisory only, does not raise the floor.
+        Verdict::Approve
+    }
 }
 
 // ─── Verdict ordering ─────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -10,11 +10,21 @@
 //! Test: this file is the test module.
 
 use super::*;
-use crate::models::{Finding, VerifyOutcome};
+use crate::models::{Finding, FindingCategory, VerifyOutcome};
 use crate::pipeline::letter_grade::Grade;
 
 fn finding(effort: Effort, confidence: f32) -> Finding {
     Finding::new("src/lib.rs", "test", "desc", "", confidence, effort)
+}
+
+/// Build a method-conformance finding (#1359) at a given effort + confidence.
+///
+/// Why: the back-gate verdict-floor tests need conformance-category findings to
+/// assert the REQUEST_CHANGES cap (never BLOCK) and the 0.80 advisory gate.
+/// What: constructs a finding and tags its category `MethodConformance`.
+/// Test: used by the `conformance_*` tests below.
+fn conformance_finding(effort: Effort, confidence: f32) -> Finding {
+    finding(effort, confidence).with_category(FindingCategory::MethodConformance)
 }
 
 /// Build a finding with a `verified` outcome already recorded.
@@ -691,4 +701,143 @@ fn grade_confirmed_high_still_blocks_despite_b_plus_grade() {
         "High-effort finding must still BLOCK regardless of grade (#1015 regression)"
     );
     assert_eq!(g, Grade::F, "grade must clamp to F when verdict=BLOCK");
+}
+
+// ── Method-conformance back gate (#1359, SPEC-CONFORMANCE-02 §5.2; AC-8..AC-12) ─
+
+/// AC-8: a confident conformance divergence floors the verdict to REQUEST_CHANGES
+/// even when the model proposed APPROVE.
+///
+/// Why: a confirmed contradiction between the diff and an explicit ticket/spec
+/// method (M5) must surface as REQUEST_CHANGES; the #1343 source-of-truth cap is
+/// exempt for grounded conformance evidence (mirrors the High-effort exemption).
+/// What: model APPROVE + one Medium@0.90 conformance finding → REQUEST_CHANGES.
+/// Test: this test itself.
+#[test]
+fn conformance_finding_caps_at_request_changes() {
+    let findings = vec![conformance_finding(Effort::Medium, 0.90)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "a confident conformance divergence must floor to REQUEST_CHANGES (AC-8)"
+    );
+}
+
+/// AC-8 (never-BLOCK): a HIGH-effort conformance finding is still capped at
+/// REQUEST_CHANGES — conformance NEVER drives BLOCK.
+///
+/// Why: BLOCK is reserved for correctness/safety (OQ-5).  Even a high-severity
+/// conformance divergence must not block; the conformance floor caps it.
+/// What: model APPROVE + one High@0.95 conformance finding → REQUEST_CHANGES
+/// (NOT BLOCK, the value a High *correctness* finding would yield).
+/// Test: this test itself.
+#[test]
+fn conformance_high_effort_never_blocks() {
+    let findings = vec![conformance_finding(Effort::High, 0.95)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "conformance must cap at REQUEST_CHANGES and NEVER drive BLOCK (AC-8)"
+    );
+    assert_ne!(verdict, Verdict::Block, "conformance must never BLOCK");
+}
+
+/// AC-12: a conformance finding BELOW FLOOR_MIN_CONFIDENCE (0.80) is advisory and
+/// does NOT raise the verdict floor.
+///
+/// Why: the 0.80 gate is the primary false-positive guard (G3); a low-confidence
+/// conformance finding must not move the verdict.
+/// What: model APPROVE + one Medium@0.75 conformance finding → APPROVE.
+/// Test: this test itself.
+#[test]
+fn conformance_below_floor_confidence_is_advisory() {
+    let findings = vec![conformance_finding(Effort::Medium, 0.75)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "a sub-0.80 conformance finding is advisory only and must not raise the floor (AC-12)"
+    );
+}
+
+/// AC-12 (High-effort variant): even a HIGH-effort conformance finding below 0.80
+/// must not block — it stays advisory on the conformance axis.
+///
+/// Why: the never-BLOCK ceiling and the 0.80 advisory gate must hold together; a
+/// low-confidence high-severity conformance finding must not sneak to BLOCK via
+/// the correctness `has_high` path.
+/// What: model APPROVE + one High@0.60 conformance finding → APPROVE (the
+/// low-confidence override keeps it advisory; it never reaches BLOCK).
+/// Test: this test itself.
+#[test]
+fn conformance_low_confidence_high_effort_never_blocks() {
+    let findings = vec![conformance_finding(Effort::High, 0.60)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "a conformance finding must never BLOCK regardless of effort/confidence (AC-8/AC-12)"
+    );
+}
+
+/// AC-9: no conformance finding (a gap / conforming diff) leaves the verdict
+/// unchanged by conformance.
+///
+/// Why: when intent is a gap (M3) or the diff conforms, the back gate emits no
+/// conformance finding and must not perturb the verdict.
+/// What: model APPROVE + only a Low correctness finding → APPROVE.
+/// Test: this test itself.
+#[test]
+fn conformance_absent_leaves_verdict_unchanged() {
+    let findings = vec![finding(Effort::Low, 0.95)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "no conformance finding → unchanged (AC-9)"
+    );
+}
+
+/// A conformance finding must NEVER yield BLOCK even when combined with the
+/// grade-aware entry point and an F-implying grade is absent.
+///
+/// Why: the verdict ceiling for conformance is REQUEST_CHANGES at every entry
+/// point, including `derive_verdict_with_grade`.
+/// What: model APPROVE, grade B (APPROVE) + one High@0.90 conformance finding →
+/// REQUEST_CHANGES, not BLOCK.
+/// Test: this test itself.
+#[test]
+fn conformance_never_blocks_via_grade_entry_point() {
+    let findings = vec![conformance_finding(Effort::High, 0.90)];
+    let (v, _g) = derive_verdict_with_grade(Verdict::Approve, Grade::B, &findings);
+    assert_eq!(
+        v,
+        Verdict::RequestChanges,
+        "conformance caps at REQUEST_CHANGES"
+    );
+    assert_ne!(v, Verdict::Block, "conformance never BLOCKs (AC-8)");
+}
+
+/// A confident conformance finding combined with a confirmed High *correctness*
+/// finding still BLOCKs — the correctness axis is unaffected by the conformance cap.
+///
+/// Why: the conformance cap must only bound the conformance axis; a real
+/// correctness blocker in the same review still drives BLOCK.
+/// What: one High@0.90 correctness + one Medium@0.90 conformance → BLOCK
+/// (stricter_of(BLOCK, REQUEST_CHANGES)).
+/// Test: this test itself.
+#[test]
+fn conformance_cap_does_not_weaken_correctness_block() {
+    let findings = vec![
+        finding(Effort::High, 0.90),
+        conformance_finding(Effort::Medium, 0.90),
+    ];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a real correctness High finding still BLOCKs alongside a conformance finding"
+    );
 }

--- a/crates/trusty-review/src/pipeline/parser.rs
+++ b/crates/trusty-review/src/pipeline/parser.rs
@@ -37,7 +37,7 @@
 use serde::Deserialize;
 use tracing::{debug, warn};
 
-use crate::models::{Effort, Finding, Verdict};
+use crate::models::{Effort, Finding, FindingCategory, Verdict};
 
 // ─── Wire types (JSON block deserialization) ──────────────────────────────────
 
@@ -69,8 +69,11 @@ struct LlmOutputBlock {
 /// Why: the LLM emits findings as structured JSON; we convert them to the
 /// internal `Finding` type.
 /// What: mirrors the finding schema in the system prompt.  All fields except
-/// `title` and `body` are optional and default gracefully.
-/// Test: covered transitively by `parse_json_block_happy_path`.
+/// `title` and `body` are optional and default gracefully.  `category` is new in
+/// #1359 (back gate); it is `#[serde(default)]` (→ `Correctness`) so responses
+/// from models that do not emit it — and every pre-#1359 fixture — still parse.
+/// Test: covered transitively by `parse_json_block_happy_path` and
+/// `parse_method_conformance_finding_category` in `parser_tests`.
 #[derive(Debug, Deserialize)]
 struct LlmFinding {
     title: String,
@@ -83,6 +86,9 @@ struct LlmFinding {
     file: String,
     #[serde(default)]
     line: Option<u32>,
+    /// Finding axis: `"correctness"` (default) or `"method-conformance"` (#1359).
+    #[serde(default)]
+    category: FindingCategory,
 }
 
 // ─── Parsed output ────────────────────────────────────────────────────────────
@@ -288,8 +294,11 @@ fn try_parse_json_block(body: &str) -> Option<ParsedReview> {
 /// Why: `Finding::new` clamps confidence and normalises effort; the LLM may
 /// produce out-of-range values or unknown effort strings.
 /// What: maps severity → effort (high/critical → High; medium → Medium; else Low);
-/// uses the `title` as the `kind` and `body` as `description`.
-/// Test: covered transitively by `parse_json_block_happy_path`.
+/// uses the `title` as the `kind` and `body` as `description`; preserves the
+/// finding `category` (#1359 — defaulting to `Correctness` when the model omits
+/// it) so the verdict floor can cap a `method-conformance` finding.
+/// Test: covered transitively by `parse_json_block_happy_path` and
+/// `parse_method_conformance_finding_category`.
 fn convert_llm_finding(f: LlmFinding) -> Finding {
     let effort = match f.severity.to_lowercase().as_str() {
         "high" | "critical" => Effort::High,
@@ -301,8 +310,11 @@ fn convert_llm_finding(f: LlmFinding) -> Finding {
     } else {
         f.file
     };
-    let mut finding = Finding::new(file, f.title, f.body, String::new(), f.confidence, effort);
-    finding.line = f.line;
+    let category = f.category;
+    let line = f.line;
+    let mut finding = Finding::new(file, f.title, f.body, String::new(), f.confidence, effort)
+        .with_category(category);
+    finding.line = line;
     finding
 }
 

--- a/crates/trusty-review/src/pipeline/parser_tests.rs
+++ b/crates/trusty-review/src/pipeline/parser_tests.rs
@@ -406,3 +406,66 @@ fn parse_direct_json_approve_star() {
     assert!(!result.is_fail_safe);
     assert_eq!(result.verdict, Verdict::ApproveWithReservations);
 }
+
+// ── Method-conformance finding category (#1359) ──────────────────────────
+
+/// A finding emitting `"category":"method-conformance"` parses to the
+/// `MethodConformance` category.
+///
+/// Why: the back gate (#1359) distinguishes conformance findings by category so
+/// the verdict floor can cap them at REQUEST_CHANGES.  The parser must preserve
+/// the LLM-emitted category.
+/// What: parses a direct-JSON finding with the conformance category, asserts the
+/// internal `Finding.category`.
+/// Test: no network.
+#[test]
+fn parse_method_conformance_finding_category() {
+    let body = r#"{
+        "verdict":"REQUEST_CHANGES",
+        "summary":"Diff contradicts the ticket method.",
+        "findings":[{
+            "title":"Uses offset pagination",
+            "body":"Ticket specifies cursor-based pagination.",
+            "severity":"medium",
+            "confidence":0.9,
+            "file":"src/page.rs",
+            "category":"method-conformance"
+        }]
+    }"#;
+    let result = parse_review_response(body);
+    assert!(!result.is_fail_safe);
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(
+        result.findings[0].category,
+        FindingCategory::MethodConformance,
+        "the conformance category must survive parsing"
+    );
+}
+
+/// A finding that OMITS `category` defaults to `Correctness` (back-compat).
+///
+/// Why: existing fixtures and models that do not emit `category` must keep
+/// parsing as correctness findings (the `#[serde(default)]` guarantee, AC).
+/// What: parses a finding with no `category` key, asserts the default.
+/// Test: no network.
+#[test]
+fn parse_finding_without_category_defaults_correctness() {
+    let body = r#"{
+        "verdict":"REQUEST_CHANGES",
+        "summary":"Bug.",
+        "findings":[{
+            "title":"Null deref",
+            "body":"Unchecked unwrap.",
+            "severity":"high",
+            "confidence":0.95,
+            "file":"src/x.rs"
+        }]
+    }"#;
+    let result = parse_review_response(body);
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(
+        result.findings[0].category,
+        FindingCategory::Correctness,
+        "a finding with no category must default to Correctness (back-compat)"
+    );
+}

--- a/crates/trusty-review/src/pipeline/parser_tests.rs
+++ b/crates/trusty-review/src/pipeline/parser_tests.rs
@@ -445,7 +445,14 @@ fn parse_method_conformance_finding_category() {
 /// A finding that OMITS `category` defaults to `Correctness` (back-compat).
 ///
 /// Why: existing fixtures and models that do not emit `category` must keep
-/// parsing as correctness findings (the `#[serde(default)]` guarantee, AC).
+/// parsing as correctness findings (the `#[serde(default)]` guarantee, AC). This
+/// is also the cross-provider safety net for #1359: `category` is in the schema's
+/// `required` array ONLY because OpenAI strict mode demands every property be
+/// required (see `review_schema_is_openai_strict_compliant`). Non-strict backends
+/// (Bedrock/Anthropic tool-use, Gemini) and older models can omit `category`
+/// WITHOUT client-side rejection — both the OpenRouter and Bedrock backends route
+/// their structured output through THIS serde path, so an omitted `category` is
+/// silently defaulted here rather than rejected by any validation layer.
 /// What: parses a finding with no `category` key, asserts the default.
 /// Test: no network.
 #[test]

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -124,6 +124,22 @@ pub fn review_response_schema() -> ResponseSchema {
                         "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
                         "file": {"type": "string"},
                         "line": {"type": ["integer", "null"]},
+                        // `category` (#1359) is intentionally listed here so
+                        // `enforce_strict_mode` adds it to `findings.items.required`.
+                        // OpenAI strict mode REQUIRES every declared property to be
+                        // in `required` (an omission rejects the whole request), so it
+                        // MUST stay required for the `openai/*` path. Non-strict
+                        // providers (Bedrock/Anthropic tool-use, Gemini) and older
+                        // models that omit `category` are NOT rejected client-side:
+                        // both backends funnel their structured output through the
+                        // SAME `parse_review_response` serde path, where
+                        // `LlmFinding.category` is `#[serde(default)]` → `Correctness`.
+                        // So "required" here is a strict-mode requirement, not a
+                        // hard contract that breaks lenient providers; the serde
+                        // default is the cross-provider safety net. See
+                        // `parse_finding_without_category_defaults_correctness`
+                        // (parser_tests.rs) and the assertion in
+                        // `review_schema_is_openai_strict_compliant` (prompt_tests.rs).
                         "category": {
                             "type": "string",
                             "enum": ["correctness", "method-conformance"],
@@ -134,7 +150,10 @@ pub fn review_response_schema() -> ResponseSchema {
             }
         }
     });
-    // Make every object node OpenAI strict-mode compliant in one pass.
+    // Make every object node OpenAI strict-mode compliant in one pass. This is
+    // what adds `category` (and every other property) to `findings.items.required`
+    // for OpenAI strict mode; non-strict providers rely on the serde default
+    // instead (see the `category` note above).
     enforce_strict_mode(&mut schema);
     ResponseSchema {
         name: REVIEW_SCHEMA_NAME.to_string(),

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -123,7 +123,12 @@ pub fn review_response_schema() -> ResponseSchema {
                         },
                         "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
                         "file": {"type": "string"},
-                        "line": {"type": ["integer", "null"]}
+                        "line": {"type": ["integer", "null"]},
+                        "category": {
+                            "type": "string",
+                            "enum": ["correctness", "method-conformance"],
+                            "description": "Almost always \"correctness\". Use \"method-conformance\" ONLY when the diff explicitly contradicts a method/approach/constraint the ticket or spec stated in the \"Intended method (ticket/spec)\" context — never for a missing method (advisory gap) or a stale-spec conflict."
+                        }
                     }
                 }
             }

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -71,6 +71,19 @@ Every finding MUST have a `severity` from:
 Focus on: correctness bugs, security issues, data-loss risks, logic errors.
 Note but do not block on: style, minor naming, documentation gaps, test coverage.
 
+## Method conformance (ticket/spec intent)
+The user message may include an "Intended method (ticket/spec)" context block that
+states a SPECIFIC method, approach, or constraint the ticket or spec prescribed for
+this change (e.g. "use cursor-based pagination", "add no new dependency", "reuse the
+existing trait"). When — and ONLY when — the diff EXPLICITLY CONTRADICTS such a
+stated method, emit a finding with `category` = "method-conformance" describing the
+contradiction. Be conservative: this is REQUEST_CHANGES-grade, NOT a blocker.
+Do NOT emit a method-conformance finding when:
+- no method/approach/constraint is stated (a gap — there is nothing to conform to);
+- the ticket and spec merely disagree (stale-spec conflict — advisory only);
+- you are merely unsure; ambiguity is not a contradiction.
+Every other finding uses `category` = "correctness" (the default).
+
 ## Output (REQUIRED — populate the structured response fields)
 - `grade`: one of A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F.
 - `grade_justification`: one-sentence reason for the grade.
@@ -78,7 +91,8 @@ Note but do not block on: style, minor naming, documentation gaps, test coverage
 - `summary`: one sentence summary of the review.
 - `findings`: array of issues found (empty array if none).
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
-  confidence (0.0–1.0), file (source file path), line (null if not applicable).
+  confidence (0.0–1.0), file (source file path), line (null if not applicable),
+  category ("correctness" by default, or "method-conformance" per the rule above).
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.
@@ -144,6 +158,19 @@ Every finding MUST have a `severity` from:
 Focus on: correctness bugs, security issues, data-loss risks, logic errors.
 Note but do not block on: style, minor naming, documentation gaps.
 
+## Method conformance (ticket/spec intent)
+The user message may include an "Intended method (ticket/spec)" context block that
+states a SPECIFIC method, approach, or constraint the ticket or spec prescribed for
+this change (e.g. "use cursor-based pagination", "add no new dependency", "reuse the
+existing trait"). When — and ONLY when — the diff EXPLICITLY CONTRADICTS such a
+stated method, emit a finding with `category` = "method-conformance" describing the
+contradiction. Be conservative: this is REQUEST_CHANGES-grade, NOT a blocker.
+Do NOT emit a method-conformance finding when:
+- no method/approach/constraint is stated (a gap — there is nothing to conform to);
+- the ticket and spec merely disagree (stale-spec conflict — advisory only);
+- you are merely unsure; ambiguity is not a contradiction.
+Every other finding uses `category` = "correctness" (the default).
+
 ## Test coverage
 A coverage report has been provided in the user message (## Test coverage context).
 You may note coverage gaps as findings (severity=low or medium), but do NOT use
@@ -157,7 +184,8 @@ coverage floor after your response based on the configured policy.
 - `summary`: one sentence summary of the review.
 - `findings`: array of issues found (empty array if none).
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
-  confidence (0.0–1.0), file (source file path), line (null if not applicable).
+  confidence (0.0–1.0), file (source file path), line (null if not applicable),
+  category ("correctness" by default, or "method-conformance" per the rule above).
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -457,6 +457,12 @@ fn review_schema_is_openai_strict_compliant() {
         .iter()
         .filter_map(serde_json::Value::as_str)
         .collect();
+    // `category` (#1359) MUST be in `required` here: OpenAI strict mode rejects
+    // any schema whose object node omits a declared property from `required`.
+    // This does NOT make `category` mandatory for non-strict providers — those
+    // funnel through the serde path where `LlmFinding.category` is
+    // `#[serde(default)]` → `Correctness`, so an omitted `category` is defaulted,
+    // never rejected (see `parse_finding_without_category_defaults_correctness`).
     assert_eq!(
         required,
         [

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -459,9 +459,17 @@ fn review_schema_is_openai_strict_compliant() {
         .collect();
     assert_eq!(
         required,
-        ["body", "confidence", "file", "line", "severity", "title"]
-            .into_iter()
-            .collect(),
+        [
+            "body",
+            "category",
+            "confidence",
+            "file",
+            "line",
+            "severity",
+            "title"
+        ]
+        .into_iter()
+        .collect(),
         "findings.items must require every property under strict mode"
     );
 }

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -262,6 +262,7 @@ pub async fn run_review(
             &changed_files,
             title,
             body,
+            pr_number,
             input.run_mode,
         ),
     );

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -182,7 +182,9 @@ fn build_apex_cross_query(
 /// What: constructs the enabled context sources from `config.context_sources`
 /// (each auto-disabled when its credentials are absent), builds a `ReviewSubject`
 /// carrying the PR title + body (#599 Fix 3 — the body is scanned for JIRA ticket
-/// keys and folded into each source's query), runs the sources concurrently and
+/// keys and folded into each source's query) and the PR number (#1359 — the
+/// conformance source threads it into the ISR `IntentQuery::Pr`; `0` in local-diff
+/// mode), runs the sources concurrently and
 /// fail-open via the orchestrator, and renders the surviving sections to a
 /// markdown block.  Returns an empty string when no source contributes.
 /// Test: source construction is covered by each source's `from_config` tests;
@@ -197,6 +199,7 @@ pub(crate) async fn gather_external_context_md(
     changed_files: &[String],
     pr_title: &str,
     pr_body: &str,
+    pr_number: u64,
     run_mode: RunMode,
 ) -> String {
     let cs = &config.context_sources;
@@ -230,6 +233,7 @@ pub(crate) async fn gather_external_context_md(
         body: pr_body.to_string(),
         changed_files: changed_files.to_vec(),
         identifiers: identifiers.to_vec(),
+        pr_number,
     };
 
     let sections = gather_external_context(&sources, &subject).await;

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -19,8 +19,8 @@ use crate::{
     integrations::{
         apex_context::fetch_apex_context,
         context::{
-            ConfluenceSource, ContextSource, GithubIssuesSource, JiraSource, ReviewSubject,
-            gather_external_context, render_sections,
+            ConfluenceSource, ConformanceSource, ContextSource, GithubIssuesSource, JiraSource,
+            ReviewSubject, gather_external_context, render_sections,
         },
         github::RunMode,
     },
@@ -205,6 +205,13 @@ pub(crate) async fn gather_external_context_md(
         Box::new(ConfluenceSource::from_config(&cs.confluence)),
         Box::new(GithubIssuesSource::from_config(
             &cs.github_issues,
+            run_mode,
+            config.clone(),
+        )),
+        // BACK gate (#1359): surfaces the resolved ticket/spec intent so the LLM
+        // can flag explicit method contradictions.  Default DISABLED (needs auth).
+        Box::new(ConformanceSource::from_config(
+            &cs.conformance,
             run_mode,
             config.clone(),
         )),


### PR DESCRIPTION
Closes #1359
Part of #1354

## Scope (SPEC-CONFORMANCE-02 §5.2 / §7.1)

Implements the **BACK gate** of the intent/method-conformance system in `trusty-review`, consuming the merged C1 ISR (`trusty_common::intent_source`, #1363).

- **`ConformanceSource`** (`integrations/context/conformance.rs`) — a `ContextSource` whose `gather` calls `intent_source::resolve(IntentQuery::Pr { … })` and renders the resolved `ResolvedIntent` as an `## Intended method (ticket/spec)` section. Registered one-line in `pipeline/runner_context.rs`. The `intent-source` feature is enabled on the `trusty-common` dep.
- **Config** — new `conformance: SourceConfig` on `ContextSourcesConfig` (+ TOML/env mirror), **default-disabled** (it calls the ISR / GitHub, so it is explicit opt-in).
- **`FindingCategory { Correctness, MethodConformance }`** — threaded through `LlmFinding` (parser), `Finding` (models), and `convert_llm_finding`, with `#[serde(default)] = Correctness` so existing fixtures/LLM responses still deserialize.
- **Prompt** — JSON schema `category` field + conservative prose: emit `method-conformance` **only** on an explicit contradiction (M5/M1/M2), **never** for an advisory gap (M3) or a stale-spec conflict (M4).
- **Verdict floor** (`grade.rs`) — conformance findings flow through the floor **capped at `REQUEST_CHANGES`** and **never drive `BLOCK`**; a conformance finding below `FLOOR_MIN_CONFIDENCE` (0.80) is advisory and does **not** raise the floor. The #1343 source-of-truth cap is exempt for a *confident* conformance divergence so a model APPROVE + grounded divergence still floors to REQUEST_CHANGES.
- **Fail-open (AC-11)** — ISR `unresolved`/gap/no-linkage → empty section, **no conformance finding manufactured**.
- **Auth (§7.4)** — pluggable `ConformanceTokenResolver` mirroring `IssueTokenResolver`; production path bridges review's dual-mode auth into the ISR's `IntentTokenResolver` (no hard-wired PAT).

## Acceptance criteria

- **AC-8** confirmed contradiction → REQUEST_CHANGES-capped (`conformance_finding_caps_at_request_changes`, `conformance_high_effort_never_blocks`)
- **AC-9** gap / conforming diff → no conformance finding, verdict unchanged (`gather_gap_renders_empty`, `conformance_absent_leaves_verdict_unchanged`)
- **AC-10** stale-spec conflict (M4) surfaced as advisory, ticket wins (`render_stale_spec_advisory`)
- **AC-11** unresolved ISR → empty section, fail-open (`gather_fail_open_on_unresolved`, `gather_no_linkage_renders_empty`, `render_unresolved_is_empty`)
- **AC-12** sub-0.80 conformance finding is advisory, does not raise the floor (`conformance_below_floor_confidence_is_advisory`)
- Back-compat: category-less fixtures still deserialize → `Correctness` (`finding_without_category_field_defaults_correctness`, `parse_finding_without_category_defaults_correctness`)

**Conformance caps at `REQUEST_CHANGES` and NEVER `BLOCK`; it is fail-open.**

## Verification (from the worktree)

- `cargo build -p trusty-review` — OK
- `cargo test -p trusty-review` — 866 passed, 0 failed, 3 ignored (incl. #1343/#1350 calibration regressions)
- `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- `cargo fmt -p trusty-review -- --check` — clean
- `cargo check -p trusty-common --features intent-source` — OK
- `bash scripts/check_line_cap.sh` — 0 violations
- full `cargo check` — workspace builds

No version bump (release handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)