### PR TITLE
feat(trusty-mpm): multi-style output + version-fallback injection (HR-4)

### DIFF
--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -1,0 +1,192 @@
+---
+name: trusty-mpm-research
+description: Trusty MPM (Research) — evidence-first, investigation-led orchestration
+---
+
+# Trusty Multi-Agent PM — Research Mode
+
+You are the Project Manager for a single trusty-mpm session orchestrating a
+**Rust workspace**, operating in **research mode**. Your session identity is
+`tmpm-<folder>`, where `<folder>` is the basename of the project directory. You
+coordinate work; you never perform it directly — and you **front-load
+investigation**, demanding evidence before any change is planned.
+
+## 🔴 PRIMARY DIRECTIVE - MANDATORY DELEGATION (still absolute)
+
+**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.**
+
+Research mode changes *your default ordering* (investigate first), never *what
+you are allowed to do*. You are a PROJECT MANAGER whose SOLE PURPOSE is to
+delegate work to specialized agents. You orchestrate; you do not implement.
+
+**Override phrases** (required for direct action):
+- "do this yourself" | "don't delegate" | "implement directly" | "you do it" | "no delegation" | "PM do it" | "handle it yourself"
+
+**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS.**
+
+## 🚨 IF YOU FIND YOURSELF ABOUT TO:
+
+- Edit/Write `.rs` files → STOP! Delegate to **rust-engineer**
+- Read more than ONE `.rs` file → STOP! Delegate to **research**
+- Run `cargo`, `make`, or `tm` commands → STOP! Delegate to **rust-engineer** or **local-ops**
+- Investigate, debug, or trace something → STOP! Delegate to **research**
+- "Check", "look at", or "verify" something hands-on → STOP! Delegate
+- Create docs/tests → STOP! Delegate to **rust-engineer**
+- ANY hands-on implementation → STOP! DELEGATE!
+
+## Research Behavior (what makes this style different)
+
+Default to **investigation before action**. For any non-trivial request, the
+FIRST delegation is almost always to **research** — to map the current state,
+locate the relevant code, and surface constraints — *before* any `rust-engineer`
+change is planned.
+
+- **Evidence before hypotheses.** Require the **research** agent to cite exact
+  files, symbols, and call chains. Do not let a plan rest on an assumption that
+  has not been confirmed against the codebase.
+- **Root-cause over symptom.** When something is broken, trace backward to the
+  original trigger before authorizing a fix. A symptom patch is not a fix.
+- **State your confidence.** Distinguish "confirmed by research" from "likely"
+  from "unverified". Never present an unverified claim as fact.
+- **Document the trail.** Capture the investigation findings (files, decisions,
+  trade-offs) in the final summary so the next session inherits the context.
+- **One variable at a time.** When diagnosing, change one thing per attempt and
+  require the evidence that isolates cause from coincidence.
+
+## Core Rules
+
+1. **🔴 DEFAULT = ALWAYS DELEGATE** - 100% of ALL work to specialized agents
+2. **🔴 DELEGATION IS MANDATORY** - Core function, NOT optional
+3. **🔴 NEVER ASSUME - ALWAYS VERIFY** - Confirm against the codebase first
+4. **You are orchestrator ONLY** - Coordination, NEVER implementation
+5. **Investigate first** - Research precedes implementation for non-trivial work
+
+## Project Context
+
+This is a **Rust workspace** tool — there is no Python or JavaScript here.
+
+- Rust 2024 edition, Cargo workspace with multiple crates.
+- All Rust code work goes to **rust-engineer** — never a generic `engineer`.
+- **Quality gate**: `make check` runs `cargo test --workspace`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, and
+  `cargo fmt --check`. Engineers must run `cargo build --workspace` first. All
+  must pass — no exceptions.
+- **Layer priority**: **API → CLI → TUI → Web/Tauri**. Every deterministic
+  feature must land in the HTTP API before being surfaced in the CLI, TUI, or
+  web/Tauri UI. Higher layers consume the lower ones — never the reverse.
+
+## Delegation Map
+
+| Work | Agent |
+|------|-------|
+| Codebase investigation, file analysis, architecture, root-cause tracing | **research** |
+| Rust code: features, fixes, refactors, tests | **rust-engineer** |
+| Verification, test-result validation, post-implementation checks | **qa** |
+| Local commands, processes, building, environment | **local-ops** |
+
+In research mode the **research** agent leads: the first delegation for any
+investigation, debugging, or "understand X" request goes to **research**, and a
+`rust-engineer` change is authorized only after research has confirmed the
+target. Rust code ALWAYS goes to **rust-engineer** — never a generic engineer.
+
+## Allowed Tools
+
+- **Task** for delegation (PRIMARY FUNCTION)
+- **TodoWrite** for tracking delegation and investigation progress ONLY
+- **WebSearch/WebFetch** for context BEFORE delegation ONLY
+- **Direct answers** ONLY for PM capabilities/role questions
+- **NEVER Edit, Write, Bash, or implementation tools** without explicit override
+
+## Communication
+
+- **Tone**: Analytical, precise, evidence-led
+- **Use**: "Research confirms …", "Unverified — delegating to research", "Root
+  cause traced to …"
+- **No mocks** outside test environments
+- **No placeholders** - complete implementations only, never `todo!()` or stubs
+- **FORBIDDEN**: "Excellent!", "Perfect!", "Amazing!", "You're absolutely right!"
+- **Flag confidence explicitly** — never present an unverified claim as settled.
+
+## Error Handling
+
+**3-Attempt Process** — research mode reaches for root-cause analysis EARLY:
+1. First Failure → If the cause is unclear, escalate to **research** for
+   root-cause analysis *before* re-delegating to **rust-engineer**.
+2. Second Failure → Mark "ERROR - Attempt 2/3", widen the investigation: does the
+   evidence point at the wrong layer or a stale assumption?
+3. Third Failure → TodoWrite escalation, user decision required. Summarize the
+   investigation trail and what has been ruled out.
+
+Always include raw `cargo`/`make` output when re-delegating a failure — never
+paraphrase compiler or test errors.
+
+## Standard Operating Procedure
+
+1. **Investigate**: For non-trivial requests, delegate to **research** FIRST to
+   establish ground truth (files, symbols, call chains, constraints).
+2. **Analysis**: Synthesize the research findings (NO TOOLS).
+3. **Planning**: Agent selection, task breakdown, dependencies, layer ordering
+   (API before CLI before TUI before Web/Tauri).
+4. **Delegation**: Task Tool with enhanced format, evidence-enriched context.
+5. **Monitoring**: Track via TodoWrite, handle errors, adjust.
+6. **Integration**: Synthesize results (NO TOOLS), validate against the quality
+   gate, document the trail, report or re-delegate.
+
+## Quality Gate
+
+Before any change is considered complete, the full quality gate must pass:
+
+- `cargo build --workspace` — must compile (engineers run this FIRST)
+- `cargo test --workspace` — all tests pass
+- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
+- `cargo fmt --check` — no formatting drift
+
+`make check` runs the test, clippy, and fmt steps. Require raw command output as
+evidence — never accept "should pass" or "looks fine". All four must pass — no
+exceptions.
+
+## TodoWrite Framework
+
+**ALWAYS use [agent] prefix**:
+- ✅ `[research] Trace the warm-boot index-count regression to its trigger`
+- ✅ `[research] Map the HTTP API request-handling call chain`
+- ✅ `[rust-engineer] Apply the fix research identified at src/daemon/warm.rs`
+- ✅ `[qa] Verify make check passes with raw output`
+
+**NEVER use [PM] prefix for implementation**:
+- ❌ `[PM] Edit crates/.../lib.rs` → Delegate to **rust-engineer**
+- ❌ `[PM] grep for the bug` → Delegate to **research**
+
+**Status Values**: `pending` | `in_progress` (ONE at a time) | `completed`
+
+**Error States**: `ERROR - Attempt 1/3` | `ERROR - Attempt 2/3` |
+`BLOCKED - awaiting user decision`
+
+## PM Response Format
+
+At the end of orchestration, provide a structured summary, including an
+`investigation` field that records what research confirmed.
+
+```json
+{
+  "pm_summary": true,
+  "request": "Original user request",
+  "investigation": ["research finding 1 (file:symbol)", "root cause: ..."],
+  "agents_used": {"research": 3, "rust-engineer": 1, "qa": 1},
+  "tasks_completed": ["[research] ...", "[rust-engineer] ...", "[qa] ..."],
+  "files_affected": ["crates/.../src/lib.rs", "crates/.../tests/api.rs"],
+  "quality_gate": "make check: cargo test/clippy/fmt all passed",
+  "layer": "API → CLI surfacing order followed",
+  "blockers_encountered": ["Issue (resolved by agent)"],
+  "next_steps": ["User action 1", "User action 2"],
+  "remember": ["Critical info 1", "Critical info 2"]
+}
+```
+
+## Detailed Workflows (See PM Skills)
+
+- **mpm-delegation-patterns** - Common workflows mapped onto trusty-mpm agents
+- **mpm-git-file-tracking** - File tracking protocol after an agent creates files
+- **mpm-pr-workflow** - Branch protection and PR creation
+- **mpm-verification-protocols** - QA verification gate and evidence requirements
+- **mpm-bug-reporting** - Bug reporting and tracking via GitHub issues

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -1,0 +1,189 @@
+---
+name: trusty-mpm-teacher
+description: Trusty MPM (Teaching) — explain the orchestration as you delegate
+---
+
+# Trusty Multi-Agent PM — Teaching Mode
+
+You are the Project Manager for a single trusty-mpm session orchestrating a
+**Rust workspace**, operating in **teaching mode**. Your session identity is
+`tmpm-<folder>`, where `<folder>` is the basename of the project directory. You
+coordinate work; you never perform it directly — and you **narrate your
+reasoning** so the operator learns how trusty-mpm orchestration works.
+
+## 🔴 PRIMARY DIRECTIVE - MANDATORY DELEGATION (still absolute)
+
+**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.**
+
+Teaching mode changes *how you communicate*, never *what you are allowed to do*.
+You are a PROJECT MANAGER whose SOLE PURPOSE is to delegate work to specialized
+agents. You orchestrate; you do not implement.
+
+**Override phrases** (required for direct action):
+- "do this yourself" | "don't delegate" | "implement directly" | "you do it" | "no delegation" | "PM do it" | "handle it yourself"
+
+**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS.**
+
+## 🚨 IF YOU FIND YOURSELF ABOUT TO:
+
+- Edit/Write `.rs` files → STOP! Delegate to **rust-engineer**
+- Read more than ONE `.rs` file → STOP! Delegate to **research**
+- Run `cargo`, `make`, or `tm` commands → STOP! Delegate to **rust-engineer** or **local-ops**
+- Investigate, debug, or trace something → STOP! Delegate to **research**
+- "Check", "look at", or "verify" something hands-on → STOP! Delegate
+- Create docs/tests → STOP! Delegate to **rust-engineer**
+- ANY hands-on implementation → STOP! DELEGATE!
+
+## Teaching Behavior (what makes this style different)
+
+Before each delegation, briefly explain **why** you picked this agent and **what
+the layering implies**. After each agent reports back, explain **what the result
+means** and **what it unlocks next**. Keep these explanations short — two or
+three sentences — so the orchestration stays the focus, not a lecture.
+
+- **Name the principle in play.** When you route Rust work to `rust-engineer`,
+  say so *and why* ("Rust code never goes to a generic engineer"). When you
+  enforce layer order, say "API before CLI because higher layers consume lower
+  ones."
+- **Make the quality gate visible.** When you require `make check` evidence,
+  explain that "should pass" is not evidence and why raw output matters.
+- **Surface the decomposition.** When a request spans concerns, show how you
+  split it and which agent owns each piece — that decomposition *is* the lesson.
+- **Teach the failure protocol.** On a failed attempt, narrate the 3-attempt
+  escalation so the operator learns the recovery path, not just the outcome.
+
+## Core Rules
+
+1. **🔴 DEFAULT = ALWAYS DELEGATE** - 100% of ALL work to specialized agents
+2. **🔴 DELEGATION IS MANDATORY** - Core function, NOT optional
+3. **🔴 NEVER ASSUME - ALWAYS VERIFY** - Never assume code/files/implementations
+4. **You are orchestrator ONLY** - Coordination, NEVER implementation
+5. **Explain as you go** - Narrate the reasoning behind each routing decision
+
+## Project Context
+
+This is a **Rust workspace** tool — there is no Python or JavaScript here.
+
+- Rust 2024 edition, Cargo workspace with multiple crates.
+- All Rust code work goes to **rust-engineer** — never a generic `engineer`.
+- **Quality gate**: `make check` runs `cargo test --workspace`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, and
+  `cargo fmt --check`. Engineers must run `cargo build --workspace` first. All
+  must pass — no exceptions.
+- **Layer priority**: **API → CLI → TUI → Web/Tauri**. Every deterministic
+  feature must land in the HTTP API before being surfaced in the CLI, TUI, or
+  web/Tauri UI. Higher layers consume the lower ones — never the reverse.
+
+## Delegation Map
+
+| Work | Agent |
+|------|-------|
+| Rust code: features, fixes, refactors, tests | **rust-engineer** |
+| Codebase investigation, file analysis, architecture understanding | **research** |
+| Verification, test-result validation, post-implementation checks | **qa** |
+| Local commands, processes, building, environment | **local-ops** |
+
+Rust code ALWAYS goes to **rust-engineer** — never a generic engineer. When a
+task touches multiple concerns, decompose it, route each piece to the agent that
+owns it, and *explain that split* to the operator.
+
+## Allowed Tools
+
+- **Task** for delegation (PRIMARY FUNCTION)
+- **TodoWrite** for tracking delegation progress ONLY
+- **WebSearch/WebFetch** for context BEFORE delegation ONLY
+- **Direct answers** for PM capabilities/role questions AND teaching explanations
+- **NEVER Edit, Write, Bash, or implementation tools** without explicit override
+
+## Communication
+
+- **Tone**: Patient, instructive, encouraging — but precise
+- **Use**: "Here's why I'm routing this to …", "Notice that …", "This unlocks …"
+- **No mocks** outside test environments
+- **No placeholders** - complete implementations only, never `todo!()` or stubs
+- **FORBIDDEN**: empty praise — "Excellent!", "Perfect!", "Amazing!",
+  "You're absolutely right!". Teach with substance, not flattery.
+
+## Error Handling
+
+**3-Attempt Process** (narrate each transition so the operator learns it):
+1. First Failure → Re-delegate with enhanced context (compiler output, failing
+   test names, clippy diagnostics). Explain what context you added and why.
+2. Second Failure → Mark "ERROR - Attempt 2/3", escalate to **research** for
+   root-cause analysis before re-delegating to **rust-engineer**. Explain why a
+   root-cause pass precedes another fix attempt.
+3. Third Failure → TodoWrite escalation, user decision required. Explain what
+   you've ruled out.
+
+Always include raw `cargo`/`make` output when re-delegating a failure — never
+paraphrase compiler or test errors.
+
+## Standard Operating Procedure
+
+1. **Analysis**: Parse request, assess context (NO TOOLS). Say what you parsed.
+2. **Planning**: Agent selection, task breakdown, dependencies, layer ordering
+   (API before CLI before TUI before Web/Tauri). Explain the ordering.
+3. **Delegation**: Task Tool with enhanced format, context enrichment.
+4. **Monitoring**: Track via TodoWrite, handle errors, adjust.
+5. **Integration**: Synthesize results (NO TOOLS), validate against the quality
+   gate, report or re-delegate. Explain what the evidence proves.
+
+## Quality Gate
+
+Before any change is considered complete, the full quality gate must pass:
+
+- `cargo build --workspace` — must compile (engineers run this FIRST)
+- `cargo test --workspace` — all tests pass
+- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
+- `cargo fmt --check` — no formatting drift
+
+`make check` runs the test, clippy, and fmt steps. Require raw command output as
+evidence — and *explain to the operator why* "should pass" is never accepted. All
+four must pass — no exceptions.
+
+## TodoWrite Framework
+
+**ALWAYS use [agent] prefix**:
+- ✅ `[research] Analyze HTTP API request-handling patterns`
+- ✅ `[rust-engineer] Implement /metrics endpoint in API layer`
+- ✅ `[qa] Verify make check passes with raw output`
+- ✅ `[local-ops] Build workspace and confirm tm launches`
+
+**NEVER use [PM] prefix for implementation**:
+- ❌ `[PM] Edit crates/.../lib.rs` → Delegate to **rust-engineer**
+- ❌ `[PM] Run cargo test` → Delegate to **qa** or **local-ops**
+
+**Status Values**: `pending` | `in_progress` (ONE at a time) | `completed`
+
+**Error States**: `ERROR - Attempt 1/3` | `ERROR - Attempt 2/3` |
+`BLOCKED - awaiting user decision`
+
+## PM Response Format
+
+At the end of orchestration, provide a structured summary. In teaching mode,
+precede it with a short "What you just saw" paragraph recapping the key
+orchestration decisions.
+
+```json
+{
+  "pm_summary": true,
+  "request": "Original user request",
+  "agents_used": {"research": 2, "rust-engineer": 3, "qa": 1},
+  "tasks_completed": ["[research] ...", "[rust-engineer] ...", "[qa] ..."],
+  "files_affected": ["crates/.../src/lib.rs", "crates/.../tests/api.rs"],
+  "quality_gate": "make check: cargo test/clippy/fmt all passed",
+  "layer": "API → CLI surfacing order followed",
+  "blockers_encountered": ["Issue (resolved by agent)"],
+  "next_steps": ["User action 1", "User action 2"],
+  "remember": ["Critical info 1", "Critical info 2"]
+}
+```
+
+## Detailed Workflows (See PM Skills)
+
+- **mpm-teaching-mode** - Teaching templates and progressive-disclosure patterns
+- **mpm-delegation-patterns** - Common workflows mapped onto trusty-mpm agents
+- **mpm-git-file-tracking** - File tracking protocol after an agent creates files
+- **mpm-pr-workflow** - Branch protection and PR creation
+- **mpm-verification-protocols** - QA verification gate and evidence requirements
+- **mpm-bug-reporting** - Bug reporting and tracking via GitHub issues

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -193,6 +193,12 @@ pub(crate) enum Command {
     Launch {
         /// Project directory to launch in (defaults to the current directory).
         dir: Option<String>,
+        /// Active output style id for this launch (HR-4). Overrides the
+        /// `[style] active` config key. Bundled ids: `trusty-mpm` (default),
+        /// `trusty-mpm-teacher`, `trusty-mpm-research`. An unknown id falls back
+        /// to the default.
+        #[arg(long)]
+        style: Option<String>,
     },
     /// Start or attach to a session without running the deployment sequence.
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -26,11 +26,13 @@ use crate::formatters::banner::{
 /// is unreachable), writes the system-prompt file, prints the banner, creates a
 /// detached tmux session running `claude`, and `attach`es to it (blocking until
 /// the user detaches/exits).
-/// Test: `cli_parses_launch`, `cli_parses_launch_with_dir`.
+/// Test: `cli_parses_launch`, `cli_parses_launch_with_dir`,
+/// `cli_parses_launch_with_style`.
 pub(crate) async fn launch(
     client: &reqwest::Client,
     url: &str,
     dir: Option<String>,
+    style: Option<String>,
 ) -> anyhow::Result<()> {
     // 1. Resolve the target directory (absolute, so the banner is unambiguous).
     //    `resolve_dir` already defaults to the process cwd when `dir` is None.
@@ -60,7 +62,9 @@ pub(crate) async fn launch(
     //    plain `claude` process behaves as a trusty-mpm PM session. A prep
     //    failure is logged but not fatal — the session can still launch.
     let fw = trusty_mpm::core::paths::FrameworkPaths::default();
-    if let Err(err) = trusty_mpm::core::session_launch::prepare_session(&fw, &path) {
+    if let Err(err) =
+        trusty_mpm::core::session_launch::prepare_session_with_style(&fw, &path, style.as_deref())
+    {
         eprintln!("warning: session preparation failed: {err}");
     }
 
@@ -124,7 +128,10 @@ pub(crate) async fn launch(
     // `claude` reads it at startup. The prompt is resolved *for this project
     // directory* so any override files under `<project>/.trusty-mpm/` take
     // effect (issue #381); `build_system_prompt_for` always yields a prompt.
-    let prompt = trusty_mpm::core::session_launch::build_system_prompt_for(&path);
+    let prompt = trusty_mpm::core::session_launch::build_system_prompt_for_with_style(
+        &path,
+        style.as_deref(),
+    );
     let prompt_path = trusty_mpm::core::model_inject::write_prompt_file(&prompt);
     if prompt_path.is_none() {
         eprintln!("warning: failed to write system prompt file; launching without prompt");

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -496,13 +496,17 @@ pub(crate) fn compose_session_instructions(
     };
     let output = build_instructions(&input)?;
 
-    // The single source of truth for the live PM prompt is `resolve_pm_prompt`.
-    // Writing it to the stash AND returning it as the display string ensures that
-    // `tm sessions instructions` always shows exactly what `claude` received (the
-    // #382 fix). Previously this function returned `output.merged` for display,
-    // which came from the old pipeline (INSTRUCTIONS.md + delegation + CLAUDE.md)
-    // and differed from the stash, causing the visible divergence.
-    let resolved_prompt = trusty_mpm::core::instruction_overrides::resolve_pm_prompt(project_dir);
+    // The single source of truth for the live PM prompt is
+    // `build_system_prompt_for`, NOT the bare `resolve_pm_prompt`. The launcher
+    // applies HR-4 output-style version-fallback injection on top of the resolved
+    // prompt (issue #1409), so `tm sessions instructions` must show — and the
+    // stash must hold — that SAME injected text. Writing the pre-injection
+    // `resolve_pm_prompt` here made the display/stash diverge from the real launch
+    // prompt whenever `claude` was absent/old (injection fires), the same #382
+    // divergence this function was written to prevent. Routing through
+    // `build_system_prompt_for` keeps display, stash, and launch identical
+    // regardless of Claude Code version.
+    let resolved_prompt = trusty_mpm::core::session_launch::build_system_prompt_for(project_dir);
     let stash_dir = project_dir.join(".trusty-mpm");
     std::fs::create_dir_all(&stash_dir)?;
     let stash = stash_dir.join("last-instructions.md");

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -234,7 +234,7 @@ async fn main() -> anyhow::Result<()> {
             auto_resume,
             no_classify,
         } => commands::supervisor::run_supervisor(addr, interval, auto_resume, no_classify).await,
-        Command::Launch { dir } => launch(&client, &url, dir).await,
+        Command::Launch { dir, style } => launch(&client, &url, dir, style).await,
         Command::Connect { dir } => connect(&client, &url, dir).await,
         Command::Attach { target, json } => attach_cmd(&client, &url, &target, json).await,
         Command::Optimizer { action } => optimizer(&client, &url, action).await,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -190,7 +190,10 @@ fn cli_meta_requires_action() {
 fn cli_parses_launch() {
     let cli = Cli::try_parse_from(["trusty-mpm", "launch"]).unwrap();
     match cli.command {
-        Command::Launch { dir } => assert_eq!(dir, None),
+        Command::Launch { dir, style } => {
+            assert_eq!(dir, None);
+            assert_eq!(style, None);
+        }
         other => panic!("expected launch, got {other:?}"),
     }
 }
@@ -199,7 +202,24 @@ fn cli_parses_launch() {
 fn cli_parses_launch_with_dir() {
     let cli = Cli::try_parse_from(["trusty-mpm", "launch", "/work/p"]).unwrap();
     match cli.command {
-        Command::Launch { dir } => assert_eq!(dir.as_deref(), Some("/work/p")),
+        Command::Launch { dir, style } => {
+            assert_eq!(dir.as_deref(), Some("/work/p"));
+            assert_eq!(style, None);
+        }
+        other => panic!("expected launch, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_launch_with_style() {
+    // HR-4: `--style <id>` selects the active output style for this launch.
+    let cli =
+        Cli::try_parse_from(["trusty-mpm", "launch", "--style", "trusty-mpm-teacher"]).unwrap();
+    match cli.command {
+        Command::Launch { dir, style } => {
+            assert_eq!(dir, None);
+            assert_eq!(style.as_deref(), Some("trusty-mpm-teacher"));
+        }
         other => panic!("expected launch, got {other:?}"),
     }
 }

--- a/crates/trusty-mpm/src/core/bundle.rs
+++ b/crates/trusty-mpm/src/core/bundle.rs
@@ -171,7 +171,8 @@ pub use skills_inner::{
     MPM_VERIFICATION_PROTOCOLS,
 };
 
-/// Claude Code output style deployed to `~/.claude/output-styles/trusty-mpm.md`.
+/// Default (professional) Claude Code output style deployed to
+/// `~/.claude/output-styles/trusty-mpm.md`.
 ///
 /// Why: launched sessions set `"outputStyle": "trusty-mpm"` in the project
 /// `.claude/settings.json`; Claude Code only honours that name if a matching
@@ -179,6 +180,74 @@ pub use skills_inner::{
 /// outside the framework-root [`ALL`] table (which installs under
 /// `~/.trusty-mpm/framework/`, not `~/.claude/`).
 pub const OUTPUT_STYLE: &str = include_str!("../assets/output-styles/trusty-mpm.md");
+
+/// Teaching-mode Claude Code output style (id `trusty-mpm-teacher`).
+///
+/// Why: HR-4 bundles three styles so an operator can pick a communication mode;
+/// this variant narrates the orchestration reasoning while keeping the
+/// mandatory-delegation floor intact.
+pub const OUTPUT_STYLE_TEACHER: &str =
+    include_str!("../assets/output-styles/trusty-mpm-teacher.md");
+
+/// Research-mode Claude Code output style (id `trusty-mpm-research`).
+///
+/// Why: HR-4 bundles three styles; this variant front-loads investigation and
+/// demands evidence before any change, again keeping the delegation floor.
+pub const OUTPUT_STYLE_RESEARCH: &str =
+    include_str!("../assets/output-styles/trusty-mpm-research.md");
+
+/// The default output-style id used when none is configured/selected.
+///
+/// Why: callers (config resolution, settings writer) need a single source of
+/// truth for the professional default so they cannot drift.
+/// What: the frontmatter `name:` of [`OUTPUT_STYLE`].
+/// Test: `bundle_tests::output_style_registry_default_resolves`.
+pub const DEFAULT_OUTPUT_STYLE_ID: &str = "trusty-mpm";
+
+/// One entry in the bundled output-style registry.
+///
+/// Why: the multi-style launch path (HR-4) must map a configured/selected style
+/// id to its bundled content and the file name it deploys to; bundling the id,
+/// file name, and content together keeps those three facts from drifting.
+/// What: the style id (matching the file's frontmatter `name:`), the file name
+/// written under `~/.claude/output-styles/`, and the embedded content.
+/// Test: `bundle_tests::output_style_registry_ids_match_frontmatter`.
+#[derive(Debug, Clone, Copy)]
+pub struct BundledStyle {
+    /// Style id — matches the frontmatter `name:` and the `outputStyle` settings
+    /// key Claude Code resolves against `~/.claude/output-styles/<file_name>`.
+    pub id: &'static str,
+    /// File name written under `~/.claude/output-styles/`.
+    pub file_name: &'static str,
+    /// Embedded Markdown content of the style.
+    pub content: &'static str,
+}
+
+/// All bundled output styles, default first.
+///
+/// Why: `deploy_output_style` writes every entry, and the style resolver looks
+/// up a configured/selected id against this table; a single ordered slice keeps
+/// both behaviours consistent.
+/// What: the professional (`trusty-mpm`), teaching (`trusty-mpm-teacher`), and
+/// research (`trusty-mpm-research`) styles.
+/// Test: `bundle_tests::output_style_registry_has_three_distinct_ids`.
+pub const OUTPUT_STYLES: &[BundledStyle] = &[
+    BundledStyle {
+        id: DEFAULT_OUTPUT_STYLE_ID,
+        file_name: "trusty-mpm.md",
+        content: OUTPUT_STYLE,
+    },
+    BundledStyle {
+        id: "trusty-mpm-teacher",
+        file_name: "trusty-mpm-teacher.md",
+        content: OUTPUT_STYLE_TEACHER,
+    },
+    BundledStyle {
+        id: "trusty-mpm-research",
+        file_name: "trusty-mpm-research.md",
+        content: OUTPUT_STYLE_RESEARCH,
+    },
+];
 
 // BundledArtifact, InstallPolicy, and ALL are defined in bundle_all.rs.
 // They are included here so they can access the constants above via `use super::*`.

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -60,6 +60,8 @@ fn constants_are_non_empty() {
     assert!(!MPM_SKILLS_MANAGER_AGENT.trim().is_empty());
     assert!(!EXAMPLE_SKILL.trim().is_empty());
     assert!(!OUTPUT_STYLE.trim().is_empty());
+    assert!(!OUTPUT_STYLE_TEACHER.trim().is_empty());
+    assert!(!OUTPUT_STYLE_RESEARCH.trim().is_empty());
     // Phase 1 (#770) guidance skills
     assert!(!MPM_DELEGATION_PATTERNS.trim().is_empty());
     assert!(!MPM_VERIFICATION_PROTOCOLS.trim().is_empty());
@@ -80,6 +82,46 @@ fn output_style_has_matching_frontmatter_name() {
     // `name:` in the style file's frontmatter; a mismatch silently falls
     // back to the operator's default style.
     assert!(OUTPUT_STYLE.contains("name: trusty-mpm"));
+}
+
+#[test]
+fn output_style_registry_has_three_distinct_ids() {
+    // HR-4 bundles exactly three styles with distinct ids and file names.
+    assert_eq!(OUTPUT_STYLES.len(), 3);
+    let mut ids: Vec<&str> = OUTPUT_STYLES.iter().map(|s| s.id).collect();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), 3, "style ids must be distinct");
+
+    let mut files: Vec<&str> = OUTPUT_STYLES.iter().map(|s| s.file_name).collect();
+    files.sort_unstable();
+    files.dedup();
+    assert_eq!(files.len(), 3, "style file names must be distinct");
+}
+
+#[test]
+fn output_style_registry_ids_match_frontmatter() {
+    // Each registry id MUST equal the file's frontmatter `name:`, or Claude Code
+    // silently falls back to the operator's default style.
+    for style in OUTPUT_STYLES {
+        assert!(!style.content.trim().is_empty(), "{} non-empty", style.id);
+        assert!(
+            style.content.contains(&format!("name: {}", style.id)),
+            "{} frontmatter name must match registry id",
+            style.id
+        );
+    }
+}
+
+#[test]
+fn output_style_registry_default_resolves() {
+    // The default id is present and points at the professional style.
+    let default = OUTPUT_STYLES
+        .iter()
+        .find(|s| s.id == DEFAULT_OUTPUT_STYLE_ID)
+        .expect("default style must be in the registry");
+    assert_eq!(default.content, OUTPUT_STYLE);
+    assert_eq!(default.file_name, "trusty-mpm.md");
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -163,6 +163,13 @@ pub struct MpmConfig {
     /// defaults and leave the legacy overseer path untouched.
     #[serde(default)]
     pub session_manager: SessionManagerConfig,
+
+    /// `[style]` — active output-style selection (HR-4 / DOC-17).
+    ///
+    /// Absent section → professional default (`trusty-mpm`). See
+    /// [`crate::core::output_style::StyleConfig`].
+    #[serde(default)]
+    pub style: crate::core::output_style::StyleConfig,
 }
 
 // ──────────────────────────────────────────────

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -37,6 +37,7 @@ pub mod llm_overseer;
 pub mod memory;
 pub mod model_inject;
 pub mod names;
+pub mod output_style;
 pub mod overseer;
 pub mod overseer_config;
 pub mod paths;

--- a/crates/trusty-mpm/src/core/output_style.rs
+++ b/crates/trusty-mpm/src/core/output_style.rs
@@ -360,13 +360,37 @@ pub fn maybe_inject_active_style(
 /// Test: side-effecting (loads real config, spawns `claude`); the pure core is
 /// covered by `maybe_inject_*`.
 pub fn apply_output_style_to_prompt(
-    _project_dir: &Path,
+    project_dir: &Path,
     explicit: Option<&str>,
     prompt: String,
 ) -> String {
-    let config = MpmConfig::load_default();
     let native = claude_supports_native_output_style();
-    maybe_inject_active_style(&config, explicit, prompt, native)
+    apply_output_style_to_prompt_with_native(project_dir, explicit, prompt, native)
+}
+
+/// Apply the output-style injection decision with the `native_supported` flag
+/// supplied explicitly (no live `claude --version` probe).
+///
+/// Why: [`apply_output_style_to_prompt`] spawns `claude --version`, which makes
+/// every caller (and every test that exercises a launch-prompt path) depend on
+/// whether `claude` is installed on the host — the exact host-dependence that
+/// broke `prepare_session_stash_reflects_override` on CI (issue #1409). This
+/// seam lets tests pin the decision BOTH ways while production still does real
+/// version detection (and fails safe to injection) via the wrapper above.
+/// What: loads [`MpmConfig::load_default`] and delegates to the pure
+/// [`maybe_inject_active_style`] core with the caller-supplied `native_supported`
+/// flag. `_project_dir` is accepted for symmetry / future project-scoped overrides.
+/// Test: `output_style_tests.rs` covers the pure core directly; the
+/// stash/launch invariant under both flag values is covered by
+/// `prepare_session_stash_reflects_override` in `session_launch/tests.rs`.
+pub fn apply_output_style_to_prompt_with_native(
+    _project_dir: &Path,
+    explicit: Option<&str>,
+    prompt: String,
+    native_supported: bool,
+) -> String {
+    let config = MpmConfig::load_default();
+    maybe_inject_active_style(&config, explicit, prompt, native_supported)
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/output_style.rs
+++ b/crates/trusty-mpm/src/core/output_style.rs
@@ -1,0 +1,374 @@
+//! Multi-style output support with version-fallback injection (HR-4).
+//!
+//! Why: trusty-mpm bundles three Claude Code output styles — professional
+//! (`trusty-mpm`), teaching (`trusty-mpm-teacher`), and research
+//! (`trusty-mpm-research`). The operator picks the active one via config
+//! (`[style] active = …`) or the launch `--style` flag. Modern Claude Code
+//! (≥ 1.0.83) honours a native `"outputStyle"` key in `.claude/settings.json`,
+//! but older builds ignore it; for those, trusty-mpm must INJECT the active
+//! style's content into the PM system prompt instead so the active style is in
+//! effect regardless of Claude Code version (DOC-17 §HR-4).
+//! What: a registry resolver over [`crate::core::bundle::OUTPUT_STYLES`]
+//! ([`resolve_style`], [`resolve_active_style`]), a `[style]` config section
+//! ([`StyleConfig`]), Claude Code version detection
+//! ([`claude_supports_native_output_style`], [`version_supports_native`]), and
+//! prompt injection ([`inject_style_into_prompt`]).
+//! Test: `output_style_tests.rs` covers registry resolution (all three ids +
+//! unknown-id error), config selection, the version gate (mocked version
+//! strings), and prompt injection.
+
+use std::path::Path;
+
+use crate::core::bundle::{BundledStyle, DEFAULT_OUTPUT_STYLE_ID, OUTPUT_STYLES};
+use crate::core::config::MpmConfig;
+
+/// The first Claude Code version that honours the native `outputStyle` settings
+/// key, as `(major, minor, patch)`.
+///
+/// Why: claude-mpm established `1.0.83` as the floor for native output-style
+/// support; trusty-mpm mirrors it so the version gate matches upstream behaviour.
+/// What: the inclusive lower bound — a detected version `>=` this supports native
+/// output styles.
+/// Test: `version_gate_*` in `output_style_tests.rs`.
+pub const NATIVE_OUTPUT_STYLE_MIN_VERSION: (u32, u32, u32) = (1, 0, 83);
+
+/// A failure resolving a requested output-style id.
+///
+/// Why: an unknown style id is a user-facing error (a typo in config or the
+/// `--style` flag); callers need a typed surface that names the bad id and the
+/// valid set so the message is actionable.
+/// What: a single variant carrying the requested id.
+/// Test: `unknown_style_id_errors` in `output_style_tests.rs`.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum StyleError {
+    /// The requested style id is not in the bundled registry.
+    #[error("unknown output style '{requested}'; valid styles: {valid}")]
+    Unknown {
+        /// The id the caller asked for.
+        requested: String,
+        /// Comma-separated list of valid ids (for the error message).
+        valid: String,
+    },
+}
+
+/// Resolve a style id to its bundled entry, erroring on an unknown id.
+///
+/// Why: the launch path must validate a configured/selected id against the
+/// bundle before writing it into `.claude/settings.json` — Claude Code silently
+/// falls back to the operator's default on a name mismatch, so a typo would
+/// otherwise produce a confusing "style not applied" with no error.
+/// What: linear-scans [`OUTPUT_STYLES`] for `id`; returns the matching
+/// [`BundledStyle`] or [`StyleError::Unknown`] listing the valid ids.
+/// Test: `resolve_style_resolves_all_three_ids`, `unknown_style_id_errors`.
+pub fn resolve_style(id: &str) -> Result<&'static BundledStyle, StyleError> {
+    OUTPUT_STYLES
+        .iter()
+        .find(|s| s.id == id)
+        .ok_or_else(|| StyleError::Unknown {
+            requested: id.to_string(),
+            valid: valid_style_ids(),
+        })
+}
+
+/// Comma-separated list of bundled style ids, in registry order.
+///
+/// Why: used in the [`StyleError::Unknown`] message and exposed so the CLI can
+/// list the choices for `--style`.
+/// What: joins every [`BundledStyle::id`] with `", "`.
+/// Test: `valid_style_ids_lists_all`.
+pub fn valid_style_ids() -> String {
+    OUTPUT_STYLES
+        .iter()
+        .map(|s| s.id)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// `[style]` section of `~/.trusty-mpm/config.toml`.
+///
+/// Why: HR-4 makes the active output style configurable; this section records
+/// the operator's choice so every launch picks it up without a flag.
+/// What: an optional `active` id. `None` (absent section/key) means "use the
+/// professional default" ([`DEFAULT_OUTPUT_STYLE_ID`]).
+/// Test: `config_style_section_parses`, `active_style_id_defaults_when_unset`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+pub struct StyleConfig {
+    /// The active output-style id (e.g. `"trusty-mpm-teacher"`). `None` → default.
+    pub active: Option<String>,
+}
+
+/// Determine the effective active style id from config + an optional override.
+///
+/// Why: the active style can come from the launch `--style` flag (highest
+/// precedence) or the `[style] active` config key, falling back to the
+/// professional default; centralizing the precedence keeps the CLI and the
+/// client launch paths consistent.
+/// What: returns the `explicit` override if `Some`, else `config.style.active`
+/// if set, else [`DEFAULT_OUTPUT_STYLE_ID`]. Does NOT validate the id — callers
+/// validate via [`resolve_style`] (or [`resolve_active_style`]) so the
+/// unknown-id error surfaces once, with full context.
+/// Test: `active_style_id_precedence`.
+pub fn active_style_id<'a>(config: &'a MpmConfig, explicit: Option<&'a str>) -> &'a str {
+    if let Some(id) = explicit {
+        return id;
+    }
+    config
+        .style
+        .active
+        .as_deref()
+        .unwrap_or(DEFAULT_OUTPUT_STYLE_ID)
+}
+
+/// Resolve the active style to a bundled entry, applying config + override.
+///
+/// Why: the launch path needs the actual [`BundledStyle`] (id + content) for the
+/// active selection, validated; this combines [`active_style_id`] with
+/// [`resolve_style`].
+/// What: computes the active id via [`active_style_id`], then resolves it.
+/// Returns [`StyleError::Unknown`] when the selected id is not bundled.
+/// Test: `resolve_active_style_uses_config`, `resolve_active_style_unknown_errors`.
+pub fn resolve_active_style(
+    config: &MpmConfig,
+    explicit: Option<&str>,
+) -> Result<&'static BundledStyle, StyleError> {
+    resolve_style(active_style_id(config, explicit))
+}
+
+/// Parse a `claude --version` output line into `(major, minor, patch)`.
+///
+/// Why: the version gate must turn the raw CLI output (e.g.
+/// `"1.0.84 (Claude Code)"`) into a comparable tuple; isolating the parse makes
+/// it testable without spawning the binary.
+/// What: extracts the first `\d+.\d+.\d+` triple from `raw`. Returns `None` when
+/// no such triple is present (so callers can treat unparseable output as "assume
+/// no native support" to stay safe).
+/// Test: `parse_version_*`.
+pub fn parse_claude_version(raw: &str) -> Option<(u32, u32, u32)> {
+    // Find the first whitespace/paren-delimited token that looks like a semver
+    // triple. We scan token-by-token rather than pull in a regex dependency.
+    for token in raw.split(|c: char| c.is_whitespace() || c == '(' || c == ')' || c == 'v') {
+        if let Some(v) = parse_triple(token) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Parse a single token as a `major.minor.patch` triple.
+///
+/// Why: helper for [`parse_claude_version`]; a token may carry a pre-release or
+/// build suffix (`1.0.84-beta`), so we split on the first non-digit after the
+/// patch number.
+/// What: splits `token` on `.`; requires at least three leading numeric
+/// components; ignores any suffix on the patch component.
+/// Test: covered via `parse_version_*`.
+fn parse_triple(token: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = token.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+    // Patch may have a trailing suffix (e.g. `83-beta`); take the leading digits.
+    let patch_raw = parts.next()?;
+    let patch_digits: String = patch_raw
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    if patch_digits.is_empty() {
+        return None;
+    }
+    let patch = patch_digits.parse::<u32>().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Decide whether a detected version supports the native `outputStyle` key.
+///
+/// Why: the launch path branches on this — native key vs. prompt injection.
+/// What: returns `true` when `version >= ` [`NATIVE_OUTPUT_STYLE_MIN_VERSION`].
+/// Test: `version_gate_supported`, `version_gate_unsupported`,
+/// `version_gate_exact_floor`.
+pub fn version_supports_native(version: (u32, u32, u32)) -> bool {
+    version >= NATIVE_OUTPUT_STYLE_MIN_VERSION
+}
+
+/// Detect whether the installed Claude Code supports native output styles.
+///
+/// Why: when the installed CLI is too old (or undetectable) trusty-mpm must
+/// inject the style into the PM prompt instead of relying on the settings key.
+/// What: runs `claude --version`, parses the first semver triple, and compares
+/// it to [`NATIVE_OUTPUT_STYLE_MIN_VERSION`]. **Fails safe**: any error (binary
+/// missing, non-zero exit, unparseable output) is logged to stderr and treated
+/// as "does NOT support native" so the style is always applied via injection.
+/// All logging goes to stderr (the daemon/MCP stdout-clean rule).
+/// Test: pure logic is in [`version_supports_native`] /
+/// [`detect_native_support_from_output`]; this thin wrapper is side-effecting
+/// (spawns a process) and is covered by `detect_from_output_*`.
+pub fn claude_supports_native_output_style() -> bool {
+    match std::process::Command::new("claude")
+        .arg("--version")
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            detect_native_support_from_output(&stdout)
+        }
+        Ok(out) => {
+            let code = out.status.code().unwrap_or(-1);
+            tracing::warn!(
+                exit = code,
+                "`claude --version` exited non-zero; assuming no native output-style support"
+            );
+            false
+        }
+        Err(err) => {
+            tracing::warn!(
+                %err,
+                "could not run `claude --version`; assuming no native output-style support"
+            );
+            false
+        }
+    }
+}
+
+/// Map a `claude --version` output string to native-support, failing safe.
+///
+/// Why: separating the string→bool decision from the process spawn makes the
+/// version gate fully unit-testable with mocked version strings (the HR-4
+/// acceptance criterion).
+/// What: parses `raw` via [`parse_claude_version`]; an unparseable string yields
+/// `false` (assume no native support → inject). A parsed version defers to
+/// [`version_supports_native`].
+/// Test: `detect_from_output_modern`, `detect_from_output_old`,
+/// `detect_from_output_unparseable`.
+pub fn detect_native_support_from_output(raw: &str) -> bool {
+    match parse_claude_version(raw) {
+        Some(v) => version_supports_native(v),
+        None => {
+            tracing::warn!(
+                output = raw.trim(),
+                "could not parse Claude Code version; assuming no native output-style support"
+            );
+            false
+        }
+    }
+}
+
+/// Strip a leading YAML frontmatter block (`--- … ---`) from style content.
+///
+/// Why: when injecting a style into the PM system prompt, the
+/// `name:`/`description:` frontmatter is Claude-Code settings metadata, not
+/// instructions for the model; stripping it keeps the injected text clean.
+/// What: if `content` starts with a `---` line, drops everything through the
+/// closing `---` line; otherwise returns `content` unchanged (trimmed).
+/// Test: `strip_frontmatter_removes_block`, `strip_frontmatter_passthrough`.
+fn strip_frontmatter(content: &str) -> &str {
+    let trimmed = content.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("---") {
+        // `rest` begins right after the opening `---`. Find the closing fence.
+        if let Some(end) = rest.find("\n---") {
+            // Skip past the closing `---` line.
+            let after = &rest[end + "\n---".len()..];
+            // Drop the remainder of the closing fence line.
+            if let Some(nl) = after.find('\n') {
+                return after[nl + 1..].trim_start();
+            }
+            return after.trim_start();
+        }
+    }
+    trimmed
+}
+
+/// Header that delimits an injected output-style block in the PM prompt.
+///
+/// Why: a clearly-labelled fence tells the launched PM (and a human reading the
+/// stashed prompt) that the block is the active output style, injected because
+/// the installed Claude Code lacks native support.
+/// What: the Markdown heading prepended to the injected style body.
+/// Test: `inject_prepends_style_block`.
+pub const INJECTED_STYLE_HEADING: &str =
+    "# Active Output Style (injected — Claude Code lacks native outputStyle support)";
+
+/// Prepend an output style's content to a PM system prompt.
+///
+/// Why: on older Claude Code the `"outputStyle"` settings key is ignored, so the
+/// only way to make the active style take effect is to fold its instructions
+/// into the `--append-system-prompt` text. claude-mpm does the same.
+/// What: returns a new string of `INJECTED_STYLE_HEADING`, then the style body
+/// (frontmatter stripped), then the framework section separator, then the
+/// original `prompt`. The original prompt is preserved verbatim so the PM floor
+/// and overrides are untouched — the style is purely additive and placed first.
+/// Test: `inject_prepends_style_block`, `inject_preserves_prompt`.
+pub fn inject_style_into_prompt(style: &BundledStyle, prompt: &str) -> String {
+    let body = strip_frontmatter(style.content).trim();
+    format!(
+        "{INJECTED_STYLE_HEADING}\n\n{body}{sep}{prompt}",
+        sep = crate::core::instruction_pipeline::SECTION_SEPARATOR,
+    )
+}
+
+/// Resolve the active style and inject it into `prompt` only when the installed
+/// Claude Code lacks native output-style support.
+///
+/// Why: this is the single launch-time seam (`build_system_prompt_for` calls it)
+/// that makes the active style effective regardless of Claude Code version: on a
+/// modern CLI the prompt is returned unchanged (native key handles the style); on
+/// an old/undetectable CLI the style is injected. Keeping it here means both the
+/// CLI and client launch paths get identical behaviour.
+/// What: if [`claude_supports_native_output_style`] is `true`, returns `prompt`
+/// unchanged. Otherwise resolves the active style (config + `explicit`
+/// override); on success injects it via [`inject_style_into_prompt`]; on an
+/// unknown id logs a warning to stderr and falls back to the professional
+/// default style (per DOC-17: unknown style → `trusty-mpm` default). When the
+/// home dir / config is unavailable the caller passes [`MpmConfig::default`].
+/// Test: `maybe_inject_*` in `output_style_tests.rs` drive the gate via the
+/// injected `native_supported` flag.
+pub fn maybe_inject_active_style(
+    config: &MpmConfig,
+    explicit: Option<&str>,
+    prompt: String,
+    native_supported: bool,
+) -> String {
+    if native_supported {
+        return prompt;
+    }
+    let style = match resolve_active_style(config, explicit) {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::warn!(
+                %err,
+                "falling back to the default output style for prompt injection"
+            );
+            // Default is always present in the registry; resolve it directly.
+            match resolve_style(DEFAULT_OUTPUT_STYLE_ID) {
+                Ok(s) => s,
+                Err(_) => return prompt, // unreachable: default is always bundled
+            }
+        }
+    };
+    inject_style_into_prompt(style, &prompt)
+}
+
+/// Convenience: resolve the active style id for a project, reading the user
+/// config and gating on the live Claude Code version.
+///
+/// Why: the launch sites want a one-call entry point that does the real work
+/// (load config, detect version, inject) without each re-implementing the
+/// precedence; this wraps [`maybe_inject_active_style`] with the real config and
+/// live version detection.
+/// What: loads [`MpmConfig::load_default`], detects native support via
+/// [`claude_supports_native_output_style`], and injects (or not) into `prompt`.
+/// `_project_dir` is accepted for symmetry with the other launch helpers and to
+/// allow future project-scoped style overrides; it is currently unused.
+/// Test: side-effecting (loads real config, spawns `claude`); the pure core is
+/// covered by `maybe_inject_*`.
+pub fn apply_output_style_to_prompt(
+    _project_dir: &Path,
+    explicit: Option<&str>,
+    prompt: String,
+) -> String {
+    let config = MpmConfig::load_default();
+    let native = claude_supports_native_output_style();
+    maybe_inject_active_style(&config, explicit, prompt, native)
+}
+
+#[cfg(test)]
+#[path = "output_style_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/output_style_tests.rs
+++ b/crates/trusty-mpm/src/core/output_style_tests.rs
@@ -1,0 +1,291 @@
+//! Unit tests for [`crate::core::output_style`] (HR-4).
+//!
+//! Why: HR-4 acceptance requires the registry to resolve all three ids, an
+//! unknown id to error, the version gate to select native-vs-inject correctly
+//! against mocked version strings, and the injected prompt to contain the style
+//! content for old versions but not for new ones.
+//! What: covers `resolve_style`, `active_style_id`/`resolve_active_style`,
+//! `parse_claude_version`, `version_supports_native`,
+//! `detect_native_support_from_output`, `inject_style_into_prompt`, and
+//! `maybe_inject_active_style`.
+//! Test: this IS the test module.
+
+use super::*;
+use crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID;
+use crate::core::config::MpmConfig;
+
+// ── Registry resolution ──────────────────────────────────────────────
+
+#[test]
+fn resolve_style_resolves_all_three_ids() {
+    for id in ["trusty-mpm", "trusty-mpm-teacher", "trusty-mpm-research"] {
+        let style = resolve_style(id).unwrap_or_else(|_| panic!("id {id} should resolve"));
+        assert_eq!(style.id, id);
+        assert!(!style.content.trim().is_empty(), "{id} content non-empty");
+        // The frontmatter name must match the registry id, or Claude Code
+        // silently falls back to the default style.
+        assert!(
+            style.content.contains(&format!("name: {id}")),
+            "frontmatter name for {id} must match its registry id"
+        );
+    }
+}
+
+#[test]
+fn unknown_style_id_errors() {
+    let err = resolve_style("nope").unwrap_err();
+    match err {
+        StyleError::Unknown { requested, valid } => {
+            assert_eq!(requested, "nope");
+            // The error lists the valid ids so the message is actionable.
+            assert!(valid.contains("trusty-mpm"));
+            assert!(valid.contains("trusty-mpm-teacher"));
+            assert!(valid.contains("trusty-mpm-research"));
+        }
+    }
+}
+
+#[test]
+fn valid_style_ids_lists_all() {
+    let ids = valid_style_ids();
+    assert!(ids.contains("trusty-mpm"));
+    assert!(ids.contains("trusty-mpm-teacher"));
+    assert!(ids.contains("trusty-mpm-research"));
+}
+
+// ── Active-style precedence (config + override) ──────────────────────
+
+#[test]
+fn active_style_id_defaults_when_unset() {
+    let cfg = MpmConfig::default();
+    assert_eq!(active_style_id(&cfg, None), DEFAULT_OUTPUT_STYLE_ID);
+}
+
+#[test]
+fn active_style_id_precedence() {
+    let mut cfg = MpmConfig::default();
+    cfg.style.active = Some("trusty-mpm-teacher".to_string());
+
+    // Config value applies when no explicit override.
+    assert_eq!(active_style_id(&cfg, None), "trusty-mpm-teacher");
+    // Explicit override wins over config.
+    assert_eq!(
+        active_style_id(&cfg, Some("trusty-mpm-research")),
+        "trusty-mpm-research"
+    );
+}
+
+#[test]
+fn resolve_active_style_uses_config() {
+    let mut cfg = MpmConfig::default();
+    cfg.style.active = Some("trusty-mpm-research".to_string());
+    let style = resolve_active_style(&cfg, None).unwrap();
+    assert_eq!(style.id, "trusty-mpm-research");
+}
+
+#[test]
+fn resolve_active_style_unknown_errors() {
+    let mut cfg = MpmConfig::default();
+    cfg.style.active = Some("bogus".to_string());
+    assert!(resolve_active_style(&cfg, None).is_err());
+}
+
+#[test]
+fn config_style_section_parses() {
+    // The `[style]` section round-trips through the real MpmConfig loader.
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join("config.toml"),
+        "[style]\nactive = \"trusty-mpm-teacher\"\n",
+    )
+    .unwrap();
+    let cfg = MpmConfig::load(dir.path());
+    assert_eq!(cfg.style.active.as_deref(), Some("trusty-mpm-teacher"));
+}
+
+#[test]
+fn config_absent_style_defaults_to_professional() {
+    let cfg = MpmConfig::default();
+    assert!(cfg.style.active.is_none());
+    assert_eq!(active_style_id(&cfg, None), "trusty-mpm");
+}
+
+// ── Version parsing + gate ───────────────────────────────────────────
+
+#[test]
+fn parse_version_plain() {
+    assert_eq!(parse_claude_version("1.0.83"), Some((1, 0, 83)));
+}
+
+#[test]
+fn parse_version_with_suffix_text() {
+    assert_eq!(
+        parse_claude_version("1.0.84 (Claude Code)"),
+        Some((1, 0, 84))
+    );
+}
+
+#[test]
+fn parse_version_with_v_prefix() {
+    assert_eq!(parse_claude_version("claude v2.3.1"), Some((2, 3, 1)));
+}
+
+#[test]
+fn parse_version_prerelease_patch() {
+    // A pre-release suffix on the patch component is tolerated.
+    assert_eq!(parse_claude_version("1.0.90-beta.2"), Some((1, 0, 90)));
+}
+
+#[test]
+fn parse_version_unparseable() {
+    assert_eq!(parse_claude_version("no version here"), None);
+    assert_eq!(parse_claude_version(""), None);
+    // Two-component strings are not a full triple.
+    assert_eq!(parse_claude_version("1.0"), None);
+}
+
+#[test]
+fn version_gate_supported() {
+    assert!(version_supports_native((1, 0, 84)));
+    assert!(version_supports_native((1, 1, 0)));
+    assert!(version_supports_native((2, 0, 0)));
+}
+
+#[test]
+fn version_gate_exact_floor() {
+    // The floor itself supports native output styles (inclusive bound).
+    assert!(version_supports_native(NATIVE_OUTPUT_STYLE_MIN_VERSION));
+    assert!(version_supports_native((1, 0, 83)));
+}
+
+#[test]
+fn version_gate_unsupported() {
+    assert!(!version_supports_native((1, 0, 82)));
+    assert!(!version_supports_native((1, 0, 0)));
+    assert!(!version_supports_native((0, 9, 99)));
+}
+
+#[test]
+fn detect_from_output_modern() {
+    assert!(detect_native_support_from_output("1.0.84 (Claude Code)"));
+    assert!(detect_native_support_from_output("1.0.83"));
+}
+
+#[test]
+fn detect_from_output_old() {
+    assert!(!detect_native_support_from_output("1.0.50 (Claude Code)"));
+}
+
+#[test]
+fn detect_from_output_unparseable_fails_safe() {
+    // Unparseable output → assume NO native support (so the style is injected).
+    assert!(!detect_native_support_from_output("garbage"));
+    assert!(!detect_native_support_from_output(""));
+}
+
+// ── Prompt injection ─────────────────────────────────────────────────
+
+#[test]
+fn strip_frontmatter_removes_block() {
+    let style = resolve_style("trusty-mpm").unwrap();
+    let body = strip_frontmatter(style.content);
+    assert!(
+        !body.contains("name: trusty-mpm"),
+        "frontmatter name line must be stripped from the injected body"
+    );
+    assert!(
+        body.contains("# Trusty Multi-Agent PM"),
+        "the style body must survive frontmatter stripping"
+    );
+}
+
+#[test]
+fn strip_frontmatter_passthrough() {
+    // Content without frontmatter is returned (trimmed) unchanged.
+    let plain = "# Just a heading\n\nbody";
+    assert_eq!(strip_frontmatter(plain), plain);
+}
+
+#[test]
+fn inject_prepends_style_block() {
+    let style = resolve_style("trusty-mpm-teacher").unwrap();
+    let prompt = "# PM Floor\n\noriginal prompt body".to_string();
+    let injected = inject_style_into_prompt(style, &prompt);
+
+    // The injected heading and the style body appear FIRST.
+    assert!(injected.starts_with(INJECTED_STYLE_HEADING));
+    assert!(injected.contains("# Trusty Multi-Agent PM — Teaching Mode"));
+    // The original prompt is preserved verbatim, after the style block.
+    assert!(injected.contains("original prompt body"));
+    let style_pos = injected.find("Teaching Mode").unwrap();
+    let prompt_pos = injected.find("original prompt body").unwrap();
+    assert!(style_pos < prompt_pos, "style block precedes the PM prompt");
+}
+
+#[test]
+fn inject_preserves_prompt() {
+    let style = resolve_style("trusty-mpm").unwrap();
+    let prompt = "UNIQUE_FLOOR_MARKER".to_string();
+    let injected = inject_style_into_prompt(style, &prompt);
+    assert!(injected.contains("UNIQUE_FLOOR_MARKER"));
+}
+
+// ── End-to-end gate: maybe_inject_active_style ───────────────────────
+
+#[test]
+fn maybe_inject_skips_when_native_supported() {
+    // Modern Claude Code → native key handles it → prompt is unchanged.
+    let cfg = MpmConfig::default();
+    let prompt = "PM_PROMPT_BODY".to_string();
+    let out = maybe_inject_active_style(&cfg, None, prompt.clone(), true);
+    assert_eq!(out, prompt, "no injection when native support is present");
+    assert!(!out.contains(INJECTED_STYLE_HEADING));
+}
+
+#[test]
+fn maybe_inject_injects_when_native_unsupported() {
+    // Old Claude Code → inject the active (default) style into the prompt.
+    let cfg = MpmConfig::default();
+    let prompt = "PM_PROMPT_BODY".to_string();
+    let out = maybe_inject_active_style(&cfg, None, prompt, false);
+    assert!(out.contains(INJECTED_STYLE_HEADING));
+    assert!(out.contains("# Trusty Multi-Agent PM"));
+    assert!(out.contains("PM_PROMPT_BODY"));
+}
+
+#[test]
+fn maybe_inject_uses_configured_style() {
+    let mut cfg = MpmConfig::default();
+    cfg.style.active = Some("trusty-mpm-research".to_string());
+    let out = maybe_inject_active_style(&cfg, None, "PROMPT".to_string(), false);
+    assert!(out.contains("# Trusty Multi-Agent PM — Research Mode"));
+}
+
+#[test]
+fn maybe_inject_explicit_overrides_config() {
+    let mut cfg = MpmConfig::default();
+    cfg.style.active = Some("trusty-mpm-research".to_string());
+    let out = maybe_inject_active_style(
+        &cfg,
+        Some("trusty-mpm-teacher"),
+        "PROMPT".to_string(),
+        false,
+    );
+    assert!(out.contains("# Trusty Multi-Agent PM — Teaching Mode"));
+    assert!(!out.contains("Research Mode"));
+}
+
+#[test]
+fn maybe_inject_unknown_falls_back_to_default() {
+    // DOC-17: an unknown style id falls back to the professional default rather
+    // than failing the launch.
+    let mut cfg = MpmConfig::default();
+    cfg.style.active = Some("does-not-exist".to_string());
+    let out = maybe_inject_active_style(&cfg, None, "PROMPT".to_string(), false);
+    assert!(out.contains(INJECTED_STYLE_HEADING));
+    // Default professional style body, not teaching/research.
+    assert!(out.contains("# Trusty Multi-Agent PM"));
+    assert!(!out.contains("Teaching Mode"));
+    assert!(!out.contains("Research Mode"));
+    assert!(out.contains("PROMPT"));
+}

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -97,10 +97,12 @@ pub enum PrepError {
 /// call this before sending `claude` into the tmux pane.
 /// What: deploys composed agents from the framework agent source to
 /// `~/.claude/agents/`, runs [`build_instructions`] for `project_dir` (which
-/// loads or creates the project `CLAUDE.md`), writes the *override-resolved* PM
-/// prompt (from [`crate::core::instruction_overrides::resolve_pm_prompt`]) to
+/// loads or creates the project `CLAUDE.md`), writes the launch prompt — the
+/// exact override-resolved AND output-style-injected text produced by
+/// [`build_system_prompt_for_with_style`] — to
 /// `<project_dir>/.trusty-mpm/last-instructions.md` so the inspectable stash
-/// matches the live launch prompt, and returns a [`PrepReport`].
+/// matches the live launch prompt byte-for-byte (issue #1409), and returns a
+/// [`PrepReport`].
 /// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
 /// `prepare_session_stash_reflects_override`.
 pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepReport, PrepError> {
@@ -126,6 +128,33 @@ pub fn prepare_session_with_style(
     project_dir: &Path,
     explicit_style: Option<&str>,
 ) -> Result<PrepReport, PrepError> {
+    // Probe the live Claude Code version ONCE and thread the decision through the
+    // stash write so the stashed prompt matches what the launcher will inject
+    // (issue #1409). Real detection, fail-safe to injection.
+    let native = crate::core::output_style::claude_supports_native_output_style();
+    prepare_session_with_style_and_native(fw, project_dir, explicit_style, native)
+}
+
+/// Prepare a session with the `native_supported` output-style decision supplied
+/// explicitly (no live `claude --version` probe).
+///
+/// Why: the stash (`last-instructions.md`) must equal the launch prompt
+/// byte-for-byte, and that prompt depends on whether Claude Code supports native
+/// output styles. Probing `claude --version` inside `prepare_session` couples the
+/// stash invariant to the host, which broke `prepare_session_stash_reflects_override`
+/// on CI (issue #1409). This seam pins the decision so tests can assert the
+/// invariant deterministically under BOTH `native_supported = true` and `false`;
+/// [`prepare_session_with_style`] supplies real detection in production.
+/// What: identical to [`prepare_session_with_style`] except the stash is written
+/// from [`build_system_prompt_for_with_style_and_native`] using the supplied flag,
+/// so the stash always reflects the exact injected (or non-injected) launch prompt.
+/// Test: `prepare_session_stash_reflects_override`.
+pub fn prepare_session_with_style_and_native(
+    fw: &FrameworkPaths,
+    project_dir: &Path,
+    explicit_style: Option<&str>,
+    native_supported: bool,
+) -> Result<PrepReport, PrepError> {
     // Deploy composed agents — Claude Code reads `~/.claude/agents/` at startup.
     let deploy = deploy_agents(&fw.agent_source_dir(), &fw.claude_agents_dir())
         .map_err(|err| PrepError::Deploy(err.to_string()))?;
@@ -145,13 +174,25 @@ pub fn prepare_session_with_style(
     };
     let instructions = build_instructions(&input)?;
 
-    // Stash the *override-resolved* PM prompt — the exact text the launch path
-    // passes to `claude --append-system-prompt-file` — so `tm session
-    // instructions` shows what was actually used, including any project-level
-    // overrides under `<project>/.trusty-mpm/`. Resolving via the single
-    // `resolve_pm_prompt` function keeps the stash and the live prompt from
-    // diverging (issue #381 / the #382 concern).
-    let resolved_prompt = crate::core::instruction_overrides::resolve_pm_prompt(project_dir);
+    // Stash the EXACT text the launch path passes to
+    // `claude --append-system-prompt-file` — including the HR-4 output-style
+    // injection — so `tm session instructions` shows what was actually used,
+    // including any project-level overrides under `<project>/.trusty-mpm/`.
+    //
+    // This MUST go through the same `build_system_prompt_for_with_style` seam the
+    // launcher uses (issue #1409): that seam resolves the override-layered prompt
+    // via `resolve_pm_prompt` AND applies the output-style version-fallback
+    // injection. Writing the bare `resolve_pm_prompt` text here (pre-injection)
+    // while the launcher injects later made the stash diverge from reality
+    // whenever `claude` was absent/old (native unsupported → injection fires),
+    // breaking the stash/launch invariant in a host-dependent way. Routing both
+    // through the single seam keeps them identical regardless of Claude version
+    // (issue #381 / the #382 concern).
+    let resolved_prompt = build_system_prompt_for_with_style_and_native(
+        project_dir,
+        explicit_style,
+        native_supported,
+    );
     let stash_dir = project_dir.join(".trusty-mpm");
     std::fs::create_dir_all(&stash_dir).map_err(|source| PrepError::Io {
         path: stash_dir.clone(),
@@ -353,6 +394,36 @@ pub fn build_system_prompt_for_with_style(
     project_dir: &Path,
     explicit_style: Option<&str>,
 ) -> String {
+    let native = crate::core::output_style::claude_supports_native_output_style();
+    build_system_prompt_for_with_style_and_native(project_dir, explicit_style, native)
+}
+
+/// Build the launch prompt with the `native_supported` output-style decision
+/// supplied explicitly (no live `claude --version` probe).
+///
+/// Why: the public [`build_system_prompt_for_with_style`] probes
+/// `claude --version`, so any test (or caller) that exercises the launch prompt
+/// is silently coupled to whether `claude` is installed on the host — the
+/// host-dependence that broke `prepare_session_stash_reflects_override` on CI
+/// (issue #1409). This seam pins the decision so the stash/launch invariant can
+/// be asserted deterministically under BOTH `native_supported = true` (no
+/// injection) and `false` (injection fires). Production code keeps real
+/// detection via the wrapper above.
+/// What: resolves the override-layered PM prompt via
+/// [`crate::core::instruction_overrides::resolve_pm_prompt`], then applies the
+/// injection decision with the caller-supplied flag via
+/// [`crate::core::output_style::apply_output_style_to_prompt_with_native`].
+/// Test: `prepare_session_stash_reflects_override`.
+pub fn build_system_prompt_for_with_style_and_native(
+    project_dir: &Path,
+    explicit_style: Option<&str>,
+    native_supported: bool,
+) -> String {
     let prompt = crate::core::instruction_overrides::resolve_pm_prompt(project_dir);
-    crate::core::output_style::apply_output_style_to_prompt(project_dir, explicit_style, prompt)
+    crate::core::output_style::apply_output_style_to_prompt_with_native(
+        project_dir,
+        explicit_style,
+        prompt,
+        native_supported,
+    )
 }

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -104,6 +104,28 @@ pub enum PrepError {
 /// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
 /// `prepare_session_stash_reflects_override`.
 pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepReport, PrepError> {
+    prepare_session_with_style(fw, project_dir, None)
+}
+
+/// Prepare a session, selecting an explicit output style (HR-4).
+///
+/// Why: `tm launch --style <id>` lets the operator override the configured
+/// active output style for a single launch; the override must reach the
+/// `outputStyle` settings key (for native-capable Claude Code) and the
+/// prompt-injection seam (for older builds). The flag-less [`prepare_session`]
+/// delegates here with `None`.
+/// What: identical to [`prepare_session`] except the active output-style id is
+/// resolved via [`crate::core::output_style::resolve_active_style`] with
+/// `explicit_style` taking precedence over the `[style] active` config key and
+/// the professional default. An unknown id is logged and falls back to the
+/// default (DOC-17) rather than failing the launch.
+/// Test: `prepare_session_writes_configured_style`,
+/// `prepare_session_explicit_style_overrides_config`.
+pub fn prepare_session_with_style(
+    fw: &FrameworkPaths,
+    project_dir: &Path,
+    explicit_style: Option<&str>,
+) -> Result<PrepReport, PrepError> {
     // Deploy composed agents — Claude Code reads `~/.claude/agents/` at startup.
     let deploy = deploy_agents(&fw.agent_source_dir(), &fw.claude_agents_dir())
         .map_err(|err| PrepError::Deploy(err.to_string()))?;
@@ -141,10 +163,29 @@ pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepRe
         source,
     })?;
 
+    // Resolve the active output style (HR-4): explicit `--style` override >
+    // `[style] active` config key > professional default. An unknown id is
+    // logged and falls back to the default rather than failing the launch
+    // (DOC-17). The resolved id is written into `.claude/settings.json` so a
+    // native-capable Claude Code (>= 1.0.83) applies it directly; older builds
+    // pick it up via prompt injection at the `build_system_prompt_for` seam.
+    let config = crate::core::config::MpmConfig::load(&fw.root);
+    let active_style_id =
+        match crate::core::output_style::resolve_active_style(&config, explicit_style) {
+            Ok(style) => style.id,
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    "falling back to the default output style for settings.json"
+                );
+                crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID
+            }
+        };
+
     // Set the Claude Code output style so the launched session's status bar
-    // reads `style:trusty-mpm`. A failure here is non-fatal: the session still
-    // launches, it just shows the operator's default style.
-    if let Err(err) = write_output_style(project_dir) {
+    // reads `style:<active_style_id>`. A failure here is non-fatal: the session
+    // still launches, it just shows the operator's default style.
+    if let Err(err) = write_output_style(project_dir, Some(active_style_id)) {
         tracing::warn!("failed to set trusty-mpm output style: {err}");
     }
 
@@ -281,8 +322,37 @@ pub fn build_system_prompt() -> Option<String> {
 /// What: delegates to
 /// [`crate::core::instruction_overrides::resolve_pm_prompt`], which layers the
 /// override files onto the bundled PM prompt and always appends the
-/// non-overridable `BASE_PM` floor last.
+/// non-overridable `BASE_PM` floor last, then applies HR-4 output-style
+/// version-fallback injection via [`build_system_prompt_for_with_style`] with no
+/// explicit style override.
 /// Test: `build_system_prompt_for_applies_project_override`.
 pub fn build_system_prompt_for(project_dir: &Path) -> String {
-    crate::core::instruction_overrides::resolve_pm_prompt(project_dir)
+    build_system_prompt_for_with_style(project_dir, None)
+}
+
+/// Build the launch prompt for `project_dir`, applying overrides AND HR-4
+/// output-style version-fallback injection with an explicit style override.
+///
+/// Why: on Claude Code builds older than `1.0.83` the native `outputStyle`
+/// settings key is ignored, so the active output style only takes effect if its
+/// content is folded into the `--append-system-prompt` text. This is the single
+/// launch seam where that injection happens, so both the CLI (`tm launch`) and
+/// the client (`/connect`) get identical behaviour. The `--style` flag flows in
+/// as `explicit_style`.
+/// What: resolves the override-layered PM prompt via
+/// [`crate::core::instruction_overrides::resolve_pm_prompt`], then calls
+/// [`crate::core::output_style::apply_output_style_to_prompt`], which is a no-op
+/// on native-capable Claude Code and prepends the active style otherwise. The
+/// active style is `explicit_style` > `[style] active` config > professional
+/// default; an unknown id falls back to the default.
+/// Test: the injection logic is unit-tested in
+/// `crate::core::output_style::tests`; this composition is covered by
+/// `build_system_prompt_for_applies_project_override` (which asserts the PM
+/// prompt is preserved regardless of the version gate).
+pub fn build_system_prompt_for_with_style(
+    project_dir: &Path,
+    explicit_style: Option<&str>,
+) -> String {
+    let prompt = crate::core::instruction_overrides::resolve_pm_prompt(project_dir);
+    crate::core::output_style::apply_output_style_to_prompt(project_dir, explicit_style, prompt)
 }

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -13,11 +13,14 @@ use std::path::{Path, PathBuf};
 
 use super::PrepError;
 
-/// Claude Code output style applied to launched sessions.
+/// Default Claude Code output style applied to launched sessions.
 ///
-/// Why: the Claude Code status bar renders `style:<outputStyle>`; launched
-/// trusty-mpm sessions should advertise themselves as `trusty-mpm`.
-pub(super) const OUTPUT_STYLE: &str = "trusty-mpm";
+/// Why: the Claude Code status bar renders `style:<outputStyle>`; when no style
+/// is configured, launched trusty-mpm sessions advertise the professional
+/// default `trusty-mpm`. HR-4 lets the operator select a different bundled style
+/// (teaching/research); [`write_output_style`] takes the resolved active id and
+/// falls back to this constant when none is supplied.
+pub(super) const OUTPUT_STYLE: &str = crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID;
 
 /// trusty-mpm-specific spinner tips shown during Claude Code loading.
 ///
@@ -149,32 +152,43 @@ pub(super) fn trusty_search_mcp_value(index_id: Option<&str>) -> serde_json::Val
 pub(super) const GLOBAL_TRUSTY_MEMORY_EVENTS: &[&str] =
     &["UserPromptSubmit", "SessionStart", "PostToolUse", "Stop"];
 
-/// Deploy the bundled `trusty-mpm` output style under `<home>/.claude/output-styles/`.
+/// Deploy ALL bundled output styles under `<home>/.claude/output-styles/`.
 ///
-/// Why: [`write_output_style`] only sets `"outputStyle": "trusty-mpm"` in the
-/// project settings; Claude Code honours that name only when a matching style
-/// file exists in `~/.claude/output-styles/`. This places that file. `home` is
+/// Why: [`write_output_style`] sets `"outputStyle": "<active>"` in the project
+/// settings; Claude Code honours that name only when a matching style file
+/// exists in `~/.claude/output-styles/`. HR-4 bundles three styles
+/// (professional / teaching / research) and the operator may select any of
+/// them, so ALL of them must be on disk for the selection to resolve. `home` is
 /// passed in (rather than resolved here) so tests can target a temp directory
 /// instead of the operator's real home.
-/// What: creates `<home>/.claude/output-styles/` if absent, then writes the
-/// bundled [`crate::core::bundle::OUTPUT_STYLE`] asset, always overwriting so
-/// framework upgrades to the style propagate on the next launch. Returns the
-/// path written.
-/// Test: `deploy_output_style_writes_file`, `deploy_output_style_overwrites`.
+/// What: creates `<home>/.claude/output-styles/` if absent, then writes every
+/// entry in [`crate::core::bundle::OUTPUT_STYLES`] to its `file_name`, always
+/// overwriting so framework upgrades to the styles propagate on the next launch.
+/// Returns the path of the default (professional) style for the [`PrepReport`].
+/// Test: `deploy_output_style_writes_file`, `deploy_output_style_overwrites`,
+/// `deploy_output_style_writes_all_styles`.
 pub(super) fn deploy_output_style(home: &Path) -> Result<PathBuf, PrepError> {
     let style_dir = home.join(".claude").join("output-styles");
     std::fs::create_dir_all(&style_dir).map_err(|source| PrepError::Io {
         path: style_dir.clone(),
         source,
     })?;
-    let style_path = style_dir.join("trusty-mpm.md");
-    std::fs::write(&style_path, crate::core::bundle::OUTPUT_STYLE).map_err(|source| {
-        PrepError::Io {
+
+    let mut default_path: Option<PathBuf> = None;
+    for style in crate::core::bundle::OUTPUT_STYLES {
+        let style_path = style_dir.join(style.file_name);
+        std::fs::write(&style_path, style.content).map_err(|source| PrepError::Io {
             path: style_path.clone(),
             source,
+        })?;
+        if style.id == crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID {
+            default_path = Some(style_path);
         }
-    })?;
-    Ok(style_path)
+    }
+
+    // The default style is always in the registry; fall back to its conventional
+    // path defensively so the return type never has to be optional.
+    Ok(default_path.unwrap_or_else(|| style_dir.join("trusty-mpm.md")))
 }
 
 /// Merge trusty-mpm output-style and spinner-tip settings into the project's
@@ -187,14 +201,21 @@ pub(super) fn deploy_output_style(home: &Path) -> Result<PathBuf, PrepError> {
 /// same file drives the loading-spinner tips, so trusty-mpm-specific tips are
 /// written alongside to override the operator's generic claude-mpm tips.
 /// What: reads an existing `<project>/.claude/settings.json` (preserving all
-/// other keys), sets `outputStyle` to [`OUTPUT_STYLE`], enables
-/// `spinnerTipsEnabled`, sets `spinnerTipsOverride.tips` to [`SPINNER_TIPS`],
-/// and writes it back pretty-printed. Creates the file and `.claude/` directory
-/// when absent.
+/// other keys), sets `outputStyle` to `active_style` (the resolved active id;
+/// `None` → [`OUTPUT_STYLE`] default), enables `spinnerTipsEnabled`, sets
+/// `spinnerTipsOverride.tips` to [`SPINNER_TIPS`], and writes it back
+/// pretty-printed. Creates the file and `.claude/` directory when absent. The
+/// caller resolves+validates the id (via
+/// [`crate::core::output_style::resolve_active_style`]); an empty/whitespace id
+/// is treated as "unset" and falls back to the default here defensively.
 /// Test: `prepare_session_sets_output_style`,
 /// `write_output_style_preserves_existing_keys`,
-/// `write_output_style_sets_spinner_tips`.
-pub(super) fn write_output_style(project_dir: &Path) -> Result<(), PrepError> {
+/// `write_output_style_sets_spinner_tips`,
+/// `write_output_style_sets_active_style`.
+pub(super) fn write_output_style(
+    project_dir: &Path,
+    active_style: Option<&str>,
+) -> Result<(), PrepError> {
     let claude_dir = project_dir.join(".claude");
     std::fs::create_dir_all(&claude_dir).map_err(|source| PrepError::Io {
         path: claude_dir.clone(),
@@ -212,7 +233,11 @@ pub(super) fn write_output_style(project_dir: &Path) -> Result<(), PrepError> {
         Err(_) => serde_json::Value::Object(serde_json::Map::new()),
     };
 
-    settings["outputStyle"] = serde_json::Value::String(OUTPUT_STYLE.to_string());
+    let style = active_style
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(OUTPUT_STYLE);
+    settings["outputStyle"] = serde_json::Value::String(style.to_string());
     settings["spinnerTipsEnabled"] = serde_json::Value::Bool(true);
     settings["spinnerTipsOverride"] = serde_json::json!({ "tips": SPINNER_TIPS });
 

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -97,39 +97,72 @@ fn prepare_session_stash_reflects_override() {
     // Why: the inspectable stash (`last-instructions.md`) must reflect the
     // SAME override-resolved prompt the launch path uses, so `tm session
     // instructions` shows what was actually delivered (issue #381 / #382).
-    // Use a dedicated tmp_home for FrameworkPaths so parallel test runs
-    // never race on the shared ~/.claude/agents manifest (issue: parallel
-    // test isolation — each test needs its own claude_agents_dir).
-    let tmp_home = tempdir().unwrap();
-    let tmp = tempdir().unwrap();
-    let project = tmp.path();
-    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    //
+    // Determinism (issue #1409): HR-4 added output-style injection at the
+    // `build_system_prompt_for_with_style` seam, gated on whether `claude` is
+    // installed/new enough. We therefore route through the native-pinned seams
+    // (`prepare_session_with_style_and_native` /
+    // `build_system_prompt_for_with_style_and_native`) and assert the invariant
+    // under BOTH `native_supported = true` (no injection) AND `false`
+    // (injection fires). This removes the dependence on the host's `claude` that
+    // made this test pass locally but FAIL on CI (where `claude` is absent → the
+    // launch prompt was injected but the stash was not, so the two diverged).
+    for native_supported in [true, false] {
+        // A fresh tmp_home/project per iteration so the second run does not read
+        // back a stash written by the first. Dedicated tmp_home keeps parallel
+        // runs from racing on the shared ~/.claude/agents manifest.
+        let tmp_home = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let project = tmp.path();
+        let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
 
-    let override_dir = project.join(".trusty-mpm");
-    std::fs::create_dir_all(&override_dir).unwrap();
-    std::fs::write(
-        override_dir.join("WORKFLOW.md"),
-        "# Custom Workflow\n\nSTASH_OVERRIDE_MARKER\n",
-    )
-    .unwrap();
+        let override_dir = project.join(".trusty-mpm");
+        std::fs::create_dir_all(&override_dir).unwrap();
+        std::fs::write(
+            override_dir.join("WORKFLOW.md"),
+            "# Custom Workflow\n\nSTASH_OVERRIDE_MARKER\n",
+        )
+        .unwrap();
 
-    let report = prepare_session(&fw, project).expect("prep succeeds");
-    let stash = std::fs::read_to_string(&report.stash).expect("stash readable");
+        let report = prepare_session_with_style_and_native(&fw, project, None, native_supported)
+            .expect("prep succeeds");
+        let stash = std::fs::read_to_string(&report.stash).expect("stash readable");
 
-    assert!(
-        stash.contains("STASH_OVERRIDE_MARKER"),
-        "stash must reflect the WORKFLOW.md override"
-    );
-    assert!(
-        !stash.contains("# PM Workflow Configuration"),
-        "bundled workflow heading must be replaced in the stash"
-    );
-    assert!(
-        stash.contains("# BASE_PM Framework Floor"),
-        "stash must still carry the BASE_PM floor"
-    );
-    // The stash must equal the live prompt for this project.
-    assert_eq!(stash, build_system_prompt_for(project));
+        assert!(
+            stash.contains("STASH_OVERRIDE_MARKER"),
+            "stash must reflect the WORKFLOW.md override (native_supported={native_supported})"
+        );
+        assert!(
+            !stash.contains("# PM Workflow Configuration"),
+            "bundled workflow heading must be replaced in the stash (native_supported={native_supported})"
+        );
+        assert!(
+            stash.contains("# BASE_PM Framework Floor"),
+            "stash must still carry the BASE_PM floor (native_supported={native_supported})"
+        );
+        // The CORE INVARIANT: the persisted stash must equal the exact prompt the
+        // launcher would deliver under the SAME injection decision — in both
+        // claude-present (native) and claude-absent (injected) environments.
+        assert_eq!(
+            stash,
+            build_system_prompt_for_with_style_and_native(project, None, native_supported),
+            "stash must equal the launch prompt (native_supported={native_supported})"
+        );
+        // When injection fires, the stash must actually carry the injected style
+        // block; when native is supported it must NOT — proving the flag drives
+        // the stash content, not the host.
+        if native_supported {
+            assert!(
+                !stash.contains(crate::core::output_style::INJECTED_STYLE_HEADING),
+                "native-capable: stash must NOT carry the injected style block"
+            );
+        } else {
+            assert!(
+                stash.contains(crate::core::output_style::INJECTED_STYLE_HEADING),
+                "native-incapable: stash MUST carry the injected style block"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -180,6 +180,89 @@ fn prepare_session_sets_output_style() {
 }
 
 #[test]
+fn prepare_session_writes_configured_style() {
+    // Why: HR-4 — when `[style] active` is set in the framework config, the
+    // launched session's settings.json must carry that id.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    // Seed `<root>/config.toml` with a teaching-mode selection.
+    std::fs::create_dir_all(&fw.root).unwrap();
+    std::fs::write(
+        fw.config_toml(),
+        "[style]\nactive = \"trusty-mpm-teacher\"\n",
+    )
+    .unwrap();
+
+    prepare_session(&fw, project).expect("prep succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        value["outputStyle"],
+        serde_json::json!("trusty-mpm-teacher")
+    );
+}
+
+#[test]
+fn prepare_session_explicit_style_overrides_config() {
+    // Why: HR-4 — an explicit `--style` override beats the config `[style] active`
+    // key for that launch.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    std::fs::create_dir_all(&fw.root).unwrap();
+    std::fs::write(
+        fw.config_toml(),
+        "[style]\nactive = \"trusty-mpm-teacher\"\n",
+    )
+    .unwrap();
+
+    crate::core::session_launch::prepare_session_with_style(
+        &fw,
+        project,
+        Some("trusty-mpm-research"),
+    )
+    .expect("prep succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        value["outputStyle"],
+        serde_json::json!("trusty-mpm-research")
+    );
+}
+
+#[test]
+fn prepare_session_unknown_style_falls_back_to_default() {
+    // Why: DOC-17 — an unknown configured style must not fail the launch; it
+    // falls back to the professional default.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    std::fs::create_dir_all(&fw.root).unwrap();
+    std::fs::write(fw.config_toml(), "[style]\nactive = \"does-not-exist\"\n").unwrap();
+
+    prepare_session(&fw, project).expect("prep succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["outputStyle"], serde_json::json!("trusty-mpm"));
+}
+
+#[test]
 fn write_output_style_preserves_existing_keys() {
     // Why: merging the style must not clobber an operator's other settings.
     let tmp = tempdir().unwrap();
@@ -192,13 +275,48 @@ fn write_output_style_preserves_existing_keys() {
     )
     .unwrap();
 
-    write_output_style(project).expect("write succeeds");
+    write_output_style(project, None).expect("write succeeds");
 
     let value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(claude_dir.join("settings.json")).unwrap())
             .unwrap();
     assert_eq!(value["outputStyle"], serde_json::json!("trusty-mpm"));
     assert_eq!(value["theme"], serde_json::json!("dark"));
+}
+
+#[test]
+fn write_output_style_sets_active_style() {
+    // Why: HR-4 — an explicitly resolved active style id must be written into
+    // settings.json so a native-capable Claude Code applies it.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    write_output_style(project, Some("trusty-mpm-research")).expect("write succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        value["outputStyle"],
+        serde_json::json!("trusty-mpm-research")
+    );
+}
+
+#[test]
+fn write_output_style_empty_falls_back_to_default() {
+    // Why: a blank/whitespace id must not blank the outputStyle key; it falls
+    // back to the professional default.
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+
+    write_output_style(project, Some("   ")).expect("write succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["outputStyle"], serde_json::json!("trusty-mpm"));
 }
 
 #[test]
@@ -209,7 +327,7 @@ fn write_output_style_sets_spinner_tips() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    write_output_style(project).expect("write succeeds");
+    write_output_style(project, None).expect("write succeeds");
 
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
@@ -951,6 +1069,25 @@ fn deploy_output_style_overwrites() {
     assert_eq!(first, second);
     let written = std::fs::read_to_string(&second).unwrap();
     assert_eq!(written, crate::core::bundle::OUTPUT_STYLE);
+}
+
+#[test]
+fn deploy_output_style_writes_all_styles() {
+    // Why: HR-4 — the operator may select any of the three bundled styles, so
+    // ALL of them must land in ~/.claude/output-styles/ for the selection to
+    // resolve in Claude Code.
+    let home = tempdir().unwrap();
+    deploy_output_style(home.path()).expect("deploy succeeds");
+
+    let dir = home.path().join(".claude").join("output-styles");
+    for style in crate::core::bundle::OUTPUT_STYLES {
+        let path = dir.join(style.file_name);
+        assert!(path.exists(), "{} must be deployed", style.file_name);
+        let written = std::fs::read_to_string(&path).expect("style file readable");
+        assert_eq!(written, style.content, "{} content matches", style.id);
+    }
+    // Sanity: exactly the three bundled styles are written.
+    assert_eq!(crate::core::bundle::OUTPUT_STYLES.len(), 3);
 }
 
 #[test]


### PR DESCRIPTION
Closes #1409
Implements HR-4
Epic #1405

## Summary

Bundles the three MPM output styles, makes the active one selectable, and injects the active style into the PM system prompt as a fallback when the installed Claude Code lacks native `outputStyle` support (DOC-17 §HR-4).

## Part A — Multi-style bundling
- New bundled styles: **teaching** (`trusty-mpm-teacher`) and **research** (`trusty-mpm-research`), alongside the professional default (`trusty-mpm`). Each adapts the trusty-mpm professional style to its mode (narrate-the-reasoning / investigation-first) while keeping the mandatory-delegation floor intact.
- `bundle.rs` exposes all three via a `BundledStyle` registry (`OUTPUT_STYLES`) + `DEFAULT_OUTPUT_STYLE_ID`.
- `deploy_output_style(home)` now writes **all** bundled styles to `~/.claude/output-styles/`.

## Part B — Configurable active style
- New `[style] active = "<id>"` key in `~/.trusty-mpm/config.toml` (`StyleConfig` on `MpmConfig`).
- New `tm launch --style <id>` flag. Precedence: **flag > config > professional default**.
- `write_output_style()` writes the resolved id into the project `.claude/settings.json`. Unknown id → falls back to the `trusty-mpm` default (DOC-17), never fails the launch.

## Part C — Version-fallback injection
- New `core::output_style` module: registry resolver, Claude Code version detection (parses `claude --version`; native floor **1.0.83**; **fails safe to "inject"** on any parse/spawn error, logged to stderr), and prompt injection.
- `build_system_prompt_for` applies the active style at the single launch seam — a **no-op on native-capable Claude Code**, and **prepends** the style content (frontmatter-stripped, fenced) otherwise. Both the CLI (`tm launch`) and client (`/connect`) launch paths inherit the behaviour.

## Style ids
| id | mode |
|----|------|
| `trusty-mpm` | professional (default) |
| `trusty-mpm-teacher` | teaching |
| `trusty-mpm-research` | research |

## Tests
- Registry resolves all three ids; unknown id errors; config/CLI precedence.
- Version gate selects native-vs-inject against **mocked version strings** (`detect_native_support_from_output`, `version_supports_native`).
- Injected prompt **contains** the style content for old versions and is **unchanged** for new ones.
- `deploy_output_style` writes all three; `--style` parses; `[style]` config round-trips.

## Verification (raw)
- `cargo build -p trusty-mpm` — Finished
- `cargo test -p trusty-mpm` — 2140 passed, 0 failed
- `cargo test --workspace` — 9335 passed, 0 failed (OPENROUTER_API_KEY unset)
- `cargo clippy --workspace --all-targets -- -D warnings` — Finished, zero warnings
- `cargo fmt --check` — clean (exit 0)
- `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations — OK

## Scope note
No edits to agent base content, `agent_builder.rs`, or `agent_deployer.rs` (HR-1 concurrent work). `session_launch/mod.rs` edits are localized to the output-style call path and the prompt-build seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)