### PR TITLE
feat(trusty-code): in-process AgentRunner + wire delegate_to_agent (refs #1029)

### DIFF
--- a/crates/trusty-code/src/agents/config.rs
+++ b/crates/trusty-code/src/agents/config.rs
@@ -144,20 +144,25 @@ pub struct RunnerConfig {
 /// Execution backend for agent invocations.
 ///
 /// Why: Abstracts over the concrete runner selected at startup so config can
-/// swap backends without code changes.
-/// What: `SubProcess` is the default (spawns a new process via NDJSON IPC);
-/// `ClaudeCode` wraps the `claude` CLI binary.
-/// Test: `runner_kind_deserializes`.
+/// swap backends without code changes. As of #1029 the in-process runner is the
+/// real, production default — the M1 model-comparison harness drives a delegated
+/// sub-agent inside the PM's own process (cheap, observable, usage rolls up onto
+/// one transcript). The subprocess and Claude-Code CLI backends are retained as
+/// future variants for deployments that need process isolation.
+/// What: `InProcess` is the default (drives the sub-agent's `AgentLoop` in the
+/// same process — see `crate::runner::InProcessAgentRunner`); `SubProcess` spawns
+/// a new process via NDJSON IPC; `ClaudeCode` wraps the `claude` CLI binary.
+/// Test: `runner_kind_deserializes`, `runner_kind_defaults_to_in_process`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RunnerKind {
-    /// Spawn a subprocess; communicate via NDJSON over stdin/stdout.
+    /// Drive the sub-agent's `AgentLoop` in the PM's own process (the default).
     #[default]
+    InProcess,
+    /// Spawn a subprocess; communicate via NDJSON over stdin/stdout.
     SubProcess,
     /// Use the `claude` CLI binary as the runner.
     ClaudeCode,
-    /// In-process mock runner (tests only).
-    InProcess,
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -245,5 +250,23 @@ kind = "claude_code"
         }
         let w: Wrapper = toml::from_str("kind = \"claude_code\"").expect("parse runner kind");
         assert_eq!(w.kind, RunnerKind::ClaudeCode);
+    }
+
+    /// `RunnerKind` defaults to `InProcess` (the real default since #1029).
+    ///
+    /// Why: The acceptance criterion for #1029 makes the in-process runner the
+    /// production default; a regression that flipped it back to `SubProcess`
+    /// would silently route every undeclared agent through the wrong backend.
+    /// What: `RunnerKind::default()` equals `InProcess`; an agent config with no
+    /// `[runner]` table leaves `runner` `None` (callers treat absence as default).
+    /// Test: this test.
+    #[test]
+    fn runner_kind_defaults_to_in_process() {
+        assert_eq!(RunnerKind::default(), RunnerKind::InProcess);
+        let cfg = AgentConfig::from_toml_str(MINIMAL_TOML).expect("parse minimal");
+        assert!(
+            cfg.runner.is_none(),
+            "absent [runner] leaves runner None; callers apply the InProcess default"
+        );
     }
 }

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -194,6 +194,22 @@ pub mod provider;
 /// recoverable tool error, usage accrual) plus an `#[ignore]`-gated live test.
 pub mod agent_loop;
 
+/// In-process agent runner — the runtime execution layer (per #1029).
+///
+/// Why: The PM's `delegate_to_agent` tool dispatches to an `AgentRunner`; the M1
+/// harness runs the delegated sub-agent *in-process* so a delegation cycle is
+/// cheap, fully observable, and rolls the sub-agent's token usage onto the same
+/// shared LLM client as the PM. This module is the production implementation of
+/// that seam — and `RunnerKind::InProcess` is the real default backend.
+/// What: `InProcessAgentRunner` (implements `tools::AgentRunner`), the
+/// `RegistryFactory` DI seam for sub-agent tool assembly, `InProcessRunnerConfig`
+/// (default turn/timeout budget), `RunnerError`, and `agent_config_exists`. Each
+/// `run` loads the agent config, gates its tools by `tools.allowed`, resolves the
+/// model + assembled system prompt, drives an `AgentLoop`, and returns its output.
+/// Test: `runner::tests::*` (stubbed-PM delegation, return-to-PM output,
+/// `tools.allowed` enforcement, usage roll-up) — all offline.
+pub mod runner;
+
 /// System-prompt assembly layer implementing the parity spec.
 ///
 /// Why: The cross-model comparison harness must assemble the same fixed

