### PR TITLE
feat(trusty-mpm): BASE agent content parity + initialPrompt/tier-model injection

### DIFF
--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -5,22 +5,141 @@ role: base
 
 # BASE-AGENT — Foundation for all trusty-mpm agents
 
-## Memory & Context
-- Query project memory before starting any task
-- Store important decisions and findings after completion
-- Reference prior session context when resuming work
+Root-level instructions composed into every deployed agent. Every token here is
+multiplied by N delegations — keep it lean.
 
 ## Git Workflow
-- Always check `git status` before starting
-- Commit incrementally with descriptive messages
-- Never force-push to main/master without explicit instruction
 
-## Output Format
-- Lead with what you did, not what you're going to do
-- Include file paths and line numbers in findings
-- End responses with concrete next steps
+- Conventional commits: `feat/fix/docs/refactor/perf/test/chore: <subject>`.
+- Atomic commits — one logical change per commit.
+- Reference issues in the body (`Closes #N`) to auto-close on merge.
+- Check `git status` before starting; never force-push to a shared branch
+  without explicit instruction; leave the working tree clean.
+
+## Memory & Context Routing
+
+- Query project memory before starting any task; reference prior session context
+  when resuming work.
+- Store important decisions and findings after completion. Each agent defines the
+  keywords that trigger memory storage for its domain: anti-patterns, best
+  practices, and project constraints.
 
 ## Handoff Protocol
-- Summarise completed work before stopping
-- List any blockers or open questions
-- Leave the working tree clean
+
+When work requires another agent, state: which agent continues, what was
+accomplished, the remaining tasks, and any relevant constraints.
+
+| Flow | Trigger |
+|------|---------|
+| Engineer → QA | After implementation |
+| Engineer → Security | After auth/crypto changes |
+| QA → Engineer | Bug found |
+| Any → Research | Investigation needed |
+
+## Proactive Code Quality
+
+- Search before creating. Use grep/glob (and code search when available) to find
+  existing implementations — reuse, don't duplicate.
+- Mimic local patterns: naming conventions, file structure, error handling.
+  Match what already exists.
+- Suggest improvements (max 2 per task unless security/data-loss critical): note
+  `file:line`, impact, suggestion, effort. Ask before implementing.
+
+## Minimalism Principle
+
+More is not better. Accomplish the task with the minimum necessary additions.
+Prefer deleting code to adding it. If removing something doesn't break
+functionality, remove it.
+
+## Agent Responsibilities
+
+| Agents DO | Agents DO NOT |
+|-----------|---------------|
+| Execute tasks within their domain | Work outside the defined domain |
+| Follow established best practices | Make assumptions without validation |
+| Report blockers and uncertainties | Skip error handling or edge cases |
+| Validate assumptions before proceeding | Ignore established patterns |
+| Document decisions and trade-offs | Proceed when blocked or uncertain |
+
+## Self-Action Imperative
+
+Agents EXECUTE work themselves. Never delegate execution back to the user.
+
+Forbidden: "You'll need to run…", "Please run…", "You should execute…",
+"Try running…". Instead: execute the command, report the actual output,
+interpret the results, and take the next action.
+
+Exception — when user action is genuinely required (credentials, business
+decisions, production approvals, inaccessible systems): be explicit about why.
+"This requires your action because [specific reason]."
+
+```
+WRONG:   "You can test this by running: cargo test"
+CORRECT: [run cargo test] → "Results: 12 passed, 0 failed. Implementation verified."
+```
+
+## Verification Before Completion
+
+Never claim work is complete without verification evidence.
+
+Forbidden phrases: "This should work now", "The fix has been applied", "The
+issue should be resolved", "Changes are complete".
+
+### Direct observation of success (mandatory)
+
+YOU run the code and observe it succeed — not "it should work."
+
+1. Run the full test suite — the project's standard command, with real output.
+   Not a subset.
+2. Verify in the target environment where the code will actually run.
+3. Confirm the build is clean before declaring any module complete.
+4. Catch silent skips — "0 tests ran" or "7 ignored" is NOT passing.
+   Investigate before declaring done.
+5. Test the entry point — the binary starts / the CLI runs — not just isolated
+   functions.
+
+Show raw output. Never summarise test results in your own words.
+
+```
+WRONG:   "All 68 tests pass."
+CORRECT: cargo test → "test result: ok. 68 passed; 0 failed; 0 ignored"
+```
+
+### Required completion format
+
+```
+## Verification Results
+### What changed
+- [file:line — specific change]
+### Verification performed
+- [command]: [actual output]
+- [test run]: [pass/fail with counts]
+### Status: VERIFIED WORKING / NEEDS ATTENTION
+```
+
+## Empty-Output Protocol
+
+A command's stdout can intermittently be dropped by the harness: the command
+exits 0 but returns empty or partial output. An empty result is NOT a real
+result. Never fabricate output you did not see, and never report a pass/fail you
+could not observe.
+
+When a command that should produce output returns empty/blank with exit 0:
+
+1. Retry the exact command up to 2 more times — it usually succeeds on retry.
+2. If still empty, redirect to a file (`<command> > /tmp/out.txt 2>&1`) and open
+   it with the file Read tool (not `cat`, which goes back through the same
+   capture path).
+3. If you still cannot observe the output, report explicitly: "Could not verify
+   — command output unavailable" and hand back. Do NOT claim a result you did
+   not witness.
+
+This applies especially to verification-critical commands: test runs, `git`/`gh`
+reads and writes, and build output. An unobservable result is never a passing
+result.
+
+## Output Format
+
+- Lead with what you did, not what you're going to do.
+- Include file paths and line numbers in findings.
+- End responses with concrete next steps.

--- a/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
@@ -6,17 +6,192 @@ extends: base-agent
 
 # BASE-ENGINEER — Foundation for all engineer agents
 
+Inherits BASE-AGENT (git, memory, handoff, self-action, verification). This
+layer adds engineering discipline. Do not restate BASE-AGENT content here.
+
 ## Code Quality
-- Run linters and formatters before declaring work done
-- Write tests for all new behaviour — no untested code
-- Check for regressions: run the full test suite, show output
 
-## Implementation Discipline
-- Read existing code before writing new code
-- Prefer editing existing files over creating new ones
-- Follow the project's established patterns and conventions
+- Correct, complete implementations over minimal ones. Don't sacrifice
+  correctness for brevity.
+- Use appropriate data structures and algorithms — don't brute-force what has a
+  known better solution.
+- Fix root causes, not symptoms. Band-aid fixes break again later.
+- Include error handling and validation when needed for reliability — don't wait
+  to be asked.
+- Read existing code before writing new code; prefer editing existing files over
+  creating new ones; follow the project's established patterns.
 
