### PR TITLE
feat(trusty-mpm): configurable managed-root via --root / TRUSTY_MPM_ROOT / config.toml

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -403,7 +403,7 @@ pub(crate) enum Command {
     ///
     /// Why: declares an alias→URL mapping without cloning so users can register
     /// their fleet cheaply and `tm load <alias>` lazily.
-    /// What: persists `{alias, url}` to `~/.trusty-mpm/registry.json` and
+    /// What: persists `{alias, url}` to `<root>/registry.json` and
     /// prints `registered <alias> → <url>`.
     /// Test: `cli_parses_register`.
     Register {
@@ -414,6 +414,13 @@ pub(crate) enum Command {
         /// Overwrite an existing alias with a different URL.
         #[arg(long)]
         force: bool,
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
+        /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
+        /// default `~/.trusty-mpm`.
+        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        root: Option<String>,
     },
 
     /// List registered aliases with loaded status (DOC-24).
@@ -427,6 +434,13 @@ pub(crate) enum Command {
         /// Output as JSON array instead of a table.
         #[arg(long)]
         json: bool,
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
+        /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
+        /// default `~/.trusty-mpm`.
+        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        root: Option<String>,
     },
 
     /// Clone or refresh the managed workspace for a registered alias (DOC-24).
@@ -439,12 +453,19 @@ pub(crate) enum Command {
     Load {
         /// Registered alias to load.
         alias: String,
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
+        /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
+        /// default `~/.trusty-mpm`.
+        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        root: Option<String>,
     },
 
     /// Launch an interactive `claude` session for a managed alias (DOC-24).
     ///
     /// Why: `tm run` is the claude-mpm replacement — it launches Claude Code
-    /// with `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` so the global
+    /// with `CLAUDE_CONFIG_DIR=<root>/claude-config` so the global
     /// hooks/MCPs are supplied and the real `~/.claude` is excluded.
     /// What: loads the alias if needed, checks credentials, and spawns `claude`
     /// with inherited stdio.
@@ -455,35 +476,57 @@ pub(crate) enum Command {
         /// Optional initial task to pre-seed (currently unused by MVP).
         #[arg(long)]
         task: Option<String>,
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
+        /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
+        /// default `~/.trusty-mpm`.
+        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        root: Option<String>,
     },
 
     /// Print the stable repo path for a loaded alias (DOC-24 IDE-attach).
     ///
     /// Why: `tm path <alias>` lets IDEs, scripts, or `cd $(tm path <alias>)`
     /// open the project directory without running a session.
-    /// What: prints the absolute path to `~/.trusty-mpm/projects/<alias>/repo/`
+    /// What: prints the absolute path to `<root>/projects/<alias>/repo/`
     /// when the alias is loaded.
     /// Test: `cli_parses_path_standalone`.
     Path {
         /// Registered and loaded alias.
         alias: String,
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
+        /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
+        /// default `~/.trusty-mpm`.
+        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        root: Option<String>,
     },
 
     /// One-time keychain login for managed `tm run` sessions (WI-10, DOC-24).
     ///
     /// Why: `CLAUDE_CONFIG_DIR` relocates the macOS Keychain entry used for
-    /// Claude Max/Pro OAuth (A9). A fresh `~/.trusty-mpm/claude-config/` has
-    /// no keychain entry, so `tm run` reports "Not logged in". `tm login` runs
+    /// Claude Max/Pro OAuth (A9). A fresh managed `claude-config/` has no
+    /// keychain entry, so `tm run` reports "Not logged in". `tm login` runs
     /// `claude auth login` under the tm-global `CLAUDE_CONFIG_DIR` so the
     /// OAuth flow creates a keychain entry for that path. This is a one-time
     /// setup — the entry persists across sessions on this machine.
     /// What: ensures the tm-global config dir exists, spawns
-    /// `claude auth login` with `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config`
+    /// `claude auth login` with `CLAUDE_CONFIG_DIR=<root>/claude-config`
     /// and inherited stdio, prints guidance before/after the OAuth flow.
     /// Alternative: set `ANTHROPIC_API_KEY` to use the API-key+`--bare` path
     /// instead (for CI/automation, no login required).
     /// Test: `cli_parses_login_standalone`.
-    Login,
+    Login {
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
+        /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
+        /// default `~/.trusty-mpm`.
+        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        root: Option<String>,
+    },
 
     /// Standalone metaharness — PM + sub-agent delegation without the daemon (#1045).
     ///

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -419,7 +419,12 @@ pub(crate) enum Command {
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
         /// default `~/.trusty-mpm`.
-        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here. The env var is
+        /// read as tier-2 inside `resolve_managed_paths`; binding it to this
+        /// arg would promote it to tier-1 (CLI-flag) and silently skip the
+        /// config-file tier whenever the env var is set.
+        #[arg(long)]
         root: Option<String>,
     },
 
@@ -439,7 +444,9 @@ pub(crate) enum Command {
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
         /// default `~/.trusty-mpm`.
-        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
+        #[arg(long)]
         root: Option<String>,
     },
 
@@ -458,7 +465,9 @@ pub(crate) enum Command {
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
         /// default `~/.trusty-mpm`.
-        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
+        #[arg(long)]
         root: Option<String>,
     },
 
@@ -481,7 +490,9 @@ pub(crate) enum Command {
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
         /// default `~/.trusty-mpm`.
-        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
+        #[arg(long)]
         root: Option<String>,
     },
 
@@ -500,7 +511,9 @@ pub(crate) enum Command {
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
         /// default `~/.trusty-mpm`.
-        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
+        #[arg(long)]
         root: Option<String>,
     },
 
@@ -524,7 +537,9 @@ pub(crate) enum Command {
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
         /// default `~/.trusty-mpm`.
-        #[arg(long, env = "TRUSTY_MPM_ROOT")]
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
+        #[arg(long)]
         root: Option<String>,
     },
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_root.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_root.rs
@@ -227,48 +227,76 @@ mod tests {
     // time, making the usage safe in practice.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    // ── helpers ─────────────────────────────────────────────────────────────
+    // ── low-level unsafe helpers ─────────────────────────────────────────────
 
-    /// Set an env var while the caller holds `ENV_LOCK`.
+    /// Set an env var (caller must hold `ENV_LOCK`).
     ///
     /// Why: `std::env::set_var` is unsafe in Rust 2024; centralising the
     /// `unsafe` block here keeps the individual tests readable.
     /// What: calls `std::env::set_var` inside an unsafe block.
-    /// Test: used internally by `with_clean_env`.
+    /// Test: used internally by the RAII guard.
     fn set_env(key: &str, val: &str) {
         // SAFETY: we hold ENV_LOCK for the entire duration of every test that
         // calls this, ensuring no concurrent env mutations from other threads.
         unsafe { std::env::set_var(key, val) }
     }
 
-    /// Remove an env var while the caller holds `ENV_LOCK`.
+    /// Remove an env var (caller must hold `ENV_LOCK`).
     ///
     /// Why: mirrors `set_env` for removals.
     /// What: calls `std::env::remove_var` inside an unsafe block.
-    /// Test: used internally by `with_clean_env`.
+    /// Test: used internally by the RAII guard.
     fn remove_env(key: &str) {
         // SAFETY: same as set_env — ENV_LOCK guarantees no concurrent mutation.
         unsafe { std::env::remove_var(key) }
     }
 
-    /// Run `f` with `TRUSTY_MPM_ROOT` and `XDG_CONFIG_HOME` cleared, while
-    /// holding the global env lock so no two tests race on env state.
-    fn with_clean_env<F: FnOnce() -> R, R>(f: F) -> R {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let saved_root = std::env::var("TRUSTY_MPM_ROOT").ok();
-        let saved_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-        remove_env("TRUSTY_MPM_ROOT");
-        remove_env("XDG_CONFIG_HOME");
-        let result = f();
-        match saved_root {
-            Some(v) => set_env("TRUSTY_MPM_ROOT", &v),
-            None => remove_env("TRUSTY_MPM_ROOT"),
+    // ── RAII env guard ───────────────────────────────────────────────────────
+
+    /// RAII guard that holds `ENV_LOCK` and restores `TRUSTY_MPM_ROOT` +
+    /// `XDG_CONFIG_HOME` on drop — even if the test panics.
+    ///
+    /// Why: the previous `with_clean_env` closure-based helper did not restore
+    /// env vars when the closure panicked, poisoning `ENV_LOCK` and leaving env
+    /// dirty for subsequent tests. A `Drop` impl restores state unconditionally.
+    /// What: acquires `ENV_LOCK`, saves the current values of both vars, clears
+    /// them; on `Drop` restores both vars to their saved state.
+    /// Test: every `test_resolve_*` test relies on this guard for isolation.
+    struct CleanEnvGuard {
+        saved_root: Option<String>,
+        saved_xdg: Option<String>,
+        // Hold the lock for the guard's lifetime.
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CleanEnvGuard {
+        /// Acquire the lock, save both vars, and clear them.
+        fn new() -> Self {
+            let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let saved_root = std::env::var("TRUSTY_MPM_ROOT").ok();
+            let saved_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+            remove_env("TRUSTY_MPM_ROOT");
+            remove_env("XDG_CONFIG_HOME");
+            Self {
+                saved_root,
+                saved_xdg,
+                _lock,
+            }
         }
-        match saved_xdg {
-            Some(v) => set_env("XDG_CONFIG_HOME", &v),
-            None => remove_env("XDG_CONFIG_HOME"),
+    }
+
+    impl Drop for CleanEnvGuard {
+        fn drop(&mut self) {
+            // Restore both vars unconditionally, even on panic.
+            match &self.saved_root {
+                Some(v) => set_env("TRUSTY_MPM_ROOT", v),
+                None => remove_env("TRUSTY_MPM_ROOT"),
+            }
+            match &self.saved_xdg {
+                Some(v) => set_env("XDG_CONFIG_HOME", v),
+                None => remove_env("XDG_CONFIG_HOME"),
+            }
         }
-        result
     }
 
     // ── ManagedPaths ────────────────────────────────────────────────────────
@@ -313,10 +341,9 @@ mod tests {
 
     #[test]
     fn test_xdg_config_path_uses_xdg_home() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = CleanEnvGuard::new();
         set_env("XDG_CONFIG_HOME", "/custom/config");
         let path = xdg_config_path();
-        remove_env("XDG_CONFIG_HOME");
         assert_eq!(
             path,
             Some(PathBuf::from("/custom/config/trusty-mpm/config.toml"))
@@ -325,8 +352,8 @@ mod tests {
 
     #[test]
     fn test_xdg_config_path_falls_back_to_home_config() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        remove_env("XDG_CONFIG_HOME");
+        let _g = CleanEnvGuard::new();
+        // XDG_CONFIG_HOME was cleared by the guard; test the fallback path.
         let path = xdg_config_path();
         if let Some(home) = dirs::home_dir() {
             assert_eq!(
@@ -341,31 +368,28 @@ mod tests {
     #[test]
     fn test_resolve_default() {
         // Nothing set → default ~/.trusty-mpm
-        with_clean_env(|| {
-            let root = resolve_root(None).expect("resolve_root should succeed");
-            let home = dirs::home_dir().expect("home dir required");
-            assert_eq!(root, home.join(".trusty-mpm"));
-        });
+        let _g = CleanEnvGuard::new();
+        let root = resolve_root(None).expect("resolve_root should succeed");
+        let home = dirs::home_dir().expect("home dir required");
+        assert_eq!(root, home.join(".trusty-mpm"));
     }
 
     #[test]
     fn test_resolve_env_wins_over_default() {
         // TRUSTY_MPM_ROOT set → env value wins over default
-        with_clean_env(|| {
-            set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
-            let root = resolve_root(None).expect("resolve_root should succeed");
-            assert_eq!(root, PathBuf::from("/tmp/from-env"));
-        });
+        let _g = CleanEnvGuard::new();
+        set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
+        let root = resolve_root(None).expect("resolve_root should succeed");
+        assert_eq!(root, PathBuf::from("/tmp/from-env"));
     }
 
     #[test]
     fn test_resolve_flag_wins_over_env() {
         // CLI flag set + env set → flag wins
-        with_clean_env(|| {
-            set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
-            let root = resolve_root(Some("/tmp/from-flag")).expect("resolve_root should succeed");
-            assert_eq!(root, PathBuf::from("/tmp/from-flag"));
-        });
+        let _g = CleanEnvGuard::new();
+        set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
+        let root = resolve_root(Some("/tmp/from-flag")).expect("resolve_root should succeed");
+        assert_eq!(root, PathBuf::from("/tmp/from-flag"));
     }
 
     #[test]
@@ -377,12 +401,12 @@ mod tests {
         let cfg_path = cfg_dir.join("config.toml");
         std::fs::write(&cfg_path, "[standalone]\nroot = \"/tmp/from-config\"\n").unwrap();
 
-        with_clean_env(|| {
-            // Point XDG_CONFIG_HOME at our temp dir so resolve_root finds the file
-            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
-            let root = resolve_root(None).expect("resolve_root should succeed");
-            assert_eq!(root, PathBuf::from("/tmp/from-config"));
-        });
+        let _g = CleanEnvGuard::new();
+        // Point XDG_CONFIG_HOME at our temp dir so resolve_root finds the file.
+        // TRUSTY_MPM_ROOT is absent (cleared by guard) → config file is tier-3.
+        set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+        let root = resolve_root(None).expect("resolve_root should succeed");
+        assert_eq!(root, PathBuf::from("/tmp/from-config"));
     }
 
     #[test]
@@ -394,11 +418,10 @@ mod tests {
         let cfg_path = cfg_dir.join("config.toml");
         std::fs::write(&cfg_path, "[standalone]\nroot = \"/tmp/from-config\"\n").unwrap();
 
-        with_clean_env(|| {
-            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
-            let root = resolve_root(Some("/tmp/from-flag")).expect("resolve_root should succeed");
-            assert_eq!(root, PathBuf::from("/tmp/from-flag"));
-        });
+        let _g = CleanEnvGuard::new();
+        set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+        let root = resolve_root(Some("/tmp/from-flag")).expect("resolve_root should succeed");
+        assert_eq!(root, PathBuf::from("/tmp/from-flag"));
     }
 
     #[test]
@@ -410,25 +433,68 @@ mod tests {
         let cfg_path = cfg_dir.join("config.toml");
         std::fs::write(&cfg_path, "[standalone]\nroot = \"/tmp/from-config\"\n").unwrap();
 
-        with_clean_env(|| {
+        let _g = CleanEnvGuard::new();
+        set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+        set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
+        let root = resolve_root(None).expect("resolve_root should succeed");
+        assert_eq!(root, PathBuf::from("/tmp/from-env"));
+    }
+
+    /// Prove that the env var does NOT skip config.toml: when env is set,
+    /// env wins; when env is absent, config.toml is consulted.
+    ///
+    /// This test guards against the regression described in review finding #1:
+    /// if `env = "TRUSTY_MPM_ROOT"` is ever added back to the clap `#[arg]`,
+    /// clap populates `root` from the env var before `main` calls
+    /// `resolve_managed_paths(root.as_deref())`, which would make the env var
+    /// look like a CLI flag (tier-1) and cause `resolve_managed_paths` to return
+    /// immediately, silently skipping config.toml. With the env var read only
+    /// inside `resolve_root` (tier-2), both branches below must pass.
+    #[test]
+    fn test_env_and_config_file_independent_tiers() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_dir = tmp.path().join("trusty-mpm");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let cfg_path = cfg_dir.join("config.toml");
+        std::fs::write(&cfg_path, "[standalone]\nroot = \"/tmp/from-config\"\n").unwrap();
+
+        // Branch A: env set + config file present + no --root → env wins (tier 2)
+        {
+            let _g = CleanEnvGuard::new();
             set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
             set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
-            let root = resolve_root(None).expect("resolve_root should succeed");
-            assert_eq!(root, PathBuf::from("/tmp/from-env"));
-        });
+            let root = resolve_root(None).expect("resolve_root");
+            assert_eq!(
+                root,
+                PathBuf::from("/tmp/from-env"),
+                "env must win over config.toml when TRUSTY_MPM_ROOT is set"
+            );
+        } // guard drops here, restoring env
+
+        // Branch B: env absent + config file present + no --root → config wins (tier 3)
+        {
+            let _g = CleanEnvGuard::new();
+            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+            // TRUSTY_MPM_ROOT is NOT set (guard cleared it)
+            let root = resolve_root(None).expect("resolve_root");
+            assert_eq!(
+                root,
+                PathBuf::from("/tmp/from-config"),
+                "config.toml must be consulted when TRUSTY_MPM_ROOT is absent"
+            );
+        }
     }
 
     #[test]
     fn test_resolve_config_file_missing_is_ok() {
         // Absent config file falls through to default without error
         let tmp = tempfile::tempdir().expect("tempdir");
-        with_clean_env(|| {
-            // Point XDG_CONFIG_HOME at an empty temp dir (no config.toml exists)
-            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
-            let root = resolve_root(None).expect("resolve_root should succeed");
-            let home = dirs::home_dir().expect("home dir required");
-            assert_eq!(root, home.join(".trusty-mpm"));
-        });
+        let _g = CleanEnvGuard::new();
+        // Point XDG_CONFIG_HOME at an empty temp dir (no config.toml exists)
+        set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+        let root = resolve_root(None).expect("resolve_root should succeed");
+        let home = dirs::home_dir().expect("home dir required");
+        assert_eq!(root, home.join(".trusty-mpm"));
     }
 
     #[test]
@@ -440,36 +506,33 @@ mod tests {
         let cfg_path = cfg_dir.join("config.toml");
         std::fs::write(&cfg_path, "this is not valid toml :::").unwrap();
 
-        with_clean_env(|| {
-            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
-            let root = resolve_root(None).expect("resolve_root should succeed");
-            let home = dirs::home_dir().expect("home dir required");
-            assert_eq!(root, home.join(".trusty-mpm"));
-        });
+        let _g = CleanEnvGuard::new();
+        set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+        let root = resolve_root(None).expect("resolve_root should succeed");
+        let home = dirs::home_dir().expect("home dir required");
+        assert_eq!(root, home.join(".trusty-mpm"));
     }
 
     #[test]
     fn test_resolve_tilde_in_env() {
         // Tilde in TRUSTY_MPM_ROOT env var is expanded
-        with_clean_env(|| {
-            set_env("TRUSTY_MPM_ROOT", "~/my-tm-root");
-            let root = resolve_root(None).expect("resolve_root should succeed");
-            let home = dirs::home_dir().expect("home dir required");
-            assert_eq!(root, home.join("my-tm-root"));
-        });
+        let _g = CleanEnvGuard::new();
+        set_env("TRUSTY_MPM_ROOT", "~/my-tm-root");
+        let root = resolve_root(None).expect("resolve_root should succeed");
+        let home = dirs::home_dir().expect("home dir required");
+        assert_eq!(root, home.join("my-tm-root"));
     }
 
     #[test]
     fn test_resolve_managed_paths_sets_claude_config_dir() {
         // resolve_managed_paths builds both root and claude_config_dir
-        with_clean_env(|| {
-            set_env("TRUSTY_MPM_ROOT", "/tmp/test-root");
-            let mp = resolve_managed_paths(None).expect("should resolve");
-            assert_eq!(mp.root, PathBuf::from("/tmp/test-root"));
-            assert_eq!(
-                mp.claude_config_dir,
-                PathBuf::from("/tmp/test-root/claude-config")
-            );
-        });
+        let _g = CleanEnvGuard::new();
+        set_env("TRUSTY_MPM_ROOT", "/tmp/test-root");
+        let mp = resolve_managed_paths(None).expect("should resolve");
+        assert_eq!(mp.root, PathBuf::from("/tmp/test-root"));
+        assert_eq!(
+            mp.claude_config_dir,
+            PathBuf::from("/tmp/test-root/claude-config")
+        );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_root.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_root.rs
@@ -1,0 +1,475 @@
+//! Configurable managed-root resolution for the `tm` standalone driver.
+//!
+//! Why: the managed root was previously hardcoded to `~/.trusty-mpm/`,
+//! making it impossible to run multiple isolated environments or override
+//! the root in CI/automation (closes #1566).
+//! What: exposes [`ManagedPaths`] (holds `root` + `claude_config_dir`) and
+//! [`resolve_managed_paths`] which applies a four-level precedence:
+//! CLI flag `--root` > env var `TRUSTY_MPM_ROOT` > config-file key
+//! `[standalone] root` > default `~/.trusty-mpm`.
+//! The config file is discovered at a FIXED XDG-style location independent of
+//! the managed root: `$XDG_CONFIG_HOME/trusty-mpm/config.toml` falling back
+//! to `~/.config/trusty-mpm/config.toml`. This avoids the chicken-and-egg
+//! problem of finding the config before the root is known.
+//! Test: `test_resolve_*` unit tests in this module cover every precedence
+//! level; see also `standalone.rs` integration path.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::Deserialize;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Resolved paths for the standalone managed driver.
+///
+/// Why: groups the two paths that every standalone command needs so they are
+/// computed once at command entry and threaded as a single value — no global
+/// state, no repeated resolution, no divergence between `root` and
+/// `claude_config_dir`.
+/// What: holds `root` (the managed root, e.g. `~/.trusty-mpm`) and
+/// `claude_config_dir` (always `<root>/claude-config`).
+/// Test: constructed by [`resolve_managed_paths`]; every `_cmd` function in
+/// `standalone.rs` accepts a `&ManagedPaths`.
+#[derive(Debug, Clone)]
+pub(crate) struct ManagedPaths {
+    /// Managed root directory (e.g. `~/.trusty-mpm`).
+    pub(crate) root: PathBuf,
+    /// CLAUDE_CONFIG_DIR for all tm-managed sessions (`<root>/claude-config`).
+    pub(crate) claude_config_dir: PathBuf,
+}
+
+impl ManagedPaths {
+    /// Construct from an already-resolved root.
+    ///
+    /// Why: lets callers (and tests) build `ManagedPaths` from any `PathBuf`
+    /// without going through the full resolver.
+    /// What: sets `claude_config_dir = root.join("claude-config")`.
+    /// Test: `test_managed_paths_claude_config_dir_is_subdir`.
+    pub(crate) fn from_root(root: PathBuf) -> Self {
+        let claude_config_dir = root.join("claude-config");
+        Self {
+            root,
+            claude_config_dir,
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Config-file section
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `[standalone]` section of the XDG-located `trusty-mpm/config.toml`.
+///
+/// Why: the managed-root config file lives at a FIXED path independent of the
+/// managed root itself to avoid a chicken-and-egg problem (the root cannot be
+/// known before the config is read).
+/// What: currently only `root` is supported; the struct is `#[non_exhaustive]`
+/// so future keys can be added without breaking the deserializer.
+/// Test: `test_resolve_config_file_wins_over_default`.
+#[derive(Debug, Deserialize, Default)]
+#[non_exhaustive]
+pub(crate) struct StandaloneConfig {
+    /// Optional managed root override (`[standalone] root = "/some/path"`).
+    pub(crate) root: Option<String>,
+}
+
+/// Wrapper for the XDG config file to deserialize `[standalone]`.
+///
+/// Why: `toml::from_str` needs a top-level struct that maps to the file's
+/// section structure; this thin wrapper lets `StandaloneConfig` live cleanly
+/// under `[standalone]`.
+/// What: deserializes only the `[standalone]` key; all other keys are ignored.
+/// Test: `test_resolve_config_file_wins_over_default`.
+#[derive(Debug, Deserialize, Default)]
+struct XdgConfigFile {
+    #[serde(default)]
+    standalone: StandaloneConfig,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Resolver
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Resolve `ManagedPaths` using the four-level precedence.
+///
+/// Why: centralises root resolution so every standalone command uses the same
+/// logic with zero divergence (closes #1566).
+///
+/// What: applies, highest-priority first:
+///
+/// 1. `cli_root` — the `--root` flag value (caller passes `None` if absent);
+/// 2. `TRUSTY_MPM_ROOT` env var;
+/// 3. `[standalone] root` key in `$XDG_CONFIG_HOME/trusty-mpm/config.toml`
+///    (or `~/.config/trusty-mpm/config.toml` fallback);
+/// 4. `~/.trusty-mpm` default.
+///
+/// Tilde (`~`) in any string source is expanded to the real home directory.
+///
+/// Test: `test_resolve_flag_wins`, `test_resolve_env_wins_over_config`,
+/// `test_resolve_config_file_wins_over_default`, `test_resolve_default`.
+pub(crate) fn resolve_managed_paths(cli_root: Option<&str>) -> anyhow::Result<ManagedPaths> {
+    let root = resolve_root(cli_root)?;
+    Ok(ManagedPaths::from_root(root))
+}
+
+/// Inner resolver that returns only the root `PathBuf`.
+///
+/// Why: separates the resolution logic from `ManagedPaths` construction so
+/// unit tests can assert on the path alone.
+/// What: walks the precedence chain and returns the first non-empty source.
+/// Test: same tests as [`resolve_managed_paths`].
+fn resolve_root(cli_root: Option<&str>) -> anyhow::Result<PathBuf> {
+    // 1. CLI flag
+    if let Some(raw) = cli_root {
+        let p = expand_tilde(raw)?;
+        return Ok(p);
+    }
+
+    // 2. Env var
+    if let Ok(raw) = std::env::var("TRUSTY_MPM_ROOT")
+        && !raw.is_empty()
+    {
+        let p = expand_tilde(&raw)?;
+        return Ok(p);
+    }
+
+    // 3. Config file
+    if let Some(cfg_path) = xdg_config_path()
+        && let Some(root) = read_standalone_root_from_file(&cfg_path)
+    {
+        let p = expand_tilde(&root)?;
+        return Ok(p);
+    }
+
+    // 4. Default
+    dirs::home_dir()
+        .map(|h| h.join(".trusty-mpm"))
+        .context("cannot resolve home directory for default managed root")
+}
+
+/// Expand a leading `~/` to the real home directory.
+///
+/// Why: users naturally write `~/my-tm-root` in env vars and config files;
+/// the shell does not expand those in non-interactive contexts.
+/// What: replaces a leading `~/` or bare `~` with `$HOME`; leaves all other
+/// paths unchanged. Returns an error when tilde expansion is needed but `HOME`
+/// is unavailable.
+/// Test: `test_expand_tilde_expands` and `test_expand_tilde_noop`.
+pub(crate) fn expand_tilde(raw: &str) -> anyhow::Result<PathBuf> {
+    if raw == "~" || raw.starts_with("~/") {
+        let home = dirs::home_dir().context("cannot resolve home directory for tilde expansion")?;
+        let rest = raw.trim_start_matches('~').trim_start_matches('/');
+        if rest.is_empty() {
+            Ok(home)
+        } else {
+            Ok(home.join(rest))
+        }
+    } else {
+        Ok(PathBuf::from(raw))
+    }
+}
+
+/// Return the XDG-style config path for trusty-mpm.
+///
+/// Why: the config file that can override the managed root must live at a
+/// FIXED location that does not depend on the managed root — otherwise the
+/// root cannot be known before the config file is read.
+/// What: returns `$XDG_CONFIG_HOME/trusty-mpm/config.toml` when
+/// `$XDG_CONFIG_HOME` is set and non-empty, else `~/.config/trusty-mpm/config.toml`.
+/// Returns `None` when neither `XDG_CONFIG_HOME` nor `HOME` is available (rare
+/// in practice; only affects stripped CI environments).
+/// Test: `test_xdg_config_path_uses_xdg_home` and
+/// `test_xdg_config_path_falls_back_to_home_config`.
+pub(crate) fn xdg_config_path() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        return Some(PathBuf::from(xdg).join("trusty-mpm").join("config.toml"));
+    }
+    dirs::home_dir().map(|h| h.join(".config").join("trusty-mpm").join("config.toml"))
+}
+
+/// Read `[standalone] root` from a TOML config file, if present.
+///
+/// Why: the config-file tier in the precedence chain lets users set a permanent
+/// managed-root override without exporting env vars in every shell.
+/// What: reads `path`, parses TOML, extracts `standalone.root`; returns `None`
+/// on any I/O or parse error (non-existent file, malformed TOML, absent key).
+/// Errors are deliberately swallowed — a bad config file should never prevent
+/// the standalone driver from starting with the default.
+/// Test: `test_resolve_config_file_wins_over_default`.
+fn read_standalone_root_from_file(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let cfg: XdgConfigFile = toml::from_str(&raw).ok()?;
+    let root = cfg.standalone.root?;
+    if root.is_empty() { None } else { Some(root) }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    // Serialize env-var mutations so parallel test threads do not race.
+    // Each test that sets env vars must hold this lock for its entire duration.
+    //
+    // Note: `set_var`/`remove_var` are unsafe in Rust 2024 edition because they
+    // are unsound in multi-threaded programs without synchronization. We hold
+    // `ENV_LOCK` across every mutation so only one thread mutates the env at a
+    // time, making the usage safe in practice.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    /// Set an env var while the caller holds `ENV_LOCK`.
+    ///
+    /// Why: `std::env::set_var` is unsafe in Rust 2024; centralising the
+    /// `unsafe` block here keeps the individual tests readable.
+    /// What: calls `std::env::set_var` inside an unsafe block.
+    /// Test: used internally by `with_clean_env`.
+    fn set_env(key: &str, val: &str) {
+        // SAFETY: we hold ENV_LOCK for the entire duration of every test that
+        // calls this, ensuring no concurrent env mutations from other threads.
+        unsafe { std::env::set_var(key, val) }
+    }
+
+    /// Remove an env var while the caller holds `ENV_LOCK`.
+    ///
+    /// Why: mirrors `set_env` for removals.
+    /// What: calls `std::env::remove_var` inside an unsafe block.
+    /// Test: used internally by `with_clean_env`.
+    fn remove_env(key: &str) {
+        // SAFETY: same as set_env — ENV_LOCK guarantees no concurrent mutation.
+        unsafe { std::env::remove_var(key) }
+    }
+
+    /// Run `f` with `TRUSTY_MPM_ROOT` and `XDG_CONFIG_HOME` cleared, while
+    /// holding the global env lock so no two tests race on env state.
+    fn with_clean_env<F: FnOnce() -> R, R>(f: F) -> R {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved_root = std::env::var("TRUSTY_MPM_ROOT").ok();
+        let saved_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        remove_env("TRUSTY_MPM_ROOT");
+        remove_env("XDG_CONFIG_HOME");
+        let result = f();
+        match saved_root {
+            Some(v) => set_env("TRUSTY_MPM_ROOT", &v),
+            None => remove_env("TRUSTY_MPM_ROOT"),
+        }
+        match saved_xdg {
+            Some(v) => set_env("XDG_CONFIG_HOME", &v),
+            None => remove_env("XDG_CONFIG_HOME"),
+        }
+        result
+    }
+
+    // ── ManagedPaths ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_managed_paths_claude_config_dir_is_subdir() {
+        let root = PathBuf::from("/tmp/my-root");
+        let mp = ManagedPaths::from_root(root.clone());
+        assert_eq!(mp.root, root);
+        assert_eq!(mp.claude_config_dir, root.join("claude-config"));
+    }
+
+    // ── expand_tilde ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_expand_tilde_expands() {
+        let home = dirs::home_dir().expect("home dir required for this test");
+        let result = expand_tilde("~/foo/bar").unwrap();
+        assert_eq!(result, home.join("foo/bar"));
+    }
+
+    #[test]
+    fn test_expand_tilde_bare_tilde() {
+        let home = dirs::home_dir().expect("home dir required for this test");
+        let result = expand_tilde("~").unwrap();
+        assert_eq!(result, home);
+    }
+
+    #[test]
+    fn test_expand_tilde_noop_absolute() {
+        let result = expand_tilde("/absolute/path").unwrap();
+        assert_eq!(result, PathBuf::from("/absolute/path"));
+    }
+
+    #[test]
+    fn test_expand_tilde_noop_relative() {
+        let result = expand_tilde("relative/path").unwrap();
+        assert_eq!(result, PathBuf::from("relative/path"));
+    }
+
+    // ── xdg_config_path ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_xdg_config_path_uses_xdg_home() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_env("XDG_CONFIG_HOME", "/custom/config");
+        let path = xdg_config_path();
+        remove_env("XDG_CONFIG_HOME");
+        assert_eq!(
+            path,
+            Some(PathBuf::from("/custom/config/trusty-mpm/config.toml"))
+        );
+    }
+
+    #[test]
+    fn test_xdg_config_path_falls_back_to_home_config() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        remove_env("XDG_CONFIG_HOME");
+        let path = xdg_config_path();
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(
+                path,
+                Some(home.join(".config").join("trusty-mpm").join("config.toml"))
+            );
+        }
+    }
+
+    // ── resolve_root precedence ──────────────────────────────────────────────
+
+    #[test]
+    fn test_resolve_default() {
+        // Nothing set → default ~/.trusty-mpm
+        with_clean_env(|| {
+            let root = resolve_root(None).expect("resolve_root should succeed");
+            let home = dirs::home_dir().expect("home dir required");
+            assert_eq!(root, home.join(".trusty-mpm"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_env_wins_over_default() {
+        // TRUSTY_MPM_ROOT set → env value wins over default
+        with_clean_env(|| {
+            set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
+            let root = resolve_root(None).expect("resolve_root should succeed");
+            assert_eq!(root, PathBuf::from("/tmp/from-env"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_flag_wins_over_env() {
+        // CLI flag set + env set → flag wins
+        with_clean_env(|| {
+            set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
+            let root = resolve_root(Some("/tmp/from-flag")).expect("resolve_root should succeed");
+            assert_eq!(root, PathBuf::from("/tmp/from-flag"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_config_file_wins_over_default() {
+        // Config file present → config value wins over default (when no flag/env set)
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_dir = tmp.path().join("trusty-mpm");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let cfg_path = cfg_dir.join("config.toml");
+        std::fs::write(&cfg_path, "[standalone]\nroot = \"/tmp/from-config\"\n").unwrap();
+
+        with_clean_env(|| {
+            // Point XDG_CONFIG_HOME at our temp dir so resolve_root finds the file
+            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+            let root = resolve_root(None).expect("resolve_root should succeed");
+            assert_eq!(root, PathBuf::from("/tmp/from-config"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_flag_wins_over_config_file() {
+        // CLI flag wins even when config file is present
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_dir = tmp.path().join("trusty-mpm");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let cfg_path = cfg_dir.join("config.toml");
+        std::fs::write(&cfg_path, "[standalone]\nroot = \"/tmp/from-config\"\n").unwrap();
+
+        with_clean_env(|| {
+            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+            let root = resolve_root(Some("/tmp/from-flag")).expect("resolve_root should succeed");
+            assert_eq!(root, PathBuf::from("/tmp/from-flag"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_env_wins_over_config_file() {
+        // Env var wins over config file
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_dir = tmp.path().join("trusty-mpm");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let cfg_path = cfg_dir.join("config.toml");
+        std::fs::write(&cfg_path, "[standalone]\nroot = \"/tmp/from-config\"\n").unwrap();
+
+        with_clean_env(|| {
+            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+            set_env("TRUSTY_MPM_ROOT", "/tmp/from-env");
+            let root = resolve_root(None).expect("resolve_root should succeed");
+            assert_eq!(root, PathBuf::from("/tmp/from-env"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_config_file_missing_is_ok() {
+        // Absent config file falls through to default without error
+        let tmp = tempfile::tempdir().expect("tempdir");
+        with_clean_env(|| {
+            // Point XDG_CONFIG_HOME at an empty temp dir (no config.toml exists)
+            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+            let root = resolve_root(None).expect("resolve_root should succeed");
+            let home = dirs::home_dir().expect("home dir required");
+            assert_eq!(root, home.join(".trusty-mpm"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_config_file_malformed_is_ignored() {
+        // Malformed TOML in config file falls through to default without error
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_dir = tmp.path().join("trusty-mpm");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let cfg_path = cfg_dir.join("config.toml");
+        std::fs::write(&cfg_path, "this is not valid toml :::").unwrap();
+
+        with_clean_env(|| {
+            set_env("XDG_CONFIG_HOME", tmp.path().to_str().unwrap());
+            let root = resolve_root(None).expect("resolve_root should succeed");
+            let home = dirs::home_dir().expect("home dir required");
+            assert_eq!(root, home.join(".trusty-mpm"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_tilde_in_env() {
+        // Tilde in TRUSTY_MPM_ROOT env var is expanded
+        with_clean_env(|| {
+            set_env("TRUSTY_MPM_ROOT", "~/my-tm-root");
+            let root = resolve_root(None).expect("resolve_root should succeed");
+            let home = dirs::home_dir().expect("home dir required");
+            assert_eq!(root, home.join("my-tm-root"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_managed_paths_sets_claude_config_dir() {
+        // resolve_managed_paths builds both root and claude_config_dir
+        with_clean_env(|| {
+            set_env("TRUSTY_MPM_ROOT", "/tmp/test-root");
+            let mp = resolve_managed_paths(None).expect("should resolve");
+            assert_eq!(mp.root, PathBuf::from("/tmp/test-root"));
+            assert_eq!(
+                mp.claude_config_dir,
+                PathBuf::from("/tmp/test-root/claude-config")
+            );
+        });
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod install;
 pub(crate) mod issue;
 pub(crate) mod launch;
 pub(crate) mod managed;
+pub(crate) mod managed_root;
 pub(crate) mod managed_route;
 pub(crate) mod meta;
 pub(crate) mod misc;

--- a/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
@@ -5,37 +5,16 @@
 //! these handlers in their own file preserves the existing handlers untouched
 //! and stays under the 500-SLOC cap.
 //! What: six thin handlers — `register_cmd`, `ls_cmd`, `load_cmd`, `run_cmd`,
-//! `path_cmd`, and `login_cmd` — each delegating to
-//! `trusty_mpm::core::standalone`. `login_cmd` (WI-10) launches
-//! `claude auth login` under the tm-global CLAUDE_CONFIG_DIR so the OAuth flow
-//! creates a keychain entry for that path, enabling future `tm run` sessions to
-//! authenticate on the user's Claude Max/Pro plan.
+//! `path_cmd`, and `login_cmd` — each accepting a `&ManagedPaths` resolved by
+//! `resolve_managed_paths` in `managed_root.rs` (closes #1566). `login_cmd`
+//! (WI-10) launches `claude auth login` under the tm-global CLAUDE_CONFIG_DIR
+//! so the OAuth flow creates a keychain entry for that path, enabling future
+//! `tm run` sessions to authenticate on the user's Claude Max/Pro plan.
 //! Test: exercised by `cli_parses_register`, `cli_parses_ls`, etc. in tests.rs.
 
 use anyhow::Context;
 
-/// Default managed root under the user's home directory.
-///
-/// Why: every handler resolves the managed root from the same place so paths
-/// are consistent across register/load/run/path/ls.
-/// What: returns `~/.trusty-mpm/` as the managed root `PathBuf`.
-/// Test: indirectly tested by every handler test.
-fn managed_root() -> anyhow::Result<std::path::PathBuf> {
-    dirs::home_dir()
-        .map(|h| h.join(".trusty-mpm"))
-        .context("cannot resolve home directory")
-}
-
-/// The tm-global CLAUDE_CONFIG_DIR used by all standalone sessions.
-///
-/// Why: all sessions launched by `tm run` share one CLAUDE_CONFIG_DIR so the
-/// global hooks/skills/MCPs are applied consistently and the real `~/.claude`
-/// is excluded.
-/// What: returns `~/.trusty-mpm/claude-config/`.
-/// Test: indirectly tested by `run_cmd`.
-fn claude_config_dir() -> anyhow::Result<std::path::PathBuf> {
-    Ok(managed_root()?.join("claude-config"))
-}
+use super::managed_root::ManagedPaths;
 
 /// Handle `tm register <alias> <url> [--force]`.
 ///
@@ -44,9 +23,14 @@ fn claude_config_dir() -> anyhow::Result<std::path::PathBuf> {
 /// What: validates the alias, calls `ManagedRegistry::add`, saves, and prints
 /// `registered <alias> → <url>` to stdout.
 /// Test: `cli_parses_register` in tests.rs; logic in registry tests.
-pub(crate) fn register_cmd(alias: &str, url: &str, force: bool) -> anyhow::Result<()> {
-    let root = managed_root()?;
-    let mut registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(&root)
+pub(crate) fn register_cmd(
+    paths: &ManagedPaths,
+    alias: &str,
+    url: &str,
+    force: bool,
+) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let mut registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(root)
         .with_context(|| format!("failed to load registry from {}", root.display()))?;
     registry
         .add(alias, url, force)
@@ -63,9 +47,9 @@ pub(crate) fn register_cmd(alias: &str, url: &str, force: bool) -> anyhow::Resul
 /// What: lists all registry entries with loaded status; prints a human-readable
 /// table by default or a JSON array with `--json`.
 /// Test: `cli_parses_ls` in tests.rs.
-pub(crate) fn ls_cmd(json: bool) -> anyhow::Result<()> {
-    let root = managed_root()?;
-    let registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(&root)
+pub(crate) fn ls_cmd(paths: &ManagedPaths, json: bool) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(root)
         .with_context(|| format!("failed to load registry from {}", root.display()))?;
     let entries = registry.list();
 
@@ -77,7 +61,7 @@ pub(crate) fn ls_cmd(json: bool) -> anyhow::Result<()> {
                     "alias": e.alias,
                     "url": e.url,
                     "ref": e.git_ref,
-                    "loaded": registry.is_loaded(&e.alias, &root),
+                    "loaded": registry.is_loaded(&e.alias, root),
                     "repo_path": root.join("projects").join(&e.alias).join("repo"),
                 })
             })
@@ -89,7 +73,7 @@ pub(crate) fn ls_cmd(json: bool) -> anyhow::Result<()> {
         println!("{:<20} {:<10} URL", "ALIAS", "LOADED");
         println!("{}", "-".repeat(60));
         for e in &entries {
-            let loaded = if registry.is_loaded(&e.alias, &root) {
+            let loaded = if registry.is_loaded(&e.alias, root) {
                 "yes"
             } else {
                 "no"
@@ -106,11 +90,11 @@ pub(crate) fn ls_cmd(json: bool) -> anyhow::Result<()> {
 /// alias and generates the project-local managed configuration.
 /// What: calls `load_alias`, then prints the repo path to stdout.
 /// Test: `cli_parses_load` in tests.rs.
-pub(crate) fn load_cmd(alias: &str) -> anyhow::Result<()> {
-    let root = managed_root()?;
-    let cfg_dir = claude_config_dir()?;
-    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(&root, &cfg_dir)?;
-    let repo_path = trusty_mpm::core::standalone::load::load_alias(alias, &root, &cfg_dir)
+pub(crate) fn load_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let cfg_dir = &paths.claude_config_dir;
+    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(root, cfg_dir)?;
+    let repo_path = trusty_mpm::core::standalone::load::load_alias(alias, root, cfg_dir)
         .with_context(|| format!("failed to load alias '{alias}'"))?;
     println!("{}", repo_path.display());
     Ok(())
@@ -123,11 +107,11 @@ pub(crate) fn load_cmd(alias: &str) -> anyhow::Result<()> {
 /// What: calls `run_alias` from the `run` module which loads if needed, checks
 /// credentials, and spawns `claude` with inherited stdio.
 /// Test: `cli_parses_run` in tests.rs; end-to-end requires `claude` binary.
-pub(crate) fn run_cmd(alias: &str) -> anyhow::Result<()> {
-    let root = managed_root()?;
-    let cfg_dir = claude_config_dir()?;
-    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(&root, &cfg_dir)?;
-    trusty_mpm::core::standalone::run::run_alias(alias, &root, &cfg_dir)
+pub(crate) fn run_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let cfg_dir = &paths.claude_config_dir;
+    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(root, cfg_dir)?;
+    trusty_mpm::core::standalone::run::run_alias(alias, root, cfg_dir)
         .with_context(|| format!("failed to run alias '{alias}'"))
 }
 
@@ -137,9 +121,9 @@ pub(crate) fn run_cmd(alias: &str) -> anyhow::Result<()> {
 /// directory directly (DOC-24 SPEC-STANDALONE-MPM-06).
 /// What: resolves the alias's repo path via the marker file and prints it.
 /// Test: `cli_parses_path` in tests.rs.
-pub(crate) fn path_cmd(alias: &str) -> anyhow::Result<()> {
-    let root = managed_root()?;
-    let repo = trusty_mpm::core::standalone::run::resolve_repo_path(alias, &root)
+pub(crate) fn path_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let repo = trusty_mpm::core::standalone::run::resolve_repo_path(alias, root)
         .with_context(|| format!("failed to resolve path for alias '{alias}'"))?;
     println!("{}", repo.display());
     Ok(())
@@ -156,7 +140,7 @@ pub(crate) fn path_cmd(alias: &str) -> anyhow::Result<()> {
 /// without repeating this step (keychain entry persists across sessions).
 /// What: ensures the tm-global config dir exists via
 /// `ensure_global_config_dir`, then spawns `claude auth login` with
-/// `CLAUDE_CONFIG_DIR=~/.trusty-mpm/claude-config` and inherited stdio so the
+/// `CLAUDE_CONFIG_DIR=<root>/claude-config` and inherited stdio so the
 /// user can complete the browser/OAuth flow. Prints guidance before and after.
 /// Returns an error (non-zero exit) when `claude auth login` fails or is
 /// cancelled so that `tm login && tm run …` does not proceed after a failed
@@ -166,10 +150,10 @@ pub(crate) fn path_cmd(alias: &str) -> anyhow::Result<()> {
 /// `core::standalone::run`. Exit-code propagation is covered by reasoning: the
 /// `bail!` path is reached whenever `status.success()` is false. The interactive
 /// OAuth completion requires a human.
-pub(crate) fn login_cmd() -> anyhow::Result<()> {
-    let root = managed_root()?;
-    let cfg_dir = claude_config_dir()?;
-    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(&root, &cfg_dir)?;
+pub(crate) fn login_cmd(paths: &ManagedPaths) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let cfg_dir = &paths.claude_config_dir;
+    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(root, cfg_dir)?;
 
     eprintln!(
         "tm login: one-time setup — authenticates managed `tm run` sessions\n\
@@ -179,7 +163,7 @@ pub(crate) fn login_cmd() -> anyhow::Result<()> {
         cfg_dir.display()
     );
 
-    let status = trusty_mpm::core::standalone::run::build_login_command(&cfg_dir)
+    let status = trusty_mpm::core::standalone::run::build_login_command(cfg_dir)
         .status()
         .context("failed to spawn 'claude auth login'; is `claude` installed and on PATH?")?;
 

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -280,12 +280,26 @@ async fn main() -> anyhow::Result<()> {
         Command::Meta { action } => commands::meta::meta(action).await,
 
         // DOC-24: standalone managed driver commands.
-        Command::Register { alias, url, force } => {
-            commands::standalone::register_cmd(&alias, &url, force)
+        // Each command resolves ManagedPaths once at entry (closes #1566):
+        // --root flag > TRUSTY_MPM_ROOT env > XDG config file > default.
+        Command::Register {
+            alias,
+            url,
+            force,
+            root,
+        } => {
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::register_cmd(&paths, &alias, &url, force)
         }
-        Command::LsAliases { json } => commands::standalone::ls_cmd(json),
-        Command::Load { alias } => commands::standalone::load_cmd(&alias),
-        Command::Run { alias, task } => {
+        Command::LsAliases { json, root } => {
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::ls_cmd(&paths, json)
+        }
+        Command::Load { alias, root } => {
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::load_cmd(&paths, &alias)
+        }
+        Command::Run { alias, task, root } => {
             // F5: --task is not yet implemented in the MVP standalone driver.
             // Per spec (DOC-24), autonomous/task dispatch is the session-manager
             // layer, not `tm run`. Warn clearly so the flag is not silently
@@ -297,10 +311,17 @@ async fn main() -> anyhow::Result<()> {
                      layer (a future phase of DOC-24)."
                 );
             }
-            commands::standalone::run_cmd(&alias)
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::run_cmd(&paths, &alias)
         }
-        Command::Path { alias } => commands::standalone::path_cmd(&alias),
-        Command::Login => commands::standalone::login_cmd(),
+        Command::Path { alias, root } => {
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::path_cmd(&paths, &alias)
+        }
+        Command::Login { root } => {
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::login_cmd(&paths)
+        }
     };
 
     // Top-level exit-code translation: a `tm sessions prune-idle` that found the

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1550,5 +1550,5 @@ fn cli_parses_login_standalone() {
     // What: assert that `tm login` maps to Command::Login.
     // Test: direct parse round-trip.
     let cli = Cli::try_parse_from(["trusty-mpm", "login"]).unwrap();
-    assert!(matches!(cli.command, Command::Login));
+    assert!(matches!(cli.command, Command::Login { .. }));
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `~/.trusty-mpm/` managed root with a four-level configurable precedence chain (closes #1566, epic #1548)
- Introduces `ManagedPaths` struct resolved once at command entry — no global state
- All six standalone commands (`register`, `ls`, `load`, `run`, `path`, `login`) accept `--root` / `TRUSTY_MPM_ROOT`

## Precedence (highest first)

1. `--root <path>` CLI flag (new on every standalone subcommand)
2. `TRUSTY_MPM_ROOT` env var
3. `[standalone] root = "..."` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` (fallback: `~/.config/trusty-mpm/config.toml`)
4. Default `~/.trusty-mpm` — **unchanged behavior when nothing is set**

## Config File Discovery

The config file lives at a **fixed XDG path independent of the managed root** to avoid the chicken-and-egg problem:

```
$XDG_CONFIG_HOME/trusty-mpm/config.toml
~/.config/trusty-mpm/config.toml  (fallback)
```

This is consistent with the existing XDG pattern in `formatters/banner.rs` and `core/discovery.rs`.

## Files Changed

- `crates/trusty-mpm/src/bin/tm/commands/managed_root.rs` — **new** — `ManagedPaths`, `resolve_managed_paths()`, `expand_tilde()`, `xdg_config_path()`, 17 unit tests
- `crates/trusty-mpm/src/bin/tm/commands/mod.rs` — declare `managed_root` module
- `crates/trusty-mpm/src/bin/tm/commands/standalone.rs` — handlers accept `&ManagedPaths` (removed old `managed_root()`/`claude_config_dir()` free functions)
- `crates/trusty-mpm/src/bin/tm/cli.rs` — add `--root / TRUSTY_MPM_ROOT` to all standalone command variants; `Login` becomes struct variant
- `crates/trusty-mpm/src/bin/tm/main.rs` — resolve `ManagedPaths` once at dispatch, thread to handler
- `crates/trusty-mpm/src/bin/tm/tests.rs` — update `Command::Login` match to `Command::Login { .. }`

## Test Plan

- [x] `cargo test -p trusty-mpm` — 1879 lib tests pass + 388 bin tests pass; only 2 pre-existing failures unrelated to this change (`daemon::state::tests::overseer_is_*`)
- [x] 17 new unit tests covering all precedence levels, tilde expansion, malformed config, missing config
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)