### PR TITLE
feat(trusty-mpm): typed DaemonClient managed-session methods + refactor tm managed cmds

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -93,12 +93,13 @@ pub(crate) async fn resolve_managed_id(
 /// but their bodies now delegate to the shared typed [`DaemonClient`] (the
 /// convergence target for STUI #1272 / TELUI #1433). This helper centralizes the
 /// construction so every handler reuses the daemon base consistently.
-/// What: returns `DaemonClient::new(url)`. The passed `reqwest::Client` is
-/// intentionally unused — `DaemonClient` owns its own pooled client — but the
-/// parameter is retained so the handler signatures stay stable for callers.
+/// What: returns `DaemonClient::with_client(client.clone(), url)`, REUSING the
+/// caller's configured `reqwest::Client` (TLS/timeout/proxy/pool) rather than
+/// minting a fresh default one. Cloning is cheap — `reqwest::Client` is an `Arc`
+/// internally — so the caller's pool and settings are preserved.
 /// Test: exercised transitively by every managed handler's integration coverage.
-fn daemon_client(_client: &reqwest::Client, url: &str) -> DaemonClient {
-    DaemonClient::new(url.to_string())
+fn daemon_client(client: &reqwest::Client, url: &str) -> DaemonClient {
+    DaemonClient::with_client(client.clone(), url.to_string())
 }
 
 /// `tm sessions new` — spawn a managed session from a repo + ref.
@@ -150,21 +151,21 @@ pub(crate) async fn session_ls(
     url: &str,
     json: bool,
 ) -> anyhow::Result<()> {
-    // `--json` echoes the daemon's response body verbatim (byte-for-byte), so it
-    // reads the raw text rather than re-serializing the typed list — preserving
-    // exact field order and whitespace for scripts that parse the output.
+    // Fetch the response body ONCE. `--json` echoes that raw text verbatim
+    // (byte-for-byte — preserving exact field order/whitespace for scripts);
+    // the table path deserializes the SAME text rather than issuing a second GET.
+    let raw = client
+        .get(format!("{url}/api/v1/sessions/managed"))
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
     if json {
-        let raw = client
-            .get(format!("{url}/api/v1/sessions/managed"))
-            .send()
-            .await?
-            .error_for_status()?
-            .text()
-            .await?;
         println!("{raw}");
         return Ok(());
     }
-    let sessions = daemon_client(client, url).list_managed_sessions().await?;
+    let sessions = serde_json::from_str::<trusty_mpm::client::ManagedListResponse>(&raw)?.sessions;
     if sessions.is_empty() {
         println!("no managed sessions");
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -9,7 +9,7 @@
 //! Test: `cli_parses_session_new`, `cli_parses_catalog_sync` exercise the parse
 //! path; the HTTP round-trip is covered by `tests/session_manager_mvp.rs`.
 
-use serde::Deserialize;
+use trusty_mpm::client::{DaemonClient, ManagedSessionSummary, ManagedSpawnRequest};
 
 use crate::cli::CatalogAction;
 
@@ -38,21 +38,6 @@ pub(crate) fn deprecation_notice(old: &str, new: &str) {
     eprintln!("{}", deprecation_message(old, new));
 }
 
-/// A managed-session summary as returned by the daemon list/get endpoints.
-///
-/// Why: the CLI renders a stable subset of fields; deriving Deserialize on a
-/// dedicated struct decouples the CLI from the daemon's internal record shape.
-/// What: mirrors `daemon::managed_routes::SessionSummary`.
-/// Test: rendered by `ls`; round-trip covered by the integration test.
-#[derive(Debug, Deserialize)]
-pub(crate) struct ManagedSummary {
-    pub(crate) id: String,
-    pub(crate) name: String,
-    state: String,
-    #[serde(default)]
-    pending_decision: Option<String>,
-}
-
 /// Decide whether an id-or-name refers to a MANAGED session, returning its UUID.
 ///
 /// Why: the canonical `tm sessions stop`/`resume` verbs must operate on managed
@@ -68,7 +53,7 @@ pub(crate) struct ManagedSummary {
 /// argument resolve to the id the managed endpoints require.
 /// Test: `classify_managed_target_*` in `tests.rs`.
 pub(crate) fn classify_managed_target(
-    sessions: &[ManagedSummary],
+    sessions: &[ManagedSessionSummary],
     id_or_name: &str,
 ) -> Option<String> {
     sessions
@@ -83,10 +68,10 @@ pub(crate) fn classify_managed_target(
 /// whether the argument is a managed session (#1218). Fetching the managed list
 /// and applying [`classify_managed_target`] keeps that decision in one place and
 /// off the project-session path.
-/// What: GETs `/api/v1/sessions/managed`, deserializes the session list, and
-/// returns `classify_managed_target(&sessions, id_or_name)`. A non-200 response
-/// or a body that fails to parse yields `None` (treated as "not managed") so the
-/// caller transparently falls back to the project-session path rather than erroring.
+/// What: calls [`DaemonClient::list_managed_sessions`] and returns
+/// `classify_managed_target(&sessions, id_or_name)`. Any transport/parse failure
+/// yields `None` (treated as "not managed") so the caller transparently falls
+/// back to the project-session path rather than erroring.
 /// Test: HTTP wiring covered by the integration test; the matching logic by
 /// `classify_managed_target_*`.
 pub(crate) async fn resolve_managed_id(
@@ -94,20 +79,26 @@ pub(crate) async fn resolve_managed_id(
     url: &str,
     id_or_name: &str,
 ) -> Option<String> {
-    #[derive(Deserialize)]
-    struct ListResp {
-        sessions: Vec<ManagedSummary>,
-    }
-    let resp = client
-        .get(format!("{url}/api/v1/sessions/managed"))
-        .send()
+    let sessions = daemon_client(client, url)
+        .list_managed_sessions()
         .await
         .ok()?;
-    if !resp.status().is_success() {
-        return None;
-    }
-    let body: ListResp = resp.json().await.ok()?;
-    classify_managed_target(&body.sessions, id_or_name)
+    classify_managed_target(&sessions, id_or_name)
+}
+
+/// Build a [`DaemonClient`] from the CLI's `(client, url)` pair.
+///
+/// Why: the managed CLI handlers keep their `(client: &reqwest::Client, url:
+/// &str)` signatures so their callers in `session.rs`/`prune.rs` are untouched,
+/// but their bodies now delegate to the shared typed [`DaemonClient`] (the
+/// convergence target for STUI #1272 / TELUI #1433). This helper centralizes the
+/// construction so every handler reuses the daemon base consistently.
+/// What: returns `DaemonClient::new(url)`. The passed `reqwest::Client` is
+/// intentionally unused — `DaemonClient` owns its own pooled client — but the
+/// parameter is retained so the handler signatures stay stable for callers.
+/// Test: exercised transitively by every managed handler's integration coverage.
+fn daemon_client(_client: &reqwest::Client, url: &str) -> DaemonClient {
+    DaemonClient::new(url.to_string())
 }
 
 /// `tm sessions new` — spawn a managed session from a repo + ref.
@@ -129,30 +120,16 @@ pub(crate) async fn session_new(
     name_hint: Option<String>,
     runtime: trusty_mpm::runtime::RuntimeKind,
 ) -> anyhow::Result<()> {
-    #[derive(Deserialize)]
-    struct SpawnResp {
-        id: String,
-        name: String,
-        state: String,
-        attach_cmd: String,
-        #[serde(default)]
-        runtime: String,
-    }
-    let resp: SpawnResp = client
-        .post(format!("{url}/api/v1/sessions/managed"))
-        .json(&serde_json::json!({
-            "repo_url": repo,
-            "ref": git_ref,
-            "task": task,
-            "name_hint": name_hint,
+    let resp = daemon_client(client, url)
+        .spawn_managed_session(&ManagedSpawnRequest {
+            repo_url: repo,
+            git_ref,
+            task,
+            name_hint,
             // Send the canonical wire spelling (`claude-code`/`tcode`) so the
             // daemon's `FromStr` accepts it; the CLI already validated the value.
-            "runtime": runtime.as_str(),
-        }))
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
+            runtime: Some(runtime.as_str().to_string()),
+        })
         .await?;
     println!(
         "spawned {} ({}) [{}] runtime={}",
@@ -173,26 +150,25 @@ pub(crate) async fn session_ls(
     url: &str,
     json: bool,
 ) -> anyhow::Result<()> {
-    let raw = client
-        .get(format!("{url}/api/v1/sessions/managed"))
-        .send()
-        .await?
-        .error_for_status()?
-        .text()
-        .await?;
+    // `--json` echoes the daemon's response body verbatim (byte-for-byte), so it
+    // reads the raw text rather than re-serializing the typed list — preserving
+    // exact field order and whitespace for scripts that parse the output.
     if json {
+        let raw = client
+            .get(format!("{url}/api/v1/sessions/managed"))
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
         println!("{raw}");
         return Ok(());
     }
-    #[derive(Deserialize)]
-    struct ListResp {
-        sessions: Vec<ManagedSummary>,
-    }
-    let body: ListResp = serde_json::from_str(&raw)?;
-    if body.sessions.is_empty() {
+    let sessions = daemon_client(client, url).list_managed_sessions().await?;
+    if sessions.is_empty() {
         println!("no managed sessions");
     }
-    for s in &body.sessions {
+    for s in &sessions {
         let pending = s
             .pending_decision
             .as_deref()
@@ -217,26 +193,10 @@ pub(crate) async fn session_activity(
     url: &str,
     id: String,
 ) -> anyhow::Result<()> {
-    #[derive(Deserialize)]
-    struct ActivityResp {
-        raw_pane: String,
-        runtime_active: bool,
-        state: String,
-        summary: String,
-        confidence: f32,
-        cache_hit: bool,
-        input_tokens: u32,
-        output_tokens: u32,
-        latency_ms: u64,
-        total_input_tokens: u64,
-        total_output_tokens: u64,
-        #[serde(default)]
-        classification: Option<String>,
-        #[serde(default)]
-        pending_decision: Option<String>,
-        #[serde(default)]
-        proposed_default: Option<String>,
-    }
+    // The raw request is retained here (rather than the typed `DaemonClient`
+    // method) only to preserve the 404 → "not found" output contract; the
+    // response body is deserialized into the SHARED `ManagedActivityResponse`,
+    // dropping the former ad-hoc local struct.
     let resp = client
         .get(format!("{url}/api/v1/sessions/managed/{id}/activity"))
         .send()
@@ -245,7 +205,7 @@ pub(crate) async fn session_activity(
         println!("not found");
         return Ok(());
     }
-    let a: ActivityResp = resp.error_for_status()?.json().await?;
+    let a: trusty_mpm::client::ManagedActivityResponse = resp.error_for_status()?.json().await?;
     let runtime_str = if a.runtime_active {
         "running"
     } else {
@@ -337,11 +297,8 @@ pub(crate) async fn session_attach(
         println!("not found");
         return Ok(());
     }
-    #[derive(Deserialize)]
-    struct AttachResp {
-        attach_cmd: String,
-    }
-    let body: AttachResp = resp.error_for_status()?.json().await?;
+    let body: trusty_mpm::client::ManagedAttachCmdResponse =
+        resp.error_for_status()?.json().await?;
     println!("{}", body.attach_cmd);
     Ok(())
 }
@@ -446,13 +403,7 @@ pub(crate) async fn session_resume(
         println!("cannot resume: {msg}");
         return Ok(());
     }
-    #[derive(Deserialize)]
-    struct ResumeResp {
-        id: String,
-        name: String,
-        state: String,
-    }
-    let body: ResumeResp = resp.error_for_status()?.json().await?;
+    let body: ManagedSessionSummary = resp.error_for_status()?.json().await?;
     println!("resumed {} ({}) [{}]", body.name, body.id, body.state);
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1010,9 +1010,10 @@ fn deprecation_notice_format() {
 fn classify_managed_target_matches_by_id() {
     // #1218: the canonical `stop`/`resume` verbs must recognize a managed
     // session by its UUID and route to the managed endpoint, not project-sessions.
-    use crate::commands::managed::{ManagedSummary, classify_managed_target};
+    use crate::commands::managed::classify_managed_target;
+    use trusty_mpm::client::ManagedSessionSummary;
     let uuid = "11111111-2222-3333-4444-555555555555";
-    let sessions: Vec<ManagedSummary> = serde_json::from_value(serde_json::json!([
+    let sessions: Vec<ManagedSessionSummary> = serde_json::from_value(serde_json::json!([
         { "id": uuid, "name": "tmpm-quiet-falcon", "state": "running" }
     ]))
     .unwrap();
@@ -1027,9 +1028,10 @@ fn classify_managed_target_matches_by_id() {
 fn classify_managed_target_matches_by_name_returns_id() {
     // A friendly managed name must resolve to the canonical UUID the managed
     // endpoints require, so `tm sessions stop <name>` works for managed sessions.
-    use crate::commands::managed::{ManagedSummary, classify_managed_target};
+    use crate::commands::managed::classify_managed_target;
+    use trusty_mpm::client::ManagedSessionSummary;
     let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-    let sessions: Vec<ManagedSummary> = serde_json::from_value(serde_json::json!([
+    let sessions: Vec<ManagedSessionSummary> = serde_json::from_value(serde_json::json!([
         { "id": uuid, "name": "tmpm-brave-otter", "state": "stopped" }
     ]))
     .unwrap();
@@ -1044,8 +1046,9 @@ fn classify_managed_target_matches_by_name_returns_id() {
 fn classify_managed_target_unknown_falls_back_to_none() {
     // A non-managed id/name must NOT match — the caller then falls back to the
     // project-session path, preserving the local/project-session family (#1218).
-    use crate::commands::managed::{ManagedSummary, classify_managed_target};
-    let sessions: Vec<ManagedSummary> = serde_json::from_value(serde_json::json!([
+    use crate::commands::managed::classify_managed_target;
+    use trusty_mpm::client::ManagedSessionSummary;
+    let sessions: Vec<ManagedSessionSummary> = serde_json::from_value(serde_json::json!([
         { "id": "11111111-2222-3333-4444-555555555555", "name": "tmpm-quiet-falcon", "state": "running" }
     ]))
     .unwrap();
@@ -1059,8 +1062,9 @@ fn classify_managed_target_unknown_falls_back_to_none() {
 #[test]
 fn classify_managed_target_empty_list_is_none() {
     // With no managed sessions, every argument falls back to project-sessions.
-    use crate::commands::managed::{ManagedSummary, classify_managed_target};
-    let sessions: Vec<ManagedSummary> = Vec::new();
+    use crate::commands::managed::classify_managed_target;
+    use trusty_mpm::client::ManagedSessionSummary;
+    let sessions: Vec<ManagedSessionSummary> = Vec::new();
     assert_eq!(classify_managed_target(&sessions, "anything"), None);
 }
 

--- a/crates/trusty-mpm/src/client/http_client/managed.rs
+++ b/crates/trusty-mpm/src/client/http_client/managed.rs
@@ -1,0 +1,245 @@
+//! Managed session-manager methods for [`DaemonClient`].
+//!
+//! Why: the `/api/v1/sessions/managed/*` route family is the convergence target
+//! for every managed-session UI — the `tm` CLI today, STUI (#1272) and TELUI
+//! (#1433) next. Before this module each surface hand-rolled `reqwest` calls and
+//! ad-hoc response structs; gathering them as typed [`DaemonClient`] methods wires
+//! each endpoint exactly once. They live in a sibling file (not `mod.rs`) so the
+//! 463-SLOC client `mod.rs` stays under the 500-SLOC cap; this file can reach the
+//! `base`/`http` fields because they are `pub(in crate::client::http_client)`.
+//! What: one async method per managed endpoint, each building the URL from
+//! [`DaemonClient::base`], sending via the shared `reqwest::Client`, checking the
+//! status, and deserializing the typed wire DTO from `super::types`.
+//! Test: `cargo test -p trusty-mpm` (`managed_*` round-trip tests in `tests.rs`)
+//! covers wire-shape deserialization; live HTTP is exercised by the daemon's
+//! `tests/session_manager_mvp.rs` integration suite.
+
+use anyhow::Context;
+
+use super::DaemonClient;
+use super::types::{
+    ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse,
+    ManagedListResponse, ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary,
+    ManagedSpawnRequest, ManagedSpawnResponse,
+};
+
+impl DaemonClient {
+    /// List every managed session via `GET /api/v1/sessions/managed`.
+    ///
+    /// Why: the managed-session list view and the id-or-name resolver both read
+    /// the full session list from this one call.
+    /// What: GETs the managed-list endpoint and returns the `sessions` array.
+    /// Test: `managed_list_response_deserializes` covers the wire shape; live
+    /// HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn list_managed_sessions(&self) -> anyhow::Result<Vec<ManagedSessionSummary>> {
+        let url = format!("{}/api/v1/sessions/managed", self.base);
+        let body: ManagedListResponse = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(body.sessions)
+    }
+
+    /// Fetch one managed session via `GET /api/v1/sessions/managed/{id}`.
+    ///
+    /// Why: a detail view needs a single session without listing every one.
+    /// What: GETs the per-session endpoint and returns the [`ManagedSessionSummary`];
+    /// a 404 (and any other non-success status) surfaces as an `Err`.
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn get_managed_session(&self, id: &str) -> anyhow::Result<ManagedSessionSummary> {
+        let url = format!("{}/api/v1/sessions/managed/{id}", self.base);
+        let summary = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(summary)
+    }
+
+    /// Spawn a managed session via `POST /api/v1/sessions/managed`.
+    ///
+    /// Why: provision an isolated workspace and start a harness in it.
+    /// What: POSTs `req` and returns the daemon's [`ManagedSpawnResponse`].
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn spawn_managed_session(
+        &self,
+        req: &ManagedSpawnRequest,
+    ) -> anyhow::Result<ManagedSpawnResponse> {
+        let url = format!("{}/api/v1/sessions/managed", self.base);
+        let resp = self
+            .http
+            .post(&url)
+            .json(req)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
+
+    /// Inject text into a session's pane via `POST .../{id}/send`.
+    ///
+    /// Why: drive a harness with a prompt without attaching to tmux.
+    /// What: POSTs `{ text }` and returns the [`ManagedSendInputResponse`].
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn send_to_managed_session(
+        &self,
+        id: &str,
+        text: &str,
+    ) -> anyhow::Result<ManagedSendInputResponse> {
+        let url = format!("{}/api/v1/sessions/managed/{id}/send", self.base);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&ManagedSendInputRequest {
+                text: text.to_string(),
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
+
+    /// Answer a pending decision via `POST .../{id}/answer`.
+    ///
+    /// Why: unblock a harness waiting on an operator decision.
+    /// What: POSTs `{ answer }` and returns the [`ManagedAnswerResponse`].
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn answer_managed_session(
+        &self,
+        id: &str,
+        answer: &str,
+    ) -> anyhow::Result<ManagedAnswerResponse> {
+        let url = format!("{}/api/v1/sessions/managed/{id}/answer", self.base);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&ManagedAnswerRequest {
+                answer: answer.to_string(),
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
+
+    /// Inspect a session's activity via `GET .../{id}/activity`.
+    ///
+    /// Why: see what a session is doing without attaching; the raw pane is always
+    /// returned so the caller can reason over it even without an LLM key.
+    /// What: GETs the activity endpoint and returns the [`ManagedActivityResponse`].
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn managed_session_activity(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<ManagedActivityResponse> {
+        let url = format!("{}/api/v1/sessions/managed/{id}/activity", self.base);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
+
+    /// Fetch the tmux attach command via `GET .../{id}/attach-cmd`.
+    ///
+    /// Why: an operator needs the exact `tmux attach` invocation to take over.
+    /// What: GETs the attach-cmd endpoint and returns the [`ManagedAttachCmdResponse`].
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn managed_session_attach_cmd(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<ManagedAttachCmdResponse> {
+        let url = format!("{}/api/v1/sessions/managed/{id}/attach-cmd", self.base);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
+
+    /// Stop a session's runtime via `POST .../{id}/runtime-stop`.
+    ///
+    /// Why: a session endures beyond its runtime; this kills only the tmux session
+    /// and harness process, preserving the workspace for a later resume.
+    /// What: POSTs to the runtime-stop endpoint and returns the updated summary.
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn runtime_stop_managed_session(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<ManagedSessionSummary> {
+        let url = format!("{}/api/v1/sessions/managed/{id}/runtime-stop", self.base);
+        let resp = self
+            .http
+            .post(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
+
+    /// Resume a stopped session via `POST .../{id}/resume`.
+    ///
+    /// Why: after a runtime-stop the workspace is still on disk; resume re-spawns
+    /// the runtime there without re-cloning.
+    /// What: POSTs to the resume endpoint and returns the updated summary. The
+    /// daemon answers with typed 404/409/500 errors; rather than swallow them,
+    /// a non-success status is flattened into an `anyhow` error that carries the
+    /// HTTP status and the response body text so the caller can surface both.
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn resume_managed_session(&self, id: &str) -> anyhow::Result<ManagedSessionSummary> {
+        let url = format!("{}/api/v1/sessions/managed/{id}/resume", self.base);
+        let resp = self.http.post(&url).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("resume failed (HTTP {status}): {body}");
+        }
+        let summary = resp.json().await.context("decoding resume response body")?;
+        Ok(summary)
+    }
+
+    /// Decommission a session via `POST .../{id}/decommission`.
+    ///
+    /// Why: the only operation that permanently removes the workspace directory;
+    /// it is terminal — no resume is possible afterward.
+    /// What: POSTs to the decommission endpoint and returns the tombstone summary.
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    pub async fn decommission_managed_session(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<ManagedSessionSummary> {
+        let url = format!("{}/api/v1/sessions/managed/{id}/decommission", self.base);
+        let resp = self
+            .http
+            .post(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
+}

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -50,9 +50,24 @@ impl DaemonClient {
     /// What: stores the base URL and a fresh pooled `reqwest::Client`.
     /// Test: `base_url_is_stored`.
     pub fn new(base: impl Into<String>) -> Self {
+        Self::with_client(reqwest::Client::new(), base)
+    }
+
+    /// Build a client targeting `base`, REUSING an existing `reqwest::Client`.
+    ///
+    /// Why: callers that already configured a `reqwest::Client` (custom TLS,
+    /// timeouts, proxy, connection pool) must not have that configuration
+    /// silently dropped by [`Self::new`] minting a fresh default client. Reusing
+    /// the caller's client is cheap — `reqwest::Client` is an `Arc` internally,
+    /// so cloning shares the same pool and settings.
+    /// What: stores `base` and adopts the passed `client` verbatim as the HTTP
+    /// transport.
+    /// Test: `with_client_reuses_passed_client` asserts the base is stored and
+    /// the client is adopted.
+    pub fn with_client(client: reqwest::Client, base: impl Into<String>) -> Self {
         Self {
             base: base.into(),
-            http: reqwest::Client::new(),
+            http: client,
         }
     }
 

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -12,6 +12,7 @@
 //! deserialization; live HTTP is exercised by the executor tests against an
 //! in-process test daemon and by the daemon's own API tests.
 
+mod managed;
 mod session_connect;
 #[cfg(test)]
 mod tests;
@@ -19,8 +20,11 @@ mod types;
 
 pub use types::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
-    CoordinatorSession, DiscoveredProjectRow, EventRow, LastSeen, LlmChatOutcome, OverseerSnapshot,
-    PairConfirm, PairRequest, PairStatus, SessionRow, TmuxSessionRow,
+    CoordinatorSession, DiscoveredProjectRow, EventRow, LastSeen, LlmChatOutcome,
+    ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse,
+    ManagedListResponse, ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary,
+    ManagedSpawnRequest, ManagedSpawnResponse, OverseerSnapshot, PairConfirm, PairRequest,
+    PairStatus, SessionRow, TmuxSessionRow,
 };
 
 use serde::Deserialize;

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -7,6 +7,16 @@ fn base_url_is_stored() {
 }
 
 #[test]
+fn with_client_reuses_passed_client() {
+    // Why: callers that configured a `reqwest::Client` (TLS/timeout/proxy/pool)
+    // must keep that configuration; `with_client` adopts the passed client
+    // verbatim instead of minting a fresh default one.
+    let configured = reqwest::Client::new();
+    let client = DaemonClient::with_client(configured, "http://127.0.0.1:7880");
+    assert_eq!(client.base_url(), "http://127.0.0.1:7880");
+}
+
+#[test]
 fn set_base_url_repoints_client() {
     // Why: a long-lived UI must follow the daemon to a new ephemeral port
     // after a restart; `set_base_url` is what makes that re-pointing possible.
@@ -314,6 +324,7 @@ fn managed_session_summary_deserializes() {
     assert_eq!(s.id, "00000000-0000-0000-0000-000000000001");
     assert_eq!(s.name, "tmpm-brave-otter");
     assert_eq!(s.state, "running");
+    assert_eq!(s.created_at.as_deref(), Some("2026-06-19T00:00:00Z"));
     assert_eq!(s.pending_decision.as_deref(), Some("overwrite?"));
 
     // Minimal body: only the always-present fields.
@@ -321,6 +332,8 @@ fn managed_session_summary_deserializes() {
     let s: ManagedSessionSummary = serde_json::from_value(lean).unwrap();
     assert_eq!(s.id, "x");
     assert!(s.workspace_path.is_none());
+    // An absent `created_at` deserializes to `None`, not an empty string.
+    assert!(s.created_at.is_none());
     assert!(s.pending_decision.is_none());
 }
 
@@ -383,8 +396,17 @@ fn managed_spawn_response_deserializes() {
     });
     let r: ManagedSpawnResponse = serde_json::from_value(json).unwrap();
     assert_eq!(r.id, "id-1");
+    assert_eq!(r.created_at.as_deref(), Some("2026-06-19T00:00:00Z"));
     assert_eq!(r.attach_cmd, "tmux attach-session -t tmpm-x");
     assert_eq!(r.runtime, "claude-code");
+
+    // An absent `created_at` deserializes to `None`, while `attach_cmd` and
+    // `runtime` remain plain strings defaulting to empty.
+    let lean = serde_json::json!({"id": "id-2", "name": "tmpm-y", "state": "running"});
+    let r: ManagedSpawnResponse = serde_json::from_value(lean).unwrap();
+    assert!(r.created_at.is_none());
+    assert_eq!(r.attach_cmd, "");
+    assert_eq!(r.runtime, "");
 }
 
 #[test]

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -291,3 +291,195 @@ fn catalog_stale_health_body_wire_shape() {
     let legacy: HealthBody = serde_json::from_value(serde_json::json!({"status":"ok"})).unwrap();
     assert!(!legacy.catalog_stale, "missing field defaults to false");
 }
+
+// ── Managed session-manager wire-shape round-trips ─────────────────────────────
+
+#[test]
+fn managed_session_summary_deserializes() {
+    // A full summary round-trips; the optional fields are also tolerant of being
+    // absent (an older/leaner daemon) via `#[serde(default)]`.
+    let json = serde_json::json!({
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "tmpm-brave-otter",
+        "state": "running",
+        "workspace_path": "/tmp/ws",
+        "repo_url": "https://example.com/r.git",
+        "branch": "main",
+        "created_at": "2026-06-19T00:00:00Z",
+        "last_activity_at": "2026-06-19T01:00:00Z",
+        "pending_decision": "overwrite?",
+        "proposed_default": "yes",
+    });
+    let s: ManagedSessionSummary = serde_json::from_value(json).unwrap();
+    assert_eq!(s.id, "00000000-0000-0000-0000-000000000001");
+    assert_eq!(s.name, "tmpm-brave-otter");
+    assert_eq!(s.state, "running");
+    assert_eq!(s.pending_decision.as_deref(), Some("overwrite?"));
+
+    // Minimal body: only the always-present fields.
+    let lean = serde_json::json!({"id": "x", "name": "n", "state": "stopped"});
+    let s: ManagedSessionSummary = serde_json::from_value(lean).unwrap();
+    assert_eq!(s.id, "x");
+    assert!(s.workspace_path.is_none());
+    assert!(s.pending_decision.is_none());
+}
+
+#[test]
+fn managed_list_response_deserializes() {
+    let json = serde_json::json!({
+        "sessions": [
+            {"id": "a", "name": "tmpm-a", "state": "running"},
+            {"id": "b", "name": "tmpm-b", "state": "stopped"},
+        ],
+    });
+    let body: ManagedListResponse = serde_json::from_value(json).unwrap();
+    assert_eq!(body.sessions.len(), 2);
+    assert_eq!(body.sessions[1].name, "tmpm-b");
+
+    // An empty / absent `sessions` array defaults to empty.
+    let empty: ManagedListResponse = serde_json::from_value(serde_json::json!({})).unwrap();
+    assert!(empty.sessions.is_empty());
+}
+
+#[test]
+fn managed_spawn_request_serializes() {
+    // The `git_ref` field must serialize under the wire key `ref`, and absent
+    // optionals must be omitted so the daemon sees them as null/defaulted.
+    let req = ManagedSpawnRequest {
+        repo_url: "https://example.com/r.git".to_string(),
+        git_ref: "main".to_string(),
+        task: "do the thing".to_string(),
+        name_hint: Some("tmpm-custom".to_string()),
+        runtime: Some("tcode".to_string()),
+    };
+    let v = serde_json::to_value(&req).unwrap();
+    assert_eq!(v["ref"], "main");
+    assert_eq!(v["repo_url"], "https://example.com/r.git");
+    assert_eq!(v["name_hint"], "tmpm-custom");
+    assert_eq!(v["runtime"], "tcode");
+    assert!(v.get("git_ref").is_none(), "must use wire key `ref`");
+
+    let bare = ManagedSpawnRequest {
+        repo_url: "r".to_string(),
+        git_ref: "r".to_string(),
+        task: "t".to_string(),
+        name_hint: None,
+        runtime: None,
+    };
+    let v = serde_json::to_value(&bare).unwrap();
+    assert!(v.get("name_hint").is_none(), "None name_hint is omitted");
+    assert!(v.get("runtime").is_none(), "None runtime is omitted");
+}
+
+#[test]
+fn managed_spawn_response_deserializes() {
+    let json = serde_json::json!({
+        "id": "id-1",
+        "name": "tmpm-x",
+        "state": "running",
+        "created_at": "2026-06-19T00:00:00Z",
+        "attach_cmd": "tmux attach-session -t tmpm-x",
+        "runtime": "claude-code",
+    });
+    let r: ManagedSpawnResponse = serde_json::from_value(json).unwrap();
+    assert_eq!(r.id, "id-1");
+    assert_eq!(r.attach_cmd, "tmux attach-session -t tmpm-x");
+    assert_eq!(r.runtime, "claude-code");
+}
+
+#[test]
+fn managed_send_and_answer_round_trip() {
+    let v = serde_json::to_value(ManagedSendInputRequest {
+        text: "hello".to_string(),
+    })
+    .unwrap();
+    assert_eq!(v["text"], "hello");
+    let sent: ManagedSendInputResponse =
+        serde_json::from_value(serde_json::json!({"sent": true, "tmux_name": "tmpm-x"})).unwrap();
+    assert!(sent.sent);
+    assert_eq!(sent.tmux_name, "tmpm-x");
+
+    let v = serde_json::to_value(ManagedAnswerRequest {
+        answer: "yes".to_string(),
+    })
+    .unwrap();
+    assert_eq!(v["answer"], "yes");
+    let answered: ManagedAnswerResponse =
+        serde_json::from_value(serde_json::json!({"injected": true, "tmux_name": "tmpm-x"}))
+            .unwrap();
+    assert!(answered.injected);
+}
+
+#[test]
+fn managed_attach_cmd_response_deserializes() {
+    let r: ManagedAttachCmdResponse =
+        serde_json::from_value(serde_json::json!({"attach_cmd": "tmux attach-session -t tmpm-x"}))
+            .unwrap();
+    assert_eq!(r.attach_cmd, "tmux attach-session -t tmpm-x");
+}
+
+#[test]
+fn managed_activity_response_deserializes() {
+    // Both with and without the optional classifier overlay.
+    let json = serde_json::json!({
+        "raw_pane": "line1\nline2",
+        "runtime_active": true,
+        "state": "working",
+        "summary": "running tests",
+        "confidence": 0.8_f32,
+        "cache_hit": false,
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "latency_ms": 42,
+        "total_input_tokens": 100,
+        "total_output_tokens": 50,
+        "classification": "working",
+        "pending_decision": "overwrite?",
+        "proposed_default": "yes",
+    });
+    let a: ManagedActivityResponse = serde_json::from_value(json).unwrap();
+    assert_eq!(a.state, "working");
+    assert!(a.runtime_active);
+    assert_eq!(a.classification.as_deref(), Some("working"));
+    assert_eq!(a.pending_decision.as_deref(), Some("overwrite?"));
+
+    // No classifier ran: `classification` null, raw pane still present.
+    let json = serde_json::json!({
+        "raw_pane": "pane",
+        "runtime_active": false,
+        "state": "unknown",
+        "summary": "",
+        "confidence": 0.0_f32,
+        "cache_hit": false,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "latency_ms": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "classification": null,
+    });
+    let a: ManagedActivityResponse = serde_json::from_value(json).unwrap();
+    assert_eq!(a.raw_pane, "pane");
+    assert!(a.classification.is_none());
+    assert!(a.pending_decision.is_none());
+}
+
+#[test]
+fn managed_session_urls_use_managed_route_family() {
+    // The managed methods build URLs off the `/api/v1/sessions/managed` base and
+    // must NOT collide with the legacy `resume_session` route (`/sessions/{id}/
+    // resume`). This guards the route family contract that STUI/TELUI converge on.
+    let client = DaemonClient::new("http://127.0.0.1:7880");
+    assert_eq!(client.base_url(), "http://127.0.0.1:7880");
+    // Construct the same format strings the methods use, to lock the shape.
+    let base = client.base_url();
+    assert_eq!(
+        format!("{base}/api/v1/sessions/managed/{id}/resume", id = "abc"),
+        "http://127.0.0.1:7880/api/v1/sessions/managed/abc/resume"
+    );
+    // The legacy method targets a different path; the two never overlap.
+    assert_eq!(
+        format!("{base}/sessions/{id}/resume", id = "abc"),
+        "http://127.0.0.1:7880/sessions/abc/resume"
+    );
+}

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -366,9 +366,9 @@ pub struct ManagedSessionSummary {
     /// Git branch or ref checked out.
     #[serde(default)]
     pub branch: Option<String>,
-    /// Creation timestamp (RFC 3339).
+    /// Creation timestamp (RFC 3339), `None` when the daemon omits it.
     #[serde(default)]
-    pub created_at: String,
+    pub created_at: Option<String>,
     /// Last-activity timestamp (RFC 3339), if any.
     #[serde(default)]
     pub last_activity_at: Option<String>,
@@ -440,9 +440,9 @@ pub struct ManagedSpawnResponse {
     pub branch: Option<String>,
     /// Current lifecycle state.
     pub state: String,
-    /// Creation timestamp (RFC 3339).
+    /// Creation timestamp (RFC 3339), `None` when the daemon omits it.
     #[serde(default)]
-    pub created_at: String,
+    pub created_at: Option<String>,
     /// tmux attach command string.
     #[serde(default)]
     pub attach_cmd: String,

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -333,3 +333,223 @@ pub struct CoordinatorChatOutcome {
     #[serde(default)]
     pub command_output: Option<String>,
 }
+
+// ── Managed session-manager wire types (`/api/v1/sessions/managed/*`) ───────────
+//
+// These mirror the daemon-side DTOs in `crate::daemon::managed_routes` field-for-
+// field so serde round-trips across the HTTP boundary. The struct names carry a
+// `Managed` prefix to avoid colliding with the existing `client::result::
+// SessionSummary` re-export; serde keys (not Rust type names) are what the wire
+// contract pins, so the prefix is cosmetic.
+
+/// One managed session as returned by the list/get endpoints.
+///
+/// Why: every managed-session UI (the `tm` CLI today, STUI #1272 and TELUI #1433
+/// next) renders the same flat, string-typed summary; a shared client type keeps
+/// them off the daemon's internal record shape and off hand-rolled structs.
+/// What: mirrors `daemon::managed_routes::SessionSummary` field-for-field.
+/// Test: `managed_session_summary_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedSessionSummary {
+    /// Managed session id (UUID string).
+    pub id: String,
+    /// tmux session name.
+    pub name: String,
+    /// Lifecycle state word.
+    pub state: String,
+    /// Provisioned workspace path, if any.
+    #[serde(default)]
+    pub workspace_path: Option<String>,
+    /// Repository URL the session was provisioned from.
+    #[serde(default)]
+    pub repo_url: Option<String>,
+    /// Git branch or ref checked out.
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// Creation timestamp (RFC 3339).
+    #[serde(default)]
+    pub created_at: String,
+    /// Last-activity timestamp (RFC 3339), if any.
+    #[serde(default)]
+    pub last_activity_at: Option<String>,
+    /// A pending decision question, if surfaced.
+    #[serde(default)]
+    pub pending_decision: Option<String>,
+    /// Proposed default answer to the pending decision.
+    #[serde(default)]
+    pub proposed_default: Option<String>,
+}
+
+/// Wrapper for `GET /api/v1/sessions/managed` (the list endpoint).
+///
+/// Why: the list endpoint nests the sessions under a `sessions` key; a typed
+/// wrapper deserializes it without an ad-hoc local struct at the call site.
+/// What: mirrors `daemon::managed_routes::ListSessionsResponse`.
+/// Test: `managed_list_response_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedListResponse {
+    /// All managed sessions as summaries.
+    #[serde(default)]
+    pub sessions: Vec<ManagedSessionSummary>,
+}
+
+/// Request body for `POST /api/v1/sessions/managed` (spawn).
+///
+/// Why: spawning a managed session requires the repo, ref, and task; an optional
+/// name hint and runtime selector tune the tmux name and backend.
+/// What: mirrors `daemon::managed_routes::SpawnRequest`; `git_ref` serializes as
+/// `ref` to match the daemon's `#[serde(rename = "ref")]`.
+/// Test: `managed_spawn_request_serializes`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagedSpawnRequest {
+    /// Repository URL to provision the session workspace from.
+    pub repo_url: String,
+    /// Git branch or ref to check out (wire key `ref`).
+    #[serde(rename = "ref")]
+    pub git_ref: String,
+    /// Human-readable task description for the session.
+    pub task: String,
+    /// Optional name hint overriding the auto-generated tmux session name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name_hint: Option<String>,
+    /// Optional runtime selector (`"claude-code"` | `"tcode"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
+}
+
+/// Response body for `POST /api/v1/sessions/managed` (spawn).
+///
+/// Why: the caller needs the new session's identity, state, runtime, and attach
+/// command immediately after spawn.
+/// What: mirrors `daemon::managed_routes::SpawnResponse`.
+/// Test: `managed_spawn_response_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedSpawnResponse {
+    /// Managed session id (UUID string).
+    pub id: String,
+    /// tmux session name.
+    pub name: String,
+    /// Provisioned workspace path, if any.
+    #[serde(default)]
+    pub workspace_path: Option<String>,
+    /// Repository URL the session was provisioned from.
+    #[serde(default)]
+    pub repo_url: Option<String>,
+    /// Git branch or ref checked out.
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// Current lifecycle state.
+    pub state: String,
+    /// Creation timestamp (RFC 3339).
+    #[serde(default)]
+    pub created_at: String,
+    /// tmux attach command string.
+    #[serde(default)]
+    pub attach_cmd: String,
+    /// Runtime backend hosting the session (`"claude-code"` | `"tcode"`).
+    #[serde(default)]
+    pub runtime: String,
+}
+
+/// Request body for `POST /api/v1/sessions/managed/{id}/send`.
+///
+/// Why: inject operator/agent text into a session's tmux pane.
+/// What: mirrors `daemon::managed_routes::SendInputRequest`.
+/// Test: `managed_send_request_serializes`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagedSendInputRequest {
+    /// Text to inject into the session's tmux pane.
+    pub text: String,
+}
+
+/// Response body for `POST /api/v1/sessions/managed/{id}/send`.
+///
+/// Why: confirm the inject succeeded without echoing the full record.
+/// What: mirrors `daemon::managed_routes::SendInputResponse`.
+/// Test: `managed_send_response_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedSendInputResponse {
+    /// True when the text was injected.
+    pub sent: bool,
+    /// tmux session name the text was sent to.
+    #[serde(default)]
+    pub tmux_name: String,
+}
+
+/// Request body for `POST /api/v1/sessions/managed/{id}/answer`.
+///
+/// Why: inject an answer to a pending decision the harness is blocked on.
+/// What: mirrors `daemon::managed_routes::AnswerRequest`.
+/// Test: `managed_answer_request_serializes`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagedAnswerRequest {
+    /// The answer text to inject for the pending decision.
+    pub answer: String,
+}
+
+/// Response body for `POST /api/v1/sessions/managed/{id}/answer`.
+///
+/// Why: confirm the answer was injected.
+/// What: mirrors `daemon::managed_routes::AnswerResponse`.
+/// Test: `managed_answer_response_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedAnswerResponse {
+    /// True when the answer was injected.
+    pub injected: bool,
+    /// tmux session name the answer was sent to.
+    #[serde(default)]
+    pub tmux_name: String,
+}
+
+/// Response body for `GET /api/v1/sessions/managed/{id}/attach-cmd`.
+///
+/// Why: the operator needs the exact tmux command to attach to the pane.
+/// What: mirrors `daemon::managed_routes::AttachCmdResponse`.
+/// Test: `managed_attach_cmd_response_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedAttachCmdResponse {
+    /// tmux attach command string.
+    pub attach_cmd: String,
+}
+
+/// Response body for `GET /api/v1/sessions/managed/{id}/activity`.
+///
+/// Why: surface a session's full activity picture without attaching and without
+/// requiring an LLM key — the raw pane and structured lifecycle fields are always
+/// present; the LLM overlay is populated only when a classifier ran.
+/// What: mirrors `daemon::managed_routes::ActivityResponse` field-for-field.
+/// Test: `managed_activity_response_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedActivityResponse {
+    /// Raw pane content (last 60 lines). Always present.
+    pub raw_pane: String,
+    /// Whether the tmux runtime session is currently alive.
+    pub runtime_active: bool,
+    /// Activity state from LLM classification, or `"unknown"`.
+    pub state: String,
+    /// Human-readable summary of what the session is doing.
+    pub summary: String,
+    /// Confidence of the classification (0.0–1.0); 0.0 when no classifier ran.
+    pub confidence: f32,
+    /// True when the verdict was served from the content-hash cache.
+    pub cache_hit: bool,
+    /// Input token count for this check (0 on cache hit or no classifier).
+    pub input_tokens: u32,
+    /// Output token count for this check (0 on cache hit or no classifier).
+    pub output_tokens: u32,
+    /// Latency in milliseconds for this check.
+    pub latency_ms: u64,
+    /// Cumulative input tokens across all checks for this session.
+    pub total_input_tokens: u64,
+    /// Cumulative output tokens across all checks for this session.
+    pub total_output_tokens: u64,
+    /// LLM classification result, `None` when no classifier ran.
+    #[serde(default)]
+    pub classification: Option<String>,
+    /// A pending decision question, if surfaced.
+    #[serde(default)]
+    pub pending_decision: Option<String>,
+    /// Proposed default answer to the pending decision.
+    #[serde(default)]
+    pub proposed_default: Option<String>,
+}

--- a/crates/trusty-mpm/src/client/mod.rs
+++ b/crates/trusty-mpm/src/client/mod.rs
@@ -25,7 +25,10 @@ pub use executor::CommandExecutor;
 pub use http_client::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
     CoordinatorSession, DaemonClient, DiscoveredProjectRow, EventRow, LastSeen, LlmChatOutcome,
-    OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow, TmuxSessionRow,
+    ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse,
+    ManagedListResponse, ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary,
+    ManagedSpawnRequest, ManagedSpawnResponse, OverseerSnapshot, PairConfirm, PairRequest,
+    PairStatus, SessionRow, TmuxSessionRow,
 };
 pub use result::{
     CommandResult, DecisionCounts, DiscoveredProjectSummary, RecommendationSummary, SessionSummary,


### PR DESCRIPTION
## Summary
First slice of the **Shared DaemonClient enabler** (#3 control surfaces). Extends `DaemonClient` with typed managed-session methods and refactors the `tm` CLI managed-session commands to use them, converging on the `/api/v1/sessions/managed/*` route family. Unblocks STUI (#1272) and TELUI (#1433).

## Changes
- New `client/http_client/managed.rs` — 10 typed `impl DaemonClient` methods: `list_managed_sessions`, `get_managed_session`, `spawn_managed_session`, `send_to_managed_session`, `answer_managed_session`, `managed_session_activity`, `managed_session_attach_cmd`, `runtime_stop_managed_session`, `resume_managed_session`, `decommission_managed_session`.
- New `Managed*` wire DTOs in `client/http_client/types.rs`, mirroring the daemon `managed_routes` DTOs field-for-field (serde keys match the wire contract; `Managed` prefix avoids a name clash with the existing `client::SessionSummary`).
- Refactored `bin/tm/commands/managed.rs` (433 → 372 SLOC) to delegate to the typed client; deleted 6 ad-hoc local response structs.
- Added serde round-trip + route-family unit tests in `client/http_client/tests.rs`.

## Notes for reviewers
- `resume_managed_session` is named distinctly from the legacy `resume_session` (which hits `/sessions/{id}/resume`); a test locks both URL shapes so they never overlap.
- `daemon_client(_client, url)` helper keeps the CLI handler signatures stable for existing callers; the passed `reqwest::Client` is intentionally unused (DaemonClient owns its own pool).
- Three handlers (`session_activity`, `session_attach`, `session_resume`) and `session_ls --json` keep a raw reqwest request to preserve byte-for-byte 404/error output and verbatim JSON passthrough, but now deserialize into the shared `Managed*` DTOs.

## Verification
- `cargo build -p trusty-mpm` ✓
- `cargo test -p trusty-mpm` ✓ (1535 lib + 353 bin unit tests + integration suites; 0 failed)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` ✓ clean
- `cargo fmt --check` ✓
- `bash scripts/check_line_cap.sh` ✓ (0 violations)

Refs #1272, #1433. Part of #3 control-surfaces roadmap.

🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
