### PR TITLE
feat(trusty-memory): wire autonomous Dreamer scheduler into daemon startup (closes #1529)

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -16,7 +16,7 @@ crates/trusty-analyze/src/lang/adapters/typescript.rs	560
 crates/trusty-analyze/src/main.rs	567
 crates/trusty-analyze/src/mcp/mod.rs	892
 crates/trusty-gworkspace/src/tools.rs	557
-crates/trusty-memory/src/lib.rs	622
+crates/trusty-memory/src/lib.rs	623
 crates/trusty-search/src/commands/doctor_checks.rs	503
 crates/trusty-search/src/core/indexer/tests.rs	2472
 crates/trusty-search/src/service/call_chain.rs	738

--- a/crates/trusty-memory/src/dream_scheduler.rs
+++ b/crates/trusty-memory/src/dream_scheduler.rs
@@ -75,7 +75,9 @@ pub fn spawn_dream_scheduler(
     }
 
     let palace_ids = registry.list();
-    let count = palace_ids.len();
+    // Track only successfully-spawned loops; a palace evicted between list()
+    // and get() is silently skipped, so palace_ids.len() can overcount.
+    let mut spawned: usize = 0;
 
     for palace_id in palace_ids {
         let handle = match registry.get(&palace_id) {
@@ -93,22 +95,24 @@ pub fn spawn_dream_scheduler(
         };
 
         let config = DreamConfig::default();
+        let idle_secs = config.idle_secs;
         let dreamer = Arc::new(Dreamer::new(config));
         let rx = shutdown_rx.clone();
         dreamer.start_with_shutdown(handle, rx);
+        spawned += 1;
 
         info!(
             palace = %palace_id,
-            idle_secs = DreamConfig::default().idle_secs,
+            idle_secs,
             "dream_scheduler: spawned background dream loop"
         );
     }
 
     info!(
-        loops_spawned = count,
+        loops_spawned = spawned,
         "dream_scheduler: all per-palace loops running"
     );
-    count
+    spawned
 }
 
 /// Build the `(Sender, Receiver)` pair for the dream-scheduler shutdown signal.
@@ -161,7 +165,7 @@ pub fn spawn_shutdown_bridge(tx: watch::Sender<bool>) -> tokio::task::JoinHandle
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::AtomicUsize;
+    use serial_test::serial;
     use std::sync::Arc;
     use std::time::Duration;
     use trusty_common::memory_core::dream::DreamConfig;
@@ -195,21 +199,24 @@ mod tests {
     /// Why: spawn_dream_scheduler must return 0 when TRUSTY_DREAM_DISABLED is
     /// set, with no loops started.
     /// What: sets the env var, calls spawn_dream_scheduler, asserts the count.
+    ///       Uses `current_thread` flavor + `#[serial]` to eliminate the data
+    ///       race that the default multi-threaded runtime would introduce when
+    ///       multiple env-mutating tests run concurrently.
     /// Test: itself.
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
+    #[serial]
     async fn dream_scheduler_honors_disable_flag() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let registry = PalaceRegistry::new();
         register_temp_palace(&registry, tmp.path());
 
-        // Safety: env-var mutation; test runs in isolation.
+        // SAFETY: single-threaded tokio runtime + #[serial] ensures no other
+        // thread reads DREAM_DISABLED_ENV concurrently. Restore on every path.
         unsafe {
             std::env::set_var(DREAM_DISABLED_ENV, "1");
         }
-
         let (_tx, rx) = make_shutdown_watch();
         let spawned = spawn_dream_scheduler(&registry, rx);
-
         unsafe {
             std::env::remove_var(DREAM_DISABLED_ENV);
         }
@@ -223,10 +230,15 @@ mod tests {
     /// Why: spawn_dream_scheduler must spawn exactly one loop per palace in the
     /// registry and return the correct count.
     /// What: registers two palaces, calls spawn_dream_scheduler, asserts count=2.
+    ///       Uses `current_thread` flavor + `#[serial]` to eliminate the data
+    ///       race that the default multi-threaded runtime would introduce when
+    ///       multiple env-mutating tests run concurrently.
     /// Test: itself.
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
+    #[serial]
     async fn dream_scheduler_spawns_per_palace_loop() {
-        // Ensure the disable flag is NOT set.
+        // SAFETY: single-threaded tokio runtime + #[serial] ensures no other
+        // thread reads DREAM_DISABLED_ENV concurrently. Restore on every path.
         unsafe {
             std::env::remove_var(DREAM_DISABLED_ENV);
         }
@@ -311,42 +323,53 @@ mod tests {
         assert!(*rx.borrow(), "value should flip to true after send");
     }
 
-    /// Why: verify the activity counter increments correctly per loop spawned.
-    /// What: use an AtomicUsize to count cycle runs — even one within a short
-    /// window confirms the loop is actually executing.
+    /// Why: verify that dream_cycle actually executes and returns stats when
+    /// called on a real PalaceHandle — this guards against regressions where
+    /// the cycle silently no-ops or panics.
+    /// What: creates a fresh palace, constructs a Dreamer with idle_secs=0
+    /// (always considered idle), calls dream_cycle directly, and asserts the
+    /// returned DreamStats fields are accessible (the call returned Ok, not a
+    /// panic or error). Also verifies that PersistedDreamStats was written to
+    /// the palace's data_dir (i.e. `<data_root>/<palace_id>/`).
     /// Test: itself.
     #[tokio::test]
     async fn dream_scheduler_loops_actually_run_cycles() {
-        unsafe {
-            std::env::remove_var(DREAM_DISABLED_ENV);
-        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let registry = PalaceRegistry::new();
+        let id = register_temp_palace(&registry, tmp.path());
+        let handle = registry.get(&id).expect("handle after create");
 
-        // We can't easily intercept dream_cycle calls from the scheduler
-        // without a mock PalaceHandle, so instead verify via the Dreamer API
-        // directly: is_idle should flip after idle_secs of inactivity.
         let config = DreamConfig {
-            idle_secs: 0, // 0 means max(1,0)=1 s sleep; idle immediately
+            idle_secs: 0, // always idle — cycle fires immediately
             ..DreamConfig::default()
         };
         let dreamer = Arc::new(Dreamer::new(config));
-        // Touch 2 seconds ago by manipulating the counter is not possible
-        // without pub(super) access, but is_idle() uses now-last >= idle_secs.
-        // With idle_secs=0 the dreamer considers itself immediately idle
-        // (0 >= 0 is true), so at least confirm the API doesn't panic.
-        assert!(
-            dreamer.is_idle(),
-            "with idle_secs=0, dreamer should be idle"
+
+        // Verify the dreamer is immediately idle with idle_secs=0.
+        assert!(dreamer.is_idle(), "idle_secs=0 should mean always idle");
+
+        // Call dream_cycle directly and assert it actually ran.
+        let stats = dreamer
+            .dream_cycle(&handle)
+            .await
+            .expect("dream_cycle should not error on a fresh empty palace");
+
+        // A real cycle returns Ok — the important assertion is that it didn't
+        // panic or error. duration_ms may be 0 on very fast machines.
+        let _ = stats.merged;
+        let _ = stats.pruned;
+        let _ = stats.duration_ms;
+
+        // PersistedDreamStats is written to handle.data_dir, which is
+        // `<data_root>/<palace_id>/` (not `<data_root>/` directly).
+        let palace_data_dir = tmp.path().join(id.as_str());
+        let persisted =
+            trusty_common::memory_core::dream::PersistedDreamStats::load(&palace_data_dir)
+                .expect("load persisted stats")
+                .expect("persisted stats should exist after a cycle");
+        assert_eq!(
+            persisted.stats.merged, stats.merged,
+            "persisted merged should match returned stats"
         );
-
-        // Confirm touch() resets the idle clock (within 1s of now).
-        dreamer.touch();
-        // After a touch, seconds elapsed is ~0 which is still >= 0,
-        // so idle_secs=0 means "always idle" regardless of touch.
-        // This test validates the API surface rather than timing.
-        let _ = dreamer.is_idle(); // no panic = pass
-
-        let cycles_run = Arc::new(AtomicUsize::new(0));
-        let cycles_clone = cycles_run.clone();
-        let _ = cycles_clone; // suppress unused warning — placeholder for future mock
     }
 }

--- a/crates/trusty-memory/src/dream_scheduler.rs
+++ b/crates/trusty-memory/src/dream_scheduler.rs
@@ -1,0 +1,352 @@
+//! Autonomous Dreamer scheduler — spawns per-palace dream loops on daemon startup.
+//!
+//! Why: `Dreamer::start_with_shutdown()` was fully implemented but never called
+//! in production (issue #1529, epic #1531). Without this module every dream
+//! cycle required a manual `POST /api/v1/dream/run`; memory consolidation,
+//! corpus pruning, and semantic consolidation never ran autonomously. Each
+//! palace now gets a background dream loop that wakes every `idle_secs`
+//! (default 300 s), checks the idle clock, and runs one cycle when the palace
+//! has been inactive long enough.
+//!
+//! What: exports `spawn_dream_scheduler`, a function that iterates the palaces
+//! already loaded in the `PalaceRegistry`, spawns one `Dreamer` loop per
+//! palace wired to the daemon's graceful-shutdown signal, and returns
+//! immediately. A global `TRUSTY_DREAM_DISABLED=1` env var disables all
+//! scheduling (useful for tests and deployments that prefer explicit runs).
+//! Failures in one palace's dream loop never crash other loops — they log and
+//! continue.
+//!
+//! Test: `tests::dream_scheduler_spawns_per_palace_loop`,
+//! `tests::dream_scheduler_honors_disable_flag`,
+//! `tests::dream_scheduler_shutdown_stops_all_loops`.
+
+use std::sync::Arc;
+
+use tokio::sync::watch;
+use tracing::{info, warn};
+use trusty_common::memory_core::dream::{DreamConfig, Dreamer};
+use trusty_common::memory_core::PalaceRegistry;
+
+/// Environment variable that disables autonomous dream scheduling when set to
+/// any non-empty value (convention: set to `"1"`).
+///
+/// Why: CI environments, integration tests, and deployments that prefer
+/// explicit `POST /api/v1/dream/run` calls need a way to opt out without
+/// recompiling. An env var at daemon startup is the lightest-weight gate.
+/// What: `spawn_dream_scheduler` checks this at startup; if set, it logs and
+/// returns immediately without spawning any loops.
+/// Test: `dream_scheduler_honors_disable_flag`.
+pub const DREAM_DISABLED_ENV: &str = "TRUSTY_DREAM_DISABLED";
+
+/// Spawn per-palace dream loops for every palace currently open in `registry`.
+///
+/// Why: issue #1529 — `Dreamer::start_with_shutdown()` was never called so
+/// memory consolidation only ran via manual API. This function closes that gap
+/// by wiring the scheduler into the daemon startup sequence.
+///
+/// What:
+/// 1. Checks `TRUSTY_DREAM_DISABLED`; returns immediately (no loops) when set.
+/// 2. Iterates every `PalaceId` currently registered in `registry`.
+/// 3. For each palace: resolves the `Arc<PalaceHandle>` via `registry.get()`,
+///    constructs a fresh `Dreamer` with `DreamConfig::default()`, and spawns
+///    a background loop via `Dreamer::start_with_shutdown(handle, rx.clone())`.
+/// 4. Spawns a bridge task that awaits `shutdown_rx` (a `watch::Receiver<bool>`
+///    driven by the daemon's SIGTERM / SIGINT signal) and broadcasts the stop
+///    signal to all dream loops.
+///
+/// Callers must provide `shutdown_rx`, a `watch::Receiver<bool>` that flips to
+/// `true` (or is closed) when the daemon should stop. See `make_shutdown_watch`
+/// for the bridge that converts `trusty_common::shutdown_signal()` into this
+/// channel.
+///
+/// Returns the number of dream loops spawned.
+///
+/// Test: `dream_scheduler_spawns_per_palace_loop`.
+pub fn spawn_dream_scheduler(
+    registry: &PalaceRegistry,
+    shutdown_rx: watch::Receiver<bool>,
+) -> usize {
+    if std::env::var(DREAM_DISABLED_ENV).is_ok_and(|v| !v.is_empty()) {
+        info!(
+            env = DREAM_DISABLED_ENV,
+            "autonomous dream scheduling disabled ({DREAM_DISABLED_ENV} is set)"
+        );
+        return 0;
+    }
+
+    let palace_ids = registry.list();
+    let count = palace_ids.len();
+
+    for palace_id in palace_ids {
+        let handle = match registry.get(&palace_id) {
+            Some(h) => h,
+            None => {
+                // Palace was evicted from the LRU between list() and get() —
+                // rare but possible under heavy load. Skip; the next startup
+                // hydration will pick it up.
+                warn!(
+                    palace = %palace_id,
+                    "dream_scheduler: handle not in registry after list(); skipping"
+                );
+                continue;
+            }
+        };
+
+        let config = DreamConfig::default();
+        let dreamer = Arc::new(Dreamer::new(config));
+        let rx = shutdown_rx.clone();
+        dreamer.start_with_shutdown(handle, rx);
+
+        info!(
+            palace = %palace_id,
+            idle_secs = DreamConfig::default().idle_secs,
+            "dream_scheduler: spawned background dream loop"
+        );
+    }
+
+    info!(
+        loops_spawned = count,
+        "dream_scheduler: all per-palace loops running"
+    );
+    count
+}
+
+/// Build the `(Sender, Receiver)` pair for the dream-scheduler shutdown signal.
+///
+/// Why: `trusty_common::shutdown_signal()` is a one-shot `async fn` that
+/// resolves when SIGTERM or SIGINT fires — it cannot be fanned out to N
+/// receivers directly. A `tokio::sync::watch` channel is the standard way
+/// to fan one cancel signal out to many background tasks without cloning a
+/// one-shot future.
+///
+/// What: returns `(tx, rx)` where `tx` is held by the daemon's shutdown
+/// bridge task (see `spawn_shutdown_bridge`) and every dream loop holds a
+/// clone of `rx`. When the bridge task flips `tx` to `true`, all dream loops
+/// see the change on their next `shutdown.changed()` / `shutdown.borrow()`
+/// poll and exit cleanly.
+///
+/// Test: `dream_scheduler_shutdown_stops_all_loops`.
+pub fn make_shutdown_watch() -> (watch::Sender<bool>, watch::Receiver<bool>) {
+    watch::channel(false)
+}
+
+/// Spawn a bridge task that converts the daemon's SIGTERM/SIGINT signal into
+/// a `watch::Sender<bool>` flip.
+///
+/// Why: `trusty_common::shutdown_signal()` is `async fn() -> ()` — it
+/// resolves exactly once and cannot be shared across tasks. The watch channel
+/// is the fan-out primitive. The bridge task awaits the one-shot signal and
+/// then sets the watch to `true`, which wakes every subscribed dream loop.
+///
+/// What: spawns a `tokio::spawn` that awaits `trusty_common::shutdown_signal()`,
+/// then sends `true` on `tx`. When the sender is dropped (e.g. if the task is
+/// cancelled), every receiver's `changed()` future returns `Err` which
+/// `start_with_shutdown` treats as a shutdown signal — so the bridge is also
+/// crash-safe.
+///
+/// Test: `dream_scheduler_shutdown_stops_all_loops` sends `true` directly on
+/// the channel (skipping the real signal) to avoid signal delivery in tests.
+pub fn spawn_shutdown_bridge(tx: watch::Sender<bool>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        trusty_common::shutdown_signal().await;
+        // Signal fired — broadcast stop to all dream loops.
+        let _ = tx.send(true);
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use trusty_common::memory_core::dream::DreamConfig;
+    use trusty_common::memory_core::dream::Dreamer;
+    use trusty_common::memory_core::palace::{Palace, PalaceId};
+    use trusty_common::memory_core::PalaceRegistry;
+
+    /// Helper: build a minimal `Palace` + open its `PalaceHandle` into a temp
+    /// dir, register it in the given registry, and return the `PalaceId`.
+    ///
+    /// Why: each test that exercises per-palace scheduling needs at least one
+    /// registered palace handle.
+    /// What: creates the palace under a `tempfile::tempdir()`, opens the handle
+    /// via `PalaceRegistry::create_palace`, and returns the id.
+    /// Test: used by the other tests in this module.
+    fn register_temp_palace(registry: &PalaceRegistry, tmp: &std::path::Path) -> PalaceId {
+        let palace = Palace {
+            id: PalaceId::new(format!("test-palace-{}", uuid::Uuid::new_v4())),
+            name: "Test Palace".to_string(),
+            description: None,
+            created_at: chrono::Utc::now(),
+            data_dir: tmp.to_path_buf(),
+        };
+        let id = palace.id.clone();
+        registry
+            .create_palace(tmp, palace)
+            .expect("create test palace");
+        id
+    }
+
+    /// Why: spawn_dream_scheduler must return 0 when TRUSTY_DREAM_DISABLED is
+    /// set, with no loops started.
+    /// What: sets the env var, calls spawn_dream_scheduler, asserts the count.
+    /// Test: itself.
+    #[tokio::test]
+    async fn dream_scheduler_honors_disable_flag() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let registry = PalaceRegistry::new();
+        register_temp_palace(&registry, tmp.path());
+
+        // Safety: env-var mutation; test runs in isolation.
+        unsafe {
+            std::env::set_var(DREAM_DISABLED_ENV, "1");
+        }
+
+        let (_tx, rx) = make_shutdown_watch();
+        let spawned = spawn_dream_scheduler(&registry, rx);
+
+        unsafe {
+            std::env::remove_var(DREAM_DISABLED_ENV);
+        }
+
+        assert_eq!(
+            spawned, 0,
+            "expect 0 loops when TRUSTY_DREAM_DISABLED=1; got {spawned}"
+        );
+    }
+
+    /// Why: spawn_dream_scheduler must spawn exactly one loop per palace in the
+    /// registry and return the correct count.
+    /// What: registers two palaces, calls spawn_dream_scheduler, asserts count=2.
+    /// Test: itself.
+    #[tokio::test]
+    async fn dream_scheduler_spawns_per_palace_loop() {
+        // Ensure the disable flag is NOT set.
+        unsafe {
+            std::env::remove_var(DREAM_DISABLED_ENV);
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tmp2 = tempfile::tempdir().expect("tempdir2");
+        let registry = PalaceRegistry::new();
+        register_temp_palace(&registry, tmp.path());
+        register_temp_palace(&registry, tmp2.path());
+
+        let (tx, rx) = make_shutdown_watch();
+        let spawned = spawn_dream_scheduler(&registry, rx);
+
+        // Stop the loops.
+        let _ = tx.send(true);
+
+        assert_eq!(
+            spawned, 2,
+            "expect 1 loop per palace (2 total); got {spawned}"
+        );
+    }
+
+    /// Why: dream loops spawned with start_with_shutdown must exit when the
+    /// watch channel flips to true. This guards the graceful-shutdown contract.
+    /// What: spawns one loop with a short idle_secs, sends shutdown=true, and
+    /// awaits the join handle to confirm it exits within a reasonable deadline.
+    /// Test: itself.
+    #[tokio::test]
+    async fn dream_scheduler_shutdown_stops_loop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let registry = PalaceRegistry::new();
+        let id = register_temp_palace(&registry, tmp.path());
+        let handle = registry.get(&id).expect("handle after create");
+
+        let config = DreamConfig {
+            idle_secs: 1,
+            ..DreamConfig::default()
+        };
+        let dreamer = Arc::new(Dreamer::new(config));
+        let (tx, rx) = make_shutdown_watch();
+
+        let join = dreamer.start_with_shutdown(handle, rx);
+
+        // Signal shutdown.
+        tx.send(true).expect("send shutdown");
+
+        // The loop should exit well within 2 s after receiving the signal.
+        let result = tokio::time::timeout(Duration::from_secs(2), join).await;
+        assert!(
+            result.is_ok(),
+            "dream loop did not exit within 2s after shutdown signal"
+        );
+    }
+
+    /// Why: an error in one palace's dream cycle must not abort the loop for
+    /// that palace or crash any other palace's loop. The loop logs and continues.
+    /// What: relies on the Dreamer implementation's `warn!` path on `dream_cycle`
+    /// error — we can only verify indirectly here that the scheduler spawns
+    /// without panic even when a palace is in a degraded state. We test the
+    /// per-loop error isolation at the `Dreamer` level in trusty-common.
+    /// Test: itself (smoke test — would panic or deadlock on regression).
+    #[tokio::test]
+    async fn dream_scheduler_no_panic_with_empty_registry() {
+        unsafe {
+            std::env::remove_var(DREAM_DISABLED_ENV);
+        }
+        let registry = PalaceRegistry::new();
+        let (_tx, rx) = make_shutdown_watch();
+        let count = spawn_dream_scheduler(&registry, rx);
+        assert_eq!(count, 0, "empty registry should produce 0 loops");
+    }
+
+    /// Why: verify `make_shutdown_watch` returns a functioning watch pair.
+    /// What: sends `true`, asserts receiver sees it.
+    /// Test: itself.
+    #[tokio::test]
+    async fn make_shutdown_watch_pair_works() {
+        let (tx, mut rx) = make_shutdown_watch();
+        assert!(!*rx.borrow(), "initial value should be false");
+        tx.send(true).expect("send");
+        rx.changed().await.expect("changed");
+        assert!(*rx.borrow(), "value should flip to true after send");
+    }
+
+    /// Why: verify the activity counter increments correctly per loop spawned.
+    /// What: use an AtomicUsize to count cycle runs — even one within a short
+    /// window confirms the loop is actually executing.
+    /// Test: itself.
+    #[tokio::test]
+    async fn dream_scheduler_loops_actually_run_cycles() {
+        unsafe {
+            std::env::remove_var(DREAM_DISABLED_ENV);
+        }
+
+        // We can't easily intercept dream_cycle calls from the scheduler
+        // without a mock PalaceHandle, so instead verify via the Dreamer API
+        // directly: is_idle should flip after idle_secs of inactivity.
+        let config = DreamConfig {
+            idle_secs: 0, // 0 means max(1,0)=1 s sleep; idle immediately
+            ..DreamConfig::default()
+        };
+        let dreamer = Arc::new(Dreamer::new(config));
+        // Touch 2 seconds ago by manipulating the counter is not possible
+        // without pub(super) access, but is_idle() uses now-last >= idle_secs.
+        // With idle_secs=0 the dreamer considers itself immediately idle
+        // (0 >= 0 is true), so at least confirm the API doesn't panic.
+        assert!(
+            dreamer.is_idle(),
+            "with idle_secs=0, dreamer should be idle"
+        );
+
+        // Confirm touch() resets the idle clock (within 1s of now).
+        dreamer.touch();
+        // After a touch, seconds elapsed is ~0 which is still >= 0,
+        // so idle_secs=0 means "always idle" regardless of touch.
+        // This test validates the API surface rather than timing.
+        let _ = dreamer.is_idle(); // no panic = pass
+
+        let cycles_run = Arc::new(AtomicUsize::new(0));
+        let cycles_clone = cycles_run.clone();
+        let _ = cycles_clone; // suppress unused warning — placeholder for future mock
+    }
+}

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -79,6 +79,15 @@ pub mod activity;
 pub mod attribution;
 pub mod bm25_supervisor;
 pub mod bootstrap;
+/// Autonomous Dreamer scheduler — spawns per-palace dream loops on daemon startup.
+///
+/// Why: issue #1529 — `Dreamer::start_with_shutdown()` was fully implemented
+/// but never called. This module wires it into the daemon so each palace gets
+/// a background dream loop that fires every 5 minutes of idle time.
+/// What: exports `spawn_dream_scheduler`, `make_shutdown_watch`, and
+/// `spawn_shutdown_bridge`. Disable with `TRUSTY_DREAM_DISABLED=1`.
+/// Test: see unit tests inside this module.
+pub mod dream_scheduler;
 /// File-descriptor usage and limit reporting for `/health`.
 ///
 /// Why: expose `open_fds` / `fd_soft_limit` so operators can see the fd

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -783,33 +783,43 @@ async fn run_serve(
     }
 }
 
-/// Why: startup tasks (palace hydration, alias discovery, pin scan) are the
-///      same regardless of whether HTTP binds to a fixed or dynamic port;
-///      keeping the logic in a single helper means a new startup task only has
-///      to be added in one place. Previously, `load_palaces_from_disk` was
-///      awaited synchronously before binding the HTTP listener — a single
-///      broken `kg.db` (stale WAL sidecar, corrupt file, permissions) could
-///      stall hydration for seconds per palace, deferring `/health` becoming
-///      reachable until every palace had been visited. The dashboard, MCP
-///      clients, and `launchctl` health-probes all interpret that as "the
-///      daemon is dead", so the launchd job thrashes and operators see no
-///      useful output. Spawning hydration as a background task lets the HTTP
-///      server bind immediately; palaces appear in `palace_list` and the
-///      dashboard as each one finishes opening. Per-palace failures are
-///      already logged and skipped inside `load_palaces_from_disk` so a
-///      single bad `kg.db` can never abort the daemon.
+/// Why: startup tasks (palace hydration, alias discovery, pin scan, and the
+///      issue-#1529 autonomous dream scheduler) are the same regardless of
+///      whether HTTP binds to a fixed or dynamic port; keeping the logic in
+///      a single helper means a new startup task only has to be added in one
+///      place. Previously, `load_palaces_from_disk` was awaited synchronously
+///      before binding the HTTP listener — a single broken `kg.db` (stale WAL
+///      sidecar, corrupt file, permissions) could stall hydration for seconds
+///      per palace, deferring `/health` becoming reachable until every palace
+///      had been visited. The dashboard, MCP clients, and `launchctl`
+///      health-probes all interpret that as "the daemon is dead", so the launchd
+///      job thrashes and operators see no useful output. Spawning hydration as a
+///      background task lets the HTTP server bind immediately; palaces appear in
+///      `palace_list` and the dashboard as each one finishes opening.
+///      Per-palace failures are already logged and skipped inside
+///      `load_palaces_from_disk` so a single bad `kg.db` can never abort the
+///      daemon.
 /// What: clones `state` (cheap — `AppState` derives `Clone` with `Arc`-wrapped
-///       internals) and spawns a background task that (1) hydrates persisted
-///       palaces from disk with timing logs, (2) once palaces are live,
-///       kicks off issue-#42 alias auto-discovery against the cwd targeting
-///       the default palace (if configured), and (3) runs the issue-#470
-///       single-pass pin scan and populates `AppState::pin_project_map`
-///       (scan-only — NO palace opens). Returns immediately — the spawned
-///       task runs concurrently with the HTTP listener bind.
+///       internals) and spawns a background task that:
+///       (1) hydrates persisted palaces from disk with timing logs;
+///       (2) once palaces are live, kicks off issue-#42 alias auto-discovery
+///           against the cwd targeting the default palace (if configured);
+///       (3) runs the issue-#470 single-pass pin scan and populates
+///           `AppState::pin_project_map` (scan-only — NO palace opens);
+///       (4) [issue #1529] spawns per-palace autonomous dream loops via
+///           `dream_scheduler::spawn_dream_scheduler` wired to a watch channel
+///           that the `spawn_shutdown_bridge` task flips on SIGTERM/SIGINT.
+///       Returns immediately — all spawned tasks run concurrently with the HTTP
+///       listener bind.
 /// Test: `spawn_startup_tasks_populates_pin_map` verifies the scan path runs
 ///       and populates the map; the log emission is confirmed by the throwaway
 ///       daemon run documented in the session notes.
 fn spawn_startup_tasks(state: &AppState) {
+    // Issue #1529: build watch channel + bridge for the autonomous dream scheduler.
+    // Sender lives in the bridge; each dream loop holds a clone of the receiver.
+    // SIGTERM / SIGINT flips the channel to `true` → all loops exit cleanly.
+    let (dtx, dream_shutdown_rx) = trusty_memory::dream_scheduler::make_shutdown_watch();
+    trusty_memory::dream_scheduler::spawn_shutdown_bridge(dtx);
     // Issue #906 / #910 / #911: eager embedder warm-up.
     // Spawn BEFORE the palace hydration task so the CoreML / CUDA cold compile
     // (30-120 s on first run) races ahead concurrently and the warm embedder
@@ -858,6 +868,14 @@ fn spawn_startup_tasks(state: &AppState) {
                 "background palace hydration failed: {e:#}"
             ),
         }
+
+        // Issue #1529: spawn per-palace autonomous dream loops after hydration.
+        let n = trusty_memory::dream_scheduler::spawn_dream_scheduler(
+            &bg_state.registry,
+            dream_shutdown_rx,
+        );
+        tracing::info!(loops = n, "dream_scheduler: {n} loop(s) running (#1529)");
+
         // Issue #42: once palaces are live, kick off auto-discovery against
         // cwd targeting the default palace (if configured). Without a default
         // palace there's no obvious destination, so skip — explicit MCP

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -815,11 +815,19 @@ async fn run_serve(
 ///       and populates the map; the log emission is confirmed by the throwaway
 ///       daemon run documented in the session notes.
 fn spawn_startup_tasks(state: &AppState) {
-    // Issue #1529: build watch channel + bridge for the autonomous dream scheduler.
-    // Sender lives in the bridge; each dream loop holds a clone of the receiver.
-    // SIGTERM / SIGINT flips the channel to `true` → all loops exit cleanly.
+    // Issue #1529: build watch channel for the autonomous dream scheduler.
+    // The sender (`dtx`) is intentionally held here and moved into the
+    // hydration task — the shutdown bridge is only wired AFTER
+    // `spawn_dream_scheduler` returns. This ordering guarantee prevents a
+    // shutdown-race where a SIGTERM that arrives during hydration could flip
+    // the watch to `true` before any dream loops are spawned, causing every
+    // newly-spawned loop to exit immediately on its first iteration. By
+    // spawning the bridge after the loops exist, early-SIGTERM during hydration
+    // is still safe: the loops will see the `true` value on their first poll
+    // and shut down cleanly, which is the correct behaviour. Normal startup
+    // (no early SIGTERM) is unaffected because the bridge task cannot fire
+    // until `trusty_common::shutdown_signal()` resolves.
     let (dtx, dream_shutdown_rx) = trusty_memory::dream_scheduler::make_shutdown_watch();
-    trusty_memory::dream_scheduler::spawn_shutdown_bridge(dtx);
     // Issue #906 / #910 / #911: eager embedder warm-up.
     // Spawn BEFORE the palace hydration task so the CoreML / CUDA cold compile
     // (30-120 s on first run) races ahead concurrently and the warm embedder
@@ -870,11 +878,18 @@ fn spawn_startup_tasks(state: &AppState) {
         }
 
         // Issue #1529: spawn per-palace autonomous dream loops after hydration.
+        // ORDERING GUARANTEE: spawn_dream_scheduler is called first, then the
+        // shutdown bridge is wired. This ensures the bridge cannot pre-cancel
+        // the loops: loops are created with receivers pointing to a watch that
+        // is still `false`, so they will do their first sleep before the bridge
+        // could ever flip the value.
         let n = trusty_memory::dream_scheduler::spawn_dream_scheduler(
             &bg_state.registry,
             dream_shutdown_rx,
         );
         tracing::info!(loops = n, "dream_scheduler: {n} loop(s) running (#1529)");
+        // Bridge is spawned AFTER the loops exist — see ordering comment above.
+        trusty_memory::dream_scheduler::spawn_shutdown_bridge(dtx);
 
         // Issue #42: once palaces are live, kick off auto-discovery against
         // cwd targeting the default palace (if configured). Without a default


### PR DESCRIPTION
## Summary

- **New module** `dream_scheduler` wires `Dreamer::start_with_shutdown()` — fully implemented but never called before this PR — into daemon startup so each palace gets a background dream loop firing every 300 s of idle time.
- **Shutdown handling**: `shutdown_signal()` is a one-shot future; a `tokio::sync::watch::channel(false)` bridge converts it into a fan-out signal so all N dream loops exit cleanly on SIGTERM/SIGINT.
- **Spawn ordering**: the scheduler is called _inside_ the hydration background task, after `load_palaces_from_disk()`, so `registry.get()` returns populated handles.
- **Disable flag**: set `TRUSTY_DREAM_DISABLED=1` to skip scheduling entirely (test rigs, staging).
- **Per-palace isolation**: a `registry.get()` miss after `list()` logs `warn!` and skips; panic/errors inside a dream loop are handled inside `Dreamer::start_with_shutdown()` (logs `warn!`, continues).

## Files changed

| File | Change |
|---|---|
| `crates/trusty-memory/src/dream_scheduler.rs` | New — scheduler, watch-channel helpers, 6 unit tests |
| `crates/trusty-memory/src/lib.rs` | Added `pub mod dream_scheduler;` |
| `crates/trusty-memory/src/main.rs` | Wired channel + bridge + post-hydration spawn in `spawn_startup_tasks()` |
| `.line-cap-allowlist.tsv` | Bumped `lib.rs` budget 622 → 623 (one-line module decl) |

## Test plan

- [x] `cargo fmt --check -p trusty-memory` — clean
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p trusty-memory` — all tests pass (includes 6 new dream_scheduler unit tests)
- [x] `cargo test -p trusty-common` — all tests pass
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations
- [x] Pre-commit hooks — all passed

Closes #1529. Part of epic #1531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)