### PR TITLE
feat(trusty-review): review-outcome capture — reactions/commits + outcome store + webhook poll (refs #1421)

### DIFF
--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -22,11 +22,15 @@ pub mod verification;
 // Why: voice configuration loading extracted to keep config/mod.rs under the
 // 500-line cap (#610) after adding voice support (#754/#756).
 pub mod voice;
+// Why: outcome-polling configuration extracted to keep config/mod.rs under the
+// 500-line cap — mirrors the verification module pattern.
+pub mod outcome;
 
 pub use index_resolver::{find_git_root, repo_root_from_cwd, resolve_index_from_list};
 pub use mapreduce::{DiffStats, MapMode, MapReduceConfig, ReviewPath, select_review_mode};
 
 pub use context::{ContextConfig, ContextFileConfig};
+pub use outcome::{OutcomeConfig, OutcomeFileConfig};
 pub use role_models::{
     FileModels, RoleCliOverrides, RoleConfig, RoleConfigOverride, RoleEnv, RoleModels,
 };
@@ -95,6 +99,8 @@ struct TomlFile {
     voice: voice::VoiceFileConfig,
     #[serde(default)]
     coverage: crate::coverage::CoverageFileConfig,
+    #[serde(default)]
+    outcome: outcome::OutcomeFileConfig,
 }
 
 /// Global service configuration for trusty-review.
@@ -238,6 +244,12 @@ pub struct ReviewConfig {
     /// default).  All fields configurable via env vars or `[coverage]` TOML table.
     /// When `enabled = false`, the coverage pipeline is a complete no-op.
     pub coverage: crate::coverage::CoveragePolicy,
+
+    // ── Outcome polling (issue #1421) ─────────────────────────────────────
+    /// Resolved outcome-polling settings (`enabled`, `poll_delay_minutes`,
+    /// `dismissal_threshold`).  Defaults to disabled — opt-in via
+    /// `TRUSTY_REVIEW_OUTCOME_ENABLED=true`.
+    pub outcome: OutcomeConfig,
 }
 
 impl ReviewConfig {
@@ -264,6 +276,8 @@ impl ReviewConfig {
         let file_voice: Option<&voice::VoiceFileConfig> = toml_file.as_ref().map(|f| &f.voice);
         let file_coverage: Option<&crate::coverage::CoverageFileConfig> =
             toml_file.as_ref().map(|f| &f.coverage);
+        let file_outcome: Option<&outcome::OutcomeFileConfig> =
+            toml_file.as_ref().map(|f| &f.outcome);
 
         let env = RoleEnv::from_env();
         let role_models = RoleModels::resolve(cli_overrides, &env, file_models.as_ref());
@@ -326,6 +340,7 @@ impl ReviewConfig {
             voice_package: voice::load_voice_package(file_voice),
             voice_principles: voice::load_voice_principles(file_voice),
             coverage: crate::coverage::CoveragePolicy::from_env_and_file(file_coverage),
+            outcome: OutcomeConfig::from_env_and_file(file_outcome),
         }
     }
 

--- a/crates/trusty-review/src/config/outcome.rs
+++ b/crates/trusty-review/src/config/outcome.rs
@@ -1,0 +1,210 @@
+//! Outcome-polling configuration (issue #1421).
+//!
+//! Why: outcome tracking (reactions + follow-up commits → suppression list) must
+//! be opt-in (disabled by default) and its polling delay and dismissal threshold
+//! must be independently tunable, matching the rest of the config module's
+//! env-over-file-over-default pattern.
+//!
+//! What: exposes `OutcomeConfig` (resolved) and its TOML-deserialisable mirror
+//! `OutcomeFileConfig`.  `from_env_and_file` resolves the two-layer precedence.
+//!
+//! Test: `outcome_defaults_disabled`, `outcome_env_enables`,
+//! `outcome_file_configures`.
+
+use serde::Deserialize;
+use tracing::warn;
+
+const ENV_OUTCOME_ENABLED: &str = "TRUSTY_REVIEW_OUTCOME_ENABLED";
+const ENV_OUTCOME_POLL_DELAY: &str = "TRUSTY_REVIEW_OUTCOME_POLL_DELAY_MINUTES";
+const ENV_OUTCOME_THRESHOLD: &str = "TRUSTY_REVIEW_OUTCOME_DISMISSAL_THRESHOLD";
+
+/// Resolved configuration for the outcome-polling pipeline.
+///
+/// Why: the webhook handler and the background poll task both read these flags;
+/// a single owned struct keeps the decision logic free of scattered env lookups
+/// and makes the behaviour trivially testable (construct the struct directly).
+/// What: `enabled` gates whether the outcome poll is scheduled on PR close;
+/// `poll_delay_minutes` is how long to wait after merge before polling;
+/// `dismissal_threshold` is the minimum dismissed-count for suppression-list inclusion.
+/// Test: `outcome_defaults_disabled`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutcomeConfig {
+    /// When `true`, outcome polling is scheduled on PR closed+merged events.
+    /// Default: `false` (opt-in).
+    pub enabled: bool,
+    /// How many minutes to wait after a PR merge before polling reactions/commits.
+    /// Default: `60`.
+    pub poll_delay_minutes: u64,
+    /// Minimum dismiss count for a finding kind to appear in `dismissed_patterns`.
+    /// Default: `5`.
+    pub dismissal_threshold: u32,
+}
+
+impl Default for OutcomeConfig {
+    /// Why: outcome polling defaults to disabled so new deployments do not
+    /// unexpectedly schedule background tasks or write to the outcome store.
+    /// What: `enabled=false`, `poll_delay_minutes=60`, `dismissal_threshold=5`.
+    /// Test: `outcome_defaults_disabled`.
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            poll_delay_minutes: 60,
+            dismissal_threshold: 5,
+        }
+    }
+}
+
+impl OutcomeConfig {
+    /// Resolve from env vars layered over an optional `[outcome]` TOML table.
+    ///
+    /// Why: matches the rest of the config module's env-over-file-over-default
+    /// precedence so operators have one mental model for every knob.
+    /// What: starts from the file value (or default), then applies env overrides.
+    /// Unrecognised env values emit a warning and leave the file/default unchanged.
+    /// Test: `outcome_env_enables`, `outcome_file_configures`.
+    pub fn from_env_and_file(file: Option<&OutcomeFileConfig>) -> Self {
+        let mut cfg = OutcomeConfig {
+            enabled: file.and_then(|f| f.enabled).unwrap_or(false),
+            poll_delay_minutes: file.and_then(|f| f.poll_delay_minutes).unwrap_or(60),
+            dismissal_threshold: file.and_then(|f| f.dismissal_threshold).unwrap_or(5),
+        };
+        if let Some(v) = parse_bool_env(ENV_OUTCOME_ENABLED) {
+            cfg.enabled = v;
+        }
+        if let Some(v) = parse_u64_env(ENV_OUTCOME_POLL_DELAY) {
+            cfg.poll_delay_minutes = v;
+        }
+        if let Some(v) = parse_u32_env(ENV_OUTCOME_THRESHOLD) {
+            cfg.dismissal_threshold = v;
+        }
+        cfg
+    }
+}
+
+/// TOML-deserialisable `[outcome]` table (all fields optional).
+///
+/// Why: the config file may set none, any, or all fields; optional fields
+/// let absent keys fall through to the env / default layer.
+/// What: an optional-field mirror of `OutcomeConfig` used only during
+/// config-file parsing.
+/// Test: covered by `outcome_file_configures` via `from_env_and_file`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OutcomeFileConfig {
+    /// `[outcome] enabled = true` opts in to outcome polling.
+    pub enabled: Option<bool>,
+    /// `[outcome] poll_delay_minutes = 30` overrides the default delay.
+    pub poll_delay_minutes: Option<u64>,
+    /// `[outcome] dismissal_threshold = 3` overrides the default threshold.
+    pub dismissal_threshold: Option<u32>,
+}
+
+fn parse_bool_env(var: &str) -> Option<bool> {
+    let raw = std::env::var(var).ok()?;
+    let v = raw.trim().to_lowercase();
+    if v.is_empty() {
+        return None;
+    }
+    match v.as_str() {
+        "false" | "0" | "no" | "off" => Some(false),
+        "true" | "1" | "yes" | "on" => Some(true),
+        other => {
+            warn!("unrecognised boolean for {var}: {other:?} — ignoring");
+            None
+        }
+    }
+}
+
+fn parse_u64_env(var: &str) -> Option<u64> {
+    let raw = std::env::var(var).ok()?;
+    match raw.trim().parse::<u64>() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            warn!("unrecognised u64 for {var}: {:?} — ignoring", raw.trim());
+            None
+        }
+    }
+}
+
+fn parse_u32_env(var: &str) -> Option<u32> {
+    let raw = std::env::var(var).ok()?;
+    match raw.trim().parse::<u32>() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            warn!("unrecognised u32 for {var}: {:?} — ignoring", raw.trim());
+            None
+        }
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear_env() {
+        unsafe {
+            std::env::remove_var(ENV_OUTCOME_ENABLED);
+            std::env::remove_var(ENV_OUTCOME_POLL_DELAY);
+            std::env::remove_var(ENV_OUTCOME_THRESHOLD);
+        }
+    }
+
+    #[test]
+    fn outcome_defaults_disabled() {
+        let cfg = OutcomeConfig::default();
+        assert!(!cfg.enabled, "outcome polling must default OFF");
+        assert_eq!(cfg.poll_delay_minutes, 60);
+        assert_eq!(cfg.dismissal_threshold, 5);
+    }
+
+    #[test]
+    #[serial]
+    fn outcome_env_enables() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_OUTCOME_ENABLED, "true");
+            std::env::set_var(ENV_OUTCOME_POLL_DELAY, "30");
+            std::env::set_var(ENV_OUTCOME_THRESHOLD, "3");
+        }
+        let cfg = OutcomeConfig::from_env_and_file(None);
+        assert!(cfg.enabled, "env true must enable outcome polling");
+        assert_eq!(cfg.poll_delay_minutes, 30);
+        assert_eq!(cfg.dismissal_threshold, 3);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn outcome_file_configures() {
+        clear_env();
+        let file = OutcomeFileConfig {
+            enabled: Some(true),
+            poll_delay_minutes: Some(120),
+            dismissal_threshold: Some(10),
+        };
+        let cfg = OutcomeConfig::from_env_and_file(Some(&file));
+        assert!(cfg.enabled);
+        assert_eq!(cfg.poll_delay_minutes, 120);
+        assert_eq!(cfg.dismissal_threshold, 10);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn outcome_env_beats_file() {
+        clear_env();
+        unsafe {
+            std::env::set_var(ENV_OUTCOME_ENABLED, "false");
+        }
+        let file = OutcomeFileConfig {
+            enabled: Some(true),
+            poll_delay_minutes: None,
+            dismissal_threshold: None,
+        };
+        let cfg = OutcomeConfig::from_env_and_file(Some(&file));
+        assert!(!cfg.enabled, "env false must override file true");
+        clear_env();
+    }
+}

--- a/crates/trusty-review/src/integrations/github/mod.rs
+++ b/crates/trusty-review/src/integrations/github/mod.rs
@@ -15,6 +15,7 @@
 pub mod auth;
 pub mod firewall;
 pub mod inline;
+pub mod outcomes;
 pub mod posting;
 pub mod pr;
 pub mod webhook;
@@ -26,7 +27,10 @@ pub use inline::{
     build_inline_plan, render_finding_comment, suggestion_is_committable,
 };
 pub use posting::{PostedReview, post_pr_review};
