### PR TITLE
fix: mpm resolves & pins its own project-path index (#1373)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10740,7 +10740,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10949,7 +10949,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11065,7 +11065,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
-trusty-common = { path = "crates/trusty-common", version = "0.16.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.17.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.4" }
@@ -41,7 +41,7 @@ tga = { path = "crates/trusty-git-analytics", version = "2.8.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
-trusty-mpm = { path = "crates/trusty-mpm", version = "0.9.0" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "0.10.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.15.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.25.0" }
+trusty-search = { path = "../trusty-search", version = "0.26.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -12,6 +12,23 @@
   drift. Re-exported at the crate root as `trusty_common::derive_index_id` and
   `trusty_common::resolve_project_root`.
 
+## [0.16.0] — 2026-06-16
+
+### Changed (refs #1361, PR #1371)
+
+- **SLD spec-resolver hardening (C4).** Strengthened the Spec-Linked
+  Documentation spec resolver so traceability survives realistic doc drift:
+  - **Block-scoped `# Spec References` parsing** — references are now collected
+    from a delimited block rather than scanned line-by-line across the whole
+    file, so stray matches outside the references block no longer pollute the
+    resolved set.
+  - **Revision-tolerant section matching** — section lookups tolerate revision
+    suffixes / minor heading reformatting, so a spec section still resolves when
+    its heading has been lightly edited.
+  - **Drift flagging** — references that no longer resolve to a live spec section
+    are surfaced as drift rather than silently dropped, giving CI a signal to act
+    on instead of a false pass.
+
 ## [0.15.3] — 2026-06-16
 
 ### Changed (closes #1326)

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — trusty-common
 
+## [0.17.0] — 2026-06-17
+
+### Added (refs #1373)
+
+- **`index_id` module: `derive_index_id` + `resolve_project_root`.** The single
+  source of truth for deriving a trusty-search index id from a project path
+  (the path basename, preserved verbatim for backward-compatibility) and for
+  walking up to the git root. Both trusty-search (`detect_project`, serve pin)
+  and trusty-mpm (register-and-pin at session launch) call these so they cannot
+  drift. Re-exported at the crate root as `trusty_common::derive_index_id` and
+  `trusty_common::resolve_project_root`.
+
 ## [0.15.3] — 2026-06-16
 
 ### Changed (closes #1326)

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/src/index_id.rs
+++ b/crates/trusty-common/src/index_id.rs
@@ -1,0 +1,139 @@
+//! Canonical trusty-search index-id derivation from a project path.
+//!
+//! Why: trusty-search derives an index id from the current project (the
+//! git-root basename, fallback to the cwd basename) when serving CLI queries,
+//! but the MCP `serve` path never reached that logic — so trusty-mpm, which
+//! injects a contextless `trusty-search serve` MCP stub, left index selection
+//! to the LLM and routinely resolved the WRONG index (issue #1373). To
+//! register-and-pin the correct project index, BOTH trusty-mpm (at session
+//! launch) and trusty-search (in `detect_project`) must derive the *identical*
+//! id from the same project root. Centralising the one rule here in
+//! `trusty-common` — which both crates already depend on, and which avoids a
+//! trusty-mpm → trusty-search dependency edge (trusty-search pulls the heavy
+//! ONNX/usearch stack) — makes it the single source of truth so the two cannot
+//! silently diverge.
+//!
+//! What: [`resolve_project_root`] walks up from a starting directory to the
+//! nearest `.git` root (fallback: the start dir itself), and
+//! [`derive_index_id`] turns a project root into its index id (the path
+//! basename, preserved verbatim for backward-compatibility with already-indexed
+//! projects). No global state; pure functions.
+//!
+//! Test: `cargo test -p trusty-common -- index_id::tests` covers basename
+//! derivation, the git-root walk, and the no-marker fallback.
+
+use std::path::{Path, PathBuf};
+
+/// Walk up from `start` to the nearest directory containing a `.git` entry.
+///
+/// Why: a trusty-search index is keyed to a project root, and the canonical
+/// project root is the git repository root. Both trusty-mpm (resolving the
+/// session's project) and trusty-search (`detect_project`) must agree on which
+/// directory is "the project root" so they derive the same index id (#1373).
+/// What: returns the first ancestor of `start` (inclusive) that contains a
+/// `.git` directory or file; when none is found, returns `start` itself
+/// (a path with no enclosing git repo is still indexable by its own basename).
+/// Test: `resolve_project_root_finds_git_root` and
+/// `resolve_project_root_falls_back_to_start` in `tests`.
+pub fn resolve_project_root(start: &Path) -> PathBuf {
+    let mut current = start.to_path_buf();
+    loop {
+        // `.git` is a directory in a normal clone and a file in a git worktree
+        // / submodule; `exists()` matches both so worktrees resolve correctly.
+        if current.join(".git").exists() {
+            return current;
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+    start.to_path_buf()
+}
+
+/// Derive the trusty-search index id for a project root.
+///
+/// Why: the index id is the stable handle every search/grep call targets. It
+/// MUST be derived identically wherever it is computed (trusty-mpm's
+/// register-and-pin at launch, trusty-search's `detect_project`) or a session
+/// would create/pin one id while querying another (#1373).
+/// What: returns the final path component of `project_root` as a `String`
+/// (lossy on non-UTF-8). The basename is preserved verbatim — NOT slugified —
+/// so the derived id byte-for-byte matches the ids trusty-search already
+/// assigned to existing on-disk indexes (changing the casing/punctuation would
+/// orphan every previously-indexed project). An empty / root path yields the
+/// empty string; callers that need a non-empty id must guard that case.
+/// Test: `derive_index_id_uses_basename` and `derive_index_id_empty_for_root`
+/// in `tests`.
+pub fn derive_index_id(project_root: &Path) -> String {
+    project_root
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let p = std::env::temp_dir().join(format!("trusty-index-id-{tag}-{pid}-{nanos}"));
+        let _ = fs::remove_dir_all(&p);
+        p
+    }
+
+    #[test]
+    fn derive_index_id_uses_basename() {
+        assert_eq!(
+            derive_index_id(Path::new("/Users/me/code/trusty-tools")),
+            "trusty-tools"
+        );
+        // Casing and punctuation are preserved verbatim (NOT slugified) so the
+        // id matches what trusty-search already stored for existing indexes.
+        assert_eq!(
+            derive_index_id(Path::new("/Users/me/code/MyProject")),
+            "MyProject"
+        );
+        assert_eq!(
+            derive_index_id(Path::new("/srv/Repo_With_Underscores")),
+            "Repo_With_Underscores"
+        );
+    }
+
+    #[test]
+    fn derive_index_id_empty_for_root() {
+        assert_eq!(derive_index_id(Path::new("/")), "");
+    }
+
+    #[test]
+    fn resolve_project_root_finds_git_root() {
+        let tmp = scratch_dir("git");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        let nested = tmp.join("a/b/c");
+        fs::create_dir_all(&nested).unwrap();
+
+        let root = resolve_project_root(&nested);
+        assert_eq!(root, tmp);
+        // And the derived id is the git-root basename, not the nested dir.
+        assert_eq!(derive_index_id(&root), derive_index_id(&tmp));
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_project_root_falls_back_to_start() {
+        let tmp = scratch_dir("no-git");
+        fs::create_dir_all(&tmp).unwrap();
+
+        let root = resolve_project_root(&tmp);
+        assert_eq!(root, tmp);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/crates/trusty-common/src/index_id.rs
+++ b/crates/trusty-common/src/index_id.rs
@@ -33,6 +33,14 @@ use std::path::{Path, PathBuf};
 /// What: returns the first ancestor of `start` (inclusive) that contains a
 /// `.git` directory or file; when none is found, returns `start` itself
 /// (a path with no enclosing git repo is still indexable by its own basename).
+///
+/// Known limitation: this returns the FIRST (innermost) ancestor with a `.git`,
+/// so in a nested-repo / monorepo layout where a parent directory above the
+/// intended project also has `.git`, the *inner* repo wins — and if the project
+/// itself has no `.git` but a parent does, that parent `.git` would win. This
+/// matches trusty-search's prior `detect_project` semantics (the two must agree
+/// to derive the same index id), so it is intentional, not a bug; documented
+/// here so a future monorepo-aware override is a conscious change, not a surprise.
 /// Test: `resolve_project_root_finds_git_root` and
 /// `resolve_project_root_falls_back_to_start` in `tests`.
 pub fn resolve_project_root(start: &Path) -> PathBuf {

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -372,6 +372,18 @@ pub mod port;
 pub mod slug;
 pub use slug::slugify_string;
 
+/// Canonical trusty-search index-id derivation from a project path (issue #1373).
+///
+/// Why: trusty-mpm (register-and-pin at session launch) and trusty-search
+/// (`detect_project`, MCP serve pin) must derive the byte-for-byte identical
+/// index id from the same project root, or a session pins one id while querying
+/// another. Centralising the rule here — the crate both already depend on —
+/// keeps them in lockstep without a trusty-mpm → trusty-search dependency edge.
+/// What: Exposes [`index_id::derive_index_id`] and [`index_id::resolve_project_root`].
+/// Test: `cargo test -p trusty-common -- index_id::tests`.
+pub mod index_id;
+pub use index_id::{derive_index_id, resolve_project_root};
+
 /// Shared GitHub `owner/repo` path derivation (issue #1220).
 ///
 /// Why: trusty-mpm's managed-session workspace root

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -14,7 +14,7 @@ name = "gworkspace-mcp"
 path = "src/bin/gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.16.0", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.17.0", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -80,7 +80,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.16.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics"] }
+trusty-common = { path = "../trusty-common", version = "0.17.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — trusty-mpm
 
+## [0.10.0] — 2026-06-17
+
+### Fixed (closes #1373)
+
+- **Sessions now register + pin their own project's trusty-search index.** At
+  session launch `prepare_session` derives the project's canonical index id
+  (git-root basename, via the shared `trusty_common::derive_index_id`),
+  best-effort find-or-creates it in the running trusty-search daemon
+  (`POST /indexes`), and injects the `trusty-search` MCP stub **pinned** to that
+  id (`serve --index <id>`). A bare `search`/`grep` therefore resolves to the
+  session's own project index instead of letting the LLM guess — which
+  routinely picked the wrong (usually persistent `claude-mpm`) index. The
+  daemon-unreachable case is graceful: it logs a warning and still pins the
+  stub (the index is created on first reindex); an empty derived id falls back
+  to the unpinned `serve` stub. Either way the session always launches.
+
 ## [0.9.0] — 2026-06-16
 
 ### Release

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -26,8 +26,8 @@ use crate::core::paths::FrameworkPaths;
 use crate::core::skill_deployer::{DeployStats, deploy_skills};
 use settings::{
     deploy_output_style, inject_trusty_memory_mcp, inject_trusty_search_mcp,
-    preseed_workspace_trust_home, remove_global_trusty_memory_hooks, write_output_style,
-    write_project_hooks,
+    preseed_workspace_trust_home, register_project_index, remove_global_trusty_memory_hooks,
+    write_output_style, write_project_hooks,
 };
 
 /// Outcome of the pre-launch preparation for one session.
@@ -167,11 +167,18 @@ pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepRe
         tracing::warn!("failed to inject trusty-memory MCP server: {err}");
     }
 
-    // Inject the `trusty-search` MCP server too (issue #1270 / step 4) so the
-    // spawned session can reach the code-search tools (`search`, `grep`,
-    // `get_call_chain`, …) alongside the memory tools. Non-fatal: the session
-    // still launches without code search.
-    if let Err(err) = inject_trusty_search_mcp(project_dir) {
+    // Register + pin the project's trusty-search index (issue #1373). Derive
+    // the project's canonical index id (git-root basename, via the shared
+    // `trusty_common::derive_index_id`), best-effort find-or-create it in the
+    // running daemon, then inject the `trusty-search` MCP stub PINNED to that id
+    // (`serve --index <id>`). Pinning makes a bare `search`/`grep` resolve to
+    // the session's OWN project index instead of letting the LLM guess (and
+    // routinely pick the wrong `claude-mpm` index). The daemon-unreachable case
+    // is handled inside `register_project_index` (logged, non-fatal) and still
+    // returns the id so the stub is pinned; a `None` id (empty derivation) falls
+    // back to the unpinned stub. Either way the session launches.
+    let pinned_index = register_project_index(project_dir);
+    if let Err(err) = inject_trusty_search_mcp(project_dir, pinned_index.as_deref()) {
         tracing::warn!("failed to inject trusty-search MCP server: {err}");
     }
 

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -443,7 +443,11 @@ pub(super) fn register_project_index(project_root: &Path) -> Option<String> {
 /// keeps that nested runtime entirely off the async worker, so the call is safe
 /// from both sync and async callers. A non-2xx response or transport error is
 /// logged at warn/debug and swallowed; the daemon endpoint is idempotent so
-/// re-creates are harmless.
+/// re-creates are harmless. The client uses a tight ~1s overall timeout
+/// (750 ms connect) so the joined thread returns quickly: this call sits on the
+/// `prepare_session` hot path and must NOT stall a session launch when the
+/// daemon is slow or unreachable. Registration is purely best-effort — the
+/// index is also created on the first reindex — so a short cap is acceptable.
 /// Test: exercised via `register_project_index_returns_derived_id` (daemon-down
 /// path) and `launch_session_errors_when_daemon_unreachable` (async-context
 /// safety); the live HTTP path is covered by integration use.
@@ -454,8 +458,11 @@ fn best_effort_create_index(base: &str, index_id: &str, root: &Path) {
     let root_display = root.display().to_string();
 
     let result = std::thread::spawn(move || {
+        // 1s overall / 750ms connect cap: this runs synchronously on the
+        // session-launch hot path, so the worst-case stall must stay small.
         let client = reqwest::blocking::Client::builder()
-            .timeout(std::time::Duration::from_secs(3))
+            .timeout(std::time::Duration::from_secs(1))
+            .connect_timeout(std::time::Duration::from_millis(750))
             .build()?;
         let resp = client.post(&url).json(&body).send()?;
         Ok::<reqwest::StatusCode, reqwest::Error>(resp.status())

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -103,25 +103,38 @@ pub(super) const TRUSTY_MEMORY_MCP_SERVER: &str = r#"{
   "args": ["serve", "--stdio"]
 }"#;
 
-/// The `trusty-search` MCP server definition injected into a project's
-/// `.mcp.json`.
+/// Build the `trusty-search` MCP server definition injected into a project's
+/// `.mcp.json`, optionally pinned to a project index (issue #1373).
 ///
-/// Why (issue #1270 / step 4): trusty-mpm-spawned sessions are expected to have
-/// both the memory *and* the code-search tools, but `trusty-search` was never
-/// registered in the workspace `.mcp.json` — only `trusty-memory` was. Without
-/// it the spawned PM cannot run `search`, `grep`, `get_call_chain`, etc. The
-/// canonical stdio MCP invocation (per `trusty-search setup`) is bare `serve`
-/// (stdio is the default transport; HTTP is off unless `--with-http`).
-/// What: a stdio MCP server entry running `trusty-search serve`. This wires the
-/// tools only — index creation is a separate concern handled elsewhere.
-/// Test: `inject_trusty_search_mcp_adds_server`,
-/// `inject_trusty_search_mcp_preserves_existing`,
-/// `inject_trusty_search_mcp_is_idempotent`.
-pub(super) const TRUSTY_SEARCH_MCP_SERVER: &str = r#"{
-  "type": "stdio",
-  "command": "trusty-search",
-  "args": ["serve"]
-}"#;
+/// Why (issue #1270 / step 4): trusty-mpm-spawned sessions need the code-search
+/// tools (`search`, `grep`, `get_call_chain`, …). Issue #1373: without pinning,
+/// the contextless `trusty-search serve` stub left index selection to the LLM,
+/// which routinely queried the WRONG index (usually the persistent `claude-mpm`
+/// one) instead of the session's own project. Passing `--index <derived-id>`
+/// pins the session to its project index so a bare `search` always resolves
+/// correctly and fan-out never sweeps every index. The canonical stdio MCP
+/// invocation is bare `serve` (stdio is the default transport; HTTP is off
+/// unless `--with-http`).
+/// What: returns the JSON `Value` for a stdio MCP server running
+/// `trusty-search serve` — with `["serve", "--index", "<id>"]` when `index_id`
+/// is `Some` (non-empty), else the unpinned `["serve"]`. Index *creation* is
+/// handled separately by [`register_project_index`].
+/// Test: `trusty_search_mcp_value_pins_index`, `trusty_search_mcp_value_unpinned`.
+pub(super) fn trusty_search_mcp_value(index_id: Option<&str>) -> serde_json::Value {
+    let args: Vec<serde_json::Value> = match index_id {
+        Some(id) if !id.trim().is_empty() => vec![
+            serde_json::Value::String("serve".to_string()),
+            serde_json::Value::String("--index".to_string()),
+            serde_json::Value::String(id.to_string()),
+        ],
+        _ => vec![serde_json::Value::String("serve".to_string())],
+    };
+    serde_json::json!({
+        "type": "stdio",
+        "command": "trusty-search",
+        "args": args,
+    })
+}
 
 /// Hook event types the global `trusty-memory` entries may have been registered
 /// under (across current and legacy trusty-mpm builds).
@@ -265,13 +278,18 @@ pub(super) fn write_project_hooks(project_dir: &Path) -> Result<(), PrepError> {
 /// semantics. Factoring the read-merge-write logic into one helper keeps the two
 /// public wrappers thin and guarantees they behave consistently (issue #1270).
 /// What: reads an existing `<project_path>/.mcp.json` (starting from `{}` when
-/// absent or malformed), adds/updates `mcpServers.<name>` to the parsed
-/// `server_json`, and writes the merged JSON back pretty-printed — preserving all
-/// other MCP servers. Idempotent: if the entry already matches, the file is left
-/// untouched and no write occurs. `server_json` MUST be a valid JSON object
-/// (callers pass compile-time constants).
+/// absent or malformed), adds/updates `mcpServers.<name>` to `server`, and
+/// writes the merged JSON back pretty-printed — preserving all other MCP
+/// servers. Idempotent: if the entry already matches, the file is left
+/// untouched and no write occurs. `server` is a `serde_json::Value` object
+/// built by the caller (a const for `trusty-memory`, a dynamically-pinned value
+/// for `trusty-search`, #1373).
 /// Test: exercised via `inject_trusty_memory_mcp_*` and `inject_trusty_search_mcp_*`.
-fn inject_mcp_server(project_path: &Path, name: &str, server_json: &str) -> Result<(), PrepError> {
+fn inject_mcp_server(
+    project_path: &Path,
+    name: &str,
+    server: serde_json::Value,
+) -> Result<(), PrepError> {
     let mcp_path = project_path.join(".mcp.json");
 
     // Load existing config to preserve unrelated servers; tolerate a missing or
@@ -283,10 +301,6 @@ fn inject_mcp_server(project_path: &Path, name: &str, server_json: &str) -> Resu
             .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new())),
         Err(_) => serde_json::Value::Object(serde_json::Map::new()),
     };
-
-    // The bundled server block is a constant and is guaranteed to parse.
-    let server: serde_json::Value =
-        serde_json::from_str(server_json).expect("bundled MCP server block is valid JSON");
 
     // Ensure `mcpServers` is an object we can insert into.
     let servers = config
@@ -328,23 +342,142 @@ fn inject_mcp_server(project_path: &Path, name: &str, server_json: &str) -> Resu
 /// `inject_trusty_memory_mcp_is_idempotent`,
 /// `inject_trusty_memory_mcp_uses_serve_stdio`.
 pub(super) fn inject_trusty_memory_mcp(project_path: &Path) -> Result<(), PrepError> {
-    inject_mcp_server(project_path, "trusty-memory", TRUSTY_MEMORY_MCP_SERVER)
+    let server: serde_json::Value = serde_json::from_str(TRUSTY_MEMORY_MCP_SERVER)
+        .expect("bundled MCP server block is valid JSON");
+    inject_mcp_server(project_path, "trusty-memory", server)
 }
 
-/// Inject the `trusty-search` MCP server into the project's `.mcp.json`.
+/// Inject the `trusty-search` MCP server into the project's `.mcp.json`,
+/// pinned to the project's index when one is known (issue #1373).
 ///
 /// Why (issue #1270 / step 4): spawned sessions must reach the code-search
 /// tools, but `trusty-search` was never registered alongside `trusty-memory`.
-/// This wires the MCP server so `search`, `grep`, `get_call_chain`, etc. are
-/// available. Index creation is out of scope here.
-/// What: thin wrapper over [`inject_mcp_server`] registering the
-/// [`TRUSTY_SEARCH_MCP_SERVER`] entry under the key `trusty-search`.
+/// Issue #1373: the stub must additionally PIN the session to the project's own
+/// index (`--index <id>`) so queries never resolve to the wrong index. When
+/// `index_id` is `None` (derivation failed) the unpinned stub is written so the
+/// session still gets the tools — backward-compatible with the pre-#1373 stub.
+/// What: builds the (optionally pinned) server value via
+/// [`trusty_search_mcp_value`] and registers it under the key `trusty-search`.
 /// Test: `inject_trusty_search_mcp_adds_server`,
 /// `inject_trusty_search_mcp_preserves_existing`,
 /// `inject_trusty_search_mcp_is_idempotent`,
+/// `inject_trusty_search_mcp_pins_index`,
 /// `inject_both_mcp_servers_coexist`.
-pub(super) fn inject_trusty_search_mcp(project_path: &Path) -> Result<(), PrepError> {
-    inject_mcp_server(project_path, "trusty-search", TRUSTY_SEARCH_MCP_SERVER)
+pub(super) fn inject_trusty_search_mcp(
+    project_path: &Path,
+    index_id: Option<&str>,
+) -> Result<(), PrepError> {
+    inject_mcp_server(
+        project_path,
+        "trusty-search",
+        trusty_search_mcp_value(index_id),
+    )
+}
+
+/// Find-or-create the trusty-search index for `project_root` and return its id
+/// (issue #1373).
+///
+/// Why: pinning the serve stub to an index id is only useful if that index
+/// actually exists in the daemon — otherwise a query against it returns nothing
+/// and the LLM falls back to guessing (the very bug #1373 fixes). At session
+/// launch we therefore derive the project's canonical index id (the same rule
+/// trusty-search's `detect_project` uses, via the shared
+/// `trusty_common::derive_index_id`) and best-effort register it with the
+/// running daemon. The daemon's `POST /indexes` is idempotent (returns
+/// `created: false` for an existing id), so a re-register is safe and cheap.
+/// What: resolves the git-root for `project_root`, derives the index id, and —
+/// when the id is non-empty AND the trusty-search daemon address is discoverable
+/// — POSTs `{id, root_path}` to `/indexes`. ALWAYS returns the derived id
+/// (`None` only when derivation yields an empty string) so the caller can pin
+/// the stub even if the daemon is unreachable; a failed/skipped registration is
+/// logged at warn/debug and never propagates (the session must still launch).
+/// Test: `register_project_index_returns_derived_id` (derivation + daemon-down
+/// graceful path) in `tests.rs`.
+pub(super) fn register_project_index(project_root: &Path) -> Option<String> {
+    let root = trusty_common::resolve_project_root(project_root);
+    let index_id = trusty_common::derive_index_id(&root);
+    if index_id.trim().is_empty() {
+        tracing::warn!(
+            "skipping trusty-search index registration: empty index id for {}",
+            root.display()
+        );
+        return None;
+    }
+
+    // Discover the running daemon's address. Absent / unreadable file ⇒ daemon
+    // not started: skip registration (best-effort) but still return the id so
+    // the stub is pinned — the daemon will create the index on first reindex.
+    match trusty_common::read_daemon_addr("trusty-search") {
+        Ok(Some(addr)) if !addr.trim().is_empty() => {
+            let base = if addr.starts_with("http://") || addr.starts_with("https://") {
+                addr
+            } else {
+                format!("http://{addr}")
+            };
+            best_effort_create_index(&base, &index_id, &root);
+        }
+        _ => {
+            tracing::warn!(
+                "trusty-search daemon address not found; pinning index '{index_id}' \
+                 without pre-registering it (it will be created on first reindex)"
+            );
+        }
+    }
+
+    Some(index_id)
+}
+
+/// POST `/indexes` to find-or-create `index_id`; failures are logged, never
+/// propagated (issue #1373).
+///
+/// Why: registration is best-effort — a daemon that is briefly unreachable, or
+/// an HTTP hiccup, must NOT abort session launch. Isolating the blocking HTTP
+/// call here keeps [`register_project_index`] readable and the error handling
+/// in one place.
+/// What: issues a short-timeout blocking `POST {base}/indexes` with body
+/// `{id, root_path}` ON A DEDICATED OS THREAD. `prepare_session` is synchronous
+/// but is frequently invoked from inside a tokio runtime (the daemon/TUI launch
+/// paths); creating `reqwest::blocking`'s internal runtime directly there panics
+/// with "Cannot drop a runtime in a context where blocking is not allowed".
+/// Running the blocking client on a freshly-spawned `std::thread` (joined here)
+/// keeps that nested runtime entirely off the async worker, so the call is safe
+/// from both sync and async callers. A non-2xx response or transport error is
+/// logged at warn/debug and swallowed; the daemon endpoint is idempotent so
+/// re-creates are harmless.
+/// Test: exercised via `register_project_index_returns_derived_id` (daemon-down
+/// path) and `launch_session_errors_when_daemon_unreachable` (async-context
+/// safety); the live HTTP path is covered by integration use.
+fn best_effort_create_index(base: &str, index_id: &str, root: &Path) {
+    let url = format!("{base}/indexes");
+    let body = serde_json::json!({ "id": index_id, "root_path": root.to_string_lossy() });
+    let index_id = index_id.to_string();
+    let root_display = root.display().to_string();
+
+    let result = std::thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .build()?;
+        let resp = client.post(&url).json(&body).send()?;
+        Ok::<reqwest::StatusCode, reqwest::Error>(resp.status())
+    })
+    .join();
+
+    match result {
+        Ok(Ok(status)) if status.is_success() => {
+            tracing::debug!("registered trusty-search index '{index_id}' (root={root_display})");
+        }
+        Ok(Ok(status)) => {
+            tracing::warn!(
+                "trusty-search index registration for '{index_id}' returned HTTP {status}"
+            );
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("trusty-search index registration for '{index_id}' failed: {e}");
+        }
+        Err(_) => {
+            tracing::warn!("trusty-search index registration thread for '{index_id}' panicked");
+        }
+    }
 }
 
 /// Collect the MCP server names declared in a workspace's `.mcp.json`.

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1,6 +1,7 @@
 use super::settings::{
     clean_global_trusty_memory_hooks, deploy_output_style, inject_trusty_memory_mcp,
-    inject_trusty_search_mcp, preseed_workspace_trust, write_output_style, write_project_hooks,
+    inject_trusty_search_mcp, preseed_workspace_trust, register_project_index,
+    trusty_search_mcp_value, write_output_style, write_project_hooks,
 };
 use super::*;
 use tempfile::tempdir;
@@ -500,7 +501,7 @@ fn inject_trusty_search_mcp_adds_server() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    inject_trusty_search_mcp(project).expect("injection succeeds");
+    inject_trusty_search_mcp(project, None).expect("injection succeeds");
 
     let value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
@@ -517,7 +518,7 @@ fn inject_trusty_search_mcp_preserves_existing() {
     let project = tmp.path();
     inject_trusty_memory_mcp(project).expect("memory injection succeeds");
 
-    inject_trusty_search_mcp(project).expect("search injection succeeds");
+    inject_trusty_search_mcp(project, None).expect("search injection succeeds");
 
     let value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
@@ -535,9 +536,9 @@ fn inject_trusty_search_mcp_is_idempotent() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    inject_trusty_search_mcp(project).expect("first injection succeeds");
+    inject_trusty_search_mcp(project, None).expect("first injection succeeds");
     let first = std::fs::read_to_string(project.join(".mcp.json")).unwrap();
-    inject_trusty_search_mcp(project).expect("second injection succeeds");
+    inject_trusty_search_mcp(project, None).expect("second injection succeeds");
     let second = std::fs::read_to_string(project.join(".mcp.json")).unwrap();
 
     assert_eq!(first, second, "re-injecting must leave the file unchanged");
@@ -551,7 +552,7 @@ fn inject_both_mcp_servers_coexist() {
     let project = tmp.path();
 
     inject_trusty_memory_mcp(project).expect("memory injection succeeds");
-    inject_trusty_search_mcp(project).expect("search injection succeeds");
+    inject_trusty_search_mcp(project, None).expect("search injection succeeds");
 
     let value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
@@ -565,6 +566,93 @@ fn inject_both_mcp_servers_coexist() {
         servers["trusty-search"]["args"],
         serde_json::json!(["serve"])
     );
+}
+
+// ──────────────────────────────────────────────
+// trusty-search index pin (#1373)
+// ──────────────────────────────────────────────
+
+#[test]
+fn trusty_search_mcp_value_pins_index() {
+    // Why (#1373): when an index id is known the stub MUST pin the session via
+    // `serve --index <id>` so a bare search resolves to the project's own index.
+    let v = trusty_search_mcp_value(Some("trusty-tools"));
+    assert_eq!(v["command"], serde_json::json!("trusty-search"));
+    assert_eq!(
+        v["args"],
+        serde_json::json!(["serve", "--index", "trusty-tools"])
+    );
+}
+
+#[test]
+fn trusty_search_mcp_value_unpinned() {
+    // Why (#1373 back-compat): a `None` (or blank) id yields the legacy bare
+    // `serve` stub so the session still gets the tools.
+    assert_eq!(
+        trusty_search_mcp_value(None)["args"],
+        serde_json::json!(["serve"])
+    );
+    assert_eq!(
+        trusty_search_mcp_value(Some("   "))["args"],
+        serde_json::json!(["serve"]),
+        "a blank id must not pin"
+    );
+}
+
+#[test]
+fn inject_trusty_search_mcp_pins_index() {
+    // Why (#1373): the injected `.mcp.json` entry must carry the pin so the
+    // launched Claude session is scoped to its project index.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    inject_trusty_search_mcp(project, Some("my-project")).expect("injection succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
+    assert_eq!(
+        value["mcpServers"]["trusty-search"]["args"],
+        serde_json::json!(["serve", "--index", "my-project"])
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn register_project_index_returns_derived_id() {
+    // Why (#1373): registration must derive the project's index id (git-root
+    // basename, via the shared `trusty_common::derive_index_id`) AND remain
+    // graceful when the trusty-search daemon is unreachable — it still returns
+    // the id so the stub can be pinned. We force the daemon-down path by
+    // pointing the data dir at an empty temp dir so `read_daemon_addr` finds no
+    // `http_addr` file (and thus issues no HTTP POST). `#[serial]` because the
+    // override env var is process-global.
+    let data_dir = tempdir().unwrap();
+    let prev = std::env::var(trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV).ok();
+    // SAFETY: guarded by `#[serial]`; restored before the test returns.
+    unsafe {
+        std::env::set_var(
+            trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV,
+            data_dir.path(),
+        );
+    }
+
+    // A git-rooted project: id == the git-root basename, even from a nested dir.
+    let project = tempdir().unwrap();
+    std::fs::create_dir_all(project.path().join(".git")).unwrap();
+    let nested = project.path().join("crates/inner");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let id = register_project_index(&nested);
+    let expected = trusty_common::derive_index_id(project.path());
+    assert_eq!(id, Some(expected), "id is the git-root basename");
+
+    // Restore the env var for other serial tests.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV, v),
+            None => std::env::remove_var(trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV),
+        }
+    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -6,6 +6,43 @@ use super::settings::{
 use super::*;
 use tempfile::tempdir;
 
+/// Why: env-mutating tests previously restored the var by hand at the end of the
+/// test body, so a panic between set and restore leaked process-global state
+/// into sibling `#[serial]` tests. This guard restores the prior value (or
+/// removes it) in `Drop`, making cleanup panic-safe.
+/// What: on construction it snapshots the current value and sets the new one;
+/// on drop it restores the snapshot (or removes the var if it was unset).
+/// Test: used by `register_project_index_returns_derived_id`; correctness is
+/// observable via that serial test passing without leaking the override env var.
+struct EnvVarGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &std::path::Path) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: env-mutating tests using this guard are tagged `#[serial]`, so
+        // no other thread races the set/restore. Restore happens in `Drop`.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `set` — serialized by `#[serial]`.
+        unsafe {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 #[test]
 fn build_system_prompt_includes_trusty_block() {
     // Why: `build_system_prompt` must always yield a prompt — generating
@@ -545,6 +582,30 @@ fn inject_trusty_search_mcp_is_idempotent() {
 }
 
 #[test]
+fn inject_trusty_search_mcp_pinned_is_idempotent() {
+    // Why (#1373): re-running prep with the SAME pinned index id must not rewrite
+    // or churn the `.mcp.json` — the pinned entry has to be stable across launches.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    inject_trusty_search_mcp(project, Some("my-project")).expect("first injection succeeds");
+    let first = std::fs::read_to_string(project.join(".mcp.json")).unwrap();
+    inject_trusty_search_mcp(project, Some("my-project")).expect("second injection succeeds");
+    let second = std::fs::read_to_string(project.join(".mcp.json")).unwrap();
+
+    assert_eq!(
+        first, second,
+        "re-injecting the same pinned id must leave the file unchanged"
+    );
+    // And the pin is still present/correct after the second pass.
+    let value: serde_json::Value = serde_json::from_str(&second).unwrap();
+    assert_eq!(
+        value["mcpServers"]["trusty-search"]["args"],
+        serde_json::json!(["serve", "--index", "my-project"])
+    );
+}
+
+#[test]
 fn inject_both_mcp_servers_coexist() {
     // Why (#1270/step 4): the end state must have BOTH servers so the spawned
     // session gets memory AND code search.
@@ -627,14 +688,13 @@ fn register_project_index_returns_derived_id() {
     // `http_addr` file (and thus issues no HTTP POST). `#[serial]` because the
     // override env var is process-global.
     let data_dir = tempdir().unwrap();
-    let prev = std::env::var(trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV).ok();
-    // SAFETY: guarded by `#[serial]`; restored before the test returns.
-    unsafe {
-        std::env::set_var(
-            trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV,
-            data_dir.path(),
-        );
-    }
+    // Panic-safe restore: the guard restores/removes the override env var in its
+    // `Drop`, so a panic in the assertions below never leaks it to sibling
+    // serial tests.
+    let _env = EnvVarGuard::set(
+        trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV,
+        data_dir.path(),
+    );
 
     // A git-rooted project: id == the git-root basename, even from a nested dir.
     let project = tempdir().unwrap();
@@ -645,14 +705,6 @@ fn register_project_index_returns_derived_id() {
     let id = register_project_index(&nested);
     let expected = trusty_common::derive_index_id(project.path());
     assert_eq!(id, Some(expected), "id is the git-root basename");
-
-    // Restore the env var for other serial tests.
-    unsafe {
-        match prev {
-            Some(v) => std::env::set_var(trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV, v),
-            None => std::env::remove_var(trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV),
-        }
-    }
 }
 
 #[test]

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -28,6 +28,37 @@ Versions correspond to `Cargo.toml` patch releases.
   `detect_project` delegates to `trusty_common::derive_index_id` so trusty-mpm's
   register-and-pin and trusty-search's CLI/MCP paths always agree on the id.
 
+## [0.25.0] — 2026-06-17
+
+### Added (closes #1372)
+
+- **Configurable per-index indexing hygiene + dashboard config API.** Indexing
+  hygiene is now per-project config defaults that are overridable per index
+  (and editable via the dashboard), rather than hardcoded constants:
+  - **Walker** gains `DATA_EXTS` (json/xml/txt/log), a 64 KiB
+    `DEFAULT_DATA_FILE_MAX_BYTES` cap for data-ish files, and
+    `DEFAULT_EXTRA_SKIP_DIRS` (data/exports/output/reports/snapshots/results).
+    `WalkOptions` carries `extra_skip_dirs` + `data_file_max_bytes`; data files
+    get the tighter cap while everything else keeps the 1 MiB global cap.
+  - **Config + persistence:** `IndexConfig` (`trusty-search.yaml`),
+    `ProjectConfig` (`.trusty-search.yaml`), and `PersistedIndex`
+    (`indexes.toml`, serde-default for backward compat) all gain the two
+    hygiene fields, threaded through `CreateIndexRequest` → handle →
+    `WalkOptions`.
+  - **New per-index config API:** `GET /indexes/{id}/config` returns the hygiene
+    config; `PATCH /indexes/{id}/config` updates the in-memory handle and
+    persists to `indexes.toml` (validates inputs, rejecting
+    `data_file_max_bytes == 0`).
+
+## [0.24.10] — 2026-06-16
+
+### Added (closes #1365)
+
+- **`trusty-search status [INDEX] --watch`.** `status` now accepts an optional
+  positional `INDEX` argument to scope the overview to a single index, plus a
+  `--watch` flag that refreshes the status view on an interval for live
+  monitoring of daemon + index state.
+
 ## [0.24.9] — 2026-06-16
 
 ### Fixed (closes #1325)

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,27 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [0.26.0] — 2026-06-17
+
+### Added (closes #1373)
+
+- **`trusty-search serve --index <id>` / `--project <path>` pin an MCP session
+  to one index.** When pinned, every tool handler defaults an omitted
+  `index_id` to the pinned id, and fan-out tools (`search_all` / `grep` without
+  `index_id`) scope to the pinned index instead of sweeping every registered
+  index. The pinned index is advertised in `tools/list` (its `index_id` becomes
+  optional and its description names the default) so the LLM never has to call
+  `list_indexes` and guess. `--index` wins over `--project`; `--project`'s id is
+  derived via the shared `trusty_common::derive_index_id` (git-root basename).
+  Without either flag, behaviour is unchanged — callers must supply `index_id`
+  and fan-out sweeps all indexes.
+
+### Changed
+
+- **Index-id derivation is now the single source of truth in `trusty-common`.**
+  `detect_project` delegates to `trusty_common::derive_index_id` so trusty-mpm's
+  register-and-pin and trusty-search's CLI/MCP paths always agree on the id.
+
 ## [0.24.9] — 2026-06-16
 
 ### Fixed (closes #1325)

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.16.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.17.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue

--- a/crates/trusty-search/src/commands/serve.rs
+++ b/crates/trusty-search/src/commands/serve.rs
@@ -23,7 +23,12 @@ use trusty_common::mcp::DaemonBridgeConfig;
 /// discovery file (issue #117). EOF self-exit is unit-tested in
 /// `crates/trusty-common/src/mcp/mod.rs` (`stdio_loop_exits_on_eof`).
 /// Auto-start behavior covered by `trusty_common::mcp::daemon_bridge` tests.
-pub async fn handle_serve(with_http: bool, port: u16, http: Option<String>) -> Result<()> {
+pub async fn handle_serve(
+    with_http: bool,
+    port: u16,
+    http: Option<String>,
+    pinned_index: Option<String>,
+) -> Result<()> {
     // Resolve the HTTP bind address. HTTP is OFF by default (issue #123) --
     // Claude Code MCP hooks only need stdio. Precedence:
     //   1. legacy `--http <addr>`   -> explicit bind (implies HTTP on)
@@ -37,10 +42,17 @@ pub async fn handle_serve(with_http: bool, port: u16, http: Option<String>) -> R
         None
     };
 
+    // Apply the optional index pin (#1373) to the dispatcher so omitted
+    // `index_id`s default to it and fan-out tools scope to it.
+    let pin = |server: crate::mcp::McpServer| match pinned_index.clone() {
+        Some(id) => server.with_pinned_index(id),
+        None => server,
+    };
+
     match bind_addr {
         Some(addr) => {
             let daemon_url = daemon_base_url();
-            let server = crate::mcp::McpServer::new(daemon_url.clone());
+            let server = pin(crate::mcp::McpServer::new(daemon_url.clone()));
             serve_http(server, addr, &daemon_url).await
         }
         None => {
@@ -48,7 +60,14 @@ pub async fn handle_serve(with_http: bool, port: u16, http: Option<String>) -> R
             // MCP dispatch loop. The McpServer forwards every tool call to
             // the daemon's REST API, so the daemon MUST be reachable.
             let base_url = ensure_search_daemon_up().await?;
-            let server = crate::mcp::McpServer::new(base_url.clone());
+            let server = pin(crate::mcp::McpServer::new(base_url.clone()));
+            if let Some(ref id) = pinned_index {
+                eprintln!(
+                    "{} MCP session pinned to index {}",
+                    "\u{25c9}".green(),
+                    id.cyan()
+                );
+            }
             eprintln!(
                 "{} MCP stdio (no HTTP) -> daemon {}",
                 "\u{25c9}".green(),

--- a/crates/trusty-search/src/detect.rs
+++ b/crates/trusty-search/src/detect.rs
@@ -45,7 +45,10 @@ pub fn detect_project(start: &Path) -> ProjectContext {
     loop {
         // Prefer .git as the strongest signal of a project root.
         if current.join(".git").exists() {
-            let name = basename(&current);
+            // Single source of truth (#1373): derive the id via the shared
+            // `trusty_common::derive_index_id` so trusty-mpm's register-and-pin
+            // and this CLI path always produce the identical index id.
+            let name = trusty_common::derive_index_id(&current);
             return ProjectContext {
                 index_id: name,
                 root_path: current,
@@ -54,7 +57,7 @@ pub fn detect_project(start: &Path) -> ProjectContext {
         }
         // Then check for an explicit trusty-search marker.
         if current.join(".trusty-search").exists() {
-            let name = basename(&current);
+            let name = trusty_common::derive_index_id(&current);
             return ProjectContext {
                 index_id: name,
                 root_path: current,
@@ -67,7 +70,7 @@ pub fn detect_project(start: &Path) -> ProjectContext {
     }
     // Fallback: use CWD basename so commands still have something to call the index.
     let cwd = start.to_path_buf();
-    let name = basename(&cwd);
+    let name = trusty_common::derive_index_id(&cwd);
     ProjectContext {
         index_id: name,
         root_path: cwd,
@@ -75,9 +78,12 @@ pub fn detect_project(start: &Path) -> ProjectContext {
     }
 }
 
-/// Why: Several detection branches need a UTF-8 directory basename.
+/// Why: the tests below assert that the derived `index_id` equals the path
+/// basename; production code now derives ids via `trusty_common::derive_index_id`
+/// (#1373), so this local helper is test-only.
 /// What: Returns the final path component as a `String`, lossy on non-UTF8.
 /// Test: basename(Path::new("/foo/bar")) == "bar"; empty path returns "".
+#[cfg(test)]
 fn basename(p: &Path) -> String {
     p.file_name()
         .unwrap_or_default()

--- a/crates/trusty-search/src/main.rs
+++ b/crates/trusty-search/src/main.rs
@@ -544,6 +544,27 @@ enum Commands {
         /// `--port`. Kept for backward compatibility with older docs.
         #[arg(long)]
         http: Option<String>,
+
+        /// Pin this MCP session to a single index id (issue #1373).
+        ///
+        /// When set, search/grep/index tools default an omitted `index_id` to
+        /// this id, and fan-out tools (`search_all`/`grep` without `index_id`)
+        /// scope to it instead of sweeping every registered index. The pinned
+        /// index is advertised in `tools/list` so the LLM never has to call
+        /// `list_indexes` and guess. Without this flag, behaviour is unchanged
+        /// (callers must supply `index_id`; fan-out sweeps all). Wins over
+        /// `--project` when both are given.
+        #[arg(long)]
+        index: Option<String>,
+
+        /// Pin the MCP session to the index for this project path (issue #1373).
+        ///
+        /// The index id is derived from the path the same way the CLI derives
+        /// it (git-root basename, fallback to the path basename), so a session
+        /// launched with `--project .` pins to the current project's index.
+        /// Ignored when `--index` is also given.
+        #[arg(long)]
+        project: Option<String>,
     },
 
     /// Manage the macOS launchd service (install/uninstall/status/logs)
@@ -1270,8 +1291,20 @@ async fn run() -> Result<()> {
             no_http: _, // deprecated no-op (issue #123): HTTP is opt-in now
             port,
             http,
+            index,
+            project,
         } => {
-            commands::serve::handle_serve(with_http, port, http).await?;
+            // Resolve the pinned index id (#1373): `--index` wins; otherwise
+            // derive it from `--project` via the shared derivation so it
+            // matches the CLI / trusty-mpm.
+            let pinned_index = index.or_else(|| {
+                project.map(|p| {
+                    let start = std::path::PathBuf::from(&p);
+                    let root = trusty_common::resolve_project_root(&start);
+                    trusty_common::derive_index_id(&root)
+                })
+            });
+            commands::serve::handle_serve(with_http, port, http, pinned_index).await?;
         }
 
         Commands::Service { action } => {

--- a/crates/trusty-search/src/mcp/tools/descriptors.rs
+++ b/crates/trusty-search/src/mcp/tools/descriptors.rs
@@ -386,7 +386,7 @@ pub fn tool_descriptors_pinned(pinned: Option<&str>) -> Value {
     let Some(id) = pinned else {
         return defs;
     };
-    let note = format!(" Defaults to this session's pinned project index ('{id}') when omitted.");
+    let note = format!("Defaults to this session's pinned project index ('{id}') when omitted.");
     if let Some(tools) = defs.as_array_mut() {
         for tool in tools.iter_mut() {
             let Some(schema) = tool.get_mut("inputSchema").and_then(Value::as_object_mut) else {
@@ -414,11 +414,14 @@ pub fn tool_descriptors_pinned(pinned: Option<&str>) -> Value {
                 let base = prop
                     .get("description")
                     .and_then(Value::as_str)
-                    .unwrap_or("Target index id")
-                    .to_string();
+                    .unwrap_or("Target index id");
+                // Normalise the join so the result reads "<base>. <note>" with
+                // exactly one separating period+space, whether or not `base`
+                // already ends in a period (avoids the ".." double-period bug).
+                let base = base.trim_end().trim_end_matches('.');
                 prop.insert(
                     "description".to_string(),
-                    Value::String(format!("{base}.{note}")),
+                    Value::String(format!("{base}. {note}")),
                 );
             }
         }

--- a/crates/trusty-search/src/mcp/tools/descriptors.rs
+++ b/crates/trusty-search/src/mcp/tools/descriptors.rs
@@ -364,3 +364,64 @@ pub fn tool_descriptors() -> Value {
         }
     ])
 }
+
+/// `tools/list` descriptors with the session's pinned index advertised (#1373).
+///
+/// Why: when `trusty-search serve --index <id>` pins the session to one
+/// project index, the LLM should not have to call `list_indexes` and guess
+/// which index to pass — it routinely picks the wrong one (usually the
+/// persistent `claude-mpm` index). Advertising the pin in the schema makes
+/// `index_id` optional and tells the model exactly what it defaults to, so a
+/// bare `search`/`grep` resolves to the session's own project index.
+/// What: returns [`tool_descriptors`] verbatim when `pinned` is `None`
+/// (backward-compatible); when `Some(id)`, for every tool whose `inputSchema`
+/// has an `index_id` property it (1) removes `index_id` from the `required`
+/// array (the pin supplies the default) and (2) appends a note to the
+/// `index_id` property description naming the pinned default.
+/// Test: `pinned_descriptors_make_index_id_optional` and
+/// `pinned_descriptors_annotate_index_id` in `tests_tools_list.rs`;
+/// `tool_descriptors_pinned_none_is_unchanged` pins the no-op case.
+pub fn tool_descriptors_pinned(pinned: Option<&str>) -> Value {
+    let mut defs = tool_descriptors();
+    let Some(id) = pinned else {
+        return defs;
+    };
+    let note = format!(" Defaults to this session's pinned project index ('{id}') when omitted.");
+    if let Some(tools) = defs.as_array_mut() {
+        for tool in tools.iter_mut() {
+            let Some(schema) = tool.get_mut("inputSchema").and_then(Value::as_object_mut) else {
+                continue;
+            };
+            // Only touch tools that actually accept an `index_id`.
+            let has_index_id = schema
+                .get("properties")
+                .and_then(Value::as_object)
+                .is_some_and(|p| p.contains_key("index_id"));
+            if !has_index_id {
+                continue;
+            }
+            // (1) Drop `index_id` from `required` — the pin supplies it.
+            if let Some(required) = schema.get_mut("required").and_then(Value::as_array_mut) {
+                required.retain(|v| v.as_str() != Some("index_id"));
+            }
+            // (2) Annotate the `index_id` property description with the default.
+            if let Some(prop) = schema
+                .get_mut("properties")
+                .and_then(Value::as_object_mut)
+                .and_then(|p| p.get_mut("index_id"))
+                .and_then(Value::as_object_mut)
+            {
+                let base = prop
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Target index id")
+                    .to_string();
+                prop.insert(
+                    "description".to_string(),
+                    Value::String(format!("{base}.{note}")),
+                );
+            }
+        }
+    }
+    defs
+}

--- a/crates/trusty-search/src/mcp/tools/index.rs
+++ b/crates/trusty-search/src/mcp/tools/index.rs
@@ -17,6 +17,22 @@ use super::{
     McpServer,
 };
 
+/// Resolve `index_id` for an index-management tool, defaulting to the pinned
+/// index (#1373) when the caller omits it.
+///
+/// Why: a pinned trusty-search session (`serve --index <id>`) should let the
+/// LLM run `index_status`, `reindex`, `list_chunks`, etc. without repeating the
+/// project's index id, exactly as the search tools do. Centralising the
+/// precedence here keeps every index arm consistent with `search`.
+/// What: returns the caller's non-empty `index_id` argument, else the session's
+/// pinned index, else an `InvalidParams` error naming the missing field.
+/// Test: `pinned_index_status_defaults_to_pin` in `tests.rs`.
+fn required_index_id(server: &McpServer, args: &Value) -> Result<String, DispatchError> {
+    server.resolve_index_id(args).ok_or_else(|| {
+        DispatchError::InvalidParams("missing required string field: index_id".into())
+    })
+}
+
 /// Route one of the eight index-management tool names to the correct daemon
 /// call.
 ///
@@ -34,7 +50,7 @@ pub(super) async fn dispatch_index_tool(
 ) -> Option<Result<Value, DispatchError>> {
     match tool {
         "index_file" => {
-            let index_id = match require_str(args, "index_id") {
+            let index_id = match required_index_id(server, args) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
@@ -56,7 +72,7 @@ pub(super) async fn dispatch_index_tool(
             )
         }
         "remove_file" => {
-            let index_id = match require_str(args, "index_id") {
+            let index_id = match required_index_id(server, args) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
@@ -95,14 +111,14 @@ pub(super) async fn dispatch_index_tool(
             )
         }
         "delete_index" => {
-            let index_id = match require_str(args, "index_id") {
+            let index_id = match required_index_id(server, args) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
             Some(server.delete(&format!("/indexes/{index_id}")).await)
         }
         "reindex" => {
-            let index_id = match require_str(args, "index_id") {
+            let index_id = match required_index_id(server, args) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
@@ -118,7 +134,7 @@ pub(super) async fn dispatch_index_tool(
             )
         }
         "index_status" => {
-            let index_id = match require_str(args, "index_id") {
+            let index_id = match required_index_id(server, args) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
@@ -130,7 +146,7 @@ pub(super) async fn dispatch_index_tool(
             // Issue #1325: an optional `after` cursor switches to an indexed
             // redb seek (O(page) at any depth) instead of the O(offset) scan;
             // the daemon echoes `next_cursor` for the next call.
-            let index_id = match require_str(args, "index_id") {
+            let index_id = match required_index_id(server, args) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };

--- a/crates/trusty-search/src/mcp/tools/misc.rs
+++ b/crates/trusty-search/src/mcp/tools/misc.rs
@@ -32,9 +32,14 @@ pub(super) async fn dispatch_misc_tool(
     match tool {
         "search_health" => Some(server.get("/health").await),
         "chat" => {
-            let index_id = match require_str(args, "index_id") {
-                Ok(v) => v,
-                Err(e) => return Some(Err(e)),
+            // Default `index_id` to the session's pinned index (#1373).
+            let index_id = match server.resolve_index_id(args) {
+                Some(v) => v,
+                None => {
+                    return Some(Err(DispatchError::InvalidParams(
+                        "missing required string field: index_id".into(),
+                    )))
+                }
             };
             // Accept either `message` (legacy / UI) or `question` (issue #15 spec).
             let message = args
@@ -71,9 +76,14 @@ pub(super) async fn dispatch_misc_tool(
             // Issue #76 — annotated call tree for an entry-point function.
             // The daemon endpoint returns `text/plain`; we wrap the body in
             // the JSON envelope MCP clients consume.
-            let index_id = match require_str(args, "index_id") {
-                Ok(v) => v,
-                Err(e) => return Some(Err(e)),
+            // Default `index_id` to the session's pinned index (#1373).
+            let index_id = match server.resolve_index_id(args) {
+                Some(v) => v,
+                None => {
+                    return Some(Err(DispatchError::InvalidParams(
+                        "missing required string field: index_id".into(),
+                    )))
+                }
             };
             let entry_point = match require_str(args, "entry_point") {
                 Ok(v) => v,
@@ -145,7 +155,10 @@ pub(super) async fn dispatch_misc_tool(
             {
                 body["max_results"] = Value::from(v);
             }
-            match args.get("index_id").and_then(Value::as_str) {
+            // Scope to the resolved index (explicit arg, else pinned, #1373).
+            // Only when neither is set do we fan out across every index via the
+            // global `/grep` endpoint — a pinned session never sweeps all.
+            match server.resolve_index_id(args) {
                 Some(id) => Some(server.post(&format!("/indexes/{id}/grep"), &body).await),
                 None => Some(server.post("/grep", &body).await),
             }

--- a/crates/trusty-search/src/mcp/tools/mod.rs
+++ b/crates/trusty-search/src/mcp/tools/mod.rs
@@ -36,7 +36,7 @@ pub(crate) mod misc;
 pub(crate) mod search;
 pub(crate) mod types;
 
-pub use descriptors::tool_descriptors;
+pub use descriptors::{tool_descriptors, tool_descriptors_pinned};
 
 use types::{
     wrap_stage_not_ready_error, wrap_text_content, wrap_tool_error, wrap_tool_result, DispatchError,
@@ -71,6 +71,14 @@ pub const STAGE_NOT_READY_CODE: i32 = -32010;
 pub struct McpServer {
     pub(crate) base_url: String,
     pub(crate) http: reqwest::Client,
+    /// Index id this MCP session is pinned to, if any (issue #1373).
+    ///
+    /// `Some(id)` when `trusty-search serve --index <id>` (or `--project`) was
+    /// passed: tool handlers default an omitted `index_id` to it and fan-out
+    /// tools scope to it instead of sweeping every registered index. `None`
+    /// preserves the legacy behaviour (callers must supply `index_id`; fan-out
+    /// sweeps all). See [`McpServer::resolve_index_id`].
+    pub(crate) pinned_index: Option<String>,
 }
 
 impl McpServer {
@@ -80,6 +88,7 @@ impl McpServer {
         Self {
             base_url: base_url.into(),
             http: reqwest::Client::new(),
+            pinned_index: None,
         }
     }
 
@@ -88,12 +97,51 @@ impl McpServer {
         Self {
             base_url: base_url.into(),
             http,
+            pinned_index: None,
         }
+    }
+
+    /// Pin this dispatcher to a single index id (issue #1373).
+    ///
+    /// Why: a trusty-mpm session launches `trusty-search serve --index <id>`
+    /// so every search/grep call targets the session's own project index
+    /// rather than letting the LLM guess (and routinely pick the wrong one,
+    /// usually `claude-mpm`). Pinning makes `index_id` optional for the LLM and
+    /// scopes fan-out tools to the one index.
+    /// What: builder that sets [`McpServer::pinned_index`]. An empty / blank id
+    /// is treated as "no pin" so a degenerate `--index ""` cannot wedge every
+    /// call onto an empty-string index.
+    /// Test: `resolve_index_id_prefers_explicit_then_pinned` in `tests.rs`;
+    /// pin-aware descriptors in `tests_tools_list.rs`.
+    pub fn with_pinned_index(mut self, index_id: impl Into<String>) -> Self {
+        let id = index_id.into();
+        self.pinned_index = if id.trim().is_empty() { None } else { Some(id) };
+        self
     }
 
     /// Daemon base URL.
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// Resolve the effective index id for a tool call (issue #1373).
+    ///
+    /// Why: pinning lets the LLM omit `index_id` entirely — the session is
+    /// already scoped to one project index — while still honouring an explicit
+    /// caller-supplied id (which always wins, so a pinned session can still
+    /// reach another index when asked). Centralising the precedence in one
+    /// helper keeps every tool arm consistent.
+    /// What: returns the caller's `index_id` argument when present and
+    /// non-empty; otherwise the session's [`McpServer::pinned_index`]; otherwise
+    /// `None` (caller must then error as before).
+    /// Test: `resolve_index_id_prefers_explicit_then_pinned` in `tests.rs`.
+    pub(crate) fn resolve_index_id(&self, args: &Value) -> Option<String> {
+        if let Some(id) = args.get("index_id").and_then(Value::as_str) {
+            if !id.is_empty() {
+                return Some(id.to_string());
+            }
+        }
+        self.pinned_index.clone()
     }
 
     /// Translate a JSON-RPC request into a daemon HTTP call and wrap the
@@ -164,7 +212,10 @@ impl McpServer {
                 }
             }
             "tools/list" => {
-                return Response::ok(id, serde_json::json!({ "tools": tool_descriptors() }));
+                // Advertise the session's pinned index (#1373) so the LLM can
+                // omit `index_id` and never has to guess which index to query.
+                let tools = tool_descriptors_pinned(self.pinned_index.as_deref());
+                return Response::ok(id, serde_json::json!({ "tools": tools }));
             }
             // OpenRPC 1.3.2 discovery — see `mcp::openrpc`. Returns the
             // full service description so orchestrators (open-mpm, etc.)

--- a/crates/trusty-search/src/mcp/tools/search.rs
+++ b/crates/trusty-search/src/mcp/tools/search.rs
@@ -41,11 +41,14 @@ pub(super) async fn dispatch_search_tool(
         "search_kg" => Some(server.run_lane_search(args, SearchLane::Graph).await),
         "search_all" => {
             // Polymorphic for back-compat (issue #138):
-            //   * with `index_id`  → per-index full hybrid (alias for
-            //     `search`; matches the #138 ticket spec).
-            //   * without `index_id` → cross-project fan-out (legacy
-            //     issue #10 behaviour preserved).
-            if args.get("index_id").and_then(Value::as_str).is_some() {
+            //   * with `index_id` (explicit or pinned, #1373) → per-index full
+            //     hybrid (alias for `search`; matches the #138 ticket spec).
+            //   * without any index → cross-project fan-out (legacy issue #10
+            //     behaviour preserved).
+            // The pinned-index resolution (#1373) means a trusty-mpm session
+            // scoped to one project never silently sweeps every registered
+            // index — it runs the per-index hybrid against its own index.
+            if server.resolve_index_id(args).is_some() {
                 return Some(server.run_lane_search(args, SearchLane::All).await);
             }
             let query = match require_str(args, "query") {
@@ -65,9 +68,15 @@ pub(super) async fn dispatch_search_tool(
             Some(server.post("/search", &body).await)
         }
         "search" => {
-            let index_id = match require_str(args, "index_id") {
-                Ok(v) => v,
-                Err(e) => return Some(Err(e)),
+            // Default `index_id` to the session's pinned index when omitted
+            // (#1373); an explicit caller-supplied id still wins.
+            let index_id = match server.resolve_index_id(args) {
+                Some(v) => v,
+                None => {
+                    return Some(Err(DispatchError::InvalidParams(
+                        "missing required string field: index_id".into(),
+                    )))
+                }
             };
             // Accept the spec form `{query: string, top_k?: int}` and
             // also a pre-built `{query: object}` body for callers that
@@ -200,7 +209,11 @@ impl McpServer {
         args: &Value,
         lane: SearchLane,
     ) -> Result<Value, DispatchError> {
-        let index_id = require_str(args, "index_id")?;
+        // Default `index_id` to the session's pinned index when omitted (#1373);
+        // an explicit caller-supplied id still wins.
+        let index_id = self.resolve_index_id(args).ok_or_else(|| {
+            DispatchError::InvalidParams("missing required string field: index_id".into())
+        })?;
         let query_text = require_str(args, "query")?;
 
         // Pre-flight stage check for lanes that need Stage 2 or Stage 3.

--- a/crates/trusty-search/src/mcp/tools/tests.rs
+++ b/crates/trusty-search/src/mcp/tools/tests.rs
@@ -405,3 +405,157 @@ pub(super) async fn spawn_mock_daemon(
     let base_url = format!("http://{addr}");
     (base_url, captured_bodies, captured_paths)
 }
+
+// Issue #1373 — pinned-index resolution + serve-time pin
+// ----------------------------------------------------------------
+
+/// `resolve_index_id` precedence: explicit arg wins, else pinned, else None.
+///
+/// Why: the whole #1373 fix hinges on this precedence — a pinned session must
+/// default an omitted `index_id` to the pin, still honour an explicit id, and
+/// (without a pin) fall through to `None` so behaviour is unchanged.
+/// What: exercises all four combinations on the bare helper.
+/// Test: this is the test.
+#[test]
+fn resolve_index_id_prefers_explicit_then_pinned() {
+    let pinned = McpServer::new("http://127.0.0.1:1").with_pinned_index("my-project");
+    // Omitted → pinned.
+    assert_eq!(
+        pinned.resolve_index_id(&serde_json::json!({})),
+        Some("my-project".to_string())
+    );
+    // Explicit wins over the pin.
+    assert_eq!(
+        pinned.resolve_index_id(&serde_json::json!({ "index_id": "other" })),
+        Some("other".to_string())
+    );
+    // Empty explicit id is ignored → falls back to the pin.
+    assert_eq!(
+        pinned.resolve_index_id(&serde_json::json!({ "index_id": "" })),
+        Some("my-project".to_string())
+    );
+
+    // No pin: omitted → None (unchanged legacy behaviour).
+    let unpinned = McpServer::new("http://127.0.0.1:1");
+    assert_eq!(unpinned.resolve_index_id(&serde_json::json!({})), None);
+    assert_eq!(
+        unpinned.resolve_index_id(&serde_json::json!({ "index_id": "x" })),
+        Some("x".to_string())
+    );
+}
+
+/// A blank `--index ""` pin is treated as "no pin" so a degenerate flag can't
+/// wedge every call onto an empty-string index.
+///
+/// Why: defensive — an operator (or a buggy launcher) passing `--index ""`
+/// must not silently pin to `""`.
+/// What: asserts `with_pinned_index("")` leaves `pinned_index` unset.
+/// Test: this is the test.
+#[test]
+fn blank_pin_is_treated_as_no_pin() {
+    let s = McpServer::new("http://127.0.0.1:1").with_pinned_index("   ");
+    assert_eq!(s.resolve_index_id(&serde_json::json!({})), None);
+}
+
+/// Without a pin, `search` with no `index_id` fast-fails (unchanged).
+///
+/// Why: backward-compatibility — the pre-#1373 contract requires `index_id`,
+/// and the fix must not relax that when no pin is configured.
+/// What: dispatches `search` (no index_id, no pin) and asserts INVALID_PARAMS.
+/// Test: this is the test.
+#[tokio::test]
+async fn search_without_pin_requires_index_id() {
+    let server = McpServer::new("http://127.0.0.1:1");
+    let resp = server
+        .dispatch(req("search", serde_json::json!({ "query": "fn main" })))
+        .await;
+    let err = resp.error.expect("expected error");
+    assert_eq!(err.code, error_codes::INVALID_PARAMS);
+}
+
+/// With a pin, `search` with no `index_id` targets the pinned index endpoint.
+///
+/// Why: the core acceptance criterion — a pinned session must resolve a bare
+/// `search` to its own project index, never sweeping or guessing.
+/// What: spins up the mock daemon, dispatches `search` (query only) against a
+/// server pinned to `pinned-proj`, and asserts the daemon saw a POST to
+/// `/indexes/pinned-proj/search`.
+/// Test: this is the test.
+#[tokio::test]
+async fn pinned_search_defaults_index_id_to_pin() {
+    let (base_url, _bodies, paths) = spawn_mock_daemon(
+        serde_json::json!({ "search_capabilities": ["vector", "kg"] }),
+        serde_json::json!({ "results": [], "intent": "Definition", "latency_ms": 1 }),
+    )
+    .await;
+    let server =
+        McpServer::with_client(base_url, reqwest::Client::new()).with_pinned_index("pinned-proj");
+
+    let resp = server
+        .dispatch(req("search", serde_json::json!({ "query": "fn main" })))
+        .await;
+    assert!(
+        resp.error.is_none(),
+        "pinned search should succeed: {resp:?}"
+    );
+
+    let seen = paths.lock().await;
+    assert_eq!(seen.len(), 1, "exactly one daemon search call: {seen:?}");
+    assert_eq!(seen[0], "/indexes/pinned-proj/search");
+}
+
+/// With a pin, `grep` with no `index_id` scopes to the pinned index endpoint
+/// instead of the global fan-out `/grep`.
+///
+/// Why: #1373 requires fan-out tools to scope to the pin so a project session
+/// never sweeps every registered index.
+/// What: mock daemon captures the grep path; asserts the pinned per-index
+/// endpoint was hit.
+/// Test: this is the test.
+#[tokio::test]
+async fn pinned_grep_scopes_to_pinned_index() {
+    use axum::extract::{Path, State};
+    use axum::routing::post;
+    use axum::{Json, Router};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+
+    async fn per_index_grep(
+        Path(id): Path<String>,
+        State(c): State<Arc<Mutex<Vec<String>>>>,
+        Json(_body): Json<Value>,
+    ) -> Json<Value> {
+        c.lock().await.push(format!("/indexes/{id}/grep"));
+        Json(serde_json::json!({ "matches": [] }))
+    }
+    async fn global_grep(
+        State(c): State<Arc<Mutex<Vec<String>>>>,
+        Json(_body): Json<Value>,
+    ) -> Json<Value> {
+        c.lock().await.push("/grep".to_string());
+        Json(serde_json::json!({ "matches": [] }))
+    }
+
+    let app = Router::new()
+        .route("/indexes/{id}/grep", post(per_index_grep))
+        .route("/grep", post(global_grep))
+        .with_state(Arc::clone(&captured));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let base_url = format!("http://{addr}");
+
+    let server =
+        McpServer::with_client(base_url, reqwest::Client::new()).with_pinned_index("pinned-proj");
+    let resp = server
+        .dispatch(req("grep", serde_json::json!({ "pattern": "fn foo" })))
+        .await;
+    assert!(resp.error.is_none(), "pinned grep should succeed: {resp:?}");
+
+    let seen = captured.lock().await;
+    assert_eq!(seen.as_slice(), &["/indexes/pinned-proj/grep".to_string()]);
+}

--- a/crates/trusty-search/src/mcp/tools/tests_tools_list.rs
+++ b/crates/trusty-search/src/mcp/tools/tests_tools_list.rs
@@ -248,6 +248,16 @@ fn pinned_descriptors_annotate_index_id() {
         desc.contains("trusty-tools") && desc.contains("pinned"),
         "index_id description should name the pinned default: {desc:?}"
     );
+    // The note must be joined with exactly one separating period — never a
+    // double-period, regardless of whether the base description ended in `.`.
+    assert!(
+        !desc.contains(".."),
+        "annotated description must not contain a double-period: {desc:?}"
+    );
+    assert!(
+        desc.contains(". Defaults to this session's pinned project index"),
+        "note must follow exactly one period+space: {desc:?}"
+    );
 }
 
 /// `tools/list` over a PINNED server advertises the optional `index_id`.

--- a/crates/trusty-search/src/mcp/tools/tests_tools_list.rs
+++ b/crates/trusty-search/src/mcp/tools/tests_tools_list.rs
@@ -167,3 +167,116 @@ async fn search_all_without_index_id_calls_global_fanout_endpoint() {
     assert!(resp.error.is_none());
     assert_eq!(captured.lock().await.as_slice(), &["/search".to_string()]);
 }
+
+// Issue #1373 — pinned-index descriptor advertisement
+// ----------------------------------------------------------------
+
+/// Find a tool's inputSchema in a `tool_descriptors*` array by name.
+fn schema_of<'a>(tools: &'a Value, name: &str) -> &'a Value {
+    tools
+        .as_array()
+        .expect("descriptors array")
+        .iter()
+        .find(|t| t.get("name").and_then(Value::as_str) == Some(name))
+        .unwrap_or_else(|| panic!("tool {name} missing"))
+        .get("inputSchema")
+        .expect("inputSchema")
+}
+
+/// `tool_descriptors_pinned(None)` is byte-identical to `tool_descriptors()`.
+///
+/// Why: the no-pin path must be a pure pass-through so legacy sessions see
+/// exactly the same catalogue they always have.
+/// What: asserts equality of the two values.
+/// Test: this is the test.
+#[test]
+fn tool_descriptors_pinned_none_is_unchanged() {
+    use super::descriptors::{tool_descriptors, tool_descriptors_pinned};
+    assert_eq!(tool_descriptors_pinned(None), tool_descriptors());
+}
+
+/// When pinned, `search`'s `inputSchema` no longer lists `index_id` as
+/// required (the pin supplies it) but `query` still is.
+///
+/// Why: the LLM should be able to call `search` with only a `query` once the
+/// session is pinned — that is what makes a bare search resolve to the right
+/// index.
+/// What: pins to `trusty-tools` and asserts `required` lost `index_id` but kept
+/// `query`.
+/// Test: this is the test.
+#[test]
+fn pinned_descriptors_make_index_id_optional() {
+    use super::descriptors::tool_descriptors_pinned;
+    let pinned = tool_descriptors_pinned(Some("trusty-tools"));
+    let schema = schema_of(&pinned, "search");
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .expect("required")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        !required.contains(&"index_id"),
+        "index_id should not be required when pinned: {required:?}"
+    );
+    assert!(
+        required.contains(&"query"),
+        "query stays required: {required:?}"
+    );
+}
+
+/// When pinned, the `index_id` property description names the pinned default.
+///
+/// Why: the schema description is a first-class prompt — telling the model what
+/// `index_id` defaults to means it never has to call `list_indexes`.
+/// What: pins to `trusty-tools` and asserts the `search` `index_id` description
+/// mentions the pinned id.
+/// Test: this is the test.
+#[test]
+fn pinned_descriptors_annotate_index_id() {
+    use super::descriptors::tool_descriptors_pinned;
+    let pinned = tool_descriptors_pinned(Some("trusty-tools"));
+    let schema = schema_of(&pinned, "search");
+    let desc = schema
+        .get("properties")
+        .and_then(|p| p.get("index_id"))
+        .and_then(|i| i.get("description"))
+        .and_then(Value::as_str)
+        .expect("index_id description");
+    assert!(
+        desc.contains("trusty-tools") && desc.contains("pinned"),
+        "index_id description should name the pinned default: {desc:?}"
+    );
+}
+
+/// `tools/list` over a PINNED server advertises the optional `index_id`.
+///
+/// Why: end-to-end — the dispatcher must feed its `pinned_index` into the
+/// descriptor builder so the wire `tools/list` reflects the pin.
+/// What: dispatches `tools/list` on a pinned server and asserts `search`'s
+/// schema dropped `index_id` from `required`.
+/// Test: this is the test.
+#[tokio::test]
+async fn tools_list_reflects_session_pin() {
+    let server = McpServer::new("http://127.0.0.1:1").with_pinned_index("trusty-tools");
+    let resp = server.dispatch(req("tools/list", Value::Null)).await;
+    let tools = resp
+        .result
+        .expect("result")
+        .get("tools")
+        .cloned()
+        .expect("tools");
+    let schema = schema_of(&tools, "search");
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .expect("required")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        !required.contains(&"index_id"),
+        "pin must reach tools/list: {required:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1373 — trusty-mpm sessions queried the **wrong** trusty-search index (usually the persistent `claude-mpm` one) instead of the current project's index, because the injected `trusty-search serve` MCP stub carried no index context and left selection to the LLM. This PR implements the chosen **Register + Pin (A+B)** approach.

## Shared id derivation (single source of truth) — `trusty-common` 0.17.0

New `index_id` module:
- `derive_index_id(project_root)` → the project basename, **preserved verbatim** (not slugified) so it matches every already-indexed project's id.
- `resolve_project_root(start)` → walks up to the git root, else returns `start`.

`trusty-search`'s `detect_project` now delegates to `derive_index_id`, so the CLI, the MCP serve pin, and trusty-mpm's register-and-pin all derive the identical id. This avoids a trusty-mpm → trusty-search dependency edge (trusty-search pulls the heavy ONNX/usearch stack); both crates already depend on trusty-common.

## Half B — pin the serve session — `trusty-search` 0.26.0

- `trusty-search serve --index <id>` (and `--project <path>`, derived via the shared helper; `--index` wins) pin the MCP session to one index.
- When pinned, every tool handler (`search`, `search_*`, `grep`, `chat`, `get_call_chain`, `index_status`, `reindex`, `list_chunks`, …) **defaults an omitted `index_id` to the pin**; an explicit caller id still wins.
- Fan-out tools (`search_all` / `grep` without `index_id`) **scope to the pinned index** instead of sweeping every registered index.
- `tools/list` advertises the pin: `index_id` is dropped from `required` and its description names the pinned default, so the LLM never has to call `list_indexes` and guess.
- **Backward compatible:** no `--index`/`--project` → behaviour unchanged (callers must supply `index_id`; fan-out sweeps all).

## Half A — register + pin at launch — `trusty-mpm` 0.10.0

At session launch `prepare_session`:
1. Derives the project's index id from the session's project root (via the shared helper).
2. **Best-effort find-or-creates** the index in the running trusty-search daemon (`POST /indexes` with `{id, root_path}`; idempotent). The blocking HTTP runs on a dedicated `std::thread` so `reqwest::blocking` is safe from the async daemon/TUI launch paths.
3. Injects the `trusty-search` MCP stub **pinned**: `{"command":"trusty-search","args":["serve","--index","<id>"]}` (built dynamically from the derived id, replacing the former const).

**Graceful daemon-down:** if the daemon address is not discoverable, it logs a warning and still pins the stub (the index is created on first reindex); an empty derived id falls back to the unpinned `serve` stub. The session always launches.

## Tests
- `trusty-common`: `derive_index_id` basename derivation + git-root walk + no-marker fallback.
- `trusty-search`: `resolve_index_id` precedence (explicit > pinned > none), blank-pin guard, unchanged-without-pin, pinned `search` hits `/indexes/<pin>/search`, pinned `grep` scopes to the per-index endpoint, pinned descriptors make `index_id` optional + annotate it, `tools/list` reflects the session pin.
- `trusty-mpm`: stub built with `--index <id>` for a known id (and unpinned for `None`/blank), `register_project_index` derives the git-root id and stays graceful when the daemon is unreachable; the async-context safety of the blocking call is covered by `launch_session_errors_when_daemon_unreachable`.

## Verification (all green)
`cargo test -p trusty-common -p trusty-search -p trusty-mpm`, `cargo clippy --all-targets -- -D warnings` (trusty-common/search/mpm), `cargo fmt --check`, `bash scripts/check_line_cap.sh`, and `SKIP_UI_BUILD=1 cargo check --workspace` (dependent version pins updated across the workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)