### PR TITLE
feat(trusty-mpm): pin palace slug in standalone MCP injection (closes #1651)

### DIFF
--- a/crates/trusty-mpm/src/core/standalone/global_config.rs
+++ b/crates/trusty-mpm/src/core/standalone/global_config.rs
@@ -273,6 +273,16 @@ fn seed_credentials(claude_config_dir: &Path) {
 /// (OPENROUTER_API_KEY, AWS credentials, TRUSTY_SEARCH_URL etc.) — no secrets
 /// are injected here; the managed session inherits the daemon env, matching the
 /// pattern used for trusty-memory and trusty-search.
+/// Palace pinning (issue #1651): the trusty-memory entry here is DELIBERATELY a
+/// bare `serve --stdio` stub with NO `env.TRUSTY_MEMORY_PALACE`. This is the
+/// SINGLE tm-global config dir (SPEC-STANDALONE-MPM-08), shared as the
+/// user-level MCP layer across EVERY alias, so it cannot carry any one project's
+/// palace slug. The per-project palace pin lives in the cloned repo's
+/// `repo/.mcp.json` (written by `load_alias` → `run_prepare_session` →
+/// `prepare_session_with_repo_url`, threading the registry clone URL), which
+/// Claude Code layers OVER this global stub (project-local precedence, A4). So
+/// the correct slug is always applied at the project layer; this global stub
+/// only declares server availability and must stay bare.
 /// Test: `test_global_config_dir_ensure_idempotent`,
 /// `test_mcp_config_contains_all_three_servers`,
 /// `test_mcp_config_no_spurious_write_when_unchanged`,

--- a/crates/trusty-mpm/src/core/standalone/load.rs
+++ b/crates/trusty-mpm/src/core/standalone/load.rs
@@ -84,7 +84,15 @@ pub fn load_alias(
         pull_ff_only(&repo_dir);
     }
 
-    run_prepare_session(&repo_dir)?;
+    // Issue #1651: thread the registry clone `url` as the authoritative git
+    // remote so the per-project `repo/.mcp.json` pins `TRUSTY_MEMORY_PALACE` to
+    // the repo's canonical `owner-repo` slug (the same `derive_palace_id`
+    // mechanism #1605 uses for the per-project injection). The clone URL is more
+    // authoritative than probing the checkout's own origin remote (which a
+    // shallow / renamed / origin-less clone might lack); the operator
+    // `TRUSTY_MEMORY_PALACE` override still wins over it per `derive_palace_id`
+    // precedence.
+    run_prepare_session(&repo_dir, Some(&url))?;
     write_marker(&repo_dir, alias, &url, &git_ref, claude_config_dir)?;
 
     // WI-3 sub-parts 2+3: pre-seed project trust + MCP-server approval into
@@ -146,16 +154,27 @@ fn pull_ff_only(repo_dir: &Path) {
     }
 }
 
-/// Run `prepare_session` on the given repo directory.
+/// Run `prepare_session` on the given repo directory, pinning the palace to the
+/// cloned-from `repo_url` (issue #1651).
 ///
-/// Why: `prepare_session` deploys composed agents, skills, and CLAUDE.md so
-/// the project-local half of the managed configuration is complete.
+/// Why: `prepare_session` deploys composed agents, skills, and CLAUDE.md so the
+/// project-local half of the managed configuration is complete — and (issue
+/// #1605/#1651) injects the per-project `repo/.mcp.json` trusty-memory stub.
+/// Threading the registry clone URL as the authoritative git remote makes the
+/// injector pin `env.TRUSTY_MEMORY_PALACE` to the repo's canonical `owner-repo`
+/// slug (the highest-precedence `derive_palace_id` source after the operator
+/// override), so the managed session lands in the SAME palace a non-tm Claude
+/// session in that repo would use. `None` falls back to probing the checkout's
+/// own `git remote get-url origin`, then to the directory-basename slug.
 /// What: resolves `FrameworkPaths` from the home directory and calls
-/// `crate::core::session_launch::prepare_session`.
-/// Test: `prepare_session` has its own unit tests in session_launch/tests.rs.
-fn run_prepare_session(repo_dir: &Path) -> anyhow::Result<()> {
+/// `crate::core::session_launch::prepare_session_with_repo_url`, forwarding
+/// `repo_url` to the trusty-memory MCP palace-slug derivation.
+/// Test: `run_prepare_session_pins_palace_from_clone_url`,
+/// `run_prepare_session_bare_stub_when_no_identity`; `prepare_session` itself is
+/// covered in session_launch/tests.rs.
+fn run_prepare_session(repo_dir: &Path, repo_url: Option<&str>) -> anyhow::Result<()> {
     let fw = crate::core::paths::FrameworkPaths::default();
-    crate::core::session_launch::prepare_session(&fw, repo_dir)
+    crate::core::session_launch::prepare_session_with_repo_url(&fw, repo_dir, repo_url)
         .map(|_| ())
         .map_err(|e| anyhow::anyhow!("prepare_session failed: {e}"))
 }
@@ -193,6 +212,119 @@ fn write_marker(
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// RAII guard that clears an env var for the duration of a test and restores
+    /// the prior value on drop.
+    ///
+    /// Why: the palace-pin test must be hermetic against an ambient
+    /// `TRUSTY_MEMORY_PALACE` override (which `derive_palace_id` honours at
+    /// highest precedence and would otherwise mask the URL-derived slug).
+    /// What: snapshots the prior value, removes the var, and restores it on drop.
+    /// Pairs with `#[serial_test::serial]` so concurrent tests never race on the
+    /// shared process environment.
+    /// Test: used by `run_prepare_session_pins_palace_from_clone_url`.
+    struct EnvClearGuard {
+        key: &'static str,
+        prior: Option<String>,
+    }
+
+    impl EnvClearGuard {
+        fn clear(key: &'static str) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: tests run serially under `#[serial_test::serial]`, so no
+            // other thread reads/writes the environment concurrently.
+            unsafe { std::env::remove_var(key) };
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for EnvClearGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `clear`.
+            unsafe {
+                match self.prior.take() {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    /// Why (issue #1651): the standalone `load` path must pin the per-project
+    /// `repo/.mcp.json` trusty-memory palace to the registry CLONE URL's
+    /// canonical `owner-repo` slug — the same `derive_palace_id` mechanism #1605
+    /// uses — rather than leaving a bare stub or relying on probing the
+    /// checkout's own origin remote. Threading the clone URL explicitly is the
+    /// authoritative identity (a shallow/origin-less clone might lack a remote).
+    /// What: runs `run_prepare_session` on a repo dir with an explicit clone URL
+    /// and asserts the injected `.mcp.json` carries
+    /// `env.TRUSTY_MEMORY_PALACE == "bobmatnyc-trusty-tools"`.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn run_prepare_session_pins_palace_from_clone_url() {
+        // Hermetic: an ambient override would win over the URL-derived slug.
+        let _guard = EnvClearGuard::clear("TRUSTY_MEMORY_PALACE");
+        let tmp = TempDir::new().unwrap();
+        // Deliberately a session-id-like basename: the pin must come from the
+        // clone URL, NOT this directory name.
+        let repo = tmp.path().join("0c8f1a2b3c4d");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        run_prepare_session(&repo, Some("git@github.com:bobmatnyc/trusty-tools.git"))
+            .expect("run_prepare_session succeeds");
+
+        let mcp_path = repo.join(".mcp.json");
+        assert!(
+            mcp_path.exists(),
+            "run_prepare_session must write repo/.mcp.json"
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&mcp_path).unwrap()).unwrap();
+        assert_eq!(
+            value["mcpServers"]["trusty-memory"]["env"]["TRUSTY_MEMORY_PALACE"],
+            serde_json::json!("bobmatnyc-trusty-tools"),
+            "standalone load must pin the palace to the clone URL's owner-repo slug, \
+             not the workspace basename"
+        );
+    }
+
+    /// Why (issue #1651): when no clone URL is threaded AND the checkout has no
+    /// git origin remote AND no env override, the injection must fail open with
+    /// a BARE trusty-memory stub (no `env` key) so the session still gets the
+    /// memory tools — backward-compatible with the pre-#1651 behaviour.
+    /// What: runs `run_prepare_session(repo, None)` on a non-repo dir whose
+    /// basename does not slugify and asserts the trusty-memory block has no
+    /// `TRUSTY_MEMORY_PALACE` pin. (A non-empty basename would fall back to the
+    /// parent-dir slug, so we assert only the no-`env` shape is preserved when
+    /// pinning is impossible.)
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn run_prepare_session_bare_stub_when_no_identity() {
+        let _guard = EnvClearGuard::clear("TRUSTY_MEMORY_PALACE");
+        let tmp = TempDir::new().unwrap();
+        // A basename that slugifies to empty (only separators) cannot yield a
+        // parent-dir slug, so with no URL/remote/override the stub stays bare.
+        let repo = tmp.path().join("---");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        run_prepare_session(&repo, None).expect("run_prepare_session succeeds");
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(repo.join(".mcp.json")).unwrap())
+                .unwrap();
+        let memory = &value["mcpServers"]["trusty-memory"];
+        assert_eq!(
+            memory["command"],
+            serde_json::json!("trusty-memory"),
+            "the trusty-memory stub must still be present"
+        );
+        assert!(
+            memory.get("env").is_none(),
+            "with no derivable identity the stub must be bare (no TRUSTY_MEMORY_PALACE env); got {memory}"
+        );
+    }
 
     #[test]
     fn test_marker_write_round_trip() {


### PR DESCRIPTION
## Summary

Closes #1651 (DOC-24 follow-up to #1605). Pins the trusty-memory palace slug in the **standalone / global-config** managed-driver injection path so a `tm load`/`tm run` session lands in the SAME memory palace a non-tm Claude session in that repo would use.

## What was wrong

#1605 pinned the palace for the per-project `.mcp.json` injection used by the session-manager backend, threading the cloned-from `repo_url` into `prepare_session_with_repo_url`. The standalone driver (`core/standalone/load.rs::load_alias`), however, ran the **flag-less** `prepare_session`, so its per-project `repo/.mcp.json` relied on best-effort probing of the cloned checkout's own `git remote get-url origin` rather than the authoritative clone URL the registry already knows.

## Fix

- `load_alias` now threads the registry clone `url` through `run_prepare_session` → `prepare_session_with_repo_url`, reusing the **exact** #1605 mechanism (`trusty_common::derive_palace_id`, env `TRUSTY_MEMORY_PALACE` in the MCP server block).
- Precedence preserved: operator env override > git-remote `owner-repo` > parent-dir slug. Bare stub when nothing derives (fail-open).
- The single tm-global `.mcp.json` stub (`ensure_mcp_config`) is **shared across all aliases** and is overridden by the per-project `repo/.mcp.json` (project-local precedence, assumption A4 in SPEC-STANDALONE-MPM-08). It therefore intentionally stays a bare stub — documented in its doc comment so future readers don't try to (incorrectly) pin one project's slug into the shared global layer.

No `trusty-memory` CLI/protocol change; the env var is the agreed seam.

## Tests (new, TDD)

- `run_prepare_session_pins_palace_from_clone_url` — explicit clone URL pins `env.TRUSTY_MEMORY_PALACE = "bobmatnyc-trusty-tools"` even when the workspace basename is a session-id-like value.
- `run_prepare_session_bare_stub_when_no_identity` — no URL / no remote / no override / non-slugifiable basename ⇒ bare stub (no `env` key).

All gates green: `cargo test -p trusty-mpm`, `cargo clippy -p trusty-mpm --all-targets -D warnings`, `cargo fmt --check`, `cargo check --workspace`, `bash scripts/check_line_cap.sh`.

Refs #1605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)