### PR TITLE
feat(trusty-mpm): WI-10 managed-session auth — tm login (keychain) + ANTHROPIC_API_KEY/--bare fallback (refs #1548)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -469,6 +469,22 @@ pub(crate) enum Command {
         alias: String,
     },
 
+    /// One-time keychain login for managed `tm run` sessions (WI-10, DOC-24).
+    ///
+    /// Why: `CLAUDE_CONFIG_DIR` relocates the macOS Keychain entry used for
+    /// Claude Max/Pro OAuth (A9). A fresh `~/.trusty-mpm/claude-config/` has
+    /// no keychain entry, so `tm run` reports "Not logged in". `tm login` runs
+    /// `claude auth login` under the tm-global `CLAUDE_CONFIG_DIR` so the
+    /// OAuth flow creates a keychain entry for that path. This is a one-time
+    /// setup — the entry persists across sessions on this machine.
+    /// What: ensures the tm-global config dir exists, spawns
+    /// `claude auth login` with `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config`
+    /// and inherited stdio, prints guidance before/after the OAuth flow.
+    /// Alternative: set `ANTHROPIC_API_KEY` to use the API-key+`--bare` path
+    /// instead (for CI/automation, no login required).
+    /// Test: `cli_parses_login_standalone`.
+    Login,
+
     /// Standalone metaharness — PM + sub-agent delegation without the daemon (#1045).
     ///
     /// Why: the M1 POC (issue #1045) builds a self-contained metaharness that

--- a/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
@@ -1,11 +1,15 @@
-//! CLI command handlers for the standalone managed driver (`tm register/load/run/ls/path`).
+//! CLI command handlers for the standalone managed driver (`tm register/load/run/ls/path/login`).
 //!
 //! Why: the standalone managed driver adds a new alias-keyed registry and
 //! lifecycle on top of the existing session-manager machinery (DOC-24). Keeping
 //! these handlers in their own file preserves the existing handlers untouched
 //! and stays under the 500-SLOC cap.
-//! What: five thin handlers — `register_cmd`, `ls_cmd`, `load_cmd`, `run_cmd`,
-//! and `path_cmd` — each delegating to `trusty_mpm::core::standalone`.
+//! What: six thin handlers — `register_cmd`, `ls_cmd`, `load_cmd`, `run_cmd`,
+//! `path_cmd`, and `login_cmd` — each delegating to
+//! `trusty_mpm::core::standalone`. `login_cmd` (WI-10) launches
+//! `claude auth login` under the tm-global CLAUDE_CONFIG_DIR so the OAuth flow
+//! creates a keychain entry for that path, enabling future `tm run` sessions to
+//! authenticate on the user's Claude Max/Pro plan.
 //! Test: exercised by `cli_parses_register`, `cli_parses_ls`, etc. in tests.rs.
 
 use anyhow::Context;
@@ -138,5 +142,54 @@ pub(crate) fn path_cmd(alias: &str) -> anyhow::Result<()> {
     let repo = trusty_mpm::core::standalone::run::resolve_repo_path(alias, &root)
         .with_context(|| format!("failed to resolve path for alias '{alias}'"))?;
     println!("{}", repo.display());
+    Ok(())
+}
+
+/// Handle `tm login` (WI-10 — one-time keychain auth setup).
+///
+/// Why: `CLAUDE_CONFIG_DIR` (A9) relocates the entire `~/.claude/` tree including
+/// the macOS Keychain entry used for Claude Max/Pro OAuth. A fresh
+/// `~/.trusty-mpm/claude-config/` has no keychain entry, so `tm run` sessions
+/// report "Not logged in". `tm login` runs `claude auth login` under the
+/// tm-global `CLAUDE_CONFIG_DIR` so the OAuth flow creates a keychain entry
+/// keyed to that path, enabling all future `tm run` sessions to authenticate
+/// without repeating this step (keychain entry persists across sessions).
+/// What: ensures the tm-global config dir exists via
+/// `ensure_global_config_dir`, then spawns `claude auth login` with
+/// `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` and inherited stdio so the
+/// user can complete the browser/OAuth flow. Prints guidance before and after.
+/// Test: command construction is unit-tested via
+/// `test_build_login_command_sets_env_and_invocation` in
+/// `core::standalone::run`. The interactive OAuth completion requires a human.
+pub(crate) fn login_cmd() -> anyhow::Result<()> {
+    let root = managed_root()?;
+    let cfg_dir = claude_config_dir()?;
+    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(&root, &cfg_dir)?;
+
+    eprintln!(
+        "tm login: one-time setup — authenticates managed `tm run` sessions\n\
+         on your Claude Max/Pro plan via the macOS Keychain.\n\
+         Config dir: {}\n\
+         Launching `claude auth login` — complete the browser OAuth flow...",
+        cfg_dir.display()
+    );
+
+    let status = trusty_mpm::core::standalone::run::build_login_command(&cfg_dir)
+        .status()
+        .context("failed to spawn 'claude auth login'; is `claude` installed and on PATH?")?;
+
+    if status.success() {
+        eprintln!(
+            "tm login: authentication complete.\n\
+             You can now run `tm run <alias>` — sessions will authenticate\n\
+             on your Claude plan automatically (no ANTHROPIC_API_KEY needed)."
+        );
+    } else {
+        eprintln!(
+            "tm login: `claude auth login` exited with {status}.\n\
+             If the OAuth flow was cancelled, run `tm login` again to retry.\n\
+             Alternatively, export ANTHROPIC_API_KEY to use the API-key path instead."
+        );
+    }
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
@@ -158,9 +158,14 @@ pub(crate) fn path_cmd(alias: &str) -> anyhow::Result<()> {
 /// `ensure_global_config_dir`, then spawns `claude auth login` with
 /// `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` and inherited stdio so the
 /// user can complete the browser/OAuth flow. Prints guidance before and after.
+/// Returns an error (non-zero exit) when `claude auth login` fails or is
+/// cancelled so that `tm login && tm run …` does not proceed after a failed
+/// login.
 /// Test: command construction is unit-tested via
 /// `test_build_login_command_sets_env_and_invocation` in
-/// `core::standalone::run`. The interactive OAuth completion requires a human.
+/// `core::standalone::run`. Exit-code propagation is covered by reasoning: the
+/// `bail!` path is reached whenever `status.success()` is false. The interactive
+/// OAuth completion requires a human.
 pub(crate) fn login_cmd() -> anyhow::Result<()> {
     let root = managed_root()?;
     let cfg_dir = claude_config_dir()?;
@@ -184,12 +189,13 @@ pub(crate) fn login_cmd() -> anyhow::Result<()> {
              You can now run `tm run <alias>` — sessions will authenticate\n\
              on your Claude plan automatically (no ANTHROPIC_API_KEY needed)."
         );
+        Ok(())
     } else {
         eprintln!(
             "tm login: `claude auth login` exited with {status}.\n\
              If the OAuth flow was cancelled, run `tm login` again to retry.\n\
              Alternatively, export ANTHROPIC_API_KEY to use the API-key path instead."
         );
+        anyhow::bail!("claude auth login failed: {status}")
     }
-    Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -300,6 +300,7 @@ async fn main() -> anyhow::Result<()> {
             commands::standalone::run_cmd(&alias)
         }
         Command::Path { alias } => commands::standalone::path_cmd(&alias),
+        Command::Login => commands::standalone::login_cmd(),
     };
 
     // Top-level exit-code translation: a `tm sessions prune-idle` that found the

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1541,3 +1541,14 @@ fn cli_parses_watch_listen_with_interval() {
         other => panic!("expected watch listen, got {other:?}"),
     }
 }
