### PR TITLE
refactor(trusty-mpm): rename CLI `tm session` → `tm sessions` (plural)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -46,6 +46,20 @@
 
 ## [Unreleased]
 
+### Changed: CLI command group `session` → `sessions` (issue #1394)
+
+The top-level CLI command group was renamed from the singular `session` to the
+plural **`sessions`** to match the `/api/v1/sessions/*` HTTP API surface. Every
+subcommand is now invoked under the plural name, e.g. `tm sessions tui`,
+`tm sessions ls`, `tm sessions new`.
+
+- The singular `session` spelling is **removed entirely** — it is not retained
+  as an alias. Invoking `tm session …` now fails with an
+  unrecognized-subcommand error. Update any scripts or muscle memory to
+  `tm sessions …`.
+- This is a CLI-only change; the HTTP API (already `/api/v1/sessions/*`) and the
+  separate `session-manager` / `sm` coordinator command are unaffected.
+
 ### Deprecated: verbose managed session-lifecycle verbs (issue #1205)
 
 The managed session-lifecycle CLI verbs were renamed to the cleaner, symmetric
@@ -55,15 +69,15 @@ will be removed in a future release.
 
 | Deprecated verb | Use instead | Behavior |
 |-----------------|-------------|----------|
-| `tm session runtime-stop <id>` | `tm session stop <id>` | Stop the runtime, keep the workspace (resumable) |
-| `tm session managed-stop <id>` | `tm session stop <id>` | Same as `runtime-stop` |
-| `tm session managed-resume <id>` | `tm session resume <id>` | Re-spawn the runtime in the existing workspace |
+| `tm sessions runtime-stop <id>` | `tm sessions stop <id>` | Stop the runtime, keep the workspace (resumable) |
+| `tm sessions managed-stop <id>` | `tm sessions stop <id>` | Same as `runtime-stop` |
+| `tm sessions managed-resume <id>` | `tm sessions resume <id>` | Re-spawn the runtime in the existing workspace |
 
-- The deprecated verbs are hidden from `tm session --help` but continue to parse
+- The deprecated verbs are hidden from `tm sessions --help` but continue to parse
   for backward compatibility.
 - Each deprecated invocation prints `warning: '<old>' is deprecated; use '<new>'`
   to stderr; stdout stays clean for scripts.
-- `tm session decommission <id>` (terminal teardown: remove workspace from disk)
+- `tm sessions decommission <id>` (terminal teardown: remove workspace from disk)
   is unchanged.
 
 ## [0.5.0] — 2026-05-28

--- a/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
+++ b/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
@@ -38,7 +38,7 @@ Trigger phrases -> act immediately:
 
 After writing: confirm file path, note "takes effect at next session startup."
 Inspect: `ls .trusty-mpm/*.md 2>/dev/null`
