### PR TITLE
fix(trusty-review): prevent truncated diff from reaching reviewer (closes #1638)

### DIFF
--- a/crates/trusty-review/src/pipeline/diff.rs
+++ b/crates/trusty-review/src/pipeline/diff.rs
@@ -113,6 +113,47 @@ pub fn truncate_diff(diff: &str) -> String {
     )
 }
 
+// ─── Truncation detection ──────────────────────────────────────────────────────
+
+/// Marker prefix `truncate_diff` appends when it cuts an over-cap diff.
+///
+/// Why: the runner's fail-closed guard (#1638) must detect that the diff handed
+/// to the reviewer had content removed; matching the exact marker string keeps
+/// the producer (`truncate_diff`) and the consumer (`diff_was_truncated`) in sync
+/// from one definition rather than two copies of a magic string.
+/// What: the literal prefix emitted by `truncate_diff` (see the `format!` above).
+/// Test: `diff_was_truncated_detects_diff_marker`.
+pub const DIFF_TRUNCATED_MARKER: &str = "[DIFF TRUNCATED";
+
+/// Marker prefix `FilteredDiff::render_for_prompt` appends when it cuts at the
+/// char budget (whole files or trailing hunks dropped).
+///
+/// Why: `render_for_prompt` drops whole files at the END of a large diff (a
+/// changed signature in a late file is silently lost); the runner must detect
+/// this and fail closed rather than review the visible portion only (#1638).
+/// What: the literal prefix emitted by `render_for_prompt` (see `models.rs`).
+/// Test: `diff_was_truncated_detects_render_marker`.
+pub const RENDER_TRUNCATED_MARKER: &str = "[RENDER TRUNCATED";
+
+/// Returns `true` when the rendered diff handed to the reviewer had content
+/// removed by either truncation path.
+///
+/// Why: a reviewer working from a partial diff produces wrong/incomplete reviews
+/// — the live symptom was a changed `build(…, null)` signature cut off so the
+/// reviewer literally could not see it (#1638).  The runner uses this predicate
+/// to fail CLOSED to UNKNOWN (consistent with the #1241 / #590 philosophy) rather
+/// than silently reviewing the visible portion.
+/// What: a pure check for the self-announcing markers that `truncate_diff` and
+/// `FilteredDiff::render_for_prompt` append when (and only when) they drop content.
+/// Detecting the markers — rather than re-deriving length math — keeps this in
+/// lock-step with the producers and is robust to either path firing.
+/// Test: `diff_was_truncated_detects_diff_marker`,
+/// `diff_was_truncated_detects_render_marker`,
+/// `diff_was_truncated_false_on_complete_diff`.
+pub fn diff_was_truncated(rendered: &str) -> bool {
+    rendered.contains(DIFF_TRUNCATED_MARKER) || rendered.contains(RENDER_TRUNCATED_MARKER)
+}
+
 // ─── Identifier extraction ────────────────────────────────────────────────────
 
 /// Extract salient identifier names from changed (`+`/`-`) diff lines.
@@ -322,6 +363,45 @@ index abc..def 100644
         let result = truncate_diff(&diff);
         // The truncation marker should appear.
         assert!(result.contains("[DIFF TRUNCATED"));