+
+// WI-10: `tm login` must parse to Command::Login.
+#[test]
+fn cli_parses_login_standalone() {
+    // Why: `tm login` is the one-time keychain auth command (WI-10). It must
+    // parse cleanly to the Login variant with no required arguments.
+    // What: assert that `tm login` maps to Command::Login.
+    // Test: direct parse round-trip.
+    let cli = Cli::try_parse_from(["trusty-mpm", "login"]).unwrap();
+    assert!(matches!(cli.command, Command::Login));
+}

--- a/crates/trusty-mpm/src/core/standalone/global_config.rs
+++ b/crates/trusty-mpm/src/core/standalone/global_config.rs
@@ -3,13 +3,31 @@
 //! Why: DOC-24 SPEC-STANDALONE-MPM-03 requires a single, shared user-level
 //! config directory that supplies the global hooks, global skills/slash-commands,
 //! and global MCP servers for ALL tm-launched sessions. Claude Code is pointed at
-//! it via the required `CLAUDE_CONFIG_DIR` env var; without it every session
-//! would be unauthenticated ("Not logged in"). This module creates that dir once
-//! and never regenerates it per project.
+//! it via the required `CLAUDE_CONFIG_DIR` env var.
+//! This module creates that dir once and never regenerates it per project.
 //! What: [`ensure_global_config_dir`] creates `<managed_root>/claude-config/`,
 //! writes a minimal `settings.json`, seeds `.credentials.json` from
-//! `~/.claude/.credentials.json` if it exists, and writes a minimal `.mcp.json`
-//! with trusty-memory and trusty-search server stubs.
+//! `~/.claude/.credentials.json` if it exists (NOTE: this file holds MCP OAuth
+//! tokens, NOT the primary session auth — see WI-10 for the auth model), and
+//! writes a minimal `.mcp.json` with trusty-memory and trusty-search server stubs.
+//!
+//! # WI-10 Auth Model
+//!
+//! Primary session auth (`claude` on a Claude Max/Pro plan) uses the macOS
+//! Keychain keyed by the `CLAUDE_CONFIG_DIR` path. Seeding `.credentials.json`
+//! does NOT establish that keychain entry — it only carries MCP OAuth tokens.
+//! The two supported auth paths are:
+//!
+//! 1. **Keychain (default):** run `tm login` once. That command launches
+//!    `claude auth login` under `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config`
+//!    so the OAuth flow creates a keychain entry for that path. All subsequent
+//!    `tm run` sessions authenticate on the Max/Pro plan automatically.
+//!
+//! 2. **API key (`--bare`):** set `ANTHROPIC_API_KEY` in the environment.
+//!    `tm run` detects the key and adds `--bare` to the `claude` invocation,
+//!    which bypasses keychain/OAuth and uses the API key directly. Useful for
+//!    CI and automation.
+//!
 //! Test: `test_global_config_dir_ensure_idempotent` in this module.
 
 use std::path::{Path, PathBuf};
