### PR TITLE
feat(trusty-mpm): SESSCTL WI-5 auth + cost model (closes #1596)

### DIFF
--- a/crates/trusty-mpm/src/control/admission.rs
+++ b/crates/trusty-mpm/src/control/admission.rs
@@ -1,0 +1,141 @@
+//! Session admission control: concurrency cap + launch stagger (§9.2, WI-5).
+//!
+//! Why: concurrent Max-OAuth sessions share one rate bucket (§9.2), so the
+//! daemon must (a) refuse to launch beyond `max_concurrent_sessions` and
+//! (b) space successive launches by `launch_stagger_ms` to avoid a thundering
+//! herd. Isolating the *decision* (admit vs. reject) into a pure function keeps
+//! it deterministically unit-testable — no clock, no sleep, no registry lock —
+//! while the registry owns the actual sleep and lock.
+//! What: [`AdmissionDecision`] is the outcome of an admission check;
+//! [`check_admission`] is the pure predicate (current live count vs. cap);
+//! [`AdmissionError`] is the typed rejection surfaced to callers.
+//! Test: `admission_*` in the inline `tests` module.
+
+use thiserror::Error;
+
+/// Outcome of an admission check (§9.2).
+///
+/// Why: callers need to distinguish "go ahead, after this stagger delay" from
+/// "rejected, cap reached" without re-deriving the rule. Carrying the stagger
+/// in the `Admit` variant means the registry never has to re-read config to
+/// know how long to sleep.
+/// What: `Admit { stagger_ms }` permits the launch after an optional delay;
+/// `Reject { live, cap }` denies it because the cap is reached.
+/// Test: `admission_under_cap_admits`, `admission_at_cap_rejects`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdmissionDecision {
+    /// The launch is permitted; sleep `stagger_ms` before spawning.
+    Admit {
+        /// Milliseconds to wait before the actual spawn (§9.2 stagger).
+        stagger_ms: u64,
+    },
+    /// The launch is denied because the concurrency cap is reached.
+    Reject {
+        /// Number of live sessions at decision time.
+        live: u32,
+        /// The configured cap.
+        cap: u32,
+    },
+}
+
+/// Typed rejection returned when a launch exceeds the concurrency cap (§9.2).
+///
+/// Why: library code uses `thiserror` (per CLAUDE.md); a structured error lets
+/// the daemon's HTTP layer map the cap rejection to a clear 429-style response
+/// and lets tests match on the variant rather than a string.
+/// What: a single `CapReached` variant carrying the live count and the cap.
+/// Test: `admission_error_display`.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AdmissionError {
+    /// The maximum number of concurrent sessions has been reached.
+    #[error(
+        "session cap reached: {live} live sessions, max_concurrent_sessions = {cap} (§9.2); \
+         stop a session or raise the cap before launching"
+    )]
+    CapReached {
+        /// Number of live sessions at decision time.
+        live: u32,
+        /// The configured cap.
+        cap: u32,
+    },
+}
+
+/// Decide whether a new session may launch given the current live count (§9.2).
+///
+/// Why: this is the single, pure decision point for the concurrency cap. Keeping
+/// it free of locks and clocks makes the cap behavior exhaustively testable and
+/// keeps the registry's locked critical section trivial.
+/// What: returns [`AdmissionDecision::Admit`] (carrying `stagger_ms`) when
+/// `live < cap`, otherwise [`AdmissionDecision::Reject`]. A `cap` of `0` rejects
+/// every launch (matches the documented `ControlPlaneConfig` semantics).
+/// Test: `admission_under_cap_admits`, `admission_at_cap_rejects`,
+/// `admission_zero_cap_always_rejects`.
+pub fn check_admission(live: u32, cap: u32, stagger_ms: u64) -> AdmissionDecision {
+    if live < cap {
+        AdmissionDecision::Admit { stagger_ms }
+    } else {
+        AdmissionDecision::Reject { live, cap }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admission_under_cap_admits() {
+        assert_eq!(
+            check_admission(0, 5, 2_000),
+            AdmissionDecision::Admit { stagger_ms: 2_000 }
+        );
+        assert_eq!(
+            check_admission(4, 5, 0),
+            AdmissionDecision::Admit { stagger_ms: 0 }
+        );
+    }
+
+    #[test]
+    fn admission_at_cap_rejects() {
+        assert_eq!(
+            check_admission(5, 5, 2_000),
+            AdmissionDecision::Reject { live: 5, cap: 5 }
+        );
+        // Over cap (should not normally happen, but be defensive) also rejects.
+        assert_eq!(
+            check_admission(6, 5, 0),
+            AdmissionDecision::Reject { live: 6, cap: 5 }
+        );
+    }
+
+    #[test]
+    fn admission_zero_cap_always_rejects() {
+        assert_eq!(
+            check_admission(0, 0, 0),
+            AdmissionDecision::Reject { live: 0, cap: 0 }
+        );
+    }
+
+    #[test]
+    fn admission_admits_exactly_up_to_cap() {
+        // With cap=3, launches at live=0,1,2 admit; live=3 rejects. This proves
+        // the cap admits EXACTLY `cap` concurrent sessions, no more.
+        for live in 0..3 {
+            assert!(matches!(
+                check_admission(live, 3, 0),
+                AdmissionDecision::Admit { .. }
+            ));
+        }
+        assert!(matches!(
+            check_admission(3, 3, 0),
+            AdmissionDecision::Reject { .. }
+        ));
+    }
+
+    #[test]
+    fn admission_error_display() {
+        let err = AdmissionError::CapReached { live: 5, cap: 5 };
+        let msg = err.to_string();
+        assert!(msg.contains("session cap reached"));
+        assert!(msg.contains("max_concurrent_sessions = 5"));
+    }
+}

--- a/crates/trusty-mpm/src/control/backend/stream_json.rs
+++ b/crates/trusty-mpm/src/control/backend/stream_json.rs
@@ -5,9 +5,11 @@
 //! newline-delimited stream-JSON events on stdout. This keeps the session warm
 //! across multiple user messages without the overhead of a new process per
 //! message, and uses Max OAuth billing by unsetting `ANTHROPIC_API_KEY` (§9.1).
-//! What: [`StreamJsonBackend`] spawns `env -u ANTHROPIC_API_KEY claude -p
-//! --output-format stream-json [--append-system-prompt-file …] --workdir <dir>`
-//! and implements [`super::SessionBackend`]. `recv()` reads stdout line-by-line
+//! What: [`StreamJsonBackend`] spawns `claude -p --output-format stream-json
+//! [--append-system-prompt-file …] --workdir <dir>` with `ANTHROPIC_API_KEY`
+//! removed from the child environment via [`build_claude_command`] (the §9.1
+//! no-key-leak seam) and implements [`super::SessionBackend`]. `recv()` reads
+//! stdout line-by-line
 //! and parses each line as a `StreamJsonEvent`. Stderr is captured but never
 //! forwarded. On clean child exit `recv()` returns `None`. A seam for the
 //! crash-watchdog / auto-restart policy (WI-4) is present but not wired in
@@ -16,7 +18,7 @@
 //! `stream_json_backend_constructs` (constructor-only; no child process),
 //! `session_input_newtype` in the inline module.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use anyhow::{Context, Result};
@@ -30,6 +32,55 @@ use crate::control::event::{SessionEvent, StreamJsonEvent};
 use crate::control::id::ControlSessionId;
 
 use super::{SessionBackend, SessionInput};
+
+/// Environment variable holding the metered Anthropic API key.
+///
+/// Why: §9.1 LOCKED requirement — this variable MUST be removed from every
+/// spawned `claude` child so the child resolves Max-OAuth credentials from
+/// `~/.claude` and no metered key leaks into a managed session. Naming it once
+/// as a constant keeps the security-critical string from drifting between the
+/// command builder and the tests that assert its removal.
+/// What: the literal `"ANTHROPIC_API_KEY"`.
+/// Test: `build_command_removes_api_key`, `build_command_removes_key_even_if_set`.
+pub const ANTHROPIC_API_KEY_VAR: &str = "ANTHROPIC_API_KEY";
+
+/// Build the `claude` stream-JSON [`std::process::Command`] for a session.
+///
+/// Why: this is the single security seam where §9.1's no-key-leak invariant is
+/// enforced. Extracting command construction into a pure function (no spawn,
+/// no I/O) lets the gating integration test inspect the built command's
+/// environment and assert `ANTHROPIC_API_KEY` is removed — WITHOUT spawning a
+/// real `claude` process. Defense-in-depth: the key is stripped two ways — an
+/// explicit [`std::process::Command::env_remove`] (which `get_envs()` exposes as
+/// an explicit removal, making it test-observable) AND, belt-and-braces, the
+/// child never inherits a re-added key because we never call `env()` for it.
+/// What: returns a `std::process::Command` for
+/// `claude -p --output-format stream-json [--append-system-prompt-file <f>]
+/// --workdir <dir>` with `ANTHROPIC_API_KEY` removed from the child env,
+/// stdin/stdout piped, stderr captured, and the working directory set. The
+/// caller converts it to a `tokio::process::Command` to spawn.
+/// Test: `build_command_removes_api_key`, `build_command_has_stream_json_args`.
+pub fn build_claude_command(workdir: &Path, prompt_file: Option<&Path>) -> std::process::Command {
+    // Invoke `claude` directly (not via the `env -u` shell wrapper). Using
+    // Command::env_remove makes the key-removal an explicit, inspectable part
+    // of the child environment (visible via get_envs() in tests), which is what
+    // the WI-5 gating test asserts. The child inherits the parent's environment
+    // MINUS the removed key.
+    let mut cmd = std::process::Command::new("claude");
+    // §9.1 LOCKED: strip the metered key so claude uses ~/.claude Max OAuth.
+    cmd.env_remove(ANTHROPIC_API_KEY_VAR);
+    cmd.arg("-p");
+    cmd.arg("--output-format").arg("stream-json");
+    if let Some(pf) = prompt_file {
+        cmd.arg("--append-system-prompt-file").arg(pf);
+    }
+    cmd.arg("--workdir").arg(workdir);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(workdir);
+    cmd
+}
 
 /// Warm headless `claude -p --output-format stream-json` execution backend.
 ///
@@ -57,33 +108,24 @@ impl StreamJsonBackend {
     /// Why: allocating the backend at session-spawn time (not lazily) lets the
     /// actor emit a `BackendSpawnError` immediately if `claude` is not found,
     /// before the session is registered with the HTTP API.
-    /// What: builds a `tokio::process::Command` for
-    /// `env -u ANTHROPIC_API_KEY claude -p --output-format stream-json
-    /// [--append-system-prompt-file <prompt_file>] --workdir <workdir>`,
-    /// spawns with stdin/stdout piped and stderr captured (never forwarded),
-    /// and wraps the handles.
+    /// What: delegates to [`build_claude_command`] (the §9.1 no-key-leak seam)
+    /// for `claude -p --output-format stream-json
+    /// [--append-system-prompt-file <prompt_file>] --workdir <workdir>` with
+    /// `ANTHROPIC_API_KEY` removed from the child environment, converts the
+    /// resulting `std::process::Command` to a `tokio::process::Command`, spawns
+    /// it (stdin/stdout piped, stderr captured and never forwarded), and wraps
+    /// the handles.
     /// Test: `stream_json_spawn_requires_claude` (integration; #[ignore] if
-    /// claude absent); constructor checked by `stream_json_backend_constructs`.
+    /// claude absent); constructor checked by `stream_json_backend_constructs`;
+    /// the no-key-leak invariant is asserted at the command seam by
+    /// `build_command_removes_api_key` and the `auth_cost` integration suite.
     pub fn spawn(
         session_id: ControlSessionId,
         workdir: PathBuf,
         prompt_file: Option<PathBuf>,
     ) -> Result<Self> {
-        let mut cmd = Command::new("env");
-        // Unset ANTHROPIC_API_KEY so claude resolves credentials from
-        // ~/.claude (Max OAuth path, §9.1 of SPEC-SESSCTL-01).
-        cmd.arg("-u").arg("ANTHROPIC_API_KEY");
-        cmd.arg("claude");
-        cmd.arg("-p");
-        cmd.arg("--output-format").arg("stream-json");
-        if let Some(pf) = prompt_file {
-            cmd.arg("--append-system-prompt-file").arg(pf);
-        }
-        cmd.arg("--workdir").arg(&workdir);
-        cmd.stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .current_dir(&workdir);
+        let std_cmd = build_claude_command(&workdir, prompt_file.as_deref());
+        let mut cmd = Command::from(std_cmd);
 
         let mut child = cmd.spawn().with_context(|| {
             format!(
@@ -226,11 +268,78 @@ impl Drop for StreamJsonBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
 
     #[test]
     fn session_input_newtype() {
         let input = SessionInput::new("hello");
         assert_eq!(input.text, "hello");
+    }
+
+    /// Collect the explicit env mutations from a built command as
+    /// `(key, Option<value>)` pairs. `None` value = `env_remove` (the security
+    /// invariant we assert below).
+    fn env_mutations(cmd: &std::process::Command) -> Vec<(String, Option<String>)> {
+        cmd.get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_command_removes_api_key() {
+        // §9.1: the built command MUST explicitly remove ANTHROPIC_API_KEY so
+        // it cannot leak into the spawned child. get_envs() surfaces an
+        // env_remove as (key, None).
+        let cmd = build_claude_command(Path::new("/tmp/wd"), None);
+        let muts = env_mutations(&cmd);
+        let removed = muts
+            .iter()
+            .find(|(k, _)| k == ANTHROPIC_API_KEY_VAR)
+            .expect("ANTHROPIC_API_KEY must appear as an explicit env mutation");
+        assert_eq!(
+            removed.1, None,
+            "ANTHROPIC_API_KEY must be REMOVED (None), never set, in the child env"
+        );
+    }
+
+    #[test]
+    fn build_command_program_is_claude() {
+        // The seam invokes `claude` directly, not the `env` shell wrapper, so
+        // get_program() is stable and inspectable.
+        let cmd = build_claude_command(Path::new("/tmp/wd"), None);
+        assert_eq!(cmd.get_program(), OsStr::new("claude"));
+    }
+
+    #[test]
+    fn build_command_has_stream_json_args() {
+        let cmd = build_claude_command(Path::new("/tmp/wd"), None);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(args.contains(&"-p".to_string()));
+        assert!(args.contains(&"--output-format".to_string()));
+        assert!(args.contains(&"stream-json".to_string()));
+        assert!(args.contains(&"--workdir".to_string()));
+        // No prompt file → no --append-system-prompt-file flag.
+        assert!(!args.contains(&"--append-system-prompt-file".to_string()));
+    }
+
+    #[test]
+    fn build_command_includes_prompt_file_when_present() {
+        let pf = PathBuf::from("/tmp/prompt.md");
+        let cmd = build_claude_command(Path::new("/tmp/wd"), Some(&pf));
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(args.contains(&"--append-system-prompt-file".to_string()));
+        assert!(args.contains(&"/tmp/prompt.md".to_string()));
     }
 
     /// Verify that spawning when `claude` is absent returns a descriptive error.

--- a/crates/trusty-mpm/src/control/classifier.rs
+++ b/crates/trusty-mpm/src/control/classifier.rs
@@ -1,0 +1,127 @@
+//! Optional OpenRouter activity classifier gate (§8.3 of SPEC-SESSCTL-01, WI-5).
+//!
+//! Why: §8.3 makes the OpenRouter LLM classifier an explicit *fallback*, not the
+//! default. AC-9 requires that with the classifier disabled (and no key) NO
+//! outbound call to openrouter.ai is ever made. The gate that decides whether to
+//! call the classifier is the single security/cost-relevant decision point, so
+//! it is isolated here as a pure function that can be exhaustively unit-tested
+//! without any network, env mutation, or LLM dependency.
+//! What: [`ClassifierGate`] captures the three §8.3 preconditions (config flag,
+//! key presence, SM-agent connection) and [`ClassifierGate::should_classify`]
+//! returns `true` only when all three permit it. No HTTP client lives here —
+//! WI-5 ships the gate; the actual OpenRouter call is wired by a later ticket
+//! once the gate proves the classifier is permitted.
+//! Test: `classifier_gate_*` in the inline `tests` module.
+
+use crate::control::config::ObservabilityConfig;
+
+/// The three §8.3 preconditions that gate the optional OpenRouter classifier.
+///
+/// Why: §8.3 lists three independent conditions, ALL of which must hold before
+/// the daemon may call OpenRouter. Modeling them as one value with one decision
+/// method keeps the policy in a single auditable place and prevents a caller
+/// from checking only a subset.
+/// What: `config_enabled` mirrors `[control_plane.observability].llm_classifier`;
+/// `api_key_present` reflects whether `OPENROUTER_API_KEY` is set in the
+/// environment; `sm_agent_connected` is `true` when a parent SM agent is
+/// attached (in which case the SM provides inference and the daemon must NOT
+/// call OpenRouter).
+/// Test: `classifier_gate_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClassifierGate {
+    /// `[control_plane.observability].llm_classifier == true`.
+    pub config_enabled: bool,
+    /// `OPENROUTER_API_KEY` is present in the environment.
+    pub api_key_present: bool,
+    /// An SM agent is currently connected (it provides inference; §8.3 #3).
+    pub sm_agent_connected: bool,
+}
+
+impl ClassifierGate {
+    /// Build a gate from the observability config and the two runtime signals.
+    ///
+    /// Why: callers hold a [`ObservabilityConfig`] and two booleans; this
+    /// constructor keeps the field-mapping in one spot so the gate's three
+    /// inputs always come from the same authoritative sources.
+    /// What: copies `config.llm_classifier` into `config_enabled` and stores the
+    /// two runtime signals verbatim.
+    /// Test: `classifier_gate_from_config`.
+    pub fn from_config(
+        config: &ObservabilityConfig,
+        api_key_present: bool,
+        sm_agent_connected: bool,
+    ) -> Self {
+        Self {
+            config_enabled: config.llm_classifier,
+            api_key_present,
+            sm_agent_connected,
+        }
+    }
+
+    /// Decide whether the OpenRouter classifier may be invoked (§8.3).
+    ///
+    /// Why: this is the AC-9 enforcement point — if it returns `false` no
+    /// outbound OpenRouter call is permitted, guaranteeing the default path
+    /// (classifier off, no key) never touches the network.
+    /// What: returns `true` only when ALL of: the config flag is on, the API key
+    /// is present, AND no SM agent is connected (an attached SM provides the
+    /// inference itself, per §8.3 condition 3).
+    /// Test: `classifier_gate_all_off`, `classifier_gate_requires_all_three`,
+    /// `classifier_gate_sm_connected_blocks`.
+    pub fn should_classify(&self) -> bool {
+        self.config_enabled && self.api_key_present && !self.sm_agent_connected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gate(config_enabled: bool, api_key_present: bool, sm_agent_connected: bool) -> ClassifierGate {
+        ClassifierGate {
+            config_enabled,
+            api_key_present,
+            sm_agent_connected,
+        }
+    }
+
+    #[test]
+    fn classifier_gate_all_off() {
+        // Default path: classifier disabled, no key, no SM → never classify.
+        assert!(!gate(false, false, false).should_classify());
+    }
+
+    #[test]
+    fn classifier_gate_requires_all_three() {
+        // Only when config-on AND key-present AND no-SM does the gate open.
+        assert!(gate(true, true, false).should_classify());
+
+        // Each single missing precondition closes the gate.
+        assert!(!gate(false, true, false).should_classify(), "config off blocks");
+        assert!(!gate(true, false, false).should_classify(), "no key blocks");
+    }
+
+    #[test]
+    fn classifier_gate_sm_connected_blocks() {
+        // Even with config-on and key-present, an attached SM agent blocks the
+        // classifier (the SM provides inference; §8.3 condition 3).
+        assert!(!gate(true, true, true).should_classify());
+    }
+
+    #[test]
+    fn classifier_gate_from_config() {
+        let on = ObservabilityConfig {
+            llm_classifier: true,
+        };
+        let g = ClassifierGate::from_config(&on, true, false);
+        assert!(g.config_enabled);
+        assert!(g.api_key_present);
+        assert!(!g.sm_agent_connected);
+        assert!(g.should_classify());
+
+        let off = ObservabilityConfig::default();
+        let g2 = ClassifierGate::from_config(&off, true, false);
+        assert!(!g2.config_enabled);
+        assert!(!g2.should_classify());
+    }
+}

--- a/crates/trusty-mpm/src/control/classifier.rs
+++ b/crates/trusty-mpm/src/control/classifier.rs
@@ -77,7 +77,11 @@ impl ClassifierGate {
 mod tests {
     use super::*;
 
-    fn gate(config_enabled: bool, api_key_present: bool, sm_agent_connected: bool) -> ClassifierGate {
+    fn gate(
+        config_enabled: bool,
+        api_key_present: bool,
+        sm_agent_connected: bool,
+    ) -> ClassifierGate {
         ClassifierGate {
             config_enabled,
             api_key_present,
@@ -97,7 +101,10 @@ mod tests {
         assert!(gate(true, true, false).should_classify());
 
         // Each single missing precondition closes the gate.
-        assert!(!gate(false, true, false).should_classify(), "config off blocks");
+        assert!(
+            !gate(false, true, false).should_classify(),
+            "config off blocks"
+        );
         assert!(!gate(true, false, false).should_classify(), "no key blocks");
     }
 

--- a/crates/trusty-mpm/src/control/config.rs
+++ b/crates/trusty-mpm/src/control/config.rs
@@ -58,10 +58,9 @@ pub const DEFAULT_AUTH_TIMEOUT_SECS: u64 = 30;
 #[serde(default)]
 pub struct ControlPlaneConfig {
     /// Maximum number of concurrent live sessions (§9.2). Default `5`. A value
-    /// of `0` is treated as "no admission allowed" (every launch is rejected);
-    /// operators who want unbounded fan-out should not set this section at all
-    /// is NOT an option — the default cap always applies. Use a large number to
-    /// effectively disable the cap.
+    /// of `0` is treated as "no admission allowed" (every launch is rejected).
+    /// There is no "unbounded" sentinel: to effectively disable the cap, set a
+    /// large number.
     pub max_concurrent_sessions: u32,
 
     /// Delay in milliseconds applied before each session launch when launching
@@ -207,7 +206,10 @@ launch_stagger_ms = 0
             launch_stagger_ms: 1_500,
             ..Default::default()
         };
-        assert_eq!(cfg.stagger_duration(), std::time::Duration::from_millis(1_500));
+        assert_eq!(
+            cfg.stagger_duration(),
+            std::time::Duration::from_millis(1_500)
+        );
         // Zero stagger (test-injection path) yields a zero duration.
         let zero = ControlPlaneConfig {
             launch_stagger_ms: 0,

--- a/crates/trusty-mpm/src/control/config.rs
+++ b/crates/trusty-mpm/src/control/config.rs
@@ -1,0 +1,224 @@
+//! Control-plane auth + cost configuration (§9 of SPEC-SESSCTL-01, WI-5 #1596).
+//!
+//! Why: WI-5 introduces the auth-and-cost guardrails for the session control
+//! plane — a concurrent-session cap, a staggered-launch delay, an auth timeout,
+//! and the optional OpenRouter activity classifier (§8.3). These need a single,
+//! opt-in, fully-defaulted config surface so operators can tune them in
+//! `~/.trusty-mpm/config.toml` without recompiling, and so an absent or partial
+//! `[control_plane]` section deserializes to the spec's documented defaults
+//! (cap 5, stagger 2000 ms, auth timeout 30 s, classifier off).
+//! What: [`ControlPlaneConfig`] mirrors the §9 / §8.3 TOML shape — three
+//! top-level cost fields plus a nested `[control_plane.observability]`
+//! subsection that gates the optional LLM classifier. Every struct and field is
+//! `#[serde(default)]` so partial and absent config both parse.
+//! Test: `control_plane_config_*` in the inline `tests` module.
+
+use serde::{Deserialize, Serialize};
+
+/// Default maximum number of concurrent sessions (§9.2).
+///
+/// Why: a single named constant keeps the spec default (`5`) authoritative and
+/// referenceable from both `Default` and tests, so a careless edit fails a
+/// pinning test rather than silently changing behavior.
+/// What: the spec §9.2 `max_concurrent_sessions` default.
+/// Test: `control_plane_config_default_values`.
+pub const DEFAULT_MAX_CONCURRENT_SESSIONS: u32 = 5;
+
+/// Default launch-stagger delay in milliseconds (§9.2).
+///
+/// Why: the spec mandates a 2 s gap between successive spawns to avoid
+/// thundering-herd contention on the shared Max rate bucket; pinning it as a
+/// constant lets tests reference it and guards against accidental zeroing.
+/// What: the spec §9.2 `launch_stagger_ms` default.
+/// Test: `control_plane_config_default_values`.
+pub const DEFAULT_LAUNCH_STAGGER_MS: u64 = 2_000;
+
+/// Default auth timeout in seconds (§4.4).
+///
+/// Why: a stream-JSON session that lands in `AuthFailed` auto-stops after this
+/// many seconds if the operator does not intervene; pinning the spec default
+/// (`30`) keeps `tm auth`'s documented behavior stable.
+/// What: the spec §4.4 `auth_timeout_secs` default.
+/// Test: `control_plane_config_default_values`.
+pub const DEFAULT_AUTH_TIMEOUT_SECS: u64 = 30;
+
+/// `[control_plane]` — auth + cost model configuration (§9 of SPEC-SESSCTL-01).
+///
+/// Why: the daemon must enforce a concurrency cap and a launch stagger to keep
+/// concurrent Max-OAuth sessions from saturating the shared rate bucket (§9.2),
+/// and must size the auth timeout (§4.4). Bundling these into one typed,
+/// fully-defaulted struct gives the registry a single injectable knob set and
+/// keeps absent config a strict no-op (all spec defaults).
+/// What: `max_concurrent_sessions` (cap), `launch_stagger_ms` (inter-spawn
+/// delay), `auth_timeout_secs` (stream-JSON `AuthFailed` auto-stop), and the
+/// nested `observability` subsection (LLM-classifier gate, §8.3). All fields
+/// `#[serde(default)]`.
+/// Test: `control_plane_config_full_parsed`, `control_plane_config_absent_is_default`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ControlPlaneConfig {
+    /// Maximum number of concurrent live sessions (§9.2). Default `5`. A value
+    /// of `0` is treated as "no admission allowed" (every launch is rejected);
+    /// operators who want unbounded fan-out should not set this section at all
+    /// is NOT an option — the default cap always applies. Use a large number to
+    /// effectively disable the cap.
+    pub max_concurrent_sessions: u32,
+
+    /// Delay in milliseconds applied before each session launch when launching
+    /// in a loop (§9.2). Default `2000`. Tests inject `0` for determinism.
+    pub launch_stagger_ms: u64,
+
+    /// Seconds a stream-JSON session may remain in `AuthFailed` before the
+    /// daemon auto-stops it (§4.4). Default `30`.
+    pub auth_timeout_secs: u64,
+
+    /// `[control_plane.observability]` — optional LLM-classifier gate (§8.3).
+    pub observability: ObservabilityConfig,
+}
+
+impl Default for ControlPlaneConfig {
+    /// Why: `#[serde(default)]` on each field requires a `Default` whose values
+    /// match the spec §9 / §4.4 documented defaults, not Rust zero-values
+    /// (which would give `max_concurrent_sessions = 0`, blocking all launches).
+    /// What: returns cap `5`, stagger `2000 ms`, auth timeout `30 s`, and the
+    /// default (classifier-off) observability subsection.
+    /// Test: `control_plane_config_default_values`.
+    fn default() -> Self {
+        Self {
+            max_concurrent_sessions: DEFAULT_MAX_CONCURRENT_SESSIONS,
+            launch_stagger_ms: DEFAULT_LAUNCH_STAGGER_MS,
+            auth_timeout_secs: DEFAULT_AUTH_TIMEOUT_SECS,
+            observability: ObservabilityConfig::default(),
+        }
+    }
+}
+
+impl ControlPlaneConfig {
+    /// Returns the launch stagger as a [`std::time::Duration`].
+    ///
+    /// Why: the registry's stagger-sleep path wants a `Duration`, not a raw
+    /// millisecond count; centralizing the conversion keeps unit handling in
+    /// one place.
+    /// What: `Duration::from_millis(self.launch_stagger_ms)`.
+    /// Test: `control_plane_config_stagger_duration`.
+    pub fn stagger_duration(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(self.launch_stagger_ms)
+    }
+
+    /// Returns the auth timeout as a [`std::time::Duration`].
+    ///
+    /// Why: callers that arm the `AuthFailed` auto-stop timer want a `Duration`.
+    /// What: `Duration::from_secs(self.auth_timeout_secs)`.
+    /// Test: `control_plane_config_auth_timeout_duration`.
+    pub fn auth_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.auth_timeout_secs)
+    }
+}
+
+/// `[control_plane.observability]` — optional OpenRouter classifier gate (§8.3).
+///
+/// Why: the §8.3 LLM classifier is an explicit fallback, NOT the default. It is
+/// gated by config so the default path never requires an `OPENROUTER_API_KEY`
+/// and never makes an outbound call. Encoding the gate as a typed flag (default
+/// `false`) makes the no-op guarantee (AC-9) auditable.
+/// What: a single `llm_classifier` toggle (default `false`).
+/// Test: `control_plane_config_default_values`, `observability_classifier_default_off`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ObservabilityConfig {
+    /// Enable the optional §8.3 OpenRouter classifier. Default `false`. Even
+    /// when `true`, the classifier only runs if `OPENROUTER_API_KEY` is present
+    /// AND no SM agent is connected (see [`classifier`](crate::control::classifier)).
+    pub llm_classifier: bool,
+}
+
+impl Default for ObservabilityConfig {
+    /// Why: the headline AC-9 guarantee is that the classifier is OFF by
+    /// default; the derived zero-value `Default` happens to give `false` but we
+    /// spell it out so the intent is explicit and a future field addition does
+    /// not silently flip it.
+    /// What: returns `llm_classifier = false`.
+    /// Test: `observability_classifier_default_off`.
+    fn default() -> Self {
+        Self {
+            llm_classifier: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn control_plane_config_absent_is_default() {
+        let cfg: ControlPlaneConfig = toml::from_str("").expect("empty input parses");
+        assert_eq!(cfg, ControlPlaneConfig::default());
+    }
+
+    #[test]
+    fn control_plane_config_default_values() {
+        let cfg = ControlPlaneConfig::default();
+        assert_eq!(cfg.max_concurrent_sessions, 5);
+        assert_eq!(cfg.launch_stagger_ms, 2_000);
+        assert_eq!(cfg.auth_timeout_secs, 30);
+        assert!(!cfg.observability.llm_classifier);
+    }
+
+    #[test]
+    fn observability_classifier_default_off() {
+        assert!(!ObservabilityConfig::default().llm_classifier);
+    }
+
+    #[test]
+    fn control_plane_config_full_parsed() {
+        let toml = r#"
+max_concurrent_sessions = 8
+launch_stagger_ms = 500
+auth_timeout_secs = 45
+
+[observability]
+llm_classifier = true
+"#;
+        let cfg: ControlPlaneConfig = toml::from_str(toml).expect("full config parses");
+        assert_eq!(cfg.max_concurrent_sessions, 8);
+        assert_eq!(cfg.launch_stagger_ms, 500);
+        assert_eq!(cfg.auth_timeout_secs, 45);
+        assert!(cfg.observability.llm_classifier);
+    }
+
+    #[test]
+    fn control_plane_config_partial_takes_defaults() {
+        let toml = r#"
+launch_stagger_ms = 0
+"#;
+        let cfg: ControlPlaneConfig = toml::from_str(toml).expect("partial config parses");
+        // Explicitly set:
+        assert_eq!(cfg.launch_stagger_ms, 0);
+        // Defaulted:
+        assert_eq!(cfg.max_concurrent_sessions, 5);
+        assert_eq!(cfg.auth_timeout_secs, 30);
+        assert_eq!(cfg.observability, ObservabilityConfig::default());
+    }
+
+    #[test]
+    fn control_plane_config_stagger_duration() {
+        let cfg = ControlPlaneConfig {
+            launch_stagger_ms: 1_500,
+            ..Default::default()
+        };
+        assert_eq!(cfg.stagger_duration(), std::time::Duration::from_millis(1_500));
+        // Zero stagger (test-injection path) yields a zero duration.
+        let zero = ControlPlaneConfig {
+            launch_stagger_ms: 0,
+            ..Default::default()
+        };
+        assert_eq!(zero.stagger_duration(), std::time::Duration::ZERO);
+    }
+
+    #[test]
+    fn control_plane_config_auth_timeout_duration() {
+        let cfg = ControlPlaneConfig::default();
+        assert_eq!(cfg.auth_timeout(), std::time::Duration::from_secs(30));
+    }
+}

--- a/crates/trusty-mpm/src/control/mod.rs
+++ b/crates/trusty-mpm/src/control/mod.rs
@@ -6,20 +6,27 @@
 //! module is the Phase 1 foundation: the runtime-adapter trait, two concrete
 //! backends, the actor skeleton, and the registry. WI-3 adds the §8.2
 //! regex/NLP parse layer via the `activity` submodule.
-//! What: re-exports the public API from six focused sub-modules:
-//!   - `activity` — §8.2 regex/NLP parse layer (`ActivityParser`, `ParseResult`)
-//!   - `id`       — `ControlSessionId` newtype + `SessionCounter` allocator
-//!   - `event`    — `SessionEvent` enum + supporting types
-//!   - `state`    — `SessionState` machine + `SessionMetadata` snapshot
-//!   - `backend`  — `SessionBackend` trait + `StreamJsonBackend` + `TmuxBackend`
-//!   - `actor`    — `SessionActor` task + `SessionActorHandle` + `spawn_actor`
-//!   - `registry` — `SessionRegistry` + `RunParams`
+//! What: re-exports the public API from focused sub-modules:
+//!   - `activity`   — §8.2 regex/NLP parse layer (`ActivityParser`, `ParseResult`)
+//!   - `admission`  — §9.2 concurrency-cap admission decision (WI-5)
+//!   - `classifier` — §8.3 optional OpenRouter classifier gate (WI-5)
+//!   - `config`     — §9 auth + cost `ControlPlaneConfig` (WI-5)
+//!   - `id`         — `ControlSessionId` newtype + `SessionCounter` allocator
+//!   - `event`      — `SessionEvent` enum + supporting types
+//!   - `state`      — `SessionState` machine + `SessionMetadata` snapshot
+//!   - `backend`    — `SessionBackend` trait + `StreamJsonBackend` + `TmuxBackend`
+//!   - `actor`      — `SessionActor` task + `SessionActorHandle` + `spawn_actor`
+//!   - `registry`   — `SessionRegistry` + `RunParams`
 //! Test: each submodule carries inline unit tests; run with
-//! `cargo test -p trusty-mpm control::` to scope to this module.
+//! `cargo test -p trusty-mpm control::` to scope to this module. The WI-5
+//! no-key-leak gating integration test lives in `tests/auth_cost.rs`.
 
 pub mod activity;
 pub mod actor;
+pub mod admission;
 pub mod backend;
+pub mod classifier;
+pub mod config;
 pub mod event;
 pub mod id;
 pub mod registry;
@@ -27,7 +34,10 @@ pub mod state;
 
 // Convenience re-exports so consumers can import from `crate::control::*`.
 pub use actor::{ActorCommand, DEFAULT_BROADCAST_CAPACITY, SessionActorHandle, spawn_actor};
+pub use admission::{AdmissionDecision, AdmissionError, check_admission};
 pub use backend::{SessionBackend, SessionInput};
+pub use classifier::ClassifierGate;
+pub use config::{ControlPlaneConfig, ObservabilityConfig};
 pub use event::{ActivityKind, BackendKind, SessionEvent, StopReason, StreamJsonEvent};
 pub use id::{ControlSessionId, SessionCounter};
 pub use registry::{RunParams, SessionRegistry};

--- a/crates/trusty-mpm/src/control/registry.rs
+++ b/crates/trusty-mpm/src/control/registry.rs
@@ -239,7 +239,10 @@ impl SessionRegistry {
         if let AdmissionDecision::Reject { live, cap } =
             check_admission(live, self.config.max_concurrent_sessions, 0)
         {
-            warn!(live, cap, "session launch rejected: concurrency cap reached (§9.2)");
+            warn!(
+                live,
+                cap, "session launch rejected: concurrency cap reached (§9.2)"
+            );
             return Err(AdmissionError::CapReached { live, cap }.into());
         }
 

--- a/crates/trusty-mpm/src/control/registry.rs
+++ b/crates/trusty-mpm/src/control/registry.rs
@@ -21,8 +21,10 @@ use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 use crate::control::actor::{DEFAULT_BROADCAST_CAPACITY, SessionActorHandle, spawn_actor};
+use crate::control::admission::{AdmissionDecision, AdmissionError, check_admission};
 use crate::control::backend::stream_json::StreamJsonBackend;
 use crate::control::backend::tmux::TmuxBackend;
+use crate::control::config::ControlPlaneConfig;
 use crate::control::event::BackendKind;
 use crate::control::id::{ControlSessionId, SessionCounter};
 
@@ -60,6 +62,10 @@ pub struct RunParams {
 #[derive(Clone, Debug)]
 pub struct SessionRegistry {
     inner: Arc<RwLock<RegistryInner>>,
+    /// Auth + cost guardrails (§9): concurrency cap, launch stagger, auth
+    /// timeout, classifier gate. Shared so the daemon can read the same config
+    /// the registry enforces.
+    config: Arc<ControlPlaneConfig>,
 }
 
 struct RegistryInner {
@@ -76,19 +82,56 @@ impl std::fmt::Debug for RegistryInner {
 }
 
 impl SessionRegistry {
-    /// Create a new empty registry.
+    /// Create a new empty registry with the default control-plane config.
     ///
     /// Why: the daemon constructs a registry at startup and injects it into
-    /// every handler; an empty initial state is the correct starting point.
-    /// What: allocates the `Arc<RwLock<…>>` with an empty map and counter.
-    /// Test: all registry tests construct via `new()`.
+    /// every handler; an empty initial state with spec-default guardrails (cap
+    /// 5, stagger 2 s) is the correct starting point.
+    /// What: allocates the `Arc<RwLock<…>>` with an empty map and counter and a
+    /// [`ControlPlaneConfig::default`].
+    /// Test: all registry tests construct via `new()` or `with_config()`.
     pub fn new() -> Self {
+        Self::with_config(ControlPlaneConfig::default())
+    }
+
+    /// Create a new empty registry with an explicit control-plane config.
+    ///
+    /// Why: the daemon loads `[control_plane]` from the operator's config and
+    /// must inject the cap/stagger/timeout values the registry enforces. Tests
+    /// inject a zero-stagger config for deterministic, fast cap testing.
+    /// What: allocates the registry as in `new()` but stores the supplied
+    /// `ControlPlaneConfig` (wrapped in an `Arc` for cheap cloning).
+    /// Test: `registry_cap_rejects_over_limit`, `registry_stagger_zero_is_instant`.
+    pub fn with_config(config: ControlPlaneConfig) -> Self {
         Self {
             inner: Arc::new(RwLock::new(RegistryInner {
                 actors: HashMap::new(),
                 counter: SessionCounter::default(),
             })),
+            config: Arc::new(config),
         }
+    }
+
+    /// Borrow the registry's control-plane config (§9).
+    ///
+    /// Why: HTTP handlers and the daemon's classifier gate need to read the
+    /// same config the registry enforces (e.g. the auth timeout, the classifier
+    /// flag) without cloning the whole struct.
+    /// What: returns a `&ControlPlaneConfig` for the lifetime of the borrow.
+    /// Test: `registry_exposes_config`.
+    pub fn config(&self) -> &ControlPlaneConfig {
+        &self.config
+    }
+
+    /// Number of live sessions currently registered.
+    ///
+    /// Why: `tm list` summaries and the admission check both need the current
+    /// live count; exposing it avoids forcing callers to materialize the full
+    /// id list just to count.
+    /// What: acquires the read lock and returns `actors.len()`.
+    /// Test: `registry_live_count`.
+    pub async fn live_count(&self) -> usize {
+        self.inner.read().await.actors.len()
     }
 
     /// Register an actor handle under a session ID.
@@ -144,22 +187,62 @@ impl SessionRegistry {
         inner.actors.keys().cloned().collect()
     }
 
-    /// Allocate a session ID and spawn an actor via the selected backend.
+    /// Check the §9.2 concurrency cap against the current live count.
+    ///
+    /// Why: callers (and the staggered-launch loop) sometimes want to know
+    /// whether a launch would be admitted *before* paying the stagger delay, so
+    /// they can fail fast. `run_session` ALSO re-checks under the write lock so
+    /// this pre-check is advisory, not the authoritative gate.
+    /// What: reads the live count under the read lock and runs the pure
+    /// [`check_admission`] predicate with the configured cap and stagger.
+    /// Test: `registry_admission_check`.
+    pub async fn admission(&self) -> AdmissionDecision {
+        let live = self.live_count().await as u32;
+        check_admission(
+            live,
+            self.config.max_concurrent_sessions,
+            self.config.launch_stagger_ms,
+        )
+    }
+
+    /// Allocate a session ID and spawn an actor via the selected backend,
+    /// enforcing the §9.2 concurrency cap and launch stagger.
     ///
     /// Why: `tm run <project-id>` must go through the registry so the ID
     /// counter is authoritative and an issued ID is always observable by
-    /// concurrent `get()` / `list_ids()` callers. The former two-step pattern
-    /// (allocate → release lock → spawn → re-acquire to register) had a TOCTOU
-    /// gap: the ID existed but `get()` returned `None` during backend setup.
-    /// What: holds ONE write lock for the entire sequence — ID allocation,
-    /// backend construction, actor spawn, and handle insertion — so `get(&id)`
-    /// is never `None` for a returned ID. Backend construction (`Command::spawn`
-    /// or `tmux new-session`) takes O(10 ms) in the worst case; holding the
-    /// write lock across that is acceptable for Phase 1.
+    /// concurrent `get()` / `list_ids()` callers. WI-5 (§9.2) adds two cost
+    /// guardrails here: the concurrency cap (hard limit, enforced under the
+    /// write lock so it is race-free) and the launch stagger (applied BEFORE
+    /// the lock so it spaces successive launches without serializing the lock).
+    /// What: (1) applies the configured `launch_stagger_ms` sleep up front;
+    /// (2) acquires ONE write lock and re-checks the cap authoritatively —
+    /// rejecting with [`AdmissionError::CapReached`] if `live >= cap`; (3) holds
+    /// that lock for ID allocation, backend construction, actor spawn, and
+    /// handle insertion so `get(&id)` is never `None` for a returned ID.
     /// Returns the allocated `ControlSessionId`.
-    /// Test: `registry_run_session`, `registry_run_session_id_visible_immediately`.
+    /// Test: `registry_run_session`, `registry_run_session_id_visible_immediately`,
+    /// `registry_cap_rejects_over_limit`.
     pub async fn run_session(&self, params: RunParams) -> Result<ControlSessionId> {
+        // §9.2 launch stagger — applied before acquiring the lock so concurrent
+        // launches are spaced without serializing the registry. Tests inject a
+        // zero stagger (Duration::ZERO) so this is a no-op and stays fast.
+        let stagger = self.config.stagger_duration();
+        if !stagger.is_zero() {
+            tokio::time::sleep(stagger).await;
+        }
+
         let mut inner = self.inner.write().await;
+
+        // §9.2 concurrency cap — authoritative check under the write lock so two
+        // concurrent launches cannot both slip past a stale count.
+        let live = inner.actors.len() as u32;
+        if let AdmissionDecision::Reject { live, cap } =
+            check_admission(live, self.config.max_concurrent_sessions, 0)
+        {
+            warn!(live, cap, "session launch rejected: concurrency cap reached (§9.2)");
+            return Err(AdmissionError::CapReached { live, cap }.into());
+        }
+
         let session_id = inner.counter.next(&params.project_id);
 
         info!(
@@ -317,6 +400,79 @@ mod tests {
         assert!(
             registry.get(&id).await.is_some(),
             "session must be visible immediately after registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_live_count_and_config() {
+        // Default config: cap 5, stagger 2000, classifier off.
+        let registry = SessionRegistry::new();
+        assert_eq!(registry.live_count().await, 0);
+        assert_eq!(registry.config().max_concurrent_sessions, 5);
+        assert!(!registry.config().observability.llm_classifier);
+
+        let id = ControlSessionId::new("p", 0);
+        registry.register(id.clone(), make_handle(&id)).await;
+        assert_eq!(registry.live_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn registry_admission_check_under_cap_admits() {
+        // cap=2, zero stagger so tests stay fast.
+        let cfg = ControlPlaneConfig {
+            max_concurrent_sessions: 2,
+            launch_stagger_ms: 0,
+            ..Default::default()
+        };
+        let registry = SessionRegistry::with_config(cfg);
+        assert!(matches!(
+            registry.admission().await,
+            AdmissionDecision::Admit { stagger_ms: 0 }
+        ));
+
+        // Fill to cap with placeholder handles.
+        for n in 0..2 {
+            let id = ControlSessionId::new("p", n);
+            registry.register(id.clone(), make_handle(&id)).await;
+        }
+        // Now at cap → reject.
+        assert!(matches!(
+            registry.admission().await,
+            AdmissionDecision::Reject { live: 2, cap: 2 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn registry_run_session_rejects_when_capped() {
+        // cap=1, zero stagger. Fill with one placeholder, then run_session must
+        // reject with CapReached without spawning a backend.
+        let cfg = ControlPlaneConfig {
+            max_concurrent_sessions: 1,
+            launch_stagger_ms: 0,
+            ..Default::default()
+        };
+        let registry = SessionRegistry::with_config(cfg);
+        let id = ControlSessionId::new("p", 0);
+        registry.register(id.clone(), make_handle(&id)).await;
+
+        let params = RunParams {
+            project_id: "p".into(),
+            workdir: PathBuf::from("/tmp"),
+            backend: BackendKind::StreamJson,
+            prompt_file: None,
+            claude_cmd: None,
+        };
+        let err = registry
+            .run_session(params)
+            .await
+            .expect_err("run_session must reject when at cap");
+        // The error chain must carry the typed CapReached rejection.
+        let admission_err = err
+            .downcast_ref::<crate::control::admission::AdmissionError>()
+            .expect("error must be an AdmissionError");
+        assert_eq!(
+            *admission_err,
+            crate::control::admission::AdmissionError::CapReached { live: 1, cap: 1 }
         );
     }
 

--- a/crates/trusty-mpm/src/control/registry.rs
+++ b/crates/trusty-mpm/src/control/registry.rs
@@ -212,20 +212,43 @@ impl SessionRegistry {
     /// counter is authoritative and an issued ID is always observable by
     /// concurrent `get()` / `list_ids()` callers. WI-5 (§9.2) adds two cost
     /// guardrails here: the concurrency cap (hard limit, enforced under the
-    /// write lock so it is race-free) and the launch stagger (applied BEFORE
-    /// the lock so it spaces successive launches without serializing the lock).
-    /// What: (1) applies the configured `launch_stagger_ms` sleep up front;
-    /// (2) acquires ONE write lock and re-checks the cap authoritatively —
-    /// rejecting with [`AdmissionError::CapReached`] if `live >= cap`; (3) holds
-    /// that lock for ID allocation, backend construction, actor spawn, and
+    /// write lock so it is race-free) and the launch stagger (applied ONLY on
+    /// the admit path, so a rejected launch returns immediately without paying
+    /// the stagger delay).
+    /// What: (1) acquires a write lock and performs a fast-fail cap check —
+    /// returning [`AdmissionError::CapReached`] immediately (no stagger) if
+    /// `live >= cap`; (2) on the admit path, releases the lock, sleeps the
+    /// configured `launch_stagger_ms`, then re-acquires the write lock and
+    /// re-checks the cap authoritatively (preventing a concurrent launch that
+    /// slipped in during the stagger from exceeding the cap); (3) holds that
+    /// second lock for ID allocation, backend construction, actor spawn, and
     /// handle insertion so `get(&id)` is never `None` for a returned ID.
     /// Returns the allocated `ControlSessionId`.
     /// Test: `registry_run_session`, `registry_run_session_id_visible_immediately`,
-    /// `registry_cap_rejects_over_limit`.
+    /// `registry_run_session_rejects_when_capped`, `registry_cap_reject_is_immediate`.
     pub async fn run_session(&self, params: RunParams) -> Result<ControlSessionId> {
-        // §9.2 launch stagger — applied before acquiring the lock so concurrent
-        // launches are spaced without serializing the registry. Tests inject a
-        // zero stagger (Duration::ZERO) so this is a no-op and stays fast.
+        // §9.2 fast-fail cap check — under the read lock (cheap; no writers
+        // blocked). A stale count that causes a false-admit is caught by the
+        // authoritative write-lock recheck below; a false-reject is safe
+        // (conservative). A rejected launch returns immediately, paying ZERO
+        // stagger delay.
+        {
+            let inner = self.inner.read().await;
+            let live = inner.actors.len() as u32;
+            if let AdmissionDecision::Reject { live, cap } =
+                check_admission(live, self.config.max_concurrent_sessions, 0)
+            {
+                warn!(
+                    live,
+                    cap, "session launch rejected: concurrency cap reached (§9.2)"
+                );
+                return Err(AdmissionError::CapReached { live, cap }.into());
+            }
+        }
+
+        // §9.2 launch stagger — applied ONLY on the admit path, AFTER the
+        // cap check, so rejected launches pay zero delay. Tests inject zero
+        // stagger (Duration::ZERO) so this guard is a no-op and stays fast.
         let stagger = self.config.stagger_duration();
         if !stagger.is_zero() {
             tokio::time::sleep(stagger).await;
@@ -233,15 +256,17 @@ impl SessionRegistry {
 
         let mut inner = self.inner.write().await;
 
-        // §9.2 concurrency cap — authoritative check under the write lock so two
-        // concurrent launches cannot both slip past a stale count.
+        // §9.2 authoritative re-check under the write lock. A concurrent
+        // launch may have been admitted during our stagger sleep and pushed
+        // the count to the cap; re-checking here closes that TOCTOU window.
         let live = inner.actors.len() as u32;
         if let AdmissionDecision::Reject { live, cap } =
             check_admission(live, self.config.max_concurrent_sessions, 0)
         {
             warn!(
                 live,
-                cap, "session launch rejected: concurrency cap reached (§9.2)"
+                cap,
+                "session launch rejected at write-lock recheck (concurrent launch raced, §9.2)"
             );
             return Err(AdmissionError::CapReached { live, cap }.into());
         }
@@ -497,5 +522,63 @@ mod tests {
         assert!(!h2.try_acquire_write_lock()); // same Arc → same flag
         h1.release_write_lock();
         assert!(h2.try_acquire_write_lock()); // now acquirable
+    }
+
+    /// A rejected launch returns immediately without paying the stagger delay.
+    ///
+    /// Why: §9.2 stagger is a *spacing* mechanism for admitted sessions, not a
+    /// penalty for all launches. A rejected launch must fail fast so callers
+    /// get a prompt error rather than waiting for a stagger that will never
+    /// produce a session. This test injects a non-zero stagger (200 ms) to
+    /// make any accidental stagger-before-reject detectable on a wall-clock
+    /// assertion with generous headroom.
+    /// What: configures cap=1, stagger=200 ms; pre-fills to cap; calls
+    /// `run_session` and times the call — it must complete in well under 200 ms
+    /// (we allow 150 ms slack for scheduling noise) and must return `CapReached`.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn registry_cap_reject_is_immediate() {
+        use std::time::Instant;
+
+        // 200 ms stagger — detectable if paid, negligible if skipped.
+        let cfg = ControlPlaneConfig {
+            max_concurrent_sessions: 1,
+            launch_stagger_ms: 200,
+            ..Default::default()
+        };
+        let registry = SessionRegistry::with_config(cfg);
+        let id = ControlSessionId::new("p", 0);
+        registry.register(id.clone(), make_handle(&id)).await;
+
+        let t0 = Instant::now();
+        let params = RunParams {
+            project_id: "p".into(),
+            workdir: PathBuf::from("/tmp"),
+            backend: BackendKind::StreamJson,
+            prompt_file: None,
+            claude_cmd: None,
+        };
+        let err = registry
+            .run_session(params)
+            .await
+            .expect_err("must reject at cap");
+        let elapsed = t0.elapsed();
+
+        // Must return CapReached.
+        let admission_err = err
+            .downcast_ref::<crate::control::admission::AdmissionError>()
+            .expect("error must be AdmissionError");
+        assert_eq!(
+            *admission_err,
+            crate::control::admission::AdmissionError::CapReached { live: 1, cap: 1 }
+        );
+
+        // Must NOT have paid the 200 ms stagger — allow 150 ms for scheduling
+        // noise (CI machines can be slow; 200 - 150 = 50 ms true budget).
+        assert!(
+            elapsed.as_millis() < 150,
+            "rejected launch must return in <150 ms, not {} ms (stagger must not be paid on reject path)",
+            elapsed.as_millis()
+        );
     }
 }

--- a/crates/trusty-mpm/src/control/registry.rs
+++ b/crates/trusty-mpm/src/control/registry.rs
@@ -529,21 +529,22 @@ mod tests {
     /// Why: §9.2 stagger is a *spacing* mechanism for admitted sessions, not a
     /// penalty for all launches. A rejected launch must fail fast so callers
     /// get a prompt error rather than waiting for a stagger that will never
-    /// produce a session. This test injects a non-zero stagger (200 ms) to
-    /// make any accidental stagger-before-reject detectable on a wall-clock
-    /// assertion with generous headroom.
-    /// What: configures cap=1, stagger=200 ms; pre-fills to cap; calls
-    /// `run_session` and times the call — it must complete in well under 200 ms
-    /// (we allow 150 ms slack for scheduling noise) and must return `CapReached`.
+    /// produce a session.
+    /// What: configures cap=1, stagger=5000 ms (5 s); pre-fills to cap; calls
+    /// `run_session` and times the call — a correct reject returns in
+    /// microseconds (we allow < 1 s), while an incorrect stagger-before-reject
+    /// would block for the full 5 s. The 4 s gap cleanly separates correct from
+    /// incorrect behaviour with no jitter risk on any CI machine.
     /// Test: this is the test.
     #[tokio::test]
     async fn registry_cap_reject_is_immediate() {
-        use std::time::Instant;
+        use std::time::{Duration, Instant};
 
-        // 200 ms stagger — detectable if paid, negligible if skipped.
+        // 5 s stagger — would be obviously detectable if paid; a <1 s threshold
+        // leaves 4 s of headroom so scheduling jitter cannot cause a false fail.
         let cfg = ControlPlaneConfig {
             max_concurrent_sessions: 1,
-            launch_stagger_ms: 200,
+            launch_stagger_ms: 5_000,
             ..Default::default()
         };
         let registry = SessionRegistry::with_config(cfg);
@@ -573,12 +574,13 @@ mod tests {
             crate::control::admission::AdmissionError::CapReached { live: 1, cap: 1 }
         );
 
-        // Must NOT have paid the 200 ms stagger — allow 150 ms for scheduling
-        // noise (CI machines can be slow; 200 - 150 = 50 ms true budget).
+        // Must NOT have paid the 5 s stagger. A <1 s threshold is generous for
+        // any real CI scheduling jitter; if this ever fires the stagger is
+        // leaking onto the reject path (a bug), not a noise artifact.
         assert!(
-            elapsed.as_millis() < 150,
-            "rejected launch must return in <150 ms, not {} ms (stagger must not be paid on reject path)",
-            elapsed.as_millis()
+            elapsed < Duration::from_secs(1),
+            "rejected launch must return in <1 s, not {elapsed:?} \
+             (5 s stagger must not be paid on reject path)"
         );
     }
 }

--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -191,6 +191,15 @@ pub struct MpmConfig {
     #[serde(default)]
     pub session_manager: SessionManagerConfig,
 
+    /// `[control_plane]` — SESSCTL auth + cost guardrails (SPEC-SESSCTL-01 §9,
+    /// WI-5 #1596).
+    ///
+    /// Absent or partial section → spec defaults (concurrency cap 5, launch
+    /// stagger 2000 ms, auth timeout 30 s, LLM classifier off). The daemon
+    /// injects this into the control-plane `SessionRegistry`.
+    #[serde(default)]
+    pub control_plane: crate::control::config::ControlPlaneConfig,
+
     /// `[style]` — active output-style selection (HR-4 / DOC-17).
     ///
     /// Absent section → professional default (`trusty-mpm`). See

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -31,6 +31,25 @@ use crate::daemon::optimizer::OptimizerConfig;
 use super::overseer::{build_overseer, load_optimizer_config, load_overseer, make_audit_logger};
 use super::sm::build_session_manager_agent;
 
+/// Build the control-plane [`SessionRegistry`] from the operator's config.
+///
+/// Why: WI-5 (§9) makes the concurrency cap, launch stagger, auth timeout, and
+/// classifier gate operator-configurable via the `[control_plane]` section of
+/// `~/.trusty-mpm/config.toml`. The daemon must read that section at startup and
+/// inject it into the registry so the cost guardrails reflect the operator's
+/// settings; an absent section falls back to spec defaults (cap 5, stagger 2 s).
+/// What: loads [`MpmConfig`](crate::core::config::MpmConfig) from `root`
+/// (silently defaulting on absence/malformed input, exactly as the loader
+/// documents) and constructs a [`SessionRegistry`] with its `control_plane`
+/// config.
+/// Test: exercised by every `DaemonState` constructor; control-plane defaults
+/// are pinned by `control::config::tests` and the cap behavior by
+/// `control::registry::tests`.
+fn build_session_registry(root: &std::path::Path) -> SessionRegistry {
+    let cfg = crate::core::config::MpmConfig::load(root);
+    SessionRegistry::with_config(cfg.control_plane)
+}
+
 /// Outcome of a reap sweep over the session registry.
 ///
 /// Why: the reaper now does two distinct things — it *removes* tmux sessions
@@ -281,6 +300,9 @@ impl DaemonState {
             tracing::info!("restored persisted Telegram pairing (chat {chat_id})");
         }
         let (event_tx, _) = tokio::sync::broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        // §9 (WI-5): build the control-plane registry with the operator's
+        // [control_plane] auth+cost config (cap, stagger, classifier gate).
+        let session_registry = Arc::new(build_session_registry(&root));
         Self {
             sessions: DashMap::new(),
             delegations: DashMap::new(),
@@ -304,7 +326,7 @@ impl DaemonState {
             managed_sessions: tokio::sync::OnceCell::new(),
             activity_monitor: std::sync::OnceLock::new(),
             project_registry: tokio::sync::OnceCell::new(),
-            session_registry: Arc::new(SessionRegistry::new()),
+            session_registry,
         }
     }
 
@@ -334,6 +356,10 @@ impl DaemonState {
         crate::daemon::pairing_store::cleanup_stale_claims(&framework_root);
         let paired = crate::daemon::pairing_store::load(&framework_root).map(|r| r.chat_id);
         let (event_tx, _) = tokio::sync::broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        // §9 (WI-5): build the control-plane registry from [control_plane] under
+        // this (possibly temp-dir) framework root, so e2e tests can inject a
+        // hermetic auth+cost config and the real daemon reads the operator's.
+        let session_registry = Arc::new(build_session_registry(&framework_root));
         Self {
             sessions: DashMap::new(),
             delegations: DashMap::new(),
@@ -357,7 +383,7 @@ impl DaemonState {
             managed_sessions: tokio::sync::OnceCell::new(),
             activity_monitor: std::sync::OnceLock::new(),
             project_registry: tokio::sync::OnceCell::new(),
-            session_registry: Arc::new(SessionRegistry::new()),
+            session_registry,
         }
     }
 

--- a/crates/trusty-mpm/tests/auth_cost.rs
+++ b/crates/trusty-mpm/tests/auth_cost.rs
@@ -1,0 +1,196 @@
+//! WI-5 (#1596) auth + cost model — GATING integration test (spec §9, §11).
+//!
+//! Why: the WI-5 acceptance gate (spec §11, AC-5) is: "spawning 3 sessions
+//! simultaneously completes WITHOUT key leakage." Spawning three real `claude`
+//! processes in CI is impractical and non-hermetic, so this test asserts the
+//! security invariant at the command-construction seam (`build_claude_command`)
+//! — the single point where §9.1's no-key-leak rule is enforced — for three
+//! simultaneously-built sessions, and asserts the §9.2 concurrency cap admits
+//! exactly the allowed number of concurrent sessions and rejects beyond it. The
+//! invariant we protect: NO managed session may ever inherit `ANTHROPIC_API_KEY`
+//! (which would silently switch billing from flat-rate Max OAuth to a metered
+//! key, §9.1).
+//! What: three test groups —
+//!   1. `three_simultaneous_sessions_no_key_leak` — build 3 commands and assert
+//!      each one explicitly REMOVES `ANTHROPIC_API_KEY` from its child env.
+//!   2. `key_removed_even_when_present_in_parent_env` — serial-guarded: set the
+//!      key in THIS process, build the command, assert it is still removed
+//!      (proving removal is unconditional, not dependent on parent state).
+//!   3. `cap_admits_exactly_allowed_concurrency` — drive the real
+//!      `SessionRegistry` admission path with cap=3, zero stagger, and assert it
+//!      admits 3 and rejects the 4th.
+//! Test: this file IS the WI-5 gate. Run with
+//! `cargo test -p trusty-mpm --test auth_cost`.
+
+use std::path::Path;
+
+use serial_test::serial;
+use trusty_mpm::control::admission::{AdmissionDecision, check_admission};
+use trusty_mpm::control::backend::stream_json::{ANTHROPIC_API_KEY_VAR, build_claude_command};
+
+/// Extract the explicit env mutations from a built command. A removed variable
+/// surfaces as `(KEY, None)`; a set variable as `(KEY, Some(value))`.
+///
+/// Why: the §9.1 invariant is specifically that `ANTHROPIC_API_KEY` is REMOVED
+/// (appears with a `None` value), so the assertions need to distinguish removal
+/// from a (forbidden) set.
+/// What: maps `Command::get_envs()` to owned `(String, Option<String>)` pairs.
+/// Test: used by the assertions below.
+fn env_mutations(cmd: &std::process::Command) -> Vec<(String, Option<String>)> {
+    cmd.get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().into_owned(),
+                v.map(|v| v.to_string_lossy().into_owned()),
+            )
+        })
+        .collect()
+}
+
+/// Assert the built command removes `ANTHROPIC_API_KEY` from the child env.
+///
+/// Why: this is the precise security check — the key must appear as an explicit
+/// removal and never as a set value.
+/// What: finds the `ANTHROPIC_API_KEY` mutation and asserts its value is `None`.
+/// Test: invoked per-command by the gating tests.
+fn assert_key_removed(cmd: &std::process::Command, label: &str) {
+    let muts = env_mutations(cmd);
+    let entry = muts
+        .iter()
+        .find(|(k, _)| k == ANTHROPIC_API_KEY_VAR)
+        .unwrap_or_else(|| {
+            panic!("[{label}] ANTHROPIC_API_KEY must appear as an explicit env mutation")
+        });
+    assert_eq!(
+        entry.1, None,
+        "[{label}] ANTHROPIC_API_KEY must be REMOVED (None) from the child env, never set"
+    );
+    // Belt-and-braces: no mutation anywhere may SET the key to a value.
+    for (k, v) in &muts {
+        if k == ANTHROPIC_API_KEY_VAR {
+            assert!(
+                v.is_none(),
+                "[{label}] ANTHROPIC_API_KEY was set to a value — key leak!"
+            );
+        }
+    }
+}
+
+/// GATE part 1: three simultaneously-built sessions all remove the API key.
+///
+/// Why: the AC-5 gate phrasing is "spawning 3 sessions simultaneously completes
+/// without key leakage." We model the three concurrent launches at the command
+/// seam — the deterministic, hermetic equivalent of three concurrent spawns.
+/// What: builds three distinct session commands (distinct workdirs, one with a
+/// prompt file) and asserts the no-key-leak invariant holds for ALL three.
+/// Test: this is the test.
+#[test]
+fn three_simultaneous_sessions_no_key_leak() {
+    let prompt = Path::new("/tmp/wi5-prompt.md");
+    let commands = [
+        build_claude_command(Path::new("/tmp/wi5-session-0"), None),
+        build_claude_command(Path::new("/tmp/wi5-session-1"), Some(prompt)),
+        build_claude_command(Path::new("/tmp/wi5-session-2"), None),
+    ];
+
+    // All three commands must invoke `claude` directly and strip the key.
+    for (n, cmd) in commands.iter().enumerate() {
+        assert_eq!(
+            cmd.get_program(),
+            std::ffi::OsStr::new("claude"),
+            "session {n} must spawn `claude` directly"
+        );
+        assert_key_removed(cmd, &format!("session-{n}"));
+    }
+}
+
+/// GATE part 2: removal is unconditional even when the parent process HAS the
+/// key set in its own environment.
+///
+/// Why: the dangerous real-world case is an operator whose shell exports
+/// `ANTHROPIC_API_KEY`. The seam must remove it regardless. This test sets the
+/// key in THIS process to simulate that, builds the command, and asserts the
+/// child env still removes it. `#[serial]` prevents env-var races with other
+/// env-mutating tests (this crate has had env-race flakes before).
+/// What: sets the key, builds the command, asserts removal, restores prior env.
+/// Test: this is the test.
+#[test]
+#[serial]
+fn key_removed_even_when_present_in_parent_env() {
+    // SAFETY: edition-2024 env mutation requires `unsafe`. The `#[serial]`
+    // attribute serializes this test against all other env-mutating tests, so
+    // there is no concurrent reader/writer of the process environment here.
+    let prior = std::env::var(ANTHROPIC_API_KEY_VAR).ok();
+    unsafe {
+        std::env::set_var(ANTHROPIC_API_KEY_VAR, "sk-ant-LEAK-CANARY-should-never-reach-child");
+    }
+
+    let cmd = build_claude_command(Path::new("/tmp/wi5-parent-has-key"), None);
+    assert_key_removed(&cmd, "parent-has-key");
+
+    // Restore the prior environment to avoid leaking the canary to later tests.
+    unsafe {
+        match prior {
+            Some(v) => std::env::set_var(ANTHROPIC_API_KEY_VAR, v),
+            None => std::env::remove_var(ANTHROPIC_API_KEY_VAR),
+        }
+    }
+}
+
+/// GATE part 3: the §9.2 cap admits EXACTLY the allowed concurrency.
+///
+/// Why: the cost guardrail must let `cap` sessions run and reject the next one,
+/// so N simultaneous launches cannot thundering-herd the shared Max bucket. We
+/// drive the pure admission predicate the registry uses, simulating a cap of 3.
+/// What: with cap=3 and zero stagger, launches at live counts 0,1,2 admit and
+/// live count 3 rejects — proving exactly 3 concurrent sessions are admitted.
+/// Test: this is the test.
+#[test]
+fn cap_admits_exactly_allowed_concurrency() {
+    let cap = 3;
+    // Three simultaneous launches (live = 0,1,2) are all admitted with no
+    // stagger (test-injected 0 for determinism).
+    for live in 0..cap {
+        assert!(
+            matches!(
+                check_admission(live, cap, 0),
+                AdmissionDecision::Admit { stagger_ms: 0 }
+            ),
+            "launch at live={live} must be admitted (cap={cap})"
+        );
+    }
+    // The 4th simultaneous launch (live = cap) is rejected.
+    assert_eq!(
+        check_admission(cap, cap, 0),
+        AdmissionDecision::Reject { live: cap, cap }
+    );
+}
+
+/// GATE part 4 (end-to-end through the registry): cap rejects beyond the limit
+/// without spawning a backend.
+///
+/// Why: parts 1–3 cover the seams in isolation; this exercises the real
+/// `SessionRegistry::run_session` admission path so the gate covers the wired
+/// behavior, not just the pure helpers. cap=2, zero stagger keeps it hermetic
+/// and fast (no real `claude` spawn for the rejected launch).
+/// What: pre-fills the registry to its cap with placeholder handles via the
+/// public register() API, then asserts `admission()` reports Reject.
+/// Test: this is the test.
+#[tokio::test]
+async fn registry_admission_rejects_at_cap() {
+    use trusty_mpm::control::config::ControlPlaneConfig;
+    use trusty_mpm::control::registry::SessionRegistry;
+
+    let cfg = ControlPlaneConfig {
+        max_concurrent_sessions: 2,
+        launch_stagger_ms: 0,
+        ..Default::default()
+    };
+    let registry = SessionRegistry::with_config(cfg);
+
+    // Below cap → admit.
+    assert!(matches!(
+        registry.admission().await,
+        AdmissionDecision::Admit { .. }
+    ));
+}

--- a/crates/trusty-mpm/tests/auth_cost.rs
+++ b/crates/trusty-mpm/tests/auth_cost.rs
@@ -10,15 +10,14 @@
 //! invariant we protect: NO managed session may ever inherit `ANTHROPIC_API_KEY`
 //! (which would silently switch billing from flat-rate Max OAuth to a metered
 //! key, §9.1).
-//! What: three test groups —
-//!   1. `three_simultaneous_sessions_no_key_leak` — build 3 commands and assert
-//!      each one explicitly REMOVES `ANTHROPIC_API_KEY` from its child env.
-//!   2. `key_removed_even_when_present_in_parent_env` — serial-guarded: set the
-//!      key in THIS process, build the command, assert it is still removed
-//!      (proving removal is unconditional, not dependent on parent state).
-//!   3. `cap_admits_exactly_allowed_concurrency` — drive the real
-//!      `SessionRegistry` admission path with cap=3, zero stagger, and assert it
-//!      admits 3 and rejects the 4th.
+//! What: three test groups — (1) `three_simultaneous_sessions_no_key_leak`
+//! builds 3 commands and asserts each one explicitly REMOVES `ANTHROPIC_API_KEY`
+//! from its child env; (2) `key_removed_even_when_present_in_parent_env`
+//! (serial-guarded) sets the key in THIS process, builds the command, and
+//! asserts it is still removed (proving removal is unconditional, not dependent
+//! on parent state); (3) `cap_admits_exactly_allowed_concurrency` drives the
+//! real `SessionRegistry` admission path with cap=3, zero stagger, and asserts
+//! it admits 3 and rejects the 4th.
 //! Test: this file IS the WI-5 gate. Run with
 //! `cargo test -p trusty-mpm --test auth_cost`.
 
@@ -122,7 +121,10 @@ fn key_removed_even_when_present_in_parent_env() {
     // there is no concurrent reader/writer of the process environment here.
     let prior = std::env::var(ANTHROPIC_API_KEY_VAR).ok();
     unsafe {
-        std::env::set_var(ANTHROPIC_API_KEY_VAR, "sk-ant-LEAK-CANARY-should-never-reach-child");
+        std::env::set_var(
+            ANTHROPIC_API_KEY_VAR,
+            "sk-ant-LEAK-CANARY-should-never-reach-child",
+        );
     }
 
     let cmd = build_claude_command(Path::new("/tmp/wi5-parent-has-key"), None);

--- a/crates/trusty-mpm/tests/auth_cost.rs
+++ b/crates/trusty-mpm/tests/auth_cost.rs
@@ -172,16 +172,40 @@ fn cap_admits_exactly_allowed_concurrency() {
 /// without spawning a backend.
 ///
 /// Why: parts 1–3 cover the seams in isolation; this exercises the real
-/// `SessionRegistry::run_session` admission path so the gate covers the wired
-/// behavior, not just the pure helpers. cap=2, zero stagger keeps it hermetic
-/// and fast (no real `claude` spawn for the rejected launch).
-/// What: pre-fills the registry to its cap with placeholder handles via the
-/// public register() API, then asserts `admission()` reports Reject.
+/// `SessionRegistry` admission path (both ADMIT and REJECT) so the gate covers
+/// the wired behavior end-to-end. cap=2, zero stagger keeps it hermetic and
+/// fast (no real `claude` spawn needed — we drive `register()` directly).
+/// What: with an empty registry, asserts Admit; then pre-fills to cap=2 via
+/// `register()`, and asserts the next `admission()` returns Reject. The Reject
+/// arm is the critical invariant — it is what actually stops a 3rd session
+/// from launching against the Max OAuth shared bucket.
 /// Test: this is the test.
 #[tokio::test]
 async fn registry_admission_rejects_at_cap() {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use tokio::sync::{RwLock, broadcast, mpsc};
+    use trusty_mpm::control::actor::SessionActorHandle;
     use trusty_mpm::control::config::ControlPlaneConfig;
+    use trusty_mpm::control::event::BackendKind;
+    use trusty_mpm::control::id::ControlSessionId;
     use trusty_mpm::control::registry::SessionRegistry;
+    use trusty_mpm::control::state::SessionMetadata;
+
+    fn make_handle(id: &ControlSessionId) -> SessionActorHandle {
+        let (command_tx, _) = mpsc::channel(1);
+        let (event_tx, _) = broadcast::channel(4);
+        SessionActorHandle {
+            command_tx,
+            event_tx,
+            write_lock_held: Arc::new(AtomicBool::new(false)),
+            metadata: Arc::new(RwLock::new(SessionMetadata::new(
+                id.clone(),
+                "proj".into(),
+                BackendKind::StreamJson,
+            ))),
+        }
+    }
 
     let cfg = ControlPlaneConfig {
         max_concurrent_sessions: 2,
@@ -190,9 +214,23 @@ async fn registry_admission_rejects_at_cap() {
     };
     let registry = SessionRegistry::with_config(cfg);
 
-    // Below cap → admit.
-    assert!(matches!(
-        registry.admission().await,
-        AdmissionDecision::Admit { .. }
-    ));
+    // Empty registry → admit.
+    assert!(
+        matches!(registry.admission().await, AdmissionDecision::Admit { .. }),
+        "empty registry must admit"
+    );
+
+    // Pre-fill to cap (2 live sessions) via the public register() API.
+    for n in 0..2u64 {
+        let id = ControlSessionId::new("gate-proj", n);
+        registry.register(id.clone(), make_handle(&id)).await;
+    }
+
+    // Now live == cap → the next launch must be REJECTED.
+    let decision = registry.admission().await;
+    assert_eq!(
+        decision,
+        AdmissionDecision::Reject { live: 2, cap: 2 },
+        "at cap=2 with 2 live sessions, admission must REJECT"
+    );
 }


### PR DESCRIPTION
## SESSCTL WI-5 (#1596) — auth + cost model

Part of epic #1590. Implements **SPEC-SESSCTL-01 §9** (auth + cost), §4.4 (auth state machine), §8.3 (optional classifier) — the last blocking control-plane WI for trusty-mpm alpha-1.

### What this delivers

**§9.1 Max OAuth, no key leak (LOCKED, security-critical)**
- New inspectable command seam `control::backend::stream_json::build_claude_command()` builds the `claude -p --output-format stream-json …` command with `Command::env_remove("ANTHROPIC_API_KEY")`. This replaces the opaque `env -u` shell wrapper with an explicit, *test-observable* removal (`get_envs()` surfaces it as `(KEY, None)`), while still guaranteeing the metered key never reaches a managed session. Defense-in-depth: the key is never re-added, and the canary test proves removal even when the parent process exports the key.

**§4.4 auth state machine**
- `AwaitingAuth` (tmux-only) and terminal `AuthFailed` (stream-JSON) transitions were already wired into the actor/state machine in WI-1..4; WI-5 adds the configurable `auth_timeout_secs` (default 30) to `ControlPlaneConfig`.

**§9.2 session cap + stagger**
- `control::admission` — pure, lock-free cap predicate + typed `AdmissionError::CapReached`.
- `SessionRegistry::run_session` now enforces the concurrency cap **authoritatively under the write lock** (race-free) and applies the launch stagger **before** the lock (so concurrent launches are spaced without serializing the registry). Stagger is injectable; tests use `0` for determinism.
- Defaults: `max_concurrent_sessions = 5`, `launch_stagger_ms = 2000`.

**§8.2/§9.2 rate-limit detection**
- `ActivityKind::RateLimited` + the rate-limit regex already exist (WI-3); WI-5 confirms surfacing through the parse layer.

**§8.3 optional OpenRouter classifier (gated, default OFF — AC-9)**
- `control::classifier::ClassifierGate` — pure gate requiring **all three** preconditions (config flag on, `OPENROUTER_API_KEY` present, no SM agent connected). Default path never touches the network.

**Config wiring**
- New `[control_plane]` section in `MpmConfig` (serde-defaulted, absent = spec defaults). The daemon loads it and injects `ControlPlaneConfig` into the `SessionRegistry` via a new `with_config` constructor (both `DaemonState::with_root` and `with_paths`).

### New config keys / defaults
```toml
[control_plane]
max_concurrent_sessions = 5      # §9.2 cap
launch_stagger_ms = 2000         # §9.2 inter-spawn delay
auth_timeout_secs = 30           # §4.4

[control_plane.observability]
llm_classifier = false           # §8.3 OpenRouter classifier gate (AC-9: default off)
```

### GATING integration test (`tests/auth_cost.rs`) — the no-key-leak gate
Required by the issue: *"spawning 3 sessions simultaneously completes without key leakage."* Spawning 3 real `claude` processes in CI is impractical, so the security invariant is asserted at the command-construction seam:
1. `three_simultaneous_sessions_no_key_leak` — builds 3 commands, asserts each explicitly **removes** `ANTHROPIC_API_KEY` (never sets it).
2. `key_removed_even_when_present_in_parent_env` — `#[serial]`-guarded; sets a canary key in the test process, asserts the built command still removes it (removal is unconditional).
3. `cap_admits_exactly_allowed_concurrency` + `registry_admission_rejects_at_cap` — cap admits exactly N, rejects N+1.

### Verification (raw)
- `cargo test -p trusty-mpm` → **2013 passed; 0 failed; 3 ignored** (+ integration suites incl. auth_cost 4/4)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → 0 violations
- `cargo check --workspace` → clean

### Files changed
- `crates/trusty-mpm/src/control/config.rs` (new), `classifier.rs` (new), `admission.rs` (new)
- `crates/trusty-mpm/src/control/backend/stream_json.rs` (env_remove seam)
- `crates/trusty-mpm/src/control/registry.rs` (cap + stagger + config)
- `crates/trusty-mpm/src/control/mod.rs` (re-exports)
- `crates/trusty-mpm/src/core/config.rs` (`[control_plane]` in MpmConfig)
- `crates/trusty-mpm/src/daemon/state/core.rs` (wire config → registry)
- `crates/trusty-mpm/tests/auth_cost.rs` (new — GATING test)

### Notes / follow-ups
- The §8.3 classifier *gate* ships here; the actual OpenRouter HTTP call is intentionally deferred to a later ticket (the gate is the security/cost decision point and is the only part needed to honor AC-9).
- Closes #1596. Does not merge — leaving for trusty-review per PM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
