### PR TITLE
feat(trusty-mpm): catalog update-check + rebuild/apply (HR-3, #1408)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -605,11 +605,15 @@ pub(crate) enum IssueCmd {
 
 /// Actions for the `catalog` subcommand.
 ///
-/// Why: catalog management splits into a remote-sync operation and a local
-/// listing; separate sub-actions keep each scriptable.
+/// Why: catalog management splits into a remote-sync operation, a local listing,
+/// a staleness check, and the rebuild/redeploy `apply`; separate sub-actions keep
+/// each scriptable.
 /// What: `Sync` fetches the catalog (respecting a TTL unless `--force`); `Ls`
-/// lists cached agents and skills.
-/// Test: `cli_parses_catalog_sync`, `cli_parses_catalog_ls`.
+/// lists cached agents and skills; `Status` reports whether deployed content is
+/// stale; `Apply` syncs then redeploys the manifest-selected content (the HR-3
+/// rebuild offer made concrete).
+/// Test: `cli_parses_catalog_sync`, `cli_parses_catalog_ls`,
+/// `cli_parses_catalog_status`, `cli_parses_catalog_apply`.
 #[derive(Debug, Subcommand)]
 pub(crate) enum CatalogAction {
     /// Fetch or refresh the agent/skill catalog from the claude-mpm repo.
@@ -623,6 +627,35 @@ pub(crate) enum CatalogAction {
         /// Output as JSON instead of a table.
         #[arg(long)]
         json: bool,
+    },
+    /// Report whether the deployed content has drifted from the synced catalog.
+    ///
+    /// Why: the HR-3 staleness check surfaced as a scriptable CLI verb — the same
+    /// signal `GET /health` and the TUI use, without mutating anything.
+    /// What: compares the deployed checksum manifests against the synced catalog
+    /// and prints stale/unknown plus a per-artifact change list.
+    /// Test: `cli_parses_catalog_status`.
+    Status {
+        /// Output as JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Rebuild/redeploy the manifest-selected content from the catalog (HR-3).
+    ///
+    /// Why: the HR-3 rebuild OFFER made actionable — accepting it syncs the
+    /// catalog then redeploys agents/skills from it, clearing staleness. Never
+    /// runs automatically; the operator (or the TUI hint) invokes it explicitly.
+    /// What: syncs (honouring the TTL unless `--force`), redeploys the
+    /// manifest-selected agents and skills (updating the checksum manifests), and
+    /// with `--prune` removes managed agents/skills the manifest no longer selects.
+    /// Test: `cli_parses_catalog_apply`; behaviour by `tests/catalog_apply.rs`.
+    Apply {
+        /// Force a catalog fetch even if the cache TTL has not expired.
+        #[arg(long)]
+        force: bool,
+        /// Also remove managed agents/skills the manifest no longer selects.
+        #[arg(long)]
+        prune: bool,
     },
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -552,6 +552,69 @@ pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
                 }
             }
         }
+        CatalogAction::Status { json } => {
+            // HR-3: report staleness without mutating anything. The framework root
+            // is the daemon-wide baseline "project" (no per-project override).
+            let report = trusty_mpm::core::update_check::detect_for_framework(
+                &trusty_mpm::core::paths::FrameworkPaths::default(),
+                &framework_root,
+            );
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "stale": report.stale,
+                        "unknown": report.unknown,
+                        "changes": report.summary_lines(),
+                    })
+                );
+            } else if report.unknown {
+                println!("catalog: unknown (never synced — run `tm catalog sync`)");
+            } else if report.stale {
+                println!("catalog: stale ({} change(s)):", report.changes.len());
+                for line in report.summary_lines() {
+                    println!("  {line}");
+                }
+                println!("run `tm catalog apply` to redeploy the updated content");
+            } else {
+                println!("catalog: up to date");
+            }
+        }
+        CatalogAction::Apply { force, prune } => {
+            // HR-3: accept the rebuild offer — sync, redeploy the selected set,
+            // optionally prune deselected managed files.
+            let report = trusty_mpm::core::update_check::apply_catalog(
+                trusty_mpm::provisioner::RealGitBackend,
+                &trusty_mpm::core::paths::FrameworkPaths::default(),
+                &framework_root,
+                force,
+                prune,
+            )?;
+            let synced = if report.fetched {
+                "synced catalog"
+            } else {
+                "catalog cache fresh"
+            };
+            println!(
+                "{synced}; redeployed {} agent(s), {} skill(s)",
+                report.agents_deployed.len(),
+                report.skills_deployed.len()
+            );
+            if !report.agents_skipped.is_empty() || !report.skills_skipped.is_empty() {
+                println!(
+                    "  skipped (user-modified/unchanged): {} agent(s), {} skill(s)",
+                    report.agents_skipped.len(),
+                    report.skills_skipped.len()
+                );
+            }
+            if prune && (!report.agents_pruned.is_empty() || !report.skills_pruned.is_empty()) {
+                println!(
+                    "  pruned (deselected): {} agent(s), {} skill(s)",
+                    report.agents_pruned.len(),
+                    report.skills_pruned.len()
+                );
+            }
+        }
     }
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1054,6 +1054,48 @@ fn cli_parses_catalog_ls() {
 }
 
 #[test]
