### PR TITLE
fix(trusty-voice): default TTS voice River (retired Rachel id removed)

### DIFF
--- a/python/trusty-voice/README.md
+++ b/python/trusty-voice/README.md
@@ -46,7 +46,7 @@ You can also override the daemon URL and other settings:
 TRUSTY_VOICE_DAEMON_URL=http://127.0.0.1:7880   # default
 TRUSTY_VOICE_STT_LANGUAGE=en-US                  # default
 TRUSTY_VOICE_STT_MODEL=nova-2                    # default
-TRUSTY_VOICE_TTS_VOICE_ID=21m00Tcm4TlvDq8ikWAM  # ElevenLabs "Rachel" (default)
+TRUSTY_VOICE_TTS_VOICE_ID=SAz9YHcvj6GT2YYXdXww  # ElevenLabs "River" (default; Rachel 21m00Tcm4TlvDq8ikWAM was retired)
 TRUSTY_VOICE_TTS_MODEL_ID=eleven_turbo_v2        # default
 TRUSTY_VOICE_CONV_ID=                            # leave blank for a fresh session
 ```

--- a/python/trusty-voice/src/trusty_voice/config.py
+++ b/python/trusty-voice/src/trusty_voice/config.py
@@ -43,7 +43,10 @@ class VoiceConfig:
     stt_model: str = "nova-2"
 
     # TTS
-    tts_voice_id: str = "21m00Tcm4TlvDq8ikWAM"  # ElevenLabs "Rachel"
+    # "Rachel" (21m00Tcm4TlvDq8ikWAM) was retired by ElevenLabs and is no longer
+    # on the account — using it causes a 404 at runtime.  "River" is a current
+    # premade conversational voice; do not revert to the Rachel id.
+    tts_voice_id: str = "SAz9YHcvj6GT2YYXdXww"  # ElevenLabs "River"
     tts_model_id: str = "eleven_turbo_v2"
 
     # Session
@@ -83,7 +86,7 @@ class VoiceConfig:
             daemon_base_url=os.environ.get("TRUSTY_VOICE_DAEMON_URL", "http://127.0.0.1:7880"),
             stt_language=os.environ.get("TRUSTY_VOICE_STT_LANGUAGE", "en-US"),
             stt_model=os.environ.get("TRUSTY_VOICE_STT_MODEL", "nova-2"),
-            tts_voice_id=os.environ.get("TRUSTY_VOICE_TTS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM"),
+            tts_voice_id=os.environ.get("TRUSTY_VOICE_TTS_VOICE_ID", "SAz9YHcvj6GT2YYXdXww"),
             tts_model_id=os.environ.get("TRUSTY_VOICE_TTS_MODEL_ID", "eleven_turbo_v2"),
             conv_id=os.environ.get("TRUSTY_VOICE_CONV_ID") or None,
         )

--- a/python/trusty-voice/src/trusty_voice/tts.py
+++ b/python/trusty-voice/src/trusty_voice/tts.py
@@ -48,7 +48,10 @@ class ElevenLabsSpeaker:
     def __init__(
         self,
         api_key: str,
-        voice_id: str = "21m00Tcm4TlvDq8ikWAM",
+        # "Rachel" (21m00Tcm4TlvDq8ikWAM) was retired by ElevenLabs — do not
+        # revert to that id.  "River" (SAz9YHcvj6GT2YYXdXww) is a current
+        # premade conversational voice.
+        voice_id: str = "SAz9YHcvj6GT2YYXdXww",  # ElevenLabs "River"
         model_id: str = "eleven_turbo_v2",
         *,
         _client: Any = None,  # injection point for tests


### PR DESCRIPTION
## Summary

- ElevenLabs retired "Rachel" (`21m00Tcm4TlvDq8ikWAM`); the id no longer exists on the account and causes a runtime 404 on every TTS call
- Switch default `tts_voice_id` to "River" (`SAz9YHcvj6GT2YYXdXww`), a current premade conversational voice
- Updated `config.py` (field default + `from_env()` fallback), `tts.py` (`ElevenLabsSpeaker.__init__` default), and `README.md` (example env-var line)
- Tombstone comments added in both source files so future readers don't "restore" the retired id

## Validation

- Real ElevenLabs synth: River → **61 440 bytes / 60 chunks** for "testing river voice" (`eleven_turbo_v2` / `pcm_22050`) ✓
- `uv run python -m pytest` → **65/65 passed** ✓
- `ruff check` + `ruff format --check` → clean ✓

Refs #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)