+    }
+
+    #[test]
+    fn diff_was_truncated_detects_diff_marker() {
+        // A diff long enough that `truncate_diff` actually cuts it must be flagged.
+        let long = "a".repeat(MAX_DIFF_CHARS + 1000);
+        let rendered = truncate_diff(&long);
+        assert!(
+            rendered.contains(DIFF_TRUNCATED_MARKER),
+            "precondition: truncate_diff must append its marker"
+        );
+        assert!(
+            diff_was_truncated(&rendered),
+            "diff_was_truncated must detect the truncate_diff marker"
+        );
+    }
+
+    #[test]
+    fn diff_was_truncated_detects_render_marker() {
+        // Simulate the marker render_for_prompt appends when it drops whole files.
+        let rendered = "--- a/src/a.rs\n+++ b/src/a.rs\n@@ -1 +1 @@\n+fn a() {}\n\
+             \n[RENDER TRUNCATED — char budget (160000) reached; ~3 file(s) omitted; \
+             review covers only the visible portion above]\n";
+        assert!(
+            diff_was_truncated(rendered),
+            "diff_was_truncated must detect the render_for_prompt marker"
+        );
+    }
+
+    #[test]
+    fn diff_was_truncated_false_on_complete_diff() {
+        assert!(
+            !diff_was_truncated(SAMPLE_DIFF),
+            "a complete diff with no truncation marker must not be flagged"
+        );
+        assert!(
+            !diff_was_truncated(""),
+            "an empty diff must not be flagged as truncated"
+        );
     }
 
     #[test]

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -27,7 +27,10 @@ use crate::{
     models::{ReviewResult, ReviewStatus, Verdict},
     pipeline::{
         context_gate::{GateOutcome, degraded_banner, preflight_context},
-        diff::{DiffSource, extract_changed_files, extract_identifiers, load_diff, truncate_diff},
+        diff::{
+            DiffSource, diff_was_truncated, extract_changed_files, extract_identifiers, load_diff,
+            truncate_diff,
+        },
         diff_analyzer::DiffAnalyzer, // noise filter (Stages A+B); #624
         parser::parse_review_response,
         prompt::{ReviewPrMeta, build_review_prompt_with_coverage},
@@ -218,6 +221,36 @@ pub async fn run_review(
     let max = crate::config::constants::MAX_DIFF_CHARS;
     let diff = truncate_diff(&filtered.render_for_prompt(max));
     debug!(orig = raw_diff.len(), filt = diff.len(), "diff filtered");
+
+    // ── Step 3b: diff-truncation guard (#1638) ────────────────────────────
+    // The unified path renders the (noise-filtered) diff bounded to MAX_DIFF_CHARS;
+    // for an over-cap diff `render_for_prompt` drops whole files at the END of the
+    // diff (and `truncate_diff` cuts trailing hunks).  A changed function/method
+    // signature in a dropped/cut region is then INVISIBLE to the reviewer — the
+    // live symptom that motivated this fix (a `build(…, null)` signature cut off so
+    // the reviewer could not see it).  Reviewing a partial diff yields a wrong /
+    // incomplete verdict, so we fail CLOSED to UNKNOWN (consistent with the #1241
+    // truncated-output guard and the #590 required-context gate) rather than
+    // silently reviewing only the visible portion.  The map-reduce path (#680) will
+    // later review over-cap diffs per-file with no truncation; until that fan-out
+    // lands, fail-closed is the safe behaviour.
+    if diff_was_truncated(&diff) {
+        warn!(
+            orig_chars = raw_diff.len(),
+            rendered_chars = diff.len(),
+            max_chars = max,
+            "diff exceeded MAX_DIFF_CHARS and was truncated — failing CLOSED to UNKNOWN \
+             so the reviewer never silently reviews a partial diff (#1638)"
+        );
+        result.verdict = Verdict::Unknown;
+        result.error = Some(format!(
+            "diff too large to review in full ({orig} chars > {max} cap) — content was \
+             truncated before the reviewer, so changed code (e.g. function signatures) \
+             may be invisible; could not review",
+            orig = raw_diff.len(),
+        ));
+        return abort_dry(result, config, &input, &deps);
+    }
 
     // ── Step 4: extract identifiers for context retrieval ─────────────────
     let identifiers = extract_identifiers(&diff, 8);

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -397,6 +397,110 @@ async fn run_review_truncated_output_is_unknown() {
     );
 }
 
+/// FAIL-CLOSED ON TRUNCATED DIFF (#1638): an over-cap diff whose tail (a changed
+/// function signature) is dropped by `render_for_prompt` / `truncate_diff` must
+/// NOT be reviewed as-if-complete.  The runner must fail CLOSED to UNKNOWN.
+///
+/// Why: this is the live bug — the reviewer received a truncated diff and could
+/// not see a changed `build(…, null)` signature near the end of a large diff, so
+/// it reviewed code it could not see.  Before the fix the runner would happily
+/// APPROVE the visible portion; after the fix it returns UNKNOWN with an
+/// actionable error.
+/// What: builds a single-file diff far larger than `MAX_DIFF_CHARS` with a
+/// distinctive changed signature on the LAST line, runs the pipeline with a
+/// FakeLlm that would APPROVE, and asserts UNKNOWN + an actionable error.
+/// Test: this test itself (no network).
+#[tokio::test]
+async fn run_review_oversized_diff_fails_closed_to_unknown() {
+    use crate::config::constants::MAX_DIFF_CHARS;
+
+    // A valid unified-diff header, then a huge body of added lines that pushes the
+    // rendered diff well past MAX_DIFF_CHARS, then a changed signature on the tail.
+    let mut diff = String::from("diff --git a/src/big.rs b/src/big.rs\n");
+    diff.push_str("--- a/src/big.rs\n+++ b/src/big.rs\n");
+    diff.push_str("@@ -1,1 +1,100000 @@\n");
+    // ~2x the cap of added content so render_for_prompt is forced to truncate.
+    let filler_line = "+    let _padding = compute_value(some_argument_here);\n";
+    while diff.len() < MAX_DIFF_CHARS * 2 {
+        diff.push_str(filler_line);
+    }
+    // The changed signature that MUST be reviewed — placed at the very end so it
+    // falls in the truncated region.
+    diff.push_str("+pub fn build(a: i32, b: i32, c: i32, previous: Option<i32>) -> i32 { 0 }\n");
+
+    let (source, _tmp) = local_diff_source(&diff);
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    // FakeLlm would APPROVE if it were ever consulted — proving the guard fires
+    // BEFORE the LLM sees a partial diff.
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(
+        result.verdict,
+        Verdict::Unknown,
+        "an over-cap (truncated) diff must fail CLOSED to UNKNOWN, never APPROVE a partial diff (#1638)"
+    );
+    let err = result
+        .error
+        .expect("a truncated diff must set an actionable error");
+    assert!(
+        err.contains("truncat"),
+        "error must explain the truncation: {err}"
+    );
+    assert!(
+        !result.posted,
+        "a truncated-diff review must never be posted live"
+    );
+    assert!(result.dry_run, "a fail-closed review is dry-run");
+}
+
+/// REGRESSION GUARD (#1638): a normal, under-cap diff must STILL be reviewed
+/// (the truncation guard must not false-positive on complete diffs).
+///
+/// Why: the fail-closed guard must only fire when content was actually dropped;
+/// a complete diff (the overwhelming common case) must review normally.
+/// What: a tiny diff with no truncation marker reviews to APPROVE as before.
+/// Test: this test itself.
+#[tokio::test]
+async fn run_review_under_cap_diff_is_not_flagged_truncated() {
+    let (source, _tmp) = local_diff_source(
+        "diff --git a/src/s.rs b/src/s.rs\n--- a/src/s.rs\n+++ b/src/s.rs\n\
+         @@ -1 +1 @@\n+pub fn build(a: i32, prev: Option<i32>) -> i32 { 0 }\n",
+    );
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+    assert_eq!(
+        result.verdict,
+        Verdict::Approve,
+        "a complete under-cap diff must review normally (no false-positive truncation)"
+    );
+    assert!(
+        result.error.is_none(),
+        "no error expected for a complete diff: {:?}",
+        result.error
+    );
+}
+
 /// PRIMARY signal (#1357): a length/max_tokens finish_reason flags truncation
 /// regardless of the token count.
 ///


### PR DESCRIPTION
## Problem

Closes #1638.

From a live review run, the reviewer model reported:

> \"The diff is truncated so the new overload signature of build(…, null) is not visible. If the fourth parameter is used unconditionally inside build (e.g. to look up previousAppliedOverbooking),...\"

The reviewer literally could not see a changed function signature because the diff it was handed had been cut off. A reviewer working from a truncated diff produces wrong/incomplete reviews.

## Confirmed root cause

`crates/trusty-review/src/pipeline/runner.rs` sends **every** review through the **unified diff path**, unconditionally:

```rust
let filtered = DiffAnalyzer::default().analyze(&raw_diff).await;
let diff = truncate_diff(&filtered.render_for_prompt(MAX_DIFF_CHARS)); // 160_000
```

For an over-cap diff, `FilteredDiff::render_for_prompt` breaks at a **file boundary** and drops the remaining files entirely (leaving only a `[RENDER TRUNCATED …]` marker); `truncate_diff` similarly cuts trailing hunks. A changed signature near the **end** of a large diff (e.g. `build(…, null)`) therefore never reaches the reviewer, yet the pipeline reviewed the visible portion and emitted a verdict anyway.

The map-reduce safety net that should route over-cap diffs to a per-file no-truncation path (`select_review_mode` / #680) is **not wired into the runner** — its module doc states \"nothing in the live review runner consumes the selector yet (wired in Phase 5)\", and the map/reduce LLM fan-out stages don't yet exist.

## Fix

Until map-reduce fan-out lands, **fail CLOSED** (consistent with the #1241 truncated-output guard and the #590 required-context gate): when the rendered+truncated diff actually had content removed, abort to `Verdict::Unknown` with an actionable error instead of silently reviewing a partial diff.

- New pure helper `pipeline::diff::diff_was_truncated()` detects the self-announcing `[DIFF TRUNCATED …]` / `[RENDER TRUNCATED …]` markers (shared via `pub const` so producer/consumer never drift).
- Runner step 3b aborts fail-closed when truncation occurred.
- `MAX_DIFF_CHARS` intentionally **unchanged** — bumping it only moves the cliff.

## Tests (fail on old behavior, pass on new)

Verified by temporarily disabling the guard: `run_review_oversized_diff_fails_closed_to_unknown` then APPROVES the partial diff (the bug); with the guard it returns UNKNOWN.

- `run_review_oversized_diff_fails_closed_to_unknown` — over-cap diff with a changed `build(...)` signature on the last line → UNKNOWN, never APPROVE.
- `run_review_under_cap_diff_is_not_flagged_truncated` — complete diff still reviews normally (no false positive).
- `diff_was_truncated_detects_diff_marker` / `_detects_render_marker` / `_false_on_complete_diff`.

## Quality bar

- `cargo test -p trusty-review` — 1007 passed; 0 failed; 3 ignored
- `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations

## Follow-up

Wire `select_review_mode` into the runner and build the map-reduce map/reduce LLM stages (#680) so over-cap diffs are reviewed per-file with no truncation; the fail-closed guard then becomes a backstop for pathological cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)