### PR TITLE
feat(trusty-sessions): harness-understanding instructions in trusty-agents-common + DOC-21 (closes #1510)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
+trusty-agents-common = { path = "crates/trusty-agents-common" }
 trusty-common = { path = "crates/trusty-common", version = "0.17.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.

--- a/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_AGNOSTIC.md
+++ b/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_AGNOSTIC.md
@@ -1,0 +1,167 @@
+# Harness Understanding — Canonical Mental Model
+
+> DOC-21 `SPEC-HARNESS-UNDERSTANDING-01~draft` | Section: Agnostic Core
+
+This section encodes the canonical mental model for any AI coding harness that
+trusty-mpm manages. Read this before interpreting any session pane.
+
+## Session Lifecycle & States
+
+Every harness session passes through a well-defined lifecycle:
+
+| State | Meaning | Observable signals |
+|-------|---------|-------------------|
+| `Starting` | Process launched, not yet producing output | Blank pane or very first output lines |
+| `Idle` | Ready and waiting for operator input | Prompt visible (`> `, `$`, `#`), no activity |
+| `Working` | Actively processing a task | Spinner glyphs, streaming output, tool calls |
+| `Paused` | Waiting on an operator decision | A question, permission dialog, or approval gate |
+| `Error` | Encountered a non-recoverable error | Error banners, exit codes, panic traces |
+| `Stopped` | Session has exited cleanly | No runtime process; final output visible |
+
+## Pane / IO Model
+
+The **pane** is the tmux-backed terminal surface — it is the ONLY observable
+surface for a running harness. You interact with it by reading captured output
+(observe) and writing to it (send a message).
+
+Key facts about panes:
+- You see the **last N lines** of the terminal (the observation window).
+- Output is **streaming** — the pane may be mid-output when you observe it.
+- **Scroll position does not matter** — the observation window always shows
+  the most recent lines.
+- A pane that has been silent for >30 seconds with no Working glyphs is
+  almost certainly Idle or Stopped.
+
+## Prompt Shapes
+
+Different harnesses show different idle prompt shapes:
+
+| Harness | Idle prompt | Notes |
+|---------|------------|-------|
+| Claude Code | `> ` (bare `>` at start of line) | Single `>` alone on the line |
+| Shell | `$ ` or `# ` | Standard Unix shell prompts |
+| tcode | No pane prompt (event-driven) | Uses `__HARNESS_EVENT__` NDJSON events |
+
+An idle prompt on the **last line** of the pane (or the last non-empty line)
+is the strongest signal that a harness is Idle and waiting for input.
+
+## Tool-Call Patterns
+
+When a harness executes tools, the pane shows structured patterns:
+
+- **Claude Code**: Tool calls appear as bracketed blocks with tool name and
+  arguments, followed by a result block. The `✻` glyph often appears during
+  tool execution. Example: `✻ Running bash...` or `✻ Reading file...`
+- **tcode**: Emits structured NDJSON event lines prefixed with `__HARNESS_EVENT__`.
+  Example: `__HARNESS_EVENT__ {"type":"tool_use","tool":"bash","input":{...}}`
+  These lines are parseable as JSON after stripping the prefix.
+- **Shell**: Raw command output; no structured wrapper.
+
+## Approval / Decision Gates
+
+Harnesses may pause and wait for operator approval:
+
+- **Permission dialogs**: Claude Code shows dialog text with `Allow` / `Deny` /
+  `Always allow` options. These are hard blockers — the session will not proceed
+  until an answer is sent.
+- **Y/N prompts**: Text ending with `? [y/N]` or `Continue? (y/n):` patterns.
+- **Trust dialogs**: First-run trust establishment (e.g. `Trust this workspace?`).
+- **Custom questions**: The harness may ask open-ended questions that require
+  an operator decision before proceeding.
+
+When you see a decision gate, the session is in `Paused` state. You must either
+send an answer (if you are authorized to do so) or escalate to the operator.
+
+## Completion & Evidence Signals
+
+A task is done only when you observe **evidence**. The canonical evidence patterns:
+
+| Claim | Evidence pattern in pane |
+|-------|--------------------------|
+| "PR opened" | A GitHub PR URL: `https://github.com/.*/pull/\d+` |
+| "tests pass" | Test summary: `N passed; 0 failed`, `test result: ok. N passed`, `All tests passed` |
+| "edit made" | Diff output or `Write(path)` / `Edit(path)` confirmation lines |
+| "task done" | `Task complete`, `Done`, `✓`, or equivalent success banner |
+| "build passes" | `cargo check` / `cargo build` success: `Finished` or `warning(0)` |
+
+**Never claim a task is complete without at least one observed evidence pattern.**
+
+## Error Patterns
+
+Errors produce recognizable output in the pane:
+
+- **Rust compilation errors**: `error[E`, `error:`, followed by file:line citations
+- **Test failures**: `FAILED`, `N failed`, `test result: FAILED`
+- **Runtime panics**: `thread 'main' panicked at`, `panicked at '`
+- **Process exit errors**: `exit code: N` (non-zero), `exited with status`
+- **Generic error prefixes**: Lines starting with `Error:` or `ERROR:`
+- **Tool errors**: `✻ Error:` or structured error blocks in Claude Code
+
+When you observe error patterns, classify the session as `Error` and include
+the error text in your report. **Do not assume recovery happened unless you see
+a subsequent success signal.**
+
+## Observability & Inference
+
+Two tiers of observation are available:
+
+1. **Deterministic (LLM-free)**: Apply the patterns in this section directly to
+   raw pane text. No tokens consumed, no network, always available. Described in
+   the fallback model below.
+
+2. **LLM-backed (optional)**: The `ActivityMonitor` classifies pane content
+   using an LLM when `OPENROUTER_API_KEY` is configured. Returns `ActivityState`
+   with a confidence score. When the key is absent, the classifier returns
+   `state = Unknown` — fall back to tier 1.
+
+Always apply tier 1 first. Tier 2 can confirm or refine, but never contradicts
+a clear tier-1 signal (e.g. an explicit PR URL in the pane is completion
+evidence regardless of the LLM's classification).
+
+## Deterministic LLM-Free Fallback Model
+
+When `OPENROUTER_API_KEY` is absent (or the LLM returns `Unknown`), apply these
+deterministic rules to raw pane text:
+
+### idle-by-silence
+- Pane has not changed for >30 seconds, AND
+- No Working glyphs (`✻`, spinner characters) in the last 5 lines, AND
+- Last non-empty line matches an idle prompt pattern (`^>\s*$`, `^\$\s`, `^#\s`)
+→ **Classify as Idle**
+
+### completion-by-banner
+- Pane contains any of: PR URL (`https://github.com/.*/pull/\d+`), test-pass
+  summary (`\d+ passed.*0 failed`, `All \d+ tests passed`), `Task complete`,
+  `Done.`, `✓ Complete`, `Finished` (Rust build)
+→ **Classify as Done / Idle with completion evidence** (report the evidence)
+
+### error-by-keyword
+- Pane contains any of: `error[E`, `FAILED`, `panicked at`, `exit code: [^0]`,
+  `Error:` (line-start), `✻ Error:`
+→ **Classify as Error** (include the error excerpt in your report)
+
+### working-by-glyph
+- Pane contains `✻` in the last 10 lines, OR output is actively streaming
+  (multiple new lines since last observation)
+→ **Classify as Working**
+
+### default
+- None of the above → **Classify as Unknown** (report honestly; consider waiting
+  and re-observing before acting)
+
+## WHEN-TO-INTERVENE Decision Protocol
+
+Use this protocol every time you observe a session pane:
+
+| Observed state | Action | Rationale |
+|----------------|--------|-----------|
+| `Working` with progress signals | **WAIT** | Session is making progress; intervention disrupts work |
+| `Idle` + pending question visible | **SEND** answer | Session is blocked waiting for your input |
+| `Idle` + no question, task incomplete | **SEND** follow-up | Session may be stuck or awaiting next instruction |
+| `Paused` + permission dialog | **ESCALATE** or send authorized answer | Permission gates may require operator judgment |
+| `Error` | **INTERRUPT** + report error | Session cannot self-recover from hard errors |
+| Silent >5 min, Unknown state | **INTERRUPT** + re-observe | Long silence without signals is abnormal |
+| `Stopped` (runtime exited) | **REPORT** result + check evidence | Session is done; apply verification gate |
+
+**Decision escalation order**: WAIT < SEND < INTERRUPT < ESCALATE (FlagForHuman).
+Choose the lowest-intensity action that resolves the observable state.

--- a/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_MPM_SM.md
+++ b/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_MPM_SM.md
@@ -1,0 +1,85 @@
+# Harness Understanding — trusty-mpm Session Manager Specifics
+
+> DOC-21 `SPEC-HARNESS-UNDERSTANDING-01~draft` | Section: SM Wiring
+
+This section extends the agnostic harness model (above) with specifics for the
+trusty-mpm session-manager (SM) role. Read this after the agnostic core.
+
+## How OBSERVE Consumes the Harness Model
+
+When you call `sessions.get(session_id)`, you receive a `RawObservation`:
+- `raw_pane`: the captured pane text (your observation window)
+- `runtime_active`: whether the tmux session process is still live
+- `pending_decision`: a detected pending question, if any
+- `proposed_default`: the suggested answer to `pending_decision`, if any
+
+**Apply the deterministic fallback model to `raw_pane`** when no LLM verdict
+is available. Your interpretation sequence:
+
+1. Check `runtime_active` — if `false`, the session has Stopped; look for
+   completion evidence in `raw_pane` before reporting.
+2. Check `pending_decision` — if set, the session is Paused waiting for input.
+   Evaluate whether you (the SM) can answer it (Allowlist 4) or must escalate.
+3. Apply the deterministic model (agnostic §8) to `raw_pane` to classify state.
+4. If the activity monitor returned a `Summary` with `state != Unknown`, use
+   it to confirm or refine your tier-1 classification.
+
+## How VERIFY Uses Completion Evidence Signals
+
+The BLOCKING verification gate (SM Workflow §5) requires observed evidence.
+Map the agnostic completion signals (agnostic §6) to SM verifications:
+
+| Task claim | SM verification step |
+|-----------|---------------------|
+| "PR opened" | `sessions.get` → `raw_pane` contains GitHub PR URL → report URL |
+| "tests pass" | `raw_pane` contains test-pass summary → report summary line |
+| "edit made" | `raw_pane` contains diff or edit confirmation → report file name |
+| "task done" | `raw_pane` contains completion banner → report it verbatim |
+
+If the evidence is not present in `raw_pane`, **do not claim the task is done**.
+Re-observe after a wait, or send a follow-up to the session.
+
+## Managed States and Adopt Semantics
+
+trusty-mpm managed sessions can be adopted (pre-existing tmux sessions).
+On adopt:
+- The SM does NOT know the session's prior history; `raw_pane` is the only truth.
+- Apply the full observation protocol from the top — do not assume any state.
+- If `pending_decision` is set, the session was already blocked before adopt;
+  handle it as a Paused session.
+
+## Chat-Core Verb Mapping to Intervention Actions
+
+| Decision-protocol action (agnostic §9) | SM verb |
+|----------------------------------------|---------|
+| WAIT | (no call; next poll cycle) |
+| SEND answer | `sessions.send(session_id, text)` |
+| INTERRUPT | `sessions.stop(session_id)` then re-launch if needed |
+| ESCALATE | Report to operator via free-text; do NOT send to session |
+
+`sessions.send` is available (Allowlist 4). Only use it when you have observed
+a Paused state or Idle state with a pending question — do not send speculatively.
+
+## RawObservation / Summary Two-Tier
+
+- **`observe` (raw, always available)**: `sessions.get` with no inference flag.
+  Returns `RawObservation`. Always available, never fails due to missing API key.
+  Use the deterministic model (agnostic §8) on `raw_pane`.
+- **`summarize` (LLM-backed, optional)**: when `OPENROUTER_API_KEY` is present,
+  returns a `Summary` with `ActivityState` and a human-readable note.
+  When absent: `state = Unknown`, `summary = None`, `confidence = 0.0`.
+
+Always be prepared to operate from `RawObservation` alone. The LLM summary is
+a bonus; the raw pane is the ground truth.
+
+## Override Convention
+
+An operator may override this harness-understanding section at:
+`~/.trusty-mpm/sm/SM_HARNESS.md`
+
+When present and non-empty, that file's content replaces the shared
+trusty-agents-common content for the harness section of the SM prompt.
+When absent or empty, the shared trusty-agents-common content is used.
+
+This follows the same override convention as `SM_INSTRUCTIONS.md`,
+`SM_WORKFLOW.md`, and `SM_TOOLS.md`.

--- a/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_OVERSEER.md
+++ b/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_OVERSEER.md
@@ -1,0 +1,67 @@
+# Harness Understanding — t-code-as-Overseer Contract (Forward-Looking)
+
+> DOC-21 `SPEC-HARNESS-UNDERSTANDING-01~draft` | Section: Overseer Contract
+>
+> **Status:** Forward-looking. The `Overseer` trait and `HarnessSource::Code`
+> slot are defined; this section governs the future wiring when tcode becomes
+> an active overseer. No emitters exist yet.
+
+## The Overseer Seam
+
+The overseer seam consists of two components already in place:
+
+1. **`Overseer` trait** (`crates/trusty-mpm/src/core/overseer.rs`): the
+   strategy interface the daemon dispatches hook events to. Returns
+   `OverseerDecision::{Allow, Block, Respond, FlagForHuman}`.
+
+2. **`HarnessSource::Code`** (`crates/trusty-agents-common/src/events/lifecycle.rs`):
+   the reserved source tag for tcode-originated `HarnessEvent`s. No emitters
+   exist yet; this slot is reserved for the future t-code overseer.
+
+## Event-to-Decision Mapping
+
+A t-code overseer subscribes to the `HarnessEvent` bus filtered on
+`HarnessSource::Code` and maps events to `OverseerDecision` using the agnostic
+WHEN-TO-INTERVENE protocol:
+
+| Observed event | Recommended decision | Rationale |
+|----------------|---------------------|-----------|
+| `pm_thinking` — routine reasoning | `Allow` | Normal Working state; no intervention needed |
+| `agent_message` — within task scope | `Allow` | Expected output |
+| Permission dialog detected in pane | `Respond` (if authorized) or `FlagForHuman` | Decision gate |
+| Error event + non-recoverable pattern | `FlagForHuman` | Human must decide next step |
+| Sensitive file write outside scope | `Block { reason }` | Scope violation |
+| Unexpected tool call (out-of-scope) | `Block { reason }` | Scope enforcement |
+| Long silence (>5 min) in Working state | `FlagForHuman` | Possible hang |
+
+## `__HARNESS_EVENT__` as Structured Input
+
+For a t-code overseer, `__HARNESS_EVENT__` lines are the primary structured
+input (vs. pane text for Claude Code). The overseer SHOULD prefer event-stream
+classification over pane-text heuristics when events are available.
+
+Parse events as `HarnessEvent` (strip `__HARNESS_EVENT__ ` prefix, parse JSON).
+Filter on `source == HarnessSource::Code` and the session ID being overseen.
+
+## `FlagForHuman` Escalation Policy
+
+The overseer MUST escalate (`FlagForHuman`) in at least these cases:
+- Permission dialog that the overseer is not authorized to answer
+- Any action that would mutate protected files (outside declared scope)
+- Session silent for >5 minutes with no completion evidence
+- Unexpected process exit (non-zero exit code without a prior error event)
+
+The `FlagForHuman.summary` field must be a concise, actionable description:
+`"Session s-abc has been silent for 6 minutes; last event was pm_thinking"`
+
+## Future Wiring
+
+When a t-code overseer is implemented:
+1. Subscribe to the `HarnessEvent` bus at startup (filtered on `HarnessSource::Code`)
+2. Register as the `Overseer` in the daemon's `DaemonState`
+3. For each hook event: apply this contract to produce an `OverseerDecision`
+4. Emit `HarnessPayload::Hook { kind, data }` events for audit purposes
+
+The `HarnessSource::Code` source tag transitions from "reserved" to "active"
+when the first real emitter lands. This spec governs the behavioral contract
+from that moment forward.

--- a/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_TCODE.md
+++ b/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_TCODE.md
@@ -1,0 +1,66 @@
+# Harness Understanding — tcode (trusty-code) Specifics
+
+> DOC-21 `SPEC-HARNESS-UNDERSTANDING-01~draft` | Section: tcode
+
+tcode (the `trusty-code` harness, binary `tcode`) differs from Claude Code
+in that it emits **structured NDJSON event lines** in addition to pane text.
+
+## `__HARNESS_EVENT__` NDJSON Events
+
+tcode emits events as NDJSON lines prefixed with `__HARNESS_EVENT__ `:
+
+```
+__HARNESS_EVENT__ {"source":"code","seq":1,"payload":{"domain":"lifecycle","event":{"type":"session_started","session_id":"s1","project":"my-repo"}}}
+```
+
+To parse: strip the `__HARNESS_EVENT__ ` prefix (21 chars including trailing
+space), then parse the remainder as JSON as a `HarnessEvent` envelope.
+
+Key event types to watch:
+- `session_started` / `session_ended` — lifecycle transitions
+- `pm_thinking` — agent is reasoning (Working state)
+- `agent_message` — agent produced output (may be Working or completion)
+- `recap_generated` — session recap; treat as completion evidence candidate
+
+## Task Banners
+
+tcode emits task-start and task-end banners in the pane:
+- Task start: lines matching `=== Task: <description> ===` or similar
+- Task end: `=== Done ===`, `=== Completed ===`, or the `recap_generated` event
+
+## Agent-Delegation Output
+
+When tcode delegates to an agent, the pane shows agent output prefixed with
+the agent name. Example:
+```
+[rust-engineer] Starting implementation...
+[rust-engineer] cargo check: Finished
+```
+
+Delegation lines are Working signals. Completion of the delegated task
+produces a summary line (the agent's final output) followed by the
+`agent_message` event.
+
+## Diff / Edit Confirmation
+
+tcode confirms file edits with structured diff output:
+```
+Edit: src/foo.rs (+15, -3)
+Write: src/bar.rs (new file, 42 lines)
+```
+
+These patterns are completion evidence for "edit made" claims.
+
+## State Classification for tcode
+
+Apply the agnostic model, but prefer `__HARNESS_EVENT__` events over pane text
+when available:
+
+| Event / pane signal | State |
+|--------------------|-------|
+| `pm_thinking` event | Working |
+| `agent_message` event (task ongoing) | Working |
+| `recap_generated` event | Done (completion evidence) |
+| `session_ended` event | Stopped |
+| Pane silent, no events for >30s | Idle (apply agnostic fallback) |
+| Error events or `error:` pane text | Error |

--- a/crates/trusty-agents-common/src/harness_doc.rs
+++ b/crates/trusty-agents-common/src/harness_doc.rs
@@ -1,0 +1,183 @@
+//! # Spec References
+//!
+//! - [`SPEC-HARNESS-UNDERSTANDING-01~draft`](../../docs/specs/harness-understanding.md)
+//!
+//! Canonical harness-understanding instructions shared between trusty-mpm SM and
+//! future t-code overseer (DOC-21).
+//!
+//! Why: The harness mental model, per-harness signals, and intervention decision
+//!      protocol must live in one place so both the SM prompt (trusty-mpm) and a
+//!      future t-code overseer can consume the same authoritative content. This
+//!      module exposes it as static `&str` slices compiled in at build time.
+//! What: Four structured accessors — `agnostic()`, `mpm_session_manager()`,
+//!       `tcode()`, `overseer()` — plus a `harness_understanding()` convenience
+//!       that concatenates all four sections for consumers that want the full doc.
+//! Test: `harness_doc::tests` verifies non-empty content, canonical marker
+//!       presence (`✻`, `__HARNESS_EVENT__`), and the structured-accessor sum
+//!       equals the full-doc output.
+
+/// Harness-agnostic mental model: session lifecycle, pane/IO model, prompt
+/// shapes, completion/error signals, observability, and the WHEN-TO-INTERVENE
+/// decision protocol with deterministic LLM-free fallback.
+///
+/// Why: Every consumer (SM, overseer, future tooling) needs the same foundation
+///      — session states, idle/working/error patterns, and when to act.
+/// What: Returns the full text of `HARNESS_AGNOSTIC.md`, compiled in at build
+///       time via `include_str!`.
+/// Test: `agnostic_non_empty`, `agnostic_contains_claude_code_glyph`,
+///       `agnostic_contains_harness_event`.
+pub fn agnostic() -> &'static str {
+    include_str!("assets/harness_understanding/HARNESS_AGNOSTIC.md")
+}
+
+/// trusty-mpm session-manager specifics: how OBSERVE/VERIFY consume the
+/// harness model, managed states, adopt semantics, chat-core verb mapping,
+/// RawObservation/Summary two-tier, and the override convention.
+///
+/// Why: The SM prompt needs SM-specific wiring on top of the agnostic model —
+///      the two-tier observation model, the override path, and chat-core verbs.
+/// What: Returns the full text of `HARNESS_MPM_SM.md`.
+/// Test: `mpm_sm_non_empty`, `mpm_sm_contains_raw_observation`.
+pub fn mpm_session_manager() -> &'static str {
+    include_str!("assets/harness_understanding/HARNESS_MPM_SM.md")
+}
+
+/// tcode-specific signals: task banners, `__HARNESS_EVENT__` NDJSON lines,
+/// agent-delegation patterns, and diff/edit confirmation output.
+///
+/// Why: tcode emits structured NDJSON events that differ from Claude Code's
+///      pane-text signals; both consumers need the tcode specifics.
+/// What: Returns the full text of `HARNESS_TCODE.md`.
+/// Test: `tcode_non_empty`, `tcode_contains_harness_event`.
+pub fn tcode() -> &'static str {
+    include_str!("assets/harness_understanding/HARNESS_TCODE.md")
+}
+
+/// Forward-looking t-code-as-overseer contract: the `Overseer` trait +
+/// `HarnessSource::Code` filter seam, event-to-decision mapping, and
+/// `__HARNESS_EVENT__` as structured overseer input.
+///
+/// Why: The overseer seam is already defined (`Overseer` trait,
+///      `HarnessSource::Code`); this section codifies the behavioral contract
+///      so the first t-code overseer implementer has a spec to build against.
+/// What: Returns the full text of `HARNESS_OVERSEER.md`.
+/// Test: `overseer_non_empty`, `overseer_contains_flag_for_human`.
+pub fn overseer() -> &'static str {
+    include_str!("assets/harness_understanding/HARNESS_OVERSEER.md")
+}
+
+/// Full harness-understanding document: all four sections concatenated in
+/// order (agnostic → mpm_session_manager → tcode → overseer), separated by
+/// `\n\n---\n\n`.
+///
+/// Why: SM prompt assembly and tests need the full body; structured accessors
+///      satisfy consumers that only need one section.
+/// What: Concatenates `agnostic()`, `mpm_session_manager()`, `tcode()`, and
+///       `overseer()` with a `\n\n---\n\n` separator.
+/// Test: `full_doc_contains_all_markers`, `full_doc_sum_of_parts`.
+pub fn harness_understanding() -> String {
+    [agnostic(), mpm_session_manager(), tcode(), overseer()]
+        .iter()
+        .map(|s| s.trim())
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agnostic_non_empty() {
+        assert!(!agnostic().trim().is_empty());
+    }
+
+    #[test]
+    fn agnostic_contains_claude_code_glyph() {
+        // The ✻ glyph is the canonical Claude Code working signal (DOC-21 §5.1)
+        assert!(
+            agnostic().contains('✻'),
+            "agnostic section must document the ✻ glyph"
+        );
+    }
+
+    #[test]
+    fn agnostic_contains_harness_event() {
+        // __HARNESS_EVENT__ is the canonical tcode NDJSON event prefix (DOC-21 §5.2)
+        assert!(
+            agnostic().contains("__HARNESS_EVENT__"),
+            "agnostic section must document __HARNESS_EVENT__ prefix"
+        );
+    }
+
+    #[test]
+    fn mpm_sm_non_empty() {
+        assert!(!mpm_session_manager().trim().is_empty());
+    }
+
+    #[test]
+    fn mpm_sm_contains_raw_observation() {
+        assert!(
+            mpm_session_manager().contains("RawObservation")
+                || mpm_session_manager().contains("raw observation")
+                || mpm_session_manager().contains("raw pane"),
+            "SM section must reference the RawObservation/raw-pane two-tier model"
+        );
+    }
+
+    #[test]
+    fn tcode_non_empty() {
+        assert!(!tcode().trim().is_empty());
+    }
+
+    #[test]
+    fn tcode_contains_harness_event() {
+        assert!(
+            tcode().contains("__HARNESS_EVENT__"),
+            "tcode section must document __HARNESS_EVENT__ NDJSON prefix"
+        );
+    }
+
+    #[test]
+    fn overseer_non_empty() {
+        assert!(!overseer().trim().is_empty());
+    }
+
+    #[test]
+    fn overseer_contains_flag_for_human() {
+        assert!(
+            overseer().contains("FlagForHuman") || overseer().contains("flag_for_human"),
+            "overseer section must reference FlagForHuman escalation"
+        );
+    }
+
+    #[test]
+    fn full_doc_contains_all_markers() {
+        let doc = harness_understanding();
+        assert!(doc.contains('✻'), "full doc must contain ✻ glyph");
+        assert!(
+            doc.contains("__HARNESS_EVENT__"),
+            "full doc must contain __HARNESS_EVENT__"
+        );
+        assert!(
+            doc.contains("FlagForHuman") || doc.contains("flag_for_human"),
+            "full doc must contain FlagForHuman"
+        );
+    }
+
+    #[test]
+    fn full_doc_sum_of_parts() {
+        // The full doc is a join of the four parts; every part's content must
+        // appear somewhere in the full doc.
+        let doc = harness_understanding();
+        // Take first 50 chars of each trimmed part as a unique anchor
+        let parts = [agnostic(), mpm_session_manager(), tcode(), overseer()];
+        for part in &parts {
+            let anchor: String = part.trim().chars().take(50).collect();
+            assert!(
+                doc.contains(anchor.trim()),
+                "full doc missing content from part starting: {anchor:?}"
+            );
+        }
+    }
+}