-Verify the resolved prompt: `tm session instructions` (or read
+Verify the resolved prompt: `tm sessions instructions` (or read
 `.trusty-mpm/last-instructions.md`).
 
 ## Trusty Tool Priority (Non-Overridable)

--- a/crates/trusty-mpm/src/assets/skills/mpm-session-management.md
+++ b/crates/trusty-mpm/src/assets/skills/mpm-session-management.md
@@ -58,7 +58,7 @@ If found:
 - Display warning with action count and context percentage
 - Options:
   - **Continue**: Resume work from pause state
-  - **Finalize**: Run `tm session --finalize` to create snapshot
+  - **Finalize**: Run `tm sessions --finalize` to create snapshot
   - **Discard**: Start fresh (previous work still in git)
 
 **Example Response**:
@@ -70,7 +70,7 @@ Context usage: ~92%
 
 Options:
 1. Continue working (actions will be recorded)
-2. Finalize pause: tm session --finalize
+2. Finalize pause: tm sessions --finalize
 3. Discard pause: Delete .trusty-mpm/sessions/ACTIVE-PAUSE.jsonl
 
 Would you like to continue from the paused session?

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -82,6 +82,17 @@ pub(crate) enum Command {
         action: ProjectAction,
     },
     /// Define and manage Claude Code sessions within a project.
+    ///
+    /// Why (#1394): the invoked name is the plural `sessions` to match the
+    /// `/api/v1/sessions/*` HTTP API surface. The singular `session` spelling
+    /// is intentionally NOT accepted (no alias) so the CLI and API agree on one
+    /// name. The Rust variant stays `Session` (with an explicit
+    /// `#[command(name = "sessions")]`) to keep the `SessionAction` group and
+    /// every match arm coherent without renaming ~80 internal references.
+    /// What: the `tm sessions <action>` command group (`tui`, `ls`, `new`, …).
+    /// Test: `cli_parses_sessions_plural` / `cli_rejects_singular_session` in
+    /// `tests.rs`.
+    #[command(name = "sessions")]
     Session {
         /// Session action to perform.
         #[command(subcommand)]
@@ -619,7 +630,7 @@ pub(crate) enum CatalogAction {
 pub(crate) enum RepairAction {
     /// Repair the agent/skill deploy state in `~/.claude/`.
     ///
-    /// Why: a crash during `tm install` or `tm session start` may leave stale
+    /// Why: a crash during `tm install` or `tm sessions start` may leave stale
     /// `.tmp` staging files in `~/.claude/agents/` or `~/.claude/skills/`, or
     /// leave either manifest corrupt. This command removes the orphans and
     /// validates both manifests.
@@ -725,7 +736,7 @@ pub(crate) enum SessionAction {
     /// session list (controller bullet + one row per managed session, the active
     /// row in two columns `[id] │ [summary]`). This is a NEW screen, distinct
     /// from the existing `tm tui` dashboard. It lives under the `session` group
-    /// as `tm session tui` (#1392): it operates on the same managed-session list
+    /// as `tm sessions tui` (#1392): it operates on the same managed-session list
     /// the other `session` verbs do, so grouping it there keeps the surface
     /// discoverable without colliding with the `coordinator` SM chat command.
     /// What: polls the daemon's coordinator-context endpoint live on the
@@ -805,7 +816,7 @@ pub(crate) enum SessionAction {
     /// Spawn a new managed session from a repo + ref (session-manager MVP).
     ///
     /// Why: the session-manager MVP provisions an isolated workspace from a git
-    /// repo and starts a harness in it; `tm session new` is the operator-facing
+    /// repo and starts a harness in it; `tm sessions new` is the operator-facing
     /// entry point that posts to `POST /api/v1/sessions/managed`.
     /// What: posts repo, ref, task, and an optional name hint to the daemon.
     /// Test: `cli_parses_session_new`.

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -60,7 +60,7 @@ pub(crate) fn install(force: bool) -> anyhow::Result<()> {
     // so the source dir is populated before this copy runs — mirroring the
     // agent ordering. Without this step a fresh `tm install` left the skills
     // directory empty and `tm doctor` reported `skills: Fail` (#386); skills
-    // only deployed lazily on `tm session start` (see `prepare_session`).
+    // only deployed lazily on `tm sessions start` (see `prepare_session`).
     println!(
         "Deploying skills into {}",
         paths.claude_skills_dir().display()

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -1,6 +1,6 @@
 //! Managed session-manager CLI handlers (session-manager MVP).
 //!
-//! Why: the session-manager MVP adds operator commands (`tm session new/ls/
+//! Why: the session-manager MVP adds operator commands (`tm sessions new/ls/
 //! activity/send/answer/attach/managed-stop` and `tm catalog sync/ls`) that talk
 //! to the daemon's `/api/v1/sessions/managed/*` surface. Keeping these handlers
 //! in their own file keeps `session.rs` under the SLOC cap.
@@ -55,7 +55,7 @@ pub(crate) struct ManagedSummary {
 
 /// Decide whether an id-or-name refers to a MANAGED session, returning its UUID.
 ///
-/// Why: the canonical `tm session stop`/`resume` verbs must operate on managed
+/// Why: the canonical `tm sessions stop`/`resume` verbs must operate on managed
 /// sessions (the documented #842 driver-skill behavior) while still serving the
 /// older local/project-session family. #1218: those verbs were routing every
 /// argument to the project-sessions API, so managed UUIDs came back "not found".
@@ -79,7 +79,7 @@ pub(crate) fn classify_managed_target(
 
 /// Resolve an id-or-name to a MANAGED session id by querying the daemon.
 ///
-/// Why: `tm session stop`/`resume` need to know — before choosing an endpoint —
+/// Why: `tm sessions stop`/`resume` need to know — before choosing an endpoint —
 /// whether the argument is a managed session (#1218). Fetching the managed list
 /// and applying [`classify_managed_target`] keeps that decision in one place and
 /// off the project-session path.
@@ -110,7 +110,7 @@ pub(crate) async fn resolve_managed_id(
     classify_managed_target(&body.sessions, id_or_name)
 }
 
-/// `tm session new` — spawn a managed session from a repo + ref.
+/// `tm sessions new` — spawn a managed session from a repo + ref.
 ///
 /// Why: the operator-facing entry point to provision an isolated workspace and
 /// start a harness in it, optionally selecting the runtime backend.
@@ -162,7 +162,7 @@ pub(crate) async fn session_new(
     Ok(())
 }
 
-/// `tm session ls` — list managed sessions.
+/// `tm sessions ls` — list managed sessions.
 ///
 /// Why: operators need a quick view of every managed session and its pending
 /// decision.
@@ -203,7 +203,7 @@ pub(crate) async fn session_ls(
     Ok(())
 }
 
-/// `tm session activity <id>` — inspect a managed session's activity state.
+/// `tm sessions activity <id>` — inspect a managed session's activity state.
 ///
 /// Why: inspect what a session is doing without attaching; the raw pane is
 /// always returned for the calling agentic process to reason over. The LLM
@@ -281,7 +281,7 @@ pub(crate) async fn session_activity(
     Ok(())
 }
 
-/// `tm session send <id> <text>` — inject text into a managed session's pane.
+/// `tm sessions send <id> <text>` — inject text into a managed session's pane.
 ///
 /// Why: send a message to the harness without attaching to tmux.
 /// What: POSTs `/api/v1/sessions/managed/{id}/send`.
@@ -300,7 +300,7 @@ pub(crate) async fn session_send(
     handle_simple_ok(resp, "sent").await
 }
 
-/// `tm session answer <id> <answer>` — answer a pending decision.
+/// `tm sessions answer <id> <answer>` — answer a pending decision.
 ///
 /// Why: resolve a decision the harness is blocked on.
 /// What: POSTs `/api/v1/sessions/managed/{id}/answer`.
@@ -319,7 +319,7 @@ pub(crate) async fn session_answer(
     handle_simple_ok(resp, "answered").await
 }
 
-/// `tm session attach <id>` — print the tmux attach command.
+/// `tm sessions attach <id>` — print the tmux attach command.
 ///
 /// Why: operators need the exact `tmux attach` command to take over a pane.
 /// What: GETs `/api/v1/sessions/managed/{id}/attach-cmd`.
@@ -346,7 +346,7 @@ pub(crate) async fn session_attach(
     Ok(())
 }
 
-/// `tm session managed-stop <id>` — stop runtime only (keep workspace, deprecated alias).
+/// `tm sessions managed-stop <id>` — stop runtime only (keep workspace, deprecated alias).
 ///
 /// Why: backward-compatible alias for `session_stop`; existing scripts that call
 /// `managed-stop` keep working but get a deprecation nudge toward `stop` (#1205).
@@ -363,7 +363,7 @@ pub(crate) async fn session_managed_stop(
     session_stop(client, url, id).await
 }
 
-/// `tm session runtime-stop <id>` — stop runtime only (deprecated alias).
+/// `tm sessions runtime-stop <id>` — stop runtime only (deprecated alias).
 ///
 /// Why: `runtime-stop` was renamed to `stop` (#1205); the old spelling still
 /// parses but emits a deprecation notice steering operators to `stop`.
@@ -378,7 +378,7 @@ pub(crate) async fn session_runtime_stop(
     session_stop(client, url, id).await
 }
 
-/// `tm session managed-resume <id>` — resume a stopped session (deprecated alias).
+/// `tm sessions managed-resume <id>` — resume a stopped session (deprecated alias).
 ///
 /// Why: `managed-resume` was renamed to `resume` (#1205); the old spelling still
 /// parses but emits a deprecation notice steering operators to `resume`.
@@ -394,7 +394,7 @@ pub(crate) async fn session_managed_resume(
     session_resume(client, url, id).await
 }
 
-/// `tm session stop <id>` — stop the runtime of a managed session, keep the workspace.
+/// `tm sessions stop <id>` — stop the runtime of a managed session, keep the workspace.
 ///
 /// Why: a session ENDURES beyond its runtime; `stop` kills only the tmux session
 /// and claude process, preserving the workspace for later `resume`. Renamed from
@@ -420,7 +420,7 @@ pub(crate) async fn session_stop(
     Ok(())
 }
 
-/// `tm session resume <id>` — resume a stopped managed session in its existing workspace.
+/// `tm sessions resume <id>` — resume a stopped managed session in its existing workspace.
 ///
 /// Why: after `stop`, the workspace is still on disk; `resume` re-spawns the
 /// runtime there without re-cloning. Renamed from the verbose `managed-resume`
@@ -457,7 +457,7 @@ pub(crate) async fn session_resume(
     Ok(())
 }
 
-/// `tm session decommission <id>` — full teardown (remove workspace from disk).
+/// `tm sessions decommission <id>` — full teardown (remove workspace from disk).
 ///
 /// Why: the ONLY operation that permanently removes the workspace directory.
 /// Unlike `runtime-stop`, decommission is terminal — no resume is possible.

--- a/crates/trusty-mpm/src/bin/tm/commands/prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/prune.rs
@@ -1,4 +1,4 @@
-//! `tm session prune-idle` — reclaim idle session-manager sessions (issue #1313).
+//! `tm sessions prune-idle` — reclaim idle session-manager sessions (issue #1313).
 //!
 //! Why: paused orchestration sessions leave behind idle SM tmux sessions that
 //! consume claude Max rate-limit slots and clutter the fleet. This command
@@ -266,7 +266,7 @@ fn short_id(id: &str) -> &str {
     id.split('-').next().unwrap_or(id)
 }
 
-/// `tm session prune-idle` — enumerate idle SM sessions and reclaim them.
+/// `tm sessions prune-idle` — enumerate idle SM sessions and reclaim them.
 ///
 /// Why: the operator-facing (and pause-automated) entry point. It must reuse the
 /// existing managed list/activity/runtime-stop/decommission surface, apply the

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -163,7 +163,7 @@ pub(crate) async fn session(
             url: tui_url,
             interval_ms,
         } => {
-            // #1392: the coordinator TUI is `tm session tui` (formerly the
+            // #1392: the coordinator TUI is `tm sessions tui` (formerly the
             // top-level `tm coordinator-tui`). It polls the daemon live, so its
             // `run` is async and runs on the tokio runtime like `tui::run`.
             // `resolve_daemon_url` honours an explicit `--url`, then the lock
@@ -466,7 +466,7 @@ pub(crate) async fn resolve_session_id(
 /// prompt — the text actually delivered to `claude --append-system-prompt-file`.
 /// The old code returned `output.merged` (the legacy pipeline: INSTRUCTIONS.md +
 /// delegation authority + CLAUDE.md) for display, while stashing `resolve_pm_prompt`
-/// separately. That caused `tm session instructions` to print content that differed
+/// separately. That caused `tm sessions instructions` to print content that differed
 /// from what Claude received, which is exactly the divergence issue #382 describes.
 /// The single source of truth for "what claude receives" is `resolve_pm_prompt`;
 /// the display and the stash must both come from it.
@@ -498,7 +498,7 @@ pub(crate) fn compose_session_instructions(
 
     // The single source of truth for the live PM prompt is `resolve_pm_prompt`.
     // Writing it to the stash AND returning it as the display string ensures that
-    // `tm session instructions` always shows exactly what `claude` received (the
+    // `tm sessions instructions` always shows exactly what `claude` received (the
     // #382 fix). Previously this function returned `output.merged` for display,
     // which came from the old pipeline (INSTRUCTIONS.md + delegation + CLAUDE.md)
     // and differed from the stash, causing the visible divergence.

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
@@ -221,7 +221,7 @@ pub(crate) async fn ticket(
 /// POST the managed-session spawn request that drives the ticket implementation.
 ///
 /// Why: reuses the exact session-manager spawn path (`POST
-/// /api/v1/sessions/managed`) that `tm session new` uses, so `tm ticket` plugs
+/// /api/v1/sessions/managed`) that `tm sessions new` uses, so `tm ticket` plugs
 /// into the existing isolated-workspace + runtime-adapter machinery rather than
 /// re-implementing it. The provisioner clones the repo and the driver agent
 /// creates `branch` off the base ref per the task instructions.

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/dispatch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/dispatch.rs
@@ -128,7 +128,7 @@ pub(crate) async fn dispatch_issue(
 /// POST the managed-session spawn request that drives the issue implementation.
 ///
 /// Why: reuses the exact session-manager spawn path (`POST
-/// /api/v1/sessions/managed`) that `tm ticket` / `tm session new` use, so
+/// /api/v1/sessions/managed`) that `tm ticket` / `tm sessions new` use, so
 /// `tm watch` plugs into the existing isolated-workspace + runtime-adapter
 /// machinery (the P4 workspace root `~/trusty-mpm-projects/<owner>/<repo>/…`)
 /// rather than re-implementing it. The provisioner clones the repo and the driver

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -274,7 +274,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Meta { action } => commands::meta::meta(action),
     };
 
-    // Top-level exit-code translation: a `tm session prune-idle` that found the
+    // Top-level exit-code translation: a `tm sessions prune-idle` that found the
     // Session Manager unavailable returns `PruneError::SmUnavailable`. That is a
     // graceful no-op, not a failure, so exit with the distinct code 75 (the
     // pause skill branches on it) instead of anyhow's default 1. Any other error

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -294,7 +294,7 @@ fn normalize_workdir_strips_trailing_slash() {
 
 #[test]
 fn cli_parses_session_start() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "start"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "start"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Start { dir },
@@ -305,7 +305,7 @@ fn cli_parses_session_start() {
 
 #[test]
 fn cli_parses_session_start_with_dir() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "start", "--dir", "/work/p"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "start", "--dir", "/work/p"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Start { dir },
@@ -316,7 +316,7 @@ fn cli_parses_session_start_with_dir() {
 
 #[test]
 fn cli_parses_session_stop() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "stop", "tmpm-quiet-falcon"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "stop", "tmpm-quiet-falcon"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Stop { id_or_name },
@@ -328,12 +328,12 @@ fn cli_parses_session_stop() {
 #[test]
 fn cli_session_stop_requires_arg() {
     // `session stop` without an id-or-name is an error.
-    assert!(Cli::try_parse_from(["trusty-mpm", "session", "stop"]).is_err());
+    assert!(Cli::try_parse_from(["trusty-mpm", "sessions", "stop"]).is_err());
 }
 
 #[test]
 fn cli_parses_session_list() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "list"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "list"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::List { dir },
@@ -344,7 +344,7 @@ fn cli_parses_session_list() {
 
 #[test]
 fn cli_parses_session_clean() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "clean"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "clean"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Clean { dir },
@@ -355,7 +355,7 @@ fn cli_parses_session_clean() {
 
 #[test]
 fn cli_parses_session_info() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "info", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "info", "abc-123"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Info { id_or_name },
@@ -366,7 +366,7 @@ fn cli_parses_session_info() {
 
 #[test]
 fn cli_parses_session_instructions() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "instructions"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "instructions"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Instructions { dir },
@@ -378,7 +378,7 @@ fn cli_parses_session_instructions() {
 #[test]
 fn cli_parses_session_instructions_with_dir() {
     let cli =
-        Cli::try_parse_from(["trusty-mpm", "session", "instructions", "--dir", "/tmp"]).unwrap();
+        Cli::try_parse_from(["trusty-mpm", "sessions", "instructions", "--dir", "/tmp"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Instructions { dir },
@@ -433,13 +433,13 @@ fn cli_parses_tui_with_interval() {
 
 #[test]
 fn cli_parses_session_tui() {
-    // #1392: the coordinator TUI is the `tm session tui` subcommand (renamed
+    // #1392: the coordinator TUI is the `tm sessions tui` subcommand (renamed
     // from the former top-level `tm coordinator-tui`). Its `--interval-ms`
     // defaults to 1500. The `url` arg carries `env = "TRUSTY_MPM_URL"`, so an
     // ambient `TRUSTY_MPM_URL` in the test runner would override the (absent)
     // default — assert only the env-independent interval default here, and the
     // url plumbing in `cli_parses_session_tui_with_flags`.
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "tui"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "tui"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Tui { interval_ms, .. },
@@ -454,7 +454,7 @@ fn cli_parses_session_tui() {
 fn cli_parses_session_tui_with_flags() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "session",
+        "sessions",
         "tui",
         "--url",
         "http://127.0.0.1:9999",
@@ -471,6 +471,34 @@ fn cli_parses_session_tui_with_flags() {
         }
         other => panic!("expected Session::Tui, got {other:?}"),
     }
+}
+
+#[test]
+fn cli_parses_sessions_plural() {
+    // #1394: the command group is invoked as the plural `sessions` (matching
+    // the `/api/v1/sessions/*` HTTP API). Assert a representative subcommand
+    // parses under the plural name.
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "list"]).unwrap();
+    match cli.command {
+        Command::Session {
+            action: SessionAction::List { dir },
+        } => assert_eq!(dir, None),
+        other => panic!("expected sessions list, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_rejects_singular_session() {
+    // #1394: the singular `session` spelling was renamed to `sessions` with NO
+    // alias kept. Parsing the singular name must fail with an
+    // unrecognized-subcommand error so the CLI and the HTTP API agree on one
+    // name. (The separate `session-manager` command is unaffected and remains.)
+    let err = Cli::try_parse_from(["trusty-mpm", "session", "list"]).unwrap_err();
+    assert_eq!(
+        err.kind(),
+        clap::error::ErrorKind::InvalidSubcommand,
+        "singular `session` must be rejected as an unrecognized subcommand"
+    );
 }
 
 #[test]
@@ -658,7 +686,7 @@ fn cli_parses_supervisor_flags() {
 fn cli_parses_session_new() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "session",
+        "sessions",
         "new",
         "https://github.com/owner/repo",
         "--git-ref",
@@ -697,7 +725,7 @@ fn cli_parses_session_new_with_tcode_runtime() {
     // `--runtime tcode`; this guards the flag wiring on the New subcommand.
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "session",
+        "sessions",
         "new",
         "https://github.com/owner/repo",
         "--task",
@@ -723,7 +751,7 @@ fn cli_rejects_unknown_runtime_at_parse_time() {
     // rather than being forwarded to the daemon and rejected at the HTTP layer.
     let err = Cli::try_parse_from([
         "trusty-mpm",
-        "session",
+        "sessions",
         "new",
         "https://github.com/owner/repo",
         "--task",
@@ -741,7 +769,7 @@ fn cli_rejects_unknown_runtime_at_parse_time() {
 
 #[test]
 fn cli_parses_session_ls() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "ls", "--json"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "ls", "--json"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Ls { json },
@@ -752,7 +780,7 @@ fn cli_parses_session_ls() {
 
 #[test]
 fn cli_parses_session_activity() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "activity", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "activity", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Activity { id },
@@ -763,7 +791,7 @@ fn cli_parses_session_activity() {
 
 #[test]
 fn cli_parses_session_send() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "send", "abc", "hello"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "send", "abc", "hello"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Send { id, text },
@@ -777,7 +805,7 @@ fn cli_parses_session_send() {
 
 #[test]
 fn cli_parses_session_answer() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "answer", "abc", "rebase"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "answer", "abc", "rebase"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Answer { id, answer },
@@ -791,7 +819,7 @@ fn cli_parses_session_answer() {
 
 #[test]
 fn cli_parses_session_attach() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "attach", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "attach", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Attach { id },
@@ -802,7 +830,7 @@ fn cli_parses_session_attach() {
 
 #[test]
 fn cli_parses_session_managed_stop() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "managed-stop", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "managed-stop", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::ManagedStop { id },
@@ -814,7 +842,7 @@ fn cli_parses_session_managed_stop() {
 #[test]
 fn cli_parses_session_runtime_stop() {
     // The deprecated `runtime-stop` verb still parses (alias of `stop`, #1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "runtime-stop", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "runtime-stop", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::RuntimeStop { id },
@@ -826,7 +854,7 @@ fn cli_parses_session_runtime_stop() {
 #[test]
 fn cli_parses_session_managed_resume() {
     // The deprecated `managed-resume` verb still parses (alias of `resume`, #1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "managed-resume", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "managed-resume", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::ManagedResume { id },
@@ -839,7 +867,7 @@ fn cli_parses_session_managed_resume() {
 fn cli_parses_session_stop_verb() {
     // The canonical `stop` verb parses to the local-session Stop action (#1205);
     // it shares the clean name the deprecated managed verbs now point at.
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "stop", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "stop", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Stop { id_or_name },
@@ -851,7 +879,7 @@ fn cli_parses_session_stop_verb() {
 #[test]
 fn cli_parses_session_resume_verb() {
     // The canonical `resume` verb parses to the Resume action (#1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "resume", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "resume", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Resume { id_or_name },
@@ -863,7 +891,7 @@ fn cli_parses_session_resume_verb() {
 #[test]
 fn cli_parses_session_decommission() {
     // `decommission` remains the terminal teardown verb (#1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "decommission", "abc"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "decommission", "abc"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Decommission { id },
@@ -875,8 +903,14 @@ fn cli_parses_session_decommission() {
 #[test]
 fn cli_parses_session_prune_idle() {
     // `prune-idle` (#1313) accepts both flags; defaults are false.
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "prune-idle", "--dry-run", "--json"])
-        .unwrap();
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "sessions",
+        "prune-idle",
+        "--dry-run",
+        "--json",
+    ])
+    .unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::PruneIdle { dry_run, json },
@@ -891,7 +925,7 @@ fn cli_parses_session_prune_idle() {
 #[test]
 fn cli_parses_session_prune_idle_defaults() {
     // With no flags, prune-idle defaults to a live (non-dry-run), text run.
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "prune-idle"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "prune-idle"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::PruneIdle { dry_run, json },
@@ -939,7 +973,7 @@ fn classify_managed_target_matches_by_id() {
 #[test]
 fn classify_managed_target_matches_by_name_returns_id() {
     // A friendly managed name must resolve to the canonical UUID the managed
-    // endpoints require, so `tm session stop <name>` works for managed sessions.
+    // endpoints require, so `tm sessions stop <name>` works for managed sessions.
     use crate::commands::managed::{ManagedSummary, classify_managed_target};
     let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
     let sessions: Vec<ManagedSummary> = serde_json::from_value(serde_json::json!([

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
@@ -271,7 +271,7 @@ fn cli_parses_optimizer_set() {
 
 #[test]
 fn cli_parses_session_events() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "events", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "events", "abc-123"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Events { id_or_name },
@@ -282,7 +282,7 @@ fn cli_parses_session_events() {
 
 #[test]
 fn cli_parses_session_breakers() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "breakers"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "breakers"]).unwrap();
     assert!(matches!(
         cli.command,
         Command::Session {
@@ -293,7 +293,8 @@ fn cli_parses_session_breakers() {
 
 #[test]
 fn cli_parses_session_pause() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "pause", "tmpm-quiet-falcon"]).unwrap();
+    let cli =
+        Cli::try_parse_from(["trusty-mpm", "sessions", "pause", "tmpm-quiet-falcon"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Pause { id_or_name, note },
@@ -309,7 +310,7 @@ fn cli_parses_session_pause() {
 fn cli_parses_session_pause_with_note() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "session",
+        "sessions",
         "pause",
         "abc-123",
         "--note",
@@ -329,7 +330,7 @@ fn cli_parses_session_pause_with_note() {
 
 #[test]
 fn cli_parses_session_resume() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "resume", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "resume", "abc-123"]).unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Resume { id_or_name },
@@ -340,7 +341,7 @@ fn cli_parses_session_resume() {
 
 #[test]
 fn cli_parses_session_run() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "run", "abc-123", "help me"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "run", "abc-123", "help me"]).unwrap();
     match cli.command {
         Command::Session {
             action:
@@ -362,7 +363,7 @@ fn cli_parses_session_run() {
 fn cli_parses_session_run_with_summarize() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "session",
+        "sessions",
         "run",
         "tmpm-abc",
         "help",
@@ -379,7 +380,7 @@ fn cli_parses_session_run_with_summarize() {
 
 #[test]
 fn cli_parses_session_output_defaults() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "output", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "output", "abc-123"]).unwrap();
     match cli.command {
         Command::Session {
             action:
@@ -401,7 +402,7 @@ fn cli_parses_session_output_defaults() {
 fn cli_parses_session_output_with_lines() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "session",
+        "sessions",
         "output",
         "abc-123",
         "--lines",
@@ -418,8 +419,14 @@ fn cli_parses_session_output_with_lines() {
 
 #[test]
 fn cli_parses_session_output_with_summarize() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "output", "tmpm-abc", "--summarize"])
-        .unwrap();
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "sessions",
+        "output",
+        "tmpm-abc",
+        "--summarize",
+    ])
+    .unwrap();
     match cli.command {
         Command::Session {
             action: SessionAction::Output { summarize, .. },
@@ -463,12 +470,12 @@ fn compression_stats_line_printed_when_compressed() {
 
 #[test]
 fn cli_session_pause_requires_arg() {
-    assert!(Cli::try_parse_from(["trusty-mpm", "session", "pause"]).is_err());
+    assert!(Cli::try_parse_from(["trusty-mpm", "sessions", "pause"]).is_err());
 }
 
 #[test]
 fn cli_session_run_requires_command() {
-    assert!(Cli::try_parse_from(["trusty-mpm", "session", "run", "abc-123"]).is_err());
+    assert!(Cli::try_parse_from(["trusty-mpm", "sessions", "run", "abc-123"]).is_err());
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b.rs
@@ -262,7 +262,7 @@ fn cli_parses_services_restart() {
 
 #[test]
 fn compose_session_instructions_display_matches_stash() {
-    // Why: the #382 bug was that `tm session instructions` printed
+    // Why: the #382 bug was that `tm sessions instructions` printed
     // `output.merged` (old pipeline text) while the stash held the
     // override-resolved PM prompt — a visible divergence. After the fix
     // both come from `resolve_pm_prompt`, so they must be identical.
@@ -282,13 +282,13 @@ fn compose_session_instructions_display_matches_stash() {
 
     assert_eq!(
         display, on_disk,
-        "tm session instructions display must equal the stash file (issue #382)"
+        "tm sessions instructions display must equal the stash file (issue #382)"
     );
 }
 
 #[test]
 fn compose_session_instructions_display_matches_live_prompt() {
-    // Why: `tm session instructions` must show exactly what `claude` receives
+    // Why: `tm sessions instructions` must show exactly what `claude` receives
     // via `--append-system-prompt-file`; the live prompt is produced by
     // `build_system_prompt_for`, which calls `resolve_pm_prompt`. If
     // `compose_session_instructions` ever returns something different from
@@ -308,7 +308,7 @@ fn compose_session_instructions_display_matches_live_prompt() {
 
     assert_eq!(
         display, live_prompt,
-        "tm session instructions output must match the live launch prompt (issue #382)"
+        "tm sessions instructions output must match the live launch prompt (issue #382)"
     );
 }
 

--- a/crates/trusty-mpm/src/client/http_client/session_connect.rs
+++ b/crates/trusty-mpm/src/client/http_client/session_connect.rs
@@ -19,7 +19,7 @@ impl DaemonClient {
     ///
     /// Why: the TUI's `/connect <dir>` command is the single entry point for
     /// "connect to or launch a session for a project" — when no session exists
-    /// for a directory it must start one, mirroring `tm session start`. A
+    /// for a directory it must start one, mirroring `tm sessions start`. A
     /// trusty-mpm session is always the `claude` (Claude Code) CLI, never
     /// `claude-mpm`; the trusty-mpm behaviour comes from the custom instructions
     /// (deployed agents + project `CLAUDE.md`) prepared before launch.

--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -280,7 +280,7 @@ impl MpmConfig {
 /// What: evaluates four sources in descending priority order:
 ///
 /// 1. `explicit` — a model string explicitly specified by the caller (e.g.,
-///    from the `tm session start --model` flag). If `Some`, wins immediately.
+///    from the `tm sessions start --model` flag). If `Some`, wins immediately.
 /// 2. `config.models.agents.<agent_name>` — the per-agent override in
 ///    `~/.trusty-mpm/config.toml`.
 /// 3. `frontmatter_model` — the `model:` field from the agent's frontmatter

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -100,7 +100,7 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 ///
 /// Why: this is the single source of truth #381 requires — both the live prompt
 /// delivered to `claude` (`--append-system-prompt-file`) and the inspectable
-/// stash (`tm session instructions` / `.trusty-mpm/last-instructions.md`) call
+/// stash (`tm sessions instructions` / `.trusty-mpm/last-instructions.md`) call
 /// it, so the inspectable copy can never diverge from what the PM actually
 /// received (the #382 concern).
 ///

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -4,7 +4,7 @@
 //! trusty-mpm must instead build the `claude` CLI invocation with an explicit
 //! `--model` flag so the resolved model actually takes effect. This module
 //! centralises the command-string construction so every launch path (CLI
-//! `tm launch`, `tm session start`, daemon) emits the same correctly-formed
+//! `tm launch`, `tm sessions start`, daemon) emits the same correctly-formed
 //! command.
 //! What: [`build_claude_command`] composes the full shell string passed to
 //! `tmux send-keys`; it optionally appends `--model <id>` and
@@ -43,7 +43,7 @@ pub fn write_prompt_file(prompt: &str) -> Option<PathBuf> {
 
 /// Resolve the model for a PM-session launch (no named agent).
 ///
-/// Why: the top-level `tm launch` / `tm session start` path spawns Claude
+/// Why: the top-level `tm launch` / `tm sessions start` path spawns Claude
 /// Code as the PM, not as a named specialist agent. The model resolution still
 /// reads from the config (using the special key `"pm"` or the configured
 /// `models.default`) so operators can pin the PM tier.

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -32,7 +32,7 @@ pub(super) const SPINNER_TIPS: &[&str] = &[
     "Delegate Rust code to rust-engineer — PM never edits .rs files",
     "gh issue create to track work; commits include Closes #N",
     "tmux ls shows all active tmpm-<folder> sessions",
-    "tm session list shows daemon-managed sessions",
+    "tm sessions list shows daemon-managed sessions",
     "/compact at ~50% context to stay focused",
     "Layer new features behind the HTTP API before wiring CLI or TUI",
 ];

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -418,7 +418,7 @@ fn inject_trusty_memory_mcp_preserves_existing() {
 
 #[test]
 fn inject_trusty_memory_mcp_is_idempotent() {
-    // Why: `/connect` and `tm session start` may run repeatedly; a second
+    // Why: `/connect` and `tm sessions start` may run repeatedly; a second
     // injection must not duplicate or alter the `trusty-memory` entry.
     let tmp = tempdir().unwrap();
     let project = tmp.path();
@@ -994,7 +994,7 @@ fn prepare_session_reports_skill_deploy() {
 
 #[test]
 fn prepare_session_is_idempotent() {
-    // Why: `/connect` and `tm session start` may run repeatedly on the same
+    // Why: `/connect` and `tm sessions start` may run repeatedly on the same
     // project; a second prep must not fail and must not recreate CLAUDE.md.
     // Use a dedicated tmp_home so parallel tests never race on the shared
     // ~/.claude/agents manifest (each test needs its own claude_agents_dir).

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -64,7 +64,7 @@ pub mod prompt;
 pub mod providers;
 /// Idle-session prune policy (issue #1313).
 ///
-/// Why: the `tm session prune-idle` command needs a pure, testable mapping from
+/// Why: the `tm sessions prune-idle` command needs a pure, testable mapping from
 /// a session's latest activity-monitor verdict to a durability-respecting
 /// teardown action (stop idle, decommission done, skip everything else). Keeping
 /// it in core (not the binary) lets it be unit-tested without a live daemon and

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -122,7 +122,7 @@ pub trait OrchestratorBackend: Send + Sync {
     ///
     /// Why: the driver skill needs a typed, JSON-native way to create an
     ///      isolated, provisioned workspace and launch a harness in it — without
-    ///      scraping `tm session new` CLI text (the #842 defect).
+    ///      scraping `tm sessions new` CLI text (the #842 defect).
     /// What: provisions a workspace cloned from `repo_url` at `git_ref`, creates
     ///       the tmux host, launches the selected `runtime` (default claude-code)
     ///       with `task`, and returns the new session's id / tmux name /

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -82,7 +82,7 @@ pub trait RuntimeAdapter: Send + Sync {
 
 /// Selector for which runtime backend a managed session uses.
 ///
-/// Why: the spawn endpoint and `tm session new` let the operator pick a backend
+/// Why: the spawn endpoint and `tm sessions new` let the operator pick a backend
 /// (`runtime=tcode` / `--runtime tcode`); the choice must survive on the
 /// persisted [`crate::session_manager::SessionRecord`] so `resume` re-spawns the
 /// SAME backend rather than silently reverting to the default.

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -51,7 +51,7 @@ pub enum ManagedError {
     Io(#[from] std::io::Error),
 
     /// A name derived from the cwd hint collided with an existing session.
-    #[error("name already in use: {0} — use `tm session ls` to find it")]
+    #[error("name already in use: {0} — use `tm sessions ls` to find it")]
     NameCollision(String),
 
     /// The operation is not valid for the current session state.
@@ -649,7 +649,7 @@ impl SessionManager {
     /// Mark a session as errored with a message.
     ///
     /// Why: when provisioning or spawning fails the session must not remain in
-    /// `Provisioning`; marking it errored surfaces the failure to `tm session ls`.
+    /// `Provisioning`; marking it errored surfaces the failure to `tm sessions ls`.
     /// What: transitions the record to `ManagedSessionState::Errored` and appends
     /// the error message to the task field for observability, then persists.
     /// Test: covered by handler_spawn_wires_provision_and_spawn error path.
@@ -668,7 +668,7 @@ impl SessionManager {
     /// Update a session's workspace path and transition to a new state.
     ///
     /// Why: after `WorkspaceProvisioner::provision` returns the workspace path
-    /// must be persisted so `tm session ls` shows it and `activity` can infer
+    /// must be persisted so `tm sessions ls` shows it and `activity` can infer
     /// context.
     /// What: looks up the record, sets `workspace_path` and `state`, and persists.
     /// Test: covered by handler_spawn_wires_provision_and_spawn.

--- a/crates/trusty-mpm/src/tui/coordinator/mod.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/mod.rs
@@ -7,7 +7,7 @@
 //! the skeleton (layout, selection, input editing, panic-safe terminal); Child
 //! #2 wires live session-list polling + daemon-down handling.
 //! What: thin façade re-exporting the submodules and exposing [`run`], the
-//! `tm session tui` entry point. [`run`] polls the daemon's
+//! `tm sessions tui` entry point. [`run`] polls the daemon's
 //! coordinator-context endpoint on the `--interval-ms` cadence and maps each
 //! session into the live list (see [`poll`]). The daemon-backed `last_summary`
 //! column and slash-command dispatch are deferred to later children; the summary
@@ -80,7 +80,7 @@ const KEY_POLL: Duration = Duration::from_millis(50);
 
 /// Launch the coordinator TUI against `url`, polling every `interval_ms`.
 ///
-/// Why: the `tm session tui` subcommand needs one entry point that owns the
+/// Why: the `tm sessions tui` subcommand needs one entry point that owns the
 /// terminal lifecycle. Now async (Child #2 added live daemon IO) so it runs on
 /// the same tokio runtime as `tui::run`.
 /// What: builds a [`DaemonClient`] for `url`, enters raw mode + the alternate

--- a/crates/trusty-mpm/src/tui/iterm2.rs
+++ b/crates/trusty-mpm/src/tui/iterm2.rs
@@ -5,7 +5,7 @@
 //! process. AppleScript is the most reliable mechanism — no extra deps, works
 //! on every macOS iTerm2 install.
 //! What: `is_iterm2()` checks env vars at startup; `open_session_tab` runs
-//! an `osascript` one-liner that creates a new tab running `tm session attach
+//! an `osascript` one-liner that creates a new tab running `tm sessions attach
 //! <id>`.
 //! Test: Detection logic is pure and unit-tested below; AppleScript calls are
 //! integration-only (no test without a live iTerm2).
@@ -27,7 +27,7 @@ pub fn is_iterm2() -> bool {
     std::path::Path::new("/Applications/iTerm.app").exists()
 }
 
-/// Open a new iTerm2 tab in the current window running `tm session attach <session_id>`.
+/// Open a new iTerm2 tab in the current window running `tm sessions attach <session_id>`.
 ///
 /// Why: The operator can monitor the session list in the TUI while the new tab
 /// runs the actual Claude Code session — no window-switching required.
@@ -39,7 +39,7 @@ pub fn open_session_tab(session_id: &str) -> Result<(), String> {
     let script = format!(
         r#"tell application "iTerm2"
   tell current window
-    create tab with default profile command "tm session attach {session_id}"
+    create tab with default profile command "tm sessions attach {session_id}"
   end tell
 end tell"#
     );

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -900,7 +900,7 @@ async fn front_gate_answer_unblocks_spawn() {
 /// it returns `PruneError::SmUnavailable`, which `main` downcasts and translates
 /// to exit 75. Pointing the command at a dead loopback port forces the transport
 /// (unreachable) branch deterministically without standing up a daemon.
-/// What: spawns `tm --url http://127.0.0.1:<dead> session prune-idle --json` and
+/// What: spawns `tm --url http://127.0.0.1:<dead> sessions prune-idle --json` and
 /// asserts the process exits with status code 75. Uses `CARGO_BIN_EXE_tm`
 /// (set by Cargo for integration tests) so no extra dev-dependency is needed.
 /// Test: this test.
@@ -915,7 +915,7 @@ fn cli_prune_idle_unreachable_exit_code() {
         .args([
             "--url",
             "http://127.0.0.1:1",
-            "session",
+            "sessions",
             "prune-idle",
             "--json",
         ])

--- a/docs/specs/tui-coordinator.md
+++ b/docs/specs/tui-coordinator.md
@@ -35,7 +35,7 @@ message]`.
 This is the conversational front door to the fleet of durable, tmux-backed
 Claude Code sessions that the session manager already owns (see the
 `session-manager-driver` skill). It replaces the need to drive the fleet through
-discrete `tm session …` CLI calls for the common "talk to my fleet, spin up
+discrete `tm sessions …` CLI calls for the common "talk to my fleet, spin up
 work, watch it progress" loop.
 
 ### 1.2 Goals
@@ -439,7 +439,7 @@ meaningful line from `recent_output`, else the status word.
 
 - Editing code or files inside a session (that is the session's own Claude Code).
 - A web/graphical UI — owned by `trusty-console` / `trusty-mpm-gui`.
-- Replacing the `tm session …` / `tm` CLI (the TUI complements it).
+- Replacing the `tm sessions …` / `tm` CLI (the TUI complements it).
 - Implementing the daemon-side `last_summary` enrichment (that is its own child
   ticket; this spec only specifies the contract the TUI needs).
 - Fixing #1268 / #1269 (external dependencies the TUI consumes).

--- a/docs/trusty-mpm/console-front-door.md
+++ b/docs/trusty-mpm/console-front-door.md
@@ -87,6 +87,6 @@ The Telegram bot currently calls the daemon's HTTP API directly
 
 ## Backward compatibility
 
-P2/P3 are strictly additive. The daemon's HTTP REST API and the `tm session …`
+P2/P3 are strictly additive. The daemon's HTTP REST API and the `tm sessions …`
 CLI are unchanged; the daemon HTTP is documented as internal plumbing but **not
 removed**. Removal is a possible follow-up once all known callers have migrated.

--- a/docs/trusty-mpm/design/RFC-session-manager-mcp-console.md
+++ b/docs/trusty-mpm/design/RFC-session-manager-mcp-console.md
@@ -16,7 +16,7 @@ The trusty-mpm session manager is currently a two-surface system:
 | Surface | Implementation | Location |
 |---|---|---|
 | HTTP REST API | axum daemon, binds `:7880` (or auto-port) | `crates/trusty-mpm/src/daemon/api.rs` |
-| CLI | `tm session …` subcommands shelling out to HTTP | `crates/trusty-mpm/src/bin/tm/commands/session.rs` |
+| CLI | `tm sessions …` subcommands shelling out to HTTP | `crates/trusty-mpm/src/bin/tm/commands/session.rs` |
 
 This creates three concrete pain points:
 
@@ -487,7 +487,7 @@ Console provides a configuration UI for trusty-mpm.
    - `FrameworkPaths` gains a `workspace_root(github_path: Option<&GithubPath>) -> PathBuf`
      method: returns `~/trusty-mpm-projects/<owner>/<repo>` when a github path is
      available, falls back to `~/.trusty-mpm/workspaces/<project>` for backward compat.
-   - `tm session new` (and the MCP `session_new` tool) derive the default workspace
+   - `tm sessions new` (and the MCP `session_new` tool) derive the default workspace
      root from the target repo's GitHub remote URL.
    - CLI flag `--workspace-root` and MCP tool param `workspace_root` override the
      default.
@@ -512,7 +512,7 @@ Console provides a configuration UI for trusty-mpm.
      (added in P1 / follow-up to P1).
 
 **Acceptance criteria:**
-- `tm session new` in a git repo defaults to `~/trusty-mpm-projects/bobmatnyc/trusty-tools/<id>/`.
+- `tm sessions new` in a git repo defaults to `~/trusty-mpm-projects/bobmatnyc/trusty-tools/<id>/`.
 - `~/.trusty-tools/trusty-mpm/config.yaml` is read at daemon startup;
   `workspace_root_template` overrides the default.
 - Console config UI renders and saves trusty-mpm config.
@@ -550,7 +550,7 @@ CLI:
 
 | Existing surface | Impact in P1 | Impact in P2–P4 |
 |---|---|---|
-| `tm session list/new/stop/resume` | No change | No change |
+| `tm sessions list/new/stop/resume` | No change | No change |
 | `GET http://...:7880/sessions` | No change | Documented as internal; not removed |
 | `trusty-mpm daemon` binary | `POST /rpc` endpoint added | No change |
 | `.mcp.json` trusty-mpm entry | Added (new) | Extended |

--- a/docs/trusty-mpm/spec/SESSION_MANAGER_DRIVER_AGENT.md
+++ b/docs/trusty-mpm/spec/SESSION_MANAGER_DRIVER_AGENT.md
@@ -107,7 +107,7 @@ command prints the cached counts and exits 0.
 ### 3.2 Step 1 — Spawn a session
 
 ```
-tm session new \
+tm sessions new \
   --repo  <https://github.com/org/repo> \
   --ref   <branch-or-sha> \
   --task  "<human-readable task description>" \
@@ -182,7 +182,7 @@ The driver must not treat the optional LLM `state` field as authoritative when
 **Send arbitrary text to the session pane:**
 
 ```
-tm session send <id> "<text>"
+tm sessions send <id> "<text>"
 ```
 
 HTTP: `POST /api/v1/sessions/managed/{id}/send  { "text": "..." }`
@@ -198,7 +198,7 @@ When `pending_decision` is non-null, the driver applies the autonomy policy
 To inject an accepted or overridden answer:
 
 ```
-tm session answer <id> "<answer text>"
+tm sessions answer <id> "<answer text>"
 ```
 
 HTTP: `POST /api/v1/sessions/managed/{id}/answer  { "answer": "..." }`
@@ -214,10 +214,10 @@ workspace.
 
 | Operation | CLI | HTTP | Effect |
 |---|---|---|---|
-| Stop runtime (keep workspace) | `tm session runtime-stop <id>` | `POST /api/v1/sessions/managed/{id}/runtime-stop` | Kills tmux session + claude process; workspace intact; state → `stopped`; resumable |
-| Resume (restart runtime) | `tm session managed-resume <id>` | `POST /api/v1/sessions/managed/{id}/resume` | Re-spawns claude in the EXISTING workspace; no re-clone; state → `active` |
-| Decommission (full teardown) | `tm session decommission <id>` | `POST /api/v1/sessions/managed/{id}/decommission` | Kills runtime, removes workspace from disk, state → `decommissioned`; tombstone record kept; no resume possible |
-| Legacy stop alias | `tm session managed-stop <id>` | `DELETE /api/v1/sessions/managed/{id}` | Delegates to `runtime-stop`; backward-compatible |
+| Stop runtime (keep workspace) | `tm sessions runtime-stop <id>` | `POST /api/v1/sessions/managed/{id}/runtime-stop` | Kills tmux session + claude process; workspace intact; state → `stopped`; resumable |
+| Resume (restart runtime) | `tm sessions managed-resume <id>` | `POST /api/v1/sessions/managed/{id}/resume` | Re-spawns claude in the EXISTING workspace; no re-clone; state → `active` |
+| Decommission (full teardown) | `tm sessions decommission <id>` | `POST /api/v1/sessions/managed/{id}/decommission` | Kills runtime, removes workspace from disk, state → `decommissioned`; tombstone record kept; no resume possible |
+| Legacy stop alias | `tm sessions managed-stop <id>` | `DELETE /api/v1/sessions/managed/{id}` | Delegates to `runtime-stop`; backward-compatible |
 
 **Lifecycle state machine:**
 
@@ -253,7 +253,7 @@ for correlating the session to its artifacts.
 **Listing all sessions:**
 
 ```
-tm session ls [--json]
+tm sessions ls [--json]
 ```
 
 HTTP: `GET /api/v1/sessions/managed`
@@ -270,7 +270,7 @@ GET /api/v1/sessions/managed/{id}
 **Getting the tmux attach command (for human inspection):**
 
 ```
-tm session attach <id>        # prints: tmux attach-session -t tmpm-<slug>
+tm sessions attach <id>        # prints: tmux attach-session -t tmpm-<slug>
 ```
 
 HTTP: `GET /api/v1/sessions/managed/{id}/attach-cmd`
@@ -359,16 +359,16 @@ the daemon base URL discovered from `~/.trusty-mpm/daemon.lock` (default
 |---|---|
 | `tm catalog sync [--force]` | `CatalogSync::sync` — fetches claude-mpm repo catalog to `~/.trusty-mpm/catalog/` |
 | `tm catalog ls [--json]` | Lists cached agents and skills |
-| `tm session new --repo --ref --task [--name]` | `POST /api/v1/sessions/managed` |
-| `tm session ls [--json]` | `GET /api/v1/sessions/managed` |
-| `tm session activity <id>` | `GET /api/v1/sessions/managed/{id}/activity` |
-| `tm session send <id> <text>` | `POST /api/v1/sessions/managed/{id}/send` |
-| `tm session answer <id> <answer>` | `POST /api/v1/sessions/managed/{id}/answer` |
-| `tm session attach <id>` | `GET /api/v1/sessions/managed/{id}/attach-cmd` |
-| `tm session runtime-stop <id>` | `POST /api/v1/sessions/managed/{id}/runtime-stop` |
-| `tm session managed-stop <id>` | Alias for `runtime-stop` (backward-compatible) |
-| `tm session managed-resume <id>` | `POST /api/v1/sessions/managed/{id}/resume` |
-| `tm session decommission <id>` | `POST /api/v1/sessions/managed/{id}/decommission` |
+| `tm sessions new --repo --ref --task [--name]` | `POST /api/v1/sessions/managed` |
+| `tm sessions ls [--json]` | `GET /api/v1/sessions/managed` |
+| `tm sessions activity <id>` | `GET /api/v1/sessions/managed/{id}/activity` |
+| `tm sessions send <id> <text>` | `POST /api/v1/sessions/managed/{id}/send` |
+| `tm sessions answer <id> <answer>` | `POST /api/v1/sessions/managed/{id}/answer` |
+| `tm sessions attach <id>` | `GET /api/v1/sessions/managed/{id}/attach-cmd` |
+| `tm sessions runtime-stop <id>` | `POST /api/v1/sessions/managed/{id}/runtime-stop` |
+| `tm sessions managed-stop <id>` | Alias for `runtime-stop` (backward-compatible) |
+| `tm sessions managed-resume <id>` | `POST /api/v1/sessions/managed/{id}/resume` |
+| `tm sessions decommission <id>` | `POST /api/v1/sessions/managed/{id}/decommission` |
 
 ---
 
@@ -396,7 +396,7 @@ The existing catalog-sync mechanism delivers the content:
 
 1. `tm catalog sync` fetches `repo/.claude/agents` and `repo/.claude/skills` from
    the claude-mpm repository and caches them under `~/.trusty-mpm/catalog/`.
-2. `prepare_session` (called by the workspace provisioner on `tm session new`) reads
+2. `prepare_session` (called by the workspace provisioner on `tm sessions new`) reads
    from `~/.trusty-mpm/catalog/` and deploys agents/skills into each new isolated
    workspace under `~/.trusty-mpm/workspaces/<project>/<session-id>/`.
 3. The calling agentic process loads the `harness-operator` agent and
@@ -440,7 +440,7 @@ end-to-end test driven by a calling agentic process (not a human typing CLI comm
 
 7. **Decommission**: the calling agentic process calls `POST .../decommission`; the
    session transitions to `decommissioned`; the workspace directory no longer exists
-   on disk; the tombstone record remains in `tm session ls` output.
+   on disk; the tombstone record remains in `tm sessions ls` output.
 
 8. **Autonomy policy**: during the cycle above, the driver auto-accepted at least one
    proposed default (using structured guardrail signals, not pane-reading alone) and

--- a/docs/trusty-mpm/spec/SESSION_MANAGER_MVP.md
+++ b/docs/trusty-mpm/spec/SESSION_MANAGER_MVP.md
@@ -141,7 +141,7 @@ runs in each session — it is purely a control plane.
 **The driving logic is borrowed, not built.** The substrate (trusty-mpm daemon) is a
 dumb harness launcher and observer. It does not make autonomy decisions. Those are
 the calling agentic process's job — whether that is Bob's CTO Claude MPM instance, a Unicorn
-Factory controlling bot, or a human typing `tm session send`. See section 5 for the
+Factory controlling bot, or a human typing `tm sessions send`. See section 5 for the
 substrate/caller boundary.
 
 ```
@@ -464,7 +464,7 @@ share.
 ### 6.3 CLI surface
 
 ```
-tm session new --repo <url> --ref <branch-or-sha> --task "<description>" [--name <hint>]
+tm sessions new --repo <url> --ref <branch-or-sha> --task "<description>" [--name <hint>]
 ```
 
 `--repo` and `--ref` replace the v1 `--cwd` flag (which assumed the caller had
@@ -671,13 +671,13 @@ Response `200 OK`:
 ### 8.3 CLI surface (`tm session`)
 
 ```
-tm session new --repo <url> --ref <branch-or-sha> --task "<desc>" [--name <hint>]
-tm session ls [--json]
-tm session activity <id>
-tm session send <id> "<text>"
-tm session answer <id> "<answer>"
-tm session attach <id>     # prints attach_cmd; does not exec into tmux
-tm session stop <id>
+tm sessions new --repo <url> --ref <branch-or-sha> --task "<desc>" [--name <hint>]
+tm sessions ls [--json]
+tm sessions activity <id>
+tm sessions send <id> "<text>"
+tm sessions answer <id> "<answer>"
+tm sessions attach <id>     # prints attach_cmd; does not exec into tmux
+tm sessions stop <id>
 ```
 
 `tm catalog sync [--force]` and `tm catalog ls` are added alongside.
@@ -837,20 +837,20 @@ The smallest independently demoable slice:
 
 1. `tm catalog sync` fetches the agent/skill catalog from the claude-mpm repo and
    caches it under `~/.trusty-mpm/catalog/`.
-2. `tm session new --repo https://github.com/… --ref main --task "implement OAuth2"`
+2. `tm sessions new --repo https://github.com/… --ref main --task "implement OAuth2"`
    provisions an isolated workspace under `~/.trusty-mpm/workspaces/`, runs
    `prepare_session` using the synced catalog, creates a named tmux session, and
    spawns `env -u ANTHROPIC_API_KEY claude` in the pane.
-3. `tm session ls` shows the session with its name, state, workspace path, repo, and
+3. `tm sessions ls` shows the session with its name, state, workspace path, repo, and
    branch.
-4. `tm session send <id> "what have you done so far?"` injects text into the pane.
-5. `tm session activity <id>` returns an LLM verdict plus any `pending_decision` +
+4. `tm sessions send <id> "what have you done so far?"` injects text into the pane.
+5. `tm sessions activity <id>` returns an LLM verdict plus any `pending_decision` +
    `proposed_default` the harness has surfaced. A second call without pane change
    returns the cached verdict without an LLM call.
-6. `tm session answer <id> "Create branch fix/token-refresh"` injects the answer
+6. `tm sessions answer <id> "Create branch fix/token-refresh"` injects the answer
    into the pane and clears `pending_decision`.
-7. `tm session attach <id>` prints `tmux attach-session -t tmpm-<slug>`.
-8. `tm session stop <id>` kills the tmux session and marks the record dead.
+7. `tm sessions attach <id>` prints `tmux attach-session -t tmpm-<slug>`.
+8. `tm sessions stop <id>` kills the tmux session and marks the record dead.
 9. After a daemon restart, running sessions are re-adopted; dead ones are marked
    orphaned.
 
@@ -861,7 +861,7 @@ The smallest independently demoable slice:
 1. `tm catalog sync` exits 0 and writes agent/skill artifacts under
    `~/.trusty-mpm/catalog/`; `tm catalog ls` lists at least one agent and one skill.
 
-2. `tm session new --repo <url> --ref main --task "…"` exits 0; the workspace exists
+2. `tm sessions new --repo <url> --ref main --task "…"` exits 0; the workspace exists
    at `~/.trusty-mpm/workspaces/<project>/<session-id>/`; it is NOT inside any of
    the operator's existing project directories; `tmux has-session -t tmpm-<slug>`
    succeeds.
@@ -874,14 +874,14 @@ The smallest independently demoable slice:
    in its environment. Confirmed by verifying the command sent was
    `env -u ANTHROPIC_API_KEY claude`.
 
-5. `tm session ls` returns a list that includes the session from criterion 2 with
+5. `tm sessions ls` returns a list that includes the session from criterion 2 with
    `state: active` or `state: starting`, and includes `workspace_path`, `repo_url`,
    and `branch` fields with correct values.
 
-6. `tm session send <id> "hello from test"` exits 0; the string appears in the pane
+6. `tm sessions send <id> "hello from test"` exits 0; the string appears in the pane
    output captured by `tmux capture-pane -p -t <name>` within 2 seconds.
 
-7. `tm session activity <id>` returns a JSON body with:
+7. `tm sessions activity <id>` returns a JSON body with:
    - `verdict.state` set to one of `{working, idle, blocked_on_permission, errored, done}`.
    - `verdict.summary` non-empty.
    - `cost.model`, `cost.input_tokens`, `cost.latency_ms` present.
@@ -889,20 +889,20 @@ The smallest independently demoable slice:
    - `proposed_default` field present (may be `null`).
 
 8. With a pane that has been idle (unchanged last-60-line tail), a second call to
-   `tm session activity <id>` returns `cache_hit: true` and does NOT increment
+   `tm sessions activity <id>` returns `cache_hit: true` and does NOT increment
    `input_tokens` in the cost tally.
 
-9. When `pending_decision` is non-null, `tm session answer <id> "<text>"` exits 0;
-   a subsequent `tm session activity <id>` returns `pending_decision: null`; the
+9. When `pending_decision` is non-null, `tm sessions answer <id> "<text>"` exits 0;
+   a subsequent `tm sessions activity <id>` returns `pending_decision: null`; the
    injected answer text appears in the pane capture.
 
-10. `tm session attach <id>` prints exactly `tmux attach-session -t tmpm-<slug>` to
+10. `tm sessions attach <id>` prints exactly `tmux attach-session -t tmpm-<slug>` to
     stdout and exits 0.
 
-11. `tm session stop <id>` exits 0; `tmux has-session -t <name>` returns non-zero
-    afterwards; `tm session ls` shows the record with `state: dead`.
+11. `tm sessions stop <id>` exits 0; `tmux has-session -t <name>` returns non-zero
+    afterwards; `tm sessions ls` shows the record with `state: dead`.
 
-12. After `tm daemon restart` (SIGTERM + relaunch), `tm session ls` shows:
+12. After `tm daemon restart` (SIGTERM + relaunch), `tm sessions ls` shows:
     - Previously active sessions as `active` (re-adopted from tmux).
     - Sessions whose tmux session was killed before the restart as `orphaned`.
 
@@ -949,7 +949,7 @@ the acceptance criteria stay tight.
 
 ### Open Questions
 
-1. Should `tm session new` block until the `claude` prompt is visible in the pane
+1. Should `tm sessions new` block until the `claude` prompt is visible in the pane
    (polling `capture-pane`) or return immediately with `state: starting`?
    Recommendation: return immediately; let the operator poll `activity` or attach.
 


### PR DESCRIPTION
Closes #1394

## What
Renames the top-level trusty-mpm CLI command group from the singular `session` to the plural **`sessions`** so the CLI matches the `/api/v1/sessions/*` HTTP API surface.

- Every subcommand is now invoked under the plural name: `tm sessions tui`, `tm sessions ls`, `tm sessions new`, `tm sessions stop`, etc.
- The singular `session` spelling is **removed entirely** — NOT kept as an alias. `tm session …` now fails with `error: unrecognized subcommand 'session'` (exit 2).
- CLI-only change. The HTTP API (already `/api/v1/sessions/*`) and the separate `session-manager` / `sm` coordinator command are untouched.

## Implementation
- `cli.rs`: added `#[command(name = "sessions")]` to the `Session` variant. The Rust identifiers (`Session` / `SessionAction` and ~80 match arms) stay unchanged — minimal, coherent churn.
- Updated all functional references: the iTerm2 `osascript` emitted command, the `NameCollision` error message, the launch spinner-tip, bundled instruction/skill assets, doc comments, `docs/` specs, and the CHANGELOG.
- Updated every CLI parse test to the plural token; fixed the `prune-idle` integration test that spawns the real binary.
- Added regression tests `cli_parses_sessions_plural` and `cli_rejects_singular_session`.

## Verification
- `cargo build -p trusty-mpm` ✓
- `tm sessions --help` lists all subcommands incl `tui`/`ls`/`new`; `tm sessions tui --help` shows `--url`/`--interval-ms`; `tm session --help` errors (exit 2). ✓
- `cargo test -p trusty-mpm` (1338 lib + 336 bin + integration) ✓; `cargo test --workspace` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` exit 0 ✓ (only pre-existing unrelated `tga` build-script / MSRV warnings)
- `cargo fmt --check` ✓; `bash scripts/check_line_cap.sh` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)