### PR TITLE
feat(trusty-mpm): wire trusty-code ToolRegistry into tm meta run (WI-2, refs #1045)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10992,6 +10992,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "trusty-code",
  "trusty-common",
  "trusty-review",
  "utoipa",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -162,6 +162,11 @@ libc.workspace = true
 # Portable executable lookup on PATH (replaces the non-portable `which` shell-out
 # in the tcode runtime adapter's availability probe — see #1213).
 which.workspace = true
+# trusty-code: in-process agent runtime (Seam A). The standalone metaharness
+# (`tm meta run`, #1045) reuses tcode's tool system — ToolRegistry plus the
+# fs/bash/delegate tools — to drive PM → sub-agent delegation without the daemon
+# or the `claude` CLI. Always-on because the `meta` subcommand is part of `cli`.
+trusty-code = { workspace = true }
 
 # ── Optional dependencies (feature-gated) ────────────────────────────────────
 

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
@@ -1,20 +1,23 @@
-//! `meta` command handler — standalone metaharness bootstrap (#1045, WI-1).
+//! `meta` command handler — standalone metaharness bootstrap (#1045, WI-1/WI-2).
 //!
 //! Why: issue #1045 builds an M1 POC metaharness that boots without the
 //! trusty-mpm daemon or the `claude` CLI and drives PM → sub-agent delegation
-//! in-process via trusty-code (Seam A). WI-1 is the bootstrap skeleton: it
-//! stands up the `meta run` entry point — argument validation, structured
-//! logging, and a placeholder run summary — so later work items (the
-//! trusty-code facade, instruction loading, the orchestrator, live OpenRouter
-//! inference, and transcript capture) have a wired, exercisable scaffold to
-//! build on. The actual delegation loop is intentionally NOT implemented here.
+//! in-process via trusty-code (Seam A). WI-1 stood up the `meta run` entry point
+//! (argument validation, structured logging, a placeholder run summary). WI-2
+//! wires a trusty-code [`ToolRegistry`](trusty_code::tools::ToolRegistry) into
+//! that path so the (future) PM loop has the fs/bash/delegate capabilities it
+//! will offer the model. Live LLM inference, real delegation, and transcript
+//! capture remain intentionally unimplemented here (WI-3..WI-8).
 //! What: [`meta`] dispatches `MetaAction`; [`run`] validates the `--project`
-//! path, emits structured tracing, prints a human-readable "not yet
-//! implemented" notice to stderr, and writes a JSON summary to stdout. Pure
-//! helpers ([`resolve_project`], [`bootstrap_summary`]) carry the testable
-//! logic so unit tests need no stdout capture or live runtime.
-//! Test: `meta_*` unit tests in this module's `tests` block; CLI parsing in
-//! `tests.rs` (`cli_parses_meta_run*`).
+//! path, builds the metaharness tool registry, logs the registered tool names,
+//! and writes a JSON summary (including the tool list) to stdout. Pure helpers
+//! ([`resolve_project`], [`wi2_summary`]) carry the testable logic so unit tests
+//! need no stdout capture or live runtime; registry assembly lives in the
+//! [`registry`] submodule.
+//! Test: `meta_*` unit tests in this module's `tests` block; registry tests in
+//! `registry::tests`; CLI parsing in `tests.rs` (`cli_parses_meta_run*`).
+
+mod registry;
 
 use std::path::{Path, PathBuf};
 
@@ -22,17 +25,18 @@ use anyhow::Context as _;
 use serde_json::json;
 use tracing::{info, warn};
 
+use self::registry::{build_meta_registry, registry_tool_names};
 use crate::cli::MetaAction;
 
-/// Status string stamped into the WI-1 bootstrap run summary.
+/// Status string stamped into the WI-2 run summary.
 ///
 /// Why: the summary `status` is a magic string consumed by tests (and,
 /// eventually, by tooling that scrapes `meta run` output); centralising it
 /// keeps the producer and every assertion in lockstep.
-/// What: the literal `"bootstrap"` — signalling that this run exercised only the
-/// WI-1 scaffold and performed no real delegation.
-/// Test: `meta_bootstrap_summary_reports_status` asserts the emitted value.
-pub(crate) const STATUS_BOOTSTRAP: &str = "bootstrap";
+/// What: the literal `"wi2"` — signalling that this run assembled the tool
+/// registry but performed no real delegation or LLM inference yet.
+/// Test: `meta_wi2_summary_reports_status` asserts the emitted value.
+pub(crate) const STATUS_WI2: &str = "wi2";
 
 /// `meta` subcommand dispatcher — route a parsed [`MetaAction`] to its handler.
 ///
@@ -48,35 +52,41 @@ pub(crate) fn meta(action: MetaAction) -> anyhow::Result<()> {
     }
 }
 