--- a/crates/trusty-code/src/runner/error.rs
+++ b/crates/trusty-code/src/runner/error.rs
@@ -1,0 +1,57 @@
+//! Error type for the in-process agent runner.
+//!
+//! Why: The runner is library code, so per the crate convention it surfaces a
+//! structured `thiserror` enum rather than `unwrap()` or bare `anyhow` strings.
+//! Each variant names a distinct failure the caller (the delegate tool, the
+//! orchestrator) may want to react to differently — a missing/invalid agent
+//! config is the caller's mistake, whereas an `AgentLoop` failure is downstream.
+//! What: `RunnerError` enumerates config-load, unknown-agent, and loop-failure
+//! cases. It converts to `anyhow::Error` automatically so it slots into the
+//! `AgentRunner` trait's `anyhow::Result` return type via `?`.
+//! Test: `runner::tests::unknown_agent_errors` and the config-load tests assert
+//! on these variants' `Display` text.
+
+use std::path::PathBuf;
+
+use crate::agent_loop::AgentLoopError;
+
+/// Failure modes of an in-process agent run.
+///
+/// Why: A typed error lets call sites distinguish "you asked for an agent that
+/// does not exist" (recoverable, surface to the model) from "the agent's loop
+/// blew up" (propagate). Bundling them in one enum keeps the runner's signature
+/// a single `Result<_, RunnerError>`.
+/// What: `UnknownAgent` and `ConfigLoad` cover resolving the agent's TOML;
+/// `Loop` wraps an `AgentLoopError` from the multi-turn loop.
+/// Test: `runner::tests::*` exercise `UnknownAgent` and `Loop` paths.
+#[derive(Debug, thiserror::Error)]
+pub enum RunnerError {
+    /// No agent config was found for the requested name in the config directory.
+    #[error("unknown agent '{name}': no config found in {dir}")]
+    UnknownAgent {
+        /// The requested agent slug.
+        name: String,
+        /// The directory that was searched for `<name>.toml`.
+        dir: PathBuf,
+    },
+
+    /// The agent's config file exists but could not be read or parsed.
+    #[error("failed to load agent config for '{name}': {source}")]
+    ConfigLoad {
+        /// The requested agent slug.
+        name: String,
+        /// The underlying load/parse error.
+        #[source]
+        source: anyhow::Error,
+    },
+
+    /// The multi-turn agent loop returned an error (turn cap, timeout, LLM, …).
+    #[error("agent '{name}' loop failed: {source}")]
+    Loop {
+        /// The agent slug whose loop failed.
+        name: String,
+        /// The underlying loop error.
+        #[source]
+        source: AgentLoopError,
+    },
+}

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -1,0 +1,310 @@
+//! In-process agent runner — drives a sub-agent's own loop without a subprocess.
+//!
+//! Why: The model-comparison harness (issue #1029) must run a delegated
+//! sub-agent *inside the same process* as the PM, so a single run is cheap,
+//! fully observable, and free of IPC/process-spawn flakiness. The PM's
+//! `delegate_to_agent` tool calls an `AgentRunner`; this is the production
+//! implementation of that seam — for each call it loads the sub-agent's config,
+//! builds the sub-agent's gated tool registry, resolves its model and assembled
+//! system prompt, and drives an `AgentLoop` to completion, returning the
+//! sub-agent's `AgentOutput` (including its accrued token usage) back to the PM.
+//! What: `InProcessAgentRunner` implements `AgentRunner`. It holds an
+//! `Arc<dyn LlmClientTrait>` (shared with the PM so usage rolls up onto one
+//! transcript), an `Arc<dyn RegistryFactory>` (the DI seam for how a sub-agent's
+//! tools are assembled — fs/bash scoped to the working dir, plus a nested
+//! delegate), the agents config directory, optional project `CLAUDE.md` context,
+//! and an `InProcessRunnerConfig` (default turn/timeout budget). `RunnerKind`'s
+//! default is `InProcess` (config.rs), making this the real default backend.
+//! Test: `runner::tests` — stubbed-PM delegation, return-to-PM `AgentOutput`,
+//! `tools.allowed` enforcement, and usage roll-up — all offline via a scripted
+//! `LlmClientTrait` mock.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::agent_loop::{AgentLoop, AgentLoopConfig};
+use crate::agents::AgentConfig;
+use crate::llm::LlmClientTrait;
+use crate::prompt::assemble_system_prompt;
+use crate::provider::resolve_model;
+use crate::runner::error::RunnerError;
+use crate::tools::{AgentOutput, AgentRunner, RunContext, ToolRegistry};
+
+/// Builds the tool registry a sub-agent is allowed to use for one invocation.
+///
+/// Why: How a sub-agent's tools are wired (fs/bash scoped to the run's working
+/// directory, a nested `delegate_to_agent`, search providers, …) is an
+/// orchestration concern that varies by deployment and must not be hard-coded
+/// into the runner. Injecting a factory keeps the runner policy-free and lets
+/// the orchestrator (#1030) and tests supply exactly the registry they want.
+/// What: `build` receives the resolved `AgentConfig` and the per-call
+/// `RunContext` and returns the *full* registry of tools available to that
+/// agent before allowlist gating; the runner then applies `tools.allowed`.
+/// Test: `runner::tests` use a closure-backed factory; production wiring lives
+/// in the orchestrator / `tm meta` layer.
+#[async_trait]
+pub trait RegistryFactory: Send + Sync {
+    /// Build the (ungated) tool registry for `agent` under `ctx`.
+    ///
+    /// Why: The factory owns tool construction; the runner owns gating. Keeping
+    /// them separate means a single factory serves every agent and the runner
+    /// applies each agent's own `tools.allowed` uniformly.
+    /// What: Returns an `Arc<ToolRegistry>` containing all tools the deployment
+    /// offers this agent; the runner narrows it to `tools.allowed`.
+    /// Test: Closure-backed impl in `runner::tests`.
+    async fn build(&self, agent: &AgentConfig, ctx: &RunContext) -> Arc<ToolRegistry>;
+}
+
+/// Blanket impl so a plain async closure can serve as a `RegistryFactory`.
+///
+/// Why: Most call sites (and every test) want to supply registry assembly as a
+/// one-line closure rather than declaring a named type; this keeps wiring terse.
+/// What: Any `Fn(&AgentConfig, &RunContext) -> Fut` returning a future of
+/// `Arc<ToolRegistry>` implements `RegistryFactory`.
+/// Test: `runner::tests::delegate_runs_engineer_loop` constructs the runner from
+/// a closure.
+#[async_trait]
+impl<F, Fut> RegistryFactory for F
+where
+    F: Fn(AgentConfig, RunContext) -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = Arc<ToolRegistry>> + Send,
+{
+    async fn build(&self, agent: &AgentConfig, ctx: &RunContext) -> Arc<ToolRegistry> {
+        self(agent.clone(), ctx.clone()).await
+    }
+}
+
+/// Static tuning for an in-process runner's default loop budget.
+///
+/// Why: The turn cap and timeout are the dials a deployment most often varies;
+/// grouping them keeps the runner constructor stable. Per-call `RunContext`
+/// overrides still take precedence over these defaults.
+/// What: `max_turns` and `timeout_secs` seed each invocation's `AgentLoopConfig`
+/// unless `RunContext.max_turns_override` overrides the turn cap.
+/// Test: `runner::tests::run_context_overrides_max_turns`.
+#[derive(Debug, Clone)]
+pub struct InProcessRunnerConfig {
+    /// Default maximum LLM round-trips per sub-agent run.
+    pub max_turns: u32,
+    /// Default wall-clock budget per sub-agent run, in seconds.
+    pub timeout_secs: u64,
+}
+
+impl Default for InProcessRunnerConfig {
+    /// Generous-but-bounded defaults matching `AgentLoopConfig`.
+    ///
+    /// Why: Avoids boilerplate at construction; mirrors the loop's own defaults
+    /// so behaviour is unsurprising.
+    /// What: 8 turns, 120s timeout.
+    /// Test: `runner::tests::config_default_is_sane`.
+    fn default() -> Self {
+        Self {
+            max_turns: 8,
+            timeout_secs: 120,
+        }
+    }
+}
+
+/// Runs a delegated sub-agent in-process by driving its own `AgentLoop`.
+///
+/// Why: This is the concrete `AgentRunner` the PM's `delegate_to_agent` tool
+/// dispatches to in the M1 harness. Running in-process (vs. subprocess) keeps a
+/// comparison run a single, observable process and lets the sub-agent's token
+/// usage accrue onto the same shared client the PM uses, so the orchestrator can
+/// roll engineer cost up into the PM's transcript (#1030).
+/// What: Holds the shared LLM client, a `RegistryFactory`, the agents config
+/// directory, optional project context, and the default loop budget. For each
+/// `run`, it loads `<config_dir>/<agent_name>.toml`, asks the factory for the
+/// agent's tools, gates them by `tools.allowed`, resolves the model and
+/// assembled system prompt, then runs an `AgentLoop` and returns its output.
+/// Test: `runner::tests::*` cover the full delegation path offline.
+pub struct InProcessAgentRunner {
+    llm: Arc<dyn LlmClientTrait>,
+    registry_factory: Arc<dyn RegistryFactory>,
+    config_dir: PathBuf,
+    project_context: Option<String>,
+    config: InProcessRunnerConfig,
+}
+
+impl InProcessAgentRunner {
+    /// Construct a runner from its collaborators.
+    ///
+    /// Why: Constructor injection keeps the runner testable — production passes a
+    /// real `LlmClient` and a real registry factory; tests pass a scripted mock
+    /// client and a closure factory.
+    /// What: Stores the shared client, the registry factory, the agents config
+    /// directory, and a default `InProcessRunnerConfig`. Project context is
+    /// `None` until `with_project_context` is called.
+    /// Test: `runner::tests::delegate_runs_engineer_loop`.
+    pub fn new(
+        llm: Arc<dyn LlmClientTrait>,
+        registry_factory: Arc<dyn RegistryFactory>,
+        config_dir: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            llm,
+            registry_factory,
+            config_dir: config_dir.into(),
+            project_context: None,
+            config: InProcessRunnerConfig::default(),
+        }
+    }
+
+    /// Attach project `CLAUDE.md` context injected into every assembled prompt.
+    ///
+    /// Why: The parity prompt assembler (#1032) merges verbatim project context
+    /// as a fixed section; threading it here means every sub-agent the runner
+    /// drives sees the same project rules the PM does.
+    /// What: Stores `context` to pass to `assemble_system_prompt`.
+    /// Test: `runner::tests::project_context_reaches_prompt` (via the system
+    /// prompt captured by the scripted client).
+    pub fn with_project_context(mut self, context: impl Into<String>) -> Self {
+        self.project_context = Some(context.into());
+        self
+    }
+
+    /// Override the default loop budget (turn cap + timeout).
+    ///
+    /// Why: Deployments and tests may want a tighter or looser default than the
+    /// built-in 8 turns / 120s.
+    /// What: Replaces `self.config`.
+    /// Test: `runner::tests::run_context_overrides_max_turns` sets a config then
+    /// overrides it per-call.
+    pub fn with_config(mut self, config: InProcessRunnerConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Load the agent config for `agent_name` from the config directory.
+    ///
+    /// Why: Each delegation targets a named agent; its model, prompt, and
+    /// `tools.allowed` come from `<config_dir>/<agent_name>.toml`. Distinguishing
+    /// "no such file" (`UnknownAgent`) from "file present but unparseable"
+    /// (`ConfigLoad`) gives the caller actionable errors.
+    /// What: Builds the path, returns `UnknownAgent` if it does not exist, else
+    /// loads it (mapping a parse failure to `ConfigLoad`).
+    /// Test: `runner::tests::unknown_agent_errors`,
+    /// `runner::tests::delegate_runs_engineer_loop`.
+    fn load_agent(&self, agent_name: &str) -> Result<AgentConfig, RunnerError> {
+        let path = self.config_dir.join(format!("{agent_name}.toml"));
+        if !path.exists() {
+            return Err(RunnerError::UnknownAgent {
+                name: agent_name.to_string(),
+                dir: self.config_dir.clone(),
+            });
+        }
+        AgentConfig::load(&path).map_err(|source| RunnerError::ConfigLoad {
+            name: agent_name.to_string(),
+            source,
+        })
+    }
+
+    /// Resolve the gated registry, model, and assembled prompt, then run the loop.
+    ///
+    /// Why: Factoring the per-call pipeline out of the trait methods lets both
+    /// `run` and `run_with_context` share one implementation; the only
+    /// difference between them is the `RunContext` they pass in.
+    /// What: Loads the agent config, builds and gates its registry (honouring
+    /// `tools.allowed`), resolves the model (`RunContext` > agent > default) and
+    /// turn cap (`RunContext.max_turns_override` > runner default), assembles the
+    /// system prompt (BASE + agent prompt + project context), runs the
+    /// `AgentLoop`, and maps any loop error to `RunnerError::Loop`.
+    /// Test: `runner::tests::*`.
+    async fn run_pipeline(
+        &self,
+        agent_name: &str,
+        task: &str,
+        ctx: &RunContext,
+    ) -> Result<AgentOutput, RunnerError> {
+        let agent = self.load_agent(agent_name)?;
+
+        // Build the agent's full tool set, then gate it by `tools.allowed`.
+        let full_registry = self.registry_factory.build(&agent, ctx).await;
+        let registry = gate_registry(&full_registry, &agent);
+
+        // Resolve the model and the per-call turn cap (RunContext wins).
+        let model = resolve_model(&agent, Some(ctx));
+        let max_turns = ctx.max_turns_override.unwrap_or(self.config.max_turns);
+
+        let loop_config = AgentLoopConfig {
+            max_turns,
+            timeout_secs: self.config.timeout_secs,
+            model,
+        };
+
+        // Assemble the parity system prompt (BASE + agent prompt + project ctx).
+        // Fallback guidance (the #1023 per-tier seam) is not wired here yet.
+        let system = assemble_system_prompt(&agent, self.project_context.as_deref(), None);
+
+        let agent_loop = AgentLoop::new(loop_config, Arc::clone(&self.llm), registry);
+
+        agent_loop
+            .run(&system, task)
+            .await
+            .map_err(|source| RunnerError::Loop {
+                name: agent_name.to_string(),
+                source,
+            })
+    }
+}
+
+/// Narrow a full registry to the agent's `tools.allowed`, if any.
+///
+/// Why: The agent loop dispatches with no per-call allowlist, so the enforcement
+/// point for `tools.allowed` (issue #1029) is handing the loop a registry that
+/// only contains the permitted tools. An absent (`None`) allowlist means "all
+/// tools the factory built are permitted".
+/// What: If `tools.allowed` is `Some(list)`, returns `Arc::new(full.gated(list))`;
+/// otherwise returns the full registry unchanged (cheap `Arc` clone).
+/// Test: `runner::tests::tools_allowed_is_enforced`,
+/// `runner::tests::no_allowlist_permits_all`.
+fn gate_registry(full: &Arc<ToolRegistry>, agent: &AgentConfig) -> Arc<ToolRegistry> {
+    match agent.tools.as_ref().and_then(|t| t.allowed.as_ref()) {
+        Some(allowed) => Arc::new(full.gated(allowed)),
+        None => Arc::clone(full),
+    }
+}
+
+#[async_trait]
+impl AgentRunner for InProcessAgentRunner {
+    /// Run `task` against the named agent with default per-call context.
+    ///
+    /// Why: The simplest entry point the delegate tool calls; no overrides.
+    /// What: Delegates to `run_pipeline` with a default `RunContext`, converting
+    /// `RunnerError` into the trait's `anyhow::Error`.
+    /// Test: `runner::tests::delegate_runs_engineer_loop`.
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+        let ctx = RunContext::default();
+        Ok(self.run_pipeline(agent_name, task, &ctx).await?)
+    }
+
+    /// Run `task` against the named agent honouring per-call `ctx` overrides.
+    ///
+    /// Why: The orchestrator may pin a model, working directory, or turn cap for
+    /// a single delegation; `RunContext` carries those without global state.
+    /// What: Delegates to `run_pipeline` with the supplied `ctx`.
+    /// Test: `runner::tests::run_context_overrides_max_turns`,
+    /// `runner::tests::run_context_overrides_model`.
+    async fn run_with_context(
+        &self,
+        agent_name: &str,
+        task: &str,
+        ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        Ok(self.run_pipeline(agent_name, task, ctx).await?)
+    }
+}
+
+/// Convenience: discover whether an agent config exists for `name` under `dir`.
+///
+/// Why: Callers (e.g. the orchestrator wiring the delegate tool) sometimes need
+/// to pre-check an agent name without constructing a runner; exposing the same
+/// path rule the runner uses keeps the two in lockstep.
+/// What: Returns `true` iff `<dir>/<name>.toml` exists.
+/// Test: `runner::tests::agent_config_exists_detects_present_and_absent`.
+pub fn agent_config_exists(dir: &Path, name: &str) -> bool {
+    dir.join(format!("{name}.toml")).exists()
+}

