### PR TITLE
feat(trusty-mpm): coordinator TUI skeleton screen + tm coordinator-tui subcommand (Child #1, refs #1272)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -100,6 +100,27 @@ pub(crate) enum Command {
         #[arg(long, default_value_t = 1000)]
         interval_ms: u64,
     },
+    /// Launch the coordinator TUI: an input box over a live session list (#1272).
+    ///
+    /// Why (DOC-13): a Claude-Code-like surface — a text input on top of a live
+    /// session list (controller bullet + one row per managed session, the active
+    /// row in two columns `[id] │ [summary]`). This is a NEW screen, distinct
+    /// from the existing `tm tui` dashboard. It is exposed under its own name
+    /// because `coordinator` already names the session-manager chat command
+    /// (`tm coordinator` / `tm sm`); a `-tui` suffix avoids that collision.
+    /// What: Child #1 ships the skeleton — layout, selection, input editing, and
+    /// a panic-safe terminal; live polling and slash-command dispatch land in
+    /// later children. `--url` is resolved via `resolve_daemon_url`;
+    /// `--interval-ms` is the (future) refresh cadence.
+    /// Test: `cli_parses_coordinator_tui` in `tests.rs`.
+    CoordinatorTui {
+        /// Base URL of the trusty-mpm daemon.
+        #[arg(long, env = "TRUSTY_MPM_URL")]
+        url: Option<String>,
+        /// Poll interval in milliseconds (refresh cadence; used by later children).
+        #[arg(long, default_value_t = 1500)]
+        interval_ms: u64,
+    },
     /// Launch the Tauri desktop GUI (or open the web build in the browser
     /// when Tauri is unavailable).
     Gui,

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -219,6 +219,16 @@ async fn main() -> anyhow::Result<()> {
             let resolved = trusty_mpm::core::resolve_daemon_url(Some(&tui_url));
             trusty_mpm::tui::run(resolved, interval_ms).await
         }
+        // #1272 Child #1: the coordinator TUI is synchronous in the skeleton (no
+        // live daemon polling yet); `resolve_daemon_url` honours an explicit
+        // `--url`, then the lock file, then the default.
+        Command::CoordinatorTui {
+            url: tui_url,
+            interval_ms,
+        } => {
+            let resolved = trusty_mpm::core::resolve_daemon_url(tui_url.as_deref());
+            trusty_mpm::tui::coordinator::run(resolved, interval_ms)
+        }
         Command::Gui => launch_gui(),
         Command::Telegram { cmd } => telegram(&url, cmd).await,
         Command::Install { force } => install(force),

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -432,6 +432,43 @@ fn cli_parses_tui_with_interval() {
 }
 
 #[test]
+fn cli_parses_coordinator_tui() {
+    // #1272 Child #1: the coordinator TUI is its own subcommand (the
+    // `coordinator` name is taken by the SM chat command). Its `--interval-ms`
+    // defaults to 1500. The `url` arg carries `env = "TRUSTY_MPM_URL"`, so an
+    // ambient `TRUSTY_MPM_URL` in the test runner would override the (absent)
+    // default — assert only the env-independent interval default here, and the
+    // url plumbing in `cli_parses_coordinator_tui_with_flags`.
+    let cli = Cli::try_parse_from(["trusty-mpm", "coordinator-tui"]).unwrap();
+    match cli.command {
+        Command::CoordinatorTui { interval_ms, .. } => {
+            assert_eq!(interval_ms, 1500);
+        }
+        other => panic!("expected CoordinatorTui, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_coordinator_tui_with_flags() {
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "coordinator-tui",
+        "--url",
+        "http://127.0.0.1:9999",
+        "--interval-ms",
+        "750",
+    ])
+    .unwrap();
+    match cli.command {
+        Command::CoordinatorTui { url, interval_ms } => {
+            assert_eq!(url.as_deref(), Some("http://127.0.0.1:9999"));
+            assert_eq!(interval_ms, 750);
+        }
+        other => panic!("expected CoordinatorTui, got {other:?}"),
+    }
+}
+
+#[test]
 fn cli_parses_telegram_pair() {
     let cli = Cli::try_parse_from(["trusty-mpm", "telegram", "pair"]).unwrap();
     assert!(matches!(

--- a/crates/trusty-mpm/src/tui/coordinator/events.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/events.rs
@@ -1,0 +1,141 @@
+//! Key dispatch for the coordinator TUI (Child #1 skeleton).
+//!
+//! Why: separating "a key arrives → mutate state" from the terminal pump keeps
+//! the dispatch pure and unit-testable, and keeps every file under the SLOC
+//! cap. The slash-command *parse* lives here too, but deliberately stops at a
+//! recognised-but-stubbed enum — Child #4 wires those to the daemon.
+//! What: [`SlashCommand`] (the recognised set + an `Unknown` fallback),
+//! [`parse_slash`] (leading-`/` detection → enum), and [`handle_key`] which
+//! routes a [`KeyEvent`] into [`CoordinatorState`] mutations (selection,
+//! editing, submit-to-history, quit).
+//! Test: `super::tests` covers `parse_slash` (including the leading-`/` stub)
+//! and the key-routing branches via synthetic `KeyEvent`s.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::state::CoordinatorState;
+
+/// A recognised slash command, parsed but NOT yet dispatched (Child #1).
+///
+/// Why: the spec's slash-command framework (DOC-13 §5.2) lands in Child #4;
+/// Child #1 only needs to *recognise* a leading `/` and classify it so the
+/// later wiring slots into a typed enum rather than re-parsing raw strings.
+/// What: one variant per documented command plus [`SlashCommand::Unknown`] for
+/// an unrecognised `/word`. Carrying the raw text lets a later child surface a
+/// "no such command" hint without re-splitting.
+/// Test: `parse_slash_recognises_known_commands`,
+/// `parse_slash_classifies_unknown`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashCommand {
+    /// `/help` — list commands + keybindings (overlay; Child #4).
+    Help,
+    /// `/new` — open the new-session form (Child #4).
+    New,
+    /// `/sessions` — open the session picker (Child #4).
+    Sessions,
+    /// `/attach` — show/copy the tmux attach command (Child #5).
+    Attach,
+    /// `/stop` — stop a session's runtime (Child #5).
+    Stop,
+    /// `/resume` — resume a stopped session (Child #5).
+    Resume,
+    /// `/kill` — decommission a session (Child #5).
+    Kill,
+    /// A leading-`/` token that matched none of the known commands.
+    Unknown(String),
+}
+
+/// Parse a submitted input line into a [`SlashCommand`], if it is one.
+///
+/// Why: Enter on a `/`-prefixed line should be classified as a command rather
+/// than echoed as chat; doing the classification in a pure function keeps it
+/// testable and keeps the leading-`/` contract (§3.4) in one place.
+/// What: returns `None` when `input` does not start with `/`; otherwise lowercases
+/// the first whitespace-delimited token (sans the `/`) and maps it to the
+/// matching [`SlashCommand`], falling back to [`SlashCommand::Unknown`] carrying
+/// that token.
+/// Test: `parse_slash_recognises_known_commands`,
+/// `parse_slash_classifies_unknown`, `parse_slash_ignores_plain_text`.
+pub fn parse_slash(input: &str) -> Option<SlashCommand> {
+    let rest = input.strip_prefix('/')?;
+    let word = rest.split_whitespace().next().unwrap_or("").to_lowercase();
+    let cmd = match word.as_str() {
+        "help" => SlashCommand::Help,
+        "new" => SlashCommand::New,
+        "sessions" => SlashCommand::Sessions,
+        "attach" => SlashCommand::Attach,
+        "stop" => SlashCommand::Stop,
+        "resume" => SlashCommand::Resume,
+        "kill" => SlashCommand::Kill,
+        other => SlashCommand::Unknown(other.to_string()),
+    };
+    Some(cmd)
+}
+
+/// True when this key event means "quit" (`q` or Ctrl-C).
+///
+/// Why: both the dispatcher and any future modal layer need the same quit
+/// predicate; factoring it out keeps the rule single-sourced.
+/// What: matches `q` (only when the input buffer is empty, so a `q` typed mid
+/// message is not hijacked) or Ctrl-C regardless of buffer.
+/// Test: `quit_on_q_when_empty`, `quit_on_ctrl_c`, `q_in_message_is_not_quit`.
+pub fn is_quit(key: &KeyEvent, input_empty: bool) -> bool {
+    let ctrl_c = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+    let bare_q = key.code == KeyCode::Char('q') && input_empty;
+    ctrl_c || bare_q
+}
+
+/// Route one key event into [`CoordinatorState`] mutations.
+///
+/// Why: this is the single seam the terminal pump calls per key; keeping it a
+/// pure `&mut state` function (no terminal, no IO) makes every branch — quit,
+/// selection, editing, submit — unit-testable with synthetic [`KeyEvent`]s.
+/// What: Ctrl-C / bare `q` set `should_exit`; ↑/↓ and `k`/`j` move the
+/// selection when the input is empty (↑/↓ recall history when it is not);
+/// printable keys edit the buffer; Backspace deletes; Esc clears; Enter submits
+/// (echoing to history — Child #1 does not dispatch). Returns any submitted line
+/// so the caller can record a last-action note; slash lines are returned too
+/// (the caller may `parse_slash` them) but are not acted on here.
+/// Test: `handle_key_*` branch tests in `super::tests`.
+pub fn handle_key(state: &mut CoordinatorState, key: KeyEvent) -> Option<String> {
+    let input_empty = state.input.is_empty();
+    if is_quit(&key, input_empty) {
+        state.should_exit = true;
+        return None;
+    }
+
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') if input_empty => {
+            state.select_up();
+            None
+        }
+        KeyCode::Down | KeyCode::Char('j') if input_empty => {
+            state.select_down();
+            None
+        }
+        // With text in the buffer, ↑/↓ recall input history instead of moving
+        // the session selection (mirrors the dashboard's CommandBar behaviour).
+        KeyCode::Up => {
+            state.history_prev();
+            None
+        }
+        KeyCode::Down => {
+            state.history_next();
+            None
+        }
+        KeyCode::Backspace => {
+            state.backspace();
+            None
+        }
+        KeyCode::Esc => {
+            state.clear_input();
+            None
+        }
+        KeyCode::Enter => state.submit_input(),
+        KeyCode::Char(c) => {
+            state.push_char(c);
+            None
+        }
+        _ => None,
+    }
+}