-/// Execute one `meta run` invocation (WI-1: bootstrap skeleton only).
+/// Execute one `meta run` invocation (WI-2: tool registry wiring).
 ///
-/// Why: this is the harness's primary entry point. WI-1 must make the scaffold
-/// exercisable end-to-end — validate inputs, log via the shared tracing setup,
-/// and emit a machine-readable summary — without implementing the (deferred)
-/// trusty-code delegation loop. Returning `Ok(())` on the happy path lets the
-/// demo command exit 0 so the scaffold can be smoke-tested.
+/// Why: this is the harness's primary entry point. WI-2 extends the WI-1
+/// scaffold by assembling the trusty-code [`ToolRegistry`] the (future) PM loop
+/// will offer the model — proving the fs/bash/delegate tools wire together —
+/// without yet implementing real delegation or live LLM inference. Returning
+/// `Ok(())` on the happy path lets the demo command exit 0 so the scaffold stays
+/// smoke-testable.
 /// What: initialises stderr tracing (idempotent, honours `RUST_LOG`), resolves
-/// and validates `--project` to an existing absolute path, prints a clear
-/// "not yet implemented — WI-1 bootstrap" notice to stderr, and writes the
-/// [`bootstrap_summary`] JSON object to stdout.
+/// and validates `--project` to an existing absolute path, builds the
+/// metaharness registry scoped to that project, logs the registered tool names
+/// at info level (stderr), and writes the [`wi2_summary`] JSON object (including
+/// the tool list) to stdout.
 /// Test: `meta_run_demo_succeeds_for_existing_project`,
 /// `meta_run_errors_on_missing_project` exercise the validation + happy paths.
 pub(crate) fn run(demo: bool, project: Option<PathBuf>) -> anyhow::Result<()> {
     init_meta_tracing();
 
     let project = resolve_project(project)?;
+    let registry = build_meta_registry(&project);
+    let tools = registry_tool_names(&registry);
+
     info!(
         demo,
         project = %project.display(),
-        "meta run: bootstrap scaffold (WI-1) — no delegation performed yet"
+        tools = ?tools,
+        "meta run: WI-2 tool registry assembled — no delegation performed yet"
     );
     warn!(
-        "`tm meta run` is not yet implemented — WI-1 bootstrap only; \
-         the trusty-code delegation loop, fs/bash tools, and live LLM \
-         inference arrive in later work items (#1045 WI-2..WI-8)"
+        "`tm meta run` is WI-2 (tool registry wiring) — real sub-agent \
+         delegation and live LLM inference arrive in later work items \
+         (#1045 WI-3..WI-8); the registered delegate tool uses a stub runner"
     );
 
-    let summary = bootstrap_summary(demo, &project);
+    let summary = wi2_summary(demo, &project, &tools);
     // stdout carries the machine-readable run summary (the human notice went to
     // stderr above), so downstream tooling can parse `meta run` output cleanly.
     println!("{}", serde_json::to_string(&summary)?);
@@ -105,26 +115,31 @@ pub(crate) fn resolve_project(project: Option<PathBuf>) -> anyhow::Result<PathBu
     Ok(resolved)
 }
 
-/// Build the WI-1 bootstrap run summary as a JSON object.
+/// Build the WI-2 run summary as a JSON object.
 ///