--- a/crates/trusty-code/src/runner/mod.rs
+++ b/crates/trusty-code/src/runner/mod.rs
@@ -1,0 +1,25 @@
+//! Runtime execution layer: the in-process agent runner (issue #1029).
+//!
+//! Why: The PM's `delegate_to_agent` tool needs a concrete `AgentRunner` that
+//! actually executes a sub-agent. The M1 model-comparison harness runs that
+//! sub-agent *in-process* — same process as the PM — so a delegation cycle is
+//! cheap, deterministic to observe, and lets the sub-agent's token usage accrue
+//! onto the same shared LLM client (and thus the PM's transcript). This module
+//! is that runner plus its DI seams.
+//! What: Re-exports `InProcessAgentRunner` (implements `crate::tools::AgentRunner`),
+//! the `RegistryFactory` trait (how a sub-agent's tools are assembled),
+//! `InProcessRunnerConfig` (default loop budget), `RunnerError` (structured
+//! library error), and the `agent_config_exists` helper.
+//! Test: `runner::tests::*` cover the full delegation path offline via a
+//! scripted `LlmClientTrait` mock.
+
+mod error;
+mod in_process;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::RunnerError;
+pub use in_process::{
+    InProcessAgentRunner, InProcessRunnerConfig, RegistryFactory, agent_config_exists,
+};

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -1,0 +1,568 @@
+//! Unit tests for the in-process agent runner (issue #1029).
+//!
+//! Why: The runner is the runtime execution layer the PM delegates through;
+//! every acceptance criterion — engineer runs its own loop on its own slug,
+//! returns an `AgentOutput` to the PM, `tools.allowed` is enforced, and usage
+//! rolls up — must be provable offline, without a live LLM. The scripted
+//! `LlmClientTrait` mock from the agent-loop tests is the seam that makes this
+//! deterministic.
+//! What: Defines a `ScriptedLlm` that replays a queue of `ChatResponse`s and
+//! records the system prompt + model of every request, a `RecordingTool` whose
+//! execution is observable, and exercises the runner end-to-end: a stubbed PM
+//! delegates to a `python-engineer` agent whose loop runs against its own slug.
+//! Test: this module is itself the test surface.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use super::{InProcessAgentRunner, InProcessRunnerConfig};
+use crate::agents::AgentConfig;
+use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
+use crate::tools::{
+    AgentRunner, DelegateToAgentTool, RunContext, ToolExecutor, ToolRegistry, ToolResult,
+};
+
+// ── Test doubles ───────────────────────────────────────────────────────────────
+
+/// A `LlmClientTrait` that replays a fixed script and records every request.
+///
+/// Why: Deterministic, offline substitute for the network client; recording the
+/// requests lets tests assert what model and system prompt the runner resolved.
+/// What: Holds scripted `ChatResponse`s, an atomic cursor, and a Mutex log of
+/// `(model, system_prompt)` pairs captured from each `chat` call. Running past
+/// the end yields a transport-style error so a runaway loop fails loudly.
+/// Test: Used by every runner test below.
+struct ScriptedLlm {
+    responses: Vec<ChatResponse>,
+    cursor: AtomicUsize,
+    seen: Mutex<Vec<(String, String)>>,
+}
+
+impl ScriptedLlm {
+    /// Build a scripted client from JSON response fixtures.
+    ///
+    /// Why: `ChatResponse` is `Deserialize`-only; tests author responses as JSON.
+    /// What: Deserialises each fixture and seeds an empty request log.
+    /// Test: Used by every runner test below.
+    fn from_json(fixtures: &[Value]) -> Self {
+        let responses = fixtures
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()).expect("valid ChatResponse fixture"))
+            .collect();
+        Self {
+            responses,
+            cursor: AtomicUsize::new(0),
+            seen: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Number of `chat` calls made so far.
+    fn calls(&self) -> usize {
+        self.cursor.load(Ordering::SeqCst)
+    }
+
+    /// The `(model, system_prompt)` of the first recorded request.
+    fn first_request(&self) -> (String, String) {
+        self.seen
+            .lock()
+            .expect("seen lock")
+            .first()
+            .cloned()
+            .expect("at least one request recorded")
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for ScriptedLlm {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let system = req
+            .messages
+            .iter()
+            .find(|m| m.role == "system")
+            .and_then(|m| m.content.clone())
+            .unwrap_or_default();
+        self.seen
+            .lock()
+            .expect("seen lock")
+            .push((req.model.clone(), system));
+
+        let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
+        match self.responses.get(idx) {
+            Some(resp) => Ok(resp.clone()),
+            None => Err(LlmError::MissingConfig(format!(
+                "scripted LLM exhausted at call {idx}"
+            ))),
+        }
+    }
+}
+
+/// A tool whose invocations are recorded, used to prove gating.
+///
+/// Why: To assert `tools.allowed` enforcement we need a tool that records
+/// whether it was actually dispatched.
+/// What: `execute` pushes its name onto a shared log and returns success.
+/// Test: `tools_allowed_is_enforced`.
+struct RecordingTool {
+    name: &'static str,
+    invoked: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl ToolExecutor for RecordingTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": "recording tool",
+                "parameters": { "type": "object", "properties": {} }
+            }
+        })
+    }
+
+    async fn execute(&self, _args: Value) -> ToolResult {
+        self.invoked
+            .lock()
+            .expect("invoked lock")
+            .push(self.name.to_string());
+        ToolResult::ok(format!("{}: ran", self.name))
+    }
+}
+
+// ── Fixture builders ─────────────────────────────────────────────────────────
+
+/// A response in which the assistant calls a named tool with empty args.
+fn tool_call_response(call_id: &str, tool: &str) -> Value {
+    json!({
+        "id": "gen-tool",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": { "name": tool, "arguments": "{}" }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 30, "completion_tokens": 10, "total_tokens": 40 }
+    })
+}
+
+/// A response in which the assistant emits final text and stops.
+fn stop_response(text: &str) -> Value {
+    json!({
+        "id": "gen-stop",
+        "choices": [{
+            "message": { "role": "assistant", "content": text, "tool_calls": [] },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 15, "completion_tokens": 5, "total_tokens": 20 }
+    })
+}
+
+// ── Fixtures: an agents config dir ───────────────────────────────────────────
+
+/// Create a temp agents dir containing a `python-engineer.toml`.
+///
+/// Why: The runner loads `<dir>/<agent>.toml`; tests need a real file on disk.
+/// What: Writes `python-engineer.toml` with the given body and returns the dir.
+/// Test: Used by most runner tests.
+fn agents_dir_with(body: &str, agent: &str) -> TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join(format!("{agent}.toml")), body).expect("write agent toml");
+    tmp
+}
+
+/// A registry factory closure that registers the given recording tools.
+///
+/// Why: Tests need a `RegistryFactory` that yields a known tool set so gating
+/// and dispatch are observable.
+/// What: Returns an `Arc<ToolRegistry>` with each `(name)` registered as a
+/// `RecordingTool` sharing `invoked`.
+fn recording_factory(
+    tools: Vec<&'static str>,
+    invoked: Arc<Mutex<Vec<String>>>,
+) -> impl Fn(
+    AgentConfig,
+    RunContext,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Arc<ToolRegistry>> + Send>> {
+    move |_agent: AgentConfig, _ctx: RunContext| {
+        let tools = tools.clone();
+        let invoked = Arc::clone(&invoked);
+        Box::pin(async move {
+            let mut reg = ToolRegistry::new();
+            for name in tools {
+                reg.register(Arc::new(RecordingTool {
+                    name,
+                    invoked: Arc::clone(&invoked),
+                }));
+            }
+            Arc::new(reg)
+        })
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// Default config is sane.
+///
+/// Why: Defaults are the most-used construction path; guard them.
+/// What: Assert positive turn cap and timeout.
+/// Test: this test.
+#[test]
+fn config_default_is_sane() {
+    let cfg = InProcessRunnerConfig::default();
+    assert!(cfg.max_turns >= 1);
+    assert!(cfg.timeout_secs >= 1);
+}
+
+/// `agent_config_exists` detects present and absent configs.
+///
+/// Why: Callers pre-check agent names with the same path rule the runner uses.
+/// What: Write one agent; assert present is true and a bogus name is false.
+/// Test: this test.
+#[test]
+fn agent_config_exists_detects_present_and_absent() {
+    let tmp = agents_dir_with("[agent]\nname = \"python-engineer\"\n", "python-engineer");
+    assert!(super::agent_config_exists(tmp.path(), "python-engineer"));
+    assert!(!super::agent_config_exists(tmp.path(), "ghost"));
+}
+
+/// Stubbed-PM: `delegate_to_agent(python-engineer)` runs the engineer's own loop
+/// on its own slug and returns an `AgentOutput` to the PM.
+///
+/// Why: This is the core #1029 acceptance criterion — the PM's delegate tool
+/// dispatches to the in-process runner, which drives the engineer's loop and
+/// hands the result back. We assert the engineer's model slug was used and the
+/// PM received the engineer's final text.
+/// What: Engineer config pins `deepseek/deepseek-chat`. Script [tool_call,
+/// stop("engineer done")]. Build the runner, wrap it in a `DelegateToAgentTool`
+/// (the PM's tool), and `execute` a delegation. Assert success, the returned
+/// content, that the engineer's slug drove the loop, and two chat calls.
+/// Test: this test.
+#[tokio::test]
+async fn delegate_runs_engineer_loop() {
+    let body = r#"
+[agent]
+name = "python-engineer"
+model = "deepseek/deepseek-chat"
+
+[system_prompt]
+content = "You are a Python engineer."
+"#;
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("c1", "work_tool"),
+        stop_response("engineer done"),
+    ]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec!["work_tool"], Arc::clone(&invoked)));
+
+    let runner = Arc::new(InProcessAgentRunner::new(
+        llm.clone(),
+        factory,
+        tmp.path().to_path_buf(),
+    ));
+
+    // The PM dispatches through its delegate tool — the production call path.
+    let delegate = DelegateToAgentTool::new(runner).with_config_dir(tmp.path().to_path_buf());
+    let result = delegate
+        .execute(json!({"agent_name": "python-engineer", "task": "write a function"}))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "delegation should succeed: {}",
+        result.content()
+    );
+    assert_eq!(
+        result.content(),
+        "engineer done",
+        "PM must receive the engineer's final AgentOutput content"
+    );
+    assert_eq!(llm.calls(), 2, "engineer loop made exactly two chat calls");
+    let (model, _) = llm.first_request();
+    assert_eq!(
+        model, "deepseek/deepseek-chat",
+        "engineer's own model slug must drive its loop"
+    );
+    assert_eq!(
+        invoked.lock().expect("invoked").as_slice(),
+        ["work_tool"],
+        "the engineer's tool must have run inside its own loop"
+    );
+}
+
+/// An unknown agent name yields a `RunnerError::UnknownAgent` (no loop runs).
+///
+/// Why: Delegating to a non-existent agent must fail cleanly, not panic or spin
+/// the loop.
+/// What: Empty agents dir; call `run("ghost", ...)`; assert an error whose
+/// message names the agent, and that the LLM was never called.
+/// Test: this test.
+#[tokio::test]
+async fn unknown_agent_errors() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("never reached")]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec![], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf());
+
+    let err = runner
+        .run("ghost", "do something")
+        .await
+        .expect_err("unknown agent must error");
+
+    assert!(
+        err.to_string().contains("ghost"),
+        "error must name the unknown agent, got: {err}"
+    );
+    assert_eq!(llm.calls(), 0, "loop must not run for an unknown agent");
+}
+
+/// `tools.allowed` is enforced: a tool the model calls but the agent does not
+/// allow is not dispatched (it is gated out of the registry).
+///
+/// Why: Per-agent tool gating is a hard #1029 criterion — an agent must not be
+/// able to invoke a tool outside its allowlist.
+/// What: Agent allows only `allowed_tool`. The factory builds BOTH `allowed_tool`
+/// and `denied_tool`. Script the model to call `denied_tool`, then stop. Assert
+/// the denied tool never ran (its name is absent from the invocation log) and the
+/// allowed tool would have run had it been called.
+/// Test: this test.
+#[tokio::test]
+async fn tools_allowed_is_enforced() {
+    let body = r#"
+[agent]
+name = "python-engineer"
+model = "openai/gpt-4o-mini"
+
+[tools]
+allowed = ["allowed_tool"]
+"#;
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    // Model tries to call the DENIED tool, then concludes.
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("c1", "denied_tool"),
+        stop_response("concluded"),
+    ]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(
+        vec!["allowed_tool", "denied_tool"],
+        Arc::clone(&invoked),
+    ));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf());
+
+    let out = runner
+        .run("python-engineer", "try the denied tool")
+        .await
+        .expect("loop completes (denied tool surfaces a recoverable error)");
+
+    assert_eq!(out.content, "concluded");
+    let ran = invoked.lock().expect("invoked");
+    assert!(
+        !ran.contains(&"denied_tool".to_string()),
+        "denied tool must never execute; gated out of the registry, ran: {ran:?}"
+    );
+}
+
+/// With no `tools.allowed`, every tool the factory builds is permitted.
+///
+/// Why: An absent allowlist means "all tools"; gating must not strip them.
+/// What: Agent has no `[tools]` table. Model calls `any_tool`, then stops.
+/// Assert the tool actually ran.
+/// Test: this test.
+#[tokio::test]
+async fn no_allowlist_permits_all() {
+    let body = r#"
+[agent]
+name = "python-engineer"
+model = "openai/gpt-4o-mini"
+"#;
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("c1", "any_tool"),
+        stop_response("ok"),
+    ]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec!["any_tool"], Arc::clone(&invoked)));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf());
+
+    runner
+        .run("python-engineer", "use a tool")
+        .await
+        .expect("completes");
+
+    assert_eq!(
+        invoked.lock().expect("invoked").as_slice(),
+        ["any_tool"],
+        "with no allowlist, the tool must run"
+    );
+}
+
+/// The engineer's token usage rolls up into the returned `AgentOutput`.
+///
+/// Why: For #1030 the orchestrator sums the sub-agent's usage into the PM's
+/// transcript; that requires the runner's `AgentOutput.usage` to carry the
+/// engineer's accrued tokens across all of its turns.
+/// What: Script [tool_call (30+10), stop (15+5)]; the returned usage must equal
+/// the sum across both engineer turns.
+/// Test: this test.
+#[tokio::test]
+async fn usage_rolls_up_to_output() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("c1", "any_tool"),
+        stop_response("done"),
+    ]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec!["any_tool"], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf());
+
+    let out = runner
+        .run("python-engineer", "task")
+        .await
+        .expect("completes");
+
+    assert_eq!(
+        out.usage.prompt_tokens,
+        30 + 15,
+        "prompt tokens sum across turns"
+    );
+    assert_eq!(
+        out.usage.completion_tokens,
+        10 + 5,
+        "completion tokens sum across turns"
+    );
+}
+
+/// `RunContext.model` overrides the agent's configured model for one call.
+///
+/// Why: The orchestrator can pin a model per delegation; per-call override must
+/// win over agent config (model-comparison harness varies the model per run).
+/// What: Agent config pins one model; `RunContext.model` pins another. Assert the
+/// RunContext slug drove the loop's request.
+/// Test: this test.
+#[tokio::test]
+async fn run_context_overrides_model() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec![], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf());
+
+    let ctx = RunContext {
+        model: Some("anthropic/claude-sonnet-4-6".to_string()),
+        ..Default::default()
+    };
+    runner
+        .run_with_context("python-engineer", "task", &ctx)
+        .await
+        .expect("completes");
+
+    let (model, _) = llm.first_request();
+    assert_eq!(
+        model, "anthropic/claude-sonnet-4-6",
+        "RunContext.model must override the agent's configured model"
+    );
+}
+
+/// `RunContext.max_turns_override` caps the loop below the runner default.
+///
+/// Why: A per-call turn cap lets the orchestrator bound a single delegation; the
+/// override must win over `InProcessRunnerConfig.max_turns`.
+/// What: Runner default is 8 turns, but `max_turns_override = 1`. Script only
+/// tool-call responses so the loop would run forever without a cap; assert it
+/// aborts after exactly one chat call.
+/// Test: this test.
+#[tokio::test]
+async fn run_context_overrides_max_turns() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    // Always-tool-call: the loop never converges, so only the cap stops it.
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("c1", "any_tool"),
+        tool_call_response("c2", "any_tool"),
+        tool_call_response("c3", "any_tool"),
+    ]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec!["any_tool"], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf())
+        .with_config(InProcessRunnerConfig {
+            max_turns: 8,
+            timeout_secs: 30,
+        });
+
+    let ctx = RunContext {
+        max_turns_override: Some(1),
+        ..Default::default()
+    };
+    let err = runner
+        .run_with_context("python-engineer", "loop", &ctx)
+        .await
+        .expect_err("a 1-turn cap on a non-converging loop must abort");
+
+    assert!(
+        err.to_string().contains("turn cap of 1"),
+        "error should report the overridden cap, got: {err}"
+    );
+    assert_eq!(
+        llm.calls(),
+        1,
+        "loop must stop after the single allowed turn"
+    );
+}
+
+/// Project `CLAUDE.md` context is injected into the assembled system prompt.
+///
+/// Why: Sub-agents must see the same project rules as the PM (parity-spec); the
+/// runner threads project context into `assemble_system_prompt`.
+/// What: Attach a distinctive project-context marker; assert it appears in the
+/// system prompt the scripted client received.
+/// Test: this test.
+#[tokio::test]
+async fn project_context_reaches_prompt() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"AGENT-PROMPT-MARKER\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec![], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf())
+        .with_project_context("PROJECT-CONTEXT-MARKER");
+
+    runner
+        .run("python-engineer", "task")
+        .await
+        .expect("completes");
+
+    let (_, system) = llm.first_request();
+    assert!(
+        system.contains("AGENT-PROMPT-MARKER"),
+        "assembled prompt must include the agent's own system prompt"
+    );
+    assert!(
+        system.contains("PROJECT-CONTEXT-MARKER"),
+        "assembled prompt must include the injected project context"
+    );
+}