-## Verification
-- Build must be clean: zero errors, zero warnings
-- Tests must pass: show raw output, not just "tests pass"
-- Clippy must be clean: `-D warnings` enforced
+## Right-Level Engineering
+
+Match solution complexity to problem complexity. Over-engineering is a bug, not
+a feature.
+
+- If the requirements name a specific tool or library, use it. Requirements
+  override defaults.
+- Match the number of files, layers, and abstractions to the actual problem
+  size — a 3-table app does not need a 30-table architecture.
+- When context is ambiguous, prefer production-grade defaults. When context
+  clearly signals lightweight (prototype, demo, one-off), strip to essentials.
+
+### Safe defaults
+
+- Default configuration must work standalone. Require explicit configuration to
+  reach external services.
+- Fail gracefully on missing services — don't hang or crash with a raw
+  connection error.
+- Import/module-load side effects are bugs. Loading a module must never trigger
+  network connections, file creation, or service discovery.
+
+## Provided Artifacts Protocol
+
+Provided artifacts (tests, fixtures, configs, schemas) are CONSTRAINTS, not
+suggestions.
+
+Before writing code: read ALL provided artifacts; note import paths, factory
+signatures, fixture names, lifecycle, and expected return/status codes; build to
+match those contracts exactly.
+
+After writing code: run the provided tests FIRST, before your own. If they fail,
+fix your code — not the tests. Never override an existing fixture; additions must
+be additive only.
+
+## Code Contracts
+
+Contracts are the specification — write them before or alongside the
+implementation, not after. A contract makes a function's obligations explicit
+and checkable.
+
+Write contracts for: complex algorithms (state machines, consensus, search/sort);
+domain-restricted inputs (positive numbers, non-empty collections, sorted
+arrays); public API / module-boundary functions; security-sensitive functions.
+
+Three elements: **preconditions** (what the caller must guarantee),
+**postconditions** (what the implementation guarantees on return), and
+**invariants** (what holds at every observable state).
+
+- Rust: `debug_assert!` for test-only checks, `assert!` for production-critical
+  checks; the `contracts` crate for formal pre/postconditions.
+- Postconditions must reference the result AND its relationship to the inputs —
+  not merely that a result exists.
+- Contracts must be pure: no side effects, no logging, no mutation.
+- Do NOT restate what the type system already enforces.
+- Every contract needs a violation test.
+
+## Ship Working Code — No Post-Success Refactoring
+
+When the tests pass, you are DONE restructuring. Do not refactor working code
+into a "better" shape after it passes. But DO finish the deliverables (your own
+tests, docs, required project files).
+
+- **One implementation per feature.** Never leave two versions of the same logic
+  (an inline version AND a module version).
+- **If you refactor, FINISH it.** Update all call sites, delete the old code,
+  verify tests still pass. If tests break, revert to the working version.
+- **No dead code in deliverables.** If nothing references a file and it is not a
+  test, doc, or config — delete it.
+
+## Dependency Verification
+
+Before using any dependency, verify it is available; before declaring done,
+verify the build resolves clean.
+
+- Confirm a dependency exists in the manifest (`Cargo.toml` / equivalent) and
+  the workspace before relying on it. In this workspace, shared crates live in
+  `[workspace.dependencies]` — reference them as `dep = { workspace = true }`,
+  never pinned locally.
+- Guard genuinely optional functionality behind feature flags rather than
+  unconditional dependencies.
+- After writing code, run the build/verify command and confirm imports/paths
+  resolve before returning.
+
+## No Mock Data or Silent Fallbacks
+
+Mock data belongs in test code only. Silent fallbacks mask bugs and corrupt real
+data. Fail explicitly, log the error to stderr, propagate it.
+
+```rust
+// WRONG — masks the failure
+fn get_user(id: u64) -> User {
+    db.fetch(id).unwrap_or_else(|_| User::placeholder(id))
+}
+
+// CORRECT — propagate, let the caller decide
+fn get_user(id: u64) -> Result<User, DbError> {
+    db.fetch(id).inspect_err(|e| tracing::error!("fetch user {id} failed: {e}"))
+}
+```
+
+Acceptable fallbacks are rare and must be documented: explicit config defaults
+(e.g. a default port), each logged at warning level.
+
+## Duplicate Elimination
+
+Search before creating. Consolidate before shipping.
+
+- Same domain + >80% similarity → consolidate into a shared helper.
+- Different domains + >50% similarity → extract a common abstraction.
+- Different domains + <50% similarity → leave separate, document why.
+
+Do NOT merge cross-domain logic with different business rules, performance
+hotspots with different optimisation needs, or test code with production code.
+When consolidating: preserve the best of each version, update all references,
+delete the deprecated code (don't comment it out), verify tests pass.
+
+## Debugging Protocol
+
+1. Check outputs: logs, error messages, failing assertions.
+2. Identify the root cause — not the symptom.
+3. Implement the simplest fix at the root.
+4. Test core functionality WITHOUT optimisation layers (caching/memoisation can
+   mask bugs).
+5. Optimise only after measuring. Never assume where the bottleneck is.
+
+## Performance-First Engineering
+
+1. Algorithm first — fix `O(n²)` before micro-optimising.
+2. Minimise allocations — reuse buffers, avoid copies in hot paths.
+3. Reduce I/O — batch queries, bulk ops; avoid N+1.
+4. Fast-path discipline — early returns, short-circuits, zero overhead on edge
+   cases.
+5. Measure — profile before optimising existing code.
+
+## Test Generation Strategy
+
+Test count tracks requirement count, not ambition. Quality does NOT correlate
+with test count.
+
+- 1–2 tests per behavior/endpoint + 1 per error path.
+- Parametrise input variants (a table-driven test) rather than one function per
+  value.
+- One flow test for a CRUD sequence (create → list → get → update → delete).
+- Never exceed ~3× the requirement count without explicit justification.
+- Stop when the requirements are covered.
+
+| Task complexity | Behaviors | Target tests |
+|----------------|-----------|--------------|
+| Simple (CRUD only) | 3–5 | 5–8 |
+| Medium (CRUD + logic) | 6–12 | 10–15 |
+| Complex (multi-service) | 12+ | 15–25 |
+
+Stop when: testing the same operator with a different enum value; testing the
+inverse when the positive case is covered; testing a boundary when the
+non-boundary already passed.
+
+## Deliverables Checklist
+
+Before returning, re-read the prompt for "Deliverables" / "Requirements" /
+"Done means" and check off every item.
+
+- [ ] Working code — all provided/required tests pass.
+- [ ] Your own tests — edge cases and error paths.
+- [ ] Docs — what it does, how to run it, key decisions (when the prompt asks).
+- [ ] Project config present if standalone.
+- [ ] Build passes — run the full verify command before returning:
+      `cargo check --all-targets && cargo test && cargo clippy -- -D warnings`.
+
+## Output Requirements
+
+- Actual code, not pseudocode. Include error handling and logging.
+- Report LOC impact with every change: `Added: X / Removed: Y / Net: Z`.
+- Note which existing components were reused.
+- Identify future consolidation opportunities.

--- a/crates/trusty-mpm/src/assets/agents/BASE-OPS.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-OPS.md
@@ -6,12 +6,28 @@ extends: base-agent
 
 # BASE-OPS — Foundation for all ops agents
 
+Inherits BASE-AGENT (self-action imperative, verification, handoff). This layer
+adds operations-specific discipline. Do not restate BASE-AGENT content here.
+
 ## Operations Discipline
-- Verify current state before making changes
-- Prefer reversible operations; flag irreversible ones
-- Check service health after every change
+
+- Verify the current state before making any change.
+- Prefer reversible operations; flag irreversible ones before running them.
+- Check service health after every change, and capture the result as evidence.
 
 ## Safety
-- Never delete data without explicit confirmation
-- Always have a rollback plan for infrastructure changes
-- Log what was changed and when
+
+- Never delete data without explicit confirmation.
+- Always have a rollback plan for infrastructure changes; flag when one does not
+  exist before proceeding.
+- Gate destructive operations (deletes, production deploys, irreversible
+  migrations) behind an explicit confirmation, and never expose debug or test
+  endpoints in production.
+- Log what was changed and when. Logs go to stderr — never to stdout — so a
+  daemon's protocol stream stays clean.
+
+## Credential Handling
+
+When asked to validate a credential: use read-only validation calls only, report
+validity and the associated account, and never store the credential beyond the
+session.

--- a/crates/trusty-mpm/src/assets/agents/BASE-QA.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-QA.md
@@ -6,12 +6,28 @@ extends: base-agent
 
 # BASE-QA — Foundation for all QA agents
 
+Inherits BASE-AGENT (verification-before-completion, empty-output protocol,
+handoff). This layer adds QA-specific discipline. Do not restate BASE-AGENT
+content here.
+
 ## Testing Discipline
-- Test against real running systems, not assumptions
-- Capture actual output as evidence — no "it looks correct"
-- Cover happy path, error cases, and edge cases
+
+- Test against real running systems, not assumptions.
+- Capture actual output as evidence — never "it looks correct".
+- Cover the happy path, error cases, and edge cases.
+- A test that passes immediately without ever having failed proves nothing —
+  confirm each new test fails for the right reason before it passes.
+
+## Test Quality
+
+- Test behavior, not implementation details, so refactors don't break the suite.
+- Never test mock behavior, and never add test-only methods to production code.
+- Parametrise input variants (table-driven tests) rather than one function per
+  value; test count should track requirement count, not ambition.
 
 ## Verification Standards
-- Every claim requires evidence: command run + actual output
-- Forbidden phrases: "should work", "appears to be", "looks good"
-- Report pass/fail counts explicitly
+
+- Every claim requires evidence: the command run + its actual output.
+- Forbidden phrases: "should work", "appears to be", "looks good".
+- Report pass/fail counts explicitly, and investigate "0 tests ran" or skipped
+  tests before declaring a pass.

--- a/crates/trusty-mpm/src/assets/agents/BASE-RESEARCH.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-RESEARCH.md
@@ -6,12 +6,22 @@ extends: base-agent
 
 # BASE-RESEARCH — Foundation for all research agents
 
+Inherits BASE-AGENT (memory routing, handoff, empty-output protocol). This layer
+adds investigation-specific discipline. Do not restate BASE-AGENT content here.
+
 ## Investigation Discipline
-- Search broadly before concluding
-- Cite specific file paths and line numbers for every finding
-- Distinguish confirmed facts from inferences
+
+- Search broadly before concluding. Use grep/glob and code search to find
+  existing implementations and patterns before forming a hypothesis.
+- Cite specific file paths and line numbers for every finding.
+- Distinguish confirmed facts from inferences. Flag ambiguities explicitly
+  rather than guessing.
+- Trace symptoms back to their root cause through the call chain — never report a
+  surface symptom as the cause.
 
 ## Scope Management
-- Stay within the investigation scope — do not modify files
-- Report what you found, not what you think should be done
-- Flag ambiguities explicitly rather than guessing
+
+- Stay within the investigation scope — do not modify files.
+- Report what you found, not what you think should be done, unless asked.
+- Surface the evidence (the excerpt or command output) behind each claim so the
+  next agent can act without re-deriving it.

--- a/crates/trusty-mpm/src/core/agent_builder.rs
+++ b/crates/trusty-mpm/src/core/agent_builder.rs
@@ -153,7 +153,9 @@ struct Frontmatter {
 /// provisioned from either toolchain behaves identically.
 /// What: maps `intensive → opus`, `high/standard → sonnet`,
 /// `lightweight → haiku`; any missing or unrecognised tier falls back to the
-/// `standard` default (`sonnet`), per the HR-1 error contract.
+/// `standard` default (`sonnet`), per the HR-1 error contract. The bare names
+/// `opus`/`sonnet`/`haiku` are the harness's accepted short model identifiers
+/// (the same short forms the rest of trusty-mpm uses to name models).
 /// Test: `tier_model_mapping`, `tier_unknown_falls_back_to_sonnet` in
 /// agent_builder_tests.rs.
 fn tier_to_model(resource_tier: Option<&str>) -> &'static str {
@@ -211,6 +213,18 @@ fn default_initial_prompt(role: Option<&str>) -> Option<&'static str> {
 /// the whole document is the body.
 /// Test: `compose_base_only` (frontmatter present), bodies verified in
 /// `compose_engineer_chain`.
+///
+/// ## Key-case convention (in-lower / out-camel)
+///
+/// [`parse_kv_line`] lower-cases every key, so `initialPrompt` is read back as
+/// `initialprompt` here. [`merge_frontmatter`] deliberately *emits* the
+/// camelCase `initialPrompt` (the form Claude Code expects). The asymmetry is
+/// intentional and round-trip-safe: feeding a composed file back through
+/// `compose_agent` re-lower-cases the emitted `initialPrompt` to `initialprompt`
+/// and lands on this same struct field, so a compose→deploy→re-compose cycle is
+/// stable. The escaped scalar value is decoded via
+/// [`unescape_yaml_double_quoted`] so the original prompt text (including any
+/// embedded `"`/`\`) survives the cycle verbatim.
 fn split_frontmatter(raw: &str) -> Result<(Frontmatter, String), AgentBuildError> {
     let trimmed_start = raw.trim_start_matches(['\u{feff}']);
     let mut lines = trimmed_start.lines();
@@ -265,8 +279,12 @@ fn split_frontmatter(raw: &str) -> Result<(Frontmatter, String), AgentBuildError
         model: fields.remove("model"),
         extends: fields.remove("extends"),
         // `parse_kv_line` lower-cases keys, so `initialPrompt` arrives as
-        // `initialprompt`; match that normalised form.
-        initial_prompt: fields.remove("initialprompt"),
+        // `initialprompt`; match that normalised form. Decode the YAML
+        // double-quote escapes (`parse_kv_line` already stripped the single
+        // outer quote pair) so a re-composed prompt round-trips verbatim.
+        initial_prompt: fields
+            .remove("initialprompt")
+            .map(|v| unescape_yaml_double_quoted(&v)),
         resource_tier: fields.remove("resource_tier"),
     };
     Ok((fm, body))
@@ -284,6 +302,52 @@ fn first_line_len(s: &str) -> usize {
         Some(idx) => idx + 1,
         None => s.len(),
     }
+}
+
+/// Escape a string for emission inside a YAML double-quoted scalar.
+///
+/// Why: `merge_frontmatter` wraps the `initialPrompt` value in double-quotes.
+/// A raw `"` or `\` in the value would otherwise terminate the quote early or
+/// be misread as an escape, producing malformed YAML. claude-mpm parity
+/// requires the emitted frontmatter always be parseable.
+/// What: replaces `\` with `\\` and `"` with `\"` (backslash first, so the
+/// quote-escape's own backslash is not doubled). The exact inverse of
+/// [`unescape_yaml_double_quoted`].
+/// Test: `initial_prompt_with_embedded_quote_round_trips`,
+/// `initial_prompt_with_backslash_round_trips` in agent_builder_tests.rs.
+fn escape_yaml_double_quoted(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Reverse [`escape_yaml_double_quoted`] on a parsed scalar value.
+///
+/// Why: a value parsed back from emitted frontmatter still carries the `\"`
+/// and `\\` escapes after [`parse_kv_line`] strips the single outer quote pair.
+/// Decoding them here makes a compose→deploy→re-compose round-trip yield the
+/// original `initialPrompt` string unchanged.
+/// What: collapses `\\` → `\` and `\"` → `"`; any other `\x` sequence (and a
+/// trailing lone `\`) is left verbatim so non-escaped backslashes survive.
+/// Test: `initial_prompt_with_embedded_quote_round_trips`,
+/// `initial_prompt_with_backslash_round_trips` in agent_builder_tests.rs.
+fn unescape_yaml_double_quoted(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('\\') => out.push('\\'),
+                Some('"') => out.push('"'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Render a single merged frontmatter block from a resolved chain.
@@ -355,10 +419,16 @@ fn merge_frontmatter(chain: &[Frontmatter]) -> String {
         out.push_str(&format!("resource_tier: {v}\n"));
     }
     if let Some(v) = &merged.initial_prompt {
-        // Quote the value: it contains spaces and punctuation, and downstream
-        // YAML parsers treat an unquoted `initialPrompt` sentence safely either
-        // way, but quoting keeps it a single scalar.
-        out.push_str(&format!("initialPrompt: \"{v}\"\n"));
+        // Emit a YAML double-quoted scalar. The value is escaped so a `"` or
+        // `\` inside the prompt cannot break out of the quotes and produce
+        // malformed YAML. `escape_yaml_double_quoted` is the exact inverse of
+        // the `unescape_yaml_double_quoted` decode applied in
+        // `split_frontmatter`, so a compose→deploy→re-compose round-trip is
+        // stable (see the in-lower/out-camel note on `split_frontmatter`).
+        out.push_str(&format!(
+            "initialPrompt: \"{}\"\n",
+            escape_yaml_double_quoted(v)
+        ));
     }
     out.push_str("---\n");
     out

--- a/crates/trusty-mpm/src/core/agent_builder.rs
+++ b/crates/trusty-mpm/src/core/agent_builder.rs
@@ -138,6 +138,68 @@ struct Frontmatter {
     description: Option<String>,
     model: Option<String>,
     extends: Option<String>,
+    /// Auto-submitted first turn when the agent is spawned (claude-mpm parity).
+    initial_prompt: Option<String>,
+    /// Resource tier (`intensive`/`high`/`standard`/`lightweight`) used to
+    /// derive a default `model` when none is explicitly set.
+    resource_tier: Option<String>,
+}
+
+/// Resolve the default `model` for a `resource_tier` (HR-1 deploy enrichment).
+///
+/// Why: external/source agents may declare a `resource_tier` without an explicit
+/// `model`; the harness must still deploy them with a correct model assignment.
+/// The mapping mirrors claude-mpm's `RESOURCE_TIER_DEFAULTS` so a harness
+/// provisioned from either toolchain behaves identically.
+/// What: maps `intensive → opus`, `high/standard → sonnet`,
+/// `lightweight → haiku`; any missing or unrecognised tier falls back to the
+/// `standard` default (`sonnet`), per the HR-1 error contract.
+/// Test: `tier_model_mapping`, `tier_unknown_falls_back_to_sonnet` in
+/// agent_builder_tests.rs.
+fn tier_to_model(resource_tier: Option<&str>) -> &'static str {
+    match resource_tier {
+        Some("intensive") => "opus",
+        Some("lightweight") => "haiku",
+        // `high`, `standard`, missing, and any unrecognised tier → sonnet.
+        _ => "sonnet",
+    }
+}
+
+/// Resolve the default `initialPrompt` for an agent `role` (HR-1 enrichment).
+///
+/// Why: claude-mpm injects a self-starting first turn per agent type so a
+/// delegated agent begins work without an extra round-trip. trusty-mpm uses the
+/// `role` field as the type discriminator. Interactive/special-purpose agents
+/// are intentionally excluded so they wait for human or PM direction.
+/// What: returns a per-role default prompt, or `None` when the role is excluded
+/// or unknown (an unknown role simply gets no injected prompt).
+/// Test: `initial_prompt_injected_by_role`, `initial_prompt_excluded_role` in
+/// agent_builder_tests.rs.
+fn default_initial_prompt(role: Option<&str>) -> Option<&'static str> {
+    match role {
+        Some("engineer") | Some("data-engineer") => {
+            Some("Begin implementation. Read the task context and start coding immediately.")
+        }
+        Some("qa") => {
+            Some("Begin verification. Read the task context and start testing immediately.")
+        }
+        Some("ops") | Some("version-control") => {
+            Some("Begin operations. Read the task context and execute immediately.")
+        }
+        Some("research") | Some("code-analyzer") => Some(
+            "Begin investigation. Analyze the task context, search for relevant files, \
+             and report findings.",
+        ),
+        Some("documentation") => {
+            Some("Begin documentation. Read the task context and start writing immediately.")
+        }
+        Some("security") => {
+            Some("Begin security analysis. Read the task context and start scanning immediately.")
+        }
+        // Interactive / special-purpose roles (base, ticketing, prompt-engineer,
+        // memory-manager, agent/skill managers) and unknown roles get none.
+        _ => None,
+    }
 }
 
 /// Split a source document into its frontmatter map and body.
@@ -202,6 +264,10 @@ fn split_frontmatter(raw: &str) -> Result<(Frontmatter, String), AgentBuildError
         description: fields.remove("description"),
         model: fields.remove("model"),
         extends: fields.remove("extends"),
+        // `parse_kv_line` lower-cases keys, so `initialPrompt` arrives as
+        // `initialprompt`; match that normalised form.
+        initial_prompt: fields.remove("initialprompt"),
+        resource_tier: fields.remove("resource_tier"),
     };
     Ok((fm, body))
 }
