### PR TITLE
feat(trusty-mpm): chat-core nucleus — shared command layer for session-manager adapters

### DIFF
--- a/crates/trusty-mpm/src/client/catalog/mod.rs
+++ b/crates/trusty-mpm/src/client/catalog/mod.rs
@@ -1,0 +1,432 @@
+//! The command catalog — single source of truth for the verb surface.
+//!
+//! Why: before this module, three things described the same verb set and could
+//! silently drift: the `/help` body (hand-written in `command.rs`), the typed
+//! [`TrustyCommand`] enum, and the SM prompt's `SM_TOOLS.md` prose. The catalog
+//! collapses them into one structured registry. Every adapter renders its help
+//! from the same [`CommandSpec`] list, and the SM prompt's tool surface is
+//! rendered from the same registry, so a new verb is described in exactly one
+//! place. This is the "catalog as single source of truth" principle of the
+//! chat-core nucleus (see `docs/specs/chat-core.md`, SPEC-CHAT-CORE-01).
+//! What: [`CommandSpec`] is one entry per operator verb — its canonical name,
+//! aliases, argument list, one-line summary, and the [`SpecKind`] that ties it
+//! to a [`TrustyCommand`] variant (or marks it SM-only). [`catalog`] returns the
+//! full registry; [`help_text`] renders the `/help` body; [`render_sm_tools`]
+//! renders the `SM_TOOLS.md` prompt section. A unit test asserts the committed
+//! `SM_TOOLS.md` byte-matches [`render_sm_tools`] so the two can never diverge.
+//! Test: `catalog_covers_every_command`, `help_text_lists_every_command`,
+//! `sm_tools_md_matches_catalog_render` (the parity / single-source-of-truth
+//! guard).
+
+use std::sync::OnceLock;
+
+mod sm_tools;
+
+pub use sm_tools::render_sm_tools;
+
+/// How a catalog entry relates to the typed [`TrustyCommand`] surface.
+///
+/// Why: most catalog verbs map onto a `TrustyCommand` variant an adapter can
+/// dispatch, but a few SM prompt verbs (memory, goals) are SM-only — the SM
+/// calls them as namespaced JSON-RPC methods, not through the chat-core
+/// executor. Modeling that distinction keeps both renderings (operator `/help`
+/// vs. SM prompt) drawn from one list without pretending every prompt verb is a
+/// dispatchable command.
+/// What: `Command` carries the canonical slash name an adapter parses;
+/// `SmOnly` marks a prompt-surface verb with no chat-core dispatch.
+/// Test: covered by `catalog_covers_every_command` and the SM-tools parity test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecKind {
+    /// A dispatchable operator command, keyed by its canonical slash name
+    /// (without the leading `/`), e.g. `"sessions"`.
+    Command,
+    /// An SM-prompt-only verb (memory/goals) with no chat-core dispatch.
+    SmOnly,
+}
+
+/// One catalog entry: a verb, its surface forms, and its one-line summary.
+///
+/// Why: a single structured description per verb lets every rendering (operator
+/// `/help`, the SM prompt tool table) derive from the same data, so adding or
+/// renaming a verb touches exactly one place.
+/// What: the canonical `name`, any `aliases`, the human-readable `args` sketch,
+/// a one-line `summary`, and the [`SpecKind`] that ties it to the typed command
+/// surface. All fields are `'static` so the catalog is a compile-time constant
+/// table with no allocation.
+/// Test: `catalog_covers_every_command`, `sm_tools_md_matches_catalog_render`.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandSpec {
+    /// Canonical verb name. For [`SpecKind::Command`] this is the slash command
+    /// (without `/`); for [`SpecKind::SmOnly`] it is the namespaced JSON-RPC
+    /// method spelling (e.g. `memory.recall(query)`).
+    pub name: &'static str,
+    /// Alternate spellings the adapters accept for this verb (may be empty).
+    pub aliases: &'static [&'static str],
+    /// Human-readable argument sketch (e.g. `<id>`), empty when the verb takes
+    /// no arguments.
+    pub args: &'static str,
+    /// One-line operator-facing summary.
+    pub summary: &'static str,
+    /// How the entry relates to the typed [`TrustyCommand`] surface.
+    pub kind: SpecKind,
+}
+
+impl CommandSpec {
+    /// The callable signature for the SM-prompt tool table.
+    ///
+    /// Why: the SM prompt renders each verb as a callable `name(args)` form (e.g.
+    /// `sessions.launch(workdir, model?, prompt?, goal_id?)`), matching the
+    /// hand-written `SM_TOOLS.md`. Both SM-only and command entries carry their
+    /// args in the dedicated `args` field, so the signature is computed uniformly.
+    /// What: renders `name(args)`; an empty `args` yields `name()`. Operator-facing
+    /// angle brackets (`<id>`) are stripped so the prompt reads as a method call.
+    /// Test: `sm_tools_md_matches_catalog_render`, `prompt_signature_renders_callable_verbs`.
+    pub(super) fn prompt_signature(&self) -> String {
+        if self.args.is_empty() {
+            format!("{}()", self.name)
+        } else {
+            let inner = self.args.replace(['<', '>'], "");
+            format!("{}({inner})", self.name)
+        }
+    }
+}
+
+/// The operator-facing chat-core commands (every dispatchable verb).
+///
+/// Why: this is the list every adapter renders its `/help` from and the typed
+/// dispatch the executor exhausts; it covers the legacy project-session/pairing
+/// family AND the managed session-manager verb set.
+/// What: ordered for a readable `/help`; each entry's `name` is the canonical
+/// slash command the adapters parse.
+/// Test: `catalog_covers_every_command`, `help_text_lists_every_command`.
+const COMMANDS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "sessions",
+        aliases: &[],
+        args: "",
+        summary: "list managed sessions",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "status",
+        aliases: &[],
+        args: "<id>",
+        summary: "detailed session status",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "approve",
+        aliases: &[],
+        args: "<id>",
+        summary: "approve a pending permission request",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "deny",
+        aliases: &[],
+        args: "<id>",
+        summary: "deny a pending permission request",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "overseer",
+        aliases: &[],
+        args: "",
+        summary: "show overseer status",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "tmux",
+        aliases: &[],
+        args: "",
+        summary: "list all tmux sessions",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "projects",
+        aliases: &[],
+        args: "",
+        summary: "discover projects from Claude Code config",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "discover",
+        aliases: &[],
+        args: "",
+        summary: "auto-discover tmux sessions running Claude Code",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "adopt",
+        aliases: &[],
+        args: "<session>",
+        summary: "adopt an external tmux session",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "config",
+        aliases: &[],
+        args: "<path>",
+        summary: "analyze Claude Code config for a project",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "snapshot",
+        aliases: &[],
+        args: "<session>",
+        summary: "capture a tmux pane",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "kill",
+        aliases: &[],
+        args: "<id>",
+        summary: "kill a session",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "send",
+        aliases: &[],
+        args: "<session> <prompt>",
+        summary: "send a prompt to a Claude Code session",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "connect",
+        aliases: &[],
+        args: "<path>",
+        summary: "connect to or start a session (no deployment)",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "alerts",
+        aliases: &[],
+        args: "",
+        summary: "show alert subscriptions",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "pair",
+        aliases: &[],
+        args: "<code>",
+        summary: "pair this bot with your daemon",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "start",
+        aliases: &[],
+        args: "",
+        summary: "pairing status and onboarding",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "doctor",
+        aliases: &[],
+        args: "",
+        summary: "run full system diagnostic",
+        kind: SpecKind::Command,
+    },
+    // ── Managed session-manager verbs ───────────────────────────────────────
+    CommandSpec {
+        name: "managed-new",
+        aliases: &["spawn"],
+        args: "<repo> <ref> <task>",
+        summary: "spawn a managed session from a repo + ref + task",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-list",
+        aliases: &[],
+        args: "",
+        summary: "list managed session-manager sessions",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-get",
+        aliases: &[],
+        args: "<id>",
+        summary: "fetch one managed session's record",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-send",
+        aliases: &[],
+        args: "<id> <text>",
+        summary: "inject text into a managed session's pane",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-answer",
+        aliases: &[],
+        args: "<id> <answer>",
+        summary: "answer a managed session's pending decision",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-activity",
+        aliases: &[],
+        args: "<id>",
+        summary: "inspect a managed session's activity",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-attach",
+        aliases: &[],
+        args: "<id>",
+        summary: "show a managed session's tmux attach command",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-stop",
+        aliases: &[],
+        args: "<id>",
+        summary: "stop a managed session's runtime (keeps the workspace)",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-resume",
+        aliases: &[],
+        args: "<id>",
+        summary: "resume a stopped managed session",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "managed-decommission",
+        aliases: &[],
+        args: "<id>",
+        summary: "decommission a managed session (terminal; removes workspace)",
+        kind: SpecKind::Command,
+    },
+    CommandSpec {
+        name: "help",
+        aliases: &[],
+        args: "",
+        summary: "this message",
+        kind: SpecKind::Command,
+    },
+];
+
+/// The full operator command catalog.
+///
+/// Why: adapters and tests need read access to the registry to render help,
+/// build pickers, and assert coverage.
+/// What: returns the static [`CommandSpec`] slice of every dispatchable command.
+/// Test: `catalog_covers_every_command`.
+pub fn catalog() -> &'static [CommandSpec] {
+    COMMANDS
+}
+
+/// Render the `/help` body from the command catalog.
+///
+/// Why: the help text is derived from the same registry the executor dispatches,
+/// so it can never list a command the executor cannot run, nor omit one.
+/// What: one line per [`SpecKind::Command`] entry, `"/name <args> — summary"`,
+/// computed once and cached for the `&'static str` callers expect.
+/// Test: `help_text_lists_every_command`.
+pub fn help_text() -> &'static str {
+    static HELP: OnceLock<String> = OnceLock::new();
+    HELP.get_or_init(|| {
+        let mut out = String::from("trusty-mpm bot commands:\n");
+        let lines: Vec<String> = COMMANDS
+            .iter()
+            .filter(|c| c.kind == SpecKind::Command)
+            .map(|c| {
+                if c.args.is_empty() {
+                    format!("/{} — {}", c.name, c.summary)
+                } else {
+                    format!("/{} {} — {}", c.name, c.args, c.summary)
+                }
+            })
+            .collect();
+        out.push_str(&lines.join("\n"));
+        out
+    })
+    .as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_covers_every_command() {
+        // The catalog must contain every operator-facing slash command, keyed by
+        // its canonical name without the leading slash.
+        let names: Vec<&str> = catalog()
+            .iter()
+            .filter(|c| c.kind == SpecKind::Command)
+            .map(|c| c.name)
+            .collect();
+        for expected in [
+            "sessions",
+            "status",
+            "approve",
+            "deny",
+            "overseer",
+            "tmux",
+            "projects",
+            "discover",
+            "adopt",
+            "config",
+            "snapshot",
+            "kill",
+            "send",
+            "connect",
+            "alerts",
+            "pair",
+            "start",
+            "doctor",
+            "managed-new",
+            "managed-list",
+            "managed-get",
+            "managed-send",
+            "managed-answer",
+            "managed-activity",
+            "managed-attach",
+            "managed-stop",
+            "managed-resume",
+            "managed-decommission",
+            "help",
+        ] {
+            assert!(names.contains(&expected), "catalog missing `{expected}`");
+        }
+    }
+
+    #[test]
+    fn help_text_lists_every_command() {
+        let text = help_text();
+        for cmd in [
+            "/sessions",
+            "/status",
+            "/approve",
+            "/deny",
+            "/overseer",
+            "/tmux",
+            "/projects",
+            "/discover",
+            "/adopt",
+            "/config",
+            "/snapshot",
+            "/kill",
+            "/send",
+            "/connect",
+            "/alerts",
+            "/pair",
+            "/start",
+            "/doctor",
+            "/managed-new",
+            "/managed-list",
+            "/managed-get",
+            "/managed-send",
+            "/managed-answer",
+            "/managed-activity",
+            "/managed-attach",
+            "/managed-stop",
+            "/managed-resume",
+            "/managed-decommission",
+            "/help",
+        ] {
+            assert!(text.contains(cmd), "help text missing {cmd}");
+        }
+    }
+}

