### PR TITLE
feat(trusty-mpm): WI-8 wire trusty-review MCP into tm-global managed config

### DIFF
--- a/crates/trusty-mpm/src/core/standalone/global_config.rs
+++ b/crates/trusty-mpm/src/core/standalone/global_config.rs
@@ -9,7 +9,7 @@
 //! writes a minimal `settings.json`, seeds `.credentials.json` from
 //! `~/.claude/.credentials.json` if it exists (NOTE: this file holds MCP OAuth
 //! tokens, NOT the primary session auth — see WI-10 for the auth model), writes
-//! a minimal `.mcp.json` with trusty-memory and trusty-search server stubs, and
+//! a minimal `.mcp.json` with trusty-memory, trusty-review, and trusty-search server stubs, and
 //! (WI-2) deploys bundled agents and skills from
 //! `<managed_root>/framework/{agents,skills}` into the managed config dir so
 //! that every tm-launched session starts with the full agent/skill set.
@@ -45,9 +45,9 @@ use std::path::{Path, PathBuf};
 /// when absent), merges the MPM hook triad into `settings.json` via
 /// [`super::hooks::ensure_managed_hooks`] (WI-3), copies
 /// `~/.claude/.credentials.json` if found (silently skips otherwise), writes
-/// `.mcp.json` with trusty-memory + trusty-search stubs (idempotent via the
-/// inject pattern), then deploys bundled agents and skills via
-/// [`deploy_agents_and_skills`].
+/// `.mcp.json` with trusty-memory, trusty-review, and trusty-search stubs
+/// (idempotent via the inject pattern; WI-8 adds trusty-review), then deploys
+/// bundled agents and skills via [`deploy_agents_and_skills`].
 /// Test: `test_global_config_dir_ensure_idempotent`,
 /// `test_deploy_agents_and_skills_populates_config_dir`,
 /// `test_deploy_agents_and_skills_missing_source_is_ok`.
@@ -227,15 +227,21 @@ fn seed_credentials(claude_config_dir: &Path) {
     }
 }
 
-/// Write a minimal `.mcp.json` with trusty-memory and trusty-search stubs.
+/// Write a minimal `.mcp.json` with trusty-memory, trusty-review, and trusty-search stubs.
 ///
 /// Why: the tm-global config dir must carry the global MCP server definitions
-/// so every tm-launched session can use memory and search tools without
-/// per-project wiring.
+/// so every tm-launched session can use memory, review, and search tools without
+/// per-project wiring. `trusty-review` was added in WI-8 (refs #1548).
 /// What: reads `<claude_config_dir>/.mcp.json` (starts from `{}` when absent),
