### PR TITLE
fix(embedder): pin ORT intra-op to 1 + disable spinning to break CUDA deferred-embed deadlock (#1542)

### DIFF
--- a/crates/trusty-common/src/embedder/fast_embedder.rs
+++ b/crates/trusty-common/src/embedder/fast_embedder.rs
@@ -11,8 +11,8 @@
 //! tests in `mod.rs` that call `FastEmbedder::init_options` directly.
 
 use super::types::{
-    DEFAULT_CACHE_CAPACITY, EMBED_DIM, ExecutionProvider, is_zero_vector,
-    resolve_fastembed_cache_dir,
+    DEFAULT_CACHE_CAPACITY, EMBED_DIM, ExecutionProvider, OrtThreadingOptions, is_zero_vector,
+    resolve_fastembed_cache_dir, resolve_ort_threading_options,
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -20,7 +20,7 @@ use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 #[cfg(feature = "embedder-cuda")]
 use super::types::{CudaOptions, resolve_cuda_options};
@@ -45,6 +45,78 @@ fn build_cuda_provider(opts: &CudaOptions) -> ort::execution_providers::Executio
         .with_arena_extend_strategy(ArenaExtendStrategy::SameAsRequested)
         .with_memory_limit(opts.gpu_mem_limit_bytes)
         .build()
+}
+
+/// Records the outcome of the one-shot ORT global-thread-pool commit so we
+/// only ever attempt it once per process and can log the resolved knobs.
+static ORT_RUNTIME: OnceLock<OrtThreadingOptions> = OnceLock::new();
+
+/// Commit an ORT global thread pool that pins intra-/inter-op threads and
+/// disables intra-op spinning for *every* embedder session, exactly once.
+///
+/// Why: fastembed-rs builds its ONNX `Session` internally and hardcodes
+/// `with_intra_threads(available_parallelism())` (= logical CPU count) — it
+/// exposes no hook to override per-session thread counts. On the CUDA
+/// deferred-embed path that multi-threaded intra-op barrier deadlocks inside
+/// `libonnxruntime` 1.24.2 (code-intelligence #1542): the pool reports
+/// `workers: 2` yet 8 ORT threads spin, two busy-wait at ~70% CPU while the
+/// rest block forever in `condition_variable::wait`, yielding 0 embeddings and
+/// an empty 112-byte HNSW. ORT's *global* thread pool is the one lever that
+/// reaches fastembed's opaque sessions: when an environment is committed with
+/// a global pool, `ort`'s `commit_*` path calls `DisablePerSessionThreads`,
+/// so fastembed's `with_intra_threads(N)` is ignored and the global pool's
+/// thread count + spin policy govern instead.
+/// What: resolves [`OrtThreadingOptions`] from the environment (defaults:
+/// intra=1, inter=1, spinning=off), commits `ort::init().with_global_thread_pool(..)`,
+/// and caches the result in [`ORT_RUNTIME`]. Must be called *before* any
+/// `TextEmbedding::try_new`; `ort::init().commit()` is a no-op once any
+/// session/environment already exists. Idempotent and thread-safe via
+/// `OnceLock`.
+/// Test: `ort_threading_*` resolver tests in `mod.rs` cover the knob parsing;
+/// the global-pool commit itself is ORT-runtime-gated and only exercised when
+/// a real model is loaded (the `#[ignore]` embedder tests).
+fn init_ort_runtime() -> OrtThreadingOptions {
+    *ORT_RUNTIME.get_or_init(|| {
+        let opts = resolve_ort_threading_options();
+
+        let pool = ort::environment::GlobalThreadPoolOptions::default()
+            .with_intra_threads(opts.intra_threads)
+            .and_then(|p| p.with_inter_threads(opts.inter_threads))
+            .and_then(|p| p.with_spin_control(opts.allow_spinning));
+
+        match pool {
+            Ok(pool) => {
+                let committed = ort::init().with_global_thread_pool(pool).commit();
+                if committed {
+                    tracing::info!(
+                        intra_threads = opts.intra_threads,
+                        inter_threads = opts.inter_threads,
+                        allow_spinning = opts.allow_spinning,
+                        "trusty-embedder: committed ORT global thread pool \
+                         (deadlock fix #1542 — overrides fastembed's per-session \
+                         with_intra_threads(num_cpus) via DisablePerSessionThreads)"
+                    );
+                } else {
+                    tracing::warn!(
+                        intra_threads = opts.intra_threads,
+                        "trusty-embedder: ORT environment already committed before \
+                         init_ort_runtime() — the single-intra-op-thread deadlock fix \
+                         (#1542) did NOT take effect; ensure no ORT session is created \
+                         before the embedder initialises"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "trusty-embedder: failed to build ORT global thread pool options; \
+                     falling back to fastembed defaults (deadlock fix #1542 NOT applied)"
+                );
+            }
+        }
+
+        opts
+    })
 }
 
 /// Local CPU embedder backed by fastembed-rs (ONNX runtime, all-MiniLM-L6-v2).
@@ -240,6 +312,13 @@ impl FastEmbedder {
 
         let (model, provider) =
             tokio::task::spawn_blocking(|| -> Result<(TextEmbedding, ExecutionProvider)> {
+                // Commit the ORT global thread pool (intra=1, spinning=off by
+                // default) BEFORE fastembed creates any session, so the
+                // per-session `with_intra_threads(num_cpus)` it hardcodes is
+                // overridden via DisablePerSessionThreads. This is the
+                // deferred-embed deadlock fix (#1542).
+                init_ort_runtime();
+
                 let require_gpu = std::env::var("TRUSTY_DEVICE")
                     .map(|v| v.eq_ignore_ascii_case("gpu"))
                     .unwrap_or(false);

--- a/crates/trusty-common/src/embedder/mod.rs
+++ b/crates/trusty-common/src/embedder/mod.rs
@@ -42,9 +42,10 @@ mod mock;
 
 pub use fast_embedder::FastEmbedder;
 pub use types::{
-    CudaOptions, DEFAULT_CACHE_CAPACITY, DEFAULT_CUDA_GPU_MEM_LIMIT_BYTES, EMBED_DIM, Embedder,
-    ExecutionProvider, embed_one, resolve_cuda_options, resolve_expected_provider,
-    resolve_fastembed_cache_dir,
+    CudaOptions, DEFAULT_CACHE_CAPACITY, DEFAULT_CUDA_GPU_MEM_LIMIT_BYTES,
+    DEFAULT_ORT_INTER_THREADS, DEFAULT_ORT_INTRA_THREADS, EMBED_DIM, Embedder, ExecutionProvider,
+    OrtThreadingOptions, embed_one, resolve_cuda_options, resolve_expected_provider,
+    resolve_fastembed_cache_dir, resolve_ort_threading_options,
 };
 
 #[cfg(any(test, feature = "embedder-test-support"))]
@@ -243,6 +244,109 @@ mod tests {
                 resolve_cuda_options().gpu_mem_limit_bytes,
                 DEFAULT_CUDA_GPU_MEM_LIMIT_BYTES,
                 "zero BYTES + malformed MB must fall back to the safe default"
+            );
+        }
+    }
+
+    /// Why: #1542 — the CUDA deferred-embed deadlock is fixed by pinning ORT's
+    /// intra-/inter-op threads to 1 and disabling intra-op spinning. With no
+    /// operator override the resolver must default to that safe single-threaded,
+    /// no-spin profile so the daemon never reproduces the 8-ORT-thread barrier
+    /// deadlock out of the box.
+    /// What: clears all three knobs and asserts the defaults.
+    /// Test: this test.
+    #[test]
+    fn ort_threading_defaults() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", None);
+        let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", None);
+        let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", None);
+
+        let opts = resolve_ort_threading_options();
+        assert_eq!(
+            opts.intra_threads, DEFAULT_ORT_INTRA_THREADS,
+            "default intra-op threads must be 1 to avoid the #1542 barrier deadlock"
+        );
+        assert_eq!(opts.inter_threads, DEFAULT_ORT_INTER_THREADS);
+        assert!(
+            !opts.allow_spinning,
+            "spinning must default to off — it is the busy-wait half of the deadlock"
+        );
+        assert_eq!(DEFAULT_ORT_INTRA_THREADS, 1);
+        assert_eq!(DEFAULT_ORT_INTER_THREADS, 1);
+    }
+
+    /// Why: operators on hosts proven free of the ORT barrier bug may want to
+    /// raise the thread counts; the knobs must be honoured so the safe default
+    /// is overridable without a code change.
+    /// What: sets explicit positive thread counts and asserts they pass through.
+    /// Test: this test.
+    #[test]
+    fn ort_threading_reads_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", Some("4"));
+        let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", Some("2"));
+        let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", None);
+
+        let opts = resolve_ort_threading_options();
+        assert_eq!(
+            opts.intra_threads, 4,
+            "explicit intra-op count must be used"
+        );
+        assert_eq!(
+            opts.inter_threads, 2,
+            "explicit inter-op count must be used"
+        );
+        assert!(!opts.allow_spinning);
+    }
+
+    /// Why: a malformed or zero thread count must never silently disable
+    /// parallelism control or panic — it must fall back to the safe default so
+    /// the deadlock fix still holds.
+    /// What: feeds non-numeric and zero values and asserts the defaults win.
+    /// Test: this test.
+    #[test]
+    fn ort_threading_ignores_malformed() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", Some("not-a-number"));
+        let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", Some("0"));
+        let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", None);
+
+        let opts = resolve_ort_threading_options();
+        assert_eq!(
+            opts.intra_threads, DEFAULT_ORT_INTRA_THREADS,
+            "malformed intra-op count must fall back to the safe default"
+        );
+        assert_eq!(
+            opts.inter_threads, DEFAULT_ORT_INTER_THREADS,
+            "zero inter-op count must fall back to the safe default"
+        );
+    }
+
+    /// Why: spinning is opt-in and only safe under constant inference; the knob
+    /// must accept the common truthy spellings and treat everything else
+    /// (including unset) as disabled.
+    /// What: asserts a truthy value enables spinning while a non-truthy value
+    /// leaves it off.
+    /// Test: this test.
+    #[test]
+    fn ort_threading_spinning_truthy() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", None);
+        let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", None);
+
+        {
+            let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", Some("TRUE"));
+            assert!(
+                resolve_ort_threading_options().allow_spinning,
+                "a truthy value (case-insensitive) must enable spinning"
+            );
+        }
+        {
+            let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", Some("maybe"));
+            assert!(
+                !resolve_ort_threading_options().allow_spinning,
+                "a non-truthy value must leave spinning disabled"
             );
         }
     }

