### PR TITLE
feat(trusty-mpm): drive managed fleet from Telegram — free-text→action chat + managed slash commands

### DIFF
--- a/crates/trusty-mpm/src/client/executor/sessions.rs
+++ b/crates/trusty-mpm/src/client/executor/sessions.rs
@@ -381,7 +381,7 @@ impl CommandExecutor {
     /// What: calls `POST /api/v1/sessions/chat` with an empty history.
     /// Test: `coordinator_chat_outcome_deserializes` in the client tests.
     pub(super) async fn coordinator_chat(&self, message: &str) -> CommandResult {
-        match self.client().coordinator_chat(message, &[]).await {
+        match self.client().coordinator_chat(message, &[], false).await {
             Ok(Some(outcome)) => {
                 let reply = match outcome.command_output {
                     Some(output) => format!("{}\n{output}", outcome.reply),

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -782,7 +782,7 @@ impl DaemonClient {
 /// What: returns a JSON object with `message`, `history`, and the `actions`
 /// boolean (the flag that routes the action-capable SM branch when `true`).
 /// Test: `coordinator_chat_serializes_actions_flag`.
-pub(crate) fn coordinator_chat_body(
+fn coordinator_chat_body(
     message: &str,
     history: &[ChatMessage],
     actions: bool,

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -707,22 +707,29 @@ impl DaemonClient {
     /// Why: the coordinator is the operator's one conversational surface over
     /// every session — a `@prefix:` message routes a command at a named
     /// session, a plain message is answered by the LLM with full session
-    /// context. The UI owns the rolling chat history and threads it through.
-    /// What: POSTs `{ message, history }` to `/api/v1/sessions/chat`; returns
+    /// context, and when `actions` is `true` the session-manager may invoke
+    /// managed-session verbs INLINE (#1283) so natural language can DRIVE the
+    /// fleet, not merely describe it. The UI owns the rolling chat history and
+    /// threads it through.
+    /// What: POSTs `{ message, history, actions }` to `/api/v1/sessions/chat`;
+    /// the `actions` flag opts into the action-capable SM branch. Returns
     /// `Ok(Some(outcome))` on success, `Ok(None)` when the daemon answers `503`
     /// (LLM not configured for a non-prefixed message), and `Err` on transport
-    /// failure.
-    /// Test: `coordinator_chat_outcome_deserializes` covers the wire shape.
+    /// failure. On the action path the outcome's `actions_taken` lists any verbs
+    /// that ran.
+    /// Test: `coordinator_chat_outcome_deserializes`,
+    /// `coordinator_chat_serializes_actions_flag` cover the wire shape.
     pub async fn coordinator_chat(
         &self,
         message: &str,
         history: &[ChatMessage],
+        actions: bool,
     ) -> anyhow::Result<Option<CoordinatorChatOutcome>> {
         let url = format!("{}/api/v1/sessions/chat", self.base);
         let resp = self
             .http
             .post(&url)
-            .json(&serde_json::json!({ "message": message, "history": history }))
+            .json(&coordinator_chat_body(message, history, actions))
             .send()
             .await?;
         if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
@@ -764,6 +771,27 @@ impl DaemonClient {
         let report = request.send().await?.error_for_status()?.json().await?;
         Ok(report)
     }
+}
+
+/// Build the `POST /api/v1/sessions/chat` request body.
+///
+/// Why: extracting the body shape from [`DaemonClient::coordinator_chat`] makes
+/// the `actions` opt-in serializable and unit-testable without a live HTTP
+/// round-trip — the wire contract is what the daemon's
+/// `CoordinatorChatRequest` reads, so it must be pinned by a test.
+/// What: returns a JSON object with `message`, `history`, and the `actions`
+/// boolean (the flag that routes the action-capable SM branch when `true`).
+/// Test: `coordinator_chat_serializes_actions_flag`.
+pub(crate) fn coordinator_chat_body(
+    message: &str,
+    history: &[ChatMessage],
+    actions: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "message": message,
+        "history": history,
+        "actions": actions,
+    })
 }
 
 /// Render a tmux snapshot JSON value as a flat text block.

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -267,6 +267,41 @@ fn coordinator_chat_outcome_deserializes() {
     let outcome: CoordinatorChatOutcome = serde_json::from_value(json).unwrap();
     assert_eq!(outcome.reply, "two sessions are active");
     assert!(outcome.routed_to_session.is_none());
+    // Additive action-path fields default to None when absent.
+    assert!(outcome.actions_taken.is_none());
+    assert!(outcome.conv_id.is_none());
+}
+
+#[test]
+fn coordinator_chat_outcome_deserializes_actions() {
+    // The action-capable path returns the audit trail and the conversation id.
+    let json = serde_json::json!({
+        "reply": "ran a health check and listed the fleet",
+        "actions_taken": ["sessions.health", "sessions.list"],
+        "conv_id": "conv-42",
+    });
+    let outcome: CoordinatorChatOutcome = serde_json::from_value(json).unwrap();
+    assert_eq!(
+        outcome.actions_taken.as_deref(),
+        Some(["sessions.health".to_string(), "sessions.list".to_string()].as_slice())
+    );
+    assert_eq!(outcome.conv_id.as_deref(), Some("conv-42"));
+}
+
+#[test]
+fn coordinator_chat_serializes_actions_flag() {
+    // The request body must carry the `actions` boolean so the daemon can route
+    // the action-capable SM branch; history is threaded through verbatim.
+    let history = [ChatMessage::user("hi"), ChatMessage::assistant("hello")];
+    let body = coordinator_chat_body("spin up a session", &history, true);
+    assert_eq!(body["message"], "spin up a session");
+    assert_eq!(body["actions"], true);
+    assert_eq!(body["history"][0]["role"], "user");
+    assert_eq!(body["history"][1]["content"], "hello");
+
+    // The passive path serializes `actions: false`.
+    let passive = coordinator_chat_body("just chatting", &[], false);
+    assert_eq!(passive["actions"], false);
 }
 
 #[test]

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -317,11 +317,17 @@ pub struct CoordinatorContext {
 
 /// Outcome of a `POST /api/v1/sessions/chat` call.
 ///
-/// Why: a coordinator message resolves to either a routed command or an LLM
-/// answer; the caller renders both from this one shape.
+/// Why: a coordinator message resolves to either a routed command, an LLM
+/// answer, or — on the action-capable path (`actions: true`, #1283) — an LLM
+/// answer plus an audit trail of the managed verbs the session-manager invoked
+/// inline; the caller renders all three from this one shape.
 /// What: the `reply` text; `routed_to_session` and `command_output` are
-/// populated only when the message was routed to a session by `@prefix:`.
-/// Test: `coordinator_chat_outcome_deserializes`.
+/// populated only when the message was routed to a session by `@prefix:`;
+/// `actions_taken` lists the verbs executed this turn (only when `actions: true`
+/// routed the SM branch and at least one verb ran), and `conv_id` echoes the SM
+/// conversation id so a follow-up turn can continue the same rolling context.
+/// Test: `coordinator_chat_outcome_deserializes`,
+/// `coordinator_chat_outcome_deserializes_actions`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct CoordinatorChatOutcome {
     /// The assistant reply, or a note about the routed command.
@@ -332,6 +338,16 @@ pub struct CoordinatorChatOutcome {
     /// Captured pane output from a routed command, if any.
     #[serde(default)]
     pub command_output: Option<String>,
+    /// The managed verbs the SM invoked inline this turn, in order, for the
+    /// operator's audit trail. Absent (`None`) on the text-only, legacy, and
+    /// prefix paths and when no verb ran; `Some([...])` only when at least one
+    /// verb executed on the `actions: true` path.
+    #[serde(default)]
+    pub actions_taken: Option<Vec<String>>,
+    /// The SM conversation id this turn used, echoed so a follow-up can continue
+    /// the same rolling context. Present only on the SM (action-capable) path.
+    #[serde(default)]
+    pub conv_id: Option<String>,
 }
 
 // ── Managed session-manager wire types (`/api/v1/sessions/managed/*`) ───────────

--- a/crates/trusty-mpm/src/telegram/commands.rs
+++ b/crates/trusty-mpm/src/telegram/commands.rs
@@ -86,6 +86,34 @@ pub enum TelegramCommand {
     /// Report daemon health.
     #[command(description = "Report daemon health (reachability, catalog, fleet)")]
     Health,
+    /// Launch a managed session — `/launch <workdir> | <task...>`.
+    // The argument tail is split on the first `|`: the left side is the
+    // workdir/repo (mapped to `repo_url` with an empty `git_ref`), the right side
+    // is the task. A plain `//` comment keeps the syntax note out of the
+    // teloxide-generated description (Telegram caps it at 256 chars).
+    #[command(description = "Launch a managed session: /launch <workdir> | <task>")]
+    Launch(String),
+    /// List managed (fleet) sessions.
+    #[command(description = "List managed fleet sessions")]
+    Fleet,
+    /// Get one managed session — `/get <id|name>`.
+    #[command(description = "Get a managed session by id or name")]
+    Get(String),
+    /// Send text to a managed session — `/msend <id|name> <text>`.
+    #[command(description = "Send text to a managed session")]
+    Msend(String),
+    /// Answer a managed session's pending decision — `/answer <id|name> <text>`.
+    #[command(description = "Answer a managed session's pending decision")]
+    Answer(String),
+    /// Inspect a managed session's activity — `/activity <id|name>`.
+    #[command(description = "Inspect a managed session's activity")]
+    Activity(String),
+    /// Resume a stopped managed session — `/resume <id|name>`.
+    #[command(description = "Resume a stopped managed session")]
+    Resume(String),
+    /// Decommission a managed session — `/decommission <id|name>`.
+    #[command(description = "Decommission a managed session (terminal)")]
+    Decommission(String),
     /// Show all commands.
     #[command(description = "Show all commands")]
     Help,
@@ -128,8 +156,74 @@ impl From<TelegramCommand> for TrustyCommand {
             TelegramCommand::Start(_) => TrustyCommand::Start,
             TelegramCommand::Doctor => TrustyCommand::Doctor,
             TelegramCommand::Health => TrustyCommand::Health,
+            TelegramCommand::Launch(args) => {
+                let (repo_url, task) = split_launch_args(&args);
+                TrustyCommand::ManagedNew {
+                    repo_url,
+                    git_ref: String::new(),
+                    task,
+                    name_hint: None,
+                    runtime: None,
+                }
+            }
+            TelegramCommand::Fleet => TrustyCommand::ManagedList,
+            TelegramCommand::Get(target) => TrustyCommand::ManagedGet {
+                target: target.trim().to_string(),
+            },
+            TelegramCommand::Msend(args) => {
+                let (target, text) = split_target_args(&args);
+                TrustyCommand::ManagedSend { target, text }
+            }
+            TelegramCommand::Answer(args) => {
+                let (target, answer) = split_target_args(&args);
+                TrustyCommand::ManagedAnswer { target, answer }
+            }
+            TelegramCommand::Activity(target) => TrustyCommand::ManagedActivity {
+                target: target.trim().to_string(),
+            },
+            TelegramCommand::Resume(target) => TrustyCommand::ManagedResume {
+                target: target.trim().to_string(),
+            },
+            TelegramCommand::Decommission(target) => TrustyCommand::ManagedDecommission {
+                target: target.trim().to_string(),
+            },
             TelegramCommand::Help => TrustyCommand::Help,
         }
+    }
+}
+
+/// Split a `/launch` argument tail into `(workdir, task)` on the first `|`.
+///
+/// Why: launching a managed session needs a workspace and a task; Telegram hands
+/// the whole tail as one string, so `/launch <workdir> | <task...>` is parsed
+/// here. The pipe keeps multi-word workdirs and tasks unambiguous without a
+/// fixed token count.
+/// What: returns the trimmed text before the first `|` as the workdir and the
+/// trimmed remainder as the task. With no `|`, the whole tail is treated as the
+/// workdir and the task is empty — the executor then reports the missing task
+/// (never a panic), and the help text documents the usage.
+/// Test: `split_launch_args_splits_on_pipe`, `launch_command_converts`.
+fn split_launch_args(args: &str) -> (String, String) {
+    match args.split_once('|') {
+        Some((workdir, task)) => (workdir.trim().to_string(), task.trim().to_string()),
+        None => (args.trim().to_string(), String::new()),
+    }
+}
+
+/// Split a managed `target <text...>` argument tail into `(target, text)`.
+///
+/// Why: `/msend` and `/answer` carry the session id/name as the first token and
+/// the (possibly multi-word) payload as the remainder; teloxide hands the whole
+/// tail as one string, so the split happens here.
+/// What: returns the first whitespace-separated token as `target` and the
+/// trimmed remainder as the payload; both are empty strings when absent (the
+/// executor then reports the missing argument rather than panicking).
+/// Test: `split_target_args_separates_target_and_text`, `msend_command_converts`.
+fn split_target_args(args: &str) -> (String, String) {
+    let trimmed = args.trim();
+    match trimmed.split_once(char::is_whitespace) {
+        Some((target, text)) => (target.to_string(), text.trim().to_string()),
+        None => (trimmed.to_string(), String::new()),
     }
 }
 
@@ -225,9 +319,10 @@ mod tests {
 
     #[test]
     fn bot_commands_lists_every_command() {
-        // teloxide's generated descriptor must enumerate all twenty commands.
+        // teloxide's generated descriptor must enumerate all commands: the 20
+        // legacy ones plus the 8 managed-fleet verbs added for the drive surface.
         let descriptions = TelegramCommand::bot_commands();
-        assert_eq!(descriptions.len(), 20);
+        assert_eq!(descriptions.len(), 28);
         assert!(descriptions.iter().any(|c| c.command == "/health"));
         assert!(descriptions.iter().any(|c| c.command == "/sessions"));
         assert!(descriptions.iter().any(|c| c.command == "/connect"));
@@ -238,6 +333,112 @@ mod tests {
         assert!(descriptions.iter().any(|c| c.command == "/send"));
         assert!(descriptions.iter().any(|c| c.command == "/discover"));
         assert!(descriptions.iter().any(|c| c.command == "/doctor"));
+        // The managed-fleet drive verbs.
+        assert!(descriptions.iter().any(|c| c.command == "/launch"));
+        assert!(descriptions.iter().any(|c| c.command == "/fleet"));
+        assert!(descriptions.iter().any(|c| c.command == "/get"));
+        assert!(descriptions.iter().any(|c| c.command == "/msend"));
+        assert!(descriptions.iter().any(|c| c.command == "/answer"));
+        assert!(descriptions.iter().any(|c| c.command == "/activity"));
+        assert!(descriptions.iter().any(|c| c.command == "/resume"));
+        assert!(descriptions.iter().any(|c| c.command == "/decommission"));
+    }
+
+    #[test]
+    fn split_launch_args_splits_on_pipe() {
+        // `/launch <workdir> | <task...>` splits on the first pipe; both sides
+        // are trimmed and the task may be multi-word.
+        let (workdir, task) = split_launch_args("/work/repo | run the full test suite");
+        assert_eq!(workdir, "/work/repo");
+        assert_eq!(task, "run the full test suite");
+        // With no pipe, the whole tail is the workdir and the task is empty.
+        let (workdir, task) = split_launch_args("/work/repo");
+        assert_eq!(workdir, "/work/repo");
+        assert!(task.is_empty());
+    }
+
+    #[test]
+    fn split_target_args_separates_target_and_text() {
+        // The first token is the target; the remainder (multi-word) is the text.
+        let (target, text) = split_target_args("sess-1 please continue now");
+        assert_eq!(target, "sess-1");
+        assert_eq!(text, "please continue now");
+        // A target with no text yields an empty payload.
+        let (target, text) = split_target_args("sess-1");
+        assert_eq!(target, "sess-1");
+        assert!(text.is_empty());
+    }
+
+    #[test]
+    fn launch_command_converts() {
+        // `/launch <workdir> | <task>` maps to ManagedNew with an empty git_ref.
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Launch("/work/repo | build it".into())),
+            TrustyCommand::ManagedNew {
+                repo_url: "/work/repo".into(),
+                git_ref: String::new(),
+                task: "build it".into(),
+                name_hint: None,
+                runtime: None,
+            }
+        );
+    }
+
+    #[test]
+    fn fleet_command_converts() {
+        // `/fleet` lists the managed fleet — distinct from legacy `/sessions`.
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Fleet),
+            TrustyCommand::ManagedList
+        );
+    }
+
+    #[test]
+    fn get_command_converts() {
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Get(" sess-1 ".into())),
+            TrustyCommand::ManagedGet {
+                target: "sess-1".into()
+            }
+        );
+    }
+
+    #[test]
+    fn msend_command_converts() {
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Msend("sess-1 build now".into())),
+            TrustyCommand::ManagedSend {
+                target: "sess-1".into(),
+                text: "build now".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn answer_command_converts() {
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Answer("sess-1 yes proceed".into())),
+            TrustyCommand::ManagedAnswer {
+                target: "sess-1".into(),
+                answer: "yes proceed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn activity_resume_decommission_convert() {
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Activity("a".into())),
+            TrustyCommand::ManagedActivity { target: "a".into() }
+        );
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Resume("b".into())),
+            TrustyCommand::ManagedResume { target: "b".into() }
+        );
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Decommission("c".into())),
+            TrustyCommand::ManagedDecommission { target: "c".into() }
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/telegram/mod.rs
+++ b/crates/trusty-mpm/src/telegram/mod.rs
@@ -46,6 +46,19 @@ type ChatHistories = Arc<Mutex<HashMap<i64, Vec<ChatMessage>>>>;
 const LLM_NOT_CONFIGURED: &str =
     "LLM chat not configured — set OPENROUTER_API_KEY in .env.local and enable the overseer";
 
+/// Maximum number of `ChatMessage`s retained per chat in the rolling history.
+///
+/// Why: the coordinator is stateless about conversations, so the bot keeps the
+/// history client-side and re-sends it every turn. Without a bound this grows
+/// without limit for the life of the process — unbounded memory and an
+/// ever-larger prompt payload (cost + latency) on a long-lived chat. Capping to
+/// the most recent turns keeps memory flat and the context window relevant.
+/// What: 20 messages = the last 10 user/assistant exchanges; after appending a
+/// turn the front of the history is drained so its length never exceeds this.
+/// Test: `record_chat_turn_caps_history` pushes past the cap and asserts the
+/// length is clamped and the oldest messages are dropped.
+const MAX_CHAT_HISTORY_TURNS: usize = 20;
+
 /// Environment variable that overrides the Telegram bot's `@username`.
 const BOT_USERNAME_ENV: &str = "TELEGRAM_BOT_USERNAME";
 
@@ -382,8 +395,7 @@ async fn action_chat_reply(
             {
                 let mut guard = histories.lock().expect("chat history mutex poisoned");
                 let entry = guard.entry(chat_id).or_default();
-                entry.push(ChatMessage::user(text));
-                entry.push(ChatMessage::assistant(&outcome.reply));
+                record_chat_turn(entry, text, &outcome.reply);
             }
             let mut body = formatter::html_escape(&outcome.reply);
             if let Some(output) = outcome.command_output.as_deref()
@@ -399,6 +411,28 @@ async fn action_chat_reply(
         }
         Ok(None) => LLM_NOT_CONFIGURED.to_string(),
         Err(e) => format!("❌ chat: daemon error: {e}"),
+    }
+}
+
+/// Append one conversation turn to a chat's rolling history, bounded.
+///
+/// Why: the coordinator is stateless, so the bot persists each turn client-side;
+/// this centralizes the two invariants that keep that store healthy — a sliding
+/// window cap ([`MAX_CHAT_HISTORY_TURNS`], so history can't grow without bound)
+/// and skipping empty assistant replies (an empty turn pollutes the context
+/// window and the re-sent prompt with a meaningless message).
+/// What: always pushes the user turn; pushes the assistant turn only when `reply`
+/// is non-empty; then drains the front of `entry` so its length is at most
+/// `MAX_CHAT_HISTORY_TURNS`, dropping the oldest messages first.
+/// Test: `record_chat_turn_caps_history` and `record_chat_turn_skips_empty_reply`.
+fn record_chat_turn(entry: &mut Vec<ChatMessage>, text: &str, reply: &str) {
+    entry.push(ChatMessage::user(text));
+    if !reply.is_empty() {
+        entry.push(ChatMessage::assistant(reply));
+    }
+    if entry.len() > MAX_CHAT_HISTORY_TURNS {
+        let overflow = entry.len() - MAX_CHAT_HISTORY_TURNS;
+        entry.drain(0..overflow);
     }
 }
 
