### PR TITLE
fix(tga): de-flake bitbucket app_password env-fallback test (parallel env-var race)

### DIFF
--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -51,6 +51,91 @@ enum BbAuth {
     Basic { username: String, password: String },
 }
 
+/// Resolve Bitbucket auth credentials from config plus an injected env lookup.
+///
+/// Why: the original logic read `std::env::var` directly, which made the auth
+/// unit tests mutate process-global environment variables. Under the
+/// multi-threaded test harness those mutations raced across tests, flaking
+/// `app_password_falls_back_to_env_when_config_absent` in CI (issue #1653).
+/// Threading the environment in as a closure removes the ambient-state
+/// coupling: production passes `std::env::var`; tests pass an in-memory map,
+/// so no test ever touches the real environment and the race cannot occur.
+/// What: applies the documented precedence — (1) Bearer `token` (config,
+/// then `BITBUCKET_TOKEN`), else (2) Basic auth `username` + `app_password`
+/// (config with `${VAR}` expansion via the same `env` lookup, then
+/// `BITBUCKET_APP_PASSWORD`). Config values written as `${MY_SECRET}` are
+/// expanded against `env` before use (closes #842). Returns
+/// [`CollectError::Config`] when no usable credential is available.
+/// Test: `client::tests` — `resolve_auth_*` cases inject env maps directly
+/// (no `std::env` mutation), covering bearer, basic, env-expansion,
+/// precedence, env-fallback, and the missing-credential error branches.
+fn resolve_auth(config: &BitbucketConfig, env: impl Fn(&str) -> Option<String>) -> Result<BbAuth> {
+    // Expand `${VAR}` placeholders using the injected env lookup so config
+    // and env resolution share one source of truth (no `std::env` here).
+    let expand = |raw: &str| -> String {
+        if let Some(var) = raw
+            .strip_prefix("${")
+            .and_then(|s| s.strip_suffix('}'))
+            .filter(|v| !v.is_empty())
+        {
+            env(var).unwrap_or_default()
+        } else {
+            raw.to_string()
+        }
+    };
+    let clean = |s: String| -> Option<String> {
+        let t = s.trim().to_string();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t)
+        }
+    };
+
+    let token = config
+        .token
+        .as_deref()
+        .map(&expand)
+        .and_then(clean)
+        .or_else(|| env("BITBUCKET_TOKEN").and_then(clean));
+
+    if let Some(t) = token {
+        return Ok(BbAuth::Bearer(t));
+    }
+
+    let username = config
+        .username
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            CollectError::Config(
+                "bitbucket auth missing: provide `token` or `username` + `app_password`".into(),
+            )
+        })?
+        .to_string();
+
+    // `app_password` may be written as `${MY_SECRET}` in YAML; without
+    // expansion the literal `${MY_SECRET}` is sent as the Basic-auth password,
+    // yielding a silent 401 (closes #842). Falls back to the
+    // `BITBUCKET_APP_PASSWORD` env var, mirroring `token` above.
+    let password = config
+        .app_password
+        .as_deref()
+        .map(&expand)
+        .and_then(clean)
+        .or_else(|| env("BITBUCKET_APP_PASSWORD").and_then(clean))
+        .ok_or_else(|| {
+            CollectError::Config(
+                "bitbucket auth missing: app_password (or BITBUCKET_APP_PASSWORD) \
+                 required when token is unset"
+                    .into(),
+            )
+        })?;
+
+    Ok(BbAuth::Basic { username, password })
+}
+
 /// Async Bitbucket Cloud REST client.
 pub struct BitbucketClient {
     client: reqwest::Client,
@@ -90,62 +175,10 @@ impl BitbucketClient {
             .ok_or_else(|| CollectError::Config("bitbucket.repo_slug is required".into()))?
             .to_string();
 
-        let token = config
-            .token
-            .as_deref()
-            .map(crate::collect::env_expand::expand_env_var)
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                std::env::var("BITBUCKET_TOKEN")
-                    .ok()
-                    .map(|v| v.trim().to_string())
-                    .filter(|s| !s.is_empty())
-            });
-
-        let auth = if let Some(t) = token {
-            BbAuth::Bearer(t)
-        } else {
-            let username = config
-                .username
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| {
-                    CollectError::Config(
-                        "bitbucket auth missing: provide `token` or `username` + `app_password`"
-                            .into(),
-                    )
-                })?
-                .to_string();
-            // Why: `app_password` may be written as `${MY_SECRET}` in YAML;
-            // without expansion the literal `${MY_SECRET}` is sent as the
-            // Basic-auth password, yielding a silent 401 (closes #842).
-            // What: expands `${VAR}` placeholders from the environment before
-            // trimming, then falls back to `BITBUCKET_APP_PASSWORD` env var —
-            // mirroring the identical treatment applied to `token` above.
-            // Test: `app_password_env_var_expanded` in this module.
-            let password = config
-                .app_password
-                .as_deref()
-                .map(crate::collect::env_expand::expand_env_var)
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .or_else(|| {
-                    std::env::var("BITBUCKET_APP_PASSWORD")
-                        .ok()
-                        .map(|v| v.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                })
-                .ok_or_else(|| {
-                    CollectError::Config(
-                        "bitbucket auth missing: app_password (or BITBUCKET_APP_PASSWORD) \
-                         required when token is unset"
-                            .into(),
-                    )
-                })?;
-            BbAuth::Basic { username, password }
-        };
+        // Resolve credentials through the live process environment. The
+        // env-coupled logic lives in `resolve_auth` so tests can exercise it
+        // with an injected lookup instead of mutating `std::env` (issue #1653).
+        let auth = resolve_auth(config, |name| std::env::var(name).ok())?;
 
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));

