### PR TITLE
feat(trusty-memory): add dream effectiveness metrics (before/after drawer counts + recall benchmark) (closes #1530)

### DIFF
--- a/crates/trusty-common/src/memory_core/dream/config.rs
+++ b/crates/trusty-common/src/memory_core/dream/config.rs
@@ -69,7 +69,18 @@ impl Default for DreamConfig {
 }
 
 /// Per-cycle dream telemetry.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Why: Operators need to see whether dreaming actually helps — raw action
+/// counts (merged, pruned) are necessary but not sufficient. The compression
+/// ratio captures structural change; the recall scores before/after capture
+/// whether retrieval quality improved or degraded after consolidation.
+/// What: Bundles counters for each dream phase plus effectiveness metrics
+/// (drawer compression ratio and mean recall benchmark scores). All new fields
+/// use `#[serde(default)]` for backward-compat with existing dream_stats.json
+/// files that predate this struct extension.
+/// Test: `dream_stats_serde_roundtrip_new_fields`, `dream_stats_backward_compat`,
+/// `dream_compression_ratio_math`, `dream_compression_ratio_zero_drawers`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct DreamStats {
     pub merged: usize,
     pub pruned: usize,
@@ -94,6 +105,82 @@ pub struct DreamStats {
     #[serde(default)]
     pub semantic_cache_hits: usize,
     pub duration_ms: u64,
+
+    // ── Effectiveness metrics (issue #1530) ──────────────────────────────────
+    /// Total drawer count at the start of the dream cycle (before any passes).
+    ///
+    /// Why: Together with `drawers_after`, this gives the compression ratio —
+    /// how many drawers were eliminated relative to what existed before.
+    /// What: Snapshot of `handle.drawers.read().len()` taken at cycle entry.
+    /// Test: `dream_cycle_records_drawer_counts` asserts this > 0 after seeding.
+    #[serde(default)]
+    pub drawers_before: u64,
+
+    /// Total drawer count at the end of the dream cycle (after all passes).
+    ///
+    /// Why: Compared with `drawers_before` to compute `compression_ratio`.
+    /// What: Snapshot of `handle.drawers.read().len()` taken after all passes.
+    /// Test: `dream_cycle_records_drawer_counts`.
+    #[serde(default)]
+    pub drawers_after: u64,
+
+    /// Fraction of drawers eliminated: `(before - after) / before`.
+    ///
+    /// Why: A single number that summarises structural consolidation for the
+    /// admin dashboard. Serialised directly so `dream_stats.json` shows it
+    /// without requiring clients to do arithmetic.
+    /// What: `0.0` when `drawers_before == 0` (guard against divide-by-zero).
+    /// Otherwise `(drawers_before - drawers_after) / drawers_before`. Always
+    /// in `[0.0, 1.0]` because no dream pass *adds* more drawers than existed
+    /// (semantic phase adds canonicals, but they are counted in `drawers_after`
+    /// so the ratio captures net change).
+    /// Test: `dream_compression_ratio_math`, `dream_compression_ratio_zero_drawers`.
+    #[serde(default)]
+    pub compression_ratio: f64,
+
+    /// Mean top-3 retrieval score across the fixed benchmark query set,
+    /// measured *before* the dream cycle ran any consolidation passes.
+    ///
+    /// Why: Establishes a quality baseline so we can compare with
+    /// `recall_score_after`. A decrease post-dream signals the cycle
+    /// accidentally discarded high-signal drawers.
+    /// What: `None` when the palace is empty or the embedder is unavailable
+    /// (graceful skip). Serialised as a JSON `null` in that case.
+    /// Test: `dream_recall_benchmark_empty_palace_returns_none`,
+    /// `dream_recall_benchmark_returns_score_with_drawers`.
+    #[serde(default)]
+    pub recall_score_before: Option<f64>,
+
+    /// Mean top-3 retrieval score across the fixed benchmark query set,
+    /// measured *after* all dream consolidation passes completed.
+    ///
+    /// Why: Pair with `recall_score_before` to compute delta. If post-dream
+    /// score ≥ pre-dream score, the cycle improved or maintained quality.
+    /// What: Same semantics as `recall_score_before`. `None` on skip.
+    /// Test: `dream_recall_benchmark_returns_score_with_drawers`.
+    #[serde(default)]
+    pub recall_score_after: Option<f64>,
+}
+
+impl DreamStats {
+    /// Compute and set the compression ratio from `drawers_before` and
+    /// `drawers_after`.
+    ///
+    /// Why: Callers that update `drawers_before`/`drawers_after` independently
+    /// need a single place to sync the derived `compression_ratio` field. This
+    /// avoids duplicating the divide-by-zero guard.
+    /// What: Sets `self.compression_ratio` to
+    /// `(drawers_before - drawers_after) / drawers_before`, or `0.0` when
+    /// `drawers_before == 0`.
+    /// Test: `dream_compression_ratio_math`, `dream_compression_ratio_zero_drawers`.
+    pub fn update_compression_ratio(&mut self) {
+        self.compression_ratio = if self.drawers_before == 0 {
+            0.0
+        } else {
+            let eliminated = self.drawers_before.saturating_sub(self.drawers_after);
+            eliminated as f64 / self.drawers_before as f64
+        };
+    }
 }
 
 /// Persisted dream stats including the wall-clock timestamp of the run.

--- a/crates/trusty-common/src/memory_core/dream/config.rs
+++ b/crates/trusty-common/src/memory_core/dream/config.rs
@@ -46,6 +46,19 @@ pub struct DreamConfig {
     /// When `true` and no OpenRouter key is available, the semantic phase uses
     /// the local model at `http://localhost:11434`.
     pub local_model_enabled: bool,
+    /// Whether to run the recall benchmark before and after each dream cycle.
+    ///
+    /// Why: The benchmark performs two full embed+search passes per cycle. On
+    /// resource-constrained deployments or very frequent dream cycles, this
+    /// overhead may be undesirable. Setting to `false` skips both passes and
+    /// leaves `recall_score_before`/`recall_score_after` as `None`.
+    /// What: When `false`, `dream_cycle` skips `run_benchmark` entirely; both
+    /// recall score fields in `DreamStats` are `None`. Defaults to `true` so
+    /// existing configs and behavior are unchanged.
+    /// Test: `dream_cycle_recall_benchmark_disabled` asserts that when
+    /// `recall_benchmark_enabled = false`, the cycle completes and both recall
+    /// scores are `None`.
+    pub recall_benchmark_enabled: bool,
 }
 
 impl Default for DreamConfig {
@@ -64,6 +77,7 @@ impl Default for DreamConfig {
             semantic: SemanticConsolidationConfig::default(),
             openrouter_api_key: String::new(),
             local_model_enabled: true,
+            recall_benchmark_enabled: true,
         }
     }
 }
