### PR TITLE
feat(trusty-mpm): custom-instruction loading for the metaharness (closes #1048)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/meta/agents.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/agents.rs
@@ -1,18 +1,23 @@
-//! Bundled PM + sub-agent configs for the standalone metaharness (#1030).
+//! Bundled PM + sub-agent configs for the standalone metaharness (#1030, #1048).
 //!
 //! Why: The metaharness boots without the trusty-mpm daemon or `.claude/`
 //! scaffolding, yet [`InProcessAgentRunner`] loads each agent from
-//! `<config_dir>/<name>.toml`. Shipping the PM and engineer configs inline (and
-//! materialising them to a run-scoped temp dir) lets `meta run --demo` drive a
-//! real PM → engineer delegation with zero external setup, while still going
-//! through the production on-disk agent-loading path.
-//! What: [`PM_AGENT_NAME`]/[`ENGINEER_AGENT_NAME`] name the two agents;
-//! [`pm_agent_toml`]/[`engineer_agent_toml`] return their TOML bodies (the PM is
-//! allowed only `delegate_to_agent` + read tools; the engineer gets the full
-//! fs/bash set); [`write_agent_configs`] materialises both into a directory and
-//! returns it.
-//! Test: `agents::tests` assert the bodies parse as `AgentConfig`s with the
-//! expected allowlists, and that `write_agent_configs` writes both files.
+//! `<config_dir>/<name>.toml`. As of WI-3 (#1048) the PM and sub-agent prompts are
+//! no longer hard-coded inline TOML literals — they are *assembled* by the
+//! instruction-loading layer ([`super::instructions`]): the PM prompt layers the
+//! bundled PM sections with the project's `.trusty-mpm/` overrides (floored by
+//! `BASE_PM.md`), and the engineer prompt is sourced from its bundled
+//! `src/assets/agents/<name>.md` asset. This module owns the *policy* (which agents
+//! exist, what tools each may call) and materialises the assembled configs to disk
+//! so the demo exercises the real on-disk agent-loading path.
+//! What: [`PM_AGENT_NAME`]/[`ENGINEER_AGENT_NAME`] name the two agents and
+//! [`PM_TOOLS`]/[`ENGINEER_TOOLS`] declare their tool allowlists (the PM gets only
+//! `delegate_to_agent` + read; the engineer gets the full fs/bash set).
+//! [`write_agent_configs`] builds both [`AgentConfig`]s via [`super::instructions`]
+//! (threading the project dir so PM overrides resolve), serialises them to TOML,
+//! and writes them into the run-scoped config dir.
+//! Test: `agents::tests` assert the written files parse as `AgentConfig`s with the
+//! assembled prompts and expected allowlists.
 //!
 //! [`InProcessAgentRunner`]: trusty_code::runner::InProcessAgentRunner
 
@@ -20,103 +25,77 @@ use std::path::Path;
 
 use anyhow::Context as _;
 
+use super::instructions::{pm_agent_config, sub_agent_config};
+
 /// Dispatch name (and config file stem) of the project-manager agent.
 ///
 /// Why: The orchestrator loads `<dir>/pm.toml` and runs the PM loop against this
 /// agent; centralising the slug keeps the loader, the config file, and the tests
 /// in lockstep.
 /// What: the literal `"pm"`.
-/// Test: `pm_toml_parses_with_delegate_allowed`.
+/// Test: `pm_config_written_with_assembled_prompt`.
 pub(crate) const PM_AGENT_NAME: &str = "pm";
 
 /// Dispatch name (and config file stem) of the sub-agent the PM delegates to.
 ///
 /// Why: The demo drives one delegation to this agent; the delegate tool
-/// validates the name against `<dir>/<name>.toml`, so the slug must match.
-/// What: the literal `"python-engineer"`.
-/// Test: `engineer_toml_parses_with_fs_tools`.
+/// validates the name against `<dir>/<name>.toml`, so the slug must match a
+/// bundled `src/assets/agents/<name>.md` asset.
+/// What: the literal `"python-engineer"` (its prompt is the bundled
+/// python-engineer asset, loaded by [`super::instructions`]).
+/// Test: `engineer_config_written_with_asset_prompt`.
 pub(crate) const ENGINEER_AGENT_NAME: &str = "python-engineer";
 
-/// TOML body for the PM agent config.
+/// Tool allowlist for the PM agent.
 ///
 /// Why: The PM's job is to delegate, not to touch files directly; restricting it
 /// to `delegate_to_agent` (plus read-only inspection) mirrors the MPM protocol
-/// where the PM orchestrates and sub-agents do the work. Acceptance criterion
-/// #1030 requires the PM to load a "delegate tool + optional read tools" config.
-/// What: an `AgentConfig` TOML pinning the default model and allowing only
-/// `delegate_to_agent` and `read_file`; the system prompt instructs the PM to
-/// delegate the task to the engineer and report the result.
-/// Test: `pm_toml_parses_with_delegate_allowed`.
-pub(crate) fn pm_agent_toml() -> String {
-    r#"[agent]
-name = "pm"
-role = "project-manager"
-description = "Orchestrates the run by delegating to sub-agents."
+/// where the PM orchestrates and sub-agents do the work (#1030 AC).
+/// What: `delegate_to_agent` + `read_file`.
+/// Test: `pm_config_written_with_assembled_prompt` asserts the allowlist.
+pub(crate) const PM_TOOLS: &[&str] = &["delegate_to_agent", "read_file"];
 
-[system_prompt]
-content = """
-You are the PM (project manager) of an in-process agent harness.
-You do not write files yourself. To accomplish the user's task you MUST call the
-delegate_to_agent tool exactly once, delegating the concrete engineering work to
-the `python-engineer` agent. Pass the full task as the `task` argument. After the
-engineer reports back, summarise what was accomplished in one short paragraph and
-then stop.
-"""
-
-[tools]
-allowed = ["delegate_to_agent", "read_file"]
-"#
-    .to_string()
-}
-
-/// TOML body for the engineer sub-agent config.
+/// Tool allowlist for the engineer sub-agent.
 ///
 /// Why: The engineer is the actor that actually performs file I/O and shell work,
-/// so it needs the full fs/bash tool set. Keeping its allowlist explicit makes
-/// the capability grant auditable.
-/// What: an `AgentConfig` TOML pinning the default model and allowing the fs
-/// tools (`read_file`, `write_file`, `edit`) and `bash`; the system prompt
-/// instructs it to carry out the task and confirm completion.
-/// Test: `engineer_toml_parses_with_fs_tools`.
-pub(crate) fn engineer_agent_toml() -> String {
-    r#"[agent]
-name = "python-engineer"
-role = "engineer"
-description = "Performs concrete engineering work: file writes, edits, shell."
+/// so it needs the full fs/bash tool set. Keeping its allowlist explicit makes the
+/// capability grant auditable.
+/// What: `read_file`, `write_file`, `edit`, `bash`.
+/// Test: `engineer_config_written_with_asset_prompt` asserts the allowlist.
+pub(crate) const ENGINEER_TOOLS: &[&str] = &["read_file", "write_file", "edit", "bash"];
 
-[system_prompt]
-content = """
-You are a software engineer in an in-process agent harness.
-Carry out the task you are given using the available tools (write_file, edit,
-read_file, bash). When the task asks you to create a file, use the write_file
-tool with the requested relative path and contents. After the work is done,
-reply with a one-line confirmation of exactly what you changed, then stop.
-"""
-
-[tools]
-allowed = ["read_file", "write_file", "edit", "bash"]
-"#
-    .to_string()
-}
-
-/// Materialise the PM + engineer configs into `dir`, returning nothing on success.
+/// Materialise the PM + engineer configs into `dir`, resolving prompts for `project`.
 ///
 /// Why: The runner and delegate tool both load agents from on-disk TOML; writing
-/// the bundled configs into a run-scoped directory lets the demo exercise the
-/// real loading path without requiring the operator to author config files.
-/// What: Creates `dir` (if needed) and writes `pm.toml` and `python-engineer.toml`
-/// with the bundled bodies; surfaces an `anyhow` error naming the offending path
-/// on any IO failure.
-/// Test: `write_agent_configs_writes_both_files`.
-pub(crate) fn write_agent_configs(dir: &Path) -> anyhow::Result<()> {
+/// the assembled configs into a run-scoped directory lets the demo exercise the
+/// real loading path while honouring the project's custom instructions (#1048):
+/// the PM prompt is layered with `<project>/.trusty-mpm/` overrides and the
+/// engineer prompt is sourced from its bundled asset.
+/// What: Builds the PM config (via [`pm_agent_config`], threading `project` so
+/// overrides resolve) and the engineer config (via [`sub_agent_config`], loading
+/// the bundled asset), serialises each to TOML, creates `dir` (if needed), and
+/// writes `pm.toml` + `python-engineer.toml`. Surfaces an `anyhow` error naming the
+/// offending step on any failure (unknown agent, serialisation, or IO).
+/// Test: `pm_config_written_with_assembled_prompt`,
+/// `engineer_config_written_with_asset_prompt`, `write_agent_configs_writes_both_files`.
+pub(crate) fn write_agent_configs(dir: &Path, project: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(dir)
         .with_context(|| format!("failed to create agents dir: {}", dir.display()))?;
+
+    let pm = pm_agent_config(PM_AGENT_NAME, project, None, PM_TOOLS);
+    let pm_toml = toml::to_string(&pm).context("failed to serialise PM agent config")?;
     let pm_path = dir.join(format!("{PM_AGENT_NAME}.toml"));
-    std::fs::write(&pm_path, pm_agent_toml())
+    std::fs::write(&pm_path, pm_toml)
         .with_context(|| format!("failed to write PM config: {}", pm_path.display()))?;
+
+    let engineer = sub_agent_config(ENGINEER_AGENT_NAME, None, ENGINEER_TOOLS)
+        .context("failed to load engineer sub-agent prompt")?;
+    let eng_toml =
+        toml::to_string(&engineer).context("failed to serialise engineer agent config")?;
     let eng_path = dir.join(format!("{ENGINEER_AGENT_NAME}.toml"));
-    std::fs::write(&eng_path, engineer_agent_toml())
+    std::fs::write(&eng_path, eng_toml)
         .with_context(|| format!("failed to write engineer config: {}", eng_path.display()))?;
+
     Ok(())
 }
 
@@ -126,44 +105,83 @@ mod tests {
 
     use super::*;
 
-    /// The PM config parses and allows only delegate + read.
+    /// The written PM config carries the assembled prompt and the delegate-only
+    /// allowlist.
     ///
-    /// Why: The PM must be able to delegate but not write files directly; a
-    /// regression in the allowlist would let the PM bypass the engineer.
-    /// What: Parse `pm_agent_toml`; assert name and the exact allowlist.
+    /// Why: The PM must be able to delegate but not write files directly, and its
+    /// prompt must come from the assembly layer (so project overrides take effect);
+    /// a regression in either would break the orchestration contract.
+    /// What: Write into a tempdir whose project carries a `PM_INSTRUCTIONS_DEPLOYED.md`
+    /// override; load `pm.toml`; assert the override text is present, the BASE_PM
+    /// floor is present, and the allowlist is delegate + read only.
     /// Test: this test.
     #[test]
-    fn pm_toml_parses_with_delegate_allowed() {
-        let cfg = AgentConfig::from_toml_str(&pm_agent_toml()).expect("pm toml parses");
-        assert_eq!(cfg.agent.name, PM_AGENT_NAME);
-        let allowed = cfg
+    fn pm_config_written_with_assembled_prompt() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let override_dir = project.path().join(".trusty-mpm");
+        std::fs::create_dir_all(&override_dir).expect("override dir");
+        std::fs::write(
+            override_dir.join("PM_INSTRUCTIONS_DEPLOYED.md"),
+            "PM_OVERRIDE_FROM_PROJECT\n",
+        )
+        .expect("write override");
+
+        let cfg_dir = tempfile::tempdir().expect("cfg tempdir");
+        write_agent_configs(cfg_dir.path(), project.path()).expect("write configs");
+
+        let pm = AgentConfig::load(&cfg_dir.path().join("pm.toml")).expect("pm.toml loads");
+        assert_eq!(pm.agent.name, PM_AGENT_NAME);
+        assert!(
+            pm.system_prompt
+                .content
+                .contains("PM_OVERRIDE_FROM_PROJECT"),
+            "project override must be assembled into the PM prompt"
+        );
+        assert!(
+            pm.system_prompt
+                .content
+                .contains("# BASE_PM Framework Floor"),
+            "BASE_PM floor must be present"
+        );
+        let allowed = pm
             .tools
             .as_ref()
             .and_then(|t| t.allowed.as_ref())
-            .expect("pm has an allowlist");
+            .expect("pm allowlist");
         assert!(allowed.contains(&"delegate_to_agent".to_string()));
-        assert!(allowed.contains(&"read_file".to_string()));
-        assert!(
-            !allowed.contains(&"write_file".to_string()),
-            "PM must not be allowed to write files directly"
-        );
+        assert!(!allowed.contains(&"write_file".to_string()));
     }
 
-    /// The engineer config parses and allows the fs/bash tool set.
+    /// The written engineer config carries the bundled-asset prompt and fs/bash
+    /// allowlist.
     ///
-    /// Why: The engineer is the actor that performs file I/O; it must have the
-    /// write/edit/bash capabilities.
-    /// What: Parse `engineer_agent_toml`; assert name and allowlist membership.
+    /// Why: The engineer's behaviour must come from its bundled asset (#1048), not
+    /// an inline literal, and it must have the write/edit/bash capabilities.
+    /// What: Write configs; load `python-engineer.toml`; assert the asset body is
+    /// present (no frontmatter) and the allowlist contains the fs/bash tools.
     /// Test: this test.
     #[test]
-    fn engineer_toml_parses_with_fs_tools() {
-        let cfg = AgentConfig::from_toml_str(&engineer_agent_toml()).expect("engineer toml parses");
-        assert_eq!(cfg.agent.name, ENGINEER_AGENT_NAME);
-        let allowed = cfg
+    fn engineer_config_written_with_asset_prompt() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let cfg_dir = tempfile::tempdir().expect("cfg tempdir");
+        write_agent_configs(cfg_dir.path(), project.path()).expect("write configs");
+
+        let eng = AgentConfig::load(&cfg_dir.path().join("python-engineer.toml"))
+            .expect("engineer toml loads");
+        assert_eq!(eng.agent.name, ENGINEER_AGENT_NAME);
+        assert!(
+            eng.system_prompt.content.contains("Python"),
+            "engineer prompt must come from the bundled python-engineer asset"
+        );
+        assert!(
+            !eng.system_prompt.content.starts_with("---"),
+            "frontmatter must be stripped from the engineer prompt"
+        );
+        let allowed = eng
             .tools
             .as_ref()
             .and_then(|t| t.allowed.as_ref())
-            .expect("engineer has an allowlist");
+            .expect("engineer allowlist");
         for tool in ["read_file", "write_file", "edit", "bash"] {
             assert!(
                 allowed.contains(&tool.to_string()),
@@ -174,15 +192,16 @@ mod tests {
 
     /// `write_agent_configs` writes both TOML files into the target dir.
     ///
-    /// Why: The runner loads agents from disk; both files must land.
-    /// What: Write into a tempdir; assert both files exist and parse.
+    /// Why: The runner loads agents from disk; both files must land and parse.
+    /// What: Write into a tempdir; assert both files exist and load as configs.
     /// Test: this test.
     #[test]
     fn write_agent_configs_writes_both_files() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        write_agent_configs(tmp.path()).expect("write configs");
-        let pm = tmp.path().join("pm.toml");
-        let eng = tmp.path().join("python-engineer.toml");
+        let project = tempfile::tempdir().expect("project tempdir");
+        let cfg_dir = tempfile::tempdir().expect("cfg tempdir");
+        write_agent_configs(cfg_dir.path(), project.path()).expect("write configs");
+        let pm = cfg_dir.path().join("pm.toml");
+        let eng = cfg_dir.path().join("python-engineer.toml");
         assert!(pm.exists(), "pm.toml must be written");
         assert!(eng.exists(), "python-engineer.toml must be written");
         AgentConfig::load(&pm).expect("pm.toml loads");

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/instructions.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/instructions.rs
@@ -1,0 +1,414 @@
+//! Custom-instruction loading for the standalone metaharness (#1048, WI-3).
+//!
+//! Why: WI-4's `agents.rs` originally hard-coded the PM and engineer system
+//! prompts as inline TOML string literals. That bypassed the trusty-mpm
+//! instruction machinery entirely — a project's `.trusty-mpm/` overrides
+//! (advertised by `BASE_PM.md`, made real by `core::instruction_overrides`) were
+//! silently ignored, and every sub-agent's behaviour was frozen in a Rust string
+//! rather than sourced from the bundled `src/assets/agents/<name>.md` prompt the
+//! rest of trusty-mpm already ships. This module is the instruction-loading layer
+//! WI-4's orchestrator consumes: it *reuses* the existing assembly machinery
+//! rather than reinventing it, so the metaharness PM honours the same override
+//! contract a daemon-launched PM does, and sub-agents inherit their bundled
+//! prompts.
+//! What: [`assemble_pm_prompt`] is a thin wrapper over
+//! [`resolve_pm_prompt`](trusty_mpm::core::instruction_overrides::resolve_pm_prompt)
+//! (bundled PM sections layered with project `.trusty-mpm/` overrides, always
+//! floored by the non-overridable `BASE_PM.md`). [`load_agent_prompt`] resolves a
+//! sub-agent's prompt body from the compile-time bundle ([`bundle::ALL`]),
+//! stripping YAML frontmatter so only the Markdown instruction body remains.
+//! [`pm_agent_config`] and [`sub_agent_config`] map each assembled/loaded prompt
+//! into a trusty-code [`AgentConfig`] (with the agent's model + tool allowlist),
+//! which the orchestrator feeds to `trusty_code::prompt::assemble_system_prompt`.
+//! Missing sub-agents return a clean [`MetaInstructionError`] rather than panic.
+//! Test: the `tests` module proves PM assembly layers a project override above
+//! the BASE_PM floor, sub-agent prompts load from the asset and map into an
+//! `AgentConfig`, and an unknown agent name yields an error (not a panic).
+
+use std::path::Path;
+
+use trusty_code::agents::{AgentConfig, AgentInfo, SystemPrompt, ToolsConfig};
+use trusty_mpm::core::bundle;
+use trusty_mpm::core::instruction_overrides::resolve_pm_prompt;
+
+/// A failure raised while loading metaharness instructions.
+///
+/// Why: Sub-agent prompt loading can fail for a recoverable, operator-facing
+/// reason — the requested agent is not in the bundle — and the harness must
+/// surface that as a typed, non-panicking error so `meta run` can report it
+/// cleanly. A `thiserror` enum keeps the failure surface explicit and lets
+/// callers `?`-propagate into `anyhow`.
+/// What: [`UnknownAgent`](MetaInstructionError::UnknownAgent) names the agent slug
+/// that had no bundled `src/assets/agents/<name>.md` asset.
+/// Test: `unknown_agent_prompt_errors` asserts the variant and its message.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MetaInstructionError {
+    /// No bundled agent asset matched the requested name.
+    #[error(
+        "unknown sub-agent '{0}': no bundled prompt at src/assets/agents/{0}.md \
+         (see trusty-mpm core::bundle for the available agents)"
+    )]
+    UnknownAgent(String),
+}
+
+/// Assemble the effective PM system prompt for `project_dir`.
+///
+/// Why: The metaharness PM must obey the same custom-instruction contract a
+/// daemon-launched PM does — bundled PM sections, layered with the project's
+/// `.trusty-mpm/` overrides, always floored by the non-overridable `BASE_PM.md`.
+/// Reusing [`resolve_pm_prompt`] (rather than re-implementing the layering) is
+/// the single source of truth #1048 requires, so the two launch paths can never
+/// diverge.
+/// What: Delegates verbatim to
+/// [`resolve_pm_prompt`](trusty_mpm::core::instruction_overrides::resolve_pm_prompt),
+/// which reads any override files under `<project_dir>/.trusty-mpm/` and appends
+/// the BASE_PM floor last.
+/// Test: `pm_prompt_layers_project_override_above_base_floor`,
+/// `pm_prompt_without_overrides_is_bundled`.
+pub(crate) fn assemble_pm_prompt(project_dir: &Path) -> String {
+    resolve_pm_prompt(project_dir)
+}
+
+/// Load a sub-agent's instruction body from the compile-time bundle.
+///
+/// Why: Sub-agent prompts live in `src/assets/agents/<name>.md` (already embedded
+/// via [`bundle::ALL`]); the metaharness should source them from there rather
+/// than from a hard-coded Rust string, so a sub-agent's behaviour stays in lockstep
+/// with the catalog the rest of trusty-mpm ships and deploys. The asset carries
+/// YAML frontmatter (name/role/model/…) plus a Markdown body; only the body is the
+/// instruction the LLM should receive.
+/// What: Looks up `agents/<name>.md` in [`bundle::ALL`]; on a hit, returns the
+/// asset body with its leading YAML frontmatter block stripped (see
+/// [`strip_frontmatter`]); on a miss, returns
+/// [`MetaInstructionError::UnknownAgent`].
+/// Test: `engineer_prompt_loads_from_asset`, `loaded_prompt_omits_frontmatter`,
+/// `unknown_agent_prompt_errors`.
+pub(crate) fn load_agent_prompt(agent_name: &str) -> Result<String, MetaInstructionError> {
+    let rel_path = format!("agents/{agent_name}.md");
+    let raw = bundle::ALL
+        .iter()
+        .find(|artifact| artifact.rel_path == rel_path)
+        .map(|artifact| artifact.contents)
+        .ok_or_else(|| MetaInstructionError::UnknownAgent(agent_name.to_string()))?;
+    Ok(strip_frontmatter(raw).trim().to_string())
+}
+
+/// Strip a leading YAML frontmatter block from a bundled agent asset.
+///
+/// Why: Agent assets begin with a `---\n…\n---\n` YAML block (name/role/model/…)
+/// that is metadata, not instruction text; feeding it to the LLM as part of the
+/// system prompt would waste tokens and leak scaffolding into the model's context.
+/// What: If `raw` starts with a `---` fence line, drops everything up to and
+/// including the matching closing `---` fence and returns the remaining body;
+/// otherwise returns `raw` unchanged (an asset without frontmatter is already a
+/// body).
+/// Test: `loaded_prompt_omits_frontmatter`, `strip_frontmatter_passes_through_bodyless`.
+fn strip_frontmatter(raw: &str) -> &str {
+    // The opening fence must be the very first line (a line that is exactly `---`,
+    // ignoring a trailing CR for CRLF files). If it is not, there is no
+    // frontmatter and the whole input is already a body.
+    let first_line = raw.lines().next().unwrap_or("");
+    if first_line.trim_end_matches('\r') != "---" {
+        return raw;
+    }
+    // Skip past the opening fence line, then scan for the closing `---` fence
+    // line. `split_inclusive('\n')` keeps line terminators so byte offsets line
+    // up with the original string, letting us return a borrowed body slice.
+    let mut consumed = first_line.len();
+    // Account for the opening fence's own newline (LF or CRLF) if present.
+    consumed += raw[consumed..]
+        .strip_prefix("\r\n")
+        .map(|_| 2)
+        .or_else(|| raw[consumed..].strip_prefix('\n').map(|_| 1))
+        .unwrap_or(0);
+
+    let mut offset = consumed;
+    for line in raw[consumed..].split_inclusive('\n') {
+        if line.trim_end_matches(['\r', '\n']) == "---" {
+            // Body begins immediately after this closing fence line.
+            return &raw[offset + line.len()..];
+        }
+        offset += line.len();
+    }
+    // Unterminated frontmatter — treat the whole thing as a body (robustness).
+    raw
+}
+
+/// Build the PM [`AgentConfig`] with its assembled prompt mapped in.
+///
+/// Why: The orchestrator loads an [`AgentConfig`] and feeds
+/// `config.system_prompt.content` into `trusty_code::prompt::assemble_system_prompt`.
+/// To make the metaharness PM honour project overrides, the assembled PM prompt
+/// (from [`assemble_pm_prompt`]) must be the config's `system_prompt.content`.
+/// What: Returns an [`AgentConfig`] named `pm` (role `project-manager`) whose
+/// `system_prompt.content` is [`assemble_pm_prompt`]'s output, with `model` set
+/// (when `Some`) and the given tool allowlist applied. The PM is constrained to a
+/// delegate + read-only surface by its `allowed` list, mirroring the MPM protocol
+/// where the PM orchestrates and sub-agents act.
+/// Test: `pm_config_carries_assembled_prompt_and_allowlist`.
+pub(crate) fn pm_agent_config(
+    pm_name: &str,
+    project_dir: &Path,
+    model: Option<&str>,
+    allowed_tools: &[&str],
+) -> AgentConfig {
+    AgentConfig {
+        agent: AgentInfo {
+            name: pm_name.to_string(),
+            role: Some("project-manager".to_string()),
+            model: model.map(str::to_string),
+            description: Some("Orchestrates the run by delegating to sub-agents.".to_string()),
+        },
+        system_prompt: SystemPrompt {
+            content: assemble_pm_prompt(project_dir),
+            append_skills: Vec::new(),
+        },
+        tools: Some(tools_allowing(allowed_tools)),
+        ..AgentConfig::default()
+    }
+}
+
+/// Build a sub-agent [`AgentConfig`] with its bundled prompt mapped in.
+///
+/// Why: Same contract as [`pm_agent_config`], but for a sub-agent: the
+/// orchestrator needs an [`AgentConfig`] whose `system_prompt.content` is the
+/// sub-agent's bundled instruction body, plus the model and tool capabilities it
+/// is allowed. Sourcing the body from the bundle (via [`load_agent_prompt`]) keeps
+/// the sub-agent's behaviour consistent with the shipped catalog.
+/// What: Loads the prompt via [`load_agent_prompt`] (propagating
+/// [`MetaInstructionError::UnknownAgent`] for an unknown name), then returns an
+/// [`AgentConfig`] named `agent_name` (role `engineer`) with that prompt, the given
+/// model, and the given tool allowlist.
+/// Test: `sub_agent_config_maps_asset_into_config`,
+/// `sub_agent_config_propagates_unknown_agent`.
+pub(crate) fn sub_agent_config(
+    agent_name: &str,
+    model: Option<&str>,
+    allowed_tools: &[&str],
+) -> Result<AgentConfig, MetaInstructionError> {
+    let content = load_agent_prompt(agent_name)?;
+    Ok(AgentConfig {
+        agent: AgentInfo {
+            name: agent_name.to_string(),
+            role: Some("engineer".to_string()),
+            model: model.map(str::to_string),
+            description: Some(
+                "Performs concrete engineering work: file writes, edits, shell.".to_string(),
+            ),
+        },
+        system_prompt: SystemPrompt {
+            content,
+            append_skills: Vec::new(),
+        },
+        tools: Some(tools_allowing(allowed_tools)),
+        ..AgentConfig::default()
+    })
+}
+
+/// Build a [`ToolsConfig`] allowlist from a slice of tool names.
+///
+/// Why: Both config builders share the same "explicit allowlist" wiring; one
+/// helper keeps the `&[&str] → ToolsConfig` mapping in a single place.
+/// What: Returns a [`ToolsConfig`] whose `allowed` is `Some(owned list)`.
+/// Test: exercised via `pm_config_carries_assembled_prompt_and_allowlist` and
+/// `sub_agent_config_maps_asset_into_config`.
+fn tools_allowing(allowed_tools: &[&str]) -> ToolsConfig {
+    ToolsConfig {
+        allowed: Some(allowed_tools.iter().map(|t| t.to_string()).collect()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    use super::super::agents::{ENGINEER_AGENT_NAME, PM_AGENT_NAME};
+
+    /// The PM tool surface used in tests (mirrors the WI-4 demo PM allowlist).
+    const PM_TOOLS: &[&str] = &["delegate_to_agent", "read_file"];
+    /// The engineer tool surface used in tests.
+    const ENGINEER_TOOLS: &[&str] = &["read_file", "write_file", "edit", "bash"];
+
+    /// Write `<project>/.trusty-mpm/<name>` with `content`, creating dirs.
+    fn write_override(project: &Path, name: &str, content: &str) {
+        let dir = project.join(".trusty-mpm");
+        fs::create_dir_all(&dir).expect("create .trusty-mpm");
+        fs::write(dir.join(name), content).expect("write override");
+    }
+
+    /// A project with a custom `PM_INSTRUCTIONS_DEPLOYED.md` yields a PM prompt
+    /// that contains the override text and is still floored by BASE_PM (#1048 AC).
+    #[test]
+    fn pm_prompt_layers_project_override_above_base_floor() {
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            "PM_INSTRUCTIONS_DEPLOYED.md",
+            "# Wholly Custom PM\n\nMETAHARNESS_OVERRIDE_MARKER\n",
+        );
+
+        let prompt = assemble_pm_prompt(tmp.path());
+
+        // The override text appears...
+        assert!(
+            prompt.contains("METAHARNESS_OVERRIDE_MARKER"),
+            "override text must appear in the assembled PM prompt"
+        );
+        // ...and the non-overridable BASE_PM floor is still appended last.
+        assert!(
+            prompt.contains("# BASE_PM Framework Floor"),
+            "BASE_PM floor must always be present"
+        );
+        let marker = prompt
+            .find("METAHARNESS_OVERRIDE_MARKER")
+            .expect("marker present");
+        let floor = prompt
+            .find("# BASE_PM Framework Floor")
+            .expect("floor present");
+        assert!(
+            marker < floor,
+            "the project override must precede (end above) the BASE_PM floor"
+        );
+    }
+
+    /// With no overrides, the PM prompt is the bundled assembly (BASE_PM last).
+    #[test]
+    fn pm_prompt_without_overrides_is_bundled() {
+        let tmp = TempDir::new().unwrap();
+        let prompt = assemble_pm_prompt(tmp.path());
+        assert!(prompt.contains("# PM Agent -- Claude MPM"));
+        assert!(prompt.contains("# BASE_PM Framework Floor"));
+    }
+
+    /// The engineer sub-agent prompt loads from the bundled asset.
+    #[test]
+    fn engineer_prompt_loads_from_asset() {
+        let prompt = load_agent_prompt(ENGINEER_AGENT_NAME).expect("engineer prompt loads");
+        // Body of src/assets/agents/python-engineer.md.
+        assert!(
+            prompt.contains("Python"),
+            "the python-engineer asset body must be loaded"
+        );
+        assert!(!prompt.is_empty(), "loaded prompt must be non-empty");
+    }
+
+    /// The loaded prompt has the YAML frontmatter stripped.
+    #[test]
+    fn loaded_prompt_omits_frontmatter() {
+        let prompt = load_agent_prompt(ENGINEER_AGENT_NAME).expect("engineer prompt loads");
+        assert!(
+            !prompt.starts_with("---"),
+            "frontmatter fence must be stripped from the loaded prompt"
+        );
+        assert!(
+            !prompt.contains("extends: base-engineer"),
+            "frontmatter keys must not leak into the instruction body"
+        );
+    }
+
+    /// An unknown agent name returns a clean error rather than panicking (#1048).
+    #[test]
+    fn unknown_agent_prompt_errors() {
+        let err = load_agent_prompt("no-such-agent-xyz")
+            .expect_err("unknown agent must error, not panic");
+        match &err {
+            MetaInstructionError::UnknownAgent(name) => assert_eq!(name, "no-such-agent-xyz"),
+        }
+        assert!(format!("{err}").contains("no-such-agent-xyz"));
+    }
+
+    /// `strip_frontmatter` passes a body-only string through unchanged.
+    #[test]
+    fn strip_frontmatter_passes_through_bodyless() {
+        let body = "# Just a Body\n\nNo frontmatter here.\n";
+        assert_eq!(strip_frontmatter(body), body);
+    }
+
+    /// `strip_frontmatter` drops a leading YAML block and keeps the body.
+    #[test]
+    fn strip_frontmatter_drops_leading_block() {
+        let doc = "---\nname: x\nrole: y\n---\n# Body\n\ncontent\n";
+        let body = strip_frontmatter(doc);
+        assert!(body.starts_with("# Body"));
+        assert!(!body.contains("name: x"));
+    }
+
+    /// The PM config carries the assembled prompt + the model + the allowlist.
+    #[test]
+    fn pm_config_carries_assembled_prompt_and_allowlist() {
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            "PM_INSTRUCTIONS_DEPLOYED.md",
+            "PM_CONFIG_MARKER\n",
+        );
+        let cfg = pm_agent_config(PM_AGENT_NAME, tmp.path(), Some("anthropic/x"), PM_TOOLS);
+
+        assert_eq!(cfg.agent.name, PM_AGENT_NAME);
+        assert_eq!(cfg.agent.model.as_deref(), Some("anthropic/x"));
+        assert!(cfg.system_prompt.content.contains("PM_CONFIG_MARKER"));
+        assert!(
+            cfg.system_prompt
+                .content
+                .contains("# BASE_PM Framework Floor")
+        );
+        let allowed = cfg
+            .tools
+            .as_ref()
+            .and_then(|t| t.allowed.as_ref())
+            .expect("pm has an allowlist");
+        assert!(allowed.contains(&"delegate_to_agent".to_string()));
+        assert!(
+            !allowed.contains(&"write_file".to_string()),
+            "PM must not be allowed to write files directly"
+        );
+    }
+
+    /// The sub-agent config maps the bundled asset body into `system_prompt`.
+    #[test]
+    fn sub_agent_config_maps_asset_into_config() {
+        let cfg = sub_agent_config(ENGINEER_AGENT_NAME, None, ENGINEER_TOOLS)
+            .expect("engineer config builds");
+        assert_eq!(cfg.agent.name, ENGINEER_AGENT_NAME);
+        assert!(cfg.system_prompt.content.contains("Python"));
+        assert!(!cfg.system_prompt.content.starts_with("---"));
+        let allowed = cfg
+            .tools
+            .as_ref()
+            .and_then(|t| t.allowed.as_ref())
+            .expect("engineer has an allowlist");
+        for tool in ENGINEER_TOOLS {
+            assert!(
+                allowed.contains(&tool.to_string()),
+                "engineer must be allowed {tool}"
+            );
+        }
+    }
+
+    /// Building a sub-agent config for an unknown agent propagates the error.
+    #[test]
+    fn sub_agent_config_propagates_unknown_agent() {
+        let err = sub_agent_config("no-such-agent-xyz", None, ENGINEER_TOOLS)
+            .expect_err("unknown agent must error");
+        assert!(matches!(err, MetaInstructionError::UnknownAgent(_)));
+    }
+
+    /// The built configs serialise back to TOML and reparse — proving they map
+    /// cleanly onto the on-disk `AgentConfig` format the runner loads.
+    #[test]
+    fn configs_roundtrip_through_toml() {
+        let tmp = TempDir::new().unwrap();
+        let pm = pm_agent_config(PM_AGENT_NAME, tmp.path(), Some("m"), PM_TOOLS);
+        let pm_toml = toml::to_string(&pm).expect("pm serialises");
+        let reparsed = AgentConfig::from_toml_str(&pm_toml).expect("pm reparses");
+        assert_eq!(reparsed.agent.name, PM_AGENT_NAME);
+        assert!(
+            reparsed
+                .system_prompt
+                .content
+                .contains("# BASE_PM Framework Floor")
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/instructions.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/instructions.rs
@@ -59,6 +59,19 @@ pub(crate) enum MetaInstructionError {
 /// Reusing [`resolve_pm_prompt`] (rather than re-implementing the layering) is
 /// the single source of truth #1048 requires, so the two launch paths can never
 /// diverge.
+///
+/// This thin passthrough is *deliberate* and must be kept: it is the stable API
+/// boundary the WI-4 metaharness orchestrator consumes. Future readers should not
+/// "simplify" it away by inlining [`resolve_pm_prompt`] at the call sites — the
+/// indirection is the seam that lets prompt assembly evolve (e.g. add caching or
+/// metaharness-specific layering) without churning the orchestrator.
+///
+/// Prompt resolution here is **infallible by design**: [`resolve_pm_prompt`]
+/// returns a plain `String`, degrading gracefully when override files are missing,
+/// empty, or unreadable (it falls back to the bundled defaults rather than
+/// erroring). That is why this function — and [`pm_agent_config`] — return owned
+/// values rather than a `Result`; a missing/broken override is a normal,
+/// non-fatal condition, not an error to propagate.
 /// What: Delegates verbatim to
 /// [`resolve_pm_prompt`](trusty_mpm::core::instruction_overrides::resolve_pm_prompt),
 /// which reads any override files under `<project_dir>/.trusty-mpm/` and appends
@@ -102,34 +115,38 @@ pub(crate) fn load_agent_prompt(agent_name: &str) -> Result<String, MetaInstruct
 /// including the matching closing `---` fence and returns the remaining body;
 /// otherwise returns `raw` unchanged (an asset without frontmatter is already a
 /// body).
-/// Test: `loaded_prompt_omits_frontmatter`, `strip_frontmatter_passes_through_bodyless`.
+/// Test: `loaded_prompt_omits_frontmatter`, `strip_frontmatter_passes_through_bodyless`,
+/// `strip_frontmatter_handles_crlf`, `strip_frontmatter_handles_fence_only_no_trailing_newline`,
+/// `strip_frontmatter_handles_lf`, `strip_frontmatter_passes_through_no_frontmatter`.
 fn strip_frontmatter(raw: &str) -> &str {
-    // The opening fence must be the very first line (a line that is exactly `---`,
-    // ignoring a trailing CR for CRLF files). If it is not, there is no
-    // frontmatter and the whole input is already a body.
-    let first_line = raw.lines().next().unwrap_or("");
-    if first_line.trim_end_matches('\r') != "---" {
+    // Work entirely in byte offsets against the *original* string so CRLF and LF
+    // inputs are handled identically and the returned slice always borrows from
+    // `raw`. `split_inclusive('\n')` is the only iterator we use because, unlike
+    // `lines()`, it preserves line terminators — so the cumulative byte length of
+    // the lines it yields exactly reconstructs `raw`, keeping our offsets honest.
+
+    // The opening fence must be the very first line: a line whose content (after
+    // dropping its `\n` and any trailing `\r`) is exactly `---`. Anything else
+    // means there is no frontmatter and the whole input is already a body.
+    let mut lines = raw.split_inclusive('\n');
+    let Some(first_line) = lines.next() else {
+        return raw; // empty input
+    };
+    if first_line.trim_end_matches(['\r', '\n']) != "---" {
         return raw;
     }
-    // Skip past the opening fence line, then scan for the closing `---` fence
-    // line. `split_inclusive('\n')` keeps line terminators so byte offsets line
-    // up with the original string, letting us return a borrowed body slice.
-    let mut consumed = first_line.len();
-    // Account for the opening fence's own newline (LF or CRLF) if present.
-    consumed += raw[consumed..]
-        .strip_prefix("\r\n")
-        .map(|_| 2)
-        .or_else(|| raw[consumed..].strip_prefix('\n').map(|_| 1))
-        .unwrap_or(0);
 
-    let mut offset = consumed;
-    for line in raw[consumed..].split_inclusive('\n') {
+    // Scan the remaining lines for the closing `---` fence. `offset` tracks the
+    // byte position of the *start* of each candidate line within `raw`; once we
+    // find the closing fence, the body begins immediately after it.
+    let mut offset = first_line.len();
+    for line in lines {
         if line.trim_end_matches(['\r', '\n']) == "---" {
-            // Body begins immediately after this closing fence line.
             return &raw[offset + line.len()..];
         }
         offset += line.len();
     }
+
     // Unterminated frontmatter — treat the whole thing as a body (robustness).
     raw
 }
@@ -145,6 +162,14 @@ fn strip_frontmatter(raw: &str) -> &str {
 /// (when `Some`) and the given tool allowlist applied. The PM is constrained to a
 /// delegate + read-only surface by its `allowed` list, mirroring the MPM protocol
 /// where the PM orchestrates and sub-agents act.
+///
+/// This function is **infallible by design** (returns `AgentConfig`, not a
+/// `Result`): the only fallible-looking step, prompt resolution via
+/// [`assemble_pm_prompt`]/[`resolve_pm_prompt`], degrades gracefully — a
+/// missing or unreadable `.trusty-mpm/` override falls back to the bundled base
+/// prompt rather than erroring. There is therefore no IO error to propagate, so
+/// the infallible signature is intentional (contrast with [`sub_agent_config`],
+/// which *can* fail on an unknown agent slug).
 /// Test: `pm_config_carries_assembled_prompt_and_allowlist`.
 pub(crate) fn pm_agent_config(
     pm_name: &str,
@@ -224,12 +249,11 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    use super::super::agents::{ENGINEER_AGENT_NAME, PM_AGENT_NAME};
-
-    /// The PM tool surface used in tests (mirrors the WI-4 demo PM allowlist).
-    const PM_TOOLS: &[&str] = &["delegate_to_agent", "read_file"];
-    /// The engineer tool surface used in tests.
-    const ENGINEER_TOOLS: &[&str] = &["read_file", "write_file", "edit", "bash"];
+    // Import the canonical tool allowlists from the agents module rather than
+    // re-declaring them here. Re-declaring local copies risks silent divergence
+    // from `agents::{PM_TOOLS, ENGINEER_TOOLS}` (the single source of truth for
+    // each agent's capability grant); importing them keeps the tests honest.
+    use super::super::agents::{ENGINEER_AGENT_NAME, ENGINEER_TOOLS, PM_AGENT_NAME, PM_TOOLS};
 
     /// Write `<project>/.trusty-mpm/<name>` with `content`, creating dirs.
     fn write_override(project: &Path, name: &str, content: &str) {
@@ -333,6 +357,51 @@ mod tests {
         let body = strip_frontmatter(doc);
         assert!(body.starts_with("# Body"));
         assert!(!body.contains("name: x"));
+    }
+
+    /// (c) Normal LF frontmatter: the body after the closing fence is returned
+    /// verbatim (no leading newline from the fence's own terminator).
+    #[test]
+    fn strip_frontmatter_handles_lf() {
+        let doc = "---\nname: x\n---\n# Body\n\ncontent\n";
+        assert_eq!(strip_frontmatter(doc), "# Body\n\ncontent\n");
+    }
+
+    /// (a) CRLF frontmatter: the same `\r\n`-terminated input strips identically,
+    /// preserving the CRLF body verbatim. This is the case the offset arithmetic
+    /// previously made fragile/non-obvious.
+    #[test]
+    fn strip_frontmatter_handles_crlf() {
+        let doc = "---\r\nname: x\r\nrole: y\r\n---\r\n# Body\r\n\r\ncontent\r\n";
+        assert_eq!(strip_frontmatter(doc), "# Body\r\n\r\ncontent\r\n");
+    }
+
+    /// (b) A file that is just the opening/closing fence pair with no trailing
+    /// newline after the second `---` yields an empty body (everything was
+    /// frontmatter), not the original string. Covers the EOF-at-fence edge.
+    #[test]
+    fn strip_frontmatter_handles_fence_only_no_trailing_newline() {
+        // Opening fence, one key, closing fence as the final bytes (no `\n`).
+        let doc = "---\nname: x\n---";
+        assert_eq!(strip_frontmatter(doc), "");
+
+        // Degenerate empty frontmatter (`---\n---`) is likewise all-frontmatter.
+        let empty = "---\n---";
+        assert_eq!(strip_frontmatter(empty), "");
+    }
+
+    /// (d) No frontmatter at all: the input is returned unchanged, including when
+    /// the first line merely *contains* dashes but is not exactly `---`.
+    #[test]
+    fn strip_frontmatter_passes_through_no_frontmatter() {
+        let plain = "# Title\n\nbody\n";
+        assert_eq!(strip_frontmatter(plain), plain);
+
+        let near_miss = "----\nname: x\n----\n# Body\n";
+        assert_eq!(strip_frontmatter(near_miss), near_miss);
+
+        // Empty input is trivially body-only.
+        assert_eq!(strip_frontmatter(""), "");
     }
 
     /// The PM config carries the assembled prompt + the model + the allowlist.

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/mod.rs
@@ -21,6 +21,7 @@
 //! `agents`/`transcript`/`orchestrator`; CLI parsing in `tests.rs`.
 
 mod agents;
+mod instructions;
 mod orchestrator;
 mod registry;
 mod transcript;
@@ -147,7 +148,7 @@ async fn run_demo(project: &Path) -> anyhow::Result<()> {
     let llm = std::sync::Arc::new(client);
 
     let agents_dir = meta_agents_dir(project);
-    agents::write_agent_configs(&agents_dir)
+    agents::write_agent_configs(&agents_dir, project)
         .context("failed to materialise bundled agent configs")?;
 
     let task = demo_task();

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/orchestrator/tests.rs
@@ -115,7 +115,7 @@ fn stop(text: &str, p: u32, c: u32) -> Value {
 async fn orchestrator_runs_full_delegation_cycle() {
     let project = tempfile::tempdir().expect("project tempdir");
     let agents = tempfile::tempdir().expect("agents tempdir");
-    write_agent_configs(agents.path()).expect("write agent configs");
+    write_agent_configs(agents.path(), project.path()).expect("write agent configs");
 
     // Call order the orchestrator drives:
     //  1. PM loop call 1   -> delegate_to_agent(python-engineer, task)
@@ -323,7 +323,7 @@ async fn orchestrator_live_demo() {
 
     let project = tempfile::tempdir().expect("project tempdir");
     let agents = tempfile::tempdir().expect("agents tempdir");
-    write_agent_configs(agents.path()).expect("write agent configs");
+    write_agent_configs(agents.path(), project.path()).expect("write agent configs");
 
     let orchestrator = Orchestrator::new(
         llm,


### PR DESCRIPTION
## Summary
**WI-3 of the trusty-mpm M1 POC milestone (#1045).** Adds the custom-instruction loading layer the metaharness orchestrator (WI-4) will consume.

## Changes
- New module `crates/trusty-mpm/src/bin/tm/commands/meta/instructions.rs` exposing: `assemble_pm_prompt(project_dir)`, `load_agent_prompt(agent_name)`, `pm_agent_config(...)`, `sub_agent_config(...)`, and a typed `MetaInstructionError::UnknownAgent` (no panics on missing agents).
- REUSES the existing `core::instruction_overrides::resolve_pm_prompt` + `instruction_pipeline` machinery (same path a daemon-launched PM uses): layers bundled PM sections + `<project>/.trusty-mpm/` overrides, with the non-overridable BASE_PM floor appended last. Sub-agent prompts load from the existing compile-time `core::bundle::ALL` asset table.
- Maps assembled prompts into trusty-code `AgentConfig` (`system_prompt.content`, `model`, `tools.allowed`); `agents.rs` refactored to build configs via the new layer (owns only PM/engineer tool policy now).

## Implementation Notes
- **No feature gating:** trusty-code is an always-on dep; the `meta` subcommand is part of `cli`, so no feature gating was added — matching the existing meta-command layout. Default `cargo build -p trusty-mpm` is unaffected.
- **Tests:** PM assembly layers a project override above the BASE_PM floor; sub-agent prompt loads + frontmatter-stripped + maps into AgentConfig; unknown agent returns a clean error; TOML round-trip. 41 meta tests pass; full trusty-mpm suite green; clippy/fmt/line-cap clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)