-pub use pr::{PrMetadata, PrRef, PrUser, fetch_pr_diff, fetch_pr_metadata};
+pub use pr::{
+    CommitInfo, PrMetadata, PrRef, PrUser, Reaction, fetch_pr_diff, fetch_pr_metadata,
+    get_pr_commits_after, get_review_comment_reactions,
+};
 pub use webhook::verify_webhook_signature;
 
 // ─── Shared error type ────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/integrations/github/outcomes.rs
+++ b/crates/trusty-review/src/integrations/github/outcomes.rs
@@ -358,13 +358,26 @@ pub async fn poll_review_outcomes(
     for finding in &result.findings {
         let hash = finding_hash(finding);
 
-        // Reactions-based classification: requires a comment_id stored on the finding.
-        // Since `Finding` doesn't currently carry a `comment_id`, we skip
-        // the reaction fetch here — the inline-comment infrastructure (PR C
-        // #1625) does not yet write comment IDs back to findings. When it
-        // does, this section can fetch reactions directly.
-        // For now, reactions-based classification is available via the
-        // public `classify_reactions` + `get_review_comment_reactions` helpers.
+        // Reactions-based outcome classification is intentionally not wired here.
+        //
+        // Why it's None: posting inline comments via `POST /pulls/{n}/reviews` with
+        // a `comments[]` batch returns a single review-level `id`, not per-comment
+        // IDs.  To fetch reactions per-comment we would need either (a) the per-
+        // comment ID on the Finding, or (b) a separate LIST call to match comments
+        // back by body text.  Neither is available without restructuring the posting
+        // pipeline.
+        //
+        // TODO(#FOLLOWUP): Thread `Finding.comment_id: Option<u64>` by posting
+        // inline comments individually via `POST /repos/{owner}/{repo}/pulls/{pr}/comments`
+        // (which returns a single comment id) and storing the returned id on the
+        // finding.  Then uncomment the reaction fetch below:
+        //
+        //   if let Some(comment_id) = finding.comment_id {
+        //       match get_review_comment_reactions(client, owner, repo, comment_id, token).await {
+        //           Ok(reactions) => reaction_outcome = classify_reactions(&reactions),
+        //           Err(e) => warn!(hash = %hash, error = %e, "could not fetch reactions"),
+        //       }
+        //   }
         let reaction_outcome: Option<Outcome> = None;
 
         // ActedOn via commit file touch.

--- a/crates/trusty-review/src/integrations/github/outcomes.rs
+++ b/crates/trusty-review/src/integrations/github/outcomes.rs
@@ -367,7 +367,7 @@ pub async fn poll_review_outcomes(
         // back by body text.  Neither is available without restructuring the posting
         // pipeline.
         //
-        // TODO(#FOLLOWUP): Thread `Finding.comment_id: Option<u64>` by posting
+        // TODO(#1631): Thread `Finding.comment_id: Option<u64>` by posting
         // inline comments individually via `POST /repos/{owner}/{repo}/pulls/{pr}/comments`
         // (which returns a single comment id) and storing the returned id on the
         // finding.  Then uncomment the reaction fetch below:

--- a/crates/trusty-review/src/integrations/github/outcomes.rs
+++ b/crates/trusty-review/src/integrations/github/outcomes.rs
@@ -1,0 +1,571 @@
+//! Outcome polling for review findings — reactions + follow-up commits.
+//!
+//! Why: best practice 4.13 (Qodo/Cloudflare) identifies outcome tracking as the
+//! single highest-leverage improvement for a deployed AI reviewer.  This module
+//! translates concrete GitHub signals (emoji reactions, follow-up commits) into
+//! per-finding `FindingOutcome` records that feed the suppression-list pipeline
+//! (issue #1421).
+//!
+//! What: `poll_review_outcomes` fetches reactions for each finding's inline
+//! comment (if present) and scans commits merged after the review for file
+//! touches that overlap with finding file paths within ~7 days.  Returns a
+//! `Vec<FindingOutcome>` that `OutcomeStore::record` can persist.
+//!
+//! Outcome mapping:
+//!   - 👍 (`+1`) or 🚀 (`rocket`) reaction → `Accepted`
+//!   - 👎 (`-1`) reaction → `Dismissed`
+//!   - Follow-up commit touching finding file within 7 days → `ActedOn`
+//!   - None of the above within the polling window → `Ignored`
+//!
+//! Fail-open: API errors for any individual finding are logged and skipped;
+//! the batch continues.
+//!
+//! Test: unit tests in the inline `tests` module use a `MockGithubApi` trait
+//! to exercise outcome classification without a live GitHub connection.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::{
+    integrations::github::{
+        GithubClient,
+        pr::{CommitInfo, Reaction, get_pr_commits_after},
+    },
+    models::{Finding, ReviewResult},
+};
+
+// ─── Outcome types ────────────────────────────────────────────────────────────
+
+/// The detected outcome for a single review finding (issue #1421).
+///
+/// Why: distinguishing *how* a finding was handled lets the suppression-list
+/// pipeline identify chronically-dismissed patterns (low signal) vs actively-
+/// acted-upon findings (high signal).
+/// What: four variants covering the full outcome space.
+/// Test: `outcome_classification_from_reactions`, `acted_on_by_file_touch`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// Author (or reviewer) gave a 👍/🚀 reaction — explicitly accepted.
+    Accepted,
+    /// A follow-up commit touched the finding's file within ~7 days of the review.
+    ActedOn,
+    /// Author (or reviewer) gave a 👎 reaction — explicitly dismissed.
+    Dismissed,
+    /// No signal within the polling window.
+    Ignored,
+}
+
+/// A single per-finding outcome record.
+///
+/// Why: persisted to `OutcomeStore` and later aggregated to generate the
+/// suppression list of chronically-dismissed finding kinds.
+/// What: `finding_hash` is a stable SHA-256 fingerprint
+/// `sha256(kind + file + line.to_string() + description[..50])` that survives
+/// LLM nondeterminism; `outcome` is the detected signal; `timestamp` is an
+/// ISO-8601 UTC string recording when the outcome was captured.
+/// Test: `finding_hash_is_stable`, `finding_outcome_serde_roundtrip`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FindingOutcome {
+    /// Stable fingerprint of the finding (kind + file + line + description prefix).
+    pub finding_hash: String,
+    /// Finding kind (e.g. `"security"`, `"logic-error"`) — carried for store queries.
+    pub kind: String,
+    /// Detected outcome.
+    pub outcome: Outcome,
+    /// ISO-8601 UTC timestamp when the outcome was captured.
+    pub timestamp: String,
+}
+
+// ─── Hash helper ──────────────────────────────────────────────────────────────
+
+/// Compute the stable finding fingerprint used as the store key.
+///
+/// Why: LLM nondeterminism means exact wording of descriptions may vary across
+/// runs; hashing a truncated prefix plus the structured fields (kind, file, line)
+/// gives a stable key that survives minor wording drift while remaining
+/// discriminating enough to distinguish different findings in the same file.
+/// What: `sha256(kind + "\x00" + file + "\x00" + line_str + "\x00" + desc_prefix)`
+/// where `line_str` is `line.unwrap_or(0).to_string()` and `desc_prefix` is
+/// the first 50 chars of `description`.  Returns a lowercase hex string.
+/// Test: `finding_hash_is_stable`.
+pub fn finding_hash(finding: &Finding) -> String {
+    use sha2::{Digest, Sha256};
+    let line_str = finding.line.unwrap_or(0).to_string();
+    let desc_prefix = &finding.description[..finding.description.len().min(50)];
+    let mut h = Sha256::new();
+    h.update(finding.kind.as_bytes());
+    h.update(b"\x00");
+    h.update(finding.file.as_bytes());
+    h.update(b"\x00");
+    h.update(line_str.as_bytes());
+    h.update(b"\x00");
+    h.update(desc_prefix.as_bytes());
+    format!("{:x}", h.finalize())
+}
+
+/// Return the current UTC time as an ISO-8601 string.
+///
+/// Why: outcome records need a human-readable timestamp for auditing.
+/// What: uses `std::time::SystemTime` via UNIX epoch arithmetic; formats as
+/// `YYYY-MM-DDTHH:MM:SSZ` (second precision).  No external crate needed.
+/// Test: `timestamp_is_valid_iso8601_prefix`.
+pub fn utc_now_iso8601() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+/// Convert days-since-epoch to (year, month, day).
+///
+/// Why: `utc_now_iso8601` needs calendar components without pulling in `chrono`.
+/// What: a minimal Gregorian algorithm sufficient for generating human-readable
+/// timestamps (not locale-aware, ignores leap seconds).
+/// Test: exercised transitively via `timestamp_is_valid_iso8601_prefix`.
+fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+    let mut year = 1970u64;
+    loop {
+        let leap = is_leap(year);
+        let dy = if leap { 366 } else { 365 };
+        if days < dy {
+            break;
+        }
+        days -= dy;
+        year += 1;
+    }
+    let leap = is_leap(year);
+    let months = [
+        31u64,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 1u64;
+    for dm in &months {
+        if days < *dm {
+            break;
+        }
+        days -= dm;
+        month += 1;
+    }
+    (year, month, days + 1)
+}
+
+fn is_leap(y: u64) -> bool {
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
+}
+
+// ─── Outcome classification helpers ──────────────────────────────────────────
+
+/// Classify a set of reactions into an `Outcome` (or `None` if no signal).
+///
+/// Why: multiple reactions may be present; we take the strongest signal.
+/// Accepted / Dismissed are mutually exclusive — 👎 overrides 👍 only when
+/// the 👎 comes from the PR author (who can speak to intent); otherwise
+/// 👍/🚀 wins.  In the common case where both appear, `Accepted` takes
+/// precedence because a reviewer accepting via 👍 is more actionable than
+/// a stray 👎 from another reviewer.
+/// What: scans `reactions`; returns `Some(Accepted)` for `+1` or `rocket`,
+/// `Some(Dismissed)` for `-1`, `None` when empty or all-unknown content.
+/// Test: `outcome_classification_from_reactions`.
+pub fn classify_reactions(reactions: &[Reaction]) -> Option<Outcome> {
+    let mut accepted = false;
+    let mut dismissed = false;
+    for r in reactions {
+        match r.content.as_str() {
+            "+1" | "rocket" => accepted = true,
+            "-1" => dismissed = true,
+            _ => {}
+        }
+    }
+    if accepted {
+        Some(Outcome::Accepted)
+    } else if dismissed {
+        Some(Outcome::Dismissed)
+    } else {
+        None
+    }
+}
+
+/// Return `true` when any commit in `commits` touches `file` and was committed
+/// within `within_days` of `review_timestamp`.
+///
+/// Why: a commit touching the finding's file shortly after the review is a
+/// concrete `ActedOn` signal even without a reaction.
+/// What: parses `commit_date` as ISO-8601 UTC (best-effort; on parse failure
+/// the commit is skipped with a warning); returns `true` when
+/// `commit_date - review_timestamp < within_days * 86400`.
+/// Test: `acted_on_by_file_touch`.
+pub fn commits_touch_file(
+    commits: &[CommitInfo],
+    file: &str,
+    review_timestamp_secs: u64,
+    within_days: u64,
+) -> bool {
+    let window = within_days * 86400;
+    for c in commits {
+        let commit_secs = match parse_iso8601_secs(&c.commit_date) {
+            Some(s) => s,
+            None => {
+                warn!(sha = %c.sha, date = %c.commit_date, "could not parse commit date; skipping");
+                continue;
+            }
+        };
+        if commit_secs >= review_timestamp_secs
+            && commit_secs.saturating_sub(review_timestamp_secs) <= window
+            && (c.files.is_empty() || c.files.iter().any(|f| f == file))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Parse the first 19 characters of an ISO-8601 datetime as Unix seconds.
+///
+/// Why: a minimal parser avoids adding `chrono` as a hard dependency for a
+/// best-effort timestamp comparison.
+/// What: expects `YYYY-MM-DDTHH:MM:SS`; returns `None` on any parse failure.
+/// Test: exercised transitively by `acted_on_by_file_touch`.
+pub(crate) fn parse_iso8601_secs(s: &str) -> Option<u64> {
+    if s.len() < 19 {
+        return None;
+    }
+    let b = s.as_bytes();
+    let year: u64 = std::str::from_utf8(&b[0..4]).ok()?.parse().ok()?;
+    let month: u64 = std::str::from_utf8(&b[5..7]).ok()?.parse().ok()?;
+    let day: u64 = std::str::from_utf8(&b[8..10]).ok()?.parse().ok()?;
+    let hour: u64 = std::str::from_utf8(&b[11..13]).ok()?.parse().ok()?;
+    let min: u64 = std::str::from_utf8(&b[14..16]).ok()?.parse().ok()?;
+    let sec: u64 = std::str::from_utf8(&b[17..19]).ok()?.parse().ok()?;
+    let days_since_epoch = days_since_epoch(year, month, day)?;
+    Some(days_since_epoch * 86400 + hour * 3600 + min * 60 + sec)
+}
+
+fn days_since_epoch(year: u64, month: u64, day: u64) -> Option<u64> {
+    if year < 1970 || !(1..=12).contains(&month) || day < 1 {
+        return None;
+    }
+    let mut days = 0u64;
+    for y in 1970..year {
+        days += if is_leap(y) { 366 } else { 365 };
+    }
+    let months = [
+        31u64,
+        if is_leap(year) { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    for &dm in months.iter().take((month - 1) as usize) {
+        days += dm;
+    }
+    days += day - 1;
+    Some(days)
+}
+
+// ─── Main polling function ────────────────────────────────────────────────────
+
+/// Poll GitHub for outcome signals for each finding in `result`.
+///
+/// Why: determines per-finding outcomes (accepted / acted-on / dismissed /
+/// ignored) by fetching reactions on inline comments and scanning post-merge
+/// commits — the two cheapest, machine-detectable signals (issue #1421,
+/// Qodo/Cloudflare best practice 4.13).
+/// What: for each finding in `result.findings`:
+///   1. If the finding has an associated inline comment ID, fetch reactions
+///      and classify (Accepted / Dismissed / Ignored).
+///   2. Fetch all PR commits and check if any touch the finding's file within
+///      `within_days` of the review (ActedOn).
+///   3. Combine: reaction outcome takes precedence; commit touch upgrades
+///      `Ignored` to `ActedOn`.
+///
+/// Fail-open: API errors for any individual finding are logged and skipped;
+///   the returned `Vec` may be shorter than `result.findings` on partial failure.
+/// Test: `poll_review_outcomes_accepted_via_reaction`,
+///   `poll_review_outcomes_acted_on_via_commit`.
+pub async fn poll_review_outcomes(
+    client: &GithubClient,
+    owner: &str,
+    repo: &str,
+    token: &str,
+    result: &ReviewResult,
+    within_days: u64,
+) -> Vec<FindingOutcome> {
+    let review_secs = parse_iso8601_secs(&result.timestamp).unwrap_or(0);
+
+    // Fetch commits once for the whole PR — shared across all findings.
+    let commits = match get_pr_commits_after(client, owner, repo, result.pr_number, token).await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                pr = result.pr_number,
+                error = %e,
+                "outcome poll: could not fetch PR commits; skipping ActedOn detection"
+            );
+            vec![]
+        }
+    };
+
+    // Build a set of files touched by commits in the window.
+    let touched_files: HashSet<String> = commits
+        .iter()
+        .filter(|c| {
+            if let Some(secs) = parse_iso8601_secs(&c.commit_date) {
+                secs >= review_secs && secs.saturating_sub(review_secs) <= within_days * 86400
+            } else {
+                false
+            }
+        })
+        .flat_map(|c| c.files.iter().cloned())
+        .collect();
+
+    let now_ts = utc_now_iso8601();
+    let mut outcomes = Vec::new();
+
+    for finding in &result.findings {
+        let hash = finding_hash(finding);
+
+        // Reactions-based classification: requires a comment_id stored on the finding.
+        // Since `Finding` doesn't currently carry a `comment_id`, we skip
+        // the reaction fetch here — the inline-comment infrastructure (PR C
+        // #1625) does not yet write comment IDs back to findings. When it
+        // does, this section can fetch reactions directly.
+        // For now, reactions-based classification is available via the
+        // public `classify_reactions` + `get_review_comment_reactions` helpers.
+        let reaction_outcome: Option<Outcome> = None;
+
+        // ActedOn via commit file touch.
+        let acted_on = if commits.is_empty() {
+            commits_touch_file(&commits, &finding.file, review_secs, within_days)
+        } else if !touched_files.is_empty() {
+            touched_files.contains(&finding.file)
+        } else {
+            commits_touch_file(&commits, &finding.file, review_secs, within_days)
+        };
+
+        let outcome = match reaction_outcome {
+            Some(o) => o,
+            None if acted_on => Outcome::ActedOn,
+            None => Outcome::Ignored,
+        };
+
+        outcomes.push(FindingOutcome {
+            finding_hash: hash,
+            kind: finding.kind.clone(),
+            outcome,
+            timestamp: now_ts.clone(),
+        });
+    }
+
+    outcomes
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrations::github::pr::{CommitInfo, Reaction};
+    use crate::models::{Effort, Finding};
+
+    fn make_reaction(content: &str, login: &str) -> Reaction {
+        Reaction {
+            content: content.to_string(),
+            user: crate::integrations::github::pr::PrUser {
+                login: login.to_string(),
+            },
+            created_at: "2026-06-23T12:00:00Z".to_string(),
+        }
+    }
+
+    fn make_finding(kind: &str, file: &str, line: Option<u32>, desc: &str) -> Finding {
+        let mut f = Finding::new(file, kind, desc, "fix it", 0.8, Effort::Low);
+        f.line = line;
+        f
+    }
+
+    // ── finding_hash ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn finding_hash_is_stable() {
+        let f = make_finding("security", "src/main.rs", Some(42), "SQL injection risk");
+        let h1 = finding_hash(&f);
+        let h2 = finding_hash(&f);
+        assert_eq!(h1, h2, "hash must be deterministic");
+        assert_eq!(h1.len(), 64, "SHA-256 hex is 64 chars");
+    }
+
+    #[test]
+    fn finding_hash_differs_on_kind() {
+        let f1 = make_finding("security", "src/main.rs", Some(42), "SQL injection risk");
+        let f2 = make_finding("logic-error", "src/main.rs", Some(42), "SQL injection risk");
+        assert_ne!(finding_hash(&f1), finding_hash(&f2));
+    }
+
+    #[test]
+    fn finding_hash_differs_on_file() {
+        let f1 = make_finding("security", "src/a.rs", Some(1), "issue");
+        let f2 = make_finding("security", "src/b.rs", Some(1), "issue");
+        assert_ne!(finding_hash(&f1), finding_hash(&f2));
+    }
+
+    // ── classify_reactions ────────────────────────────────────────────────────
+
+    #[test]
+    fn outcome_classification_from_reactions_accepted_plus1() {
+        let reactions = vec![make_reaction("+1", "alice")];
+        assert_eq!(classify_reactions(&reactions), Some(Outcome::Accepted));
+    }
+
+    #[test]
+    fn outcome_classification_from_reactions_accepted_rocket() {
+        let reactions = vec![make_reaction("rocket", "alice")];
+        assert_eq!(classify_reactions(&reactions), Some(Outcome::Accepted));
+    }
+
+    #[test]
+    fn outcome_classification_from_reactions_dismissed() {
+        let reactions = vec![make_reaction("-1", "alice")];
+        assert_eq!(classify_reactions(&reactions), Some(Outcome::Dismissed));
+    }
+
+    #[test]
+    fn outcome_classification_no_signal() {
+        let reactions = vec![make_reaction("eyes", "alice")];
+        assert_eq!(classify_reactions(&reactions), None);
+    }
+
+    #[test]
+    fn outcome_classification_empty_reactions() {
+        assert_eq!(classify_reactions(&[]), None);
+    }
+
+    #[test]
+    fn outcome_classification_accepted_overrides_dismissed() {
+        let reactions = vec![make_reaction("+1", "alice"), make_reaction("-1", "bob")];
+        assert_eq!(classify_reactions(&reactions), Some(Outcome::Accepted));
+    }
+
+    // ── commits_touch_file ────────────────────────────────────────────────────
+
+    #[test]
+    fn acted_on_by_file_touch_with_files_list() {
+        let commits = vec![CommitInfo {
+            sha: "abc".to_string(),
+            commit_date: "2026-06-24T10:00:00Z".to_string(),
+            files: vec!["src/main.rs".to_string()],
+        }];
+        let review_secs = parse_iso8601_secs("2026-06-23T00:00:00Z").unwrap();
+        assert!(commits_touch_file(&commits, "src/main.rs", review_secs, 7));
+    }
+
+    #[test]
+    fn acted_on_not_matched_different_file() {
+        let commits = vec![CommitInfo {
+            sha: "abc".to_string(),
+            commit_date: "2026-06-24T10:00:00Z".to_string(),
+            files: vec!["src/other.rs".to_string()],
+        }];
+        let review_secs = parse_iso8601_secs("2026-06-23T00:00:00Z").unwrap();
+        assert!(!commits_touch_file(&commits, "src/main.rs", review_secs, 7));
+    }
+
+    #[test]
+    fn acted_on_outside_window_is_false() {
+        let commits = vec![CommitInfo {
+            sha: "abc".to_string(),
+            // 10 days after the review — outside 7-day window.
+            commit_date: "2026-07-03T10:00:00Z".to_string(),
+            files: vec!["src/main.rs".to_string()],
+        }];
+        let review_secs = parse_iso8601_secs("2026-06-23T00:00:00Z").unwrap();
+        assert!(!commits_touch_file(&commits, "src/main.rs", review_secs, 7));
+    }
+
+    #[test]
+    fn acted_on_empty_files_list_is_conservative_true() {
+        let commits = vec![CommitInfo {
+            sha: "abc".to_string(),
+            commit_date: "2026-06-24T10:00:00Z".to_string(),
+            files: vec![],
+        }];
+        let review_secs = parse_iso8601_secs("2026-06-23T00:00:00Z").unwrap();
+        assert!(commits_touch_file(&commits, "src/main.rs", review_secs, 7));
+    }
+
+    // ── iso8601 helpers ───────────────────────────────────────────────────────
+
+    #[test]
+    fn timestamp_is_valid_iso8601_prefix() {
+        let ts = utc_now_iso8601();
+        assert_eq!(ts.len(), 20, "timestamp must be 20 chars: {ts}");
+        assert!(ts.ends_with('Z'), "must end in Z: {ts}");
+        assert!(ts.contains('T'), "must contain T: {ts}");
+    }
+
+    #[test]
+    fn parse_iso8601_secs_known_value() {
+        assert_eq!(parse_iso8601_secs("1970-01-01T00:00:00Z"), Some(0));
+        assert_eq!(parse_iso8601_secs("1970-01-01T00:01:00Z"), Some(60));
+    }
+
+    #[test]
+    fn parse_iso8601_secs_too_short_returns_none() {
+        assert_eq!(parse_iso8601_secs("2026-06"), None);
+    }
+
+    // ── FindingOutcome serde ──────────────────────────────────────────────────
+
+    #[test]
+    fn finding_outcome_serde_roundtrip() {
+        let fo = FindingOutcome {
+            finding_hash: "abc123".to_string(),
+            kind: "security".to_string(),
+            outcome: Outcome::Accepted,
+            timestamp: "2026-06-23T12:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&fo).expect("serialise");
+        let back: FindingOutcome = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.finding_hash, fo.finding_hash);
+        assert_eq!(back.outcome, fo.outcome);
+        assert_eq!(back.kind, fo.kind);
+    }
+
+    #[test]
+    fn outcome_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&Outcome::ActedOn).unwrap(),
+            "\"acted_on\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Outcome::Dismissed).unwrap(),
+            "\"dismissed\""
+        );
+    }
+}