+fn cli_parses_catalog_status() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "catalog", "status", "--json"]).unwrap();
+    match cli.command {
+        Command::Catalog {
+            action: CatalogAction::Status { json },
+        } => assert!(json),
+        other => panic!("expected catalog status, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_catalog_apply() {
+    let cli =
+        Cli::try_parse_from(["trusty-mpm", "catalog", "apply", "--force", "--prune"]).unwrap();
+    match cli.command {
+        Command::Catalog {
+            action: CatalogAction::Apply { force, prune },
+        } => {
+            assert!(force);
+            assert!(prune);
+        }
+        other => panic!("expected catalog apply, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_catalog_apply_defaults() {
+    // Without flags, both `force` and `prune` default to false (no surprise
+    // network refetch, no surprise removals).
+    let cli = Cli::try_parse_from(["trusty-mpm", "catalog", "apply"]).unwrap();
+    match cli.command {
+        Command::Catalog {
+            action: CatalogAction::Apply { force, prune },
+        } => {
+            assert!(!force);
+            assert!(!prune);
+        }
+        other => panic!("expected catalog apply, got {other:?}"),
+    }
+}
+
+#[test]
 fn cli_parses_ticket() {
     // Why: the minimal form `tm ticket <issue#>` must parse with the `gh`
     // backend as the default and an empty notes list (#1237).

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -167,6 +167,38 @@ impl DaemonClient {
         matches!(self.http.get(&url).send().await, Ok(r) if r.status().is_success())
     }
 
+    /// Fetch the daemon's catalog-staleness flag from `GET /health` (HR-3).
+    ///
+    /// Why: the coordinator TUI shows an "updates available" indicator when the
+    /// deployed harness content has drifted from the synced catalog (DOC-17
+    /// §HR-3). It already polls health on its timer; reading the additive
+    /// `catalog_stale` field reuses that one probe rather than adding a request.
+    /// What: GETs `/health`, parses the JSON body, and returns `catalog_stale`.
+    /// Any transport/parse failure (or an older daemon returning the legacy
+    /// string body) yields `false` so the indicator degrades to "no updates"
+    /// rather than erroring — staleness never blocks the TUI.
+    /// Test: `coord_poll_daemon` integration is exercised against a live daemon;
+    /// the parse contract (incl. the missing-field default) is covered by
+    /// `catalog_stale_health_body_wire_shape`.
+    pub async fn catalog_stale(&self) -> bool {
+        let url = format!("{}/health", self.base);
+        let Ok(resp) = self.http.get(&url).send().await else {
+            return false;
+        };
+        if !resp.status().is_success() {
+            return false;
+        }
+        #[derive(Deserialize)]
+        struct HealthBody {
+            #[serde(default)]
+            catalog_stale: bool,
+        }
+        resp.json::<HealthBody>()
+            .await
+            .map(|b| b.catalog_stale)
+            .unwrap_or(false)
+    }
+
     /// Pause a session via `POST /sessions/{id}/pause`.
     ///
     /// Why: the dashboard's `p` key pauses the selected session in place.

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -237,3 +237,28 @@ fn pair_status_deserializes() {
     assert!(status.paired);
     assert_eq!(status.chat_id, Some(12345678));
 }
+
+#[test]
+fn catalog_stale_health_body_wire_shape() {
+    // The HR-3 `catalog_stale` flag must round-trip from the `/health` body, and
+    // a body MISSING the field (an older daemon) must default to `false` so
+    // `DaemonClient::catalog_stale` degrades to "no updates" instead of erroring.
+    // This mirrors the private `HealthBody` the client parses.
+    #[derive(serde::Deserialize)]
+    struct HealthBody {
+        #[serde(default)]
+        catalog_stale: bool,
+    }
+
+    let stale: HealthBody =
+        serde_json::from_value(serde_json::json!({"status":"ok","catalog_stale":true})).unwrap();
+    assert!(stale.catalog_stale);
+
+    let fresh: HealthBody =
+        serde_json::from_value(serde_json::json!({"status":"ok","catalog_stale":false})).unwrap();
+    assert!(!fresh.catalog_stale);
+
+    // Legacy daemon: no `catalog_stale` field present → defaults to false.
+    let legacy: HealthBody = serde_json::from_value(serde_json::json!({"status":"ok"})).unwrap();
+    assert!(!legacy.catalog_stale, "missing field defaults to false");
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -53,6 +53,7 @@ pub mod skill_manifest;
 pub mod sm;
 pub mod tmux;
 pub mod trusty_tools_config;
+pub mod update_check;
 pub mod workspace_scan;
 
 pub use connect::{ResolveResult, SessionSummary, resolve_target};

--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -114,6 +114,34 @@ impl FrameworkPaths {
         }
     }
 
+    /// Resolve the framework layout from a known framework ROOT (`…/.trusty-mpm`).
+    ///
+    /// Why: the daemon holds only the resolved framework root (`base/.trusty-mpm`),
+    /// not the base/home it was derived from. The HR-3 `/health` staleness check
+    /// must rebuild a `FrameworkPaths` whose `.root` equals that exact root — so
+    /// the deployed-content (`<base>/.claude/...`) and catalog paths line up with
+    /// what the launcher used. Passing the root to [`under`](Self::under) directly
+    /// would double-nest (`…/.trusty-mpm/.trusty-mpm`); this constructor inverts
+    /// the `base.join(".trusty-mpm")` `under` performs by taking the root's parent
+    /// as the base, reproducing the original layout exactly.
+    /// What: when `root` ends in `.trusty-mpm`, delegates to
+    /// [`under`](Self::under)`(root.parent())`; otherwise (a test root that is not
+    /// home-nested) treats `root` itself as the base so the type is still
+    /// constructible. Either way the resulting `.root` is the requested directory
+    /// when it is `.trusty-mpm`-named.
+    /// Test: `from_root_reproduces_under`, `from_root_handles_non_nested`.
+    pub fn from_root(root: impl AsRef<Path>) -> Self {
+        let root = root.as_ref();
+        if root.file_name().and_then(|n| n.to_str()) == Some(FRAMEWORK_DIR_NAME)
+            && let Some(base) = root.parent()
+        {
+            return Self::under(base);
+        }
+        // The root is not `.trusty-mpm`-nested (e.g. a bare test tempdir). Treat
+        // it as the base; subdirectories nest under `<root>/.trusty-mpm` as usual.
+        Self::under(root)
+    }
+
     /// Path of the token-optimizer policy file (`hooks/optimizer.toml`).
     ///
     /// Why: the daemon reads this at startup and on file-change to build its
@@ -286,6 +314,25 @@ mod tests {
             PathBuf::from("/base/.trusty-mpm/framework/instructions")
         );
         assert_eq!(paths.registry, PathBuf::from("/base/.trusty-mpm/registry"));
+    }
+
+    #[test]
+    fn from_root_reproduces_under() {
+        // A `.trusty-mpm`-named root must rebuild the exact layout `under` would
+        // have produced for the parent base (no double-nesting).
+        let under = FrameworkPaths::under("/base");
+        let from_root = FrameworkPaths::from_root("/base/.trusty-mpm");
+        assert_eq!(from_root.root, under.root);
+        assert_eq!(from_root.claude_agents, under.claude_agents);
+        assert_eq!(from_root.agents, under.agents);
+    }
+
+    #[test]
+    fn from_root_handles_non_nested() {
+        // A bare (non-`.trusty-mpm`) root is treated as the base, so subdirs nest
+        // under `<root>/.trusty-mpm` — the type is always constructible.
+        let from_root = FrameworkPaths::from_root("/tmp/testroot");
+        assert_eq!(from_root.root, PathBuf::from("/tmp/testroot/.trusty-mpm"));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/update_check/apply.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply.rs
@@ -1,0 +1,233 @@
+//! Catalog apply: the HR-3 rebuild/redeploy offer made concrete (DOC-17).
+//!
+//! Why: detecting staleness is only half of HR-3 — the operator must be able to
+//! ACCEPT the rebuild offer. `tm catalog apply` (and any future TUI keybind) calls
+//! [`apply_catalog`] to sync the catalog, redeploy the manifest-selected agents
+//! and skills from it (refreshing the checksum manifests so staleness clears), and
+//! optionally PRUNE managed artifacts the manifest no longer selects (the removal
+//! HR-2 deferred — kept behind an explicit opt-in, never silent).
+//! What: [`apply_catalog`] threads a [`GitBackend`] (real git in production, a
+//! fake in tests), syncs via [`CatalogSync`], resolves the harness manifest +
+//! plan exactly as the launcher does, redeploys via the filtered deployers, and
+//! when `prune` is set removes deselected managed files. It returns an
+//! [`ApplyReport`] summarising the sync, the deploy counts, and the prune list.
+//! Test: this module's `tests` cover redeploy-clears-staleness and prune-removes-
+//! deselected against a `FakeGitBackend`-seeded catalog.
+
+use std::path::Path;
+
+use crate::core::agent_deployer::deploy_agents_filtered;
+use crate::core::agent_manifest::{AgentManifest, MANIFEST_FILE as AGENT_MANIFEST_FILE};
+use crate::core::manifest::HarnessPlan;
+use crate::core::paths::FrameworkPaths;
+use crate::core::skill_deployer::deploy_skills_filtered;
+use crate::core::skill_manifest::{SKILL_MANIFEST_FILE, SkillManifest};
+use crate::provisioner::GitBackend;
+
+/// A failure raised while applying a catalog update.
+///
+/// Why: `apply` performs a network-ish sync (via the backend), agent/skill
+/// deploys, and filesystem pruning; the CLI needs one typed surface naming which
+/// stage failed.
+/// What: variants for the sync, the agent deploy, the skill deploy, and prune I/O.
+/// Test: surfaced on a backend that fails to clone; the happy path is covered by
+/// `apply_redeploys_and_clears_staleness`.
+#[derive(Debug, thiserror::Error)]
+pub enum ApplyError {
+    /// Syncing the catalog checkout failed.
+    #[error("catalog sync failed: {0}")]
+    Sync(String),
+    /// Redeploying agents failed.
+    #[error("agent redeploy failed: {0}")]
+    AgentDeploy(String),
+    /// Redeploying skills failed.
+    #[error("skill redeploy failed: {0}")]
+    SkillDeploy(String),
+    /// A filesystem operation during pruning failed.
+    #[error("prune io error: {0}")]
+    Prune(String),
+}
+
+/// Summary of one [`apply_catalog`] run.
+///
+/// Why: the CLI prints what the apply did; callers (and tests) need the counts
+/// and lists split by outcome.
+/// What: whether the sync actually fetched, the deployed/skipped agent filenames,
+/// the deployed/skipped skill stems, and the pruned agent + skill names.
+/// Test: `apply_redeploys_and_clears_staleness`, `apply_prune_removes_deselected`.
+#[derive(Debug, Default)]
+pub struct ApplyReport {
+    /// True if the catalog sync performed a real fetch (vs a TTL-fresh skip).
+    pub fetched: bool,
+    /// Agent filenames (re)written this run.
+    pub agents_deployed: Vec<String>,
+    /// Agent filenames left as-is (user-modified / unchanged).
+    pub agents_skipped: Vec<String>,
+    /// Skill stems (re)written this run.
+    pub skills_deployed: Vec<String>,
+    /// Skill stems left as-is.
+    pub skills_skipped: Vec<String>,
+    /// Managed agent filenames removed because the manifest no longer selects them.
+    pub agents_pruned: Vec<String>,
+    /// Managed skill stems removed because the manifest no longer selects them.
+    pub skills_pruned: Vec<String>,
+}
+
+/// Apply a catalog update: sync, redeploy the selected set, optionally prune.
+///
+/// Why: this is the single autonomous-rebuild entry point HR-3 names — accepting
+/// the staleness offer. It deliberately mirrors the launcher's resolve→plan→deploy
+/// sequence so the content `apply` lands is exactly what a fresh session would get,
+/// and it refreshes the checksum manifests so a subsequent `detect_staleness`
+/// reports fresh.
+/// What: syncs the catalog via [`CatalogSync::sync`] (honouring the TTL unless
+/// `force`), resolves the harness manifest for `project_dir`, materializes the
+/// [`HarnessPlan`], redeploys the selected agents/skills via the filtered
+/// deployers, and — when `prune` is set — removes managed agents/skills the plan
+/// no longer selects (and drops their manifest entries). Returns an
+/// [`ApplyReport`]. Pruning is opt-in and only ever touches MANAGED files (those
+/// in the checksum manifest); user-owned files are never removed.
+/// Test: `apply_redeploys_and_clears_staleness`, `apply_prune_removes_deselected`,
+/// `apply_prune_spares_user_owned`.
+pub fn apply_catalog<G: GitBackend>(
+    git: G,
+    fw: &FrameworkPaths,
+    project_dir: &Path,
+    force: bool,
+    prune: bool,
+) -> Result<ApplyReport, ApplyError> {
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    let config = crate::core::config::MpmConfig::load(&fw.root);
+
+    // 1. Sync the catalog checkout (TTL-gated unless forced).
+    let sync =
+        crate::content::CatalogSync::with_config(git, catalog_root.clone(), Some(&config.manifest));
+    let sync_result = sync
+        .sync(force)
+        .map_err(|e| ApplyError::Sync(e.to_string()))?;
+
+    // 2. Resolve manifest + plan exactly as the launcher does.
+    let sources =
+        crate::core::manifest::ManifestSources::resolve(project_dir, &fw.root, &catalog_root);
+    let manifest = crate::core::manifest::resolve_manifest(&sources);
+    let plan = HarnessPlan::from_manifest(&manifest, fw, &catalog_root);
+
+    let mut report = ApplyReport {
+        fetched: sync_result.fetched,
+        ..ApplyReport::default()
+    };
+
+    // 3. Redeploy the manifest-selected agents and skills, refreshing checksums.
+    let agent_target = fw.claude_agents_dir();
+    let deploy = deploy_agents_filtered(&plan.agent_source, &agent_target, |name| {
+        plan.agent_selected(name)
+    })
+    .map_err(|e| ApplyError::AgentDeploy(e.to_string()))?;
+    report.agents_deployed = deploy.deployed;
+    report.agents_skipped = deploy.skipped;
+
+    let skill_target = fw.claude_skills_dir();
+    let skill_deploy = deploy_skills_filtered(&plan.skill_source, &skill_target, |name| {
+        plan.skill_selected(name)
+    })
+    .map_err(|e| ApplyError::SkillDeploy(e.to_string()))?;
+    report.skills_deployed = skill_deploy.deployed;
+    report.skills_skipped = skill_deploy.skipped;
+
+    // 4. Optionally prune managed artifacts the manifest no longer selects.
+    if prune {
+        report.agents_pruned = prune_agents(&agent_target, &plan)?;
+        report.skills_pruned = prune_skills(&skill_target, &plan)?;
+    }
+
+    Ok(report)
+}
+
+/// Remove managed agent files the plan no longer selects; return their names.
+///
+/// Why: HR-2 deferred removal of deselected agents; HR-3 supplies it behind the
+/// explicit `--prune` flag. Only MANAGED files (present in the agent checksum
+/// manifest) are eligible — a user-dropped file is never removed.
+/// What: for each manifest-managed agent filename whose stem the plan rejects,
+/// deletes `<target>/<filename>` (ignoring an already-absent file) and drops the
+/// manifest entry; saves the manifest if anything changed. Returns the removed
+/// filenames, sorted.
+/// Test: `apply_prune_removes_deselected`, `apply_prune_spares_user_owned`.
+fn prune_agents(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
+    let mut manifest = AgentManifest::load(target);
+    let mut pruned: Vec<String> = Vec::new();
+
+    let candidates: Vec<String> = manifest.managed.keys().cloned().collect();
+    for filename in candidates {
+        let stem = filename.trim_end_matches(".md");
+        if plan.agent_selected(stem) {
+            continue;
+        }
+        remove_if_present(&target.join(&filename))?;
+        manifest.managed.remove(&filename);
+        pruned.push(filename);
+    }
+
+    if !pruned.is_empty() {
+        manifest
+            .save(target)
+            .map_err(|e| ApplyError::Prune(e.to_string()))?;
+        // The manifest file itself is never an agent; ensure it is left intact.
+        debug_assert!(target.join(AGENT_MANIFEST_FILE).exists());
+    }
+    pruned.sort_unstable();
+    Ok(pruned)
+}
+
+/// Remove managed skill directories the plan no longer selects; return stems.
+///
+/// Why: the skill counterpart to [`prune_agents`]. Skills deploy as
+/// `<target>/<stem>/SKILL.md`, so pruning removes the whole skill directory.
+/// What: for each manifest-managed skill stem the plan rejects, removes
+/// `<target>/<stem>/` (ignoring absence) and drops the manifest entry; saves the
+/// manifest if anything changed. The [`SkillManifest`] is keyed by stem, matching
+/// the skill deployer. Returns the removed stems, sorted.
+/// Test: `apply_prune_removes_deselected`.
+fn prune_skills(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
+    let mut manifest = SkillManifest::load(target);
+    let mut pruned: Vec<String> = Vec::new();
+
+    let candidates: Vec<String> = manifest.managed.keys().cloned().collect();
+    for stem in candidates {
+        if plan.skill_selected(&stem) {
+            continue;
+        }
+        let skill_dir = target.join(&stem);
+        if skill_dir.is_dir() {
+            std::fs::remove_dir_all(&skill_dir).map_err(|e| ApplyError::Prune(e.to_string()))?;
+        }
+        manifest.managed.remove(&stem);
+        pruned.push(stem);
+    }
+
+    if !pruned.is_empty() {
+        manifest
+            .save(target)
+            .map_err(|e| ApplyError::Prune(e.to_string()))?;
+        debug_assert!(target.join(SKILL_MANIFEST_FILE).exists());
+    }
+    pruned.sort_unstable();
+    Ok(pruned)
+}
+
+/// Delete a file if it exists, treating "already gone" as success.
+///
+/// Why: pruning is idempotent — a file the manifest lists may already be absent
+/// (the user deleted it); that is not an error.
+/// What: removes `path`; maps `NotFound` to `Ok(())`, propagates other I/O errors.
+/// Test: exercised by `apply_prune_removes_deselected`.
+fn remove_if_present(path: &Path) -> Result<(), ApplyError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(ApplyError::Prune(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/core/update_check/apply/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/tests.rs
@@ -1,0 +1,198 @@
+//! Unit tests for `apply_catalog` (HR-3 rebuild offer).
+//!
+//! Why: the apply path must be verifiable offline — a `FakeGitBackend` simulates
+//! the catalog checkout (creating only the `repo` dir), the test seeds catalog
+//! agent/skill files into it, and the assertions cover redeploy + staleness-clear
+//! and the opt-in prune (including that prune spares user-owned files).
+//! What: build a hermetic `FrameworkPaths` under a tempdir, write a project
+//! manifest selecting the CATALOG source, run `apply_catalog`, and assert the
+//! deployed files + a subsequent `detect_for_framework` reports fresh.
+//! Test: this IS the test module.
+
+use super::*;
+use crate::core::update_check::detect_for_framework;
+use crate::provisioner::FakeGitBackend;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Seed a catalog agent file at the layout `CatalogSync` writes
+/// (`<catalog>/repo/.claude/agents/<stem>.md`).
+fn seed_catalog_agent(catalog_root: &Path, stem: &str, body: &str) {
+    let dir = catalog_root.join("repo/.claude/agents");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join(format!("{stem}.md")),
+        format!("---\nname: {stem}\nrole: {stem}\n---\n\n# {stem}\n\n{body}\n"),
+    )
+    .unwrap();
+}
+
+/// Seed a catalog skill file at `<catalog>/repo/.claude/skills/<stem>.md`.
+fn seed_catalog_skill(catalog_root: &Path, stem: &str, body: &str) {
+    let dir = catalog_root.join("repo/.claude/skills");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join(format!("{stem}.md")),
+        format!("# {stem}\n\n{body}\n"),
+    )
+    .unwrap();
+}
+
+/// Write a project manifest selecting the CATALOG source for agents and skills.
+fn write_catalog_manifest(project_dir: &Path) {
+    let dir = project_dir.join(".trusty-mpm");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("manifest.toml"),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn apply_redeploys_and_clears_staleness() {
+    // A catalog-sourced manifest with new content must deploy that content and
+    // leave the harness NOT stale (the checksum manifests now match the catalog).
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+    write_catalog_manifest(project.path());
+
+    // Pre-seed the catalog checkout content (the FakeGitBackend only mkdirs).
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_agent(&catalog_root, "rust-engineer", "ENGINEER BODY");
+    seed_catalog_skill(&catalog_root, "tm-doctor", "DOCTOR BODY");
+
+    let report = apply_catalog(
+        FakeGitBackend::new(),
+        &fw,
+        project.path(),
+        true,  // force sync
+        false, // no prune
+    )
+    .unwrap();
+
+    assert!(
+        report
+            .agents_deployed
+            .contains(&"rust-engineer.md".to_string()),
+        "agent deployed: {report:?}"
+    );
+    assert!(
+        report.skills_deployed.contains(&"tm-doctor".to_string()),
+        "skill deployed: {report:?}"
+    );
+
+    // The deployed files exist where Claude Code reads them.
+    assert!(fw.claude_agents_dir().join("rust-engineer.md").is_file());
+    assert!(
+        fw.claude_skills_dir()
+            .join("tm-doctor")
+            .join("SKILL.md")
+            .is_file()
+    );
+
+    // After apply, the framework-level staleness check reports fresh (not stale,
+    // not unknown — the catalog tree exists and the deployed hashes match).
+    let report = detect_for_framework(&fw, project.path());
+    assert!(!report.stale, "apply must clear staleness: {report:?}");
+    assert!(!report.unknown, "catalog is synced: {report:?}");
+}
+
+#[test]
+fn apply_is_stale_before_apply_then_fresh_after() {
+    // End-to-end staleness lifecycle: a catalog agent absent from the deployment
+    // reads stale BEFORE apply, then fresh AFTER.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+    write_catalog_manifest(project.path());
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_agent(&catalog_root, "newcomer", "NEW BODY");
+
+    // BEFORE apply: the catalog has an agent the deployment lacks → stale.
+    let before = detect_for_framework(&fw, project.path());
+    assert!(
+        before.stale,
+        "new catalog agent is stale before apply: {before:?}"
+    );
+
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    // AFTER apply: deployed, so fresh.
+    let after = detect_for_framework(&fw, project.path());
+    assert!(!after.stale, "apply clears it: {after:?}");
+}
+
+#[test]
+fn apply_prune_removes_deselected() {
+    // After deploying two agents, a manifest that EXCLUDES one must, with --prune,
+    // remove the deselected agent's deployed file and manifest entry.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_agent(&catalog_root, "keep-me", "KEEP");
+    seed_catalog_agent(&catalog_root, "drop-me", "DROP");
+
+    // First apply deploys BOTH (no exclude).
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+    assert!(fw.claude_agents_dir().join("drop-me.md").is_file());
+
+    // Now narrow the manifest to exclude drop-me, and apply WITH prune.
+    fs::write(
+        project.path().join(".trusty-mpm").join("manifest.toml"),
+        "[agents]\nsource = \"catalog\"\nexclude = [\"drop-me\"]\n\n[skills]\nsource = \"catalog\"\n",
+    )
+    .unwrap();
+
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+    assert!(
+        report.agents_pruned.contains(&"drop-me.md".to_string()),
+        "drop-me must be pruned: {report:?}"
+    );
+    assert!(
+        !fw.claude_agents_dir().join("drop-me.md").exists(),
+        "pruned agent file removed"
+    );
+    assert!(
+        fw.claude_agents_dir().join("keep-me.md").is_file(),
+        "selected agent retained"
+    );
+
+    // The pruned agent is gone from the manifest too.
+    let manifest = AgentManifest::load(&fw.claude_agents_dir());
+    assert!(!manifest.is_managed("drop-me.md"));
+    assert!(manifest.is_managed("keep-me.md"));
+}
+
+#[test]
+fn apply_prune_spares_user_owned() {
+    // A user-dropped file (absent from the manifest) must NEVER be pruned, even
+    // when its name is not selected.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_agent(&catalog_root, "managed-agent", "BODY");
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    // User drops their own unrelated file into the agents dir.
+    let user_file = fw.claude_agents_dir().join("my-own.md");
+    fs::write(&user_file, "USER OWNED").unwrap();
+
+    // Apply with prune and a manifest that would NOT select `my-own`.
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+    assert!(
+        !report.agents_pruned.contains(&"my-own.md".to_string()),
+        "user-owned file must not be pruned: {report:?}"
+    );
+    assert!(user_file.is_file(), "user-owned file survives prune");
+    assert_eq!(fs::read_to_string(&user_file).unwrap(), "USER OWNED");
+}

--- a/crates/trusty-mpm/src/core/update_check/mod.rs
+++ b/crates/trusty-mpm/src/core/update_check/mod.rs
@@ -1,0 +1,329 @@
+//! Catalog update-check: detect when deployed content is stale (HR-3 / DOC-17).
+//!
+//! Why: the claude-mpm catalog evolves; a session deployed last week may run
+//! agents/skills that no longer match the upstream catalog. DOC-17 §HR-3 requires
+//! the runner to DETECT that drift autonomously and OFFER a rebuild — never to
+//! silently force one. This module owns the pure detection: a SHA compare of the
+//! catalog's current content against the deployed checksum manifests
+//! (`agent_deployer`/`skill_deployer` write them, §2.2). It is intentionally
+//! cheap and offline: it hashes an already-synced catalog checkout and the
+//! already-deployed files; it NEVER pulls from the network (a network sync is the
+//! TTL-gated [`crate::content::CatalogSync::sync`], a separate concern).
+//! What: [`detect_staleness`] compares a catalog agent/skill source tree against
+//! the deployed [`AgentManifest`]/[`SkillManifest`] under a selection predicate
+//! and returns a [`StalenessReport`] — `stale`/`unknown` flags plus a small list
+//! of WHAT changed. [`StalenessReport::summary_lines`] renders the change list.
+//! Test: this module's `tests` cover stale-on-change, not-stale-on-identical,
+//! unknown-when-never-synced, and selection filtering; the `/health` and `apply`
+//! wiring is covered in the daemon and CLI suites.
+
+use std::path::Path;
+
+use crate::core::agent_builder::compose_agent;
+use crate::core::agent_manifest::{AgentManifest, checksum};
+use crate::core::skill_manifest::SkillManifest;
+
+mod apply;
+pub use apply::{ApplyError, ApplyReport, apply_catalog};
+
+/// The classification of one catalog artifact relative to what was deployed.
+///
+/// Why: the rebuild offer needs to tell the operator WHAT changed, not just that
+/// *something* did; a per-artifact verb makes the `catalog_changes` summary
+/// actionable ("agent rust-engineer: changed", "skill foo: new").
+/// What: a closed enum naming the three drift outcomes the SHA compare yields.
+/// Test: asserted indirectly via [`StalenessReport::summary_lines`] in `tests`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeKind {
+    /// Present in the catalog but never deployed (absent from the manifest).
+    New,
+    /// Deployed, but the catalog's current content hashes differently.
+    Changed,
+}
+
+impl ChangeKind {
+    /// The lowercase verb shown in a change summary line.
+    ///
+    /// Why: keeps the rendered wording single-sourced between the summary builder
+    /// and any test asserting on it.
+    /// What: `"new"` or `"changed"`.
+    /// Test: `summary_lines_render_kind_and_name`.
+    fn label(self) -> &'static str {
+        match self {
+            ChangeKind::New => "new",
+            ChangeKind::Changed => "changed",
+        }
+    }
+}
+
+/// One catalog artifact that differs from the deployed copy.
+///
+/// Why: the report carries a bounded list of these so the operator (and the TUI)
+/// can see the first handful of changes without the daemon doing string work on
+/// the hot health path.
+/// What: the artifact kind (agent/skill), its name, and how it drifted.
+/// Test: `detect_flags_changed_agent`, `detect_flags_new_skill`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogChange {
+    /// `"agent"` or `"skill"` — the artifact class.
+    pub artifact: &'static str,
+    /// The artifact's stem name (e.g. `rust-engineer`, `tm-doctor`).
+    pub name: String,
+    /// How the catalog copy drifted from the deployed copy.
+    pub kind: ChangeKind,
+}
+
+/// The outcome of a catalog staleness check.
+///
+/// Why: `/health` surfaces `catalog_stale` and a small change summary; the TUI
+/// reads the flag for its indicator; the `apply` command reports what it will
+/// refresh. One struct serves all three so the detection logic stays in one
+/// place.
+/// What: `stale` is true when at least one selected catalog artifact is new or
+/// changed; `unknown` is true when the catalog has never been synced (no source
+/// tree to compare against) — distinct from "fresh" so the surface can say
+/// "run `tm catalog sync` first" rather than implying currency. `changes` is the
+/// bounded per-artifact drift list.
+/// Test: `detect_*` tests assert each flag and the change list.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StalenessReport {
+    /// True when at least one selected catalog artifact differs from deployed.
+    pub stale: bool,
+    /// True when the catalog has never been synced (nothing to compare).
+    pub unknown: bool,
+    /// The drift list (bounded by [`MAX_CHANGES`]); empty when not stale.
+    pub changes: Vec<CatalogChange>,
+}
+
+/// Cap on the number of per-artifact changes retained in a report.
+///
+/// Why: a first-ever sync against an empty deployment would flag ~40 agents +
+/// ~25 skills as `new`; carrying every one onto the health response is needless.
+/// A small cap keeps the payload (and the TUI hint) tidy while still proving
+/// staleness. The `stale` flag itself is never capped.
+/// What: the maximum length of [`StalenessReport::changes`].
+/// Test: `detect_caps_change_list`.
+pub const MAX_CHANGES: usize = 12;
+
+impl StalenessReport {
+    /// Render the change list as short human lines (e.g. `agent foo: changed`).
+    ///
+    /// Why: both the CLI `apply` output and the daemon's `catalog_changes` field
+    /// want the same compact wording; centralizing it keeps them identical.
+    /// What: one `"<artifact> <name>: <kind>"` string per change, in list order.
+    /// Test: `summary_lines_render_kind_and_name`.
+    pub fn summary_lines(&self) -> Vec<String> {
+        self.changes
+            .iter()
+            .map(|c| format!("{} {}: {}", c.artifact, c.name, c.kind.label()))
+            .collect()
+    }
+}
+
+/// List the `.md` stems directly under `dir`, sorted; empty when `dir` is absent.
+///
+/// Why: both the agent and skill catalog comparisons iterate the source `.md`
+/// files deterministically; a shared helper keeps ordering stable so the change
+/// list (and its cap) are reproducible.
+/// What: reads `dir`, keeps regular `*.md` files, returns their `.md`-stripped
+/// stems sorted. A missing directory yields an empty vec (the caller treats that
+/// as "never synced" for the whole tree).
+/// Test: exercised via `detect_*` which seed catalog dirs.
+fn md_stems(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut stems: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter_map(|e| {
+            let name = e.file_name();
+            let name = name.to_str()?;
+            name.strip_suffix(".md").map(str::to_owned)
+        })
+        .collect();
+    stems.sort_unstable();
+    stems
+}
+
+/// Compare a catalog agent source tree against the deployed agent manifest.
+///
+/// Why: the agent half of staleness — for each selected catalog agent, the
+/// content the next deploy WOULD write (the composed agent) is hashed and
+/// compared to the checksum the manifest recorded for the deployed file. A
+/// missing manifest entry means the agent is new; a differing hash means it
+/// changed upstream since deploy.
+/// What: pushes a [`CatalogChange`] for every selected catalog agent whose
+/// composed-hash is absent-from or differs-from the deployed manifest. Agents the
+/// predicate rejects are skipped (they are not part of this harness's set). An
+/// agent that fails to compose is skipped rather than reported (it cannot be
+/// deployed either, so it is not actionable drift).
+/// Test: `detect_flags_changed_agent`, `detect_not_stale_when_identical`,
+/// `detect_respects_selection`.
+fn agent_changes(
+    catalog_agents: &Path,
+    deployed: &AgentManifest,
+    select: &impl Fn(&str) -> bool,
+    out: &mut Vec<CatalogChange>,
+) {
+    for stem in md_stems(catalog_agents) {
+        if !select(&stem) {
+            continue;
+        }
+        let Ok(composed) = compose_agent(&stem, catalog_agents) else {
+            continue;
+        };
+        let filename = format!("{stem}.md");
+        let catalog_hash = checksum(&composed);
+        match deployed.managed.get(&filename) {
+            None => out.push(CatalogChange {
+                artifact: "agent",
+                name: stem,
+                kind: ChangeKind::New,
+            }),
+            Some(entry) if entry.checksum != catalog_hash => out.push(CatalogChange {
+                artifact: "agent",
+                name: stem,
+                kind: ChangeKind::Changed,
+            }),
+            Some(_) => {}
+        }
+    }
+}
+
+/// Compare a catalog skill source tree against the deployed skill manifest.
+///
+/// Why: the skill half of staleness. Skills carry no inheritance, so the catalog
+/// content the next deploy would write is the raw file body; its hash is compared
+/// to the deployed skill manifest's checksum.
+/// What: pushes a [`CatalogChange`] for every selected catalog skill whose raw
+/// content hash is absent-from or differs-from the deployed skill manifest.
+/// Unreadable files are skipped (not actionable). The skill source the deployer
+/// consumes is a flat `<stem>.md` layout, and the [`SkillManifest`] is keyed by
+/// the bare STEM (no `.md`) — so the lookup uses `stem`, matching the deployer.
+/// Test: `detect_flags_new_skill`, `detect_not_stale_when_identical`.
+fn skill_changes(
+    catalog_skills: &Path,
+    deployed: &SkillManifest,
+    select: &impl Fn(&str) -> bool,
+    out: &mut Vec<CatalogChange>,
+) {
+    for stem in md_stems(catalog_skills) {
+        if !select(&stem) {
+            continue;
+        }
+        let filename = format!("{stem}.md");
+        let Ok(body) = std::fs::read_to_string(catalog_skills.join(&filename)) else {
+            continue;
+        };
+        // The SkillManifest is keyed by stem (no `.md`), per the skill deployer.
+        if deployed.is_managed(&stem) {
+            if !deployed.checksum_matches(&stem, &body) {
+                out.push(CatalogChange {
+                    artifact: "skill",
+                    name: stem,
+                    kind: ChangeKind::Changed,
+                });
+            }
+        } else {
+            out.push(CatalogChange {
+                artifact: "skill",
+                name: stem,
+                kind: ChangeKind::New,
+            });
+        }
+    }
+}
+
+/// Detect whether the deployed harness content is stale vs the synced catalog.
+///
+/// Why: this is the single autonomous check DOC-17 §HR-3 mandates — surfaced on
+/// `/health`, shown in the TUI, and the precondition for the rebuild offer. It is
+/// deliberately a pure, offline SHA compare so it can run on the health hot path
+/// and in deterministic tests without a network or a live `claude`.
+/// What: when neither catalog source tree exists (the catalog was never synced)
+/// returns `unknown` (and NOT stale) so the surface can prompt a sync rather than
+/// imply currency — DOC-17's "catalog unreachable → treat as not-stale, never
+/// block". Otherwise it compares the selected catalog agents (composed-hash vs
+/// the deployed [`AgentManifest`]) and skills (raw-hash vs the deployed
+/// [`SkillManifest`]); `stale` is true iff any selected artifact is new or
+/// changed. The change list is capped at [`MAX_CHANGES`].
+/// Test: `detect_unknown_when_never_synced`, `detect_flags_changed_agent`,
+/// `detect_flags_new_skill`, `detect_not_stale_when_identical`,
+/// `detect_respects_selection`, `detect_caps_change_list`.
+pub fn detect_staleness(
+    catalog_agents: &Path,
+    catalog_skills: &Path,
+    deployed_agents: &AgentManifest,
+    deployed_skills: &SkillManifest,
+    agent_select: impl Fn(&str) -> bool,
+    skill_select: impl Fn(&str) -> bool,
+) -> StalenessReport {
+    // Never-synced: neither source tree is present. Report `unknown` rather than
+    // fabricating staleness — there is nothing authoritative to compare against.
+    if !catalog_agents.is_dir() && !catalog_skills.is_dir() {
+        return StalenessReport {
+            stale: false,
+            unknown: true,
+            changes: Vec::new(),
+        };
+    }
+
+    let mut changes = Vec::new();
+    agent_changes(catalog_agents, deployed_agents, &agent_select, &mut changes);
+    skill_changes(catalog_skills, deployed_skills, &skill_select, &mut changes);
+
+    let stale = !changes.is_empty();
+    changes.truncate(MAX_CHANGES);
+    StalenessReport {
+        stale,
+        unknown: false,
+        changes,
+    }
+}
+
+/// Detect staleness for a framework root, resolving the harness manifest itself.
+///
+/// Why: both `GET /health` and `tm catalog apply` need staleness against the SAME
+/// inputs the launcher uses — the catalog checkout `CatalogSync` populates and the
+/// manifest-selected agent/skill set. Centralizing the resolve→plan→compare here
+/// means the daemon and the CLI cannot drift on WHAT counts as the harness set.
+/// It performs NO network sync: it compares the already-synced catalog checkout
+/// (gated upstream by the TTL) against the already-deployed manifests, so it is
+/// cheap enough for the health hot path.
+/// What: resolves the effective [`HarnessManifest`] for `project_dir` (the
+/// project override layer; pass the framework root for the daemon-wide baseline),
+/// materializes the [`HarnessPlan`] to learn the catalog source dirs + selection
+/// predicates, loads the deployed [`AgentManifest`]/[`SkillManifest`] from
+/// `~/.claude/`, and runs [`detect_staleness`]. When the plan's content sources
+/// are *bundled* (the default manifest) the catalog dirs do not exist, so the
+/// result is `unknown` — staleness is only meaningful once a manifest opts an
+/// artifact class onto the catalog source.
+/// Test: `detect_for_framework_unknown_without_catalog` (bundled default →
+/// unknown); the catalog-source path is covered by the daemon/apply integration
+/// tests which seed a catalog checkout.
+pub fn detect_for_framework(
+    fw: &crate::core::paths::FrameworkPaths,
+    project_dir: &Path,
+) -> StalenessReport {
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    let sources =
+        crate::core::manifest::ManifestSources::resolve(project_dir, &fw.root, &catalog_root);
+    let manifest = crate::core::manifest::resolve_manifest(&sources);
+    let plan = crate::core::manifest::HarnessPlan::from_manifest(&manifest, fw, &catalog_root);
+
+    let deployed_agents = AgentManifest::load(&fw.claude_agents_dir());
+    let deployed_skills = SkillManifest::load(&fw.claude_skills_dir());
+
+    detect_staleness(
+        &plan.agent_source,
+        &plan.skill_source,
+        &deployed_agents,
+        &deployed_skills,
+        |name| plan.agent_selected(name),
+        |name| plan.skill_selected(name),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/core/update_check/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/tests.rs
@@ -1,0 +1,324 @@
+//! Unit tests for catalog staleness detection (HR-3).
+//!
+//! Why: DOC-17 §HR-3 requires deterministic, offline staleness detection — these
+//! tests pin the contract (stale on change, not-stale on identical, unknown when
+//! never synced, selection filtering, change-list cap) without any network or a
+//! live `claude`.
+//! What: seed a catalog source tree on disk, build a deployed manifest whose
+//! checksums match (or do not match) the composed/raw content, and assert the
+//! [`StalenessReport`] flags + change list.
+//! Test: this IS the test module.
+
+use super::*;
+use crate::core::agent_manifest::{AgentManifest, ManifestEntry, Origin, checksum};
+use crate::core::skill_manifest::{SkillManifest, SkillManifestEntry};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Write a single self-contained (no `extends:`) agent file into `dir`.
+fn write_agent(dir: &Path, stem: &str, body: &str) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join(format!("{stem}.md")),
+        format!("---\nname: {stem}\nrole: {stem}\n---\n\n# {stem}\n\n{body}\n"),
+    )
+    .unwrap();
+}
+
+/// Write a flat skill file into `dir`.
+fn write_skill(dir: &Path, stem: &str, body: &str) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join(format!("{stem}.md")),
+        format!("# {stem}\n\n{body}\n"),
+    )
+    .unwrap();
+}
+
+/// Build a deployed agent manifest whose entry matches the COMPOSED catalog
+/// agent (i.e. as if it had just been deployed from this exact catalog).
+fn deployed_agent_matching(catalog_agents: &Path, stem: &str) -> AgentManifest {
+    let composed = compose_agent(stem, catalog_agents).unwrap();
+    let mut m = AgentManifest::default();
+    m.managed.insert(
+        format!("{stem}.md"),
+        ManifestEntry {
+            source_chain: vec![stem.to_owned()],
+            checksum: checksum(&composed),
+            deployed_at: "2026-06-17T00:00:00Z".to_owned(),
+            origin: Origin::Bundled,
+        },
+    );
+    m
+}
+
+/// Build a deployed skill manifest whose entry matches the RAW catalog skill.
+fn deployed_skill_matching(catalog_skills: &Path, stem: &str) -> SkillManifest {
+    let body = fs::read_to_string(catalog_skills.join(format!("{stem}.md"))).unwrap();
+    let mut m = SkillManifest::default();
+    m.managed.insert(
+        stem.to_owned(),
+        SkillManifestEntry {
+            checksum: checksum(&body),
+            deployed_at: "2026-06-17T00:00:00Z".to_owned(),
+        },
+    );
+    m
+}
+
+#[test]
+fn detect_unknown_when_never_synced() {
+    // No catalog source trees exist (never synced). The report must be
+    // `unknown` and NOT stale — DOC-17: never fabricate staleness, never block.
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("repo/.claude/agents");
+    let skills = root.path().join("repo/.claude/skills");
+
+    let report = detect_staleness(
+        &agents,
+        &skills,
+        &AgentManifest::default(),
+        &SkillManifest::default(),
+        |_| true,
+        |_| true,
+    );
+    assert!(report.unknown, "never-synced must be unknown");
+    assert!(!report.stale, "never-synced must not be stale");
+    assert!(report.changes.is_empty());
+}
+
+#[test]
+fn detect_not_stale_when_identical() {
+    // A catalog whose content exactly matches the deployed checksums is NOT
+    // stale, even though the source trees exist (so not `unknown` either).
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("agents");
+    let skills = root.path().join("skills");
+    write_agent(&agents, "rust-engineer", "ENGINEER BODY");
+    write_skill(&skills, "tm-doctor", "DOCTOR BODY");
+
+    let dep_agents = deployed_agent_matching(&agents, "rust-engineer");
+    let dep_skills = deployed_skill_matching(&skills, "tm-doctor");
+
+    let report = detect_staleness(
+        &agents,
+        &skills,
+        &dep_agents,
+        &dep_skills,
+        |_| true,
+        |_| true,
+    );
+    assert!(!report.unknown, "synced catalog is not unknown");
+    assert!(!report.stale, "identical content is not stale: {report:?}");
+    assert!(report.changes.is_empty());
+}
+
+#[test]
+fn detect_flags_changed_agent() {
+    // Deploy matches the catalog, THEN the catalog agent changes upstream. The
+    // report must be stale with a single `agent ...: changed` entry.
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("agents");
+    let skills = root.path().join("skills");
+    write_agent(&agents, "rust-engineer", "ORIGINAL BODY");
+
+    // Baseline deploy matches the original catalog content.
+    let dep_agents = deployed_agent_matching(&agents, "rust-engineer");
+
+    // Upstream edit: the catalog agent body changes.
+    write_agent(&agents, "rust-engineer", "UPSTREAM EDIT — NEW BEHAVIOUR");
+
+    let report = detect_staleness(
+        &agents,
+        &skills,
+        &dep_agents,
+        &SkillManifest::default(),
+        |_| true,
+        |_| true,
+    );
+    assert!(report.stale, "changed agent must be stale");
+    assert!(!report.unknown);
+    assert_eq!(report.changes.len(), 1, "exactly one change: {report:?}");
+    assert_eq!(report.changes[0].artifact, "agent");
+    assert_eq!(report.changes[0].name, "rust-engineer");
+    assert_eq!(report.changes[0].kind, ChangeKind::Changed);
+}
+
+#[test]
+fn detect_flags_new_agent() {
+    // A catalog agent absent from the deployed manifest is `new` → stale.
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("agents");
+    write_agent(&agents, "newcomer", "BRAND NEW");
+
+    let report = detect_staleness(
+        &agents,
+        &root.path().join("skills"),
+        &AgentManifest::default(),
+        &SkillManifest::default(),
+        |_| true,
+        |_| true,
+    );
+    assert!(report.stale);
+    assert_eq!(report.changes[0].kind, ChangeKind::New);
+    assert_eq!(report.changes[0].name, "newcomer");
+}
+
+#[test]
+fn detect_flags_new_skill() {
+    // A catalog skill absent from the deployed skill manifest is `new` → stale.
+    let root = TempDir::new().unwrap();
+    let skills = root.path().join("skills");
+    write_skill(&skills, "fresh-skill", "NEW SKILL");
+
+    let report = detect_staleness(
+        &root.path().join("agents"),
+        &skills,
+        &AgentManifest::default(),
+        &SkillManifest::default(),
+        |_| true,
+        |_| true,
+    );
+    assert!(report.stale);
+    assert_eq!(report.changes.len(), 1);
+    assert_eq!(report.changes[0].artifact, "skill");
+    assert_eq!(report.changes[0].name, "fresh-skill");
+    assert_eq!(report.changes[0].kind, ChangeKind::New);
+}
+
+#[test]
+fn detect_flags_changed_skill() {
+    // Deploy matches, then the catalog skill body changes → `skill ...: changed`.
+    let root = TempDir::new().unwrap();
+    let skills = root.path().join("skills");
+    write_skill(&skills, "tm-doctor", "ORIGINAL");
+    let dep_skills = deployed_skill_matching(&skills, "tm-doctor");
+    write_skill(&skills, "tm-doctor", "UPSTREAM CHANGED");
+
+    let report = detect_staleness(
+        &root.path().join("agents"),
+        &skills,
+        &AgentManifest::default(),
+        &dep_skills,
+        |_| true,
+        |_| true,
+    );
+    assert!(report.stale);
+    assert_eq!(report.changes[0].kind, ChangeKind::Changed);
+    assert_eq!(report.changes[0].artifact, "skill");
+}
+
+#[test]
+fn detect_respects_selection() {
+    // An agent the selection predicate REJECTS must not count toward staleness,
+    // even when it differs from (here: is absent from) the deployed manifest.
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("agents");
+    write_agent(&agents, "rust-engineer", "BODY");
+    write_agent(&agents, "php-engineer", "BODY");
+
+    // Deploy matches rust-engineer; php-engineer is new BUT deselected.
+    let dep_agents = deployed_agent_matching(&agents, "rust-engineer");
+
+    let report = detect_staleness(
+        &agents,
+        &root.path().join("skills"),
+        &dep_agents,
+        &SkillManifest::default(),
+        |name| name == "rust-engineer", // exclude php-engineer
+        |_| true,
+    );
+    assert!(
+        !report.stale,
+        "a deselected new agent must not make the harness stale: {report:?}"
+    );
+}
+
+#[test]
+fn detect_caps_change_list() {
+    // Many new agents must still set `stale`, but the change list is capped at
+    // MAX_CHANGES so the health payload stays small.
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("agents");
+    for i in 0..(MAX_CHANGES + 8) {
+        write_agent(&agents, &format!("agent{i:02}"), "BODY");
+    }
+
+    let report = detect_staleness(
+        &agents,
+        &root.path().join("skills"),
+        &AgentManifest::default(),
+        &SkillManifest::default(),
+        |_| true,
+        |_| true,
+    );
+    assert!(report.stale);
+    assert_eq!(
+        report.changes.len(),
+        MAX_CHANGES,
+        "change list must be capped"
+    );
+}
+
+#[test]
+fn summary_lines_render_kind_and_name() {
+    // The human summary must read `<artifact> <name>: <kind>`.
+    let report = StalenessReport {
+        stale: true,
+        unknown: false,
+        changes: vec![
+            CatalogChange {
+                artifact: "agent",
+                name: "rust-engineer".into(),
+                kind: ChangeKind::Changed,
+            },
+            CatalogChange {
+                artifact: "skill",
+                name: "tm-doctor".into(),
+                kind: ChangeKind::New,
+            },
+        ],
+    };
+    let lines = report.summary_lines();
+    assert_eq!(lines[0], "agent rust-engineer: changed");
+    assert_eq!(lines[1], "skill tm-doctor: new");
+}
+
+#[test]
+fn detect_for_framework_unknown_without_catalog() {
+    // With the compiled-in default manifest (bundled sources) and an empty
+    // framework root, the catalog source trees do not exist, so the framework-
+    // level detection reports `unknown` — never a fabricated staleness.
+    let fw_root = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::under(fw_root.path());
+    let report = detect_for_framework(&fw, fw_root.path());
+    assert!(
+        report.unknown,
+        "bundled default with no catalog must be unknown: {report:?}"
+    );
+    assert!(!report.stale);
+}
+
+#[test]
+fn detect_unknown_when_only_one_tree_missing_is_not_unknown() {
+    // If at least ONE source tree exists, the catalog has been synced; the report
+    // is a real comparison (not `unknown`) over whichever tree is present.
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("agents");
+    write_agent(&agents, "solo", "BODY"); // skills tree absent
+
+    let report = detect_staleness(
+        &agents,
+        &root.path().join("skills"), // does not exist
+        &AgentManifest::default(),
+        &SkillManifest::default(),
+        |_| true,
+        |_| true,
+    );
+    assert!(
+        !report.unknown,
+        "one present tree means synced, not unknown"
+    );
+    assert!(report.stale, "the present agent is new → stale");
+}

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -199,15 +199,36 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .with_state(state)
 }
 