@@ -48,6 +66,11 @@ pub fn ensure_global_config_dir(
 /// with explicit `src`/`dst` parameters makes real unit tests possible without
 /// `dirs::home_dir()` inside the hot path (F3 fix; previously the test
 /// replicated the logic inline rather than calling the production code).
+/// NOTE: `.credentials.json` carries MCP OAuth tokens (trusty-memory etc.),
+/// NOT the primary Claude Max/Pro session auth. Primary session auth requires
+/// a macOS Keychain entry keyed by the `CLAUDE_CONFIG_DIR` path — established
+/// via `tm login` (keychain path) or bypassed by `ANTHROPIC_API_KEY`+`--bare`
+/// (API-key path). See module-level WI-10 doc for details.
 /// What: copies `src` → `dst` when `dst` is missing OR `src` mtime is strictly
 /// newer than `dst`. When `src` is missing the function returns `Ok(())` and
 /// emits a warning. Any metadata error is treated as "copy to be safe".
@@ -62,8 +85,8 @@ pub(crate) fn seed_credentials_from(
 ) -> anyhow::Result<()> {
     if !src.exists() {
         eprintln!(
-            "warning: {} not found; \
-             set ANTHROPIC_API_KEY or run `tm install` to seed credentials",
+            "note: {} not found; MCP OAuth tokens will not be pre-seeded \
+             (primary auth is via `tm login` or ANTHROPIC_API_KEY, not this file)",
             src.display()
         );
         return Ok(());
@@ -88,17 +111,19 @@ pub(crate) fn seed_credentials_from(
     Ok(())
 }
 
-/// Copy `~/.claude/.credentials.json` into the tm-global config dir.
+/// Copy `~/.claude/.credentials.json` into the tm-global config dir (MCP tokens).
 ///
-/// Why: CLAUDE_CONFIG_DIR relocates the entire user-level layer including
-/// `.credentials.json` (validated 2026-06-22 / v2.1.185, A9). Without seeding
-/// the file the session is unauthenticated. Delegates to `seed_credentials_from`
-/// so the mtime-comparison and copy logic is unit-testable with explicit paths.
+/// Why: `.credentials.json` carries MCP OAuth tokens (trusty-memory, etc.) which
+/// are useful to pre-seed so managed sessions can reach those MCP servers. NOTE:
+/// this does NOT establish primary Claude Max/Pro session auth — that requires a
+/// macOS Keychain entry keyed by the `CLAUDE_CONFIG_DIR` path, established via
+/// `tm login` (keychain path). See module-level WI-10 auth model.
+/// Delegates to `seed_credentials_from` so the mtime-comparison and copy logic
+/// is unit-testable with explicit paths. Silently warns when the home dir or src
+/// is absent (non-blocking; primary auth is independent of this file).
 /// What: resolves `src = ~/.claude/.credentials.json` and
-/// `dst = <claude_config_dir>/.credentials.json`, then delegates to
-/// `seed_credentials_from`. Silently warns (no error) when home dir is
-/// unresolvable.
-/// Credential contents are never logged.
+/// `dst = <claude_config_dir>/.credentials.json`, delegates to
+/// `seed_credentials_from`. Credential contents are never logged.
 /// Test: `test_seed_credentials_skips_when_source_missing` exercises the
 /// missing-source path via `ensure_global_config_dir`. Direct logic is covered
 /// by the `seed_credentials_from` tests.

--- a/crates/trusty-mpm/src/core/standalone/run.rs
+++ b/crates/trusty-mpm/src/core/standalone/run.rs
@@ -20,7 +20,7 @@
 //! `test_check_credentials_with_env_var`.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::Context;
 
@@ -35,9 +35,13 @@ use super::registry::ManagedRegistry;
 /// WI-10 two-path auth model is encoded here: when `api_key` is `Some(_)`, the
 /// `--bare` flag is added so Claude Code bypasses keychain/OAuth and uses the
 /// API key directly; otherwise the keychain entry created by `tm login` is used.
+/// Stdio is set to `Stdio::inherit()` explicitly so the attended interactive
+/// session is always connected to the terminal, even if a future caller switches
+/// from `.status()` to `.output()`.
 /// What: returns a `Command` with program `"claude"`, cwd `repo_path`,
-/// env `CLAUDE_CONFIG_DIR=<claude_config_dir>`, and (when `api_key` is
-/// `Some(s)` with a non-empty `s`) the `--bare` arg. Does NOT spawn.
+/// env `CLAUDE_CONFIG_DIR=<claude_config_dir>`, stdin/stdout/stderr set to
+/// `Stdio::inherit()`, and (when `api_key` is `Some(s)` with a non-empty `s`)
+/// the `--bare` arg. Does NOT spawn.
 /// Test: `test_build_launch_command_sets_env_and_cwd`,
 /// `test_build_launch_command_adds_bare_with_api_key`,
 /// `test_build_launch_command_no_bare_without_api_key`.
@@ -49,6 +53,9 @@ pub fn build_launch_command(
     let mut cmd = Command::new("claude");
     cmd.current_dir(repo_path);
     cmd.env("CLAUDE_CONFIG_DIR", claude_config_dir);
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
     // WI-10: when ANTHROPIC_API_KEY is set, add --bare so Claude Code bypasses
     // keychain/OAuth reads and uses the API key directly. When the key is absent
     // the session relies on the keychain entry created by `tm login`.
@@ -66,15 +73,20 @@ pub fn build_launch_command(
 /// `CLAUDE_CONFIG_DIR=<tm-global-config-dir>` so the resulting keychain entry
 /// is keyed to that dir and `tm run` sessions can authenticate on the user's
 /// Claude Max/Pro plan. Factoring out the command construction makes it
-/// unit-testable without launching a browser.
+/// unit-testable without launching a browser. Stdio inheritance is set
+/// explicitly (not left to the `.status()` default) so a future caller using
+/// `.output()` cannot silently suppress the interactive OAuth prompt.
 /// What: returns a `Command` with program `"claude"`, args `["auth", "login"]`,
-/// and env `CLAUDE_CONFIG_DIR=<claude_config_dir>`. Inherits stdio so the user
-/// can complete the OAuth flow interactively. Does NOT spawn.
+/// env `CLAUDE_CONFIG_DIR=<claude_config_dir>`, and stdin/stdout/stderr all
+/// set to `Stdio::inherit()`. Does NOT spawn.
 /// Test: `test_build_login_command_sets_env_and_invocation`.
 pub fn build_login_command(claude_config_dir: &Path) -> Command {
     let mut cmd = Command::new("claude");
     cmd.args(["auth", "login"]);
     cmd.env("CLAUDE_CONFIG_DIR", claude_config_dir);
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
     cmd
 }
 

--- a/crates/trusty-mpm/src/core/standalone/run.rs
+++ b/crates/trusty-mpm/src/core/standalone/run.rs
@@ -3,13 +3,20 @@
 //! Why: `tm run <alias>` is the claude-mpm replacement — it ensures the alias
 //! is loaded, sets `CLAUDE_CONFIG_DIR` to the tm-global config dir (the
 //! load-bearing isolation primitive, DOC-24 SPEC-STANDALONE-MPM-05c), and
-//! launches `claude` in the project's `repo/` directory. This module is
-//! intentionally unit-testable: `build_launch_command` returns a configured
-//! `Command` without spawning it.
-//! What: three public functions — `build_launch_command` (pure, unit-testable),
-//! `check_credentials` (env check), and `run_alias` (orchestrator that calls
-//! load, checks credentials, builds and spawns the command).
+//! launches `claude` in the project's `repo/` directory. Auth follows the
+//! WI-10 two-path model: when `ANTHROPIC_API_KEY` is set, `claude` is launched
+//! with `--bare` (bypasses keychain/OAuth); otherwise, the session relies on
+//! the keychain entry created by `tm login`. This module is intentionally
+//! unit-testable: `build_launch_command` and `build_login_command` return
+//! configured `Command`s without spawning them.
+//! What: four public functions — `build_launch_command` (pure, unit-testable),
+//! `build_login_command` (pure, unit-testable), `check_credentials` (env check),
+//! and `run_alias` (orchestrator that calls load, checks auth, builds and spawns
+//! the command).
 //! Test: `test_build_launch_command_sets_env_and_cwd`,
+//! `test_build_launch_command_adds_bare_with_api_key`,
+//! `test_build_launch_command_no_bare_without_api_key`,
+//! `test_build_login_command_sets_env_and_invocation`,
 //! `test_check_credentials_with_env_var`.
 
 use std::path::{Path, PathBuf};
@@ -24,78 +31,156 @@ use super::registry::ManagedRegistry;
 ///
 /// Why: separating command construction from spawning makes the launch contract
 /// unit-testable without actually starting a process. The caller (or a test)
-/// can inspect program, current_dir, and env before spawning.
-/// What: returns a `Command` with program `"claude"`, cwd `repo_path`, and
-/// env `CLAUDE_CONFIG_DIR=<claude_config_dir>`. Does NOT spawn the process.
-/// Test: `test_build_launch_command_sets_env_and_cwd`.
-pub fn build_launch_command(repo_path: &Path, claude_config_dir: &Path) -> Command {
+/// can inspect program, current_dir, args, and env before spawning. The
+/// WI-10 two-path auth model is encoded here: when `api_key` is `Some(_)`, the
+/// `--bare` flag is added so Claude Code bypasses keychain/OAuth and uses the
+/// API key directly; otherwise the keychain entry created by `tm login` is used.
+/// What: returns a `Command` with program `"claude"`, cwd `repo_path`,
+/// env `CLAUDE_CONFIG_DIR=<claude_config_dir>`, and (when `api_key` is
+/// `Some(s)` with a non-empty `s`) the `--bare` arg. Does NOT spawn.
+/// Test: `test_build_launch_command_sets_env_and_cwd`,
+/// `test_build_launch_command_adds_bare_with_api_key`,
+/// `test_build_launch_command_no_bare_without_api_key`.
+pub fn build_launch_command(
+    repo_path: &Path,
+    claude_config_dir: &Path,
+    api_key: Option<&str>,
+) -> Command {
     let mut cmd = Command::new("claude");
     cmd.current_dir(repo_path);
+    cmd.env("CLAUDE_CONFIG_DIR", claude_config_dir);
+    // WI-10: when ANTHROPIC_API_KEY is set, add --bare so Claude Code bypasses
+    // keychain/OAuth reads and uses the API key directly. When the key is absent
+    // the session relies on the keychain entry created by `tm login`.
+    if let Some(key) = api_key
+        && !key.trim().is_empty()
+    {
+        cmd.arg("--bare");
+    }
+    cmd
+}
+
+/// Build the `claude auth login` `Command` for the tm-global config dir.
+///
+/// Why: `tm login` needs to run the OAuth login flow under
+/// `CLAUDE_CONFIG_DIR=<tm-global-config-dir>` so the resulting keychain entry
+/// is keyed to that dir and `tm run` sessions can authenticate on the user's
+/// Claude Max/Pro plan. Factoring out the command construction makes it
+/// unit-testable without launching a browser.
+/// What: returns a `Command` with program `"claude"`, args `["auth", "login"]`,
+/// and env `CLAUDE_CONFIG_DIR=<claude_config_dir>`. Inherits stdio so the user
+/// can complete the OAuth flow interactively. Does NOT spawn.
+/// Test: `test_build_login_command_sets_env_and_invocation`.
+pub fn build_login_command(claude_config_dir: &Path) -> Command {
+    let mut cmd = Command::new("claude");
+    cmd.args(["auth", "login"]);
     cmd.env("CLAUDE_CONFIG_DIR", claude_config_dir);
     cmd
 }
 
-/// Check whether valid credentials are available for the managed session.
+/// Determine whether the managed session will have a usable auth path.
 ///
-/// Why: CLAUDE_CONFIG_DIR relocates `.credentials.json` away from `~/.claude/`
-/// (validated 2026-06-22 / v2.1.185, A9); without credentials the session
-/// launches but cannot make API calls. This guard lets `run_alias` warn early.
+/// Why: CLAUDE_CONFIG_DIR (A9) relocates the entire `~/.claude/` tree including
+/// `.credentials.json`; a clean tm-global config dir is therefore unauthenticated.
+/// WI-10 defines two valid auth paths — `ANTHROPIC_API_KEY` (+`--bare`) and the
+/// keychain login created by `tm login`. This function encodes the same two-path
+/// check so `run_alias` can emit an informative warning when neither appears
+/// available, without blocking the launch (a keychain entry cannot be probed
+/// non-interactively).
 /// Accepting `api_key` as a parameter (rather than reading the env directly)
-/// removes the `unsafe set_var/remove_var` from tests and makes this unit-
-/// testable without env mutation under parallel test runners (F4 fix).
-/// What: returns `true` when `api_key` is `Some(s)` where `s` is non-empty
-/// OR `<claude_config_dir>/.credentials.json` exists.
+/// removes env mutation from tests and keeps this pure under parallel test
+/// runners (F4 fix).
+/// What: returns `AuthState::ApiKey` when `api_key` is `Some(s)` with a
+/// non-empty `s`; `AuthState::CredentialsFile` when
+/// `<claude_config_dir>/.credentials.json` exists; `AuthState::Unknown`
+/// otherwise (the keychain entry, if any, cannot be probed from Rust without
+/// spawning `claude auth status`, so we issue a hint instead of a hard failure).
 /// Test: `test_check_credentials_with_key_param`,
 /// `test_check_credentials_with_file`.
-pub fn check_credentials(claude_config_dir: &Path, api_key: Option<&str>) -> bool {
+#[derive(Debug, PartialEq, Eq)]
+pub enum AuthState {
+    /// ANTHROPIC_API_KEY is set — `--bare` will be used.
+    ApiKey,
+    /// `.credentials.json` exists in the tm-global config dir (MCP OAuth tokens
+    /// only, not primary session auth; kept for diagnostic purposes).
+    CredentialsFile,
+    /// Neither path is detectable non-interactively (keychain entry may still
+    /// exist from a prior `tm login` — issue a hint, not a hard failure).
+    Unknown,
+}
+
+/// Check which auth path is available for the managed session.
+///
+/// Why: see `AuthState` doc; encodes the WI-10 two-path check without probing
+/// the macOS keychain (requires spawning `claude auth status`).
+/// What: evaluates `api_key` then `.credentials.json` presence and returns the
+/// matching `AuthState`.
+/// Test: `test_check_credentials_with_key_param`, `test_check_credentials_with_file`.
+pub fn check_credentials(claude_config_dir: &Path, api_key: Option<&str>) -> AuthState {
     if let Some(key) = api_key
         && !key.trim().is_empty()
     {
-        return true;
+        return AuthState::ApiKey;
     }
-    claude_config_dir.join(".credentials.json").exists()
+    if claude_config_dir.join(".credentials.json").exists() {
+        return AuthState::CredentialsFile;
+    }
+    AuthState::Unknown
 }
 
 /// Load and run an interactive `claude` session for the given alias.
 ///
 /// Why: `tm run <alias>` is the primary daily-driver entry point. It calls
-/// `load_alias` unconditionally (idempotent), warns when credentials are
-/// absent, then spawns `claude` with inherited stdio so the user drives the
-/// session interactively.
-/// What: (1) ensures `load_alias` succeeds, (2) warns to stderr when no
-/// credential path is available (does NOT block — a session with
-/// ANTHROPIC_API_KEY still works), (3) calls `build_launch_command` and
-/// spawns it with `wait()`. The attended session's exit code is NOT treated
-/// as a tm error — the user ending an interactive session (e.g. typing `exit`
-/// or pressing Ctrl-C, which yields exit code 130) is normal, not a failure.
-/// Test: end-to-end path requires a real `claude` binary; unit-level coverage
-/// via `test_build_launch_command_sets_env_and_cwd`.
+/// `load_alias` unconditionally (idempotent), then applies the WI-10 two-path
+/// auth model: when `ANTHROPIC_API_KEY` is set the session launches with
+/// `--bare` (API-key path); otherwise it relies on the keychain entry created
+/// by `tm login` (keychain path). A best-effort stderr hint is emitted when
+/// neither a seeded `.credentials.json` nor `ANTHROPIC_API_KEY` is detected,
+/// pointing users to `tm login` — but we do not block, because a valid keychain
+/// entry cannot be probed without spawning `claude auth status`.
+/// What: (1) `load_alias` — idempotent, (2) reads `ANTHROPIC_API_KEY` and
+/// calls `check_credentials` for a hint, (3) builds the command with
+/// `build_launch_command` (which adds `--bare` when the key is set), (4)
+/// spawns and waits. The attended session's non-zero exit code is not treated
+/// as a tm error (Ctrl-C → 130, typing `exit` → 0/1, etc. are all normal).
+/// Test: end-to-end requires a real `claude` binary; auth-path logic is covered
+/// by `test_build_launch_command_adds_bare_with_api_key` and
+/// `test_build_launch_command_no_bare_without_api_key`.
 pub fn run_alias(alias: &str, managed_root: &Path, claude_config_dir: &Path) -> anyhow::Result<()> {
     let repo_path = load_alias(alias, managed_root, claude_config_dir)
         .with_context(|| format!("failed to load alias '{alias}'"))?;
 
-    // Read the env var here at the call site so `check_credentials` remains
+    // Read ANTHROPIC_API_KEY at the call site so `check_credentials` remains
     // pure and unit-testable without env mutation (F4 fix).
     let api_key = std::env::var("ANTHROPIC_API_KEY").ok();
-    if !check_credentials(claude_config_dir, api_key.as_deref()) {
-        eprintln!(
-            "warning: no credentials found in {} and ANTHROPIC_API_KEY is not set.\n\
-             The session will launch but cannot make API calls.\n\
-             Seed credentials with `tm install` or export ANTHROPIC_API_KEY.",
-            claude_config_dir.display()
-        );
+
+    match check_credentials(claude_config_dir, api_key.as_deref()) {
+        AuthState::ApiKey => {
+            // API key present → --bare will be added by build_launch_command.
+        }
+        AuthState::CredentialsFile => {
+            // .credentials.json exists — likely MCP OAuth tokens; the primary
+            // keychain session auth was established by `tm login`.
+        }
+        AuthState::Unknown => {
+            // Cannot detect a keychain entry without spawning `claude auth
+            // status`; emit a non-blocking hint so the user knows about tm login.
+            eprintln!(
+                "hint: no ANTHROPIC_API_KEY and no .credentials.json found in {}.\n\
+                 If you haven't run `tm login` yet, do so once to authenticate\n\
+                 managed sessions on your Claude Max/Pro plan.\n\
+                 Alternatively, export ANTHROPIC_API_KEY to use the API-key path.",
+                claude_config_dir.display()
+            );
+        }
     }
 
-    let mut cmd = build_launch_command(&repo_path, claude_config_dir);
+    let mut cmd = build_launch_command(&repo_path, claude_config_dir, api_key.as_deref());
     cmd.status()
         .context("failed to spawn 'claude'; is it installed and on PATH?")?;
 
-    // The user ending an attended interactive session (e.g. Ctrl-C → exit 130
-    // or typing `exit`) commonly results in a non-zero exit code. That is not a
-    // tm error — we return Ok unconditionally here. If callers ever need to
-    // propagate the child's exit code as the process exit code they should call
-    // std::process::exit(code) directly; adding an error message here would be
-    // misleading to the user.
+    // A non-zero exit from an attended interactive session (Ctrl-C → 130,
+    // `/exit` → 0, etc.) is normal end-of-session, not a tm error.
     Ok(())
 }
 
@@ -132,7 +217,7 @@ mod tests {
         let repo = tmp.path().join("repo");
         let cfg = tmp.path().join("claude-config");
 
-        let cmd = build_launch_command(&repo, &cfg);
+        let cmd = build_launch_command(&repo, &cfg, None);
 
         // Verify program is "claude".
         assert_eq!(cmd.get_program(), "claude");
@@ -154,6 +239,84 @@ mod tests {
         }
     }
 
+    // WI-10: `--bare` MUST be present when api_key is supplied (API-key path).
+    #[test]
+    fn test_build_launch_command_adds_bare_with_api_key() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        let cfg = tmp.path().join("claude-config");
+
+        let cmd = build_launch_command(&repo, &cfg, Some("sk-ant-test-key"));
+
+        let args: Vec<_> = cmd.get_args().collect();
+        assert!(
+            args.iter().any(|a| a == &std::ffi::OsStr::new("--bare")),
+            "expected --bare in args when api_key is set; got {args:?}"
+        );
+    }
+
+    // WI-10: `--bare` MUST NOT be present when no api_key (keychain path).
+    #[test]
+    fn test_build_launch_command_no_bare_without_api_key() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        let cfg = tmp.path().join("claude-config");
+
+        // None key → no --bare
+        let cmd = build_launch_command(&repo, &cfg, None);
+        let args: Vec<_> = cmd.get_args().collect();
+        assert!(
+            !args.iter().any(|a| a == &std::ffi::OsStr::new("--bare")),
+            "--bare must not be present when api_key is None; got {args:?}"
+        );
+
+        // Empty key → no --bare (treated same as None)
+        let cmd2 = build_launch_command(&repo, &cfg, Some(""));
+        let args2: Vec<_> = cmd2.get_args().collect();
+        assert!(
+            !args2.iter().any(|a| a == &std::ffi::OsStr::new("--bare")),
+            "--bare must not be present for empty api_key; got {args2:?}"
+        );
+
+        // Whitespace-only key → no --bare
+        let cmd3 = build_launch_command(&repo, &cfg, Some("   "));
+        let args3: Vec<_> = cmd3.get_args().collect();
+        assert!(
+            !args3.iter().any(|a| a == &std::ffi::OsStr::new("--bare")),
+            "--bare must not be present for whitespace-only key; got {args3:?}"
+        );
+    }
+
+    // WI-10: `tm login` command builder sets the correct program, args, and env.
+    #[test]
+    fn test_build_login_command_sets_env_and_invocation() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("claude-config");
+
+        let cmd = build_login_command(&cfg);
+
+        assert_eq!(cmd.get_program(), "claude");
+
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(
+            args,
+            vec![std::ffi::OsStr::new("auth"), std::ffi::OsStr::new("login")],
+            "expected [auth, login], got {args:?}"
+        );
+
+        let env_vars: Vec<_> = cmd.get_envs().collect();
+        let cfg_var = env_vars
+            .iter()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("CLAUDE_CONFIG_DIR"));
+        assert!(
+            cfg_var.is_some(),
+            "CLAUDE_CONFIG_DIR must be set on the login command"
+        );
+        if let Some((_, val)) = cfg_var {
+            assert_eq!(*val, Some(cfg.as_os_str()));
+        }
+    }
+
     // F4: check_credentials now accepts the key value as a parameter so tests
     // never need unsafe env mutation (safe under parallel test runners).
     #[test]
@@ -161,15 +324,18 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = tmp.path().to_path_buf();
 
-        // Non-empty key → true even with no credentials file.
-        assert!(check_credentials(&cfg, Some("sk-test-key")));
+        // Non-empty key → ApiKey.
+        assert_eq!(
+            check_credentials(&cfg, Some("sk-test-key")),
+            AuthState::ApiKey
+        );
 
-        // Empty / whitespace-only key → falls through to file check.
-        assert!(!check_credentials(&cfg, Some("")));
-        assert!(!check_credentials(&cfg, Some("   ")));
+        // Empty / whitespace-only key → falls through to file/unknown check.
+        assert_eq!(check_credentials(&cfg, Some("")), AuthState::Unknown);
+        assert_eq!(check_credentials(&cfg, Some("   ")), AuthState::Unknown);
 
-        // None key, no file → false.
-        assert!(!check_credentials(&cfg, None));
+        // None key, no file → Unknown.
+        assert_eq!(check_credentials(&cfg, None), AuthState::Unknown);
     }
 
     #[test]
@@ -177,11 +343,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = tmp.path().to_path_buf();
 
-        // No key, file exists → true.
+        // No key, file exists → CredentialsFile.
         std::fs::write(cfg.join(".credentials.json"), r#"{"token":"t"}"#).unwrap();
-        assert!(check_credentials(&cfg, None));
+        assert_eq!(check_credentials(&cfg, None), AuthState::CredentialsFile);
 
-        // Both key and file → true.
-        assert!(check_credentials(&cfg, Some("sk-also-valid")));
+        // Both key and file → ApiKey (API key takes precedence).
+        assert_eq!(
+            check_credentials(&cfg, Some("sk-also-valid")),
+            AuthState::ApiKey
+        );
     }
 }

--- a/docs/specs/standalone-managed-trusty-mpm.md
+++ b/docs/specs/standalone-managed-trusty-mpm.md
@@ -310,15 +310,24 @@ the tm-global config dir). When tm emits `.trusty-mpm/tm-settings.json` / `tm-mc
 as an optional override/replication aid, not the load-bearing path. See §SPEC-STANDALONE-MPM-04 for
 the invariant and §6 for the longevity note.
 
-**Credential precondition (the cost of relocating the user-level layer).** Because
-`CLAUDE_CONFIG_DIR` relocates the **entire** `~/.claude/` tree-equivalent, it also relocates
+**Credential precondition (the cost of relocating the user-level layer) — WI-10 IMPLEMENTED.**
+Because `CLAUDE_CONFIG_DIR` relocates the **entire** `~/.claude/` tree-equivalent, it also relocates
 `~/.claude/.credentials.json` (validated 2026-06-22 / v2.1.185, A9). A session launched against a
 *clean* tm-global config dir is therefore **unauthenticated** ("Not logged in") and cannot make API
-calls. The tm-global config dir MUST carry valid credentials via **one** of: **(a)** `tm` seeds a
-valid `.credentials.json` into `~/.trusty-mpm/claude-config/`, or **(b)** the session runs with
-**`ANTHROPIC_API_KEY`** set (which pairs with Claude Code's **`--bare`** flag — `--bare` skips the
-keychain/credentials lookup and *requires* `ANTHROPIC_API_KEY`). This precondition is owned by `tm
-install`/`tm config` and realized by **WI-10**; `tm run` enforces it (§SPEC-STANDALONE-MPM-05).
+calls. **NOTE:** `.credentials.json` carries MCP OAuth tokens, NOT primary Claude Max/Pro session
+auth — primary auth uses the macOS Keychain keyed by the `CLAUDE_CONFIG_DIR` path.
+
+The two WI-10 auth paths (both implemented, 2026-06-22):
+- **(a) Keychain (default — `tm login`).** Run `tm login` once. This launches
+  `claude auth login` under `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` so the OAuth flow
+  creates a keychain entry for that path. All subsequent `tm run` sessions authenticate on the
+  Claude Max/Pro plan via the keychain (no further setup needed).
+- **(b) API key + `--bare` (CI/automation).** When `ANTHROPIC_API_KEY` is set in the environment,
+  `tm run` automatically adds `--bare` to the `claude` invocation. `--bare` bypasses
+  keychain/OAuth reads and uses the API key directly; no `tm login` needed.
+
+`tm run` emits a non-blocking hint to run `tm login` when neither path is detectable
+(keychain entries cannot be probed without spawning `claude auth status`).
 
 **(d) The marker file.** `.trusty-mpm/managed.toml` records `{alias, url, ref, claude_config_dir,
 settings_arg_path?, mcp_config_arg_path?, generated_by_version}` so `path`/`ls`/`update`/`rm` and an
@@ -482,20 +491,21 @@ session-manager spec and is **out of scope** here except for the seam: a managed
   retains control; the process is foregrounded / attachable.
 - **Preconditions:** alias registered; the tm-global config dir established (`tm install`/`tm config`);
   **the tm-global config dir carries valid credentials** (see *Credential precondition* below).
-- **Credential precondition (required for API calls).** Because the required `CLAUDE_CONFIG_DIR`
-  relocates the **entire** `~/.claude/` tree-equivalent — including `.credentials.json` (A9) — a session
-  launched against a *clean* tm-global config dir starts **unauthenticated** (`claude` reports "Not
-  logged in") and **cannot make API calls**. `tm run` MUST therefore ensure one of two credential paths
-  is in place before launch:
-  - **(a) Seeded credentials:** `tm` seeds a valid `.credentials.json` into the tm-global config dir
-    (`~/.trusty-mpm/claude-config/`) so the relocated user-level layer is authenticated, **or**
-  - **(b) API-key env:** the session runs with **`ANTHROPIC_API_KEY`** set in the environment. This
-    pairs well with Claude Code's **`--bare`** flag (which skips the keychain/credentials lookup and
-    **requires** `ANTHROPIC_API_KEY`).
-
-  Without one of these, the managed session launches but cannot call the API. Establishing/maintaining
-  the credential path is owned by `tm install`/`tm config` (the tm-global config dir) and realized by
-  **WI-10**.
+- **Credential precondition (required for API calls) — WI-10 IMPLEMENTED.** Because the required
+  `CLAUDE_CONFIG_DIR` relocates the **entire** `~/.claude/` tree-equivalent — including the macOS
+  Keychain entry used for Claude Max/Pro OAuth (A9) — a session launched against a *clean* tm-global
+  config dir starts **unauthenticated** (`claude` reports "Not logged in"). **NOTE:** `.credentials.json`
+  (MCP OAuth tokens) is seeded by `ensure_global_config_dir` but does NOT establish primary session
+  auth. `tm run` supports two WI-10 auth paths:
+  - **(a) Keychain (default — `tm login` once):** `tm login` runs `claude auth login` under
+    `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` so the OAuth flow creates a Keychain entry for
+    that path. All subsequent `tm run` sessions authenticate via the Keychain on the user's Claude
+    Max/Pro plan (no further setup needed, no `ANTHROPIC_API_KEY` required).
+  - **(b) API key + `--bare` (CI/automation):** when `ANTHROPIC_API_KEY` is set, `tm run`
+    automatically adds `--bare` to the `claude` invocation. `--bare` bypasses Keychain/OAuth reads
+    and uses the API key directly; no `tm login` step needed.
+  When neither path is detected, `tm run` emits a non-blocking stderr hint pointing to `tm login`
+  (Keychain entries cannot be probed without spawning `claude auth status`, so no hard failure).
 - **Postconditions:** an **attended, interactive** managed Claude Code session is running for the
   alias with the isolation invariant intact — global hooks/MCPs supplied via the tm-global
   `CLAUDE_CONFIG_DIR`, the real `~/.claude` excluded, project-local config discovered from `repo/`,
@@ -521,7 +531,8 @@ override args make a replication command fully explicit.
 
 | Module | Role |
 |--------|------|
-| `tm::commands::run` (new) | Resolves alias, ensures load, **verifies the credential precondition** (seeded `.credentials.json` in the tm-global config dir **or** `ANTHROPIC_API_KEY`+`--bare`), then launches an **attended** Claude Code session with the required `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` and `cwd = repo/` (optional `--settings`/`--mcp-config` override args). |
+| `tm::commands::run` (new) | Resolves alias, ensures load, checks WI-10 auth path (`ANTHROPIC_API_KEY` → `--bare`; otherwise keychain hint), then launches an **attended** Claude Code session with `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` and `cwd = repo/`. `build_launch_command` (in `core::standalone::run`) adds `--bare` when the API key is set. |
+| `tm login` (new, WI-10) | New `Login` CLI variant; `login_cmd` in `commands::standalone` calls `build_login_command` → `claude auth login` under `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` with inherited stdio so the user completes the OAuth flow. |
 | `core::session_launch` | Launches Claude Code with the tm-global `CLAUDE_CONFIG_DIR` (and optional override args) for an interactive session. |
 | Session manager (Layer 2, consumed; DOC-23) | The semi-autonomous orchestrator that *drives* tm-managed projects; **not** implemented by `tm run`. |
 
@@ -691,7 +702,7 @@ specs); a managed project produced by `load` is exactly the seam the session man
 |---|-------------------|--------|-----------------|
 | A1 | **`CLAUDE_CONFIG_DIR` redirects Claude Code's user-level config dir per-process, *excluding* the real `~/.claude` — CONFIRMED as the isolation mechanism.** **CONFIRMED** (empirically tested **and** maintainer-confirmed): setting `CLAUDE_CONFIG_DIR` to a clean directory provides **full user-level config isolation** — (i) **MCP**: all global/cloud MCPs *and* the user-scoped `trusty-review` disappear ("No MCP servers configured"); **both reads and writes** redirect into the clean dir; **zero leakage** into the real `~/.claude`; (ii) **settings/hooks**: the clean dir's `settings.json` is consulted and the real `~/.claude/settings.json` hooks (PostToolUse/SessionStart/Stop/SubagentStop) are **not** read; (iii) it relocates the **entire `~/.claude/` tree-equivalent** (settings, MCP data, sessions, projects, credentials). So pointing it at the tm-global config dir makes Claude Code merge **that** dir as the user-level layer instead of the real `~/.claude` (the maintainer's claude-mpm global hooks/MCPs are excluded). Empirically validated on Claude Code v2.1.185 (macOS, 2026-06-22) **and confirmed by the maintainer** — this is a settled design assumption, not an open risk. The one residual note: the flag is **undocumented** in `--help`, so re-verify the isolation behavior on **major Claude Code upgrades** (a lightweight regression guard, not a blocking risk). **This is the load-bearing isolation primitive — REQUIRED, primary:** the global hooks + skills/slash-commands + MCPs are delivered through it, and it is what prevents real-`~/.claude` step-on. | **CONFIRMED** — full MCP + settings/hooks isolation, empirically tested on Claude Code 2.1.185 (2026-06-22) **and maintainer-confirmed**. Residual: undocumented in `--help` → re-verify on major CC upgrades (lightweight regression guard). | **WI-1** is a minimal **regression-guard / version-pin** (re-verify the user-level swap + real-`~/.claude` exclusion against the pinned CC version on major upgrades). It is **non-blocking** — the mechanism is confirmed, so implementation can proceed; this WI only guards against a future undocumented-behavior regression. |
 | A2 | **`CLAUDE_CONFIG_DIR` does not suppress project-local `.claude/` creation.** Confirmed: a local `.claude/settings.local.json` may still be written in the workspace even with the var set. This is **acceptable** — the managed layout *wants* project-local files under `repo/`; we just must not assume the var centralizes everything. | **Confirmed (acceptable).** | Managed layout treats `repo/.claude/` as the statically-discovered half by design. |
-| A9 | **`CLAUDE_CONFIG_DIR` ALSO relocates `~/.claude/.credentials.json` → a clean tm-global config dir starts UNAUTHENTICATED.** Discovered during the same 2026-06-22 / v2.1.185 test: because the var relocates the **entire** `~/.claude/` tree-equivalent (A1), it also relocates `.credentials.json`, so a session launched with a *clean* tm-global config dir has **no credentials** — `claude` reports "Not logged in" and cannot make API calls. This is a real gap for the managed-session use case, not a benign side effect. | **Confirmed gotcha (blocks API calls).** | The tm-global config dir must carry valid credentials before a managed session can run: either (a) `tm` seeds a valid `.credentials.json` into the tm-global config dir, **or** (b) the session runs with `ANTHROPIC_API_KEY` set (pairs well with `--bare`, which skips the keychain/credentials lookup and requires `ANTHROPIC_API_KEY`). Realized by **WI-10** (credential provisioning); the precondition is recorded in §SPEC-STANDALONE-MPM-03 / -05. |
+| A9 | **`CLAUDE_CONFIG_DIR` ALSO relocates `~/.claude/.credentials.json` → a clean tm-global config dir starts UNAUTHENTICATED.** Discovered 2026-06-22 / v2.1.185: the var relocates the **entire** `~/.claude/` tree-equivalent (A1) including `.credentials.json`. **KEY INSIGHT (empirically confirmed, 2026-06-22):** primary Claude Max/Pro session auth is the macOS **Keychain** entry keyed by the `CLAUDE_CONFIG_DIR` path — NOT `.credentials.json` (which carries MCP OAuth tokens only). A fresh `~/.trusty-mpm/claude-config/` has no Keychain entry, so `claude` reports "Not logged in". | **Confirmed + MITIGATED by WI-10 (2026-06-22).** | **WI-10 IMPLEMENTED:** two auth paths — **(a) `tm login`** (one-time keychain setup, `claude auth login` under `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config`) and **(b) `ANTHROPIC_API_KEY`+`--bare`** (API-key path, auto-detected by `tm run`). Primary managed-session auth is via the Keychain or API key; seeding `.credentials.json` addresses MCP OAuth tokens only. |
 | A3 | **The VS Code / Cursor extension IGNORES `CLAUDE_CONFIG_DIR`** (reads/writes the real `~/.claude/` regardless). | **Confirmed risk — bounds the IDE path.** | Because the load-bearing primitive is `CLAUDE_CONFIG_DIR` (A1) and the IDE ignores it, an IDE-attached session loads project-local config layered on the **real** `~/.claude` (claude-mpm step-on) and does **not** get tm's global hooks/MCPs. IDE-attach (§06) therefore relies **only** on standard project-local discovery of `repo/CLAUDE.md` + `repo/.claude/agents/` + `repo/.claude/skills/`, which the extension *does* honor; faithful, isolated sessions launch via `tm`. WI-1 documents this boundary. |
 | A4 | **Project-local `.claude/` precedence over the user-level layer.** Confirmed: precedence is Managed > CLI args > Local (`settings.local.json`) > Project (`.claude/`) > User (the user-level layer — the real `~/.claude`, or the **tm-global config dir** when `CLAUDE_CONFIG_DIR` redirects it). | **Confirmed.** | Relied on by §03/§06/§08 — project-local `repo/.claude` overlays the tm-global user-level layer. |
 | A8 | **Claude Code CLI accepts argument-supplied settings + MCP config files (the *secondary* override mechanism).** **Verified** against the installed CLI (v2.1.185, `claude --help`): `--settings <file-or-json>` ("Path to a settings JSON file … to load additional settings from" — the file carries the `hooks` block); `--mcp-config <configs...>` ("Load MCP servers from JSON files or strings (space-separated)"); `--strict-mcp-config` ("Only use MCP servers from `--mcp-config`, ignoring all other MCP configurations"). `--bare`/`--safe-mode` help text confirms hooks/MCPs are otherwise standard-discovery customizations. **Reframed as secondary:** these flags are kept for per-run overrides and for *manually replicating* a tm launch (same arguments) — they are **no longer** the primary delivery mechanism for hooks/MCPs (that is the tm-global `CLAUDE_CONFIG_DIR`, A1). | **Verified (CLI v2.1.185); secondary.** | §03/§08 keep them documented as the optional override/replication path; WI-1 re-confirms against the pinned CC version. |
@@ -708,7 +719,7 @@ specs); a managed project produced by `load` is exactly the seam the session man
 |----|-------|------|----------|------------|
 | **WI-1** | **S** | **Regression-guard / version-pin `CLAUDE_CONFIG_DIR` + write the standard.** The load-bearing isolation mechanism is **CONFIRMED** (empirically tested on CC 2.1.185, macOS, 2026-06-22, **and maintainer-confirmed**, A1) — full user-level swap to the tm-global config dir with the real `~/.claude` excluded. This WI is therefore a **minimal regression guard, not a blocking prerequisite and not a "does it work" investigation**: pin a known-good minimum CC version and re-verify `CLAUDE_CONFIG_DIR` isolation (user-level swap + real-`~/.claude` exclusion) against that pinned version on **major** Claude Code upgrades (the flag is undocumented, so guard against a future regression). Also: confirm the IDE ignores it (A3) and document that boundary, re-confirm the **secondary** `--settings`/`--mcp-config` override flags (A8), and capture the credential-relocation gotcha (A9) so WI-10's precondition is accounted for. Write the standard doc (one tm-global config dir + per-alias project layout, marker schema incl. the `CLAUDE_CONFIG_DIR` path, ownership, isolation invariant, the project-local-discovery vs tm-global split, the credential precondition) and a conformance checklist incl. session-replay via the same `CLAUDE_CONFIG_DIR`. **Non-blocking:** the build does not wait on this WI to prove the mechanism — the mechanism is confirmed. | SPEC-STANDALONE-MPM-03, -04 (assumptions A1–A4, A8, A9) | — |
 | **WI-9** | **M** | **Establish + maintain the single tm-global config dir (`tm install` / `tm config`).** Create and maintain `~/.trusty-mpm/claude-config/` holding the **one** set of global hooks, the global skills / slash-commands, and the global MCP servers (memory/search/review); idempotent merge that preserves user-added entries; this is established **once** (not per project) and is what `CLAUDE_CONFIG_DIR` selects at launch. | SPEC-STANDALONE-MPM-03, -04, -08 | — (mechanism confirmed, A1; WI-1 runs alongside as a non-blocking guard) |
-| **WI-10** | **S** | **Credential provisioning for the tm-global config / managed sessions.** Because `CLAUDE_CONFIG_DIR` relocates `.credentials.json` (A9), a clean tm-global config dir is unauthenticated. Provide one of two paths and wire `tm run`'s precondition check: **(a)** seed a valid `.credentials.json` into `~/.trusty-mpm/claude-config/` (at `tm install`/`tm config`), or **(b)** wire `ANTHROPIC_API_KEY` into the launch env and pass Claude Code's `--bare` (skips keychain/credentials lookup, requires `ANTHROPIC_API_KEY`). Document both; fail `tm run` with a clear diagnostic when neither is available. | SPEC-STANDALONE-MPM-03, -05 (A9) | WI-9 |
+| **WI-10** | **S** | **IMPLEMENTED (2026-06-22, refs #1548).** Managed-session auth — `tm login` (keychain, default) + `ANTHROPIC_API_KEY`/`--bare` fallback (CI/automation). Primary auth uses the macOS Keychain keyed by `CLAUDE_CONFIG_DIR` path; `.credentials.json` is MCP OAuth tokens, NOT session auth. `tm login` → `claude auth login` under `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` (one-time setup; creates the Keychain entry). `tm run` auto-adds `--bare` when `ANTHROPIC_API_KEY` is set (bypasses Keychain/OAuth). Non-blocking hint when neither is detected. `build_launch_command(api_key: Option<&str>)` and `build_login_command(claude_config_dir)` are unit-testable; `AuthState` enum encodes the three states (ApiKey / CredentialsFile / Unknown). | SPEC-STANDALONE-MPM-03, -05 (A9) | WI-9 |
 | **WI-2** | **M** | **Project-local-scope the agent/skill/output-style deploys.** Thread an explicit target through `deploy_agents_filtered`, `deploy_skills_filtered` → `repo/.claude/agents/`, `repo/.claude/skills/` (project, standard discovery; global skills/slash-commands go to the tm-global config dir per WI-9); `deploy_output_style` → `repo/.claude/settings.json` / tm-global config dir; remove the real-`home_dir()` global fallback in managed mode (fail closed). | SPEC-STANDALONE-MPM-04 (sites 1–3) | WI-9 |
 | **WI-3** | **S** | **Emit the one global hooks block + trust into the tm-global config dir; stop the real-global writes.** Re-target hook composition (`remove_global_trusty_memory_hooks` + the managed hooks) to write the **single** global `hooks` block into the tm-global config dir's `settings.json` (selected by `CLAUDE_CONFIG_DIR`); re-target `preseed_workspace_trust_home` to the tm-global config dir's `.claude.json` equivalent; **stop** seeding the real `~/.claude.json`. | SPEC-STANDALONE-MPM-04 (sites 4–5), -08 | WI-9 |
 | **WI-4** | **M** | **Standalone-driver registry + `register`/`ls`.** New registry file under the trusty-mpm config root; `tm register`, `tm ls`. Reuse/align with the DOC-22 project registry. | SPEC-STANDALONE-MPM-01, -07 (`ls`) | — |


### PR DESCRIPTION
## Summary

Implements WI-10 (epic #1548): managed-session authentication for the standalone `tm` driver.

### Root cause (A9 update)

Live e2e revealed that under `CLAUDE_CONFIG_DIR` isolation, `claude` reports "Not logged in" because the primary Claude Max/Pro OAuth session token is stored in the **macOS Keychain, keyed by `CLAUDE_CONFIG_DIR` path** — not in `.credentials.json` (which carries MCP OAuth tokens only). A fresh `~/.trusty-mpm/claude-config/` directory has no Keychain entry.

### Two auth paths

**Default — one-time keychain login (`tm login`):**
```
tm login
# Runs: CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config claude auth login
# Creates a Keychain entry scoped to that path.
# All subsequent tm run sessions authenticate on Max/Pro plan.
```

**CI / API-key fallback (automatic):**
When `ANTHROPIC_API_KEY` is set (non-empty), `tm run` automatically passes `--bare` to `claude`, disabling Keychain reads and using the API key strictly.

### Implementation

- **`run.rs`**: `AuthState` enum (`ApiKey` / `CredentialsFile` / `Unknown`) replaces `bool`. `build_login_command` and `build_launch_command` are pure functions returning `Command` — no spawning, unit-testable. `run_alias` emits a non-blocking stderr hint when `AuthState::Unknown`. 4 new unit tests.
- **`global_config.rs`**: Doc comments clarify `.credentials.json` is MCP OAuth tokens (not primary session auth); missing-src warning updated.
- **`cli.rs`**: `Login` variant added to `Command` enum.
- **`commands/standalone.rs`**: `login_cmd()` implements one-time setup flow with success/failure messaging.
- **`main.rs`**: Dispatch wired for `Command::Login`.
- **`tests.rs`**: `cli_parses_login_standalone()` CLI smoke test.
- **`docs/specs/standalone-managed-trusty-mpm.md`**: A9 updated (MITIGATED); §03/§05 credential preconditions rewritten; WI-10 row marked IMPLEMENTED.

### Quality bar

- `cargo test -p trusty-mpm`: **1865 passed**, 2 pre-existing failures (overseer tests, unrelated to this PR — fail on main too)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `bash scripts/check_line_cap.sh`: 14 allowlisted, 0 violations
- All pre-commit hooks: Passed

### What needs human OAuth validation

The `tm login` path (`claude auth login` + Keychain write) can only be verified by running the OAuth browser flow manually. Recommend:
```bash
cargo build -p trusty-mpm
tm login            # complete the OAuth browser flow
tm run <repo>       # verify session authenticates on Max/Pro plan
```
The `ANTHROPIC_API_KEY` + `--bare` path can be tested by setting the env var and running `tm run` without a prior `tm login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)