### PR TITLE
fix(trusty-agents): de-flake run_sanitizes_finish_task_from_cli_args temp-file collision (closes #1634)

### DIFF
--- a/crates/trusty-agents/src/agents/claude_code_runner/mod.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/mod.rs
@@ -205,3 +205,56 @@ fn candidate_exists(dir: &Path, name: &str) -> bool {
     let p = dir.join(name);
     p.is_file()
 }
+
+/// Spawn a freshly-built `Command`, retrying on ETXTBSY (os error 26).
+///
+/// Why: `execve` can fail with `ETXTBSY` ("Text file busy") when the kernel
+/// still considers the target inode open-for-write — e.g. when a just-written,
+/// just-chmod'd script is exec'd before the page-cache flush settles. This is
+/// the same race #1528 fixed for the test-only `spawn_script` helper, but the
+/// production runner's `cmd.spawn()` lacked the guard, so the flaky test
+/// `run_sanitizes_finish_task_from_cli_args` (#1634) — whose mock `claude`
+/// script is exec'd through THIS path — still intermittently hit ETXTBSY under
+/// concurrent `cargo test` load. Retrying here de-flakes the test and hardens
+/// the real `claude` CLI spawn against the same transient kernel state.
+/// What: Calls `build()` to obtain a fresh `Command` on each attempt (required
+/// because `Command` is not `Clone`) and `.spawn()`s it. On `ETXTBSY` it backs
+/// off with a short exponential delay (≤3 attempts, 5 ms base) and retries; any
+/// other error, or the success path, returns immediately. The bound keeps real
+/// failures (missing binary, permission denied) from being masked or delayed.
+/// Test: Exercised by every claude-code-runner spawn test, in particular
+/// `run_sanitizes_finish_task_from_cli_args`, which was order-/load-dependent
+/// before this retry was added.
+pub(crate) async fn spawn_with_etxtbsy_retry<F>(
+    mut build: F,
+) -> std::io::Result<tokio::process::Child>
+where
+    F: FnMut() -> Command,
+{
+    const MAX_ATTEMPTS: u32 = 3;
+    const BACKOFF_MS: u64 = 5;
+
+    let mut last_err: Option<std::io::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match build().spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    BACKOFF_MS * (1 << attempt),
+                ))
+                .await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    // Unreachable in practice: the loop only falls through after recording an
+    // ETXTBSY error, so `last_err` is always `Some`. Construct a defensive
+    // fallback rather than panicking.
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::ExecutableFileBusy,
+            "spawn retries exhausted",
+        )
+    }))
+}