@@ -130,10 +144,10 @@ pub struct DreamStats {
     /// admin dashboard. Serialised directly so `dream_stats.json` shows it
     /// without requiring clients to do arithmetic.
     /// What: `0.0` when `drawers_before == 0` (guard against divide-by-zero).
-    /// Otherwise `(drawers_before - drawers_after) / drawers_before`. Always
-    /// in `[0.0, 1.0]` because no dream pass *adds* more drawers than existed
-    /// (semantic phase adds canonicals, but they are counted in `drawers_after`
-    /// so the ratio captures net change).
+    /// Otherwise `(drawers_before - drawers_after) / drawers_before`. In
+    /// `[0.0, 1.0]`; 0.0 means no net shrinkage OR net growth (growth is
+    /// clamped to 0.0 via `saturating_sub`). Net growth can occur when the
+    /// semantic consolidation phase adds canonical drawers.
     /// Test: `dream_compression_ratio_math`, `dream_compression_ratio_zero_drawers`.
     #[serde(default)]
     pub compression_ratio: f64,
@@ -171,12 +185,23 @@ impl DreamStats {
     /// avoids duplicating the divide-by-zero guard.
     /// What: Sets `self.compression_ratio` to
     /// `(drawers_before - drawers_after) / drawers_before`, or `0.0` when
-    /// `drawers_before == 0`.
-    /// Test: `dream_compression_ratio_math`, `dream_compression_ratio_zero_drawers`.
+    /// `drawers_before == 0`. When `drawers_after > drawers_before` (net
+    /// growth), the ratio is clamped to `0.0` via `saturating_sub` and a
+    /// `tracing::warn!` is emitted so the growth is observable.
+    /// Test: `dream_compression_ratio_math`, `dream_compression_ratio_zero_drawers`,
+    /// `dream_compression_ratio_net_growth`.
     pub fn update_compression_ratio(&mut self) {
         self.compression_ratio = if self.drawers_before == 0 {
             0.0
         } else {
+            if self.drawers_after > self.drawers_before {
+                tracing::warn!(
+                    drawers_before = self.drawers_before,
+                    drawers_after = self.drawers_after,
+                    "dream cycle: net palace growth detected (more drawers after than before); \
+                     compression_ratio clamped to 0.0"
+                );
+            }
             let eliminated = self.drawers_before.saturating_sub(self.drawers_after);
             eliminated as f64 / self.drawers_before as f64
         };

--- a/crates/trusty-common/src/memory_core/dream/dreamer.rs
+++ b/crates/trusty-common/src/memory_core/dream/dreamer.rs
@@ -224,8 +224,12 @@ impl Dreamer {
         // Count drawers before any pass so we can compute the compression ratio.
         let drawers_before = handle.drawers.read().len() as u64;
 
-        // Recall benchmark before consolidation — skip silently on failure.
-        let recall_score_before = run_benchmark(handle).await;
+        // Recall benchmark before consolidation — skip silently on failure or when disabled.
+        let recall_score_before = if self.config.recall_benchmark_enabled {
+            run_benchmark(handle).await
+        } else {
+            None
+        };
 
         let content_pruned = if self.config.content_prune_enabled {
             content_prune_pass(handle, started, budget, self.config.content_prune_min_words)
@@ -257,8 +261,12 @@ impl Dreamer {
         // ── Effectiveness metric: post-cycle snapshot (issue #1530) ───────────
         let drawers_after = handle.drawers.read().len() as u64;
 
-        // Recall benchmark after consolidation — skip silently on failure.
-        let recall_score_after = run_benchmark(handle).await;
+        // Recall benchmark after consolidation — skip silently on failure or when disabled.
+        let recall_score_after = if self.config.recall_benchmark_enabled {
+            run_benchmark(handle).await
+        } else {
+            None
+        };
 
         let mut stats = DreamStats {
             merged,

--- a/crates/trusty-common/src/memory_core/dream/dreamer.rs
+++ b/crates/trusty-common/src/memory_core/dream/dreamer.rs
@@ -14,6 +14,7 @@ use super::cycle::{
     semantic_consolidation_pass,
 };
 use super::guard::CompactionGuard;
+use super::recall_benchmark::run_benchmark;
 use crate::memory_core::retrieval::PalaceHandle;
 use crate::memory_core::semantic_consolidation::SemanticConsolidator;
 use anyhow::{Context, Result};
@@ -114,6 +115,9 @@ impl Dreamer {
                         semantically_consolidated = stats.semantically_consolidated,
                         semantic_llm_calls = stats.semantic_llm_calls,
                         duration_ms = stats.duration_ms,
+                        drawers_before = stats.drawers_before,
+                        drawers_after = stats.drawers_after,
+                        compression_ratio = stats.compression_ratio,
                         "dream cycle complete"
                     ),
                     Err(e) => tracing::warn!(palace = %handle.id, "dream cycle failed: {e:#}"),
@@ -171,6 +175,9 @@ impl Dreamer {
                         semantically_consolidated = stats.semantically_consolidated,
                         semantic_llm_calls = stats.semantic_llm_calls,
                         duration_ms = stats.duration_ms,
+                        drawers_before = stats.drawers_before,
+                        drawers_after = stats.drawers_after,
+                        compression_ratio = stats.compression_ratio,
                         "dream cycle complete"
                     ),
                     Err(e) => tracing::warn!(palace = %handle.id, "dream cycle failed: {e:#}"),
@@ -213,6 +220,13 @@ impl Dreamer {
         // panics alike.
         let _compaction_guard = CompactionGuard::new(handle.is_compacting.clone());
 
+        // ── Effectiveness metric: pre-cycle snapshot (issue #1530) ────────────
+        // Count drawers before any pass so we can compute the compression ratio.
+        let drawers_before = handle.drawers.read().len() as u64;
+
+        // Recall benchmark before consolidation — skip silently on failure.
+        let recall_score_before = run_benchmark(handle).await;
+
         let content_pruned = if self.config.content_prune_enabled {
             content_prune_pass(handle, started, budget, self.config.content_prune_min_words)
                 .await
@@ -240,7 +254,13 @@ impl Dreamer {
             tracing::warn!("dream flush failed: {e:#}");
         }
 
-        let stats = DreamStats {
+        // ── Effectiveness metric: post-cycle snapshot (issue #1530) ───────────
+        let drawers_after = handle.drawers.read().len() as u64;
+
+        // Recall benchmark after consolidation — skip silently on failure.
+        let recall_score_after = run_benchmark(handle).await;
+
+        let mut stats = DreamStats {
             merged,
             pruned,
             closets_updated,
@@ -250,7 +270,13 @@ impl Dreamer {
             semantic_llm_calls,
             semantic_cache_hits,
             duration_ms: started.elapsed().as_millis() as u64,
+            drawers_before,
+            drawers_after,
+            compression_ratio: 0.0, // populated below
+            recall_score_before,
+            recall_score_after,
         };
+        stats.update_compression_ratio();
 
         // WAL checkpoint — PASSIVE mode is non-blocking. Issue #36: without
         // periodic checkpointing the SQLite WAL grows unbounded over a

--- a/crates/trusty-common/src/memory_core/dream/mod.rs
+++ b/crates/trusty-common/src/memory_core/dream/mod.rs
@@ -13,6 +13,7 @@ mod cycle;
 mod dreamer;
 mod guard;
 mod helpers;
+mod recall_benchmark;
 
 #[cfg(test)]
 mod tests;

--- a/crates/trusty-common/src/memory_core/dream/recall_benchmark.rs
+++ b/crates/trusty-common/src/memory_core/dream/recall_benchmark.rs
@@ -1,0 +1,152 @@
+//! Fixed recall-quality benchmark for the dream effectiveness metric.
+//!
+//! Why: The dream cycle consolidates memories — dedup, prune, semantic merge.
+//! Without a measurement layer we cannot tell whether these passes *help*
+//! retrieval quality or accidentally destroy high-signal drawers.  A fixed
+//! query set executed before and after each cycle gives us a comparable score
+//! that surfaces regressions early.
+//!
+//! What: Defines `BENCHMARK_QUERIES` — 8 topic-spanning string literals chosen
+//! to probe the kinds of facts a typical coding assistant accumulates across
+//! common domains (tooling, architecture, workflow, conventions, testing,
+//! infrastructure, performance, and debugging). `run_benchmark` embeds each
+//! query against the palace, collects the top-3 retrieval scores, and returns
+//! the mean.  If the palace is empty, the embedder is unavailable, or any
+//! individual query fails, the function degrades gracefully rather than
+//! panicking or poisoning the dream cycle.
+//!
+//! Test: `dream_recall_benchmark_empty_palace_returns_none`,
+//! `dream_recall_benchmark_returns_score_with_drawers`, and
+//! `dream_recall_benchmark_compression_ratio_math` in `dream::tests`.
+
+use crate::memory_core::retrieval::{PalaceHandle, shared_embedder};
+use crate::memory_core::store::vector::VectorStore;
+use std::sync::Arc;
+
+/// Fixed set of representative recall queries used to measure retrieval
+/// quality before and after a dream cycle.
+///
+/// Why: The queries span eight common knowledge domains that accumulate in
+/// an engineering assistant's memory palace — tooling, architecture,
+/// conventions, workflow, testing, infrastructure, performance, and
+/// debugging. Fixing the set makes scores comparable across cycles and
+/// deployments; changing it would invalidate historical comparisons.
+///
+/// What: Static string literals. Each query is run through the same L2
+/// embedding + vector search path the user-facing `recall` call uses.
+/// Adding or removing entries here constitutes a breaking change to the
+/// benchmark; update the doc comment and tests accordingly.
+///
+/// Test: `dream_recall_benchmark_returns_score_with_drawers` runs all
+/// queries against a seeded palace and asserts the score is in [0, 1].
+pub(super) const BENCHMARK_QUERIES: &[&str] = &[
+    // Domain 1 — Tooling & build system
+    "cargo build and test commands for the workspace",
+    // Domain 2 — Architecture & crate structure
+    "how are crates organized and shared in the workspace",
+    // Domain 3 — Code conventions & style
+    "error handling patterns with thiserror and anyhow",
+    // Domain 4 — Workflow & release process
+    "how to create a git tag and publish a crate",
+    // Domain 5 — Testing strategy
+    "unit test patterns and mock usage in Rust tests",
+    // Domain 6 — Infrastructure & deployment
+    "daemon startup and graceful shutdown with SIGTERM",
+    // Domain 7 — Performance & optimisation
+    "HNSW vector search performance and batch embedding",
+    // Domain 8 — Debugging & diagnostics
+    "how to trace and debug slow recall queries",
+];
+
+/// Run the fixed benchmark against `handle` and return the mean top-3 score.
+///
+/// Why: Wrapping the benchmark in a standalone `async fn` keeps `dream_cycle`
+/// readable and makes the benchmarking logic independently testable.  The
+/// function is intentionally non-panicking: any failure (empty palace,
+/// embedder unavailable, individual query error) records `None` rather than
+/// propagating an error and aborting the dream cycle.
+///
+/// What: For each query in `BENCHMARK_QUERIES`, embeds it via the shared
+/// embedder and queries the vector store for the top 3 hits.  The mean score
+/// across all queries × all (up to 3) hits is returned.  When no hits are
+/// found for *any* query (empty palace), returns `None`.
+///
+/// Test: `dream_recall_benchmark_empty_palace_returns_none` asserts `None`
+/// on an empty palace; `dream_recall_benchmark_returns_score_with_drawers`
+/// seeds the palace and asserts a `Some(score)` in `[0.0, 1.0]`.
+pub(super) async fn run_benchmark(handle: &Arc<PalaceHandle>) -> Option<f64> {
+    // Guard: if there are no drawers the vector store returns nothing useful.
+    if handle.drawers.read().is_empty() {
+        tracing::debug!(
+            palace = %handle.id,
+            "dream recall benchmark: palace empty, skipping"
+        );
+        return None;
+    }
+
+    let embedder = match shared_embedder().await {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(
+                palace = %handle.id,
+                "dream recall benchmark: embedder unavailable, skipping: {e:#}"
+            );
+            return None;
+        }
+    };
+
+    let mut total_score: f64 = 0.0;
+    let mut total_hits: usize = 0;
+
+    for &query in BENCHMARK_QUERIES {
+        let vectors = match embedder.embed_batch(&[query.to_string()]).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    palace = %handle.id,
+                    query,
+                    "dream recall benchmark: embed failed, skipping query: {e:#}"
+                );
+                continue;
+            }
+        };
+
+        let Some(query_vec) = vectors.into_iter().next() else {
+            continue;
+        };
+
+        let hits = match handle.vector_store.search(&query_vec, 3).await {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(
+                    palace = %handle.id,
+                    query,
+                    "dream recall benchmark: search failed, skipping query: {e:#}"
+                );
+                continue;
+            }
+        };
+
+        for hit in &hits {
+            total_score += hit.score as f64;
+            total_hits += 1;
+        }
+    }
+
+    if total_hits == 0 {
+        tracing::debug!(
+            palace = %handle.id,
+            "dream recall benchmark: no hits across all queries (palace may be empty)"
+        );
+        return None;
+    }
+
+    let mean = total_score / total_hits as f64;
+    tracing::debug!(
+        palace = %handle.id,
+        mean_score = mean,
+        total_hits,
+        "dream recall benchmark complete"
+    );
+    Some(mean)
+}

--- a/crates/trusty-common/src/memory_core/dream/recall_benchmark.rs
+++ b/crates/trusty-common/src/memory_core/dream/recall_benchmark.rs
@@ -38,7 +38,8 @@ use std::sync::Arc;
 /// benchmark; update the doc comment and tests accordingly.
 ///
 /// Test: `dream_recall_benchmark_returns_score_with_drawers` runs all
-/// queries against a seeded palace and asserts the score is in [0, 1].
+/// queries against a seeded palace and asserts the score is finite and
+/// non-negative.
 pub(super) const BENCHMARK_QUERIES: &[&str] = &[
     // Domain 1 — Tooling & build system
     "cargo build and test commands for the workspace",
@@ -67,13 +68,16 @@ pub(super) const BENCHMARK_QUERIES: &[&str] = &[
 /// propagating an error and aborting the dream cycle.
 ///
 /// What: For each query in `BENCHMARK_QUERIES`, embeds it via the shared
-/// embedder and queries the vector store for the top 3 hits.  The mean score
-/// across all queries × all (up to 3) hits is returned.  When no hits are
-/// found for *any* query (empty palace), returns `None`.
+/// embedder and queries the vector store for the top 3 hits.  Returns the
+/// mean top-3 native similarity score returned by the vector store; higher
+/// is better; exact range depends on the store's distance metric.  When no
+/// hits are found for *any* query (empty palace), returns `None`.
 ///
 /// Test: `dream_recall_benchmark_empty_palace_returns_none` asserts `None`
 /// on an empty palace; `dream_recall_benchmark_returns_score_with_drawers`
-/// seeds the palace and asserts a `Some(score)` in `[0.0, 1.0]`.
+/// seeds the palace and asserts a `Some(score)` that is finite and
+/// non-negative; the exact upper bound depends on the vector store's
+/// distance metric.
 pub(super) async fn run_benchmark(handle: &Arc<PalaceHandle>) -> Option<f64> {
     // Guard: if there are no drawers the vector store returns nothing useful.
     if handle.drawers.read().is_empty() {

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -23,6 +23,10 @@ fn dream_config_defaults() {
         "content-quality pruning is on by default"
     );
     assert_eq!(cfg.content_prune_min_words, 4);
+    assert!(
+        cfg.recall_benchmark_enabled,
+        "recall benchmark is enabled by default"
+    );
 }
 
 /// Why: `touch` must reset the idle clock; with `idle_secs=0` `is_idle`
@@ -760,6 +764,25 @@ fn dream_compression_ratio_zero_drawers() {
     );
 }
 
+/// Why: The semantic consolidation phase can add canonical drawers, causing
+/// `drawers_after > drawers_before`. The ratio must be clamped to 0.0 and
+/// must not panic.
+/// What: Directly construct `DreamStats` with `drawers_after > drawers_before`
+/// and assert `compression_ratio == 0.0`.
+/// Test: This test itself.
+#[test]
+fn dream_compression_ratio_net_growth() {
+    let mut stats = DreamStats {
+        drawers_before: 5,
+        drawers_after: 8, // net growth
+        ..DreamStats::default()
+    };
+    stats.update_compression_ratio();
+    assert_eq!(
+        stats.compression_ratio, 0.0,
+        "net palace growth (after > before) must clamp compression_ratio to 0.0"
+    );
+}
 /// Why: `DreamStats` adds `f64` fields so the old `Eq` bound is gone;
 /// verify serde round-trips preserve all new fields faithfully.
 /// What: Construct a `DreamStats` with non-default effectiveness fields,
@@ -950,8 +973,8 @@ async fn dream_recall_benchmark_returns_score_with_drawers() {
     let result = super::recall_benchmark::run_benchmark(&handle).await;
     let score = result.expect("expected Some(score) with seeded drawers");
     assert!(
-        (0.0..=1.0).contains(&score),
-        "recall benchmark score must be in [0, 1]; got {score}"
+        score.is_finite() && score >= 0.0,
+        "recall benchmark score must be finite and non-negative; got {score}"
     );
 }
 
@@ -989,12 +1012,12 @@ async fn dream_cycle_records_recall_scores() {
     let before = stats.recall_score_before.unwrap();
     let after = stats.recall_score_after.unwrap();
     assert!(
-        (0.0..=1.0).contains(&before),
-        "recall_score_before={before} out of range"
+        before.is_finite() && before >= 0.0,
+        "recall_score_before={before} must be finite and non-negative"
     );
     assert!(
-        (0.0..=1.0).contains(&after),
-        "recall_score_after={after} out of range"
+        after.is_finite() && after >= 0.0,
+        "recall_score_after={after} must be finite and non-negative"
     );
 }
 
@@ -1044,6 +1067,53 @@ async fn dream_stats_effectiveness_fields_persisted() {
     assert_eq!(
         loaded.stats.recall_score_after, stats.recall_score_after,
         "recall_score_after must be persisted"
+    );
+}
+
+/// Why: The recall benchmark adds two full embed+search passes per cycle.
+/// When `recall_benchmark_enabled = false`, both passes must be skipped and
+/// both recall score fields must be `None`, while the cycle itself completes
+/// normally.
+/// What: Run `dream_cycle` with `recall_benchmark_enabled = false` on a
+/// seeded palace and assert both `recall_score_before` and
+/// `recall_score_after` are `None`.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_cycle_recall_benchmark_disabled() {
+    let handle = open_test_handle("dream-bench-disabled").await;
+    handle
+        .remember(
+            "recall benchmark opt-out test drawer".into(),
+            RoomType::General,
+            vec![],
+            0.6,
+        )
+        .await
+        .unwrap();
+
+    let dreamer = Dreamer::new(DreamConfig {
+        recall_benchmark_enabled: false,
+        dedup_threshold: 0.999, // nothing removed
+        ..DreamConfig::default()
+    });
+    let stats = dreamer.dream_cycle(&handle).await.unwrap();
+
+    assert_eq!(
+        stats.recall_score_before, None,
+        "recall_score_before must be None when benchmark is disabled"
+    );
+    assert_eq!(
+        stats.recall_score_after, None,
+        "recall_score_after must be None when benchmark is disabled"
+    );
+    // Cycle must still complete and report drawer counts.
+    assert_eq!(
+        stats.drawers_before, 1,
+        "drawers_before must still be counted"
+    );
+    assert_eq!(
+        stats.drawers_after, 1,
+        "drawers_after must still be counted"
     );
 }
 

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -719,6 +719,334 @@ async fn dream_cycle_semantic_consolidation_disabled_by_config() {
     );
 }
 
+// ─── Effectiveness metrics tests (issue #1530) ───────────────────────────
+
+/// Why: The compression ratio is the key effectiveness signal; guard its
+/// arithmetic against common edge cases (normal case, zero drawers).
+/// What: Directly constructs `DreamStats` with known field values and
+/// asserts `update_compression_ratio` sets the expected ratio.
+/// Test: This test itself.
+#[test]
+fn dream_compression_ratio_math() {
+    let mut stats = DreamStats {
+        drawers_before: 10,
+        drawers_after: 7,
+        ..DreamStats::default()
+    };
+    stats.update_compression_ratio();
+    // (10 - 7) / 10 = 0.3
+    let diff = (stats.compression_ratio - 0.3_f64).abs();
+    assert!(
+        diff < 1e-10,
+        "expected 0.3, got {}",
+        stats.compression_ratio
+    );
+}
+
+/// Why: Guard the divide-by-zero path when the palace starts empty.
+/// What: `drawers_before = 0` must yield `compression_ratio = 0.0`.
+/// Test: This test itself.
+#[test]
+fn dream_compression_ratio_zero_drawers() {
+    let mut stats = DreamStats {
+        drawers_before: 0,
+        drawers_after: 0,
+        ..DreamStats::default()
+    };
+    stats.update_compression_ratio();
+    assert_eq!(
+        stats.compression_ratio, 0.0,
+        "zero drawers_before must produce 0.0 compression_ratio"
+    );
+}
+
+/// Why: `DreamStats` adds `f64` fields so the old `Eq` bound is gone;
+/// verify serde round-trips preserve all new fields faithfully.
+/// What: Construct a `DreamStats` with non-default effectiveness fields,
+/// serialize to JSON, deserialize back, and assert equality on each field.
+/// Test: This test itself.
+#[test]
+fn dream_stats_serde_roundtrip_new_fields() {
+    let original = DreamStats {
+        merged: 2,
+        pruned: 1,
+        drawers_before: 8,
+        drawers_after: 5,
+        compression_ratio: 0.375,
+        recall_score_before: Some(0.72),
+        recall_score_after: Some(0.81),
+        duration_ms: 1200,
+        ..DreamStats::default()
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    let decoded: DreamStats = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(decoded.drawers_before, 8);
+    assert_eq!(decoded.drawers_after, 5);
+    let cr_diff = (decoded.compression_ratio - 0.375_f64).abs();
+    assert!(cr_diff < 1e-10, "compression_ratio round-trip failed");
+    assert_eq!(decoded.recall_score_before, Some(0.72));
+    assert_eq!(decoded.recall_score_after, Some(0.81));
+    assert_eq!(decoded.merged, 2);
+    assert_eq!(decoded.duration_ms, 1200);
+}
+
+/// Why: Old `dream_stats.json` files written before this PR lack the new
+/// fields. `#[serde(default)]` must allow them to deserialize without error,
+/// defaulting new fields to zero / None.
+/// What: Deserializes a JSON string that only contains the fields present
+/// before issue #1530, then asserts the new fields are at their defaults.
+/// Test: This test itself.
+#[test]
+fn dream_stats_backward_compat() {
+    // A dream_stats.json as written by the pre-#1530 code.
+    let legacy_json = r#"{
+        "merged": 3,
+        "pruned": 1,
+        "closets_updated": 12,
+        "compacted": 0,
+        "content_pruned": 2,
+        "semantically_consolidated": 0,
+        "semantic_llm_calls": 0,
+        "semantic_cache_hits": 0,
+        "duration_ms": 800
+    }"#;
+    let decoded: DreamStats =
+        serde_json::from_str(legacy_json).expect("backward-compat deserialize must succeed");
+    assert_eq!(decoded.merged, 3);
+    assert_eq!(decoded.drawers_before, 0, "missing field must default to 0");
+    assert_eq!(decoded.drawers_after, 0, "missing field must default to 0");
+    assert_eq!(
+        decoded.compression_ratio, 0.0,
+        "missing field must default to 0.0"
+    );
+    assert_eq!(
+        decoded.recall_score_before, None,
+        "missing Option field must default to None"
+    );
+    assert_eq!(
+        decoded.recall_score_after, None,
+        "missing Option field must default to None"
+    );
+}
+
+/// Why: After a dream cycle the stats must include drawer counts that
+/// reflect the actual palace state before and after consolidation passes.
+/// What: Seed one drawer, run a dream cycle with high dedup threshold so
+/// nothing is removed, and assert `drawers_before == drawers_after == 1`.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_cycle_records_drawer_counts() {
+    let handle = open_test_handle("dream-drawer-counts").await;
+    handle
+        .remember(
+            "drawer count baseline for effectiveness metrics".into(),
+            RoomType::General,
+            vec![],
+            0.6,
+        )
+        .await
+        .unwrap();
+
+    let dreamer = Dreamer::new(DreamConfig {
+        dedup_threshold: 0.999, // nothing deduped
+        ..DreamConfig::default()
+    });
+    let stats = dreamer.dream_cycle(&handle).await.unwrap();
+
+    assert_eq!(stats.drawers_before, 1, "expected 1 drawer before");
+    assert_eq!(
+        stats.drawers_after, 1,
+        "expected 1 drawer after (none removed)"
+    );
+    // Compression ratio: (1 - 1) / 1 = 0.0
+    assert_eq!(
+        stats.compression_ratio, 0.0,
+        "no drawers removed → ratio 0.0"
+    );
+}
+
+/// Why: When the dedup pass removes a drawer, `drawers_after < drawers_before`
+/// and the compression ratio must be non-zero.
+/// What: Insert two identical drawers, run a cycle, assert `compression_ratio > 0`.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_cycle_compression_ratio_nonzero_after_dedup() {
+    let handle = open_test_handle("dream-compress-nonzero").await;
+    handle
+        .remember(
+            "duplicate drawer for compression test".into(),
+            RoomType::General,
+            vec![],
+            0.7,
+        )
+        .await
+        .unwrap();
+    handle
+        .remember(
+            "duplicate drawer for compression test".into(),
+            RoomType::General,
+            vec![],
+            0.6,
+        )
+        .await
+        .unwrap();
+    assert_eq!(handle.drawers.read().len(), 2);
+
+    let dreamer = Dreamer::new(DreamConfig::default());
+    let stats = dreamer.dream_cycle(&handle).await.unwrap();
+
+    assert_eq!(stats.drawers_before, 2, "two drawers before cycle");
+    assert_eq!(stats.drawers_after, 1, "one remaining after dedup");
+    // (2 - 1) / 2 = 0.5
+    let diff = (stats.compression_ratio - 0.5_f64).abs();
+    assert!(
+        diff < 1e-10,
+        "expected compression_ratio=0.5, got {}",
+        stats.compression_ratio
+    );
+}
+
+/// Why: An empty palace must not cause the recall benchmark to panic or
+/// return a misleading score. `run_benchmark` must return `None`.
+/// What: Run `run_benchmark` directly on an empty palace and assert `None`.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_recall_benchmark_empty_palace_returns_none() {
+    let handle = open_test_handle("dream-bench-empty").await;
+    // Palace is empty — no drawers seeded.
+    let result = super::recall_benchmark::run_benchmark(&handle).await;
+    assert_eq!(
+        result, None,
+        "empty palace must yield None from recall benchmark"
+    );
+}
+
+/// Why: With at least one drawer, the recall benchmark must return a score
+/// in the valid [0, 1] range.
+/// What: Seed two drawers, run the benchmark, assert `Some(score)` in range.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_recall_benchmark_returns_score_with_drawers() {
+    let handle = open_test_handle("dream-bench-score").await;
+    handle
+        .remember(
+            "cargo build and test commands for the Rust workspace".into(),
+            RoomType::Backend,
+            vec!["cargo".into()],
+            0.8,
+        )
+        .await
+        .unwrap();
+    handle
+        .remember(
+            "error handling with thiserror for libraries and anyhow for binaries".into(),
+            RoomType::Backend,
+            vec!["errors".into()],
+            0.7,
+        )
+        .await
+        .unwrap();
+
+    let result = super::recall_benchmark::run_benchmark(&handle).await;
+    let score = result.expect("expected Some(score) with seeded drawers");
+    assert!(
+        (0.0..=1.0).contains(&score),
+        "recall benchmark score must be in [0, 1]; got {score}"
+    );
+}
+
+/// Why: The dream cycle must record both pre- and post-cycle recall scores
+/// in the returned stats so they land in dream_stats.json.
+/// What: Seed a drawer, run the cycle, assert both score fields are Some.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_cycle_records_recall_scores() {
+    let handle = open_test_handle("dream-recall-scores").await;
+    handle
+        .remember(
+            "HNSW vector search and batch embedding performance patterns".into(),
+            RoomType::Backend,
+            vec!["hnsw".into(), "embedding".into()],
+            0.8,
+        )
+        .await
+        .unwrap();
+
+    let dreamer = Dreamer::new(DreamConfig {
+        dedup_threshold: 0.999, // nothing removed
+        ..DreamConfig::default()
+    });
+    let stats = dreamer.dream_cycle(&handle).await.unwrap();
+
+    assert!(
+        stats.recall_score_before.is_some(),
+        "recall_score_before must be Some with a seeded palace"
+    );
+    assert!(
+        stats.recall_score_after.is_some(),
+        "recall_score_after must be Some with a seeded palace"
+    );
+    let before = stats.recall_score_before.unwrap();
+    let after = stats.recall_score_after.unwrap();
+    assert!(
+        (0.0..=1.0).contains(&before),
+        "recall_score_before={before} out of range"
+    );
+    assert!(
+        (0.0..=1.0).contains(&after),
+        "recall_score_after={after} out of range"
+    );
+}
+
+/// Why: Effectiveness fields must survive a round-trip through
+/// `PersistedDreamStats::save` → `PersistedDreamStats::load`.
+/// What: Run a cycle with seeded drawers, write to disk, read back, and
+/// assert all effectiveness fields match.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_stats_effectiveness_fields_persisted() {
+    let handle = open_test_handle("dream-persist-eff").await;
+    handle
+        .remember(
+            "unit test patterns and mock usage in Rust tests".into(),
+            RoomType::General,
+            vec!["testing".into()],
+            0.7,
+        )
+        .await
+        .unwrap();
+
+    let dreamer = Dreamer::new(DreamConfig {
+        dedup_threshold: 0.999,
+        ..DreamConfig::default()
+    });
+    let stats = dreamer.dream_cycle(&handle).await.unwrap();
+
+    let data_dir = handle.data_dir.clone().expect("data_dir set");
+    let loaded = PersistedDreamStats::load(&data_dir)
+        .unwrap()
+        .expect("dream_stats.json must exist after cycle");
+
+    assert_eq!(
+        loaded.stats.drawers_before, stats.drawers_before,
+        "drawers_before must be persisted"
+    );
+    assert_eq!(
+        loaded.stats.drawers_after, stats.drawers_after,
+        "drawers_after must be persisted"
+    );
+    let cr_diff = (loaded.stats.compression_ratio - stats.compression_ratio).abs();
+    assert!(cr_diff < 1e-10, "compression_ratio must be persisted");
+    assert_eq!(
+        loaded.stats.recall_score_before, stats.recall_score_before,
+        "recall_score_before must be persisted"
+    );
+    assert_eq!(
+        loaded.stats.recall_score_after, stats.recall_score_after,
+        "recall_score_after must be persisted"
+    );
+}
+
 // ─── RAII env-var guard for tests ────────────────────────────────────────
 //
 // Safety: test-only; the tokio::test macro with default settings uses the