--- a/crates/trusty-agents-common/src/harness_doc.rs
+++ b/crates/trusty-agents-common/src/harness_doc.rs
@@ -68,19 +68,23 @@ pub fn overseer() -> &'static str {
 
 /// Full harness-understanding document: all four sections concatenated in
 /// order (agnostic → mpm_session_manager → tcode → overseer), separated by
-/// `\n\n---\n\n`.
+/// a plain `"\n\n"`.
 ///
-/// Why: SM prompt assembly and tests need the full body; structured accessors
-///      satisfy consumers that only need one section.
+/// Why: SM prompt assembly joins top-level sections with `SECTION_SEPARATOR`
+///      (`"\n\n---\n\n"`). Using that same separator internally would cause
+///      the harness block to fragment into spurious top-level sections when
+///      the assembler splits on `---`. Each sub-section starts with its own
+///      `#`/`##` heading, so a plain double-newline is sufficient visual
+///      separation without colliding with the outer separator.
 /// What: Concatenates `agnostic()`, `mpm_session_manager()`, `tcode()`, and
-///       `overseer()` with a `\n\n---\n\n` separator.
+///       `overseer()` with a `"\n\n"` separator (not `---`).
 /// Test: `full_doc_contains_all_markers`, `full_doc_sum_of_parts`.
 pub fn harness_understanding() -> String {
     [agnostic(), mpm_session_manager(), tcode(), overseer()]
         .iter()
         .map(|s| s.trim())
         .collect::<Vec<_>>()
-        .join("\n\n---\n\n")
+        .join("\n\n")
 }
 
 #[cfg(test)]
