### PR TITLE
fix(trusty-search): anchor Makefile sync-ui paths to makefile dir so it works from workspace root (closes #1540)

### DIFF
--- a/crates/trusty-search/Makefile
+++ b/crates/trusty-search/Makefile
@@ -11,9 +11,14 @@
 # Test: `make release-prep` populates `ui-dist/index.html` and the `assets/` tree.
 
 CLOSES      ?=
-UI_DIR      := ui
+# Why: paths must resolve to this crate dir regardless of the invoking CWD, so
+# `make -C crates/trusty-search sync-ui` from the workspace root produces a
+# correct `ui-dist/` (not a nested `ui-dist/dist/`) — see issue #1540.
+# What: anchor every UI path to the directory containing THIS Makefile.
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+UI_DIR      := $(MAKEFILE_DIR)ui
 UI_DIST     := $(UI_DIR)/dist
-UI_EMBED    := ui-dist
+UI_EMBED    := $(MAKEFILE_DIR)ui-dist
 
 .PHONY: ui build-ui sync-ui release-prep install patch reinstall deploy check clippy test smoke
 


### PR DESCRIPTION
Fixes #1540.

**What/Why:** The `crates/trusty-search/Makefile` `build-ui`/`sync-ui` targets used CWD-relative paths (`UI_DIR := ui`, `UI_EMBED := ui-dist`). They only resolved when `make` ran from inside `crates/trusty-search/`. Running `make -C crates/trusty-search sync-ui` from the workspace root made `cp -r $(UI_DIST) $(UI_EMBED)` produce a wrong `ui-dist/dist/` nesting (or fail "no such file"). Since `release-prep` chains `build-ui` → `sync-ui` and is the publish prerequisite, building from a workspace-root shell could embed stale/misplaced UI assets.

**Fix:** Anchor every UI path to the Makefile's own directory via the standard GNU make idiom `$(dir $(abspath $(lastword $(MAKEFILE_LIST))))`, so the targets are correct regardless of the invoking CWD. Behavior from inside the crate dir is unchanged.

**How verified:**
- `make -C crates/trusty-search build-ui sync-ui` from the **workspace root**: `ui-dist/index.html` exists, **no** `ui-dist/dist/` nesting. ✅
- `make sync-ui` from **inside** `crates/trusty-search/`: same correct layout. ✅
- `bash scripts/check_line_cap.sh`: exit 0. ✅
- `git diff --stat`: only the Makefile changed (7 insertions, 2 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)