### PR TITLE
feat(trusty-mpm): adopt existing tmux sessions + local-path managed spawn (refs #1433)

### DIFF
--- a/crates/trusty-mpm/src/client/catalog/mod.rs
+++ b/crates/trusty-mpm/src/client/catalog/mod.rs
@@ -297,6 +297,13 @@ const COMMANDS: &[CommandSpec] = &[
         summary: "decommission a managed session (terminal; removes workspace)",
         kind: SpecKind::Command,
     },
+    CommandSpec {
+        name: "managed-adopt",
+        aliases: &[],
+        args: "<tmux_name> <cwd>",
+        summary: "adopt an existing tmux session into the managed store",
+        kind: SpecKind::Command,
+    },
     // ── Ops / diagnostics ───────────────────────────────────────────────────
     CommandSpec {
         name: "health",
@@ -397,6 +404,7 @@ mod tests {
             "managed-stop",
             "managed-resume",
             "managed-decommission",
+            "managed-adopt",
             "health",
             "help",
         ] {
@@ -471,6 +479,7 @@ mod tests {
             "/managed-stop",
             "/managed-resume",
             "/managed-decommission",
+            "/managed-adopt",
             "/health",
             "/help",
         ] {

--- a/crates/trusty-mpm/src/client/catalog/sm_tools.rs
+++ b/crates/trusty-mpm/src/client/catalog/sm_tools.rs
@@ -85,17 +85,28 @@ const SM_SESSION_VERBS: &[CommandSpec] = &[
 /// `sessions.*` spelling so the action-loop prompt and dispatch stay uniform with
 /// [`SM_SESSION_VERBS`].
 /// What: the ops verb slice the action loop appends to [`SM_SESSION_VERBS`] —
-/// currently just `sessions.health`.
-/// Test: `sm_ops_verbs_exposes_health`; `chat_action_tests.rs` asserts the prompt
-/// lists `sessions.health` and that it dispatches; the SM-tools parity test proves
-/// these are NOT rendered into `SM_TOOLS.md`.
-const SM_OPS_VERBS: &[CommandSpec] = &[CommandSpec {
-    name: "sessions.health",
-    aliases: &[],
-    args: "",
-    summary: "Report daemon health: reachability, catalog freshness, and a fleet summary",
-    kind: SpecKind::SmOnly,
-}];
+/// `sessions.health` plus `sessions.adopt` (#1433), kept OUT of `SM_TOOLS.md` for
+/// the same minimal-surface reason: adopting an existing pane is an operator/ops
+/// action, not part of the SM's session-control prompt tables.
+/// Test: `sm_ops_verbs_exposes_health`, `sm_ops_verbs_exposes_adopt`;
+/// `chat_action_tests.rs` asserts the prompt lists these and that they dispatch;
+/// the SM-tools parity test proves they are NOT rendered into `SM_TOOLS.md`.
+const SM_OPS_VERBS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "sessions.health",
+        aliases: &[],
+        args: "",
+        summary: "Report daemon health: reachability, catalog freshness, and a fleet summary",
+        kind: SpecKind::SmOnly,
+    },
+    CommandSpec {
+        name: "sessions.adopt",
+        aliases: &[],
+        args: "tmux_name, cwd, task?, runtime?",
+        summary: "Adopt an existing unmanaged tmux session into the managed store",
+        kind: SpecKind::SmOnly,
+    },
+];
 
 /// The SM memory verbs (prompt table only).
 const SM_MEMORY_VERBS: &[CommandSpec] = &[
@@ -322,6 +333,14 @@ mod tests {
             names.contains(&"sessions.health"),
             "missing ops health verb"
         );
+    }
+
+    #[test]
+    fn sm_ops_verbs_exposes_adopt() {
+        // The action-loop ops slice must advertise `sessions.adopt` so the
+        // self-aware chat can adopt an existing tmux session inline (#1433).
+        let names: Vec<&str> = sm_ops_verbs().iter().map(|c| c.name).collect();
+        assert!(names.contains(&"sessions.adopt"), "missing ops adopt verb");
     }
 
     #[test]

--- a/crates/trusty-mpm/src/client/command.rs
+++ b/crates/trusty-mpm/src/client/command.rs
@@ -222,6 +222,27 @@ pub enum TrustyCommand {
         /// Managed session id or friendly name.
         target: String,
     },
+    /// Adopt an EXISTING unmanaged tmux session into the managed store
+    /// (`sessions.adopt`, #1433).
+    ///
+    /// Why: connect the managed surface to a pane the operator already has (a
+    /// hand-started session, an externally-created one, or one whose record was
+    /// lost) so it can be driven through observe/send/stop/resume. Distinct from
+    /// the project-session `Adopt` (oversight-only, stateless): this REGISTERS a
+    /// durable managed record via `POST /api/v1/sessions/managed/adopt`.
+    /// What: the live `tmux_name` to adopt, the REQUIRED `cwd` (provenance is
+    /// unknown so the operator supplies it), an optional `task`, and an optional
+    /// `runtime` selector (`claude-code` | `tcode`).
+    ManagedAdopt {
+        /// The live tmux session name to adopt (any name; need not be `tmpm-`).
+        tmux_name: String,
+        /// Working directory the adopted session runs in (required).
+        cwd: String,
+        /// Optional human-readable task description (empty allowed).
+        task: Option<String>,
+        /// Optional runtime selector (`claude-code` | `tcode`).
+        runtime: Option<String>,
+    },
 
     /// Report daemon health: reachability + catalog freshness + fleet summary.
     ///

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -14,7 +14,7 @@
 //! Test: the `execute_managed_*` tests in `tests.rs` (wire-shape + dispatch).
 
 use super::CommandExecutor;
-use crate::client::http_client::{ManagedSessionSummary, ManagedSpawnRequest};
+use crate::client::http_client::{ManagedAdoptRequest, ManagedSessionSummary, ManagedSpawnRequest};
 use crate::client::resolver::resolve_target;
 use crate::client::result::{CommandResult, ManagedSessionView};
 
@@ -69,6 +69,47 @@ impl CommandExecutor {
                 attach_cmd: resp.attach_cmd,
             },
             Err(e) => CommandResult::Error(format!("spawn failed: {e}")),
+        }
+    }
+
+    /// `managed-adopt` — adopt an EXISTING tmux session into the managed store
+    /// (#1433).
+    ///
+    /// Why: connect the managed surface to a pane the operator already has so it
+    /// can be driven through observe/send/stop/resume. `cwd` is required because
+    /// the pane's provenance is unknown to the daemon.
+    /// What: validates `tmux_name`/`cwd` are non-empty, POSTs the adopt request,
+    /// and returns a [`CommandResult::ManagedAdopted`]; a transport/HTTP failure
+    /// (including the daemon's typed 404/409) becomes a renderable error.
+    /// Test: `execute_managed_adopt_*` in `tests.rs`.
+    pub(super) async fn managed_adopt(
+        &self,
+        tmux_name: String,
+        cwd: String,
+        task: Option<String>,
+        runtime: Option<String>,
+    ) -> CommandResult {
+        if tmux_name.trim().is_empty() {
+            return CommandResult::Error("adopt: tmux_name is required".to_string());
+        }
+        if cwd.trim().is_empty() {
+            return CommandResult::Error("adopt: cwd is required".to_string());
+        }
+        let req = ManagedAdoptRequest {
+            tmux_name,
+            cwd,
+            task,
+            runtime,
+        };
+        match self.client().adopt_managed_session(&req).await {
+            Ok(resp) => CommandResult::ManagedAdopted {
+                id: resp.id,
+                name: resp.name,
+                state: resp.state,
+                runtime: resp.runtime,
+                attach_cmd: resp.attach_cmd,
+            },
+            Err(e) => CommandResult::Error(format!("adopt failed: {e}")),
         }
     }
 

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -106,6 +106,7 @@ impl CommandExecutor {
                 id: resp.id,
                 name: resp.name,
                 state: resp.state,
+                cwd: resp.cwd,
                 runtime: resp.runtime,
                 attach_cmd: resp.attach_cmd,
             },

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -152,6 +152,12 @@ impl CommandExecutor {
             TrustyCommand::ManagedDecommission { target } => {
                 self.managed_decommission(&target).await
             }
+            TrustyCommand::ManagedAdopt {
+                tmux_name,
+                cwd,
+                task,
+                runtime,
+            } => self.managed_adopt(tmux_name, cwd, task, runtime).await,
             // ── Pairing (state query only; confirm needs a chat id) ──────────
             // `Start` (the bot's entry command) and a bare `Pair` (no code) both
             // mean "show me the current pairing state", so they share one arm.

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -405,6 +405,44 @@ async fn execute_send_empty_prompt_errors() {
 }
 
 #[tokio::test]
+async fn execute_managed_adopt_requires_tmux_name() {
+    // Validation is pure — no daemon needed. An empty tmux_name is rejected with a
+    // renderable error before any HTTP call (#1433).
+    let executor = CommandExecutor::new("http://unused");
+    match executor
+        .execute(TrustyCommand::ManagedAdopt {
+            tmux_name: "  ".into(),
+            cwd: "/x".into(),
+            task: None,
+            runtime: None,
+        })
+        .await
+    {
+        CommandResult::Error(msg) => assert!(msg.contains("tmux_name")),
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn execute_managed_adopt_requires_cwd() {
+    // The cwd is required because the pane's provenance is unknown to the daemon;
+    // an empty cwd is rejected before any HTTP call (#1433).
+    let executor = CommandExecutor::new("http://unused");
+    match executor
+        .execute(TrustyCommand::ManagedAdopt {
+            tmux_name: "tmpm-x".into(),
+            cwd: "".into(),
+            task: None,
+            runtime: None,
+        })
+        .await
+    {
+        CommandResult::Error(msg) => assert!(msg.contains("cwd")),
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn pair_request_returns_code() {
     let (_state, url) = spawn_test_daemon().await;
     let executor = CommandExecutor::new(url);

--- a/crates/trusty-mpm/src/client/http_client/managed.rs
+++ b/crates/trusty-mpm/src/client/http_client/managed.rs
@@ -18,9 +18,9 @@ use anyhow::Context;
 
 use super::DaemonClient;
 use super::types::{
-    ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse,
-    ManagedListResponse, ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary,
-    ManagedSpawnRequest, ManagedSpawnResponse,
+    ManagedActivityResponse, ManagedAdoptRequest, ManagedAdoptResponse, ManagedAnswerRequest,
+    ManagedAnswerResponse, ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
+    ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
 };
 
 impl DaemonClient {
@@ -83,6 +83,35 @@ impl DaemonClient {
             .json()
             .await?;
         Ok(resp)
+    }
+
+    /// Adopt an EXISTING tmux session via `POST /api/v1/sessions/managed/adopt`
+    /// (#1433).
+    ///
+    /// Why: register a durable managed record for a pane the operator already has,
+    /// so it can be driven through the full managed surface. Distinct from the
+    /// stateless `POST /tmux/adopt` snapshot endpoint.
+    /// What: POSTs `req` and returns the daemon's [`ManagedAdoptResponse`]. The
+    /// daemon answers typed 404 (no such pane) / 409 (already adopted) / 400 (bad
+    /// runtime) errors; rather than swallow them, a non-success status is flattened
+    /// into an `anyhow` error carrying the HTTP status and the response body so the
+    /// caller can surface both.
+    /// Test: `managed_adopt_request_serializes` /
+    /// `managed_adopt_response_deserializes` cover the wire shapes; live HTTP via
+    /// `tests/session_manager_mvp.rs`.
+    pub async fn adopt_managed_session(
+        &self,
+        req: &ManagedAdoptRequest,
+    ) -> anyhow::Result<ManagedAdoptResponse> {
+        let url = format!("{}/api/v1/sessions/managed/adopt", self.base);
+        let resp = self.http.post(&url).json(req).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("adopt failed (HTTP {status}): {body}");
+        }
+        let adopted = resp.json().await.context("decoding adopt response body")?;
+        Ok(adopted)
     }
 
     /// Inject text into a session's pane via `POST .../{id}/send`.

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -21,10 +21,10 @@ mod types;
 pub use types::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
     CoordinatorSession, DiscoveredProjectRow, EventRow, HealthSnapshot, LastSeen, LlmChatOutcome,
-    ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse,
-    ManagedListResponse, ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary,
-    ManagedSpawnRequest, ManagedSpawnResponse, OverseerSnapshot, PairConfirm, PairRequest,
-    PairStatus, SessionRow, TmuxSessionRow,
+    ManagedActivityResponse, ManagedAdoptRequest, ManagedAdoptResponse, ManagedAnswerRequest,
+    ManagedAnswerResponse, ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
+    ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
+    OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow, TmuxSessionRow,
 };
 
 use serde::Deserialize;

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -445,6 +445,61 @@ fn managed_spawn_response_deserializes() {
 }
 
 #[test]
+fn managed_adopt_request_serializes() {
+    // Required fields are always present; absent optionals are omitted so the
+    // daemon defaults them (#1433).
+    let req = ManagedAdoptRequest {
+        tmux_name: "tmpm-hand-started".to_string(),
+        cwd: "/Users/op/work/proj".to_string(),
+        task: Some("drive it".to_string()),
+        runtime: Some("claude-code".to_string()),
+    };
+    let v = serde_json::to_value(&req).unwrap();
+    assert_eq!(v["tmux_name"], "tmpm-hand-started");
+    assert_eq!(v["cwd"], "/Users/op/work/proj");
+    assert_eq!(v["task"], "drive it");
+    assert_eq!(v["runtime"], "claude-code");
+
+    let bare = ManagedAdoptRequest {
+        tmux_name: "my-cli-session".to_string(),
+        cwd: "/x".to_string(),
+        task: None,
+        runtime: None,
+    };
+    let v = serde_json::to_value(&bare).unwrap();
+    assert_eq!(v["tmux_name"], "my-cli-session");
+    assert!(v.get("task").is_none(), "None task is omitted");
+    assert!(v.get("runtime").is_none(), "None runtime is omitted");
+}
+
+#[test]
+fn managed_adopt_response_deserializes() {
+    let json = serde_json::json!({
+        "id": "id-9",
+        "name": "tmpm-hand-started",
+        "state": "active",
+        "cwd": "/Users/op/work/proj",
+        "runtime": "claude-code",
+        "attach_cmd": "tmux attach-session -t tmpm-hand-started",
+    });
+    let r: ManagedAdoptResponse = serde_json::from_value(json).unwrap();
+    assert_eq!(r.id, "id-9");
+    assert_eq!(r.name, "tmpm-hand-started");
+    assert_eq!(r.state, "active");
+    assert_eq!(r.cwd, "/Users/op/work/proj");
+    assert_eq!(r.runtime, "claude-code");
+    assert_eq!(r.attach_cmd, "tmux attach-session -t tmpm-hand-started");
+
+    // A lean response (only id/name/state) still deserializes; the defaulted
+    // string fields fall back to empty.
+    let lean = serde_json::json!({"id": "id-10", "name": "x", "state": "active"});
+    let r: ManagedAdoptResponse = serde_json::from_value(lean).unwrap();
+    assert_eq!(r.cwd, "");
+    assert_eq!(r.runtime, "");
+    assert_eq!(r.attach_cmd, "");
+}
+
+#[test]
 fn managed_send_and_answer_round_trip() {
     let v = serde_json::to_value(ManagedSendInputRequest {
         text: "hello".to_string(),

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -467,6 +467,52 @@ pub struct ManagedSpawnResponse {
     pub runtime: String,
 }
 
+/// Request body for `POST /api/v1/sessions/managed/adopt` (#1433).
+///
+/// Why: adopting an EXISTING tmux session connects the managed surface to a pane
+/// the operator already has. The pane's provenance is unknown to the daemon, so
+/// `cwd` is REQUIRED; `task`/`runtime` are optional.
+/// What: mirrors `daemon::managed_routes::AdoptExistingRequest` field-for-field.
+/// Test: `managed_adopt_request_serializes` in `tests.rs`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagedAdoptRequest {
+    /// The live tmux session name to adopt (any name; need not be `tmpm-`).
+    pub tmux_name: String,
+    /// Working directory the adopted session runs in (required).
+    pub cwd: String,
+    /// Optional human-readable task description (empty/absent allowed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    /// Optional runtime selector (`"claude-code"` | `"tcode"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
+}
+
+/// Response body for `POST /api/v1/sessions/managed/adopt` (201 Created, #1433).
+///
+/// Why: the caller needs the new managed record's identity, state, runtime, and
+/// attach command immediately after adoption.
+/// What: mirrors `daemon::managed_routes::AdoptExistingResponse`.
+/// Test: `managed_adopt_response_deserializes` in `tests.rs`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedAdoptResponse {
+    /// Managed session id (UUID string).
+    pub id: String,
+    /// tmux session name that was adopted.
+    pub name: String,
+    /// Current lifecycle state (`active` immediately after adoption).
+    pub state: String,
+    /// Working directory the adopted session runs in.
+    #[serde(default)]
+    pub cwd: String,
+    /// Runtime backend hosting the session (`"claude-code"` | `"tcode"`).
+    #[serde(default)]
+    pub runtime: String,
+    /// tmux attach command string.
+    #[serde(default)]
+    pub attach_cmd: String,
+}
+
 /// Request body for `POST /api/v1/sessions/managed/{id}/send`.
 ///
 /// Why: inject operator/agent text into a session's tmux pane.

--- a/crates/trusty-mpm/src/client/mod.rs
+++ b/crates/trusty-mpm/src/client/mod.rs
@@ -28,10 +28,11 @@ pub use executor::CommandExecutor;
 pub use http_client::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
     CoordinatorSession, DaemonClient, DiscoveredProjectRow, EventRow, HealthSnapshot, LastSeen,
-    LlmChatOutcome, ManagedActivityResponse, ManagedAnswerRequest, ManagedAnswerResponse,
-    ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
-    ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
-    OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow, TmuxSessionRow,
+    LlmChatOutcome, ManagedActivityResponse, ManagedAdoptRequest, ManagedAdoptResponse,
+    ManagedAnswerRequest, ManagedAnswerResponse, ManagedAttachCmdResponse, ManagedListResponse,
+    ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest,
+    ManagedSpawnResponse, OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow,
+    TmuxSessionRow,
 };
 pub use resolver::{Resolvable, resolve_target};
 pub use result::{

--- a/crates/trusty-mpm/src/client/result.rs
+++ b/crates/trusty-mpm/src/client/result.rs
@@ -309,6 +309,25 @@ pub enum CommandResult {
         /// tmux attach command string.
         attach_cmd: String,
     },
+    /// `managed-adopt` — an existing tmux session was adopted into the managed
+    /// store (#1433).
+    ///
+    /// Why: the operator needs the new managed session's identity and the exact
+    /// tmux command to drive/attach immediately after adoption.
+    /// What: the new record's id, friendly name, lifecycle state (`active`),
+    /// runtime backend, and the attach command string.
+    ManagedAdopted {
+        /// Managed session id (UUID string).
+        id: String,
+        /// tmux session name that was adopted.
+        name: String,
+        /// Current lifecycle state word (`active` immediately after adoption).
+        state: String,
+        /// Runtime backend (`claude-code` | `tcode`).
+        runtime: String,
+        /// tmux attach command string.
+        attach_cmd: String,
+    },
     /// `managed-stop`/`managed-resume`/`managed-decommission` — the updated
     /// lifecycle state after a runtime transition.
     ///

--- a/crates/trusty-mpm/src/client/result.rs
+++ b/crates/trusty-mpm/src/client/result.rs
@@ -315,7 +315,9 @@ pub enum CommandResult {
     /// Why: the operator needs the new managed session's identity and the exact
     /// tmux command to drive/attach immediately after adoption.
     /// What: the new record's id, friendly name, lifecycle state (`active`),
-    /// runtime backend, and the attach command string.
+    /// the registered working directory, runtime backend, and the attach command
+    /// string. `cwd` is surfaced so the operator can confirm the directory the
+    /// daemon recorded for the adopted pane (its provenance is otherwise unknown).
     ManagedAdopted {
         /// Managed session id (UUID string).
         id: String,
@@ -323,6 +325,8 @@ pub enum CommandResult {
         name: String,
         /// Current lifecycle state word (`active` immediately after adoption).
         state: String,
+        /// Working directory the daemon registered for the adopted session.
+        cwd: String,
         /// Runtime backend (`claude-code` | `tcode`).
         runtime: String,
         /// tmux attach command string.

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
@@ -280,8 +280,10 @@ pub fn action_instructions() -> String {
         "\nArgument conventions: pass a session id as `args.session_id`; \
          `sessions.send` also takes `args.text`; `sessions.launch` takes \
          `args.workdir` (required) plus optional `args.model`, `args.prompt`, \
-         `args.goal_id`. When you have gathered enough to answer, emit the `final` \
-         shape — do not keep calling verbs once you can answer.",
+         `args.goal_id`; `sessions.adopt` takes `args.tmux_name` and `args.cwd` \
+         (both required) plus optional `args.task`, `args.runtime`. When you have \
+         gathered enough to answer, emit the `final` shape — do not keep calling \
+         verbs once you can answer.",
     );
     out
 }
@@ -319,6 +321,32 @@ pub async fn execute_verb(
         "sessions.resume" => control.resume(require_session_id(args)?).await,
         "sessions.kill" => control.kill(require_session_id(args)?).await,
         "sessions.health" => health_via(control).await,
+        "sessions.adopt" => {
+            let tmux_name = args
+                .get("tmux_name")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .ok_or_else(|| {
+                    SessionControlError::Backend(
+                        "sessions.adopt requires args.tmux_name".to_string(),
+                    )
+                })?;
+            let cwd = args
+                .get("cwd")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .ok_or_else(|| {
+                    SessionControlError::Backend("sessions.adopt requires args.cwd".to_string())
+                })?;
+            control
+                .adopt(
+                    tmux_name,
+                    cwd,
+                    str_arg(args, "task").as_deref(),
+                    str_arg(args, "runtime").as_deref(),
+                )
+                .await
+        }
         "sessions.launch" => {
             let workdir = args
                 .get("workdir")

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_tests.rs
@@ -174,6 +174,94 @@ async fn unknown_verb_error_lists_health() {
     assert!(err.to_string().contains("sessions.health"));
 }
 
+/// Why: the action loop must ADVERTISE `sessions.adopt` so the self-aware chat
+/// knows it can adopt an existing tmux session inline (#1433).
+/// What: asserts the instruction block lists the ops `sessions.adopt` verb and its
+/// argument convention.
+/// Test: this is the test.
+#[test]
+fn prompt_lists_adopt_ops_verb() {
+    let prompt = action_instructions();
+    assert!(
+        prompt.contains("sessions.adopt"),
+        "action prompt must advertise the executable `sessions.adopt` verb"
+    );
+    assert!(
+        prompt.contains("args.tmux_name"),
+        "action prompt must document the adopt args"
+    );
+}
+
+/// Why: `sessions.adopt` must EXECUTE inline, parsing `tmux_name`/`cwd`/`task`/
+/// `runtime` and reaching `SessionControl::adopt` (#1433).
+/// What: dispatches `sessions.adopt` against the mock and asserts the args were
+/// parsed and forwarded, and a session id comes back.
+/// Test: this is the test.
+#[tokio::test]
+async fn execute_adopt_reads_args() {
+    let mock = Arc::new(MockSessionControl::default());
+    let control: Arc<dyn SessionControl> = mock.clone();
+    let out = execute_verb(
+        &control,
+        "sessions.adopt",
+        &json!({
+            "tmux_name": "tmpm-hand-started",
+            "cwd": "/Users/op/work/proj",
+            "task": "drive it",
+            "runtime": "claude-code"
+        }),
+    )
+    .await
+    .expect("adopt dispatches");
+    assert!(
+        out.get("session_id").and_then(|v| v.as_str()).is_some(),
+        "adopt must return a session_id"
+    );
+    let adopts = mock.adopts();
+    assert_eq!(adopts.len(), 1, "exactly one adopt recorded");
+    assert_eq!(adopts[0].0, "tmpm-hand-started");
+    assert_eq!(adopts[0].1, "/Users/op/work/proj");
+    assert_eq!(adopts[0].2.as_deref(), Some("drive it"));
+    assert_eq!(adopts[0].3.as_deref(), Some("claude-code"));
+}
+
+/// Why: `sessions.adopt` requires `tmux_name` and `cwd`; a missing one must feed a
+/// clear error back to the model rather than panicking (#1433).
+/// What: dispatches adopt with no args and asserts a Backend error naming the
+/// missing required field.
+/// Test: this is the test.
+#[tokio::test]
+async fn execute_adopt_requires_tmux_name_and_cwd() {
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+
+    let err = execute_verb(&control, "sessions.adopt", &json!({ "cwd": "/x" }))
+        .await
+        .expect_err("missing tmux_name errors");
+    assert!(err.to_string().contains("tmux_name"));
+
+    let err = execute_verb(
+        &control,
+        "sessions.adopt",
+        &json!({ "tmux_name": "tmpm-x" }),
+    )
+    .await
+    .expect_err("missing cwd errors");
+    assert!(err.to_string().contains("cwd"));
+}
+
+/// Why: the unknown-verb error must name `sessions.adopt` among the valid set so a
+/// model that mistypes it can recover (#1433).
+/// What: triggers the unknown-verb error and asserts `sessions.adopt` is listed.
+/// Test: this is the test.
+#[tokio::test]
+async fn unknown_verb_error_lists_adopt() {
+    let control: Arc<dyn SessionControl> = Arc::new(MockSessionControl::default());
+    let err = execute_verb(&control, "sessions.bogus", &json!({}))
+        .await
+        .expect_err("unknown verb errors");
+    assert!(err.to_string().contains("sessions.adopt"));
+}
+
 /// Why: `sessions.list` must dispatch to `SessionControl::list`.
 /// What: executes the verb and asserts the mock's list body comes back.
 /// Test: this is the test.

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/mock_control.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/mock_control.rs
@@ -24,6 +24,14 @@ use crate::core::sm::control::{
     LaunchParams, RawObservation, SessionControl, SessionControlError, Submit, Summary,
 };
 
+/// One recorded adoption: `(tmux_name, cwd, task, runtime)` (#1433).
+///
+/// Why: a named alias keeps the `adopts` log's type readable and satisfies the
+/// `clippy::type_complexity` lint (a 4-tuple of optionals is "very complex").
+/// What: the four `adopt` arguments the mock records for test assertions.
+/// Test: `chat_action_tests.rs::execute_adopt_reads_args`.
+type AdoptRecord = (String, String, Option<String>, Option<String>);
+
 /// A scriptable, recording mock [`SessionControl`] (test-only).
 ///
 /// Why: see the module docs — records launches/sends and returns a scripted
@@ -38,6 +46,8 @@ pub struct MockSessionControl {
     launches: Mutex<Vec<(String, LaunchParams)>>,
     /// Recorded task deliveries: `(session_id, text)` from `send` (#1299).
     sends: Mutex<Vec<(String, String)>>,
+    /// Recorded adoptions from `adopt` (#1433).
+    adopts: Mutex<Vec<AdoptRecord>>,
     /// The pane/record JSON each `get` returns (the OBSERVE input). Shared so a
     /// test can script evidence (or none).
     get_body: Mutex<Value>,
@@ -49,6 +59,7 @@ impl Default for MockSessionControl {
             next_id: AtomicUsize::new(0),
             launches: Mutex::new(Vec::new()),
             sends: Mutex::new(Vec::new()),
+            adopts: Mutex::new(Vec::new()),
             // Default observation: a running session with NO evidence — the gate
             // stays closed unless a test scripts evidence.
             get_body: Mutex::new(json!({ "session": { "state": "running" } })),
@@ -79,6 +90,11 @@ impl MockSessionControl {
     /// The recorded task deliveries `(session_id, text)` (test read, #1299).
     pub fn sends(&self) -> Vec<(String, String)> {
         self.sends.lock().expect("lock").clone()
+    }
+
+    /// The recorded adoptions `(tmux_name, cwd, task, runtime)` (test read, #1433).
+    pub fn adopts(&self) -> Vec<AdoptRecord> {
+        self.adopts.lock().expect("lock").clone()
     }
 }
 
@@ -167,5 +183,30 @@ impl SessionControl for MockSessionControl {
             summary: None,
             confidence: 0.0,
         })
+    }
+
+    /// Record an adoption and return a deterministic session id (#1433).
+    ///
+    /// Why: the action-loop dispatch test must assert that `sessions.adopt` parsed
+    /// `tmux_name`/`cwd`/`task`/`runtime` correctly and reached `adopt` — the
+    /// trait's default impl errors, so the mock overrides it to record + succeed.
+    /// What: records `(tmux_name, cwd, task, runtime)` and returns `{ session_id }`
+    /// minted from the same monotonic counter `launch` uses.
+    /// Test: `chat_action_tests.rs::execute_adopt_reads_args`.
+    async fn adopt(
+        &self,
+        tmux_name: &str,
+        cwd: &str,
+        task: Option<&str>,
+        runtime: Option<&str>,
+    ) -> Result<Value, SessionControlError> {
+        let n = self.next_id.fetch_add(1, Ordering::SeqCst) + 1;
+        self.adopts.lock().expect("lock").push((
+            tmux_name.to_string(),
+            cwd.to_string(),
+            task.map(str::to_string),
+            runtime.map(str::to_string),
+        ));
+        Ok(json!({ "session_id": format!("s-{n}") }))
     }
 }

--- a/crates/trusty-mpm/src/core/sm/control.rs
+++ b/crates/trusty-mpm/src/core/sm/control.rs
@@ -230,4 +230,36 @@ pub trait SessionControl: Send + Sync {
     /// Test: `summarize_degrades_to_unknown_without_key`,
     /// `summarize_returns_fake_verdict`, `summarize_serves_cached_verdict`.
     async fn summarize(&self, session_id: &str) -> Result<Summary, SessionControlError>;
+
+    /// Adopt an EXISTING unmanaged tmux session into the managed store (#1433).
+    ///
+    /// Why: the action-capable coordinator chat (#1496) and the SM-STDIO surface
+    /// need to CONNECT to a pane the operator already has (a hand-started session,
+    /// an externally-created one, or one whose record was lost) and drive it
+    /// through the rest of this trait. It is the explicit counterpart to the
+    /// automatic boot-time adoption in
+    /// [`reconcile_on_boot`](crate::session_manager::SessionManager::reconcile_on_boot).
+    /// What: connects to the live pane named `tmux_name`, registering an `Active`
+    /// record with the supplied `cwd` (REQUIRED — provenance is unknown), an
+    /// optional `task`, and an optional `runtime` selector. Returns `{ session_id }`
+    /// on success.
+    ///
+    /// A DEFAULT impl returns [`SessionControlError::Backend`] so the only impls
+    /// that gain the verb are those that override it (the production
+    /// `DaemonSessionControl`); test mocks and any other impls keep compiling
+    /// unchanged without silently pretending to adopt.
+    /// Test: `DaemonSessionControl::adopt` via the managed integration tests; the
+    /// action-loop dispatch via `chat_action_tests.rs::execute_adopt_*`.
+    async fn adopt(
+        &self,
+        tmux_name: &str,
+        cwd: &str,
+        task: Option<&str>,
+        runtime: Option<&str>,
+    ) -> Result<serde_json::Value, SessionControlError> {
+        let _ = (tmux_name, cwd, task, runtime);
+        Err(SessionControlError::Backend(
+            "adopt is not supported by this control surface".to_string(),
+        ))
+    }
 }

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -76,9 +76,9 @@ pub use rpc::rpc_handler;
 /// lets `router` refer to them unqualified, mirroring the `coordinator_routes`
 /// wiring.
 use super::managed_routes::{
-    answer_session_decision, decommission_managed_session, get_attach_cmd, get_managed_session,
-    get_session_activity, list_managed_sessions, resume_managed_session, send_to_session,
-    spawn_session, stop_managed_session, stop_managed_session_runtime,
+    adopt_existing_session, answer_session_decision, decommission_managed_session, get_attach_cmd,
+    get_managed_session, get_session_activity, list_managed_sessions, resume_managed_session,
+    send_to_session, spawn_session, stop_managed_session, stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.
@@ -159,6 +159,14 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route(
             "/api/v1/sessions/managed",
             post(spawn_session).get(list_managed_sessions),
+        )
+        // #1433: adopt an EXISTING tmux session into the managed store. The literal
+        // `/adopt` segment is registered BEFORE the `/{id}` param route so it is
+        // never captured as an id (axum prefers literal matches, but ordering here
+        // makes the intent explicit). Distinct from the stateless `/tmux/adopt`.
+        .route(
+            "/api/v1/sessions/managed/adopt",
+            post(adopt_existing_session),
         )
         .route(
             "/api/v1/sessions/managed/{id}",

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -75,6 +75,22 @@ pub async fn spawn_managed(
         Some(raw) => raw.parse::<RuntimeKind>().map_err(|e| e.to_string())?,
     };
 
+    let session_id = ManagedSessionId::new();
+
+    // Step 0.5 — LOCAL-PATH FAST PATH (#1433): if `repo_url` is an existing local
+    // absolute directory, treat it AS the session workspace and SKIP the git
+    // clone entirely. This lets `sessions.launch` (which maps `workdir → repo_url`)
+    // drive a session against a directory the operator already has on disk — e.g.
+    // `workdir=/Users/masa/Projects/trusty-tools` — without cloning a remote.
+    //
+    // Detection heuristic (documented): the string is an ABSOLUTE path that EXISTS
+    // and is a DIRECTORY on the daemon host. Anything else (a `https://…` /
+    // `git@…` URL, a relative path, a non-existent path) falls through to the
+    // existing clone-based provisioning below, so remote-URL callers are unaffected.
+    if is_local_workdir(&params.repo_url) {
+        return spawn_managed_local(state, &session_id, &params, runtime).await;
+    }
+
     // Step 1: pre-generate the id + provision an isolated workspace.
     //
     // #1220: the workspace root defaults to `~/trusty-mpm-projects/` (overridable
@@ -85,7 +101,6 @@ pub async fn spawn_managed(
     // GitHub identity we fall back to the legacy single-slug `provision` path so a
     // bare/non-GitHub URL still provisions cleanly.
     let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
-    let session_id = ManagedSessionId::new();
     let prepared = match trusty_common::github_path::parse_github_path(&params.repo_url) {
         Some(gh) => {
             let project_dir = crate::core::trusty_tools_config::workspace_subpath(&config, &gh);
@@ -181,6 +196,108 @@ pub async fn spawn_managed(
             name = %record.tmux_name,
             path = %prepared.path.display(),
             "managed session spawned successfully"
+        );
+    }
+
+    Ok(mgr.get(&record.id).await.unwrap_or(record))
+}
+
+/// Whether `s` names an EXISTING local directory usable as a session workspace
+/// directly, i.e. without a git clone (#1433).
+///
+/// Why: the local-path spawn fast path must reliably distinguish "an absolute
+/// directory the operator already has on disk" from "a remote repo URL to clone".
+/// A URL (`https://…`, `git@…:…`) is never an absolute filesystem path, a relative
+/// path is rejected (ambiguous against the daemon's cwd), and a non-existent path
+/// falls through to clone — so this errs toward the safe existing behaviour.
+/// What: returns `true` iff `s` is an ABSOLUTE path that EXISTS and is a directory.
+/// Test: `is_local_workdir_detects_absolute_dir`,
+/// `is_local_workdir_rejects_url_relative_and_missing` in tests/local_spawn.rs.
+pub fn is_local_workdir(s: &str) -> bool {
+    let p = std::path::Path::new(s);
+    p.is_absolute() && p.exists() && p.is_dir()
+}
+
+/// Spawn a managed session rooted at an EXISTING local directory — NO clone (#1433).
+///
+/// Why: the local-path fast path of [`spawn_managed`]. When `repo_url` is already
+/// an on-disk directory, there is nothing to provision: the directory IS the
+/// workspace. This mirrors the clone path's create→front-gate→spawn ritual but
+/// uses the local path verbatim as the session cwd and records no `repo_url`
+/// (there is no remote) so `resume` re-spawns in the same local directory.
+/// What: in order — (1) creates the tmux session rooted at the local path via
+/// `create_with_id` (with `cwd = workspace_path = <local path>`, `repo_url = None`,
+/// `branch = None`); (2) runs the same FRONT gate (fail-open, non-GitHub →
+/// auto-proceed); (3) marks the record `Active`; (4) spawns the runtime in the
+/// pane (a spawn failure marks the record errored but is not fatal). Returns the
+/// final record.
+/// Test: `local_path_spawn_uses_path_as_cwd_and_skips_clone` in tests/local_spawn.rs
+/// asserts the chosen cwd equals the local path and NO clone backend was invoked.
+async fn spawn_managed_local(
+    state: &Arc<DaemonState>,
+    session_id: &ManagedSessionId,
+    params: &SpawnParams,
+    runtime: RuntimeKind,
+) -> Result<SessionRecord, String> {
+    let workspace = std::path::PathBuf::from(&params.repo_url);
+    info!(
+        id = %session_id,
+        path = %workspace.display(),
+        "spawn_managed: local-path workdir detected — using it directly, skipping git clone"
+    );
+
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create_with_id(
+            *session_id,
+            params.task.clone(),
+            Some(workspace.clone()),
+            params.name_hint.clone(),
+            Some(workspace.clone()),
+            // No remote — this is a local directory, not a cloned repo.
+            None,
+            None,
+            runtime,
+        )
+        .await
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed (local): session create failed: {e}");
+            e.to_string()
+        })?;
+
+    // Same FRONT gate as the clone path. With `repo_url` being a local path it has
+    // no GitHub identity, so `front_gate_or_escalate` fails open (auto-proceeds).
+    if let Some(record) =
+        front_gate_or_escalate(&mgr, &record, &params.repo_url, &params.task).await?
+    {
+        return Ok(record);
+    }
+
+    if let Err(e) = mgr
+        .set_workspace(&record.id, workspace.clone(), ManagedSessionState::Active)
+        .await
+    {
+        warn!(id = %record.id, "spawn_managed (local): set_workspace failed: {e}");
+    }
+
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = build_adapter(record.runtime, tmux_arc);
+    if let Err(e) = adapter.spawn(&record.tmux_name, &workspace, &params.task) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            runtime = %record.runtime.as_str(),
+            "spawn_managed (local): runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            path = %workspace.display(),
+            "managed session spawned successfully (local-path, no clone)"
         );
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -91,7 +91,9 @@ pub async fn spawn_managed(
         return spawn_managed_local(state, &session_id, &params, runtime).await;
     }
 
-    // Step 1: pre-generate the id + provision an isolated workspace.
+    // Provision an isolated workspace under the pre-generated `session_id` (the id
+    // is generated ONCE above, before the local-path/clone branch split, so both
+    // branches register the same id).
     //
     // #1220: the workspace root defaults to `~/trusty-mpm-projects/` (overridable
     // via the `TRUSTY_MPM_WORKSPACE_ROOT` env var or the
@@ -210,12 +212,14 @@ pub async fn spawn_managed(
 /// A URL (`https://…`, `git@…:…`) is never an absolute filesystem path, a relative
 /// path is rejected (ambiguous against the daemon's cwd), and a non-existent path
 /// falls through to clone — so this errs toward the safe existing behaviour.
-/// What: returns `true` iff `s` is an ABSOLUTE path that EXISTS and is a directory.
+/// What: returns `true` iff `s` is an ABSOLUTE path that is a directory. `is_dir()`
+/// already implies existence in a single `stat` syscall (a missing path is not a
+/// dir) and follows symlinks, so a separate `exists()` probe is redundant.
 /// Test: `is_local_workdir_detects_absolute_dir`,
 /// `is_local_workdir_rejects_url_relative_and_missing` in tests/local_spawn.rs.
 pub fn is_local_workdir(s: &str) -> bool {
     let p = std::path::Path::new(s);
-    p.is_absolute() && p.exists() && p.is_dir()
+    p.is_absolute() && p.is_dir()
 }
 
 /// Spawn a managed session rooted at an EXISTING local directory — NO clone (#1433).

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -32,7 +32,8 @@ pub use front_gate::{
     ConformanceGate, FrontGateOutcome, HeadlessApproval, IsrConformanceGate, run_front_gate,
 };
 pub use lifecycle::{
-    ResumeManagedError, SpawnParams, resume_managed, spawn_managed, spawn_runtime_for,
+    ResumeManagedError, SpawnParams, is_local_workdir, resume_managed, spawn_managed,
+    spawn_runtime_for,
 };
 
 // ── Request / Response shapes ─────────────────────────────────────────────────
@@ -90,6 +91,55 @@ pub struct SpawnResponse {
     pub attach_cmd: String,
     /// Runtime backend that hosts the session (`"claude-code"` | `"tcode"`).
     pub runtime: String,
+}
+
+/// Request body for POST /api/v1/sessions/managed/adopt (#1433).
+///
+/// Why: adopting an EXISTING unmanaged tmux session connects the managed surface
+/// to a pane the operator already has. Unlike the stateless snapshot adopt at
+/// `POST /tmux/adopt` (which registers nothing), this REGISTERS a durable record.
+/// Because the pane's provenance is unknown to the daemon, the operator must
+/// supply the `cwd`; `task` is optional (empty → a generic description) and
+/// `runtime` is optional (absent → the default managed runtime).
+/// What: `tmux_name` (the live pane to adopt), the required `cwd`, an optional
+/// `task`, and an optional `runtime` selector (`"claude-code"` | `"tcode"`).
+/// Test: `adopt_existing_*` handler tests in tests/session_manager_mvp.rs.
+#[derive(Debug, Deserialize)]
+pub struct AdoptExistingRequest {
+    /// The live tmux session name to adopt (any name; need not be `tmpm-`).
+    pub tmux_name: String,
+    /// Working directory the adopted session runs in (REQUIRED — provenance is
+    /// unknown to the daemon, so the operator supplies it).
+    pub cwd: String,
+    /// Optional human-readable task description (empty/absent allowed).
+    #[serde(default)]
+    pub task: Option<String>,
+    /// Optional runtime selector (`"claude-code"` | `"tcode"`); absent → default.
+    #[serde(default)]
+    pub runtime: Option<String>,
+}
+
+/// Response body for POST /api/v1/sessions/managed/adopt (201 Created).
+///
+/// Why: the caller needs the new managed record's identity + the attach command
+/// to immediately drive or attach to the now-managed session.
+/// What: the same flat summary fields as [`SessionSummary`] plus the derived
+/// `attach_cmd`, mirroring [`SpawnResponse`].
+/// Test: `adopt_existing_registers_record` in tests/session_manager_mvp.rs.
+#[derive(Debug, Serialize)]
+pub struct AdoptExistingResponse {
+    /// Managed session id (UUID string).
+    pub id: String,
+    /// tmux session name that was adopted.
+    pub name: String,
+    /// Current lifecycle state (`active` immediately after adoption).
+    pub state: String,
+    /// Working directory the adopted session runs in.
+    pub cwd: String,
+    /// Runtime backend hosting the session (`"claude-code"` | `"tcode"`).
+    pub runtime: String,
+    /// tmux attach command string.
+    pub attach_cmd: String,
 }
 
 /// List response for GET /api/v1/sessions/managed.
@@ -383,6 +433,63 @@ pub async fn spawn_session(
             (StatusCode::CREATED, Json(resp)).into_response()
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+    }
+}
+
+/// POST /api/v1/sessions/managed/adopt — adopt an EXISTING tmux session (#1433).
+///
+/// Why: the operator already has a live, unmanaged tmux pane (a hand-started
+/// Claude Code, an externally-created session, or one whose record was lost) and
+/// wants to drive it through the full managed surface. This REGISTERS a durable
+/// `Active` record for that pane. It is deliberately distinct from the stateless
+/// `POST /tmux/adopt` snapshot endpoint, which captures a session's shape but
+/// registers NOTHING — that endpoint's semantics are unchanged.
+/// What: validates an optional runtime selector up front (400 on a bad value),
+/// then delegates to [`crate::session_manager::SessionManager::adopt_existing`].
+/// Maps its typed errors: `TmuxSessionMissing` → 404 (no such pane),
+/// `AlreadyAdopted` → 409 (already tracked), any other → 500. On success returns
+/// 201 Created with the new record + attach command.
+/// Test: `adopt_existing_registers_record`, `adopt_existing_missing_is_404`,
+/// `adopt_existing_double_is_409` in tests/session_manager_mvp.rs.
+pub async fn adopt_existing_session(
+    State(state): State<Arc<DaemonState>>,
+    Json(req): Json<AdoptExistingRequest>,
+) -> impl IntoResponse {
+    // Resolve the runtime selector up front so a typo is a 400, not a 500.
+    let runtime = match req.runtime.as_deref() {
+        None => RuntimeKind::default(),
+        Some(raw) => match raw.parse::<RuntimeKind>() {
+            Ok(rk) => rk,
+            Err(e) => {
+                warn!("adopt_existing: invalid runtime selector: {e}");
+                return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+            }
+        },
+    };
+
+    let task = req.task.unwrap_or_default();
+    let cwd = std::path::PathBuf::from(&req.cwd);
+
+    let mgr = state.session_manager().await;
+    match mgr.adopt_existing(&req.tmux_name, cwd, task, runtime).await {
+        Ok(record) => {
+            let resp = AdoptExistingResponse {
+                id: record.id.to_string(),
+                name: record.tmux_name.clone(),
+                state: record.state.to_string(),
+                cwd: record.cwd.to_string_lossy().to_string(),
+                runtime: record.runtime.as_str().to_owned(),
+                attach_cmd: attach_cmd_for(&record.tmux_name),
+            };
+            (StatusCode::CREATED, Json(resp)).into_response()
+        }
+        Err(crate::session_manager::ManagedError::TmuxSessionMissing(msg)) => {
+            (StatusCode::NOT_FOUND, msg).into_response()
+        }
+        Err(crate::session_manager::ManagedError::AlreadyAdopted(msg)) => {
+            (StatusCode::CONFLICT, msg).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -256,6 +256,46 @@ impl SessionControl for DaemonSessionControl {
             .map_err(|e| SessionControlError::Backend(e.to_string()))?;
         Ok(verdict_to_summary(result.verdict))
     }
+
+    /// Adopt an existing tmux session via the in-process manager (#1433).
+    ///
+    /// Why: the production wiring of the explicit-adopt verb. It forwards to
+    /// [`crate::session_manager::SessionManager::adopt_existing`] so the stdio /
+    /// action-loop path and the HTTP `…/managed/adopt` route share one code path.
+    /// What: resolves an optional runtime selector (a bad value → `Backend`), then
+    /// adopts the named pane with the supplied `cwd`/`task`/`runtime`. Maps the
+    /// manager's `TmuxSessionMissing` to `NotFound` (no such pane) and every other
+    /// failure (already-adopted, store) to `Backend`. Returns `{ session_id }`.
+    /// Test: forwards to `adopt_existing` (covered by the manager unit tests); the
+    /// action-loop dispatch is covered by `chat_action_tests.rs`.
+    async fn adopt(
+        &self,
+        tmux_name: &str,
+        cwd: &str,
+        task: Option<&str>,
+        runtime: Option<&str>,
+    ) -> Result<serde_json::Value, SessionControlError> {
+        let runtime_kind = match runtime {
+            None => crate::runtime::RuntimeKind::default(),
+            Some(raw) => raw
+                .parse::<crate::runtime::RuntimeKind>()
+                .map_err(|e| SessionControlError::Backend(e.to_string()))?,
+        };
+        let mgr = self.state.session_manager().await;
+        let record = mgr
+            .adopt_existing(
+                tmux_name,
+                std::path::PathBuf::from(cwd),
+                task.unwrap_or_default().to_string(),
+                runtime_kind,
+            )
+            .await
+            .map_err(|e| match e {
+                ManagedError::TmuxSessionMissing(msg) => SessionControlError::NotFound(msg),
+                other => SessionControlError::Backend(other.to_string()),
+            })?;
+        Ok(serde_json::json!({ "session_id": record.id.to_string() }))
+    }
 }
 
 /// Map an [`crate::activity::cache::ActivityVerdict`] onto a [`Summary`] (#1461).

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -1,0 +1,103 @@
+//! Explicit adoption of an EXISTING, unmanaged tmux session (#1433).
+//!
+//! Why: the session-manager normally only drives sessions it `create`d, but an
+//! operator often already has a live tmux pane (a hand-started Claude Code, a
+//! session created outside trusty-mpm, or one whose record was lost) that they
+//! want to connect to and drive through the full managed surface. This is the
+//! EXPLICIT counterpart to [`SessionManager::reconcile_on_boot`]'s automatic
+//! adoption. It lives in its own module so [`manager`](super::manager) stays under
+//! the 500-SLOC production cap.
+//! What: an inherent `impl SessionManager` block adding
+//! [`SessionManager::adopt_existing`].
+//! Test: `manager_adopt_existing_*` in `super::tests`.
+
+use std::path::PathBuf;
+
+use chrono::Utc;
+use tracing::info;
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+impl SessionManager {
+    /// Adopt an EXISTING, unmanaged tmux session into the durable store (#1433).
+    ///
+    /// Why: connect the managed surface to a live pane the operator already has so
+    /// it can be driven through observe/send/stop/resume, rather than spawning a
+    /// new one. This is the EXPLICIT counterpart to
+    /// [`reconcile_on_boot`](SessionManager::reconcile_on_boot)'s automatic
+    /// adoption — it synthesises a durable `Active` record for a pane that already
+    /// exists.
+    ///
+    /// Design decisions (DOC-20 / DOC-14):
+    /// - **Collision check is INVERTED vs. `create`.** `create` fails when the name
+    ///   already exists; `adopt_existing` fails with
+    ///   [`ManagedError::TmuxSessionMissing`] when the pane does NOT exist (you
+    ///   cannot adopt what is not there) and with [`ManagedError::AlreadyAdopted`]
+    ///   when the store already tracks the name.
+    /// - **No `create_session` call.** The pane already exists; the driver is only
+    ///   consulted via `session_exists` to verify presence.
+    /// - **`cwd` is REQUIRED** (a plain `PathBuf`): the pane's provenance is unknown
+    ///   to the daemon, so the operator supplies the working directory rather than
+    ///   have it stubbed to `/unknown` (as auto-boot adoption does). `task` may be
+    ///   empty. `runtime` is caller-supplied; call sites that do not care pass
+    ///   [`crate::runtime::RuntimeKind::default`].
+    /// - **Non-`tmpm-` names are ALLOWED.** Unlike `reconcile_on_boot` (which filters
+    ///   to the `tmpm-` prefix for SAFE automatic adoption), this explicit path
+    ///   adopts ANY name the operator names. The reconcile filter is left untouched.
+    ///
+    /// What: verifies the pane exists, rejects an already-tracked name, then upserts
+    /// an `Active` [`SessionRecord`] carrying the supplied `cwd`/`task`/`runtime`
+    /// (a fresh id, no workspace/repo/branch — provenance is unknown). Returns the
+    /// new record.
+    /// Test: `manager_adopt_existing_registers_active`,
+    /// `manager_adopt_existing_missing_tmux_errors`,
+    /// `manager_adopt_existing_double_adopt_errors`,
+    /// `manager_adopt_existing_allows_non_tmpm_name` in `super::tests`.
+    pub async fn adopt_existing(
+        &self,
+        tmux_name: &str,
+        cwd: PathBuf,
+        task: String,
+        runtime: crate::runtime::RuntimeKind,
+    ) -> Result<SessionRecord, ManagedError> {
+        // The pane MUST already exist — adoption connects, it does not spawn.
+        // `tmux_driver()` is the public accessor over the shared driver Arc.
+        if !self.tmux_driver().session_exists(tmux_name) {
+            return Err(ManagedError::TmuxSessionMissing(tmux_name.to_string()));
+        }
+
+        // Reject an already-tracked name so we never create a second record for the
+        // same pane. `known_tmux_names` reloads-on-read so a record another process
+        // registered is also seen.
+        if self.known_tmux_names().await?.contains(tmux_name) {
+            return Err(ManagedError::AlreadyAdopted(tmux_name.to_string()));
+        }
+
+        let record = SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: tmux_name.to_string(),
+            cwd,
+            task,
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime,
+        };
+
+        self.store.write().await.upsert(record.clone()).await?;
+        info!(
+            id = %record.id,
+            name = %tmux_name,
+            runtime = %runtime.as_str(),
+            "adopted existing tmux session into the managed store"
+        );
+        Ok(record)
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -35,6 +35,17 @@ impl SessionManager {
     ///   [`ManagedError::TmuxSessionMissing`] when the pane does NOT exist (you
     ///   cannot adopt what is not there) and with [`ManagedError::AlreadyAdopted`]
     ///   when the store already tracks the name.
+    /// - **The already-adopted check and the upsert run under ONE held write lock.**
+    ///   Reading the store to test for the name and then upserting must be atomic —
+    ///   otherwise two concurrent `adopt_existing` calls for the same `tmux_name`
+    ///   could both observe "absent" before either writes, producing duplicate
+    ///   `Active` records (TOCTOU). We therefore take the store write guard ONCE,
+    ///   scan the live records through it (`all()` reloads-on-read so a record
+    ///   another process registered is also seen), reject a tracked name, and
+    ///   upsert — all without releasing the guard. The tmux `session_exists`
+    ///   liveness check stays OUTSIDE the lock (it touches tmux, not the store, and
+    ///   a stale pane between the check and the lock is the operator's race to lose,
+    ///   not a store-consistency hazard).
     /// - **No `create_session` call.** The pane already exists; the driver is only
     ///   consulted via `session_exists` to verify presence.
     /// - **`cwd` is REQUIRED** (a plain `PathBuf`): the pane's provenance is unknown
@@ -50,9 +61,11 @@ impl SessionManager {
     /// an `Active` [`SessionRecord`] carrying the supplied `cwd`/`task`/`runtime`
     /// (a fresh id, no workspace/repo/branch — provenance is unknown). Returns the
     /// new record.
-    /// Test: `manager_adopt_existing_registers_active`,
+    /// Test: `manager_adopt_existing_registers_active` (also asserts the returned
+    /// record's `cwd` matches the adopted cwd),
     /// `manager_adopt_existing_missing_tmux_errors`,
-    /// `manager_adopt_existing_double_adopt_errors`,
+    /// `manager_adopt_existing_double_adopt_errors` (the single-locked path still
+    /// rejects a second adopt of the same name),
     /// `manager_adopt_existing_allows_non_tmpm_name` in `super::tests`.
     pub async fn adopt_existing(
         &self,
@@ -62,16 +75,11 @@ impl SessionManager {
         runtime: crate::runtime::RuntimeKind,
     ) -> Result<SessionRecord, ManagedError> {
         // The pane MUST already exist — adoption connects, it does not spawn.
-        // `tmux_driver()` is the public accessor over the shared driver Arc.
+        // `tmux_driver()` is the public accessor over the shared driver Arc. This
+        // liveness check touches tmux (not the store), so it stays OUTSIDE the
+        // store write lock taken below.
         if !self.tmux_driver().session_exists(tmux_name) {
             return Err(ManagedError::TmuxSessionMissing(tmux_name.to_string()));
-        }
-
-        // Reject an already-tracked name so we never create a second record for the
-        // same pane. `known_tmux_names` reloads-on-read so a record another process
-        // registered is also seen.
-        if self.known_tmux_names().await?.contains(tmux_name) {
-            return Err(ManagedError::AlreadyAdopted(tmux_name.to_string()));
         }
 
         let record = SessionRecord {
@@ -91,7 +99,20 @@ impl SessionManager {
             runtime,
         };
 
-        self.store.write().await.upsert(record.clone()).await?;
+        // ── Atomic already-adopted check + upsert under ONE held write guard ──────
+        // Acquire the store write lock ONCE and keep it for both the existence
+        // scan and the upsert, so two concurrent adopts of the same `tmux_name`
+        // cannot both pass the "absent" test and create duplicate `Active` records
+        // (the TOCTOU the previous read-then-write split exposed). `all()` requires
+        // `&mut self` and reloads-on-read, so a record another process registered
+        // is also seen through this same guard.
+        {
+            let mut store = self.store.write().await;
+            if store.all().await?.iter().any(|r| r.tmux_name == tmux_name) {
+                return Err(ManagedError::AlreadyAdopted(tmux_name.to_string()));
+            }
+            store.upsert(record.clone()).await?;
+        }
         info!(
             id = %record.id,
             name = %tmux_name,

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -58,6 +58,22 @@ pub enum ManagedError {
     /// The operation is not valid for the current session state.
     #[error("invalid state transition for session {0}: {1}")]
     InvalidState(String, String),
+
+    /// Adoption was requested for a tmux session that does not exist on the host.
+    ///
+    /// Why: adoption CONNECTS to a pre-existing, unmanaged pane — there is nothing
+    /// to drive if the pane is absent. This is the inverse of [`NameCollision`]:
+    /// `create` fails when a name exists, `adopt_existing` fails when it does NOT.
+    #[error("tmux session does not exist: {0} — adoption requires a live pane")]
+    TmuxSessionMissing(String),
+
+    /// Adoption was requested for a tmux session this store already tracks.
+    ///
+    /// Why: re-adopting a session the manager already owns would create a second,
+    /// conflicting record for the same pane. The operator should drive the existing
+    /// record instead.
+    #[error("tmux session already adopted/registered: {0}")]
+    AlreadyAdopted(String),
 }
 
 /// Trait seam over tmux operations used by the session manager.

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -8,6 +8,7 @@
 //! Test: each sub-module carries its own unit tests; manager integration is
 //! tested in `manager::tests`.
 
+pub mod adopt;
 pub mod manager;
 pub mod record;
 pub mod session_guard;

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -1025,6 +1025,154 @@ async fn manager_get_reflects_out_of_process_write() {
     );
 }
 
+/// Adopting an EXISTING (driver-reports-live) tmux session must register a
+/// durable `Active` record carrying the supplied cwd/task/runtime (#1433).
+///
+/// Why: the explicit adopt path connects to a pane that already exists — it must
+/// NOT call `create_session` (no new pane) and must persist a queryable record.
+/// What: seeds a live tmux name on the fake driver, adopts it, and asserts the
+/// record is `Active`, NOT created via `create_session`, and is retrievable.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_registers_active() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    // The pane already exists (operator started it outside trusty-mpm).
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("tmpm-hand-started".into());
+
+    let record = mgr
+        .adopt_existing(
+            "tmpm-hand-started",
+            PathBuf::from("/Users/op/work/proj"),
+            "drive my hand-started session".into(),
+            crate::runtime::RuntimeKind::default(),
+        )
+        .await
+        .expect("adopt existing");
+
+    assert_eq!(record.tmux_name, "tmpm-hand-started");
+    assert_eq!(record.state, ManagedSessionState::Active);
+    assert_eq!(record.cwd, PathBuf::from("/Users/op/work/proj"));
+    assert_eq!(record.task, "drive my hand-started session");
+
+    // Adoption must NOT spawn a new tmux session — the pane already exists.
+    assert!(
+        fake.create_cwd_calls.lock().unwrap().is_empty(),
+        "adopt_existing must NOT call create_session; calls: {:?}",
+        fake.create_cwd_calls.lock().unwrap()
+    );
+
+    // The record is durably queryable.
+    let got = mgr.get(&record.id).await.expect("get adopted");
+    assert_eq!(got.id, record.id);
+    assert_eq!(got.state, ManagedSessionState::Active);
+}
+
+/// Adopting a tmux name that does NOT exist on the host must error — you cannot
+/// adopt a pane that is not there (#1433).
+///
+/// Why: this is the inverse of `create`'s NameCollision guard. The error must be
+/// the dedicated `TmuxSessionMissing` variant so the HTTP layer maps it to a 404.
+/// What: adopts a name the driver does not report and asserts the typed error.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_missing_tmux_errors() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let err = mgr
+        .adopt_existing(
+            "tmpm-not-here",
+            PathBuf::from("/tmp/x"),
+            String::new(),
+            crate::runtime::RuntimeKind::default(),
+        )
+        .await
+        .expect_err("adopting a nonexistent pane must fail");
+
+    assert!(
+        matches!(err, ManagedError::TmuxSessionMissing(ref n) if n == "tmpm-not-here"),
+        "expected TmuxSessionMissing, got {err:?}"
+    );
+}
+
+/// Adopting a tmux name the store ALREADY tracks must error — no double records
+/// for one pane (#1433).
+///
+/// Why: a second record for the same pane would split ownership and confuse every
+/// downstream verb. The dedicated `AlreadyAdopted` variant lets the HTTP layer map
+/// it to a 409 Conflict.
+/// What: adopts once (succeeds), then adopts the same live name again and asserts
+/// the second call returns `AlreadyAdopted`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_double_adopt_errors() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    fake.seeded_names.lock().unwrap().push("tmpm-once".into());
+
+    mgr.adopt_existing(
+        "tmpm-once",
+        PathBuf::from("/tmp/once"),
+        String::new(),
+        crate::runtime::RuntimeKind::default(),
+    )
+    .await
+    .expect("first adopt succeeds");
+
+    let err = mgr
+        .adopt_existing(
+            "tmpm-once",
+            PathBuf::from("/tmp/once"),
+            String::new(),
+            crate::runtime::RuntimeKind::default(),
+        )
+        .await
+        .expect_err("second adopt of the same pane must fail");
+
+    assert!(
+        matches!(err, ManagedError::AlreadyAdopted(ref n) if n == "tmpm-once"),
+        "expected AlreadyAdopted, got {err:?}"
+    );
+}
+
+/// The explicit adopt path must allow NON-`tmpm-` names (unlike reconcile, which
+/// filters to the `tmpm-` prefix for safe automatic adoption) (#1433).
+///
+/// Why: an operator naming a pane explicitly knows what they are adopting; the
+/// `tmpm-` prefix filter exists only to make AUTOMATIC boot adoption safe. The
+/// explicit path must not reject a session just because it lacks the prefix.
+/// What: seeds a non-`tmpm-` live name, adopts it, and asserts success.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_allows_non_tmpm_name() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("my-cli-session".into());
+
+    let record = mgr
+        .adopt_existing(
+            "my-cli-session",
+            PathBuf::from("/Users/op/repo"),
+            "adopt non-prefixed".into(),
+            crate::runtime::RuntimeKind::default(),
+        )
+        .await
+        .expect("non-tmpm names are adoptable on the explicit path");
+
+    assert_eq!(record.tmux_name, "my-cli-session");
+    assert_eq!(record.state, ManagedSessionState::Active);
+}
+
 /// Corrupt the manager's backing `sessions.json` so the next reload-on-read
 /// fails. Writing garbage (a) changes the file length so `reload_if_changed`
 /// detects a change and re-reads, and (b) makes `serde_json::from_str` fail with

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -221,15 +221,18 @@ impl TelegramFormatter {
                 id,
                 name,
                 state,
+                cwd,
                 runtime,
                 attach_cmd,
             } => format!(
                 "✅ Adopted <b>{}</b> (<code>{}</code>) [{}] runtime={}\n\
+                 cwd: <code>{}</code>\n\
                  attach: <code>{}</code>",
                 html_escape(name),
                 short_id(id),
                 html_escape(state),
                 html_escape(runtime),
+                html_escape(cwd),
                 html_escape(attach_cmd),
             ),
             CommandResult::ManagedSessions(sessions) => format_managed_sessions(sessions),

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -214,6 +214,24 @@ impl TelegramFormatter {
                 html_escape(runtime),
                 html_escape(attach_cmd),
             ),
+            // #1433: adoption mirrors a spawn's identity shape; render it the same
+            // way (different verb prose). Added in the session-adopt branch — the
+            // Telegram engineer may relocate/restyle this arm on rebase.
+            CommandResult::ManagedAdopted {
+                id,
+                name,
+                state,
+                runtime,
+                attach_cmd,
+            } => format!(
+                "✅ Adopted <b>{}</b> (<code>{}</code>) [{}] runtime={}\n\
+                 attach: <code>{}</code>",
+                html_escape(name),
+                short_id(id),
+                html_escape(state),
+                html_escape(runtime),
+                html_escape(attach_cmd),
+            ),
             CommandResult::ManagedSessions(sessions) => format_managed_sessions(sessions),
             CommandResult::ManagedSession(view) => format_managed_session(view),
             CommandResult::ManagedSent { id, tmux_name } => {

--- a/crates/trusty-mpm/src/telegram/formatter/tests.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/tests.rs
@@ -258,6 +258,34 @@ fn managed_arms_escape_daemon_sourced_fields() {
 }
 
 #[test]
+fn managed_adopted_renders_and_escapes_cwd() {
+    // Why: review #1502 — the adopt result must SURFACE the registered cwd so the
+    // operator can confirm the directory the daemon recorded for the adopted pane
+    // (the pane's provenance is otherwise unknown). The cwd is also daemon-sourced
+    // and must be HTML-escaped like every other interpolated field.
+    // What: format a `ManagedAdopted` carrying a cwd with HTML-significant chars
+    // and assert the escaped cwd appears (and no raw chars leak).
+    // Test: this function IS the test.
+    let adopted = CommandResult::ManagedAdopted {
+        id: "abcd1234-5678".into(),
+        name: "tmpm-hand-started".into(),
+        state: "active".into(),
+        cwd: "/Users/op/work/<proj>&x".into(),
+        runtime: "claude-code".into(),
+        attach_cmd: "tmux attach -t tmpm-hand-started".into(),
+    };
+    let text = TelegramFormatter::format(&adopted);
+    assert!(
+        text.contains("cwd: <code>/Users/op/work/&lt;proj&gt;&amp;x</code>"),
+        "ManagedAdopted must render the escaped cwd line: {text}"
+    );
+    assert!(
+        !text.contains("/Users/op/work/<proj>&x"),
+        "ManagedAdopted must not emit the raw cwd: {text}"
+    );
+}
+
+#[test]
 fn snapshot_escapes_html() {
     let result = CommandResult::Snapshot {
         session: "s".into(),

--- a/crates/trusty-mpm/tests/local_spawn.rs
+++ b/crates/trusty-mpm/tests/local_spawn.rs
@@ -1,0 +1,77 @@
+//! Integration tests for the local-path (non-clone) managed spawn heuristic (#1433).
+//!
+//! Why: managed spawn must accept an EXISTING local directory as the workdir and
+//! use it directly (skipping the git clone), while a remote repo URL still takes
+//! the clone branch. The branch decision is entirely captured by the documented
+//! `is_local_workdir` heuristic, so these PURE-LOGIC tests pin that detection
+//! deterministically — no daemon, no tmux, no runtime spawn (which would hit the
+//! known local tokio-runtime-drop env panic). The end-to-end create→cwd behaviour
+//! of the local path is covered by the manager unit tests (`create_with_id` with
+//! `cwd = workspace_path`) which the local spawn reuses verbatim.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use trusty_mpm::daemon::managed_routes::is_local_workdir;
+
+/// An existing absolute directory must be detected as a local workdir so the
+/// spawn uses it directly and SKIPS the clone (#1433).
+///
+/// Why: this is the positive half of the clone-vs-no-clone decision — a real
+/// on-disk directory (e.g. `/Users/masa/Projects/trusty-tools`) is the workspace.
+/// What: creates a temp dir and asserts `is_local_workdir` returns true for it.
+/// Test: this function IS the test.
+#[test]
+fn is_local_workdir_detects_absolute_dir() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let path = dir.path().to_string_lossy().to_string();
+    assert!(
+        std::path::Path::new(&path).is_absolute(),
+        "tempdir path is absolute on every supported platform"
+    );
+    assert!(
+        is_local_workdir(&path),
+        "an existing absolute directory must be detected as a local workdir: {path}"
+    );
+}
+
+/// A remote URL, a relative path, and a non-existent path must all FALL THROUGH
+/// to the clone branch (`is_local_workdir` returns false) (#1433).
+///
+/// Why: the negative half — remote-URL callers and ambiguous/relative inputs must
+/// be unaffected by the local-path fast path, so they keep cloning as before.
+/// What: asserts `is_local_workdir` is false for an https URL, an ssh-style URL, a
+/// relative path, and an absolute-but-missing path.
+/// Test: this function IS the test.
+#[test]
+fn is_local_workdir_rejects_url_relative_and_missing() {
+    // A remote HTTPS repo URL — never a local path.
+    assert!(!is_local_workdir("https://github.com/owner/repo.git"));
+    // An scp-style git URL — never a local path.
+    assert!(!is_local_workdir("git@github.com:owner/repo.git"));
+    // A relative path — rejected (ambiguous against the daemon's cwd).
+    assert!(!is_local_workdir("relative/dir"));
+    // An absolute path that does not exist — falls through to clone.
+    assert!(!is_local_workdir(
+        "/nonexistent/path/that/should/never/exist/abc123"
+    ));
+    // An empty string — never a local path.
+    assert!(!is_local_workdir(""));
+}
+
+/// An existing absolute path that is a FILE (not a directory) must NOT be treated
+/// as a local workdir (#1433).
+///
+/// Why: a workspace must be a directory; a stray file path matching by accident
+/// would root a tmux session at a non-directory. The heuristic requires `is_dir`.
+/// What: creates a temp file and asserts `is_local_workdir` returns false for it.
+/// Test: this function IS the test.
+#[test]
+fn is_local_workdir_rejects_existing_file() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let file = dir.path().join("a-file.txt");
+    std::fs::write(&file, b"hi").expect("write file");
+    let path = file.to_string_lossy().to_string();
+    assert!(
+        !is_local_workdir(&path),
+        "an existing FILE must not be treated as a local workdir: {path}"
+    );
+}

--- a/crates/trusty-mpm/tests/local_spawn.rs
+++ b/crates/trusty-mpm/tests/local_spawn.rs
@@ -75,3 +75,27 @@ fn is_local_workdir_rejects_existing_file() {
         "an existing FILE must not be treated as a local workdir: {path}"
     );
 }
+
+/// An absolute symlink pointing at a real directory IS a usable local workdir
+/// (review #1502: the `is_dir()`-only check follows symlinks correctly).
+///
+/// Why: replacing `exists() && is_dir()` with `is_dir()` must not regress the
+/// symlinked-directory case — `Path::is_dir()` follows symlinks, so a symlink to a
+/// directory resolves to a directory and is a valid workspace root.
+/// What: creates a real dir, an absolute symlink to it, and asserts the symlink
+/// path is detected as a local workdir.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn is_local_workdir_follows_symlinked_dir() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let real = tmp.path().join("real-dir");
+    std::fs::create_dir(&real).expect("create real dir");
+    let link = tmp.path().join("link-dir");
+    std::os::unix::fs::symlink(&real, &link).expect("create symlink");
+    let path = link.to_string_lossy().to_string();
+    assert!(
+        is_local_workdir(&path),
+        "a symlink to a directory must be a usable local workdir: {path}"
+    );
+}


### PR DESCRIPTION
## Summary

Two backend capabilities for the session-manager + chat-core nucleus (epic #1433, spec DOC-20 / DOC-14):

1. **`SessionManager::adopt_existing`** — connect to and drive an UNMANAGED tmux pane.
2. **Local-path (non-clone) managed spawn** — use an existing local directory as the workdir, skipping the git clone.

No Telegram-surface or `http_client` mock changes beyond the minimum required for compilation/wiring (flagged below for the parallel Telegram engineer's rebase).

## Part 1 — `adopt_existing` design

A new manager method that synthesises a durable `Active` `SessionRecord` for a tmux pane that **already exists** (a hand-started Claude Code, an externally-created session, or one whose record was lost). It is the explicit counterpart to `reconcile_on_boot`'s automatic adoption.

**Design decisions (documented in code):**
- **Collision check INVERTED vs. `create`.** `create` fails when a name exists; `adopt_existing` fails with `TmuxSessionMissing` when the pane is absent (you cannot adopt what is not there) and `AlreadyAdopted` when the store already tracks it. It does **not** call `create_session` — the pane already exists; the driver is only consulted via `session_exists`.
- **`cwd` is REQUIRED** (a plain `PathBuf`): the pane's provenance is unknown to the daemon, so the operator supplies it (rather than the `/unknown` stub auto-boot adoption uses).
- **`runtime` defaults** to the standard managed runtime; **`task` is optional/empty-allowed**.
- **Non-`tmpm-` names are ALLOWED** on this explicit path. `reconcile_on_boot`'s `tmpm-` auto-boot filter is **left untouched**.

It lives in a focused `session_manager/adopt.rs` so `manager.rs` stays under the 500-SLOC production cap.

### New route + verb
- **`POST /api/v1/sessions/managed/adopt`** with request/response DTOs. Maps `TmuxSessionMissing → 404`, `AlreadyAdopted → 409`, bad runtime `→ 400`, success `→ 201`. The stateless `POST /tmux/adopt` snapshot endpoint (which registers nothing) is **unchanged** — a doc note now distinguishes the two.
- **chat-core**: `TrustyCommand::ManagedAdopt`, `CommandResult::ManagedAdopted`, `CommandExecutor::managed_adopt`, catalog `managed-adopt` operator verb, and the action-loop **`sessions.adopt`** ops verb (via `SM_OPS_VERBS` + a default-erroring `SessionControl::adopt` overridden by `DaemonSessionControl`).

## Part 2 — local-path spawn heuristic

`spawn_managed` now detects an existing local absolute directory and uses it verbatim as the session cwd, **skipping the git clone**. Detection heuristic:

```rust
Path::new(s).is_absolute() && Path::new(s).exists() && Path::new(s).is_dir()
```

Anything else (an `https://…` / `git@…` URL, a relative path, a missing path, an existing **file**) falls through to the existing clone path, so remote-URL callers are unaffected. `sessions.launch` with `workdir=/Users/masa/Projects/trusty-tools` now works end-to-end (it maps `workdir → repo_url`).

## SM_TOOLS.md regeneration: **NO**

`sessions.adopt` lives in the `SM_OPS_VERBS` slice that `render_sm_tools()` does **not** emit (the same minimal-surface pattern `sessions.health` established in #1498). The committed `SM_TOOLS.md` asset stays byte-identical and the `sm_tools_md_matches_catalog_render` parity test passes unchanged.

## `sessions.adopt` is in the action loop

```rust
"sessions.adopt" => {
    let tmux_name = args.get("tmux_name")... // required
    let cwd = args.get("cwd")...             // required
    control.adopt(tmux_name, cwd, str_arg(args, "task").as_deref(),
                  str_arg(args, "runtime").as_deref()).await
}
```

advertised by `action_instructions()` (rendered from the catalog SoT) and listed in the unknown-verb error set.

## ⚠️ Files under `client/http_client/` (flag for rebase)

The parallel Telegram engineer also touches this area. My additions there are localized:
- `http_client/types.rs`: new `ManagedAdoptRequest` / `ManagedAdoptResponse` DTOs.
- `http_client/managed.rs`: new `DaemonClient::adopt_managed_session` method.
- `http_client/mod.rs`: re-export of the two new DTOs (one line in the existing `pub use` block).
- `http_client/tests.rs`: two new wire-shape tests.

Also flagged: `telegram/formatter/mod.rs` gains ONE `CommandResult::ManagedAdopted` render arm (required to keep the exhaustive match compiling); it mirrors the existing `ManagedSpawned` arm and can be relocated/restyled on rebase.

## Tests (pure-logic; no daemon spawn)

- Manager: adopt happy-path registers Active / missing-pane errors / double-adopt errors / non-`tmpm-` name allowed.
- DTO serde round-trips; executor validation (tmux_name + cwd required); action-loop dispatch + prompt advertisement + unknown-verb listing; catalog parity.
- `tests/local_spawn.rs`: `is_local_workdir` detection matrix (absolute dir, URL/relative/missing/empty, existing file).

The ~106 daemon-spawning tests that fail LOCALLY are the known pre-existing tokio runtime-drop env panic (every failure is the identical `tokio/.../shutdown.rs:51` panic, none assertion failures); CI on pinned 1.91 is the gate. All NEW pure-logic tests pass locally.

Refs epic #1433; spec DOC-20 / DOC-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)