### PR TITLE
refactor(trusty-mpm): WI-2 review nits — single missing-source hint + deploy layout docs (refs #1548)

### DIFF
--- a/crates/trusty-mpm/src/core/standalone/global_config.rs
+++ b/crates/trusty-mpm/src/core/standalone/global_config.rs
@@ -98,26 +98,49 @@ fn deploy_agents_and_skills(managed_root: &Path, claude_config_dir: &Path) -> an
     let agents_dest = claude_config_dir.join("agents");
     let skills_dest = claude_config_dir.join("skills");
 
-    // Guard: if agents source dir is missing (tm install not yet run), skip and
-    // print a hint to stderr. Never error — tm load/run/login must stay functional
-    // before the framework is installed.
-    if !agents_src.exists() {
+    // Nit 3 (accepted TOCTOU): `exists()` is checked here before calling the
+    // deployers so we can emit a targeted hint. The deployers already handle a
+    // missing source dir by returning Ok(empty) internally, so this is a
+    // benign, accepted TOCTOU window — the framework directory essentially never
+    // disappears mid-run in normal dev use.
+    let agents_missing = !agents_src.exists();
+    let skills_missing = !skills_src.exists();
+
+    // Nit 1: collapse the two missing-source hints into a single combined message
+    // when both source dirs are absent (framework not yet installed), so the user
+    // sees one clear actionable line instead of two. When only one is missing,
+    // print just that specific hint so it names the exact missing path.
+    if agents_missing && skills_missing {
         eprintln!(
-            "note: no bundled agents found at {}; run `tm install` to populate them",
-            agents_src.display()
+            "note: no bundled agents or skills found under {}/framework; \
+             run `tm install` to populate them",
+            managed_root.display()
         );
     } else {
+        if agents_missing {
+            eprintln!(
+                "note: no bundled agents found at {}; run `tm install` to populate them",
+                agents_src.display()
+            );
+        }
+        if skills_missing {
+            eprintln!(
+                "note: no bundled skills found at {}; run `tm install` to populate them",
+                skills_src.display()
+            );
+        }
+    }
+
+    if !agents_missing {
+        // Nit 2: layout contract — deploy_agents writes each flat <name>.md source
+        // as <agents_dest>/<name>.md plus a .trusty-mpm-manifest.json side-car
+        // (see core::agent_deployer). deploy_skills writes each flat <name>.md
+        // source as <skills_dest>/<name>/SKILL.md (see core::skill_deployer).
         crate::core::agent_deployer::deploy_agents(&agents_src, &agents_dest)
             .map_err(|e| anyhow::anyhow!("failed to deploy agents into managed config dir: {e}"))?;
     }
 
-    // Guard: same for skills.
-    if !skills_src.exists() {
-        eprintln!(
-            "note: no bundled skills found at {}; run `tm install` to populate them",
-            skills_src.display()
-        );
-    } else {
+    if !skills_missing {
         crate::core::skill_deployer::deploy_skills(&skills_src, &skills_dest)
             .map_err(|e| anyhow::anyhow!("failed to deploy skills into managed config dir: {e}"))?;
     }


### PR DESCRIPTION
## Summary

Addresses three low-severity trusty-review advisories on the already-merged WI-2 code in `crates/trusty-mpm/src/core/standalone/global_config.rs`, function `deploy_agents_and_skills`.

### Nit 1 (confidence 0.8) — collapsed double stderr hint

Previously, when both the agents and skills source dirs were missing (i.e., `tm install` not yet run), two separate `eprintln!` lines fired. Now:
- **Both missing**: single combined hint pointing to `<managed_root>/framework` with `run \`tm install\` to populate them`
- **Only one missing**: the specific per-dir hint for whichever is absent

All hints remain on stderr. Behavior otherwise unchanged: missing source = soft-skip, no error.

### Nit 2 (confidence 0.7) — deploy layout contract documented

Added a concise inline comment near the agents deploy call describing the filesystem contract both deployers establish:
- `deploy_agents` writes `<agents_dest>/<name>.md` + `.trusty-mpm-manifest.json`
- `deploy_skills` writes `<skills_dest>/<name>/SKILL.md`

### Nit 3 (confidence 0.55) — kept `exists()` pre-check with TOCTOU comment

**Decision: kept with comment (not refactored).**

Rationale: the reviewer suggested calling the deployers and mapping a NotFound error to skip-with-hint. However, both `deploy_agents` and `deploy_skills` already handle a missing source dir internally by returning `Ok(empty_result)` — they do not return any error for "source dir not found". There is no NotFound error variant to map. Calling them directly would eliminate the hint entirely (we cannot distinguish "no source dir" from "source dir with no .md files" from the return value). The pre-check is therefore kept as-is, with a new one-line comment acknowledging the accepted, benign TOCTOU window.

## Quality Gates

- `cargo fmt` — clean
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `bash scripts/check_line_cap.sh` — exit 0 (0 violations)
- `cargo test -p trusty-mpm` — 1877 passed, 2 pre-existing failures (`daemon::state` tests), 0 new failures
- `cargo check` (workspace) — clean

## LOC Delta

- Added: 36 lines
- Removed: 13 lines
- Net: +23 lines (comment + hint-collapse logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)