@@ -224,10 +290,17 @@ fn first_line_len(s: &str) -> usize {
 ///
 /// Why: the composed file needs exactly one frontmatter block; child fields
 /// must win over base fields so a concrete agent's `model`/`description`
-/// survive.
-/// What: folds the chain base-first, overlaying each file's set fields, and
-/// emits the populated keys in a stable order.
-/// Test: `compose_engineer_chain` asserts the merged `name`/`model`.
+/// survive. Deploy-time enrichments (HR-1) are applied here so every composed
+/// agent carries a tier-derived `model` default and a self-starting
+/// `initialPrompt` without editing each source file.
+/// What: folds the chain base-first, overlaying each file's set fields, then
+/// (a) fills `model` from `resource_tier` when no explicit `model` was set
+/// (explicit always wins), and (b) fills `initialPrompt` from the agent `role`
+/// when the source declared none and the role is not excluded. Emits the
+/// populated keys in a stable order.
+/// Test: `compose_engineer_chain` (merge), `tier_model_mapping`,
+/// `explicit_model_wins_over_tier`, `initial_prompt_injected_by_role`,
+/// `initial_prompt_explicit_wins` in agent_builder_tests.rs.
 fn merge_frontmatter(chain: &[Frontmatter]) -> String {
     let mut merged = Frontmatter::default();
     for fm in chain {
@@ -243,6 +316,26 @@ fn merge_frontmatter(chain: &[Frontmatter]) -> String {
         if fm.model.is_some() {
             merged.model = fm.model.clone();
         }
+        if fm.initial_prompt.is_some() {
+            merged.initial_prompt = fm.initial_prompt.clone();
+        }
+        if fm.resource_tier.is_some() {
+            merged.resource_tier = fm.resource_tier.clone();
+        }
+    }
+
+    // HR-1 Part C: derive `model` from `resource_tier` only when no explicit
+    // `model` survived the merge. Explicit model always wins.
+    if merged.model.is_none() && merged.resource_tier.is_some() {
+        merged.model = Some(tier_to_model(merged.resource_tier.as_deref()).to_string());
+    }
+
+    // HR-1 Part B: inject a role-derived `initialPrompt` when the source set
+    // none. A source-declared `initialPrompt` (now in `merged`) always wins.
+    if merged.initial_prompt.is_none()
+        && let Some(prompt) = default_initial_prompt(merged.role.as_deref())
+    {
+        merged.initial_prompt = Some(prompt.to_string());
     }
 
     let mut out = String::from("---\n");
@@ -257,6 +350,15 @@ fn merge_frontmatter(chain: &[Frontmatter]) -> String {
     }
     if let Some(v) = &merged.model {
         out.push_str(&format!("model: {v}\n"));
+    }
+    if let Some(v) = &merged.resource_tier {
+        out.push_str(&format!("resource_tier: {v}\n"));
+    }
+    if let Some(v) = &merged.initial_prompt {
+        // Quote the value: it contains spaces and punctuation, and downstream
+        // YAML parsers treat an unquoted `initialPrompt` sentence safely either
+        // way, but quoting keeps it a single scalar.
+        out.push_str(&format!("initialPrompt: \"{v}\"\n"));
     }
     out.push_str("---\n");
     out

--- a/crates/trusty-mpm/src/core/agent_builder_tests.rs
+++ b/crates/trusty-mpm/src/core/agent_builder_tests.rs
@@ -482,6 +482,95 @@ fn enrichment_survives_inheritance_chain() {
 }
 
 #[test]
+fn initial_prompt_with_embedded_quote_round_trips() {
+    // A source initialPrompt containing an embedded double-quote must emit
+    // valid, parseable frontmatter and survive a compose→re-compose cycle
+    // verbatim (the embedded quote is escaped on emit, decoded on re-parse).
+    let tmp = TempDir::new().unwrap();
+    let original = r#"Run the "fast path" then stop."#;
+    write_agent(
+        tmp.path(),
+        "quoted",
+        &format!("---\nname: quoted\nrole: engineer\ninitialPrompt: {original}\n---\n\n# Quoted\n"),
+    );
+
+    let composed = compose_agent("quoted", tmp.path()).unwrap();
+    // Emitted line must escape the inner quotes — never a bare `"` that would
+    // prematurely close the YAML scalar.
+    assert!(
+        composed.contains(r#"initialPrompt: "Run the \"fast path\" then stop.""#),
+        "embedded quote must be escaped in emitted frontmatter; got:\n{composed}"
+    );
+
+    // Round-trip: feed the composed file back through compose_agent. The
+    // emitted camelCase key re-parses, the escapes decode, and the prompt is
+    // recovered unchanged.
+    write_agent(tmp.path(), "quoted2", &composed);
+    let (fm, _) = split_frontmatter(&composed).expect("composed frontmatter must re-parse");
+    assert_eq!(
+        fm.initial_prompt.as_deref(),
+        Some(original),
+        "initialPrompt must survive the compose→re-parse cycle verbatim"
+    );
+
+    // And a full re-compose of the round-tripped file emits the same line.
+    let recomposed = compose_agent("quoted2", tmp.path()).unwrap();
+    assert!(
+        recomposed.contains(r#"initialPrompt: "Run the \"fast path\" then stop.""#),
+        "re-composed frontmatter must be stable; got:\n{recomposed}"
+    );
+}
+
+#[test]
+fn initial_prompt_with_backslash_round_trips() {
+    // A backslash in the prompt must be escaped (`\` → `\\`) on emit and
+    // decoded on re-parse so a path-like or regex-like prompt survives.
+    let tmp = TempDir::new().unwrap();
+    let original = r#"Use the C:\path and the \d+ pattern."#;
+    write_agent(
+        tmp.path(),
+        "slash",
+        &format!("---\nname: slash\nrole: engineer\ninitialPrompt: {original}\n---\n\n# Slash\n"),
+    );
+    let composed = compose_agent("slash", tmp.path()).unwrap();
+    let (fm, _) = split_frontmatter(&composed).expect("composed frontmatter must re-parse");
+    assert_eq!(
+        fm.initial_prompt.as_deref(),
+        Some(original),
+        "backslash-bearing initialPrompt must round-trip verbatim; got:\n{composed}"
+    );
+}
+
+#[test]
+fn initial_prompt_role_default_round_trips() {
+    // The role-derived default prompt (no source initialPrompt) must also be
+    // stable across a compose→re-compose cycle, confirming the in-lower /
+    // out-camel key convention round-trips.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "eng",
+        "---\nname: eng\nrole: engineer\n---\n\n# Eng\n",
+    );
+    let composed = compose_agent("eng", tmp.path()).unwrap();
+    let (fm, _) = split_frontmatter(&composed).expect("composed frontmatter must re-parse");
+    assert_eq!(
+        fm.initial_prompt.as_deref(),
+        Some("Begin implementation. Read the task context and start coding immediately."),
+        "role default initialPrompt must re-parse unchanged; got:\n{composed}"
+    );
+    // Re-composing the round-tripped file yields identical frontmatter for the
+    // initialPrompt line (camelCase key, escaped scalar).
+    write_agent(tmp.path(), "eng2", &composed);
+    let recomposed = compose_agent("eng2", tmp.path()).unwrap();
+    let first_line = "initialPrompt: \"Begin implementation.";
+    assert!(
+        composed.contains(first_line) && recomposed.contains(first_line),
+        "initialPrompt line must be stable across the cycle"
+    );
+}
+
+#[test]
 fn case_insensitive_resolve_via_map() {
     // Write `BASE-QA.md` (UPPERCASE stem, as shipped in the bundle) and a
     // concrete `qa.md` that extends it via the lowercase name `base-qa`.

--- a/crates/trusty-mpm/src/core/agent_builder_tests.rs
+++ b/crates/trusty-mpm/src/core/agent_builder_tests.rs
@@ -261,6 +261,226 @@ fn bedrock_model_id_round_trips() {
 // composition succeeds. On a case-SENSITIVE filesystem this would fail
 // with the old direct-path code but passes with the new map-based lookup.
 
+// ── HR-1 deploy-time enrichment tests (issue #1406) ──────────────────────────
+
+#[test]
+fn tier_model_mapping() {
+    // An agent declaring `resource_tier: intensive` with no explicit `model`
+    // must receive the tier-derived default (`opus`). Mirrors claude-mpm's
+    // RESOURCE_TIER_DEFAULTS.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "heavy",
+        "---\nname: heavy\nrole: engineer\nresource_tier: intensive\n---\n\n# Heavy\n",
+    );
+    let composed = compose_agent("heavy", tmp.path()).unwrap();
+    assert!(
+        composed.contains("model: opus"),
+        "intensive tier must map to opus; got:\n{composed}"
+    );
+    // The tier itself is preserved for downstream consumers.
+    assert!(composed.contains("resource_tier: intensive"));
+}
+
+#[test]
+fn tier_lightweight_maps_to_haiku() {
+    // `lightweight` → haiku.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "light",
+        "---\nname: light\nrole: ops\nresource_tier: lightweight\n---\n\n# Light\n",
+    );
+    let composed = compose_agent("light", tmp.path()).unwrap();
+    assert!(
+        composed.contains("model: haiku"),
+        "lightweight tier must map to haiku; got:\n{composed}"
+    );
+}
+
+#[test]
+fn tier_high_and_standard_map_to_sonnet() {
+    // Both `high` and `standard` map to sonnet.
+    let tmp = TempDir::new().unwrap();
+    for (name, tier) in [("hi", "high"), ("std", "standard")] {
+        write_agent(
+            tmp.path(),
+            name,
+            &format!("---\nname: {name}\nrole: engineer\nresource_tier: {tier}\n---\n\n# {name}\n"),
+        );
+        let composed = compose_agent(name, tmp.path()).unwrap();
+        assert!(
+            composed.contains("model: sonnet"),
+            "{tier} tier must map to sonnet; got:\n{composed}"
+        );
+    }
+}
+
+#[test]
+fn tier_unknown_falls_back_to_sonnet() {
+    // An unrecognised tier falls back to the standard default (sonnet), per the
+    // HR-1 error contract.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "weird",
+        "---\nname: weird\nrole: engineer\nresource_tier: galaxy-brain\n---\n\n# Weird\n",
+    );
+    let composed = compose_agent("weird", tmp.path()).unwrap();
+    assert!(
+        composed.contains("model: sonnet"),
+        "unknown tier must fall back to sonnet; got:\n{composed}"
+    );
+}
+
+#[test]
+fn explicit_model_wins_over_tier() {
+    // An explicit `model` must override the tier-derived default — explicit
+    // always wins, even when the tier would map to something else.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "pinned",
+        "---\nname: pinned\nrole: engineer\nresource_tier: intensive\nmodel: haiku\n---\n\n# Pinned\n",
+    );
+    let composed = compose_agent("pinned", tmp.path()).unwrap();
+    assert!(
+        composed.contains("model: haiku"),
+        "explicit model must win over tier-derived opus; got:\n{composed}"
+    );
+    assert!(
+        !composed.contains("model: opus"),
+        "tier-derived model must not appear when explicit model is set"
+    );
+}
+
+#[test]
+fn no_tier_no_model_emits_no_model() {
+    // With neither tier nor explicit model, no `model:` line is synthesised —
+    // the enrichment only fires when a tier is present.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "bare",
+        "---\nname: bare\nrole: base\n---\n\n# Bare\n",
+    );
+    let composed = compose_agent("bare", tmp.path()).unwrap();
+    assert!(
+        !composed.contains("model:"),
+        "no model should be emitted without tier or explicit model; got:\n{composed}"
+    );
+}
+
+#[test]
+fn initial_prompt_injected_by_role() {
+    // An engineer-role agent that declares no initialPrompt must receive the
+    // engineer default at compose time.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "eng",
+        "---\nname: eng\nrole: engineer\nmodel: sonnet\n---\n\n# Eng\n",
+    );
+    let composed = compose_agent("eng", tmp.path()).unwrap();
+    assert!(
+        composed.contains(r#"initialPrompt: "Begin implementation."#),
+        "engineer role must get the implementation initialPrompt; got:\n{composed}"
+    );
+}
+
+#[test]
+fn initial_prompt_role_qa_and_ops() {
+    // qa and ops roles get their type-specific prompts.
+    let tmp = TempDir::new().unwrap();
+    write_agent(tmp.path(), "q", "---\nname: q\nrole: qa\n---\n\n# Q\n");
+    write_agent(tmp.path(), "o", "---\nname: o\nrole: ops\n---\n\n# O\n");
+    let q = compose_agent("q", tmp.path()).unwrap();
+    let o = compose_agent("o", tmp.path()).unwrap();
+    assert!(
+        q.contains(r#"initialPrompt: "Begin verification."#),
+        "qa prompt:\n{q}"
+    );
+    assert!(
+        o.contains(r#"initialPrompt: "Begin operations."#),
+        "ops prompt:\n{o}"
+    );
+}
+
+#[test]
+fn initial_prompt_excluded_role() {
+    // Special-purpose / interactive roles (e.g. `base`, `ticketing`) must NOT
+    // get an injected initialPrompt — they wait for direction.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "mgr",
+        "---\nname: mgr\nrole: base\nmodel: sonnet\n---\n\n# Mgr\n",
+    );
+    let composed = compose_agent("mgr", tmp.path()).unwrap();
+    assert!(
+        !composed.contains("initialPrompt:"),
+        "excluded role must not get an initialPrompt; got:\n{composed}"
+    );
+}
+
+#[test]
+fn initial_prompt_explicit_wins() {
+    // A source-declared initialPrompt must survive verbatim and override the
+    // role-derived default.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "custom",
+        "---\nname: custom\nrole: engineer\ninitialPrompt: Do the special thing first.\n---\n\n# Custom\n",
+    );
+    let composed = compose_agent("custom", tmp.path()).unwrap();
+    assert!(
+        composed.contains(r#"initialPrompt: "Do the special thing first.""#),
+        "explicit initialPrompt must win; got:\n{composed}"
+    );
+    assert!(
+        !composed.contains("Begin implementation."),
+        "role default must not appear when an explicit prompt is set"
+    );
+}
+
+#[test]
+fn enrichment_survives_inheritance_chain() {
+    // tier and role come from the child; the enrichment must apply to the fully
+    // composed chain, and base content must still be present.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "base-agent",
+        "---\nname: base-agent\nrole: base\n---\n\n# Base\n\nBASE GUARANTEE\n",
+    );
+    write_agent(
+        tmp.path(),
+        "base-engineer",
+        "---\nname: base-engineer\nrole: base-engineer\nextends: base-agent\n---\n\n# Base Eng\n\nENG GUARANTEE\n",
+    );
+    write_agent(
+        tmp.path(),
+        "leaf",
+        "---\nname: leaf\nrole: engineer\nextends: base-engineer\nresource_tier: intensive\n---\n\n# Leaf\n\nLEAF GUARANTEE\n",
+    );
+    let composed = compose_agent("leaf", tmp.path()).unwrap();
+    // Enrichments applied from the merged (child-wins) frontmatter.
+    assert!(
+        composed.contains("model: opus"),
+        "tier→model on chain:\n{composed}"
+    );
+    assert!(
+        composed.contains(r#"initialPrompt: "Begin implementation."#),
+        "role-derived prompt on chain:\n{composed}"
+    );
+    // Inherited base content still present.
+    assert!(composed.contains("BASE GUARANTEE"));
+    assert!(composed.contains("ENG GUARANTEE"));
+    assert!(composed.contains("LEAF GUARANTEE"));
+}
+
 #[test]
 fn case_insensitive_resolve_via_map() {
     // Write `BASE-QA.md` (UPPERCASE stem, as shipped in the bundle) and a

--- a/crates/trusty-mpm/src/core/agent_deployer.rs
+++ b/crates/trusty-mpm/src/core/agent_deployer.rs
@@ -326,6 +326,67 @@ mod tests {
     }
 
     #[test]
+    fn deploy_injects_initial_prompt_and_tier_model() {
+        // A deployed agent that declares a `resource_tier` but no `model`, and
+        // an engineer `role` but no `initialPrompt`, must land on disk with both
+        // deploy-time enrichments applied (HR-1).
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        fs::write(
+            src.path().join("base-engineer.md"),
+            "---\nname: base-engineer\nrole: base-engineer\n---\n\n# Base Eng\n\nBASE ENG CONTENT\n",
+        )
+        .unwrap();
+        fs::write(
+            src.path().join("heavy-eng.md"),
+            "---\nname: heavy-eng\nrole: engineer\nextends: base-engineer\nresource_tier: intensive\n---\n\n# Heavy\n\nLEAF CONTENT\n",
+        )
+        .unwrap();
+
+        deploy_agents(src.path(), tgt.path()).unwrap();
+
+        let deployed = fs::read_to_string(tgt.path().join("heavy-eng.md")).unwrap();
+        assert!(
+            deployed.contains("model: opus"),
+            "intensive tier must inject opus on deploy; got:\n{deployed}"
+        );
+        assert!(
+            deployed.contains(r#"initialPrompt: "Begin implementation."#),
+            "engineer role must inject implementation initialPrompt on deploy; got:\n{deployed}"
+        );
+        // Inherited base content survives composition + deploy.
+        assert!(deployed.contains("BASE ENG CONTENT"));
+        assert!(deployed.contains("LEAF CONTENT"));
+    }
+
+    #[test]
+    fn deploy_preserves_explicit_model_and_prompt() {
+        // Explicit `model` and explicit `initialPrompt` in the source must
+        // survive deploy unchanged (explicit always wins over enrichment).
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        fs::write(
+            src.path().join("pinned.md"),
+            "---\nname: pinned\nrole: engineer\nresource_tier: intensive\nmodel: haiku\ninitialPrompt: Custom start.\n---\n\n# Pinned\n",
+        )
+        .unwrap();
+
+        deploy_agents(src.path(), tgt.path()).unwrap();
+
+        let deployed = fs::read_to_string(tgt.path().join("pinned.md")).unwrap();
+        assert!(
+            deployed.contains("model: haiku"),
+            "explicit model wins:\n{deployed}"
+        );
+        assert!(!deployed.contains("model: opus"));
+        assert!(
+            deployed.contains(r#"initialPrompt: "Custom start.""#),
+            "explicit prompt wins:\n{deployed}"
+        );
+        assert!(!deployed.contains("Begin implementation."));
+    }
+
+    #[test]
     fn deploy_content_file_is_atomic() {
         // After a successful deploy no stale .tmp file should remain in the
         // target directory — the atomic rename must have completed.

--- a/crates/trusty-mpm/src/core/frontmatter.rs
+++ b/crates/trusty-mpm/src/core/frontmatter.rs
@@ -20,10 +20,18 @@
 /// model ids — so splitting on the first colon and preserving the rest is the
 /// only correct interpretation.
 /// What: splits `line` on the first `':'`, lower-cases and trims the key, trims
-/// the value and strips one layer of surrounding `"` or `'` quotes. Returns
-/// `None` when the line is blank, a comment (`#`), a fence (`---`), or has no
-/// colon at all.
+/// the value and strips a single balanced layer of surrounding `"` or `'`
+/// quotes. Returns `None` when the line is blank, a comment (`#`), a fence
+/// (`---`), or has no colon at all.
 /// Test: `frontmatter::tests::parse_kv_*` in this file.
+///
+/// Quote handling: only ONE balanced outer pair is removed (a leading and
+/// matching trailing quote of the same kind). A greedy strip of every outer
+/// quote would corrupt values whose escaped content ends in a quote — e.g.
+/// an emitted YAML scalar `"He said \"hi\""` — by also eating the inner
+/// `\"`. Stripping exactly one pair leaves the inner escapes intact so a
+/// caller (see `agent_builder::split_frontmatter`) can unescape them and
+/// recover the original string verbatim.
 pub fn parse_kv_line(line: &str) -> Option<(String, String)> {
     let trimmed = line.trim();
 
@@ -42,12 +50,31 @@ pub fn parse_kv_line(line: &str) -> Option<(String, String)> {
         return None;
     }
 
-    let value = raw_value
-        .trim()
-        .trim_matches(|c| c == '"' || c == '\'')
-        .to_string();
+    let value = strip_one_quote_pair(raw_value.trim()).to_string();
 
     Some((key, value))
+}
+
+/// Strip at most one balanced pair of surrounding `"` or `'` quotes.
+///
+/// Why: emitted YAML double-quoted scalars escape inner quotes as `\"`; a
+/// greedy quote-trim would consume those inner quotes when they sit adjacent
+/// to the closing fence (e.g. `"...\""`). Removing exactly one matching outer
+/// pair preserves the escaped body for downstream unescaping.
+/// What: returns the slice between a matching leading/trailing quote of the
+/// same kind, or the input unchanged when it is not wrapped in a balanced pair.
+/// Test: `parse_kv_strips_double_quotes`, `parse_kv_strips_single_quotes`,
+/// `parse_kv_keeps_inner_escaped_quotes` in this file.
+fn strip_one_quote_pair(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
 }
 
 #[cfg(test)]
@@ -121,6 +148,16 @@ mod tests {
         let (k, v) = parse_kv_line("description: 'Implements features.'").unwrap();
         assert_eq!(k, "description");
         assert_eq!(v, "Implements features.");
+    }
+
+    #[test]
+    fn parse_kv_keeps_inner_escaped_quotes() {
+        // Only ONE balanced outer pair is stripped; inner escaped quotes
+        // (`\"`) from an emitted YAML scalar must survive for the caller to
+        // unescape. A greedy trim would have eaten the trailing `\"`.
+        let (k, v) = parse_kv_line(r#"initialprompt: "He said \"hi\"""#).unwrap();
+        assert_eq!(k, "initialprompt");
+        assert_eq!(v, r#"He said \"hi\""#);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1406

Implements **HR-1** (BASE_AGENT/BASE_ENGINEER content parity + deploy-time injections) from the harness-runner vision spec (DOC-17). Part of **Epic #1045**.

## Scope (three parts)

### Part A — BASE content parity (pure content)
Ported the substantive content from claude-mpm's `BASE_AGENT.md` and `BASE_ENGINEER.md` into t-mpm's lean base assets under `crates/trusty-mpm/src/assets/agents/`, adapted to be provider/language-neutral (Rust examples, no Python/branding) and de-duplicated against the child layers the composer concatenates.

- **BASE-AGENT.md** — git workflow, memory routing, handoff protocol, self-action imperative, verification-before-completion, empty-output protocol, output format.
- **BASE-ENGINEER.md** — code quality, right-level engineering, provided-artifacts protocol, code contracts, ship-working-code (no post-success refactoring), dependency verification, no-mock/no-silent-fallback, duplicate elimination, debugging protocol, performance-first, test-generation strategy, deliverables checklist.
- **BASE-QA / BASE-OPS / BASE-RESEARCH** — lightly enriched with role-specific discipline (test quality, ops safety/credential handling, root-cause investigation) that complements rather than restates the inherited BASE-AGENT content.

All `extends:` frontmatter preserved; markdown assets so the 500-SLOC cap does not apply.

### Part B — `initialPrompt` injection at deploy
`compose_agent` derives a self-starting `initialPrompt` from the agent **`role`** when the source declares none. Mechanism mirrors claude-mpm's `INITIAL_PROMPT_BY_TYPE`:
- engineer/data-engineer → "Begin implementation…", qa → "Begin verification…", ops/version-control → "Begin operations…", research/code-analyzer → "Begin investigation…", documentation → "Begin documentation…", security → "Begin security analysis…".
- A source-declared `initialPrompt:` **always wins** (child-wins merge).
- Interactive/special roles (`base`, `ticketing`, etc.) are **excluded** — they wait for direction.
- Emitted as a quoted scalar into the merged frontmatter.

### Part C — `resource_tier` → model defaults
`compose_agent` maps a frontmatter `resource_tier` to `model:` only when no explicit model is set (**explicit always wins**). Mapping mirrors claude-mpm's `RESOURCE_TIER_DEFAULTS`: `intensive→opus`, `high/standard→sonnet`, `lightweight→haiku`; missing/unknown tier falls back to `sonnet` (the HR-1 error contract).

## Mechanism / design
Both enrichments live in `merge_frontmatter` — the single composition path that `deploy_agents` already uses — so every composed/deployed agent in `~/.claude/agents/` carries them transparently. The `Frontmatter` struct gained `initial_prompt` and `resource_tier` fields; manifest checksums and `source_chain` reporting are unaffected. Implemented inside `compose_agent` (not a separate deploy pass) because that is the one place the merged child-wins frontmatter is materialized.

## Tests
- 11 new compose-level unit tests in `agent_builder_tests.rs`: tier→model (intensive/lightweight/high/standard/unknown-fallback), explicit-model-wins, no-tier-no-model, initialPrompt by-role (engineer/qa/ops), excluded-role, explicit-prompt-wins, and enrichment-survives-inheritance-chain (base content still present).
- 2 new deploy-level tests in `agent_deployer.rs`: enrichments land on the written file with inherited base content; explicit model+prompt preserved through deploy.

## Verification (from worktree, OPENROUTER_API_KEY unset)
- `cargo build -p trusty-mpm` — clean
- `cargo test -p trusty-mpm` — 1351 + 355 lib/integration pass, 0 failed
- `cargo test --workspace` — green except one pre-existing **unrelated** `tga` env-var flake (`bitbucket::client::tests::app_password_falls_back_to_env_when_config_absent`) that passes in isolation
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations (agent_builder.rs at 299 SLOC)

## Composed-agent sample (`compose_agent("engineer", …)`)
Frontmatter now carries the injected prompt (explicit `model: sonnet` preserved):
```
name: engineer
role: engineer
model: sonnet
initialPrompt: "Begin implementation. Read the task context and start coding immediately."
```
Section headers prove all three layers compose base-first: `# BASE-AGENT …` → `# BASE-ENGINEER …` → `# Engineer`.

## Intentionally omitted (non-applicable claude-mpm content)
- Python-specific contract tooling (`icontract`, `assert -O`), TS/JS guard-fn snippets, and the per-language pre-return matrix beyond Rust.
- `effort` field from `RESOURCE_TIER_DEFAULTS` (HR-1 only specifies tier→model).
- Ontology tagging, SLD/`wwl-granularity` references, and claude-mpm `TodoWrite`/dashboard specifics.
- claude-mpm's name-keyed initialPrompt table (t-mpm uses the `role` discriminator; per-agent override via the source `initialPrompt:` field covers the name-specific case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)