### PR TITLE
feat(trusty-mpm): project registry + MCP tools (closes #1519)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10994,6 +10994,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "trusty-agents-common",
  "trusty-common",
  "trusty-review",
  "utoipa",

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -102,6 +102,16 @@ pub struct TrustyToolsConfig {
     /// are applied to every `gh` subprocess `tm` spawns for the active project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github: Option<GithubConfig>,
+
+    /// Statically-declared projects for the project registry (#1519 MR-1).
+    ///
+    /// `None` / absent → no static projects; the registry starts empty and is
+    /// populated by MCP `project_register` calls and boot auto-registration from
+    /// session history. When present, each entry is upserted into the registry
+    /// at daemon startup, so an operator can declare frequently-used repos once
+    /// in config rather than registering them via MCP on every restart.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub projects: Vec<ProjectConfig>,
 }
 
 /// The `github:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#1265).
@@ -192,6 +202,40 @@ pub struct WatchConfig {
     /// Default poll interval (seconds) for `listen` mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interval_secs: Option<u64>,
+}
+
+/// A single project entry declared in the `projects:` YAML section (#1519 MR-1).
+///
+/// Why: operators who use a fixed set of repos want to declare them once in
+/// `config.yaml` so the project registry is pre-populated on daemon startup
+/// without requiring MCP `project_register` calls. Every field beyond `name`
+/// and `repo_url` is optional so a minimal two-line entry is valid.
+/// What: on-disk shape for one project declaration. The daemon reads these at
+/// startup and upserts them into the `ProjectRegistry` via `seed_from_config`.
+/// Test: `registry_seed_from_config` in the `project::registry` module.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectConfig {
+    /// Short name used as the registry key (e.g. `trusty-tools`).
+    pub name: String,
+
+    /// Full repository URL (e.g. `https://github.com/owner/trusty-tools`).
+    pub repo_url: String,
+
+    /// Default branch; falls back to `"main"` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_branch: Option<String>,
+
+    /// Optional technology-stack hint (e.g. `"rust"`, `"python"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stack_hint: Option<String>,
+
+    /// Classification tags (e.g. `["backend", "production"]`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+
+    /// Free-form description of the project.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 impl TrustyToolsConfig {

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -457,6 +457,37 @@ impl OrchestratorBackend for StateBackend {
     ) -> Result<Value, String> {
         super::mcp_console::config_write(workspace_root_template, auto_resume, default_model)
     }
+
+    // ── #1519 WI-2: project-registry tools (delegate to mcp_project) ─────────
+
+    async fn project_list(&self) -> Result<Value, String> {
+        super::mcp_project::project_list(&self.state).await
+    }
+
+    async fn project_register(
+        &self,
+        name: &str,
+        repo_url: &str,
+        default_branch: Option<&str>,
+        stack_hint: Option<&str>,
+        tags: Option<Vec<String>>,
+        description: Option<&str>,
+    ) -> Result<Value, String> {
+        super::mcp_project::project_register(
+            &self.state,
+            name,
+            repo_url,
+            default_branch,
+            stack_hint,
+            tags,
+            description,
+        )
+        .await
+    }
+
+    async fn project_get(&self, name: &str) -> Result<Value, String> {
+        super::mcp_project::project_get(&self.state, name).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/mcp_project.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_project.rs
@@ -31,11 +31,12 @@ pub async fn project_list(state: &Arc<DaemonState>) -> Result<Value, String> {
         .list()
         .await
         .map_err(|e| format!("project_list: registry error: {e}"))?;
-    let values: Vec<Value> = projects
+    let values = projects
         .into_iter()
-        .map(|p| serde_json::to_value(p).unwrap_or(Value::Null))
-        .collect();
-    Ok(json!({ "projects": values, "count": values.len() }))
+        .map(|p| serde_json::to_value(p).map_err(|e| format!("project_list: serialize error: {e}")))
+        .collect::<Result<Vec<Value>, String>>()?;
+    let count = values.len();
+    Ok(json!({ "projects": values, "count": count }))
 }
 
 /// Register or update a project in the registry.

--- a/crates/trusty-mpm/src/daemon/mcp_project.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_project.rs
@@ -1,0 +1,88 @@
+//! Daemon-side implementation of the three project-registry MCP tools
+//! (#1519 WI-2).
+//!
+//! Why: the MCP `StateBackend` (in `mcp_backend.rs`) must service the new
+//! `project_*` tools, but inlining their bodies there would push that file
+//! over the 500-SLOC production cap. This module holds the wrapping logic,
+//! mirroring the `mcp_session.rs` / `mcp_console.rs` pattern.
+//! What: three free async functions — `project_list`, `project_register`, and
+//! `project_get` — each taking `&Arc<DaemonState>` plus parsed arguments and
+//! returning a JSON value or a human-readable error string.
+//! Test: the dispatch-level tests in `crate::mcp::tests` exercise these
+//! functions through the mock backend.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+
+use crate::daemon::state::DaemonState;
+use crate::project::record::Project;
+
+/// Return all registered projects as a JSON array.
+///
+/// Why: `project_list` gives the driver skill and operators a typed,
+/// JSON-native inventory of known repos without scraping CLI text.
+/// What: delegates to `DaemonState::project_registry` and serializes all
+/// entries; an empty registry returns `{ "projects": [] }`.
+/// Test: `dispatch_project_list_tool` in `crate::mcp::tests`.
+pub async fn project_list(state: &Arc<DaemonState>) -> Result<Value, String> {
+    let registry = state.project_registry().await;
+    let projects = registry
+        .list()
+        .await
+        .map_err(|e| format!("project_list: registry error: {e}"))?;
+    let values: Vec<Value> = projects
+        .into_iter()
+        .map(|p| serde_json::to_value(p).unwrap_or(Value::Null))
+        .collect();
+    Ok(json!({ "projects": values, "count": values.len() }))
+}
+
+/// Register or update a project in the registry.
+///
+/// Why: `project_register` is the typed, JSON-native way to add a project
+/// without editing `config.yaml` or restarting the daemon.
+/// What: builds a `Project` from the supplied fields (defaulting
+/// `default_branch` to `"main"` when omitted), calls `registry.register`,
+/// and returns the persisted record.
+/// Test: `dispatch_project_register_tool` in `crate::mcp::tests`.
+pub async fn project_register(
+    state: &Arc<DaemonState>,
+    name: &str,
+    repo_url: &str,
+    default_branch: Option<&str>,
+    stack_hint: Option<&str>,
+    tags: Option<Vec<String>>,
+    description: Option<&str>,
+) -> Result<Value, String> {
+    let project = Project {
+        name: name.to_string(),
+        repo_url: repo_url.to_string(),
+        default_branch: default_branch.unwrap_or("main").to_string(),
+        stack_hint: stack_hint.map(str::to_string),
+        tags: tags.unwrap_or_default(),
+        description: description.map(str::to_string),
+    };
+    let registry = state.project_registry().await;
+    registry
+        .register(project.clone())
+        .await
+        .map_err(|e| format!("project_register: registry error: {e}"))?;
+    serde_json::to_value(&project).map_err(|e| e.to_string())
+}
+
+/// Look up a single project by name.
+///
+/// Why: `project_get` is the typed point-lookup that lets a driver retrieve
+/// a project's `repo_url` and `default_branch` without listing all projects.
+/// What: calls `registry.get(name)` and serializes the result; returns a
+/// descriptive error string when the name is not registered.
+/// Test: `dispatch_project_get_tool` in `crate::mcp::tests`.
+pub async fn project_get(state: &Arc<DaemonState>, name: &str) -> Result<Value, String> {
+    let registry = state.project_registry().await;
+    let project = registry
+        .get(name)
+        .await
+        .map_err(|e| format!("project `{name}` not found: {e}"))?;
+    serde_json::to_value(&project).map_err(|e| e.to_string())
+}

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -23,6 +23,7 @@ pub mod lock;
 pub mod managed_routes;
 pub mod mcp_backend;
 pub mod mcp_console;
+pub mod mcp_project;
 pub mod mcp_session;
 pub mod openapi;
 pub mod optimizer;

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -199,6 +199,19 @@ pub struct DaemonState {
             >,
         >,
     >,
+
+    /// Lazily-initialized project registry for the `project_*` MCP tools (#1519).
+    ///
+    /// Why: `ProjectRegistry::load` is async (it reads the on-disk store) and
+    /// cannot be called inside the synchronous `DaemonState` constructors. A
+    /// `OnceCell` defers construction to the first `project_*` MCP request and
+    /// caches the shared handle thereafter, following the same pattern as
+    /// `managed_sessions`.
+    /// What: holds `None` until [`Self::project_registry`] first runs, then the
+    /// shared `Arc<ProjectRegistry>`.
+    /// Test: `mcp_project` tests exercise the registry via the dispatch path.
+    pub(super) project_registry:
+        tokio::sync::OnceCell<std::sync::Arc<crate::project::ProjectRegistry>>,
 }
 
 impl Default for DaemonState {
@@ -252,6 +265,7 @@ impl DaemonState {
             event_tx,
             managed_sessions: tokio::sync::OnceCell::new(),
             activity_monitor: std::sync::OnceLock::new(),
+            project_registry: tokio::sync::OnceCell::new(),
         }
     }
 
@@ -324,6 +338,7 @@ impl DaemonState {
             event_tx,
             managed_sessions: tokio::sync::OnceCell::new(),
             activity_monitor: std::sync::OnceLock::new(),
+            project_registry: tokio::sync::OnceCell::new(),
         }
     }
 
@@ -474,5 +489,49 @@ impl DaemonState {
         let mut state = Self::new();
         state.session_manager_agent = agent;
         state
+    }
+
+    /// Return the shared project registry, constructing it on first access (#1519).
+    ///
+    /// Why: `ProjectRegistry::load` is async and needs a data directory; deferring
+    /// construction to first use (like `session_manager()`) keeps the synchronous
+    /// `new()` constructors unblocked. At startup the daemon seeds the registry
+    /// from `config.yaml`'s `projects:` list and from session history.
+    /// What: on first call loads the registry from `<framework_root>/project-registry/`,
+    /// seeds it from config and session history, and caches the `Arc`. Subsequent
+    /// calls return the cached handle.
+    /// Test: `mcp_project` dispatch tests exercise this via the mock backend path.
+    pub async fn project_registry(&self) -> std::sync::Arc<crate::project::ProjectRegistry> {
+        self.project_registry
+            .get_or_init(|| async {
+                let data_dir = self.framework_root.join("project-registry");
+                let registry = match crate::project::ProjectRegistry::load(&data_dir).await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::error!(
+                            "failed to load project registry at {}: {e}; using temp dir",
+                            data_dir.display()
+                        );
+                        let tmp = std::env::temp_dir().join("trusty-mpm-project-registry");
+                        let _ = std::fs::create_dir_all(&tmp);
+                        crate::project::ProjectRegistry::load(&tmp)
+                            .await
+                            .expect("temp-dir project registry must load")
+                    }
+                };
+                // Seed from config.yaml `projects:` list.
+                let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+                if !config.projects.is_empty() {
+                    registry.seed_from_config(&config.projects).await;
+                }
+                // Auto-register projects from existing session history.
+                if let Some(sm) = self.managed_sessions.get() {
+                    let records = sm.list().await;
+                    registry.auto_register_from_sessions(&records).await;
+                }
+                std::sync::Arc::new(registry)
+            })
+            .await
+            .clone()
     }
 }

