### PR TITLE
fix(trusty-voice): default TTS voice Autumn Veil (refs #1561)

### DIFF
--- a/python/trusty-voice/README.md
+++ b/python/trusty-voice/README.md
@@ -46,7 +46,7 @@ You can also override the daemon URL and other settings:
 TRUSTY_VOICE_DAEMON_URL=http://127.0.0.1:7880   # default
 TRUSTY_VOICE_STT_LANGUAGE=en-US                  # default
 TRUSTY_VOICE_STT_MODEL=nova-2                    # default
-TRUSTY_VOICE_TTS_VOICE_ID=DODLEQrClDo8wCz460ld  # ElevenLabs "Lauren B" (default; River SAz9YHcvj6GT2YYXdXww and Rachel 21m00Tcm4TlvDq8ikWAM are retired)
+TRUSTY_VOICE_TTS_VOICE_ID=KoVIHoyLDrQyd4pGalbs  # ElevenLabs "Autumn Veil" (default; Lauren B DODLEQrClDo8wCz460ld, River SAz9YHcvj6GT2YYXdXww, and Rachel 21m00Tcm4TlvDq8ikWAM are retired)
 TRUSTY_VOICE_TTS_MODEL_ID=eleven_turbo_v2        # default
 TRUSTY_VOICE_CONV_ID=                            # leave blank for a fresh session
 ```

--- a/python/trusty-voice/src/trusty_voice/config.py
+++ b/python/trusty-voice/src/trusty_voice/config.py
@@ -45,9 +45,10 @@ class VoiceConfig:
     # TTS
     # "Rachel" (21m00Tcm4TlvDq8ikWAM) was retired by ElevenLabs and is no longer
     # on the account — using it causes a 404 at runtime.  Do not revert to the
-    # Rachel id.  "River" (SAz9YHcvj6GT2YYXdXww) was the previous default; replaced
-    # by "Lauren B" from the ElevenLabs Voice Library (refs #1561).
-    tts_voice_id: str = "DODLEQrClDo8wCz460ld"  # ElevenLabs "Lauren B"
+    # Rachel id.  "River" (SAz9YHcvj6GT2YYXdXww) and "Lauren B"
+    # (DODLEQrClDo8wCz460ld) were previous defaults; replaced by "Autumn Veil"
+    # from the ElevenLabs Voice Library (refs #1561).
+    tts_voice_id: str = "KoVIHoyLDrQyd4pGalbs"  # ElevenLabs "Autumn Veil"
     tts_model_id: str = "eleven_turbo_v2"
 
     # Session
@@ -87,7 +88,7 @@ class VoiceConfig:
             daemon_base_url=os.environ.get("TRUSTY_VOICE_DAEMON_URL", "http://127.0.0.1:7880"),
             stt_language=os.environ.get("TRUSTY_VOICE_STT_LANGUAGE", "en-US"),
             stt_model=os.environ.get("TRUSTY_VOICE_STT_MODEL", "nova-2"),
-            tts_voice_id=os.environ.get("TRUSTY_VOICE_TTS_VOICE_ID", "DODLEQrClDo8wCz460ld"),
+            tts_voice_id=os.environ.get("TRUSTY_VOICE_TTS_VOICE_ID", "KoVIHoyLDrQyd4pGalbs"),
             tts_model_id=os.environ.get("TRUSTY_VOICE_TTS_MODEL_ID", "eleven_turbo_v2"),
             conv_id=os.environ.get("TRUSTY_VOICE_CONV_ID") or None,
         )

--- a/python/trusty-voice/src/trusty_voice/tts.py
+++ b/python/trusty-voice/src/trusty_voice/tts.py
@@ -49,10 +49,10 @@ class ElevenLabsSpeaker:
         self,
         api_key: str,
         # "Rachel" (21m00Tcm4TlvDq8ikWAM) was retired by ElevenLabs — do not
-        # revert to that id.  "River" (SAz9YHcvj6GT2YYXdXww) was the previous
-        # default; replaced by "Lauren B" from the ElevenLabs Voice Library
-        # (refs #1561).
-        voice_id: str = "DODLEQrClDo8wCz460ld",  # ElevenLabs "Lauren B"
+        # revert to that id.  "River" (SAz9YHcvj6GT2YYXdXww) and "Lauren B"
+        # (DODLEQrClDo8wCz460ld) were previous defaults; replaced by "Autumn
+        # Veil" from the ElevenLabs Voice Library (refs #1561).
+        voice_id: str = "KoVIHoyLDrQyd4pGalbs",  # ElevenLabs "Autumn Veil"
         model_id: str = "eleven_turbo_v2",
         *,
         _client: Any = None,  # injection point for tests


### PR DESCRIPTION
## Summary

- Replace Lauren B (`DODLEQrClDo8wCz460ld`) with Autumn Veil (`KoVIHoyLDrQyd4pGalbs`) from the ElevenLabs Voice Library as the default TTS voice
- Updated in all three places: `VoiceConfig.tts_voice_id` dataclass default, `from_env()` env-var fallback, and `ElevenLabsSpeaker.__init__` `voice_id` param default
- README example env var block updated to show new default
- Rachel tombstone comment retained; Lauren B and River retirement comments added

## Validation

- Direct network synth confirmed: `KoVIHoyLDrQyd4pGalbs` returns 38,912 PCM bytes on the account (voice name: "Autumn Veil: Warm. Reflective. Immersive. A voice of quiet power.")
- 65 tests pass; ruff check + format check clean

## Test plan

- [ ] `uv run python -m pytest` — 65 tests pass
- [ ] `uv run python -m ruff check src/ tests/` — no issues
- [ ] `uv run python -c "from trusty_voice.config import VoiceConfig; print(VoiceConfig.from_env().tts_voice_id)"` → `KoVIHoyLDrQyd4pGalbs`

Closes / refs #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)