-/// Liveness probe — always returns `ok` while the daemon is up.
+/// Liveness probe plus the HR-3 catalog-staleness signal.
+///
+/// Why: liveness alone is not enough for an autonomous runner — DOC-17 §HR-3
+/// requires `/health` to SURFACE whether the deployed harness content has drifted
+/// from the synced catalog so the TUI can show an indicator and the operator can
+/// rebuild. The check is a cheap, offline SHA compare (no network pull on the
+/// hot path), and an unreachable/never-synced catalog degrades to `unknown`
+/// (never `stale`, never an error) per the spec's "never block" rule.
+/// What: returns `status: "ok"` with `catalog_stale`/`catalog_unknown` flags and
+/// a small `catalog_changes` summary, computed via
+/// [`crate::core::update_check::detect_for_framework`] anchored at the daemon's
+/// framework root.
+/// Test: `health_reports_ok_status`, `health_reports_catalog_unknown_without_catalog`.
 #[utoipa::path(
     get,
     path = "/health",
     tag = "config",
-    responses((status = 200, description = "Daemon is alive", body = String))
+    responses((status = 200, description = "Daemon is alive", body = HealthResponse))
 )]
-pub async fn health() -> &'static str {
-    "ok"
+pub async fn health(State(state): State<Arc<DaemonState>>) -> Json<HealthResponse> {
+    let fw = crate::core::paths::FrameworkPaths::from_root(state.framework_root());
+    // The daemon-wide baseline uses the framework root as the "project" so only
+    // the user/catalog/default manifest layers apply (no per-project override).
+    let report = crate::core::update_check::detect_for_framework(&fw, state.framework_root());
+    Json(HealthResponse {
+        status: "ok".to_owned(),
+        catalog_stale: report.stale,
+        catalog_unknown: report.unknown,
+        catalog_changes: report.summary_lines(),
+    })
 }
 
 /// Query parameters for `GET /sessions`.

