### PR TITLE
fix(trusty-mpm): supervise Telegram bot + unify pairing-code store (closes #1499, closes #1500)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -92,22 +92,29 @@ pub(crate) async fn run_daemon(addr: SocketAddr, tailscale: bool, mcp: bool) -> 
     // Write lock file so clients can discover us.
     trusty_mpm::daemon::lock::write_lock(&base_url, tailscale_url.as_deref());
 
+    // Auto-start the Telegram bot alongside the daemon when a bot token is
+    // configured. `resolve_token` honours `.env.local` → `.env` → the process
+    // environment, so a single dotenv file configures both the daemon and the
+    // bot. Without a token the daemon runs normally; only a warning is logged.
+    // The returned token lets the shutdown handler stop the supervised bot
+    // promptly so it never blocks (or outlives) graceful shutdown (#1499).
+    let bot_shutdown = spawn_telegram_bot(&base_url);
+
     // Clean up the lock file on shutdown for BOTH Ctrl-C (SIGINT) and SIGTERM.
     // `tm restart` stops the old daemon with `pkill`, which sends SIGTERM — if we
     // only trapped SIGINT the lock file would leak with a dead PID, and the next
     // client's `resolve_daemon_url` would fall back to the default port (often
     // occupied by an unrelated process) and report "daemon unreachable".
-    tokio::spawn(async {
+    tokio::spawn(async move {
         wait_for_shutdown_signal().await;
+        // Stop the supervised Telegram bot first so it does not log a spurious
+        // restart while the process is on its way down.
+        if let Some(token) = bot_shutdown {
+            token.cancel();
+        }
         trusty_mpm::daemon::lock::remove_lock();
         std::process::exit(0);
     });
-
-    // Auto-start the Telegram bot alongside the daemon when a bot token is
-    // configured. `resolve_token` honours `.env.local` → `.env` → the process
-    // environment, so a single dotenv file configures both the daemon and the
-    // bot. Without a token the daemon runs normally; only a warning is logged.
-    spawn_telegram_bot(&base_url);
 
     trusty_mpm::daemon::serve_http(state, listener).await
 }
@@ -145,33 +152,47 @@ async fn wait_for_shutdown_signal() {
     }
 }
 
-/// Spawn the Telegram bot as a background task when a token is configured.
+/// Spawn the SUPERVISED Telegram bot as a background task when a token is
+/// configured.
 ///
 /// Why: an operator who has set `TELEGRAM_BOT_TOKEN` expects the bot to come up
-/// with the daemon — not as a separate process they must remember to start.
+/// with the daemon — not as a separate process they must remember to start —
+/// AND to stay up. The previous bare spawn logged once and ended on the first
+/// error (a 409 long-poll conflict, a network blip), so the Telegram surface
+/// went silently dark until a full daemon restart (#1499). Wrapping the run loop
+/// in the supervisor makes a transient failure self-heal with bounded
+/// exponential backoff, makes a permanent misconfiguration back off and give up
+/// loudly instead of tight-looping, and keeps the bot shutdown-safe.
 /// What: resolves the token via `trusty_mpm::telegram::resolve_token` (which
-/// reads `.env.local`, then `.env`, then the environment). When a token is
-/// found the bot's `run` is spawned on a tokio task pointed at `base_url`; when
-/// absent a single warning is logged and the daemon continues.
+/// reads `.env.local`, then `.env`, then the environment). When a token is found
+/// the supervised bot loop ([`trusty_mpm::telegram::run_supervised`]) is spawned
+/// on a tokio task pointed at `base_url`, cancellable via the returned
+/// [`CancellationToken`] so graceful shutdown can stop it; when absent a single
+/// warning is logged and the daemon continues. Returns the token (or `None` when
+/// no bot was started) so the caller can cancel it on shutdown.
 /// Test: token resolution is covered by `trusty-mpm-telegram`'s
-/// `resolve_token_*` tests; the spawn path is exercised by running the daemon.
-fn spawn_telegram_bot(base_url: &str) {
+/// `resolve_token_*` tests; the restart/give-up/cancellation logic is covered by
+/// `telegram::supervisor::tests`; the spawn path is exercised by running the
+/// daemon.
+fn spawn_telegram_bot(base_url: &str) -> Option<tokio_util::sync::CancellationToken> {
     match trusty_mpm::telegram::resolve_token("TELEGRAM_BOT_TOKEN") {
         Some(token) => {
-            tracing::info!("TELEGRAM_BOT_TOKEN found — starting Telegram bot");
+            tracing::info!("TELEGRAM_BOT_TOKEN found — starting supervised Telegram bot");
             let url = base_url.to_string();
+            let shutdown = tokio_util::sync::CancellationToken::new();
+            let bot_shutdown = shutdown.clone();
             tokio::spawn(async move {
                 let options = trusty_mpm::telegram::BotOptions::default();
-                if let Err(e) = trusty_mpm::telegram::run(url, Some(token), false, options).await {
-                    tracing::warn!("Telegram bot exited: {e}");
-                }
+                trusty_mpm::telegram::run_supervised(url, Some(token), options, bot_shutdown).await;
             });
+            Some(shutdown)
         }
         None => {
             tracing::warn!(
                 "TELEGRAM_BOT_TOKEN not set — Telegram bot not started \
                  (set it in .env.local to enable)"
             );
+            None
         }
     }
 }

--- a/crates/trusty-mpm/src/daemon/pairing_store.rs
+++ b/crates/trusty-mpm/src/daemon/pairing_store.rs
@@ -11,11 +11,26 @@
 //! through save / load / clear against a temp directory.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 /// File name of the pairing record under the framework root.
 const PAIRING_FILE: &str = "pairing.json";
+
+/// File name of the *pending* (not-yet-confirmed) pairing code.
+///
+/// Why: the live pairing CODE used to live only in the daemon's in-memory
+/// `pair_code` mutex (see #1500). That made the mint surface (`tm telegram pair`
+/// → `POST /pair/request`) and the confirm surface (the bot's `/pair <code>`)
+/// agree ONLY when both happened to hit the very same daemon process. A second
+/// daemon instance (e.g. the silent ephemeral-port duplicate from #1499) holds a
+/// DIFFERENT empty mutex, so a code minted on one is rejected as "invalid" on the
+/// other — which is exactly the symptom operators worked around by pre-seeding
+/// `pairing.json`. Persisting the pending code to a single canonical file under
+/// the framework root makes it a shared source of truth that survives a restart
+/// and is visible to every surface rooted at the same `~/.trusty-mpm`.
+const PENDING_PAIR_FILE: &str = "pending_pair.json";
 
 /// The persisted Telegram-pairing record.
 ///
@@ -108,6 +123,128 @@ pub fn clear(root: &Path) -> std::io::Result<()> {
     }
 }
 
+/// A pending, not-yet-confirmed pairing code persisted to disk.
+///
+/// Why: see [`PENDING_PAIR_FILE`] — the live code must be a shared source of
+/// truth so any daemon instance (or `tm telegram` surface) rooted at the same
+/// framework root validates a `/pair <code>` against the SAME outstanding code,
+/// rather than each holding a private in-memory copy.
+/// What: the six-character code plus the wall-clock instant it was issued, stored
+/// as Unix epoch milliseconds so TTL math is portable across processes (an
+/// in-memory `std::time::Instant` is not comparable across processes).
+/// Test: `pending_round_trips`, `pending_expiry_uses_issued_at`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingPairCode {
+    /// The outstanding one-time pairing code.
+    pub code: String,
+    /// Unix epoch milliseconds at which the code was issued.
+    pub issued_at_ms: u64,
+}
+
+impl PendingPairCode {
+    /// Build a pending code stamped with the current wall-clock time.
+    ///
+    /// Why: `POST /pair/request` mints a code and must record WHEN so a later
+    /// confirm can enforce the TTL window using a process-portable timestamp.
+    /// What: pairs `code` with the current `SystemTime` as epoch milliseconds.
+    /// Test: `pending_round_trips`.
+    pub fn new(code: String) -> Self {
+        Self {
+            code,
+            issued_at_ms: now_unix_ms(),
+        }
+    }
+
+    /// True when this code is still within `ttl` of its issue time.
+    ///
+    /// Why: confirmation must reject codes older than the TTL identically no
+    /// matter which surface reads them, so the expiry rule lives here next to
+    /// the timestamp it compares against rather than being re-derived per caller.
+    /// What: returns `true` when `now - issued_at_ms < ttl`; a clock that has
+    /// gone backwards (now < issued_at) is treated as "not expired" (saturating).
+    /// Test: `pending_expiry_uses_issued_at`.
+    pub fn is_fresh(&self, ttl: Duration) -> bool {
+        let elapsed_ms = now_unix_ms().saturating_sub(self.issued_at_ms);
+        elapsed_ms < ttl.as_millis() as u64
+    }
+}
+
+/// Current Unix time in milliseconds (saturating at the epoch on a skewed clock).
+///
+/// Why: pending-code TTL is compared across processes, so it needs a wall-clock
+/// timestamp rather than a monotonic `Instant`.
+/// What: returns `SystemTime::now()` since the Unix epoch in whole milliseconds;
+/// a pre-epoch clock yields `0`.
+/// Test: exercised by `pending_round_trips` (issued_at is non-zero).
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Resolve the pending-pair file path under the given framework root.
+///
+/// Why: tests redirect this at a temp directory; production callers pass the
+/// home-relative root so every surface agrees on one canonical location.
+/// What: joins `root/pending_pair.json`.
+/// Test: exercised by `pending_round_trips`.
+pub fn pending_path(root: &Path) -> PathBuf {
+    root.join(PENDING_PAIR_FILE)
+}
+
+/// Persist the outstanding pending pairing code under `root`.
+///
+/// Why: minting a code must make it visible to every confirm surface rooted at
+/// the same framework root, not just the in-memory state of the minting process.
+/// What: atomically writes `pending_pair.json` (write `.tmp`, then rename),
+/// creating `root` if needed.
+/// Test: `pending_round_trips`.
+pub fn save_pending(root: &Path, pending: &PendingPairCode) -> std::io::Result<()> {
+    std::fs::create_dir_all(root)?;
+    let path = pending_path(root);
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(pending)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// Load the outstanding pending pairing code from `root`, if present and valid.
+///
+/// Why: the confirm path reads the shared outstanding code so a code minted by a
+/// different surface (or before a restart) still validates.
+/// What: returns `Some(pending)` when the file exists and parses; `None` when it
+/// is absent or malformed (a corrupt file is logged and treated as "no code").
+/// Test: `pending_round_trips`, `load_pending_missing_is_none`.
+pub fn load_pending(root: &Path) -> Option<PendingPairCode> {
+    let path = pending_path(root);
+    let contents = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<PendingPairCode>(&contents) {
+        Ok(pending) => Some(pending),
+        Err(e) => {
+            tracing::warn!("ignoring malformed {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+/// Delete the outstanding pending pairing code under `root`.
+///
+/// Why: a code is single-use — once confirmed (or explicitly invalidated) the
+/// shared store must drop it so it can never validate twice.
+/// What: removes `pending_pair.json`; an already-absent file is success.
+/// Test: `clear_pending_removes_file`.
+pub fn clear_pending(root: &Path) -> std::io::Result<()> {
+    let path = pending_path(root);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,5 +297,57 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         std::fs::write(pairing_path(dir.path()), "{ not json").expect("write garbage");
         assert!(load(dir.path()).is_none());
+    }
+
+    #[test]
+    fn pending_round_trips() {
+        // A minted code persists to a canonical path and reads back identically,
+        // with a non-zero issue timestamp — the basis for cross-process sharing.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let pending = PendingPairCode::new("ABC123".to_string());
+        assert!(pending.issued_at_ms > 0);
+        save_pending(dir.path(), &pending).expect("save_pending succeeds");
+        let loaded = load_pending(dir.path()).expect("pending loads");
+        assert_eq!(loaded, pending);
+    }
+
+    #[test]
+    fn load_pending_missing_is_none() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        assert!(load_pending(dir.path()).is_none());
+    }
+
+    #[test]
+    fn clear_pending_removes_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        save_pending(dir.path(), &PendingPairCode::new("XYZ999".into())).expect("save");
+        assert!(load_pending(dir.path()).is_some());
+        clear_pending(dir.path()).expect("clear succeeds");
+        assert!(load_pending(dir.path()).is_none());
+        // Clearing an already-absent file is not an error.
+        clear_pending(dir.path()).expect("idempotent clear");
+    }
+
+    #[test]
+    fn pending_expiry_uses_issued_at() {
+        // A code issued 10 minutes ago is stale under a 5-minute TTL; a code
+        // issued "now" is fresh. Expiry is derived from the persisted timestamp
+        // so every surface agrees regardless of process-local clocks.
+        let ttl = Duration::from_secs(300);
+        let fresh = PendingPairCode::new("FRESH1".into());
+        assert!(fresh.is_fresh(ttl));
+
+        let stale = PendingPairCode {
+            code: "STALE1".into(),
+            issued_at_ms: now_unix_ms().saturating_sub(600_000),
+        };
+        assert!(!stale.is_fresh(ttl));
+    }
+
+    #[test]
+    fn load_pending_malformed_is_none() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(pending_path(dir.path()), "{ not json").expect("write garbage");
+        assert!(load_pending(dir.path()).is_none());
     }
 }

--- a/crates/trusty-mpm/src/daemon/pairing_store.rs
+++ b/crates/trusty-mpm/src/daemon/pairing_store.rs
@@ -165,7 +165,7 @@ impl PendingPairCode {
     /// Test: `pending_expiry_uses_issued_at`.
     pub fn is_fresh(&self, ttl: Duration) -> bool {
         let elapsed_ms = now_unix_ms().saturating_sub(self.issued_at_ms);
-        elapsed_ms < ttl.as_millis() as u64
+        elapsed_ms < u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX)
     }
 }
 
