### PR TITLE
feat(trusty-review): prior-PR change-history context source (closes #1423)

### DIFF
--- a/crates/trusty-review/src/integrations/context/config.rs
+++ b/crates/trusty-review/src/integrations/context/config.rs
@@ -82,6 +82,9 @@ pub struct ContextSourcesConfig {
     /// Intent/method-conformance back gate (#1359).  Default DISABLED: it calls
     /// the ISR (GitHub ticket fetch) so it must be explicitly opted in.
     pub conformance: SourceConfig,
+    /// Prior-PR / file change-history source (T10, #1423).  Default DISABLED:
+    /// makes multiple GitHub API calls per review; opt in explicitly.
+    pub pr_history: SourceConfig,
 }
 
 impl ContextSourcesConfig {
@@ -99,6 +102,7 @@ impl ContextSourcesConfig {
             confluence: resolve_source("CONFLUENCE", file.map(|f| &f.confluence)),
             github_issues: resolve_source("GITHUB_ISSUES", file.map(|f| &f.github_issues)),
             conformance: resolve_source("CONFORMANCE", file.map(|f| &f.conformance)),
+            pr_history: resolve_source("PR_HISTORY", file.map(|f| &f.pr_history)),
         }
     }
 }
@@ -148,6 +152,9 @@ pub struct ContextSourcesFileConfig {
     /// `[context.sources.conformance]` — the intent/method-conformance back gate.
     #[serde(default)]
     pub conformance: SourceFileConfig,
+    /// `[context.sources.pr_history]` — prior-PR / file change-history source.
+    #[serde(default)]
+    pub pr_history: SourceFileConfig,
 }
 
 /// TOML-deserialisable single-source table (all fields optional).

--- a/crates/trusty-review/src/integrations/context/mod.rs
+++ b/crates/trusty-review/src/integrations/context/mod.rs
@@ -38,6 +38,7 @@ pub mod github_issues;
 pub mod jira;
 pub mod jira_parse;
 pub mod orchestrator;
+pub mod pr_history;
 
 pub use config::{ContextSourcesConfig, ContextSourcesFileConfig, SourceConfig, SourceFileConfig};
 pub use confluence::ConfluenceSource;
@@ -45,6 +46,7 @@ pub use conformance::ConformanceSource;
 pub use github_issues::GithubIssuesSource;
 pub use jira::JiraSource;
 pub use orchestrator::{gather_external_context, render_sections};
+pub use pr_history::PrHistorySource;
 
 use async_trait::async_trait;
 

