### PR TITLE
fix(trusty-mpm): guard decommission against deleting non-owned workspaces (P0, closes #1511)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
@@ -209,6 +209,7 @@ pub(crate) async fn launch_and_wait(
             None,
             RuntimeKind::ClaudeCode,
             false,
+            false, // not SM-owned: meta-launch uses an existing local dir (#1511)
         )
         .await
         .context("failed to create the tmux session for the metaharness")?;

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -140,6 +140,10 @@ pub async fn spawn_managed(
     })?;
 
     // Step 2: create the tmux session rooted at the provisioned workspace.
+    // `owned=true` is set ATOMICALLY at record creation (#1511): the SM
+    // provisioned this directory via git clone, so decommission may remove it.
+    // Local-path spawn and adopt_existing pass `owned=false`; they are never
+    // eligible for automatic disk deletion.
     let mgr = state.session_manager().await;
     let record = mgr
         .create_with_id(
@@ -152,20 +156,13 @@ pub async fn spawn_managed(
             Some(params.git_ref.clone()),
             runtime,
             params.ephemeral.unwrap_or(false),
+            true, // owned: SM provisioned via git clone
         )
         .await
         .map_err(|e| {
             warn!(id = %session_id, "spawn_managed: session create failed: {e}");
             e.to_string()
         })?;
-
-    // Step 2a: mark the workspace as SM-owned (#1511). The SM provisioned
-    // this directory via git clone — decommission is allowed to remove it.
-    // Local-path spawn and adopt_existing never reach this path and therefore
-    // never set workspace_owned = true; they remain unowned → never deleted.
-    if let Err(e) = mgr.set_workspace_owned(&record.id, true).await {
-        warn!(id = %record.id, "spawn_managed: set_workspace_owned failed: {e}");
-    }
 
     // Step 2.5 — INTENT-CONFORMANCE FRONT GATE (#1360, spec §5.1).
     //
@@ -279,6 +276,7 @@ async fn spawn_managed_local(
             None,
             runtime,
             params.ephemeral.unwrap_or(false),
+            false, // owned: local-path spawn never owns the directory (#1511)
         )
         .await
         .map_err(|e| {

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -159,6 +159,14 @@ pub async fn spawn_managed(
             e.to_string()
         })?;
 
+    // Step 2a: mark the workspace as SM-owned (#1511). The SM provisioned
+    // this directory via git clone — decommission is allowed to remove it.
+    // Local-path spawn and adopt_existing never reach this path and therefore
+    // never set workspace_owned = true; they remain unowned → never deleted.
+    if let Err(e) = mgr.set_workspace_owned(&record.id, true).await {
+        warn!(id = %record.id, "spawn_managed: set_workspace_owned failed: {e}");
+    }
+
     // Step 2.5 — INTENT-CONFORMANCE FRONT GATE (#1360, spec §5.1).
     //
     // Between record-creation and `adapter.spawn`, resolve the ticket+spec intent

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -101,6 +101,9 @@ impl SessionManager {
             correlation: Default::default(),
             runtime,
             ephemeral,
+            // Adopted sessions point at a pre-existing pane: the SM did NOT
+            // create the workspace, so decommission must never delete it (#1511).
+            workspace_owned: false,
         };
 
         // ── Atomic already-adopted check + upsert under ONE held write guard ──────

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -4,13 +4,15 @@
 //! from `manager.rs` to keep that file under the 500-SLOC production cap,
 //! mirroring the pattern used by `adopt.rs` and `prune.rs`. The decommission
 //! logic is also a natural home for the ownership-tracking primitive.
-//! What: two inherent `impl SessionManager` methods —
-//! [`SessionManager::decommission`] (full teardown with the #1511 dual guard)
-//! and [`SessionManager::set_workspace_owned`] (marks a workspace as
-//! SM-provisioned after a git clone).
+//! What: public [`SessionManager::decommission`] (full teardown with the #1511
+//! dual guard), internal [`SessionManager::decommission_with_root`] (injectable
+//! managed-root for test isolation without env mutation), and
+//! [`SessionManager::set_workspace_owned`] (marks a workspace as SM-provisioned).
 //! Test: `manager_decommission_removes_workspace`,
 //! `manager_decommission_unowned_skips_deletion`,
 //! `workspace_owned_flag_round_trips_via_set` in `super::tests`.
+
+use std::path::Path;
 
 use tracing::{info, warn};
 
@@ -43,14 +45,33 @@ impl SessionManager {
     /// transitions the record to `Decommissioned` and returns successfully — the
     /// session becomes unreachable without deleting the user's directory.
     ///
-    /// What: kills the tmux session (best-effort), evaluates the two-condition
-    /// deletion gate, removes the workspace directory when it is safe to do so,
-    /// clears `workspace_path` on the record, marks it `Decommissioned`, persists.
+    /// What: delegates to [`decommission_with_root`](Self::decommission_with_root)
+    /// with the config-derived managed root so callers remain env-agnostic.
     /// Test: `manager_decommission_removes_workspace` — asserts the workspace dir
     /// is gone from disk and the record state is `Decommissioned`.
     /// `manager_decommission_unowned_skips_deletion` — asserts that decommissioning
     /// a local-path/adopt record does NOT delete the directory.
     pub async fn decommission(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
+        let config = TrustyToolsConfig::load();
+        let managed_root = workspace_root(&config);
+        self.decommission_with_root(id, &managed_root).await
+    }
+
+    /// Internal: decommission with an explicit managed root (test seam).
+    ///
+    /// Why: tests need to inject a temp directory as the managed root to keep the
+    /// containment guard working without mutating process-global env vars
+    /// (`TRUSTY_MPM_WORKSPACE_ROOT`). Env mutation is thread-unsafe and pollutes
+    /// parallel tests; injecting the root avoids that entirely.
+    /// What: identical teardown logic as the public `decommission` but resolves the
+    /// managed root from the caller-supplied `managed_root` instead of the config.
+    /// Test: called by `manager_decommission_removes_workspace` (which passes a
+    /// TempDir as the managed root, removing the need for `set_var`).
+    pub(crate) async fn decommission_with_root(
+        &self,
+        id: &ManagedSessionId,
+        managed_root: &Path,
+    ) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
 
         // Kill the runtime (best-effort).
@@ -72,36 +93,43 @@ impl SessionManager {
                      created by the session manager"
                 );
             } else {
-                // Owned: apply the belt-and-suspenders path-containment guard.
-                let config = TrustyToolsConfig::load();
-                let managed_root = workspace_root(&config);
-
-                if !is_safe_to_remove(ws, &managed_root) {
-                    warn!(
+                // Owned workspace: check existence first so a path that is
+                // already gone is not misreported as a containment failure.
+                if !ws.exists() {
+                    // Benign: the workspace was removed before decommission ran
+                    // (e.g. a prior partial teardown). The tombstone is still
+                    // written below; no further disk action is needed.
+                    tracing::debug!(
                         id = %id,
                         workspace = %ws.display(),
-                        root = %managed_root.display(),
-                        "decommission: skipping workspace removal — path fails \
-                         containment guard (outside managed root or unsafe path)"
-                    );
-                } else if ws.exists() {
-                    std::fs::remove_dir_all(ws).map_err(|e| {
-                        ManagedError::Io(std::io::Error::new(
-                            e.kind(),
-                            format!("remove workspace {:?}: {e}", ws),
-                        ))
-                    })?;
-                    info!(
-                        id = %id,
-                        workspace = %ws.display(),
-                        "decommission: owned workspace removed from disk"
+                        "decommission: owned workspace already absent — skipping removal"
                     );
                 } else {
-                    warn!(
-                        id = %id,
-                        workspace = %ws.display(),
-                        "decommission: workspace path absent (already removed?)"
-                    );
+                    // Workspace exists: apply the belt-and-suspenders
+                    // path-containment guard before touching the filesystem.
+                    // Only paths that exist but are OUTSIDE the managed root
+                    // (or are otherwise unsafe) reach this warning.
+                    if !is_safe_to_remove(ws, managed_root) {
+                        warn!(
+                            id = %id,
+                            workspace = %ws.display(),
+                            root = %managed_root.display(),
+                            "decommission: skipping workspace removal — path fails \
+                             containment guard (outside managed root or unsafe path)"
+                        );
+                    } else {
+                        std::fs::remove_dir_all(ws).map_err(|e| {
+                            ManagedError::Io(std::io::Error::new(
+                                e.kind(),
+                                format!("remove workspace {:?}: {e}", ws),
+                            ))
+                        })?;
+                        info!(
+                            id = %id,
+                            workspace = %ws.display(),
+                            "decommission: owned workspace removed from disk"
+                        );
+                    }
                 }
             }
         }

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -1,0 +1,140 @@
+//! Decommission and workspace-ownership methods for the session manager (#1511).
+//!
+//! Why: `decommission` and the companion `set_workspace_owned` are extracted
+//! from `manager.rs` to keep that file under the 500-SLOC production cap,
+//! mirroring the pattern used by `adopt.rs` and `prune.rs`. The decommission
+//! logic is also a natural home for the ownership-tracking primitive.
+//! What: two inherent `impl SessionManager` methods —
+//! [`SessionManager::decommission`] (full teardown with the #1511 dual guard)
+//! and [`SessionManager::set_workspace_owned`] (marks a workspace as
+//! SM-provisioned after a git clone).
+//! Test: `manager_decommission_removes_workspace`,
+//! `manager_decommission_unowned_skips_deletion`,
+//! `workspace_owned_flag_round_trips_via_set` in `super::tests`.
+
+use tracing::{info, warn};
+
+use crate::core::trusty_tools_config::{TrustyToolsConfig, workspace_root};
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use super::workspace_guard::is_safe_to_remove;
+
+impl SessionManager {
+    /// Decommission a session: stop the runtime, remove the workspace from disk
+    /// (ONLY if the SM provisioned it), and mark the record `Decommissioned`.
+    ///
+    /// Why: the only full teardown operation. Unlike `stop`, this removes the
+    /// workspace directory from disk so no future `resume` is possible. A
+    /// tombstone record is kept in the store so `ls` can show history.
+    ///
+    /// Safety (#1511): `remove_dir_all` is executed ONLY when BOTH conditions hold:
+    /// (a) `record.workspace_owned == true` — the SM provisioned (cloned) the
+    ///     directory and is the rightful owner; local-path spawn (#1502) and
+    ///     `adopt_existing` (#1433) leave `workspace_owned = false` so they are
+    ///     NEVER deleted by this path.
+    /// (b) `is_safe_to_remove(workspace_path, managed_root)` — the canonicalized
+    ///     path is strictly INSIDE the SM's managed workspace root, rejecting any
+    ///     path outside it (including `$HOME`, volume roots, and paths with too
+    ///     few components). This belt-and-suspenders guard catches stale/incorrect
+    ///     `workspace_owned` flags before disk mutation occurs.
+    ///
+    /// When deletion is skipped (unowned or unsafe path), decommission still
+    /// transitions the record to `Decommissioned` and returns successfully — the
+    /// session becomes unreachable without deleting the user's directory.
+    ///
+    /// What: kills the tmux session (best-effort), evaluates the two-condition
+    /// deletion gate, removes the workspace directory when it is safe to do so,
+    /// clears `workspace_path` on the record, marks it `Decommissioned`, persists.
+    /// Test: `manager_decommission_removes_workspace` — asserts the workspace dir
+    /// is gone from disk and the record state is `Decommissioned`.
+    /// `manager_decommission_unowned_skips_deletion` — asserts that decommissioning
+    /// a local-path/adopt record does NOT delete the directory.
+    pub async fn decommission(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
+        let mut record = self.get(id).await?;
+
+        // Kill the runtime (best-effort).
+        if self.tmux.session_exists(&record.tmux_name)
+            && let Err(e) = self.tmux.kill_session(&record.tmux_name)
+        {
+            warn!(name = %record.tmux_name, "decommission: kill_session failed: {e}");
+        }
+
+        // Guard: only remove the workspace directory if the SM provisioned it.
+        if let Some(ref ws) = record.workspace_path {
+            if !record.workspace_owned {
+                // Unowned workspace (local-path spawn or adopt): never delete.
+                warn!(
+                    id = %id,
+                    workspace = %ws.display(),
+                    "decommission: skipping workspace removal — not SM-owned \
+                     (local-path or adopted session); the directory was NOT \
+                     created by the session manager"
+                );
+            } else {
+                // Owned: apply the belt-and-suspenders path-containment guard.
+                let config = TrustyToolsConfig::load();
+                let managed_root = workspace_root(&config);
+
+                if !is_safe_to_remove(ws, &managed_root) {
+                    warn!(
+                        id = %id,
+                        workspace = %ws.display(),
+                        root = %managed_root.display(),
+                        "decommission: skipping workspace removal — path fails \
+                         containment guard (outside managed root or unsafe path)"
+                    );
+                } else if ws.exists() {
+                    std::fs::remove_dir_all(ws).map_err(|e| {
+                        ManagedError::Io(std::io::Error::new(
+                            e.kind(),
+                            format!("remove workspace {:?}: {e}", ws),
+                        ))
+                    })?;
+                    info!(
+                        id = %id,
+                        workspace = %ws.display(),
+                        "decommission: owned workspace removed from disk"
+                    );
+                } else {
+                    warn!(
+                        id = %id,
+                        workspace = %ws.display(),
+                        "decommission: workspace path absent (already removed?)"
+                    );
+                }
+            }
+        }
+
+        // Tombstone: clear workspace_path, mark Decommissioned, persist.
+        record.workspace_path = None;
+        record.workspace_owned = false;
+        record.state = ManagedSessionState::Decommissioned;
+        self.store.write().await.upsert(record.clone()).await?;
+        info!(id = %id, name = %record.tmux_name, "managed session decommissioned");
+        Ok(record)
+    }
+
+    /// Mark a session's workspace as SM-owned (provisioned by clone) or unowned.
+    ///
+    /// Why (#1511): the decommission path must know whether the SM provisioned the
+    /// `workspace_path` (and therefore may `remove_dir_all` it) or whether the path
+    /// is a real, pre-existing user directory (local-path spawn, adopt) that must
+    /// NEVER be deleted. Setting `workspace_owned = true` is the explicit assertion
+    /// that this SM cloned the workspace; `false` (the serde default) means "do not
+    /// touch this directory on decommission." Callers that use the local-path spawn
+    /// or `adopt_existing` path MUST NOT call this method (or call it with `false`).
+    /// What: looks up the record, sets `workspace_owned`, and persists.
+    /// Test: `workspace_owned_flag_round_trips_via_set` + the decommission guard
+    /// tests in `session_manager/tests.rs`.
+    pub async fn set_workspace_owned(
+        &self,
+        id: &ManagedSessionId,
+        owned: bool,
+    ) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.workspace_owned = owned;
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -185,7 +185,8 @@ pub struct SessionManager {
     /// Persisted session store; `pub(crate)` for test helpers that need to
     /// seed internal state without going through the public API.
     pub(crate) store: Arc<RwLock<SessionStore>>,
-    tmux: Arc<dyn ManagedTmuxDriver>,
+    /// tmux driver; `pub(crate)` for the decommission / adopt sibling modules.
+    pub(crate) tmux: Arc<dyn ManagedTmuxDriver>,
     data_dir: PathBuf,
 }
 
@@ -340,6 +341,10 @@ impl SessionManager {
             correlation,
             runtime,
             ephemeral,
+            // Default to unowned: callers that provisioned the workspace via
+            // git clone MUST call `set_workspace_owned(id, true)` afterward.
+            // Local-path spawn (#1502) and adopt (#1433) never set this to true.
+            workspace_owned: false,
         };
 
         // Persist the record. On failure the freshly-created tmux session has
@@ -634,50 +639,6 @@ impl SessionManager {
         Ok(record)
     }
 
-    /// Decommission a session: stop the runtime, remove the workspace from disk,
-    /// and mark the record `Decommissioned`.
-    ///
-    /// Why: the only full teardown operation. Unlike `stop`, this removes the
-    /// workspace directory from disk so no future `resume` is possible. A
-    /// tombstone record is kept in the store so `ls` can show history.
-    /// What: kills the tmux session (best-effort), removes the workspace directory
-    /// via `std::fs::remove_dir_all` when `workspace_path` is set, clears
-    /// `workspace_path` on the record, marks it `Decommissioned`, and persists.
-    /// Test: `manager_decommission_removes_workspace` — asserts the workspace dir
-    /// is gone from disk and the record state is `Decommissioned`.
-    pub async fn decommission(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
-        let mut record = self.get(id).await?;
-
-        // Kill the runtime (best-effort).
-        if self.tmux.session_exists(&record.tmux_name)
-            && let Err(e) = self.tmux.kill_session(&record.tmux_name)
-        {
-            warn!(name = %record.tmux_name, "decommission: kill_session failed: {e}");
-        }
-
-        // Remove the workspace directory from disk.
-        if let Some(ref ws) = record.workspace_path {
-            if ws.exists() {
-                std::fs::remove_dir_all(ws).map_err(|e| {
-                    ManagedError::Io(std::io::Error::new(
-                        e.kind(),
-                        format!("remove workspace {:?}: {e}", ws),
-                    ))
-                })?;
-                info!(id = %id, workspace = %ws.display(), "decommission: workspace removed from disk");
-            } else {
-                warn!(id = %id, workspace = %ws.display(), "decommission: workspace path absent (already removed?)");
-            }
-        }
-
-        // Tombstone: clear workspace_path, mark Decommissioned, persist.
-        record.workspace_path = None;
-        record.state = ManagedSessionState::Decommissioned;
-        self.store.write().await.upsert(record.clone()).await?;
-        info!(id = %id, name = %record.tmux_name, "managed session decommissioned");
-        Ok(record)
-    }
-
     /// Reconcile daemon state against live tmux sessions after a restart.
     ///
     /// Why: the daemon may have crashed or been restarted while sessions were
@@ -763,6 +724,10 @@ impl SessionManager {
                     // Adopted external sessions are NEVER ephemeral: their
                     // provenance is unknown, so they must never be auto-reaped.
                     ephemeral: false,
+                    // Externally-adopted sessions are NEVER SM-owned — the SM
+                    // did not create the workspace; decommission must not delete
+                    // it (#1511).
+                    workspace_owned: false,
                 };
                 guard.upsert(external).await?;
                 report.external_adopted.push(name.clone());

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -250,6 +250,7 @@ impl SessionManager {
             branch,
             crate::runtime::RuntimeKind::default(),
             false,
+            false,
         )
         .await
     }
@@ -267,7 +268,9 @@ impl SessionManager {
     /// persists a [`SessionRecord`] in state `Provisioning` carrying `runtime`,
     /// and returns it. The `ephemeral` flag (#1508) tags test/throwaway sessions
     /// so the bulk-teardown and age-based reap paths may decommission them
-    /// automatically; real callers pass `false`.
+    /// automatically; real callers pass `false`. The `owned` flag (#1511) must be
+    /// `true` ONLY when the SM provisioned the workspace via git clone; local-path
+    /// spawn, adopt, and reconcile all pass `false` (safe default — never delete).
     /// Test: `spawn_session_tmux_cwd_is_workspace` in session_manager/tests.rs;
     /// `handler_spawn_creates_tmux_at_workspace_cwd` in session_manager_mvp.rs;
     /// `manager_create_persists_runtime` in session_manager/tests.rs;
@@ -284,6 +287,7 @@ impl SessionManager {
         branch: Option<String>,
         runtime: crate::runtime::RuntimeKind,
         ephemeral: bool,
+        owned: bool,
     ) -> Result<SessionRecord, ManagedError> {
         let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
         let tmux_name = if let Some(hint) = name_hint {
@@ -341,10 +345,11 @@ impl SessionManager {
             correlation,
             runtime,
             ephemeral,
-            // Default to unowned: callers that provisioned the workspace via
-            // git clone MUST call `set_workspace_owned(id, true)` afterward.
-            // Local-path spawn (#1502) and adopt (#1433) never set this to true.
-            workspace_owned: false,
+            // Ownership is set atomically at creation: `true` ONLY when the SM
+            // provisioned the workspace via git clone; local-path spawn (#1502),
+            // adopt (#1433), and reconcile all pass `false` (safe default —
+            // prefer NOT deleting over accidental deletion).
+            workspace_owned: owned,
         };
 
         // Persist the record. On failure the freshly-created tmux session has

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -9,11 +9,13 @@
 //! tested in `manager::tests`.
 
 pub mod adopt;
+pub mod decommission;
 pub mod manager;
 pub mod prune;
 pub mod record;
 pub mod session_guard;
 pub mod store;
+pub mod workspace_guard;
 
 #[cfg(test)]
 mod tests;

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -193,6 +193,25 @@ pub struct SessionRecord {
     /// tool for purging those legacy tombstones).
     #[serde(default)]
     pub ephemeral: bool,
+
+    /// Whether the SM **provisioned** (cloned/created) the `workspace_path` itself.
+    ///
+    /// Why (#1511): `decommission` previously `remove_dir_all`'d `workspace_path`
+    /// unconditionally, which deleted a real user repository when the #1502
+    /// local-path spawn set `workspace_path` to a pre-existing on-disk directory.
+    /// This flag marks ownership: `true` ONLY when the SM provisioned the directory
+    /// via a git clone (the normal `SpawnParams` + `WorkspaceProvisioner` path);
+    /// `false` for local-path spawn (#1502), explicit `adopt_existing` (#1433), and
+    /// every legacy record (safe default — prefer NOT deleting over accidental
+    /// deletion). The decommission path checks this flag BEFORE calling
+    /// `remove_dir_all`, so a local-path or adopted workspace is never deleted.
+    ///
+    /// `#[serde(default)]` (→ `false`) ensures every pre-#1511 record deserializes
+    /// as UNOWNED: legacy records are treated as not-owned → never auto-deleted,
+    /// which is the safe direction — a "lost" workspace can be cleaned up manually;
+    /// an accidentally deleted live repo cannot be un-deleted.
+    #[serde(default)]
+    pub workspace_owned: bool,
 }
 
 /// Error types for session record operations.
@@ -254,6 +273,7 @@ mod tests {
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral: false,
+            workspace_owned: false,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -282,6 +302,7 @@ mod tests {
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral: false,
+            workspace_owned: false,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -308,6 +329,7 @@ mod tests {
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral: false,
+            workspace_owned: false,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -359,6 +381,7 @@ mod tests {
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral: false,
+            workspace_owned: false,
         };
         record.runtime = crate::runtime::RuntimeKind::Tcode;
         let json = serde_json::to_string(&record).expect("serialize");
@@ -414,9 +437,65 @@ mod tests {
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral: true,
+            workspace_owned: false,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
         assert!(back.ephemeral, "ephemeral=true must round-trip");
+    }
+
+    #[test]
+    fn record_without_workspace_owned_field_defaults_to_false() {
+        // Why (#1511): every pre-#1511 record has no `workspace_owned` key; they
+        // MUST deserialize as unowned (false) so the decommission path never
+        // auto-deletes a workspace it did not provision. "Prefer not deleting" is
+        // the safe direction — a lost workspace can be cleaned up manually.
+        let legacy_json = serde_json::json!({
+            "id": ManagedSessionId::new(),
+            "tmux_name": "tmpm-legacy",
+            "cwd": "/tmp",
+            "task": "legacy task",
+            "state": "stopped",
+            "created_at": Utc::now().to_rfc3339(),
+            "last_activity_at": null,
+            "workspace_path": "/tmp/some-workspace",
+            "repo_url": null,
+            "branch": null,
+            "pending_decision": null,
+            "proposed_default": null
+        })
+        .to_string();
+        let back: SessionRecord = serde_json::from_str(&legacy_json).expect("deserialize legacy");
+        assert!(
+            !back.workspace_owned,
+            "a record with no `workspace_owned` key must default to false (unowned — safe)"
+        );
+    }
+
+    #[test]
+    fn record_round_trips_workspace_owned_true() {
+        // Why (#1511): a clone-provisioned session must persist workspace_owned=true
+        // so decommission knows it is safe to remove the workspace.
+        let record = SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-clone".into(),
+            cwd: PathBuf::from("/managed/root/owner/repo/abc"),
+            task: "fix bug".into(),
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: Some(PathBuf::from("/managed/root/owner/repo/abc")),
+            repo_url: Some("https://github.com/owner/repo".into()),
+            branch: Some("fix/thing".into()),
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: true,
+        };
+        let json = serde_json::to_string(&record).expect("serialize");
+        let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.workspace_owned, "workspace_owned=true must round-trip");
     }
 }

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -365,6 +365,7 @@ mod tests {
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral: false,
+            workspace_owned: false,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -445,25 +445,47 @@ async fn manager_resume_respawns_in_existing_workspace() {
     );
 }
 
-/// `decommission` must remove the workspace directory from disk and set state
-/// to `Decommissioned`, but keep a tombstone record.
+/// `decommission` removes an SM-OWNED workspace directory and sets state to
+/// `Decommissioned`, but keeps a tombstone record.
 ///
-/// Why: decommission is the ONLY teardown that removes disk artifacts; without
-/// it the workspace dir accumulates indefinitely.
-/// What: creates a session with a real temp workspace dir, decommissions it,
-/// asserts the workspace dir is gone from disk and the record state is
-/// `Decommissioned` with `workspace_path = None`.
+/// Why: decommission is the ONLY teardown that removes disk artifacts for
+/// SM-provisioned (clone-based) sessions. The workspace must only be deleted
+/// when `workspace_owned = true` AND the path is inside the managed root —
+/// this test exercises the owned path by pointing the workspace inside a temp
+/// dir that serves as the managed root (#1511).
+/// What: creates a session, marks it workspace_owned=true, uses a temp dir as
+/// the managed root (via env override), decommissions it, asserts the workspace
+/// dir is gone from disk and the record state is `Decommissioned` with
+/// `workspace_path = None`.
 /// Test: this function IS the test.
 #[tokio::test]
 async fn manager_decommission_removes_workspace() {
     let dir = TempDir::new().unwrap();
     let (mgr, _fake) = make_manager(&dir).await;
 
-    // Create a real temp workspace directory that we can check after decommission.
-    let workspace_dir = TempDir::new().unwrap();
-    let workspace_path = workspace_dir.path().to_owned();
+    // Build a workspace path INSIDE a temp "managed root" dir so the
+    // path-containment guard passes. We set TRUSTY_MPM_WORKSPACE_ROOT to this
+    // temp dir to control what is_safe_to_remove considers the managed root.
+    let managed_root = TempDir::new().unwrap();
+    let workspace_path = managed_root
+        .path()
+        .join("owner")
+        .join("repo")
+        .join("abc-session-id");
+    std::fs::create_dir_all(&workspace_path).unwrap();
     // Write a sentinel file so we can verify the dir was removed.
     std::fs::write(workspace_path.join("sentinel.txt"), "exists").unwrap();
+
+    // Override the managed root to our temp dir so `is_safe_to_remove` sees it
+    // as the authoritative root during this test.
+    // SAFETY: this test runs in isolation; setting this env var only affects the
+    // current test process and is removed before the test exits.
+    unsafe {
+        std::env::set_var(
+            crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV,
+            managed_root.path().to_str().unwrap(),
+        );
+    }
 
     let record = mgr
         .create(
@@ -477,8 +499,20 @@ async fn manager_decommission_removes_workspace() {
         .await
         .expect("create");
 
+    // Mark as SM-owned (simulating what the clone-provision path does via
+    // `set_workspace_owned`). Without this the decommission guard skips deletion.
+    mgr.set_workspace_owned(&record.id, true)
+        .await
+        .expect("set_workspace_owned");
+
     // Decommission.
     let tombstone = mgr.decommission(&record.id).await.expect("decommission");
+
+    // Clean up the env override regardless of assertions.
+    // SAFETY: same as above.
+    unsafe {
+        std::env::remove_var(crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV);
+    }
 
     // State must be Decommissioned.
     assert_eq!(tombstone.state, ManagedSessionState::Decommissioned);
@@ -540,6 +574,7 @@ async fn manager_reconcile_gone_tmux_yields_stopped() {
         correlation: Default::default(),
         runtime: Default::default(),
         ephemeral: false,
+        workspace_owned: false,
     };
     // A record whose tmux session will NOT be found (simulating reboot).
     let rebooted_record = SessionRecord {
@@ -558,6 +593,7 @@ async fn manager_reconcile_gone_tmux_yields_stopped() {
         correlation: Default::default(),
         runtime: Default::default(),
         ephemeral: false,
+        workspace_owned: false,
     };
     {
         let mut store = mgr.store.write().await;
@@ -618,6 +654,7 @@ async fn manager_reconcile_skips_decommissioned() {
         correlation: Default::default(),
         runtime: Default::default(),
         ephemeral: false,
+        workspace_owned: false,
     };
     {
         let mut store = mgr.store.write().await;
@@ -1333,6 +1370,7 @@ async fn seed_record(
         correlation: Default::default(),
         runtime: Default::default(),
         ephemeral,
+        workspace_owned: false,
     };
     mgr.store
         .write()
@@ -1749,6 +1787,7 @@ async fn reap_aged_ephemeral_picks_old_ephemeral_only() {
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral,
+            workspace_owned: false,
         };
         mgr.store.write().await.upsert(record).await.expect("seed");
     }
@@ -1782,5 +1821,126 @@ async fn reap_aged_ephemeral_picks_old_ephemeral_only() {
         mgr.get(&old_durable).await.unwrap().state,
         ManagedSessionState::Active,
         "a non-ephemeral session is NEVER reaped by age"
+    );
+}
+
+// ── workspace-ownership guard tests (#1511) ──────────────────────────────────
+
+/// Decommissioning an UNOWNED record (local-path spawn, adopt) does NOT delete
+/// the workspace directory — only the session record is tombstoned.
+///
+/// Why (#1511): this is the core safety property. Before #1511, `decommission`
+/// unconditionally `remove_dir_all`'d `workspace_path`, which deleted a live
+/// user repo. With the `workspace_owned = false` guard, the directory must be
+/// preserved even though decommission completes successfully.
+/// What: creates a temp dir as the "workspace", builds an unowned record that
+/// points at it, decommissions the session, asserts the dir still exists on
+/// disk AND the record state is `Decommissioned`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_decommission_unowned_skips_deletion() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    // This dir represents a REAL user repo — it was not created by the SM.
+    let real_user_repo = TempDir::new().unwrap();
+    let repo_path = real_user_repo.path().to_owned();
+    // Write a sentinel file; if decommission deletes the dir this assert fails.
+    std::fs::write(repo_path.join("important_file.txt"), "do not delete").unwrap();
+
+    // Create the session record directly in the store, simulating a local-path
+    // spawn (#1502) that sets workspace_path to the real directory.
+    let id = ManagedSessionId::new();
+    let record = SessionRecord {
+        id,
+        tmux_name: format!("tmpm-local-{id}"),
+        cwd: repo_path.clone(),
+        task: "local task".into(),
+        state: ManagedSessionState::Stopped,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: Some(repo_path.clone()),
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        // workspace_owned = false — the SM did NOT create this directory.
+        workspace_owned: false,
+    };
+    mgr.store.write().await.upsert(record).await.unwrap();
+
+    // Decommission must SUCCEED (return Ok) but NOT delete the directory.
+    let tombstone = mgr
+        .decommission(&id)
+        .await
+        .expect("decommission of an unowned record must succeed (skip deletion, not error)");
+
+    // The record must be tombstoned.
+    assert_eq!(
+        tombstone.state,
+        ManagedSessionState::Decommissioned,
+        "record state must be Decommissioned"
+    );
+
+    // The REAL directory must still exist — decommission must not have deleted it.
+    assert!(
+        repo_path.exists(),
+        "the unowned workspace directory must NOT be deleted by decommission (#1511)"
+    );
+    assert!(
+        repo_path.join("important_file.txt").exists(),
+        "the sentinel file inside the unowned workspace must still exist"
+    );
+}
+
+/// `set_workspace_owned` persists the flag so a subsequent `decommission` can
+/// read it back and make the correct deletion decision.
+///
+/// Why (#1511): the clone-provision path calls `set_workspace_owned(id, true)`
+/// after creating the tmux session; this test pins that the flag survives the
+/// store round-trip and is visible on `get`.
+/// What: creates a session with `workspace_owned = false`, calls
+/// `set_workspace_owned(id, true)`, reads the record back, asserts the flag is
+/// now `true`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn workspace_owned_flag_round_trips_via_set() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "clone task".into(),
+            Some(PathBuf::from("/tmp/ws")),
+            None,
+            Some(PathBuf::from("/tmp/ws")),
+            Some("https://github.com/owner/repo".into()),
+            Some("main".into()),
+        )
+        .await
+        .expect("create");
+
+    // Fresh record starts unowned (the default).
+    assert!(
+        !record.workspace_owned,
+        "a freshly created record must default to workspace_owned = false"
+    );
+
+    // Simulate what the clone-provision path does.
+    mgr.set_workspace_owned(&record.id, true)
+        .await
+        .expect("set_workspace_owned");
+
+    // Read back and assert.
+    let updated = mgr
+        .get(&record.id)
+        .await
+        .expect("get after set_workspace_owned");
+    assert!(
+        updated.workspace_owned,
+        "workspace_owned must be true after set_workspace_owned(true)"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -464,8 +464,8 @@ async fn manager_decommission_removes_workspace() {
     let (mgr, _fake) = make_manager(&dir).await;
 
     // Build a workspace path INSIDE a temp "managed root" dir so the
-    // path-containment guard passes. We set TRUSTY_MPM_WORKSPACE_ROOT to this
-    // temp dir to control what is_safe_to_remove considers the managed root.
+    // path-containment guard passes. `decommission_with_root` is called with
+    // the managed root injected directly — no env var mutation required.
     let managed_root = TempDir::new().unwrap();
     let workspace_path = managed_root
         .path()
@@ -476,43 +476,29 @@ async fn manager_decommission_removes_workspace() {
     // Write a sentinel file so we can verify the dir was removed.
     std::fs::write(workspace_path.join("sentinel.txt"), "exists").unwrap();
 
-    // Override the managed root to our temp dir so `is_safe_to_remove` sees it
-    // as the authoritative root during this test.
-    // SAFETY: this test runs in isolation; setting this env var only affects the
-    // current test process and is removed before the test exits.
-    unsafe {
-        std::env::set_var(
-            crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV,
-            managed_root.path().to_str().unwrap(),
-        );
-    }
-
+    // Create the session with `owned=true` (atomic: mirrors what `spawn_managed`
+    // does for clone-provisioned workspaces after Fix 1).
     let record = mgr
-        .create(
+        .create_with_id(
+            ManagedSessionId::new(),
             "task".into(),
             Some(workspace_path.clone()),
             None,
             Some(workspace_path.clone()),
             None,
             None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            true, // owned: SM provisioned via clone
         )
         .await
         .expect("create");
 
-    // Mark as SM-owned (simulating what the clone-provision path does via
-    // `set_workspace_owned`). Without this the decommission guard skips deletion.
-    mgr.set_workspace_owned(&record.id, true)
+    // Decommission using the injectable root — no unsafe env mutation.
+    let tombstone = mgr
+        .decommission_with_root(&record.id, managed_root.path())
         .await
-        .expect("set_workspace_owned");
-
-    // Decommission.
-    let tombstone = mgr.decommission(&record.id).await.expect("decommission");
-
-    // Clean up the env override regardless of assertions.
-    // SAFETY: same as above.
-    unsafe {
-        std::env::remove_var(crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV);
-    }
+        .expect("decommission");
 
     // State must be Decommissioned.
     assert_eq!(tombstone.state, ManagedSessionState::Decommissioned);
@@ -886,6 +872,7 @@ async fn spawn_session_tmux_cwd_is_workspace() {
             Some("main".into()),
             crate::runtime::RuntimeKind::default(),
             false,
+            false,
         )
         .await
         .expect("create_with_id");
@@ -978,6 +965,7 @@ async fn manager_create_persists_runtime() {
             None,
             None,
             crate::runtime::RuntimeKind::Tcode,
+            false,
             false,
         )
         .await
@@ -1404,6 +1392,7 @@ async fn manager_create_persists_ephemeral_flag() {
             None,
             crate::runtime::RuntimeKind::default(),
             true,
+            false,
         )
         .await
         .expect("create ephemeral");
@@ -1417,6 +1406,7 @@ async fn manager_create_persists_ephemeral_flag() {
             None,
             None,
             crate::runtime::RuntimeKind::default(),
+            false,
             false,
         )
         .await

--- a/crates/trusty-mpm/src/session_manager/workspace_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/workspace_guard.rs
@@ -1,0 +1,205 @@
+//! Path-containment guard for workspace deletion (#1511).
+//!
+//! Why: `SessionManager::decommission` previously `remove_dir_all`'d
+//! `workspace_path` unconditionally, which deleted a live user repo when the
+//! #1502 local-path spawn set `workspace_path` to a real on-disk directory.
+//! This module provides the belt-and-suspenders containment guard that prevents
+//! any path OUTSIDE the SM's managed workspace root from being deleted —
+//! regardless of the `workspace_owned` flag.
+//! What: [`is_safe_to_remove`] canonicalizes both paths and verifies that the
+//! workspace is strictly INSIDE the managed root, rejecting: path == root, path
+//! outside root, paths with too few components, and `$HOME`.
+//! Test: `is_safe_to_remove_*` unit tests below.
+
+use std::path::Path;
+
+use tracing::warn;
+
+/// Decide whether `workspace_path` is safe to `remove_dir_all` (#1511).
+///
+/// Why: even an `workspace_owned = true` record should only be deleted when the
+/// path is strictly INSIDE the SM's managed workspaces root. This prevents
+/// decommission from deleting a directory if `workspace_owned` were stale or if a
+/// bug let a real path slip through as "owned". The guard rejects: path == root,
+/// path outside root, path with too few components (filesystem / volume root), and
+/// the user's home directory.
+///
+/// What: canonicalizes both paths and checks that `workspace_path` starts with
+/// `managed_root` AND is not equal to it (strictly INSIDE). Also rejects any path
+/// that is `$HOME` or has fewer than 3 components (e.g. `/`, `/tmp`) as an extra
+/// safety net against catastrophic deletion. Returns `false` on any I/O error
+/// during canonicalization (e.g. path does not exist) — never errors out.
+///
+/// Test: `is_safe_to_remove_rejects_outside_root`, `is_safe_to_remove_rejects_root_itself`,
+/// `is_safe_to_remove_rejects_home`, `is_safe_to_remove_rejects_shallow_path`,
+/// `is_safe_to_remove_accepts_valid_child` in this module.
+pub(crate) fn is_safe_to_remove(workspace_path: &Path, managed_root: &Path) -> bool {
+    // Reject suspiciously shallow paths before trying to canonicalize them.
+    // A real SM-provisioned workspace always nests at least 3 segments under
+    // the root (e.g. <root>/<owner>/<repo>/<session-id>/).
+    let component_count = workspace_path.components().count();
+    if component_count < 3 {
+        warn!(
+            path = %workspace_path.display(),
+            components = component_count,
+            "is_safe_to_remove: rejecting — too few path components"
+        );
+        return false;
+    }
+
+    // Reject $HOME outright — no managed session should ever BE the home dir.
+    if dirs::home_dir().is_some_and(|home| workspace_path == home) {
+        warn!(
+            path = %workspace_path.display(),
+            "is_safe_to_remove: rejecting — path is $HOME"
+        );
+        return false;
+    }
+
+    // Canonicalize both paths to resolve symlinks and `..` so a symlink into
+    // the managed root (or vice-versa) cannot trick the prefix check.
+    let canon_ws = match workspace_path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                path = %workspace_path.display(),
+                "is_safe_to_remove: cannot canonicalize workspace path ({e}); skipping deletion"
+            );
+            return false;
+        }
+    };
+    let canon_root = match managed_root.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                root = %managed_root.display(),
+                "is_safe_to_remove: cannot canonicalize managed root ({e}); skipping deletion"
+            );
+            return false;
+        }
+    };
+
+    // Must be strictly INSIDE the root (starts_with AND not equal to root).
+    if canon_ws == canon_root {
+        warn!(
+            path = %workspace_path.display(),
+            "is_safe_to_remove: rejecting — path IS the managed root"
+        );
+        return false;
+    }
+    if !canon_ws.starts_with(&canon_root) {
+        warn!(
+            path = %workspace_path.display(),
+            root = %managed_root.display(),
+            "is_safe_to_remove: rejecting — path is outside the managed root"
+        );
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    use super::is_safe_to_remove;
+
+    // ── is_safe_to_remove unit tests (#1511) ────────────────────────────────
+
+    /// A valid child of the managed root passes the guard.
+    ///
+    /// Why: this is the happy path — an SM-provisioned workspace is always
+    /// nested under the managed root.
+    /// Test: this function IS the test.
+    #[test]
+    fn is_safe_to_remove_accepts_valid_child() {
+        let root = TempDir::new().unwrap();
+        let child = root.path().join("owner").join("repo").join("session-abc");
+        std::fs::create_dir_all(&child).unwrap();
+        assert!(
+            is_safe_to_remove(&child, root.path()),
+            "a path strictly inside the managed root must pass"
+        );
+    }
+
+    /// A path equal to the managed root is rejected.
+    ///
+    /// Why: deleting the root itself would wipe all managed workspaces at once.
+    /// Test: this function IS the test.
+    #[test]
+    fn is_safe_to_remove_rejects_root_itself() {
+        let root = TempDir::new().unwrap();
+        assert!(
+            !is_safe_to_remove(root.path(), root.path()),
+            "the managed root itself must be rejected"
+        );
+    }
+
+    /// A path outside the managed root is rejected even if it exists.
+    ///
+    /// Why: a stale or stale `workspace_owned` flag must not cause out-of-root
+    /// deletion.
+    /// Test: this function IS the test.
+    #[test]
+    fn is_safe_to_remove_rejects_outside_root() {
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap(); // different temp dir
+        let outside_child = outside.path().join("some").join("path");
+        std::fs::create_dir_all(&outside_child).unwrap();
+        assert!(
+            !is_safe_to_remove(&outside_child, root.path()),
+            "a path outside the managed root must be rejected"
+        );
+    }
+
+    /// A path with fewer than 3 components is rejected.
+    ///
+    /// Why: `/`, `/tmp`, or a single-segment path is never a valid SM workspace.
+    /// Test: this function IS the test.
+    #[test]
+    fn is_safe_to_remove_rejects_shallow_path() {
+        let root = TempDir::new().unwrap();
+        // A 1-component path like "/" or a 2-component path like "/tmp" must be
+        // rejected before even reaching canonicalization.
+        let shallow = PathBuf::from("/tmp");
+        assert!(
+            !is_safe_to_remove(&shallow, root.path()),
+            "a shallow path (/tmp) must be rejected by the component-count guard"
+        );
+    }
+
+    /// `$HOME` is rejected outright.
+    ///
+    /// Why: deleting the user's home directory is catastrophic and must be
+    /// impossible regardless of what the managed root is set to.
+    /// Test: this function IS the test.
+    #[test]
+    fn is_safe_to_remove_rejects_home() {
+        if let Some(home) = dirs::home_dir() {
+            // Use home as both path and root — even if "home is inside home" the
+            // home-directory check fires first and rejects.
+            assert!(
+                !is_safe_to_remove(&home, &home),
+                "$HOME must always be rejected"
+            );
+        }
+    }
+
+    /// A non-existent path returns false (canonicalize fails).
+    ///
+    /// Why: a workspace that has already been deleted must not cause a panic;
+    /// the guard should simply return false so decommission logs and moves on.
+    /// Test: this function IS the test.
+    #[test]
+    fn is_safe_to_remove_returns_false_for_nonexistent_path() {
+        let root = TempDir::new().unwrap();
+        let nonexistent = root.path().join("ghost").join("nope").join("absent");
+        // path does not exist → canonicalize fails → returns false
+        assert!(
+            !is_safe_to_remove(&nonexistent, root.path()),
+            "a non-existent workspace path must return false (canonicalize fails)"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/workspace_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/workspace_guard.rs
@@ -34,9 +34,11 @@ use tracing::warn;
 /// `is_safe_to_remove_rejects_home`, `is_safe_to_remove_rejects_shallow_path`,
 /// `is_safe_to_remove_accepts_valid_child` in this module.
 pub(crate) fn is_safe_to_remove(workspace_path: &Path, managed_root: &Path) -> bool {
-    // Reject suspiciously shallow paths before trying to canonicalize them.
-    // A real SM-provisioned workspace always nests at least 3 segments under
-    // the root (e.g. <root>/<owner>/<repo>/<session-id>/).
+    // Reject suspiciously shallow ABSOLUTE paths before canonicalizing.
+    // This counts components from the filesystem root (e.g. `/` counts 1,
+    // `/tmp` counts 2) as a coarse guard against catastrophic paths like `/`
+    // or `/tmp` — NOT as a measure of depth relative to the managed root.
+    // The real containment check (canonicalize + starts_with) follows below.
     let component_count = workspace_path.components().count();
     if component_count < 3 {
         warn!(

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -173,6 +173,7 @@ async fn seed_sessions(
             correlation: Default::default(),
             runtime: Default::default(),
             ephemeral: false,
+            workspace_owned: false,
         };
         store.upsert(rec).await.expect("seed upsert");
         ids.push(id);
@@ -299,6 +300,7 @@ fn rec(state: ManagedSessionState, pending: Option<&str>) -> SessionRecord {
         correlation: Default::default(),
         runtime: Default::default(),
         ephemeral: false,
+        workspace_owned: false,
     }
 }
 

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -530,6 +530,7 @@ async fn handler_spawn_creates_tmux_at_workspace_cwd() {
             Some(git_ref.into()),
             trusty_mpm::runtime::RuntimeKind::default(),
             false,
+            false,
         )
         .await
         .expect("create_with_id");
@@ -674,6 +675,7 @@ async fn tcode_session_spawns_and_accepts_commands() {
             Some("main".into()),
             RuntimeKind::Tcode,
             false,
+            false,
         )
         .await
         .expect("create_with_id");
@@ -808,6 +810,7 @@ async fn resume_managed_typed_invalid_state_is_conflict() {
             Some("main".to_string()),
             ResumeRuntimeKind::default(),
             false,
+            false,
         )
         .await
         .expect("seed session");
@@ -859,6 +862,7 @@ async fn front_gate_answer_unblocks_spawn() {
             Some("https://github.com/owner/repo".to_string()),
             Some("main".to_string()),
             ResumeRuntimeKind::default(),
+            false,
             false,
         )
         .await
@@ -1032,6 +1036,7 @@ async fn decommission_ephemeral_route_tears_down_only_ephemeral() {
                 Some("main".to_string()),
                 ResumeRuntimeKind::default(),
                 ephemeral,
+                false,
             )
             .await
             .expect("seed session");
@@ -1099,6 +1104,7 @@ async fn prune_route_dry_run_reports() {
             Some("main".to_string()),
             ResumeRuntimeKind::default(),
             true,
+            false,
         )
         .await
         .expect("seed ephemeral");


### PR DESCRIPTION
## P0 — data loss fix
`SessionManager::decommission` unconditionally `remove_dir_all`'d `workspace_path`. The #1502 local-path spawn and adopt paths set `workspace_path` to REAL, non-isolated user directories, so `tm sessions prune` deleted a live repository (`/Users/masa/Projects/trusty-tools`, recovered from origin). This makes that impossible.

## Fix (defense in depth)
- **`workspace_owned: bool`** on `SessionRecord` (`#[serde(default)]` → legacy records deserialize as `false` = UNOWNED = never auto-deleted). Set `true` only on clone-provisioned spawns; `false` on local-path spawn (#1502), adopt (#1433), and boot reconciliation.
- **decommission ownership gate**: deletes the dir only when `workspace_owned == true`; otherwise logs and skips, still tombstoning the record.
- **path-containment guard** `is_safe_to_remove`: even for owned dirs, only removes when the canonicalized path is strictly inside the canonicalized managed workspaces root; rejects `$HOME`, the root itself, outside-root, and shallow (<3-component) paths.
- prune/compaction audited — routes through the guarded `decommission`; no unguarded `remove_dir_all` remains.

## Tests
11 new tests: unowned decommission skips deletion, owned-under-root deletes, guard rejects $HOME/root/outside/shallow, legacy JSON defaults to unowned, owned-flag round-trips. clippy \`-D warnings\`, fmt, line-cap clean.

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)