### PR TITLE
feat(trusty-review): hold automated-reviewer praise to a higher bar — only when clearly justified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11025,7 +11025,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.14"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.16] — 2026-06-18
+
+### Changed
+
+- Reviewer prompt: praise from an automated reviewer is held to a higher bar
+  than human praise — included only when clearly justified.
+
 ## [0.3.15] — 2026-06-18
 
 ### Changed

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.15"
+version     = "0.3.16"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/src/voice/principles.rs
+++ b/crates/trusty-review/src/voice/principles.rs
@@ -47,10 +47,12 @@ conclusion without reasoning reads as personal opinion. Propose the concrete
 fix when you can. When uncertain, ask a question rather than issuing a mandate.
 Do not open with or pad reviews with praise, affirmation, or restated
 approval — lead with what needs action and keep every comment proportionate
-to its substance. A `praise:` comment is optional and reserved for genuinely
-notable engineering (a non-obvious correct decision, a real risk averted); it
-is never a per-review formality and never used to soften criticism. When
-nothing rises to that bar, omit praise entirely. Avoid the words "simply,"
+to its substance. Praise from an automated reviewer is not equivalent to
+praise from a human colleague: it costs the reader attention without carrying
+the social value, so include a `praise:` comment only when clearly justified —
+a non-obvious correct decision or a real risk averted. It is never a per-review
+formality and never used to soften criticism. When nothing clearly rises to
+that bar, omit praise entirely. Avoid the words "simply,"
 "just," "obviously"; do not use sarcasm or hyperbole. Request that unclear code
 be rewritten in the source — explanations in review comments do not help future
 readers.


### PR DESCRIPTION
Follow-up to #1469 (owner directive). Sharpens the praise guidance in the reviewer prompt with the rationale that praise from an automated reviewer is not equivalent to praise from a human colleague — it costs reader attention without the social value — so a `praise:` comment is included only when clearly justified (a non-obvious correct decision or a real risk averted).

## Change
`voice/principles.rs` (`PRINCIPLES_ADDENDUM`): the praise block (already made optional in 0.3.15) now states the AI-vs-human distinction and the "only when clearly justified" bar explicitly. No other principle changed; the Conventional-Comments label set still lists `praise:`.

Version bump 0.3.15 → 0.3.16 + CHANGELOG entry.

Ticket #1417 re-scoped accordingly (praise-first framing dropped; Conventional-Comments severity labels remain in scope).

## Verification
- `cargo test -p trusty-review`: 871 + 19 pass, 0 failed; voice tests pass.
- clippy -D warnings, fmt --check, line-cap: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)