### PR TITLE
feat(trusty-mpm): web adapter on chat-core seam (refs #1433, #1295, #926)

### DIFF
--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -58,6 +58,19 @@ pub use claude_config_routes::*;
 pub mod coordinator_routes;
 pub use coordinator_routes::*;
 
+/// The Web control-surface route (`GET /web`, DOC-20 §6 Phase 2 / ONB-3).
+///
+/// Why: ONB-3 names a Web control surface as a peer of the TUI/Telegram
+/// adapters. It is a *thin* presentation layer — a single static browser chat
+/// page that drives the EXISTING action-capable `POST /api/v1/sessions/chat`
+/// endpoint — so it embeds no session logic. Keeping it in a sibling module
+/// mirrors `coordinator_routes` and keeps `api.rs` focused.
+/// What: the `web_chat_page` handler (serves the embedded page); re-exported so
+/// `router` refers to it as `super::api::web_chat_page`.
+/// Test: `web_routes::web_chat_tests` drives the page and the `/web` route.
+pub mod web_routes;
+pub use web_routes::*;
+
 /// The loopback-only JSON-RPC dispatch endpoint (`POST /rpc`, #1221).
 ///
 /// Why: the `serve --stdio` bridge forwards MCP JSON-RPC envelopes to the durable
@@ -132,6 +145,10 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         // as the session context/chat endpoints; these are the canonical SM names.
         .route("/api/v1/session-manager/context", get(coordinator_context))
         .route("/api/v1/session-manager/chat", post(coordinator_chat))
+        // DOC-20 §6 Phase 2 / ONB-3: the Web control surface — a static browser
+        // chat page that drives the action-capable `/api/v1/sessions/chat`
+        // endpoint above. Thin adapter; no new session logic.
+        .route("/web", get(web_chat_page))
         .route("/tmux/sessions", get(list_tmux_sessions))
         .route("/tmux/sessions/{name}/snapshot", get(tmux_snapshot))
         .route("/tmux/adopt", post(adopt_tmux_session))

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -153,7 +153,9 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         // leaves (`context`, `chat`) avoid colliding with the managed-session
         // routes below.
         .route("/api/v1/sessions/context", get(coordinator_context))
-        .route("/api/v1/sessions/chat", post(coordinator_chat))
+        // Use the shared `COORDINATOR_CHAT_PATH` constant so the registered route
+        // and the browser Web adapter (`web_chat.html`) can never drift (#1503).
+        .route(COORDINATOR_CHAT_PATH, post(coordinator_chat))
         // DOC-14 D0.1: `/session-manager/*` aliases resolve to the SAME handlers
         // as the session context/chat endpoints; these are the canonical SM names.
         .route("/api/v1/session-manager/context", get(coordinator_context))

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -71,6 +71,19 @@ pub use coordinator_routes::*;
 pub mod web_routes;
 pub use web_routes::*;
 
+/// The CSRF/origin guard for the browser-facing, action-capable chat endpoint.
+///
+/// Why: the Web surface (`GET /web`) drives the state-mutating
+/// `POST /api/v1/sessions/chat` with `actions: true` from a browser; without an
+/// origin check a malicious cross-origin page could trigger session actions if
+/// the daemon were reachable off loopback. Keeping the policy in a sibling module
+/// makes it unit-testable in isolation and keeps `coordinator_routes` thin.
+/// What: re-exports [`origin_guard::origin_allowed`] so `coordinator_chat` can
+/// gate on it.
+/// Test: `origin_guard::origin_guard_tests`.
+pub mod origin_guard;
+pub use origin_guard::origin_allowed;
+
 /// The loopback-only JSON-RPC dispatch endpoint (`POST /rpc`, #1221).
 ///
 /// Why: the `serve --stdio` bridge forwards MCP JSON-RPC envelopes to the durable

--- a/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
@@ -17,6 +17,20 @@ use axum::http::HeaderMap;
 use axum::{Json, extract::State};
 
 use crate::daemon::api::origin_guard::origin_allowed;
+
+/// The canonical registered path for the coordinator chat endpoint.
+///
+/// Why: this single constant is the ONE source of truth for the chat route path,
+/// shared by the router registration (`api::router`) and the browser Web adapter
+/// (`web_chat.html` is asserted against it). Sharing it kills the route/HTML
+/// drift class the #1503 review flagged — if the route path ever changes, the
+/// `web_chat_path_is_registered` test fails until the page is updated to match.
+/// What: the literal `/api/v1/sessions/chat` path the `coordinator_chat` handler
+/// is mounted at (its `/api/v1/session-manager/chat` alias maps to the same
+/// handler; both are registered in `api::router`).
+/// Test: `web_routes::web_chat_tests::web_chat_path_is_registered`, and the
+/// route-registration test `router_registers_coordinator_chat_path`.
+pub const COORDINATOR_CHAT_PATH: &str = "/api/v1/sessions/chat";
 use crate::daemon::coordinator::{
     CoordinatorContext, build_coordinator_context, coordinator_system_prompt, parse_session_prefix,
 };
@@ -162,15 +176,21 @@ pub async fn coordinator_chat(
     Json(body): Json<CoordinatorChatRequest>,
 ) -> Result<Json<CoordinatorChatResponse>, DaemonError> {
     // CSRF/origin guard for the browser surface (review #1503). The daemon binds
-    // loopback by default; the Web adapter (`GET /web`) drives THIS endpoint with
-    // `actions: true` from a browser, so a cross-origin page could otherwise POST
-    // here and trigger session actions. The guard rejects a request only when it
-    // carries a cross-origin `Origin` header — server-side callers (the Telegram
-    // adapter and TUI via reqwest, plus `curl`) send no `Origin` and always pass,
-    // so all existing behavior is preserved. Gating only the action-capable path
-    // keeps the read-only/text-only paths (and any non-browser `actions:false`
-    // caller) completely untouched.
-    if body.actions == Some(true) && !origin_allowed(&headers) {
+    // loopback by default; the Web adapter (`GET /web`) drives THIS endpoint from
+    // a browser, so a cross-origin page could otherwise POST here and trigger
+    // session actions. The guard rejects a request only when it carries a
+    // cross-origin `Origin` header — server-side callers (the Telegram adapter and
+    // TUI via reqwest, plus `curl`) send no `Origin` and always pass, so all
+    // existing behavior is preserved.
+    //
+    // Defense-in-depth (review #1503): the guard fires whenever actions are NOT
+    // explicitly disabled (`actions != Some(false)`), so an OMITTED or `null`
+    // `actions` field is guarded too. Rationale: a cross-origin browser attacker
+    // controls the body and would simply omit `actions` to dodge a guard keyed on
+    // `Some(true)`; since the SM path treats an absent `actions` as text-only it
+    // costs the legitimate browser nothing to be checked, while only an explicit
+    // `actions: false` (a deliberate text-only opt-out) skips the check.
+    if csrf_guard_applies(body.actions) && !origin_allowed(&headers) {
         return Err(DaemonError::Forbidden(
             "cross-origin request to the action-capable chat endpoint is not allowed".to_string(),
         ));
@@ -246,6 +266,24 @@ pub async fn coordinator_chat(
         conv_id: None,
         actions_taken: None,
     }))
+}
+
+/// Whether the CSRF/origin guard applies to a chat request, given its `actions`
+/// field.
+///
+/// Why: defense-in-depth (review #1503). A guard keyed strictly on
+/// `actions == Some(true)` is trivially bypassed — a cross-origin browser
+/// attacker controls the JSON body and would simply OMIT `actions` (or send
+/// `null`), which the SM path already treats as a chat turn. So the guard must
+/// fire whenever actions are not EXPLICITLY disabled. Pulling the decision into a
+/// pure `Option<bool> → bool` function makes the policy provable without a tokio
+/// runtime or a wired overseer (the handler-level tests need both).
+/// What: returns `true` for `None` (omitted/null) and `Some(true)`, and `false`
+/// ONLY for `Some(false)` — a deliberate text-only opt-out that skips the check.
+/// Test: `csrf_guard_tests::{guard_fires_when_actions_omitted,
+/// guard_fires_when_actions_true, guard_skips_when_actions_explicitly_false}`.
+fn csrf_guard_applies(actions: Option<bool>) -> bool {
+    actions != Some(false)
 }
 
 /// Drive one Session Manager chat turn and map it onto the wire response (SM-7).
@@ -326,5 +364,39 @@ async fn route_through_action_loop(
         })),
         Err(SmAgentError::Degraded(notice)) => Err(DaemonError::ServiceUnavailable(notice)),
         Err(e) => Err(DaemonError::Internal(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod csrf_guard_tests {
+    use super::csrf_guard_applies;
+
+    /// Why: the original guard fired only on `Some(true)`, so an attacker omitting
+    /// `actions` dodged it (review #1503). The hardened guard MUST fire on an
+    /// omitted/null `actions` field — this is the whole point of the fix.
+    /// What: `None` (omitted/null `actions`) → guard applies.
+    /// Test: this is the test.
+    #[test]
+    fn guard_fires_when_actions_omitted() {
+        assert!(csrf_guard_applies(None));
+    }
+
+    /// Why: the explicit action opt-in is the highest-risk path and must always be
+    /// guarded.
+    /// What: `Some(true)` → guard applies.
+    /// Test: this is the test.
+    #[test]
+    fn guard_fires_when_actions_true() {
+        assert!(csrf_guard_applies(Some(true)));
+    }
+
+    /// Why: a deliberate `actions: false` is a non-mutating text-only opt-out; the
+    /// guard skips it so a non-browser `actions:false` caller stays untouched (and
+    /// the read-only contract is preserved).
+    /// What: `Some(false)` → guard does NOT apply.
+    /// Test: this is the test.
+    #[test]
+    fn guard_skips_when_actions_explicitly_false() {
+        assert!(!csrf_guard_applies(Some(false)));
     }
 }

--- a/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/coordinator_routes.rs
@@ -13,8 +13,10 @@
 
 use std::sync::Arc;
 
+use axum::http::HeaderMap;
 use axum::{Json, extract::State};
 
+use crate::daemon::api::origin_guard::origin_allowed;
 use crate::daemon::coordinator::{
     CoordinatorContext, build_coordinator_context, coordinator_system_prompt, parse_session_prefix,
 };
@@ -156,8 +158,24 @@ pub async fn coordinator_context(
 )]
 pub async fn coordinator_chat(
     State(state): State<Arc<DaemonState>>,
+    headers: HeaderMap,
     Json(body): Json<CoordinatorChatRequest>,
 ) -> Result<Json<CoordinatorChatResponse>, DaemonError> {
+    // CSRF/origin guard for the browser surface (review #1503). The daemon binds
+    // loopback by default; the Web adapter (`GET /web`) drives THIS endpoint with
+    // `actions: true` from a browser, so a cross-origin page could otherwise POST
+    // here and trigger session actions. The guard rejects a request only when it
+    // carries a cross-origin `Origin` header — server-side callers (the Telegram
+    // adapter and TUI via reqwest, plus `curl`) send no `Origin` and always pass,
+    // so all existing behavior is preserved. Gating only the action-capable path
+    // keeps the read-only/text-only paths (and any non-browser `actions:false`
+    // caller) completely untouched.
+    if body.actions == Some(true) && !origin_allowed(&headers) {
+        return Err(DaemonError::Forbidden(
+            "cross-origin request to the action-capable chat endpoint is not allowed".to_string(),
+        ));
+    }
+
     let context = build_coordinator_context(&state);
 
     // A `@prefix:` message is a direct command — route it straight to the

--- a/crates/trusty-mpm/src/daemon/api/origin_guard.rs
+++ b/crates/trusty-mpm/src/daemon/api/origin_guard.rs
@@ -1,0 +1,215 @@
+//! Origin guard for the now browser-facing, action-capable chat endpoint.
+//!
+//! Why: the DOC-20 §6 / ONB-3 Web surface (`GET /web`) makes a browser drive the
+//! state-mutating `POST /api/v1/sessions/chat` with `actions: true`, which can
+//! spawn/stop/mutate managed sessions. The daemon binds loopback by default, but
+//! if it is ever reachable from a browser on a non-loopback interface, a
+//! malicious cross-origin page could silently POST to that endpoint and trigger
+//! session actions (classic CSRF). This module is the lightweight mitigation: a
+//! same-origin/loopback Origin check that costs nothing for the existing
+//! server-side callers.
+//! What: [`origin_allowed`] inspects the request's `Origin` header (if any) and
+//! its `Host`. With NO `Origin` header the request is allowed — this is the
+//! server-side case (the Telegram adapter, the TUI, and `curl` all call the
+//! endpoint via reqwest/localhost and send no `Origin`), so all current behavior
+//! is preserved. With an `Origin` header present, the request is allowed only if
+//! the origin is loopback (`http://127.0.0.1[:port]`, `http://localhost[:port]`,
+//! `http://[::1][:port]`) or matches the request `Host`; any other (cross-origin)
+//! browser request is rejected.
+//! Test: `origin_guard_tests` covers no-Origin → allowed, loopback/same-origin →
+//! allowed, and cross-origin → rejected.
+
+use axum::http::HeaderMap;
+use axum::http::header::{HOST, ORIGIN};
+
+/// Decide whether a request to the action-capable chat endpoint is allowed by the
+/// CSRF/origin guard.
+///
+/// Why: this is the single, unit-testable seam for the CSRF mitigation. Keeping
+/// the policy in one pure function (header map in, bool out) means the handler
+/// stays a thin caller and the allow/reject matrix is provable without spinning
+/// up a server. The no-`Origin` allowance is what keeps every existing
+/// server-side caller (Telegram/TUI via reqwest, `curl`) working unchanged —
+/// only real browsers attach an `Origin` header to a `POST`.
+/// What: returns `true` when the request carries NO `Origin` header (server-side
+/// callers), or when the `Origin` is loopback (`127.0.0.1`, `localhost`, `::1`,
+/// any scheme/port) or its host:port matches the request's `Host` header
+/// (same-origin). Returns `false` for any other present `Origin` (cross-origin),
+/// and for a malformed `Origin` that is neither loopback nor same-origin.
+/// Test: `origin_guard_tests::{no_origin_allowed, loopback_origin_allowed,
+/// same_origin_allowed, cross_origin_rejected}`.
+pub fn origin_allowed(headers: &HeaderMap) -> bool {
+    // No `Origin` header → a non-browser, server-side caller (reqwest, curl, the
+    // Telegram/TUI adapters). These are trusted by construction (they reach the
+    // loopback daemon directly), so they always pass — this preserves 100% of the
+    // existing behavior and is the crux of "do not break server callers".
+    let Some(origin) = header_str(headers, ORIGIN) else {
+        return true;
+    };
+
+    // A present `Origin` means a browser issued the request. Allow it only if it
+    // is loopback or same-origin as the request `Host`.
+    let Some(origin_authority) = authority_of(origin) else {
+        // A non-URL `Origin` (or the literal "null") is not same-origin and not
+        // loopback — reject it.
+        return false;
+    };
+
+    if is_loopback_host(origin_authority) {
+        return true;
+    }
+
+    // Same-origin: the Origin's authority (host[:port]) equals the request Host.
+    match header_str(headers, HOST) {
+        Some(host) => origin_authority.eq_ignore_ascii_case(host),
+        None => false,
+    }
+}
+
+/// Read a header as a UTF-8 `&str`, treating absent/non-UTF-8 as missing.
+///
+/// Why: header values are bytes; the guard only reasons about textual origins, so
+/// a non-UTF-8 value should be treated as "no usable header" rather than panic.
+/// What: returns `Some(&str)` when the header exists and is valid UTF-8, else
+/// `None`.
+/// Test: exercised indirectly via [`origin_allowed`] tests.
+fn header_str(headers: &HeaderMap, name: axum::http::HeaderName) -> Option<&str> {
+    headers.get(name).and_then(|v| v.to_str().ok())
+}
+
+/// Extract the `host[:port]` authority from an `Origin` value.
+///
+/// Why: an `Origin` is `scheme://host[:port]`; the guard compares authorities
+/// (and detects loopback) on the host part, so the scheme prefix must be
+/// stripped. Doing it by hand avoids pulling in a URL-parser dependency for one
+/// header.
+/// What: strips a leading `scheme://` (everything up to and including the first
+/// `://`) and returns the remainder, or `None` when there is no `://` (e.g. the
+/// literal `null`, which browsers send for opaque origins).
+/// Test: exercised indirectly via [`origin_allowed`] tests
+/// (`cross_origin_rejected` includes a `null` origin).
+fn authority_of(origin: &str) -> Option<&str> {
+    origin.split_once("://").map(|(_scheme, rest)| rest)
+}
+
+/// Whether an authority (`host[:port]`) names the loopback interface.
+///
+/// Why: the daemon serves the browser page itself, so a same-machine browser's
+/// `Origin` is loopback; those must always pass regardless of which loopback
+/// alias or ephemeral port the browser used.
+/// What: returns `true` when the host portion (authority with any `:port`
+/// stripped, and any IPv6 brackets removed) is `127.0.0.1`, `localhost`, or
+/// `::1`. Case-insensitive on `localhost`.
+/// Test: `origin_guard_tests::loopback_origin_allowed`.
+fn is_loopback_host(authority: &str) -> bool {
+    // Strip an optional `:port`. For a bracketed IPv6 authority (`[::1]:8080`)
+    // split on the closing bracket first so the colons inside the address are not
+    // mistaken for a port separator.
+    let host = if let Some(rest) = authority.strip_prefix('[') {
+        // `::1]` or `::1]:port` → take up to the closing bracket.
+        rest.split(']').next().unwrap_or(rest)
+    } else {
+        // `host` or `host:port` → take up to the first colon.
+        authority.split(':').next().unwrap_or(authority)
+    };
+
+    host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+}
+
+#[cfg(test)]
+mod origin_guard_tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    /// Build a `HeaderMap` from optional `Origin` and `Host` values.
+    fn headers(origin: Option<&str>, host: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(o) = origin {
+            h.insert(ORIGIN, HeaderValue::from_str(o).expect("valid origin"));
+        }
+        if let Some(host) = host {
+            h.insert(HOST, HeaderValue::from_str(host).expect("valid host"));
+        }
+        h
+    }
+
+    /// Why: server-side callers (Telegram/TUI via reqwest, `curl`) send NO
+    /// `Origin` header; the guard MUST let them through or every existing caller
+    /// breaks. This is the single most important case.
+    /// What: an empty header map (and one with only a `Host`) is allowed.
+    /// Test: this is the test.
+    #[test]
+    fn no_origin_allowed() {
+        assert!(origin_allowed(&headers(None, None)));
+        assert!(origin_allowed(&headers(None, Some("127.0.0.1:8765"))));
+    }
+
+    /// Why: a same-machine browser hitting `/web` carries a loopback `Origin`;
+    /// those are trusted and must pass regardless of alias or port.
+    /// What: `127.0.0.1`, `localhost`, and `[::1]` origins (with/without port)
+    /// are allowed even when the `Host` differs or is absent.
+    /// Test: this is the test.
+    #[test]
+    fn loopback_origin_allowed() {
+        assert!(origin_allowed(&headers(
+            Some("http://127.0.0.1:8765"),
+            Some("127.0.0.1:8765")
+        )));
+        assert!(origin_allowed(&headers(
+            Some("http://localhost:3000"),
+            Some("example.com")
+        )));
+        assert!(origin_allowed(&headers(Some("http://localhost"), None)));
+        assert!(origin_allowed(&headers(
+            Some("http://[::1]:8765"),
+            Some("[::1]:8765")
+        )));
+    }
+
+    /// Why: a browser served the page from the daemon's own host should keep
+    /// working even when the daemon is bound to a non-loopback address — the
+    /// `Origin` then matches the `Host`.
+    /// What: an `Origin` whose authority equals the request `Host` is allowed.
+    /// Test: this is the test.
+    #[test]
+    fn same_origin_allowed() {
+        assert!(origin_allowed(&headers(
+            Some("https://daemon.internal:9000"),
+            Some("daemon.internal:9000")
+        )));
+        // Host comparison is case-insensitive.
+        assert!(origin_allowed(&headers(
+            Some("https://Daemon.Internal"),
+            Some("daemon.internal")
+        )));
+    }
+
+    /// Why: this is the threat — a malicious cross-origin page POSTing to the
+    /// action-capable endpoint. Its `Origin` is neither loopback nor same-origin,
+    /// so it MUST be rejected (the handler maps `false` → 403).
+    /// What: a cross-origin `Origin`, a mismatched-port `Origin`, and the opaque
+    /// `null` origin are all rejected.
+    /// Test: this is the test.
+    #[test]
+    fn cross_origin_rejected() {
+        assert!(!origin_allowed(&headers(
+            Some("https://evil.example.com"),
+            Some("127.0.0.1:8765")
+        )));
+        // Same host, different port is a different origin.
+        assert!(!origin_allowed(&headers(
+            Some("http://daemon.internal:1234"),
+            Some("daemon.internal:9000")
+        )));
+        // Opaque origin (e.g. sandboxed iframe) → reject.
+        assert!(!origin_allowed(&headers(
+            Some("null"),
+            Some("daemon.internal:9000")
+        )));
+        // Present Origin but no Host to match against → reject.
+        assert!(!origin_allowed(&headers(
+            Some("https://evil.example.com"),
+            None
+        )));
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api/origin_guard.rs
+++ b/crates/trusty-mpm/src/daemon/api/origin_guard.rs
@@ -84,12 +84,18 @@ fn header_str(headers: &HeaderMap, name: axum::http::HeaderName) -> Option<&str>
 /// stripped. Doing it by hand avoids pulling in a URL-parser dependency for one
 /// header.
 /// What: strips a leading `scheme://` (everything up to and including the first
-/// `://`) and returns the remainder, or `None` when there is no `://` (e.g. the
-/// literal `null`, which browsers send for opaque origins).
-/// Test: exercised indirectly via [`origin_allowed`] tests
-/// (`cross_origin_rejected` includes a `null` origin).
+/// `://`) AND any trailing `/path` component, returning just the `host[:port]`
+/// authority; returns `None` when there is no `://` (e.g. the literal `null`,
+/// which browsers send for opaque origins). The trailing-path strip means an
+/// `Origin` like `http://localhost:8765/` (a stray slash) is still treated as the
+/// `localhost:8765` authority rather than `localhost:8765/`, which would never
+/// match a `Host` and would wrongly be rejected.
+/// Test: exercised via [`origin_allowed`] tests (`cross_origin_rejected` includes
+/// a `null` origin; `same_origin_with_trailing_slash_allowed` covers the slash).
 fn authority_of(origin: &str) -> Option<&str> {
-    origin.split_once("://").map(|(_scheme, rest)| rest)
+    origin
+        .split_once("://")
+        .map(|(_scheme, rest)| rest.split('/').next().unwrap_or(rest))
 }
 
 /// Whether an authority (`host[:port]`) names the loopback interface.
@@ -181,6 +187,26 @@ mod origin_guard_tests {
         assert!(origin_allowed(&headers(
             Some("https://Daemon.Internal"),
             Some("daemon.internal")
+        )));
+    }
+
+    /// Why: some browsers/proxies can present an `Origin` with a trailing slash
+    /// (e.g. `http://daemon.internal:9000/`). Without stripping the path component
+    /// the authority would be `daemon.internal:9000/`, which never equals the
+    /// `Host` `daemon.internal:9000` — so a legitimate same-origin POST would be
+    /// wrongly rejected (review #1503). It must be treated as same-origin.
+    /// What: an `Origin` with a trailing slash whose authority matches the `Host`
+    /// is allowed; a loopback `Origin` with a trailing slash is also allowed.
+    /// Test: this is the test.
+    #[test]
+    fn same_origin_with_trailing_slash_allowed() {
+        assert!(origin_allowed(&headers(
+            Some("https://daemon.internal:9000/"),
+            Some("daemon.internal:9000")
+        )));
+        assert!(origin_allowed(&headers(
+            Some("http://127.0.0.1:8765/"),
+            Some("127.0.0.1:8765")
         )));
     }
 

--- a/crates/trusty-mpm/src/daemon/api/web_chat.html
+++ b/crates/trusty-mpm/src/daemon/api/web_chat.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<!--
+  Why: the Web control surface (DOC-20 §6 Phase 2, ONB-3) — a browser chat page
+       that drives managed sessions through the EXISTING action-capable chat
+       endpoint. It embeds no session logic; it is a thin presentation layer over
+       POST /api/v1/sessions/chat with `actions: true`.
+  What: a single self-contained page (no build step, no external assets) that
+       POSTs the operator's message to the chat-core endpoint, renders the SM
+       `reply`, and surfaces the `actions_taken` audit trail. `conv_id` is echoed
+       back and resent so the rolling SM context continues across turns.
+  Test: served by `web_chat_page` (see web_routes.rs); the daemon route tests pin
+       status + content-type + key markers in this body.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>trusty-mpm — Session Manager chat</title>
+  <style>
+    :root {
+      --bg: #0e1116; --panel: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #2f81f7;
+      --user: #1f6feb33; --sm: #23863633; --action: #3d2d00;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI",
+      Roboto, Helvetica, Arial, sans-serif; background: var(--bg);
+      color: var(--text); display: flex; flex-direction: column; height: 100vh;
+    }
+    header {
+      padding: 12px 16px; border-bottom: 1px solid var(--border);
+      background: var(--panel); display: flex; align-items: center; gap: 12px;
+    }
+    header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+    header .conv { color: var(--muted); font-size: 12px; margin-left: auto; }
+    #log { flex: 1; overflow-y: auto; padding: 16px; }
+    .msg { max-width: 760px; margin: 0 auto 12px; padding: 10px 14px;
+      border-radius: 8px; border: 1px solid var(--border); white-space: pre-wrap;
+      word-wrap: break-word; }
+    .msg.user { background: var(--user); }
+    .msg.sm { background: var(--sm); }
+    .msg.error { background: #f8514933; border-color: #f85149; }
+    .role { font-size: 11px; text-transform: uppercase; letter-spacing: .05em;
+      color: var(--muted); margin-bottom: 4px; }
+    .actions { max-width: 760px; margin: -6px auto 12px; padding: 8px 14px;
+      border-radius: 8px; background: var(--action); border: 1px solid #5a4500;
+      font-size: 13px; }
+    .actions ul { margin: 4px 0 0; padding-left: 18px; }
+    .meta { color: var(--muted); font-size: 11px; margin-top: 4px; }
+    form { display: flex; gap: 8px; padding: 12px 16px;
+      border-top: 1px solid var(--border); background: var(--panel); }
+    #input { flex: 1; resize: none; background: var(--bg); color: var(--text);
+      border: 1px solid var(--border); border-radius: 8px; padding: 10px;
+      font: inherit; }
+    #send { background: var(--accent); color: #fff; border: 0; border-radius: 8px;
+      padding: 0 18px; font-weight: 600; cursor: pointer; }
+    #send:disabled { opacity: .5; cursor: default; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>trusty-mpm — Session Manager</h1>
+    <span class="conv" id="conv">new conversation</span>
+  </header>
+  <div id="log" aria-live="polite">
+    <div class="msg sm">
+      <div class="role">session manager</div>Ask me to spawn, list, send to, or stop managed sessions. I can run those actions inline and show you the audit trail.</div>
+  </div>
+  <form id="form">
+    <textarea id="input" rows="2" placeholder="Message the session manager…" autofocus></textarea>
+    <button id="send" type="submit">Send</button>
+  </form>
+  <script>
+    "use strict";
+    // Why: continue one SM rolling-context conversation across turns. Echoed by
+    // the endpoint and resent so the SM keeps its compressed history.
+    let convId = null;
+    const log = document.getElementById("log");
+    const form = document.getElementById("form");
+    const input = document.getElementById("input");
+    const sendBtn = document.getElementById("send");
+    const convLabel = document.getElementById("conv");
+
+    function append(role, cls, text) {
+      const el = document.createElement("div");
+      el.className = "msg " + cls;
+      const r = document.createElement("div");
+      r.className = "role";
+      r.textContent = role;
+      el.appendChild(r);
+      el.appendChild(document.createTextNode(text));
+      log.appendChild(el);
+      log.scrollTop = log.scrollHeight;
+      return el;
+    }
+
+    function appendActions(actions, meta) {
+      const el = document.createElement("div");
+      el.className = "actions";
+      el.appendChild(document.createTextNode("Actions taken:"));
+      const ul = document.createElement("ul");
+      for (const a of actions) {
+        const li = document.createElement("li");
+        li.textContent = a;
+        ul.appendChild(li);
+      }
+      el.appendChild(ul);
+      if (meta) {
+        const m = document.createElement("div");
+        m.className = "meta";
+        m.textContent = meta;
+        el.appendChild(m);
+      }
+      log.appendChild(el);
+      log.scrollTop = log.scrollHeight;
+    }
+
+    async function submit(message) {
+      append("you", "user", message);
+      sendBtn.disabled = true;
+      try {
+        const body = { message, actions: true };
+        if (convId) body.conv_id = convId;
+        const resp = await fetch("/api/v1/sessions/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+          const t = await resp.text();
+          append("error", "error", "HTTP " + resp.status + ": " + t);
+          return;
+        }
+        const data = await resp.json();
+        if (data.conv_id) {
+          convId = data.conv_id;
+          convLabel.textContent = "conv " + convId.slice(0, 8);
+        }
+        append("session manager", "sm", data.reply || "(no reply)");
+        if (Array.isArray(data.actions_taken) && data.actions_taken.length) {
+          let meta = "";
+          if (typeof data.cost === "number") meta = "cost $" + data.cost.toFixed(4);
+          appendActions(data.actions_taken, meta);
+        }
+      } catch (e) {
+        append("error", "error", String(e));
+      } finally {
+        sendBtn.disabled = false;
+        input.focus();
+      }
+    }
+
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const message = input.value.trim();
+      if (!message) return;
+      input.value = "";
+      submit(message);
+    });
+    // Enter sends; Shift+Enter inserts a newline.
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        form.requestSubmit();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/crates/trusty-mpm/src/daemon/api/web_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/web_routes.rs
@@ -40,6 +40,18 @@ const WEB_CHAT_HTML: &str = include_str!("web_chat.html");
 /// `content-type: text/html; charset=utf-8`). Always `200`; no state is touched,
 /// so it works even when the SM/LLM is unconfigured (the page surfaces the
 /// endpoint's `503` to the operator at send time).