--- a/crates/trusty-agents/src/agents/claude_code_runner/run.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/run.rs
@@ -146,77 +146,88 @@ impl ClaudeCodeAgentRunner {
             Self::prepend_harness_layers(&cfg.system_prompt.content, cfg.llm.use_finish_task);
         let sanitized_system = Self::strip_finish_task_instructions(&composed_system);
 
-        let mut cmd = Command::new(&self.claude_bin);
-        cmd.args([
-            "-p",
-            &sanitized_task,
-            "--model",
-            &model,
-            "--system-prompt",
-            &sanitized_system,
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--dangerously-skip-permissions",
-            "--max-turns",
-            &max_turns,
-        ])
-        .stdout(Stdio::piped())
-        // #268: Sub-agent `claude` CLI subprocesses must not bleed their own
-        // tracing/log output to the parent's TTY. The parent REPL routes its
-        // own tracing to `~/.trusty-agents/logs/repl.log` when stdin is a TTY, but
-        // sub-agent processes detect a non-TTY stdin and default to stderr —
-        // which the parent inherits, so log lines clobber the carefully
-        // positioned chat scrollback.
-        // Detection: when the parent's stdin is a TTY, this is an interactive
-        // REPL session and sub-agent stderr must be silenced. When the parent
-        // is non-interactive (CI, piped input, --workflow, --api), inherit
-        // stderr so existing log-capture tooling continues to work.
-        .stderr(if crate::repl::is_tty() {
-            Stdio::null()
-        } else {
-            Stdio::inherit()
-        });
+        // Build the command inside a closure so the ETXTBSY retry wrapper can
+        // reconstruct it on each attempt (`Command` is not `Clone`). See
+        // `spawn_with_etxtbsy_retry` for why the retry exists (#1634 / #1528).
+        let build_cmd = || {
+            let mut cmd = Command::new(&self.claude_bin);
+            cmd.args([
+                "-p",
+                &sanitized_task,
+                "--model",
+                &model,
+                "--system-prompt",
+                &sanitized_system,
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--dangerously-skip-permissions",
+                "--max-turns",
+                &max_turns,
+            ])
+            .stdout(Stdio::piped())
+            // #268: Sub-agent `claude` CLI subprocesses must not bleed their own
+            // tracing/log output to the parent's TTY. The parent REPL routes its
+            // own tracing to `~/.trusty-agents/logs/repl.log` when stdin is a TTY, but
+            // sub-agent processes detect a non-TTY stdin and default to stderr —
+            // which the parent inherits, so log lines clobber the carefully
+            // positioned chat scrollback.
+            // Detection: when the parent's stdin is a TTY, this is an interactive
+            // REPL session and sub-agent stderr must be silenced. When the parent
+            // is non-interactive (CI, piped input, --workflow, --api), inherit
+            // stderr so existing log-capture tooling continues to work.
+            .stderr(if crate::repl::is_tty() {
+                Stdio::null()
+            } else {
+                Stdio::inherit()
+            });
 
-        if let Some(wd) = &ctx.working_dir {
-            cmd.current_dir(wd);
-            // #159: The `claude` CLI anchors write paths to the git root, not
-            // the subprocess CWD. Passing `--add-dir` scopes the claude
-            // session to the designated output directory so file writes land
-            // in `out_dir` rather than the repo root.
-            cmd.arg("--add-dir").arg(wd);
-        }
-        // Pass --allowedTools if the agent config restricts claude CLI tools.
-        // Why: Research agents should not write files or run shell — only
-        // WebSearch/WebFetch. Empty vec (default) means no restriction.
-        if !cfg.llm.claude_allowed_tools.is_empty() {
-            cmd.arg("--allowedTools")
-                .arg(cfg.llm.claude_allowed_tools.join(","));
-        }
-        if let Some(path) = &ctx.assigned_file {
-            cmd.env("TAGENT_ASSIGNED_FILE", path);
-        }
-        // Mark this claude CLI invocation as an MPM-spawned sub-agent so the
-        // `trusty-mpm hook` command wired into its Claude Code settings
-        // short-circuits. Without this guard a nested claude session would
-        // re-emit PreToolUse / PostToolUse events (doubling the daemon's
-        // audit feed). The memory enrichment hook (`trusty-memory
-        // prompt-context`) deliberately does NOT guard on this variable —
-        // sub-agents benefit from the parent palace's prompt-fact block as
-        // much as the PM does. The variable name is sourced from
-        // `trusty_common::claude_config::CLAUDE_MPM_SUB_AGENT_ENV_VAR` so
-        // every spawn site and consumer references the same literal.
-        cmd.env(
-            trusty_common::claude_config::CLAUDE_MPM_SUB_AGENT_ENV_VAR,
-            "1",
-        );
+            if let Some(wd) = &ctx.working_dir {
+                cmd.current_dir(wd);
+                // #159: The `claude` CLI anchors write paths to the git root,
+                // not the subprocess CWD. Passing `--add-dir` scopes the claude
+                // session to the designated output directory so file writes land
+                // in `out_dir` rather than the repo root.
+                cmd.arg("--add-dir").arg(wd);
+            }
+            // Pass --allowedTools if the agent config restricts claude CLI tools.
+            // Why: Research agents should not write files or run shell — only
+            // WebSearch/WebFetch. Empty vec (default) means no restriction.
+            if !cfg.llm.claude_allowed_tools.is_empty() {
+                cmd.arg("--allowedTools")
+                    .arg(cfg.llm.claude_allowed_tools.join(","));
+            }
+            if let Some(path) = &ctx.assigned_file {
+                cmd.env("TAGENT_ASSIGNED_FILE", path);
+            }
+            // Mark this claude CLI invocation as an MPM-spawned sub-agent so the
+            // `trusty-mpm hook` command wired into its Claude Code settings
+            // short-circuits. Without this guard a nested claude session would
+            // re-emit PreToolUse / PostToolUse events (doubling the daemon's
+            // audit feed). The memory enrichment hook (`trusty-memory
+            // prompt-context`) deliberately does NOT guard on this variable —
+            // sub-agents benefit from the parent palace's prompt-fact block as
+            // much as the PM does. The variable name is sourced from
+            // `trusty_common::claude_config::CLAUDE_MPM_SUB_AGENT_ENV_VAR` so
+            // every spawn site and consumer references the same literal.
+            cmd.env(
+                trusty_common::claude_config::CLAUDE_MPM_SUB_AGENT_ENV_VAR,
+                "1",
+            );
+            cmd
+        };
 
-        let mut child = cmd.spawn().with_context(|| {
-            format!(
-                "failed to spawn claude CLI at {}",
-                self.claude_bin.display()
-            )
-        })?;
+        // Spawn with a bounded ETXTBSY retry (#1634): freshly written, just
+        // chmod'd mock scripts (and the real `claude` CLI under load) can
+        // transiently return "Text file busy" from `execve`.
+        let mut child = super::spawn_with_etxtbsy_retry(build_cmd)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to spawn claude CLI at {}",
+                    self.claude_bin.display()
+                )
+            })?;
 
         // #283 follow-up: latency instrumentation. Record spawn-to-ready
         // wall-clock so we can distinguish "CLI took forever to start" from


