### PR TITLE
feat(trusty-mpm): add health verb to chat-core catalog + action loop (refs #1433)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -102,6 +102,8 @@ pub(crate) enum Command {
     Events,
     /// Run a full system diagnostic of the trusty-mpm stack.
     Doctor,
+    /// Report daemon health: reachability, catalog freshness, and a fleet summary.
+    Health,
     /// Launch the ratatui multi-session TUI dashboard.
     Tui {
         /// Base URL of the trusty-mpm daemon.

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -107,6 +107,47 @@ pub(crate) async fn doctor(url: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// `health` subcommand — report daemon health through chat-core.
+///
+/// Why: the operator (and scripts) want a quick "is the daemon up, is the catalog
+/// fresh, how big is the fleet?" probe. Routing it through the shared
+/// [`CommandExecutor`] (rather than a bespoke `reqwest` call here) means the CLI
+/// shares the exact `health` dispatch with every other adapter — a single source
+/// of truth per the chat-core nucleus.
+/// What: runs [`TrustyCommand::Health`] through the executor and prints a compact,
+/// scriptable summary. A dead daemon prints `daemon: unreachable` and is NOT an
+/// error exit (the probe succeeded in determining the daemon is down).
+/// Test: `cli_parses_health` covers parsing; the executor's `execute_health_*`
+/// tests cover the live and dead-daemon report paths.
+pub(crate) async fn health(url: &str) -> anyhow::Result<()> {
+    use trusty_mpm::client::{CommandExecutor, CommandResult, TrustyCommand};
+
+    let executor = CommandExecutor::new(url.to_string());
+    match executor.execute(TrustyCommand::Health).await {
+        CommandResult::Health(report) if !report.reachable => {
+            println!("daemon: unreachable ({})", report.url);
+        }
+        CommandResult::Health(report) => {
+            let catalog = if report.catalog_unknown {
+                "never synced"
+            } else if report.catalog_stale {
+                "updates available"
+            } else {
+                "up to date"
+            };
+            println!("daemon: {} ({})", report.status, report.url);
+            println!("catalog: {catalog}");
+            println!(
+                "fleet: {} session(s), {} awaiting a decision",
+                report.managed_total, report.managed_pending_decisions
+            );
+        }
+        CommandResult::Error(msg) => eprintln!("health failed: {msg}"),
+        other => eprintln!("health: unexpected result {other:?}"),
+    }
+    Ok(())
+}
+
 /// Render a [`CheckStatus`] as a status icon for terminal output.
 ///
 /// Why: the `tm doctor` table marks each check with a glanceable symbol; one

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -19,7 +19,7 @@ use commands::{
     daemon::{restart, run_daemon, start, stop_daemon},
     install::install,
     launch::{connect, launch},
-    misc::{attach_cmd, coordinator, doctor, hook, optimizer, overseer, status},
+    misc::{attach_cmd, coordinator, doctor, health, hook, optimizer, overseer, status},
     project::project,
     repair::repair_deploy,
     services::services,
@@ -212,6 +212,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Session { action } => session(&client, &url, action).await,
         Command::Events => commands::misc::events(&client, &url).await,
         Command::Doctor => doctor(&url).await,
+        Command::Health => health(&url).await,
         Command::Tui {
             url: tui_url,
             interval_ms,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -85,6 +85,12 @@ fn cli_parses_doctor() {
 }
 
 #[test]
+fn cli_parses_health() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "health"]).unwrap();
+    assert!(matches!(cli.command, Command::Health));
+}
+
+#[test]
 fn cli_parses_project_init() {
     let cli = Cli::try_parse_from(["trusty-mpm", "project", "init"]).unwrap();
     match cli.command {

--- a/crates/trusty-mpm/src/client/catalog/mod.rs
+++ b/crates/trusty-mpm/src/client/catalog/mod.rs
@@ -22,7 +22,7 @@ use std::sync::OnceLock;
 
 mod sm_tools;
 
-pub use sm_tools::{render_sm_tools, sm_session_verbs};
+pub use sm_tools::{render_sm_tools, sm_ops_verbs, sm_session_verbs};
 
 /// How a catalog entry relates to the typed [`TrustyCommand`] surface.
 ///
@@ -297,6 +297,17 @@ const COMMANDS: &[CommandSpec] = &[
         summary: "decommission a managed session (terminal; removes workspace)",
         kind: SpecKind::Command,
     },
+    // ── Ops / diagnostics ───────────────────────────────────────────────────
+    CommandSpec {
+        name: "health",
+        // `status` is intentionally NOT an alias — it is already the
+        // project-session status verb, so reusing it would collide. `healthcheck`
+        // and `ping` are the natural operator spellings.
+        aliases: &["healthcheck", "ping"],
+        args: "",
+        summary: "report daemon health (reachability, catalog freshness, fleet)",
+        kind: SpecKind::Command,
+    },
     CommandSpec {
         name: "help",
         aliases: &[],
@@ -386,9 +397,45 @@ mod tests {
             "managed-stop",
             "managed-resume",
             "managed-decommission",
+            "health",
             "help",
         ] {
             assert!(names.contains(&expected), "catalog missing `{expected}`");
+        }
+    }
+
+    #[test]
+    fn health_verb_has_expected_aliases_and_no_status_collision() {
+        // `health` carries the operator-friendly spellings but NEVER `status`,
+        // which is already the project-session status verb (a collision).
+        let health = catalog()
+            .iter()
+            .find(|c| c.name == "health")
+            .expect("catalog has a health verb");
+        assert!(health.aliases.contains(&"healthcheck"));
+        assert!(health.aliases.contains(&"ping"));
+        assert!(
+            !health.aliases.contains(&"status"),
+            "`status` must not alias health — it is the session status verb"
+        );
+        assert_eq!(health.kind, SpecKind::Command);
+    }
+
+    #[test]
+    fn catalog_has_no_duplicate_command_names_or_aliases() {
+        // Every dispatchable verb's canonical name AND each alias must be unique
+        // across the catalog, so a parsed token resolves to exactly one verb.
+        use std::collections::HashSet;
+        let mut seen: HashSet<&str> = HashSet::new();
+        for spec in catalog().iter().filter(|c| c.kind == SpecKind::Command) {
+            assert!(
+                seen.insert(spec.name),
+                "duplicate verb name `{}`",
+                spec.name
+            );
+            for alias in spec.aliases {
+                assert!(seen.insert(alias), "duplicate alias `{alias}`");
+            }
         }
     }
 
@@ -424,6 +471,7 @@ mod tests {
             "/managed-stop",
             "/managed-resume",
             "/managed-decommission",
+            "/health",
             "/help",
         ] {
             assert!(text.contains(cmd), "help text missing {cmd}");

--- a/crates/trusty-mpm/src/client/catalog/sm_tools.rs
+++ b/crates/trusty-mpm/src/client/catalog/sm_tools.rs
@@ -73,6 +73,30 @@ const SM_SESSION_VERBS: &[CommandSpec] = &[
     },
 ];
 
+/// The action-loop OPS verbs — advertised + executable, but NOT in `SM_TOOLS.md`.
+///
+/// Why: the action-capable coordinator chat (#1496) must be able to run a daemon
+/// `health` check inline, but `health` is an OPERATOR/ops diagnostic — it does
+/// NOT belong in the SM's session-control / memory / goals prompt tables that
+/// `render_sm_tools()` emits. Keeping ops verbs in a SEPARATE slice that
+/// `render_sm_tools()` does NOT render lets the action loop advertise and execute
+/// `health` while the committed `SM_TOOLS.md` asset stays byte-identical (the
+/// parity test needs no asset regen). These verbs carry the namespaced
+/// `sessions.*` spelling so the action-loop prompt and dispatch stay uniform with
+/// [`SM_SESSION_VERBS`].
+/// What: the ops verb slice the action loop appends to [`SM_SESSION_VERBS`] —
+/// currently just `sessions.health`.
+/// Test: `sm_ops_verbs_exposes_health`; `chat_action_tests.rs` asserts the prompt
+/// lists `sessions.health` and that it dispatches; the SM-tools parity test proves
+/// these are NOT rendered into `SM_TOOLS.md`.
+const SM_OPS_VERBS: &[CommandSpec] = &[CommandSpec {
+    name: "sessions.health",
+    aliases: &[],
+    args: "",
+    summary: "Report daemon health: reachability, catalog freshness, and a fleet summary",
+    kind: SpecKind::SmOnly,
+}];
+
 /// The SM memory verbs (prompt table only).
 const SM_MEMORY_VERBS: &[CommandSpec] = &[
     CommandSpec {
@@ -140,6 +164,20 @@ const SM_GOAL_VERBS: &[CommandSpec] = &[
 /// `chat_action.rs` tests assert the rendered prompt lists these verbs.
 pub fn sm_session_verbs() -> &'static [CommandSpec] {
     SM_SESSION_VERBS
+}
+
+/// The action-loop OPS verbs (advertised + executable; NOT in `SM_TOOLS.md`).
+///
+/// Why: the action-capable chat (#1496) advertises and executes ops diagnostics
+/// like `health` IN ADDITION to the session-control verbs, but those ops verbs
+/// must not pollute the SM prompt's three tables. Exposing them as a separate
+/// slice that `render_sm_tools()` ignores keeps the committed `SM_TOOLS.md`
+/// byte-identical (no asset regen) while the action loop still gains the verb.
+/// What: returns the [`SM_OPS_VERBS`] slice — currently `sessions.health`.
+/// Test: `sm_ops_verbs_exposes_health` (this module); `chat_action_tests.rs`
+/// asserts the prompt lists and dispatches it.
+pub fn sm_ops_verbs() -> &'static [CommandSpec] {
+    SM_OPS_VERBS
 }
 
 /// Render one prompt-table row for a [`CommandSpec`].
@@ -272,6 +310,33 @@ mod tests {
             "sessions.kill",
         ] {
             assert!(names.contains(&expected), "missing SM verb `{expected}`");
+        }
+    }
+
+    #[test]
+    fn sm_ops_verbs_exposes_health() {
+        // The action-loop ops slice must advertise `sessions.health` so the
+        // self-aware chat can run a health check inline.
+        let names: Vec<&str> = sm_ops_verbs().iter().map(|c| c.name).collect();
+        assert!(
+            names.contains(&"sessions.health"),
+            "missing ops health verb"
+        );
+    }
+
+    #[test]
+    fn render_sm_tools_omits_ops_verbs() {
+        // The ops verbs are deliberately NOT rendered into SM_TOOLS.md, so adding
+        // `health` requires no asset regen — the parity test stays green. This
+        // guard pins that decision: if a future change starts rendering ops verbs
+        // into the prompt, this fails and forces a conscious asset regen.
+        let rendered = render_sm_tools();
+        for spec in SM_OPS_VERBS {
+            assert!(
+                !rendered.contains(spec.name),
+                "ops verb `{}` leaked into SM_TOOLS.md render (would need asset regen)",
+                spec.name
+            );
         }
     }
 

--- a/crates/trusty-mpm/src/client/command.rs
+++ b/crates/trusty-mpm/src/client/command.rs
@@ -223,6 +223,17 @@ pub enum TrustyCommand {
         target: String,
     },
 
+    /// Report daemon health: reachability + catalog freshness + fleet summary.
+    ///
+    /// Why: operators (and the action-capable coordinator chat) routinely ask
+    /// "run a health check" / "is the daemon up?". Before this verb there was no
+    /// catalog entry for it, so the coordinator chat deflected. `Health` is the
+    /// one dispatchable health probe every adapter shares.
+    /// What: takes no arguments; the executor probes `GET /health` and the managed
+    /// list, returning a [`super::result::CommandResult::Health`]. A dead daemon
+    /// yields a `Health { reachable: false, .. }` result, never a panic.
+    Health,
+
     /// Show the command list.
     Help,
 }

--- a/crates/trusty-mpm/src/client/executor/health.rs
+++ b/crates/trusty-mpm/src/client/executor/health.rs
@@ -1,0 +1,82 @@
+//! The `health` verb: a daemon health probe (`GET /health` + fleet summary).
+//!
+//! Why: operators (and the action-capable coordinator chat, #1496) routinely ask
+//! "run a health check" / "is the daemon up?". The chat-core nucleus had no
+//! health verb, so the coordinator deflected. This module is the single
+//! dispatchable health probe every adapter shares — it reuses the existing
+//! `GET /health` route (liveness + catalog-freshness flags) and the managed-list
+//! call (fleet summary) rather than inventing a new daemon endpoint. Splitting it
+//! into its own executor submodule keeps every file under the 500-SLOC cap.
+//! What: the [`CommandExecutor::health`] method — it probes `GET /health` and the
+//! managed list, composing a [`CommandResult::Health`]. A dead daemon yields a
+//! `Health { reachable: false, status: "unreachable", .. }` result (NEVER a
+//! panic), so an unreachable daemon stays renderable.
+//! Test: `execute_health_against_test_daemon` and `execute_health_dead_daemon_renders`
+//! in `tests.rs`.
+
+use super::CommandExecutor;
+use crate::client::result::{CommandResult, HealthReport};
+
+/// The liveness word reported when the daemon's `/health` probe fails.
+const STATUS_UNREACHABLE: &str = "unreachable";
+
+impl CommandExecutor {
+    /// `health` — report daemon reachability, catalog freshness, and a fleet
+    /// summary.
+    ///
+    /// Why: the one health probe shared by every adapter and the action loop. It
+    /// must be genuinely useful (liveness + catalog drift + how many sessions, how
+    /// many blocked) yet degrade gracefully — a daemon that is entirely down is a
+    /// renderable `reachable: false` result, not an error or a panic.
+    /// What: GETs `GET /health` for the liveness word and the `catalog_stale` /
+    /// `catalog_unknown` flags; on success, additionally fetches the managed list
+    /// to count total sessions and those blocked on a pending decision. If the
+    /// `/health` probe fails (daemon down), returns a `Health` with
+    /// `reachable: false` and `status: "unreachable"`, leaving the remaining
+    /// fields at their defaults; a managed-list failure after a healthy probe
+    /// leaves the fleet counts at zero (the daemon is up; only the secondary call
+    /// failed) rather than masking the up status.
+    /// Test: `execute_health_against_test_daemon`, `execute_health_dead_daemon_renders`.
+    pub(super) async fn health(&self) -> CommandResult {
+        let url = self.client().base_url().to_string();
+        let snapshot = match self.client().health_snapshot().await {
+            Ok(snapshot) => snapshot,
+            // The daemon is unreachable: convey that as a renderable Health result
+            // (reachable=false) rather than a transport error or a panic.
+            Err(_) => {
+                return CommandResult::Health(HealthReport {
+                    reachable: false,
+                    url,
+                    status: STATUS_UNREACHABLE.to_string(),
+                    ..HealthReport::default()
+                });
+            }
+        };
+
+        // The daemon answered: summarise the managed fleet too. A failure of this
+        // secondary call must not flip the report to "down" — the daemon IS up —
+        // so the counts default to zero and the up status is preserved.
+        let (managed_total, managed_pending_decisions) =
+            match self.client().list_managed_sessions().await {
+                Ok(sessions) => {
+                    let total = sessions.len();
+                    let pending = sessions
+                        .iter()
+                        .filter(|s| s.pending_decision.is_some())
+                        .count();
+                    (total, pending)
+                }
+                Err(_) => (0, 0),
+            };
+
+        CommandResult::Health(HealthReport {
+            reachable: true,
+            url,
+            status: snapshot.status,
+            catalog_stale: snapshot.catalog_stale,
+            catalog_unknown: snapshot.catalog_unknown,
+            managed_total,
+            managed_pending_decisions,
+        })
+    }
+}

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -20,6 +20,7 @@ use super::command::{TrustyCommand, help_text};
 use super::http_client::DaemonClient;
 use super::result::CommandResult;
 
+mod health;
 mod managed;
 mod pairing;
 mod sessions;
@@ -123,6 +124,7 @@ impl CommandExecutor {
             TrustyCommand::Launch { project, .. } => self.launch(&project).await,
             TrustyCommand::Connect { project, .. } => self.connect(&project).await,
             TrustyCommand::Doctor => self.doctor().await,
+            TrustyCommand::Health => self.health().await,
             TrustyCommand::CoordinatorChat { message } => self.coordinator_chat(&message).await,
             // ── Managed session-manager verbs ───────────────────────────────
             TrustyCommand::ManagedNew {

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -228,6 +228,39 @@ async fn execute_status_no_events() {
     }
 }
 
+#[tokio::test]
+async fn execute_health_against_test_daemon() {
+    // Against a live daemon the `health` verb reports reachable=true, a status
+    // word, and a fleet summary (empty fleet → zero counts) — never an error.
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url.clone());
+    match executor.execute(TrustyCommand::Health).await {
+        CommandResult::Health(report) => {
+            assert!(report.reachable, "daemon should be reachable");
+            assert!(!report.status.is_empty());
+            assert_eq!(report.url, url);
+            assert_eq!(report.managed_total, 0);
+            assert_eq!(report.managed_pending_decisions, 0);
+        }
+        other => panic!("expected Health, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn execute_health_dead_daemon_renders() {
+    // A dead daemon must render as a Health result with reachable=false — never a
+    // panic and never a transport Error.
+    let executor = CommandExecutor::new("http://127.0.0.1:0");
+    match executor.execute(TrustyCommand::Health).await {
+        CommandResult::Health(report) => {
+            assert!(!report.reachable, "dead daemon must be reachable=false");
+            assert_eq!(report.status, "unreachable");
+            assert_eq!(report.managed_total, 0);
+        }
+        other => panic!("expected Health, got {other:?}"),
+    }
+}
+
 #[test]
 fn resolve_session_exact_and_prefix() {
     use crate::client::http_client::SessionRow;

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -20,7 +20,7 @@ mod types;
 
 pub use types::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
-    CoordinatorSession, DiscoveredProjectRow, EventRow, LastSeen, LlmChatOutcome,
+    CoordinatorSession, DiscoveredProjectRow, EventRow, HealthSnapshot, LastSeen, LlmChatOutcome,
     ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse,
     ManagedListResponse, ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary,
     ManagedSpawnRequest, ManagedSpawnResponse, OverseerSnapshot, PairConfirm, PairRequest,
@@ -216,6 +216,31 @@ impl DaemonClient {
             .await
             .map(|b| b.catalog_stale)
             .unwrap_or(false)
+    }
+
+    /// Fetch the daemon's full `GET /health` snapshot.
+    ///
+    /// Why: the `health` verb needs more than the liveness boolean
+    /// [`Self::is_healthy`] returns — it surfaces the daemon's liveness word and
+    /// the catalog-freshness flags (HR-3) in one probe. Reading them as a typed
+    /// struct keeps the verb off raw JSON indexing.
+    /// What: GETs `/health`, returns the parsed [`HealthSnapshot`]. `Err` on any
+    /// transport or decode failure so the caller renders the daemon as
+    /// unreachable rather than panicking. Missing fields default (an older daemon
+    /// returning only `status` still parses).
+    /// Test: `health_snapshot_deserializes` covers the wire shape; the executor's
+    /// `execute_health_*` tests exercise the live and dead-daemon paths.
+    pub async fn health_snapshot(&self) -> anyhow::Result<HealthSnapshot> {
+        let url = format!("{}/health", self.base);
+        let snapshot = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(snapshot)
     }
 
     /// Pause a session via `POST /sessions/{id}/pause`.

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -505,3 +505,25 @@ fn managed_session_urls_use_managed_route_family() {
         "http://127.0.0.1:7880/sessions/abc/resume"
     );
 }
+
+#[test]
+fn health_snapshot_deserializes() {
+    // The `/health` body deserializes into HealthSnapshot; the catalog flags
+    // default when absent so an older daemon returning only `status` still parses.
+    let full: HealthSnapshot = serde_json::from_value(serde_json::json!({
+        "status": "ok",
+        "catalog_stale": true,
+        "catalog_unknown": false,
+        "catalog_changes": ["agents/foo"],
+    }))
+    .expect("full health body parses");
+    assert_eq!(full.status, "ok");
+    assert!(full.catalog_stale);
+    assert!(!full.catalog_unknown);
+
+    let minimal: HealthSnapshot =
+        serde_json::from_value(serde_json::json!({ "status": "ok" })).expect("minimal body parses");
+    assert_eq!(minimal.status, "ok");
+    assert!(!minimal.catalog_stale);
+    assert!(!minimal.catalog_unknown);
+}

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -553,3 +553,26 @@ pub struct ManagedActivityResponse {
     #[serde(default)]
     pub proposed_default: Option<String>,
 }
+
+/// The daemon's `GET /health` snapshot.
+///
+/// Why: the `health` verb reports the daemon's liveness word and the
+/// catalog-freshness flags (HR-3 / DOC-17) in one typed shape, rather than the
+/// bare boolean [`super::DaemonClient::is_healthy`] returns. Mirroring the
+/// daemon's `HealthResponse` field names keeps the wire contract type-checked.
+/// What: `status` is the liveness word (`"ok"` while up); `catalog_stale` is true
+/// when deployed agents/skills drift from the synced catalog; `catalog_unknown`
+/// is true when the catalog has never been synced. All non-`status` fields
+/// default so an older daemon that returns only `status` still parses.
+/// Test: `health_snapshot_deserializes` in `tests.rs`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HealthSnapshot {
+    /// Liveness word — `"ok"` while the daemon is up.
+    pub status: String,
+    /// True when deployed content drifts from the synced catalog (HR-3).
+    #[serde(default)]
+    pub catalog_stale: bool,
+    /// True when the catalog has never been synced (nothing to compare).
+    #[serde(default)]
+    pub catalog_unknown: bool,
+}

--- a/crates/trusty-mpm/src/client/mod.rs
+++ b/crates/trusty-mpm/src/client/mod.rs
@@ -27,14 +27,14 @@ pub use command::TrustyCommand;
 pub use executor::CommandExecutor;
 pub use http_client::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
-    CoordinatorSession, DaemonClient, DiscoveredProjectRow, EventRow, LastSeen, LlmChatOutcome,
-    ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse,
-    ManagedListResponse, ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary,
-    ManagedSpawnRequest, ManagedSpawnResponse, OverseerSnapshot, PairConfirm, PairRequest,
-    PairStatus, SessionRow, TmuxSessionRow,
+    CoordinatorSession, DaemonClient, DiscoveredProjectRow, EventRow, HealthSnapshot, LastSeen,
+    LlmChatOutcome, ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse,
+    ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
+    ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
+    OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow, TmuxSessionRow,
 };
 pub use resolver::{Resolvable, resolve_target};
 pub use result::{
-    CommandResult, DecisionCounts, DiscoveredProjectSummary, ManagedSessionView,
+    CommandResult, DecisionCounts, DiscoveredProjectSummary, HealthReport, ManagedSessionView,
     RecommendationSummary, SessionSummary, TmuxSessionSummary,
 };

--- a/crates/trusty-mpm/src/client/result.rs
+++ b/crates/trusty-mpm/src/client/result.rs
@@ -85,6 +85,38 @@ pub struct RecommendationSummary {
     pub message: String,
 }
 
+/// A daemon health snapshot for the `health` verb.
+///
+/// Why: the `health` verb must report a genuinely useful, transport-free picture
+/// of the stack in one shape every adapter can render — whether the daemon is
+/// reachable, what its `/health` probe reports (liveness + catalog freshness),
+/// and a quick fleet summary (how many managed sessions, how many are blocked on
+/// an operator decision). A dead daemon is conveyed by `reachable: false` rather
+/// than an error, so the result is always renderable.
+/// What: `reachable` is false when the daemon could not be reached at all (the
+/// remaining fields then carry their defaults); `status` is the daemon's liveness
+/// word (`"ok"`, or `"unreachable"` when down); `catalog_stale`/`catalog_unknown`
+/// mirror the `/health` flags; `managed_total` counts managed sessions and
+/// `managed_pending_decisions` counts those blocked on a pending decision.
+/// Test: covered by the executor's `execute_health_*` tests.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HealthReport {
+    /// Whether the daemon was reachable at all (false → the daemon is down).
+    pub reachable: bool,
+    /// Daemon URL the probe targeted.
+    pub url: String,
+    /// Liveness word from `GET /health` (`"unreachable"` when the daemon is down).
+    pub status: String,
+    /// True when deployed agents/skills drift from the synced catalog (HR-3).
+    pub catalog_stale: bool,
+    /// True when the catalog has never been synced (nothing to compare).
+    pub catalog_unknown: bool,
+    /// Total number of managed sessions (0 when unreachable).
+    pub managed_total: usize,
+    /// How many managed sessions are blocked on a pending operator decision.
+    pub managed_pending_decisions: usize,
+}
+
 /// The structured, UI-agnostic outcome of executing a [`crate::TrustyCommand`].
 ///
 /// Why: keeping the result structured (not a string) lets each UI format it in
@@ -209,6 +241,8 @@ pub enum CommandResult {
     },
     /// `/help` — the command list text.
     Help(String),
+    /// `/health` — a daemon health snapshot (reachability + catalog + fleet).
+    Health(HealthReport),
 
     // ── Managed session-manager outcomes (`/api/v1/sessions/managed/*`) ──────
     /// `managed-new` — a managed session was spawned.

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::client::catalog::sm_session_verbs;
+use crate::client::catalog::{sm_ops_verbs, sm_session_verbs};
 use crate::core::sm::control::{LaunchParams, SessionControl, SessionControlError};
 
 /// The sentinel `action` value the model emits to END the action loop.
@@ -266,7 +266,10 @@ pub fn action_instructions() -> String {
          {\"action\":\"final\",\"message\":\"<operator-facing reply>\"}\n\n\
          The verbs available to you (call by exact name):\n",
     );
-    for spec in sm_session_verbs() {
+    // The advertised surface is the session-control verbs PLUS the ops verbs
+    // (e.g. `sessions.health`). Both are rendered from the catalog single source
+    // of truth so the prompt can never advertise a verb the loop cannot execute.
+    for spec in sm_session_verbs().iter().chain(sm_ops_verbs()) {
         out.push_str(&format!(
             "- `{}` — {}\n",
             spec.prompt_signature(),
@@ -315,6 +318,7 @@ pub async fn execute_verb(
         "sessions.stop" => control.stop(require_session_id(args)?).await,
         "sessions.resume" => control.resume(require_session_id(args)?).await,
         "sessions.kill" => control.kill(require_session_id(args)?).await,
+        "sessions.health" => health_via(control).await,
         "sessions.launch" => {
             let workdir = args
                 .get("workdir")
@@ -372,12 +376,62 @@ fn str_arg(args: &Value, key: &str) -> Option<String> {
 }
 
 /// A comma-joined list of valid verb names for the unknown-verb error.
+///
+/// Why: the error fed back to the model must name every executable verb — the
+/// session-control verbs AND the ops verbs (`sessions.health`) — so it can
+/// recover by picking a real one.
+/// What: joins the catalog names of [`sm_session_verbs`] then [`sm_ops_verbs`].
+/// Test: `execute_unknown_verb_errors` (the set is named in the error).
 fn valid_verb_names() -> String {
     sm_session_verbs()
         .iter()
+        .chain(sm_ops_verbs())
         .map(|c| c.name)
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Synthesize a `sessions.health` result from the in-process control surface.
+///
+/// Why: `sessions.health` runs IN-PROCESS through the same [`SessionControl`] the
+/// other action verbs use (no HTTP loopback back to the daemon). The narrow
+/// control trait has no dedicated health method, so health is derived from the
+/// always-available `list` call: if the list resolves, the daemon's
+/// session-manager is reachable and we can summarise the fleet; if it errors, the
+/// control surface is degraded and we report that — never panicking.
+/// What: calls `control.list()`. On success returns
+/// `{ reachable: true, status: "ok", managed_total, managed_pending_decisions }`,
+/// counting sessions whose record carries a `pending_decision`. On error returns
+/// `{ reachable: false, status: "degraded", error }` so the model sees the failure
+/// rather than a thrown error (the action loop also tolerates an `Err`, but a
+/// structured "down" result is more useful to feed back).
+/// Test: `chat_action_tests.rs::execute_health_reports_fleet`.
+async fn health_via(control: &Arc<dyn SessionControl>) -> Result<Value, SessionControlError> {
+    match control.list().await {
+        Ok(listing) => {
+            let sessions = listing.get("sessions").and_then(Value::as_array);
+            let managed_total = sessions.map(Vec::len).unwrap_or(0);
+            let managed_pending_decisions = sessions
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter(|s| s.get("pending_decision").is_some_and(|v| !v.is_null()))
+                        .count()
+                })
+                .unwrap_or(0);
+            Ok(serde_json::json!({
+                "reachable": true,
+                "status": "ok",
+                "managed_total": managed_total,
+                "managed_pending_decisions": managed_pending_decisions,
+            }))
+        }
+        Err(e) => Ok(serde_json::json!({
+            "reachable": false,
+            "status": "degraded",
+            "error": e.to_string(),
+        })),
+    }
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
@@ -127,6 +127,53 @@ fn prompt_lists_every_catalog_verb() {
     assert!(prompt.contains("INLINE"), "must state verbs run inline");
 }
 
+/// Why: the PRIMARY fix — the action loop must ADVERTISE `sessions.health` so the
+/// self-aware coordinator chat knows it can run a health check inline (#1496).
+/// What: asserts the instruction block lists the ops `sessions.health` verb.
+/// Test: this is the test.
+#[test]
+fn prompt_lists_health_ops_verb() {
+    let prompt = action_instructions();
+    assert!(
+        prompt.contains("sessions.health"),
+        "action prompt must advertise the executable `sessions.health` verb"
+    );
+}
+
+/// Why: the PRIMARY fix — `sessions.health` must EXECUTE inline in the action loop
+/// (not just be advertised), synthesizing a fleet summary from the control surface.
+/// What: dispatches `sessions.health` against the mock and asserts the synthesized
+/// reachable=true / status=ok / zero-count shape.
+/// Test: this is the test.
+#[tokio::test]
+async fn execute_health_reports_fleet() {
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let out = execute_verb(&control, "sessions.health", &json!({}))
+        .await
+        .expect("health dispatches");
+    assert_eq!(out.get("reachable").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(out.get("status").and_then(|v| v.as_str()), Some("ok"));
+    assert_eq!(out.get("managed_total").and_then(|v| v.as_u64()), Some(0));
+    assert_eq!(
+        out.get("managed_pending_decisions")
+            .and_then(|v| v.as_u64()),
+        Some(0)
+    );
+}
+
+/// Why: the unknown-verb error must now name `sessions.health` among the valid set
+/// so a model that mistypes it can recover by picking the real ops verb.
+/// What: triggers the unknown-verb error and asserts `sessions.health` is listed.
+/// Test: this is the test.
+#[tokio::test]
+async fn unknown_verb_error_lists_health() {
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let err = execute_verb(&control, "sessions.bogus", &json!({}))
+        .await
+        .expect_err("unknown verb errors");
+    assert!(err.to_string().contains("sessions.health"));
+}
+
 /// Why: `sessions.list` must dispatch to `SessionControl::list`.
 /// What: executes the verb and asserts the mock's list body comes back.
 /// Test: this is the test.

--- a/crates/trusty-mpm/src/telegram/commands.rs
+++ b/crates/trusty-mpm/src/telegram/commands.rs
@@ -83,6 +83,9 @@ pub enum TelegramCommand {
     /// Run a full system diagnostic.
     #[command(description = "Run full system diagnostic")]
     Doctor,
+    /// Report daemon health.
+    #[command(description = "Report daemon health (reachability, catalog, fleet)")]
+    Health,
     /// Show all commands.
     #[command(description = "Show all commands")]
     Help,
@@ -124,6 +127,7 @@ impl From<TelegramCommand> for TrustyCommand {
             },
             TelegramCommand::Start(_) => TrustyCommand::Start,
             TelegramCommand::Doctor => TrustyCommand::Doctor,
+            TelegramCommand::Health => TrustyCommand::Health,
             TelegramCommand::Help => TrustyCommand::Help,
         }
     }
@@ -204,6 +208,11 @@ mod tests {
             TrustyCommand::from(TelegramCommand::Doctor),
             TrustyCommand::Doctor
         );
+        // `/health` maps one-to-one onto the health verb.
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Health),
+            TrustyCommand::Health
+        );
         // `/connect <path>` threads the project path through, no session name.
         assert_eq!(
             TrustyCommand::from(TelegramCommand::Connect("/work/p".into())),
@@ -216,9 +225,10 @@ mod tests {
 
     #[test]
     fn bot_commands_lists_every_command() {
-        // teloxide's generated descriptor must enumerate all nineteen commands.
+        // teloxide's generated descriptor must enumerate all twenty commands.
         let descriptions = TelegramCommand::bot_commands();
-        assert_eq!(descriptions.len(), 19);
+        assert_eq!(descriptions.len(), 20);
+        assert!(descriptions.iter().any(|c| c.command == "/health"));
         assert!(descriptions.iter().any(|c| c.command == "/sessions"));
         assert!(descriptions.iter().any(|c| c.command == "/connect"));
         assert!(descriptions.iter().any(|c| c.command == "/pair"));

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -8,7 +8,7 @@
 //! [`TelegramFormatter::keyboard_for`] the optional inline keyboard.
 //! Test: `cargo test -p trusty-mpm-telegram` covers each variant's rendering.
 
-use crate::client::{CommandResult, DiscoveredProjectSummary, ManagedSessionView};
+use crate::client::{CommandResult, DiscoveredProjectSummary, HealthReport, ManagedSessionView};
 use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup};
 
 #[cfg(test)]
@@ -271,6 +271,7 @@ impl TelegramFormatter {
                 html_escape(state),
             ),
             CommandResult::Help(text) => text.clone(),
+            CommandResult::Health(report) => format_health(report),
             CommandResult::Error(msg) => format!("❌ {msg}"),
         }
     }
@@ -455,6 +456,39 @@ fn format_doctor_report(report: &crate::client::DoctorReport) -> String {
         status_word(report.overall),
     ));
     text
+}
+
+/// Render a [`HealthReport`] as a glanceable Telegram health summary.
+///
+/// Why: the `/health` reply must read at a glance on a phone — daemon up/down
+/// first, then catalog freshness and a one-line fleet summary.
+/// What: leads with a ✅/❌ liveness line (using `reachable`/`status`); when the
+/// daemon is up, appends the catalog-freshness line and the managed fleet counts
+/// (total + how many are blocked on a decision). A down daemon renders just the
+/// liveness line — no fleet (which would all be zero/misleading).
+/// Test: `format_health_up_and_down` in `tests.rs`.
+fn format_health(report: &HealthReport) -> String {
+    if !report.reachable {
+        return format!(
+            "❌ <b>daemon unreachable</b>\n<code>{}</code>",
+            html_escape(&report.url),
+        );
+    }
+    let catalog = if report.catalog_unknown {
+        "catalog: never synced"
+    } else if report.catalog_stale {
+        "catalog: ⚠️ updates available"
+    } else {
+        "catalog: up to date"
+    };
+    format!(
+        "✅ <b>daemon {}</b>\n<code>{}</code>\n{}\nfleet: {} session(s), {} awaiting a decision",
+        html_escape(&report.status),
+        html_escape(&report.url),
+        catalog,
+        report.managed_total,
+        report.managed_pending_decisions,
+    )
 }
 
 /// The emoji icon for a doctor [`CheckStatus`](crate::core::doctor::CheckStatus).

--- a/crates/trusty-mpm/src/telegram/formatter/tests.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/tests.rs
@@ -266,3 +266,34 @@ fn snapshot_escapes_html() {
     let text = TelegramFormatter::format(&result);
     assert!(text.contains("&lt;script&gt;"));
 }
+
+#[test]
+fn format_health_up_and_down() {
+    use crate::client::HealthReport;
+    // A reachable daemon renders the liveness line, catalog state, and fleet counts.
+    let up = CommandResult::Health(HealthReport {
+        reachable: true,
+        url: "http://127.0.0.1:7880".into(),
+        status: "ok".into(),
+        catalog_stale: true,
+        catalog_unknown: false,
+        managed_total: 3,
+        managed_pending_decisions: 1,
+    });
+    let up_text = TelegramFormatter::format(&up);
+    assert!(up_text.contains("daemon"));
+    assert!(up_text.contains("updates available"));
+    assert!(up_text.contains("3 session(s)"));
+    assert!(up_text.contains("1 awaiting a decision"));
+
+    // A dead daemon renders only the unreachable line (no misleading zero fleet).
+    let down = CommandResult::Health(HealthReport {
+        reachable: false,
+        url: "http://127.0.0.1:0".into(),
+        status: "unreachable".into(),
+        ..HealthReport::default()
+    });
+    let down_text = TelegramFormatter::format(&down);
+    assert!(down_text.contains("unreachable"));
+    assert!(!down_text.contains("fleet:"));
+}

--- a/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
@@ -97,6 +97,7 @@ fn route_slash(cmd: SlashCommand, line: &str, focused: Option<&str>) -> Dispatch
     let args = args.trim();
     match cmd {
         SlashCommand::Help => Dispatch::Command(TrustyCommand::Help),
+        SlashCommand::Health => Dispatch::Command(TrustyCommand::Health),
         SlashCommand::Sessions => Dispatch::Command(TrustyCommand::ManagedList),
         SlashCommand::New => route_new(args),
         SlashCommand::Attach => target_only(args, focused, |t| TrustyCommand::ManagedAttachCmd {

--- a/crates/trusty-mpm/src/tui/coordinator/events.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/events.rs
@@ -49,6 +49,8 @@ pub enum SlashCommand {
     Activity,
     /// `/get` (aliases `/status`, `/managed-get`) — fetch a session's record.
     Get,
+    /// `/health` (aliases `/healthcheck`, `/ping`) — report daemon health.
+    Health,
     /// A leading-`/` token that matched none of the known commands.
     Unknown(String),
 }
@@ -109,6 +111,7 @@ pub fn parse_slash(input: &str) -> Option<SlashCommand> {
         "answer" | "approve" | "managed-answer" => SlashCommand::Answer,
         "activity" | "managed-activity" => SlashCommand::Activity,
         "get" | "status" | "managed-get" => SlashCommand::Get,
+        "health" | "healthcheck" | "ping" => SlashCommand::Health,
         other => SlashCommand::Unknown(other.to_string()),
     };
     Some(cmd)

--- a/crates/trusty-mpm/src/tui/coordinator/render.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/render.rs
@@ -20,7 +20,7 @@ use ratatui::{
     text::{Line, Span},
 };
 
-use crate::client::{CommandResult, ManagedSessionView};
+use crate::client::{CommandResult, HealthReport, ManagedSessionView};
 
 /// The style for an error line in the output log.
 ///
@@ -106,11 +106,43 @@ pub fn render_result(result: &CommandResult) -> Vec<Line<'static>> {
             "{action} {name} [{state}] ({})",
             short(id)
         ))],
+        CommandResult::Health(report) => render_health(report),
         // The coordinator does not invoke the legacy project-session/pairing
         // family, but the formatter stays total: render a compact, debug-style
         // fallback so any unexpected variant is still visible rather than blank.
         other => vec![Line::from(format!("{other:?}"))],
     }
+}
+
+/// Render a [`HealthReport`] as a heading plus detail lines.
+///
+/// Why: the `/health` reply in the TUI output log should lead with daemon up/down
+/// (the heading style), then the catalog and fleet detail.
+/// What: an "daemon ok/unreachable" heading; when reachable, detail lines for the
+/// catalog freshness and the fleet counts; when down, an error-styled line only.
+/// Test: `render_result_renders_health` in `super::tests`.
+fn render_health(report: &HealthReport) -> Vec<Line<'static>> {
+    if !report.reachable {
+        return vec![Line::from(Span::styled(
+            format!("✗ daemon unreachable ({})", report.url),
+            error_style(),
+        ))];
+    }
+    let catalog = if report.catalog_unknown {
+        "catalog: never synced"
+    } else if report.catalog_stale {
+        "catalog: updates available"
+    } else {
+        "catalog: up to date"
+    };
+    vec![
+        heading_line(format!("daemon {} ({})", report.status, report.url)),
+        detail_line(catalog.to_string()),
+        detail_line(format!(
+            "fleet: {} session(s), {} awaiting a decision",
+            report.managed_total, report.managed_pending_decisions
+        )),
+    ]
 }
 
 /// Render the managed-session list as a heading plus one row per session.

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -508,6 +508,10 @@ fn parse_slash_recognises_known_commands() {
     assert_eq!(parse_slash("/stop"), Some(SlashCommand::Stop));
     assert_eq!(parse_slash("/resume"), Some(SlashCommand::Resume));
     assert_eq!(parse_slash("/kill"), Some(SlashCommand::Kill));
+    // `/health` and its operator aliases all classify as the health verb.
+    assert_eq!(parse_slash("/health"), Some(SlashCommand::Health));
+    assert_eq!(parse_slash("/healthcheck"), Some(SlashCommand::Health));
+    assert_eq!(parse_slash("/ping"), Some(SlashCommand::Health));
     // Case-insensitive on the verb.
     assert_eq!(parse_slash("/HELP"), Some(SlashCommand::Help));
 }
@@ -1208,6 +1212,11 @@ fn route_slash_maps_to_command() {
         Dispatch::Command(TrustyCommand::ManagedList)
     );
     assert_eq!(route("/help", None), Dispatch::Command(TrustyCommand::Help));
+    // `/health` is a no-target ops verb routing straight to TrustyCommand::Health.
+    assert_eq!(
+        route("/health", None),
+        Dispatch::Command(TrustyCommand::Health)
+    );
     assert_eq!(
         route("/stop red-owl", None),
         Dispatch::Command(TrustyCommand::ManagedRuntimeStop {
@@ -1538,4 +1547,33 @@ fn render_result_renders_help() {
     assert_eq!(lines.len(), 2);
     assert_eq!(line_text(&lines[0]), "line one");
     assert_eq!(line_text(&lines[1]), "line two");
+}
+
+#[test]
+fn render_result_renders_health() {
+    use crate::client::HealthReport;
+    // A reachable daemon renders a heading + catalog + fleet detail lines.
+    let up = render_result(&CommandResult::Health(HealthReport {
+        reachable: true,
+        url: "http://127.0.0.1:7880".into(),
+        status: "ok".into(),
+        catalog_stale: false,
+        catalog_unknown: false,
+        managed_total: 2,
+        managed_pending_decisions: 0,
+    }));
+    let up_joined = up.iter().map(line_text).collect::<Vec<_>>().join("\n");
+    assert!(up_joined.contains("daemon ok"));
+    assert!(up_joined.contains("up to date"));
+    assert!(up_joined.contains("2 session(s)"));
+
+    // A dead daemon renders a single unreachable line.
+    let down = render_result(&CommandResult::Health(HealthReport {
+        reachable: false,
+        url: "http://127.0.0.1:0".into(),
+        status: "unreachable".into(),
+        ..HealthReport::default()
+    }));
+    assert_eq!(down.len(), 1);
+    assert!(line_text(&down[0]).contains("unreachable"));
 }


### PR DESCRIPTION
## Summary

Adds a real `health` verb to the chat-core nucleus, end-to-end, so the
action-capable coordinator chat (`chat_with_actions`, PR #1496) can run a daemon
health check **inline** instead of deflecting ("I don't have the capability…").

Spec: DOC-20 — `docs/specs/chat-core.md` (SPEC-CHAT-CORE-01). Epic: #1433.

## What `health` reports
- **Daemon reachability** — `GET /health` liveness word. A dead daemon renders as
  `CommandResult::Health { reachable: false, status: "unreachable", .. }`, **never a panic**.
- **Catalog freshness** — `catalog_stale` / `catalog_unknown` (HR-3) read from the
  existing `/health` route.
- **Managed-fleet summary** — total managed sessions + how many are blocked on a
  pending operator decision, reused from the existing `list_managed_sessions` call.
  **No new daemon route was invented** — `/health` already existed; the fleet
  summary reuses the managed-list endpoint.

## Nucleus wiring (mirrors the existing managed verbs)
- `TrustyCommand::Health` (no args).
- `CommandResult::Health(HealthReport)` — structured, transport-free; down-daemon
  is a renderable result, not a panic.
- `DaemonClient::health_snapshot()` — typed `GET /health` → `HealthSnapshot`.
- `CommandExecutor::health()` — in a focused `executor/health.rs` submodule.
- Catalog entry `health` — aliases `healthcheck`, `ping`. **Not** `status` (already
  the project-session status verb — collision avoided; asserted by a test).

## Adapters + action loop (the point of the nucleus)
- **`tm` CLI**: new `tm health` subcommand routes `TrustyCommand::Health` through the shared `CommandExecutor`.
- **STUI**: `/health` (+ `/healthcheck`, `/ping`) parse → route → `TrustyCommand::Health`, with a dedicated TUI render.
- **Telegram**: `/health` bot command maps to `TrustyCommand::Health`, with an HTML formatter arm.
- **Action loop (PRIMARY fix)**: `sessions.health` is now **advertised AND executed**
  by `chat_with_actions` via `execute_verb`, synthesizing the fleet summary from the
  in-process `SessionControl` — **no trait change, no HTTP loopback**.

## SM_TOOLS.md regenerated? **No.** Why
`render_sm_tools()` renders only the session-control / memory / goals tables. The
`health` ops verb lives in a **separate** `SM_OPS_VERBS` slice (`sm_ops_verbs()`)
that the action loop advertises + dispatches but `render_sm_tools()` ignores. So the
committed `SM_TOOLS.md` stays byte-identical and `sm_tools_md_matches_catalog_render`
passes unchanged — the minimal-surface option per DOC-20 §3. A guard test
(`render_sm_tools_omits_ops_verbs`) pins this decision.

## Tests
- Catalog: coverage + help-text + no-duplicate-name/alias + `status`-collision guard.
- Executor: `execute_health_against_test_daemon` (live shape) and
  `execute_health_dead_daemon_renders` (down → renderable, not a panic).
- Wire: `health_snapshot_deserializes` (incl. older-daemon missing-field default).
- Action loop: `prompt_lists_health_ops_verb`, `execute_health_reports_fleet`,
  `unknown_verb_error_lists_health`.
- Adapters: Telegram `format_health_up_and_down` + command conversion; STUI
  `parse_slash` / `route_slash_maps_to_command` / `render_result_renders_health`;
  CLI `cli_parses_health`.

> Note: this local environment resolves tokio 1.52.3 under Homebrew rust 1.95,
> which panics ("Cannot drop a runtime…") in the pre-existing `spawn_test_daemon`
> helper — so every daemon-spawning `#[tokio::test]` (104 of them, incl. the
> untouched baseline tests) fails identically and pre-existingly here. All
> pure-logic tests, including the catalog parity test, pass. CI runs the pinned
> `dtolnay/rust-toolchain@1.91`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)