--- a/crates/trusty-review/src/integrations/context/pr_history.rs
+++ b/crates/trusty-review/src/integrations/context/pr_history.rs
@@ -251,8 +251,9 @@ impl PrHistoryTransport for ReqwestPrHistoryTransport {
             .http
             .get(&url)
             .header("Authorization", format!("Bearer {token}"))
-            // groot-preview header required to list PRs for a commit.
-            .header("Accept", "application/vnd.github.groot-preview+json")
+            // The "List pull requests associated with a commit" endpoint
+            // graduated to the stable API; use the standard Accept header.
+            .header("Accept", "application/vnd.github+json")
             .header("User-Agent", "trusty-review")
             .send()
             .await
@@ -589,7 +590,9 @@ impl ContextSource for PrHistorySource {
 
             // For each commit, look up associated PRs.
             for sha in &shas {
-                // Stop early if we already have enough PRs.
+                // Stop early if we have collected 2× the output cap already.
+                // This `break` exits only this file's SHA loop, not the outer
+                // file loop — other changed files are still processed.
                 if seen.len() >= MAX_PRS * 2 {
                     break;
                 }

--- a/crates/trusty-review/src/integrations/context/pr_history.rs
+++ b/crates/trusty-review/src/integrations/context/pr_history.rs
@@ -1,0 +1,638 @@
+//! LIVE prior-PR / file change-history context source (T10, #1423).
+//!
+//! Why: reviewers ground feedback in prior commits/PRs touching the same files
+//! ("this looks like a bandaid fix — see prior streaming work in PR #10234").
+//! Without historical PR context the LLM has no awareness of how the touched
+//! files have been changed before or what technical debt patterns exist.  This
+//! source surfaces recent closed PRs that touched the changed files so the
+//! reviewer can detect repeated patterns, regressions, or related prior fixes.
+//!
+//! What: `PrHistorySource` implements `ContextSource` in `Live` mode.  For each
+//! changed file (capped at `MAX_FILES_TO_QUERY`) it calls
+//! `GET /repos/{owner}/{repo}/commits?path={file}&per_page=10` to get recent
+//! commits touching that file, then for each commit SHA calls
+//! `GET /repos/{owner}/{repo}/commits/{sha}/pulls` (with the groot-preview
+//! header) to find PRs associated with that commit.  All discovered PRs are
+//! deduped by number, sorted by descending PR number (most recent first), and
+//! capped at `MAX_PRS` entries.  Each is rendered as a `ContextSnippet` under
+//! `## Prior PRs touching changed files`.
+//!
+//! ## Auth reuse (NO new auth)
+//! GitHub auth is the Phase-1 dual-mode abstraction (#582): the token is
+//! resolved by an injected `PrHistoryTokenResolver` that, in production,
+//! delegates to `AuthStrategy::select(run_mode).resolve_token(...)` — CLI →
+//! PAT/`gh`, serve → App.  No new credential mechanism is added.
+//!
+//! ## Config / default-disabled
+//! Default DISABLED (mirrors `ConformanceSource`): this source requires GitHub
+//! API access and makes multiple requests per review.  Operators opt in by
+//! setting `TRUSTY_REVIEW_CONTEXT_PR_HISTORY_ENABLED=true` or
+//! `[context.sources.pr_history] enabled = true` in the TOML config.
+//!
+//! ## Fail-open
+//! Any API error (per-file commit fetch, per-commit PR lookup) is logged and
+//! contributes no snippets.  A partial result (some files succeed, some fail)
+//! is better than no result, so per-file errors are not fatal.  The orchestrator
+//! never sees these errors; they are caught within `gather`.
+//!
+//! Test: `pr_history_tests.rs` — snippet count, dedup, heading, default-disabled
+//! skip, and fail-open on API error.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tracing::{debug, warn};
+
+use super::{
+    ContextSection, ContextSnippet, ContextSource, ContextSourceError, RetrievalMode,
+    ReviewSubject, TransportErr, truncate_on_char_boundary,
+};
+use crate::config::ReviewConfig;
+use crate::integrations::github::{AuthStrategy, GithubClient, RunMode};
+
+/// Source identifier used in logs, config keys, and error messages.
+const SOURCE_NAME: &str = "pr_history";
+
+/// Max changed files to query (limits API call count: `MAX_FILES * up-to-10
+/// commits * 1 PR-lookup` per file = up to 50 HTTP requests).
+const MAX_FILES_TO_QUERY: usize = 5;
+
+/// Max recent commits fetched per file (GitHub API `per_page`).
+const COMMITS_PER_FILE: u32 = 10;
+
+/// Max distinct PRs to include in the section.
+const MAX_PRS: usize = 5;
+
+/// Max chars of a PR body excerpt embedded under a `## Prior PRs…` bullet.
+///
+/// Why: the spec calls for ~300 chars per PR body to bound prompt size while
+/// still conveying intent; the other sources use `SNIPPET_BODY_CHARS` (500),
+/// but historical PR context is secondary enrichment so we keep it shorter.
+/// What: the truncation limit passed to `truncate_on_char_boundary`.
+/// Test: `snippet_body_truncated`.
+const PR_BODY_CHARS: usize = 300;
+
+// ─── Auth seam (reuses #582 dual-mode auth) ─────────────────────────────────
+
+/// Resolves a GitHub bearer token for the commit / PR-lookup calls.
+///
+/// Why: mirrors `github_issues::IssueTokenResolver` — reuses the Phase-1
+/// dual-mode auth (#582) without this source knowing whether it is PAT- or
+/// App-backed, and lets tests inject a fixed token so the fetch logic is
+/// testable without `gh`/network.
+/// What: one async method returning a token for `owner`, or a
+/// `ContextSourceError` (mapped to `NotConfigured` so the orchestrator skips
+/// fail-open).
+/// Test: implemented by `DualModePrHistoryToken` (prod) and a fake in tests.
+#[async_trait]
+pub trait PrHistoryTokenResolver: Send + Sync {
+    /// Resolve a GitHub token for `owner`, or an error (treated as skip).
+    async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError>;
+}
+
+/// Production resolver delegating to the #582 `AuthStrategy`.
+///
+/// Why: keeps the single dual-mode auth funnel — no second credential path.
+/// What: holds the resolved run mode + a cloned `ReviewConfig`; on `resolve`,
+/// selects the strategy (CLI→PAT/`gh`, Serve→App) and resolves a token, mapping
+/// any `GithubError` to `NotConfigured` (skip).
+/// Test: not unit-tested directly (requires real auth); the seam is exercised
+/// via the fake in `pr_history_tests`.
+pub struct DualModePrHistoryToken {
+    run_mode: RunMode,
+    config: ReviewConfig,
+}
+
+impl DualModePrHistoryToken {
+    /// Construct from the run mode and a config snapshot.
+    ///
+    /// Why: the resolver needs the same config the rest of the GitHub path uses
+    /// (App id/key, PAT) to mint a token.
+    /// What: stores `run_mode` and a clone of `config`.
+    /// Test: covered transitively by `PrHistorySource::from_config`.
+    pub fn new(run_mode: RunMode, config: ReviewConfig) -> Self {
+        Self { run_mode, config }
+    }
+}
+
+#[async_trait]
+impl PrHistoryTokenResolver for DualModePrHistoryToken {
+    async fn resolve(&self, owner: &str) -> Result<String, ContextSourceError> {
+        let client = GithubClient::new().map_err(|e| ContextSourceError::NotConfigured {
+            src: SOURCE_NAME,
+            reason: format!("failed to build HTTP client: {e}"),
+        })?;
+        AuthStrategy::select(self.run_mode, None)
+            .resolve_token(&client, &self.config, owner)
+            .await
+            .map_err(|e| ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: format!("GitHub token unavailable: {e}"),
+            })
+    }
+}
+
+// ─── Transport seam ──────────────────────────────────────────────────────────
+
+/// Injectable transport for the GitHub commits-per-path and PR-lookup calls.
+///
+/// Why: isolate all network calls so fetch logic + dedup + rendering are tested
+/// against canned JSON without hitting the real GitHub API.
+/// What: two async methods — one for `GET /repos/{owner}/{repo}/commits?path=`
+/// and one for `GET /repos/{owner}/{repo}/commits/{sha}/pulls`.  Both return
+/// the raw JSON body on 2xx, or a `ContextSourceError` on failure.
+/// Test: implemented by `ReqwestPrHistoryTransport` (prod) and a fake in tests.
+#[async_trait]
+pub trait PrHistoryTransport: Send + Sync {
+    /// Fetch recent commits touching `path` in `{owner}/{repo}`.
+    async fn fetch_commits(
+        &self,
+        token: &str,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        per_page: u32,
+    ) -> Result<String, ContextSourceError>;
+
+    /// Fetch PRs associated with a commit `sha` in `{owner}/{repo}`.
+    ///
+    /// Uses the `groot-preview` media type required by the GitHub Commits API
+    /// "List pull requests associated with a commit" endpoint.
+    async fn fetch_prs_for_commit(
+        &self,
+        token: &str,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<String, ContextSourceError>;
+}
+
+/// Production `PrHistoryTransport` over reqwest + GitHub REST API.
+///
+/// Why: the default transport for real reviews.
+/// What: GETs `https://api.github.com/repos/{owner}/{repo}/commits?path=…` and
+/// the per-commit `/pulls` endpoint, mapping non-2xx → `Api` and transport
+/// failures → `Transport`.
+/// Test: exercised via the fake in `pr_history_tests`.
+pub struct ReqwestPrHistoryTransport {
+    http: reqwest::Client,
+}
+
+impl ReqwestPrHistoryTransport {
+    /// Construct with a default 15s-timeout client.
+    ///
+    /// Why: bound the worst-case latency of an enrichment call.
+    /// What: builds a reqwest client.  Returns `Err(ContextSourceError::Transport)`
+    /// if the TLS backend cannot be initialised.
+    /// Test: covered transitively by `PrHistorySource::from_config`.
+    pub fn new() -> Result<Self, ContextSourceError> {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("failed to build HTTP client: {e}")),
+            })?;
+        Ok(Self { http })
+    }
+}
+
+#[async_trait]
+impl PrHistoryTransport for ReqwestPrHistoryTransport {
+    async fn fetch_commits(
+        &self,
+        token: &str,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        per_page: u32,
+    ) -> Result<String, ContextSourceError> {
+        let url = format!("https://api.github.com/repos/{owner}/{repo}/commits");
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("path", path), ("per_page", &per_page.to_string())])
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "trusty-review")
+            .send()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("GET {url}: {e}")),
+            })?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("read body of {url}: {e}")),
+            })?;
+        if !status.is_success() {
+            return Err(ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: status.as_u16(),
+                body: text,
+            });
+        }
+        Ok(text)
+    }
+
+    async fn fetch_prs_for_commit(
+        &self,
+        token: &str,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<String, ContextSourceError> {
+        let url = format!("https://api.github.com/repos/{owner}/{repo}/commits/{sha}/pulls");
+        let resp = self
+            .http
+            .get(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            // groot-preview header required to list PRs for a commit.
+            .header("Accept", "application/vnd.github.groot-preview+json")
+            .header("User-Agent", "trusty-review")
+            .send()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("GET {url}: {e}")),
+            })?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ContextSourceError::Transport {
+                src: SOURCE_NAME,
+                err: TransportErr(format!("read body of {url}: {e}")),
+            })?;
+        if !status.is_success() {
+            return Err(ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: status.as_u16(),
+                body: text,
+            });
+        }
+        Ok(text)
+    }
+}
+
+// Disabled sentinels: returned by `from_config` when TLS init fails.
+struct DisabledPrHistoryToken;
+
+#[async_trait]
+impl PrHistoryTokenResolver for DisabledPrHistoryToken {
+    async fn resolve(&self, _owner: &str) -> Result<String, ContextSourceError> {
+        Err(ContextSourceError::NotConfigured {
+            src: SOURCE_NAME,
+            reason: "HTTP transport unavailable (TLS init failed)".to_string(),
+        })
+    }
+}
+
+struct DisabledPrHistoryTransport;
+
+#[async_trait]
+impl PrHistoryTransport for DisabledPrHistoryTransport {
+    async fn fetch_commits(
+        &self,
+        _token: &str,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _per_page: u32,
+    ) -> Result<String, ContextSourceError> {
+        Err(ContextSourceError::Transport {
+            src: SOURCE_NAME,
+            err: TransportErr("HTTP transport unavailable (TLS init failed)".to_string()),
+        })
+    }
+
+    async fn fetch_prs_for_commit(
+        &self,
+        _token: &str,
+        _owner: &str,
+        _repo: &str,
+        _sha: &str,
+    ) -> Result<String, ContextSourceError> {
+        Err(ContextSourceError::Transport {
+            src: SOURCE_NAME,
+            err: TransportErr("HTTP transport unavailable (TLS init failed)".to_string()),
+        })
+    }
+}
+
+// ─── JSON shapes ────────────────────────────────────────────────────────────
+
+/// One entry in the commits-per-path response array.
+#[derive(Debug, Deserialize)]
+struct CommitEntry {
+    sha: String,
+}
+
+/// One entry in the PRs-for-commit response array.
+#[derive(Debug, Deserialize)]
+struct PrEntry {
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    html_url: String,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+// ─── The source ──────────────────────────────────────────────────────────────
+
+/// LIVE prior-PR / file change-history context source (T10, #1423).
+///
+/// Why: surfaces recent PRs that touched the same files so the LLM reviewer
+/// can detect repeated patterns, regressions, and related prior work.
+/// Default DISABLED: multiple API calls per review; opt in via config or env.
+/// What: holds `enabled`, `mode`, the token resolver, and the transport.
+/// Test: `pr_history_tests.rs` — dedup, heading, fail-open, disabled skip.
+pub struct PrHistorySource {
+    enabled: bool,
+    mode: RetrievalMode,
+    token: Box<dyn PrHistoryTokenResolver>,
+    transport: Box<dyn PrHistoryTransport>,
+}
+
+impl PrHistorySource {
+    /// Build from resolved config + run mode (production constructor).
+    ///
+    /// Why: default DISABLED (mirrors `ConformanceSource`) — the source makes
+    /// multiple GitHub API calls per review and should only run when the
+    /// operator explicitly opts in via env or TOML.
+    /// What: computes `effective_enabled(false)` so the source is disabled by
+    /// default even when GitHub credentials are present.  If the reqwest TLS
+    /// backend cannot be initialised the source is constructed in a
+    /// permanently-disabled state (graceful degradation, closes #953).
+    /// Test: `from_config_default_disabled`, `from_config_respects_explicit_enable`.
+    pub fn from_config(cfg: &super::SourceConfig, run_mode: RunMode, config: ReviewConfig) -> Self {
+        let transport = match ReqwestPrHistoryTransport::new() {
+            Ok(t) => Box::new(t) as Box<dyn PrHistoryTransport>,
+            Err(e) => {
+                tracing::error!(
+                    "pr_history: failed to build HTTP transport (source disabled): {e}"
+                );
+                return Self {
+                    enabled: false,
+                    mode: cfg.mode,
+                    token: Box::new(DisabledPrHistoryToken),
+                    transport: Box::new(DisabledPrHistoryTransport),
+                };
+            }
+        };
+        // Default DISABLED: creds_present = false so `effective_enabled(false)`
+        // returns false unless the operator has explicitly set enabled = true.
+        let enabled = cfg.effective_enabled(false);
+        Self {
+            enabled,
+            mode: cfg.mode,
+            token: Box::new(DualModePrHistoryToken::new(run_mode, config)),
+            transport,
+        }
+    }
+
+    /// Construct directly (tests inject fakes).
+    ///
+    /// Why: drive `gather` without auth or network.
+    /// What: stores the provided fields verbatim.
+    /// Test: all tests in `pr_history_tests.rs`.
+    pub fn new(
+        enabled: bool,
+        mode: RetrievalMode,
+        token: Box<dyn PrHistoryTokenResolver>,
+        transport: Box<dyn PrHistoryTransport>,
+    ) -> Self {
+        Self {
+            enabled,
+            mode,
+            token,
+            transport,
+        }
+    }
+
+    /// Parse a commits-per-path JSON body into a list of SHAs.
+    ///
+    /// Why: separate parsing from the network call for testability.
+    /// What: deserialises the `[{"sha": "…"}, …]` array and returns the SHA
+    /// strings.  An empty array or a parse error both yield an empty vec (the
+    /// caller should log parse errors before calling this).
+    /// Test: `parse_commit_shas`.
+    fn parse_commit_shas(body: &str) -> Result<Vec<String>, ContextSourceError> {
+        let entries: Vec<CommitEntry> =
+            serde_json::from_str(body).map_err(|e| ContextSourceError::Parse {
+                src: SOURCE_NAME,
+                detail: format!("commits response: {e}"),
+            })?;
+        Ok(entries.into_iter().map(|c| c.sha).collect())
+    }
+
+    /// Parse a PRs-for-commit JSON body into `PrEntry` items.
+    ///
+    /// Why: separate parsing from the network call for testability.
+    /// What: deserialises the `[{"number": N, …}, …]` array.
+    /// Test: `parse_pr_entries`.
+    fn parse_pr_entries(body: &str) -> Result<Vec<PrEntry>, ContextSourceError> {
+        serde_json::from_str(body).map_err(|e| ContextSourceError::Parse {
+            src: SOURCE_NAME,
+            detail: format!("PRs-for-commit response: {e}"),
+        })
+    }
+
+    /// Convert a map of deduped PRs (keyed by number) into a sorted
+    /// `ContextSection`.
+    ///
+    /// Why: after gathering PRs across all files, we need to deduplicate by PR
+    /// number, take the top `MAX_PRS` by descending number (most recent first),
+    /// and map them to `ContextSnippet`s — keeping this logic a pure function
+    /// makes it testable without fakes.
+    /// What: sorts the iterator by `number` descending, takes `MAX_PRS`, maps
+    /// each entry to a snippet with title, subtitle, body excerpt, and link.
+    /// Test: `render_deduped_prs_section`.
+    fn build_section(prs: HashMap<u64, PrEntry>) -> ContextSection {
+        let mut entries: Vec<PrEntry> = prs.into_values().collect();
+        // Most-recent-first (highest PR number first).
+        entries.sort_by_key(|e| std::cmp::Reverse(e.number));
+        entries.truncate(MAX_PRS);
+
+        let snippets = entries
+            .into_iter()
+            .map(|pr| {
+                let title = if pr.title.is_empty() {
+                    format!("PR #{}", pr.number)
+                } else {
+                    format!("PR #{}: {}", pr.number, pr.title)
+                };
+                let body_excerpt = pr.body.as_deref().map(str::trim).and_then(|b| {
+                    (!b.is_empty()).then(|| truncate_on_char_boundary(b, PR_BODY_CHARS).to_string())
+                });
+                ContextSnippet {
+                    title,
+                    subtitle: (!pr.state.is_empty()).then(|| pr.state.clone()),
+                    body: body_excerpt,
+                    link: (!pr.html_url.is_empty()).then(|| pr.html_url.clone()),
+                }
+            })
+            .collect();
+
+        ContextSection {
+            heading: "Prior PRs touching changed files".to_string(),
+            snippets,
+        }
+    }
+}
+
+#[async_trait]
+impl ContextSource for PrHistorySource {
+    fn name(&self) -> &'static str {
+        SOURCE_NAME
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn mode(&self) -> RetrievalMode {
+        self.mode
+    }
+
+    /// Gather prior PRs touching the changed files.
+    ///
+    /// Why: surfaces historical context so the LLM reviewer can detect
+    /// recurring patterns or prior fixes to the same code paths.
+    /// What: for each changed file (capped at `MAX_FILES_TO_QUERY`), fetches
+    /// recent commits touching that file, then for each commit fetches its
+    /// associated PRs (groot-preview endpoint).  All PRs are deduped by number;
+    /// the top `MAX_PRS` most-recent are rendered into a section.  Per-file API
+    /// errors are logged and skipped (fail-open within the gather).
+    /// Test: `gather_deduplicates_prs`, `gather_fail_open_on_api_error`,
+    /// `gather_returns_empty_section_for_no_signal`.
+    async fn gather(&self, subject: &ReviewSubject) -> Result<ContextSection, ContextSourceError> {
+        if self.mode == RetrievalMode::Semantic {
+            return Err(ContextSourceError::SemanticNotImplemented { src: SOURCE_NAME });
+        }
+        // No owner/repo → local-diff mode; return empty section.
+        if subject.owner.is_empty() || subject.repo.is_empty() {
+            return Ok(ContextSection {
+                heading: "Prior PRs touching changed files".to_string(),
+                snippets: Vec::new(),
+            });
+        }
+        // Resolve the token once; fail-open if unavailable.
+        let token = self.token.resolve(&subject.owner).await?;
+
+        let files_to_query: Vec<&String> = subject
+            .changed_files
+            .iter()
+            .take(MAX_FILES_TO_QUERY)
+            .collect();
+
+        if files_to_query.is_empty() {
+            return Ok(ContextSection {
+                heading: "Prior PRs touching changed files".to_string(),
+                snippets: Vec::new(),
+            });
+        }
+
+        // Accumulate deduped PRs: keyed by PR number.
+        let mut seen: HashMap<u64, PrEntry> = HashMap::new();
+
+        for file in files_to_query {
+            // Fetch commits touching this file.
+            let commits_body = match self
+                .transport
+                .fetch_commits(
+                    &token,
+                    &subject.owner,
+                    &subject.repo,
+                    file,
+                    COMMITS_PER_FILE,
+                )
+                .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(
+                        source = SOURCE_NAME,
+                        file = file.as_str(),
+                        "failed to fetch commits for file (skipping): {e}"
+                    );
+                    continue;
+                }
+            };
+
+            let shas = match Self::parse_commit_shas(&commits_body) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(
+                        source = SOURCE_NAME,
+                        file = file.as_str(),
+                        "failed to parse commits response (skipping): {e}"
+                    );
+                    continue;
+                }
+            };
+
+            debug!(
+                source = SOURCE_NAME,
+                file = file.as_str(),
+                sha_count = shas.len(),
+                "fetched commits for file"
+            );
+
+            // For each commit, look up associated PRs.
+            for sha in &shas {
+                // Stop early if we already have enough PRs.
+                if seen.len() >= MAX_PRS * 2 {
+                    break;
+                }
+
+                let prs_body = match self
+                    .transport
+                    .fetch_prs_for_commit(&token, &subject.owner, &subject.repo, sha)
+                    .await
+                {
+                    Ok(b) => b,
+                    Err(e) => {
+                        warn!(
+                            source = SOURCE_NAME,
+                            sha = sha.as_str(),
+                            "failed to fetch PRs for commit (skipping): {e}"
+                        );
+                        continue;
+                    }
+                };
+
+                let prs = match Self::parse_pr_entries(&prs_body) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        warn!(
+                            source = SOURCE_NAME,
+                            sha = sha.as_str(),
+                            "failed to parse PRs-for-commit response (skipping): {e}"
+                        );
+                        continue;
+                    }
+                };
+
+                for pr in prs {
+                    // Dedup by PR number.
+                    seen.entry(pr.number).or_insert(pr);
+                }
+            }
+        }
+
+        Ok(Self::build_section(seen))
+    }
+}
+
+#[cfg(test)]
+#[path = "pr_history_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/integrations/context/pr_history_tests.rs
+++ b/crates/trusty-review/src/integrations/context/pr_history_tests.rs
@@ -1,0 +1,572 @@
+//! Tests for the prior-PR / file change-history context source.
+//!
+//! Why: extracted from `pr_history.rs` to keep that file under the 500-line
+//! cap while preserving full coverage (parse helpers, dedup logic, the
+//! semantic-mode error path, default-disabled config, and the fail-open
+//! token/transport seams).
+//! What: query/parse unit tests plus fake-driven `gather` tests (no network).
+//! Test: included as `#[cfg(test)] mod tests` from `pr_history.rs`.
+
+use super::*;
+
+// ─── Fake token resolver ─────────────────────────────────────────────────────
+
+struct FakeToken(Result<String, ()>);
+
+#[async_trait]
+impl PrHistoryTokenResolver for FakeToken {
+    async fn resolve(&self, _owner: &str) -> Result<String, ContextSourceError> {
+        self.0
+            .clone()
+            .map_err(|_| ContextSourceError::NotConfigured {
+                src: SOURCE_NAME,
+                reason: "no token".to_string(),
+            })
+    }
+}
+
+// ─── Fake transport ──────────────────────────────────────────────────────────
+
+/// A fake transport that maps file paths to (commits_body, prs_body_per_sha).
+///
+/// Why: drives the full gather loop without network calls; supports
+/// per-file commit responses and per-sha PR responses.
+struct FakeTransport {
+    /// Keyed by file path → raw JSON commits body (or Err for API failure).
+    commits_by_file: std::collections::HashMap<String, Result<String, ()>>,
+    /// Keyed by sha → raw JSON PRs body (or Err for API failure).
+    prs_by_sha: std::collections::HashMap<String, Result<String, ()>>,
+}
+
+impl FakeTransport {
+    fn new() -> Self {
+        Self {
+            commits_by_file: std::collections::HashMap::new(),
+            prs_by_sha: std::collections::HashMap::new(),
+        }
+    }
+
+    fn with_commits(mut self, file: &str, body: Result<&str, ()>) -> Self {
+        self.commits_by_file
+            .insert(file.to_string(), body.map(|s| s.to_string()));
+        self
+    }
+
+    fn with_prs(mut self, sha: &str, body: Result<&str, ()>) -> Self {
+        self.prs_by_sha
+            .insert(sha.to_string(), body.map(|s| s.to_string()));
+        self
+    }
+}
+
+#[async_trait]
+impl PrHistoryTransport for FakeTransport {
+    async fn fetch_commits(
+        &self,
+        _token: &str,
+        _owner: &str,
+        _repo: &str,
+        path: &str,
+        _per_page: u32,
+    ) -> Result<String, ContextSourceError> {
+        match self.commits_by_file.get(path) {
+            Some(Ok(body)) => Ok(body.clone()),
+            Some(Err(())) => Err(ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: 500,
+                body: "server error".to_string(),
+            }),
+            None => Ok("[]".to_string()), // no commits → empty array
+        }
+    }
+
+    async fn fetch_prs_for_commit(
+        &self,
+        _token: &str,
+        _owner: &str,
+        _repo: &str,
+        sha: &str,
+    ) -> Result<String, ContextSourceError> {
+        match self.prs_by_sha.get(sha) {
+            Some(Ok(body)) => Ok(body.clone()),
+            Some(Err(())) => Err(ContextSourceError::Api {
+                src: SOURCE_NAME,
+                status: 500,
+                body: "server error".to_string(),
+            }),
+            None => Ok("[]".to_string()), // no PRs for this commit
+        }
+    }
+}
+
+// ─── Subject helper ──────────────────────────────────────────────────────────
+
+fn subject_with_files(files: &[&str]) -> ReviewSubject {
+    ReviewSubject {
+        owner: "acme".to_string(),
+        repo: "backend".to_string(),
+        title: "Fix streaming".to_string(),
+        changed_files: files.iter().map(|s| s.to_string()).collect(),
+        ..Default::default()
+    }
+}
+
+// ─── Parse tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn parse_commit_shas_extracts_shas() {
+    // Why: verifies the commit JSON is parsed correctly into SHA strings.
+    let body = r#"[{"sha":"abc123"},{"sha":"def456"}]"#;
+    let shas = PrHistorySource::parse_commit_shas(body).unwrap();
+    assert_eq!(shas, vec!["abc123", "def456"]);
+}
+
+#[test]
+fn parse_commit_shas_empty_array() {
+    // Why: an empty commits array must yield an empty vec (no panic).
+    let shas = PrHistorySource::parse_commit_shas("[]").unwrap();
+    assert!(shas.is_empty());
+}
+
+#[test]
+fn parse_commit_shas_garbage_returns_parse_error() {
+    // Why: malformed JSON must return a Parse error (no panic).
+    assert!(matches!(
+        PrHistorySource::parse_commit_shas("nope"),
+        Err(ContextSourceError::Parse { .. })
+    ));
+}
+
+#[test]
+fn parse_pr_entries_extracts_fields() {
+    // Why: verifies PR entry fields are parsed (number, title, state, url, body).
+    let body = r#"[{
+        "number": 42,
+        "title": "Fix streaming regression",
+        "state": "closed",
+        "html_url": "https://github.com/acme/backend/pull/42",
+        "body": "Closes the streaming bug introduced in #40."
+    }]"#;
+    let prs = PrHistorySource::parse_pr_entries(body).unwrap();
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].number, 42);
+    assert_eq!(prs[0].title, "Fix streaming regression");
+    assert_eq!(prs[0].state, "closed");
+    assert_eq!(prs[0].html_url, "https://github.com/acme/backend/pull/42");
+    assert_eq!(
+        prs[0].body.as_deref(),
+        Some("Closes the streaming bug introduced in #40.")
+    );
+}
+
+#[test]
+fn parse_pr_entries_garbage_returns_parse_error() {
+    // Why: malformed JSON must return a Parse error (no panic).
+    assert!(matches!(
+        PrHistorySource::parse_pr_entries("not json"),
+        Err(ContextSourceError::Parse { .. })
+    ));
+}
+
+// ─── build_section tests ─────────────────────────────────────────────────────
+
+fn make_pr_entry(number: u64, title: &str, state: &str) -> PrEntry {
+    PrEntry {
+        number,
+        title: title.to_string(),
+        state: state.to_string(),
+        html_url: format!("https://github.com/acme/backend/pull/{number}"),
+        body: Some(format!("Description of PR {number}")),
+    }
+}
+
+#[test]
+fn build_section_heading() {
+    // Why: the section heading must be exactly the expected constant string.
+    let section = PrHistorySource::build_section(HashMap::new());
+    assert_eq!(section.heading, "Prior PRs touching changed files");
+}
+
+#[test]
+fn build_section_deduplicates_by_pr_number() {
+    // Why: the same PR discovered via multiple files/commits must appear once.
+    let mut prs = HashMap::new();
+    prs.insert(42, make_pr_entry(42, "Fix streaming", "closed"));
+    prs.insert(43, make_pr_entry(43, "Add context", "merged"));
+    let section = PrHistorySource::build_section(prs);
+    assert_eq!(section.snippets.len(), 2);
+}
+
+#[test]
+fn build_section_most_recent_first() {
+    // Why: snippets are ordered by descending PR number (most recent first).
+    let mut prs = HashMap::new();
+    for n in [10, 30, 20u64] {
+        prs.insert(n, make_pr_entry(n, "PR title", "closed"));
+    }
+    let section = PrHistorySource::build_section(prs);
+    let numbers: Vec<u64> = section
+        .snippets
+        .iter()
+        .map(|s| {
+            s.title
+                .trim_start_matches("PR #")
+                .split(':')
+                .next()
+                .unwrap()
+                .parse::<u64>()
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(numbers, vec![30, 20, 10]);
+}
+
+#[test]
+fn build_section_capped_at_max_prs() {
+    // Why: output must be capped at MAX_PRS (5) even with more unique PRs.
+    let mut prs = HashMap::new();
+    for n in 1..=10u64 {
+        prs.insert(n, make_pr_entry(n, "PR", "closed"));
+    }
+    let section = PrHistorySource::build_section(prs);
+    assert_eq!(section.snippets.len(), MAX_PRS);
+}
+
+#[test]
+fn build_section_snippet_title_format() {
+    // Why: title must follow the "PR #N: title" format.
+    let mut prs = HashMap::new();
+    prs.insert(99, make_pr_entry(99, "Big refactor", "closed"));
+    let section = PrHistorySource::build_section(prs);
+    assert_eq!(section.snippets[0].title, "PR #99: Big refactor");
+}
+
+#[test]
+fn build_section_snippet_body_truncated() {
+    // Why: long PR bodies must be truncated to PR_BODY_CHARS.
+    let long_body = "x".repeat(PR_BODY_CHARS + 100);
+    let mut prs = HashMap::new();
+    prs.insert(
+        1,
+        PrEntry {
+            number: 1,
+            title: "t".to_string(),
+            state: "closed".to_string(),
+            html_url: "u".to_string(),
+            body: Some(long_body),
+        },
+    );
+    let section = PrHistorySource::build_section(prs);
+    let body_len = section.snippets[0].body.as_deref().unwrap().chars().count();
+    assert_eq!(body_len, PR_BODY_CHARS);
+}
+
+#[test]
+fn build_section_no_body_when_empty() {
+    // Why: empty/whitespace-only PR bodies must not produce a snippet body.
+    let mut prs = HashMap::new();
+    prs.insert(
+        1,
+        PrEntry {
+            number: 1,
+            title: "t".to_string(),
+            state: "closed".to_string(),
+            html_url: "u".to_string(),
+            body: Some("   ".to_string()),
+        },
+    );
+    let section = PrHistorySource::build_section(prs);
+    assert!(section.snippets[0].body.is_none());
+}
+
+// ─── gather integration tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn gather_deduplicates_prs_across_files() {
+    // Why: the same PR associated with commits from two different files must
+    // appear only once in the output.
+    let commits_a = r#"[{"sha":"sha1"}]"#;
+    let commits_b = r#"[{"sha":"sha2"}]"#;
+    // Both commits map to the same PR number 42.
+    let prs_for_sha1 = r#"[{"number":42,"title":"Fix streaming","state":"closed","html_url":"https://github.com/acme/backend/pull/42","body":"desc"}]"#;
+    let prs_for_sha2 = r#"[{"number":42,"title":"Fix streaming","state":"closed","html_url":"https://github.com/acme/backend/pull/42","body":"desc"}]"#;
+
+    let transport = FakeTransport::new()
+        .with_commits("src/stream.rs", Ok(commits_a))
+        .with_commits("src/context.rs", Ok(commits_b))
+        .with_prs("sha1", Ok(prs_for_sha1))
+        .with_prs("sha2", Ok(prs_for_sha2));
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Ok("tok".to_string()))),
+        Box::new(transport),
+    );
+
+    let section = src
+        .gather(&subject_with_files(&["src/stream.rs", "src/context.rs"]))
+        .await
+        .expect("gather should succeed");
+
+    assert_eq!(section.heading, "Prior PRs touching changed files");
+    assert_eq!(section.snippets.len(), 1, "PR #42 deduplicated");
+    assert!(section.snippets[0].title.contains("42"));
+}
+
+#[tokio::test]
+async fn gather_collects_multiple_prs() {
+    // Why: when different files/commits yield different PR numbers, all
+    // distinct PRs are included (up to MAX_PRS).
+    let commits_a = r#"[{"sha":"sha1"}]"#;
+    let commits_b = r#"[{"sha":"sha2"}]"#;
+    let prs_sha1 =
+        r#"[{"number":10,"title":"PR ten","state":"closed","html_url":"u10","body":"b10"}]"#;
+    let prs_sha2 =
+        r#"[{"number":20,"title":"PR twenty","state":"merged","html_url":"u20","body":"b20"}]"#;
+
+    let transport = FakeTransport::new()
+        .with_commits("a.rs", Ok(commits_a))
+        .with_commits("b.rs", Ok(commits_b))
+        .with_prs("sha1", Ok(prs_sha1))
+        .with_prs("sha2", Ok(prs_sha2));
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Ok("tok".to_string()))),
+        Box::new(transport),
+    );
+
+    let section = src
+        .gather(&subject_with_files(&["a.rs", "b.rs"]))
+        .await
+        .expect("gather should succeed");
+
+    assert_eq!(section.snippets.len(), 2);
+    // Most recent first: PR #20 before PR #10.
+    assert!(section.snippets[0].title.contains("20"));
+    assert!(section.snippets[1].title.contains("10"));
+}
+
+#[tokio::test]
+async fn gather_fail_open_on_commits_api_error() {
+    // Why: when the commits fetch fails for a file, that file is skipped
+    // (fail-open) and the source returns whatever PRs were found for other
+    // files — the review is NOT blocked.
+    let commits_good = r#"[{"sha":"sha_good"}]"#;
+    let prs_good =
+        r#"[{"number":7,"title":"Good PR","state":"closed","html_url":"u7","body":"desc"}]"#;
+
+    let transport = FakeTransport::new()
+        .with_commits("good.rs", Ok(commits_good))
+        .with_commits("bad.rs", Err(())) // API error on this file
+        .with_prs("sha_good", Ok(prs_good));
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Ok("tok".to_string()))),
+        Box::new(transport),
+    );
+
+    let section = src
+        .gather(&subject_with_files(&["good.rs", "bad.rs"]))
+        .await
+        .expect("gather should succeed (fail-open)");
+
+    // The good file's PR survives; the bad file's error is swallowed.
+    assert_eq!(section.snippets.len(), 1);
+    assert!(section.snippets[0].title.contains("7"));
+}
+
+#[tokio::test]
+async fn gather_fail_open_on_prs_for_commit_api_error() {
+    // Why: when the PR-lookup for a specific commit fails, that commit is
+    // skipped (fail-open) and other commits in the same file are still
+    // processed.
+    let commits = r#"[{"sha":"sha_err"},{"sha":"sha_ok"}]"#;
+    let prs_ok = r#"[{"number":5,"title":"OK PR","state":"closed","html_url":"u5","body":"d"}]"#;
+
+    let transport = FakeTransport::new()
+        .with_commits("file.rs", Ok(commits))
+        .with_prs("sha_err", Err(())) // PR lookup error
+        .with_prs("sha_ok", Ok(prs_ok));
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Ok("tok".to_string()))),
+        Box::new(transport),
+    );
+
+    let section = src
+        .gather(&subject_with_files(&["file.rs"]))
+        .await
+        .expect("gather should succeed (fail-open)");
+
+    assert_eq!(section.snippets.len(), 1);
+    assert!(section.snippets[0].title.contains("5"));
+}
+
+#[tokio::test]
+async fn gather_returns_empty_section_for_no_signal() {
+    // Why: when no changed files are provided (local-diff with no diff), the
+    // source must return an empty section, not an error.
+    let transport = FakeTransport::new();
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Ok("tok".to_string()))),
+        Box::new(transport),
+    );
+
+    let section = src
+        .gather(&subject_with_files(&[]))
+        .await
+        .expect("empty subject should yield empty section, not error");
+
+    assert!(section.snippets.is_empty());
+    assert_eq!(section.heading, "Prior PRs touching changed files");
+}
+
+#[tokio::test]
+async fn gather_returns_empty_section_for_local_diff_mode() {
+    // Why: when owner/repo are empty (local-diff mode), gather must short-circuit
+    // and return an empty section, not call the transport.
+    let transport = FakeTransport::new();
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Ok("tok".to_string()))),
+        Box::new(transport),
+    );
+
+    let local_diff_subject = ReviewSubject {
+        owner: String::new(),
+        repo: String::new(),
+        changed_files: vec!["src/main.rs".to_string()],
+        ..Default::default()
+    };
+
+    let section = src
+        .gather(&local_diff_subject)
+        .await
+        .expect("local-diff mode must return empty section, not error");
+
+    assert!(section.snippets.is_empty());
+}
+
+#[tokio::test]
+async fn gather_skip_when_token_unavailable() {
+    // Why: a token resolution failure must propagate as a NotConfigured error
+    // so the orchestrator can log it and skip this source (fail-open at the
+    // orchestrator level, not inside gather).
+    let transport = FakeTransport::new();
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Err(()))), // no token
+        Box::new(transport),
+    );
+
+    let r = src.gather(&subject_with_files(&["src/main.rs"])).await;
+    assert!(
+        matches!(r, Err(ContextSourceError::NotConfigured { .. })),
+        "token failure must produce NotConfigured"
+    );
+}
+
+#[tokio::test]
+async fn gather_semantic_mode_errors() {
+    // Why: semantic mode is not yet implemented; the source must return
+    // SemanticNotImplemented so the orchestrator can log it.
+    let transport = FakeTransport::new();
+
+    let src = PrHistorySource::new(
+        true,
+        RetrievalMode::Semantic,
+        Box::new(FakeToken(Ok("tok".to_string()))),
+        Box::new(transport),
+    );
+
+    let r = src.gather(&subject_with_files(&["a.rs"])).await;
+    assert!(
+        matches!(
+            r,
+            Err(ContextSourceError::SemanticNotImplemented { src: "pr_history" })
+        ),
+        "semantic mode must produce SemanticNotImplemented"
+    );
+}
+
+// ─── from_config tests ────────────────────────────────────────────────────────
+
+#[test]
+fn from_config_default_disabled_without_explicit_enable() {
+    // Why: mirrors ConformanceSource — default DISABLED even when creds are
+    // present; operator must explicitly set enabled = true.
+    let cfg = super::super::SourceConfig {
+        enabled: None, // no explicit intent
+        mode: RetrievalMode::Live,
+    };
+    let src = PrHistorySource::from_config(
+        &cfg,
+        crate::integrations::github::RunMode::Cli,
+        crate::config::ReviewConfig::load(None),
+    );
+    assert!(
+        !src.is_enabled(),
+        "pr_history must be default-disabled without explicit enabled = true"
+    );
+}
+
+#[test]
+fn from_config_respects_explicit_enable() {
+    // Why: an operator who opts in (enabled = true) must get the source enabled.
+    let cfg = super::super::SourceConfig {
+        enabled: Some(true),
+        mode: RetrievalMode::Live,
+    };
+    let src = PrHistorySource::from_config(
+        &cfg,
+        crate::integrations::github::RunMode::Cli,
+        crate::config::ReviewConfig::load(None),
+    );
+    assert!(
+        src.is_enabled(),
+        "explicit enabled = true must enable the source"
+    );
+}
+
+#[test]
+fn from_config_respects_explicit_disable() {
+    // Why: explicit enabled = false must always win.
+    let cfg = super::super::SourceConfig {
+        enabled: Some(false),
+        mode: RetrievalMode::Live,
+    };
+    let src = PrHistorySource::from_config(
+        &cfg,
+        crate::integrations::github::RunMode::Cli,
+        crate::config::ReviewConfig::load(None),
+    );
+    assert!(!src.is_enabled());
+}
+
+// ─── Heading constant test ────────────────────────────────────────────────────
+
+#[test]
+fn source_name_is_pr_history() {
+    // Why: the name is used in env-var construction and logs; must be stable.
+    let src = PrHistorySource::new(
+        false,
+        RetrievalMode::Live,
+        Box::new(FakeToken(Err(()))),
+        Box::new(FakeTransport::new()),
+    );
+    assert_eq!(src.name(), "pr_history");
+}

