### PR TITLE
feat(intent-conformance): docs + AC-18 cross-gate golden test (C5) (#1362)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10993,6 +10993,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "trusty-common",
+ "trusty-review",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -210,6 +210,15 @@ nix = { version = "0.29", features = ["signal"] }
 # `cargo build --features sm-memory`. `memory-core` is repeated so the unified
 # feature set still includes the palace storage engine the SM-4 tests exercise.
 trusty-common = { workspace = true, features = ["memory-core", "embedder-test-support"] }
+# DEV-ONLY (DOC-15 C5 / #1362): the cross-gate AC-18 golden test
+# (`tests/conformance_cross_gate.rs`) drives BOTH conformance gates from one
+# shared `trusty_common::intent_source::ResolvedIntent` — the trusty-mpm FRONT
+# gate (`front_gate_disposition`) and the trusty-review BACK gate
+# (`ConformanceSource::would_flag`). trusty-review is a dev-dependency ONLY (it
+# is NOT a runtime dependency of trusty-mpm, and neither crate depends on the
+# other normally, so this introduces no dependency cycle and adds zero cost to a
+# production `cargo build`).
+trusty-review = { workspace = true }
 tempfile.workspace = true
 axum.workspace = true
 http-body-util.workspace = true

--- a/crates/trusty-mpm/tests/conformance_cross_gate.rs
+++ b/crates/trusty-mpm/tests/conformance_cross_gate.rs
@@ -1,0 +1,237 @@
+//! AC-18 cross-gate golden test (DOC-15 C5, #1362) — the capstone of the
+//! intent/method-conformance epic (#1354).
+//!
+//! Why: the whole point of the shared intent-source resolver (ISR) is that the
+//! FRONT gate (trusty-mpm, pre-work) and the BACK gate (trusty-review,
+//! post-implementation) can **never disagree** about a given intent (spec §6.5,
+//! goal G1/G4). AC-18 (spec §8) makes that guarantee a *test*: the SAME
+//! `ResolvedIntent` must drive both gates to consistent matrix outcomes — FRONT
+//! `Escalate` ⇔ BACK would-flag for **M5** inputs (divergence), and FRONT
+//! `AutoAccept` ⇔ BACK no-finding for **M3** inputs (gap). A regression in either
+//! gate's matrix mapping (e.g. the FRONT gate stops escalating on divergence, or
+//! the BACK renderer starts surfacing a method for a gap) breaks this equivalence
+//! and fails here — which is exactly the cross-gate contract the epic promised.
+//!
+//! What: this is a genuine cross-crate test. It lives in trusty-mpm (which
+//! dev-depends on trusty-review, see Cargo.toml) so it can call BOTH real gate
+//! entry points against ONE shared intent value — the FRONT entry point
+//! `trusty_mpm::daemon::managed_routes::front_gate::front_gate_disposition` (the
+//! pure matrix→`Disposition` mapping, spec §4.1 / §5.1), and the BACK entry point
+//! `trusty_review::integrations::context::ConformanceSource::would_flag` (derived
+//! from the real `render_section` renderer, spec §5.2).
+//! The shared `ResolvedIntent` is produced by the REAL ISR
+//! (`trusty_common::intent_source::resolve_default`) from a fixture ticket body,
+//! using offline mock `TicketFetcher`/`SpecLookup` seams — so the test exercises
+//! the actual resolution + precedence path, not a hand-built struct, and never
+//! touches the network.
+//!
+//! Test: this file IS the AC-18 golden test. Run with
+//! `cargo test -p trusty-mpm --test conformance_cross_gate`.
+
+use async_trait::async_trait;
+
+use trusty_common::intent_source::{
+    ChangedFile, IntentQuery, IsrError, Method, MethodKind, Precedence, ResolvedIntent, SpecLookup,
+    TicketData, TicketFetcher, heuristic_method, resolve_default,
+};
+
+use trusty_mpm::daemon::managed_routes::front_gate::front_gate_disposition;
+use trusty_review::integrations::context::ConformanceSource;
+
+// ───────────────────────── offline ISR seams ─────────────────────────────────
+
+/// A `TicketFetcher` returning a fixed ticket body (no network).
+///
+/// Why: the golden test must drive the REAL resolver offline; this injects the
+/// ticket body that determines whether the resolved intent is an M5 (a
+/// prescribed method) or an M3 (a gap).
+/// What: returns a `TicketData` carrying `body` for any id.
+/// Test: used by `resolve_fixture` below.
+struct FixtureFetcher {
+    body: String,
+}
+
+#[async_trait]
+impl TicketFetcher for FixtureFetcher {
+    async fn fetch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        ticket_id: &str,
+    ) -> Result<TicketData, IsrError> {
+        Ok(TicketData {
+            id: ticket_id.to_string(),
+            title: "AC-18 fixture".to_string(),
+            body: self.body.clone(),
+            url: Some("https://github.com/x/y/issues/1362".to_string()),
+            backend: "github".to_string(),
+        })
+    }
+}
+
+/// A `SpecLookup` that resolves no spec (the spec axis is intentionally a gap so
+/// the fixture's intent is driven purely by the ticket body).
+struct NoSpecLookup;
+impl SpecLookup for NoSpecLookup {
+    fn load(&self, _spec_file: &str) -> Option<String> {
+        None
+    }
+}
+
+/// Resolve a shared `ResolvedIntent` from a ticket `body`, via the REAL ISR.
+///
+/// Why: AC-18 demands the SAME resolved intent drive both gates; producing it
+/// through `resolve_default` (the actual resolver + precedence) — rather than
+/// hand-constructing the struct — proves the gates agree on what the resolver
+/// *actually* returns (spec §6.1).
+/// What: builds a `Ticket` query with no changed files (spec axis = gap), runs
+/// `resolve_default` with the offline fetcher + `NoSpecLookup`, and returns the
+/// resolved intent.
+/// Test: used by both `ac18_*` cases below.
+async fn resolve_fixture(body: &str) -> ResolvedIntent {
+    let fetcher = FixtureFetcher {
+        body: body.to_string(),
+    };
+    let query = IntentQuery::Ticket {
+        ticket_id: "#1362".to_string(),
+        owner: "bobmatnyc".to_string(),
+        repo: "trusty-tools".to_string(),
+        changed_files: Vec::<ChangedFile>::new(),
+    };
+    resolve_default(query, &fetcher, &NoSpecLookup).await
+}
+
+/// A planned method for the FRONT gate (the pre-work "subject" being judged).
+fn planned(text: &str) -> Method {
+    Method {
+        text: text.to_string(),
+        kind: MethodKind::Approach,
+        source_excerpt: text.to_string(),
+    }
+}
+
+// ═════════════════════ AC-18: the cross-gate equivalence ═════════════════════
+
+/// AC-18 (M5): FRONT `Escalate` ⇔ BACK would-flag for a divergent method.
+///
+/// Why: M5 is the *divergence* row (spec §4.1) — the subject contradicts an
+/// explicit prescribed method. The cross-gate contract requires the FRONT gate to
+/// escalate (before coding) and the BACK gate to be able to flag (during review)
+/// for the SAME resolved intent. If they ever diverge here, the epic's central
+/// guarantee is broken.
+/// What: resolves a fixture whose ticket prescribes "use cursor-based pagination"
+/// (→ `precedence_winner = Ticket`, a prescribed method), then:
+///   - drives the REAL FRONT gate with a *diverging* planned method
+///     ("use offset-based pagination") and asserts `Escalate`;
+///   - drives the REAL BACK gate (`would_flag`) on the SAME intent and asserts it
+///     would flag (true);
+///   - asserts the two outcomes are EQUIVALENT (escalate ⇔ would-flag).
+/// Test: this test; offline (mock ISR seams), no network.
+#[tokio::test]
+async fn ac18_m5_divergence_front_escalate_iff_back_would_flag() {
+    // One shared intent, resolved by the real ISR. The ticket prescribes a
+    // method → M-class intent (M1; a divergent subject makes it M5).
+    let intent = resolve_fixture(
+        "Implement the listing endpoint. We must use cursor-based pagination, not offset.",
+    )
+    .await;
+
+    // Sanity: the fixture really is a prescribed-method (non-gap) intent.
+    assert_eq!(
+        intent.precedence_winner,
+        Precedence::Ticket,
+        "M5 fixture must resolve a ticket-prescribed method"
+    );
+    assert!(
+        intent.ticket_method.is_some(),
+        "M5 fixture must carry a ticket method"
+    );
+    assert!(!intent.is_gap(), "M5 fixture must NOT be a gap");
+
+    // FRONT gate (real): a planned method that DIVERGES from the prescribed one.
+    let diverging_plan = planned("use offset-based pagination");
+    let front = front_gate_disposition(&intent, Some(&diverging_plan));
+    let front_escalates = !front.is_auto_accept();
+
+    // BACK gate (real): would the conformance source surface a method to flag?
+    let back_would_flag = ConformanceSource::would_flag(&intent);
+
+    assert!(front_escalates, "M5: FRONT must escalate on divergence");
+    assert!(back_would_flag, "M5: BACK must be able to flag (M5)");
+    // The AC-18 equivalence itself: escalate ⇔ would-flag.
+    assert_eq!(
+        front_escalates, back_would_flag,
+        "AC-18 (M5): FRONT escalate must hold IFF BACK would-flag"
+    );
+}
+
+/// AC-18 (M3): FRONT `AutoAccept` ⇔ BACK no-finding for a gap.
+///
+/// Why: M3 is the *gap* row (spec §4.1) — neither ticket nor spec prescribes a
+/// method, so there is nothing to conform to. The cross-gate contract requires
+/// the FRONT gate to auto-proceed and the BACK gate to emit nothing for the SAME
+/// resolved intent.
+/// What: resolves a fixture whose ticket body has no imperative-method cue
+/// (→ a gap, `precedence_winner = None`), then:
+///   - drives the REAL FRONT gate with no planned method and asserts `AutoAccept`;
+///   - drives the REAL BACK gate (`would_flag`) on the SAME intent and asserts it
+///     would NOT flag (false);
+///   - asserts the two outcomes are EQUIVALENT (auto-accept ⇔ no-finding).
+/// Test: this test; offline, no network.
+#[tokio::test]
+async fn ac18_m3_gap_front_auto_accept_iff_back_no_finding() {
+    // One shared intent, resolved by the real ISR. The body prescribes NO method
+    // → a gap (M3).
+    let intent =
+        resolve_fixture("Add a new field to the response payload. See the discussion thread.")
+            .await;
+
+    // Sanity: the fixture really is a gap.
+    assert!(intent.is_gap(), "M3 fixture must be a gap");
+    assert_eq!(
+        intent.precedence_winner,
+        Precedence::None,
+        "M3 fixture must have no precedence winner"
+    );
+
+    // FRONT gate (real): no planned method (pre-work plan is implicit) — and even
+    // a gap intent has nothing to conform to.
+    let front = front_gate_disposition(&intent, None);
+    let front_auto_accepts = front.is_auto_accept();
+
+    // BACK gate (real): a gap surfaces no method → no finding possible.
+    let back_no_finding = !ConformanceSource::would_flag(&intent);
+
+    assert!(front_auto_accepts, "M3: FRONT must auto-accept on a gap");
+    assert!(back_no_finding, "M3: BACK must emit no finding on a gap");
+    // The AC-18 equivalence itself: auto-accept ⇔ no-finding.
+    assert_eq!(
+        front_auto_accepts, back_no_finding,
+        "AC-18 (M3): FRONT auto-accept must hold IFF BACK emits no finding"
+    );
+}
+
+/// AC-18 (cross-check): the heuristic that derives the FRONT planned method is
+/// the SAME one the ISR uses for the ticket method — so "divergence" is measured
+/// on a like-for-like basis, not an artefact of two different extractors.
+///
+/// Why: the FRONT gate derives its planned method from the task prose via
+/// `heuristic_method` (front_gate.rs), and the ISR derives the ticket method via
+/// the same heuristic. Pinning that they classify the divergent/prescribed pair
+/// consistently guards against a subtle false-equivalence where the gates "agree"
+/// only because one extractor silently dropped a method.
+/// What: asserts the prescribed cue extracts an Approach method and the divergent
+/// plan extracts a different Approach method (so the FRONT comparison is genuine).
+/// Test: this test; pure.
+#[test]
+fn ac18_planned_and_prescribed_extract_consistently() {
+    let prescribed = heuristic_method("use cursor-based pagination").expect("prescribed method");
+    let divergent = heuristic_method("use offset-based pagination").expect("divergent method");
+    assert_eq!(prescribed.kind, MethodKind::Approach);
+    assert_eq!(divergent.kind, MethodKind::Approach);
+    assert_ne!(
+        prescribed.text.to_lowercase(),
+        divergent.text.to_lowercase(),
+        "the prescribed and divergent methods must differ (genuine M5 divergence)"
+    );
+}

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -255,6 +255,51 @@ Returns a health status object:
 AWS credentials can also be supplied via `~/.aws/credentials`, IAM roles, or SSO.
 The full AWS credential chain is supported.
 
