### PR TITLE
feat(trusty-code): Provider trait + ModelAdapter factory + per-agent model routing (refs #1021)

### DIFF
--- a/crates/trusty-code/src/agents/config.rs
+++ b/crates/trusty-code/src/agents/config.rs
@@ -79,7 +79,10 @@ pub struct AgentInfo {
 
 /// LLM parameters for a single agent.
 ///
-/// Why: Each agent may need different temperature, token budget, or provider.
+/// Why: Each agent may need different temperature, token budget, or model. The
+/// backend (OpenRouter vs. Bedrock) is no longer a boolean here — it is derived
+/// from the resolved model slug by `provider::provider_for` (#1021), so a single
+/// slug like `bedrock/...` selects the backend without a separate flag.
 /// What: Standard LLM knobs, all optional with sensible defaults.
 /// Test: `agent_config_llm_params`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -90,9 +93,6 @@ pub struct LlmParams {
     /// Maximum tokens in the LLM response.
     #[serde(default)]
     pub max_tokens: Option<u32>,
-    /// Route directly to Anthropic API instead of OpenRouter.
-    #[serde(default)]
-    pub use_anthropic_direct: bool,
     /// Model override at the `[llm]` level (lower precedence than `[agent].model`).
     #[serde(default)]
     pub model_override: Option<String>,

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -169,6 +169,17 @@ pub mod identity;
 /// Test: `logging::tests::*`.
 pub mod logging;
 
+/// Provider abstraction and per-agent model routing.
+///
+/// Why: Each agent routes to its own model, possibly behind a different backend
+/// (OpenRouter today, AWS Bedrock later). The agent loop depends on the
+/// `Provider` trait rather than branching on the backend, and a factory maps a
+/// model slug to the right implementation.
+/// What: `Provider`, `ToolChoice`, `OpenRouterProvider`, `BedrockProvider`,
+/// `provider_for`, `resolve_model`, `DEFAULT_MODEL`.
+/// Test: `provider::*` submodule tests.
+pub mod provider;
+
 // ── Phase 4 orchestration layer (per #1028) ──
 
 /// Multi-turn agent loop driving an LLM through tool calls to completion.

--- a/crates/trusty-code/src/provider/adapter.rs
+++ b/crates/trusty-code/src/provider/adapter.rs
@@ -1,0 +1,89 @@
+//! Model-adapter factory — maps a model slug to a concrete [`Provider`].
+//!
+//! Why: The agent loop holds a model slug and needs the matching backend
+//! behaviour (tool-choice mapping, usage extraction). A single factory keeps the
+//! slug→provider decision in one place instead of scattering `if slug.starts_with`
+//! branches across the loop (#1021).
+//! What: [`provider_for`] returns an `Arc<dyn Provider>` — [`BedrockProvider`]
+//! for `bedrock/*` slugs and [`OpenRouterProvider`] for everything else.
+//! Test: `adapter::tests::*`.
+
+use std::sync::Arc;
+
+use super::bedrock::BedrockProvider;
+use super::openrouter::OpenRouterProvider;
+use super::traits::Provider;
+
+/// Slug prefix that routes to the Bedrock backend.
+const BEDROCK_PREFIX: &str = "bedrock/";
+
+/// Select the provider implementation for a model slug.
+///
+/// Why: The loop must stay backend-agnostic; this factory is the only place that
+/// knows how to map a slug to a backend, so adding a backend touches one site.
+/// What: Returns [`BedrockProvider`] for slugs beginning with `bedrock/`, and
+/// the default [`OpenRouterProvider`] (carrying the slug for its
+/// `supports_native_tools` decision) for everything else.
+/// Test: `adapter::tests::provider_for_routes_*`.
+pub fn provider_for(slug: &str) -> Arc<dyn Provider> {
+    if slug.starts_with(BEDROCK_PREFIX) {
+        Arc::new(BedrockProvider::new())
+    } else {
+        Arc::new(OpenRouterProvider::new(slug))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `bedrock/*` slugs route to the Bedrock provider.
+    ///
+    /// Why: Per-agent routing must direct Bedrock-hosted models to the Bedrock
+    /// backend, not OpenRouter.
+    /// What: Resolve a `bedrock/...` slug, assert `name() == "bedrock"`.
+    /// Test: this test.
+    #[test]
+    fn provider_for_routes_bedrock() {
+        let p = provider_for("bedrock/us.anthropic.claude-sonnet-4-5");
+        assert_eq!(p.name(), "bedrock");
+    }
+
+    /// Non-Bedrock slugs route to OpenRouter (the default).
+    ///
+    /// Why: Qwen/DeepSeek/Gemma/OpenAI/Anthropic-via-OR all go through
+    /// OpenRouter; verify the default branch for several families.
+    /// What: Resolve each slug, assert `name() == "openrouter"`.
+    /// Test: this test.
+    #[test]
+    fn provider_for_routes_openrouter_default() {
+        for slug in [
+            "qwen/qwen-2.5-coder-32b-instruct",
+            "deepseek/deepseek-chat",
+            "google/gemma-2-27b-it",
+            "openai/gpt-4o-mini",
+            "anthropic/claude-sonnet-4-5",
+        ] {
+            assert_eq!(
+                provider_for(slug).name(),
+                "openrouter",
+                "slug {slug} should route to OpenRouter"
+            );
+        }
+    }
+
+    /// The OpenRouter default carries the slug through to `supports_native_tools`.
+    ///
+    /// Why: The factory must build the OpenRouter provider with the slug so its
+    /// native-tool decision is correct, not a blank default.
+    /// What: Resolve a Claude slug and a Qwen slug; assert their native-tool
+    /// flags differ as expected.
+    /// Test: this test.
+    #[test]
+    fn provider_for_preserves_slug_for_native_tool_decision() {
+        assert!(provider_for("anthropic/claude-sonnet-4-5").supports_native_tools());
+        assert!(!provider_for("qwen/qwen-2.5-coder-32b-instruct").supports_native_tools());
+    }
+}

--- a/crates/trusty-code/src/provider/bedrock.rs
+++ b/crates/trusty-code/src/provider/bedrock.rs
@@ -1,0 +1,122 @@
+//! AWS Bedrock provider — STUB (real implementation deferred).
+//!
+//! Why: #1021 establishes the provider abstraction and the `bedrock/*` routing
+//! seam so per-agent model routing can name Bedrock slugs today, while the
+//! actual Bedrock wire integration (SigV4 auth, Converse API tool-choice
+//! mapping, usage extraction) lands in a later ticket. The stub keeps the
+//! factory total and lets routing tests pass without pulling in the AWS SDK.
+//! What: [`BedrockProvider`] implements [`Provider`]. `name` and
+//! `supports_native_tools` are real; `map_tool_choice` and `extract_usage` are
+//! NOT yet implemented and will panic if called — the agent loop never invokes
+//! a Bedrock provider until the real implementation lands, so a panic here is a
+//! loud programmer-error signal rather than a silent wrong answer.
+//! Test: `bedrock::tests::*` cover the implemented methods and assert the stubs
+//! panic.
+//!
+//! NOTE: Real Bedrock implementation deferred (see #1021 acceptance criteria —
+//! "Stub BedrockProvider needs no change to agent loop").
+
+use serde_json::Value;
+
+use super::traits::{Provider, ToolChoice};
+use crate::llm::ChatResponse;
+use crate::perf::TokenUsage;
+
+/// Stub provider for AWS Bedrock-hosted models (`bedrock/*` slugs).
+///
+/// Why: Reserves the routing target and proves the abstraction is multi-backend
+/// without committing to the AWS SDK surface yet.
+/// What: Zero-sized marker type implementing [`Provider`]; tool-choice mapping
+/// and usage extraction are deferred stubs.
+/// Test: `bedrock::tests::*`.
+#[derive(Debug, Clone, Default)]
+pub struct BedrockProvider;
+
+impl BedrockProvider {
+    /// Construct a `BedrockProvider`.
+    ///
+    /// Why: Gives the factory a uniform constructor call site.
+    /// What: Returns the zero-sized marker.
+    /// Test: `bedrock::tests::name_is_bedrock`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for BedrockProvider {
+    fn name(&self) -> &str {
+        "bedrock"
+    }
+
+    fn map_tool_choice(&self, _choice: ToolChoice) -> Value {
+        // NOTE: Real implementation deferred. Bedrock's Converse API expresses
+        // tool choice differently from the OpenAI schema; mapping lands with the
+        // full Bedrock integration. The agent loop does not call this stub yet.
+        unimplemented!("BedrockProvider::map_tool_choice is a deferred stub (#1021)")
+    }
+
+    fn extract_usage(&self, _response: &ChatResponse) -> TokenUsage {
+        // NOTE: Real implementation deferred. Bedrock reports usage in its own
+        // response envelope, not the OpenAI `usage` block parsed by
+        // `ChatResponse`. The agent loop does not call this stub yet.
+        unimplemented!("BedrockProvider::extract_usage is a deferred stub (#1021)")
+    }
+
+    fn supports_native_tools(&self) -> bool {
+        // Bedrock-hosted Anthropic/other models support native tool use; the
+        // strategy matrix (#1023) may refine this per-model later.
+        true
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `name()` returns `"bedrock"`.
+    ///
+    /// Why: Routing and telemetry distinguish Bedrock from OpenRouter by name.
+    /// What: Construct the stub, assert the name.
+    /// Test: this test.
+    #[test]
+    fn name_is_bedrock() {
+        assert_eq!(BedrockProvider::new().name(), "bedrock");
+    }
+
+    /// Bedrock reports native-tool support.
+    ///
+    /// Why: Bedrock-hosted Anthropic models accept the native `tools` array.
+    /// What: Assert `supports_native_tools()` is `true`.
+    /// Test: this test.
+    #[test]
+    fn bedrock_supports_native_tools() {
+        assert!(BedrockProvider::new().supports_native_tools());
+    }
+
+    /// `map_tool_choice` panics while stubbed.
+    ///
+    /// Why: Document and lock in the deferred-stub contract so a future caller
+    /// hits a loud error rather than a silent wrong mapping.
+    /// What: Expect the call to panic.
+    /// Test: this test.
+    #[test]
+    #[should_panic(expected = "deferred stub")]
+    fn map_tool_choice_is_stubbed() {
+        let _ = BedrockProvider::new().map_tool_choice(ToolChoice::Auto);
+    }
+
+    /// `extract_usage` panics while stubbed.
+    ///
+    /// Why: Same deferred-stub contract for usage extraction.
+    /// What: Expect the call to panic.
+    /// Test: this test.
+    #[test]
+    #[should_panic(expected = "deferred stub")]
+    fn extract_usage_is_stubbed() {
+        let fixture = r#"{"id":"x","choices":[],"usage":{}}"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let _ = BedrockProvider::new().extract_usage(&resp);
+    }
+}

--- a/crates/trusty-code/src/provider/mod.rs
+++ b/crates/trusty-code/src/provider/mod.rs
@@ -1,0 +1,25 @@
+//! Provider abstraction and per-agent model routing.
+//!
+//! Why: trusty-code routes each agent to its own model, which may live behind
+//! different backends (OpenRouter today, AWS Bedrock later). The agent loop must
+//! not branch on the backend; it depends on the [`Provider`] trait and asks a
+//! factory for the right implementation given a model slug. This module is that
+//! seam (#1021) and the precedence resolver for which slug to use.
+//! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the two
+//! concrete providers ([`OpenRouterProvider`], [`BedrockProvider`]), the
+//! [`provider_for`] factory, and the [`resolve_model`] precedence function plus
+//! its [`DEFAULT_MODEL`] constant.
+//! Test: submodule `tests` in each file; routing/adapter coverage in
+//! `routing.rs` and `adapter.rs`.
+
+mod adapter;
+mod bedrock;
+mod openrouter;
+mod routing;
+mod traits;
+
+pub use adapter::provider_for;
+pub use bedrock::BedrockProvider;
+pub use openrouter::OpenRouterProvider;
+pub use routing::{DEFAULT_MODEL, resolve_model};
+pub use traits::{Provider, ToolChoice};

--- a/crates/trusty-code/src/provider/openrouter.rs
+++ b/crates/trusty-code/src/provider/openrouter.rs
@@ -1,0 +1,193 @@
+//! OpenRouter provider — the default backend for trusty-code.
+//!
+//! Why: OpenRouter fronts dozens of model families (Qwen, DeepSeek, Gemma,
+//! OpenAI, Anthropic, Gemini, …) behind one OpenAI-compatible chat-completions
+//! schema. It is the right default for every slug that is not explicitly routed
+//! elsewhere (#1021).
+//! What: [`OpenRouterProvider`] implements [`Provider`] using OpenAI-style
+//! `tool_choice` JSON and the standard `usage` block. `supports_native_tools`
+//! is conservative: it returns `true` only for well-known native-capable model
+//! families and `false` otherwise (#1023 refines this per the strategy matrix).
+//! Test: `openrouter::tests::*`.
+
+use serde_json::{Value, json};
+
+use super::traits::{Provider, ToolChoice};
+use crate::llm::ChatResponse;
+use crate::perf::TokenUsage;
+
+/// The default OpenRouter-backed provider.
+///
+/// Why: Carries the model slug so `supports_native_tools` can decide per-model
+/// without the loop having to pass the slug on every call.
+/// What: Holds the model slug it was constructed for; the trait methods read it.
+/// Test: `openrouter::tests::*`.
+#[derive(Debug, Clone)]
+pub struct OpenRouterProvider {
+    /// The OpenRouter model slug this provider instance was built for.
+    slug: String,
+}
+
+impl OpenRouterProvider {
+    /// Construct an `OpenRouterProvider` for a given model slug.
+    ///
+    /// Why: `supports_native_tools` is slug-dependent, so the provider must
+    /// remember which model it routes for.
+    /// What: Stores the slug; all trait behaviour derives from it.
+    /// Test: `openrouter::tests::supports_native_tools_claude`.
+    pub fn new(slug: impl Into<String>) -> Self {
+        Self { slug: slug.into() }
+    }
+}
+
+/// Whether a model slug belongs to a family with native function-calling.
+///
+/// Why: Sending a `tools` array to a model that ignores it wastes tokens and
+/// produces malformed output; the loop needs a conservative yes/no per slug.
+/// What: Returns `true` when the slug names a known native-capable family
+/// (Claude, OpenAI GPT, Gemini); `false` otherwise. Matching is
+/// case-insensitive and substring-based so both bare slugs (`gpt-4o-mini`) and
+/// OpenRouter-namespaced slugs (`openai/gpt-4o-mini`) are recognised.
+/// Test: `openrouter::tests::supports_native_tools_*`.
+fn slug_supports_native_tools(slug: &str) -> bool {
+    let lower = slug.to_ascii_lowercase();
+    // Well-known native-tool-capable families. Conservative by design (#1023).
+    const NATIVE_MARKERS: [&str; 3] = ["claude-", "gpt-", "gemini-"];
+    NATIVE_MARKERS.iter().any(|m| lower.contains(m))
+}
+
+impl Provider for OpenRouterProvider {
+    fn name(&self) -> &str {
+        "openrouter"
+    }
+
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value {
+        match choice {
+            ToolChoice::None => json!("none"),
+            ToolChoice::Auto => json!("auto"),
+            ToolChoice::Required => json!("required"),
+            ToolChoice::Function(name) => json!({
+                "type": "function",
+                "function": { "name": name },
+            }),
+        }
+    }
+
+    fn extract_usage(&self, response: &ChatResponse) -> TokenUsage {
+        response.clone().token_usage()
+    }
+
+    fn supports_native_tools(&self) -> bool {
+        slug_supports_native_tools(&self.slug)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `name()` returns the stable `"openrouter"` identifier.
+    ///
+    /// Why: Telemetry keys off this string; a change would break log filters.
+    /// What: Construct a provider, assert `name() == "openrouter"`.
+    /// Test: this test.
+    #[test]
+    fn name_is_stable() {
+        let p = OpenRouterProvider::new("openai/gpt-4o-mini");
+        assert_eq!(p.name(), "openrouter");
+    }
+
+    /// `map_tool_choice` maps the three scalar policies to OpenAI strings.
+    ///
+    /// Why: The wire format requires exact `"none"`/`"auto"`/`"required"`
+    /// strings; a typo would be silently rejected by the API.
+    /// What: Map each scalar variant, assert the JSON string value.
+    /// Test: this test.
+    #[test]
+    fn map_tool_choice_scalars() {
+        let p = OpenRouterProvider::new("openai/gpt-4o-mini");
+        assert_eq!(p.map_tool_choice(ToolChoice::None), json!("none"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Auto), json!("auto"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Required), json!("required"));
+    }
+
+    /// `map_tool_choice(Function)` produces the OpenAI function-selector object.
+    ///
+    /// Why: Forcing a specific function requires the nested
+    /// `{type:function, function:{name}}` shape, not a bare string.
+    /// What: Map `Function("search")`, assert the object structure.
+    /// Test: this test.
+    #[test]
+    fn map_tool_choice_function() {
+        let p = OpenRouterProvider::new("openai/gpt-4o-mini");
+        let v = p.map_tool_choice(ToolChoice::Function("search_code".into()));
+        assert_eq!(v["type"], "function");
+        assert_eq!(v["function"]["name"], "search_code");
+    }
+
+    /// `extract_usage` maps the standard usage block into `TokenUsage`.
+    ///
+    /// Why: Cost accounting depends on correct field mapping; verify the
+    /// provider delegates to the canonical conversion.
+    /// What: Deserialise a response fixture with a usage block, extract usage,
+    /// assert each field.
+    /// Test: this test.
+    #[test]
+    fn extract_usage_maps_fields() {
+        let fixture = r#"{
+          "id": "gen-1",
+          "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17,
+                    "cache_read_input_tokens": 3, "cache_creation_input_tokens": 1}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let p = OpenRouterProvider::new("anthropic/claude-sonnet-4-5");
+        let usage = p.extract_usage(&resp);
+        assert_eq!(usage.prompt_tokens, 12);
+        assert_eq!(usage.completion_tokens, 5);
+        assert_eq!(usage.cache_read_tokens, 3);
+        assert_eq!(usage.cache_creation_tokens, 1);
+    }
+
+    /// Claude / GPT / Gemini slugs report native-tool support.
+    ///
+    /// Why: These families support native function-calling; the loop should send
+    /// the `tools` array directly.
+    /// What: Construct providers for representative native slugs, assert `true`.
+    /// Test: this test.
+    #[test]
+    fn supports_native_tools_native_families() {
+        for slug in [
+            "anthropic/claude-sonnet-4-5",
+            "openai/gpt-4o-mini",
+            "google/gemini-2.5-pro",
+        ] {
+            assert!(
+                OpenRouterProvider::new(slug).supports_native_tools(),
+                "expected native-tool support for {slug}"
+            );
+        }
+    }
+
+    /// Qwen / DeepSeek / Gemma slugs do NOT report native-tool support.
+    ///
+    /// Why: These are conservatively treated as non-native until #1023 refines
+    /// the matrix; the loop must use prompt-based fallback guidance for them.
+    /// What: Construct providers for these slugs, assert `false`.
+    /// Test: this test.
+    #[test]
+    fn supports_native_tools_non_native_families() {
+        for slug in [
+            "qwen/qwen-2.5-coder-32b-instruct",
+            "deepseek/deepseek-chat",
+            "google/gemma-2-27b-it",
+        ] {
+            assert!(
+                !OpenRouterProvider::new(slug).supports_native_tools(),
+                "expected NO native-tool support for {slug}"
+            );
+        }
+    }
+}

--- a/crates/trusty-code/src/provider/routing.rs
+++ b/crates/trusty-code/src/provider/routing.rs
@@ -1,0 +1,162 @@
+//! Per-agent model routing precedence.
+//!
+//! Why: A model can be specified in three places — the per-call [`RunContext`],
+//! the agent's TOML config (`[agent].model` or `[llm].model_override`), and a
+//! built-in default. The orchestrator needs one authoritative function that
+//! resolves these to a single slug so every call site agrees on precedence
+//! (#1021).
+//! What: [`resolve_model`] implements the precedence ladder and
+//! [`DEFAULT_MODEL`] names the fallback slug.
+//! Test: `routing::tests::*`.
+
+use crate::agents::AgentConfig;
+use crate::tools::RunContext;
+
+/// Default model slug when nothing else is specified.
+///
+/// Why: A run must always resolve to *some* model; this is the cheap, broadly
+/// available fallback used across trusty-code.
+/// What: The OpenRouter slug for GPT-4o-mini.
+/// Test: `routing::tests::resolve_model_falls_back_to_default`.
+pub const DEFAULT_MODEL: &str = "openai/gpt-4o-mini";
+
+/// Resolve the model slug for an invocation.
+///
+/// Why: Centralises the precedence so per-call overrides, per-agent config, and
+/// the global default never disagree across call sites.
+/// What: Returns, in priority order, the first non-empty of:
+/// (1) `run_context.model` (per-call override),
+/// (2) `agent_config.agent.model`,
+/// (3) `agent_config.llm.model_override`,
+/// else (4) [`DEFAULT_MODEL`].
+/// Test: `routing::tests::resolve_model_*` cover every tier.
+pub fn resolve_model(agent_config: &AgentConfig, run_context: Option<&RunContext>) -> String {
+    // 1. Per-call override wins.
+    if let Some(ctx) = run_context
+        && let Some(model) = non_empty(ctx.model.as_deref())
+    {
+        return model.to_string();
+    }
+
+    // 2. Agent-level model.
+    if let Some(model) = non_empty(agent_config.agent.model.as_deref()) {
+        return model.to_string();
+    }
+
+    // 3. `[llm].model_override` (lower precedence than `[agent].model`).
+    if let Some(model) = non_empty(agent_config.llm.model_override.as_deref()) {
+        return model.to_string();
+    }
+
+    // 4. Built-in default.
+    DEFAULT_MODEL.to_string()
+}
+
+/// Treat empty/whitespace-only strings as absent.
+///
+/// Why: An empty `model = ""` in TOML or an empty `RunContext.model` should fall
+/// through to the next tier rather than route to a blank slug.
+/// What: Returns `Some(trimmed-original)` only when the value has non-whitespace
+/// content; `None` otherwise.
+/// Test: `routing::tests::resolve_model_skips_empty_strings`.
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.filter(|v| !v.trim().is_empty())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::config::{AgentInfo, LlmParams};
+
+    /// Build an `AgentConfig` with the given agent model and `model_override`.
+    fn cfg(agent_model: Option<&str>, override_model: Option<&str>) -> AgentConfig {
+        AgentConfig {
+            agent: AgentInfo {
+                name: "test-agent".into(),
+                model: agent_model.map(str::to_string),
+                ..Default::default()
+            },
+            llm: LlmParams {
+                model_override: override_model.map(str::to_string),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// `RunContext.model` wins over agent config and default.
+    ///
+    /// Why: Per-call overrides must take precedence so a caller can pin a model
+    /// for a single invocation.
+    /// What: Provide all three sources; assert the RunContext slug is returned.
+    /// Test: this test.
+    #[test]
+    fn resolve_model_run_context_wins() {
+        let config = cfg(Some("anthropic/claude-sonnet-4-5"), Some("qwen/qwen-2.5"));
+        let ctx = RunContext {
+            model: Some("openai/gpt-4o".into()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_model(&config, Some(&ctx)), "openai/gpt-4o");
+    }
+
+    /// `[agent].model` wins when no RunContext override is present.
+    ///
+    /// Why: The agent's declared model is the next authority below per-call.
+    /// What: No RunContext model; assert the agent slug is returned over the
+    /// `model_override` and the default.
+    /// Test: this test.
+    #[test]
+    fn resolve_model_agent_config_wins_over_default() {
+        let config = cfg(Some("anthropic/claude-haiku-4-5"), Some("qwen/qwen-2.5"));
+        assert_eq!(
+            resolve_model(&config, None),
+            "anthropic/claude-haiku-4-5",
+            "agent.model must win over model_override and default"
+        );
+    }
+
+    /// `[llm].model_override` is used when `[agent].model` is absent.
+    ///
+    /// Why: `model_override` is the documented lower-precedence config slot.
+    /// What: Agent model `None`, override set; assert override is returned.
+    /// Test: this test.
+    #[test]
+    fn resolve_model_uses_model_override_when_agent_absent() {
+        let config = cfg(None, Some("deepseek/deepseek-chat"));
+        assert_eq!(resolve_model(&config, None), "deepseek/deepseek-chat");
+    }
+
+    /// Falls back to `DEFAULT_MODEL` when nothing is specified.
+    ///
+    /// Why: A run must always resolve to a usable slug.
+    /// What: Empty config and no RunContext; assert the default.
+    /// Test: this test.
+    #[test]
+    fn resolve_model_falls_back_to_default() {
+        let config = cfg(None, None);
+        assert_eq!(resolve_model(&config, None), DEFAULT_MODEL);
+    }
+
+    /// Empty / whitespace strings are treated as absent at each tier.
+    ///
+    /// Why: A blank `model = ""` should not route to an empty slug; it must fall
+    /// through to the next source.
+    /// What: Empty RunContext + empty agent model + valid override → override.
+    /// Test: this test.
+    #[test]
+    fn resolve_model_skips_empty_strings() {
+        let config = cfg(Some("   "), Some("google/gemma-2-27b-it"));
+        let ctx = RunContext {
+            model: Some("".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_model(&config, Some(&ctx)),
+            "google/gemma-2-27b-it",
+            "empty RunContext and empty agent model must fall through"
+        );
+    }
+}

--- a/crates/trusty-code/src/provider/routing.rs
+++ b/crates/trusty-code/src/provider/routing.rs
@@ -60,7 +60,14 @@ pub fn resolve_model(agent_config: &AgentConfig, run_context: Option<&RunContext
 /// content; `None` otherwise.
 /// Test: `routing::tests::resolve_model_skips_empty_strings`.
 fn non_empty(value: Option<&str>) -> Option<&str> {
-    value.filter(|v| !v.trim().is_empty())
+    value.and_then(|v| {
+        let trimmed = v.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -157,6 +164,46 @@ mod tests {
             resolve_model(&config, Some(&ctx)),
             "google/gemma-2-27b-it",
             "empty RunContext and empty agent model must fall through"
+        );
+    }
+
+    /// Whitespace-padded slugs are trimmed at every precedence tier.
+    ///
+    /// Why: A TOML or RunContext slug like `"  openai/gpt-4o  "` would otherwise
+    /// route to an invalid, whitespace-padded model id. `non_empty` must return
+    /// the trimmed value, not the original padded slice.
+    /// What: (a) padded `RunContext.model` resolves to the trimmed slug; (b) with
+    /// no RunContext, a padded `agent.model` resolves to its trimmed slug; (c) an
+    /// all-whitespace `agent.model` falls through to the next tier (`model_override`).
+    /// Test: this test.
+    #[test]
+    fn resolve_model_trims_padded_slugs() {
+        // (a) Padded per-call override is trimmed and wins.
+        let config = cfg(Some("anthropic/claude-sonnet-4-5"), None);
+        let ctx = RunContext {
+            model: Some("  openai/gpt-4o  ".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_model(&config, Some(&ctx)),
+            "openai/gpt-4o",
+            "padded RunContext.model must resolve to the trimmed slug"
+        );
+
+        // (b) Padded agent.model is trimmed when no RunContext override exists.
+        let config = cfg(Some("  anthropic/claude-haiku-4-5  "), None);
+        assert_eq!(
+            resolve_model(&config, None),
+            "anthropic/claude-haiku-4-5",
+            "padded agent.model must resolve to the trimmed slug"
+        );
+
+        // (c) All-whitespace agent.model falls through to model_override.
+        let config = cfg(Some("   "), Some("deepseek/deepseek-chat"));
+        assert_eq!(
+            resolve_model(&config, None),
+            "deepseek/deepseek-chat",
+            "all-whitespace agent.model must fall through to the next tier"
         );
     }
 }

--- a/crates/trusty-code/src/provider/traits.rs
+++ b/crates/trusty-code/src/provider/traits.rs
@@ -1,0 +1,87 @@
+//! Provider trait and tool-choice abstraction.
+//!
+//! Why: Different LLM backends (OpenRouter, AWS Bedrock, …) normalise
+//! `tool_choice` and token-usage differently on the wire. The agent loop should
+//! not branch on the provider; instead it asks a `Provider` to translate a
+//! provider-neutral [`ToolChoice`] into the backend's wire format and to extract
+//! a canonical [`TokenUsage`] from the response. This keeps per-backend quirks
+//! behind one seam (#1021) and feeds fallback-guidance selection in #1032/#1023.
+//! What: Defines [`ToolChoice`] (the neutral policy enum) and the [`Provider`]
+//! trait with `name`, `map_tool_choice`, `extract_usage`, and
+//! `supports_native_tools`.
+//! Test: `provider::tests::*` plus per-impl tests in `openrouter` and `bedrock`.
+
+use serde_json::Value;
+
+use crate::llm::ChatResponse;
+use crate::perf::TokenUsage;
+
+/// Provider-neutral tool-choice policy.
+///
+/// Why: Callers (the agent loop) want to express intent — "don't call tools",
+/// "you may call tools", "you must call a tool", or "call this specific
+/// function" — without knowing how each backend spells it on the wire. The
+/// `Provider` translates this enum via [`Provider::map_tool_choice`].
+/// What: `None` disables tools, `Auto` lets the model decide, `Required` forces
+/// some tool call, and `Function(name)` forces a specific named function.
+/// Test: `openrouter::tests::map_tool_choice_*` cover every variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolChoice {
+    /// The model must not call any tool (`"none"`).
+    None,
+    /// The model may call a tool if it decides to (`"auto"`).
+    Auto,
+    /// The model must call some tool this turn (`"required"`).
+    Required,
+    /// The model must call the named function.
+    Function(String),
+}
+
+/// A backend that normalises tool-choice and usage for one family of models.
+///
+/// Why: The agent loop must stay backend-agnostic. By depending on `dyn
+/// Provider` it can drive OpenRouter today and Bedrock later without changing
+/// the loop — the factory ([`crate::provider::provider_for`]) picks the impl
+/// from the model slug.
+/// What: Object-safe (`Send + Sync`) trait with the four normalisation hooks the
+/// loop needs. Implementations live in `openrouter` and `bedrock`.
+/// Test: `openrouter::tests::*`, `bedrock::tests::*`.
+pub trait Provider: Send + Sync {
+    /// Stable provider name for logging and diagnostics.
+    ///
+    /// Why: Telemetry and error messages need a human-readable backend label
+    /// that does not change across releases.
+    /// What: Returns a short identifier such as `"openrouter"` or `"bedrock"`.
+    /// Test: `openrouter::tests::name_is_stable`, `bedrock::tests::name_is_bedrock`.
+    fn name(&self) -> &str;
+
+    /// Translate a neutral [`ToolChoice`] into this backend's wire JSON.
+    ///
+    /// Why: OpenAI-style backends use `"none"`/`"auto"`/`"required"` strings and
+    /// a `{type:function, function:{name}}` object for a specific call; other
+    /// backends differ. Centralising the mapping keeps the loop clean.
+    /// What: Returns the `serde_json::Value` to place in
+    /// `ChatRequest.tool_choice`.
+    /// Test: `openrouter::tests::map_tool_choice_*`.
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value;
+
+    /// Extract canonical token usage from a chat response.
+    ///
+    /// Why: Cost accounting needs a single `TokenUsage` shape regardless of how
+    /// the backend reports prompt/completion/cache tokens.
+    /// What: Reads the provider-specific usage block out of `response` and maps
+    /// it to [`TokenUsage`].
+    /// Test: `openrouter::tests::extract_usage_maps_fields`.
+    fn extract_usage(&self, response: &ChatResponse) -> TokenUsage;
+
+    /// Whether the backend/model supports native function-calling.
+    ///
+    /// Why: Models without native tool support need prompt-injected fallback
+    /// guidance instead of the `tools` array; this flag drives that selection in
+    /// #1032/#1023.
+    /// What: Returns `true` when the model can be sent the native `tools` array,
+    /// `false` when the loop must fall back to prompt-based tool emulation.
+    /// Test: `openrouter::tests::supports_native_tools_*`,
+    /// `bedrock::tests::bedrock_supports_native_tools`.
+    fn supports_native_tools(&self) -> bool;
+}


### PR DESCRIPTION
Trait-based provider abstraction normalizing tool_choice/usage across providers. New `provider/` module: `Provider` trait (name/map_tool_choice/extract_usage/supports_native_tools), `ToolChoice` enum, `OpenRouterProvider` (default), `BedrockProvider` stub, `provider_for(slug)` factory (bedrock/* → Bedrock, else OpenRouter), `resolve_model` precedence (RunContext.model > agent.model > llm.model_override > DEFAULT_MODEL). Removed `use_anthropic_direct` from trusty-code's LlmParams (backend now derives from resolved slug). 18 new tests. Not yet wired into the agent loop (downstream #1023/#1028/#1032). Unblocks #1023. Refs #1021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)