### PR TITLE
feat(trusty-mpm): sessions TUI startup banner + service probes (STUI-0)

### DIFF
--- a/crates/trusty-mpm/src/tui/coordinator/banner.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/banner.rs
@@ -198,15 +198,18 @@ fn service_line(label: &str, outcome: &ProbeOutcome) -> String {
 /// misleading `0`. A pure helper keeps the pluralisation and the unknown-count
 /// branch testable offline.
 /// What: renders `<n> active session(s)` (singular at `1`) when the count is
-/// known, or `daemon unreachable` when `None`, then `  ·  <HELP_HINT>`.
-/// Test: `compose_banner_pluralizes_count`, `compose_banner_handles_unknown_count`.
+/// known, or `daemon unreachable` when `None`, then `  ·  <HELP_HINT>`, and
+/// terminates with a single trailing newline so the composed banner ends cleanly
+/// (the print site adds exactly one blank separator, never two).
+/// Test: `compose_banner_pluralizes_count`, `compose_banner_handles_unknown_count`,
+/// `compose_banner_has_single_trailing_newline`.
 fn startup_line(active_count: Option<usize>) -> String {
     let lead = match active_count {
         Some(1) => "1 active session".to_string(),
         Some(n) => format!("{n} active sessions"),
         None => "daemon unreachable".to_string(),
     };
-    format!("{lead}  ·  {HELP_HINT}")
+    format!("{lead}  ·  {HELP_HINT}\n")
 }
 
 /// Probe trusty-search health for the startup banner (fail-safe).
@@ -215,12 +218,14 @@ fn startup_line(active_count: Option<usize>) -> String {
 /// failure must degrade to `○ unreachable` (the TUI still opens), never abort.
 /// What: GETs `<base>/health` with a short timeout; any transport or non-2xx
 /// response yields [`ProbeOutcome::unreachable`]. `base` defaults to
-/// [`DEFAULT_SEARCH_URL`] when `None`.
+/// [`DEFAULT_SEARCH_URL`] when `None`. Builds a single bounded client and reuses
+/// it for the health check.
 /// Test: `probe_unreachable_search_is_inactive` drives the dead-daemon branch;
 /// the live path is exercised by launching the TUI against a running daemon.
 pub async fn probe_search(base: Option<&str>) -> ProbeOutcome {
     let base = base.unwrap_or(DEFAULT_SEARCH_URL);
-    if health_ok(base).await {
+    let client = probe_client();
+    if health_ok_with(&client, base).await {
         ProbeOutcome::active(None)
     } else {
         ProbeOutcome::unreachable(None)
@@ -235,7 +240,8 @@ pub async fn probe_search(base: Option<&str>) -> ProbeOutcome {
 /// palace assertion degrades to `○ unreachable` with a reason note, and the TUI
 /// still opens.
 /// What: GETs `<base>/health`; on success, GETs `<base>/api/v1/palaces/user` and,
-/// if absent, POSTs `<base>/api/v1/palaces` with `{"name":"user"}` to create it.
+/// only on a real 404, POSTs `<base>/api/v1/palaces` with `{"name":"user"}` to
+/// create it. Builds a single bounded client and threads it into both helpers.
 /// Returns [`ProbeOutcome::active`] with note `palace: user` when memory is live
 /// and the palace is present/creatable, else [`ProbeOutcome::unreachable`] with a
 /// short reason. `base` defaults to [`DEFAULT_MEMORY_URL`] when `None`.
@@ -243,10 +249,11 @@ pub async fn probe_search(base: Option<&str>) -> ProbeOutcome {
 /// the live + palace-assertion path is exercised against a running daemon.
 pub async fn probe_memory(base: Option<&str>) -> ProbeOutcome {
     let base = base.unwrap_or(DEFAULT_MEMORY_URL);
-    if !health_ok(base).await {
+    let client = probe_client();
+    if !health_ok_with(&client, base).await {
         return ProbeOutcome::unreachable(Some("memory daemon down".to_string()));
     }
-    if ensure_user_palace(base).await {
+    if ensure_user_palace_with(&client, base).await {
         ProbeOutcome::active(Some(format!("palace: {USER_PALACE}")))
     } else {
         ProbeOutcome::unreachable(Some(format!("{USER_PALACE} palace unavailable")))
@@ -260,49 +267,67 @@ pub async fn probe_memory(base: Option<&str>) -> ProbeOutcome {
 /// What: a `reqwest::Client` with [`PROBE_TIMEOUT`], falling back to the default
 /// client if the builder somehow fails (it cannot in practice).
 /// Test: covered indirectly by the probe tests.
-fn probe_client() -> reqwest::Client {
+pub(super) fn probe_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(PROBE_TIMEOUT)
         .build()
         .unwrap_or_default()
 }
 
-/// GET `<base>/health` and report whether it answered 2xx.
+/// GET `<base>/health` with the shared client and report whether it answered 2xx.
 ///
 /// Why: both probes share the same health check; a daemon that is down, slow, or
 /// returns an error status all collapse to "not healthy" so the banner degrades
-/// cleanly.
-/// What: issues a bounded GET to `<base>/health` and returns `true` only on a
-/// 2xx response.
+/// cleanly. Taking the client by reference lets each probe build exactly one
+/// client and reuse it across the health check and any follow-up request.
+/// What: issues a bounded GET to `<base>/health` via `client` and returns `true`
+/// only on a 2xx response.
 /// Test: covered by `probe_unreachable_*` (dead daemon → `false`).
-async fn health_ok(base: &str) -> bool {
-    let client = probe_client();
+async fn health_ok_with(client: &reqwest::Client, base: &str) -> bool {
     matches!(
         client.get(format!("{base}/health")).send().await,
         Ok(resp) if resp.status().is_success()
     )
 }
 
-/// Ensure the fixed `user` palace exists at `base`, creating it if absent (D4).
+/// Ensure the fixed `user` palace exists at `base`, creating it ONLY on a 404 (D4).
 ///
 /// Why: D4 makes memory "active" only when the `user` palace is present; the
 /// banner asserts it idempotently so first-run operators get a confirmed memory
-/// line without a manual provisioning step.
-/// What: GETs `<base>/api/v1/palaces/user`; on a 2xx it already exists. On a 404
-/// (or any non-2xx) it POSTs `<base>/api/v1/palaces` with `{"name":"user"}` and
-/// reports whether the create answered 2xx. Any transport error yields `false`.
-/// Test: covered indirectly by `probe_memory`; the live assertion path runs
-/// against a running daemon.
-async fn ensure_user_palace(base: &str) -> bool {
-    let client = probe_client();
-    if let Ok(resp) = client
+/// line without a manual provisioning step. Crucially, creation must be gated on
+/// a *real* 404 — a transient `500`/`503` (or any other non-2xx) means the
+/// daemon's state is unknown, so blindly POSTing a create would be wrong (it
+/// could race a half-up daemon or mask a real outage). Those cases degrade to
+/// `false` (memory renders `○ unreachable`) instead of attempting a write.
+/// What: GETs `<base>/api/v1/palaces/user` with the shared `client` and branches
+/// on the status: a 2xx means the palace already exists → `true`; a 404 means it
+/// is genuinely absent → POST `<base>/api/v1/palaces` with `{"name":"user"}` and
+/// return whether the create answered 2xx; any other status (5xx, etc.) →
+/// `false` without creating; a transport error → `false`.
+/// Test: `ensure_user_palace_creates_only_on_404` exercises the status branching
+/// against a stub server; the live assertion path runs against a running daemon.
+pub(super) async fn ensure_user_palace_with(client: &reqwest::Client, base: &str) -> bool {
+    let resp = match client
         .get(format!("{base}/api/v1/palaces/{USER_PALACE}"))
         .send()
         .await
-        && resp.status().is_success()
     {
+        Ok(resp) => resp,
+        // Transport error (daemon unreachable): do not attempt a create.
+        Err(_) => return false,
+    };
+
+    let status = resp.status();
+    if status.is_success() {
+        // Palace already exists.
         return true;
     }
+    if status != reqwest::StatusCode::NOT_FOUND {
+        // Any non-404 (5xx, etc.): state is unknown — do NOT create.
+        return false;
+    }
+
+    // Genuine 404 → the palace is absent, so create it.
     matches!(
         client
             .post(format!("{base}/api/v1/palaces"))
@@ -323,9 +348,10 @@ async fn ensure_user_palace(base: &str) -> bool {
 /// are fail-safe, so a down service slows startup by at most one [`PROBE_TIMEOUT`]
 /// and never aborts.
 /// What: probes memory + search concurrently, composes the banner with the
-/// crate `CARGO_PKG_VERSION` and `active_count`, and writes it to stderr followed
-/// by a blank line. `memory_url` / `search_url` default to the canonical local
-/// addresses when `None`.
+/// crate `CARGO_PKG_VERSION` and `active_count`, and writes it to stderr. The
+/// composed banner ends with a single trailing newline (from `startup_line`), so
+/// `eprintln!` adds exactly one blank separator after it — not two. `memory_url`
+/// / `search_url` default to the canonical local addresses when `None`.
 /// Test: composition is unit-tested via [`compose_banner`]; this print-only glue
 /// is exercised by launching the TUI.
 pub async fn print_startup_banner(
@@ -335,5 +361,5 @@ pub async fn print_startup_banner(
 ) {
     let (memory, search) = tokio::join!(probe_memory(memory_url), probe_search(search_url));
     let banner = compose_banner(env!("CARGO_PKG_VERSION"), &memory, &search, active_count);
-    eprintln!("{banner}\n");
+    eprintln!("{banner}");
 }

--- a/crates/trusty-mpm/src/tui/coordinator/banner.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/banner.rs
@@ -1,0 +1,339 @@
+//! Claude-Code-style startup banner + backplane probes (STUI-0, DOC-16 §3.1).
+//!
+//! Why: operators launching `tm sessions tui` want the same confidence-building
+//! startup Claude Code gives — the tool names itself + its version and confirms
+//! the trusty backplane (memory + search) is live before the interactive view
+//! takes over the terminal. DOC-16 §3.1 (STUI-0) pins that contract: a banner
+//! line `trusty-mpm sessions v<CARGO_PKG_VERSION>`, a memory line (probed against
+//! the fixed user-level `user` palace, decision D4), a search line (plain health
+//! probe), and a startup line with the active-session count + a `/help` hint. A
+//! probe failure renders `○ unreachable` and never blocks the TUI (§3.1 error
+//! conditions).
+//! What: the pure [`compose_banner`] (probe results + count → the exact banner
+//! text, unit-testable offline), the [`ProbeOutcome`] result type, the async
+//! [`probe_memory`] / [`probe_search`] probes (short-timeout, fail-safe), and
+//! [`print_startup_banner`] which runs the probes and prints the banner to
+//! stderr (stdout stays clean) before the alternate screen is entered.
+//! Test: `super::tests` covers the pure composition (version, glyphs, palace
+//! note, count + `/help`) for active/unreachable/zero-count permutations; the
+//! async probes degrade to `unreachable` against a dead daemon and are exercised
+//! by `probe_unreachable_*`.
+
+use std::time::Duration;
+
+use crate::tui::health::{DEFAULT_MEMORY_URL, DEFAULT_SEARCH_URL};
+
+/// Per-probe HTTP timeout for the startup backplane checks.
+///
+/// Why: a down (or slow) memory/search daemon must not stall the operator's
+/// startup; a short timeout turns an unresponsive service into a clean
+/// `○ unreachable` line rather than a multi-second hang before the TUI opens.
+/// What: two seconds — comfortably above a healthy local round-trip yet short
+/// enough to keep startup snappy when a service is down.
+/// Test: timeout value is side-effect-only; the unreachable path is covered by
+/// `probe_unreachable_memory_is_inactive` / `probe_unreachable_search_is_inactive`.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The fixed user-level palace the banner confirms memory against (D4).
+///
+/// Why: DOC-16 decision D4 fixes memory confirmation to a single user-scoped
+/// palace named `user` (shared across projects, distinct from the per-project
+/// and `session-manager` palaces). Naming it once here single-sources the id
+/// between the probe and its rendered note.
+/// What: the literal palace id `user`.
+/// Test: `compose_banner_active_shows_palace_note` asserts the rendered note
+/// carries this id.
+pub const USER_PALACE: &str = "user";
+
+/// Glyph shown for an active (reachable + confirmed) backplane service.
+///
+/// Why: §3.1 pins `●` for active so the operator reads "live" at a glance; a
+/// constant keeps the glyph single-sourced between the renderer and its tests.
+/// What: the literal `●`.
+/// Test: `compose_banner_active_shows_glyphs`.
+pub const GLYPH_ACTIVE: char = '●';
+
+/// Glyph shown for an unreachable backplane service.
+///
+/// Why: the counterpart to [`GLYPH_ACTIVE`] — §3.1 pins `○` for unreachable so
+/// a degraded backplane reads distinctly without aborting startup.
+/// What: the literal `○`.
+/// Test: `compose_banner_unreachable_shows_glyphs`.
+pub const GLYPH_UNREACHABLE: char = '○';
+
+/// The `/help` hint appended to the startup line.
+///
+/// Why: §3.1 requires the startup line to point operators at `/help`; naming
+/// the literal here keeps the hint single-sourced.
+/// What: the literal `type /help for commands`.
+/// Test: `compose_banner_appends_help_hint`.
+pub const HELP_HINT: &str = "type /help for commands";
+
+/// The outcome of probing one backplane service for the startup banner.
+///
+/// Why: the pure [`compose_banner`] must render memory/search lines without
+/// performing any IO, so the async probes collapse their (network-dependent)
+/// result into this small value the composer consumes. Carrying an optional
+/// `note` lets the memory probe surface the `user`-palace detail (or the reason
+/// it is degraded) alongside the active/unreachable verdict (D4).
+/// What: `active` (reachable + any service-specific confirmation passed) plus an
+/// optional parenthetical `note` (e.g. `palace: user`).
+/// Test: `compose_banner_*` construct these directly to drive the composer
+/// offline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeOutcome {
+    /// Whether the service is active (health probe succeeded and, for memory,
+    /// the `user` palace is present/creatable).
+    pub active: bool,
+    /// Optional parenthetical detail rendered after the status (e.g.
+    /// `palace: user`, or a degraded reason). `None` renders no parenthetical.
+    pub note: Option<String>,
+}
+
+impl ProbeOutcome {
+    /// Build an active outcome carrying an optional note.
+    ///
+    /// Why: keeps the probe call sites terse when reporting success.
+    /// What: `ProbeOutcome { active: true, note }`.
+    /// Test: `compose_banner_active_shows_palace_note`.
+    pub fn active(note: Option<String>) -> Self {
+        Self { active: true, note }
+    }
+
+    /// Build an unreachable outcome carrying an optional reason note.
+    ///
+    /// Why: keeps the probe call sites terse when reporting a degraded service.
+    /// What: `ProbeOutcome { active: false, note }`.
+    /// Test: `compose_banner_unreachable_shows_glyphs`.
+    pub fn unreachable(note: Option<String>) -> Self {
+        Self {
+            active: false,
+            note,
+        }
+    }
+
+    /// The status glyph for this outcome.
+    ///
+    /// Why: the composer renders `●`/`○` per the active flag; centralising the
+    /// mapping keeps it consistent across the two service lines.
+    /// What: [`GLYPH_ACTIVE`] when active, else [`GLYPH_UNREACHABLE`].
+    /// Test: `compose_banner_active_shows_glyphs`,
+    /// `compose_banner_unreachable_shows_glyphs`.
+    fn glyph(&self) -> char {
+        if self.active {
+            GLYPH_ACTIVE
+        } else {
+            GLYPH_UNREACHABLE
+        }
+    }
+
+    /// The status word for this outcome.
+    ///
+    /// Why: the service line reads `<glyph> <word>`; a pure helper keeps the
+    /// word mapping in one place.
+    /// What: `active` when active, else `unreachable`.
+    /// Test: `compose_banner_unreachable_shows_glyphs`.
+    fn word(&self) -> &'static str {
+        if self.active { "active" } else { "unreachable" }
+    }
+}
+
+/// Compose the full startup banner text from probe results and a session count.
+///
+/// Why: STUI-0's banner shape (§3.1) is a behavior contract that must be
+/// verifiable WITHOUT a terminal or live daemons; keeping composition pure
+/// (probe outcomes + count to string) makes the exact layout — a version line,
+/// memory/search glyph lines with optional parentheticals, and an active-count
+/// plus `/help` startup line — unit-testable offline. The version is the crate
+/// `CARGO_PKG_VERSION` resolved at the call site so this stays a pure function.
+/// What: returns a multi-line string of the form:
+/// ```text
+/// trusty-mpm sessions  v<version>
+///   memory  <glyph> <word>   (<note>)
+///   search  <glyph> <word>
+/// <count> active sessions  ·  type /help for commands
+/// ```
+/// The memory/search parentheticals are emitted only when the outcome carries a
+/// `note`. The count line uses the singular `session` when `active_count == 1`
+/// and renders a daemon-down marker when `active_count` is `None`.
+/// Test: `compose_banner_active_shows_glyphs`,
+/// `compose_banner_unreachable_shows_glyphs`,
+/// `compose_banner_active_shows_palace_note`, `compose_banner_appends_help_hint`,
+/// `compose_banner_pluralizes_count`, `compose_banner_handles_unknown_count`.
+pub fn compose_banner(
+    version: &str,
+    memory: &ProbeOutcome,
+    search: &ProbeOutcome,
+    active_count: Option<usize>,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("trusty-mpm sessions  v{version}\n"));
+    out.push_str(&service_line("memory", memory));
+    out.push_str(&service_line("search", search));
+    out.push_str(&startup_line(active_count));
+    out
+}
+
+/// Build one backplane service line: `  <label>  <glyph> <word>   (<note>)`.
+///
+/// Why: the memory and search lines share the same shape (only the label and the
+/// optional note differ); a helper keeps the two-space indent, the padded label,
+/// and the optional parenthetical consistent.
+/// What: returns `  <label padded to 6>  <glyph> <word>` plus `   (<note>)` when
+/// the outcome carries a note, terminated by a newline.
+/// Test: covered by the `compose_banner_*` tests via [`compose_banner`].
+fn service_line(label: &str, outcome: &ProbeOutcome) -> String {
+    let mut line = format!("  {label:<6}  {} {}", outcome.glyph(), outcome.word());
+    if let Some(note) = &outcome.note {
+        line.push_str(&format!("   ({note})"));
+    }
+    line.push('\n');
+    line
+}
+
+/// Build the startup line: `<count> active sessions  ·  type /help for commands`.
+///
+/// Why: §3.1 requires the active-session count plus a `/help` hint; an unknown
+/// count (daemon unreachable at startup) degrades to a marker rather than a
+/// misleading `0`. A pure helper keeps the pluralisation and the unknown-count
+/// branch testable offline.
+/// What: renders `<n> active session(s)` (singular at `1`) when the count is
+/// known, or `daemon unreachable` when `None`, then `  ·  <HELP_HINT>`.
+/// Test: `compose_banner_pluralizes_count`, `compose_banner_handles_unknown_count`.
+fn startup_line(active_count: Option<usize>) -> String {
+    let lead = match active_count {
+        Some(1) => "1 active session".to_string(),
+        Some(n) => format!("{n} active sessions"),
+        None => "daemon unreachable".to_string(),
+    };
+    format!("{lead}  ·  {HELP_HINT}")
+}
+
+/// Probe trusty-search health for the startup banner (fail-safe).
+///
+/// Why: §3.1 requires search to be confirmed via its plain health probe; a
+/// failure must degrade to `○ unreachable` (the TUI still opens), never abort.
+/// What: GETs `<base>/health` with a short timeout; any transport or non-2xx
+/// response yields [`ProbeOutcome::unreachable`]. `base` defaults to
+/// [`DEFAULT_SEARCH_URL`] when `None`.
+/// Test: `probe_unreachable_search_is_inactive` drives the dead-daemon branch;
+/// the live path is exercised by launching the TUI against a running daemon.
+pub async fn probe_search(base: Option<&str>) -> ProbeOutcome {
+    let base = base.unwrap_or(DEFAULT_SEARCH_URL);
+    if health_ok(base).await {
+        ProbeOutcome::active(None)
+    } else {
+        ProbeOutcome::unreachable(None)
+    }
+}
+
+/// Probe trusty-memory health + the fixed `user` palace for the banner (D4).
+///
+/// Why: §3.1 + decision D4 make memory "active" only when (a) the health probe
+/// succeeds AND (b) the `user` palace exists — created idempotently on first run
+/// via `POST /api/v1/palaces`. The probe is fail-safe: a down daemon or a failed
+/// palace assertion degrades to `○ unreachable` with a reason note, and the TUI
+/// still opens.
+/// What: GETs `<base>/health`; on success, GETs `<base>/api/v1/palaces/user` and,
+/// if absent, POSTs `<base>/api/v1/palaces` with `{"name":"user"}` to create it.
+/// Returns [`ProbeOutcome::active`] with note `palace: user` when memory is live
+/// and the palace is present/creatable, else [`ProbeOutcome::unreachable`] with a
+/// short reason. `base` defaults to [`DEFAULT_MEMORY_URL`] when `None`.
+/// Test: `probe_unreachable_memory_is_inactive` drives the dead-daemon branch;
+/// the live + palace-assertion path is exercised against a running daemon.
+pub async fn probe_memory(base: Option<&str>) -> ProbeOutcome {
+    let base = base.unwrap_or(DEFAULT_MEMORY_URL);
+    if !health_ok(base).await {
+        return ProbeOutcome::unreachable(Some("memory daemon down".to_string()));
+    }
+    if ensure_user_palace(base).await {
+        ProbeOutcome::active(Some(format!("palace: {USER_PALACE}")))
+    } else {
+        ProbeOutcome::unreachable(Some(format!("{USER_PALACE} palace unavailable")))
+    }
+}
+
+/// Build the short-timeout HTTP client shared by the startup probes.
+///
+/// Why: every probe needs the same bounded client so a hung service cannot stall
+/// startup; centralising construction keeps the timeout single-sourced.
+/// What: a `reqwest::Client` with [`PROBE_TIMEOUT`], falling back to the default
+/// client if the builder somehow fails (it cannot in practice).
+/// Test: covered indirectly by the probe tests.
+fn probe_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(PROBE_TIMEOUT)
+        .build()
+        .unwrap_or_default()
+}
+
+/// GET `<base>/health` and report whether it answered 2xx.
+///
+/// Why: both probes share the same health check; a daemon that is down, slow, or
+/// returns an error status all collapse to "not healthy" so the banner degrades
+/// cleanly.
+/// What: issues a bounded GET to `<base>/health` and returns `true` only on a
+/// 2xx response.
+/// Test: covered by `probe_unreachable_*` (dead daemon → `false`).
+async fn health_ok(base: &str) -> bool {
+    let client = probe_client();
+    matches!(
+        client.get(format!("{base}/health")).send().await,
+        Ok(resp) if resp.status().is_success()
+    )
+}
+
+/// Ensure the fixed `user` palace exists at `base`, creating it if absent (D4).
+///
+/// Why: D4 makes memory "active" only when the `user` palace is present; the
+/// banner asserts it idempotently so first-run operators get a confirmed memory
+/// line without a manual provisioning step.
+/// What: GETs `<base>/api/v1/palaces/user`; on a 2xx it already exists. On a 404
+/// (or any non-2xx) it POSTs `<base>/api/v1/palaces` with `{"name":"user"}` and
+/// reports whether the create answered 2xx. Any transport error yields `false`.
+/// Test: covered indirectly by `probe_memory`; the live assertion path runs
+/// against a running daemon.
+async fn ensure_user_palace(base: &str) -> bool {
+    let client = probe_client();
+    if let Ok(resp) = client
+        .get(format!("{base}/api/v1/palaces/{USER_PALACE}"))
+        .send()
+        .await
+        && resp.status().is_success()
+    {
+        return true;
+    }
+    matches!(
+        client
+            .post(format!("{base}/api/v1/palaces"))
+            .json(&serde_json::json!({ "name": USER_PALACE }))
+            .send()
+            .await,
+        Ok(resp) if resp.status().is_success()
+    )
+}
+
+/// Run the backplane probes and print the startup banner to stderr.
+///
+/// Why: §3.1 requires the banner to render before the interactive view opens.
+/// Printing to stderr (not stdout) follows the workspace convention that stdout
+/// stays clean for any downstream framing, and printing BEFORE the alternate
+/// screen is entered (mirroring Claude Code) means the banner stays visible in
+/// the operator's scrollback after the TUI exits. Probes run concurrently and
+/// are fail-safe, so a down service slows startup by at most one [`PROBE_TIMEOUT`]
+/// and never aborts.
+/// What: probes memory + search concurrently, composes the banner with the
+/// crate `CARGO_PKG_VERSION` and `active_count`, and writes it to stderr followed
+/// by a blank line. `memory_url` / `search_url` default to the canonical local
+/// addresses when `None`.
+/// Test: composition is unit-tested via [`compose_banner`]; this print-only glue
+/// is exercised by launching the TUI.
+pub async fn print_startup_banner(
+    memory_url: Option<&str>,
+    search_url: Option<&str>,
+    active_count: Option<usize>,
+) {
+    let (memory, search) = tokio::join!(probe_memory(memory_url), probe_search(search_url));
+    let banner = compose_banner(env!("CARGO_PKG_VERSION"), &memory, &search, active_count);
+    eprintln!("{banner}\n");
+}

--- a/crates/trusty-mpm/src/tui/coordinator/mod.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/mod.rs
@@ -15,6 +15,7 @@
 //! Test: the pure pieces (rows, state, events, layout text) are unit-tested in
 //! [`tests`]; [`run`] is the thin terminal glue exercised by launching the TUI.
 
+pub mod banner;
 pub mod events;
 pub mod layout;
 pub mod poll;
@@ -94,6 +95,21 @@ pub async fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
     tracing::info!(%url, interval_ms, "launching coordinator TUI");
     let mut client = DaemonClient::new(url);
 
+    // STUI-0: prime the fleet state with one poll BEFORE the alternate screen so
+    // the startup banner can report the active-session count (or `daemon
+    // unreachable` when the daemon is down). This is the same priming poll the
+    // run loop would otherwise do first; doing it here lets the banner and the
+    // first frame share one initial fetch.
+    let mut state = CoordinatorState::live();
+    coord_poll_daemon(&mut state, &mut client).await;
+    let active_count = state.daemon_reachable.then_some(state.sessions.len());
+
+    // STUI-0: render the Claude-Code-style banner (name + version, memory +
+    // search probes, active-session count + `/help` hint) to stderr before the
+    // alternate screen swallows the scrollback. Probes are fail-safe — a down
+    // backplane shows `○ unreachable`, never blocking the TUI (DOC-16 §3.1).
+    banner::print_startup_banner(None, None, active_count).await;
+
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -104,7 +120,7 @@ pub async fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    run_loop(&mut terminal, &mut client, interval_ms).await
+    run_loop(&mut terminal, &mut client, state, interval_ms).await
     // `_guard` drops here (or during an unwind), restoring the terminal.
 }
 
@@ -112,8 +128,8 @@ pub async fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
 ///
 /// Why: kept separate from [`run`] so terminal setup/teardown wraps it cleanly
 /// and the loop body stays focused on poll → draw → poll-key → dispatch.
-/// What: seeds [`CoordinatorState::live`], primes it with one
-/// [`coord_poll_daemon`] so the list is populated before the first frame, then
+/// What: takes the already-primed [`CoordinatorState`] (the STUI-0 banner poll
+/// in [`run`] populated it so the list is ready before the first frame), then
 /// each iteration draws the frame, polls the keyboard for [`KEY_POLL`] and
 /// dispatches any key via [`handle_key`], and re-polls the daemon once at least
 /// `interval_ms` has elapsed since the last poll (tokio [`Instant`] timer).
@@ -123,14 +139,12 @@ pub async fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
 async fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     client: &mut DaemonClient,
+    mut state: CoordinatorState,
     interval_ms: u64,
 ) -> anyhow::Result<()> {
     let interval = Duration::from_millis(interval_ms);
-    let mut state = CoordinatorState::live();
-
-    // Prime the list before the first frame so the operator never sees an empty
-    // list flash before the first interval tick.
-    coord_poll_daemon(&mut state, client).await;
+    // The state arrives already primed from `run`'s banner poll, so the operator
+    // never sees an empty list flash before the first interval tick.
     let mut last_poll = Instant::now();
 
     loop {

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -10,6 +10,10 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+use super::banner::{
+    GLYPH_ACTIVE, GLYPH_UNREACHABLE, HELP_HINT, ProbeOutcome, USER_PALACE, compose_banner,
+    probe_memory, probe_search,
+};
 use super::events::{SlashCommand, handle_key, is_quit, parse_slash};
 use super::layout::{
     CATALOG_STALE_HINT, CONTROLLER_STATUS, DAEMON_REACHABLE, DAEMON_UNREACHABLE, INPUT_PROMPT,
@@ -544,5 +548,193 @@ async fn poll_marks_unreachable_clears_sessions() {
     assert_eq!(
         state.selected, 0,
         "clearing the list clamps the selection back to the controller row"
+    );
+}
+
+// ---- STUI-0 banner --------------------------------------------------------
+
+/// Why: §3.1 fixes the banner's first line to `trusty-mpm sessions v<version>`;
+/// the composition must embed the crate `CARGO_PKG_VERSION` verbatim so the
+/// operator sees which build is running.
+/// What: composes a banner and asserts the version line is present with the
+/// compile-time version.
+/// Test: this IS the test.
+#[test]
+fn compose_banner_includes_name_and_version() {
+    let banner = compose_banner(
+        env!("CARGO_PKG_VERSION"),
+        &ProbeOutcome::active(None),
+        &ProbeOutcome::active(None),
+        Some(3),
+    );
+    let expected = format!("trusty-mpm sessions  v{}", env!("CARGO_PKG_VERSION"));
+    assert!(
+        banner.lines().next() == Some(expected.as_str()),
+        "banner must lead with the name + version line, got:\n{banner}"
+    );
+}
+
+/// Why: §3.1 pins the active glyph `●` and the word `active` for a reachable
+/// backplane; both memory and search lines must render them.
+/// What: composes an all-active banner and asserts each service line carries
+/// the active glyph + word.
+/// Test: this IS the test.
+#[test]
+fn compose_banner_active_shows_glyphs() {
+    let banner = compose_banner(
+        "1.2.3",
+        &ProbeOutcome::active(None),
+        &ProbeOutcome::active(None),
+        Some(2),
+    );
+    assert!(
+        banner.contains(&format!("memory  {GLYPH_ACTIVE} active")),
+        "active memory must show `● active`, got:\n{banner}"
+    );
+    assert!(
+        banner.contains(&format!("search  {GLYPH_ACTIVE} active")),
+        "active search must show `● active`, got:\n{banner}"
+    );
+}
+
+/// Why: §3.1 error conditions require an unreachable service to render
+/// `○ unreachable` (a glyph distinct from active) without aborting — so the
+/// composer must emit it for a down probe.
+/// What: composes a banner with both services unreachable and asserts the
+/// unreachable glyph + word appear for each.
+/// Test: this IS the test.
+#[test]
+fn compose_banner_unreachable_shows_glyphs() {
+    let banner = compose_banner(
+        "1.2.3",
+        &ProbeOutcome::unreachable(None),
+        &ProbeOutcome::unreachable(None),
+        Some(0),
+    );
+    assert!(
+        banner.contains(&format!("memory  {GLYPH_UNREACHABLE} unreachable")),
+        "down memory must show `○ unreachable`, got:\n{banner}"
+    );
+    assert!(
+        banner.contains(&format!("search  {GLYPH_UNREACHABLE} unreachable")),
+        "down search must show `○ unreachable`, got:\n{banner}"
+    );
+}
+
+/// Why: decision D4 confirms memory against the fixed `user` palace; the banner
+/// must surface that palace as a parenthetical note so the operator sees WHICH
+/// palace was checked.
+/// What: composes a banner whose memory outcome carries the `palace: user` note
+/// and asserts the rendered memory line includes it.
+/// Test: this IS the test.
+#[test]
+fn compose_banner_active_shows_palace_note() {
+    let banner = compose_banner(
+        "0.1.0",
+        &ProbeOutcome::active(Some(format!("palace: {USER_PALACE}"))),
+        &ProbeOutcome::active(None),
+        Some(1),
+    );
+    assert!(
+        banner.contains(&format!("(palace: {USER_PALACE})")),
+        "memory line must note the `user` palace per D4, got:\n{banner}"
+    );
+}
+
+/// Why: §3.1 requires the startup line to point operators at `/help`.
+/// What: composes a banner and asserts the final line carries the `/help` hint.
+/// Test: this IS the test.
+#[test]
+fn compose_banner_appends_help_hint() {
+    let banner = compose_banner(
+        "0.1.0",
+        &ProbeOutcome::active(None),
+        &ProbeOutcome::active(None),
+        Some(4),
+    );
+    let last = banner.lines().last().unwrap_or_default();
+    assert!(
+        last.ends_with(HELP_HINT),
+        "startup line must end with the /help hint, got: {last:?}"
+    );
+    assert!(
+        last.starts_with("4 active sessions"),
+        "startup line must lead with the active-session count, got: {last:?}"
+    );
+}
+
+/// Why: a single active session must read naturally (`1 active session`, not
+/// `1 active sessions`); the count line pluralises on the count.
+/// What: composes banners for counts 0, 1, and 5 and asserts the exact lead.
+/// Test: this IS the test.
+#[test]
+fn compose_banner_pluralizes_count() {
+    let line_for = |n: usize| {
+        let banner = compose_banner(
+            "0.1.0",
+            &ProbeOutcome::active(None),
+            &ProbeOutcome::active(None),
+            Some(n),
+        );
+        banner.lines().last().unwrap_or_default().to_string()
+    };
+    assert!(line_for(0).starts_with("0 active sessions"));
+    assert!(line_for(1).starts_with("1 active session  ·"));
+    assert!(line_for(5).starts_with("5 active sessions"));
+}
+
+/// Why: when the daemon is unreachable at startup the count is unknown; the
+/// banner must say so rather than render a misleading `0 active sessions`.
+/// What: composes a banner with `active_count = None` and asserts the startup
+/// line reports `daemon unreachable` while still carrying the `/help` hint.
+/// Test: this IS the test.
+#[test]
+fn compose_banner_handles_unknown_count() {
+    let banner = compose_banner(
+        "0.1.0",
+        &ProbeOutcome::unreachable(None),
+        &ProbeOutcome::unreachable(None),
+        None,
+    );
+    let last = banner.lines().last().unwrap_or_default();
+    assert!(
+        last.starts_with("daemon unreachable"),
+        "unknown count must read `daemon unreachable`, got: {last:?}"
+    );
+    assert!(
+        last.ends_with(HELP_HINT),
+        "the /help hint must remain even when the count is unknown, got: {last:?}"
+    );
+}
+
+/// Why: §3.1 makes probes fail-safe — a down search daemon yields `○ unreachable`
+/// and never panics or hangs the TUI.
+/// What: probes a guaranteed-dead loopback address and asserts the outcome is
+/// inactive.
+/// Test: this IS the test.
+#[tokio::test]
+async fn probe_unreachable_search_is_inactive() {
+    let outcome = probe_search(Some(&dead_loopback_url())).await;
+    assert!(
+        !outcome.active,
+        "an unreachable search daemon must probe inactive"
+    );
+}
+
+/// Why: §3.1 + D4 make the memory probe fail-safe — a down memory daemon yields
+/// `○ unreachable` with a reason and never panics.
+/// What: probes a guaranteed-dead loopback address and asserts the outcome is
+/// inactive and carries a reason note.
+/// Test: this IS the test.
+#[tokio::test]
+async fn probe_unreachable_memory_is_inactive() {
+    let outcome = probe_memory(Some(&dead_loopback_url())).await;
+    assert!(
+        !outcome.active,
+        "an unreachable memory daemon must probe inactive"
+    );
+    assert!(
+        outcome.note.is_some(),
+        "a degraded memory probe should carry a reason note"
     );
 }

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -12,7 +12,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::banner::{
     GLYPH_ACTIVE, GLYPH_UNREACHABLE, HELP_HINT, ProbeOutcome, USER_PALACE, compose_banner,
-    probe_memory, probe_search,
+    ensure_user_palace_with, probe_client, probe_memory, probe_search,
 };
 use super::events::{SlashCommand, handle_key, is_quit, parse_slash};
 use super::layout::{
@@ -736,5 +736,126 @@ async fn probe_unreachable_memory_is_inactive() {
     assert!(
         outcome.note.is_some(),
         "a degraded memory probe should carry a reason note"
+    );
+}
+
+/// Why: the print site composes the banner and prints it with `eprintln!`; if the
+/// composed banner itself ended with a newline AND `startup_line` also ended with
+/// one, the operator would see two blank lines. The contract is a single trailing
+/// newline so the print site yields exactly one blank separator.
+/// What: composes a banner and asserts it ends with exactly one `\n` (not two and
+/// not zero).
+/// Test: this IS the test.
+#[test]
+fn compose_banner_has_single_trailing_newline() {
+    let banner = compose_banner(
+        "0.1.0",
+        &ProbeOutcome::active(None),
+        &ProbeOutcome::active(None),
+        Some(2),
+    );
+    assert!(
+        banner.ends_with('\n'),
+        "composed banner must end with a newline, got:\n{banner:?}"
+    );
+    assert!(
+        !banner.ends_with("\n\n"),
+        "composed banner must NOT end with a double newline, got:\n{banner:?}"
+    );
+}
+
+/// Spawn a one-shot HTTP mock that answers the FIRST request with `status_line`
+/// and records whether a SECOND request (the would-be `POST` create) ever
+/// arrives, signalling that via the returned watch channel.
+///
+/// Why: `ensure_user_palace_with` must only POST a create on a real 404. To prove
+/// it does NOT create on a non-404 error, the test needs to observe whether a
+/// second connection (the POST) is attempted at all.
+/// What: binds an ephemeral port; the first accepted connection replies with
+/// `status_line`; if a second connection arrives it flips `post_seen` to `true`
+/// and replies `200 OK`. Returns the base URL and a receiver for `post_seen`.
+/// Test: used by `ensure_user_palace_does_not_create_on_non_404`.
+async fn spawn_palace_mock(
+    status_line: &'static str,
+) -> (String, tokio::sync::watch::Receiver<bool>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let (tx, rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        // First request: the GET palace lookup → reply with the given status.
+        if let Ok((mut sock, _)) = listener.accept().await {
+            let mut buf = [0u8; 1024];
+            let _ = sock.read(&mut buf).await;
+            let body = "{}";
+            let resp = format!(
+                "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+        // Any SECOND request means a create POST was attempted — record it.
+        if let Ok((mut sock, _)) = listener.accept().await {
+            let _ = tx.send(true);
+            let mut buf = [0u8; 1024];
+            let _ = sock.read(&mut buf).await;
+            let resp =
+                "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}".to_string();
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+
+    (format!("http://{addr}"), rx)
+}
+
+/// Why: the review flagged that `ensure_user_palace` over-eagerly created the
+/// palace — any non-2xx GET (including a transient `500`/`503`) fell through to a
+/// create POST. The fix gates creation on a *real* 404; any other error status
+/// must return `false` WITHOUT attempting a write.
+/// What: stubs the palace GET to answer `500`, runs `ensure_user_palace_with`,
+/// and asserts it returns `false` AND that no second (POST) request was made.
+/// Test: this IS the test.
+#[tokio::test]
+async fn ensure_user_palace_does_not_create_on_non_404() {
+    let (base, post_seen) = spawn_palace_mock("HTTP/1.1 500 Internal Server Error").await;
+    let client = probe_client();
+    let created = ensure_user_palace_with(&client, &base).await;
+    assert!(
+        !created,
+        "a 500 from the palace GET must NOT confirm the palace as active"
+    );
+    // Give any erroneous POST a moment to land, then assert none was attempted.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !*post_seen.borrow(),
+        "a non-404 GET error must NOT trigger a create POST"
+    );
+}
+
+/// Why: the complement to the non-404 case — a genuine 404 means the palace is
+/// absent, so the banner SHOULD create it idempotently (D4). This pins the one
+/// status that is allowed to trigger a write.
+/// What: stubs the palace GET to answer `404` (and the create POST to answer
+/// `200`), runs `ensure_user_palace_with`, and asserts it returns `true` and that
+/// a second (POST) request was observed.
+/// Test: this IS the test.
+#[tokio::test]
+async fn ensure_user_palace_creates_only_on_404() {
+    let (base, post_seen) = spawn_palace_mock("HTTP/1.1 404 Not Found").await;
+    let client = probe_client();
+    let created = ensure_user_palace_with(&client, &base).await;
+    assert!(
+        created,
+        "a 404 GET followed by a 2xx create POST must confirm the palace"
+    );
+    assert!(
+        *post_seen.borrow(),
+        "a 404 GET must trigger exactly the create POST"
     );
 }


### PR DESCRIPTION
Closes #1398

Implements STUI-0 (DOC-16 §3.1, `docs/specs/sessions-tui-interactive.md`) — a
Claude-Code-style startup banner for `tm sessions tui`.

Epic #1272.

## What this adds

On launch, before the interactive view, the TUI prints a banner to **stderr**
(stdout stays clean) and confirms the trusty backplane:

```
trusty-mpm sessions  v0.10.0
  memory  ● active   (palace: user)
  search  ● active
3 active sessions  ·  type /help for commands
```

### `tui/coordinator/banner.rs` (new, ~122 SLOC)
- **`compose_banner` (pure)** — version line `trusty-mpm sessions v<CARGO_PKG_VERSION>`
  (`env!`), `memory`/`search` glyph lines (`● active` / `○ unreachable`), and a
  startup line with the active-session count (pluralised; `daemon unreachable`
  when the count is unknown) plus the `/help` hint. Fully unit-testable offline.
- **`probe_memory` (decision D4)** — memory is "active" only when `GET /health`
  succeeds **and** the fixed user-level **`user` palace** is present, asserted
  idempotently via `GET /api/v1/palaces/user` then `POST /api/v1/palaces`
  (`{"name":"user"}`) on absence. Renders a `palace: user` note. Fail-safe →
  `○ unreachable` with a reason.
- **`probe_search`** — plain `GET /health` probe. Fail-safe.
- Short **2s** per-probe timeout so a down service never stalls startup; probes
  run concurrently (`tokio::join!`).

### Wiring (`coordinator::run`)
Primes one daemon poll **before** the alternate screen to source the
active-session count, prints the banner, then hands the already-primed state to
`run_loop` (removing the duplicate priming poll). A probe failure never blocks
or aborts the TUI (§3.1 error conditions).

## Scope discipline
STUI-0 only — banner + probes + startup line. Does **not** touch daemon
coordinator-context code or the `CoordinatorSession` wire struct (owned by the
concurrent STUI-4). No scrollable list (STUI-1), statusline (STUI-2),
transcripts (STUI-5), filter view (STUI-7), or multi-line input (STUI-10).

## Tests (deterministic, offline — no live daemon / `claude`)
- `compose_banner_*`: name+version, active/unreachable glyphs, `user`-palace
  note, count pluralisation (`1 active session` vs `N active sessions`),
  unknown-count `daemon unreachable`, `/help` hint.
- `probe_unreachable_{memory,search}_is_inactive`: fail-safe probes against a
  dead loopback → inactive, no panic.

## Verification
- `cargo build -p trusty-mpm` — OK
- `cargo test -p trusty-mpm` — 1460 lib + integration tests pass
- `cargo test --workspace` (OPENROUTER_API_KEY unset) — pass, exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — exit 0
- `bash scripts/check_line_cap.sh` — OK (banner.rs ~122 SLOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)