+## Context sources & the conformance gate
+
+`trusty-review` enriches a review with external **context sources** (JIRA,
+Confluence, GitHub Issues, and the intent/method-**conformance** back gate). Each
+source resolves independently from layered config — an env var beats a TOML key
+beats the built-in default (the `ContextSourcesConfig` struct):
+
+| Source | Enable env var | Mode env var | TOML table | Default |
+|--------|----------------|--------------|------------|---------|
+| JIRA | `TRUSTY_REVIEW_CONTEXT_JIRA_ENABLED` | `…_JIRA_MODE` | `[context.sources.jira]` | auto (on creds) |
+| Confluence | `TRUSTY_REVIEW_CONTEXT_CONFLUENCE_ENABLED` | `…_CONFLUENCE_MODE` | `[context.sources.confluence]` | auto (on creds) |
+| GitHub Issues | `TRUSTY_REVIEW_CONTEXT_GITHUB_ISSUES_ENABLED` | `…_GITHUB_ISSUES_MODE` | `[context.sources.github_issues]` | auto (on creds) |
+| **Conformance** | `TRUSTY_REVIEW_CONTEXT_CONFORMANCE_ENABLED` | `…_CONFORMANCE_MODE` | `[context.sources.conformance]` | **DISABLED** |
+
+Enable values are lenient (`true`/`1`/`yes`/`on`); mode is `live` (only mode
+supported today) or `semantic` (not yet implemented for these sources).
+
+### The `conformance` back gate (DOC-15)
+
+The conformance source is the **BACK gate** of the intent/method-conformance
+capability ([`docs/specs/intent-conformance.md`](../../docs/specs/intent-conformance.md)).
+During review it resolves "what method did the ticket/spec prescribe?" via the
+shared intent-source resolver (ISR) and surfaces it so the reviewer LLM can flag a
+diff that **explicitly contradicts** that method (matrix M5). A gap or an
+unresolved intent surfaces nothing — the gate is conservative and fail-open, so it
+never manufactures a false-positive finding.
+
+It is **default-DISABLED** (unlike the other sources, it does not auto-enable on
+mere credential presence) because it issues a GitHub ticket fetch and is opt-in.
+Turn it on explicitly:
+
+```bash
+# Env (one-shot)
+TRUSTY_REVIEW_CONTEXT_CONFORMANCE_ENABLED=true trusty-review serve
+
+# …or in $XDG_CONFIG_HOME/trusty-review/config.toml
+[context.sources.conformance]
+enabled = true
+mode = "live"
+```
+
+The gate is backed by the `intent_source` module in **trusty-common**, gated
+behind that crate's **`intent-source`** Cargo feature (which `trusty-review`
+already enables). See the [Cargo features](#cargo-features) note below.
+
 ## Reviewer model
 
 The default reviewer model is `us.anthropic.claude-sonnet-4-6` on AWS Bedrock.
@@ -277,6 +322,12 @@ Provider prefix convention:
 | `http-server` | yes | Axum HTTP daemon (`serve` subcommand without `--stdio`) |
 | `mcp` | yes | MCP stdio JSON-RPC service (`serve --stdio`) |
 | `profile` | yes | Longitudinal contributor-profiling pipeline (`profile` subcommand); pulls in `tga` + `rusqlite` |
+
+> The conformance back gate (above) is backed by **trusty-common**'s
+> **`intent-source`** feature, which `trusty-review` enables unconditionally
+> (it is part of the dependency declaration, not a `trusty-review` feature). That
+> feature gates the shared intent-source resolver (ISR) so the other trusty-common
+> consumers that do not need it pay nothing.
 
 Slim build (no contributor profiling, no `tga`/`rusqlite` compilation):
 

--- a/crates/trusty-review/src/integrations/context/conformance.rs
+++ b/crates/trusty-review/src/integrations/context/conformance.rs
@@ -360,6 +360,34 @@ impl ConformanceSource {
         }
     }
 
