### PR TITLE
chore(release): trusty-review v0.3.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11023,7 +11023,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.9.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.3.13" }
+trusty-review = { path = "crates/trusty-review", version = "0.3.14" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.13"
+version     = "0.3.14"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Summary

- Bumps `trusty-review` from 0.3.13 → 0.3.14 (PATCH)
- Ships merged #1352 (explicit `is_high_severity` predicate) and #1357 (0.3.13 hardening follow-ups)
- Updates `[workspace.dependencies]` version pin in root `Cargo.toml` to match

## Test plan

- [x] `cargo build -p trusty-review` — clean
- [x] `cargo test -p trusty-review` — 19 passed, 0 failed
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-review -- --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 15 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)