### PR TITLE
chore(release): bump trusty-review to 0.6.1 (synthesis floor calibration #1665)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11027,7 +11027,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.11.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.6.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.6.1" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -7,6 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.6.1] — 2026-06-25
+
+### Fixed
+
+- per-chunk BLOCK floors synthesis to REQUEST_CHANGES, fix log whitespace, observable floor telemetry (closes #1665) ([#1674](https://github.com/bobmatnyc/trusty-tools/pull/1674)) ([`734dac6`](https://github.com/bobmatnyc/trusty-tools/commit/734dac64))
+
 ## [0.6.0] — 2026-06-24
 
 ### Added

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.6.0"
+version     = "0.6.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Summary

- Bump `trusty-review` `0.6.0` → `0.6.1` (PATCH)
- Update workspace `Cargo.toml` pin to `0.6.1`
- Add `[0.6.1]` CHANGELOG entry

## Changes in this release

Closes #1665 — per-chunk BLOCK floors synthesis to REQUEST_CHANGES, fix log whitespace, observable floor telemetry (squash commit `734dac64`, already merged to main via #1674).

## Dependent crate pins updated

- `Cargo.toml` workspace table: `trusty-review = { ..., version = "0.6.1" }` (was `0.6.0`)
- `trusty-mpm` and `trusty-analyze` use `{ workspace = true }` — no individual bumps needed

## Test plan

- [x] `cargo test -p trusty-review` — 35/35 passed
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)