### PR TITLE
feat(trusty-mpm): track & tear down ephemeral managed sessions (closes #1508)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -1068,6 +1068,37 @@ pub(crate) enum SessionAction {
         #[arg(long)]
         json: bool,
     },
+    /// Tear down EVERY ephemeral (test/throwaway) managed session (#1508).
+    ///
+    /// Why: e2e harnesses (and any operator who tagged test sessions) need a
+    /// one-shot "clean up all my throwaway sessions" verb. REAL sessions default
+    /// `ephemeral=false` and are unreachable, so durable work is never harmed.
+    /// What: POSTs `/api/v1/sessions/managed/decommission-ephemeral` and prints the
+    /// count torn down.
+    /// Test: `cli_parses_session_decommission_ephemeral`.
+    DecommissionEphemeral,
+    /// Prune managed sessions by state + compact tombstones (#1508).
+    ///
+    /// Why: ONE tool to (a) tear down ephemeral/stopped sessions and (b) compact
+    /// the store by dropping decommissioned tombstones, so the legacy stale records
+    /// can be purged with the same verb that cleans up test sessions. The
+    /// fail-closed default never touches a RUNNING session.
+    /// What: POSTs `/api/v1/sessions/managed/prune` with the `--state` filter;
+    /// `--dry-run` reports what WOULD be pruned without mutating.
+    /// Test: `cli_parses_session_prune`.
+    Prune {
+        /// Which records to target: `ephemeral` | `stopped` | `decommissioned` | `all`.
+        #[arg(long)]
+        state: String,
+        /// Report what WOULD be pruned without killing, removing, or tombstoning
+        /// any record.
+        #[arg(long)]
+        dry_run: bool,
+        /// Also tear down RUNNING (`Active`/`Provisioning`) sessions. Off by
+        /// default — the fail-closed safety gate.
+        #[arg(long)]
+        include_active: bool,
+    },
 }
 
 /// Actions for the `overseer` subcommand.

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -228,6 +228,98 @@ pub(crate) async fn session_decommission(
     Ok(())
 }
 