--- a/crates/trusty-mpm/src/lib.rs
+++ b/crates/trusty-mpm/src/lib.rs
@@ -118,6 +118,17 @@ pub mod driver;
 /// N-session fleet sweep, and the HTTP handlers.
 pub mod supervisor;
 
+/// Project registry: models, on-disk persistence, and lifecycle management (#1519).
+///
+/// Why: operators and driver skills need to reference repositories by name rather
+/// than supplying full URLs on every session spawn. The registry persists known
+/// projects to `~/.trusty-mpm/projects.json`, seeds from `config.yaml`'s
+/// `projects:` list at startup, and auto-registers projects from session history.
+/// What: re-exports `Project`, `ProjectRegistry`, `derive_name_from_url`, and
+/// `ProjectStoreError` from the three submodules (record, store, registry).
+/// Test: each submodule carries inline unit tests run by `cargo test -p trusty-mpm`.
+pub mod project;
+
 // ── Feature-gated modules ────────────────────────────────────────────────────
 
 /// MCP server: six orchestration tools exposed to Claude Code sessions.

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -24,6 +24,7 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use trusty_common::mcp::{Request, Response, error_codes};
 
+pub mod project_dispatch;
 pub mod session_dispatch;
 pub mod tools;
 
@@ -276,6 +277,49 @@ pub trait OrchestratorBackend: Send + Sync {
         auto_resume: Option<bool>,
         default_model: Option<&str>,
     ) -> Result<Value, String>;
+
+    // ── #1519 WI-2: project-registry tools ───────────────────────────────────
+
+    /// Back `project_list`: return a JSON array of all registered projects.
+    ///
+    /// Why: the driver skill and operators need a typed list of known projects
+    ///      to pick a repository for a new session without specifying the URL
+    ///      every time.
+    /// What: lists all entries in the project registry and returns them as a
+    ///      JSON array. An empty registry returns `[]`.
+    /// Test: `dispatch_project_list_tool` (mock).
+    async fn project_list(&self) -> Result<Value, String>;
+
+    /// Back `project_register`: upsert a project entry in the registry.
+    ///
+    /// Why: operators and the driver skill must be able to add or update a
+    ///      project without restarting the daemon or editing config.yaml.
+    ///      Registration is idempotent — calling with the same `name` updates
+    ///      the entry rather than duplicating it.
+    /// What: upserts the project keyed by `name` and returns the persisted
+    ///      project record as JSON.
+    /// Test: `dispatch_project_register_tool`,
+    ///       `dispatch_project_register_requires_name` (mock).
+    async fn project_register(
+        &self,
+        name: &str,
+        repo_url: &str,
+        default_branch: Option<&str>,
+        stack_hint: Option<&str>,
+        tags: Option<Vec<String>>,
+        description: Option<&str>,
+    ) -> Result<Value, String>;
+
+    /// Back `project_get`: look up a single project by name.
+    ///
+    /// Why: the driver skill needs a point-lookup to retrieve a project's
+    ///      `repo_url` and `default_branch` before spawning a session without
+    ///      listing all projects first.
+    /// What: returns the project record as JSON or a descriptive error when
+    ///      the name is not in the registry.
+    /// Test: `dispatch_project_get_tool`,
+    ///       `dispatch_project_get_missing_name` (mock).
+    async fn project_get(&self, name: &str) -> Result<Value, String>;
 }
 
 /// Route a JSON-RPC request to the backend, returning the MCP response.
@@ -411,11 +455,16 @@ async fn dispatch_tool_call<B: OrchestratorBackend>(
                 .config_write(template, auto_resume, default_model)
                 .await
         }
-        // #1221 + #1508: the eight session-lifecycle tools route through a sibling
-        // module so this match stays focused and `mod.rs` stays under the SLOC cap.
-        other => match session_dispatch::try_dispatch(backend, other, &args).await {
+        // #1519 WI-2: the three project-registry tools route through a sibling
+        // module before the session tools so both groups can extend independently.
+        other => match project_dispatch::try_dispatch(backend, other, &args).await {
             Some(result) => result,
-            None => Err(format!("unknown tool: {other}")),
+            // #1221 + #1508: the eight session-lifecycle tools route through a sibling
+            // module so this match stays focused and `mod.rs` stays under the SLOC cap.
+            None => match session_dispatch::try_dispatch(backend, other, &args).await {
+                Some(result) => result,
+                None => Err(format!("unknown tool: {other}")),
+            },
         },
     };
 

--- a/crates/trusty-mpm/src/mcp/project_dispatch.rs
+++ b/crates/trusty-mpm/src/mcp/project_dispatch.rs
@@ -1,0 +1,77 @@
+//! Argument parsing + routing for the three project-registry MCP tools
+//! (#1519 WI-2).
+//!
+//! Why: mirroring `session_dispatch.rs`, pulling the project-tool parse-and-call
+//! arms into a sibling module keeps `mcp/mod.rs` under the 500-SLOC production
+//! cap while giving the project tools an auditable home.
+//! What: [`try_dispatch`] matches a tool name against the three project tools
+//! (`project_list`, `project_register`, `project_get`); when it matches, parses
+//! arguments and calls the corresponding [`super::OrchestratorBackend`] method,
+//! returning `Some(result)`. A non-project tool name returns `None`.
+//! Test: `super::tests::dispatch_project_*` cases drive this module through
+//! the public `dispatch` entry point with a mock backend.
+
+use serde_json::Value;
+
+use super::{OrchestratorBackend, required_str};
+
+/// Route a project-registry tool call to the backend.
+///
+/// Why: a single entry point lets `dispatch_tool_call` delegate every
+/// project-tool name in one arm without widening the core dispatch match.
+/// What: returns `Some(Result)` for the three project tool names, parsing
+/// args and calling the matching backend method, or `None` for any other name.
+/// Test: exercised by every `dispatch_project_*` test in `super::tests`.
+pub async fn try_dispatch<B: OrchestratorBackend>(
+    backend: &B,
+    name: &str,
+    args: &Value,
+) -> Option<Result<Value, String>> {
+    let result = match name {
+        "project_list" => backend.project_list().await,
+        "project_register" => project_register(backend, args).await,
+        "project_get" => match required_str(args, "name") {
+            Ok(n) => backend.project_get(&n).await,
+            Err(e) => Err(e),
+        },
+        _ => return None,
+    };
+    Some(result)
+}
+
+/// Parse `project_register` arguments and call the backend.
+///
+/// Why: `project_register` has the widest argument surface (name, repo_url
+/// required + four optionals); a helper keeps [`try_dispatch`] readable.
+/// What: requires `name` and `repo_url`; reads optional `default_branch`,
+/// `stack_hint`, `tags`, and `description`; calls
+/// [`OrchestratorBackend::project_register`]. Missing required fields yield a
+/// descriptive error string.
+/// Test: `super::tests::dispatch_project_register_tool`,
+/// `super::tests::dispatch_project_register_requires_name`.
+async fn project_register<B: OrchestratorBackend>(
+    backend: &B,
+    args: &Value,
+) -> Result<Value, String> {
+    let name = required_str(args, "name")?;
+    let repo_url = required_str(args, "repo_url")?;
+    let default_branch = args.get("default_branch").and_then(Value::as_str);
+    let stack_hint = args.get("stack_hint").and_then(Value::as_str);
+    let tags: Option<Vec<String>> = args.get("tags").and_then(Value::as_array).map(|arr| {
+        arr.iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect()
+    });
+    let description = args.get("description").and_then(Value::as_str);
+    backend
+        .project_register(
+            &name,
+            &repo_url,
+            default_branch,
+            stack_hint,
+            tags,
+            description,
+        )
+        .await
+}

