### PR TITLE
fix(trusty-memory): open daemon palace redb as Writer — fail-loud, no silent read-only (closes #1487)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -16,7 +16,7 @@ crates/trusty-analyze/src/lang/adapters/typescript.rs	560
 crates/trusty-analyze/src/main.rs	567
 crates/trusty-analyze/src/mcp/mod.rs	892
 crates/trusty-gworkspace/src/tools.rs	557
-crates/trusty-memory/src/lib.rs	616
+crates/trusty-memory/src/lib.rs	622
 crates/trusty-search/src/commands/doctor_checks.rs	503
 crates/trusty-search/src/core/indexer/tests.rs	2472
 crates/trusty-search/src/service/call_chain.rs	738

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -15,6 +15,7 @@
 use crate::memory_core::community::KnowledgeGap;
 use crate::memory_core::palace::{Palace, PalaceId};
 use crate::memory_core::retrieval::PalaceHandle;
+use crate::memory_core::store::concurrent_open::OpenIntent;
 use crate::memory_core::store::palace_store::PalaceStore;
 use anyhow::{Context, Result};
 use dashmap::DashMap;
@@ -67,6 +68,18 @@ pub struct PalaceRegistry {
     /// readers should treat that as an empty list, not an error.
     /// Test: `gaps_cache_round_trip` in this module.
     gaps_cache: Arc<DashMap<PalaceId, Vec<KnowledgeGap>>>,
+    /// Redb open intent applied to every palace this registry opens.
+    ///
+    /// Why (issue #1487): the HTTP daemon is the sole writer and must open
+    /// palace redb files with [`OpenIntent::Writer`] so a second daemon
+    /// instance fails loud instead of silently degrading to a read-only
+    /// snapshot. All other registries (CLI, stdio MCP, tests) default to
+    /// [`OpenIntent::ReadOnlyClient`] to preserve the snapshot read-fallback
+    /// (issue #59). The daemon opts in via [`PalaceRegistry::with_writer_intent`].
+    /// What: `Copy` enum carried by value; threaded into `open_palace`,
+    /// `create_palace`, and the eager `open` hydration path.
+    /// Test: `with_writer_intent_sets_writer_open_intent`.
+    open_intent: OpenIntent,
 }
 
 impl Default for PalaceRegistry {
@@ -99,7 +112,41 @@ impl PalaceRegistry {
         Self {
             handles: Arc::new(Mutex::new(LruCache::new(cap))),
             gaps_cache: Arc::new(DashMap::new()),
+            // Default to read-only-client intent so CLI / stdio / test
+            // registries keep the issue-#59 snapshot read-fallback. The HTTP
+            // daemon overrides this via `with_writer_intent` (issue #1487).
+            open_intent: OpenIntent::ReadOnlyClient,
         }
+    }
+
+    /// Mark this registry as the sole writer: open every palace with
+    /// [`OpenIntent::Writer`].
+    ///
+    /// Why (issue #1487): the HTTP daemon must fail loud when another live
+    /// daemon already holds a palace's redb write lock, rather than silently
+    /// opening a read-only snapshot and rejecting every write for its
+    /// lifetime (the original bug — a rogue second listener served read-only
+    /// and the legitimate `memory_remember` was lost). Calling this on the
+    /// daemon's registry threads `Writer` intent down to every
+    /// `PalaceHandle::open_with_intent`.
+    /// What: Consuming builder that sets `open_intent = OpenIntent::Writer`
+    /// and returns `self`. All `Arc`-shared state is preserved.
+    /// Test: `with_writer_intent_sets_writer_open_intent`.
+    #[must_use]
+    pub fn with_writer_intent(mut self) -> Self {
+        self.open_intent = OpenIntent::Writer;
+        self
+    }
+
+    /// The redb open intent this registry applies to every palace it opens.
+    ///
+    /// Why: Lets the daemon assert (in tests / diagnostics) that it really is
+    /// running as the writer, and lets callers branch if needed.
+    /// What: Returns the `Copy` `OpenIntent` value.
+    /// Test: `with_writer_intent_sets_writer_open_intent`.
+    #[must_use]
+    pub fn open_intent(&self) -> OpenIntent {
+        self.open_intent
     }
 
     /// Insert a new palace handle, replacing any prior entry with the same id.
@@ -264,7 +311,10 @@ impl PalaceRegistry {
         let palace_dir = data_root.join(palace_id.as_str());
         let palace = PalaceStore::load_palace(&palace_dir)
             .with_context(|| format!("load palace metadata for {palace_id}"))?;
-        let handle = PalaceHandle::open(&palace)?;
+        // Issue #1487: honour the registry's open intent. On the HTTP daemon
+        // (`Writer`) a second live instance holding the lock makes this fail
+        // loud rather than returning a snapshot-mode (read-only) handle.
+        let handle = PalaceHandle::open_with_intent(&palace, self.open_intent)?;
         self.register_arc(handle.clone());
         Ok(handle)
     }
@@ -287,7 +337,10 @@ impl PalaceRegistry {
             .with_context(|| format!("create palace dir {}", palace_dir.display()))?;
         PalaceStore::save_palace(&palace)
             .with_context(|| format!("save palace metadata for {}", palace.id))?;
-        let handle = PalaceHandle::open(&palace)?;
+        // Issue #1487: honour the registry's open intent (Writer on the HTTP
+        // daemon) so a freshly-created palace is opened under the same
+        // fail-loud contract as a re-opened one.
+        let handle = PalaceHandle::open_with_intent(&palace, self.open_intent)?;
         self.register_arc(handle.clone());
         Ok(handle)
     }
@@ -330,7 +383,12 @@ impl PalaceRegistry {
         let palaces = PalaceStore::list_palaces(data_root)
             .with_context(|| format!("list palaces under {}", data_root.display()))?;
         for palace in palaces {
-            match PalaceHandle::open(&palace) {
+            // Use the registry's configured intent (issue #1487). The eager
+            // hydration constructor builds a `ReadOnlyClient` registry via
+            // `Self::new()`, so this preserves the historical snapshot-fallback
+            // behaviour while staying correct if a future caller hydrates a
+            // writer registry.
+            match PalaceHandle::open_with_intent(&palace, registry.open_intent) {
                 Ok(handle) => registry.register_arc(handle),
                 Err(e) => {
                     tracing::warn!(palace = %palace.id, "skipping palace during registry open: {e:#}");
@@ -361,6 +419,30 @@ mod tests {
         reg.register(make_handle("alpha", dir.path()));
         let h = reg.get(&PalaceId::new("alpha")).expect("registered");
         assert_eq!(h.id.as_str(), "alpha");
+    }
+
+    /// Why (issue #1487): a default registry must open palaces as a read-only
+    /// client (preserving the snapshot fallback for CLI / stdio / tests),
+    /// while a registry built with `with_writer_intent` must open as a writer
+    /// (fail-loud on a held lock) — this is what the HTTP daemon relies on.
+    /// What: Asserts the default `open_intent()` is `ReadOnlyClient` and that
+    /// `with_writer_intent()` flips it to `Writer`.
+    /// Test: this test.
+    #[test]
+    fn with_writer_intent_sets_writer_open_intent() {
+        let default_reg = PalaceRegistry::new();
+        assert_eq!(
+            default_reg.open_intent(),
+            OpenIntent::ReadOnlyClient,
+            "default registry must open palaces read-only (snapshot fallback)"
+        );
+
+        let writer_reg = PalaceRegistry::new().with_writer_intent();
+        assert_eq!(
+            writer_reg.open_intent(),
+            OpenIntent::Writer,
+            "with_writer_intent() must mark the registry as a writer"
+        );
     }
 
     /// Why: Issue #180 — palace deletion must invalidate the in-memory

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -15,6 +15,7 @@ use crate::memory_core::decay::DecayConfig;
 use crate::memory_core::dream::extract_keywords;
 use crate::memory_core::filter::{FilterReject, classify};
 use crate::memory_core::palace::{Drawer, DrawerType, Palace, PalaceId, RoomType};
+use crate::memory_core::store::concurrent_open::OpenIntent;
 use crate::memory_core::store::kg::KnowledgeGraph;
 use crate::memory_core::store::l1_cache::L1Cache;
 use crate::memory_core::store::palace_store::PalaceStore;
@@ -199,6 +200,25 @@ impl PalaceHandle {
     /// Test: `registry_create_and_open` creates a palace, drops the registry,
     /// and re-opens it.
     pub fn open(palace: &Palace) -> Result<Arc<PalaceHandle>> {
+        Self::open_with_intent(palace, OpenIntent::ReadOnlyClient)
+    }
+
+    /// Open a palace from disk with the caller's redb open intent.
+    ///
+    /// Why (issue #1487): the HTTP daemon is the sole writer and must open its
+    /// palaces with [`OpenIntent::Writer`] so a second daemon instance fails
+    /// loud (after the bounded handoff window) instead of silently opening a
+    /// read-only snapshot and rejecting every write for its lifetime. CLI,
+    /// stdio MCP, and test callers keep [`OpenIntent::ReadOnlyClient`] so they
+    /// can still serve reads from a snapshot while the daemon holds the lock.
+    /// What: Same hydration pipeline as [`PalaceHandle::open`], but passes
+    /// `intent` down to `UsearchStore::new_with_intent` and
+    /// `KnowledgeGraph::open_with_intent`. When `Writer` and a second live
+    /// daemon already holds the lock, this returns `Err` (no handle), so the
+    /// daemon process fails to start rather than serving in a broken state.
+    /// Test: `registry_create_and_open` (default read-only path) and
+    /// `writer_intent_open_fails_loud_on_locked_palace` in the store tests.
+    pub fn open_with_intent(palace: &Palace, intent: OpenIntent) -> Result<Arc<PalaceHandle>> {
         let data_dir = &palace.data_dir;
         std::fs::create_dir_all(data_dir)
             .with_context(|| format!("create palace data dir {}", data_dir.display()))?;
@@ -211,12 +231,12 @@ impl PalaceHandle {
             .with_context(|| format!("load L1 cache for {}", palace.id))?;
 
         let vector_path = data_dir.join("index.usearch");
-        let vector_store = UsearchStore::new(vector_path, 384)
+        let vector_store = UsearchStore::new_with_intent(vector_path, 384, intent)
             .with_context(|| format!("open vector store for {}", palace.id))?;
 
         let kg_path = data_dir.join("kg.db");
-        let kg =
-            KnowledgeGraph::open(&kg_path).with_context(|| format!("open KG for {}", palace.id))?;
+        let kg = KnowledgeGraph::open_with_intent(&kg_path, intent)
+            .with_context(|| format!("open KG for {}", palace.id))?;
 
         // Load full drawer table from SQLite (the persistent source of truth).
         // Fall back to an empty list on error so a corrupt table doesn't make

--- a/crates/trusty-common/src/memory_core/store/concurrent_open.rs
+++ b/crates/trusty-common/src/memory_core/store/concurrent_open.rs
@@ -54,6 +54,40 @@ pub enum OpenIntent {
     ReadOnlyClient,
 }
 
+/// Number of `Database::create` attempts the `Writer` path makes before it
+/// gives up and fails loud on a persistent `DatabaseAlreadyOpen`.
+///
+/// Why (issue #1487): a graceful launchd handoff
+/// (`bootout` old → `bootstrap` new) briefly overlaps two daemons — the old
+/// one may still hold the redb `flock(LOCK_EX)` for a few hundred
+/// milliseconds while the new one starts. A naive fail-loud on the very
+/// first `DatabaseAlreadyOpen` would make the fresh daemon exit non-zero,
+/// triggering launchd's `KeepAlive { SuccessfulExit: false }` respawn — i.e.
+/// restart flapping. Retrying for a short, bounded window absorbs the
+/// handoff without masking a *persistent* conflict (a second live daemon).
+/// What: 5 attempts. Combined with [`WRITER_RETRY_SLEEP_MS`] the total wait
+/// is bounded at ~1.55 s — long enough to outlast a normal flock handoff,
+/// short enough that a genuine conflict still fails loud quickly.
+/// Test: `writer_intent_fails_on_locked_file` (persistent conflict still
+/// errors) and `writer_intent_retries_then_succeeds_when_lock_released`
+/// (transient conflict succeeds within the window).
+pub(crate) const WRITER_RETRY_ATTEMPTS: u8 = 5;
+
+/// Per-attempt backoff (milliseconds) for the `Writer` retry loop.
+///
+/// Why (issue #1487): exponential backoff spreads the 5 attempts across a
+/// ~1.55 s window (0 + 50 + 100 + 400 + 1000) so the common case (handoff
+/// finishes in <500 ms) succeeds on attempt 2 or 3 without waiting the full
+/// budget, while a still-held lock is re-probed a few more times before we
+/// declare a hard conflict. The first attempt has no preceding sleep, so the
+/// uncontended open returns immediately.
+/// What: One sleep value per attempt *after* the first
+/// (`WRITER_RETRY_ATTEMPTS - 1 == 4` entries). The sleep at index `i` is
+/// applied before attempt `i + 1`.
+/// Test: `writer_retry_sleep_table_matches_attempt_count` asserts the table
+/// length stays in lock-step with [`WRITER_RETRY_ATTEMPTS`].
+pub(crate) const WRITER_RETRY_SLEEP_MS: [u64; 4] = [50, 100, 400, 1000];
+
 /// Whether a redb file was opened directly (read/write) or via a snapshot
 /// (read-only).
 ///
@@ -196,20 +230,26 @@ fn snapshot_path_for(original: &Path) -> PathBuf {
 /// the same palace at all — every recall fails with "open palace …".
 /// With this helper, a read-only client detects lock contention and
 /// transparently switches to a snapshot copy so reads can proceed.
-/// Issue #1152 (Tier 3): a daemon/writer that gets `DatabaseAlreadyOpen`
-/// must NOT silently open a snapshot — it would service all its writes
-/// against a throw-away copy while the real daemon continues writing to
-/// the live file. Writer contexts receive a loud `Err` instead.
-/// What: First attempts `Database::create(path)`. On
+/// Issue #1152 (Tier 3) / #1487: a daemon/writer that gets
+/// `DatabaseAlreadyOpen` must NOT silently open a snapshot — it would service
+/// all its writes against a throw-away copy while the real daemon continues
+/// writing to the live file. Writer contexts receive a loud `Err` instead,
+/// but only after a short bounded retry window (issue #1487) that absorbs the
+/// brief flock overlap of a graceful launchd handoff without flapping.
+/// What: Attempts `Database::create(path)`. On
 /// `DatabaseError::DatabaseAlreadyOpen` the behaviour depends on `intent`.
 /// ReadOnlyClient: copies `path` to a per-process snapshot and opens that
-/// (existing read-only fallback for issue #59). Writer: returns `Err`
-/// immediately with a clear message and ERROR log so the daemon fails
-/// loudly rather than diverging. Returns the open database, a
-/// `SnapshotGuard` that removes the snapshot file when dropped, and the
-/// `OpenMode` so the caller can reject writes when running on a snapshot.
-/// Test: `snapshot_fallback_when_locked` (ReadOnlyClient path) and
-/// `writer_intent_fails_on_locked_file` (Writer path, issue #1152).
+/// (existing read-only fallback for issue #59). Writer: retries up to
+/// [`WRITER_RETRY_ATTEMPTS`] times with exponential backoff
+/// ([`WRITER_RETRY_SLEEP_MS`]); if the lock is still held after the window,
+/// returns `Err` with a clear, actionable message and an ERROR log — never a
+/// snapshot. Returns the open database, a `SnapshotGuard` that removes the
+/// snapshot file when dropped, and the `OpenMode` so the caller can reject
+/// writes when running on a snapshot.
+/// Test: `snapshot_fallback_when_locked` (ReadOnlyClient path),
+/// `writer_intent_fails_on_locked_file` (Writer persistent-conflict path),
+/// and `writer_intent_retries_then_succeeds_when_lock_released` (Writer
+/// transient-conflict path, issue #1487).
 pub fn try_open_or_snapshot(
     path: &Path,
     intent: OpenIntent,
@@ -244,53 +284,123 @@ pub fn try_open_or_snapshot(
             Ok((Arc::new(db), SnapshotGuard::noop(), OpenMode::Recreated))
         }
         Err(DatabaseError::DatabaseAlreadyOpen) => match intent {
-            // Issue #1152, Tier 3: a writer that hits the lock must fail loud,
-            // not silently diverge by writing to a snapshot copy.
-            OpenIntent::Writer => {
-                tracing::error!(
-                    path = %path.display(),
-                    "redb file is already locked by another process but this process \
-                     requires write access (OpenIntent::Writer). Refusing to open a \
-                     read-only snapshot — another daemon is running and holds the write \
-                     lock. Stop the other daemon first or ensure only one writer is \
-                     active at a time."
-                );
-                Err(anyhow::anyhow!(
-                    "palace redb file {} is already locked by another process; \
-                     this daemon requires write access and cannot safely proceed. \
-                     Stop the other daemon or run `trusty-memory stop` first.",
-                    path.display()
-                ))
-            }
+            // Issue #1152, Tier 3 + #1487: a writer that hits the lock must
+            // fail loud (never a snapshot), but only after a short bounded
+            // retry to absorb a graceful launchd handoff's flock overlap.
+            OpenIntent::Writer => open_writer_with_handoff_retry(path),
             // Original fallback for read-only clients (issue #59).
-            OpenIntent::ReadOnlyClient => {
-                let snap = snapshot_path_for(path);
-                // Snapshot paths are per-call unique (pid + monotonic
-                // counter), so no stale-file cleanup is needed here.
-                std::fs::copy(path, &snap).with_context(|| {
-                    format!(
-                        "snapshot {} -> {} for read-only fallback",
-                        path.display(),
-                        snap.display()
-                    )
-                })?;
-                let db = Database::create(&snap).with_context(|| {
-                    format!(
-                        "open redb snapshot at {} (fallback for locked {})",
-                        snap.display(),
-                        path.display()
-                    )
-                })?;
-                tracing::info!(
-                    original = %path.display(),
-                    snapshot = %snap.display(),
-                    "redb file locked by another process; opened read-only snapshot"
-                );
-                Ok((Arc::new(db), SnapshotGuard::new(snap), OpenMode::Snapshot))
-            }
+            OpenIntent::ReadOnlyClient => open_read_only_snapshot(path),
         },
         Err(e) => Err(anyhow::anyhow!("open redb at {}: {e}", path.display())),
     }
+}
+
+/// Open `path` exclusively for a writer, retrying through a brief
+/// `DatabaseAlreadyOpen` window before failing loud.
+///
+/// Why (issue #1487): a graceful daemon restart (`launchctl bootout` the old
+/// instance, then `bootstrap` the new one) briefly overlaps two processes;
+/// the old daemon can still hold the redb `flock` for a few hundred
+/// milliseconds. Failing on the first `DatabaseAlreadyOpen` would make the
+/// new daemon exit non-zero and trigger launchd's respawn-on-failure, i.e.
+/// flapping. Retrying for a bounded window
+/// ([`WRITER_RETRY_ATTEMPTS`] × [`WRITER_RETRY_SLEEP_MS`]) lets the handoff
+/// complete. A *persistent* lock (a second live daemon) still fails loud at
+/// the end of the window — it MUST NOT degrade to a snapshot.
+/// What: Re-attempts `Database::create(path)` with exponential backoff. On
+/// success returns `OpenMode::ReadWrite`; if every attempt sees
+/// `DatabaseAlreadyOpen`, logs an ERROR and returns a clear `Err` naming the
+/// conflict and the path. Any *other* error (incompatible format, I/O) is
+/// surfaced immediately without retry.
+/// Test: `writer_intent_fails_on_locked_file`,
+/// `writer_intent_retries_then_succeeds_when_lock_released`.
+fn open_writer_with_handoff_retry(path: &Path) -> Result<(Arc<Database>, SnapshotGuard, OpenMode)> {
+    // Attempt 0 already failed with DatabaseAlreadyOpen at the call site, so
+    // re-probe through the remaining window. We re-run the *first* create here
+    // too (after the initial backoff) to keep the loop self-contained and the
+    // attempt accounting honest.
+    for attempt in 0..WRITER_RETRY_ATTEMPTS {
+        if attempt > 0 {
+            // Sleep before every attempt after the first; index is attempt-1
+            // because the first retry uses the smallest backoff.
+            let sleep_ms = WRITER_RETRY_SLEEP_MS[(attempt - 1) as usize];
+            backoff_sleep_ms(sleep_ms);
+        }
+        match Database::create(path) {
+            Ok(db) => {
+                if attempt > 0 {
+                    tracing::info!(
+                        path = %path.display(),
+                        attempt = attempt + 1,
+                        "acquired redb write lock after a transient conflict \
+                         (graceful daemon handoff absorbed; issue #1487)"
+                    );
+                }
+                return Ok((Arc::new(db), SnapshotGuard::noop(), OpenMode::ReadWrite));
+            }
+            Err(DatabaseError::DatabaseAlreadyOpen) => {
+                // Still held — keep probing until the window is exhausted.
+                continue;
+            }
+            // A non-lock error (I/O, incompatible format that slipped past the
+            // caller's branch) is not a handoff race; fail immediately.
+            Err(e) => return Err(anyhow::anyhow!("open redb at {}: {e}", path.display())),
+        }
+    }
+
+    tracing::error!(
+        path = %path.display(),
+        attempts = WRITER_RETRY_ATTEMPTS,
+        "redb file is still locked by another process after the write-lock handoff \
+         retry window but this process requires write access (OpenIntent::Writer). \
+         Refusing to open a read-only snapshot — another live trusty-memory instance \
+         holds the write lock. Stop the other daemon first or ensure only one writer \
+         is active at a time."
+    );
+    Err(anyhow::anyhow!(
+        "palace redb file {} is still locked by another live trusty-memory instance \
+         after {} write-lock acquisition attempts; this daemon requires write access \
+         and refuses to degrade to read-only/snapshot mode. Stop the other daemon or \
+         run `trusty-memory stop` first.",
+        path.display(),
+        WRITER_RETRY_ATTEMPTS,
+    ))
+}
+
+/// Open a process-local read-only snapshot copy of a locked redb file.
+///
+/// Why (issue #59): a read-only stdio MCP client must still serve `recall`,
+/// `kg_query`, and `palace_info` while the HTTP daemon holds the exclusive
+/// `flock`. Copying the file to a per-process snapshot lets redb's lock check
+/// succeed against the copy.
+/// What: Copies `path` to a per-call-unique snapshot path, opens it as a
+/// fresh redb database, and returns it in `OpenMode::Snapshot` with a
+/// `SnapshotGuard` that deletes the copy on drop.
+/// Test: `snapshot_fallback_when_locked`, `snapshot_guard_removes_file_on_drop`.
+fn open_read_only_snapshot(path: &Path) -> Result<(Arc<Database>, SnapshotGuard, OpenMode)> {
+    let snap = snapshot_path_for(path);
+    // Snapshot paths are per-call unique (pid + monotonic counter), so no
+    // stale-file cleanup is needed here.
+    std::fs::copy(path, &snap).with_context(|| {
+        format!(
+            "snapshot {} -> {} for read-only fallback",
+            path.display(),
+            snap.display()
+        )
+    })?;
+    let db = Database::create(&snap).with_context(|| {
+        format!(
+            "open redb snapshot at {} (fallback for locked {})",
+            snap.display(),
+            path.display()
+        )
+    })?;
+    tracing::info!(
+        original = %path.display(),
+        snapshot = %snap.display(),
+        "redb file locked by another process; opened read-only snapshot"
+    );
+    Ok((Arc::new(db), SnapshotGuard::new(snap), OpenMode::Snapshot))
 }
 
 /// Sleep for `ms` milliseconds in a way that is safe from both sync and async
@@ -358,32 +468,88 @@ mod tests {
         drop(guard); // snapshot file removed here
     }
 
-    /// Why (issue #1152, Tier 3): a daemon / writer that hits
-    /// `DatabaseAlreadyOpen` must return `Err` immediately rather than
-    /// silently opening a snapshot — writing to a snapshot copy would
-    /// diverge from the live file and corrupt the user's palace data.
-    /// What: Opens `db.redb` in this process (acquiring the lock), then
-    /// calls `try_open_or_snapshot` with `Writer`. The second call must
-    /// return `Err`.
+    /// Why (issue #1152, Tier 3 + #1487): a daemon / writer that hits a
+    /// *persistent* `DatabaseAlreadyOpen` (a second live daemon, not a
+    /// transient handoff) must return `Err` rather than silently opening a
+    /// snapshot — writing to a snapshot copy would diverge from the live file
+    /// and corrupt the user's palace data. The error must arrive only after
+    /// the bounded retry window is exhausted (issue #1487), never degrading
+    /// to snapshot mode.
+    /// What: Opens `db.redb` in this process (acquiring the lock) and HOLDS it
+    /// for the whole test, then calls `try_open_or_snapshot` with `Writer`.
+    /// The call must return `Err` (after retrying the full window) with a
+    /// message naming the lock conflict.
     /// Test: this test.
     #[test]
     fn writer_intent_fails_on_locked_file() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("db.redb");
 
-        // First open holds the flock.
+        // First open holds the flock for the duration of the call below.
         let _live = Database::create(&path).expect("first open");
 
-        // Writer intent must not fall back to a snapshot — must be Err.
+        // Writer intent must not fall back to a snapshot — must be Err after
+        // the retry window since the lock is never released.
         let result = try_open_or_snapshot(&path, OpenIntent::Writer);
         assert!(
             result.is_err(),
-            "Writer intent must return Err on lock contention, not silently snapshot"
+            "Writer intent must return Err on persistent lock contention, not silently snapshot"
         );
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("already locked") || msg.contains("write access"),
+            msg.contains("still locked") || msg.contains("write access"),
             "error message must explain the lock conflict; got: {msg}"
+        );
+    }
+
+    /// Why (issue #1487): the `Writer` retry window must absorb a transient
+    /// lock — when the holding handle is released *within* the backoff window,
+    /// the writer open must eventually SUCCEED in `ReadWrite` mode (never a
+    /// snapshot). This guards the restart-handoff behaviour: a graceful
+    /// `bootout`→`bootstrap` overlap resolves into a clean writer open.
+    /// What: Holds the flock on `db.redb`, spawns a thread that drops the lock
+    /// after ~120 ms (inside the ~1.55 s retry window), then calls
+    /// `try_open_or_snapshot` with `Writer`. The open must return `ReadWrite`.
+    /// Test: this test.
+    #[test]
+    fn writer_intent_retries_then_succeeds_when_lock_released() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("db.redb");
+
+        // Hold the flock, then release it from a background thread after a
+        // short delay that lands well inside the writer retry window.
+        let live = Database::create(&path).expect("first open");
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            drop(live); // releases the OS flock
+        });
+
+        // Writer intent should retry past the initial DatabaseAlreadyOpen and
+        // succeed once the background thread drops the lock.
+        let (_db, _guard, mode) = try_open_or_snapshot(&path, OpenIntent::Writer)
+            .expect("Writer open should succeed after the lock is released within the window");
+        assert_eq!(
+            mode,
+            OpenMode::ReadWrite,
+            "Writer must acquire the live lock (ReadWrite), never degrade to Snapshot"
+        );
+        assert!(!mode.is_read_only());
+
+        releaser.join().expect("releaser thread");
+    }
+
+    /// Why (issue #1487): the per-attempt backoff table must stay in lock-step
+    /// with the attempt count — one sleep precedes every attempt after the
+    /// first. A drift between the two would either skip a backoff or index
+    /// out of bounds.
+    /// What: Asserts `WRITER_RETRY_SLEEP_MS.len() == WRITER_RETRY_ATTEMPTS - 1`.
+    /// Test: this test.
+    #[test]
+    fn writer_retry_sleep_table_matches_attempt_count() {
+        assert_eq!(
+            WRITER_RETRY_SLEEP_MS.len(),
+            (WRITER_RETRY_ATTEMPTS - 1) as usize,
+            "one backoff value must precede every attempt after the first"
         );
     }
 

--- a/crates/trusty-common/src/memory_core/store/concurrent_open.rs
+++ b/crates/trusty-common/src/memory_core/store/concurrent_open.rs
@@ -68,6 +68,15 @@ pub enum OpenIntent {
 /// What: 5 attempts. Combined with [`WRITER_RETRY_SLEEP_MS`] the total wait
 /// is bounded at ~1.55 s — long enough to outlast a normal flock handoff,
 /// short enough that a genuine conflict still fails loud quickly.
+///
+/// Storage note: the ~1.55 s window is tuned for a local SSD, where a graceful
+/// launchd `bootout` releases the flock in a few hundred milliseconds. On
+/// NFS/SMB/network-mounted palace directories, flock release can be
+/// substantially slower (lease revocation, client-side caching), so a
+/// legitimate handoff may outlast this window and the new daemon could
+/// fail-loud spuriously. Operators running palaces on network storage may need
+/// to raise this (and/or extend [`WRITER_RETRY_SLEEP_MS`]). The defaults are
+/// intentionally conservative for the common local-disk case.
 /// Test: `writer_intent_fails_on_locked_file` (persistent conflict still
 /// errors) and `writer_intent_retries_then_succeeds_when_lock_released`
 /// (transient conflict succeeds within the window).
@@ -84,6 +93,11 @@ pub(crate) const WRITER_RETRY_ATTEMPTS: u8 = 5;
 /// What: One sleep value per attempt *after* the first
 /// (`WRITER_RETRY_ATTEMPTS - 1 == 4` entries). The sleep at index `i` is
 /// applied before attempt `i + 1`.
+///
+/// Storage note: these slots assume local-SSD flock semantics (see
+/// [`WRITER_RETRY_ATTEMPTS`]). On NFS/SMB/network-mounted palace dirs a
+/// graceful bootout's flock release can take longer than this table's ~1.55 s
+/// total, so operators on network storage may need larger values here.
 /// Test: `writer_retry_sleep_table_matches_attempt_count` asserts the table
 /// length stays in lock-step with [`WRITER_RETRY_ATTEMPTS`].
 pub(crate) const WRITER_RETRY_SLEEP_MS: [u64; 4] = [50, 100, 400, 1000];
@@ -315,14 +329,24 @@ pub fn try_open_or_snapshot(
 /// Test: `writer_intent_fails_on_locked_file`,
 /// `writer_intent_retries_then_succeeds_when_lock_released`.
 fn open_writer_with_handoff_retry(path: &Path) -> Result<(Arc<Database>, SnapshotGuard, OpenMode)> {
-    // Attempt 0 already failed with DatabaseAlreadyOpen at the call site, so
-    // re-probe through the remaining window. We re-run the *first* create here
-    // too (after the initial backoff) to keep the loop self-contained and the
-    // attempt accounting honest.
+    // Control flow (issue #1487): the call site already saw one
+    // `DatabaseAlreadyOpen` before delegating here. This loop performs
+    // [`WRITER_RETRY_ATTEMPTS`] (= 5) *real* `Database::create` attempts on top
+    // of that initial failure:
+    //   - attempt 0 fires IMMEDIATELY with no preceding sleep — an instant
+    //     re-probe that catches a lock already released between the call site's
+    //     failure and now;
+    //   - attempts 1..=4 each sleep `WRITER_RETRY_SLEEP_MS[attempt - 1]`
+    //     (50, 100, 400, 1000 ms) *before* the create, so all four backoff
+    //     slots are consumed exactly once, in order.
+    // Total worst-case wait across the loop is 0 + 50 + 100 + 400 + 1000 =
+    // ~1.55 s. The loop body does the create *after* the (conditional) sleep,
+    // so the final attempt (4) is not followed by a trailing sleep — the loop
+    // exits straight into the fail-loud path once attempt 4 also sees the lock.
     for attempt in 0..WRITER_RETRY_ATTEMPTS {
         if attempt > 0 {
             // Sleep before every attempt after the first; index is attempt-1
-            // because the first retry uses the smallest backoff.
+            // because the first retry uses the smallest backoff slot.
             let sleep_ms = WRITER_RETRY_SLEEP_MS[(attempt - 1) as usize];
             backoff_sleep_ms(sleep_ms);
         }
@@ -508,8 +532,12 @@ mod tests {
     /// snapshot). This guards the restart-handoff behaviour: a graceful
     /// `bootout`→`bootstrap` overlap resolves into a clean writer open.
     /// What: Holds the flock on `db.redb`, spawns a thread that drops the lock
-    /// after ~120 ms (inside the ~1.55 s retry window), then calls
+    /// after ~400 ms (comfortably inside the ~1.55 s retry window), then calls
     /// `try_open_or_snapshot` with `Writer`. The open must return `ReadWrite`.
+    /// The 400 ms release is deliberately larger than the first backoff slot
+    /// (50 ms) so the success is observed on a later retry, yet leaves >1 s of
+    /// slack before the window closes — margin against slow-CI scheduling jitter
+    /// while staying fully deterministic (release always precedes the deadline).
     /// Test: this test.
     #[test]
     fn writer_intent_retries_then_succeeds_when_lock_released() {
@@ -517,10 +545,11 @@ mod tests {
         let path = dir.path().join("db.redb");
 
         // Hold the flock, then release it from a background thread after a
-        // short delay that lands well inside the writer retry window.
+        // delay that lands well inside the writer retry window with ample
+        // margin for slow CI (release at ~400 ms vs the ~1.55 s deadline).
         let live = Database::create(&path).expect("first open");
         let releaser = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(120));
+            std::thread::sleep(std::time::Duration::from_millis(400));
             drop(live); // releases the OS flock
         });
 

--- a/crates/trusty-common/src/memory_core/store/kg/graph.rs
+++ b/crates/trusty-common/src/memory_core/store/kg/graph.rs
@@ -10,6 +10,7 @@
 
 use super::adjacency::{Adjacency, hydrate_adjacency};
 use super::types::{KgEdge, Triple, UndirectedSnapshot};
+use crate::memory_core::store::concurrent_open::OpenIntent;
 use crate::memory_core::store::kg_redb::KgStoreRedb;
 use crate::memory_core::store::kg_writer::KgWriter;
 use anyhow::{Context, Result};
@@ -79,14 +80,33 @@ fn migrate_from_sqlite_if_needed(_data_dir: &Path, _redb_store: &KgStoreRedb) ->
 }
 
 impl KnowledgeGraph {
-    /// Open or create the redb-backed KG at the path derived from `path`.
+    /// Open or create the redb-backed KG with read-only-client intent.
     ///
-    /// Why: Callers continue to pass the legacy `<data_dir>/kg.db` path. We
-    /// translate that to `<data_dir>/kg.redb` and open the redb file there.
+    /// Why: Preserves the historical zero-config signature for CLI / read /
+    /// test callers, which want the snapshot read-fallback on a cross-process
+    /// lock (issue #59).
+    /// What: Delegates to [`KnowledgeGraph::open_with_intent`] with
+    /// [`OpenIntent::ReadOnlyClient`].
     /// Test: `open_creates_schema`.
     pub fn open(path: &Path) -> Result<Self> {
+        Self::open_with_intent(path, OpenIntent::ReadOnlyClient)
+    }
+
+    /// Open or create the redb-backed KG with the caller's open intent.
+    ///
+    /// Why (issue #1487): the HTTP daemon opens with [`OpenIntent::Writer`]
+    /// so a second instance fails loud instead of silently degrading to a
+    /// read-only snapshot. Callers continue to pass the legacy
+    /// `<data_dir>/kg.db` path; we translate that to `<data_dir>/kg.redb`.
+    /// What: Opens the redb store with `intent`, runs the (no-op) legacy
+    /// migration hook, hydrates the in-memory adjacency, and spawns the
+    /// coalescing writer actor for read-write palaces opened inside a tokio
+    /// runtime (read-only / snapshot palaces and sync test contexts get a
+    /// `bypass` handle).
+    /// Test: `open_creates_schema`.
+    pub fn open_with_intent(path: &Path, intent: OpenIntent) -> Result<Self> {
         let redb_path = redb_path_for(path);
-        let store = KgStoreRedb::open(&redb_path)
+        let store = KgStoreRedb::open_with_intent(&redb_path, intent)
             .with_context(|| format!("open KG redb at {}", redb_path.display()))?;
         if let Some(data_dir) = redb_path.parent() {
             migrate_from_sqlite_if_needed(data_dir, &store)

--- a/crates/trusty-common/src/memory_core/store/kg_redb/store.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/store.rs
@@ -32,16 +32,40 @@ pub struct KgStoreRedb {
 }
 
 impl KgStoreRedb {
-    /// Open or create the redb database at `path`.
+    /// Open or create the redb database at `path` with read-only-client intent.
     ///
-    /// Why: Creating the file plus initializing every table must be idempotent
-    /// so daemon restarts succeed without manual setup. redb's
-    /// `Database::create` opens an existing file or creates a fresh one.
-    /// What: Opens the file, then in a single write transaction touches every
-    /// table so the file always carries a stable schema even when no data has
-    /// been written.
+    /// Why: Preserves the historical zero-config signature for the many
+    /// CLI / read / test call sites. Snapshot-fallback on a cross-process
+    /// lock (issue #59) is the right behaviour for those callers.
+    /// What: Delegates to [`KgStoreRedb::open_with_intent`] with
+    /// [`OpenIntent::ReadOnlyClient`].
     /// Test: `open_then_reopen_persists_state`.
     pub fn open(path: &Path) -> Result<Self> {
+        Self::open_with_intent(path, OpenIntent::ReadOnlyClient)
+    }
+
+    /// Open or create the redb database at `path` with the caller's intent.
+    ///
+    /// Why (issue #1487): the HTTP daemon is the sole writer and must open
+    /// with [`OpenIntent::Writer`] so a second instance fails LOUD (after a
+    /// bounded handoff-retry window) instead of silently degrading to a
+    /// read-only snapshot and rejecting every write for its lifetime.
+    /// Read-only clients (stdio MCP, CLI, tests) keep
+    /// [`OpenIntent::ReadOnlyClient`] so they can serve reads from a snapshot
+    /// while the daemon holds the live lock.
+    /// What: Creating the file plus initializing every table must be
+    /// idempotent so daemon restarts succeed without manual setup. redb's
+    /// `Database::create` opens an existing file or creates a fresh one. For
+    /// `ReadOnlyClient`, a short in-process TOCTOU retry loop (issue #1152)
+    /// absorbs an aborting async writer dropping the lock. For `Writer`, the
+    /// bounded handoff retry lives inside `try_open_or_snapshot` itself, so
+    /// this function makes a single intent-passing call and does not double-
+    /// retry. Opens the file, then in a single write transaction touches
+    /// every table so the file always carries a stable schema even when no
+    /// data has been written.
+    /// Test: `open_then_reopen_persists_state`,
+    /// `writer_intent_open_fails_loud_on_locked_file`.
+    pub fn open_with_intent(path: &Path, intent: OpenIntent) -> Result<Self> {
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
         {
@@ -69,15 +93,21 @@ impl KgStoreRedb {
         //
         // Retry schedule: exponential backoff 2/10/50/100 ms. Total max wait
         // 162 ms — invisible at daemon startup, sufficient for async-drop.
-        // A genuine cross-process lock conflict (another daemon is still up)
-        // falls through to a snapshot on the first attempt; the daemon-level
-        // `single_instance_check` in `main.rs` is the right place to reject
-        // that scenario loudly.
+        // This outer loop ONLY covers the in-process TOCTOU race for the
+        // `ReadOnlyClient` path. For the `Writer` path the authoritative
+        // bounded handoff retry lives inside `try_open_or_snapshot`
+        // (issue #1487), so we make a single attempt here and never
+        // double-retry — otherwise the ~1.55 s writer window would be
+        // multiplied 5×.
         const RETRIES: u8 = 4;
         const RETRY_SLEEP_MS: [u64; 4] = [2, 10, 50, 100];
+        // Writer → 0 extra attempts (handoff retry lives in `try_open_or_snapshot`).
+        // ReadOnlyClient → RETRIES in-process TOCTOU retries (issue #1152). The
+        // `u8::from(bool)` keeps this a single non-`if` expression (fmt-stable).
+        let max_attempts = RETRIES * u8::from(intent != OpenIntent::Writer);
 
         let mut last_err: Option<anyhow::Error> = None;
-        for attempt in 0..=RETRIES {
+        for attempt in 0..=max_attempts {
             // Check in-process cache first — avoids re-opening the same
             // redb file from two code paths within one process.
             {
@@ -99,7 +129,7 @@ impl KgStoreRedb {
             // snapshot are rejected via `READ_ONLY_ERROR_MSG`. In-process TOCTOU
             // races resolve on the next retry cycle (the aborting task drops
             // the lock within the exponential-backoff window).
-            match try_open_or_snapshot(path, OpenIntent::ReadOnlyClient) {
+            match try_open_or_snapshot(path, intent) {
                 Ok((db, snapshot_guard, mode)) => {
                     // Touch every table in a single write txn so they exist
                     // on disk even before the first write. Skip in snapshot
@@ -145,7 +175,7 @@ impl KgStoreRedb {
                 }
                 Err(e) => {
                     last_err = Some(e);
-                    if attempt < RETRIES {
+                    if attempt < max_attempts {
                         // Exponential backoff: let any concurrent in-process
                         // `Database::drop` (or async `KgWriter` abort) finish
                         // releasing the OS file lock before retrying.

--- a/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
@@ -390,6 +390,40 @@ mod tests {
         );
     }
 
+    /// Why (issue #1487): the HTTP daemon opens with `OpenIntent::Writer`.
+    /// When a second live instance already holds the redb write lock, the
+    /// Writer open MUST fail loud (after the bounded handoff window) and MUST
+    /// NOT degrade to a read-only snapshot — otherwise the daemon would
+    /// silently reject every write for its lifetime (the original bug).
+    /// What: Seeds a palace file, drops the seeding store so the cache entry
+    /// expires, holds the file lock with a raw `Database::create`, then calls
+    /// `KgStoreRedb::open_with_intent(.., Writer)`. The call must return `Err`
+    /// whose message names the lock conflict — never an `Ok` snapshot handle.
+    /// Test: this test.
+    #[test]
+    fn writer_intent_open_fails_loud_on_locked_file() {
+        use crate::memory_core::store::concurrent_open::OpenIntent;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("kg.redb");
+        // Touch the file so it has the redb header, then expire the cache.
+        drop(KgStoreRedb::open(&path).unwrap());
+        let _live = lock_redb_file(&path);
+
+        let result = KgStoreRedb::open_with_intent(&path, OpenIntent::Writer);
+        // Match rather than `unwrap_err()` so we don't require KgStoreRedb: Debug.
+        let err = match result {
+            Ok(_) => {
+                panic!("Writer open on a locked file must fail loud, not return a snapshot handle")
+            }
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("still locked") || msg.contains("write access"),
+            "Writer error must name the lock conflict; got: {msg}"
+        );
+    }
+
     /// Why: Cached in-process handles to the same canonical path must be
     /// usable concurrently — multiple tasks holding cloned `KgStoreRedb`
     /// handles must each be able to issue reads simultaneously without

--- a/crates/trusty-common/src/memory_core/store/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/mod.rs
@@ -21,6 +21,7 @@ pub mod redb_open;
 pub mod vector;
 
 pub use chat_sessions::{ChatSession, ChatSessionMeta, ChatSessionStore};
+pub use concurrent_open::{OpenIntent, OpenMode};
 pub use kg::{KnowledgeGraph, Triple};
 pub use l1_cache::{L1Cache, L1CacheError};
 pub use palace_store::{PalaceStore, PalaceStoreError};

--- a/crates/trusty-common/src/memory_core/store/vector.rs
+++ b/crates/trusty-common/src/memory_core/store/vector.rs
@@ -85,20 +85,29 @@ fn canonical_key(path: &Path) -> PathBuf {
 /// open mode so callers can switch the HNSW store into read-only mode
 /// when the live file was locked.
 ///
-/// Why: mirrors `KgStoreRedb::open` with the same TOCTOU retry strategy
-/// (issue #1152 / issue #59). See that function for the full rationale.
-/// What: Cache-check → `try_open_or_snapshot(ReadOnlyClient)` → up to 4
-/// retries with exponential backoff (2/10/50/100 ms) on in-process TOCTOU
-/// races. Cross-process lock conflicts fall back to a read-only snapshot;
-/// writes against that snapshot are rejected via `READ_ONLY_ERROR_MSG`.
+/// Why: mirrors `KgStoreRedb::open_with_intent` with the same TOCTOU retry
+/// strategy (issue #1152 / #59) and the same Writer fail-loud contract
+/// (issue #1487). See those functions for the full rationale.
+/// What: Cache-check → `try_open_or_snapshot(intent)`. For `ReadOnlyClient`,
+/// up to 4 retries with exponential backoff (2/10/50/100 ms) absorb in-process
+/// TOCTOU races and cross-process lock conflicts fall back to a read-only
+/// snapshot (writes rejected via `READ_ONLY_ERROR_MSG`). For `Writer`, the
+/// bounded handoff retry lives inside `try_open_or_snapshot`, so this function
+/// makes a single attempt and never double-retries; a persistent conflict
+/// fails loud rather than degrading to snapshot mode.
 /// Test: Indirectly via `trusty-memory`'s
-/// `default_palace_used_when_arg_omitted`.
-fn open_or_get_cached_db(path: &Path) -> Result<Arc<VectorDbState>> {
+/// `default_palace_used_when_arg_omitted`, plus
+/// `writer_intent_open_fails_loud_on_locked_vector_file`.
+fn open_or_get_cached_db(path: &Path, intent: OpenIntent) -> Result<Arc<VectorDbState>> {
     const RETRIES: u8 = 4;
     const RETRY_SLEEP_MS: [u64; 4] = [2, 10, 50, 100];
+    // Writer → 0 extra attempts (handoff retry lives in `try_open_or_snapshot`).
+    // ReadOnlyClient → RETRIES in-process TOCTOU retries (issue #1152). The
+    // `u8::from(bool)` keeps this a single non-`if` expression (fmt-stable).
+    let max_attempts = RETRIES * u8::from(intent != OpenIntent::Writer);
 
     let mut last_err: Option<anyhow::Error> = None;
-    for attempt in 0..=RETRIES {
+    for attempt in 0..=max_attempts {
         {
             let mut cache = vector_db_cache().lock().expect("vector_db_cache poisoned");
             let key = canonical_key(path);
@@ -110,11 +119,13 @@ fn open_or_get_cached_db(path: &Path) -> Result<Arc<VectorDbState>> {
             cache.remove(&key);
         }
 
-        // ReadOnlyClient: cross-process lock conflicts fall back to a
-        // read-only snapshot (issue #59 behaviour). Writes are rejected
-        // via the `READ_ONLY_ERROR_MSG` guard. In-process TOCTOU races
-        // (async `KgWriter` abort) are resolved by the retry loop.
-        match try_open_or_snapshot(path, OpenIntent::ReadOnlyClient)
+        // Pass the caller's intent: `ReadOnlyClient` cross-process lock
+        // conflicts fall back to a read-only snapshot (issue #59), with writes
+        // rejected via `READ_ONLY_ERROR_MSG`; `Writer` conflicts fail loud
+        // after the bounded handoff window (issue #1487). In-process TOCTOU
+        // races (async `KgWriter` abort) are resolved by the retry loop for
+        // the read-only path.
+        match try_open_or_snapshot(path, intent)
             .with_context(|| format!("open vector redb at {}", path.display()))
         {
             Ok((db, snapshot_guard, mode)) => {
@@ -131,7 +142,7 @@ fn open_or_get_cached_db(path: &Path) -> Result<Arc<VectorDbState>> {
             }
             Err(e) => {
                 last_err = Some(e);
-                if attempt < RETRIES {
+                if attempt < max_attempts {
                     // Exponential backoff: let any concurrent in-process
                     // `Database::drop` (or async `KgWriter` abort) finish
                     // releasing the OS file lock before retrying.
@@ -248,6 +259,24 @@ impl UsearchStore {
     /// Test: `persist_and_reload` exercises the open path twice on the
     /// same logical path.
     pub fn new(path: PathBuf, dim: usize) -> Result<Self> {
+        Self::new_with_intent(path, dim, OpenIntent::ReadOnlyClient)
+    }
+
+    /// Open or create an HNSW index with the caller's open intent.
+    ///
+    /// Why (issue #1487): the HTTP daemon (sole writer) must open the vector
+    /// redb with [`OpenIntent::Writer`] so a second instance fails LOUD after
+    /// the bounded handoff window instead of silently serving a read-only
+    /// snapshot and rejecting every `upsert`/`remove` for its lifetime.
+    /// CLI / stdio / test callers keep [`OpenIntent::ReadOnlyClient`] for the
+    /// snapshot read-fallback (issue #59).
+    /// What: Translates `path` to `<path>.redb`, opens (or creates) the redb
+    /// file with `intent`, opens an `HnswStore` against it (read-only when the
+    /// snapshot fallback fired), and runs the one-shot legacy migration for
+    /// read-write opens.
+    /// Test: `persist_and_reload` (ReadOnlyClient default) and
+    /// `writer_intent_open_fails_loud_on_locked_vector_file` (Writer path).
+    pub fn new_with_intent(path: PathBuf, dim: usize, intent: OpenIntent) -> Result<Self> {
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
         {
@@ -257,12 +286,13 @@ impl UsearchStore {
         }
 
         let redb_path = redb_path_for(&path);
-        let db_state = open_or_get_cached_db(&redb_path)
+        let db_state = open_or_get_cached_db(&redb_path, intent)
             .with_context(|| format!("open vector redb at {}", redb_path.display()))?;
         let read_only = db_state.mode.is_read_only();
-        let inner = HnswStore::open_with_mode(db_state.db.clone(), dim, read_only)
-            .with_context(|| format!("open HnswStore at {}", redb_path.display()))?;
-        let inner = Arc::new(inner);
+        let inner = Arc::new(
+            HnswStore::open_with_mode(db_state.db.clone(), dim, read_only)
+                .with_context(|| format!("open HnswStore at {}", redb_path.display()))?,
+        );
 
         // One-shot migration from the legacy `.usearch` file, if any. The
         // closure is split out so the feature gate stays isolated. Skip
@@ -737,6 +767,54 @@ mod tests {
         assert!(
             snap.is_read_only(),
             "snapshot store must report is_read_only()"
+        );
+    }
+
+    /// Why (issue #1487): the HTTP daemon opens the vector store with
+    /// `OpenIntent::Writer`. When a second live instance already holds the
+    /// redb write lock, the Writer open MUST fail loud (after the bounded
+    /// handoff window) and MUST NOT return a read-only snapshot handle —
+    /// otherwise every `upsert`/`remove` would be silently rejected for the
+    /// daemon's lifetime (the original bug).
+    /// What: Seeds the vector file, drops the store so the cache expires,
+    /// holds the redb file lock with a raw handle, then calls
+    /// `UsearchStore::new_with_intent(.., Writer)`. The call must return `Err`
+    /// naming the lock conflict — never an `Ok` snapshot handle.
+    /// Test: this test.
+    #[tokio::test]
+    async fn writer_intent_open_fails_loud_on_locked_vector_file() {
+        let dir = tempdir().unwrap();
+        let logical = dir.path().join("test.usearch");
+
+        // Populate and drop so the cache entry expires.
+        {
+            let primary = UsearchStore::new(logical.clone(), 384).unwrap();
+            primary
+                .upsert(Uuid::new_v4(), unit_vec(384, 1))
+                .await
+                .unwrap();
+        }
+
+        // Hold the redb file lock with a raw `Database::create`.
+        let redb_path = redb_path_for(&logical);
+        let _live = redb::Database::create(&redb_path).expect("lock vector redb");
+
+        // Writer open must fail loud, never snapshot.
+        let result = UsearchStore::new_with_intent(logical.clone(), 384, OpenIntent::Writer);
+        // Match rather than `unwrap_err()` so we don't require UsearchStore: Debug.
+        let err = match result {
+            Ok(_) => panic!(
+                "Writer open on a locked vector redb must fail loud, not return a snapshot handle"
+            ),
+            Err(e) => e,
+        };
+        // Use the alternate `{:#}` form so the full anyhow context chain
+        // (the `open_or_get_cached_db` wrapper + the root lock message) is
+        // rendered, not just the outermost context line.
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("still locked") || msg.contains("write access"),
+            "Writer error must name the lock conflict; got: {msg}"
         );
     }
 

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -1038,14 +1038,29 @@ impl AppState {
     /// reads-only. CLI, stdio-proxy, and test code paths never call this, so
     /// they keep the snapshot read-fallback (issue #59).
     /// What: Replaces `self.registry` with a fresh `PalaceRegistry` carrying
-    /// `OpenIntent::Writer`. Safe because `AppState::new` builds an empty
-    /// registry with no hydrated handles yet, and this builder runs during
-    /// startup before `spawn_startup_tasks` hydrates any palace.
-    /// Test: `with_writer_intent_marks_registry_writer` in `lib_tests`.
+    /// `OpenIntent::Writer`.
+    ///
+    /// Invariant: MUST be called on a fresh, unhydrated, unshared registry —
+    /// during startup, before `spawn_startup_tasks`/`load_palaces_from_disk`
+    /// registers any `PalaceHandle` and before the `AppState` (hence its
+    /// `Arc<PalaceRegistry>`) is cloned to a handler. Replacing the registry
+    /// discards the prior `Arc`; doing so after hydration would silently drop
+    /// live handles (data loss), and doing so after the state is shared would
+    /// leave other clones on the stale read-only registry. The guard is a
+    /// `debug_assert!` on the strongest cheap signals the registry exposes —
+    /// `is_empty()` (no handles hydrated) and `Arc::strong_count == 1` (not yet
+    /// shared) — so an ordering violation fails fast as the programmer error it
+    /// is (the call site is startup-only and fixed). Release builds elide the
+    /// assert; the real call site (`run_serve`) always satisfies it.
+    /// Test: `with_writer_intent_marks_registry_writer` and
+    /// `with_writer_intent_panics_on_hydrated_registry` in `lib_tests`.
     #[must_use]
     pub fn with_writer_intent(mut self) -> Self {
-        self.registry =
-            Arc::new(trusty_common::memory_core::PalaceRegistry::new().with_writer_intent());
+        // Fail fast on an ordering bug: a hydrated registry (`!is_empty`) or a
+        // shared one (`strong_count > 1`) would silently drop live handles or
+        // strand other clones on the stale read-only registry (issue #1487).
+        debug_assert!(self.registry.is_empty() && Arc::strong_count(&self.registry) == 1);
+        self.registry = Arc::new(PalaceRegistry::new().with_writer_intent());
         self
     }
 

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -1024,6 +1024,31 @@ impl AppState {
         self
     }
 
+    /// Builder-style: mark this daemon as the sole palace writer so palace
+    /// redb files open with `OpenIntent::Writer` (issue #1487).
+    ///
+    /// Why: The HTTP daemon owns the write lock on every palace's `kg.redb`
+    /// and `index.usearch.redb`. Before this fix, when a *second* daemon
+    /// instance opened the same store it silently degraded to a read-only
+    /// snapshot and rejected every `memory_remember` for its lifetime —
+    /// effectively silent data loss when an MCP client routed a write to the
+    /// rogue instance. Opening as `Writer` makes the second instance fail
+    /// loud (after a short handoff-retry window that absorbs a graceful
+    /// launchd `bootout`→`bootstrap` overlap) instead of serving broken
+    /// reads-only. CLI, stdio-proxy, and test code paths never call this, so
+    /// they keep the snapshot read-fallback (issue #59).
+    /// What: Replaces `self.registry` with a fresh `PalaceRegistry` carrying
+    /// `OpenIntent::Writer`. Safe because `AppState::new` builds an empty
+    /// registry with no hydrated handles yet, and this builder runs during
+    /// startup before `spawn_startup_tasks` hydrates any palace.
+    /// Test: `with_writer_intent_marks_registry_writer` in `lib_tests`.
+    #[must_use]
+    pub fn with_writer_intent(mut self) -> Self {
+        self.registry =
+            Arc::new(trusty_common::memory_core::PalaceRegistry::new().with_writer_intent());
+        self
+    }
+
     /// Builder-style: attach the bug-capture `ErrorStore` handle (bug-reporting #478).
     ///
     /// Why: Phase 2 MCP / HTTP endpoints need a handle to the in-memory error

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -406,6 +406,51 @@ async fn with_writer_intent_marks_registry_writer() {
     );
 }
 
+/// Why (issue #1487 hardening): `with_writer_intent` replaces the registry
+/// `Arc`, so it must only ever run on a fresh, unhydrated registry — calling
+/// it after palaces are loaded would silently drop the hydrated handles. The
+/// `debug_assert!` invariant guard makes that ordering violation a loud,
+/// fail-fast programmer error in debug/test builds instead of silent data loss.
+/// What: persists a palace to disk, hydrates a fresh `AppState`'s registry via
+/// `load_palaces_from_disk`, then calls `with_writer_intent` and asserts it
+/// panics on the `is_empty()` invariant (the strongest cheap guard).
+/// Test: this test itself (via `#[should_panic]`).
+#[tokio::test]
+#[should_panic(expected = "is_empty()")]
+async fn with_writer_intent_panics_on_hydrated_registry() {
+    use trusty_common::memory_core::{Palace, PalaceId, PalaceRegistry};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+
+    // Persist one palace to disk via the same path the palace_create tool uses.
+    {
+        let writer = PalaceRegistry::new();
+        let palace = Palace {
+            id: PalaceId::new("hydrated"),
+            name: "hydrated".to_string(),
+            description: None,
+            created_at: chrono::Utc::now(),
+            data_dir: root.join("hydrated"),
+        };
+        writer
+            .create_palace(&root, palace)
+            .expect("persist palace to disk");
+    }
+
+    // Hydrate a fresh AppState's registry from disk so it is no longer empty.
+    let state = AppState::new(root);
+    let count = state
+        .load_palaces_from_disk()
+        .await
+        .expect("load_palaces_from_disk");
+    assert_eq!(count, 1, "precondition: registry must be hydrated");
+
+    // Calling the builder on a hydrated registry must trip the debug_assert!
+    // invariant guard rather than silently dropping the live handle.
+    let _ = state.with_writer_intent();
+}
+
 /// Why: existing installs (and the legacy standalone `trusty-memory` repo)
 /// nest palaces one level deeper under a `palaces/` subdirectory. When that
 /// subdirectory exists, `resolve_palace_registry_dir` must descend into it

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -375,6 +375,37 @@ async fn load_palaces_from_disk_rehydrates_registry() {
     assert!(ids.contains(&"beta".to_string()));
 }
 
+/// Why (issue #1487): the HTTP daemon must open palace redb files as a
+/// writer so a second instance fails loud instead of silently degrading to
+/// read-only snapshot mode. `AppState::with_writer_intent()` is the builder
+/// `run_serve` calls on the daemon path; this asserts it actually flips the
+/// registry's open intent to `Writer`, while a plain `AppState::new`
+/// (used by CLI / tests) stays `ReadOnlyClient`.
+/// What: builds a default `AppState` and asserts `ReadOnlyClient`, then a
+/// `with_writer_intent()` `AppState` and asserts `Writer`.
+/// Test: this test itself.
+#[tokio::test]
+async fn with_writer_intent_marks_registry_writer() {
+    use trusty_common::memory_core::store::OpenIntent;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+
+    let default_state = AppState::new(root.clone());
+    assert_eq!(
+        default_state.registry.open_intent(),
+        OpenIntent::ReadOnlyClient,
+        "default AppState registry must be read-only (CLI / test paths)"
+    );
+
+    let writer_state = AppState::new(root).with_writer_intent();
+    assert_eq!(
+        writer_state.registry.open_intent(),
+        OpenIntent::Writer,
+        "with_writer_intent() must flip the daemon registry to Writer"
+    );
+}
+
 /// Why: existing installs (and the legacy standalone `trusty-memory` repo)
 /// nest palaces one level deeper under a `palaces/` subdirectory. When that
 /// subdirectory exists, `resolve_palace_registry_dir` must descend into it

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -760,39 +760,26 @@ async fn run_serve(
         tracing::warn!("default-palace name migration skipped: {e:#}");
     }
 
+    // Build the daemon AppState once — the builder chain is identical for the
+    // fixed-port and dynamic/foreground HTTP paths. Issue #1487:
+    // `with_writer_intent()` MUST come first (it replaces the registry) and
+    // run before `spawn_startup_tasks` hydration so palace redb files open as
+    // `Writer` — a second daemon instance then fails loud instead of silently
+    // degrading to read-only snapshot mode. Bug-reporting #478 wires the
+    // ErrorStore; #156/#193 opt into the BM25 lexical lane when enabled.
+    let state = AppState::new(data_root)
+        .with_writer_intent()
+        .with_default_palace(palace)
+        .with_log_buffer(log_buffer)
+        .with_error_store(error_store)
+        .with_bm25_client_from_env();
+    spawn_startup_tasks(&state);
     if let Some(addr) = http {
-        let state = AppState::new(data_root)
-            .with_default_palace(palace)
-            .with_log_buffer(log_buffer)
-            // Bug-reporting #478: wire the bug-capture ErrorStore into AppState
-            // so Phase 2 HTTP / MCP endpoints can query it. The store is an
-            // Arc-backed clone of the same ring the BugCaptureLayer writes to.
-            .with_error_store(error_store)
-            // Issue #156 + #193: opt in to the BM25 lexical lane (and its
-            // spawn supervisor) when TRUSTY_BM25_DAEMON=1. The builder is
-            // a no-op when the env var is unset so existing deployments
-            // see no behavioural change.
-            .with_bm25_client_from_env();
-        spawn_startup_tasks(&state);
         run_http(state, addr).await
+    } else if foreground {
+        run_http_foreground(state).await
     } else {
-        let state = AppState::new(data_root)
-            .with_default_palace(palace)
-            .with_log_buffer(log_buffer)
-            // Bug-reporting #478: wire the bug-capture ErrorStore into AppState
-            // so Phase 2 HTTP / MCP endpoints can query it.
-            .with_error_store(error_store)
-            // Issue #156 + #193: opt in to the BM25 lexical lane (and its
-            // spawn supervisor) when TRUSTY_BM25_DAEMON=1. The builder is
-            // a no-op when the env var is unset so existing deployments
-            // see no behavioural change.
-            .with_bm25_client_from_env();
-        spawn_startup_tasks(&state);
-        if foreground {
-            run_http_foreground(state).await
-        } else {
-            run_http_dynamic(state).await
-        }
+        run_http_dynamic(state).await
     }
 }
 


### PR DESCRIPTION
## Bug #1487
When a second `trusty-memory` process opened the same palace redb, it silently fell back to `OpenMode::Snapshot` (read-only) and rejected ALL writes for its lifetime — silent data loss. Root cause: `KgStoreRedb::open`/`UsearchStore::new` hard-coded `OpenIntent::ReadOnlyClient`, so the writer daemon never used the existing fail-loud `Writer` path (#1152).

## Fix
Threaded an `OpenIntent` parameter through the store open path (all existing callers default to `ReadOnlyClient`, preserving behavior). The HTTP daemon writer path (`run_serve` → `AppState::with_writer_intent()` → `PalaceRegistry::with_writer_intent()`) now opens with `Writer`, so a second daemon fails LOUD instead of silently degrading. CLI/read/test paths and `serve --stdio` (a pure proxy) are unchanged.

## Restart-handoff safety (no launchd flap)
The `Writer` branch retries `Database::create` on `DatabaseAlreadyOpen` with bounded backoff (`WRITER_RETRY_ATTEMPTS=5`, sleeps `[50,100,400,1000]ms` ≈ 1.55s total) to absorb the graceful `bootout→bootstrap` flock-overlap window, then fails loud only on a persistent conflict. Never degrades to snapshot.

## Tests
Writer open succeeds when sole; second writer open fails loud (not snapshot) after retries; retry-then-succeed when the lock is released; ReadOnlyClient still snapshots; registry/AppState writer-intent wiring. Full trusty-common (memory-core) + trusty-memory suites green; clippy/fmt/line-cap clean.

## ⚠️ Reviewer note
`.line-cap-allowlist.tsv` bumps `crates/trusty-memory/src/lib.rs` 616→622 (+6) via the documented `--force-add` path for the one-line `with_writer_intent` builder; overage was reclaimed in `vector.rs`/`store.rs`/`main.rs` to keep those under the 500 prod cap. Flagging because this runs slightly against the ratchet-down rule — reviewer may prefer a small split instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)