### PR TITLE
fix(trusty-voice): default TTS voice Lauren B from library (refs #1561)

### DIFF
--- a/python/trusty-voice/README.md
+++ b/python/trusty-voice/README.md
@@ -46,7 +46,7 @@ You can also override the daemon URL and other settings:
 TRUSTY_VOICE_DAEMON_URL=http://127.0.0.1:7880   # default
 TRUSTY_VOICE_STT_LANGUAGE=en-US                  # default
 TRUSTY_VOICE_STT_MODEL=nova-2                    # default
-TRUSTY_VOICE_TTS_VOICE_ID=SAz9YHcvj6GT2YYXdXww  # ElevenLabs "River" (default; Rachel 21m00Tcm4TlvDq8ikWAM was retired)
+TRUSTY_VOICE_TTS_VOICE_ID=DODLEQrClDo8wCz460ld  # ElevenLabs "Lauren B" (default; River SAz9YHcvj6GT2YYXdXww and Rachel 21m00Tcm4TlvDq8ikWAM are retired)
 TRUSTY_VOICE_TTS_MODEL_ID=eleven_turbo_v2        # default
 TRUSTY_VOICE_CONV_ID=                            # leave blank for a fresh session
 ```

--- a/python/trusty-voice/src/trusty_voice/config.py
+++ b/python/trusty-voice/src/trusty_voice/config.py
@@ -44,9 +44,10 @@ class VoiceConfig:
 
     # TTS
     # "Rachel" (21m00Tcm4TlvDq8ikWAM) was retired by ElevenLabs and is no longer
-    # on the account — using it causes a 404 at runtime.  "River" is a current
-    # premade conversational voice; do not revert to the Rachel id.
-    tts_voice_id: str = "SAz9YHcvj6GT2YYXdXww"  # ElevenLabs "River"
+    # on the account — using it causes a 404 at runtime.  Do not revert to the
+    # Rachel id.  "River" (SAz9YHcvj6GT2YYXdXww) was the previous default; replaced
+    # by "Lauren B" from the ElevenLabs Voice Library (refs #1561).
+    tts_voice_id: str = "DODLEQrClDo8wCz460ld"  # ElevenLabs "Lauren B"
     tts_model_id: str = "eleven_turbo_v2"
 
     # Session
@@ -86,7 +87,7 @@ class VoiceConfig:
             daemon_base_url=os.environ.get("TRUSTY_VOICE_DAEMON_URL", "http://127.0.0.1:7880"),
             stt_language=os.environ.get("TRUSTY_VOICE_STT_LANGUAGE", "en-US"),
             stt_model=os.environ.get("TRUSTY_VOICE_STT_MODEL", "nova-2"),
-            tts_voice_id=os.environ.get("TRUSTY_VOICE_TTS_VOICE_ID", "SAz9YHcvj6GT2YYXdXww"),
+            tts_voice_id=os.environ.get("TRUSTY_VOICE_TTS_VOICE_ID", "DODLEQrClDo8wCz460ld"),
             tts_model_id=os.environ.get("TRUSTY_VOICE_TTS_MODEL_ID", "eleven_turbo_v2"),
             conv_id=os.environ.get("TRUSTY_VOICE_CONV_ID") or None,
         )

--- a/python/trusty-voice/src/trusty_voice/tts.py
+++ b/python/trusty-voice/src/trusty_voice/tts.py
@@ -49,9 +49,10 @@ class ElevenLabsSpeaker:
         self,
         api_key: str,
         # "Rachel" (21m00Tcm4TlvDq8ikWAM) was retired by ElevenLabs — do not
-        # revert to that id.  "River" (SAz9YHcvj6GT2YYXdXww) is a current
-        # premade conversational voice.
-        voice_id: str = "SAz9YHcvj6GT2YYXdXww",  # ElevenLabs "River"
+        # revert to that id.  "River" (SAz9YHcvj6GT2YYXdXww) was the previous
+        # default; replaced by "Lauren B" from the ElevenLabs Voice Library
+        # (refs #1561).
+        voice_id: str = "DODLEQrClDo8wCz460ld",  # ElevenLabs "Lauren B"
         model_id: str = "eleven_turbo_v2",
         *,
         _client: Any = None,  # injection point for tests


### PR DESCRIPTION
## Summary

- Replace River (`SAz9YHcvj6GT2YYXdXww`) with Lauren B (`DODLEQrClDo8wCz460ld`) from the ElevenLabs Voice Library as the default TTS voice
- Updated in all three places: `VoiceConfig.tts_voice_id` dataclass default, `from_env()` env-var fallback, and `ElevenLabsSpeaker.__init__` `voice_id` param default
- README example env var block updated to show new default
- Rachel tombstone comment retained; River retirement comment added

## Validation

- Direct network synth confirmed: `DODLEQrClDo8wCz460ld` returns 43,008 PCM bytes on the account (voice name: "Lauren B – Friendly & Comforting Voice for AI Companion & Assistants")
- 65 tests pass; ruff check + format check clean

## Test plan

- [ ] `uv run python -m pytest` — 65 tests pass
- [ ] `uv run python -m ruff check src/ tests/` — no issues
- [ ] `uv run python -c "from trusty_voice.config import VoiceConfig; print(VoiceConfig.from_env().tts_voice_id)"` → `DODLEQrClDo8wCz460ld`

Closes / refs #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)