@@ -179,7 +179,7 @@ impl PendingPairCode {
 fn now_unix_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
         .unwrap_or(0)
 }
 

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -24,10 +24,17 @@ impl DaemonState {
     ///
     /// Why: `tm pair` asks the daemon for a short code the operator types into
     /// the Telegram bot; the daemon must remember it (and its issue time) so a
-    /// later `/pair` confirm can validate it within the TTL window.
+    /// later `/pair` confirm can validate it within the TTL window. The code is
+    /// ALSO persisted to a canonical file under the framework root so the confirm
+    /// surface validates against a single shared source of truth — without it a
+    /// code minted on one daemon instance was rejected as "invalid" when confirmed
+    /// against another instance's empty in-memory store (#1500).
     /// What: derives a six-character uppercase alphanumeric code from a fresh
-    /// UUID, stores it with the current instant, and returns the code.
-    /// Test: `pairing_round_trip`.
+    /// UUID, stores it both in memory (`pair_code`) and on disk
+    /// (`<framework_root>/pending_pair.json`), and returns the code. A failed disk
+    /// write is logged, not fatal — the in-memory copy still works for the
+    /// same-process case.
+    /// Test: `pairing_round_trip`, `pairing_code_persists_to_disk`.
     pub fn generate_pair_code(&self) -> String {
         let code: String = uuid::Uuid::new_v4()
             .simple()
@@ -38,6 +45,10 @@ impl DaemonState {
             .collect::<String>()
             .to_uppercase();
         *self.pair_code.lock() = Some((code.clone(), std::time::Instant::now()));
+        let pending = crate::daemon::pairing_store::PendingPairCode::new(code.clone());
+        if let Err(e) = crate::daemon::pairing_store::save_pending(&self.framework_root, &pending) {
+            tracing::warn!("failed to persist pending Telegram pairing code: {e}");
+        }
         code
     }
 
@@ -45,25 +56,42 @@ impl DaemonState {
     ///
     /// Why: the bot's `/pair <code>` flow validates the operator's code and, on
     /// success, binds the chat so push alerts have a destination — and the
-    /// binding must survive a daemon restart.
+    /// binding must survive a daemon restart. The code is validated against the
+    /// SHARED on-disk store (falling back to the in-memory copy) so a code minted
+    /// by any surface rooted at the same framework root is accepted, eliminating
+    /// the cross-instance mismatch that forced the `pairing.json` pre-seed
+    /// workaround (#1500).
     /// What: returns `true` and stores `chat_id` (in memory *and* persisted to
     /// `~/.trusty-mpm/pairing.json`) when `code` matches the outstanding code
-    /// and it is within [`PAIR_CODE_TTL`]; clears the code either way (a used or
-    /// expired code never validates twice). A failed disk write is logged, not
-    /// fatal — the in-memory pairing still takes effect.
-    /// Test: `pairing_round_trip`, `pairing_persists_to_disk`.
+    /// (on disk OR in memory) and it is within [`PAIR_CODE_TTL`]; clears the
+    /// pending code from BOTH stores either way (a used or expired code never
+    /// validates twice). A failed disk write is logged, not fatal.
+    /// Test: `pairing_round_trip`, `pairing_persists_to_disk`,
+    /// `pairing_confirms_shared_disk_code`.
     pub fn confirm_pair_code(&self, code: &str, chat_id: i64) -> bool {
+        use crate::daemon::pairing_store;
         let mut guard = self.pair_code.lock();
-        let valid = matches!(
+        // Prefer the shared on-disk pending code (the cross-instance source of
+        // truth); fall back to the in-memory copy for the same-process case when
+        // no disk write has happened (or the file is unreadable).
+        let disk_valid = pairing_store::load_pending(&self.framework_root)
+            .is_some_and(|p| p.code == code && p.is_fresh(PAIR_CODE_TTL));
+        let mem_valid = matches!(
             guard.as_ref(),
             Some((stored, issued))
                 if stored == code && issued.elapsed() < PAIR_CODE_TTL
         );
+        let valid = disk_valid || mem_valid;
+        // A confirm attempt always consumes the outstanding code from both
+        // stores so neither a used nor an expired code can validate twice.
         *guard = None;
+        if let Err(e) = pairing_store::clear_pending(&self.framework_root) {
+            tracing::warn!("failed to clear pending Telegram pairing code: {e}");
+        }
         if valid {
             *self.paired_chat_id.lock() = Some(chat_id);
-            let record = crate::daemon::pairing_store::PairingRecord::new(chat_id);
-            if let Err(e) = crate::daemon::pairing_store::save(&self.framework_root, &record) {
+            let record = pairing_store::PairingRecord::new(chat_id);
+            if let Err(e) = pairing_store::save(&self.framework_root, &record) {
                 tracing::warn!("failed to persist Telegram pairing: {e}");
             }
         }
@@ -73,14 +101,21 @@ impl DaemonState {
     /// Clear the Telegram pairing, in memory and on disk.
     ///
     /// Why: `POST /pair/reset` (or any explicit unpair) must drop the binding so
-    /// a restart does not resurrect it from `pairing.json`.
-    /// What: sets `paired_chat_id` to `None` and deletes the persisted record;
-    /// a failed delete is logged, not fatal.
+    /// a restart does not resurrect it from `pairing.json`. Any outstanding
+    /// pending CODE is dropped too so a reset truly returns the daemon to an
+    /// unpaired, no-code state.
+    /// What: sets `paired_chat_id` to `None`, clears the in-memory `pair_code`,
+    /// and deletes both the persisted record and the shared pending code; a
+    /// failed delete is logged, not fatal.
     /// Test: `pairing_reset_clears_disk`.
     pub fn clear_pairing(&self) {
         *self.paired_chat_id.lock() = None;
+        *self.pair_code.lock() = None;
         if let Err(e) = crate::daemon::pairing_store::clear(&self.framework_root) {
             tracing::warn!("failed to delete persisted Telegram pairing: {e}");
+        }
+        if let Err(e) = crate::daemon::pairing_store::clear_pending(&self.framework_root) {
+            tracing::warn!("failed to delete pending Telegram pairing code: {e}");
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/state/tests.rs
+++ b/crates/trusty-mpm/src/daemon/state/tests.rs
@@ -441,3 +441,42 @@ fn pairing_reset_clears_disk() {
     assert_eq!(state.paired_chat_id(), None);
     assert!(crate::daemon::pairing_store::load(&root).is_none());
 }
+
+#[test]
+fn pairing_code_persists_to_disk() {
+    // Minting a code writes the shared pending_pair.json, the single source of
+    // truth that every confirm surface validates against (#1500).
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path().to_path_buf();
+    let state = DaemonState::with_root(root.clone());
+    let code = state.generate_pair_code();
+    let pending = crate::daemon::pairing_store::load_pending(&root).expect("pending code on disk");
+    assert_eq!(pending.code, code);
+}
+
+#[test]
+fn pairing_confirms_shared_disk_code() {
+    // THE #1500 REGRESSION GUARD: a code minted on one DaemonState instance is
+    // confirmed on a DIFFERENT instance rooted at the same framework root, even
+    // though the second instance never held the code in its in-memory mutex.
+    // Before the shared on-disk pending store this returned false ("invalid
+    // code") and operators had to pre-seed pairing.json.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path().to_path_buf();
+
+    let minting = DaemonState::with_root(root.clone());
+    let code = minting.generate_pair_code();
+
+    // A second, independent daemon instance (e.g. the ephemeral-port duplicate
+    // from #1499) shares the framework root but has an empty in-memory pair_code.
+    let confirming = DaemonState::with_root(root.clone());
+    assert!(
+        confirming.confirm_pair_code(&code, 31415),
+        "code minted on a sibling instance must validate via the shared store"
+    );
+    assert_eq!(confirming.paired_chat_id(), Some(31415));
+
+    // The shared pending code was consumed: a third instance cannot replay it.
+    let replay = DaemonState::with_root(root);
+    assert!(!replay.confirm_pair_code(&code, 999));
+}

--- a/crates/trusty-mpm/src/telegram/mod.rs
+++ b/crates/trusty-mpm/src/telegram/mod.rs
@@ -17,6 +17,7 @@
 pub mod alerts;
 pub mod commands;
 pub mod formatter;
+pub mod supervisor;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -264,6 +265,48 @@ pub async fn run(
 
     shutdown.cancel();
     Ok(())
+}
+
+/// Run the Telegram bot under restart-on-exit supervision (#1499).
+///
+/// Why: the daemon auto-spawns the bot in the background; a bare spawn that logs
+/// once and ends on the first error (a 409 long-poll conflict, a network blip)
+/// left the Telegram surface silently dead until a full daemon restart. This
+/// wraps [`run`] in [`supervisor::supervise`] so a transient error self-heals
+/// with bounded exponential backoff, a permanent misconfiguration backs off and
+/// gives up loudly instead of tight-looping, and a daemon shutdown stops the bot
+/// promptly without blocking graceful shutdown.
+/// What: loops [`run`] via the supervisor, classifying each exit — `Ok(())` is a
+/// graceful stop, an error is classified by [`supervisor::classify_error`] into
+/// transient vs permanent. The `token`, `options`, and `url` are cloned per
+/// attempt so each restart gets a fresh bot. Returns when the bot stops
+/// gracefully, the permanent-failure budget is exhausted, or `shutdown` fires.
+/// Test: the restart/give-up/cancellation logic is covered by `supervisor::tests`
+/// against an injected factory; this thin adapter is exercised by running the
+/// daemon.
+pub async fn run_supervised(
+    url: String,
+    token: Option<String>,
+    options: BotOptions,
+    shutdown: CancellationToken,
+) {
+    let policy = supervisor::BackoffPolicy::default();
+    let factory = || {
+        let url = url.clone();
+        let token = token.clone();
+        let options = options.clone();
+        async move {
+            match run(url, token, false, options).await {
+                Ok(()) => supervisor::BotExit::Graceful,
+                Err(e) => {
+                    let exit = supervisor::classify_error(&e);
+                    tracing::warn!("telegram bot run returned an error: {e:#}");
+                    exit
+                }
+            }
+        }
+    };
+    supervisor::supervise(factory, policy, shutdown).await;
 }
 
 /// teloxide message handler: authorize, parse, execute, render, reply.

--- a/crates/trusty-mpm/src/telegram/supervisor.rs
+++ b/crates/trusty-mpm/src/telegram/supervisor.rs
@@ -1,0 +1,242 @@
+//! Restart-on-exit supervision for the Telegram bot task (#1499).
+//!
+//! Why: the daemon used to launch the bot with a bare `tokio::spawn` whose body
+//! logged once and ENDED on any error. A long-poll `getUpdates` 409 Conflict (a
+//! duplicate consumer), a transient network blip, or any other error therefore
+//! killed the bot for the rest of the daemon's life with no recovery — the
+//! Telegram surface went dark while the daemon looked healthy, which is exactly
+//! the silent-death symptom in #1499. This module wraps the bot's run loop in a
+//! supervisor that restarts it with bounded exponential backoff, logs every
+//! restart and every give-up, refuses to tight-loop on a permanent
+//! misconfiguration (e.g. a missing/invalid token), and stops cleanly the moment
+//! the daemon signals graceful shutdown.
+//! What: [`supervise`] drives a caller-supplied async factory: it runs one bot
+//! attempt, classifies the outcome ([`BotExit`]), and either restarts after a
+//! backoff or gives up. [`BackoffPolicy`] computes the delay schedule; both are
+//! unit-tested with an injected factory so no real Telegram network is involved.
+//! Test: `supervisor::tests` — restart-after-transient, exponential growth +
+//! cap, give-up after the permanent-failure budget, and cancellation-safety.
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+/// How a single bot attempt ended, telling the supervisor how to react.
+///
+/// Why: not every exit deserves the same response. A transient error (conflict,
+/// network) should restart quickly; a permanent misconfiguration (no token)
+/// should back off hard and eventually give up rather than hammer the same
+/// doomed startup every few hundred milliseconds.
+/// What: the three outcomes the supervisor distinguishes.
+/// Test: `classify_*` and the restart/give-up tests assert per-variant behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BotExit {
+    /// The bot's dispatcher returned normally (graceful stop). Do not restart.
+    Graceful,
+    /// A transient failure (e.g. a 409 long-poll conflict, a network error).
+    /// Restart after a short, growing backoff — this is expected to self-heal.
+    Transient,
+    /// A permanent misconfiguration (e.g. missing/invalid token). Restarting at
+    /// the same cadence would tight-loop forever, so the supervisor backs off to
+    /// the cap and gives up after a small budget of attempts.
+    Permanent,
+}
+
+/// Classify an `anyhow::Error` from the bot's run loop into a [`BotExit`].
+///
+/// Why: the supervisor's reaction hinges on whether a failure is worth retrying.
+/// A missing token (the bot's `run` returns a "TELEGRAM_BOT_TOKEN is required"
+/// error) is permanent — retrying cannot help until the operator fixes config —
+/// whereas a `getUpdates` conflict or a socket error is transient and expected
+/// to clear on its own.
+/// What: returns [`BotExit::Permanent`] when the error message names a
+/// missing/invalid token (the only configuration error `run` raises before it
+/// starts polling); every other error is [`BotExit::Transient`].
+/// Test: `classify_missing_token_is_permanent`, `classify_other_is_transient`.
+pub fn classify_error(err: &anyhow::Error) -> BotExit {
+    let msg = err.to_string().to_ascii_lowercase();
+    let permanent = msg.contains("token is required")
+        || msg.contains("invalid token")
+        || msg.contains("not a valid bot token")
+        || msg.contains("unauthorized");
+    if permanent {
+        BotExit::Permanent
+    } else {
+        BotExit::Transient
+    }
+}
+
+/// Bounded exponential-backoff schedule for bot restarts.
+///
+/// Why: restart-on-exit must not become a busy loop. A geometric schedule
+/// (base, base·factor, base·factor², … capped) self-heals a transient conflict
+/// in well under a second while a persistent fault settles to one attempt per
+/// `max` interval instead of thousands per second.
+/// What: holds the first delay, the per-step multiplier, and the ceiling, and
+/// computes the delay for a given consecutive-failure count via [`delay_for`].
+/// Test: `backoff_grows_and_caps`, `backoff_resets_to_base`.
+#[derive(Debug, Clone, Copy)]
+pub struct BackoffPolicy {
+    /// Delay before the first restart.
+    pub base: Duration,
+    /// Multiplier applied per consecutive failure.
+    pub factor: u32,
+    /// Upper bound on any single delay.
+    pub max: Duration,
+}
+
+impl Default for BackoffPolicy {
+    /// The production schedule: 500ms → 1s → 2s → … capped at 30s.
+    ///
+    /// Why: 500ms recovers a momentary `getUpdates` conflict almost immediately
+    /// (the typical case when a second consumer is shutting down) while the 30s
+    /// cap keeps a stubborn fault to two attempts per minute.
+    /// What: `base = 500ms`, `factor = 2`, `max = 30s`.
+    /// Test: `default_policy_is_bounded`.
+    fn default() -> Self {
+        Self {
+            base: Duration::from_millis(500),
+            factor: 2,
+            max: Duration::from_secs(30),
+        }
+    }
+}
+
+impl BackoffPolicy {
+    /// Delay before the restart that follows `failures` consecutive failures.
+    ///
+    /// Why: the supervisor needs a pure, testable mapping from "how many times
+    /// has it failed in a row" to "how long to wait" so the growth and cap are
+    /// verifiable without sleeping.
+    /// What: returns `base · factor^(failures-1)` saturated at `max`; a
+    /// `failures` of 0 or 1 yields `base`. Overflow saturates to `max`.
+    /// Test: `backoff_grows_and_caps`.
+    pub fn delay_for(&self, failures: u32) -> Duration {
+        let exp = failures.saturating_sub(1);
+        let mut delay = self.base;
+        for _ in 0..exp {
+            match delay.checked_mul(self.factor) {
+                Some(d) if d <= self.max => delay = d,
+                _ => return self.max,
+            }
+        }
+        delay.min(self.max)
+    }
+}
+
+/// Maximum consecutive *permanent* failures before the supervisor gives up.
+///
+/// Why: a permanent misconfiguration cannot be retried into success, but a
+/// couple of attempts cover the case where the operator is mid-edit on
+/// `.env.local`; beyond that, continuing to spawn a doomed task only spams logs.
+/// What: after this many back-to-back permanent exits the supervisor logs a
+/// clear give-up message and returns.
+/// Test: `gives_up_after_permanent_budget`.
+const MAX_PERMANENT_FAILURES: u32 = 3;
+
+/// Supervise a Telegram bot run loop, restarting it on exit with backoff.
+///
+/// Why: see the module docs — a single transient error must not permanently kill
+/// the bot, and the supervisor must remain shutdown-safe (it must stop promptly
+/// when the daemon is shutting down and never block graceful shutdown).
+/// What: repeatedly calls `factory` to produce one bot attempt, races it against
+/// `shutdown`, and reacts to its [`BotExit`]:
+/// - [`BotExit::Graceful`] → return (the bot stopped cleanly).
+/// - [`BotExit::Transient`] → log and restart after [`BackoffPolicy::delay_for`],
+///   resetting the permanent-failure counter.
+/// - [`BotExit::Permanent`] → log clearly and restart after the *capped* delay;
+///   after [`MAX_PERMANENT_FAILURES`] in a row, give up and return.
+///
+/// The backoff sleep itself is cancellable, so a shutdown during a backoff window
+/// returns immediately rather than waiting out the delay.
+/// Test: `restarts_after_transient_then_succeeds`, `gives_up_after_permanent_budget`,
+/// `stops_on_cancellation` and `backoff_sleep_is_cancellable`.
+pub async fn supervise<F, Fut>(factory: F, policy: BackoffPolicy, shutdown: CancellationToken)
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = BotExit>,
+{
+    let mut transient_failures: u32 = 0;
+    let mut permanent_failures: u32 = 0;
+
+    loop {
+        if shutdown.is_cancelled() {
+            tracing::info!("telegram supervisor: shutdown requested — not restarting bot");
+            return;
+        }
+
+        // Run one attempt, but abandon it the instant shutdown is signalled so a
+        // graceful stop is never blocked by an in-flight bot dispatcher.
+        let exit = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                tracing::info!("telegram supervisor: shutdown during bot run — exiting");
+                return;
+            }
+            exit = factory() => exit,
+        };
+
+        match exit {
+            BotExit::Graceful => {
+                tracing::info!("telegram bot stopped gracefully — supervisor exiting");
+                return;
+            }
+            BotExit::Transient => {
+                permanent_failures = 0;
+                transient_failures = transient_failures.saturating_add(1);
+                let delay = policy.delay_for(transient_failures);
+                tracing::warn!(
+                    "telegram bot exited (transient, attempt {transient_failures}); \
+                     restarting in {delay:?}"
+                );
+                if !sleep_or_cancel(delay, &shutdown).await {
+                    tracing::info!("telegram supervisor: shutdown during backoff — exiting");
+                    return;
+                }
+            }
+            BotExit::Permanent => {
+                transient_failures = 0;
+                permanent_failures = permanent_failures.saturating_add(1);
+                if permanent_failures >= MAX_PERMANENT_FAILURES {
+                    tracing::error!(
+                        "telegram bot exited with a permanent error {permanent_failures} \
+                         times in a row — giving up. Fix TELEGRAM_BOT_TOKEN (and bot config) \
+                         then restart the daemon to re-enable the Telegram surface."
+                    );
+                    return;
+                }
+                // Back off to the cap on a permanent fault so we never tight-loop.
+                let delay = policy.max;
+                tracing::error!(
+                    "telegram bot exited with a permanent error (attempt {permanent_failures}/\
+                     {MAX_PERMANENT_FAILURES}); retrying in {delay:?} in case config was just \
+                     updated"
+                );
+                if !sleep_or_cancel(delay, &shutdown).await {
+                    tracing::info!("telegram supervisor: shutdown during backoff — exiting");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Sleep for `delay`, returning early if `shutdown` fires.
+///
+/// Why: a backoff window must not delay graceful shutdown — a 30s cap would
+/// otherwise hold the daemon open for up to 30s after SIGTERM.
+/// What: races a timer against the cancellation token; returns `true` when the
+/// full delay elapsed (caller should proceed to restart) and `false` when
+/// shutdown interrupted it (caller should exit).
+/// Test: `backoff_sleep_is_cancellable`.
+async fn sleep_or_cancel(delay: Duration, shutdown: &CancellationToken) -> bool {
+    tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => false,
+        _ = tokio::time::sleep(delay) => true,
+    }
+}
+
+#[cfg(test)]
+#[path = "supervisor_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/telegram/supervisor.rs
+++ b/crates/trusty-mpm/src/telegram/supervisor.rs
@@ -72,9 +72,11 @@ pub fn classify_error(err: &anyhow::Error) -> BotExit {
 /// (base, base·factor, base·factor², … capped) self-heals a transient conflict
 /// in well under a second while a persistent fault settles to one attempt per
 /// `max` interval instead of thousands per second.
-/// What: holds the first delay, the per-step multiplier, and the ceiling, and
-/// computes the delay for a given consecutive-failure count via [`delay_for`].
-/// Test: `backoff_grows_and_caps`, `backoff_resets_to_base`.
+/// What: holds the first delay, the per-step multiplier, the ceiling, and the
+/// minimum run duration that counts as "healthy" (after which the consecutive
+/// transient-failure counter resets so backoff starts fresh). Computes the delay
+/// for a given consecutive-failure count via [`delay_for`].
+/// Test: `backoff_grows_and_caps`, `healthy_run_resets_transient_backoff`.
 #[derive(Debug, Clone, Copy)]
 pub struct BackoffPolicy {
     /// Delay before the first restart.
@@ -83,21 +85,33 @@ pub struct BackoffPolicy {
     pub factor: u32,
     /// Upper bound on any single delay.
     pub max: Duration,
+    /// Minimum run duration that counts as a "healthy" run. When a transient
+    /// exit follows a run that lasted at least this long, the supervisor resets
+    /// the consecutive-transient-failure counter so the next backoff starts at
+    /// `base` instead of staying pinned near `max`. Injectable so tests can use a
+    /// millisecond-scale threshold rather than sleeping for the production value.
+    pub healthy_run: Duration,
 }
 
 impl Default for BackoffPolicy {
-    /// The production schedule: 500ms → 1s → 2s → … capped at 30s.
+    /// The production schedule: 500ms → 1s → 2s → … capped at 30s, with a 60s
+    /// healthy-run threshold.
     ///
     /// Why: 500ms recovers a momentary `getUpdates` conflict almost immediately
     /// (the typical case when a second consumer is shutting down) while the 30s
-    /// cap keeps a stubborn fault to two attempts per minute.
-    /// What: `base = 500ms`, `factor = 2`, `max = 30s`.
+    /// cap keeps a stubborn fault to two attempts per minute. The 60s
+    /// healthy-run threshold (twice the backoff cap) means a bot that polled
+    /// successfully for at least a minute before exiting transiently is treated
+    /// as recovered: its next failure restarts the backoff at `base` rather than
+    /// inheriting an escalated exponent from long-past early failures.
+    /// What: `base = 500ms`, `factor = 2`, `max = 30s`, `healthy_run = 60s`.
     /// Test: `default_policy_is_bounded`.
     fn default() -> Self {
         Self {
             base: Duration::from_millis(500),
             factor: 2,
             max: Duration::from_secs(30),
+            healthy_run: Duration::from_secs(60),
         }
     }
 }
@@ -122,6 +136,27 @@ impl BackoffPolicy {
         }
         delay.min(self.max)
     }
+
+    /// The consecutive-transient-failure count after one more transient exit,
+    /// given how long the run that just exited lasted.
+    ///
+    /// Why: the backoff exponent must escalate while failures are rapid but must
+    /// NOT stay pinned near the cap for the daemon's whole life after a burst of
+    /// early flapping once the bot has recovered. Factoring the reset decision out
+    /// of the async [`supervise`] loop makes it pure and directly unit-testable
+    /// without sleeping or driving the tokio runtime.
+    /// What: returns `prior + 1` normally, but first resets `prior` to 0 when the
+    /// just-ended run lasted at least `healthy_run` (so the result is 1, mapping
+    /// `delay_for` back to `base`).
+    /// Test: `healthy_run_resets_transient_count`.
+    pub fn next_transient_count(&self, prior: u32, run_duration: Duration) -> u32 {
+        let effective_prior = if run_duration >= self.healthy_run {
+            0
+        } else {
+            prior
+        };
+        effective_prior.saturating_add(1)
+    }
 }
 
 /// Maximum consecutive *permanent* failures before the supervisor gives up.
@@ -139,18 +174,23 @@ const MAX_PERMANENT_FAILURES: u32 = 3;
 /// Why: see the module docs — a single transient error must not permanently kill
 /// the bot, and the supervisor must remain shutdown-safe (it must stop promptly
 /// when the daemon is shutting down and never block graceful shutdown).
-/// What: repeatedly calls `factory` to produce one bot attempt, races it against
-/// `shutdown`, and reacts to its [`BotExit`]:
+/// What: repeatedly calls `factory` to produce one bot attempt, times how long it
+/// ran, races it against `shutdown`, and reacts to its [`BotExit`]:
 /// - [`BotExit::Graceful`] → return (the bot stopped cleanly).
 /// - [`BotExit::Transient`] → log and restart after [`BackoffPolicy::delay_for`],
-///   resetting the permanent-failure counter.
+///   resetting the permanent-failure counter. If the run that just exited lasted
+///   at least [`BackoffPolicy::healthy_run`], the consecutive-transient counter is
+///   first reset to 0 so the bot's recovery is honoured and the next backoff
+///   starts at `base` rather than staying pinned near the cap for the daemon's
+///   whole life after an early flap.
 /// - [`BotExit::Permanent`] → log clearly and restart after the *capped* delay;
 ///   after [`MAX_PERMANENT_FAILURES`] in a row, give up and return.
 ///
 /// The backoff sleep itself is cancellable, so a shutdown during a backoff window
 /// returns immediately rather than waiting out the delay.
 /// Test: `restarts_after_transient_then_succeeds`, `gives_up_after_permanent_budget`,
-/// `stops_on_cancellation` and `backoff_sleep_is_cancellable`.
+/// `stops_on_cancellation`, `backoff_sleep_is_cancellable`, and
+/// `healthy_run_resets_transient_backoff`.
 pub async fn supervise<F, Fut>(factory: F, policy: BackoffPolicy, shutdown: CancellationToken)
 where
     F: Fn() -> Fut,
@@ -165,6 +205,10 @@ where
             return;
         }
 
+        // Time the attempt so a transient exit that follows a healthy-duration run
+        // can reset the backoff (see the `BotExit::Transient` arm below).
+        let started = tokio::time::Instant::now();
+
         // Run one attempt, but abandon it the instant shutdown is signalled so a
         // graceful stop is never blocked by an in-flight bot dispatcher.
         let exit = tokio::select! {
@@ -176,6 +220,8 @@ where
             exit = factory() => exit,
         };
 
+        let run_duration = started.elapsed();
+
         match exit {
             BotExit::Graceful => {
                 tracing::info!("telegram bot stopped gracefully — supervisor exiting");
@@ -183,7 +229,18 @@ where
             }
             BotExit::Transient => {
                 permanent_failures = 0;
-                transient_failures = transient_failures.saturating_add(1);
+                // A run that lasted at least `healthy_run` proves the bot recovered
+                // and polled successfully for a meaningful stretch; the helper folds
+                // that into a counter reset so backoff restarts at `base` instead of
+                // remaining pinned near the cap after early flapping.
+                let prior = transient_failures;
+                transient_failures = policy.next_transient_count(prior, run_duration);
+                if prior > 0 && transient_failures == 1 {
+                    tracing::info!(
+                        "telegram bot ran healthily for {run_duration:?} before exiting \
+                         transiently — resetting backoff to base"
+                    );
+                }
                 let delay = policy.delay_for(transient_failures);
                 tracing::warn!(
                     "telegram bot exited (transient, attempt {transient_failures}); \

--- a/crates/trusty-mpm/src/telegram/supervisor_tests.rs
+++ b/crates/trusty-mpm/src/telegram/supervisor_tests.rs
@@ -36,6 +36,7 @@ fn backoff_grows_and_caps() {
         base: Duration::from_millis(500),
         factor: 2,
         max: Duration::from_secs(30),
+        healthy_run: Duration::from_secs(60),
     };
     // 0 and 1 failures both wait the base delay.
     assert_eq!(policy.delay_for(0), Duration::from_millis(500));
@@ -54,17 +55,137 @@ fn default_policy_is_bounded() {
     let p = BackoffPolicy::default();
     assert_eq!(p.base, Duration::from_millis(500));
     assert_eq!(p.max, Duration::from_secs(30));
+    assert_eq!(p.healthy_run, Duration::from_secs(60));
     // No computed delay ever exceeds the cap, even for an absurd failure count.
     assert!(p.delay_for(u32::MAX) <= p.max);
 }
 
+#[test]
+fn healthy_run_resets_transient_count() {
+    // The pure reset rule (#1499 follow-up): many short transient failures must
+    // escalate the consecutive-failure count (driving backoff up the geometric
+    // schedule), but a transient exit that follows a healthy-duration run must
+    // reset the count to 1 so the very next backoff is back at `base`.
+    let policy = BackoffPolicy {
+        base: Duration::from_millis(1),
+        factor: 2,
+        max: Duration::from_millis(8),
+        healthy_run: Duration::from_millis(50),
+    };
+    let short = Duration::from_millis(0);
+    let healthy = Duration::from_millis(50);
+
+    // Short runs escalate: 0 → 1 → 2 → … so the backoff exponent climbs.
+    assert_eq!(policy.next_transient_count(0, short), 1);
+    assert_eq!(policy.next_transient_count(1, short), 2);
+    assert_eq!(policy.next_transient_count(7, short), 8);
+    // Escalation pins the backoff at the cap once the exponent is high enough.
+    assert_eq!(policy.delay_for(8), policy.max);
+
+    // A transient exit after a healthy run resets the count to 1, regardless of
+    // how high the prior count had climbed …
+    assert_eq!(policy.next_transient_count(8, healthy), 1);
+    assert_eq!(policy.next_transient_count(u32::MAX, healthy), 1);
+    // … and a count of 1 maps backoff back to the floor (`base`), proving the
+    // delay is no longer pinned at the cap.
+    assert_eq!(policy.delay_for(1), policy.base);
+
+    // A run exactly at the threshold counts as healthy (>=, not >).
+    assert_eq!(
+        policy.next_transient_count(5, policy.healthy_run),
+        1,
+        "a run lasting exactly healthy_run must reset the counter"
+    );
+    // Just-under-threshold does NOT reset — it keeps escalating.
+    assert_eq!(
+        policy.next_transient_count(5, policy.healthy_run - Duration::from_millis(1)),
+        6,
+        "a sub-threshold run must keep the backoff escalating"
+    );
+}
+
+#[tokio::test]
+async fn healthy_run_resets_transient_backoff() {
+    // End-to-end proof through `supervise`: the bot flaps transiently several
+    // times with near-instant runs (escalating backoff), then runs "healthily"
+    // (longer than `healthy_run`) before exiting transiently once more, then
+    // stops gracefully. We assert on the OBSERVED gap between the start of the
+    // post-healthy restart and its predecessor: after the reset it must be ~base,
+    // not the escalated/capped delay the prior flaps had built up to.
+    let policy = BackoffPolicy {
+        base: Duration::from_millis(2),
+        factor: 4,
+        // A high cap so escalated delays are clearly distinguishable from `base`.
+        max: Duration::from_millis(400),
+        // Small enough that a deliberately delayed run trips it without a slow test.
+        healthy_run: Duration::from_millis(20),
+    };
+
+    // attempt index → exit. Indices 0,1,2 flap fast (escalating: delay_for(1)=2ms,
+    // delay_for(2)=8ms, delay_for(3)=32ms). Index 3 runs healthily then exits
+    // transiently (must reset → next delay back to base=2ms). Index 4 is graceful.
+    let starts: Arc<std::sync::Mutex<Vec<tokio::time::Instant>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let a = Arc::clone(&attempts);
+    let s = Arc::clone(&starts);
+    let healthy_for = policy.healthy_run;
+    let factory = move || {
+        let a = Arc::clone(&a);
+        let s = Arc::clone(&s);
+        async move {
+            let n = a.fetch_add(1, Ordering::SeqCst);
+            s.lock().unwrap().push(tokio::time::Instant::now());
+            if n == 3 {
+                // Run long enough to count as healthy, then exit transiently.
+                tokio::time::sleep(healthy_for + Duration::from_millis(5)).await;
+                BotExit::Transient
+            } else if n < 3 {
+                BotExit::Transient
+            } else {
+                BotExit::Graceful
+            }
+        }
+    };
+
+    supervise(factory, policy, CancellationToken::new()).await;
+    assert_eq!(attempts.load(Ordering::SeqCst), 5);
+
+    let starts = starts.lock().unwrap();
+    assert_eq!(starts.len(), 5);
+
+    // Gap before attempt 3 (the healthy run's restart) reflects the ESCALATED
+    // backoff after three flaps: delay_for(3) = base*factor^2 = 2ms*16 = 32ms.
+    let escalated_gap = starts[3].duration_since(starts[2]);
+    assert!(
+        escalated_gap >= Duration::from_millis(25),
+        "pre-reset backoff should be escalated (>=~32ms), saw {escalated_gap:?}"
+    );
+
+    // Gap before attempt 4 = (healthy run duration ~25ms) + (post-reset backoff).
+    // The backoff component must be back at base (~2ms), NOT the prior escalated
+    // delay_for(4)=128ms. We subtract the known healthy run to isolate the backoff
+    // and assert it is small — proving the counter reset to the floor.
+    let post_healthy_total = starts[4].duration_since(starts[3]);
+    let backoff_component = post_healthy_total.saturating_sub(healthy_for);
+    assert!(
+        backoff_component < Duration::from_millis(20),
+        "post-healthy backoff must reset to ~base, isolated backoff was {backoff_component:?} \
+         (total {post_healthy_total:?})"
+    );
+}
+
 /// A fast policy with millisecond-scale delays so real backoff sleeps in the
-/// restart/give-up tests complete near-instantly.
+/// restart/give-up tests complete near-instantly. `healthy_run` is set well above
+/// the near-instant run durations these tests produce, so the healthy-run reset
+/// never fires unless a test deliberately delays its run (see
+/// `healthy_run_resets_transient_backoff`).
 fn fast_policy() -> BackoffPolicy {
     BackoffPolicy {
         base: Duration::from_millis(1),
         factor: 2,
         max: Duration::from_millis(8),
+        healthy_run: Duration::from_secs(60),
     }
 }
 
@@ -190,6 +311,7 @@ async fn backoff_sleep_is_cancellable() {
         base: Duration::from_secs(3600),
         factor: 2,
         max: Duration::from_secs(3600),
+        healthy_run: Duration::from_secs(60),
     };
 
     let factory = move || {

--- a/crates/trusty-mpm/src/telegram/supervisor_tests.rs
+++ b/crates/trusty-mpm/src/telegram/supervisor_tests.rs
@@ -1,0 +1,215 @@
+//! Unit tests for the Telegram bot supervisor (#1499).
+//!
+//! Why: lives in a recognized `_tests.rs` sibling so `supervisor.rs` stays well
+//! under the 500-SLOC production cap while sharing its private items via
+//! `use super::*`. The tests inject a counting factory so restart, backoff, and
+//! give-up behaviour are verified deterministically with no real Telegram
+//! network. Backoff delays use a millisecond-scale `fast_policy` so the real
+//! sleeps complete near-instantly (no `tokio` `test-util` paused-time feature
+//! is required), and the cancellation test fires shutdown before its long
+//! backoff can elapse.
+//! Test: this *is* the test module.
+
+use super::*;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn classify_missing_token_is_permanent() {
+    let err = anyhow::anyhow!("TELEGRAM_BOT_TOKEN is required (or pass --check)");
+    assert_eq!(classify_error(&err), BotExit::Permanent);
+    let invalid = anyhow::anyhow!("Not a valid bot token");
+    assert_eq!(classify_error(&invalid), BotExit::Permanent);
+}
+
+#[test]
+fn classify_other_is_transient() {
+    let conflict = anyhow::anyhow!("terminated by other getUpdates request (409 Conflict)");
+    assert_eq!(classify_error(&conflict), BotExit::Transient);
+    let network = anyhow::anyhow!("error sending request: connection reset");
+    assert_eq!(classify_error(&network), BotExit::Transient);
+}
+
+#[test]
+fn backoff_grows_and_caps() {
+    let policy = BackoffPolicy {
+        base: Duration::from_millis(500),
+        factor: 2,
+        max: Duration::from_secs(30),
+    };
+    // 0 and 1 failures both wait the base delay.
+    assert_eq!(policy.delay_for(0), Duration::from_millis(500));
+    assert_eq!(policy.delay_for(1), Duration::from_millis(500));
+    // Geometric growth: 500ms, 1s, 2s, 4s, 8s, 16s …
+    assert_eq!(policy.delay_for(2), Duration::from_secs(1));
+    assert_eq!(policy.delay_for(3), Duration::from_secs(2));
+    assert_eq!(policy.delay_for(6), Duration::from_secs(16));
+    // … then saturates at the 30s cap and never exceeds it.
+    assert_eq!(policy.delay_for(7), Duration::from_secs(30));
+    assert_eq!(policy.delay_for(100), Duration::from_secs(30));
+}
+
+#[test]
+fn default_policy_is_bounded() {
+    let p = BackoffPolicy::default();
+    assert_eq!(p.base, Duration::from_millis(500));
+    assert_eq!(p.max, Duration::from_secs(30));
+    // No computed delay ever exceeds the cap, even for an absurd failure count.
+    assert!(p.delay_for(u32::MAX) <= p.max);
+}
+
+/// A fast policy with millisecond-scale delays so real backoff sleeps in the
+/// restart/give-up tests complete near-instantly.
+fn fast_policy() -> BackoffPolicy {
+    BackoffPolicy {
+        base: Duration::from_millis(1),
+        factor: 2,
+        max: Duration::from_millis(8),
+    }
+}
+
+#[tokio::test]
+async fn restarts_after_transient_then_succeeds() {
+    // The bot "fails" transiently twice, then exits gracefully. The supervisor
+    // must restart it across BOTH transient failures (3 total attempts) and then
+    // stop — proving a transient conflict self-heals instead of killing the bot.
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let a = Arc::clone(&attempts);
+    let factory = move || {
+        let a = Arc::clone(&a);
+        async move {
+            let n = a.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                BotExit::Transient
+            } else {
+                BotExit::Graceful
+            }
+        }
+    };
+
+    supervise(factory, fast_policy(), CancellationToken::new()).await;
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        3,
+        "expected 2 restarts after transient failures, then a graceful exit"
+    );
+}
+
+#[tokio::test]
+async fn gives_up_after_permanent_budget() {
+    // A permanently-failing bot must be retried only up to the permanent budget
+    // and then abandoned — never an infinite tight loop.
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let a = Arc::clone(&attempts);
+    let factory = move || {
+        let a = Arc::clone(&a);
+        async move {
+            a.fetch_add(1, Ordering::SeqCst);
+            BotExit::Permanent
+        }
+    };
+
+    supervise(factory, fast_policy(), CancellationToken::new()).await;
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        MAX_PERMANENT_FAILURES as usize,
+        "permanent failures must give up at the budget, not loop forever"
+    );
+}
+
+#[tokio::test]
+async fn transient_resets_permanent_counter() {
+    // A transient success between permanent failures must reset the permanent
+    // counter, so a flapping bot is not prematurely abandoned. Sequence:
+    // Permanent, Permanent, Transient, Permanent, Permanent, Graceful.
+    // Without the reset the 3rd permanent (index 4) would trip the give-up; with
+    // it, all 6 attempts run.
+    let script = Arc::new([
+        BotExit::Permanent,
+        BotExit::Permanent,
+        BotExit::Transient,
+        BotExit::Permanent,
+        BotExit::Permanent,
+        BotExit::Graceful,
+    ]);
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let a = Arc::clone(&attempts);
+    let s = Arc::clone(&script);
+    let factory = move || {
+        let a = Arc::clone(&a);
+        let s = Arc::clone(&s);
+        async move {
+            let n = a.fetch_add(1, Ordering::SeqCst);
+            s[n]
+        }
+    };
+
+    supervise(factory, fast_policy(), CancellationToken::new()).await;
+    assert_eq!(attempts.load(Ordering::SeqCst), 6);
+}
+
+#[tokio::test]
+async fn stops_on_cancellation() {
+    // When shutdown is already requested, the supervisor must not run the bot at
+    // all — it exits immediately, never blocking graceful shutdown.
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let a = Arc::clone(&attempts);
+    let factory = move || {
+        let a = Arc::clone(&a);
+        async move {
+            a.fetch_add(1, Ordering::SeqCst);
+            BotExit::Transient
+        }
+    };
+
+    let token = CancellationToken::new();
+    token.cancel();
+    supervise(factory, fast_policy(), token).await;
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        0,
+        "a pre-cancelled supervisor must not start the bot"
+    );
+}
+
+#[tokio::test]
+async fn backoff_sleep_is_cancellable() {
+    // A shutdown that arrives DURING a backoff window must end the supervisor
+    // promptly rather than waiting out the (here, capped) delay. We run one
+    // transient failure to enter a backoff, cancel, and assert the supervisor
+    // returns having made exactly one attempt.
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let a = Arc::clone(&attempts);
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+
+    // A policy whose backoff is an hour long: without the cancellation bailout
+    // the supervisor would block here for an hour, so a prompt return proves the
+    // backoff sleep is interrupted by shutdown.
+    let policy = BackoffPolicy {
+        base: Duration::from_secs(3600),
+        factor: 2,
+        max: Duration::from_secs(3600),
+    };
+
+    let factory = move || {
+        let a = Arc::clone(&a);
+        let cancel_token = cancel_token.clone();
+        async move {
+            let n = a.fetch_add(1, Ordering::SeqCst);
+            // On the first attempt, request shutdown so the supervisor enters its
+            // backoff already cancelled and must bail out of the sleep.
+            if n == 0 {
+                cancel_token.cancel();
+            }
+            BotExit::Transient
+        }
+    };
+
+    supervise(factory, policy, token).await;
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "supervisor must exit out of the backoff sleep on cancellation"
+    );
+}


### PR DESCRIPTION
## What
Two Telegram-bot stability fixes for the trusty-mpm daemon (TELUI control surface).

### #1499 — bot no longer dies silently on startup conflict
The daemon spawned the Telegram bot with a bare `tokio::spawn` that logged once and ended on any error (e.g. a 409 long-poll `getUpdates` conflict). Added a restart-on-exit supervisor (`telegram/supervisor.rs`) with bounded exponential backoff (500ms→30s cap), error classification (graceful / transient / permanent), give-up after 3 consecutive permanent failures (missing/invalid token), and `CancellationToken` shutdown-safety so the bot still stops cleanly on SIGINT/SIGTERM without blocking graceful shutdown.

### #1500 — pairing code now shared via disk, fixing cross-instance mismatch
The live pairing *code* lived only in an in-memory mutex, so a code minted on one daemon instance was rejected by another — exactly the silent ephemeral-port duplicate that #1499 used to create. Persist the pending code to a canonical `<framework_root>/pending_pair.json` (`pairing_store::{save,load,clear}_pending`); `generate_pair_code`/`confirm_pair_code` now agree via the shared store. Removes the `~/.trusty-mpm/pairing.json` pre-seed workaround.

## Tests
- 9 supervisor unit tests (restart-after-transient, give-up budget, transient resets counter, cancellation, cancellable backoff sleep, error classification, backoff growth/cap).
- 7 pairing tests incl. `pairing_confirms_shared_disk_code` cross-instance regression guard.
- clippy `-D warnings`, `fmt --check`, and `scripts/check_line_cap.sh` all clean.

Closes #1499
Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)