@@ -167,17 +171,40 @@ mod tests {
 
     #[test]
     fn full_doc_sum_of_parts() {
-        // The full doc is a join of the four parts; every part's content must
-        // appear somewhere in the full doc.
+        // The full doc is a join of the four parts; every part's distinctive
+        // body content must appear in the full doc. Each anchor is chosen from
+        // the interior body of that section — unique to it and stable against
+        // heading or prefix changes.
         let doc = harness_understanding();
-        // Take first 50 chars of each trimmed part as a unique anchor
-        let parts = [agnostic(), mpm_session_manager(), tcode(), overseer()];
-        for part in &parts {
-            let anchor: String = part.trim().chars().take(50).collect();
-            assert!(
-                doc.contains(anchor.trim()),
-                "full doc missing content from part starting: {anchor:?}"
-            );
-        }
+
+        // AGNOSTIC: the canonical mental-model section (DOC-21 §1).
+        // "WHEN-TO-INTERVENE" is the unique label for the intervention protocol
+        // described only in the agnostic section.
+        assert!(
+            doc.contains("WHEN-TO-INTERVENE"),
+            "full doc must contain AGNOSTIC body phrase 'WHEN-TO-INTERVENE'"
+        );
+
+        // MPM_SM: session-manager specifics (DOC-21 SM Wiring section).
+        // "RawObservation" is the struct name unique to the SM two-tier model.
+        assert!(
+            doc.contains("RawObservation"),
+            "full doc must contain MPM_SM body phrase 'RawObservation'"
+        );
+
+        // TCODE: tcode-specific signals (DOC-21 tcode section).
+        // "structured NDJSON event lines" is the unique description of tcode's
+        // event emission that does not appear in the other three sections.
+        assert!(
+            doc.contains("structured NDJSON event lines"),
+            "full doc must contain TCODE body phrase 'structured NDJSON event lines'"
+        );
+
+        // OVERSEER: the t-code-as-overseer contract (DOC-21 Overseer section).
+        // "HarnessSource::Code" is the reserved source tag unique to this section.
+        assert!(
+            doc.contains("HarnessSource::Code"),
+            "full doc must contain OVERSEER body phrase 'HarnessSource::Code'"
+        );
     }
 }