--- a/crates/trusty-mpm/src/mcp/tests.rs
+++ b/crates/trusty-mpm/src/mcp/tests.rs
@@ -165,6 +165,45 @@ impl OrchestratorBackend for MockBackend {
             "workspace_root": workspace_root_template.unwrap_or("/home/test/trusty-mpm-projects"),
         }))
     }
+
+    // ── #1519 WI-2: project-registry mock impls ───────────────────────────────
+    async fn project_list(&self) -> Result<Value, String> {
+        Ok(json!({
+            "projects": [
+                { "name": "trusty-tools", "repo_url": "https://github.com/o/trusty-tools", "default_branch": "main" }
+            ],
+            "count": 1,
+        }))
+    }
+    async fn project_register(
+        &self,
+        name: &str,
+        repo_url: &str,
+        default_branch: Option<&str>,
+        stack_hint: Option<&str>,
+        tags: Option<Vec<String>>,
+        description: Option<&str>,
+    ) -> Result<Value, String> {
+        Ok(json!({
+            "name": name,
+            "repo_url": repo_url,
+            "default_branch": default_branch.unwrap_or("main"),
+            "stack_hint": stack_hint,
+            "tags": tags.unwrap_or_default(),
+            "description": description,
+        }))
+    }
+    async fn project_get(&self, name: &str) -> Result<Value, String> {
+        if name == "trusty-tools" {
+            Ok(json!({
+                "name": "trusty-tools",
+                "repo_url": "https://github.com/o/trusty-tools",
+                "default_branch": "main",
+            }))
+        } else {
+            Err(format!("project `{name}` not found"))
+        }
+    }
 }
 
 fn call(name: &str, args: Value) -> Request {
@@ -191,8 +230,9 @@ async fn dispatch_initialize_returns_server_info() {
 
 #[tokio::test]
 async fn dispatch_tools_list_returns_full_catalog() {
-    // 9 pre-existing + 8 session-lifecycle + 5 console-facing tools = 22
-    // (#1222 + the two #1220 config tools + the two #1508 fleet-teardown tools).
+    // 9 pre-existing + 8 session-lifecycle + 5 console-facing + 3 project = 25
+    // (#1222 + the two #1220 config tools + the two #1508 fleet-teardown tools
+    // + the three #1519 project-registry tools).
     let req = Request {
         jsonrpc: Some("2.0".into()),
         id: Some(json!(1)),
@@ -201,7 +241,7 @@ async fn dispatch_tools_list_returns_full_catalog() {
     };
     let resp = dispatch(&MockBackend, req).await;
     let tools = resp.result.unwrap()["tools"].clone();
-    assert_eq!(tools.as_array().unwrap().len(), 22);
+    assert_eq!(tools.as_array().unwrap().len(), 25);
 }
 
 /// Why: the console Config tab calls `config_read`; dispatch must route it and
@@ -700,5 +740,138 @@ async fn dispatch_session_prune_requires_state() {
             .as_str()
             .unwrap()
             .contains("state")
+    );
+}
+
+// ── #1519 WI-2: project-registry dispatch tests ───────────────────────────────
+
+/// Why (#1519): `project_list` takes no args and must route to the backend,
+/// returning the projects array.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_list_tool() {
+    let resp = dispatch(&MockBackend, call("project_list", json!({}))).await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("projects"), "expected 'projects' in: {text}");
+}
+
+/// Why (#1519): `project_register` must accept `name` + `repo_url` (required)
+/// and optional fields, and return the registered record.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_register_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call(
+            "project_register",
+            json!({
+                "name": "my-repo",
+                "repo_url": "https://github.com/o/my-repo",
+                "default_branch": "develop",
+                "stack_hint": "rust",
+                "tags": ["backend"],
+                "description": "a repo"
+            }),
+        ),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("my-repo"), "expected 'my-repo' in: {text}");
+}
+
+/// Why (#1519): `project_register` must error when the required `name` arg is missing.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_register_requires_name() {
+    let resp = dispatch(
+        &MockBackend,
+        call(
+            "project_register",
+            json!({ "repo_url": "https://github.com/o/repo" }),
+        ),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("name")
+    );
+}
+
+/// Why (#1519): `project_register` must error when the required `repo_url` arg is missing.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_register_requires_repo_url() {
+    let resp = dispatch(
+        &MockBackend,
+        call("project_register", json!({ "name": "my-repo" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("repo_url")
+    );
+}
+
+/// Why (#1519): `project_get` must return the project for a known name.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_get_tool() {
+    let resp = dispatch(
+        &MockBackend,
+        call("project_get", json!({ "name": "trusty-tools" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(
+        text.contains("trusty-tools"),
+        "expected 'trusty-tools' in: {text}"
+    );
+}
+
+/// Why (#1519): `project_get` must surface an error for an unknown project name.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_get_missing_name() {
+    let resp = dispatch(
+        &MockBackend,
+        call("project_get", json!({ "name": "does-not-exist" })),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("not found")
+    );
+}
+
+/// Why (#1519): `project_get` must error when the required `name` arg is missing.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_get_requires_name() {
+    let resp = dispatch(&MockBackend, call("project_get", json!({}))).await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("name")
     );
 }

--- a/crates/trusty-mpm/src/mcp/tools/mod.rs
+++ b/crates/trusty-mpm/src/mcp/tools/mod.rs
@@ -3,14 +3,15 @@
 //! Why: `tools/list` must advertise a JSON Schema for every tool so Claude Code
 //! knows how to call it. Keeping the catalog separate from the dispatch logic
 //! makes the tool surface easy to audit and version. Since #1221 the catalog
-//! spans two concepts — the original orchestration/bug-reporting tools
-//! ([`core`]) and the new session-lifecycle tools ([`session`]) — so this is a
-//! thin facade that re-exports both and concatenates their descriptors, keeping
-//! each leaf file well under the 500-SLOC production cap.
-//! What: [`tool_catalog`] builds the twenty-two MCP tool descriptors (nine core +
-//! eight session + five console — #1222 / #1220 / #1508); [`TOOL_CATALOG`] lists
-//! their names for tests and the startup log; [`tool`] is the shared descriptor
-//! builder used by every submodule.
+//! spans several concepts — the original orchestration/bug-reporting tools
+//! ([`core`]), the session-lifecycle tools ([`session`]), the console tools
+//! ([`console`]), and the project-registry tools ([`project`], #1519) — so this
+//! is a thin facade that re-exports all and concatenates their descriptors,
+//! keeping each leaf file well under the 500-SLOC production cap.
+//! What: [`tool_catalog`] builds the twenty-five MCP tool descriptors (nine core +
+//! eight session + five console + three project — #1222 / #1220 / #1508 / #1519);
+//! [`TOOL_CATALOG`] lists their names for tests and the startup log; [`tool`] is
+//! the shared descriptor builder used by every submodule.
 //! Test: the `tests` module below asserts the catalog has the expected count,
 //! well-formed entries, and names matching [`TOOL_CATALOG`].
 
@@ -18,20 +19,19 @@ use serde_json::{Value, json};
 
 pub mod console;
 pub mod core;
+pub mod project;
 pub mod session;
 
 /// Canonical names of every tool the server exposes, in catalog order.
 ///
 /// Why: tests, the daemon's startup log, and the loopback-`/rpc` audit all want
 /// the authoritative list without re-parsing the JSON schema. Keeping it exact
-/// resolves the #1221 review nit about ambiguous existing-vs-new counts: there
-/// are exactly NINE pre-existing tools and EIGHT session-lifecycle tools (six
-/// per-session #1221 + the two fleet-wide #1508 teardown verbs).
-/// What: a static slice of the twenty-two tool names — the six orchestration
-/// tools, the three bug-reporting tools, the eight session-lifecycle tools, then
-/// the five console-facing tools (#1222 + the two #1220 config tools + #1508).
+/// resolves the #1221 review nit about ambiguous existing-vs-new counts.
+/// What: a static slice of the twenty-five tool names — the nine core/bug tools,
+/// the eight session-lifecycle tools, the five console-facing tools, and the
+/// three project-registry tools (#1519).
 /// Test: `catalog_names_match_constant`.
-pub const TOOL_CATALOG: [&str; 22] = [
+pub const TOOL_CATALOG: [&str; 25] = [
     // ── 9 pre-existing tools (core.rs) ───────────────────────────────────────
     "session_list",
     "session_status",
@@ -59,22 +59,27 @@ pub const TOOL_CATALOG: [&str; 22] = [
     // #1220 config-convention tools: read/write ~/.trusty-tools/trusty-mpm/config.yaml
     "config_read",
     "config_write",
+    // ── 3 project-registry tools (#1519 WI-2, project.rs) ───────────────────
+    "project_list",
+    "project_register",
+    "project_get",
 ];
 
 /// Build the MCP tool descriptor list returned by `tools/list`.
 ///
 /// Why: Claude Code reads `inputSchema` to validate calls; a single builder
-/// keeps the schemas and the dispatch argument-parsing in lockstep across both
-/// the core and session-lifecycle tool groups.
+/// keeps the schemas and the dispatch argument-parsing in lockstep across all
+/// tool groups.
 /// What: concatenates [`core::core_tools`] (nine descriptors),
-/// [`session::session_tools`] (eight descriptors), and [`console::console_tools`]
-/// (five descriptors) in catalog order, returning twenty-two
-/// `{ name, description, inputSchema }` objects.
+/// [`session::session_tools`] (eight descriptors), [`console::console_tools`]
+/// (five descriptors), and [`project::project_tools`] (three descriptors) in
+/// catalog order, returning twenty-five `{ name, description, inputSchema }` objects.
 /// Test: `catalog_has_expected_tool_count` and `every_tool_has_input_schema`.
 pub fn tool_catalog() -> Vec<Value> {
     let mut tools = core::core_tools();
     tools.extend(session::session_tools());
     tools.extend(console::console_tools());
+    tools.extend(project::project_tools());
     tools
 }
 
@@ -98,9 +103,9 @@ mod tests {
 
     #[test]
     fn catalog_has_expected_tool_count() {
-        // 9 pre-existing + 8 session-lifecycle + 5 console-facing tools = 22.
-        assert_eq!(tool_catalog().len(), 22);
-        assert_eq!(TOOL_CATALOG.len(), 22);
+        // 9 pre-existing + 8 session-lifecycle + 5 console-facing + 3 project = 25.
+        assert_eq!(tool_catalog().len(), 25);
+        assert_eq!(TOOL_CATALOG.len(), 25);
     }
 
     #[test]
@@ -157,6 +162,15 @@ mod tests {
             "config_read",
             "config_write",
         ] {
+            assert!(names.contains(&expected), "missing {expected}: {names:?}");
+        }
+    }
+
+    #[test]
+    fn project_tools_present() {
+        let catalog = tool_catalog();
+        let names: Vec<&str> = catalog.iter().filter_map(|t| t["name"].as_str()).collect();
+        for expected in ["project_list", "project_register", "project_get"] {
             assert!(names.contains(&expected), "missing {expected}: {names:?}");
         }
     }

--- a/crates/trusty-mpm/src/mcp/tools/project.rs
+++ b/crates/trusty-mpm/src/mcp/tools/project.rs
@@ -1,0 +1,99 @@
+//! Project-registry MCP tool descriptors (#1519 WI-2).
+//!
+//! Why: the driver skill needs a typed, JSON-native surface to list, register,
+//! and look up projects in the registry — without scraping CLI text. Keeping
+//! these descriptors in their own file mirrors the pattern of `session.rs` and
+//! keeps each file well under the 500-SLOC production cap.
+//! What: [`project_tools`] returns the three `{ name, description, inputSchema }`
+//! descriptors — `project_list`, `project_register`, and `project_get`.
+//! Test: `super::tests::project_tools_present`,
+//! `super::tests::catalog_names_match_constant`.
+
+use serde_json::{Value, json};
+
+use super::tool;
+
+/// Build the three project-registry tool descriptors.
+///
+/// Why: project listing, registration, and lookup are the MCP surface the
+/// driver skill needs to interact with the project registry without CLI text
+/// scraping. Keeping them in their own builder keeps this file under the SLOC
+/// cap and gives the project tools an auditable home.
+/// What: returns the three descriptors in catalog order. `project_register`
+/// requires `name` and `repo_url` and accepts optional `default_branch`,
+/// `stack_hint`, `tags`, and `description`; `project_get` requires `name`;
+/// `project_list` takes no arguments. Every schema sets
+/// `additionalProperties: false`.
+/// Test: `super::tests::project_tools_present`.
+pub(super) fn project_tools() -> Vec<Value> {
+    vec![
+        tool(
+            "project_list",
+            "List all projects registered in the project registry. Returns a JSON \
+             array of project objects, each with `name`, `repo_url`, \
+             `default_branch`, and optional `stack_hint`, `tags`, and \
+             `description`.",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "project_register",
+            "Register or update a project in the project registry. Registration \
+             is idempotent — calling with the same `name` updates the existing \
+             entry rather than creating a duplicate. Returns the registered \
+             project record.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Short name used as the registry key (e.g. `trusty-tools`)."
+                    },
+                    "repo_url": {
+                        "type": "string",
+                        "description": "Full repository URL (e.g. `https://github.com/owner/trusty-tools`)."
+                    },
+                    "default_branch": {
+                        "type": "string",
+                        "description": "Default branch for session spawns. Defaults to `main` when omitted."
+                    },
+                    "stack_hint": {
+                        "type": "string",
+                        "description": "Optional technology-stack hint (e.g. `rust`, `python`)."
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional classification tags (e.g. [\"backend\", \"production\"])."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Optional free-form human-readable description."
+                    }
+                },
+                "required": ["name", "repo_url"],
+                "additionalProperties": false
+            }),
+        ),
+        tool(
+            "project_get",
+            "Look up a single project by name. Returns the project record \
+             (`name`, `repo_url`, `default_branch`, and optional fields) or an \
+             error when the name is not found in the registry.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Project name to look up."
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+            }),
+        ),
+    ]
+}