--- a/crates/trusty-mpm/src/tui/coordinator/events.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/events.rs
@@ -50,15 +50,20 @@ pub enum SlashCommand {
 /// Why: Enter on a `/`-prefixed line should be classified as a command rather
 /// than echoed as chat; doing the classification in a pure function keeps it
 /// testable and keeps the leading-`/` contract (§3.4) in one place.
-/// What: returns `None` when `input` does not start with `/`; otherwise lowercases
-/// the first whitespace-delimited token (sans the `/`) and maps it to the
-/// matching [`SlashCommand`], falling back to [`SlashCommand::Unknown`] carrying
-/// that token.
+/// What: returns `None` when `input` does not start with `/`, or when the input
+/// is a bare `/` with no command word (e.g. `/` or `/   `) — a lone slash is not
+/// a command, so it falls through to chat rather than yielding
+/// `Unknown("")`. Otherwise lowercases the first whitespace-delimited token
+/// (sans the `/`) and maps it to the matching [`SlashCommand`], falling back to
+/// [`SlashCommand::Unknown`] carrying that token.
 /// Test: `parse_slash_recognises_known_commands`,
-/// `parse_slash_classifies_unknown`, `parse_slash_ignores_plain_text`.
+/// `parse_slash_classifies_unknown`, `parse_slash_ignores_plain_text`,
+/// `parse_slash_bare_slash_is_not_a_command`.
 pub fn parse_slash(input: &str) -> Option<SlashCommand> {
     let rest = input.strip_prefix('/')?;
-    let word = rest.split_whitespace().next().unwrap_or("").to_lowercase();
+    // A bare `/` (no command word) is not a command — treat it as chat so the
+    // operator never sees a spurious `Unknown("")` classification.
+    let word = rest.split_whitespace().next()?.to_lowercase();
     let cmd = match word.as_str() {
         "help" => SlashCommand::Help,
         "new" => SlashCommand::New,

--- a/crates/trusty-mpm/src/tui/coordinator/layout.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/layout.rs
@@ -1,0 +1,155 @@
+//! Vertical layout + rendering for the coordinator TUI skeleton.
+//!
+//! Why: the spec (DOC-13 §3) pins a Claude-Code-like shape — input box on
+//! TOP, the live session list in the MIDDLE (controller bullet always row 0),
+//! and a status/key bar at the BOTTOM. Keeping the frame composition here,
+//! separate from state and key dispatch, isolates the only terminal-touching
+//! render path and keeps each file under the SLOC cap.
+//! What: [`render`] draws the three regions for one frame; the small helpers
+//! ([`input_line`], [`status_bar_text`]) build the text the layout shows and are
+//! reused by tests. The session list is built from the pure row-builders in
+//! [`super::rows`], so the *content* is unit-tested without a terminal.
+//! Test: text helpers are unit-tested in `super::tests`; the full `render` is
+//! exercised by launching the TUI (terminal glue).
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::Line,
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+};
+
+use super::rows::{active_row_two_col, controller_bullet_row, session_row};
+use super::state::CoordinatorState;
+
+/// The prompt prefix shown in the input box.
+///
+/// Why: the spec's mockup shows a `coordinator ›` prompt; a constant keeps the
+/// prompt single-sourced between the renderer and its test.
+/// What: the literal `coordinator › `.
+/// Test: `input_line_shows_prompt_and_cursor`.
+pub const INPUT_PROMPT: &str = "coordinator › ";
+
+/// The bottom status/key-hint bar text.
+///
+/// Why: the spec's status bar lists the slash commands + global keys; the
+/// skeleton shows the (stubbed) command names plus the keys Child #1 implements.
+/// What: a one-line hint string drawn reversed at the bottom.
+/// Test: `status_bar_lists_keys`.
+pub const STATUS_BAR_HINT: &str =
+    "/new /sessions /attach /stop /resume /kill /help  ·  ↵ send  ·  ↑↓/jk select  ·  q quit";
+
+/// The synthetic right-column status shown for the controller bullet.
+///
+/// Why: the controller has no daemon summary; its right column is a synthetic
+/// readiness string (§3.3). A constant keeps the skeleton value in one place.
+/// What: the literal `idle · 0 delegations · ready`.
+/// Test: `controller_status_is_synthetic`.
+pub const CONTROLLER_STATUS: &str = "idle · 0 delegations · ready";
+
+/// Build the input-box line: prompt + buffer + a cursor glyph.
+///
+/// Why: kept pure so a test can assert the rendered prompt and trailing cursor
+/// without a terminal frame.
+/// What: returns `coordinator › <buffer>_` (the trailing `_` is the cursor).
+/// Test: `input_line_shows_prompt_and_cursor`.
+pub fn input_line(state: &CoordinatorState) -> String {
+    format!("{INPUT_PROMPT}{}_", state.input)
+}
+
+/// Build the bottom status-bar text.
+///
+/// Why: a single helper keeps the bar text consistent and testable.
+/// What: returns [`STATUS_BAR_HINT`] (Child #1 has no transient last-action
+/// note; later children may fold one in here).
+/// Test: `status_bar_lists_keys`.
+pub fn status_bar_text() -> &'static str {
+    STATUS_BAR_HINT
+}
+
+/// Build the unified session-list items: controller row 0, then sessions.
+///
+/// Why: the list always leads with the controller bullet and renders the
+/// selected row in the two-column form; building the `ListItem`s here (from the
+/// pure row-builders) keeps `render` short and the row content testable.
+/// What: returns one [`ListItem`] per row — the controller at index 0 (its
+/// right column the synthetic status), then each session, with the selected row
+/// expanded to `[id] │ [summary]` via [`active_row_two_col`].
+/// Test: row *content* is covered by the `super::rows` tests; ordering here is
+/// exercised by launching the TUI.
+fn session_list_items(state: &CoordinatorState) -> Vec<ListItem<'static>> {
+    let mut items: Vec<ListItem<'static>> = vec![ListItem::new(build_controller_row(state))];
+    for (idx, session) in state.sessions.iter().enumerate() {
+        // Row 0 is the controller, so session `idx` lives at selection `idx + 1`.
+        let selected = state.selected == idx + 1;
+        let line: Line<'static> = if selected {
+            active_row_two_col(&session.short_id, &session.summary)
+        } else {
+            session_row(&session.short_id, &session.prefix, &session.status)
+        };
+        items.push(ListItem::new(line));
+    }
+    items
+}
+
+/// Build the controller row, honouring whether it is the active selection.
+///
+/// Why: keeps the selected/unselected branch out of [`session_list_items`].
+/// What: delegates to [`controller_bullet_row`] with the synthetic status and
+/// the current selection state.
+/// Test: covered by `controller_bullet_row` tests + `controller_status_is_synthetic`.
+fn build_controller_row(state: &CoordinatorState) -> Line<'static> {
+    controller_bullet_row(CONTROLLER_STATUS, state.controller_selected())
+}
+
+/// Draw the coordinator TUI frame: input (top), list (middle), status (bottom).
+///
+/// Why: the single entry point the event loop calls each tick; composing the
+/// vertical layout in one place matches the dashboard's `render` convention.
+/// What: a vertical [`Layout`] — a 3-row input box, a flexing session list, and
+/// a 1-row status bar; the session list pins the controller at row 0 and
+/// highlights the selected row in two columns.
+/// Test: the text/content helpers are unit-tested; this terminal-touching path
+/// is exercised by launching the TUI.
+pub fn render(frame: &mut Frame, state: &CoordinatorState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // input box (top)
+            Constraint::Min(4),    // session list (middle)
+            Constraint::Length(1), // status / key bar (bottom)
+        ])
+        .split(frame.area());
+
+    // Input box (top).
+    let input = Paragraph::new(input_line(state))
+        .style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(input, chunks[0]);
+
+    // Session list (middle): controller bullet pinned as row 0.
+    let title = Line::from(format!("SESSIONS ({})", state.sessions.len()));
+    let list = List::new(session_list_items(state)).block(
+        Block::default().borders(Borders::ALL).title(
+            title.style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ),
+    );
+    frame.render_widget(list, chunks[1]);
+
+    // Status / key bar (bottom).
+    let status = Paragraph::new(Line::from(status_bar_text())).style(
+        Style::default()
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::REVERSED),
+    );
+    frame.render_widget(status, chunks[2]);
+}

