### PR TITLE
docs(e2e): Docker E2E run policy (release gate at 3+ crates/PRs)

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -30,6 +30,11 @@
 #     validate after a new crate publish before the nightly run fires.
 #   NOT triggered on push/PR — the source build CI covers those paths.
 #
+# RELEASE GATE POLICY (issue #1376):
+#   Run E2E manually when a release batch spans ≥3 crates OR ≥3 PRs.
+#   Smaller releases (1–2 crates, 1–2 PRs) may skip and rely on standard CI.
+#   See docs/reference/release-workflow.md "Docker end-to-end validation (release gate)" for details.
+#
 # CARGO REGISTRY CACHE:
 #   The Cargo registry (index + downloaded crate sources) is cached via
 #   actions/cache using a weekly key. Docker layer caching is not used here

--- a/docker/e2e/README.md
+++ b/docker/e2e/README.md
@@ -154,14 +154,26 @@ that trusty-search >= 0.25.0 excludes them by default.
 directory component with that name. Naming the container path `sample-code`
 avoids this exclusion so the `.rs` files are actually indexed.
 
-## CI trigger
+## When does this run?
 
-The workflow (`.github/workflows/e2e-docker.yml`) runs:
-- **Nightly** at 02:00 UTC — catches regressions in published crates.
-- **Manual** via `workflow_dispatch` — run after a new crate publish to
-  validate before the next nightly run fires.
+The workflow (`.github/workflows/e2e-docker.yml`) is triggered by three conditions:
 
-It is **not triggered on PRs** — the source-build CI covers that path.
+### 1. On-demand (manual)
+Run from the GitHub Actions UI (**Actions → e2e-docker → Run workflow**) or the CLI:
+```bash
+gh workflow run e2e-docker.yml
+```
+Use this anytime to validate a published release before declaring it complete. Optionally pin specific crate versions via the workflow inputs.
+
+### 2. Release gate (scheduled on-demand)
+When a release batch spans **≥3 crates OR ≥3 PRs**, manually run the E2E validation before marking the release as done. This ensures published artifacts work end-to-end on a clean Linux image. Smaller releases (1–2 crates, 1–2 PRs) may skip this and rely on standard CI.
+
+### 3. Nightly safety-net (automatic schedule)
+Runs automatically **every day at 02:00 UTC**. This catches regressions in published crates independently of releases — e.g., crates.io outages, yanked dependencies, or external ecosystem changes.
+
+### Why separate from main CI?
+
+Source-build CI (`.github/workflows/ci.yml`) builds from the local checkout. This workflow is the complementary **install-from-crates.io** gate, proving that published binaries install cleanly on a clean Linux base image. This path is what users actually run, so it must be tested independently.
 
 ## Environment variables
 

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -44,6 +44,20 @@ The `[workspace.package]` table no longer carries a `version` field (see #343).
 When publishing, bump only the crates that actually changed — do not cascade
 version bumps to siblings with no functional changes.
 
+### Docker end-to-end validation (release gate)
+
+The Docker E2E harness (`.github/workflows/e2e-docker.yml`, driver `scripts/e2e-docker.sh`, docs `docker/e2e/README.md`) validates that published crates install cleanly from crates.io on a clean Linux image and pass minimal end-to-end scenarios.
+
+**Release gate policy:**
+- **On-demand** via `workflow_dispatch` (manual trigger): primary workflow; run anytime from the Actions UI.
+- **As a release gate**: when a release batch spans **≥3 crates OR ≥3 PRs**, run the E2E validation manually before declaring the release complete. Smaller releases (1–2 crates, 1–2 PRs) may skip it and rely on standard CI.
+- **Nightly schedule**: runs automatically at 02:00 UTC as a regression safety-net, catching published-artifact and crates.io breakage independent of releases.
+
+The workflow is **not** triggered on every PR or every release; it is a deliberate gate. When needed, trigger it from **Actions → e2e-docker → Run workflow** or:
+```bash
+gh workflow run e2e-docker.yml
+```
+
 ## Bundled Crates — Intentionally Skipped by `release.yml`
 
 `release.yml` only builds standalone distributable binaries. Three crates are


### PR DESCRIPTION
## Summary
Document the Docker E2E workflow run policy across three locations:
- Release gate applies when release batch spans **≥3 crates OR ≥3 PRs** (run manually)
- Nightly schedule runs automatically as regression safety-net
- Manual trigger available on-demand from Actions UI or CLI

## Changes
- **docs/reference/release-workflow.md**: Add "Docker end-to-end validation (release gate)" subsection with policy and CLI command
- **docker/e2e/README.md**: Expand "CI trigger" → "When does this run?" with three trigger conditions and rationale
- **.github/workflows/e2e-docker.yml**: Add release-gate policy note to file header

No CI trigger changes. No behavior changes — this formalizes the documented policy.

🤖 Generated with Claude Code