### PR TITLE
feat(trusty-mpm): wire in-process AgentRunner into meta run orchestrator (closes #1030)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -383,15 +383,13 @@ pub(crate) enum Command {
     /// Why: the M1 POC (issue #1045) builds a self-contained metaharness that
     /// boots without the trusty-mpm daemon or the `claude` CLI, driving PM →
     /// sub-agent delegation in-process via trusty-code (Seam A). The `meta`
-    /// command group is the operator entry point for that harness. WI-1 lands
-    /// only the bootstrap skeleton: argument parsing, structured logging, and a
-    /// placeholder run summary. The live delegation loop, fs/bash tool wiring,
-    /// and OpenRouter inference arrive in WI-2..WI-8 and are intentionally
-    /// deferred here.
-    /// What: a `run` sub-subcommand that accepts `--demo` (run the bundled demo
-    /// task) and `--project <PATH>` (the working directory the harness operates
-    /// in). For WI-1 the handler validates its arguments, emits a structured
-    /// "bootstrap" JSON summary to stdout, and exits 0.
+    /// command group is the operator entry point for that harness. As of WI-4
+    /// (#1030) `meta run --demo` performs a real PM → engineer delegation against
+    /// a live OpenRouter model and persists a combined transcript; a bare
+    /// `meta run` stays offline and prints the assembled tool-registry summary.
+    /// What: a `run` sub-subcommand that accepts `--demo` (drive the live demo
+    /// delegation) and `--project <PATH>` (the working directory the harness
+    /// operates in). The demo requires `OPENROUTER_API_KEY`.
     /// Test: `cli_parses_meta_run`, `cli_parses_meta_run_demo`,
     /// `cli_parses_meta_run_project`, `cli_meta_requires_action` in `tests.rs`.
     Meta {
@@ -401,7 +399,7 @@ pub(crate) enum Command {
     },
 }
 
-/// Verbs for the `tm meta` standalone-metaharness command group (#1045, WI-1).
+/// Verbs for the `tm meta` standalone-metaharness command group (#1045).
 ///
 /// Why: `meta` is a group rather than a bare command because future work items
 /// will add sibling verbs (e.g. inspecting transcripts under
@@ -413,18 +411,20 @@ pub(crate) enum Command {
 /// `cli_parses_meta_run_project`, `cli_meta_requires_action` in `tests.rs`.
 #[derive(Debug, Subcommand)]
 pub(crate) enum MetaAction {
-    /// Boot the metaharness for a single run (WI-1: bootstrap skeleton only).
+    /// Boot the metaharness for a single run.
     ///
-    /// Why: this is the harness's primary entry point — eventually it boots the
-    /// PM, delegates to a sub-agent, captures a transcript, and exits. For WI-1
-    /// it only validates inputs and prints a bootstrap summary so the scaffold
-    /// is exercisable end-to-end before the real runtime lands.
-    /// What: `--demo` selects the bundled demo task; `--project <PATH>` sets the
-    /// working directory the harness runs against (defaults to the process cwd).
+    /// Why: this is the harness's primary entry point — it boots the PM,
+    /// delegates one task to a sub-agent, captures a combined transcript, and
+    /// exits. With `--demo` (#1030, WI-4) it drives a live PM → engineer
+    /// delegation against a real model; without it, it prints the offline
+    /// tool-registry summary.
+    /// What: `--demo` runs the bundled demo task (requires `OPENROUTER_API_KEY`)
+    /// and writes a transcript under `<project>/.trusty-mpm/meta-runs/`;
+    /// `--project <PATH>` sets the working directory (defaults to the cwd).
     /// Test: `cli_parses_meta_run*` in `tests.rs`; handler behaviour in the
     /// `commands::meta` unit tests.
     Run {
-        /// Run the bundled demo task instead of a user-supplied task.
+        /// Drive the live demo delegation (requires OPENROUTER_API_KEY).
         #[arg(long)]
         demo: bool,
 

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/agents.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/agents.rs
@@ -1,0 +1,191 @@
+//! Bundled PM + sub-agent configs for the standalone metaharness (#1030).
+//!
+//! Why: The metaharness boots without the trusty-mpm daemon or `.claude/`
+//! scaffolding, yet [`InProcessAgentRunner`] loads each agent from
+//! `<config_dir>/<name>.toml`. Shipping the PM and engineer configs inline (and
+//! materialising them to a run-scoped temp dir) lets `meta run --demo` drive a
+//! real PM → engineer delegation with zero external setup, while still going
+//! through the production on-disk agent-loading path.
+//! What: [`PM_AGENT_NAME`]/[`ENGINEER_AGENT_NAME`] name the two agents;
+//! [`pm_agent_toml`]/[`engineer_agent_toml`] return their TOML bodies (the PM is
+//! allowed only `delegate_to_agent` + read tools; the engineer gets the full
+//! fs/bash set); [`write_agent_configs`] materialises both into a directory and
+//! returns it.
+//! Test: `agents::tests` assert the bodies parse as `AgentConfig`s with the
+//! expected allowlists, and that `write_agent_configs` writes both files.
+//!
+//! [`InProcessAgentRunner`]: trusty_code::runner::InProcessAgentRunner
+
+use std::path::Path;
+
+use anyhow::Context as _;
+
+/// Dispatch name (and config file stem) of the project-manager agent.
+///
+/// Why: The orchestrator loads `<dir>/pm.toml` and runs the PM loop against this
+/// agent; centralising the slug keeps the loader, the config file, and the tests
+/// in lockstep.
+/// What: the literal `"pm"`.
+/// Test: `pm_toml_parses_with_delegate_allowed`.
+pub(crate) const PM_AGENT_NAME: &str = "pm";
+
+/// Dispatch name (and config file stem) of the sub-agent the PM delegates to.
+///
+/// Why: The demo drives one delegation to this agent; the delegate tool
+/// validates the name against `<dir>/<name>.toml`, so the slug must match.
+/// What: the literal `"python-engineer"`.
+/// Test: `engineer_toml_parses_with_fs_tools`.
+pub(crate) const ENGINEER_AGENT_NAME: &str = "python-engineer";
+
+/// TOML body for the PM agent config.
+///
+/// Why: The PM's job is to delegate, not to touch files directly; restricting it
+/// to `delegate_to_agent` (plus read-only inspection) mirrors the MPM protocol
+/// where the PM orchestrates and sub-agents do the work. Acceptance criterion
+/// #1030 requires the PM to load a "delegate tool + optional read tools" config.
+/// What: an `AgentConfig` TOML pinning the default model and allowing only
+/// `delegate_to_agent` and `read_file`; the system prompt instructs the PM to
+/// delegate the task to the engineer and report the result.
+/// Test: `pm_toml_parses_with_delegate_allowed`.
+pub(crate) fn pm_agent_toml() -> String {
+    r#"[agent]
+name = "pm"
+role = "project-manager"
+description = "Orchestrates the run by delegating to sub-agents."
+
+[system_prompt]
+content = """
+You are the PM (project manager) of an in-process agent harness.
+You do not write files yourself. To accomplish the user's task you MUST call the
+delegate_to_agent tool exactly once, delegating the concrete engineering work to
+the `python-engineer` agent. Pass the full task as the `task` argument. After the
+engineer reports back, summarise what was accomplished in one short paragraph and
+then stop.
+"""
+
+[tools]
+allowed = ["delegate_to_agent", "read_file"]
+"#
+    .to_string()
+}
+
+/// TOML body for the engineer sub-agent config.
+///
+/// Why: The engineer is the actor that actually performs file I/O and shell work,
+/// so it needs the full fs/bash tool set. Keeping its allowlist explicit makes
+/// the capability grant auditable.
+/// What: an `AgentConfig` TOML pinning the default model and allowing the fs
+/// tools (`read_file`, `write_file`, `edit`) and `bash`; the system prompt
+/// instructs it to carry out the task and confirm completion.
+/// Test: `engineer_toml_parses_with_fs_tools`.
+pub(crate) fn engineer_agent_toml() -> String {
+    r#"[agent]
+name = "python-engineer"
+role = "engineer"
+description = "Performs concrete engineering work: file writes, edits, shell."
+
+[system_prompt]
+content = """
+You are a software engineer in an in-process agent harness.
+Carry out the task you are given using the available tools (write_file, edit,
+read_file, bash). When the task asks you to create a file, use the write_file
+tool with the requested relative path and contents. After the work is done,
+reply with a one-line confirmation of exactly what you changed, then stop.
+"""
+
+[tools]
+allowed = ["read_file", "write_file", "edit", "bash"]
+"#
+    .to_string()
+}
+
+/// Materialise the PM + engineer configs into `dir`, returning nothing on success.
+///
+/// Why: The runner and delegate tool both load agents from on-disk TOML; writing
+/// the bundled configs into a run-scoped directory lets the demo exercise the
+/// real loading path without requiring the operator to author config files.
+/// What: Creates `dir` (if needed) and writes `pm.toml` and `python-engineer.toml`
+/// with the bundled bodies; surfaces an `anyhow` error naming the offending path
+/// on any IO failure.
+/// Test: `write_agent_configs_writes_both_files`.
+pub(crate) fn write_agent_configs(dir: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create agents dir: {}", dir.display()))?;
+    let pm_path = dir.join(format!("{PM_AGENT_NAME}.toml"));
+    std::fs::write(&pm_path, pm_agent_toml())
+        .with_context(|| format!("failed to write PM config: {}", pm_path.display()))?;
+    let eng_path = dir.join(format!("{ENGINEER_AGENT_NAME}.toml"));
+    std::fs::write(&eng_path, engineer_agent_toml())
+        .with_context(|| format!("failed to write engineer config: {}", eng_path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use trusty_code::agents::AgentConfig;
+
+    use super::*;
+
+    /// The PM config parses and allows only delegate + read.
+    ///
+    /// Why: The PM must be able to delegate but not write files directly; a
+    /// regression in the allowlist would let the PM bypass the engineer.
+    /// What: Parse `pm_agent_toml`; assert name and the exact allowlist.
+    /// Test: this test.
+    #[test]
+    fn pm_toml_parses_with_delegate_allowed() {
+        let cfg = AgentConfig::from_toml_str(&pm_agent_toml()).expect("pm toml parses");
+        assert_eq!(cfg.agent.name, PM_AGENT_NAME);
+        let allowed = cfg
+            .tools
+            .as_ref()
+            .and_then(|t| t.allowed.as_ref())
+            .expect("pm has an allowlist");
+        assert!(allowed.contains(&"delegate_to_agent".to_string()));
+        assert!(allowed.contains(&"read_file".to_string()));
+        assert!(
+            !allowed.contains(&"write_file".to_string()),
+            "PM must not be allowed to write files directly"
+        );
+    }
+
+    /// The engineer config parses and allows the fs/bash tool set.
+    ///
+    /// Why: The engineer is the actor that performs file I/O; it must have the
+    /// write/edit/bash capabilities.
+    /// What: Parse `engineer_agent_toml`; assert name and allowlist membership.
+    /// Test: this test.
+    #[test]
+    fn engineer_toml_parses_with_fs_tools() {
+        let cfg = AgentConfig::from_toml_str(&engineer_agent_toml()).expect("engineer toml parses");
+        assert_eq!(cfg.agent.name, ENGINEER_AGENT_NAME);
+        let allowed = cfg
+            .tools
+            .as_ref()
+            .and_then(|t| t.allowed.as_ref())
+            .expect("engineer has an allowlist");
+        for tool in ["read_file", "write_file", "edit", "bash"] {
+            assert!(
+                allowed.contains(&tool.to_string()),
+                "engineer must be allowed {tool}"
+            );
+        }
+    }
+
+    /// `write_agent_configs` writes both TOML files into the target dir.
+    ///
+    /// Why: The runner loads agents from disk; both files must land.
+    /// What: Write into a tempdir; assert both files exist and parse.
+    /// Test: this test.
+    #[test]
+    fn write_agent_configs_writes_both_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_agent_configs(tmp.path()).expect("write configs");
+        let pm = tmp.path().join("pm.toml");
+        let eng = tmp.path().join("python-engineer.toml");
+        assert!(pm.exists(), "pm.toml must be written");
+        assert!(eng.exists(), "python-engineer.toml must be written");
+        AgentConfig::load(&pm).expect("pm.toml loads");
+        AgentConfig::load(&eng).expect("engineer toml loads");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
@@ -1,107 +1,269 @@
-//! `meta` command handler — standalone metaharness bootstrap (#1045, WI-1/WI-2).
+//! `meta` command handler — standalone metaharness (#1045, WI-1..WI-4).
 //!
 //! Why: issue #1045 builds an M1 POC metaharness that boots without the
 //! trusty-mpm daemon or the `claude` CLI and drives PM → sub-agent delegation
-//! in-process via trusty-code (Seam A). WI-1 stood up the `meta run` entry point
-//! (argument validation, structured logging, a placeholder run summary). WI-2
-//! wires a trusty-code [`ToolRegistry`](trusty_code::tools::ToolRegistry) into
-//! that path so the (future) PM loop has the fs/bash/delegate capabilities it
-//! will offer the model. Live LLM inference, real delegation, and transcript
-//! capture remain intentionally unimplemented here (WI-3..WI-8).
-//! What: [`meta`] dispatches `MetaAction`; [`run`] validates the `--project`
-//! path, builds the metaharness tool registry, logs the registered tool names,
-//! and writes a JSON summary (including the tool list) to stdout. Pure helpers
-//! ([`resolve_project`], [`wi2_summary`]) carry the testable logic so unit tests
-//! need no stdout capture or live runtime; registry assembly lives in the
-//! [`registry`] submodule.
-//! Test: `meta_*` unit tests in this module's `tests` block; registry tests in
-//! `registry::tests`; CLI parsing in `tests.rs` (`cli_parses_meta_run*`).
+//! in-process via trusty-code (Seam A). WI-1 stood up the `meta run` entry point;
+//! WI-2 wired a trusty-code [`ToolRegistry`](trusty_code::tools::ToolRegistry);
+//! WI-4 (this change, closing #1030) replaces the WI-2 `NoopAgentRunner` with the
+//! live [`InProcessAgentRunner`](trusty_code::runner::InProcessAgentRunner): a
+//! bare `meta run` still prints the registry summary (offline, no LLM), while
+//! `meta run --demo` performs a *real* PM → engineer delegation against a live
+//! OpenRouter model and persists a combined transcript.
+//! What: [`meta`] dispatches `MetaAction`; [`run`] validates `--project`, and for
+//! `--demo` materialises the bundled PM + engineer configs, constructs the live
+//! [`Orchestrator`](orchestrator::Orchestrator) over a shared LLM client, runs one
+//! delegation cycle, writes the transcript under `.trusty-mpm/meta-runs/`, and
+//! prints a summary; without `--demo` it falls back to the WI-2 registry summary.
+//! Pure helpers ([`resolve_project`], [`wi2_summary`], [`demo_task`]) carry the
+//! testable logic; agent configs, the transcript schema, and the orchestrator
+//! live in sibling submodules.
+//! Test: `meta_*` unit tests in this module's `tests` block; submodule tests in
+//! `agents`/`transcript`/`orchestrator`; CLI parsing in `tests.rs`.
 
+mod agents;
+mod orchestrator;
 mod registry;
+mod transcript;
 
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
 use serde_json::json;
-use tracing::{info, warn};
+use tracing::{error, info};
+use trusty_code::llm::{LlmClient, LlmClientConfig};
+use trusty_code::runner::InProcessRunnerConfig;
 
+use self::orchestrator::Orchestrator;
 use self::registry::{build_meta_registry, registry_tool_names};
 use crate::cli::MetaAction;
 
-/// Status string stamped into the WI-2 run summary.
+/// Status string stamped into the WI-2 registry-only run summary.
 ///
-/// Why: the summary `status` is a magic string consumed by tests (and,
-/// eventually, by tooling that scrapes `meta run` output); centralising it
-/// keeps the producer and every assertion in lockstep.
-/// What: the literal `"wi2"` — signalling that this run assembled the tool
-/// registry but performed no real delegation or LLM inference yet.
+/// Why: the summary `status` is a magic string consumed by tests (and tooling
+/// that scrapes `meta run` output); centralising it keeps the producer and every
+/// assertion in lockstep.
+/// What: the literal `"wi2"` — signalling a registry-assembly-only run (no demo).
 /// Test: `meta_wi2_summary_reports_status` asserts the emitted value.
 pub(crate) const STATUS_WI2: &str = "wi2";
 
+/// Subdirectory (under the project) where transcripts and agent configs live.
+///
+/// Why: The demo persists its combined transcript and materialises the bundled
+/// agent configs under a predictable, project-scoped location so operators can
+/// inspect a run after the fact (#1045 success criterion).
+/// What: the literal `".trusty-mpm"` directory name.
+/// Test: `meta_run_dir_paths_are_project_scoped`.
+pub(crate) const META_STATE_DIR: &str = ".trusty-mpm";
+
+/// The bundled demo task the PM is asked to accomplish.
+///
+/// Why: `--demo` runs a fixed, checkable task (write a known file) so a run's
+/// success is verifiable without operator input (#1045: writes
+/// `hello_metaharness.txt`, verifies content, exits 0).
+/// What: instructs the PM to have the engineer create `hello_metaharness.txt`
+/// with a known line of content.
+/// Test: `meta_demo_task_names_expected_file`.
+pub(crate) const DEMO_ARTIFACT: &str = "hello_metaharness.txt";
+
 /// `meta` subcommand dispatcher — route a parsed [`MetaAction`] to its handler.
 ///
-/// Why: mirrors the other `tm` command groups (e.g. `project`, `issue`) by
-/// keeping `main`'s match arm thin and folding verb dispatch into the module
-/// that owns the verbs.
-/// What: matches the `MetaAction` and forwards `meta run` to [`run`].
+/// Why: mirrors the other `tm` command groups by keeping `main`'s match arm thin
+/// and folding verb dispatch into the module that owns the verbs.
+/// What: matches the `MetaAction` and forwards `meta run` to [`run`] (async, so
+/// the demo can drive the live agent loop without a nested runtime).
 /// Test: covered by the handler unit tests via the `Run` arm; CLI parse
 /// round-trips live in `tests.rs`.
-pub(crate) fn meta(action: MetaAction) -> anyhow::Result<()> {
+pub(crate) async fn meta(action: MetaAction) -> anyhow::Result<()> {
     match action {
-        MetaAction::Run { demo, project } => run(demo, project),
+        MetaAction::Run { demo, project } => run(demo, project).await,
     }
 }
 
-/// Execute one `meta run` invocation (WI-2: tool registry wiring).
+/// The bundled demo task string handed to the PM.
 ///
-/// Why: this is the harness's primary entry point. WI-2 extends the WI-1
-/// scaffold by assembling the trusty-code [`ToolRegistry`] the (future) PM loop
-/// will offer the model — proving the fs/bash/delegate tools wire together —
-/// without yet implementing real delegation or live LLM inference. Returning
-/// `Ok(())` on the happy path lets the demo command exit 0 so the scaffold stays
-/// smoke-testable.
-/// What: initialises stderr tracing (idempotent, honours `RUST_LOG`), resolves
-/// and validates `--project` to an existing absolute path, builds the
-/// metaharness registry scoped to that project, logs the registered tool names
-/// at info level (stderr), and writes the [`wi2_summary`] JSON object (including
-/// the tool list) to stdout.
-/// Test: `meta_run_demo_succeeds_for_existing_project`,
-/// `meta_run_errors_on_missing_project` exercise the validation + happy paths.
-pub(crate) fn run(demo: bool, project: Option<PathBuf>) -> anyhow::Result<()> {
-    init_meta_tracing();
+/// Why: Isolating the task text keeps it unit-testable and the `run` handler
+/// free of inline prose.
+/// What: returns a one-line instruction to create [`DEMO_ARTIFACT`] with a known
+/// body.
+/// Test: `meta_demo_task_names_expected_file`.
+pub(crate) fn demo_task() -> String {
+    format!(
+        "Create a file named `{DEMO_ARTIFACT}` in the project root containing exactly the line \
+         `hello from the metaharness`. Delegate the file creation to the python-engineer agent."
+    )
+}
 
+/// Execute one `meta run` invocation.
+///
+/// Why: this is the harness's primary entry point. Without `--demo` it stays an
+/// offline registry-assembly smoke test (no LLM, no network). With `--demo` it is
+/// the WI-4 deliverable (#1030): a real PM → engineer delegation driven by a live
+/// OpenRouter model, with a combined transcript persisted for inspection.
+/// What: initialises stderr tracing; resolves and validates `--project`; for the
+/// non-demo path builds the registry and prints the [`wi2_summary`]; for the demo
+/// path delegates to [`run_demo`].
+/// Test: `meta_run_registry_summary_for_existing_project`,
+/// `meta_run_errors_on_missing_project` exercise the offline paths; the live demo
+/// is covered by the `orchestrator` tests (mock LLM) and an ignored live test.
+pub(crate) async fn run(demo: bool, project: Option<PathBuf>) -> anyhow::Result<()> {
+    init_meta_tracing();
     let project = resolve_project(project)?;
+
+    if demo {
+        return run_demo(&project).await;
+    }
+
     let registry = build_meta_registry(&project);
     let tools = registry_tool_names(&registry);
-
     info!(
         demo,
         project = %project.display(),
         tools = ?tools,
-        "meta run: WI-2 tool registry assembled — no delegation performed yet"
+        "meta run: tool registry assembled (offline summary — pass --demo to run the live harness)"
     );
-    warn!(
-        "`tm meta run` is WI-2 (tool registry wiring) — real sub-agent \
-         delegation and live LLM inference arrive in later work items \
-         (#1045 WI-3..WI-8); the registered delegate tool uses a stub runner"
-    );
-
     let summary = wi2_summary(demo, &project, &tools);
-    // stdout carries the machine-readable run summary (the human notice went to
-    // stderr above), so downstream tooling can parse `meta run` output cleanly.
     println!("{}", serde_json::to_string(&summary)?);
     Ok(())
 }
 
+/// Run the live PM → engineer demo delegation and persist the transcript.
+///
+/// Why: This is the WI-4 / #1030 payoff — proof the in-process orchestrator
+/// drives a real agent end-to-end. It requires a live LLM key; absent one it
+/// fails with a clear, actionable error rather than silently mocking.
+/// What: requires `OPENROUTER_API_KEY` (clear error if missing); materialises the
+/// bundled PM + engineer configs under `<project>/.trusty-mpm/meta-agents/`; runs
+/// the [`Orchestrator`] over a shared `LlmClient`; writes the combined transcript
+/// under `<project>/.trusty-mpm/meta-runs/`; prints a JSON summary to stdout and
+/// logs progress to stderr.
+/// Test: side-effect/IO-heavy; the orchestration logic is covered offline by
+/// `orchestrator::tests` (scripted LLM) and an ignored live end-to-end test.
+async fn run_demo(project: &Path) -> anyhow::Result<()> {
+    let config = LlmClientConfig::from_env().context(
+        "meta run --demo requires a live LLM: set OPENROUTER_API_KEY in the environment. \
+         (The wiring is fully covered offline by `cargo test -p trusty-mpm meta::orchestrator`.)",
+    )?;
+    let client = LlmClient::from_config(config).context("failed to build OpenRouter client")?;
+    let llm = std::sync::Arc::new(client);
+
+    let agents_dir = meta_agents_dir(project);
+    agents::write_agent_configs(&agents_dir)
+        .context("failed to materialise bundled agent configs")?;
+
+    let task = demo_task();
+    info!(
+        project = %project.display(),
+        agents_dir = %agents_dir.display(),
+        "meta run --demo: driving live PM → engineer delegation"
+    );
+
+    let mut orchestrator = Orchestrator::new(llm, agents_dir, project.to_path_buf()).with_config(
+        InProcessRunnerConfig {
+            max_turns: 6,
+            timeout_secs: 180,
+        },
+    );
+    // Thread the project's CLAUDE.md (if any) into every assembled prompt so the
+    // PM and engineer see the same project rules (parity-spec).
+    if let Some(ctx) = read_project_context(project) {
+        orchestrator = orchestrator.with_project_context(ctx);
+    }
+
+    let transcript = match orchestrator.run(&task).await {
+        Ok(t) => t,
+        Err(e) => {
+            error!(error = %e, "meta run --demo: orchestration failed");
+            return Err(e);
+        }
+    };
+
+    let transcript_path = write_transcript(project, &transcript)?;
+    info!(
+        delegations = transcript.delegations.len(),
+        artifacts = transcript.artifacts.len(),
+        total_tokens = transcript.usage.total_tokens,
+        transcript = %transcript_path.display(),
+        "meta run --demo: delegation cycle complete"
+    );
+
+    let summary = json!({
+        "status": "demo",
+        "project": project.display().to_string(),
+        "model": transcript.model,
+        "delegations": transcript.delegations.len(),
+        "artifacts": transcript.artifacts.iter().map(|a| &a.path).collect::<Vec<_>>(),
+        "total_tokens": transcript.usage.total_tokens,
+        "transcript": transcript_path.display().to_string(),
+    });
+    println!("{}", serde_json::to_string(&summary)?);
+    Ok(())
+}
+
+/// Read the project's `CLAUDE.md`, if present, for prompt injection.
+///
+/// Why: The parity-spec wants the PM and every sub-agent to see the same project
+/// rules; the project `CLAUDE.md` is that surface. Reading it here keeps the
+/// orchestrator agnostic to where context comes from.
+/// What: returns `Some(contents)` if `<project>/CLAUDE.md` reads successfully,
+/// else `None` (a missing/unreadable file is not an error — context is optional).
+/// Test: `meta_read_project_context_reads_existing_file`.
+pub(crate) fn read_project_context(project: &Path) -> Option<String> {
+    std::fs::read_to_string(project.join("CLAUDE.md")).ok()
+}
+
+/// Directory holding the bundled agent configs for a run.
+///
+/// Why: The runner loads agents from on-disk TOML; placing them under the
+/// project's state dir keeps the run self-contained and inspectable.
+/// What: returns `<project>/.trusty-mpm/meta-agents`.
+/// Test: `meta_run_dir_paths_are_project_scoped`.
+pub(crate) fn meta_agents_dir(project: &Path) -> PathBuf {
+    project.join(META_STATE_DIR).join("meta-agents")
+}
+
+/// Directory where run transcripts are persisted.
+///
+/// Why: Operators inspect past runs; a stable location makes them discoverable
+/// (#1045 success criterion).
+/// What: returns `<project>/.trusty-mpm/meta-runs`.
+/// Test: `meta_run_dir_paths_are_project_scoped`.
+pub(crate) fn meta_runs_dir(project: &Path) -> PathBuf {
+    project.join(META_STATE_DIR).join("meta-runs")
+}
+
+/// Persist a combined transcript as pretty JSON, returning its path.
+///
+/// Why: The transcript is the run's auditable record; writing it to disk lets
+/// downstream tooling (and humans) inspect the PM + engineer turns after exit.
+/// What: creates the runs dir, writes `run-<unix_ts>.json` with the serialised
+/// transcript, and returns the path; surfaces an `anyhow` error on IO failure.
+/// Test: side-effect IO; the transcript shape is covered by `transcript::tests`.
+fn write_transcript(
+    project: &Path,
+    transcript: &transcript::MetaTranscript,
+) -> anyhow::Result<PathBuf> {
+    let dir = meta_runs_dir(project);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("failed to create runs dir: {}", dir.display()))?;
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let path = dir.join(format!("run-{ts}.json"));
+    let body = serde_json::to_string_pretty(transcript)
+        .context("failed to serialise transcript to JSON")?;
+    std::fs::write(&path, body)
+        .with_context(|| format!("failed to write transcript: {}", path.display()))?;
+    Ok(path)
+}
+
 /// Resolve the optional `--project` argument to an existing absolute path.
 ///
-/// Why: every later work item operates relative to a concrete working
-/// directory, so the bootstrap must fail fast and clearly if the operator
-/// points it at a path that does not exist — surfacing the bad input now
-/// instead of deep inside a future delegation loop.
+/// Why: every later step operates relative to a concrete working directory, so
+/// the bootstrap must fail fast and clearly if pointed at a missing path.
 /// What: defaults a missing argument to the process cwd, canonicalises the path
-/// (which also asserts existence) and returns the absolute form; returns an
-/// `anyhow` error naming the offending path when it is absent or unreadable.
+/// (asserting existence) and returns the absolute form; returns an `anyhow` error
+/// naming the offending path when it is absent or unreadable.
 /// Test: `meta_resolve_project_accepts_existing_dir`,
 /// `meta_resolve_project_rejects_missing_path`,
 /// `meta_resolve_project_defaults_to_cwd`.
@@ -115,16 +277,13 @@ pub(crate) fn resolve_project(project: Option<PathBuf>) -> anyhow::Result<PathBu
     Ok(resolved)
 }
 
-/// Build the WI-2 run summary as a JSON object.
+/// Build the registry-only run summary as a JSON object (non-demo path).
 ///
-/// Why: `meta run` emits a single machine-readable line so the run summary has a
-/// stable shape across work items; isolating its construction keeps it
-/// unit-testable without stdout capture. WI-2 enriches the WI-1 shape with the
-/// registered tool list so downstream tooling can confirm the harness offered
-/// the expected capabilities.
+/// Why: a bare `meta run` emits a single machine-readable line summarising the
+/// assembled tool registry so downstream tooling can confirm the harness offered
+/// the expected capabilities, without invoking an LLM.
 /// What: returns
-/// `{"status":"wi2","demo":<bool>,"project":"<abs path>","tools":[<names>]}`,
-/// where `tools` is the (sorted) list of registered tool names.
+/// `{"status":"wi2","demo":<bool>,"project":"<abs path>","tools":[<names>]}`.
 /// Test: `meta_wi2_summary_reports_status`,
 /// `meta_wi2_summary_carries_demo_project_and_tools`.
 pub(crate) fn wi2_summary(demo: bool, project: &Path, tools: &[String]) -> serde_json::Value {
@@ -138,15 +297,12 @@ pub(crate) fn wi2_summary(demo: bool, project: &Path, tools: &[String]) -> serde
 
 /// Initialise stderr tracing for the short-lived `meta run` invocation.
 ///
-/// Why: short-lived `tm` subcommands skip the daemon's subscriber init, but
-/// the metaharness requires structured logging that honours `RUST_LOG`. Using `try_init`
-/// keeps this idempotent — it silently no-ops if a global subscriber is already
-/// installed (e.g. under a test harness), satisfying the workspace's "no global
-/// state except the idempotent tracing subscriber" rule.
+/// Why: short-lived `tm` subcommands skip the daemon's subscriber init, but the
+/// metaharness requires structured logging that honours `RUST_LOG`. `try_init`
+/// keeps this idempotent — it silently no-ops if a subscriber already exists.
 /// What: installs a stderr `fmt` subscriber filtered by `RUST_LOG` (default
-/// `info`); ignores the error returned when a subscriber already exists.
-/// Test: side-effect-only (global subscriber install); exercised indirectly by
-/// `meta_run_demo_succeeds_for_existing_project`.
+/// `info`); ignores the error when a subscriber already exists.
+/// Test: side-effect-only; exercised indirectly by the handler tests.
 fn init_meta_tracing() {
     let filter =
         tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
@@ -207,8 +363,8 @@ mod tests {
 
     #[test]
     fn meta_run_demo_emits_expected_tool_list() {
-        // The full registry-backed run over an existing project must list every
-        // metaharness tool in its summary — guards the run()→registry wiring.
+        // The registry-backed summary over an existing project must list every
+        // metaharness tool — guards the run()→registry wiring.
         let tmp = std::env::temp_dir();
         let registry = build_meta_registry(&tmp);
         let tools = registry_tool_names(&registry);
@@ -222,30 +378,59 @@ mod tests {
                 "write_file".to_string(),
             ]
         );
-        let summary = wi2_summary(true, &tmp, &tools);
-        assert_eq!(
-            summary["tools"],
-            json!([
-                "bash",
-                "delegate_to_agent",
-                "edit",
-                "read_file",
-                "write_file"
-            ])
+    }
+
+    #[tokio::test]
+    async fn meta_run_registry_summary_for_existing_project() {
+        // The non-demo path over an existing project must exit Ok (exit 0) so the
+        // offline scaffold stays smoke-testable without an LLM key.
+        let tmp = std::env::temp_dir();
+        run(false, Some(tmp))
+            .await
+            .expect("registry summary succeeds");
+    }
+
+    #[tokio::test]
+    async fn meta_run_errors_on_missing_project() {
+        let missing = PathBuf::from("/nonexistent-meta-bootstrap-run-xyz-98765");
+        assert!(run(true, Some(missing)).await.is_err());
+    }
+
+    #[test]
+    fn meta_demo_task_names_expected_file() {
+        assert!(
+            demo_task().contains(DEMO_ARTIFACT),
+            "demo task must name the artifact file"
+        );
+        assert!(
+            demo_task().contains("python-engineer"),
+            "demo task must direct delegation to the engineer"
         );
     }
 
     #[test]
-    fn meta_run_demo_succeeds_for_existing_project() {
-        // The demo path over an existing project must exit Ok (exit 0) so the
-        // WI-1 scaffold is smoke-testable.
-        let tmp = std::env::temp_dir();
-        run(true, Some(tmp)).expect("demo run over existing project succeeds");
+    fn meta_read_project_context_reads_existing_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Absent file → None.
+        assert!(read_project_context(tmp.path()).is_none());
+        // Present file → Some(contents).
+        std::fs::write(tmp.path().join("CLAUDE.md"), "PROJECT RULES").expect("write CLAUDE.md");
+        assert_eq!(
+            read_project_context(tmp.path()).as_deref(),
+            Some("PROJECT RULES")
+        );
     }
 
     #[test]
-    fn meta_run_errors_on_missing_project() {
-        let missing = PathBuf::from("/nonexistent-meta-bootstrap-run-xyz-98765");
-        assert!(run(true, Some(missing)).is_err());
+    fn meta_run_dir_paths_are_project_scoped() {
+        let project = Path::new("/work/proj");
+        assert_eq!(
+            meta_agents_dir(project),
+            Path::new("/work/proj/.trusty-mpm/meta-agents")
+        );
+        assert_eq!(
+            meta_runs_dir(project),
+            Path::new("/work/proj/.trusty-mpm/meta-runs")
+        );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
@@ -231,13 +231,35 @@ pub(crate) fn meta_runs_dir(project: &Path) -> PathBuf {
     project.join(META_STATE_DIR).join("meta-runs")
 }
 
+/// Compute the transcript filename for a run at instant `now`.
+///
+/// Why: Second-granularity filenames collide when two runs start within the same
+/// wall-clock second, silently overwriting the earlier transcript. Deriving the
+/// name from milliseconds-since-epoch makes intra-second collisions vanishingly
+/// unlikely while keeping the name sortable and human-readable. Factoring this out
+/// of [`write_transcript`] keeps the (otherwise IO-bound) naming logic unit-testable.
+/// What: returns `run-<unix_ts_millis>.json`, falling back to `0` if the clock is
+/// before the Unix epoch (which cannot happen for `SystemTime::now`).
+/// Test: `meta_run_filename_uses_millisecond_precision`.
+fn run_transcript_filename(now: std::time::SystemTime) -> String {
+    let millis = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    format!("run-{millis}.json")
+}
+
 /// Persist a combined transcript as pretty JSON, returning its path.
 ///
 /// Why: The transcript is the run's auditable record; writing it to disk lets
 /// downstream tooling (and humans) inspect the PM + engineer turns after exit.
-/// What: creates the runs dir, writes `run-<unix_ts>.json` with the serialised
-/// transcript, and returns the path; surfaces an `anyhow` error on IO failure.
-/// Test: side-effect IO; the transcript shape is covered by `transcript::tests`.
+/// What: creates the runs dir, writes `run-<unix_ts_millis>.json` with the
+/// serialised transcript, and returns the path; surfaces an `anyhow` error on IO
+/// failure. Millisecond (not second) precision is used for the filename so two
+/// runs started within the same wall-clock second do not collide and overwrite
+/// each other's transcript.
+/// Test: `meta_run_filename_uses_millisecond_precision`; the transcript shape is
+/// covered by `transcript::tests`.
 fn write_transcript(
     project: &Path,
     transcript: &transcript::MetaTranscript,
@@ -245,11 +267,7 @@ fn write_transcript(
     let dir = meta_runs_dir(project);
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("failed to create runs dir: {}", dir.display()))?;
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let path = dir.join(format!("run-{ts}.json"));
+    let path = dir.join(run_transcript_filename(std::time::SystemTime::now()));
     let body = serde_json::to_string_pretty(transcript)
         .context("failed to serialise transcript to JSON")?;
     std::fs::write(&path, body)
@@ -418,6 +436,22 @@ mod tests {
         assert_eq!(
             read_project_context(tmp.path()).as_deref(),
             Some("PROJECT RULES")
+        );
+    }
+
+    #[test]
+    fn meta_run_filename_uses_millisecond_precision() {
+        // Two instants in the same wall-clock second but different milliseconds
+        // must yield distinct filenames (fix #3: no same-second overwrite).
+        let base = std::time::UNIX_EPOCH + std::time::Duration::from_millis(1_700_000_000_123);
+        let same_second = base + std::time::Duration::from_millis(456);
+        let a = run_transcript_filename(base);
+        let b = run_transcript_filename(same_second);
+        assert_eq!(a, "run-1700000000123.json");
+        assert_eq!(b, "run-1700000000579.json");
+        assert_ne!(
+            a, b,
+            "millisecond precision must disambiguate same-second runs"
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/mod.rs
@@ -1,0 +1,510 @@
+//! Live in-process orchestrator for the standalone metaharness (#1030, WI-4).
+//!
+//! Why: This is the gating WI-4 piece of the #1045 metaharness — it replaces the
+//! WI-2 `NoopAgentRunner` with the live [`InProcessAgentRunner`] so `tm meta run`
+//! drives a *real* PM → sub-agent delegation end-to-end. The PM runs its own
+//! [`AgentLoop`]; its `delegate_to_agent` tool dispatches to the in-process
+//! runner, which loads the engineer agent and drives the engineer's own loop;
+//! both share one `Arc<dyn LlmClientTrait>` so token usage rolls up onto a single
+//! transcript. The orchestrator returns a combined [`MetaTranscript`] (PM turn +
+//! engineer turns + usage rollup + file artifacts).
+//! What: [`RecordingRunner`] wraps the real runner to capture each delegation's
+//! `(agent, task, AgentOutput)` for the transcript. [`MetaRegistryFactory`] is the
+//! [`RegistryFactory`] that assembles each sub-agent's tool set (fs/bash scoped to
+//! the project + a nested delegate). [`Orchestrator`] wires the PM registry +
+//! AgentLoop and exposes [`Orchestrator::run`], which executes one delegation
+//! cycle and returns a [`MetaTranscript`].
+//! Test: `orchestrator::tests` drive a full PM → delegate → engineer loop with a
+//! scripted `LlmClientTrait` mock (no live LLM), asserting the combined transcript
+//! captures both turns, both usages, and the engineer's file artifact.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use trusty_code::agent_loop::{AgentLoop, AgentLoopConfig};
+use trusty_code::agents::AgentConfig;
+use trusty_code::llm::LlmClientTrait;
+use trusty_code::prompt::assemble_system_prompt;
+use trusty_code::provider::resolve_model;
+use trusty_code::runner::{InProcessAgentRunner, InProcessRunnerConfig, RegistryFactory};
+use trusty_code::tools::{
+    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, ReadFileTool, RunContext,
+    ToolRegistry, WriteFileTool,
+};
+
+use super::agents::PM_AGENT_NAME;
+use super::transcript::{AgentTurn, Artifact, MetaTranscript};
+
+/// One captured delegation: the agent, its task, and the returned output.
+///
+/// Why: The combined transcript needs every sub-agent turn, but the PM's
+/// `AgentLoop` only returns the PM's own output — sub-agent results flow through
+/// the delegate tool. Recording each delegation as it happens is how the
+/// orchestrator reconstructs the sub-agent turns for the transcript.
+/// What: the delegated `agent` slug, the `task` string, and the engineer's
+/// `AgentOutput` (content + usage).
+/// Test: `orchestrator_records_delegation` asserts a record is captured.
+#[derive(Debug, Clone)]
+pub(crate) struct DelegationRecord {
+    /// The sub-agent slug that was delegated to.
+    pub agent: String,
+    /// The task string passed to the sub-agent.
+    pub task: String,
+    /// The sub-agent's returned output.
+    pub output: AgentOutput,
+}
+
+/// An [`AgentRunner`] decorator that records every delegation it performs.
+///
+/// Why: The orchestrator must observe each sub-agent's output and usage to build
+/// the combined transcript; the runner is the single choke point every delegation
+/// flows through, so wrapping it captures them all without threading state through
+/// the agent loop.
+/// What: Holds the inner runner and a shared `Mutex<Vec<DelegationRecord>>`. Its
+/// `run`/`run_with_context` delegate to the inner runner, then push the result
+/// (on success) into the shared log before returning it unchanged.
+/// Test: `orchestrator_records_delegation`.
+pub(crate) struct RecordingRunner {
+    inner: Arc<dyn AgentRunner>,
+    records: Arc<Mutex<Vec<DelegationRecord>>>,
+}
+
+impl RecordingRunner {
+    /// Wrap `inner`, recording into the shared `records` log.
+    ///
+    /// Why: Constructor injection keeps the decorator testable and lets the
+    /// orchestrator share the same `records` handle it later reads.
+    /// What: Stores the inner runner and the shared record log.
+    /// Test: `orchestrator_records_delegation`.
+    pub(crate) fn new(
+        inner: Arc<dyn AgentRunner>,
+        records: Arc<Mutex<Vec<DelegationRecord>>>,
+    ) -> Self {
+        Self { inner, records }
+    }
+
+    /// Push a successful delegation onto the shared log.
+    ///
+    /// Why: Both trait methods record identically; factoring it avoids drift.
+    /// What: Locks the log and appends a `DelegationRecord`. A poisoned lock is
+    /// ignored (recording is best-effort telemetry, never a failure path).
+    /// Test: `orchestrator_records_delegation`.
+    fn record(&self, agent: &str, task: &str, output: &AgentOutput) {
+        if let Ok(mut log) = self.records.lock() {
+            log.push(DelegationRecord {
+                agent: agent.to_string(),
+                task: task.to_string(),
+                output: output.clone(),
+            });
+        }
+    }
+}
+
+#[async_trait]
+impl AgentRunner for RecordingRunner {
+    /// Delegate to the inner runner and record the result on success.
+    ///
+    /// Why: The PM's delegate tool calls this; recording here captures the
+    /// sub-agent turn for the transcript.
+    /// What: Forwards to `inner.run`; on `Ok`, records `(agent, task, output)`.
+    /// Test: `orchestrator_records_delegation`.
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+        let out = self.inner.run(agent_name, task).await?;
+        self.record(agent_name, task, &out);
+        Ok(out)
+    }
+
+    /// Context-carrying variant: forward and record identically.
+    ///
+    /// Why: The orchestrator may pin a model/turn cap per delegation; this keeps
+    /// recording consistent across both entry points.
+    /// What: Forwards to `inner.run_with_context`; records on `Ok`.
+    /// Test: covered indirectly by the recording path.
+    async fn run_with_context(
+        &self,
+        agent_name: &str,
+        task: &str,
+        ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        let out = self.inner.run_with_context(agent_name, task, ctx).await?;
+        self.record(agent_name, task, &out);
+        Ok(out)
+    }
+}
+
+/// [`RegistryFactory`] that assembles each sub-agent's tool set.
+///
+/// Why: The in-process runner is policy-free about tool construction (#1029); the
+/// orchestrator owns *how* a sub-agent's tools are wired. For the metaharness,
+/// every sub-agent gets fs/bash scoped to the project working directory plus a
+/// nested `delegate_to_agent` (so deeper delegation is possible). Reusing the
+/// same construction the PM uses keeps the capability surface consistent.
+/// What: Holds the project dir, the recording runner (for the nested delegate),
+/// and the agents config dir. `build` returns the *ungated* registry; the runner
+/// then narrows it to each agent's `tools.allowed`.
+/// Test: `orchestrator_runs_full_delegation_cycle` (the engineer's `write_file`
+/// must run, proving the factory wired it).
+pub(crate) struct MetaRegistryFactory {
+    project: PathBuf,
+    runner: Arc<dyn AgentRunner>,
+    config_dir: PathBuf,
+}
+
+impl MetaRegistryFactory {
+    /// Construct the factory from its collaborators.
+    ///
+    /// Why: Constructor injection lets the orchestrator share one project dir,
+    /// one nested-delegate runner, and one config dir across every sub-agent.
+    /// What: Stores the three inputs.
+    /// Test: `orchestrator_runs_full_delegation_cycle`.
+    pub(crate) fn new(
+        project: impl Into<PathBuf>,
+        runner: Arc<dyn AgentRunner>,
+        config_dir: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            project: project.into(),
+            runner,
+            config_dir: config_dir.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl RegistryFactory for MetaRegistryFactory {
+    /// Build the ungated tool registry offered to `_agent` under `_ctx`.
+    ///
+    /// Why: Centralising tool assembly here means a single factory serves every
+    /// sub-agent; the runner applies each agent's `tools.allowed` afterwards.
+    /// What: Registers fs tools (`read_file`/`write_file`/`edit`) scoped to the
+    /// project dir, a default `bash`, and a nested `delegate_to_agent` backed by
+    /// the shared recording runner (validated against the config dir).
+    /// Test: `orchestrator_runs_full_delegation_cycle`.
+    async fn build(&self, _agent: &AgentConfig, _ctx: &RunContext) -> Arc<ToolRegistry> {
+        Arc::new(build_agent_registry(
+            &self.project,
+            Arc::clone(&self.runner),
+            &self.config_dir,
+        ))
+    }
+}
+
+/// Build the shared tool registry (fs/bash + delegate) scoped to `project`.
+///
+/// Why: Both the PM and every sub-agent are offered the same capability set; one
+/// builder keeps them identical and reuses the WI-2 tool wiring concept.
+/// What: Registers `read_file`/`write_file`/`edit` (scoped to `project`), a
+/// default `bash`, and a `delegate_to_agent` backed by `runner` and validated
+/// against `config_dir`.
+/// Test: exercised via `Orchestrator::run` in `orchestrator_runs_full_delegation_cycle`.
+fn build_agent_registry(
+    project: &Path,
+    runner: Arc<dyn AgentRunner>,
+    config_dir: &Path,
+) -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    registry.register(Arc::new(ReadFileTool::new(project)));
+    registry.register(Arc::new(WriteFileTool::new(project)));
+    registry.register(Arc::new(EditTool::new(project)));
+    registry.register(Arc::new(BashTool::default_config()));
+    registry.register(Arc::new(
+        DelegateToAgentTool::new(runner).with_config_dir(config_dir.to_path_buf()),
+    ));
+    registry
+}
+
+/// Wires the live PM loop + in-process sub-agent runner for one run.
+///
+/// Why: This is the #1030 orchestration entry point — it loads the PM config,
+/// builds the PM's registry (delegate + read tools, gated by the PM's
+/// `tools.allowed`), runs the PM via [`AgentLoop`], and returns the combined
+/// transcript. A single shared LLM client threads through the PM and the runner
+/// so usage rolls up.
+/// What: Holds the shared client, the agents config dir, the project working dir,
+/// the loop budget, and optional project context. [`run`] executes one delegation
+/// cycle and returns a [`MetaTranscript`].
+/// Test: `orchestrator::tests`.
+///
+/// [`run`]: Orchestrator::run
+pub(crate) struct Orchestrator {
+    llm: Arc<dyn LlmClientTrait>,
+    config_dir: PathBuf,
+    project: PathBuf,
+    config: InProcessRunnerConfig,
+    project_context: Option<String>,
+}
+
+impl Orchestrator {
+    /// Construct an orchestrator from its collaborators.
+    ///
+    /// Why: Constructor injection keeps the orchestrator testable — production
+    /// passes a real `LlmClient`; tests pass a scripted mock — and lets the same
+    /// client be shared with the runner for usage rollup.
+    /// What: Stores the shared client, config dir, project dir, and a default
+    /// loop budget; project context starts `None`.
+    /// Test: `orchestrator_runs_full_delegation_cycle`.
+    pub(crate) fn new(
+        llm: Arc<dyn LlmClientTrait>,
+        config_dir: impl Into<PathBuf>,
+        project: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            llm,
+            config_dir: config_dir.into(),
+            project: project.into(),
+            config: InProcessRunnerConfig::default(),
+            project_context: None,
+        }
+    }
+
+    /// Attach project `CLAUDE.md` context injected into every assembled prompt.
+    ///
+    /// Why: Both the PM and sub-agents should see the same project rules
+    /// (parity-spec); threading it here injects it into every prompt.
+    /// What: Stores `context`.
+    /// Test: `orchestrator_runs_full_delegation_cycle` (context-free path); the
+    /// runner's own tests cover context propagation to sub-agents.
+    pub(crate) fn with_project_context(mut self, context: impl Into<String>) -> Self {
+        self.project_context = Some(context.into());
+        self
+    }
+
+    /// Override the default loop budget (turn cap + timeout).
+    ///
+    /// Why: Tests want a tight, deterministic budget; deployments may want more.
+    /// What: Replaces `self.config`.
+    /// Test: `orchestrator_runs_full_delegation_cycle` uses a small budget.
+    pub(crate) fn with_config(mut self, config: InProcessRunnerConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Run one PM → sub-agent delegation cycle and return the combined transcript.
+    ///
+    /// Why: This is the orchestration deliverable — load the PM, run its loop
+    /// (which delegates once to the engineer through the shared in-process
+    /// runner), then assemble the combined transcript with both turns, the usage
+    /// rollup, and the engineer's file artifacts.
+    /// What: Loads `pm.toml`, builds the live recording runner + registry factory,
+    /// constructs the PM's gated registry, resolves the PM model + assembled
+    /// prompt, drives an `AgentLoop`, then folds the PM output and every recorded
+    /// delegation into a [`MetaTranscript`] (artifacts captured by diffing the
+    /// project tree against a pre-run snapshot).
+    /// Test: `orchestrator_runs_full_delegation_cycle`.
+    pub(crate) async fn run(&self, task: &str) -> Result<MetaTranscript> {
+        let pm_path = self.config_dir.join(format!("{PM_AGENT_NAME}.toml"));
+        let pm_config = AgentConfig::load(&pm_path)
+            .with_context(|| format!("failed to load PM config: {}", pm_path.display()))?;
+
+        // Snapshot the project tree so we can attribute new/changed files to the run.
+        let before = snapshot_files(&self.project);
+
+        // The live in-process runner the PM delegates through; wrapped so the
+        // orchestrator can record each sub-agent turn for the transcript.
+        let records: Arc<Mutex<Vec<DelegationRecord>>> = Arc::new(Mutex::new(Vec::new()));
+        let real_runner: Arc<dyn AgentRunner> = Arc::new(
+            InProcessAgentRunner::new(
+                Arc::clone(&self.llm),
+                self.registry_factory(records.clone()),
+                self.config_dir.clone(),
+            )
+            .with_config(self.config.clone())
+            .maybe_with_project_context(self.project_context.clone()),
+        );
+        let recording: Arc<dyn AgentRunner> =
+            Arc::new(RecordingRunner::new(real_runner, records.clone()));
+
+        // The PM's own registry: fs/bash + a delegate tool dispatching to the
+        // recording runner. The PM's `tools.allowed` then gates it down to
+        // delegate + read.
+        let full_pm_registry =
+            build_agent_registry(&self.project, Arc::clone(&recording), &self.config_dir);
+        let pm_registry = gate_registry(full_pm_registry, &pm_config);
+
+        let model = resolve_model(&pm_config, None);
+        let system = assemble_system_prompt(&pm_config, self.project_context.as_deref(), None);
+        let loop_config = AgentLoopConfig {
+            max_turns: self.config.max_turns,
+            timeout_secs: self.config.timeout_secs,
+            model: model.clone(),
+        };
+
+        let pm_loop = AgentLoop::new(loop_config, Arc::clone(&self.llm), Arc::new(pm_registry));
+        let pm_output = pm_loop
+            .run(&system, task)
+            .await
+            .context("PM agent loop failed")?;
+
+        // Assemble the combined transcript from the PM output + recorded
+        // delegations + the file artifacts the run produced.
+        let pm_turn = AgentTurn::from_pm_output(&pm_output);
+        let delegations = drain_delegations(&records);
+        let artifacts = new_artifacts(&self.project, &before);
+        Ok(MetaTranscript::assemble(
+            model,
+            task,
+            pm_turn,
+            delegations,
+            artifacts,
+        ))
+    }
+
+    /// Build the registry factory sharing `records` with the orchestrator.
+    ///
+    /// Why: The factory needs the recording runner so nested delegations are also
+    /// captured; sharing `records` keeps every turn in one log.
+    /// What: Returns a `MetaRegistryFactory` whose nested delegate dispatches to a
+    /// recording runner wrapping a fresh in-process runner.
+    /// Test: exercised via `run`.
+    fn registry_factory(
+        &self,
+        records: Arc<Mutex<Vec<DelegationRecord>>>,
+    ) -> Arc<dyn RegistryFactory> {
+        // Sub-agents delegate (if at all) through their own recording runner so
+        // nested turns also land in the transcript. For the demo the engineer
+        // does not delegate further, but wiring it keeps the seam complete.
+        let nested_real: Arc<dyn AgentRunner> = Arc::new(
+            InProcessAgentRunner::new(
+                Arc::clone(&self.llm),
+                Arc::new(NullRegistryFactory),
+                self.config_dir.clone(),
+            )
+            .with_config(self.config.clone()),
+        );
+        let nested: Arc<dyn AgentRunner> = Arc::new(RecordingRunner::new(nested_real, records));
+        Arc::new(MetaRegistryFactory::new(
+            self.project.clone(),
+            nested,
+            self.config_dir.clone(),
+        ))
+    }
+}
+
+/// A `RegistryFactory` that yields an empty registry.
+///
+/// Why: The nested delegate runner needs *some* factory, but a sub-agent that
+/// delegates further would itself need tools; for the bounded demo an empty set
+/// is sufficient and avoids unbounded recursion in factory construction.
+/// What: `build` returns an empty `Arc<ToolRegistry>`.
+/// Test: covered by `orchestrator_runs_full_delegation_cycle` (no nested
+/// delegation occurs, so the empty registry is never narrowed).
+struct NullRegistryFactory;
+
+#[async_trait]
+impl RegistryFactory for NullRegistryFactory {
+    async fn build(&self, _agent: &AgentConfig, _ctx: &RunContext) -> Arc<ToolRegistry> {
+        Arc::new(ToolRegistry::new())
+    }
+}
+
+/// Narrow `registry` to `config.tools.allowed`, if present.
+///
+/// Why: The PM's registry must be gated the same way the runner gates sub-agents
+/// — the PM may only call the tools in its allowlist (delegate + read).
+/// What: If `tools.allowed` is `Some`, returns `registry.gated(list)`; else
+/// returns it unchanged.
+/// Test: exercised via `run` (the PM cannot call `write_file`).
+fn gate_registry(registry: ToolRegistry, config: &AgentConfig) -> ToolRegistry {
+    match config.tools.as_ref().and_then(|t| t.allowed.as_ref()) {
+        Some(allowed) => registry.gated(allowed),
+        None => registry,
+    }
+}
+
+/// Drain the recorded delegations into transcript turns.
+///
+/// Why: The transcript needs the sub-agent turns in delegation order; draining
+/// the shared log yields exactly those, once.
+/// What: Locks the log, maps each `DelegationRecord` to an `AgentTurn`, and
+/// returns them. A poisoned lock yields an empty list (best-effort telemetry).
+/// Test: `orchestrator_runs_full_delegation_cycle`.
+fn drain_delegations(records: &Arc<Mutex<Vec<DelegationRecord>>>) -> Vec<AgentTurn> {
+    let Ok(log) = records.lock() else {
+        return Vec::new();
+    };
+    log.iter()
+        .map(|r| AgentTurn::for_delegation(&r.agent, &r.task, &r.output))
+        .collect()
+}
+
+/// Snapshot the relative paths of every file under `dir` (recursively).
+///
+/// Why: To attribute new/changed files to the run we compare the post-run tree
+/// against this pre-run snapshot.
+/// What: Walks `dir`, collecting each file's path relative to `dir`. IO errors
+/// yield an empty set (the run still proceeds; artifacts are best-effort).
+/// Test: `snapshot_then_new_artifacts_detects_created_file`.
+fn snapshot_files(dir: &Path) -> std::collections::BTreeSet<PathBuf> {
+    let mut out = std::collections::BTreeSet::new();
+    collect_files(dir, dir, &mut out);
+    out
+}
+
+/// Recursive helper for [`snapshot_files`].
+///
+/// Why: Directory walking needs a recursive worker that records paths relative to
+/// the snapshot root.
+/// What: For each entry under `current`, recurse into dirs and insert files'
+/// paths relative to `root`. Unreadable entries are skipped.
+/// Test: via `snapshot_files` in `snapshot_then_new_artifacts_detects_created_file`.
+fn collect_files(root: &Path, current: &Path, out: &mut std::collections::BTreeSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(current) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(root, &path, out);
+        } else if let Ok(rel) = path.strip_prefix(root) {
+            out.insert(rel.to_path_buf());
+        }
+    }
+}
+
+/// List files that appear after the run but were absent from `before`.
+///
+/// Why: The transcript must surface the engineer's file changes; newly created
+/// files are the auditable evidence of the delegation's side effects.
+/// What: Snapshots `dir` again, keeps paths not in `before`, and builds an
+/// [`Artifact`] (relative path + byte length) for each, sorted by path.
+/// Test: `snapshot_then_new_artifacts_detects_created_file`.
+fn new_artifacts(dir: &Path, before: &std::collections::BTreeSet<PathBuf>) -> Vec<Artifact> {
+    let after = snapshot_files(dir);
+    after
+        .into_iter()
+        .filter(|p| !before.contains(p))
+        .map(|rel| {
+            let bytes = std::fs::metadata(dir.join(&rel))
+                .map(|m| m.len())
+                .unwrap_or(0);
+            Artifact {
+                path: rel.to_string_lossy().into_owned(),
+                bytes,
+            }
+        })
+        .collect()
+}
+
+/// Internal extension: optionally attach project context to the runner.
+///
+/// Why: `InProcessAgentRunner::with_project_context` takes a value, but the
+/// orchestrator holds an `Option`; this keeps the call site branch-free.
+/// What: If `Some`, calls `with_project_context`; else returns the runner as-is.
+/// Test: exercised via `Orchestrator::run`.
+trait MaybeProjectContext: Sized {
+    fn maybe_with_project_context(self, ctx: Option<String>) -> Self;
+}
+
+impl MaybeProjectContext for InProcessAgentRunner {
+    fn maybe_with_project_context(self, ctx: Option<String>) -> Self {
+        match ctx {
+            Some(c) => self.with_project_context(c),
+            None => self,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/mod.rs
@@ -89,15 +89,21 @@ impl RecordingRunner {
     ///
     /// Why: Both trait methods record identically; factoring it avoids drift.
     /// What: Locks the log and appends a `DelegationRecord`. A poisoned lock is
-    /// ignored (recording is best-effort telemetry, never a failure path).
+    /// best-effort-skipped — recording is telemetry, never a failure path — but it
+    /// emits a `tracing::warn!` (to stderr) so the dropped delegation turn is
+    /// visible rather than silently lost.
     /// Test: `orchestrator_records_delegation`.
     fn record(&self, agent: &str, task: &str, output: &AgentOutput) {
-        if let Ok(mut log) = self.records.lock() {
-            log.push(DelegationRecord {
+        match self.records.lock() {
+            Ok(mut log) => log.push(DelegationRecord {
                 agent: agent.to_string(),
                 task: task.to_string(),
                 output: output.clone(),
-            });
+            }),
+            Err(_) => tracing::warn!(
+                agent,
+                "metaharness: delegation-record lock poisoned; dropping recorded turn (transcript will omit this delegation)"
+            ),
         }
     }
 }
@@ -390,11 +396,22 @@ impl Orchestrator {
 /// What: `build` returns an empty `Arc<ToolRegistry>`.
 /// Test: covered by `orchestrator_runs_full_delegation_cycle` (no nested
 /// delegation occurs, so the empty registry is never narrowed).
+///
+/// NOTE (known limitation): in this bounded demo, a sub-agent that delegates
+/// *further* (a nested sub-agent) gets this empty tool set — nested delegation is
+/// wired for completeness but is not expected to occur. `build` therefore emits a
+/// `tracing::warn!` if it is ever actually invoked, so the limitation surfaces in
+/// the logs rather than silently handing a nested agent zero tools.
 struct NullRegistryFactory;
 
 #[async_trait]
 impl RegistryFactory for NullRegistryFactory {
-    async fn build(&self, _agent: &AgentConfig, _ctx: &RunContext) -> Arc<ToolRegistry> {
+    async fn build(&self, agent: &AgentConfig, _ctx: &RunContext) -> Arc<ToolRegistry> {
+        tracing::warn!(
+            agent = %agent.agent.name,
+            "metaharness: nested sub-agent delegation is unsupported in this bounded demo; \
+             handing the nested agent an empty tool set"
+        );
         Arc::new(ToolRegistry::new())
     }
 }
@@ -418,10 +435,14 @@ fn gate_registry(registry: ToolRegistry, config: &AgentConfig) -> ToolRegistry {
 /// Why: The transcript needs the sub-agent turns in delegation order; draining
 /// the shared log yields exactly those, once.
 /// What: Locks the log, maps each `DelegationRecord` to an `AgentTurn`, and
-/// returns them. A poisoned lock yields an empty list (best-effort telemetry).
+/// returns them. A poisoned lock yields an empty list (best-effort telemetry) but
+/// first emits a `tracing::warn!` (to stderr) so the lost turns are visible.
 /// Test: `orchestrator_runs_full_delegation_cycle`.
 fn drain_delegations(records: &Arc<Mutex<Vec<DelegationRecord>>>) -> Vec<AgentTurn> {
     let Ok(log) = records.lock() else {
+        tracing::warn!(
+            "metaharness: delegation-record lock poisoned; transcript will omit all recorded delegations"
+        );
         return Vec::new();
     };
     log.iter()
@@ -445,19 +466,33 @@ fn snapshot_files(dir: &Path) -> std::collections::BTreeSet<PathBuf> {
 /// Recursive helper for [`snapshot_files`].
 ///
 /// Why: Directory walking needs a recursive worker that records paths relative to
-/// the snapshot root.
-/// What: For each entry under `current`, recurse into dirs and insert files'
-/// paths relative to `root`. Unreadable entries are skipped.
-/// Test: via `snapshot_files` in `snapshot_then_new_artifacts_detects_created_file`.
+/// the snapshot root — and must not follow symlinks, which would risk infinite
+/// recursion (and a stack overflow) on a symlink cycle, and would also record a
+/// symlink's target as if it were a run artifact.
+/// What: For each entry under `current`, classifies it with `entry.file_type()`
+/// (which does *not* traverse symlinks, unlike `Path::is_dir`/`is_file`): recurses
+/// only into real directories and records only real files' paths relative to
+/// `root`. Symlinks (and entries whose type is unreadable) are skipped, so a
+/// symlink cycle can never drive the recursion.
+/// Test: via `snapshot_files` in `snapshot_then_new_artifacts_detects_created_file`
+/// and `collect_files_skips_symlinks` (symlink-skip / no-cycle-recursion).
 fn collect_files(root: &Path, current: &Path, out: &mut std::collections::BTreeSet<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(current) else {
         return;
     };
     for entry in entries.flatten() {
+        // `file_type()` here reflects the entry itself (it does not follow
+        // symlinks), so a symlink — even one pointing at a directory or forming a
+        // cycle — is neither recursed into nor recorded.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
         let path = entry.path();
-        if path.is_dir() {
+        if file_type.is_dir() {
             collect_files(root, &path, out);
-        } else if let Ok(rel) = path.strip_prefix(root) {
+        } else if file_type.is_file()
+            && let Ok(rel) = path.strip_prefix(root)
+        {
             out.insert(rel.to_path_buf());
         }
     }
@@ -470,6 +505,9 @@ fn collect_files(root: &Path, current: &Path, out: &mut std::collections::BTreeS
 /// What: Snapshots `dir` again, keeps paths not in `before`, and builds an
 /// [`Artifact`] (relative path + byte length) for each, sorted by path.
 /// Test: `snapshot_then_new_artifacts_detects_created_file`.
+// TODO: also detect modified (not just new) files via mtime/size — the current
+// snapshot diff only surfaces files that did not exist before the run, so an
+// in-place edit of a pre-existing file is invisible in the transcript.
 fn new_artifacts(dir: &Path, before: &std::collections::BTreeSet<PathBuf>) -> Vec<Artifact> {
     let after = snapshot_files(dir);
     after

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/tests.rs
@@ -263,6 +263,44 @@ fn snapshot_then_new_artifacts_detects_created_file() {
     assert_eq!(arts[0].bytes, 12);
 }
 
+/// `collect_files` skips symlinks (no cycle recursion, no symlink artifacts).
+///
+/// Why: Fix #1 — walking with `Path::is_dir()` follows symlinks, so a symlink
+/// cycle would recurse forever (stack overflow) and a symlink to a file would be
+/// recorded as a bogus artifact. Using `entry.file_type()` (which does not follow
+/// symlinks) fixes both. This test creates a directory symlink cycle and a file
+/// symlink and asserts the walk terminates and records only the real file.
+/// What: Build `dir/real.txt` and `dir/sub/`; symlink `dir/sub/loop -> dir`
+/// (a cycle) and `dir/link.txt -> dir/real.txt`; snapshot and assert the only
+/// recorded path is `real.txt`.
+/// Test: this test (Unix-only; symlink creation differs on Windows).
+#[cfg(unix)]
+#[test]
+fn collect_files_skips_symlinks() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("real.txt"), b"hi").expect("write real file");
+    std::fs::create_dir(root.join("sub")).expect("create subdir");
+
+    // A directory-symlink cycle: sub/loop -> root. With is_dir() this recurses
+    // forever; with file_type() it is skipped.
+    std::os::unix::fs::symlink(root, root.join("sub").join("loop")).expect("dir symlink");
+    // A file symlink that must NOT be recorded as an artifact.
+    std::os::unix::fs::symlink(root.join("real.txt"), root.join("link.txt")).expect("file symlink");
+
+    let snapshot = snapshot_files(root);
+
+    let paths: Vec<String> = snapshot
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        paths,
+        vec!["real.txt".to_string()],
+        "only the real file is recorded; symlinks (cycle + file link) are skipped, got: {paths:?}"
+    );
+}
+
 /// Live end-to-end: a real OpenRouter model drives the PM → engineer cycle and
 /// the engineer writes the demo artifact (#1045 WI-8 live variant).
 ///

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/tests.rs
@@ -1,0 +1,313 @@
+//! Offline tests for the live metaharness orchestrator (#1030, WI-4).
+//!
+//! Why: Acceptance criterion #1030 requires the full PM → delegate → engineer
+//! cycle to be provable without a live LLM. The scripted `LlmClientTrait` mock
+//! (shared between the PM loop and the in-process sub-agent runner, exactly as in
+//! production) makes the whole delegation deterministic, so every criterion —
+//! both turns captured, both usages rolled up, the engineer's file artifact
+//! visible, the structured schema adhered to — is asserted offline.
+//! What: A `ScriptedLlm` replays a fixed queue of `ChatResponse`s. The orchestrator
+//! is wired over a temp project + a temp agents dir (PM + engineer configs
+//! written by `super::super::agents::write_agent_configs`). The script drives the
+//! PM to delegate to the engineer, the engineer to call `write_file`, and both to
+//! stop — then the combined transcript is asserted.
+//! Test: this module is itself the test surface.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::*;
+use crate::commands::meta::agents::write_agent_configs;
+use trusty_code::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
+
+/// A `LlmClientTrait` that replays a fixed JSON script in call order.
+///
+/// Why: Deterministic, offline substitute for the network client; the same
+/// instance is shared by the PM loop and the engineer loop so the script must
+/// interleave their turns in the order the orchestrator drives them.
+/// What: Holds scripted `ChatResponse`s and an atomic cursor; each `chat`
+/// returns the next response, erroring loudly once the script is exhausted.
+/// Test: used by every orchestrator test below.
+struct ScriptedLlm {
+    responses: Vec<ChatResponse>,
+    cursor: AtomicUsize,
+}
+
+impl ScriptedLlm {
+    /// Build a scripted client from JSON response fixtures.
+    fn from_json(fixtures: &[Value]) -> Self {
+        let responses = fixtures
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()).expect("valid ChatResponse fixture"))
+            .collect();
+        Self {
+            responses,
+            cursor: AtomicUsize::new(0),
+        }
+    }
+
+    /// Number of `chat` calls made so far.
+    fn calls(&self) -> usize {
+        self.cursor.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for ScriptedLlm {
+    async fn chat(&self, _req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
+        match self.responses.get(idx) {
+            Some(resp) => Ok(resp.clone()),
+            None => Err(LlmError::MissingConfig(format!(
+                "scripted LLM exhausted at call {idx}"
+            ))),
+        }
+    }
+}
+
+/// A response in which the assistant calls a named tool with the given JSON args.
+fn tool_call(call_id: &str, tool: &str, args: Value, p: u32, c: u32) -> Value {
+    json!({
+        "id": "gen-tool",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": { "name": tool, "arguments": args.to_string() }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": p, "completion_tokens": c, "total_tokens": p + c }
+    })
+}
+
+/// A response in which the assistant emits final text and stops.
+fn stop(text: &str, p: u32, c: u32) -> Value {
+    json!({
+        "id": "gen-stop",
+        "choices": [{
+            "message": { "role": "assistant", "content": text, "tool_calls": [] },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": p, "completion_tokens": c, "total_tokens": p + c }
+    })
+}
+
+/// The full PM → delegate → engineer cycle yields a combined transcript with
+/// both turns, both usages, and the engineer's file artifact.
+///
+/// Why: This is the core #1030 acceptance test — a stubbed end-to-end run must
+/// produce a unified transcript adhering to the structured schema, with the PM
+/// and engineer usages both captured and the engineer's file change visible.
+/// What: Script: PM delegates → engineer writes `hello_metaharness.txt` →
+/// engineer stops → PM stops. Run the orchestrator over temp project + agents
+/// dirs; assert the file exists, the transcript carries one delegation, the usage
+/// rolls up across all four turns, and the artifact is listed.
+/// Test: this test.
+#[tokio::test]
+async fn orchestrator_runs_full_delegation_cycle() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let agents = tempfile::tempdir().expect("agents tempdir");
+    write_agent_configs(agents.path()).expect("write agent configs");
+
+    // Call order the orchestrator drives:
+    //  1. PM loop call 1   -> delegate_to_agent(python-engineer, task)
+    //  2. engineer call 1  -> write_file(hello_metaharness.txt)
+    //  3. engineer call 2  -> stop ("wrote the file")
+    //  4. PM loop call 2   -> stop ("delegated and done")
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call(
+            "d1",
+            "delegate_to_agent",
+            json!({"agent_name": "python-engineer", "task": "create hello_metaharness.txt"}),
+            40,
+            10,
+        ),
+        tool_call(
+            "w1",
+            "write_file",
+            json!({"path": "hello_metaharness.txt", "content": "hello from the metaharness\n"}),
+            30,
+            8,
+        ),
+        stop("wrote hello_metaharness.txt", 12, 4),
+        stop("Delegated to the engineer; the file was created.", 20, 6),
+    ]));
+
+    let orchestrator = Orchestrator::new(
+        llm.clone(),
+        agents.path().to_path_buf(),
+        project.path().to_path_buf(),
+    )
+    .with_config(InProcessRunnerConfig {
+        max_turns: 4,
+        timeout_secs: 30,
+    });
+
+    let transcript = orchestrator
+        .run("create hello_metaharness.txt")
+        .await
+        .expect("orchestration cycle succeeds");
+
+    // The engineer actually wrote the file (real tool dispatch, not a stub).
+    let written = project.path().join("hello_metaharness.txt");
+    assert!(written.exists(), "engineer must have written the file");
+    let body = std::fs::read_to_string(&written).expect("read written file");
+    assert_eq!(body, "hello from the metaharness\n");
+
+    // Exactly four chat calls (two PM, two engineer) over the shared client.
+    assert_eq!(llm.calls(), 4, "shared client drove all four turns");
+
+    // PM turn captured.
+    assert_eq!(transcript.pm.role, "pm");
+    assert!(
+        transcript.pm.output.contains("Delegated"),
+        "PM output captured: {}",
+        transcript.pm.output
+    );
+
+    // One delegation captured, to the engineer, with its task and output.
+    assert_eq!(transcript.delegations.len(), 1, "one delegation captured");
+    let eng = &transcript.delegations[0];
+    assert_eq!(eng.role, "python-engineer");
+    assert_eq!(eng.task.as_deref(), Some("create hello_metaharness.txt"));
+    assert_eq!(eng.output, "wrote hello_metaharness.txt");
+
+    // Both usages captured and rolled up: PM (40+10 + 20+6) + engineer (30+8 + 12+4).
+    assert_eq!(transcript.pm.usage.prompt_tokens, 40 + 20);
+    assert_eq!(transcript.pm.usage.completion_tokens, 10 + 6);
+    assert_eq!(eng.usage.prompt_tokens, 30 + 12);
+    assert_eq!(eng.usage.completion_tokens, 8 + 4);
+    assert_eq!(transcript.usage.prompt_tokens, 40 + 20 + 30 + 12);
+    assert_eq!(transcript.usage.completion_tokens, 10 + 6 + 8 + 4);
+
+    // The engineer's file change is visible in the transcript artifacts.
+    let art = transcript
+        .artifacts
+        .iter()
+        .find(|a| a.path == "hello_metaharness.txt")
+        .expect("artifact listed for the created file");
+    assert_eq!(art.bytes, body.len() as u64);
+
+    // The structured schema is adhered to (round-trips through serde_json).
+    let v = serde_json::to_value(&transcript).expect("transcript serializes");
+    assert_eq!(
+        v["schema_version"],
+        super::super::transcript::TRANSCRIPT_SCHEMA_VERSION
+    );
+    assert!(v["pm"].is_object());
+    assert!(v["delegations"].is_array());
+    assert!(v["usage"].is_object());
+    assert!(v["artifacts"].is_array());
+}
+
+/// The recording runner captures each delegation it performs.
+///
+/// Why: The transcript's sub-agent turns come from the recording runner; a
+/// regression that dropped the recording would silently lose delegation turns.
+/// What: Wrap a stub runner that returns a fixed output; call `run`; assert one
+/// record with the right agent, task, and content.
+/// Test: this test.
+#[tokio::test]
+async fn orchestrator_records_delegation() {
+    use trusty_code::tools::{AgentOutput, AgentRunner};
+
+    struct StubRunner;
+    #[async_trait]
+    impl AgentRunner for StubRunner {
+        async fn run(&self, _agent: &str, _task: &str) -> anyhow::Result<AgentOutput> {
+            Ok(AgentOutput::from_content("stub engineer output"))
+        }
+    }
+
+    let records: Arc<Mutex<Vec<DelegationRecord>>> = Arc::new(Mutex::new(Vec::new()));
+    let runner = RecordingRunner::new(Arc::new(StubRunner), records.clone());
+
+    let out = runner
+        .run("python-engineer", "do the thing")
+        .await
+        .expect("stub runner succeeds");
+    assert_eq!(out.content, "stub engineer output");
+
+    let log = records.lock().expect("records lock");
+    assert_eq!(log.len(), 1, "one delegation recorded");
+    assert_eq!(log[0].agent, "python-engineer");
+    assert_eq!(log[0].task, "do the thing");
+    assert_eq!(log[0].output.content, "stub engineer output");
+}
+
+/// Artifact detection lists only files created during the run.
+///
+/// Why: The transcript must attribute *new* files to the run, not pre-existing
+/// ones; a snapshot diff is how that attribution works.
+/// What: Snapshot an empty dir, create a file, then diff — assert the new file is
+/// the sole artifact with the correct byte length.
+/// Test: this test.
+#[test]
+fn snapshot_then_new_artifacts_detects_created_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let before = snapshot_files(dir.path());
+    assert!(before.is_empty(), "fresh dir has no files");
+
+    std::fs::write(dir.path().join("created.txt"), b"twelve bytes").expect("write file");
+    let arts = new_artifacts(dir.path(), &before);
+    assert_eq!(arts.len(), 1, "exactly one new artifact");
+    assert_eq!(arts[0].path, "created.txt");
+    assert_eq!(arts[0].bytes, 12);
+}
+
+/// Live end-to-end: a real OpenRouter model drives the PM → engineer cycle and
+/// the engineer writes the demo artifact (#1045 WI-8 live variant).
+///
+/// Why: The mock test proves the wiring; this proves the harness works against a
+/// real LLM. It is `#[ignore]`d so CI stays offline and fast — run it locally
+/// with `OPENROUTER_API_KEY` set:
+/// `cargo test -p trusty-mpm --bin tm -- --ignored orchestrator_live_demo`.
+/// What: Builds a real `LlmClient` from env, writes the bundled agent configs,
+/// runs the orchestrator over the bundled demo task, and asserts the demo
+/// artifact was created and at least one delegation was captured.
+/// Test: this test (network-gated, ignored by default).
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY and network access"]
+async fn orchestrator_live_demo() {
+    use trusty_code::llm::{LlmClient, LlmClientConfig};
+
+    let config = LlmClientConfig::from_env().expect("OPENROUTER_API_KEY must be set for live test");
+    let client = LlmClient::from_config(config).expect("build client");
+    let llm = Arc::new(client);
+
+    let project = tempfile::tempdir().expect("project tempdir");
+    let agents = tempfile::tempdir().expect("agents tempdir");
+    write_agent_configs(agents.path()).expect("write agent configs");
+
+    let orchestrator = Orchestrator::new(
+        llm,
+        agents.path().to_path_buf(),
+        project.path().to_path_buf(),
+    );
+
+    let task = "Create a file named `hello_metaharness.txt` in the project root containing \
+                exactly the line `hello from the metaharness`. Delegate the file creation to \
+                the python-engineer agent.";
+    let transcript = orchestrator.run(task).await.expect("live run succeeds");
+
+    assert!(
+        project.path().join("hello_metaharness.txt").exists(),
+        "engineer must have created the demo artifact"
+    );
+    assert!(
+        !transcript.delegations.is_empty(),
+        "the PM must have delegated at least once"
+    );
+    assert!(
+        transcript.usage.total_tokens > 0,
+        "the run must have consumed tokens"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/transcript.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/transcript.rs
@@ -66,9 +66,16 @@ impl UsageTotals {
     /// Accumulate another `UsageTotals` into this one.
     ///
     /// Why: The run-wide rollup is the sum of the PM's usage and every
-    /// sub-agent's usage; a single `add` keeps the summation in one place.
-    /// What: Adds each counter field-wise (saturating to avoid overflow panics).
+    /// sub-agent's usage; a single `add` keeps the summation in one place. Rather
+    /// than accumulating `total_tokens` independently (which would drift if any
+    /// actor's `total` did not equal its prompt+completion), the total is *derived*
+    /// from the summed components after the fact — keeping `add` consistent with
+    /// [`from_token_usage`], where `total = prompt + completion`.
+    /// What: Adds prompt/completion/cache counters field-wise (saturating to avoid
+    /// overflow panics), then sets `total_tokens = prompt + completion`.
     /// Test: `usage_totals_add_sums_fields`.
+    ///
+    /// [`from_token_usage`]: UsageTotals::from_token_usage
     pub fn add(&mut self, other: &UsageTotals) {
         self.prompt_tokens = self.prompt_tokens.saturating_add(other.prompt_tokens);
         self.completion_tokens = self
@@ -80,7 +87,7 @@ impl UsageTotals {
         self.cache_creation_tokens = self
             .cache_creation_tokens
             .saturating_add(other.cache_creation_tokens);
-        self.total_tokens = self.total_tokens.saturating_add(other.total_tokens);
+        self.total_tokens = self.prompt_tokens.saturating_add(self.completion_tokens);
     }
 }
 
@@ -280,6 +287,39 @@ mod tests {
         a.add(&UsageTotals::from_token_usage(&usage(15, 5)));
         assert_eq!(a.prompt_tokens, 45);
         assert_eq!(a.completion_tokens, 15);
+        assert_eq!(a.total_tokens, 60);
+    }
+
+    /// `add` derives `total_tokens` from the summed components, not from the
+    /// operands' own totals.
+    ///
+    /// Why: Fix #2 — accumulating `total_tokens` independently is fragile if an
+    /// actor's `total` ever diverges from prompt+completion (e.g. a provider that
+    /// reports a non-additive total). The rollup must equal the summed
+    /// prompt+completion regardless of the operands' stored totals.
+    /// What: Hand-build two totals whose `total_tokens` is deliberately wrong, add
+    /// them, and assert the result's `total_tokens` equals summed prompt+completion.
+    /// Test: this test.
+    #[test]
+    fn usage_totals_add_derives_total_from_components() {
+        let mut a = UsageTotals {
+            prompt_tokens: 30,
+            completion_tokens: 10,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 999, // deliberately inconsistent
+        };
+        let b = UsageTotals {
+            prompt_tokens: 15,
+            completion_tokens: 5,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 7, // deliberately inconsistent
+        };
+        a.add(&b);
+        assert_eq!(a.prompt_tokens, 45);
+        assert_eq!(a.completion_tokens, 15);
+        // Derived from components (45 + 15), NOT 999 + 7.
         assert_eq!(a.total_tokens, 60);
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/transcript.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/transcript.rs
@@ -1,0 +1,387 @@
+//! Structured transcript schema for one metaharness orchestration run (#1030).
+//!
+//! Why: The orchestrator drives a PM → sub-agent delegation cycle and must hand
+//! back a single, machine-readable record of what happened — both the PM's turns
+//! and every sub-agent's turns, the token usage each accrued, and the file
+//! artifacts the run produced. Acceptance criterion #1030 requires a *defined
+//! transcript schema* that captures PM + subagent turns, both usages, and the
+//! engineer's file changes; centralising that schema here keeps the orchestrator
+//! focused on wiring and gives downstream tooling a stable shape to parse.
+//! What: [`MetaTranscript`] is the top-level record: a `model`, the PM
+//! [`AgentTurn`], the ordered list of delegation [`AgentTurn`]s, the
+//! [`UsageTotals`] rolled up across PM + sub-agents, and the [`Artifact`] list of
+//! files observed under the project after the run. [`UsageTotals::from_token_usage`]
+//! and [`MetaTranscript::rollup_usage`] keep the totals consistent. Everything is
+//! `Serialize` so the orchestrator can persist it as JSON.
+//! Test: `transcript::tests` cover usage rollup, turn capture, and JSON shape.
+
+use serde::Serialize;
+use trusty_code::perf::TokenUsage;
+use trusty_code::tools::AgentOutput;
+
+/// Token usage for a single actor or for the whole run.
+///
+/// Why: The PM and each sub-agent accrue tokens independently; the schema must
+/// expose both the per-turn usage and the run-wide rollup so a comparison
+/// harness can attribute cost. A small `Serialize` mirror of [`TokenUsage`]
+/// keeps the JSON shape stable and decoupled from the upstream type.
+/// What: prompt/completion/total token counts. [`from_token_usage`] copies from a
+/// [`TokenUsage`]; [`add`] accumulates another `UsageTotals` for the rollup.
+/// Test: `usage_totals_add_sums_fields`, `transcript_rolls_up_pm_and_subagents`.
+///
+/// [`from_token_usage`]: UsageTotals::from_token_usage
+/// [`add`]: UsageTotals::add
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct UsageTotals {
+    /// Prompt (input) tokens consumed.
+    pub prompt_tokens: u32,
+    /// Completion (output) tokens produced.
+    pub completion_tokens: u32,
+    /// Cache-read tokens (reused prompt cache), if the provider reports them.
+    pub cache_read_tokens: u32,
+    /// Cache-creation tokens (prompt cache writes), if the provider reports them.
+    pub cache_creation_tokens: u32,
+    /// Convenience sum of prompt + completion tokens.
+    pub total_tokens: u32,
+}
+
+impl UsageTotals {
+    /// Build a `UsageTotals` from a trusty-code [`TokenUsage`].
+    ///
+    /// Why: The agent loop reports usage as [`TokenUsage`] (which has no rolled
+    /// total); the transcript schema needs an owned, `Serialize`-friendly copy
+    /// plus a derived `total_tokens` so consumers do not have to re-add.
+    /// What: Copies the four counters and computes `total = prompt + completion`.
+    /// Test: `usage_totals_from_token_usage_copies_fields`.
+    pub fn from_token_usage(usage: &TokenUsage) -> Self {
+        Self {
+            prompt_tokens: usage.prompt_tokens,
+            completion_tokens: usage.completion_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+            cache_creation_tokens: usage.cache_creation_tokens,
+            total_tokens: usage.prompt_tokens.saturating_add(usage.completion_tokens),
+        }
+    }
+
+    /// Accumulate another `UsageTotals` into this one.
+    ///
+    /// Why: The run-wide rollup is the sum of the PM's usage and every
+    /// sub-agent's usage; a single `add` keeps the summation in one place.
+    /// What: Adds each counter field-wise (saturating to avoid overflow panics).
+    /// Test: `usage_totals_add_sums_fields`.
+    pub fn add(&mut self, other: &UsageTotals) {
+        self.prompt_tokens = self.prompt_tokens.saturating_add(other.prompt_tokens);
+        self.completion_tokens = self
+            .completion_tokens
+            .saturating_add(other.completion_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(other.cache_read_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(other.cache_creation_tokens);
+        self.total_tokens = self.total_tokens.saturating_add(other.total_tokens);
+    }
+}
+
+/// One actor's turn in the run — either the PM or a delegated sub-agent.
+///
+/// Why: A unified turn type lets the schema list the PM turn and each delegation
+/// uniformly, so consumers iterate one shape regardless of role. Capturing the
+/// `task` for delegations (and `None` for the PM, whose task is the run's prompt)
+/// records exactly what each actor was asked to do.
+/// What: `role` is the actor name (`"pm"` or the agent slug), `task` is the
+/// delegated instruction (only present for sub-agents), `output` is the actor's
+/// final text, and `usage` is the tokens that actor accrued.
+/// Test: `agent_turn_from_pm_output_sets_role_pm`,
+/// `agent_turn_for_delegation_carries_task`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AgentTurn {
+    /// Actor name: `"pm"` for the project manager, else the sub-agent slug.
+    pub role: String,
+    /// The task this actor was delegated (sub-agents only; `None` for the PM).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    /// The actor's final textual output.
+    pub output: String,
+    /// Tokens this actor accrued across its own loop.
+    pub usage: UsageTotals,
+}
+
+impl AgentTurn {
+    /// Build the PM turn from the PM loop's [`AgentOutput`].
+    ///
+    /// Why: The PM is the run's top-level actor; its turn has no delegated task
+    /// (its "task" is the run prompt recorded at the transcript level).
+    /// What: Sets `role = "pm"`, `task = None`, copies content + usage.
+    /// Test: `agent_turn_from_pm_output_sets_role_pm`.
+    pub fn from_pm_output(output: &AgentOutput) -> Self {
+        Self {
+            role: ROLE_PM.to_string(),
+            task: None,
+            output: output.content.clone(),
+            usage: UsageTotals::from_token_usage(&output.usage),
+        }
+    }
+
+    /// Build a sub-agent turn from a recorded delegation.
+    ///
+    /// Why: Each `delegate_to_agent` call produces a sub-agent turn the schema
+    /// must expose alongside the task it was given.
+    /// What: Sets `role = agent`, records `task`, copies content + usage.
+    /// Test: `agent_turn_for_delegation_carries_task`.
+    pub fn for_delegation(agent: &str, task: &str, output: &AgentOutput) -> Self {
+        Self {
+            role: agent.to_string(),
+            task: Some(task.to_string()),
+            output: output.content.clone(),
+            usage: UsageTotals::from_token_usage(&output.usage),
+        }
+    }
+}
+
+/// A file artifact observed in the project working directory after the run.
+///
+/// Why: Acceptance criterion #1030 requires the engineer's file changes to be
+/// *visible in the transcript*; recording each produced file (relative path +
+/// byte length) makes the side effects auditable without re-reading the disk.
+/// What: `path` is the path relative to the project root; `bytes` is the file's
+/// size in bytes at capture time.
+/// Test: `artifact_serializes_relative_path`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Artifact {
+    /// Path relative to the project working directory.
+    pub path: String,
+    /// File size in bytes.
+    pub bytes: u64,
+}
+
+/// Actor name stamped on the PM's turn.
+///
+/// Why: The `"pm"` role string is asserted by tests and parsed by tooling;
+/// centralising it keeps the producer and consumers in lockstep.
+/// What: the literal `"pm"`.
+/// Test: `agent_turn_from_pm_output_sets_role_pm`.
+pub(crate) const ROLE_PM: &str = "pm";
+
+/// Schema version stamped into every emitted transcript.
+///
+/// Why: Downstream tooling must detect schema changes; a version token lets the
+/// shape evolve without silently breaking parsers.
+/// What: the current transcript schema version string.
+/// Test: `transcript_json_carries_schema_version`.
+pub(crate) const TRANSCRIPT_SCHEMA_VERSION: &str = "1.0.0";
+
+/// Top-level record of one metaharness orchestration run (#1030).
+///
+/// Why: The orchestrator must return a *single combined transcript* spanning the
+/// PM and every sub-agent, with usage rolled up and artifacts listed — the core
+/// #1030 deliverable. Bundling these into one `Serialize` type gives the run a
+/// stable persisted shape under `.trusty-mpm/meta-runs/`.
+/// What: `schema_version` tags the shape; `model` is the slug the PM loop used;
+/// `prompt` is the run's top-level task; `pm` is the PM turn; `delegations` are
+/// the sub-agent turns in call order; `usage` is the PM+subagent rollup;
+/// `artifacts` are the files observed after the run.
+/// Test: `transcript_rolls_up_pm_and_subagents`,
+/// `transcript_json_carries_schema_version`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct MetaTranscript {
+    /// Transcript schema version (see [`TRANSCRIPT_SCHEMA_VERSION`]).
+    pub schema_version: String,
+    /// Model slug the PM loop ran against.
+    pub model: String,
+    /// The run's top-level task prompt handed to the PM.
+    pub prompt: String,
+    /// The PM's turn.
+    pub pm: AgentTurn,
+    /// Sub-agent turns, in delegation order.
+    pub delegations: Vec<AgentTurn>,
+    /// Token usage rolled up across the PM and every sub-agent.
+    pub usage: UsageTotals,
+    /// File artifacts observed under the project after the run.
+    pub artifacts: Vec<Artifact>,
+}
+
+impl MetaTranscript {
+    /// Assemble a transcript from the PM turn, delegations, and artifacts.
+    ///
+    /// Why: One constructor that also computes the usage rollup guarantees the
+    /// `usage` total always matches the parts — callers cannot forget to sum.
+    /// What: Stamps the schema version, stores the inputs, and sets `usage` to the
+    /// sum of the PM turn's usage and every delegation's usage via
+    /// [`rollup_usage`].
+    /// Test: `transcript_rolls_up_pm_and_subagents`.
+    ///
+    /// [`rollup_usage`]: MetaTranscript::rollup_usage
+    pub fn assemble(
+        model: impl Into<String>,
+        prompt: impl Into<String>,
+        pm: AgentTurn,
+        delegations: Vec<AgentTurn>,
+        artifacts: Vec<Artifact>,
+    ) -> Self {
+        let usage = Self::rollup_usage(&pm, &delegations);
+        Self {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION.to_string(),
+            model: model.into(),
+            prompt: prompt.into(),
+            pm,
+            delegations,
+            usage,
+            artifacts,
+        }
+    }
+
+    /// Sum the PM turn's usage with every delegation's usage.
+    ///
+    /// Why: The run-wide total is exactly the PM plus all sub-agents; factoring
+    /// the summation out keeps it unit-testable in isolation.
+    /// What: Starts from the PM's usage and folds in each delegation's usage.
+    /// Test: `transcript_rolls_up_pm_and_subagents`.
+    fn rollup_usage(pm: &AgentTurn, delegations: &[AgentTurn]) -> UsageTotals {
+        let mut total = pm.usage.clone();
+        for turn in delegations {
+            total.add(&turn.usage);
+        }
+        total
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `TokenUsage` fixture with explicit prompt/completion counters.
+    fn usage(p: u32, c: u32) -> TokenUsage {
+        TokenUsage::new(p, c, 0, 0)
+    }
+
+    /// `from_token_usage` copies all three counters verbatim.
+    ///
+    /// Why: Guards the schema-mirror conversion against field drift.
+    /// What: Convert a usage fixture; assert each field matches.
+    /// Test: this test.
+    #[test]
+    fn usage_totals_from_token_usage_copies_fields() {
+        let totals = UsageTotals::from_token_usage(&usage(30, 10));
+        assert_eq!(totals.prompt_tokens, 30);
+        assert_eq!(totals.completion_tokens, 10);
+        assert_eq!(totals.total_tokens, 40);
+    }
+
+    /// `add` sums each counter field-wise.
+    ///
+    /// Why: The rollup depends on correct accumulation.
+    /// What: Add two totals; assert each field is the sum.
+    /// Test: this test.
+    #[test]
+    fn usage_totals_add_sums_fields() {
+        let mut a = UsageTotals::from_token_usage(&usage(30, 10));
+        a.add(&UsageTotals::from_token_usage(&usage(15, 5)));
+        assert_eq!(a.prompt_tokens, 45);
+        assert_eq!(a.completion_tokens, 15);
+        assert_eq!(a.total_tokens, 60);
+    }
+
+    /// The PM turn carries `role = "pm"` and no task.
+    ///
+    /// Why: Consumers key the PM turn off its role; `task` is `None` for the PM.
+    /// What: Build a PM turn from an output; assert role and absent task.
+    /// Test: this test.
+    #[test]
+    fn agent_turn_from_pm_output_sets_role_pm() {
+        let out = AgentOutput {
+            content: "pm did its job".to_string(),
+            summary: None,
+            usage: usage(30, 10),
+        };
+        let turn = AgentTurn::from_pm_output(&out);
+        assert_eq!(turn.role, ROLE_PM);
+        assert!(turn.task.is_none());
+        assert_eq!(turn.output, "pm did its job");
+        assert_eq!(turn.usage.total_tokens, 40);
+    }
+
+    /// A delegation turn records the agent slug and the delegated task.
+    ///
+    /// Why: The schema must show what each sub-agent was asked to do.
+    /// What: Build a delegation turn; assert role, task, output, usage.
+    /// Test: this test.
+    #[test]
+    fn agent_turn_for_delegation_carries_task() {
+        let out = AgentOutput {
+            content: "engineer wrote the file".to_string(),
+            summary: None,
+            usage: usage(15, 5),
+        };
+        let turn = AgentTurn::for_delegation("python-engineer", "write hello.txt", &out);
+        assert_eq!(turn.role, "python-engineer");
+        assert_eq!(turn.task.as_deref(), Some("write hello.txt"));
+        assert_eq!(turn.usage.total_tokens, 20);
+    }
+
+    /// The transcript rolls PM + sub-agent usage into the run-wide total.
+    ///
+    /// Why: This is the #1030 "both usages captured" criterion at the schema
+    /// level — the total must equal PM plus every delegation.
+    /// What: Assemble a transcript with a PM turn (30/10) and one delegation
+    /// (15/5); assert the rolled-up total is 45/15/60.
+    /// Test: this test.
+    #[test]
+    fn transcript_rolls_up_pm_and_subagents() {
+        let pm = AgentTurn::from_pm_output(&AgentOutput {
+            content: "pm".to_string(),
+            summary: None,
+            usage: usage(30, 10),
+        });
+        let eng = AgentTurn::for_delegation(
+            "python-engineer",
+            "task",
+            &AgentOutput {
+                content: "eng".to_string(),
+                summary: None,
+                usage: usage(15, 5),
+            },
+        );
+        let t = MetaTranscript::assemble("openai/gpt-4o-mini", "prompt", pm, vec![eng], vec![]);
+        assert_eq!(t.usage.prompt_tokens, 45);
+        assert_eq!(t.usage.completion_tokens, 15);
+        assert_eq!(t.usage.total_tokens, 60);
+        assert_eq!(t.delegations.len(), 1);
+    }
+
+    /// An artifact serializes with its relative path and byte length.
+    ///
+    /// Why: File changes must be visible in the transcript JSON.
+    /// What: Serialize an artifact; assert the JSON fields.
+    /// Test: this test.
+    #[test]
+    fn artifact_serializes_relative_path() {
+        let art = Artifact {
+            path: "hello_metaharness.txt".to_string(),
+            bytes: 12,
+        };
+        let v = serde_json::to_value(&art).expect("serialize artifact");
+        assert_eq!(v["path"], "hello_metaharness.txt");
+        assert_eq!(v["bytes"], 12);
+    }
+
+    /// The emitted transcript JSON carries the schema version token.
+    ///
+    /// Why: Tooling detects schema changes via this field.
+    /// What: Assemble + serialize; assert `schema_version` is present.
+    /// Test: this test.
+    #[test]
+    fn transcript_json_carries_schema_version() {
+        let pm = AgentTurn::from_pm_output(&AgentOutput {
+            content: "pm".to_string(),
+            summary: None,
+            usage: usage(1, 1),
+        });
+        let t = MetaTranscript::assemble("m", "p", pm, vec![], vec![]);
+        let v = serde_json::to_value(&t).expect("serialize transcript");
+        assert_eq!(v["schema_version"], TRANSCRIPT_SCHEMA_VERSION);
+        assert_eq!(v["model"], "m");
+        assert_eq!(v["prompt"], "p");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -269,9 +269,10 @@ async fn main() -> anyhow::Result<()> {
         } => commands::ticket::ticket(&client, &url, issue, system, notes, runtime).await,
         Command::Issue { cmd, system } => commands::issue::issue(cmd, system),
         Command::Watch { cmd } => dispatch_watch(&client, &url, cmd).await,
-        // #1045 WI-1: the metaharness boots standalone (no daemon, no HTTP
-        // client). Dispatch straight to the synchronous bootstrap handler.
-        Command::Meta { action } => commands::meta::meta(action),
+        // #1045: the metaharness boots standalone (no daemon, no HTTP client).
+        // The handler is async because `meta run --demo` (#1030, WI-4) drives a
+        // live in-process PM → engineer agent loop.
+        Command::Meta { action } => commands::meta::meta(action).await,
     };
 
     // Top-level exit-code translation: a `tm sessions prune-idle` that found the


### PR DESCRIPTION
Closes #1030
Completes WI-4 of #1045

## Summary
Replaces the WI-2 `NoopAgentRunner` stub with the live trusty-code
`InProcessAgentRunner` so `tm meta run --demo` drives a real PM → engineer
delegation end-to-end. This is the **gating WI-4** piece of the #1045 metaharness.

## What landed
- **`orchestrator/`** — `Orchestrator` wires the PM `AgentLoop` +
  `InProcessAgentRunner` + `DelegateToAgentTool`, sharing **one
  `Arc<dyn LlmClientTrait>`** between the PM and every sub-agent so token usage
  rolls up onto a single transcript. A `RecordingRunner` decorator captures each
  delegation for the transcript; `MetaRegistryFactory` (a `RegistryFactory`)
  assembles each sub-agent's fs/bash + nested-delegate tool set, reusing the WI-2
  tool wiring. The PM's registry is gated to its `tools.allowed` (delegate + read).
- **`transcript.rs`** — `MetaTranscript` schema: `schema_version`, `model`,
  `prompt`, the PM turn, the ordered delegation turns, the **usage rollup** across
  PM + sub-agents, and the **file artifacts** observed after the run (the
  engineer's file changes are visible here).
- **`agents.rs`** — bundled PM + `python-engineer` configs materialised to
  `<project>/.trusty-mpm/meta-agents/`, so the demo exercises the real on-disk
  agent-loading path with zero external setup. The PM is allowed only
  `delegate_to_agent` + `read_file`; the engineer gets the full fs/bash set.
- **`meta/mod.rs`** — `meta run --demo` builds a live OpenRouter client, runs the
  orchestrator over the bundled demo task (`hello_metaharness.txt`), and persists
  the combined transcript under `<project>/.trusty-mpm/meta-runs/`. A bare
  `meta run` stays offline (tool-registry summary, no LLM).

## Design decision — demo LLM backend
The live demo **requires `OPENROUTER_API_KEY`** and **degrades gracefully** when
absent (clear, actionable error — it never silently mocks). The full
PM → delegate → engineer wiring is proven **offline** by a scripted-`LlmClientTrait`
test where real tool dispatch writes a real file and only the LLM is scripted; a
live end-to-end variant is `#[ignore]`-gated for key-equipped local runs. This
matches #1045's "mock gate in CI, live variant ignored" success criteria.

## Acceptance criteria (#1030)
- [x] Orchestrator loads PM config (delegate + read tools)
- [x] Runs PM via `AgentLoop`
- [x] Drives one delegation to the engineer
- [x] Returns combined transcript + artifacts
- [x] Defined transcript schema (PM + subagent turns)
- [x] Both usages captured (PM + engineer) and rolled up
- [x] Engineer file changes visible in the transcript (artifacts)
- [x] Structured transcript schema adhered to (serde round-trip asserted)
- [x] No `unwrap()` in library code

## Verification (OPENROUTER_API_KEY unset)
- `cargo build -p trusty-mpm` — clean
- `cargo test -p trusty-mpm -p trusty-code` — all pass
- `cargo test --workspace` — pass (one flaky trusty-search test, unrelated to this
  change, passes on re-run; this PR touches only trusty-mpm)
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)