--- a/crates/trusty-mpm/src/tui/coordinator/mod.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/mod.rs
@@ -20,7 +20,7 @@ pub mod state;
 #[cfg(test)]
 mod tests;
 
-use std::io::Stdout;
+use std::io::{self, Stdout};
 use std::time::Duration;
 
 use crossterm::{
@@ -32,6 +32,37 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 
 use events::handle_key;
 use state::CoordinatorState;
+
+/// RAII guard that restores the terminal on drop — including during a panic.
+///
+/// Why: the original `run` did its teardown (disable raw mode, leave the
+/// alternate screen, show the cursor) only AFTER `run_loop` returned, so a
+/// panic anywhere in the loop unwound straight past the cleanup and left the
+/// operator's terminal in raw mode + the alternate screen (no echo, no prompt).
+/// A `Drop` impl runs on BOTH the normal return and the unwind path, so the
+/// terminal is always restored. The dashboard's `run`/`run_focused` still use
+/// the older sequential teardown; this is the panic-safe pattern for the new
+/// coordinator screen.
+/// What: constructed right after entering raw mode + the alternate screen; its
+/// `Drop` best-effort runs `disable_raw_mode`, `LeaveAlternateScreen`, and
+/// `Show` (the cursor) against stdout, ignoring errors (nothing useful can be
+/// done while unwinding). Idempotent enough to be the SOLE teardown path.
+/// Test: terminal glue is exercised by launching the TUI; `Drop` cannot be
+/// unit-tested without a real terminal, so correctness rests on it being the
+/// only teardown seam (no manual cleanup duplicates it).
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    /// Why: see [`TerminalGuard`] — runs on normal return and on panic unwind.
+    /// What: best-effort restore of cooked mode, the main screen, and the
+    /// cursor; every step ignores its error because a `Drop` cannot propagate
+    /// one and a partial restore is still better than none.
+    /// Test: side-effect-only teardown; covered by launching the TUI.
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen, crossterm::cursor::Show);
+    }
+}
 
 /// How long [`run`] blocks waiting for a key before redrawing.
 ///
@@ -45,9 +76,10 @@ const KEY_POLL: Duration = Duration::from_millis(50);
 /// Why: the `tm coordinator-tui` subcommand needs one entry point that owns the
 /// terminal lifecycle. Kept synchronous (no daemon IO in Child #1) so the
 /// caller does not need an async context for the skeleton.
-/// What: enters raw mode + the alternate screen, runs the event loop, and
-/// ALWAYS restores the terminal afterward — even if the loop returns an error —
-/// so a panic or early exit never leaves the operator's terminal corrupted.
+/// What: enters raw mode + the alternate screen, installs a [`TerminalGuard`]
+/// whose `Drop` restores the terminal, then runs the event loop. Because the
+/// guard restores on unwind as well as on normal return, a panic or early exit
+/// never leaves the operator's terminal in raw mode / the alternate screen.
 /// `url` and `interval_ms` are accepted now (and threaded into state via the
 /// signature) so Child #2 can wire live polling without a signature change.
 /// Test: terminal glue is exercised by launching the TUI; the loop's pure
