### PR TITLE
fix(trusty-search): surface silent reindex failures with logged cause (closes #1428)

### DIFF
--- a/crates/trusty-search/src/service/reindex/batch.rs
+++ b/crates/trusty-search/src/service/reindex/batch.rs
@@ -604,8 +604,11 @@ pub(super) async fn emit_batch_error(
     // the underlying cause at `error!` to stderr so the operator can always see
     // WHY a batch failed (the `{:#}` alternate form expands the anyhow cause
     // chain, e.g. "batch embed_batch failed: embed call timed out").
+    // The index id is carried in the human-readable `reindex[{}]:` prefix only
+    // (not also as a structured `index_id` field) to avoid double emission in
+    // JSON log backends — operator greps like `reindex[...]: batch failed` still
+    // match the message string (issue #1428 review follow-up).
     tracing::error!(
-        index_id = %ctx.index_id.0,
         batch_files = to_index_paths.len(),
         indexed = ctx.progress.indexed.load(Ordering::Acquire),
         total_files = ctx.total,

--- a/crates/trusty-search/src/service/reindex/batch.rs
+++ b/crates/trusty-search/src/service/reindex/batch.rs
@@ -598,6 +598,20 @@ pub(super) async fn emit_batch_error(
         .iter()
         .map(|p| to_corpus_relative_path(&ctx.root, p))
         .collect();
+    // Issue #1428: a batch parse/embed/commit failure was previously surfaced
+    // ONLY as an SSE `error` frame — nothing reached the daemon log, which is
+    // exactly the "no error logged" symptom on a GPU OOM / sidecar stall. Log
+    // the underlying cause at `error!` to stderr so the operator can always see
+    // WHY a batch failed (the `{:#}` alternate form expands the anyhow cause
+    // chain, e.g. "batch embed_batch failed: embed call timed out").
+    tracing::error!(
+        index_id = %ctx.index_id.0,
+        batch_files = to_index_paths.len(),
+        indexed = ctx.progress.indexed.load(Ordering::Acquire),
+        total_files = ctx.total,
+        "reindex[{}]: batch failed — {err:#}",
+        ctx.index_id.0,
+    );
     ctx.progress
         .errors
         .fetch_add(to_index_paths.len(), Ordering::Release);

--- a/crates/trusty-search/src/service/reindex/guard.rs
+++ b/crates/trusty-search/src/service/reindex/guard.rs
@@ -107,11 +107,20 @@ impl ReindexTerminationGuard {
     /// abort) replace the generic "exited unexpectedly" message with the real
     /// cause, which `Drop` then both logs and broadcasts.
     /// What: writes `Some(reason)` into the shared slot (last writer wins).
+    /// Recovers a poisoned mutex via `into_inner` so the cause is never lost —
+    /// this whole path exists to handle panics, the exact thing that poisons the
+    /// lock, so silently no-op'ing on poison would defeat its purpose (issue
+    /// #1428 review follow-up).
     /// Test: `reindex_guard_uses_captured_failure_reason`.
     pub fn set_failure_reason(slot: &FailureReasonSlot, reason: impl Into<String>) {
-        if let Ok(mut guard) = slot.lock() {
-            *guard = Some(reason.into());
-        }
+        let mut guard = slot.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(
+                "reindex: failure-reason mutex was poisoned — recovering inner \
+                 value so the captured cause is not lost"
+            );
+            poisoned.into_inner()
+        });
+        *guard = Some(reason.into());
     }
 
     /// Disarm the guard — call this after successfully emitting the terminal
@@ -133,7 +142,22 @@ impl Drop for ReindexTerminationGuard {
         }
         // The task is exiting without having emitted a terminal event. Pull the
         // most specific cause the runner recorded; fall back to a generic hint.
-        let captured = self.failure_reason.lock().ok().and_then(|g| g.clone());
+        // Recover a poisoned mutex via `into_inner` rather than silently treating
+        // it as "no captured reason": this `Drop` runs precisely on the panic
+        // paths that poison the lock, so swallowing the reason would discard the
+        // real cause the runner recorded just before unwinding (issue #1428
+        // review follow-up).
+        let captured = self
+            .failure_reason
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!(
+                    "reindex: failure-reason mutex was poisoned in Drop — \
+                     recovering inner value so the captured cause is not lost"
+                );
+                poisoned.into_inner()
+            })
+            .clone();
         let detail = captured.unwrap_or_else(|| {
             "reindex task exited unexpectedly (panic or cancellation) — \
              check daemon logs for details"
@@ -143,11 +167,14 @@ impl Drop for ReindexTerminationGuard {
         // Issue #1428: ALWAYS log at `error!` to stderr so a `status=error`
         // reindex can never again be silent in the daemon log. Logs go to
         // stderr only (daemon stdout is reserved for MCP JSON-RPC framing).
+        // Index id is carried in the human-readable `reindex[{}]:` prefix only
+        // (no duplicate structured `index_id` field) so JSON log backends don't
+        // double-emit it; `reindex[...]: terminated` greps still match (issue
+        // #1428 review follow-up).
         if self.index_id.is_empty() {
             tracing::error!("reindex: terminated without a completion event — {detail}");
         } else {
             tracing::error!(
-                index_id = %self.index_id,
                 "reindex[{}]: terminated without a completion event — {detail}",
                 self.index_id,
             );

--- a/crates/trusty-search/src/service/reindex/guard.rs
+++ b/crates/trusty-search/src/service/reindex/guard.rs
@@ -3,46 +3,114 @@
 //! Why: a Rust panic inside a `tokio::spawn` task unwinds that task silently
 //! — the `broadcast::Sender` in `ReindexProgress` drops, live SSE subscribers
 //! never receive a terminal frame, and the CLI reports "stream ended without
-//! completion event" indefinitely. Placing this guard at the start of the
-//! spawned future and calling `disarm()` only after `emit_complete_event`
-//! completes ensures that ANY early exit (panic, early return, or `.await`
-//! cancellation) emits `{"event":"error","message":"…"}` before the sender
-//! drops.
+//! completion event" indefinitely. Worse (issue #1428): on a CUDA build a
+//! mid-batch GPU stall could cancel or panic the runner future, the guard set
+//! `status=Failed` and broadcast a generic SSE error, but it logged **nothing**
+//! to stderr — so the daemon log showed no error at all ("silent" `status=error`
+//! with `duration=None`). Placing this guard at the start of the spawned future
+//! and calling `disarm()` only after `emit_complete_event` completes ensures
+//! that ANY early exit (panic, early return, or `.await` cancellation) emits
+//! `{"event":"error","message":"…"}` **and** logs the underlying cause at
+//! `error!` on stderr.
 //!
-//! What: holds `Arc<ReindexProgress>` and an `armed: bool` flag. `Drop`
-//! checks the flag — if still armed, it pushes a blocking-channel send of
-//! the error event directly onto the broadcast sender (no `.await` in `Drop`;
-//! use `try_send`) and marks the progress status as `Failed`.
+//! What: holds `Arc<ReindexProgress>`, an `armed: bool` flag, and a shared
+//! `failure_reason` slot. The runner records a specific cause via
+//! `set_failure_reason` whenever it knows one (e.g. a captured producer-task
+//! panic). `Drop` checks the flag — if still armed, it (1) logs the captured
+//! reason (or a generic fallback) at `error!` to stderr so the daemon log is
+//! never silent, (2) pushes a blocking-channel send of the error event directly
+//! onto the broadcast sender (no `.await` in `Drop`; use the non-blocking
+//! `send`), and (3) marks the progress status as `Failed`.
 //!
-//! Test: `reindex_guard_fires_on_early_return` in `tests.rs`.
+//! Test: `reindex_guard_fires_on_early_return`,
+//! `reindex_guard_uses_captured_failure_reason`, and
+//! `reindex_guard_failure_reason_is_none_by_default` in `tests.rs`.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use super::progress::{ReindexProgress, ReindexStatus};
 
-/// RAII guard that emits a terminal SSE error event if the reindex task exits
-/// without having emitted one via the normal path.
+/// Shared, writable slot carrying the most specific failure reason known to the
+/// reindex task at the moment it exits early.
+///
+/// Why: the guard's `Drop` runs after the runner future has unwound, so it
+/// cannot inspect local error values directly. The runner writes the cause it
+/// observed (e.g. a producer-task `JoinError`, or an aborting carryover-copy
+/// failure) into this slot **before** the early return; `Drop` then reads it so
+/// the operator sees the real cause instead of "exited unexpectedly".
+/// What: an `Arc<Mutex<Option<String>>>` cloneable handle. `None` means no
+/// specific cause was recorded and `Drop` falls back to the generic message.
+/// Test: `reindex_guard_uses_captured_failure_reason`.
+pub(crate) type FailureReasonSlot = Arc<Mutex<Option<String>>>;
+
+/// RAII guard that emits a terminal SSE error event AND an `error!` stderr log
+/// if the reindex task exits without having emitted one via the normal path.
 ///
 /// Why: ensures that ANY early exit from the spawned reindex task (panic,
-/// early return, `.await` cancellation) emits `{"event":"error","message":"…"}`
-/// so live SSE subscribers are never left hanging.
-/// What: armed on construction; `Drop` fires the error event synchronously
-/// when still armed. Call `disarm()` after the normal terminal event is emitted.
-/// Test: `reindex_guard_fires_on_early_return`.
+/// early return, `.await` cancellation) is non-silent — it emits
+/// `{"event":"error","message":"…"}` for live SSE subscribers and logs the
+/// underlying cause at `error!` so the daemon log always records WHY a reindex
+/// ended in `status=error` (issue #1428).
+/// What: armed on construction; `Drop` fires the error event + stderr log
+/// synchronously when still armed. Call `disarm()` after the normal terminal
+/// event is emitted. Call `set_failure_reason()` to record a specific cause.
+/// Test: `reindex_guard_fires_on_early_return`,
+/// `reindex_guard_uses_captured_failure_reason`.
 pub(crate) struct ReindexTerminationGuard {
     progress: Arc<ReindexProgress>,
     armed: bool,
+    index_id: String,
+    failure_reason: FailureReasonSlot,
 }
 
 impl ReindexTerminationGuard {
-    /// Why: construct a guard that will fire an error event on drop unless
-    /// `disarm()` is called.
-    /// What: sets `armed = true`; stores the `Arc<ReindexProgress>`.
+    /// Why: construct a guard that will fire an error event + stderr log on drop
+    /// unless `disarm()` is called.
+    /// What: sets `armed = true`; stores the `Arc<ReindexProgress>` with an
+    /// unlabelled index id and an empty failure-reason slot.
     /// Test: `reindex_guard_fires_on_early_return`.
     pub fn new(progress: Arc<ReindexProgress>) -> Self {
         Self {
             progress,
             armed: true,
+            index_id: String::new(),
+            failure_reason: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Why: the daemon log is most actionable when the silent-failure line names
+    /// the index that died. The runner knows the id; pass it in so `Drop`'s
+    /// `error!` line is greppable per-index.
+    /// What: builder-style setter that stamps the index id used in the `error!`
+    /// log and the SSE payload.
+    /// Test: `reindex_guard_uses_captured_failure_reason` asserts the id appears.
+    pub fn with_index_id(mut self, index_id: impl Into<String>) -> Self {
+        self.index_id = index_id.into();
+        self
+    }
+
+    /// Clone the shared failure-reason slot so the runner can record a specific
+    /// cause out-of-band (e.g. a captured producer-task panic) before exiting.
+    ///
+    /// Why: `Drop` cannot see the runner's local error values; the slot is the
+    /// hand-off. Handing back a clone (rather than a `&mut`) lets the runner
+    /// write to it even after the guard has been moved into `FinishCtx`.
+    /// What: returns an `Arc` clone of the inner `Mutex<Option<String>>`.
+    /// Test: `reindex_guard_uses_captured_failure_reason`.
+    pub fn failure_reason_slot(&self) -> FailureReasonSlot {
+        Arc::clone(&self.failure_reason)
+    }
+
+    /// Record the most specific failure reason known at the call site.
+    ///
+    /// Why: lets a code path that detects a concrete fault (producer panic,
+    /// abort) replace the generic "exited unexpectedly" message with the real
+    /// cause, which `Drop` then both logs and broadcasts.
+    /// What: writes `Some(reason)` into the shared slot (last writer wins).
+    /// Test: `reindex_guard_uses_captured_failure_reason`.
+    pub fn set_failure_reason(slot: &FailureReasonSlot, reason: impl Into<String>) {
+        if let Ok(mut guard) = slot.lock() {
+            *guard = Some(reason.into());
         }
     }
 
@@ -52,7 +120,7 @@ impl ReindexTerminationGuard {
     /// Why: the orchestrator must commit to exactly one terminal SSE frame.
     /// `disarm()` marks that commitment — the guard's `Drop` is now a no-op.
     /// What: sets `self.armed = false`.
-    /// Test: verified by the absence of a double-event in `reindex_guard_fires_on_early_return`.
+    /// Test: verified by the absence of a double-event in `reindex_guard_does_not_fire_after_disarm`.
     pub fn disarm(&mut self) {
         self.armed = false;
     }
@@ -63,22 +131,43 @@ impl Drop for ReindexTerminationGuard {
         if !self.armed {
             return;
         }
-        // The task is exiting without having emitted a terminal event.
-        // Set the status to Failed and push an error event synchronously
-        // (broadcast::Sender::send is non-blocking).
+        // The task is exiting without having emitted a terminal event. Pull the
+        // most specific cause the runner recorded; fall back to a generic hint.
+        let captured = self.failure_reason.lock().ok().and_then(|g| g.clone());
+        let detail = captured.unwrap_or_else(|| {
+            "reindex task exited unexpectedly (panic or cancellation) — \
+             check daemon logs for details"
+                .to_string()
+        });
+
+        // Issue #1428: ALWAYS log at `error!` to stderr so a `status=error`
+        // reindex can never again be silent in the daemon log. Logs go to
+        // stderr only (daemon stdout is reserved for MCP JSON-RPC framing).
+        if self.index_id.is_empty() {
+            tracing::error!("reindex: terminated without a completion event — {detail}");
+        } else {
+            tracing::error!(
+                index_id = %self.index_id,
+                "reindex[{}]: terminated without a completion event — {detail}",
+                self.index_id,
+            );
+        }
+
+        // Set the status and push the terminal error frame. `broadcast::send`
+        // is non-blocking, so this is `Drop`-safe (no `.await`).
         self.progress.status.store(ReindexStatus::Failed);
         let msg = serde_json::json!({
             "event": "error",
-            "message": "reindex task exited unexpectedly — check daemon logs for details"
+            "index_id": self.index_id,
+            "message": detail,
+            "fatal": true,
         })
         .to_string();
         // `send` returns Err when there are no receivers; ignore — the replay
         // buffer is updated async by `push`, but Drop cannot be async. The
-        // broadcast path alone is sufficient for live subscribers; replay is
-        // not updated here because we cannot `.await` in Drop. Live
-        // subscribers connected at the time of the crash will see the frame;
-        // late subscribers reading the replay buffer will see the status as
-        // `Failed` and can surface that to the user via the /status endpoint.
+        // broadcast path alone is sufficient for live subscribers; late
+        // subscribers reading the replay buffer will see the status as
+        // `Failed` (and now an `error!` line in the daemon log).
         let _ = self.progress.sender.send(msg);
     }
 }

--- a/crates/trusty-search/src/service/reindex/runner.rs
+++ b/crates/trusty-search/src/service/reindex/runner.rs
@@ -72,11 +72,16 @@ pub(super) async fn run_reindex(
     }
 
     // Arm the termination guard. Any early exit — panic, early return, or
-    // `.await` cancellation — fires `ReindexTerminationGuard::drop`, which
-    // broadcasts an error event and marks the status `Failed`. The guard is
-    // disarmed just after `emit_complete_event` confirms the normal terminal
-    // event has been sent.
-    let term_guard = ReindexTerminationGuard::new(Arc::clone(&progress));
+    // `.await` cancellation — fires `ReindexTerminationGuard::drop`, which logs
+    // the cause at `error!` (issue #1428: never silent), broadcasts an error
+    // event, and marks the status `Failed`. The guard is disarmed just after
+    // `emit_complete_event` confirms the normal terminal event has been sent.
+    // Stamping the index id makes the stderr line greppable per-index; the
+    // failure-reason slot lets us hand a specific cause (e.g. a captured
+    // producer-task panic) to `Drop`.
+    let term_guard =
+        ReindexTerminationGuard::new(Arc::clone(&progress)).with_index_id(handle.id.0.clone());
+    let failure_slot = term_guard.failure_reason_slot();
 
     let started = Instant::now();
     // Issue #602 — portable paths.
@@ -319,8 +324,9 @@ pub(super) async fn run_reindex(
     let producer_ctx = ctx.clone();
     let producer_mem_abort = mem_abort.clone();
     let producer_index_id = index_id.0.clone();
+    let total_batches = batches.len();
     let producer = tokio::spawn(async move {
-        for batch in batches {
+        for (batch_idx, batch) in batches.into_iter().enumerate() {
             if producer_mem_abort.load(AtomicOrdering::Acquire) {
                 let rss = current_rss_mb().unwrap_or(0);
                 tracing::warn!(
@@ -332,6 +338,16 @@ pub(super) async fn run_reindex(
                 );
                 break;
             }
+            // RUST_LOG=debug visibility into batch flush cadence — pinpoints the
+            // exact batch index where a deterministic mid-run halt occurs
+            // (issue #1428). Cheap: a single debug-gated log per batch.
+            tracing::debug!(
+                index_id = %producer_index_id,
+                batch_idx,
+                total_batches,
+                batch_files = batch.len(),
+                "reindex: producer preparing batch"
+            );
             let Some(ready) = prepare_and_parse_batch(&producer_ctx, &batch).await else {
                 continue;
             };
@@ -343,6 +359,11 @@ pub(super) async fn run_reindex(
 
     // Consumer loop: commits batches sequentially.
     while let Some(ready) = rx.recv().await {
+        tracing::debug!(
+            index_id = %index_id.0,
+            indexed = progress.indexed_count(),
+            "reindex: consumer committing batch"
+        );
         let outcome = commit_parsed_and_finalize(&ctx, ready).await;
         total_parse_ms = total_parse_ms.saturating_add(outcome.parse_ms);
         total_embed_ms = total_embed_ms.saturating_add(outcome.embed_ms);
@@ -363,7 +384,45 @@ pub(super) async fn run_reindex(
             break;
         }
     }
-    let _ = producer.await;
+    // Issue #1428: the producer's `JoinHandle` result was previously discarded
+    // (`let _ = producer.await`), so a PANIC inside the parse/embed producer
+    // task (e.g. an `unwrap` deep in the embed path, or an allocation failure
+    // under GPU/memory pressure) unwound silently — the consumer loop just saw
+    // the channel close and fell through to a "successful" finish. Capture the
+    // `JoinError` here: log it at `error!` (stderr) and record it in the guard's
+    // failure-reason slot so that if the run ends up failing, the operator sees
+    // the real cause rather than the generic "exited unexpectedly" message.
+    if let Err(join_err) = producer.await {
+        if join_err.is_panic() {
+            tracing::error!(
+                index_id = %index_id.0,
+                "reindex[{}]: parse/embed producer task PANICKED — the reindex \
+                 is incomplete; this usually indicates an embedder fault (e.g. \
+                 GPU OOM / sidecar stall). JoinError: {join_err}",
+                index_id.0,
+            );
+            ReindexTerminationGuard::set_failure_reason(
+                &failure_slot,
+                format!(
+                    "parse/embed producer task panicked ({join_err}) — reindex \
+                     incomplete; check the daemon log for the panic backtrace \
+                     and the embedder (GPU OOM / sidecar stall is the common cause)"
+                ),
+            );
+        } else {
+            // Cancellation (e.g. runtime shutdown) — still non-silent.
+            tracing::error!(
+                index_id = %index_id.0,
+                "reindex[{}]: parse/embed producer task was cancelled — reindex \
+                 incomplete. JoinError: {join_err}",
+                index_id.0,
+            );
+            ReindexTerminationGuard::set_failure_reason(
+                &failure_slot,
+                format!("parse/embed producer task cancelled ({join_err}) — reindex incomplete"),
+            );
+        }
+    }
 
     // Delegate post-loop work: prune, KG rebuild, corpus swap, terminal event, GC.
     let finish_ctx = FinishCtx {

--- a/crates/trusty-search/src/service/reindex/runner.rs
+++ b/crates/trusty-search/src/service/reindex/runner.rs
@@ -392,10 +392,20 @@ pub(super) async fn run_reindex(
     // `JoinError` here: log it at `error!` (stderr) and record it in the guard's
     // failure-reason slot so that if the run ends up failing, the operator sees
     // the real cause rather than the generic "exited unexpectedly" message.
+    //
+    // Limitation: this handles a panic/cancellation *inside* the spawned producer
+    // task (surfaced as a `JoinError`). It does NOT cover `producer.await` itself
+    // panicking (e.g. the tokio runtime shutting down out from under the await):
+    // in that case the failure_slot is never written and the termination guard's
+    // `Drop` falls back to its generic "exited unexpectedly" message. That path
+    // is still non-silent (the guard logs at `error!`), just less specific.
     if let Err(join_err) = producer.await {
         if join_err.is_panic() {
+            // Index id lives in the `reindex[{}]:` message prefix only (no
+            // duplicate structured `index_id` field) to avoid double emission
+            // in JSON log backends; `reindex[...]: ... PANICKED` greps still
+            // match (issue #1428 review follow-up).
             tracing::error!(
-                index_id = %index_id.0,
                 "reindex[{}]: parse/embed producer task PANICKED — the reindex \
                  is incomplete; this usually indicates an embedder fault (e.g. \
                  GPU OOM / sidecar stall). JoinError: {join_err}",
@@ -410,9 +420,10 @@ pub(super) async fn run_reindex(
                 ),
             );
         } else {
-            // Cancellation (e.g. runtime shutdown) — still non-silent.
+            // Cancellation (e.g. runtime shutdown) — still non-silent. Index id
+            // is in the `reindex[{}]:` message prefix only (no duplicate
+            // structured field) per the #1428 review follow-up.
             tracing::error!(
-                index_id = %index_id.0,
                 "reindex[{}]: parse/embed producer task was cancelled — reindex \
                  incomplete. JoinError: {join_err}",
                 index_id.0,

--- a/crates/trusty-search/src/service/reindex/tests.rs
+++ b/crates/trusty-search/src/service/reindex/tests.rs
@@ -1219,6 +1219,90 @@ fn reindex_guard_fires_on_early_return() {
         msg.contains("\"error\""),
         "broadcast message must contain event:error; got: {msg}"
     );
+    // Issue #1428: the generic frame must carry the `fatal` marker so SSE
+    // clients can distinguish a terminal failure from a per-file error.
+    assert!(
+        msg.contains("\"fatal\":true"),
+        "guard error frame must be marked fatal; got: {msg}"
+    );
+}
+
+/// Issue #1428: when the runner records a specific failure reason, the guard's
+/// `Drop` must surface THAT reason (not the generic fallback) in the SSE frame,
+/// and the index id must appear in the payload.
+///
+/// Why: the original silent-failure symptom was a generic
+/// "exited unexpectedly" message with no underlying cause. Capturing a producer
+/// panic (or any known fault) into the failure-reason slot lets the operator
+/// see the real cause both in the daemon log and on the SSE stream.
+///
+/// What: arm a guard with an index id, write a specific reason into its slot,
+/// drop it armed, and assert the broadcast frame contains the reason + id.
+///
+/// Test: this test.
+#[test]
+fn reindex_guard_uses_captured_failure_reason() {
+    let progress = Arc::new(ReindexProgress::new());
+    let mut rx = progress.sender.subscribe();
+
+    {
+        let guard = ReindexTerminationGuard::new(Arc::clone(&progress)).with_index_id("my-index");
+        let slot = guard.failure_reason_slot();
+        ReindexTerminationGuard::set_failure_reason(
+            &slot,
+            "parse/embed producer task panicked (GPU OOM)",
+        );
+        // Drop without disarming.
+    }
+
+    assert_eq!(
+        progress.status.load(),
+        ReindexStatus::Failed,
+        "status must be Failed after an armed guard drops"
+    );
+    let msg = rx
+        .try_recv()
+        .expect("guard must have broadcast an error event");
+    assert!(
+        msg.contains("parse/embed producer task panicked (GPU OOM)"),
+        "guard must surface the captured failure reason; got: {msg}"
+    );
+    assert!(
+        msg.contains("my-index"),
+        "guard error frame must carry the index id; got: {msg}"
+    );
+}
+
+/// Issue #1428: a freshly-armed guard with no recorded reason falls back to the
+/// generic message but is STILL non-silent (status Failed + fatal frame).
+///
+/// Why: not every early exit has a captured cause (e.g. a raw `.await`
+/// cancellation). The fallback path must still set Failed and emit a fatal
+/// frame so the failure is never silent.
+///
+/// What: arm a guard, drop it without recording a reason, assert the fallback
+/// message and the Failed status.
+///
+/// Test: this test.
+#[test]
+fn reindex_guard_failure_reason_is_none_by_default() {
+    let progress = Arc::new(ReindexProgress::new());
+    let mut rx = progress.sender.subscribe();
+
+    {
+        let _guard = ReindexTerminationGuard::new(Arc::clone(&progress)).with_index_id("idx-x");
+    }
+
+    assert_eq!(progress.status.load(), ReindexStatus::Failed);
+    let msg = rx.try_recv().expect("guard must broadcast on drop");
+    assert!(
+        msg.contains("exited unexpectedly"),
+        "fallback message expected when no reason recorded; got: {msg}"
+    );
+    assert!(
+        msg.contains("\"fatal\":true"),
+        "fallback frame must still be fatal; got: {msg}"
+    );
 }
 
 /// A disarmed `ReindexTerminationGuard` must NOT emit an error event on drop.


### PR DESCRIPTION
## Summary

Reindex could end as status=error with duration=None and NOTHING logged. ReindexTerminationGuard::drop now ALWAYS logs the underlying cause at error! to stderr, stamps the index id, surfaces the captured failure reason (new FailureReasonSlot) instead of a generic string, and emits an SSE frame with fatal:true. The producer JoinError (previously discarded) is now captured + logged; emit_batch_error logs the full anyhow cause chain (incl. GPU-OOM). Added RUST_LOG=debug tracing around batch flush + commit.

## Root Cause Note

The ~1665-chunk halt is a CUDA BFCArena VRAM-pressure stall/OOM on the Tesla T4 (16GB), not a fixed-count code bug. All halt-mitigations already shipped in 0.24.4; 0.26.0 adds no new halt fix. This PR fixes the SILENCE, not the stall.

## Tests

4 guard tests + fatal:true assertion; 932 lib tests + integration green; clippy/fmt/line-cap clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)