+    /// Whether the BACK gate would surface a method to flag the diff against.
+    ///
+    /// Why: the cross-gate golden test (AC-18, spec §8) must assert that the SAME
+    /// `ResolvedIntent` drives the FRONT gate (`trusty_mpm`) and the BACK gate
+    /// (here) to *consistent* matrix outcomes — FRONT `Escalate` ⇔ BACK
+    /// would-flag (M5), FRONT `AutoAccept` ⇔ BACK no-finding (M3). The back gate
+    /// never emits a conformance finding unless it first surfaces a prescribed
+    /// method for the reviewer LLM to check the diff against; a gap / unresolved
+    /// intent renders an empty section and can produce no finding (spec §5.2,
+    /// §4.2). This predicate exposes exactly that "is there an intent to flag
+    /// against?" signal — derived from the *real* renderer ([`render_section`]),
+    /// not a reimplementation — so a cross-crate test can drive the genuine gate
+    /// code path against a shared intent.
+    /// What: returns `true` iff [`render_section`] produces a non-empty section
+    /// (i.e. the precedence-winning method exists and is surfaced); `false` for a
+    /// gap (M3), an `unresolved` fail-open intent, or any intent with no method on
+    /// either axis. This is a necessary condition for a back-gate finding: the
+    /// LLM is instructed to flag *only* an explicit contradiction of a surfaced
+    /// method, so no surfaced method ⇒ no possible conformance finding.
+    ///
+    /// [`render_section`]: ConformanceSource::render_section
+    /// Test: `would_flag_*` in `conformance_tests.rs`; the cross-gate AC-18 golden
+    /// test in `trusty-mpm/tests/conformance_cross_gate.rs`.
+    #[must_use]
+    pub fn would_flag(intent: &ResolvedIntent) -> bool {
+        !Self::render_section(intent).snippets.is_empty()
+    }
+
     /// An empty section (no snippets) — the fail-open / gap signal.
     ///
     /// Why: the orchestrator drops empty sections, so an empty section is exactly

