### PR TITLE
chore(release): bump trusty-search to 0.29.0 (boot-time stale-index reconciliation #1670)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11068,7 +11068,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.16.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.28.0" }
+trusty-search = { path = "../trusty-search", version = "0.29.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,6 +9,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- boot-time stale-index reconciliation via git-diff delta reindex (closes #1670) ([#1671](https://github.com/bobmatnyc/trusty-tools/pull/1671)) ([`fe4c0b2`](https://github.com/bobmatnyc/trusty-tools/commit/fe4c0b28d340b19d3ada390925b17305412f96b2))
+## [Unreleased]
+
+### Added
+
 - auto-fresh reindex file watcher (closes #1621, refs #1619) ([#1635](https://github.com/bobmatnyc/trusty-tools/pull/1635)) ([`80e247f`](https://github.com/bobmatnyc/trusty-tools/commit/80e247fa8e64f2f701a83500e778cfb4bf5522b5))
 - reindex-on-commit git hooks + hook install/uninstall (closes #1620) ([#1622](https://github.com/bobmatnyc/trusty-tools/pull/1622)) ([`6b70579`](https://github.com/bobmatnyc/trusty-tools/commit/6b705792512bc1c7a2d7ef26ba03c470d4c9fc97))
 - typeahead endpoint + MCP tool (lexical default, opt-in blended) (closes #1557) ([#1559](https://github.com/bobmatnyc/trusty-tools/pull/1559)) ([`db16554`](https://github.com/bobmatnyc/trusty-tools/commit/db16554bbfb6d5bc1f42f3aeb29bf0c7b71b9510))

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bumps `trusty-search` version `0.28.0` → `0.29.0` (minor bump for new feature: boot-time stale-index reconciliation, closes #1670)
- Updates `trusty-agents` dependency pin `trusty-search = "0.28.0"` → `"0.29.0"` for workspace consistency (`trusty-agents` has `publish = false`, no crates.io publish needed)
- Updates `Cargo.lock`

## Dependent crate version pins updated

- `crates/trusty-agents/Cargo.toml`: `trusty-search` pin `0.28.0` → `0.29.0`
  - `trusty-agents` is `publish = false`, so no crates.io publish required for it

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo test -p trusty-search` — all tests green
- [x] Pre-commit hooks — all passed

## Post-merge

After CI is green and this merges, publish `trusty-search 0.29.0` to crates.io:
```
SKIP_UI_BUILD=1 cargo publish --dry-run -p trusty-search
SKIP_UI_BUILD=1 cargo publish -p trusty-search
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)