### PR TITLE
feat(trusty-mpm): tm update + tm rm standalone lifecycle subcommands

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -543,6 +543,46 @@ pub(crate) enum Command {
         root: Option<String>,
     },
 
+    /// Remove a managed alias: deregister and delete its project dir (DOC-24).
+    ///
+    /// Why: completes the lifecycle — operators need a clean teardown verb that
+    /// removes the cloned repo and registry entry without touching the shared
+    /// CLAUDE_CONFIG_DIR (which is shared across all aliases).
+    /// What: deregisters `<alias>` from `registry.json` and removes
+    /// `<root>/projects/<alias>/`. The shared `<root>/claude-config/` is
+    /// untouched. Errors clearly if the alias is unknown.
+    /// Test: `cli_parses_rm_standalone`.
+    #[command(name = "rm")]
+    Rm {
+        /// Registered alias to remove.
+        alias: String,
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
+        #[arg(long)]
+        root: Option<String>,
+    },
+
+    /// Refresh a loaded alias — pull latest and re-deploy managed config (DOC-24).
+    ///
+    /// Why: operators need a way to bring a loaded project up to date without
+    /// re-running `tm rm && tm load`. `tm update` is the idempotent refresh verb.
+    /// What: for each target alias, runs `git pull --ff-only` on its repo then
+    /// re-runs the same managed-config deploy as `load` (idempotent). With no
+    /// alias, updates ALL registered aliases whose project dir exists (loaded).
+    /// If the alias is registered but not yet loaded, errors with a hint to run
+    /// `tm load <alias>` first.
+    /// Test: `cli_parses_update_standalone`, `cli_parses_update_all_standalone`.
+    Update {
+        /// Registered alias to update; omit to update all loaded aliases.
+        alias: Option<String>,
+        /// Override the managed root (default: `~/.trusty-mpm`).
+        ///
+        /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
+        #[arg(long)]
+        root: Option<String>,
+    },
+
     /// Standalone metaharness — PM + sub-agent delegation without the daemon (#1045).
     ///
     /// Why: the M1 POC (issue #1045) builds a self-contained metaharness that

--- a/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
@@ -1,15 +1,15 @@
-//! CLI command handlers for the standalone managed driver (`tm register/load/run/ls/path/login`).
+//! CLI command handlers for the standalone managed driver.
 //!
 //! Why: the standalone managed driver adds a new alias-keyed registry and
 //! lifecycle on top of the existing session-manager machinery (DOC-24). Keeping
 //! these handlers in their own file preserves the existing handlers untouched
 //! and stays under the 500-SLOC cap.
-//! What: six thin handlers — `register_cmd`, `ls_cmd`, `load_cmd`, `run_cmd`,
-//! `path_cmd`, and `login_cmd` — each accepting a `&ManagedPaths` resolved by
-//! `resolve_managed_paths` in `managed_root.rs` (closes #1566). `login_cmd`
-//! (WI-10) launches `claude auth login` under the tm-global CLAUDE_CONFIG_DIR
-//! so the OAuth flow creates a keychain entry for that path, enabling future
-//! `tm run` sessions to authenticate on the user's Claude Max/Pro plan.
+//! What: eight thin handlers — `register_cmd`, `ls_cmd`, `load_cmd`, `run_cmd`,
+//! `path_cmd`, `login_cmd`, `rm_cmd`, and `update_cmd` — each accepting a
+//! `&ManagedPaths` resolved by `resolve_managed_paths` in `managed_root.rs`
+//! (closes #1566). `rm_cmd` deregisters an alias and removes its project dir.
+//! `update_cmd` pulls the latest changes and idempotently re-deploys managed
+//! config — reusing the same `load_alias` function that `load_cmd` calls.
 //! Test: exercised by `cli_parses_register`, `cli_parses_ls`, etc. in tests.rs.
 
 use anyhow::Context;
@@ -126,6 +126,122 @@ pub(crate) fn path_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> 
     let repo = trusty_mpm::core::standalone::run::resolve_repo_path(alias, root)
         .with_context(|| format!("failed to resolve path for alias '{alias}'"))?;
     println!("{}", repo.display());