--- a/crates/trusty-agents-common/src/lib.rs
+++ b/crates/trusty-agents-common/src/lib.rs
@@ -88,6 +88,17 @@ pub mod session_registry;
 /// Test: `events::tests` is the comprehensive suite for this foundation type.
 pub mod events;
 
+/// Canonical harness-understanding instructions shared by all consumers (DOC-21).
+///
+/// Why: Both trusty-mpm's SM prompt and a future t-code overseer need the same
+///      harness mental model — session lifecycle, pane signals, decision protocol,
+///      and per-harness specifics. A single shared source prevents drift.
+/// What: Four structured accessors (`agnostic`, `mpm_session_manager`, `tcode`,
+///       `overseer`) plus a `harness_understanding` convenience that concatenates
+///       all sections. Content is bundled markdown compiled in via `include_str!`.
+/// Test: `harness_doc::tests` exercises every accessor and the full-doc combinator.
+pub mod harness_doc;
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -119,6 +119,7 @@ path = "tests/services_integration.rs"
 # ── Always-on dependencies ─────────────────────────────────────────────────────
 # Required by the `core` and `client` library modules (compiled unconditionally).
 [dependencies]
+trusty-agents-common = { workspace = true }
 trusty-common = { workspace = true, features = [
     "mcp",
     "cli-help",

--- a/crates/trusty-mpm/src/core/sm/prompt.rs
+++ b/crates/trusty-mpm/src/core/sm/prompt.rs
@@ -3,19 +3,21 @@
 //! Why: the SM carries its own role-specific system prompt, composed and
 //! delivered with the same discipline as the PM prompt
 //! ([`crate::core::instruction_pipeline`] /
-//! [`crate::core::instruction_overrides`]) but one level up. The four bundled
-//! assets under `src/assets/sm_instructions/` define the SM's behavior
-//! (identity, prohibitions SP1-SP7, allowlist, the 6-phase delegation loop, the
-//! BLOCKING verification gate, the tool/verb surface, and the non-overridable
-//! framework floor). Assembling them ad-hoc at each call site would invite the
+//! [`crate::core::instruction_overrides`]) but one level up. The five sections
+//! define the SM's behavior: identity, prohibitions SP1-SP7, allowlist; the
+//! canonical harness mental model (DOC-21); the 6-phase delegation loop; the
+//! BLOCKING verification gate; the tool/verb surface; and the non-overridable
+//! framework floor. Assembling them ad-hoc at each call site would invite the
 //! same ordering/content drift the PM pipeline was built to prevent.
-//! What: [`assemble_sm_prompt`] embeds the four assets via `include_str!` at
-//! compile time and joins them in the fixed order
-//! SM_INSTRUCTIONS -> SM_WORKFLOW -> SM_TOOLS -> BASE_SM, BASE_SM **always last**
-//! as the non-overridable floor. [`resolve_sm_prompt`] layers optional per-file
-//! overrides from an override directory (`~/.trusty-mpm/sm/`, see
-//! [`sm_override_dir`]) onto the bundled defaults, **always** appending the
-//! bundled BASE_SM floor last -- BASE_SM is never overridable.
+//! What: [`assemble_sm_prompt`] embeds the four bundled assets via `include_str!`
+//! at compile time and joins them with the shared harness-understanding content
+//! from `trusty_agents_common::harness_doc` in the fixed order
+//! SM_INSTRUCTIONS -> SM_HARNESS -> SM_WORKFLOW -> SM_TOOLS -> BASE_SM,
+//! BASE_SM **always last** as the non-overridable floor. [`resolve_sm_prompt`]
+//! layers optional per-file overrides from an override directory
+//! (`~/.trusty-mpm/sm/`, see [`sm_override_dir`]) onto the bundled defaults,
+//! **always** appending the bundled BASE_SM floor last -- BASE_SM is never
+//! overridable.
 //! Test: the `tests` module mirrors `instruction_overrides::tests` -- bundled
 //! content, per-file override replacement, the never-overridable BASE_SM floor
 //! invariant, and the missing/empty/unreadable fallbacks.
@@ -28,6 +30,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::core::instruction_pipeline::SECTION_SEPARATOR;
+use trusty_agents_common::harness_doc;
 
 // `pub(crate)` is deliberate: these bundled defaults are consumed only through
 // `assemble_sm_prompt` / `resolve_sm_prompt`, which own the ordering and the
@@ -64,30 +67,45 @@ pub const FILE_SM_INSTRUCTIONS: &str = "SM_INSTRUCTIONS.md";
 pub const FILE_SM_WORKFLOW: &str = "SM_WORKFLOW.md";
 /// Override file: replaces the bundled `SM_TOOLS` section.
 pub const FILE_SM_TOOLS: &str = "SM_TOOLS.md";
+/// Override file: replaces the bundled `SM_HARNESS` section (the shared
+/// harness-understanding content from `trusty-agents-common`).
+pub const FILE_SM_HARNESS: &str = "SM_HARNESS.md";
 
-/// Assemble the SM system prompt from the four bundled assets.
+/// Assemble the SM system prompt from the four bundled assets plus the shared
+/// harness-understanding content from `trusty_agents_common::harness_doc`.
 ///
 /// Why: the SM's provider request needs an identical, version-controlled system
 /// prompt every time; embedding the sources and joining them here removes any
 /// runtime dependency on an external install and keeps the ordering rule in one
 /// auditable place (mirrors [`assemble_system_prompt`]).
-/// What: joins the four bundled assets in the fixed order SM_INSTRUCTIONS ->
-/// SM_WORKFLOW -> SM_TOOLS -> BASE_SM, separated by the `---` rule. Each section
+/// What: joins the five sections in the fixed order SM_INSTRUCTIONS ->
+/// SM_HARNESS -> SM_WORKFLOW -> SM_TOOLS -> BASE_SM, separated by the `---`
+/// rule. The SM_HARNESS section is the full harness-understanding doc from
+/// `trusty_agents_common::harness_doc::harness_understanding()`. Each section
 /// is trimmed before joining -- byte-for-byte the same treatment
 /// [`resolve_sm_prompt`] applies -- so the two produce identical output when no
 /// override is present. BASE_SM is **always last** as the non-overridable
 /// framework floor.
 /// Test: `assemble_sm_prompt_contains_all_sections`,
 /// `assemble_sm_prompt_base_floor_is_last`,
+/// `assemble_sm_prompt_contains_harness_section`,
 /// `resolve_with_no_overrides_matches_assembled_sections` (exact equality).
 ///
 /// [`assemble_system_prompt`]: crate::core::instruction_pipeline::assemble_system_prompt
 pub fn assemble_sm_prompt() -> String {
-    [SM_INSTRUCTIONS, SM_WORKFLOW, SM_TOOLS, BASE_SM]
-        .iter()
-        .map(|s| s.trim())
-        .collect::<Vec<_>>()
-        .join(SECTION_SEPARATOR)
+    let harness = harness_doc::harness_understanding();
+    let harness_trimmed = harness.trim();
+    vec![
+        SM_INSTRUCTIONS.trim(),
+        harness_trimmed,
+        SM_WORKFLOW.trim(),
+        SM_TOOLS.trim(),
+        BASE_SM.trim(),
+    ]
+    .into_iter()
+    .filter(|s| !s.is_empty())
+    .collect::<Vec<_>>()
+    .join(SECTION_SEPARATOR)
 }
 
 /// Resolve `~/.trusty-mpm/sm/`, the SM's override directory.
@@ -151,35 +169,51 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 /// floor. Both the live prompt (the provider `system` message, SM-7) and any
 /// future inspectable stash call this one function so they can never diverge.
 ///
-/// What: for each of `SM_INSTRUCTIONS`, `SM_WORKFLOW`, and `SM_TOOLS`, uses the
-/// override file from `dir` when present and non-empty, else the bundled
-/// default. The bundled `BASE_SM` floor is **always** appended last and is
-/// **never** overridable -- even a `BASE_SM.md` placed in `dir` is ignored; the
-/// bundled floor is used. Sections are joined with [`SECTION_SEPARATOR`], the
-/// same rule [`assemble_sm_prompt`] uses, so the two never visually diverge.
+/// What: for each of `SM_INSTRUCTIONS`, `SM_HARNESS`, `SM_WORKFLOW`, and
+/// `SM_TOOLS`, uses the override file from `dir` when present and non-empty,
+/// else the bundled default (SM_HARNESS falls back to
+/// `harness_doc::harness_understanding()`). The bundled `BASE_SM` floor is
+/// **always** appended last and is **never** overridable -- even a `BASE_SM.md`
+/// placed in `dir` is ignored; the bundled floor is used. Sections are joined
+/// with [`SECTION_SEPARATOR`], the same rule [`assemble_sm_prompt`] uses, so
+/// the two never visually diverge. Order: SM_INSTRUCTIONS -> SM_HARNESS ->
+/// SM_WORKFLOW -> SM_TOOLS -> BASE_SM.
 ///
 /// Robustness: a missing override directory, missing files, empty files, and
 /// unreadable files all fall back to the bundled defaults without failing.
 ///
 /// Test: `no_overrides_uses_bundled`, `sm_instructions_override_replaces`,
-/// `workflow_override_replaces`, `tools_override_replaces`,
-/// `base_sm_floor_is_never_overridable`, and the robustness tests.
+/// `harness_override_replaces`, `workflow_override_replaces`,
+/// `tools_override_replaces`, `base_sm_floor_is_never_overridable`, and the
+/// robustness tests.
 pub fn resolve_sm_prompt(dir: &Path) -> String {
     let instructions = read_override(dir, FILE_SM_INSTRUCTIONS)
         .unwrap_or_else(|| SM_INSTRUCTIONS.trim().to_string());
+
+    // The harness section uses the shared trusty-agents-common content, with
+    // an optional override via SM_HARNESS.md in the override directory.
+    let harness_default = harness_doc::harness_understanding();
+    let harness =
+        read_override(dir, FILE_SM_HARNESS).unwrap_or_else(|| harness_default.trim().to_string());
+
     let workflow =
         read_override(dir, FILE_SM_WORKFLOW).unwrap_or_else(|| SM_WORKFLOW.trim().to_string());
     let tools = read_override(dir, FILE_SM_TOOLS).unwrap_or_else(|| SM_TOOLS.trim().to_string());
 
     // BASE_SM is the non-overridable floor: always the bundled one, always last.
-    let sections = [instructions, workflow, tools, BASE_SM.trim().to_string()];
-
-    sections
-        .iter()
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join(SECTION_SEPARATOR)
+    // Order: SM_INSTRUCTIONS -> SM_HARNESS -> SM_WORKFLOW -> SM_TOOLS -> BASE_SM
+    vec![
+        instructions,
+        harness,
+        workflow,
+        tools,
+        BASE_SM.trim().to_string(),
+    ]
+    .into_iter()
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+    .collect::<Vec<_>>()
+    .join(SECTION_SEPARATOR)
 }
 
 /// Resolve the effective SM prompt for the production `~/.trusty-mpm/sm/`
@@ -214,15 +248,21 @@ mod tests {
     #[test]
     fn assemble_sm_prompt_contains_all_sections() {
         // Why: the assembled prompt IS the SM's behavior contract; every bundled
-        // section -- prohibitions, allowlist, 6-phase loop, verification gate,
-        // and the BASE_SM floor -- must be present and joined with the `---`
-        // rule.
+        // section -- prohibitions, allowlist, harness model, 6-phase loop,
+        // verification gate, and the BASE_SM floor -- must be present and joined
+        // with the `---` rule.
         let prompt = assemble_sm_prompt();
         // Identity + prohibitions table (SP1-SP7) + allowlist.
         assert!(prompt.contains("# Session Manager (SM) -- trusty-mpm"));
         assert!(prompt.contains("| SP1 |"));
         assert!(prompt.contains("| SP7 |"));
         assert!(prompt.contains("You MAY do directly (Allowlist)"));
+        // The harness-understanding section (DOC-21) canonical markers.
+        assert!(prompt.contains('✻'), "harness ✻ glyph must be present");
+        assert!(
+            prompt.contains("__HARNESS_EVENT__"),
+            "harness __HARNESS_EVENT__ must be present"
+        );
         // The 6-phase loop + verification gate.
         assert!(prompt.contains("# SM Workflow -- the delegation loop"));
         assert!(prompt.contains("1. **INTAKE.**"));
@@ -250,6 +290,43 @@ mod tests {
             .expect("workflow");
         assert!(workflow < tools, "workflow precedes tools");
         assert!(base > tools, "BASE_SM floor must be appended last");
+        // Verify harness section appears before BASE_SM floor
+        let harness_pos = prompt.find('✻').expect("harness ✻ glyph");
+        assert!(
+            harness_pos < base,
+            "harness section must precede BASE_SM floor"
+        );
+    }
+
+    #[test]
+    fn assemble_sm_prompt_contains_harness_section() {
+        let prompt = assemble_sm_prompt();
+        // The harness understanding section contains the Claude Code working glyph
+        // and the tcode event prefix as canonical markers (DOC-21).
+        assert!(
+            prompt.contains('✻'),
+            "assembled SM prompt must contain ✻ (harness understanding glyph marker)"
+        );
+        assert!(
+            prompt.contains("__HARNESS_EVENT__"),
+            "assembled SM prompt must contain __HARNESS_EVENT__ (tcode event marker)"
+        );
+    }
+
+    #[test]
+    fn harness_override_replaces() {
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_SM_HARNESS,
+            "# Custom Harness Doc\n\nHARNESS_OVERRIDE_SENTINEL\n",
+        );
+        let prompt = resolve_sm_prompt(tmp.path());
+        assert!(prompt.contains("HARNESS_OVERRIDE_SENTINEL"));
+        assert!(prompt.contains("# Session Manager (SM) -- trusty-mpm"));
+        assert!(prompt.contains("# SM Workflow -- the delegation loop"));
+        assert!(prompt.contains("# SM Tools -- the verbs you may call"));
+        assert!(prompt.contains("# BASE_SM Framework Floor"));
     }
 
     #[test]
@@ -434,8 +511,16 @@ mod tests {
             resolved, assembled,
             "no-override resolve must be byte-identical to assemble"
         );
+        // The harness section itself contains internal `---` separators (it is a
+        // concatenation of 4 sub-documents), so the total split count is > 5.
+        // Assert at least 5 top-level sections are present (SM_INSTRUCTIONS +
+        // SM_HARNESS-body + SM_WORKFLOW + SM_TOOLS + BASE_SM, with the harness
+        // body contributing additional `---` delimiters from its sub-sections).
         let section_count = assembled.split(SECTION_SEPARATOR).count();
-        assert_eq!(section_count, 4, "four sections expected");
+        assert!(
+            section_count >= 5,
+            "at least five sections expected (got {section_count})"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/sm/prompt.rs
+++ b/crates/trusty-mpm/src/core/sm/prompt.rs
@@ -511,15 +511,15 @@ mod tests {
             resolved, assembled,
             "no-override resolve must be byte-identical to assemble"
         );
-        // The harness section itself contains internal `---` separators (it is a
-        // concatenation of 4 sub-documents), so the total split count is > 5.
-        // Assert at least 5 top-level sections are present (SM_INSTRUCTIONS +
-        // SM_HARNESS-body + SM_WORKFLOW + SM_TOOLS + BASE_SM, with the harness
-        // body contributing additional `---` delimiters from its sub-sections).
+        // The harness block joins its four sub-sections with plain "\n\n" (not
+        // "---"), so it does NOT embed SECTION_SEPARATOR internally. The assembled
+        // SM prompt contains exactly 5 top-level sections separated by "---":
+        // SM_INSTRUCTIONS → SM_HARNESS → SM_WORKFLOW → SM_TOOLS → BASE_SM.
         let section_count = assembled.split(SECTION_SEPARATOR).count();
-        assert!(
-            section_count >= 5,
-            "at least five sections expected (got {section_count})"
+        assert_eq!(
+            section_count, 5,
+            "exactly five top-level sections expected (got {section_count}); \
+             the harness block must not embed the top-level separator"
         );
     }
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -29,6 +29,7 @@ can resolve a changed file back to the section that governs it.
 | DOC-18 | `SPEC-METACODING-01~draft` | [Metacoding — the trusty-tools product north-star](./metacoding-vision.md) | trusty-tools — product vision (cross-crate) |
 | DOC-19 | `SPEC-TELUI-01~draft` | [TELUI: the Telegram UI for trusty-mpm](./telui-telegram-ui.md) | trusty-mpm — control surface / Telegram |
 | DOC-20 | `SPEC-CHAT-CORE-01~draft` | [Chat-Core: the shared command nucleus](./chat-core.md) | trusty-mpm — control surface / shared client |
+| DOC-21 | `SPEC-HARNESS-UNDERSTANDING-01~draft` | [Harness Understanding](./harness-understanding.md) | trusty-agents-common + trusty-mpm |
 
 ## Status lifecycle
 

--- a/docs/specs/harness-understanding.md
+++ b/docs/specs/harness-understanding.md
@@ -1,0 +1,283 @@
+# DOC-21 — Harness Understanding: canonical mental model for SM and future t-code overseer
+
+**Status:** Draft
+**Subsystem:** trusty-agents-common — harness-understanding instructions; trusty-mpm — SM prompt
+**Owner:** Engineering (trusty-agents-common, trusty-mpm)
+**Last-updated:** 2026-06-20
+**Spec ID:** `SPEC-HARNESS-UNDERSTANDING-01~draft` (DOC-21)
+**Builds on:** DOC-14 — Session Manager (SM) Agent (`docs/specs/session-manager-agent.md`); DOC-17 — Autonomous Multi-Session Managed Harness Runner (`docs/specs/harness-runner-vision.md`); DOC-20 — Chat-Core (`docs/specs/chat-core.md`)
+**Cross-ref:** `crates/trusty-agents-common/src/harness_doc.rs`, `crates/trusty-agents-common/src/assets/harness_understanding/`, `crates/trusty-mpm/src/core/sm/prompt.rs`, `crates/trusty-mpm/src/assets/sm_instructions/`, issues **#1510**, **#862**, **#875**
+
+> **Scope note.** This is a behavior-contract spec for the *canonical harness-understanding instruction set* shared by trusty-agents-common and consumed by trusty-mpm's session-manager (SM) prompt today and a future t-code overseer tomorrow. It defines the harness mental model, per-harness signals, the intervention decision protocol, a deterministic LLM-free fallback, SM-specific wiring, and the forward-looking t-code-as-overseer contract.
+
+---
+
+## 1. Motivation
+
+The current gap: `SM_WORKFLOW` tells the SM to "interpret the raw pane state yourself" but never teaches *how*. No harness mechanics are encoded anywhere the SM can reason from. Additionally, the `ActivityMonitor` degrades to `ActivityState::Unknown` when `OPENROUTER_API_KEY` is absent, leaving the SM with no deterministic fallback to classify sessions.
+
+This spec fills the gap by defining:
+1. A canonical harness mental model (session lifecycle, pane/IO model, prompt shapes, tool-call patterns, approval gates, completion evidence, error patterns).
+2. A WHEN-TO-INTERVENE decision protocol mapping observable state to SM actions.
+3. A deterministic LLM-free fallback that applies directly to raw pane text.
+4. Per-harness specifics for Claude Code and tcode.
+5. trusty-mpm SM wiring: how OBSERVE/VERIFY consume the model.
+6. Forward-looking t-code-as-overseer contract.
+
+The shared module in `trusty-agents-common` ensures both the SM prompt and a future t-code overseer consume the same authoritative content.
+
+---
+
+## 2. Canonical Harness Mental Model (Agnostic)
+
+### 2.1 Session Lifecycle & States
+
+Every harness session passes through a well-defined lifecycle mapping to `HarnessState`:
+
+| State | Meaning | Observable signals |
+|-------|---------|-------------------|
+| `Starting` | Process launched, not yet producing output | Blank pane or very first output lines |
+| `Idle` | Ready and waiting for operator input | Prompt visible (`> `, `$`, `#`), no activity |
+| `Working` | Actively processing a task | Spinner glyphs, streaming output, tool calls |
+| `Paused` | Waiting on an operator decision | A question, permission dialog, or approval gate |
+| `Error` | Encountered a non-recoverable error | Error banners, exit codes, panic traces |
+| `Stopped` | Session has exited cleanly | No runtime process; final output visible |
+
+### 2.2 Pane / IO Model
+
+The **pane** is the tmux-backed terminal surface — it is the ONLY observable surface for a running harness. The SM reads captured pane text (observe) and writes to it (send a message).
+
+Key facts:
+- The SM sees the **last N lines** of the terminal (the observation window).
+- Output is **streaming** — the pane may be mid-output when observed.
+- A pane silent for >30 seconds with no Working glyphs is almost certainly Idle or Stopped.
+
+### 2.3 Prompt Shapes
+
+| Harness | Idle prompt | Notes |
+|---------|------------|-------|
+| Claude Code | `> ` (bare `>` at start of line) | Single `>` alone on the line |
+| Shell | `$ ` or `# ` | Standard Unix shell prompts |
+| tcode | No pane prompt (event-driven) | Uses `__HARNESS_EVENT__` NDJSON events |
+
+An idle prompt on the **last line** of the pane is the strongest signal that a harness is Idle.
+
+### 2.4 Tool-Call Patterns
+
+- **Claude Code**: Tool calls appear as bracketed blocks. The `✻` glyph appears during tool execution (`✻ Running bash...`, `✻ Reading file...`).
+- **tcode**: Emits structured NDJSON event lines prefixed with `__HARNESS_EVENT__`. Example: `__HARNESS_EVENT__ {"type":"tool_use","tool":"bash","input":{...}}`. Parseable as JSON after stripping the prefix.
+- **Shell**: Raw command output; no structured wrapper.
+
+### 2.5 Approval / Decision Gates
+
+Harnesses may pause and wait for operator approval:
+- **Permission dialogs**: Claude Code shows `Allow` / `Deny` / `Always allow` options — hard blockers.
+- **Y/N prompts**: Text ending with `? [y/N]` or `Continue? (y/n):`.
+- **Trust dialogs**: First-run trust establishment.
+- **Custom questions**: Open-ended operator decisions.
+
+When a decision gate is visible, the session is in `Paused` state.
+
+### 2.6 Completion & Evidence Signals
+
+A task is done only when evidence is observed:
+
+| Claim | Evidence pattern |
+|-------|-----------------|
+| "PR opened" | GitHub PR URL: `https://github.com/.*/pull/\d+` |
+| "tests pass" | `N passed; 0 failed`, `test result: ok. N passed`, `All tests passed` |
+| "edit made" | Diff output or `Write(path)` / `Edit(path)` confirmation lines |
+| "task done" | `Task complete`, `Done`, `✓`, or equivalent success banner |
+| "build passes" | `Finished` or `warning(0)` from `cargo check` / `cargo build` |
+
+Never claim a task is complete without at least one observed evidence pattern.
+
+### 2.7 Error Patterns
+
+- **Rust compilation errors**: `error[E`, `error:` with file:line citations
+- **Test failures**: `FAILED`, `N failed`, `test result: FAILED`
+- **Runtime panics**: `thread 'main' panicked at`, `panicked at '`
+- **Process exit errors**: `exit code: N` (non-zero), `exited with status`
+- **Generic prefixes**: Lines starting with `Error:` or `ERROR:`
+- **Tool errors**: `✻ Error:` or structured error blocks in Claude Code
+
+### 2.8 Observability & Inference
+
+Two tiers:
+1. **Deterministic (LLM-free)**: Apply patterns to raw pane text. No tokens, no network, always available.
+2. **LLM-backed (optional)**: `ActivityMonitor` with `OPENROUTER_API_KEY`. Returns `ActivityState` with confidence. When key absent: `state = Unknown` — fall back to tier 1.
+
+Always apply tier 1 first; tier 2 can confirm or refine but never overrides a clear tier-1 signal.
+
+---
+
+## 3. WHEN-TO-INTERVENE Decision Protocol
+
+The canonical decision tree for every pane observation:
+
+| Observed state | Action | Rationale |
+|----------------|--------|-----------|
+| `Working` with progress signals | **WAIT** | Session is making progress |
+| `Idle` + pending question visible | **SEND** answer | Session is blocked |
+| `Idle` + no question, task incomplete | **SEND** follow-up | Session may be stuck |
+| `Paused` + permission dialog | **ESCALATE** or send authorized answer | May require operator judgment |
+| `Error` | **INTERRUPT** + report error | Cannot self-recover |
+| Silent >5 min, Unknown state | **INTERRUPT** + re-observe | Abnormal silence |
+| `Stopped` (runtime exited) | **REPORT** result + check evidence | Apply verification gate |
+
+**Decision escalation order**: WAIT < SEND < INTERRUPT < ESCALATE (FlagForHuman).
+Choose the lowest-intensity action that resolves the observable state.
+
+---
+
+## 4. Deterministic (LLM-Free) Fallback Model
+
+When `OPENROUTER_API_KEY` is absent (or the LLM returns `Unknown`), apply these rules to raw pane text:
+
+### idle-by-silence
+- Pane silent for >30 seconds, AND no Working glyphs in the last 5 lines, AND last non-empty line matches `^>\s*$`, `^\$\s`, or `^#\s`
+→ **Classify as Idle**
+
+### completion-by-banner
+- Pane contains: PR URL, test-pass summary, `Task complete`, `Done.`, `✓ Complete`, or `Finished` (Rust build)
+→ **Classify as Done / Idle with completion evidence**
+
+### error-by-keyword
+- Pane contains: `error[E`, `FAILED`, `panicked at`, `exit code: [^0]`, `Error:` (line-start), `✻ Error:`
+→ **Classify as Error**
+
+### working-by-glyph
+- Pane contains `✻` in the last 10 lines, OR output is actively streaming
+→ **Classify as Working**
+
+### default
+- None of the above → **Classify as Unknown** (re-observe before acting)
+
+This directly addresses the `ActivityState::Unknown` fallback gap (issue #875).
+
+---
+
+## 5. Per-Harness Specifics
+
+### 5.1 Claude Code
+
+- **Banner**: `Claude Code vX.Y` (startup)
+- **Working glyph**: `✻`
+- **Idle prompt**: `> ` (single `>` alone on line)
+- **Permission dialogs**: Shows `Allow`, `Deny`, `Always allow` options
+- **Completion patterns**: `Task complete`, PR URL, diff output
+- **Error patterns**: `✻ Error:`, `error[E`, compilation errors
+
+### 5.2 tcode
+
+- **Task banners**: `=== Task: <description> ===` (start), `=== Done ===` (end)
+- **Event prefix**: `__HARNESS_EVENT__` NDJSON lines — parseable events
+- **Agent-delegation output**: `[agent-name] <output>` prefixed lines
+- **Diff/edit confirmation**: `Edit: src/foo.rs (+15, -3)`, `Write: src/bar.rs`
+- **State classification**: Prefer `__HARNESS_EVENT__` events over pane text
+
+---
+
+## 6. trusty-mpm Session Manager Wiring
+
+### 6.1 How OBSERVE Consumes This
+
+`sessions.get(session_id)` returns a `RawObservation` with `raw_pane`, `runtime_active`, `pending_decision`, and `proposed_default`. The SM:
+1. Checks `runtime_active` — if `false`, session has Stopped.
+2. Checks `pending_decision` — if set, session is Paused.
+3. Applies the deterministic model (§4) to `raw_pane`.
+4. Optionally uses the LLM `Summary` to confirm tier-1 classification.
+
+### 6.2 How VERIFY Uses §2.6 Completion Evidence Signals
+
+The BLOCKING verification gate (SM Workflow §5) maps completion claims to observed evidence in `raw_pane`. No evidence → task not done. Re-observe, then send follow-up.
+
+### 6.3 Managed States and Adopt Semantics
+
+On adopt of a pre-existing tmux session, the SM has no prior history. Apply the full observation protocol from scratch. If `pending_decision` is set, handle as Paused.
+
+### 6.4 Chat-Core Verbs and §3 Mapping
+
+| §3 action | SM verb |
+|-----------|---------|
+| WAIT | (no call; next poll cycle) |
+| SEND answer | `sessions.send(session_id, text)` |
+| INTERRUPT | `sessions.stop(session_id)` then re-launch |
+| ESCALATE | Report to operator; do NOT send to session |
+
+### 6.5 RawObservation/Summary Two-Tier
+
+- **`observe` (raw, always available)**: `sessions.get` with no inference. Uses deterministic model.
+- **`summarize` (LLM-backed, optional)**: When `OPENROUTER_API_KEY` is present. When absent: `state = Unknown`, `summary = None`, `confidence = 0.0`.
+
+Operate from `RawObservation` alone when needed; LLM summary is a bonus.
+
+### 6.6 Override Convention
+
+`~/.trusty-mpm/sm/SM_HARNESS.md` overrides the shared trusty-agents-common harness section. When absent or empty, the shared content from `trusty-agents-common::harness_doc` is used. Follows the same convention as `SM_INSTRUCTIONS.md`, `SM_WORKFLOW.md`, and `SM_TOOLS.md`.
+
+---
+
+## 7. Forward-Looking t-code-as-Overseer Contract
+
+### 7.1 The Seam
+
+Two components already in place:
+1. **`Overseer` trait** (`crates/trusty-mpm/src/core/overseer.rs`): dispatches hook events; returns `OverseerDecision::{Allow, Block, Respond, FlagForHuman}`.
+2. **`HarnessSource::Code`** (`crates/trusty-agents-common/src/events/lifecycle.rs`): reserved source tag for tcode-originated `HarnessEvent`s.
+
+### 7.2 Event-to-Decision Mapping
+
+A t-code overseer maps `HarnessEvent`s (filtered on `HarnessSource::Code`) to `OverseerDecision` using the §3 WHEN-TO-INTERVENE protocol:
+
+| Observed event | Decision | Rationale |
+|----------------|----------|-----------|
+| `pm_thinking` — routine reasoning | `Allow` | Normal Working state |
+| `agent_message` — within scope | `Allow` | Expected output |
+| Permission dialog detected | `Respond` or `FlagForHuman` | Decision gate |
+| Error + non-recoverable | `FlagForHuman` | Human must decide |
+| Sensitive file write outside scope | `Block { reason }` | Scope violation |
+| Unexpected tool call | `Block { reason }` | Scope enforcement |
+| Long silence (>5 min) in Working state | `FlagForHuman` | Possible hang |
+
+### 7.3 `__HARNESS_EVENT__` Lines as Structured Overseer Input
+
+For a t-code overseer, `__HARNESS_EVENT__` lines are the primary structured input (vs. pane text for Claude Code). Strip the prefix, parse as `HarnessEvent`, filter on `source == HarnessSource::Code`.
+
+### 7.4 Reserved `HarnessSource::Code` Slot
+
+No emitters exist yet. This spec governs the behavioral contract when the first real emitter lands. The `HarnessSource::Code` tag transitions from "reserved" to "active" at that point.
+
+---
+
+## 8. Where It Lives
+
+The shared module lives in:
+- **Module**: `crates/trusty-agents-common/src/harness_doc.rs`
+- **Assets**: `crates/trusty-agents-common/src/assets/harness_understanding/`
+  - `HARNESS_AGNOSTIC.md` — §2 + §3 + §4 content
+  - `HARNESS_MPM_SM.md` — §6 content
+  - `HARNESS_TCODE.md` — §5.2 content
+  - `HARNESS_OVERSEER.md` — §7 content
+
+**Consumers load it via**:
+- `trusty-mpm`: `use trusty_agents_common::harness_doc; harness_doc::harness_understanding()`
+  called from `crates/trusty-mpm/src/core/sm/prompt.rs`.
+- Future tcode overseer: same API, filtered to relevant sections.
+
+---
+
+## References
+
+- DOC-14: Session Manager (SM) Agent — `docs/specs/session-manager-agent.md`
+- DOC-17: Autonomous Multi-Session Managed Harness Runner — `docs/specs/harness-runner-vision.md`
+- DOC-20: Chat-Core — `docs/specs/chat-core.md`
+- Issues: #1510 (this spec), #862 (trusty-agents-common extraction), #875 (ActivityState::Unknown fallback)
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-06-20 | Initial draft (DOC-21, #1510) |


### PR DESCRIPTION
## What
Encodes deep "harness-understanding" knowledge so today's trusty-mpm session-manager (SM) and a future t-code overseer both reason competently about coding-harness sessions. Closes the gap where SM_WORKFLOW said "interpret the raw pane yourself" without teaching how.

### Shared source (trusty-agents-common)
New `harness_doc` module + 4 bundled markdown assets:
- HARNESS_AGNOSTIC.md — lifecycle/states, pane/IO, prompt shapes, tool-call & approval-gate patterns, completion/evidence + error signals, the WHEN-TO-INTERVENE protocol (wait/send/interrupt/escalate), and a deterministic LLM-free fallback (idle-by-silence, completion-by-banner, error-by-keyword) for when OPENROUTER_API_KEY is absent.
- HARNESS_MPM_SM.md — OBSERVE/VERIFY flow, managed states, adopt, chat-core verbs, RawObservation/Summary two-tier, override convention.
- HARNESS_TCODE.md — tcode `__HARNESS_EVENT__` NDJSON events, task banners, agent-delegation/diff patterns.
- HARNESS_OVERSEER.md — forward-looking t-code overseer contract (Overseer trait + HarnessSource::Code seam, event→decision mapping, FlagForHuman escalation).
Public API: `harness_doc::{agnostic, mpm_session_manager, tcode, overseer}() -> &'static str` + `harness_understanding() -> String`.

### Consumed by the SM prompt (trusty-mpm)
`core/sm/prompt.rs` now assembles `SM_INSTRUCTIONS → harness_understanding() → SM_WORKFLOW → SM_TOOLS → BASE_SM`, reaching all three injection sites with no call-site changes. Overridable via `~/.trusty-mpm/sm/SM_HARNESS.md` (same convention as the other sections), falling back to the shared content.

### Spec
docs/specs/harness-understanding.md — `SPEC-HARNESS-UNDERSTANDING-01~draft` (DOC-21), builds on DOC-14/17/20; README catalog updated.

## Tests
trusty-agents-common 83 passed; trusty-mpm prompt-assembly 15 passed (incl. harness-section-present + override-replaces). clippy `-D warnings`, fmt, line-cap clean. Cross-crate.

Closes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)