--- a/crates/trusty-review/src/integrations/context/conformance_tests.rs
+++ b/crates/trusty-review/src/integrations/context/conformance_tests.rs
@@ -240,6 +240,75 @@ fn render_unresolved_is_empty() {
     assert!(section.snippets.is_empty());
 }
 
+// ─── would_flag predicate (cross-gate AC-18 contribution) ─────────────────────
+
+/// A resolved intent whose TICKET prescribes `m` (precedence: Ticket) — the M5
+/// shape (a prescribed method the diff could contradict).
+fn ticket_intent(m: &str) -> ResolvedIntent {
+    ResolvedIntent {
+        ticket: Some(TicketRef {
+            id: "#1362".to_string(),
+            title: "t".to_string(),
+            url: None,
+            backend: "github".to_string(),
+        }),
+        ticket_method: Some(Method {
+            text: m.to_string(),
+            kind: MethodKind::Approach,
+            source_excerpt: m.to_string(),
+        }),
+        spec_section: None,
+        spec_method: None,
+        precedence_winner: Precedence::Ticket,
+        conflict: false,
+        stale_spec: false,
+        unresolved: None,
+    }
+}
+
+/// `would_flag` is TRUE when a prescribed method exists (M1/M2/M5) — the back
+/// gate surfaces a method to check the diff against.
+///
+/// Why: AC-18 asserts FRONT `Escalate` ⇔ BACK would-flag for M5 inputs; this
+/// pins the BACK half of that equivalence at the renderer level (spec §5.2).
+/// What: a ticket-prescribed-method intent → `would_flag == true`.
+/// Test: this test; pure, no network.
+#[test]
+fn would_flag_true_for_prescribed_method() {
+    let intent = ticket_intent("use cursor-based pagination");
+    assert!(
+        ConformanceSource::would_flag(&intent),
+        "a prescribed method must be surfaced (M5 would-flag)"
+    );
+}
+
+/// `would_flag` is FALSE for a gap (M3) — nothing to flag against.
+///
+/// Why: AC-18 asserts FRONT `AutoAccept` ⇔ BACK no-finding for M3 inputs; this
+/// pins the BACK half (spec §4.1 M3, §4.2).
+/// What: `ResolvedIntent::none()` → `would_flag == false`.
+/// Test: this test; pure.
+#[test]
+fn would_flag_false_for_gap() {
+    assert!(
+        !ConformanceSource::would_flag(&ResolvedIntent::none()),
+        "a gap (M3) surfaces no method → no finding possible"
+    );
+}
+
+/// `would_flag` is FALSE for an `unresolved` (fail-open) intent (AC-11).
+///
+/// Why: a missing/unfetchable intent source must never manufacture a finding.
+/// What: `ResolvedIntent::unresolved(..)` → `would_flag == false`.
+/// Test: this test; pure.
+#[test]
+fn would_flag_false_for_unresolved() {
+    assert!(
+        !ConformanceSource::would_flag(&ResolvedIntent::unresolved("fetch failed")),
+        "an unresolved intent is fail-open → no finding (AC-11)"
+    );
+}
+
 // ─── gather: mode + enabled ───────────────────────────────────────────────────
 
 /// Semantic mode is not implemented (PR-B parity) → error (logged, fail-open by

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,13 @@
   - [0002 — Single-install convention](./adr/0002-single-install-convention.md)
   - [0003 — MSRV & edition policy](./adr/0003-msrv-and-edition-policy.md)
 