--- a/crates/trusty-review/src/pipeline/runner_context.rs
+++ b/crates/trusty-review/src/pipeline/runner_context.rs
@@ -20,7 +20,7 @@ use crate::{
         apex_context::fetch_apex_context,
         context::{
             ConfluenceSource, ConformanceSource, ContextSource, GithubIssuesSource, JiraSource,
-            ReviewSubject, gather_external_context, render_sections,
+            PrHistorySource, ReviewSubject, gather_external_context, render_sections,
         },
         github::RunMode,
     },
@@ -215,6 +215,12 @@ pub(crate) async fn gather_external_context_md(
         // can flag explicit method contradictions.  Default DISABLED (needs auth).
         Box::new(ConformanceSource::from_config(
             &cs.conformance,
+            run_mode,
+            config.clone(),
+        )),
+        // Prior-PR / file change-history source (T10, #1423).  Default DISABLED.
+        Box::new(PrHistorySource::from_config(
+            &cs.pr_history,
             run_mode,
             config.clone(),
         )),


### PR DESCRIPTION
## Summary

PR F of epic #1413 — implements the `PrHistorySource` context source (child ticket #1423, T10 P3).

- **New `PrHistorySource`** implementing `ContextSource`: for each changed file (≤5), fetches recent commits touching that file via `GET /repos/{owner}/{repo}/commits?path={file}`, then maps each commit SHA to associated PRs via `GET /repos/{owner}/{repo}/commits/{sha}/pulls` (groot-preview header). Deduplicates by PR number, takes the 5 most-recent (descending PR number), renders under `## Prior PRs touching changed files`.
- **Default DISABLED** — mirrors `ConformanceSource`; requires explicit opt-in via `TRUSTY_REVIEW_CONTEXT_PR_HISTORY_ENABLED=true` or `[context.sources.pr_history] enabled = true` in TOML config.
- **Fail-open** — per-file commit fetch errors and per-commit PR-lookup errors are logged and skipped; partial results survive; the review is never blocked.
- **Auth reuse** — threads the existing `#582` dual-mode auth (CLI→PAT/`gh`, serve→App) through `PrHistoryTokenResolver`; no new credential mechanism.
- **Bounded API calls** — `MAX_FILES_TO_QUERY=5`, `COMMITS_PER_FILE=10`, `MAX_PRS=5`.

### Files changed

| File | Change |
|------|--------|
| `src/integrations/context/pr_history.rs` | NEW — `PrHistorySource`, `PrHistoryTokenResolver`, `PrHistoryTransport` traits + prod impls |
| `src/integrations/context/pr_history_tests.rs` | NEW — 24 unit + async tests (no network) |
| `src/integrations/context/mod.rs` | Register `pub mod pr_history` + re-export `PrHistorySource` |
| `src/integrations/context/config.rs` | Add `pr_history: SourceConfig` to `ContextSourcesConfig` + `pr_history: SourceFileConfig` to TOML mirror |
| `src/pipeline/runner_context.rs` | Register `PrHistorySource::from_config` in `gather_external_context_md` |

### Test evidence (all 940 tests pass; 24 new pr_history tests)

```
test integrations::context::pr_history::tests::build_section_capped_at_max_prs ... ok
test integrations::context::pr_history::tests::build_section_deduplicates_by_pr_number ... ok
test integrations::context::pr_history::tests::build_section_heading ... ok
test integrations::context::pr_history::tests::build_section_most_recent_first ... ok
test integrations::context::pr_history::tests::build_section_no_body_when_empty ... ok
test integrations::context::pr_history::tests::build_section_snippet_body_truncated ... ok
test integrations::context::pr_history::tests::build_section_snippet_title_format ... ok
test integrations::context::pr_history::tests::from_config_default_disabled_without_explicit_enable ... ok
test integrations::context::pr_history::tests::from_config_respects_explicit_disable ... ok
test integrations::context::pr_history::tests::from_config_respects_explicit_enable ... ok
test integrations::context::pr_history::tests::gather_collects_multiple_prs ... ok
test integrations::context::pr_history::tests::gather_deduplicates_prs_across_files ... ok
test integrations::context::pr_history::tests::gather_fail_open_on_commits_api_error ... ok
test integrations::context::pr_history::tests::gather_fail_open_on_prs_for_commit_api_error ... ok
test integrations::context::pr_history::tests::gather_returns_empty_section_for_local_diff_mode ... ok
test integrations::context::pr_history::tests::gather_returns_empty_section_for_no_signal ... ok
test integrations::context::pr_history::tests::gather_semantic_mode_errors ... ok
test integrations::context::pr_history::tests::gather_skip_when_token_unavailable ... ok
test integrations::context::pr_history::tests::parse_commit_shas_empty_array ... ok
test integrations::context::pr_history::tests::parse_commit_shas_extracts_shas ... ok
test integrations::context::pr_history::tests::parse_commit_shas_garbage_returns_parse_error ... ok
test integrations::context::pr_history::tests::parse_pr_entries_extracts_fields ... ok
test integrations::context::pr_history::tests::parse_pr_entries_garbage_returns_parse_error ... ok
test integrations::context::pr_history::tests::source_name_is_pr_history ... ok

test result: ok. 940 passed; 0 failed; 3 ignored
```

### Quality bar

- `cargo check -p trusty-review` ✅ zero warnings
- `cargo clippy -p trusty-review --all-targets -- -D warnings` ✅ zero warnings
- `cargo test -p trusty-review` ✅ 940 passed, 0 failed
- `cargo fmt --check` ✅ no drift
- `bash scripts/check_line_cap.sh` ✅ 0 violations

### LOC delta

- Added: ~620 lines (`pr_history.rs`) + ~570 lines (`pr_history_tests.rs`) + ~8 lines (edits to 3 files)
- Net: +1198 lines (new source + full test coverage; zero deletions)

### Relation to epic #1413

This is PR F (T10, P3) in the #1413 sequence. It is independent of PR C (conformance — `conformance.rs` / `prompt_templates.rs` untouched).

Closes #1423
Part of epic #1413