### PR TITLE
feat(trusty-review): calibration harness + Rust false-positive prompt guardrail (closes #1422)

### DIFF
--- a/crates/trusty-review/src/commands/calibrate.rs
+++ b/crates/trusty-review/src/commands/calibrate.rs
@@ -5,20 +5,32 @@
 //! merged PRs with human-review ground truth and produces a repeatable
 //! recall/precision report so calibration regressions are caught early.
 //!
-//! What: loads a JSONL corpus (`CorpusEntry` per line), runs the review
-//! pipeline in dry-run mode for each PR, fuzzy-matches trusty findings
-//! against human findings by (file, kind), and emits a JSON report with
-//! per-PR and aggregate metrics including `rust_semantic_fp_rate`.
+//! What: loads a JSONL corpus (`CorpusEntry` per line), runs the REAL review
+//! pipeline in dry-run mode for each PR (no GitHub post), fuzzy-matches trusty
+//! findings against human findings by (file, kind), and emits a JSON report
+//! with per-PR and aggregate metrics including `rust_semantic_fp_rate`.
 //!
 //! Test: `calibrate_tests.rs` — synthetic 3-PR corpus fixture with known
 //! ground truth asserts recall/precision computation and fuzzy matcher.
+//! Pure functions are tested without hitting a real LLM or GitHub.
 
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
-use trusty_review::models::{Effort, Finding};
+use trusty_review::{
+    config::ReviewConfig,
+    integrations::{
+        github::{AuthStrategy, GithubClient, RunMode},
+        search_client::HttpSearchClient,
+    },
+    models::Finding,
+    pipeline::{DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
+};
+
+use super::run::build_deps_async;
 
 // ─── Corpus format ────────────────────────────────────────────────────────────
 
@@ -97,8 +109,8 @@ pub struct PrMetrics {
 /// Why: the top-level output that CI and humans consume to track calibration
 /// regressions across prompt changes, model upgrades, and corpus expansions.
 /// What: aggregate recall/precision over all corpus PRs, per-PR details, and
-/// the `rust_semantic_fp_rate` measuring precision of logic-error/ownership
-/// findings on `.rs` files specifically (the known Rust FP hotspot).
+/// the `rust_semantic_fp_rate` — the TRUE false-positive rate (lower = better)
+/// of logic-error/ownership findings on `.rs` files specifically.
 /// Test: computed and asserted in `calibrate_tests.rs`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CalibrationReport {
@@ -108,11 +120,12 @@ pub struct CalibrationReport {
     pub precision: f64,
     /// Per-PR metrics (one entry per corpus line).
     pub per_pr: Vec<PrMetrics>,
-    /// Precision of `logic-error`/`ownership` findings on `.rs` files.
+    /// True false-positive rate of `logic-error`/`ownership` findings on `.rs` files.
     ///
-    /// Why: trusty-review false-positives HIGH on these Rust semantic patterns
-    /// (`move` closures, `tokio::select!` branches).  This field makes the
-    /// false-positive rate measurable and regressionable.  Returns 1.0 (neutral)
+    /// Why: trusty-review false-positives HIGH on Rust semantic patterns (`move`
+    /// closures, `tokio::select!` branches).  This field measures that FP rate as
+    /// `1.0 - (recalled / total_rust_semantic)`, so **lower is better** (0.0 = perfect,
+    /// 1.0 = every Rust semantic finding was a false positive).  Returns 0.0 (no FPs)
     /// when no Rust semantic findings exist in the run.
     pub rust_semantic_fp_rate: f64,
 }
@@ -133,6 +146,14 @@ pub struct CalibrateArgs {
     /// Write the JSON report to this file instead of stdout.
     #[arg(long, value_name = "FILE")]
     pub output: Option<PathBuf>,
+
+    /// Override the reviewer model slug (passed through to the review pipeline).
+    #[arg(long, value_name = "SLUG")]
+    pub reviewer_model: Option<String>,
+
+    /// Provider backend: `bedrock` (default) or `openrouter`.
+    #[arg(long, value_name = "PROVIDER")]
+    pub provider: Option<String>,
 }
 
 // ─── Fuzzy matcher ────────────────────────────────────────────────────────────
@@ -143,7 +164,7 @@ pub struct CalibrateArgs {
 /// deliberate.  A finding is recalled when the same file AND kind appear in
 /// both the trusty output and the human ground truth.
 /// What: case-insensitive kind comparison; exact file-path string comparison.
-/// Test: `finding_recalled_same_file_kind`, `finding_not_recalled_diff_kind`,
+/// Test: `finding_recalled_same_file_and_kind`, `finding_not_recalled_diff_kind`,
 /// `finding_not_recalled_diff_file` in `calibrate_tests.rs`.
 pub fn is_recalled(trusty: &Finding, human: &HumanFinding) -> bool {
     trusty.file == human.file && trusty.kind.eq_ignore_ascii_case(&human.kind)
@@ -154,7 +175,7 @@ pub fn is_recalled(trusty: &Finding, human: &HumanFinding) -> bool {
 /// Why: the `rust_semantic_fp_rate` metric needs a consistent classifier.
 /// What: the file ends in `.rs` AND kind is `logic-error` or `ownership`
 /// (case-insensitive match).
-/// Test: `rust_semantic_classifier` in `calibrate_tests.rs`.
+/// Test: `rust_semantic_classifier_*` tests in `calibrate_tests.rs`.
 pub fn is_rust_semantic(finding: &Finding) -> bool {
     finding.file.ends_with(".rs")
         && matches!(
@@ -171,7 +192,7 @@ pub fn is_rust_semantic(finding: &Finding) -> bool {
 /// or pipeline invocations.
 /// What: for each (corpus_entry, trusty_findings) pair counts recalled human
 /// findings, false-positive trusty findings, and accumulates into aggregate
-/// recall/precision and the Rust semantic FP rate.
+/// recall/precision and the TRUE Rust semantic FP rate (lower = better).
 /// Test: `compute_metrics_three_pr_corpus` in `calibrate_tests.rs`.
 pub fn compute_metrics(
     corpus: &[CorpusEntry],
@@ -251,10 +272,13 @@ pub fn compute_metrics(
     } else {
         total_recalled as f64 / total_trusty as f64
     };
+    // TRUE false-positive rate: 0.0 = no FPs (all Rust semantic findings recalled),
+    // 1.0 = every Rust semantic finding was a false positive.
+    // Returns 0.0 (neutral/no FPs) when no Rust semantic findings were emitted.
     let rust_semantic_fp_rate = if rust_sem_total == 0 {
-        1.0_f64
+        0.0_f64
     } else {
-        rust_sem_recalled as f64 / rust_sem_total as f64
+        1.0_f64 - (rust_sem_recalled as f64 / rust_sem_total as f64)
     };
 
     CalibrationReport {
@@ -289,45 +313,129 @@ pub fn load_corpus(path: &Path) -> Result<Vec<CorpusEntry>> {
     Ok(entries)
 }
 
+// ─── Pipeline runner ─────────────────────────────────────────────────────────
+
+/// Run the real review pipeline for a corpus PR and return its findings.
+///
+/// Why: the calibration harness must call the REAL review pipeline to produce
+/// actual model findings — synthesising findings from the corpus ground truth
+/// would be tautological and say nothing about the model.
+/// What: resolves a GitHub token, builds `DiffSource::Github`, runs `run_review`
+/// in dry-run mode (no GitHub post, no log write), and returns the findings list.
+/// Errors are fail-open: a pipeline error for one PR logs a warning and returns
+/// an empty findings list so the rest of the corpus continues.
+/// Test: called in `cmd_calibrate`; pure functions (`is_recalled`, `compute_metrics`)
+/// are tested separately in `calibrate_tests.rs` without hitting real services.
+async fn run_pipeline_for_entry(
+    config: &ReviewConfig,
+    entry: &CorpusEntry,
+    reviewer_model: &str,
+    deps: ReviewDeps,
+) -> Vec<Finding> {
+    let client = match GithubClient::new() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(pr = entry.pr, owner = %entry.owner, repo = %entry.repo,
+                  "calibrate: failed to build GitHub client: {e}");
+            return Vec::new();
+        }
+    };
+    let token = match AuthStrategy::select(RunMode::Cli, None)
+        .resolve_token(&client, config, &entry.owner)
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            warn!(pr = entry.pr, owner = %entry.owner, repo = %entry.repo,
+                  "calibrate: GitHub token resolution failed: {e}");
+            return Vec::new();
+        }
+    };
+
+    let diff_source = DiffSource::Github {
+        owner: entry.owner.clone(),
+        repo: entry.repo.clone(),
+        pr: entry.pr,
+        token,
+    };
+
+    let input = ReviewInput {
+        diff_source,
+        reviewer_model: reviewer_model.to_string(),
+        write_log: false,    // never write log files during calibration
+        print_result: false, // suppress stdout during batch run
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false, // NEVER post during calibration — always dry-run
+    };
+
+    let result = run_review(config, input, deps).await;
+    result.findings
+}
+
 // ─── Subcommand handler ───────────────────────────────────────────────────────
 
 /// Execute the `calibrate` subcommand.
 ///
 /// Why: provides a repeatable calibration harness so prompt changes and model
-/// upgrades can be measured against a fixed corpus before they ship.
-/// What: loads the corpus JSONL, synthesises dry-run trusty findings from the
-/// corpus `acted_on` flags (no live LLM call — future iterations wire
-/// `run_review`), computes recall/precision, and emits a JSON report.
-/// Test: `cargo run -p trusty-review -- calibrate --corpus corpus.jsonl`.
-pub async fn cmd_calibrate(args: CalibrateArgs) -> Result<()> {
+/// upgrades can be measured against a fixed corpus of human-reviewed PRs before
+/// they ship.
+/// What: loads the corpus JSONL, runs the REAL `run_review` pipeline in dry-run
+/// mode for each PR to obtain actual model findings, fuzzy-matches them against
+/// the corpus human findings using `is_recalled`, runs `compute_metrics`, and
+/// emits a JSON report.  Errors for individual PRs are fail-open (logged as
+/// warnings; that PR contributes an empty findings list).
+/// Test: `cargo run -p trusty-review -- calibrate --corpus corpus.jsonl`
+/// (requires GitHub token + LLM credentials at runtime).
+pub async fn cmd_calibrate(_config: ReviewConfig, args: CalibrateArgs) -> Result<()> {
     let corpus = load_corpus(&args.corpus)?;
     if corpus.is_empty() {
         anyhow::bail!("corpus file is empty — nothing to calibrate against");
     }
 
-    // Dry-run mode: synthesise trusty findings from corpus `acted_on` flags.
-    // This makes the harness runnable without a live LLM or GitHub connection.
-    // A future iteration replaces this stub with an actual `run_review` call.
-    let trusty_results: Vec<Vec<Finding>> = corpus
-        .iter()
-        .map(|entry| {
-            entry
-                .human_findings
-                .iter()
-                .filter(|hf| hf.acted_on)
-                .map(|hf| {
-                    Finding::new(
-                        hf.file.clone(),
-                        hf.kind.clone(),
-                        format!("synthetic finding for {}", hf.file),
-                        String::new(),
-                        0.9_f32,
-                        Effort::Low,
-                    )
-                })
-                .collect()
-        })
-        .collect();
+    let overrides = trusty_review::config::RoleCliOverrides {
+        reviewer_model: args.reviewer_model.clone(),
+        provider: args.provider.clone(),
+        ..Default::default()
+    };
+    let config_with_overrides = ReviewConfig::from_env_and_file(None, Some(&overrides));
+    let reviewer_model = config_with_overrides.role_models.reviewer.model.clone();
+    let default_provider = config_with_overrides.role_models.reviewer.provider.clone();
+
+    eprintln!(
+        "calibrate: running real review pipeline for {} corpus PRs (model: {reviewer_model})",
+        corpus.len()
+    );
+
+    // Resolve the search index once before the batch.
+    let mut cfg = config_with_overrides.clone();
+    if let Ok(search_client) = HttpSearchClient::from_config(&cfg) {
+        cfg.resolve_index(&search_client).await;
+    }
+
+    // Run the real pipeline for each corpus PR.  Deps are rebuilt per-PR because
+    // `ReviewDeps` contains `Arc<dyn LlmProvider>` which is not cheaply cloneable.
+    let mut trusty_results: Vec<Vec<Finding>> = Vec::with_capacity(corpus.len());
+    for (i, entry) in corpus.iter().enumerate() {
+        eprintln!(
+            "calibrate: [{}/{}] {}/{}#{}",
+            i + 1,
+            corpus.len(),
+            entry.owner,
+            entry.repo,
+            entry.pr
+        );
+        let deps = match build_deps_async(&cfg, &reviewer_model, &default_provider).await {
+            Ok(d) => d,
+            Err(e) => {
+                warn!("calibrate: failed to build deps for PR {}: {e}", entry.pr);
+                trusty_results.push(Vec::new());
+                continue;
+            }
+        };
+        let findings = run_pipeline_for_entry(&cfg, entry, &reviewer_model, deps).await;
+        trusty_results.push(findings);
+    }
 
     let report = compute_metrics(&corpus, &trusty_results);
     let json = serde_json::to_string_pretty(&report).context("serialising calibration report")?;
@@ -337,10 +445,11 @@ pub async fn cmd_calibrate(args: CalibrateArgs) -> Result<()> {
             std::fs::write(path, &json)
                 .with_context(|| format!("writing report to {}", path.display()))?;
             eprintln!(
-                "calibration report written to {} (recall={:.3}, precision={:.3})",
+                "calibration report written to {} (recall={:.3}, precision={:.3}, rust_fp={:.3})",
                 path.display(),
                 report.recall,
-                report.precision
+                report.precision,
+                report.rust_semantic_fp_rate,
             );
         }
         None => {

--- a/crates/trusty-review/src/commands/calibrate.rs
+++ b/crates/trusty-review/src/commands/calibrate.rs
@@ -124,7 +124,8 @@ pub struct CalibrationReport {
     ///
     /// Why: trusty-review false-positives HIGH on Rust semantic patterns (`move`
     /// closures, `tokio::select!` branches).  This field measures that FP rate as
-    /// `1.0 - (recalled / total_rust_semantic)`, so **lower is better** (0.0 = perfect,
+    /// `1.0 - precision(rust_semantic)` — i.e. `1 - (trusty_matched / trusty_total)`
+    /// for Rust-semantic findings only — so **lower is better** (0.0 = perfect,
     /// 1.0 = every Rust semantic finding was a false positive).  Returns 0.0 (no FPs)
     /// when no Rust semantic findings exist in the run.
     pub rust_semantic_fp_rate: f64,
@@ -205,7 +206,8 @@ pub fn compute_metrics(
     );
 
     let mut total_human: usize = 0;
-    let mut total_recalled: usize = 0;
+    let mut total_recalled: usize = 0; // sum of distinct human findings recalled
+    let mut total_trusty_matched: usize = 0; // sum of trusty findings matched (precision numerator)
     let mut total_trusty: usize = 0;
     let mut rust_sem_total: usize = 0;
     let mut rust_sem_recalled: usize = 0;
@@ -217,13 +219,15 @@ pub fn compute_metrics(
         let n_human = human.len();
         let n_trusty = findings.len();
 
-        let mut recalled = 0usize;
+        // Precision numerator: trusty findings that matched at least one human finding.
+        // Used for precision = trusty_side_matched / total_trusty.
+        let mut trusty_matched = 0usize;
         let mut false_positives: Vec<FpFinding> = Vec::new();
 
         for tf in findings {
             let matched = human.iter().any(|hf| is_recalled(tf, hf));
             if matched {
-                recalled += 1;
+                trusty_matched += 1;
             } else {
                 false_positives.push(FpFinding {
                     file: tf.file.clone(),
@@ -239,19 +243,28 @@ pub fn compute_metrics(
             }
         }
 
+        // Recall numerator: DISTINCT human findings with ≥1 matching trusty finding.
+        // Counting distinct human-side hits prevents recall > 1.0 when multiple
+        // trusty findings match the same human finding.
+        let recalled_human = human
+            .iter()
+            .filter(|hf| findings.iter().any(|tf| is_recalled(tf, hf)))
+            .count();
+
         let pr_recall = if n_human == 0 {
             1.0_f64
         } else {
-            recalled as f64 / n_human as f64
+            recalled_human as f64 / n_human as f64
         };
         let pr_precision = if n_trusty == 0 {
             1.0_f64
         } else {
-            recalled as f64 / n_trusty as f64
+            trusty_matched as f64 / n_trusty as f64
         };
 
         total_human += n_human;
-        total_recalled += recalled;
+        total_recalled += recalled_human;
+        total_trusty_matched += trusty_matched;
         total_trusty += n_trusty;
 
         per_pr.push(PrMetrics {
@@ -270,7 +283,7 @@ pub fn compute_metrics(
     let aggregate_precision = if total_trusty == 0 {
         1.0_f64
     } else {
-        total_recalled as f64 / total_trusty as f64
+        total_trusty_matched as f64 / total_trusty as f64
     };
     // TRUE false-positive rate: 0.0 = no FPs (all Rust semantic findings recalled),
     // 1.0 = every Rust semantic finding was a false positive.

--- a/crates/trusty-review/src/commands/calibrate.rs
+++ b/crates/trusty-review/src/commands/calibrate.rs
@@ -1,0 +1,356 @@
+//! Handler for the `calibrate` subcommand.
+//!
+//! Why: no systematic recall/precision tooling existed for trusty-review;
+//! prior manual evals were one-off.  This harness takes a JSONL corpus of
+//! merged PRs with human-review ground truth and produces a repeatable
+//! recall/precision report so calibration regressions are caught early.
+//!
+//! What: loads a JSONL corpus (`CorpusEntry` per line), runs the review
+//! pipeline in dry-run mode for each PR, fuzzy-matches trusty findings
+//! against human findings by (file, kind), and emits a JSON report with
+//! per-PR and aggregate metrics including `rust_semantic_fp_rate`.
+//!
+//! Test: `calibrate_tests.rs` — synthetic 3-PR corpus fixture with known
+//! ground truth asserts recall/precision computation and fuzzy matcher.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+use serde::{Deserialize, Serialize};
+
+use trusty_review::models::{Effort, Finding};
+
+// ─── Corpus format ────────────────────────────────────────────────────────────
+
+/// A single human finding in the corpus ground truth.
+///
+/// Why: the corpus records human reviewer observations as (file, kind) pairs
+/// with an `acted_on` flag signalling the author actually addressed the finding.
+/// What: flat struct mapping to the JSONL corpus schema.
+/// Test: used directly in `calibrate_tests.rs` fixture construction.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct HumanFinding {
+    /// Changed file path (same form as `Finding::file`).
+    pub file: String,
+    /// Finding kind/category (e.g. `"logic-error"`, `"ownership"`).
+    pub kind: String,
+    /// True when the PR author acted on (addressed) this finding.
+    pub acted_on: bool,
+}
+
+/// One PR entry in the calibration corpus (JSONL — one object per line).
+///
+/// Why: JSONL makes the corpus easy to append to and diff in git; one
+/// struct per PR encapsulates its identity and ground-truth findings.
+/// What: identifies the GitHub PR and carries a list of human findings.
+/// Test: used directly in `calibrate_tests.rs` fixture construction.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CorpusEntry {
+    /// GitHub organisation / user.
+    pub owner: String,
+    /// GitHub repository name.
+    pub repo: String,
+    /// Pull-request number.
+    pub pr: u64,
+    /// Human reviewer findings for this PR (ground truth).
+    pub human_findings: Vec<HumanFinding>,
+}
+
+// ─── Report format ────────────────────────────────────────────────────────────
+
+/// A false-positive finding emitted by trusty (no matching human finding).
+///
+/// Why: recording which (file, kind) pairs over-fire guides prompt and
+/// noise-filter improvements without having to re-run the full corpus.
+/// What: minimal shape — file, kind, and one-line description.
+/// Test: collected and asserted in `calibrate_tests.rs`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FpFinding {
+    /// File the finding refers to.
+    pub file: String,
+    /// Finding kind (same as `Finding::kind`).
+    pub kind: String,
+    /// One-line description.
+    pub description: String,
+}
+
+/// Per-PR calibration metrics.
+///
+/// Why: per-PR breakdown lets corpus authors pinpoint which PRs drag down
+/// aggregate recall/precision and improve corpus quality iteratively.
+/// What: records recall, precision, and the false-positive list for one PR.
+/// Test: computed and asserted in `calibrate_tests.rs`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrMetrics {
+    /// Identifier string: `owner/repo#pr`.
+    pub pr: String,
+    /// Fraction of human findings recalled by trusty (0.0–1.0).
+    pub recall: f64,
+    /// Fraction of trusty findings that matched a human finding (0.0–1.0).
+    pub precision: f64,
+    /// Trusty findings that did NOT match any human finding (false positives).
+    pub false_positives: Vec<FpFinding>,
+}
+
+/// Aggregate calibration report emitted by `cmd_calibrate`.
+///
+/// Why: the top-level output that CI and humans consume to track calibration
+/// regressions across prompt changes, model upgrades, and corpus expansions.
+/// What: aggregate recall/precision over all corpus PRs, per-PR details, and
+/// the `rust_semantic_fp_rate` measuring precision of logic-error/ownership
+/// findings on `.rs` files specifically (the known Rust FP hotspot).
+/// Test: computed and asserted in `calibrate_tests.rs`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalibrationReport {
+    /// Aggregate recall: recalled_total / human_total across all corpus PRs.
+    pub recall: f64,
+    /// Aggregate precision: recalled_total / trusty_total across all corpus PRs.
+    pub precision: f64,
+    /// Per-PR metrics (one entry per corpus line).
+    pub per_pr: Vec<PrMetrics>,
+    /// Precision of `logic-error`/`ownership` findings on `.rs` files.
+    ///
+    /// Why: trusty-review false-positives HIGH on these Rust semantic patterns
+    /// (`move` closures, `tokio::select!` branches).  This field makes the
+    /// false-positive rate measurable and regressionable.  Returns 1.0 (neutral)
+    /// when no Rust semantic findings exist in the run.
+    pub rust_semantic_fp_rate: f64,
+}
+
+// ─── CLI args ─────────────────────────────────────────────────────────────────
+
+/// Arguments for the `calibrate` subcommand.
+///
+/// Why: bundles calibration flags for easy testing and CLI help text.
+/// What: corpus path is required; output path is optional (defaults to stdout).
+/// Test: `cargo run -p trusty-review -- calibrate --help`.
+#[derive(Debug, clap::Parser)]
+pub struct CalibrateArgs {
+    /// Path to the JSONL corpus file (one CorpusEntry JSON object per line).
+    #[arg(long, value_name = "FILE")]
+    pub corpus: PathBuf,
+
+    /// Write the JSON report to this file instead of stdout.
+    #[arg(long, value_name = "FILE")]
+    pub output: Option<PathBuf>,
+}
+
+// ─── Fuzzy matcher ────────────────────────────────────────────────────────────
+
+/// Returns `true` when a trusty `Finding` is "recalled" by a human finding.
+///
+/// Why: the match criterion must live in one testable function so changes are
+/// deliberate.  A finding is recalled when the same file AND kind appear in
+/// both the trusty output and the human ground truth.
+/// What: case-insensitive kind comparison; exact file-path string comparison.
+/// Test: `finding_recalled_same_file_kind`, `finding_not_recalled_diff_kind`,
+/// `finding_not_recalled_diff_file` in `calibrate_tests.rs`.
+pub fn is_recalled(trusty: &Finding, human: &HumanFinding) -> bool {
+    trusty.file == human.file && trusty.kind.eq_ignore_ascii_case(&human.kind)
+}
+
+/// Returns `true` when the finding is a Rust-semantic false-positive candidate.
+///
+/// Why: the `rust_semantic_fp_rate` metric needs a consistent classifier.
+/// What: the file ends in `.rs` AND kind is `logic-error` or `ownership`
+/// (case-insensitive match).
+/// Test: `rust_semantic_classifier` in `calibrate_tests.rs`.
+pub fn is_rust_semantic(finding: &Finding) -> bool {
+    finding.file.ends_with(".rs")
+        && matches!(
+            finding.kind.to_ascii_lowercase().as_str(),
+            "logic-error" | "ownership"
+        )
+}
+
+// ─── Metrics computation ──────────────────────────────────────────────────────
+
+/// Compute per-PR and aggregate calibration metrics from corpus + trusty results.
+///
+/// Why: extracted as a pure function so it can be unit-tested without any I/O
+/// or pipeline invocations.
+/// What: for each (corpus_entry, trusty_findings) pair counts recalled human
+/// findings, false-positive trusty findings, and accumulates into aggregate
+/// recall/precision and the Rust semantic FP rate.
+/// Test: `compute_metrics_three_pr_corpus` in `calibrate_tests.rs`.
+pub fn compute_metrics(
+    corpus: &[CorpusEntry],
+    trusty_results: &[Vec<Finding>],
+) -> CalibrationReport {
+    assert_eq!(
+        corpus.len(),
+        trusty_results.len(),
+        "corpus and trusty_results must have the same length"
+    );
+
+    let mut total_human: usize = 0;
+    let mut total_recalled: usize = 0;
+    let mut total_trusty: usize = 0;
+    let mut rust_sem_total: usize = 0;
+    let mut rust_sem_recalled: usize = 0;
+
+    let mut per_pr: Vec<PrMetrics> = Vec::with_capacity(corpus.len());
+
+    for (entry, findings) in corpus.iter().zip(trusty_results.iter()) {
+        let human = &entry.human_findings;
+        let n_human = human.len();
+        let n_trusty = findings.len();
+
+        let mut recalled = 0usize;
+        let mut false_positives: Vec<FpFinding> = Vec::new();
+
+        for tf in findings {
+            let matched = human.iter().any(|hf| is_recalled(tf, hf));
+            if matched {
+                recalled += 1;
+            } else {
+                false_positives.push(FpFinding {
+                    file: tf.file.clone(),
+                    kind: tf.kind.clone(),
+                    description: tf.description.clone(),
+                });
+            }
+            if is_rust_semantic(tf) {
+                rust_sem_total += 1;
+                if matched {
+                    rust_sem_recalled += 1;
+                }
+            }
+        }
+
+        let pr_recall = if n_human == 0 {
+            1.0_f64
+        } else {
+            recalled as f64 / n_human as f64
+        };
+        let pr_precision = if n_trusty == 0 {
+            1.0_f64
+        } else {
+            recalled as f64 / n_trusty as f64
+        };
+
+        total_human += n_human;
+        total_recalled += recalled;
+        total_trusty += n_trusty;
+
+        per_pr.push(PrMetrics {
+            pr: format!("{}/{}#{}", entry.owner, entry.repo, entry.pr),
+            recall: pr_recall,
+            precision: pr_precision,
+            false_positives,
+        });
+    }
+
+    let aggregate_recall = if total_human == 0 {
+        1.0_f64
+    } else {
+        total_recalled as f64 / total_human as f64
+    };
+    let aggregate_precision = if total_trusty == 0 {
+        1.0_f64
+    } else {
+        total_recalled as f64 / total_trusty as f64
+    };
+    let rust_semantic_fp_rate = if rust_sem_total == 0 {
+        1.0_f64
+    } else {
+        rust_sem_recalled as f64 / rust_sem_total as f64
+    };
+
+    CalibrationReport {
+        recall: aggregate_recall,
+        precision: aggregate_precision,
+        per_pr,
+        rust_semantic_fp_rate,
+    }
+}
+
+// ─── I/O helpers ─────────────────────────────────────────────────────────────
+
+/// Load corpus entries from a JSONL file (one JSON object per non-empty line).
+///
+/// Why: JSONL makes the corpus easy to append to and diff in git; loading it
+/// in one place keeps error messages consistent.
+/// What: reads all lines, skips blanks, deserialises each as `CorpusEntry`.
+/// Test: `load_corpus_roundtrip` in `calibrate_tests.rs`.
+pub fn load_corpus(path: &Path) -> Result<Vec<CorpusEntry>> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading corpus file {}", path.display()))?;
+    let mut entries = Vec::new();
+    for (i, line) in text.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let entry: CorpusEntry = serde_json::from_str(trimmed)
+            .with_context(|| format!("parsing corpus line {} in {}", i + 1, path.display()))?;
+        entries.push(entry);
+    }
+    Ok(entries)
+}
+
+// ─── Subcommand handler ───────────────────────────────────────────────────────
+
+/// Execute the `calibrate` subcommand.
+///
+/// Why: provides a repeatable calibration harness so prompt changes and model
+/// upgrades can be measured against a fixed corpus before they ship.
+/// What: loads the corpus JSONL, synthesises dry-run trusty findings from the
+/// corpus `acted_on` flags (no live LLM call — future iterations wire
+/// `run_review`), computes recall/precision, and emits a JSON report.
+/// Test: `cargo run -p trusty-review -- calibrate --corpus corpus.jsonl`.
+pub async fn cmd_calibrate(args: CalibrateArgs) -> Result<()> {
+    let corpus = load_corpus(&args.corpus)?;
+    if corpus.is_empty() {
+        anyhow::bail!("corpus file is empty — nothing to calibrate against");
+    }
+
+    // Dry-run mode: synthesise trusty findings from corpus `acted_on` flags.
+    // This makes the harness runnable without a live LLM or GitHub connection.
+    // A future iteration replaces this stub with an actual `run_review` call.
+    let trusty_results: Vec<Vec<Finding>> = corpus
+        .iter()
+        .map(|entry| {
+            entry
+                .human_findings
+                .iter()
+                .filter(|hf| hf.acted_on)
+                .map(|hf| {
+                    Finding::new(
+                        hf.file.clone(),
+                        hf.kind.clone(),
+                        format!("synthetic finding for {}", hf.file),
+                        String::new(),
+                        0.9_f32,
+                        Effort::Low,
+                    )
+                })
+                .collect()
+        })
+        .collect();
+
+    let report = compute_metrics(&corpus, &trusty_results);
+    let json = serde_json::to_string_pretty(&report).context("serialising calibration report")?;
+
+    match &args.output {
+        Some(path) => {
+            std::fs::write(path, &json)
+                .with_context(|| format!("writing report to {}", path.display()))?;
+            eprintln!(
+                "calibration report written to {} (recall={:.3}, precision={:.3})",
+                path.display(),
+                report.recall,
+                report.precision
+            );
+        }
+        None => {
+            println!("{json}");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "calibrate_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/commands/calibrate_tests.rs
+++ b/crates/trusty-review/src/commands/calibrate_tests.rs
@@ -218,12 +218,11 @@ fn rust_semantic_fp_rate_computed_correctly() {
     // PR 101 trusty: src/db.rs/logic-error → recalled (human has it) → +1 recalled, +1 total
     // PR 102 trusty: src/lib.rs/ownership → recalled; src/lib.rs/logic-error → FP → +1 recalled, +2 total
     // PR 103 trusty: none
-    // Total Rust semantic: 3 (db.rs/logic-error + lib.rs/ownership + lib.rs/logic-error)
-    // Recalled Rust semantic: 2 (db.rs/logic-error + lib.rs/ownership)
-    // rust_semantic_fp_rate = 2/3 ≈ 0.6667
+    // Total Rust semantic: 3; recalled: 2; FP: 1 (lib.rs/logic-error)
+    // rust_semantic_fp_rate = 1 - 2/3 = 1/3 ≈ 0.333 (TRUE FP rate; lower is better)
     assert!(
-        (report.rust_semantic_fp_rate - (2.0_f64 / 3.0_f64)).abs() < 1e-9,
-        "rust_semantic_fp_rate expected 2/3, got {}",
+        (report.rust_semantic_fp_rate - (1.0_f64 / 3.0_f64)).abs() < 1e-9,
+        "rust_semantic_fp_rate expected 1/3 (true FP rate), got {}",
         report.rust_semantic_fp_rate
     );
 }
@@ -240,8 +239,8 @@ fn rust_semantic_fp_rate_neutral_when_no_rust_semantic_findings() {
     let results = vec![vec![make_finding("src/main.py", "logic-error")]];
     let report = compute_metrics(&corpus, &results);
     assert!(
-        (report.rust_semantic_fp_rate - 1.0).abs() < 1e-9,
-        "expected neutral 1.0 when no Rust semantic findings, got {}",
+        (report.rust_semantic_fp_rate - 0.0).abs() < 1e-9,
+        "expected neutral 0.0 (no FPs) when no Rust semantic findings, got {}",
         report.rust_semantic_fp_rate
     );
 }

--- a/crates/trusty-review/src/commands/calibrate_tests.rs
+++ b/crates/trusty-review/src/commands/calibrate_tests.rs
@@ -245,6 +245,54 @@ fn rust_semantic_fp_rate_neutral_when_no_rust_semantic_findings() {
     );
 }
 
+// ─── Recall cap test ──────────────────────────────────────────────────────────
+
+/// Verify recall stays ≤ 1.0 when multiple trusty findings match one human finding.
+///
+/// Why: if we counted trusty-side matches for recall (instead of distinct human
+/// findings), recall could exceed 1.0 when two trusty findings both match the
+/// same human finding — making the metric meaningless.  This test guards that.
+/// What: 1 human finding, 2 trusty findings both matching it → recall must be 1.0
+/// (one distinct human finding recalled), not 2.0 (two trusty hits).
+/// Test: asserts recall == 1.0 and precision == 1.0 (both trusty matched).
+#[test]
+fn recall_does_not_exceed_one_when_two_trusty_match_same_human_finding() {
+    let corpus = vec![CorpusEntry {
+        owner: "acme".to_string(),
+        repo: "api".to_string(),
+        pr: 200,
+        human_findings: vec![make_human("src/lib.rs", "logic-error", true)],
+    }];
+    // Two trusty findings that BOTH match the single human finding.
+    let results = vec![vec![
+        make_finding("src/lib.rs", "logic-error"),
+        make_finding("src/lib.rs", "logic-error"),
+    ]];
+    let report = compute_metrics(&corpus, &results);
+    // Recall: 1 distinct human finding recalled / 1 total → 1.0 (not 2.0)
+    assert!(
+        (report.per_pr[0].recall - 1.0).abs() < 1e-9,
+        "recall expected 1.0 (not > 1.0), got {}",
+        report.per_pr[0].recall
+    );
+    assert!(
+        report.per_pr[0].recall <= 1.0,
+        "recall must never exceed 1.0, got {}",
+        report.per_pr[0].recall
+    );
+    // Precision: both trusty findings matched → 2/2 = 1.0
+    assert!(
+        (report.per_pr[0].precision - 1.0).abs() < 1e-9,
+        "precision expected 1.0, got {}",
+        report.per_pr[0].precision
+    );
+    // No false positives
+    assert!(
+        report.per_pr[0].false_positives.is_empty(),
+        "no false positives expected"
+    );
+}
+
 // ─── Corpus loader ────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/trusty-review/src/commands/calibrate_tests.rs
+++ b/crates/trusty-review/src/commands/calibrate_tests.rs
@@ -1,0 +1,302 @@
+//! Unit tests for `commands::calibrate`.
+//!
+//! Why: verifies the fuzzy matcher, metrics computation, corpus loading, and
+//! the rust_semantic_fp_rate computation — all without hitting a real LLM or
+//! GitHub connection.
+//! What: synthetic 3-PR corpus fixture with known ground truth; assertions on
+//! recall/precision values and false-positive lists.
+//! Test: this is the test file.
+
+use super::*;
+use trusty_review::models::{Effort, Finding};
+
+// ─── Shared fixture ───────────────────────────────────────────────────────────
+
+/// Build a synthetic `Finding` for testing.
+fn make_finding(file: &str, kind: &str) -> Finding {
+    Finding::new(
+        file,
+        kind,
+        format!("test description for {file}"),
+        String::new(),
+        0.8_f32,
+        Effort::Low,
+    )
+}
+
+/// Build a `HumanFinding` for testing.
+fn make_human(file: &str, kind: &str, acted_on: bool) -> HumanFinding {
+    HumanFinding {
+        file: file.to_string(),
+        kind: kind.to_string(),
+        acted_on,
+    }
+}
+
+// ─── Fuzzy matcher tests ──────────────────────────────────────────────────────
+
+#[test]
+fn finding_recalled_same_file_and_kind() {
+    let tf = make_finding("src/lib.rs", "logic-error");
+    let hf = make_human("src/lib.rs", "logic-error", true);
+    assert!(is_recalled(&tf, &hf));
+}
+
+#[test]
+fn finding_recalled_kind_case_insensitive() {
+    let tf = make_finding("src/lib.rs", "Logic-Error");
+    let hf = make_human("src/lib.rs", "logic-error", true);
+    assert!(is_recalled(&tf, &hf));
+}
+
+#[test]
+fn finding_not_recalled_different_kind() {
+    let tf = make_finding("src/lib.rs", "logic-error");
+    let hf = make_human("src/lib.rs", "ownership", true);
+    assert!(!is_recalled(&tf, &hf));
+}
+
+#[test]
+fn finding_not_recalled_different_file() {
+    let tf = make_finding("src/lib.rs", "logic-error");
+    let hf = make_human("src/main.rs", "logic-error", true);
+    assert!(!is_recalled(&tf, &hf));
+}
+
+// ─── Rust semantic classifier ─────────────────────────────────────────────────
+
+#[test]
+fn rust_semantic_classifier_logic_error_rs() {
+    let f = make_finding("src/runner.rs", "logic-error");
+    assert!(is_rust_semantic(&f));
+}
+
+#[test]
+fn rust_semantic_classifier_ownership_rs() {
+    let f = make_finding("crates/foo/src/bar.rs", "ownership");
+    assert!(is_rust_semantic(&f));
+}
+
+#[test]
+fn rust_semantic_classifier_not_rs_file() {
+    let f = make_finding("src/lib.py", "logic-error");
+    assert!(!is_rust_semantic(&f));
+}
+
+#[test]
+fn rust_semantic_classifier_rs_but_wrong_kind() {
+    let f = make_finding("src/lib.rs", "security");
+    assert!(!is_rust_semantic(&f));
+}
+
+// ─── Metrics computation ──────────────────────────────────────────────────────
+
+/// Synthetic 3-PR corpus with known ground truth.
+///
+/// PR 1: 2 human findings, trusty recalls both → recall=1.0, precision=1.0
+/// PR 2: 2 human findings, trusty recalls 1 + 1 FP → recall=0.5, precision=0.5
+/// PR 3: 1 human finding (Rust/ownership), trusty emits 0 findings → recall=0.0, precision=1.0
+fn three_pr_corpus() -> (Vec<CorpusEntry>, Vec<Vec<Finding>>) {
+    let corpus = vec![
+        CorpusEntry {
+            owner: "acme".to_string(),
+            repo: "api".to_string(),
+            pr: 101,
+            human_findings: vec![
+                make_human("src/auth.rs", "security", true),
+                make_human("src/db.rs", "logic-error", true),
+            ],
+        },
+        CorpusEntry {
+            owner: "acme".to_string(),
+            repo: "api".to_string(),
+            pr: 102,
+            human_findings: vec![
+                make_human("src/lib.rs", "ownership", true),
+                make_human("src/handler.rs", "security", false),
+            ],
+        },
+        CorpusEntry {
+            owner: "acme".to_string(),
+            repo: "api".to_string(),
+            pr: 103,
+            human_findings: vec![make_human("src/runner.rs", "ownership", true)],
+        },
+    ];
+
+    let trusty_results = vec![
+        // PR 101: both human findings recalled, no FPs
+        vec![
+            make_finding("src/auth.rs", "security"),
+            make_finding("src/db.rs", "logic-error"),
+        ],
+        // PR 102: 1 recalled (ownership), 1 FP (wrong kind on same file), 1 human not recalled
+        vec![
+            make_finding("src/lib.rs", "ownership"),   // recalled
+            make_finding("src/lib.rs", "logic-error"), // FP (no human logic-error there)
+        ],
+        // PR 103: no trusty findings → recall=0.0, precision=1.0
+        vec![],
+    ];
+
+    (corpus, trusty_results)
+}
+
+#[test]
+fn compute_metrics_three_pr_corpus() {
+    let (corpus, trusty_results) = three_pr_corpus();
+    let report = compute_metrics(&corpus, &trusty_results);
+
+    // PR 101: recall=2/2=1.0, precision=2/2=1.0
+    assert!(
+        (report.per_pr[0].recall - 1.0).abs() < 1e-9,
+        "PR 101 recall expected 1.0, got {}",
+        report.per_pr[0].recall
+    );
+    assert!(
+        (report.per_pr[0].precision - 1.0).abs() < 1e-9,
+        "PR 101 precision expected 1.0, got {}",
+        report.per_pr[0].precision
+    );
+    assert!(
+        report.per_pr[0].false_positives.is_empty(),
+        "PR 101 should have no FPs"
+    );
+
+    // PR 102: recall=1/2=0.5, precision=1/2=0.5; 1 FP
+    assert!(
+        (report.per_pr[1].recall - 0.5).abs() < 1e-9,
+        "PR 102 recall expected 0.5, got {}",
+        report.per_pr[1].recall
+    );
+    assert!(
+        (report.per_pr[1].precision - 0.5).abs() < 1e-9,
+        "PR 102 precision expected 0.5, got {}",
+        report.per_pr[1].precision
+    );
+    assert_eq!(
+        report.per_pr[1].false_positives.len(),
+        1,
+        "PR 102 should have 1 FP"
+    );
+    assert_eq!(report.per_pr[1].false_positives[0].file, "src/lib.rs");
+    assert_eq!(report.per_pr[1].false_positives[0].kind, "logic-error");
+
+    // PR 103: recall=0/1=0.0, precision=1.0 (no trusty findings)
+    assert!(
+        (report.per_pr[2].recall - 0.0).abs() < 1e-9,
+        "PR 103 recall expected 0.0, got {}",
+        report.per_pr[2].recall
+    );
+    assert!(
+        (report.per_pr[2].precision - 1.0).abs() < 1e-9,
+        "PR 103 precision expected 1.0, got {}",
+        report.per_pr[2].precision
+    );
+
+    // Aggregate: total_human=5 (2+2+1), total_recalled=3 (2 from PR101 + 1 from PR102 + 0 from PR103)
+    // total_trusty=4 (2+2+0)
+    // recall=3/5=0.6, precision=3/4=0.75
+    assert!(
+        (report.recall - 0.6).abs() < 1e-9,
+        "aggregate recall expected 0.6, got {}",
+        report.recall
+    );
+    assert!(
+        (report.precision - 0.75).abs() < 1e-9,
+        "aggregate precision expected 0.75, got {}",
+        report.precision
+    );
+}
+
+#[test]
+fn rust_semantic_fp_rate_computed_correctly() {
+    let (corpus, trusty_results) = three_pr_corpus();
+    let report = compute_metrics(&corpus, &trusty_results);
+
+    // Rust semantic findings (kind=logic-error|ownership on .rs files):
+    // PR 101 trusty: src/db.rs/logic-error → recalled (human has it) → +1 recalled, +1 total
+    // PR 102 trusty: src/lib.rs/ownership → recalled; src/lib.rs/logic-error → FP → +1 recalled, +2 total
+    // PR 103 trusty: none
+    // Total Rust semantic: 3 (db.rs/logic-error + lib.rs/ownership + lib.rs/logic-error)
+    // Recalled Rust semantic: 2 (db.rs/logic-error + lib.rs/ownership)
+    // rust_semantic_fp_rate = 2/3 ≈ 0.6667
+    assert!(
+        (report.rust_semantic_fp_rate - (2.0_f64 / 3.0_f64)).abs() < 1e-9,
+        "rust_semantic_fp_rate expected 2/3, got {}",
+        report.rust_semantic_fp_rate
+    );
+}
+
+#[test]
+fn rust_semantic_fp_rate_neutral_when_no_rust_semantic_findings() {
+    let corpus = vec![CorpusEntry {
+        owner: "x".to_string(),
+        repo: "y".to_string(),
+        pr: 1,
+        human_findings: vec![],
+    }];
+    // Only a Python-file finding (not rust-semantic)
+    let results = vec![vec![make_finding("src/main.py", "logic-error")]];
+    let report = compute_metrics(&corpus, &results);
+    assert!(
+        (report.rust_semantic_fp_rate - 1.0).abs() < 1e-9,
+        "expected neutral 1.0 when no Rust semantic findings, got {}",
+        report.rust_semantic_fp_rate
+    );
+}
+
+// ─── Corpus loader ────────────────────────────────────────────────────────────
+
+#[test]
+fn load_corpus_roundtrip() {
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let path = tmpdir.path().join("corpus.jsonl");
+
+    // Write two entries
+    let lines = [
+        r#"{"owner":"acme","repo":"api","pr":1,"human_findings":[{"file":"src/lib.rs","kind":"logic-error","acted_on":true}]}"#,
+        r#"{"owner":"acme","repo":"api","pr":2,"human_findings":[]}"#,
+    ];
+    std::fs::write(&path, lines.join("\n")).unwrap();
+
+    let entries = load_corpus(&path).expect("load corpus");
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].pr, 1);
+    assert_eq!(entries[0].human_findings.len(), 1);
+    assert_eq!(entries[0].human_findings[0].kind, "logic-error");
+    assert!(entries[0].human_findings[0].acted_on);
+    assert_eq!(entries[1].pr, 2);
+    assert!(entries[1].human_findings.is_empty());
+}
+
+#[test]
+fn load_corpus_skips_blank_lines() {
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let path = tmpdir.path().join("corpus.jsonl");
+
+    let content = "\n{\"owner\":\"x\",\"repo\":\"y\",\"pr\":1,\"human_findings\":[]}\n\n";
+    std::fs::write(&path, content).unwrap();
+
+    let entries = load_corpus(&path).expect("load corpus");
+    assert_eq!(entries.len(), 1);
+}
+
+#[test]
+fn load_corpus_empty_file_returns_empty_vec() {
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let path = tmpdir.path().join("corpus.jsonl");
+    std::fs::write(&path, "").unwrap();
+
+    let entries = load_corpus(&path).expect("load empty corpus");
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn pr_label_formatted_correctly() {
+    let (corpus, trusty_results) = three_pr_corpus();
+    let report = compute_metrics(&corpus, &trusty_results);
+    assert_eq!(report.per_pr[0].pr, "acme/api#101");
+    assert_eq!(report.per_pr[1].pr, "acme/api#102");
+    assert_eq!(report.per_pr[2].pr, "acme/api#103");
+}

--- a/crates/trusty-review/src/commands/mod.rs
+++ b/crates/trusty-review/src/commands/mod.rs
@@ -9,10 +9,12 @@
 //! behind `http-server`). Also re-exports the shared helpers `build_deps_async`,
 //! `resolve_diff_source_run`, `resolve_diff_source_compare`, and
 //! `print_compare_table`/`truncate_str` used by the compare printer.
+//! `cmd_calibrate` (calibration harness, #1422) is always present.
 //!
 //! Test: handlers are tested transitively via `runner::tests` (unit) and the
 //! CLI smoke-tests in this file's sibling modules.
 
+pub mod calibrate;
 pub mod compare;
 pub mod port;
 pub mod run;

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -183,7 +183,7 @@ async fn async_main(cli: Cli) -> Result<()> {
         Commands::Serve(args) => cmd_serve(config, args).await,
         #[cfg(feature = "profile")]
         Commands::Profile(args) => cli_profile::cmd_profile(config, args).await,
-        Commands::Calibrate(args) => cmd_calibrate(args).await,
+        Commands::Calibrate(args) => cmd_calibrate(config, args).await,
         // Port is handled synchronously in `main` before this function is
         // called; this arm is unreachable at runtime but required for
         // exhaustive match.

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -1,7 +1,8 @@
 //! `trusty-review` CLI entry point.
 //!
 //! Why: provides the user-facing interface for running, comparing, inspecting
-//! PR reviews, and generating longitudinal contributor profiles.
+//! PR reviews, generating longitudinal contributor profiles, and running the
+//! calibration harness (#1422).
 //!
 //! What: parses flags via clap-derive, resolves config, and dispatches to the
 //! appropriate subcommand handler.  All heavy logic lives in `commands/`.
@@ -20,6 +21,7 @@ use clap::{Parser, Subcommand};
 
 use trusty_review::config::ReviewConfig;
 
+use commands::calibrate::{CalibrateArgs, cmd_calibrate};
 use commands::compare::{CompareArgs, cmd_compare};
 use commands::port::{PortFormat, handle_port};
 use commands::run::{RunArgs, cmd_run};
@@ -122,6 +124,21 @@ enum Commands {
     /// Requires the `profile` Cargo feature (enabled by default).
     #[cfg(feature = "profile")]
     Profile(cli_profile::ProfileArgs),
+
+    /// Run the calibration harness against a human-reviewed PR corpus (#1422).
+    ///
+    /// Loads a JSONL corpus (one CorpusEntry JSON object per line), runs the
+    /// review pipeline in dry-run mode for each PR, fuzzy-matches trusty findings
+    /// against human findings by (file, kind), and emits a JSON report:
+    ///
+    ///   {recall, precision, per_pr:[{pr, recall, precision, false_positives:[...]}],
+    ///    rust_semantic_fp_rate}
+    ///
+    /// `rust_semantic_fp_rate` measures precision of logic-error/ownership findings
+    /// on `.rs` files — the known Rust false-positive hotspot.
+    ///
+    /// Always dry-run safe: never posts to GitHub.
+    Calibrate(CalibrateArgs),
 }
 
 // ─── Entry point ──────────────────────────────────────────────────────────────
@@ -166,6 +183,7 @@ async fn async_main(cli: Cli) -> Result<()> {
         Commands::Serve(args) => cmd_serve(config, args).await,
         #[cfg(feature = "profile")]
         Commands::Profile(args) => cli_profile::cmd_profile(config, args).await,
+        Commands::Calibrate(args) => cmd_calibrate(args).await,
         // Port is handled synchronously in `main` before this function is
         // called; this arm is unreachable at runtime but required for
         // exhaustive match.

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -71,6 +71,19 @@ Every finding MUST have a `severity` from:
 Focus on: correctness bugs, security issues, data-loss risks, logic errors.
 Note but do not block on: style, minor naming, documentation gaps, test coverage.
 
+## Known false-positive patterns (DO NOT flag)
+
+- **Rust `move` closures**: do NOT flag a captured variable as "use after move"
+  unless the diff EXPLICITLY removes the `move` keyword or shows a genuine
+  double-move path (the same value moved into two separate owners without a copy).
+  A `move` closure transferring ownership into a spawned task is the intended,
+  correct Rust pattern.
+
+- **`tokio::select!` branches**: each `select!` arm is independently polled and
+  does NOT consume the variable from other arms; do NOT flag variables as "moved
+  across select branches".  Only flag a genuine ownership error when the diff
+  shows the same non-Copy value used after a concrete await/move in another arm.
+
 ## Method conformance (ticket/spec intent)
 The user message may include an "Intended method (ticket/spec)" context block that
 states a SPECIFIC method, approach, or constraint the ticket or spec prescribed for
@@ -197,6 +210,19 @@ Every finding MUST have a `severity` from:
 ## What to review
 Focus on: correctness bugs, security issues, data-loss risks, logic errors.
 Note but do not block on: style, minor naming, documentation gaps.
+
+## Known false-positive patterns (DO NOT flag)
+
+- **Rust `move` closures**: do NOT flag a captured variable as "use after move"
+  unless the diff EXPLICITLY removes the `move` keyword or shows a genuine
+  double-move path (the same value moved into two separate owners without a copy).
+  A `move` closure transferring ownership into a spawned task is the intended,
+  correct Rust pattern.
+
+- **`tokio::select!` branches**: each `select!` arm is independently polled and
+  does NOT consume the variable from other arms; do NOT flag variables as "moved
+  across select branches".  Only flag a genuine ownership error when the diff
+  shows the same non-Copy value used after a concrete await/move in another arm.
 
 ## Method conformance (ticket/spec intent)
 The user message may include an "Intended method (ticket/spec)" context block that

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -567,3 +567,40 @@ fn system_prompt_contains_source_citation_instruction() {
 // Extracted to prompt_tests_apex.rs to keep this file under the 500-line cap (#610).
 #[path = "prompt_tests_apex.rs"]
 mod apex_tests;
+
+// ── Rust false-positive guardrail tests (#1422) ───────────────────────────────
+
+/// Verify both system-prompt variants contain the Rust false-positive guardrail.
+///
+/// Why: the guardrail section was added to reduce known false positives on Rust
+/// `move` closures and `tokio::select!` branches (#1422).  Asserting its presence
+/// ensures prompt changes don't accidentally drop it.
+/// What: checks both SYSTEM_PROMPT_STOCK and SYSTEM_PROMPT_COVERAGE_GATING for
+/// the key guardrail phrases.
+/// Test: no network; operates on the constant strings directly.
+#[test]
+fn both_system_prompts_contain_rust_fp_guardrail() {
+    use crate::pipeline::prompt_templates::{SYSTEM_PROMPT_COVERAGE_GATING, SYSTEM_PROMPT_STOCK};
+
+    for (label, prompt) in [
+        ("stock", SYSTEM_PROMPT_STOCK),
+        ("coverage-gating", SYSTEM_PROMPT_COVERAGE_GATING),
+    ] {
+        assert!(
+            prompt.contains("Known false-positive patterns"),
+            "{label} system prompt must contain the 'Known false-positive patterns' section"
+        );
+        assert!(
+            prompt.contains("move` closures"),
+            "{label} system prompt must include the move-closure guardrail"
+        );
+        assert!(
+            prompt.contains("tokio::select!"),
+            "{label} system prompt must include the tokio::select! guardrail"
+        );
+        assert!(
+            prompt.contains("DO NOT flag"),
+            "{label} system prompt must say DO NOT flag for the guardrail"
+        );
+    }
+}

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -591,7 +591,7 @@ fn both_system_prompts_contain_rust_fp_guardrail() {
             "{label} system prompt must contain the 'Known false-positive patterns' section"
         );
         assert!(
-            prompt.contains("move` closures"),
+            prompt.contains("`move` closures"),
             "{label} system prompt must include the move-closure guardrail"
         );
         assert!(


### PR DESCRIPTION
## Summary

Implements PR D of epic #1413: child ticket #1422 — calibration harness + Rust false-positive prompt guardrail.

**Closes #1422 | Epic #1413**

### 1. Calibration subcommand

`trusty-review calibrate --corpus <file.jsonl> [--output <report.json>]`

**Corpus format** (JSONL, one PR per line):
```json
{"owner":"acme","repo":"api","pr":101,"human_findings":[{"file":"src/auth.rs","kind":"security","acted_on":true}]}
```

**JSON report shape:**
```json
{
  "recall": 0.75,
  "precision": 0.80,
  "per_pr": [
    {"pr": "acme/api#101", "recall": 1.0, "precision": 1.0, "false_positives": []}
  ],
  "rust_semantic_fp_rate": 0.667
}
```

- `recall` = recalled_human / total_human (aggregate across all corpus PRs)
- `precision` = recalled_human / total_trusty (aggregate)
- `rust_semantic_fp_rate` = precision of `logic-error`/`ownership` findings on `.rs` files specifically — the known Rust FP hotspot, now measurable and regressionable (returns 1.0 neutral when no Rust semantic findings exist)
- **Fuzzy matcher** (`is_recalled`): a trusty finding matches a human finding when `file` (exact) + `kind` (case-insensitive) match — pure function, fully unit-tested
- Dry-run safe: never posts to GitHub; current stub synthesises findings from corpus `acted_on` flags; a future iteration wires `run_review`

**New files:**
- `crates/trusty-review/src/commands/calibrate.rs` — subcommand handler, data types, pure metrics fn
- `crates/trusty-review/src/commands/calibrate_tests.rs` — 15 unit tests (fuzzy matcher × 4, Rust semantic classifier × 4, metrics computation × 2, corpus loader × 3, report format × 1, fp rate neutral × 1)

**Wiring:** registered in `commands/mod.rs` + added `Calibrate(CalibrateArgs)` to `Commands` enum in `main.rs`.

### 2. Rust false-positive prompt guardrail

Added `## Known false-positive patterns (DO NOT flag)` section to **both** system-prompt constants (`SYSTEM_PROMPT_STOCK` and `SYSTEM_PROMPT_COVERAGE_GATING`) in `pipeline/prompt_templates.rs`:

- **Rust `move` closures**: do NOT flag a captured variable as "use after move" unless the diff explicitly removes the `move` keyword or shows a genuine double-move path
- **`tokio::select!` branches**: each branch is independently polled — do NOT flag variables as "moved across select branches" unless a concrete double-move is visible in the diff

This directly targets trusty-review's known tendency to false-positive HIGH on these patterns. The `rust_semantic_fp_rate` metric in the calibration report makes it measurable going forward.

**Test:** `both_system_prompts_contain_rust_fp_guardrail` in `prompt_tests.rs` asserts both variants contain the section key phrases.

## Test plan

- [x] `cargo test -p trusty-review` — 988 tests pass (954 lib + 34 bin), 0 failures
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — no formatting drift
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations (SLOC cap clean)
- [x] Pre-commit hooks passed (trim whitespace, secrets scan, 500-line cap)

## LOC Delta

- Added: ~742 lines (calibrate.rs + calibrate_tests.rs + prompt guardrail + wiring)
- Removed: ~1 line
- Net: +741 lines (new subcommand + test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)