--- a/crates/trusty-common/src/embedder/types.rs
+++ b/crates/trusty-common/src/embedder/types.rs
@@ -88,6 +88,97 @@ pub fn resolve_cuda_options() -> CudaOptions {
     }
 }
 
+/// Default ORT intra-op thread count for embedder sessions.
+///
+/// Why: fastembed-rs hardcodes `with_intra_threads(available_parallelism())` on
+/// every session it builds, so each embed-pool worker's ORT session spins up
+/// one intra-op thread *per logical CPU*. On the CUDA deferred-embed path this
+/// multi-threaded intra-op barrier deadlocks inside `libonnxruntime` 1.24.2: a
+/// couple of workers busy-spin while the rest block forever in
+/// `condition_variable::wait`, producing 0 embeddings and an empty HNSW index
+/// (code-intelligence #1542). Pinning intra-op to a single thread removes the
+/// barrier entirely — there is no second worker to wait on — so the pass can
+/// never deadlock. `1` is the safe default; raise it only on hosts proven not
+/// to hit the ORT barrier bug.
+/// What: `1`, used when `TRUSTY_ORT_INTRA_THREADS` is unset or unparseable.
+/// Test: `ort_threading_defaults` asserts the resolver returns this value.
+pub const DEFAULT_ORT_INTRA_THREADS: usize = 1;
+
+/// Default ORT inter-op thread count for embedder sessions.
+///
+/// Why: inter-op parallelism only matters for models with parallelizable
+/// branches under `with_parallel_execution(true)`, which the all-MiniLM
+/// embedder does not use. Pinning it to `1` keeps the total ORT thread count
+/// deterministic (= number of embed-pool workers) instead of
+/// workers × CPUs, which is the workers-vs-threads mismatch behind #1542.
+/// What: `1`, used when `TRUSTY_ORT_INTER_THREADS` is unset or unparseable.
+/// Test: `ort_threading_defaults`.
+pub const DEFAULT_ORT_INTER_THREADS: usize = 1;
+
+/// Resolved ORT threading tuning for embedder sessions, derived purely from
+/// the environment so it is unit-testable on any host.
+///
+/// Why: the deadlock fix must be verifiable without a CUDA GPU or a real ONNX
+/// session, so the knob parsing lives in a pure function and only the *effect*
+/// (committing an ORT global thread pool) is applied in `fast_embedder.rs`.
+/// What: carries the intra-op / inter-op thread counts and whether intra-op
+/// spinning is allowed. These are applied to an ORT *global* thread pool
+/// (`ort::init().with_global_thread_pool(..)`) because fastembed does not
+/// expose the per-session `SessionBuilder`; committing a global pool makes ORT
+/// call `DisablePerSessionThreads`, overriding fastembed's hardcoded
+/// per-session `with_intra_threads(N)`.
+/// Test: `ort_threading_*` tests below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OrtThreadingOptions {
+    /// Threads used for parallelization *within* a single ORT operator.
+    pub intra_threads: usize,
+    /// Threads used for parallelization *between* ORT operators.
+    pub inter_threads: usize,
+    /// Whether ORT worker threads may busy-spin when their queue is empty.
+    /// Disabled by default: spinning is the half of the #1542 deadlock that
+    /// pins two workers at ~70% CPU, and the embed pass is bursty (not a
+    /// constant inference stream) so spinning buys nothing here.
+    pub allow_spinning: bool,
+}
+
+/// Resolve ORT threading options from the process environment.
+///
+/// Why: centralises the `TRUSTY_ORT_*` knob parsing so the live global-thread-
+/// pool builder and the unit tests agree on precedence and defaults, keeping
+/// the deadlock fix (#1542) verifiable without ORT/CUDA.
+/// What: reads `TRUSTY_ORT_INTRA_THREADS` and `TRUSTY_ORT_INTER_THREADS`
+/// (positive integers; malformed/zero values fall back to the safe defaults of
+/// `1`) and `TRUSTY_ORT_ALLOW_SPINNING` (truthy = `1`/`true`/`yes`/`on`,
+/// case-insensitive; anything else, including unset, means spinning stays
+/// disabled).
+/// Test: `ort_threading_defaults`, `ort_threading_reads_env`,
+/// `ort_threading_ignores_malformed`, `ort_threading_spinning_truthy`.
+pub fn resolve_ort_threading_options() -> OrtThreadingOptions {
+    fn positive_thread_count(key: &str, default: usize) -> usize {
+        std::env::var(key)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(default)
+    }
+
+    let allow_spinning = std::env::var("TRUSTY_ORT_ALLOW_SPINNING")
+        .ok()
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false);
+
+    OrtThreadingOptions {
+        intra_threads: positive_thread_count("TRUSTY_ORT_INTRA_THREADS", DEFAULT_ORT_INTRA_THREADS),
+        inter_threads: positive_thread_count("TRUSTY_ORT_INTER_THREADS", DEFAULT_ORT_INTER_THREADS),
+        allow_spinning,
+    }
+}
+
 /// Identifier for the execution provider an embedder is actually using.
 ///
 /// Why: callers want to log which backend is active (CPU vs CoreML/Metal vs


