### PR TITLE
fix(trusty-review): per-chunk BLOCK floors synthesis to REQUEST_CHANGES + log/telemetry fixes (closes #1665)

### DIFF
--- a/crates/trusty-review/src/pipeline/mapreduce/outcome.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/outcome.rs
@@ -131,26 +131,35 @@ impl MapReduceStats {
 /// verdict + finding set with the SAME shape the unified path produces, so the
 /// downstream grade/verify/post code is unchanged.  After an optional LLM
 /// synthesis pass (#1663), `verdict` may be the synthesis-calibrated verdict
-/// (High-severity floored), `grade` carries the synthesis letter grade, and
-/// `summary` carries the synthesis prose summary.
+/// (two-tier-floored, #1665), `grade` carries the post-floor synthesis letter
+/// grade, and `summary` carries the synthesis prose summary.
 /// What: `verdict` is derived deterministically from the union of findings via
 /// the existing `derive_verdict` precedence rules (a chunk REQUEST_CHANGES/BLOCK
 /// propagates up); `findings` is the deduped, capped, prioritised union;
 /// `stats` carries the partial-coverage telemetry.  `grade` and `summary` are
 /// `None`/empty when synthesis is disabled (the runner falls back to the
-/// mechanical defaults in that case).
+/// mechanical defaults in that case).  `grade_pre_floor` (#1665 item 3) carries
+/// the grade derived from the LLM's RAW (pre-floor) synthesis verdict so
+/// downstream telemetry can detect when the floor changed the grade.
 /// Test: `reduce_*` in `reduce_tests.rs`; `synthesis_*` in `synthesis_tests.rs`.
 #[derive(Debug, Clone)]
 pub struct ReducedReview {
-    /// Aggregated verdict — mechanical (deterministic) or synthesis-calibrated.
+    /// Aggregated verdict — mechanical (deterministic) or synthesis-calibrated
+    /// (post-floor per #1665).
     pub verdict: Verdict,
     /// Deduped, prioritised, capped union of all per-chunk findings.
     pub findings: Vec<Finding>,
     /// Partial-coverage telemetry.
     pub stats: MapReduceStats,
-    /// Synthesis letter grade (e.g. `"B+"`) from the calibration LLM pass,
-    /// or `None` when synthesis is disabled or failed.
+    /// Post-floor synthesis letter grade (e.g. `"B+"`) from the calibration LLM
+    /// pass, or `None` when synthesis is disabled or failed.
     pub grade: Option<String>,
+    /// Pre-floor synthesis letter grade — the grade derived from the LLM's RAW
+    /// synthesis verdict BEFORE the two-tier floor (#1665) was applied.  `None`
+    /// when synthesis is disabled, failed, or produced no grade.  When `grade !=
+    /// grade_pre_floor`, the floor changed the verdict; when they are equal, no
+    /// flooring occurred (observable telemetry, #1665 item 3).
+    pub grade_pre_floor: Option<String>,
     /// Synthesis prose summary from the calibration LLM pass, or empty string
     /// when synthesis is disabled or failed.
     pub summary: String,

--- a/crates/trusty-review/src/pipeline/mapreduce/reduce.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/reduce.rs
@@ -103,9 +103,11 @@ pub fn reduce(outcomes: Vec<MapOutcome>, config: &MapReduceConfig) -> ReducedRev
         verdict,
         findings,
         stats,
-        // grade and summary are populated by the optional synthesis pass (#1663);
-        // the mechanical reduce stage leaves them absent.
+        // grade, grade_pre_floor, and summary are populated by the optional
+        // synthesis pass (#1663 / #1665); the mechanical reduce stage leaves
+        // them absent.
         grade: None,
+        grade_pre_floor: None,
         summary: String::new(),
     }
 }

--- a/crates/trusty-review/src/pipeline/mapreduce/synthesis.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/synthesis.rs
@@ -13,10 +13,14 @@
 //! makes ONE additional LLM call asking the model to judge the PR holistically
 //! (given the deduped finding list and per-chunk verdicts), and returns a new
 //! `ReducedReview` whose `verdict`, `grade`, and `summary` come from the synthesis
-//! response.  The High-severity safety floor is re-applied after synthesis, but the
-//! count-based Medium floor is deliberately omitted — the LLM has already holistically
-//! judged those findings.  Any synthesis error causes a graceful fall-back to the
-//! original mechanical `ReducedReview` so synthesis can NEVER fail the whole review.
+//! response.  The two-tier safety floor is re-applied after synthesis (#1665):
+//! any non-refuted `Effort::High` finding floors the verdict to at least BLOCK;
+//! failing that, a mechanical BLOCK floors the synthesis verdict to at least
+//! REQUEST_CHANGES (so synthesis cannot de-escalate BLOCK to APPROVE/APPROVE*).
+//! The count-based Medium floor is deliberately omitted — the LLM has already
+//! holistically judged those findings.  Any synthesis error causes a graceful
+//! fall-back to the original mechanical `ReducedReview` so synthesis can NEVER
+//! fail the whole review.
 //!
 //! Test: `synthesis_tests.rs`.
 
@@ -82,21 +86,32 @@ struct SynthesisResponse {
 /// Why: the mechanical reduce path applies a count-based `≥2 Medium →
 /// REQUEST_CHANGES` floor that fires on minor isolated nits and over-strictens the
 /// verdict compared to a single reviewer reading the whole PR.  The synthesis pass
-/// lets an LLM judge the PR holistically and optionally forgive nits.  The
-/// High-severity safety floor is re-applied so critical issues cannot be softened.
+/// lets an LLM judge the PR holistically and optionally forgive nits.  A two-tier
+/// safety floor (#1665) is re-applied so critical issues cannot be softened past
+/// defined lower bounds.
 /// What:
 ///   1. If `!config.synthesis` → returns `reduced` unchanged (legacy path preserved).
-///   2. Builds a synthesis prompt from PR metadata + deduped finding list.
-///   3. Calls the LLM; on any error, logs a warning and returns `reduced` unchanged.
-///   4. Parses the JSON response (verdict, grade, summary).
-///   5. Applies `apply_high_severity_floor_only` (High-severity floor ONLY —
-///      deliberately omitting the count-based Medium floor, which is the over-strictness
-///      source).
-///   6. Returns a new `ReducedReview` with the synthesis verdict/grade/summary.
+///   2. Captures `mechanical_verdict = reduced.verdict` BEFORE any modification.
+///   3. Builds a synthesis prompt from PR metadata + deduped finding list.
+///   4. Calls the LLM; on any error, logs a warning and returns `reduced` unchanged.
+///   5. Parses the JSON response (verdict, grade, summary).
+///   6. Applies `apply_synthesis_floor` with the two-tier policy (#1665).
+///      Tier 1: any unrefuted `Effort::High` finding → floor to BLOCK.
+///      Tier 2: else if `mechanical_verdict == Block` → floor to REQUEST_CHANGES
+///      (synthesis may de-escalate BLOCK→REQUEST_CHANGES but NEVER →APPROVE).
+///      Tier 3: else no floor; synthesis verdict stands.
+///      The count-based Medium floor is deliberately omitted (it is the
+///      over-strictness source the synthesis pass is calibrating away).
+///   7. Returns a new `ReducedReview` with synthesis verdict/grade/summary plus
+///      `grade_pre_floor` for observable telemetry (#1665 item 3).
 ///
-/// Test: `synthesis_tests.rs` — `synthesis_softens_minor_nits`,
-///   `synthesis_high_severity_still_floors`, `synthesis_false_returns_unchanged`,
-///   `synthesis_llm_error_falls_back`, `synthesis_grade_and_summary_flow_through`.
+/// Test: `synthesis_tests.rs` — covers `synthesis_softens_minor_nits`,
+/// `synthesis_high_severity_still_floors`, `synthesis_false_returns_unchanged`,
+/// `synthesis_llm_error_falls_back`, `synthesis_grade_and_summary_flow_through`,
+/// `synthesis_block_without_high_finding_floors_to_request_changes`,
+/// `synthesis_mechanical_rc_allows_full_softening`,
+/// `synthesis_floor_telemetry_differs_when_floored`,
+/// `synthesis_floor_telemetry_equal_when_no_floor`.
 pub async fn synthesize_review(
     reduced: ReducedReview,
     llm: &Arc<dyn LlmProvider>,
@@ -108,6 +123,10 @@ pub async fn synthesize_review(
         debug!("synthesis disabled via config.synthesis=false — returning mechanical reduce");
         return reduced;
     }
+
+    // Capture the mechanical verdict BEFORE any modification — needed by the
+    // two-tier floor (#1665 item 1) and for telemetry logging.
+    let mechanical_verdict = reduced.verdict.clone();
 
     // Build the synthesis prompt from PR metadata and the deduped finding list.
     let prompt = build_synthesis_prompt(ctx, &reduced);
@@ -148,24 +167,50 @@ pub async fn synthesize_review(
         }
     };
 
-    // Apply the High-severity safety floor (omitting the count-based Medium floor).
-    let floored_verdict =
-        apply_high_severity_floor_only(synthesis.synthesized_verdict, &reduced.findings);
+    // Capture the raw (pre-floor) synthesized verdict so we can compute the
+    // pre-floor grade independently from the post-floor grade (#1665 item 3).
+    let raw_verdict = synthesis.synthesized_verdict.clone();
 
-    // Parse the synthesized grade string through the Grade type so invalid tokens
-    // (e.g. "Pass", "A+/B") are caught; fall back to the floor-derived default on
-    // parse failure or empty string.
+    // Apply the two-tier synthesis floor (#1665 item 1):
+    //   Tier 1: any unrefuted High finding → floor to BLOCK.
+    //   Tier 2: else mechanical_verdict was BLOCK → floor to REQUEST_CHANGES.
+    //   Tier 3: else no floor; synthesis verdict stands (may soften freely).
+    let floored_verdict = apply_synthesis_floor(
+        synthesis.synthesized_verdict,
+        &reduced.findings,
+        &mechanical_verdict,
+    );
+
+    // Pre-floor grade: clamp the LLM grade to the RAW (pre-floor) verdict for
+    // observable telemetry (#1665 item 3).  When the floor changes the verdict,
+    // pre_floor_grade_str differs from grade_str below; when no floor fires
+    // (raw_verdict == floored_verdict), they are identical.
+    let pre_floor_grade_str = synthesis
+        .grade
+        .parse::<Grade>()
+        .ok()
+        .map(|g| {
+            use crate::pipeline::letter_grade::clamp_grade_to_verdict;
+            clamp_grade_to_verdict(g, &raw_verdict).to_string()
+        })
+        .unwrap_or_else(|| grade_for_verdict(&raw_verdict).to_string());
+
+    // Post-floor grade: clamp the LLM grade to the FLOORED verdict so invalid
+    // combinations (e.g. "A" on a floored BLOCK) are corrected.
     let grade_str = synthesis
         .grade
         .parse::<Grade>()
         .ok()
-        .map(|g| g.to_string())
+        .map(|g| {
+            use crate::pipeline::letter_grade::clamp_grade_to_verdict;
+            clamp_grade_to_verdict(g, &floored_verdict).to_string()
+        })
         .unwrap_or_else(|| grade_for_verdict(&floored_verdict).to_string());
 
     let summary = synthesis.summary.clone();
 
     info!(
-        mechanical_verdict = %reduced.verdict,
+        mechanical_verdict = %mechanical_verdict,
         synthesis_verdict = %floored_verdict,
         grade = %grade_str,
         "synthesis pass complete"
@@ -176,6 +221,7 @@ pub async fn synthesize_review(
         findings: reduced.findings,
         stats: reduced.stats,
         grade: Some(grade_str),
+        grade_pre_floor: Some(pre_floor_grade_str),
         summary,
     }
 }
@@ -198,46 +244,49 @@ struct ParsedSynthesis {
     summary: String,
 }
 
-// ─── High-severity-only floor ─────────────────────────────────────────────────
+// ─── Two-tier synthesis floor ─────────────────────────────────────────────────
 
-/// Apply ONLY the High-severity floor after synthesis (closes #1663).
+/// Apply the two-tier synthesis floor after the synthesis LLM call (#1665).
 ///
 /// Why: the synthesis LLM has holistically judged the PR; re-applying the full
 /// `derive_verdict` (which includes the count-based `≥2 Medium →
 /// REQUEST_CHANGES` floor) would undo the calibration the synthesis was designed
-/// to provide.  The one non-negotiable floor is: ANY non-refuted High-severity
-/// finding must still floor the verdict to at least BLOCK.  Critical findings
-/// cannot be forgiven by synthesis — that would be a safety hole.
+/// to provide.  Two non-negotiable floors remain (#1665, decided policy):
 ///
-/// **High → BLOCK is the correct and intentional floor** (floor semantics note):
-/// The unified single-file path's `derive_verdict` (in `pipeline/grade.rs`,
-/// `correctness_floor`) maps `Effort::High` → `Verdict::Block` as Tier 1.
-/// `Effort::High` is the only severity level above Medium in the domain model
-/// ("Critical or High severity" per the `grade.rs` module-level comment).  There
-/// is no separate `Critical` variant in `Effort`.  Our `High → BLOCK` floor here
-/// therefore MATCHES the unified path's semantics exactly, keeping map-reduce and
-/// unified verdicts on a single standard.
+///   **Tier 1 — High finding → BLOCK:**
+///   ANY non-refuted `Effort::High` finding must floor the verdict to at least
+///   BLOCK.  Critical findings cannot be forgiven by synthesis — that would be a
+///   safety hole.  This matches the unified path's `correctness_floor` semantics
+///   (`Effort::High` is the only severity above Medium; there is no separate
+///   `Critical` variant).
 ///
-/// **Softening a mechanical BLOCK IS intentional** (calibration goal):
-/// The `worst-chunk-wins` mechanical reduce can produce a BLOCK verdict even when
-/// no High-severity finding exists — for example, when the count-based `≥2 Medium
-/// → REQUEST_CHANGES` floor fires on many chunks and the most severe chunk verdict
-/// is REQUEST_CHANGES, not BLOCK.  In practice, a mechanical BLOCK may arise from
-/// a per-chunk BLOCK that was itself driven by a Medium-count heuristic rather than
-/// a genuine High-severity finding.  Synthesis is PERMITTED to soften such a
-/// mechanical BLOCK, because the LLM has seen all findings holistically and judged
-/// them minor.  The High-severity floor below is the only hard backstop: synthesis
-/// can NEVER soften a BLOCK that is backed by a non-refuted `Effort::High` finding.
+///   **Tier 2 — mechanical BLOCK → at least REQUEST_CHANGES:**
+///   If no High finding is present but the mechanical (pre-synthesis) verdict was
+///   `Verdict::Block`, synthesis may de-escalate BLOCK → REQUEST_CHANGES but MUST
+///   NOT de-escalate BLOCK → APPROVE or APPROVE*.  A per-chunk BLOCK without a
+///   High finding is typically driven by a Medium-count heuristic; an LLM
+///   holistically judging those nits minor is permitted — but the human reviewer
+///   must at minimum be informed via REQUEST_CHANGES, not silently APPROVED.
 ///
-/// What: if any finding in `findings` is `Effort::High` AND not refuted →
-/// returns the stricter of (`synthesized_verdict`, BLOCK).  Otherwise returns
-/// `synthesized_verdict` unchanged.  This deliberately does NOT apply the
-/// count-based `≥2 Medium → REQUEST_CHANGES` floor (that floor is the
-/// over-strictness source the synthesis is calibrating away).
-/// Test: `synthesis_high_severity_still_floors` in synthesis_tests.rs.
-pub(crate) fn apply_high_severity_floor_only(
+///   **Tier 3 — no floor:** when neither condition above applies, synthesis may
+///   soften the verdict freely (e.g. REQUEST_CHANGES → APPROVE is allowed for
+///   non-BLOCK mechanical verdicts with no High findings).
+///
+/// What: given `synthesized` (the LLM's raw output), `findings` (the deduped
+/// finding set), and `mechanical_verdict` (the deterministic pre-synthesis
+/// verdict captured before synthesis ran):
+///   - Returns `BLOCK` when `has_unrefuted_high`.
+///   - Returns `max_by_ordinal(synthesized, REQUEST_CHANGES)` when
+///     `mechanical_verdict == Block` (and no High finding).
+///   - Otherwise returns `synthesized` unchanged.
+///
+/// Test: `synthesis_high_severity_still_floors`,
+/// `synthesis_block_without_high_finding_floors_to_request_changes`,
+/// `synthesis_mechanical_rc_allows_full_softening` in synthesis_tests.rs.
+pub(crate) fn apply_synthesis_floor(
     synthesized: Verdict,
     findings: &[Finding],
+    mechanical_verdict: &Verdict,
 ) -> Verdict {
     use crate::models::VerifyOutcome;
 
@@ -253,17 +302,50 @@ pub(crate) fn apply_high_severity_floor_only(
     });
 
     if has_unrefuted_high {
-        // BLOCK is the minimum for a critical finding — take the stricter of
-        // the synthesized verdict and BLOCK.
+        // Tier 1: BLOCK is the minimum for a critical finding — take the stricter
+        // of the synthesized verdict and BLOCK.
         if synthesized.ordinal() < Verdict::Block.ordinal() {
             debug!(
                 synthesis_verdict = %synthesized,
-                "High-severity safety floor: synthesis verdict upgraded to BLOCK"
+                "synthesis floor tier-1: High-severity finding — upgrading verdict to BLOCK"
             );
             return Verdict::Block;
         }
+        return synthesized;
     }
+
+    if *mechanical_verdict == Verdict::Block {
+        // Tier 2: mechanical BLOCK without High finding — synthesis may de-escalate
+        // BLOCK → REQUEST_CHANGES but NOT further toward APPROVE.
+        if synthesized.ordinal() < Verdict::RequestChanges.ordinal() {
+            debug!(
+                synthesis_verdict = %synthesized,
+                "synthesis floor tier-2: mechanical BLOCK (no High finding) — \
+                 upgrading synthesis verdict to REQUEST_CHANGES"
+            );
+            return Verdict::RequestChanges;
+        }
+    }
+
+    // Tier 3: no floor — return synthesized verdict unchanged.
     synthesized
+}
+
+/// Alias kept for backward-compat in existing test call-sites; delegates to
+/// `apply_synthesis_floor` with an `Approve` mechanical verdict (tier-2 never
+/// fires, only tier-1 applies) so the semantics of the old single-floor helper
+/// are preserved exactly.
+///
+/// Why: avoids a noisy test diff; all call-sites that only exercise the
+/// High-severity floor can keep using the name they document.
+/// What: calls `apply_synthesis_floor(synthesized, findings, &Verdict::Approve)`.
+/// Test: old helper unit tests in synthesis_tests.rs.
+#[cfg(test)]
+pub(crate) fn apply_high_severity_floor_only(
+    synthesized: Verdict,
+    findings: &[Finding],
+) -> Verdict {
+    apply_synthesis_floor(synthesized, findings, &Verdict::Approve)
 }
 
 // ─── Prompt builders ──────────────────────────────────────────────────────────
@@ -453,7 +535,7 @@ fn parse_verdict_str(s: &str) -> Option<Verdict> {
         "UNKNOWN" => {
             warn!(
                 verdict = "UNKNOWN",
-                "synthesis: model returned UNKNOWN verdict — treating as unrecognised,                  falling back to mechanical result"
+                "synthesis: model returned UNKNOWN verdict — treating as unrecognised, falling back to mechanical result"
             );
             None
         }

--- a/crates/trusty-review/src/pipeline/mapreduce/synthesis_tests.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/synthesis_tests.rs
@@ -106,6 +106,7 @@ fn reduced_with_findings(verdict: Verdict, findings: Vec<Finding>) -> ReducedRev
         findings,
         stats: stats_one_reviewed(),
         grade: None,
+        grade_pre_floor: None,
         summary: String::new(),
     }
 }
@@ -415,6 +416,190 @@ async fn synthesis_unknown_verdict_falls_back() {
     assert!(
         result.grade.is_none(),
         "fallback path must not populate grade"
+    );
+}
+
+// ── #1665 follow-up tests ──────────────────────────────────────────────────
+
+/// #1665 item 1 — DECIDED policy, Tier-2 floor:
+/// per-chunk BLOCK (no High finding, only Medium) + synthesis returns APPROVE
+/// → final verdict must be REQUEST_CHANGES (NOT APPROVE, NOT BLOCK).
+///
+/// The mechanical reduce produced BLOCK via the worst-chunk-wins aggregate even
+/// though the only finding is Medium-effort.  Synthesis sees minor isolated nits
+/// holistically and returns APPROVE.  Tier-2 of `apply_synthesis_floor` must
+/// floor that APPROVE to at least REQUEST_CHANGES because the mechanical verdict
+/// was BLOCK.
+#[tokio::test]
+async fn synthesis_block_without_high_finding_floors_to_request_changes() {
+    // Mechanical BLOCK, only Medium findings (no High present).
+    let findings = vec![
+        finding(
+            "nit",
+            "missing doc comment on public fn",
+            Effort::Medium,
+            0.85,
+        ),
+        finding("style", "inconsistent naming", Effort::Medium, 0.80),
+    ];
+    let reduced = reduced_with_findings(Verdict::Block, findings);
+
+    // Synthesis LLM judges nits minor and returns APPROVE — Tier-2 must fire.
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE","grade":"B","summary":"Nits are minor; approving holistically."}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_eq!(
+        result.verdict,
+        Verdict::RequestChanges,
+        "#1665 tier-2 floor: per-chunk BLOCK + only Medium findings + synthesis APPROVE \
+         must produce REQUEST_CHANGES, not APPROVE and not BLOCK"
+    );
+}
+
+/// #1665 item 1 — High finding still floors to BLOCK (Tier-1, existing rule preserved).
+///
+/// Confirms the Tier-1 floor still fires: a High-effort finding is present so the
+/// verdict must be BLOCK regardless of the synthesis output.
+#[tokio::test]
+async fn synthesis_high_finding_tier1_still_blocks() {
+    let findings = vec![finding(
+        "auth-bypass",
+        "skips all auth on admin endpoints",
+        Effort::High,
+        0.97,
+    )];
+    let reduced = reduced_with_findings(Verdict::Block, findings);
+
+    // Synthesis returns APPROVE — Tier-1 must upgrade to BLOCK.
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE","grade":"A","summary":"Looks fine."}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_eq!(
+        result.verdict,
+        Verdict::Block,
+        "#1665 tier-1: High-effort finding must always floor to BLOCK"
+    );
+}
+
+/// #1665 item 1 — Tier-3 (no floor): mechanical REQUEST_CHANGES + synthesis
+/// returns APPROVE* → final must be APPROVE* (synthesis allowed to soften freely).
+///
+/// The mechanical verdict was REQUEST_CHANGES (not BLOCK) and there are no High
+/// findings — neither Tier-1 nor Tier-2 fires.  Synthesis can soften freely to
+/// APPROVE*.
+#[tokio::test]
+async fn synthesis_mechanical_rc_allows_full_softening() {
+    let findings = vec![finding("nit", "cosmetic whitespace", Effort::Low, 0.7)];
+    let reduced = reduced_with_findings(Verdict::RequestChanges, findings);
+
+    // Synthesis returns APPROVE* — must NOT be floored (mechanical was RC, not BLOCK).
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE*","grade":"B-","summary":"Minor nit, approvable with reservations."}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_eq!(
+        result.verdict,
+        Verdict::ApproveWithReservations,
+        "#1665 tier-3 (no floor): mechanical RC + no High finding must allow \
+         synthesis to soften to APPROVE*"
+    );
+}
+
+/// #1665 item 3 — telemetry: when the floor changes the verdict, `grade_pre_floor`
+/// differs from `grade` so downstream code can detect flooring.
+///
+/// Mechanical BLOCK + only Medium findings + synthesis returns APPROVE.
+/// Tier-2 floors APPROVE → REQUEST_CHANGES, so the pre-floor grade (B, for APPROVE)
+/// must differ from the post-floor grade (clamped for REQUEST_CHANGES).
+#[tokio::test]
+async fn synthesis_floor_telemetry_differs_when_floored() {
+    let findings = vec![finding("nit", "style", Effort::Medium, 0.8)];
+    let reduced = reduced_with_findings(Verdict::Block, findings);
+
+    // Synthesis returns APPROVE (grade "B") — Tier-2 floors verdict to RC.
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE","grade":"B","summary":"Minor nit."}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    // Flooring occurred — verify the verdict was changed.
+    assert_eq!(
+        result.verdict,
+        Verdict::RequestChanges,
+        "tier-2 floor must produce RC"
+    );
+
+    // Telemetry: grade and grade_pre_floor must differ (floor was observable).
+    assert!(
+        result.grade.is_some(),
+        "grade must be populated after synthesis"
+    );
+    assert!(
+        result.grade_pre_floor.is_some(),
+        "grade_pre_floor must be populated when synthesis ran"
+    );
+    assert_ne!(
+        result.grade, result.grade_pre_floor,
+        "#1665 item 3: when the floor changes the verdict, \
+         grade (post-floor) must differ from grade_pre_floor (pre-floor)"
+    );
+}
+
+/// #1665 item 3 — telemetry: when no floor fires, `grade_pre_floor == grade`.
+///
+/// Mechanical REQUEST_CHANGES + synthesis APPROVE* (Tier-3, no floor) — both
+/// grades should be equal because synthesis verdict was not changed.
+#[tokio::test]
+async fn synthesis_floor_telemetry_equal_when_no_floor() {
+    let findings = vec![finding("nit", "whitespace", Effort::Low, 0.6)];
+    let reduced = reduced_with_findings(Verdict::RequestChanges, findings);
+
+    // Synthesis returns APPROVE* — no floor fires (RC mechanical, no High finding).
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE*","grade":"B-","summary":"Minor nit, approvable."}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_eq!(
+        result.verdict,
+        Verdict::ApproveWithReservations,
+        "no floor — verdict unchanged"
+    );
+
+    // Telemetry: no floor → grades must be equal.
+    assert_eq!(
+        result.grade, result.grade_pre_floor,
+        "#1665 item 3: when no floor fires, grade and grade_pre_floor must be equal"
     );
 }
 

