### PR TITLE
chore(trusty-agents): make ETXTBSY backoff shift overflow-safe (closes #1642)

### DIFF
--- a/crates/trusty-agents/src/agents/claude_code_runner/mod.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/mod.rs
@@ -240,10 +240,13 @@ where
             Ok(child) => return Ok(child),
             Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
                 last_err = Some(e);
-                tokio::time::sleep(std::time::Duration::from_millis(
-                    BACKOFF_MS * (1 << attempt),
-                ))
-                .await;
+                // Exponential backoff: 5ms, 10ms, 20ms for MAX_ATTEMPTS=3.
+                // `attempt` is bounded by MAX_ATTEMPTS, so the shift is far
+                // below u64's 64-bit width. Use an explicit `1u64` shift and a
+                // saturating multiply so this stays overflow-safe for any
+                // reasonable MAX_ATTEMPTS value if it is ever raised.
+                let backoff_ms = BACKOFF_MS.saturating_mul(1u64 << attempt);
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
             }
             Err(e) => return Err(e),
         }


### PR DESCRIPTION
## Summary

Advisory follow-up #1642 (low severity, from trusty-review on PR #1636).

In `crates/trusty-agents/src/agents/claude_code_runner/mod.rs`, the ETXTBSY
spawn-retry backoff computed `BACKOFF_MS * (1 << attempt)`. The `1 << attempt`
shift is safe at the current `MAX_ATTEMPTS = 3`, but is a latent overflow hazard
if `MAX_ATTEMPTS` is ever raised.

## Change

- Use an explicit `1u64 << attempt` so the shift type is unambiguous.
- Use `BACKOFF_MS.saturating_mul(1u64 << attempt)` to avoid multiply overflow.
- Add a clarifying comment noting the shift is bounded by `MAX_ATTEMPTS` and is
  overflow-safe for any reasonable value.

Behavior is identical for the current `MAX_ATTEMPTS = 3` (delays 5ms, 10ms, 20ms).

## Verification

- `cargo test -p trusty-agents` — 1821 + 6 + 4 + 2 passed, 0 failed
- `cargo clippy -p trusty-agents --all-targets -- -D warnings` — exit 0, no warnings
- `cargo fmt --check` — exit 0
- `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations

Closes #1642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)