### PR TITLE
docs(trusty-controller): phased implementation plan + progress manifest (03-plan)

### DIFF
--- a/docs/trusty-controller/research/03-plan/00-current-state.md
+++ b/docs/trusty-controller/research/03-plan/00-current-state.md
@@ -1,0 +1,281 @@
+# 00 — Current State Snapshot (trusty-controller / `tctl`)
+
+> **Self-contained.** This file restates everything a plan reader needs about the
+> *as-built* state of `crates/trusty-controller/` so they can read
+> [`01-phased-plan.md`](./01-phased-plan.md) with no prior context. It is the
+> authoritative reconciliation between the **02-design** doc set (the intended
+> design) and the code that actually shipped.
+>
+> **Source of truth for intent:** [`../02-design/`](../02-design/) (DOC-0..DOC-12).
+> **Source of truth for "what's built":** this snapshot, derived from a verified
+> reconciliation pass over `crates/trusty-controller/` at `v0.2.0`.
+
+---
+
+## 1. Crate facts
+
+| Fact | Value |
+|---|---|
+| Crate / dir | `trusty-controller` / `crates/trusty-controller/` |
+| Binary + alias | `tctl` |
+| Version | `0.2.0` |
+| Publishable | Yes (publish is enabled) |
+| Tests | **214 inline unit tests**; **NO `tests/` integration directory** |
+| License | `Elastic-2.0` via `license-file = "LICENSE"` (DOC-0 A5) |
+| README | **Badly stale** — claims "Phase 0 scaffold" and `publish = false` although everything in §2 below is shipped. Must be rewritten (P0). |
+
+**Critical testing gap:** all 214 tests are **pure-function unit tests**. They do
+**not** exercise dispatch, scope threading, or end-to-end install/upgrade. They
+will **not** catch dispatch/scope regressions. This is why a harness skeleton is
+pulled *early* (P0), harness assertions A1/A2/A8 gate **P3** against a real member,
+and the full battery / CI infra land in **P7a/P7b** (see
+[`01-phased-plan.md`](./01-phased-plan.md)).
+
+---
+
+## 2. DONE & real (shipped, working)
+
+These commands/flows are implemented and functioning:
+
+- `install` — install members.
+- `upgrade` / `updates` — upgrade + list-updates.
+- `ensure` (incl. `--wait`): `.mcp.json` patch, index register, palace create,
+  readiness poll.
+- `start` / `stop` / `restart` — launchd lifecycle.
+- `config` — config rendering.
+- `port` — report controller port.
+- `doctor --self-check` — **ad-hoc** member self-check (not yet contract-driven).
+- `ui` — launches `trusty-console` (per ADR-0011, superseding DOC-7's embedded UI).
+- `version` — present but emits **placeholder data** (see §3).
+- The full **`up/` bootstrap orchestrator** (DOC-12): STAGE 0–5, a **real `flock`
+  lock**, prompt-first `claude_code` stage. This is the **most-built** part of the
+  crate — but it is built on the **stubbed foundations** of §3, so it will need
+  **rewiring** through the real Dispatcher/passthrough/manifest once those land.
+
+---
+
+## 3. SUBSET STAND-INS (will be REWRITTEN, not extended)
+
+These exist but implement a degenerate subset of the design. The plan **replaces**
+them rather than growing them:
+
+> **Path note (m1):** these files live under `src/commands/...` (e.g.
+> `src/commands/stack/health.rs`, `src/commands/probe.rs`); `scope.rs` is at
+> `src/scope.rs`. Paths below are spelled out fully.
+
+| File | What it does today | What the design (DOC) requires |
+|---|---|---|
+| `src/commands/stack/health.rs` | flat 2-value `.any()` fold | DOC-4 §2: 4-value lattice + tools×scope matrix + clusters |
+| `src/commands/stack/doctor.rs` | flat 2-value `.any()` fold | DOC-4 §2/§3: deep matrix + drill-down + remediation |
+| `src/commands/probe.rs` | ad-hoc `serde_json::Value` envelope validation | DOC-1 D3a: typed `Envelope<T>` parse |
+| `src/commands/version.rs` / `src/commands/output.rs` | `stack_version = "0.0.0-scaffold"`, `contract_floor = 1` literal | DOC-2: real `stack_version = "YYYY.MM-N"` from manifest; DOC-1 D2: real floor |
+
+---
+
+## 4. DEAD / ORPHANED code (decide fate in P0)
+
+- `src/scope.rs` — **built, zero non-test callers.** The scope primitive exists but
+  is never wired. (`src/main.rs` has `let _ = cli.scope` with `TODO(#920)`.)
+- `src/commands/auto_update.rs::maybe_notify` — **built, zero callers.** Speculative.
+  Fate is now an **OPEN DECISION (D-m3)**: delete the orphan vs wire it to the DOC-9
+  drift notification. Not pre-decided here (see
+  [`02-adversarial-review.md`](./02-adversarial-review.md) m3 and the decisions log).
+
+---
+
+## 5. THE ONE TRUE STUB
+
+- `src/commands/passthrough.rs` — `print_not_yet_implemented`. Yet the design (DOC-5 §2) makes
+  this the **substrate of the entire 9-step dispatch engine**. Every first-class
+  command is meant to be sugar over passthrough. **This is the single most
+  load-bearing unbuilt piece in the crate.**
+
+---
+
+## 6. THE FOUR MISSING FOUNDATIONS
+
+Nothing downstream can be correct until these land. (Build order: DOC-2 → DOC-1 →
+DOC-4 → DOC-5; see [`01-phased-plan.md`](./01-phased-plan.md).)
+
+### Foundation 1 — DOC-1 contract module (`trusty_common::contract`) **DOES NOT EXIST**
+
+Required (DOC-1 D1–D8, ADR-0007):
+- `Envelope<T>` uniform response (`contract_version`, `tool`, `tool_version`,
+  `verb`, `scope`, `status`, `data`, `messages`).
+- `contract_version`: **monotonic integer**, floor `F = 1` (D2). NOT semver.
+- `verbs[]` capability advertisement — **independent of `contract_version`** (D3,
+  the "versioning split"). The 7 verbs: `doctor health version start stop restart
+  config`.
+- `ContractTool` trait + `Dispatcher` (D6).
+- **Golden-snapshot CI test (C3)** that fails any envelope/`data`-shape change
+  unless `contract_version` is bumped + a ledger row added (D3).
+- **Redaction marker `***redacted***` (D8)** — layered: tool-side `redact_value`
+  primary line + controller-side belt-and-suspenders pass.
+
+Current reality: **no member emits `contract_version` or advertises `verbs[]`.**
+The `restart` verb is **net-new on every daemon**. `trusty-review` implements
+**none** of the 7 verbs. → This foundation is only worth funding if the cross-crate
+retrofit epic (Foundation/DOC-6, plan P4) is funded **in the same campaign**, else
+the controller validates envelopes no member emits.
+
+### Foundation 2 — DOC-2 manifest / BOM **NOT LOADED**
+
+- `--manifest` flag is **inert**.
+- **FOUR divergent hard-coded member lists** that already disagree on
+  `review`/`tga`/`controller`:
+
+  | Source | # members | Notable contents |
+  |---|---|---|
+  | `src/commands/up/manifest.rs::default_manifest()` | 6 | incl. `controller` |
+  | `src/commands/stable_set.rs` | 7 | incl. `review` + `tga` |
+  | `src/commands/up/manifest.rs::analyze_core_targets()` | 5 | — |
+  | `src/commands/ensure/mcp_patch.rs::mcp_members()` | 4 | — |
+
+  These four lists are the single largest correctness hazard. Collapsing them into
+  one `manifest.toml` is the first work item of the whole campaign. Note
+  `analyze_core_targets` is **also read** via `cfg.analyze_core_targets` in
+  `src/commands/up/policy.rs` — that read is allowed to remain *as a manifest-backed
+  query* after the collapse (see [`01-phased-plan.md`](./01-phased-plan.md) P0 EXIT
+  GATE allowed-remaining-refs).
+
+Design (DOC-2): **TOML**; **embedded default + system override only** (NO project
+tier); `include_str!` the committed `manifest.toml`; `[[member]]` schema with
+`id`, `display_name`, `binary`, `kind`, `install{source}`, `version` pin,
+`min_contract_version`, `changelog`, `enabled`, per-member `timeout`,
+`depends_on`; `stack_version = "YYYY.MM-N"`.
+
+### Foundation 3 — DOC-3 scope threading **NOT WIRED**
+
+- `src/main.rs`: `let _ = cli.scope` — `TODO(#920)`.
+- `src/scope.rs` is dead (§4).
+- Canonical project id must be the **full-path slug of the nearest git root**
+  (canonicalize-then-slug, ADR-0008). The **slug primitive** is already hoisted
+  (`trusty_common::slugify_string`), but the **detection walk**
+  (`detect_project` / `id_from_path`) is **NOT** hoisted.
+- The **system advisory lock (M7)** exists only in `src/commands/up/`, not on the
+  `ensure` rung.
+
+> 🔴 **CRITICAL (B1) — the identity flip is a LIVE re-key, not a "subtle id
+> change."** The **live keying scheme today is the BASENAME**, not the slug:
+> `trusty_common::derive_index_id` returns the basename (`index_id.rs:71` doc:
+> *"changing casing/punctuation would orphan every previously-indexed project"*);
+> `trusty-search/src/detect.rs` keys on the basename. The slug form
+> (`fs_discovery.rs::id_from_path`) is a **different live key**. Flipping
+> `derive_index_id` (basename) → `id_from_path` (slug) **re-keys every existing
+> index and palace** and **orphans all user state** unless the re-key migration
+> co-ships. Therefore the slug path must be **inert until the migration lands**
+> (see §8 caveat (c) and [`01-phased-plan.md`](./01-phased-plan.md) P1 + P6).
+
+### Foundation 4 — DOC-4 rollup **degenerate**
+
+Needs (DOC-4 §2):
+- **4-value lattice** `down ≻ degraded ≻ pending ≻ ready` (`skipped` absorbed).
+- **tools×scope matrix**: the **system track (GLOBAL) drives the verdict**; a
+  **project `pending` (LOCAL) never degrades the global verdict** — the
+  load-bearing *"unindexed project ≠ broken stack"* rule that the **current flat
+  fold gets WRONG**.
+- **Transitive cluster fold** over `depends_on ∪ deps[]` (C4).
+- **2 s / 10 s** timeouts (health / doctor). **Per DOC-4 Resolved Decision 1
+  (owner-approved 2026-06-08), v1 ships ONLY a single global `--timeout` flag;
+  per-member manifest timeout overrides are DEFERRED.** (The draft's "RD1 + M10"
+  was wrong on both counts — RD1 *defers* per-member timeouts, and "M10" does not
+  exist in DOC-4. See [`02-adversarial-review.md`](./02-adversarial-review.md) B2
+  and OPEN DECISION D-B2.)
+- Exit codes `0/2/1/3`; **stack aggregate = worst-wins `3 ≻ 1 ≻ 2 ≻ 0`**. Per
+  **DOC-4 RD3**, a **project-scope** `down`/`fail` degrades **only the project
+  cell** and does **NOT** raise the process exit code (the system track drives the
+  exit). See P2 EXIT GATE (m6).
+- `pending_since` time-escalation (a stalled `pending` past a budget → `degraded`).
+
+---
+
+## 7. The rest of the design surface (state at a glance)
+
+| DOC | Concern | State |
+|---|---|---|
+| **DOC-5** | 9-step universal dispatch (load manifest → select → scope → blast-gate → capability-negotiate → invoke → collect → rollup → exit); passthrough is substrate; verb-aware; reject controller-self (M5); non-TTY system-mutating w/o `--yes` → exit 3 | dispatch engine unbuilt; `src/commands/passthrough.rs` is the stub (§5) |
+| **DOC-6** | per-tool retrofit **across 4 OTHER crates** (search T3 pattern-setter → memory/analyze T3 → review T2, none built) + claude-mpm `uv` shim in `trusty_common::contract::orchestrator` (T1, `["doctor","health","version"]`) + **M15 stateful re-key migration carried in trusty-search `core::migration` (m001..m004 framework) with a `schema_version` bump (DOC-6 §7.1)** | unbuilt; multi-PR cross-crate iceberg |
+| **DOC-8/9** | cargo install/verify **DONE**; BOM-pin / `--latest` drift **MISSING** (needs manifest); uv/python orchestrator install **MISSING**; launch-hook (Claude Code SessionStart) **needs verification** | partial |
+| **DOC-10** | isolation harness (`tests/isolation_harness.rs` + `isolation.yml` + A0–A8 battery + macOS cdhash/warm-boot assertion M14) | **entirely unbuilt** |
+| **DOC-12** (DRAFT) | `src/commands/up/` STAGE 0–5 **DONE** but on stubbed foundations; `src/commands/up/system_runner.rs`/`os_env.rs` use raw `Command::new`, **bypassing passthrough** and trusting status blindly → needs **rewiring** through Dispatcher/passthrough/manifest. **DOC-12 is still Draft** — P3 must not rewire `up/` until DOC-12 is Accepted (or Q1–Q6 re-confirmed): OPEN DECISION D-M5. | built-but-must-rewire |
+| **DOC-7** | embedded web UI | **SUPERSEDED by ADR-0011**; targets moved to `trusty-console`. DOC-11 still routes some UI follow-ups here — those are stale. |
+
+---
+
+## 8. Devil's-advocate caveats (carry into every phase)
+
+These are **settled findings** and must be honoured by the plan:
+
+- **(a) DOC-1 only pays off with DOC-6 funded in the same campaign** — else the
+  controller validates envelopes no member emits. **This makes P1 (contract) and
+  P4 (retrofit) a single sub-campaign that must be justified together** — they are
+  *not* the assumed spine. See the Option A / Option B strategic choice in
+  [`01-phased-plan.md`](./01-phased-plan.md) and the DECISION GATE after P0/P2.
+- **(b) Build the DOC-10 integration harness EARLY** — the 214 unit tests are
+  pure-function and will not catch dispatch/scope regressions. **Corollary (B3):**
+  P2/P3 acceptance must be validated against ≥1 **real** member envelope (the
+  trusty-search retrofit, pulled forward to gate P3), not synthetic fixtures.
+- **(c) The identity flip orphans ALL state unless the re-key migration co-ships.**
+  The live key today is the **basename** (`derive_index_id`); the canonical slug
+  (`id_from_path`) is a *different* live key. The flip must be **inert behind a
+  flag until the migration lands**, and the migration must **re-key by `root_path`**
+  (no re-embed/no reindex) inside **trusty-search `core::migration`** with a
+  `schema_version` bump (DOC-6 §7.1). A naive flip-then-migrate-later orphans every
+  index and palace; a naive migration triggers a from-scratch reindex (multi-minute
+  + storage doubling).
+- **(d) Timeouts: honor DOC-4 RD1 — v1 ships ONLY a global `--timeout`.** Per-member
+  manifest overrides are **DEFERRED** (RD1, owner-approved 2026-06-08). The draft's
+  "RD1 + M10" was wrong: RD1 defers per-member timeouts and "M10" does not exist.
+  Un-deferring is an OPEN DECISION (D-B2) requiring explicit owner reversal of RD1.
+- **(e) DOC-11 still routes UI follow-ups to the superseded DOC-7** — those targets
+  moved to `trusty-console`; do not re-implement an embedded UI.
+- **(f) DOC-12 is DRAFT while its `up/` is the most-built part** — treat DOC-12 as
+  subject to change; expect rewiring, not preservation. **P3 may not rewire `up/`
+  until DOC-12 is Accepted or Q1–Q6 re-confirmed (D-M5).**
+
+---
+
+## 9. Forced build order (post-adversarial-review)
+
+Revised after the adversarial pass ([`02-adversarial-review.md`](./02-adversarial-review.md)).
+The key structural changes vs the draft: (1) the identity-slug path is **inert
+until its migration co-ships**; (2) the **trusty-search retrofit (P4a) is pulled
+forward to gate P3** so dispatch is validated against a real member; (3) the
+cross-crate epic is split P4a–P4d; (4) the harness is split P7a (code) / P7b
+(CI infra); (5) a strategic **DECISION GATE (Option A vs B)** sits after P0/P2.
+
+```
+P0  DOC-2 manifest (FIRST — no upstream dep; kills 4-list divergence; unblocks
+        stack_version + member selection + dispatch step 1)
+        NON-contract fields only (M2 two-pass); + README rewrite; + real stack_version
+   ↓
+P2  DOC-4 lattice + scope matrix  (DEFER cluster fold C4 → P8)
+        [Option-A deliverable ends here: README + 4-list collapse + real rollup,
+         NO identity flip, NO cross-crate epic]
+   ↓
+======================  DECISION GATE — Option A vs Option B  ======================
+   (stop at the value-first deliverable, OR commit P1+P4 together as a sub-campaign)
+   ↓ (Option B only)
+P1  DOC-1 contract module + identity-walk hoist (slug path INERT behind flag) +
+        finalize manifest CONTRACT fields (M2 second pass)
+   ↓
+P3  DOC-5 dispatch loop + real passthrough + thread scope + rewire up/
+        ── HARD-GATED by P4a (trusty-search emits a REAL Envelope<T>) ──
+        ── A1/A2/A8 pulled forward to gate P3 ──
+   ↓
+P4a trusty-search retrofit (pattern-setter; lands inside/before P3 exit)
+P4b trusty-memory  ·  P4c trusty-analyze  ·  P4d trusty-review (heaviest; none of 7 verbs)
+   ↓
+P5  claude-mpm uv shim (LAST, minimal, T1 only)
+   ↓
+P6  M15 re-key migration  +  FLIP the inert slug flag  (ATOMIC within one phase;
+        carried in trusty-search core::migration, schema_version bump, DOC-6 §7.1;
+        re-key by root_path, NO reindex)
+   ↓
+P7a DOC-10 harness CODE + A0–A8 battery   ·   P7b CI INFRA (macOS-VM/Linux-container)
+   ↓
+P8  transitive cluster fold C4 + DOC-11 residuals
+```
+
+Also throughout: rewrite stale README (P0); `auto_update` fate is OPEN DECISION
+D-m3 (not pre-decided); `src/scope.rs` retained, wired in P3.

--- a/docs/trusty-controller/research/03-plan/01-phased-plan.md
+++ b/docs/trusty-controller/research/03-plan/01-phased-plan.md
@@ -1,0 +1,990 @@
+# 01 — Phased Implementation Plan (trusty-controller / `tctl`)
+
+> **Source of truth for *intent*:** [`../02-design/`](../02-design/) (DOC-0..DOC-12).
+> **Source of truth for *as-built*:** [`00-current-state.md`](./00-current-state.md).
+> **Adversarial review that shaped this plan:** [`02-adversarial-review.md`](./02-adversarial-review.md).
+> **Living tracker (update at every gate):** [`progress-manifest.md`](./progress-manifest.md).
+>
+> This plan defines phases in this **execution order**: **P0 → P2 → [DECISION
+> GATE] → P1 → P4a → P3 → P4b → P4c → P4d → P5 → P6 → P7a → P7b → P8.** (The
+> numbering is deliberately *dependency-ordered*, not alphabetical — P2 precedes
+> P1 because the Option-A deliverable, P0+P2, must be shippable **without** the
+> contract rebuild; P4a is pulled forward to gate P3.) Each phase has an **ENTER GATE**
+> (preconditions), ordered **WORK ITEMS** (each PR-sized), an **EXIT GATE** of
+> binary pass/fail acceptance criteria, **RISKS + MITIGATIONS**, and a **BLAST
+> RADIUS** (crates/files touched). Acceptance criteria are drawn from the
+> referenced DOC sections so they are verifiable, not aspirational.
+
+---
+
+## Strategic choice — Option A vs Option B (read first)
+
+The adversarial review (whole-approach critique) surfaced that the full
+contract/dispatch rebuild is **not** an unconditional spine. By the plan's own
+caveat (a), the P1 contract module is **worthless unless the P4 cross-crate
+retrofit is funded in the same campaign**. So the campaign must make an explicit
+choice:
+
+- **Option A — value-first minimal sub-campaign.** Ship **P0** (manifest +
+  README rewrite + collapse the 4 lists + real `stack_version`) **and the P2
+  lattice** as a **standalone deliverable**. This alone fixes:
+  - the **lying README** (claims scaffold / `publish = false`),
+  - the **four-divergent-member-list** correctness hazard, and
+  - the load-bearing **"unindexed project ≠ broken stack"** rollup bug.
+  Option A involves **no identity flip** and **no cross-crate epic** — it is
+  low-risk, self-contained, and independently valuable.
+
+- **Option B — full contract/dispatch rebuild.** P1 / P3 / P4a–P4d / P5, plus
+  the P6 migration and the P7a/P7b harness. Per caveat (a), **P1 and P4 must be
+  justified and funded *together*** — committing to P1 without funding P4 ships a
+  contract module no member emits.
+
+A **DECISION GATE** sits **after P0/P2** (see the diagram). The campaign decides
+there whether to stop at the Option-A deliverable or commit to Option B as a
+P1+P4 sub-campaign. The decision is logged as **D-OptAB** in the decisions log.
+
+---
+
+## Phase dependency / ordering diagram
+
+```
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P0  manifest.toml + loader (NON-contract fields) · collapse 4 │
+            │     lists · real stack_version · README rewrite · MIN harness  │
+            │     skeleton   (auto_update fate = OPEN DECISION D-m3)          │
+            └───────────────┬──────────────────────────────────────────────┘
+                            │ (DOC-2 manifest is the keystone — no upstream dep)
+                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P2  DOC-4 rollup: 4-value lattice + tools×scope matrix        │
+            │     global --timeout only (RD1) · RD3 project-cell-only exit   │
+            │     (DEFER transitive cluster fold C4 → P8)                    │
+            └───────────────┬──────────────────────────────────────────────┘
+                            ▼
+   ╔════════════════════════════════════════════════════════════════════════╗
+   ║  DECISION GATE — Option A (stop here, value-first) vs Option B (rebuild) ║
+   ║  Option B requires committing P1 + P4 TOGETHER (caveat (a)).  [D-OptAB]  ║
+   ╚════════════════════════════════════════════════════════════════════════╝
+                            │ (Option B only)
+                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P1  trusty_common::contract (Envelope<T>, verbs[], ContractTool│
+            │     Dispatcher) + golden snapshot + redaction                  │
+            │     + HOIST identity walk — slug path INERT behind flag (B1)   │
+            │     + finalize manifest CONTRACT fields (M2 second pass)       │
+            └───────────────┬──────────────────────────────────────────────┘
+                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P4a trusty-search retrofit (pattern-setter) — emits a REAL     │
+            │     Envelope<T>.  HARD-GATES P3 exit (B3).                     │
+            └───────────────┬──────────────────────────────────────────────┘
+                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P3  DOC-5 9-step dispatch + REAL passthrough + scope (kill     │
+            │     TODO #920) + blast-gate (M5) + rewire up/                  │
+            │     EXIT gated by P4a (real member) + A1/A2/A8 (B3)            │
+            │     ENTER gated by DOC-12 Accepted/Q1–Q6 re-confirmed (M5)     │
+            └───────────────┬──────────────────────────────────────────────┘
+                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P4b trusty-memory · P4c trusty-analyze · P4d trusty-review     │
+            │     (each independently gated; review heaviest — none of 7)    │
+            └───────────────┬──────────────────────────────────────────────┘
+                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P5  claude-mpm uv shim (minimal, T1 only)                      │
+            └───────────────┬──────────────────────────────────────────────┘
+                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P6  M15 re-key migration + FLIP the inert slug flag (ATOMIC).  │
+            │     Carried in trusty-search core::migration (schema_version   │
+            │     bump, DOC-6 §7.1); re-key by root_path, NO reindex. (B1)   │
+            └───────────────┬──────────────────────────────────────────────┘
+                            ▼
+            ┌───────────────────────────────┐   ┌──────────────────────────┐
+            │ P7a harness CODE + A0–A8       │   │ P7b CI INFRA: macOS-VM / │
+            │     battery (code only)        │──▶│ Linux-container +        │
+            │                                │   │ isolation.yml (M4)       │
+            └───────────────┬───────────────┘   └────────────┬─────────────┘
+                            └───────────────┬─────────────────┘
+                                            ▼
+            ┌──────────────────────────────────────────────────────────────┐
+            │ P8  fast-follow: transitive cluster fold (C4)                  │
+            │     + DOC-11 residual follow-ups (re-route stale DOC-7 refs)   │
+            └──────────────────────────────────────────────────────────────┘
+```
+
+**Ordering rationale.** DOC-2 (manifest, **P0**) is built **first**: no upstream
+dependency, kills the four-divergent-list hazard, unblocks `stack_version`,
+member selection, and dispatch step 1. The DOC-4 rollup (**P2**) lands next so
+the Option-A deliverable (P0+P2) is independently shippable. **Then the DECISION
+GATE.** In Option B, DOC-1 (**P1**) lands the contract + the *inert* identity
+walk; **P4a (search retrofit) is pulled forward to gate P3** so dispatch is
+validated against a **real** member (not a fixture); the rest of the retrofit
+epic (P4b–P4d) follows; the shim (P5) is minimal/last; the **M15 migration and
+the slug-flag flip are atomic in P6**; the harness splits into **code (P7a)** and
+**CI infra (P7b)**; the speculative cluster fold (C4) and DOC-11 residuals are
+the fast-follow (P8).
+
+> **There is no "freely parallelizable" consumer track.** (The draft's
+> "two parallelizable tracks" note is removed.) **P2/P3 acceptance depends on
+> P4a** (the first real member) — the controller side cannot be validated until a
+> real member emits an `Envelope<T>`. P4b–P4d may proceed concurrently *after*
+> P4a sets the pattern, but P3's exit gate is the synchronization point.
+
+---
+
+## CROSS-PHASE INVARIANTS (every phase must hold)
+
+> Referenced from every phase below that bumps `trusty-common` or installs a
+> daemon binary. (M3.)
+
+- **CLAUDE.md rules:** Why/What/Test doc comments on public items; `thiserror` in
+  libraries (`trusty-common`), `anyhow` in binaries (`tctl`); no `unwrap()` in
+  library code; logs to **stderr** (stdout is contract-JSON only).
+- **SLOC caps:** 500 prod / 1500 test; run `bash scripts/check_line_cap.sh` before
+  every commit; split modules proactively.
+- **Shared-crate publish order (M3):** when a phase bumps `trusty-common`
+  (P1, P5, P6), **publish `trusty-common` BEFORE its consumers**. Follow the
+  cargo-publish skill with a **`cargo publish --dry-run`** first; bump the
+  dependent-crate pins and run **whole-workspace `cargo check`** + each
+  dependent's tests. Keep `[patch.crates-io]` for `trusty-common` consistent in
+  the root `Cargo.toml`.
+- **macOS daemon-install hygiene (M3, CLAUDE.md #873):** after **every**
+  `cargo install` of a daemon binary (search/memory/analyze/controller),
+  **re-grant Full Disk Access** and **verify the cdhash** (the install must use
+  `cargo install`'s atomic rename — **never `cp`-over-PATH**). Restart via
+  `launchctl bootout`→`bootstrap` (SIGTERM), not `kickstart -k`.
+- **Worktree discipline:** all work in a dedicated worktree off `origin/main`; the
+  main checkout is inspection-only.
+- **Manifest is the only registry:** after P0, **no** hard-coded member list may be
+  re-introduced in any phase.
+- **Update the progress manifest at every enter/exit gate** (date, PR #, status).
+  Note this protocol is **advisory/honor-system** (see manifest m5).
+
+---
+
+## P0 — Manifest + repo hygiene (DOC-2; DOC-0 README; cleanup)
+
+**Goal (one line):** make a single embedded `manifest.toml` the sole source of the
+member list (non-contract fields), and clean up the repo's stale/dead surface.
+
+**Satisfies:** DOC-2 (manifest/BOM, `stack_version`), DOC-0 (README/charter),
+repo hygiene, partial DOC-10 (harness skeleton seed).
+
+### ENTER GATE
+- Worktree provisioned off `origin/main` (campaign's first phase).
+- [`00-current-state.md`](./00-current-state.md) reviewed; four divergent member
+  lists located (`src/commands/up/manifest.rs::default_manifest`,
+  `src/commands/stable_set.rs`, `src/commands/up/manifest.rs::analyze_core_targets`,
+  `src/commands/ensure/mcp_patch.rs::mcp_members`).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Author `crates/trusty-controller/manifest.toml` — NON-contract fields only
+   (M2).** One `[[member]]` per member with the DOC-2 §3 schema for the
+   *non-contract* fields: `id`, `display_name`, `binary`,
+   `kind` (`daemon|cli|controller|orchestrator`),
+   `install = { source = "cargo", crate = … }` (or `python`/`uv` for the
+   orchestrator), `version` pin, `changelog`, `depends_on?`, `enabled`. Set
+   `stack_version = "YYYY.MM-N"`. A `timeout?` field MAY be carried for
+   forward-compat but is **not consumed in v1** (RD1, B2). **The contract fields
+   (`min_contract_version`, `expected_contract_version`, `contract_floor`) are
+   OUT OF P0 SCOPE — finalized in P1 (second pass).** Reconcile the
+   **review/tga/controller** disagreements explicitly (decide membership; record
+   in the decisions log).
+2. **Build the manifest loader** (`src/manifest/mod.rs`): `include_str!` the
+   embedded default; resolve the optional system override
+   (`~/.config/trusty-controller/manifest.toml` via `trusty_common` config
+   helpers); precedence **system override > embedded default**; wire the
+   `--manifest <path>` flag (currently inert) to override both.
+3. **Collapse the four lists (m2 binary gate).** Replace every one of the four
+   hard-coded lists with a query against the loaded manifest. Delete the dead list
+   constructors. (Allowed remaining ref: `cfg.analyze_core_targets` read in
+   `src/commands/up/policy.rs`, now backed by a manifest query — see EXIT GATE.)
+4. **Wire real `stack_version`** — replace `src/commands/version.rs` /
+   `src/commands/output.rs` `"0.0.0-scaffold"` with the manifest `stack_version`.
+   **Leave `contract_floor` as-is for now (a literal/placeholder); it is finalized
+   in P1** — state this two-pass explicitly in the PR description.
+5. **Dead-code: `auto_update` fate is an OPEN DECISION (D-m3).** Do **not** delete
+   in P0. Leave `src/commands/auto_update.rs::maybe_notify` in place with a TODO
+   pointing at D-m3 (delete the orphan vs wire to DOC-9 drift notification — owner
+   call). **Keep `src/scope.rs`** with a "wired in P3" marker.
+6. **Rewrite the stale README** — remove "Phase 0 scaffold" / `publish = false`
+   language; describe the real shipped surface (`install`/`upgrade`/`ensure`/
+   `start`/`stop`/`restart`/`config`/`port`/`doctor --self-check`/`ui`/`up`),
+   present the **Option A vs Option B** framing, and point to the design set.
+7. **Seed a minimal harness skeleton** — create
+   `crates/trusty-controller/tests/isolation_harness.rs` with a single smoke
+   assertion (`tctl version --json` parses + `stack_version` is non-placeholder)
+   and a stub `.github/workflows/isolation.yml` CI job. (Full battery/CI in
+   P7a/P7b.)
+
+### EXIT GATE (binary pass/fail)
+- [ ] `crates/trusty-controller/manifest.toml` exists, is `include_str!`-embedded,
+      and parses into the `[[member]]` schema (unit test asserts every required
+      **non-contract** field present per member).
+- [ ] **Collapse is mechanically clean (m2):** a grep proves **zero `vec![…]` /
+      array literals of member ids** remain in `default_manifest`, `stable_set`,
+      `analyze_core_targets`, `mcp_members` — these symbols are **deleted or return
+      manifest queries**. The **only** allowed remaining reference is
+      `cfg.analyze_core_targets` in `src/commands/up/policy.rs`, and a test asserts
+      it resolves from the manifest (not a literal).
+- [ ] `tctl version --json` emits a real `stack_version` (matches the manifest;
+      **not** `0.0.0-scaffold`). (`contract_floor` may still be a placeholder here;
+      finalized in P1.)
+- [ ] `--manifest <path>` override is honoured (test: a temp override file changes
+      the loaded member set).
+- [ ] README contains **no** "Phase 0 scaffold" / `publish = false` text and
+      presents the Option A / Option B choice.
+- [ ] `auto_update.rs::maybe_notify` **retained** with a D-m3 TODO (not deleted);
+      `src/scope.rs` retained with a P3 marker.
+- [ ] `cargo test -p trusty-controller` green; `cargo clippy -p trusty-controller
+      -- -D warnings` clean; `cargo fmt --check` clean.
+- [ ] `bash scripts/check_line_cap.sh` clean (manifest loader split if >500 SLOC).
+- [ ] Harness skeleton smoke test runs (locally; CI stub present).
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated (date, PR #s).
+
+### RISKS + MITIGATIONS
+- **R: choosing wrong membership for review/tga/controller.** → Record the decision
+  + rationale in the decisions log; the manifest is a single editable file, so a
+  wrong call is a one-line fix later.
+- **R: `up/` already consumes the hard-coded lists and breaks.** → P0 only swaps
+  the *list source*, preserving member identities; full `up/` rewiring is deferred
+  to P3. Add a regression test that `up/`'s member set equals the manifest set.
+
+### BLAST RADIUS
+`crates/trusty-controller/`: new `manifest.toml`, new `src/manifest/` module,
+`src/commands/up/manifest.rs`, `src/commands/stable_set.rs`,
+`src/commands/ensure/mcp_patch.rs`, `src/commands/up/policy.rs`,
+`src/commands/version.rs`, `src/commands/output.rs`, `src/main.rs` (`--manifest`
+wiring), `README.md`, new `tests/isolation_harness.rs`, new
+`.github/workflows/isolation.yml` (stub). Possibly `trusty-common` config helpers
+(read-only use).
+
+---
+
+## P2 — DOC-4 rollup: 4-value lattice + tools×scope matrix
+
+**Goal (one line):** replace the flat 2-value fold with the 4-value verdict lattice
+and the tools×scope matrix that gets *"unindexed project ≠ broken stack"* right.
+
+**Satisfies:** DOC-4 §2 (lattice), §2.0 (vocabulary), §1.3 + **RD1** (global
+`--timeout` only in v1), **RD3** (project-cell-only exit), §7 (exit codes).
+**Defers** the transitive cluster fold (C4) to P8.
+
+> P2 lands directly after P0 (it consumes the manifest's `depends_on`/`kind`, not
+> the contract module). It completes the **Option-A deliverable**. It does **not**
+> require the typed `Envelope<T>` from P1 — it can parse member output via the
+> existing `src/commands/probe.rs` path and switch to `Envelope<T>` opportunistically
+> once P1 lands.
+
+### ENTER GATE
+- P0 EXIT GATE met (manifest is the sole member source; `stack_version` real;
+  `depends_on` available from the manifest).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Implement the 4-value lattice** `down ≻ degraded ≻ pending ≻ ready`, with
+   `skipped` **absorbed** (neither improves nor worsens). Map both source
+   vocabularies (doctor, health) into it per DOC-4 §2.0.
+2. **Tools×scope matrix** — each member yields `cells.{system,project}`. **System
+   track (GLOBAL) drives the stack verdict; a project `pending` (LOCAL) never
+   degrades the global verdict.** Unit-test this rule explicitly (it is the bug the
+   current flat fold has).
+3. **Timeouts — global `--timeout` only (RD1, B2).** 2 s health / 10 s doctor
+   defaults, overridable by a **single global `--timeout` flag**. **Per-member
+   manifest timeout overrides are DEFERRED** (DOC-4 RD1, owner-approved
+   2026-06-08). The rollup **does not read the manifest `timeout?` field in v1**
+   (asserted negatively in the exit gate). On timeout/spawn-fail/unparseable,
+   synthesize a `down` envelope stamped with a `reason`
+   (`not_running|timeout|wedged|unreachable|contract_incompatible`).
+4. **`pending_since` time-escalation** — a `pending` check stalled past the
+   staleness budget rolls up to `degraded` (§5.5).
+5. **Exit-code aggregation (worst-wins + RD3, m6).** Stack aggregate = worst-wins
+   `3 ≻ 1 ≻ 2 ≻ 0` driven by the **system track**; a **project-scope `down`/`fail`
+   degrades ONLY the project cell and does NOT raise the process exit code**
+   (DOC-4 RD3). `--json` rollup struct emits `verdict`, `exit_code`, `summary`
+   counts (incl. `na`), `cells`, `clusters[]` (empty until P8), `remediations[]`.
+6. **Rewrite `src/commands/stack/health.rs` + `src/commands/stack/doctor.rs`** to
+   consume the new rollup (replace the `.any()` fold). Parallel collection via
+   bounded `tokio` join set.
+
+### EXIT GATE (binary pass/fail)
+- [ ] `tctl stack doctor --json` emits a `verdict ∈ {ready,degraded,pending,down}`
+      (4-value), **not** a 2-value boolean.
+- [ ] Unit test: a healthy system + an **unindexed project** rolls up to a
+      **global `ready`** with a **project cell `pending`**; a regression test
+      asserts the global verdict is *not* `degraded`/`down`.
+- [ ] **RD3 (m6):** a project-scope `down`/`fail` degrades **only the project
+      cell** and the **process exit code is unchanged** (negative test must FAIL an
+      impl that lets project-pending/down move the exit).
+- [ ] `summary` counts sum to the member count including `na`; matrix has
+      `cells.{system,project}` for every member (DOC-4 §8.2 A2 shape).
+- [ ] A hung member is synthesized as `down` with a `reason`, and the rest of the
+      matrix still renders (no partial blocking). **Global `--timeout` is honoured;
+      the manifest `timeout?` field is NOT consulted (RD1 — negative assertion).**
+- [ ] Stack exit code follows worst-wins `3 ≻ 1 ≻ 2 ≻ 0`; the `--json` `exit_code`
+      field mirrors the process exit (A1 mirror).
+- [ ] `pending_since` escalation test: a `pending` past budget → `degraded`.
+- [ ] `cargo test -p trusty-controller` green; clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated.
+
+### RISKS + MITIGATIONS
+- **R: re-introducing the flat-fold bug under a new name.** → The explicit
+  "unindexed project ≠ broken" regression test is the gate; it must exist before
+  the phase closes.
+- **R: drifting from RD1 by quietly honouring per-member timeouts (B2).** → The
+  exit gate's **negative** assertion (manifest `timeout?` not consulted) is the
+  guard; un-deferring requires owner reversal (OPEN DECISION D-B2).
+- **R: cluster fold (C4) entanglement.** → Keep `clusters[]` an empty-but-valid
+  array in P2; the lattice + scope split is load-bearing, the cluster fold is
+  speculative at 7 members → P8.
+
+### BLAST RADIUS
+`crates/trusty-controller/`: `src/commands/stack/health.rs`,
+`src/commands/stack/doctor.rs`, new `src/rollup/` module (lattice, matrix,
+exit-codes), `src/commands/probe.rs` (timeout/synthesis),
+`src/commands/output.rs` (`--json` rollup struct). Reads manifest
+`depends_on`/`kind`.
+
+---
+
+## ── DECISION GATE — Option A vs Option B (after P0/P2) ──
+
+**This is a gate, not a phase.** Before any P1/P3/P4 work begins, the campaign
+records **D-OptAB** in the decisions log:
+
+- **Stop at Option A** — ship P0+P2 as the value-first deliverable; close the
+  campaign (or pause it) here. No identity flip, no contract module, no
+  cross-crate epic.
+- **Proceed to Option B** — commit to funding **P1 and P4 together** (caveat (a)):
+  the contract module is only worthwhile if the cross-crate retrofit lands in the
+  same campaign. Record the funding commitment and the DOC-12-promotion plan
+  (D-M5) here.
+
+Do not enter P1 until D-OptAB records "proceed to Option B" **with** the P1+P4
+joint-funding commitment.
+
+---
+
+## P1 — Contract module in `trusty_common` (DOC-1; identity hoist, INERT)
+
+**Goal (one line):** land the shared `trusty_common::contract` module + the hoisted
+project-identity walk (slug path **inert behind a flag**), and finalize the
+manifest's contract fields.
+
+**Satisfies:** DOC-1 D1–D8 (ADR-0007), DOC-3 §8 identity hoist (ADR-0008, gated),
+implementation-spine steps 1–2, and the M2 second pass.
+
+### ENTER GATE
+- DECISION GATE recorded "proceed to Option B" **with P1+P4 joint-funding
+  commitment** (caveat (a), D-OptAB).
+- P0 EXIT GATE met (manifest is the sole member source; `stack_version` real).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Create `crates/trusty-common/src/contract/mod.rs`** — serde `Envelope<T>`
+   (`contract_version`, `tool`, `tool_version`, `verb`, `scope`, `status`, `data`,
+   `messages`), the status vocabularies (doctor `ok|warn|fail|pending|skipped`,
+   health `running|degraded|down`), and the `Scope` wire enum
+   (`project|system|all`).
+2. **`verbs[]` capability descriptor** + the `version --json` shape
+   (`{tool,version,contract_version,verbs[]}`). Enforce DOC-1 D3 "versioning
+   split": verb presence is independent of `contract_version`.
+3. **`ContractTool` trait + `Dispatcher`** (D6) — the trait each Rust tool
+   implements; the dispatcher the controller shares.
+4. **`redact_value` helper + `***redacted***` marker** (D8), with the
+   high-confidence pattern set (AKIA…, Bearer/Authorization, `scheme://user:pass@`,
+   `sk-`/`ghp_`/`xox…`, long high-entropy blobs).
+5. **Golden-snapshot test (C3)** — serialize the envelope + each verb's `data`
+   shape; a snapshot diff fails CI unless `contract_version` is bumped **and** a
+   "what's new per contract_version" ledger row is added. Seed the ledger with
+   `contract_version: 1`. **Note (m4 backlog):** the golden snapshot does **not**
+   cover CLI arg-surface breaking changes — an arg-surface guard is tracked in the
+   backlog.
+6. **Hoist the identity walk — but keep the slug path INERT (B1).** Promote
+   `detect_project` / `id_from_path` (full-path-slug of nearest git root,
+   canonicalize-then-slug, ADR-0008) into `trusty_common` next to the
+   already-hoisted `slugify_string`. **`trusty_common::derive_index_id`
+   (BASENAME) REMAINS the live key.** The slug `id_from_path` is added **behind a
+   feature/flag that no read or write path consults** until the P6 migration flips
+   it. Fallback to cwd-path-slug with a warning when no git root/marker.
+7. **Replace `tctl`'s `src/commands/probe.rs`** ad-hoc `serde_json::Value`
+   validation with the typed `Envelope<T>` parse from the new module.
+8. **Finalize manifest CONTRACT fields (M2 second pass).** Add
+   `min_contract_version` / `expected_contract_version?` per member and replace the
+   P0 placeholder `contract_floor` with the DOC-1 D2 value. **Re-verify the 4
+   collapsed call sites** still resolve correctly now that the contract fields are
+   present.
+
+### EXIT GATE (binary pass/fail)
+- [ ] `trusty_common::contract` compiles and is re-exported; `Envelope<T>`,
+      `verbs[]`, `ContractTool`, `Dispatcher`, `redact_value` are public.
+- [ ] Golden-snapshot test **green**; deliberately mutating a `data` field
+      **without** a `contract_version` bump makes it **fail** (proven by a
+      throwaway local edit, then reverted).
+- [ ] `***redacted***` redaction unit tests pass for every pattern in the D8 set.
+- [ ] `detect_project`/`id_from_path` live in `trusty_common`; a unit test proves
+      the same git checkout yields the same **slug** id from any subdirectory
+      (canonicalize-then-slug), and the no-root fallback emits a warning. **A test
+      asserts the slug path is INERT: `derive_index_id` (basename) is still the key
+      every live read/write uses** (B1) — no production read/write path consults
+      `id_from_path` yet.
+- [ ] `tctl probe.rs` parses real envelopes via `Envelope<T>` (no
+      `serde_json::Value` envelope validation remains).
+- [ ] Manifest now carries `min_contract_version`/`expected_contract_version`/real
+      `contract_floor`; `tctl version --json` emits the real floor; the 4 collapsed
+      call sites re-verified (M2).
+- [ ] **Publish-order check (M3):** `cargo publish --dry-run -p trusty-common`
+      passes; consumer pins bumped; **whole-workspace `cargo check`** green;
+      `cargo test -p trusty-common` + `-p trusty-controller` green; clippy/fmt clean;
+      line-cap clean (split `contract/` into submodules if >500).
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated.
+
+### RISKS + MITIGATIONS
+- **R: contract module ships but no member emits envelopes (caveat (a)).** → ENTER
+  GATE requires the P1+P4 joint-funding commitment; P1's value is realized only
+  when P4 lands. Keep the module minimal (`contract_version: 1`,
+  additive-superset) to avoid churn before consumers exist.
+- **R: `trusty_common` is a shared crate — a change ripples to all dependents.** →
+  Run full-workspace `cargo check` + dependent-crate tests (cross-phase invariant);
+  publish `trusty-common` before consumers; bump + propagate pins.
+- **R (B1, rewritten): the hoist FLIPS THE LIVE KEYING SCHEME — orphans all state
+  unless the migration co-ships.** The basename (`derive_index_id`) is the live
+  key; the slug (`id_from_path`) is a *different* key. → P1 keeps the slug path
+  **inert behind a flag**; the flip happens **only in P6, atomically with the
+  re-key migration**. The inert-flag test (above) is the gate that prevents an
+  accidental early flip.
+
+### BLAST RADIUS
+`crates/trusty-common/` (new `src/contract/` module, identity walk + inert slug
+flag, version bump); `crates/trusty-controller/` (`src/commands/probe.rs`,
+`src/commands/version.rs` floor, `manifest.toml` contract fields); every crate that
+depends on `trusty-common` (compile-check only at this phase).
+
+---
+
+## P4a — trusty-search retrofit (DOC-6 §2, pattern-setter) — GATES P3
+
+**Goal (one line):** make trusty-search emit the DOC-1 envelope + advertise
+`verbs[]` so the controller's dispatch (P3) is validated against a **real** member,
+not a fixture (B3).
+
+**Satisfies:** DOC-6 §2 conformance retrofit (T3 pattern-setter); closes the
+fixture-only gap in caveat (b)/B3.
+
+> **Pulled forward (B3).** P4a lands **inside the P3 window** and is a **hard gate
+> on P3's exit** — dispatch + rollup must be exercised against trusty-search
+> emitting a real `Envelope<T>`. It also sets the retrofit pattern that P4b–P4d
+> copy.
+
+### ENTER GATE
+- P1 EXIT GATE met (`trusty_common::contract` + `ContractTool` available; floor
+  finalized).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Implement `ContractTool` on trusty-search** — emit the envelope for all 7
+   verbs (`doctor health version start stop restart config`); advertise `verbs[]`;
+   route secrets through `redact_value`; add net-new `restart`. This crate defines
+   the retrofit pattern the others copy.
+2. **`<binary> version --json` snapshot test** — advertises `verbs[]` + a
+   `contract_version >= floor`.
+3. **Restart lifecycle test** — reuse the graceful-drain shutdown (#534) +
+   launchd `bootout`/`bootstrap`; verify `health` before/after restart.
+
+### EXIT GATE (binary pass/fail)
+- [ ] `trusty-search version --json` advertises `verbs[]` containing the 7 verbs
+      and a `contract_version >= floor`.
+- [ ] trusty-search emits a typed `Envelope<T>` for `doctor`/`health` consumed by
+      `tctl` without synthesis.
+- [ ] Secrets redacted with `***redacted***` (negative conformance assertion,
+      DOC-6 §8).
+- [ ] Restart lifecycle test green (graceful drain; `health` running before/after).
+- [ ] **Publish-order check (M3):** if `trusty-common` was bumped, it is published
+      first; cdhash re-verified + FDA re-granted after `cargo install trusty-search`.
+- [ ] `cargo check` whole-workspace green; `cargo test -p trusty-search` green;
+      clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) P4a row updated.
+
+### RISKS + MITIGATIONS
+- **R: net-new `restart` introduces lifecycle bugs.** → Reuse #534 graceful drain
+  + `bootout`/`bootstrap`; the restart lifecycle test is the gate.
+- **R: pattern set wrong, forcing rework in P4b–P4d.** → Land P4a fully (incl.
+  redaction + restart) before starting the followers; treat it as the reference.
+
+### BLAST RADIUS
+`crates/trusty-search/` (new `ContractTool` impl + `restart` + version bump);
+`trusty-common` (consumed). The controller is **not** modified here.
+
+---
+
+## P3 — DOC-5 dispatch engine + real passthrough + rewire `up/`
+
+**Goal (one line):** build the 9-step universal dispatch loop, make
+`src/commands/passthrough.rs` real, thread scope (kill TODO #920), then re-route
+the `up/` orchestrator through it — **validated against trusty-search (P4a)**.
+
+**Satisfies:** DOC-5 §2 (9-step dispatch), §3 (scope/blast-gate, M5), DOC-3 scope
+threading + system advisory lock (M7) on the ensure rung; DOC-12 rewiring.
+
+### ENTER GATE
+- P2 EXIT GATE met (rollup is the real step-8 backend).
+- P1 identity walk available (scope resolution needs `detect_project`; the slug
+  key remains inert).
+- **DOC-12 promoted to Accepted, OR the owner re-confirms Q1–Q6 in the decisions
+  log (M5, D-M5)** — required before the `up/` rewiring work item begins.
+
+### WORK ITEMS (each ≈ one PR)
+1. **Implement the 9-step pipeline** (DOC-5 §2.1): load manifest → select members →
+   resolve scope → blast-radius gate → capability-negotiate (`version --json` →
+   `verbs[]` + `contract_version`; below-floor → `contract_incompatible`; verb not
+   advertised → `na`) → invoke (parallel, global `--timeout`) → collect
+   `Envelope<T>` → rollup/render (P2) → exit code.
+2. **Make `src/commands/passthrough.rs` real** — `tctl <tool> <verb> [args]`
+   forwards any **advertised** verb and renders the envelope verbatim; first-class
+   commands become sugar over it. Reject `tctl <controller-id> <verb>`
+   (self-reference, M5) with exit 3.
+3. **Thread scope** — replace `src/main.rs`'s `let _ = cli.scope` (TODO #920) with
+   the DOC-3 §3 default rule + per-verb scope polymorphism; wire `src/scope.rs`
+   (kept in P0) into the resolver. Lifecycle verbs
+   (`install/upgrade/start/stop/restart`) are **system only** —
+   `--scope project` → usage error exit 3.
+4. **Blast-radius gate (M5)** — system-mutating op + TTY + no `--yes` → confirm;
+   **non-TTY system-mutating without `--yes` → exit 3** (fail loud).
+5. **System advisory lock (M7) on the ensure rung** — currently only in
+   `src/commands/up/`; extend it to `ensure`.
+6. **Re-route `up/` through the Dispatcher/passthrough** — replace the raw
+   `Command::new` calls in `src/commands/up/system_runner.rs` /
+   `src/commands/up/os_env.rs` with dispatch through the contract path (behind the
+   existing `Runner`/`ClaudeEnv`/`ConsoleLocator` traits, so this is mechanical).
+   `up/` must now trust **envelope status**, not blind exit codes. (Gated by D-M5.)
+
+### EXIT GATE (binary pass/fail)
+- [ ] **Validated against a real member (B3):** dispatch + rollup are exercised
+      end-to-end against **trusty-search (P4a merged)** emitting a **real
+      `Envelope<T>` — not a fixture**.
+- [ ] **A1 pulled forward:** `--json` `exit_code` field == process exit (asserted
+      against the real search envelope).
+- [ ] **A2 pulled forward:** the rollup matrix shape is well-formed
+      (`verdict ∈ {ready,degraded,pending,down}`, `summary` counts sum incl. `na`,
+      `cells.{system,project}`, `clusters[]`/`remediations[]` well-formed) over the
+      real stack.
+- [ ] **A8 pulled forward:** `tctl doctor --self-check trusty-search` passes
+      (envelope shape + vocab + redaction).
+- [ ] `tctl <tool> <verb>` passthrough forwards an advertised verb and renders the
+      envelope; an **unadvertised** verb → `na`/usage error (exit 3); a self-target
+      `tctl trusty-controller <verb>` → **rejected, exit 3** (M5).
+- [ ] `src/main.rs` has **no** `let _ = cli.scope`; scope is resolved and threaded
+      (TODO #920 closed). Test: `--scope project` on `install` → usage error exit 3.
+- [ ] Non-TTY + system-mutating + no `--yes` → **exit 3** (test drives a piped
+      stdin); TTY path prompts; `--yes` skips the prompt.
+- [ ] Every first-class command routes through the **same** dispatch primitive
+      (DOC-5 §2.2 proof): grep shows no per-named-tool branching in the dispatch
+      path.
+- [ ] `up/` STAGE 0–5 runs through the Dispatcher (no raw `Command::new` to member
+      binaries in `src/commands/up/system_runner.rs` / `src/commands/up/os_env.rs`);
+      `up/`'s member set == manifest set; `up/` trusts envelope status (regression
+      test: a wedged daemon answering `degraded` is not treated as success).
+- [ ] `ensure` acquires the M7 system advisory lock.
+- [ ] `cargo test -p trusty-controller` green; clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated.
+
+### RISKS + MITIGATIONS
+- **R: `up/` is the most-built part and DOC-12 is DRAFT (caveats (b),(f),M5).** →
+  ENTER GATE blocks the rewiring until DOC-12 is Accepted/Q1–Q6 re-confirmed
+  (D-M5); rewire behind the existing traits (mechanical); keep STAGE 0–5 behaviour
+  identical; gate with a before/after `up`-dry-run comparison.
+- **R: dispatch validated only on fixtures (B3).** → The exit gate requires P4a
+  (real trusty-search envelope) + A1/A2/A8 — no fixture-only acceptance.
+- **R: scope threading regresses ensure/up behaviour.** → The harness skeleton +
+  the explicit `--scope` usage-error tests catch this; pure-function unit tests
+  will not (caveat (b)).
+
+### BLAST RADIUS
+`crates/trusty-controller/`: `src/commands/passthrough.rs` (real), new
+`src/dispatch/` module, `src/scope.rs` (wired), `src/main.rs` (scope + flags),
+`src/commands/*` (sugar-over-dispatch), `src/commands/up/system_runner.rs`,
+`src/commands/up/os_env.rs`, `src/commands/up/` stages, `src/commands/ensure/`
+(M7 lock).
+
+---
+
+## P4b/P4c/P4d — Remaining cross-crate retrofits (DOC-6 §2)
+
+**Goal (one line):** retrofit the remaining members onto the DOC-1 envelope, in
+dependency order, following the P4a pattern.
+
+**Satisfies:** DOC-6 §2 conformance retrofits; closes caveat (a).
+
+> **Each crate is an independently-gated sub-phase** (M4). P4d (review) is the
+> long pole — it implements **none** of the 7 verbs today and is budgeted
+> separately.
+
+### ENTER GATE
+- P4a landed (pattern set) and P3 landed (the controller can exercise each
+  retrofit as it lands).
+
+### WORK ITEMS (per crate ≈ one+ PR)
+- **P4b — trusty-memory (T3)** — `ContractTool`, 7 verbs, `verbs[]`,
+  `redact_value`, net-new `restart`; follow the search pattern.
+- **P4c — trusty-analyze (T3)** — same retrofit, follow the search pattern.
+- **P4d — trusty-review (T2, heaviest)** — implements **none** of the 7 verbs
+  today; full retrofit. Expect the most work here; budget separately.
+- **Per crate:** bump the crate version; add a `<binary> version --json` snapshot
+  test; add a **per-crate restart-lifecycle test** (graceful drain #534); ensure
+  `tctl doctor --self-check <member>` passes (DOC-6 §8); redaction negative
+  assertion.
+
+### EXIT GATE (binary pass/fail, per crate)
+- [ ] `<binary> version --json` advertises `verbs[]` (the 7, or a documented subset
+      for CLI-only members) and a `contract_version >= floor`.
+- [ ] `tctl stack doctor --json` yields a typed envelope for the member (no
+      synthesized `contract_incompatible` for a member that *should* be conformant).
+- [ ] `tctl doctor --self-check <member>` passes (envelope shape + vocab +
+      redaction); restart-lifecycle test green.
+- [ ] Secrets redacted with `***redacted***` (negative conformance assertion).
+- [ ] **Publish-order check (M3):** `trusty-common` published before the member if
+      bumped; cdhash re-verified + FDA re-granted after each daemon `cargo install`.
+- [ ] `cargo check` whole-workspace green; the crate's tests green;
+      clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated **per crate** (each
+      is its own gate row: P4b/P4c/P4d).
+
+### RISKS + MITIGATIONS
+- **R: scope creep across crates.** → Strictly dependency-ordered; P4a set the
+  pattern so memory/analyze are near-mechanical; review is the known long pole —
+  budgeted separately as P4d.
+- **R: `restart` net-new on every daemon.** → Reuse #534 graceful drain +
+  launchd convention; per-crate restart test under the harness.
+- **R: version skew between controller and member.** → Golden snapshot (P1) +
+  `min_contract_version` floor (P1 manifest) guard; bump+propagate pins together.
+
+### BLAST RADIUS
+`crates/trusty-memory/`, `crates/trusty-analyze/`, `crates/trusty-review/` (new
+contract impls + `restart` + version bumps); `trusty-common` (consumed). The
+controller is **not** modified here.
+
+---
+
+## P5 — claude-mpm `uv` shim (DOC-6 §4) — minimal, last
+
+**Goal (one line):** give the external Python orchestrator a contract adapter behind
+a `uv` shim so it advertises the same envelope/verbs — built **last and minimal**.
+
+**Satisfies:** DOC-6 §4 / Resolved Decision 3/5 (orchestrator shim, `uv tool
+install claude-mpm`), implementation-spine step 4.
+
+> **Build minimal, T1 only.** Advertise exactly `["doctor","health","version"]`.
+> This shim is **doomed when trusty-mpm lands** (it becomes the native Rust
+> orchestrator member) — invest the minimum.
+
+### ENTER GATE
+- P4b/P4c/P4d substantially landed (the Rust members are conformant; the shim is
+  the last member to make conformant).
+- P3 dispatch routes `kind = "orchestrator"` through the shim path.
+
+### WORK ITEMS (each ≈ one PR)
+1. **`trusty_common::contract::orchestrator` shim** — synthesize the DOC-1 envelope
+   for `doctor`/`health`/`version` from `mpm-doctor` + liveness probes; advertise
+   exactly `["doctor","health","version"]`.
+2. **Manifest member** — add claude-mpm as `kind = "orchestrator"`,
+   `install = { source = "python", tool = "uv", package = "claude-mpm" }` in
+   `manifest.toml`; pin the concrete version (the harness, P7a, resolves the pin
+   per DOC-10 §6).
+3. **Wire dispatch** — the controller routes the orchestrator member through the
+   shim (keyed off `kind`, never the name).
+
+### EXIT GATE (binary pass/fail)
+- [ ] `tctl <orchestrator> version --json` (via shim) advertises exactly
+      `["doctor","health","version"]`.
+- [ ] `tctl stack doctor --json` includes the orchestrator as a normal envelope
+      source (synthesized), not a hard failure when `uv`/claude-mpm absent → it
+      degrades gracefully with the DOC-8 §5 guide-and-abort hint for `uv`.
+- [ ] `tctl doctor --self-check <orchestrator>` passes (shim conformance).
+- [ ] **Publish-order check (M3):** `trusty-common` published before consumers if
+      the shim required a `trusty-common` bump.
+- [ ] `cargo check`/tests/clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated.
+
+### RISKS + MITIGATIONS
+- **R: over-investing in a doomed shim.** → T1 only (3 verbs); no lifecycle verbs.
+- **R: Python/uv environment fragility.** → The shim degrades to a
+  guide-and-abort (exit 3 + `https://astral.sh/uv` hint) when `uv` is absent,
+  asserted by harness A0.
+
+### BLAST RADIUS
+`crates/trusty-common/` (`src/contract/orchestrator` shim);
+`crates/trusty-controller/manifest.toml` (orchestrator member);
+`crates/trusty-controller/` dispatch (orchestrator routing).
+
+---
+
+## P6 — M15 re-key migration + slug-flag flip (DOC-6 §7.1) — HIGHEST RISK, ATOMIC
+
+**Goal (one line):** migrate per-project state to the canonical full-path-slug id by
+**re-keying** (renaming), and **flip the inert slug flag in the same phase** so the
+flip and the migration are atomic (B1).
+
+**Satisfies:** DOC-6 M15 (stateful re-key migration), DOC-6 §7.1 (migration
+framework), ADR-0008 identity.
+
+> **This is the single highest-risk item — isolate it in its own PR(s).** The live
+> key today is the **basename** (`derive_index_id`); the canonical slug
+> (`id_from_path`) is a *different* key. P1 landed the slug path **inert behind a
+> flag**. **P6 re-keys all state by `root_path` AND flips the flag, atomically.**
+> Done naively the flip orphans every index/palace, and a naive migration triggers
+> a from-scratch reindex (multi-minute + storage doubling). The migration MUST
+> **re-key by `root_path`** (rename the keyed state), **no re-embed / no reindex**.
+
+> **Where the migration lives (B1-b):** in **trusty-search's existing
+> `core::migration` `_meta` framework** (`m001..m004.rs`, idempotent/crash-safe),
+> as a new `m005`-style step with a **`schema_version` bump** per DOC-6 §7.1 —
+> **NOT** a controller/common helper.
+
+### ENTER GATE
+- P1 EXIT GATE met (the canonical `id_from_path` is hoisted and golden-tested, and
+  is the migration's target key — but still **inert**).
+- P4a–P4d landed (members consume the shared identity primitives; their on-disk
+  state is what gets re-keyed).
+- A **backup/rollback plan** recorded in the decisions log (this phase mutates
+  user state on disk).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Add the migration to trusty-search `core::migration`** — a new `_meta` step
+   (m005-style) gated by a `schema_version` bump (DOC-6 §7.1); idempotent +
+   crash-safe like the existing m001..m004.
+2. **Inventory the keyed state** — enumerate every per-project store keyed by the
+   old **basename** id (indexes, palaces, `.mcp.json` entries, controller state).
+3. **Re-key by `root_path`** — for each store, compute the new canonical slug id
+   from the stored `root_path` and **rename** the key/entry in place. **No reindex,
+   no re-embed.** Idempotent: a second run is a no-op.
+4. **`--dry-run` mode** — prints the planned re-keys without mutating.
+5. **Flip the inert slug flag (ATOMIC, B1)** — only **after** the re-key step
+   verifies, flip the flag so `id_from_path` (slug) becomes the live key. The flip
+   and the re-key are the same migration unit; the system never has a live slug key
+   without re-keyed state.
+6. **Verification pass** — after migration, assert no store still uses an old
+   basename id and the data byte-count is unchanged (no storage doubling).
+
+### EXIT GATE (binary pass/fail)
+- [ ] The migration lives in **trusty-search `core::migration`** with a
+      `schema_version` bump (DOC-6 §7.1) — not a controller/common helper.
+- [ ] Migration **re-keys** (renames) and does **not** reindex: a test asserts the
+      index/palace byte-count is **unchanged** pre/post (no duplication).
+- [ ] The slug flag flips **only after** the re-key verifies; a test proves that
+      pre-flip the live key is the basename and post-migration the live key is the
+      slug, with **zero** stores referencing an old basename id.
+- [ ] `--dry-run` mutates nothing; a real run is **idempotent** (second run no-op).
+- [ ] A rollback path is documented and tested (restore from the recorded backup;
+      schema_version downgrade behaviour defined).
+- [ ] **Publish-order check (M3):** `trusty-search`/`trusty-common` published in
+      order; cdhash re-verified + FDA re-granted after install.
+- [ ] `cargo test` green for the migration + every consumer crate's state tests;
+      clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated; decisions log notes
+      the migration window + rollback.
+
+### RISKS + MITIGATIONS
+- **R (B1): flip orphans all state.** → The flag stays inert through P1–P5; the
+  flip is atomic with the re-key here; the "pre=basename / post=slug, zero old-id
+  stores" test is the gate.
+- **R: data loss / storage doubling.** → Re-key (rename) only; byte-count-unchanged
+  assertion; `--dry-run` first; recorded backup.
+- **R: partial migration leaves split state.** → Idempotent crash-safe `_meta`
+  step + the "zero old-id stores remain" verification pass.
+
+### BLAST RADIUS
+`crates/trusty-search/src/core/migration/` (new `_meta` step + `schema_version`);
+every stateful crate's on-disk store (`trusty-search` indexes, `trusty-memory`
+palaces, controller state, project `.mcp.json`); the inert slug flag in
+`trusty-common` (flipped here).
+
+---
+
+## P7a — DOC-10 isolation harness: CODE + A0–A8 battery
+
+**Goal (one line):** implement the harness code and the full A0–A8 assertion
+battery (code only — CI infra is P7b).
+
+**Satisfies:** DOC-10 (MUC1/MUC2), §5 A0–A8 (A1/A2/A8 already proven in P3 against
+the real search member; here they generalize to the full stack).
+
+> The **minimal skeleton already exists from P0**, and **A1/A2/A8 were pulled
+> forward to P3** (B3). P7a fills in the remaining battery (A0, A3–A7) and the
+> macOS cdhash assertion logic. (Caveat (b): the harness is *why* the skeleton was
+> pulled early — the 214 unit tests cannot catch dispatch/scope regressions.)
+
+### ENTER GATE
+- P3 EXIT GATE met (dispatch + scope + `up/` rewiring complete; A1/A2/A8 proven).
+- P4a–P4d/P5 landed (the harness asserts real members + the orchestrator shim, A8).
+- P6 landed (the harness runs against re-keyed/slug state, not legacy basename ids).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Drive the canonical scenario** (DOC-10 §2 STEP 0–6): bootstrap toolchain →
+   `cargo install trusty-controller` → `tctl install --yes` → `tctl ensure
+   --scope project --wait --yes` → idempotency re-run → `tctl upgrade --yes` →
+   verify-after.
+2. **Implement the A0–A8 assertion battery:**
+   - **A0** hard-dep guide-and-abort → exit 3 + `https://sh.rustup.rs` /
+     `https://astral.sh/uv` stderr hints.
+   - **A1** exit-code mirror (`--json` `exit_code` == process exit). *(generalized
+     from P3.)*
+   - **A2** rollup matrix shape. *(generalized from P3.)*
+   - **A3** version truth post-install **and** post-upgrade (`stack_version` +
+     each `tool_version` == BOM pin), asserted **twice**.
+   - **A4** daemons actually running (`health --json` status == `running`).
+   - **A5** `.mcp.json` patched (each enabled two-layer member entry present).
+   - **A6** idempotency (second install/ensure → no-op).
+   - **A7** progressive readiness non-racy (`ensure --wait` → `fresh`).
+   - **A8** conformance self-check per member (+ mpm shim 3-verb). *(generalized
+     from P3.)*
+3. **macOS cdhash/warm-boot assertion logic (M14, §3.4)** — assert the on-PATH
+   binary execs without SIGKILL via `cargo install`'s atomic-rename (the forbidden
+   `cp`-over path is **not** used). (Wiring to a runner is P7b.)
+
+### EXIT GATE (binary pass/fail)
+- [ ] `tests/isolation_harness.rs` runs the full A0–A8 battery **locally** (green).
+- [ ] The canonical STEP 0–6 scenario runs **non-interactively** (`--yes`, non-TTY)
+      and asserts only machine fields (no scraped human text).
+- [ ] A deliberately-broken member (local throwaway) makes the harness **fail** with
+      the failing cell surfaced from `clusters[]`/`remediations[]` (proves the
+      oracle is real), then reverted.
+- [ ] `cargo test`/clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated.
+
+### RISKS + MITIGATIONS
+- **R: flaky background-reindex races.** → `ensure --wait` (A7) gates on `fresh`.
+- **R: cdhash SIGKILL trap (§3.4, CLAUDE.md #873).** → The harness only ever
+  installs via `cargo install`/`tctl`, never `cp`; the cdhash assertion fails if
+  that property regresses.
+
+### BLAST RADIUS
+`crates/trusty-controller/tests/isolation_harness.rs`, harness fixtures (sample
+repo, BOM N-1 seed). No production-code changes (capstone validation only).
+
+---
+
+## P7b — DOC-10 isolation CI infra: macOS-VM / Linux-container + `isolation.yml`
+
+**Goal (one line):** stand up the CI isolation environment and wire `isolation.yml`
+so the P7a battery runs in a vanilla environment on macOS primary / Linux
+secondary.
+
+**Satisfies:** DOC-10 §3/§4 (vanilla-env construction), §3.4 cdhash, M14 warm-boot.
+
+> Split out from the harness code (M4) because the **environment/provisioning** is
+> a distinct, higher-risk concern. **GitHub-hosted macOS runners cannot trivially
+> run nested VMs** — provisioning a nested VM is a known risk; per DOC-10 §3 the
+> **`macos-14` runner itself is the isolation host** (a clean `$HOME` + clean PATH
+> on the runner, not a nested VM, is the realistic v1 isolation; launchd is
+> per-user, so a separate user session / runner is the isolation boundary).
+
+### ENTER GATE
+- P7a EXIT GATE met (the A0–A8 battery runs green locally).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Vanilla-env construction** (DOC-10 §3/§4) — clean `$HOME`, no cargo/uv/tool
+   binaries on PATH; **macOS:** the `macos-14` runner as isolation host (clean
+   `$HOME`/PATH; **document the nested-VM limitation** and why the runner-as-host
+   approach is used); **Linux:** a container.
+2. **CI wiring (`isolation.yml`)** — promote the P0 stub to the full job: nightly
+   full §2 scenario + per-PR path-filtered macOS smoke + Linux legs.
+3. **macOS cdhash/warm-boot CI leg (M14)** — a per-PR `macos-14` smoke job:
+   `cargo install` → daemon up under launchd → `health` == running → `restart`
+   (`bootout`→`bootstrap`) → `health` again; **no `cp`-over-PATH**.
+
+### EXIT GATE (binary pass/fail)
+- [ ] The full **A0–A8 battery is green on `macos-14`** (and on the Linux leg).
+- [ ] macOS cdhash assertion green in CI (install via `cargo install` → daemon up
+      under launchd → `health` running → `restart` → `health`; **no `cp`-over-PATH**).
+- [ ] `isolation.yml` runs the macOS smoke **per PR** (path-filtered) and the full
+      scenario nightly; the Linux leg runs in a container.
+- [ ] The nested-VM limitation + runner-as-isolation-host approach is documented in
+      `isolation.yml`/harness docs.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated.
+
+### RISKS + MITIGATIONS
+- **R: nested VMs not feasible on GitHub-hosted macOS runners (M4).** → Use the
+  `macos-14` runner itself as the isolation host (clean `$HOME`/PATH); document the
+  trade-off; revisit self-hosted runners only if true VM isolation is mandated.
+- **R: macOS launchd-per-user contamination (§3).** → Use a separate user
+  session / runner as the boundary; do not rely on a clean `$HOME` alone.
+
+### BLAST RADIUS
+`.github/workflows/isolation.yml`, CI runner config, harness fixtures. No
+production-code changes.
+
+---
+
+## P8 — Fast-follow: transitive cluster fold (C4) + DOC-11 residuals
+
+**Goal (one line):** add the transitive `depends_on ∪ deps[]` cluster fold and clear
+the residual DOC-11 follow-ups (re-routing stale DOC-7 → trusty-console).
+
+**Satisfies:** DOC-4 C4 (deferred from P2), DOC-11 residual tracker items.
+
+### ENTER GATE
+- P2 EXIT GATE met (the lattice + matrix exist; `clusters[]` is a valid-but-empty
+  array ready to be populated).
+- P7a/P7b green (so the C4 change can be regression-tested end to end).
+
+### WORK ITEMS (each ≈ one PR)
+1. **Transitive cluster fold (C4)** — fold member verdicts over the union of
+   manifest `depends_on` and envelope `health.data.deps[]`; populate `clusters[]`
+   in the `--json` rollup so a failing dependency surfaces its dependents.
+2. **DOC-11 residual sweep** — re-route the follow-ups that still point at the
+   superseded DOC-7 embedded UI to `trusty-console` (caveat (e)); close or
+   re-file remaining DOC-11 items.
+3. **Re-audit the README + abbreviation table** — confirm `tctl →
+   trusty-controller` is present (DOC-0 follow-up) and the README reflects the
+   now-complete surface.
+
+### EXIT GATE (binary pass/fail)
+- [ ] `tctl stack doctor --json` populates `clusters[]`: a test where
+      `trusty-analyze depends_on trusty-search` and search is `down` surfaces
+      analyze in the same cluster with the correct rolled verdict.
+- [ ] No DOC-11 follow-up still references the superseded DOC-7 embedded UI as a
+      live target (all re-routed to trusty-console or closed).
+- [ ] README + abbreviation table accurate; `tctl` alias present.
+- [ ] Full A0–A8 harness still green; `cargo test`/clippy/fmt/line-cap clean.
+- [ ] [`progress-manifest.md`](./progress-manifest.md) updated; campaign marked
+      complete.
+
+### RISKS + MITIGATIONS
+- **R: C4 is speculative at 7 members and may over-engineer.** → Deliberately
+  deferred from P2; keep the fold simple (single transitive pass) and gate it
+  behind the harness.
+- **R: DOC-11 has stale UI items that mislead future readers (caveat (e)).** →
+  Re-route every DOC-7 reference to trusty-console; record in the decisions log.
+
+### BLAST RADIUS
+`crates/trusty-controller/`: `src/rollup/` (cluster fold), `src/commands/output.rs`
+(`clusters[]`), `README.md`;
+`docs/trusty-controller/research/02-design/DOC-11-open-issues.md` (tracker
+updates, documentation-only).
+
+---
+
+## Carried-but-unscheduled / backlog (M4)
+
+Items that are real but not yet placed in a numbered phase. Each carries a
+tentative **owner-phase**; promote into a phase (or a follow-up campaign) when
+scheduled. Mirrored in the progress manifest.
+
+| # | Item | Source | Tentative owner-phase |
+|---|---|---|---|
+| BL-1 | DOC-8 §4 launch-hook (Claude Code SessionStart) **verification** | DOC-8 §4 | P3 or P7a (harness assertion) |
+| BL-2 | `--latest` / BOM-drift consumer | `updates.rs:67` TODO #1316 | post-P1 (needs manifest+floor) |
+| BL-3 | Upgrade **rollback / pin-back** (`tctl upgrade --to`) testing | DOC-9 | P7a (harness) |
+| BL-4 | Controller-side redaction **belt-and-suspenders** + CI **negative-assertion** that it fires when a member forgets to redact | DOC-1 D8 | P1 (helper) + P4a–d (assertion) |
+| BL-5 | **Arg-surface guard** — golden snapshot does NOT cover CLI arg-surface breaking changes | DOC-1 C3 gap | P1 (add guard) |
+| BL-6 | **Observability/tracing** for the dispatch path | DOC-5 | P3 (instrument) |
+
+---
+
+## Cross-phase invariants
+
+> See the **CROSS-PHASE INVARIANTS** section near the top of this document (it is
+> referenced from every phase that bumps `trusty-common` or installs a daemon
+> binary). The short list: doc/error rules; 500/1500 SLOC caps; shared-crate
+> publish-order + dry-run + whole-workspace check; macOS FDA/cdhash after every
+> daemon install; worktree discipline; manifest-is-the-only-registry after P0;
+> update the (advisory) progress manifest at every gate.

--- a/docs/trusty-controller/research/03-plan/02-adversarial-review.md
+++ b/docs/trusty-controller/research/03-plan/02-adversarial-review.md
@@ -1,0 +1,362 @@
+# 02 — Adversarial Review of the trusty-controller Completion Plan
+
+> **Purpose.** A hard adversarial pass over the draft phased plan
+> ([`01-phased-plan.md`](./01-phased-plan.md)) and its supporting snapshot
+> ([`00-current-state.md`](./00-current-state.md)). Each finding below has a
+> **Resolution in plan** line stating exactly how the revised plan addresses it
+> — or that it is parked as an **OPEN DECISION** in the
+> [`progress-manifest.md`](./progress-manifest.md) decisions log (no silent
+> owner-call substitution).
+>
+> Severity tiers: **BLOCKER** (changes the phase graph), **MAJOR** (changes a
+> phase's scope/gates), **MINOR** (corrects a detail or fills a gap).
+>
+> **Source of truth for intent:** [`../02-design/`](../02-design/) (DOC-0..DOC-12,
+> ADRs). Where a finding cites a design fact (e.g. DOC-4 Resolved Decision 1,
+> DOC-6 §7.1, DOC-12 §3, `index_id.rs:71`), that citation is the governing
+> authority and overrides the draft's prose.
+
+---
+
+## TOP-5 (the findings that actually move the needle)
+
+1. **B1 — The identity flip orphans all user state five phases before its
+   migration exists.** This is the central defect: the draft hoists the
+   canonical full-path-slug key in P1/P3 but only builds the re-key migration in
+   P6. The live keying scheme is the **basename** (`derive_index_id`), not the
+   slug. Flipping the key without the migration co-shipping orphans every index
+   and palace. **Fix: the migration co-ships with the flip; until it lands, the
+   slug path is INERT behind a flag and `derive_index_id` (basename) stays the
+   live key.**
+2. **B3 + M1 — P2/P3 exit gates pass on fixtures no real member emits.** No
+   member emits `Envelope<T>`/`verbs[]`/`contract_version` today. Validating
+   dispatch against synthetic fixtures violates the plan's own caveat (b). **Fix:
+   pull the trusty-search retrofit forward to gate P3's exit, and pull harness
+   assertions A1/A2/A8 forward to P3.**
+3. **B2 — A timeout decision was inverted against an owner-approved resolution,
+   citing a non-existent "M10".** DOC-4 RD1 (owner-approved 2026-06-08) *defers*
+   per-member timeouts and ships a single global `--timeout` in v1. "M10" does
+   not exist. **Fix: honor RD1; delete every "M10"; log the un-defer as an OPEN
+   DECISION.**
+4. **Whole-approach framing — P1+P4 (contract/dispatch rebuild) is being assumed
+   as the spine, but by the plan's own caveat (a) it is worthless unless the
+   cross-crate retrofit is funded in the same campaign.** **Fix: present Option A
+   (value-first minimal sub-campaign) vs Option B (full rebuild) and add a
+   DECISION GATE after P0/P2.**
+5. **M3 + M4 — Cross-crate release reality and epic-sized phases are missing
+   structure.** No publish-order/FDA/cdhash invariants; P4 and the harness phase
+   are each really several independently-gated phases. **Fix: add a CROSS-PHASE
+   INVARIANTS section; split P4 → P4a–P4d and the harness → code battery +
+   CI-infra.**
+
+---
+
+## BLOCKERS (change the phase graph)
+
+### B1 — Identity flip orphans state (the central defect)
+
+**Finding.** The basename→full-path-slug canonical-id flip (ADR-0008 / DOC-3 §8)
+re-keys **every** existing index and palace. Today the live key is the
+**basename**: `trusty_common::derive_index_id` returns the basename
+(`index_id.rs:71` doc: *"changing casing/punctuation would orphan every
+previously-indexed project"*); `trusty-search/src/detect.rs` keys on the
+basename; the slug form (`fs_discovery.rs::id_from_path`) is a **different live
+key**. The draft hoists the slug walk in P1 and discovers/builds the M15 re-key
+migration only in P6 — so P1/P3 would orphan all user state **five phases before
+the migration exists**. The draft also mis-locates the migration as a
+controller/common helper, and mis-labels the P1 risk as "subtly changes ids".
+
+**Required fix (all parts mandatory):**
+
+- **(a)** Restructure so the M15 re-key migration **co-ships** with the identity
+  flip. Either merge the migration into the same phase that first writes the slug
+  key, **or** keep `derive_index_id` (basename) as the live key and gate the
+  canonical-slug path behind a flag that is **INERT until the migration lands**.
+- **(b)** The migration MUST be carried in **trusty-search's existing
+  `core::migration` `_meta` framework** (confirmed present: `m001..m004.rs`,
+  idempotent/crash-safe) with a **`schema_version` bump**, per **DOC-6 §7.1** —
+  NOT a controller/common helper as the draft P6 says. It re-keys **by
+  `root_path`** with **no re-embed / no reindex**.
+- **(c)** Re-label the P1 risk from "subtly changes ids" to **"flips the live
+  keying scheme — orphans all state unless the migration co-ships."**
+
+**Resolution in plan.** Adopted the **gated-inert** strategy:
+- P1 now **explicitly keeps `derive_index_id` (basename) as the live key** and
+  lands `id_from_path` (canonical slug) **behind an inert feature/flag** that no
+  read/write path consults until the migration phase activates it. P1's risk
+  bullet is rewritten verbatim per (c).
+- The migration phase (renumbered **P6**) is rewritten so the migration lives in
+  **trusty-search `core::migration` (`m005`-style) with a `schema_version`
+  bump** per DOC-6 §7.1, re-keys by `root_path`, and **flips the inert flag as
+  the last step** — i.e. the flip and the migration are now atomic within one
+  phase.
+- Caveat **(c)** in [`00-current-state.md`](./00-current-state.md) §8 and the
+  phase-dependency diagram are updated to show the flag-flip/migration edge and
+  to forbid any earlier phase from activating the slug key.
+
+---
+
+### B2 — Timeout decision inverted / invented "M10" citation
+
+**Finding.** The draft says *"implement RD1 + M10 (un-deferred): per-member
+timeout overrides ship day one."* This is wrong on two counts:
+1. **DOC-4 Resolved Decision 1** (owner-approved **2026-06-08**) **defers**
+   per-member manifest timeouts to a later release and ships **only a single
+   global `--timeout` flag in v1**.
+2. **"M10" does not exist** anywhere in DOC-4.
+
+**Required fix:** remove every "M10" reference; default the plan to **HONOR RD1**
+(global `--timeout` only in v1, per-member overrides deferred); add an OPEN
+DECISION: *"Un-defer per-member timeouts? Requires explicit owner reversal of
+DOC-4 RD1 — not assumed."*
+
+**Resolution in plan.**
+- Every "M10" token is deleted across all four plan files.
+- P2 (rollup) WI/exit-gate/risk now specify **global `--timeout` > 2 s/10 s
+  defaults** only; **per-member manifest `timeout` overrides are DEFERRED** per
+  RD1. The manifest may *carry* a `timeout?` field for forward-compat, but the
+  rollup **does not consult it in v1** (asserted negatively in the exit gate).
+- Caveat **(d)** is rewritten to say "honor RD1 (global-only); per-member
+  override is an OPEN DECISION."
+- OPEN DECISION **D-B2** logged in the decisions log.
+
+---
+
+### B3 + M1 — Validation ordering (dispatch validated only against fixtures)
+
+**Finding.** P2 (lattice/matrix) and P3 (dispatch/capability-negotiation)
+consume `Envelope<T>` / `verbs[]` / `contract_version` that **no member emits
+today** (zero hits across non-controller crates). As drafted, P2/P3 exit gates
+pass on **synthetic fixtures with zero real-member coverage** — violating the
+plan's own caveat (b) (*"unit tests won't catch dispatch/scope regressions"*).
+
+**Required fix:**
+- **(a)** Make the **trusty-search retrofit (first member, pattern-setter)** a
+  **hard dependency that lands and gates P3's exit** — pull the search retrofit
+  forward so it sits between the P3 dispatch skeleton and the P3 exit gate (or
+  add to P3 EXIT GATE: *"dispatch validated against ≥1 real member emitting a
+  real `Envelope<T>`, not a fixture"*).
+- **(b)** Pull harness assertions **A1 (exit-code mirror), A2 (rollup schema),
+  A8 (conformance self-check)** FORWARD to gate P3; leave the vanilla-env
+  macOS-VM capstone at the late harness phase.
+- **(c)** Stop labeling P2/P3 and P4 "parallelizable" — P2/P3 **acceptance**
+  depends on the first real member.
+
+**Resolution in plan.**
+- **P4a (trusty-search retrofit)** is reordered to land **inside the P3 window**
+  and is named a **hard gate on P3 exit**. P3 EXIT GATE adds: *"dispatch +
+  rollup validated against trusty-search emitting a **real** `Envelope<T>` (P4a
+  merged) — not a fixture."*
+- Harness assertions **A1/A2/A8 are pulled forward** into P3's exit gate
+  (asserted against the real search envelope). The vanilla-env macOS-VM capstone
+  (A0/A3–A7 + cdhash) remains in the late harness phase (now **P7a/P7b**).
+- The "two parallelizable tracks" note is **deleted**; replaced with an explicit
+  statement that **P2/P3 acceptance depends on P4a (the first real member)**, so
+  the consumer side cannot be treated as freely concurrent.
+
+---
+
+## MAJOR (change a phase's scope/gates)
+
+### M2 — P0 wires contract fields before P1 finalizes them (two passes)
+
+**Finding.** P0 collapses the 4 member lists and wires `contract_floor` before
+P1 finalizes the contract fields → an unavoidable two-pass on the manifest.
+
+**Required fix:** scope P0's manifest to **non-contract fields only**; add a P1
+work item *"finalize manifest contract fields
+(`min_contract_version`/`expected_contract_version`/floor) + re-verify the 4
+collapsed call sites"*; state the two-pass explicitly.
+
+**Resolution in plan.** P0 WI-1 now authors the manifest with **non-contract
+fields only** (`id`, `display_name`, `binary`, `kind`, `install`, `version`,
+`changelog`, `depends_on`, `enabled`, `stack_version`); `contract_floor`/
+`min_contract_version`/`expected_contract_version` are **explicitly out of P0
+scope**. P1 gains **WI "finalize manifest contract fields + re-verify the 4
+collapsed call sites"**. Both P0 and P1 state the **two-pass** explicitly.
+
+### M3 — Cross-crate release reality missing
+
+**Finding.** No section covers publish order, the cargo-publish dry-run, macOS
+FDA re-grant + cdhash verification after every daemon-binary `cargo install`
+(CLAUDE.md #873), or `[patch.crates-io]` consistency for `trusty-common`.
+
+**Required fix:** add a **CROSS-PHASE INVARIANTS** section referenced from every
+phase that bumps `trusty-common`; add publish-order checks to P1/P4/P5 exit
+gates.
+
+**Resolution in plan.** A **CROSS-PHASE INVARIANTS** section is added to
+[`01-phased-plan.md`](./01-phased-plan.md) (publish `trusty-common` **before**
+consumers; cargo-publish skill + dry-run; re-grant FDA + verify cdhash after
+every daemon-binary `cargo install`; keep `[patch.crates-io]` consistent). P1,
+P4(a–d), and P5 exit gates each add a **publish-order check**.
+
+### M4 — Epics sized as single phases
+
+**Finding.** P4 (4 cross-crate retrofits) and the harness phase are each really
+several independently-gated phases. Review implements **none** of the 7 verbs
+(heaviest). GitHub-hosted macOS runners cannot trivially run nested VMs.
+
+**Required fix:** promote P4 → **P4a(search)/P4b(memory)/P4c(analyze)/P4d(review)**
+with independent enter/exit gates (review budgeted separately as heaviest). Split
+the harness phase into **(i) harness CODE/battery** and **(ii) macOS-VM +
+Linux-container CI INFRA**, separately gated; flag that GitHub-hosted macOS
+runners cannot trivially run nested VMs (provisioning risk; the `macos-14`
+runner itself is the isolation host per DOC-10 §3).
+
+**Resolution in plan.** P4 is split into **P4a/P4b/P4c/P4d**, each with its own
+enter/exit gate and manifest sub-row; **P4d (review)** carries a note that it
+implements none of the 7 verbs and is budgeted as the long pole. The harness
+phase is split into **P7a (harness code + A0–A8 battery)** and **P7b (CI infra:
+macOS-VM/Linux-container + `isolation.yml`)**, separately gated. P7b records the
+**nested-VM provisioning risk** and that the `macos-14` runner itself is the
+isolation host (DOC-10 §3) — i.e. a clean `$HOME` on the runner, not a nested
+VM, is the realistic v1 isolation.
+
+### M5 — Building on DRAFT DOC-12
+
+**Finding.** P3 rewires `up/` against DOC-12, which is still **Draft**.
+
+**Required fix:** add a P3 ENTER GATE: *"DOC-12 promoted to Accepted (or owner
+re-confirms Q1–Q6 in decisions log) before rewiring `up/`."*
+
+**Resolution in plan.** P3 ENTER GATE adds the DOC-12-promotion precondition; an
+OPEN DECISION pointer is noted so the owner either promotes DOC-12 or re-confirms
+Q1–Q6 in the decisions log before P3's `up/` rewiring begins.
+
+---
+
+## MINOR (corrections / gap-fills)
+
+### m1 — File paths wrong
+
+**Finding.** `passthrough`/`probe`/`auto_update`/`stack`/`health`/`ensure`/
+`mcp_patch` live under `src/commands/...` (e.g. `src/commands/passthrough.rs`,
+`src/commands/stack/health.rs`, `src/commands/ensure/mcp_patch.rs`); `scope.rs`
+**is** at `src/scope.rs` (correct).
+
+**Resolution in plan.** Every BLAST RADIUS path and grep-based gate is corrected
+to the `src/commands/...` prefix across all files; `src/scope.rs` left as-is.
+
+### m2 — P0 collapse exit gate not binary
+
+**Finding.** The collapse gate must be mechanically checkable.
+
+**Required fix:** assert *"zero `vec![…]`/array literals of member ids remain in
+`default_manifest`/`stable_set`/`analyze_core_targets`/`mcp_members`; these
+symbols either deleted or return manifest queries"* — and note
+`analyze_core_targets` is also read via `cfg.analyze_core_targets` in
+`up/policy.rs` (enumerate allowed remaining refs).
+
+**Resolution in plan.** P0 EXIT GATE rewritten to the binary form above, with an
+explicit **allowed-remaining-refs** enumeration (the `up/policy.rs`
+`cfg.analyze_core_targets` read is permitted as a manifest-backed query, not a
+literal).
+
+### m3 — `auto_update` fate
+
+**Finding.** The draft says "delete unless grep finds a ref." That is an
+owner-class call (delete the orphaned `maybe_notify` vs wire it to DOC-9 drift
+notification).
+
+**Resolution in plan.** Made an **OPEN DECISION (D-m3)** in the decisions log;
+P0 no longer pre-decides deletion. Until the owner rules, `auto_update.rs` is
+left in place with a TODO pointer to D-m3.
+
+### m4 — Carried-but-unscheduled work has no home
+
+**Required fix:** add a **"Carried-but-unscheduled / backlog"** section with
+owners+phases for: DOC-8 §4 launch-hook (Claude Code SessionStart) verification;
+`--latest`/BOM-drift consumer (`updates.rs:67` TODO #1316); upgrade rollback /
+pin-back (`tctl upgrade --to`) testing (DOC-9); controller-side redaction
+belt-and-suspenders + a CI negative-assertion that it fires when a member forgets
+to redact (DOC-1 D8); golden-snapshot does **not** cover CLI arg-surface breaking
+changes — add an arg-surface guard; observability/tracing for the dispatch path.
+
+**Resolution in plan.** A **Carried-but-unscheduled / backlog** section is added
+to [`01-phased-plan.md`](./01-phased-plan.md) with each item assigned a tentative
+owner-phase, and the matching rows added to the progress manifest.
+
+### m5 — Progress manifest honesty + 1:1 with work items
+
+**Finding.** The update protocol is advisory/honor-system (unlike the mechanical
+line-cap gate), and the checklist must match the restructured work items 1:1.
+
+**Resolution in plan.** The manifest now **states plainly** that the update
+protocol is **advisory/honor-system** and **proposes an optional lightweight CI
+check** (a phase-labeled PR must move the manifest's phase status). The checklist
+is rebuilt 1:1 against the restructured work items, including **P4a–P4d sub-rows
+with per-crate restart-lifecycle testing** and the **P3 self-target/M5
+reject-controller** line.
+
+### m6 — P2 exit gate must assert both rollup invariants
+
+**Required fix:** P2 exit gate must assert **both**: (i) stack aggregate
+worst-wins `3≻1≻2≻0`, **and** (ii) per DOC-4 **RD3** a project-scope down/fail
+degrades **only the project cell** and does **not** raise the process exit code.
+The gate must **fail** an impl that lets project-pending/down move the exit.
+
+**Resolution in plan.** P2 EXIT GATE now carries both assertions, with an
+explicit negative test: a project-scope `down`/`fail` leaves the **process exit
+code unchanged** (only the project cell degrades) per DOC-4 RD3.
+
+---
+
+## Whole-approach critique (strategic framing)
+
+**Finding.** The draft treats the full contract/dispatch rebuild (P1/P3/P4/P5)
+as the campaign spine. But the plan's own **caveat (a)** says the P1 contract
+module is **worthless unless the P4 cross-crate retrofit is funded in the same
+campaign** — so **P1+P4 must be justified together as a sub-campaign**, not
+assumed as the spine. A large amount of real, low-risk value (the lying README,
+the 4-list correctness hazard, the load-bearing *"unindexed project ≠ broken
+stack"* rollup bug) can ship **without** any identity flip or cross-crate epic.
+
+**The explicit strategic choice:**
+
+- **Option A — value-first minimal sub-campaign.** Ship **P0** (manifest +
+  README rewrite + collapse 4 lists + real `stack_version`) **and the P2
+  lattice** as a **standalone deliverable**. Fixes the lying README, the 4-list
+  correctness hazard, and the load-bearing *"unindexed project ≠ broken stack"*
+  rollup bug — with **no identity flip** and **no cross-crate epic**.
+- **Option B — full contract/dispatch rebuild.** P1/P3/P4(a–d)/P5 (+ P6
+  migration, + P7 harness). Justified **only** as a P1+P4 sub-campaign per
+  caveat (a).
+
+**Resolution in plan.** [`README.md`](./README.md) and
+[`01-phased-plan.md`](./01-phased-plan.md) now present Option A vs Option B
+explicitly. A **DECISION GATE** is inserted **after P0/P2**: the campaign must
+choose whether to proceed into Option B (committing P1+P4 *together*) or stop at
+the Option-A deliverable. OPEN DECISION **D-OptAB** is logged.
+
+---
+
+## Findings index (traceability)
+
+| ID | Severity | One-line | Resolution |
+|---|---|---|---|
+| B1 | BLOCKER | Identity flip orphans state before migration exists | Slug path inert behind flag; migration co-ships in P6 via trusty-search `core::migration` (DOC-6 §7.1) |
+| B2 | BLOCKER | Timeout decision inverted; "M10" invented | Honor RD1 (global-only); "M10" deleted; OPEN DECISION D-B2 |
+| B3+M1 | BLOCKER | Dispatch validated only on fixtures | P4a (search) gates P3 exit; A1/A2/A8 pulled forward; "parallelizable" removed |
+| M2 | MAJOR | Manifest contract fields wired twice | P0 non-contract only; P1 finalizes contract fields (two-pass stated) |
+| M3 | MAJOR | Cross-crate release reality missing | CROSS-PHASE INVARIANTS section; publish-order checks in P1/P4/P5 |
+| M4 | MAJOR | Epics sized as phases | P4→P4a–d; harness→P7a (code) + P7b (CI infra); nested-VM risk flagged |
+| M5 | MAJOR | Building on DRAFT DOC-12 | P3 ENTER GATE: DOC-12 Accepted or Q1–Q6 re-confirmed |
+| m1 | MINOR | Wrong file paths | Corrected to `src/commands/...`; `src/scope.rs` kept |
+| m2 | MINOR | P0 collapse gate not binary | Binary literal-free assertion + allowed-refs enumeration |
+| m3 | MINOR | auto_update fate pre-decided | OPEN DECISION D-m3 |
+| m4 | MINOR | Carried work unscheduled | Backlog section + manifest rows |
+| m5 | MINOR | Manifest honesty + 1:1 | Advisory note + optional CI check; checklist rebuilt 1:1 |
+| m6 | MINOR | P2 gate misses RD3 | Both worst-wins AND project-cell-only exit asserted |
+| D-OptAB | DECISION | Option A vs B | Whole-approach choice; DECISION GATE after P0/P2 |
+
+---
+
+## OPEN DECISIONS raised by this review (see decisions log)
+
+- **D-B2** — Un-defer per-member timeouts? (requires owner reversal of DOC-4 RD1).
+- **D-m3** — `auto_update.rs::maybe_notify`: delete vs wire to DOC-9 drift notification.
+- **D-OptAB** — Option A (value-first) vs Option B (full rebuild); decided at the
+  DECISION GATE after P0/P2.
+- **D-M5** — DOC-12 promotion to Accepted vs owner re-confirmation of Q1–Q6
+  (gating P3 enter).

--- a/docs/trusty-controller/research/03-plan/README.md
+++ b/docs/trusty-controller/research/03-plan/README.md
@@ -1,0 +1,122 @@
+# 03-plan — trusty-controller / `tctl` Completion Plan
+
+This directory holds the **phased implementation plan** for completing the
+`trusty-controller` crate (binary `tctl`) against its **02-design** doc set, the
+**hard adversarial review** that shaped it, plus the **living progress manifest**
+that tracks execution.
+
+## Strategic choice — Option A vs Option B (decide this first)
+
+The adversarial review ([`02-adversarial-review.md`](./02-adversarial-review.md))
+established that the full contract/dispatch rebuild is **not** an unconditional
+spine. The campaign faces an explicit choice, decided at a **DECISION GATE after
+P0/P2**:
+
+- **Option A — value-first minimal sub-campaign.** Ship **P0** (manifest + README
+  rewrite + collapse the 4 divergent member lists + real `stack_version`) **and
+  the P2 lattice** as a **standalone deliverable**. This alone fixes the lying
+  README, the four-list correctness hazard, and the load-bearing *"unindexed
+  project ≠ broken stack"* rollup bug — with **no identity flip** and **no
+  cross-crate epic**. Low-risk, self-contained, independently valuable.
+- **Option B — full contract/dispatch rebuild** (P1 / P3 / P4a–P4d / P5, + P6
+  migration + P7a/P7b harness). Per the plan's own caveat (a), the P1 contract
+  module is **worthless unless the P4 cross-crate retrofit is funded in the same
+  campaign** — so **P1+P4 must be justified and committed together**, not assumed
+  as the spine.
+
+Do not enter P1 until the DECISION GATE records "proceed to Option B" **with** the
+P1+P4 joint-funding commitment (decision **D-OptAB**).
+
+## Current state (one paragraph)
+
+`crates/trusty-controller/` is at `v0.2.0` and is **further along than its README
+admits** (the README still claims "Phase 0 scaffold" / `publish = false`, both
+false). A large surface is shipped and working — `install`, `upgrade`/`updates`,
+`ensure --wait`, launchd `start`/`stop`/`restart`, `config`, `port`, `doctor
+--self-check`, `ui` (launches `trusty-console` per ADR-0011), and the full `up/`
+bootstrap orchestrator (STAGE 0–5, real `flock` lock). But it is built on
+**stubbed foundations**: the rollup is a flat 2-value fold (not the DOC-4 lattice),
+envelope validation is ad-hoc `serde_json::Value` (not a typed `Envelope<T>`),
+`version` emits `0.0.0-scaffold`, scope is unwired (`let _ = cli.scope`,
+TODO #920), `src/commands/passthrough.rs` is a stub, and **four divergent hard-coded member
+lists** stand in for the missing manifest. **Four foundations do not exist yet**:
+the `trusty_common::contract` module (DOC-1), the manifest/BOM loader (DOC-2),
+scope threading (DOC-3), and the real rollup (DOC-4). The 214 tests are all
+pure-function unit tests and will not catch dispatch/scope regressions. Full
+detail: [`00-current-state.md`](./00-current-state.md).
+
+## Files in this directory
+
+| File | Purpose |
+|---|---|
+| [`00-current-state.md`](./00-current-state.md) | Self-contained snapshot: DONE / SUBSET-STAND-IN / DEAD / STUB / MISSING, with the four missing foundations and four divergent member lists. Read first. |
+| [`01-phased-plan.md`](./01-phased-plan.md) | **The plan.** Phases **P0, P2, [DECISION GATE], P1, P4a, P3, P4b/c/d, P5, P6, P7a, P7b, P8** with enter gates, PR-sized work items, binary exit gates, risks, blast radius, CROSS-PHASE INVARIANTS, a backlog section, and an ASCII phase-ordering diagram. |
+| [`02-adversarial-review.md`](./02-adversarial-review.md) | **The hard review.** All findings (BLOCKERS B1–B3, MAJORS M1–M5, MINORS m1–m6, the whole-approach critique, TOP-5), each with a "Resolution in plan" line and the OPEN DECISIONS it raised. Read alongside the plan to understand *why* the phase graph is shaped this way. |
+| [`progress-manifest.md`](./progress-manifest.md) | **Living tracker.** Phase-status table, per-phase work-item checklists, backlog tracker, decisions log (incl. OPEN DECISIONS), deviations log, caveat watch. **Must be updated at every phase gate** (advisory/honor-system — see manifest m5). |
+
+## How to use this plan
+
+1. **Read [`00-current-state.md`](./00-current-state.md)** to understand what is
+   built vs. designed, then skim
+   [`02-adversarial-review.md`](./02-adversarial-review.md) to see why the phase
+   graph is shaped the way it is.
+2. **Work the phases in dependency order** from
+   [`01-phased-plan.md`](./01-phased-plan.md): **P0 → P2 → DECISION GATE → (Option
+   B) P1 → P4a → P3 → P4b/c/d → P5 → P6 → P7a → P7b → P8.** Do not start a phase
+   until its **ENTER GATE** preconditions are met. In particular: do not enter P1
+   until D-OptAB chooses Option B with P1+P4 joint funding; P4a gates P3's exit;
+   the slug-flag flip happens only in P6 (atomic with the migration).
+3. **At every gate, update [`progress-manifest.md`](./progress-manifest.md)** —
+   record the date, PR #, and status, and tick the work-item checkboxes. The
+   manifest is the authoritative state of the campaign; keeping it current is part
+   of the definition of done for each phase.
+4. **Treat exit gates as binary pass/fail.** Each is phrased so it is mechanically
+   verifiable (a test is green, a grep returns nothing, a `--json` field has a
+   specific value). A phase is not done until every box is ticked.
+5. **Honour the CROSS-PHASE INVARIANTS** (see the dedicated section in
+   [`01-phased-plan.md`](./01-phased-plan.md)): CLAUDE.md doc/error rules, 500/1500
+   SLOC caps, **shared-crate publish-order + `cargo publish --dry-run` +
+   whole-workspace `cargo check`**, **macOS FDA re-grant + cdhash verify after
+   every daemon `cargo install` (#873)**, worktree discipline, and "the manifest is
+   the only member registry after P0".
+
+## Forced build order (why this sequence)
+
+The order is dependency-driven, **revised by the adversarial review**:
+
+1. **P0 — DOC-2 manifest first** (no upstream dep; kills the four-divergent-list
+   hazard; unblocks `stack_version`, member selection, dispatch step 1).
+   *Non-contract fields only* — contract fields land in P1 (two-pass, M2).
+2. **P2 — DOC-4 rollup** (lattice + scope matrix). Completes the **Option-A
+   deliverable**. Honors **DOC-4 RD1** (global `--timeout` only; per-member
+   override deferred — B2) and **RD3** (a project-scope down/fail degrades only
+   the project cell, does not move the exit — m6).
+3. **DECISION GATE — Option A vs Option B** (D-OptAB).
+4. *(Option B)* **P1 — DOC-1 contract + identity hoist.** The slug identity path
+   is landed **INERT behind a flag** — `derive_index_id` (basename) stays the live
+   key — because flipping it re-keys every index/palace and **orphans all state
+   unless the re-key migration co-ships** (B1).
+5. **P4a — trusty-search retrofit pulled FORWARD to gate P3** so dispatch is
+   validated against a **real** member envelope, not a fixture (B3); A1/A2/A8 are
+   pulled forward to P3.
+6. **P3 — DOC-5 dispatch + passthrough + rewire `up/`** (enter-gated on DOC-12
+   promotion, M5/D-M5).
+7. **P4b/c/d — remaining retrofits**; **P5 — minimal mpm shim**.
+8. **P6 — M15 re-key migration *and the slug-flag flip are ATOMIC*** — carried in
+   trusty-search's `core::migration` framework with a `schema_version` bump
+   (DOC-6 §7.1), re-keying by `root_path` (no reindex) (B1).
+9. **P7a (harness code + A0–A8) / P7b (CI infra)** — split because the macOS-VM /
+   Linux-container provisioning is a distinct, higher-risk concern (M4). A harness
+   skeleton is pulled **early** (P0) because the 214 pure-function unit tests
+   cannot catch dispatch/scope regressions.
+10. **P8 — fast-follow** (transitive cluster fold C4 + DOC-11 residuals).
+
+## Source of truth
+
+The **02-design** set is the authoritative source for *intent* and
+acceptance-criteria detail: [`../02-design/`](../02-design/) (DOC-0..DOC-12, with
+ADR-0006/0007/0008/0011). DOC-7 is **superseded** (ADR-0011 / #1104 — its UI
+surface moved to `trusty-console`); DOC-12 is **Draft** (its `up/` is the
+most-built part of the crate and is subject to change). Where this plan states an
+acceptance criterion, it cites the governing DOC section so it can be checked
+against the design.

--- a/docs/trusty-controller/research/03-plan/progress-manifest.md
+++ b/docs/trusty-controller/research/03-plan/progress-manifest.md
@@ -1,0 +1,261 @@
+# Progress Manifest — trusty-controller / `tctl` completion campaign
+
+> **LIVING DOCUMENT.** This is the single tracker for the campaign defined in
+> [`01-phased-plan.md`](./01-phased-plan.md). It MUST be updated at every phase
+> gate. Do not let it drift — a stale manifest is worse than none.
+>
+> Restructured after the adversarial pass
+> ([`02-adversarial-review.md`](./02-adversarial-review.md)): the phase set is
+> **P0, P2, [DECISION GATE], P1, P4a, P3, P4b/c/d, P5, P6, P7a, P7b, P8** (P2
+> precedes P1 because P0+P2 is the value-first Option-A deliverable; P4a is pulled
+> forward to gate P3).
+
+---
+
+## Update protocol (read before editing)
+
+> 🟡 **HONESTY NOTE (m5).** This update protocol is **advisory / honor-system** —
+> unlike the **mechanical** line-cap gate (`scripts/check_line_cap.sh`, CI-enforced),
+> nothing forces this manifest to stay current. **Optional lightweight CI check
+> (proposed):** a PR labeled with a phase (`phase:P3`, …) must change that phase's
+> Status cell in this file, else CI warns/fails. Until that exists, keeping this
+> file current is part of each phase's definition of done by convention only.
+
+1. **At an ENTER gate:** before starting a phase, confirm every enter-gate
+   precondition is met, set the phase **Status → IN PROGRESS**, set **Enter-gate
+   met? → ✅** with the date, and add a Notes line.
+2. **At an EXIT gate:** when all exit-gate criteria pass, set **Status →
+   EXIT-GATE-PENDING** until independently verified (tests green, CI green), then
+   **→ DONE** with **Exit-gate met? → ✅**, the date, and the merged **PR #(s)**.
+3. **If blocked:** set **Status → BLOCKED**, record the blocker in Notes and in the
+   "Deviations from plan" log.
+4. **Every status change records:** the **date** (YYYY-MM-DD), the **PR #(s)**, and
+   a one-line **Note**. Check the boxes in the per-phase checklist as work items
+   merge.
+5. **Decisions** (membership calls, deferrals, scope changes, OPEN DECISIONS) go in
+   the **Decisions log**; **anything that departs from
+   [`01-phased-plan.md`](./01-phased-plan.md)** goes in **Deviations from plan**.
+
+**Status legend:** `NOT STARTED` · `IN PROGRESS` · `BLOCKED` ·
+`EXIT-GATE-PENDING` · `DONE`.
+
+---
+
+## Phase status table
+
+| Phase | Title | Status | Enter-gate met? | Exit-gate met? | PRs | Notes |
+|---|---|---|---|---|---|---|
+| **P0** | Manifest (non-contract) + repo hygiene + README | NOT STARTED | ☐ | ☐ | — | Keystone (DOC-2); contract fields deferred to P1 (M2) |
+| **P2** | DOC-4 rollup: 4-value lattice + scope matrix | NOT STARTED | ☐ | ☐ | — | RD1 global-timeout-only; RD3 project-cell-only exit; defers C4→P8 |
+| **DECISION GATE** | Option A vs Option B (after P0/P2) | NOT REACHED | — | — | — | Records D-OptAB; Option B requires P1+P4 joint funding |
+| **P1** | Contract module (`trusty_common`) + identity hoist (INERT) + finalize contract fields | NOT STARTED | ☐ | ☐ | — | Option B only. Slug path INERT (B1); M2 second pass |
+| **P4a** | trusty-search retrofit (pattern-setter) — GATES P3 | NOT STARTED | ☐ | ☐ | — | Pulled forward (B3); real Envelope<T> |
+| **P3** | DOC-5 dispatch + real passthrough + rewire `up/` | NOT STARTED | ☐ | ☐ | — | Exit gated by P4a + A1/A2/A8 (B3); enter gated by DOC-12 (D-M5); closes TODO #920 |
+| **P4b** | trusty-memory retrofit (T3) | NOT STARTED | ☐ | ☐ | — | Follows P4a pattern |
+| **P4c** | trusty-analyze retrofit (T3) | NOT STARTED | ☐ | ☐ | — | Follows P4a pattern |
+| **P4d** | trusty-review retrofit (T2, heaviest) | NOT STARTED | ☐ | ☐ | — | Implements none of 7 verbs; budget separately |
+| **P5** | claude-mpm `uv` shim (minimal, T1) | NOT STARTED | ☐ | ☐ | — | Doomed when trusty-mpm lands |
+| **P6** | M15 re-key migration + slug-flag FLIP (ATOMIC) | NOT STARTED | ☐ | ☐ | — | HIGHEST RISK; trusty-search core::migration + schema_version (DOC-6 §7.1); re-key by root_path |
+| **P7a** | DOC-10 harness CODE + A0–A8 battery | NOT STARTED | ☐ | ☐ | — | A1/A2/A8 already proven in P3 |
+| **P7b** | DOC-10 CI infra: macOS-VM/Linux-container + `isolation.yml` | NOT STARTED | ☐ | ☐ | — | Nested-VM risk; macos-14 runner is isolation host (DOC-10 §3) |
+| **P8** | Cluster fold C4 + DOC-11 residuals | NOT STARTED | ☐ | ☐ | — | Fast-follow |
+
+---
+
+## Per-phase work-item checklist
+
+### P0 — Manifest (non-contract) + repo hygiene
+- [ ] Author `crates/trusty-controller/manifest.toml` — **NON-contract fields only** (M2): `id`/`display_name`/`binary`/`kind`/`install`/`version`/`changelog`/`depends_on`/`enabled`, `stack_version="YYYY.MM-N"`; review/tga/controller membership resolved; `timeout?` may exist but is unused (RD1)
+- [ ] Build manifest loader `src/manifest/mod.rs` (`include_str!` embedded default + system override; precedence system > embedded)
+- [ ] Wire the `--manifest <path>` flag (currently inert)
+- [ ] Collapse all 4 hard-coded lists (`default_manifest`, `stable_set`, `analyze_core_targets`, `mcp_members`) → manifest queries; delete list constructors
+- [ ] Replace `stack_version="0.0.0-scaffold"` with manifest value (leave `contract_floor` placeholder — finalized P1)
+- [ ] `auto_update` fate = **OPEN DECISION D-m3** (do NOT delete; leave TODO); keep `src/scope.rs` (P3 marker)
+- [ ] Rewrite stale README (remove "Phase 0 scaffold"/`publish=false`; add Option A vs B framing)
+- [ ] Seed minimal harness skeleton (`tests/isolation_harness.rs` smoke + `isolation.yml` stub)
+- [ ] Exit gate verified: **m2 binary check** (zero member-id `vec!`/array literals in the 4 symbols; only allowed ref = `cfg.analyze_core_targets` in `src/commands/up/policy.rs`, manifest-backed); real `stack_version`; tests/clippy/fmt/line-cap green
+
+### P2 — DOC-4 rollup
+- [ ] 4-value lattice `down≻degraded≻pending≻ready` (skipped absorbed)
+- [ ] tools×scope matrix; system drives verdict; project `pending` never degrades global
+- [ ] Timeouts: **global `--timeout` only** (2s/10s defaults) — **per-member manifest override DEFERRED (RD1, B2)**; synthesized `down` w/ `reason`
+- [ ] `pending_since` time-escalation (§5.5)
+- [ ] Exit-code aggregation worst-wins `3≻1≻2≻0`; **RD3: project-scope down/fail degrades only the project cell, does NOT raise process exit (m6)**; `--json` rollup struct
+- [ ] Rewrite `src/commands/stack/health.rs` + `src/commands/stack/doctor.rs` onto the rollup (drop `.any()` fold)
+- [ ] Regression test: healthy system + unindexed project → global `ready`, project cell `pending`
+- [ ] Negative test (m6): project-scope down/fail leaves process exit unchanged; (B2) manifest `timeout?` NOT consulted
+- [ ] Exit gate verified
+
+### DECISION GATE — Option A vs Option B
+- [ ] Record **D-OptAB** in decisions log (stop at Option A, OR proceed to Option B)
+- [ ] If Option B: record **P1+P4 joint-funding commitment** (caveat a) and DOC-12-promotion plan (D-M5)
+
+### P1 — Contract module + identity hoist (INERT) + finalize contract fields
+- [ ] (Enter) DECISION GATE = "proceed to Option B" with P1+P4 joint funding
+- [ ] Create `trusty_common::contract` `Envelope<T>` + status vocabularies + `Scope` enum
+- [ ] `verbs[]` descriptor + `version --json` shape; enforce D3 versioning split
+- [ ] `ContractTool` trait + `Dispatcher`
+- [ ] `redact_value` + `***redacted***` marker (D8 pattern set)
+- [ ] Golden-snapshot test C3 + seed `contract_version: 1` ledger
+- [ ] Hoist `detect_project`/`id_from_path` (canonicalize-then-slug, ADR-0008) **behind an INERT flag**; `derive_index_id` (basename) STAYS the live key (B1)
+- [ ] **Inert-flag test (B1):** no production read/write path consults `id_from_path`; live key is still basename
+- [ ] Replace `tctl src/commands/probe.rs` `serde_json::Value` validation with `Envelope<T>`
+- [ ] **Finalize manifest CONTRACT fields (M2 second pass):** `min_contract_version`/`expected_contract_version`/real `contract_floor`; re-verify the 4 collapsed call sites
+- [ ] Exit gate verified: **publish-order (M3)** `cargo publish --dry-run -p trusty-common`; whole-workspace `cargo check`; snapshot fails on un-bumped mutation
+
+### P4a — trusty-search retrofit (pattern-setter; GATES P3)
+- [ ] Implement `ContractTool` on trusty-search; 7 verbs; `verbs[]`; `redact_value`; net-new `restart`
+- [ ] `trusty-search version --json` snapshot test (verbs + `contract_version >= floor`)
+- [ ] Restart lifecycle test (graceful drain #534; `health` before/after)
+- [ ] Real `Envelope<T>` consumed by `tctl` without synthesis
+- [ ] Exit gate verified: **publish-order + cdhash/FDA (M3)**; whole-workspace `cargo check`
+
+### P3 — DOC-5 dispatch + real passthrough + rewire `up/`
+- [ ] (Enter) **DOC-12 Accepted OR Q1–Q6 re-confirmed (D-M5)** before `up/` rewiring
+- [ ] 9-step pipeline (load→select→scope→blast-gate→negotiate→invoke→collect→rollup→exit)
+- [ ] Make `src/commands/passthrough.rs` real; first-class commands become sugar over it
+- [ ] Reject self-target `tctl trusty-controller <verb>` (M5) → exit 3
+- [ ] Thread scope; kill `src/main.rs` `let _ = cli.scope` (TODO #920); lifecycle verbs system-only
+- [ ] Blast-radius gate (M5): non-TTY system-mutating w/o `--yes` → exit 3
+- [ ] System advisory lock (M7) on the `ensure` rung
+- [ ] Re-route `up/` through Dispatcher/passthrough (`src/commands/up/system_runner.rs`/`os_env.rs`); trust envelope status
+- [ ] **Validated against real member (B3):** dispatch+rollup exercised against trusty-search (P4a) real `Envelope<T>` — not a fixture
+- [ ] **A1 pulled forward:** `--json` `exit_code` == process exit
+- [ ] **A2 pulled forward:** rollup matrix shape well-formed over real stack
+- [ ] **A8 pulled forward:** `tctl doctor --self-check trusty-search` passes
+- [ ] Exit gate verified
+
+### P4b — trusty-memory retrofit
+- [ ] `ContractTool`, 7 verbs, `verbs[]`, `redact_value`, net-new `restart`; follow P4a pattern
+- [ ] version bump + `version --json` snapshot + redaction negative assertion + **restart-lifecycle test**
+- [ ] `tctl doctor --self-check trusty-memory` passes; **publish-order + cdhash/FDA (M3)**
+- [ ] Exit gate verified
+
+### P4c — trusty-analyze retrofit
+- [ ] `ContractTool`, 7 verbs, `verbs[]`, `redact_value`, net-new `restart`; follow P4a pattern
+- [ ] version bump + `version --json` snapshot + redaction negative assertion + **restart-lifecycle test**
+- [ ] `tctl doctor --self-check trusty-analyze` passes; **publish-order + cdhash/FDA (M3)**
+- [ ] Exit gate verified
+
+### P4d — trusty-review retrofit (heaviest)
+- [ ] Full retrofit (implements **none** of the 7 today); `ContractTool`, 7 verbs, `verbs[]`, `redact_value`, `restart`
+- [ ] version bump + `version --json` snapshot + redaction negative assertion + **restart-lifecycle test**
+- [ ] `tctl doctor --self-check trusty-review` passes; **publish-order + cdhash/FDA (M3)**
+- [ ] Exit gate verified
+
+### P5 — claude-mpm `uv` shim
+- [ ] `trusty_common::contract::orchestrator` shim (synthesize doctor/health/version; advertise exactly 3 verbs)
+- [ ] Add orchestrator member to `manifest.toml` (`kind=orchestrator`, `install=python/uv`, version pin)
+- [ ] Wire dispatch to route `kind=orchestrator` through the shim
+- [ ] Graceful degrade + `https://astral.sh/uv` hint when uv absent
+- [ ] Exit gate verified (self-check passes; advertises `["doctor","health","version"]`); **publish-order (M3)**
+
+### P6 — M15 re-key migration + slug-flag FLIP (ATOMIC, isolated)
+- [ ] Record backup/rollback plan in decisions log
+- [ ] Add migration to **trusty-search `core::migration`** (m005-style `_meta` step + `schema_version` bump, DOC-6 §7.1) — NOT a controller/common helper (B1)
+- [ ] Inventory all per-project keyed state (indexes, palaces, `.mcp.json`, controller state) keyed by OLD basename id
+- [ ] Re-key by `root_path` (rename in place) — NO reindex/re-embed; idempotent
+- [ ] `--dry-run` mode (no mutation)
+- [ ] **Flip the inert slug flag ATOMICALLY** after re-key verifies (B1)
+- [ ] Verification pass: zero old-basename-id stores remain; byte-count unchanged; pre=basename/post=slug test
+- [ ] Rollback tested (restore from backup; schema_version downgrade behaviour defined)
+- [ ] Exit gate verified; **publish-order + cdhash/FDA (M3)**
+
+### P7a — DOC-10 harness CODE + A0–A8 battery
+- [ ] Drive canonical scenario STEP 0–6 non-interactively
+- [ ] A0 hard-dep guide-and-abort (exit 3 + rustup/uv hints)
+- [ ] A1 exit-code mirror (generalize from P3)
+- [ ] A2 rollup matrix shape (generalize from P3)
+- [ ] A3 version truth post-install AND post-upgrade (asserted twice)
+- [ ] A4 daemons running (`health` == running)
+- [ ] A5 `.mcp.json` patched
+- [ ] A6 idempotency (second run no-op)
+- [ ] A7 progressive readiness non-racy (`ensure --wait` → `fresh`)
+- [ ] A8 conformance self-check per member (+ mpm shim 3-verb) (generalize from P3)
+- [ ] macOS cdhash/warm-boot assertion logic (M14, §3.4; no `cp`-over-PATH)
+- [ ] Broken-member fault-injection makes harness FAIL (oracle proof), then reverted
+- [ ] Exit gate verified (A0–A8 green locally)
+
+### P7b — DOC-10 CI infra
+- [ ] Vanilla-env construction (macOS: `macos-14` runner as isolation host — **document nested-VM limitation, M4**; Linux: container)
+- [ ] `isolation.yml`: per-PR path-filtered macOS smoke + nightly full scenario + Linux legs
+- [ ] macOS cdhash/warm-boot CI leg (install→launchd→health→restart→health; no `cp`)
+- [ ] Exit gate verified (A0–A8 green on `macos-14` + Linux)
+
+### P8 — Cluster fold C4 + DOC-11 residuals
+- [ ] Transitive cluster fold over `depends_on ∪ deps[]`; populate `clusters[]`
+- [ ] Cluster test (analyze depends_on search; search down → analyze in cluster)
+- [ ] DOC-11 residual sweep: re-route stale DOC-7 refs → trusty-console
+- [ ] README + abbreviation table re-audit (`tctl` alias present)
+- [ ] Exit gate verified; campaign marked complete
+
+---
+
+## Backlog tracker (carried-but-unscheduled — M4)
+
+> Mirror of [`01-phased-plan.md`](./01-phased-plan.md) "Carried-but-unscheduled".
+> Promote into a phase when scheduled.
+
+| # | Item | Owner-phase (tentative) | Status |
+|---|---|---|---|
+| BL-1 | DOC-8 §4 launch-hook (SessionStart) verification | P3 / P7a | ☐ |
+| BL-2 | `--latest` / BOM-drift consumer (`updates.rs:67`, #1316) | post-P1 | ☐ |
+| BL-3 | Upgrade rollback / pin-back (`tctl upgrade --to`) testing (DOC-9) | P7a | ☐ |
+| BL-4 | Redaction belt-and-suspenders + CI negative-assertion (DOC-1 D8) | P1 + P4a–d | ☐ |
+| BL-5 | Arg-surface guard (golden snapshot misses CLI arg-surface) | P1 | ☐ |
+| BL-6 | Observability/tracing for the dispatch path (DOC-5) | P3 | ☐ |
+
+---
+
+## Decisions log
+
+> Record membership calls, deferrals, scope changes, funding commitments, backup
+> plans, and OPEN DECISIONS. Format:
+> `YYYY-MM-DD — [Phase] decision — rationale — who`.
+
+**OPEN DECISIONS (owner call required — do not assume a default):**
+
+- **D-OptAB — [DECISION GATE] Option A (value-first; stop at P0+P2) vs Option B
+  (full contract/dispatch rebuild).** Option B requires committing **P1 and P4
+  together** (caveat (a) — the contract module is worthless without the cross-crate
+  retrofit funded in the same campaign). **Status: OPEN** — decide at the DECISION
+  GATE after P0/P2.
+- **D-B2 — [P2] Un-defer per-member timeouts?** The plan honors **DOC-4 RD1**
+  (owner-approved 2026-06-08): v1 ships **only a global `--timeout`**; per-member
+  manifest overrides are **deferred**. Un-deferring requires an **explicit owner
+  reversal of RD1** — NOT assumed. (The draft's "M10" does not exist.) **Status:
+  OPEN.**
+- **D-m3 — [P0] `auto_update.rs::maybe_notify` fate:** delete the orphan vs wire it
+  to the DOC-9 drift notification. Owner call; not pre-decided. **Status: OPEN.**
+- **D-M5 — [P3 enter] DOC-12 promotion:** promote DOC-12 to **Accepted**, OR have
+  the owner **re-confirm Q1–Q6** in this log, before P3 rewires `up/`. **Status:
+  OPEN.**
+
+**Resolved / recorded decisions:**
+
+- _(stub — first entry: P0 review/tga/controller membership resolution)_
+- _(stub — DECISION GATE: D-OptAB outcome + P1+P4 joint-funding commitment if Option B)_
+- _(stub — P6 backup/rollback plan before any state mutation)_
+
+---
+
+## Deviations from plan
+
+> Anything that departs from [`01-phased-plan.md`](./01-phased-plan.md): reordered
+> phases, dropped/added work items, changed acceptance criteria. Format:
+> `YYYY-MM-DD — [Phase] deviation — reason — impact`.
+
+- _(none yet)_
+
+---
+
+## Caveat watch (must stay satisfied through completion)
+
+| # | Caveat | Owning phase(s) | Status |
+|---|---|---|---|
+| (a) | DOC-1 contract worthless without DOC-6 retrofit in same campaign → P1+P4 funded together | DECISION GATE + P1 + P4a–d | ☐ committed |
+| (b) | Build DOC-10 harness EARLY; validate dispatch against a REAL member (B3) | P0 skeleton → P4a gates P3 → P7a/P7b | ☐ |
+| (c) | Identity flip orphans ALL state unless re-key migration co-ships; slug path INERT until P6 (B1) | P1 (inert) + P6 (atomic flip) | ☐ |
+| (d) | Honor DOC-4 RD1 (global `--timeout` only); per-member override deferred (B2) | P2 + D-B2 | ☐ |
+| (e) | DOC-11 still routes UI follow-ups to superseded DOC-7 → trusty-console | P8 | ☐ |
+| (f) | DOC-12 is DRAFT while its `up/` is most-built → P3 enter gated on promotion (M5/D-M5) | P3 | ☐ |


### PR DESCRIPTION
## Summary
Adds the `03-plan/` planning set for completing `trusty-controller` (`tctl`). Reconciles the implemented crate (v0.2.0) against the `02-design` set, defines a phased implementation plan with binary enter/exit gates, a living progress manifest, and an adversarial review of the plan itself. **Documentation only — no code implemented.**

## Files (docs/trusty-controller/research/03-plan/)
- `README.md` — index, current-state summary, Option A vs B strategic framing
- `00-current-state.md` — reconciliation: DONE / SUBSET-STAND-IN / DEAD / STUB / MISSING with file:line evidence
- `01-phased-plan.md` — phases with binary enter/exit gates, PR-sized work items, dependency diagram
- `progress-manifest.md` — living tracker (phase-status table, per-phase checklists, decisions log, backlog)
- `02-adversarial-review.md` — review record (blockers/majors/minors) each with a resolution

## Key findings
- The implementation was built out of design order: `install`/`upgrade`/`ensure`/`lifecycle`/`up` are real, but the rollup/dispatch/version surfaces are subset stand-ins to be rewritten once the four missing foundations land (contract module, manifest/BOM loading, scope threading, DOC-4 matrix). Members currently live in **four divergent hard-coded lists**; the generic passthrough (dispatch substrate) is the one true stub.

## Adversarial-pass restructuring
- **B1:** M15 re-key migration co-ships with the basename→slug identity flip (carried in trusty-search `core::migration` per DOC-6 §7.1) to avoid orphaning all index/palace state.
- **B2:** honors DOC-4 RD1 (global `--timeout` only); removed an invented citation.
- **B3:** P3 dispatch gated on a real member envelope (search retrofit pulled forward).
- Cross-phase release invariants (publish order, macOS cdhash/FDA #873); P4 split per-crate (P4a–d); harness split (code vs CI infra); Option A (value-first) vs Option B (full rebuild) decision gate after P0/P2.

## Open decisions (in progress-manifest)
- **D-OptAB:** value-first slice vs full rebuild
- **D-B2:** un-defer per-member timeouts (needs owner reversal of RD1)
- **D-m3:** delete orphaned `auto_update` notifier vs wire to DOC-9 drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)