### PR TITLE
feat(trusty-mpm): standard harness-agnostic inject_text/observe/summarize on SessionControl (#1461)

### DIFF
--- a/crates/trusty-mpm/src/core/sm/agent/delegate/mock_control.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/mock_control.rs
@@ -19,7 +19,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use crate::core::sm::control::{LaunchParams, SessionControl, SessionControlError};
+use crate::activity::cache::ActivityState;
+use crate::core::sm::control::{
+    LaunchParams, RawObservation, SessionControl, SessionControlError, Submit, Summary,
+};
 
 /// A scriptable, recording mock [`SessionControl`] (test-only).
 ///
@@ -117,5 +120,52 @@ impl SessionControl for MockSessionControl {
 
     async fn kill(&self, _session_id: &str) -> Result<Value, SessionControlError> {
         Ok(json!({ "ok": true }))
+    }
+
+    /// Record an injected text as a `(session_id, text)` send, regardless of the
+    /// [`Submit`] mode, so the delegation tests can assert delivery (#1461).
+    async fn inject_text(
+        &self,
+        session_id: &str,
+        text: &str,
+        _submit: Submit,
+    ) -> Result<(), SessionControlError> {
+        self.sends
+            .lock()
+            .expect("lock")
+            .push((session_id.to_string(), text.to_string()));
+        Ok(())
+    }
+
+    /// Return a deterministic raw observation derived from the scripted `get`
+    /// body (the same OBSERVE input), with no LLM (#1461).
+    async fn observe(
+        &self,
+        _session_id: &str,
+        _lines: usize,
+    ) -> Result<RawObservation, SessionControlError> {
+        let body = self.get_body.lock().expect("lock").clone();
+        let raw_pane = body
+            .get("session")
+            .and_then(|s| s.get("pane"))
+            .and_then(|p| p.as_str())
+            .unwrap_or_default()
+            .to_string();
+        Ok(RawObservation {
+            raw_pane,
+            runtime_active: true,
+            pending_decision: None,
+            proposed_default: None,
+        })
+    }
+
+    /// Return a degraded `Unknown` summary (the mock has no LLM) so callers see
+    /// the LLM-optional contract honored (#1461).
+    async fn summarize(&self, _session_id: &str) -> Result<Summary, SessionControlError> {
+        Ok(Summary {
+            state: ActivityState::Unknown,
+            summary: None,
+            confidence: 0.0,
+        })
     }
 }

--- a/crates/trusty-mpm/src/core/sm/control.rs
+++ b/crates/trusty-mpm/src/core/sm/control.rs
@@ -20,6 +20,9 @@
 //! tests both inject mock impls of this trait.
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::activity::cache::ActivityState;
 
 /// Inputs for `sessions.launch` (§1A.1: `{ workdir, model?, prompt?, goal_id? }`).
 ///
@@ -69,6 +72,81 @@ pub enum SessionControlError {
     Backend(String),
 }
 
+/// How an injected text is committed to a session's runtime (#1461).
+///
+/// Why: the harness-agnostic `inject_text` verb must express the THREE distinct
+/// keystroke intents every runtime needs without leaking tmux argv into the
+/// trait: "type this line and run it", "type this but DON'T submit" (e.g. stage
+/// a partial command, or fill a prompt the human will edit), and "interrupt the
+/// running task". Modelling them as one closed enum keeps the seam runtime-neutral
+/// — a future tcode/SDK backend maps the same three variants onto its own
+/// submit/interrupt primitives.
+/// What: [`Enter`](Submit::Enter) sends the literal text then a newline (today's
+/// `send_line`); [`NoSubmit`](Submit::NoSubmit) sends the literal text with NO
+/// trailing newline; [`Interrupt`](Submit::Interrupt) ignores any text and sends
+/// the runtime's interrupt (Ctrl-C in tmux). Serde-friendly (snake_case) so it
+/// round-trips through the wire/config.
+/// Test: `inject_dispatch_enter_sends_literal_then_enter`,
+/// `inject_dispatch_nosubmit_sends_literal_only`,
+/// `inject_dispatch_interrupt_sends_ctrl_c` in tests/session_control_api.rs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Submit {
+    /// Send the literal text, then press Enter — the runtime executes the line.
+    Enter,
+    /// Send the literal text WITHOUT a trailing Enter — leaves it unsubmitted.
+    NoSubmit,
+    /// Ignore the text and send the runtime's interrupt (Ctrl-C in tmux).
+    Interrupt,
+}
+
+/// A raw, LLM-free observation of a session's current surface (#1461).
+///
+/// Why: `observe` must ALWAYS be available — even on a host with no
+/// `OPENROUTER_API_KEY` — so any harness can read a session's actual pane and
+/// make its OWN inference (the session-manager-driver does exactly this). It is
+/// the cheap, deterministic counterpart to [`Summary`]: no tokens, no network.
+/// What: the captured `raw_pane` (last N lines), `runtime_active` (is the
+/// runtime process still live in the pane?), and the two escalation fields the
+/// managed surface already tracks — `pending_decision` (a question awaiting a
+/// human) and its `proposed_default` answer.
+/// Test: `observe_returns_raw_pane_without_llm`,
+/// `observe_reports_runtime_active` in tests/session_control_api.rs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawObservation {
+    /// The captured pane text (the last `lines` rows requested).
+    pub raw_pane: String,
+    /// True when the session's runtime is still live (tmux session exists).
+    pub runtime_active: bool,
+    /// A pending decision the session is blocked on, if any (awaiting a human).
+    pub pending_decision: Option<String>,
+    /// The conformant default answer proposed for `pending_decision`, if any.
+    pub proposed_default: Option<String>,
+}
+
+/// An optional, LLM-derived summary of a session's activity state (#1461).
+///
+/// Why: `summarize` is the OPTIONAL, inference-backed counterpart to `observe`.
+/// It MUST degrade gracefully: on a host with no `OPENROUTER_API_KEY` it returns
+/// `state = Unknown` and `summary = None` rather than erroring, preserving the
+/// LLM-optional invariant the activity monitor already guarantees.
+/// What: reuses the existing [`ActivityState`] enum (NOT a duplicate) for the
+/// classified `state`; `summary` is the human-readable note (None when no
+/// genuine verdict was produced — i.e. degraded/unconfigured); `confidence` is
+/// the classifier's `[0.0, 1.0]` score (0.0 when degraded).
+/// Test: `summarize_degrades_to_unknown_without_key`,
+/// `summarize_returns_fake_verdict`, `summarize_serves_cached_verdict` in
+/// tests/session_control_api.rs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Summary {
+    /// The classified activity state (`Unknown` when inference is unavailable).
+    pub state: ActivityState,
+    /// The human-readable summary, or `None` when no genuine verdict exists.
+    pub summary: Option<String>,
+    /// Classifier confidence in `[0.0, 1.0]` (0.0 when degraded to `Unknown`).
+    pub confidence: f32,
+}
+
 /// The narrow session-control surface the SM drives its fleet through (§2.6).
 ///
 /// Why: keeps both `sm.sessions.*` (a thin translation) AND the SM-8 delegation
