### PR TITLE
feat(trusty-review): output fidelity — inline comments, suggestion blocks, consequence/uncertainty, nit cap (0.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11025,7 +11025,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.3.16"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.10.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.3.14" }
+trusty-review = { path = "crates/trusty-review", version = "0.4.0" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -31,12 +31,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   section (linter-enforced style, speculative/hypothetical concerns, restating
   the diff, and consequence-free preferences).
 
+### Fixed
+
+- **Summary body no longer silently drops same-line findings (#1414).** The
+  review summary previously decided which findings to render by matching each
+  finding's `(file, line)` against the posted inline comments. Two distinct
+  findings at the same `(file, line)` collided: one could be flagged as "inline"
+  and then dropped from *both* the inline set and the summary body. The summary
+  now partitions by finding identity using the authoritative inline index set
+  carried on `ReviewResult.inline_finding_indices` (populated from the
+  `InlinePlan`), so every non-inline finding is rendered and none is lost.
+- **`github_issues` context query clamped to GitHub's 256-char limit.** An
+  over-long assembled search query (`repo:… is:issue <keywords>`) caused the
+  GitHub Search API to return HTTP 422 ("The search is longer than 256
+  characters"), silently skipping the GitHub Issues context section. The query
+  is now truncated to ≤256 chars at a word boundary (debug-logged when it
+  occurs).
+- **Corrected stale CLI help text.** `run`/`serve` help no longer claims reviews
+  are "always dry-run, no comments posted" — they post live when posting is
+  enabled (dry-run by default, controlled by `PR_INTELLIGENCE_DRY_RUN`).
+
 ### Compatibility
 
 - New finding fields (`consequence`, `suggested_replacement`) and the
-  `inline_comments` / `suppressed_nits` result fields are all `#[serde(default)]`
-  and remain OpenAI strict-mode compliant, so older/looser model responses and
-  pre-0.4.0 review logs still parse unchanged.
+  `inline_comments` / `inline_finding_indices` / `suppressed_nits` result fields
+  are all `#[serde(default)]` and remain OpenAI strict-mode compliant, so
+  older/looser model responses and pre-0.4.0 review logs still parse unchanged.
 
 ## [0.3.16] — 2026-06-18
 

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.4.0] — 2026-06-18
+
+### Added — output fidelity (epic #1413)
+
+- **Inline per-line PR comments (#1414).** Findings now post as inline review
+  comments anchored to the exact file + diff line via the GitHub reviews API
+  `comments[]` array, instead of being concatenated into one summary comment. A
+  finding whose line is not in the PR diff (or has no line) falls back to the
+  review summary body rather than failing the post. The would-be inline comments
+  are carried on `ReviewResult.inline_comments` so dry-run / the MCP response
+  previews exactly what live mode would post.
+- **Committable `suggestion` blocks (#1415).** Findings that carry a concrete code
+  fix render a one-click-appliable GitHub ```suggestion block (new
+  `Finding.suggested_replacement` field). Malformed or multi-line/prose
+  replacements degrade to a prose fix, never a broken block.
+- **Consequence + uncertainty signaling (#1416).** Findings carry a new
+  `consequence` field ("what goes wrong if unaddressed"), rendered as a
+  `_Why it matters:_` line. Low-confidence findings (`confidence < 0.6`) are
+  hedged ("This may be an issue: …") rather than asserted.
+- **Nit-volume cap + what-not-to-flag guardrails (#1420).** At most 5 low-severity
+  nits post inline; the overflow rolls up into a single "+N more minor nits
+  suppressed" summary line. The reviewer prompt gains a concise "do NOT flag"
+  section (linter-enforced style, speculative/hypothetical concerns, restating
+  the diff, and consequence-free preferences).
+
+### Compatibility
+
+- New finding fields (`consequence`, `suggested_replacement`) and the
+  `inline_comments` / `suppressed_nits` result fields are all `#[serde(default)]`
+  and remain OpenAI strict-mode compliant, so older/looser model responses and
+  pre-0.4.0 review logs still parse unchanged.
+
 ## [0.3.16] — 2026-06-18
 
 ### Changed

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.3.16"
+version     = "0.4.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/src/integrations/context/github_issues.rs
+++ b/crates/trusty-review/src/integrations/context/github_issues.rs
@@ -80,10 +80,18 @@ fn cap_query(q: &str) -> &str {
         .unwrap_or(q.len());
     let candidate = &q[..hard_cut_byte];
     // Prefer to break at the last whitespace so we don't split mid-token.
-    match candidate.rfind(|c: char| c.is_whitespace()) {
+    let capped = match candidate.rfind(|c: char| c.is_whitespace()) {
         Some(ws_byte) if ws_byte > 0 => &q[..ws_byte],
         _ => candidate, // fallback: hard char-boundary cut
-    }
+    };
+    tracing::debug!(
+        source = SOURCE_NAME,
+        original_chars = q.chars().count(),
+        capped_chars = capped.chars().count(),
+        limit = GITHUB_QUERY_MAX_CHARS,
+        "truncated GitHub issue-search query to stay within the Search API limit"
+    );
+    capped
 }
 
 // ─── Auth seam (reuses #582 dual-mode auth) ─────────────────────────────────

--- a/crates/trusty-review/src/integrations/github/inline.rs
+++ b/crates/trusty-review/src/integrations/github/inline.rs
@@ -220,7 +220,11 @@ pub struct InlineComment {
 /// and lets dry-run render the same structure the live path would post.
 /// What: `comments` are the inline comments to attach to the review;
 /// `summary_findings` are findings that could not be anchored inline (off-diff or
-/// no line) and must be rendered into the review summary body; `suppressed_nits`
+/// no line) and must be rendered into the review summary body; `inline_indices`
+/// records the index (into the original `findings` slice) of every finding that
+/// became an inline comment, so downstream code can partition by finding identity
+/// rather than by `(file, line)` coordinate (two distinct findings can share the
+/// same anchor — coordinate matching silently drops one); `suppressed_nits`
 /// is the count of low-severity findings rolled up past the inline cap (#1420).
 /// Test: `build_inline_plan_*` tests in `inline_tests.rs`.
 #[derive(Debug, Clone, Default)]
@@ -229,6 +233,14 @@ pub struct InlinePlan {
     pub comments: Vec<InlineComment>,
     /// Findings that fall back to the summary body (no anchorable line).
     pub summary_findings: Vec<Finding>,
+    /// Indices (into the input `findings` slice) of findings placed inline.
+    ///
+    /// Why: the summary body must render exactly the findings that did NOT land
+    /// inline.  Identifying those by `(file, line)` coordinate is lossy — two
+    /// distinct findings at the same anchor collide and one is silently dropped
+    /// from both the inline set and the summary.  Carrying the authoritative
+    /// inline index set makes the partition by identity, never by coordinate.
+    pub inline_indices: Vec<usize>,
     /// Count of low-severity nits suppressed past the inline cap (#1420).
     pub suppressed_nits: usize,
 }
@@ -277,7 +289,7 @@ pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -
     let mut plan = InlinePlan::default();
     let mut inline_nits = 0usize;
 
-    for finding in findings {
+    for (idx, finding) in findings.iter().enumerate() {
         let anchor = finding
             .line
             .filter(|l| commentable.contains(&finding.file, *l));
@@ -302,6 +314,9 @@ pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -
             line,
             body: render_finding_comment(finding),
         });
+        // Record identity (not coordinate) of the inline-placed finding so the
+        // summary body can exclude exactly these — never a same-anchor sibling.
+        plan.inline_indices.push(idx);
     }
 
     plan

--- a/crates/trusty-review/src/integrations/github/inline.rs
+++ b/crates/trusty-review/src/integrations/github/inline.rs
@@ -27,7 +27,7 @@
 
 use std::collections::HashSet;
 
-use crate::models::Finding;
+use crate::models::{Effort, Finding};
 
 // ─── Tuning constants ─────────────────────────────────────────────────────────
 
@@ -40,6 +40,19 @@ use crate::models::Finding;
 /// What: findings with `confidence < UNCERTAINTY_THRESHOLD` get a hedging prefix.
 /// Test: `low_confidence_finding_is_hedged`, `high_confidence_finding_is_asserted`.
 pub const UNCERTAINTY_THRESHOLD: f32 = 0.6;
+
+/// Maximum low-severity (nit) findings posted inline before the rest roll up (#1420).
+///
+/// Why: a review flooded with low-severity nits trains authors to ignore the feed
+/// and buries the real issues (the principles layer's "keep signal-to-noise high"
+/// rule).  Capping inline nits at a small N and rolling the overflow into one
+/// summary line keeps the inline feed high-signal.
+/// What: at most `MAX_INLINE_NITS` `Effort::Low` findings are emitted inline; the
+/// remainder increment [`InlinePlan::suppressed_nits`].  Higher-severity findings
+/// are never subject to the cap.
+/// Test: `nit_cap_rolls_up_overflow`, `nit_cap_keeps_first_n_inline`,
+/// `nit_cap_does_not_suppress_high_severity`.
+pub const MAX_INLINE_NITS: usize = 5;
 
 // ─── Commentable-line index ───────────────────────────────────────────────────
 
@@ -207,7 +220,8 @@ pub struct InlineComment {
 /// and lets dry-run render the same structure the live path would post.
 /// What: `comments` are the inline comments to attach to the review;
 /// `summary_findings` are findings that could not be anchored inline (off-diff or
-/// no line) and must be rendered into the review summary body.
+/// no line) and must be rendered into the review summary body; `suppressed_nits`
+/// is the count of low-severity findings rolled up past the inline cap (#1420).
 /// Test: `build_inline_plan_*` tests in `inline_tests.rs`.
 #[derive(Debug, Clone, Default)]
 pub struct InlinePlan {
@@ -215,37 +229,79 @@ pub struct InlinePlan {
     pub comments: Vec<InlineComment>,
     /// Findings that fall back to the summary body (no anchorable line).
     pub summary_findings: Vec<Finding>,
+    /// Count of low-severity nits suppressed past the inline cap (#1420).
+    pub suppressed_nits: usize,
+}
+
+impl InlinePlan {
+    /// One-line rollup sentence for suppressed nits, or `None` when none (#1420).
+    ///
+    /// Why: overflow nits must be acknowledged in the summary so the author knows
+    /// feedback was withheld for signal — silently dropping them is worse than one
+    /// honest line.
+    /// What: returns e.g. `"+7 more minor nits suppressed to keep this review focused."`
+    /// when `suppressed_nits > 0`, else `None`.
+    /// Test: `nit_cap_rolls_up_overflow`.
+    pub fn suppressed_nits_line(&self) -> Option<String> {
+        if self.suppressed_nits == 0 {
+            None
+        } else {
+            Some(format!(
+                "+{} more minor nit{} suppressed to keep this review focused.",
+                self.suppressed_nits,
+                if self.suppressed_nits == 1 { "" } else { "s" }
+            ))
+        }
+    }
 }
 
 // ─── Mapping: findings → inline plan ──────────────────────────────────────────
 
 /// Map a review's findings to an [`InlinePlan`] against the diff's commentable lines.
 ///
-/// Why: this is the heart of #1414 — it decides, per finding, whether it can land
-/// inline (its `(file, line)` is in the diff) or must fall back to the summary
-/// body, so an off-diff finding never fails the whole post.
+/// Why: this is the heart of #1414 + #1420 — it decides, per finding, whether it
+/// can land inline (its `(file, line)` is in the diff) or must fall back to the
+/// summary body, and it enforces the nit-volume cap so low-severity findings cannot
+/// flood the inline feed.
 /// What: iterates findings; a finding with a `line` that is a commentable anchor
 /// becomes an [`InlineComment`] (body via [`render_finding_comment`]); a finding
-/// with no line, or an off-diff line, goes to `summary_findings`.  Ordering of
-/// inputs is preserved.
+/// with no line, or an off-diff line, goes to `summary_findings`.  Among the
+/// anchorable findings, `Effort::Low` (nit) findings beyond [`MAX_INLINE_NITS`]
+/// inline placements are not emitted inline — they increment `suppressed_nits`
+/// instead.  Higher-severity findings are never suppressed.  Input order is
+/// preserved.
 /// Test: `build_inline_plan_maps_on_diff_finding`,
-/// `build_inline_plan_off_diff_falls_back`, `build_inline_plan_no_line_falls_back`.
+/// `build_inline_plan_off_diff_falls_back`, `build_inline_plan_no_line_falls_back`,
+/// `nit_cap_rolls_up_overflow`, `nit_cap_does_not_suppress_high_severity`.
 pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -> InlinePlan {
     let mut plan = InlinePlan::default();
+    let mut inline_nits = 0usize;
 
     for finding in findings {
         let anchor = finding
             .line
             .filter(|l| commentable.contains(&finding.file, *l));
 
-        match anchor {
-            Some(line) => plan.comments.push(InlineComment {
-                path: finding.file.clone(),
-                line,
-                body: render_finding_comment(finding),
-            }),
-            None => plan.summary_findings.push(finding.clone()),
+        let Some(line) = anchor else {
+            // No usable diff anchor → summary body (never fails the post).
+            plan.summary_findings.push(finding.clone());
+            continue;
+        };
+
+        // Nit-volume cap (#1420): only Effort::Low findings are subject to it.
+        if finding.effort == Effort::Low {
+            if inline_nits >= MAX_INLINE_NITS {
+                plan.suppressed_nits += 1;
+                continue;
+            }
+            inline_nits += 1;
         }
+
+        plan.comments.push(InlineComment {
+            path: finding.file.clone(),
+            line,
+            body: render_finding_comment(finding),
+        });
     }
 
     plan

--- a/crates/trusty-review/src/integrations/github/inline.rs
+++ b/crates/trusty-review/src/integrations/github/inline.rs
@@ -1,0 +1,270 @@
+//! Inline per-line PR review comments (#1414).
+//!
+//! Why: posting all findings concatenated into one PR-level summary comment
+//! buries actionable feedback — the author has to map each finding back to the
+//! line it is about by hand.  GitHub's "pull request review" API accepts a
+//! `comments[]` array where each entry is anchored to a `path` + `line` in the
+//! diff, so the reviewer's findings can land *exactly* on the offending line as
+//! a normal inline review comment.  This module turns a review's `Finding`s into
+//! that `comments[]` payload, with a robust fallback: a finding whose line is not
+//! part of the PR diff (GitHub rejects off-diff anchors) is rolled into the
+//! summary body instead of failing the whole review.
+//!
+//! What:
+//!   * [`CommentableLines`] indexes which `(file, line)` pairs are valid inline
+//!     anchors by parsing the unified diff's `@@` hunks (added + context lines on
+//!     the new/right side, which is what the GitHub `line`/`side: RIGHT` anchor
+//!     addresses).
+//!   * [`InlineComment`] is one would-be inline review comment (path/line/body).
+//!   * [`InlinePlan`] is the full structured decision for a review: the inline
+//!     comments to post plus the findings that fell back to the summary — surfaced
+//!     verbatim in dry-run so the MCP response shows exactly what *would* be posted.
+//!   * [`build_inline_plan`] is the pure mapping from findings → plan.
+//!   * [`render_finding_comment`] renders one finding's inline-comment markdown.
+//!
+//! Test: `inline_tests.rs` (sibling) — covers diff-index construction, the
+//! finding→comment mapping, and off-diff fallback.
+
+use std::collections::HashSet;
+
+use crate::models::Finding;
+
+// ─── Commentable-line index ───────────────────────────────────────────────────
+
+/// Index of `(file, new-side line)` pairs that are valid inline-comment anchors.
+///
+/// Why: GitHub rejects a review comment whose `line` is not part of the PR diff;
+/// posting such a comment fails the whole `POST /pulls/{n}/reviews` call.  We must
+/// therefore know, *before* building the payload, which lines are anchorable so
+/// off-diff findings can be diverted to the summary body instead of breaking the
+/// post.  The valid anchors are the added (`+`) and context (` `) lines on the new
+/// side of each hunk — these are the lines GitHub's `side: RIGHT` anchor addresses.
+/// What: a set of `(path, line)` pairs parsed from the unified diff's `@@` headers.
+/// Test: `commentable_lines_indexes_added_and_context`,
+/// `commentable_lines_excludes_removed_lines`.
+#[derive(Debug, Default, Clone)]
+pub struct CommentableLines {
+    anchors: HashSet<(String, u32)>,
+}
+
+impl CommentableLines {
+    /// Parse a unified diff into the set of commentable new-side line anchors.
+    ///
+    /// Why: this is the single source of truth for "can a comment land on this
+    /// line?"; centralising the unified-diff hunk walk keeps the fallback logic in
+    /// [`build_inline_plan`] trivial (a set membership test).
+    /// What: walks the diff line by line, tracking the current file (from `+++ b/`
+    /// headers) and the new-side line counter (seeded from each `@@ -a,b +c,d @@`
+    /// header's `+c`).  Added (`+`) and context (` `) lines advance the new-side
+    /// counter and are recorded as anchors; removed (`-`) lines do not (they have
+    /// no new-side line number).  Malformed `@@` headers are skipped defensively.
+    /// Test: `commentable_lines_indexes_added_and_context`,
+    /// `commentable_lines_excludes_removed_lines`,
+    /// `commentable_lines_handles_multiple_hunks`.
+    pub fn from_unified_diff(diff: &str) -> Self {
+        let mut anchors: HashSet<(String, u32)> = HashSet::new();
+        let mut current_file: Option<String> = None;
+        let mut new_line: u32 = 0;
+        let mut in_hunk = false;
+
+        for line in diff.lines() {
+            if let Some(path) = line.strip_prefix("+++ b/") {
+                current_file = Some(path.trim().to_string());
+                in_hunk = false;
+                continue;
+            }
+            if line.starts_with("+++ ") {
+                // e.g. `+++ /dev/null` — not a usable new-side path.
+                current_file = None;
+                in_hunk = false;
+                continue;
+            }
+            if line.starts_with("--- ") {
+                in_hunk = false;
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("@@") {
+                match parse_hunk_new_start(rest) {
+                    Some(start) => {
+                        new_line = start;
+                        in_hunk = true;
+                    }
+                    None => in_hunk = false,
+                }
+                continue;
+            }
+            if !in_hunk {
+                continue;
+            }
+            // Diff-file metadata lines that can appear between hunks.
+            if line.starts_with("diff ")
+                || line.starts_with("index ")
+                || line.starts_with("\\ No newline")
+            {
+                continue;
+            }
+            let Some(file) = current_file.as_ref() else {
+                continue;
+            };
+            match line.chars().next() {
+                Some('+') => {
+                    anchors.insert((file.clone(), new_line));
+                    new_line += 1;
+                }
+                Some('-') => {
+                    // Removed line: no new-side number, do not advance.
+                }
+                _ => {
+                    // Context line (leading space or empty): anchorable, advances.
+                    anchors.insert((file.clone(), new_line));
+                    new_line += 1;
+                }
+            }
+        }
+
+        Self { anchors }
+    }
+
+    /// Return whether `(file, line)` is a valid inline-comment anchor.
+    ///
+    /// Why: [`build_inline_plan`] uses this to decide inline vs. summary fallback.
+    /// What: set-membership test against the parsed anchors.
+    /// Test: `commentable_lines_indexes_added_and_context`.
+    pub fn contains(&self, file: &str, line: u32) -> bool {
+        self.anchors.contains(&(file.to_string(), line))
+    }
+
+    /// Number of indexed anchors (used in tests / telemetry).
+    ///
+    /// Why: lets tests assert the index size without exposing the inner set.
+    /// What: returns the anchor count.
+    /// Test: `commentable_lines_indexes_added_and_context`.
+    pub fn len(&self) -> usize {
+        self.anchors.len()
+    }
+
+    /// Whether the index is empty (no commentable lines parsed).
+    ///
+    /// Why: clippy requires `is_empty` alongside `len`; also a quick "no diff
+    /// positions available" check for callers.
+    /// What: returns `true` when no anchors were parsed.
+    /// Test: covered transitively by `commentable_lines_indexes_added_and_context`.
+    pub fn is_empty(&self) -> bool {
+        self.anchors.is_empty()
+    }
+}
+
+/// Parse the new-side start line from the remainder of an `@@` hunk header.
+///
+/// Why: the new-side line counter must be seeded from `+c` in `@@ -a,b +c,d @@`
+/// so anchors map to the right (post-change) line numbers GitHub expects.
+/// What: finds the `+` token, parses the integer before an optional `,count`.
+/// Returns `None` for a malformed header (caller then skips the hunk).
+/// Test: `parse_hunk_new_start_basic`, `parse_hunk_new_start_without_count`.
+fn parse_hunk_new_start(rest: &str) -> Option<u32> {
+    let plus = rest.find('+')?;
+    let after = &rest[plus + 1..];
+    let token: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    token.parse::<u32>().ok()
+}
+
+// ─── Inline comment + plan types ──────────────────────────────────────────────
+
+/// One would-be inline review comment anchored to a diff line.
+///
+/// Why: the GitHub review payload needs `{ path, line, body }` per inline comment;
+/// modelling it explicitly lets the dry-run path surface the exact set that would
+/// be posted (so the MCP response is faithful) and keeps the live POST a trivial
+/// serialisation.
+/// What: `path` + `line` are the new-side anchor; `body` is the rendered markdown.
+/// Test: `build_inline_plan_maps_on_diff_finding`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineComment {
+    /// Changed file path (new side), e.g. `src/db.rs`.
+    pub path: String,
+    /// New-side line number the comment anchors to.
+    pub line: u32,
+    /// Rendered comment markdown body.
+    pub body: String,
+}
+
+/// The full inline-posting decision for one review.
+///
+/// Why: separating the *decision* (which comments go inline, which fall back) from
+/// the *side effect* (the POST) makes the mapping unit-testable with no network,
+/// and lets dry-run render the same structure the live path would post.
+/// What: `comments` are the inline comments to attach to the review;
+/// `summary_findings` are findings that could not be anchored inline (off-diff or
+/// no line) and must be rendered into the review summary body.
+/// Test: `build_inline_plan_*` tests in `inline_tests.rs`.
+#[derive(Debug, Clone, Default)]
+pub struct InlinePlan {
+    /// Inline comments to post (each anchored to a diff line).
+    pub comments: Vec<InlineComment>,
+    /// Findings that fall back to the summary body (no anchorable line).
+    pub summary_findings: Vec<Finding>,
+}
+
+// ─── Mapping: findings → inline plan ──────────────────────────────────────────
+
+/// Map a review's findings to an [`InlinePlan`] against the diff's commentable lines.
+///
+/// Why: this is the heart of #1414 — it decides, per finding, whether it can land
+/// inline (its `(file, line)` is in the diff) or must fall back to the summary
+/// body, so an off-diff finding never fails the whole post.
+/// What: iterates findings; a finding with a `line` that is a commentable anchor
+/// becomes an [`InlineComment`] (body via [`render_finding_comment`]); a finding
+/// with no line, or an off-diff line, goes to `summary_findings`.  Ordering of
+/// inputs is preserved.
+/// Test: `build_inline_plan_maps_on_diff_finding`,
+/// `build_inline_plan_off_diff_falls_back`, `build_inline_plan_no_line_falls_back`.
+pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -> InlinePlan {
+    let mut plan = InlinePlan::default();
+
+    for finding in findings {
+        let anchor = finding
+            .line
+            .filter(|l| commentable.contains(&finding.file, *l));
+
+        match anchor {
+            Some(line) => plan.comments.push(InlineComment {
+                path: finding.file.clone(),
+                line,
+                body: render_finding_comment(finding),
+            }),
+            None => plan.summary_findings.push(finding.clone()),
+        }
+    }
+
+    plan
+}
+
+// ─── Per-finding comment rendering ────────────────────────────────────────────
+
+/// Render one finding as inline-comment markdown.
+///
+/// Why: an inline comment must read as a single, self-contained, actionable note:
+/// a clear lead line and the proposed fix.  Centralising the rendering keeps the
+/// inline and (future) summary renderings consistent.
+/// What: builds `**<kind>** — <description>` followed by a `_Fix:_ <suggestion>`
+/// line when the finding carries a suggestion.
+/// Test: `render_finding_comment_includes_kind_and_fix`.
+pub fn render_finding_comment(finding: &Finding) -> String {
+    let mut out = String::with_capacity(256);
+    out.push_str(&format!(
+        "**{}** — {}\n",
+        finding.kind,
+        finding.description.trim()
+    ));
+    let suggestion = finding.suggestion.trim();
+    if !suggestion.is_empty() {
+        out.push_str(&format!("\n_Fix:_ {suggestion}\n"));
+    }
+    out
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "inline_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/integrations/github/inline.rs
+++ b/crates/trusty-review/src/integrations/github/inline.rs
@@ -244,11 +244,16 @@ pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -
 /// Render one finding as inline-comment markdown.
 ///
 /// Why: an inline comment must read as a single, self-contained, actionable note:
-/// a clear lead line and the proposed fix.  Centralising the rendering keeps the
-/// inline and (future) summary renderings consistent.
-/// What: builds `**<kind>** — <description>` followed by a `_Fix:_ <suggestion>`
-/// line when the finding carries a suggestion.
-/// Test: `render_finding_comment_includes_kind_and_fix`.
+/// a clear lead line, the fix as a *committable* GitHub ```suggestion block when
+/// the finding carries concrete replacement code (#1415) or as prose otherwise.
+/// Centralising the rendering keeps the inline and (future) summary renderings
+/// consistent.
+/// What: builds `**<kind>** — <description>`, then appends either a fenced
+/// ```suggestion block (when [`suggestion_replacement`] accepts the finding's
+/// `suggested_replacement`) or a `_Fix:_ <prose>` line.  A malformed or non-code
+/// replacement degrades to prose, never a broken suggestion block.
+/// Test: `render_finding_comment_includes_kind_and_fix`,
+/// `render_emits_suggestion_block`, `render_falls_back_to_prose_fix`.
 pub fn render_finding_comment(finding: &Finding) -> String {
     let mut out = String::with_capacity(256);
     out.push_str(&format!(
@@ -256,11 +261,61 @@ pub fn render_finding_comment(finding: &Finding) -> String {
         finding.kind,
         finding.description.trim()
     ));
-    let suggestion = finding.suggestion.trim();
-    if !suggestion.is_empty() {
-        out.push_str(&format!("\n_Fix:_ {suggestion}\n"));
+
+    // Fix: committable suggestion block when concrete (#1415), else prose.
+    if let Some(replacement) = suggestion_replacement(finding) {
+        out.push_str("\n```suggestion\n");
+        out.push_str(&replacement);
+        out.push_str("\n```\n");
+    } else {
+        let suggestion = finding.suggestion.trim();
+        if !suggestion.is_empty() {
+            out.push_str(&format!("\n_Fix:_ {suggestion}\n"));
+        }
     }
     out
+}
+
+/// Extract a committable replacement block from a finding's `suggested_replacement`.
+///
+/// Why: a GitHub ```suggestion block must contain the *exact* replacement lines —
+/// not prose, not a multi-hunk patch.  Emitting prose inside a suggestion fence
+/// produces a broken one-click-apply that corrupts the file, so we only emit the
+/// block when the structured field looks like a safe, fence-free replacement and
+/// otherwise degrade to a prose `_Fix:_` line.
+/// What: returns `Some(lines)` when the finding's `suggested_replacement` is
+/// present and [`suggestion_is_committable`] accepts it, else `None`.  The returned
+/// string is the verbatim replacement text (leading/trailing blank lines trimmed).
+/// Test: `render_emits_suggestion_block`, `render_falls_back_to_prose_fix`,
+/// `suggestion_with_fence_is_rejected`.
+fn suggestion_replacement(finding: &Finding) -> Option<String> {
+    let raw = finding.suggested_replacement.as_deref()?;
+    let s = raw.trim_matches('\n');
+    if suggestion_is_committable(s) {
+        Some(s.to_string())
+    } else {
+        None
+    }
+}
+
+/// Decide whether a replacement string is a safe committable suggestion block.
+///
+/// Why: malformed replacements must degrade to prose, never break posting — a
+/// triple-backtick fence inside the replacement would close the ```suggestion
+/// block early, and an empty replacement is not committable code.
+/// What: rejects empty strings and any string containing a ``` fence; accepts
+/// everything else as a literal replacement block.
+/// Test: `suggestion_with_fence_is_rejected`, `code_suggestion_is_committable`.
+pub fn suggestion_is_committable(suggestion: &str) -> bool {
+    let s = suggestion.trim();
+    if s.is_empty() {
+        return false;
+    }
+    // A ``` fence inside the replacement would prematurely close the block.
+    if s.contains("```") {
+        return false;
+    }
+    true
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/integrations/github/inline.rs
+++ b/crates/trusty-review/src/integrations/github/inline.rs
@@ -29,6 +29,18 @@ use std::collections::HashSet;
 
 use crate::models::Finding;
 
+// ─── Tuning constants ─────────────────────────────────────────────────────────
+
+/// Confidence below which a finding is hedged rather than asserted (#1416).
+///
+/// Why: an automated reviewer that asserts a low-confidence guess as fact erodes
+/// author trust; hedging ("This may…") signals the uncertainty honestly without
+/// dropping the finding.  0.6 is the midpoint between "plausible" and "likely" on
+/// the LLM's own 0.0–1.0 confidence scale.
+/// What: findings with `confidence < UNCERTAINTY_THRESHOLD` get a hedging prefix.
+/// Test: `low_confidence_finding_is_hedged`, `high_confidence_finding_is_asserted`.
+pub const UNCERTAINTY_THRESHOLD: f32 = 0.6;
+
 // ─── Commentable-line index ───────────────────────────────────────────────────
 
 /// Index of `(file, new-side line)` pairs that are valid inline-comment anchors.
@@ -244,23 +256,37 @@ pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -
 /// Render one finding as inline-comment markdown.
 ///
 /// Why: an inline comment must read as a single, self-contained, actionable note:
-/// a clear lead line, the fix as a *committable* GitHub ```suggestion block when
-/// the finding carries concrete replacement code (#1415) or as prose otherwise.
+/// a clear lead line, *why it matters* (the consequence, #1416), and the fix as a
+/// *committable* GitHub ```suggestion block when the finding carries concrete
+/// replacement code (#1415) or as prose otherwise.  Low-confidence findings are
+/// hedged rather than asserted (#1416) so the reviewer never overstates a guess.
 /// Centralising the rendering keeps the inline and (future) summary renderings
 /// consistent.
-/// What: builds `**<kind>** — <description>`, then appends either a fenced
+/// What: builds `**<kind>** — <description>` (hedged with "This may…" when
+/// `confidence < UNCERTAINTY_THRESHOLD`), appends a `_Why it matters:_ <consequence>`
+/// line when the finding carries a consequence, then appends either a fenced
 /// ```suggestion block (when [`suggestion_replacement`] accepts the finding's
 /// `suggested_replacement`) or a `_Fix:_ <prose>` line.  A malformed or non-code
 /// replacement degrades to prose, never a broken suggestion block.
 /// Test: `render_finding_comment_includes_kind_and_fix`,
-/// `render_emits_suggestion_block`, `render_falls_back_to_prose_fix`.
+/// `render_emits_suggestion_block`, `render_falls_back_to_prose_fix`,
+/// `render_includes_consequence`, `low_confidence_finding_is_hedged`.
 pub fn render_finding_comment(finding: &Finding) -> String {
     let mut out = String::with_capacity(256);
-    out.push_str(&format!(
-        "**{}** — {}\n",
-        finding.kind,
-        finding.description.trim()
-    ));
+
+    // Lead line: kind + description, hedged for low confidence (#1416).
+    let hedged = if finding.confidence < UNCERTAINTY_THRESHOLD {
+        hedge_description(&finding.description)
+    } else {
+        finding.description.trim().to_string()
+    };
+    out.push_str(&format!("**{}** — {}\n", finding.kind, hedged));
+
+    // Consequence: what goes wrong if unaddressed (#1416).
+    let consequence = finding.consequence.trim();
+    if !consequence.is_empty() {
+        out.push_str(&format!("\n_Why it matters:_ {consequence}\n"));
+    }
 
     // Fix: committable suggestion block when concrete (#1415), else prose.
     if let Some(replacement) = suggestion_replacement(finding) {
@@ -274,6 +300,32 @@ pub fn render_finding_comment(finding: &Finding) -> String {
         }
     }
     out
+}
+
+/// Prefix a description with a hedging phrase when not already hedged (#1416).
+///
+/// Why: low-confidence findings should *read* as tentative; mechanically prefixing
+/// a hedge is more reliable than asking the LLM to self-hedge.
+/// What: if the description already opens with a hedging word (may/might/possibly/
+/// could/perhaps), returns it trimmed unchanged; otherwise lowercases the first
+/// letter and prepends "This may be an issue: ".  Empty descriptions pass through.
+/// Test: `low_confidence_finding_is_hedged`, `already_hedged_not_double_hedged`.
+fn hedge_description(description: &str) -> String {
+    let trimmed = description.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    const HEDGES: &[&str] = &[
+        "may ", "might ", "possibly", "could ", "perhaps", "this may",
+    ];
+    if HEDGES.iter().any(|h| lower.starts_with(h)) {
+        return trimmed.to_string();
+    }
+    let mut chars = trimmed.chars();
+    let first = chars.next().unwrap_or(' ').to_ascii_lowercase();
+    let rest: String = chars.collect();
+    format!("This may be an issue: {first}{rest}")
 }
 
 /// Extract a committable replacement block from a finding's `suggested_replacement`.

--- a/crates/trusty-review/src/integrations/github/inline_tests.rs
+++ b/crates/trusty-review/src/integrations/github/inline_tests.rs
@@ -1,0 +1,156 @@
+//! Unit tests for inline per-line review comments (#1414).
+//!
+//! Why: the finding→inline-comment mapping and the off-diff fallback are the
+//! load-bearing correctness logic of #1414 — a mistake either posts comments on
+//! lines GitHub rejects (failing the whole review) or drops findings silently.
+//! What: exercises diff-index construction, on-diff mapping, off-diff fallback,
+//! and the no-line fallback against representative unified diffs.
+//! Test: this module.
+
+use super::*;
+use crate::models::{Effort, Finding};
+
+/// A small two-file unified diff with added, context, and removed lines.
+fn sample_diff() -> &'static str {
+    "\
+diff --git a/src/db.rs b/src/db.rs
+index 1111111..2222222 100644
+--- a/src/db.rs
++++ b/src/db.rs
+@@ -10,3 +10,4 @@ fn query() {
+ let conn = pool.get();
+-let sql = format!(\"SELECT {}\", input);
++let sql = \"SELECT ?\";
++bind(input);
+ run(sql);
+diff --git a/src/util.rs b/src/util.rs
+index 3333333..4444444 100644
+--- a/src/util.rs
++++ b/src/util.rs
+@@ -1,2 +1,3 @@
+ fn a() {}
++fn b() {}
+ fn c() {}
+"
+}
+
+fn finding_at(file: &str, line: Option<u32>) -> Finding {
+    let mut f = Finding::new(
+        file,
+        "security",
+        "SQL injection via string interpolation",
+        "Use a parameterised query",
+        0.9,
+        Effort::Medium,
+    );
+    f.line = line;
+    f
+}
+
+#[test]
+fn parse_hunk_new_start_basic() {
+    assert_eq!(parse_hunk_new_start(" -10,3 +10,4 @@ fn query()"), Some(10));
+}
+
+#[test]
+fn parse_hunk_new_start_without_count() {
+    // `@@ -0,0 +1 @@` form (single-line new side, no `,count`).
+    assert_eq!(parse_hunk_new_start(" -0,0 +1 @@"), Some(1));
+}
+
+#[test]
+fn commentable_lines_indexes_added_and_context() {
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    // src/db.rs hunk: new lines 10 (context), 11 (+), 12 (+), 13 (context).
+    assert!(c.contains("src/db.rs", 10), "context line 10 anchorable");
+    assert!(c.contains("src/db.rs", 11), "added line 11 anchorable");
+    assert!(c.contains("src/db.rs", 12), "added line 12 anchorable");
+    assert!(c.contains("src/db.rs", 13), "context line 13 anchorable");
+    // src/util.rs hunk: new lines 1 (context), 2 (+), 3 (context).
+    assert!(c.contains("src/util.rs", 2), "added line 2 anchorable");
+    assert!(!c.is_empty());
+}
+
+#[test]
+fn commentable_lines_excludes_removed_lines() {
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    // The removed `format!` line has no new-side number; line 14 is past the hunk.
+    assert!(
+        !c.contains("src/db.rs", 14),
+        "no anchor beyond the hunk's new-side range"
+    );
+    // A file not in the diff is never anchorable.
+    assert!(!c.contains("src/other.rs", 10));
+}
+
+#[test]
+fn commentable_lines_handles_multiple_hunks() {
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    assert!(c.contains("src/db.rs", 11));
+    assert!(c.contains("src/util.rs", 2));
+    // Both files contributed anchors.
+    assert!(
+        c.len() >= 6,
+        "expected anchors across both files, got {}",
+        c.len()
+    );
+}
+
+#[test]
+fn build_inline_plan_maps_on_diff_finding() {
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    let findings = vec![finding_at("src/db.rs", Some(11))];
+    let plan = build_inline_plan(&findings, &c);
+    assert_eq!(plan.comments.len(), 1, "on-diff finding posts inline");
+    assert!(plan.summary_findings.is_empty());
+    assert_eq!(plan.comments[0].path, "src/db.rs");
+    assert_eq!(plan.comments[0].line, 11);
+    assert!(plan.comments[0].body.contains("security"));
+}
+
+#[test]
+fn build_inline_plan_off_diff_falls_back() {
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    // Line 99 is not in any hunk → must fall back to summary, not break the post.
+    let findings = vec![finding_at("src/db.rs", Some(99))];
+    let plan = build_inline_plan(&findings, &c);
+    assert!(plan.comments.is_empty(), "off-diff finding is not inline");
+    assert_eq!(plan.summary_findings.len(), 1, "off-diff finding → summary");
+}
+
+#[test]
+fn build_inline_plan_no_line_falls_back() {
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    // File-level / general finding (no line) → summary body.
+    let findings = vec![finding_at("src/db.rs", None)];
+    let plan = build_inline_plan(&findings, &c);
+    assert!(plan.comments.is_empty());
+    assert_eq!(plan.summary_findings.len(), 1);
+}
+
+#[test]
+fn build_inline_plan_preserves_order_and_splits() {
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    let findings = vec![
+        finding_at("src/db.rs", Some(11)),  // inline
+        finding_at("src/db.rs", Some(500)), // off-diff → summary
+        finding_at("src/util.rs", Some(2)), // inline
+    ];
+    let plan = build_inline_plan(&findings, &c);
+    assert_eq!(plan.comments.len(), 2);
+    assert_eq!(plan.summary_findings.len(), 1);
+    assert_eq!(plan.comments[0].line, 11);
+    assert_eq!(plan.comments[1].line, 2);
+}
+
+#[test]
+fn render_finding_comment_includes_kind_and_fix() {
+    let f = finding_at("src/db.rs", Some(11));
+    let body = render_finding_comment(&f);
+    assert!(body.contains("**security**"), "kind in bold: {body}");
+    assert!(
+        body.contains("SQL injection"),
+        "description present: {body}"
+    );
+    assert!(body.contains("_Fix:_"), "fix line present: {body}");
+}

--- a/crates/trusty-review/src/integrations/github/inline_tests.rs
+++ b/crates/trusty-review/src/integrations/github/inline_tests.rs
@@ -207,3 +207,78 @@ fn empty_replacement_is_not_committable() {
     assert!(!suggestion_is_committable("   "));
     assert!(suggestion_is_committable("let x = 1;"));
 }
+
+// ── #1416: consequence + uncertainty signalling ──────────────────────────────
+
+#[test]
+fn render_includes_consequence() {
+    let mut f = finding_at("src/db.rs", Some(11));
+    f.consequence = "panics on empty input".to_string();
+    let body = render_finding_comment(&f);
+    assert!(
+        body.contains("_Why it matters:_ panics on empty input"),
+        "consequence line must appear: {body}"
+    );
+}
+
+#[test]
+fn render_omits_consequence_when_empty() {
+    let f = finding_at("src/db.rs", Some(11)); // consequence defaults to ""
+    let body = render_finding_comment(&f);
+    assert!(
+        !body.contains("_Why it matters:_"),
+        "no consequence line when empty: {body}"
+    );
+}
+
+#[test]
+fn low_confidence_finding_is_hedged() {
+    // Confidence below the threshold → the description is hedged ("This may…").
+    let mut f = finding_at("src/db.rs", Some(11));
+    f.confidence = 0.4;
+    let body = render_finding_comment(&f);
+    assert!(
+        body.to_lowercase().contains("this may be an issue"),
+        "low-confidence finding must be hedged: {body}"
+    );
+}
+
+#[test]
+fn high_confidence_finding_is_asserted() {
+    // Confidence at/above the threshold → asserted, not hedged.
+    let mut f = finding_at("src/db.rs", Some(11));
+    f.confidence = 0.9;
+    let body = render_finding_comment(&f);
+    assert!(
+        !body.to_lowercase().contains("this may be an issue"),
+        "high-confidence finding must not be hedged: {body}"
+    );
+    // The bare description still appears.
+    assert!(body.contains("SQL injection"), "{body}");
+}
+
+#[test]
+fn already_hedged_not_double_hedged() {
+    // A low-confidence finding whose description already hedges is not re-hedged.
+    let mut f = Finding::new(
+        "src/db.rs",
+        "logic",
+        "May overflow for large inputs",
+        "clamp it",
+        0.3,
+        Effort::Low,
+    );
+    f.line = Some(11);
+    let body = render_finding_comment(&f);
+    assert!(
+        !body.contains("This may be an issue: may overflow"),
+        "already-hedged description must not be double-hedged: {body}"
+    );
+    assert!(body.contains("May overflow for large inputs"), "{body}");
+}
+
+#[test]
+fn uncertainty_threshold_is_point_six() {
+    // Lock the documented threshold so a silent change is caught.
+    assert_eq!(UNCERTAINTY_THRESHOLD, 0.6);
+}

--- a/crates/trusty-review/src/integrations/github/inline_tests.rs
+++ b/crates/trusty-review/src/integrations/github/inline_tests.rs
@@ -141,6 +141,30 @@ fn build_inline_plan_preserves_order_and_splits() {
     assert_eq!(plan.summary_findings.len(), 1);
     assert_eq!(plan.comments[0].line, 11);
     assert_eq!(plan.comments[1].line, 2);
+    // The inline index set records identity (original indices 0 and 2), not the
+    // off-diff finding at index 1 — this is the authoritative partition the
+    // summary body uses to avoid coordinate-based silent omission (#1414).
+    assert_eq!(plan.inline_indices, vec![0, 2]);
+}
+
+#[test]
+fn build_inline_plan_same_line_distinct_findings_keep_distinct_indices() {
+    // Two distinct findings at the SAME (file, line): both are anchorable, so both
+    // go inline here and get distinct indices.  The key property is that
+    // `inline_indices` keys on identity (index), never the shared coordinate — so a
+    // consumer can tell exactly which findings were placed, with no collision.
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    let findings = vec![
+        finding_at("src/db.rs", Some(11)),
+        finding_at("src/db.rs", Some(11)),
+    ];
+    let plan = build_inline_plan(&findings, &c);
+    assert_eq!(plan.comments.len(), 2);
+    assert_eq!(
+        plan.inline_indices,
+        vec![0, 1],
+        "distinct same-line findings get distinct indices, not a collapsed coordinate"
+    );
 }
 
 #[test]

--- a/crates/trusty-review/src/integrations/github/inline_tests.rs
+++ b/crates/trusty-review/src/integrations/github/inline_tests.rs
@@ -154,3 +154,56 @@ fn render_finding_comment_includes_kind_and_fix() {
     );
     assert!(body.contains("_Fix:_"), "fix line present: {body}");
 }
+
+// ── #1415: committable suggestion blocks ─────────────────────────────────────
+
+#[test]
+fn render_emits_suggestion_block() {
+    // A finding with concrete replacement code emits a ```suggestion block.
+    let mut f = finding_at("src/db.rs", Some(11));
+    f.suggested_replacement = Some("let sql = bind(\"SELECT ?\", input);".to_string());
+    let body = render_finding_comment(&f);
+    assert!(
+        body.contains("```suggestion\n"),
+        "must open a suggestion fence: {body}"
+    );
+    assert!(
+        body.contains("let sql = bind(\"SELECT ?\", input);"),
+        "must contain the replacement code: {body}"
+    );
+    // When a committable block is shown, the prose `_Fix:_` line is not also shown.
+    assert!(
+        !body.contains("_Fix:_"),
+        "committable block replaces the prose fix: {body}"
+    );
+}
+
+#[test]
+fn render_falls_back_to_prose_fix() {
+    // No suggested_replacement → prose `_Fix:_`, no suggestion block.
+    let f = finding_at("src/db.rs", Some(11));
+    let body = render_finding_comment(&f);
+    assert!(!body.contains("```suggestion"), "no block: {body}");
+    assert!(body.contains("_Fix:_"), "prose fix present: {body}");
+}
+
+#[test]
+fn suggestion_with_fence_is_rejected() {
+    // A replacement containing a ``` fence must degrade to prose, never break the
+    // suggestion block.
+    let mut f = finding_at("src/db.rs", Some(11));
+    f.suggested_replacement = Some("```rust\nlet x = 1;\n```".to_string());
+    let body = render_finding_comment(&f);
+    assert!(
+        !body.contains("```suggestion"),
+        "fenced replacement must not emit a suggestion block: {body}"
+    );
+    assert!(body.contains("_Fix:_"), "degrades to prose: {body}");
+}
+
+#[test]
+fn empty_replacement_is_not_committable() {
+    assert!(!suggestion_is_committable(""));
+    assert!(!suggestion_is_committable("   "));
+    assert!(suggestion_is_committable("let x = 1;"));
+}

--- a/crates/trusty-review/src/integrations/github/inline_tests.rs
+++ b/crates/trusty-review/src/integrations/github/inline_tests.rs
@@ -282,3 +282,90 @@ fn uncertainty_threshold_is_point_six() {
     // Lock the documented threshold so a silent change is caught.
     assert_eq!(UNCERTAINTY_THRESHOLD, 0.6);
 }
+
+// ── #1420: nit-volume cap + rollup ───────────────────────────────────────────
+
+/// A diff that adds `n` lines to src/big.rs so each nit gets a distinct anchor.
+fn diff_with_n_added(n: u32) -> String {
+    let mut s = String::from("+++ b/src/big.rs\n");
+    s.push_str(&format!("@@ -0,0 +1,{n} @@\n"));
+    for i in 0..n {
+        s.push_str(&format!("+line {i}\n"));
+    }
+    s
+}
+
+fn nit_at(line: u32) -> Finding {
+    let mut f = Finding::new(
+        "src/big.rs",
+        "nit",
+        "minor style",
+        "tweak",
+        0.9,
+        Effort::Low,
+    );
+    f.line = Some(line);
+    f
+}
+
+#[test]
+fn nit_cap_keeps_first_n_inline() {
+    let diff = diff_with_n_added(20);
+    let c = CommentableLines::from_unified_diff(&diff);
+    // Exactly MAX_INLINE_NITS nits → all inline, none suppressed.
+    let findings: Vec<Finding> = (1..=MAX_INLINE_NITS as u32).map(nit_at).collect();
+    let plan = build_inline_plan(&findings, &c);
+    assert_eq!(plan.comments.len(), MAX_INLINE_NITS);
+    assert_eq!(plan.suppressed_nits, 0);
+    assert!(plan.suppressed_nits_line().is_none());
+}
+
+#[test]
+fn nit_cap_rolls_up_overflow() {
+    let diff = diff_with_n_added(30);
+    let c = CommentableLines::from_unified_diff(&diff);
+    // MAX_INLINE_NITS + 7 nits → first N inline, 7 rolled up.
+    let total = MAX_INLINE_NITS as u32 + 7;
+    let findings: Vec<Finding> = (1..=total).map(nit_at).collect();
+    let plan = build_inline_plan(&findings, &c);
+    assert_eq!(plan.comments.len(), MAX_INLINE_NITS, "cap inline nits at N");
+    assert_eq!(plan.suppressed_nits, 7, "overflow rolled up");
+    let line = plan.suppressed_nits_line().expect("rollup line");
+    assert!(line.contains("+7 more minor nits suppressed"), "{line}");
+}
+
+#[test]
+fn nit_cap_does_not_suppress_high_severity() {
+    let diff = diff_with_n_added(30);
+    let c = CommentableLines::from_unified_diff(&diff);
+    // 10 nits (over the cap) interleaved with 3 medium findings; only nits cap.
+    let mut findings: Vec<Finding> = (1..=10).map(nit_at).collect();
+    for line in [11, 12, 13] {
+        let mut f = Finding::new("src/big.rs", "bug", "real", "fix", 0.9, Effort::Medium);
+        f.line = Some(line);
+        findings.push(f);
+    }
+    let plan = build_inline_plan(&findings, &c);
+    // 5 nits inline + 3 medium inline = 8; 5 nits suppressed.
+    assert_eq!(plan.comments.len(), MAX_INLINE_NITS + 3);
+    assert_eq!(plan.suppressed_nits, 5);
+}
+
+#[test]
+fn suppressed_nits_line_singular() {
+    let diff = diff_with_n_added(30);
+    let c = CommentableLines::from_unified_diff(&diff);
+    let total = MAX_INLINE_NITS as u32 + 1;
+    let findings: Vec<Finding> = (1..=total).map(nit_at).collect();
+    let plan = build_inline_plan(&findings, &c);
+    assert_eq!(plan.suppressed_nits, 1);
+    let line = plan.suppressed_nits_line().expect("rollup line");
+    assert!(line.contains("+1 more minor nit suppressed"), "{line}");
+    assert!(!line.contains("nits"), "singular form: {line}");
+}
+
+#[test]
+fn max_inline_nits_is_five() {
+    // Lock the documented cap so a silent change is caught.
+    assert_eq!(MAX_INLINE_NITS, 5);
+}

--- a/crates/trusty-review/src/integrations/github/mod.rs
+++ b/crates/trusty-review/src/integrations/github/mod.rs
@@ -14,12 +14,16 @@
 
 pub mod auth;
 pub mod firewall;
+pub mod inline;
 pub mod posting;
 pub mod pr;
 pub mod webhook;
 
 pub use auth::{AuthStrategy, RunMode, mint_app_jwt, resolve_token_for_mode};
 pub use firewall::{GH_ALLOW_PUSH, assert_no_push_operation};
+pub use inline::{
+    CommentableLines, InlineComment, InlinePlan, build_inline_plan, render_finding_comment,
+};
 pub use posting::{PostedReview, post_pr_review};
 pub use pr::{PrMetadata, PrRef, PrUser, fetch_pr_diff, fetch_pr_metadata};
 pub use webhook::verify_webhook_signature;

--- a/crates/trusty-review/src/integrations/github/mod.rs
+++ b/crates/trusty-review/src/integrations/github/mod.rs
@@ -23,6 +23,7 @@ pub use auth::{AuthStrategy, RunMode, mint_app_jwt, resolve_token_for_mode};
 pub use firewall::{GH_ALLOW_PUSH, assert_no_push_operation};
 pub use inline::{
     CommentableLines, InlineComment, InlinePlan, build_inline_plan, render_finding_comment,
+    suggestion_is_committable,
 };
 pub use posting::{PostedReview, post_pr_review};
 pub use pr::{PrMetadata, PrRef, PrUser, fetch_pr_diff, fetch_pr_metadata};

--- a/crates/trusty-review/src/integrations/github/mod.rs
+++ b/crates/trusty-review/src/integrations/github/mod.rs
@@ -22,8 +22,8 @@ pub mod webhook;
 pub use auth::{AuthStrategy, RunMode, mint_app_jwt, resolve_token_for_mode};
 pub use firewall::{GH_ALLOW_PUSH, assert_no_push_operation};
 pub use inline::{
-    CommentableLines, InlineComment, InlinePlan, UNCERTAINTY_THRESHOLD, build_inline_plan,
-    render_finding_comment, suggestion_is_committable,
+    CommentableLines, InlineComment, InlinePlan, MAX_INLINE_NITS, UNCERTAINTY_THRESHOLD,
+    build_inline_plan, render_finding_comment, suggestion_is_committable,
 };
 pub use posting::{PostedReview, post_pr_review};
 pub use pr::{PrMetadata, PrRef, PrUser, fetch_pr_diff, fetch_pr_metadata};

--- a/crates/trusty-review/src/integrations/github/mod.rs
+++ b/crates/trusty-review/src/integrations/github/mod.rs
@@ -22,8 +22,8 @@ pub mod webhook;
 pub use auth::{AuthStrategy, RunMode, mint_app_jwt, resolve_token_for_mode};
 pub use firewall::{GH_ALLOW_PUSH, assert_no_push_operation};
 pub use inline::{
-    CommentableLines, InlineComment, InlinePlan, build_inline_plan, render_finding_comment,
-    suggestion_is_committable,
+    CommentableLines, InlineComment, InlinePlan, UNCERTAINTY_THRESHOLD, build_inline_plan,
+    render_finding_comment, suggestion_is_committable,
 };
 pub use posting::{PostedReview, post_pr_review};
 pub use pr::{PrMetadata, PrRef, PrUser, fetch_pr_diff, fetch_pr_metadata};

--- a/crates/trusty-review/src/integrations/github/posting.rs
+++ b/crates/trusty-review/src/integrations/github/posting.rs
@@ -1,15 +1,17 @@
-//! Live PR review-comment posting (issue #582 work-item a).
+//! Live PR review-comment posting (issue #582 work-item a; inline comments #1414).
 //!
 //! Why: until Phase 1 the pipeline was always dry-run — it could form a verdict
-//! but never tell the author.  Live mode posts the verdict back as a PR-level
-//! review comment so the review is actually actionable.  We post a *review*
-//! (`POST /pulls/{n}/reviews` with `event: COMMENT`), not per-line inline
-//! comments, mirroring duetto-code-intelligence's `_post_review`.
+//! but never tell the author.  Live mode posts the verdict back as a review so it
+//! is actually actionable.  As of #1414 the review carries *inline per-line
+//! comments* (`POST /pulls/{n}/reviews` with a `comments[]` array, each anchored
+//! to a file + diff line) for every finding that maps to a line in the diff;
+//! findings with no diff anchor are rolled into the review summary body.
 //!
-//! What: `build_review_comment_body` renders the markdown body (a prose summary
-//! followed by a fenced ```json block of the structured verdict + findings, so
-//! both humans and downstream tooling can read it); `post_pr_review` POSTs it
-//! through the shared `GithubClient` using a token from the auth abstraction.
+//! What: `build_review_comment_body` renders the summary body (verdict heading,
+//! prose, a counts header, the non-inline summary findings, and a fenced ```json
+//! block of the structured verdict + findings); `post_pr_review` POSTs it through
+//! the shared `GithubClient` together with the `comments[]` array built from
+//! `result.inline_comments`.
 //!
 //! Firewall note: posting a *review comment* is an explicitly permitted
 //! operation (spec COMPONENTS §pr.rs) — it is read+comment only and does not
@@ -78,20 +80,37 @@ impl VerdictBlock {
 /// Test: `body_contains_signature`.
 pub const REVIEW_SIGNATURE: &str = "<!-- trusty-review -->";
 
-/// Build the markdown body for a PR review comment.
+/// Return whether a finding was posted as an inline comment (#1414).
 ///
-/// Why: the body must be readable by humans (prose summary, verdict, findings)
-/// and parseable by tooling (the fenced JSON block), matching code-intelligence
-/// so existing consumers keep working.
-/// What: renders the signature, a grade+verdict heading, the LLM prose summary
-/// (or a fallback line, trimmed), and a findings list followed by a trailing
-/// fenced ```json block holding a `VerdictBlock`.  The grade/model/token/cost
-/// footer is NOT generated here — it is appended to `result.review_body` by
-/// `finalize_review` (via `format_review_footer` in `pipeline/post.rs`) before
-/// this function is called, so the footer appears naturally in the prose section
-/// and is identical in both the live GitHub comment and the dry-run/MCP response
-/// (single source of truth for closes #728 + #732).
-/// Test: `body_contains_prose_and_json_block`, `body_contains_signature`.
+/// Why: the summary body must list only the findings that did NOT land inline —
+/// otherwise every finding appears twice (inline AND in the summary list).  A
+/// finding is "inline" when an `InlineCommentOut` shares its file + line.
+/// What: matches on `(file, Some(line))` against `result.inline_comments`.
+/// Test: `body_omits_inline_findings_from_summary`.
+fn finding_is_inline(result: &ReviewResult, f: &crate::models::Finding) -> bool {
+    match f.line {
+        Some(line) => result
+            .inline_comments
+            .iter()
+            .any(|c| c.path == f.file && c.line == line),
+        None => false,
+    }
+}
+
+/// Build the markdown summary body for a PR review (#1414).
+///
+/// Why: with inline per-line comments carrying the actionable findings, the
+/// review-level body becomes a *summary*: a verdict heading, the prose, a counts
+/// header, and only the findings that could NOT be anchored inline (off-diff /
+/// file-level).  It stays readable by humans and parseable by tooling (the fenced
+/// JSON block of the full verdict + findings is retained for downstream consumers).
+/// What: renders the signature, a grade+verdict heading, the LLM prose summary (or
+/// a fallback), an inline/summary counts header, the non-inline findings list, and
+/// the trailing fenced ```json `VerdictBlock`.  The grade/model/token/cost footer
+/// is NOT generated here — `finalize_review` appends it to `result.review_body`
+/// before this is called (single source of truth for #728 + #732).
+/// Test: `body_contains_prose_and_json_block`, `body_contains_signature`,
+/// `body_omits_inline_findings_from_summary`.
 pub fn build_review_comment_body(result: &ReviewResult) -> String {
     let mut md = String::with_capacity(1024);
     md.push_str(REVIEW_SIGNATURE);
@@ -117,12 +136,32 @@ pub fn build_review_comment_body(result: &ReviewResult) -> String {
         md.push_str("\n\n");
     }
 
-    // Findings list (human-readable).
-    if result.findings.is_empty() {
-        md.push_str("**Findings:** none\n\n");
+    // Counts header: how many findings landed inline vs. in this summary.
+    let inline_count = result.inline_comments.len();
+    let summary_findings: Vec<&crate::models::Finding> = result
+        .findings
+        .iter()
+        .filter(|f| !finding_is_inline(result, f))
+        .collect();
+    if inline_count > 0 {
+        md.push_str(&format!(
+            "**Findings:** {} total — {inline_count} inline, {} below.\n\n",
+            result.findings.len(),
+            summary_findings.len()
+        ));
+    }
+
+    // Findings list — only the findings NOT posted inline (off-diff / file-level).
+    if summary_findings.is_empty() {
+        if inline_count == 0 {
+            md.push_str("**Findings:** none\n\n");
+        }
     } else {
-        md.push_str(&format!("**Findings ({}):**\n\n", result.findings.len()));
-        for (i, f) in result.findings.iter().enumerate() {
+        md.push_str(&format!(
+            "**General / off-diff findings ({}):**\n\n",
+            summary_findings.len()
+        ));
+        for (i, f) in summary_findings.iter().enumerate() {
             let loc = match f.line {
                 Some(l) => format!("{}:{l}", f.file),
                 None => f.file.clone(),
@@ -190,13 +229,38 @@ fn review_event(_verdict: &Verdict) -> &'static str {
     "COMMENT"
 }
 
-/// Post a completed review to a GitHub PR as a review comment.
+/// Build the `comments[]` array for the review from inline comments (#1414).
 ///
-/// Why: the live half of the runner's post-or-log decision — it makes the
-/// review visible on the PR.  Routed through the auth abstraction's resolved
-/// token so it works identically in CLI (PAT/`gh`) and service (App) modes.
-/// What: `POST /repos/{owner}/{repo}/pulls/{pr}/reviews` with a `COMMENT` event
-/// and the markdown body from `build_review_comment_body`.  Returns the created
+/// Why: GitHub's review API attaches per-line comments via a `comments[]` array,
+/// each entry anchored with the modern `line` + `side: RIGHT` format (the new-side
+/// diff line).  Building it here keeps `post_pr_review` a thin POST.
+/// What: maps each `result.inline_comments` entry to `{path, line, side, body}`.
+/// Returns an empty vec when there are no inline comments (a plain summary review).
+/// Test: `inline_comments_payload_shape` (asserts the per-comment JSON shape).
+fn build_inline_comments_payload(result: &ReviewResult) -> Vec<serde_json::Value> {
+    result
+        .inline_comments
+        .iter()
+        .map(|c| {
+            json!({
+                "path": c.path,
+                "line": c.line,
+                "side": "RIGHT",
+                "body": c.body,
+            })
+        })
+        .collect()
+}
+
+/// Post a completed review to a GitHub PR with inline per-line comments (#1414).
+///
+/// Why: the live half of the runner's post-or-log decision — it makes the review
+/// visible on the PR.  Routed through the auth abstraction's resolved token so it
+/// works identically in CLI (PAT/`gh`) and service (App) modes.
+/// What: `POST /repos/{owner}/{repo}/pulls/{pr}/reviews` with a `COMMENT` event,
+/// the summary `body` from `build_review_comment_body`, and a `comments[]` array
+/// of inline per-line comments built from `result.inline_comments`.  The
+/// `comments` key is omitted when there are none.  Returns the created
 /// `PostedReview` on success or a typed `GithubError`.
 /// Test: `post_pr_review_transport_error_on_unreachable` (network-free); the
 /// happy path requires a live PR and is covered by `#[ignore]` integration tests.
@@ -212,10 +276,16 @@ pub async fn post_pr_review(
     let event = review_event(&result.verdict);
     let url = format!("https://api.github.com/repos/{owner}/{repo}/pulls/{pr}/reviews");
 
-    let payload = json!({
+    let comments = build_inline_comments_payload(result);
+    let mut payload = json!({
         "body": body,
         "event": event,
     });
+    if !comments.is_empty()
+        && let Some(obj) = payload.as_object_mut()
+    {
+        obj.insert("comments".to_string(), serde_json::Value::Array(comments));
+    }
 
     let resp = client
         .http
@@ -325,6 +395,59 @@ mod tests {
         result.review_body = String::new();
         let body = build_review_comment_body(&result);
         assert!(body.contains("No narrative summary"));
+    }
+
+    #[test]
+    fn body_omits_inline_findings_from_summary() {
+        // A finding that was posted inline must not be duplicated in the summary
+        // findings list; an off-diff finding (no matching inline comment) stays.
+        let mut result = sample_result();
+        // The sole finding is at src/db.rs:42 → mark it inline.
+        result
+            .inline_comments
+            .push(crate::models::InlineCommentOut {
+                path: "src/db.rs".to_string(),
+                line: 42,
+                body: "**security** — SQL injection".to_string(),
+            });
+        let body = build_review_comment_body(&result);
+        // Counts header reflects the inline placement.
+        assert!(
+            body.contains("1 inline"),
+            "counts header must show inline count: {body}"
+        );
+        // The inline finding is NOT re-listed under the off-diff section.
+        assert!(
+            !body.contains("**General / off-diff findings"),
+            "no off-diff section when the only finding went inline: {body}"
+        );
+    }
+
+    #[test]
+    fn inline_comments_payload_shape() {
+        let mut result = sample_result();
+        result
+            .inline_comments
+            .push(crate::models::InlineCommentOut {
+                path: "src/db.rs".to_string(),
+                line: 42,
+                body: "**security** — use a bind param".to_string(),
+            });
+        let payload = build_inline_comments_payload(&result);
+        assert_eq!(payload.len(), 1);
+        assert_eq!(payload[0]["path"], "src/db.rs");
+        assert_eq!(payload[0]["line"], 42);
+        assert_eq!(payload[0]["side"], "RIGHT");
+        assert!(payload[0]["body"].as_str().unwrap().contains("bind param"));
+    }
+
+    #[test]
+    fn payload_empty_when_no_inline_comments() {
+        let result = sample_result();
+        assert!(
+            build_inline_comments_payload(&result).is_empty(),
+            "no inline comments → empty comments[] (plain summary review)"
+        );
     }
 
     #[test]

--- a/crates/trusty-review/src/integrations/github/posting.rs
+++ b/crates/trusty-review/src/integrations/github/posting.rs
@@ -180,6 +180,15 @@ pub fn build_review_comment_body(result: &ReviewResult) -> String {
         md.push('\n');
     }
 
+    // Suppressed-nit rollup (#1420): one honest line instead of inline nit spam.
+    if result.suppressed_nits > 0 {
+        let plural = if result.suppressed_nits == 1 { "" } else { "s" };
+        md.push_str(&format!(
+            "_+{} more minor nit{plural} suppressed to keep this review focused._\n\n",
+            result.suppressed_nits
+        ));
+    }
+
     // Embedded structured block — fenced JSON, mirroring code-intelligence.
     let block = VerdictBlock::from_result(result);
     match serde_json::to_string_pretty(&block) {
@@ -439,6 +448,28 @@ mod tests {
         assert_eq!(payload[0]["line"], 42);
         assert_eq!(payload[0]["side"], "RIGHT");
         assert!(payload[0]["body"].as_str().unwrap().contains("bind param"));
+    }
+
+    #[test]
+    fn body_renders_suppressed_nit_rollup() {
+        // The suppressed-nit count surfaces as one summary line (#1420).
+        let mut result = sample_result();
+        result.suppressed_nits = 7;
+        let body = build_review_comment_body(&result);
+        assert!(
+            body.contains("+7 more minor nits suppressed"),
+            "rollup line must appear: {body}"
+        );
+    }
+
+    #[test]
+    fn body_no_rollup_when_zero_suppressed() {
+        let result = sample_result(); // suppressed_nits defaults to 0
+        let body = build_review_comment_body(&result);
+        assert!(
+            !body.contains("suppressed"),
+            "no rollup line when nothing suppressed: {body}"
+        );
     }
 
     #[test]

--- a/crates/trusty-review/src/integrations/github/posting.rs
+++ b/crates/trusty-review/src/integrations/github/posting.rs
@@ -80,21 +80,27 @@ impl VerdictBlock {
 /// Test: `body_contains_signature`.
 pub const REVIEW_SIGNATURE: &str = "<!-- trusty-review -->";
 
-/// Return whether a finding was posted as an inline comment (#1414).
+/// Return the findings that did NOT land inline, in original order (#1414).
 ///
-/// Why: the summary body must list only the findings that did NOT land inline —
-/// otherwise every finding appears twice (inline AND in the summary list).  A
-/// finding is "inline" when an `InlineCommentOut` shares its file + line.
-/// What: matches on `(file, Some(line))` against `result.inline_comments`.
-/// Test: `body_omits_inline_findings_from_summary`.
-fn finding_is_inline(result: &ReviewResult, f: &crate::models::Finding) -> bool {
-    match f.line {
-        Some(line) => result
-            .inline_comments
-            .iter()
-            .any(|c| c.path == f.file && c.line == line),
-        None => false,
-    }
+/// Why: the summary body must render exactly the findings that were not placed
+/// inline.  Earlier this was derived by matching each finding's `(file, line)`
+/// against `inline_comments` — but two distinct findings can share an anchor, so
+/// a finding that did *not* get an inline comment could be flagged inline and
+/// silently dropped from BOTH the inline set and the summary (data loss).  The
+/// `InlinePlan` already partitions findings authoritatively; its inline index set
+/// is carried on the result, so we partition by identity (index), never coordinate.
+/// What: returns every `findings[i]` whose index `i` is NOT in
+/// `result.inline_finding_indices`.  Order is preserved.
+/// Test: `summary_keeps_same_line_non_inline_finding`,
+/// `body_omits_inline_findings_from_summary`.
+fn summary_findings(result: &ReviewResult) -> Vec<&crate::models::Finding> {
+    result
+        .findings
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !result.inline_finding_indices.contains(i))
+        .map(|(_, f)| f)
+        .collect()
 }
 
 /// Build the markdown summary body for a PR review (#1414).
@@ -138,11 +144,7 @@ pub fn build_review_comment_body(result: &ReviewResult) -> String {
 
     // Counts header: how many findings landed inline vs. in this summary.
     let inline_count = result.inline_comments.len();
-    let summary_findings: Vec<&crate::models::Finding> = result
-        .findings
-        .iter()
-        .filter(|f| !finding_is_inline(result, f))
-        .collect();
+    let summary_findings = summary_findings(result);
     if inline_count > 0 {
         md.push_str(&format!(
             "**Findings:** {} total — {inline_count} inline, {} below.\n\n",
@@ -411,7 +413,7 @@ mod tests {
         // A finding that was posted inline must not be duplicated in the summary
         // findings list; an off-diff finding (no matching inline comment) stays.
         let mut result = sample_result();
-        // The sole finding is at src/db.rs:42 → mark it inline.
+        // The sole finding (index 0) is at src/db.rs:42 → mark it inline.
         result
             .inline_comments
             .push(crate::models::InlineCommentOut {
@@ -419,6 +421,7 @@ mod tests {
                 line: 42,
                 body: "**security** — SQL injection".to_string(),
             });
+        result.inline_finding_indices = vec![0];
         let body = build_review_comment_body(&result);
         // Counts header reflects the inline placement.
         assert!(
@@ -429,6 +432,54 @@ mod tests {
         assert!(
             !body.contains("**General / off-diff findings"),
             "no off-diff section when the only finding went inline: {body}"
+        );
+    }
+
+    #[test]
+    fn summary_keeps_same_line_non_inline_finding() {
+        // Two DISTINCT findings at the SAME file+line: one is placed inline, the
+        // other is NOT.  The non-inline one must appear in the summary body — it
+        // must never be silently dropped just because it shares a coordinate with
+        // an inline finding (the #1414 silent-omission regression this fix closes).
+        let mut result = sample_result(); // findings[0] @ src/db.rs:42
+        let mut second = Finding::new(
+            "src/db.rs",
+            "performance",
+            "N+1 query in the same hot path",
+            "Batch the lookups",
+            0.80,
+            Effort::Medium,
+        );
+        second.line = Some(42); // SAME (file, line) as findings[0]
+        result.findings.push(second); // findings[1]
+
+        // Only findings[0] became an inline comment; findings[1] fell back.
+        result
+            .inline_comments
+            .push(crate::models::InlineCommentOut {
+                path: "src/db.rs".to_string(),
+                line: 42,
+                body: "**security** — SQL injection".to_string(),
+            });
+        result.inline_finding_indices = vec![0];
+
+        let body = build_review_comment_body(&result);
+
+        // The non-inline finding (index 1) must be rendered in the summary body.
+        assert!(
+            body.contains("N+1 query in the same hot path"),
+            "the non-inline same-line finding must appear in the summary body \
+             (never silently dropped): {body}"
+        );
+        // The off-diff / summary section header must be present and report 1 finding.
+        assert!(
+            body.contains("**General / off-diff findings (1):**"),
+            "summary section must list exactly the one non-inline finding: {body}"
+        );
+        // Counts header: 2 total — 1 inline, 1 below. Neither finding is lost.
+        assert!(
+            body.contains("2 total — 1 inline, 1 below"),
+            "counts header must account for every finding: {body}"
         );
     }
 

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -33,7 +33,9 @@ use commands::serve::{ServeArgs, cmd_serve};
 /// An LLM-backed code reviewer that fetches PR diffs, retrieves code context
 /// from trusty-search, and produces structured review verdicts.
 ///
-/// All reviews are dry-run by default (no comments posted to GitHub).
+/// Reviews are dry-run by default (no comments posted to GitHub). `run` and
+/// `serve` post live when posting is enabled — set `PR_INTELLIGENCE_DRY_RUN=false`
+/// to allow live PR comments.
 #[derive(Debug, Parser)]
 #[command(
     name = "trusty-review",
@@ -58,9 +60,11 @@ enum Commands {
     /// Run a single PR review with the default (or overridden) reviewer model.
     ///
     /// Fetches the PR diff from GitHub and runs the LLM review pipeline.
-    /// Always dry-run in the MVP (no comment posted to GitHub).
+    /// Dry-run by default (no comment posted). Posts the review live to the PR
+    /// when posting is enabled — set `PR_INTELLIGENCE_DRY_RUN=false` to allow it.
     ///
-    /// Use --local-diff to review a local unified diff file without GitHub.
+    /// Use --local-diff to review a local unified diff file without GitHub
+    /// (local-diff is always dry-run — it can never post).
     Run(RunArgs),
 
     /// Compare the same PR across multiple models to evaluate speed/cost/quality.
@@ -95,12 +99,13 @@ enum Commands {
     /// Exposes:
     ///   GET  /health                  — liveness + dep status
     ///   GET  /status                  — in-flight count + last error
-    ///   POST /review                  — synchronous on-demand review (dry-run)
+    ///   POST /review                  — synchronous on-demand review
     ///   POST /pr/github/webhook       — GitHub PR webhook (HMAC-validated)
     ///
     /// Pass --stdio to run as a MCP JSON-RPC stdio service instead.
     ///
-    /// All reviews are dry-run (no comments posted to GitHub).
+    /// Dry-run by default (no comments posted). Posts reviews live to the PR
+    /// when posting is enabled — set `PR_INTELLIGENCE_DRY_RUN=false` to allow it.
     /// Graceful shutdown on SIGTERM/SIGINT (in-flight requests are drained).
     #[cfg(feature = "http-server")]
     Serve(ServeArgs),

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -290,6 +290,27 @@ impl Finding {
     }
 }
 
+// ─── InlineCommentOut ───────────────────────────────────────────────────────────
+
+/// A serialisable inline review comment anchored to a PR diff line (#1414).
+///
+/// Why: the runner builds the inline-comment set from the findings + diff, and it
+/// must be carried on the `ReviewResult` so (a) the live poster can attach it to
+/// the GitHub review and (b) the dry-run / MCP response can preview exactly what
+/// would be posted.  It is a flat, owned projection (no borrows, serde-friendly)
+/// distinct from the posting-layer's internal `InlineComment` type.
+/// What: `path` + `line` are the new-side anchor; `body` is the rendered markdown.
+/// Test: `inline_comment_out_serde_roundtrip`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InlineCommentOut {
+    /// Changed file path (new side), e.g. `src/db.rs`.
+    pub path: String,
+    /// New-side line number the comment anchors to.
+    pub line: u32,
+    /// Rendered inline-comment markdown body.
+    pub body: String,
+}
+
 // ─── ReviewResult ─────────────────────────────────────────────────────────────
 
 /// The complete output of a PR review pass.
@@ -325,6 +346,17 @@ pub struct ReviewResult {
     pub grade: Option<String>,
     /// Extracted findings.
     pub findings: Vec<Finding>,
+    /// Per-line inline review comments that were (or, in dry-run, would be)
+    /// posted to the PR diff (#1414).
+    ///
+    /// Why: when posting findings as inline per-line comments, the dry-run /MCP
+    /// response must show the exact set of would-be inline comments so a caller
+    /// can preview what live mode would attach to the diff.  Storing them on the
+    /// result is the single source of truth for both the live POST and the
+    /// dry-run preview.  `#[serde(default)]` keeps every pre-#1414 serialised
+    /// result deserialising with an empty list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inline_comments: Vec<InlineCommentOut>,
 
     // ── Telemetry ─────────────────────────────────────────────────────────
     /// Model id used for the main reviewer call.
@@ -386,6 +418,7 @@ impl ReviewResult {
             verdict: Verdict::Unknown,
             grade: None,
             findings: Vec::new(),
+            inline_comments: Vec::new(),
             model: String::new(),
             input_tokens: 0,
             output_tokens: 0,
@@ -634,6 +667,43 @@ mod tests {
         let f: Finding = serde_json::from_str(json).expect("legacy finding must deserialise");
         assert_eq!(f.category, FindingCategory::Correctness);
         assert_eq!(f.kind, "logic-error");
+    }
+
+    /// `InlineCommentOut` survives a serde round-trip (#1414).
+    ///
+    /// Why: the dry-run / MCP response serialises `ReviewResult.inline_comments`;
+    /// the projection must round-trip so callers can preview would-be comments.
+    /// What: serialises an `InlineCommentOut`, deserialises it, asserts equality.
+    /// Test: this test itself.
+    #[test]
+    fn inline_comment_out_serde_roundtrip() {
+        let c = InlineCommentOut {
+            path: "src/db.rs".to_string(),
+            line: 42,
+            body: "**security** — SQL injection".to_string(),
+        };
+        let json = serde_json::to_string(&c).expect("serialise");
+        let back: InlineCommentOut = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back, c);
+    }
+
+    /// A pre-#1414 `ReviewResult` JSON (no `inline_comments`) still deserialises.
+    ///
+    /// Why: `inline_comments` is `#[serde(default)]` so older review logs keep
+    /// loading with an empty inline-comment list.
+    /// What: builds a result, serialises with no comments (skipped when empty),
+    /// re-parses, asserts the field defaults to empty.
+    /// Test: this test itself.
+    #[test]
+    fn review_result_without_inline_comments_defaults_empty() {
+        let result = ReviewResult::new("o", "r", 1, "t", "u");
+        let json = serde_json::to_string(&result).expect("serialise");
+        assert!(
+            !json.contains("inline_comments"),
+            "empty inline_comments is skipped in serialisation"
+        );
+        let back: ReviewResult = serde_json::from_str(&json).expect("deserialise");
+        assert!(back.inline_comments.is_empty());
     }
 
     #[test]

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -224,8 +224,18 @@ pub struct Finding {
     pub kind: String,
     /// Human-readable description of the issue.
     pub description: String,
-    /// Proposed fix or remediation suggestion.
+    /// Proposed fix or remediation suggestion (prose).
     pub suggestion: String,
+    /// Exact replacement code for a committable GitHub `suggestion` block (#1415).
+    ///
+    /// Why: a one-click-appliable GitHub ```suggestion block must contain the
+    /// *exact* replacement lines for the anchored location — not prose.  Keeping
+    /// it in a dedicated field (separate from the prose `suggestion`) lets the
+    /// renderer emit a committable block only when the model provides concrete
+    /// replacement code, and degrade to prose otherwise.  `#[serde(default)]` +
+    /// skip-if-none keeps every pre-#1415 finding deserialising with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_replacement: Option<String>,
     /// Confidence score in `[0.0, 1.0]`.  Clamped at construction time.
     pub confidence: f32,
     /// Estimated remediation effort.
@@ -267,6 +277,7 @@ impl Finding {
             kind: kind.into(),
             description: description.into(),
             suggestion: suggestion.into(),
+            suggested_replacement: None,
             confidence: confidence.clamp(0.0, 1.0),
             effort,
             category: FindingCategory::Correctness,

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -224,6 +224,15 @@ pub struct Finding {
     pub kind: String,
     /// Human-readable description of the issue.
     pub description: String,
+    /// Brief "what goes wrong if unaddressed" — the failure mechanism (#1416).
+    ///
+    /// Why: a finding that states the failure consequence (not just the issue) is
+    /// far more actionable — it tells the author *why it matters* and helps them
+    /// prioritise.  Kept as its own field so the renderer can place it distinctly
+    /// (a `_Why it matters:_` line) rather than burying it in the description.
+    /// `#[serde(default)]` (empty string) keeps every pre-#1416 finding parsing.
+    #[serde(default)]
+    pub consequence: String,
     /// Proposed fix or remediation suggestion (prose).
     pub suggestion: String,
     /// Exact replacement code for a committable GitHub `suggestion` block (#1415).
@@ -276,6 +285,7 @@ impl Finding {
             line: None,
             kind: kind.into(),
             description: description.into(),
+            consequence: String::new(),
             suggestion: suggestion.into(),
             suggested_replacement: None,
             confidence: confidence.clamp(0.0, 1.0),

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -378,6 +378,14 @@ pub struct ReviewResult {
     /// result deserialising with an empty list.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inline_comments: Vec<InlineCommentOut>,
+    /// Count of low-severity nits suppressed past the inline cap (#1420).
+    ///
+    /// Why: the nit-volume cap rolls overflow nits into one summary line rather
+    /// than spamming inline comments; the count must reach the body renderer (and
+    /// the dry-run / MCP response) so the suppression is acknowledged, not silent.
+    /// `#[serde(default)]` + skip-if-zero keeps pre-#1420 results unchanged.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub suppressed_nits: usize,
 
     // ── Telemetry ─────────────────────────────────────────────────────────
     /// Model id used for the main reviewer call.
@@ -440,6 +448,7 @@ impl ReviewResult {
             grade: None,
             findings: Vec::new(),
             inline_comments: Vec::new(),
+            suppressed_nits: 0,
             model: String::new(),
             input_tokens: 0,
             output_tokens: 0,
@@ -468,6 +477,16 @@ impl ReviewResult {
         self.latency_ms = resp.latency_ms;
         self.review_body = resp.text.clone();
     }
+}
+
+/// Serde skip-predicate: true when a `usize` is zero (#1420).
+///
+/// Why: `#[serde(skip_serializing_if)]` needs a path to a predicate; this keeps
+/// `suppressed_nits: 0` out of serialised results so pre-#1420 logs are unchanged.
+/// What: returns `*n == 0`.
+/// Test: covered transitively by `review_result_serde_roundtrip`.
+fn is_zero_usize(n: &usize) -> bool {
+    *n == 0
 }
 
 /// Return a simple ISO-8601 UTC timestamp without depending on chrono.

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -378,6 +378,18 @@ pub struct ReviewResult {
     /// result deserialising with an empty list.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inline_comments: Vec<InlineCommentOut>,
+    /// Indices (into `findings`) of the findings that were placed inline (#1414).
+    ///
+    /// Why: the summary body must render exactly the findings that did NOT land
+    /// inline.  Deriving that set by matching `(file, line)` against
+    /// `inline_comments` is lossy — two distinct findings at the same anchor
+    /// collide and one is silently omitted from *both* the inline set and the
+    /// summary (data loss).  Carrying the authoritative inline index set from the
+    /// `InlinePlan` lets the renderer partition by finding identity, so no finding
+    /// is ever dropped.  `#[serde(default)]` + skip-if-empty keeps pre-existing
+    /// serialised results deserialising unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inline_finding_indices: Vec<usize>,
     /// Count of low-severity nits suppressed past the inline cap (#1420).
     ///
     /// Why: the nit-volume cap rolls overflow nits into one summary line rather
@@ -448,6 +460,7 @@ impl ReviewResult {
             grade: None,
             findings: Vec::new(),
             inline_comments: Vec::new(),
+            inline_finding_indices: Vec::new(),
             suppressed_nits: 0,
             model: String::new(),
             input_tokens: 0,

--- a/crates/trusty-review/src/pipeline/parser.rs
+++ b/crates/trusty-review/src/pipeline/parser.rs
@@ -89,6 +89,12 @@ struct LlmFinding {
     /// Finding axis: `"correctness"` (default) or `"method-conformance"` (#1359).
     #[serde(default)]
     category: FindingCategory,
+    /// Exact replacement code for a committable GitHub `suggestion` block (#1415).
+    ///
+    /// `#[serde(default)]` → `None` so models that omit it — and every pre-#1415
+    /// fixture — still parse.
+    #[serde(default)]
+    suggested_replacement: Option<String>,
 }
 
 // ─── Parsed output ────────────────────────────────────────────────────────────
@@ -315,6 +321,9 @@ fn convert_llm_finding(f: LlmFinding) -> Finding {
     let mut finding = Finding::new(file, f.title, f.body, String::new(), f.confidence, effort)
         .with_category(category);
     finding.line = line;
+    // Carry the committable replacement code through for a GitHub suggestion
+    // block (#1415); normalise empty/whitespace-only strings to None.
+    finding.suggested_replacement = f.suggested_replacement.filter(|s| !s.trim().is_empty());
     finding
 }
 

--- a/crates/trusty-review/src/pipeline/parser.rs
+++ b/crates/trusty-review/src/pipeline/parser.rs
@@ -89,6 +89,12 @@ struct LlmFinding {
     /// Finding axis: `"correctness"` (default) or `"method-conformance"` (#1359).
     #[serde(default)]
     category: FindingCategory,
+    /// Brief failure consequence — what goes wrong if unaddressed (#1416).
+    ///
+    /// `#[serde(default)]` → `""` so models that omit it — and every pre-#1416
+    /// fixture — still parse.
+    #[serde(default)]
+    consequence: String,
     /// Exact replacement code for a committable GitHub `suggestion` block (#1415).
     ///
     /// `#[serde(default)]` → `None` so models that omit it — and every pre-#1415
@@ -321,6 +327,8 @@ fn convert_llm_finding(f: LlmFinding) -> Finding {
     let mut finding = Finding::new(file, f.title, f.body, String::new(), f.confidence, effort)
         .with_category(category);
     finding.line = line;
+    // Carry the failure consequence through for the inline comment (#1416).
+    finding.consequence = f.consequence;
     // Carry the committable replacement code through for a GitHub suggestion
     // block (#1415); normalise empty/whitespace-only strings to None.
     finding.suggested_replacement = f.suggested_replacement.filter(|s| !s.trim().is_empty());

--- a/crates/trusty-review/src/pipeline/parser_tests.rs
+++ b/crates/trusty-review/src/pipeline/parser_tests.rs
@@ -480,6 +480,40 @@ fn parse_finding_without_category_defaults_correctness() {
         result.findings[0].suggested_replacement.is_none(),
         "absent suggested_replacement must default to None"
     );
+    // A finding with no `consequence` defaults to "" (#1416 back-compat).
+    assert!(
+        result.findings[0].consequence.is_empty(),
+        "absent consequence must default to empty string"
+    );
+}
+
+/// A finding's `consequence` is carried through the parser (#1416).
+///
+/// Why: the inline-comment renderer reads `Finding.consequence`; it must survive
+/// the JSON → internal conversion so the "_Why it matters:_" line renders.
+/// What: parses a finding carrying a `consequence`, asserts it is preserved.
+/// Test: this test itself.
+#[test]
+fn parse_finding_carries_consequence() {
+    let body = r#"{
+        "verdict":"REQUEST_CHANGES",
+        "summary":"Bug.",
+        "findings":[{
+            "title":"Unwrap",
+            "body":"Unchecked unwrap on parse.",
+            "severity":"high",
+            "confidence":0.9,
+            "file":"src/x.rs",
+            "line":7,
+            "consequence":"panics on malformed input"
+        }]
+    }"#;
+    let result = parse_review_response(body);
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(
+        result.findings[0].consequence, "panics on malformed input",
+        "consequence must be carried through"
+    );
 }
 
 /// A finding's `suggested_replacement` is carried through the parser (#1415).

--- a/crates/trusty-review/src/pipeline/parser_tests.rs
+++ b/crates/trusty-review/src/pipeline/parser_tests.rs
@@ -475,4 +475,56 @@ fn parse_finding_without_category_defaults_correctness() {
         FindingCategory::Correctness,
         "a finding with no category must default to Correctness (back-compat)"
     );
+    // A finding with no `suggested_replacement` defaults to None (#1415 back-compat).
+    assert!(
+        result.findings[0].suggested_replacement.is_none(),
+        "absent suggested_replacement must default to None"
+    );
+}
+
+/// A finding's `suggested_replacement` is carried through the parser (#1415).
+///
+/// Why: the committable-suggestion renderer reads `Finding.suggested_replacement`;
+/// it must survive the JSON → internal conversion, and an empty value must
+/// normalise to `None` so the renderer never emits an empty suggestion block.
+/// What: parses one finding with concrete replacement code and one with an empty
+/// string, asserting the first is `Some` and the second is `None`.
+/// Test: this test itself.
+#[test]
+fn parse_finding_carries_suggested_replacement() {
+    let body = r#"{
+        "verdict":"REQUEST_CHANGES",
+        "summary":"Bug.",
+        "findings":[
+            {
+                "title":"SQLi",
+                "body":"Interpolated SQL.",
+                "severity":"high",
+                "confidence":0.9,
+                "file":"src/db.rs",
+                "line":42,
+                "suggested_replacement":"let sql = bind(\"SELECT ?\", input);"
+            },
+            {
+                "title":"Nit",
+                "body":"Naming.",
+                "severity":"low",
+                "confidence":0.5,
+                "file":"src/db.rs",
+                "line":43,
+                "suggested_replacement":"   "
+            }
+        ]
+    }"#;
+    let result = parse_review_response(body);
+    assert_eq!(result.findings.len(), 2);
+    assert_eq!(
+        result.findings[0].suggested_replacement.as_deref(),
+        Some("let sql = bind(\"SELECT ?\", input);"),
+        "concrete replacement must be carried through"
+    );
+    assert!(
+        result.findings[1].suggested_replacement.is_none(),
+        "whitespace-only replacement must normalise to None"
+    );
 }

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -144,6 +144,15 @@ pub fn review_response_schema() -> ResponseSchema {
                             "type": "string",
                             "enum": ["correctness", "method-conformance"],
                             "description": "Almost always \"correctness\". Use \"method-conformance\" ONLY when the diff explicitly contradicts a method/approach/constraint the ticket or spec stated in the \"Intended method (ticket/spec)\" context — never for a missing method (advisory gap) or a stale-spec conflict."
+                        },
+                        // `suggested_replacement` (#1415) is nullable (like `line`)
+                        // so it can be `null` while still satisfying OpenAI strict
+                        // mode (every property must be in `required`).  Non-strict
+                        // providers and pre-#1415 models simply omit it → serde
+                        // default `None`. See `LlmFinding.suggested_replacement`.
+                        "suggested_replacement": {
+                            "type": ["string", "null"],
+                            "description": "EXACT replacement code for the line(s) at `line`, suitable for a one-click GitHub suggestion block. Provide ONLY when the fix is a concrete code replacement that maps to specific line(s) at this location; otherwise null and describe the fix in `body`. Do NOT include a code fence or surrounding prose — just the literal replacement line(s)."
                         }
                     }
                 }

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -145,6 +145,14 @@ pub fn review_response_schema() -> ResponseSchema {
                             "enum": ["correctness", "method-conformance"],
                             "description": "Almost always \"correctness\". Use \"method-conformance\" ONLY when the diff explicitly contradicts a method/approach/constraint the ticket or spec stated in the \"Intended method (ticket/spec)\" context — never for a missing method (advisory gap) or a stale-spec conflict."
                         },
+                        // `consequence` (#1416) is a plain required string;
+                        // pre-#1416 models / lenient providers that omit it funnel
+                        // through serde where `LlmFinding.consequence` is
+                        // `#[serde(default)]` → "". Empty is fine (renderer skips it).
+                        "consequence": {
+                            "type": "string",
+                            "description": "Brief failure mechanism: what goes wrong in practice if this is NOT addressed (e.g. \"panics on empty input\", \"leaks the connection under load\"). One short phrase. Empty string if there is no concrete consequence."
+                        },
                         // `suggested_replacement` (#1415) is nullable (like `line`)
                         // so it can be `null` while still satisfying OpenAI strict
                         // mode (every property must be in `required`).  Non-strict

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -93,7 +93,17 @@ Every other finding uses `category` = "correctness" (the default).
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
   confidence (0.0–1.0), file (source file path), line (null if not applicable),
   category ("correctness" by default, or "method-conformance" per the rule above),
-  suggested_replacement (see below).
+  consequence (see below), suggested_replacement (see below).
+
+`consequence`: a brief statement of the FAILURE MECHANISM — what concretely goes
+wrong in practice if this finding is not addressed (e.g. "panics on empty input",
+"silently drops the last row", "leaks the DB connection under load"). One short
+phrase, not a restatement of the issue. Empty string when there is no concrete
+consequence.
+
+`confidence`: be honest — use a LOW value (< 0.6) when you are not sure the
+finding is real; the review will hedge low-confidence findings rather than assert
+them.
 
 `suggested_replacement`: when — and ONLY when — the fix is a concrete code
 replacement for the specific line(s) at `line`, provide the EXACT replacement
@@ -195,7 +205,17 @@ coverage floor after your response based on the configured policy.
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
   confidence (0.0–1.0), file (source file path), line (null if not applicable),
   category ("correctness" by default, or "method-conformance" per the rule above),
-  suggested_replacement (see below).
+  consequence (see below), suggested_replacement (see below).
+
+`consequence`: a brief statement of the FAILURE MECHANISM — what concretely goes
+wrong in practice if this finding is not addressed (e.g. "panics on empty input",
+"silently drops the last row", "leaks the DB connection under load"). One short
+phrase, not a restatement of the issue. Empty string when there is no concrete
+consequence.
+
+`confidence`: be honest — use a LOW value (< 0.6) when you are not sure the
+finding is real; the review will hedge low-confidence findings rather than assert
+them.
 
 `suggested_replacement`: when — and ONLY when — the fix is a concrete code
 replacement for the specific line(s) at `line`, provide the EXACT replacement

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -92,7 +92,16 @@ Every other finding uses `category` = "correctness" (the default).
 - `findings`: array of issues found (empty array if none).
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
   confidence (0.0–1.0), file (source file path), line (null if not applicable),
-  category ("correctness" by default, or "method-conformance" per the rule above).
+  category ("correctness" by default, or "method-conformance" per the rule above),
+  suggested_replacement (see below).
+
+`suggested_replacement`: when — and ONLY when — the fix is a concrete code
+replacement for the specific line(s) at `line`, provide the EXACT replacement
+line(s) here so the author can one-click apply them as a GitHub suggestion. Do
+NOT wrap it in a code fence and do NOT put prose in it — just the literal
+replacement code. When the fix is not a concrete line replacement (it spans
+multiple hunks, is advisory, or is best described in words), set it to null and
+explain the fix in `body`.
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.
@@ -185,7 +194,16 @@ coverage floor after your response based on the configured policy.
 - `findings`: array of issues found (empty array if none).
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
   confidence (0.0–1.0), file (source file path), line (null if not applicable),
-  category ("correctness" by default, or "method-conformance" per the rule above).
+  category ("correctness" by default, or "method-conformance" per the rule above),
+  suggested_replacement (see below).
+
+`suggested_replacement`: when — and ONLY when — the fix is a concrete code
+replacement for the specific line(s) at `line`, provide the EXACT replacement
+line(s) here so the author can one-click apply them as a GitHub suggestion. Do
+NOT wrap it in a code fence and do NOT put prose in it — just the literal
+replacement code. When the fix is not a concrete line replacement (it spans
+multiple hunks, is advisory, or is best described in words), set it to null and
+explain the fix in `body`.
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -469,6 +469,7 @@ fn review_schema_is_openai_strict_compliant() {
             "body",
             "category",
             "confidence",
+            "consequence",
             "file",
             "line",
             "severity",

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -472,6 +472,7 @@ fn review_schema_is_openai_strict_compliant() {
             "file",
             "line",
             "severity",
+            "suggested_replacement",
             "title"
         ]
         .into_iter()

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -16,7 +16,9 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use super::runner_coverage::load_coverage_contrib;
-use super::runner_helpers::{abort_dry, apply_grade_and_floor, fetch_github_pr_meta, finalize_run};
+use super::runner_helpers::{
+    abort_dry, apply_grade_and_floor, attach_inline_comments, fetch_github_pr_meta, finalize_run,
+};
 use crate::{
     config::ReviewConfig,
     coverage::{CoverageVerdictContrib, apply_coverage_floor},
@@ -410,6 +412,12 @@ pub async fn run_review(
         crate::pipeline::letter_grade::clamp_grade_to_verdict(final_grade, &result.verdict)
             .to_string(),
     );
+
+    // 7e: build inline per-line comments from the RAW diff (#1414).  Using the
+    // pre-filter `raw_diff` (not the noise-filtered `diff` sent to the LLM) means
+    // anchors map to the actual PR diff lines GitHub will accept; findings that do
+    // not map to a diff line fall back to the summary body.
+    attach_inline_comments(&mut result, &raw_diff);
 
     finalize_run(result, config, &input, deps.dedup.as_ref()).await
 }

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -151,6 +151,10 @@ pub(super) fn attach_inline_comments(result: &mut ReviewResult, raw_diff: &str) 
     let commentable = CommentableLines::from_unified_diff(raw_diff);
     let plan = build_inline_plan(&result.findings, &commentable);
     result.suppressed_nits = plan.suppressed_nits;
+    // Carry the authoritative inline/summary partition by finding identity so the
+    // summary body never drops a finding that shares a (file, line) with an inline
+    // one (#1414 silent-omission fix).
+    result.inline_finding_indices = plan.inline_indices;
     result.inline_comments = plan
         .comments
         .into_iter()

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -13,11 +13,12 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::integrations::github::{
-    AuthStrategy, GithubClient, GithubError, RunMode, fetch_pr_metadata,
+    AuthStrategy, CommentableLines, GithubClient, GithubError, RunMode, build_inline_plan,
+    fetch_pr_metadata,
 };
 use crate::{
     config::ReviewConfig,
-    models::{ReviewResult, Verdict},
+    models::{InlineCommentOut, ReviewResult, Verdict},
     pipeline::{
         grade::derive_verdict_with_grade,
         letter_grade::default_grade_for_verdict,
@@ -128,6 +129,35 @@ pub(super) fn abort_dry(
         print_review_result(&result);
     }
     result
+}
+
+/// Build inline per-line comments from the raw diff and attach to the result (#1414).
+///
+/// Why: findings reach posting with only `file` + `line`; to post them as inline
+/// review comments (or, in dry-run, preview them) the runner must map each finding
+/// to a commentable diff line and divert off-diff findings to the summary body.
+/// Computing this here — where the raw, unfiltered diff is available — is the only
+/// place that knows the true PR diff positions GitHub will accept.
+/// What: parses `raw_diff` into a `CommentableLines` index, builds the inline plan
+/// from `result.findings`, and stores the inline comments as `InlineCommentOut` on
+/// the result.  Findings that fall back to the summary stay in `result.findings`
+/// (the body renders the non-inline ones).  A no-op when there are no findings.
+/// Test: `attach_inline_comments_maps_on_diff` (runner_tests.rs).
+pub(super) fn attach_inline_comments(result: &mut ReviewResult, raw_diff: &str) {
+    if result.findings.is_empty() {
+        return;
+    }
+    let commentable = CommentableLines::from_unified_diff(raw_diff);
+    let plan = build_inline_plan(&result.findings, &commentable);
+    result.inline_comments = plan
+        .comments
+        .into_iter()
+        .map(|c| InlineCommentOut {
+            path: c.path,
+            line: c.line,
+            body: c.body,
+        })
+        .collect();
 }
 
 /// Apply post-or-log finalisation (Phase 1, #582) for a completed review.

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -140,8 +140,9 @@ pub(super) fn abort_dry(
 /// place that knows the true PR diff positions GitHub will accept.
 /// What: parses `raw_diff` into a `CommentableLines` index, builds the inline plan
 /// from `result.findings`, and stores the inline comments as `InlineCommentOut` on
-/// the result.  Findings that fall back to the summary stay in `result.findings`
-/// (the body renders the non-inline ones).  A no-op when there are no findings.
+/// the result plus the suppressed-nit count (#1420).  Findings that fall back to the
+/// summary stay in `result.findings` (the body renders the non-inline ones).  A
+/// no-op when there are no findings.
 /// Test: `attach_inline_comments_maps_on_diff` (runner_tests.rs).
 pub(super) fn attach_inline_comments(result: &mut ReviewResult, raw_diff: &str) {
     if result.findings.is_empty() {
@@ -149,6 +150,7 @@ pub(super) fn attach_inline_comments(result: &mut ReviewResult, raw_diff: &str) 
     }
     let commentable = CommentableLines::from_unified_diff(raw_diff);
     let plan = build_inline_plan(&result.findings, &commentable);
+    result.suppressed_nits = plan.suppressed_nits;
     result.inline_comments = plan
         .comments
         .into_iter()

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -946,3 +946,44 @@ async fn run_review_verification_disabled_skips_round() {
 async fn run_review_live_post_and_dedup_skip_integration() {
     // Placeholder for a future live integration test against a fixture PR.
 }
+
+/// `attach_inline_comments` maps on-diff findings to inline comments and leaves
+/// off-diff findings for the summary body (#1414).
+///
+/// Why: this is the runner-side glue that turns findings + the raw diff into the
+/// `inline_comments` set; a regression would either post off-diff anchors (which
+/// GitHub rejects, failing the whole review) or never post any inline comment.
+/// What: builds a result with one on-diff finding (line 1, present in the hunk)
+/// and one off-diff finding (line 999), calls `attach_inline_comments`, asserts
+/// exactly one inline comment for the on-diff finding.
+/// Test: this test itself (no network).
+#[test]
+fn attach_inline_comments_maps_on_diff() {
+    use crate::models::{Effort, Finding};
+    use crate::pipeline::runner_helpers::attach_inline_comments;
+
+    let raw_diff = "\
+diff --git a/src/db.rs b/src/db.rs
+--- a/src/db.rs
++++ b/src/db.rs
+@@ -1,1 +1,2 @@
+ fn a() {}
++fn b() {}
+";
+    let mut result = crate::models::ReviewResult::new("o", "r", 1, "t", "u");
+    let mut on_diff = Finding::new("src/db.rs", "bug", "desc", "fix", 0.9, Effort::Medium);
+    on_diff.line = Some(2); // the added `fn b()` line on the new side.
+    let mut off_diff = Finding::new("src/db.rs", "bug2", "desc2", "fix2", 0.9, Effort::Medium);
+    off_diff.line = Some(999);
+    result.findings = vec![on_diff, off_diff];
+
+    attach_inline_comments(&mut result, raw_diff);
+
+    assert_eq!(
+        result.inline_comments.len(),
+        1,
+        "only the on-diff finding becomes an inline comment"
+    );
+    assert_eq!(result.inline_comments[0].path, "src/db.rs");
+    assert_eq!(result.inline_comments[0].line, 2);
+}

--- a/crates/trusty-review/src/voice/principles.rs
+++ b/crates/trusty-review/src/voice/principles.rs
@@ -67,7 +67,19 @@ equally sound, defer to the author.
 **Scope discipline.**
 Separate in-scope fixes from out-of-scope cleanup; defer the latter to a
 tracked follow-up rather than expanding the PR. Do not approve "I'll fix it
-later" promises for real correctness or complexity problems."#;
+later" promises for real correctness or complexity problems.
+
+**Do NOT flag.**
+Stay silent on — do not emit a finding for — any of the following:
+- Pure style/formatting nits already enforced by fmt/clippy/linters (spacing,
+  import order, trailing commas, line length).
+- Speculative or hypothetical concerns ("if someone later calls this with X…")
+  with no evidence the diff actually triggers them.
+- Restating what the diff obviously does, or narrating the change back to the
+  author without identifying a problem.
+- Subjective preferences (naming taste, "I'd structure this differently") that
+  carry no correctness or maintainability consequence.
+A finding must name a concrete consequence; if you cannot, do not raise it."#;
 
 /// Return the universal best-practices principles addendum.
 ///

--- a/crates/trusty-review/src/voice/tests.rs
+++ b/crates/trusty-review/src/voice/tests.rs
@@ -200,6 +200,35 @@ fn principles_contains_key_concepts() {
     );
 }
 
+/// Principles addendum carries the "do NOT flag" guardrails (#1420).
+///
+/// Why: the what-not-to-flag section is the prompt half of the nit-volume work;
+/// it must be present so the model stops emitting style/speculative/restating/
+/// preference findings.
+/// What: asserts the guardrail header and its key prohibitions appear.
+/// Test: no network.
+#[test]
+fn principles_contains_do_not_flag_guardrails() {
+    let p = principles_addendum();
+    assert!(
+        p.contains("Do NOT flag"),
+        "principles must carry the do-not-flag section"
+    );
+    let lower = p.to_lowercase();
+    assert!(
+        lower.contains("fmt/clippy") || lower.contains("linters"),
+        "must mention linter-enforced style nits"
+    );
+    assert!(
+        lower.contains("speculative") || lower.contains("hypothetical"),
+        "must mention speculative/hypothetical concerns"
+    );
+    assert!(
+        lower.contains("restat") || lower.contains("narrat"),
+        "must mention restating what the diff does"
+    );
+}
+
 // ── VoiceLoader — bundled fixtures ────────────────────────────────────────────
 
 /// The bundled duetto voice loads correctly and has expected content.


### PR DESCRIPTION
Epic #1413 output-fidelity batch — makes trusty-review post professional, inline, actionable review output instead of one summary blob. Lean "ship it" cut. Bumps trusty-review 0.3.16 → 0.4.0.

## #1414 — inline per-line PR comments
Findings now post as GitHub review comments anchored to file+line in the diff (new `inline.rs`: parses `@@` hunks into a commentable-line index, maps findings to comments, side:RIGHT). No-line/off-diff findings fall back to the summary body (GitHub rejects off-diff comments) — never fails the post. Dry-run/MCP previews the would-be comments via `ReviewResult.inline_comments`.

## #1415 — GitHub suggestion blocks
Findings with a concrete fix render a committable ```suggestion fence (new `Finding.suggested_replacement`); malformed/non-committable fixes degrade to prose.

## #1416 — consequence + uncertainty
New `Finding.consequence` ("why it matters" / failure mechanism) rendered per comment; low-confidence findings (< 0.6) are hedged ("This may…") instead of asserted.

## #1420 — nit cap + what-not-to-flag
Inline low-severity nits capped at 5; overflow rolled into one summary line. Prompt gains a concise "Do NOT flag" guardrail section (style/formatting already enforced by fmt/clippy, speculative concerns, restating the obvious). Complements the recent praise-rare direction.

## Back-compat
New schema fields are OpenAI strict-mode compliant AND `#[serde(default)]` so non-strict providers and pre-0.4.0 review logs still parse (regression test updated).

## Verification
- `cargo test -p trusty-review`: lib 907 passed / 0 failed / 3 ignored; bin 19 passed. New unit tests cover mapping, off-diff fallback, suggestion render+rejection, consequence/hedging, nit cap+overflow.
- clippy -D warnings, fmt --check, line-cap (0 violations): clean.
- Live end-to-end dogfood verification posted on this PR by the new binary (see QA comments).

Closes #1414
Closes #1415
Closes #1416
Closes #1420
Part of epic #1413

🤖 Generated with [Claude Code](https://claude.com/claude-code)