--- a/crates/trusty-mpm/src/client/catalog/sm_tools.rs
+++ b/crates/trusty-mpm/src/client/catalog/sm_tools.rs
@@ -1,0 +1,253 @@
+//! SM-prompt tool-surface rendering, derived from the command catalog.
+//!
+//! Why: the SM's `SM_TOOLS.md` prompt asset and the chat-core command surface
+//! describe the same verbs and must never drift. Keeping the SM verb tables and
+//! the `render_sm_tools` renderer here (a sibling of the catalog types) makes the
+//! catalog the single source of truth for the prompt while keeping each file
+//! under the 500-SLOC cap. A committed `SM_TOOLS.md` is asserted byte-identical
+//! to [`render_sm_tools`] by [`sm_tools_md_matches_catalog_render`].
+//! What: the three SM verb tables (session control, memory, goals) as
+//! [`CommandSpec`] slices, and [`render_sm_tools`] which emits the full markdown
+//! document — fixed prose plus the three tables.
+//! Test: `sm_tools_md_matches_catalog_render`, `prompt_signature_renders_callable_verbs`.
+
+use super::{CommandSpec, SpecKind};
+
+/// The session-control verbs the SM drives its fleet through (prompt table).
+///
+/// Why: these are the catalog rows the `SM_TOOLS.md` "Session control" table
+/// renders AND the managed verbs the chat-core executor dispatches; pinning them
+/// in one slice keeps the prompt and the wire surface aligned (the SM's
+/// `sessions.launch` is the executor's [`crate::TrustyCommand::ManagedNew`]).
+/// What: ordered to match the bundled `SM_TOOLS.md` session-control table.
+/// Test: `sm_tools_md_matches_catalog_render`.
+const SM_SESSION_VERBS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "sessions.launch",
+        aliases: &[],
+        args: "workdir, model?, prompt?, goal_id?",
+        summary: "Launch a new t-mpm session scoped to a task; links to a goal when `goal_id` is given",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "sessions.list",
+        aliases: &[],
+        args: "",
+        summary: "List the current fleet of sessions",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "sessions.get",
+        aliases: &[],
+        args: "session_id",
+        summary: "Fetch a session's state, captured output, and events",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "sessions.send",
+        aliases: &[],
+        args: "session_id, text",
+        summary: "Send a command / answer a decision prompt to a session",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "sessions.stop",
+        aliases: &[],
+        args: "session_id",
+        summary: "Gracefully stop a session",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "sessions.resume",
+        aliases: &[],
+        args: "session_id",
+        summary: "Resume a paused or stopped session",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "sessions.kill",
+        aliases: &[],
+        args: "session_id",
+        summary: "Force-stop / reap an unresponsive or dead session",
+        kind: SpecKind::SmOnly,
+    },
+];
+
+/// The SM memory verbs (prompt table only).
+const SM_MEMORY_VERBS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "memory.recall",
+        aliases: &[],
+        args: "query",
+        summary: "Recall relevant context (prior goals, outcomes, decisions) for the current intent",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "memory.remember",
+        aliases: &[],
+        args: "text",
+        summary: "Store a durable fact: goal records, session outcomes, cross-session knowledge",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "memory.note",
+        aliases: &[],
+        args: "text",
+        summary: "Record a decision or blocker as it happens (\"chose Bedrock for cost\", \"split goal X into 3 sessions\")",
+        kind: SpecKind::SmOnly,
+    },
+];
+
+/// The SM goal verbs (prompt table only).
+const SM_GOAL_VERBS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "goals.list",
+        aliases: &[],
+        args: "status?",
+        summary: "List goals, optionally filtered by status",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "goals.create",
+        aliases: &[],
+        args: "description, acceptance?",
+        summary: "Create a goal from operator intent with testable acceptance criteria",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "goals.update",
+        aliases: &[],
+        args: "id, status?, progress?, note?",
+        summary: "Update status / progress / append a note as sessions are verified",
+        kind: SpecKind::SmOnly,
+    },
+];
+
+/// Render one prompt-table row for a [`CommandSpec`].
+fn render_table_row(spec: &CommandSpec) -> String {
+    format!("| `{}` | {} |", spec.prompt_signature(), spec.summary)
+}
+
+/// Render the `SM_TOOLS.md` prompt section from the catalog.
+///
+/// Why: `SM_TOOLS.md` is the SM's tool-surface prompt; deriving its three verb
+/// tables (session control, memory, goals) from the same catalog the executor
+/// dispatches makes the catalog the single source of truth. A committed
+/// `SM_TOOLS.md` is kept byte-identical to this output by
+/// `sm_tools_md_matches_catalog_render`, so the prompt and the code can never
+/// silently drift.
+/// What: emits the full markdown document — the fixed prose plus the three
+/// tables rendered from [`SM_SESSION_VERBS`], [`SM_MEMORY_VERBS`], and
+/// [`SM_GOAL_VERBS`]. The trailing newline matches the committed file.
+/// Test: `sm_tools_md_matches_catalog_render`.
+pub fn render_sm_tools() -> String {
+    let mut out = String::new();
+    out.push_str("# SM Tools -- the verbs you may call\n\n");
+    out.push_str(
+        "These are the only verb surfaces available to you. They map onto the\n\
+         session-manager control surface, the `session-manager` memory palace, and the\n\
+         goal model. Anything that is *not* one of these verbs -- editing files, reading\n\
+         project source, running builds/tests -- is a prohibition (SP1-SP5): launch a\n\
+         session for it.\n\n",
+    );
+
+    out.push_str("## Session control (your hands)\n\n");
+    out.push_str(
+        "You drive sessions exclusively through these verbs; you never bypass the control\n\
+         surface. Observing **panes** is allowed; reading project **source** is not.\n\n",
+    );
+    out.push_str(
+        "All verbs are **namespaced** JSON-RPC methods (`sessions.*`, `goals.*`,\n\
+         `memory.*`) -- the exact wire surface the SM-STDIO adapter exposes. Always call\n\
+         them by their fully namespaced name so the prompt and the wire never diverge.\n\n",
+    );
+    out.push_str("| Verb | Purpose |\n|------|---------|\n");
+    for spec in SM_SESSION_VERBS {
+        out.push_str(&render_table_row(spec));
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(
+        "Use `sessions.get` to OBSERVE (phase 4) and to gather VERIFY evidence (phase 5).\n\
+         Use `sessions.send` to answer session decision prompts. Use\n\
+         `sessions.stop`/`sessions.kill` when a task is complete, abandoned, or wedged.\n\n",
+    );
+
+    out.push_str("## Memory (your durable knowledge)\n\n");
+    out.push_str(
+        "Scoped by default to the **`session-manager` palace** -- your own dedicated,\n\
+         cross-session store, distinct from project and personal palaces. You read from\n\
+         it at INTAKE and write to it at REPORT & PERSIST.\n\n",
+    );
+    out.push_str("| Verb | Purpose |\n|------|---------|\n");
+    for spec in SM_MEMORY_VERBS {
+        out.push_str(&render_table_row(spec));
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(
+        "You may recall from granted read-only palaces, but you **only ever write to the\n\
+         `session-manager` palace** -- never to project or personal palaces.\n\n",
+    );
+
+    out.push_str("## Goals (your tracking model)\n\n");
+    out.push_str(
+        "A goal maps operator intent to one-or-many launched sessions (fan-out). Each\n\
+         session belongs to exactly one goal. You maintain the `goal_id <-> session_id`\n\
+         index.\n\n",
+    );
+    out.push_str("| Verb | Purpose |\n|------|---------|\n");
+    for spec in SM_GOAL_VERBS {
+        out.push_str(&render_table_row(spec));
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(
+        "A goal closes (`status = Done`) only when **every linked task is verified and\n\
+         its acceptance criteria are met** -- gated by the verification gate in\n\
+         SM_WORKFLOW. Otherwise it is `Blocked` or `Abandoned` with a recorded reason.\n\n",
+    );
+
+    out.push_str("## Tone & output\n\n");
+    out.push_str(
+        "Concise, operator-facing, status-first. Lead with what changed and what is\n\
+         blocked. When summarizing the fleet, one line per session: `ID | crisp status`.\n\
+         Surface decisions the operator must make. Never pad.\n",
+    );
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sm_tools_md_matches_catalog_render() {
+        // The committed SM_TOOLS.md prompt asset MUST be byte-identical to the
+        // catalog's render. This is the single-source-of-truth guard: if a verb
+        // changes in the catalog without regenerating the asset (or vice versa),
+        // this test fails, so the prompt and the code can never silently drift.
+        let committed = include_str!("../../assets/sm_instructions/SM_TOOLS.md");
+        let rendered = render_sm_tools();
+        assert_eq!(
+            rendered, committed,
+            "SM_TOOLS.md is out of sync with catalog::render_sm_tools(); \
+             regenerate it (the catalog is authoritative)"
+        );
+    }
+
+    #[test]
+    fn prompt_signature_renders_callable_verbs() {
+        // Every catalog row renders `name(args)`; an SM verb keeps its namespaced
+        // spelling, args inlined.
+        let sm = SM_SESSION_VERBS
+            .iter()
+            .find(|c| c.name == "sessions.launch")
+            .unwrap();
+        assert_eq!(
+            sm.prompt_signature(),
+            "sessions.launch(workdir, model?, prompt?, goal_id?)"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/client/command.rs
+++ b/crates/trusty-mpm/src/client/command.rs
@@ -1,14 +1,20 @@
 //! UI-agnostic command model.
 //!
 //! Why: the Telegram bot, the TUI, and the CLI all express the same operator
-//! intents — list sessions, check status, approve a request, pair the bot. A
-//! single typed command keeps every UI's dispatch exhaustive and lets the one
-//! [`super::executor::CommandExecutor`] translate intent into daemon HTTP calls.
+//! intents — list sessions, check status, approve a request, pair the bot, drive
+//! the managed session-manager fleet. A single typed command keeps every UI's
+//! dispatch exhaustive and lets the one [`super::executor::CommandExecutor`]
+//! translate intent into daemon HTTP calls. The managed-verb variants
+//! (`Managed*`) cover the full `/api/v1/sessions/managed/*` surface so any
+//! adapter (CLI today; STUI #1272, TELUI #1433, Web/Slack next) can express
+//! every operation through this one enum.
 //! What: [`TrustyCommand`] enumerates every remote-management action. UI crates
 //! convert their own native command representation into a `TrustyCommand` and
-//! hand it to the executor.
-//! Test: `cargo test -p trusty-mpm-client` covers the executor; conversions are
-//! tested in the UI crates.
+//! hand it to the executor. The command catalog ([`super::catalog`]) is the
+//! single source of truth for the names, aliases, and help prose; this enum is
+//! the typed target each catalog entry maps to.
+//! Test: `cargo test -p trusty-mpm` covers the executor and the catalog parity;
+//! conversions are tested in the UI crates and in `telegram::commands`.
 
 use std::path::PathBuf;
 
@@ -17,9 +23,11 @@ use std::path::PathBuf;
 /// Why: a typed command is the shared contract between every UI and the
 /// executor — UIs parse their input into one of these, the executor maps each
 /// to daemon calls.
-/// What: the full set of remote-management actions trusty-mpm supports,
-/// including the bot-pairing handshake.
-/// Test: see the executor tests in `executor.rs`.
+/// What: the full set of remote-management actions trusty-mpm supports — the
+/// legacy project-session/pairing/overseer family AND the managed
+/// session-manager verb set (`Managed*`).
+/// Test: see the executor tests in `executor/tests.rs` and the catalog parity
+/// test in `catalog/sm_tools.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TrustyCommand {
     /// List all managed sessions.
@@ -136,69 +144,103 @@ pub enum TrustyCommand {
         /// The message to send to the coordinator.
         message: String,
     },
+
+    // ── Managed session-manager verbs (`/api/v1/sessions/managed/*`) ─────────
+    //
+    // These mirror the typed `DaemonClient` managed methods one-to-one and the
+    // `SessionControl` verb names (launch/list/get/send/stop/resume/kill) so the
+    // intent layer, the prompt catalog, and the wire surface never diverge.
+    /// Spawn a managed session from a repo + ref + task (`sessions.launch`).
+    ///
+    /// Why: the managed analogue of `Launch` — provision an isolated git
+    /// workspace and start a harness in it. Distinct from the project-session
+    /// `Launch`/`Connect` family, which operate on an existing directory.
+    /// What: the repo URL, git ref, task description, and optional name/runtime
+    /// hints POSTed to `POST /api/v1/sessions/managed`.
+    ManagedNew {
+        /// Repository URL to provision the session workspace from.
+        repo_url: String,
+        /// Git branch or ref to check out.
+        git_ref: String,
+        /// Human-readable task description for the session.
+        task: String,
+        /// Optional name hint overriding the auto-generated tmux session name.
+        name_hint: Option<String>,
+        /// Optional runtime selector (`claude-code` | `tcode`).
+        runtime: Option<String>,
+    },
+    /// List every managed session (`sessions.list`).
+    ManagedList,
+    /// Fetch one managed session's record (`sessions.get`).
+    ManagedGet {
+        /// Managed session id or friendly name.
+        target: String,
+    },
+    /// Inject text into a managed session's pane (`sessions.send`).
+    ManagedSend {
+        /// Managed session id or friendly name.
+        target: String,
+        /// Text to inject into the session's tmux pane.
+        text: String,
+    },
+    /// Answer a managed session's pending decision (`sessions.send` decision).
+    ///
+    /// Why: the correctness-correct decision path — unblocks a harness waiting
+    /// on an operator decision via the real `.../answer` endpoint, NOT a
+    /// synthetic hook. `/approve`/`/deny` on a managed session resolve here.
+    /// What: the target session and the answer text to inject.
+    ManagedAnswer {
+        /// Managed session id or friendly name.
+        target: String,
+        /// The answer text to inject for the pending decision.
+        answer: String,
+    },
+    /// Inspect a managed session's activity (`sessions.get` observe).
+    ManagedActivity {
+        /// Managed session id or friendly name.
+        target: String,
+    },
+    /// Fetch a managed session's tmux attach command.
+    ManagedAttachCmd {
+        /// Managed session id or friendly name.
+        target: String,
+    },
+    /// Stop a managed session's runtime, preserving the workspace
+    /// (`sessions.stop`).
+    ManagedRuntimeStop {
+        /// Managed session id or friendly name.
+        target: String,
+    },
+    /// Resume a stopped managed session (`sessions.resume`).
+    ManagedResume {
+        /// Managed session id or friendly name.
+        target: String,
+    },
+    /// Decommission a managed session — terminal, removes the workspace
+    /// (`sessions.kill`).
+    ManagedDecommission {
+        /// Managed session id or friendly name.
+        target: String,
+    },
+
     /// Show the command list.
     Help,
 }
 
 /// The `/help` text listing every command.
 ///
-/// Why: a single source of truth for the help body shared by every UI.
-/// What: returns the multi-line help string.
-/// Test: `help_text_lists_every_command`.
+/// Why: a single source of truth for the help body shared by every UI; it is
+/// rendered from the [`super::catalog`] registry so it can never drift from the
+/// typed command set.
+/// What: returns the catalog-rendered multi-line help string.
+/// Test: `super::catalog::tests` asserts the catalog covers every command.
 pub fn help_text() -> &'static str {
-    "trusty-mpm bot commands:\n\
-     /sessions — list managed sessions\n\
-     /status <id> — detailed session status\n\
-     /approve <id> — approve a pending permission request\n\
-     /deny <id> — deny a pending permission request\n\
-     /overseer — show overseer status\n\
-     /tmux — list all tmux sessions\n\
-     /projects — discover projects from Claude Code config\n\
-     /discover — auto-discover tmux sessions running Claude Code\n\
-     /adopt <session> — adopt an external tmux session\n\
-     /config <path> — analyze Claude Code config for a project\n\
-     /snapshot <session> — capture a tmux pane\n\
-     /kill <id> — kill a session\n\
-     /send <session> <prompt> — send a prompt to a Claude Code session\n\
-     /connect <path> — connect to or start a session (no deployment)\n\
-     /alerts — show alert subscriptions\n\
-     /pair <code> — pair this bot with your daemon\n\
-     /start — pairing status and onboarding\n\
-     /doctor — run full system diagnostic\n\
-     /help — this message"
+    super::catalog::help_text()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn help_text_lists_every_command() {
-        let text = help_text();
-        for cmd in [
-            "/sessions",
-            "/status",
-            "/approve",
-            "/deny",
-            "/overseer",
-            "/tmux",
-            "/projects",
-            "/discover",
-            "/adopt",
-            "/config",
-            "/snapshot",
-            "/kill",
-            "/send",
-            "/connect",
-            "/alerts",
-            "/pair",
-            "/start",
-            "/doctor",
-            "/help",
-        ] {
-            assert!(text.contains(cmd), "help text missing {cmd}");
-        }
-    }
 
     #[test]
     fn pair_command_distinguishes_code_and_status() {
@@ -207,5 +249,43 @@ mod tests {
         };
         let status = TrustyCommand::Pair { code: None };
         assert_ne!(with_code, status);
+    }
+
+    #[test]
+    fn managed_variants_round_trip_by_value() {
+        // The managed verbs carry their fields by value; equality is structural
+        // so adapters can build, compare, and pattern-match them losslessly.
+        let spawn = TrustyCommand::ManagedNew {
+            repo_url: "https://example/r.git".into(),
+            git_ref: "main".into(),
+            task: "do the thing".into(),
+            name_hint: Some("api".into()),
+            runtime: Some("tcode".into()),
+        };
+        assert_eq!(spawn.clone(), spawn);
+        let answer = TrustyCommand::ManagedAnswer {
+            target: "tmpm-red-owl".into(),
+            answer: "yes".into(),
+        };
+        assert_eq!(
+            answer,
+            TrustyCommand::ManagedAnswer {
+                target: "tmpm-red-owl".into(),
+                answer: "yes".into(),
+            }
+        );
+        assert_ne!(
+            TrustyCommand::ManagedResume { target: "a".into() },
+            TrustyCommand::ManagedRuntimeStop { target: "a".into() },
+        );
+    }
+
+    #[test]
+    fn help_text_is_catalog_rendered() {
+        // The help body is the catalog rendering — it must list managed verbs.
+        let text = help_text();
+        assert!(text.contains("/managed-list"));
+        assert!(text.contains("/managed-decommission"));
+        assert!(text.contains("/sessions"));
     }
 }

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -91,7 +91,11 @@ impl CommandExecutor {
     /// [`ManagedSessionView`]. When `target` already parses as a UUID it is an
     /// id, so the list fetch in [`resolve_managed`] is skipped and the
     /// per-session endpoint is hit directly; friendly names/prefixes still go
-    /// through the list-based resolver.
+    /// through the list-based resolver. Note the resulting asymmetry: the UUID
+    /// fast-path bypasses the list and therefore relies on the per-session
+    /// endpoint enforcing the same access control the list endpoint applies —
+    /// fine for this local/single-user daemon, but a constraint to revisit
+    /// before any multi-tenant deployment.
     /// Test: `execute_managed_get_unknown_errors`.
     pub(super) async fn managed_get(&self, target: &str) -> CommandResult {
         // Skip the redundant list round-trip when the caller already gave us an

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -88,12 +88,22 @@ impl CommandExecutor {
     /// record (rather than reusing the list row) so the detail view reflects the
     /// freshest state.
     /// What: resolves `target`, GETs the per-session endpoint, and returns a
-    /// [`ManagedSessionView`].
+    /// [`ManagedSessionView`]. When `target` already parses as a UUID it is an
+    /// id, so the list fetch in [`resolve_managed`] is skipped and the
+    /// per-session endpoint is hit directly; friendly names/prefixes still go
+    /// through the list-based resolver.
     /// Test: `execute_managed_get_unknown_errors`.
     pub(super) async fn managed_get(&self, target: &str) -> CommandResult {
-        let id = match self.resolve_managed(target).await {
-            Ok(s) => s.id,
-            Err(err) => return err,
+        // Skip the redundant list round-trip when the caller already gave us an
+        // id: a UUID can only be a canonical id, so resolving it against the
+        // list would fetch the whole catalog only to look up a value we hold.
+        let id = if is_session_id(target) {
+            target.to_string()
+        } else {
+            match self.resolve_managed(target).await {
+                Ok(s) => s.id,
+                Err(err) => return err,
+            }
         };
         match self.client().get_managed_session(&id).await {
             Ok(summary) => CommandResult::ManagedSession(ManagedSessionView::from(summary)),
@@ -232,4 +242,15 @@ fn lifecycle(summary: ManagedSessionSummary, action: &str) -> CommandResult {
         state: summary.state,
         action: action.to_string(),
     }
+}
+
+/// Whether `target` is already a canonical managed-session id (a UUID).
+///
+/// Why: managed ids are UUIDs while friendly names/prefixes are not; detecting
+/// an id lets `managed_get` skip the list round-trip and hit the per-session
+/// endpoint directly. Friendly names still need the list to resolve.
+/// What: returns `true` when `target` parses as a `uuid::Uuid`.
+/// Test: `is_session_id_detects_uuid_vs_name` in `tests.rs`.
+pub(super) fn is_session_id(target: &str) -> bool {
+    uuid::Uuid::parse_str(target).is_ok()
 }

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -1,0 +1,235 @@
+//! Managed session-manager command methods (`/api/v1/sessions/managed/*`).
+//!
+//! Why: the managed verb set is the convergence target for every managed-session
+//! UI (the `tm` CLI today; STUI #1272, TELUI #1433, Web/Slack next). Each verb
+//! maps one-to-one onto a typed [`crate::client::DaemonClient`] managed method,
+//! so wiring them here once gives every adapter the full surface through the
+//! shared [`CommandResult`]. Splitting these out of the dispatch facade keeps
+//! every executor file under the 500-SLOC cap.
+//! What: inherent `CommandExecutor` methods, one per managed verb. Verbs that
+//! take a target resolve the fuzzy id-or-name against the live managed list via
+//! the canonical [`resolve_target`] resolver before calling the endpoint, so a
+//! friendly name or prefix works everywhere. Transport/HTTP failures become a
+//! renderable [`CommandResult::Error`], never a panic.
+//! Test: the `execute_managed_*` tests in `tests.rs` (wire-shape + dispatch).
+
+use super::CommandExecutor;
+use crate::client::http_client::{ManagedSessionSummary, ManagedSpawnRequest};
+use crate::client::resolver::resolve_target;
+use crate::client::result::{CommandResult, ManagedSessionView};
+
+impl CommandExecutor {
+    /// Resolve a fuzzy managed target to its canonical id.
+    ///
+    /// Why: every target-taking managed verb accepts an id, a friendly name, or
+    /// an unambiguous prefix; resolving once against the live list keeps the
+    /// endpoint call unambiguous and the precedence identical across verbs.
+    /// What: fetches the managed list, applies [`resolve_target`], and returns
+    /// the matched session's canonical `id`. Returns `Err(CommandResult::Error)`
+    /// when the daemon is unreachable or nothing matches, so callers can `?`-style
+    /// short-circuit with a renderable error.
+    /// Test: covered by `execute_managed_get_unknown_errors` and the happy-path
+    /// managed tests.
+    async fn resolve_managed(&self, target: &str) -> Result<ManagedSessionSummary, CommandResult> {
+        let sessions = self
+            .client()
+            .list_managed_sessions()
+            .await
+            .map_err(|e| CommandResult::Error(format!("daemon unreachable: {e}")))?;
+        match resolve_target(&sessions, target) {
+            Some(found) => Ok(found.clone()),
+            None => Err(CommandResult::Error(format!(
+                "managed session {target} not found"
+            ))),
+        }
+    }
+
+    /// `managed-new` — spawn a managed session from a repo + ref + task.
+    pub(super) async fn managed_new(
+        &self,
+        repo_url: String,
+        git_ref: String,
+        task: String,
+        name_hint: Option<String>,
+        runtime: Option<String>,
+    ) -> CommandResult {
+        let req = ManagedSpawnRequest {
+            repo_url,
+            git_ref,
+            task,
+            name_hint,
+            runtime,
+        };
+        match self.client().spawn_managed_session(&req).await {
+            Ok(resp) => CommandResult::ManagedSpawned {
+                id: resp.id,
+                name: resp.name,
+                state: resp.state,
+                runtime: resp.runtime,
+                attach_cmd: resp.attach_cmd,
+            },
+            Err(e) => CommandResult::Error(format!("spawn failed: {e}")),
+        }
+    }
+
+    /// `managed-list` — list every managed session.
+    pub(super) async fn managed_list(&self) -> CommandResult {
+        match self.client().list_managed_sessions().await {
+            Ok(sessions) => CommandResult::ManagedSessions(
+                sessions.into_iter().map(ManagedSessionView::from).collect(),
+            ),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `managed-get` — fetch one managed session's record.
+    ///
+    /// Why: resolves a fuzzy target then fetches the authoritative per-session
+    /// record (rather than reusing the list row) so the detail view reflects the
+    /// freshest state.
+    /// What: resolves `target`, GETs the per-session endpoint, and returns a
+    /// [`ManagedSessionView`].
+    /// Test: `execute_managed_get_unknown_errors`.
+    pub(super) async fn managed_get(&self, target: &str) -> CommandResult {
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().get_managed_session(&id).await {
+            Ok(summary) => CommandResult::ManagedSession(ManagedSessionView::from(summary)),
+            Err(e) => CommandResult::Error(format!("get failed: {e}")),
+        }
+    }
+
+    /// `managed-send` — inject text into a managed session's pane.
+    pub(super) async fn managed_send(&self, target: &str, text: &str) -> CommandResult {
+        if text.trim().is_empty() {
+            return CommandResult::Error("send: text is required".to_string());
+        }
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().send_to_managed_session(&id, text).await {
+            Ok(resp) => CommandResult::ManagedSent {
+                id,
+                tmux_name: resp.tmux_name,
+            },
+            Err(e) => CommandResult::Error(format!("send failed: {e}")),
+        }
+    }
+
+    /// `managed-answer` — answer a managed session's pending decision.
+    ///
+    /// Why: the direct decision-answer verb. It reaches the REAL
+    /// `POST .../{id}/answer` endpoint so the harness actually unblocks (the
+    /// `/approve`/`/deny` family routes here too via the sessions module).
+    /// What: resolves `target`, POSTs `{ answer }` to the answer endpoint, and
+    /// returns a [`CommandResult::ManagedAnswered`].
+    /// Test: `execute_managed_answer_unknown_errors`,
+    /// `execute_managed_answer_routes_to_answer_endpoint`.
+    pub(super) async fn managed_answer(&self, target: &str, answer: &str) -> CommandResult {
+        if answer.trim().is_empty() {
+            return CommandResult::Error("answer: text is required".to_string());
+        }
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().answer_managed_session(&id, answer).await {
+            Ok(resp) => CommandResult::ManagedAnswered {
+                id,
+                answer: answer.to_string(),
+                tmux_name: resp.tmux_name,
+            },
+            Err(e) => CommandResult::Error(format!("answer failed: {e}")),
+        }
+    }
+
+    /// `managed-activity` — inspect a managed session's activity.
+    pub(super) async fn managed_activity(&self, target: &str) -> CommandResult {
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().managed_session_activity(&id).await {
+            Ok(act) => CommandResult::ManagedActivity {
+                id,
+                state: act.state,
+                summary: act.summary,
+                raw_pane: act.raw_pane,
+                runtime_active: act.runtime_active,
+                pending_decision: act.pending_decision,
+            },
+            Err(e) => CommandResult::Error(format!("activity failed: {e}")),
+        }
+    }
+
+    /// `managed-attach` — show a managed session's tmux attach command.
+    pub(super) async fn managed_attach_cmd(&self, target: &str) -> CommandResult {
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().managed_session_attach_cmd(&id).await {
+            Ok(resp) => CommandResult::ManagedAttachCmd {
+                id,
+                attach_cmd: resp.attach_cmd,
+            },
+            Err(e) => CommandResult::Error(format!("attach-cmd failed: {e}")),
+        }
+    }
+
+    /// `managed-stop` — stop a managed session's runtime (keeps the workspace).
+    pub(super) async fn managed_runtime_stop(&self, target: &str) -> CommandResult {
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().runtime_stop_managed_session(&id).await {
+            Ok(summary) => lifecycle(summary, "stopped"),
+            Err(e) => CommandResult::Error(format!("runtime-stop failed: {e}")),
+        }
+    }
+
+    /// `managed-resume` — resume a stopped managed session.
+    pub(super) async fn managed_resume(&self, target: &str) -> CommandResult {
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().resume_managed_session(&id).await {
+            Ok(summary) => lifecycle(summary, "resumed"),
+            Err(e) => CommandResult::Error(format!("resume failed: {e}")),
+        }
+    }
+
+    /// `managed-decommission` — decommission a session (terminal; removes the
+    /// workspace).
+    pub(super) async fn managed_decommission(&self, target: &str) -> CommandResult {
+        let id = match self.resolve_managed(target).await {
+            Ok(s) => s.id,
+            Err(err) => return err,
+        };
+        match self.client().decommission_managed_session(&id).await {
+            Ok(summary) => lifecycle(summary, "decommissioned"),
+            Err(e) => CommandResult::Error(format!("decommission failed: {e}")),
+        }
+    }
+}
+
+/// Map a managed summary + verb to a [`CommandResult::ManagedLifecycle`].
+///
+/// Why: the three lifecycle verbs (stop/resume/decommission) all report the same
+/// id/name/state shape; one helper keeps their result construction identical.
+/// What: builds the lifecycle result from the updated summary and the verb that
+/// produced it.
+/// Test: covered by the managed lifecycle dispatch tests.
+fn lifecycle(summary: ManagedSessionSummary, action: &str) -> CommandResult {
+    CommandResult::ManagedLifecycle {
+        id: summary.id,
+        name: summary.name,
+        state: summary.state,
+        action: action.to_string(),
+    }
+}

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -103,7 +103,6 @@ impl CommandExecutor {
             TrustyCommand::Send { session, prompt } => self.send(&session, &prompt).await,
             TrustyCommand::Launch { project, .. } => self.launch(&project).await,
             TrustyCommand::Connect { project, .. } => self.connect(&project).await,
-            TrustyCommand::Start => self.pair_state().await,
             TrustyCommand::Doctor => self.doctor().await,
             TrustyCommand::CoordinatorChat { message } => self.coordinator_chat(&message).await,
             // ── Managed session-manager verbs ───────────────────────────────
@@ -133,7 +132,9 @@ impl CommandExecutor {
                 self.managed_decommission(&target).await
             }
             // ── Pairing (state query only; confirm needs a chat id) ──────────
-            TrustyCommand::Pair { code: None } => self.pair_state().await,
+            // `Start` (the bot's entry command) and a bare `Pair` (no code) both
+            // mean "show me the current pairing state", so they share one arm.
+            TrustyCommand::Start | TrustyCommand::Pair { code: None } => self.pair_state().await,
             TrustyCommand::Pair { code: Some(_) } => {
                 // A code-carrying pair requires the caller's chat id, which is
                 // not part of the command; UIs route those to `pair_confirm`.

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -1,37 +1,46 @@
-//! The single command executor.
+//! The single command executor (dispatch facade).
 //!
 //! Why: before this crate, three UIs each translated operator intent into
 //! daemon HTTP calls independently. [`CommandExecutor`] is the *one* place that
 //! mapping lives — every UI hands it a [`TrustyCommand`] and gets back a
-//! [`CommandResult`]. A new endpoint is wired here once.
-//! What: [`CommandExecutor`] owns a [`DaemonClient`] and exposes [`execute`]
-//! (command → result) plus [`pair_confirm`] for the chat-id-carrying pairing
-//! confirm that does not fit the pure `TrustyCommand → CommandResult` shape.
-//! Unreachable-daemon errors become a [`CommandResult::Error`], never a panic.
-//! Test: `cargo test -p trusty-mpm-client` covers the pure `/help` path and the
-//! HTTP paths against an in-process test daemon.
+//! [`CommandResult`]. A new endpoint is wired here once. The executor was a
+//! single ~540-line file; it is now split into focused submodules so each stays
+//! well under the 500-SLOC cap and each concern (project sessions, managed
+//! sessions, pairing) lives in its own file: this `mod.rs` owns only the struct,
+//! the constructor, and the [`execute`](CommandExecutor::execute) dispatch.
+//! What: [`CommandExecutor`] owns a [`DaemonClient`]; [`execute`] maps each
+//! [`TrustyCommand`] to the corresponding submodule method. The project-session
+//! family lives in [`sessions`], the managed session-manager verbs in
+//! [`managed`], and the pairing handshake in [`pairing`]. Unreachable-daemon
+//! errors become a [`CommandResult::Error`], never a panic.
+//! Test: `cargo test -p trusty-mpm` covers the pure `/help` path and the HTTP
+//! paths against an in-process test daemon (`tests.rs`).
 
 use super::command::{TrustyCommand, help_text};
-use super::http_client::{DaemonClient, SessionRow};
+use super::http_client::DaemonClient;
+use super::result::CommandResult;
 
-/// Maximum captured-output length returned by `/send` (Telegram's message cap).
-///
-/// Why: Telegram rejects messages longer than ~4096 characters; truncating the
-/// captured pane keeps the reply deliverable on every UI.
-pub const MAX_OUTPUT_CHARS: usize = 4000;
-use super::result::{
-    CommandResult, DecisionCounts, DiscoveredProjectSummary, RecommendationSummary, SessionSummary,
-    TmuxSessionSummary,
-};
+mod managed;
+mod pairing;
+mod sessions;
 
 #[cfg(test)]
 mod tests;
+
+// Re-export the pure helpers the executor tests reference by their historical
+// paths (`executor::resolve_session`, `executor::truncate_output`,
+// `executor::MAX_OUTPUT_CHARS`). Only the test module consumes these names, so
+// the re-export is test-gated to avoid an unused-import warning in lib builds.
+#[cfg(test)]
+pub(crate) use sessions::{MAX_OUTPUT_CHARS, resolve_session, truncate_output};
 
 /// Translates [`TrustyCommand`]s into daemon HTTP calls.
 ///
 /// Why: the single seam between UI intent and the daemon API; isolating it here
 /// means the Telegram bot, the TUI, and the CLI never embed HTTP logic.
-/// What: wraps a [`DaemonClient`]; [`execute`] runs one command end-to-end.
+/// What: wraps a [`DaemonClient`]; [`execute`](Self::execute) runs one command
+/// end-to-end by delegating to the [`sessions`], [`managed`], and [`pairing`]
+/// submodules.
 /// Test: `execute_help_returns_help`, `execute_sessions_against_test_daemon`.
 pub struct CommandExecutor {
     /// The shared daemon HTTP client.
@@ -63,19 +72,22 @@ impl CommandExecutor {
     /// Execute one [`TrustyCommand`] against the daemon.
     ///
     /// Why: the single dispatch point — every UI funnels intent through here.
-    /// What: maps each command to daemon calls and returns a structured
+    /// What: maps each command to its submodule method and returns a structured
     /// [`CommandResult`]; a transport failure becomes [`CommandResult::Error`].
     /// `Pair { code: Some(_) }` cannot complete here (it needs a chat id) and is
-    /// reported as a state query — UIs must call [`Self::pair_confirm`] instead.
+    /// reported as a state query — UIs must call
+    /// [`Self::pair_confirm`](Self::pair_confirm) instead.
     /// Test: `execute_help_returns_help`, `execute_sessions_against_test_daemon`,
-    /// `execute_kill_returns_killed`.
+    /// `execute_kill_returns_killed`, and the `managed_*` dispatch tests.
     pub async fn execute(&self, cmd: TrustyCommand) -> CommandResult {
         match cmd {
+            // ── Pure / static ───────────────────────────────────────────────
             TrustyCommand::Help => CommandResult::Help(help_text().to_string()),
             TrustyCommand::Alerts => CommandResult::AlertSubscriptions(vec![
                 "Categories: Permission, Agent".to_string(),
                 "Memory alerts: enabled".to_string(),
             ]),
+            // ── Project-session family ──────────────────────────────────────
             TrustyCommand::Sessions => self.sessions().await,
             TrustyCommand::Status { session_id } => self.status(&session_id).await,
             TrustyCommand::Approve { session_id } => self.decide(&session_id, true).await,
@@ -94,6 +106,33 @@ impl CommandExecutor {
             TrustyCommand::Start => self.pair_state().await,
             TrustyCommand::Doctor => self.doctor().await,
             TrustyCommand::CoordinatorChat { message } => self.coordinator_chat(&message).await,
+            // ── Managed session-manager verbs ───────────────────────────────
+            TrustyCommand::ManagedNew {
+                repo_url,
+                git_ref,
+                task,
+                name_hint,
+                runtime,
+            } => {
+                self.managed_new(repo_url, git_ref, task, name_hint, runtime)
+                    .await
+            }
+            TrustyCommand::ManagedList => self.managed_list().await,
+            TrustyCommand::ManagedGet { target } => self.managed_get(&target).await,
+            TrustyCommand::ManagedSend { target, text } => self.managed_send(&target, &text).await,
+            TrustyCommand::ManagedAnswer { target, answer } => {
+                self.managed_answer(&target, &answer).await
+            }
+            TrustyCommand::ManagedActivity { target } => self.managed_activity(&target).await,
+            TrustyCommand::ManagedAttachCmd { target } => self.managed_attach_cmd(&target).await,
+            TrustyCommand::ManagedRuntimeStop { target } => {
+                self.managed_runtime_stop(&target).await
+            }
+            TrustyCommand::ManagedResume { target } => self.managed_resume(&target).await,
+            TrustyCommand::ManagedDecommission { target } => {
+                self.managed_decommission(&target).await
+            }
+            // ── Pairing (state query only; confirm needs a chat id) ──────────
             TrustyCommand::Pair { code: None } => self.pair_state().await,
             TrustyCommand::Pair { code: Some(_) } => {
                 // A code-carrying pair requires the caller's chat id, which is
@@ -102,440 +141,4 @@ impl CommandExecutor {
             }
         }
     }
-
-    /// Confirm a pairing code on behalf of a specific chat.
-    ///
-    /// Why: `POST /pair/confirm` needs the confirming chat's id, which is not
-    /// carried by [`TrustyCommand::Pair`]; the bot adapter supplies it here.
-    /// What: calls the daemon's confirm endpoint and maps the result to
-    /// [`CommandResult::PairSuccess`] or [`CommandResult::Error`].
-    /// Test: `pair_confirm_unknown_code_errors`.
-    pub async fn pair_confirm(&self, code: &str, chat_id: i64) -> CommandResult {
-        match self.client.pair_confirm(code, chat_id).await {
-            Ok(confirm) if confirm.success => CommandResult::PairSuccess {
-                chat_info: format!("chat {}", confirm.chat_id.unwrap_or(chat_id)),
-            },
-            Ok(confirm) => CommandResult::Error(
-                confirm
-                    .error
-                    .unwrap_or_else(|| "invalid or expired code".to_string()),
-            ),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// Request a one-time pairing code from the daemon.
-    ///
-    /// Why: `tm pair` asks the local daemon for a code to display.
-    /// What: calls `POST /pair/request` and maps it to [`CommandResult::PairCode`].
-    /// Test: `pair_request_returns_code`.
-    pub async fn pair_request(&self) -> CommandResult {
-        match self.client.pair_request().await {
-            Ok(req) => CommandResult::PairCode {
-                code: req.code,
-                expires_in_seconds: req.expires_in_seconds,
-            },
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/sessions` — fetch and summarize the managed session list.
-    async fn sessions(&self) -> CommandResult {
-        match self.client.sessions().await {
-            Ok(rows) => CommandResult::Sessions(
-                rows.into_iter()
-                    .map(|s| SessionSummary {
-                        id: s.id.0.to_string(),
-                        status: status_label(s.status),
-                        workdir: s.workdir,
-                    })
-                    .collect(),
-            ),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/status` — fetch one session's recent events.
-    async fn status(&self, session_id: &str) -> CommandResult {
-        match self.client.session_events(session_id).await {
-            Ok(events) => {
-                let names: Vec<String> = events
-                    .iter()
-                    .rev()
-                    .take(5)
-                    .rev()
-                    .map(|e| e.event.wire_name().to_string())
-                    .collect();
-                CommandResult::SessionDetail {
-                    id: session_id.to_string(),
-                    status: "active".to_string(),
-                    events: names,
-                }
-            }
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/approve` and `/deny` — verify the session, record a synthetic decision.
-    ///
-    /// Why: both share the same flow — confirm the session is known, then post a
-    /// synthetic `PostToolUse` hook carrying `{"approved": bool}` so the
-    /// decision is audited.
-    /// What: lists sessions to confirm `session_id`, posts the hook, and returns
-    /// the approve/deny result; an unknown session is an `Error`.
-    /// Test: `execute_approve_unknown_session_errors`.
-    async fn decide(&self, session_id: &str, approved: bool) -> CommandResult {
-        let exists = match self.client.sessions().await {
-            Ok(rows) => rows.iter().any(|s| s.id.0.to_string() == session_id),
-            Err(e) => return CommandResult::Error(format!("daemon unreachable: {e}")),
-        };
-        if !exists {
-            return CommandResult::Error(format!("session {session_id} not found"));
-        }
-        // Record the decision as a synthetic PostToolUse hook event.
-        let hook_url = format!("{}/hooks", self.client.base_url());
-        let _ = reqwest::Client::new()
-            .post(&hook_url)
-            .json(&serde_json::json!({
-                "session_id": session_id,
-                "event": "PostToolUse",
-                "payload": { "approved": approved },
-            }))
-            .send()
-            .await;
-        if approved {
-            CommandResult::Approved {
-                session_id: session_id.to_string(),
-            }
-        } else {
-            CommandResult::Denied {
-                session_id: session_id.to_string(),
-            }
-        }
-    }
-
-    /// `/overseer` — fetch the overseer status.
-    async fn overseer(&self) -> CommandResult {
-        match self.client.overseer_status().await {
-            Ok(snap) => CommandResult::OverseerStatus {
-                enabled: snap.enabled,
-                handler: snap.handler,
-                decisions: DecisionCounts {
-                    allow: snap.decisions.0,
-                    block: snap.decisions.1,
-                    flag: snap.decisions.2,
-                },
-            },
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/tmux` — list every tmux session on the host.
-    async fn tmux(&self) -> CommandResult {
-        match self.client.tmux_sessions().await {
-            Ok(rows) => CommandResult::TmuxSessions(
-                rows.into_iter()
-                    .map(|r| TmuxSessionSummary {
-                        name: r.name,
-                        managed: r.managed,
-                    })
-                    .collect(),
-            ),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/projects` — discover projects from the Claude Code configuration.
-    ///
-    /// Why: lets the operator browse projects Claude Code already knows about
-    /// and register one without typing its path.
-    /// What: calls `GET /projects/discover` and maps each row to a
-    /// [`DiscoveredProjectSummary`].
-    /// Test: `execute_projects_against_test_daemon`.
-    async fn projects(&self) -> CommandResult {
-        match self.client.discover_projects().await {
-            Ok(rows) => CommandResult::DiscoveredProjects(
-                rows.into_iter()
-                    .map(|r| DiscoveredProjectSummary {
-                        path: r.path,
-                        session_count: r.session_count,
-                        last_session: r.last_session,
-                    })
-                    .collect(),
-            ),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/discover` — auto-discover tmux sessions running Claude Code.
-    ///
-    /// Why: operators run Claude Code in tmux panes the daemon never created;
-    /// `/discover` scans every pane and adopts the ones running it so they show
-    /// up without a manual `/adopt`.
-    /// What: calls `POST /sessions/discover`; returns [`CommandResult::Discovered`]
-    /// with the count, or an `Error` when the daemon is unreachable.
-    /// Test: `execute_discover_against_test_daemon`.
-    async fn discover(&self) -> CommandResult {
-        match self.client.discover_sessions().await {
-            Ok(count) => CommandResult::Discovered { count },
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/adopt` — adopt an external tmux session for oversight.
-    ///
-    /// Why: brings a session trusty-mpm did not create under management with a
-    /// single command.
-    /// What: calls `POST /tmux/adopt`; returns [`CommandResult::Adopted`] on
-    /// success, an `Error` when the session is unknown or the daemon is down.
-    /// Test: `execute_adopt_unknown_session_errors`.
-    async fn adopt(&self, session: &str) -> CommandResult {
-        match self.client.adopt_tmux_session(session).await {
-            Ok(true) => CommandResult::Adopted {
-                session: session.to_string(),
-            },
-            Ok(false) => CommandResult::Error(format!("tmux session {session} not found")),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// Register a discovered project with the daemon.
-    ///
-    /// Why: the Telegram `/projects` keyboard's "Set Active" button registers a
-    /// project by path; that does not fit the pure `TrustyCommand` shape (the
-    /// path is keyboard callback data), so the bot adapter calls this directly.
-    /// What: calls `POST /projects`; returns a confirmation via the registered
-    /// path. Returns an `Error` when the daemon is unreachable.
-    /// Test: `register_project_succeeds`.
-    pub async fn register_project(&self, path: &str) -> CommandResult {
-        match self.client.register_project(path).await {
-            Ok(()) => CommandResult::ProjectRegistered {
-                path: path.to_string(),
-            },
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/config` — analyze a project's Claude Code config.
-    async fn config(&self, project: &str) -> CommandResult {
-        match self.client.analyze_config(project).await {
-            Ok(recs) => CommandResult::ConfigAnalysis {
-                project: project.to_string(),
-                recommendations: recs
-                    .into_iter()
-                    .map(|r| RecommendationSummary {
-                        id: r.id,
-                        message: r.message,
-                    })
-                    .collect(),
-            },
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/snapshot` — capture a tmux pane.
-    async fn snapshot(&self, session: &str) -> CommandResult {
-        match self.client.snapshot_tmux_session(session).await {
-            Ok(Some(output)) => CommandResult::Snapshot {
-                session: session.to_string(),
-                output,
-            },
-            Ok(None) => CommandResult::Error(format!("tmux session {session} not found")),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/kill` — kill a session.
-    async fn kill(&self, session_id: &str) -> CommandResult {
-        match self.client.kill_session(session_id).await {
-            Ok(true) => CommandResult::Killed {
-                session_id: session_id.to_string(),
-            },
-            Ok(false) => CommandResult::Error(format!("session {session_id} not found")),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/send` — resolve a session and send a prompt to its tmux pane.
-    ///
-    /// Why: `/send <session> <prompt>` drives a running Claude Code session
-    /// remotely; the session is identified by id, friendly name, or a name
-    /// prefix, so the executor resolves it against `GET /sessions` first.
-    /// What: fetches the session list, finds the first session whose id or
-    /// `tmux_name` matches `session` (exact, then prefix), posts the prompt via
-    /// `POST /sessions/{id}/command`, and returns the captured pane output
-    /// truncated to [`MAX_OUTPUT_CHARS`] (Telegram's message limit). An unknown
-    /// session or unreachable daemon yields a [`CommandResult::Error`].
-    /// Test: `execute_send_unknown_session_errors`.
-    async fn send(&self, session: &str, prompt: &str) -> CommandResult {
-        if prompt.trim().is_empty() {
-            return CommandResult::Error("send: a prompt is required".to_string());
-        }
-        let rows = match self.client.sessions().await {
-            Ok(rows) => rows,
-            Err(e) => return CommandResult::Error(format!("daemon unreachable: {e}")),
-        };
-        let Some(target) = resolve_session(&rows, session) else {
-            return CommandResult::Error(format!("session {session} not found"));
-        };
-        match self.client.send_session_command(&target, prompt).await {
-            Ok(Some(output)) => CommandResult::CommandSent {
-                session: target,
-                output: truncate_output(&output),
-            },
-            Ok(None) => CommandResult::Error(format!("session {session} not found")),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/launch` — deploy the framework, then start or attach to a session.
-    ///
-    /// Why: `tm launch` is the full entry point — it runs `prepare_session`
-    /// to deploy instructions, agents, and skills before bringing the
-    /// tmux-hosted session up.
-    /// What: calls [`DaemonClient::launch_session`], which runs the deployment
-    /// sequence and then registers + starts the tmux session.
-    /// Test: `execute_launch_errors_when_daemon_unreachable`.
-    async fn launch(&self, project: &std::path::Path) -> CommandResult {
-        let workdir = project.to_string_lossy().to_string();
-        match self.client.launch_session(&workdir).await {
-            Ok(session) => CommandResult::SessionStarted {
-                session,
-                workdir,
-                deployed: true,
-            },
-            Err(e) => CommandResult::Error(format!("launch failed: {e}")),
-        }
-    }
-
-    /// `/connect` — start or attach to a session *without* deploying anything.
-    ///
-    /// Why: `tm connect` skips the `prepare_session` deployment sequence and
-    /// only ensures the tmux-hosted session is running — idempotent: create
-    /// when absent, attach when present.
-    /// What: calls [`DaemonClient::connect_session`].
-    /// Test: `execute_connect_errors_when_daemon_unreachable`.
-    async fn connect(&self, project: &std::path::Path) -> CommandResult {
-        let workdir = project.to_string_lossy().to_string();
-        match self.client.connect_session(&workdir).await {
-            Ok(session) => CommandResult::SessionStarted {
-                session,
-                workdir,
-                deployed: false,
-            },
-            Err(e) => CommandResult::Error(format!("connect failed: {e}")),
-        }
-    }
-
-    /// `/doctor` — run the full system diagnostic.
-    ///
-    /// Why: a single command that confirms the whole trusty-mpm stack is wired
-    /// correctly; every UI funnels `/doctor` here so the report is identical.
-    /// What: resolves the process cwd as the project to scope the instruction
-    /// probe, calls `GET /api/v1/doctor`, and maps the result to
-    /// [`CommandResult::Doctor`]; an unreachable daemon becomes an `Error`.
-    /// Test: `execute_doctor_against_test_daemon`.
-    async fn doctor(&self) -> CommandResult {
-        let cwd = std::env::current_dir()
-            .ok()
-            .map(|p| p.display().to_string());
-        match self.client.doctor(cwd.as_deref()).await {
-            Ok(report) => CommandResult::Doctor(report),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `tm coordinator <message>` — send a message to the cross-session
-    /// coordinator and return its reply.
-    ///
-    /// Why: the CLI/Telegram entry point for the coordinator; a stateless
-    /// invocation has no rolling history, so each call is a fresh conversation.
-    /// What: calls `POST /api/v1/sessions/chat` with an empty history.
-    /// Test: `coordinator_chat_outcome_deserializes` in the client tests.
-    async fn coordinator_chat(&self, message: &str) -> CommandResult {
-        match self.client.coordinator_chat(message, &[]).await {
-            Ok(Some(outcome)) => {
-                let reply = match outcome.command_output {
-                    Some(output) => format!("{}\n{output}", outcome.reply),
-                    None => outcome.reply,
-                };
-                CommandResult::ChatReply { reply }
-            }
-            Ok(None) => CommandResult::Error(
-                "coordinator chat is not configured (no OpenRouter API key)".to_string(),
-            ),
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-
-    /// `/start` and `/pair` (no code) — query the pairing status.
-    async fn pair_state(&self) -> CommandResult {
-        match self.client.pair_status().await {
-            Ok(status) => CommandResult::PairState {
-                paired: status.paired,
-            },
-            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
-        }
-    }
-}
-
-/// Resolve a session reference (id, name, or prefix) to a definitive target.
-///
-/// Why: `/send` accepts a fuzzy session reference; resolving it against the
-/// live session list keeps the daemon call unambiguous.
-/// What: returns the first session whose id or `tmux_name` equals `query`, or —
-/// failing an exact match — whose `tmux_name` starts with `query`.
-/// Test: `resolve_session_exact_and_prefix`.
-pub(crate) fn resolve_session(rows: &[SessionRow], query: &str) -> Option<String> {
-    if let Some(row) = rows
-        .iter()
-        .find(|r| r.id.0.to_string() == query || r.tmux_name == query)
-    {
-        return Some(target_of(row));
-    }
-    rows.iter()
-        .find(|r| !r.tmux_name.is_empty() && r.tmux_name.starts_with(query))
-        .map(target_of)
-}
-
-/// The path-segment target for a session: its friendly name when set, else its id.
-///
-/// Why: `POST /sessions/{id}/command` resolves either form; the friendly name
-/// is more readable in the reply, so it is preferred when present.
-/// What: returns `tmux_name` when non-empty, otherwise the UUID string.
-/// Test: covered by `resolve_session_exact_and_prefix`.
-fn target_of(row: &SessionRow) -> String {
-    if row.tmux_name.is_empty() {
-        row.id.0.to_string()
-    } else {
-        row.tmux_name.clone()
-    }
-}
-
-/// Truncate captured output to [`MAX_OUTPUT_CHARS`] on a character boundary.
-///
-/// Why: a session's pane capture can exceed Telegram's message limit; the
-/// reply must stay deliverable.
-/// What: returns `text` unchanged when short enough, otherwise the first
-/// [`MAX_OUTPUT_CHARS`] characters followed by a truncation marker.
-/// Test: `truncate_output_caps_long_text`.
-pub(crate) fn truncate_output(text: &str) -> String {
-    if text.chars().count() <= MAX_OUTPUT_CHARS {
-        return text.to_string();
-    }
-    let head: String = text.chars().take(MAX_OUTPUT_CHARS).collect();
-    format!("{head}\n… (output truncated)")
-}
-
-/// Render a [`SessionStatus`] as its wire label.
-///
-/// Why: `SessionSummary.status` is a display string; serializing the typed
-/// status keeps the label identical to the daemon's JSON wire form.
-/// What: serializes the status via serde and strips the surrounding quotes.
-/// Test: covered by `execute_sessions_against_test_daemon`.
-fn status_label(status: crate::core::session::SessionStatus) -> String {
-    serde_json::to_value(status)
-        .ok()
-        .and_then(|v| v.as_str().map(str::to_string))
-        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/crates/trusty-mpm/src/client/executor/pairing.rs
+++ b/crates/trusty-mpm/src/client/executor/pairing.rs
@@ -1,0 +1,63 @@
+//! Pairing-handshake command methods.
+//!
+//! Why: the bot-pairing flow (`/pair`, `tm pair`) does not fit the pure
+//! `TrustyCommand → CommandResult` shape — `pair_confirm` needs the confirming
+//! chat's id, which the command does not carry. Keeping the pairing methods in
+//! their own file isolates that asymmetry and keeps the dispatch facade lean.
+//! What: inherent `CommandExecutor` methods for the three pairing operations —
+//! [`pair_confirm`](CommandExecutor::pair_confirm) (chat-id-carrying confirm),
+//! [`pair_request`](CommandExecutor::pair_request) (`tm pair` code request), and
+//! the internal [`pair_state`](CommandExecutor::pair_state) status query that
+//! `/start` and `/pair` (no code) dispatch to.
+//! Test: the `pair_*` tests in `tests.rs`.
+
+use super::CommandExecutor;
+use crate::client::result::CommandResult;
+
+impl CommandExecutor {
+    /// Confirm a pairing code on behalf of a specific chat.
+    ///
+    /// Why: `POST /pair/confirm` needs the confirming chat's id, which is not
+    /// carried by [`crate::TrustyCommand::Pair`]; the bot adapter supplies it here.
+    /// What: calls the daemon's confirm endpoint and maps the result to
+    /// [`CommandResult::PairSuccess`] or [`CommandResult::Error`].
+    /// Test: `pair_confirm_unknown_code_errors`.
+    pub async fn pair_confirm(&self, code: &str, chat_id: i64) -> CommandResult {
+        match self.client().pair_confirm(code, chat_id).await {
+            Ok(confirm) if confirm.success => CommandResult::PairSuccess {
+                chat_info: format!("chat {}", confirm.chat_id.unwrap_or(chat_id)),
+            },
+            Ok(confirm) => CommandResult::Error(
+                confirm
+                    .error
+                    .unwrap_or_else(|| "invalid or expired code".to_string()),
+            ),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// Request a one-time pairing code from the daemon.
+    ///
+    /// Why: `tm pair` asks the local daemon for a code to display.
+    /// What: calls `POST /pair/request` and maps it to [`CommandResult::PairCode`].
+    /// Test: `pair_request_returns_code`.
+    pub async fn pair_request(&self) -> CommandResult {
+        match self.client().pair_request().await {
+            Ok(req) => CommandResult::PairCode {
+                code: req.code,
+                expires_in_seconds: req.expires_in_seconds,
+            },
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/start` and `/pair` (no code) — query the pairing status.
+    pub(super) async fn pair_state(&self) -> CommandResult {
+        match self.client().pair_status().await {
+            Ok(status) => CommandResult::PairState {
+                paired: status.paired,
+            },
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+}

--- a/crates/trusty-mpm/src/client/executor/sessions.rs
+++ b/crates/trusty-mpm/src/client/executor/sessions.rs
@@ -80,9 +80,18 @@ impl CommandExecutor {
     pub(super) async fn decide(&self, session_id: &str, approved: bool) -> CommandResult {
         // Prefer the managed answer endpoint: if this id/name is a managed
         // session, the operator's approve/deny is a real decision answer.
-        if let Ok(managed) = self.client().list_managed_sessions().await
-            && let Some(found) = resolve_target(&managed, session_id)
-        {
+        //
+        // A daemon transport error must NOT be swallowed: previously an
+        // `if let Ok(..)` silently fell through to the project-session path,
+        // turning an unreachable daemon into a misleading "not found". Match
+        // the result explicitly — surface the transport error, and only fall
+        // through to the project path when the managed list was fetched
+        // successfully but did not contain the target.
+        let managed = match self.client().list_managed_sessions().await {
+            Ok(managed) => managed,
+            Err(e) => return CommandResult::Error(format!("daemon unreachable: {e}")),
+        };
+        if let Some(found) = resolve_target(&managed, session_id) {
             let answer = if approved {
                 found
                     .proposed_default

--- a/crates/trusty-mpm/src/client/executor/sessions.rs
+++ b/crates/trusty-mpm/src/client/executor/sessions.rs
@@ -1,0 +1,437 @@
+//! Project-session command methods + the pure session-resolution helpers.
+//!
+//! Why: the project-session family (`/sessions`, `/status`, `/tmux`, `/send`,
+//! `/launch`, …) is the original executor surface; splitting it out of the
+//! dispatch facade keeps `mod.rs` to the dispatch table alone and every file
+//! under the 500-SLOC cap. The pure helpers (`resolve_session`, `truncate_output`,
+//! `status_label`) live here because they are project-session shaped.
+//! What: inherent `CommandExecutor` methods for the project-session commands,
+//! plus the canonical-resolver-backed [`resolve_session`] and the output/status
+//! formatting helpers the methods (and tests) use.
+//! Test: covered by the `execute_*` tests in `tests.rs`.
+
+use super::CommandExecutor;
+use crate::client::http_client::SessionRow;
+use crate::client::resolver::resolve_target;
+use crate::client::result::{
+    CommandResult, DecisionCounts, DiscoveredProjectSummary, RecommendationSummary, SessionSummary,
+    TmuxSessionSummary,
+};
+
+/// Maximum captured-output length returned by `/send` (Telegram's message cap).
+///
+/// Why: Telegram rejects messages longer than ~4096 characters; truncating the
+/// captured pane keeps the reply deliverable on every UI.
+pub(crate) const MAX_OUTPUT_CHARS: usize = 4000;
+
+impl CommandExecutor {
+    /// `/sessions` — fetch and summarize the managed session list.
+    pub(super) async fn sessions(&self) -> CommandResult {
+        match self.client().sessions().await {
+            Ok(rows) => CommandResult::Sessions(
+                rows.into_iter()
+                    .map(|s| SessionSummary {
+                        id: s.id.0.to_string(),
+                        status: status_label(s.status),
+                        workdir: s.workdir,
+                    })
+                    .collect(),
+            ),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/status` — fetch one session's recent events.
+    pub(super) async fn status(&self, session_id: &str) -> CommandResult {
+        match self.client().session_events(session_id).await {
+            Ok(events) => {
+                let names: Vec<String> = events
+                    .iter()
+                    .rev()
+                    .take(5)
+                    .rev()
+                    .map(|e| e.event.wire_name().to_string())
+                    .collect();
+                CommandResult::SessionDetail {
+                    id: session_id.to_string(),
+                    status: "active".to_string(),
+                    events: names,
+                }
+            }
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/approve` and `/deny` — answer a session's pending decision.
+    ///
+    /// Why: this is the corrected decision-answer path. A managed session's
+    /// decision is answered through the REAL `POST .../{id}/answer` endpoint
+    /// (`answer_managed_session`) instead of the former synthetic `PostToolUse`
+    /// hook, so the harness actually unblocks. A project session (not in the
+    /// managed list) keeps its lightweight existence-check-and-acknowledge
+    /// behavior — there is no managed decision to answer.
+    /// What: resolves `session_id` against the managed list first; on a match it
+    /// posts the derived answer (the session's `proposed_default`, else `"yes"`,
+    /// for approve; `"no"` for deny) to the answer endpoint. Otherwise it
+    /// confirms the project session exists and returns Approved/Denied. An
+    /// unknown session is an `Error`.
+    /// Test: `execute_approve_known_session`, `execute_approve_unknown_session_errors`,
+    /// `execute_managed_answer_approve_routes_to_answer_endpoint`.
+    pub(super) async fn decide(&self, session_id: &str, approved: bool) -> CommandResult {
+        // Prefer the managed answer endpoint: if this id/name is a managed
+        // session, the operator's approve/deny is a real decision answer.
+        if let Ok(managed) = self.client().list_managed_sessions().await
+            && let Some(found) = resolve_target(&managed, session_id)
+        {
+            let answer = if approved {
+                found
+                    .proposed_default
+                    .clone()
+                    .unwrap_or_else(|| "yes".to_string())
+            } else {
+                "no".to_string()
+            };
+            return match self
+                .client()
+                .answer_managed_session(&found.id, &answer)
+                .await
+            {
+                Ok(_) if approved => CommandResult::Approved {
+                    session_id: found.id.clone(),
+                },
+                Ok(_) => CommandResult::Denied {
+                    session_id: found.id.clone(),
+                },
+                Err(e) => CommandResult::Error(format!("answer failed: {e}")),
+            };
+        }
+        // Fall back to the project-session path: confirm the session exists,
+        // then acknowledge. (No synthetic hook — the managed path above is the
+        // only real decision channel.)
+        let exists = match self.client().sessions().await {
+            Ok(rows) => rows.iter().any(|s| s.id.0.to_string() == session_id),
+            Err(e) => return CommandResult::Error(format!("daemon unreachable: {e}")),
+        };
+        if !exists {
+            return CommandResult::Error(format!("session {session_id} not found"));
+        }
+        if approved {
+            CommandResult::Approved {
+                session_id: session_id.to_string(),
+            }
+        } else {
+            CommandResult::Denied {
+                session_id: session_id.to_string(),
+            }
+        }
+    }
+
+    /// `/overseer` — fetch the overseer status.
+    pub(super) async fn overseer(&self) -> CommandResult {
+        match self.client().overseer_status().await {
+            Ok(snap) => CommandResult::OverseerStatus {
+                enabled: snap.enabled,
+                handler: snap.handler,
+                decisions: DecisionCounts {
+                    allow: snap.decisions.0,
+                    block: snap.decisions.1,
+                    flag: snap.decisions.2,
+                },
+            },
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/tmux` — list every tmux session on the host.
+    pub(super) async fn tmux(&self) -> CommandResult {
+        match self.client().tmux_sessions().await {
+            Ok(rows) => CommandResult::TmuxSessions(
+                rows.into_iter()
+                    .map(|r| TmuxSessionSummary {
+                        name: r.name,
+                        managed: r.managed,
+                    })
+                    .collect(),
+            ),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/projects` — discover projects from the Claude Code configuration.
+    ///
+    /// Why: lets the operator browse projects Claude Code already knows about
+    /// and register one without typing its path.
+    /// What: calls `GET /projects/discover` and maps each row to a
+    /// [`DiscoveredProjectSummary`].
+    /// Test: `execute_projects_against_test_daemon`.
+    pub(super) async fn projects(&self) -> CommandResult {
+        match self.client().discover_projects().await {
+            Ok(rows) => CommandResult::DiscoveredProjects(
+                rows.into_iter()
+                    .map(|r| DiscoveredProjectSummary {
+                        path: r.path,
+                        session_count: r.session_count,
+                        last_session: r.last_session,
+                    })
+                    .collect(),
+            ),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/discover` — auto-discover tmux sessions running Claude Code.
+    ///
+    /// Why: operators run Claude Code in tmux panes the daemon never created;
+    /// `/discover` scans every pane and adopts the ones running it so they show
+    /// up without a manual `/adopt`.
+    /// What: calls `POST /sessions/discover`; returns [`CommandResult::Discovered`]
+    /// with the count, or an `Error` when the daemon is unreachable.
+    /// Test: `execute_discover_against_test_daemon`.
+    pub(super) async fn discover(&self) -> CommandResult {
+        match self.client().discover_sessions().await {
+            Ok(count) => CommandResult::Discovered { count },
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/adopt` — adopt an external tmux session for oversight.
+    ///
+    /// Why: brings a session trusty-mpm did not create under management with a
+    /// single command.
+    /// What: calls `POST /tmux/adopt`; returns [`CommandResult::Adopted`] on
+    /// success, an `Error` when the session is unknown or the daemon is down.
+    /// Test: `execute_adopt_unknown_session_errors`.
+    pub(super) async fn adopt(&self, session: &str) -> CommandResult {
+        match self.client().adopt_tmux_session(session).await {
+            Ok(true) => CommandResult::Adopted {
+                session: session.to_string(),
+            },
+            Ok(false) => CommandResult::Error(format!("tmux session {session} not found")),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// Register a discovered project with the daemon.
+    ///
+    /// Why: the Telegram `/projects` keyboard's "Set Active" button registers a
+    /// project by path; that does not fit the pure `TrustyCommand` shape (the
+    /// path is keyboard callback data), so the bot adapter calls this directly.
+    /// What: calls `POST /projects`; returns a confirmation via the registered
+    /// path. Returns an `Error` when the daemon is unreachable.
+    /// Test: `register_project_succeeds`.
+    pub async fn register_project(&self, path: &str) -> CommandResult {
+        match self.client().register_project(path).await {
+            Ok(()) => CommandResult::ProjectRegistered {
+                path: path.to_string(),
+            },
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/config` — analyze a project's Claude Code config.
+    pub(super) async fn config(&self, project: &str) -> CommandResult {
+        match self.client().analyze_config(project).await {
+            Ok(recs) => CommandResult::ConfigAnalysis {
+                project: project.to_string(),
+                recommendations: recs
+                    .into_iter()
+                    .map(|r| RecommendationSummary {
+                        id: r.id,
+                        message: r.message,
+                    })
+                    .collect(),
+            },
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/snapshot` — capture a tmux pane.
+    pub(super) async fn snapshot(&self, session: &str) -> CommandResult {
+        match self.client().snapshot_tmux_session(session).await {
+            Ok(Some(output)) => CommandResult::Snapshot {
+                session: session.to_string(),
+                output,
+            },
+            Ok(None) => CommandResult::Error(format!("tmux session {session} not found")),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/kill` — kill a session.
+    pub(super) async fn kill(&self, session_id: &str) -> CommandResult {
+        match self.client().kill_session(session_id).await {
+            Ok(true) => CommandResult::Killed {
+                session_id: session_id.to_string(),
+            },
+            Ok(false) => CommandResult::Error(format!("session {session_id} not found")),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/send` — resolve a session and send a prompt to its tmux pane.
+    ///
+    /// Why: `/send <session> <prompt>` drives a running Claude Code session
+    /// remotely; the session is identified by id, friendly name, or a name
+    /// prefix, so the executor resolves it against `GET /sessions` first.
+    /// What: fetches the session list, resolves `session` via the canonical
+    /// [`resolve_session`] (id-exact, name-exact, then prefix), posts the prompt
+    /// via `POST /sessions/{id}/command`, and returns the captured pane output
+    /// truncated to [`MAX_OUTPUT_CHARS`]. An unknown session or unreachable
+    /// daemon yields a [`CommandResult::Error`].
+    /// Test: `execute_send_unknown_session_errors`.
+    pub(super) async fn send(&self, session: &str, prompt: &str) -> CommandResult {
+        if prompt.trim().is_empty() {
+            return CommandResult::Error("send: a prompt is required".to_string());
+        }
+        let rows = match self.client().sessions().await {
+            Ok(rows) => rows,
+            Err(e) => return CommandResult::Error(format!("daemon unreachable: {e}")),
+        };
+        let Some(target) = resolve_session(&rows, session) else {
+            return CommandResult::Error(format!("session {session} not found"));
+        };
+        match self.client().send_session_command(&target, prompt).await {
+            Ok(Some(output)) => CommandResult::CommandSent {
+                session: target,
+                output: truncate_output(&output),
+            },
+            Ok(None) => CommandResult::Error(format!("session {session} not found")),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `/launch` — deploy the framework, then start or attach to a session.
+    ///
+    /// Why: `tm launch` is the full entry point — it runs `prepare_session`
+    /// to deploy instructions, agents, and skills before bringing the
+    /// tmux-hosted session up.
+    /// What: calls [`DaemonClient::launch_session`], which runs the deployment
+    /// sequence and then registers + starts the tmux session.
+    /// Test: `execute_launch_errors_when_daemon_unreachable`.
+    pub(super) async fn launch(&self, project: &std::path::Path) -> CommandResult {
+        let workdir = project.to_string_lossy().to_string();
+        match self.client().launch_session(&workdir).await {
+            Ok(session) => CommandResult::SessionStarted {
+                session,
+                workdir,
+                deployed: true,
+            },
+            Err(e) => CommandResult::Error(format!("launch failed: {e}")),
+        }
+    }
+
+    /// `/connect` — start or attach to a session *without* deploying anything.
+    ///
+    /// Why: `tm connect` skips the `prepare_session` deployment sequence and
+    /// only ensures the tmux-hosted session is running — idempotent: create
+    /// when absent, attach when present.
+    /// What: calls [`DaemonClient::connect_session`].
+    /// Test: `execute_connect_errors_when_daemon_unreachable`.
+    pub(super) async fn connect(&self, project: &std::path::Path) -> CommandResult {
+        let workdir = project.to_string_lossy().to_string();
+        match self.client().connect_session(&workdir).await {
+            Ok(session) => CommandResult::SessionStarted {
+                session,
+                workdir,
+                deployed: false,
+            },
+            Err(e) => CommandResult::Error(format!("connect failed: {e}")),
+        }
+    }
+
+    /// `/doctor` — run the full system diagnostic.
+    ///
+    /// Why: a single command that confirms the whole trusty-mpm stack is wired
+    /// correctly; every UI funnels `/doctor` here so the report is identical.
+    /// What: resolves the process cwd as the project to scope the instruction
+    /// probe, calls `GET /api/v1/doctor`, and maps the result to
+    /// [`CommandResult::Doctor`]; an unreachable daemon becomes an `Error`.
+    /// Test: `execute_doctor_against_test_daemon`.
+    pub(super) async fn doctor(&self) -> CommandResult {
+        let cwd = std::env::current_dir()
+            .ok()
+            .map(|p| p.display().to_string());
+        match self.client().doctor(cwd.as_deref()).await {
+            Ok(report) => CommandResult::Doctor(report),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+
+    /// `tm coordinator <message>` — send a message to the cross-session
+    /// coordinator and return its reply.
+    ///
+    /// Why: the CLI/Telegram entry point for the coordinator; a stateless
+    /// invocation has no rolling history, so each call is a fresh conversation.
+    /// What: calls `POST /api/v1/sessions/chat` with an empty history.
+    /// Test: `coordinator_chat_outcome_deserializes` in the client tests.
+    pub(super) async fn coordinator_chat(&self, message: &str) -> CommandResult {
+        match self.client().coordinator_chat(message, &[]).await {
+            Ok(Some(outcome)) => {
+                let reply = match outcome.command_output {
+                    Some(output) => format!("{}\n{output}", outcome.reply),
+                    None => outcome.reply,
+                };
+                CommandResult::ChatReply { reply }
+            }
+            Ok(None) => CommandResult::Error(
+                "coordinator chat is not configured (no OpenRouter API key)".to_string(),
+            ),
+            Err(e) => CommandResult::Error(format!("daemon unreachable: {e}")),
+        }
+    }
+}
+
+/// Resolve a session reference (id, name, or prefix) to a definitive target.
+///
+/// Why: `/send` accepts a fuzzy session reference; resolving it against the live
+/// session list keeps the daemon call unambiguous. This is now a thin wrapper
+/// over the canonical [`resolve_target`] resolver so the project-session and
+/// managed paths share one precedence definition.
+/// What: delegates to [`resolve_target`] (id-exact, name-exact, unambiguous
+/// prefix) and maps the matched row to its path-segment target via [`target_of`].
+/// Test: `resolve_session_exact_and_prefix`.
+pub(crate) fn resolve_session(rows: &[SessionRow], query: &str) -> Option<String> {
+    resolve_target(rows, query).map(target_of)
+}
+
+/// The path-segment target for a session: its friendly name when set, else its id.
+///
+/// Why: `POST /sessions/{id}/command` resolves either form; the friendly name
+/// is more readable in the reply, so it is preferred when present.
+/// What: returns `tmux_name` when non-empty, otherwise the UUID string.
+/// Test: covered by `resolve_session_exact_and_prefix`.
+fn target_of(row: &SessionRow) -> String {
+    if row.tmux_name.is_empty() {
+        row.id.0.to_string()
+    } else {
+        row.tmux_name.clone()
+    }
+}
+
+/// Truncate captured output to [`MAX_OUTPUT_CHARS`] on a character boundary.
+///
+/// Why: a session's pane capture can exceed Telegram's message limit; the
+/// reply must stay deliverable.
+/// What: returns `text` unchanged when short enough, otherwise the first
+/// [`MAX_OUTPUT_CHARS`] characters followed by a truncation marker.
+/// Test: `truncate_output_caps_long_text`.
+pub(crate) fn truncate_output(text: &str) -> String {
+    if text.chars().count() <= MAX_OUTPUT_CHARS {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(MAX_OUTPUT_CHARS).collect();
+    format!("{head}\n… (output truncated)")
+}
+
+/// Render a [`SessionStatus`] as its wire label.
+///
+/// Why: `SessionSummary.status` is a display string; serializing the typed
+/// status keeps the label identical to the daemon's JSON wire form.
+/// What: serializes the status via serde and strips the surrounding quotes.
+/// Test: covered by `execute_sessions_against_test_daemon`.
+fn status_label(status: crate::core::session::SessionStatus) -> String {
+    serde_json::to_value(status)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string())
+}

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -489,3 +489,45 @@ async fn pair_request_then_confirm_succeeds() {
         other => panic!("expected PairState, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn execute_approve_errors_when_managed_list_unreachable() {
+    // Regression for the swallowed-daemon-error fix: `decide()` fetches the
+    // managed list first. When that fetch fails (daemon down), the operator
+    // must see a transport error, NOT a misleading "session not found" from a
+    // silent fall-through to the project-session path.
+    let executor = CommandExecutor::new("http://127.0.0.1:0");
+    match executor
+        .execute(TrustyCommand::Approve {
+            session_id: uuid::Uuid::new_v4().to_string(),
+        })
+        .await
+    {
+        CommandResult::Error(msg) => {
+            assert!(
+                msg.contains("daemon unreachable"),
+                "expected a daemon-unreachable error, got: {msg}"
+            );
+            assert!(
+                !msg.contains("not found"),
+                "must not masquerade a transport failure as not-found: {msg}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[test]
+fn is_session_id_detects_uuid_vs_name() {
+    // A canonical id (UUID) is treated as an id so `managed_get` can skip the
+    // list round-trip; a friendly name or prefix is not.
+    assert!(super::managed::is_session_id(
+        &uuid::Uuid::new_v4().to_string()
+    ));
+    assert!(super::managed::is_session_id(
+        "367c6c51-1025-419c-b6d6-be9a753e8914"
+    ));
+    assert!(!super::managed::is_session_id("brave-otter"));
+    assert!(!super::managed::is_session_id("brave"));
+    assert!(!super::managed::is_session_id(""));
+}

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -364,6 +364,114 @@ async fn pair_confirm_unknown_code_errors() {
 }
 
 #[tokio::test]
+async fn execute_managed_list_against_test_daemon() {
+    // With no managed sessions provisioned, `managed-list` returns an empty
+    // (but well-formed) list against the live managed route — never an error.
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url);
+    match executor.execute(TrustyCommand::ManagedList).await {
+        CommandResult::ManagedSessions(list) => assert!(list.is_empty()),
+        other => panic!("expected ManagedSessions, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn execute_managed_get_unknown_errors() {
+    // A target that resolves against no managed session is a renderable error,
+    // not a panic.
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url);
+    match executor
+        .execute(TrustyCommand::ManagedGet {
+            target: "no-such-managed".into(),
+        })
+        .await
+    {
+        CommandResult::Error(msg) => assert!(msg.contains("not found")),
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn execute_managed_answer_unknown_errors() {
+    // The corrected decision-answer path: answering an unknown managed session
+    // resolves to a not-found error (it never falls through to a synthetic hook).
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url);
+    match executor
+        .execute(TrustyCommand::ManagedAnswer {
+            target: "no-such-managed".into(),
+            answer: "yes".into(),
+        })
+        .await
+    {
+        CommandResult::Error(msg) => assert!(msg.contains("not found")),
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn execute_managed_answer_empty_errors() {
+    // An empty answer is rejected before any HTTP call.
+    let executor = CommandExecutor::new("http://unused");
+    match executor
+        .execute(TrustyCommand::ManagedAnswer {
+            target: "x".into(),
+            answer: "   ".into(),
+        })
+        .await
+    {
+        CommandResult::Error(msg) => assert!(msg.contains("answer")),
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn execute_managed_lifecycle_unknown_errors() {
+    // stop / resume / decommission of an unknown managed target all error.
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url);
+    for cmd in [
+        TrustyCommand::ManagedRuntimeStop {
+            target: "no-such".into(),
+        },
+        TrustyCommand::ManagedResume {
+            target: "no-such".into(),
+        },
+        TrustyCommand::ManagedDecommission {
+            target: "no-such".into(),
+        },
+    ] {
+        match executor.execute(cmd).await {
+            CommandResult::Error(msg) => assert!(msg.contains("not found")),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn execute_managed_verbs_error_when_daemon_unreachable() {
+    // Every target-taking managed verb surfaces an unreachable daemon as a
+    // renderable Error rather than panicking.
+    let executor = CommandExecutor::new("http://127.0.0.1:0");
+    let cmds = [
+        TrustyCommand::ManagedGet { target: "x".into() },
+        TrustyCommand::ManagedActivity { target: "x".into() },
+        TrustyCommand::ManagedAttachCmd { target: "x".into() },
+        TrustyCommand::ManagedSend {
+            target: "x".into(),
+            text: "hi".into(),
+        },
+    ];
+    for cmd in cmds {
+        match executor.execute(cmd).await {
+            CommandResult::Error(_) => {}
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
 async fn pair_request_then_confirm_succeeds() {
     // The full handshake: request a code, confirm it, then status is paired.
     let (_state, url) = spawn_test_daemon().await;

--- a/crates/trusty-mpm/src/client/mod.rs
+++ b/crates/trusty-mpm/src/client/mod.rs
@@ -14,12 +14,15 @@
 //! Test: `cargo test -p trusty-mpm-client` covers URL construction, the command
 //! model, and the executor against an in-process test daemon.
 
+pub mod catalog;
 pub mod command;
 pub mod executor;
 pub mod http_client;
+pub mod resolver;
 pub mod result;
 
 pub use crate::core::doctor::{CheckStatus, DoctorCheck, DoctorReport};
+pub use catalog::{CommandSpec, SpecKind, catalog, render_sm_tools};
 pub use command::TrustyCommand;
 pub use executor::CommandExecutor;
 pub use http_client::{
@@ -30,7 +33,8 @@ pub use http_client::{
     ManagedSpawnRequest, ManagedSpawnResponse, OverseerSnapshot, PairConfirm, PairRequest,
     PairStatus, SessionRow, TmuxSessionRow,
 };
+pub use resolver::{Resolvable, resolve_target};
 pub use result::{
-    CommandResult, DecisionCounts, DiscoveredProjectSummary, RecommendationSummary, SessionSummary,
-    TmuxSessionSummary,
+    CommandResult, DecisionCounts, DiscoveredProjectSummary, ManagedSessionView,
+    RecommendationSummary, SessionSummary, TmuxSessionSummary,
 };

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -1,0 +1,194 @@
+//! The canonical session-target resolver.
+//!
+//! Why: four call sites historically resolved an operator's fuzzy session
+//! reference (a UUID, a friendly name, or a name prefix) to a definitive target,
+//! each with subtly different precedence: the executor's `resolve_session`
+//! (`executor/mod.rs`), the CLI's `classify_managed_target` and
+//! `resolve_managed_id` (`bin/tm/commands/managed.rs`), and the CLI's
+//! `resolve_session_id` (`bin/tm/commands/session.rs`). Divergent precedence is
+//! a latent correctness bug: the same argument could resolve differently across
+//! UIs. [`resolve_target`] is the one pure resolver every surface adopts so the
+//! id-exact / name-exact / name-prefix precedence is defined exactly once.
+//! What: a generic pure function over any list of items that expose an id-match
+//! predicate and a name (via [`Resolvable`]) plus a query string. It applies a
+//! fixed precedence — id-exact, then name-exact, then unambiguous name-prefix —
+//! and returns the matched item. The executor's managed and project paths both
+//! call it; the CLI resolvers adopt it in Phase 1B.
+//! Test: `resolve_target_precedence`, `resolve_target_prefix`,
+//! `resolve_target_no_match`, `resolve_target_prefix_is_unambiguous`.
+
+/// Something a [`resolve_target`] query can match: it knows its id and name.
+///
+/// Why: the resolver must work over both [`crate::client::http_client::SessionRow`]
+/// (project sessions, keyed by a UUID newtype + `tmux_name`) and
+/// [`crate::client::http_client::ManagedSessionSummary`] (managed sessions,
+/// keyed by a `String` id + `name`) without duplicating the precedence logic or
+/// forcing an allocation to stringify the UUID. `id_matches` (a predicate, not
+/// an accessor) lets the UUID newtype compare against the query in place.
+/// What: an `id_matches` predicate for id-exact comparison and a `resolve_name`
+/// accessor for the friendly name (may be empty).
+/// Test: implemented for the two session shapes and exercised by the resolver
+/// tests via a local stub.
+pub trait Resolvable {
+    /// True when `query` exactly equals this item's canonical id.
+    fn id_matches(&self, query: &str) -> bool;
+    /// The item's friendly name (may be empty).
+    fn resolve_name(&self) -> &str;
+}
+
+/// Resolve a fuzzy session reference to a single matched item.
+///
+/// Why: every UI accepts "id, name, or prefix" and must resolve it the same way;
+/// centralizing the precedence here removes the per-call-site drift that let the
+/// same argument resolve differently across the CLI, TUI, and bot.
+/// What: returns the first item whose id equals `query` (id-exact), else the
+/// first whose `resolve_name` equals `query` (name-exact), else — only when
+/// **exactly one** item's non-empty name starts with `query` — that unambiguous
+/// prefix match. An ambiguous prefix (two or more matches) resolves to `None` so
+/// a UI never silently picks the wrong session. An empty `query` never matches.
+/// Test: `resolve_target_precedence`, `resolve_target_prefix`,
+/// `resolve_target_prefix_is_unambiguous`, `resolve_target_no_match`.
+pub fn resolve_target<'a, T: Resolvable>(items: &'a [T], query: &str) -> Option<&'a T> {
+    if query.is_empty() {
+        return None;
+    }
+    // 1. id-exact.
+    if let Some(item) = items.iter().find(|i| i.id_matches(query)) {
+        return Some(item);
+    }
+    // 2. name-exact.
+    if let Some(item) = items.iter().find(|i| i.resolve_name() == query) {
+        return Some(item);
+    }
+    // 3. unambiguous name-prefix.
+    let mut prefix_matches = items
+        .iter()
+        .filter(|i| !i.resolve_name().is_empty() && i.resolve_name().starts_with(query));
+    match (prefix_matches.next(), prefix_matches.next()) {
+        (Some(only), None) => Some(only),
+        _ => None,
+    }
+}
+
+impl Resolvable for crate::client::http_client::SessionRow {
+    /// Why: project sessions are keyed by their UUID `id` and friendly
+    /// `tmux_name`; the resolver matches against both, comparing the UUID to the
+    /// query string in place rather than allocating it.
+    /// What: `id_matches` stringifies the UUID for the comparison; `resolve_name`
+    /// returns `tmux_name`.
+    /// Test: covered by the executor's `resolve_session_*` tests.
+    fn id_matches(&self, query: &str) -> bool {
+        self.id.0.to_string() == query
+    }
+    fn resolve_name(&self) -> &str {
+        &self.tmux_name
+    }
+}
+
+impl Resolvable for crate::client::http_client::ManagedSessionSummary {
+    /// Why: managed sessions are keyed by their string `id` and `name`; the
+    /// resolver matches against both with the shared precedence.
+    /// What: `id_matches` compares the `id` string; `resolve_name` returns `name`.
+    /// Test: `resolve_target_managed_precedence`.
+    fn id_matches(&self, query: &str) -> bool {
+        self.id == query
+    }
+    fn resolve_name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal stub for exercising the precedence rules directly.
+    struct Stub {
+        id: String,
+        name: String,
+    }
+    impl Resolvable for Stub {
+        fn id_matches(&self, query: &str) -> bool {
+            self.id == query
+        }
+        fn resolve_name(&self) -> &str {
+            &self.name
+        }
+    }
+    fn stub(id: &str, name: &str) -> Stub {
+        Stub {
+            id: id.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn resolve_target_precedence() {
+        // id-exact beats name-exact beats prefix.
+        let items = vec![stub("uuid-1", "frontend"), stub("uuid-2", "backend")];
+        assert_eq!(
+            resolve_target(&items, "uuid-1").map(|s| s.id.as_str()),
+            Some("uuid-1")
+        );
+        assert_eq!(
+            resolve_target(&items, "backend").map(|s| s.id.as_str()),
+            Some("uuid-2")
+        );
+    }
+
+    #[test]
+    fn resolve_target_prefix() {
+        let items = vec![stub("uuid-1", "tmpm-blue-fox"), stub("uuid-2", "backend")];
+        assert_eq!(
+            resolve_target(&items, "tmpm-blue").map(|s| s.name.as_str()),
+            Some("tmpm-blue-fox")
+        );
+    }
+
+    #[test]
+    fn resolve_target_prefix_is_unambiguous() {
+        // Two names share a prefix → ambiguous → no match (never guess).
+        let items = vec![stub("uuid-1", "frontend-a"), stub("uuid-2", "frontend-b")];
+        assert!(resolve_target(&items, "frontend-").is_none());
+        // But an exact name still wins even when it is a prefix of another.
+        let items2 = vec![stub("uuid-1", "front"), stub("uuid-2", "frontend")];
+        assert_eq!(
+            resolve_target(&items2, "front").map(|s| s.id.as_str()),
+            Some("uuid-1"),
+            "exact name match beats the ambiguous-prefix rule"
+        );
+    }
+
+    #[test]
+    fn resolve_target_no_match() {
+        let items = vec![stub("uuid-1", "frontend")];
+        assert!(resolve_target(&items, "no-such").is_none());
+        assert!(resolve_target(&items, "").is_none());
+    }
+
+    #[test]
+    fn resolve_target_managed_precedence() {
+        use crate::client::http_client::ManagedSessionSummary;
+        let summary = |id: &str, name: &str| ManagedSessionSummary {
+            id: id.to_string(),
+            name: name.to_string(),
+            state: "Running".to_string(),
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            created_at: None,
+            last_activity_at: None,
+            pending_decision: None,
+            proposed_default: None,
+        };
+        let items = vec![summary("m-1", "tmpm-red-owl"), summary("m-2", "api")];
+        assert_eq!(
+            resolve_target(&items, "m-2").map(|s| s.id.as_str()),
+            Some("m-2")
+        );
+        assert_eq!(
+            resolve_target(&items, "tmpm-red").map(|s| s.id.as_str()),
+            Some("m-1")
+        );
+    }
+}

--- a/crates/trusty-mpm/src/client/result.rs
+++ b/crates/trusty-mpm/src/client/result.rs
@@ -209,6 +209,138 @@ pub enum CommandResult {
     },
     /// `/help` — the command list text.
     Help(String),
+
+    // ── Managed session-manager outcomes (`/api/v1/sessions/managed/*`) ──────
+    /// `managed-new` — a managed session was spawned.
+    ///
+    /// Why: the operator needs the new session's identity and the exact tmux
+    /// command to attach to it immediately after a spawn.
+    /// What: the new session's id, friendly name, lifecycle state, runtime
+    /// backend, and the attach command string.
+    ManagedSpawned {
+        /// Managed session id (UUID string).
+        id: String,
+        /// tmux session name.
+        name: String,
+        /// Current lifecycle state word.
+        state: String,
+        /// Runtime backend (`claude-code` | `tcode`).
+        runtime: String,
+        /// tmux attach command string.
+        attach_cmd: String,
+    },
+    /// `managed-list` — the managed session-manager session list.
+    ManagedSessions(Vec<ManagedSessionView>),
+    /// `managed-get` — one managed session's record.
+    ManagedSession(ManagedSessionView),
+    /// `managed-send` — text was injected into a managed session's pane.
+    ManagedSent {
+        /// The resolved managed session id.
+        id: String,
+        /// tmux session name the text was sent to.
+        tmux_name: String,
+    },
+    /// `managed-answer` — a pending decision was answered.
+    ///
+    /// Why: confirms the real `.../answer` endpoint accepted the operator's
+    /// decision so the harness unblocks.
+    /// What: the resolved session id, the answer injected, and the tmux name.
+    ManagedAnswered {
+        /// The resolved managed session id.
+        id: String,
+        /// The answer text that was injected.
+        answer: String,
+        /// tmux session name the answer was sent to.
+        tmux_name: String,
+    },
+    /// `managed-activity` — a managed session's activity snapshot.
+    ManagedActivity {
+        /// The resolved managed session id.
+        id: String,
+        /// Classified activity state (`unknown` when no classifier ran).
+        state: String,
+        /// Human-readable summary of what the session is doing.
+        summary: String,
+        /// Raw pane content (last lines).
+        raw_pane: String,
+        /// Whether the tmux runtime is currently alive.
+        runtime_active: bool,
+        /// A pending decision question, if surfaced.
+        pending_decision: Option<String>,
+    },
+    /// `managed-attach` — the tmux command to attach to a managed session.
+    ManagedAttachCmd {
+        /// The resolved managed session id.
+        id: String,
+        /// tmux attach command string.
+        attach_cmd: String,
+    },
+    /// `managed-stop`/`managed-resume`/`managed-decommission` — the updated
+    /// lifecycle state after a runtime transition.
+    ///
+    /// Why: all three terminal/lifecycle verbs report the same shape — the
+    /// session's id, name, and new state — so a UI renders them uniformly.
+    /// What: the resolved id, friendly name, the new lifecycle state, and the
+    /// human-readable verb that produced it (`stopped`/`resumed`/`decommissioned`).
+    ManagedLifecycle {
+        /// The resolved managed session id.
+        id: String,
+        /// tmux session name.
+        name: String,
+        /// New lifecycle state word.
+        state: String,
+        /// The verb applied (`stopped` | `resumed` | `decommissioned`).
+        action: String,
+    },
+
     /// Any failure rendered as a message rather than a panic.
     Error(String),
+}
+
+/// A flat, UI-agnostic view of a managed session.
+///
+/// Why: the managed list/get results render the same flat summary every adapter
+/// consumes; a dedicated view keeps the UIs off the wire DTO
+/// ([`crate::client::ManagedSessionSummary`]) so a wire-shape change does not
+/// ripple into every formatter.
+/// What: the identity and lifecycle fields the UIs render, plus the pending
+/// decision a session may be blocked on.
+/// Test: covered by the executor's `managed_*` tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedSessionView {
+    /// Managed session id (UUID string).
+    pub id: String,
+    /// tmux session name.
+    pub name: String,
+    /// Lifecycle state word.
+    pub state: String,
+    /// Provisioned workspace path, if any.
+    pub workspace_path: Option<String>,
+    /// Repository URL the session was provisioned from.
+    pub repo_url: Option<String>,
+    /// Git branch or ref checked out.
+    pub branch: Option<String>,
+    /// A pending decision question, if surfaced.
+    pub pending_decision: Option<String>,
+    /// Proposed default answer to the pending decision.
+    pub proposed_default: Option<String>,
+}
+
+impl From<crate::client::ManagedSessionSummary> for ManagedSessionView {
+    /// Why: the executor maps the wire DTO to the UI view at the dispatch seam
+    /// so adapters never see the transport shape.
+    /// What: moves the shared fields across one-to-one.
+    /// Test: covered by `execute_managed_list_against_test_daemon`.
+    fn from(s: crate::client::ManagedSessionSummary) -> Self {
+        Self {
+            id: s.id,
+            name: s.name,
+            state: s.state,
+            workspace_path: s.workspace_path,
+            repo_url: s.repo_url,
+            branch: s.branch,
+            pending_decision: s.pending_decision,
+            proposed_default: s.proposed_default,
+        }
+    }
 }

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -206,15 +206,20 @@ impl TelegramFormatter {
                 runtime,
                 attach_cmd,
             } => format!(
-                "✅ Spawned <b>{name}</b> (<code>{}</code>) [{state}] runtime={runtime}\n\
-                 attach: <code>{attach_cmd}</code>",
+                "✅ Spawned <b>{}</b> (<code>{}</code>) [{}] runtime={}\n\
+                 attach: <code>{}</code>",
+                html_escape(name),
                 short_id(id),
+                html_escape(state),
+                html_escape(runtime),
+                html_escape(attach_cmd),
             ),
             CommandResult::ManagedSessions(sessions) => format_managed_sessions(sessions),
             CommandResult::ManagedSession(view) => format_managed_session(view),
             CommandResult::ManagedSent { id, tmux_name } => {
                 format!(
-                    "📨 Sent to managed <code>{tmux_name}</code> ({})",
+                    "📨 Sent to managed <code>{}</code> ({})",
+                    html_escape(tmux_name),
                     short_id(id)
                 )
             }
@@ -223,7 +228,8 @@ impl TelegramFormatter {
                 answer,
                 tmux_name,
             } => format!(
-                "✅ Answered decision on <code>{tmux_name}</code> ({}) → <code>{}</code>",
+                "✅ Answered decision on <code>{}</code> ({}) → <code>{}</code>",
+                html_escape(tmux_name),
                 short_id(id),
                 html_escape(answer),
             ),
@@ -239,20 +245,31 @@ impl TelegramFormatter {
                     .map(|d| format!("\n⚠️ pending: {}", html_escape(d)))
                     .unwrap_or_default();
                 format!(
-                    "<b>Activity {} [{state}]</b>\n{}{decision}",
+                    "<b>Activity {} [{}]</b>\n{}{decision}",
                     short_id(id),
+                    html_escape(state),
                     html_escape(summary),
                 )
             }
             CommandResult::ManagedAttachCmd { id, attach_cmd } => {
-                format!("<b>Attach {}</b>\n<code>{attach_cmd}</code>", short_id(id),)
+                format!(
+                    "<b>Attach {}</b>\n<code>{}</code>",
+                    short_id(id),
+                    html_escape(attach_cmd),
+                )
             }
             CommandResult::ManagedLifecycle {
                 id,
                 name,
                 state,
                 action,
-            } => format!("✅ {name} ({}) {action} → {state}", short_id(id)),
+            } => format!(
+                "✅ {} ({}) {} → {}",
+                html_escape(name),
+                short_id(id),
+                html_escape(action),
+                html_escape(state),
+            ),
             CommandResult::Help(text) => text.clone(),
             CommandResult::Error(msg) => format!("❌ {msg}"),
         }
@@ -374,7 +391,7 @@ pub fn format_managed_sessions(sessions: &[ManagedSessionView]) -> String {
             "\n• <code>{}</code> {} [{}]{flag}",
             short_id(&s.id),
             html_escape(&s.name),
-            s.state,
+            html_escape(&s.state),
         ));
     }
     text
@@ -391,14 +408,18 @@ pub fn format_managed_session(view: &ManagedSessionView) -> String {
         "<b>{}</b> (<code>{}</code>) [{}]",
         html_escape(&view.name),
         short_id(&view.id),
-        view.state,
+        html_escape(&view.state),
     );
     if let Some(ws) = &view.workspace_path {
         text.push_str(&format!("\n📁 <code>{}</code>", html_escape(ws)));
     }
     if let Some(repo) = &view.repo_url {
         let branch = view.branch.as_deref().unwrap_or("");
-        text.push_str(&format!("\n🔗 {} {branch}", html_escape(repo)));
+        text.push_str(&format!(
+            "\n🔗 {} {}",
+            html_escape(repo),
+            html_escape(branch)
+        ));
     }
     if let Some(d) = &view.pending_decision {
         let def = view.proposed_default.as_deref().unwrap_or("");

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -8,7 +8,7 @@
 //! [`TelegramFormatter::keyboard_for`] the optional inline keyboard.
 //! Test: `cargo test -p trusty-mpm-telegram` covers each variant's rendering.
 
-use crate::client::{CommandResult, DiscoveredProjectSummary};
+use crate::client::{CommandResult, DiscoveredProjectSummary, ManagedSessionView};
 use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup};
 
 #[cfg(test)]
@@ -199,6 +199,60 @@ impl TelegramFormatter {
                 };
                 format!("✅ Session <b>{session}</b> {mode}\n<code>{workdir}</code>")
             }
+            CommandResult::ManagedSpawned {
+                id,
+                name,
+                state,
+                runtime,
+                attach_cmd,
+            } => format!(
+                "✅ Spawned <b>{name}</b> (<code>{}</code>) [{state}] runtime={runtime}\n\
+                 attach: <code>{attach_cmd}</code>",
+                short_id(id),
+            ),
+            CommandResult::ManagedSessions(sessions) => format_managed_sessions(sessions),
+            CommandResult::ManagedSession(view) => format_managed_session(view),
+            CommandResult::ManagedSent { id, tmux_name } => {
+                format!(
+                    "📨 Sent to managed <code>{tmux_name}</code> ({})",
+                    short_id(id)
+                )
+            }
+            CommandResult::ManagedAnswered {
+                id,
+                answer,
+                tmux_name,
+            } => format!(
+                "✅ Answered decision on <code>{tmux_name}</code> ({}) → <code>{}</code>",
+                short_id(id),
+                html_escape(answer),
+            ),
+            CommandResult::ManagedActivity {
+                id,
+                state,
+                summary,
+                pending_decision,
+                ..
+            } => {
+                let decision = pending_decision
+                    .as_deref()
+                    .map(|d| format!("\n⚠️ pending: {}", html_escape(d)))
+                    .unwrap_or_default();
+                format!(
+                    "<b>Activity {} [{state}]</b>\n{}{decision}",
+                    short_id(id),
+                    html_escape(summary),
+                )
+            }
+            CommandResult::ManagedAttachCmd { id, attach_cmd } => {
+                format!("<b>Attach {}</b>\n<code>{attach_cmd}</code>", short_id(id),)
+            }
+            CommandResult::ManagedLifecycle {
+                id,
+                name,
+                state,
+                action,
+            } => format!("✅ {name} ({}) {action} → {state}", short_id(id)),
             CommandResult::Help(text) => text.clone(),
             CommandResult::Error(msg) => format!("❌ {msg}"),
         }
@@ -293,6 +347,65 @@ pub fn format_discovered_projects(projects: &[DiscoveredProjectSummary]) -> Stri
         text.push_str(&format!(
             "\n📁 <code>{}</code>\n  {} session(s) · last used {last}\n",
             p.path, p.session_count,
+        ));
+    }
+    text
+}
+
+/// Render a managed session-manager session list as a Telegram HTML body.
+///
+/// Why: `managed-list` reports the managed fleet; keeping the rendering a free
+/// function makes it unit-testable and reusable.
+/// What: a placeholder when empty, else one line per session: state dot, short
+/// id, name, and a pending-decision flag when blocked.
+/// Test: `format_managed_sessions_lists_each`.
+pub fn format_managed_sessions(sessions: &[ManagedSessionView]) -> String {
+    if sessions.is_empty() {
+        return "No managed sessions.".to_string();
+    }
+    let mut text = String::from("<b>managed sessions</b>\n");
+    for s in sessions {
+        let flag = if s.pending_decision.is_some() {
+            " ⚠️"
+        } else {
+            ""
+        };
+        text.push_str(&format!(
+            "\n• <code>{}</code> {} [{}]{flag}",
+            short_id(&s.id),
+            html_escape(&s.name),
+            s.state,
+        ));
+    }
+    text
+}
+
+/// Render one managed session's detail as a Telegram HTML body.
+///
+/// Why: `managed-get` shows a single session's full record on a phone.
+/// What: the name, state, workspace/repo/branch when present, and any pending
+/// decision with its proposed default.
+/// Test: `format_managed_session_renders_fields`.
+pub fn format_managed_session(view: &ManagedSessionView) -> String {
+    let mut text = format!(
+        "<b>{}</b> (<code>{}</code>) [{}]",
+        html_escape(&view.name),
+        short_id(&view.id),
+        view.state,
+    );
+    if let Some(ws) = &view.workspace_path {
+        text.push_str(&format!("\n📁 <code>{}</code>", html_escape(ws)));
+    }
+    if let Some(repo) = &view.repo_url {
+        let branch = view.branch.as_deref().unwrap_or("");
+        text.push_str(&format!("\n🔗 {} {branch}", html_escape(repo)));
+    }
+    if let Some(d) = &view.pending_decision {
+        let def = view.proposed_default.as_deref().unwrap_or("");
+        text.push_str(&format!(
+            "\n⚠️ pending: {} (default: <code>{}</code>)",
+            html_escape(d),
+            html_escape(def),
         ));
     }
     text

--- a/crates/trusty-mpm/src/telegram/formatter/tests.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/tests.rs
@@ -215,6 +215,49 @@ fn format_doctor_report_lists_each_check() {
 }
 
 #[test]
+fn managed_arms_escape_daemon_sourced_fields() {
+    // Why: daemon-sourced names/states (repo/tmux/session names) may contain
+    // HTML-significant characters; un-escaped `<`/`>`/`&` make Telegram reject
+    // or misrender the message. These arms must run every interpolated
+    // daemon-sourced field through `html_escape`, matching the other formatters.
+    let raw = "a<b>&c";
+    let escaped = "a&lt;b&gt;&amp;c";
+
+    let spawned = CommandResult::ManagedSpawned {
+        id: "abcd1234-5678".into(),
+        name: raw.into(),
+        state: raw.into(),
+        runtime: raw.into(),
+        attach_cmd: raw.into(),
+    };
+    let spawned_text = TelegramFormatter::format(&spawned);
+    assert!(
+        spawned_text.contains(escaped),
+        "ManagedSpawned must escape daemon fields: {spawned_text}"
+    );
+    assert!(
+        !spawned_text.contains("a<b>&c"),
+        "ManagedSpawned must not emit raw chars: {spawned_text}"
+    );
+
+    let lifecycle = CommandResult::ManagedLifecycle {
+        id: "abcd1234-5678".into(),
+        name: raw.into(),
+        state: raw.into(),
+        action: raw.into(),
+    };
+    let lifecycle_text = TelegramFormatter::format(&lifecycle);
+    assert!(
+        lifecycle_text.contains(escaped),
+        "ManagedLifecycle must escape daemon fields: {lifecycle_text}"
+    );
+    assert!(
+        !lifecycle_text.contains("a<b>&c"),
+        "ManagedLifecycle must not emit raw chars: {lifecycle_text}"
+    );
+}
+
+#[test]
 fn snapshot_escapes_html() {
     let result = CommandResult::Snapshot {
         session: "s".into(),

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -28,6 +28,7 @@ can resolve a changed file back to the section that governs it.
 | DOC-17 | `SPEC-HARNESS-01~draft` | [Autonomous Multi-Session Managed Harness Runner](./harness-runner-vision.md) | trusty-mpm — harness runner / provisioning |
 | DOC-18 | `SPEC-METACODING-01~draft` | [Metacoding — the trusty-tools product north-star](./metacoding-vision.md) | trusty-tools — product vision (cross-crate) |
 | DOC-19 | `SPEC-TELUI-01~draft` | [TELUI: the Telegram UI for trusty-mpm](./telui-telegram-ui.md) | trusty-mpm — control surface / Telegram |
+| DOC-20 | `SPEC-CHAT-CORE-01~draft` | [Chat-Core: the shared command nucleus](./chat-core.md) | trusty-mpm — control surface / shared client |
 
 ## Status lifecycle
 

--- a/docs/specs/chat-core.md
+++ b/docs/specs/chat-core.md
@@ -1,0 +1,186 @@
+# DOC-20 — Chat-Core: the shared command nucleus for trusty-mpm UIs
+
+**Status:** Draft
+**Subsystem:** trusty-mpm — control surface / shared client (`crates/trusty-mpm/src/client/`)
+**Owner:** Engineering (trusty-mpm)
+**Last-updated:** 2026-06-19
+**Spec ID:** `SPEC-CHAT-CORE-01~draft` (DOC-20)
+**Builds on:** DOC-14 — Session Manager (SM) Agent (`docs/specs/session-manager-agent.md`,
+the `SessionControl` verb names this catalog aligns with); DOC-16 — Interactive
+Sessions TUI (`docs/specs/sessions-tui-interactive.md`, the STUI adapter); DOC-19 —
+TELUI (`docs/specs/telui-telegram-ui.md`, the Telegram adapter); DOC-18 — Metacoding
+(`docs/specs/metacoding-vision.md`, the ONB-3 control surfaces).
+**Cross-ref:** the shared client module (`crates/trusty-mpm/src/client/`), the typed
+managed `DaemonClient` methods (PR #1491), the SM tool prompt asset
+(`crates/trusty-mpm/src/assets/sm_instructions/SM_TOOLS.md`), and issues **#1283**
+(chat-core nucleus), **#1433** (TELUI), **#1272** (STUI).
+
+> **Scope note.** This is a **behavior-contract** spec for the **chat-core nucleus** —
+> the shared base library every session-manager UI adapter (CLI, TUI, TELUI, future
+> Web/Slack) dispatches through. It specifies the layered architecture, the
+> catalog-as-single-source-of-truth principle, the resolver contract, and the planned
+> adapter rollout. It does **not** implement the adapters; CLI and TUI retain their own
+> paths until Phases 1B/1C.
+
+---
+
+## 1. Motivation
+
+Before chat-core, every UI surface (the Telegram bot, the TUI dashboard, the `tm` CLI)
+translated operator intent into daemon HTTP calls independently. Three things described
+the same verb set and could silently drift:
+
+1. The `/help` body, hand-written in `command.rs`.
+2. The typed `TrustyCommand` enum.
+3. The SM prompt's `SM_TOOLS.md` prose.
+
+And the same "resolve a fuzzy session reference to a definitive target" logic was
+re-implemented at four call sites with subtly different precedence — a latent
+correctness bug where the same argument could resolve differently across UIs.
+
+Chat-core collapses all of this into one nucleus: one transport, one intent enum, one
+dispatch seam, one result type, one resolver, and one authoritative command catalog.
+
+## 2. Layered architecture {#SPEC-CHAT-CORE-01-layers}
+
+Intent flows top-to-bottom; data flows back up. Every adapter is a thin shell over the
+nucleus.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Adapter (CLI / TUI / TELUI / Web / Slack)                   │  thin: parse → dispatch → render
+│    parses native input  ──►  TrustyCommand                   │
+│    renders CommandResult ◄──                                 │
+└───────────────┬─────────────────────────────▲───────────────┘
+                │ TrustyCommand                │ CommandResult
+                ▼                              │
+┌─────────────────────────────────────────────────────────────┐
+│  CommandExecutor::execute  (the single dispatch seam)        │  one match arm per verb
+│    sessions.rs · managed.rs · pairing.rs                     │
+└───────────────┬─────────────────────────────▲───────────────┘
+                │ typed method call            │ typed DTO / Result
+                ▼                              │
+┌─────────────────────────────────────────────────────────────┐
+│  DaemonClient  (the one HTTP transport)                      │  reqwest; URL building; serde DTOs
+│    project-session routes · managed-session routes · pairing │
+└─────────────────────────────────────────────────────────────┘
+```
+
+| Layer | Type | File(s) | Responsibility |
+|-------|------|---------|----------------|
+| Transport | `DaemonClient` | `client/http_client/` | One `reqwest` client; one typed method per daemon endpoint; serde DTOs. |
+| Intent | `TrustyCommand` | `client/command.rs` | UI-agnostic enum; one variant per operator action (project-session, managed, pairing, overseer families). |
+| Dispatch | `CommandExecutor` | `client/executor/` | The single `execute(TrustyCommand) → CommandResult` seam; split into `sessions.rs` / `managed.rs` / `pairing.rs`. |
+| Result | `CommandResult` | `client/result.rs` | Structured, transport-free outcome; an `Error` variant keeps a dead daemon renderable (never a panic). |
+| Catalog | `CommandSpec` | `client/catalog/` (`mod.rs` + `sm_tools.rs`) | The authoritative verb registry (§3). |
+| Resolver | `resolve_target` | `client/resolver.rs` | The one fuzzy-reference resolver (§4). |
+
+**Invariant — adapters are thin.** An adapter parses its native input into a
+`TrustyCommand`, calls `execute`, and renders the `CommandResult`. It embeds **no** HTTP
+logic and **no** resolution precedence. A new daemon endpoint is wired into the nucleus
+exactly once and every adapter gains it for free.
+
+## 3. Catalog as single source of truth {#SPEC-CHAT-CORE-01-catalog}
+
+The `catalog` module is the **one** structured description of the verb surface. Every
+`CommandSpec` carries a canonical `name`, `aliases`, an `args` sketch, a one-line
+`summary`, and a `SpecKind` tying it to the typed command surface (`Command` =
+dispatchable; `SmOnly` = SM-prompt-only memory/goals verbs).
+
+Two renderings derive from the same registry, so they can never drift:
+
+- **`help_text()`** renders the operator `/help` body from the `Command` entries. The
+  `command::help_text()` shim delegates here, so the help and the dispatch table can
+  never disagree.
+- **`render_sm_tools()`** renders the `SM_TOOLS.md` prompt section (the three verb
+  tables — session control, memory, goals) from the catalog.
+
+**Chosen mechanism — option (b): committed rendering + parity test.** `SM_TOOLS.md` is
+kept as a committed asset (so the SM prompt assembly stays a zero-cost `include_str!`
+with no runtime allocation, and the prompt-override layering in `core::sm::prompt` is
+unchanged). The unit test `catalog::sm_tools::tests::sm_tools_md_matches_catalog_render` asserts
+the committed file is **byte-identical** to `render_sm_tools()`. If a verb changes in the
+catalog without regenerating the asset (or vice versa), the test fails — so the prompt
+and the code can never silently drift. The catalog is authoritative: to change the SM
+tool surface, edit the catalog and regenerate the asset; the test enforces it.
+
+> Option (a) — generating the prompt section from the catalog at use time — was rejected
+> only to avoid touching the audited `core::sm::prompt` assembly/override floor and to
+> keep prompt assembly allocation-free. The parity test gives option (b) the same
+> no-drift guarantee.
+
+## 4. The resolver contract {#SPEC-CHAT-CORE-01-resolver}
+
+`resolve_target<T: Resolvable>(items, query) -> Option<&T>` is the **one** fuzzy-reference
+resolver. `Resolvable` exposes `id_matches(query)` (a predicate, so a UUID newtype
+compares in place without allocating) and `resolve_name()`. Precedence is fixed:
+
+1. **id-exact** — the first item whose id equals `query`.
+2. **name-exact** — the first item whose friendly name equals `query`.
+3. **unambiguous name-prefix** — the prefix match **only when exactly one** item's
+   non-empty name starts with `query`. An ambiguous prefix (≥2 matches) resolves to
+   `None` — a UI never silently picks the wrong session. An empty `query` never matches.
+
+The trait is implemented for both `SessionRow` (project sessions) and
+`ManagedSessionSummary` (managed sessions), so one precedence definition serves both
+families. The executor's project-session `resolve_session` and the managed verbs both
+delegate here.
+
+**Phasing note.** Phase 1A provides the canonical resolver and adopts it inside the
+executor. The CLI's `classify_managed_target` / `resolve_managed_id` / `resolve_session_id`
+resolvers adopt it in **Phase 1B** — they are intentionally untouched in 1A.
+
+## 5. The verb surface {#SPEC-CHAT-CORE-01-verbs}
+
+`TrustyCommand` covers the full managed verb set so any adapter can express every
+operation, alongside the retained project-session/pairing/overseer family:
+
+| Verb (command) | `TrustyCommand` | `DaemonClient` method | `SessionControl` alignment |
+|----------------|-----------------|-----------------------|----------------------------|
+| `managed-new` / `spawn` | `ManagedNew` | `spawn_managed_session` | `sessions.launch` |
+| `managed-list` | `ManagedList` | `list_managed_sessions` | `sessions.list` |
+| `managed-get` | `ManagedGet` | `get_managed_session` | `sessions.get` |
+| `managed-send` | `ManagedSend` | `send_to_managed_session` | `sessions.send` |
+| `managed-answer` | `ManagedAnswer` | `answer_managed_session` | `sessions.send` (decision) |
+| `managed-activity` | `ManagedActivity` | `managed_session_activity` | `sessions.get` (observe) |
+| `managed-attach` | `ManagedAttachCmd` | `managed_session_attach_cmd` | — |
+| `managed-stop` | `ManagedRuntimeStop` | `runtime_stop_managed_session` | `sessions.stop` |
+| `managed-resume` | `ManagedResume` | `resume_managed_session` | `sessions.resume` |
+| `managed-decommission` | `ManagedDecommission` | `decommission_managed_session` | `sessions.kill` |
+
+### 5.1 Decision-answer correctness {#SPEC-CHAT-CORE-01-decision}
+
+A managed session's decision is answered through the **real**
+`POST /api/v1/sessions/managed/{id}/answer` endpoint (`answer_managed_session`), **not** a
+synthetic `PostToolUse` hook. The former synthetic-hook path in `decide()` was a
+correctness gap: it audited a decision the harness never actually received, so the
+session stayed blocked. Now:
+
+- `ManagedAnswer { target, answer }` posts the answer directly to the answer endpoint.
+- `/approve` / `/deny` (the `Approve`/`Deny` commands the Telegram bot uses) resolve the
+  target against the managed list first; on a match they answer via the real endpoint
+  (approve → the session's `proposed_default`, else `"yes"`; deny → `"no"`). The Telegram
+  surface transparently gets the corrected behavior — its `TrustyCommand`/`CommandResult`
+  contract is unchanged. A non-managed project session keeps its lightweight
+  existence-check-and-acknowledge behavior (there is no managed decision to answer), with
+  the synthetic hook removed entirely.
+
+## 6. Planned adapter rollout {#SPEC-CHAT-CORE-01-rollout}
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| **1A** | Build the nucleus: full `TrustyCommand` verb set, canonical `resolve_target`, executor split (`sessions`/`managed`/`pairing`), real decision-answer, catalog SoT + parity test. **Telegram keeps working unchanged.** | This spec / PR |
+| **1B** | Route the `tm` CLI (`bin/tm/commands/managed.rs`, `session.rs`) through chat-core; adopt `resolve_target` at those call sites. | Planned |
+| **1C** | Wire the TUI (STUI) slash-dispatch through `CommandExecutor`. | Planned |
+| **2** | Make the HTTP `/api/v1/sessions/chat` endpoint action-capable; Web adapter. | Planned |
+| **future** | Slack adapter (peer of TUI/TELUI per DOC-18 §ONB-3). | Planned |
+
+Each adapter is a thin presentation/control layer over the **same** nucleus; none
+re-implements the session-manager engine, the inference layer, or the lifecycle logic.
+
+## 7. Non-goals (Phase 1A)
+
+- Rewiring the `tm` CLI resolvers (1B) or the TUI slash-dispatch (1C).
+- Making `/api/v1/sessions/chat` action-capable (Phase 2).
+- Any change to the SM prompt **content** — `SM_TOOLS.md` is byte-identical to its prior
+  text; only its provenance (catalog-rendered, parity-tested) changes.


### PR DESCRIPTION
## Summary
Phase 1A of the **shared chat-core** effort: consolidates the session-manager command surface into one UI-agnostic base library in `src/client/`, so every adapter (CLI, TUI, TELUI/Telegram, future Web/Slack) dispatches through the same layer instead of re-implementing it. Builds directly on the typed `DaemonClient` (PR #1491). Design spec: `docs/specs/chat-core.md`.

## Changes
- **`TrustyCommand`** expanded to the full managed verb set (spawn/list/get/send/answer/activity/attach/runtime-stop/resume/decommission) alongside existing pairing/overseer variants.
- **Single canonical `resolve_target`** (`client/resolver.rs`) with a `Resolvable` trait impl'd for both `SessionRow` and `ManagedSessionSummary` — id-exact / name-exact / name-prefix precedence. The executor's resolver now delegates to it. (CLI/TUI duplicate resolvers are intentionally left for Phase 1B.)
- **`CommandExecutor` split** out of an over-cap single file into `executor/{mod (facade),sessions,managed,pairing}.rs`; dispatch implemented for every managed verb via the typed `DaemonClient` methods.
- **Decision correctness fix**: `/approve`/`/deny`-style decisions now call the REAL `DaemonClient::answer_managed_session` endpoint instead of a fire-and-forget synthetic `PostToolUse` hook that never unblocked the harness. Telegram transparently inherits the fix.
- **Command catalog as single source of truth** (`client/catalog/`): a `CommandSpec` registry drives both `help_text()` and the SM prompt's tool list. `SM_TOOLS.md` is kept as a committed `include_str!` asset, guarded by a byte-parity unit test against the catalog render so they can never drift. `SM_TOOLS.md` is byte-unchanged (no SM-prompt regression).
- `docs/specs/chat-core.md` design spec added.
- `telegram/formatter/mod.rs` updated to render the new `CommandResult` variants.

## Out of scope (later phases)
- Routing the `tm` CLI through chat-core (Phase 1B).
- Wiring the STUI slash-dispatch (Phase 1C).
- Making HTTP `/api/v1/sessions/chat` action-capable (Phase 2).
CLI and TUI are untouched and behave exactly as before.

## Verification
- `cargo build -p trusty-mpm` ✓
- `cargo test -p trusty-mpm` ✓ (1552 passed, 0 failed, 1 ignored; Telegram + SM suites green)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓
- `bash scripts/check_line_cap.sh` ✓ (0 violations; executor split keeps every file under cap)

Refs #1283, #1433, #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)