### PR TITLE
feat(trusty-mpm): owning tmux Session guard with RAII Drop reaper + test teardown guards (#1453, #1459)

### DIFF
--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -236,6 +236,15 @@ impl SessionManager {
             .create_session(&tmux_name, &workdir)
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
 
+        // OWN the freshly-created tmux session immediately (#1453). From here
+        // until the record is durably persisted, this guard is the session's
+        // sole owner: any early return (e.g. a failing `store.upsert`) drops the
+        // guard and reaps the otherwise-orphaned tmux session. Ownership is
+        // transferred to the persistent store via `disarm` only AFTER upsert
+        // succeeds — closing the window that let 159 orphans accumulate (#1452).
+        let mut tmux_guard =
+            super::session_guard::TmuxSessionGuard::new(tmux_name.clone(), self.tmux.clone());
+
         // Seed the session↔artifact correlation from what we know at creation
         // time (worktree path + branch). PR / issue ids accrue later as the
         // driver pushes work and opens a PR.
@@ -265,6 +274,12 @@ impl SessionManager {
         };
 
         self.store.write().await.upsert(record.clone()).await?;
+
+        // The record is durably persisted; the store/registry now owns the
+        // session's lifetime. Disarm so the guard's drop is a no-op and the
+        // tracked session is NOT reaped at the end of this request scope (#1453).
+        tmux_guard.disarm();
+
         info!(id = %id, name = %tmux_name, runtime = %runtime.as_str(), "managed session created");
         Ok(record)
     }

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod manager;
 pub mod record;
+pub mod session_guard;
 pub mod store;
 
 #[cfg(test)]
@@ -22,6 +23,7 @@ pub mod real_tmux;
 
 pub use manager::{ManagedError, ManagedTmuxDriver, ReconcileReport, SessionManager};
 pub use record::{ManagedSessionId, ManagedSessionState, RecordError, SessionRecord};
+pub use session_guard::TmuxSessionGuard;
 pub use store::{SessionStore, StoreError};
 
 #[cfg(feature = "daemon")]

--- a/crates/trusty-mpm/src/session_manager/session_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/session_guard.rs
@@ -1,0 +1,248 @@
+//! Owning RAII guard that reaps a tmux session on drop.
+//!
+//! Why: every tmux session the daemon spawns must have exactly ONE owner that is
+//! responsible for killing it. Before this guard existed, a spawn site that
+//! created a tmux session and then failed (or returned early) before recording
+//! ownership leaked the session — 159 such orphans once accumulated and
+//! saturated the host fork limit (epic #1452, #1453). [`TmuxSessionGuard`] makes
+//! the ownership explicit and reaps the session via `Drop` UNLESS ownership is
+//! explicitly transferred to a long-lived registry by calling [`disarm`].
+//! What: holds the tmux session name plus an `Arc` clone of the
+//! [`ManagedTmuxDriver`]. While armed, its `Drop` impl issues a best-effort
+//! `kill_session` (logging at warn on failure; stderr only via `tracing`).
+//! [`disarm`] flips the guard to a no-op so the tracked store/registry — not the
+//! request scope — owns the session's lifetime.
+//! Test: `guard_kills_on_drop_when_armed`, `guard_does_not_kill_after_disarm`,
+//! `guard_kills_only_named_session` in this module's test section.
+//!
+//! [`disarm`]: TmuxSessionGuard::disarm
+
+use std::sync::Arc;
+
+use tracing::{debug, warn};
+
+use super::manager::ManagedTmuxDriver;
+
+/// An owning guard that kills its tmux session on drop unless disarmed.
+///
+/// Why: a tmux session created by a spawn site has no owner until it is recorded
+/// in the persistent store. During that window — between `create_session` and a
+/// successful `store.upsert` — any early return would orphan the session. This
+/// guard closes that window: construct it immediately after `create_session`,
+/// and the session is guaranteed to be reaped if anything fails before the
+/// record is durably persisted. Once persisted, [`disarm`](Self::disarm)
+/// transfers ownership to the registry so the request scope does not reap a
+/// session the daemon is meant to keep tracking.
+/// What: wraps the session name and an `Arc<dyn ManagedTmuxDriver>`. The `armed`
+/// flag is the disarm latch: `true` (default) means `Drop` reaps; `false` means
+/// `Drop` is a no-op. The driver is shared (`Arc`) so holding a guard never
+/// blocks the manager from using the same driver concurrently.
+/// Test: see the module test section.
+pub struct TmuxSessionGuard {
+    /// The tmux session name this guard owns (e.g. `tmpm-<slug>`).
+    name: String,
+    /// Shared handle to the tmux driver used to reap the session on drop.
+    driver: Arc<dyn ManagedTmuxDriver>,
+    /// While `true`, `Drop` reaps the session. [`disarm`](Self::disarm) clears it
+    /// once ownership passes to the persistent registry.
+    armed: bool,
+}
+
+impl TmuxSessionGuard {
+    /// Construct an ARMED guard owning `name`, reaped via `driver` on drop.
+    ///
+    /// Why: callers create the guard at the exact moment they take ownership of a
+    /// freshly-created tmux session, so the reaping window opens immediately and
+    /// no early return can leak the session.
+    /// What: stores `name` and the shared `driver`, with `armed = true`.
+    /// Test: `guard_kills_on_drop_when_armed`.
+    pub fn new(name: impl Into<String>, driver: Arc<dyn ManagedTmuxDriver>) -> Self {
+        Self {
+            name: name.into(),
+            driver,
+            armed: true,
+        }
+    }
+
+    /// The tmux session name this guard owns.
+    ///
+    /// Why: tests and callers occasionally need to confirm which session a guard
+    /// is responsible for without consuming it.
+    /// What: returns the owned name as a `&str`.
+    /// Test: `guard_exposes_name`.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Transfer ownership away from the guard so `Drop` will NOT reap.
+    ///
+    /// Why: once the session has been durably recorded in the persistent store /
+    /// registry, that registry — not the request-scoped guard — owns the
+    /// session's lifetime. Reaping it here would kill a session the daemon must
+    /// keep tracking. Disarming makes the guard's `Drop` a no-op so ownership
+    /// passes cleanly to the long-lived store.
+    /// What: clears the `armed` flag. Idempotent: disarming an already-disarmed
+    /// guard is harmless. After this call the guard may be dropped freely.
+    /// Test: `guard_does_not_kill_after_disarm`.
+    pub fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl std::fmt::Debug for TmuxSessionGuard {
+    /// Why: `Arc<dyn ManagedTmuxDriver>` is not `Debug`, so the derive cannot be
+    /// used; enclosing types may still want to print a guard.
+    /// What: prints the name and armed flag, omitting the opaque driver handle.
+    /// Test: compile-time only.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TmuxSessionGuard")
+            .field("name", &self.name)
+            .field("armed", &self.armed)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for TmuxSessionGuard {
+    /// Why: this is the whole point of the guard — an armed guard going out of
+    /// scope (normal return, `?` early-exit, or panic unwind) must reap the
+    /// session it owns so it can never become an orphan.
+    /// What: when `armed`, issues a best-effort `kill_session`. A failure is
+    /// logged at `warn` (the session may already be gone, which is fine) and
+    /// never panics — `Drop` must not unwind. When disarmed, does nothing.
+    /// Test: `guard_kills_on_drop_when_armed`, `guard_does_not_kill_after_disarm`.
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        match self.driver.kill_session(&self.name) {
+            Ok(()) => debug!(name = %self.name, "TmuxSessionGuard reaped owned session on drop"),
+            Err(e) => warn!(
+                name = %self.name,
+                "TmuxSessionGuard: best-effort reap on drop failed (may already be gone): {e}"
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::session_manager::manager::ManagedError;
+
+    /// A recording tmux driver that captures `kill_session` calls.
+    ///
+    /// Why: the guard's behavior is observable only through which `kill_session`
+    /// calls it makes; this fake records them so tests can assert exact reaping.
+    /// What: implements [`ManagedTmuxDriver`]; every method is a no-op except
+    /// `kill_session`, which appends the name to `kills`.
+    /// Test: used by the guard tests below.
+    struct RecordingDriver {
+        kills: Mutex<Vec<String>>,
+    }
+
+    impl RecordingDriver {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                kills: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn kills(&self) -> Vec<String> {
+            self.kills.lock().unwrap().clone()
+        }
+    }
+
+    impl ManagedTmuxDriver for RecordingDriver {
+        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn kill_session(&self, name: &str) -> Result<(), ManagedError> {
+            self.kills.lock().unwrap().push(name.to_owned());
+            Ok(())
+        }
+        fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+            Ok(String::new())
+        }
+        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// A driver whose `kill_session` always errors, to prove `Drop` never panics.
+    struct FailingDriver;
+    impl ManagedTmuxDriver for FailingDriver {
+        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn kill_session(&self, name: &str) -> Result<(), ManagedError> {
+            Err(ManagedError::TmuxUnavailable(format!("boom for {name}")))
+        }
+        fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+            Ok(String::new())
+        }
+        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn guard_kills_on_drop_when_armed() {
+        let driver = RecordingDriver::new();
+        {
+            let _guard = TmuxSessionGuard::new("tmpm-armed", driver.clone());
+            // Guard is armed; nothing killed yet.
+            assert!(driver.kills().is_empty(), "no kill before drop");
+        } // <- drop here must reap.
+        assert_eq!(
+            driver.kills(),
+            vec!["tmpm-armed".to_string()],
+            "armed guard must kill its session exactly once on drop"
+        );
+    }
+
+    #[test]
+    fn guard_does_not_kill_after_disarm() {
+        let driver = RecordingDriver::new();
+        {
+            let mut guard = TmuxSessionGuard::new("tmpm-disarmed", driver.clone());
+            guard.disarm();
+        } // <- drop here must be a no-op.
+        assert!(
+            driver.kills().is_empty(),
+            "disarmed guard must NOT kill its session on drop (ownership transferred)"
+        );
+    }
+
+    #[test]
+    fn guard_kills_only_named_session() {
+        let driver = RecordingDriver::new();
+        drop(TmuxSessionGuard::new("tmpm-only-this", driver.clone()));
+        let kills = driver.kills();
+        assert_eq!(kills.len(), 1, "exactly one kill");
+        assert_eq!(kills[0], "tmpm-only-this", "kills only the named session");
+    }
+
+    #[test]
+    fn guard_drop_never_panics_on_kill_error() {
+        // A failing driver must not cause `Drop` to unwind. The test passing
+        // (no panic/abort) IS the assertion.
+        let driver: Arc<dyn ManagedTmuxDriver> = Arc::new(FailingDriver);
+        drop(TmuxSessionGuard::new("tmpm-doomed", driver));
+    }
+
+    #[test]
+    fn guard_exposes_name() {
+        let driver = RecordingDriver::new();
+        let mut guard = TmuxSessionGuard::new("tmpm-name-probe", driver);
+        assert_eq!(guard.name(), "tmpm-name-probe");
+        guard.disarm(); // avoid an unrelated kill recording in this assertion test
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -141,6 +141,100 @@ async fn manager_create_record() {
     assert_eq!(listed[0].id, record.id);
 }
 
+/// A SUCCESSFUL create must DISARM the ownership guard so the freshly-created
+/// tmux session is NOT reaped at the end of the request scope (#1453).
+///
+/// Why: the create path owns the new tmux session via a `TmuxSessionGuard` until
+/// the record is persisted, then hands ownership to the store by disarming. If
+/// disarm were ever dropped from the happy path, every created session would be
+/// killed the instant `create_with_id` returned — a catastrophic regression.
+/// This test pins disarm to the success path: no `kill_session` must occur.
+/// What: creates a session through the manager (which persists successfully via
+/// the temp store) and asserts the fake driver recorded ZERO kill calls.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_create_success_does_not_reap_session() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "keep me alive".into(),
+            Some(PathBuf::from("/tmp/keepalive")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    assert!(
+        fake.kill_calls.lock().unwrap().is_empty(),
+        "a successful create must NOT kill the session it created (guard disarmed); \
+         kills seen: {:?}",
+        fake.kill_calls.lock().unwrap()
+    );
+    // And the session is still tracked.
+    assert_eq!(mgr.get(&record.id).await.unwrap().id, record.id);
+}
+
+/// When the store write FAILS, the orphaned tmux session must be reaped (#1453).
+///
+/// Why: this is the exact failure that produced 159 orphans (#1452). If
+/// `create_session` succeeds but the subsequent `store.upsert` fails, the tmux
+/// session has no owner in the registry — the armed `TmuxSessionGuard` must drop
+/// and kill it so it cannot accumulate as an orphan.
+/// What: makes the store's backing `sessions.json` a NON-EMPTY directory so the
+/// atomic `rename(tmp, sessions.json)` inside `save()` fails, drives a create,
+/// asserts the create returns a `Store` error AND that the fake driver recorded
+/// a `kill_session` for the exact tmux name that was created.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_create_store_failure_reaps_orphan() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    // Sabotage the store: replace `sessions.json` (a file after `load`) with a
+    // NON-EMPTY directory of the same name. `save()` writes `sessions.json.tmp`
+    // then renames it onto `sessions.json`; renaming a file onto a non-empty
+    // directory fails on every supported platform, so `upsert` returns an error
+    // AFTER `create_session` already created the tmux session — the orphan case.
+    let store_path = dir.path().join("sessions.json");
+    let _ = std::fs::remove_file(&store_path);
+    std::fs::create_dir_all(store_path.join("not-empty")).expect("make sessions.json a dir");
+
+    let err = mgr
+        .create(
+            "doomed".into(),
+            Some(PathBuf::from("/tmp/doomed-ws")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("create must fail when the store write fails");
+
+    assert!(
+        matches!(err, ManagedError::Store(_)),
+        "store-write failure must surface as a Store error, got {err:?}"
+    );
+
+    // The orphaned tmux session must have been reaped by the guard's Drop.
+    let kills = fake.kill_calls.lock().unwrap();
+    assert_eq!(
+        kills.len(),
+        1,
+        "exactly one orphaned tmux session must be reaped; kills: {kills:?}"
+    );
+    assert!(
+        kills[0].starts_with("tmpm-"),
+        "the reaped session is the one just created (tmpm- prefix): {}",
+        kills[0]
+    );
+}
+
 #[tokio::test]
 async fn manager_naming_convention() {
     let dir = TempDir::new().unwrap();

--- a/crates/trusty-mpm/tests/e2e/harness.rs
+++ b/crates/trusty-mpm/tests/e2e/harness.rs
@@ -41,6 +41,12 @@ pub struct TestDaemon {
     _tmpdir: TempDir,
     /// The background task serving the router; aborted on drop.
     handle: tokio::task::JoinHandle<()>,
+    /// This harness's own isolated daemon state. Held so `Drop` can enumerate
+    /// the sessions THIS daemon registered and reap their tmux hosts (#1459).
+    /// Because each `TestDaemon` owns a distinct `DaemonState`, every session in
+    /// this registry was created by this harness — so the reap is correctly
+    /// scoped and never touches `tmpm-` sessions owned by other live agents.
+    state: Arc<DaemonState>,
 }
 
 impl TestDaemon {
@@ -75,7 +81,9 @@ impl TestDaemon {
         setup(&paths);
 
         let state = Arc::new(DaemonState::with_paths(&paths));
-        let app = trusty_mpm::daemon::api::router(state);
+        // Clone the Arc so the harness retains a handle for `Drop`-time session
+        // reaping (#1459) while the router takes its own clone for serving.
+        let app = trusty_mpm::daemon::api::router(Arc::clone(&state));
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -96,6 +104,7 @@ impl TestDaemon {
             paths,
             _tmpdir: tmpdir,
             handle,
+            state,
         }
     }
 
@@ -120,9 +129,50 @@ impl TestDaemon {
 }
 
 impl Drop for TestDaemon {
+    /// Why: aborting only the HTTP task left any `tmpm-` tmux session this daemon
+    /// spawned running forever — those orphans once saturated the host fork
+    /// limit (epic #1452, #1459). This `Drop` now also reaps the tmux hosts THIS
+    /// harness created.
+    /// What: aborts the server task, then best-effort kills the tmux session
+    /// named by every record in this daemon's OWN registry (each `TestDaemon`
+    /// owns an isolated `DaemonState`, so the registry contains only sessions
+    /// this harness created — the reap never touches unrelated `tmpm-` sessions).
+    /// A `tmpm-` prefix check is an extra belt-and-braces guard. tmux being
+    /// absent (CI) is fine: discovery fails and the loop is a no-op.
+    /// Test: covered indirectly by every e2e session scenario; the reaping
+    /// primitive itself is unit-tested in `session_manager::session_guard`.
     fn drop(&mut self) {
         // Stop serving so the port is released and the task does not leak.
         self.handle.abort();
+
+        // Best-effort reap of tmux sessions this harness's daemon created.
+        let created: Vec<String> = self
+            .state
+            .list_sessions()
+            .into_iter()
+            .map(|s| s.tmux_name)
+            .filter(|name| name.starts_with("tmpm-"))
+            .collect();
+
+        if created.is_empty() {
+            return;
+        }
+
+        match trusty_mpm::daemon::tmux::TmuxDriver::discover() {
+            Ok(driver) => {
+                for name in created {
+                    if let Err(e) = driver.kill_session(&name) {
+                        // stderr only — the daemon keeps stdout clean; a failure
+                        // here is non-fatal (the session may already be gone).
+                        eprintln!("TestDaemon::drop: best-effort kill of {name} failed: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                // No tmux on this host (e.g. CI) — nothing to reap.
+                eprintln!("TestDaemon::drop: tmux unavailable, skipping session reap: {e}");
+            }
+        }
     }
 }
 

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -720,6 +720,25 @@ use trusty_mpm::daemon::managed_routes::{ResumeManagedError, resume_managed};
 use trusty_mpm::daemon::state::DaemonState;
 use trusty_mpm::runtime::RuntimeKind as ResumeRuntimeKind;
 use trusty_mpm::session_manager::ManagedSessionId as ResumeSessionId;
+use trusty_mpm::session_manager::TmuxSessionGuard;
+
+/// Build an ARMED RAII teardown guard that reaps `tmux_name` on test exit (#1459).
+///
+/// Why: the two tests below seed a session through a `DaemonState` whose session
+/// manager uses the REAL tmux driver when `tmux` is on the host. Without this,
+/// each run leaked a live `tmpm-…` tmux session — those orphans saturated the
+/// host fork limit (epic #1452). Reusing the production [`TmuxSessionGuard`]
+/// (left ARMED — never disarmed) means the session is killed when the guard
+/// drops at the end of the test, on success, failure, OR panic unwind.
+/// What: pulls the manager's real driver via `tmux_driver()` and wraps it in an
+/// armed guard owning `tmux_name`.
+/// Test: exercised by `resume_managed_typed_invalid_state_is_conflict` and
+/// `front_gate_answer_unblocks_spawn`; the guard's own kill/disarm behavior is
+/// unit-tested in `session_manager::session_guard`.
+async fn reap_on_drop(state: &Arc<DaemonState>, tmux_name: &str) -> TmuxSessionGuard {
+    let driver = state.session_manager().await.tmux_driver();
+    TmuxSessionGuard::new(tmux_name.to_string(), driver)
+}
 
 /// Resuming a missing session yields the typed `NotFound` variant (→ HTTP 404).
 ///
@@ -776,18 +795,23 @@ async fn resume_managed_typed_invalid_state_is_conflict() {
     // keeps the name unique even after truncation; rooting it under the hermetic
     // temp dir keeps it isolated.
     let ws = root.path().join(format!("{id}-resume-ws"));
-    mgr.create_with_id(
-        id,
-        "regression: invalid-state resume".to_string(),
-        Some(ws.clone()),
-        None,
-        Some(ws),
-        Some("https://example.com/r.git".to_string()),
-        Some("main".to_string()),
-        ResumeRuntimeKind::default(),
-    )
-    .await
-    .expect("seed session");
+    let seeded = mgr
+        .create_with_id(
+            id,
+            "regression: invalid-state resume".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws),
+            Some("https://example.com/r.git".to_string()),
+            Some("main".to_string()),
+            ResumeRuntimeKind::default(),
+        )
+        .await
+        .expect("seed session");
+
+    // Reap the real tmux session this test created on exit (#1459). Held to the
+    // end of the function so success, failure, or panic all trigger the kill.
+    let _reaper = reap_on_drop(&state, &seeded.tmux_name).await;
 
     let err = resume_managed(&state, &id)
         .await
@@ -835,6 +859,11 @@ async fn front_gate_answer_unblocks_spawn() {
         )
         .await
         .expect("seed session");
+
+    // Reap the real tmux session this test created (and any runtime
+    // `spawn_runtime_for` starts in the SAME `tmux_name`) on exit (#1459). Held
+    // to function end so success, failure, or panic all trigger the kill.
+    let _reaper = reap_on_drop(&state, &record.tmux_name).await;
 
     // Simulate a FRONT-gate escalation: pending decision, still Provisioning.
     mgr.set_pending_decision(&record.id, "conformance divergence", Some("use cursor"))


### PR DESCRIPTION
Foundation of epic #1452 (single Session object owning the tmux lifecycle — no fire-and-forget). Closes #1453 and #1459.

## What — Adds `TmuxSessionGuard` (session_guard.rs): holds the tmux session name + driver; armed `Drop` does best-effort `kill_session` (stderr `warn` on failure, never unwinds); `disarm()` transfers ownership to the persistent store. `SessionManager::create_with_id` constructs the guard right after `create_session` and disarms ONLY after `store.upsert().await?` succeeds — so a failed upsert drops the still-armed guard and reaps the orphaned tmux session (closes the orphan window that produced ~159 leaked sessions).

## Test teardown (#1459) — `tests/session_manager_mvp.rs` `front_gate_answer_unblocks_spawn` + `resume_managed_typed_invalid_state_is_conflict` now hold reap-on-drop guards; `tests/e2e/harness.rs` `TestDaemon::Drop` reaps only the `tmpm-` sessions in ITS OWN registry (scoped — never kills unrelated live sessions).

## Tests — 5 guard unit tests (kill-on-drop, no-kill-after-disarm, scoped-kill, never-panic) + `manager_create_store_failure_reaps_orphan` + `manager_create_success_does_not_reap_session`; full suite 1478 lib tests green; clippy/fmt/line-cap clean.

## Out of scope (rest of #1452): startup/periodic orphan-reconciliation sweep for pre-existing untracked sessions (#1458), guard application to other spawn/resume sites, fork-limit backpressure, DELETE-kills-tmux (#1454), shutdown reaper (#1455), spawn rollbacks (#1456/#1457).

🤖 Generated with [Claude Code](https://claude.com/claude-code)