### PR DESCRIPTION
## Problem

The deferred-embed background pass deadlocks inside ORT's intra-op thread pool (`libonnxruntime` 1.24.2, CUDA provider). Diagnosed via gdb: 2 worker threads busy-spin at ~70% CPU in ORT spin frames while ~5 siblings block forever in `std::condition_variable::wait` on an ORT barrier; the orchestrator parks in `futex_wait`. Result: **0 embeddings, empty 112-byte HNSW (0 vectors)**. Tracked as code-intelligence #1542.

## Root cause

`fastembed-rs` (5.13.4) hardcodes `Session::builder()?.with_intra_threads(available_parallelism())` on every ONNX session and exposes **no hook** to override per-session thread counts (`TextInitOptions` only carries execution providers). So the single shared `FastEmbedder` ORT session spins up **one intra-op thread per logical CPU** (8 on the GPU instance), and that multi-threaded intra-op barrier deadlocks.

### The "workers: 2" vs "8 ORT threads" mismatch

These are two **orthogonal** pools:
- `trusty-search`'s `EmbedPool` runs **2 worker threads** (RAM autotune, 17–32 GB tier) that all funnel through **one** `Arc<dyn Embedder>` — a single `FastEmbedder` whose ONNX inference is serialised by `Mutex<TextEmbedding>`.
- That **one** ORT session's intra-op pool is sized to the **CPU count** (8), not 2×4.