-/// injects `trusty-memory` and `trusty-search` entries under `mcpServers` using
-/// the same idempotent merge used by `inject_mcp_server` in settings.rs.
-/// Test: `test_global_config_dir_ensure_idempotent`.
+/// injects `trusty-memory`, `trusty-review`, and `trusty-search` entries under
+/// `mcpServers` using the same idempotent merge used by `inject_mcp_server` in
+/// settings.rs.
+/// Secrets/env: trusty-review reads its config from the environment
+/// (OPENROUTER_API_KEY, AWS credentials, TRUSTY_SEARCH_URL etc.) — no secrets
+/// are injected here; the managed session inherits the daemon env, matching the
+/// pattern used for trusty-memory and trusty-search.
+/// Test: `test_global_config_dir_ensure_idempotent`,
+/// `test_mcp_config_contains_all_three_servers`.
 fn ensure_mcp_config(claude_config_dir: &Path) -> anyhow::Result<()> {
     let mcp_path = claude_config_dir.join(".mcp.json");
     let mut config = match std::fs::read_to_string(&mcp_path) {
@@ -261,6 +267,15 @@ fn ensure_mcp_config(claude_config_dir: &Path) -> anyhow::Result<()> {
         "command": "trusty-memory",
         "args": ["serve", "--stdio"]
     });
+    // WI-8 (refs #1548): trusty-review MCP server, stdio transport.
+    // trusty-review reads its LLM credentials (OPENROUTER_API_KEY, AWS credentials)
+    // and TRUSTY_SEARCH_URL from the environment — no secrets are injected here;
+    // the managed session inherits the daemon env, matching the memory/search pattern.
+    let review_entry = serde_json::json!({
+        "type": "stdio",
+        "command": "trusty-review",
+        "args": ["serve", "--stdio"]
+    });
     let search_entry = serde_json::json!({
         "type": "stdio",
         "command": "trusty-search",
@@ -270,6 +285,9 @@ fn ensure_mcp_config(claude_config_dir: &Path) -> anyhow::Result<()> {
     servers
         .entry("trusty-memory")
         .or_insert(memory_entry.clone());
+    servers
+        .entry("trusty-review")
+        .or_insert(review_entry.clone());
     servers
         .entry("trusty-search")
         .or_insert(search_entry.clone());
@@ -299,16 +317,112 @@ mod tests {
         assert!(claude_config.join("settings.json").exists());
     }
 
+    // WI-3 + WI-8: ensure_mcp_config must define all three managed MCP servers,
+    // including trusty-review added in WI-8 (refs #1548).
     #[test]
-    fn test_mcp_config_contains_both_servers() {
+    fn test_mcp_config_contains_all_three_servers() {
         let tmp = TempDir::new().unwrap();
         let cfg = tmp.path().to_path_buf();
         ensure_mcp_config(&cfg).unwrap();
         let text = std::fs::read_to_string(cfg.join(".mcp.json")).unwrap();
         let val: serde_json::Value = serde_json::from_str(&text).unwrap();
         let servers = val["mcpServers"].as_object().unwrap();
-        assert!(servers.contains_key("trusty-memory"));
-        assert!(servers.contains_key("trusty-search"));
+        assert!(
+            servers.contains_key("trusty-memory"),
+            "trusty-memory must be defined in .mcp.json"
+        );
+        assert!(
+            servers.contains_key("trusty-review"),
+            "trusty-review must be defined in .mcp.json (WI-8)"
+        );
+        assert!(
+            servers.contains_key("trusty-search"),
+            "trusty-search must be defined in .mcp.json"
+        );
+    }
+
+    // WI-8: trusty-review server entry must use stdio transport and the correct command/args.
+    #[test]
+    fn test_mcp_config_review_server_entry() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().to_path_buf();
+        ensure_mcp_config(&cfg).unwrap();
+        let text = std::fs::read_to_string(cfg.join(".mcp.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let review = &val["mcpServers"]["trusty-review"];
+        assert_eq!(
+            review["type"].as_str(),
+            Some("stdio"),
+            "trusty-review transport must be stdio"
+        );
+        assert_eq!(
+            review["command"].as_str(),
+            Some("trusty-review"),
+            "trusty-review command must be 'trusty-review'"
+        );
+        let args: Vec<&str> = review["args"]
+            .as_array()
+            .expect("args must be an array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(
+            args,
+            vec!["serve", "--stdio"],
+            "trusty-review args must be [\"serve\", \"--stdio\"]"
+        );
+    }
+
+    // WI-8 ISOLATION: ensure_mcp_config must write the review entry without
+    // touching any file outside the given claude_config_dir.
+    #[serial_test::serial]
+    #[test]
+    fn test_mcp_config_review_no_home_write() {
+        /// RAII guard restoring $HOME on drop (including panic).
+        struct HomeGuard(Option<String>);
+        impl Drop for HomeGuard {
+            fn drop(&mut self) {
+                match self.0 {
+                    Some(ref p) => unsafe { std::env::set_var("HOME", p) },
+                    None => unsafe { std::env::remove_var("HOME") },
+                }
+            }
+        }
+
+        let root = TempDir::new().unwrap();
+        let cfg = root.path().join("claude-config");
+        std::fs::create_dir_all(&cfg).unwrap();
+
+        let fake_home = TempDir::new().unwrap();
+        // SAFETY: test is serial; HomeGuard restores HOME even on panic.
+        let _home_guard = {
+            let prev = std::env::var("HOME").ok();
+            unsafe { std::env::set_var("HOME", fake_home.path()) };
+            HomeGuard(prev)
+        };
+
+        ensure_mcp_config(&cfg).unwrap();
+
+        // .mcp.json must exist inside cfg.
+        assert!(
+            cfg.join(".mcp.json").exists(),
+            "ensure_mcp_config must write .mcp.json inside the given dir"
+        );
+        // Nothing must land directly under root (outside cfg).
+        assert!(
+            !root.path().join(".mcp.json").exists(),
+            "ensure_mcp_config must NOT write .mcp.json outside the given dir (isolation)"
+        );
+        // $HOME must remain empty — no .claude.json or .claude/ created.
+        assert!(
+            !fake_home.path().join(".mcp.json").exists(),
+            "ensure_mcp_config must NOT write .mcp.json to $HOME (isolation)"
+        );
+        assert!(
+            !fake_home.path().join(".claude").exists(),
+            "ensure_mcp_config must NOT create $HOME/.claude/ (isolation)"
+        );
+        // _home_guard drops here and restores HOME.
     }
 
     // F3: seed_credentials_from — src missing → returns Ok, dst unchanged.

--- a/crates/trusty-mpm/src/core/standalone/trust_seed.rs
+++ b/crates/trusty-mpm/src/core/standalone/trust_seed.rs
@@ -12,7 +12,7 @@
 //!
 //! What: [`preseed_managed_trust`] merges `projects.<workspace>` trust keys and
 //! `enabledMcpjsonServers` into `<claude_config_dir>/.claude.json`. The MCP
-//! server list is derived from `ensure_mcp_config` output (the same two servers
+//! server list is derived from `ensure_mcp_config` output (the same three servers
 //! written into the managed `.mcp.json`).
 //! Test: `test_preseed_managed_trust_marks_directory`,
 //!   `test_preseed_managed_trust_is_idempotent`,
@@ -27,10 +27,13 @@ use std::path::Path;
 /// Why: `preseed_managed_trust` must pre-approve exactly the servers that
 /// `ensure_mcp_config` wires into the managed `.mcp.json`; deriving them from the
 /// same constant keeps the two in sync without re-parsing the file at trust-seed time.
-/// What: the sorted list of server names — `["trusty-memory", "trusty-search"]` —
-/// matching the keys written by `ensure_mcp_config` in `global_config.rs`.
+/// What: the sorted list of server names —
+/// `["trusty-memory", "trusty-review", "trusty-search"]` — matching the keys
+/// written by `ensure_mcp_config` in `global_config.rs`.
+/// `trusty-review` was added in WI-8 (refs #1548).
 /// Test: asserted in `test_preseed_managed_trust_enables_mcp_servers`.
-pub(super) const MANAGED_MCP_SERVERS: &[&str] = &["trusty-memory", "trusty-search"];
+pub(super) const MANAGED_MCP_SERVERS: &[&str] =
+    &["trusty-memory", "trusty-review", "trusty-search"];
 
 /// Pre-seed project trust and MCP-server approval into `<claude_config_dir>/.claude.json`.
 ///
@@ -50,7 +53,7 @@ pub(super) const MANAGED_MCP_SERVERS: &[&str] = &["trusty-memory", "trusty-searc
 /// proceeds from a fresh `{}`), then ensures `projects.<workspace>` carries
 /// `hasTrustDialogAccepted: true`, `hasCompletedProjectOnboarding: true`,
 /// `projectOnboardingSeenCount: 1` (if not already ≥ 1), and
-/// `enabledMcpjsonServers: ["trusty-memory","trusty-search"]`.
+/// `enabledMcpjsonServers: ["trusty-memory","trusty-review","trusty-search"]`.
 /// Writes back pretty-printed; idempotent: if all fields already match, the
 /// file is NOT rewritten. All other keys in the file are preserved.
 /// Test: `test_preseed_managed_trust_marks_directory`,
@@ -211,7 +214,8 @@ mod tests {
         );
     }
 
-    // WI-3 MCP-ENABLE: preseed_managed_trust must pre-approve the managed MCP servers.
+    // WI-3 MCP-ENABLE / WI-8: preseed_managed_trust must pre-approve the managed MCP
+    // servers, including trusty-review added in WI-8 (refs #1548).
     #[test]
     fn test_preseed_managed_trust_enables_mcp_servers() {
         let tmp = TempDir::new().unwrap();
@@ -237,6 +241,12 @@ mod tests {
         assert!(
             names.contains(&"trusty-search"),
             "trusty-search must be in enabledMcpjsonServers; got {names:?}"
+        );
+        // WI-8: trusty-review must appear in the pre-approved server list so
+        // managed sessions do not see the "New MCP servers found" dialog for it.
+        assert!(
+            names.contains(&"trusty-review"),
+            "trusty-review must be in enabledMcpjsonServers (WI-8); got {names:?}"
         );
     }
 


### PR DESCRIPTION
WI-8 of epic #1548 (DOC-24): wire the `trusty-review` MCP server into the tm-global managed config dir (`~/.trusty-mpm/claude-config/`).

- `global_config.rs::ensure_mcp_config` now writes a `trusty-review` server entry into `.mcp.json`: `{"type":"stdio","command":"trusty-review","args":["serve","--stdio"]}` (mirrors the trusty-memory/trusty-search pattern).
- `trust_seed.rs::MANAGED_MCP_SERVERS` now includes `trusty-review`, so `preseed_managed_trust` writes it into `enabledMcpjsonServers` → no "new MCP servers found" dialog.
- No secrets injected: trusty-review inherits `OPENROUTER_API_KEY` / AWS / `TRUSTY_SEARCH_URL` from the daemon env, same as memory/search (documented in a code comment).
- Tests: extended the enable test + added an exact-entry test and a serial isolation guard (`test_mcp_config_review_no_home_write`) asserting no writes to the real `~/.claude*`.

Isolation invariant upheld: all writes stay inside `CLAUDE_CONFIG_DIR`. clippy/fmt/line-cap clean. (The 2 `daemon::state::tests` failures are pre-existing env flakes from a local `overseer.toml`, unrelated.)

Refs #1548 (WI-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)