### PR TITLE
fix(trusty-mpm): repair daemon::state overseer tests and daemon::api blocking-client panic

### DIFF
--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1,14 +1,49 @@
 use super::*;
+use crate::core::paths::FrameworkPaths;
 use crate::core::session::{ControlModel, Session, SessionStatus};
 use axum::http::{HeaderMap, StatusCode};
 use serial_test::serial;
 
+/// Build a hermetic [`DaemonState`] rooted at an empty temp directory.
+///
+/// Why: tests that assert overseer-disabled or no-LLM behaviour must not read
+/// from the real `~/.trusty-mpm/framework/hooks/overseer.toml`. On a developer
+/// machine with `OPENROUTER_API_KEY` set and a live `overseer.toml` the LLM
+/// overseer is active, causing two distinct failures (#1523):
+///
+/// - Tests that assert HTTP 503 ("overseer unavailable") receive HTTP 200 because
+///   the real LLM responds.
+/// - `ingest_hook` triggers the composite overseer's `pre_tool_use`, which lazily
+///   initialises `reqwest::blocking::Client` — that construction internally spawns
+///   a new `tokio::Runtime` and panics with "Cannot drop a runtime in a context
+///   where blocking is not allowed" when called from a `#[tokio::test]` runtime.
+///
+/// Both failures vanish when the state reads from a temp dir that contains no
+/// `overseer.toml`, so the daemon builds the disabled deterministic overseer.
+///
+/// What: creates a `tempfile::TempDir`, builds `FrameworkPaths::under` it, calls
+/// `DaemonState::with_paths`, and returns both so the caller can keep the
+/// `TempDir` alive for the test's duration (the paths are only consulted at
+/// construction; in-memory state is self-contained afterwards).
+///
+/// Test: `hook_relay_runs_with_disabled_overseer`,
+/// `non_session_start_event_does_not_auto_register`, `llm_chat_without_overseer_is_503`,
+/// `coordinator_chat_without_overseer_is_503`.
+fn hermetic_shared() -> (Arc<DaemonState>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir for hermetic DaemonState");
+    let paths = FrameworkPaths::under(dir.path());
+    let state = Arc::new(DaemonState::with_paths(&paths));
+    (state, dir)
+}
+
 fn state_with_session() -> (Arc<DaemonState>, SessionId) {
-    let state = DaemonState::shared();
+    let (state, _dir) = hermetic_shared();
     let id = SessionId::new();
     let mut session = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
     session.status = SessionStatus::Active;
     state.register_session(session);
+    // _dir is intentionally dropped here: FrameworkPaths are only read at
+    // construction; the in-memory state is self-contained afterwards.
     (state, id)
 }
 
