### PR TITLE
feat(trusty-code): system-prompt assembly layer implementing parity spec (refs #1032)

### DIFF
--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -183,6 +183,19 @@ pub mod logging;
 /// recoverable tool error, usage accrual) plus an `#[ignore]`-gated live test.
 pub mod agent_loop;
 
+/// System-prompt assembly layer implementing the parity spec.
+///
+/// Why: The cross-model comparison harness must assemble the same fixed
+/// instruction surface for every model so the comparison measures the model,
+/// not the scaffolding (`docs/trusty-code/parity-spec.md` §1). This module owns
+/// that surface: the byte-identical BASE preamble, its version token, and the
+/// fixed-order assembler that merges BASE + agent prompt + project `CLAUDE.md`
+/// context + optional per-tier fallback guidance (the #1023 seam).
+/// What: `BASE_PREAMBLE`, `BASE_PREAMBLE_VERSION`, `PromptAssembler`, and
+/// `assemble_system_prompt`.
+/// Test: `prompt::tests::*`.
+pub mod prompt;
+
 // ── Package-level re-exports ──
 
 /// Version string, re-exported so integration tests can assert it without

--- a/crates/trusty-code/src/prompt/assembler.rs
+++ b/crates/trusty-code/src/prompt/assembler.rs
@@ -1,0 +1,104 @@
+//! System-prompt assembler — composes the fixed-order parity prompt.
+//!
+//! Why: The cross-model harness must assemble a system prompt whose only
+//! intentional per-model variation is the optional tool-use fallback guidance
+//! (parity-spec §1, §2). Centralising assembly here guarantees the stable,
+//! fixed section order the spec requires (§2) and the trusty-mpm-style
+//! `\n\n---\n\n` separators (§2), so two runs of the same task differ only by
+//! the model.
+//! What: [`PromptAssembler`] and the free function [`assemble_system_prompt`],
+//! which concatenate up to four sections — BASE preamble, agent prompt,
+//! project/`CLAUDE.md` context, and fallback guidance — joining only the
+//! non-empty ones with the section separator.
+//! Test: `prompt::tests` covers stable order, idempotence, separator collapse,
+//! empty-section skipping, and fallback-guidance ordering.
+
+use crate::agents::AgentConfig;
+use crate::prompt::preamble::BASE_PREAMBLE;
+
+/// Section separator between assembled prompt blocks (parity-spec §2).
+///
+/// Why: The spec fixes the separator as the same Markdown horizontal rule that
+/// trusty-mpm uses, for visual and diff consistency across the two harnesses.
+/// What: The literal `"\n\n---\n\n"`.
+/// Test: `prompt::tests::omitted_sections_produce_no_double_separator` depends
+/// on this exact value.
+const SECTION_SEPARATOR: &str = "\n\n---\n\n";
+
+/// Assembles the parity system prompt from its constituent sections.
+///
+/// Why: A named type gives call sites (the agent loop, the parity report) a
+/// single, discoverable entry point and room to grow — e.g. to also surface the
+/// per-section hashes the parity report records (spec D5) — without changing the
+/// free-function signature callers already use.
+/// What: A zero-sized struct whose [`PromptAssembler::assemble`] method forwards
+/// to [`assemble_system_prompt`]. Holds no state, honouring the crate's
+/// no-global-state convention.
+/// Test: `prompt::tests::assembler_struct_matches_free_function`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PromptAssembler;
+
+impl PromptAssembler {
+    /// Assemble the system prompt for the given agent.
+    ///
+    /// Why: Provides the OO-style entry point that mirrors the free function so
+    /// callers may hold an assembler instance if they prefer.
+    /// What: Delegates verbatim to [`assemble_system_prompt`].
+    /// Test: `prompt::tests::assembler_struct_matches_free_function`.
+    pub fn assemble(
+        &self,
+        config: &AgentConfig,
+        project_context: Option<&str>,
+        fallback_guidance: Option<&str>,
+    ) -> String {
+        assemble_system_prompt(config, project_context, fallback_guidance)
+    }
+}
+
+/// Assemble the parity system prompt in the spec's stable, fixed order.
+///
+/// Why: The model-comparison harness (parity-spec §1) requires that, for a
+/// given agent and task, every byte of the assembled prompt except the
+/// documented fallback exception is identical across models. A single
+/// deterministic assembler with a fixed section order is how that guarantee is
+/// realised.
+/// What: Concatenates, in this order (spec §2): (1) [`BASE_PREAMBLE`],
+/// (2) `config.system_prompt.content` if non-empty, (3) `project_context`
+/// (verbatim `CLAUDE.md`, spec §2c/D1) if `Some` and non-empty, (4)
+/// `fallback_guidance` (the §4 per-tier exception, supplied by #1023) if `Some`
+/// and non-empty. Sections are joined by [`SECTION_SEPARATOR`]; empty sections
+/// contribute neither text nor a separator, so the common native-tool case is
+/// exactly sections 1→2→3 (spec D4) with no dangling rules.
+/// Test: `prompt::tests::assembled_order_is_stable`,
+/// `base_identical_across_calls`,
+/// `omitted_sections_produce_no_double_separator`,
+/// `empty_agent_prompt_skipped`, `fallback_guidance_is_last`.
+pub fn assemble_system_prompt(
+    config: &AgentConfig,
+    project_context: Option<&str>,
+    fallback_guidance: Option<&str>,
+) -> String {
+    // Collect the sections in fixed order, dropping any that are empty so the
+    // separator never doubles up (spec §2c: "the separator collapses").
+    let agent_prompt = config.system_prompt.content.trim();
+    let project = project_context.map(str::trim).unwrap_or("");
+    let fallback = fallback_guidance.map(str::trim).unwrap_or("");
+
+    let mut sections: Vec<&str> = Vec::with_capacity(4);
+    sections.push(BASE_PREAMBLE);
+    if !agent_prompt.is_empty() {
+        sections.push(agent_prompt);
+    }
+    if !project.is_empty() {
+        sections.push(project);
+    }
+    if !fallback.is_empty() {
+        sections.push(fallback);
+    }
+
+    sections.join(SECTION_SEPARATOR)
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/prompt/mod.rs
+++ b/crates/trusty-code/src/prompt/mod.rs
@@ -1,0 +1,19 @@
+//! System-prompt assembly layer (parity-spec — `docs/trusty-code/parity-spec.md`).
+//!
+//! Why: The model-comparison harness must drive the *same* system instruction
+//! surface through every model so a comparison measures the model, not the
+//! scaffolding (parity-spec §1). This module owns that surface: the
+//! byte-identical BASE preamble, its version token, and the fixed-order
+//! assembler that merges the BASE preamble with the per-agent prompt, project
+//! `CLAUDE.md` context, and the optional per-tier fallback guidance.
+//! What: Re-exports [`BASE_PREAMBLE`], [`BASE_PREAMBLE_VERSION`],
+//! [`PromptAssembler`], and [`assemble_system_prompt`].
+//! Test: `prompt::tests::*` (via `assembler.rs`'s inline test include).
+
+mod assembler;
+mod preamble;
+mod version;
+
+pub use assembler::{PromptAssembler, assemble_system_prompt};
+pub use preamble::BASE_PREAMBLE;
+pub use version::BASE_PREAMBLE_VERSION;

--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -1,0 +1,63 @@
+//! The BASE protocol preamble — byte-identical across every model and provider.
+//!
+//! Why: A cross-model comparison is only fair if the fixed instruction surface
+//! is the *same* for every model (parity-spec §1, §2a). This constant is the
+//! cross-provider analogue of trusty-mpm's `BASE_PM` floor: the minimum
+//! claude-code-equivalent instruction surface that every agent shares,
+//! re-expressed natively (not ported from open-mpm, per milestone note).
+//! What: A single compile-time `&str` holding the five required blocks of
+//! spec §2a — identity, tool-use protocol, filesystem safety, output
+//! convention, and the finish-convention pointer — and nothing host-specific.
+//! Test: `prompt::tests::base_preamble_contains_required_blocks` and
+//! `prompt::tests::base_identical_across_calls`.
+
+/// The BASE protocol preamble (spec §2a) — identical for every model slug.
+///
+/// Why: Establishes the model-agnostic rules of engagement so the comparison
+/// measures the model, not the scaffolding. It MUST NOT contain model names,
+/// provider names, host paths, MCP catalogs, or skill lists (spec §2a, §3).
+/// What: A `MAJOR.MINOR.PATCH`-versioned constant (see
+/// [`crate::prompt::BASE_PREAMBLE_VERSION`]) carrying the five required blocks.
+/// Test: `prompt::tests::base_preamble_contains_required_blocks` asserts the
+/// load-bearing phrases ("tool call", "project root", "## Summary", and the
+/// finish signal) are present.
+pub const BASE_PREAMBLE: &str = "\
+You are an autonomous coding agent operating inside the trusty-code harness. \
+You accomplish tasks by acting directly through the tools provided to you, not \
+by narrating what you intend to do. Prefer taking a concrete action over \
+describing one.
+
+## Tool-use protocol
+
+- You invoke a tool by emitting a tool call. The harness executes it and \
+returns the result to you before the conversation continues; never assume a \
+tool's effect without seeing its result.
+- Take one logical step at a time: emit a tool call, wait for its result, then \
+decide the next step based on what actually happened.
+- Every tool call's arguments MUST validate against that tool's provided JSON \
+Schema. Supply all required fields and respect declared types.
+- A tool result may report an error. When it does, recover: retry with \
+corrected arguments, choose a different tool, or explain why you cannot \
+proceed. Do not repeat the same failing call unchanged.
+
+## Filesystem-safety contract
+
+- All file paths are resolved relative to the project root and are confined to \
+it. Use project-relative paths.
+- Never attempt to read or write outside the project root, and never assume \
+access to the wider filesystem, the network, or the host environment beyond \
+what the tools expose.
+
+## Output and answer convention
+
+- When the task is complete, produce a final answer addressed to the operator.
+- You may include an optional `## Summary` section in your final answer; its \
+contents are extracted downstream as the run summary. Keep it concise and \
+factual.
+
+## Finish convention
+
+- You signal that the task is complete by producing an assistant turn that \
+contains no tool call. A turn with zero tool calls is the terminal state and \
+its content is returned as the final answer. While work remains, keep emitting \
+tool calls.";

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -1,0 +1,254 @@
+//! Unit tests for the prompt-assembly layer (parity-spec §2, §4, §6).
+//!
+//! Why: The parity guarantee is only as strong as the assembler's determinism
+//! and section discipline; these tests pin the stable order, idempotence,
+//! separator collapse, and fallback-last placement the spec mandates.
+//! What: Exercises [`assemble_system_prompt`] and [`PromptAssembler`] over the
+//! full matrix of present/absent sections, plus shape checks on
+//! [`BASE_PREAMBLE`] and [`BASE_PREAMBLE_VERSION`].
+//! Test: this file.
+
+use crate::agents::AgentConfig;
+use crate::prompt::{
+    BASE_PREAMBLE, BASE_PREAMBLE_VERSION, PromptAssembler, assemble_system_prompt,
+};
+
+/// Build an `AgentConfig` whose `system_prompt.content` is the given string.
+///
+/// Why: Tests need a minimal config that varies only by prompt content.
+/// What: Returns a defaulted `AgentConfig` with `system_prompt.content` set.
+/// Test: Used by the tests below (no assertions of its own).
+fn config_with_prompt(content: &str) -> AgentConfig {
+    let mut cfg = AgentConfig::default();
+    cfg.system_prompt.content = content.to_string();
+    cfg
+}
+
+/// With all four sections present, the assembled order is 1→2→3→4 (spec §2).
+///
+/// Why: A stable, fixed section order is the backbone of the parity guarantee.
+/// What: Asserts the `str::find` positions of BASE, agent prompt, project
+/// context, and fallback guidance are strictly increasing.
+/// Test: this test.
+#[test]
+fn assembled_order_is_stable() {
+    let cfg = config_with_prompt("AGENT_PROMPT_MARKER");
+    let out = assemble_system_prompt(
+        &cfg,
+        Some("PROJECT_CONTEXT_MARKER"),
+        Some("FALLBACK_GUIDANCE_MARKER"),
+    );
+
+    let base = out.find(BASE_PREAMBLE).expect("base present");
+    let agent = out.find("AGENT_PROMPT_MARKER").expect("agent present");
+    let project = out.find("PROJECT_CONTEXT_MARKER").expect("project present");
+    let fallback = out
+        .find("FALLBACK_GUIDANCE_MARKER")
+        .expect("fallback present");
+
+    assert!(base < agent, "BASE must precede agent prompt");
+    assert!(agent < project, "agent prompt must precede project context");
+    assert!(
+        project < fallback,
+        "project context must precede fallback guidance"
+    );
+}
+
+/// Identical inputs produce byte-identical output across calls (spec §1).
+///
+/// Why: Parity requires determinism; assembly must never reorder or vary.
+/// What: Calls the assembler twice with the same inputs and asserts equality.
+/// Test: this test.
+#[test]
+fn base_identical_across_calls() {
+    let cfg = config_with_prompt("You are an engineer.");
+    let first = assemble_system_prompt(&cfg, Some("# Project\nrules"), None);
+    let second = assemble_system_prompt(&cfg, Some("# Project\nrules"), None);
+    assert_eq!(first, second);
+}
+
+/// Omitted optional sections never produce a doubled separator (spec §2c).
+///
+/// Why: A collapsed separator (`---\n\n\n\n---`) would be a malformed prompt and
+/// signal a section-skipping bug.
+/// What: Assembles with no project context and no fallback, then asserts the
+/// output contains neither a doubled separator nor a trailing separator.
+/// Test: this test.
+#[test]
+fn omitted_sections_produce_no_double_separator() {
+    let cfg = config_with_prompt("Solo agent prompt.");
+    let out = assemble_system_prompt(&cfg, None, None);
+
+    assert!(
+        !out.contains("\n\n---\n\n\n\n---\n\n"),
+        "must not contain a doubled separator: {out:?}"
+    );
+    assert!(
+        !out.ends_with("\n\n---\n\n"),
+        "must not end with a dangling separator: {out:?}"
+    );
+    // Exactly one separator joins BASE and the single agent section.
+    assert_eq!(out.matches("\n\n---\n\n").count(), 1);
+}
+
+/// An empty agent prompt is skipped, leaving BASE first with no extra rule.
+///
+/// Why: A blank `system_prompt.content` must not inject an empty section or a
+/// dangling separator.
+/// What: With an empty agent prompt and no other sections, the output equals
+/// `BASE_PREAMBLE` exactly.
+/// Test: this test.
+#[test]
+fn empty_agent_prompt_skipped() {
+    let cfg = config_with_prompt("");
+    let out = assemble_system_prompt(&cfg, None, None);
+
+    assert!(out.starts_with(BASE_PREAMBLE), "must start with BASE");
+    assert_eq!(out, BASE_PREAMBLE, "BASE only — no separators added");
+    assert!(
+        !out.contains("\n\n---\n\n"),
+        "no separator with one section"
+    );
+}
+
+/// Whitespace-only optional sections are treated as empty.
+///
+/// Why: A `CLAUDE.md` that is only whitespace (or a fallback string that is)
+/// must not inject a meaningless section or a dangling separator.
+/// What: Passes whitespace for both optional sections; output equals BASE only.
+/// Test: this test.
+#[test]
+fn whitespace_only_sections_are_skipped() {
+    let cfg = config_with_prompt("   \n  ");
+    let out = assemble_system_prompt(&cfg, Some("\n\t  \n"), Some("   "));
+    assert_eq!(out, BASE_PREAMBLE);
+}
+
+/// When supplied, fallback guidance is the final section (spec §4, D4).
+///
+/// Why: Placing fallback last makes a strong model's prompt a strict prefix of
+/// a weak model's, yielding clean diffs and easy disclosure.
+/// What: With all sections present, asserts the output ends with the fallback
+/// text and that fallback follows the project context.
+/// Test: this test.
+#[test]
+fn fallback_guidance_is_last() {
+    let cfg = config_with_prompt("Agent prompt.");
+    let out = assemble_system_prompt(&cfg, Some("Project context."), Some("FALLBACK_LAST"));
+
+    assert!(
+        out.ends_with("FALLBACK_LAST"),
+        "fallback must be last: {out:?}"
+    );
+    let project = out.find("Project context.").expect("project present");
+    let fallback = out.find("FALLBACK_LAST").expect("fallback present");
+    assert!(project < fallback);
+}
+
+/// Native-tier models (no fallback) get exactly sections 1→2→3 (spec D4).
+///
+/// Why: Confirms the prefix-compatibility design: the common case omits §4.
+/// What: With a project context but no fallback, asserts the output does not
+/// contain the fallback and ends with the project context.
+/// Test: this test.
+#[test]
+fn native_tier_omits_fallback_section() {
+    let cfg = config_with_prompt("Agent prompt.");
+    let out = assemble_system_prompt(&cfg, Some("PROJECT_END"), None);
+    assert!(out.ends_with("PROJECT_END"));
+    assert_eq!(out.matches("\n\n---\n\n").count(), 2);
+}
+
+/// `BASE_PREAMBLE` contains every load-bearing block of spec §2a.
+///
+/// Why: The preamble is a machine-readable contract; a missing block would
+/// silently weaken every agent's instructions.
+/// What: Asserts the presence of the tool-use, filesystem, output, and finish
+/// signals via their key phrases.
+/// Test: this test.
+#[test]
+fn base_preamble_contains_required_blocks() {
+    assert!(
+        BASE_PREAMBLE.contains("tool call"),
+        "tool-use protocol block missing"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("project root"),
+        "filesystem-safety block missing"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("## Summary"),
+        "output-convention block missing"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("contains no tool call"),
+        "finish-convention block missing"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("trusty-code harness"),
+        "identity/role block missing"
+    );
+}
+
+/// `BASE_PREAMBLE` carries no host- or model-specific tokens (spec §2a/§3).
+///
+/// Why: Any model name, provider name, or host path in the BASE preamble would
+/// break the byte-identical guarantee.
+/// What: Asserts the preamble does not mention common provider/model slugs.
+/// Test: this test.
+#[test]
+fn base_preamble_is_model_agnostic() {
+    for forbidden in ["claude", "openai", "gpt", "anthropic", "qwen", "deepseek"] {
+        assert!(
+            !BASE_PREAMBLE.to_lowercase().contains(forbidden),
+            "BASE_PREAMBLE must not mention provider/model token {forbidden:?}"
+        );
+    }
+}
+
+/// `BASE_PREAMBLE_VERSION` is a three-component semver-shaped string (spec D5).
+///
+/// Why: The parity report records this token; a malformed version would make
+/// the report ambiguous.
+/// What: Splits on `.` and asserts three numeric components.
+/// Test: this test.
+#[test]
+fn base_preamble_version_is_semver_shaped() {
+    let parts: Vec<&str> = BASE_PREAMBLE_VERSION.split('.').collect();
+    assert_eq!(parts.len(), 3, "expected MAJOR.MINOR.PATCH");
+    for part in parts {
+        assert!(
+            part.chars().all(|c| c.is_ascii_digit()),
+            "non-numeric version component: {part:?}"
+        );
+    }
+}
+
+/// The `PromptAssembler` struct produces the same output as the free function.
+///
+/// Why: The two entry points must never diverge.
+/// What: Compares `PromptAssembler::assemble` to `assemble_system_prompt` for
+/// identical inputs.
+/// Test: this test.
+#[test]
+fn assembler_struct_matches_free_function() {
+    let cfg = config_with_prompt("Agent prompt.");
+    let via_struct = PromptAssembler.assemble(&cfg, Some("ctx"), Some("fb"));
+    let via_fn = assemble_system_prompt(&cfg, Some("ctx"), Some("fb"));
+    assert_eq!(via_struct, via_fn);
+}
+
+/// All four sections are present in the fully-populated assembled prompt.
+///
+/// Why: Acceptance criterion — "all sections present in assembled prompt".
+/// What: Asserts BASE, agent, project, and fallback markers all appear.
+/// Test: this test.
+#[test]
+fn all_sections_present_when_supplied() {
+    let cfg = config_with_prompt("AGENT");
+    let out = assemble_system_prompt(&cfg, Some("PROJECT"), Some("FALLBACK"));
+    assert!(out.contains(BASE_PREAMBLE));
+    assert!(out.contains("AGENT"));
+    assert!(out.contains("PROJECT"));
+    assert!(out.contains("FALLBACK"));
+}

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -224,6 +224,54 @@ fn base_preamble_version_is_semver_shaped() {
     }
 }
 
+/// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
+/// byte length. Regenerate this whenever the preamble legitimately changes
+/// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
+const EXPECTED_PREAMBLE_HASH: u64 = 0x4443_27ac_ff1b_c454;
+
+/// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
+///
+/// Why: `BASE_PREAMBLE_VERSION` (in `prompt/version.rs`) is hand-maintained and
+/// otherwise decoupled from the preamble text — a contributor can edit the
+/// preamble and forget to bump the version, silently making the parity report's
+/// version token (spec D5 disclosure) stale. This tripwire fails the build the
+/// moment the preamble bytes change without the expected hash being refreshed,
+/// forcing the version bump into the same review.
+///
+/// What: Folds `BASE_PREAMBLE`'s bytes with an inline FNV-1a-style hash (mixed
+/// with the byte length) and asserts it equals [`EXPECTED_PREAMBLE_HASH`].
+///
+/// Note: This is a *tripwire*, not a security or cryptographic hash — collision
+/// resistance is irrelevant; we only need a deterministic fingerprint that
+/// trips on edits. We deliberately compute the fold inline (FNV-1a over the
+/// bytes plus a length mix) rather than using `std::collections::hash_map::
+/// DefaultHasher`, whose output is only guaranteed stable *within* a Rust
+/// release; the inline fold is byte-stable across every toolchain, so the
+/// stored constant never needs a cross-compiler caveat.
+///
+/// Test: this test (self-checking against the stored constant).
+#[test]
+fn base_preamble_hash_tripwire() {
+    // FNV-1a 64-bit constants (public-domain reference values).
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = FNV_OFFSET_BASIS;
+    for &byte in BASE_PREAMBLE.as_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    // Mix the byte length so a pure-truncation edit can't preserve the hash.
+    hash ^= BASE_PREAMBLE.len() as u64;
+    hash = hash.wrapping_mul(FNV_PRIME);
+
+    assert_eq!(
+        hash, EXPECTED_PREAMBLE_HASH,
+        "BASE_PREAMBLE changed — update EXPECTED_PREAMBLE_HASH and bump \
+         BASE_PREAMBLE_VERSION in prompt/version.rs (actual hash: {hash:#018x})"
+    );
+}
+
 /// The `PromptAssembler` struct produces the same output as the free function.
 ///
 /// Why: The two entry points must never diverge.

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -1,0 +1,21 @@
+//! Version identifier for the BASE protocol preamble.
+//!
+//! Why: The parity report (spec §6/D5) must record, per run, the exact BASE
+//! version that was assembled so any parity claim is auditable. Pinning the
+//! version to a constant — rather than deriving it from the crate version —
+//! lets the preamble text and its identity evolve independently of crate
+//! releases, and gives the report a stable, byte-comparable token.
+//! What: A single `&str` constant naming the current BASE preamble revision.
+//! Bump it whenever `BASE_PREAMBLE` (in `preamble.rs`) changes in a way that
+//! affects assembled bytes.
+//! Test: `prompt::tests::base_preamble_version_is_semver_shaped`.
+
+/// Semantic version of the [`crate::prompt::BASE_PREAMBLE`] constant.
+///
+/// Why: Disclosed in the parity report (spec D5) so a reader can tie a run's
+/// assembled prompt back to an exact, immutable preamble revision.
+/// What: A `MAJOR.MINOR.PATCH` string. Increment on any change to the
+/// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
+/// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
+/// three-component shape.
+pub const BASE_PREAMBLE_VERSION: &str = "1.0.0";


### PR DESCRIPTION
Implements the signed-off parity spec (docs/trusty-code/parity-spec.md). New `prompt/` module: `BASE_PREAMBLE` (byte-identical, 5 blocks per §2a), `assemble_system_prompt(config, project_context, fallback_guidance)` joining sections 1→2→3→(4) with `\n\n---\n\n`, omitting empty sections; `BASE_PREAMBLE_VERSION` for parity-report disclosure (D5). The `fallback_guidance: Option<&str>` is the clean seam for #1023 (None = native-tier prefix-compatible prompt, per D4). 12 tests. Unblocks #1029. Refs #1032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)