--- a/crates/trusty-code/src/tools/registry.rs
+++ b/crates/trusty-code/src/tools/registry.rs
@@ -131,6 +131,30 @@ impl ToolRegistry {
         self.dispatch_gated(name, args, allowed).await
     }
 
+    /// Build a new registry containing only the tools named in `allowed`.
+    ///
+    /// Why: The agent loop calls `dispatch_gated(name, args, None)` — it does
+    /// not thread a per-agent allowlist through every dispatch. The robust place
+    /// to enforce an agent's `tools.allowed` (issue #1029 acceptance criterion)
+    /// is therefore *before* the loop runs: hand the loop a registry that simply
+    /// does not contain the denied tools, so a denied call surfaces as the same
+    /// structured "no tool registered" error and the model can self-correct.
+    /// Unknown names in `allowed` are ignored (they register nothing); this keeps
+    /// a typo in an agent config from being a hard error.
+    /// What: Returns a fresh `ToolRegistry` whose map holds cloned `Arc`s for
+    /// exactly the registered tools whose `name()` appears in `allowed`,
+    /// preserving the shared executors (no re-construction). Order-independent.
+    /// Test: `gated_keeps_only_allowed`, `gated_ignores_unknown_names`.
+    pub fn gated(&self, allowed: &[String]) -> ToolRegistry {
+        let tools = self
+            .tools
+            .iter()
+            .filter(|(name, _)| allowed.iter().any(|a| a == *name))
+            .map(|(name, tool)| (name.clone(), Arc::clone(tool)))
+            .collect();
+        ToolRegistry { tools }
+    }
+
     /// Emit all registered tool schemas as raw JSON values.
     ///
     /// Why: The sub-agent tool-calling loop attaches raw JSON schemas to LLM