--- a/crates/trusty-mpm/src/project/mod.rs
+++ b/crates/trusty-mpm/src/project/mod.rs
@@ -1,0 +1,21 @@
+//! Project registry: models, on-disk persistence, and lifecycle management.
+//!
+//! Why: the project registry tracks known repositories so operators and driver
+//! skills can reference projects by name rather than supplying a full URL on
+//! every session spawn. It seeds from `config.yaml`, auto-registers projects
+//! from session history at boot, and exposes typed MCP tools.
+//! What: re-exports [`Project`], [`ProjectRegistry`], [`derive_name_from_url`],
+//! and the error types from the three submodules:
+//! - `record` — the [`Project`] struct and `derive_name_from_url`.
+//! - `store`  — [`ProjectStore`] on-disk JSON persistence.
+//! - `registry` — [`ProjectRegistry`] lifecycle manager.
+//! Test: each submodule carries inline unit tests; `record`, `store`, and
+//! `registry` tests are run by `cargo test -p trusty-mpm`.
+
+pub mod record;
+pub mod registry;
+pub mod store;
+
+pub use record::{Project, derive_name_from_url};
+pub use registry::ProjectRegistry;
+pub use store::ProjectStoreError;

--- a/crates/trusty-mpm/src/project/record.rs
+++ b/crates/trusty-mpm/src/project/record.rs
@@ -1,0 +1,178 @@
+//! Project record type for the project registry.
+//!
+//! Why: the project registry needs a canonical, serializable representation of
+//! every known project so it can survive daemon restarts and be exchanged over
+//! MCP tools without ambiguity.
+//! What: defines [`Project`] — the persisted project record — with all fields
+//! needed to identify a project and seed session spawns.
+//! Test: serde round-trips are verified in `project_serde_round_trip`; missing
+//! optional fields default correctly in `project_without_optionals`.
+
+use serde::{Deserialize, Serialize};
+
+/// A project entry in the project registry.
+///
+/// Why: the registry tracks repositories an operator works with so that session
+/// spawns can reference them by name and auto-registration from session history
+/// can populate the registry without operator effort.
+/// What: captures the project name (registry key), repository URL,
+/// default branch, and optional descriptive metadata.
+/// Test: `project_serde_round_trip`, `project_without_optionals`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Project {
+    /// Short name used as the registry key (e.g. `trusty-tools`).
+    ///
+    /// Why: a human-readable stable key enables lookups by name rather than by
+    /// repo URL, and matches the convention of deriving names from repo basenames.
+    /// What: must be non-empty; upsert is keyed on this field.
+    pub name: String,
+
+    /// Full repository URL (e.g. `https://github.com/owner/trusty-tools`).
+    ///
+    /// Why: the session spawner needs the URL to clone a workspace; the registry
+    /// provides it so callers do not have to supply it on every `session_new`.
+    pub repo_url: String,
+
+    /// The project's default branch (e.g. `main` or `develop`).
+    ///
+    /// Why: session spawns default to this branch when no explicit ref is given,
+    /// reducing the caller's boilerplate.
+    pub default_branch: String,
+
+    /// Optional technology-stack hint for the project (e.g. `rust`, `python`).
+    ///
+    /// Why: agents that auto-configure their tooling can use this hint to select
+    /// the right skill set without introspecting the repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stack_hint: Option<String>,
+
+    /// Classification tags for the project (e.g. `["backend", "production"]`).
+    ///
+    /// Why: tags let operators filter the project list and let agents select
+    /// projects by domain without parsing descriptions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+
+    /// Free-form human-readable description of the project.
+    ///
+    /// Why: helps operators identify a project from the registry list, especially
+    /// when the name alone is ambiguous.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Derive a project name from a repository URL by stripping the `.git` suffix
+/// and taking the last path segment.
+///
+/// Why: auto-registration from session history should produce a sensible name
+/// without operator input; the repo basename is the conventional choice.
+/// What: handles both HTTPS (`https://host/owner/repo`) and SSH
+/// (`git@host:owner/repo.git`) URL forms. For HTTPS, requires at least three
+/// non-empty slash-segments so that a bare host URL (`https://github.com/`)
+/// returns `None`. For SSH, splits on `:` first, then on `/` within the path
+/// component. Strips a trailing `.git` from the chosen segment.
+/// Test: `derive_name_from_url_basic`, `derive_name_from_url_with_git_suffix`,
+/// `derive_name_from_url_ssh`, `derive_name_from_url_no_path`.
+pub fn derive_name_from_url(repo_url: &str) -> Option<String> {
+    // SSH form: "git@github.com:owner/repo.git" — no "://" present but ":" is.
+    if !repo_url.contains("://") && repo_url.contains(':') {
+        let path_part = repo_url.split_once(':')?.1;
+        let segment = path_part.trim_end_matches('/').split('/').next_back()?;
+        if segment.is_empty() {
+            return None;
+        }
+        return Some(segment.strip_suffix(".git").unwrap_or(segment).to_string());
+    }
+    // HTTPS / git:// form — collect non-empty slash-segments.
+    // Require at least 3 (scheme "https:", host, repo) so that
+    // "https://github.com/" (only 2 non-empty segments) returns None.
+    let segments: Vec<&str> = repo_url.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() < 3 {
+        return None;
+    }
+    let segment = segments.last()?;
+    Some(segment.strip_suffix(".git").unwrap_or(segment).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_serde_round_trip() {
+        let p = Project {
+            name: "trusty-tools".into(),
+            repo_url: "https://github.com/owner/trusty-tools".into(),
+            default_branch: "main".into(),
+            stack_hint: Some("rust".into()),
+            tags: vec!["backend".into(), "oss".into()],
+            description: Some("the unified trusty workspace".into()),
+        };
+        let json = serde_json::to_string(&p).expect("serialize");
+        let back: Project = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn project_without_optionals() {
+        // Optional fields must default to empty/None and must not appear in JSON.
+        let p = Project {
+            name: "minimal".into(),
+            repo_url: "https://github.com/owner/minimal".into(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+        };
+        let json = serde_json::to_string(&p).expect("serialize");
+        assert!(
+            !json.contains("stack_hint"),
+            "absent optional must not serialise: {json}"
+        );
+        assert!(
+            !json.contains("tags"),
+            "empty tags must not serialise: {json}"
+        );
+        let back: Project = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.stack_hint, None);
+        assert!(back.tags.is_empty());
+    }
+
+    #[test]
+    fn derive_name_from_url_basic() {
+        assert_eq!(
+            derive_name_from_url("https://github.com/owner/my-repo"),
+            Some("my-repo".into())
+        );
+    }
+
+    #[test]
+    fn derive_name_from_url_with_git_suffix() {
+        assert_eq!(
+            derive_name_from_url("https://github.com/owner/trusty-tools.git"),
+            Some("trusty-tools".into())
+        );
+    }
+
+    #[test]
+    fn derive_name_from_url_ssh() {
+        assert_eq!(
+            derive_name_from_url("git@github.com:owner/repo.git"),
+            Some("repo".into())
+        );
+    }
+
+    #[test]
+    fn derive_name_from_url_trailing_slash() {
+        assert_eq!(
+            derive_name_from_url("https://github.com/owner/repo/"),
+            Some("repo".into())
+        );
+    }
+
+    #[test]
+    fn derive_name_from_url_no_path() {
+        // A bare host with no path segment has no valid name.
+        assert_eq!(derive_name_from_url("https://github.com/"), None);
+    }
+}

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -1,0 +1,396 @@
+//! Project registry: lifecycle management and auto-registration.
+//!
+//! Why: the registry is the single authoritative source for known projects.
+//! It seeds from `config.yaml`'s `projects:` list on startup, auto-registers
+//! projects implied by session history, and exposes typed register/get/list ops
+//! for the MCP tools and CLI.
+//! What: [`ProjectRegistry`] wraps a [`ProjectStore`] in an async `RwLock`,
+//! exposes `register` (idempotent upsert), `get`, and `list`; `seed_from_config`
+//! upserts statically-declared entries; `auto_register_from_sessions` derives
+//! implicit entries from existing session records.
+//! Test: `registry_register_idempotent`, `registry_list`, `registry_get`,
+//! `registry_seed_from_config`, `registry_auto_register_from_sessions`,
+//! `registry_derive_name_skips_missing_url`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+use super::record::{Project, derive_name_from_url};
+use super::store::{ProjectStore, ProjectStoreError};
+use crate::core::trusty_tools_config::ProjectConfig;
+use crate::session_manager::record::SessionRecord;
+
+/// Async project registry backed by an on-disk JSON store.
+///
+/// Why: the daemon and MCP tools need a single shared, thread-safe view of all
+/// known projects. Wrapping the store in an `Arc<RwLock<…>>` follows the same
+/// pattern as the session manager.
+/// What: wraps a `ProjectStore` with async shared-mutable access; all mutating
+/// ops (register, seed, auto-register) take a write lock; reads take a read
+/// lock by re-reading through the store.
+/// Test: `registry_register_idempotent`, `registry_list`, `registry_get`.
+#[derive(Debug, Clone)]
+pub struct ProjectRegistry {
+    store: Arc<RwLock<ProjectStore>>,
+}
+
+impl ProjectRegistry {
+    /// Load (or create) the project registry at the given data directory.
+    ///
+    /// Why: on startup the daemon restores the registry from the previous run;
+    /// an absent `projects.json` starts a fresh, empty registry.
+    /// What: constructs a `ProjectStore` from `<data_dir>/projects.json` and
+    /// wraps it in an `Arc<RwLock>`.
+    /// Test: `registry_register_idempotent`.
+    pub async fn load(data_dir: &Path) -> Result<Self, ProjectStoreError> {
+        let store = ProjectStore::load(data_dir).await?;
+        Ok(Self {
+            store: Arc::new(RwLock::new(store)),
+        })
+    }
+
+    /// Idempotent upsert: register or update a project by name.
+    ///
+    /// Why: registration must be safe to call multiple times — re-registering
+    /// with updated fields updates rather than duplicates the entry.
+    /// What: acquires a write lock and calls `ProjectStore::upsert`.
+    /// Test: `registry_register_idempotent`.
+    pub async fn register(&self, project: Project) -> Result<(), ProjectStoreError> {
+        let mut guard = self.store.write().await;
+        guard.upsert(project).await
+    }
+
+    /// Look up a project by name.
+    ///
+    /// Why: MCP `project_get` and session spawning need a point-lookup by name.
+    /// What: acquires a write lock (required by store reload semantics) and
+    /// returns a clone of the matching project or `ProjectStoreError::NotFound`.
+    /// Test: `registry_get`.
+    pub async fn get(&self, name: &str) -> Result<Project, ProjectStoreError> {
+        let mut guard = self.store.write().await;
+        guard.get(name).await
+    }
+
+    /// Return all registered projects.
+    ///
+    /// Why: MCP `project_list` needs the full set; the auto-registration pass
+    /// uses it to avoid re-registering existing entries.
+    /// What: acquires a write lock (required by store reload semantics) and
+    /// returns all project records.
+    /// Test: `registry_list`.
+    pub async fn list(&self) -> Result<Vec<Project>, ProjectStoreError> {
+        let mut guard = self.store.write().await;
+        guard.all().await
+    }
+
+    /// Seed the registry from statically-declared `projects:` config entries.
+    ///
+    /// Why: #1519 MR-1 — operators can declare projects in
+    /// `~/.trusty-tools/trusty-mpm/config.yaml` under a `projects:` key so the
+    /// registry is pre-populated without manual MCP calls.
+    /// What: upserts each `ProjectConfig` entry into the store. Errors on
+    /// individual entries are logged and skipped so a bad entry does not abort
+    /// the whole seed pass.
+    /// Test: `registry_seed_from_config`.
+    pub async fn seed_from_config(&self, config_projects: &[ProjectConfig]) {
+        for entry in config_projects {
+            let project = Project {
+                name: entry.name.clone(),
+                repo_url: entry.repo_url.clone(),
+                default_branch: entry
+                    .default_branch
+                    .clone()
+                    .unwrap_or_else(|| "main".to_string()),
+                stack_hint: entry.stack_hint.clone(),
+                tags: entry.tags.clone().unwrap_or_default(),
+                description: entry.description.clone(),
+            };
+            let name = project.name.clone();
+            if let Err(e) = self.register(project).await {
+                warn!(name = %name, "seed_from_config: failed to register project: {e}");
+            } else {
+                debug!(name = %name, "seed_from_config: registered project");
+            }
+        }
+    }
+
+    /// Auto-register projects implied by existing session records.
+    ///
+    /// Why: #1519 MR-1 boot auto-registration — the daemon's reconcile pass
+    /// already has access to all session records; this pass derives `Project`
+    /// entries from records that have a `repo_url` but are not yet in the
+    /// registry, populating it without operator effort.
+    /// What: for each session record with a `repo_url` not already registered,
+    /// derives a name from the repo URL basename (stripping `.git`) and upserts
+    /// an implicit `Project`. The `default_branch` comes from the record's
+    /// `branch` field, falling back to `"main"`.
+    /// Test: `registry_auto_register_from_sessions`,
+    /// `registry_derive_name_skips_missing_url`.
+    pub async fn auto_register_from_sessions(&self, records: &[SessionRecord]) {
+        // Collect existing names to avoid overwriting manually-registered entries.
+        let existing: std::collections::HashSet<String> = match self.list().await {
+            Ok(projects) => projects.into_iter().map(|p| p.name).collect(),
+            Err(e) => {
+                warn!("auto_register: failed to list existing projects: {e}");
+                return;
+            }
+        };
+
+        for record in records {
+            let Some(repo_url) = &record.repo_url else {
+                continue;
+            };
+            let Some(name) = derive_name_from_url(repo_url) else {
+                warn!(
+                    repo_url = %repo_url,
+                    "auto_register: could not derive project name from URL; skipping"
+                );
+                continue;
+            };
+            if existing.contains(&name) {
+                debug!(name = %name, "auto_register: project already registered; skipping");
+                continue;
+            }
+            let default_branch = record.branch.clone().unwrap_or_else(|| "main".to_string());
+            let project = Project {
+                name: name.clone(),
+                repo_url: repo_url.clone(),
+                default_branch,
+                stack_hint: None,
+                tags: vec![],
+                description: None,
+            };
+            if let Err(e) = self.register(project).await {
+                warn!(name = %name, "auto_register: failed to register: {e}");
+            } else {
+                info!(name = %name, repo_url = %repo_url, "auto_register: registered project from session history");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_manager::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_session_with_repo(repo_url: &str, branch: Option<&str>) -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-test".into(),
+            cwd: PathBuf::from("/tmp"),
+            task: "test".into(),
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: Some(repo_url.to_string()),
+            branch: branch.map(String::from),
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+        }
+    }
+
+    fn make_session_no_repo() -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-no-repo".into(),
+            cwd: PathBuf::from("/tmp"),
+            task: "no repo".into(),
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_register_idempotent() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+
+        let p = Project {
+            name: "alpha".into(),
+            repo_url: "https://github.com/o/alpha".into(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+        };
+        registry.register(p.clone()).await.expect("register once");
+        registry
+            .register(p)
+            .await
+            .expect("register again (idempotent)");
+
+        let all = registry.list().await.expect("list");
+        assert_eq!(all.len(), 1, "idempotent registration must not duplicate");
+    }
+
+    #[tokio::test]
+    async fn registry_get() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+
+        let p = Project {
+            name: "beta".into(),
+            repo_url: "https://github.com/o/beta".into(),
+            default_branch: "develop".into(),
+            stack_hint: Some("rust".into()),
+            tags: vec!["backend".into()],
+            description: Some("desc".into()),
+        };
+        registry.register(p.clone()).await.expect("register");
+
+        let got = registry.get("beta").await.expect("get");
+        assert_eq!(got.name, "beta");
+        assert_eq!(got.default_branch, "develop");
+        assert_eq!(got.stack_hint.as_deref(), Some("rust"));
+
+        let err = registry.get("nonexistent").await;
+        assert!(matches!(err, Err(ProjectStoreError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn registry_list() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+
+        for name in ["gamma", "delta", "epsilon"] {
+            let p = Project {
+                name: name.into(),
+                repo_url: format!("https://github.com/o/{name}"),
+                default_branch: "main".into(),
+                stack_hint: None,
+                tags: vec![],
+                description: None,
+            };
+            registry.register(p).await.expect("register");
+        }
+
+        let all = registry.list().await.expect("list");
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn registry_seed_from_config() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+
+        let config_entries = vec![
+            ProjectConfig {
+                name: "from-config-a".into(),
+                repo_url: "https://github.com/o/from-config-a".into(),
+                default_branch: Some("main".into()),
+                stack_hint: Some("python".into()),
+                tags: Some(vec!["ml".into()]),
+                description: Some("ml project".into()),
+            },
+            ProjectConfig {
+                name: "from-config-b".into(),
+                repo_url: "https://github.com/o/from-config-b".into(),
+                default_branch: None,
+                stack_hint: None,
+                tags: None,
+                description: None,
+            },
+        ];
+
+        registry.seed_from_config(&config_entries).await;
+
+        let all = registry.list().await.expect("list after seed");
+        let names: Vec<&str> = all.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"from-config-a"), "{names:?}");
+        assert!(names.contains(&"from-config-b"), "{names:?}");
+
+        let a = registry.get("from-config-a").await.expect("get a");
+        assert_eq!(a.stack_hint.as_deref(), Some("python"));
+        assert_eq!(a.default_branch, "main");
+
+        // Entry without default_branch must fall back to "main".
+        let b = registry.get("from-config-b").await.expect("get b");
+        assert_eq!(b.default_branch, "main");
+    }
+
+    #[tokio::test]
+    async fn registry_auto_register_from_sessions() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+
+        let sessions = vec![
+            make_session_with_repo("https://github.com/owner/trusty-tools.git", Some("main")),
+            make_session_with_repo("https://github.com/owner/another-repo", None),
+            make_session_no_repo(), // must be silently skipped
+        ];
+        registry.auto_register_from_sessions(&sessions).await;
+
+        let all = registry.list().await.expect("list after auto-register");
+        let names: Vec<&str> = all.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"trusty-tools"), "{names:?}");
+        assert!(names.contains(&"another-repo"), "{names:?}");
+        assert_eq!(all.len(), 2, "no-repo session must be skipped");
+
+        let p = registry
+            .get("trusty-tools")
+            .await
+            .expect("get trusty-tools");
+        assert_eq!(p.default_branch, "main");
+        assert_eq!(p.repo_url, "https://github.com/owner/trusty-tools.git");
+
+        let p2 = registry
+            .get("another-repo")
+            .await
+            .expect("get another-repo");
+        assert_eq!(p2.default_branch, "main", "no branch falls back to main");
+    }
+
+    #[tokio::test]
+    async fn registry_auto_register_skips_already_registered() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+
+        // Pre-register with explicit description.
+        let existing = Project {
+            name: "trusty-tools".into(),
+            repo_url: "https://github.com/owner/trusty-tools".into(),
+            default_branch: "develop".into(),
+            stack_hint: Some("rust".into()),
+            tags: vec![],
+            description: Some("manually registered".into()),
+        };
+        registry.register(existing).await.expect("pre-register");
+
+        // Auto-register with a different URL for the same name — must not overwrite.
+        let sessions = vec![make_session_with_repo(
+            "https://github.com/owner/trusty-tools.git",
+            Some("feature"),
+        )];
+        registry.auto_register_from_sessions(&sessions).await;
+
+        let p = registry.get("trusty-tools").await.expect("get");
+        assert_eq!(
+            p.description.as_deref(),
+            Some("manually registered"),
+            "auto-register must not overwrite existing entry"
+        );
+        assert_eq!(p.default_branch, "develop");
+    }
+}

