### PR TITLE
chore(release): bump trusty-review to 0.5.0 (map-reduce non-truncated reviews #1643)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11027,7 +11027,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.11.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.4.2" }
+trusty-review = { path = "crates/trusty-review", version = "0.5.0" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -7,8 +7,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.5.0] — 2026-06-24
+
 ### Added
 
+- per-file map-reduce review for over-cap diffs (closes #1643, refs #1638, #680) ([#1657](https://github.com/bobmatnyc/trusty-tools/pull/1657)) ([`ea5c49b`](https://github.com/bobmatnyc/trusty-tools/commit/ea5c49bd))
 - external linked-spec fetch for grounding (closes #1419) ([#1630](https://github.com/bobmatnyc/trusty-tools/pull/1630)) ([`f2e58c2`](https://github.com/bobmatnyc/trusty-tools/commit/f2e58c2f6d92262d0ed9b12d0ec50b9ea77d33d0))
 - review-outcome capture — reactions/commits + outcome store + webhook poll (refs #1421) ([#1628](https://github.com/bobmatnyc/trusty-tools/pull/1628)) ([`d95fba9`](https://github.com/bobmatnyc/trusty-tools/commit/d95fba906e90f124cb76a3746fc90bb403ab117f))
 - calibration harness + Rust false-positive prompt guardrail (closes #1422) ([#1629](https://github.com/bobmatnyc/trusty-tools/pull/1629)) ([`98d66d5`](https://github.com/bobmatnyc/trusty-tools/commit/98d66d5c412591bdcffb7761317fb2f78202c4cc))

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.4.2"
+version     = "0.5.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
Phase 1 of the trusty-review 0.5.0 crates.io release. Version-bump only — no publish/merge in this phase.

## What changed
- `crates/trusty-review/Cargo.toml`: version 0.4.2 → 0.5.0 (MINOR)
- Root `Cargo.toml`: `[workspace.dependencies]` pin for `trusty-review` updated to 0.5.0
- `Cargo.lock`: regenerated (only trusty-review moved; 167 deps unchanged)
- `crates/trusty-review/CHANGELOG.md`: folded accumulated `[Unreleased]` work into `[0.5.0]` and prepended the map-reduce entry

## Why 0.5.0 (MINOR)
0.5.0 ships the per-file map-reduce review path so over-cap diffs are reviewed fully rather than truncated (#1643, refs #1638, #680). New feature → MINOR.

## Preflight (all green)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — rc=0
- `cargo test -p trusty-review` — 1032 + 35 passed, 0 failed
- `cargo check --workspace` — rc=0
- `cargo publish --dry-run -p trusty-review` — reached `Uploading trusty-review v0.5.0`, resolved `trusty-common 0.17.1` from crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)