@@ -336,6 +360,64 @@ mod tests {
             .dispatch_for_user("open_tool", json!({}), None, &user)
             .await;
         assert!(!result.is_error());
+    }
+
+    /// `gated` retains only the tools named in the allowlist.
+    ///
+    /// Why: This is the enforcement point for an agent's `tools.allowed`; the
+    /// resulting registry must contain exactly the permitted tools.
+    /// What: Register three tools, gate to two of them, assert membership.
+    /// Test: This test.
+    #[test]
+    fn gated_keeps_only_allowed() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("read_file")));
+        reg.register(Arc::new(MockTool::new("write_file")));
+        reg.register(Arc::new(MockTool::new("bash")));
+
+        let allowed = vec!["read_file".to_string(), "bash".to_string()];
+        let gated = reg.gated(&allowed);
+
+        assert!(gated.contains("read_file"), "allowed tool must survive");
+        assert!(gated.contains("bash"), "allowed tool must survive");
+        assert!(
+            !gated.contains("write_file"),
+            "denied tool must be dropped from the gated registry"
+        );
+        assert_eq!(gated.schemas().len(), 2, "exactly the two allowed tools");
+    }
+
+    /// `gated` silently ignores allowlist entries that match no registered tool.
+    ///
+    /// Why: A typo in an agent's `tools.allowed` should not be a hard error; it
+    /// simply contributes no tool to the gated registry.
+    /// What: Gate with a mix of a real and a bogus name; only the real one survives.
+    /// Test: This test.
+    #[test]
+    fn gated_ignores_unknown_names() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("read_file")));
+
+        let allowed = vec!["read_file".to_string(), "does_not_exist".to_string()];
+        let gated = reg.gated(&allowed);
+
+        assert!(gated.contains("read_file"));
+        assert_eq!(gated.schemas().len(), 1, "unknown name registers nothing");
+    }
+
+    /// `gated` with an empty allowlist produces an empty registry.
+    ///
+    /// Why: An agent that explicitly allows no tools must be handed a registry
+    /// with no tools (the model then has nothing to call).
+    /// What: Gate a populated registry with `&[]`; assert empty.
+    /// Test: This test.
+    #[test]
+    fn gated_empty_allowlist_is_empty() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("read_file")));
+        let gated = reg.gated(&[]);
+        assert!(gated.schemas().is_empty());
+        assert!(!gated.contains("read_file"));
     }
 
     /// `filter_tools_for_user` drops tools that the user's tier is blocked for.