### PR DESCRIPTION
Implements #1530 (part of epic #1531).

## What
Adds the measurement layer to the trusty-memory dreaming subsystem so dream cycles are provably effective:
- `DreamStats` gains `drawers_before`, `drawers_after`, `compression_ratio` (divide-by-zero guarded), and `recall_score_before` / `recall_score_after` (`Option<f64>`), all `#[serde(default)]` for backward compatibility with existing `dream_stats.json` files.
- New `recall_benchmark` module with a fixed, documented set of 8 representative recall queries; runs pre/post cycle and records mean top-3 retrieval scores.
- Drawer counts captured at cycle entry/exit; compression ratio derived and persisted.
- Benchmark degrades gracefully (records `None`) when the palace is empty or the embedder/inference is unavailable, and never aborts a dream cycle.

## Acceptance criteria (all met)
- ✅ DreamStats includes drawers_before/drawers_after
- ✅ dream_stats.json shows compression ratio per cycle
- ✅ Fixed recall benchmark defined and documented
- ✅ Pre/post recall scores stored for cross-run comparison
- ✅ Backward-compatible deserialization of old stats files

## Verification
- `cargo check` (workspace), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `bash scripts/check_line_cap.sh` — all clean
- `cargo test -p trusty-common` and `cargo test -p trusty-memory` — green (one pre-existing env-dependent failure `inference_available_false_without_key` unrelated to this change)
- 9 new unit tests: compression-ratio math incl. divide-by-zero, serde round-trip, serde backward-compat, benchmark graceful-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)