### PR TITLE
fix(trusty-review): envelope verdict/grade derive from review_body (#1486) + expose calibration thresholds via env (#1597)

### DIFF
--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -150,6 +150,101 @@ const FLOOR_MIN_CONFIDENCE: f32 = 0.80;
 /// `low_confidence_high_effort_finding_still_drives_floor`.
 const FLOOR_COUNT_MIN_CONFIDENCE: f32 = 0.50;
 
+// ─── Calibration env-var overrides (#1597) ────────────────────────────────────
+
+/// Environment variable for overriding [`LOW_CONFIDENCE_THRESHOLD`] at runtime.
+///
+/// Why: per-deployment tuning of grading strictness without recompiling.  Parsed
+/// as `f32`; invalid or out-of-`[0.0, 1.0]` values silently fall back to the
+/// compile-time constant (closes #1597).
+/// What: when set to a valid `f32` in `[0.0, 1.0]`, overrides the advisory-batch
+/// collapse threshold.  Default value when unset: `0.65`.
+/// Test: `env_override_low_confidence_threshold_changes_value`,
+/// `env_override_defaults_when_unset`.
+pub const TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV: &str =
+    "TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD";
+
+/// Environment variable for overriding [`FLOOR_MIN_CONFIDENCE`] at runtime.
+///
+/// Why: per-deployment control over how strictly Medium findings must score to
+/// count toward the REQUEST_CHANGES floor (closes #1597).
+/// What: when set to a valid `f32` in `[0.0, 1.0]`, overrides the Medium-floor
+/// gate.  Default value when unset: `0.80`.
+/// Test: `env_override_floor_min_confidence_changes_value`,
+/// `env_override_defaults_when_unset`.
+pub const TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV: &str = "TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE";
+
+/// Environment variable for overriding [`FLOOR_COUNT_MIN_CONFIDENCE`] at runtime.
+///
+/// Why: per-deployment control over the sub-coin-flip exclusion floor (closes #1597).
+/// What: when set to a valid `f32` in `[0.0, 1.0]`, overrides the minimum
+/// confidence for a finding to participate in the verdict floor at all.  Default
+/// value when unset: `0.50`.
+/// Test: `env_override_floor_count_min_confidence_changes_value`,
+/// `env_override_defaults_when_unset`.
+pub const TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE_ENV: &str =
+    "TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE";
+
+/// Read a calibration threshold from an env var, falling back to `default`.
+///
+/// Why: centralises the parse-or-fallback logic so every threshold reads the same
+/// way (close #1597 without any runtime config struct or re-compilation).
+/// What: tries `std::env::var(key)`; on success parses as `f32` and accepts the
+/// value only when it is finite and in `[0.0, 1.0]`.  Any other outcome returns
+/// `default` silently (operators who want to debug set `RUST_LOG=debug`).
+/// Test: `env_override_low_confidence_threshold_changes_value` (verifies a valid
+/// override is applied); `env_override_defaults_when_unset` (verifies the
+/// constant default is returned when the var is absent or invalid).
+fn read_threshold_env(key: &str, default: f32) -> f32 {
+    match std::env::var(key) {
+        Ok(raw) => match raw.trim().parse::<f32>() {
+            Ok(v) if v.is_finite() && (0.0..=1.0).contains(&v) => {
+                debug!(key, value = v, "calibration threshold overridden via env");
+                v
+            }
+            _ => default,
+        },
+        Err(_) => default,
+    }
+}
+
+/// Effective `LOW_CONFIDENCE_THRESHOLD` (env-override aware, closes #1597).
+///
+/// Why: exposes the advisory-batch collapse line as an operator knob so
+/// per-deployment strictness can be tuned without recompiling.
+/// What: returns the env-var value when set and valid; otherwise the compile-time
+/// constant `0.65`.
+/// Test: `env_override_low_confidence_threshold_changes_value`.
+fn low_confidence_threshold() -> f32 {
+    read_threshold_env(
+        TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV,
+        LOW_CONFIDENCE_THRESHOLD,
+    )
+}
+
+/// Effective `FLOOR_MIN_CONFIDENCE` (env-override aware, closes #1597).
+///
+/// Why: exposes the Medium-floor confidence gate so operators can tighten or
+/// loosen the REQUEST_CHANGES escalation without recompiling.
+/// What: returns the env-var value when set and valid; otherwise `0.80`.
+/// Test: `env_override_floor_min_confidence_changes_value`.
+fn floor_min_confidence() -> f32 {
+    read_threshold_env(TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV, FLOOR_MIN_CONFIDENCE)
+}
+
+/// Effective `FLOOR_COUNT_MIN_CONFIDENCE` (env-override aware, closes #1597).
+///
+/// Why: exposes the sub-coin-flip exclusion floor so operators can widen or
+/// narrow which findings are considered substantive without recompiling.
+/// What: returns the env-var value when set and valid; otherwise `0.50`.
+/// Test: `env_override_floor_count_min_confidence_changes_value`.
+fn floor_count_min_confidence() -> f32 {
+    read_threshold_env(
+        TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE_ENV,
+        FLOOR_COUNT_MIN_CONFIDENCE,
+    )
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /// Compute the final review verdict from the model-proposed verdict and findings.
@@ -195,15 +290,15 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
     // over-fire (Fix 4).  High-effort findings escape this gate: a confirmed
     // bug with low confidence should still BLOCK, not disappear.
     let has_high = substantive.iter().any(|f| is_high_severity(f));
-    let all_low_confidence = !substantive.is_empty()
-        && substantive
-            .iter()
-            .all(|f| f.confidence <= LOW_CONFIDENCE_THRESHOLD);
+    let threshold = low_confidence_threshold();
+    let all_low_confidence =
+        !substantive.is_empty() && substantive.iter().all(|f| f.confidence <= threshold);
 
     if all_low_confidence && !has_high {
         debug!(
             model_verdict = %model_proposed,
-            "low-confidence override: all substantive findings ≤0.65 confidence, no High-effort → APPROVE"
+            threshold,
+            "low-confidence override: all substantive findings ≤ threshold confidence, no High-effort → APPROVE"
         );
         return Verdict::Approve;
     }
@@ -228,7 +323,7 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
     // RequestChanges floor in the first place — see `conformance_floor` — so the
     // cap correctly still applies to advisory-only conformance, honouring AC-12.)
     let has_confident_conformance = substantive.iter().any(|f| {
-        f.category == FindingCategory::MethodConformance && f.confidence >= FLOOR_MIN_CONFIDENCE
+        f.category == FindingCategory::MethodConformance && f.confidence >= floor_min_confidence()
     });
     if model_proposed == Verdict::Approve
         && floor == Verdict::RequestChanges
@@ -292,7 +387,7 @@ fn is_substantive(f: &Finding) -> bool {
     // (critical or high) finding: a genuine critical or high-severity concern must
     // keep its place at the verdict floor even when the model is only uncertain
     // about it.
-    !refuted && (f.confidence >= FLOOR_COUNT_MIN_CONFIDENCE || is_high_severity(f))
+    !refuted && (f.confidence >= floor_count_min_confidence() || is_high_severity(f))
 }
 
 /// Return `true` when a finding is critical- or high-severity (closes #1352).
@@ -397,9 +492,10 @@ fn correctness_floor(findings: &[&&Finding]) -> Verdict {
 
     // Only count Medium findings whose confidence clears the floor threshold
     // (#1015: advisory-tier Medium findings must not force REQUEST_CHANGES).
+    let medium_floor = floor_min_confidence();
     let medium_count = findings
         .iter()
-        .filter(|f| f.effort == Effort::Medium && f.confidence > FLOOR_MIN_CONFIDENCE)
+        .filter(|f| f.effort == Effort::Medium && f.confidence > medium_floor)
         .count();
 
     // Tier 1: any High-effort (critical/high severity) → BLOCK floor.
@@ -440,9 +536,8 @@ fn correctness_floor(findings: &[&&Finding]) -> Verdict {
 /// `conformance_below_floor_confidence_is_advisory`.
 fn conformance_floor(findings: &[&&Finding]) -> Verdict {
     // Effort is intentionally ignored: the conformance cap is confidence-only (never BLOCK).
-    let any_confident = findings
-        .iter()
-        .any(|f| f.confidence >= FLOOR_MIN_CONFIDENCE);
+    let floor = floor_min_confidence();
+    let any_confident = findings.iter().any(|f| f.confidence >= floor);
     if any_confident {
         // Capped at REQUEST_CHANGES — conformance NEVER drives BLOCK.
         Verdict::RequestChanges

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -841,3 +841,292 @@ fn conformance_cap_does_not_weaken_correctness_block() {
         "a real correctness High finding still BLOCKs alongside a conformance finding"
     );
 }
+
+// ─── Calibration env-var override tests (#1597) ──────────────────────────────
+// These tests mutate process-global env vars.  All env-var-mutating tests are
+// annotated `#[serial_test::serial]` so they run one at a time (a global mutex
+// in the serial_test runtime prevents interleaving with each other).
+//
+// Additionally, every env mutation uses `EnvGuard` (below) to guarantee cleanup
+// via `Drop` even when an assertion panics — a non-RAII approach would leak the
+// override to other test threads if the test thread unwinds.
+
+/// RAII guard that restores (or removes) an env var on drop.
+///
+/// Why: a plain `set_var` + manual restore after assertions is not panic-safe —
+/// if an assertion panics, the restore code is skipped and the env var stays set
+/// for the lifetime of the test process.  This guard wraps the restore in `drop`
+/// so it runs even on unwinding, preventing env-var leaks across test threads.
+/// What: on construction saves the current value of `key`; on drop restores it
+/// (or removes the var if it was absent before construction).
+/// Test: used by every env-var override test in this module (#1597).
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+impl EnvGuard {
+    /// Set `key` to `value` and return a guard that will restore the previous value.
+    ///
+    /// # Safety
+    /// Caller must ensure no other thread is concurrently reading or writing the
+    /// same env var.  In practice all callers hold the `serial_test` global lock.
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: serial_test lock held; no concurrent env access on this key.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+}
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: same guarantee as `set`: serial_test lock held.
+        match &self.prev {
+            Some(v) => unsafe { std::env::set_var(self.key, v) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+/// REGRESSION GUARD (#1597, defaults): all three calibration thresholds return
+/// their compile-time defaults when the corresponding env vars are absent.
+///
+/// Why: any future refactor that accidentally changes a default value would be
+/// caught here.  The defaults are the values calibrated over the duetto review
+/// board; silently changing them would affect all deployments.
+/// What: asserts `low_confidence_threshold()` == 0.65, `floor_min_confidence()`
+/// == 0.80, `floor_count_min_confidence()` == 0.50.
+/// Test: this test itself (serialised via `#[serial]`).
+#[serial_test::serial]
+#[test]
+fn env_override_defaults_when_unset() {
+    // Temporarily remove all three vars so the defaults are exercised.
+    // The EnvGuard restores each on drop — including if an assertion panics.
+    let _g1 = EnvGuard {
+        key: TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV,
+        prev: {
+            let p = std::env::var(TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV).ok();
+            // SAFETY: serial_test lock held.
+            unsafe { std::env::remove_var(TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV) };
+            p
+        },
+    };
+    let _g2 = EnvGuard {
+        key: TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV,
+        prev: {
+            let p = std::env::var(TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV).ok();
+            unsafe { std::env::remove_var(TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV) };
+            p
+        },
+    };
+    let _g3 = EnvGuard {
+        key: TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE_ENV,
+        prev: {
+            let p = std::env::var(TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE_ENV).ok();
+            unsafe { std::env::remove_var(TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE_ENV) };
+            p
+        },
+    };
+
+    assert!(
+        (low_confidence_threshold() - LOW_CONFIDENCE_THRESHOLD).abs() < f32::EPSILON,
+        "default LOW_CONFIDENCE_THRESHOLD must be {LOW_CONFIDENCE_THRESHOLD}"
+    );
+    assert!(
+        (floor_min_confidence() - FLOOR_MIN_CONFIDENCE).abs() < f32::EPSILON,
+        "default FLOOR_MIN_CONFIDENCE must be {FLOOR_MIN_CONFIDENCE}"
+    );
+    assert!(
+        (floor_count_min_confidence() - FLOOR_COUNT_MIN_CONFIDENCE).abs() < f32::EPSILON,
+        "default FLOOR_COUNT_MIN_CONFIDENCE must be {FLOOR_COUNT_MIN_CONFIDENCE}"
+    );
+    // _g1, _g2, _g3 drop here and restore the vars.
+}
+
+/// #1597: overriding `TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD` to a higher value
+/// causes findings that would have been advisory under the default (0.65) to now
+/// fall below the raised threshold — collapsing the batch to APPROVE.
+///
+/// Two Medium findings at confidence 0.66 (just above the default 0.65 → NOT
+/// all-advisory by default → the low-conf collapse does not fire).  With the
+/// threshold raised to 0.70, those same findings are now all ≤ threshold →
+/// the collapse fires → verdict becomes APPROVE even for model=APPROVE*.
+///
+/// Why: proves the env var is actually read at runtime (not just at startup).
+/// What: with `TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD=0.70`, derive_verdict
+/// over two Medium@0.66 findings (model=APPROVE*) → APPROVE.
+/// Test: this test itself (serialised via `#[serial]`; cleanup via `EnvGuard`).
+#[serial_test::serial]
+#[test]
+fn env_override_low_confidence_threshold_changes_value() {
+    // 0.66 > 0.65 (default) → NOT all-advisory → no collapse.
+    // 0.66 < 0.80 (FLOOR_MIN_CONFIDENCE) → these Mediums don't count toward the
+    // REQUEST_CHANGES floor; floor = APPROVE.
+    // stricter_of(APPROVE*, APPROVE) = APPROVE*.
+    let boundary_findings = vec![finding(Effort::Medium, 0.66), finding(Effort::Medium, 0.66)];
+
+    // --- section A: with override (EnvGuard ensures cleanup on panic) ---
+    let _g = EnvGuard::set(TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV, "0.70");
+    // 0.66 ≤ 0.70 (overridden) → all-advisory → collapse fires → APPROVE.
+    let overridden_verdict = derive_verdict(Verdict::ApproveWithReservations, &boundary_findings);
+    assert_eq!(
+        overridden_verdict,
+        Verdict::Approve,
+        "#1597: raised LOW_CONFIDENCE_THRESHOLD=0.70 triggers collapse on 0.66-conf findings"
+    );
+    assert!(
+        (low_confidence_threshold() - 0.70_f32).abs() < f32::EPSILON,
+        "#1597: low_confidence_threshold() must reflect env override"
+    );
+    drop(_g); // restore the var before section B
+
+    // --- section B: without override (after restore, default must hold) ---
+    // 0.66 > 0.65 (default) → collapse does NOT fire → APPROVE*.
+    let default_verdict = derive_verdict(Verdict::ApproveWithReservations, &boundary_findings);
+    assert_eq!(
+        default_verdict,
+        Verdict::ApproveWithReservations,
+        "#1597: after restore, default LOW_CONFIDENCE_THRESHOLD: 0.66-conf findings do not collapse"
+    );
+}
+
+/// #1597: overriding `TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE` to a lower value
+/// allows a previously-advisory Medium finding (below the default 0.80) to count
+/// toward the REQUEST_CHANGES floor.
+///
+/// Two Medium findings at confidence 0.70.  Under the default 0.80 threshold they
+/// are advisory (don't count toward REQUEST_CHANGES); with the threshold lowered to
+/// 0.60, 0.70 > 0.60 → they count → REQUEST_CHANGES floor.  Source-of-truth
+/// reconciliation does NOT cap here because model=RequestChanges, not APPROVE.
+///
+/// Why: proves the Medium-floor gate is wirable at runtime without recompiling.
+/// What: with `TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE=0.60`, two Medium@0.70 findings
+/// and model=REQUEST_CHANGES floor to REQUEST_CHANGES.
+/// Test: this test itself (serialised via `#[serial]`; cleanup via `EnvGuard`).
+#[serial_test::serial]
+#[test]
+fn env_override_floor_min_confidence_changes_value() {
+    // Two Medium findings at 0.70.
+    // 0.70 > 0.65 (LOW_CONFIDENCE_THRESHOLD) → NOT all-advisory → no collapse.
+    // 0.70 ≥ 0.50 (FLOOR_COUNT_MIN_CONFIDENCE) → substantive.
+    // 0.70 ≤ 0.80 (default FLOOR_MIN_CONFIDENCE) → not counted toward floor.
+    // floor = APPROVE; model = RequestChanges → stricter_of = RequestChanges.
+    let findings = vec![finding(Effort::Medium, 0.70), finding(Effort::Medium, 0.70)];
+
+    // --- section A: with override (EnvGuard cleans up on panic) ---
+    let _g = EnvGuard::set(TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV, "0.60");
+    // 0.70 > 0.60 → Mediums count toward floor; ≥2 → REQUEST_CHANGES floor.
+    // model=RequestChanges; stricter_of(RC, RC) = RC.
+    let overridden_verdict = derive_verdict(Verdict::RequestChanges, &findings);
+    assert_eq!(
+        overridden_verdict,
+        Verdict::RequestChanges,
+        "#1597: lowered FLOOR_MIN_CONFIDENCE=0.60 makes 0.70-conf Mediums count toward RC floor"
+    );
+    assert!(
+        (floor_min_confidence() - 0.60_f32).abs() < f32::EPSILON,
+        "#1597: floor_min_confidence() must reflect env override"
+    );
+    drop(_g); // restore before section B
+
+    // --- section B: without override (after restore; floor = APPROVE) ---
+    // model=Approve; floor=APPROVE (Mediums advisory); stricter_of = APPROVE.
+    let default_verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        default_verdict,
+        Verdict::Approve,
+        "#1597: with restored FLOOR_MIN_CONFIDENCE=0.80, 0.70-conf Mediums are advisory → APPROVE"
+    );
+}
+
+/// #1597: overriding `TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE` to a lower value
+/// promotes previously-excluded sub-coin-flip findings to substantive so they can
+/// count toward the verdict floor.
+///
+/// Two Medium findings at confidence 0.45 — by default excluded (0.45 < 0.50 =
+/// FLOOR_COUNT_MIN_CONFIDENCE).  With the count floor lowered to 0.40, 0.45 ≥ 0.40
+/// → substantive.  But: the low-conf override (LOW_CONFIDENCE_THRESHOLD=0.65) would
+/// collapse this batch to APPROVE since all findings ≤ 0.65.  To isolate the
+/// FLOOR_COUNT_MIN_CONFIDENCE knob, we also lower LOW_CONFIDENCE_THRESHOLD to 0.30
+/// (so 0.45 > 0.30 → NOT all-advisory → no collapse) and FLOOR_MIN_CONFIDENCE to
+/// 0.30 (so 0.45 > 0.30 → Mediums count toward the floor).
+///
+/// Why: proves the sub-coin-flip exclusion line is tunable at runtime without
+/// recompiling, and that the three thresholds interact correctly.
+/// What: with the three overrides, two Medium@0.45 findings + model=RequestChanges
+/// remain REQUEST_CHANGES (floor matches model).
+/// Test: this test itself (serialised via `#[serial]`; cleanup via `EnvGuard`).
+#[serial_test::serial]
+#[test]
+fn env_override_floor_count_min_confidence_changes_value() {
+    let findings = vec![finding(Effort::Medium, 0.45), finding(Effort::Medium, 0.45)];
+
+    // --- section A: all three overrides active ---
+    // FLOOR_COUNT_MIN_CONFIDENCE=0.40 → 0.45 ≥ 0.40 → findings are substantive.
+    // LOW_CONFIDENCE_THRESHOLD=0.30   → 0.45 > 0.30 → NOT all-advisory → no collapse.
+    // FLOOR_MIN_CONFIDENCE=0.30       → 0.45 > 0.30 → Mediums counted; ≥2 → RC floor.
+    // model=RequestChanges; stricter_of(RC, RC) = RC.
+    let _g1 = EnvGuard::set(TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE_ENV, "0.40");
+    let _g2 = EnvGuard::set(TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV, "0.30");
+    let _g3 = EnvGuard::set(TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV, "0.30");
+
+    assert!(
+        (floor_count_min_confidence() - 0.40_f32).abs() < f32::EPSILON,
+        "#1597: floor_count_min_confidence() must reflect env override"
+    );
+    let overridden_verdict = derive_verdict(Verdict::RequestChanges, &findings);
+    assert_eq!(
+        overridden_verdict,
+        Verdict::RequestChanges,
+        "#1597: with FLOOR_COUNT_MIN_CONFIDENCE=0.40, Medium@0.45 findings count toward RC floor"
+    );
+    drop(_g3);
+    drop(_g2);
+    drop(_g1); // restore all three before section B
+
+    // --- section B: defaults restored; findings excluded again ---
+    // 0.45 < 0.50 (FLOOR_COUNT_MIN_CONFIDENCE) → excluded → substantive set empty.
+    // all_low_confidence check: substantive is empty → condition false → no collapse.
+    // floor = APPROVE (no qualifying findings); model=APPROVE → APPROVE.
+    let default_verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        default_verdict,
+        Verdict::Approve,
+        "#1597: after restore, 0.45-conf Medium findings are sub-coin-flip → excluded → APPROVE"
+    );
+}
+
+/// #1597: an invalid env-var value (out of range, or non-numeric) falls back to
+/// the compile-time constant and never panics.
+///
+/// Why: a misconfigured deployment must not cause a panic or a silent 0-value
+/// default — it must silently use the safe built-in value.
+/// What: sets each var to "not-a-number" and an out-of-range value; asserts the
+/// accessor returns the constant default.
+/// Test: this test itself (serialised via `#[serial]`; cleanup via `EnvGuard`).
+#[serial_test::serial]
+#[test]
+fn env_override_invalid_value_falls_back_to_default() {
+    {
+        let _g = EnvGuard::set(TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD_ENV, "not-a-number");
+        assert!(
+            (low_confidence_threshold() - LOW_CONFIDENCE_THRESHOLD).abs() < f32::EPSILON,
+            "non-numeric override must fall back to constant"
+        );
+    } // _g drops here, restoring the var
+
+    {
+        let _g = EnvGuard::set(TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE_ENV, "2.5");
+        assert!(
+            (floor_min_confidence() - FLOOR_MIN_CONFIDENCE).abs() < f32::EPSILON,
+            "out-of-range (>1.0) override must fall back to constant"
+        );
+    }
+
+    {
+        let _g = EnvGuard::set(TRUSTY_REVIEW_FLOOR_COUNT_MIN_CONFIDENCE_ENV, "-0.1");
+        assert!(
+            (floor_count_min_confidence() - FLOOR_COUNT_MIN_CONFIDENCE).abs() < f32::EPSILON,
+            "negative override must fall back to constant"
+        );
+    }
+}

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -369,7 +369,13 @@ pub async fn run_review(
     }
 
     // ── Step 7b–7e: grade derivation, coverage floor, verification, reconcile ─
-    let (final_verdict, final_grade) = apply_grade_and_floor(&parsed);
+    // `original_llm_grade` is the pre-floor LLM grade; it is held separately so
+    // that after verification potentially RELAXES the verdict (e.g. BLOCK → APPROVE
+    // because the only blocking finding was refuted), the envelope grade can be
+    // re-clamped from the original LLM grade rather than the floor-escalated grade.
+    // Without this, a floor that escalated B- → F would not recover to B- when
+    // verification refutes the escalating finding (closes #1486).
+    let (final_verdict, final_grade, original_llm_grade) = apply_grade_and_floor(&parsed);
     info!(
         verdict = %final_verdict,
         grade = %final_grade,
@@ -380,7 +386,12 @@ pub async fn run_review(
     // 7b-post: apply coverage floor AFTER severity derivation (#1014).
     // Coverage can only TIGHTEN (REQUEST_CHANGES) — never soften a BLOCK.
     // This is a no-op when coverage gating is disabled (the default).
-    let (final_verdict, final_grade) = if let Some(ref cov) = coverage_contrib {
+    // Note: the coverage-adjusted grade (_cov_grade) is intentionally not used as
+    // the source for step 7d's grade derivation — see the #1486 fix comment below
+    // for why the original_llm_grade is the correct basis for the post-verification
+    // grade clamp.  The coverage floor only shifts the verdict; the grade is
+    // re-clamped from original_llm_grade to the final post-verification verdict.
+    let (final_verdict, _cov_grade) = if let Some(ref cov) = coverage_contrib {
         let before = final_verdict.clone();
         let (cv, cg) = apply_coverage_floor(final_verdict, final_grade, cov);
         if cv != before {
@@ -407,9 +418,30 @@ pub async fn run_review(
     )
     .await;
     result.findings = findings;
-    // 7d: clamp grade to stay consistent with the post-verification verdict.
+
+    // 7d: derive the envelope grade from the post-verification verdict (closes #1486).
+    //
+    // BEFORE this fix: the grade was clamped from `final_grade` (the floor-escalated
+    // grade) to `result.verdict`.  When verification RELAXES the verdict (e.g. BLOCK
+    // → APPROVE because the only blocking finding was refuted by the verifier), the
+    // clamp of F→APPROVE is a no-op (F implies BLOCK which is already stricter than
+    // APPROVE), so the envelope grade stayed F even though the verdict became APPROVE.
+    //
+    // AFTER this fix: we clamp the original LLM grade (pre-floor) to the
+    // post-verification verdict.  The floor escalation (B- → F for a BLOCK) no
+    // longer leaks into the envelope when verification relaxes the verdict: if the
+    // floor finding was refuted, the envelope correctly shows B-/APPROVE instead of
+    // F/APPROVE.  If the blocking finding survives verification (verdict stays BLOCK),
+    // `clamp_grade_to_verdict(B-, BLOCK)` = F — the correct, consistent result.
+    //
+    // Coverage-floor tightening (step 7b-post above) may also shift `final_grade`
+    // independently of verification; for now we treat original_llm_grade as the
+    // soft starting point and defer tighter coverage-grade interaction to a follow-up.
+    // In practice the coverage floor only drives REQUEST_CHANGES (not BLOCK), and the
+    // original LLM grade for REQUEST_CHANGES is already at the D-band, so the clamp
+    // is correct in the common case.
     result.grade = Some(
-        crate::pipeline::letter_grade::clamp_grade_to_verdict(final_grade, &result.verdict)
+        crate::pipeline::letter_grade::clamp_grade_to_verdict(original_llm_grade, &result.verdict)
             .to_string(),
     );
 

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -31,21 +31,31 @@ use crate::{
 
 use super::runner::{ReviewDeps, ReviewInput};
 
-/// Derive (verdict, grade) from a `ParsedReview` using grade + severity floor.
+/// Derive (verdict, floor_grade, original_llm_grade) from a `ParsedReview`.
 ///
 /// Why: extracted to keep `run_review` under the line cap and make it testable.
-/// What: fail-safe → (APPROVE, default grade); normal → resolves LLM grade string
+/// Also returns the original LLM grade (pre-floor) so the runner can re-derive
+/// the envelope grade AFTER verification by clamping the original grade to the
+/// post-verification verdict (fixes #1486: the floor-escalated grade must not
+/// survive verification relaxation).
+///
+/// What: fail-safe → (UNKNOWN, F, F); normal → resolves LLM grade string
 /// (or default), calls `derive_verdict_with_grade` for max(grade, model) + floor.
-/// Test: covered by runner integration tests.
+/// Returns `(floor_verdict, floor_grade, original_llm_grade)`.
+/// Test: covered by runner integration tests and the #1486 regression test.
 pub(super) fn apply_grade_and_floor(
     parsed: &crate::pipeline::parser::ParsedReview,
-) -> (Verdict, crate::pipeline::letter_grade::Grade) {
+) -> (
+    Verdict,
+    crate::pipeline::letter_grade::Grade,
+    crate::pipeline::letter_grade::Grade,
+) {
     if parsed.is_fail_safe {
         let v = parsed.verdict.clone();
         let g = default_grade_for_verdict(&v);
-        return (v, g);
+        return (v, g, g);
     }
-    let grade = parsed
+    let original_llm_grade = parsed
         .grade
         .as_deref()
         .and_then(|s| s.parse().ok())
@@ -58,7 +68,9 @@ pub(super) fn apply_grade_and_floor(
             );
             g
         });
-    derive_verdict_with_grade(parsed.verdict.clone(), grade, &parsed.findings)
+    let (floor_verdict, floor_grade) =
+        derive_verdict_with_grade(parsed.verdict.clone(), original_llm_grade, &parsed.findings);
+    (floor_verdict, floor_grade, original_llm_grade)
 }
 
 /// Fetch PR metadata and return `(ReviewPrMeta, head_sha)`.

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -947,6 +947,139 @@ async fn run_review_live_post_and_dedup_skip_integration() {
     // Placeholder for a future live integration test against a fixture PR.
 }
 
+/// REGRESSION GUARD (#1486): when a High-effort finding causes the severity floor
+/// to escalate the LLM's APPROVE/B- to BLOCK/F, but verification then REFUTES
+/// that finding, the envelope verdict must relax (BLOCK → APPROVE) AND the
+/// envelope grade must also relax (F → B-), not stay pinned at F.
+///
+/// Root cause (before fix): step 7d clamped the FLOOR-ESCALATED grade (F) to the
+/// post-verification verdict.  `clamp_grade_to_verdict(F, APPROVE)` is a no-op
+/// (F implies BLOCK which is already stricter than APPROVE), so the grade stayed F
+/// even though the verdict became APPROVE.  The fix clamps the ORIGINAL LLM grade
+/// (B-) to the post-verification verdict instead.
+///
+/// Why this test matters: any automation gating on the top-level `grade` field
+/// (not just `verdict`) would see F/APPROVE — an incoherent state.
+/// What: runs the full pipeline with a FakeLlm that emits APPROVE/B- plus a
+/// High-effort/0.95-confidence finding, a FakeVerifier that refutes that finding,
+/// and asserts that the post-verification envelope has verdict=APPROVE and
+/// grade=B-.
+#[tokio::test]
+async fn envelope_grade_tracks_verdict_after_verification_relaxation_1486() {
+    // LLM says: clean APPROVE with grade B-, but there is a high-severity finding
+    // that the LLM is nonetheless confident about (confidence 0.95).  The severity
+    // floor in derive_verdict_with_grade escalates this to BLOCK/F.  Verification
+    // then refutes the high-severity finding → verdict drops back to APPROVE.
+    let llm_response = r#"Code looks good overall, minor concern.
+
+```json
+{"verdict":"APPROVE","grade":"B-","summary":"Looks solid","findings":[{"title":"Potential XSS","body":"line 5 unescaped","severity":"high","confidence":0.95,"file":"src/render.rs","line":5}]}
+```"#;
+    let (source, _tmp) = local_diff_source("+fn render(s: &str) { println!(\"{s}\"); }\n");
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "fake-model".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ready_deps(
+        Arc::new(FakeLlm {
+            response: llm_response.to_string(),
+            error: None,
+            output_tokens: None,
+        }),
+        Some(Arc::new(FakeVerifier {
+            judgment: "REFUTED",
+        })),
+    );
+
+    let result = run_review(&config, input, deps).await;
+
+    // After verification refutes the High-effort finding, the verdict must relax.
+    assert_eq!(
+        result.verdict,
+        Verdict::Approve,
+        "#1486: verification refutes the only blocking finding → verdict must be APPROVE (got {:?})",
+        result.verdict,
+    );
+
+    // The envelope grade must be consistent with APPROVE, not the pre-verification F.
+    let grade = result.grade.as_deref().unwrap_or("(none)");
+    // B- maps to APPROVE; any APPROVE-band grade (A+ through B-) is correct here.
+    // The specific value is B- (the original LLM grade, clamped to APPROVE which
+    // accepts any grade, so no clamping occurs → grade stays B-).
+    assert_eq!(
+        grade, "B-",
+        "#1486: envelope grade must be the original LLM grade B- after verification \
+         relaxes the verdict to APPROVE (before fix, it was F)"
+    );
+
+    // Sanity: the finding is preserved (demoted, not dropped) and is refuted.
+    assert_eq!(result.findings.len(), 1, "finding must be preserved");
+    assert!(
+        matches!(
+            result.findings[0].verified,
+            Some(crate::models::VerifyOutcome::Refuted)
+        ),
+        "the High-effort finding must be marked Refuted"
+    );
+}
+
+/// REGRESSION GUARD (#1486 — stable-escalation path): when a High-effort finding
+/// is CONFIRMED by verification, the envelope must stay at BLOCK/F (the floor
+/// escalation correctly survives).
+///
+/// Why: the #1486 fix must not accidentally soften verdicts where the escalating
+/// finding WAS confirmed — only the refuted case should relax.
+#[tokio::test]
+async fn envelope_grade_stays_block_when_high_effort_confirmed_1486() {
+    let llm_response = r#"Review with confirmed critical finding.
+
+```json
+{"verdict":"APPROVE","grade":"B-","summary":"Mostly OK","findings":[{"title":"Auth bypass","body":"line 10","severity":"high","confidence":0.95,"file":"src/auth.rs","line":10}]}
+```"#;
+    let (source, _tmp) = local_diff_source("+fn auth(t: &str) {}\n");
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "fake-model".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ready_deps(
+        Arc::new(FakeLlm {
+            response: llm_response.to_string(),
+            error: None,
+            output_tokens: None,
+        }),
+        Some(Arc::new(FakeVerifier {
+            judgment: "CONFIRMED",
+        })),
+    );
+
+    let result = run_review(&config, input, deps).await;
+
+    // High-effort confirmed → BLOCK floor must survive verification.
+    assert_eq!(
+        result.verdict,
+        Verdict::Block,
+        "#1486 stable path: confirmed High-effort finding must keep verdict at BLOCK"
+    );
+    // Grade must be clamped to F (BLOCK's band ceiling).
+    let grade = result.grade.as_deref().unwrap_or("(none)");
+    assert_eq!(
+        grade, "F",
+        "#1486 stable path: confirmed BLOCK must clamp B- → F (consistent with verdict)"
+    );
+}
+
 /// `attach_inline_comments` maps on-diff findings to inline comments and leaves
 /// off-diff findings for the summary body (#1414).
 ///


### PR DESCRIPTION
## Summary
- **#1486**: Fixes envelope `verdict`/`grade` contradicting the structured `review_body`. Root cause: `clamp_grade_to_verdict(F, APPROVE)` is a no-op because F already implies BLOCK (stricter than APPROVE), so the floor-escalated grade leaked through even when the post-verification verdict relaxed to APPROVE. Fix threads the original pre-floor LLM grade through `apply_grade_and_floor` and clamps THAT to the post-verification verdict, so envelope and body agree (e.g. refuted High → APPROVE + B-; confirmed High → BLOCK + F). Two regression tests added.
- **#1597**: Exposes the three PR-review calibration thresholds as env vars (with the current compile-time values as defaults): new `pub const` env-var-name constants + `read_threshold_env()` + accessor fns replacing direct constant refs. Five serial tests with a Drop-based EnvGuard.

## Quality
- 916 trusty-review tests pass
- clippy/fmt/line-cap clean

Closes #1486
Closes #1597

🤖 Generated with [Claude Code](https://claude.com/claude-code)