### PR TITLE
chore(release): bump trusty-review to 0.6.0 (map-reduce synthesis calibration #1663)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11027,7 +11027,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.11.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.5.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.6.0" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -7,6 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-24
+
+### Added
+
+- LLM synthesis pass in map-reduce reduce stage (closes #1663) ([#1664](https://github.com/bobmatnyc/trusty-tools/pull/1664)) ([`1ade9a5`](https://github.com/bobmatnyc/trusty-tools/commit/1ade9a5d1e82e255b447fb995541a80551e854a5))
+
 ## [0.5.0] — 2026-06-24
 
 ### Added

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.5.0"
+version     = "0.6.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Summary

- Bump `trusty-review` version `0.5.0` → `0.6.0` (minor: new feature in squash commit `1ade9a5d`)
- Update workspace `Cargo.toml` version pin `trusty-review = "0.5.0"` → `"0.6.0"` (required by `trusty-analyze`)
- Update `Cargo.lock` accordingly
- Add `[0.6.0]` CHANGELOG entry for LLM synthesis pass in map-reduce reduce stage (closes #1663)

## Pre-flight
- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` ✓ (clean)
- `cargo test -p trusty-review` ✓ (35/35 passed)

Closes #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)