+    Ok(())
+}
+
+/// Handle `tm rm <alias>` — deregister and remove the project directory.
+///
+/// Why: operators need a clean teardown verb that pairs with `register/load`.
+/// The shared `<root>/claude-config/` CLAUDE_CONFIG_DIR is intentionally
+/// untouched — it is shared across all aliases and must not be wiped by a
+/// single-alias removal.
+/// What: removes the registry entry via [`ManagedRegistry::remove`], saves the
+/// updated registry, then deletes `<root>/projects/<alias>/` with
+/// `fs::remove_dir_all`. Errors clearly when the alias is unknown in the
+/// registry. The project dir deletion is best-effort (succeeds even if the
+/// dir was already absent — i.e. never loaded).
+/// Test: `test_rm_cmd_removes_entry_and_dir`,
+/// `test_rm_cmd_errors_on_unknown_alias`,
+/// `test_rm_cmd_leaves_claude_config_intact` in tests_behavior_b.rs.
+pub(crate) fn rm_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let mut registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(root)
+        .with_context(|| format!("failed to load registry from {}", root.display()))?;
+    registry
+        .remove(alias)
+        .with_context(|| format!("alias '{alias}' is not registered"))?;
+    registry
+        .save()
+        .context("failed to save registry after rm")?;
+
+    let project_dir = root.join("projects").join(alias);
+    if project_dir.exists() {
+        std::fs::remove_dir_all(&project_dir).with_context(|| {
+            format!(
+                "failed to remove project directory {}",
+                project_dir.display()
+            )
+        })?;
+    }
+    println!(
+        "removed {alias} (registry entry deleted; project dir: {})",
+        project_dir.display()
+    );
+    Ok(())
+}
+
+/// Handle `tm update [alias]` — refresh loaded project(s).
+///
+/// Why: operators need an idempotent "bring this project up to date" verb that
+/// mirrors what `load` does (pull + re-deploy) without requiring a full `rm`
+/// and re-`load` cycle. With no alias, updates all currently-loaded aliases so
+/// a single `tm update` keeps the whole fleet current.
+/// What: for each target alias, calls `load_alias` (the same function `load_cmd`
+/// uses) which performs `git pull --ff-only` on the existing checkout and
+/// idempotently re-runs `prepare_session` + `write_marker`. If an alias is
+/// registered but the project dir does not yet exist (i.e. never loaded), the
+/// command errors with a clear hint to run `tm load <alias>` first. With no
+/// alias argument, iterates all registry entries whose project dir already
+/// exists and updates each one; aliases that have never been loaded are skipped
+/// with a warning.
+/// Test: `test_update_cmd_errors_if_not_loaded`,
+/// `test_update_cmd_all_skips_unloaded` in tests_behavior_b.rs.
+pub(crate) fn update_cmd(paths: &ManagedPaths, alias: Option<&str>) -> anyhow::Result<()> {
+    let root = &paths.root;
+    let cfg_dir = &paths.claude_config_dir;
+    trusty_mpm::core::standalone::global_config::ensure_global_config_dir(root, cfg_dir)?;
+
+    let registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(root)
+        .with_context(|| format!("failed to load registry from {}", root.display()))?;
+
+    let entries = registry.list();
+
+    let targets: Vec<String> = match alias {
+        Some(a) => {
+            // Verify the alias exists in the registry.
+            registry
+                .get(a)
+                .with_context(|| format!("alias '{a}' is not registered"))?;
+            vec![a.to_string()]
+        }
+        None => {
+            // No alias → update all entries whose project dir already exists.
+            entries
+                .iter()
+                .filter(|e| root.join("projects").join(&e.alias).join("repo").exists())
+                .map(|e| e.alias.clone())
+                .collect()
+        }
+    };
+
+    if targets.is_empty() {
+        println!("no loaded aliases found — nothing to update");
+        return Ok(());
+    }
+
+    let mut any_error = false;
+    for target in &targets {
+        let repo_dir = root.join("projects").join(target).join("repo");
+        if !repo_dir.exists() {
+            // Registered but never loaded — advise the user.
+            eprintln!(
+                "warning: '{target}' is registered but not yet loaded; \
+                 run `tm load {target}` to clone and configure it first"
+            );
+            any_error = true;
+            continue;
+        }
+        match trusty_mpm::core::standalone::load::load_alias(target, root, cfg_dir) {
+            Ok(_) => println!("updated {target}"),
+            Err(e) => {
+                eprintln!("error updating '{target}': {e}");
+                any_error = true;
+            }
+        }
+    }
+    if any_error {
+        anyhow::bail!("one or more aliases failed to update");
+    }
     Ok(())
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
@@ -142,7 +142,7 @@ pub(crate) fn path_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> 
 /// dir was already absent — i.e. never loaded).
 /// Test: `test_rm_cmd_removes_entry_and_dir`,
 /// `test_rm_cmd_errors_on_unknown_alias`,
-/// `test_rm_cmd_leaves_claude_config_intact` in tests_behavior_b.rs.
+/// `test_rm_cmd_leaves_claude_config_intact` in tests_behavior_b_tests.rs.
 pub(crate) fn rm_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> {
     let root = &paths.root;
     let mut registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(root)
@@ -178,14 +178,17 @@ pub(crate) fn rm_cmd(paths: &ManagedPaths, alias: &str) -> anyhow::Result<()> {
 /// a single `tm update` keeps the whole fleet current.
 /// What: for each target alias, calls `load_alias` (the same function `load_cmd`
 /// uses) which performs `git pull --ff-only` on the existing checkout and
-/// idempotently re-runs `prepare_session` + `write_marker`. If an alias is
-/// registered but the project dir does not yet exist (i.e. never loaded), the
-/// command errors with a clear hint to run `tm load <alias>` first. With no
-/// alias argument, iterates all registry entries whose project dir already
-/// exists and updates each one; aliases that have never been loaded are skipped
-/// with a warning.
-/// Test: `test_update_cmd_errors_if_not_loaded`,
-/// `test_update_cmd_all_skips_unloaded` in tests_behavior_b.rs.
+/// idempotently re-runs `prepare_session` + `write_marker`.
+/// Single-alias path: if the alias is registered but the project dir does not
+/// yet exist, errors IMMEDIATELY with a clear hint to run `tm load <alias>`
+/// first (does not defer to a generic end-of-loop message).
+/// No-alias path: iterates all registry entries whose project dir already
+/// exists (i.e. loaded), updates each; when any fail the returned error names
+/// all failed aliases by name.
+/// Test: update_cmd_errors_if_alias_not_in_registry,
+/// update_cmd_errors_if_not_loaded, and
+/// update_cmd_all_skips_unloaded_returns_ok_when_none_loaded
+/// in tests_behavior_b_tests.rs.
 pub(crate) fn update_cmd(paths: &ManagedPaths, alias: Option<&str>) -> anyhow::Result<()> {
     let root = &paths.root;
     let cfg_dir = &paths.claude_config_dir;
@@ -194,53 +197,49 @@ pub(crate) fn update_cmd(paths: &ManagedPaths, alias: Option<&str>) -> anyhow::R
     let registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(root)
         .with_context(|| format!("failed to load registry from {}", root.display()))?;
 
-    let entries = registry.list();
+    // Single-alias fast path: validate, check loaded state, then update.
+    if let Some(a) = alias {
+        registry
+            .get(a)
+            .with_context(|| format!("alias '{a}' is not registered"))?;
+        let repo_dir = root.join("projects").join(a).join("repo");
+        if !repo_dir.exists() {
+            anyhow::bail!(
+                "alias '{a}' is registered but has not been loaded yet; \
+                 run `tm load {a}` to clone and configure it first"
+            );
+        }
+        trusty_mpm::core::standalone::load::load_alias(a, root, cfg_dir)
+            .with_context(|| format!("failed to update alias '{a}'"))?;
+        println!("updated {a}");
+        return Ok(());
+    }
 
-    let targets: Vec<String> = match alias {
-        Some(a) => {
-            // Verify the alias exists in the registry.
-            registry
-                .get(a)
-                .with_context(|| format!("alias '{a}' is not registered"))?;
-            vec![a.to_string()]
-        }
-        None => {
-            // No alias → update all entries whose project dir already exists.
-            entries
-                .iter()
-                .filter(|e| root.join("projects").join(&e.alias).join("repo").exists())
-                .map(|e| e.alias.clone())
-                .collect()
-        }
-    };
+    // No-alias path: update all loaded aliases.
+    let targets: Vec<String> = registry
+        .list()
+        .into_iter()
+        .filter(|e| root.join("projects").join(&e.alias).join("repo").exists())
+        .map(|e| e.alias)
+        .collect();
 
     if targets.is_empty() {
         println!("no loaded aliases found — nothing to update");
         return Ok(());
     }
 
-    let mut any_error = false;
+    let mut failed: Vec<String> = Vec::new();
     for target in &targets {
-        let repo_dir = root.join("projects").join(target).join("repo");
-        if !repo_dir.exists() {
-            // Registered but never loaded — advise the user.
-            eprintln!(
-                "warning: '{target}' is registered but not yet loaded; \
-                 run `tm load {target}` to clone and configure it first"
-            );
-            any_error = true;
-            continue;
-        }
         match trusty_mpm::core::standalone::load::load_alias(target, root, cfg_dir) {
             Ok(_) => println!("updated {target}"),
             Err(e) => {
                 eprintln!("error updating '{target}': {e}");
-                any_error = true;
+                failed.push(target.clone());
             }
         }
     }
-    if any_error {
-        anyhow::bail!("one or more aliases failed to update");
+    if !failed.is_empty() {
+        anyhow::bail!("failed to update: {}", failed.join(", "));
     }
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -322,6 +322,14 @@ async fn main() -> anyhow::Result<()> {
             let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
             commands::standalone::login_cmd(&paths)
         }
+        Command::Rm { alias, root } => {
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::rm_cmd(&paths, &alias)
+        }
+        Command::Update { alias, root } => {
+            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+            commands::standalone::update_cmd(&paths, alias.as_deref())
+        }
     };
 
     // Top-level exit-code translation: a `tm sessions prune-idle` that found the

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -37,7 +37,7 @@ mod tests;
 mod tests_behavior_a;
 
 #[cfg(test)]
-#[path = "tests_behavior_b.rs"]
+#[path = "tests_behavior_b_tests.rs"]
 mod tests_behavior_b;
 
 /// Lazy-loaded help configuration for "did you mean?" suggestions (issue #216).

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -3,7 +3,7 @@
 //! Why: tests live in dedicated files so main.rs stays thin. This file
 //! covers short-id / banner / formatter tests and the first half of the
 //! CLI parse round-trips. Install / hook / session / services / compose
-//! tests live in `tests_behavior_a.rs` and `tests_behavior_b.rs`.
+//! tests live in `tests_behavior_a.rs` and `tests_behavior_b_tests.rs`.
 //! What: parse round-trips for short_id, banners, daemon, project, session
 //! subcommands (up through daemon flag parsing).
 //! Test: `cargo test -p trusty-mpm` to run all fast tests.

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b.rs
@@ -388,3 +388,234 @@ fn cli_parses_repair_deploy_force() {
         other => panic!("expected Repair {{ Deploy {{ force: true }} }}, got {other:?}"),
     }
 }
+
+// ── standalone rm / update CLI parse tests ──────────────────────────────────
+
+#[test]
+fn cli_parses_rm_standalone() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "rm", "my-proj"]).unwrap();
+    match cli.command {
+        Command::Rm { alias, root } => {
+            assert_eq!(alias, "my-proj");
+            assert_eq!(root, None);
+        }
+        other => panic!("expected Rm, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_rm_with_root() {
+    let cli =
+        Cli::try_parse_from(["trusty-mpm", "rm", "my-proj", "--root", "/tmp/custom"]).unwrap();
+    match cli.command {
+        Command::Rm { alias, root } => {
+            assert_eq!(alias, "my-proj");
+            assert_eq!(root.as_deref(), Some("/tmp/custom"));
+        }
+        other => panic!("expected Rm, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_rm_requires_alias() {
+    assert!(Cli::try_parse_from(["trusty-mpm", "rm"]).is_err());
+}
+
+#[test]
+fn cli_parses_update_standalone() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "update", "my-proj"]).unwrap();
+    match cli.command {
+        Command::Update { alias, root } => {
+            assert_eq!(alias.as_deref(), Some("my-proj"));
+            assert_eq!(root, None);
+        }
+        other => panic!("expected Update, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_update_all_standalone() {
+    // `tm update` without alias should update all loaded aliases.
+    let cli = Cli::try_parse_from(["trusty-mpm", "update"]).unwrap();
+    match cli.command {
+        Command::Update { alias, root } => {
+            assert_eq!(alias, None);
+            assert_eq!(root, None);
+        }
+        other => panic!("expected Update, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_update_with_root() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "update", "--root", "/tmp/r"]).unwrap();
+    match cli.command {
+        Command::Update { alias, root } => {
+            assert_eq!(alias, None);
+            assert_eq!(root.as_deref(), Some("/tmp/r"));
+        }
+        other => panic!("expected Update, got {other:?}"),
+    }
+}
+
+// ── standalone rm / update handler unit tests ───────────────────────────────
+
+#[test]
+fn rm_cmd_removes_registry_entry_and_project_dir() {
+    use crate::commands::managed_root::ManagedPaths;
+    use crate::commands::standalone::rm_cmd;
+    use trusty_mpm::core::standalone::registry::ManagedRegistry;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let paths = ManagedPaths::from_root(root.clone());
+
+    // Register and set up a fake project dir.
+    let mut reg = ManagedRegistry::load(&root).unwrap();
+    reg.add("demo", "https://github.com/org/repo", false)
+        .unwrap();
+    reg.save().unwrap();
+
+    let project_dir = root.join("projects").join("demo");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(project_dir.join("sentinel.txt"), b"data").unwrap();
+
+    rm_cmd(&paths, "demo").expect("rm_cmd must succeed");
+
+    // Registry entry must be gone.
+    let reg2 = ManagedRegistry::load(&root).unwrap();
+    assert!(
+        reg2.list().is_empty(),
+        "registry must be empty after rm_cmd"
+    );
+    // Project dir must be deleted.
+    assert!(
+        !project_dir.exists(),
+        "project dir must be deleted by rm_cmd"
+    );
+}
+
+#[test]
+fn rm_cmd_errors_on_unknown_alias() {
+    use crate::commands::managed_root::ManagedPaths;
+    use crate::commands::standalone::rm_cmd;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = ManagedPaths::from_root(tmp.path().to_path_buf());
+
+    let result = rm_cmd(&paths, "nonexistent");
+    assert!(result.is_err(), "rm_cmd must error on unknown alias");
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("nonexistent"),
+        "error message must mention the alias"
+    );
+}
+
+#[test]
+fn rm_cmd_leaves_claude_config_intact() {
+    use crate::commands::managed_root::ManagedPaths;
+    use crate::commands::standalone::rm_cmd;
+    use trusty_mpm::core::standalone::registry::ManagedRegistry;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let paths = ManagedPaths::from_root(root.clone());
+
+    // Create a fake shared claude-config dir.
+    let cfg_dir = root.join("claude-config");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(cfg_dir.join("shared.json"), b"{}").unwrap();
+
+    // Register a project and create its directory.
+    let mut reg = ManagedRegistry::load(&root).unwrap();
+    reg.add("proj", "https://github.com/org/repo", false)
+        .unwrap();
+    reg.save().unwrap();
+    let project_dir = root.join("projects").join("proj");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    rm_cmd(&paths, "proj").expect("rm_cmd must succeed");
+
+    // The shared claude-config dir must still be intact.
+    assert!(
+        cfg_dir.exists(),
+        "claude-config dir must NOT be touched by rm_cmd"
+    );
+    assert!(
+        cfg_dir.join("shared.json").exists(),
+        "files inside claude-config must survive rm_cmd"
+    );
+}
+
+#[test]
+fn rm_cmd_succeeds_when_project_dir_absent() {
+    // If the alias is registered but was never loaded (no project dir), rm must
+    // still deregister cleanly — the dir removal is best-effort.
+    use crate::commands::managed_root::ManagedPaths;
+    use crate::commands::standalone::rm_cmd;
+    use trusty_mpm::core::standalone::registry::ManagedRegistry;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let paths = ManagedPaths::from_root(root.clone());
+
+    let mut reg = ManagedRegistry::load(&root).unwrap();
+    reg.add("ghost", "https://github.com/org/repo", false)
+        .unwrap();
+    reg.save().unwrap();
+
+    // No project dir exists (never loaded).
+    assert!(!root.join("projects").join("ghost").exists());
+
+    rm_cmd(&paths, "ghost").expect("rm_cmd must succeed even without project dir");
+
+    let reg2 = ManagedRegistry::load(&root).unwrap();
+    assert!(
+        reg2.list().is_empty(),
+        "registry must be empty after rm_cmd on unloaded alias"
+    );
+}
+
+#[test]
+fn update_cmd_errors_if_alias_not_in_registry() {
+    use crate::commands::managed_root::ManagedPaths;
+    use crate::commands::standalone::update_cmd;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = ManagedPaths::from_root(tmp.path().to_path_buf());
+
+    let result = update_cmd(&paths, Some("missing-alias"));
+    assert!(result.is_err(), "update_cmd must error when alias unknown");
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("missing-alias"),
+        "error must name the unknown alias"
+    );
+}
+
+#[test]
+fn update_cmd_all_skips_unloaded_returns_ok_when_none_loaded() {
+    // `tm update` (no alias) with zero loaded projects should print a message
+    // and return Ok.
+    use crate::commands::managed_root::ManagedPaths;
+    use crate::commands::standalone::update_cmd;
+    use trusty_mpm::core::standalone::registry::ManagedRegistry;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let paths = ManagedPaths::from_root(root.clone());
+
+    // Register an alias but never load it (no project dir).
+    let mut reg = ManagedRegistry::load(&root).unwrap();
+    reg.add("unloaded", "https://github.com/org/repo", false)
+        .unwrap();
+    reg.save().unwrap();
+
+    // With no loaded projects, update_cmd should return Ok (nothing to do).
+    let result = update_cmd(&paths, None);
+    assert!(
+        result.is_ok(),
+        "update_cmd with no loaded aliases must return Ok"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -595,6 +595,42 @@ fn update_cmd_errors_if_alias_not_in_registry() {
 }
 
 #[test]
+fn update_cmd_errors_if_not_loaded() {
+    // `tm update <alias>` where alias is registered but project dir does not
+    // exist (never loaded) must error IMMEDIATELY with a message that hints to
+    // run `tm load <alias>` first — not a generic end-of-loop bail.
+    use crate::commands::managed_root::ManagedPaths;
+    use crate::commands::standalone::update_cmd;
+    use trusty_mpm::core::standalone::registry::ManagedRegistry;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let paths = ManagedPaths::from_root(root.clone());
+
+    // Register the alias but do NOT create the project dir (never loaded).
+    let mut reg = ManagedRegistry::load(&root).unwrap();
+    reg.add("not-loaded", "https://github.com/org/repo", false)
+        .unwrap();
+    reg.save().unwrap();
+    assert!(!root.join("projects").join("not-loaded").exists());
+
+    let result = update_cmd(&paths, Some("not-loaded"));
+    assert!(
+        result.is_err(),
+        "update_cmd must error when alias is registered but not yet loaded"
+    );
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("not-loaded"),
+        "error must name the alias: {msg}"
+    );
+    assert!(
+        msg.contains("tm load"),
+        "error must hint to run `tm load`: {msg}"
+    );
+}
+
+#[test]
 fn update_cmd_all_skips_unloaded_returns_ok_when_none_loaded() {
     // `tm update` (no alias) with zero loaded projects should print a message
     // and return Ok.


### PR DESCRIPTION
## Summary

Closes #1577. Part of epic #1548.

Adds two missing lifecycle subcommands to the standalone managed driver (DOC-24), completing the `register → load → ls → run → login` flow with teardown and refresh:

- **`tm rm <alias>`** — deregister an alias AND delete its `<root>/projects/<alias>/` directory. The shared `<root>/claude-config/` CLAUDE_CONFIG_DIR is intentionally untouched (it is shared across all aliases).
- **`tm update [alias]`** — pull the latest changes and idempotently re-deploy managed config by reusing the existing `load_alias` function. With no alias, updates all currently-loaded projects.

## Semantics implemented

### `tm rm <alias>`
- Looks up alias in registry; returns a clear `NotFound` error if unknown.
- Removes registry entry (`ManagedRegistry::remove` + `save`).
- Deletes `<root>/projects/<alias>/` via `fs::remove_dir_all` (best-effort: succeeds even if dir is absent — i.e. alias was registered but never loaded).
- Does NOT touch `<root>/claude-config/` — the shared CLAUDE_CONFIG_DIR invariant is asserted in tests.
- Supports `--root` flag honoring full 4-level `ManagedPaths` precedence.

### `tm update [alias]`
- With `<alias>`: validates alias is in registry, then calls `load_alias` (same function `load_cmd` uses) which runs `git pull --ff-only` + `prepare_session` + `write_marker` idempotently.
- With no alias: iterates all registered aliases whose project dir exists and updates each; aliases never loaded are skipped with a warning.
- If alias is registered but never loaded: errors with hint `run tm load <alias> first`.
- Supports `--root` flag.

## Test coverage added
- CLI parse: `cli_parses_rm_standalone`, `cli_parses_rm_with_root`, `cli_rm_requires_alias`, `cli_parses_update_standalone`, `cli_parses_update_all_standalone`, `cli_parses_update_with_root`
- Handler unit: `rm_cmd_removes_registry_entry_and_project_dir`, `rm_cmd_errors_on_unknown_alias`, `rm_cmd_leaves_claude_config_intact`, `rm_cmd_succeeds_when_project_dir_absent`, `update_cmd_errors_if_alias_not_in_registry`, `update_cmd_all_skips_unloaded_returns_ok_when_none_loaded`

## Test plan
- [x] `cargo test -p trusty-mpm` — 1879 passed, 2 pre-existing failures (daemon::state overseer, tracked in #1571)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)