-/// Why: `meta run` emits a single machine-readable line so the (eventual) run
-/// summary has a stable shape from the very first work item; isolating its
-/// construction keeps it unit-testable without stdout capture.
-/// What: returns `{"status":"bootstrap","demo":<bool>,"project":"<abs path>"}`.
-/// Test: `meta_bootstrap_summary_reports_status`,
-/// `meta_bootstrap_summary_carries_demo_and_project`.
-pub(crate) fn bootstrap_summary(demo: bool, project: &Path) -> serde_json::Value {
+/// Why: `meta run` emits a single machine-readable line so the run summary has a
+/// stable shape across work items; isolating its construction keeps it
+/// unit-testable without stdout capture. WI-2 enriches the WI-1 shape with the
+/// registered tool list so downstream tooling can confirm the harness offered
+/// the expected capabilities.
+/// What: returns
+/// `{"status":"wi2","demo":<bool>,"project":"<abs path>","tools":[<names>]}`,
+/// where `tools` is the (sorted) list of registered tool names.
+/// Test: `meta_wi2_summary_reports_status`,
+/// `meta_wi2_summary_carries_demo_project_and_tools`.
+pub(crate) fn wi2_summary(demo: bool, project: &Path, tools: &[String]) -> serde_json::Value {
     json!({
-        "status": STATUS_BOOTSTRAP,
+        "status": STATUS_WI2,
         "demo": demo,
         "project": project.display().to_string(),
+        "tools": tools,
     })
 }
 
 /// Initialise stderr tracing for the short-lived `meta run` invocation.
 ///
 /// Why: short-lived `tm` subcommands skip the daemon's subscriber init, but
-/// WI-1 requires structured logging that honours `RUST_LOG`. Using `try_init`
+/// the metaharness requires structured logging that honours `RUST_LOG`. Using `try_init`
 /// keeps this idempotent — it silently no-ops if a global subscriber is already
 /// installed (e.g. under a test harness), satisfying the workspace's "no global
 /// state except the idempotent tracing subscriber" rule.
@@ -175,16 +190,49 @@ mod tests {
     }
 
     #[test]
-    fn meta_bootstrap_summary_reports_status() {
-        let summary = bootstrap_summary(true, Path::new("/tmp"));
-        assert_eq!(summary["status"], STATUS_BOOTSTRAP);
+    fn meta_wi2_summary_reports_status() {
+        let tools = vec!["bash".to_string()];
+        let summary = wi2_summary(true, Path::new("/tmp"), &tools);
+        assert_eq!(summary["status"], STATUS_WI2);
     }
 
     #[test]
-    fn meta_bootstrap_summary_carries_demo_and_project() {
-        let summary = bootstrap_summary(false, Path::new("/work/p"));
+    fn meta_wi2_summary_carries_demo_project_and_tools() {
+        let tools = vec!["bash".to_string(), "read_file".to_string()];
+        let summary = wi2_summary(false, Path::new("/work/p"), &tools);
         assert_eq!(summary["demo"], false);
         assert_eq!(summary["project"], "/work/p");
+        assert_eq!(summary["tools"], json!(["bash", "read_file"]));
+    }
+
+    #[test]
+    fn meta_run_demo_emits_expected_tool_list() {
+        // The full registry-backed run over an existing project must list every
+        // metaharness tool in its summary — guards the run()→registry wiring.
+        let tmp = std::env::temp_dir();
+        let registry = build_meta_registry(&tmp);
+        let tools = registry_tool_names(&registry);
+        assert_eq!(
+            tools,
+            vec![
+                "bash".to_string(),
+                "delegate_to_agent".to_string(),
+                "edit".to_string(),
+                "read_file".to_string(),
+                "write_file".to_string(),
+            ]
+        );
+        let summary = wi2_summary(true, &tmp, &tools);
+        assert_eq!(
+            summary["tools"],
+            json!([
+                "bash",
+                "delegate_to_agent",
+                "edit",
+                "read_file",
+                "write_file"
+            ])
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/registry.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/registry.rs
@@ -1,0 +1,181 @@
+//! Tool registry assembly for the standalone metaharness (#1045, WI-2).
+//!
+//! Why: the M1 metaharness drives PM → sub-agent delegation in-process via
+//! trusty-code (Seam A). Before the orchestrator (WI-4) and live LLM inference
+//! can run, `meta run` needs a populated [`ToolRegistry`] so the (future) PM
+//! loop has the fs/bash/delegate capabilities it will offer the model. WI-2
+//! stands up that registry — the wiring is real, but the delegation runner is a
+//! stub: actual sub-agent execution arrives in WI-4. Keeping the assembly in its
+//! own submodule keeps `meta/mod.rs` focused on the CLI verb and stays well
+//! under the SLOC cap.
+//! What: [`NoopAgentRunner`] is a placeholder [`AgentRunner`] whose `run`
+//! returns a fixed stub message (no real delegation yet);
+//! [`build_meta_registry`] constructs a [`ToolRegistry`] populated with the
+//! trusty-code fs tools (`read_file`, `write_file`, `edit`), the `bash` tool,
+//! and the `delegate_to_agent` tool backed by the stub runner.
+//! Test: `registry_contains_expected_tools` and `noop_runner_returns_stub` in
+//! this module's `tests` block.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use trusty_code::tools::{
+    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, ReadFileTool, ToolRegistry,
+    WriteFileTool,
+};
+
+/// Placeholder text returned by [`NoopAgentRunner::run`] until WI-4 lands.
+///
+/// Why: the `delegate_to_agent` tool requires a concrete [`AgentRunner`], but
+/// WI-2's scope stops short of real sub-agent execution. Centralising the stub
+/// string keeps the producer and the unit-test assertion in lockstep.
+/// What: the literal message the stub runner echoes back as its agent output.
+/// Test: `noop_runner_returns_stub` asserts the emitted value.
+pub(crate) const NOOP_RUNNER_STUB: &str = "stub: WI-4 will implement real delegation";
+
+/// Stub [`AgentRunner`] for the WI-2 metaharness registry.
+///
+/// Why: [`DelegateToAgentTool`] needs an injected [`AgentRunner`], yet WI-2 must
+/// not perform live delegation (that is WI-4). This no-op runner lets the
+/// delegate tool register and be exercised structurally without spawning agents
+/// or calling an LLM.
+/// What: a zero-sized type implementing [`AgentRunner`]; `run` ignores its
+/// arguments and returns a fixed-content [`AgentOutput`].
+/// Test: `noop_runner_returns_stub` calls `run` and asserts the stub content;
+/// `registry_contains_expected_tools` proves it wires into the registry.
+pub(crate) struct NoopAgentRunner;
+
+#[async_trait]
+impl AgentRunner for NoopAgentRunner {
+    /// Return the fixed WI-2 stub output instead of running a sub-agent.
+    ///
+    /// Why: WI-2 wires the delegate tool without live delegation; a deterministic
+    /// stub keeps the path exercisable and unit-testable.
+    /// What: ignores `agent_name`/`task` and returns
+    /// `AgentOutput::from_content(NOOP_RUNNER_STUB)`.
+    /// Test: `noop_runner_returns_stub`.
+    async fn run(&self, _agent_name: &str, _task: &str) -> Result<AgentOutput> {
+        Ok(AgentOutput::from_content(NOOP_RUNNER_STUB))
+    }
+}
+
+/// Build the metaharness [`ToolRegistry`] scoped to `project`.
+///
+/// Why: the metaharness PM loop (WI-4) offers the model a fixed capability set —
+/// file read/write/edit, shell, and sub-agent delegation. Assembling that set in
+/// one place gives later work items a single, tested entry point and lets WI-2
+/// verify the wiring before any orchestration exists.
+/// What: constructs a [`ToolRegistry`] and registers [`ReadFileTool`],
+/// [`WriteFileTool`], and [`EditTool`] (each scoped to `project`), a default
+/// [`BashTool`], and a [`DelegateToAgentTool`] backed by [`NoopAgentRunner`].
+/// The fs tools are scoped to `project` so file operations stay inside the
+/// run's working directory.
+/// Test: `registry_contains_expected_tools` asserts every expected tool name is
+/// registered.
+pub(crate) fn build_meta_registry(project: &Path) -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    registry.register(Arc::new(ReadFileTool::new(project)));
+    registry.register(Arc::new(WriteFileTool::new(project)));
+    registry.register(Arc::new(EditTool::new(project)));
+    registry.register(Arc::new(BashTool::default_config()));
+    registry.register(Arc::new(DelegateToAgentTool::new(Arc::new(
+        NoopAgentRunner,
+    ))));
+    registry
+}
+
+/// Sorted list of tool names registered by [`build_meta_registry`].
+///
+/// Why: both the structured run summary (stdout JSON) and the info-level log
+/// line need a stable, deterministic ordering of the registered tools; the
+/// registry's underlying `HashMap` does not guarantee order, so callers must
+/// sort. Centralising the projection keeps the summary and the log consistent.
+/// What: returns the registered schema function names sorted lexicographically.
+/// Test: `registry_tool_names_are_sorted_and_complete`.
+pub(crate) fn registry_tool_names(registry: &ToolRegistry) -> Vec<String> {
+    let mut names: Vec<String> = registry
+        .schemas()
+        .into_iter()
+        .filter_map(|s| {
+            s.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `build_meta_registry` registers every expected metaharness tool.
+    ///
+    /// Why: the registry is the contract WI-4 builds on; a missing tool would
+    /// silently strip a capability from the PM loop.
+    /// What: builds the registry over a temp project dir and asserts each tool
+    /// name (`bash`, `read_file`, `write_file`, `edit`, `delegate_to_agent`) is
+    /// registered via `contains`.
+    /// Test: this test.
+    #[test]
+    fn registry_contains_expected_tools() {
+        let project = std::env::temp_dir();
+        let registry = build_meta_registry(&project);
+        assert!(registry.contains("bash"), "bash must be registered");
+        assert!(
+            registry.contains("read_file"),
+            "read_file must be registered"
+        );
+        assert!(
+            registry.contains("write_file"),
+            "write_file must be registered"
+        );
+        assert!(registry.contains("edit"), "edit must be registered");
+        assert!(
+            registry.contains("delegate_to_agent"),
+            "delegate_to_agent must be registered"
+        );
+    }
+
+    /// `registry_tool_names` returns the complete tool set in sorted order.
+    ///
+    /// Why: the summary JSON and log line depend on a deterministic ordering;
+    /// this guards both the contents and the sort.
+    /// What: asserts the projected names equal the expected sorted list.
+    /// Test: this test.
+    #[test]
+    fn registry_tool_names_are_sorted_and_complete() {
+        let project = std::env::temp_dir();
+        let registry = build_meta_registry(&project);
+        let names = registry_tool_names(&registry);
+        assert_eq!(
+            names,
+            vec![
+                "bash".to_string(),
+                "delegate_to_agent".to_string(),
+                "edit".to_string(),
+                "read_file".to_string(),
+                "write_file".to_string(),
+            ]
+        );
+    }
+
+    /// `NoopAgentRunner::run` returns the fixed WI-2 stub output.
+    ///
+    /// Why: confirms the placeholder runner behaves deterministically and does
+    /// not accidentally perform real work before WI-4.
+    /// What: calls `run` with arbitrary args; asserts content equals the stub.
+    /// Test: this test.
+    #[tokio::test]
+    async fn noop_runner_returns_stub() {
+        let out = NoopAgentRunner
+            .run("engineer", "write a file")
+            .await
+            .expect("noop runner never errors");
+        assert_eq!(out.content, NOOP_RUNNER_STUB);
+    }
+}


### PR DESCRIPTION
WI-2 of the M1 metaharness epic — `build_meta_registry()` registers trusty-code's ReadFileTool/WriteFileTool/EditTool/BashTool + DelegateToAgentTool (backed by a NoopAgentRunner stub; real delegation is WI-4). `tm meta run` now emits `{"status":"wi2","tools":[...]}`. WI-3 (#1031/#1032) and WI-4 (#1028/#1029/#1030) remain blocked on open trusty-code deps and were not touched. Use `Refs #1045` (do NOT close the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)