So the fix is not about the worker count — it's about the single session's intra-op thread pool.

## Fix

Commit an ORT **global thread pool** *before* any fastembed session is created. In `ort` 2.0.0-rc.12, `SessionBuilder::commit_*` calls `DisablePerSessionThreads` when the environment has a global pool (`pre_commit` → `impl_commit.rs:155`), so fastembed's per-session `with_intra_threads(N)` is **ignored** and the global pool governs:

- **intra-op threads = 1** (default) — removes the barrier entirely: no sibling worker to wait on, so the pass can never deadlock.
- **inter-op threads = 1** (default) — keeps total ORT threads deterministic.
- **spin control off** (default) — kills the busy-wait half of the deadlock (`SetGlobalSpinControl(0)`).

Knobs are configurable (`TRUSTY_ORT_INTRA_THREADS` / `TRUSTY_ORT_INTER_THREADS` / `TRUSTY_ORT_ALLOW_SPINNING`) but default to the safe single-threaded, no-spin profile.

### API used (`ort` 2.0.0-rc.12, verified against vendored source)

```rust
let pool = ort::environment::GlobalThreadPoolOptions::default()
    .with_intra_threads(opts.intra_threads)?   // SetGlobalIntraOpNumThreads
    .with_inter_threads(opts.inter_threads)?   // SetGlobalInterOpNumThreads
    .with_spin_control(opts.allow_spinning)?;  // SetGlobalSpinControl
ort::init().with_global_thread_pool(pool).commit();
```

