### PR TITLE
docs(trusty-memory): correct stale SQLite references to redb in comments and README

### DIFF
--- a/crates/trusty-common/src/memory_core/dream/dreamer.rs
+++ b/crates/trusty-common/src/memory_core/dream/dreamer.rs
@@ -286,9 +286,9 @@ impl Dreamer {
         };
         stats.update_compression_ratio();
 
-        // WAL checkpoint — PASSIVE mode is non-blocking. Issue #36: without
-        // periodic checkpointing the SQLite WAL grows unbounded over a
-        // long-running daemon's lifetime.
+        // WAL checkpoint hook — kept for API compatibility; redb manages its
+        // own write log internally so this is a no-op (issue #36, #989).
+        // Previously, SQLite needed periodic checkpointing to bound WAL growth.
         match handle.kg.checkpoint() {
             Ok((wal, done)) => {
                 tracing::debug!(

--- a/crates/trusty-common/src/memory_core/mod.rs
+++ b/crates/trusty-common/src/memory_core/mod.rs
@@ -9,7 +9,7 @@
 //! What: Re-exports the palace hierarchy (`Palace`, `Wing`, `Room`,
 //! `Drawer`), the registry, and the retrieval handle. Gated behind the
 //! `memory-core` feature because it pulls in heavy storage deps
-//! (`usearch`, `rusqlite`, `r2d2`, `tiktoken-rs`, `git2`).
+//! (`usearch`, `redb`, `postcard`, `tiktoken-rs`, `git2`).
 //! Test: Each submodule keeps its existing unit tests; `cargo test -p
 //! trusty-common --features memory-core` exercises the full surface.
 

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -49,8 +49,8 @@ pub struct PalaceHandle {
     pub kg: Arc<KnowledgeGraph>,
     pub drawers: Arc<RwLock<Vec<Drawer>>>,
     /// On-disk data directory for this palace (where palace.json,
-    /// identity.txt, l1_cache.json, the usearch index, and the KG SQLite
-    /// file all live). `None` for in-memory tests built via `new`.
+    /// identity.txt, l1_cache.json, the usearch index, and the KG redb
+    /// store all live). `None` for in-memory tests built via `new`.
     pub data_dir: Option<std::path::PathBuf>,
     /// Temporal decay configuration applied during L2/L3 ranking.
     ///
@@ -92,7 +92,7 @@ pub struct PalaceHandle {
     pub is_compacting: Arc<AtomicBool>,
     /// Serialises mutating ops (`remember_with_options`, `forget`) on this
     /// palace so concurrent writers don't race on the L1 snapshot rename,
-    /// the vector store upsert, the KG SQLite row insert, or the in-memory
+    /// the vector store upsert, the KG redb record insert, or the in-memory
     /// drawer table.
     ///
     /// Why: Issue #154 — under 20 concurrent HTTP `memory_remember` calls,
@@ -193,7 +193,7 @@ impl PalaceHandle {
     /// What: Creates the data directory if missing, loads identity.txt
     /// (defaulting to empty), loads the L1 snapshot (defaulting to empty),
     /// opens the usearch index at `<data_dir>/index.usearch` (384-d), and
-    /// opens the KG SQLite at `<data_dir>/kg.db`. The drawer table is
+    /// opens the KG redb store at `<data_dir>/kg.redb`. The drawer table is
     /// initialized from the L1 snapshot (the L1 cache is the only
     /// authoritative drawer metadata until the full drawer table is
     /// persisted in a follow-up issue).
@@ -238,7 +238,7 @@ impl PalaceHandle {
         let kg = KnowledgeGraph::open_with_intent(&kg_path, intent)
             .with_context(|| format!("open KG for {}", palace.id))?;
 
-        // Load full drawer table from SQLite (the persistent source of truth).
+        // Load full drawer table from redb (the persistent source of truth).
         // Fall back to an empty list on error so a corrupt table doesn't make
         // the palace unopenable — the L1 snapshot still provides essentials.
         let persisted_drawers = match kg.load_drawers() {
@@ -353,7 +353,7 @@ impl PalaceHandle {
     /// Attach a recall analytics log to this handle.
     ///
     /// Why: Recall logging is opt-in so simple tests don't need to manage a
-    /// SQLite file; production palaces wire one in at construction time.
+    /// redb file; production palaces wire one in at construction time.
     /// What: Builder-style mutator returning `self`.
     /// Test: `recall_logs_events_when_log_present` uses this to enable logging.
     pub fn with_recall_log(mut self, log: Arc<RecallLog>) -> Self {
@@ -539,7 +539,7 @@ impl PalaceHandle {
         }
 
         // Persist drawer metadata BEFORE the in-memory push so a crash mid-op
-        // cannot leave an in-memory drawer with no SQLite row backing it.
+        // cannot leave an in-memory drawer with no redb record backing it.
         self.kg
             .upsert_drawer(&drawer)
             .await

--- a/crates/trusty-common/src/memory_core/store/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/mod.rs
@@ -1,4 +1,4 @@
-//! Storage backends: vector index (HNSW) + temporal knowledge graph (SQLite).
+//! Storage backends: vector index (HNSW) + temporal knowledge graph (redb).
 //!
 //! Why: Two complementary data shapes — dense vectors for semantic recall and
 //! triples-with-time for relational facts — covered by separate modules so each

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -3,10 +3,10 @@
 [![crates.io](https://img.shields.io/crates/v/trusty-memory.svg)](https://crates.io/crates/trusty-memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Memory palace MCP server (HTTP/SSE) backed by `usearch` vector store, SQLite
-metadata, and `fastembed` embeddings. Stores and retrieves natural-language
-memories organized into named "palaces" (namespaces), with an optional
-knowledge-graph layer for structured triples.
+Memory palace MCP server (HTTP/SSE) backed by `usearch` (HNSW) vector store,
+`redb` metadata and knowledge-graph stores, and `fastembed` embeddings. Stores
+and retrieves natural-language memories organized into named "palaces"
+(namespaces), with an optional knowledge-graph layer for structured triples.
 
 Claude Code integration uses `trusty-memory serve --stdio` — a direct
 stdio JSON-RPC MCP server that forwards every request to the running HTTP

--- a/crates/trusty-memory/src/chat/handler.rs
+++ b/crates/trusty-memory/src/chat/handler.rs
@@ -8,24 +8,24 @@
 //! pulled in from the sibling `tools` submodule.
 //! Test: behaviour exercised end-to-end via the chat SSE integration paths.
 
-use crate::AppState;
 use crate::web::load_user_config;
+use crate::AppState;
 use axum::{
-    Json,
     body::Body,
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Response},
+    Json,
 };
-use serde_json::{Value, json};
-use trusty_common::memory_core::PalaceRegistry;
+use serde_json::{json, Value};
 use trusty_common::memory_core::palace::PalaceId;
 use trusty_common::memory_core::retrieval::recall_with_default_embedder;
+use trusty_common::memory_core::PalaceRegistry;
 use trusty_common::{ChatEvent, ChatMessage};
 
 // ---------------------------------------------------------------------------
 
-use super::tools::{ChatBody, MAX_TOOL_ROUNDS, all_tools, execute_get_dream_status, execute_tool};
+use super::tools::{all_tools, execute_get_dream_status, execute_tool, ChatBody, MAX_TOOL_ROUNDS};
 
 pub(crate) async fn chat_handler(
     State(state): State<AppState>,

--- a/crates/trusty-memory/src/chat/handler.rs
+++ b/crates/trusty-memory/src/chat/handler.rs
@@ -8,24 +8,24 @@
 //! pulled in from the sibling `tools` submodule.
 //! Test: behaviour exercised end-to-end via the chat SSE integration paths.
 
-use crate::web::load_user_config;
 use crate::AppState;
+use crate::web::load_user_config;
 use axum::{
+    Json,
     body::Body,
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
+use trusty_common::memory_core::PalaceRegistry;
 use trusty_common::memory_core::palace::PalaceId;
 use trusty_common::memory_core::retrieval::recall_with_default_embedder;
-use trusty_common::memory_core::PalaceRegistry;
 use trusty_common::{ChatEvent, ChatMessage};
 
 // ---------------------------------------------------------------------------
 
-use super::tools::{all_tools, execute_get_dream_status, execute_tool, ChatBody, MAX_TOOL_ROUNDS};
+use super::tools::{ChatBody, MAX_TOOL_ROUNDS, all_tools, execute_get_dream_status, execute_tool};
 
 pub(crate) async fn chat_handler(
     State(state): State<AppState>,
@@ -181,7 +181,7 @@ pub(crate) async fn chat_handler(
          service running locally on this user's machine. trusty-memory stores \
          knowledge in named \"palaces\" — isolated memory namespaces, each with \
          its own vector index (usearch HNSW) and temporal knowledge graph \
-         (SQLite). Memories are organized as Palace -> Wing -> Room -> Closet \
+         (redb). Memories are organized as Palace -> Wing -> Room -> Closet \
          -> Drawer, where a Drawer is an atomic memory unit.\n\
          There are currently {palace_count} palace(s) on this machine.\n",
     ));

--- a/crates/trusty-memory/src/console_metrics.rs
+++ b/crates/trusty-memory/src/console_metrics.rs
@@ -14,8 +14,8 @@
 //! descriptor shape and handler via the existing `dispatch_tool` harness.
 
 use anyhow::Result;
-use serde_json::{json, Value};
-use trusty_common::console_metrics::{make_report, ServiceHealth};
+use serde_json::{Value, json};
+use trusty_common::console_metrics::{ServiceHealth, make_report};
 use trusty_common::memory_core::PalaceRegistry;
 
 use crate::AppState;
@@ -99,7 +99,7 @@ pub async fn handle_console_metrics(state: &AppState, _args: Value) -> Result<Va
 
     // Open each palace and aggregate statistics on the blocking thread pool.
     // `PalaceRegistry::open_palace` does synchronous FS I/O (loads metadata,
-    // opens SQLite/usearch files) so it must not run on the async executor.
+    // opens redb/usearch files) so it must not run on the async executor.
     let root2 = state.data_root.clone();
     let registry = state.registry.clone();
     let stats =
@@ -131,7 +131,7 @@ pub async fn handle_console_metrics(state: &AppState, _args: Value) -> Result<Va
 ///
 /// Why: Extracted as a free function so it can run entirely on the
 /// `spawn_blocking` thread pool — `open_palace` does synchronous FS I/O
-/// (`std::fs`, SQLite, usearch file open) that must not block the async
+/// (`std::fs`, redb, usearch file open) that must not block the async
 /// executor.
 /// What: Iterates `palace_infos`; the first MAX_PALACES_IN_REPORT produce full
 /// entries in `palace_entries`; the remainder contribute only to the totals.

--- a/crates/trusty-memory/src/console_metrics.rs
+++ b/crates/trusty-memory/src/console_metrics.rs
@@ -14,8 +14,8 @@
 //! descriptor shape and handler via the existing `dispatch_tool` harness.
 
 use anyhow::Result;
-use serde_json::{Value, json};
-use trusty_common::console_metrics::{ServiceHealth, make_report};
+use serde_json::{json, Value};
+use trusty_common::console_metrics::{make_report, ServiceHealth};
 use trusty_common::memory_core::PalaceRegistry;
 
 use crate::AppState;

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -16,17 +16,17 @@
 //! `tests/serve_stdio_e2e.rs` end-to-end harness.
 
 use anyhow::Result;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
-use tokio::sync::{OnceCell, RwLock, broadcast};
-use trusty_common::ChatProvider;
+use tokio::sync::{broadcast, OnceCell, RwLock};
 use trusty_common::bm25_client::Bm25Client;
 use trusty_common::mcp::initialize_response;
 use trusty_common::memory_core::embed::FastEmbedder;
-use trusty_common::memory_core::{PalaceRegistry, store::ChatSessionStore};
+use trusty_common::memory_core::{store::ChatSessionStore, PalaceRegistry};
+use trusty_common::ChatProvider;
 
 // Why: `tracing::info` is only used by the axum HTTP-serving helpers
 //      (`run_http_on`, `spawn_uds_listener`). Pulling it in unconditionally
@@ -67,7 +67,11 @@ impl DaemonReadiness {
     /// `1` is ever written).
     /// Test: `daemon_readiness_from_u8` in this module.
     pub fn from_u8(v: u8) -> Self {
-        if v == 0 { Self::Warming } else { Self::Ready }
+        if v == 0 {
+            Self::Warming
+        } else {
+            Self::Ready
+        }
     }
 }
 
@@ -203,7 +207,11 @@ pub use tools::MemoryMcpServer;
 /// `resolve_palace_registry_dir_falls_back_to_data_dir`.
 pub fn resolve_palace_registry_dir(data_dir: PathBuf) -> PathBuf {
     let nested = data_dir.join("palaces");
-    if nested.is_dir() { nested } else { data_dir }
+    if nested.is_dir() {
+        nested
+    } else {
+        data_dir
+    }
 }
 
 /// Hook type — labels the Claude Code hook that triggered a submission.

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -16,17 +16,17 @@
 //! `tests/serve_stdio_e2e.rs` end-to-end harness.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
-use tokio::sync::{broadcast, OnceCell, RwLock};
+use tokio::sync::{OnceCell, RwLock, broadcast};
+use trusty_common::ChatProvider;
 use trusty_common::bm25_client::Bm25Client;
 use trusty_common::mcp::initialize_response;
 use trusty_common::memory_core::embed::FastEmbedder;
-use trusty_common::memory_core::{store::ChatSessionStore, PalaceRegistry};
-use trusty_common::ChatProvider;
+use trusty_common::memory_core::{PalaceRegistry, store::ChatSessionStore};
 
 // Why: `tracing::info` is only used by the axum HTTP-serving helpers
 //      (`run_http_on`, `spawn_uds_listener`). Pulling it in unconditionally
@@ -67,11 +67,7 @@ impl DaemonReadiness {
     /// `1` is ever written).
     /// Test: `daemon_readiness_from_u8` in this module.
     pub fn from_u8(v: u8) -> Self {
-        if v == 0 {
-            Self::Warming
-        } else {
-            Self::Ready
-        }
+        if v == 0 { Self::Warming } else { Self::Ready }
     }
 }
 
@@ -207,11 +203,7 @@ pub use tools::MemoryMcpServer;
 /// `resolve_palace_registry_dir_falls_back_to_data_dir`.
 pub fn resolve_palace_registry_dir(data_dir: PathBuf) -> PathBuf {
     let nested = data_dir.join("palaces");
-    if nested.is_dir() {
-        nested
-    } else {
-        data_dir
-    }
+    if nested.is_dir() { nested } else { data_dir }
 }
 
 /// Hook type — labels the Claude Code hook that triggered a submission.
@@ -1177,10 +1169,10 @@ impl AppState {
 
     /// Open (or return cached) the chat-session store for a palace.
     ///
-    /// Why: Chat session persistence lives in a dedicated SQLite file under
-    /// the palace's data dir (`chat_sessions.db`) so it doesn't intermingle
+    /// Why: Chat session persistence lives in a dedicated redb file under
+    /// the palace's data dir (`chat_sessions.redb`) so it doesn't intermingle
     /// with the KG's transactional load. The store is cheap to clone via
-    /// `Arc` but the underlying r2d2 pool should be reused, so cache by id.
+    /// `Arc` but the underlying connection should be reused, so cache by id.
     /// What: Creates the palace data dir if missing, opens (or reuses) a
     /// `ChatSessionStore` and stashes an `Arc` in the DashMap.
     /// Test: Indirectly via the session HTTP handlers in `web::tests`.

--- a/crates/trusty-memory/src/prompt_facts.rs
+++ b/crates/trusty-memory/src/prompt_facts.rs
@@ -161,7 +161,7 @@ pub fn build_prompt_context(triples: &[(String, String, String)]) -> String {
 /// the fact, so a single MCP connection sees aliases / conventions from
 /// every project namespace. Reading once into a `Vec<(String, String,
 /// String)>` keeps the formatter side-effect-free and lets tests build
-/// fixtures without touching SQLite.
+/// fixtures without touching redb.
 /// What: Iterates every palace handle currently registered, calls
 /// `list_active` with a generous limit, and filters each batch through
 /// `is_hot_predicate`. A palace whose KG fails to read is logged at `warn`

--- a/crates/trusty-memory/src/tools/palace_ops.rs
+++ b/crates/trusty-memory/src/tools/palace_ops.rs
@@ -188,7 +188,7 @@ pub(crate) async fn handle_palace_info(state: &AppState, args: Value) -> Result<
 pub(crate) async fn handle_palace_compact(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "palace_compact")?;
     let handle = open_palace_handle(state, &palace)?;
-    // Use the live drawer table (sourced from SQLite at palace open) as
+    // Use the live drawer table (sourced from redb at palace open) as
     // the authoritative valid-id set, then run the vector store's
     // synchronous compaction on a blocking thread.
     let valid_ids: std::collections::HashSet<Uuid> =


### PR DESCRIPTION
## Summary

- A research agent wrongly concluded trusty-memory uses SQLite because stale doc-comments and the README still described the live persistent store as SQLite. In reality, all memory-core stores were migrated to **redb + postcard** (with `hnsw_rs` for vectors) under issues #44–#57/#989.
- This PR is **comment/doc only — zero logic changes**. It corrects statements that describe the *current* store as SQLite; it leaves all historical/migration notes intact (those correctly say "previously SQLite, now redb").

## Files and lines changed

| File | What changed |
|---|---|
| `crates/trusty-memory/README.md:6` | Crate description: "SQLite metadata" → "redb metadata and knowledge-graph stores" |
| `crates/trusty-memory/src/lib.rs:1180–1183` | `session_store()` doc: SQLite → redb, `chat_sessions.db` → `chat_sessions.redb` |
| `crates/trusty-memory/src/chat/handler.rs:184` | System-prompt string: "temporal knowledge graph (SQLite)" → "(redb)" |
| `crates/trusty-memory/src/tools/palace_ops.rs:191` | "sourced from SQLite at palace open" → "sourced from redb at palace open" |
| `crates/trusty-memory/src/console_metrics.rs:102,134` | Two "opens SQLite/usearch" → "redb/usearch" |
| `crates/trusty-memory/src/prompt_facts.rs:163–164` | "without touching SQLite" → "without touching redb" |
| `crates/trusty-common/src/memory_core/mod.rs:12` | Dep list: remove `rusqlite`/`r2d2`, add `redb`/`postcard` |
| `crates/trusty-common/src/memory_core/retrieval/handle.rs:52,95,196,241,356,542` | Six SQLite refs (KG file path `kg.db`→`kg.redb`, "KG SQLite row insert", "Load full drawer table from SQLite", "SQLite file; production palaces", "no SQLite row backing it", "KG SQLite file all live") |
| `crates/trusty-common/src/memory_core/store/mod.rs:1` | Module doc: "temporal knowledge graph (SQLite)" → "(redb)" |
| `crates/trusty-common/src/memory_core/dream/dreamer.rs:289–291` | WAL checkpoint comment reworded: redb manages its own write log internally; the call is now a no-op per `kg_redb/read_ops.rs:224`. Old comment said "SQLite WAL grows unbounded" which no longer applies. |

## Borderline cases kept (not changed)

- `analytics.rs` — all hits already say "Now that the store is redb-backed" and reference "#989" — correct historical notes, left alone.
- `store/kg_store.rs:2,71,73` — "without the r2d2/rusqlite dependency chain" — historical contrast, correct.
- `store/kg_redb/mod.rs`, `kg_redb/types.rs:146`, `kg_redb/read_ops.rs:219` — migration history notes, correct.
- `store/chat_sessions/store.rs:27,232,236` — "Replaces the previous r2d2/rusqlite pool", "matches the legacy SQLite contract" — historical, correct.
- `store/payload_store/types.rs:125` — "Now that the store is redb-backed" — correct.
- `store/kg/graph.rs:56–68` — `redb_path_for()` function deliberately accepts `kg.db` and rewrites it to `kg.redb`; its doc explains the historical API compatibility story. That is the correct description of the live migration shim — not a misleading "live store is SQLite" claim.
- `commands/migrate.rs`, `commands/kuzu_migrate.rs` — legitimately read legacy SQLite files during migration, not changed.

## Verification

```
cargo build -p trusty-common -p trusty-memory   ✅ Finished
cargo test -p trusty-memory --doc               ✅ 0 tests, ok
cargo test -p trusty-common --doc               ✅ 0 tests, ok
cargo clippy -p trusty-common -p trusty-memory  ✅ 0 warnings
bash scripts/check_line_cap.sh                  ✅ 14 allowlisted, 0 violations
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)