### PR DESCRIPTION
## Summary

De-flakes the intermittently-failing test `run_sanitizes_finish_task_from_cli_args`
in `trusty-agents`, which sporadically failed with **`Text file busy` (ETXTBSY,
os error 26)**.

Closes #1634.

## Root cause

The test writes its mock `claude` shell script via
`test_env::write_executable_script` (open → write → flush → **drop fd** → chmod),
which correctly closes the writer fd before exec — the #1528 pattern. But the
*actual* `execve` happens through the **production** spawn path
(`claude_code_runner/run.rs` → `cmd.spawn()`), which — unlike the test-only
`test_env::spawn_script` helper added in #1528 — had **no ETXTBSY bounded retry**.

Under concurrent `cargo test` load the kernel can still return `ETXTBSY` when the
page-cache flush of the freshly written+chmod'd inode races with the `execve`, so
the production spawn occasionally failed even though the test prepared the file
safely. This is the same class of bug as #1528 and mirrors the "apply an existing
isolation/hardening pattern to a code path that lacks it" shape of #1624.

## Fix

- Add `spawn_with_etxtbsy_retry` (production helper in `claude_code_runner/mod.rs`):
  spawns a freshly-built `Command`, retrying on `ETXTBSY` with a short bounded
  exponential back-off (≤3 attempts, 5 ms base). Any other error returns
  immediately so real failures (missing binary, permission denied) are never
  masked. This mirrors the test-only `spawn_script` retry from #1528.
- Refactor the `run.rs` spawn site to build the `Command` inside a closure (so the
  retry can reconstruct it each attempt — `Command` is not `Clone`) and route the
  spawn through the new helper.

This de-flakes the test **and** hardens the real `claude` CLI spawn against the
same transient kernel state.

## Verification (raw output)

De-flake loop — target test 10×:

```
SUMMARY over 10 runs: target_test_passed=10  text_file_busy=0  any_FAILED=0
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1827 filtered out; ...   (×10)
```

Full crate suite:

```
$ cargo test -p trusty-agents
test result: ok. 1821 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
(+ integration test binaries: all ok, 0 failed)
```

- `cargo clippy -p trusty-agents --all-targets -- -D warnings` — exit 0, zero warnings
- `cargo fmt --check` — exit 0, no drift
- `bash scripts/check_line_cap.sh` — `14 allowlisted, 0 violations — OK`

## LOC Delta

- Added: ~134 lines (retry helper + doc comments + closure scaffolding)
- Removed: ~70 lines (the inline command-build/spawn it replaced)
- Net: +64 lines (production hardening + Why/What/Test docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