--- a/crates/trusty-review/src/pipeline/parser.rs
+++ b/crates/trusty-review/src/pipeline/parser.rs
@@ -127,6 +127,12 @@ pub struct ParsedReview {
     pub verdict: Verdict,
     /// Letter grade from the LLM (A+ through F), or `None` if not provided.
     pub grade: Option<String>,
+    /// Pre-floor synthesis letter grade (#1665 item 3) — the grade derived from
+    /// the LLM's RAW synthesis verdict BEFORE the two-tier floor was applied.
+    /// `None` for non-synthesis reviews or when synthesis is disabled/failed.
+    /// When `grade_pre_floor != grade`, the floor changed the verdict; when equal,
+    /// no flooring occurred.
+    pub grade_pre_floor: Option<String>,
     /// One-line summary extracted from the JSON block, or empty string.
     pub summary: String,
     /// Parsed findings (may be empty).
@@ -151,6 +157,7 @@ impl ParsedReview {
         Self {
             verdict: Verdict::Unknown,
             grade: None,
+            grade_pre_floor: None,
             summary: String::new(),
             findings: Vec::new(),
             is_fail_safe: true,
@@ -206,6 +213,7 @@ pub fn parse_review_response(body: &str) -> ParsedReview {
         return ParsedReview {
             verdict,
             grade: None,
+            grade_pre_floor: None,
             summary: String::new(),
             findings: Vec::new(),
             is_fail_safe: false,
@@ -254,6 +262,7 @@ fn try_parse_direct_json(body: &str) -> Option<ParsedReview> {
     Some(ParsedReview {
         verdict,
         grade,
+        grade_pre_floor: None,
         summary: block.summary,
         findings,
         is_fail_safe: false,
@@ -300,6 +309,7 @@ fn try_parse_json_block(body: &str) -> Option<ParsedReview> {
     Some(ParsedReview {
         verdict,
         grade,
+        grade_pre_floor: None,
         summary: block.summary,
         findings,
         is_fail_safe: false,

--- a/crates/trusty-review/src/pipeline/runner_mapreduce.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce.rs
@@ -132,6 +132,10 @@ pub(super) async fn run_mapreduce_branch(
     let parsed = ParsedReview {
         verdict: reduced.verdict.clone(),
         grade: reduced.grade.clone(),
+        // Thread the pre-floor grade for observable telemetry (#1665 item 3).
+        // When synthesis fired the two-tier floor, grade_pre_floor differs from
+        // grade and downstream code can detect it.
+        grade_pre_floor: reduced.grade_pre_floor.clone(),
         summary: reduced.summary.clone(),
         findings: reduced.findings.clone(),
         is_fail_safe: false,
@@ -236,16 +240,31 @@ async fn fold_reduced_into_result(
     synthesis_active: bool,
 ) {
     // Derive (final_verdict, final_grade, original_llm_grade) depending on path.
+    //
+    // For the synthesis path (#1663 / #1665 item 3):
+    //   - `final_grade`        = grade for the FLOORED verdict (post-floor).
+    //   - `original_llm_grade` = grade from the LLM's RAW synthesis verdict
+    //                            (pre-floor), threaded in via `ReducedReview::grade_pre_floor`.
+    //   When the two-tier floor (#1665) changed the verdict, the two grades differ
+    //   and downstream telemetry can detect the flooring.  When no floor fired,
+    //   both are equal (same behaviour as before #1665).
     let (final_verdict, final_grade, original_llm_grade) = if synthesis_active {
-        // Synthesis path (#1663): verdict is already High-severity-floored.
+        // Synthesis path (#1663): verdict is already floored by apply_synthesis_floor.
         // Re-applying derive_verdict_with_grade would wrongly re-add the count
         // floor.  Use the synthesis verdict + grade directly instead.
-        let synthesis_grade: Grade = parsed
+        let final_grade: Grade = parsed
             .grade
             .as_deref()
             .and_then(|s| s.parse().ok())
             .unwrap_or_else(|| default_grade_for_verdict(&parsed.verdict));
-        (parsed.verdict.clone(), synthesis_grade, synthesis_grade)
+        // Pre-floor grade for telemetry: use grade_pre_floor when available;
+        // fall back to final_grade when no flooring occurred (they'll be equal).
+        let pre_floor_grade: Grade = parsed
+            .grade_pre_floor
+            .as_deref()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(final_grade);
+        (parsed.verdict.clone(), final_grade, pre_floor_grade)
     } else {
         // Mechanical path: apply the full severity floor via apply_grade_and_floor.
         apply_grade_and_floor(&parsed)


### PR DESCRIPTION
## Summary
Implements synthesis-pass follow-ups for trusty-review: per-file BLOCK verdict handling policy, log formatting cleanup, and observable floor telemetry when the synthesis floor fires.

## Changes

### 1. Synthesis Floor Policy (DECIDED)
In the map-reduce synthesis pass, when a per-file reviewer's BLOCK verdict contains only Medium findings (no High severity), the synthesized verdict now floors to at least REQUEST_CHANGES. High findings still hard-floor to BLOCK. The policy preserves escalation discipline while preventing over-emphasis of Medium-only blocks:
- High findings → BLOCK (unchanged)
- BLOCK with Medium only → REQUEST_CHANGES (new floor)
- Synthesis may further de-escalate REQUEST_CHANGES → APPROVE but never escalates BLOCK back up
- Implemented as a two-tier `apply_synthesis_floor(synthesized, findings, mechanical_verdict)` function

### 2. Log Whitespace Fix
Collapsed a whitespace artifact in the UNKNOWN-verdict `warn!` log where a newline was embedding debug state in the middle of the message.

### 3. Observable Floor Telemetry
Threaded the pre-floor synthesized grade (`grade_pre_floor`) through the verdict struct so telemetry can distinguish:
- `original_llm_grade` (raw LLM output before any floor)
- `final_grade` (after synthesis floor applied)
- Enables observability of when and why the floor fires in production

## Testing
- 5 new tests covering per-chunk BLOCK floor logic
- All 1049 tests pass
- `cargo clippy` clean (no warnings)
- `cargo fmt` clean
- Line-cap validation clean

Closes #1665

🤖 Generated with [Claude Code](https://claude.com/claude-code)