--- a/crates/trusty-mpm/src/daemon/api/types.rs
+++ b/crates/trusty-mpm/src/daemon/api/types.rs
@@ -22,6 +22,32 @@ use crate::core::session::Session;
 use crate::daemon::optimizer::OptimizerConfig;
 use crate::daemon::tmux::{AdoptedSession, SessionSnapshot};
 
+/// Response of `GET /health`.
+///
+/// Why: HR-3 / DOC-17 requires the daemon to SURFACE catalog staleness so the
+/// TUI can show an indicator and the operator can decide to rebuild. The probe
+/// stays a liveness check (`status: "ok"`) and additionally carries the
+/// cheap, offline catalog-staleness signal computed from the already-synced
+/// catalog checkout vs the deployed checksum manifests — it never blocks on a
+/// network pull.
+/// What: `status` is the liveness word; `catalog_stale` is true when deployed
+/// content drifts from the synced catalog; `catalog_unknown` is true when the
+/// catalog has never been synced (distinct from "fresh"); `catalog_changes` is a
+/// small human summary of WHAT changed (empty unless stale).
+/// Test: `health_reports_catalog_unknown_without_catalog`,
+/// `health_reports_ok_status`.
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct HealthResponse {
+    /// Liveness word — `"ok"` while the daemon is up.
+    pub status: String,
+    /// True when deployed agents/skills drift from the synced catalog (HR-3).
+    pub catalog_stale: bool,
+    /// True when the catalog has never been synced (nothing to compare).
+    pub catalog_unknown: bool,
+    /// Short human summary of changed artifacts (empty unless `catalog_stale`).
+    pub catalog_changes: Vec<String>,
+}
+
 /// Response of `GET /sessions`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SessionsResponse {

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -13,8 +13,27 @@ fn state_with_session() -> (Arc<DaemonState>, SessionId) {
 }
 
 #[tokio::test]