+///
+/// Threat model (review #1503): this page drives the STATE-MUTATING, action-
+/// capable `POST /api/v1/sessions/chat` (`actions: true`), which can spawn/stop/
+/// mutate managed sessions. The daemon binds **loopback by default**, so the
+/// browser surface is normally only reachable from the same machine. If the
+/// daemon is ever bound to a non-loopback interface, the CSRF mitigation is the
+/// Origin guard on that POST handler
+/// ([`origin_allowed`](crate::daemon::api::origin_guard::origin_allowed)): a
+/// cross-origin browser POST is rejected with `403`, while same-origin/loopback
+/// requests and header-less server-side callers (Telegram/TUI via reqwest,
+/// `curl`) pass unchanged. This `GET /web` page itself is a read-only static
+/// asset and touches no state, so it carries no CSRF risk on its own.
 /// Test: `web_chat_page_serves_html`, and the router-level
 /// `web_route_returns_200_html` in `web_chat_tests`.
 #[utoipa::path(

--- a/crates/trusty-mpm/src/daemon/api/web_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/web_routes.rs
@@ -1,0 +1,127 @@
+//! Web control-surface route (`GET /web`) — DOC-20 §6 Phase 2 / ONB-3.
+//!
+//! Why: the chat-core nucleus (DOC-20) makes every operator verb reachable
+//! through one action-capable HTTP endpoint, `POST /api/v1/sessions/chat` with
+//! `actions: true`. ONB-3 (DOC-18) names a **Web** control surface as a peer of
+//! the TUI and Telegram. This module is that surface — but kept deliberately
+//! thin: it serves a single static browser chat page that drives the EXISTING
+//! endpoint. It embeds **no** session logic, **no** resolver, **no** transport;
+//! it is a presentation layer over the same nucleus, exactly as the spec's
+//! "adapters are thin" invariant requires.
+//! What: the `web_chat_page` handler returns the embedded `web_chat.html` (an
+//! `include_str!` so there is no build step and `SKIP_UI_BUILD` is irrelevant —
+//! nothing is compiled). The page POSTs to `/api/v1/sessions/chat`, renders the
+//! `reply`, and surfaces the `actions_taken` audit trail. It is wired into the
+//! router by `api::router`.
+//! Test: `web_chat_tests` pins the served status, content-type, and the
+//! load-bearing markers in the page body (the endpoint path it calls and the
+//! `actions:true` opt-in).
+
+use axum::response::Html;
+
+/// The embedded Web chat page.
+///
+/// Why: shipping the page as a committed `include_str!` asset keeps the Web
+/// adapter zero-cost and zero-dependency — no Svelte/Vite/pnpm build, so a
+/// default `cargo build -p trusty-mpm` (and `SKIP_UI_BUILD`) needs nothing
+/// extra. The page is a true client of the chat-core endpoint.
+/// What: the raw HTML+JS body of `web_chat.html`, served verbatim.
+/// Test: `web_chat_page_serves_html` asserts it is non-empty and well-formed.
+const WEB_CHAT_HTML: &str = include_str!("web_chat.html");
+
+/// `GET /web` — the browser chat surface over the chat-core nucleus.
+///
+/// Why: gives the operator a no-install control surface (just a browser) that is
+/// a peer to the TUI/Telegram adapters. It is intentionally a static page rather
+/// than a server-rendered one so the daemon stays stateless about the Web UI and
+/// the page can be cached; all dynamism happens client-side against the existing
+/// action-capable chat endpoint.
+/// What: returns the embedded [`WEB_CHAT_HTML`] as an `Html` response (axum sets
+/// `content-type: text/html; charset=utf-8`). Always `200`; no state is touched,
+/// so it works even when the SM/LLM is unconfigured (the page surfaces the
+/// endpoint's `503` to the operator at send time).
+/// Test: `web_chat_page_serves_html`, and the router-level
+/// `web_route_returns_200_html` in `web_chat_tests`.
+#[utoipa::path(
+    get,
+    path = "/web",
+    tag = "config",
+    responses((status = 200, description = "Browser chat surface over /api/v1/sessions/chat"))
+)]
+pub async fn web_chat_page() -> Html<&'static str> {
+    Html(WEB_CHAT_HTML)
+}
+
+#[cfg(test)]
+mod web_chat_tests {
+    use super::*;
+    use crate::daemon::state::DaemonState;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    /// Why: the page must actually exist and carry the load-bearing wiring — the
+    /// endpoint it calls and the `actions:true` opt-in — or the adapter silently
+    /// breaks. A pure-string assertion needs no daemon, so it is CI-safe.
+    /// What: asserts the embedded body is non-empty, is an HTML document, calls
+    /// the chat-core endpoint, and opts into the action loop.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn web_chat_page_serves_html() {
+        let Html(body) = web_chat_page().await;
+        assert!(!body.is_empty(), "embedded page must not be empty");
+        assert!(body.contains("<!DOCTYPE html>"), "must be an HTML document");
+        assert!(
+            body.contains("/api/v1/sessions/chat"),
+            "page must POST to the chat-core endpoint"
+        );
+        assert!(
+            body.contains("actions: true") || body.contains("actions:true"),
+            "page must opt into the action-capable loop"
+        );
+        assert!(
+            body.contains("actions_taken"),
+            "page must render the audit trail"
+        );
+        assert!(
+            body.contains("conv_id"),
+            "page must continue the SM rolling context via conv_id"
+        );
+    }
+
+    /// Why: pins the wiring into the daemon router — `GET /web` must resolve to
+    /// the handler and return a `200` with an HTML content-type, exactly as a
+    /// browser expects. This is the router-level contract the other adapters get
+    /// for free but the Web one must register explicitly.
+    /// What: builds the full router over a default `DaemonState`, drives a
+    /// `GET /web` request via `oneshot`, asserts `200` and the `text/html`
+    /// content-type. Pure in-memory — no socket bind, CI-safe.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn web_route_returns_200_html() {
+        let state = Arc::new(DaemonState::new());
+        let app = crate::daemon::api::router(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/web")
+                    .body(Body::empty())
+                    .expect("request builds"),
+            )
+            .await
+            .expect("router serves /web");
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ctype = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            ctype.starts_with("text/html"),
+            "expected text/html, got {ctype:?}"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api/web_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/web_routes.rs
@@ -85,7 +85,7 @@ mod web_chat_tests {
         assert!(!body.is_empty(), "embedded page must not be empty");
         assert!(body.contains("<!DOCTYPE html>"), "must be an HTML document");
         assert!(
-            body.contains("/api/v1/sessions/chat"),
+            body.contains(crate::daemon::api::coordinator_routes::COORDINATOR_CHAT_PATH),
             "page must POST to the chat-core endpoint"
         );
         assert!(
@@ -134,6 +134,35 @@ mod web_chat_tests {
         assert!(
             ctype.starts_with("text/html"),
             "expected text/html, got {ctype:?}"
+        );
+    }
+
+    /// Why: this is the EXACT drift the #1503 review feared — the browser page
+    /// POSTing to a path the router never registered (a silent 404). The fix
+    /// routes BOTH the router registration (`api::router`) and this page through
+    /// ONE shared constant, `COORDINATOR_CHAT_PATH`; this test pins the page's
+    /// `fetch("…")` literal to that constant. Because the router mounts the route
+    /// with the SAME constant (`.route(COORDINATOR_CHAT_PATH, …)`), agreement here
+    /// proves the page targets a registered route — turning a would-be runtime 404
+    /// into a test failure. Kept pure-string (no router/`DaemonState` build) so it
+    /// runs without the daemon-spawn blocking-runtime panic that the router-level
+    /// `web_route_returns_200_html` hits in the local test env.
+    /// What: asserts the embedded page contains `fetch("<COORDINATOR_CHAT_PATH>"`,
+    /// the verbatim shared constant the router registers.
+    /// Test: this is the test.
+    #[test]
+    fn web_chat_path_is_registered() {
+        use crate::daemon::api::coordinator_routes::COORDINATOR_CHAT_PATH;
+
+        // The page must call the shared constant verbatim. We locate the
+        // `fetch("…")` literal so a renamed/typo'd path in the HTML is caught.
+        // The router mounts this SAME constant, so a match proves the page POSTs to
+        // a registered route (no 404).
+        let needle = format!("fetch(\"{COORDINATOR_CHAT_PATH}\"");
+        assert!(
+            WEB_CHAT_HTML.contains(&needle),
+            "web_chat.html must fetch the shared COORDINATOR_CHAT_PATH ({COORDINATOR_CHAT_PATH:?}) \
+             that api::router registers; route/HTML drift would otherwise 404"
         );
     }
 }

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::core::session::{ControlModel, Session, SessionStatus};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use serial_test::serial;
 
 fn state_with_session() -> (Arc<DaemonState>, SessionId) {
@@ -518,6 +518,7 @@ async fn coordinator_chat_without_overseer_is_503() {
     let state = DaemonState::shared();
     let err = coordinator_chat(
         State(state),
+        HeaderMap::new(),
         Json(CoordinatorChatRequest {
             message: "what is happening?".into(),
             history: Vec::new(),
@@ -543,6 +544,7 @@ async fn coordinator_chat_routes_prefixed_message() {
 
     let resp = coordinator_chat(
         State(state),
+        HeaderMap::new(),
         Json(CoordinatorChatRequest {
             message: "@coordtest: echo hi".into(),
             history: Vec::new(),

--- a/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
+++ b/crates/trusty-mpm/src/daemon/coordinator_sm_tests.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::{Json, body::Body, http::Request};
 use serde_json::Value;
 use tempfile::TempDir;
@@ -59,6 +59,7 @@ async fn sm_chat_returns_reply_and_cost() {
 
     let resp = coordinator_chat(
         State(state),
+        HeaderMap::new(),
         Json(CoordinatorChatRequest {
             message: "plan the migration".into(),
             history: Vec::new(),
@@ -88,6 +89,7 @@ async fn sm_chat_degraded_is_503() {
 
     let err = coordinator_chat(
         State(state),
+        HeaderMap::new(),
         Json(CoordinatorChatRequest {
             message: "anything".into(),
             history: Vec::new(),
@@ -124,6 +126,7 @@ async fn disabled_sm_falls_back_to_legacy_503() {
 
     let err = coordinator_chat(
         State(state),
+        HeaderMap::new(),
         Json(CoordinatorChatRequest {
             message: "what is happening?".into(),
             history: Vec::new(),
@@ -155,6 +158,7 @@ async fn coordinator_chat_action_path_returns_actions_taken() {
 
     let resp = coordinator_chat(
         State(state),
+        HeaderMap::new(),
         Json(CoordinatorChatRequest {
             message: "check sessions".into(),
             history: Vec::new(),
@@ -192,6 +196,7 @@ async fn coordinator_chat_actions_absent_is_text_only() {
 
     let resp = coordinator_chat(
         State(state),
+        HeaderMap::new(),
         Json(CoordinatorChatRequest {
             message: "plain chat".into(),
             history: Vec::new(),

--- a/crates/trusty-mpm/src/daemon/error.rs
+++ b/crates/trusty-mpm/src/daemon/error.rs
@@ -77,6 +77,18 @@ pub enum DaemonError {
     #[error("service unavailable: {0}")]
     ServiceUnavailable(String),
 
+    /// The request was rejected by a security guard (e.g. the cross-origin CSRF
+    /// guard on the browser-facing, action-capable chat endpoint).
+    ///
+    /// Why: distinct from [`OverseerBlocked`](Self::OverseerBlocked) (which is a
+    /// policy decision about a *session*), this is a transport-level rejection of
+    /// the *request itself* — it never reached business logic. A dedicated variant
+    /// keeps the operator message self-describing and maps cleanly to 403.
+    /// What: carries a human-readable reason; maps to HTTP 403 Forbidden.
+    /// Test: `error_status_codes_map`, and the origin-guard handler tests.
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
     /// The request is syntactically valid but semantically un-fulfillable.
     ///
     /// Why: a precondition the daemon cannot satisfy (e.g. `POST /sessions`
@@ -101,7 +113,7 @@ impl DaemonError {
         match self {
             Self::SessionNotFound { .. } | Self::CheckpointNotFound { .. } => StatusCode::NOT_FOUND,
             Self::SessionNotActive { .. } => StatusCode::CONFLICT,
-            Self::OverseerBlocked { .. } => StatusCode::FORBIDDEN,
+            Self::OverseerBlocked { .. } | Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::InvalidRequest(_) | Self::InvalidPairCode => StatusCode::BAD_REQUEST,
             Self::TmuxUnavailable(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
@@ -177,6 +189,10 @@ mod tests {
         assert_eq!(
             DaemonError::ServiceUnavailable("x".into()).status(),
             StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            DaemonError::Forbidden("x".into()).status(),
+            StatusCode::FORBIDDEN
         );
         assert_eq!(
             DaemonError::Unprocessable("x".into()).status(),

--- a/crates/trusty-mpm/src/daemon/openapi.rs
+++ b/crates/trusty-mpm/src/daemon/openapi.rs
@@ -69,6 +69,7 @@ use utoipa::OpenApi;
         super::api::pair_status,
         super::api::pair_reset,
         super::api::doctor,
+        super::api::web_chat_page,
     ),
     components(schemas(
         super::api::HealthResponse,


### PR DESCRIPTION
## What this adds

A **thin Web control surface** for trusty-mpm — Phase-4 of the chat-core rollout (DOC-20 §6 Phase 2 "Web adapter"; ONB-3 control surfaces, DOC-18). A single static browser chat page lets an operator drive **managed sessions** through the **existing** action-capable chat endpoint.

## The route

- `GET /web` → serves a self-contained HTML+JS chat page (no external assets, no build step).

The page is a true **client** of the chat-core nucleus: it `POST`s to the **existing** `POST /api/v1/sessions/chat` with `actions: true`, renders the SM `reply`, surfaces the `actions_taken` audit trail, and continues the SM rolling context by echoing back `conv_id` on each turn.

Open it at: **`http://<daemon-host:port>/web`** (the daemon's HTTP address).

## How it reuses the action-capable endpoint

Per the spec's *"adapters are thin"* invariant, this adapter embeds **no** session logic, **no** resolver, **no** transport. It is purely a presentation/control layer over the same nucleus the Telegram/TUI adapters use — `coordinator_chat` → `route_through_action_loop` → in-process `DaemonSessionControl`. A new daemon verb wired into the nucleus is reachable from the Web surface for free.

## Zero new weight

- The page ships as a committed `include_str!` asset → **no** Svelte/Vite/pnpm build, so `SKIP_UI_BUILD` is irrelevant and a default `cargo build -p trusty-mpm` needs nothing extra.
- **No new dependency** and **no root `Cargo.toml` change** — the daemon already links `axum`/`tower`/`tower-http`.

## Files touched

| File | Change |
|------|--------|
| `crates/trusty-mpm/src/daemon/api/web_routes.rs` | **new** — `web_chat_page` handler + tests |
| `crates/trusty-mpm/src/daemon/api/web_chat.html` | **new** — embedded chat page |
| `crates/trusty-mpm/src/daemon/api.rs` | **router** — `pub mod web_routes` + one `.route("/web", get(web_chat_page))` |
| `crates/trusty-mpm/src/daemon/openapi.rs` | one `web_chat_page` paths entry |

> ⚠️ **Rebase coordination with the parallel Slack PR:** the only shared edits are in `api.rs` (one module-decl block + one `.route(...)` line, placed right after the `/api/v1/session-manager/*` routes) and `openapi.rs` (one paths entry). Both are localized, additive lines — minimal conflict surface.

## Tests

- `web_chat_page_serves_html` (pure-logic, CI-safe) — asserts the page exists, POSTs to `/api/v1/sessions/chat`, opts into `actions: true`, renders `actions_taken`, and threads `conv_id`. **Passes locally.**
- `web_route_returns_200_html` (router `oneshot`) — asserts `GET /web` returns `200 text/html`. Fails **only** on the known pre-existing local tokio runtime-drop env panic that every sibling `DaemonState` router test hits; CI on pinned 1.91 is the gate.

`cargo clippy -p trusty-mpm --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `bash scripts/check_line_cap.sh` exit 0.

## Deferred

- Richer UI (WebSocket streaming, session-list panel, focused-session state) — the broader `trusty-console` epic (#926) territory. v1 is the minimal coherent chat surface.
- Auth/rate-limiting on `/web` — the daemon binds loopback by default; hardening tracked with the other control-surface adapters.

Links: #1433 (TELUI epic / chat-core rollout), #1295 (SM Web console), #926 (trusty-console epic), spec DOC-20 (`docs/specs/chat-core.md` §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)