### PR TITLE
feat(trusty-mpm): action-capable coordinator chat — self-aware inline verb execution

### DIFF
--- a/crates/trusty-mpm/src/client/catalog/mod.rs
+++ b/crates/trusty-mpm/src/client/catalog/mod.rs
@@ -22,7 +22,7 @@ use std::sync::OnceLock;
 
 mod sm_tools;
 
-pub use sm_tools::render_sm_tools;
+pub use sm_tools::{render_sm_tools, sm_session_verbs};
 
 /// How a catalog entry relates to the typed [`TrustyCommand`] surface.
 ///
@@ -81,7 +81,7 @@ impl CommandSpec {
     /// What: renders `name(args)`; an empty `args` yields `name()`. Operator-facing
     /// angle brackets (`<id>`) are stripped so the prompt reads as a method call.
     /// Test: `sm_tools_md_matches_catalog_render`, `prompt_signature_renders_callable_verbs`.
-    pub(super) fn prompt_signature(&self) -> String {
+    pub fn prompt_signature(&self) -> String {
         if self.args.is_empty() {
             format!("{}()", self.name)
         } else {

--- a/crates/trusty-mpm/src/client/catalog/sm_tools.rs
+++ b/crates/trusty-mpm/src/client/catalog/sm_tools.rs
@@ -123,6 +123,25 @@ const SM_GOAL_VERBS: &[CommandSpec] = &[
     },
 ];
 
+/// The SM session-control verbs, exposed as the action-loop's verb catalog.
+///
+/// Why: the action-capable coordinator chat (#1283) advertises the inline verb
+/// surface in its prompt and maps each chosen verb onto a `SessionControl`
+/// method. Both the advertised list AND the executable mapping must stay driven
+/// by this single catalog slice so a new verb is described in exactly one place
+/// and the prompt can never advertise a verb the loop cannot execute (or omit one
+/// it can). Re-exporting the SAME slice that renders the `SM_TOOLS.md` table keeps
+/// the chat-action prompt and the SM-STDIO tool table aligned.
+/// What: returns the [`SM_SESSION_VERBS`] slice — `sessions.launch`,
+/// `sessions.list`, `sessions.get`, `sessions.send`, `sessions.stop`,
+/// `sessions.resume`, `sessions.kill` — each carrying its callable signature via
+/// [`CommandSpec::prompt_signature`].
+/// Test: `sm_session_verbs_exposes_catalog_slice` (this module);
+/// `chat_action.rs` tests assert the rendered prompt lists these verbs.
+pub fn sm_session_verbs() -> &'static [CommandSpec] {
+    SM_SESSION_VERBS
+}
+
 /// Render one prompt-table row for a [`CommandSpec`].
 fn render_table_row(spec: &CommandSpec) -> String {
     format!("| `{}` | {} |", spec.prompt_signature(), spec.summary)
@@ -235,6 +254,25 @@ mod tests {
             "SM_TOOLS.md is out of sync with catalog::render_sm_tools(); \
              regenerate it (the catalog is authoritative)"
         );
+    }
+
+    #[test]
+    fn sm_session_verbs_exposes_catalog_slice() {
+        // The action-loop verb catalog must be the SAME slice that renders the
+        // SM_TOOLS.md session-control table — one source of truth for the
+        // advertised AND executable verb surface.
+        let names: Vec<&str> = sm_session_verbs().iter().map(|c| c.name).collect();
+        for expected in [
+            "sessions.launch",
+            "sessions.list",
+            "sessions.get",
+            "sessions.send",
+            "sessions.stop",
+            "sessions.resume",
+            "sessions.kill",
+        ] {
+            assert!(names.contains(&expected), "missing SM verb `{expected}`");
+        }
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/sm/agent/chat.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat.rs
@@ -244,7 +244,7 @@ impl SessionManagerAgent {
     /// lost. A persistence error (disk) propagates as [`SmAgentError::Context`].
     /// Test: `chat_tests.rs::chat_records_round`,
     /// `chat_records_round_when_no_provider_for_compaction`.
-    async fn record_round(
+    pub(super) async fn record_round(
         &self,
         runtime: &super::AgentRuntime,
         engine: &mut SmContextEngine,
@@ -343,7 +343,7 @@ pub(crate) fn degraded_notice() -> String {
 /// other variant → [`SmAgentError::Inference`].
 /// Test: `chat_tests.rs::chat_without_provider_is_degraded`,
 /// `chat_unknown_provider_is_inference_error`.
-fn map_resolve_error(err: SmLlmError) -> SmAgentError {
+pub(super) fn map_resolve_error(err: SmLlmError) -> SmAgentError {
     if err.is_degraded() {
         SmAgentError::Degraded(degraded_notice())
     } else {

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action.rs
@@ -1,0 +1,274 @@
+//! The action-capable SM chat turn: inline verb execution within one turn (#1283).
+//!
+//! Why: Phase 2 makes the coordinator chat ACTION-CAPABLE. The text-only
+//! [`chat`](super::chat) turn relays a single reply; this turn lets the SM
+//! INVOKE managed-session verbs INLINE — a synchronous read→decide→execute→
+//! feed-back→answer loop — so the operator can say "stop the stuck session" and
+//! the SM actually does it within the turn. It is deliberately SEPARATE from the
+//! goal-shaped background delegation of [`super::delegate`] (which launches
+//! sessions and returns a tracking outcome): here verbs run NOW, in-process,
+//! against the injected [`SessionControl`], and their results steer the next
+//! step. Keeping the loop in its own file (the parse/prompt/dispatch helpers live
+//! in [`super::chat_action_protocol`]) keeps every file under the SLOC cap.
+//! What: [`SmChatActionOutcome`] (reply + conv_id + cost + the human-readable
+//! list of verbs invoked) and the `impl` block adding
+//! [`super::SessionManagerAgent::chat_with_actions`] — the bounded loop that
+//! composes the §7.5 working prompt + the action-instruction block, calls the
+//! orchestration provider, parses each reply into a verb-call or a final answer,
+//! executes verbs against the control surface, accumulates a transcript, and
+//! terminates on a final answer or the max-iteration guard.
+//! Test: `chat_action_tests.rs` — one-verb-then-final, the max-iteration guard,
+//! the prose-fallback (no verb), and degraded provider.
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::core::sm::context::SmContextEngine;
+use crate::core::sm::control::SessionControl;
+use crate::core::sm::prompt::resolve_sm_prompt_default;
+use crate::core::sm::providers::{ChatMessage, LlmRequest, SmModelTier};
+
+use super::SessionManagerAgent;
+use super::chat::{SmAgentError, degraded_notice, map_resolve_error};
+use super::chat_action_protocol::{Decided, action_instructions, execute_verb, parse_action};
+
+/// Hard ceiling on action-loop iterations within ONE chat turn (#1283 safety).
+///
+/// Why: the loop runs inside the HTTP handler; an unbounded read→act loop could
+/// spin forever (a model that always emits a verb-call). A small ceiling bounds
+/// the turn's cost and latency while leaving ample room for a multi-step
+/// observe→act→answer sequence.
+/// What: when the loop reaches this many provider calls without a final answer,
+/// it forces a final-answer synthesis instead of calling another verb.
+/// Test: `chat_action_tests.rs::max_iterations_guard_terminates`.
+const MAX_ACTION_ITERATIONS: usize = 8;
+
+/// Generation cap for one action-loop reply (mirrors the chat turn's ceiling).
+const ACTION_MAX_TOKENS: u32 = 4_096;
+
+/// The result of one action-capable SM chat turn (#1283).
+///
+/// Why: the endpoint needs the reply, the conversation id (so a follow-up can
+/// continue the rolling context), the summed per-turn cost (every provider call
+/// in the loop), AND an audit trail of which verbs actually executed — the safety
+/// requirement that the operator can always see what the SM did on their behalf.
+/// What: `reply` is the final operator-facing text; `conv_id` is the (possibly
+/// minted) conversation id; `cost_usd` sums every `complete()` call this turn;
+/// `actions_taken` lists each invoked verb in order (e.g. `["sessions.list",
+/// "sessions.send abc123"]`).
+/// Test: `chat_action_tests.rs::loop_executes_verb_then_answers`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SmChatActionOutcome {
+    /// The assistant's final reply text.
+    pub reply: String,
+    /// The conversation id this turn used (echoed so callers can continue it).
+    pub conv_id: String,
+    /// Summed estimated USD cost of every provider call in the loop (§5.5).
+    pub cost_usd: f64,
+    /// Human-readable list of the verbs invoked this turn, in order.
+    pub actions_taken: Vec<String>,
+}
+
+impl SessionManagerAgent {
+    /// Drive one ACTION-CAPABLE SM chat turn: invoke verbs inline, then answer.
+    ///
+    /// Why: this is Phase 2's headline deliverable — a self-aware chat turn that
+    /// knows the managed-session verb catalog and can EXECUTE those verbs inline
+    /// (read→decide→execute→feed-back→answer), as opposed to the text-only
+    /// [`chat`](super::chat) path. Verbs run IN-PROCESS through the injected
+    /// `control` (never over HTTP back to the daemon), so there is no loopback.
+    /// What: (1) resolves the conversation id; (2) opens the per-`conv_id`
+    /// [`SmContextEngine`]; (3) recalls SM-palace memory; (4) composes the working
+    /// prompt = SM system prompt + the [`action_instructions`] block (verb list
+    /// rendered from the catalog SoT) + the engine's §7.5 context + the message;
+    /// (5) loops up to [`MAX_ACTION_ITERATIONS`]: call the orchestration provider,
+    /// [`parse_action`] the reply, and on a verb-call [`execute_verb`] against
+    /// `control` and append a `(verb-call → result)` pair to a per-turn transcript
+    /// that is fed back as the next user turn; (6) on a final answer (or when the
+    /// guard trips) records the round and returns the reply, conv_id, summed cost,
+    /// and the audited `actions_taken`. With no runtime (the inert agent) returns
+    /// [`SmAgentError::Degraded`].
+    /// Test: `chat_action_tests.rs` — verb-then-final, the max-iter guard,
+    /// prose-fallback, and degraded.
+    pub async fn chat_with_actions(
+        &self,
+        message: &str,
+        conv_id: Option<&str>,
+        control: &Arc<dyn SessionControl>,
+    ) -> Result<SmChatActionOutcome, SmAgentError> {
+        let Some(runtime) = self.runtime_ref() else {
+            return Err(SmAgentError::Degraded(degraded_notice()));
+        };
+
+        let conv_id = conv_id
+            .filter(|c| !c.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+        let inference = &self.config().inference;
+        let rounds = &self.config().rounds;
+
+        let mut engine = SmContextEngine::open(&conv_id, &runtime.data_root, inference, rounds)?;
+
+        // System prompt = the SM identity/floor + the inline-action instructions
+        // (verb surface rendered from the catalog single source of truth).
+        let system_prompt = format!(
+            "{}\n\n---\n\n{}",
+            resolve_sm_prompt_default(),
+            action_instructions()
+        );
+
+        let recall = self.delegate_recall(runtime, message).await;
+
+        // Assemble the §7.5 base prompt once; the per-iteration transcript is
+        // appended as a trailing synthetic user turn so the model always sees the
+        // verb results it has gathered so far this turn.
+        let base = engine.assemble_working_prompt(&system_prompt, recall.as_deref(), message);
+        let (system, base_turns) = split_system_message(base);
+
+        let mut transcript: Vec<String> = Vec::new();
+        let mut actions_taken: Vec<String> = Vec::new();
+        let mut total_cost = 0.0_f64;
+        let mut final_reply: Option<String> = None;
+
+        for iteration in 0..MAX_ACTION_ITERATIONS {
+            let mut turns = base_turns.clone();
+            if !transcript.is_empty() {
+                turns.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: format!(
+                        "Verb results so far this turn:\n{}\n\nDecide your next action \
+                         (call another verb, or give your final answer).",
+                        transcript.join("\n")
+                    ),
+                });
+            }
+            // The last allowed iteration must produce an answer, not another verb —
+            // tell the model to stop calling verbs so the guard yields a real reply.
+            if iteration + 1 == MAX_ACTION_ITERATIONS {
+                turns.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: "You have reached the action limit for this turn. Do NOT \
+                              call another verb — reply now with the `final` answer shape."
+                        .to_string(),
+                });
+            }
+
+            let resolved = runtime
+                .resolver
+                .resolve(inference, SmModelTier::Orchestration)
+                .await
+                .map_err(map_resolve_error)?;
+            let req = LlmRequest {
+                model: resolved.model.clone(),
+                system: system.clone(),
+                messages: turns,
+                temperature: inference.temperature,
+                max_tokens: ACTION_MAX_TOKENS,
+            };
+            let response = resolved
+                .provider
+                .complete(req)
+                .await
+                .map_err(SmAgentError::Inference)?;
+            total_cost += response.cost_usd;
+
+            match parse_action(&response.text) {
+                Decided::Final { message } => {
+                    final_reply = Some(message);
+                    break;
+                }
+                Decided::Verb { verb, args } => {
+                    let (label, result_line) = run_one_verb(control, &verb, &args).await;
+                    actions_taken.push(label);
+                    transcript.push(result_line);
+                }
+            }
+        }
+
+        // The guard guarantees a final answer on the last iteration; if the model
+        // still failed to produce one, synthesize a transcript summary rather than
+        // spin or panic.
+        let reply = final_reply.unwrap_or_else(|| forced_summary(&transcript));
+
+        // Record the round (message + final reply) so the action turn persists
+        // exactly like the text-only chat turn (data-integrity invariant).
+        self.record_round(runtime, &mut engine, message, &reply)
+            .await?;
+
+        Ok(SmChatActionOutcome {
+            reply,
+            conv_id,
+            cost_usd: total_cost,
+            actions_taken,
+        })
+    }
+}
+
+/// Execute one verb and render its `(audit label, transcript line)` pair.
+///
+/// Why: keeps the loop body terse and gives the verb-result rendering — both the
+/// human-readable `actions_taken` label and the JSON line fed back to the model —
+/// one home. A verb error is NOT fatal: it is fed back to the model (so it can
+/// recover or answer) and recorded in the audit trail, never panicking.
+/// What: runs [`execute_verb`]; on success returns `(label, "<verb> -> <json>")`;
+/// on error returns `(label, "<verb> -> error: <e>")`. The label appends the
+/// session id (when present in args) so the operator sees the target.
+/// Test: `chat_action_tests.rs::loop_executes_verb_then_answers`,
+/// `verb_error_is_fed_back_not_fatal`.
+async fn run_one_verb(
+    control: &Arc<dyn SessionControl>,
+    verb: &str,
+    args: &serde_json::Value,
+) -> (String, String) {
+    let label = match args.get("session_id").and_then(|v| v.as_str()) {
+        Some(id) if !id.trim().is_empty() => format!("{verb} {id}"),
+        _ => verb.to_string(),
+    };
+    match execute_verb(control, verb, args).await {
+        Ok(result) => (label, format!("{verb} -> {result}")),
+        Err(e) => (label, format!("{verb} -> error: {e}")),
+    }
+}
+
+/// Synthesize a final reply from the transcript when the model produced none.
+///
+/// Why: the max-iteration guard must ALWAYS yield an operator-facing reply — even
+/// in the pathological case where the model never emits a `final` shape — rather
+/// than returning an empty string or spinning.
+/// What: returns a short note plus the accumulated verb transcript (or a generic
+/// "no actions" note when the transcript is empty).
+/// Test: `chat_action_tests.rs::max_iterations_guard_terminates`.
+fn forced_summary(transcript: &[String]) -> String {
+    if transcript.is_empty() {
+        "I reached the action limit for this turn without completing the request.".to_string()
+    } else {
+        format!(
+            "I reached the action limit for this turn. Here is what I did:\n{}",
+            transcript.join("\n")
+        )
+    }
+}
+
+/// Split the assembled §7.5 messages into the out-of-band system string and turns.
+///
+/// Why: [`SmContextEngine::assemble_working_prompt`] consolidates the system
+/// sections into ONE leading `system`-role message, but [`LlmRequest`] carries
+/// the system prompt as a dedicated field. This adapts one shape to the other
+/// (the same split the text-only chat turn performs).
+/// What: if the first message is `system`-role, returns `(its content, the rest)`;
+/// otherwise `(String::new(), all messages)`.
+/// Test: covered via the loop tests (the mock asserts the system prompt).
+fn split_system_message(mut messages: Vec<ChatMessage>) -> (String, Vec<ChatMessage>) {
+    if messages.first().is_some_and(|m| m.role == "system") {
+        let system = messages.remove(0).content;
+        (system, messages)
+    } else {
+        (String::new(), messages)
+    }
+}
+
+#[cfg(test)]
+#[path = "chat_action_loop_tests.rs"]
+mod chat_action_loop_tests;

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action.rs
@@ -47,6 +47,18 @@ const MAX_ACTION_ITERATIONS: usize = 8;
 /// Generation cap for one action-loop reply (mirrors the chat turn's ceiling).
 const ACTION_MAX_TOKENS: u32 = 4_096;
 
+/// Max chars of a single verb result rendered into the fed-back transcript.
+///
+/// Why: a verb result (e.g. a large `sessions.list`) is embedded raw into the
+/// transcript line that is fed back to the model on the next iteration. An
+/// unbounded result would grow the prompt on every iteration and can overflow the
+/// model's context window. Capping each rendered result bounds total transcript
+/// growth to `MAX_ACTION_ITERATIONS × ACTION_RESULT_MAX_CHARS`.
+/// What: results longer than this are truncated on a char boundary with a clear
+/// `… [truncated N chars]` marker appended.
+/// Test: `chat_action_loop_tests.rs::large_verb_result_is_truncated`.
+const ACTION_RESULT_MAX_CHARS: usize = 2_000;
+
 /// The result of one action-capable SM chat turn (#1283).
 ///
 /// Why: the endpoint needs the reply, the conversation id (so a follow-up can
@@ -133,6 +145,8 @@ impl SessionManagerAgent {
         let mut final_reply: Option<String> = None;
 
         for iteration in 0..MAX_ACTION_ITERATIONS {
+            let is_final_iteration = iteration + 1 == MAX_ACTION_ITERATIONS;
+
             let mut turns = base_turns.clone();
             if !transcript.is_empty() {
                 turns.push(ChatMessage {
@@ -144,9 +158,11 @@ impl SessionManagerAgent {
                     ),
                 });
             }
-            // The last allowed iteration must produce an answer, not another verb —
-            // tell the model to stop calling verbs so the guard yields a real reply.
-            if iteration + 1 == MAX_ACTION_ITERATIONS {
+            // On the last allowed iteration, tell the model to stop calling verbs so
+            // it has the chance to yield a real `final` reply. This is only a HINT —
+            // a misbehaving model may still emit a verb-call, which is handled below
+            // by NOT executing it (see the `is_final_iteration` branch).
+            if is_final_iteration {
                 turns.push(ChatMessage {
                     role: "user".to_string(),
                     content: "You have reached the action limit for this turn. Do NOT \
@@ -180,6 +196,14 @@ impl SessionManagerAgent {
                     break;
                 }
                 Decided::Verb { verb, args } => {
+                    // The action cap is HARD: on the final iteration we must NOT
+                    // execute another verb (that would run one step beyond the cap).
+                    // A verb-call here means the model ignored the stop-hint, so we
+                    // break to the forced-summary path without executing it — the cap
+                    // bounds verbs at exactly MAX_ACTION_ITERATIONS - 1 executions.
+                    if is_final_iteration {
+                        break;
+                    }
                     let (label, result_line) = run_one_verb(control, &verb, &args).await;
                     actions_taken.push(label);
                     transcript.push(result_line);
@@ -187,9 +211,10 @@ impl SessionManagerAgent {
             }
         }
 
-        // The guard guarantees a final answer on the last iteration; if the model
-        // still failed to produce one, synthesize a transcript summary rather than
-        // spin or panic.
+        // If the loop ended without a `final` answer — either the model never
+        // emitted one, or it emitted a verb-call on the capped final iteration
+        // (which we refuse to execute) — synthesize a transcript summary rather than
+        // spin or panic. This ALWAYS yields an operator-facing reply.
         let reply = final_reply.unwrap_or_else(|| forced_summary(&transcript));
 
         // Record the round (message + final reply) so the action turn persists
@@ -213,10 +238,12 @@ impl SessionManagerAgent {
 /// one home. A verb error is NOT fatal: it is fed back to the model (so it can
 /// recover or answer) and recorded in the audit trail, never panicking.
 /// What: runs [`execute_verb`]; on success returns `(label, "<verb> -> <json>")`;
-/// on error returns `(label, "<verb> -> error: <e>")`. The label appends the
-/// session id (when present in args) so the operator sees the target.
+/// on error returns `(label, "<verb> -> error: <e>")`. The rendered result is
+/// bounded by [`truncate_result`] so a large verb output cannot grow the prompt
+/// unbounded. The label appends the session id (when present in args) so the
+/// operator sees the target.
 /// Test: `chat_action_tests.rs::loop_executes_verb_then_answers`,
-/// `verb_error_is_fed_back_not_fatal`.
+/// `chat_action_loop_tests.rs::large_verb_result_is_truncated`.
 async fn run_one_verb(
     control: &Arc<dyn SessionControl>,
     verb: &str,
@@ -227,9 +254,36 @@ async fn run_one_verb(
         _ => verb.to_string(),
     };
     match execute_verb(control, verb, args).await {
-        Ok(result) => (label, format!("{verb} -> {result}")),
-        Err(e) => (label, format!("{verb} -> error: {e}")),
+        Ok(result) => (
+            label,
+            format!("{verb} -> {}", truncate_result(&result.to_string())),
+        ),
+        Err(e) => (
+            label,
+            format!("{verb} -> error: {}", truncate_result(&e.to_string())),
+        ),
     }
+}
+
+/// Bound a rendered verb result to [`ACTION_RESULT_MAX_CHARS`] on a char boundary.
+///
+/// Why: each verb result is fed back into the next iteration's prompt; without a
+/// cap a single large result (a long `sessions.list`) grows the prompt unbounded
+/// and can overflow the model's context window on later iterations.
+/// What: returns `rendered` unchanged when it is within the cap; otherwise returns
+/// the first [`ACTION_RESULT_MAX_CHARS`] characters (split on a char boundary so
+/// multibyte input never panics) followed by a `… [truncated N chars]` marker
+/// where `N` is the number of characters dropped.
+/// Test: `chat_action_loop_tests.rs::large_verb_result_is_truncated`,
+/// `truncate_result_keeps_short_input` and `truncate_result_is_char_safe`.
+fn truncate_result(rendered: &str) -> String {
+    let total = rendered.chars().count();
+    if total <= ACTION_RESULT_MAX_CHARS {
+        return rendered.to_string();
+    }
+    let kept: String = rendered.chars().take(ACTION_RESULT_MAX_CHARS).collect();
+    let dropped = total - ACTION_RESULT_MAX_CHARS;
+    format!("{kept}… [truncated {dropped} chars]")
 }
 
 /// Synthesize a final reply from the transcript when the model produced none.

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_loop_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_loop_tests.rs
@@ -1,0 +1,287 @@
+//! Acceptance tests for the action-capable SM chat loop (#1283).
+//!
+//! Why: Phase 2's headline behaviours must be pinned deterministically with NO
+//! network and NO real session: a turn where the model calls one verb then
+//! answers must actually execute the verb (the mock control records it), list it
+//! in `actions_taken`, and return the final text; the max-iteration guard must
+//! terminate a model that always calls a verb; plain prose must be the final
+//! answer with no verb executed; and a degraded provider must surface the
+//! degraded error. These tests use a SCRIPTED mock provider (a per-call reply
+//! queue) + the recording `MockSessionControl` + the `MockResolver`.
+//! What: drives [`SessionManagerAgent::chat_with_actions`] over a tempdir and
+//! asserts the outcome + the mock control's recorded calls.
+//! Test: this is the test module.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tempfile::TempDir;
+
+use crate::core::sm::agent::SessionManagerAgent;
+use crate::core::sm::agent::delegate::mock_control::MockSessionControl;
+use crate::core::sm::config::{SessionManagerConfig, SmInferenceConfig};
+use crate::core::sm::control::SessionControl;
+use crate::core::sm::providers::{
+    LlmProvider, LlmRequest, LlmResponse, ProviderKind, ResolvedCall, SmLlmError, SmModelTier,
+    TierResolver, resolve_tier_model,
+};
+
+/// A scripted, recording mock provider: returns a queued reply per `complete`.
+///
+/// Why: the action loop calls the provider once per iteration; a test must script
+/// a DIFFERENT reply per call (e.g. a verb-call, then a final answer) and assert
+/// how many calls happened. `MockChatProvider` only returns a fixed reply, so the
+/// loop tests need this per-call queue.
+/// What: holds a `VecDeque` of canned reply texts; each `complete` pops the front
+/// (or repeats the last when exhausted, so an "always verb" script never starves
+/// the max-iter guard). Records the call count.
+struct ScriptedProvider {
+    replies: Mutex<VecDeque<String>>,
+    last: Mutex<String>,
+    calls: Mutex<usize>,
+}
+
+impl ScriptedProvider {
+    fn new(replies: impl IntoIterator<Item = &'static str>) -> Self {
+        let q: VecDeque<String> = replies.into_iter().map(str::to_string).collect();
+        let last = q.back().cloned().unwrap_or_default();
+        Self {
+            replies: Mutex::new(q),
+            last: Mutex::new(last),
+            calls: Mutex::new(0),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        *self.calls.lock().unwrap()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ScriptedProvider {
+    fn name(&self) -> &str {
+        "scripted"
+    }
+
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError> {
+        *self.calls.lock().unwrap() += 1;
+        let text = {
+            let mut q = self.replies.lock().unwrap();
+            match q.pop_front() {
+                Some(t) => {
+                    *self.last.lock().unwrap() = t.clone();
+                    t
+                }
+                None => self.last.lock().unwrap().clone(),
+            }
+        };
+        Ok(LlmResponse {
+            text,
+            model: req.model,
+            input_tokens: 1,
+            output_tokens: 1,
+            latency_ms: 1,
+            cost_usd: 0.001,
+        })
+    }
+}
+
+/// A resolver that hands back a shared [`ScriptedProvider`] for every tier.
+struct ScriptedResolver {
+    provider: Arc<ScriptedProvider>,
+}
+
+#[async_trait]
+impl TierResolver for ScriptedResolver {
+    async fn resolve(
+        &self,
+        cfg: &SmInferenceConfig,
+        tier: SmModelTier,
+    ) -> Result<ResolvedCall, SmLlmError> {
+        let model = resolve_tier_model(cfg, tier)?;
+        Ok(ResolvedCall {
+            provider: self.provider.clone(),
+            model,
+            kind: ProviderKind::Anthropic,
+        })
+    }
+}
+
+/// A resolver that always reports degraded (no provider).
+struct DegradedResolver;
+
+#[async_trait]
+impl TierResolver for DegradedResolver {
+    async fn resolve(
+        &self,
+        _cfg: &SmInferenceConfig,
+        _tier: SmModelTier,
+    ) -> Result<ResolvedCall, SmLlmError> {
+        Err(SmLlmError::Degraded("mock: no provider".to_string()))
+    }
+}
+
+fn enabled_config() -> SessionManagerConfig {
+    SessionManagerConfig {
+        enabled: true,
+        ..SessionManagerConfig::default()
+    }
+}
+
+/// Build an action-capable agent over a scripted provider + a tempdir.
+fn agent_with(
+    replies: impl IntoIterator<Item = &'static str>,
+    data_root: &std::path::Path,
+) -> (SessionManagerAgent, Arc<ScriptedProvider>) {
+    let provider = Arc::new(ScriptedProvider::new(replies));
+    let resolver = Arc::new(ScriptedResolver {
+        provider: provider.clone(),
+    });
+    let agent = SessionManagerAgent::for_test(enabled_config(), resolver, data_root.to_path_buf());
+    (agent, provider)
+}
+
+/// Why: the headline acceptance — the model calls one verb (`sessions.list`),
+/// then answers; the verb must actually execute (mock records the call),
+/// `actions_taken` must list it, and `reply` must be the final text.
+/// What: scripts a verb-call then a final answer; asserts all three.
+/// Test: this is the test.
+#[tokio::test]
+async fn loop_executes_verb_then_answers() {
+    let tmp = TempDir::new().unwrap();
+    let (agent, provider) = agent_with(
+        [
+            r#"{"action":"sessions.list","args":{}}"#,
+            r#"{"action":"final","message":"you have no sessions"}"#,
+        ],
+        tmp.path(),
+    );
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+
+    let outcome = agent
+        .chat_with_actions("show my sessions", Some("c1"), &control)
+        .await
+        .expect("action turn succeeds");
+
+    assert_eq!(outcome.reply, "you have no sessions");
+    assert_eq!(outcome.conv_id, "c1");
+    assert_eq!(outcome.actions_taken, vec!["sessions.list".to_string()]);
+    // Two provider calls: one to decide the verb, one to produce the final answer.
+    assert_eq!(provider.call_count(), 2);
+    // Cost is summed across both calls.
+    assert!((outcome.cost_usd - 0.002).abs() < 1e-9);
+}
+
+/// Why: a `sessions.send` verb must reach the control with its id + text, and the
+/// audit label must carry the session id so the operator sees the target.
+/// What: scripts a send then a final; asserts the mock recorded the send and the
+/// label includes the id.
+/// Test: this is the test.
+#[tokio::test]
+async fn loop_send_records_target_and_label() {
+    let tmp = TempDir::new().unwrap();
+    let (agent, _p) = agent_with(
+        [
+            r#"{"action":"sessions.send","args":{"session_id":"abc123","text":"go"}}"#,
+            r#"{"action":"final","message":"sent"}"#,
+        ],
+        tmp.path(),
+    );
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+
+    let outcome = agent
+        .chat_with_actions("nudge it", None, &control)
+        .await
+        .expect("action turn succeeds");
+
+    assert_eq!(mock.sends(), vec![("abc123".to_string(), "go".to_string())]);
+    assert_eq!(
+        outcome.actions_taken,
+        vec!["sessions.send abc123".to_string()]
+    );
+}
+
+/// Why: the max-iteration guard must terminate a model that ALWAYS emits a verb-
+/// call — the loop must not spin unbounded inside the HTTP handler.
+/// What: scripts a single always-repeated verb-call (the queue repeats its last);
+/// asserts the loop terminates with a non-empty reply and a bounded call count.
+/// Test: this is the test.
+#[tokio::test]
+async fn max_iterations_guard_terminates() {
+    let tmp = TempDir::new().unwrap();
+    // Only ever a verb-call: the ScriptedProvider repeats it forever.
+    let (agent, provider) = agent_with([r#"{"action":"sessions.list","args":{}}"#], tmp.path());
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+
+    let outcome = agent
+        .chat_with_actions("loop please", Some("c2"), &control)
+        .await
+        .expect("guard terminates the loop");
+
+    // Bounded by MAX_ACTION_ITERATIONS (8): never unbounded.
+    assert!(
+        provider.call_count() <= 8,
+        "call count {} exceeded the guard",
+        provider.call_count()
+    );
+    assert!(!outcome.reply.is_empty(), "guard must yield a final reply");
+}
+
+/// Why: plain prose (no action JSON) must be treated as the final answer with NO
+/// verb executed — the always-safe terminal.
+/// What: scripts a prose reply; asserts no verb ran and the reply is the prose.
+/// Test: this is the test.
+#[tokio::test]
+async fn prose_reply_is_final_no_verb() {
+    let tmp = TempDir::new().unwrap();
+    let (agent, provider) = agent_with(["Everything is healthy, nothing to do."], tmp.path());
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+
+    let outcome = agent
+        .chat_with_actions("status?", Some("c3"), &control)
+        .await
+        .expect("prose answer succeeds");
+
+    assert_eq!(outcome.reply, "Everything is healthy, nothing to do.");
+    assert!(outcome.actions_taken.is_empty(), "no verb should run");
+    assert!(mock.sends().is_empty());
+    assert_eq!(provider.call_count(), 1);
+}
+
+/// Why: a degraded provider (no credentials) must surface as the degraded error
+/// so the endpoint can map it to a 503.
+/// What: builds an agent over a degraded resolver; asserts `Degraded`.
+/// Test: this is the test.
+#[tokio::test]
+async fn degraded_provider_surfaces_degraded() {
+    use crate::core::sm::SmAgentError;
+    let tmp = TempDir::new().unwrap();
+    let resolver = Arc::new(DegradedResolver);
+    let agent = SessionManagerAgent::for_test(enabled_config(), resolver, tmp.path().to_path_buf());
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+
+    let err = agent
+        .chat_with_actions("do a thing", None, &control)
+        .await
+        .expect_err("degraded provider errors");
+    assert!(matches!(err, SmAgentError::Degraded(_)));
+}
+
+/// Why: the inert agent (no runtime) must report degraded immediately — there is
+/// no provider.
+/// What: builds via `new` and asserts `chat_with_actions` is degraded.
+/// Test: this is the test.
+#[tokio::test]
+async fn inert_agent_is_degraded() {
+    use crate::core::sm::SmAgentError;
+    let agent = SessionManagerAgent::new(enabled_config());
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let err = agent
+        .chat_with_actions("hi", None, &control)
+        .await
+        .expect_err("inert agent is degraded");
+    assert!(matches!(err, SmAgentError::Degraded(_)));
+}

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_loop_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_loop_tests.rs
@@ -16,12 +16,16 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use serde_json::{Value, json};
 use tempfile::TempDir;
 
+use crate::activity::cache::ActivityState;
 use crate::core::sm::agent::SessionManagerAgent;
 use crate::core::sm::agent::delegate::mock_control::MockSessionControl;
 use crate::core::sm::config::{SessionManagerConfig, SmInferenceConfig};
-use crate::core::sm::control::SessionControl;
+use crate::core::sm::control::{
+    LaunchParams, RawObservation, SessionControl, SessionControlError, Submit, Summary,
+};
 use crate::core::sm::providers::{
     LlmProvider, LlmRequest, LlmResponse, ProviderKind, ResolvedCall, SmLlmError, SmModelTier,
     TierResolver, resolve_tier_model,
@@ -204,9 +208,15 @@ async fn loop_send_records_target_and_label() {
 }
 
 /// Why: the max-iteration guard must terminate a model that ALWAYS emits a verb-
-/// call — the loop must not spin unbounded inside the HTTP handler.
+/// call — the loop must not spin unbounded inside the HTTP handler — AND the cap
+/// is HARD: the capped final iteration must NOT execute one more verb (the bug the
+/// guard used to have). The transcript/audit must therefore grow on every
+/// non-final iteration and stop exactly at the cap, yet a final reply is still
+/// returned via the forced summary.
 /// What: scripts a single always-repeated verb-call (the queue repeats its last);
-/// asserts the loop terminates with a non-empty reply and a bounded call count.
+/// asserts the provider was called up to 8 times, that exactly 7 verbs executed
+/// (`MAX_ACTION_ITERATIONS - 1` — none on the final, capped iteration), and that a
+/// non-empty reply is still produced.
 /// Test: this is the test.
 #[tokio::test]
 async fn max_iterations_guard_terminates() {
@@ -225,6 +235,13 @@ async fn max_iterations_guard_terminates() {
         provider.call_count() <= 8,
         "call count {} exceeded the guard",
         provider.call_count()
+    );
+    // The cap is HARD: the final (8th) iteration's verb-call is NOT executed, so
+    // exactly 7 verbs ran. This proves actions_taken does NOT grow on the last step.
+    assert_eq!(
+        outcome.actions_taken.len(),
+        7,
+        "the capped final iteration must not execute an extra verb"
     );
     assert!(!outcome.reply.is_empty(), "guard must yield a final reply");
 }
@@ -284,4 +301,98 @@ async fn inert_agent_is_degraded() {
         .await
         .expect_err("inert agent is degraded");
     assert!(matches!(err, SmAgentError::Degraded(_)));
+}
+
+/// A mock [`SessionControl`] whose `list` returns a very large JSON result.
+///
+/// Why: FIX 2 — a large verb result must be truncated before it is fed back into
+/// the next iteration's prompt. Only `list` needs to be huge here; every other
+/// verb is unused by the truncation test.
+/// What: `list` returns a `{"blob": "<10k 'x'>"}` body; all other verbs return a
+/// trivial `ok`/empty result so the trait is satisfied.
+/// Test: `large_verb_result_is_truncated`.
+struct HugeListControl;
+
+#[async_trait]
+impl SessionControl for HugeListControl {
+    async fn launch(&self, _params: LaunchParams) -> Result<Value, SessionControlError> {
+        Ok(json!({ "session_id": "s-1" }))
+    }
+    async fn list(&self) -> Result<Value, SessionControlError> {
+        Ok(json!({ "blob": "x".repeat(10_000) }))
+    }
+    async fn get(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn send(&self, _session_id: &str, _text: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn stop(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn resume(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn kill(&self, _session_id: &str) -> Result<Value, SessionControlError> {
+        Ok(json!({ "ok": true }))
+    }
+    async fn inject_text(
+        &self,
+        _session_id: &str,
+        _text: &str,
+        _submit: Submit,
+    ) -> Result<(), SessionControlError> {
+        Ok(())
+    }
+    async fn observe(
+        &self,
+        _session_id: &str,
+        _lines: usize,
+    ) -> Result<RawObservation, SessionControlError> {
+        Ok(RawObservation {
+            raw_pane: String::new(),
+            runtime_active: true,
+            pending_decision: None,
+            proposed_default: None,
+        })
+    }
+    async fn summarize(&self, _session_id: &str) -> Result<Summary, SessionControlError> {
+        Ok(Summary {
+            state: ActivityState::Unknown,
+            summary: None,
+            confidence: 0.0,
+        })
+    }
+}
+
+/// Why: FIX 2 — a verb whose result is very large must NOT embed the raw result in
+/// the fed-back transcript; it must be truncated with a clear marker so the prompt
+/// cannot grow unbounded and overflow the context window.
+/// What: scripts an always-repeated `sessions.list` against [`HugeListControl`]
+/// (10k chars); the loop never gets a `final`, so the forced summary contains the
+/// transcript lines. Asserts the reply carries the `[truncated N chars]` marker and
+/// does NOT contain the full 10k-char blob.
+/// Test: this is the test.
+#[tokio::test]
+async fn large_verb_result_is_truncated() {
+    let tmp = TempDir::new().unwrap();
+    let (agent, _p) = agent_with([r#"{"action":"sessions.list","args":{}}"#], tmp.path());
+    let control: Arc<dyn SessionControl> = Arc::new(HugeListControl);
+
+    let outcome = agent
+        .chat_with_actions("dump everything", Some("c4"), &control)
+        .await
+        .expect("loop terminates via forced summary");
+
+    // The forced summary embeds the (truncated) transcript lines.
+    assert!(
+        outcome.reply.contains("[truncated"),
+        "expected a truncation marker in: {}",
+        outcome.reply
+    );
+    // The full 10k blob must never appear verbatim (it was capped well below 10k).
+    assert!(
+        !outcome.reply.contains(&"x".repeat(10_000)),
+        "the raw oversized result must not be embedded verbatim"
+    );
 }

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
@@ -222,7 +222,9 @@ fn next_balanced_object(text: &str, from: usize) -> Option<(String, usize)> {
             '"' => in_string = true,
             '{' => depth += 1,
             '}' => {
-                depth -= 1;
+                // `saturating_sub` defends against an unmatched `}` (depth already
+                // zero) underflowing `usize` in debug builds on pathological input.
+                depth = depth.saturating_sub(1);
                 if depth == 0 {
                     let end = start + offset + ch.len_utf8();
                     return Some((text[start..end].to_string(), end));

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
@@ -1,0 +1,383 @@
+//! The action-chat decision protocol: prompt surface, parse, and verb dispatch.
+//!
+//! Why: Phase 2 (#1283) makes the coordinator chat ACTION-CAPABLE — the SM may
+//! invoke managed-session verbs INLINE within one chat turn (a synchronous
+//! read→decide→execute→feed-back loop), not the goal-shaped background
+//! delegation of [`super::delegate`]. That loop needs three pieces kept apart
+//! from the loop driver itself (so each file stays under the SLOC cap): the
+//! structured-text decision shape the model emits, the lenient parser that turns
+//! the model's text into that shape, and the verb-name → [`SessionControl`]
+//! dispatch. They live here; [`super::chat_action`] owns the loop.
+//! What: [`ActionDecision`] (a verb-call or a final answer), [`parse_action`]
+//! (lenient JSON extraction reusing the balanced-brace style of
+//! [`super::delegate`]'s `parse_decision`, falling back to a final answer on any
+//! parse miss), [`action_instructions`] (the prompt block advertising the inline
+//! verb surface — its verb list rendered from the [`catalog`](crate::client::catalog)
+//! single source of truth, NOT hand-listed), and [`execute_verb`] (maps a chosen
+//! verb name onto the matching [`SessionControl`] method and returns its JSON).
+//! Test: `chat_action_tests.rs` — verb-call parse, final-answer parse, prose
+//! fallback, prompt lists every catalog verb, and each verb dispatches.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::client::catalog::sm_session_verbs;
+use crate::core::sm::control::{LaunchParams, SessionControl, SessionControlError};
+
+/// The sentinel `action` value the model emits to END the action loop.
+const FINAL_ACTION: &str = "final";
+
+/// One decision the SM emits per action-loop iteration (#1283).
+///
+/// Why: the text-only provider has no native tool calling, so the inline action
+/// loop is driven by a structured-text decision the model emits and the loop
+/// parses — exactly ONE of: call a managed-session verb (and feed its result
+/// back), or stop with a final operator-facing answer. Modelling it as one flat
+/// struct (`action` + optional `args`/`message`) avoids serde's tagged/untagged
+/// ambiguity and lets [`ActionDecision::classify`] decide verb-vs-final from the
+/// `action` value; anything unparseable degrades to the final answer (the
+/// always-safe terminal — the SM is talking, not acting).
+/// What: `action` is the verb name or the `"final"` sentinel; `args` carries a
+/// verb's arguments (ignored for `final`); `message` carries the final reply
+/// (ignored for a verb). [`ActionDecision::classify`] maps it to [`Decided`].
+/// Test: `chat_action_tests.rs::parse_verb_call`, `parse_final_answer`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionDecision {
+    /// The verb name (e.g. `sessions.list`) or the `"final"` sentinel.
+    pub action: String,
+    /// The verb's arguments (verb-specific; may be absent/empty).
+    #[serde(default)]
+    pub args: Value,
+    /// The operator-facing final reply (present on the `final` action).
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+/// A classified [`ActionDecision`]: either run a verb or stop with a final answer.
+///
+/// Why: the loop driver wants a clean two-way split, not raw string-matching on
+/// `action` at the call site. Classifying once here keeps the loop readable.
+/// What: [`Verb`](Decided::Verb) carries the verb name + args to execute;
+/// [`Final`](Decided::Final) carries the operator-facing reply that ends the turn.
+/// Test: `chat_action_tests.rs::parse_verb_call`, `parse_final_answer`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decided {
+    /// Execute this verb with these args, then feed the result back.
+    Verb {
+        /// The catalog verb name (e.g. `sessions.list`).
+        verb: String,
+        /// The verb's arguments.
+        args: Value,
+    },
+    /// Stop the loop and answer the operator with this text.
+    Final {
+        /// The operator-facing final reply.
+        message: String,
+    },
+}
+
+impl ActionDecision {
+    /// Classify this decision into a verb call or a final answer.
+    ///
+    /// Why: the loop needs a clean enum to branch on; a `"final"` action (or any
+    /// blank action) is the terminal, everything else is a verb call.
+    /// What: returns [`Decided::Final`] when `action` is the `"final"` sentinel
+    /// (or blank), carrying `message` (or an empty string); otherwise
+    /// [`Decided::Verb`] with the verb name + args.
+    /// Test: `chat_action_tests.rs::parse_verb_call`, `parse_final_answer`.
+    pub fn classify(self) -> Decided {
+        if is_final_action(self.action.trim()) || self.action.trim().is_empty() {
+            Decided::Final {
+                message: self.message.unwrap_or_default(),
+            }
+        } else {
+            Decided::Verb {
+                verb: self.action,
+                args: self.args,
+            }
+        }
+    }
+}
+
+/// Parse the model's reply into a [`Decided`] action (lenient extraction).
+///
+/// Why: the model returns TEXT (no tool calls) and may wrap its JSON action in a
+/// ```json fence or surround it with prose. The loop must extract robustly but
+/// NEVER guess: if no valid action object is found, the safe terminal is to treat
+/// the whole reply as the final answer (the SM is talking, not acting). This
+/// mirrors [`super::delegate`]'s `parse_decision` philosophy.
+/// What: scans `reply` for the first balanced top-level `{ … }` object (honoring
+/// fenced blocks and JSON string literals) that deserializes into an
+/// [`ActionDecision`], then [`classify`](ActionDecision::classify)es it; on any
+/// miss returns `Decided::Final { message: <trimmed reply> }`.
+/// Test: `chat_action_tests.rs::parse_verb_call`, `parse_final_answer`,
+/// `parse_prose_is_final`, `parse_fenced_verb`.
+pub fn parse_action(reply: &str) -> Decided {
+    let trimmed = reply.trim();
+    for candidate in candidate_objects(trimmed) {
+        if let Ok(decision) = serde_json::from_str::<ActionDecision>(&candidate) {
+            let decided = decision.classify();
+            // A bare object that happens to deserialize (every field defaulting)
+            // but names no real verb and carries no message is NOT a decision —
+            // skip it so the prose fallback can win.
+            if let Decided::Verb { ref verb, .. } = decided
+                && verb.trim().is_empty()
+            {
+                continue;
+            }
+            return decided;
+        }
+    }
+    Decided::Final {
+        message: trimmed.to_string(),
+    }
+}
+
+/// Collect candidate JSON-object spans from the model's reply, best-first.
+///
+/// Why: the action JSON may sit inside a ```json fence or amid prose; a naive
+/// `first '{' ..= last '}'` span breaks on prose braces. A balanced-brace walk
+/// that respects string literals yields each well-formed top-level object so the
+/// caller can try them in turn (mirrors `parse_decision`'s extractor).
+/// What: returns the first object inside a fenced block (if any), then every
+/// complete top-level object scanned over the whole text, de-duplicated.
+/// Test: exercised via [`parse_action`] in `chat_action_tests.rs`.
+fn candidate_objects(text: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Some(inner) = fenced_inner(text)
+        && let Some((obj, _)) = next_balanced_object(&inner, 0)
+    {
+        candidates.push(obj);
+    }
+    let mut from = 0;
+    while let Some((obj, end)) = next_balanced_object(text, from) {
+        if !candidates.contains(&obj) {
+            candidates.push(obj);
+        }
+        from = end;
+    }
+    candidates
+}
+
+/// Return the inner content of the first fenced code block, if any.
+///
+/// Why: the model may wrap its action in a ```json (or bare ```) fence; isolating
+/// fence handling keeps [`candidate_objects`] readable.
+/// What: finds a ```json opening (else a bare ```), skips to the end of that line,
+/// and returns the substring up to the next ``` (or end of text). `None` when
+/// there is no opening fence.
+/// Test: `chat_action_tests.rs::parse_fenced_verb`.
+fn fenced_inner(text: &str) -> Option<String> {
+    const JSON_FENCE: &str = "```json";
+    const BARE_FENCE: &str = "```";
+    let (open_at, fence_len) = match text.find(JSON_FENCE) {
+        Some(i) => (i, JSON_FENCE.len()),
+        None => (text.find(BARE_FENCE)?, BARE_FENCE.len()),
+    };
+    let after_open = open_at + fence_len;
+    let body_start = match text[after_open..].find('\n') {
+        Some(nl) => after_open + nl + 1,
+        None => after_open,
+    };
+    let rest = &text[body_start..];
+    let inner = match rest.find(BARE_FENCE) {
+        Some(close) => &rest[..close],
+        None => rest,
+    };
+    Some(inner.to_string())
+}
+
+/// Find the next COMPLETE top-level `{ … }` object at or after `from`.
+///
+/// Why: a depth-tracking scan that honors JSON string literals + escapes finds
+/// each well-formed top-level object in turn, so prose braces before/after the
+/// real object (or braces inside string values) do not corrupt the span.
+/// What: from the first `{` at/after `from`, tracks brace depth outside string
+/// literals and returns `(object_span, end_offset)` when depth returns to zero;
+/// `None` if there is no `{` or it never closes.
+/// Test: exercised via [`parse_action`] in `chat_action_tests.rs`.
+fn next_balanced_object(text: &str, from: usize) -> Option<(String, usize)> {
+    if from >= text.len() {
+        return None;
+    }
+    let rel = text[from..].find('{')?;
+    let start = from + rel;
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (offset, ch) in text[start..].char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let end = start + offset + ch.len_utf8();
+                    return Some((text[start..end].to_string(), end));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Render the action-chat instruction block advertising the inline verb surface.
+///
+/// Why: the chat agent is "self-aware" — it must know the full managed-session
+/// verb catalog and that those verbs execute INLINE in this turn (not as
+/// background delegation). The verb list is rendered from the
+/// [`catalog`](crate::client::catalog) single source of truth so it can never
+/// drift from the executable surface; this is SEPARATE from the goal-shaped
+/// `DECISION_INSTRUCTIONS` (delegate/respond), which must NOT be reused here.
+/// What: returns a fixed prose block that (1) lists every
+/// [`sm_session_verbs`] verb as a callable signature, (2) defines the two
+/// response shapes — a verb-call `{"action":"<verb>","args":{…}}` and a final
+/// answer `{"action":"final","message":"…"}` — and (3) states the verbs run
+/// inline this turn and are read→decide→execute→feed-back.
+/// Test: `chat_action_tests.rs::prompt_lists_every_catalog_verb`.
+pub fn action_instructions() -> String {
+    let mut out = String::from(
+        "# INLINE ACTIONS (machine-read)\n\n\
+         You can INVOKE managed-session verbs INLINE within this single chat turn. \
+         A verb you call EXECUTES NOW (synchronously, in-process) and its JSON result \
+         is fed straight back to you so you can decide your next step. This is NOT \
+         background delegation: there is no tracking goal, you act and observe in this \
+         very turn.\n\n\
+         Reply with EXACTLY ONE JSON object (optionally inside a ```json fence) and no \
+         other text. Choose ONE of two shapes:\n\n\
+         1. Call a verb (it runs now; you will see its result and may call another):\n   \
+         {\"action\":\"<verb>\",\"args\":{ … }}\n\n\
+         2. Give your FINAL answer to the operator (ends the turn):\n   \
+         {\"action\":\"final\",\"message\":\"<operator-facing reply>\"}\n\n\
+         The verbs available to you (call by exact name):\n",
+    );
+    for spec in sm_session_verbs() {
+        out.push_str(&format!(
+            "- `{}` — {}\n",
+            spec.prompt_signature(),
+            spec.summary
+        ));
+    }
+    out.push_str(
+        "\nArgument conventions: pass a session id as `args.session_id`; \
+         `sessions.send` also takes `args.text`; `sessions.launch` takes \
+         `args.workdir` (required) plus optional `args.model`, `args.prompt`, \
+         `args.goal_id`. When you have gathered enough to answer, emit the `final` \
+         shape — do not keep calling verbs once you can answer.",
+    );
+    out
+}
+
+/// Execute one chosen verb against the in-process [`SessionControl`].
+///
+/// Why: the action loop maps the model's chosen verb name onto the matching
+/// `SessionControl` method and runs it IN-PROCESS (never over HTTP back to the
+/// daemon, which would loop back on itself). Centralising the verb→method mapping
+/// here keeps the loop driver thin and the catalog-name → method table in one
+/// auditable place.
+/// What: dispatches `verb` (a catalog `sessions.*` name) to the corresponding
+/// `control` method, parsing `args` for the ids/text/launch params each needs;
+/// returns the verb's JSON result. An unknown verb is a
+/// [`SessionControlError::Backend`] so the loop can feed the error back to the
+/// model rather than panicking.
+/// Test: `chat_action_tests.rs::execute_dispatches_list`, `execute_send_reads_args`,
+/// `execute_unknown_verb_errors`.
+pub async fn execute_verb(
+    control: &Arc<dyn SessionControl>,
+    verb: &str,
+    args: &Value,
+) -> Result<Value, SessionControlError> {
+    match verb {
+        "sessions.list" => control.list().await,
+        "sessions.get" => control.get(require_session_id(args)?).await,
+        "sessions.send" => {
+            let id = require_session_id(args)?;
+            let text = args.get("text").and_then(Value::as_str).ok_or_else(|| {
+                SessionControlError::Backend("sessions.send requires args.text".to_string())
+            })?;
+            control.send(id, text).await
+        }
+        "sessions.stop" => control.stop(require_session_id(args)?).await,
+        "sessions.resume" => control.resume(require_session_id(args)?).await,
+        "sessions.kill" => control.kill(require_session_id(args)?).await,
+        "sessions.launch" => {
+            let workdir = args
+                .get("workdir")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    SessionControlError::Backend(
+                        "sessions.launch requires args.workdir".to_string(),
+                    )
+                })?
+                .to_string();
+            let params = LaunchParams {
+                workdir,
+                model: str_arg(args, "model"),
+                prompt: str_arg(args, "prompt"),
+                goal_id: str_arg(args, "goal_id"),
+            };
+            control.launch(params).await
+        }
+        other => Err(SessionControlError::Backend(format!(
+            "unknown verb `{other}`; valid verbs: {}",
+            valid_verb_names()
+        ))),
+    }
+}
+
+/// Whether `action` names the loop-terminating final answer.
+///
+/// Why: the loop driver checks the decision's tag to decide whether to execute a
+/// verb or stop; centralising the sentinel keeps the magic string in one place.
+/// What: returns `true` iff `action` equals the `"final"` sentinel.
+/// Test: covered transitively by the loop tests (`parse_final_answer`).
+pub fn is_final_action(action: &str) -> bool {
+    action == FINAL_ACTION
+}
+
+/// Extract a required `args.session_id` string, or a typed error.
+///
+/// Why: every per-session verb needs an id; a missing/blank id is fed back to the
+/// model as an error rather than panicking.
+/// What: returns `args.session_id` as `&str`, or [`SessionControlError::NotFound`].
+/// Test: `chat_action_tests.rs::execute_get_requires_id`.
+fn require_session_id(args: &Value) -> Result<&str, SessionControlError> {
+    args.get("session_id")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| SessionControlError::NotFound("missing args.session_id".to_string()))
+}
+
+/// Read an optional string arg, treating blank as absent.
+fn str_arg(args: &Value, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+}
+
+/// A comma-joined list of valid verb names for the unknown-verb error.
+fn valid_verb_names() -> String {
+    sm_session_verbs()
+        .iter()
+        .map(|c| c.name)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+#[path = "chat_action_tests.rs"]
+mod chat_action_tests;

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
@@ -59,6 +59,33 @@ fn parse_prose_is_final() {
     );
 }
 
+/// Why: FIX 4 — `next_balanced_object`'s `depth` decrement must not underflow on a
+/// stray unmatched `}` (a `saturating_sub` guard). The parser must never panic and
+/// must still extract a valid object when one follows the stray brace.
+/// What: parses inputs with leading/trailing stray `}`; asserts no panic and that a
+/// real object is still recovered (else the prose fallback).
+/// Test: this is the test.
+#[test]
+fn parse_handles_stray_closing_brace_without_panic() {
+    // A bare stray brace + prose: no object → prose fallback, no panic.
+    let d = parse_action("} stray");
+    assert_eq!(
+        d,
+        Decided::Final {
+            message: "} stray".to_string()
+        }
+    );
+
+    // A valid object followed by a stray `}`: the object must still be extracted.
+    let d = parse_action(r#"{"action":"final","message":"ok"} junk }"#);
+    assert_eq!(
+        d,
+        Decided::Final {
+            message: "ok".to_string()
+        }
+    );
+}
+
 /// Why: the model often wraps its JSON in a ```json fence; the parser must still
 /// extract the verb-call.
 /// What: parses a fenced verb-call and asserts the verb name.

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
@@ -1,0 +1,157 @@
+//! Unit tests for the action-chat decision protocol (#1283).
+//!
+//! Why: the inline-action loop is only as safe as its parser and dispatch — a
+//! verb-call must parse to a verb, a final answer must terminate, prose must
+//! fall back to a final answer (never a spurious verb), the advertised verb list
+//! must come from the catalog SoT, and each verb must map onto the right
+//! `SessionControl` method. These tests pin all of that deterministically with a
+//! recording mock control.
+//! What: exercises [`parse_action`], [`action_instructions`], and [`execute_verb`]
+//! against the shared `MockSessionControl`.
+//! Test: this is the test module.
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use super::{Decided, action_instructions, execute_verb, parse_action};
+use crate::core::sm::agent::delegate::mock_control::MockSessionControl;
+use crate::core::sm::control::SessionControl;
+
+/// Why: a bare verb-call JSON must parse to a `Verb` with the name + args.
+/// What: parses `{"action":"sessions.list","args":{}}`.
+/// Test: this is the test.
+#[test]
+fn parse_verb_call() {
+    let d = parse_action(r#"{"action":"sessions.list","args":{}}"#);
+    match d {
+        Decided::Verb { verb, .. } => assert_eq!(verb, "sessions.list"),
+        other => panic!("expected verb, got {other:?}"),
+    }
+}
+
+/// Why: the `final` action must terminate the loop, carrying the message.
+/// What: parses `{"action":"final","message":"all good"}`.
+/// Test: this is the test.
+#[test]
+fn parse_final_answer() {
+    let d = parse_action(r#"{"action":"final","message":"all good"}"#);
+    assert_eq!(
+        d,
+        Decided::Final {
+            message: "all good".to_string()
+        }
+    );
+}
+
+/// Why: plain prose (no JSON) must be treated as the final answer — never a
+/// spurious verb — so an unparseable reply is the always-safe terminal.
+/// What: parses a prose string and asserts it becomes the final message verbatim.
+/// Test: this is the test.
+#[test]
+fn parse_prose_is_final() {
+    let d = parse_action("I checked and everything looks fine.");
+    assert_eq!(
+        d,
+        Decided::Final {
+            message: "I checked and everything looks fine.".to_string()
+        }
+    );
+}
+
+/// Why: the model often wraps its JSON in a ```json fence; the parser must still
+/// extract the verb-call.
+/// What: parses a fenced verb-call and asserts the verb name.
+/// Test: this is the test.
+#[test]
+fn parse_fenced_verb() {
+    let reply = "Let me look.\n```json\n{\"action\":\"sessions.get\",\"args\":{\"session_id\":\"s1\"}}\n```";
+    match parse_action(reply) {
+        Decided::Verb { verb, args } => {
+            assert_eq!(verb, "sessions.get");
+            assert_eq!(args.get("session_id").unwrap(), "s1");
+        }
+        other => panic!("expected verb, got {other:?}"),
+    }
+}
+
+/// Why: the advertised verb list must be rendered from the catalog single source
+/// of truth, so the prompt can never drift from the executable surface.
+/// What: asserts the instruction block lists every catalog verb + both shapes.
+/// Test: this is the test.
+#[test]
+fn prompt_lists_every_catalog_verb() {
+    let prompt = action_instructions();
+    for verb in [
+        "sessions.launch",
+        "sessions.list",
+        "sessions.get",
+        "sessions.send",
+        "sessions.stop",
+        "sessions.resume",
+        "sessions.kill",
+    ] {
+        assert!(prompt.contains(verb), "prompt missing `{verb}`");
+    }
+    assert!(
+        prompt.contains("\"action\":\"final\""),
+        "missing final shape"
+    );
+    assert!(prompt.contains("INLINE"), "must state verbs run inline");
+}
+
+/// Why: `sessions.list` must dispatch to `SessionControl::list`.
+/// What: executes the verb and asserts the mock's list body comes back.
+/// Test: this is the test.
+#[tokio::test]
+async fn execute_dispatches_list() {
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let out = execute_verb(&control, "sessions.list", &json!({}))
+        .await
+        .expect("list dispatches");
+    assert!(out.get("sessions").is_some());
+}
+
+/// Why: `sessions.send` must read `session_id` + `text` and reach `send`.
+/// What: executes the verb and asserts the mock recorded the send.
+/// Test: this is the test.
+#[tokio::test]
+async fn execute_send_reads_args() {
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+    execute_verb(
+        &control,
+        "sessions.send",
+        &json!({"session_id":"abc","text":"hello"}),
+    )
+    .await
+    .expect("send dispatches");
+    let sends = mock.sends();
+    assert_eq!(sends, vec![("abc".to_string(), "hello".to_string())]);
+}
+
+/// Why: `sessions.get` without an id must error (fed back to the model), not panic.
+/// What: executes `sessions.get` with empty args and asserts an error.
+/// Test: this is the test.
+#[tokio::test]
+async fn execute_get_requires_id() {
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let err = execute_verb(&control, "sessions.get", &json!({}))
+        .await
+        .expect_err("missing id errors");
+    assert!(err.to_string().contains("session_id"));
+}
+
+/// Why: an unknown verb must be a recoverable error fed back to the model, never
+/// a panic or a silent no-op.
+/// What: executes a bogus verb and asserts the error names the valid set.
+/// Test: this is the test.
+#[tokio::test]
+async fn execute_unknown_verb_errors() {
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let err = execute_verb(&control, "sessions.frobnicate", &json!({}))
+        .await
+        .expect_err("unknown verb errors");
+    assert!(err.to_string().contains("unknown verb"));
+    assert!(err.to_string().contains("sessions.list"));
+}

--- a/crates/trusty-mpm/src/core/sm/agent/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/mod.rs
@@ -24,6 +24,8 @@
 //! `agent/chat_tests.rs` covers the composed turn, degraded mode, and recall.
 
 mod chat;
+mod chat_action;
+mod chat_action_protocol;
 mod delegate;
 mod health;
 
@@ -42,6 +44,7 @@ use super::providers::TierResolver;
 use super::memory::SmMemory;
 
 pub use chat::{SmAgentError, SmChatOutcome};
+pub use chat_action::SmChatActionOutcome;
 pub use health::{SmHealth, SmModelTiers};
 
 /// The Session Manager orchestrator (SM-7: real conversational chat turn).

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -73,7 +73,9 @@ pub mod providers;
 /// Test: `prune::tests`.
 pub mod prune;
 
-pub use agent::{SessionManagerAgent, SmAgentError, SmChatOutcome, SmHealth, SmModelTiers};
+pub use agent::{
+    SessionManagerAgent, SmAgentError, SmChatActionOutcome, SmChatOutcome, SmHealth, SmModelTiers,
+};
 pub use config::{SessionManagerConfig, SmInferenceConfig, SmMemoryConfig, SmRoundsConfig};
 pub use context::{
     ConversationStore, ConversationStoreError, Round, SmContextEngine, SmContextError,

--- a/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
@@ -93,8 +93,9 @@ pub struct CoordinatorChatResponse {
     pub conv_id: Option<String>,
     /// The verbs the SM invoked inline this turn (Phase 2, #1283), in order, for
     /// the operator's audit trail. Additive: `None` (skipped) on the text-only,
-    /// legacy, and prefix paths; present only when `actions: true` routed the SM
-    /// branch through the inline-action loop.
+    /// legacy, and prefix paths AND on the action path when NO verb ran — so its
+    /// presence means "verbs ran" and `[]` is never serialized. `Some([...])` only
+    /// when `actions: true` routed the SM branch and at least one verb executed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actions_taken: Option<Vec<String>>,
 }
@@ -276,10 +277,11 @@ async fn route_through_session_manager(
 /// `Arc<dyn SessionControl>`, calls
 /// [`SessionManagerAgent::chat_with_actions`](crate::core::sm::SessionManagerAgent::chat_with_actions)
 /// with the message + optional `conv_id`; on success fills `reply`, the additive
-/// `cost`, `conv_id`, and the audit `actions_taken` (leaving the routed/output
-/// fields `None`); on [`SmAgentError::Degraded`] returns a 503; on any other error
-/// a 500.
-/// Test: `coordinator_chat_action_path_executes_verbs`,
+/// `cost`, `conv_id`, and the audit `actions_taken` — `Some([...])` only when at
+/// least one verb ran, else `None` so an empty `[]` is never serialized (leaving
+/// the routed/output fields `None`); on [`SmAgentError::Degraded`] returns a 503;
+/// on any other error a 500.
+/// Test: `coordinator_chat_action_path_returns_actions_taken`,
 /// `coordinator_chat_actions_absent_is_text_only` in the SM-path suite.
 async fn route_through_action_loop(
     sm: &crate::core::sm::SessionManagerAgent,
@@ -300,7 +302,9 @@ async fn route_through_action_loop(
             command_output: None,
             cost: Some(outcome.cost_usd),
             conv_id: Some(outcome.conv_id),
-            actions_taken: Some(outcome.actions_taken),
+            // Presence means "verbs ran": omit the field (None) when none ran so
+            // `[]` is never serialized; `skip_serializing_if` then drops it.
+            actions_taken: Some(outcome.actions_taken).filter(|v| !v.is_empty()),
         })),
         Err(SmAgentError::Degraded(notice)) => Err(DaemonError::ServiceUnavailable(notice)),
         Err(e) => Err(DaemonError::Internal(e.to_string())),

--- a/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
@@ -51,6 +51,14 @@ pub struct CoordinatorChatRequest {
     /// the same SM conversation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conv_id: Option<String>,
+    /// Opt in to ACTION-CAPABLE chat (Phase 2, #1283): the SM may invoke managed-
+    /// session verbs INLINE within this turn via the in-process `SessionControl`.
+    ///
+    /// Optional and additive: absent/`false` preserves the exact text-only SM
+    /// `chat` path (and the legacy/@prefix paths). Only `Some(true)` routes the SM
+    /// branch through the inline-action loop.
+    #[serde(default)]
+    pub actions: Option<bool>,
 }
 
 /// Response of `POST /api/v1/sessions/chat`.
@@ -83,6 +91,12 @@ pub struct CoordinatorChatResponse {
     /// the same rolling context. Additive (SM-7); present only on the SM path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conv_id: Option<String>,
+    /// The verbs the SM invoked inline this turn (Phase 2, #1283), in order, for
+    /// the operator's audit trail. Additive: `None` (skipped) on the text-only,
+    /// legacy, and prefix paths; present only when `actions: true` routed the SM
+    /// branch through the inline-action loop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actions_taken: Option<Vec<String>>,
 }
 
 /// `GET /api/v1/sessions/context` — a cross-session activity snapshot.
@@ -160,6 +174,7 @@ pub async fn coordinator_chat(
             command_output: Some(output),
             cost: None,
             conv_id: None,
+            actions_taken: None,
         }));
     }
 
@@ -172,6 +187,14 @@ pub async fn coordinator_chat(
     // notice; any other SM error is a genuine 500.
     let sm = state.session_manager_agent();
     if sm.is_enabled() && sm.has_runtime() {
+        // Phase 2 (#1283): when the caller opts in with `actions: true`, route the
+        // SM turn through the ACTION-CAPABLE loop — the SM may invoke managed-
+        // session verbs inline via the IN-PROCESS `DaemonSessionControl` (never
+        // over HTTP back to this daemon, so no loopback). Absent/`false` preserves
+        // the exact text-only `sm.chat` path below.
+        if body.actions == Some(true) {
+            return route_through_action_loop(&sm, &state, &body).await;
+        }
         return route_through_session_manager(&sm, &body).await;
     }
 
@@ -202,6 +225,7 @@ pub async fn coordinator_chat(
         command_output: None,
         cost: None,
         conv_id: None,
+        actions_taken: None,
     }))
 }
 
@@ -231,6 +255,52 @@ async fn route_through_session_manager(
             command_output: None,
             cost: Some(outcome.cost_usd),
             conv_id: Some(outcome.conv_id),
+            actions_taken: None,
+        })),
+        Err(SmAgentError::Degraded(notice)) => Err(DaemonError::ServiceUnavailable(notice)),
+        Err(e) => Err(DaemonError::Internal(e.to_string())),
+    }
+}
+
+/// Drive one ACTION-CAPABLE Session Manager chat turn and map it to the wire
+/// response (Phase 2, #1283).
+///
+/// Why: the `actions: true` path lets the SM invoke managed-session verbs INLINE.
+/// Execution goes through the IN-PROCESS [`DaemonSessionControl`] (the same
+/// helpers the HTTP `…/managed/*` routes use), NOT chat-core's HTTP-backed
+/// executor — so the daemon never loops back over HTTP onto itself. Isolating
+/// this branch keeps [`coordinator_chat`] readable and gives the error mapping
+/// (graceful degraded → 503; real failure → 500) one home, mirroring
+/// [`route_through_session_manager`].
+/// What: constructs `DaemonSessionControl::new(state.clone())` as
+/// `Arc<dyn SessionControl>`, calls
+/// [`SessionManagerAgent::chat_with_actions`](crate::core::sm::SessionManagerAgent::chat_with_actions)
+/// with the message + optional `conv_id`; on success fills `reply`, the additive
+/// `cost`, `conv_id`, and the audit `actions_taken` (leaving the routed/output
+/// fields `None`); on [`SmAgentError::Degraded`] returns a 503; on any other error
+/// a 500.
+/// Test: `coordinator_chat_action_path_executes_verbs`,
+/// `coordinator_chat_actions_absent_is_text_only` in the SM-path suite.
+async fn route_through_action_loop(
+    sm: &crate::core::sm::SessionManagerAgent,
+    state: &Arc<DaemonState>,
+    body: &CoordinatorChatRequest,
+) -> Result<Json<CoordinatorChatResponse>, DaemonError> {
+    use crate::core::sm::{SessionControl, SmAgentError};
+    use crate::daemon::sm_stdio::DaemonSessionControl;
+
+    let control: Arc<dyn SessionControl> = Arc::new(DaemonSessionControl::new(state.clone()));
+    match sm
+        .chat_with_actions(&body.message, body.conv_id.as_deref(), &control)
+        .await
+    {
+        Ok(outcome) => Ok(Json(CoordinatorChatResponse {
+            reply: outcome.reply,
+            routed_to_session: None,
+            command_output: None,
+            cost: Some(outcome.cost_usd),
+            conv_id: Some(outcome.conv_id),
+            actions_taken: Some(outcome.actions_taken),
         })),
         Err(SmAgentError::Degraded(notice)) => Err(DaemonError::ServiceUnavailable(notice)),
         Err(e) => Err(DaemonError::Internal(e.to_string())),

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -522,6 +522,7 @@ async fn coordinator_chat_without_overseer_is_503() {
             message: "what is happening?".into(),
             history: Vec::new(),
             conv_id: None,
+            actions: None,
         }),
     )
     .await
@@ -546,6 +547,7 @@ async fn coordinator_chat_routes_prefixed_message() {
             message: "@coordtest: echo hi".into(),
             history: Vec::new(),
             conv_id: None,
+            actions: None,
         }),
     )
     .await

--- a/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
+++ b/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
@@ -137,13 +137,15 @@ async fn disabled_sm_falls_back_to_legacy_503() {
 }
 
 /// Why: Phase 2 (#1283) — `actions: true` routes the SM branch through the
-/// ACTION-CAPABLE loop, which returns the additive `actions_taken` audit field.
-/// With the model emitting a `final` answer immediately (no verb), the in-process
-/// control is never invoked, so the handler test stays hermetic while still
-/// proving the action branch is wired and `actions_taken` is populated (here,
-/// empty — no verb ran).
+/// ACTION-CAPABLE loop. With the model emitting a `final` answer immediately (no
+/// verb), the in-process control is never invoked, so the handler test stays
+/// hermetic while still proving the action BRANCH was taken: it parses the action
+/// JSON into the `final` message (the text path would echo the raw JSON verbatim)
+/// and emits the additive `cost`/`conv_id`. Because no verb ran, `actions_taken`
+/// is `None` (an empty `[]` is never serialized — presence means "verbs ran").
 /// What: posts with `actions: Some(true)` and a provider whose reply is a `final`
-/// action JSON; asserts `reply`, `cost`, and `actions_taken: Some([])`.
+/// action JSON; asserts the action path was taken (parsed `reply`, `cost`,
+/// `conv_id`) and that `actions_taken` is `None` when no verb ran.
 /// Test: this is the test.
 #[tokio::test]
 async fn coordinator_chat_action_path_returns_actions_taken() {
@@ -163,11 +165,16 @@ async fn coordinator_chat_action_path_returns_actions_taken() {
     .await
     .expect("action path succeeds");
 
+    // The action path PARSED the JSON into the `final` message; the text path would
+    // instead echo the raw JSON verbatim — so this proves the action branch ran.
     assert_eq!(resp.reply, "nothing to do");
     assert_eq!(resp.cost, Some(0.002));
     assert_eq!(resp.conv_id.as_deref(), Some("act-conv"));
-    // The action path always returns the audit field (empty here: no verb ran).
-    assert_eq!(resp.actions_taken, Some(Vec::new()));
+    // No verb ran this turn, so the audit field is omitted (None), not `Some([])`.
+    assert!(
+        resp.actions_taken.is_none(),
+        "no verb ran: actions_taken must be None, not Some([])"
+    );
 }
 
 /// Why: NO REGRESSION — `actions` absent (or `false`) must preserve the EXACT

--- a/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
+++ b/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
@@ -63,6 +63,7 @@ async fn sm_chat_returns_reply_and_cost() {
             message: "plan the migration".into(),
             history: Vec::new(),
             conv_id: Some("endpoint-conv".into()),
+            actions: None,
         }),
     )
     .await
@@ -91,6 +92,7 @@ async fn sm_chat_degraded_is_503() {
             message: "anything".into(),
             history: Vec::new(),
             conv_id: None,
+            actions: None,
         }),
     )
     .await
@@ -126,11 +128,80 @@ async fn disabled_sm_falls_back_to_legacy_503() {
             message: "what is happening?".into(),
             history: Vec::new(),
             conv_id: None,
+            actions: None,
         }),
     )
     .await
     .unwrap_err();
     assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: Phase 2 (#1283) — `actions: true` routes the SM branch through the
+/// ACTION-CAPABLE loop, which returns the additive `actions_taken` audit field.
+/// With the model emitting a `final` answer immediately (no verb), the in-process
+/// control is never invoked, so the handler test stays hermetic while still
+/// proving the action branch is wired and `actions_taken` is populated (here,
+/// empty — no verb ran).
+/// What: posts with `actions: Some(true)` and a provider whose reply is a `final`
+/// action JSON; asserts `reply`, `cost`, and `actions_taken: Some([])`.
+/// Test: this is the test.
+#[tokio::test]
+async fn coordinator_chat_action_path_returns_actions_taken() {
+    let tmp = TempDir::new().unwrap();
+    let provider = MockChatProvider::new(r#"{"action":"final","message":"nothing to do"}"#, 0.002);
+    let state = state_with_sm(Arc::new(MockResolver::with_provider(provider)), &tmp);
+
+    let resp = coordinator_chat(
+        State(state),
+        Json(CoordinatorChatRequest {
+            message: "check sessions".into(),
+            history: Vec::new(),
+            conv_id: Some("act-conv".into()),
+            actions: Some(true),
+        }),
+    )
+    .await
+    .expect("action path succeeds");
+
+    assert_eq!(resp.reply, "nothing to do");
+    assert_eq!(resp.cost, Some(0.002));
+    assert_eq!(resp.conv_id.as_deref(), Some("act-conv"));
+    // The action path always returns the audit field (empty here: no verb ran).
+    assert_eq!(resp.actions_taken, Some(Vec::new()));
+}
+
+/// Why: NO REGRESSION — `actions` absent (or `false`) must preserve the EXACT
+/// text-only `sm.chat` path: the raw reply text is returned verbatim (NOT parsed
+/// as an action) and `actions_taken` is absent (`None`).
+/// What: posts the same provider reply WITHOUT `actions: true`; asserts the raw
+/// JSON-looking reply is returned verbatim and `actions_taken` is `None`.
+/// Test: this is the test.
+#[tokio::test]
+async fn coordinator_chat_actions_absent_is_text_only() {
+    let tmp = TempDir::new().unwrap();
+    // A reply that WOULD parse as an action — the text path must NOT interpret it.
+    let provider = MockChatProvider::new(r#"{"action":"final","message":"x"}"#, 0.007);
+    let state = state_with_sm(Arc::new(MockResolver::with_provider(provider)), &tmp);
+
+    let resp = coordinator_chat(
+        State(state),
+        Json(CoordinatorChatRequest {
+            message: "plain chat".into(),
+            history: Vec::new(),
+            conv_id: Some("text-conv".into()),
+            actions: None,
+        }),
+    )
+    .await
+    .expect("text path succeeds");
+
+    // The text path returns the raw provider text verbatim, unparsed.
+    assert_eq!(resp.reply, r#"{"action":"final","message":"x"}"#);
+    assert_eq!(resp.cost, Some(0.007));
+    assert!(
+        resp.actions_taken.is_none(),
+        "text path must not populate actions_taken"
+    );
 }
 
 /// Why: D0.1 — the `/api/v1/session-manager/chat` alias must resolve to the SAME
@@ -219,6 +290,7 @@ fn doc13_tui_contract_is_preserved() {
         command_output: None,
         cost: None,
         conv_id: None,
+        actions_taken: None,
     };
     let json: Value = serde_json::to_value(&resp).unwrap();
     assert_eq!(json["reply"], "ok");


### PR DESCRIPTION
## Summary
Phase 2 of the shared chat-core effort: makes the HTTP coordinator-chat endpoint **action-capable**. The session-manager chat agent is now "self-aware" — its prompt advertises the managed-session verb catalog (single source of truth) and it can invoke those verbs inline within a chat turn, executing them in-process via `SessionControl`. Opt-in and fully backward-compatible.

## How it works
- New `core/sm/agent/chat_action.rs` — `SessionManagerAgent::chat_with_actions(message, conv_id, control)`: a bounded read→decide→execute→feed-back→final-answer loop (max 8 iterations, then forced final answer). Each step the model emits either a verb-call JSON or a final answer (lenient parse, prose falls back to final).
- New `chat_action_protocol.rs` — `ActionDecision`/parse + the action-prompt block, whose advertised verb list is **generated from `client::catalog`** (`sm_session_verbs()`), so awareness can't drift from the catalog SoT.
- Execution maps each catalog verb → the matching `SessionControl` method (list/get/send/stop/resume/kill/launch), run via in-process `DaemonSessionControl` — **no HTTP loopback** (does not use chat-core's HTTP `CommandExecutor`).
- Every executed verb is recorded in `actions_taken` for operator audit.

## Opt-in & backward compatibility
- New additive request field `actions: Option<bool>` (`#[serde(default)]`). `Some(true)` → action loop; absent/false → the unchanged text-only `sm.chat` path. New additive response field `actions_taken: Option<Vec<String>>` (None on text/legacy/@prefix paths).
- The @prefix and legacy-overseer branches are untouched. Existing coordinator/sm tests pass unchanged (only `actions: None`/`actions_taken: None` added to their struct literals).

## Tests
- Verb-call-then-final, max-iteration guard (no infinite loop), prose→final fallback, degraded provider, and handler gating (actions=true routes to loop; absent preserves text-only). Mock provider + mock SessionControl. `prompt_lists_every_catalog_verb` pins the catalog-driven prompt.

## Follow-ups (noted, not built)
- Confirmation-gating destructive verbs (kill/decommission) before autonomous execution.
- Per-conv_id concurrency guard (#1309) — inherited from the existing text-only chat path.

## Verification
- build ✓ · `cargo test -p trusty-mpm` ✓ (1601 passed, 0 failed, 1 ignored; run with OPENROUTER_API_KEY unset) · clippy ✓ · fmt ✓ · line-cap ✓ (new code in sibling files; 0 violations).

Refs #1283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)