### PR TITLE
feat(trusty-code): M1 critical path — tcode run-task executes PM→engineer end-to-end (#1033, #1034, #1035)

### DIFF
--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -222,6 +222,18 @@ pub mod agent_loop;
 /// `tools.allowed` enforcement, usage roll-up) — all offline.
 pub mod runner;
 
+/// `tcode run-task` end-to-end execution layer (#1034, #1035).
+///
+/// Why: This is the orchestration closer that makes the `tcode` binary run a task
+/// for real — load project context, assemble the PM prompt, run the PM loop, let
+/// it delegate to the engineer in-process, capture the diff + transcript + usage,
+/// and render a human or JSON report with meaningful exit codes. The LLM client is
+/// injected so the whole path is testable offline with a scripted mock.
+/// What: `RunTaskParams`, `execute_run_task`, `RunReport`, `ExitCode`, and the
+/// transcript types (`TurnRecord`, `SharedTranscript`, `RecordingLlmClient`).
+/// Test: `run_task::tests::*` (all offline, mocked LLM).
+pub mod run_task;
+
 /// System-prompt assembly layer implementing the parity spec.
 ///
 /// Why: The cross-model comparison harness must assemble the same fixed

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -180,6 +180,18 @@ pub mod logging;
 /// Test: `provider::*` submodule tests.
 pub mod provider;
 
+/// Project-context ingestion — load `CLAUDE.md` for prompt injection (#1033).
+///
+/// Why: A Claude-Code-compatible harness must give the PM and every sub-agent
+/// the same project-specific rules a human Claude Code session sees — the
+/// project-root `CLAUDE.md`. This module reads that file, bounds its size so a
+/// runaway file cannot blow the model context budget, and degrades gracefully
+/// when the file is absent.
+/// What: `load_project_context` (root then `.claude/` lookup, size-capped with a
+/// provenance note on truncation) and `MAX_CONTEXT_BYTES`.
+/// Test: `project_context::tests::*`.
+pub mod project_context;
+
 // ── Phase 4 orchestration layer (per #1028) ──
 
 /// Multi-turn agent loop driving an LLM through tool calls to completion.

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -26,6 +26,9 @@ use tracing::info;
 use trusty_code::llm::{LlmClient, LlmClientConfig, LlmClientTrait};
 use trusty_code::run_task::{ExitCode, RunTaskParams, execute_run_task};
 
+/// Environment variable that overrides the engineer model for a single run (#1035).
+const ENGINEER_MODEL_ENV: &str = "TCODE_ENGINEER_MODEL";
+
 /// tcode — per-project Claude-Code-compatible MPM orchestration harness.
 #[derive(Parser)]
 #[command(
@@ -78,6 +81,12 @@ enum Command {
         /// Emit a machine-readable JSON report on stdout instead of human text.
         #[arg(long)]
         json: bool,
+
+        /// Override the python-engineer's model for this run only (#1035).
+        /// Falls back to the `TCODE_ENGINEER_MODEL` env var, then the agent
+        /// config's own model.
+        #[arg(long, value_name = "SLUG")]
+        engineer_model: Option<String>,
     },
 
     /// Execute a named MPM workflow end-to-end.
@@ -116,7 +125,8 @@ async fn main() -> Result<()> {
             task,
             project,
             json,
-        } => run_task(&agent, &task, &project, json).await,
+            engineer_model,
+        } => run_task(&agent, &task, &project, json, engineer_model).await,
 
         Command::RunWorkflow { name, project } => {
             eprintln!(
@@ -163,12 +173,19 @@ fn validate_agent_name(agent_name: &str) -> Result<()> {
 /// unit-tested offline). When `--json` is set, only the JSON report is written to
 /// stdout; logs always go to stderr.
 /// What: Validates the agent name and project path (traversal guards), locates the
-/// agents dir, builds the real `LlmClient` from `OPENROUTER_API_KEY`, runs
+/// agents dir, resolves the engineer-model override (CLI flag > `TCODE_ENGINEER_MODEL`
+/// env), builds the real `LlmClient` from `OPENROUTER_API_KEY`, runs
 /// `execute_run_task`, prints the human or JSON report, and exits with the
 /// report's `ExitCode`. A missing API key is a config error (exit 2).
-/// Test: Orchestration is covered by `run_task::tests`; the wrapper is exercised
-/// manually via `tcode run-task pm "<task>" --project <path>`.
-async fn run_task(agent_name: &str, task: &str, project: &Path, json: bool) -> Result<()> {
+/// Test: Orchestration (incl. the model swap) is covered by `run_task::tests`; the
+/// wrapper is exercised manually via `tcode run-task pm "<task>" --project <path>`.
+async fn run_task(
+    agent_name: &str,
+    task: &str,
+    project: &Path,
+    json: bool,
+    engineer_model_flag: Option<String>,
+) -> Result<()> {
     if let Err(e) = validate_agent_name(agent_name) {
         eprintln!("tcode run-task: {e}");
         process::exit(ExitCode::ConfigError.code());
@@ -189,11 +206,22 @@ async fn run_task(agent_name: &str, task: &str, project: &Path, json: bool) -> R
 
     let agents_dir = locate_agents_dir(&project_root);
 
+    // Engineer-model override (#1035): CLI flag wins, then the env var; an empty
+    // value is treated as "unset" so it falls through to the agent config model.
+    let engineer_model = engineer_model_flag
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var(ENGINEER_MODEL_ENV)
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        });
+
     info!(
         agent = agent_name,
         project = %project_root.display(),
         agents_dir = %agents_dir.display(),
         json,
+        engineer_model = engineer_model.as_deref().unwrap_or("(agent default)"),
         "tcode run-task: starting"
     );
 
@@ -211,6 +239,7 @@ async fn run_task(agent_name: &str, task: &str, project: &Path, json: bool) -> R
         task: task.to_string(),
         project: project_root,
         agents_dir,
+        engineer_model,
     };
 
     let report = execute_run_task(params, llm).await;

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -2,23 +2,29 @@
 //!
 //! Why: provides the `tcode` binary that operators, agents, and TUI frontends
 //! use to interact with the per-project MPM orchestration harness. Phase 0
-//! defines the CLI surface (subcommands + flags) so that callers can depend on
-//! a stable interface while the underlying implementation is extracted from
-//! open-mpm across Phases 1–N of epic #587.
+//! defines the CLI surface (subcommands + flags); the `run-task` path is now a
+//! full PM→engineer execution (epic #1039 / #1034).
 //!
-//! What: thin clap CLI with subcommands. `run-task` is functional as of Phase 6;
-//! `serve` and `run-workflow` remain stubs.
+//! What: thin clap CLI. `run-task` resolves the agents dir, validates the agent
+//! name + project path, builds the real OpenRouter `LlmClient` from env, and
+//! delegates to `trusty_code::run_task::execute_run_task`, then prints a human or
+//! `--json` report and exits with the report's meaningful exit code. `serve` and
+//! `run-workflow` remain stubs.
 //!
 //! Test: `cargo run -p trusty-code -- --version` must exit 0 and print the
-//! crate version. `tcode run-task <agent> <task> --project <path>` must
-//! locate the agent config, validate it, and report readiness.
+//! crate version. The execution path is covered by `trusty_code::run_task::tests`
+//! (offline, mocked LLM); the binary handler is a thin wrapper over that.
 
 use std::path::{Path, PathBuf};
 use std::process;
+use std::sync::Arc;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing::info;
+
+use trusty_code::llm::{LlmClient, LlmClientConfig, LlmClientTrait};
+use trusty_code::run_task::{ExitCode, RunTaskParams, execute_run_task};
 
 /// tcode — per-project Claude-Code-compatible MPM orchestration harness.
 #[derive(Parser)]
@@ -36,7 +42,7 @@ struct Cli {
 /// Top-level subcommands for `tcode`.
 ///
 /// Why: defines the stable CLI surface for all Phase 0+ callers. Stubs are
-/// replaced by real implementations as each phase of #587 lands.
+/// replaced by real implementations as each phase of #587/#1039 lands.
 /// What: clap enum; each variant maps to one subcommand.
 /// Test: `tcode --help` lists all variants; functional commands exit 0.
 #[derive(Subcommand)]
@@ -51,13 +57,14 @@ enum Command {
         project: PathBuf,
     },
 
-    /// Delegate a single task to a named agent and print the result.
+    /// Delegate a single task to a named agent and run it end-to-end.
     ///
     /// Loads the agent config from `<project>/.claude/agents/<agent>.toml`,
-    /// validates it, and reports the agent's capabilities. In a future phase
-    /// this will spawn the agent subprocess and return its result.
+    /// assembles its system prompt (with project `CLAUDE.md` context), runs the
+    /// PM through the agent loop, lets it delegate to the python-engineer
+    /// in-process, and prints the resulting diff, transcript, and usage.
     RunTask {
-        /// Agent name as declared in `.claude/agents/<name>.toml`.
+        /// Agent name as declared in `.claude/agents/<name>.toml` (e.g. `pm`).
         agent: String,
 
         /// Free-form task description passed to the agent's system prompt.
@@ -67,6 +74,10 @@ enum Command {
         /// Defaults to the current working directory.
         #[arg(long, short, value_name = "PATH", default_value = ".")]
         project: PathBuf,
+
+        /// Emit a machine-readable JSON report on stdout instead of human text.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Execute a named MPM workflow end-to-end.
@@ -83,8 +94,10 @@ enum Command {
     },
 }
 
-fn main() -> Result<()> {
-    // Initialise tracing to stderr (never stdout — stdout is the API transport).
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialise tracing to stderr (never stdout — stdout is the API transport,
+    // and `--json` mode requires stdout to carry only the JSON report).
     trusty_code::logging::init_tracing();
 
     let cli = Cli::parse();
@@ -102,7 +115,8 @@ fn main() -> Result<()> {
             agent,
             task,
             project,
-        } => run_task(&agent, &task, &project),
+            json,
+        } => run_task(&agent, &task, &project, json).await,
 
         Command::RunWorkflow { name, project } => {
             eprintln!(
@@ -116,7 +130,7 @@ fn main() -> Result<()> {
 
 /// Validate that `agent_name` contains only safe filesystem characters.
 ///
-/// Why: The LLM supplies `agent_name` which is joined into a filesystem path
+/// Why: The agent name is joined into a filesystem path
 /// (`<agents_dir>/<agent_name>.toml`). Without this guard a crafted name such
 /// as `../../etc/passwd` escapes the agents directory and enables path
 /// traversal. Restricting to `[a-zA-Z0-9_-]` is safe, predictable, and covers
@@ -140,100 +154,99 @@ fn validate_agent_name(agent_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Execute `tcode run-task`: validate agent config and report readiness.
+/// Execute `tcode run-task`: run the PM→engineer pipeline and print the report.
 ///
-/// Why: Phase 6 establishes the public API entry point for single-task
-/// dispatch so callers and integration tests have a stable interface to target
-/// before the subprocess runner is wired in (Phase 3b/5).
-/// What: Locates the project `.claude/agents/<agent>.toml`, loads and validates
-/// the config, then prints a JSON-structured status line to stdout. Exits 0 on
-/// success, non-zero on error.
-/// Test: `cargo run -p trusty-code -- run-task engineer "write a test"
-///        --project /path/to/project` exits 0 when engineer.toml exists.
-fn run_task(agent_name: &str, task: &str, project: &Path) -> Result<()> {
-    // Guard against path traversal via LLM-supplied agent_name.
+/// Why: This is the binary-layer wrapper over the library orchestrator. It owns
+/// only the concerns that are genuinely CLI-shaped — argument validation, env
+/// key/model resolution, output mode, and process exit codes — and delegates all
+/// orchestration to `trusty_code::run_task::execute_run_task` (which is fully
+/// unit-tested offline). When `--json` is set, only the JSON report is written to
+/// stdout; logs always go to stderr.
+/// What: Validates the agent name and project path (traversal guards), locates the
+/// agents dir, builds the real `LlmClient` from `OPENROUTER_API_KEY`, runs
+/// `execute_run_task`, prints the human or JSON report, and exits with the
+/// report's `ExitCode`. A missing API key is a config error (exit 2).
+/// Test: Orchestration is covered by `run_task::tests`; the wrapper is exercised
+/// manually via `tcode run-task pm "<task>" --project <path>`.
+async fn run_task(agent_name: &str, task: &str, project: &Path, json: bool) -> Result<()> {
     if let Err(e) = validate_agent_name(agent_name) {
         eprintln!("tcode run-task: {e}");
-        process::exit(1);
+        process::exit(ExitCode::ConfigError.code());
     }
 
-    // Resolve canonical project root.
-    let project_root = project
-        .canonicalize()
-        .unwrap_or_else(|_| project.to_path_buf());
+    // Resolve canonical project root (path-traversal-safe: canonicalize collapses
+    // any `..` so the project root is a real, existing directory).
+    let project_root = match project.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "tcode run-task: invalid --project path '{}': {e}",
+                project.display()
+            );
+            process::exit(ExitCode::ConfigError.code());
+        }
+    };
 
-    // Locate the agents directory — prefer `.claude/agents`, fall back to
-    // `.open-mpm/agents` for open-mpm-compatible projects.
     let agents_dir = locate_agents_dir(&project_root);
 
     info!(
         agent = agent_name,
         project = %project_root.display(),
         agents_dir = %agents_dir.display(),
-        "tcode run-task: locating agent config"
+        json,
+        "tcode run-task: starting"
     );
 
-    // Discover available agents for helpful error messages.
-    let available = trusty_code::agents::discover_agents(&agents_dir);
-    let available_names: Vec<&str> = available.iter().map(|(n, _)| n.as_str()).collect();
+    // Build the real OpenRouter client from env. A missing key is a config error.
+    let llm: Arc<dyn LlmClientTrait> = match build_llm_client() {
+        Ok(client) => client,
+        Err(e) => {
+            eprintln!("tcode run-task: {e}");
+            process::exit(ExitCode::ConfigError.code());
+        }
+    };
 
-    // Locate the agent's TOML.
-    let agent_toml = agents_dir.join(format!("{agent_name}.toml"));
-    if !agent_toml.exists() {
-        let available_str = if available_names.is_empty() {
-            "(none found)".to_string()
-        } else {
-            available_names.join(", ")
-        };
-        eprintln!(
-            "tcode run-task: unknown agent '{agent_name}'. \
-             Available agents: {available_str}. \
-             Check that {agent_toml} exists.",
-            agent_toml = agent_toml.display()
-        );
-        process::exit(1);
+    let params = RunTaskParams {
+        agent: agent_name.to_string(),
+        task: task.to_string(),
+        project: project_root,
+        agents_dir,
+    };
+
+    let report = execute_run_task(params, llm).await;
+
+    // Print the report. In `--json` mode stdout carries only the JSON document.
+    if json {
+        println!("{}", report.render_json());
+    } else {
+        println!("{}", report.render_human());
     }
 
-    // Load and validate the config.
-    let cfg = trusty_code::agents::AgentConfig::load(&agent_toml).unwrap_or_else(|e| {
-        eprintln!("tcode run-task: failed to load agent config: {e}");
-        process::exit(1);
-    });
+    process::exit(report.exit.code());
+}
 
-    let model = cfg
-        .agent
-        .model
-        .as_deref()
-        .or(cfg.llm.model_override.as_deref())
-        .unwrap_or("(default)");
-
-    // Char-safe truncation: slicing bytes at offset 80 panics when a multi-byte
-    // UTF-8 character straddles the boundary. Collecting the first 80 chars is
-    // always valid regardless of the Unicode content of the task string.
-    let task_preview: String = task.chars().take(80).collect();
-
-    info!(
-        agent = agent_name,
-        model,
-        task_preview = task_preview.as_str(),
-        "tcode run-task: agent config validated"
-    );
-
-    // Emit a structured status line so machine callers can parse it.
-    // In a future phase this transitions to actually spawning the agent.
-    println!(
-        "{}",
-        serde_json::json!({
-            "status": "ready",
-            "agent": agent_name,
-            "model": model,
-            "task_len": task.len(),
-            "config": agent_toml.display().to_string(),
-            "note": "subprocess dispatch not yet wired (#587 Phase 3b/5)"
-        })
-    );
-
-    Ok(())
+/// Build the real OpenRouter `LlmClient` from `OPENROUTER_API_KEY`.
+///
+/// Why: The binary is the only place that reads the API key from the environment
+/// (library code never touches `std::env` for secrets). Attribution headers help
+/// OpenRouter dashboards label tcode traffic.
+/// What: Reads the key via `LlmClientConfig::from_env`, attaches referer/title,
+/// and constructs the client. Returns a descriptive error when the key is unset.
+/// Test: Exercised manually (a live run requires a real key); the offline tests
+/// inject a mock client instead.
+fn build_llm_client() -> Result<Arc<dyn LlmClientTrait>> {
+    let config = LlmClientConfig::from_env()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "OPENROUTER_API_KEY is required for run-task ({e}). \
+                 Export it before running, e.g. `export OPENROUTER_API_KEY=sk-or-...`."
+            )
+        })?
+        .with_referer("https://github.com/bobmatnyc/trusty-tools")
+        .with_title("trusty-code run-task");
+    let client = LlmClient::from_config(config)
+        .map_err(|e| anyhow::anyhow!("failed to build LLM client: {e}"))?;
+    Ok(Arc::new(client))
 }
 
 /// Locate the agents directory for the given project root.
@@ -263,8 +276,9 @@ mod tests {
 
     /// A path-traversal agent name is rejected.
     ///
-    /// Why: Guards the `agents_dir.join(format!("{agent_name}.toml"))` call in
-    /// `run_task` against LLM-supplied names that escape the agents directory.
+    /// Why: Guards the `agents_dir.join(format!("{agent_name}.toml"))` path
+    /// construction in the run-task pipeline against names that escape the agents
+    /// directory.
     /// What: Asserts that `../../etc/passwd` and similar strings fail validation.
     /// Test: This test.
     #[test]
@@ -298,10 +312,11 @@ mod tests {
     /// A well-formed agent name is accepted.
     ///
     /// Why: Verifies the allowlist does not over-reject legitimate names.
-    /// What: Asserts that common agent names (`engineer`, `qa-agent`, etc.) pass.
+    /// What: Asserts that common agent names (`pm`, `qa-agent`, etc.) pass.
     /// Test: This test.
     #[test]
     fn validate_agent_name_accepts_valid() {
+        assert!(validate_agent_name("pm").is_ok());
         assert!(validate_agent_name("engineer").is_ok());
         assert!(validate_agent_name("qa-agent").is_ok());
         assert!(validate_agent_name("python_engineer").is_ok());

--- a/crates/trusty-code/src/project_context/mod.rs
+++ b/crates/trusty-code/src/project_context/mod.rs
@@ -1,0 +1,300 @@
+//! Project-context ingestion — load `CLAUDE.md` for prompt injection (#1033).
+//!
+//! Why: A Claude-Code-compatible harness must give the PM and every sub-agent
+//! the same project-specific rules a human Claude Code session would see — the
+//! `CLAUDE.md` at the project root. The parity prompt assembler (#1032) already
+//! accepts a verbatim project-context section; this module is the missing piece
+//! that *reads* that section off disk, bounds its size so a runaway file cannot
+//! blow the model's context budget, and degrades gracefully when no file exists.
+//! What: [`load_project_context`] walks the project root for `CLAUDE.md` (and,
+//! when present, the nested `.claude/CLAUDE.md` Claude-Code convention), reads
+//! the first one found, caps it at [`MAX_CONTEXT_BYTES`], and — on truncation —
+//! appends a provenance note so the model knows the context was clipped. A
+//! missing file yields `None`, never an error.
+//! Test: `project_context::tests` cover present/oversized/missing/positioning.
+
+use std::path::{Path, PathBuf};
+
+/// Maximum number of bytes of `CLAUDE.md` content injected into a prompt.
+///
+/// Why: `CLAUDE.md` can grow without bound (this very repo's is tens of KB).
+/// Injecting it whole would dominate the model's context window and inflate
+/// per-call cost. 16 KiB is a generous budget for project rules while keeping
+/// the injected surface bounded and comparable across runs.
+/// What: 16 * 1024 bytes. Content longer than this is truncated on a UTF-8
+/// boundary and annotated (see [`truncate_with_note`]).
+/// Test: `oversized_context_is_truncated_with_note`.
+pub const MAX_CONTEXT_BYTES: usize = 16 * 1024;
+
+/// Canonical filename for Claude-Code project context.
+///
+/// Why: Centralises the magic string so the root and nested lookups agree.
+/// What: The literal `"CLAUDE.md"`.
+/// Test: Exercised by every loader test.
+const CLAUDE_MD: &str = "CLAUDE.md";
+
+/// Load the project's `CLAUDE.md` context, size-capped and provenance-annotated.
+///
+/// Why: The PM and sub-agents must see the project's own rules; this is the
+/// single entry point the `run-task` handler and the in-process runner use to
+/// obtain the verbatim context section for `assemble_system_prompt`.
+/// What: Resolves the first existing of `<root>/CLAUDE.md` then
+/// `<root>/.claude/CLAUDE.md`; reads it; returns `Some(content)` capped at
+/// [`MAX_CONTEXT_BYTES`] (with a truncation note appended when clipped). Returns
+/// `None` when no file exists or the file cannot be read (absence is not an
+/// error — a project simply may not define project context).
+/// Test: `loads_root_claude_md`, `loads_nested_claude_md`,
+/// `missing_file_returns_none`, `oversized_context_is_truncated_with_note`.
+pub fn load_project_context(project_root: &Path) -> Option<String> {
+    let path = locate_claude_md(project_root)?;
+    // A read failure (permissions, races) is treated as "no context" rather than
+    // a hard error: the harness must still run with just the BASE + agent prompt.
+    let raw = std::fs::read_to_string(&path).ok()?;
+    Some(truncate_with_note(&raw, MAX_CONTEXT_BYTES))
+}
+
+/// Locate the project `CLAUDE.md`, preferring the root then the `.claude/` nest.
+///
+/// Why: Claude Code reads a root `CLAUDE.md`; some projects nest it under
+/// `.claude/`. Checking both (root first) matches what a human session sees
+/// without forcing a particular layout.
+/// What: Returns the first existing path of `<root>/CLAUDE.md` or
+/// `<root>/.claude/CLAUDE.md`; `None` when neither exists.
+/// Test: `loads_root_claude_md`, `loads_nested_claude_md`,
+/// `missing_file_returns_none`.
+fn locate_claude_md(project_root: &Path) -> Option<PathBuf> {
+    let root = project_root.join(CLAUDE_MD);
+    if root.is_file() {
+        return Some(root);
+    }
+    let nested = project_root.join(".claude").join(CLAUDE_MD);
+    if nested.is_file() {
+        return Some(nested);
+    }
+    None
+}
+
+/// Truncate `content` to at most `max_bytes`, appending a provenance note when
+/// clipping occurs.
+///
+/// Why: A bounded context must remain valid UTF-8 (the model receives a string,
+/// and slicing mid-codepoint would panic) and must tell the model it is reading
+/// a partial file so it does not assume the rules are complete.
+/// What: If `content` is within budget, returns it unchanged. Otherwise truncates
+/// at the largest UTF-8 char boundary `<= max_bytes`, then appends
+/// `"\n\n[CLAUDE.md truncated to N bytes of M total]"` where `N` is the kept byte
+/// count and `M` the original length.
+/// Test: `oversized_context_is_truncated_with_note`,
+/// `within_budget_is_returned_verbatim`, `truncation_respects_utf8_boundary`.
+fn truncate_with_note(content: &str, max_bytes: usize) -> String {
+    if content.len() <= max_bytes {
+        return content.to_string();
+    }
+
+    // Find the largest char boundary at or below max_bytes so the slice is valid
+    // UTF-8 even when a multi-byte codepoint straddles the cap.
+    let mut end = max_bytes;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    let kept = &content[..end];
+    format!(
+        "{kept}\n\n[CLAUDE.md truncated to {end} bytes of {total} total]",
+        total = content.len()
+    )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A root `CLAUDE.md` is loaded and its content returned verbatim.
+    ///
+    /// Why: The common case — the PM must see the project's rules from the root
+    /// file exactly as written.
+    /// What: Write `<root>/CLAUDE.md`; assert `load_project_context` returns its
+    /// exact content.
+    /// Test: this test.
+    #[test]
+    fn loads_root_claude_md() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("CLAUDE.md"), "PROJECT RULES: be concise.")
+            .expect("write CLAUDE.md");
+
+        let ctx = load_project_context(tmp.path()).expect("context loaded");
+        assert_eq!(ctx, "PROJECT RULES: be concise.");
+    }
+
+    /// A nested `.claude/CLAUDE.md` is loaded when no root file exists.
+    ///
+    /// Why: Some projects nest their context; the loader must find it too.
+    /// What: Write only `<root>/.claude/CLAUDE.md`; assert it is returned.
+    /// Test: this test.
+    #[test]
+    fn loads_nested_claude_md() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested = tmp.path().join(".claude");
+        std::fs::create_dir_all(&nested).expect("mkdir .claude");
+        std::fs::write(nested.join("CLAUDE.md"), "NESTED RULES").expect("write nested");
+
+        let ctx = load_project_context(tmp.path()).expect("nested context loaded");
+        assert_eq!(ctx, "NESTED RULES");
+    }
+
+    /// The root file wins over a nested one when both exist.
+    ///
+    /// Why: Precedence must be deterministic; a human session reads the root.
+    /// What: Write both; assert the root content is returned.
+    /// Test: this test.
+    #[test]
+    fn root_takes_precedence_over_nested() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("CLAUDE.md"), "ROOT").expect("write root");
+        let nested = tmp.path().join(".claude");
+        std::fs::create_dir_all(&nested).expect("mkdir .claude");
+        std::fs::write(nested.join("CLAUDE.md"), "NESTED").expect("write nested");
+
+        let ctx = load_project_context(tmp.path()).expect("loaded");
+        assert_eq!(ctx, "ROOT", "root CLAUDE.md must take precedence");
+    }
+
+    /// A project with no `CLAUDE.md` yields `None` (no error).
+    ///
+    /// Why: Absence must be handled gracefully — the harness still runs with just
+    /// the BASE + agent prompt.
+    /// What: Empty tempdir; assert `None`.
+    /// Test: this test.
+    #[test]
+    fn missing_file_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            load_project_context(tmp.path()).is_none(),
+            "missing CLAUDE.md must return None, not error"
+        );
+    }
+
+    /// Content within budget is returned verbatim (no note).
+    ///
+    /// Why: The truncation note must only appear when clipping actually happens.
+    /// What: A short file is returned byte-for-byte with no annotation.
+    /// Test: this test.
+    #[test]
+    fn within_budget_is_returned_verbatim() {
+        let small = "a".repeat(100);
+        let out = truncate_with_note(&small, MAX_CONTEXT_BYTES);
+        assert_eq!(out, small);
+        assert!(!out.contains("truncated"), "no note for in-budget content");
+    }
+
+    /// Oversized content is truncated and annotated with a provenance note.
+    ///
+    /// Why: A runaway `CLAUDE.md` must not blow the context budget, and the model
+    /// must know it received a partial file.
+    /// What: Build content larger than a tiny cap; assert the result is within the
+    /// cap-plus-note, that it carries the provenance note, and that the kept
+    /// prefix matches the original.
+    /// Test: this test.
+    #[test]
+    fn oversized_context_is_truncated_with_note() {
+        let content = "x".repeat(50);
+        let out = truncate_with_note(&content, 10);
+        assert!(
+            out.starts_with(&"x".repeat(10)),
+            "kept prefix must be the first 10 bytes"
+        );
+        assert!(
+            out.contains("[CLAUDE.md truncated to 10 bytes of 50 total]"),
+            "must carry the provenance note, got: {out}"
+        );
+    }
+
+    /// Truncation never splits a multi-byte UTF-8 codepoint.
+    ///
+    /// Why: Slicing a `&str` mid-codepoint panics; the cap must back off to a
+    /// char boundary so any content (incl. emoji / accented text) is safe.
+    /// What: Content of multi-byte chars truncated at a cap that lands mid-char;
+    /// assert the result is valid UTF-8 (it is, by construction) and the kept
+    /// length is `<= cap`.
+    /// Test: this test.
+    #[test]
+    fn truncation_respects_utf8_boundary() {
+        // "é" is 2 bytes in UTF-8; a cap of 5 lands mid-char on the 3rd "é".
+        let content = "é".repeat(10); // 20 bytes
+        let out = truncate_with_note(&content, 5);
+        // The kept portion before the note must be 4 bytes (two full "é"), not 5.
+        let note_start = out.find("\n\n[CLAUDE.md").expect("note present");
+        assert_eq!(&out[..note_start], "éé", "must back off to a char boundary");
+    }
+
+    /// Loaded context lands in the assembled prompt AFTER the agent prompt.
+    ///
+    /// Why: Parity-spec §2 fixes section order as BASE → agent prompt → project
+    /// context. This test ties `load_project_context` to `assemble_system_prompt`
+    /// to prove the injected context is positioned correctly (criterion d),
+    /// not merely present.
+    /// What: Build an `AgentConfig` with a distinctive agent-prompt marker; load a
+    /// project `CLAUDE.md` with its own marker; assemble; assert both markers are
+    /// present and the project marker appears strictly after the agent marker.
+    /// Test: this test.
+    #[test]
+    fn loaded_context_is_positioned_after_agent_prompt() {
+        use crate::agents::AgentConfig;
+        use crate::agents::config::{AgentInfo, SystemPrompt};
+        use crate::prompt::assemble_system_prompt;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("CLAUDE.md"), "PROJECT-CONTEXT-MARKER").expect("write");
+        let ctx = load_project_context(tmp.path()).expect("loaded");
+
+        let config = AgentConfig {
+            agent: AgentInfo {
+                name: "pm".into(),
+                ..Default::default()
+            },
+            system_prompt: SystemPrompt {
+                content: "AGENT-PROMPT-MARKER".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let prompt = assemble_system_prompt(&config, Some(&ctx), None);
+        let agent_at = prompt
+            .find("AGENT-PROMPT-MARKER")
+            .expect("agent marker present");
+        let ctx_at = prompt
+            .find("PROJECT-CONTEXT-MARKER")
+            .expect("project context marker present");
+        assert!(
+            ctx_at > agent_at,
+            "project context must be positioned after the agent prompt"
+        );
+    }
+
+    /// `load_project_context` applies the byte cap end-to-end through the loader.
+    ///
+    /// Why: Guards the integration of file read + truncation, not just the helper.
+    /// What: Write a file larger than `MAX_CONTEXT_BYTES`; assert the loaded
+    /// context carries the truncation note and the kept body is within budget.
+    /// Test: this test.
+    #[test]
+    fn loader_enforces_byte_cap() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let big = "z".repeat(MAX_CONTEXT_BYTES + 4096);
+        std::fs::write(tmp.path().join("CLAUDE.md"), &big).expect("write big");
+
+        let ctx = load_project_context(tmp.path()).expect("loaded");
+        assert!(
+            ctx.contains("[CLAUDE.md truncated to"),
+            "oversized file must be truncated with a note"
+        );
+        let note_start = ctx.find("\n\n[CLAUDE.md").expect("note present");
+        assert!(
+            note_start <= MAX_CONTEXT_BYTES,
+            "kept body must be within the byte cap"
+        );
+    }
+}

--- a/crates/trusty-code/src/run_task/diff.rs
+++ b/crates/trusty-code/src/run_task/diff.rs
@@ -1,0 +1,275 @@
+//! Working-tree diff capture for `run-task` (#1034).
+//!
+//! Why: A run's primary artifact is the change it made to the project. The
+//! report must show that change as a diff so an operator (or the PM smoke-test)
+//! can see exactly what the engineer wrote. When the project is a git repo we
+//! capture `git diff` before vs. after the run; when it is not, we fall back to a
+//! recursive file-content snapshot compared before vs. after.
+//! What: `capture_snapshot` records the project state; `diff_snapshots` renders a
+//! unified-ish textual diff between two snapshots. `Snapshot` is the captured
+//! state (git working-tree diff text, or a map of relative path → content).
+//! Test: `run_task::tests` drive a mocked engineer that writes a file and assert
+//! the rendered diff names that file and its new content.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+
+/// A point-in-time capture of the project's mutable state.
+///
+/// Why: To diff "before" against "after" we must snapshot the same shape twice.
+/// Git repos and plain directories need different representations, so the snapshot
+/// is an enum that the differ matches on.
+/// What: `Git` holds the textual `git diff` of the working tree against HEAD at
+/// capture time; `Files` holds a sorted map of relative path → file content for
+/// non-git projects.
+/// Test: `run_task::tests::diff_reflects_engineer_file_change`.
+#[derive(Debug, Clone)]
+pub enum Snapshot {
+    /// Git working-tree diff (vs. HEAD) captured at this moment.
+    Git(String),
+    /// Recursive file-content map for a non-git project.
+    Files(BTreeMap<String, String>),
+}
+
+/// Capture the project's current state for later diffing.
+///
+/// Why: The run needs a "before" and an "after" of identical shape; this is the
+/// single capture entry point both phases call.
+/// What: If `root` is inside a git work tree, returns `Snapshot::Git` with the
+/// current `git diff` (unstaged + staged via `HEAD`). Otherwise returns
+/// `Snapshot::Files` with a recursive content map (skipping `.git`).
+/// Test: `run_task::tests::diff_reflects_engineer_file_change` (Files path) and
+/// `git_snapshot_is_used_in_repo` (Git path).
+pub fn capture_snapshot(root: &Path) -> Snapshot {
+    if is_git_repo(root) {
+        Snapshot::Git(git_diff(root))
+    } else {
+        Snapshot::Files(snapshot_files(root))
+    }
+}
+
+/// Render a textual diff between a before and after snapshot.
+///
+/// Why: The report shows the run's net change; this produces that text for both
+/// the human and JSON outputs.
+/// What: For `Git`, returns the *after* diff (git already expresses the full
+/// working-tree change vs. HEAD, so the after-snapshot IS the diff). For `Files`,
+/// emits per-file `+++ added`, `--- removed`, or a content delta for changed
+/// files, comparing the two maps. Returns an empty string when nothing changed.
+/// Test: `run_task::tests::diff_reflects_engineer_file_change`.
+pub fn diff_snapshots(before: &Snapshot, after: &Snapshot) -> String {
+    match (before, after) {
+        // Git already diffs vs HEAD, so the after-snapshot is the authoritative
+        // working-tree change. When it is byte-identical to the before-snapshot
+        // the run changed nothing — report an empty diff so the caller can emit
+        // the distinct "no changes" exit code.
+        (Snapshot::Git(before_diff), Snapshot::Git(after_diff)) => {
+            if before_diff == after_diff {
+                String::new()
+            } else {
+                after_diff.clone()
+            }
+        }
+        (Snapshot::Files(before_map), Snapshot::Files(after_map)) => {
+            diff_file_maps(before_map, after_map)
+        }
+        // Mixed snapshot kinds cannot happen (capture is deterministic for a
+        // given root), but handle it defensively rather than panicking.
+        _ => String::new(),
+    }
+}
+
+/// Whether `root` is inside a git work tree.
+///
+/// Why: Chooses the snapshot strategy; a git repo gets a real `git diff`.
+/// What: Runs `git rev-parse --is-inside-work-tree` and checks for a `true`
+/// stdout. Any failure (git absent, not a repo) yields `false`.
+/// Test: Indirect via snapshot tests.
+fn is_git_repo(root: &Path) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
+        .unwrap_or(false)
+}
+
+/// Capture the git working-tree diff against HEAD.
+///
+/// Why: Expresses every uncommitted change (the run's net edit) in standard
+/// unified-diff form. Using `HEAD` includes both staged and unstaged edits.
+/// What: Runs `git diff HEAD` in `root`; returns stdout (empty on failure or no
+/// change). Untracked files are added with `--no-color` and intent-to-add so new
+/// files appear in the diff.
+/// Test: `run_task::tests::git_snapshot_is_used_in_repo`.
+fn git_diff(root: &Path) -> String {
+    // Stage intent-to-add for untracked files so brand-new files show in the diff
+    // without actually committing anything (`-N` records only the path).
+    let _ = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["add", "-AN"])
+        .output();
+
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["diff", "--no-color", "HEAD"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+        .unwrap_or_default()
+}
+
+/// Recursively snapshot file contents under `root` (skipping `.git`).
+///
+/// Why: Non-git projects still need a before/after comparison; a content map is
+/// the simplest faithful representation.
+/// What: Walks `root`, reading each regular file into a `relative-path → content`
+/// map. Binary/unreadable files are stored as a placeholder marker. Skips the
+/// `.git` directory and any path component starting with `.git`.
+/// Test: `run_task::tests::diff_reflects_engineer_file_change`.
+fn snapshot_files(root: &Path) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    collect_files(root, root, &mut map);
+    map
+}
+
+/// Recursive helper for `snapshot_files`.
+///
+/// Why: Directory walking needs the original `base` to compute relative paths.
+/// What: Iterates `dir`; recurses into subdirs (except `.git`); records readable
+/// files keyed by their path relative to `base`.
+/// Test: Indirect via `snapshot_files` and the diff tests.
+fn collect_files(base: &Path, dir: &Path, map: &mut BTreeMap<String, String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with(".git") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_files(base, &path, map);
+        } else if path.is_file() {
+            let rel = path
+                .strip_prefix(base)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .to_string();
+            let content =
+                std::fs::read_to_string(&path).unwrap_or_else(|_| "<binary or unreadable>".into());
+            map.insert(rel, content);
+        }
+    }
+}
+
+/// Diff two file-content maps into a readable change report.
+///
+/// Why: For non-git projects this is the only way to show what changed; the
+/// report compares the before/after maps key by key.
+/// What: Emits `+++ added: <path>` (with content) for new keys, `--- removed:
+/// <path>` for deleted keys, and a `~~~ changed: <path>` block with old→new
+/// content for keys whose content differs. Unchanged keys are omitted. Returns an
+/// empty string when the maps are identical.
+/// Test: `run_task::tests::diff_reflects_engineer_file_change`.
+fn diff_file_maps(before: &BTreeMap<String, String>, after: &BTreeMap<String, String>) -> String {
+    let mut out = String::new();
+
+    for (path, content) in after {
+        match before.get(path) {
+            None => {
+                out.push_str(&format!("+++ added: {path}\n{content}\n"));
+            }
+            Some(old) if old != content => {
+                out.push_str(&format!(
+                    "~~~ changed: {path}\n--- before\n{old}\n+++ after\n{content}\n"
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+
+    for path in before.keys() {
+        if !after.contains_key(path) {
+            out.push_str(&format!("--- removed: {path}\n"));
+        }
+    }
+
+    out
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// File-map diff reports an added file with its content.
+    ///
+    /// Why: The non-git path must surface a brand-new file as an addition.
+    /// What: Before is empty; after has one file; assert the rendered diff names
+    /// the file and includes its content.
+    /// Test: this test.
+    #[test]
+    fn file_map_diff_reports_addition() {
+        let before = BTreeMap::new();
+        let mut after = BTreeMap::new();
+        after.insert("hello.py".to_string(), "print('hi')".to_string());
+
+        let diff = diff_file_maps(&before, &after);
+        assert!(diff.contains("+++ added: hello.py"), "diff: {diff}");
+        assert!(diff.contains("print('hi')"), "diff: {diff}");
+    }
+
+    /// File-map diff reports a changed file with old and new content.
+    ///
+    /// Why: Edits to existing files must be visible.
+    /// What: Same key, different content; assert a `changed` block with both.
+    /// Test: this test.
+    #[test]
+    fn file_map_diff_reports_change() {
+        let mut before = BTreeMap::new();
+        before.insert("a.txt".to_string(), "old".to_string());
+        let mut after = BTreeMap::new();
+        after.insert("a.txt".to_string(), "new".to_string());
+
+        let diff = diff_file_maps(&before, &after);
+        assert!(diff.contains("~~~ changed: a.txt"), "diff: {diff}");
+        assert!(diff.contains("old") && diff.contains("new"), "diff: {diff}");
+    }
+
+    /// Identical maps produce an empty diff (no-op detection).
+    ///
+    /// Why: A run that changes nothing must report no diff, enabling the
+    /// distinct "no changes" exit code.
+    /// What: Equal maps; assert empty string.
+    /// Test: this test.
+    #[test]
+    fn identical_maps_produce_empty_diff() {
+        let mut m = BTreeMap::new();
+        m.insert("x".to_string(), "y".to_string());
+        assert!(diff_file_maps(&m, &m).is_empty());
+    }
+
+    /// `capture_snapshot` + `diff_snapshots` surface a new file in a non-git dir.
+    ///
+    /// Why: End-to-end guard for the non-git capture/diff path.
+    /// What: Snapshot an empty dir, write a file, snapshot again, diff; assert the
+    /// file appears as an addition.
+    /// Test: this test.
+    #[test]
+    fn capture_and_diff_non_git_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let before = capture_snapshot(tmp.path());
+        std::fs::write(tmp.path().join("new.rs"), "fn main() {}").expect("write");
+        let after = capture_snapshot(tmp.path());
+
+        let diff = diff_snapshots(&before, &after);
+        assert!(diff.contains("+++ added: new.rs"), "diff: {diff}");
+        assert!(diff.contains("fn main()"), "diff: {diff}");
+    }
+}

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -1,0 +1,307 @@
+//! `tcode run-task` end-to-end execution (#1034, #1035).
+//!
+//! Why: This is the closer that makes the `tcode` binary actually run a task. It
+//! wires every M1 piece together: load the project `CLAUDE.md` context (#1033),
+//! assemble the PM system prompt, run the PM through an `AgentLoop` against the
+//! real (or mocked) `LlmClient`, let the PM delegate to the `python-engineer` via
+//! the `DelegateToAgentTool` + `InProcessAgentRunner`, and have the engineer run
+//! its own loop with fs/bash tools scoped to the project. The run captures a diff
+//! of the working tree, the PM+engineer transcript, and aggregated token/cost
+//! usage, then renders both a human and a JSON report with meaningful exit codes.
+//! What: `RunTaskParams` carries the CLI inputs; `execute_run_task` is the async
+//! orchestrator returning a `RunReport`. The LLM client is injected so production
+//! passes a real `LlmClient` and tests pass a scripted mock — no live key needed.
+//! Test: `run_task::tests` drive the whole PM→engineer path offline.
+
+mod diff;
+mod recorder;
+mod report;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::agent_loop::{AgentLoop, AgentLoopConfig};
+use crate::agents::AgentConfig;
+use crate::llm::LlmClientTrait;
+use crate::project_context::load_project_context;
+use crate::prompt::assemble_system_prompt;
+use crate::provider::resolve_model;
+use crate::runner::{InProcessAgentRunner, RegistryFactory};
+use crate::tools::{
+    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, ReadFileTool, RunContext,
+    ToolRegistry, WriteFileTool,
+};
+
+pub use recorder::{RecordingLlmClient, SharedTranscript, TurnRecord};
+pub use report::{ExitCode, RunReport, aggregate_usage};
+
+/// Default bash timeout for the engineer's tools, in seconds.
+const ENGINEER_BASH_TIMEOUT_SECS: u64 = 120;
+
+/// Inputs to a single `run-task` invocation, parsed from the CLI.
+///
+/// Why: Bundling the inputs keeps `execute_run_task`'s signature stable as flags
+/// are added and lets the binary layer construct one value from clap.
+/// What: `agent` is the top-level (PM) agent name; `task` is the request; `project`
+/// is the canonical project root; `agents_dir` is where `<agent>.toml` live.
+/// Test: `run_task::tests` build these directly.
+#[derive(Debug, Clone)]
+pub struct RunTaskParams {
+    /// Top-level agent name (typically `"pm"`).
+    pub agent: String,
+    /// Free-form task description.
+    pub task: String,
+    /// Canonical project root.
+    pub project: PathBuf,
+    /// Directory holding `<agent>.toml` configs.
+    pub agents_dir: PathBuf,
+}
+
+/// Execute a `run-task` end-to-end and return the rendered report.
+///
+/// Why: The single orchestration entry point the binary calls (with a real
+/// `LlmClient`) and tests call (with a scripted mock). Keeping the LLM client as
+/// an injected `Arc<dyn LlmClientTrait>` is what makes the whole path testable
+/// offline without a network call or an API key.
+/// What: Loads the PM config, assembles its prompt (BASE + PM prompt + project
+/// `CLAUDE.md`), builds the engineer runner (fs/bash scoped to the project, with
+/// the optional per-run model override), wraps it in the PM's
+/// `DelegateToAgentTool`, snapshots the working tree, runs the PM `AgentLoop`,
+/// snapshots again, and assembles a `RunReport` (diff + transcript + usage/cost +
+/// exit code). A PM-config or loop error yields a `ConfigError`/`RunFailure`
+/// report rather than a panic.
+/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`,
+/// `diff_reflects_engineer_file_change`, `usage_and_cost_aggregate_end_to_end`,
+/// `exit_code_reflects_run_failure`.
+pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait>) -> RunReport {
+    let transcript: SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+
+    // Load the PM config; a missing/invalid config is a configuration error.
+    let pm_config =
+        match AgentConfig::load(&params.agents_dir.join(format!("{}.toml", params.agent))) {
+            Ok(cfg) => cfg,
+            Err(e) => return config_error_report(&params, &transcript, &format!("{e:#}")),
+        };
+
+    // Load project context (#1033) — absent file is fine.
+    let project_context = load_project_context(&params.project);
+
+    // Resolve the PM's own model (no per-call override for the PM).
+    let pm_model = resolve_model(&pm_config, None);
+
+    // Build the engineer runner, scoped to the project working dir, sharing the
+    // transcript (engineer turns are tagged "python-engineer").
+    let engineer_runner = build_engineer_runner(
+        Arc::clone(&llm),
+        &params,
+        project_context.clone(),
+        Arc::clone(&transcript),
+    );
+
+    // The PM's tool registry: just the delegate tool (the PM orchestrates; the
+    // engineer does the file work). Pre-flight validation uses the agents dir.
+    let mut pm_registry = ToolRegistry::new();
+    pm_registry.register(Arc::new(
+        DelegateToAgentTool::new(engineer_runner).with_config_dir(params.agents_dir.clone()),
+    ));
+
+    // The PM's loop uses a transcript-recording client tagged "pm".
+    let pm_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
+        Arc::clone(&llm),
+        "pm",
+        Arc::clone(&transcript),
+    ));
+
+    let pm_system = assemble_system_prompt(&pm_config, project_context.as_deref(), None);
+    let pm_loop = AgentLoop::new(
+        AgentLoopConfig {
+            model: pm_model.clone(),
+            ..AgentLoopConfig::default()
+        },
+        pm_llm,
+        Arc::new(pm_registry),
+    );
+
+    // Snapshot before, run the PM, snapshot after.
+    let before = diff::capture_snapshot(&params.project);
+    let pm_result = pm_loop.run(&pm_system, &params.task).await;
+    let after = diff::capture_snapshot(&params.project);
+
+    assemble_report(&params, &transcript, &pm_model, before, after, pm_result)
+}
+
+/// Build the in-process engineer runner with project-scoped fs/bash tools.
+///
+/// Why: The engineer must write/read/run inside the project and see the same
+/// project context as the PM. This wires a `RegistryFactory` that constructs fs +
+/// bash tools scoped to the project dir plus the project context, then routes the
+/// result through the per-run model-override seam (`apply_engineer_model_override`).
+/// What: Returns an `Arc<dyn AgentRunner>` the `DelegateToAgentTool` dispatches
+/// to. The engineer's own LLM turns are recorded under the "python-engineer" role.
+/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`.
+fn build_engineer_runner(
+    llm: Arc<dyn LlmClientTrait>,
+    params: &RunTaskParams,
+    project_context: Option<String>,
+    transcript: SharedTranscript,
+) -> Arc<dyn AgentRunner> {
+    let engineer_llm: Arc<dyn LlmClientTrait> =
+        Arc::new(RecordingLlmClient::new(llm, "python-engineer", transcript));
+
+    let factory: Arc<dyn RegistryFactory> = Arc::new(ProjectToolFactory {
+        project: params.project.clone(),
+    });
+
+    let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone());
+    if let Some(ctx) = project_context {
+        runner = runner.with_project_context(ctx);
+    }
+    apply_engineer_model_override(Arc::new(runner), params)
+}
+
+/// Builds the engineer's project-scoped tool registry for each delegation.
+///
+/// Why: The engineer needs real file and shell tools that cannot escape the
+/// project root. This factory constructs `read_file`, `write_file`, `edit`, and
+/// `bash` all scoped to `self.project` so the engineer operates only inside the
+/// project working tree.
+/// What: Implements `RegistryFactory::build`, returning an `Arc<ToolRegistry>`
+/// with the four tools; the runner then gates them by the engineer's
+/// `tools.allowed`.
+/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer` (the engineer's
+/// `write_file` actually writes into the project).
+struct ProjectToolFactory {
+    project: PathBuf,
+}
+
+#[async_trait]
+impl RegistryFactory for ProjectToolFactory {
+    async fn build(&self, _agent: &AgentConfig, _ctx: &RunContext) -> Arc<ToolRegistry> {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(ReadFileTool::new(&self.project)));
+        reg.register(Arc::new(WriteFileTool::new(&self.project)));
+        reg.register(Arc::new(EditTool::new(&self.project)));
+        reg.register(Arc::new(BashTool::new(
+            Some(self.project.clone()),
+            Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),
+        )));
+        Arc::new(reg)
+    }
+}
+
+/// Apply the per-run engineer-model override to the runner, if any.
+///
+/// Why: The engineer routes to its own configured model by default. The per-run
+/// override seam (#1035) lives here so `build_engineer_runner` stays agnostic to
+/// how (or whether) a model is pinned. In this milestone the seam is a
+/// pass-through; #1035 fills it with a model-pinning decorator.
+/// What: Returns the runner unchanged. The `_params` argument is the hook #1035
+/// reads `engineer_model` from.
+/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer` (default routing).
+fn apply_engineer_model_override(
+    runner: Arc<dyn AgentRunner>,
+    _params: &RunTaskParams,
+) -> Arc<dyn AgentRunner> {
+    runner
+}
+
+/// Drain the shared transcript into an owned `Vec`.
+///
+/// Why: The report owns its transcript; this lifts it out of the shared mutex.
+/// What: Clones the locked vector (empty on a poisoned lock — the run must not
+/// panic while building the report).
+/// Test: Exercised by every end-to-end test.
+fn drain_transcript(transcript: &SharedTranscript) -> Vec<TurnRecord> {
+    transcript.lock().map(|g| g.clone()).unwrap_or_default()
+}
+
+/// Build a `ConfigError` report (PM config missing/invalid).
+///
+/// Why: A configuration failure must produce a faithful report + exit code, not a
+/// panic, so callers can branch on it.
+/// What: Returns a `RunReport` with an empty diff, the (likely empty) transcript,
+/// zero usage, and `ExitCode::ConfigError`; the error text rides in the task line
+/// of the human form via a synthesized note.
+/// Test: `run_task::tests::missing_pm_config_is_config_error`.
+fn config_error_report(
+    params: &RunTaskParams,
+    transcript: &SharedTranscript,
+    err: &str,
+) -> RunReport {
+    RunReport {
+        agent: params.agent.clone(),
+        task: format!("{} [config error: {err}]", params.task),
+        diff: String::new(),
+        transcript: drain_transcript(transcript),
+        usage: crate::perf::TokenUsage::default(),
+        cost_usd: None,
+        exit: ExitCode::ConfigError,
+    }
+}
+
+/// Assemble the final report from the run's outcome.
+///
+/// Why: Centralises the mapping from (PM loop result, before/after snapshots) to a
+/// `RunReport` with the correct exit code so the success / no-change / failure
+/// branches never drift.
+/// What: On a PM-loop error → `RunFailure` (with whatever transcript accrued). On
+/// success → compute the diff; empty diff → `NoChanges`, else `Success`. Usage and
+/// cost are aggregated from the PM output (which already rolls up the engineer's
+/// usage via the shared client) and priced against the PM model.
+/// Test: `run_task::tests::*` (success, no-change, and failure paths).
+fn assemble_report(
+    params: &RunTaskParams,
+    transcript: &SharedTranscript,
+    pm_model: &str,
+    before: diff::Snapshot,
+    after: diff::Snapshot,
+    pm_result: Result<AgentOutput, crate::agent_loop::AgentLoopError>,
+) -> RunReport {
+    let turns = drain_transcript(transcript);
+
+    // A PM-loop error is a runtime failure; the transcript still reflects whatever
+    // turns ran before the error. The PM's `AgentOutput` content is not needed for
+    // the report — the transcript and diff are the authoritative artifacts.
+    if let Err(e) = pm_result {
+        return RunReport {
+            agent: params.agent.clone(),
+            task: format!("{} [run failure: {e}]", params.task),
+            diff: String::new(),
+            transcript: turns,
+            usage: crate::perf::TokenUsage::default(),
+            cost_usd: None,
+            exit: ExitCode::RunFailure,
+        };
+    }
+
+    let rendered_diff = diff::diff_snapshots(&before, &after);
+
+    // Sum usage across every recorded PM + engineer turn and price it against the
+    // PM (dominant) model. The PM's own `AgentOutput.usage` omits the engineer's
+    // tokens (they return as a tool-result string), so the transcript is the
+    // faithful total.
+    let (total_usage, cost) = aggregate_usage(&turns, pm_model);
+
+    let exit = if rendered_diff.trim().is_empty() {
+        ExitCode::NoChanges
+    } else {
+        ExitCode::Success
+    };
+
+    RunReport {
+        agent: params.agent.clone(),
+        task: params.task.clone(),
+        diff: rendered_diff,
+        transcript: turns,
+        usage: total_usage,
+        cost_usd: Some(cost),
+        exit,
+    }
+}

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -50,7 +50,8 @@ const ENGINEER_BASH_TIMEOUT_SECS: u64 = 120;
 /// Why: Bundling the inputs keeps `execute_run_task`'s signature stable as flags
 /// are added and lets the binary layer construct one value from clap.
 /// What: `agent` is the top-level (PM) agent name; `task` is the request; `project`
-/// is the canonical project root; `agents_dir` is where `<agent>.toml` live.
+/// is the canonical project root; `agents_dir` is where `<agent>.toml` live;
+/// `engineer_model` is the optional per-run engineer model override (#1035).
 /// Test: `run_task::tests` build these directly.
 #[derive(Debug, Clone)]
 pub struct RunTaskParams {
@@ -62,6 +63,9 @@ pub struct RunTaskParams {
     pub project: PathBuf,
     /// Directory holding `<agent>.toml` configs.
     pub agents_dir: PathBuf,
+    /// Optional per-run engineer model override (#1035). `None` routes the
+    /// engineer via its own config model.
+    pub engineer_model: Option<String>,
 }
 
 /// Execute a `run-task` end-to-end and return the rendered report.
@@ -196,20 +200,66 @@ impl RegistryFactory for ProjectToolFactory {
     }
 }
 
-/// Apply the per-run engineer-model override to the runner, if any.
+/// Apply the per-run engineer-model override to the runner, if any (#1035).
 ///
-/// Why: The engineer routes to its own configured model by default. The per-run
-/// override seam (#1035) lives here so `build_engineer_runner` stays agnostic to
-/// how (or whether) a model is pinned. In this milestone the seam is a
-/// pass-through; #1035 fills it with a model-pinning decorator.
-/// What: Returns the runner unchanged. The `_params` argument is the hook #1035
-/// reads `engineer_model` from.
-/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer` (default routing).
+/// Why: The engineer routes to its own configured model by default. A per-run
+/// `--engineer-model` (or `TCODE_ENGINEER_MODEL`) must reroute *only* the engineer
+/// for that single run — the model-comparison harness varies the engineer model
+/// while the PM model stays fixed. Keeping the override here lets
+/// `build_engineer_runner` stay agnostic to whether a model is pinned.
+/// What: When `params.engineer_model` is `Some`, wraps the runner in a
+/// `ModelPinningRunner` that injects `RunContext.model` on every delegation;
+/// otherwise returns the runner unchanged.
+/// Test: `run_task::tests::engineer_model_swap_routes_engineer`,
+/// `two_runs_route_engineer_to_distinct_slugs`.
 fn apply_engineer_model_override(
     runner: Arc<dyn AgentRunner>,
-    _params: &RunTaskParams,
+    params: &RunTaskParams,
 ) -> Arc<dyn AgentRunner> {
-    runner
+    match &params.engineer_model {
+        Some(model) => Arc::new(ModelPinningRunner {
+            inner: runner,
+            model: model.clone(),
+        }),
+        None => runner,
+    }
+}
+
+/// An `AgentRunner` decorator that pins a fixed model for every delegation (#1035).
+///
+/// Why: `DelegateToAgentTool::execute` calls `runner.run` with a default
+/// `RunContext`, so the per-run `--engineer-model` override cannot be threaded
+/// through the tool itself. This decorator injects `RunContext.model` and forwards
+/// to `run_with_context`, so the engineer's loop routes to the pinned slug while
+/// the PM model stays fixed.
+/// What: Holds the inner runner and the pinned model; both `run` and
+/// `run_with_context` set `ctx.model` before delegating.
+/// Test: `run_task::tests::engineer_model_swap_routes_engineer`.
+struct ModelPinningRunner {
+    inner: Arc<dyn AgentRunner>,
+    model: String,
+}
+
+#[async_trait]
+impl AgentRunner for ModelPinningRunner {
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+        let ctx = RunContext {
+            model: Some(self.model.clone()),
+            ..Default::default()
+        };
+        self.inner.run_with_context(agent_name, task, &ctx).await
+    }
+
+    async fn run_with_context(
+        &self,
+        agent_name: &str,
+        task: &str,
+        ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        let mut ctx = ctx.clone();
+        ctx.model = Some(self.model.clone());
+        self.inner.run_with_context(agent_name, task, &ctx).await
+    }
 }
 
 /// Drain the shared transcript into an owned `Vec`.

--- a/crates/trusty-code/src/run_task/recorder.rs
+++ b/crates/trusty-code/src/run_task/recorder.rs
@@ -1,0 +1,131 @@
+//! Transcript-recording `LlmClientTrait` decorator (#1034).
+//!
+//! Why: `AgentLoop::run` returns only the final `AgentOutput` (content + usage);
+//! it does not expose the per-turn conversation. The `run-task` command must
+//! emit a structured transcript of every PM and engineer turn (model + assistant
+//! text + tool calls). Rather than change the loop's signature, we wrap the
+//! shared `LlmClientTrait` in a recorder that observes each request/response
+//! pair and appends a `TurnRecord`. The wrapper is transparent — it forwards to
+//! the inner client unchanged — so the real OpenRouter client and the offline
+//! mock both work behind it.
+//! What: `RecordingLlmClient` holds an inner `Arc<dyn LlmClientTrait>`, a role
+//! label (`"pm"` / `"python-engineer"`), and a shared `Arc<Mutex<Vec<TurnRecord>>>`.
+//! Each `chat` call records the resolved model and the resulting assistant text
+//! plus tool-call names, then returns the inner response verbatim.
+//! Test: `run_task::tests` assert the recorded transcript carries both roles, and
+//! the per-run engineer model slug.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde::Serialize;
+
+use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
+use crate::perf::TokenUsage;
+
+/// One recorded assistant turn for the run transcript.
+///
+/// Why: The transcript output needs a machine- and human-renderable shape that
+/// captures who spoke (role), with which model, what text, and which tools it
+/// invoked — enough to reconstruct the PM→engineer interaction without leaking
+/// the full raw message history.
+/// What: `role` is the agent label; `model` is the resolved slug for that turn;
+/// `text` is the assistant prose (empty for tool-only turns); `tool_calls` lists
+/// the invoked tool names in order; `usage` is the token usage the provider
+/// reported for this turn (the per-turn unit the run aggregates over both PM and
+/// engineer turns, since the engineer's usage is otherwise lost when its output
+/// flows back to the PM as a tool-result string).
+/// Test: `run_task::tests::transcript_has_pm_and_engineer_turns`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TurnRecord {
+    /// Agent label that produced this turn (e.g. `"pm"`, `"python-engineer"`).
+    pub role: String,
+    /// Resolved model slug used for this turn.
+    pub model: String,
+    /// Assistant prose for the turn (empty string for tool-only turns).
+    pub text: String,
+    /// Names of tools the assistant called this turn, in order.
+    pub tool_calls: Vec<String>,
+    /// Token usage the provider reported for this turn.
+    pub usage: TokenUsage,
+}
+
+/// Shared, thread-safe transcript accumulator.
+///
+/// Why: The PM and engineer recorders run on the same tokio runtime and both
+/// append to one ordered transcript; an `Arc<Mutex<…>>` is the minimal shared
+/// sink that keeps turn order without global state.
+/// What: A type alias for the shared vector of `TurnRecord`s.
+/// Test: Exercised by every `run_task` end-to-end test.
+pub type SharedTranscript = Arc<Mutex<Vec<TurnRecord>>>;
+
+/// A transparent `LlmClientTrait` that records each turn into a shared transcript.
+///
+/// Why: Captures the conversation for the run report without modifying the agent
+/// loop. Wrapping the shared client means PM and engineer turns land in one
+/// ordered transcript while usage still accrues on the inner client.
+/// What: Forwards `chat` to the inner client, then appends a `TurnRecord` tagged
+/// with this wrapper's `role` and the request's model. A poisoned transcript
+/// lock is treated as a no-op record (the run must not panic mid-flight).
+/// Test: `run_task::tests::transcript_has_pm_and_engineer_turns`.
+pub struct RecordingLlmClient {
+    inner: Arc<dyn LlmClientTrait>,
+    role: String,
+    transcript: SharedTranscript,
+}
+
+impl RecordingLlmClient {
+    /// Wrap `inner`, tagging recorded turns with `role`.
+    ///
+    /// Why: Each agent (PM, engineer) needs its own labelled recorder sharing the
+    /// same transcript sink so the report can distinguish their turns.
+    /// What: Stores the inner client, the role label, and the shared transcript.
+    /// Test: `run_task::tests::transcript_has_pm_and_engineer_turns`.
+    pub fn new(
+        inner: Arc<dyn LlmClientTrait>,
+        role: impl Into<String>,
+        transcript: SharedTranscript,
+    ) -> Self {
+        Self {
+            inner,
+            role: role.into(),
+            transcript,
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for RecordingLlmClient {
+    /// Forward the chat call and record the resulting turn.
+    ///
+    /// Why: The transcript must reflect exactly what the model returned; recording
+    /// after the call (on success) keeps the report faithful and never fabricates
+    /// turns for failed requests.
+    /// What: Calls the inner client; on `Ok`, appends a `TurnRecord` with the
+    /// request model, the response's first text, and its tool-call names; returns
+    /// the response unchanged. Errors propagate untouched (and are not recorded).
+    /// Test: `run_task::tests::transcript_has_pm_and_engineer_turns`.
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let resp = self.inner.chat(req).await?;
+
+        let tool_calls = resp
+            .first_tool_calls()
+            .iter()
+            .map(|c| c.function.name.clone())
+            .collect();
+        let record = TurnRecord {
+            role: self.role.clone(),
+            model: req.model.clone(),
+            text: resp.first_text().unwrap_or_default(),
+            tool_calls,
+            usage: resp.clone().token_usage(),
+        };
+
+        // A poisoned lock must not abort the run; drop the record rather than panic.
+        if let Ok(mut guard) = self.transcript.lock() {
+            guard.push(record);
+        }
+
+        Ok(resp)
+    }
+}

--- a/crates/trusty-code/src/run_task/report.rs
+++ b/crates/trusty-code/src/run_task/report.rs
@@ -1,0 +1,341 @@
+//! Run report: structured result, exit codes, and human/JSON rendering (#1034).
+//!
+//! Why: `run-task` must emit its outcome in two faithful forms — a human-readable
+//! summary on a normal terminal, and a clean machine-readable JSON document when
+//! `--json` is set (stdout must then carry *only* that JSON so callers can parse
+//! it). Both forms draw from one `RunReport` so they never drift. Meaningful exit
+//! codes let scripts branch on success vs. config error vs. run failure vs. a
+//! no-op run.
+//! What: `RunReport` bundles the diff, transcript, and usage/cost; `ExitCode`
+//! enumerates the distinct outcomes; `render_human` / `render_json` produce the
+//! two output forms.
+//! Test: `run_task::tests` assert the JSON shape, the human summary content, and
+//! the exit-code mapping.
+
+use serde_json::json;
+
+use crate::perf::TokenUsage;
+use crate::run_task::recorder::TurnRecord;
+
+/// Distinct process exit codes for a `run-task` invocation.
+///
+/// Why: A caller (CI, the PM smoke-test, a wrapper script) needs to distinguish
+/// outcomes without parsing output. The ladder separates a clean success, a
+/// successful run that changed nothing, a configuration error (bad agent, bad
+/// project), and a runtime failure (the loop or LLM errored).
+/// What: `repr(i32)` so the values are stable and documented; `Success = 0`.
+/// Test: `run_task::tests::exit_codes_are_distinct`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum ExitCode {
+    /// The run completed and produced a diff. `0`.
+    Success = 0,
+    /// Configuration error: missing/invalid agent, bad project path, missing key. `2`.
+    ConfigError = 2,
+    /// Runtime failure: the agent loop or LLM call errored. `3`.
+    RunFailure = 3,
+    /// The run completed but changed nothing (empty diff). `4`.
+    NoChanges = 4,
+}
+
+impl ExitCode {
+    /// The numeric exit code.
+    ///
+    /// Why: `process::exit` takes an `i32`; this is the single conversion point.
+    /// What: Returns `self as i32`.
+    /// Test: `run_task::tests::exit_codes_are_distinct`.
+    pub fn code(self) -> i32 {
+        self as i32
+    }
+}
+
+/// The full result of a `run-task` invocation, ready to render.
+///
+/// Why: One source of truth for both output forms keeps the human and JSON
+/// reports in lockstep and makes the success path trivially testable.
+/// What: `agent` is the top-level (PM) agent name; `task` is the request; `diff`
+/// is the captured working-tree change; `transcript` is the ordered PM+engineer
+/// turns; `usage` is the aggregated token usage; `cost_usd` is the summed cost;
+/// `exit` is the computed outcome.
+/// Test: `run_task::tests::report_renders_json` and `report_renders_human`.
+#[derive(Debug, Clone)]
+pub struct RunReport {
+    /// Top-level agent name (the PM).
+    pub agent: String,
+    /// The task description that was run.
+    pub task: String,
+    /// Captured working-tree diff (empty when nothing changed).
+    pub diff: String,
+    /// Ordered transcript of every PM and engineer turn.
+    pub transcript: Vec<TurnRecord>,
+    /// Aggregated token usage across the whole run.
+    pub usage: TokenUsage,
+    /// Summed USD cost across the whole run (`None` when pricing is unavailable).
+    pub cost_usd: Option<f64>,
+    /// Computed process exit outcome.
+    pub exit: ExitCode,
+}
+
+impl RunReport {
+    /// Render the report as a single machine-readable JSON document.
+    ///
+    /// Why: `--json` mode requires clean, parseable stdout; this is the only thing
+    /// printed in that mode.
+    /// What: Serialises all fields into a stable JSON object, including a `status`
+    /// string derived from `exit` and a `cost_usd` that is `null` when pricing is
+    /// unavailable. Pretty-printed for readability without affecting parseability.
+    /// Test: `run_task::tests::report_renders_json`.
+    pub fn render_json(&self) -> String {
+        let value = json!({
+            "status": self.status_str(),
+            "exit_code": self.exit.code(),
+            "agent": self.agent,
+            "task": self.task,
+            "diff": self.diff,
+            "transcript": self.transcript,
+            "usage": {
+                "prompt_tokens": self.usage.prompt_tokens,
+                "completion_tokens": self.usage.completion_tokens,
+                "cache_read_tokens": self.usage.cache_read_tokens,
+                "cache_creation_tokens": self.usage.cache_creation_tokens,
+            },
+            "cost_usd": self.cost_usd,
+        });
+        serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Render the report as a human-readable summary.
+    ///
+    /// Why: On a normal terminal the operator wants a scannable summary, not raw
+    /// JSON. The diff is shown verbatim; the transcript is condensed to one line
+    /// per turn; usage and cost are a footer.
+    /// What: Builds a multi-section string: a header, the transcript (role, model,
+    /// truncated text, tool calls), the diff (or "no changes"), and a usage/cost
+    /// footer.
+    /// Test: `run_task::tests::report_renders_human`.
+    pub fn render_human(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "tcode run-task: agent={} status={}\n",
+            self.agent,
+            self.status_str()
+        ));
+        out.push_str(&format!("task: {}\n\n", self.task));
+
+        out.push_str("── Transcript ──\n");
+        if self.transcript.is_empty() {
+            out.push_str("(no turns recorded)\n");
+        } else {
+            for (i, turn) in self.transcript.iter().enumerate() {
+                let text_preview: String = turn.text.chars().take(120).collect();
+                let tools = if turn.tool_calls.is_empty() {
+                    String::new()
+                } else {
+                    format!(" tools=[{}]", turn.tool_calls.join(", "))
+                };
+                out.push_str(&format!(
+                    "{n}. [{role}|{model}]{tools} {text}\n",
+                    n = i + 1,
+                    role = turn.role,
+                    model = turn.model,
+                    text = text_preview,
+                ));
+            }
+        }
+
+        out.push_str("\n── Diff ──\n");
+        if self.diff.trim().is_empty() {
+            out.push_str("(no changes)\n");
+        } else {
+            out.push_str(&self.diff);
+            if !self.diff.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+
+        out.push_str("\n── Usage ──\n");
+        let cost = match self.cost_usd {
+            Some(c) => format!("${c:.6}"),
+            None => "(pricing unavailable)".to_string(),
+        };
+        out.push_str(&format!(
+            "prompt={} completion={} cache_read={} cache_creation={} cost={}\n",
+            self.usage.prompt_tokens,
+            self.usage.completion_tokens,
+            self.usage.cache_read_tokens,
+            self.usage.cache_creation_tokens,
+            cost,
+        ));
+        out
+    }
+
+    /// Map the exit outcome to a stable status string.
+    ///
+    /// Why: Both output forms label the outcome with the same vocabulary.
+    /// What: Returns `"success"`, `"no_changes"`, `"config_error"`, or
+    /// `"run_failure"`.
+    /// Test: `run_task::tests::report_renders_json`.
+    fn status_str(&self) -> &'static str {
+        match self.exit {
+            ExitCode::Success => "success",
+            ExitCode::NoChanges => "no_changes",
+            ExitCode::ConfigError => "config_error",
+            ExitCode::RunFailure => "run_failure",
+        }
+    }
+}
+
+/// Sum every transcript turn's usage and price the total against a model slug.
+///
+/// Why: The PM's `AgentOutput.usage` only covers the PM's own turns — the
+/// engineer's usage is lost when its output flows back as a tool-result string.
+/// The transcript recorder, by contrast, captures the provider-reported usage of
+/// *every* PM and engineer turn, so summing those turns is the faithful run total.
+/// Pricing once against the dominant (PM) model keeps the cost figure stable and
+/// comparable across runs.
+/// What: Field-wise sums each turn's `usage` into a single `TokenUsage`, then
+/// prices it via `perf::cost_usd`. Returns `(total_usage, cost)`.
+/// Test: `run_task::tests::usage_and_cost_aggregate_end_to_end`.
+pub fn aggregate_usage(turns: &[TurnRecord], model: &str) -> (TokenUsage, f64) {
+    let mut total = TokenUsage::default();
+    for turn in turns {
+        total.add(&turn.usage);
+    }
+    let cost = crate::perf::cost_usd(
+        model,
+        total.prompt_tokens,
+        total.completion_tokens,
+        total.cache_read_tokens,
+        total.cache_creation_tokens,
+    );
+    (total, cost)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_report(exit: ExitCode, diff: &str) -> RunReport {
+        RunReport {
+            agent: "pm".into(),
+            task: "do the thing".into(),
+            diff: diff.into(),
+            transcript: vec![
+                TurnRecord {
+                    role: "pm".into(),
+                    model: "openai/gpt-4o-mini".into(),
+                    text: String::new(),
+                    tool_calls: vec!["delegate_to_agent".into()],
+                    usage: TokenUsage::new(60, 20, 0, 0),
+                },
+                TurnRecord {
+                    role: "python-engineer".into(),
+                    model: "deepseek/deepseek-chat".into(),
+                    text: "wrote the file".into(),
+                    tool_calls: vec!["write_file".into()],
+                    usage: TokenUsage::new(40, 20, 0, 0),
+                },
+            ],
+            usage: TokenUsage::new(100, 40, 0, 0),
+            cost_usd: Some(0.001),
+            exit,
+        }
+    }
+
+    /// Exit codes are distinct and stable.
+    ///
+    /// Why: Scripts branch on these; collisions would be silent breakage.
+    /// What: Assert the four codes are 0/2/3/4 and pairwise distinct.
+    /// Test: this test.
+    #[test]
+    fn exit_codes_are_distinct() {
+        assert_eq!(ExitCode::Success.code(), 0);
+        assert_eq!(ExitCode::ConfigError.code(), 2);
+        assert_eq!(ExitCode::RunFailure.code(), 3);
+        assert_eq!(ExitCode::NoChanges.code(), 4);
+    }
+
+    /// JSON render carries status, diff, transcript, usage, and cost.
+    ///
+    /// Why: `--json` consumers depend on this exact shape.
+    /// What: Render a success report; parse it back; assert key fields.
+    /// Test: this test.
+    #[test]
+    fn report_renders_json() {
+        let report = sample_report(ExitCode::Success, "+++ added: x.py\n");
+        let rendered = report.render_json();
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+
+        assert_eq!(parsed["status"], "success");
+        assert_eq!(parsed["exit_code"], 0);
+        assert_eq!(parsed["agent"], "pm");
+        assert!(parsed["diff"].as_str().unwrap().contains("added: x.py"));
+        assert_eq!(parsed["transcript"].as_array().unwrap().len(), 2);
+        assert_eq!(parsed["usage"]["prompt_tokens"], 100);
+        assert_eq!(parsed["cost_usd"], 0.001);
+        // The engineer turn must carry its own model slug for #1035 assertions.
+        assert_eq!(parsed["transcript"][1]["model"], "deepseek/deepseek-chat");
+    }
+
+    /// Human render summarises transcript, diff, and usage.
+    ///
+    /// Why: Operators read this; key facts must be present.
+    /// What: Render a success report; assert role labels, the diff, and usage line.
+    /// Test: this test.
+    #[test]
+    fn report_renders_human() {
+        let report = sample_report(ExitCode::Success, "+++ added: x.py\n");
+        let text = report.render_human();
+        assert!(text.contains("status=success"));
+        assert!(text.contains("[pm|openai/gpt-4o-mini]"));
+        assert!(text.contains("[python-engineer|deepseek/deepseek-chat]"));
+        assert!(text.contains("added: x.py"));
+        assert!(text.contains("prompt=100 completion=40"));
+    }
+
+    /// A no-changes report renders "(no changes)" in the human form.
+    ///
+    /// Why: The no-op outcome must be visible to a human reader.
+    /// What: Render with an empty diff; assert the marker.
+    /// Test: this test.
+    #[test]
+    fn human_render_shows_no_changes() {
+        let report = sample_report(ExitCode::NoChanges, "");
+        let text = report.render_human();
+        assert!(text.contains("(no changes)"), "text: {text}");
+        assert!(text.contains("status=no_changes"));
+    }
+
+    /// `aggregate_usage` sums every turn's usage and prices the total.
+    ///
+    /// Why: The run cost is the combined cost across PM + engineer turns; the math
+    /// must be exact and span the whole transcript.
+    /// What: Sum two turns' usages, assert field-wise totals and a non-negative
+    /// cost.
+    /// Test: this test.
+    #[test]
+    fn usage_and_cost_aggregate() {
+        let turns = vec![
+            TurnRecord {
+                role: "pm".into(),
+                model: "openai/gpt-4o-mini".into(),
+                text: String::new(),
+                tool_calls: vec![],
+                usage: TokenUsage::new(10, 5, 0, 0),
+            },
+            TurnRecord {
+                role: "python-engineer".into(),
+                model: "openai/gpt-4o-mini".into(),
+                text: "done".into(),
+                tool_calls: vec![],
+                usage: TokenUsage::new(20, 8, 0, 0),
+            },
+        ];
+        let (total, cost) = aggregate_usage(&turns, "openai/gpt-4o-mini");
+        assert_eq!(total.prompt_tokens, 30);
+        assert_eq!(total.completion_tokens, 13);
+        assert!(cost >= 0.0, "cost must be non-negative");
+    }
+}

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -12,8 +12,8 @@
 //! dir; tests assert on the returned `RunReport`.
 //! Test: this module is itself the test surface.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -24,17 +24,19 @@ use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
 
 // ── Scripted offline LLM ───────────────────────────────────────────────────────
 
-/// Replays a fixed queue of responses in call order.
+/// Replays a fixed queue of responses and records every request's model.
 ///
 /// Why: Deterministic, offline substitute for the network client shared by the
-/// PM and engineer loops. The transcript recorder captures each turn's model from
-/// the response side, so the tests assert routing via `report.transcript`.
-/// What: Holds JSON-deserialised responses and an atomic cursor. Exhaustion yields
-/// a transport-style error so a runaway loop fails loudly rather than hanging.
+/// PM and engineer loops. Recording the per-request model lets the #1035 tests
+/// assert which slug drove the engineer's turns (alongside the transcript).
+/// What: Holds JSON-deserialised responses, an atomic cursor, and a log of the
+/// models seen. Exhaustion yields a transport-style error so a runaway loop fails
+/// loudly rather than hanging.
 /// Test: Used by every test below.
 struct ScriptedLlm {
     responses: Vec<ChatResponse>,
     cursor: AtomicUsize,
+    models: Mutex<Vec<String>>,
 }
 
 impl ScriptedLlm {
@@ -46,14 +48,23 @@ impl ScriptedLlm {
         Self {
             responses,
             cursor: AtomicUsize::new(0),
+            models: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Every model slug the client was asked to use, in call order.
+    fn models_seen(&self) -> Vec<String> {
+        self.models.lock().expect("models lock").clone()
     }
 }
 
 #[async_trait]
 impl LlmClientTrait for ScriptedLlm {
     async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
-        let _ = req;
+        self.models
+            .lock()
+            .expect("models lock")
+            .push(req.model.clone());
         let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
         match self.responses.get(idx) {
             Some(resp) => Ok(resp.clone()),
@@ -149,14 +160,15 @@ fn agents_dir(engineer_model: &str) -> TempDir {
 
 /// Build the standard params for a run against the given dirs.
 ///
-/// The `_engineer_model` slot is the #1035 hook; it is unused in the #1034 tests
-/// (the engineer routes via its own config model) and wired up in #1035.
-fn params(agents: &TempDir, project: &TempDir, _engineer_model: Option<&str>) -> RunTaskParams {
+/// The `engineer_model` slot carries the per-run `--engineer-model` override
+/// (#1035); `None` routes the engineer via its own config model.
+fn params(agents: &TempDir, project: &TempDir, engineer_model: Option<&str>) -> RunTaskParams {
     RunTaskParams {
         agent: "pm".into(),
         task: "write hello.py".into(),
         project: project.path().to_path_buf(),
         agents_dir: agents.path().to_path_buf(),
+        engineer_model: engineer_model.map(str::to_string),
     }
 }
 
@@ -298,6 +310,7 @@ async fn missing_pm_config_is_config_error() {
             task: "anything".into(),
             project: project.path().to_path_buf(),
             agents_dir: empty_agents.path().to_path_buf(),
+            engineer_model: None,
         },
         llm,
     )
@@ -362,4 +375,99 @@ async fn report_json_is_parseable() {
     assert_eq!(parsed["status"], "success");
     assert!(parsed["diff"].as_str().unwrap().contains("j.py"));
     assert!(parsed["transcript"].as_array().unwrap().len() >= 2);
+}
+
+// ── #1035: per-run engineer model swap ──────────────────────────────────────────
+
+/// `engineer_model` override routes the engineer's turns to the given slug while
+/// the PM model stays fixed.
+///
+/// Why: The #1035 acceptance criterion — a per-run `--engineer-model` reroutes
+/// only the engineer; the PM model is unchanged.
+/// What: Engineer config pins `deepseek/deepseek-chat`, but the run overrides it
+/// to `anthropic/claude-haiku-4-5`. Assert the engineer transcript turns carry the
+/// override slug and the PM turns carry the PM model.
+/// Test: this test.
+#[tokio::test]
+async fn engineer_model_swap_routes_engineer() {
+    let agents = agents_dir("deepseek/deepseek-chat");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("create s.py"),
+        write_file_response("s.py", "z=3"),
+        stop_response("engineer done"),
+        stop_response("pm done"),
+    ]));
+
+    let report = execute_run_task(
+        params(&agents, &project, Some("anthropic/claude-haiku-4-5")),
+        llm,
+    )
+    .await;
+
+    // Engineer turns must carry the OVERRIDE slug, not the config slug.
+    let eng_models: Vec<&str> = report
+        .transcript
+        .iter()
+        .filter(|t| t.role == "python-engineer")
+        .map(|t| t.model.as_str())
+        .collect();
+    assert!(!eng_models.is_empty(), "expected engineer turns");
+    assert!(
+        eng_models
+            .iter()
+            .all(|m| *m == "anthropic/claude-haiku-4-5"),
+        "engineer turns must route to the override slug, got: {eng_models:?}"
+    );
+
+    // PM turns must keep the PM model.
+    let pm_models: Vec<&str> = report
+        .transcript
+        .iter()
+        .filter(|t| t.role == "pm")
+        .map(|t| t.model.as_str())
+        .collect();
+    assert!(
+        pm_models.iter().all(|m| *m == "openai/gpt-4o-mini"),
+        "PM turns must keep the PM model, got: {pm_models:?}"
+    );
+}
+
+/// Two runs with different `--engineer-model` slugs route the engineer to each.
+///
+/// Why: Criterion (a) of #1035 — distinct slugs route distinctly across runs.
+/// What: Run twice with two different override slugs; assert each run's engineer
+/// turns carry its own slug.
+/// Test: this test.
+#[tokio::test]
+async fn two_runs_route_engineer_to_distinct_slugs() {
+    for slug in ["openai/gpt-4o", "anthropic/claude-sonnet-4-6"] {
+        let agents = agents_dir("deepseek/deepseek-chat");
+        let project = tempfile::tempdir().expect("project tempdir");
+        let llm = Arc::new(ScriptedLlm::from_json(&[
+            delegate_response("create m.py"),
+            write_file_response("m.py", "v=1"),
+            stop_response("engineer done"),
+            stop_response("pm done"),
+        ]));
+
+        let report = execute_run_task(params(&agents, &project, Some(slug)), llm.clone()).await;
+
+        let eng_models: Vec<String> = report
+            .transcript
+            .iter()
+            .filter(|t| t.role == "python-engineer")
+            .map(|t| t.model.clone())
+            .collect();
+        assert!(
+            eng_models.iter().all(|m| m == slug),
+            "engineer must route to {slug}, got: {eng_models:?}"
+        );
+        // Confirm the model log on the scripted client also saw the slug.
+        assert!(
+            llm.models_seen().iter().any(|m| m == slug),
+            "scripted client must have seen {slug}"
+        );
+    }
 }

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -1,0 +1,365 @@
+//! End-to-end tests for `tcode run-task` (#1034, #1035) — all offline.
+//!
+//! Why: The closer must be provable without a live LLM or API key. Every M1
+//! acceptance criterion — the PM delegates to the engineer, the engineer's
+//! file change shows up in the diff, the transcript carries both roles, usage +
+//! cost aggregate, exit codes reflect outcome, and the per-run `--engineer-model`
+//! swap routes the engineer — is driven through a scripted `LlmClientTrait` mock
+//! so no network call is ever made.
+//! What: A `ScriptedLlm` replays a queue of `ChatResponse`s; because the PM and
+//! engineer share one inner client, the script is consumed in call order
+//! (PM-turn-1, engineer-turn-1, …). Fixtures build agents-dir TOMLs and a project
+//! dir; tests assert on the returned `RunReport`.
+//! Test: this module is itself the test surface.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use super::{ExitCode, RunTaskParams, execute_run_task};
+use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
+
+// ── Scripted offline LLM ───────────────────────────────────────────────────────
+
+/// Replays a fixed queue of responses in call order.
+///
+/// Why: Deterministic, offline substitute for the network client shared by the
+/// PM and engineer loops. The transcript recorder captures each turn's model from
+/// the response side, so the tests assert routing via `report.transcript`.
+/// What: Holds JSON-deserialised responses and an atomic cursor. Exhaustion yields
+/// a transport-style error so a runaway loop fails loudly rather than hanging.
+/// Test: Used by every test below.
+struct ScriptedLlm {
+    responses: Vec<ChatResponse>,
+    cursor: AtomicUsize,
+}
+
+impl ScriptedLlm {
+    fn from_json(fixtures: &[Value]) -> Self {
+        let responses = fixtures
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()).expect("valid ChatResponse fixture"))
+            .collect();
+        Self {
+            responses,
+            cursor: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for ScriptedLlm {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let _ = req;
+        let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
+        match self.responses.get(idx) {
+            Some(resp) => Ok(resp.clone()),
+            None => Err(LlmError::MissingConfig(format!(
+                "scripted LLM exhausted at call {idx}"
+            ))),
+        }
+    }
+}
+
+// ── Fixture builders ───────────────────────────────────────────────────────────
+
+/// A response where the assistant calls `delegate_to_agent(python-engineer, …)`.
+fn delegate_response(task: &str) -> Value {
+    json!({
+        "id": "gen-delegate",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-del",
+                    "type": "function",
+                    "function": {
+                        "name": "delegate_to_agent",
+                        "arguments": json!({"agent_name": "python-engineer", "task": task}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 50, "completion_tokens": 12, "total_tokens": 62}
+    })
+}
+
+/// A response where the assistant calls `write_file(path, content)`.
+fn write_file_response(path: &str, content: &str) -> Value {
+    json!({
+        "id": "gen-write",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-wf",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": json!({"path": path, "content": content}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 30, "completion_tokens": 8, "total_tokens": 38}
+    })
+}
+
+/// A response where the assistant emits final text and stops.
+fn stop_response(text: &str) -> Value {
+    json!({
+        "id": "gen-stop",
+        "choices": [{
+            "message": {"role": "assistant", "content": text, "tool_calls": []},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 15, "completion_tokens": 5, "total_tokens": 20}
+    })
+}
+
+/// Build an agents dir with `pm.toml` and `python-engineer.toml`.
+///
+/// Why: `run-task` loads the PM config from `<agents_dir>/pm.toml` and the
+/// engineer from `<agents_dir>/python-engineer.toml`; tests need both on disk.
+/// What: Writes both TOMLs (engineer pinned to `engineer_model`) and returns the
+/// tempdir.
+fn agents_dir(engineer_model: &str) -> TempDir {
+    let tmp = tempfile::tempdir().expect("agents tempdir");
+    std::fs::write(
+        tmp.path().join("pm.toml"),
+        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM.\"\n",
+    )
+    .expect("write pm.toml");
+    std::fs::write(
+        tmp.path().join("python-engineer.toml"),
+        format!(
+            "[agent]\nname = \"python-engineer\"\nmodel = \"{engineer_model}\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n"
+        ),
+    )
+    .expect("write python-engineer.toml");
+    tmp
+}
+
+/// Build the standard params for a run against the given dirs.
+///
+/// The `_engineer_model` slot is the #1035 hook; it is unused in the #1034 tests
+/// (the engineer routes via its own config model) and wired up in #1035.
+fn params(agents: &TempDir, project: &TempDir, _engineer_model: Option<&str>) -> RunTaskParams {
+    RunTaskParams {
+        agent: "pm".into(),
+        task: "write hello.py".into(),
+        project: project.path().to_path_buf(),
+        agents_dir: agents.path().to_path_buf(),
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+/// Full path: the PM delegates to the engineer, who writes a file; the diff
+/// reflects that change, the transcript carries both roles, and exit is Success.
+///
+/// Why: The core #1034 acceptance criterion — `run-task` actually executes
+/// PM→engineer end-to-end and reports the real change.
+/// What: Script [PM delegate, engineer write_file, engineer stop, PM stop].
+/// Run; assert exit=Success, the diff names `hello.py` with its content, and the
+/// transcript has a "pm" turn and a "python-engineer" turn.
+/// Test: this test.
+#[tokio::test]
+async fn end_to_end_pm_delegates_to_engineer() {
+    let agents = agents_dir("deepseek/deepseek-chat");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("create hello.py"),
+        write_file_response("hello.py", "print('hello from engineer')"),
+        stop_response("engineer: wrote hello.py"),
+        stop_response("pm: task complete"),
+    ]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm).await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::Success,
+        "run with a file change must exit Success; diff was: {}",
+        report.diff
+    );
+    assert!(
+        report.diff.contains("hello.py"),
+        "diff must name the engineer's file, got: {}",
+        report.diff
+    );
+    assert!(
+        report.diff.contains("hello from engineer"),
+        "diff must contain the new content, got: {}",
+        report.diff
+    );
+
+    // File actually landed in the project.
+    let written = std::fs::read_to_string(project.path().join("hello.py")).expect("file written");
+    assert_eq!(written, "print('hello from engineer')");
+
+    // Transcript carries both roles.
+    let roles: Vec<&str> = report.transcript.iter().map(|t| t.role.as_str()).collect();
+    assert!(
+        roles.contains(&"pm"),
+        "transcript must have a PM turn: {roles:?}"
+    );
+    assert!(
+        roles.contains(&"python-engineer"),
+        "transcript must have an engineer turn: {roles:?}"
+    );
+}
+
+/// Usage and cost aggregate across PM and engineer turns.
+///
+/// Why: The report must sum token usage over the whole run (criterion c).
+/// What: Same script as the happy path; assert the report's prompt/completion
+/// totals equal the sum of every scripted turn's usage, and cost is computed.
+/// Test: this test.
+#[tokio::test]
+async fn usage_and_cost_aggregate_end_to_end() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("create out.py"),   // 50 + 12
+        write_file_response("out.py", "x=1"), // 30 + 8
+        stop_response("engineer done"),       // 15 + 5
+        stop_response("pm done"),             // 15 + 5
+    ]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm).await;
+
+    assert_eq!(
+        report.usage.prompt_tokens,
+        50 + 30 + 15 + 15,
+        "prompt tokens must sum across all PM + engineer turns"
+    );
+    assert_eq!(
+        report.usage.completion_tokens,
+        12 + 8 + 5 + 5,
+        "completion tokens must sum across all turns"
+    );
+    assert!(
+        report.cost_usd.is_some_and(|c| c >= 0.0),
+        "cost must be computed and non-negative"
+    );
+}
+
+/// A run that changes nothing reports `NoChanges` and an empty diff.
+///
+/// Why: The distinct no-op exit code must fire when the engineer writes nothing.
+/// What: Script [PM stop] only — the PM concludes without delegating, so no file
+/// is touched. Assert exit=NoChanges and an empty diff.
+/// Test: this test.
+#[tokio::test]
+async fn no_changes_yields_no_changes_exit() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response(
+        "pm: nothing to do",
+    )]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm).await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::NoChanges,
+        "a run that touches no files must exit NoChanges; diff: {}",
+        report.diff
+    );
+    assert!(report.diff.trim().is_empty(), "diff must be empty");
+}
+
+/// A missing PM config is a configuration error (no panic, distinct exit code).
+///
+/// Why: Bad configuration must produce a faithful `ConfigError`, not a crash.
+/// What: Point the params at an agents dir with no `pm.toml`; assert
+/// exit=ConfigError.
+/// Test: this test.
+#[tokio::test]
+async fn missing_pm_config_is_config_error() {
+    let empty_agents = tempfile::tempdir().expect("agents tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("unused")]));
+
+    let report = execute_run_task(
+        RunTaskParams {
+            agent: "pm".into(),
+            task: "anything".into(),
+            project: project.path().to_path_buf(),
+            agents_dir: empty_agents.path().to_path_buf(),
+        },
+        llm,
+    )
+    .await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::ConfigError,
+        "missing pm.toml must be a config error"
+    );
+}
+
+/// A PM loop that errors (scripted client exhausts on a tool-call turn) yields
+/// `RunFailure`.
+///
+/// Why: A runtime failure must map to the `RunFailure` exit code (criterion d).
+/// What: Script only a delegate turn but no engineer responses, so the engineer
+/// loop hits the exhausted client and errors, surfacing back through the PM. With
+/// the PM then also exhausted, the PM loop errors. Assert exit=RunFailure.
+/// Test: this test.
+#[tokio::test]
+async fn exit_code_reflects_run_failure() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    // PM delegates, but there are NO further responses: the engineer loop's first
+    // chat call exhausts the script and errors; the delegate tool surfaces a
+    // recoverable error; the PM's next turn also exhausts → PM loop errors.
+    let llm = Arc::new(ScriptedLlm::from_json(&[delegate_response("do work")]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm).await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::RunFailure,
+        "an LLM/loop error must map to RunFailure"
+    );
+}
+
+/// JSON render of the report is clean, parseable, and complete.
+///
+/// Why: `--json` mode must emit machine-readable output; the report is its source.
+/// What: Run the happy path, render JSON, parse it back, assert status + diff +
+/// transcript presence.
+/// Test: this test.
+#[tokio::test]
+async fn report_json_is_parseable() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("create j.py"),
+        write_file_response("j.py", "y=2"),
+        stop_response("engineer done"),
+        stop_response("pm done"),
+    ]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm).await;
+    let rendered = report.render_json();
+    let parsed: Value = serde_json::from_str(&rendered).expect("report JSON must parse");
+
+    assert_eq!(parsed["status"], "success");
+    assert!(parsed["diff"].as_str().unwrap().contains("j.py"));
+    assert!(parsed["transcript"].as_array().unwrap().len() >= 2);
+}


### PR DESCRIPTION
trusty-code (tcode) M1 critical-path closer — the binary now actually runs a task end-to-end instead of emitting a stub. Three epic #1039 children, built NATIVELY on trusty-code's own AgentLoop / runner / PromptAssembler / provider routing (no open-mpm/trusty-agents porting).

## #1033 — CLAUDE.md / project-context ingestion
`load_project_context` finds root `CLAUDE.md` (falls back to `.claude/CLAUDE.md`), caps at 16 KiB on a UTF-8 boundary with a truncation provenance note, injects into agent system prompts via PromptAssembler; missing file → None (no error).

## #1034 — tcode run-task end-to-end
`tcode run-task pm "<task>" --project <p>` now: loads PM config → loads project context → assembles PM prompt → runs PM AgentLoop (real OpenRouter LlmClient) → PM delegates to python-engineer (InProcessAgentRunner with project-scoped fs/bash tools) → captures diff (git diff HEAD, or before/after snapshot for non-git), transcript, token usage + cost. Human + `--json` output (clean stdout in JSON mode, logs to stderr). Exit codes: 0 success / 2 config / 3 run failure / 4 no-changes. Agent-name validation + project path traversal guards retained. New `RecordingLlmClient` decorator captures the transcript + correct run-total usage without widening AgentLoop's API.

## #1035 — per-run engineer model swap
`--engineer-model <slug>` (+ `TCODE_ENGINEER_MODEL` env; flag wins) overrides the engineer's model for one run via RunContext.model (rides existing resolve_model precedence); PM model fixed. Enables the benchmark comparison.

## Verification
- `cargo test -p trusty-code`: 324 passed / 0 failed / 2 ignored. New: 10 project_context + 17 run_task tests (mocked end-to-end PM→engineer delegation, usage/cost aggregation, exit codes, JSON parseability, engineer-model routing to distinct slugs). All offline via the mockable LlmClientTrait.
- clippy -D warnings, fmt --check, line-cap (0 violations): clean.
- Live smoke test against a real cheap model: see QA notes on this PR.

Closes #1033
Closes #1034
Closes #1035
Part of epic #1039 (trusty-code M1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)