--- a/crates/trusty-mpm/src/project/store.rs
+++ b/crates/trusty-mpm/src/project/store.rs
@@ -124,9 +124,15 @@ impl ProjectStore {
     ///
     /// Why: both `load` and `reload_if_changed` need the same "read or treat
     /// absence as empty" logic; factoring it out keeps the two callers in lockstep.
+    /// Critically, only `NotFound` is treated as "file absent" — all other I/O
+    /// errors (permission denied, directory in place of file, I/O fault) are
+    /// propagated so the caller never silently overwrites `projects.json` with an
+    /// empty store on a transient error.
     /// What: if `path` exists reads and JSON-parses it, returning `(data, Some(sig))`
-    /// with the signature captured AFTER the read; if absent returns `(empty, None)`.
-    /// Test: `store_load_save_round_trip`, `store_reload_picks_up_external_write`.
+    /// with the signature captured AFTER the read; if absent (`NotFound`) returns
+    /// `(empty, None)`; propagates all other I/O errors as `ProjectStoreError::Io`.
+    /// Test: `store_load_save_round_trip`, `store_reload_picks_up_external_write`,
+    /// `store_not_found_starts_fresh`, `store_other_io_error_propagates`.
     async fn read_file(path: &Path) -> Result<(StoredData, Option<FileSig>), ProjectStoreError> {
         match fs::read_to_string(path).await {
             Ok(raw) => {
@@ -135,10 +141,11 @@ impl ProjectStore {
                 let sig = Self::sig_of(path).await.unwrap_or_default();
                 Ok((data, Some(sig)))
             }
-            Err(_) => {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 debug!(path = %path.display(), "no project store file found; starting fresh");
                 Ok((StoredData::default(), None))
             }
+            Err(e) => Err(ProjectStoreError::Io(e)),
         }
     }
 
@@ -357,5 +364,61 @@ mod tests {
         let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
         let back = store2.get("full-project").await.expect("get");
         assert_eq!(back, full);
+    }
+
+    /// Verify that a NotFound path still starts with an empty store (happy-path
+    /// absence handling) and that a subsequent upsert+reload round-trips correctly.
+    ///
+    /// Why: the bug fix narrows the "start fresh" arm to NotFound only; this test
+    /// confirms that the intended absent-file path still works as before.
+    /// What: loads from a directory that contains no `projects.json`, asserts the
+    /// store is empty, then writes and reloads to confirm persistence works.
+    /// Test: this IS the test.
+    #[tokio::test]
+    async fn store_not_found_starts_fresh() {
+        let dir = TempDir::new().expect("tempdir");
+        // No projects.json exists yet — load must return an empty store.
+        let mut store = ProjectStore::load(dir.path())
+            .await
+            .expect("not-found should start fresh");
+        assert!(
+            store.all().await.expect("all").is_empty(),
+            "fresh store must be empty"
+        );
+
+        // Confirm we can round-trip through a save after starting fresh.
+        store
+            .upsert(make_project("theta"))
+            .await
+            .expect("upsert after fresh load");
+        let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
+        assert_eq!(store2.get("theta").await.expect("get theta").name, "theta");
+    }
+
+    /// Verify that a non-NotFound I/O error (e.g. a directory occupying the file
+    /// path) is propagated rather than silently treated as absent.
+    ///
+    /// Why: the data-loss bug caused any I/O error to be swallowed, so the next
+    /// `save()` would overwrite projects.json with an empty store. This test
+    /// exercises the fix by pointing `read_file` at a directory, which produces
+    /// `IsADirectory` (or equivalent) — not `NotFound`.
+    /// What: creates a directory at `projects.json`'s expected path, then calls
+    /// `ProjectStore::load`; asserts the result is an `Io` error, not `Ok`.
+    /// Test: this IS the test.
+    #[tokio::test]
+    async fn store_other_io_error_propagates() {
+        let dir = TempDir::new().expect("tempdir");
+        // Plant a directory where projects.json would live so read_to_string
+        // returns an OS error that is NOT NotFound.
+        let blocking_dir = dir.path().join("projects.json");
+        tokio::fs::create_dir_all(&blocking_dir)
+            .await
+            .expect("create blocking dir");
+
+        let result = ProjectStore::load(dir.path()).await;
+        assert!(
+            matches!(result, Err(ProjectStoreError::Io(_))),
+            "expected Io error when path is a directory, got: {result:?}"
+        );
     }
 }

--- a/crates/trusty-mpm/src/project/store.rs
+++ b/crates/trusty-mpm/src/project/store.rs
@@ -1,0 +1,361 @@
+//! On-disk JSON persistence for project registry entries.
+//!
+//! Why: the project registry must survive daemon restarts without losing track
+//! of which projects an operator has registered. A simple JSON file at a
+//! well-known path gives crash recovery without requiring a database dependency,
+//! mirroring the session-store pattern.
+//! What: [`ProjectStore`] loads and saves a map of [`Project`]s from/to
+//! `~/.trusty-mpm/projects.json`, using atomic temp-file + rename writes and
+//! reload-on-read freshness detection.
+//! Test: `store_load_save_round_trip`, `store_upsert_idempotent`,
+//! `store_list_and_get`, `store_reload_picks_up_external_write`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::fs;
+use tracing::debug;
+
+use super::record::Project;
+
+/// Errors that can arise from project store I/O or serialization.
+///
+/// Why: callers need structured error information to distinguish transient I/O
+/// failures from data-corruption problems so they can surface actionable messages.
+/// What: one variant per failure mode: I/O, serialization, or not-found.
+/// Test: exercised indirectly through `ProjectStore` method tests.
+#[derive(Debug, Error)]
+pub enum ProjectStoreError {
+    /// An I/O operation on the backing file failed.
+    #[error("project store I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization or deserialization failed.
+    #[error("project store serialization error: {0}")]
+    Serialize(String),
+
+    /// The requested project name was not found in the store.
+    #[error("project not found: {0}")]
+    NotFound(String),
+}
+
+/// In-memory representation of the serialized store file.
+///
+/// Why: serde needs a stable top-level shape for the JSON file; wrapping the
+/// map in a versioned struct makes future schema migrations possible.
+/// What: a flat map from project name to [`Project`].
+/// Test: round-tripped implicitly by `ProjectStore` tests.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct StoredData {
+    /// All projects, keyed by project name.
+    projects: HashMap<String, Project>,
+}
+
+/// A cheap freshness fingerprint for the backing file.
+///
+/// Why: the cross-process reload check keys off "did the file change since we
+/// last touched it". An mtime alone is insufficient on coarse filesystems — two
+/// writes in the same second would compare equal. Pairing mtime with byte length
+/// catches same-second writes that changed the file size.
+/// What: the file's last-modified time and length in bytes.
+/// Test: `store_reload_picks_up_external_write`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct FileSig {
+    mtime: Option<SystemTime>,
+    len: u64,
+}
+
+/// Async, file-backed store for [`Project`] records.
+///
+/// Why: the project registry must persist across daemon restarts, and both the
+/// daemon and CLI may read the same `projects.json`. Atomic writes (temp +
+/// rename) prevent torn reads, and reload-on-read freshness detection keeps the
+/// in-memory view current when another process writes.
+/// What: holds the in-memory map, the path to `projects.json`, and the file
+/// signature observed at the last load/save. All mutations call `save()`
+/// immediately; reads call `reload_if_changed()` first.
+/// Test: `store_load_save_round_trip`, `store_upsert_idempotent`,
+/// `store_reload_picks_up_external_write`.
+#[derive(Debug)]
+pub struct ProjectStore {
+    data: StoredData,
+    path: PathBuf,
+    last_sig: Option<FileSig>,
+}
+
+impl ProjectStore {
+    /// Load (or create) the project store at the given data directory.
+    ///
+    /// Why: on startup the registry needs to restore state from the previous
+    /// run; if no file exists a fresh empty store is returned so the daemon can
+    /// start cleanly.
+    /// What: reads `<data_dir>/projects.json` if it exists; returns an empty
+    /// store if the file is absent; propagates I/O and JSON errors.
+    /// Test: `store_load_save_round_trip`.
+    pub async fn load(data_dir: &Path) -> Result<Self, ProjectStoreError> {
+        let path = data_dir.join("projects.json");
+        let (data, last_sig) = Self::read_file(&path).await?;
+        Ok(Self {
+            data,
+            path,
+            last_sig,
+        })
+    }
+
+    /// Stat `path` and return its freshness fingerprint, or `None` if absent.
+    ///
+    /// Why: both the reload check and `save` need the same (mtime, len) signature;
+    /// centralising it keeps "what counts as the file's identity" in one place.
+    /// What: on `metadata` success returns `Some(FileSig { mtime, len })`; on any
+    /// stat error returns `None`.
+    /// Test: exercised via `store_reload_*` tests.
+    async fn sig_of(path: &Path) -> Option<FileSig> {
+        let meta = fs::metadata(path).await.ok()?;
+        Some(FileSig {
+            mtime: meta.modified().ok(),
+            len: meta.len(),
+        })
+    }
+
+    /// Read and parse the backing file, returning the data and its fingerprint.
+    ///
+    /// Why: both `load` and `reload_if_changed` need the same "read or treat
+    /// absence as empty" logic; factoring it out keeps the two callers in lockstep.
+    /// What: if `path` exists reads and JSON-parses it, returning `(data, Some(sig))`
+    /// with the signature captured AFTER the read; if absent returns `(empty, None)`.
+    /// Test: `store_load_save_round_trip`, `store_reload_picks_up_external_write`.
+    async fn read_file(path: &Path) -> Result<(StoredData, Option<FileSig>), ProjectStoreError> {
+        match fs::read_to_string(path).await {
+            Ok(raw) => {
+                let data = serde_json::from_str::<StoredData>(&raw)
+                    .map_err(|e| ProjectStoreError::Serialize(e.to_string()))?;
+                let sig = Self::sig_of(path).await.unwrap_or_default();
+                Ok((data, Some(sig)))
+            }
+            Err(_) => {
+                debug!(path = %path.display(), "no project store file found; starting fresh");
+                Ok((StoredData::default(), None))
+            }
+        }
+    }
+
+    /// Reload the in-memory map from disk if the backing file changed.
+    ///
+    /// Why: another process (e.g. the CLI) may have written `projects.json` since
+    /// this store last touched it. Reading first reconciles the in-memory view with
+    /// the authoritative on-disk state.
+    /// What: stats the file; if its fingerprint differs from `last_sig`, re-reads
+    /// and replaces `data` and `last_sig`. A matching fingerprint is a fast no-op.
+    /// Test: `store_reload_picks_up_external_write`,
+    /// `store_reload_noop_when_unchanged`.
+    pub async fn reload_if_changed(&mut self) -> Result<(), ProjectStoreError> {
+        let current = Self::sig_of(&self.path).await;
+        let unchanged = matches!((current, self.last_sig), (Some(a), Some(b)) if a == b);
+        if unchanged {
+            return Ok(());
+        }
+        let (data, sig) = Self::read_file(&self.path).await?;
+        self.data = data;
+        self.last_sig = sig;
+        debug!(path = %self.path.display(), "project store reloaded after external change");
+        Ok(())
+    }
+
+    /// Persist the current in-memory state to disk atomically.
+    ///
+    /// Why: every mutating operation must flush to disk for crash safety. Writing
+    /// a temp file and renaming atomically prevents concurrent readers from seeing
+    /// a torn (partially-written) file.
+    /// What: serializes `data` to JSON, writes a sibling `.tmp` file, then renames
+    /// it over the real path; records the resulting signature.
+    /// Test: verified by every mutating store test.
+    pub async fn save(&mut self) -> Result<(), ProjectStoreError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let json = serde_json::to_string_pretty(&self.data)
+            .map_err(|e| ProjectStoreError::Serialize(e.to_string()))?;
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, json).await?;
+        fs::rename(&tmp, &self.path).await?;
+        self.last_sig = Self::sig_of(&self.path).await;
+        debug!(path = %self.path.display(), "project store saved");
+        Ok(())
+    }
+
+    /// Insert or update a project record, keyed by `project.name`.
+    ///
+    /// Why: registration is idempotent — re-registering a project with the same
+    /// name updates its fields rather than creating a duplicate. Reloading first
+    /// ensures concurrent writes from another process are not lost.
+    /// What: reloads from disk if changed, inserts or replaces the record keyed by
+    /// `name`, then saves.
+    /// Test: `store_upsert_idempotent`.
+    pub async fn upsert(&mut self, project: Project) -> Result<(), ProjectStoreError> {
+        self.reload_if_changed().await?;
+        let key = project.name.clone();
+        self.data.projects.insert(key, project);
+        self.save().await
+    }
+
+    /// Look up a project by name, reloading from disk first if changed.
+    ///
+    /// Why: the caller must see out-of-process writes; reloading before answering
+    /// ensures freshness.
+    /// What: calls `reload_if_changed`, then returns a clone or `NotFound`.
+    /// Test: `store_list_and_get`.
+    pub async fn get(&mut self, name: &str) -> Result<Project, ProjectStoreError> {
+        self.reload_if_changed().await?;
+        self.data
+            .projects
+            .get(name)
+            .cloned()
+            .ok_or_else(|| ProjectStoreError::NotFound(name.to_string()))
+    }
+
+    /// Return all stored project records, reloading from disk first if changed.
+    ///
+    /// Why: `project_list` and registry-seeding operations both need the full set
+    /// and must reflect any write made by another process.
+    /// What: calls `reload_if_changed`, then clones and collects all values.
+    /// Test: `store_list_and_get`.
+    pub async fn all(&mut self) -> Result<Vec<Project>, ProjectStoreError> {
+        self.reload_if_changed().await?;
+        Ok(self.data.projects.values().cloned().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_project(name: &str) -> Project {
+        Project {
+            name: name.to_string(),
+            repo_url: format!("https://github.com/owner/{name}"),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn store_load_save_round_trip() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut store = ProjectStore::load(dir.path()).await.expect("load empty");
+        assert!(store.all().await.expect("all").is_empty());
+
+        store.upsert(make_project("alpha")).await.expect("upsert");
+
+        let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
+        let p = store2.get("alpha").await.expect("get after reload");
+        assert_eq!(p.name, "alpha");
+    }
+
+    #[tokio::test]
+    async fn store_upsert_idempotent() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut store = ProjectStore::load(dir.path()).await.expect("load");
+
+        let p1 = make_project("beta");
+        store.upsert(p1).await.expect("first upsert");
+
+        // Update the description — must replace, not duplicate.
+        let p2 = Project {
+            description: Some("updated".into()),
+            ..make_project("beta")
+        };
+        store.upsert(p2).await.expect("second upsert");
+
+        let all = store.all().await.expect("all");
+        assert_eq!(all.len(), 1, "idempotent upsert must not duplicate");
+        assert_eq!(all[0].description.as_deref(), Some("updated"));
+    }
+
+    #[tokio::test]
+    async fn store_list_and_get() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut store = ProjectStore::load(dir.path()).await.expect("load");
+
+        store
+            .upsert(make_project("gamma"))
+            .await
+            .expect("upsert gamma");
+        store
+            .upsert(make_project("delta"))
+            .await
+            .expect("upsert delta");
+
+        let all = store.all().await.expect("all");
+        assert_eq!(all.len(), 2);
+
+        let p = store.get("gamma").await.expect("get gamma");
+        assert_eq!(p.name, "gamma");
+
+        let err = store.get("missing").await;
+        assert!(
+            matches!(err, Err(ProjectStoreError::NotFound(_))),
+            "expected NotFound"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_reload_picks_up_external_write() {
+        let dir = TempDir::new().expect("tempdir");
+
+        let mut store_a = ProjectStore::load(dir.path()).await.expect("load A");
+        store_a
+            .upsert(make_project("epsilon"))
+            .await
+            .expect("seed A");
+
+        // Simulate a second process writing a new project.
+        let mut store_b = ProjectStore::load(dir.path()).await.expect("load B");
+        store_b.upsert(make_project("zeta")).await.expect("write B");
+
+        // Store A must pick up the external write on its next read.
+        let all = store_a.all().await.expect("all A after external write");
+        let names: Vec<&str> = all.iter().map(|p| p.name.as_str()).collect();
+        assert!(
+            names.contains(&"zeta"),
+            "store A must reload zeta: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_reload_noop_when_unchanged() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut store = ProjectStore::load(dir.path()).await.expect("load");
+        store.upsert(make_project("eta")).await.expect("upsert");
+
+        // No external write — reload must be a no-op that preserves data.
+        store.reload_if_changed().await.expect("reload no-op");
+        let p = store.get("eta").await.expect("get");
+        assert_eq!(p.name, "eta");
+    }
+
+    #[tokio::test]
+    async fn json_round_trip_preserves_all_fields() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut store = ProjectStore::load(dir.path()).await.expect("load");
+
+        let full = Project {
+            name: "full-project".into(),
+            repo_url: "https://github.com/owner/full-project.git".into(),
+            default_branch: "develop".into(),
+            stack_hint: Some("typescript".into()),
+            tags: vec!["frontend".into(), "oss".into()],
+            description: Some("a fully-populated project".into()),
+        };
+        store.upsert(full.clone()).await.expect("upsert full");
+
+        let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
+        let back = store2.get("full-project").await.expect("get");
+        assert_eq!(back, full);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `project/` module with `Project` record, `ProjectStore` (atomic-write + reload-on-read), and `ProjectRegistry` (idempotent upsert, get, list, config seeding, session-history auto-registration)
- Extends `TrustyToolsConfig` with optional `projects: Vec<ProjectConfig>` for `config.yaml` bootstrapping
- Wires three new MCP tools (`project_list`, `project_register`, `project_get`) through the full dispatch chain: tool catalog → `OrchestratorBackend` trait → `project_dispatch::try_dispatch` → `mcp_project` free fns → `DaemonState::project_registry` (lazy `OnceCell`)
- 23 unit tests for the project module + 7 dispatch-level tests in `mcp::tests`; all pass; SLOC cap: 0 violations

## Test plan

- [x] `cargo check -p trusty-mpm` — clean
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test -p trusty-mpm` — 1682 passed, 107 failed (all 107 are pre-existing baseline failures on `origin/main`; 0 regressions introduced)
- [x] `cargo fmt -p trusty-mpm --check` — no drift
- [x] `bash scripts/check_line_cap.sh` — 0 violations

Closes #1519
Refs #1517, #1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)