### PR TITLE
feat(trusty-mpm): manifest-driven harness provisioning (HR-2, #1407)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -506,16 +506,16 @@ async fn handle_simple_ok(resp: reqwest::Response, verb: &str) -> anyhow::Result
 /// Catalog operations are local (no daemon round-trip).
 /// Test: `cli_parses_catalog_sync`, `cli_parses_catalog_ls`.
 pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
-    let catalog_dir = dirs::home_dir()
-        .ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?
-        .join(".trusty-mpm")
-        .join("catalog");
-    // Honour the `[manifest]` config catalog-source overrides (HR-2): config >
-    // env > default. Load the user config to thread its `[manifest]` section in.
+    // Resolve the framework root (`~/.trusty-mpm`) and build the CatalogSync from
+    // the SHARED `for_framework` constructor so this CLI roots the catalog at the
+    // exact same `<framework>/catalog` checkout `session_launch` reads its manifest
+    // from (no independent `home/.trusty-mpm/catalog` recompute). Honour the
+    // `[manifest]` config catalog-source overrides (HR-2): config > env > default.
+    let framework_root = trusty_mpm::core::paths::FrameworkPaths::default().root;
     let config = trusty_mpm::core::config::MpmConfig::load_default();
-    let sync = trusty_mpm::content::CatalogSync::with_config(
+    let sync = trusty_mpm::content::CatalogSync::for_framework(
         trusty_mpm::provisioner::RealGitBackend,
-        catalog_dir,
+        &framework_root,
         Some(&config.manifest),
     );
     match action {

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -510,8 +510,14 @@ pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?
         .join(".trusty-mpm")
         .join("catalog");
-    let sync =
-        trusty_mpm::content::CatalogSync::new(trusty_mpm::provisioner::RealGitBackend, catalog_dir);
+    // Honour the `[manifest]` config catalog-source overrides (HR-2): config >
+    // env > default. Load the user config to thread its `[manifest]` section in.
+    let config = trusty_mpm::core::config::MpmConfig::load_default();
+    let sync = trusty_mpm::content::CatalogSync::with_config(
+        trusty_mpm::provisioner::RealGitBackend,
+        catalog_dir,
+        Some(&config.manifest),
+    );
     match action {
         CatalogAction::Sync { force } => {
             let result = sync.sync(force)?;

--- a/crates/trusty-mpm/src/content/catalog_sync.rs
+++ b/crates/trusty-mpm/src/content/catalog_sync.rs
@@ -20,6 +20,25 @@ use crate::provisioner::GitBackend;
 
 /// Default TTL for the catalog cache: 24 hours.
 const DEFAULT_TTL_HOURS: u64 = 24;
+/// Subdirectory (under the framework root) that holds the synced catalog.
+const CATALOG_SUBDIR: &str = "catalog";
+
+/// The canonical catalog root directory for a given framework root.
+///
+/// Why: BEFORE this helper, two launch paths computed the catalog root
+/// independently — `session_launch::prepare_session` used `fw.root.join("catalog")`
+/// while the `tm catalog` CLI used `dirs::home_dir().join(".trusty-mpm/catalog")`.
+/// They agree in production but the duplication invited drift, and nothing tied
+/// the manifest path the launcher reads to the checkout `CatalogSync` actually
+/// populates. Centralizing the join here makes "where the catalog lives" a single
+/// definition both paths share.
+/// What: returns `<framework_root>/catalog`. The framework root is `~/.trusty-mpm`
+/// in production ([`crate::core::paths::FrameworkPaths::root`]); in tests it is a
+/// tempdir root, so the catalog stays hermetic.
+/// Test: `catalog_root_for_joins_subdir`.
+pub fn catalog_root_for(framework_root: &Path) -> PathBuf {
+    framework_root.join(CATALOG_SUBDIR)
+}
 /// Default claude-mpm repository URL.
 const DEFAULT_CATALOG_REPO: &str = "https://github.com/bobmatnyc/claude-mpm";
 /// Sentinel file written after a successful sync.
@@ -135,6 +154,26 @@ impl<G: GitBackend> CatalogSync<G> {
             git_ref,
             ttl_secs: ttl_hours * 3600,
         }
+    }
+
+    /// Construct a CatalogSync rooted at the framework's canonical catalog dir,
+    /// threading the `[manifest]` config through `with_config`.
+    ///
+    /// Why: this is the single constructor BOTH launch paths share so the catalog
+    /// root, repo, ref, and TTL come from one place. `session_launch` derives the
+    /// manifest path and source dirs from `catalog_root()`; the `tm catalog` CLI
+    /// drives `sync`. Building both from the same framework root + config means the
+    /// manifest the launcher reads is the same checkout the CLI populates.
+    /// What: computes the root via [`catalog_root_for`] and delegates to
+    /// [`with_config`](Self::with_config) so the repo/ref/TTL precedence
+    /// (`[manifest]` config > `TRUSTY_MPM_CATALOG_*` env > default) is preserved.
+    /// Test: `for_framework_uses_catalog_root`.
+    pub fn for_framework(
+        git: G,
+        framework_root: &Path,
+        config: Option<&crate::core::config::ManifestConfig>,
+    ) -> Self {
+        Self::with_config(git, catalog_root_for(framework_root), config)
     }
 
     /// Construct with explicit repo_url and git_ref (for testing).
@@ -542,6 +581,26 @@ mod tests {
         let root = TempDir::new().unwrap();
         let sync = make_sync(&root);
         assert_eq!(sync.catalog_root(), root.path());
+    }
+
+    #[test]
+    fn catalog_root_for_joins_subdir() {
+        // The shared root helper must place the catalog under <framework>/catalog
+        // so both launch paths agree on the location.
+        let fw_root = std::path::Path::new("/home/.trusty-mpm");
+        assert_eq!(
+            super::catalog_root_for(fw_root),
+            std::path::PathBuf::from("/home/.trusty-mpm/catalog")
+        );
+    }
+
+    #[test]
+    fn for_framework_uses_catalog_root() {
+        // `for_framework` must root the sync at <framework>/catalog (the same root
+        // `catalog_root_for` yields) so the CLI and launcher share one checkout.
+        let fw_root = TempDir::new().unwrap();
+        let sync = CatalogSync::for_framework(FakeGitBackend::new(), fw_root.path(), None);
+        assert_eq!(sync.catalog_root(), fw_root.path().join("catalog"));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/content/catalog_sync.rs
+++ b/crates/trusty-mpm/src/content/catalog_sync.rs
@@ -89,14 +89,45 @@ impl<G: GitBackend> CatalogSync<G> {
     /// What: stores all config; no I/O at construction time.
     /// Test: used in every CatalogSync unit test.
     pub fn new(git: G, catalog_dir: PathBuf) -> Self {
-        let ttl_hours = std::env::var("TRUSTY_MPM_CATALOG_TTL_HOURS")
+        Self::with_config(git, catalog_dir, None)
+    }
+
+    /// Construct a CatalogSync resolving repo/ref/TTL with the HR-2 precedence:
+    /// `[manifest]` config > `TRUSTY_MPM_CATALOG_*` env > compiled-in default.
+    ///
+    /// Why: HR-2 adds a persistent, file-based way to control the catalog source
+    /// (a user fork, a pinned ref, a shorter TTL) via the `[manifest]` section of
+    /// `config.toml`, on top of the existing env knobs. Threading the optional
+    /// config through one constructor keeps the precedence in a single place and
+    /// preserves the env-only behavior of [`new`] (which passes `None`).
+    /// What: for each of repo, ref, and TTL, takes the config value when set,
+    /// else the env var, else the compiled-in default.
+    /// Test: `catalog_config_overrides_env_and_default`.
+    pub fn with_config(
+        git: G,
+        catalog_dir: PathBuf,
+        config: Option<&crate::core::config::ManifestConfig>,
+    ) -> Self {
+        let env_ttl = std::env::var("TRUSTY_MPM_CATALOG_TTL_HOURS")
             .ok()
-            .and_then(|v| v.parse::<u64>().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+        let ttl_hours = config
+            .and_then(|c| c.ttl_hours)
+            .or(env_ttl)
             .unwrap_or(DEFAULT_TTL_HOURS);
-        let repo_url = std::env::var("TRUSTY_MPM_CATALOG_REPO")
-            .unwrap_or_else(|_| DEFAULT_CATALOG_REPO.to_owned());
-        let git_ref = std::env::var("TRUSTY_MPM_CATALOG_REF")
-            .unwrap_or_else(|_| DEFAULT_CATALOG_REF.to_owned());
+
+        let env_repo = std::env::var("TRUSTY_MPM_CATALOG_REPO").ok();
+        let repo_url = config
+            .and_then(|c| c.repo.clone())
+            .or(env_repo)
+            .unwrap_or_else(|| DEFAULT_CATALOG_REPO.to_owned());
+
+        let env_ref = std::env::var("TRUSTY_MPM_CATALOG_REF").ok();
+        let git_ref = config
+            .and_then(|c| c.git_ref.clone())
+            .or(env_ref)
+            .unwrap_or_else(|| DEFAULT_CATALOG_REF.to_owned());
+
         Self {
             git,
             catalog_dir,
@@ -263,6 +294,38 @@ impl<G: GitBackend> CatalogSync<G> {
     /// Test: catalog_ls_lists_skills.
     pub fn list_skills(&self) -> Vec<String> {
         list_skill_names(&self.catalog_subdir("skills"))
+    }
+
+    /// Path to the harness manifest inside the synced catalog (HR-2).
+    ///
+    /// Why: HR-2 sources the catalog-layer harness manifest from the synced
+    /// claude-mpm checkout; the session-launch resolver
+    /// (`crate::core::manifest::ManifestSources`) reads this exact path as its
+    /// lowest-of-the-overrides precedence layer. Exposing it on `CatalogSync`
+    /// keeps the catalog repo/ref/TTL configuration (the env knobs threaded into
+    /// `new`) as the single source of truth for WHERE the catalog manifest lives.
+    /// What: `<catalog_dir>/repo/.claude/manifest.toml` — the conventional
+    /// location of a `manifest.toml` committed at the catalog repo's `.claude/`
+    /// root. The file need not exist; the resolver tolerates absence.
+    /// Test: `catalog_manifest_path_points_at_repo_dotclaude`.
+    pub fn manifest_path(&self) -> PathBuf {
+        self.catalog_dir
+            .join("repo")
+            .join(".claude")
+            .join("manifest.toml")
+    }
+
+    /// The catalog root directory (`~/.trusty-mpm/catalog/` in production).
+    ///
+    /// Why: `crate::core::manifest::ManifestSources::resolve` and
+    /// `HarnessPlan::from_manifest` derive the catalog manifest path and the
+    /// catalog agent/skill source dirs from this root; exposing it lets a caller
+    /// thread the *configured* catalog root (which honours the env knobs) into
+    /// manifest resolution instead of recomputing the join.
+    /// What: returns the `catalog_dir` this `CatalogSync` was constructed with.
+    /// Test: `catalog_root_returns_catalog_dir`.
+    pub fn catalog_root(&self) -> &Path {
+        &self.catalog_dir
     }
 }
 
@@ -436,6 +499,49 @@ mod tests {
             skills.contains(&"auto-bug-reporter".to_owned()),
             "skills: {skills:?}"
         );
+    }
+
+    #[test]
+    fn catalog_config_overrides_env_and_default() {
+        // HR-2: a `[manifest]` config value must win over the env var and the
+        // compiled-in default. Config has highest precedence, so this holds
+        // regardless of whether the env vars happen to be set in the test host.
+        let root = TempDir::new().unwrap();
+        let cfg = crate::core::config::ManifestConfig {
+            repo: Some("https://github.com/me/fork".to_owned()),
+            git_ref: Some("dev".to_owned()),
+            ttl_hours: Some(2),
+        };
+        let sync =
+            CatalogSync::with_config(FakeGitBackend::new(), root.path().to_owned(), Some(&cfg));
+        assert_eq!(sync.repo_url, "https://github.com/me/fork");
+        assert_eq!(sync.git_ref, "dev");
+        assert_eq!(sync.ttl_secs, 2 * 3600);
+    }
+
+    #[test]
+    fn catalog_manifest_path_points_at_repo_dotclaude() {
+        // HR-2: the catalog-layer manifest path must be
+        // <catalog>/repo/.claude/manifest.toml so it lines up with the synced
+        // claude-mpm repo layout the resolver reads.
+        let root = TempDir::new().unwrap();
+        let sync = make_sync(&root);
+        assert_eq!(
+            sync.manifest_path(),
+            root.path()
+                .join("repo")
+                .join(".claude")
+                .join("manifest.toml")
+        );
+    }
+
+    #[test]
+    fn catalog_root_returns_catalog_dir() {
+        // The catalog root accessor must return the constructed catalog_dir so a
+        // caller can thread the configured root into manifest resolution.
+        let root = TempDir::new().unwrap();
+        let sync = make_sync(&root);
+        assert_eq!(sync.catalog_root(), root.path());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/content/mod.rs
+++ b/crates/trusty-mpm/src/content/mod.rs
@@ -9,4 +9,4 @@
 
 pub mod catalog_sync;
 
-pub use catalog_sync::{CatalogError, CatalogSync, CatalogSyncResult};
+pub use catalog_sync::{CatalogError, CatalogSync, CatalogSyncResult, catalog_root_for};

--- a/crates/trusty-mpm/src/core/agent_deployer.rs
+++ b/crates/trusty-mpm/src/core/agent_deployer.rs
@@ -71,6 +71,29 @@ pub fn deploy_agents(
     source_dir: &Path,
     target_dir: &Path,
 ) -> Result<DeployResult, AgentBuildError> {
+    // Default policy: deploy every agent in the source directory.
+    deploy_agents_filtered(source_dir, target_dir, |_name| true)
+}
+
+/// Deploy agents from `source_dir`, restricting to those `select` accepts.
+///
+/// Why: HR-2 manifests describe an agent *set* (include/exclude globs), so the
+/// session-launch path must be able to deploy a subset of the source agents
+/// without copying the whole directory. Factoring the selection into a predicate
+/// keeps the manifest logic in `session_launch` while reusing the identical
+/// compose/ownership/atomic-write machinery here.
+/// What: identical to [`deploy_agents`] except a source agent whose stem (the
+/// `.md`-stripped name) the `select` predicate rejects is skipped entirely — it
+/// is neither composed nor written, and an already-deployed managed copy is left
+/// in place (deselecting an agent does not remove a previously deployed file;
+/// that is an HR-3 concern). [`deploy_agents`] delegates here with an accept-all
+/// predicate, so existing behavior is unchanged.
+/// Test: `deploy_filtered_respects_predicate`.
+pub fn deploy_agents_filtered(
+    source_dir: &Path,
+    target_dir: &Path,
+    select: impl Fn(&str) -> bool,
+) -> Result<DeployResult, AgentBuildError> {
     let mut result = DeployResult::default();
 
     // No source directory means nothing to deploy — an empty result, not an
@@ -102,7 +125,12 @@ pub fn deploy_agents(
             continue;
         };
         if entry.file_type()?.is_file() && is_agent_file(name) {
-            names.push(name.trim_end_matches(".md").to_string());
+            let stem = name.trim_end_matches(".md").to_string();
+            // Honour the manifest's agent-set selection (HR-2). A deselected
+            // agent is skipped before compose, so it is never written.
+            if select(&stem) {
+                names.push(stem);
+            }
         }
     }
     names.sort_unstable();
@@ -384,6 +412,24 @@ mod tests {
             "explicit prompt wins:\n{deployed}"
         );
         assert!(!deployed.contains("Begin implementation."));
+    }
+
+    #[test]
+    fn deploy_filtered_respects_predicate() {
+        // HR-2: a selection predicate must restrict which source agents deploy.
+        // Only the accepted agent lands; the rejected one is never written.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path()); // base-agent.md + engineer.md
+
+        let result =
+            deploy_agents_filtered(src.path(), tgt.path(), |name| name == "engineer").unwrap();
+
+        // engineer.md deployed; base-agent.md filtered out and not written.
+        assert!(result.deployed.contains(&"engineer.md".to_string()));
+        assert!(!result.deployed.contains(&"base-agent.md".to_string()));
+        assert!(tgt.path().join("engineer.md").exists());
+        assert!(!tgt.path().join("base-agent.md").exists());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -103,6 +103,29 @@ pub struct SkillsConfig {
     pub sources: Vec<String>,
 }
 
+/// `[manifest]` section — harness-manifest catalog source (HR-2 / DOC-17).
+///
+/// Why: HR-2 sources the catalog-layer harness manifest from a configurable
+/// claude-mpm checkout. The repo/ref/TTL are already controllable via the
+/// `TRUSTY_MPM_CATALOG_REPO` / `_REF` / `_TTL_HOURS` env vars
+/// (`crate::content::CatalogSync`); this section gives operators a persistent,
+/// file-based way to express the same choice (e.g. point at a user fork) without
+/// exporting env vars on every launch. It is read by the catalog-sync
+/// construction path; absent values fall back to the env vars, then the
+/// compiled-in defaults.
+/// What: an optional catalog repo URL, git ref, and TTL (hours). All `None` by
+/// default, so an absent section changes nothing.
+/// Test: `config_manifest_section_parses`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ManifestConfig {
+    /// Catalog repo URL (overrides `TRUSTY_MPM_CATALOG_REPO`'s default).
+    pub repo: Option<String>,
+    /// Catalog git ref (overrides `TRUSTY_MPM_CATALOG_REF`'s default).
+    pub git_ref: Option<String>,
+    /// Catalog cache TTL in hours (overrides `TRUSTY_MPM_CATALOG_TTL_HOURS`).
+    pub ttl_hours: Option<u64>,
+}
+
 /// `[pm]` section — PM-layer toggles.
 ///
 /// Why: the circuit-breaker and other PM-layer features need user-facing
@@ -152,6 +175,10 @@ pub struct MpmConfig {
     /// `[skills]` — skill source configuration.
     #[serde(default)]
     pub skills: SkillsConfig,
+
+    /// `[manifest]` — harness-manifest catalog source (HR-2 / DOC-17).
+    #[serde(default)]
+    pub manifest: ManifestConfig,
 
     /// `[pm]` — PM-layer feature toggles.
     #[serde(default)]
@@ -449,6 +476,30 @@ engineer = "haiku"
             crate::core::sm::config::SessionManagerConfig::default()
         );
         assert!(!cfg.session_manager.enabled);
+    }
+
+    #[test]
+    fn config_manifest_section_parses() {
+        // HR-2: the [manifest] section must parse the catalog source overrides,
+        // and an absent section must leave them all None (no behavior change).
+        let dir = tempfile::TempDir::new().unwrap();
+        let toml = r#"
+[manifest]
+repo = "https://github.com/me/my-fork"
+git_ref = "dev"
+ttl_hours = 6
+"#;
+        let cfg = load_from_str(dir.path(), toml);
+        assert_eq!(
+            cfg.manifest.repo.as_deref(),
+            Some("https://github.com/me/my-fork")
+        );
+        assert_eq!(cfg.manifest.git_ref.as_deref(), Some("dev"));
+        assert_eq!(cfg.manifest.ttl_hours, Some(6));
+
+        // Absent section → all None.
+        let empty = MpmConfig::load(tempfile::TempDir::new().unwrap().path());
+        assert_eq!(empty.manifest, ManifestConfig::default());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/manifest/apply.rs
+++ b/crates/trusty-mpm/src/core/manifest/apply.rs
@@ -1,0 +1,259 @@
+//! Translate a resolved [`HarnessManifest`] into concrete provisioning inputs.
+//!
+//! Why: `prepare_session` consumes the resolved manifest, but it should not have
+//! to know how each manifest section maps onto a source directory, a selection
+//! predicate, or an MCP toggle. Centralizing that translation here keeps
+//! `session_launch/mod.rs` focused on the provisioning *sequence* and keeps the
+//! manifest→deployment mapping independently testable.
+//! What: [`HarnessPlan`] is the materialized provisioning plan derived from a
+//! manifest plus the framework/catalog roots — the agent and skill source dirs
+//! (bundled vs catalog), the agent/skill selection predicates, the MCP toggles,
+//! and the manifest's default output-style id. [`HarnessPlan::from_manifest`]
+//! builds it.
+//! Test: `plan_default_uses_bundled_sources`, `plan_catalog_source_paths`,
+//! `plan_selection_filters`, `plan_mcp_toggles`.
+
+use std::path::PathBuf;
+
+use super::schema::{ContentSource, HarnessManifest, selection_matches};
+use crate::core::paths::FrameworkPaths;
+
+/// A materialized provisioning plan derived from a resolved manifest.
+///
+/// Why: `prepare_session` needs concrete inputs (where to read agents/skills
+/// from, which to deploy, which MCP servers to inject, the default style) rather
+/// than a manifest it must re-interpret inline; bundling them keeps the launch
+/// path readable.
+/// What: source directories already resolved to bundled-or-catalog paths, the
+/// include/exclude lists for the agent and skill selection predicates, the two
+/// MCP toggles (defaulting to on), and the optional manifest-default style id.
+/// Test: `plan_default_uses_bundled_sources`, `plan_catalog_source_paths`.
+#[derive(Debug, Clone)]
+pub struct HarnessPlan {
+    /// Directory the agent *source* files are read from.
+    pub agent_source: PathBuf,
+    /// Agent include patterns (empty = all).
+    pub agent_include: Vec<String>,
+    /// Agent exclude patterns.
+    pub agent_exclude: Vec<String>,
+    /// Directory the skill *source* files are read from.
+    pub skill_source: PathBuf,
+    /// Skill include patterns (empty = all).
+    pub skill_include: Vec<String>,
+    /// Skill exclude patterns.
+    pub skill_exclude: Vec<String>,
+    /// Whether to inject the `trusty-memory` MCP server.
+    pub inject_trusty_memory: bool,
+    /// Whether to inject the `trusty-search` MCP server.
+    pub inject_trusty_search: bool,
+    /// The manifest's default output-style id, if it sets one.
+    ///
+    /// This is the LOWEST-precedence style input: an explicit `--style` flag and
+    /// the `[style] active` config key both override it (HR-4 precedence is
+    /// preserved by the launch path).
+    pub style: Option<String>,
+}
+
+impl HarnessPlan {
+    /// Build a provisioning plan from a resolved manifest.
+    ///
+    /// Why: this is the single place the manifest's declarative sections become
+    /// concrete provisioning inputs, so the manifest→deployment mapping can be
+    /// audited and tested in one spot.
+    /// What: resolves each content source to a directory — `Bundled` uses the
+    /// framework's own `agent_source_dir()`/`skill_source_dir()`; `Catalog` uses
+    /// `<catalog_root>/repo/.claude/agents` and `…/skills` (the layout
+    /// `CatalogSync` writes). Copies the include/exclude lists, reads the MCP
+    /// toggles (absent → on, matching the default), and extracts the style id.
+    /// Absent sections fall back to bundled-source/all/on so a default manifest
+    /// reproduces today's behavior.
+    /// Test: `plan_default_uses_bundled_sources`, `plan_catalog_source_paths`,
+    /// `plan_mcp_toggles`.
+    pub fn from_manifest(
+        manifest: &HarnessManifest,
+        fw: &FrameworkPaths,
+        catalog_root: &std::path::Path,
+    ) -> Self {
+        let catalog_agents = catalog_root.join("repo").join(".claude").join("agents");
+        let catalog_skills = catalog_root.join("repo").join(".claude").join("skills");
+
+        let (agent_source, agent_include, agent_exclude) = match &manifest.agents {
+            Some(set) => {
+                let source = match set.source {
+                    ContentSource::Bundled => fw.agent_source_dir(),
+                    ContentSource::Catalog => catalog_agents,
+                };
+                (source, set.include.clone(), set.exclude.clone())
+            }
+            None => (fw.agent_source_dir(), Vec::new(), Vec::new()),
+        };
+
+        let (skill_source, skill_include, skill_exclude) = match &manifest.skills {
+            Some(set) => {
+                let source = match set.source {
+                    ContentSource::Bundled => fw.skill_source_dir(),
+                    ContentSource::Catalog => catalog_skills,
+                };
+                (source, set.include.clone(), set.exclude.clone())
+            }
+            None => (fw.skill_source_dir(), Vec::new(), Vec::new()),
+        };
+
+        // MCP toggles: absent section or absent flag → on (today's behavior).
+        let (inject_trusty_memory, inject_trusty_search) = match &manifest.mcp {
+            Some(mcp) => (
+                mcp.trusty_memory.unwrap_or(true),
+                mcp.trusty_search.unwrap_or(true),
+            ),
+            None => (true, true),
+        };
+
+        let style = manifest.style.as_ref().and_then(|s| s.active.clone());
+
+        Self {
+            agent_source,
+            agent_include,
+            agent_exclude,
+            skill_source,
+            skill_include,
+            skill_exclude,
+            inject_trusty_memory,
+            inject_trusty_search,
+            style,
+        }
+    }
+
+    /// Whether an agent stem is selected by this plan.
+    ///
+    /// Why: the agent deploy step takes a predicate; exposing the manifest's
+    /// include/exclude rule as a method keeps the rule next to the plan it came
+    /// from.
+    /// What: delegates to [`selection_matches`] with the plan's agent lists.
+    /// Test: `plan_selection_filters`.
+    pub fn agent_selected(&self, stem: &str) -> bool {
+        selection_matches(stem, &self.agent_include, &self.agent_exclude)
+    }
+
+    /// Whether a skill stem is selected by this plan.
+    ///
+    /// Why/What/Test: as [`agent_selected`](Self::agent_selected), for skills.
+    pub fn skill_selected(&self, stem: &str) -> bool {
+        selection_matches(stem, &self.skill_include, &self.skill_exclude)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::default::default_manifest;
+    use super::super::schema::{AgentSet, McpServers, SkillSet, StyleSelection};
+    use super::*;
+
+    #[test]
+    fn plan_default_uses_bundled_sources() {
+        // The compiled-in default manifest must plan bundled sources, no filter,
+        // both MCP servers on, and the professional style — i.e. today's path.
+        let fw = FrameworkPaths::under("/base");
+        let plan = HarnessPlan::from_manifest(
+            &default_manifest(),
+            &fw,
+            std::path::Path::new("/home/.trusty-mpm/catalog"),
+        );
+        assert_eq!(plan.agent_source, fw.agent_source_dir());
+        assert_eq!(plan.skill_source, fw.skill_source_dir());
+        assert!(plan.agent_include.is_empty());
+        assert!(plan.agent_selected("anything"));
+        assert!(plan.skill_selected("anything"));
+        assert!(plan.inject_trusty_memory);
+        assert!(plan.inject_trusty_search);
+        assert_eq!(plan.style.as_deref(), Some("trusty-mpm"));
+    }
+
+    #[test]
+    fn plan_catalog_source_paths() {
+        // A manifest pointing agents at the catalog must resolve to the
+        // <catalog>/repo/.claude/agents layout CatalogSync writes.
+        let fw = FrameworkPaths::under("/base");
+        let manifest = HarnessManifest {
+            agents: Some(AgentSet {
+                include: vec![],
+                exclude: vec![],
+                source: ContentSource::Catalog,
+            }),
+            ..default_manifest()
+        };
+        let plan = HarnessPlan::from_manifest(
+            &manifest,
+            &fw,
+            std::path::Path::new("/home/.trusty-mpm/catalog"),
+        );
+        assert_eq!(
+            plan.agent_source,
+            PathBuf::from("/home/.trusty-mpm/catalog/repo/.claude/agents")
+        );
+        // skills stayed bundled (default manifest's skills section).
+        assert_eq!(plan.skill_source, fw.skill_source_dir());
+    }
+
+    #[test]
+    fn plan_selection_filters() {
+        // include/exclude on the manifest must drive the selection predicates.
+        let fw = FrameworkPaths::under("/base");
+        let manifest = HarnessManifest {
+            agents: Some(AgentSet {
+                include: vec!["*-engineer".into()],
+                exclude: vec!["php-engineer".into()],
+                source: ContentSource::Bundled,
+            }),
+            skills: Some(SkillSet {
+                include: vec!["example-skill".into()],
+                exclude: vec![],
+                source: ContentSource::Bundled,
+            }),
+            ..default_manifest()
+        };
+        let plan = HarnessPlan::from_manifest(&manifest, &fw, std::path::Path::new("/c"));
+        assert!(plan.agent_selected("rust-engineer"));
+        assert!(!plan.agent_selected("php-engineer"), "exclude wins");
+        assert!(!plan.agent_selected("qa"), "not in include");
+        assert!(plan.skill_selected("example-skill"));
+        assert!(!plan.skill_selected("tm-doctor"));
+    }
+
+    #[test]
+    fn plan_mcp_toggles() {
+        // Disabling an MCP server in the manifest must turn off injection.
+        let fw = FrameworkPaths::under("/base");
+        let manifest = HarnessManifest {
+            mcp: Some(McpServers {
+                trusty_memory: Some(false),
+                trusty_search: Some(true),
+            }),
+            ..default_manifest()
+        };
+        let plan = HarnessPlan::from_manifest(&manifest, &fw, std::path::Path::new("/c"));
+        assert!(!plan.inject_trusty_memory);
+        assert!(plan.inject_trusty_search);
+    }
+
+    #[test]
+    fn plan_style_default_lowest_precedence() {
+        // The manifest style is exposed as the plan's style; an absent style
+        // section yields None.
+        let fw = FrameworkPaths::under("/base");
+        let manifest = HarnessManifest {
+            style: Some(StyleSelection {
+                active: Some("trusty-mpm-research".into()),
+            }),
+            ..HarnessManifest::default()
+        };
+        let plan = HarnessPlan::from_manifest(&manifest, &fw, std::path::Path::new("/c"));
+        assert_eq!(plan.style.as_deref(), Some("trusty-mpm-research"));
+
+        let none_plan = HarnessPlan::from_manifest(
+            &HarnessManifest::default(),
+            &fw,
+            std::path::Path::new("/c"),
+        );
+        assert_eq!(none_plan.style, None);
+    }
+}

--- a/crates/trusty-mpm/src/core/manifest/default.rs
+++ b/crates/trusty-mpm/src/core/manifest/default.rs
@@ -1,0 +1,123 @@
+//! The compiled-in default harness manifest (HR-2 / DOC-17).
+//!
+//! Why: the NORMATIVE precedence (project override > user config > catalog >
+//! compiled-in default) requires a fully-populated floor layer that, when no
+//! higher layer overrides anything, reproduces *today's* provisioning behavior
+//! exactly — so an absent manifest is a zero-regression no-op. This module is
+//! that floor.
+//! What: [`default_manifest`] returns a [`HarnessManifest`] with every section
+//! set to the values that match the pre-HR-2 behavior: deploy ALL bundled agents
+//! and skills, every instruction layer on, the professional output style, BOTH
+//! MCP servers injected, and no per-tier model overrides (HR-1's built-in tier
+//! mapping stands).
+//! Test: `default_manifest_reproduces_bundled_behavior`,
+//! `default_manifest_enables_both_mcp`, `default_manifest_carries_current_version`.
+
+use super::schema::{
+    AgentSet, ContentSource, HarnessManifest, InstructionLayers, MANIFEST_VERSION, McpServers,
+    ModelTiers, SkillSet, StyleSelection,
+};
+
+/// Build the compiled-in default harness manifest.
+///
+/// Why: this is the lowest-precedence layer; it must encode the exact behavior
+/// `prepare_session` had before HR-2 so that, absent any override, provisioning
+/// is unchanged (regression-safe).
+/// What: returns a manifest that deploys every bundled agent/skill (empty
+/// include = all), enables all instruction layers, selects the professional
+/// `trusty-mpm` output style, injects both `trusty-memory` and `trusty-search`
+/// MCP servers, and leaves model tiers unset (HR-1 deploy-time mapping applies).
+/// Test: `default_manifest_reproduces_bundled_behavior`.
+pub fn default_manifest() -> HarnessManifest {
+    HarnessManifest {
+        version: Some(MANIFEST_VERSION),
+        agents: Some(AgentSet {
+            include: Vec::new(), // empty = all available agents
+            exclude: Vec::new(),
+            source: ContentSource::Bundled,
+        }),
+        skills: Some(all_skills()),
+        instructions: Some(InstructionLayers {
+            system: Some(true),
+            contextual: Some(true),
+            domain: Some(true),
+        }),
+        style: Some(StyleSelection {
+            active: Some(crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID.to_string()),
+        }),
+        mcp: Some(McpServers {
+            trusty_memory: Some(true),
+            trusty_search: Some(true),
+        }),
+        models: Some(ModelTiers::default()),
+    }
+}
+
+/// The default skill set: deploy every bundled skill from the bundled source.
+///
+/// Why: keeps [`default_manifest`] readable by naming the all-skills default in
+/// one place.
+/// What: an empty-include (= all) [`SkillSet`] reading from the bundled source.
+/// Test: covered by `default_manifest_reproduces_bundled_behavior`.
+fn all_skills() -> SkillSet {
+    SkillSet {
+        include: Vec::new(),
+        exclude: Vec::new(),
+        source: ContentSource::Bundled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_manifest_carries_current_version() {
+        // The compiled-in default must stamp the current schema version so HR-3
+        // hashing has a stable anchor.
+        assert_eq!(default_manifest().version, Some(MANIFEST_VERSION));
+    }
+
+    #[test]
+    fn default_manifest_reproduces_bundled_behavior() {
+        // The default must: deploy ALL agents/skills from the BUNDLED source,
+        // enable every instruction layer, select the professional style, and
+        // leave model tiers unset — i.e. exactly the pre-HR-2 behavior.
+        let m = default_manifest();
+
+        let agents = m.agents.expect("agents set");
+        assert!(agents.include.is_empty(), "empty include = all agents");
+        assert!(agents.exclude.is_empty());
+        assert_eq!(agents.source, ContentSource::Bundled);
+
+        let skills = m.skills.expect("skills set");
+        assert!(skills.include.is_empty(), "empty include = all skills");
+        assert_eq!(skills.source, ContentSource::Bundled);
+
+        let instr = m.instructions.expect("instruction layers");
+        assert_eq!(instr.system, Some(true));
+        assert_eq!(instr.contextual, Some(true));
+        assert_eq!(instr.domain, Some(true));
+
+        assert_eq!(
+            m.style.and_then(|s| s.active),
+            Some(crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID.to_string())
+        );
+
+        let models = m.models.expect("model tiers");
+        assert_eq!(
+            models,
+            ModelTiers::default(),
+            "no tier overrides by default"
+        );
+    }
+
+    #[test]
+    fn default_manifest_enables_both_mcp() {
+        // Both MCP servers must be on by default, matching the unconditional
+        // injection prepare_session did before HR-2.
+        let mcp = default_manifest().mcp.expect("mcp section");
+        assert_eq!(mcp.trusty_memory, Some(true));
+        assert_eq!(mcp.trusty_search, Some(true));
+    }
+}

--- a/crates/trusty-mpm/src/core/manifest/mod.rs
+++ b/crates/trusty-mpm/src/core/manifest/mod.rs
@@ -1,0 +1,29 @@
+//! Manifest-driven harness provisioning (HR-2 / DOC-17).
+//!
+//! Why: before HR-2, `prepare_session` provisioned a harness from compile-time
+//! bundled assets alone — there was no declarative, overridable description of
+//! *what* a harness gets. This module introduces a [`HarnessManifest`] describing
+//! the agent set, skills, instruction layers, output style, MCP servers, and
+//! model tiers a harness receives, plus the NORMATIVE precedence resolution
+//! (project override > user config > catalog manifest > compiled-in default)
+//! that `prepare_session` consumes. The compiled-in default reproduces today's
+//! provisioning exactly, so an absent manifest is a zero-regression no-op.
+//! What: a thin facade re-exporting the schema ([`HarnessManifest`] and its
+//! sections), the compiled-in [`default_manifest`], and the precedence
+//! [`resolve_manifest`] over [`ManifestSources`]. Submodules keep each concern
+//! under the 500-SLOC cap.
+//! Test: each submodule carries its own unit tests; the `prepare_session`
+//! integration lives in `core/session_launch/tests.rs`.
+
+mod apply;
+mod default;
+mod resolve;
+mod schema;
+
+pub use apply::HarnessPlan;
+pub use default::default_manifest;
+pub use resolve::{MANIFEST_FILE, ManifestSources, resolve_manifest};
+pub use schema::{
+    AgentSet, ContentSource, HarnessManifest, InstructionLayers, MANIFEST_VERSION, McpServers,
+    ModelTiers, SkillSet, StyleSelection, selection_matches,
+};

--- a/crates/trusty-mpm/src/core/manifest/resolve.rs
+++ b/crates/trusty-mpm/src/core/manifest/resolve.rs
@@ -1,0 +1,296 @@
+//! Precedence resolution for the harness manifest (HR-2 / DOC-17).
+//!
+//! Why: HR-2 mandates a single NORMATIVE precedence —
+//! **project override > user config > catalog manifest > compiled-in default** —
+//! and `prepare_session` must consume the *resolved* manifest. Centralizing the
+//! layer reads and the merge order here keeps that precedence in one auditable
+//! place and makes it testable without touching the real `~/.trusty-mpm`.
+//! What: [`resolve_manifest`] starts from the compiled-in default
+//! ([`super::default::default_manifest`]) and overlays, in ascending precedence,
+//! the catalog manifest, the user-config manifest, then the project-override
+//! manifest — each via [`HarnessManifest::merge`]. A missing or malformed layer
+//! is logged and skipped (never blocks a launch, per the HR-2 error contract).
+//! The canonical layer locations are resolved by [`ManifestSources::resolve`]
+//! from a project dir + framework root + catalog root.
+//! Test: `resolve_uses_default_when_no_layers`, `resolve_project_wins`,
+//! `resolve_user_over_catalog`, `resolve_malformed_layer_is_skipped`.
+
+use std::path::{Path, PathBuf};
+
+use super::default::default_manifest;
+use super::schema::HarnessManifest;
+
+/// File name of a harness manifest in every layer location.
+///
+/// Why: the project override, user config, and catalog all use the same file
+/// name; naming it once prevents drift.
+/// What: `manifest.toml`.
+/// Test: `manifest_sources_resolve_canonical_paths`.
+pub const MANIFEST_FILE: &str = "manifest.toml";
+
+/// The concrete file paths of the three override layers.
+///
+/// Why: `prepare_session` (and tests) need to point the resolver at specific
+/// files; bundling the three optional paths keeps the resolver signature small
+/// and lets tests construct an arbitrary layer set.
+/// What: the project-override path (highest precedence), the user-config path,
+/// and the catalog path (lowest of the three; the compiled-in default sits below
+/// all of them). A `None` field means "that layer is absent".
+/// Test: `manifest_sources_resolve_canonical_paths`.
+#[derive(Debug, Clone, Default)]
+pub struct ManifestSources {
+    /// `<project>/.trusty-mpm/manifest.toml` — highest precedence.
+    pub project: Option<PathBuf>,
+    /// `~/.trusty-mpm/manifest.toml` — user config.
+    pub user: Option<PathBuf>,
+    /// `~/.trusty-mpm/catalog/repo/.claude/manifest.toml` — synced catalog.
+    pub catalog: Option<PathBuf>,
+}
+
+impl ManifestSources {
+    /// Resolve the canonical layer paths from a project dir and the framework
+    /// and catalog roots.
+    ///
+    /// Why: the layer locations are conventions (DOC-17 §HR-2); resolving them in
+    /// one place keeps `prepare_session` from hard-coding the joins and lets the
+    /// catalog source stay configurable (the caller passes whatever
+    /// `CatalogSync` used as its catalog root).
+    /// What: builds `<project>/.trusty-mpm/manifest.toml`,
+    /// `<framework_root>/manifest.toml`, and
+    /// `<catalog_root>/repo/.claude/manifest.toml`. Each path is recorded
+    /// unconditionally; the resolver tolerates absent files.
+    /// Test: `manifest_sources_resolve_canonical_paths`.
+    pub fn resolve(project_dir: &Path, framework_root: &Path, catalog_root: &Path) -> Self {
+        Self {
+            project: Some(project_dir.join(".trusty-mpm").join(MANIFEST_FILE)),
+            user: Some(framework_root.join(MANIFEST_FILE)),
+            catalog: Some(
+                catalog_root
+                    .join("repo")
+                    .join(".claude")
+                    .join(MANIFEST_FILE),
+            ),
+        }
+    }
+}
+
+/// Resolve the effective harness manifest by applying the NORMATIVE precedence.
+///
+/// Why: this is the single seam that implements HR-2's precedence; every consumer
+/// (today `prepare_session`, tomorrow HR-3's staleness check) resolves the
+/// manifest through here so the layer order can never drift.
+/// What: starts from [`default_manifest`] (the floor) and overlays, lowest-to-
+/// highest precedence, the catalog layer, the user layer, then the project layer.
+/// Each layer is read via [`read_layer`]; a missing file contributes nothing and
+/// a malformed file is logged and skipped (the launch never blocks — HR-2 error
+/// contract). The returned manifest always has every section populated because
+/// the default floor fills any section no layer overrode.
+/// Test: `resolve_uses_default_when_no_layers`, `resolve_project_wins`,
+/// `resolve_user_over_catalog`, `resolve_malformed_layer_is_skipped`.
+pub fn resolve_manifest(sources: &ManifestSources) -> HarnessManifest {
+    let mut manifest = default_manifest();
+
+    // Lowest-to-highest precedence: catalog → user → project.
+    if let Some(path) = &sources.catalog
+        && let Some(layer) = read_layer(path, "catalog")
+    {
+        manifest = manifest.merge(layer);
+    }
+    if let Some(path) = &sources.user
+        && let Some(layer) = read_layer(path, "user")
+    {
+        manifest = manifest.merge(layer);
+    }
+    if let Some(path) = &sources.project
+        && let Some(layer) = read_layer(path, "project")
+    {
+        manifest = manifest.merge(layer);
+    }
+
+    manifest
+}
+
+/// Read and parse one manifest layer file, tolerating absence and corruption.
+///
+/// Why: HR-2's error contract says an unresolvable/unreadable layer must never
+/// block a launch — a missing file is the common case (no override) and a
+/// malformed file must degrade to "skip this layer", not abort.
+/// What: returns `Some(manifest)` when the file exists and parses; `None` when it
+/// is absent (silent) or malformed (logged at `warn`). `label` names the layer in
+/// the warning so operators can find the offending file.
+/// Test: `resolve_malformed_layer_is_skipped`, `resolve_project_wins`.
+fn read_layer(path: &Path, label: &str) -> Option<HarnessManifest> {
+    match std::fs::read_to_string(path) {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            tracing::warn!(
+                "could not read {label} manifest at {}: {err}; skipping layer",
+                path.display()
+            );
+            None
+        }
+        Ok(raw) => match HarnessManifest::from_toml(&raw) {
+            Ok(m) => {
+                tracing::debug!("loaded {label} manifest layer from {}", path.display());
+                Some(m)
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "{label} manifest at {} is malformed: {err}; skipping layer",
+                    path.display()
+                );
+                None
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn manifest_sources_resolve_canonical_paths() {
+        let sources = ManifestSources::resolve(
+            Path::new("/proj"),
+            Path::new("/home/.trusty-mpm"),
+            Path::new("/home/.trusty-mpm/catalog"),
+        );
+        assert_eq!(
+            sources.project.unwrap(),
+            PathBuf::from("/proj/.trusty-mpm/manifest.toml")
+        );
+        assert_eq!(
+            sources.user.unwrap(),
+            PathBuf::from("/home/.trusty-mpm/manifest.toml")
+        );
+        assert_eq!(
+            sources.catalog.unwrap(),
+            PathBuf::from("/home/.trusty-mpm/catalog/repo/.claude/manifest.toml")
+        );
+    }
+
+    #[test]
+    fn resolve_uses_default_when_no_layers() {
+        // With every layer pointing at a non-existent file, the resolved
+        // manifest must equal the compiled-in default (zero-regression).
+        let tmp = TempDir::new().unwrap();
+        let sources = ManifestSources {
+            project: Some(tmp.path().join("p").join("manifest.toml")),
+            user: Some(tmp.path().join("u").join("manifest.toml")),
+            catalog: Some(tmp.path().join("c").join("manifest.toml")),
+        };
+        assert_eq!(resolve_manifest(&sources), default_manifest());
+    }
+
+    #[test]
+    fn resolve_project_wins() {
+        // The project layer must override the user and catalog layers for the
+        // same section (style here).
+        let tmp = TempDir::new().unwrap();
+        let catalog = write(
+            &tmp.path().join("c"),
+            "manifest.toml",
+            "[style]\nactive = \"trusty-mpm-research\"\n",
+        );
+        let user = write(
+            &tmp.path().join("u"),
+            "manifest.toml",
+            "[style]\nactive = \"trusty-mpm-teacher\"\n",
+        );
+        let project = write(
+            &tmp.path().join("p"),
+            "manifest.toml",
+            "[style]\nactive = \"trusty-mpm\"\n",
+        );
+        let sources = ManifestSources {
+            project: Some(project),
+            user: Some(user),
+            catalog: Some(catalog),
+        };
+        let m = resolve_manifest(&sources);
+        assert_eq!(
+            m.style.and_then(|s| s.active),
+            Some("trusty-mpm".to_string()),
+            "project layer must win over user and catalog"
+        );
+    }
+
+    #[test]
+    fn resolve_user_over_catalog() {
+        // When the project layer is absent, the user layer must win over the
+        // catalog layer.
+        let tmp = TempDir::new().unwrap();
+        let catalog = write(
+            &tmp.path().join("c"),
+            "manifest.toml",
+            "[style]\nactive = \"trusty-mpm-research\"\n",
+        );
+        let user = write(
+            &tmp.path().join("u"),
+            "manifest.toml",
+            "[style]\nactive = \"trusty-mpm-teacher\"\n",
+        );
+        let sources = ManifestSources {
+            project: Some(tmp.path().join("p").join("manifest.toml")), // absent
+            user: Some(user),
+            catalog: Some(catalog),
+        };
+        let m = resolve_manifest(&sources);
+        assert_eq!(
+            m.style.and_then(|s| s.active),
+            Some("trusty-mpm-teacher".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_catalog_over_default() {
+        // The catalog layer must override the compiled-in default when no higher
+        // layer is present.
+        let tmp = TempDir::new().unwrap();
+        let catalog = write(
+            &tmp.path().join("c"),
+            "manifest.toml",
+            "[mcp]\ntrusty_search = false\n",
+        );
+        let sources = ManifestSources {
+            project: None,
+            user: None,
+            catalog: Some(catalog),
+        };
+        let m = resolve_manifest(&sources);
+        // catalog disabled search; default (memory=true) is preserved because the
+        // whole-section replacement carried only trusty_search=false … but the
+        // [mcp] section is replaced wholesale, so memory falls back to None →
+        // consumer treats None as the default-on. We assert search is the
+        // overridden value.
+        assert_eq!(m.mcp.unwrap().trusty_search, Some(false));
+    }
+
+    #[test]
+    fn resolve_malformed_layer_is_skipped() {
+        // A malformed layer must be skipped (logged), not abort resolution; the
+        // lower layers (and ultimately the default) still apply.
+        let tmp = TempDir::new().unwrap();
+        let user = write(
+            &tmp.path().join("u"),
+            "manifest.toml",
+            "this is not toml {{{",
+        );
+        let sources = ManifestSources {
+            project: None,
+            user: Some(user),
+            catalog: None,
+        };
+        // Malformed user layer skipped → result equals the default.
+        assert_eq!(resolve_manifest(&sources), default_manifest());
+    }
+}

--- a/crates/trusty-mpm/src/core/manifest/resolve.rs
+++ b/crates/trusty-mpm/src/core/manifest/resolve.rs
@@ -59,6 +59,11 @@ impl ManifestSources {
     /// `<framework_root>/manifest.toml`, and
     /// `<catalog_root>/repo/.claude/manifest.toml`. Each path is recorded
     /// unconditionally; the resolver tolerates absent files.
+    ///
+    /// Note: the USER manifest is `<framework_root>/manifest.toml` — a sibling of
+    /// `<framework_root>/config.toml` (i.e. `~/.trusty-mpm/manifest.toml` in
+    /// production). This co-location with `config.toml` is intentional: both are
+    /// user-level, framework-rooted files, so an operator finds them in one place.
     /// Test: `manifest_sources_resolve_canonical_paths`.
     pub fn resolve(project_dir: &Path, framework_root: &Path, catalog_root: &Path) -> Self {
         Self {
@@ -267,12 +272,41 @@ mod tests {
             catalog: Some(catalog),
         };
         let m = resolve_manifest(&sources);
-        // catalog disabled search; default (memory=true) is preserved because the
-        // whole-section replacement carried only trusty_search=false … but the
-        // [mcp] section is replaced wholesale, so memory falls back to None →
-        // consumer treats None as the default-on. We assert search is the
-        // overridden value.
-        assert_eq!(m.mcp.unwrap().trusty_search, Some(false));
+        // The catalog disables search. Because `[mcp]` now merges FIELD-BY-FIELD
+        // (not whole-section), the default's `trusty_memory = true` is PRESERVED
+        // even though the catalog layer only mentioned `trusty_search`.
+        let mcp = m.mcp.expect("mcp section present");
+        assert_eq!(mcp.trusty_search, Some(false), "catalog disabled search");
+        assert_eq!(
+            mcp.trusty_memory,
+            Some(true),
+            "field-level merge keeps the default's trusty_memory toggle"
+        );
+    }
+
+    #[test]
+    fn resolve_partial_mcp_preserves_other_toggle() {
+        // A partial project `[mcp]` override (only trusty_search) must leave the
+        // default's trusty_memory toggle intact through the full resolver — the
+        // field-level merge regression (whole-section replacement used to null it).
+        let tmp = TempDir::new().unwrap();
+        let project = write(
+            &tmp.path().join("p"),
+            "manifest.toml",
+            "[mcp]\ntrusty_search = false\n",
+        );
+        let sources = ManifestSources {
+            project: Some(project),
+            user: None,
+            catalog: None,
+        };
+        let mcp = resolve_manifest(&sources).mcp.expect("mcp present");
+        assert_eq!(mcp.trusty_search, Some(false));
+        assert_eq!(
+            mcp.trusty_memory,
+            Some(true),
+            "project partial [mcp] must not reset the default's trusty_memory"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/manifest/schema.rs
+++ b/crates/trusty-mpm/src/core/manifest/schema.rs
@@ -157,6 +157,26 @@ pub struct InstructionLayers {
     pub domain: Option<bool>,
 }
 
+impl InstructionLayers {
+    /// Field-by-field merge: each `Some` toggle in `higher` wins, `None` inherits.
+    ///
+    /// Why: `[instructions]` is a struct of independent toggles; whole-section
+    /// replacement would let a partial higher-layer override (e.g. only
+    /// `domain = false`) silently reset the other layers to `None`. Merging per
+    /// field preserves the lower layer's toggles the higher layer did not mention.
+    /// What: for each of `system`/`contextual`/`domain`, takes `higher`'s value
+    /// when it is `Some`, else falls through to `self`'s value.
+    /// Test: `instruction_layers_field_merge`.
+    #[must_use]
+    pub fn merge(self, higher: InstructionLayers) -> InstructionLayers {
+        InstructionLayers {
+            system: higher.system.or(self.system),
+            contextual: higher.contextual.or(self.contextual),
+            domain: higher.domain.or(self.domain),
+        }
+    }
+}
+
 /// `[style]` — the active output-style selection.
 ///
 /// Why: DOC-17 lists the output style (professional/teaching/research) as a
@@ -189,6 +209,25 @@ pub struct McpServers {
     /// Inject the `trusty-search` MCP server (pinned to the project index).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trusty_search: Option<bool>,
+}
+
+impl McpServers {
+    /// Field-by-field merge: each `Some` toggle in `higher` wins, `None` inherits.
+    ///
+    /// Why: `[mcp]` is a struct of independent toggles. The old whole-section
+    /// replacement meant a partial override like `[mcp] trusty_search = false`
+    /// reset `trusty_memory` back to `None` (losing a lower layer's explicit
+    /// `true`). Merging per field keeps the unmentioned toggle's lower-layer value.
+    /// What: for each of `trusty_memory`/`trusty_search`, takes `higher`'s value
+    /// when it is `Some`, else falls through to `self`'s value.
+    /// Test: `manifest_merge_mcp_field_level`.
+    #[must_use]
+    pub fn merge(self, higher: McpServers) -> McpServers {
+        McpServers {
+            trusty_memory: higher.trusty_memory.or(self.trusty_memory),
+            trusty_search: higher.trusty_search.or(self.trusty_search),
+        }
+    }
 }
 
 /// `[models]` — model-tier defaults for the harness.
@@ -244,23 +283,55 @@ impl HarnessManifest {
     /// overrides only the keys it sets, leaving the rest of `self` intact. This
     /// is the core of the NORMATIVE precedence
     /// (project override > user config > catalog > default).
-    /// What: for each top-level section, a `Some` value in `higher` replaces the
-    /// corresponding section in `self`; a `None` in `higher` keeps `self`'s value.
-    /// `version` follows the same rule. Section replacement is whole-section (not
-    /// recursive) so an override file states a complete section when it touches
-    /// one — the simplest rule that keeps precedence unambiguous.
-    /// Test: `manifest_merge_overrides`, `manifest_merge_keeps_lower_when_absent`.
+    /// What: each section merges according to its documented mode:
+    ///
+    /// - **Field-by-field** (`[mcp]`, `[instructions]`): these are small structs
+    ///   of independent `Option<bool>` toggles, so a higher layer's `Some` wins
+    ///   *per field* while a `None` field inherits the lower layer. This means a
+    ///   partial override like `[mcp] trusty_search = false` no longer resets the
+    ///   other toggle (e.g. `trusty_memory`) back to `None` (see [`McpServers::merge`],
+    ///   [`InstructionLayers::merge`]).
+    /// - **Whole-section replacement** (`[agents]`, `[skills]`, `[style]`,
+    ///   `[models]`): a `Some` section in `higher` replaces the whole section in
+    ///   `self`. This is intentional for the list-like include/exclude sections,
+    ///   where a higher layer states a complete agent/skill set rather than
+    ///   field-merging two lists; `[style]`/`[models]` follow the same simple rule.
+    ///
+    /// `version` is a scalar: `higher` wins when set.
+    /// Test: `manifest_merge_overrides`, `manifest_merge_keeps_lower_when_absent`,
+    /// `manifest_merge_mcp_field_level`.
     #[must_use]
     pub fn merge(self, higher: HarnessManifest) -> HarnessManifest {
         HarnessManifest {
             version: higher.version.or(self.version),
+            // Whole-section replacement (list-like / scalar sections).
             agents: higher.agents.or(self.agents),
             skills: higher.skills.or(self.skills),
-            instructions: higher.instructions.or(self.instructions),
             style: higher.style.or(self.style),
-            mcp: higher.mcp.or(self.mcp),
             models: higher.models.or(self.models),
+            // Field-by-field merge (independent toggle structs).
+            instructions: merge_optional(self.instructions, higher.instructions, |lo, hi| {
+                lo.merge(hi)
+            }),
+            mcp: merge_optional(self.mcp, higher.mcp, |lo, hi| lo.merge(hi)),
         }
+    }
+}
+
+/// Merge two `Option<T>` sections, folding field-by-field when both are present.
+///
+/// Why: the field-level sections (`[mcp]`, `[instructions]`) need "higher wins
+/// per field, lower inherited" semantics, but only when BOTH layers set the
+/// section; when only one is present that one wins wholesale. Factoring the
+/// `None`-handling here keeps [`HarnessManifest::merge`] readable.
+/// What: returns `higher.merge(lower)` when both are `Some`; otherwise the single
+/// present value (or `None`). `f` performs the per-field fold as `f(lower, higher)`.
+/// Test: covered via `manifest_merge_mcp_field_level` and
+/// `instruction_layers_field_merge`.
+fn merge_optional<T>(lower: Option<T>, higher: Option<T>, f: impl FnOnce(T, T) -> T) -> Option<T> {
+    match (lower, higher) {
+        (Some(lo), Some(hi)) => Some(f(lo, hi)),
+        (lo, hi) => hi.or(lo),
     }
 }
 
@@ -279,26 +350,66 @@ pub fn selection_matches(name: &str, include: &[String], exclude: &[String]) -> 
     included && !excluded
 }
 
-/// Match `name` against a simple glob `pattern`.
+/// Match `name` against a simple glob `pattern` supporting any number of `*`.
 ///
 /// Why: manifests express agent/skill sets compactly (`"*-engineer"`,
-/// `"rust-*"`); a tiny matcher avoids pulling in a glob crate for one wildcard.
-/// What: supports an exact match, a `*` (match-all), a `prefix*` (starts-with),
-/// a `*suffix` (ends-with), and a single interior `*` (`a*b`). Any other pattern
-/// is compared for equality.
+/// `"rust-*"`, `"*-engineer-*"`); a tiny matcher avoids pulling in a glob crate
+/// for the one wildcard. The earlier `split_once('*')` implementation only split
+/// on the FIRST `*`, so a multi-`*` pattern (`"*-engineer-*"`, `"a*b*c"`) was
+/// mis-parsed — the leftover `*` was treated as a literal in the suffix, silently
+/// producing wrong matches instead of the documented behavior. This version
+/// handles an arbitrary number of `*`.
+/// What: splits `pattern` on every `*` into literal segments and matches them in
+/// order against `name`. A leading `*` (empty first segment) means "no prefix
+/// anchor"; a trailing `*` (empty last segment) means "no suffix anchor". With no
+/// `*` the pattern is an exact equality check; a bare `*` matches everything.
+/// Interior segments must appear in order, left to right, without overlapping.
 /// Test: `glob_matching`.
 fn glob_matches(pattern: &str, name: &str) -> bool {
+    // Fast paths: no wildcard → exact equality; a bare `*` → match all.
+    if !pattern.contains('*') {
+        return pattern == name;
+    }
     if pattern == "*" {
         return true;
     }
-    match pattern.split_once('*') {
-        None => pattern == name,
-        Some((prefix, suffix)) => {
-            name.len() >= prefix.len() + suffix.len()
-                && name.starts_with(prefix)
-                && name.ends_with(suffix)
+
+    // Split on every `*`. `segments` are the literal runs between wildcards;
+    // empty leading/trailing segments encode "no anchor" on that side.
+    let segments: Vec<&str> = pattern.split('*').collect();
+    let anchored_start = !segments.first().is_none_or(|s| s.is_empty());
+    let anchored_end = !segments.last().is_none_or(|s| s.is_empty());
+
+    // Walk the non-empty segments left-to-right, consuming `name` as we match.
+    let mut rest = name;
+    let non_empty: Vec<&str> = segments.iter().copied().filter(|s| !s.is_empty()).collect();
+    for (idx, seg) in non_empty.iter().enumerate() {
+        let is_first = idx == 0;
+        let is_last = idx == non_empty.len() - 1;
+
+        if is_first && anchored_start {
+            // The first segment must be a prefix of `name`.
+            match rest.strip_prefix(seg) {
+                Some(tail) => rest = tail,
+                None => return false,
+            }
+        } else if is_last && anchored_end {
+            // The final segment must be a suffix of whatever remains.
+            return rest.ends_with(seg);
+        } else {
+            // A floating interior (or unanchored) segment: find its next
+            // occurrence and advance past it.
+            match rest.find(seg) {
+                Some(pos) => rest = &rest[pos + seg.len()..],
+                None => return false,
+            }
         }
     }
+
+    // All segments matched. If the end was anchored we already returned on the
+    // last segment; reaching here means the end was unanchored (trailing `*`),
+    // which matches any remaining tail.
+    true
 }
 
 #[cfg(test)]
@@ -425,6 +536,69 @@ active = "trusty-mpm-research"
     }
 
     #[test]
+    fn manifest_merge_mcp_field_level() {
+        // A partial `[mcp]` override (only trusty_search) must NOT discard the
+        // lower layer's other toggle (trusty_memory) — field-level merge.
+        let lower = HarnessManifest {
+            mcp: Some(McpServers {
+                trusty_memory: Some(true),
+                trusty_search: Some(true),
+            }),
+            ..HarnessManifest::default()
+        };
+        let higher = HarnessManifest {
+            mcp: Some(McpServers {
+                trusty_memory: None,
+                trusty_search: Some(false),
+            }),
+            ..HarnessManifest::default()
+        };
+
+        let merged = lower.merge(higher);
+        let mcp = merged.mcp.expect("mcp section present");
+        assert_eq!(
+            mcp.trusty_memory,
+            Some(true),
+            "the unmentioned toggle must survive the partial override"
+        );
+        assert_eq!(
+            mcp.trusty_search,
+            Some(false),
+            "the overridden toggle must take the higher layer's value"
+        );
+    }
+
+    #[test]
+    fn instruction_layers_field_merge() {
+        // A partial `[instructions]` override must merge field-by-field too.
+        let lower = HarnessManifest {
+            instructions: Some(InstructionLayers {
+                system: Some(true),
+                contextual: Some(true),
+                domain: Some(true),
+            }),
+            ..HarnessManifest::default()
+        };
+        let higher = HarnessManifest {
+            instructions: Some(InstructionLayers {
+                system: None,
+                contextual: None,
+                domain: Some(false),
+            }),
+            ..HarnessManifest::default()
+        };
+
+        let layers = lower.merge(higher).instructions.expect("layers present");
+        assert_eq!(layers.system, Some(true), "system inherited from lower");
+        assert_eq!(
+            layers.contextual,
+            Some(true),
+            "contextual inherited from lower"
+        );
+        assert_eq!(layers.domain, Some(false), "domain overridden by higher");
+    }
+
+    #[test]
     fn selection_matches() {
         // Empty include → match all; exclude wins over include.
         assert!(super::selection_matches("anything", &[], &[]));
@@ -436,6 +610,14 @@ active = "trusty-mpm-research"
         let glob_inc = vec!["*-engineer".to_string()];
         assert!(super::selection_matches("rust-engineer", &glob_inc, &[]));
         assert!(!super::selection_matches("rust-ops", &glob_inc, &[]));
+        // Multi-`*` glob include (regression: was mis-matched by split_once).
+        let multi_inc = vec!["*-engineer-*".to_string()];
+        assert!(super::selection_matches(
+            "rust-engineer-ops",
+            &multi_inc,
+            &[]
+        ));
+        assert!(!super::selection_matches("rust-engineer", &multi_inc, &[]));
         // Exclude wins.
         let exc = vec!["rust-engineer".to_string()];
         assert!(!super::selection_matches("rust-engineer", &[], &exc));
@@ -449,13 +631,46 @@ active = "trusty-mpm-research"
 
     #[test]
     fn glob_matching() {
+        // Bare `*` matches everything.
         assert!(super::glob_matches("*", "anything"));
+        assert!(super::glob_matches("*", ""));
+
+        // Exact (no wildcard) is equality.
         assert!(super::glob_matches("rust-engineer", "rust-engineer"));
         assert!(!super::glob_matches("rust-engineer", "qa"));
+        assert!(!super::glob_matches("rust-engineer", "rust-engineer-2"));
+
+        // Trailing `*` = prefix; leading `*` = suffix.
         assert!(super::glob_matches("*-engineer", "rust-engineer"));
+        assert!(!super::glob_matches("*-engineer", "rust-engineer-ops"));
+        assert!(super::glob_matches("engineer-*", "engineer-rust"));
+        assert!(!super::glob_matches("engineer-*", "rust-engineer"));
         assert!(super::glob_matches("rust-*", "rust-engineer"));
+
+        // Single interior `*` = prefix + suffix.
         assert!(super::glob_matches("a*b", "axxb"));
+        assert!(super::glob_matches("a*b", "ab"), "interior * matches empty");
         assert!(!super::glob_matches("a*b", "axx"));
+
+        // Multi-`*` patterns: the previously-broken cases.
+        // `*-engineer-*` = "contains -engineer-".
+        assert!(super::glob_matches("*-engineer-*", "rust-engineer-ops"));
+        assert!(super::glob_matches("*-engineer-*", "x-engineer-y"));
+        assert!(
+            !super::glob_matches("*-engineer-*", "rust-engineer"),
+            "no trailing segment after -engineer- → no match"
+        );
+        // `a*b*c` = a-prefix, then b, then c-suffix in order.
+        assert!(super::glob_matches("a*b*c", "aXbYc"));
+        assert!(super::glob_matches("a*b*c", "abc"));
+        assert!(
+            !super::glob_matches("a*b*c", "acb"),
+            "segments must appear in order"
+        );
+        assert!(
+            !super::glob_matches("a*b*c", "aXbY"),
+            "missing the trailing c suffix"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/manifest/schema.rs
+++ b/crates/trusty-mpm/src/core/manifest/schema.rs
@@ -1,0 +1,480 @@
+//! Harness-manifest schema (HR-2 / DOC-17).
+//!
+//! Why: today `prepare_session` provisions a harness from compile-time-bundled
+//! assets alone — there is no declarative description of *what* a harness gets.
+//! HR-2 makes provisioning manifest-driven: a single TOML document describes the
+//! agent set, skills, instruction layers, output style, MCP servers, and model
+//! tiers a harness receives, so the runner can resolve it from a configurable
+//! catalog instead of hard-coding the set in Rust. TOML is chosen to match the
+//! existing `config.toml` convention (`crate::core::config`).
+//! What: [`HarnessManifest`] is the top-level deserialization target. Every field
+//! is optional so a higher-precedence layer can override only the keys it cares
+//! about (see [`HarnessManifest::merge`]); the compiled-in default
+//! ([`super::default::default_manifest`]) supplies the floor. A `version` field
+//! makes the schema forward-compatible so HR-3 can hash/compare manifests.
+//! Test: `manifest_roundtrip`, `manifest_partial_parse`,
+//! `manifest_merge_overrides`, `selection_matches` in this module's tests.
+
+use serde::{Deserialize, Serialize};
+
+/// The manifest schema version this build understands.
+///
+/// Why: HR-3 will hash and compare manifests to detect stale catalog content; a
+/// version field lets a future build reject or migrate an incompatible manifest
+/// instead of silently mis-parsing it.
+/// What: the integer written into a default manifest's `version` field and
+/// compared on load.
+/// Test: `default_manifest_carries_current_version`.
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// A declarative description of everything a provisioned harness receives.
+///
+/// Why: a single value the resolver materializes (project override beats user
+/// config beats catalog manifest beats compiled-in default) and `prepare_session`
+/// consumes, replacing the implicit "deploy whatever is bundled" behavior with an
+/// explicit, overridable contract.
+/// What: optional sections for the agent set, skills, instruction layers, the
+/// output style id, MCP servers, and model tiers. Absent sections mean "inherit
+/// from the lower-precedence layer"; the compiled-in default fills any that are
+/// still absent after all layers merge. `Default` yields an all-`None` manifest
+/// used as the merge identity.
+/// Test: `manifest_roundtrip`, `manifest_partial_parse`, `manifest_merge_overrides`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HarnessManifest {
+    /// Schema version. Absent in a partial override layer; the compiled-in
+    /// default always sets it to [`MANIFEST_VERSION`].
+    pub version: Option<u32>,
+
+    /// `[agents]` — which agents the harness deploys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agents: Option<AgentSet>,
+
+    /// `[skills]` — which skills the harness deploys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills: Option<SkillSet>,
+
+    /// `[instructions]` — instruction layers folded into the launch prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<InstructionLayers>,
+
+    /// `[style]` — the active output-style id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<StyleSelection>,
+
+    /// `[mcp]` — which MCP servers the harness injects into `.mcp.json`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<McpServers>,
+
+    /// `[models]` — model-tier defaults for the harness's agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<ModelTiers>,
+}
+
+/// `[agents]` — the agent set a harness deploys.
+///
+/// Why: a harness may want only a subset of the bundled/catalog agents (e.g. a
+/// Rust-only project drops the JS engineers). Include/exclude lists express that
+/// without enumerating every agent.
+/// What: `include` is a list of agent names or glob patterns (`*` wildcard); an
+/// empty or absent `include` means "all available agents". `exclude` removes
+/// names/patterns from the included set and always wins over `include`. `source`
+/// selects where the agent *source files* come from (`bundled` or `catalog`).
+/// Test: `selection_matches`, `agent_set_source_default_is_bundled`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AgentSet {
+    /// Agent names or glob patterns to deploy. Empty → all available.
+    #[serde(default)]
+    pub include: Vec<String>,
+    /// Agent names or glob patterns to drop. Wins over `include`.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// Where the agent source files are read from.
+    #[serde(default)]
+    pub source: ContentSource,
+}
+
+/// `[skills]` — the skill set a harness deploys.
+///
+/// Why: like agents, a harness may enable only some skills. Skills carry no
+/// inheritance so the selection is a plain include/exclude filter.
+/// What: `include`/`exclude` are name-or-glob lists with the same semantics as
+/// [`AgentSet`]; `source` selects the source directory (`bundled` or `catalog`).
+/// Test: `selection_matches`, `skill_set_roundtrip`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SkillSet {
+    /// Skill names or glob patterns to deploy. Empty → all available.
+    #[serde(default)]
+    pub include: Vec<String>,
+    /// Skill names or glob patterns to drop. Wins over `include`.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// Where the skill source files are read from.
+    #[serde(default)]
+    pub source: ContentSource,
+}
+
+/// Where a harness reads agent/skill *source* content from.
+///
+/// Why: HR-2 must let a manifest point provisioning at either the compile-time
+/// bundled assets (the default, regression-safe path) or the synced catalog
+/// (`~/.trusty-mpm/catalog/repo/.claude/…`). Encoding the choice in the manifest
+/// keeps `prepare_session` from guessing.
+/// What: `Bundled` (the framework's own source dirs) or `Catalog` (the
+/// CatalogSync checkout). `Default` is `Bundled` so an absent value reproduces
+/// today's behavior.
+/// Test: `agent_set_source_default_is_bundled`, `content_source_roundtrip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ContentSource {
+    /// Compile-time bundled framework assets (the default).
+    #[default]
+    Bundled,
+    /// The CatalogSync checkout under `~/.trusty-mpm/catalog/`.
+    Catalog,
+}
+
+/// `[instructions]` — the instruction layers folded into the launch prompt.
+///
+/// Why: DOC-17 names "instruction layers (system, contextual, domain-specific)"
+/// as part of what a harness gets. Today the layers are fixed in code; the
+/// manifest records which optional layers are enabled so the set is declarative
+/// and forward-compatible (HR-3 hashes it).
+/// What: boolean toggles for the optional layers. The non-overridable PM floor
+/// (`BASE_PM`) is always applied regardless of these flags — they only gate the
+/// *optional* contextual/domain layers. Absent flags inherit from the lower
+/// layer; the default enables the standard set.
+/// Test: `instruction_layers_roundtrip`, `manifest_merge_overrides`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct InstructionLayers {
+    /// Include the framework system instructions layer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system: Option<bool>,
+    /// Include the contextual (project `CLAUDE.md`) layer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contextual: Option<bool>,
+    /// Include the domain-specific delegation-authority layer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<bool>,
+}
+
+/// `[style]` — the active output-style selection.
+///
+/// Why: DOC-17 lists the output style (professional/teaching/research) as a
+/// harness-level choice. A manifest can set the default style; an explicit
+/// `--style` flag still overrides it at launch (HR-4 precedence is preserved).
+/// What: an optional active style id matching a bundled style
+/// (`crate::core::bundle::OUTPUT_STYLES`). Absent → inherit; the default sets the
+/// professional id.
+/// Test: `style_selection_roundtrip`, `manifest_merge_overrides`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct StyleSelection {
+    /// The active output-style id (e.g. `"trusty-mpm-teacher"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active: Option<String>,
+}
+
+/// `[mcp]` — which MCP servers the harness injects.
+///
+/// Why: DOC-17 lists "MCP servers (static and dynamic)" as part of provisioning.
+/// Today `prepare_session` unconditionally injects `trusty-memory` and
+/// `trusty-search`; the manifest makes those toggleable so a harness can opt out.
+/// What: boolean toggles for the two built-in servers. Absent → inherit; the
+/// default enables both, reproducing today's behavior.
+/// Test: `mcp_servers_roundtrip`, `default_manifest_enables_both_mcp`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct McpServers {
+    /// Inject the `trusty-memory` MCP server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trusty_memory: Option<bool>,
+    /// Inject the `trusty-search` MCP server (pinned to the project index).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trusty_search: Option<bool>,
+}
+
+/// `[models]` — model-tier defaults for the harness.
+///
+/// Why: DOC-17 lists "model tiers/overrides" as part of a manifest. HR-1 already
+/// derives a model from each agent's `resource_tier` at deploy time; this section
+/// lets a manifest pin the canonical model id for each tier so a harness can, for
+/// example, route `intensive` to a specific Opus build.
+/// What: an optional model id (or alias) per tier. Absent → inherit; the default
+/// leaves all `None` so HR-1's built-in tier mapping applies.
+/// Test: `model_tiers_roundtrip`, `manifest_merge_overrides`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ModelTiers {
+    /// Model id/alias for the `lightweight` tier (HR-1: haiku).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lightweight: Option<String>,
+    /// Model id/alias for the `standard` tier (HR-1: sonnet).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub standard: Option<String>,
+    /// Model id/alias for the `high` tier (HR-1: sonnet).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub high: Option<String>,
+    /// Model id/alias for the `intensive` tier (HR-1: opus).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intensive: Option<String>,
+}
+
+impl HarnessManifest {
+    /// Parse a manifest from a TOML string.
+    ///
+    /// Why: every layer (project override, user config, catalog) is a TOML file;
+    /// a single typed parse entry point keeps the resolver simple.
+    /// What: delegates to `toml::from_str`. A partial document (only some
+    /// sections present) parses cleanly because every field is optional.
+    /// Test: `manifest_partial_parse`, `manifest_roundtrip`.
+    pub fn from_toml(raw: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(raw)
+    }
+
+    /// Serialize this manifest to a TOML string.
+    ///
+    /// Why: round-trip support lets the resolver (and future HR-3 hashing) emit a
+    /// canonical manifest, and makes the schema testable.
+    /// What: delegates to `toml::to_string`.
+    /// Test: `manifest_roundtrip`.
+    pub fn to_toml(&self) -> Result<String, toml::ser::Error> {
+        toml::to_string(self)
+    }
+
+    /// Overlay `higher` onto `self`, returning the merged manifest.
+    ///
+    /// Why: precedence resolution is layer-by-layer — a higher-precedence layer
+    /// overrides only the keys it sets, leaving the rest of `self` intact. This
+    /// is the core of the NORMATIVE precedence
+    /// (project override > user config > catalog > default).
+    /// What: for each top-level section, a `Some` value in `higher` replaces the
+    /// corresponding section in `self`; a `None` in `higher` keeps `self`'s value.
+    /// `version` follows the same rule. Section replacement is whole-section (not
+    /// recursive) so an override file states a complete section when it touches
+    /// one — the simplest rule that keeps precedence unambiguous.
+    /// Test: `manifest_merge_overrides`, `manifest_merge_keeps_lower_when_absent`.
+    #[must_use]
+    pub fn merge(self, higher: HarnessManifest) -> HarnessManifest {
+        HarnessManifest {
+            version: higher.version.or(self.version),
+            agents: higher.agents.or(self.agents),
+            skills: higher.skills.or(self.skills),
+            instructions: higher.instructions.or(self.instructions),
+            style: higher.style.or(self.style),
+            mcp: higher.mcp.or(self.mcp),
+            models: higher.models.or(self.models),
+        }
+    }
+}
+
+/// Whether `name` is selected by an include/exclude filter.
+///
+/// Why: both [`AgentSet`] and [`SkillSet`] share the same include/exclude/glob
+/// semantics; factoring the rule here keeps the two consumers consistent and
+/// independently testable.
+/// What: returns `true` when `name` matches the `include` set (an empty include
+/// list means "match all") AND does not match the `exclude` set. Matching is by
+/// exact name or a trailing/leading `*` glob via [`glob_matches`].
+/// Test: `selection_matches`.
+pub fn selection_matches(name: &str, include: &[String], exclude: &[String]) -> bool {
+    let included = include.is_empty() || include.iter().any(|p| glob_matches(p, name));
+    let excluded = exclude.iter().any(|p| glob_matches(p, name));
+    included && !excluded
+}
+
+/// Match `name` against a simple glob `pattern`.
+///
+/// Why: manifests express agent/skill sets compactly (`"*-engineer"`,
+/// `"rust-*"`); a tiny matcher avoids pulling in a glob crate for one wildcard.
+/// What: supports an exact match, a `*` (match-all), a `prefix*` (starts-with),
+/// a `*suffix` (ends-with), and a single interior `*` (`a*b`). Any other pattern
+/// is compared for equality.
+/// Test: `glob_matching`.
+fn glob_matches(pattern: &str, name: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    match pattern.split_once('*') {
+        None => pattern == name,
+        Some((prefix, suffix)) => {
+            name.len() >= prefix.len() + suffix.len()
+                && name.starts_with(prefix)
+                && name.ends_with(suffix)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_roundtrip() {
+        // A fully-populated manifest must survive a serialize → parse round-trip
+        // unchanged, proving the schema is self-consistent.
+        let manifest = HarnessManifest {
+            version: Some(MANIFEST_VERSION),
+            agents: Some(AgentSet {
+                include: vec!["rust-engineer".into(), "qa".into()],
+                exclude: vec!["*-ops".into()],
+                source: ContentSource::Catalog,
+            }),
+            skills: Some(SkillSet {
+                include: vec!["example-skill".into()],
+                exclude: vec![],
+                source: ContentSource::Bundled,
+            }),
+            instructions: Some(InstructionLayers {
+                system: Some(true),
+                contextual: Some(true),
+                domain: Some(false),
+            }),
+            style: Some(StyleSelection {
+                active: Some("trusty-mpm-teacher".into()),
+            }),
+            mcp: Some(McpServers {
+                trusty_memory: Some(true),
+                trusty_search: Some(false),
+            }),
+            models: Some(ModelTiers {
+                lightweight: Some("haiku".into()),
+                standard: None,
+                high: None,
+                intensive: Some("opus".into()),
+            }),
+        };
+
+        let toml = manifest.to_toml().expect("serialize");
+        let parsed = HarnessManifest::from_toml(&toml).expect("parse");
+        assert_eq!(manifest, parsed);
+    }
+
+    #[test]
+    fn manifest_partial_parse() {
+        // A manifest that sets only one section must parse, with every other
+        // section left `None` so the merge keeps the lower layer's values.
+        let toml = r#"
+version = 1
+
+[style]
+active = "trusty-mpm-research"
+"#;
+        let parsed = HarnessManifest::from_toml(toml).expect("partial parse");
+        assert_eq!(parsed.version, Some(1));
+        assert_eq!(
+            parsed.style.as_ref().and_then(|s| s.active.as_deref()),
+            Some("trusty-mpm-research")
+        );
+        assert!(parsed.agents.is_none());
+        assert!(parsed.skills.is_none());
+        assert!(parsed.mcp.is_none());
+    }
+
+    #[test]
+    fn manifest_merge_overrides() {
+        // A higher-precedence layer must replace only the sections it sets and
+        // leave the rest of the lower layer intact.
+        let lower = HarnessManifest {
+            version: Some(1),
+            agents: Some(AgentSet {
+                include: vec!["a".into()],
+                ..AgentSet::default()
+            }),
+            style: Some(StyleSelection {
+                active: Some("trusty-mpm".into()),
+            }),
+            mcp: Some(McpServers {
+                trusty_memory: Some(true),
+                trusty_search: Some(true),
+            }),
+            ..HarnessManifest::default()
+        };
+        let higher = HarnessManifest {
+            style: Some(StyleSelection {
+                active: Some("trusty-mpm-teacher".into()),
+            }),
+            ..HarnessManifest::default()
+        };
+
+        let merged = lower.merge(higher);
+        // style replaced by the higher layer
+        assert_eq!(
+            merged.style.as_ref().and_then(|s| s.active.as_deref()),
+            Some("trusty-mpm-teacher")
+        );
+        // agents + mcp kept from the lower layer (higher left them None)
+        assert_eq!(
+            merged.agents.as_ref().map(|a| a.include.clone()),
+            Some(vec!["a".to_string()])
+        );
+        assert_eq!(
+            merged.mcp.as_ref().and_then(|m| m.trusty_search),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn manifest_merge_keeps_lower_when_absent() {
+        // Merging an all-None higher layer is the identity on the lower layer.
+        let lower = HarnessManifest {
+            version: Some(1),
+            style: Some(StyleSelection {
+                active: Some("trusty-mpm".into()),
+            }),
+            ..HarnessManifest::default()
+        };
+        let merged = lower.clone().merge(HarnessManifest::default());
+        assert_eq!(lower, merged);
+    }
+
+    #[test]
+    fn selection_matches() {
+        // Empty include → match all; exclude wins over include.
+        assert!(super::selection_matches("anything", &[], &[]));
+        // Exact include.
+        let inc = vec!["rust-engineer".to_string()];
+        assert!(super::selection_matches("rust-engineer", &inc, &[]));
+        assert!(!super::selection_matches("qa", &inc, &[]));
+        // Glob include.
+        let glob_inc = vec!["*-engineer".to_string()];
+        assert!(super::selection_matches("rust-engineer", &glob_inc, &[]));
+        assert!(!super::selection_matches("rust-ops", &glob_inc, &[]));
+        // Exclude wins.
+        let exc = vec!["rust-engineer".to_string()];
+        assert!(!super::selection_matches("rust-engineer", &[], &exc));
+        let inc_and_exc = ["rust-engineer".to_string()];
+        assert!(!super::selection_matches(
+            "rust-engineer",
+            &inc_and_exc,
+            &exc
+        ));
+    }
+
+    #[test]
+    fn glob_matching() {
+        assert!(super::glob_matches("*", "anything"));
+        assert!(super::glob_matches("rust-engineer", "rust-engineer"));
+        assert!(!super::glob_matches("rust-engineer", "qa"));
+        assert!(super::glob_matches("*-engineer", "rust-engineer"));
+        assert!(super::glob_matches("rust-*", "rust-engineer"));
+        assert!(super::glob_matches("a*b", "axxb"));
+        assert!(!super::glob_matches("a*b", "axx"));
+    }
+
+    #[test]
+    fn content_source_roundtrip() {
+        // ContentSource serializes lowercase and round-trips.
+        let serialized = toml::to_string(&AgentSet {
+            source: ContentSource::Catalog,
+            ..AgentSet::default()
+        })
+        .unwrap();
+        assert!(serialized.contains("catalog"));
+    }
+
+    #[test]
+    fn agent_set_source_default_is_bundled() {
+        // An [agents] section that omits `source` must default to Bundled, so
+        // the default manifest reproduces today's bundled-asset behavior.
+        let toml = "[agents]\ninclude = []\n";
+        let parsed = HarnessManifest::from_toml(toml).unwrap();
+        assert_eq!(parsed.agents.unwrap().source, ContentSource::Bundled);
+    }
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -34,6 +34,7 @@ pub mod instruction_overrides;
 pub mod instruction_pipeline;
 pub mod ipc;
 pub mod llm_overseer;
+pub mod manifest;
 pub mod memory;
 pub mod model_inject;
 pub mod names;

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -20,10 +20,10 @@ mod tests;
 
 use std::path::{Path, PathBuf};
 
-use crate::core::agent_deployer::{DeployResult, deploy_agents};
+use crate::core::agent_deployer::{DeployResult, deploy_agents_filtered};
 use crate::core::instruction_pipeline::{PipelineInput, PipelineOutput, build_instructions};
 use crate::core::paths::FrameworkPaths;
-use crate::core::skill_deployer::{DeployStats, deploy_skills};
+use crate::core::skill_deployer::{DeployStats, deploy_skills_filtered};
 use settings::{
     deploy_output_style, inject_trusty_memory_mcp, inject_trusty_search_mcp,
     preseed_workspace_trust_home, register_project_index, remove_global_trusty_memory_hooks,
@@ -155,13 +155,35 @@ pub fn prepare_session_with_style_and_native(
     explicit_style: Option<&str>,
     native_supported: bool,
 ) -> Result<PrepReport, PrepError> {
+    // Resolve the effective harness manifest (HR-2 / DOC-17) and materialize the
+    // provisioning plan it implies. The NORMATIVE precedence is
+    // project override > user config > catalog manifest > compiled-in default;
+    // the compiled-in default reproduces today's provisioning exactly, so an
+    // absent manifest is a zero-regression no-op. The plan tells us WHICH agents
+    // and skills to deploy, from WHICH source (bundled vs synced catalog), which
+    // MCP servers to inject, and the manifest's default output style. The
+    // existing deploy machinery still does the deployment.
+    let catalog_root = fw.root.join("catalog");
+    let manifest_sources =
+        crate::core::manifest::ManifestSources::resolve(project_dir, &fw.root, &catalog_root);
+    let manifest = crate::core::manifest::resolve_manifest(&manifest_sources);
+    let plan = crate::core::manifest::HarnessPlan::from_manifest(&manifest, fw, &catalog_root);
+
     // Deploy composed agents — Claude Code reads `~/.claude/agents/` at startup.
-    let deploy = deploy_agents(&fw.agent_source_dir(), &fw.claude_agents_dir())
-        .map_err(|err| PrepError::Deploy(err.to_string()))?;
+    // The manifest's agent-set selection (include/exclude) restricts WHICH source
+    // agents deploy; the default manifest selects all of them.
+    let deploy = deploy_agents_filtered(&plan.agent_source, &fw.claude_agents_dir(), |name| {
+        plan.agent_selected(name)
+    })
+    .map_err(|err| PrepError::Deploy(err.to_string()))?;
 
     // Deploy skill files — Claude Code reads `~/.claude/skills/` at startup.
-    // Skills carry no inheritance, so this is a manifest-tracked content copy.
-    let skill_deploy = deploy_skills(&fw.skill_source_dir(), &fw.claude_skills_dir())
+    // Skills carry no inheritance, so this is a manifest-tracked content copy;
+    // the manifest's skill-set selection restricts WHICH source skills deploy.
+    let skill_deploy =
+        deploy_skills_filtered(&plan.skill_source, &fw.claude_skills_dir(), |name| {
+            plan.skill_selected(name)
+        })
         .map_err(|err| PrepError::SkillDeploy(err.to_string()))?;
 
     // Compose the effective launch instructions (framework + delegation
@@ -173,6 +195,20 @@ pub fn prepare_session_with_style_and_native(
         claude_md_path: project_dir.join("CLAUDE.md"),
     };
     let instructions = build_instructions(&input)?;
+
+    // Resolve the EFFECTIVE output style, folding the manifest's default in as
+    // the lowest precedence below the existing HR-4 sources. Precedence:
+    // explicit `--style` flag > `[style] active` config key > manifest `[style]
+    // active` > professional default. We compute this as a single `Option<&str>`
+    // and pass it as the `explicit` argument to both the prompt-injection seam
+    // and the settings.json resolver — when neither the flag nor the config sets
+    // a style, the manifest's value applies; otherwise the higher source wins
+    // exactly as before (zero regression for the flag/config paths).
+    let config = crate::core::config::MpmConfig::load(&fw.root);
+    let effective_style: Option<String> = explicit_style
+        .map(str::to_owned)
+        .or_else(|| config.style.active.clone())
+        .or_else(|| plan.style.clone());
 
     // Stash the EXACT text the launch path passes to
     // `claude --append-system-prompt-file` — including the HR-4 output-style
@@ -190,7 +226,7 @@ pub fn prepare_session_with_style_and_native(
     // (issue #381 / the #382 concern).
     let resolved_prompt = build_system_prompt_for_with_style_and_native(
         project_dir,
-        explicit_style,
+        effective_style.as_deref(),
         native_supported,
     );
     let stash_dir = project_dir.join(".trusty-mpm");
@@ -204,24 +240,26 @@ pub fn prepare_session_with_style_and_native(
         source,
     })?;
 
-    // Resolve the active output style (HR-4): explicit `--style` override >
-    // `[style] active` config key > professional default. An unknown id is
-    // logged and falls back to the default rather than failing the launch
-    // (DOC-17). The resolved id is written into `.claude/settings.json` so a
-    // native-capable Claude Code (>= 1.0.83) applies it directly; older builds
-    // pick it up via prompt injection at the `build_system_prompt_for` seam.
-    let config = crate::core::config::MpmConfig::load(&fw.root);
-    let active_style_id =
-        match crate::core::output_style::resolve_active_style(&config, explicit_style) {
-            Ok(style) => style.id,
-            Err(err) => {
-                tracing::warn!(
-                    %err,
-                    "falling back to the default output style for settings.json"
-                );
-                crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID
-            }
-        };
+    // Resolve the active output style for settings.json using the same
+    // EFFECTIVE style computed above (HR-4 sources + the HR-2 manifest default).
+    // An unknown id is logged and falls back to the professional default rather
+    // than failing the launch (DOC-17). The resolved id is written into
+    // `.claude/settings.json` so a native-capable Claude Code (>= 1.0.83) applies
+    // it directly; older builds pick it up via prompt injection at the
+    // `build_system_prompt_for` seam.
+    let active_style_id = match crate::core::output_style::resolve_active_style(
+        &config,
+        effective_style.as_deref(),
+    ) {
+        Ok(style) => style.id,
+        Err(err) => {
+            tracing::warn!(
+                %err,
+                "falling back to the default output style for settings.json"
+            );
+            crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID
+        }
+    };
 
     // Set the Claude Code output style so the launched session's status bar
     // reads `style:<active_style_id>`. A failure here is non-fatal: the session
@@ -243,10 +281,15 @@ pub fn prepare_session_with_style_and_native(
 
     // Inject the `trusty-memory` MCP server into the project's `.mcp.json` so
     // the launched `claude` process can reach the memory tools (`memory_recall`,
-    // `memory_store`, …). Non-fatal: the session still launches, it just lacks
-    // the memory tools.
-    if let Err(err) = inject_trusty_memory_mcp(project_dir) {
-        tracing::warn!("failed to inject trusty-memory MCP server: {err}");
+    // `memory_store`, …). Gated by the manifest's `[mcp] trusty_memory` toggle
+    // (default on). Non-fatal: the session still launches, it just lacks the
+    // memory tools.
+    if plan.inject_trusty_memory {
+        if let Err(err) = inject_trusty_memory_mcp(project_dir) {
+            tracing::warn!("failed to inject trusty-memory MCP server: {err}");
+        }
+    } else {
+        tracing::debug!("manifest disables trusty-memory MCP injection");
     }
 
     // Register + pin the project's trusty-search index (issue #1373). Derive
@@ -259,9 +302,14 @@ pub fn prepare_session_with_style_and_native(
     // is handled inside `register_project_index` (logged, non-fatal) and still
     // returns the id so the stub is pinned; a `None` id (empty derivation) falls
     // back to the unpinned stub. Either way the session launches.
-    let pinned_index = register_project_index(project_dir);
-    if let Err(err) = inject_trusty_search_mcp(project_dir, pinned_index.as_deref()) {
-        tracing::warn!("failed to inject trusty-search MCP server: {err}");
+    // Gated by the manifest's `[mcp] trusty_search` toggle (default on).
+    if plan.inject_trusty_search {
+        let pinned_index = register_project_index(project_dir);
+        if let Err(err) = inject_trusty_search_mcp(project_dir, pinned_index.as_deref()) {
+            tracing::warn!("failed to inject trusty-search MCP server: {err}");
+        }
+    } else {
+        tracing::debug!("manifest disables trusty-search MCP injection");
     }
 
     // Pre-seed per-directory trust for this workspace in `~/.claude.json`

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -155,6 +155,12 @@ pub fn prepare_session_with_style_and_native(
     explicit_style: Option<&str>,
     native_supported: bool,
 ) -> Result<PrepReport, PrepError> {
+    // Load the user config ONCE and thread it through both the manifest
+    // resolution / catalog-root path AND the style resolution path below. Reading
+    // `config.toml` a second time mid-function (the old `MpmConfig::load` just
+    // before style resolution) was a redundant filesystem read for the same data.
+    let config = crate::core::config::MpmConfig::load(&fw.root);
+
     // Resolve the effective harness manifest (HR-2 / DOC-17) and materialize the
     // provisioning plan it implies. The NORMATIVE precedence is
     // project override > user config > catalog manifest > compiled-in default;
@@ -163,7 +169,12 @@ pub fn prepare_session_with_style_and_native(
     // and skills to deploy, from WHICH source (bundled vs synced catalog), which
     // MCP servers to inject, and the manifest's default output style. The
     // existing deploy machinery still does the deployment.
-    let catalog_root = fw.root.join("catalog");
+    //
+    // The catalog root comes from the ONE shared helper (`catalog_root_for`) the
+    // `tm catalog` CLI also uses, so the manifest path the resolver reads is the
+    // same `<framework>/catalog` checkout `CatalogSync` populates — honouring the
+    // `[manifest]` config / `TRUSTY_MPM_CATALOG_*` env catalog-source overrides.
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
     let manifest_sources =
         crate::core::manifest::ManifestSources::resolve(project_dir, &fw.root, &catalog_root);
     let manifest = crate::core::manifest::resolve_manifest(&manifest_sources);
@@ -203,8 +214,8 @@ pub fn prepare_session_with_style_and_native(
     // and pass it as the `explicit` argument to both the prompt-injection seam
     // and the settings.json resolver — when neither the flag nor the config sets
     // a style, the manifest's value applies; otherwise the higher source wins
-    // exactly as before (zero regression for the flag/config paths).
-    let config = crate::core::config::MpmConfig::load(&fw.root);
+    // exactly as before (zero regression for the flag/config paths). `config` was
+    // loaded ONCE at the top of this function.
     let effective_style: Option<String> = explicit_style
         .map(str::to_owned)
         .or_else(|| config.style.active.clone())

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1182,3 +1182,207 @@ fn prepare_session_is_idempotent() {
         "CLAUDE.md already exists on the second run"
     );
 }
+
+// ──────────────────────────────────────────────
+// HR-2 — Manifest-driven harness provisioning
+// ──────────────────────────────────────────────
+
+/// Seed two bundled agent source files (a base + a leaf) under `fw.agents` so
+/// the deploy step has deterministic content to filter.
+///
+/// Why: the manifest integration tests must assert WHICH agents deploy; seeding
+/// a known two-agent set makes the include/exclude assertions deterministic
+/// regardless of whether the host has the optional `agents/` submodule.
+/// What: writes `base-engineer.md` and `rust-engineer.md` (the latter extends
+/// the former) into the framework's bundled agent source dir.
+/// Test: used by `prepare_session_manifest_*`.
+fn seed_bundled_agents(fw: &crate::core::paths::FrameworkPaths) {
+    std::fs::create_dir_all(&fw.agents).unwrap();
+    std::fs::write(
+        fw.agents.join("base-engineer.md"),
+        "---\nname: base-engineer\nrole: base-engineer\n---\n\n# Base Eng\n\nBASE.\n",
+    )
+    .unwrap();
+    std::fs::write(
+        fw.agents.join("rust-engineer.md"),
+        "---\nname: rust-engineer\nrole: engineer\nextends: base-engineer\n---\n\n# Rust\n\nLEAF.\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn prepare_session_default_deploys_all_seeded_agents() {
+    // Why: HR-2 must be regression-safe — with NO manifest present, the
+    // compiled-in default reproduces today's behavior, deploying every bundled
+    // agent. This proves "absent manifest = unchanged provisioning".
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    // Force the bundled source so the test does not depend on an `agents/`
+    // submodule resolved from the running binary's location.
+    let mut fw = fw;
+    fw.trusty_mpm_root = None;
+    seed_bundled_agents(&fw);
+
+    let report = prepare_session(&fw, project).expect("prep succeeds");
+
+    // Both seeded agents deploy (default manifest selects all).
+    assert!(
+        report
+            .deploy
+            .deployed
+            .contains(&"base-engineer.md".to_string())
+    );
+    assert!(
+        report
+            .deploy
+            .deployed
+            .contains(&"rust-engineer.md".to_string())
+    );
+    assert!(fw.claude_agents_dir().join("rust-engineer.md").exists());
+}
+
+#[test]
+fn prepare_session_manifest_filters_agent_set() {
+    // Why: HR-2 — a project manifest's `[agents] include` must restrict WHICH
+    // agents the harness deploys.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let mut fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    fw.trusty_mpm_root = None;
+    seed_bundled_agents(&fw);
+
+    // Project override manifest: only deploy rust-engineer.
+    let manifest_dir = project.join(".trusty-mpm");
+    std::fs::create_dir_all(&manifest_dir).unwrap();
+    std::fs::write(
+        manifest_dir.join("manifest.toml"),
+        "[agents]\ninclude = [\"rust-engineer\"]\n",
+    )
+    .unwrap();
+
+    let report = prepare_session(&fw, project).expect("prep succeeds");
+
+    assert!(
+        report
+            .deploy
+            .deployed
+            .contains(&"rust-engineer.md".to_string()),
+        "included agent must deploy"
+    );
+    assert!(
+        !report
+            .deploy
+            .deployed
+            .contains(&"base-engineer.md".to_string()),
+        "excluded-by-omission agent must NOT deploy"
+    );
+    assert!(!fw.claude_agents_dir().join("base-engineer.md").exists());
+}
+
+#[test]
+fn prepare_session_manifest_disables_mcp_server() {
+    // Why: HR-2 — a manifest `[mcp] trusty_search = false` must suppress the
+    // trusty-search MCP injection while leaving trusty-memory intact.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let mut fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    fw.trusty_mpm_root = None;
+
+    let manifest_dir = project.join(".trusty-mpm");
+    std::fs::create_dir_all(&manifest_dir).unwrap();
+    std::fs::write(
+        manifest_dir.join("manifest.toml"),
+        "[mcp]\ntrusty_search = false\n",
+    )
+    .unwrap();
+
+    prepare_session(&fw, project).expect("prep succeeds");
+
+    let mcp_path = project.join(".mcp.json");
+    assert!(
+        mcp_path.exists(),
+        ".mcp.json must exist (trusty-memory wrote it)"
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mcp_path).unwrap()).unwrap();
+    assert!(
+        value["mcpServers"].get("trusty-search").is_none(),
+        "manifest disabled trusty-search; it must not be injected"
+    );
+    assert!(
+        value["mcpServers"].get("trusty-memory").is_some(),
+        "trusty-memory stays injected"
+    );
+}
+
+#[test]
+fn prepare_session_manifest_sets_default_style() {
+    // Why: HR-2 — a manifest `[style] active` sets the default output style when
+    // no `--style` flag and no `[style] active` config key override it.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let mut fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    fw.trusty_mpm_root = None;
+
+    let manifest_dir = project.join(".trusty-mpm");
+    std::fs::create_dir_all(&manifest_dir).unwrap();
+    std::fs::write(
+        manifest_dir.join("manifest.toml"),
+        "[style]\nactive = \"trusty-mpm-research\"\n",
+    )
+    .unwrap();
+
+    prepare_session(&fw, project).expect("prep succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        value["outputStyle"],
+        serde_json::json!("trusty-mpm-research")
+    );
+}
+
+#[test]
+fn prepare_session_config_style_overrides_manifest() {
+    // Why: HR-2 precedence — the `[style] active` CONFIG key must win over the
+    // manifest's `[style] active` (config > manifest > default).
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let mut fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    fw.trusty_mpm_root = None;
+
+    // Config selects teacher; manifest selects research. Config must win.
+    std::fs::create_dir_all(&fw.root).unwrap();
+    std::fs::write(
+        fw.config_toml(),
+        "[style]\nactive = \"trusty-mpm-teacher\"\n",
+    )
+    .unwrap();
+    let manifest_dir = project.join(".trusty-mpm");
+    std::fs::create_dir_all(&manifest_dir).unwrap();
+    std::fs::write(
+        manifest_dir.join("manifest.toml"),
+        "[style]\nactive = \"trusty-mpm-research\"\n",
+    )
+    .unwrap();
+
+    prepare_session(&fw, project).expect("prep succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        value["outputStyle"],
+        serde_json::json!("trusty-mpm-teacher"),
+        "config [style] active must override the manifest's style"
+    );
+}

--- a/crates/trusty-mpm/src/core/skill_deployer.rs
+++ b/crates/trusty-mpm/src/core/skill_deployer.rs
@@ -72,6 +72,28 @@ fn skill_stem(filename: &str) -> &str {
 /// Test: `deploy_new_skill`, `deploy_skips_user_modified`,
 /// `deploy_unchanged_no_write`, `deploy_user_owned_skipped`.
 pub fn deploy_skills(source: &Path, dest: &Path) -> Result<DeployStats, Error> {
+    // Default policy: deploy every skill in the source directory.
+    deploy_skills_filtered(source, dest, |_name| true)
+}
+
+/// Deploy skills from `source`, restricting to those `select` accepts.
+///
+/// Why: HR-2 manifests describe a skill *set* (include/exclude globs); the
+/// session-launch path must deploy a subset of the source skills without copying
+/// the whole directory. Factoring the selection into a predicate keeps the
+/// manifest logic in `session_launch` while reusing the identical
+/// ownership/atomic-write machinery here.
+/// What: identical to [`deploy_skills`] except a source skill whose stem (the
+/// `.md`-stripped name) `select` rejects is skipped before any write.
+/// [`deploy_skills`] delegates here with an accept-all predicate, so existing
+/// behavior is unchanged. Deselecting a skill does not remove a previously
+/// deployed copy (an HR-3 concern).
+/// Test: `deploy_filtered_respects_predicate`.
+pub fn deploy_skills_filtered(
+    source: &Path,
+    dest: &Path,
+    select: impl Fn(&str) -> bool,
+) -> Result<DeployStats, Error> {
     let mut stats = DeployStats::default();
 
     // No source directory means nothing to deploy — an empty result, not an
@@ -92,7 +114,11 @@ pub fn deploy_skills(source: &Path, dest: &Path) -> Result<DeployStats, Error> {
             continue;
         };
         if entry.file_type()?.is_file() && is_skill_file(name) {
-            names.push(name.to_string());
+            // Honour the manifest's skill-set selection (HR-2). The stem is the
+            // `.md`-stripped name used as the skill id and target dir name.
+            if select(skill_stem(name)) {
+                names.push(name.to_string());
+            }
         }
     }
     names.sort_unstable();
@@ -189,6 +215,22 @@ mod tests {
 
         let manifest = SkillManifest::load(tgt.path());
         assert!(manifest.is_managed("tm-doctor"));
+    }
+
+    #[test]
+    fn deploy_filtered_respects_predicate() {
+        // HR-2: a selection predicate restricts which source skills deploy.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path()); // tm-doctor.md + example-skill.md
+
+        let stats =
+            deploy_skills_filtered(src.path(), tgt.path(), |name| name == "example-skill").unwrap();
+
+        assert!(stats.deployed.contains(&"example-skill".to_string()));
+        assert!(!stats.deployed.contains(&"tm-doctor".to_string()));
+        assert!(tgt.path().join("example-skill").join("SKILL.md").exists());
+        assert!(!tgt.path().join("tm-doctor").exists());
     }
 
     #[test]

--- a/docs/trusty-mpm/harness-manifest.md
+++ b/docs/trusty-mpm/harness-manifest.md
@@ -24,6 +24,15 @@ A higher layer overrides only the **sections it sets**; every other section fall
 through to the layer below. A missing or malformed layer is logged and skipped —
 a launch is **never** blocked by an unreadable manifest.
 
+**Per-section merge mode.** How a *set* section combines with the layer below
+depends on the section:
+
+| Section | Merge mode | Rationale |
+|---|---|---|
+| `[mcp]`, `[instructions]` | **Field-by-field** | Small structs of independent toggles; a higher layer's `Some` wins *per field*, a `None` field inherits the lower layer. So `[mcp] trusty_search = false` alone leaves `trusty_memory` untouched. |
+| `[agents]`, `[skills]` | **Whole-section replacement** | The include/exclude lists are a complete set; a higher layer states the full agent/skill selection rather than field-merging two lists. |
+| `[style]`, `[models]` | **Whole-section replacement** | Simple scalar/group sections; the higher layer's section wins outright. |
+
 The catalog source (repo URL, git ref, TTL) is configurable via the
 `[manifest]` section of `~/.trusty-mpm/config.toml` (highest), the
 `TRUSTY_MPM_CATALOG_REPO` / `_REF` / `_TTL_HOURS` env vars, then the compiled-in
@@ -108,6 +117,16 @@ with it:
 
 The manifest decides *which* content; the established compose / ownership /
 atomic-write machinery still performs the deployment.
+
+> **⚠️ Deselecting does not prune already-deployed files.** Removing an agent or
+> skill from a manifest's selection only stops `prepare_session` from *(re)deploying*
+> that file on the next launch — it does **not** delete a copy that a previous launch
+> already wrote into `~/.claude/agents/` (or the skills dir). So if you launched once
+> with `rust-engineer` included and then drop it from `include`, the stale
+> `~/.claude/agents/rust-engineer.md` remains on disk and Claude Code will still load
+> it. User-visible implication: tightening a selection has no effect until the
+> previously-deployed files are removed by hand. Automatic pruning (reconciling the
+> deployed set against the resolved manifest) is an **HR-3** concern, not HR-2.
 
 ## Scope
 

--- a/docs/trusty-mpm/harness-manifest.md
+++ b/docs/trusty-mpm/harness-manifest.md
@@ -1,0 +1,116 @@
+# Harness Manifest (HR-2 / DOC-17)
+
+`trusty-mpm` provisions every harness from a **manifest** — a TOML document that
+declares *what* a harness receives: which agents and skills to deploy, which
+instruction layers to fold in, the output style, which MCP servers to inject, and
+per-tier model overrides. The manifest is **optional**: when none is present the
+compiled-in default reproduces the historical provisioning behavior exactly, so
+no manifest = no change.
+
+This implements **HR-2** of the harness-runner vision
+(`docs/specs/harness-runner-vision.md`, DOC-17).
+
+## Precedence (NORMATIVE)
+
+The effective manifest is resolved layer-by-layer, highest precedence first:
+
+1. **Project override** — `<project>/.trusty-mpm/manifest.toml`
+2. **User config** — `~/.trusty-mpm/manifest.toml`
+3. **Catalog manifest** — `~/.trusty-mpm/catalog/repo/.claude/manifest.toml`
+   (synced by `CatalogSync` from the configurable claude-mpm repo/ref)
+4. **Compiled-in default** — the floor that reproduces today's behavior
+
+A higher layer overrides only the **sections it sets**; every other section falls
+through to the layer below. A missing or malformed layer is logged and skipped —
+a launch is **never** blocked by an unreadable manifest.
+
+The catalog source (repo URL, git ref, TTL) is configurable via the
+`[manifest]` section of `~/.trusty-mpm/config.toml` (highest), the
+`TRUSTY_MPM_CATALOG_REPO` / `_REF` / `_TTL_HOURS` env vars, then the compiled-in
+default.
+
+## Output-style precedence
+
+The manifest's `[style] active` slots in **below** the existing HR-4 sources:
+`--style` flag > `[style] active` config key > manifest `[style] active` >
+professional default.
+
+## Schema
+
+```toml
+# Schema version (forward-compatible; HR-3 hashes/compares manifests).
+version = 1
+
+[agents]
+# Agent names or glob patterns to deploy. Empty/omitted = all available.
+include = ["*-engineer", "qa", "research"]
+# Names/patterns to drop. Exclude always wins over include.
+exclude = ["php-engineer"]
+# Where source agent files come from: "bundled" (default) or "catalog".
+source = "bundled"
+
+[skills]
+include = []            # empty = all bundled/catalog skills
+exclude = []
+source = "bundled"
+
+[instructions]
+# Optional layers. The non-overridable PM floor (BASE_PM) is always applied.
+system = true
+contextual = true       # the project CLAUDE.md layer
+domain = true           # the delegation-authority layer
+
+[style]
+# Default output-style id (must match a bundled style).
+active = "trusty-mpm"   # or "trusty-mpm-teacher" / "trusty-mpm-research"
+
+[mcp]
+# Which MCP servers to inject into the project's .mcp.json. Both default on.
+trusty_memory = true
+trusty_search = true
+
+[models]
+# Per-tier model id/alias overrides (HR-1's built-in mapping applies otherwise).
+lightweight = "haiku"
+standard = "sonnet"
+high = "sonnet"
+intensive = "opus"
+
+[manifest]
+# (config.toml only) Configure the catalog source for the catalog layer.
+# repo = "https://github.com/me/my-fork"
+# git_ref = "main"
+# ttl_hours = 24
+```
+
+Every section is optional. The simplest useful override is a single section, e.g.
+a project that only wants the Rust engineer and the research style:
+
+```toml
+# <project>/.trusty-mpm/manifest.toml
+[agents]
+include = ["rust-engineer", "qa", "research"]
+
+[style]
+active = "trusty-mpm-research"
+```
+
+## How `prepare_session` consumes it
+
+`prepare_session` resolves the manifest, materializes a `HarnessPlan`
+(`crate::core::manifest::HarnessPlan`), and drives the existing deploy machinery
+with it:
+
+- the agent/skill **source directory** (bundled vs catalog) and an
+  **include/exclude selection predicate** restrict which content deploys;
+- the `[mcp]` toggles gate the `trusty-memory` / `trusty-search` injections;
+- the `[style] active` becomes the lowest-precedence output-style default.
+
+The manifest decides *which* content; the established compose / ownership /
+atomic-write machinery still performs the deployment.
+
+## Scope
+
+HR-2 covers provisioning **from** a manifest. The update-check + rebuild-offer
+(comparing catalog content hashes against the deployed manifest) is **HR-3**
+(#1408); the schema's `version` field is the forward-compatibility anchor for it.


### PR DESCRIPTION
Closes #1407
Implements HR-2 (see `docs/specs/harness-runner-vision.md`, DOC-17)
Epic #1405

## What

`trusty-mpm` now provisions a harness from a configurable TOML **manifest** —
declaring the agent set, skills, instruction layers, output style, MCP servers,
and model tiers a harness receives — instead of compile-time bundled assets
alone. An absent manifest is a **zero-regression no-op**: the compiled-in
default reproduces today's provisioning exactly.

## Manifest schema (TOML)

```toml
version = 1                       # forward-compatible (HR-3 hashes it)

[agents]                          # which agents deploy
include = ["*-engineer", "qa"]    # empty/omitted = all available
exclude = ["php-engineer"]        # exclude wins over include
source = "bundled"                # "bundled" (default) or "catalog"

[skills]                          # same include/exclude/source semantics
include = []

[instructions]                    # optional layers (PM floor always applied)
system = true
contextual = true
domain = true

[style]
active = "trusty-mpm"             # default output style (below --style / config)

[mcp]                             # both default on
trusty_memory = true
trusty_search = true

[models]                          # per-tier model overrides (HR-1 mapping otherwise)
intensive = "opus"
```

Full reference + examples: `docs/trusty-mpm/harness-manifest.md`.

## Precedence (NORMATIVE)

Resolved layer-by-layer, highest first; a higher layer overrides only the
sections it sets:

1. **Project override** — `<project>/.trusty-mpm/manifest.toml`
2. **User config** — `~/.trusty-mpm/manifest.toml`
3. **Catalog manifest** — `~/.trusty-mpm/catalog/repo/.claude/manifest.toml`
   (synced by `CatalogSync` from the configurable claude-mpm repo/ref)
4. **Compiled-in default** — the floor that reproduces today's behavior

A missing/malformed layer is logged and skipped — a launch is never blocked.
The catalog source is configurable via the new `[manifest]` config section
(`repo`/`git_ref`/`ttl_hours`), layering config > env (`TRUSTY_MPM_CATALOG_*`)
> default.

## How `prepare_session` consumes it

Resolves the manifest, builds a `HarnessPlan`, then drives the existing deploy
machinery:
- agent/skill **source** (bundled vs catalog) + **include/exclude predicate**
  restrict which content deploys (new `deploy_agents_filtered` /
  `deploy_skills_filtered`; existing callers delegate with accept-all → unchanged);
- `[mcp]` toggles gate the `trusty-memory` / `trusty-search` injections;
- `[style] active` is the lowest-precedence output-style default (below the
  `--style` flag and the `[style]` config key — HR-4 precedence preserved).

## Regression safety

The default manifest reproduces the pre-HR-2 behavior. Proven by
`prepare_session_default_deploys_all_seeded_agents` and the unchanged existing
`prepare_session_*` suite (all green).

## Scope

Provisioning **from** a manifest only. The update-check / rebuild-offer is
**HR-3** (#1408); the schema's `version` field is its forward-compat anchor.

## Tests

- schema round-trip + merge/precedence + glob/selection
- default reproduces bundled behavior; enables both MCP; carries version
- resolver precedence (project > user > catalog > default); malformed-layer skip
- plan source/selection/MCP/style mapping
- `prepare_session` integration: agent-set filter, MCP disable, style default,
  config-over-manifest precedence
- `CatalogSync` config override + manifest path/root

`cargo test -p trusty-mpm`, `cargo test --workspace`,
`cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`,
and `scripts/check_line_cap.sh` all pass (the one trusty-search
`patch_persists_to_toml` flake passes in isolation and is unrelated to this PR).

## Design decisions

- **TOML** for the manifest (matches the existing `config.toml` convention).
- **Catalog manifest location** `repo/.claude/manifest.toml` (mirrors how
  `CatalogSync` already lays out `repo/.claude/agents|skills`). claude-mpm was
  not present locally, so the manifest schema was designed fresh.
- New `src/core/manifest/` module (schema/default/resolve/apply behind a thin
  `mod.rs` facade) to stay under the 500-SLOC cap with single-responsibility
  files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)