@@ -108,4 +186,48 @@ pub trait SessionControl: Send + Sync {
 
     /// Force-stop / reap a session (`DELETE /sessions/{id}`, §2.6).
     async fn kill(&self, session_id: &str) -> Result<serde_json::Value, SessionControlError>;
+
+    /// Inject `text` into a session, committed per `submit` (#1461).
+    ///
+    /// Why: the standard harness-agnostic write verb. Where [`send`](Self::send)
+    /// returns the wire `{ ok }` body and is fixed to "type + Enter", this
+    /// expresses ALL THREE keystroke intents ([`Submit::Enter`] /
+    /// [`Submit::NoSubmit`] / [`Submit::Interrupt`]) through one seam so any
+    /// runtime (tmux today, tcode/SDK later) is driven the same way.
+    /// What: keyed by the opaque `session_id`; dispatches on `submit` to the
+    /// runtime's literal-then-Enter, literal-only, or interrupt primitive.
+    /// Returns `()` on success (no wire body to shape).
+    /// Test: the inject-dispatch tests in tests/session_control_api.rs.
+    async fn inject_text(
+        &self,
+        session_id: &str,
+        text: &str,
+        submit: Submit,
+    ) -> Result<(), SessionControlError>;
+
+    /// Observe a session's raw surface — ALWAYS available, NO LLM (#1461).
+    ///
+    /// Why: every harness needs to read what a session is actually showing
+    /// WITHOUT depending on an LLM key; this is the deterministic, free read the
+    /// driver makes its own inference from.
+    /// What: captures the last `lines` pane rows, probes `runtime_active`, and
+    /// surfaces any `pending_decision` / `proposed_default`. Never calls the LLM.
+    /// Test: `observe_returns_raw_pane_without_llm`, `observe_reports_runtime_active`.
+    async fn observe(
+        &self,
+        session_id: &str,
+        lines: usize,
+    ) -> Result<RawObservation, SessionControlError>;
+
+    /// Summarize a session via the activity monitor — LLM-OPTIONAL (#1461).
+    ///
+    /// Why: the optional inference-backed counterpart to [`observe`](Self::observe).
+    /// It MUST degrade to `state = Unknown` / `summary = None` (never error) when
+    /// no `OPENROUTER_API_KEY` is configured, and serve a cached verdict when the
+    /// pane content is unchanged (content-hash hit) so repeated polls are cheap.
+    /// What: captures the pane, runs it through the shared
+    /// `ActivityMonitor::check`, and maps the verdict onto a [`Summary`].
+    /// Test: `summarize_degrades_to_unknown_without_key`,
+    /// `summarize_returns_fake_verdict`, `summarize_serves_cached_verdict`.
+    async fn summarize(&self, session_id: &str) -> Result<Summary, SessionControlError>;
 }

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -79,7 +79,9 @@ pub use context::{
     ConversationStore, ConversationStoreError, Round, SmContextEngine, SmContextError,
     SmConversation, ToolTrace,
 };