@@ -608,152 +642,4 @@ async fn poll_overseer_alert(client: &reqwest::Client, daemon_url: &str) -> Opti
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_token_reads_dotenv() {
-        use std::io::Write;
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(".env");
-        let mut file = std::fs::File::create(&path).unwrap();
-        writeln!(file, "TELEGRAM_BOT_TOKEN=\"123:ABC\"").unwrap();
-        let value = read_dotenv_key(&path, "TELEGRAM_BOT_TOKEN");
-        assert_eq!(value.as_deref(), Some("123:ABC"));
-    }
-
-    #[test]
-    fn resolve_token_missing_is_none() {
-        let value = read_dotenv_key(Path::new("/no/such/.env"), "TELEGRAM_BOT_TOKEN");
-        assert!(value.is_none());
-    }
-
-    #[test]
-    fn resolve_username_uses_env_when_set() {
-        // An explicit value wins over the default and is trimmed.
-        assert_eq!(resolve_username(Some("my_bot".into())), "my_bot");
-        assert_eq!(resolve_username(Some("  my_bot  ".into())), "my_bot");
-    }
-
-    #[test]
-    fn resolve_username_falls_back_when_unset() {
-        // No env var → the real deployed bot default.
-        assert_eq!(resolve_username(None), DEFAULT_BOT_USERNAME);
-        assert_eq!(resolve_username(None), "t_sess_bot");
-    }
-
-    #[test]
-    fn resolve_username_falls_back_when_empty() {
-        // Empty or whitespace-only env value is treated as unset.
-        assert_eq!(resolve_username(Some(String::new())), DEFAULT_BOT_USERNAME);
-        assert_eq!(resolve_username(Some("   ".into())), DEFAULT_BOT_USERNAME);
-    }
-
-    #[test]
-    fn authorization_respects_allowed_user() {
-        let unrestricted = BotOptions::default();
-        assert!(is_authorized(&unrestricted, Some(7)));
-        assert!(is_authorized(&unrestricted, None));
-
-        let restricted = BotOptions {
-            allowed_user_id: Some(42),
-            alert_chat_id: None,
-        };
-        assert!(is_authorized(&restricted, Some(42)));
-        assert!(!is_authorized(&restricted, Some(99)));
-        assert!(!is_authorized(&restricted, None));
-    }
-
-    /// Spawn the daemon's real HTTP API on a random loopback port.
-    ///
-    /// Why: lets the bot's command dispatch be tested against the genuine
-    /// daemon routes without a live daemon, tmux, or external network.
-    /// What: builds `api::router(DaemonState::shared())`, binds an ephemeral
-    /// port, serves it on a background task, and returns the state plus base URL.
-    /// Test: used by the `dispatch_*` tests below.
-    async fn spawn_test_daemon() -> (std::sync::Arc<crate::daemon::state::DaemonState>, String) {
-        use crate::daemon::{api, state::DaemonState};
-        use std::future::IntoFuture;
-        // Root the daemon's persisted state at a throwaway temp directory so
-        // the test never reads (or writes) the operator's real pairing record.
-        // `keep` leaks the directory so it outlives the background server.
-        let root = tempfile::tempdir().unwrap().keep();
-        let state = std::sync::Arc::new(DaemonState::with_root(root));
-        let router = api::router(std::sync::Arc::clone(&state));
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(axum::serve(listener, router).into_future());
-        (state, format!("http://{addr}"))
-    }
-
-    #[tokio::test]
-    async fn action_chat_reply_reports_unconfigured() {
-        // A default test daemon has the SM disabled and no OpenRouter key, so a
-        // free-text message routed through the action-capable coordinator gets
-        // the not-configured hint rather than a model reply.
-        let (_state, url) = spawn_test_daemon().await;
-        let executor = CommandExecutor::new(url);
-        let histories: ChatHistories = Arc::new(Mutex::new(HashMap::new()));
-        let reply = action_chat_reply(&executor, &histories, 42, "hello there").await;
-        assert_eq!(reply, LLM_NOT_CONFIGURED);
-        // No history is stored when chat is unconfigured.
-        assert!(histories.lock().unwrap().get(&42).is_none());
-    }
-
-    #[test]
-    fn action_footer_lists_verbs() {
-        // A non-empty audit trail renders as a compact italic footer so the
-        // operator sees exactly which verbs the free-text turn executed.
-        let verbs = vec!["sessions.health".to_string(), "sessions.list".to_string()];
-        let footer = action_footer(Some(&verbs)).expect("footer for non-empty verbs");
-        assert_eq!(footer, "\n\n<i>ran: sessions.health, sessions.list</i>");
-    }
-
-    #[test]
-    fn action_footer_absent_when_empty() {
-        // No verbs ran (None) or an empty list both suppress the footer — a
-        // text-only turn must not advertise side effects.
-        assert!(action_footer(None).is_none());
-        assert!(action_footer(Some(&[])).is_none());
-    }
-
-    #[tokio::test]
-    async fn dispatch_help_returns_help() {
-        let executor = CommandExecutor::new("http://unused");
-        let result = dispatch_command(TelegramCommand::Help, &executor, 1).await;
-        assert!(matches!(result, CommandResult::Help(_)));
-    }
-
-    #[tokio::test]
-    async fn dispatch_start_with_no_code_queries_state() {
-        // `/start` with no code is a pairing-status query against the daemon.
-        let (_state, url) = spawn_test_daemon().await;
-        let executor = CommandExecutor::new(url);
-        let result = dispatch_command(TelegramCommand::Start(String::new()), &executor, 1).await;
-        match result {
-            CommandResult::PairState { paired } => assert!(!paired),
-            other => panic!("expected PairState, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn dispatch_start_with_deep_link_code_confirms() {
-        // `/start <code>` (the `?start=` deep-link form) confirms the code.
-        let (state, url) = spawn_test_daemon().await;
-        let code = state.generate_pair_code();
-        let executor = CommandExecutor::new(url);
-        let result = dispatch_command(TelegramCommand::Start(code), &executor, 555).await;
-        match result {
-            CommandResult::PairSuccess { chat_info } => assert!(chat_info.contains("555")),
-            other => panic!("expected PairSuccess, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn dispatch_pair_with_bad_code_errors() {
-        let (_state, url) = spawn_test_daemon().await;
-        let executor = CommandExecutor::new(url);
-        let result = dispatch_command(TelegramCommand::Pair("ZZZZZZ".into()), &executor, 1).await;
-        assert!(matches!(result, CommandResult::Error(_)));
-    }
-}
+mod tests;

--- a/crates/trusty-mpm/src/telegram/mod.rs
+++ b/crates/trusty-mpm/src/telegram/mod.rs
@@ -33,11 +33,11 @@ use alerts::{AlertConfig, LastSeen};
 use commands::TelegramCommand;
 use formatter::TelegramFormatter;
 
-/// Per-chat LLM conversation history, keyed by Telegram `chat_id`.
+/// Per-chat coordinator conversation history, keyed by Telegram `chat_id`.
 ///
-/// Why: free-text (non-command) messages route to the daemon's LLM chat, which
-/// is stateless about conversations — the bot holds the rolling history per
-/// chat and threads it through each turn.
+/// Why: free-text (non-command) messages route to the action-capable
+/// coordinator, which is stateless about conversations — the bot holds the
+/// rolling history per chat and threads it through each turn.
 /// What: an `Arc<Mutex<…>>` of chat-id → message-history so every teloxide
 /// handler task shares one conversation store.
 type ChatHistories = Arc<Mutex<HashMap<i64, Vec<ChatMessage>>>>;
@@ -287,10 +287,11 @@ async fn on_message(
     let command = match TelegramCommand::parse(text, &bot_username()) {
         Ok(cmd) => cmd,
         Err(_) => {
-            // Not a slash command — route the free text to LLM chat (unless the
-            // message is empty, in which case there is nothing to ask).
+            // Not a slash command — route the free text to the action-capable
+            // coordinator so natural language can DRIVE the fleet (#1283), unless
+            // the message is empty, in which case there is nothing to ask.
             if !text.trim().is_empty() {
-                let reply = llm_chat_reply(&executor, &histories, msg.chat.id.0, text).await;
+                let reply = action_chat_reply(&executor, &histories, msg.chat.id.0, text).await;
                 bot.send_message(msg.chat.id, reply)
                     .parse_mode(ParseMode::Html)
                     .await?;
@@ -341,16 +342,26 @@ async fn dispatch_command(
     }
 }
 
-/// Route a free-text message to the daemon's LLM chat and render the reply.
+/// Route a free-text message to the action-capable coordinator and render it.
 ///
-/// Why: messages that are not slash commands are treated as conversation; the
-/// bot holds the per-chat history and threads it through `POST /llm/chat`.
-/// What: loads this chat's history, calls [`DaemonClient::llm_chat`], stores the
-/// updated history on success, and returns the assistant reply (HTML-escaped).
-/// When the daemon reports LLM chat is not configured (`503`) it returns the
-/// [`LLM_NOT_CONFIGURED`] hint; a transport failure returns an error line.
-/// Test: `llm_chat_reply_reports_unconfigured` covers the not-configured path.
-async fn llm_chat_reply(
+/// Why: messages that are not slash commands are treated as conversation that
+/// can DRIVE the managed fleet — routing them through the coordinator with
+/// `actions: true` lets the session-manager invoke managed-session verbs inline
+/// (#1283), so "spin up a session for repo X" actually does it rather than
+/// merely describing it. The bot holds the per-chat history and threads it
+/// through `POST /api/v1/sessions/chat`; the coordinator is stateless about
+/// conversations, so the user turn and the assistant reply are appended here.
+/// What: loads this chat's history, calls
+/// [`DaemonClient::coordinator_chat`](crate::client::DaemonClient::coordinator_chat)
+/// with `actions = true`, appends the user/assistant turns to the stored history
+/// on success, and returns the HTML-escaped reply. When the coordinator routed a
+/// `@prefix:` command its captured pane output is appended; when one or more
+/// verbs executed, a compact italic `ran: …` footer is appended so the operator
+/// sees what ran. A `503` returns the [`LLM_NOT_CONFIGURED`] hint; a transport
+/// failure returns an error line.
+/// Test: `action_chat_reply_reports_unconfigured` covers the not-configured
+/// path; `action_footer_lists_verbs` covers the footer rendering.
+async fn action_chat_reply(
     executor: &CommandExecutor,
     histories: &ChatHistories,
     chat_id: i64,
@@ -360,17 +371,53 @@ async fn llm_chat_reply(
         let guard = histories.lock().expect("chat history mutex poisoned");
         guard.get(&chat_id).cloned().unwrap_or_default()
     };
-    match executor.client().llm_chat(text, &history).await {
+    match executor
+        .client()
+        .coordinator_chat(text, &history, true)
+        .await
+    {
         Ok(Some(outcome)) => {
-            histories
-                .lock()
-                .expect("chat history mutex poisoned")
-                .insert(chat_id, outcome.history);
-            formatter::html_escape(&outcome.reply)
+            // The coordinator keeps no conversation state of its own, so persist
+            // this turn (user message + assistant reply) for the next message.
+            {
+                let mut guard = histories.lock().expect("chat history mutex poisoned");
+                let entry = guard.entry(chat_id).or_default();
+                entry.push(ChatMessage::user(text));
+                entry.push(ChatMessage::assistant(&outcome.reply));
+            }
+            let mut body = formatter::html_escape(&outcome.reply);
+            if let Some(output) = outcome.command_output.as_deref()
+                && !output.is_empty()
+            {
+                body.push('\n');
+                body.push_str(&formatter::html_escape(output));
+            }
+            if let Some(footer) = action_footer(outcome.actions_taken.as_deref()) {
+                body.push_str(&footer);
+            }
+            body
         }
         Ok(None) => LLM_NOT_CONFIGURED.to_string(),
         Err(e) => format!("❌ chat: daemon error: {e}"),
     }
+}
+
+/// Build a compact "ran: …" footer listing the verbs the coordinator executed.
+///
+/// Why: when free-text drives the fleet, the operator must see the audit trail
+/// of what actually ran — silent side effects are dangerous on a remote surface.
+/// What: returns `Some("\n\n<i>ran: a, b</i>")` (HTML-escaped, comma-joined) when
+/// `actions` is `Some` and non-empty; `None` otherwise (text-only turns add no
+/// footer). A `Some(&[])` is treated as "nothing ran" and yields `None`.
+/// Test: `action_footer_lists_verbs`, `action_footer_absent_when_empty`.
+fn action_footer(actions: Option<&[String]>) -> Option<String> {
+    let verbs = actions.filter(|v| !v.is_empty())?;
+    let joined = verbs
+        .iter()
+        .map(|v| formatter::html_escape(v))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!("\n\n<i>ran: {joined}</i>"))
 }
 
 /// teloxide callback-query handler for inline-keyboard buttons.
@@ -640,16 +687,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn llm_chat_reply_reports_unconfigured() {
-        // A default test daemon has no OpenRouter key, so a free-text message
-        // gets the not-configured hint rather than a model reply.
+    async fn action_chat_reply_reports_unconfigured() {
+        // A default test daemon has the SM disabled and no OpenRouter key, so a
+        // free-text message routed through the action-capable coordinator gets
+        // the not-configured hint rather than a model reply.
         let (_state, url) = spawn_test_daemon().await;
         let executor = CommandExecutor::new(url);
         let histories: ChatHistories = Arc::new(Mutex::new(HashMap::new()));
-        let reply = llm_chat_reply(&executor, &histories, 42, "hello there").await;
+        let reply = action_chat_reply(&executor, &histories, 42, "hello there").await;
         assert_eq!(reply, LLM_NOT_CONFIGURED);
         // No history is stored when chat is unconfigured.
         assert!(histories.lock().unwrap().get(&42).is_none());
+    }
+
+    #[test]
+    fn action_footer_lists_verbs() {
+        // A non-empty audit trail renders as a compact italic footer so the
+        // operator sees exactly which verbs the free-text turn executed.
+        let verbs = vec!["sessions.health".to_string(), "sessions.list".to_string()];
+        let footer = action_footer(Some(&verbs)).expect("footer for non-empty verbs");
+        assert_eq!(footer, "\n\n<i>ran: sessions.health, sessions.list</i>");
+    }
+
+    #[test]
+    fn action_footer_absent_when_empty() {
+        // No verbs ran (None) or an empty list both suppress the footer — a
+        // text-only turn must not advertise side effects.
+        assert!(action_footer(None).is_none());
+        assert!(action_footer(Some(&[])).is_none());
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/telegram/tests.rs
+++ b/crates/trusty-mpm/src/telegram/tests.rs
@@ -1,0 +1,196 @@
+//! Unit tests for the Telegram drive surface.
+//!
+//! Why: this lives in a sibling `tests.rs` (a recognized test-file path) so the
+//! production `telegram/mod.rs` stays under the 500-SLOC production cap while the
+//! suite shares `mod.rs`'s private items via `use super::*`.
+//! What: covers token/username resolution, authorization, the action-capable
+//! coordinator reply path, the bounded chat-history recorder, the action footer,
+//! and command dispatch against a real in-process daemon router.
+//! Test: this *is* the test module.
+
+use super::*;
+
+#[test]
+fn resolve_token_reads_dotenv() {
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(".env");
+    let mut file = std::fs::File::create(&path).unwrap();
+    writeln!(file, "TELEGRAM_BOT_TOKEN=\"123:ABC\"").unwrap();
+    let value = read_dotenv_key(&path, "TELEGRAM_BOT_TOKEN");
+    assert_eq!(value.as_deref(), Some("123:ABC"));
+}
+
+#[test]
+fn resolve_token_missing_is_none() {
+    let value = read_dotenv_key(Path::new("/no/such/.env"), "TELEGRAM_BOT_TOKEN");
+    assert!(value.is_none());
+}
+
+#[test]
+fn resolve_username_uses_env_when_set() {
+    // An explicit value wins over the default and is trimmed.
+    assert_eq!(resolve_username(Some("my_bot".into())), "my_bot");
+    assert_eq!(resolve_username(Some("  my_bot  ".into())), "my_bot");
+}
+
+#[test]
+fn resolve_username_falls_back_when_unset() {
+    // No env var → the real deployed bot default.
+    assert_eq!(resolve_username(None), DEFAULT_BOT_USERNAME);
+    assert_eq!(resolve_username(None), "t_sess_bot");
+}
+
+#[test]
+fn resolve_username_falls_back_when_empty() {
+    // Empty or whitespace-only env value is treated as unset.
+    assert_eq!(resolve_username(Some(String::new())), DEFAULT_BOT_USERNAME);
+    assert_eq!(resolve_username(Some("   ".into())), DEFAULT_BOT_USERNAME);
+}
+
+#[test]
+fn authorization_respects_allowed_user() {
+    let unrestricted = BotOptions::default();
+    assert!(is_authorized(&unrestricted, Some(7)));
+    assert!(is_authorized(&unrestricted, None));
+
+    let restricted = BotOptions {
+        allowed_user_id: Some(42),
+        alert_chat_id: None,
+    };
+    assert!(is_authorized(&restricted, Some(42)));
+    assert!(!is_authorized(&restricted, Some(99)));
+    assert!(!is_authorized(&restricted, None));
+}
+
+/// Spawn the daemon's real HTTP API on a random loopback port.
+///
+/// Why: lets the bot's command dispatch be tested against the genuine
+/// daemon routes without a live daemon, tmux, or external network.
+/// What: builds `api::router(DaemonState::shared())`, binds an ephemeral
+/// port, serves it on a background task, and returns the state plus base URL.
+/// Test: used by the `dispatch_*` tests below.
+async fn spawn_test_daemon() -> (std::sync::Arc<crate::daemon::state::DaemonState>, String) {
+    use crate::daemon::{api, state::DaemonState};
+    use std::future::IntoFuture;
+    // Root the daemon's persisted state at a throwaway temp directory so
+    // the test never reads (or writes) the operator's real pairing record.
+    // `keep` leaks the directory so it outlives the background server.
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root(root));
+    let router = api::router(std::sync::Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    (state, format!("http://{addr}"))
+}
+
+#[tokio::test]
+async fn action_chat_reply_reports_unconfigured() {
+    // A default test daemon has the SM disabled and no OpenRouter key, so a
+    // free-text message routed through the action-capable coordinator gets
+    // the not-configured hint rather than a model reply.
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url);
+    let histories: ChatHistories = Arc::new(Mutex::new(HashMap::new()));
+    let reply = action_chat_reply(&executor, &histories, 42, "hello there").await;
+    assert_eq!(reply, LLM_NOT_CONFIGURED);
+    // No history is stored when chat is unconfigured.
+    assert!(histories.lock().unwrap().get(&42).is_none());
+}
+
+#[test]
+fn record_chat_turn_caps_history() {
+    // Pushing far past the cap must clamp the stored history to the last
+    // MAX_CHAT_HISTORY_TURNS messages and drop the oldest first, so a
+    // long-lived chat can't grow the history (and the re-sent prompt)
+    // without bound.
+    let mut entry: Vec<ChatMessage> = Vec::new();
+    let turns = MAX_CHAT_HISTORY_TURNS * 2; // each turn pushes 2 messages
+    for i in 0..turns {
+        record_chat_turn(&mut entry, &format!("user {i}"), &format!("reply {i}"));
+    }
+    // Length is clamped to the cap, never above it.
+    assert_eq!(entry.len(), MAX_CHAT_HISTORY_TURNS);
+    // The oldest messages were dropped: the very first user turn is gone…
+    assert!(
+        !entry.iter().any(|m| m.content == "user 0"),
+        "oldest turn must be evicted"
+    );
+    // …and the most recent turn is retained.
+    let last = turns - 1;
+    assert_eq!(entry.last().unwrap().content, format!("reply {last}"));
+}
+
+#[test]
+fn record_chat_turn_skips_empty_reply() {
+    // An empty assistant reply must not be stored — only the user turn is
+    // persisted — so the context window isn't polluted with a blank message.
+    let mut entry: Vec<ChatMessage> = Vec::new();
+    record_chat_turn(&mut entry, "hello", "");
+    assert_eq!(entry.len(), 1);
+    assert_eq!(entry[0].role, "user");
+    assert_eq!(entry[0].content, "hello");
+    // A non-empty reply still stores both turns.
+    record_chat_turn(&mut entry, "again", "there");
+    assert_eq!(entry.len(), 3);
+    assert_eq!(entry[2].role, "assistant");
+    assert_eq!(entry[2].content, "there");
+}
+
+#[test]
+fn action_footer_lists_verbs() {
+    // A non-empty audit trail renders as a compact italic footer so the
+    // operator sees exactly which verbs the free-text turn executed.
+    let verbs = vec!["sessions.health".to_string(), "sessions.list".to_string()];
+    let footer = action_footer(Some(&verbs)).expect("footer for non-empty verbs");
+    assert_eq!(footer, "\n\n<i>ran: sessions.health, sessions.list</i>");
+}
+
+#[test]
+fn action_footer_absent_when_empty() {
+    // No verbs ran (None) or an empty list both suppress the footer — a
+    // text-only turn must not advertise side effects.
+    assert!(action_footer(None).is_none());
+    assert!(action_footer(Some(&[])).is_none());
+}
+
+#[tokio::test]
+async fn dispatch_help_returns_help() {
+    let executor = CommandExecutor::new("http://unused");
+    let result = dispatch_command(TelegramCommand::Help, &executor, 1).await;
+    assert!(matches!(result, CommandResult::Help(_)));
+}
+
+#[tokio::test]
+async fn dispatch_start_with_no_code_queries_state() {
+    // `/start` with no code is a pairing-status query against the daemon.
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url);
+    let result = dispatch_command(TelegramCommand::Start(String::new()), &executor, 1).await;
+    match result {
+        CommandResult::PairState { paired } => assert!(!paired),
+        other => panic!("expected PairState, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_start_with_deep_link_code_confirms() {
+    // `/start <code>` (the `?start=` deep-link form) confirms the code.
+    let (state, url) = spawn_test_daemon().await;
+    let code = state.generate_pair_code();
+    let executor = CommandExecutor::new(url);
+    let result = dispatch_command(TelegramCommand::Start(code), &executor, 555).await;
+    match result {
+        CommandResult::PairSuccess { chat_info } => assert!(chat_info.contains("555")),
+        other => panic!("expected PairSuccess, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_pair_with_bad_code_errors() {
+    let (_state, url) = spawn_test_daemon().await;
+    let executor = CommandExecutor::new(url);
+    let result = dispatch_command(TelegramCommand::Pair("ZZZZZZ".into()), &executor, 1).await;
+    assert!(matches!(result, CommandResult::Error(_)));
+}

--- a/crates/trusty-mpm/src/tui/mod.rs
+++ b/crates/trusty-mpm/src/tui/mod.rs
@@ -236,7 +236,10 @@ pub(crate) async fn coordinator_send(
     message: &str,
 ) {
     state.push_chat(ChatMessage::user(message));
-    match client.coordinator_chat(message, &state.coord_history).await {
+    match client
+        .coordinator_chat(message, &state.coord_history, false)
+        .await
+    {
         Ok(Some(outcome)) => {
             let reply = match outcome.command_output {
                 Some(output) => format!("{}\n{output}", outcome.reply),


### PR DESCRIPTION
## What changed

Makes the Telegram surface DRIVE the managed fleet, not just describe it. Two parts, scoped to the Telegram + client/http_client layers (no session-manager backend, daemon route, or action-loop catalog changes — those are owned by a parallel engineer).

### Part 1 — free-text → action chat
Non-slash messages used to fall into a passive `llm_chat` path (LLM answer, no actions). They now route through the **action-capable coordinator** so natural language executes managed-session verbs inline (#1283).

- `DaemonClient::coordinator_chat` gains an `actions: bool` param, serialized as `"actions"` in the `POST /api/v1/sessions/chat` body. Body construction extracted to a testable `coordinator_chat_body` helper.
- `CoordinatorChatOutcome` gains `actions_taken: Option<Vec<String>>` and `conv_id: Option<String>` (the daemon already emits both) so the executed-verb audit trail is surfaced.
- Telegram free-text handler (`action_chat_reply`) calls the coordinator with `actions=true`, renders the reply, appends any routed `command_output`, and appends a compact footer `\n\n<i>ran: sessions.health, sessions.list</i>` when verbs executed. Per-chat history is preserved (the coordinator is conversation-stateless, so the user turn + assistant reply are appended client-side).

### Part 2 — managed verbs as Telegram slash commands
Extends `TelegramCommand` + its `From<TelegramCommand> for TrustyCommand` conversion + the bot command list. **Reuses the existing `TrustyCommand::Managed*` variants** — no new `TrustyCommand` variants. Results render through the existing Telegram formatter (every managed result variant was already covered, so no formatter change was needed).

| Slash command | TrustyCommand mapping |
|---|---|
| `/launch <workdir> \| <task...>` | `ManagedNew { repo_url: <workdir>, git_ref: "", task: <task>, name_hint: None, runtime: None }` |
| `/fleet` | `ManagedList` |
| `/get <id\|name>` | `ManagedGet { target }` |
| `/msend <id\|name> <text>` | `ManagedSend { target, text }` |
| `/answer <id\|name> <text>` | `ManagedAnswer { target, answer }` |
| `/activity <id\|name>` | `ManagedActivity { target }` |
| `/resume <id\|name>` | `ManagedResume { target }` |
| `/decommission <id\|name>` | `ManagedDecommission { target }` |

**Naming:** distinct from the legacy project-session surface to avoid collisions — `/fleet` (not `/sessions`), `/msend` (not `/send`), `/decommission` (not `/kill`). `/launch` uses a pipe-delimited `<workdir> | <task>` syntax so multi-word workdirs and tasks are unambiguous without a fixed token count. Malformed args parse pragmatically (empty fields) and the executor reports the missing argument — never a panic.

## Tests
- `commands.rs`: parse + convert for every new verb; `split_launch_args` (pipe split) and `split_target_args` (token split); `bot_commands_lists_every_command` updated 20→28.
- `http_client/tests.rs`: `coordinator_chat_serializes_actions_flag` (request body shape), `coordinator_chat_outcome_deserializes_actions` (`actions_taken`/`conv_id`), and the existing deserialize test extended for the additive defaults.
- `telegram/mod.rs`: `action_footer_lists_verbs`, `action_footer_absent_when_empty`, and the renamed `action_chat_reply_reports_unconfigured`.

All 19 new/affected **pure-logic** tests pass. `cargo clippy -p trusty-mpm --all-targets -- -D warnings` is clean; `cargo fmt --check` clean; `bash scripts/check_line_cap.sh` exits 0.

**Local test note:** the full `cargo test -p trusty-mpm` reports `1524 passed; 106 failed`. All 106 failures are pre-existing/environmental: 104 are the known tokio runtime-drop panic in daemon-spawning tests (the untouched `dispatch_start_with_no_code_queries_state` fails identically), and 2 are `daemon::state::tests` overseer-disabled assertions that fail because `OPENROUTER_API_KEY` is set in this local shell. None originate from this change. CI on pinned 1.91 is the gate.

Epic: #1433 · Spec: DOC-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)