### PR DESCRIPTION
## Summary

Implements **#1029 (in-process AgentRunner)** — the WI-10 runtime execution layer for the #1045 metaharness. This is the concrete `AgentRunner` the PM's `delegate_to_agent` tool dispatches to: for each delegation it loads the sub-agent's config, builds a gated tool registry, resolves the model + assembled system prompt, drives the multi-turn `AgentLoop` (#1028) to completion, and returns the sub-agent's `AgentOutput` back to the PM.

Refs #1029. Unblocks #1030 (orchestrator / PM-as-agent entry).

## What landed

- **`InProcessAgentRunner`** (`crates/trusty-code/src/runner/`) implements the **existing** `tools::AgentRunner` trait — reusing the established DI seam rather than inventing a new runner type, so #1030 wires it through `DelegateToAgentTool::new(Arc::new(runner))` with zero new glue.
- Per-call pipeline (exactly the #1029 acceptance criteria): load `AgentConfig` → build gated `ToolRegistry` → resolve model + assembled system prompt → run `AgentLoop` → return `AgentOutput`.
- **`RegistryFactory`** trait (with an async-closure blanket impl) — the DI seam for *how* each sub-agent's tools are assembled (fs/bash scoped to the working dir, nested delegate, etc.). The factory owns tool construction; the runner owns allowlist gating. This keeps the runner policy-free and lets #1030 / `tm` supply exactly the registry they want.
- **`ToolRegistry::gated(allowed)`** — narrows a registry to an agent's `tools.allowed`. The `AgentLoop` dispatches with no per-call allowlist (`dispatch_gated(.., None)`), so the robust enforcement point for `tools.allowed` is *before* the loop runs: hand the loop a registry that simply omits denied tools, so a denied call surfaces the same structured "no tool registered" error the model can self-correct from.
- **`RunnerKind::InProcess` is now the real default** backend; `SubProcess` / `ClaudeCode` retained as future variants.
- **`RunnerError`** (`thiserror`): `UnknownAgent` / `ConfigLoad` / `Loop`. No `unwrap()` in library code.
- Usage roll-up: the runner shares the PM's `Arc<dyn LlmClientTrait>`, and `AgentOutput.usage` carries the sub-agent's tokens summed across its turns, so the orchestrator can roll engineer cost into the PM's transcript (#1030).

## Tests (all offline via the mockable `LlmClientTrait` from #1028)

`runner::tests` — 10 tests covering every acceptance criterion:
- `delegate_runs_engineer_loop` — stubbed PM `delegate_to_agent(python-engineer)` runs the engineer's own loop on its own slug and returns `AgentOutput` to the PM (asserts the engineer's model slug drove the loop + its tool ran).
- `tools_allowed_is_enforced` — a tool the model calls but the agent does not allow never executes.
- `usage_rolls_up_to_output` — token usage sums across the engineer's turns.
- `run_context_overrides_model`, `run_context_overrides_max_turns` — per-call `RunContext` overrides.
- `project_context_reaches_prompt`, `no_allowlist_permits_all`, `unknown_agent_errors`, `config_default_is_sane`, `agent_config_exists_*`.