-async fn health_endpoint_responds() {
-    assert_eq!(health().await, "ok");
+async fn health_reports_ok_status() {
+    // The liveness word stays `ok` — the HR-3 staleness fields are additive.
+    let state = DaemonState::shared();
+    let Json(body) = health(State(state)).await;
+    assert_eq!(body.status, "ok");
+}
+
+#[tokio::test]
+async fn health_reports_catalog_unknown_without_catalog() {
+    // With a fresh framework root and no synced catalog, the staleness check must
+    // report `catalog_unknown` (NOT stale, NOT an error) — DOC-17's degrade rule.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(tmp.path().to_path_buf()));
+    let Json(body) = health(State(state)).await;
+    assert_eq!(body.status, "ok");
+    assert!(
+        body.catalog_unknown,
+        "no catalog synced → unknown: {body:?}"
+    );
+    assert!(!body.catalog_stale, "unknown must not be stale");
+    assert!(body.catalog_changes.is_empty());
 }
 
 #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/openapi.rs
+++ b/crates/trusty-mpm/src/daemon/openapi.rs
@@ -71,6 +71,7 @@ use utoipa::OpenApi;
         super::api::doctor,
     ),
     components(schemas(
+        super::api::HealthResponse,
         crate::core::session::Session,
         crate::core::session::SessionStatus,
         crate::core::session::SessionId,

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -327,6 +327,20 @@ impl DaemonState {
         }
     }
 
+    /// The framework root directory this daemon was configured with.
+    ///
+    /// Why: the `GET /health` catalog-staleness check (HR-3) resolves the harness
+    /// manifest and the deployed-content manifests under this root; exposing it
+    /// lets the handler build a [`crate::core::paths::FrameworkPaths`] anchored to
+    /// the SAME root the daemon uses (a temp dir in tests, `~/.trusty-mpm` in
+    /// production) instead of recomputing the default.
+    /// What: returns the resolved framework root path.
+    /// Test: `health_reports_catalog_unknown_without_catalog` builds state
+    /// `with_root` a tempdir and asserts the handler reads it.
+    pub fn framework_root(&self) -> &std::path::Path {
+        &self.framework_root
+    }
+
     /// Return the shared activity monitor, constructing it on first access.
     ///
     /// Why: the `/sessions/managed/{id}/activity` handler needs a single,

--- a/crates/trusty-mpm/src/tui/coordinator/layout.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/layout.rs
@@ -101,6 +101,33 @@ pub fn daemon_indicator(state: &CoordinatorState) -> &'static str {
     }
 }
 
