### PR TITLE
refactor(trusty-mpm): rename `tm coordinator-tui` → `tm session tui` + move coordinator API under /api/v1/sessions

### DIFF
--- a/crates/trusty-mpm-gui/src/commands.rs
+++ b/crates/trusty-mpm-gui/src/commands.rs
@@ -157,15 +157,15 @@ pub async fn session_output(id: String, state: State<'_, GuiState>) -> Result<Va
     Ok(resp.json::<Value>().await.unwrap_or(Value::Null))
 }
 
-/// `GET /api/v1/coordinator/context` — fetch the coordinator's context.
+/// `GET /api/v1/sessions/context` — fetch the coordinator's context.
 ///
 /// Why: `CoordinatorChat` opens with a greeting summarizing the active
 /// sessions; this proxy supplies that snapshot in desktop mode.
-/// What: Forwards to `/api/v1/coordinator/context` and returns the JSON body.
+/// What: Forwards to `/api/v1/sessions/context` and returns the JSON body.
 /// Test: Invoke with a live daemon and assert a JSON object is returned.
 #[tauri::command]
 pub async fn coordinator_context(state: State<'_, GuiState>) -> Result<Value, String> {
-    let url = format!("{}/api/v1/coordinator/context", state.daemon_url);
+    let url = format!("{}/api/v1/sessions/context", state.daemon_url);
     let resp = state
         .client
         .get(&url)
@@ -180,11 +180,11 @@ pub async fn coordinator_context(state: State<'_, GuiState>) -> Result<Value, St
         .map_err(|e| format!("coordinator_context parse failed: {e}"))
 }
 
-/// `POST /api/v1/coordinator/chat` — send a chat turn to the coordinator.
+/// `POST /api/v1/sessions/chat` — send a chat turn to the coordinator.
 ///
 /// Why: The coordinator chat is the GUI's permanent main panel; every user
 /// message flows through here. The shell only relays the call.
-/// What: POSTs `{message, history}` to `/api/v1/coordinator/chat` and returns
+/// What: POSTs `{message, history}` to `/api/v1/sessions/chat` and returns
 /// the JSON reply (which may carry `routed_to` / `command_output`).
 /// Test: POST a plain message against a live daemon and assert a JSON reply.
 #[tauri::command]
@@ -193,7 +193,7 @@ pub async fn coordinator_chat(
     history: Value,
     state: State<'_, GuiState>,
 ) -> Result<Value, String> {
-    let url = format!("{}/api/v1/coordinator/chat", state.daemon_url);
+    let url = format!("{}/api/v1/sessions/chat", state.daemon_url);
     let body = serde_json::json!({ "message": message, "history": history });
     let resp = state
         .client

--- a/crates/trusty-mpm-gui/ui/src/lib/transport.ts
+++ b/crates/trusty-mpm-gui/ui/src/lib/transport.ts
@@ -21,8 +21,8 @@ const API_MAP: Record<string, { method: string; path: (args: any) => string }> =
   get_breakers:   { method: 'GET', path: () => '/breakers' },
   get_daemon_url: { method: 'GET', path: () => '/health' }, // no-op in web mode
   session_output: { method: 'GET', path: (a) => `/sessions/${a.id}/output` },
-  coordinator_context: { method: 'GET', path: () => '/api/v1/coordinator/context' },
-  coordinator_chat: { method: 'POST', path: () => '/api/v1/coordinator/chat' },
+  coordinator_context: { method: 'GET', path: () => '/api/v1/sessions/context' },
+  coordinator_chat: { method: 'POST', path: () => '/api/v1/sessions/chat' },
 };
 
 /** Forward a call to the native Tauri command of the same name. */
@@ -73,7 +73,7 @@ export async function invoke(command: string, args?: Record<string, unknown>): P
  *
  * Why: `CoordinatorChat` opens with a greeting summarizing what the
  * coordinator can see; this is the single call that supplies that snapshot.
- * What: Dual-mode wrapper over `GET /api/v1/coordinator/context`.
+ * What: Dual-mode wrapper over `GET /api/v1/sessions/context`.
  * Test: With the daemon up, the returned value is a JSON object describing
  * the active sessions.
  */
@@ -87,7 +87,7 @@ export async function coordinatorContext(): Promise<any> {
  * Why: The coordinator chat is the GUI's permanent main panel; every user
  * message flows through here. `@session-name:` prefixes are interpreted
  * server-side, which may populate `routed_to` / `command_output` on the reply.
- * What: Dual-mode wrapper over `POST /api/v1/coordinator/chat` carrying the
+ * What: Dual-mode wrapper over `POST /api/v1/sessions/chat` carrying the
  * new message plus prior history for context.
  * Test: Post a plain message → a `coordinator` reply returns; post one
  * prefixed with `@id:` → the reply (or the user echo) carries `routed_to`.

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -100,27 +100,6 @@ pub(crate) enum Command {
         #[arg(long, default_value_t = 1000)]
         interval_ms: u64,
     },
-    /// Launch the coordinator TUI: an input box over a live session list (#1272).
-    ///
-    /// Why (DOC-13): a Claude-Code-like surface — a text input on top of a live
-    /// session list (controller bullet + one row per managed session, the active
-    /// row in two columns `[id] │ [summary]`). This is a NEW screen, distinct
-    /// from the existing `tm tui` dashboard. It is exposed under its own name
-    /// because `coordinator` already names the session-manager chat command
-    /// (`tm coordinator` / `tm sm`); a `-tui` suffix avoids that collision.
-    /// What: Child #2 polls the daemon's coordinator-context endpoint live on the
-    /// `--interval-ms` cadence (self-healing the daemon URL on failure) and maps
-    /// each session into the list; slash-command dispatch lands in later children.
-    /// `--url` is resolved via `resolve_daemon_url`.
-    /// Test: `cli_parses_coordinator_tui` in `tests.rs`.
-    CoordinatorTui {
-        /// Base URL of the trusty-mpm daemon.
-        #[arg(long, env = "TRUSTY_MPM_URL")]
-        url: Option<String>,
-        /// Poll interval in milliseconds (daemon refresh cadence).
-        #[arg(long, default_value_t = 1500)]
-        interval_ms: u64,
-    },
     /// Launch the Tauri desktop GUI (or open the web build in the browser
     /// when Tauri is unavailable).
     Gui,
@@ -739,6 +718,27 @@ pub(crate) enum SessionAction {
         /// Project directory (defaults to the cwd).
         #[arg(long)]
         dir: Option<String>,
+    },
+    /// Launch the coordinator TUI: an input box over a live session list (#1272).
+    ///
+    /// Why (DOC-13): a Claude-Code-like surface — a text input on top of a live
+    /// session list (controller bullet + one row per managed session, the active
+    /// row in two columns `[id] │ [summary]`). This is a NEW screen, distinct
+    /// from the existing `tm tui` dashboard. It lives under the `session` group
+    /// as `tm session tui` (#1392): it operates on the same managed-session list
+    /// the other `session` verbs do, so grouping it there keeps the surface
+    /// discoverable without colliding with the `coordinator` SM chat command.
+    /// What: polls the daemon's coordinator-context endpoint live on the
+    /// `--interval-ms` cadence (self-healing the daemon URL on failure) and maps
+    /// each session into the list. `--url` is resolved via `resolve_daemon_url`.
+    /// Test: `cli_parses_session_tui` in `tests.rs`.
+    Tui {
+        /// Base URL of the trusty-mpm daemon.
+        #[arg(long, env = "TRUSTY_MPM_URL")]
+        url: Option<String>,
+        /// Poll interval in milliseconds (daemon refresh cadence).
+        #[arg(long, default_value_t = 1500)]
+        interval_ms: u64,
     },
     /// Reap dead sessions for the current project.
     Clean {

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -159,6 +159,19 @@ pub(crate) async fn session(
                 println!("{} {} {}", short_id(&s.id), status, s.workdir);
             }
         }
+        SessionAction::Tui {
+            url: tui_url,
+            interval_ms,
+        } => {
+            // #1392: the coordinator TUI is `tm session tui` (formerly the
+            // top-level `tm coordinator-tui`). It polls the daemon live, so its
+            // `run` is async and runs on the tokio runtime like `tui::run`.
+            // `resolve_daemon_url` honours an explicit `--url`, then the lock
+            // file, then the default — so we resolve from this subcommand's own
+            // `--url`/`TRUSTY_MPM_URL` flag rather than the dispatcher's `url`.
+            let resolved = trusty_mpm::core::resolve_daemon_url(tui_url.as_deref());
+            trusty_mpm::tui::coordinator::run(resolved, interval_ms).await?;
+        }
         SessionAction::Clean { dir } => {
             // `dir` is accepted for symmetry; the daemon reaps globally.
             let _ = resolve_dir(dir)?;

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -219,17 +219,6 @@ async fn main() -> anyhow::Result<()> {
             let resolved = trusty_mpm::core::resolve_daemon_url(Some(&tui_url));
             trusty_mpm::tui::run(resolved, interval_ms).await
         }
-        // #1274 Child #2: the coordinator TUI now polls the daemon live, so its
-        // `run` is async and runs on the tokio runtime like `tui::run`.
-        // `resolve_daemon_url` honours an explicit `--url`, then the lock file,
-        // then the default.
-        Command::CoordinatorTui {
-            url: tui_url,
-            interval_ms,
-        } => {
-            let resolved = trusty_mpm::core::resolve_daemon_url(tui_url.as_deref());
-            trusty_mpm::tui::coordinator::run(resolved, interval_ms).await
-        }
         Command::Gui => launch_gui(),
         Command::Telegram { cmd } => telegram(&url, cmd).await,
         Command::Install { force } => install(force),

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -432,27 +432,30 @@ fn cli_parses_tui_with_interval() {
 }
 
 #[test]
-fn cli_parses_coordinator_tui() {
-    // #1272 Child #1: the coordinator TUI is its own subcommand (the
-    // `coordinator` name is taken by the SM chat command). Its `--interval-ms`
+fn cli_parses_session_tui() {
+    // #1392: the coordinator TUI is the `tm session tui` subcommand (renamed
+    // from the former top-level `tm coordinator-tui`). Its `--interval-ms`
     // defaults to 1500. The `url` arg carries `env = "TRUSTY_MPM_URL"`, so an
     // ambient `TRUSTY_MPM_URL` in the test runner would override the (absent)
     // default — assert only the env-independent interval default here, and the
-    // url plumbing in `cli_parses_coordinator_tui_with_flags`.
-    let cli = Cli::try_parse_from(["trusty-mpm", "coordinator-tui"]).unwrap();
+    // url plumbing in `cli_parses_session_tui_with_flags`.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "tui"]).unwrap();
     match cli.command {
-        Command::CoordinatorTui { interval_ms, .. } => {
+        Command::Session {
+            action: SessionAction::Tui { interval_ms, .. },
+        } => {
             assert_eq!(interval_ms, 1500);
         }
-        other => panic!("expected CoordinatorTui, got {other:?}"),
+        other => panic!("expected Session::Tui, got {other:?}"),
     }
 }
 
 #[test]
-fn cli_parses_coordinator_tui_with_flags() {
+fn cli_parses_session_tui_with_flags() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "coordinator-tui",
+        "session",
+        "tui",
         "--url",
         "http://127.0.0.1:9999",
         "--interval-ms",
@@ -460,12 +463,27 @@ fn cli_parses_coordinator_tui_with_flags() {
     ])
     .unwrap();
     match cli.command {
-        Command::CoordinatorTui { url, interval_ms } => {
+        Command::Session {
+            action: SessionAction::Tui { url, interval_ms },
+        } => {
             assert_eq!(url.as_deref(), Some("http://127.0.0.1:9999"));
             assert_eq!(interval_ms, 750);
         }
-        other => panic!("expected CoordinatorTui, got {other:?}"),
+        other => panic!("expected Session::Tui, got {other:?}"),
     }
+}
+
+#[test]
+fn cli_rejects_removed_coordinator_tui() {
+    // #1392: the old top-level `tm coordinator-tui` was deleted (not aliased).
+    // Parsing it must now fail with an unrecognized-subcommand error.
+    let err = Cli::try_parse_from(["trusty-mpm", "coordinator-tui"]).unwrap_err();
+    assert_eq!(
+        err.kind(),
+        clap::error::ErrorKind::InvalidSubcommand,
+        "expected InvalidSubcommand, got {:?}",
+        err.kind()
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/client/command.rs
+++ b/crates/trusty-mpm/src/client/command.rs
@@ -131,7 +131,7 @@ pub enum TrustyCommand {
     /// for the coordinator — a message prefixed with `@session:` routes a
     /// command at that session, a plain message is answered by the LLM with
     /// full session context.
-    /// What: the message text to send to `POST /api/v1/coordinator/chat`.
+    /// What: the message text to send to `POST /api/v1/sessions/chat`.
     CoordinatorChat {
         /// The message to send to the coordinator.
         message: String,

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -450,7 +450,7 @@ impl CommandExecutor {
     ///
     /// Why: the CLI/Telegram entry point for the coordinator; a stateless
     /// invocation has no rolling history, so each call is a fresh conversation.
-    /// What: calls `POST /api/v1/coordinator/chat` with an empty history.
+    /// What: calls `POST /api/v1/sessions/chat` with an empty history.
     /// Test: `coordinator_chat_outcome_deserializes` in the client tests.
     async fn coordinator_chat(&self, message: &str) -> CommandResult {
         match self.client.coordinator_chat(message, &[]).await {

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -610,11 +610,11 @@ impl DaemonClient {
     /// Why: the TUI/GUI coordinator sidebar refreshes its session list from the
     /// daemon's activity snapshot — every session with its status and a
     /// recent-output excerpt.
-    /// What: `GET /api/v1/coordinator/context`, returns the deserialized
+    /// What: `GET /api/v1/sessions/context`, returns the deserialized
     /// [`CoordinatorContext`]; `Err` on a transport or decode failure.
     /// Test: `coordinator_context_deserializes` covers the wire shape.
     pub async fn coordinator_context(&self) -> anyhow::Result<CoordinatorContext> {
-        let url = format!("{}/api/v1/coordinator/context", self.base);
+        let url = format!("{}/api/v1/sessions/context", self.base);
         let context = self
             .http
             .get(&url)
@@ -632,7 +632,7 @@ impl DaemonClient {
     /// every session — a `@prefix:` message routes a command at a named
     /// session, a plain message is answered by the LLM with full session
     /// context. The UI owns the rolling chat history and threads it through.
-    /// What: POSTs `{ message, history }` to `/api/v1/coordinator/chat`; returns
+    /// What: POSTs `{ message, history }` to `/api/v1/sessions/chat`; returns
     /// `Ok(Some(outcome))` on success, `Ok(None)` when the daemon answers `503`
     /// (LLM not configured for a non-prefixed message), and `Err` on transport
     /// failure.
@@ -642,7 +642,7 @@ impl DaemonClient {
         message: &str,
         history: &[ChatMessage],
     ) -> anyhow::Result<Option<CoordinatorChatOutcome>> {
-        let url = format!("{}/api/v1/coordinator/chat", self.base);
+        let url = format!("{}/api/v1/sessions/chat", self.base);
         let resp = self
             .http
             .post(&url)

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -190,7 +190,7 @@ fn llm_chat_response_deserializes() {
 
 #[test]
 fn coordinator_context_deserializes() {
-    // The `GET /api/v1/coordinator/context` snapshot carries the session
+    // The `GET /api/v1/sessions/context` snapshot carries the session
     // summaries; the daemon's `recent_events` field is ignored.
     let json = serde_json::json!({
         "sessions": [{

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -282,7 +282,7 @@ pub struct CoordinatorSession {
     pub recent_output: Vec<String>,
 }
 
-/// Snapshot returned by `GET /api/v1/coordinator/context`.
+/// Snapshot returned by `GET /api/v1/sessions/context`.
 ///
 /// Why: the coordinator UI displays the per-session summaries that the daemon's
 /// coordinator reasons over; this is the deserialized view of that snapshot.
@@ -296,7 +296,7 @@ pub struct CoordinatorContext {
     pub sessions: Vec<CoordinatorSession>,
 }
 
-/// Outcome of a `POST /api/v1/coordinator/chat` call.
+/// Outcome of a `POST /api/v1/sessions/chat` call.
 ///
 /// Why: a coordinator message resolves to either a routed command or an LLM
 /// answer; the caller renders both from this one shape.

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -45,11 +45,14 @@ use super::state::DaemonState;
 pub mod claude_config_routes;
 pub use claude_config_routes::*;
 
-/// The cross-session coordinator routes (`/api/v1/coordinator/*`).
+/// The cross-session coordinator routes (`/api/v1/sessions/context` + `/chat`).
 ///
 /// Why: the coordinator's context and chat endpoints form their own cohesive
 /// cluster; keeping them in a sibling module mirrors `claude_config_routes` and
-/// keeps `api.rs` focused on the core session / hook / tmux surface.
+/// keeps `api.rs` focused on the core session / hook / tmux surface. As of #1392
+/// these endpoints live under the plural `/api/v1/sessions/*` namespace (the
+/// former `/api/v1/coordinator/*` paths are removed); the internal module and
+/// handler names keep the `coordinator_` prefix for continuity.
 /// The handlers are re-exported so `router` can refer to them as
 /// `super::api::<handler>`.
 pub mod coordinator_routes;
@@ -118,11 +121,15 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route("/optimizer", get(get_optimizer))
         .route("/overseer", get(get_overseer))
         .route("/llm/chat", post(llm_chat))
-        .route("/api/v1/coordinator/context", get(coordinator_context))
-        .route("/api/v1/coordinator/chat", post(coordinator_chat))
+        // #1392: the cross-session coordinator surface lives under the plural
+        // `/api/v1/sessions/*` namespace (unified with `/sessions/managed/*`);
+        // the former `/api/v1/coordinator/*` paths are removed. The descriptive
+        // leaves (`context`, `chat`) avoid colliding with the managed-session
+        // routes below.
+        .route("/api/v1/sessions/context", get(coordinator_context))
+        .route("/api/v1/sessions/chat", post(coordinator_chat))
         // DOC-14 D0.1: `/session-manager/*` aliases resolve to the SAME handlers
-        // as `/coordinator/*`. The coordinator paths remain the stable surface
-        // (DOC-13 TUI + GUI bind them); these aliases are the canonical SM names.
+        // as the session context/chat endpoints; these are the canonical SM names.
         .route("/api/v1/session-manager/context", get(coordinator_context))
         .route("/api/v1/session-manager/chat", post(coordinator_chat))
         .route("/tmux/sessions", get(list_tmux_sessions))

--- a/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
@@ -1,4 +1,4 @@
-//! Coordinator HTTP routes (`/api/v1/coordinator/*`).
+//! Coordinator HTTP routes (`/api/v1/sessions/context` + `/api/v1/sessions/chat`).
 //!
 //! Why: the TUI/GUI coordinator surface needs two daemon endpoints — one that
 //! returns a cross-session activity snapshot for display, and one that takes a
@@ -23,7 +23,7 @@ use crate::daemon::llm_overseer::ChatMessage;
 use crate::daemon::services::{SessionService, TmuxService};
 use crate::daemon::state::DaemonState;
 
-/// JSON body for `POST /api/v1/coordinator/chat`.
+/// JSON body for `POST /api/v1/sessions/chat`.
 ///
 /// Why: the coordinator chat is conversational; the caller owns the history so
 /// the daemon stays stateless about chat sessions, exactly like `/llm/chat`.
@@ -53,7 +53,7 @@ pub struct CoordinatorChatRequest {
     pub conv_id: Option<String>,
 }
 
-/// Response of `POST /api/v1/coordinator/chat`.
+/// Response of `POST /api/v1/sessions/chat`.
 ///
 /// Why: a coordinator message resolves to one of two outcomes — a direct
 /// command routed at a session, or an LLM answer; the response carries enough
@@ -85,7 +85,7 @@ pub struct CoordinatorChatResponse {
     pub conv_id: Option<String>,
 }
 
-/// `GET /api/v1/coordinator/context` — a cross-session activity snapshot.
+/// `GET /api/v1/sessions/context` — a cross-session activity snapshot.
 ///
 /// Why: the TUI/GUI display the per-session summaries (name, status, recent
 /// output) the coordinator reasons over; this endpoint is that read-only view.
@@ -95,7 +95,7 @@ pub struct CoordinatorChatResponse {
 /// Test: `coordinator_context_returns_snapshot`.
 #[utoipa::path(
     get,
-    path = "/api/v1/coordinator/context",
+    path = "/api/v1/sessions/context",
     tag = "config",
     responses((status = 200, description = "Cross-session activity snapshot"))
 )]
@@ -105,7 +105,7 @@ pub async fn coordinator_context(
     Json(build_coordinator_context(&state))
 }
 
-/// `POST /api/v1/coordinator/chat` — coordinator message; route or answer.
+/// `POST /api/v1/sessions/chat` — coordinator message; route or answer.
 ///
 /// Also serves the DOC-14 D0.1 alias `POST /api/v1/session-manager/chat` (same
 /// handler).
@@ -131,7 +131,7 @@ pub async fn coordinator_context(
 /// `coordinator_sm_tests.rs`.
 #[utoipa::path(
     post,
-    path = "/api/v1/coordinator/chat",
+    path = "/api/v1/sessions/chat",
     tag = "config",
     request_body = CoordinatorChatRequest,
     responses(

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -485,7 +485,7 @@ async fn llm_chat_without_overseer_is_503() {
 
 #[tokio::test]
 async fn coordinator_context_returns_snapshot() {
-    // `GET /api/v1/coordinator/context` always returns a snapshot; with a
+    // `GET /api/v1/sessions/context` always returns a snapshot; with a
     // registered session it appears in the `sessions` array.
     let (state, _id) = state_with_session();
     let snapshot = coordinator_context(State(state)).await;

--- a/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
+++ b/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
@@ -1,6 +1,6 @@
-//! Session-Manager endpoint tests for `coordinator/chat` (DOC-14 SM-7).
+//! Session-Manager endpoint tests for `/api/v1/sessions/chat` (DOC-14 SM-7).
 //!
-//! Why: SM-7 rewires `POST /api/v1/coordinator/chat` to route through the SM
+//! Why: SM-7 rewires `POST /api/v1/sessions/chat` to route through the SM
 //! agent when enabled + provisioned, adds `/api/v1/session-manager/*` aliases,
 //! and preserves the DOC-13 TUI contract. These tests pin every one of those:
 //! the SM turn returns reply + cost; degraded maps to 503; `enabled = false`
@@ -134,7 +134,7 @@ async fn disabled_sm_falls_back_to_legacy_503() {
 }
 
 /// Why: D0.1 — the `/api/v1/session-manager/chat` alias must resolve to the SAME
-/// handler as `/api/v1/coordinator/chat`, so identical input yields identical
+/// handler as `/api/v1/sessions/chat`, so identical input yields identical
 /// output. Driving both through the router via `oneshot` proves the alias wiring.
 /// What: posts the same SM request to both paths; asserts both 200 with equal
 /// `reply`/`cost`/`conv_id`.
@@ -175,7 +175,7 @@ async fn session_manager_chat_alias_matches_coordinator() {
         }
     };
 
-    let (coord_status, coord_json) = post("/api/v1/coordinator/chat").await;
+    let (coord_status, coord_json) = post("/api/v1/sessions/chat").await;
     let (sm_status, sm_json) = post("/api/v1/session-manager/chat").await;
 
     assert_eq!(coord_status, StatusCode::OK);
@@ -228,4 +228,39 @@ fn doc13_tui_contract_is_preserved() {
         "conv_id must be absent when None"
     );
     assert!(json.get("routed_to_session").is_none());
+}
+
+/// Why: #1392 — the cross-session coordinator surface moved under the plural
+/// `/api/v1/sessions/*` namespace and the former `/api/v1/coordinator/*` paths
+/// were removed. This pins both halves of that contract at the router level so a
+/// future re-add of the old mount (or a typo in the new one) fails loudly.
+/// What: drives the `router` via `oneshot` and asserts `GET /api/v1/sessions/context`
+/// answers `200` while the retired `GET /api/v1/coordinator/context` answers `404`.
+/// Test: this is the test.
+#[tokio::test]
+async fn sessions_context_replaces_coordinator_namespace() {
+    let get = |path: &str| {
+        let app = router(DaemonState::shared());
+        let path = path.to_string();
+        async move {
+            app.oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+        }
+    };
+
+    // New plural namespace responds.
+    assert_eq!(get("/api/v1/sessions/context").await, StatusCode::OK);
+    // Retired coordinator namespace is gone.
+    assert_eq!(
+        get("/api/v1/coordinator/context").await,
+        StatusCode::NOT_FOUND,
+    );
 }

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -119,7 +119,7 @@ pub struct DaemonState {
     pub(super) llm: Option<Arc<crate::daemon::llm_overseer::LlmOverseer>>,
     /// The Session Manager agent (DOC-14 SM-7), built once at startup.
     ///
-    /// Why: `POST /api/v1/coordinator/chat` (and its `/session-manager/*`
+    /// Why: `POST /api/v1/sessions/chat` (and its `/session-manager/*`
     /// aliases) route a chat turn through this agent when
     /// `[session_manager].enabled = true` AND a provider is available, superseding
     /// the legacy [`LlmOverseer`] path. Built unconditionally (cheap — config +

--- a/crates/trusty-mpm/src/daemon/state/resources.rs
+++ b/crates/trusty-mpm/src/daemon/state/resources.rs
@@ -190,7 +190,7 @@ impl DaemonState {
 
     /// The Session Manager agent (DOC-14 SM-7).
     ///
-    /// Why: `POST /api/v1/coordinator/chat` (and its `/session-manager/*`
+    /// Why: `POST /api/v1/sessions/chat` (and its `/session-manager/*`
     /// aliases) consult this to decide whether to route a turn through the SM
     /// (`is_enabled()` AND `has_runtime()`) or fall back to the legacy
     /// [`LlmOverseer`](crate::daemon::llm_overseer::LlmOverseer) path. Sharing the

--- a/crates/trusty-mpm/src/tui/coordinator/mod.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/mod.rs
@@ -7,7 +7,7 @@
 //! the skeleton (layout, selection, input editing, panic-safe terminal); Child
 //! #2 wires live session-list polling + daemon-down handling.
 //! What: thin façade re-exporting the submodules and exposing [`run`], the
-//! `tm coordinator-tui` entry point. [`run`] polls the daemon's
+//! `tm session tui` entry point. [`run`] polls the daemon's
 //! coordinator-context endpoint on the `--interval-ms` cadence and maps each
 //! session into the live list (see [`poll`]). The daemon-backed `last_summary`
 //! column and slash-command dispatch are deferred to later children; the summary
@@ -80,7 +80,7 @@ const KEY_POLL: Duration = Duration::from_millis(50);
 
 /// Launch the coordinator TUI against `url`, polling every `interval_ms`.
 ///
-/// Why: the `tm coordinator-tui` subcommand needs one entry point that owns the
+/// Why: the `tm session tui` subcommand needs one entry point that owns the
 /// terminal lifecycle. Now async (Child #2 added live daemon IO) so it runs on
 /// the same tokio runtime as `tui::run`.
 /// What: builds a [`DaemonClient`] for `url`, enters raw mode + the alternate

--- a/crates/trusty-mpm/src/tui/coordinator/poll.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/poll.rs
@@ -29,7 +29,7 @@ use super::state::{CoordinatorState, SessionEntry};
 /// `tui::poll_daemon` so both surfaces self-heal the daemon URL identically.
 /// What: probes health; if the daemon looks down, re-resolves the URL from the
 /// lock file via [`rediscover`] and retries one health probe. When reachable it
-/// pulls `GET /api/v1/coordinator/context` and maps every session into a
+/// pulls `GET /api/v1/sessions/context` and maps every session into a
 /// [`SessionEntry`]; on a transport error or an unreachable daemon it clears the
 /// rows and sets `daemon_reachable = false`. Always clamps the selection so a
 /// shrunk list never leaves `selected` past the end.

--- a/crates/trusty-mpm/src/tui/dashboard/mod.rs
+++ b/crates/trusty-mpm/src/tui/dashboard/mod.rs
@@ -232,7 +232,7 @@ pub struct DashboardState {
     pub command_bar: CommandBar,
     /// Rolling LLM chat history threaded through the coordinator endpoint.
     ///
-    /// Why: `POST /api/v1/coordinator/chat` is stateless; the TUI holds the
+    /// Why: `POST /api/v1/sessions/chat` is stateless; the TUI holds the
     /// conversation window so successive messages form one conversation.
     pub coord_history: Vec<crate::client::ChatMessage>,
     /// Whether the event loop should exit.

--- a/crates/trusty-mpm/src/tui/mod.rs
+++ b/crates/trusty-mpm/src/tui/mod.rs
@@ -223,7 +223,7 @@ pub(crate) fn spawn_health_pollers(
 /// Send the typed message to the coordinator and fold the reply into the chat.
 ///
 /// Why: pressing Enter is the single action of the coordinator dashboard —
-/// every message goes to `POST /api/v1/coordinator/chat`, which either routes a
+/// every message goes to `POST /api/v1/sessions/chat`, which either routes a
 /// `@prefix:` command at a session or answers via the LLM.
 /// What: appends the user message to the transcript, calls the daemon, then
 /// appends the coordinator reply (or routed-command output). A `None` response

--- a/docs/specs/session-manager-agent.md
+++ b/docs/specs/session-manager-agent.md
@@ -33,7 +33,7 @@ the name **coordinator** in several load-bearing places:
 
 | Surface | Current name | Files |
 |---|---|---|
-| REST endpoints | `/api/v1/coordinator/context`, `/api/v1/coordinator/chat` | `daemon/api.rs:98-99`, `daemon/api/coordinator_routes.rs` |
+| REST endpoints | `/api/v1/sessions/context`, `/api/v1/sessions/chat` (renamed from `/api/v1/coordinator/*` in #1392) | `daemon/api.rs`, `daemon/api/coordinator_routes.rs` |
 | Daemon module | `coordinator` | `daemon/coordinator.rs`, `daemon/mod.rs:16` |
 | CLI | `tm coordinator` | `bin/tm/cli.rs:166` |
 | GUI bridge | coordinator commands | `trusty-mpm-gui/src/commands.rs:160-210` |
@@ -47,6 +47,10 @@ config, prompts, and docs. For the existing wire/CLI surface we adopt a
 
 - **D0.1 — Endpoints: keep `/api/v1/coordinator/*` as the stable path; add
   `/api/v1/session-manager/*` aliases** routed to the same handlers. The
+  > **Superseded by #1392:** the `/api/v1/coordinator/*` paths were retired and
+  > unified under the plural `/api/v1/sessions/*` namespace
+  > (`/api/v1/sessions/context`, `/api/v1/sessions/chat`); the
+  > `/api/v1/session-manager/*` aliases remain.
   coordinator paths remain valid (DOC-13 TUI and `trusty-mpm-gui` already bind
   them) and are marked *legacy alias* in OpenRPC/route docs. A future major
   version may retire the coordinator paths; that retirement is out of scope here.
@@ -664,7 +668,7 @@ are thin front-ends over the same surface (§1A.3).
 │ trusty-mpm daemon                                                │
 │                                                                  │
 │  PRIMARY: claude-mpm / PM ──JSON-RPC/stdio──► SM core (§1A.1)    │
-│  ALSO:    DOC-13 TUI / GUI ──HTTP──► /api/v1/coordinator/chat    │
+│  ALSO:    DOC-13 TUI / GUI ──HTTP──► /api/v1/sessions/chat       │
 │                              (alias /api/v1/session-manager/chat)│
 │                                   │                              │
 │                                   ▼                              │

--- a/docs/specs/tui-coordinator.md
+++ b/docs/specs/tui-coordinator.md
@@ -77,8 +77,8 @@ Today it provides:
 |---|---|---|
 | Coordinator chat pane + `CMD>` input bar (history ring) | `tui/dashboard/mod.rs` (`CommandBar`, `DashboardState`, `render`) | Input is **at the bottom**, chat above it, session **sidebar** to the side. |
 | Session **sidebar** | `tui/dashboard/mod.rs` (`SessionRow`) | A side panel, not the "below the input" list this spec asks for. |
-| Poll `GET /api/v1/coordinator/context` → session rows | `tui/mod.rs::poll_daemon` + `tui/client.rs` | Timer-based, `--interval-ms` (default poll). |
-| Send to `POST /api/v1/coordinator/chat` | `tui/mod.rs::coordinator_send` | Free text → LLM; `@prefix:` → routed command. |
+| Poll `GET /api/v1/sessions/context` → session rows | `tui/mod.rs::poll_daemon` + `tui/client.rs` | Timer-based, `--interval-ms` (default poll). |
+| Send to `POST /api/v1/sessions/chat` | `tui/mod.rs::coordinator_send` | Free text → LLM; `@prefix:` → routed command. |
 | Health screen (`[2]`), screen switching | `tui/mod.rs` (`Screen`), `tui/health/` | Secondary surface. |
 | Self-healing daemon URL re-resolution | `tui/mod.rs::rediscover_daemon` + `core/discovery.rs` | Re-reads `~/.trusty-mpm/daemon.lock` on failed poll. |
 
@@ -267,7 +267,7 @@ Frame
 ### 5.1 The coordinator (top input)
 
 The input talks to a **coordinator / PM-like agent**. Two routing modes
-(existing `POST /api/v1/coordinator/chat` semantics, `coordinator.rs`):
+(existing `POST /api/v1/sessions/chat` semantics, `coordinator.rs`):
 
 - **Free text** → the coordinator LLM answers using a snapshot of all sessions
   (`build_coordinator_context`). Requires `OPENROUTER_API_KEY`; when absent the
@@ -321,7 +321,7 @@ list reflects the mutation immediately (§3.2).
 
 Two viable feeds (the TUI already uses the first):
 
-1. **Coordinator context** — `GET /api/v1/coordinator/context` returns
+1. **Coordinator context** — `GET /api/v1/sessions/context` returns
    `sessions: [CoordinatorSession { id, name, prefix, workdir, status,
    active_delegations, recent_output }]`. Lifecycle status words map to
    `core::session::SessionStatus` (`Starting`, `Active`, `AwaitingApproval`,
@@ -402,7 +402,7 @@ meaningful line from `recent_output`, else the status word.
 
 ## 8. Behavior contract (summary)
 
-- **Inputs:** keystrokes; daemon poll responses (`coordinator/context`,
+- **Inputs:** keystrokes; daemon poll responses (`sessions/context`,
   `sessions/managed*`, `…/activity`); the daemon URL (resolved).
 - **Outputs:** a rendered full-screen TUI; `POST`s to coordinator-chat and
   managed-lifecycle endpoints; a restored terminal on exit (always, even on
@@ -517,7 +517,7 @@ shippable.
   files ≤500 SLOC.
 
 ### Child #2 — Session-list data wiring from the session-manager API
-- **Scope:** Poll `GET /api/v1/coordinator/context` (reuse `poll_daemon` /
+- **Scope:** Poll `GET /api/v1/sessions/context` (reuse `poll_daemon` /
   `coordinator_session_to_row`) to fill the list under the controller bullet;
   map status words to `SessionStatus`; bullet glyph/color by status
   (incl. `AwaitingApproval`); selection-by-ID survives refresh; render the

--- a/docs/trusty-mpm/spec/ARCHITECTURE.md
+++ b/docs/trusty-mpm/spec/ARCHITECTURE.md
@@ -279,7 +279,7 @@ Built in `api::router` (`daemon/api.rs:72-127`). Default base
 | GET | `/breakers` | Per-agent circuit-breaker state. | ✅ |
 | GET | `/optimizer` · `/overseer` | Read framework-managed policy. | ✅ |
 | POST | `/llm/chat` | Coordinator LLM chat (503 if no overseer). | ✅ |
-| GET / POST | `/api/v1/coordinator/context` · `/chat` | Cross-session coordinator. | ✅ |
+| GET / POST | `/api/v1/sessions/context` · `/chat` | Cross-session coordinator. | ✅ |
 | GET / POST | `/tmux/sessions`, `/tmux/sessions/{name}/snapshot`, `/tmux/adopt` | Universal tmux management. | ✅ |
 | GET / POST | `/claude-config*` | Claude Code config analyzer + checkpoints/profiles. | ✅ |
 | POST / GET | `/pair/request` · `/confirm` · `/status` · `/reset` | Telegram pairing. | ✅ |

--- a/docs/trusty-mpm/spec/COMPONENTS.md
+++ b/docs/trusty-mpm/spec/COMPONENTS.md
@@ -219,7 +219,7 @@ paths), **current state**, and **gaps**.
 - **Key types.** `Overseer` trait + `DeterministicOverseer` (always on) + optional
   `CompositeOverseer`/`llm_overseer` (built from `overseer.toml [llm]`);
   `overseer_compose` (`daemon/overseer_compose.rs`); `POST /llm/chat` and the
-  `/api/v1/coordinator/*` routes (`daemon/api/coordinator_routes.rs`); the `tm
+  `/api/v1/sessions/*` routes (formerly `/api/v1/coordinator/*`, renamed in #1392) (`daemon/api/coordinator_routes.rs`); the `tm
   coordinator` CLI + `tui` coordinator chat.
 - **Current state.** ✅ Deterministic overseer + opt-in LLM overseer (reuses
   `OPENROUTER_API_KEY`); cross-session coordinator chat. Disabled by default.


### PR DESCRIPTION
Closes #1392.

This PR makes the coordinator surface consistent under the plural **`session(s)`** namespace in **both** the CLI and the HTTP API.

---

## Part 1 — CLI rename (`tm coordinator-tui` → `tm session tui`)

### What
Renames the coordinator TUI CLI command from the top-level `tm coordinator-tui` to a `tui` subcommand under the existing `tm session` group. The canonical command is now **`tm session tui`**.

### Why
The coordinator TUI operates on the same managed-session list that the other `tm session` verbs (`ls`, `new`, `activity`, …) work with, so grouping it under `session` keeps the surface discoverable and drops the awkward top-level `-tui` suffix — which existed only to dodge the `coordinator` SM-chat name collision.

### Changes
- **Add** `SessionAction::Tui { url: Option<String>, interval_ms: u64 }` with identical flags/behaviour to the old command:
  - `--url` (`Option<String>`, `env = "TRUSTY_MPM_URL"`)
  - `--interval-ms` (default `1500`)
  - Wired to the same `trusty_mpm::tui::coordinator::run` entry point; URL resolved via `resolve_daemon_url` (lock file → 7880 fallback). Behaviour of `tm session tui` is identical to the old `tm coordinator-tui`.
- **Delete** the top-level `CoordinatorTui` variant and its dispatch arm entirely — **no alias**. `tm coordinator-tui` now errors with `unrecognized subcommand`.
- Updated the internal doc comments in `src/tui/coordinator/mod.rs` (`tm coordinator-tui` → `tm session tui`).

The internal module dir `src/tui/coordinator/` is intentionally left unchanged (internal detail only; the user-facing command is what moved).

---

## Part 2 — HTTP API rename (`/api/v1/coordinator/*` → `/api/v1/sessions/*`)

### What
Unifies the cross-session coordinator HTTP surface under the plural `/api/v1/sessions/*` namespace and **removes the `/api/v1/coordinator/*` namespace entirely**:

| Old (removed) | New |
|---|---|
| `GET  /api/v1/coordinator/context` | `GET  /api/v1/sessions/context` |
| `POST /api/v1/coordinator/chat`    | `POST /api/v1/sessions/chat`    |

The descriptive leaves (`context`, `chat`) avoid colliding with the existing `/api/v1/sessions/managed/*` routes. The `/api/v1/session-manager/*` aliases (DOC-14 D0.1) are **retained** and still resolve to the same handlers.

### Why
For consistency with the CLI move and with the already-plural `/api/v1/sessions/managed/*` routes — the cross-session coordinator endpoints belong in the same `sessions` namespace.

### Consumers updated
Every consumer of the old paths was moved to `/api/v1/sessions/*`:
- Daemon router mount + `coordinator_routes` handler `#[utoipa::path]` annotations.
- **TUI poll client** (`client::http_client::coordinator_context` / `coordinator_chat`) — so `tm session tui` keeps working live against the daemon.
- GUI Tauri commands (`trusty-mpm-gui/src/commands.rs`) + the web-mode REST transport map (`ui/src/lib/transport.ts`).
- Doc comments across `client/`, `tui/`, `daemon/state/`, plus the SM/TUI specs and architecture docs.

---

## Tests
- **CLI:** replaced `cli_parses_coordinator_tui` / `…_with_flags` with `cli_parses_session_tui` / `…_with_flags`; added `cli_rejects_removed_coordinator_tui`.
- **API:** updated the SM alias router test to POST to `/api/v1/sessions/chat`; added `sessions_context_replaces_coordinator_namespace` asserting `GET /api/v1/sessions/context` → **200** while the retired `GET /api/v1/coordinator/context` → **404**.

## Verification (API commit, `OPENROUTER_API_KEY` unset)
- `cargo build -p trusty-mpm` ✓ · `SKIP_UI_BUILD=1 cargo build -p trusty-mpm-gui` ✓
- `cargo test -p trusty-mpm` ✓ (1338 + 334 + … all pass)
- `cargo test --workspace` ✓ (0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (exit 0)
- `cargo fmt --check` ✓
- `bash scripts/check_line_cap.sh` ✓ (0 violations)
- Grep proof: no functional `/api/v1/coordinator/*` references remain — only the new explanatory comments and the deliberate 404 assertion in the new test.

## Note on the reported `tm session ls` port-7881 bug
Investigated; it does **not** reproduce in source. `session ls` resolves the daemon URL through the global `resolve_daemon_url` (→ lock file → `7880` fallback), the same path the TUI uses. The only `7881` in `trusty-mpm` source is the supervisor's `DEFAULT_METRICS_ADDR` (`127.0.0.1:7881`), an intentionally separate metrics port. Left out of this PR; if it recurs it warrants a separate ticket with a concrete repro (likely a stale `TRUSTY_MPM_URL=…:7881` in the operator's environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)