+/// `tm sessions decommission-ephemeral` — bulk-tear-down every ephemeral session (#1508).
+///
+/// Why: e2e harnesses and operators need a one-shot "clean up all my throwaway
+/// test sessions" verb. REAL sessions default `ephemeral=false` and are
+/// unreachable, so durable work is never harmed.
+/// What: POSTs `/api/v1/sessions/managed/decommission-ephemeral` and prints the
+/// returned `decommissioned` count.
+/// Test: HTTP path covered by `decommission_ephemeral_route_tears_down_only_ephemeral`
+/// in tests/session_manager_mvp.rs; CLI parse by `cli_parses_session_decommission_ephemeral`.
+pub(crate) async fn session_decommission_ephemeral(
+    client: &reqwest::Client,
+    url: &str,
+) -> anyhow::Result<()> {
+    let resp = client
+        .post(format!(
+            "{url}/api/v1/sessions/managed/decommission-ephemeral"
+        ))
+        .send()
+        .await?;
+    let body: serde_json::Value = resp.error_for_status()?.json().await?;
+    let count = body
+        .get("decommissioned")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    println!("decommissioned {count} ephemeral session(s)");
+    Ok(())
+}
+
+/// `tm sessions prune --state <filter> [--dry-run] [--include-active]` — by-state prune (#1508).
+///
+/// Why: ONE tool to tear down ephemeral/stopped sessions AND compact the store by
+/// dropping decommissioned tombstones, so legacy stale records can be purged with
+/// the same verb that cleans up test sessions. The fail-closed default never
+/// touches a RUNNING session unless `--include-active` is passed.
+/// What: POSTs `/api/v1/sessions/managed/prune` with `{ state, dry_run,
+/// include_active }`; on success prints one line per affected session
+/// (`<action> <id> <name> [<prior-state>]`) and a summary count. A 400 (bad
+/// `--state`) prints the daemon's actionable error.
+/// Test: HTTP path covered by `prune_route_dry_run_reports` /
+/// `prune_route_rejects_bad_state` in tests/session_manager_mvp.rs; CLI parse by
+/// `cli_parses_session_prune`.
+pub(crate) async fn session_prune(
+    client: &reqwest::Client,
+    url: &str,
+    state: String,
+    dry_run: bool,
+    include_active: bool,
+) -> anyhow::Result<()> {
+    let resp = client
+        .post(format!("{url}/api/v1/sessions/managed/prune"))
+        .json(&serde_json::json!({
+            "state": state,
+            "dry_run": dry_run,
+            "include_active": include_active,
+        }))
+        .send()
+        .await?;
+    if resp.status() == reqwest::StatusCode::BAD_REQUEST {
+        let msg = resp.text().await.unwrap_or_default();
+        println!("error: {msg}");
+        return Ok(());
+    }
+    let body: serde_json::Value = resp.error_for_status()?.json().await?;
+    let sessions = body
+        .get("sessions")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for s in &sessions {
+        let action = s
+            .get("action")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+        let id = s
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+        let name = s
+            .get("tmux_name")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+        let prior = s
+            .get("state")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+        println!("{action} {id} {name} [{prior}]");
+    }
+    let verb = if dry_run { "would prune" } else { "pruned" };
+    println!("{verb} {} session(s) (filter={state})", sessions.len());
+    Ok(())
+}
+
 /// `tm catalog` — sync or list the claude-mpm agent/skill catalog.
 ///
 /// Why: the session-manager MVP deploys agents/skills from the claude-mpm repo;

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -286,9 +286,12 @@ pub(crate) async fn session_prune(
         .send()
         .await?;
     if resp.status() == reqwest::StatusCode::BAD_REQUEST {
+        // Fail closed: a bad `--state` is a usage error, so surface it on STDERR
+        // and return an error → non-zero exit, so scripts/CI don't silently
+        // "succeed" on a rejected prune (#1508 review fix).
         let msg = resp.text().await.unwrap_or_default();
-        println!("error: {msg}");
-        return Ok(());
+        eprintln!("error: {msg}");
+        return Err(anyhow::anyhow!("prune rejected: {msg}"));
     }
     let body: serde_json::Value = resp.error_for_status()?.json().await?;
     let sessions = body

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
@@ -208,6 +208,7 @@ pub(crate) async fn launch_and_wait(
             None,
             None,
             RuntimeKind::ClaudeCode,
+            false,
         )
         .await
         .context("failed to create the tmux session for the metaharness")?;

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -405,6 +405,20 @@ pub(crate) async fn session(
         SessionAction::PruneIdle { dry_run, json } => {
             crate::commands::prune::prune_idle(client, url, dry_run, json).await?
         }
+        // #1508: bulk teardown + by-state prune go through direct HTTP (like
+        // `PruneIdle`), not chat-core — they are fleet-wide store operations, not
+        // single-session intents.
+        SessionAction::DecommissionEphemeral => {
+            crate::commands::managed::session_decommission_ephemeral(client, url).await?
+        }
+        SessionAction::Prune {
+            state,
+            dry_run,
+            include_active,
+        } => {
+            crate::commands::managed::session_prune(client, url, state, dry_run, include_active)
+                .await?
+        }
         // The deprecated verbose aliases emit their deprecation notice, then
         // route through chat-core exactly like their canonical verb (#1205).
         action @ (SessionAction::ManagedStop { .. }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1066,6 +1066,58 @@ fn cli_parses_session_prune_idle_defaults() {
 }
 
 #[test]
+fn cli_parses_session_decommission_ephemeral() {
+    // #1508: the bulk-teardown verb takes no arguments.
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "decommission-ephemeral"]).unwrap();
+    match cli.command {
+        Command::Session {
+            action: SessionAction::DecommissionEphemeral,
+        } => {}
+        other => panic!("expected session decommission-ephemeral, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_prune() {
+    // #1508: `prune` requires `--state` and accepts `--dry-run`/`--include-active`.
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "sessions",
+        "prune",
+        "--state",
+        "stopped",
+        "--dry-run",
+    ])
+    .unwrap();
+    match cli.command {
+        Command::Session {
+            action:
+                SessionAction::Prune {
+                    state,
+                    dry_run,
+                    include_active,
+                },
+        } => {
+            assert_eq!(state, "stopped");
+            assert!(dry_run);
+            assert!(
+                !include_active,
+                "include_active defaults to the fail-closed false"
+            );
+        }
+        other => panic!("expected session prune, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_session_prune_requires_state() {
+    // #1508: `--state` is mandatory — omitting it must be a parse error (the
+    // fail-closed CLI contract; we never default to a destructive filter).
+    let err = Cli::try_parse_from(["trusty-mpm", "sessions", "prune"]);
+    assert!(err.is_err(), "prune without --state must fail to parse");
+}
+
+#[test]
 fn deprecation_notice_format() {
     // The deprecation helper renders a stable, single-line message (#1205).
     // We assert the pure message builder since the eprintln side-effect itself

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action_protocol.rs
@@ -362,6 +362,9 @@ pub async fn execute_verb(
                 model: str_arg(args, "model"),
                 prompt: str_arg(args, "prompt"),
                 goal_id: str_arg(args, "goal_id"),
+                // #1508: an explicit `ephemeral` arg marks the launched session
+                // disposable; absent → a normal durable session.
+                ephemeral: args.get("ephemeral").and_then(Value::as_bool),
             };
             control.launch(params).await
         }

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
@@ -381,6 +381,8 @@ impl SessionManagerAgent {
                 model: task.model.clone(),
                 prompt: Some(task.prompt.clone()),
                 goal_id: Some(goal_id.to_string()),
+                // Delegated goal-fan-out sessions are real work, never ephemeral.
+                ephemeral: None,
             };
             // Per-task best-effort: a single launch failure must NOT abort the whole
             // fan-out (which would orphan sessions already launched for earlier

--- a/crates/trusty-mpm/src/core/sm/control.rs
+++ b/crates/trusty-mpm/src/core/sm/control.rs
@@ -46,6 +46,12 @@ pub struct LaunchParams {
     pub prompt: Option<String>,
     /// Optional goal id to link the launched session to (§9.3).
     pub goal_id: Option<String>,
+    /// Whether the launched session is EPHEMERAL (a test/throwaway session) (#1508).
+    ///
+    /// Why: the chat-driven launch path must be able to mark a session disposable
+    /// so the bulk-teardown and age-based reap paths can clean it up. `None`/
+    /// `Some(false)` → a normal durable session the automatic paths never touch.
+    pub ephemeral: Option<bool>,
 }
 
 /// A failure surfaced by a [`SessionControl`] operation.

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -102,9 +102,10 @@ pub use rpc::rpc_handler;
 /// lets `router` refer to them unqualified, mirroring the `coordinator_routes`
 /// wiring.
 use super::managed_routes::{
-    adopt_existing_session, answer_session_decision, decommission_managed_session, get_attach_cmd,
-    get_managed_session, get_session_activity, list_managed_sessions, resume_managed_session,
-    send_to_session, spawn_session, stop_managed_session, stop_managed_session_runtime,
+    adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
+    decommission_managed_session, get_attach_cmd, get_managed_session, get_session_activity,
+    list_managed_sessions, prune_managed_route, resume_managed_session, send_to_session,
+    spawn_session, stop_managed_session, stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.
@@ -200,6 +201,14 @@ pub fn router(state: Arc<DaemonState>) -> Router {
             "/api/v1/sessions/managed/adopt",
             post(adopt_existing_session),
         )
+        // #1508: bulk teardown + by-state prune. Both literal segments are
+        // registered BEFORE the `/{id}` param route so they are never captured as
+        // an id (mirroring the `/adopt` ordering above).
+        .route(
+            "/api/v1/sessions/managed/decommission-ephemeral",
+            post(decommission_ephemeral_route),
+        )
+        .route("/api/v1/sessions/managed/prune", post(prune_managed_route))
         .route(
             "/api/v1/sessions/managed/{id}",
             get(get_managed_session).delete(stop_managed_session),

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -47,6 +47,13 @@ pub struct SpawnParams {
     pub name_hint: Option<String>,
     /// Optional runtime selector (`"claude-code"` | `"tcode"`).
     pub runtime: Option<String>,
+    /// Whether the spawned session is EPHEMERAL (a test/throwaway session) (#1508).
+    ///
+    /// Why: e2e harnesses (and any caller that knows it is creating a disposable
+    /// session) set this so the bulk-teardown and age-based reap paths may clean
+    /// the session up automatically. `None`/`Some(false)` → a normal, durable
+    /// session that the automatic paths never touch.
+    pub ephemeral: Option<bool>,
 }
 
 /// Spawn a managed session, shared by the HTTP handler and the MCP tool.
@@ -144,6 +151,7 @@ pub async fn spawn_managed(
             Some(params.repo_url.clone()),
             Some(params.git_ref.clone()),
             runtime,
+            params.ephemeral.unwrap_or(false),
         )
         .await
         .map_err(|e| {
@@ -262,6 +270,7 @@ async fn spawn_managed_local(
             None,
             None,
             runtime,
+            params.ephemeral.unwrap_or(false),
         )
         .await
         .map_err(|e| {

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -28,6 +28,7 @@ use crate::session_manager::{ManagedSessionId, SessionRecord};
 
 pub mod front_gate;
 mod lifecycle;
+pub mod prune;
 pub use front_gate::{
     ConformanceGate, FrontGateOutcome, HeadlessApproval, IsrConformanceGate, run_front_gate,
 };
@@ -35,6 +36,7 @@ pub use lifecycle::{
     ResumeManagedError, SpawnParams, is_local_workdir, resume_managed, spawn_managed,
     spawn_runtime_for,
 };
+pub use prune::{PruneRequest, decommission_ephemeral_route, prune_managed_route};
 
 // ── Request / Response shapes ─────────────────────────────────────────────────
 
@@ -63,6 +65,11 @@ pub struct SpawnRequest {
     /// unaffected. Parsed via [`crate::runtime::RuntimeKind::from_str`]; an
     /// unrecognized value yields a `400 Bad Request`.
     pub runtime: Option<String>,
+    /// Optional ephemeral marker (#1508): `true` tags this as a test/throwaway
+    /// session eligible for bulk teardown + age-based auto-reap. Absent/null/false
+    /// → a normal durable session the automatic paths never touch.
+    #[serde(default)]
+    pub ephemeral: Option<bool>,
 }
 
 /// Response body for POST /api/v1/sessions/managed (spawn, 201 Created).
@@ -117,6 +124,12 @@ pub struct AdoptExistingRequest {
     /// Optional runtime selector (`"claude-code"` | `"tcode"`); absent → default.
     #[serde(default)]
     pub runtime: Option<String>,
+    /// Optional ephemeral marker (#1508): `true` tags this adoption as a
+    /// test/throwaway session eligible for bulk teardown + age-based auto-reap.
+    /// Absent/null/false → a durable operator adoption the automatic paths never
+    /// touch.
+    #[serde(default)]
+    pub ephemeral: Option<bool>,
 }
 
 /// Response body for POST /api/v1/sessions/managed/adopt (201 Created).
@@ -412,6 +425,7 @@ pub async fn spawn_session(
         task: req.task,
         name_hint: req.name_hint,
         runtime: req.runtime,
+        ephemeral: req.ephemeral,
     };
 
     match spawn_managed(&state, params).await {
@@ -471,7 +485,16 @@ pub async fn adopt_existing_session(
     let cwd = std::path::PathBuf::from(&req.cwd);
 
     let mgr = state.session_manager().await;
-    match mgr.adopt_existing(&req.tmux_name, cwd, task, runtime).await {
+    match mgr
+        .adopt_existing(
+            &req.tmux_name,
+            cwd,
+            task,
+            runtime,
+            req.ephemeral.unwrap_or(false),
+        )
+        .await
+    {
         Ok(record) => {
             let resp = AdoptExistingResponse {
                 id: record.id.to_string(),

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -1,0 +1,96 @@
+//! HTTP handlers for the #1508 ephemeral bulk-teardown + by-state prune routes.
+//!
+//! Why: the managed-session API needs two new teardown endpoints — one to tear
+//! down every ephemeral (test) session, and a general by-state prune that can also
+//! purge the legacy 239 stale records. They live in their own file so the route
+//! module (`mod.rs`) stays under the 500-SLOC production cap.
+//! What: [`decommission_ephemeral_route`] (POST …/managed/decommission-ephemeral)
+//! and [`prune_managed_route`] (POST …/managed/prune) handlers, plus the
+//! [`PruneRequest`] body. Both delegate to the shared
+//! [`crate::session_manager::SessionManager`] prune engine so HTTP, CLI, and MCP
+//! share ONE implementation.
+//! Test: `prune_route_*` in tests/session_manager_mvp.rs.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use serde::Deserialize;
+use tracing::warn;
+
+use crate::daemon::state::DaemonState;
+use crate::session_manager::PruneFilter;
+
+/// Request body for POST /api/v1/sessions/managed/prune (#1508).
+///
+/// Why: the by-state prune must let an operator choose WHICH records to target
+/// (`ephemeral`/`stopped`/`decommissioned`/`all`), preview with `dry_run`, and —
+/// only when they really mean it — also include RUNNING sessions via
+/// `include_active`. Modelling it as a typed body keeps the safety defaults
+/// explicit (running sessions are spared unless `include_active` is `true`).
+/// What: `state` (the [`PruneFilter`] spelling), `dry_run` (default false), and
+/// `include_active` (default false).
+/// Test: `prune_route_dry_run_reports`, `prune_route_rejects_bad_state`.
+#[derive(Debug, Deserialize)]
+pub struct PruneRequest {
+    /// Which records to target: `ephemeral` | `stopped` | `decommissioned` | `all`.
+    pub state: String,
+    /// When true, report what WOULD be pruned without mutating anything.
+    #[serde(default)]
+    pub dry_run: bool,
+    /// When true, also tear down RUNNING (`Active`/`Provisioning`) sessions.
+    /// Defaults to false — the fail-closed safety default.
+    #[serde(default)]
+    pub include_active: bool,
+}
+
+/// POST /api/v1/sessions/managed/decommission-ephemeral — bulk-tear-down ephemeral (#1508).
+///
+/// Why: the one-shot "clean up all my throwaway test sessions" verb for e2e
+/// harnesses and operators. REAL sessions default `ephemeral=false` and are
+/// unreachable, so this can never harm durable work.
+/// What: delegates to
+/// [`SessionManager::decommission_all_ephemeral`](crate::session_manager::SessionManager::decommission_all_ephemeral)
+/// and returns `{ decommissioned: <count> }`.
+/// Test: `decommission_ephemeral_route_tears_down_only_ephemeral` in
+/// tests/session_manager_mvp.rs.
+pub async fn decommission_ephemeral_route(
+    State(state): State<Arc<DaemonState>>,
+) -> impl IntoResponse {
+    let mgr = state.session_manager().await;
+    match mgr.decommission_all_ephemeral().await {
+        Ok(count) => Json(serde_json::json!({ "decommissioned": count })).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// POST /api/v1/sessions/managed/prune — by-state prune + compaction (#1508).
+///
+/// Why: the general teardown tool, exposed so the legacy 239 stale records can be
+/// purged over HTTP with the SAME engine that cleans up ephemeral sessions.
+/// What: parses the `state` filter (400 on an unknown value), then delegates to
+/// [`SessionManager::prune_managed`](crate::session_manager::SessionManager::prune_managed)
+/// with the request's `dry_run`/`include_active`. Returns the
+/// [`crate::session_manager::PruneOutcome`] JSON (its `dry_run`, `filter`, and
+/// per-session `action` list).
+/// Test: `prune_route_dry_run_reports`, `prune_route_rejects_bad_state` in
+/// tests/session_manager_mvp.rs.
+pub async fn prune_managed_route(
+    State(state): State<Arc<DaemonState>>,
+    Json(req): Json<PruneRequest>,
+) -> impl IntoResponse {
+    let filter = match PruneFilter::parse(&req.state) {
+        Ok(f) => f,
+        Err(e) => {
+            warn!("prune route: {e}");
+            return (StatusCode::BAD_REQUEST, e).into_response();
+        }
+    };
+    let mgr = state.session_manager().await;
+    match mgr
+        .prune_managed(filter, req.dry_run, req.include_active)
+        .await
+    {
+        Ok(outcome) => Json(outcome).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -380,9 +380,18 @@ impl OrchestratorBackend for StateBackend {
         task: &str,
         name_hint: Option<&str>,
         runtime: Option<&str>,
+        ephemeral: Option<bool>,
     ) -> Result<Value, String> {
-        super::mcp_session::session_new(&self.state, repo_url, git_ref, task, name_hint, runtime)
-            .await
+        super::mcp_session::session_new(
+            &self.state,
+            repo_url,
+            git_ref,
+            task,
+            name_hint,
+            runtime,
+            ephemeral,
+        )
+        .await
     }
 
     async fn session_stop(&self, session_id: &str) -> Result<Value, String> {
@@ -403,6 +412,21 @@ impl OrchestratorBackend for StateBackend {
 
     async fn session_send(&self, session_id: &str, text: &str) -> Result<Value, String> {
         super::mcp_session::session_send(&self.state, session_id, text).await
+    }
+
+    // ── #1508: fleet-wide teardown tools (delegate to mcp_session) ───────────
+
+    async fn session_decommission_ephemeral(&self) -> Result<Value, String> {
+        super::mcp_session::session_decommission_ephemeral(&self.state).await
+    }
+
+    async fn session_prune(
+        &self,
+        state: &str,
+        dry_run: bool,
+        include_active: bool,
+    ) -> Result<Value, String> {
+        super::mcp_session::session_prune(&self.state, state, dry_run, include_active).await
     }
 
     // ── #1222: console-facing tools (delegate to mcp_console) ────────────────

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -1,4 +1,5 @@
-//! Daemon-side implementation of the six session-lifecycle MCP tools (#1221).
+//! Daemon-side implementation of the eight session-lifecycle MCP tools
+//! (#1221 + the two fleet-wide #1508 teardown verbs).
 //!
 //! Why: the MCP `StateBackend` (in `mcp_backend.rs`) must service the new
 //! session-lifecycle tools, but inlining their bodies there would push that file
@@ -8,10 +9,12 @@
 //! reimplementation — so MCP and HTTP behave identically. This module holds the
 //! wrapping logic; `session_new` delegates to the shared
 //! [`crate::daemon::managed_routes::spawn_managed`] used by the HTTP handler too.
-//! What: six free async functions — `session_new`, `session_stop`,
-//! `session_resume`, `session_decommission`, `session_activity`, `session_send`
-//! — each taking `&Arc<DaemonState>` plus parsed arguments and returning the
-//! same JSON shapes the HTTP routes return, or a human-readable error string.
+//! What: eight free async functions — the six per-session ops (`session_new`,
+//! `session_stop`, `session_resume`, `session_decommission`, `session_activity`,
+//! `session_send`) plus the two fleet-wide #1508 verbs
+//! (`session_decommission_ephemeral`, `session_prune`) — each taking
+//! `&Arc<DaemonState>` plus parsed arguments and returning the same JSON shapes
+//! the HTTP routes return, or a human-readable error string.
 //! Test: `cargo test -p trusty-mpm daemon::mcp_session` plus the dispatch-level
 //! tests in `crate::mcp`.
 
@@ -21,7 +24,7 @@ use serde_json::{Value, json};
 
 use crate::daemon::managed_routes::{SpawnParams, record_to_json, spawn_managed};
 use crate::daemon::state::DaemonState;
-use crate::session_manager::{ManagedError, ManagedSessionId};
+use crate::session_manager::{ManagedError, ManagedSessionId, PruneFilter};
 
 /// Parse a managed-session id string into a [`ManagedSessionId`].
 ///
@@ -52,7 +55,9 @@ fn managed_err(e: ManagedError) -> String {
 /// [`spawn_managed`] helper so the MCP and HTTP spawn flows are identical.
 /// What: validates the optional `runtime` selector, provisions the workspace,
 /// creates the tmux host, launches the harness, and returns the new record as
-/// JSON (id, tmux name, workspace path, state, attach command, runtime).
+/// JSON (id, tmux name, workspace path, state, attach command, runtime). The
+/// optional `ephemeral` flag (#1508) tags a test/throwaway session for the
+/// bulk-teardown + auto-reap paths.
 /// Test: `session_new_invalid_runtime_errors` (unit, no tmux needed).
 pub async fn session_new(
     state: &Arc<DaemonState>,
@@ -61,6 +66,7 @@ pub async fn session_new(
     task: &str,
     name_hint: Option<&str>,
     runtime: Option<&str>,
+    ephemeral: Option<bool>,
 ) -> Result<Value, String> {
     let params = SpawnParams {
         repo_url: repo_url.to_string(),
@@ -68,6 +74,7 @@ pub async fn session_new(
         task: task.to_string(),
         name_hint: name_hint.map(str::to_string),
         runtime: runtime.map(str::to_string),
+        ephemeral,
     };
     let record = spawn_managed(state, params).await?;
     Ok(record_to_json(&record))
@@ -186,6 +193,51 @@ pub async fn session_send(
     }))
 }
 
+/// Bulk-tear-down every ephemeral session (`session_decommission_ephemeral` tool, #1508).
+///
+/// Why: gives the driver a typed "clean up all my throwaway test sessions" path
+/// over MCP, delegating to the SAME
+/// [`SessionManager::decommission_all_ephemeral`](crate::session_manager::SessionManager::decommission_all_ephemeral)
+/// engine the HTTP route and CLI use, so behaviour is identical across transports.
+/// REAL sessions default `ephemeral=false` and are unreachable — durable work is safe.
+/// What: decommissions every ephemeral session and returns `{ decommissioned: <count> }`.
+/// Test: `dispatch_session_decommission_ephemeral_tool` (mock) in `crate::mcp`.
+pub async fn session_decommission_ephemeral(state: &Arc<DaemonState>) -> Result<Value, String> {
+    let mgr = state.session_manager().await;
+    let count = mgr
+        .decommission_all_ephemeral()
+        .await
+        .map_err(managed_err)?;
+    Ok(json!({ "decommissioned": count }))
+}
+
+/// By-state prune + tombstone compaction (`session_prune` tool, #1508).
+///
+/// Why: the fleet-wide teardown tool exposed over MCP so the legacy stale records
+/// can be purged with the SAME
+/// [`SessionManager::prune_managed`](crate::session_manager::SessionManager::prune_managed)
+/// engine the HTTP route and CLI use.
+/// What: parses `state` (an unknown spelling is a `400`-style error string), then
+/// prunes with `dry_run`/`include_active` and returns the serialized
+/// [`crate::session_manager::PruneOutcome`]. A RUNNING session is NEVER torn down
+/// unless `include_active`; with `dry_run` nothing is mutated.
+/// Test: `dispatch_session_prune_tool`, `dispatch_session_prune_rejects_bad_state`
+/// (mock) in `crate::mcp`.
+pub async fn session_prune(
+    state: &Arc<DaemonState>,
+    filter: &str,
+    dry_run: bool,
+    include_active: bool,
+) -> Result<Value, String> {
+    let filter = PruneFilter::parse(filter)?;
+    let mgr = state.session_manager().await;
+    let outcome = mgr
+        .prune_managed(filter, dry_run, include_active)
+        .await
+        .map_err(managed_err)?;
+    serde_json::to_value(&outcome).map_err(|e| format!("failed to serialize prune outcome: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,6 +326,7 @@ mod tests {
             "t",
             None,
             Some("bogus"),
+            None,
         )
         .await
         .unwrap_err();

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -403,6 +403,19 @@ async fn orphan_gc_loop(state: Arc<DaemonState>) {
         if reaped > 0 {
             info!("orphan-GC reaped {reaped} orphaned managed session(s)");
         }
+
+        // #1508: alongside the orphan sweep, auto-reap STALE EPHEMERAL sessions.
+        // Only `ephemeral == true` records older than `MAX_EPHEMERAL_AGE_HOURS`
+        // are in scope — real sessions default `ephemeral=false` and are
+        // unreachable here, so this never touches durable work. This is the
+        // backstop for an e2e test that panicked before its Drop-guard could tear
+        // its session down.
+        let max_age = chrono::Duration::hours(crate::session_manager::MAX_EPHEMERAL_AGE_HOURS);
+        match mgr.reap_aged_ephemeral(max_age).await {
+            Ok(n) if n > 0 => info!("ephemeral auto-reap decommissioned {n} stale session(s)"),
+            Ok(_) => {}
+            Err(e) => tracing::warn!("ephemeral auto-reap failed: {e}"),
+        }
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -121,6 +121,7 @@ impl SessionControl for DaemonSessionControl {
             task,
             name_hint: None,
             runtime: params.model,
+            ephemeral: params.ephemeral,
         };
         let record = spawn_managed(&self.state, spawn)
             .await
@@ -288,6 +289,9 @@ impl SessionControl for DaemonSessionControl {
                 std::path::PathBuf::from(cwd),
                 task.unwrap_or_default().to_string(),
                 runtime_kind,
+                // Chat/action-loop adoptions are durable operator sessions, never
+                // ephemeral — they must not be auto-reaped (#1508).
+                false,
             )
             .await
             .map_err(|e| match e {

--- a/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
@@ -217,6 +217,9 @@ pub async fn sm_sessions_launch(d: &SmDispatcher, params: &Value) -> Result<Valu
         model: opt_str(params, "model"),
         prompt: opt_str(params, "prompt"),
         goal_id: goal_id.clone(),
+        // #1508: honour an explicit `ephemeral` flag from the wire so a
+        // chat/test launch can mark its session disposable; absent → durable.
+        ephemeral: params.get("ephemeral").and_then(Value::as_bool),
     };
     let result = d.sessions.launch(launch).await.map_err(map_control_err)?;
 

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -137,6 +137,7 @@ pub trait OrchestratorBackend: Send + Sync {
         task: &str,
         name_hint: Option<&str>,
         runtime: Option<&str>,
+        ephemeral: Option<bool>,
     ) -> Result<Value, String>;
 
     /// Back `session_stop`: stop a session's runtime, keeping its workspace.
@@ -188,6 +189,36 @@ pub trait OrchestratorBackend: Send + Sync {
     ///       confirmation with the tmux name. A missing id is an error string.
     /// Test: `dispatch_session_send_tool` (mock).
     async fn session_send(&self, session_id: &str, text: &str) -> Result<Value, String>;
+
+    // ── #1508: fleet-wide teardown tools ─────────────────────────────────────
+
+    /// Back `session_decommission_ephemeral`: bulk-tear-down every ephemeral session.
+    ///
+    /// Why: e2e harnesses and drivers need a typed, JSON-native "clean up all my
+    ///      throwaway test sessions" verb without scraping the CLI. REAL sessions
+    ///      default `ephemeral=false` and are unreachable, so durable work is safe.
+    /// What: decommissions every `ephemeral == true` session (kill runtime + remove
+    ///       workspace + tombstone) and returns `{ decommissioned: <count> }`.
+    /// Test: `dispatch_session_decommission_ephemeral_tool` (mock).
+    async fn session_decommission_ephemeral(&self) -> Result<Value, String>;
+
+    /// Back `session_prune`: by-state prune + tombstone compaction.
+    ///
+    /// Why: ONE fleet-wide tool to tear down ephemeral/stopped sessions AND compact
+    ///      the store by dropping decommissioned tombstones, so legacy stale records
+    ///      can be purged over MCP with the same engine that cleans up test sessions.
+    /// What: parses `state` (`ephemeral`|`stopped`|`decommissioned`|`all`); a RUNNING
+    ///       session is NEVER torn down unless `include_active`; with `dry_run`
+    ///       NOTHING is mutated. Returns the `PruneOutcome` JSON. An unknown `state`
+    ///       is an error string.
+    /// Test: `dispatch_session_prune_tool`, `dispatch_session_prune_rejects_bad_state`
+    ///       (mock).
+    async fn session_prune(
+        &self,
+        state: &str,
+        dry_run: bool,
+        include_active: bool,
+    ) -> Result<Value, String>;
 
     // ── #1222: console-facing tools ──────────────────────────────────────────
 
@@ -380,8 +411,8 @@ async fn dispatch_tool_call<B: OrchestratorBackend>(
                 .config_write(template, auto_resume, default_model)
                 .await
         }
-        // #1221: the six session-lifecycle tools route through a sibling module
-        // so this match stays focused and `mod.rs` stays under the SLOC cap.
+        // #1221 + #1508: the eight session-lifecycle tools route through a sibling
+        // module so this match stays focused and `mod.rs` stays under the SLOC cap.
         other => match session_dispatch::try_dispatch(backend, other, &args).await {
             Some(result) => result,
             None => Err(format!("unknown tool: {other}")),

--- a/crates/trusty-mpm/src/mcp/session_dispatch.rs
+++ b/crates/trusty-mpm/src/mcp/session_dispatch.rs
@@ -1,13 +1,15 @@
-//! Argument parsing + routing for the six session-lifecycle MCP tools (#1221).
+//! Argument parsing + routing for the eight session-lifecycle MCP tools
+//! (#1221 + #1508).
 //!
 //! Why: the session-lifecycle tools more than half-again the catalog; routing
 //! them inline in `mcp/mod.rs`'s `dispatch_tool_call` would push that file over
 //! the 500-SLOC production cap. Extracting the parse-and-call arms into a sibling
 //! module keeps `mod.rs` focused on the handshake + core tools and gives the
 //! session tools one auditable home.
-//! What: [`try_dispatch`] matches a tool name against the six session tools;
-//! when it matches it parses arguments (via the shared `required_str` helper),
-//! calls the corresponding [`super::OrchestratorBackend`] method, and returns
+//! What: [`try_dispatch`] matches a tool name against the eight session tools
+//! (six per-session #1221 + the two fleet-wide #1508 teardown verbs); when it
+//! matches it parses arguments (via the shared `required_str` helper), calls the
+//! corresponding [`super::OrchestratorBackend`] method, and returns
 //! `Some(result)`. A non-session tool name returns `None` so the caller can
 //! report "unknown tool".
 //! Test: the `super::tests` `dispatch_session_*` cases drive this module through
@@ -29,9 +31,11 @@ const DEFAULT_ACTIVITY_LINES: u32 = 60;
 ///
 /// Why: a single entry point lets `dispatch_tool_call` delegate every
 /// session-tool name in one arm, keeping the core dispatch match small.
-/// What: returns `Some(Result)` for the six session tool names (parsing args and
-/// calling the matching backend method), or `None` when `name` is not a session
-/// tool — signalling the caller to fall through to its "unknown tool" branch.
+/// What: returns `Some(Result)` for the eight session tool names — the six
+/// per-session ops plus the two fleet-wide #1508 verbs (`session_decommission_ephemeral`,
+/// `session_prune`) — parsing args and calling the matching backend method, or
+/// `None` when `name` is not a session tool — signalling the caller to fall
+/// through to its "unknown tool" branch.
 /// Errors from argument parsing are returned as `Some(Err(_))` so they surface
 /// to the client as a tool-error result, identical to the core tools.
 /// Test: exercised by every `dispatch_session_*` test in `super::tests`.
@@ -69,6 +73,22 @@ pub async fn try_dispatch<B: OrchestratorBackend>(
             (Ok(id), Ok(text)) => backend.session_send(&id, &text).await,
             (Err(e), _) | (_, Err(e)) => Err(e),
         },
+        // #1508 fleet-wide teardown tools — no per-session id required.
+        "session_decommission_ephemeral" => backend.session_decommission_ephemeral().await,
+        "session_prune" => match required_str(args, "state") {
+            Ok(state) => {
+                let dry_run = args
+                    .get("dry_run")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let include_active = args
+                    .get("include_active")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                backend.session_prune(&state, dry_run, include_active).await
+            }
+            Err(e) => Err(e),
+        },
         // Not a session tool — let the caller report "unknown tool".
         _ => return None,
     };
@@ -90,7 +110,8 @@ async fn session_new<B: OrchestratorBackend>(backend: &B, args: &Value) -> Resul
     let task = required_str(args, "task")?;
     let name_hint = args.get("name_hint").and_then(Value::as_str);
     let runtime = args.get("runtime").and_then(Value::as_str);
+    let ephemeral = args.get("ephemeral").and_then(Value::as_bool);
     backend
-        .session_new(&repo_url, &git_ref, &task, name_hint, runtime)
+        .session_new(&repo_url, &git_ref, &task, name_hint, runtime, ephemeral)
         .await
 }

--- a/crates/trusty-mpm/src/mcp/tests.rs
+++ b/crates/trusty-mpm/src/mcp/tests.rs
@@ -5,7 +5,8 @@
 //! cap) live alongside it. Included via `#[path = "tests.rs"] mod tests;`.
 //! What: a `MockBackend` implementing every `OrchestratorBackend` method plus
 //! dispatch tests for the handshake, the core tools, the bug-reporting tools,
-//! and the six session-lifecycle tools.
+//! and the eight session-lifecycle tools (six per-session #1221 + the two
+//! fleet-wide #1508 teardown verbs).
 //! Test: this IS the test module.
 
 use super::*;
@@ -73,12 +74,14 @@ impl OrchestratorBackend for MockBackend {
         _task: &str,
         _name_hint: Option<&str>,
         runtime: Option<&str>,
+        ephemeral: Option<bool>,
     ) -> Result<Value, String> {
         Ok(json!({
             "id": "m-1",
             "repo_url": repo_url,
             "branch": git_ref,
             "runtime": runtime.unwrap_or("claude-code"),
+            "ephemeral": ephemeral.unwrap_or(false),
             "state": "active",
         }))
     }
@@ -96,6 +99,27 @@ impl OrchestratorBackend for MockBackend {
     }
     async fn session_send(&self, session_id: &str, text: &str) -> Result<Value, String> {
         Ok(json!({ "id": session_id, "sent": true, "text": text }))
+    }
+
+    // ── #1508: fleet-wide teardown mock impls ────────────────────────────────
+    async fn session_decommission_ephemeral(&self) -> Result<Value, String> {
+        Ok(json!({ "decommissioned": 3 }))
+    }
+    async fn session_prune(
+        &self,
+        state: &str,
+        dry_run: bool,
+        include_active: bool,
+    ) -> Result<Value, String> {
+        // Mirror the real engine's contract: reject an unknown filter spelling so
+        // the dispatch-level "rejects bad state" test exercises the error path.
+        crate::session_manager::PruneFilter::parse(state)?;
+        Ok(json!({
+            "dry_run": dry_run,
+            "filter": state,
+            "include_active": include_active,
+            "sessions": [],
+        }))
     }
 
     // ── #1222: console-facing mock impls ─────────────────────────────────────
@@ -167,8 +191,8 @@ async fn dispatch_initialize_returns_server_info() {
 
 #[tokio::test]
 async fn dispatch_tools_list_returns_full_catalog() {
-    // 9 pre-existing + 6 session-lifecycle + 5 console-facing tools = 20
-    // (#1222 + the two #1220 config tools).
+    // 9 pre-existing + 8 session-lifecycle + 5 console-facing tools = 22
+    // (#1222 + the two #1220 config tools + the two #1508 fleet-teardown tools).
     let req = Request {
         jsonrpc: Some("2.0".into()),
         id: Some(json!(1)),
@@ -177,7 +201,7 @@ async fn dispatch_tools_list_returns_full_catalog() {
     };
     let resp = dispatch(&MockBackend, req).await;
     let tools = resp.result.unwrap()["tools"].clone();
-    assert_eq!(tools.as_array().unwrap().len(), 20);
+    assert_eq!(tools.as_array().unwrap().len(), 22);
 }
 
 /// Why: the console Config tab calls `config_read`; dispatch must route it and
@@ -596,5 +620,85 @@ async fn dispatch_session_send_requires_text() {
             .as_str()
             .unwrap()
             .contains("text")
+    );
+}
+
+/// Why (#1508): the fleet-wide `session_decommission_ephemeral` tool takes no
+/// args and must route to the backend, returning the `decommissioned` count.
+/// This is the dispatch wiring that was missing — the descriptor was in the
+/// catalog but `try_dispatch` had no arm, so the tool returned "unknown tool".
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_decommission_ephemeral_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call("session_decommission_ephemeral", json!({})),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("decommissioned")
+    );
+}
+
+/// Why (#1508): `session_prune` must route its `state`/`dry_run`/`include_active`
+/// args to the backend and surface the `PruneOutcome` JSON.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_prune_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call(
+            "session_prune",
+            json!({ "state": "ephemeral", "dry_run": true }),
+        ),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("ephemeral")
+    );
+}
+
+/// Why (#1508): `session_prune` must reject an unknown `state` spelling with a
+/// tool-error, mirroring the engine's `PruneFilter::parse` contract.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_prune_rejects_bad_state() {
+    let resp = dispatch(
+        &MockBackend,
+        call("session_prune", json!({ "state": "garbage" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("unknown prune filter")
+    );
+}
+
+/// Why (#1508): `session_prune` must error when the required `state` arg is missing.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_session_prune_requires_state() {
+    let resp = dispatch(&MockBackend, call("session_prune", json!({}))).await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("state")
     );
 }

--- a/crates/trusty-mpm/src/mcp/tools/mod.rs
+++ b/crates/trusty-mpm/src/mcp/tools/mod.rs
@@ -7,10 +7,10 @@
 //! ([`core`]) and the new session-lifecycle tools ([`session`]) — so this is a
 //! thin facade that re-exports both and concatenates their descriptors, keeping
 //! each leaf file well under the 500-SLOC production cap.
-//! What: [`tool_catalog`] builds the twenty MCP tool descriptors (nine core +
-//! six session + five console — #1222 / #1220); [`TOOL_CATALOG`] lists their names
-//! for tests and the startup log; [`tool`] is the shared descriptor builder used
-//! by every submodule.
+//! What: [`tool_catalog`] builds the twenty-two MCP tool descriptors (nine core +
+//! eight session + five console — #1222 / #1220 / #1508); [`TOOL_CATALOG`] lists
+//! their names for tests and the startup log; [`tool`] is the shared descriptor
+//! builder used by every submodule.
 //! Test: the `tests` module below asserts the catalog has the expected count,
 //! well-formed entries, and names matching [`TOOL_CATALOG`].
 
@@ -25,12 +25,13 @@ pub mod session;
 /// Why: tests, the daemon's startup log, and the loopback-`/rpc` audit all want
 /// the authoritative list without re-parsing the JSON schema. Keeping it exact
 /// resolves the #1221 review nit about ambiguous existing-vs-new counts: there
-/// are exactly NINE pre-existing tools and SIX new session-lifecycle tools.
-/// What: a static slice of the twenty tool names — the six orchestration
-/// tools, the three bug-reporting tools, the six session-lifecycle tools, then
-/// the five console-facing tools (#1222 + the two #1220 config tools).
+/// are exactly NINE pre-existing tools and EIGHT session-lifecycle tools (six
+/// per-session #1221 + the two fleet-wide #1508 teardown verbs).
+/// What: a static slice of the twenty-two tool names — the six orchestration
+/// tools, the three bug-reporting tools, the eight session-lifecycle tools, then
+/// the five console-facing tools (#1222 + the two #1220 config tools + #1508).
 /// Test: `catalog_names_match_constant`.
-pub const TOOL_CATALOG: [&str; 20] = [
+pub const TOOL_CATALOG: [&str; 22] = [
     // ── 9 pre-existing tools (core.rs) ───────────────────────────────────────
     "session_list",
     "session_status",
@@ -41,13 +42,16 @@ pub const TOOL_CATALOG: [&str; 20] = [
     "list_recent_errors",
     "preview_bug_report",
     "report_bug",
-    // ── 6 new session-lifecycle tools (#1221, session.rs) ────────────────────
+    // ── 8 session-lifecycle tools (#1221 + #1508, session.rs) ────────────────
     "session_new",
     "session_stop",
     "session_resume",
     "session_decommission",
     "session_activity",
     "session_send",
+    // #1508 bulk teardown + by-state prune.
+    "session_decommission_ephemeral",
+    "session_prune",
     // ── 5 console-facing tools (#1222 + #1220, console.rs) ───────────────────
     "console_metrics",
     "supervisor_status",
@@ -63,8 +67,8 @@ pub const TOOL_CATALOG: [&str; 20] = [
 /// keeps the schemas and the dispatch argument-parsing in lockstep across both
 /// the core and session-lifecycle tool groups.
 /// What: concatenates [`core::core_tools`] (nine descriptors),
-/// [`session::session_tools`] (six descriptors), and [`console::console_tools`]
-/// (five descriptors) in catalog order, returning twenty
+/// [`session::session_tools`] (eight descriptors), and [`console::console_tools`]
+/// (five descriptors) in catalog order, returning twenty-two
 /// `{ name, description, inputSchema }` objects.
 /// Test: `catalog_has_expected_tool_count` and `every_tool_has_input_schema`.
 pub fn tool_catalog() -> Vec<Value> {
@@ -94,9 +98,9 @@ mod tests {
 
     #[test]
     fn catalog_has_expected_tool_count() {
-        // 9 pre-existing + 6 session-lifecycle + 5 console-facing tools = 20.
-        assert_eq!(tool_catalog().len(), 20);
-        assert_eq!(TOOL_CATALOG.len(), 20);
+        // 9 pre-existing + 8 session-lifecycle + 5 console-facing tools = 22.
+        assert_eq!(tool_catalog().len(), 22);
+        assert_eq!(TOOL_CATALOG.len(), 22);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/mcp/tools/session.rs
+++ b/crates/trusty-mpm/src/mcp/tools/session.rs
@@ -8,9 +8,10 @@
 //! existing [`crate::session_manager::SessionManager`] lifecycle ops that the
 //! HTTP `…/managed/*` routes already use, so the behaviour is identical across
 //! transports.
-//! What: [`session_tools`] returns the six `{ name, description, inputSchema }`
+//! What: [`session_tools`] returns the eight `{ name, description, inputSchema }`
 //! descriptors — `session_new`, `session_stop`, `session_resume`,
-//! `session_decommission`, `session_activity`, `session_send`. The shared
+//! `session_decommission`, `session_activity`, `session_send`, and the #1508
+//! fleet-wide `session_decommission_ephemeral` + `session_prune`. The shared
 //! [`tool`] builder is re-exported from the parent module.
 //! Test: `cargo test -p trusty-mpm` (in [`super`]) asserts the full catalog is
 //! well-formed and that each of these six names is present.
@@ -19,16 +20,20 @@ use serde_json::{Value, json};
 
 use super::tool;
 
-/// Build the six session-lifecycle tool descriptors.
+/// Build the eight session-lifecycle tool descriptors.
 ///
 /// Why: spawning, stopping, resuming, decommissioning, observing, and driving a
 /// managed session are the operations the driver skill needs; surfacing them as
-/// MCP tools removes the CLI-scraping defect. Keeping them in their own builder
-/// keeps `tools/core.rs` and this file each well under the 500-SLOC cap.
-/// What: returns the six descriptors in catalog order. `session_new` takes the
-/// repo/ref/task spawn inputs; the other five take a `session_id` (the managed
-/// UUID) plus operation-specific fields. Every schema sets
-/// `additionalProperties: false` so the driver gets a clear error on a typo.
+/// MCP tools removes the CLI-scraping defect. #1508 adds two fleet-wide teardown
+/// tools so a driver can clean up its throwaway test sessions and purge legacy
+/// tombstones without scraping the CLI. Keeping them in their own builder keeps
+/// `tools/core.rs` and this file each well under the 500-SLOC cap.
+/// What: returns the eight descriptors in catalog order. `session_new` takes the
+/// repo/ref/task spawn inputs (plus optional `ephemeral`); the per-session tools
+/// take a `session_id`; `session_decommission_ephemeral` takes no args; and
+/// `session_prune` takes a `state` filter plus `dry_run`/`include_active`. Every
+/// schema sets `additionalProperties: false` so the driver gets a clear error on a
+/// typo.
 /// Test: `super::tests::session_tools_present`,
 /// `super::tests::catalog_names_match_constant`.
 pub(super) fn session_tools() -> Vec<Value> {
@@ -64,6 +69,10 @@ pub(super) fn session_tools() -> Vec<Value> {
                         "type": "string",
                         "enum": ["claude-code", "tcode"],
                         "description": "Optional runtime backend; defaults to claude-code."
+                    },
+                    "ephemeral": {
+                        "type": "boolean",
+                        "description": "Tag this as an EPHEMERAL (test/throwaway) session eligible for bulk teardown and age-based auto-reap. Defaults to false (a durable session the automatic teardown paths never touch)."
                     }
                 },
                 "required": ["repo_url", "ref", "task"],
@@ -168,6 +177,49 @@ pub(super) fn session_tools() -> Vec<Value> {
                     }
                 },
                 "required": ["session_id", "text"],
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "session_decommission_ephemeral",
+            "Tear down EVERY ephemeral (test/throwaway) managed session in one \
+             shot: kill each runtime, remove its workspace, and tombstone the \
+             record. REAL sessions default `ephemeral=false` and are NEVER touched \
+             by this tool. Returns the count decommissioned. Use this from e2e \
+             harnesses or to clean up after a test run.",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "session_prune",
+            "Prune managed sessions by state and compact tombstones. `state` \
+             selects which records to target: `ephemeral` (test sessions), \
+             `stopped`, `decommissioned` (drop existing tombstones from the store), \
+             or `all` (every NON-running record). A RUNNING session is NEVER torn \
+             down unless `include_active` is true. With `dry_run` the tool REPORTS \
+             what would be pruned without mutating anything. This is the tool to \
+             purge legacy stale records that predate the ephemeral flag.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "state": {
+                        "type": "string",
+                        "enum": ["ephemeral", "stopped", "decommissioned", "all"],
+                        "description": "Which records to target."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "Report what WOULD be pruned without mutating anything (default false)."
+                    },
+                    "include_active": {
+                        "type": "boolean",
+                        "description": "Also tear down RUNNING (Active/Provisioning) sessions. Off by default — the fail-closed safety gate."
+                    }
+                },
+                "required": ["state"],
                 "additionalProperties": false
             }),
         ),

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -58,9 +58,11 @@ impl SessionManager {
     ///   adopts ANY name the operator names. The reconcile filter is left untouched.
     ///
     /// What: verifies the pane exists, rejects an already-tracked name, then upserts
-    /// an `Active` [`SessionRecord`] carrying the supplied `cwd`/`task`/`runtime`
-    /// (a fresh id, no workspace/repo/branch — provenance is unknown). Returns the
-    /// new record.
+    /// an `Active` [`SessionRecord`] carrying the supplied `cwd`/`task`/`runtime`/
+    /// `ephemeral` (a fresh id, no workspace/repo/branch — provenance is unknown).
+    /// `ephemeral` (#1508) tags a throwaway adoption (e.g. an e2e test pane) so the
+    /// auto-reap paths may decommission it; operator adoptions pass `false`.
+    /// Returns the new record.
     /// Test: `manager_adopt_existing_registers_active` (also asserts the returned
     /// record's `cwd` matches the adopted cwd),
     /// `manager_adopt_existing_missing_tmux_errors`,
@@ -73,6 +75,7 @@ impl SessionManager {
         cwd: PathBuf,
         task: String,
         runtime: crate::runtime::RuntimeKind,
+        ephemeral: bool,
     ) -> Result<SessionRecord, ManagedError> {
         // The pane MUST already exist — adoption connects, it does not spawn.
         // `tmux_driver()` is the public accessor over the shared driver Arc. This
@@ -97,6 +100,7 @@ impl SessionManager {
             proposed_default: None,
             correlation: Default::default(),
             runtime,
+            ephemeral,
         };
 
         // ── Atomic already-adopted check + upsert under ONE held write guard ──────

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -248,6 +248,7 @@ impl SessionManager {
             repo_url,
             branch,
             crate::runtime::RuntimeKind::default(),
+            false,
         )
         .await
     }
@@ -263,10 +264,13 @@ impl SessionManager {
     /// What: identical to [`create`] except the id and runtime backend are
     /// supplied by the caller. Creates the tmux session at `cwd` via the driver,
     /// persists a [`SessionRecord`] in state `Provisioning` carrying `runtime`,
-    /// and returns it.
+    /// and returns it. The `ephemeral` flag (#1508) tags test/throwaway sessions
+    /// so the bulk-teardown and age-based reap paths may decommission them
+    /// automatically; real callers pass `false`.
     /// Test: `spawn_session_tmux_cwd_is_workspace` in session_manager/tests.rs;
     /// `handler_spawn_creates_tmux_at_workspace_cwd` in session_manager_mvp.rs;
-    /// `manager_create_persists_runtime` in session_manager/tests.rs.
+    /// `manager_create_persists_runtime` in session_manager/tests.rs;
+    /// `manager_create_persists_ephemeral_flag` in session_manager/tests.rs.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_with_id(
         &self,
@@ -278,6 +282,7 @@ impl SessionManager {
         repo_url: Option<String>,
         branch: Option<String>,
         runtime: crate::runtime::RuntimeKind,
+        ephemeral: bool,
     ) -> Result<SessionRecord, ManagedError> {
         let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
         let tmux_name = if let Some(hint) = name_hint {
@@ -334,6 +339,7 @@ impl SessionManager {
             proposed_default: None,
             correlation,
             runtime,
+            ephemeral,
         };
 
         // Persist the record. On failure the freshly-created tmux session has
@@ -754,6 +760,9 @@ impl SessionManager {
                     // Externally-created tmux sessions have unknown provenance;
                     // assume the default (claude-code) backend.
                     runtime: crate::runtime::RuntimeKind::default(),
+                    // Adopted external sessions are NEVER ephemeral: their
+                    // provenance is unknown, so they must never be auto-reaped.
+                    ephemeral: false,
                 };
                 guard.upsert(external).await?;
                 report.external_adopted.push(name.clone());

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod adopt;
 pub mod manager;
+pub mod prune;
 pub mod record;
 pub mod session_guard;
 pub mod store;
@@ -23,6 +24,7 @@ mod tests;
 pub mod real_tmux;
 
 pub use manager::{ManagedError, ManagedTmuxDriver, ReconcileReport, SessionManager};
+pub use prune::{MAX_EPHEMERAL_AGE_HOURS, PruneAction, PruneFilter, PruneOutcome, PrunedSession};
 pub use record::{ManagedSessionId, ManagedSessionState, RecordError, SessionRecord};
 pub use session_guard::TmuxSessionGuard;
 pub use store::{SessionStore, StoreError};

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -1,0 +1,410 @@
+//! Bulk teardown + by-state pruning + tombstone compaction for managed sessions (#1508).
+//!
+//! Why: the `SessionRecord` store was monotonically append-only and accumulated
+//! 239 stale TEST sessions — `decommission` wrote a tombstone but never deleted,
+//! `store.remove()` was never called in production, and there was no test/ephemeral
+//! marker or bulk teardown. This module adds the two missing teardown verbs and the
+//! compaction pass so the store stops growing unbounded, all on top of the existing
+//! per-session [`SessionManager::decommission`] internals (tmux kill + workspace
+//! removal + tombstone). It lives in its own file so [`super::manager`] stays under
+//! the 500-SLOC production cap (mirroring [`super::adopt`]).
+//! What: [`PruneFilter`] (which records a prune targets), [`PruneAction`] /
+//! [`PrunedSession`] / [`PruneOutcome`] (what a prune did or WOULD do under
+//! `dry_run`), and an inherent `impl SessionManager` block adding
+//! [`SessionManager::decommission_all_ephemeral`] and the general
+//! [`SessionManager::prune_managed`].
+//! Test: `prune_*` in `super::tests`.
+
+use std::fmt;
+
+use chrono::{Duration, Utc};
+use tracing::{info, warn};
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// Maximum age an EPHEMERAL session may reach before the auto-reaper tears it
+/// down — default 24 hours (#1508).
+///
+/// Why: a panicking or abandoned e2e test can leave an ephemeral session behind
+/// even though the harness Drop-guard normally cleans it up; without a backstop
+/// these would accumulate exactly like the 239 legacy records this feature exists
+/// to prevent. 24h is long enough that no legitimate short-lived test session is
+/// ever caught, yet short enough that leaks are reclaimed within a day. ONLY
+/// `ephemeral == true` records are ever in scope — real sessions default `false`
+/// and are unreachable by this path, so the threshold can be aggressive without
+/// risking real work.
+/// What: a `chrono::Duration` of 24 hours; the reaper decommissions any
+/// `ephemeral` session whose `created_at` is older than `now - MAX_EPHEMERAL_AGE`.
+/// Test: `reap_aged_ephemeral_picks_old_ephemeral_only` drives both the "too
+/// young" and "non-ephemeral" exclusions against this threshold.
+pub const MAX_EPHEMERAL_AGE_HOURS: i64 = 24;
+
+/// Which managed-session records a prune targets (#1508).
+///
+/// Why: one teardown tool must serve BOTH the ephemeral-cleanup case (tear down
+/// every test session) AND the legacy-purge case (clear the 239 stale
+/// stopped/decommissioned records that predate the `ephemeral` flag). Modelling
+/// the target as a closed enum keeps the safety rule — never touch a RUNNING
+/// (`Active`/`Provisioning`) record unless explicitly forced — in one place.
+/// What: [`Ephemeral`](PruneFilter::Ephemeral) selects `ephemeral == true`
+/// non-terminal records; [`Stopped`](PruneFilter::Stopped) selects `Stopped`
+/// records; [`Decommissioned`](PruneFilter::Decommissioned) selects existing
+/// tombstones (for compaction only); [`All`](PruneFilter::All) selects every
+/// NON-running record (ephemeral + stopped + errored + decommissioned).
+/// Test: `prune_filter_parse_round_trip`, and the per-filter `prune_*` tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PruneFilter {
+    /// Only sessions tagged `ephemeral == true` (test/throwaway sessions).
+    Ephemeral,
+    /// Only `Stopped` sessions (runtime gone, workspace still on disk).
+    Stopped,
+    /// Only `Decommissioned` tombstones — compacted (removed) from the store.
+    Decommissioned,
+    /// Every NON-running record: ephemeral, stopped, errored, and decommissioned.
+    All,
+}
+
+impl PruneFilter {
+    /// Parse a CLI/wire string into a [`PruneFilter`].
+    ///
+    /// Why: the CLI `--state` flag, the HTTP body, and the MCP tool all accept the
+    /// same lowercase spellings; centralising the parse keeps them consistent and
+    /// rejects typos with a single actionable message.
+    /// What: maps `ephemeral`/`stopped`/`decommissioned`/`all` (case-insensitive,
+    /// trimmed) to the matching variant; anything else is an `Err` naming the
+    /// supported values.
+    /// Test: `prune_filter_parse_round_trip` (covers both the round-trip and the
+    /// garbage-rejection case).
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "ephemeral" => Ok(Self::Ephemeral),
+            "stopped" => Ok(Self::Stopped),
+            "decommissioned" => Ok(Self::Decommissioned),
+            "all" => Ok(Self::All),
+            other => Err(format!(
+                "unknown prune filter `{other}` (expected: ephemeral | stopped | decommissioned | all)"
+            )),
+        }
+    }
+
+    /// The canonical lowercase name of this filter.
+    ///
+    /// Why: responses echo the filter back so callers can confirm what ran.
+    /// What: the inverse of [`parse`](Self::parse).
+    /// Test: `prune_filter_parse_round_trip`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ephemeral => "ephemeral",
+            Self::Stopped => "stopped",
+            Self::Decommissioned => "decommissioned",
+            Self::All => "all",
+        }
+    }
+}
+
+impl fmt::Display for PruneFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// What a prune did (or WOULD do under `dry_run`) to a single record (#1508).
+///
+/// Why: `decommission` (tear down a live/stopped session) and `remove` (drop an
+/// existing tombstone from the store) are semantically distinct outcomes; the
+/// caller wants to know which happened per session so a dry-run report is precise.
+/// What: [`Decommissioned`](PruneAction::Decommissioned) — killed runtime +
+/// removed workspace + tombstoned; [`Removed`](PruneAction::Removed) — an existing
+/// `Decommissioned` tombstone was deleted from the store (compaction).
+/// Test: asserted by `decommission_all_ephemeral_ignores_non_ephemeral` (the
+/// `Decommissioned` action) and `prune_decommissioned_compacts` (the `Removed`
+/// action).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PruneAction {
+    /// The session was torn down (runtime killed, workspace removed, tombstoned).
+    Decommissioned,
+    /// An existing tombstone was deleted from the store (compaction).
+    Removed,
+}
+
+impl PruneAction {
+    /// The canonical lowercase name of this action (for wire/log rendering).
+    ///
+    /// Why: HTTP/MCP responses and the CLI dry-run render the action per row.
+    /// What: `Decommissioned` → `"decommissioned"`, `Removed` → `"removed"`.
+    /// Test: `prune_outcome_serializes`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Decommissioned => "decommissioned",
+            Self::Removed => "removed",
+        }
+    }
+}
+
+/// One record a prune touched (or would touch), with enough identity to report.
+///
+/// Why: a dry-run must show the operator EXACTLY which sessions are in scope —
+/// id, tmux name, and prior state — before anything is destroyed.
+/// What: the session id, tmux name, the state the record was in, and the
+/// [`PruneAction`] applied (or that would be applied under `dry_run`).
+/// Test: `prune_dry_run_reports_without_mutating`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PrunedSession {
+    /// Managed session id (UUID string).
+    pub id: String,
+    /// tmux session name.
+    pub tmux_name: String,
+    /// The lifecycle state the record was in before the prune.
+    pub state: String,
+    /// What the prune did (or would do under `dry_run`).
+    pub action: PruneAction,
+}
+
+/// The result of a prune: which sessions were (or would be) affected (#1508).
+///
+/// Why: the CLI, HTTP, and MCP surfaces all need a structured, serializable
+/// summary that works for BOTH a real run and a `dry_run` preview.
+/// What: `dry_run` (true → nothing was mutated), the targeted `filter`, and the
+/// per-session [`PrunedSession`] list. `count()` is the total affected.
+/// Test: `prune_outcome_serializes`, `prune_dry_run_reports_without_mutating`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PruneOutcome {
+    /// True when this was a preview — no record was killed, removed, or tombstoned.
+    pub dry_run: bool,
+    /// The filter that selected the affected records.
+    pub filter: String,
+    /// Every session affected (or that would be affected under `dry_run`).
+    pub sessions: Vec<PrunedSession>,
+}
+
+impl PruneOutcome {
+    /// Number of sessions affected (or that would be affected).
+    ///
+    /// Why: callers log/print "pruned N sessions" without re-deriving the length.
+    /// What: returns `self.sessions.len()`.
+    /// Test: `decommission_all_ephemeral_ignores_non_ephemeral` (asserts the count).
+    pub fn count(&self) -> usize {
+        self.sessions.len()
+    }
+}
+
+/// Whether a record is currently RUNNING (must not be auto-torn-down).
+///
+/// Why: the core #1508 safety invariant — a prune must NEVER kill an
+/// `Active`/`Provisioning` session unless the operator explicitly forces it. This
+/// single predicate is the fail-closed gate every filter consults.
+/// What: returns true for `Active` and `Provisioning`; false for `Stopped`,
+/// `Errored`, and `Decommissioned`.
+/// Test: `prune_by_state_never_touches_active`.
+fn is_running(state: &ManagedSessionState) -> bool {
+    matches!(
+        state,
+        ManagedSessionState::Active | ManagedSessionState::Provisioning
+    )
+}
+
+/// Whether a record matches a prune `filter` (ignoring the running-state guard).
+///
+/// Why: keeping the match logic separate from the running-state safety gate keeps
+/// each rule readable and individually testable.
+/// What: `Ephemeral` → `ephemeral && state != Decommissioned`; `Stopped` →
+/// `state == Stopped`; `Decommissioned` → `state == Decommissioned`; `All` → any
+/// non-running record (the caller still applies [`is_running`] as the final gate).
+/// Test: the per-filter `prune_*` tests.
+fn matches_filter(record: &SessionRecord, filter: PruneFilter) -> bool {
+    match filter {
+        PruneFilter::Ephemeral => {
+            record.ephemeral && record.state != ManagedSessionState::Decommissioned
+        }
+        PruneFilter::Stopped => record.state == ManagedSessionState::Stopped,
+        PruneFilter::Decommissioned => record.state == ManagedSessionState::Decommissioned,
+        PruneFilter::All => true,
+    }
+}
+
+impl SessionManager {
+    /// Tear down EVERY ephemeral session — bulk teardown (#1508).
+    ///
+    /// Why: e2e harnesses (and any operator who tagged test sessions) need a
+    /// one-shot "clean up all my throwaway sessions" verb that reuses the existing
+    /// per-session [`decommission`](SessionManager::decommission) internals (tmux
+    /// kill + workspace removal + tombstone). REAL sessions default
+    /// `ephemeral == false` and so are unreachable here — the safety invariant.
+    /// What: convenience wrapper over [`prune_managed`](Self::prune_managed) with
+    /// `PruneFilter::Ephemeral`, not a dry run, never touching running sessions
+    /// (a running ephemeral session is decommissioned like any other — `decommission`
+    /// itself kills the runtime first). Returns the count of sessions decommissioned.
+    /// Test: `decommission_all_ephemeral_ignores_non_ephemeral` (asserts the
+    /// ephemeral-only decommission path and the non-ephemeral safety exclusion).
+    pub async fn decommission_all_ephemeral(&self) -> Result<usize, ManagedError> {
+        // Ephemeral sessions are throwaway by definition: include running ones so a
+        // panicking test that left an Active ephemeral session is still cleaned up.
+        let outcome = self
+            .prune_managed(PruneFilter::Ephemeral, false, true)
+            .await?;
+        Ok(outcome.count())
+    }
+
+    /// Prune managed sessions by state — bulk teardown + compaction (#1508).
+    ///
+    /// Why: ONE tool must (a) tear down all ephemeral/stopped sessions and (b)
+    /// compact the store by dropping decommissioned tombstones, so the legacy 239
+    /// stale records can be purged with the SAME verb that cleans up test sessions.
+    /// It is the engine behind `decommission_all_ephemeral`, the `tm sessions prune`
+    /// CLI verb, the prune HTTP route, and the prune MCP tool.
+    ///
+    /// SAFETY (the #1508 invariant): a RUNNING record (`Active`/`Provisioning`) is
+    /// NEVER killed or removed unless `include_active` is explicitly `true`. The
+    /// `Decommissioned` filter only ever removes tombstones (it cannot reach a
+    /// running record by construction).
+    ///
+    /// What: snapshots `store.all()`, selects records that both
+    /// [`matches_filter`] AND pass the running-state gate (unless `include_active`),
+    /// then per record —
+    /// - a non-`Decommissioned` match → [`decommission`](Self::decommission) it
+    ///   (kill runtime + remove workspace + tombstone) → [`PruneAction::Decommissioned`];
+    /// - a `Decommissioned` match → [`SessionStore::remove`] it from the store
+    ///   (compaction) → [`PruneAction::Removed`].
+    ///
+    /// When `dry_run` is true NOTHING is mutated — the returned [`PruneOutcome`]
+    /// lists what WOULD happen. A per-session failure is logged and skipped (the
+    /// sweep is best-effort, like the orphan-GC) so one stuck session cannot block
+    /// the rest of a legacy purge.
+    /// Test: `decommission_all_ephemeral_ignores_non_ephemeral` (ephemeral path),
+    /// `prune_by_state_never_touches_active` (Stopped→Decommissioned + the
+    /// running-state safety gate), `prune_decommissioned_compacts` (compaction),
+    /// `prune_all_targets_non_running`, `prune_dry_run_reports_without_mutating`.
+    pub async fn prune_managed(
+        &self,
+        filter: PruneFilter,
+        dry_run: bool,
+        include_active: bool,
+    ) -> Result<PruneOutcome, ManagedError> {
+        // Snapshot the full set ONCE (reloads-on-read so out-of-process writes are
+        // seen). We then mutate per record below, each of which re-reads/saves.
+        let all = self.store.write().await.all().await?;
+
+        // Select the in-scope records, applying the running-state safety gate.
+        let targets: Vec<SessionRecord> = all
+            .into_iter()
+            .filter(|r| matches_filter(r, filter))
+            .filter(|r| include_active || !is_running(&r.state))
+            .collect();
+
+        let mut sessions = Vec::with_capacity(targets.len());
+        for record in targets {
+            let is_tombstone = record.state == ManagedSessionState::Decommissioned;
+            let action = if is_tombstone {
+                PruneAction::Removed
+            } else {
+                PruneAction::Decommissioned
+            };
+
+            if !dry_run {
+                if is_tombstone {
+                    // Compaction: drop the tombstone from the store entirely.
+                    if let Err(e) = self.store.write().await.remove(&record.id).await {
+                        warn!(id = %record.id, "prune: compaction remove failed: {e}; skipping");
+                        continue;
+                    }
+                } else if let Err(e) = self.decommission(&record.id).await {
+                    warn!(id = %record.id, "prune: decommission failed: {e}; skipping");
+                    continue;
+                }
+            }
+
+            sessions.push(PrunedSession {
+                id: record.id.to_string(),
+                tmux_name: record.tmux_name.clone(),
+                state: record.state.to_string(),
+                action,
+            });
+        }
+
+        if dry_run {
+            info!(
+                filter = %filter,
+                count = sessions.len(),
+                "prune (dry-run): reporting candidates, no mutation"
+            );
+        } else {
+            info!(
+                filter = %filter,
+                count = sessions.len(),
+                "prune: applied teardown/compaction"
+            );
+        }
+
+        Ok(PruneOutcome {
+            dry_run,
+            filter: filter.as_str().to_string(),
+            sessions,
+        })
+    }
+
+    /// Remove a single decommissioned tombstone from the store (#1508).
+    ///
+    /// Why: the age-based reaper and any caller that has just decommissioned a
+    /// record may want it gone from `sessions.json` rather than left as a tombstone,
+    /// so the file stops growing unbounded. This is the single-record compaction
+    /// primitive [`prune_managed`](Self::prune_managed) uses for the
+    /// `Decommissioned` filter, exposed for direct callers.
+    /// What: removes the record keyed by `id` via [`SessionStore::remove`] and
+    /// persists. A not-present id is a no-op warning inside `remove`.
+    /// Test: `compact_record_removes_from_store`.
+    pub async fn compact_record(&self, id: &ManagedSessionId) -> Result<(), ManagedError> {
+        self.store.write().await.remove(id).await?;
+        Ok(())
+    }
+
+    /// Age-based auto-reap of stale ephemeral sessions (#1508).
+    ///
+    /// Why: a panicking or abandoned e2e test can leave an ephemeral session behind
+    /// despite the harness Drop-guard. Without a backstop these leak exactly like
+    /// the 239 legacy records this feature prevents. The orphan-GC loop calls this
+    /// each sweep so leaked test sessions are reclaimed within
+    /// [`MAX_EPHEMERAL_AGE_HOURS`].
+    ///
+    /// SAFETY: only `ephemeral == true` records are EVER in scope — real sessions
+    /// default `false` and are unreachable by this path. State is irrelevant
+    /// (a stuck Active ephemeral session past the age cutoff is reaped too, since
+    /// `decommission` kills the runtime first).
+    /// What: takes `max_age` as a parameter (for deterministic tests), snapshots the
+    /// store, selects `ephemeral && created_at < now - max_age`, and decommissions
+    /// each (best-effort; a per-session failure is logged and skipped). Returns the
+    /// count reaped and logs the tmux names so the sweep is visible in daemon logs.
+    /// Test: `reap_aged_ephemeral_picks_old_ephemeral_only`.
+    pub async fn reap_aged_ephemeral(&self, max_age: Duration) -> Result<usize, ManagedError> {
+        let cutoff = Utc::now() - max_age;
+        let all = self.store.write().await.all().await?;
+        let stale: Vec<SessionRecord> = all
+            .into_iter()
+            .filter(|r| {
+                r.ephemeral
+                    && r.state != ManagedSessionState::Decommissioned
+                    && r.created_at < cutoff
+            })
+            .collect();
+
+        let mut reaped = 0usize;
+        for record in stale {
+            match self.decommission(&record.id).await {
+                Ok(_) => {
+                    reaped += 1;
+                    info!(
+                        id = %record.id,
+                        name = %record.tmux_name,
+                        created_at = %record.created_at.to_rfc3339(),
+                        "auto-reap: decommissioned stale ephemeral session"
+                    );
+                }
+                Err(e) => {
+                    warn!(id = %record.id, "auto-reap: decommission failed: {e}; skipping");
+                }
+            }
+        }
+        Ok(reaped)
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -284,7 +284,13 @@ impl SessionManager {
     ) -> Result<PruneOutcome, ManagedError> {
         // Snapshot the full set ONCE (reloads-on-read so out-of-process writes are
         // seen). We then mutate per record below, each of which re-reads/saves.
-        let all = self.store.write().await.all().await?;
+        //
+        // Pick up any out-of-process write under a brief write lock (the reload is
+        // `&mut`), then drop it and take the read-only snapshot under a READ lock so
+        // the (in-memory) `cached_all()` clone never blocks concurrent store readers
+        // (#1508 review fix). `cached_all()` is `&self` and does no I/O.
+        self.store.write().await.reload_if_changed().await?;
+        let all = self.store.read().await.cached_all();
 
         // Select the in-scope records, applying the running-state safety gate.
         let targets: Vec<SessionRecord> = all
@@ -378,7 +384,11 @@ impl SessionManager {
     /// Test: `reap_aged_ephemeral_picks_old_ephemeral_only`.
     pub async fn reap_aged_ephemeral(&self, max_age: Duration) -> Result<usize, ManagedError> {
         let cutoff = Utc::now() - max_age;
-        let all = self.store.write().await.all().await?;
+        // Reload under a brief write lock (the reload is `&mut`), then snapshot under
+        // a READ lock via the in-memory, I/O-free `cached_all()` so the snapshot
+        // clone never blocks concurrent store readers (#1508 review fix).
+        self.store.write().await.reload_if_changed().await?;
+        let all = self.store.read().await.cached_all();
         let stale: Vec<SessionRecord> = all
             .into_iter()
             .filter(|r| {

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -177,6 +177,22 @@ pub struct SessionRecord {
     /// old sessions resume on Claude Code exactly as before.
     #[serde(default)]
     pub runtime: crate::runtime::RuntimeKind,
+    /// Whether this session is EPHEMERAL — a test / throwaway session that the
+    /// bulk-teardown and age-based auto-reap paths may decommission automatically.
+    ///
+    /// Why (#1508): the store was monotonically append-only and accumulated 239
+    /// stale TEST sessions because there was no way to mark a session as
+    /// throwaway and no bulk teardown. Tagging a session at creation lets
+    /// [`SessionManager::decommission_all_ephemeral`] and the age-based reaper
+    /// target ONLY test sessions — REAL sessions default `false` and so are
+    /// unreachable by either automatic path (the core safety invariant).
+    ///
+    /// `#[serde(default)]` (→ `false`) keeps the 239 legacy records — and every
+    /// other pre-#1508 record — deserializable: they load as non-ephemeral, so an
+    /// automatic teardown never touches them (the explicit by-state prune is the
+    /// tool for purging those legacy tombstones).
+    #[serde(default)]
+    pub ephemeral: bool,
 }
 
 /// Error types for session record operations.
@@ -237,6 +253,7 @@ mod tests {
             proposed_default: None,
             correlation: Default::default(),
             runtime: Default::default(),
+            ephemeral: false,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -264,6 +281,7 @@ mod tests {
             proposed_default: None,
             correlation: Default::default(),
             runtime: Default::default(),
+            ephemeral: false,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -289,6 +307,7 @@ mod tests {
             proposed_default: None,
             correlation: Default::default(),
             runtime: Default::default(),
+            ephemeral: false,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -339,10 +358,65 @@ mod tests {
             proposed_default: None,
             correlation: Default::default(),
             runtime: Default::default(),
+            ephemeral: false,
         };
         record.runtime = crate::runtime::RuntimeKind::Tcode;
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.runtime, crate::runtime::RuntimeKind::Tcode);
+    }
+
+    #[test]
+    fn record_without_ephemeral_field_defaults_to_false() {
+        // Why (#1508): the 239 legacy records — and every other pre-#1508 record —
+        // have no `ephemeral` key; they MUST deserialize as non-ephemeral so the
+        // automatic teardown/auto-reap paths never touch them. This pins the
+        // `#[serde(default)]` → false backward-compat contract.
+        let legacy_json = serde_json::json!({
+            "id": ManagedSessionId::new(),
+            "tmux_name": "tmpm-legacy",
+            "cwd": "/tmp",
+            "task": "legacy task",
+            "state": "stopped",
+            "created_at": Utc::now().to_rfc3339(),
+            "last_activity_at": null,
+            "workspace_path": null,
+            "repo_url": null,
+            "branch": null,
+            "pending_decision": null,
+            "proposed_default": null
+        })
+        .to_string();
+        let back: SessionRecord = serde_json::from_str(&legacy_json).expect("deserialize legacy");
+        assert!(
+            !back.ephemeral,
+            "a record with no `ephemeral` key must default to false (non-ephemeral)"
+        );
+    }
+
+    #[test]
+    fn record_round_trips_ephemeral_true() {
+        // Why (#1508): a session tagged ephemeral at creation must persist the flag
+        // so the bulk-teardown + age-based reap paths can later target it.
+        let record = SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-ephemeral".into(),
+            cwd: PathBuf::from("/tmp"),
+            task: "throwaway".into(),
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: true,
+        };
+        let json = serde_json::to_string(&record).expect("serialize");
+        let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.ephemeral, "ephemeral=true must round-trip");
     }
 }

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -364,6 +364,7 @@ mod tests {
             proposed_default: None,
             correlation: Default::default(),
             runtime: Default::default(),
+            ephemeral: false,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -539,6 +539,7 @@ async fn manager_reconcile_gone_tmux_yields_stopped() {
         proposed_default: None,
         correlation: Default::default(),
         runtime: Default::default(),
+        ephemeral: false,
     };
     // A record whose tmux session will NOT be found (simulating reboot).
     let rebooted_record = SessionRecord {
@@ -556,6 +557,7 @@ async fn manager_reconcile_gone_tmux_yields_stopped() {
         proposed_default: None,
         correlation: Default::default(),
         runtime: Default::default(),
+        ephemeral: false,
     };
     {
         let mut store = mgr.store.write().await;
@@ -615,6 +617,7 @@ async fn manager_reconcile_skips_decommissioned() {
         proposed_default: None,
         correlation: Default::default(),
         runtime: Default::default(),
+        ephemeral: false,
     };
     {
         let mut store = mgr.store.write().await;
@@ -845,6 +848,7 @@ async fn spawn_session_tmux_cwd_is_workspace() {
             Some("https://github.com/owner/repo".into()),
             Some("main".into()),
             crate::runtime::RuntimeKind::default(),
+            false,
         )
         .await
         .expect("create_with_id");
@@ -937,6 +941,7 @@ async fn manager_create_persists_runtime() {
             None,
             None,
             crate::runtime::RuntimeKind::Tcode,
+            false,
         )
         .await
         .expect("create_with_id");
@@ -1050,6 +1055,7 @@ async fn manager_adopt_existing_registers_active() {
             PathBuf::from("/Users/op/work/proj"),
             "drive my hand-started session".into(),
             crate::runtime::RuntimeKind::default(),
+            false,
         )
         .await
         .expect("adopt existing");
@@ -1090,6 +1096,7 @@ async fn manager_adopt_existing_missing_tmux_errors() {
             PathBuf::from("/tmp/x"),
             String::new(),
             crate::runtime::RuntimeKind::default(),
+            false,
         )
         .await
         .expect_err("adopting a nonexistent pane must fail");
@@ -1121,6 +1128,7 @@ async fn manager_adopt_existing_double_adopt_errors() {
         PathBuf::from("/tmp/once"),
         String::new(),
         crate::runtime::RuntimeKind::default(),
+        false,
     )
     .await
     .expect("first adopt succeeds");
@@ -1131,6 +1139,7 @@ async fn manager_adopt_existing_double_adopt_errors() {
             PathBuf::from("/tmp/once"),
             String::new(),
             crate::runtime::RuntimeKind::default(),
+            false,
         )
         .await
         .expect_err("second adopt of the same pane must fail");
@@ -1165,6 +1174,7 @@ async fn manager_adopt_existing_allows_non_tmpm_name() {
             PathBuf::from("/Users/op/repo"),
             "adopt non-prefixed".into(),
             crate::runtime::RuntimeKind::default(),
+            false,
         )
         .await
         .expect("non-tmpm names are adoptable on the explicit path");
@@ -1277,5 +1287,500 @@ async fn manager_get_returns_last_known_on_reload_error() {
             Err(ManagedError::SessionNotFound(_))
         ),
         "an unknown id must still yield SessionNotFound"
+    );
+}
+
+// ── #1508: ephemeral tagging, bulk teardown, by-state prune, compaction ─────────
+
+/// Seed a record DIRECTLY into the store with explicit state/ephemeral flags.
+///
+/// Why: the prune tests need records in arbitrary lifecycle states (Stopped,
+/// Decommissioned, …) and ephemeral flags without driving the full create/stop
+/// ritual; upserting a hand-built record is the cheapest way to set up the matrix.
+/// What: builds a `SessionRecord` with the given id/state/ephemeral and a
+/// workspace path that actually exists on disk (so a real decommission can remove
+/// it), upserts it, and returns the workspace path for assertions.
+/// Test: used by the prune tests below.
+async fn seed_record(
+    mgr: &SessionManager,
+    root: &TempDir,
+    id: ManagedSessionId,
+    state: ManagedSessionState,
+    ephemeral: bool,
+) -> PathBuf {
+    let ws = root.path().join(format!("ws-{id}"));
+    // Decommissioned tombstones carry NO workspace (it was already removed); every
+    // other state keeps a real on-disk dir so a teardown can remove it.
+    let workspace_path = if state == ManagedSessionState::Decommissioned {
+        None
+    } else {
+        std::fs::create_dir_all(&ws).expect("mk ws");
+        Some(ws.clone())
+    };
+    let record = SessionRecord {
+        id,
+        tmux_name: format!("tmpm-seed-{id}"),
+        cwd: root.path().to_path_buf(),
+        task: "seed".into(),
+        state,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral,
+    };
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("seed upsert");
+    ws
+}
+
+/// `create_with_id` persists the caller-supplied `ephemeral` flag (#1508).
+///
+/// Why: the flag is the foundation of the whole feature — it must round-trip
+/// through the create path onto the persisted record.
+/// What: creates one session with `ephemeral=true` and one with `false`, then
+/// reads each back and asserts the flag survived.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_create_persists_ephemeral_flag() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let eph = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "ephemeral task".into(),
+            Some(PathBuf::from("/tmp/eph")),
+            None,
+            None,
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            true,
+        )
+        .await
+        .expect("create ephemeral");
+    let durable = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "durable task".into(),
+            Some(PathBuf::from("/tmp/dur")),
+            None,
+            None,
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+        )
+        .await
+        .expect("create durable");
+
+    assert!(
+        mgr.get(&eph.id).await.unwrap().ephemeral,
+        "ephemeral flag persisted"
+    );
+    assert!(
+        !mgr.get(&durable.id).await.unwrap().ephemeral,
+        "durable stays false"
+    );
+}
+
+/// `adopt_existing` persists the caller-supplied `ephemeral` flag (#1508).
+///
+/// Why: the e2e harness adopts panes as ephemeral; the flag must reach the record.
+/// What: seeds a live pane, adopts it with `ephemeral=true`, asserts it persisted.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_persists_ephemeral_flag() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("tmpm-eph-adopt".into());
+
+    let record = mgr
+        .adopt_existing(
+            "tmpm-eph-adopt",
+            PathBuf::from("/tmp/adopt"),
+            "throwaway adopt".into(),
+            crate::runtime::RuntimeKind::default(),
+            true,
+        )
+        .await
+        .expect("adopt ephemeral");
+
+    assert!(
+        mgr.get(&record.id).await.unwrap().ephemeral,
+        "adopted ephemeral flag persisted"
+    );
+}
+
+/// `decommission_all_ephemeral` tears down ONLY ephemeral sessions (#1508).
+///
+/// Why: the core safety invariant — REAL (non-ephemeral) sessions must never be
+/// touched by the bulk-teardown path.
+/// What: seeds two ephemeral (Active + Stopped) and two durable (Active + Stopped)
+/// sessions, runs the bulk teardown, and asserts only the two ephemeral records
+/// became Decommissioned while the two durable records are untouched.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_all_ephemeral_ignores_non_ephemeral() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let eph_active = ManagedSessionId::new();
+    let eph_stopped = ManagedSessionId::new();
+    let dur_active = ManagedSessionId::new();
+    let dur_stopped = ManagedSessionId::new();
+    seed_record(&mgr, &dir, eph_active, ManagedSessionState::Active, true).await;
+    seed_record(&mgr, &dir, eph_stopped, ManagedSessionState::Stopped, true).await;
+    seed_record(&mgr, &dir, dur_active, ManagedSessionState::Active, false).await;
+    seed_record(&mgr, &dir, dur_stopped, ManagedSessionState::Stopped, false).await;
+
+    let count = mgr
+        .decommission_all_ephemeral()
+        .await
+        .expect("bulk teardown");
+    assert_eq!(count, 2, "exactly the two ephemeral sessions are torn down");
+
+    assert_eq!(
+        mgr.get(&eph_active).await.unwrap().state,
+        ManagedSessionState::Decommissioned
+    );
+    assert_eq!(
+        mgr.get(&eph_stopped).await.unwrap().state,
+        ManagedSessionState::Decommissioned
+    );
+    // Durable sessions are untouched.
+    assert_eq!(
+        mgr.get(&dur_active).await.unwrap().state,
+        ManagedSessionState::Active
+    );
+    assert_eq!(
+        mgr.get(&dur_stopped).await.unwrap().state,
+        ManagedSessionState::Stopped
+    );
+}
+
+/// The by-state Stopped prune NEVER touches a running (Active) session (#1508).
+///
+/// Why: clearing legacy stopped/decommissioned records must not risk reaping a
+/// live session. `include_active=false` is the fail-closed default.
+/// What: seeds an Active and a Stopped session, prunes `Stopped`, asserts only the
+/// Stopped one is decommissioned and the Active one is left running.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_by_state_never_touches_active() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let active = ManagedSessionId::new();
+    let stopped = ManagedSessionId::new();
+    seed_record(&mgr, &dir, active, ManagedSessionState::Active, false).await;
+    seed_record(&mgr, &dir, stopped, ManagedSessionState::Stopped, false).await;
+
+    let outcome = mgr
+        .prune_managed(crate::session_manager::PruneFilter::Stopped, false, false)
+        .await
+        .expect("prune stopped");
+    assert_eq!(outcome.count(), 1, "only the Stopped session is pruned");
+    assert_eq!(
+        mgr.get(&active).await.unwrap().state,
+        ManagedSessionState::Active,
+        "the Active session must be untouched"
+    );
+    assert_eq!(
+        mgr.get(&stopped).await.unwrap().state,
+        ManagedSessionState::Decommissioned
+    );
+}
+
+/// The Decommissioned prune COMPACTS the store (removes tombstones) (#1508).
+///
+/// Why: tombstones accumulated unbounded; the compaction pass must actually delete
+/// them from sessions.json so the file stops growing.
+/// What: seeds two Decommissioned tombstones + one Stopped session, prunes
+/// `Decommissioned`, and asserts both tombstones are GONE from the store while the
+/// Stopped session remains.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_decommissioned_compacts() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let t1 = ManagedSessionId::new();
+    let t2 = ManagedSessionId::new();
+    let stopped = ManagedSessionId::new();
+    seed_record(&mgr, &dir, t1, ManagedSessionState::Decommissioned, false).await;
+    seed_record(&mgr, &dir, t2, ManagedSessionState::Decommissioned, false).await;
+    seed_record(&mgr, &dir, stopped, ManagedSessionState::Stopped, false).await;
+
+    let outcome = mgr
+        .prune_managed(
+            crate::session_manager::PruneFilter::Decommissioned,
+            false,
+            false,
+        )
+        .await
+        .expect("compact");
+    assert_eq!(outcome.count(), 2, "both tombstones compacted");
+    assert!(
+        outcome
+            .sessions
+            .iter()
+            .all(|s| s.action == crate::session_manager::PruneAction::Removed),
+        "decommissioned prune reports Removed"
+    );
+
+    // Both tombstones are GONE from the store; the Stopped record survives.
+    assert!(matches!(
+        mgr.get(&t1).await,
+        Err(ManagedError::SessionNotFound(_))
+    ));
+    assert!(matches!(
+        mgr.get(&t2).await,
+        Err(ManagedError::SessionNotFound(_))
+    ));
+    assert_eq!(
+        mgr.list().await.len(),
+        1,
+        "only the Stopped session remains"
+    );
+}
+
+/// `All` targets every NON-running record (#1508).
+///
+/// Why: the legacy purge needs ONE sweep that tears down stopped/errored/ephemeral
+/// AND compacts decommissioned, while leaving running sessions alone.
+/// What: seeds Active + Stopped + Errored + Decommissioned, prunes `All`, and
+/// asserts the Active is untouched, Stopped/Errored became Decommissioned, and the
+/// pre-existing tombstone was removed.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_all_targets_non_running() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let active = ManagedSessionId::new();
+    let stopped = ManagedSessionId::new();
+    let errored = ManagedSessionId::new();
+    let tomb = ManagedSessionId::new();
+    seed_record(&mgr, &dir, active, ManagedSessionState::Active, false).await;
+    seed_record(&mgr, &dir, stopped, ManagedSessionState::Stopped, false).await;
+    seed_record(&mgr, &dir, errored, ManagedSessionState::Errored, false).await;
+    seed_record(&mgr, &dir, tomb, ManagedSessionState::Decommissioned, false).await;
+
+    let outcome = mgr
+        .prune_managed(crate::session_manager::PruneFilter::All, false, false)
+        .await
+        .expect("prune all");
+    assert_eq!(
+        outcome.count(),
+        3,
+        "stopped + errored + tombstone (not active)"
+    );
+
+    assert_eq!(
+        mgr.get(&active).await.unwrap().state,
+        ManagedSessionState::Active,
+        "running session is never touched by All"
+    );
+    assert_eq!(
+        mgr.get(&stopped).await.unwrap().state,
+        ManagedSessionState::Decommissioned
+    );
+    assert_eq!(
+        mgr.get(&errored).await.unwrap().state,
+        ManagedSessionState::Decommissioned
+    );
+    assert!(matches!(
+        mgr.get(&tomb).await,
+        Err(ManagedError::SessionNotFound(_))
+    ));
+}
+
+/// A dry-run reports candidates WITHOUT mutating anything (#1508).
+///
+/// Why: the operator must be able to preview a legacy purge before destroying
+/// records. `--dry-run` must be side-effect free.
+/// What: seeds a Stopped session, prunes `Stopped` with `dry_run=true`, asserts the
+/// outcome lists it but the record is STILL Stopped afterward.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_dry_run_reports_without_mutating() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let stopped = ManagedSessionId::new();
+    seed_record(&mgr, &dir, stopped, ManagedSessionState::Stopped, false).await;
+
+    let outcome = mgr
+        .prune_managed(crate::session_manager::PruneFilter::Stopped, true, false)
+        .await
+        .expect("dry run");
+    assert!(outcome.dry_run, "outcome flagged dry_run");
+    assert_eq!(outcome.count(), 1, "candidate reported");
+    // The record must be UNCHANGED after a dry run.
+    assert_eq!(
+        mgr.get(&stopped).await.unwrap().state,
+        ManagedSessionState::Stopped,
+        "dry run must not mutate the record"
+    );
+}
+
+/// `PruneFilter::parse` round-trips and rejects garbage (#1508).
+///
+/// Why: the CLI/HTTP/MCP surfaces all parse the same spellings; a typo must be a
+/// clear error, not a silent default.
+/// What: parses every valid spelling (asserting `as_str` round-trips) and asserts
+/// an unknown value errors.
+/// Test: this function IS the test.
+#[test]
+fn prune_filter_parse_round_trip() {
+    use crate::session_manager::PruneFilter;
+    for f in [
+        PruneFilter::Ephemeral,
+        PruneFilter::Stopped,
+        PruneFilter::Decommissioned,
+        PruneFilter::All,
+    ] {
+        assert_eq!(PruneFilter::parse(f.as_str()).unwrap(), f);
+    }
+    assert_eq!(
+        PruneFilter::parse("EPHEMERAL ").unwrap(),
+        PruneFilter::Ephemeral
+    );
+    assert!(PruneFilter::parse("bogus").is_err());
+}
+
+/// `PruneOutcome`/`PruneAction` serialize to the wire shape the HTTP+MCP surfaces
+/// expect (#1508).
+///
+/// Why: the dry-run/report JSON must carry `dry_run`, `filter`, and per-session
+/// `action` so callers can render a precise preview; a serde regression would
+/// silently change the wire contract.
+/// What: builds an outcome, serializes it, and asserts the key fields/strings.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_outcome_serializes() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let id = ManagedSessionId::new();
+    seed_record(&mgr, &dir, id, ManagedSessionState::Stopped, true).await;
+
+    let outcome = mgr
+        .prune_managed(crate::session_manager::PruneFilter::Ephemeral, true, false)
+        .await
+        .expect("dry run");
+    let v = serde_json::to_value(&outcome).expect("serialize outcome");
+    assert_eq!(v["dry_run"], serde_json::json!(true));
+    assert_eq!(v["filter"], serde_json::json!("ephemeral"));
+    assert_eq!(
+        v["sessions"][0]["action"],
+        serde_json::json!("decommissioned")
+    );
+}
+
+/// `compact_record` deletes a tombstone from the store (#1508).
+///
+/// Why: the single-record compaction primitive must actually remove the record so
+/// the age-based reaper / prune can shrink sessions.json.
+/// What: seeds a Decommissioned tombstone, compacts it, asserts it is gone.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn compact_record_removes_from_store() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let id = ManagedSessionId::new();
+    seed_record(&mgr, &dir, id, ManagedSessionState::Decommissioned, false).await;
+
+    mgr.compact_record(&id).await.expect("compact");
+    assert!(matches!(
+        mgr.get(&id).await,
+        Err(ManagedError::SessionNotFound(_))
+    ));
+}
+
+/// Age-based auto-reap targets ONLY old EPHEMERAL sessions (#1508).
+///
+/// Why: the backstop must reclaim leaked test sessions older than the threshold
+/// WITHOUT ever touching a real (non-ephemeral) session or a young ephemeral one.
+/// What: seeds (a) an OLD ephemeral, (b) a YOUNG ephemeral, (c) an OLD durable, and
+/// reaps with a 1-hour threshold. Only (a) must be decommissioned.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reap_aged_ephemeral_picks_old_ephemeral_only() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    // Helper: seed a record with an explicit created_at + ephemeral flag.
+    async fn seed_aged(
+        mgr: &SessionManager,
+        root: &TempDir,
+        id: ManagedSessionId,
+        created_at: chrono::DateTime<Utc>,
+        ephemeral: bool,
+    ) {
+        let ws = root.path().join(format!("aged-{id}"));
+        std::fs::create_dir_all(&ws).expect("mk ws");
+        let record = SessionRecord {
+            id,
+            tmux_name: format!("tmpm-aged-{id}"),
+            cwd: root.path().to_path_buf(),
+            task: "aged".into(),
+            state: ManagedSessionState::Active,
+            created_at,
+            last_activity_at: None,
+            workspace_path: Some(ws),
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral,
+        };
+        mgr.store.write().await.upsert(record).await.expect("seed");
+    }
+
+    let old_eph = ManagedSessionId::new();
+    let young_eph = ManagedSessionId::new();
+    let old_durable = ManagedSessionId::new();
+    let two_hours_ago = Utc::now() - chrono::Duration::hours(2);
+    let now = Utc::now();
+    seed_aged(&mgr, &dir, old_eph, two_hours_ago, true).await;
+    seed_aged(&mgr, &dir, young_eph, now, true).await;
+    seed_aged(&mgr, &dir, old_durable, two_hours_ago, false).await;
+
+    let reaped = mgr
+        .reap_aged_ephemeral(chrono::Duration::hours(1))
+        .await
+        .expect("reap");
+    assert_eq!(reaped, 1, "only the OLD ephemeral session is reaped");
+
+    assert_eq!(
+        mgr.get(&old_eph).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "old ephemeral was reaped"
+    );
+    assert_eq!(
+        mgr.get(&young_eph).await.unwrap().state,
+        ManagedSessionState::Active,
+        "young ephemeral is below the age threshold"
+    );
+    assert_eq!(
+        mgr.get(&old_durable).await.unwrap().state,
+        ManagedSessionState::Active,
+        "a non-ephemeral session is NEVER reaped by age"
     );
 }

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -172,6 +172,7 @@ async fn seed_sessions(
             proposed_default: None,
             correlation: Default::default(),
             runtime: Default::default(),
+            ephemeral: false,
         };
         store.upsert(rec).await.expect("seed upsert");
         ids.push(id);
@@ -297,6 +298,7 @@ fn rec(state: ManagedSessionState, pending: Option<&str>) -> SessionRecord {
         proposed_default: None,
         correlation: Default::default(),
         runtime: Default::default(),
+        ephemeral: false,
     }
 }
 

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -529,6 +529,7 @@ async fn handler_spawn_creates_tmux_at_workspace_cwd() {
             Some(repo_url.into()),
             Some(git_ref.into()),
             trusty_mpm::runtime::RuntimeKind::default(),
+            false,
         )
         .await
         .expect("create_with_id");
@@ -672,6 +673,7 @@ async fn tcode_session_spawns_and_accepts_commands() {
             Some("https://github.com/owner/repo".into()),
             Some("main".into()),
             RuntimeKind::Tcode,
+            false,
         )
         .await
         .expect("create_with_id");
@@ -805,6 +807,7 @@ async fn resume_managed_typed_invalid_state_is_conflict() {
             Some("https://example.com/r.git".to_string()),
             Some("main".to_string()),
             ResumeRuntimeKind::default(),
+            false,
         )
         .await
         .expect("seed session");
@@ -856,6 +859,7 @@ async fn front_gate_answer_unblocks_spawn() {
             Some("https://github.com/owner/repo".to_string()),
             Some("main".to_string()),
             ResumeRuntimeKind::default(),
+            false,
         )
         .await
         .expect("seed session");
@@ -962,5 +966,198 @@ fn cli_prune_idle_unreachable_exit_code() {
     assert!(
         stdout.contains("\"sm_available\": false"),
         "expected sm_available:false in JSON, got: {stdout}"
+    );
+}
+
+// ── #1508: HTTP route tests for the bulk-teardown + by-state prune endpoints ──
+//
+// These call the route handlers directly with axum's `State`/`Json` extractors
+// (the same pattern as the typed `resume_managed` tests above) against a hermetic
+// `DaemonState`, then decode the JSON response body. They seed real sessions via
+// `create_with_id` (so they exercise the genuine store + decommission engine) and
+// reap each tmux session on exit via `reap_on_drop`.
+
+/// Decode an axum `impl IntoResponse` into `(StatusCode, serde_json::Value)`.
+///
+/// Why: the prune route handlers return `impl IntoResponse`; a route test must
+/// inspect both the status and the JSON body. Centralising the body-read keeps
+/// each test focused on its assertion.
+/// What: converts the response, reads the full body to bytes, and parses it as
+/// JSON (an empty/non-JSON body yields `Value::Null`).
+/// Test: used by the `*_route_*` tests below.
+async fn decode_response(
+    resp: impl axum::response::IntoResponse,
+) -> (axum::http::StatusCode, serde_json::Value) {
+    let resp = resp.into_response();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, value)
+}
+
+/// POST …/decommission-ephemeral tears down ONLY ephemeral sessions (#1508).
+///
+/// Why: the HTTP surface must honour the same safety invariant as the engine —
+/// REAL (non-ephemeral) sessions are never touched by the bulk-teardown route.
+/// What: seeds two ephemeral and one durable session through the daemon's manager,
+/// calls [`decommission_ephemeral_route`], asserts the response reports
+/// `decommissioned == 2`, and confirms the durable session is left untouched.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_ephemeral_route_tears_down_only_ephemeral() {
+    use trusty_mpm::daemon::managed_routes::decommission_ephemeral_route;
+    use trusty_mpm::session_manager::ManagedSessionState;
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(root.path().to_path_buf()));
+    let mgr = state.session_manager().await;
+
+    // Seed two ephemeral + one durable session. `create_with_id` starts each in
+    // Provisioning (running); the bulk-teardown intentionally includes running
+    // ephemerals, so both ephemeral records are torn down and the durable is not.
+    let mut seeded = Vec::new();
+    for (label, ephemeral) in [("eph-a", true), ("eph-b", true), ("durable", false)] {
+        let id = ResumeSessionId::new();
+        let ws = root.path().join(format!("{id}-{label}"));
+        let rec = mgr
+            .create_with_id(
+                id,
+                format!("route test {label}"),
+                Some(ws.clone()),
+                None,
+                Some(ws),
+                Some("https://example.com/r.git".to_string()),
+                Some("main".to_string()),
+                ResumeRuntimeKind::default(),
+                ephemeral,
+            )
+            .await
+            .expect("seed session");
+        seeded.push((rec, ephemeral));
+    }
+    // Reap every tmux session this test created, on success/failure/panic.
+    let _reapers: Vec<TmuxSessionGuard> = {
+        let mut v = Vec::new();
+        for (rec, _) in &seeded {
+            v.push(reap_on_drop(&state, &rec.tmux_name).await);
+        }
+        v
+    };
+
+    let (status, body) =
+        decode_response(decommission_ephemeral_route(axum::extract::State(state.clone())).await)
+            .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(
+        body["decommissioned"], 2,
+        "exactly the two ephemeral sessions are torn down, got {body}"
+    );
+
+    // The durable session must remain (NOT Decommissioned).
+    let durable = seeded
+        .iter()
+        .find(|(_, eph)| !eph)
+        .map(|(r, _)| r.id)
+        .expect("durable seeded");
+    assert_ne!(
+        mgr.get(&durable).await.expect("get durable").state,
+        ManagedSessionState::Decommissioned,
+        "the durable session must never be touched by the ephemeral teardown route"
+    );
+}
+
+/// POST …/prune with `dry_run` REPORTS candidates and mutates NOTHING (#1508).
+///
+/// Why: a dry-run is the operator's safe preview before a destructive purge; the
+/// route must echo the candidates without changing any record.
+/// What: seeds one ephemeral session, calls [`prune_managed_route`] with
+/// `state=ephemeral, dry_run=true`, asserts the body reports `dry_run:true` with
+/// one candidate, and confirms the session is still its original (non-terminal)
+/// state afterwards.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_route_dry_run_reports() {
+    use trusty_mpm::daemon::managed_routes::{PruneRequest, prune_managed_route};
+    use trusty_mpm::session_manager::ManagedSessionState;
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(root.path().to_path_buf()));
+    let mgr = state.session_manager().await;
+
+    let id = ResumeSessionId::new();
+    let ws = root.path().join(format!("{id}-dryrun"));
+    let rec = mgr
+        .create_with_id(
+            id,
+            "dry-run candidate".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws),
+            Some("https://example.com/r.git".to_string()),
+            Some("main".to_string()),
+            ResumeRuntimeKind::default(),
+            true,
+        )
+        .await
+        .expect("seed ephemeral");
+    let _reaper = reap_on_drop(&state, &rec.tmux_name).await;
+    let before = mgr.get(&id).await.expect("get before").state;
+
+    let req = serde_json::from_value::<PruneRequest>(serde_json::json!({
+        "state": "ephemeral",
+        "dry_run": true,
+        // Provisioning is a running state; include it so the dry-run still lists
+        // the freshly-created candidate (a real purge would pass false here).
+        "include_active": true,
+    }))
+    .expect("build request");
+    let (status, body) = decode_response(
+        prune_managed_route(axum::extract::State(state.clone()), axum::Json(req)).await,
+    )
+    .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(body["dry_run"], serde_json::json!(true));
+    assert_eq!(body["filter"], serde_json::json!("ephemeral"));
+    assert_eq!(
+        body["sessions"].as_array().map(|a| a.len()),
+        Some(1),
+        "dry-run lists the one ephemeral candidate, got {body}"
+    );
+    // Nothing was mutated: the session is still in its pre-prune state.
+    assert_eq!(
+        mgr.get(&id).await.expect("get after").state,
+        before,
+        "a dry-run must NOT change any record's state"
+    );
+    assert_ne!(before, ManagedSessionState::Decommissioned);
+}
+
+/// POST …/prune with an unknown `state` returns 400 (#1508).
+///
+/// Why: a typo'd filter must be a loud, actionable error — never a silent default
+/// to a destructive scope.
+/// What: posts `state=garbage` to [`prune_managed_route`] and asserts a
+/// `400 Bad Request`. No session is seeded — the parse rejection happens before
+/// any store access.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_route_rejects_bad_state() {
+    use trusty_mpm::daemon::managed_routes::{PruneRequest, prune_managed_route};
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(root.path().to_path_buf()));
+
+    let req = serde_json::from_value::<PruneRequest>(serde_json::json!({ "state": "garbage" }))
+        .expect("build request");
+    let (status, _body) =
+        decode_response(prune_managed_route(axum::extract::State(state), axum::Json(req)).await)
+            .await;
+    assert_eq!(
+        status,
+        axum::http::StatusCode::BAD_REQUEST,
+        "an unknown prune filter must yield 400"
     );
 }


### PR DESCRIPTION
## What
Adds a full lifecycle for test/ephemeral managed sessions so they stop accumulating in `~/.trusty-mpm/session-manager/sessions.json` (which had grown to 239 stale records). The System-B project-session registry (GET /sessions, live Claude Code clients) is untouched.

### 1. Tagging
`#[serde(default)] ephemeral: bool` on `SessionRecord` (serde-default so all existing records deserialize as false). Threaded `ephemeral: Option<bool>` through every creation seam: SpawnRequest, AdoptExistingRequest, SpawnParams, MCP session_new, SM LaunchParams, and create_with_id / adopt_existing.

### 2. Bulk teardown + by-state prune
- `decommission_all_ephemeral()` — tears down only ephemeral, non-terminal records.
- `prune_managed(filter, dry_run, include_active)` with `PruneFilter{Ephemeral,Stopped,Decommissioned,All}`; fail-closed `is_running` gate never touches Active/Provisioning without explicit `--include-active`.
- Surfaces: CLI (`tm sessions decommission-ephemeral`, `tm sessions prune --state <…> [--dry-run] [--include-active]`), HTTP (`POST /api/v1/sessions/managed/decommission-ephemeral`, `POST /api/v1/sessions/managed/prune`), MCP (`session_decommission_ephemeral`, `session_prune`).

### 3. Compaction
Decommission/prune now actually `store.remove()` terminal records (+ compact existing tombstones) so sessions.json stops growing. `stop` stays resumable (Stopped, kept); `decommission` is terminal and removable.

### 4. e2e harness cleanup
New managed-route tests tag sessions `ephemeral: true` and reap via a panic-safe Drop guard.

### 5. Age-based auto-reap
`reap_aged_ephemeral` in the GC loop decommissions `ephemeral && created_at < now - MAX_EPHEMERAL_AGE_HOURS` (24h). Real sessions default ephemeral=false and are unreachable by this path.

## Tests
19 new/affected unit tests (ephemeral round-trips, prune-never-touches-active, compaction removes tombstones, age reap selection, dry-run mutates nothing) + CLI parse tests. clippy `-D warnings`, `fmt --check`, line-cap all clean. Note: the new HTTP route integration tests hit the known local tokio-1.95 runtime-drop artifact (as do pre-existing tests in the same file); CI on pinned 1.91 is authoritative.

Closes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)