+/// The status-bar hint shown when the daemon reports the catalog is stale (HR-3).
+///
+/// Why: DOC-17 §HR-3 requires a non-intrusive "update available" signal plus a
+/// hint at the rebuild action; naming the literal here single-sources it between
+/// the renderer and its test. The trailing command names the apply path so the
+/// operator knows HOW to act on the offer.
+/// What: the literal `catalog: ↑updates available (tm catalog apply)`.
+/// Test: `catalog_indicator_reflects_staleness`.
+pub const CATALOG_STALE_HINT: &str = "catalog: ↑updates available (tm catalog apply)";
+
+/// The catalog-staleness hint for the current state, if any.
+///
+/// Why: the status bar only shows the rebuild offer when there IS an update, and
+/// only when the daemon is reachable (a down daemon's flag is meaningless). A
+/// pure helper keeps that branch out of [`render`] and testable without a
+/// terminal.
+/// What: returns `Some(`[`CATALOG_STALE_HINT`]`)` when the daemon is reachable
+/// AND `catalog_stale`, else `None`.
+/// Test: `catalog_indicator_reflects_staleness`.
+pub fn catalog_indicator(state: &CoordinatorState) -> Option<&'static str> {
+    if state.daemon_reachable && state.catalog_stale {
+        Some(CATALOG_STALE_HINT)
+    } else {
+        None
+    }
+}
+
 /// Build the unified session-list items: controller row 0, then sessions.
 ///
 /// Why: the list always leads with the controller bullet and renders the