+# Behavior-Contract Specs
+
+- [Specs Index](./specs/README.md)
+  - [DOC-13 — Coordinator TUI](./specs/tui-coordinator.md)
+  - [DOC-14 — Session Manager Agent](./specs/session-manager-agent.md)
+  - [DOC-15 — Intent / Method Conformance](./specs/intent-conformance.md)
+
 # trusty-agents
 
 - [Overview](./trusty-agents/README.md)

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,55 @@
+# Behavior-Contract Specs
+
+This directory holds the **workspace-wide engineering specs** for trusty-tools.
+
+## What is a spec?
+
+A spec is a **behavior contract**: it states *what* a subsystem does — its
+inputs, outputs, pre/postconditions, error behavior, and the rationale behind
+the design — without prescribing the implementation. Specs are engineering-owned
+and complement the product-facing PRDs: a PRD says *why* and *for whom*; a spec
+says *what the code must do*.
+
+Each spec carries a `DOC-N` document number and one or more stable spec IDs in
+the `SPEC-{SUBSYSTEM}-{NN}~{rev}` grammar (e.g. `SPEC-CONFORMANCE-01~draft`).
+Every governed section anchors its ID with a `{#SPEC-…}` heading marker so that
+source code can link to it via the [Spec-Linked Documentation (SLD)][sld]
+`# Spec References` rustdoc convention, and tooling (the intent-source resolver)
+can resolve a changed file back to the section that governs it.
+
+## Spec catalog
+
+| DOC | Spec ID | Title | Subsystem |
+|-----|---------|-------|-----------|
+| DOC-13 | `SPEC-TUI-COORD-01~draft` | [Coordinator TUI (`tm coordinator`)](./tui-coordinator.md) | trusty-mpm — TUI / coordinator |
+| DOC-14 | `SPEC-SM-AGENT-01~draft` | [Session Manager (SM) Agent](./session-manager-agent.md) | trusty-mpm — daemon / session-manager agent |
+| DOC-15 | `SPEC-CONFORMANCE-01~draft` … `-03~draft` | [Intent / Method Conformance](./intent-conformance.md) | cross-crate — trusty-mpm + trusty-review + trusty-common |
+
+## Status lifecycle
+
+A spec section's **Status** is one of `Draft → Accepted → Superseded`. A `~draft`
+revision suffix marks a section that is not yet frozen; the suffix becomes a
+version tag (`~v1`, `~v2`, …) when the section is accepted. Draft sections are
+where most cross-crate behavior contracts begin — they are linked by code via
+SLD even while `~draft` so traceability is established from the first
+implementation PR.
+
+## Spec-Linked Documentation (SLD)
+
+Source code declares which spec section governs it using a module-level
+`//! # Spec References` (or function-level `/// # Spec References`) rustdoc block
+linking the spec ID to its anchor, e.g.:
+
+```rust
+//! # Spec References
+//!
+//! - [`SPEC-CONFORMANCE-03~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-03~draft)
+```
+
+The intent-source resolver (`trusty_common::intent_source`) reads these blocks
+to resolve a changed file back to the spec section that governs it. It is a
+*reader* of declared links only — it never invents linkage where none is
+declared, and it does **not** enforce a four-status traceability model (that is
+an explicit non-goal, DOC-15 §1.3).
+
+[sld]: #spec-linked-documentation-sld

--- a/docs/specs/intent-conformance.md
+++ b/docs/specs/intent-conformance.md
@@ -603,6 +603,60 @@ token-resolver seam** (mirroring review's `IssueTokenResolver`,
 
 ---
 
+## 10. Operating the gates (config & feature flags)
+
+These are the operator-facing knobs the implemented gates (C1–C4) expose. They
+are documented here so a reader of the spec can map the contract above onto the
+concrete configuration surface (C5, #1362).
+
+### 10.1 The `intent-source` feature flag (trusty-common)
+
+The shared ISR lives behind the **`intent-source`** Cargo feature in
+trusty-common (`Cargo.toml [features]`, §7.3). The feature gates the
+`intent_source` module so the ~11 non-consumer trusty-common dependents pay
+nothing (§6.5). The two gate crates enable it explicitly:
+
+- **trusty-review** enables it unconditionally in its dependency declaration
+  (`trusty-common = { workspace = true, features = ["intent-source"] }`).
+- **trusty-mpm**'s FRONT gate reaches the same module through the crate's
+  trusty-common dependency.
+
+Build/test the ISR in isolation with
+`cargo test -p trusty-common --features intent-source`.
+
+### 10.2 The `conformance` context-source config (trusty-review BACK gate)
+
+The BACK gate is registered as a `ContextSource` named `conformance`
+(§7.1) and configured through trusty-review's layered context-source config
+(`ContextSourcesConfig` / `[context.sources.conformance]`). Resolution precedence
+is **env var > TOML > default** per source:
+
+| Knob | Value |
+|---|---|
+| Enable (env) | `TRUSTY_REVIEW_CONTEXT_CONFORMANCE_ENABLED=true` (lenient: `true`/`1`/`yes`/`on`) |
+| Mode (env) | `TRUSTY_REVIEW_CONTEXT_CONFORMANCE_MODE=live` (`semantic` not implemented) |
+| TOML | `[context.sources.conformance] enabled = true` (under `[context]`) |
+| Default | **DISABLED** — unlike the other sources it does NOT auto-enable on credential presence (it issues a GitHub ticket fetch; opt-in only). |
+
+Auth follows review's dual-mode `AuthStrategy` (CLI → PAT/`gh`, serve → App/JWT)
+through the pluggable token-resolver seam (§7.4) — the gate adds no new credential
+path. On any auth/fetch failure the source fails open to an empty section and
+manufactures no finding (§4.2, AC-11).
+
+Operator-facing copy of these knobs lives in the trusty-review README
+(*Context sources & the conformance gate*).
+
+### 10.3 The FRONT gate (trusty-mpm) — capability state
+
+The FRONT gate composes its conformance disposition with `evaluate_autonomy_tier`
+(stricter-wins, §5.1, AC-16) and escalates via `pending_decision`. Until **#1269**
+(headless-spawn) lands, the headless auto-spawn approval path is unavailable and
+an escalation degrades to the CLI-owned operator-confirm path
+(`HeadlessApproval::current() == OperatorConfirm`, §5.1). There is no separate
+feature flag — the gate runs on the default `daemon` feature set.
+
+---
+
 ## 12. Non-goals
 
 - Implementing any gate or the ISR in Rust (this PR is doc-only).


### PR DESCRIPTION
Closes #1362. **Completes epic #1354** — with C5 landed, all five children of the
intent/method-conformance epic are done: C1 (#1358 ISR) · C2 (#1359 BACK gate) ·
C3 (#1360 FRONT gate) · C4 (#1361 SLD spec-resolver) · **C5 (#1362, this PR)**.

## Primary deliverable — AC-18 cross-gate golden test

`crates/trusty-mpm/tests/conformance_cross_gate.rs` proves the epic's central
guarantee: the FRONT and BACK gates can **never disagree** about a given intent.
The **same** `trusty_common::intent_source::ResolvedIntent` — produced by the
**real ISR** (`resolve_default`) from a fixture ticket body through offline mock
`TicketFetcher`/`SpecLookup` seams (no network) — drives **both real gate entry
points** and asserts the equivalence:

| Row | FRONT (`front_gate_disposition`) | BACK (`ConformanceSource::would_flag`) | Asserted |
|-----|----------------------------------|----------------------------------------|----------|
| **M5** (divergence) | `Escalate` | would-flag = `true` | escalate ⇔ would-flag |
| **M3** (gap) | `AutoAccept` | would-flag = `false` | auto-accept ⇔ no-finding |

- **M5**: ticket prescribes "use cursor-based pagination"; the FRONT planned
  method diverges ("use offset-based pagination") → real FRONT gate escalates;
  the BACK gate surfaces the prescribed method (would-flag) on the same intent.
- **M3**: ticket body has no imperative-method cue → a gap; FRONT auto-accepts,
  BACK surfaces nothing.
- A third test pins that the FRONT planned-method heuristic and the ISR
  ticket-method heuristic classify the pair consistently (so "divergence" is
  measured like-for-like, not an extractor artefact).

To let a cross-crate test drive the genuine BACK-gate logic, this PR adds
`pub fn ConformanceSource::would_flag(&ResolvedIntent) -> bool`, which reuses the
real `render_section` renderer (`!section.snippets.is_empty()`) — it is *not* a
reimplementation. `trusty-review` is added as a **dev-dependency of trusty-mpm
only** (neither crate depends on the other at runtime → no cycle; zero production
cost).

## Also in this PR

- **Docs index**: created `docs/specs/README.md` (behavior-contract spec catalog,
  matching the `docs/adr/README.md` index pattern) and wired all three
  `docs/specs` specs (DOC-13/14/15) into `docs/SUMMARY.md` under a new
  "Behavior-Contract Specs" section — the `docs/specs` tree previously had no
  index and none of its specs were in SUMMARY.
- **Config + feature-flag docs**: documented the `conformance` `ContextSource`
  config (env `TRUSTY_REVIEW_CONTEXT_CONFORMANCE_ENABLED/_MODE`, TOML
  `[context.sources.conformance]`, default-DISABLED) and the trusty-common
  `intent-source` feature in the trusty-review README and a new spec §10
  "Operating the gates".
- **SLD linkage**: verified the three modules carry parser-recognized
  module-level `# Spec References` blocks pointing at the governing sections
  (`intent_source` → SPEC-CONFORMANCE-03; review `conformance` → 02; mpm
  `front_gate` → 02 + 01). See the deviation note below.