Plus `ToolRegistry::gated` tests and a `runner_kind_defaults_to_in_process` regression guard.

## Design decisions / ambiguities resolved

- **Reuse the existing `AgentRunner` trait** (issue said "implements AgentRunner trait"; CLAUDE.md says prefer the existing seam). Keeps #1030 trivial.
- **`tm meta run` left as its documented WI-2 stub.** Swapping `NoopAgentRunner` for the live runner there requires constructing an `LlmClient` + real `RegistryFactory`, which is orchestration (#1030 / later WIs) and would break that stub command's offline unit tests. The production wiring path is fully exercised here via `DelegateToAgentTool::new(InProcessAgentRunner)` in `delegate_runs_engineer_loop`.

## How #1030 consumes this

```rust
let llm: Arc<dyn LlmClientTrait> = Arc::new(LlmClient::from_config(cfg)?);
let runner = Arc::new(
    InProcessAgentRunner::new(llm, registry_factory, agents_dir)
        .with_project_context(claude_md)            // optional
        .with_config(InProcessRunnerConfig { max_turns, timeout_secs }),
);
// PM's delegate tool dispatches to the runner:
let delegate = DelegateToAgentTool::new(runner).with_config_dir(agents_dir);
registry.register(Arc::new(delegate));
// PM AgentLoop runs; when the model calls delegate_to_agent, the engineer's
// loop runs in-process and its AgentOutput (content + usage) returns to the PM.
```
The `RegistryFactory` is `#1030`'s hook to assemble each sub-agent's tools (fs/bash scoped to the run dir, a nested delegate for deeper hierarchies, search providers). The runner applies each agent's `tools.allowed` on top.

## Verification

- `cargo test -p trusty-code` — 298 passed, 0 failed, 2 ignored (10 new `runner::tests` all pass)
- `cargo test -p trusty-mpm` — all pass (depends on trusty-code)
- `cargo test --workspace` — touched crates green; 4 pre-existing `trusty-common` env-var/test-pollution flakes (`bm25_client` env-override + `memory_core` api-key tests) that pass in isolation and are unrelated to this diff
- `cargo clippy -p trusty-code -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — `14 allowlisted, 0 violations — OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)