### PR TITLE
fix(trusty-search): close #1372 (data-file over-index — docs + regression guard) + #1560 typeahead review nits

### DIFF
--- a/crates/trusty-search/src/core/indexer/typeahead.rs
+++ b/crates/trusty-search/src/core/indexer/typeahead.rs
@@ -75,6 +75,14 @@ impl TypeaheadHit {
     /// `"kg"`) that clients consume.
     /// What: `"hybrid+kg"` → `"kg"`, `"vector"` → `"semantic"`,
     /// everything else (`"hybrid"`, `"bm25"`, `"fallback:ripgrep"`) → `"lexical"`.
+    /// Note: `"hybrid"` collapses to `"lexical"` because the three-valued
+    /// `source` enum (`lexical` / `semantic` / `kg`) has no slot for a combined
+    /// BM25+vector result. In lexical typeahead mode the pipeline only runs BM25
+    /// so results are truly lexical; in blended mode the RRF fuser may produce
+    /// `"hybrid"` hits, and we conservatively tag them as `"lexical"` (the
+    /// majority contributor at the BM25-heavy weights used for typeahead) rather
+    /// than inventing a fourth tag that would break existing client rendering
+    /// (issue #1560 nit 3).
     /// Test: `classify_source_*` unit tests below.
     pub fn classify_source(match_reason: &str) -> &'static str {
         if match_reason.contains("kg") {
@@ -82,6 +90,8 @@ impl TypeaheadHit {
         } else if match_reason == "vector" {
             "semantic"
         } else {
+            // Covers "hybrid" (BM25+vector blend), "bm25", "fallback:ripgrep",
+            // and any future reason strings — all collapse to the "lexical" tag.
             "lexical"
         }
     }
@@ -145,7 +155,9 @@ pub struct TypeaheadResponse {
     pub hits: Vec<TypeaheadHit>,
     /// The effective mode used (`"lexical"` or `"blended"`).
     pub mode: String,
-    /// Server-side handler latency in milliseconds.
+    /// Search execution latency in milliseconds (measured after the index
+    /// read-lock is acquired, so it reflects BM25 + HNSW time only — not
+    /// lock-acquisition wait under contention).
     pub latency_ms: u64,
 }
 

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -94,6 +94,14 @@ use files::{call_chain_handler, global_grep_handler, grep_handler};
 use typeahead::typeahead_handler;
 
 // Re-export for integration tests in `tests/typeahead.rs`.
+//
+// Why: the integration tests in `tests/typeahead.rs` call the handler directly
+// (not via a running HTTP router), which requires importing both the handler
+// function and its `TypeaheadParams` extractor. These names are public so the
+// integration-test crate can see them, but `#[doc(hidden)]` keeps them off the
+// crate's documented public API surface to avoid misleading downstream callers
+// (issue #1560 nit 1).
+#[doc(hidden)]
 pub use typeahead::{
     typeahead_handler as typeahead_handler_for_tests, TypeaheadParams as TypeaheadParamsForTests,
 };

--- a/crates/trusty-search/src/service/server/typeahead.rs
+++ b/crates/trusty-search/src/service/server/typeahead.rs
@@ -116,8 +116,12 @@ pub async fn typeahead_handler(
         ..SearchQuery::default()
     };
 
-    let started = std::time::Instant::now();
+    // Acquire the read lock first, then start the latency timer so `latency_ms`
+    // measures search execution time rather than search + lock-acquisition wait
+    // (issue #1560 nit 2). Under contention the lock-wait could dominate and
+    // mislead callers who use `latency_ms` to budget ONNX / BM25 time.
     let indexer = handle.indexer.read().await;
+    let started = std::time::Instant::now();
     let chunks = indexer.search(&query).await.map_err(|e| {
         tracing::warn!(index_id = %id, err = %e, "typeahead search error");
         (

--- a/crates/trusty-search/src/service/walker.rs
+++ b/crates/trusty-search/src/service/walker.rs
@@ -192,6 +192,21 @@ pub const DOC_EXCLUDE_BASENAME_SUBSTRINGS: &[&str] = &["changelog", "license", "
 /// [`SKIP_DIRS`]) and `data_file_max_bytes` (a tighter size cap applied only to
 /// [`DATA_EXTS`] files). Because these carry an owned `Vec<String>`, `WalkOptions`
 /// is no longer `Copy`; the orchestrator clones it per subtree.
+///
+/// The full config stack for #1372 is complete:
+///
+/// - **Walker defaults** (`DEFAULT_EXTRA_SKIP_DIRS` / `DEFAULT_DATA_FILE_MAX_BYTES`) —
+///   this file.
+/// - **Per-index config** (`IndexConfig` / `ProjectConfig`) — `core/repo_config.rs`
+///   and `core/project_config.rs`; defaults flow into `WalkOptions` at reindex time.
+/// - **Runtime edit API** (`GET`/`PATCH /indexes/:id/config`) —
+///   `service/server/index_config.rs`; changes persist to `indexes.toml`.
+/// - **Dashboard UI** (`IndexConfig.svelte`) — the settings view reads and
+///   writes the config API so operators can tune hygiene without touching config files.
+///
+/// Issue #1554 (walk root in skip-dir path) is addressed by stripping the
+/// canonical root prefix before checking components — only segments RELATIVE
+/// to the walk root are tested against the skip lists.
 #[derive(Debug, Clone)]
 pub struct WalkOptions {
     /// When `true` (default as of v0.8.3 / issue #118), files matching


### PR DESCRIPTION
#1372 — the data-dir skip list + 64 KiB data-file cap + relative-to-root skip-dir check already shipped in PR #1375; this documents the full config stack (walker defaults → IndexConfig/ProjectConfig → PATCH config API → dashboard) and the #1554 regression guard, and closes the lingering issue. Acceptance-criteria tests already present.

#1560 — three typeahead PR-review nits: (1) `#[doc(hidden)]` on the test-only re-exports (kept `pub` for integration tests); (2) latency timer moved after read-lock acquisition so `latency_ms` measures search execution only; (3) doc comment explaining why `hybrid` collapses to `lexical` in `classify_source`.

Quality: 242 trusty-search tests pass, clippy/fmt/line-cap clean.

Closes #1372
Closes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)