### PR TITLE
chore(release): trusty-search v0.27.0 (typeahead #1557)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11068,7 +11068,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.15.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.26.0" }
+trusty-search = { path = "../trusty-search", version = "0.27.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [Unreleased]
+
+### Added
+
+- typeahead endpoint + MCP tool (lexical default, opt-in blended) (closes #1557) ([#1559](https://github.com/bobmatnyc/trusty-tools/pull/1559)) ([`db16554`](https://github.com/bobmatnyc/trusty-tools/commit/db16554bbfb6d5bc1f42f3aeb29bf0c7b71b9510))
+
+### Fixed
+
+- make publish.sh monorepo- and redb2-aware (closes #1539) ([#1544](https://github.com/bobmatnyc/trusty-tools/pull/1544)) ([`495dd92`](https://github.com/bobmatnyc/trusty-tools/commit/495dd926b8bcef2834aba725a991d1cd96b59047))
+- anchor Makefile sync-ui paths to makefile dir so it works from workspace root (closes #1540) ([#1543](https://github.com/bobmatnyc/trusty-tools/pull/1543)) ([`a54c6aa`](https://github.com/bobmatnyc/trusty-tools/commit/a54c6aa42bb84a45878d9b1225a9635688dd76bf))
+# Changelog
+
 All notable changes to trusty-search are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.26.1"
+version = "0.27.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
Version bump for the trusty-search typeahead release (#1557 / PR #1559). 0.26.1 → 0.27.0 (minor; feat). Dry-run clean; sidecars trusty-common 0.17.0 + trusty-embedderd 0.3.4 already on crates.io.

Tag + publish follow this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)