--- a/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
@@ -3,8 +3,11 @@
 //! Why: split from `client.rs` to keep that file under the 500-line cap
 //! while keeping the tests adjacent to the code they exercise.
 //! What: covers JSON deserialisation, PR state mapping, pagination, auth
-//! construction (including env-expansion of `app_password` — issue #842),
-//! and auth rejection when credentials are absent.
+//! resolution via [`super::resolve_auth`] with an injected env lookup
+//! (including env-expansion of `app_password` — issue #842 — and the
+//! env-fallback path — issue #1653), and auth rejection when credentials
+//! are absent. Auth tests inject an in-memory env map rather than mutating
+//! `std::env`, so they cannot race under the parallel test harness.
 //! Test: `cargo test -p tga collect::bitbucket::tests`.
 
 use super::*;
@@ -179,57 +182,109 @@ async fn fetch_pull_requests_follows_next_cursor() {
     assert!(prs[1].commit_shas.contains("abc123"));
 }
 
-/// Drop guard that snapshots an env var, removes it for the test, and
-/// restores it (or re-removes it if originally absent) on drop. The Drop
-/// impl runs during stack unwinding, so a panic inside the test body
-/// still triggers env restore — unlike a closure-based save/run/restore
-/// pattern, which silently leaks mutated state when the closure panics.
-pub(super) struct EnvVarGuard {
-    pub(super) name: &'static str,
-    pub(super) original: Option<String>,
-}
-
-impl EnvVarGuard {
-    pub(super) fn remove(name: &'static str) -> Self {
-        let original = std::env::var(name).ok();
-        // SAFETY: 2024-edition env mutation; the guard is the sole writer
-        // for `name` within the test it covers, restored unconditionally
-        // on drop.
-        unsafe { std::env::remove_var(name) };
-        Self { name, original }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        // SAFETY: see [`EnvVarGuard::remove`].
-        unsafe {
-            match self.original.as_deref() {
-                Some(v) => std::env::set_var(self.name, v),
-                None => std::env::remove_var(self.name),
-            }
-        }
-    }
-}
-
-/// `new()` rejects a config that has neither token nor username+password.
-#[test]
-fn client_new_rejects_missing_auth() {
-    // Take care not to pick up a real env credential during this
-    // assertion; guards restore env even if the test below panics.
-    let _t = EnvVarGuard::remove("BITBUCKET_TOKEN");
-    let _p = EnvVarGuard::remove("BITBUCKET_APP_PASSWORD");
-
-    let result = BitbucketClient::new(&BitbucketConfig {
+/// Build a `BitbucketConfig` with workspace/repo set and the given auth
+/// fields, so each auth test only states what it actually cares about.
+fn auth_config(
+    token: Option<&str>,
+    username: Option<&str>,
+    app_password: Option<&str>,
+) -> BitbucketConfig {
+    BitbucketConfig {
+        token: token.map(Into::into),
+        username: username.map(Into::into),
+        app_password: app_password.map(Into::into),
         workspace: Some("acme".into()),
         repo_slug: Some("widgets".into()),
         fetch_prs: true,
         ..Default::default()
-    });
-    match result {
+    }
+}
+
+/// Build an injected env lookup from a fixed `(name, value)` table.
+///
+/// Why: `resolve_auth` takes the environment as a closure precisely so tests
+/// never mutate process-global `std::env` — that ambient mutation is what
+/// raced across parallel tests and flaked the env-fallback case (issue #1653).
+/// What: returns a closure that resolves names against an owned map; any name
+/// not in the table reads as unset, regardless of the real process env.
+fn env_map(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+    let owned: Vec<(String, String)> = pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    move |name: &str| {
+        owned
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.clone())
+    }
+}
+
+/// `resolve_auth` rejects a config with neither token nor username+password,
+/// even when the (empty) environment offers nothing either.
+///
+/// Why: missing credentials must surface as a `Config` error, never a panic
+/// or a silent default.
+/// What: empty config auth fields + empty env → `CollectError::Config`.
+/// Test: this test (pure, no env mutation).
+#[test]
+fn resolve_auth_rejects_missing_auth() {
+    let cfg = auth_config(None, None, None);
+    match resolve_auth(&cfg, env_map(&[])) {
         Ok(_) => panic!("expected auth failure, got Ok(_)"),
         Err(CollectError::Config(_)) => {}
         Err(other) => panic!("unexpected error: {other:?}"),
+    }
+}
+
+/// A `username` set without any app_password (config or env) is rejected.
+///
+/// Why: half-specified Basic auth must error rather than send an empty
+/// password.
+/// What: username present, app_password absent, empty env → `Config` error.
+/// Test: this test.
+#[test]
+fn resolve_auth_rejects_username_without_password() {
+    let cfg = auth_config(None, Some("carol"), None);
+    match resolve_auth(&cfg, env_map(&[])) {
+        Err(CollectError::Config(_)) => {}
+        other => panic!("expected Config error, got {other:?}"),
+    }
+}
+
+/// A plain config `token` resolves to Bearer auth and wins over Basic fields.
+///
+/// Why: documents the precedence — token always supersedes username/password.
+/// What: config token + username/app_password → `BbAuth::Bearer(token)`.
+/// Test: this test.
+#[test]
+fn resolve_auth_config_token_yields_bearer() {
+    let cfg = auth_config(Some("tok-123"), Some("u"), Some("p"));
+    match resolve_auth(&cfg, env_map(&[])).expect("resolves") {
+        BbAuth::Bearer(t) => assert_eq!(t, "tok-123"),
+        BbAuth::Basic { .. } => panic!("expected Bearer, got Basic"),
+    }
+}
+
+/// A `${VAR}` token placeholder is expanded from the injected env, and the
+/// `BITBUCKET_TOKEN` env var is used as a fallback when config token is unset.
+///
+/// Why: keeps token env-expansion (#741) and the env fallback covered after
+/// the refactor.
+/// What: placeholder token → expanded value; absent token → env var value.
+/// Test: this test.
+#[test]
+fn resolve_auth_token_expands_and_falls_back() {
+    let cfg = auth_config(Some("${TGA_BB_TOKEN}"), None, None);
+    match resolve_auth(&cfg, env_map(&[("TGA_BB_TOKEN", "expanded-tok")])).expect("resolves") {
+        BbAuth::Bearer(t) => assert_eq!(t, "expanded-tok"),
+        BbAuth::Basic { .. } => panic!("expected Bearer"),
+    }
+
+    let cfg = auth_config(None, None, None);
+    match resolve_auth(&cfg, env_map(&[("BITBUCKET_TOKEN", "env-tok")])).expect("resolves") {
+        BbAuth::Bearer(t) => assert_eq!(t, "env-tok"),
+        BbAuth::Basic { .. } => panic!("expected Bearer from env fallback"),
     }
 }
 
@@ -239,35 +294,13 @@ fn client_new_rejects_missing_auth() {
 /// Why: PR #743 fixed env-expansion for `token` but missed `app_password`,
 /// so users who wrote `app_password = "${MY_SECRET}"` in their YAML config
 /// got a literal `${MY_SECRET}` sent as the HTTP Basic password → silent 401.
-/// What: sets a known env var, configures `app_password` as a placeholder,
-/// builds the client, and asserts the resolved password equals the env value.
-/// Test: this test (unit, no network). Precedence variant (config wins over
-/// env fallback) is also covered: explicit password string is used as-is.
+/// What: injects an env value, configures `app_password` as a placeholder,
+/// resolves auth, and asserts the resolved password equals the env value.
+/// Test: this test (pure; injected env, no `std::env` mutation).
 #[test]
-fn app_password_env_var_expanded() {
-    // Isolate env state so parallel tests cannot interfere.
-    let _t = EnvVarGuard::remove("BITBUCKET_TOKEN");
-    let _fallback = EnvVarGuard::remove("BITBUCKET_APP_PASSWORD");
-
-    // SAFETY: same pattern used by EnvVarGuard; sole writer in this test.
-    unsafe { std::env::set_var("TGA_TEST_BB_APP_PW_842", "s3cr3t-expanded") };
-    let _guard = EnvVarGuard {
-        name: "TGA_TEST_BB_APP_PW_842",
-        original: None,
-    };
-
-    let client = BitbucketClient::new(&BitbucketConfig {
-        username: Some("myuser".into()),
-        app_password: Some("${TGA_TEST_BB_APP_PW_842}".into()),
-        workspace: Some("acme".into()),
-        repo_slug: Some("widgets".into()),
-        fetch_prs: true,
-        ..Default::default()
-    })
-    .expect("client builds with expanded app_password");
-
-    // Inspect the resolved password via the auth field on the client.
-    match &client.auth {
+fn resolve_auth_app_password_env_var_expanded() {
+    let cfg = auth_config(None, Some("myuser"), Some("${TGA_BB_APP_PW}"));
+    match resolve_auth(&cfg, env_map(&[("TGA_BB_APP_PW", "s3cr3t-expanded")])).expect("resolves") {
         BbAuth::Basic { username, password } => {
             assert_eq!(username, "myuser");
             assert_eq!(
@@ -286,31 +319,18 @@ fn app_password_env_var_expanded() {
 /// Why: verifies the precedence chain — config value wins over env fallback —
 /// so adding env-expansion does not accidentally break callers who store the
 /// literal password in YAML.
-/// What: sets `BITBUCKET_APP_PASSWORD` to a different string, configures a
-/// plain `app_password`, and asserts the config value wins.
+/// What: injects a different `BITBUCKET_APP_PASSWORD`, configures a plain
+/// `app_password`, and asserts the config value wins.
 /// Test: this test.
 #[test]
-fn app_password_config_takes_precedence_over_env_fallback() {
-    let _t = EnvVarGuard::remove("BITBUCKET_TOKEN");
-
-    // SAFETY: sole writer; EnvVarGuard restores on drop.
-    unsafe { std::env::set_var("BITBUCKET_APP_PASSWORD", "env-fallback-value") };
-    let _fallback = EnvVarGuard {
-        name: "BITBUCKET_APP_PASSWORD",
-        original: None,
-    };
-
-    let client = BitbucketClient::new(&BitbucketConfig {
-        username: Some("bob".into()),
-        app_password: Some("config-literal-pw".into()),
-        workspace: Some("acme".into()),
-        repo_slug: Some("widgets".into()),
-        fetch_prs: true,
-        ..Default::default()
-    })
-    .expect("client builds");
-
-    match &client.auth {
+fn resolve_auth_app_password_config_takes_precedence_over_env_fallback() {
+    let cfg = auth_config(None, Some("bob"), Some("config-literal-pw"));
+    match resolve_auth(
+        &cfg,
+        env_map(&[("BITBUCKET_APP_PASSWORD", "env-fallback-value")]),
+    )
+    .expect("resolves")
+    {
         BbAuth::Basic { password, .. } => {
             assert_eq!(
                 password, "config-literal-pw",
@@ -324,32 +344,18 @@ fn app_password_config_takes_precedence_over_env_fallback() {
 /// When `app_password` is absent from config, the `BITBUCKET_APP_PASSWORD`
 /// env var is used as the fallback credential.
 ///
-/// Why: validates the fallback branch is still reachable after the env-expansion
-/// fix — a regression here would silently break users who rely on the env var.
-/// What: removes config `app_password`, sets env fallback, asserts env value used.
-/// Test: this test.
+/// Why: validates the fallback branch is still reachable after the
+/// env-expansion fix — a regression here would silently break users who rely
+/// on the env var. This is the case that flaked in CI (issue #1653); injecting
+/// the env removes the parallel-test race entirely.
+/// What: config `app_password` absent, env fallback present → env value used.
+/// Test: this test (pure; injected env, no `std::env` mutation).
 #[test]
-fn app_password_falls_back_to_env_when_config_absent() {
-    let _t = EnvVarGuard::remove("BITBUCKET_TOKEN");
-
-    // SAFETY: sole writer; EnvVarGuard restores on drop.
-    unsafe { std::env::set_var("BITBUCKET_APP_PASSWORD", "env-only-pw") };
-    let _fallback = EnvVarGuard {
-        name: "BITBUCKET_APP_PASSWORD",
-        original: None,
-    };
-
-    let client = BitbucketClient::new(&BitbucketConfig {
-        username: Some("carol".into()),
-        app_password: None, // rely entirely on env
-        workspace: Some("acme".into()),
-        repo_slug: Some("widgets".into()),
-        fetch_prs: true,
-        ..Default::default()
-    })
-    .expect("client builds from env fallback");
-
-    match &client.auth {
+fn resolve_auth_app_password_falls_back_to_env_when_config_absent() {
+    let cfg = auth_config(None, Some("carol"), None);
+    match resolve_auth(&cfg, env_map(&[("BITBUCKET_APP_PASSWORD", "env-only-pw")]))
+        .expect("resolves")
+    {
         BbAuth::Basic { password, .. } => {
             assert_eq!(password, "env-only-pw");
         }


### PR DESCRIPTION
Closes #1653.

## Problem
`collect::bitbucket::client::tests::app_password_falls_back_to_env_when_config_absent`
flaked in CI on an **unrelated PR**:

```
panicked at crates/trusty-git-analytics/src/collect/bitbucket/tests.rs:350:
Config("bitbucket auth missing: app_password (or BITBUCKET_APP_PASSWORD) required when token is unset")
```

## Root cause (confirmed)
`tga`'s lib test binary runs all tests in one multi-threaded process. Multiple tests
mutate the **same** process-global env vars (`BITBUCKET_TOKEN`, `BITBUCKET_APP_PASSWORD`)
with no serialization:
- `bitbucket/tests.rs`: the target test and `..config_takes_precedence..` **set** `BITBUCKET_APP_PASSWORD`; `..env_var_expanded` / `client_new_rejects_missing_auth` **remove** it.
- `core/config/validator_tests.rs::with_clean_bitbucket_env` **removes** both vars (and re-removes on `Drop`).

The target test set `BITBUCKET_APP_PASSWORD` then read it back inside
`BitbucketClient::new`; a concurrent `remove_var` (test body or guard `Drop`) cleared the
var mid-read → fallback returned `None` → `Config(...)` error. Classic `std::env`
write/read race.

Reproduced locally: **3/30 failures (~10%)** with `cargo test -p tga collect::bitbucket`
in a loop; passes in isolation.

## Fix (root cause, not papered over)
Extracted a pure `resolve_auth(config, env: impl Fn(&str) -> Option<String>)` in
`bitbucket/client.rs`. `BitbucketClient::new` passes `|n| std::env::var(n).ok()` in
production; the auth unit tests inject an in-memory env map and call `resolve_auth`
directly. **No bitbucket auth test touches `std::env` anymore**, so the race is
eliminated at the source — no `#[serial]` needed. Precedence, `${VAR}` expansion (#842),
and `BITBUCKET_*` env fallback behaviour are unchanged and covered per-branch by the new
injected-env tests.

## Verification
- De-flake loop: **30/30 green** on `cargo test -p tga collect::bitbucket` (was ~10% flake).
- `cargo test -p tga`: **771 passed, 0 failed** (1 ignored).
- `cargo clippy -p tga --all-targets -- -D warnings`: exit 0.
- `cargo fmt -p tga -- --check`: clean.
- `bash scripts/check_line_cap.sh`: 0 violations.

## Files changed
- `crates/trusty-git-analytics/src/collect/bitbucket/client.rs`
- `crates/trusty-git-analytics/src/collect/bitbucket/tests.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)