**NON-GOAL (untouched):** SLD four-status CI enforcement (spec §1.3).

## Deviation from the ticket's Step-4 SLD ID mapping

The ticket's checklist maps `intent_source → 03`, review `conformance → 02`, and
mpm `front_gate → 03`. The first two match the spec's section ownership, but the
spec body assigns the FRONT-gate semantics to **§5.1 = SPEC-CONFORMANCE-02** and
the ISR contract to **§6 = SPEC-CONFORMANCE-03**. Pointing the FRONT gate at 03
(the ISR section) would be wrong, and the merged C3 code already links it
correctly at 02 (§5.1) + 01 (matrix). I kept the **spec-accurate** links the
landed code already declares — that is what the ISR's `spec_resolve` parser and
AC-6 actually validate against — rather than scrambling them to match the
checklist.

## Verification (run from the worktree)

- **AC-18**: `ac18_m5_divergence_front_escalate_iff_back_would_flag`,
  `ac18_m3_gap_front_auto_accept_iff_back_no_finding`,
  `ac18_planned_and_prescribed_extract_consistently` — `test result: ok. 3 passed`.
- `cargo test -p trusty-common --features intent-source` — 185 passed.
- `cargo test -p trusty-review` — 871 + 19 passed (incl. 3 new `would_flag_*`).
- `cargo test -p trusty-mpm` — 1296 + cross-gate 3 + front_gate suites passed.
- `cargo clippy --all-targets -- -D warnings` on review / mpm / common — clean.
- `cargo fmt --check` — clean. `bash scripts/check_line_cap.sh` — 0 violations.
- `SKIP_UI_BUILD=1 cargo check --workspace` — Finished, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)