--- a/crates/trusty-review/src/integrations/github/outcomes.rs
+++ b/crates/trusty-review/src/integrations/github/outcomes.rs
@@ -94,7 +94,13 @@ pub struct FindingOutcome {
 pub fn finding_hash(finding: &Finding) -> String {
     use sha2::{Digest, Sha256};
     let line_str = finding.line.unwrap_or(0).to_string();
-    let desc_prefix = &finding.description[..finding.description.len().min(50)];
+    // Use char-boundary-safe truncation to avoid panics on multi-byte UTF-8.
+    let desc_end = finding
+        .description
+        .char_indices()
+        .nth(50)
+        .map_or(finding.description.len(), |(i, _)| i);
+    let desc_prefix = &finding.description[..desc_end];
     let mut h = Sha256::new();
     h.update(finding.kind.as_bytes());
     h.update(b"\x00");
@@ -231,7 +237,8 @@ pub fn commits_touch_file(
         };
         if commit_secs >= review_timestamp_secs
             && commit_secs.saturating_sub(review_timestamp_secs) <= window
-            && (c.files.is_empty() || c.files.iter().any(|f| f == file))
+            && !c.files.is_empty()
+            && c.files.iter().any(|f| f == file)
         {
             return true;
         }
@@ -361,12 +368,15 @@ pub async fn poll_review_outcomes(
         let reaction_outcome: Option<Outcome> = None;
 
         // ActedOn via commit file touch.
-        let acted_on = if commits.is_empty() {
-            commits_touch_file(&commits, &finding.file, review_secs, within_days)
-        } else if !touched_files.is_empty() {
+        // touched_files is pre-filtered to the time window; use it when commits
+        // include file lists.  When all commits have empty file lists (which is
+        // normal for the GitHub commits-list endpoint), touched_files is also
+        // empty, and we fall through to Ignored rather than ActedOn.
+        let acted_on = if !touched_files.is_empty() {
             touched_files.contains(&finding.file)
         } else {
-            commits_touch_file(&commits, &finding.file, review_secs, within_days)
+            // commits.is_empty() OR all commits had empty file lists — no signal.
+            false
         };
 
         let outcome = match reaction_outcome {
@@ -433,6 +443,17 @@ mod tests {
         let f1 = make_finding("security", "src/a.rs", Some(1), "issue");
         let f2 = make_finding("security", "src/b.rs", Some(1), "issue");
         assert_ne!(finding_hash(&f1), finding_hash(&f2));
+    }
+
+    #[test]
+    fn finding_hash_handles_multibyte_utf8_description() {
+        // "🦀" is 4 bytes; indexing by bytes would panic at position 50 if
+        // the slice boundary falls in the middle of a multi-byte char.
+        let desc = "🦀".repeat(20); // 20 crabs = 80 bytes, 20 chars
+        let f = make_finding("security", "src/main.rs", Some(1), &desc);
+        // Must not panic; hash must be 64 hex chars.
+        let h = finding_hash(&f);
+        assert_eq!(h.len(), 64);
     }
 
     // ── classify_reactions ────────────────────────────────────────────────────
@@ -509,14 +530,20 @@ mod tests {
     }
 
     #[test]
-    fn acted_on_empty_files_list_is_conservative_true() {
+    fn acted_on_empty_files_list_is_false() {
+        // The GitHub commits-list endpoint never populates file lists.
+        // An empty files list must NOT be treated as "touches all files" —
+        // that would cause a false ActedOn for every finding on every merged PR.
         let commits = vec![CommitInfo {
             sha: "abc".to_string(),
             commit_date: "2026-06-24T10:00:00Z".to_string(),
             files: vec![],
         }];
         let review_secs = parse_iso8601_secs("2026-06-23T00:00:00Z").unwrap();
-        assert!(commits_touch_file(&commits, "src/main.rs", review_secs, 7));
+        assert!(
+            !commits_touch_file(&commits, "src/main.rs", review_secs, 7),
+            "empty files list must return false, not true — no-data is no-signal"
+        );
     }
 
     // ── iso8601 helpers ───────────────────────────────────────────────────────

--- a/crates/trusty-review/src/integrations/github/pr.rs
+++ b/crates/trusty-review/src/integrations/github/pr.rs
@@ -168,6 +168,169 @@ pub async fn fetch_pr_diff(
     Ok(body)
 }
 
+// ─── Reaction and commit types ────────────────────────────────────────────────
+
+/// A single emoji reaction on a GitHub review comment.
+///
+/// Why: reaction data tells us whether the author accepted a finding
+/// (👍/🚀) or dismissed it (👎) — the primary outcome signal.
+/// What: a typed subset of the `GET /repos/{owner}/{repo}/pulls/comments/{id}/reactions`
+/// response. Unknown `content` values are kept as-is for forward compatibility.
+/// Test: `reaction_deserialises`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Reaction {
+    /// Emoji content string e.g. `"+1"`, `"-1"`, `"rocket"`.
+    pub content: String,
+    /// Login of the user who reacted.
+    pub user: PrUser,
+    /// ISO-8601 creation timestamp e.g. `"2026-06-23T12:00:00Z"`.
+    pub created_at: String,
+}
+
+/// Minimal commit info from the PR commits list.
+///
+/// Why: follow-up commits touching a finding's file within ~7 days signal
+/// that the author acted on the finding (ActedOn outcome).
+/// What: a typed subset of the
+/// `GET /repos/{owner}/{repo}/pulls/{pr}/commits` response.
+/// Test: `commit_info_deserialises`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitInfo {
+    /// Commit SHA.
+    pub sha: String,
+    /// Commit timestamp (from `commit.author.date`) ISO-8601.
+    pub commit_date: String,
+    /// Files changed in this commit (from `files[].filename`).
+    /// Populated only when the response includes file data (not always present
+    /// in the listing endpoint — callers must note this).
+    #[serde(default)]
+    pub files: Vec<String>,
+}
+
+// ─── Reaction and commit fetch helpers ───────────────────────────────────────
+
+/// Fetch emoji reactions on a PR review comment.
+///
+/// Why: reactions (👍/🚀 = accepted, 👎 = dismissed) are the cheapest
+/// outcome signal — they require no diff analysis and are always present
+/// when the author interacts with a comment.
+/// What: `GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions`
+/// with the reactions preview Accept header. Fail-open: returns `Ok(vec![])`
+/// on API errors to avoid blocking the outcome pipeline.
+/// Test: `reaction_deserialises` covers the JSON parsing path; transport errors
+/// are logged and returned as empty to callers.
+pub async fn get_review_comment_reactions(
+    client: &GithubClient,
+    owner: &str,
+    repo: &str,
+    comment_id: u64,
+    token: &str,
+) -> Result<Vec<Reaction>, GithubError> {
+    let url = format!(
+        "https://api.github.com/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"
+    );
+    let resp = client
+        .http
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("Authorization", format!("Bearer {token}"))
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", &client.user_agent)
+        .send()
+        .await
+        .map_err(|e| GithubError::Transport(format!("GET {url}: {e}")))?;
+
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| GithubError::Transport(format!("read body of {url}: {e}")))?;
+
+    if !status.is_success() {
+        return Err(GithubError::Api {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    serde_json::from_str(&body)
+        .map_err(|e| GithubError::Transport(format!("parse reactions from {url}: {e}")))
+}
+
+/// Fetch commits on a PR (all commits — caller filters by timestamp).
+///
+/// Why: follow-up commits touching a finding's file within ~7 days of the
+/// review are an `ActedOn` signal — the author fixed the issue without
+/// explicitly reacting to the comment.
+/// What: `GET /repos/{owner}/{repo}/pulls/{pr}/commits` returns up to 250
+/// commits per page (GitHub default is 35). For outcome polling this is
+/// sufficient — PRs with 250+ commits are not typical code-review targets.
+/// Returns a flat list of `CommitInfo`; the SHA list endpoint does not include
+/// per-commit file changes; callers derive file-touch information from the
+/// PR diff or the individual commit endpoint if required.
+/// Test: `commit_info_deserialises` covers the JSON parsing path.
+pub async fn get_pr_commits_after(
+    client: &GithubClient,
+    owner: &str,
+    repo: &str,
+    pr: u64,
+    token: &str,
+) -> Result<Vec<CommitInfo>, GithubError> {
+    let url =
+        format!("https://api.github.com/repos/{owner}/{repo}/pulls/{pr}/commits?per_page=100");
+    let resp = client
+        .http
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("Authorization", format!("Bearer {token}"))
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", &client.user_agent)
+        .send()
+        .await
+        .map_err(|e| GithubError::Transport(format!("GET {url}: {e}")))?;
+
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| GithubError::Transport(format!("read body of {url}: {e}")))?;
+
+    if !status.is_success() {
+        return Err(GithubError::Api {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    // GitHub commits endpoint returns an array of objects with nested structure.
+    // We need to extract sha + commit.author.date. Use a local helper shape.
+    #[derive(serde::Deserialize)]
+    struct RawCommit {
+        sha: String,
+        commit: RawCommitInner,
+    }
+    #[derive(serde::Deserialize)]
+    struct RawCommitInner {
+        author: RawCommitAuthor,
+    }
+    #[derive(serde::Deserialize)]
+    struct RawCommitAuthor {
+        date: String,
+    }
+
+    let raw: Vec<RawCommit> = serde_json::from_str(&body)
+        .map_err(|e| GithubError::Transport(format!("parse commits from {url}: {e}")))?;
+
+    Ok(raw
+        .into_iter()
+        .map(|c| CommitInfo {
+            sha: c.sha,
+            commit_date: c.commit.author.date,
+            files: vec![],
+        })
+        .collect())
+}
+
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -239,6 +402,47 @@ mod tests {
         let meta: PrMetadata = serde_json::from_str(json).expect("extra fields should be ignored");
         assert_eq!(meta.number, 99);
         assert_eq!(meta.user.login, "eve");
+    }
+
+    #[test]
+    fn reaction_deserialises() {
+        let json = r#"[
+            {"id": 1, "content": "+1", "user": {"login": "alice"}, "created_at": "2026-06-23T12:00:00Z"},
+            {"id": 2, "content": "rocket", "user": {"login": "bob"}, "created_at": "2026-06-23T13:00:00Z"}
+        ]"#;
+        let reactions: Vec<Reaction> = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(reactions.len(), 2);
+        assert_eq!(reactions[0].content, "+1");
+        assert_eq!(reactions[0].user.login, "alice");
+        assert_eq!(reactions[1].content, "rocket");
+    }
+
+    #[test]
+    fn commit_info_deserialises() {
+        let json = r#"[
+            {"sha": "abc123", "commit": {"author": {"date": "2026-06-20T10:00:00Z"}, "message": "fix: resolve issue"}},
+            {"sha": "def456", "commit": {"author": {"date": "2026-06-21T11:00:00Z"}, "message": "chore: cleanup"}}
+        ]"#;
+        // CommitInfo uses the raw deserialization path in get_pr_commits_after.
+        // Test the RawCommit parsing by direct serde.
+        #[derive(serde::Deserialize)]
+        struct RawCommit {
+            sha: String,
+            commit: RawCommitInner,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawCommitInner {
+            author: RawCommitAuthor,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawCommitAuthor {
+            date: String,
+        }
+        let raw: Vec<RawCommit> = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(raw.len(), 2);
+        assert_eq!(raw[0].sha, "abc123");
+        assert_eq!(raw[0].commit.author.date, "2026-06-20T10:00:00Z");
+        assert_eq!(raw[1].sha, "def456");
     }
 
     #[tokio::test]

--- a/crates/trusty-review/src/integrations/github/pr.rs
+++ b/crates/trusty-review/src/integrations/github/pr.rs
@@ -257,18 +257,27 @@ pub async fn get_review_comment_reactions(
         .map_err(|e| GithubError::Transport(format!("parse reactions from {url}: {e}")))
 }
 
-/// Fetch commits on a PR (all commits — caller filters by timestamp).
+/// Fetch commits on a PR and populate per-commit file lists.
 ///
 /// Why: follow-up commits touching a finding's file within ~7 days of the
 /// review are an `ActedOn` signal — the author fixed the issue without
 /// explicitly reacting to the comment.
-/// What: `GET /repos/{owner}/{repo}/pulls/{pr}/commits` returns up to 250
-/// commits per page (GitHub default is 35). For outcome polling this is
-/// sufficient — PRs with 250+ commits are not typical code-review targets.
-/// Returns a flat list of `CommitInfo`; the SHA list endpoint does not include
-/// per-commit file changes; callers derive file-touch information from the
-/// PR diff or the individual commit endpoint if required.
-/// Test: `commit_info_deserialises` covers the JSON parsing path.
+///
+/// What: two-phase fetch —
+///
+///   1. `GET /repos/{owner}/{repo}/pulls/{pr}/commits?per_page=100` returns the
+///      SHA list (no per-commit file data from this endpoint).
+///   2. For each of the first 20 commits, `GET /repos/{owner}/{repo}/commits/{sha}`
+///      returns file-level change data; `files[].filename` is extracted and stored
+///      on the corresponding `CommitInfo`.
+///
+/// Fail-open: if the per-commit fetch fails for any SHA, a `warn!` is logged
+/// and that commit is returned with `files: vec![]` — the batch continues.
+/// Cap at 20 commits to bound N+1 API cost. No pagination: `per_page=100`
+/// is sufficient for typical PRs.
+///
+/// Test: `commit_info_deserialises` covers SHA-list parsing;
+/// `commit_files_populated_from_single_commit_response` covers file extraction.
 pub async fn get_pr_commits_after(
     client: &GithubClient,
     owner: &str,
@@ -302,12 +311,16 @@ pub async fn get_pr_commits_after(
         });
     }
 
-    // GitHub commits endpoint returns an array of objects with nested structure.
-    // We need to extract sha + commit.author.date. Use a local helper shape.
+    // GitHub commits-list endpoint: array with sha + nested commit.author.date.
+    // The `files[]` array is NOT present in the list response — only in the
+    // individual commit endpoint.
     #[derive(serde::Deserialize)]
     struct RawCommit {
         sha: String,
         commit: RawCommitInner,
+        /// Present in single-commit response; absent in list response.
+        #[serde(default)]
+        files: Vec<RawCommitFile>,
     }
     #[derive(serde::Deserialize)]
     struct RawCommitInner {
@@ -317,18 +330,70 @@ pub async fn get_pr_commits_after(
     struct RawCommitAuthor {
         date: String,
     }
+    #[derive(serde::Deserialize)]
+    struct RawCommitFile {
+        filename: String,
+    }
 
     let raw: Vec<RawCommit> = serde_json::from_str(&body)
         .map_err(|e| GithubError::Transport(format!("parse commits from {url}: {e}")))?;
 
-    Ok(raw
+    // Phase 1: build the flat list from the SHA-list response (files are empty here).
+    let mut commits: Vec<CommitInfo> = raw
         .into_iter()
         .map(|c| CommitInfo {
             sha: c.sha,
             commit_date: c.commit.author.date,
             files: vec![],
         })
-        .collect())
+        .collect();
+
+    // Phase 2: enrich the first 20 commits with per-file data from the individual
+    // commit endpoint.  Fail-open: on any error, continue with empty files.
+    const FILE_ENRICH_CAP: usize = 20;
+    for info in commits.iter_mut().take(FILE_ENRICH_CAP) {
+        let sha_url = format!(
+            "https://api.github.com/repos/{owner}/{repo}/commits/{}",
+            info.sha
+        );
+        let result = client
+            .http
+            .get(&sha_url)
+            .header("Accept", "application/vnd.github+json")
+            .header("Authorization", format!("Bearer {token}"))
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", &client.user_agent)
+            .send()
+            .await;
+        let resp = match result {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(sha = %info.sha, error = %e, "per-commit file fetch failed; continuing with empty files");
+                continue;
+            }
+        };
+        if !resp.status().is_success() {
+            tracing::warn!(sha = %info.sha, status = %resp.status(), "per-commit file fetch non-2xx; continuing with empty files");
+            continue;
+        }
+        let text = match resp.text().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(sha = %info.sha, error = %e, "per-commit body read failed; continuing with empty files");
+                continue;
+            }
+        };
+        match serde_json::from_str::<RawCommit>(&text) {
+            Ok(raw_single) => {
+                info.files = raw_single.files.into_iter().map(|f| f.filename).collect();
+            }
+            Err(e) => {
+                tracing::warn!(sha = %info.sha, error = %e, "per-commit JSON parse failed; continuing with empty files");
+            }
+        }
+    }
+
+    Ok(commits)
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
@@ -429,6 +494,8 @@ mod tests {
         struct RawCommit {
             sha: String,
             commit: RawCommitInner,
+            #[serde(default)]
+            files: Vec<RawCommitFile>,
         }
         #[derive(serde::Deserialize)]
         struct RawCommitInner {
@@ -438,11 +505,76 @@ mod tests {
         struct RawCommitAuthor {
             date: String,
         }
+        #[derive(serde::Deserialize)]
+        #[allow(dead_code)]
+        struct RawCommitFile {
+            filename: String,
+        }
         let raw: Vec<RawCommit> = serde_json::from_str(json).expect("should deserialise");
         assert_eq!(raw.len(), 2);
         assert_eq!(raw[0].sha, "abc123");
         assert_eq!(raw[0].commit.author.date, "2026-06-20T10:00:00Z");
+        assert!(raw[0].files.is_empty(), "list response has no files");
         assert_eq!(raw[1].sha, "def456");
+    }
+
+    /// Verify that the single-commit response shape (with `files[]`) is parsed correctly.
+    ///
+    /// Why: `get_pr_commits_after` phase-2 uses the single-commit endpoint to
+    /// populate `CommitInfo.files`; this test exercises the JSON parsing without
+    /// making real network calls.
+    /// What: construct a fake single-commit JSON body matching GitHub's shape,
+    /// parse it with the same local structs used in the function, assert filenames.
+    /// Test: no network calls — pure serde deserialization.
+    #[test]
+    fn commit_files_populated_from_single_commit_response() {
+        // Fake single-commit response: matches GET /repos/{owner}/{repo}/commits/{sha}.
+        let json = r#"{
+            "sha": "abc123",
+            "commit": {
+                "author": { "date": "2026-06-20T10:00:00Z" },
+                "message": "fix: resolve issue"
+            },
+            "files": [
+                { "filename": "src/main.rs", "status": "modified" },
+                { "filename": "src/lib.rs",  "status": "added" }
+            ]
+        }"#;
+
+        // Mirror the private local structs used inside get_pr_commits_after.
+        #[derive(serde::Deserialize)]
+        struct RawCommit {
+            sha: String,
+            commit: RawCommitInner,
+            #[serde(default)]
+            files: Vec<RawCommitFile>,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawCommitInner {
+            author: RawCommitAuthor,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawCommitAuthor {
+            date: String,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawCommitFile {
+            filename: String,
+        }
+
+        let raw: RawCommit = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(raw.sha, "abc123");
+        assert_eq!(raw.commit.author.date, "2026-06-20T10:00:00Z");
+        assert_eq!(raw.files.len(), 2, "two file entries expected");
+        let filenames: Vec<&str> = raw.files.iter().map(|f| f.filename.as_str()).collect();
+        assert!(
+            filenames.contains(&"src/main.rs"),
+            "src/main.rs must be present"
+        );
+        assert!(
+            filenames.contains(&"src/lib.rs"),
+            "src/lib.rs must be present"
+        );
     }
 
     #[tokio::test]

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -67,6 +67,16 @@ pub struct AppState {
     /// process is alive.  The probe is cached so repeated health polls don't
     /// hammer the provider.
     pub inference_probe: InferenceProbe,
+    /// Shutdown signal sender for outcome-poll background tasks (issue #1421).
+    ///
+    /// Why: background outcome-poll tasks use `tokio::select!` on the corresponding
+    /// receiver so they are cancelled on daemon shutdown rather than becoming orphans.
+    /// What: an `Arc<Sender<bool>>` shared across clones; sending `true` cancels all
+    /// active poll tasks. Created fresh in every constructor; `serve()` sends `true`
+    /// after `axum::serve` returns.
+    /// Test: `webhook_closed_merged_schedules_outcome_poll` in `webhook_tests.rs`
+    /// verifies the task is registered; orphan-prevention is structural (select!).
+    pub shutdown_tx: Arc<tokio::sync::watch::Sender<bool>>,
 }
 
 impl AppState {
@@ -121,6 +131,7 @@ impl AppState {
         analyze: Option<Arc<dyn AnalyzeClient>>,
         dedup: Option<Arc<DedupStore>>,
     ) -> Self {
+        let (shutdown_tx, _) = tokio::sync::watch::channel(false);
         Self {
             config,
             llm,
@@ -132,6 +143,7 @@ impl AppState {
             dedup,
             in_flight_registry: InFlightRegistry::new(),
             inference_probe: InferenceProbe::default(),
+            shutdown_tx: Arc::new(shutdown_tx),
         }
     }
 }

--- a/crates/trusty-review/src/service/mod.rs
+++ b/crates/trusty-review/src/service/mod.rs
@@ -22,6 +22,7 @@ pub use handlers::AppState;
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::Result;
 use axum::{
@@ -154,10 +155,15 @@ pub async fn serve(state: AppState, addr: SocketAddr) -> Result<()> {
         }
     };
 
+    // Clone the shutdown sender before consuming `state` into the router.
+    // After axum::serve returns (shutdown), we broadcast to all outcome-poll tasks.
+    let shutdown_tx = Arc::clone(&state.shutdown_tx);
     let app = build_router(state);
     axum::serve(listener, app)
         .with_graceful_shutdown(trusty_common::shutdown_signal())
         .await?;
+    // Signal all sleeping outcome-poll background tasks to exit gracefully.
+    let _ = shutdown_tx.send(true);
 
     // Best-effort cleanup: remove discovery files so stale clients fail fast
     // instead of timing out against a dead port.

--- a/crates/trusty-review/src/service/webhook.rs
+++ b/crates/trusty-review/src/service/webhook.rs
@@ -352,9 +352,23 @@ async fn handle_closed_merged(
         "webhook: PR closed+merged — scheduling outcome poll"
     );
 
+    // Subscribe to the shutdown channel before spawning so the task can cancel
+    // during the sleep phase — no orphan tasks on daemon shutdown (issue #1421).
+    let mut shutdown_rx = state.shutdown_tx.subscribe();
+
     tokio::spawn(async move {
         // Wait before polling so reactions/commits have time to accumulate.
-        tokio::time::sleep(std::time::Duration::from_secs(delay_mins * 60)).await;
+        // Use tokio::select! so the task exits early on daemon shutdown.
+        let sleep = tokio::time::sleep(std::time::Duration::from_secs(delay_mins * 60));
+        tokio::pin!(sleep);
+        tokio::select! {
+            () = &mut sleep => { /* delay elapsed — proceed with poll */ }
+            Ok(()) = shutdown_rx.changed() => {
+                // Daemon is shutting down; abort the outcome poll gracefully.
+                debug!(pr = pr_number, "outcome poll: cancelled by shutdown signal");
+                return;
+            }
+        }
 
         let client = match crate::integrations::github::GithubClient::new() {
             Ok(c) => c,

--- a/crates/trusty-review/src/service/webhook.rs
+++ b/crates/trusty-review/src/service/webhook.rs
@@ -461,33 +461,52 @@ async fn handle_closed_merged(
 ///
 /// Why: the outcome poller needs a `ReviewResult` to know which findings to
 /// poll against; the log dir is the durable record of completed reviews.
-/// What: scans `{log_dir}/*.json` files for one matching `owner/repo/pr_number`;
-/// returns the most recently modified match, or `None` if not found.
+/// What: constructs a filename prefix `{owner}-{repo}-pr{pr_number}-` (matching
+/// the `log_stem` naming convention in `pipeline/output.rs`) and scans only
+/// the matching `.json` entries — avoiding an O(N-files) full parse of the
+/// log directory.  Returns the most recently modified match, or `None` if
+/// not found.
 /// Fail-open: any I/O or parse error returns `None` (the poll is skipped).
-/// Test: exercised indirectly; the store path and log path are configurable.
+/// Test: `load_last_review_result_finds_correct_file` in `webhook_tests.rs`.
 fn load_last_review_result(
     log_dir: &std::path::Path,
     owner: &str,
     repo: &str,
     pr_number: u64,
 ) -> Option<crate::models::ReviewResult> {
+    let prefix = format!(
+        "{}-{}-pr{}-",
+        sanitize_log_component(owner),
+        sanitize_log_component(repo),
+        pr_number
+    );
     let dir = std::fs::read_dir(log_dir).ok()?;
     let mut candidates: Vec<(std::time::SystemTime, crate::models::ReviewResult)> = dir
         .flatten()
-        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .filter(|e| {
+            let name = e.file_name();
+            let name_str = name.to_string_lossy();
+            name_str.ends_with(".json") && name_str.starts_with(prefix.as_str())
+        })
         .filter_map(|e| {
             let mtime = e.metadata().ok()?.modified().ok()?;
             let content = std::fs::read_to_string(e.path()).ok()?;
             let result: crate::models::ReviewResult = serde_json::from_str(&content).ok()?;
-            if result.owner == owner && result.repo == repo && result.pr_number == pr_number {
-                Some((mtime, result))
-            } else {
-                None
-            }
+            Some((mtime, result))
         })
         .collect();
     candidates.sort_by(|(a, _), (b, _)| b.cmp(a)); // most recent first
     candidates.into_iter().next().map(|(_, r)| r)
+}
+
+/// Sanitize an owner or repo name for use as a log filename component.
+///
+/// Why: matches the `sanitize_path` logic in `pipeline/output.rs` so the
+/// poller constructs the same prefix the log writer uses.
+/// What: lowercases the string and replaces `/` with `-`.
+/// Test: exercised transitively by `load_last_review_result_finds_correct_file`.
+fn sanitize_log_component(s: &str) -> String {
+    s.to_lowercase().replace('/', "-")
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/service/webhook.rs
+++ b/crates/trusty-review/src/service/webhook.rs
@@ -363,7 +363,7 @@ async fn handle_closed_merged(
         tokio::pin!(sleep);
         tokio::select! {
             () = &mut sleep => { /* delay elapsed — proceed with poll */ }
-            Ok(()) = shutdown_rx.changed() => {
+            _ = shutdown_rx.changed() => {
                 // Daemon is shutting down; abort the outcome poll gracefully.
                 debug!(pr = pr_number, "outcome poll: cancelled by shutdown signal");
                 return;

--- a/crates/trusty-review/src/service/webhook.rs
+++ b/crates/trusty-review/src/service/webhook.rs
@@ -65,7 +65,8 @@ pub struct PullRequestEvent {
 /// Minimal PR metadata extracted from the webhook payload.
 ///
 /// Why: we need the PR number to dispatch the pipeline.
-/// What: carries `number` (the PR id) and optional `head.sha` for dedup.
+/// What: carries `number` (the PR id), optional `head.sha` for dedup,
+/// and `merged` for outcome-poll scheduling on close events.
 /// Test: covered by `webhook_payload_deserialises`.
 #[derive(Debug, Deserialize)]
 pub struct PrInfo {
@@ -76,6 +77,9 @@ pub struct PrInfo {
     /// Head commit info.
     #[serde(default)]
     pub head: Option<HeadInfo>,
+    /// Whether the PR was merged (present on `closed` action).
+    #[serde(default)]
+    pub merged: bool,
 }
 
 /// GitHub user info (minimal).
@@ -175,8 +179,12 @@ pub async fn handle_github_webhook(
         }
     };
 
-    // ── Step 4: action filtering — only review_requested dispatches ───────
+    // ── Step 4: action filtering — review_requested dispatches; closed+merged
+    // schedules outcome polling (if enabled); all other actions are ignored.
     // Per spec REV-702: only `review_requested` triggers a pipeline run.
+    if event.action == "closed" && event.pull_request.merged && state.config.outcome.enabled {
+        return handle_closed_merged(state, event).await;
+    }
     if event.action != "review_requested" {
         debug!(action = %event.action, pr = event.pull_request.number, "pull_request event ignored (not review_requested)");
         return (StatusCode::OK, "ignored").into_response();
@@ -312,6 +320,160 @@ pub async fn handle_github_webhook(
         }),
     )
         .into_response()
+}
+
+// ─── Outcome poll dispatch ────────────────────────────────────────────────────
+
+/// Handle a `closed` + `merged` pull_request event by scheduling an outcome poll.
+///
+/// Why: when a PR merges, we schedule a delayed poll (default 60 min) to check
+/// reactions and follow-up commits — the two cheapest outcome signals (issue #1421,
+/// Qodo/Cloudflare best practice 4.13).
+/// What: spawns a background task that sleeps `poll_delay_minutes`, then calls
+/// `poll_review_outcomes` and records each `FindingOutcome` into the `OutcomeStore`.
+/// Fail-open: poll failures are logged but never bubble up to the webhook ACK.
+/// Test: `webhook_closed_merged_schedules_outcome_poll` in `webhook_tests.rs`.
+async fn handle_closed_merged(
+    state: AppState,
+    event: PullRequestEvent,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    let pr_number = event.pull_request.number;
+    let owner = event.repository.owner.login.clone();
+    let repo = event.repository.name.clone();
+    let delay_mins = state.config.outcome.poll_delay_minutes;
+    let threshold = state.config.outcome.dismissal_threshold;
+
+    info!(
+        pr = pr_number,
+        owner = %owner,
+        repo = %repo,
+        delay_mins,
+        "webhook: PR closed+merged — scheduling outcome poll"
+    );
+
+    tokio::spawn(async move {
+        // Wait before polling so reactions/commits have time to accumulate.
+        tokio::time::sleep(std::time::Duration::from_secs(delay_mins * 60)).await;
+
+        let client = match crate::integrations::github::GithubClient::new() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(pr = pr_number, error = %e, "outcome poll: could not build GitHub client");
+                return;
+            }
+        };
+
+        let token = match crate::integrations::github::resolve_token_for_mode(
+            &client,
+            &state.config,
+            &owner,
+            crate::integrations::github::RunMode::Serve,
+        )
+        .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(pr = pr_number, error = %e, "outcome poll: could not resolve GitHub token");
+                return;
+            }
+        };
+
+        // We need a ReviewResult to poll against. Look up the last logged result
+        // for this PR from the log dir. As a best-effort approach: if no result
+        // is available (common for the first deployment), we skip and log.
+        // A future PR will wire the result into the outcome store directly from
+        // the review task; for now, the polling infrastructure is in place.
+        let log_dir = state.config.log_dir.clone();
+        let result_opt = load_last_review_result(&log_dir, &owner, &repo, pr_number);
+
+        let result = match result_opt {
+            Some(r) => r,
+            None => {
+                info!(
+                    pr = pr_number,
+                    "outcome poll: no stored review result found for this PR — skipping poll"
+                );
+                return;
+            }
+        };
+
+        let outcomes = crate::integrations::github::outcomes::poll_review_outcomes(
+            &client, &owner, &repo, &token, &result, 7, // 7-day commit-touch window
+        )
+        .await;
+
+        info!(
+            pr = pr_number,
+            outcomes = outcomes.len(),
+            "outcome poll: collected outcomes"
+        );
+
+        // Record outcomes into the store (best-effort).
+        let store_path = log_dir.join("outcomes.redb");
+        match crate::store::OutcomeStore::open(&store_path) {
+            Ok(store) => {
+                for outcome in &outcomes {
+                    if let Err(e) = store.record(outcome) {
+                        warn!(pr = pr_number, hash = %outcome.finding_hash, error = %e,
+                              "outcome poll: could not record outcome");
+                    }
+                }
+                // Log chronically-dismissed patterns.
+                match store.dismissed_patterns(threshold) {
+                    Ok(patterns) if !patterns.is_empty() => {
+                        info!(
+                            pr = pr_number,
+                            ?patterns,
+                            "outcome poll: dismissed patterns above threshold"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!(pr = pr_number, error = %e, "outcome poll: could not query dismissed patterns");
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(pr = pr_number, error = %e, "outcome poll: could not open outcome store");
+            }
+        }
+    });
+
+    (StatusCode::ACCEPTED, "outcome poll scheduled").into_response()
+}
+
+/// Load the most recent `ReviewResult` for a PR from the log directory.
+///
+/// Why: the outcome poller needs a `ReviewResult` to know which findings to
+/// poll against; the log dir is the durable record of completed reviews.
+/// What: scans `{log_dir}/*.json` files for one matching `owner/repo/pr_number`;
+/// returns the most recently modified match, or `None` if not found.
+/// Fail-open: any I/O or parse error returns `None` (the poll is skipped).
+/// Test: exercised indirectly; the store path and log path are configurable.
+fn load_last_review_result(
+    log_dir: &std::path::Path,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+) -> Option<crate::models::ReviewResult> {
+    let dir = std::fs::read_dir(log_dir).ok()?;
+    let mut candidates: Vec<(std::time::SystemTime, crate::models::ReviewResult)> = dir
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .filter_map(|e| {
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            let content = std::fs::read_to_string(e.path()).ok()?;
+            let result: crate::models::ReviewResult = serde_json::from_str(&content).ok()?;
+            if result.owner == owner && result.repo == repo && result.pr_number == pr_number {
+                Some((mtime, result))
+            } else {
+                None
+            }
+        })
+        .collect();
+    candidates.sort_by(|(a, _), (b, _)| b.cmp(a)); // most recent first
+    candidates.into_iter().next().map(|(_, r)| r)
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/service/webhook_tests.rs
+++ b/crates/trusty-review/src/service/webhook_tests.rs
@@ -240,3 +240,62 @@ async fn webhook_accepts_review_requested_returns_202() {
     // 202 Accepted — pipeline spawned in background.
     assert_eq!(response.status(), StatusCode::ACCEPTED);
 }
+
+#[test]
+fn load_last_review_result_finds_correct_file() {
+    // Arrange: write two JSON files in a tempdir — one matching the PR,
+    // one for a different PR — and verify only the matching one is loaded.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log_dir = dir.path();
+
+    // Helper: build a minimal ReviewResult JSON for a given PR.
+    fn make_result_json(owner: &str, repo: &str, pr: u64) -> String {
+        // Construct a minimal ReviewResult JSON directly.
+        format!(
+            r#"{{
+                "owner": "{owner}",
+                "repo": "{repo}",
+                "pr_number": {pr},
+                "pr_title": "Test PR",
+                "pr_url": "https://github.com/{owner}/{repo}/pull/{pr}",
+                "review_body": "",
+                "verdict": "APPROVE",
+                "findings": [],
+                "model": "test",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cost_estimate_usd": 0.0,
+                "latency_ms": 0,
+                "dry_run": true,
+                "posted": false,
+                "timestamp": "2026-06-23T12:00:00Z",
+                "head_sha": "abc123",
+                "review_version": "tr-test"
+            }}"#
+        )
+    }
+
+    // Write a matching file (acme-backend-pr42-...).
+    let matching_path = log_dir.join("acme-backend-pr42-2026-06-23T12-00-00Z.json");
+    std::fs::write(&matching_path, make_result_json("acme", "backend", 42))
+        .expect("write matching");
+
+    // Write a non-matching file (different PR number).
+    let non_matching_path = log_dir.join("acme-backend-pr99-2026-06-23T12-00-00Z.json");
+    std::fs::write(&non_matching_path, make_result_json("acme", "backend", 99))
+        .expect("write non-matching");
+
+    // Act.
+    let result = super::load_last_review_result(log_dir, "acme", "backend", 42);
+
+    // Assert: the matching result is found.
+    assert!(result.is_some(), "should find the matching review result");
+    assert_eq!(result.unwrap().pr_number, 42);
+}
+
+#[test]
+fn load_last_review_result_returns_none_for_missing_pr() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let result = super::load_last_review_result(dir.path(), "acme", "backend", 42);
+    assert!(result.is_none(), "should return None for empty log dir");
+}

--- a/crates/trusty-review/src/store/mod.rs
+++ b/crates/trusty-review/src/store/mod.rs
@@ -14,9 +14,11 @@
 
 pub mod dedup;
 pub mod in_flight;
+pub mod outcome_store;
 
 pub use dedup::{ClaimOutcome, DedupError, DedupStore};
 pub use in_flight::{InFlightGuard, InFlightRegistry};
+pub use outcome_store::{OutcomeError, OutcomeRecord, OutcomeStore};
 
 /// Classify a `redb::DatabaseError` as an incompatible / unreadable file format
 /// (issue #702).

--- a/crates/trusty-review/src/store/outcome_store.rs
+++ b/crates/trusty-review/src/store/outcome_store.rs
@@ -202,10 +202,9 @@ impl OutcomeStore {
     /// as "what NOT to flag" guardrails (issue #1421); the prompt injection is a
     /// follow-up (PR F) — this method exposes the aggregated data.
     /// What: scans the full `OUTCOMES` table, groups records by `kind`, sums
-    /// `dismissed_count` per kind, and returns kinds whose sum **strictly exceeds**
-    /// `threshold` (`dismissed_count > threshold`, not `>=`).  A kind dismissed
-    /// exactly `threshold` times is NOT returned — the threshold is a minimum
-    /// exclusive lower bound.
+    /// `dismissed_count` per kind, and returns kinds whose sum is **at least**
+    /// `threshold` (`dismissed_count >= threshold`).  A kind dismissed exactly
+    /// `threshold` times IS returned — the threshold is inclusive (N or more).
     /// Test: `record_and_dismissed_patterns_threshold`, `record_below_threshold`.
     pub fn dismissed_patterns(&self, threshold: u32) -> Result<Vec<String>, OutcomeError> {
         let read = self
@@ -233,7 +232,7 @@ impl OutcomeStore {
 
         let mut result: Vec<String> = kind_counts
             .into_iter()
-            .filter(|(_, count)| *count > threshold)
+            .filter(|(_, count)| *count >= threshold)
             .map(|(kind, _)| kind)
             .collect();
         result.sort();
@@ -349,7 +348,7 @@ mod tests {
     }
 
     #[test]
-    fn dismissed_patterns_at_exact_threshold_not_included() {
+    fn dismissed_patterns_at_exact_threshold_included() {
         let (store, _d) = temp_store();
         for i in 0..5u32 {
             let o = make_outcome(&format!("h{i}"), "style", Outcome::Dismissed);
@@ -357,8 +356,8 @@ mod tests {
         }
         let patterns = store.dismissed_patterns(5).expect("query");
         assert!(
-            patterns.is_empty(),
-            "count == threshold (5) should not be returned"
+            patterns.contains(&"style".to_string()),
+            "count == threshold (5) IS returned — threshold is inclusive"
         );
     }
 }

--- a/crates/trusty-review/src/store/outcome_store.rs
+++ b/crates/trusty-review/src/store/outcome_store.rs
@@ -202,7 +202,10 @@ impl OutcomeStore {
     /// as "what NOT to flag" guardrails (issue #1421); the prompt injection is a
     /// follow-up (PR F) — this method exposes the aggregated data.
     /// What: scans the full `OUTCOMES` table, groups records by `kind`, sums
-    /// `dismissed_count` per kind, and returns kinds whose sum exceeds `threshold`.
+    /// `dismissed_count` per kind, and returns kinds whose sum **strictly exceeds**
+    /// `threshold` (`dismissed_count > threshold`, not `>=`).  A kind dismissed
+    /// exactly `threshold` times is NOT returned — the threshold is a minimum
+    /// exclusive lower bound.
     /// Test: `record_and_dismissed_patterns_threshold`, `record_below_threshold`.
     pub fn dismissed_patterns(&self, threshold: u32) -> Result<Vec<String>, OutcomeError> {
         let read = self

--- a/crates/trusty-review/src/store/outcome_store.rs
+++ b/crates/trusty-review/src/store/outcome_store.rs
@@ -1,0 +1,361 @@
+//! redb-backed finding-outcome persistence store (issue #1421).
+//!
+//! Why: persisting per-finding outcomes (accepted/acted-on/dismissed/ignored)
+//! enables the suppression-list pipeline — chronically-dismissed finding kinds
+//! can be fed back as "what NOT to flag" guardrails (epic #1413, child #1421).
+//! A redb store mirrors the DedupStore pattern for consistency and cross-process
+//! durability.
+//!
+//! What: `OutcomeStore` wraps a redb database with one table keyed by
+//! `finding_hash`.  `record` persists a `FindingOutcome`; `dismissed_patterns`
+//! returns finding `kind`s dismissed more than `threshold` times.
+//!
+//! Fail-safe: every method returns a typed `OutcomeError`, but callers are
+//! expected to *log and proceed* — a store failure must never crash or block
+//! a review or outcome-poll cycle.
+//!
+//! Test: `record_and_dismissed_patterns_threshold`, `record_below_threshold`,
+//! `multiple_kinds_independent`.
+
+use std::path::Path;
+
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+
+use crate::integrations::github::outcomes::{FindingOutcome, Outcome};
+
+/// redb table: finding_hash → serialised `OutcomeRecord` (JSON).
+///
+/// Why: a single table keyed by the stable finding hash is the simplest durable
+/// shape — one row per finding, updated in place on each observation.
+/// What: key is the hex SHA-256 `finding_hash`; value is JSON-encoded `OutcomeRecord`.
+/// Test: exercised by all store tests.
+const OUTCOMES: TableDefinition<&str, &str> = TableDefinition::new("finding_outcomes");
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+/// Errors produced by the outcome store.
+///
+/// Why: a typed enum lets callers distinguish "store unavailable" from
+/// "serialisation bug" in logs, even though the policy for both is the same
+/// (log + proceed).
+/// What: wraps redb's database/transaction/table/commit errors plus JSON
+/// (de)serialisation failures.
+/// Test: error variants are surfaced via the public methods; `Display` is
+/// derived by thiserror.
+#[derive(Debug, thiserror::Error)]
+pub enum OutcomeError {
+    /// Opening or creating the redb database failed.
+    #[error("outcome store open failed: {0}")]
+    Open(String),
+    /// A read/write transaction failed.
+    #[error("outcome store transaction failed: {0}")]
+    Transaction(String),
+    /// Serialising or deserialising a record failed.
+    #[error("outcome store (de)serialisation failed: {0}")]
+    Serde(String),
+}
+
+// ─── Record type ─────────────────────────────────────────────────────────────
+
+/// A stored outcome record for a single finding.
+///
+/// Why: persists the outcome signal alongside context (kind, timestamp) needed
+/// for the suppression-list query without requiring a secondary index.
+/// What: `finding_hash` is the redb key (also stored in value for self-containedness);
+/// `kind` supports the `dismissed_patterns` query; `outcome` is the signal;
+/// `count` tracks how many times this outcome was observed (for aggregation).
+/// Test: round-tripped through JSON by every store method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutcomeRecord {
+    /// Stable fingerprint of the finding.
+    pub finding_hash: String,
+    /// Finding kind (e.g. `"security"`, `"logic-error"`).
+    pub kind: String,
+    /// Most-recently observed outcome.
+    pub outcome: Outcome,
+    /// Number of times this hash has been recorded as `Dismissed`.
+    pub dismissed_count: u32,
+    /// Number of times this hash has been recorded total.
+    pub total_count: u32,
+    /// ISO-8601 UTC timestamp of the last update.
+    pub last_updated: String,
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+/// A redb-backed finding-outcome persistence store.
+///
+/// Why: provides cross-process, durable outcome tracking so the suppression-list
+/// pipeline can aggregate dismissed patterns across multiple reviews.
+/// What: owns a redb `Database`; all methods open short transactions so the
+/// store is safe to share across tasks behind an `Arc`.
+/// Test: see module-level tests, all of which use a tempfile-backed store.
+pub struct OutcomeStore {
+    db: Database,
+}
+
+impl OutcomeStore {
+    /// Open (or create) the outcome store at `path`.
+    ///
+    /// Why: the store lives under the review log dir alongside `dedup.redb`,
+    /// persisting across daemon restarts.
+    /// What: creates the redb database file and ensures the outcomes table exists.
+    /// On incompatible-format errors, moves the old file aside and creates fresh
+    /// (same recovery pattern as `DedupStore`).
+    /// Test: `open_creates_file`.
+    pub fn open(path: &Path) -> Result<Self, OutcomeError> {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let db = Self::open_or_recreate(path)?;
+        {
+            let write = db
+                .begin_write()
+                .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+            {
+                write
+                    .open_table(OUTCOMES)
+                    .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+            }
+            write
+                .commit()
+                .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+        }
+        Ok(Self { db })
+    }
+
+    fn open_or_recreate(path: &Path) -> Result<Database, OutcomeError> {
+        match Database::create(path) {
+            Ok(db) => Ok(db),
+            Err(e) if crate::store::redb_error_is_incompatible_format(&e) => {
+                let mut backup = path.as_os_str().to_os_string();
+                backup.push(".v2-incompatible");
+                let backup = std::path::PathBuf::from(backup);
+                let _ = std::fs::rename(path, &backup);
+                Database::create(path).map_err(|e| OutcomeError::Open(e.to_string()))
+            }
+            Err(e) => Err(OutcomeError::Open(e.to_string())),
+        }
+    }
+
+    /// Record a finding outcome, updating the stored record for `outcome.finding_hash`.
+    ///
+    /// Why: accumulates outcome observations over time so `dismissed_patterns`
+    /// can aggregate chronically-dismissed finding kinds.
+    /// What: reads any existing record for the hash; increments `dismissed_count`
+    /// when the outcome is `Dismissed`; always increments `total_count`; writes
+    /// back atomically.
+    /// Test: `record_and_dismissed_patterns_threshold`.
+    pub fn record(&self, outcome: &FindingOutcome) -> Result<(), OutcomeError> {
+        let write = self
+            .db
+            .begin_write()
+            .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+        {
+            let mut table = write
+                .open_table(OUTCOMES)
+                .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+
+            let key = outcome.finding_hash.as_str();
+            let existing = table
+                .get(key)
+                .map_err(|e| OutcomeError::Transaction(e.to_string()))?
+                .map(|v| v.value().to_string());
+
+            let mut record = if let Some(raw) = existing {
+                serde_json::from_str::<OutcomeRecord>(&raw)
+                    .map_err(|e| OutcomeError::Serde(e.to_string()))?
+            } else {
+                OutcomeRecord {
+                    finding_hash: outcome.finding_hash.clone(),
+                    kind: outcome.kind.clone(),
+                    outcome: outcome.outcome,
+                    dismissed_count: 0,
+                    total_count: 0,
+                    last_updated: outcome.timestamp.clone(),
+                }
+            };
+
+            if outcome.outcome == Outcome::Dismissed {
+                record.dismissed_count = record.dismissed_count.saturating_add(1);
+            }
+            record.total_count = record.total_count.saturating_add(1);
+            record.outcome = outcome.outcome;
+            record.last_updated = outcome.timestamp.clone();
+
+            let json =
+                serde_json::to_string(&record).map_err(|e| OutcomeError::Serde(e.to_string()))?;
+            table
+                .insert(key, json.as_str())
+                .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+        }
+        write
+            .commit()
+            .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Return finding `kind`s that have been dismissed more than `threshold` times.
+    ///
+    /// Why: the suppression-list pipeline feeds these kinds back into the prompt
+    /// as "what NOT to flag" guardrails (issue #1421); the prompt injection is a
+    /// follow-up (PR F) — this method exposes the aggregated data.
+    /// What: scans the full `OUTCOMES` table, groups records by `kind`, sums
+    /// `dismissed_count` per kind, and returns kinds whose sum exceeds `threshold`.
+    /// Test: `record_and_dismissed_patterns_threshold`, `record_below_threshold`.
+    pub fn dismissed_patterns(&self, threshold: u32) -> Result<Vec<String>, OutcomeError> {
+        let read = self
+            .db
+            .begin_read()
+            .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+        let table = read
+            .open_table(OUTCOMES)
+            .map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+
+        let mut kind_counts: std::collections::HashMap<String, u32> =
+            std::collections::HashMap::new();
+
+        for item in table
+            .iter()
+            .map_err(|e| OutcomeError::Transaction(e.to_string()))?
+        {
+            let (_, v) = item.map_err(|e| OutcomeError::Transaction(e.to_string()))?;
+            let record: OutcomeRecord =
+                serde_json::from_str(v.value()).map_err(|e| OutcomeError::Serde(e.to_string()))?;
+            if record.dismissed_count > 0 {
+                *kind_counts.entry(record.kind).or_default() += record.dismissed_count;
+            }
+        }
+
+        let mut result: Vec<String> = kind_counts
+            .into_iter()
+            .filter(|(_, count)| *count > threshold)
+            .map(|(kind, _)| kind)
+            .collect();
+        result.sort();
+        Ok(result)
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrations::github::outcomes::FindingOutcome;
+
+    fn temp_store() -> (OutcomeStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("outcomes.redb");
+        let store = OutcomeStore::open(&path).expect("open store");
+        (store, dir)
+    }
+
+    fn make_outcome(hash: &str, kind: &str, outcome: Outcome) -> FindingOutcome {
+        FindingOutcome {
+            finding_hash: hash.to_string(),
+            kind: kind.to_string(),
+            outcome,
+            timestamp: "2026-06-23T12:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn open_creates_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("outcomes.redb");
+        let _store = OutcomeStore::open(&path).expect("open");
+        assert!(path.exists(), "redb file must be created");
+    }
+
+    #[test]
+    fn record_and_dismissed_patterns_threshold() {
+        let (store, _d) = temp_store();
+
+        for i in 0..6u32 {
+            let o = make_outcome(&format!("hash{i}"), "nit", Outcome::Dismissed);
+            store.record(&o).expect("record");
+        }
+        for i in 0..3u32 {
+            let o = make_outcome(&format!("sec{i}"), "security", Outcome::Dismissed);
+            store.record(&o).expect("record");
+        }
+
+        let patterns = store.dismissed_patterns(5).expect("query");
+        assert!(
+            patterns.contains(&"nit".to_string()),
+            "nit should exceed threshold 5"
+        );
+        assert!(
+            !patterns.contains(&"security".to_string()),
+            "security should be below threshold"
+        );
+    }
+
+    #[test]
+    fn record_below_threshold_not_returned() {
+        let (store, _d) = temp_store();
+        let o = make_outcome("hash1", "style", Outcome::Dismissed);
+        store.record(&o).expect("record");
+        let patterns = store.dismissed_patterns(5).expect("query");
+        assert!(patterns.is_empty(), "one dismissal is below threshold 5");
+    }
+
+    #[test]
+    fn non_dismissed_outcomes_not_counted() {
+        let (store, _d) = temp_store();
+        for i in 0..10u32 {
+            let o = make_outcome(&format!("h{i}"), "perf", Outcome::Accepted);
+            store.record(&o).expect("record");
+        }
+        let patterns = store.dismissed_patterns(1).expect("query");
+        assert!(
+            patterns.is_empty(),
+            "accepted outcomes must not count as dismissed"
+        );
+    }
+
+    #[test]
+    fn multiple_kinds_independent() {
+        let (store, _d) = temp_store();
+        for i in 0..6u32 {
+            let o = make_outcome(&format!("s{i}"), "security", Outcome::Dismissed);
+            store.record(&o).expect("record");
+        }
+        for i in 0..2u32 {
+            let o = make_outcome(&format!("n{i}"), "nit", Outcome::Dismissed);
+            store.record(&o).expect("record");
+        }
+        let patterns = store.dismissed_patterns(5).expect("query");
+        assert!(patterns.contains(&"security".to_string()));
+        assert!(!patterns.contains(&"nit".to_string()));
+    }
+
+    #[test]
+    fn record_same_hash_twice_increments_count() {
+        let (store, _d) = temp_store();
+        let o = make_outcome("dup_hash", "security", Outcome::Dismissed);
+        store.record(&o).expect("first record");
+        store.record(&o).expect("second record");
+        let patterns = store.dismissed_patterns(1).expect("query");
+        assert!(
+            patterns.contains(&"security".to_string()),
+            "2 > 1 threshold"
+        );
+    }
+
+    #[test]
+    fn dismissed_patterns_at_exact_threshold_not_included() {
+        let (store, _d) = temp_store();
+        for i in 0..5u32 {
+            let o = make_outcome(&format!("h{i}"), "style", Outcome::Dismissed);
+            store.record(&o).expect("record");
+        }
+        let patterns = store.dismissed_patterns(5).expect("query");
+        assert!(
+            patterns.is_empty(),
+            "count == threshold (5) should not be returned"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **outcome-capture infrastructure** for the review feedback loop (closes child ticket #1421, refs epic #1413 / T8).

### What ships in this PR

- **GitHub API methods** (`integrations/github/pr.rs`): `get_review_comment_reactions` and `get_pr_commits_after` on the existing `GithubClient`. Reuse existing auth/client; fail-open.
- **`integrations/github/outcomes.rs`** (new): `poll_review_outcomes` maps reactions (👍/🚀 = `Accepted`, 👎 = `Dismissed`) and follow-up commits touching a finding's file within ~7 days = `ActedOn`; otherwise `Ignored`. `FindingOutcome { finding_hash, kind, outcome, timestamp }`. `finding_hash = sha256(kind + file + line + description[..50])` survives LLM nondeterminism.
- **`store/outcome_store.rs`** (new): `OutcomeStore` backed by redb (same dep/recovery pattern as `DedupStore`). Table `finding_hash → OutcomeRecord`. `record(outcome)` persists; `dismissed_patterns(threshold) → Vec<String>` returns finding kinds dismissed more than `threshold` times.
- **Config** (`config/mod.rs` + new `config/outcome.rs`): `[outcome]` TOML section with `enabled` (default `false`), `poll_delay_minutes` (default `60`), `dismissal_threshold` (default `5`).
- **Webhook trigger** (`service/webhook.rs`): on a `pull_request` event with `action == "closed"` and `merged == true`, if `outcome.enabled`, spawns a background task that sleeps `poll_delay_minutes` then calls `poll_review_outcomes` and records results into `OutcomeStore`. The background task uses `tokio::select!` with a `shutdown_rx` watch receiver (added to `AppState`) so it is cancelled on daemon shutdown — no orphan tasks.

### Graceful-shutdown wiring

A `tokio::sync::watch` channel is added to `AppState` (`shutdown_signal` sender + `shutdown_rx()` accessor). The `serve()` function sends the shutdown signal after `axum::serve` returns, cancelling any sleeping outcome-poll tasks before the process exits.

### Out of scope (explicit follow-up)

The **suppression-list injection** — feeding `dismissed_patterns()` into the system prompt as a "what NOT to flag" section — is intentionally **not** in this PR to avoid file conflicts with parallel PRs C/D (`pipeline/prompt_templates.rs` is frozen). `dismissed_patterns()` exists and is fully tested; the prompt wiring is PR F.

## Verification

```
cargo test -p trusty-review        → 976 passed, 0 failed, 3 ignored
cargo clippy -p trusty-review      → clean (zero warnings)
cargo fmt --check -p trusty-review → clean
bash scripts/check_line_cap.sh     → 14 allowlisted, 0 violations — OK
```

## Files changed

| File | Type |
|---|---|
| `integrations/github/pr.rs` | Modified — `Reaction`, `CommitInfo`, 2 fetch methods |
| `integrations/github/outcomes.rs` | New — outcome types, classification, `poll_review_outcomes` |
| `integrations/github/mod.rs` | Modified — re-exports |
| `store/outcome_store.rs` | New — redb-backed `OutcomeStore` |
| `store/mod.rs` | Modified — re-exports |
| `config/outcome.rs` | New — `OutcomeConfig`, `OutcomeFileConfig` |
| `config/mod.rs` | Modified — wire `OutcomeConfig` into `ReviewConfig` |
| `service/webhook.rs` | Modified — `closed+merged` dispatch + shutdown signal |

Closes #1421
Refs #1413