@@ -60,16 +92,15 @@ pub fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
+    // From here on the terminal is in raw mode + the alternate screen; the guard
+    // restores both on every exit path — normal return AND panic unwind — so it
+    // is the SOLE teardown (no manual cleanup follows `run_loop`).
+    let _guard = TerminalGuard;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_loop(&mut terminal);
-
-    // Always restore the terminal, even on error (panic-safe boundary).
-    let _ = disable_raw_mode();
-    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
-    let _ = terminal.show_cursor();
-    result
+    run_loop(&mut terminal)
+    // `_guard` drops here (or during an unwind), restoring the terminal.
 }
 
 /// The skeleton render + input loop.

--- a/crates/trusty-mpm/src/tui/coordinator/mod.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/mod.rs
@@ -1,0 +1,98 @@
+//! Coordinator TUI — a Claude-Code-like input box over a live session list.
+//!
+//! Why: operators want one conversational surface to talk to a coordinator and
+//! watch a fleet of sessions (DOC-13). This module is the NEW coordinator screen
+//! built alongside (not on top of) the existing `tui/dashboard` — keeping it
+//! separate avoids touching the at-cap dashboard/health files. Child #1 lands
+//! the skeleton: layout, selection, input editing, and a panic-safe terminal.
+//! What: thin façade re-exporting the submodules and exposing [`run`], the
+//! `tm coordinator-tui` entry point. Live polling, the daemon-backed
+//! `last_summary` column, and slash-command dispatch are deferred to later
+//! children; Child #1 renders static placeholder rows.
+//! Test: the pure pieces (rows, state, events, layout text) are unit-tested in
+//! [`tests`]; [`run`] is the thin terminal glue exercised by launching the TUI.
+
+pub mod events;
+pub mod layout;
+pub mod rows;
+pub mod state;
+
+#[cfg(test)]
+mod tests;
+
+use std::io::Stdout;
+use std::time::Duration;
+
+use crossterm::{
+    event::{self, Event},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+
+use events::handle_key;
+use state::CoordinatorState;
+
+/// How long [`run`] blocks waiting for a key before redrawing.
+///
+/// Why: a short poll keeps input responsive while still yielding the CPU; the
+/// skeleton has no live data, so the interval only bounds redraw latency.
+/// What: 50ms, matching the dashboard's input cadence.
+const KEY_POLL: Duration = Duration::from_millis(50);
+
+/// Launch the coordinator TUI against `url`.
+///
+/// Why: the `tm coordinator-tui` subcommand needs one entry point that owns the
+/// terminal lifecycle. Kept synchronous (no daemon IO in Child #1) so the
+/// caller does not need an async context for the skeleton.
+/// What: enters raw mode + the alternate screen, runs the event loop, and
+/// ALWAYS restores the terminal afterward — even if the loop returns an error —
+/// so a panic or early exit never leaves the operator's terminal corrupted.
+/// `url` and `interval_ms` are accepted now (and threaded into state via the
+/// signature) so Child #2 can wire live polling without a signature change.
+/// Test: terminal glue is exercised by launching the TUI; the loop's pure
+/// pieces (key dispatch, layout text) are unit-tested.
+pub fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
+    // `url` / `interval_ms` are not consumed by the skeleton (no live poll yet);
+    // logging them keeps the launch auditable and documents the deferred wiring.
+    tracing::info!(%url, interval_ms, "launching coordinator TUI (skeleton)");
+
+    enable_raw_mode()?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run_loop(&mut terminal);
+
+    // Always restore the terminal, even on error (panic-safe boundary).
+    let _ = disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let _ = terminal.show_cursor();
+    result
+}
+
+/// The skeleton render + input loop.
+///
+/// Why: kept separate from [`run`] so terminal setup/teardown wraps it cleanly
+/// and the loop body stays focused on draw → poll-key → dispatch.
+/// What: seeds [`CoordinatorState::skeleton`], then each iteration draws the
+/// frame, polls the keyboard for [`KEY_POLL`], dispatches any key via
+/// [`handle_key`], and exits once `should_exit` is set (`q` / Ctrl-C).
+/// Test: the dispatch and layout text are unit-tested; this terminal-bound loop
+/// is exercised by launching the TUI.
+fn run_loop(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> anyhow::Result<()> {
+    let mut state = CoordinatorState::skeleton();
+    loop {
+        terminal.draw(|frame| layout::render(frame, &state))?;
+
+        if event::poll(KEY_POLL)?
+            && let Event::Key(key) = event::read()?
+        {
+            handle_key(&mut state, key);
+            if state.should_exit {
+                return Ok(());
+            }
+        }
+    }
+}

--- a/crates/trusty-mpm/src/tui/coordinator/rows.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/rows.rs
@@ -1,0 +1,132 @@
+//! Pure row-builders for the coordinator session list.
+//!
+//! Why: the coordinator TUI renders one bullet for the controller plus one row
+//! per managed session, and the *selected* session expands into a two-column
+//! `[id] │ [summary]` line. Keeping the text/`Line` construction here — free of
+//! any terminal or daemon dependency — lets the list content be unit-tested
+//! exactly as the dashboard's `sidebar_items` are, satisfying the spec's
+//! "pure/unit (no terminal, no network)" test tier (DOC-13 §9).
+//! What: free functions that build ratatui [`Line`]s (and a couple of `String`
+//! helpers the tests assert on) for the controller bullet, a non-selected
+//! session row, and the selected two-column active row. No live data is wired
+//! here — Child #1 feeds these placeholder rows; Child #2/#3 swap in the live
+//! feed + real `last_summary`.
+//! Test: `super::tests` covers `controller_bullet_row`, `session_short_id`, and
+//! the two-column split via `active_row_two_col`.
+
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+/// The glyph drawn for the always-present controller bullet (row 0).
+///
+/// Why: the spec pins the controller as row 0 and always-active (`●`); a named
+/// constant keeps the glyph in one place so the controller and an active
+/// session render the same bullet.
+/// What: the filled-circle bullet `●`.
+/// Test: asserted in `controller_bullet_row` via the rendered span text.
+pub const CONTROLLER_GLYPH: char = '●';
+
+/// The glyph drawn for an idle / placeholder session row.
+///
+/// Why: non-active sessions use a hollow bullet (`○`) per the spec's bullet
+/// legend (§3.2); Child #2 maps real `SessionStatus` to colored glyphs, but the
+/// skeleton only needs the idle glyph for its placeholder rows.
+/// What: the hollow-circle bullet `○`.
+/// Test: asserted in `session_row_renders_bullet_and_prefix`.
+pub const SESSION_GLYPH: char = '○';
+
+/// The column separator drawn between a selected row's id and its summary.
+///
+/// Why: the spec's "active row" contract (§3.3) separates the short id from the
+/// last-summarized message with a `│` glyph; centralising it keeps the split
+/// rule and its unit test in agreement.
+/// What: the box-drawing vertical bar `│`.
+/// Test: asserted in `active_row_two_col_splits_on_bar`.
+pub const COLUMN_SEPARATOR: char = '│';
+
+/// Build the controller bullet line (always row 0 of the session list).
+///
+/// Why: the coordinator itself is represented by a pinned first row whose right
+/// half is a synthetic status (`idle · N delegations · ready`), distinct from a
+/// managed session. Rendering it through a dedicated builder keeps that contract
+/// explicit and testable without a terminal.
+/// What: returns a [`Line`] of `● controller   <status>`; when `selected` the
+/// whole line is bold/cyan to mirror the dashboard's selection highlight.
+/// Test: `controller_bullet_row` asserts the glyph, label, and status text.
+pub fn controller_bullet_row(status: &str, selected: bool) -> Line<'static> {
+    let bullet_style = Style::default().fg(Color::Green);
+    let label_style = if selected {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    };
+    Line::from(vec![
+        Span::styled(format!("{CONTROLLER_GLYPH} "), bullet_style),
+        Span::styled("controller", label_style),
+        Span::raw("   "),
+        Span::styled(status.to_string(), Style::default().fg(Color::DarkGray)),
+    ])
+}
+
+/// Build a non-selected managed-session row.
+///
+/// Why: rows beneath the controller show a hollow bullet, the session's short
+/// id, its routing prefix, and a dimmed one-line status — the compact form for
+/// every row that is not the active selection (§3.2).
+/// What: returns a [`Line`] of `○ <short-id> <prefix>   <status>` with the
+/// status dimmed.
+/// Test: `session_row_renders_bullet_and_prefix`.
+pub fn session_row(short_id: &str, prefix: &str, status: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{SESSION_GLYPH} "),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::styled(
+            format!("{short_id} "),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!("{prefix}   ")),
+        Span::styled(status.to_string(), Style::default().fg(Color::DarkGray)),
+    ])
+}
+
+/// Build the selected session's two-column active row: `[id] │ [summary]`.
+///
+/// Why: the headline feature of the coordinator list is that the *active* row
+/// expands to show what the session is doing. The summary source (daemon
+/// `last_summary`) lands in Child #3; Child #1 renders whatever placeholder
+/// summary it is handed so the column contract (§3.3) exists and is testable.
+/// What: returns a [`Line`] of `● <short-id> │ <summary>`, the whole row
+/// bold/cyan to mark it as the selection; the `│` separator is the single
+/// source of the column split.
+/// Test: `active_row_two_col_splits_on_bar`.
+pub fn active_row_two_col(short_id: &str, summary_placeholder: &str) -> Line<'static> {
+    let accent = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    Line::from(vec![
+        Span::styled(format!("{CONTROLLER_GLYPH} "), accent),
+        Span::styled(format!("{short_id} "), accent),
+        Span::styled(
+            format!("{COLUMN_SEPARATOR} "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(summary_placeholder.to_string(), accent),
+    ])
+}
+
+/// Truncate a session id to its short, human-readable 8-char form.
+///
+/// Why: the list's left column shows the first 8 hex chars of the UUID, not the
+/// full id (§3.3); a shared helper keeps the rule identical to the dashboard's
+/// `short_session` so the two surfaces never diverge.
+/// What: returns the first 8 characters of `id` (fewer if `id` is shorter).
+/// Test: `session_short_id_truncates`.
+pub fn session_short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}

