### PR TITLE
feat(trusty-review): praise findings optional, not mandatory — reviews lead with actionable feedback

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.15] — 2026-06-18
+
+### Changed
+
+- **Reviewer prompt: praise findings are now optional and rare** (no longer
+  mandatory per review); reviews lead with actionable findings. The
+  principles addendum no longer requires at least one `praise:` per review —
+  praise is reserved for genuinely notable engineering and is never used to
+  soften criticism or pad a review.
+
 ## [0.3.10] — 2026-06-16
 
 ### Changed (closes part of #1318)

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.14"
+version     = "0.3.15"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/src/voice/principles.rs
+++ b/crates/trusty-review/src/voice/principles.rs
@@ -45,8 +45,12 @@ comment without asking.
 Comment on the code, not the author. Explain *why* every finding matters; a
 conclusion without reasoning reads as personal opinion. Propose the concrete
 fix when you can. When uncertain, ask a question rather than issuing a mandate.
-Leave at least one `praise:` per review — genuine recognition accelerates
-learning and sustains a healthy review culture. Avoid the words "simply,"
+Do not open with or pad reviews with praise, affirmation, or restated
+approval — lead with what needs action and keep every comment proportionate
+to its substance. A `praise:` comment is optional and reserved for genuinely
+notable engineering (a non-obvious correct decision, a real risk averted); it
+is never a per-review formality and never used to soften criticism. When
+nothing rises to that bar, omit praise entirely. Avoid the words "simply,"
 "just," "obviously"; do not use sarcasm or hyperbole. Request that unclear code
 be rewritten in the source — explanations in review comments do not help future
 readers.


### PR DESCRIPTION
Reduces sycophantic language in trusty-review's LLM output. The reviewer prompt previously mandated "Leave at least one `praise:` per review", which guaranteed an affirming finding (e.g. "...is exactly right", "Solid fix") on every review regardless of substance.

## Change
`voice/principles.rs` (`PRINCIPLES_ADDENDUM`): the mandatory-praise sentence is replaced with guidance that praise is OPTIONAL and rare — reviews lead with what needs action, comments stay proportionate to substance, and `praise:` is reserved for genuinely notable engineering (never a per-review formality, never used to soften criticism). The Conventional Comments label set is unchanged (`praise:` remains an available label).

`pipeline/prompt_templates.rs`: confirmed neither stock template mandates praise — no change needed. The "default verdict APPROVE / grade A-" calibration line is intentionally left untouched (verdict calibration, not praise).

Version bump 0.3.14 → 0.3.15 + CHANGELOG entry.

## Note
This runs counter to open ticket #1417 ("praise-first verdict framing"), which likely needs re-scoping given this directive — flagged separately.

## Verification
- `cargo test -p trusty-review`: 871 + 19 pass, 0 failed; voice tests (principles_addendum_is_non_empty, principles_contains_key_concepts) pass.
- clippy -D warnings, fmt --check, line-cap: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)