@@ -179,11 +206,16 @@ pub fn render(frame: &mut Frame, state: &CoordinatorState) {
     frame.render_widget(list, chunks[1]);
 
     // Status / key bar (bottom): key hints on the left, the live daemon-
-    // reachability indicator on the right.
+    // reachability indicator on the right, plus the HR-3 catalog-staleness hint
+    // when the daemon reports an available update.
+    let catalog_segment = catalog_indicator(state)
+        .map(|hint| format!("  ·  {hint}"))
+        .unwrap_or_default();
     let status = Paragraph::new(Line::from(format!(
-        "{}  ·  {}",
+        "{}  ·  {}{}",
         status_bar_text(),
-        daemon_indicator(state)
+        daemon_indicator(state),
+        catalog_segment
     )))
     .style(
         Style::default()

--- a/crates/trusty-mpm/src/tui/coordinator/poll.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/poll.rs
@@ -44,6 +44,9 @@ pub(crate) async fn coord_poll_daemon(state: &mut CoordinatorState, client: &mut
         state.daemon_reachable = client.is_healthy().await;
     }
     if state.daemon_reachable {
+        // Read the additive HR-3 catalog-staleness flag off the SAME health
+        // surface; a failure or older daemon degrades to "no updates" (false).
+        state.catalog_stale = client.catalog_stale().await;
         match client.coordinator_context().await {
             Ok(context) => {
                 state.sessions = context
@@ -58,6 +61,9 @@ pub(crate) async fn coord_poll_daemon(state: &mut CoordinatorState, client: &mut
             }
         }
     } else {
+        // Daemon down: clear the session rows AND the staleness hint so neither
+        // shows stale information.
+        state.catalog_stale = false;
         state.sessions.clear();
     }
     state.clamp_selection();

--- a/crates/trusty-mpm/src/tui/coordinator/state.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/state.rs
@@ -96,6 +96,18 @@ pub struct CoordinatorState {
     /// daemon-down flip to `false`; the daemon-up flip needs a live daemon and is
     /// exercised manually.
     pub daemon_reachable: bool,
+    /// Whether the daemon reports the deployed catalog content is stale (HR-3).
+    ///
+    /// Why: DOC-17 §HR-3 requires the operator surface to show that an update is
+    /// available so they can rebuild. The coordinator poll reads the additive
+    /// `catalog_stale` field off `GET /health` and the status bar renders a small
+    /// `catalog: ↑updates available` hint when it is set. Defaults to `false`
+    /// (no update) until the first health poll reports otherwise.
+    /// What: set by [`super::poll::coord_poll_daemon`] from the health probe.
+    /// Test: `poll_marks_unreachable_clears_sessions` confirms it stays `false`
+    /// on a dead daemon; the rendered hint is covered by
+    /// `catalog_indicator_reflects_staleness` in `super::tests`.
+    pub catalog_stale: bool,
     /// Set when the operator asks to quit; the event loop exits on the next tick.
     pub should_exit: bool,
 }

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -12,8 +12,8 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::events::{SlashCommand, handle_key, is_quit, parse_slash};
 use super::layout::{
-    CONTROLLER_STATUS, DAEMON_REACHABLE, DAEMON_UNREACHABLE, INPUT_PROMPT, STATUS_BAR_HINT,
-    daemon_indicator, input_line, status_bar_text,
+    CATALOG_STALE_HINT, CONTROLLER_STATUS, DAEMON_REACHABLE, DAEMON_UNREACHABLE, INPUT_PROMPT,
+    STATUS_BAR_HINT, catalog_indicator, daemon_indicator, input_line, status_bar_text,
 };
 use super::poll::{coord_poll_daemon, coord_session_to_entry};
 use super::rows::{
@@ -444,6 +444,30 @@ fn daemon_indicator_reflects_reachability() {
     assert_eq!(daemon_indicator(&state), DAEMON_REACHABLE);
     // The two indicators are visually distinct.
     assert_ne!(DAEMON_REACHABLE, DAEMON_UNREACHABLE);
+}
+
+#[test]
+fn catalog_indicator_reflects_staleness() {
+    // The HR-3 rebuild offer shows ONLY when the daemon is reachable AND reports
+    // the catalog is stale; otherwise the status bar stays clean.
+    let mut state = CoordinatorState::live();
+    // Down daemon, no flag → nothing.
+    assert_eq!(catalog_indicator(&state), None);
+
+    // Stale flag but daemon DOWN → still nothing (a down daemon's flag is moot).
+    state.catalog_stale = true;
+    assert_eq!(catalog_indicator(&state), None);
+
+    // Reachable + stale → the rebuild-offer hint appears.
+    state.daemon_reachable = true;
+    assert_eq!(catalog_indicator(&state), Some(CATALOG_STALE_HINT));
+
+    // Reachable + fresh → nothing.
+    state.catalog_stale = false;
+    assert_eq!(catalog_indicator(&state), None);
+
+    // The hint names the apply command so the offer is actionable.
+    assert!(CATALOG_STALE_HINT.contains("tm catalog apply"));
 }
 
 // ---- Child #2: live polling — daemon-down branch (async) ------------------

--- a/crates/trusty-mpm/tests/e2e/test_health.rs
+++ b/crates/trusty-mpm/tests/e2e/test_health.rs
@@ -1,8 +1,11 @@
-//! E2E: liveness probe.
+//! E2E: liveness probe + HR-3 catalog-staleness fields.
 
 use crate::harness::TestDaemon;
 
-/// `GET /health` returns `200` with the `ok` liveness body.
+/// `GET /health` returns `200` with the JSON liveness body, including the HR-3
+/// `catalog_stale` / `catalog_unknown` fields. Against a fresh test daemon with
+/// no synced catalog, staleness must degrade to `catalog_unknown` (never an
+/// error, never `catalog_stale`).
 #[tokio::test]
 async fn health_returns_ok() {
     let daemon = TestDaemon::spawn().await;
@@ -13,6 +16,18 @@ async fn health_returns_ok() {
         .await
         .expect("health request");
     assert_eq!(resp.status(), 200);
-    let body = resp.text().await.expect("health body");
-    assert_eq!(body, "ok");
+    let body: serde_json::Value = resp.json().await.expect("health json body");
+    assert_eq!(body["status"], "ok");
+    // The staleness fields are present and well-typed.
+    assert!(body["catalog_stale"].is_boolean(), "catalog_stale present");
+    assert!(
+        body["catalog_unknown"].is_boolean(),
+        "catalog_unknown present"
+    );
+    assert!(
+        body["catalog_changes"].is_array(),
+        "catalog_changes present"
+    );
+    // A fresh daemon with no synced catalog must never report stale.
+    assert_eq!(body["catalog_stale"], false, "no false-positive staleness");
 }


### PR DESCRIPTION
Closes #1408
Implements HR-3 (DOC-17: `docs/specs/harness-runner-vision.md`).
Epic #1405.

## What

Each launched session and the daemon now detect when the deployed harness
content has drifted from the synced claude-mpm catalog, surface that staleness,
and offer to rebuild/redeploy with the updated content — **the check is
autonomous; the rebuild is offered, never silently forced.**

### Staleness detection (`core/update_check`)
- `detect_staleness` is a pure, offline SHA compare: for the manifest-selected
  set, it hashes the catalog's current **agents** (composed, via `compose_agent`)
  and **skills** (raw body) and compares against the deployed `AgentManifest`
  (keyed by `<name>.md`) and `SkillManifest` (keyed by stem) checksums.
- Returns a `StalenessReport { stale, unknown, changes }` — `unknown` when the
  catalog was never synced (no tree to compare), `stale` when any selected
  artifact is new/changed, with a bounded (`MAX_CHANGES = 12`) per-artifact
  change list. **Never fabricates staleness; never blocks.**
- `detect_for_framework` resolves the harness manifest + `HarnessPlan` exactly
  as the launcher does, so the daemon and the CLI share one definition of the
  harness set and the catalog source dirs.

### `GET /health`
Now returns JSON `{ status, catalog_stale, catalog_unknown, catalog_changes }`.
Computed from the already-synced catalog checkout vs the deployed checksum
manifests — **no network pull on the hot path**; an unreachable/never-synced
catalog degrades to `catalog_unknown` (never `catalog_stale`, never an error).

### TUI indicator
The coordinator status bar shows `catalog: ↑updates available (tm catalog apply)`
when the daemon reports staleness, read off the **existing** health poll via the
new `DaemonClient::catalog_stale` (one probe, additive field; older daemons →
`false`).

### Rebuild offer: `tm catalog status` / `tm catalog apply`
- `tm catalog status [--json]` — reports staleness without mutating anything.
- `tm catalog apply [--force] [--prune]` — the offer made concrete: syncs the
  catalog (TTL-gated unless `--force`), redeploys the manifest-selected
  agents/skills (refreshing the checksum manifests so staleness **clears**), and
  with `--prune` removes **managed** (never user-owned) agents/skills the
  manifest no longer selects — the removal HR-2 deferred, behind an explicit
  opt-in.

## Regression-safety

With no catalog configured/synced (the compiled-in default manifest uses
**bundled** sources), everything behaves as today: `catalog_unknown`, no errors,
no staleness. Covered by `detect_for_framework_unknown_without_catalog` and
`health_reports_catalog_unknown_without_catalog`.

## Tests

Deterministic and offline — `FakeGitBackend` + seeded catalog trees, no live
network, no live `claude`. New coverage: staleness (stale on change, not stale
on identical, unknown when never synced, selection filtering, change-list cap),
`/health` fields, TUI indicator, client wire-shape, `apply` redeploy + clears
staleness, `apply --prune` removes deselected + spares user-owned, CLI parse.

`cargo test --workspace` (OPENROUTER_API_KEY unset), `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo fmt --check`, and
`bash scripts/check_line_cap.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)