### PR TITLE
feat(trusty-mpm): orphan-GC PID registry + PR A nits (#1595)

### DIFF
--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -43,6 +43,7 @@ pub mod output_style_deployer;
 pub mod overseer;
 pub mod overseer_config;
 pub mod paths;
+pub mod pid_registry;
 pub mod process;
 pub mod project;
 pub mod project_discovery;

--- a/crates/trusty-mpm/src/core/pid_registry.rs
+++ b/crates/trusty-mpm/src/core/pid_registry.rs
@@ -142,8 +142,9 @@ pub struct PidEntry {
 /// 2. process not alive → [`PidDecision::RemoveStale`]`(ProcessDead)`; else
 /// 3. process alive but not named `claude` → [`PidDecision::RemoveStale`]`(PidReused)`; else
 /// 4. untracked, alive, still `claude` → [`PidDecision::Terminate`].
+///
 /// Test: `classify_keeps_tracked`, `classify_removes_dead`,
-/// `classify_removes_reused_pid`, `classify_terminates_untracked_claude`.
+/// `classify_removes_reused_pid`, and `classify_terminates_untracked_claude`.
 pub fn classify_pidfile(
     entry: &PidEntry,
     live_session_ids: &HashSet<String>,
@@ -257,9 +258,7 @@ impl PidRegistry {
         std::fs::create_dir_all(&self.dir)?;
         let final_path = self.pid_path(session_id);
         // Atomic write: stage in a temp sibling, then rename over the target.
-        let tmp_path = self
-            .dir
-            .join(format!(".{session_id}.{PID_FILE_EXT}.tmp"));
+        let tmp_path = self.dir.join(format!(".{session_id}.{PID_FILE_EXT}.tmp"));
         std::fs::write(&tmp_path, pid.to_string())?;
         std::fs::rename(&tmp_path, &final_path)?;
         debug!(session_id, pid, "pid-registry: registered");
@@ -662,7 +661,14 @@ mod tests {
         reg.register("tracked", 9).unwrap();
         let probe = FakeProbe::new(&[9], &[9]);
         let outcome = reg.sweep_orphans(&live(&["tracked"]), &probe);
-        assert_eq!(outcome, SweepOutcome { scanned: 1, terminated: 0, removed_stale: 0 });
+        assert_eq!(
+            outcome,
+            SweepOutcome {
+                scanned: 1,
+                terminated: 0,
+                removed_stale: 0
+            }
+        );
         assert_eq!(reg.entries().unwrap(), vec![entry("tracked", 9)]);
     }
 }

--- a/crates/trusty-mpm/src/core/pid_registry.rs
+++ b/crates/trusty-mpm/src/core/pid_registry.rs
@@ -1,0 +1,668 @@
+//! On-disk PID-file registry for daemon-owned `claude` child processes.
+//!
+//! Why: a tmux session can vanish (or a daemon can crash with `kill -9`) while
+//! the `claude` process it launched keeps running, reparented to PID 1. The
+//! name-scanning orphan-GC (`crate::daemon::orphan_gc`) reconciles *tmux
+//! sessions* against the registries, but it cannot see a `claude` process whose
+//! tmux pane is already gone — that process is invisible to `tmux ls`. The spec
+//! (DOC-26 §10.3) closes that gap with a PID-file registry: at spawn the daemon
+//! writes the child PID to `~/.trusty-mpm/pids/<session-id>.pid`; a restarted
+//! daemon reads every `.pid` file, cross-references the live session registry,
+//! and SIGTERMs any PID whose session-id is no longer tracked. Tying each PID to
+//! a specific session-id (rather than scanning `/proc/*/comm` for "claude") is
+//! unambiguous: it never matches an unrelated user-launched `claude`, and it
+//! survives PID-1 reparenting.
+//!
+//! What: [`PidRegistry`] is a thin handle over the `pids/` directory.
+//! [`register`](PidRegistry::register) writes (atomically, before `spawn`
+//! returns — the §10.3 invariant) a `<session-id>.pid` file;
+//! [`unregister`](PidRegistry::unregister) removes it on normal termination;
+//! [`entries`](PidRegistry::entries) enumerates `(session_id, pid)` pairs; and
+//! [`sweep_orphans`](PidRegistry::sweep_orphans) is the GC pass — for every PID
+//! file whose session-id is NOT in the live set it verifies (via the injected
+//! [`ProcessProbe`]) that the process is still alive AND still named `claude`
+//! before sending SIGTERM, then removes the file. Mismatches and dead PIDs are
+//! removed WITHOUT signalling (stale or PID-reused — see §13.5).
+//!
+//! Safety: the name-verification gate is the alpha-1 mitigation for the PID-reuse
+//! race (§13.5, accepted limitation). It reduces — but does not eliminate — the
+//! chance of SIGTERMing a recycled PID. Every decision is a pure function of the
+//! probe's answer, so the full matrix is unit-testable with a fake probe and a
+//! `tempfile` directory; no real process is ever signalled in tests.
+//!
+//! Test: the `tests` submodule exercises register/unregister/entries round-trips
+//! and the full [`classify_pidfile`] decision matrix against a fake probe and a
+//! temp directory.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use tracing::{debug, info, warn};
+
+/// File-extension marker for PID files in the registry directory.
+const PID_FILE_EXT: &str = "pid";
+
+/// A liveness + identity probe over an OS process, abstracted for testing.
+///
+/// Why: the orphan sweep must answer two questions about a recorded PID — "is it
+/// still alive?" and "is it still a `claude` process?" — both of which poke the
+/// real OS. Abstracting them behind a trait keeps [`classify_pidfile`] a pure
+/// decision function and lets tests inject deterministic answers instead of
+/// spawning (and signalling) real processes.
+/// What: two methods — [`is_alive`](ProcessProbe::is_alive) and
+/// [`is_claude`](ProcessProbe::is_claude) — plus a [`terminate`](ProcessProbe::terminate)
+/// action seam so the sweep's SIGTERM is also test-observable. The production
+/// impl ([`OsProcessProbe`]) delegates to `crate::core::process`.
+/// Test: [`FakeProbe`] in the `tests` submodule drives the decision matrix.
+pub trait ProcessProbe {
+    /// True if a process with this PID currently exists.
+    ///
+    /// Why: a dead PID's file is stale and must be removed without signalling.
+    /// What: existence check (e.g. `kill(pid, 0)`).
+    /// Test: `FakeProbe` returns a canned answer.
+    fn is_alive(&self, pid: u32) -> bool;
+
+    /// True if the process at this PID is (still) named `claude`.
+    ///
+    /// Why: the alpha-1 PID-reuse mitigation (§13.5) — before SIGTERMing an
+    /// orphan we confirm the PID still refers to a `claude` process, so a
+    /// recycled PID assigned to an unrelated process is spared.
+    /// What: command-name check (e.g. `/proc/<pid>/comm` or `ps -o comm=`).
+    /// Test: `FakeProbe` returns a canned answer.
+    fn is_claude(&self, pid: u32) -> bool;
+
+    /// Send SIGTERM to the process at this PID; returns whether it was delivered.
+    ///
+    /// Why: making the kill an explicit trait method keeps the sweep pure-ish and
+    /// lets tests assert exactly which PIDs were signalled without a real kill.
+    /// What: best-effort SIGTERM; `false` if the signal could not be delivered
+    /// (e.g. the process exited between the check and the signal — a benign race).
+    /// Test: `FakeProbe` records the PID and reports success.
+    fn terminate(&self, pid: u32) -> bool;
+}
+
+/// The verdict for a single `.pid` file during an orphan sweep.
+///
+/// Why: separating the decision from the file-system action makes the
+/// safety-critical SIGTERM rule unit-testable and gives the sweep a clear,
+/// auditable per-file outcome to log.
+/// What: one variant per outcome — keep (session still tracked), terminate
+/// (untracked, alive, still `claude` → SIGTERM + remove the file), or remove the
+/// stale file without signalling (untracked but dead, or the PID was reused by a
+/// non-`claude` process).
+/// Test: `classify_*` unit tests assert the variant for each input class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PidDecision {
+    /// The session-id is still in the live registry — leave the PID file alone.
+    Keep,
+    /// Untracked, alive, and still a `claude` process → SIGTERM, then remove.
+    Terminate,
+    /// Untracked but dead, or alive under a reused (non-`claude`) PID → remove
+    /// the stale file without signalling. Carries why, for the audit log.
+    RemoveStale(StaleReason),
+}
+
+/// Why a `.pid` file was removed without sending a signal.
+///
+/// Why: a single `RemoveStale` would lose the audit trail; recording the reason
+/// lets the sweep log explain itself and lets tests assert the precise gate.
+/// What: the mutually-exclusive reasons a stale file is dropped silently.
+/// Test: asserted by `classify_removes_dead`, `classify_removes_reused_pid`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaleReason {
+    /// No process exists at the recorded PID — the child already exited.
+    ProcessDead,
+    /// A process exists at the PID but is no longer named `claude` (PID reused).
+    PidReused,
+}
+
+/// One parsed `.pid` file: a session-id and the PID it recorded.
+///
+/// Why: the sweep reasons about plain data — the file's stem (session-id) and
+/// its contents (PID) — so parsing is separated from the decision logic.
+/// What: the `<session-id>` parsed from the file name and the `pid` read from
+/// its body.
+/// Test: built throughout the `tests` submodule and by [`PidRegistry::entries`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PidEntry {
+    /// The session-id (the `.pid` file's stem).
+    pub session_id: String,
+    /// The recorded OS process id.
+    pub pid: u32,
+}
+
+/// Decide what to do with one PID-file entry — the heart of the sweep (pure).
+///
+/// Why: this is the one place the PID-reuse mitigation (§13.5) lives, so it can
+/// be audited and unit-tested exhaustively. A bug here risks SIGTERMing the wrong
+/// process, so the rule is conservative: signal ONLY a still-alive, still-named-
+/// `claude`, genuinely-untracked PID.
+/// What: a [`PidDecision`] computed as —
+/// 1. session-id present in `live_session_ids` → [`PidDecision::Keep`]; else
+/// 2. process not alive → [`PidDecision::RemoveStale`]`(ProcessDead)`; else
+/// 3. process alive but not named `claude` → [`PidDecision::RemoveStale`]`(PidReused)`; else
+/// 4. untracked, alive, still `claude` → [`PidDecision::Terminate`].
+/// Test: `classify_keeps_tracked`, `classify_removes_dead`,
+/// `classify_removes_reused_pid`, `classify_terminates_untracked_claude`.
+pub fn classify_pidfile(
+    entry: &PidEntry,
+    live_session_ids: &HashSet<String>,
+    probe: &dyn ProcessProbe,
+) -> PidDecision {
+    // Gate 1: still tracked → never touch (the common, safe case).
+    if live_session_ids.contains(&entry.session_id) {
+        return PidDecision::Keep;
+    }
+    // Gate 2: dead PID → the file is stale; drop it without signalling.
+    if !probe.is_alive(entry.pid) {
+        return PidDecision::RemoveStale(StaleReason::ProcessDead);
+    }
+    // Gate 3: alive but not `claude` → PID was reused; spare it (§13.5).
+    if !probe.is_claude(entry.pid) {
+        return PidDecision::RemoveStale(StaleReason::PidReused);
+    }
+    // All gates passed: an untracked, live, genuine `claude` orphan.
+    PidDecision::Terminate
+}
+
+/// Outcome counts from one [`PidRegistry::sweep_orphans`] pass.
+///
+/// Why: the daemon's GC loop logs a per-pass summary and `GET /health` may
+/// surface orphan-GC activity (§10.3); returning structured counts keeps the
+/// caller free of any file-system detail.
+/// What: how many PID files were scanned, terminated (SIGTERM sent), and removed
+/// as stale (no signal).
+/// Test: asserted by `sweep_terminates_only_untracked_claude` and siblings.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SweepOutcome {
+    /// Total `.pid` files examined this pass.
+    pub scanned: usize,
+    /// PIDs that were SIGTERMed (untracked, alive, still `claude`).
+    pub terminated: usize,
+    /// Stale PID files removed without signalling (dead PID or reused PID).
+    pub removed_stale: usize,
+}
+
+/// A handle over the `~/.trusty-mpm/pids/` PID-file directory.
+///
+/// Why: every caller (the spawn path, the session-drop path, the GC loop) needs
+/// a single, consistent answer for "where do PID files live and how are they
+/// named?". Wrapping the directory in one type keeps that convention in one place
+/// and makes the whole registry hermetically testable by pointing `dir` at a
+/// `tempfile::TempDir`.
+/// What: holds the absolute `pids/` directory path. The directory is created
+/// lazily on first [`register`](Self::register). File names are
+/// `<session-id>.pid`; bodies are the decimal PID.
+/// Test: the `tests` submodule constructs a registry under a temp dir.
+#[derive(Debug, Clone)]
+pub struct PidRegistry {
+    /// Absolute path of the `pids/` directory.
+    dir: PathBuf,
+}
+
+impl PidRegistry {
+    /// Build a registry rooted at an explicit `pids/` directory.
+    ///
+    /// Why: tests must point the registry at a temp dir, and the daemon resolves
+    /// the directory from its framework root — both want to supply the path
+    /// directly rather than re-derive the home directory.
+    /// What: stores `dir` verbatim (created lazily on first write).
+    /// Test: used throughout the `tests` submodule.
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// Build the registry under a framework base directory (`<base>/pids`).
+    ///
+    /// Why: production callers hold a framework root (`~/.trusty-mpm`) and want
+    /// the canonical `pids/` subdirectory without hard-coding the join at each
+    /// call site (the same drift the `paths` module guards against).
+    /// What: joins `<base>/pids` and delegates to [`new`](Self::new).
+    /// Test: `under_nests_pids_subdir`.
+    pub fn under(base: impl AsRef<Path>) -> Self {
+        Self::new(base.as_ref().join("pids"))
+    }
+
+    /// The `pids/` directory this registry manages.
+    ///
+    /// Why: callers (and tests) occasionally need to inspect the directory path.
+    /// What: returns the stored directory.
+    /// Test: `under_nests_pids_subdir`.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Path of the `.pid` file for a given session-id.
+    ///
+    /// Why: register / unregister / classify all need the same file name; one
+    /// helper keeps the `<session-id>.pid` convention authoritative.
+    /// What: `<dir>/<session_id>.pid`.
+    /// Test: exercised by `register_then_entries_round_trip`.
+    fn pid_path(&self, session_id: &str) -> PathBuf {
+        self.dir.join(format!("{session_id}.{PID_FILE_EXT}"))
+    }
+
+    /// Record `pid` for `session_id`, writing the PID file atomically.
+    ///
+    /// Why: §10.3 requires the PID file to exist BEFORE `spawn()` returns, so a
+    /// crash immediately after spawn never leaves an orphan with no PID file.
+    /// Writing it here (rather than letting the child write its own) keeps the
+    /// daemon the single authority. The write is atomic (temp file + rename) so a
+    /// concurrent sweep never reads a half-written PID.
+    /// What: creates the `pids/` directory if needed, writes the decimal PID to a
+    /// sibling `.<session_id>.pid.tmp` file, then renames it over the final path.
+    /// Returns an `io::Error` if the directory or file cannot be written.
+    /// Test: `register_then_entries_round_trip`, `register_is_idempotent`.
+    pub fn register(&self, session_id: &str, pid: u32) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.dir)?;
+        let final_path = self.pid_path(session_id);
+        // Atomic write: stage in a temp sibling, then rename over the target.
+        let tmp_path = self
+            .dir
+            .join(format!(".{session_id}.{PID_FILE_EXT}.tmp"));
+        std::fs::write(&tmp_path, pid.to_string())?;
+        std::fs::rename(&tmp_path, &final_path)?;
+        debug!(session_id, pid, "pid-registry: registered");
+        Ok(())
+    }
+
+    /// Remove the PID file for `session_id` on normal termination.
+    ///
+    /// Why: the Drop / decommission path must clear the PID file so a future
+    /// sweep does not treat a cleanly-stopped session as an orphan. A missing
+    /// file is not an error — the session may never have had a PID recorded.
+    /// What: deletes `<session_id>.pid`, treating `NotFound` as success.
+    /// Test: `unregister_removes_file`, `unregister_missing_is_ok`.
+    pub fn unregister(&self, session_id: &str) -> std::io::Result<()> {
+        let path = self.pid_path(session_id);
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                debug!(session_id, "pid-registry: unregistered");
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Enumerate every `(session_id, pid)` pair currently on disk.
+    ///
+    /// Why: the sweep needs the full set of recorded PIDs to reconcile against
+    /// the live session registry. A missing directory means nothing was ever
+    /// registered → an empty list (not an error).
+    /// What: reads `<dir>/*.pid`, parsing each file's stem as the session-id and
+    /// its body as a `u32` PID. Files that do not end in `.pid`, lack a stem, or
+    /// hold an unparsable PID are skipped (logged at `warn!`) — a corrupt entry
+    /// must never abort the sweep.
+    /// Test: `register_then_entries_round_trip`, `entries_skips_unparsable`.
+    pub fn entries(&self) -> std::io::Result<Vec<PidEntry>> {
+        let read_dir = match std::fs::read_dir(&self.dir) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
+        let mut out = Vec::new();
+        for dent in read_dir.flatten() {
+            let path = dent.path();
+            if path.extension().and_then(|e| e.to_str()) != Some(PID_FILE_EXT) {
+                continue;
+            }
+            let Some(session_id) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let body = match std::fs::read_to_string(&path) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(path = %path.display(), "pid-registry: read failed: {e}");
+                    continue;
+                }
+            };
+            match body.trim().parse::<u32>() {
+                Ok(pid) => out.push(PidEntry {
+                    session_id: session_id.to_string(),
+                    pid,
+                }),
+                Err(_) => {
+                    warn!(path = %path.display(), "pid-registry: unparsable PID; skipping");
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Reap orphaned `claude` processes recorded in the registry.
+    ///
+    /// Why: the §10.3 PID-file orphan-GC pass. A restarted (or long-running)
+    /// daemon reconciles every recorded PID against the set of still-live
+    /// session-ids; any recorded PID whose session is gone is a candidate
+    /// orphan. The name-verification gate (§13.5) means we SIGTERM only a PID
+    /// that is still alive AND still a `claude` process — a recycled PID that now
+    /// belongs to an unrelated process is spared (its stale file is removed
+    /// silently). Every gate fails toward NOT signalling.
+    /// What: lists [`entries`](Self::entries), classifies each via
+    /// [`classify_pidfile`] against `live_session_ids` and `probe`, then for each
+    /// non-`Keep` decision performs the action (terminate → SIGTERM then remove;
+    /// remove-stale → remove only) and removes the PID file. A removal failure is
+    /// logged and does not abort the pass. Returns a [`SweepOutcome`] summary.
+    /// Test: `sweep_terminates_only_untracked_claude`,
+    /// `sweep_removes_dead_without_signal`, `sweep_spares_reused_pid`,
+    /// `sweep_keeps_tracked`.
+    pub fn sweep_orphans(
+        &self,
+        live_session_ids: &HashSet<String>,
+        probe: &dyn ProcessProbe,
+    ) -> SweepOutcome {
+        let entries = match self.entries() {
+            Ok(e) => e,
+            Err(e) => {
+                warn!("pid-registry: entries() failed; skipping sweep: {e}");
+                return SweepOutcome::default();
+            }
+        };
+        let mut outcome = SweepOutcome {
+            scanned: entries.len(),
+            ..SweepOutcome::default()
+        };
+        for entry in &entries {
+            match classify_pidfile(entry, live_session_ids, probe) {
+                PidDecision::Keep => {}
+                PidDecision::Terminate => {
+                    let delivered = probe.terminate(entry.pid);
+                    info!(
+                        session_id = %entry.session_id,
+                        pid = entry.pid,
+                        delivered,
+                        "pid-registry: SIGTERM orphaned claude process"
+                    );
+                    outcome.terminated += 1;
+                    self.remove_pidfile_logged(&entry.session_id);
+                }
+                PidDecision::RemoveStale(reason) => {
+                    debug!(
+                        session_id = %entry.session_id,
+                        pid = entry.pid,
+                        ?reason,
+                        "pid-registry: removing stale PID file (no signal)"
+                    );
+                    outcome.removed_stale += 1;
+                    self.remove_pidfile_logged(&entry.session_id);
+                }
+            }
+        }
+        debug!(
+            scanned = outcome.scanned,
+            terminated = outcome.terminated,
+            removed_stale = outcome.removed_stale,
+            "pid-registry: orphan sweep complete"
+        );
+        outcome
+    }
+
+    /// Remove a PID file during a sweep, logging (not propagating) any error.
+    ///
+    /// Why: a sweep must process every entry; one removal failing (e.g. a
+    /// concurrent unregister already deleted it) must not abort the rest.
+    /// What: delegates to [`unregister`](Self::unregister), logging a warning on
+    /// error.
+    /// Test: exercised by every `sweep_*` test (the files are gone afterwards).
+    fn remove_pidfile_logged(&self, session_id: &str) {
+        if let Err(e) = self.unregister(session_id) {
+            warn!(session_id, "pid-registry: failed to remove PID file: {e}");
+        }
+    }
+}
+
+/// Production [`ProcessProbe`] backed by `crate::core::process` and `nix`.
+///
+/// Why: the registry's safety gates are only real if they inspect the live OS;
+/// this impl wires [`is_alive`](ProcessProbe::is_alive) to the existing
+/// `is_process_alive` (a `kill(pid, 0)` existence check), the name check to the
+/// same `claude`-substring `comm` lookup the rest of the crate uses, and
+/// [`terminate`](ProcessProbe::terminate) to a real SIGTERM.
+/// What: a unit struct whose methods delegate to OS calls. Construct with
+/// [`OsProcessProbe::default`].
+/// Test: only the `terminate` seam touches the OS destructively, so it is not
+/// unit-tested against a live process; the decision logic that drives it is
+/// tested via [`classify_pidfile`] with a fake probe.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OsProcessProbe;
+
+impl ProcessProbe for OsProcessProbe {
+    fn is_alive(&self, pid: u32) -> bool {
+        crate::core::process::is_process_alive(pid)
+    }
+
+    fn is_claude(&self, pid: u32) -> bool {
+        crate::core::process::process_name_is_claude(pid)
+    }
+
+    fn terminate(&self, pid: u32) -> bool {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{Signal, kill};
+            use nix::unistd::Pid;
+            let Ok(raw) = i32::try_from(pid) else {
+                return false;
+            };
+            if raw <= 0 {
+                return false;
+            }
+            kill(Pid::from_raw(raw), Signal::SIGTERM).is_ok()
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = pid;
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fully-scripted probe: liveness and `claude`-name answers are looked up
+    /// per-PID from sets; `terminate` records every PID it was asked to signal.
+    struct FakeProbe {
+        alive: HashSet<u32>,
+        claude: HashSet<u32>,
+        terminated: std::cell::RefCell<Vec<u32>>,
+    }
+
+    impl FakeProbe {
+        fn new(alive: &[u32], claude: &[u32]) -> Self {
+            Self {
+                alive: alive.iter().copied().collect(),
+                claude: claude.iter().copied().collect(),
+                terminated: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ProcessProbe for FakeProbe {
+        fn is_alive(&self, pid: u32) -> bool {
+            self.alive.contains(&pid)
+        }
+        fn is_claude(&self, pid: u32) -> bool {
+            self.claude.contains(&pid)
+        }
+        fn terminate(&self, pid: u32) -> bool {
+            self.terminated.borrow_mut().push(pid);
+            true
+        }
+    }
+
+    fn live(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn entry(id: &str, pid: u32) -> PidEntry {
+        PidEntry {
+            session_id: id.to_string(),
+            pid,
+        }
+    }
+
+    #[test]
+    fn under_nests_pids_subdir() {
+        let reg = PidRegistry::under("/base/.trusty-mpm");
+        assert_eq!(reg.dir(), Path::new("/base/.trusty-mpm/pids"));
+    }
+
+    #[test]
+    fn register_then_entries_round_trip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("sess-a", 1234).unwrap();
+        reg.register("sess-b", 5678).unwrap();
+
+        let mut got = reg.entries().unwrap();
+        got.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+        assert_eq!(got, vec![entry("sess-a", 1234), entry("sess-b", 5678)]);
+    }
+
+    #[test]
+    fn register_is_idempotent() {
+        // Re-registering the same session overwrites the PID (atomic rename), so
+        // exactly one entry remains with the latest value.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("sess", 11).unwrap();
+        reg.register("sess", 22).unwrap();
+        assert_eq!(reg.entries().unwrap(), vec![entry("sess", 22)]);
+    }
+
+    #[test]
+    fn unregister_removes_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("gone", 99).unwrap();
+        reg.unregister("gone").unwrap();
+        assert!(reg.entries().unwrap().is_empty());
+    }
+
+    #[test]
+    fn unregister_missing_is_ok() {
+        // Removing a PID file that was never written is a no-op success — a
+        // cleanly-stopped session that never had a PID recorded must not error.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.unregister("never").unwrap();
+    }
+
+    #[test]
+    fn entries_on_missing_dir_is_empty() {
+        // No `pids/` directory yet (nothing ever registered) → empty, not error.
+        let reg = PidRegistry::new("/nonexistent/path/that/does/not/exist/pids");
+        assert!(reg.entries().unwrap().is_empty());
+    }
+
+    #[test]
+    fn entries_skips_unparsable() {
+        // A corrupt PID body and a non-`.pid` file must be skipped, never abort
+        // the enumeration of the valid entries.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("good", 7).unwrap();
+        std::fs::write(tmp.path().join("bad.pid"), "not-a-number").unwrap();
+        std::fs::write(tmp.path().join("ignore.txt"), "100").unwrap();
+        assert_eq!(reg.entries().unwrap(), vec![entry("good", 7)]);
+    }
+
+    #[test]
+    fn classify_keeps_tracked() {
+        // A session still in the live registry is never touched, even if the
+        // probe would say it is a live claude.
+        let probe = FakeProbe::new(&[10], &[10]);
+        let d = classify_pidfile(&entry("alive-sess", 10), &live(&["alive-sess"]), &probe);
+        assert_eq!(d, PidDecision::Keep);
+    }
+
+    #[test]
+    fn classify_removes_dead() {
+        // Untracked + dead PID → remove the stale file, no signal.
+        let probe = FakeProbe::new(&[], &[]); // not alive
+        let d = classify_pidfile(&entry("dead", 20), &live(&[]), &probe);
+        assert_eq!(d, PidDecision::RemoveStale(StaleReason::ProcessDead));
+    }
+
+    #[test]
+    fn classify_removes_reused_pid() {
+        // Untracked + alive but NOT named claude → PID was reused; spare it.
+        let probe = FakeProbe::new(&[30], &[]); // alive but not claude
+        let d = classify_pidfile(&entry("reused", 30), &live(&[]), &probe);
+        assert_eq!(d, PidDecision::RemoveStale(StaleReason::PidReused));
+    }
+
+    #[test]
+    fn classify_terminates_untracked_claude() {
+        // The ONLY SIGTERM case: untracked + alive + still claude.
+        let probe = FakeProbe::new(&[40], &[40]);
+        let d = classify_pidfile(&entry("orphan", 40), &live(&[]), &probe);
+        assert_eq!(d, PidDecision::Terminate);
+    }
+
+    #[test]
+    fn sweep_terminates_only_untracked_claude() {
+        // Full matrix in one sweep: only the untracked-alive-claude PID is
+        // SIGTERMed; its file (and the stale ones) are removed; the tracked
+        // session's file survives.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("tracked", 100).unwrap(); // live + claude, but tracked → KEEP
+        reg.register("orphan", 200).unwrap(); // untracked + live + claude → KILL
+        reg.register("dead", 300).unwrap(); // untracked + dead → remove stale
+        reg.register("reused", 400).unwrap(); // untracked + live, not claude → remove stale
+
+        let probe = FakeProbe::new(&[100, 200, 400], &[100, 200]);
+        let outcome = reg.sweep_orphans(&live(&["tracked"]), &probe);
+
+        assert_eq!(outcome.scanned, 4);
+        assert_eq!(outcome.terminated, 1);
+        assert_eq!(outcome.removed_stale, 2);
+        assert_eq!(*probe.terminated.borrow(), vec![200]);
+
+        // Only the tracked session's PID file remains.
+        assert_eq!(reg.entries().unwrap(), vec![entry("tracked", 100)]);
+    }
+
+    #[test]
+    fn sweep_removes_dead_without_signal() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("dead", 7).unwrap();
+        let probe = FakeProbe::new(&[], &[]);
+        let outcome = reg.sweep_orphans(&live(&[]), &probe);
+        assert_eq!(outcome.removed_stale, 1);
+        assert_eq!(outcome.terminated, 0);
+        assert!(probe.terminated.borrow().is_empty());
+        assert!(reg.entries().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sweep_spares_reused_pid() {
+        // A recycled PID now owned by a non-claude process must NEVER be SIGTERMed.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("reused", 8).unwrap();
+        let probe = FakeProbe::new(&[8], &[]); // alive, not claude
+        let outcome = reg.sweep_orphans(&live(&[]), &probe);
+        assert_eq!(outcome.terminated, 0);
+        assert_eq!(outcome.removed_stale, 1);
+        assert!(
+            probe.terminated.borrow().is_empty(),
+            "a reused PID must never be signalled"
+        );
+    }
+
+    #[test]
+    fn sweep_keeps_tracked() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reg = PidRegistry::new(tmp.path());
+        reg.register("tracked", 9).unwrap();
+        let probe = FakeProbe::new(&[9], &[9]);
+        let outcome = reg.sweep_orphans(&live(&["tracked"]), &probe);
+        assert_eq!(outcome, SweepOutcome { scanned: 1, terminated: 0, removed_stale: 0 });
+        assert_eq!(reg.entries().unwrap(), vec![entry("tracked", 9)]);
+    }
+}

--- a/crates/trusty-mpm/src/core/process.rs
+++ b/crates/trusty-mpm/src/core/process.rs
@@ -116,6 +116,22 @@ fn process_name_contains_claude(pid: u32) -> bool {
     }
 }
 
+/// Check whether the process at `pid` is (still) a `claude` process.
+///
+/// Why: the PID-file orphan-GC ([`crate::core::pid_registry`]) must verify, just
+/// before SIGTERMing a recorded PID, that the process at that PID is still named
+/// `claude` — the alpha-1 mitigation for the PID-reuse race (spec §13.5). A
+/// recycled PID now owned by an unrelated process fails this check and is spared.
+/// What: a thin public wrapper over the crate-internal `comm`/`ps` name check,
+/// returning `true` only when the process's command name contains `claude`
+/// (case-insensitive), matching both `claude` and `claude-code`. A dead PID or
+/// any lookup failure returns `false`.
+/// Test: `process_name_is_claude_for_dead_pid_is_false` (a non-existent PID is
+/// never `claude`); the positive path is covered by `find_claude_pid_in_tmux`.
+pub fn process_name_is_claude(pid: u32) -> bool {
+    process_name_contains_claude(pid)
+}
+
 /// Check whether a process with the given PID is still alive.
 ///
 /// Why: the daemon's reaper must distinguish a tmux session whose `claude`
@@ -177,5 +193,11 @@ mod tests {
     fn is_process_alive_dead_pid() {
         // u32::MAX is far above any real PID — no such process can exist.
         assert!(!is_process_alive(u32::MAX));
+    }
+
+    #[test]
+    fn process_name_is_claude_for_dead_pid_is_false() {
+        // A non-existent PID can never be a live `claude` process.
+        assert!(!process_name_is_claude(u32::MAX));
     }
 }

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -424,6 +424,24 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                 if reaped > 0 {
                     info!("orphan-GC reaped {reaped} orphaned managed session(s)");
                 }
+
+                // PID-file orphan-GC (§10.3): reap daemon-owned `claude` child
+                // processes whose tmux pane is already gone — invisible to the
+                // tmux-name sweep above. Live session-ids come from BOTH registries;
+                // any recorded PID whose session-id is absent is a candidate, and
+                // the registry SIGTERMs it only after verifying it is still a live
+                // `claude` process (the §13.5 PID-reuse mitigation).
+                let live_ids = state.gather_live_session_ids().await;
+                let pid_outcome = state
+                    .pid_registry()
+                    .sweep_orphans(&live_ids, &crate::core::pid_registry::OsProcessProbe);
+                if pid_outcome.terminated > 0 || pid_outcome.removed_stale > 0 {
+                    info!(
+                        terminated = pid_outcome.terminated,
+                        removed_stale = pid_outcome.removed_stale,
+                        "orphan-GC PID-file sweep cleaned up orphaned claude process(es)"
+                    );
+                }
                 // #1508: auto-reap STALE EPHEMERAL sessions as a backstop.
                 let max_age = chrono::Duration::hours(crate::session_manager::MAX_EPHEMERAL_AGE_HOURS);
                 match mgr.reap_aged_ephemeral(max_age).await {

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -375,6 +375,22 @@ impl DaemonState {
         &self.framework_root
     }
 
+    /// The PID-file registry rooted under this daemon's framework root.
+    ///
+    /// Why: the §10.3 orphan-GC needs a single, consistent answer for "where do
+    /// daemon-owned `claude` child PIDs get recorded?". Deriving it from
+    /// [`framework_root`](Self::framework_root) keeps the `pids/` directory under
+    /// the SAME root the daemon uses — a temp dir in tests, `~/.trusty-mpm` in
+    /// production — so the spawn path, the session-drop path, and the GC sweep all
+    /// agree without any global state.
+    /// What: returns a fresh [`crate::core::pid_registry::PidRegistry`] over
+    /// `<framework_root>/pids`. The handle is cheap (just a path), so a new one
+    /// per call is fine and avoids holding a long-lived field.
+    /// Test: `pid_registry_is_under_framework_root` in `state/tests.rs`.
+    pub fn pid_registry(&self) -> crate::core::pid_registry::PidRegistry {
+        crate::core::pid_registry::PidRegistry::under(&self.framework_root)
+    }
+
     /// Return the shared activity monitor, constructing it on first access.
     ///
     /// Why: the `/sessions/managed/{id}/activity` handler needs a single,

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -149,9 +149,7 @@ impl DaemonState {
     /// Test: `set_session_pid_updates_field`, `set_session_pid_writes_pidfile`.
     pub fn set_session_pid(&self, id: SessionId, pid: u32) -> bool {
         let updated = self.update_session(&id, |s| s.pid = Some(pid));
-        if updated
-            && let Err(e) = self.pid_registry().register(&id.0.to_string(), pid)
-        {
+        if updated && let Err(e) = self.pid_registry().register(&id.0.to_string(), pid) {
             tracing::warn!(session_id = %id.0, pid, "pid-registry: register failed: {e}");
         }
         updated

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -141,15 +141,32 @@ impl DaemonState {
     /// pane *after* launch; reporting it back lets the reaper check process
     /// liveness rather than relying on the tmux session alone.
     /// What: sets `session.pid = Some(pid)` under a write guard; returns `true`
-    /// when the session existed, `false` for an unknown id.
-    /// Test: `set_session_pid_updates_field`.
+    /// when the session existed, `false` for an unknown id. On success it ALSO
+    /// records the PID in the on-disk PID-file registry (§10.3) so a future
+    /// orphan-GC sweep can find and reap this `claude` process even after its
+    /// tmux pane (and this in-memory entry) are gone. A registry write failure is
+    /// logged but never fails the call — PID tracking is best-effort hardening.
+    /// Test: `set_session_pid_updates_field`, `set_session_pid_writes_pidfile`.
     pub fn set_session_pid(&self, id: SessionId, pid: u32) -> bool {
-        self.update_session(&id, |s| s.pid = Some(pid))
+        let updated = self.update_session(&id, |s| s.pid = Some(pid));
+        if updated
+            && let Err(e) = self.pid_registry().register(&id.0.to_string(), pid)
+        {
+            tracing::warn!(session_id = %id.0, pid, "pid-registry: register failed: {e}");
+        }
+        updated
     }
 
     /// Remove a session and its associated memory snapshot.
+    ///
+    /// Also unregisters the session's PID-file (§10.3) so a cleanly-removed
+    /// session is never treated as an orphan by a later sweep. A missing PID file
+    /// is a no-op; an unexpected removal error is logged, not propagated.
     pub fn remove_session(&self, id: SessionId) -> Option<Session> {
         self.memory.remove(&id);
+        if let Err(e) = self.pid_registry().unregister(&id.0.to_string()) {
+            tracing::warn!(session_id = %id.0, "pid-registry: unregister failed: {e}");
+        }
         self.sessions.remove(&id).map(|(_, s)| s)
     }
 
@@ -331,6 +348,32 @@ impl DaemonState {
                 }
             }
         }
+    }
+
+    /// Gather the set of live session-id strings across BOTH registries.
+    ///
+    /// Why: the PID-file orphan-GC (§10.3) reaps any recorded PID whose session
+    /// is no longer tracked. The PID files are keyed by session-id (a UUID
+    /// string), so the sweep needs the union of every live id — from the legacy
+    /// `DaemonState` registry (the launch path's `set_session_pid` records PIDs
+    /// under these ids) and from the `SessionManager` store — to know which PID
+    /// files are still attached to a live session and must be spared.
+    /// What: collects `self.sessions` keys and every `SessionManager` record id
+    /// (`mgr.list()`) into one `HashSet<String>` of lowercase-hyphenated UUIDs.
+    /// The union is conservative for the PID sweep: a session tracked by EITHER
+    /// registry has its PID file spared, so a still-live `claude` is never reaped.
+    /// Test: `gather_live_session_ids_unions_both` in `state/tests.rs`.
+    pub async fn gather_live_session_ids(&self) -> std::collections::HashSet<String> {
+        let mut ids: std::collections::HashSet<String> = self
+            .sessions
+            .iter()
+            .map(|e| e.key().0.to_string())
+            .collect();
+        let mgr = self.session_manager().await;
+        for record in mgr.list().await {
+            ids.insert(record.id.0.to_string());
+        }
+        ids
     }
 
     // ---- projects -------------------------------------------------------

--- a/crates/trusty-mpm/src/daemon/state/tests.rs
+++ b/crates/trusty-mpm/src/daemon/state/tests.rs
@@ -254,7 +254,9 @@ fn reap_keeps_native_sessions() {
 #[test]
 fn set_session_pid_updates_field() {
     // Registering a session leaves `pid` unset; set_session_pid records it.
-    let state = DaemonState::new();
+    // Use a hermetic state so the PID-file write lands under a temp dir, never
+    // the operator's real `~/.trusty-mpm/pids`.
+    let (state, _tmp) = hermetic_state();
     let s = sample_session();
     let id = s.id;
     state.register_session(s);
@@ -265,6 +267,53 @@ fn set_session_pid_updates_field() {
 
     // An unknown id is reported as not updated.
     assert!(!state.set_session_pid(SessionId::new(), 1));
+}
+
+#[test]
+fn pid_registry_is_under_framework_root() {
+    // The PID registry must resolve to `<framework_root>/pids` so the spawn,
+    // drop, and sweep paths all agree on one directory.
+    let (state, _tmp) = hermetic_state();
+    let expected = state.framework_root().join("pids");
+    assert_eq!(state.pid_registry().dir(), expected.as_path());
+}
+
+#[test]
+fn set_session_pid_writes_pidfile() {
+    // Recording a PID must also write a `<uuid>.pid` file to the registry so a
+    // future orphan-GC sweep can find this claude process even after the tmux
+    // pane and in-memory entry are gone (§10.3).
+    let (state, _tmp) = hermetic_state();
+    let s = sample_session();
+    let id = s.id;
+    state.register_session(s);
+    assert!(state.set_session_pid(id, 4242));
+
+    let entries = state.pid_registry().entries().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].session_id, id.0.to_string());
+    assert_eq!(entries[0].pid, 4242);
+
+    // Removing the session must clear its PID file (no orphan left behind).
+    state.remove_session(id);
+    assert!(state.pid_registry().entries().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn gather_live_session_ids_unions_both() {
+    // The live-id set the PID sweep uses must include every legacy DaemonState
+    // session id (the SM store starts empty in a hermetic state, so the legacy
+    // ids are what must be present).
+    let (state, _tmp) = hermetic_state();
+    let a = sample_session();
+    let b = sample_session();
+    let (id_a, id_b) = (a.id, b.id);
+    state.register_session(a);
+    state.register_session(b);
+
+    let ids = state.gather_live_session_ids().await;
+    assert!(ids.contains(&id_a.0.to_string()));
+    assert!(ids.contains(&id_b.0.to_string()));
 }
 
 #[test]

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -21,6 +21,9 @@ pub mod workspace_guard;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod restart_tests;
+
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.
 #[cfg(feature = "daemon")]

--- a/crates/trusty-mpm/src/session_manager/restart_ops.rs
+++ b/crates/trusty-mpm/src/session_manager/restart_ops.rs
@@ -5,15 +5,18 @@
 //! while keeping related lifecycle logic co-located in the `session_manager`
 //! module tree.
 //! What: `impl SessionManager { shutdown }` — gracefully stops every live
-//! (non-terminal) managed session. For each session it sends a best-effort
-//! Ctrl-C interrupt (`send_interrupt`), waits 2 s asynchronously so the claude
-//! process can flush state, then kills the tmux session via `graceful_stop`.
-//! SIGTERM-with-known-PID is deferred to PR B (#1595) once the PID registry
-//! exists. The 2 s wait is done with `tokio::time::sleep` — never a blocking
-//! `std::thread::sleep` — so it does not starve the Tokio thread pool.
+//! (non-terminal) managed session. For each session it resolves the live
+//! `claude` PID (a single quick `find_claude_pid_in_tmux` probe), waits 2 s
+//! asynchronously so the claude process can flush state, then calls
+//! `graceful_stop(name, pid)` ONCE — SIGTERM when the PID is known (#1595 PR B),
+//! else a single Ctrl-C fallback. There is exactly one signal per session: the
+//! earlier double-Ctrl-C (a pre-signal loop *plus* `graceful_stop`'s own
+//! fallback interrupt) is gone. The 2 s wait is done with `tokio::time::sleep` —
+//! never a blocking `std::thread::sleep` — so it does not starve the Tokio
+//! thread pool.
 //! Test: `shutdown_calls_graceful_stop_for_active_sessions` (integration test
 //! in session_manager/tests.rs), `fake_driver_graceful_stop_with_pid`,
-//! `fake_driver_graceful_stop_without_pid`.
+//! `fake_driver_graceful_stop_without_pid`, `default_graceful_stop_sends_sigterm`.
 
 use std::time::Duration;
 
@@ -40,17 +43,20 @@ impl SessionManager {
     /// Why: the graceful-shutdown path in `daemon/mod.rs` needs to give every
     /// running session a chance to persist its state before the process exits.
     /// `kill_session` is abrupt; `shutdown` separates signal from kill: it
-    /// first interrupts all sessions (best-effort Ctrl-C via `send_interrupt`),
-    /// then awaits a [`SIGTERM_GRACE_SECS`]-second async sleep so the claude
-    /// processes can flush state, then hard-kills each session via
-    /// `tmux.graceful_stop`. Using `tokio::time::sleep` (never
-    /// `std::thread::sleep`) keeps the Tokio thread pool free during the wait.
-    /// The one-sleep-for-all approach bounds total shutdown time at O(1).
-    /// What: collects all Active/Provisioning records; sends send_interrupt to
-    /// each; awaits the grace window; calls graceful_stop on each. Currently
-    /// passes `None` as the PID (Ctrl-C + grace + kill path); the SIGTERM-with-
-    /// known-PID branch of `graceful_stop` activates once the PID registry
-    /// lands in PR B (#1595). Fails open per session. Logs a summary line.
+    /// resolves each session's live `claude` PID, awaits a [`SIGTERM_GRACE_SECS`]
+    /// async grace window so the processes can flush state, then calls
+    /// `graceful_stop(name, pid)` ONCE per session. `graceful_stop` sends SIGTERM
+    /// when the PID is known (#1595 PR B) and falls back to a single Ctrl-C only
+    /// when it is not — so each session receives exactly ONE termination signal.
+    /// The previous implementation pre-signalled every session with Ctrl-C *and*
+    /// then let `graceful_stop(None)` send another, double-interrupting the pane;
+    /// that pre-signal loop is removed. Using `tokio::time::sleep` (never
+    /// `std::thread::sleep`) keeps the Tokio thread pool free; the one-sleep-for-
+    /// all approach bounds total shutdown time at O(1).
+    /// What: collects all Active/Provisioning records; resolves each session's
+    /// PID via a single [`crate::core::process::find_claude_pid_in_tmux`] probe
+    /// (one attempt — at shutdown we do not retry); awaits the grace window once;
+    /// calls `graceful_stop(name, pid)` per session, failing open. Logs a summary.
     /// Test: `shutdown_calls_graceful_stop_for_active_sessions` in tests.rs.
     pub async fn shutdown(&self) {
         let records = self.list().await;
@@ -71,30 +77,29 @@ impl SessionManager {
             return;
         }
 
-        // Phase 1: send termination signal to all live sessions synchronously.
-        // `graceful_stop` on the trait does signal + kill in one step; to honour
-        // the grace window without blocking a thread, we split into two phases:
-        // signal via send_interrupt (best-effort), sleep, then graceful_stop
-        // (which re-signals and kills). For simplicity in the default-impl path,
-        // we call graceful_stop directly — it does its own signal + kill without
-        // sleeping. The async grace window here covers the gap between our first
-        // signal and the final kill.
-        for record in &live {
-            // Best-effort pre-signal (Ctrl-C / SIGTERM not possible without PID
-            // at this layer, so we use the driver's interrupt seam).
-            let _ = self.tmux.send_interrupt(&record.tmux_name);
-        }
+        // Resolve each session's live `claude` PID up front (a single quick probe
+        // per session — no retry budget at shutdown). A known PID lets
+        // `graceful_stop` send SIGTERM directly instead of a tmux Ctrl-C.
+        let pids: Vec<Option<u32>> = live
+            .iter()
+            .map(|r| {
+                crate::core::process::find_claude_pid_in_tmux(
+                    &r.tmux_name,
+                    1,
+                    Duration::from_millis(0),
+                )
+            })
+            .collect();
 
-        // Phase 2: async grace window — await without blocking a thread.
+        // Single async grace window for ALL sessions — bounds shutdown at O(1)
+        // and lets the claude processes flush state before the kill.
         tokio::time::sleep(Duration::from_secs(SIGTERM_GRACE_SECS)).await;
 
-        // Phase 3: hard-kill any sessions still alive via graceful_stop
-        // (which will re-signal and call kill_session; the session may already
-        // be gone, in which case kill_session is a quiet no-op for the session).
+        // Exactly one signal + kill per session via `graceful_stop`: SIGTERM when
+        // the PID is known, else a single Ctrl-C fallback (no double interrupt).
         let mut stopped = 0usize;
-        for record in &live {
-            // TODO(#1595 PR B): thread record.claude_pid here once the PID registry exists
-            match self.tmux.graceful_stop(&record.tmux_name, None) {
+        for (record, pid) in live.iter().zip(pids) {
+            match self.tmux.graceful_stop(&record.tmux_name, pid) {
                 Ok(()) => {
                     stopped += 1;
                 }

--- a/crates/trusty-mpm/src/session_manager/restart_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/restart_tests.rs
@@ -1,0 +1,119 @@
+//! Tests for the graceful-shutdown / restart lifecycle (`restart_ops`).
+//!
+//! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; the
+//! shutdown-specific coverage that exercises the DEFAULT `graceful_stop` trait
+//! impl lives here so neither file grows past its limit. Keeping it in a focused
+//! sibling also makes the SIGTERM-path coverage easy to find.
+//! What: a minimal driver that does NOT override `graceful_stop` (so the trait
+//! default runs) plus an OS-level test that the default impl actually delivers
+//! SIGTERM to a known PID and then kills the tmux session.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::sync::Mutex;
+
+use super::manager::{ManagedError, ManagedTmuxDriver};
+
+/// A minimal driver that does NOT override `graceful_stop`, so the DEFAULT trait
+/// impl runs — exercising its real SIGTERM-with-known-PID branch.
+///
+/// Why: the `FakeTmuxDriver` in `tests.rs` overrides `graceful_stop` to skip
+/// signalling, so none of those tests prove the default impl delivers SIGTERM.
+/// This driver leaves `graceful_stop` to the trait default and records only the
+/// post-signal `kill_session` call, so the test can assert both the OS-level
+/// SIGTERM (the child dies) and the mandatory cleanup kill.
+/// What: no-op `create_session`/`send_line`/`capture`/`list_sessions` plus a
+/// `kill_calls` recorder; `graceful_stop` is inherited from the trait default.
+/// Test: `default_graceful_stop_sends_sigterm`.
+#[cfg(unix)]
+struct DefaultGsDriver {
+    kill_calls: Mutex<Vec<String>>,
+}
+
+#[cfg(unix)]
+impl ManagedTmuxDriver for DefaultGsDriver {
+    fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn kill_session(&self, name: &str) -> Result<(), ManagedError> {
+        self.kill_calls.lock().unwrap().push(name.to_owned());
+        Ok(())
+    }
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+        Ok(String::new())
+    }
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        Ok(Vec::new())
+    }
+    // graceful_stop intentionally NOT overridden — exercise the trait default.
+}
+
+/// The default `graceful_stop` impl sends SIGTERM to a known PID, then kills.
+///
+/// Why: PR A follow-up nit — prove the default trait impl's SIGTERM-with-known-
+/// PID branch actually terminates the process (not just records a call). A
+/// recycled-PID kill is the risk this branch must get right, so it is worth an
+/// OS-level assertion against a real child.
+/// What: spawns a long-lived `sleep` child, calls the DEFAULT `graceful_stop`
+/// with that child's PID, then asserts the child exits (SIGTERM delivered) AND
+/// `kill_session` was called as the final cleanup step. An RAII guard reaps the
+/// child on any early exit so the test never leaks a process.
+/// Test: this is the test.
+#[cfg(unix)]
+#[test]
+fn default_graceful_stop_sends_sigterm() {
+    use std::process::{Child, Command};
+    use std::time::{Duration, Instant};
+
+    // RAII guard: ensures the child is killed+reaped even if an assert panics.
+    struct ChildGuard(Child);
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    let child = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn sleep child");
+    let pid = child.id();
+    let mut guard = ChildGuard(child);
+
+    let driver = DefaultGsDriver {
+        kill_calls: Mutex::new(Vec::new()),
+    };
+
+    // Default impl: SIGTERM the known PID, then kill_session.
+    driver
+        .graceful_stop("tmpm-default-gs", Some(pid))
+        .expect("graceful_stop");
+
+    // The cleanup kill must have run.
+    assert!(
+        driver
+            .kill_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|n| n == "tmpm-default-gs"),
+        "default graceful_stop must call kill_session after signalling"
+    );
+
+    // The child must terminate from the SIGTERM within a short window.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let exited = loop {
+        match guard.0.try_wait().expect("try_wait") {
+            Some(_status) => break true,
+            None if Instant::now() >= deadline => break false,
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    };
+    assert!(
+        exited,
+        "default graceful_stop must deliver SIGTERM — the sleep child should exit"
+    );
+}

--- a/crates/trusty-mpm/tests/pid_registry_sweep.rs
+++ b/crates/trusty-mpm/tests/pid_registry_sweep.rs
@@ -1,0 +1,123 @@
+//! End-to-end safety tests for the PID-file orphan-GC sweep (#1595, §10.3).
+//!
+//! Why: the PID-file registry SIGTERMs orphaned `claude` child processes whose
+//! tmux pane is already gone — a false kill of a recycled PID would terminate an
+//! unrelated process (§13.5). These tests prove, against a real on-disk registry
+//! (a `tempfile::TempDir`) and a recording probe, that the sweep signals ONLY a
+//! still-alive, still-`claude`, genuinely-untracked PID and removes every other
+//! stale file WITHOUT signalling.
+//! What: drives [`PidRegistry::sweep_orphans`] with a recording [`ProcessProbe`]
+//! and asserts the terminated-PID list and the surviving PID files.
+//! Test: this file IS the test; run with
+//! `cargo test -p trusty-mpm --test pid_registry_sweep`.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+use trusty_mpm::core::pid_registry::{PidRegistry, ProcessProbe};
+
+/// A scripted probe: per-PID liveness / `claude`-name answers; records SIGTERMs.
+struct RecordingProbe {
+    alive: HashSet<u32>,
+    claude: HashSet<u32>,
+    terminated: RefCell<Vec<u32>>,
+}
+
+impl RecordingProbe {
+    fn new(alive: &[u32], claude: &[u32]) -> Self {
+        Self {
+            alive: alive.iter().copied().collect(),
+            claude: claude.iter().copied().collect(),
+            terminated: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl ProcessProbe for RecordingProbe {
+    fn is_alive(&self, pid: u32) -> bool {
+        self.alive.contains(&pid)
+    }
+    fn is_claude(&self, pid: u32) -> bool {
+        self.claude.contains(&pid)
+    }
+    fn terminate(&self, pid: u32) -> bool {
+        self.terminated.borrow_mut().push(pid);
+        true
+    }
+}
+
+fn live(ids: &[&str]) -> HashSet<String> {
+    ids.iter().map(|s| s.to_string()).collect()
+}
+
+/// The full safety matrix in one sweep: ONLY the untracked-alive-`claude` PID is
+/// SIGTERMed; the tracked file survives; the dead and reused files are removed
+/// without any signal.
+#[test]
+fn sweep_signals_only_untracked_live_claude() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let reg = PidRegistry::new(tmp.path());
+
+    reg.register("tracked", 100).unwrap(); // live + claude but TRACKED -> keep
+    reg.register("orphan", 200).unwrap(); // untracked + live + claude -> KILL
+    reg.register("dead", 300).unwrap(); // untracked + dead         -> remove stale
+    reg.register("reused", 400).unwrap(); // untracked + live, NOT claude -> remove stale
+
+    let probe = RecordingProbe::new(&[100, 200, 400], &[100, 200]);
+    let outcome = reg.sweep_orphans(&live(&["tracked"]), &probe);
+
+    assert_eq!(outcome.scanned, 4);
+    assert_eq!(outcome.terminated, 1);
+    assert_eq!(outcome.removed_stale, 2);
+    assert_eq!(
+        *probe.terminated.borrow(),
+        vec![200],
+        "only the untracked, live, claude PID may be signalled"
+    );
+
+    // Only the tracked session's PID file remains on disk.
+    let mut remaining: Vec<String> = reg
+        .entries()
+        .unwrap()
+        .into_iter()
+        .map(|e| e.session_id)
+        .collect();
+    remaining.sort();
+    assert_eq!(remaining, vec!["tracked".to_string()]);
+}
+
+/// A recycled PID now owned by a non-`claude` process is NEVER signalled (§13.5).
+#[test]
+fn sweep_never_signals_reused_pid() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let reg = PidRegistry::new(tmp.path());
+    reg.register("reused", 4242).unwrap();
+
+    // Alive, but NOT a claude process — the PID was recycled.
+    let probe = RecordingProbe::new(&[4242], &[]);
+    let outcome = reg.sweep_orphans(&live(&[]), &probe);
+
+    assert_eq!(outcome.terminated, 0);
+    assert_eq!(outcome.removed_stale, 1);
+    assert!(
+        probe.terminated.borrow().is_empty(),
+        "a recycled PID must never receive SIGTERM"
+    );
+    assert!(reg.entries().unwrap().is_empty());
+}
+
+/// A registered, still-tracked session's PID file is left completely untouched.
+#[test]
+fn sweep_keeps_tracked_session_pidfile() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let reg = PidRegistry::new(tmp.path());
+    reg.register("alive-sess", 7).unwrap();
+
+    let probe = RecordingProbe::new(&[7], &[7]);
+    let outcome = reg.sweep_orphans(&live(&["alive-sess"]), &probe);
+
+    assert_eq!(outcome.terminated, 0);
+    assert_eq!(outcome.removed_stale, 0);
+    assert!(probe.terminated.borrow().is_empty());
+    assert_eq!(reg.entries().unwrap().len(), 1);
+}


### PR DESCRIPTION
## WI-4 PR B — orphan-GC PID-file registry (closes #1595, refs #1413)

Part of epic #1590, SESSCTL Phase 4 lifecycle hardening. Implements the
**PID-file registry** orphan-GC per spec DOC-26 §10.3, with the §13.5
PID-reuse mitigation (name-verify before SIGTERM), plus the two PR A follow-up
nits.

### What landed

**New `core::pid_registry` module** — the §10.3 registry:
- `register(session_id, pid)` writes `~/.trusty-mpm/pids/<session-id>.pid`
  **atomically** (temp + rename), satisfying the "PID file written before spawn
  returns" invariant.
- `unregister(session_id)` removes it on normal termination.
- `entries()` enumerates `(session_id, pid)`; skips corrupt/unparsable files.
- `sweep_orphans(live_ids, probe)` is the GC pass. `classify_pidfile` (pure,
  exhaustively unit-tested) SIGTERMs **only** an untracked, alive, still-`claude`
  PID; dead PIDs and recycled (non-`claude`) PIDs have their stale files removed
  **without signalling** — the accepted alpha-1 PID-reuse mitigation (§13.5).
- `ProcessProbe` trait abstracts liveness/identity/SIGTERM so the full decision
  matrix is tested against a fake probe + tempfile dir — **no real process is
  ever signalled in tests**. `OsProcessProbe` wires the production path.

**Daemon wiring**:
- `DaemonState::pid_registry()` resolves `<framework_root>/pids`.
- `set_session_pid()` now also writes the PID file (best-effort, fail-open);
  `remove_session()` unregisters it.
- `gather_live_session_ids()` unions legacy + SM session ids.
- `orphan_gc_loop` runs the PID-file sweep each tick after the existing
  tmux-name sweep.

**PR A follow-up nits**:
1. **Double Ctrl-C fixed** — `SessionManager::shutdown` previously pre-signalled
   every session with Ctrl-C *and* then let `graceful_stop(None)` send another.
   It now resolves each PID once and calls `graceful_stop(name, pid)` exactly
   once: SIGTERM when the PID is known, else a single Ctrl-C fallback.
2. **Default `graceful_stop` SIGTERM test** — new `restart_tests.rs` exercises
   the *default* trait impl (not the FakeTmuxDriver override): spawns a real
   `sleep` child, calls the default `graceful_stop` with its PID, and asserts the
   child is SIGTERMed and `kill_session` runs.

### Gate (#1595): orphan-GC test passes
- `tests/pid_registry_sweep.rs` (3 integration tests) drives the full sweep
  end-to-end against an on-disk registry: only the untracked-live-`claude` PID is
  signalled; recycled PIDs are never signalled; tracked files survive.
- 15 unit tests in `core::pid_registry` cover the decision matrix.

### Verification (raw)
- `cargo test -p trusty-mpm` → **1990 passed; 0 failed; 3 ignored**
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → 14 allowlisted, 0 violations

> Note: `core::standalone::trust_seed::tests::test_preseed_managed_trust_no_home_write`
> is a pre-existing flake (mutates global `HOME` via `set_var`, racy under the
> parallel harness); passes in isolation and on re-run. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)