### PR TITLE
fix(trusty-memory): serialize env-mutating cwd_palace_slug_at tests to stop CI flake

### DIFF
--- a/crates/trusty-memory/src/messaging/mod.rs
+++ b/crates/trusty-memory/src/messaging/mod.rs
@@ -322,10 +322,17 @@ mod tests {
     /// What: create a root dir named `actual-dir`, write a pin with
     /// `palace: pinned-name`, call `cwd_palace_slug_at`, assert result is
     /// `pinned-name` not `actual-dir`.
-    /// Test: itself.
+    /// Test: itself; serialised against all other env-mutating tests via
+    /// `#[serial_test::serial]` + `EnvGuard::clear` so that a concurrently
+    /// racing `cwd_palace_slug_at_env_override_wins` cannot leak
+    /// `TRUSTY_MEMORY_PALACE` into this test (env check is step 1, pin file
+    /// is step 2 — a leaked env var would shadow the pin and return
+    /// "my-override" instead of "pinned-name").
+    #[serial_test::serial]
     #[test]
     fn cwd_palace_slug_at_prefers_pin_file() {
         use crate::project_root::{write_project_pin, ProjectPin, PIN_SCHEMA_VERSION};
+        let _guard = EnvGuard::clear(crate::palace_id_derive::PALACE_OVERRIDE_ENV);
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().join("actual-dir");
         std::fs::create_dir_all(root.join(".git")).unwrap();
@@ -348,10 +355,14 @@ mod tests {
     /// calling it from the root — consistent with how `prompt-context` runs.
     /// What: pin file at root, call from a nested subdirectory, assert pinned
     /// slug is returned.
-    /// Test: itself.
+    /// Test: itself; serialised against env-mutating sibling tests so that
+    /// `TRUSTY_MEMORY_PALACE` (step-1 precedence) cannot leak and shadow the
+    /// pin-file result (step-2 precedence).
+    #[serial_test::serial]
     #[test]
     fn cwd_palace_slug_at_reads_pin_from_subdir() {
         use crate::project_root::{write_project_pin, ProjectPin, PIN_SCHEMA_VERSION};
+        let _guard = EnvGuard::clear(crate::palace_id_derive::PALACE_OVERRIDE_ENV);
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().join("my-repo");
         std::fs::create_dir_all(root.join(".git")).unwrap();
@@ -373,10 +384,14 @@ mod tests {
     /// variant so no file write occurs even when no pin exists.
     /// What: call `cwd_palace_slug_at` from a git repo with no pin file;
     /// assert the pin file is absent after the call.
-    /// Test: itself.
+    /// Test: itself; serialised so that a leaked `TRUSTY_MEMORY_PALACE` env
+    /// var cannot short-circuit step 1 and return early before the pin-file
+    /// absence check at step 2.
+    #[serial_test::serial]
     #[test]
     fn cwd_palace_slug_at_pin_read_does_not_create_pin_file() {
         use crate::project_root::{read_project_pin, PIN_FILE_REL};
+        let _guard = EnvGuard::clear(crate::palace_id_derive::PALACE_OVERRIDE_ENV);
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().join("no-pin-project");
         std::fs::create_dir_all(root.join(".git")).unwrap();


### PR DESCRIPTION
## Summary

- The three pin-file tests (`cwd_palace_slug_at_prefers_pin_file`, `cwd_palace_slug_at_reads_pin_from_subdir`, `cwd_palace_slug_at_pin_read_does_not_create_pin_file`) were missing `#[serial_test::serial]` and an `EnvGuard::clear` call, leaving them vulnerable to env-var leakage from the sibling test `cwd_palace_slug_at_env_override_wins`.
- The resolution order in `cwd_palace_slug_at()` is: (1) `TRUSTY_MEMORY_PALACE` env override → (2) pin file → (3) git-derived slug. A leaked env var from a concurrently-running test fires step 1 and returns `"my-override"` before step 2's pin file is ever reached, causing intermittent assertion failures on CI.
- Fix: add `#[serial_test::serial]` + `let _guard = EnvGuard::clear(PALACE_OVERRIDE_ENV)` to all three pin-file tests. This places them in the same serial token group as the env-setting test, preventing concurrent execution and guaranteeing the env var is absent.

## Root cause

`cargo test` runs test functions across OS threads within a single process. Env vars are process-global. The `EnvGuard` RAII type (already present in the module) correctly restores the env on drop, but a test that doesn't hold the guard can still observe a non-empty env var if it runs concurrently with a test that holds one. The `#[serial_test::serial]` attribute serialises all tests sharing the same token (the default token), so only one env-mutating or env-sensitive test can run at a time.

## Test plan

- [x] `cargo test -p trusty-memory cwd_palace_slug_at` — all 5 tests pass (verified 3 consecutive runs)
- [x] `cargo test -p trusty-memory` — full suite passes
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt -p trusty-memory --check` — no formatting drift
- [x] `bash scripts/check_line_cap.sh` — 0 violations

## LOC Delta

- Added: 18 lines (serial attributes + env guards + updated doc comments)
- Removed: 3 lines (old minimalist doc comments replaced)
- Net: +15 lines (test isolation scaffolding only, no production code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)