Verified each method exists in `~/.cargo/.../ort-2.0.0-rc.12/src/environment.rs` (lines 290/298/308) and that `commit_*` honours the global pool via `DisablePerSessionThreads` (`src/session/builder/impl_commit.rs:155`). The global pool is committed once via `OnceLock`.

## Files changed

- `crates/trusty-common/src/embedder/types.rs` — `OrtThreadingOptions` + pure `resolve_ort_threading_options()` resolver + defaults.
- `crates/trusty-common/src/embedder/fast_embedder.rs` — `init_ort_runtime()` (commits global pool once), called before the first `TextEmbedding::try_new`.
- `crates/trusty-common/src/embedder/mod.rs` — re-exports + 4 resolver unit tests.

## Testing

- `cargo check -p trusty-common --features embedder-bundled-ort` ✅
- `cargo build -p trusty-embedderd --features bundled-ort` ✅
- `cargo clippy -p trusty-common --features embedder-bundled-ort --all-targets -- -D warnings` ✅
- `cargo test -p trusty-common --features embedder-bundled-ort` ✅ 131 passed / 0 failed / 8 ignored, including 4 new `ort_threading_*` tests
- `cargo fmt -p trusty-common -- --check` ✅

**macOS CUDA limitation:** `--features embedder-cuda` cannot build/link locally (the transitive `cudarc` build script requires `nvcc`). The new code is **not** CUDA-feature-gated, so it is fully type-checked by the `embedder-bundled-ort` build.

> ⚠️ **A from-source CUDA rebuild of trusty-search on the AL2023 GPU host is still required** before this can be validated on the GPU — that is a separate ops step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)