-pub use control::{LaunchParams, SessionControl, SessionControlError};
+pub use control::{
+    LaunchParams, RawObservation, SessionControl, SessionControlError, Submit, Summary,
+};
 pub use goals::{
     GOAL_TAG, Goal, GoalCache, GoalMemory, GoalStatus, SessionLink, SessionTaskState,
     SessionUpdate, SmGoalError, SmGoalResult, SmGoalStore,

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -143,7 +143,13 @@ pub async fn session_activity(
     let id = parse_managed_id(session_id)?;
     let mgr = state.session_manager().await;
     let record = mgr.get(&id).await.map_err(managed_err)?;
-    let raw_pane = mgr.capture_pane(&id, lines).await.unwrap_or_default();
+    // `lines` arrives as u32 from the MCP `session_activity` contract; the
+    // `capture_pane` param is `usize` (aligned with the observe path). u32→usize
+    // never narrows on supported platforms; saturate defensively just in case.
+    let raw_pane = mgr
+        .capture_pane(&id, usize::try_from(lines).unwrap_or(usize::MAX))
+        .await
+        .unwrap_or_default();
     let runtime_active = mgr.tmux_driver().session_exists(&record.tmux_name);
     Ok(json!({
         "id": record.id.to_string(),

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -24,7 +24,10 @@ use async_trait::async_trait;
 // Re-export the relocated trait + types so `sm_stdio`'s public surface
 // (`pub use control::{DaemonSessionControl, LaunchParams, SessionControl,
 // SessionControlError}`) is unchanged after the SM-8 move to core.
-pub use crate::core::sm::control::{LaunchParams, SessionControl, SessionControlError};
+use crate::activity::cache::ActivityState;
+pub use crate::core::sm::control::{
+    LaunchParams, RawObservation, SessionControl, SessionControlError, Submit, Summary,
+};
 
 use crate::daemon::managed_routes::{SpawnParams, record_to_json, resume_managed, spawn_managed};
 use crate::daemon::state::DaemonState;
@@ -185,5 +188,132 @@ impl SessionControl for DaemonSessionControl {
         let mgr = self.state.session_manager().await;
         mgr.decommission(&id).await.map_err(Self::map_managed_err)?;
         Ok(serde_json::json!({ "ok": true }))
+    }
+
+    /// Inject text via the manager, dispatched per [`Submit`] (#1461).
+    ///
+    /// Why: the production wiring of the harness-agnostic write verb. It forwards
+    /// to [`SessionManager::inject`], which dispatches the keystroke intent onto
+    /// the real tmux driver (literal+Enter / literal / C-c).
+    /// What: parses the id, then calls `inject`, mapping a manager failure onto
+    /// `Backend` (the pane/tmux failure class).
+    /// Test: forwards to `SessionManager::inject` (covered by the inject-dispatch
+    /// tests against a recording driver in tests/session_control_api.rs).
+    async fn inject_text(
+        &self,
+        session_id: &str,
+        text: &str,
+        submit: Submit,
+    ) -> Result<(), SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        let mgr = self.state.session_manager().await;
+        mgr.inject(&id, text, submit)
+            .await
+            .map_err(|e| SessionControlError::Backend(e.to_string()))
+    }
+
+    /// Observe the session's raw surface — LLM-FREE (#1461).
+    ///
+    /// Why: the production wiring of the always-available read verb. It forwards
+    /// to [`SessionManager::observe`], which never touches the LLM.
+    /// What: parses the id and returns the [`RawObservation`] (pane + liveness +
+    /// pending fields). `NotFound` is preserved for a genuinely-absent session.
+    /// Test: `observe_returns_raw_pane_without_llm`, `observe_reports_runtime_active`.
+    async fn observe(
+        &self,
+        session_id: &str,
+        lines: usize,
+    ) -> Result<RawObservation, SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        let mgr = self.state.session_manager().await;
+        mgr.observe(&id, lines as u32)
+            .await
+            .map_err(Self::map_managed_err)
+    }
+
+    /// Summarize the session via the activity monitor — LLM-OPTIONAL (#1461).
+    ///
+    /// Why: the production wiring of the optional inference verb. It reuses the
+    /// SAME shared [`crate::activity::monitor::ActivityMonitor`] the `/activity`
+    /// route uses, so the content-hash cache and the missing-key degrade are
+    /// inherited verbatim — repeated polls on unchanged panes are cheap, and an
+    /// unconfigured host returns `Unknown`/`None` instead of erroring.
+    /// What: captures the pane (LLM-free), runs `ActivityMonitor::check` (which
+    /// converts `MissingApiKey` to an `Unknown` verdict non-erroring), and maps
+    /// the verdict onto a [`Summary`] — dropping the placeholder summary text to
+    /// `None` whenever the state is `Unknown` (degraded), per the LLM-optional
+    /// contract.
+    /// Test: `summarize_degrades_to_unknown_without_key`, `summarize_returns_fake_verdict`,
+    /// `summarize_serves_cached_verdict` (the last two via a fake-classifier monitor).
+    async fn summarize(&self, session_id: &str) -> Result<Summary, SessionControlError> {
+        let id = Self::parse_id(session_id)?;
+        let mgr = self.state.session_manager().await;
+        // Capture is LLM-free and tolerant of a gone pane (empty string).
+        let pane_text = mgr.capture_pane(&id, 60).await.unwrap_or_default();
+        let monitor = self.state.activity_monitor();
+        // `check` already degrades MissingApiKey → Unknown verdict (no error).
+        let result = monitor
+            .check(session_id, &pane_text)
+            .await
+            .map_err(|e| SessionControlError::Backend(e.to_string()))?;
+        Ok(verdict_to_summary(result.verdict))
+    }
+}
+
+/// Map an [`crate::activity::cache::ActivityVerdict`] onto a [`Summary`] (#1461).
+///
+/// Why: the LLM-optional contract says a degraded (`Unknown`) verdict must carry
+/// `summary = None` — the placeholder text ("OPENROUTER_API_KEY not configured")
+/// is NOT a real summary. Centralising the mapping keeps that rule in one place
+/// and mirrors the activity sidecar, which also never stores an `Unknown` summary.
+/// What: copies `state`/`confidence`; sets `summary = Some(text)` only when the
+/// state is anything other than `Unknown`.
+/// Test: `summarize_degrades_to_unknown_without_key` (None) and
+/// `summarize_returns_fake_verdict` (Some) in tests/session_control_api.rs.
+fn verdict_to_summary(verdict: crate::activity::cache::ActivityVerdict) -> Summary {
+    let summary = if verdict.state == ActivityState::Unknown {
+        None
+    } else {
+        Some(verdict.summary)
+    };
+    Summary {
+        state: verdict.state,
+        summary,
+        confidence: verdict.confidence,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activity::cache::ActivityVerdict;
+
+    #[test]
+    fn verdict_to_summary_drops_unknown_summary_to_none() {
+        // The degraded placeholder (Unknown + "OPENROUTER_API_KEY not configured")
+        // must map to summary=None so the LLM-optional contract holds.
+        let v = ActivityVerdict {
+            state: ActivityState::Unknown,
+            summary: "OPENROUTER_API_KEY not configured".into(),
+            confidence: 0.0,
+        };
+        let s = verdict_to_summary(v);
+        assert_eq!(s.state, ActivityState::Unknown);
+        assert_eq!(s.summary, None);
+        assert_eq!(s.confidence, 0.0);
+    }
+
+    #[test]
+    fn verdict_to_summary_keeps_real_summary() {
+        // A genuine (non-Unknown) verdict keeps its summary text and confidence.
+        let v = ActivityVerdict {
+            state: ActivityState::Working,
+            summary: "writing code".into(),
+            confidence: 0.87,
+        };
+        let s = verdict_to_summary(v);
+        assert_eq!(s.state, ActivityState::Working);
+        assert_eq!(s.summary.as_deref(), Some("writing code"));
+        assert_eq!(s.confidence, 0.87);
     }
 }

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -225,8 +225,6 @@ impl SessionControl for DaemonSessionControl {
         lines: usize,
     ) -> Result<RawObservation, SessionControlError> {
         let id = Self::parse_id(session_id)?;
-        let lines = u32::try_from(lines)
-            .map_err(|_| SessionControlError::Backend(format!("lines out of range: {lines}")))?;
         let mgr = self.state.session_manager().await;
         mgr.observe(&id, lines).await.map_err(Self::map_managed_err)
     }
@@ -314,6 +312,9 @@ mod tests {
         let s = verdict_to_summary(v);
         assert_eq!(s.state, ActivityState::Working);
         assert_eq!(s.summary.as_deref(), Some("writing code"));
-        assert_eq!(s.confidence, 0.87);
+        // Approx comparison: `confidence` is an f64 carried through the verdict,
+        // so an exact `==` is fragile to float representation. 1e-6 is far
+        // tighter than any meaningful confidence delta.
+        assert!((s.confidence - 0.87).abs() < 1e-6);
     }
 }

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -225,10 +225,10 @@ impl SessionControl for DaemonSessionControl {
         lines: usize,
     ) -> Result<RawObservation, SessionControlError> {
         let id = Self::parse_id(session_id)?;
+        let lines = u32::try_from(lines)
+            .map_err(|_| SessionControlError::Backend(format!("lines out of range: {lines}")))?;
         let mgr = self.state.session_manager().await;
-        mgr.observe(&id, lines as u32)
-            .await
-            .map_err(Self::map_managed_err)
+        mgr.observe(&id, lines).await.map_err(Self::map_managed_err)
     }
 
     /// Summarize the session via the activity monitor — LLM-OPTIONAL (#1461).

--- a/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
@@ -22,9 +22,11 @@ use trusty_common::mcp::{Request, Response, error_codes};
 use super::SmDispatcher;
 use super::control::{LaunchParams, SessionControl, SessionControlError};
 use super::methods::{CODE_NOT_FOUND, CODE_UNAVAILABLE};
+use crate::activity::cache::ActivityState;
 use crate::core::sm::SessionManagerConfig;
 use crate::core::sm::agent::SessionManagerAgent;
 use crate::core::sm::agent::mock::{MockChatProvider, MockResolver};
+use crate::core::sm::control::{RawObservation, Submit, Summary};
 
 // ── Mock session control ────────────────────────────────────────────────────────
 
@@ -88,7 +90,7 @@ impl SessionControl for MockSessionControl {
         &self,
         _id: &str,
         _text: &str,
-        _submit: crate::core::sm::control::Submit,
+        _submit: Submit,
     ) -> Result<(), SessionControlError> {
         Ok(())
     }
@@ -96,20 +98,17 @@ impl SessionControl for MockSessionControl {
         &self,
         _id: &str,
         _lines: usize,
-    ) -> Result<crate::core::sm::control::RawObservation, SessionControlError> {
-        Ok(crate::core::sm::control::RawObservation {
+    ) -> Result<RawObservation, SessionControlError> {
+        Ok(RawObservation {
             raw_pane: String::new(),
             runtime_active: true,
             pending_decision: None,
             proposed_default: None,
         })
     }
-    async fn summarize(
-        &self,
-        _id: &str,
-    ) -> Result<crate::core::sm::control::Summary, SessionControlError> {
-        Ok(crate::core::sm::control::Summary {
-            state: crate::activity::cache::ActivityState::Unknown,
+    async fn summarize(&self, _id: &str) -> Result<Summary, SessionControlError> {
+        Ok(Summary {
+            state: ActivityState::Unknown,
             summary: None,
             confidence: 0.0,
         })

--- a/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
@@ -84,6 +84,36 @@ impl SessionControl for MockSessionControl {
         }
         Ok(json!({ "ok": true }))
     }
+    async fn inject_text(
+        &self,
+        _id: &str,
+        _text: &str,
+        _submit: crate::core::sm::control::Submit,
+    ) -> Result<(), SessionControlError> {
+        Ok(())
+    }
+    async fn observe(
+        &self,
+        _id: &str,
+        _lines: usize,
+    ) -> Result<crate::core::sm::control::RawObservation, SessionControlError> {
+        Ok(crate::core::sm::control::RawObservation {
+            raw_pane: String::new(),
+            runtime_active: true,
+            pending_decision: None,
+            proposed_default: None,
+        })
+    }
+    async fn summarize(
+        &self,
+        _id: &str,
+    ) -> Result<crate::core::sm::control::Summary, SessionControlError> {
+        Ok(crate::core::sm::control::Summary {
+            state: crate::activity::cache::ActivityState::Unknown,
+            summary: None,
+            confidence: 0.0,
+        })
+    }
 }
 
 // ── Dispatcher builders (feature-aware) ─────────────────────────────────────────
@@ -911,6 +941,40 @@ impl SessionControl for EvidenceControl {
     }
     async fn kill(&self, _id: &str) -> Result<Value, SessionControlError> {
         Ok(json!({ "ok": true }))
+    }
+    async fn inject_text(
+        &self,
+        id: &str,
+        text: &str,
+        _submit: crate::core::sm::control::Submit,
+    ) -> Result<(), SessionControlError> {
+        self.sends
+            .lock()
+            .expect("lock")
+            .push((id.to_string(), text.to_string()));
+        Ok(())
+    }
+    async fn observe(
+        &self,
+        _id: &str,
+        _lines: usize,
+    ) -> Result<crate::core::sm::control::RawObservation, SessionControlError> {
+        Ok(crate::core::sm::control::RawObservation {
+            raw_pane: self.evidence.clone(),
+            runtime_active: true,
+            pending_decision: None,
+            proposed_default: None,
+        })
+    }
+    async fn summarize(
+        &self,
+        _id: &str,
+    ) -> Result<crate::core::sm::control::Summary, SessionControlError> {
+        Ok(crate::core::sm::control::Summary {
+            state: crate::activity::cache::ActivityState::Unknown,
+            summary: None,
+            confidence: 0.0,
+        })
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -199,6 +199,23 @@ impl TmuxDriver {
         Ok(())
     }
 
+    /// Send literal text to a session/pane WITHOUT a trailing Enter.
+    ///
+    /// Why: the harness-agnostic no-submit inject intent (#1461) types into the
+    /// pane but leaves the line uncommitted (vs. [`send_line`](Self::send_line),
+    /// which appends Enter). Keeping it a separate one-shot avoids the second
+    /// `Enter` send-keys call.
+    /// What: a single `send-keys -l` invocation (literal, no key-name follow-up).
+    /// Test: `core::tmux::send_keys_literal_argv` covers the argv shape.
+    pub fn send_keys_literal(&self, target: &TmuxTarget, text: &str) -> Result<()> {
+        self.run(&TmuxCommand::SendKeys {
+            target: target.clone(),
+            keys: text.to_string(),
+            literal: true,
+        })?;
+        Ok(())
+    }
+
     /// Send a Ctrl-C interrupt to a session/pane.
     ///
     /// Why: restarting Claude Code in place means interrupting the running

--- a/crates/trusty-mpm/src/runtime/test_helpers.rs
+++ b/crates/trusty-mpm/src/runtime/test_helpers.rs
@@ -61,7 +61,7 @@ impl ManagedTmuxDriver for FakeTmux {
         Ok(())
     }
 
-    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
         Ok(String::new())
     }
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -77,6 +77,36 @@ pub trait ManagedTmuxDriver: Send + Sync {
     /// Send literal text followed by Enter to the session named `name`.
     fn send_line(&self, name: &str, text: &str) -> Result<(), ManagedError>;
 
+    /// Send literal text to `name` WITHOUT a trailing Enter (#1461).
+    ///
+    /// Why: the harness-agnostic [`Submit::NoSubmit`](crate::core::sm::control::Submit::NoSubmit)
+    /// intent must type into the pane without committing the line (e.g. staging a
+    /// partial command a human will edit). Splitting this out keeps `send_line`
+    /// (literal + Enter) and this (literal only) as distinct, testable primitives.
+    /// What: sends `text` literally; the default routes through `send_line` for
+    /// drivers that do not distinguish the two — the real tmux driver overrides
+    /// this to omit the Enter. Default keeps the six existing impls compiling
+    /// untouched.
+    /// Test: `RealTmuxDriver` override is asserted via `core::tmux` argv tests;
+    /// the no-submit dispatch is asserted by `inject_dispatch_nosubmit_sends_literal_only`.
+    fn send_keys_literal(&self, name: &str, text: &str) -> Result<(), ManagedError> {
+        self.send_line(name, text)
+    }
+
+    /// Send an interrupt (Ctrl-C) to the session named `name` (#1461).
+    ///
+    /// Why: the [`Submit::Interrupt`](crate::core::sm::control::Submit::Interrupt)
+    /// intent stops a running task in place (the clean precursor to relaunching a
+    /// runtime). Exposing it on the trait keeps the interrupt path runtime-neutral.
+    /// What: sends the runtime's interrupt; the default is a no-op `Ok(())` so the
+    /// existing impls compile untouched — the real tmux driver overrides this to
+    /// send `C-c`.
+    /// Test: `RealTmuxDriver` override via `core::tmux::send_keys_keyname_argv`;
+    /// dispatch asserted by `inject_dispatch_interrupt_sends_ctrl_c`.
+    fn send_interrupt(&self, _name: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
     /// Capture the last `lines` of pane output for the session named `name`.
     fn capture(&self, name: &str, lines: u32) -> Result<String, ManagedError>;
 
@@ -393,6 +423,77 @@ impl SessionManager {
         record.last_activity_at = Some(Utc::now());
         self.store.write().await.upsert(record).await?;
         Ok(())
+    }
+
+    /// Inject text into a live session, committed per [`Submit`] (#1461).
+    ///
+    /// Why: the harness-agnostic `inject_text` verb needs ONE manager helper that
+    /// dispatches the three keystroke intents onto the [`ManagedTmuxDriver`] seam
+    /// so the `SessionControl` impl stays a thin mapping. It reuses the same
+    /// Stopped/Decommissioned guard as [`send_input`](Self::send_input) so input
+    /// is never sent to a dead pane.
+    /// What: looks up the record, rejects Stopped/Decommissioned sessions, then
+    /// dispatches: [`Submit::Enter`] → `send_line` (literal + Enter),
+    /// [`Submit::NoSubmit`] → `send_keys_literal` (literal only),
+    /// [`Submit::Interrupt`] → `send_interrupt` (Ctrl-C). Updates `last_activity_at`.
+    /// Test: `inject_dispatch_enter_sends_literal_then_enter`,
+    /// `inject_dispatch_nosubmit_sends_literal_only`,
+    /// `inject_dispatch_interrupt_sends_ctrl_c` in tests/session_control_api.rs.
+    pub async fn inject(
+        &self,
+        id: &ManagedSessionId,
+        text: &str,
+        submit: crate::core::sm::control::Submit,
+    ) -> Result<(), ManagedError> {
+        use crate::core::sm::control::Submit;
+        let mut record = self.get(id).await?;
+        if matches!(
+            record.state,
+            ManagedSessionState::Stopped | ManagedSessionState::Decommissioned
+        ) {
+            return Err(ManagedError::TmuxUnavailable(format!(
+                "session {} is {}; cannot inject input",
+                record.tmux_name, record.state
+            )));
+        }
+        let result = match submit {
+            Submit::Enter => self.tmux.send_line(&record.tmux_name, text),
+            Submit::NoSubmit => self.tmux.send_keys_literal(&record.tmux_name, text),
+            Submit::Interrupt => self.tmux.send_interrupt(&record.tmux_name),
+        };
+        result.map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
+        record.last_activity_at = Some(Utc::now());
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+
+    /// Observe a session's raw surface — LLM-FREE (#1461).
+    ///
+    /// Why: every harness needs a cheap, deterministic read of what a session is
+    /// actually showing (pane + liveness + any pending escalation) WITHOUT an LLM
+    /// key. This bundles the three reads the managed activity route already does
+    /// into one manager helper so `SessionControl::observe` is a thin mapping.
+    /// What: captures the last `lines` pane rows (empty string if the pane is
+    /// gone), probes `runtime_active` via `session_exists`, and reads the record's
+    /// `pending_decision` / `proposed_default`. Never calls the LLM.
+    /// Test: `observe_returns_raw_pane_without_llm`, `observe_reports_runtime_active`.
+    pub async fn observe(
+        &self,
+        id: &ManagedSessionId,
+        lines: u32,
+    ) -> Result<crate::core::sm::control::RawObservation, ManagedError> {
+        let record = self.get(id).await?;
+        let raw_pane = self
+            .tmux
+            .capture(&record.tmux_name, lines)
+            .unwrap_or_default();
+        let runtime_active = self.tmux.session_exists(&record.tmux_name);
+        Ok(crate::core::sm::control::RawObservation {
+            raw_pane,
+            runtime_active,
+            pending_decision: record.pending_decision,
+            proposed_default: record.proposed_default,
+        })
     }
 
     /// Stop the runtime of a managed session, keeping the workspace intact.

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -21,6 +21,7 @@ use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 use crate::core::names::{name_from_dir, name_from_uuid};
+use crate::core::sm::control::Submit;
 
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::store::{SessionStore, StoreError};
@@ -83,14 +84,18 @@ pub trait ManagedTmuxDriver: Send + Sync {
     /// intent must type into the pane without committing the line (e.g. staging a
     /// partial command a human will edit). Splitting this out keeps `send_line`
     /// (literal + Enter) and this (literal only) as distinct, testable primitives.
-    /// What: sends `text` literally; the default routes through `send_line` for
-    /// drivers that do not distinguish the two — the real tmux driver overrides
-    /// this to omit the Enter. Default keeps the six existing impls compiling
-    /// untouched.
+    /// What: sends `text` literally. The default returns an explicit
+    /// `TmuxUnavailable` error rather than silently falling back to `send_line`:
+    /// delegating to `send_line` would append an Enter and SUBMIT a line the
+    /// caller asked NOT to submit (`Submit::NoSubmit`) — a silent-wrong-behavior
+    /// trap. Any driver actually used with `inject(.., NoSubmit)` MUST override
+    /// this (the real `RealTmuxDriver` does); an un-overriding driver fails loudly.
     /// Test: `RealTmuxDriver` override is asserted via `core::tmux` argv tests;
     /// the no-submit dispatch is asserted by `inject_dispatch_nosubmit_sends_literal_only`.
-    fn send_keys_literal(&self, name: &str, text: &str) -> Result<(), ManagedError> {
-        self.send_line(name, text)
+    fn send_keys_literal(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Err(ManagedError::TmuxUnavailable(
+            "send_keys_literal not implemented for this driver".into(),
+        ))
     }
 
     /// Send an interrupt (Ctrl-C) to the session named `name` (#1461).
@@ -98,13 +103,19 @@ pub trait ManagedTmuxDriver: Send + Sync {
     /// Why: the [`Submit::Interrupt`](crate::core::sm::control::Submit::Interrupt)
     /// intent stops a running task in place (the clean precursor to relaunching a
     /// runtime). Exposing it on the trait keeps the interrupt path runtime-neutral.
-    /// What: sends the runtime's interrupt; the default is a no-op `Ok(())` so the
-    /// existing impls compile untouched — the real tmux driver overrides this to
-    /// send `C-c`.
+    /// What: sends the runtime's interrupt. The default returns an explicit
+    /// `TmuxUnavailable` error rather than a silent no-op `Ok(())`: Interrupt is
+    /// the verb used to STOP a running task, so a silent no-op would leave the
+    /// task running while the caller believes it was interrupted — a dangerous
+    /// silent-wrong-behavior trap. Any driver actually used with
+    /// `inject(.., Interrupt)` MUST override this (the real `RealTmuxDriver` sends
+    /// `C-c`); an un-overriding driver fails loudly.
     /// Test: `RealTmuxDriver` override via `core::tmux::send_keys_keyname_argv`;
     /// dispatch asserted by `inject_dispatch_interrupt_sends_ctrl_c`.
     fn send_interrupt(&self, _name: &str) -> Result<(), ManagedError> {
-        Ok(())
+        Err(ManagedError::TmuxUnavailable(
+            "send_interrupt not implemented for this driver".into(),
+        ))
     }
 
     /// Capture the last `lines` of pane output for the session named `name`.
@@ -443,9 +454,8 @@ impl SessionManager {
         &self,
         id: &ManagedSessionId,
         text: &str,
-        submit: crate::core::sm::control::Submit,
+        submit: Submit,
     ) -> Result<(), ManagedError> {
-        use crate::core::sm::control::Submit;
         let mut record = self.get(id).await?;
         if matches!(
             record.state,

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -119,7 +119,13 @@ pub trait ManagedTmuxDriver: Send + Sync {
     }
 
     /// Capture the last `lines` of pane output for the session named `name`.
-    fn capture(&self, name: &str, lines: u32) -> Result<String, ManagedError>;
+    ///
+    /// `lines` is `usize` to match the harness-agnostic
+    /// [`SessionControl::observe`](crate::core::sm::control::SessionControl::observe)
+    /// contract end-to-end; the single `usize → u32` narrowing the underlying
+    /// tmux `-S` argv requires is confined to the real-tmux driver edge, so no
+    /// caller in the observe path needs a `try_from`.
+    fn capture(&self, name: &str, lines: usize) -> Result<String, ManagedError>;
 
     /// Return all live tmux session names on the host.
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError>;
@@ -446,7 +452,11 @@ impl SessionManager {
     /// What: looks up the record, rejects Stopped/Decommissioned sessions, then
     /// dispatches: [`Submit::Enter`] → `send_line` (literal + Enter),
     /// [`Submit::NoSubmit`] → `send_keys_literal` (literal only),
-    /// [`Submit::Interrupt`] → `send_interrupt` (Ctrl-C). Updates `last_activity_at`.
+    /// [`Submit::Interrupt`] → `send_interrupt` (Ctrl-C). Bumps
+    /// `last_activity_at` ONLY for `Enter`/`NoSubmit`: an `Interrupt` (Ctrl-C) is
+    /// a STOP signal, not forward progress, so treating it as activity would
+    /// mislead the idle/orphan-GC reconciliation into believing a stalled session
+    /// is still working.
     /// Test: `inject_dispatch_enter_sends_literal_then_enter`,
     /// `inject_dispatch_nosubmit_sends_literal_only`,
     /// `inject_dispatch_interrupt_sends_ctrl_c` in tests/session_control_api.rs.
@@ -472,7 +482,10 @@ impl SessionManager {
             Submit::Interrupt => self.tmux.send_interrupt(&record.tmux_name),
         };
         result.map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
-        record.last_activity_at = Some(Utc::now());
+        // Interrupt is a STOP signal, not activity — do not bump last_activity_at.
+        if matches!(submit, Submit::Enter | Submit::NoSubmit) {
+            record.last_activity_at = Some(Utc::now());
+        }
         self.store.write().await.upsert(record).await?;
         Ok(())
     }
@@ -490,7 +503,7 @@ impl SessionManager {
     pub async fn observe(
         &self,
         id: &ManagedSessionId,
-        lines: u32,
+        lines: usize,
     ) -> Result<crate::core::sm::control::RawObservation, ManagedError> {
         let record = self.get(id).await?;
         let raw_pane = self
@@ -800,7 +813,7 @@ impl SessionManager {
     pub async fn capture_pane(
         &self,
         id: &ManagedSessionId,
-        lines: u32,
+        lines: usize,
     ) -> Result<String, ManagedError> {
         let record = self.get(id).await?;
         self.tmux

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -63,6 +63,21 @@ impl ManagedTmuxDriver for RealTmuxDriver {
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
     }
 
+    /// Type literal text with NO trailing Enter (overrides the trait default so
+    /// the production path actually omits the newline; #1461).
+    fn send_keys_literal(&self, name: &str, text: &str) -> Result<(), ManagedError> {
+        self.driver
+            .send_keys_literal(&TmuxTarget::session(name), text)
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
+
+    /// Send Ctrl-C to the session (overrides the no-op trait default; #1461).
+    fn send_interrupt(&self, name: &str) -> Result<(), ManagedError> {
+        self.driver
+            .send_interrupt(&TmuxTarget::session(name))
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
+
     fn capture(&self, name: &str, lines: u32) -> Result<String, ManagedError> {
         self.driver
             .capture(&TmuxTarget::session(name), Some(lines))

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -78,7 +78,12 @@ impl ManagedTmuxDriver for RealTmuxDriver {
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
     }
 
-    fn capture(&self, name: &str, lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, name: &str, lines: usize) -> Result<String, ManagedError> {
+        // The tmux `-S -<n>` argv takes a u32; this driver edge is the single
+        // narrowing point so the rest of the observe path stays `usize`. An
+        // out-of-range request is saturated to u32::MAX (capturing the whole
+        // scrollback) rather than erroring — more pane than asked for is benign.
+        let lines = u32::try_from(lines).unwrap_or(u32::MAX);
         self.driver
             .capture(&TmuxTarget::session(name), Some(lines))
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
@@ -117,7 +122,7 @@ impl ManagedTmuxDriver for NoopTmuxDriver {
         Err(ManagedError::TmuxUnavailable("tmux not installed".into()))
     }
 
-    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
         Ok(String::new())
     }
 

--- a/crates/trusty-mpm/src/session_manager/session_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/session_guard.rs
@@ -165,7 +165,7 @@ mod tests {
         fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
             Ok(())
         }
-        fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+        fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
             Ok(String::new())
         }
         fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
@@ -185,7 +185,7 @@ mod tests {
         fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
             Ok(())
         }
-        fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+        fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
             Ok(String::new())
         }
         fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -84,7 +84,7 @@ impl ManagedTmuxDriver for FakeTmuxDriver {
         Ok(())
     }
 
-    fn capture(&self, name: &str, _lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, name: &str, _lines: usize) -> Result<String, ManagedError> {
         Ok(self
             .capture_responses
             .lock()

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -78,7 +78,7 @@ impl ManagedTmuxDriver for FakeTmux {
         Ok(())
     }
 
-    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
         Ok("working on the task...\n$ cargo test".to_owned())
     }
 

--- a/crates/trusty-mpm/tests/orphan_gc_sweep.rs
+++ b/crates/trusty-mpm/tests/orphan_gc_sweep.rs
@@ -44,7 +44,7 @@ impl ManagedTmuxDriver for RecordingDriver {
     fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
         Ok(())
     }
-    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
         Ok(String::new())
     }
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {

--- a/crates/trusty-mpm/tests/session_control_api.rs
+++ b/crates/trusty-mpm/tests/session_control_api.rs
@@ -1,0 +1,368 @@
+//! Contract tests for the harness-agnostic session-capability API (#1461).
+//!
+//! Why: the `SessionControl` seam grows three standard verbs every harness uses
+//! — `inject_text` (write, with a [`Submit`] mode), `observe` (LLM-free read),
+//! and `summarize` (LLM-OPTIONAL inference). These tests prove the CONTRACT at
+//! the substance behind the trait: `SessionManager::inject` dispatches the three
+//! keystroke intents onto the driver; `SessionManager::observe` returns the raw
+//! pane + liveness WITHOUT any LLM; and the activity monitor that backs
+//! `summarize` degrades to `Unknown`/`None` without a key and serves a cached
+//! verdict on identical pane content.
+//! What: a recording `ManagedTmuxDriver` lets us assert the exact driver calls
+//! each `Submit` mode makes; a fake `LlmClassifier` lets us assert the cache-hit
+//! and degrade behavior offline. Back-compat for `send`/`send_input` is asserted
+//! alongside `inject(.., Enter)` so the two paths cannot diverge.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm
+//! --test session_control_api`.
+
+use std::sync::{Arc, Mutex};
+
+use tempfile::TempDir;
+
+use trusty_mpm::core::sm::control::Submit;
+use trusty_mpm::session_manager::{
+    ManagedError, ManagedSessionId, ManagedTmuxDriver, SessionManager,
+};
+
+/// A recording tmux driver that captures EVERY keystroke primitive (#1461).
+///
+/// Why: the inject-dispatch contract is exactly "which driver call does each
+/// `Submit` mode make?"; recording `send_line` / `send_keys_literal` /
+/// `send_interrupt` separately lets each test assert the precise dispatch
+/// (literal+Enter vs literal-only vs Ctrl-C). It also serves a scriptable
+/// capture body and a liveness flag so `observe` can be exercised.
+/// What: per-primitive call logs behind mutexes; `capture` returns a seeded
+/// pane; `session_exists` is configurable so `runtime_active` can be both true
+/// and false.
+/// Test: drives every test in this file.
+struct RecordingDriver {
+    /// `(name, text)` recorded by `send_line` (the Enter path).
+    send_line_calls: Mutex<Vec<(String, String)>>,
+    /// `(name, text)` recorded by `send_keys_literal` (the NoSubmit path).
+    literal_calls: Mutex<Vec<(String, String)>>,
+    /// `name` recorded by `send_interrupt` (the Interrupt path).
+    interrupt_calls: Mutex<Vec<String>>,
+    /// Pane text `capture` returns (the OBSERVE input).
+    capture_body: Mutex<String>,
+    /// Names that `session_exists` reports as live (also `create_session` adds).
+    live: Mutex<Vec<String>>,
+    /// What `session_exists` returns regardless of `live` (None ⇒ consult `live`).
+    force_alive: Mutex<Option<bool>>,
+}
+
+impl RecordingDriver {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            send_line_calls: Mutex::new(Vec::new()),
+            literal_calls: Mutex::new(Vec::new()),
+            interrupt_calls: Mutex::new(Vec::new()),
+            capture_body: Mutex::new(String::new()),
+            live: Mutex::new(Vec::new()),
+            force_alive: Mutex::new(None),
+        })
+    }
+}
+
+impl ManagedTmuxDriver for RecordingDriver {
+    fn create_session(&self, name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        self.live.lock().unwrap().push(name.to_owned());
+        Ok(())
+    }
+    fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn send_line(&self, name: &str, text: &str) -> Result<(), ManagedError> {
+        self.send_line_calls
+            .lock()
+            .unwrap()
+            .push((name.to_owned(), text.to_owned()));
+        Ok(())
+    }
+    fn send_keys_literal(&self, name: &str, text: &str) -> Result<(), ManagedError> {
+        self.literal_calls
+            .lock()
+            .unwrap()
+            .push((name.to_owned(), text.to_owned()));
+        Ok(())
+    }
+    fn send_interrupt(&self, name: &str) -> Result<(), ManagedError> {
+        self.interrupt_calls.lock().unwrap().push(name.to_owned());
+        Ok(())
+    }
+    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+        Ok(self.capture_body.lock().unwrap().clone())
+    }
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        Ok(self.live.lock().unwrap().clone())
+    }
+    fn session_exists(&self, name: &str) -> bool {
+        if let Some(f) = *self.force_alive.lock().unwrap() {
+            return f;
+        }
+        self.live.lock().unwrap().iter().any(|n| n == name)
+    }
+}
+
+/// Create a manager + a fresh active session, returning the id and the driver.
+async fn make_session(dir: &TempDir) -> (SessionManager, Arc<RecordingDriver>, ManagedSessionId) {
+    let driver = RecordingDriver::new();
+    let mgr = SessionManager::new(dir.path(), driver.clone())
+        .await
+        .expect("manager");
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(dir.path().to_path_buf()),
+            Some("proj".into()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    (mgr, driver, record.id)
+}
+
+// ── inject_text dispatch (the three Submit modes) ────────────────────────────
+
+#[tokio::test]
+async fn inject_dispatch_enter_sends_literal_then_enter() {
+    // Submit::Enter must route through the driver's send_line (literal + Enter),
+    // NOT the literal-only or interrupt primitives.
+    let dir = TempDir::new().unwrap();
+    let (mgr, driver, id) = make_session(&dir).await;
+
+    mgr.inject(&id, "do the thing", Submit::Enter)
+        .await
+        .expect("inject enter");
+
+    let sends = driver.send_line_calls.lock().unwrap();
+    assert_eq!(sends.len(), 1, "Enter must call send_line exactly once");
+    assert_eq!(sends[0].1, "do the thing");
+    assert!(
+        driver.literal_calls.lock().unwrap().is_empty(),
+        "Enter must NOT call send_keys_literal"
+    );
+    assert!(
+        driver.interrupt_calls.lock().unwrap().is_empty(),
+        "Enter must NOT send an interrupt"
+    );
+}
+
+#[tokio::test]
+async fn inject_dispatch_nosubmit_sends_literal_only() {
+    // Submit::NoSubmit must type the literal text with NO Enter (literal path
+    // only) and never touch send_line or interrupt.
+    let dir = TempDir::new().unwrap();
+    let (mgr, driver, id) = make_session(&dir).await;
+
+    mgr.inject(&id, "partial cmd", Submit::NoSubmit)
+        .await
+        .expect("inject nosubmit");
+
+    let literal = driver.literal_calls.lock().unwrap();
+    assert_eq!(
+        literal.len(),
+        1,
+        "NoSubmit must call send_keys_literal once"
+    );
+    assert_eq!(literal[0].1, "partial cmd");
+    assert!(
+        driver.send_line_calls.lock().unwrap().is_empty(),
+        "NoSubmit must NOT call send_line (no Enter)"
+    );
+    assert!(
+        driver.interrupt_calls.lock().unwrap().is_empty(),
+        "NoSubmit must NOT send an interrupt"
+    );
+}
+
+#[tokio::test]
+async fn inject_dispatch_interrupt_sends_ctrl_c() {
+    // Submit::Interrupt must send the interrupt (Ctrl-C) and ignore any text.
+    let dir = TempDir::new().unwrap();
+    let (mgr, driver, id) = make_session(&dir).await;
+
+    mgr.inject(&id, "ignored", Submit::Interrupt)
+        .await
+        .expect("inject interrupt");
+
+    let interrupts = driver.interrupt_calls.lock().unwrap();
+    assert_eq!(interrupts.len(), 1, "Interrupt must send exactly one C-c");
+    assert!(
+        driver.send_line_calls.lock().unwrap().is_empty(),
+        "Interrupt must NOT call send_line"
+    );
+    assert!(
+        driver.literal_calls.lock().unwrap().is_empty(),
+        "Interrupt must NOT call send_keys_literal"
+    );
+}
+
+// ── observe (LLM-free) ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn observe_returns_raw_pane_without_llm() {
+    // observe is ALWAYS available with no LLM configured: it returns whatever the
+    // driver captured verbatim. We explicitly clear the key to prove no inference.
+    unsafe { std::env::remove_var("OPENROUTER_API_KEY") };
+    let dir = TempDir::new().unwrap();
+    let (mgr, driver, id) = make_session(&dir).await;
+    *driver.capture_body.lock().unwrap() = "line 1\nline 2\nPR: https://x/1".into();
+
+    let obs = mgr.observe(&id, 60).await.expect("observe");
+    assert_eq!(obs.raw_pane, "line 1\nline 2\nPR: https://x/1");
+    assert_eq!(obs.pending_decision, None);
+    assert_eq!(obs.proposed_default, None);
+}
+
+#[tokio::test]
+async fn observe_reports_runtime_active() {
+    // runtime_active reflects tmux liveness: true while the session exists,
+    // false once it is gone — all without any LLM.
+    let dir = TempDir::new().unwrap();
+    let (mgr, driver, id) = make_session(&dir).await;
+
+    *driver.force_alive.lock().unwrap() = Some(true);
+    assert!(
+        mgr.observe(&id, 10)
+            .await
+            .expect("observe alive")
+            .runtime_active
+    );
+
+    *driver.force_alive.lock().unwrap() = Some(false);
+    assert!(
+        !mgr.observe(&id, 10)
+            .await
+            .expect("observe dead")
+            .runtime_active
+    );
+}
+
+// ── back-compat: send_input (the legacy `send` path) still works ─────────────
+
+#[tokio::test]
+async fn send_input_back_compat_still_uses_send_line() {
+    // The pre-#1461 send_input path (what SessionControl::send wraps) must remain
+    // a literal+Enter send — equivalent to inject(.., Submit::Enter).
+    let dir = TempDir::new().unwrap();
+    let (mgr, driver, id) = make_session(&dir).await;
+
+    mgr.send_input(&id, "legacy text")
+        .await
+        .expect("send_input");
+
+    let sends = driver.send_line_calls.lock().unwrap();
+    assert_eq!(sends.len(), 1);
+    assert_eq!(sends[0].1, "legacy text");
+}
+
+// ── summarize: LLM-OPTIONAL degrade + cache (via the activity monitor) ────────
+
+mod summarize {
+    use trusty_mpm::activity::cache::{ActivityState, ActivityVerdict};
+    use trusty_mpm::activity::monitor::{ActivityError, ActivityMonitor, LlmClassifier};
+
+    use std::sync::Mutex;
+
+    /// A classifier that always reports `MissingApiKey` — models an unconfigured
+    /// host so we can prove `summarize` degrades to Unknown/None, never errors.
+    struct NoKeyClassifier;
+    impl LlmClassifier for NoKeyClassifier {
+        async fn classify(
+            &self,
+            _pane: &str,
+        ) -> Result<(ActivityVerdict, u32, u32), ActivityError> {
+            Err(ActivityError::MissingApiKey)
+        }
+    }
+
+    use std::sync::Arc;
+
+    /// A classifier returning a fixed verdict and counting calls, so we can prove
+    /// a content-hash cache hit serves the cached verdict without re-classifying.
+    /// The call counter is an `Arc<Mutex>` the test keeps a handle to so it can
+    /// read the count even after the classifier is moved into the monitor.
+    struct CountingClassifier {
+        verdict: ActivityVerdict,
+        calls: Arc<Mutex<u32>>,
+    }
+    impl LlmClassifier for CountingClassifier {
+        async fn classify(
+            &self,
+            _pane: &str,
+        ) -> Result<(ActivityVerdict, u32, u32), ActivityError> {
+            *self.calls.lock().unwrap() += 1;
+            Ok((self.verdict.clone(), 10, 5))
+        }
+    }
+
+    /// Map a verdict the way `summarize` does: drop the placeholder summary to
+    /// None whenever the state is Unknown (the LLM-optional contract).
+    fn summary_text(v: &ActivityVerdict) -> Option<String> {
+        if v.state == ActivityState::Unknown {
+            None
+        } else {
+            Some(v.summary.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn summarize_degrades_to_unknown_without_key() {
+        // No key ⇒ the monitor yields an Unknown verdict (NOT an error), and the
+        // summarize mapping drops the placeholder text to None.
+        let monitor = ActivityMonitor::new(NoKeyClassifier, "test-model");
+        let result = monitor
+            .check("s1", "pane content")
+            .await
+            .expect("check must not error on missing key");
+        assert_eq!(result.verdict.state, ActivityState::Unknown);
+        assert_eq!(summary_text(&result.verdict), None);
+    }
+
+    #[tokio::test]
+    async fn summarize_returns_fake_verdict() {
+        // A configured (fake) classifier ⇒ the verdict flows through with a real
+        // summary string.
+        let classifier = CountingClassifier {
+            verdict: ActivityVerdict {
+                state: ActivityState::Working,
+                summary: "writing code".into(),
+                confidence: 0.9,
+            },
+            calls: Arc::new(Mutex::new(0)),
+        };
+        let monitor = ActivityMonitor::new(classifier, "test-model");
+        let result = monitor.check("s1", "pane A").await.expect("check");
+        assert_eq!(result.verdict.state, ActivityState::Working);
+        assert_eq!(
+            summary_text(&result.verdict).as_deref(),
+            Some("writing code")
+        );
+        assert!(!result.cache_hit);
+    }
+
+    #[tokio::test]
+    async fn summarize_serves_cached_verdict() {
+        // Identical pane content ⇒ the second check is a content-hash cache hit,
+        // so the classifier is called exactly once and the verdict is reused.
+        let calls = Arc::new(Mutex::new(0));
+        let classifier = CountingClassifier {
+            verdict: ActivityVerdict {
+                state: ActivityState::Working,
+                summary: "same".into(),
+                confidence: 1.0,
+            },
+            calls: calls.clone(),
+        };
+        let monitor = ActivityMonitor::new(classifier, "test-model");
+
+        let r1 = monitor.check("s1", "unchanged pane").await.expect("first");
+        assert!(!r1.cache_hit);
+        let r2 = monitor.check("s1", "unchanged pane").await.expect("second");
+        assert!(r2.cache_hit, "identical pane must be a cache hit");
+        assert_eq!(*calls.lock().unwrap(), 1, "classifier called once only");
+        assert_eq!(r2.verdict.summary, "same");
+    }
+}

--- a/crates/trusty-mpm/tests/session_control_api.rs
+++ b/crates/trusty-mpm/tests/session_control_api.rs
@@ -89,7 +89,7 @@ impl ManagedTmuxDriver for RecordingDriver {
         self.interrupt_calls.lock().unwrap().push(name.to_owned());
         Ok(())
     }
-    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
         Ok(self.capture_body.lock().unwrap().clone())
     }
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
@@ -197,6 +197,56 @@ async fn inject_dispatch_interrupt_sends_ctrl_c() {
         driver.literal_calls.lock().unwrap().is_empty(),
         "Interrupt must NOT call send_keys_literal"
     );
+}
+
+#[tokio::test]
+async fn inject_activity_bump_only_for_enter_and_nosubmit_not_interrupt() {
+    // Advisory follow-up (#1461): an Interrupt (Ctrl-C) is a STOP signal, not
+    // forward progress. A freshly-created record has `last_activity_at == None`;
+    // Enter/NoSubmit must set it, Interrupt must leave it untouched so the
+    // idle/orphan-GC reconciliation is not misled into thinking a stalled
+    // session is still working.
+    let dir = TempDir::new().unwrap();
+
+    // Interrupt: last_activity_at stays None.
+    {
+        let (mgr, _driver, id) = make_session(&dir).await;
+        assert!(
+            mgr.get(&id).await.unwrap().last_activity_at.is_none(),
+            "precondition: a fresh record has no activity timestamp"
+        );
+        mgr.inject(&id, "ignored", Submit::Interrupt)
+            .await
+            .expect("inject interrupt");
+        assert!(
+            mgr.get(&id).await.unwrap().last_activity_at.is_none(),
+            "Interrupt is a STOP signal and must NOT bump last_activity_at"
+        );
+    }
+
+    // Enter: last_activity_at becomes Some.
+    {
+        let (mgr, _driver, id) = make_session(&dir).await;
+        mgr.inject(&id, "go", Submit::Enter)
+            .await
+            .expect("inject enter");
+        assert!(
+            mgr.get(&id).await.unwrap().last_activity_at.is_some(),
+            "Enter is forward progress and MUST bump last_activity_at"
+        );
+    }
+
+    // NoSubmit: last_activity_at becomes Some.
+    {
+        let (mgr, _driver, id) = make_session(&dir).await;
+        mgr.inject(&id, "partial", Submit::NoSubmit)
+            .await
+            .expect("inject nosubmit");
+        assert!(
+            mgr.get(&id).await.unwrap().last_activity_at.is_some(),
+            "NoSubmit is forward progress and MUST bump last_activity_at"
+        );
+    }
 }
 
 // ── observe (LLM-free) ───────────────────────────────────────────────────────

--- a/crates/trusty-mpm/tests/session_control_api.rs
+++ b/crates/trusty-mpm/tests/session_control_api.rs
@@ -204,8 +204,10 @@ async fn inject_dispatch_interrupt_sends_ctrl_c() {
 #[tokio::test]
 async fn observe_returns_raw_pane_without_llm() {
     // observe is ALWAYS available with no LLM configured: it returns whatever the
-    // driver captured verbatim. We explicitly clear the key to prove no inference.
-    unsafe { std::env::remove_var("OPENROUTER_API_KEY") };
+    // driver captured verbatim. `observe` is LLM-FREE — it never touches the
+    // classifier — so no env manipulation is needed (and `std::env::remove_var`
+    // is UB under the multi-threaded test runner). The raw pane + runtime_active
+    // are returned regardless of any key.
     let dir = TempDir::new().unwrap();
     let (mgr, driver, id) = make_session(&dir).await;
     *driver.capture_body.lock().unwrap() = "line 1\nline 2\nPR: https://x/1".into();

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -63,7 +63,7 @@ impl ManagedTmuxDriver for RecordingTmux {
             .push((name.to_owned(), text.to_owned()));
         Ok(())
     }
-    fn capture(&self, _name: &str, _lines: u32) -> Result<String, ManagedError> {
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
         Ok(String::new())
     }
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {


### PR DESCRIPTION
Closes #1461. Standard, in-process, harness-agnostic session-capability API any harness (Claude Code, tcode, future runtimes) can use — keyed by opaque session_id, no tmux_name leakage.

## API (on the existing async SessionControl trait, core/sm/control.rs): `inject_text(id, text, Submit)` with Submit ∈ {Enter (literal+Enter), NoSubmit (literal, no Enter), Interrupt (C-c)} — closes the C-c/no-submit gaps in the trait; `observe(id, lines) -> RawObservation { raw_pane, runtime_active, pending_decision, proposed_default }` — always available, zero LLM; `summarize(id) -> Summary { state, summary: Option<String>, confidence }` — delegates to ActivityMonitor, LLM-OPTIONAL (degrades to state=Unknown/summary=None without OPENROUTER_API_KEY, serves content-hash-cached verdicts).

## Wiring: ManagedTmuxDriver gains send_keys_literal + send_interrupt (DEFAULT impls so existing impls + the in-flight #1458 branch rebase trivially); TmuxDriver/RealTmuxDriver real impls; SessionManager::inject/observe; DaemonSessionControl (real) + mock_control + sm_stdio test mocks. Back-compat: send/send_input untouched (still literal+Enter).

## Scope: in-process Rust trait only — no new MCP/HTTP endpoints this pass (deferred), per decision.

## Tests: 9 (inject dispatch Enter/NoSubmit/Interrupt; observe raw pane w/o LLM + runtime_active; summarize degrades-to-Unknown / fake-verdict / cached; send back-compat) + 2 inline verdict-mapper; full suite green; clippy/fmt/line-cap clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)