@@ -457,8 +492,11 @@ async fn session_start_auto_registers_unknown_session() {
 #[tokio::test]
 async fn non_session_start_event_does_not_auto_register() {
     // Only `SessionStart` auto-registers. A non-start event for an unknown
-    // session must not create a session record.
-    let state = DaemonState::shared();
+    // session must not create a session record. Uses hermetic state: a
+    // `PreToolUse` event triggers the LLM overseer when one is configured via
+    // `~/.trusty-mpm/overseer.toml`; the blocking reqwest client init then
+    // panics inside the tokio test runtime (#1523).
+    let (state, _dir) = hermetic_shared();
     let unknown = crate::core::session::SessionId::new();
     let post = HookPost {
         session_id: unknown.0.to_string(),
@@ -487,9 +525,10 @@ async fn session_start_for_known_session_does_not_duplicate() {
 
 #[tokio::test]
 async fn llm_chat_without_overseer_is_503() {
-    // A default daemon has no OpenRouter key, so `POST /llm/chat` reports the
-    // capability as unavailable rather than attempting a network call.
-    let state = DaemonState::shared();
+    // A daemon built without an overseer config (hermetic empty temp dir) must
+    // report the LLM chat capability as unavailable — the endpoint can only
+    // route to the LLM when an API key resolved at startup (#1523).
+    let (state, _dir) = hermetic_shared();
     let err = llm_chat(
         State(state),
         Json(LlmChatRequest {
@@ -513,9 +552,10 @@ async fn coordinator_context_returns_snapshot() {
 
 #[tokio::test]
 async fn coordinator_chat_without_overseer_is_503() {
-    // A non-prefixed coordinator message needs the LLM; a default daemon has
-    // no key, so the chat endpoint reports the capability unavailable.
-    let state = DaemonState::shared();
+    // A daemon built without an overseer config (hermetic empty temp dir) has
+    // neither LLM overseer nor Session Manager runtime, so a non-prefixed
+    // coordinator message must return HTTP 503 (#1523).
+    let (state, _dir) = hermetic_shared();
     let err = coordinator_chat(
         State(state),
         HeaderMap::new(),

--- a/crates/trusty-mpm/src/daemon/state/tests.rs
+++ b/crates/trusty-mpm/src/daemon/state/tests.rs
@@ -5,12 +5,37 @@ use crate::core::hook::HookEventRecord;
 use crate::core::memory::MemoryPressure;
 use crate::core::memory::MemoryUsage;
 use crate::core::overseer_config::OverseerConfig;
+use crate::core::paths::FrameworkPaths;
 use crate::core::session::{ControlModel, SessionStatus};
 
 use super::core::{DaemonState, HOOK_HISTORY_LIMIT, ReapResult};
 use super::overseer::build_overseer;
 
 use crate::core::session::{Session, SessionId};
+
+/// Build a [`DaemonState`] rooted under an empty temp directory.
+///
+/// Why: tests that assert overseer/LLM config defaults must NOT read from the
+/// real `~/.trusty-mpm/framework/hooks/` — on a dev machine the operator's
+/// `overseer.toml` may have `[llm] enabled = true` with a live API key, which
+/// would make "disabled by default" assertions fail (#1571). Pointing
+/// [`DaemonState::with_paths`] at a freshly-created, empty temp directory
+/// guarantees that `overseer.toml` and `optimizer.toml` are absent, so the
+/// daemon falls back to its disabled/default policy regardless of the host
+/// environment. The `TempDir` is returned so the caller can hold it alive for
+/// the test's duration; the paths it contains are only consulted at
+/// construction time, so the directory can be dropped afterwards without
+/// affecting the in-memory state.
+/// What: creates a `tempfile::TempDir`, builds `FrameworkPaths::under` it, and
+/// calls `DaemonState::with_paths`, returning both.
+/// Test: `new_overseer_is_disabled_when_file_missing`, `overseer_is_accessible`,
+/// `llm_overseer_is_none_without_key`, `overseer_handler_reports_strategy`.
+fn hermetic_state() -> (DaemonState, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir for hermetic DaemonState");
+    let paths = FrameworkPaths::under(dir.path());
+    let state = DaemonState::with_paths(&paths);
+    (state, dir)
+}
 
 fn sample_session() -> Session {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -305,9 +330,12 @@ fn reload_optimizer_config_picks_up_file_changes() {
 
 #[test]
 fn new_overseer_is_disabled_when_file_missing() {
-    // With no framework installed (overseer.toml absent), the overseer
-    // must be present but disabled — oversight is opt-in.
-    let state = DaemonState::new();
+    // With no framework installed (overseer.toml absent in a hermetic temp
+    // dir), the overseer must be present but disabled — oversight is opt-in.
+    // Uses `hermetic_state()` so the real `~/.trusty-mpm/overseer.toml` — if
+    // present on a dev machine with an API key — cannot enable the LLM
+    // overseer and make this assertion spuriously fail (#1571).
+    let (state, _dir) = hermetic_state();
     assert!(!state.overseer().is_enabled());
 }
 
@@ -338,22 +366,26 @@ fn overseer_falls_back_when_llm_key_missing() {
 
 #[test]
 fn llm_overseer_is_none_without_key() {
-    // A default daemon (no OpenRouter key) exposes no LLM chat handler.
-    let state = DaemonState::new();
+    // A daemon that starts from an empty framework root (no overseer.toml
+    // → no [llm] config) must not build an LLM chat handler, regardless of
+    // any API keys present in the operator's environment (#1571).
+    let (state, _dir) = hermetic_state();
     assert!(state.llm_overseer().is_none());
 }
 
 #[test]
 fn overseer_handler_reports_strategy() {
-    // The default daemon reports the deterministic handler.
-    let state = DaemonState::new();
+    // A daemon built from an empty framework root reports the deterministic
+    // handler — the default when no overseer.toml is installed (#1571).
+    let (state, _dir) = hermetic_state();
     assert_eq!(state.overseer_handler(), "deterministic");
 }
 
 #[test]
 fn overseer_is_accessible() {
-    let state = DaemonState::new();
-    // The shared overseer can be cloned out and queried.
+    // The shared overseer can be cloned out and queried; with no overseer.toml
+    // in the hermetic temp dir the overseer must report disabled (#1571).
+    let (state, _dir) = hermetic_state();
     let overseer = state.overseer();
     assert!(!overseer.is_enabled());
 }


### PR DESCRIPTION
## Summary

- **#1571**: Four `daemon::state::tests` fail on a clean checkout because `DaemonState::new()` reads the real `~/.trusty-mpm/framework/hooks/overseer.toml`; on a dev machine with `OPENROUTER_API_KEY` set and `[llm] enabled = true`, the assertions `!state.overseer().is_enabled()`, `state.llm_overseer().is_none()`, and `state.overseer_handler() == "deterministic"` all fail.
- **#1523**: Two `daemon::api::tests` panic with "Cannot drop a runtime in a context where blocking is not allowed" — `ingest_hook` triggers the composite LLM overseer's `pre_tool_use`, which lazily initialises `reqwest::blocking::Client`; that construction internally spawns a new `tokio::Runtime` and panics inside `#[tokio::test]`. Two other tests assert HTTP 503 but receive 200 because the real LLM responds.

**Root cause (both issues):** `DaemonState::new()` / `DaemonState::shared()` reads from the developer's live framework install, not a hermetic environment.

**Fix:** Add `hermetic_state()` (state tests) and `hermetic_shared()` (api tests) helpers that call `DaemonState::with_paths(&FrameworkPaths::under(tmpdir))`, pointing the state at an empty temp directory where no `overseer.toml` exists, ensuring the disabled deterministic overseer is built regardless of host environment.

## Files changed

- `crates/trusty-mpm/src/daemon/state/tests.rs` — add `hermetic_state()` helper; switch four tests that assert disabled-overseer defaults to use it
- `crates/trusty-mpm/src/daemon/api_tests.rs` — add `hermetic_shared()` helper; switch `state_with_session()` and four directly-affected tests (`hook_relay_runs_with_disabled_overseer`, `non_session_start_event_does_not_auto_register`, `llm_chat_without_overseer_is_503`, `coordinator_chat_without_overseer_is_503`) to use it

## Test plan

- [x] `cargo test -p trusty-mpm daemon::state` → 32 passed, 0 failed
- [x] `cargo test -p trusty-mpm daemon::api -- --test-threads=1` → 85 passed, 0 failed, no panics
- [x] `cargo test -p trusty-mpm` → 1891 passed, 0 failed
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check` → clean
- [x] `bash scripts/check_line_cap.sh` → 14 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)