### PR TITLE
Fix atomic read-then-delete in confirm_pair_code (#1506)

### DIFF
--- a/crates/trusty-mpm/src/daemon/pairing_store.rs
+++ b/crates/trusty-mpm/src/daemon/pairing_store.rs
@@ -230,6 +230,36 @@ pub fn load_pending(root: &Path) -> Option<PendingPairCode> {
     }
 }
 
+/// Atomically claim and load the outstanding pending pairing code from `root`.
+///
+/// Why: confirming a code must be atomic so two concurrent `/pair` requests to
+/// different daemon processes cannot both read the file before either deletes it.
+/// What: renames `pending_pair.json` to a PID-specific temp file first; only the
+/// process that succeeds at the rename "wins" the claim. Returns `Some(pending)`
+/// if claimed and parseable; `None` otherwise. The temp file is deleted.
+/// Test: `concurrent_pairing_confirms`.
+pub fn claim_pending(root: &Path) -> Option<PendingPairCode> {
+    let path = pending_path(root);
+    let tmp = path.with_extension(format!("json.claim.{}", std::process::id()));
+
+    // Atomically claim ownership of the file by renaming it.
+    if std::fs::rename(&path, &tmp).is_err() {
+        return None;
+    }
+
+    let contents = std::fs::read_to_string(&tmp);
+    let _ = std::fs::remove_file(&tmp);
+    let contents = contents.ok()?;
+
+    match serde_json::from_str::<PendingPairCode>(&contents) {
+        Ok(pending) => Some(pending),
+        Err(e) => {
+            tracing::warn!("ignoring malformed {}: {e}", tmp.display());
+            None
+        }
+    }
+}
+
 /// Delete the outstanding pending pairing code under `root`.
 ///
 /// Why: a code is single-use — once confirmed (or explicitly invalidated) the

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -74,7 +74,7 @@ impl DaemonState {
         // Prefer the shared on-disk pending code (the cross-instance source of
         // truth); fall back to the in-memory copy for the same-process case when
         // no disk write has happened (or the file is unreadable).
-        let disk_valid = pairing_store::load_pending(&self.framework_root)
+        let disk_valid = pairing_store::claim_pending(&self.framework_root)
             .is_some_and(|p| p.code == code && p.is_fresh(PAIR_CODE_TTL));
         let mem_valid = matches!(
             guard.as_ref(),

--- a/crates/trusty-mpm/src/daemon/state/tests.rs
+++ b/crates/trusty-mpm/src/daemon/state/tests.rs
@@ -480,3 +480,30 @@ fn pairing_confirms_shared_disk_code() {
     let replay = DaemonState::with_root(root);
     assert!(!replay.confirm_pair_code(&code, 999));
 }
+
+#[test]
+fn concurrent_pairing_confirms() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path().to_path_buf();
+
+    let minting = DaemonState::with_root(root.clone());
+    let code = minting.generate_pair_code();
+
+    let confirming1 = DaemonState::with_root(root.clone());
+    let confirming2 = DaemonState::with_root(root.clone());
+
+    let code_clone = code.clone();
+    let c1 = std::thread::spawn(move || {
+        confirming1.confirm_pair_code(&code_clone, 111)
+    });
+    let c2 = std::thread::spawn(move || {
+        confirming2.confirm_pair_code(&code, 222)
+    });
+
+    let res1 = c1.join().unwrap();
+    let res2 = c2.join().unwrap();
+
+    // Exactly one confirm should succeed due to the atomic claim.
+    assert!(res1 ^ res2, "exactly one concurrent confirm must win the atomic claim");
+}
+


### PR DESCRIPTION
Fixes #1506 by atomically claiming ownership of the pending_pair.json file during confirm using a file rename.