### PR TITLE
feat(trusty-review): Finding.source_citation + spec-grounding prompt wiring (refs #1419)

### DIFF
--- a/crates/trusty-review/src/integrations/context/conformance.rs
+++ b/crates/trusty-review/src/integrations/context/conformance.rs
@@ -295,27 +295,42 @@ impl ConformanceSource {
 
         // The precedence-winning method is the thing to check conformance against.
         if let Some(method) = Self::winning_method(intent) {
-            let ticket_label = intent
-                .ticket
-                .as_ref()
-                .map(|t| format!("ticket {}", t.id))
-                .unwrap_or_else(|| "ticket".to_string());
-            let source_label = match intent.precedence_winner {
-                Precedence::Ticket => ticket_label,
-                Precedence::Spec => intent
-                    .spec_section
-                    .as_ref()
-                    .map(|s| format!("spec {}", s.spec_id))
-                    .unwrap_or_else(|| "spec".to_string()),
-                Precedence::None => "intent".to_string(),
+            // Build the human-readable source label AND a bare citation key the
+            // LLM can copy verbatim into `source_citation` (#1419).
+            let (source_label, citation_key) = match intent.precedence_winner {
+                Precedence::Ticket => {
+                    let id = intent
+                        .ticket
+                        .as_ref()
+                        .map(|t| t.id.clone())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    (format!("ticket {id}"), id)
+                }
+                Precedence::Spec => {
+                    let spec_id = intent
+                        .spec_section
+                        .as_ref()
+                        .map(|s| s.spec_id.clone())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    (format!("spec {spec_id}"), spec_id)
+                }
+                Precedence::None => ("intent".to_string(), String::new()),
             };
             let body =
                 truncate_on_char_boundary(method.text.trim(), SNIPPET_BODY_CHARS).to_string();
+            // Subtitle carries the copyable citation so the LLM can populate
+            // `source_citation` with the exact identifier (#1419).
+            let subtitle = if citation_key.is_empty() {
+                "Flag the diff ONLY if it explicitly contradicts this method.".to_string()
+            } else {
+                format!(
+                    "Flag the diff ONLY if it explicitly contradicts this method. \
+                     Source citation key: {citation_key}"
+                )
+            };
             snippets.push(ContextSnippet {
                 title: format!("Prescribed method (from {source_label})"),
-                subtitle: Some(
-                    "Flag the diff ONLY if it explicitly contradicts this method.".to_string(),
-                ),
+                subtitle: Some(subtitle),
                 body: (!body.is_empty()).then_some(body),
                 link: intent.ticket.as_ref().and_then(|t| t.url.clone()),
             });

--- a/crates/trusty-review/src/integrations/context/conformance_tests.rs
+++ b/crates/trusty-review/src/integrations/context/conformance_tests.rs
@@ -440,3 +440,59 @@ fn query_none_without_owner_repo() {
         "no owner/repo (local-diff) must yield None"
     );
 }
+
+// ─── source_citation: snippet title/subtitle carry the ticket key (#1419) ────
+
+/// The rendered snippet title contains the ticket ID so the LLM can copy it
+/// verbatim into `source_citation` (#1419).
+///
+/// Why: the source-citation grounding mechanism (AC #1419) requires the LLM
+/// to have the EXACT ticket key available as a copyable string in the context
+/// snippet; if the key is absent from the rendered snippet, the LLM cannot
+/// populate `source_citation` reliably.
+/// What: renders a `ResolvedIntent` with a known ticket ID and asserts both
+/// the snippet title and the subtitle contain that ID.
+/// Test: this test; pure, no network.
+#[test]
+fn render_section_title_and_subtitle_contain_ticket_key() {
+    let ticket_id = "IMPL-2026-05-009".to_string();
+    let intent = ResolvedIntent {
+        ticket: Some(TicketRef {
+            id: ticket_id.clone(),
+            title: "Paginate listing".to_string(),
+            url: None,
+            backend: "github".to_string(),
+        }),
+        ticket_method: Some(Method {
+            text: "use cursor-based pagination".to_string(),
+            kind: MethodKind::Approach,
+            source_excerpt: "use cursor-based pagination".to_string(),
+        }),
+        spec_section: None,
+        spec_method: None,
+        precedence_winner: Precedence::Ticket,
+        conflict: false,
+        stale_spec: false,
+        unresolved: None,
+    };
+    let section = ConformanceSource::render_section(&intent);
+    assert!(
+        !section.snippets.is_empty(),
+        "a prescribed method must produce a non-empty section"
+    );
+    let snippet = &section.snippets[0];
+    assert!(
+        snippet.title.contains(&ticket_id),
+        "snippet title must contain the ticket ID for source_citation grounding: got {:?}",
+        snippet.title
+    );
+    let subtitle = snippet
+        .subtitle
+        .as_deref()
+        .expect("subtitle must be present");
+    assert!(
+        subtitle.contains(&ticket_id),
+        "snippet subtitle must contain the ticket ID as the citation key: got {:?}",
+        subtitle
+    );
+}

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -7,7 +7,8 @@
 //! What: exposes `Verdict`, `Effort`, `VerifyOutcome`, `Finding`
 //! (FixSuggestion), and `ReviewResult` — all serde-serialisable.
 //! Test: `verdict_serde_roundtrip`, `review_result_serde_roundtrip`,
-//! and `finding_confidence_clamping` in this module.
+//! `finding_confidence_clamping`, and `finding_source_citation_roundtrip`
+//! in this module.
 
 use serde::{Deserialize, Serialize};
 
@@ -256,6 +257,18 @@ pub struct Finding {
     /// pre-#1359 serialised finding deserialising as `Correctness`.
     #[serde(default)]
     pub category: FindingCategory,
+    /// Exact spec/ticket/test-plan source grounding this finding (#1419).
+    ///
+    /// Why: citing the precise source (e.g. `"IMPL-2026-05-009 WP-9"`,
+    /// `"PRD §4.2"`) makes a finding authoritative — it demonstrates a
+    /// prescribed intent was violated, not just an LLM inference.  The LLM
+    /// populates this when the context snippet it used carries a source label
+    /// (see `prompt_templates.rs`).  `None` when the finding rests on general
+    /// code reasoning rather than a cited spec/ticket snippet.
+    /// `#[serde(default, skip_serializing_if)]` keeps every pre-#1419 finding
+    /// deserialising unchanged (backward-compatible `None` default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_citation: Option<String>,
     // ── Transient pipeline state ──────────────────────────────────────────
     /// Verification outcome; `None` before the verification round.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -291,6 +304,7 @@ impl Finding {
             confidence: confidence.clamp(0.0, 1.0),
             effort,
             category: FindingCategory::Correctness,
+            source_citation: None,
             verified: None,
             issue_eligible: false,
         }
@@ -698,6 +712,54 @@ mod tests {
         let f = Finding::new("src/lib.rs", "bug", "desc", "fix", 0.9, Effort::Medium)
             .with_category(FindingCategory::MethodConformance);
         assert_eq!(f.category, FindingCategory::MethodConformance);
+    }
+
+    /// `source_citation` round-trips via serde and is absent from legacy fixtures.
+    ///
+    /// Why: the serde attributes must (a) preserve a populated citation through
+    /// a JSON round-trip, and (b) be absent from the serialised form when `None`
+    /// so pre-#1419 fixtures (no `source_citation` key) keep deserialising.
+    /// What: serialises a finding with a citation, round-trips it, asserts the
+    /// field survives; then asserts the key is absent when `None`.
+    /// Test: this test itself; no network.
+    #[test]
+    fn finding_source_citation_roundtrip() {
+        // Populated citation survives a JSON round-trip.
+        let json = r#"{
+            "file": "src/page.rs",
+            "kind": "method-conformance",
+            "description": "uses offset pagination",
+            "suggestion": "switch to cursor",
+            "confidence": 0.9,
+            "effort": "medium",
+            "source_citation": "IMPL-2026-05-009 WP-9"
+        }"#;
+        let f: Finding = serde_json::from_str(json).expect("must deserialise");
+        assert_eq!(
+            f.source_citation.as_deref(),
+            Some("IMPL-2026-05-009 WP-9"),
+            "source_citation must survive deserialisation"
+        );
+        let re_json = serde_json::to_string(&f).expect("must serialise");
+        let back: Finding = serde_json::from_str(&re_json).expect("must round-trip");
+        assert_eq!(
+            back.source_citation.as_deref(),
+            Some("IMPL-2026-05-009 WP-9"),
+            "source_citation must survive a full round-trip"
+        );
+
+        // When `None`, the key is skipped entirely (back-compat).
+        let f_none = Finding::new("src/lib.rs", "bug", "desc", "fix", 0.8, Effort::Low);
+        let json_none = serde_json::to_string(&f_none).expect("serialise");
+        assert!(
+            !json_none.contains("source_citation"),
+            "absent source_citation must not appear in serialised form (pre-#1419 back-compat)"
+        );
+        let back_none: Finding = serde_json::from_str(&json_none).expect("deserialise");
+        assert!(
+            back_none.source_citation.is_none(),
+            "absent source_citation key must deserialise to None"
+        );
     }
 
     /// A serialised finding WITHOUT a `category` field still deserialises (the

--- a/crates/trusty-review/src/pipeline/parser.rs
+++ b/crates/trusty-review/src/pipeline/parser.rs
@@ -101,6 +101,12 @@ struct LlmFinding {
     /// fixture — still parse.
     #[serde(default)]
     suggested_replacement: Option<String>,
+    /// Exact spec/ticket/test-plan source grounding this finding (#1419).
+    ///
+    /// `#[serde(default)]` → `None` so models that omit it — and every pre-#1419
+    /// fixture — still parse.
+    #[serde(default)]
+    source_citation: Option<String>,
 }
 
 // ─── Parsed output ────────────────────────────────────────────────────────────
@@ -308,9 +314,11 @@ fn try_parse_json_block(body: &str) -> Option<ParsedReview> {
 /// What: maps severity → effort (high/critical → High; medium → Medium; else Low);
 /// uses the `title` as the `kind` and `body` as `description`; preserves the
 /// finding `category` (#1359 — defaulting to `Correctness` when the model omits
-/// it) so the verdict floor can cap a `method-conformance` finding.
-/// Test: covered transitively by `parse_json_block_happy_path` and
-/// `parse_method_conformance_finding_category`.
+/// it) so the verdict floor can cap a `method-conformance` finding; carries
+/// `source_citation` (#1419) when the model provides it.
+/// Test: covered transitively by `parse_json_block_happy_path`,
+/// `parse_method_conformance_finding_category`, and
+/// `parse_finding_carries_source_citation`.
 fn convert_llm_finding(f: LlmFinding) -> Finding {
     let effort = match f.severity.to_lowercase().as_str() {
         "high" | "critical" => Effort::High,
@@ -332,6 +340,9 @@ fn convert_llm_finding(f: LlmFinding) -> Finding {
     // Carry the committable replacement code through for a GitHub suggestion
     // block (#1415); normalise empty/whitespace-only strings to None.
     finding.suggested_replacement = f.suggested_replacement.filter(|s| !s.trim().is_empty());
+    // Carry the spec/ticket source citation through (#1419); normalise
+    // empty/whitespace-only strings to None.
+    finding.source_citation = f.source_citation.filter(|s| !s.trim().is_empty());
     finding
 }
 

--- a/crates/trusty-review/src/pipeline/parser_tests.rs
+++ b/crates/trusty-review/src/pipeline/parser_tests.rs
@@ -562,3 +562,78 @@ fn parse_finding_carries_suggested_replacement() {
         "whitespace-only replacement must normalise to None"
     );
 }
+
+// ── Source citation (#1419) ───────────────────────────────────────────────
+
+/// A finding's `source_citation` is carried through the parser (#1419).
+///
+/// Why: the renderer and log reader need the exact spec/ticket key the LLM
+/// cited; it must survive the JSON → `Finding` conversion and be `None`-normalised
+/// for empty/whitespace values, mirroring `suggested_replacement`.
+/// What: parses one finding with a concrete citation and one with an empty
+/// string, asserting the first is `Some` and the second is `None`.
+/// Test: this test itself; no network.
+#[test]
+fn parse_finding_carries_source_citation() {
+    let body = r#"{
+        "verdict":"REQUEST_CHANGES",
+        "summary":"Conformance finding.",
+        "findings":[
+            {
+                "title":"Uses offset pagination",
+                "body":"Ticket specifies cursor-based pagination.",
+                "severity":"medium",
+                "confidence":0.9,
+                "file":"src/page.rs",
+                "category":"method-conformance",
+                "source_citation":"IMPL-2026-05-009 WP-9"
+            },
+            {
+                "title":"Nit",
+                "body":"Style.",
+                "severity":"low",
+                "confidence":0.4,
+                "file":"src/page.rs",
+                "source_citation":"   "
+            }
+        ]
+    }"#;
+    let result = parse_review_response(body);
+    assert_eq!(result.findings.len(), 2);
+    assert_eq!(
+        result.findings[0].source_citation.as_deref(),
+        Some("IMPL-2026-05-009 WP-9"),
+        "concrete source_citation must be carried through"
+    );
+    assert!(
+        result.findings[1].source_citation.is_none(),
+        "whitespace-only source_citation must normalise to None"
+    );
+}
+
+/// A finding that OMITS `source_citation` defaults to `None` (back-compat).
+///
+/// Why: pre-#1419 fixtures and models that do not emit `source_citation` must
+/// keep parsing — the field is opt-in, never required.
+/// What: parses a finding with no `source_citation` key, asserts `None`.
+/// Test: this test itself; no network.
+#[test]
+fn parse_finding_without_source_citation_defaults_none() {
+    let body = r#"{
+        "verdict":"APPROVE",
+        "summary":"Clean.",
+        "findings":[{
+            "title":"Minor nit",
+            "body":"Style issue.",
+            "severity":"low",
+            "confidence":0.5,
+            "file":"src/lib.rs"
+        }]
+    }"#;
+    let result = parse_review_response(body);
+    assert_eq!(result.findings.len(), 1);
+    assert!(
+        result.findings[0].source_citation.is_none(),
+        "absent source_citation must default to None (pre-#1419 back-compat)"
+    );
+}

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -93,7 +93,8 @@ Every other finding uses `category` = "correctness" (the default).
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
   confidence (0.0–1.0), file (source file path), line (null if not applicable),
   category ("correctness" by default, or "method-conformance" per the rule above),
-  consequence (see below), suggested_replacement (see below).
+  consequence (see below), suggested_replacement (see below),
+  source_citation (see below).
 
 `consequence`: a brief statement of the FAILURE MECHANISM — what concretely goes
 wrong in practice if this finding is not addressed (e.g. "panics on empty input",
@@ -112,6 +113,14 @@ NOT wrap it in a code fence and do NOT put prose in it — just the literal
 replacement code. When the fix is not a concrete line replacement (it spans
 multiple hunks, is advisory, or is best described in words), set it to null and
 explain the fix in `body`.
+
+`source_citation`: when a context snippet in the user message carries an explicit
+source label (e.g. "Prescribed method (from ticket IMPL-2026-05-009 WP-9)" or
+"Prescribed method (from spec PRD §4.2)"), copy the EXACT ticket key and
+section/work-package identifier from that label here (e.g. "IMPL-2026-05-009 WP-9"
+or "PRD §4.2"). This makes the finding authoritative — it is grounded in a
+prescribed intent, not just an LLM inference. Set to null when the finding is
+based on general code reasoning rather than a cited context snippet.
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.
@@ -205,7 +214,8 @@ coverage floor after your response based on the configured policy.
   Each finding has: title, body (detailed description), severity (low/medium/high/critical),
   confidence (0.0–1.0), file (source file path), line (null if not applicable),
   category ("correctness" by default, or "method-conformance" per the rule above),
-  consequence (see below), suggested_replacement (see below).
+  consequence (see below), suggested_replacement (see below),
+  source_citation (see below).
 
 `consequence`: a brief statement of the FAILURE MECHANISM — what concretely goes
 wrong in practice if this finding is not addressed (e.g. "panics on empty input",
@@ -224,6 +234,14 @@ NOT wrap it in a code fence and do NOT put prose in it — just the literal
 replacement code. When the fix is not a concrete line replacement (it spans
 multiple hunks, is advisory, or is best described in words), set it to null and
 explain the fix in `body`.
+
+`source_citation`: when a context snippet in the user message carries an explicit
+source label (e.g. "Prescribed method (from ticket IMPL-2026-05-009 WP-9)" or
+"Prescribed method (from spec PRD §4.2)"), copy the EXACT ticket key and
+section/work-package identifier from that label here (e.g. "IMPL-2026-05-009 WP-9"
+or "PRD §4.2"). This makes the finding authoritative — it is grounded in a
+prescribed intent, not just an LLM inference. Set to null when the finding is
+based on general code reasoning rather than a cited context snippet.
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -531,6 +531,38 @@ fn max_tokens_default_for_non_gemini() {
     );
 }
 
+// ── source_citation instruction (#1419) ──────────────────────────────────────
+
+/// Verify both system prompt variants instruct the LLM to populate
+/// `source_citation` when a context snippet carries an explicit source
+/// label (#1419).
+///
+/// Why: the spec-grounding mechanism is inert unless the LLM is told *when*
+/// and *how* to populate `source_citation`.  If the instruction is absent,
+/// the field will always be `None` regardless of the schema.
+/// What: asserts the key instruction phrase is present in both the stock
+/// prompt (coverage gating off) and the coverage-gating variant.
+/// Test: no network.
+#[test]
+fn system_prompt_contains_source_citation_instruction() {
+    for (label, prompt) in [
+        ("stock", reviewer_system_prompt_with_coverage(false)),
+        (
+            "coverage-gating",
+            reviewer_system_prompt_with_coverage(true),
+        ),
+    ] {
+        assert!(
+            prompt.contains("source_citation"),
+            "{label} system prompt must instruct the LLM to populate source_citation (#1419)"
+        );
+        assert!(
+            prompt.contains("prescribed intent"),
+            "{label} system prompt must explain the purpose of source_citation (spec grounding)"
+        );
+    }
+}
+
 // ── APEX prompt tests ─────────────────────────────────────────────────────────
 // Extracted to prompt_tests_apex.rs to keep this file under the 500-line cap (#610).
 #[path = "prompt_tests_apex.rs"]


### PR DESCRIPTION
## Summary

PR **A of 4** in the [`#1413`](https://github.com/bobmatnyc/trusty-tools/issues/1413) best-practice alignment epic — foundational, tightly scoped.

- **Schema:** Added `source_citation: Option<String>` to `Finding` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Fully backward-compatible — all pre-#1419 fixtures deserialise unchanged with `None`.
- **Parser:** Added `source_citation` to the `LlmFinding` wire type (`serde(default)` → `None`) and thread it through `convert_llm_finding` with the same whitespace-normalisation as `suggested_replacement`.
- **Prompt:** Extended both system prompt variants (stock + coverage-gating) with a `source_citation` output instruction: the LLM is told to copy the EXACT ticket key / section identifier from the context snippet label when a finding is grounded in a cited spec/ticket snippet.
- **Conformance snippet titles:** `render_section` now surfaces the bare citation key in the snippet subtitle (`"Source citation key: <id>"`) so the LLM has a ready-to-copy string without needing to parse the title.

**Closes:** part of #1419 (AC 1 — per-finding `source_citation` when grounded)
**Epic:** #1413

## What is NOT in this PR

- External-repo spec fetch / APEX resolver (AC 2–4 of #1419) — PR B, separate issue.
- Test-plan / AC conformance check (#1418) — PR C.

## Test plan

- [ ] `cargo test -p trusty-review` — 940 tests pass (was 935; +5 new)
- [ ] `cargo clippy -p trusty-review --all-targets -- -D warnings` — zero warnings
- [ ] `cargo fmt --check` — no drift
- [ ] `bash scripts/check_line_cap.sh` — 0 violations; all production files under 500 SLOC cap

New tests added:
- `models::tests::finding_source_citation_roundtrip` — serde round-trip + absent-key back-compat
- `pipeline::parser::tests::parse_finding_carries_source_citation` — parser carry-through + whitespace normalisation
- `pipeline::parser::tests::parse_finding_without_source_citation_defaults_none` — back-compat default
- `integrations::context::conformance::tests::render_section_title_and_subtitle_contain_ticket_key` — citation key in subtitle
- `pipeline::prompt::tests::system_prompt_contains_source_citation_instruction` — both prompt variants carry the instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)