--- a/crates/trusty-mpm/src/tui/coordinator/state.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/state.rs
@@ -1,0 +1,288 @@
+//! Coordinator TUI application state (Child #1 skeleton).
+//!
+//! Why: the render loop and the key dispatcher both read and mutate one piece
+//! of state — the input buffer, an input-history ring, the placeholder session
+//! rows, and which row is selected. Holding it in a single struct with pure,
+//! unit-testable mutators keeps the terminal glue thin and the selection /
+//! history logic verifiable without a terminal (DOC-13 §9).
+//! What: [`CoordinatorState`] plus its placeholder [`SessionEntry`] rows, the
+//! input-history ring, and [`CoordinatorState::clamp_selection`] /
+//! selection-movement helpers that mirror `DashboardState::clamp_selection`.
+//! Test: `super::tests` covers `clamp_selection` boundary cases (empty list,
+//! single row, selection past end) and the history ring.
+
+/// Maximum number of submitted inputs retained in the history ring.
+///
+/// Why: the input box recalls prior submissions with ↑/↓ (like the dashboard's
+/// `CommandBar`); bounding the ring keeps memory flat over a long session.
+/// What: the cap used by [`CoordinatorState::submit_input`].
+/// Test: `history_ring_is_bounded`.
+pub const INPUT_HISTORY_LIMIT: usize = 50;
+
+/// One placeholder session row shown beneath the controller bullet.
+///
+/// Why: Child #1 renders static rows so the layout, selection, and two-column
+/// active row can be exercised before the live feed lands (Child #2). Modelling
+/// the row now — id, routing prefix, status, placeholder summary — means the
+/// live feed later fills the *same* shape rather than reshaping the UI.
+/// What: a managed session's short id, its `@prefix:` routing prefix, a
+/// one-word status, and a placeholder summary for the active-row right column.
+/// Test: rows are consumed by the row-builders, themselves unit-tested.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEntry {
+    /// Short (8-hex) session id shown in the list's left column.
+    pub short_id: String,
+    /// Routing prefix (`aipowerranking`) shown after the id.
+    pub prefix: String,
+    /// One-word status word (`Active`, `Idle`, …) shown dimmed.
+    pub status: String,
+    /// Placeholder "last summarized message" for the active-row right column.
+    ///
+    /// Replaced by the daemon `last_summary` in Child #3.
+    pub summary: String,
+}
+
+impl SessionEntry {
+    /// Construct a placeholder session entry.
+    ///
+    /// Why: the skeleton seeds a couple of illustrative rows; a constructor
+    /// keeps that seeding terse and the field order explicit.
+    /// What: moves the four owned strings into a [`SessionEntry`].
+    /// Test: indirectly via `default_state_has_placeholder_rows`.
+    pub fn new(
+        short_id: impl Into<String>,
+        prefix: impl Into<String>,
+        status: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Self {
+        Self {
+            short_id: short_id.into(),
+            prefix: prefix.into(),
+            status: status.into(),
+            summary: summary.into(),
+        }
+    }
+}
+
+/// Everything the coordinator TUI renders and mutates this frame (skeleton).
+///
+/// Why: a single owned struct (like the dashboard's `DashboardState`) keeps the
+/// data/render split clean — the event loop mutates it, the layout reads it.
+/// What: the input buffer + history ring, the placeholder session rows, the
+/// selected row index (`0` = controller), and an `should_exit` flag the loop
+/// polls to leave on `q` / Ctrl-C.
+/// Test: `super::tests` covers selection clamp, movement, and history.
+#[derive(Debug, Clone, Default)]
+pub struct CoordinatorState {
+    /// The current input-box edit buffer.
+    pub input: String,
+    /// Submitted inputs, newest last, bounded by [`INPUT_HISTORY_LIMIT`].
+    pub history: Vec<String>,
+    /// Cursor into [`Self::history`] while recalling with ↑/↓; `None` = live.
+    history_cursor: Option<usize>,
+    /// Placeholder managed-session rows (Child #2 swaps in the live feed).
+    pub sessions: Vec<SessionEntry>,
+    /// Selected row index across the unified list (`0` = controller bullet).
+    pub selected: usize,
+    /// Set when the operator asks to quit; the event loop exits on the next tick.
+    pub should_exit: bool,
+}
+
+impl CoordinatorState {
+    /// Build the skeleton state with a couple of illustrative placeholder rows.
+    ///
+    /// Why: Child #1 has no daemon feed, but an empty list would make the
+    /// layout, selection movement, and two-column active row impossible to see
+    /// or test. Seeding static rows exercises the full UI path; Child #2
+    /// replaces them with `poll_daemon` output.
+    /// What: returns a [`CoordinatorState`] with two placeholder sessions and
+    /// the controller selected (row 0).
+    /// Test: `default_state_has_placeholder_rows`.
+    pub fn skeleton() -> Self {
+        Self {
+            sessions: vec![
+                SessionEntry::new(
+                    "4f9ca1b2",
+                    "aipowerranking",
+                    "Active",
+                    "Running tests — 12 passed, fixing flaky timeout",
+                ),
+                SessionEntry::new(
+                    "7b2ec0d1",
+                    "genealogy",
+                    "Idle",
+                    "Idle — last activity 6m ago",
+                ),
+            ],
+            ..Self::default()
+        }
+    }
+
+    /// Total number of selectable rows: the controller plus every session.
+    ///
+    /// Why: selection spans a unified list whose row 0 is always the controller
+    /// bullet, so bounds checks must account for that synthetic first row.
+    /// What: `1 + sessions.len()`.
+    /// Test: `clamp_selection_*` rely on this count implicitly.
+    pub fn row_count(&self) -> usize {
+        1 + self.sessions.len()
+    }
+
+    /// Clamp [`Self::selected`] into `0..row_count`.
+    ///
+    /// Why: the live list shrinks between polls (sessions end); a stale index
+    /// would render — and later index — out of bounds. Mirrors
+    /// `DashboardState::clamp_selection`, but over the controller-plus-sessions
+    /// row space so row 0 (the controller) is always valid.
+    /// What: pins `selected` to `row_count - 1`; `row_count` is always ≥ 1
+    /// because the controller row always exists, so the index never underflows.
+    /// Test: `clamp_selection_empty_list`, `clamp_selection_single_row`,
+    /// `clamp_selection_past_end`.
+    pub fn clamp_selection(&mut self) {
+        let max = self.row_count() - 1;
+        if self.selected > max {
+            self.selected = max;
+        }
+    }
+
+    /// Move the selection up one row (saturating at the controller, row 0).
+    ///
+    /// Why: ↑ / `k` move the highlight toward the controller.
+    /// What: decrements `selected`, saturating at 0.
+    /// Test: `selection_movement_saturates`.
+    pub fn select_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Move the selection down one row (saturating at the last session).
+    ///
+    /// Why: ↓ / `j` move the highlight toward the newest session.
+    /// What: increments `selected` while it is below the last row.
+    /// Test: `selection_movement_saturates`.
+    pub fn select_down(&mut self) {
+        let max = self.row_count() - 1;
+        if self.selected < max {
+            self.selected += 1;
+        }
+    }
+
+    /// True when the controller bullet (row 0) is the active selection.
+    ///
+    /// Why: the layout renders the controller's right column as a synthetic
+    /// status and a session's as its summary; the renderer branches on this.
+    /// What: `selected == 0`.
+    /// Test: `controller_is_selected_at_row_zero`.
+    pub fn controller_selected(&self) -> bool {
+        self.selected == 0
+    }
+
+    /// The session under the current selection, if a session (not the
+    /// controller) is selected.
+    ///
+    /// Why: the active-row two-column renderer and future focus/action paths
+    /// need the selected session; row 0 maps to the controller, so session
+    /// indices are offset by one.
+    /// What: returns `sessions[selected - 1]` when `selected > 0`, else `None`.
+    /// Test: `selected_session_offsets_by_controller_row`.
+    pub fn selected_session(&self) -> Option<&SessionEntry> {
+        self.selected
+            .checked_sub(1)
+            .and_then(|idx| self.sessions.get(idx))
+    }
+
+    /// Append a character to the input buffer (a printable keystroke).
+    ///
+    /// Why: typing builds the coordinator message; editing resets the recall
+    /// cursor so the next ↑ starts from the newest history entry.
+    /// What: pushes `c`; clears the history cursor.
+    /// Test: `input_edits_buffer`.
+    pub fn push_char(&mut self, c: char) {
+        self.input.push(c);
+        self.history_cursor = None;
+    }
+
+    /// Delete the last input character (Backspace).
+    ///
+    /// Why: Backspace edits a mistyped message.
+    /// What: pops the trailing char; clears the recall cursor.
+    /// Test: `input_edits_buffer`.
+    pub fn backspace(&mut self) {
+        self.input.pop();
+        self.history_cursor = None;
+    }
+
+    /// Clear the input buffer (Esc).
+    ///
+    /// Why: Esc abandons a half-typed message.
+    /// What: empties [`Self::input`]; clears the recall cursor.
+    /// Test: `input_edits_buffer`.
+    pub fn clear_input(&mut self) {
+        self.input.clear();
+        self.history_cursor = None;
+    }
+
+    /// Submit the current input: record it in history and return it, clearing
+    /// the buffer.
+    ///
+    /// Why: Enter submits. Child #1 only *echoes* the submission to history (no
+    /// daemon wiring yet); later children route it to the coordinator chat.
+    /// What: trims the buffer; when non-empty, pushes it onto the bounded
+    /// history ring (dropping the oldest beyond [`INPUT_HISTORY_LIMIT`]) and
+    /// returns `Some(text)`; an empty/whitespace buffer returns `None`. Always
+    /// clears the buffer and resets the recall cursor.
+    /// Test: `submit_records_history`, `history_ring_is_bounded`,
+    /// `submit_empty_input_is_noop`.
+    pub fn submit_input(&mut self) -> Option<String> {
+        let typed = std::mem::take(&mut self.input);
+        self.history_cursor = None;
+        let trimmed = typed.trim().to_string();
+        if trimmed.is_empty() {
+            return None;
+        }
+        self.history.push(trimmed.clone());
+        if self.history.len() > INPUT_HISTORY_LIMIT {
+            let overflow = self.history.len() - INPUT_HISTORY_LIMIT;
+            self.history.drain(0..overflow);
+        }
+        Some(trimmed)
+    }
+
+    /// Recall the previous (older) history entry into the input (↑).
+    ///
+    /// Why: re-sending or editing a recent message should not require retyping.
+    /// What: steps the recall cursor one entry toward the oldest and loads it;
+    /// a no-op when history is empty.
+    /// Test: `history_recall_walks_entries`.
+    pub fn history_prev(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+        let next = match self.history_cursor {
+            None => self.history.len() - 1,
+            Some(0) => 0,
+            Some(i) => i - 1,
+        };
+        self.history_cursor = Some(next);
+        self.input = self.history[next].clone();
+    }
+
+    /// Recall the next (newer) history entry into the input (↓).
+    ///
+    /// Why: lets the operator step back down after recalling too far with ↑.
+    /// What: advances the cursor toward the newest entry; stepping past the
+    /// newest clears the cursor and empties the buffer; a no-op when not
+    /// currently recalling.
+    /// Test: `history_recall_walks_entries`.
+    pub fn history_next(&mut self) {
+        let Some(i) = self.history_cursor else {
+            return;
+        };
+        if i + 1 >= self.history.len() {
+            self.history_cursor = None;
+            self.input.clear();
+        } else {
+            self.history_cursor = Some(i + 1);
+            self.input = self.history[i + 1].clone();
+        }
+    }
+}

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -268,6 +268,15 @@ fn parse_slash_ignores_plain_text() {
     assert_eq!(parse_slash(""), None);
 }
 
+#[test]
+fn parse_slash_bare_slash_is_not_a_command() {
+    // A lone `/` (or `/` followed only by whitespace) has no command word, so it
+    // must NOT classify as `Unknown("")` — it falls through to chat as `None`.
+    assert_eq!(parse_slash("/"), None);
+    assert_eq!(parse_slash("/   "), None);
+    assert_eq!(parse_slash("/\t"), None);
+}
+
 // ---- events: key dispatch -------------------------------------------------
 
 #[test]

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -1,0 +1,358 @@
+//! Unit tests for the coordinator TUI skeleton (Child #1).
+//!
+//! Why: the spec's pure/unit test tier (DOC-13 §9) requires the row-builders,
+//! the selection clamp, and the slash-command parse to be verified WITHOUT a
+//! terminal or a daemon. These tests exercise exactly that surface.
+//! What: covers row construction, `CoordinatorState` selection/history, the
+//! `parse_slash` stub (incl. leading-`/` detection), key dispatch branches, and
+//! the layout text helpers.
+//! Test: this IS the test module.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::events::{SlashCommand, handle_key, is_quit, parse_slash};
+use super::layout::{
+    CONTROLLER_STATUS, INPUT_PROMPT, STATUS_BAR_HINT, input_line, status_bar_text,
+};
+use super::rows::{
+    COLUMN_SEPARATOR, CONTROLLER_GLYPH, SESSION_GLYPH, active_row_two_col, controller_bullet_row,
+    session_row, session_short_id,
+};
+use super::state::{CoordinatorState, INPUT_HISTORY_LIMIT, SessionEntry};
+
+/// Render a ratatui `Line` to a flat string for content assertions.
+fn line_text(line: &ratatui::text::Line<'_>) -> String {
+    line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+// ---- rows -----------------------------------------------------------------
+
+#[test]
+fn controller_bullet_row_renders_glyph_label_and_status() {
+    let line = controller_bullet_row("idle · ready", false);
+    let text = line_text(&line);
+    assert!(
+        text.starts_with(CONTROLLER_GLYPH),
+        "expected leading bullet: {text}"
+    );
+    assert!(text.contains("controller"), "missing label: {text}");
+    assert!(text.contains("idle · ready"), "missing status: {text}");
+}
+
+#[test]
+fn controller_bullet_row_selected_is_still_well_formed() {
+    // The selected variant changes style, not text content.
+    let plain = line_text(&controller_bullet_row("ready", false));
+    let selected = line_text(&controller_bullet_row("ready", true));
+    assert_eq!(plain, selected);
+}
+
+#[test]
+fn session_row_renders_bullet_and_prefix() {
+    let text = line_text(&session_row("4f9ca1b2", "aipowerranking", "Active"));
+    assert!(
+        text.starts_with(SESSION_GLYPH),
+        "expected hollow bullet: {text}"
+    );
+    assert!(text.contains("4f9ca1b2"), "missing short id: {text}");
+    assert!(text.contains("aipowerranking"), "missing prefix: {text}");
+    assert!(text.contains("Active"), "missing status: {text}");
+}
+
+#[test]
+fn active_row_two_col_splits_on_bar() {
+    let text = line_text(&active_row_two_col("4f9ca1b2", "Running tests"));
+    assert!(
+        text.contains(COLUMN_SEPARATOR),
+        "missing column separator: {text}"
+    );
+    // The id is left of the bar, the summary right of it.
+    let (left, right) = text
+        .split_once(COLUMN_SEPARATOR)
+        .expect("a bar separator must be present");
+    assert!(left.contains("4f9ca1b2"), "id not in left column: {left}");
+    assert!(
+        right.contains("Running tests"),
+        "summary not in right column: {right}"
+    );
+}
+
+#[test]
+fn session_short_id_truncates() {
+    assert_eq!(session_short_id("4f9ca1b2deadbeef"), "4f9ca1b2");
+    // Shorter-than-8 ids are returned whole.
+    assert_eq!(session_short_id("abc"), "abc");
+    assert_eq!(session_short_id(""), "");
+}
+
+// ---- state: selection clamp (boundary cases) ------------------------------
+
+#[test]
+fn clamp_selection_empty_list() {
+    // Empty session list: only the controller row exists (row 0).
+    let mut state = CoordinatorState::default();
+    assert_eq!(state.row_count(), 1);
+    state.selected = 9;
+    state.clamp_selection();
+    assert_eq!(state.selected, 0, "clamp to the sole controller row");
+}
+
+#[test]
+fn clamp_selection_single_row() {
+    // Controller + exactly one session → valid indices are 0 and 1.
+    let mut state = CoordinatorState::default();
+    state
+        .sessions
+        .push(SessionEntry::new("id", "p", "Active", "s"));
+    assert_eq!(state.row_count(), 2);
+    state.selected = 1;
+    state.clamp_selection();
+    assert_eq!(state.selected, 1, "valid selection is preserved");
+    state.selected = 5;
+    state.clamp_selection();
+    assert_eq!(state.selected, 1, "past-end clamps to last session");
+}
+
+#[test]
+fn clamp_selection_past_end() {
+    let mut state = CoordinatorState::skeleton(); // controller + 2 sessions
+    assert_eq!(state.row_count(), 3);
+    state.selected = 99;
+    state.clamp_selection();
+    assert_eq!(state.selected, 2, "clamps to the last valid row index");
+}
+
+#[test]
+fn selection_movement_saturates() {
+    let mut state = CoordinatorState::skeleton(); // rows 0..=2
+    state.select_up(); // already at 0
+    assert_eq!(state.selected, 0);
+    state.select_down();
+    assert_eq!(state.selected, 1);
+    state.select_down();
+    assert_eq!(state.selected, 2);
+    state.select_down(); // saturates at last
+    assert_eq!(state.selected, 2);
+    state.select_up();
+    assert_eq!(state.selected, 1);
+}
+
+#[test]
+fn controller_is_selected_at_row_zero() {
+    let mut state = CoordinatorState::skeleton();
+    assert!(state.controller_selected());
+    state.selected = 1;
+    assert!(!state.controller_selected());
+}
+
+#[test]
+fn selected_session_offsets_by_controller_row() {
+    let mut state = CoordinatorState::skeleton();
+    assert!(
+        state.selected_session().is_none(),
+        "row 0 is the controller"
+    );
+    state.selected = 1;
+    assert_eq!(state.selected_session().unwrap().prefix, "aipowerranking");
+    state.selected = 2;
+    assert_eq!(state.selected_session().unwrap().prefix, "genealogy");
+}
+
+#[test]
+fn default_state_has_placeholder_rows() {
+    let state = CoordinatorState::skeleton();
+    assert_eq!(state.sessions.len(), 2);
+    assert_eq!(state.selected, 0);
+}
+
+// ---- state: input + history ring ------------------------------------------
+
+#[test]
+fn input_edits_buffer() {
+    let mut state = CoordinatorState::default();
+    state.push_char('h');
+    state.push_char('i');
+    assert_eq!(state.input, "hi");
+    state.backspace();
+    assert_eq!(state.input, "h");
+    state.clear_input();
+    assert!(state.input.is_empty());
+}
+
+#[test]
+fn submit_records_history() {
+    let mut state = CoordinatorState::default();
+    state.input = "  status please  ".to_string();
+    let submitted = state.submit_input();
+    assert_eq!(
+        submitted.as_deref(),
+        Some("status please"),
+        "trims and returns"
+    );
+    assert_eq!(state.history, vec!["status please".to_string()]);
+    assert!(state.input.is_empty(), "buffer cleared after submit");
+}
+
+#[test]
+fn submit_empty_input_is_noop() {
+    let mut state = CoordinatorState::default();
+    state.input = "   ".to_string();
+    assert!(state.submit_input().is_none());
+    assert!(state.history.is_empty());
+}
+
+#[test]
+fn history_ring_is_bounded() {
+    let mut state = CoordinatorState::default();
+    for i in 0..(INPUT_HISTORY_LIMIT + 5) {
+        state.input = format!("msg{i}");
+        let _ = state.submit_input();
+    }
+    assert_eq!(state.history.len(), INPUT_HISTORY_LIMIT, "ring is capped");
+    // Oldest entries were evicted; the newest is retained.
+    assert_eq!(
+        state.history.last().unwrap(),
+        &format!("msg{}", INPUT_HISTORY_LIMIT + 4)
+    );
+    assert_eq!(state.history.first().unwrap(), "msg5", "oldest dropped");
+}
+
+#[test]
+fn history_recall_walks_entries() {
+    let mut state = CoordinatorState::default();
+    for m in ["one", "two", "three"] {
+        state.input = m.to_string();
+        let _ = state.submit_input();
+    }
+    state.history_prev();
+    assert_eq!(state.input, "three");
+    state.history_prev();
+    assert_eq!(state.input, "two");
+    state.history_next();
+    assert_eq!(state.input, "three");
+    state.history_next();
+    assert!(state.input.is_empty(), "stepping past newest clears buffer");
+}
+
+// ---- events: slash parsing (the stub) -------------------------------------
+
+#[test]
+fn parse_slash_recognises_known_commands() {
+    assert_eq!(parse_slash("/help"), Some(SlashCommand::Help));
+    assert_eq!(parse_slash("/new repo=x"), Some(SlashCommand::New));
+    assert_eq!(parse_slash("/sessions"), Some(SlashCommand::Sessions));
+    assert_eq!(parse_slash("/attach"), Some(SlashCommand::Attach));
+    assert_eq!(parse_slash("/stop"), Some(SlashCommand::Stop));
+    assert_eq!(parse_slash("/resume"), Some(SlashCommand::Resume));
+    assert_eq!(parse_slash("/kill"), Some(SlashCommand::Kill));
+    // Case-insensitive on the verb.
+    assert_eq!(parse_slash("/HELP"), Some(SlashCommand::Help));
+}
+
+#[test]
+fn parse_slash_classifies_unknown() {
+    assert_eq!(
+        parse_slash("/frobnicate now"),
+        Some(SlashCommand::Unknown("frobnicate".to_string()))
+    );
+}
+
+#[test]
+fn parse_slash_ignores_plain_text() {
+    assert_eq!(parse_slash("hello there"), None);
+    assert_eq!(parse_slash("@aipowerranking: run tests"), None);
+    assert_eq!(parse_slash(""), None);
+}
+
+// ---- events: key dispatch -------------------------------------------------
+
+#[test]
+fn quit_on_q_when_empty() {
+    assert!(is_quit(&key(KeyCode::Char('q')), true));
+    let mut state = CoordinatorState::skeleton();
+    handle_key(&mut state, key(KeyCode::Char('q')));
+    assert!(state.should_exit);
+}
+
+#[test]
+fn quit_on_ctrl_c() {
+    let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+    assert!(is_quit(&ctrl_c, true));
+    assert!(is_quit(&ctrl_c, false), "Ctrl-C quits even mid-message");
+    let mut state = CoordinatorState::default();
+    state.input = "typing".to_string();
+    handle_key(&mut state, ctrl_c);
+    assert!(state.should_exit);
+}
+
+#[test]
+fn q_in_message_is_not_quit() {
+    assert!(!is_quit(&key(KeyCode::Char('q')), false));
+    let mut state = CoordinatorState::default();
+    state.input = "fi".to_string();
+    handle_key(&mut state, key(KeyCode::Char('q')));
+    assert!(!state.should_exit, "q is editing text, not quitting");
+    assert_eq!(state.input, "fiq");
+}
+
+#[test]
+fn handle_key_moves_selection_when_input_empty() {
+    let mut state = CoordinatorState::skeleton();
+    handle_key(&mut state, key(KeyCode::Down));
+    assert_eq!(state.selected, 1);
+    handle_key(&mut state, key(KeyCode::Char('j')));
+    assert_eq!(state.selected, 2);
+    handle_key(&mut state, key(KeyCode::Char('k')));
+    assert_eq!(state.selected, 1);
+    handle_key(&mut state, key(KeyCode::Up));
+    assert_eq!(state.selected, 0);
+}
+
+#[test]
+fn handle_key_enter_submits_and_returns_line() {
+    let mut state = CoordinatorState::default();
+    state.input = "spin up a session".to_string();
+    let submitted = handle_key(&mut state, key(KeyCode::Enter));
+    assert_eq!(submitted.as_deref(), Some("spin up a session"));
+    assert_eq!(state.history.len(), 1);
+}
+
+#[test]
+fn handle_key_up_recalls_history_when_input_nonempty() {
+    let mut state = CoordinatorState::default();
+    state.input = "earlier".to_string();
+    let _ = state.submit_input();
+    // Type something, then ↑ should recall history rather than move selection.
+    state.push_char('x');
+    handle_key(&mut state, key(KeyCode::Up));
+    assert_eq!(state.input, "earlier");
+}
+
+// ---- layout text ----------------------------------------------------------
+
+#[test]
+fn input_line_shows_prompt_and_cursor() {
+    let mut state = CoordinatorState::default();
+    state.input = "hi".to_string();
+    let line = input_line(&state);
+    assert!(line.starts_with(INPUT_PROMPT), "missing prompt: {line}");
+    assert!(line.ends_with('_'), "missing cursor glyph: {line}");
+    assert!(line.contains("hi"));
+}
+
+#[test]
+fn status_bar_lists_keys() {
+    let bar = status_bar_text();
+    assert_eq!(bar, STATUS_BAR_HINT);
+    assert!(bar.contains("/help"));
+    assert!(bar.contains("quit"));
+}
+
+#[test]
+fn controller_status_is_synthetic() {
+    assert!(CONTROLLER_STATUS.contains("ready"));
+}

--- a/crates/trusty-mpm/src/tui/mod.rs
+++ b/crates/trusty-mpm/src/tui/mod.rs
@@ -13,6 +13,7 @@
 //! client; `trusty-mpm tui` launches the live dashboard.
 
 pub mod client;
+pub mod coordinator;
 pub mod dashboard;
 mod event_loop;
 pub mod health;


### PR DESCRIPTION
Child #1 of the Session Manager TUI epic — new `tui/coordinator/` skeleton screen (input box top, session list with controller pinned row 0, status bar bottom) and a `tm coordinator-tui` subcommand (named to avoid the existing `tm coordinator` SM-chat alias). Static/placeholder data; 31 unit tests for row-builders/selection/slash-parse. Deferred to later children: live session-list polling (#2), the daemon-backed `last_summary` right column needing a new SessionSummary field (#3), and `/new`//stop//focus action dispatch (#4/#5) — leading `/` is parsed into a stubbed enum but not wired to the daemon. Blockers #1268/#1269 confirmed closed. Use `Refs #1272` (do NOT close the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)