### PR TITLE
feat(release): add scripts/bump-version.sh version-bump helper (closes #1345)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,14 @@ versions by version number.
 ### Quick Release Steps
 
 1. Bump the crate version in `crates/<name>/Cargo.toml`.
+   - Shortcut: `scripts/bump-version.sh <crate-dir> <major|minor|patch>` reads the
+     current version, computes the next semver, edits the package version in
+     place, stages the unreleased `CHANGELOG.md` section (via
+     `scripts/generate-changelog.sh`), and **prints** the exact `git tag` /
+     `git push` commands for you to run. It never tags or pushes — the human
+     stays in the loop per the manual-tag convention. It honours the
+     `trusty-git-analytics` tag-prefix gotcha automatically (tags are
+     `trusty-git-analytics-v*`, not `tga-v*`).
 2. Update any dependent crates that pin that version.
 3. Run `cargo test -p <name>` and `cargo clippy --workspace -- -D warnings`.
 4. Commit the version bump.

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -7,6 +7,26 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
 
 1. Bump the crate version in `crates/<name>/Cargo.toml`.
 2. Update any dependent crates that pin that version.
+
+> **Convenience helper:** `scripts/bump-version.sh <crate-dir> <major|minor|patch>`
+> automates step 1 and the changelog staging. It reads the current package
+> `version` from `crates/<crate-dir>/Cargo.toml`, computes the next semver,
+> rewrites the package version line in place (dependency `version =` pins are
+> left untouched), calls `scripts/generate-changelog.sh <crate-dir> <tag-prefix>`
+> to prepend the unreleased `CHANGELOG.md` section, then **prints — but does not
+> run —** the `git tag <prefix>-v<version>` and `git push origin <prefix>-v<version>`
+> commands. This preserves the manual-tag convention (the human reviews and
+> tags). The tag prefix defaults to the crate-dir name, with the one documented
+> exception baked in: `trusty-git-analytics` (package name `tga`) releases under
+> the `trusty-git-analytics-v*` tag series, NOT `tga-v*`.
+>
+> ```bash
+> scripts/bump-version.sh trusty-search patch
+> scripts/bump-version.sh trusty-git-analytics minor
+> ```
+>
+> The `--suggest` auto-bump-from-commit-types enhancement noted in #1322/#1345
+> is intentionally deferred and not yet implemented.
 3. Run `cargo test -p <name>` and `cargo clippy --workspace -- -D warnings`.
 4. Commit the version bump.
 5. Create the tag: `git tag <crate-name>-v<version>`.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,20 +4,18 @@
 # Why: trusty-tools releases each crate independently (tag `<prefix>-v<version>`),
 # and the manual ritual — read the current version, hand-compute the next semver,
 # edit Cargo.toml, regenerate the unreleased CHANGELOG section, then recall the
-# exact tag/push commands — is error-prone. The most common slip is the
-# trusty-git-analytics tag-prefix gotcha (its crate name is `tga` but its release
-# tags are `trusty-git-analytics-v*`). This helper does the mechanical bump and
-# changelog staging, then PRINTS (never runs) the tag/push commands so the human
-# stays in the loop per the repo's manual-tag release convention.
+# exact tag/push commands — is error-prone. This helper does the mechanical bump
+# and changelog staging, then PRINTS (never runs) the tag/push commands so the
+# human stays in the loop per the repo's manual-tag release convention.
 #
 # What: Given a crate directory under crates/ and a bump level
 # (major|minor|patch), reads the package `version = "X.Y.Z"` from
 # crates/<crate-dir>/Cargo.toml, computes the next semver, edits that line in
 # place, then calls scripts/generate-changelog.sh <crate-dir> <tag-prefix> to
-# prepend the unreleased CHANGELOG section. The tag prefix defaults to the
-# crate-dir name; a small lookup table records the only exception
-# (trusty-git-analytics, whose prefix is NOT its `tga` package name). Finally it
-# prints — but does NOT execute — the `git tag` and `git push` commands.
+# prepend the unreleased CHANGELOG section. For every current crate the tag
+# prefix equals the crate-dir name (tag_prefix_for() is the single, easy-to-
+# extend place that derives it). Finally it prints — but does NOT execute — the
+# `git tag` and `git push` commands.
 #
 # Test: `bash -n scripts/bump-version.sh` for syntax and `shellcheck
 # scripts/bump-version.sh` for lint. Functionally, the pure version-bump logic
@@ -36,17 +34,16 @@ set -euo pipefail
 
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Why: encode the ONLY tag-prefix exception so callers never have to remember it.
-# The release tag prefix equals the crate-dir name for every crate EXCEPT
-# trusty-git-analytics, whose package name is `tga` but whose tags are
-# `trusty-git-analytics-v*`. generate-changelog.sh makes the same distinction.
-# What: maps crate-dir -> tag-prefix; any dir not listed defaults to itself.
+# Why: keep a single place where the release tag prefix is derived so it is easy
+# to extend if a crate ever needs a prefix that differs from its directory name.
+# For every CURRENT crate the tag prefix IS the crate directory name — including
+# trusty-git-analytics, whose tags are `trusty-git-analytics-v*` (the cargo
+# *package* short-name `tga` is never used as a tag prefix). The caller already
+# passes the crate-dir, so today this is an identity mapping.
+# What: prints the tag prefix for a given crate-dir.
 tag_prefix_for() {
   local crate_dir="$1"
-  case "${crate_dir}" in
-    trusty-git-analytics) echo "trusty-git-analytics" ;;
-    *) echo "${crate_dir}" ;;
-  esac
+  echo "${crate_dir}"
 }
 
 usage() {
@@ -159,17 +156,41 @@ main() {
     exit 1
   fi
 
+  # Pre-flight (BEFORE mutating any Cargo.toml): the changelog generator must
+  # exist and be executable. Failing here keeps the repo unmodified rather than
+  # leaving it half-bumped (version edited but CHANGELOG never staged).
+  local changelog_script="${WORKSPACE_ROOT}/scripts/generate-changelog.sh"
+  if [[ ! -x "${changelog_script}" ]]; then
+    echo "ERROR: ${changelog_script} is missing or not executable — refusing to" >&2
+    echo "       bump ${manifest} to avoid leaving the repo half-bumped." >&2
+    exit 1
+  fi
+
   local current next prefix
   current="$(read_package_version "${manifest}")"
   next="$(bump_semver "${current}" "${level}")"
   prefix="$(tag_prefix_for "${crate_dir}")"
 
+  # Defensive no-op guard: a computed version equal to the current one means
+  # nothing would change — abort rather than print a misleading "Bumped" line.
+  if [[ "${next}" == "${current}" ]]; then
+    echo "ERROR: computed version ${next} equals current version ${current}; nothing to bump" >&2
+    exit 1
+  fi
+
   write_package_version "${manifest}" "${current}" "${next}"
+
+  # Verify the rewrite actually landed: a silent awk non-match (e.g. an
+  # unexpected manifest layout) must abort here instead of printing "Bumped".
+  if ! grep -qF "version = \"${next}\"" "${manifest}"; then
+    echo "ERROR: version rewrite failed — ${manifest} still contains ${current}" >&2
+    exit 1
+  fi
   echo "Bumped crates/${crate_dir}/Cargo.toml: ${current} -> ${next} (${level})" >&2
 
   # Stage the unreleased CHANGELOG section for this crate's tag series.
   echo "Staging unreleased CHANGELOG section via generate-changelog.sh ..." >&2
-  "${WORKSPACE_ROOT}/scripts/generate-changelog.sh" "${crate_dir}" "${prefix}"
+  "${changelog_script}" "${crate_dir}" "${prefix}"
 
   # Print — but DO NOT RUN — the manual tag/push commands (human stays in loop).
   local tag="${prefix}-v${next}"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# scripts/bump-version.sh
+#
+# Why: trusty-tools releases each crate independently (tag `<prefix>-v<version>`),
+# and the manual ritual — read the current version, hand-compute the next semver,
+# edit Cargo.toml, regenerate the unreleased CHANGELOG section, then recall the
+# exact tag/push commands — is error-prone. The most common slip is the
+# trusty-git-analytics tag-prefix gotcha (its crate name is `tga` but its release
+# tags are `trusty-git-analytics-v*`). This helper does the mechanical bump and
+# changelog staging, then PRINTS (never runs) the tag/push commands so the human
+# stays in the loop per the repo's manual-tag release convention.
+#
+# What: Given a crate directory under crates/ and a bump level
+# (major|minor|patch), reads the package `version = "X.Y.Z"` from
+# crates/<crate-dir>/Cargo.toml, computes the next semver, edits that line in
+# place, then calls scripts/generate-changelog.sh <crate-dir> <tag-prefix> to
+# prepend the unreleased CHANGELOG section. The tag prefix defaults to the
+# crate-dir name; a small lookup table records the only exception
+# (trusty-git-analytics, whose prefix is NOT its `tga` package name). Finally it
+# prints — but does NOT execute — the `git tag` and `git push` commands.
+#
+# Test: `bash -n scripts/bump-version.sh` for syntax and `shellcheck
+# scripts/bump-version.sh` for lint. Functionally, the pure version-bump logic
+# lives in bump_semver()/read_package_version()/write_package_version(), which
+# can be exercised against a throwaway copy of a Cargo.toml without mutating any
+# real crate manifest (see the PR's verification notes).
+#
+# Usage:
+#   scripts/bump-version.sh <crate-dir> <major|minor|patch>
+#
+# Example:
+#   scripts/bump-version.sh trusty-search patch
+#   scripts/bump-version.sh trusty-git-analytics minor
+
+set -euo pipefail
+
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Why: encode the ONLY tag-prefix exception so callers never have to remember it.
+# The release tag prefix equals the crate-dir name for every crate EXCEPT
+# trusty-git-analytics, whose package name is `tga` but whose tags are
+# `trusty-git-analytics-v*`. generate-changelog.sh makes the same distinction.
+# What: maps crate-dir -> tag-prefix; any dir not listed defaults to itself.
+tag_prefix_for() {
+  local crate_dir="$1"
+  case "${crate_dir}" in
+    trusty-git-analytics) echo "trusty-git-analytics" ;;
+    *) echo "${crate_dir}" ;;
+  esac
+}
+
+usage() {
+  echo "Usage: scripts/bump-version.sh <crate-dir> <major|minor|patch>" >&2
+  echo "" >&2
+  echo "  <crate-dir>            directory under crates/ (e.g. trusty-search)" >&2
+  echo "  <major|minor|patch>    semver component to increment" >&2
+  echo "" >&2
+  echo "Reads the package version from crates/<crate-dir>/Cargo.toml, bumps it," >&2
+  echo "stages the unreleased CHANGELOG section, and PRINTS the tag/push commands" >&2
+  echo "for you to run (it never tags or pushes itself)." >&2
+  exit 2
+}
+
+# Why: the package version is the FIRST `version = "..."` line in a crate
+# Cargo.toml (it sits in the [package] table, above any dependency version
+# pins). Anchoring on the first occurrence avoids accidentally matching a
+# dependency's `version = "..."`.
+# What: prints the X.Y.Z string from crates/<crate-dir>/Cargo.toml, or fails.
+read_package_version() {
+  local manifest="$1"
+  local version
+  version="$(grep -m1 -E '^version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "${manifest}" \
+    | sed -E 's/^version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+  if [[ -z "${version}" ]]; then
+    echo "ERROR: could not find a package version (version = \"X.Y.Z\") in ${manifest}" >&2
+    return 1
+  fi
+  echo "${version}"
+}
+
+# Why: centralise the semver arithmetic so it is unit-testable in isolation.
+# What: given X.Y.Z and a level, returns the next version (resetting lower
+# components: a minor bump zeroes patch; a major bump zeroes minor and patch).
+bump_semver() {
+  local current="$1" level="$2"
+  local major minor patch
+  IFS='.' read -r major minor patch <<<"${current}"
+  case "${level}" in
+    major) major=$((major + 1)); minor=0; patch=0 ;;
+    minor) minor=$((minor + 1)); patch=0 ;;
+    patch) patch=$((patch + 1)) ;;
+    *)
+      echo "ERROR: invalid bump level '${level}' (expected major|minor|patch)" >&2
+      return 1
+      ;;
+  esac
+  echo "${major}.${minor}.${patch}"
+}
+
+# Why: edit only the package version line, leaving dependency pins untouched.
+# What: rewrites the FIRST matching `version = "<old>"` line to <new> in place.
+# Robustness details:
+#   - The match is RIGHT-anchored (`"<old>"$`) so a trailing-comment-free
+#     package version line matches exactly and a longer string such as
+#     "<old>-beta" never matches.
+#   - `old` is regex-escaped before being interpolated into awk's `~` pattern,
+#     so the dots in a semver like 1.2.3 match literal dots (awk treats `.` as
+#     "any char" otherwise).
+#   - The replacement uses index()/substr() (literal), not sub() (regex), so
+#     the new version is inserted verbatim with no metacharacter surprises.
+#   - The temp file is created in the SAME directory as the manifest so `mv` is
+#     a guaranteed-atomic rename (never a cross-filesystem copy), and a trap
+#     removes it if awk fails or the process is interrupted under `set -e`.
+write_package_version() {
+  local manifest="$1" old="$2" new="$3"
+  local tmp="${manifest}.bump.$$"
+  # shellcheck disable=SC2064  # expand tmp now so the trap targets this exact file
+  trap "rm -f '${tmp}'" RETURN
+  awk -v old="${old}" -v new="${new}" '
+    BEGIN {
+      # Escape regex metacharacters in old so dots match literally.
+      old_re = old
+      gsub(/[][(){}.^$*+?|\\]/, "\\\\&", old_re)
+    }
+    !done && $0 ~ "^version[[:space:]]*=[[:space:]]*\"" old_re "\"$" {
+      pos = index($0, "\"" old "\"")
+      if (pos > 0) {
+        $0 = substr($0, 1, pos - 1) "\"" new "\"" substr($0, pos + length(old) + 2)
+        done = 1
+      }
+    }
+    { print }
+  ' "${manifest}" >"${tmp}"
+  mv "${tmp}" "${manifest}"
+}
+
+main() {
+  [[ $# -ne 2 ]] && usage
+
+  local crate_dir="$1" level="$2"
+
+  case "${level}" in
+    major | minor | patch) ;;
+    *)
+      echo "ERROR: invalid bump level '${level}' (expected major|minor|patch)" >&2
+      usage
+      ;;
+  esac
+
+  local crate_path="${WORKSPACE_ROOT}/crates/${crate_dir}"
+  if [[ ! -d "${crate_path}" ]]; then
+    echo "ERROR: crate directory not found: crates/${crate_dir}" >&2
+    exit 1
+  fi
+
+  local manifest="${crate_path}/Cargo.toml"
+  if [[ ! -f "${manifest}" ]]; then
+    echo "ERROR: Cargo.toml not found: crates/${crate_dir}/Cargo.toml" >&2
+    exit 1
+  fi
+
+  local current next prefix
+  current="$(read_package_version "${manifest}")"
+  next="$(bump_semver "${current}" "${level}")"
+  prefix="$(tag_prefix_for "${crate_dir}")"
+
+  write_package_version "${manifest}" "${current}" "${next}"
+  echo "Bumped crates/${crate_dir}/Cargo.toml: ${current} -> ${next} (${level})" >&2
+
+  # Stage the unreleased CHANGELOG section for this crate's tag series.
+  echo "Staging unreleased CHANGELOG section via generate-changelog.sh ..." >&2
+  "${WORKSPACE_ROOT}/scripts/generate-changelog.sh" "${crate_dir}" "${prefix}"
+
+  # Print — but DO NOT RUN — the manual tag/push commands (human stays in loop).
+  local tag="${prefix}-v${next}"
+  echo "" >&2
+  echo "Next steps (review, then run these yourself):" >&2
+  echo "" >&2
+  echo "  git add crates/${crate_dir}/Cargo.toml crates/${crate_dir}/CHANGELOG.md  # add Cargo.lock too if cargo regenerated it" >&2
+  echo "  git commit -m \"chore(release): ${crate_dir} ${next}\"" >&2
+  echo "  git tag ${tag}" >&2
+  echo "  git push origin ${tag}" >&2
+}
+
+main "$@"


### PR DESCRIPTION
new executable scripts/bump-version.sh reads/edits a crate's package version, calls generate-changelog.sh, and prints (does NOT run) the git tag/push commands per the manual-tag convention; tag-prefix mapping handles the trusty-git-analytics exception; input validation + shellcheck-clean. `--suggest` auto-bump deferred. Docs updated.

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)