### PR TITLE
feat(trusty-memory): chat session manager MVP — force palaces, chat-session MCP tools, room-scoped consolidation, Task drawers (closes #1700, #1701, #1702, #1703)

### DIFF
--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -457,6 +457,17 @@ pub(super) async fn semantic_consolidation_pass(
     config: &DreamConfig,
     injected: Option<Arc<SemanticConsolidator>>,
 ) -> (usize, usize, usize) {
+    // The idle cycle honours the `semantic.enabled` switch even when a
+    // consolidator is injected (tests rely on this): disabling the phase in
+    // config must skip it entirely.
+    if !config.semantic.enabled {
+        tracing::debug!(
+            palace = %handle.id,
+            "skipping semantic consolidation: disabled in config"
+        );
+        return (0, 0, 0);
+    }
+
     // Use the injected consolidator (test path) or build one from config.
     let consolidator: Arc<SemanticConsolidator> = match injected {
         Some(c) => c,

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -294,94 +294,82 @@ pub(super) fn refresh_closets(handle: &Arc<PalaceHandle>) -> usize {
     count
 }
 
-/// Optional inference-backed semantic consolidation pass.
+/// Result of an on-demand, room-scoped consolidation (spec-001 Phase 3).
 ///
-/// Why: the NLP-only passes miss semantic equivalence (aliases, paraphrases,
-/// near-duplicate triples expressed differently). This phase delegates
-/// canonicalization to a cheap LLM, preserving original drawers and adding
-/// canonical replacements with `superseded_by` links in the KG.
-/// What: gates on `inference_available`; when false logs at DEBUG and
-/// returns `(0, 0, 0)` immediately. When true (or when a consolidator is
-/// injected via `Dreamer::with_consolidator`), runs consolidation on all
-/// current drawers, writes each canonical drawer via `handle.remember`,
-/// and records the `superseded_by` KG triple so the original drawers are
-/// traceable. Returns `(canonical_count, llm_calls, cache_hits)`.
-/// Test: `dream_cycle_semantic_consolidation_with_mock` (injected
-/// consolidator); `dream_cycle_semantic_consolidation_no_inference`.
-pub(super) async fn semantic_consolidation_pass(
-    handle: &Arc<PalaceHandle>,
-    config: &DreamConfig,
-    injected: Option<Arc<SemanticConsolidator>>,
-) -> (usize, usize, usize) {
+/// Why: the `dream_consolidate_room` MCP tool reports how much work it did so
+/// the calling application can log progress / decide whether to run again.
+/// What: `summary_facts_created` is the number of canonical summary drawers
+/// added; `facts_evicted` is the number of superseded originals removed.
+/// Test: `consolidate_scoped_*` in `dream::tests`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RoomConsolidationStats {
+    pub summary_facts_created: usize,
+    pub facts_evicted: usize,
+}
+
+/// Build the production semantic consolidator from config, gating on inference
+/// availability.
+///
+/// Why: both the idle dream pass and the on-demand room consolidation need the
+/// identical "is inference configured? then build a backend" logic; sharing it
+/// keeps the gate in one place.
+/// What: returns `None` when `config.semantic` is disabled or no inference
+/// backend is available; otherwise builds an `OllamaInference` (when a local
+/// model is enabled and no key is set) or `OpenRouterInference` and wraps it in
+/// a `SemanticConsolidator`.
+/// Test: exercised via `dream_cycle_semantic_consolidation_no_inference` (None
+/// path) and the production daemon.
+fn build_consolidator_from_config(config: &DreamConfig) -> Option<Arc<SemanticConsolidator>> {
     if !config.semantic.enabled {
-        tracing::debug!(
-            palace = %handle.id,
-            "skipping semantic consolidation: disabled in config"
-        );
-        return (0, 0, 0);
+        return None;
     }
-
-    // Use the injected consolidator (test path) or build one from config.
-    let consolidator: Arc<SemanticConsolidator> = if let Some(c) = injected {
-        c
+    let api_key = if !config.openrouter_api_key.is_empty() {
+        config.openrouter_api_key.clone()
     } else {
-        // Production path: gate on inference availability.
-        let api_key = if !config.openrouter_api_key.is_empty() {
-            config.openrouter_api_key.clone()
-        } else {
-            std::env::var("OPENROUTER_API_KEY").unwrap_or_default()
-        };
-
-        if !inference_available(&api_key, config.local_model_enabled) {
-            tracing::debug!(
-                palace = %handle.id,
-                "skipping semantic consolidation: inference unavailable \
-                 (set OPENROUTER_API_KEY or enable local_model)"
-            );
-            return (0, 0, 0);
-        }
-
-        // Build the inference backend: prefer local model (free),
-        // fall back to OpenRouter.
-        use crate::memory_core::semantic_consolidation::{OllamaInference, OpenRouterInference};
-        let backend: Arc<dyn crate::memory_core::semantic_consolidation::Inference> =
-            if config.local_model_enabled && api_key.is_empty() {
-                Arc::new(OllamaInference::new(
-                    "http://localhost:11434",
-                    &config.semantic.model,
-                ))
-            } else {
-                Arc::new(OpenRouterInference::new(api_key, &config.semantic.model))
-            };
-
-        Arc::new(SemanticConsolidator::new(backend, config.semantic.clone()))
+        std::env::var("OPENROUTER_API_KEY").unwrap_or_default()
     };
-
-    // spec-001: exclude protected Task drawers from consolidation entirely so
-    // they are never folded into a canonical summary or superseded.
-    let snapshot: Vec<Drawer> = handle
-        .drawers
-        .read()
-        .iter()
-        .filter(|d| !d.drawer_type.is_protected())
-        .cloned()
-        .collect();
-    if snapshot.is_empty() {
-        return (0, 0, 0);
+    if !inference_available(&api_key, config.local_model_enabled) {
+        return None;
     }
+    use crate::memory_core::semantic_consolidation::{OllamaInference, OpenRouterInference};
+    let backend: Arc<dyn crate::memory_core::semantic_consolidation::Inference> =
+        if config.local_model_enabled && api_key.is_empty() {
+            Arc::new(OllamaInference::new(
+                "http://localhost:11434",
+                &config.semantic.model,
+            ))
+        } else {
+            Arc::new(OpenRouterInference::new(api_key, &config.semantic.model))
+        };
+    Some(Arc::new(SemanticConsolidator::new(
+        backend,
+        config.semantic.clone(),
+    )))
+}
 
-    let consolidation_result = consolidator.consolidate(&snapshot).await;
-
-    // Apply results: add canonical drawers, mark superseded ids in KG.
+/// Apply a consolidation result: add canonical drawers + record KG provenance.
+///
+/// Why: the canonical-add / `superseded_by` / `alias_of` / flagged-log logic is
+/// identical for the idle pass and the on-demand room consolidation; extracting
+/// it removes duplication and keeps side-effect ordering consistent.
+/// What: for each canonical drawer, writes it via `handle.remember` and asserts
+/// a `superseded_by` triple per original; stores `alias_of` triples; logs
+/// flagged contradictions. Returns `(canonical_count, superseded_ids)` where
+/// `superseded_ids` are the original drawer ids that were folded into a
+/// canonical (callers that compact — e.g. the room tool — evict these).
+/// Test: `dream_cycle_semantic_consolidation_with_mock`, `consolidate_scoped_*`.
+async fn apply_consolidation_result(
+    handle: &Arc<PalaceHandle>,
+    result: &crate::memory_core::semantic_consolidation::ConsolidationResult,
+) -> (usize, Vec<Uuid>) {
     let mut canonical_count = 0usize;
+    let mut superseded_ids: Vec<Uuid> = Vec::new();
 
-    for canonical in &consolidation_result.canonical_drawers {
-        // Add the canonical drawer to the palace.
-        let room_type = RoomType::General;
+    for canonical in &result.canonical_drawers {
         match handle
             .remember(
                 canonical.content.clone(),
-                room_type,
+                RoomType::General,
                 canonical.tags.clone(),
                 canonical.importance,
             )
@@ -389,15 +377,12 @@ pub(super) async fn semantic_consolidation_pass(
         {
             Ok(canonical_id) => {
                 canonical_count += 1;
-                // Record `superseded_by` triples in the KG for every
-                // original drawer so the provenance chain is preserved.
                 for &orig_id in &canonical.canonical_for {
-                    let triple_subject = format!("drawer:{orig_id}");
-                    let triple_object = format!("drawer:{canonical_id}");
+                    superseded_ids.push(orig_id);
                     let triple = crate::memory_core::store::kg::Triple {
-                        subject: triple_subject,
+                        subject: format!("drawer:{orig_id}"),
                         predicate: "superseded_by".to_string(),
-                        object: triple_object,
+                        object: format!("drawer:{canonical_id}"),
                         valid_from: chrono::Utc::now(),
                         valid_to: None,
                         confidence: 1.0,
@@ -421,8 +406,7 @@ pub(super) async fn semantic_consolidation_pass(
         }
     }
 
-    // Store aliases as KG triples.
-    for (from, to) in &consolidation_result.aliases {
+    for (from, to) in &result.aliases {
         let triple = crate::memory_core::store::kg::Triple {
             subject: from.clone(),
             predicate: "alias_of".to_string(),
@@ -441,8 +425,7 @@ pub(super) async fn semantic_consolidation_pass(
         }
     }
 
-    // Log flagged contradictions (no auto-resolution).
-    for (id, reason) in &consolidation_result.flagged_ids {
+    for (id, reason) in &result.flagged_ids {
         tracing::info!(
             palace = %handle.id,
             drawer_id = %id,
@@ -451,19 +434,147 @@ pub(super) async fn semantic_consolidation_pass(
         );
     }
 
+    (canonical_count, superseded_ids)
+}
+
+/// Optional inference-backed semantic consolidation pass.
+///
+/// Why: the NLP-only passes miss semantic equivalence (aliases, paraphrases,
+/// near-duplicate triples expressed differently). This phase delegates
+/// canonicalization to a cheap LLM, preserving original drawers and adding
+/// canonical replacements with `superseded_by` links in the KG.
+/// What: gates on `inference_available`; when false logs at DEBUG and
+/// returns `(0, 0, 0)` immediately. When true (or when a consolidator is
+/// injected via `Dreamer::with_consolidator`), runs consolidation on all
+/// current non-Task drawers, writes each canonical drawer via `handle.remember`,
+/// and records the `superseded_by` KG triple so the original drawers are
+/// traceable. Additive-only — originals are preserved.
+/// Returns `(canonical_count, llm_calls, cache_hits)`.
+/// Test: `dream_cycle_semantic_consolidation_with_mock` (injected
+/// consolidator); `dream_cycle_semantic_consolidation_no_inference`.
+pub(super) async fn semantic_consolidation_pass(
+    handle: &Arc<PalaceHandle>,
+    config: &DreamConfig,
+    injected: Option<Arc<SemanticConsolidator>>,
+) -> (usize, usize, usize) {
+    // Use the injected consolidator (test path) or build one from config.
+    let consolidator: Arc<SemanticConsolidator> = match injected {
+        Some(c) => c,
+        None => match build_consolidator_from_config(config) {
+            Some(c) => c,
+            None => {
+                tracing::debug!(
+                    palace = %handle.id,
+                    "skipping semantic consolidation: disabled or inference unavailable"
+                );
+                return (0, 0, 0);
+            }
+        },
+    };
+
+    // spec-001: exclude protected Task drawers from consolidation entirely so
+    // they are never folded into a canonical summary or superseded.
+    let snapshot: Vec<Drawer> = handle
+        .drawers
+        .read()
+        .iter()
+        .filter(|d| !d.drawer_type.is_protected())
+        .cloned()
+        .collect();
+    if snapshot.is_empty() {
+        return (0, 0, 0);
+    }
+
+    let result = consolidator.consolidate(&snapshot).await;
+    let (canonical_count, _superseded) = apply_consolidation_result(handle, &result).await;
+
     tracing::debug!(
         palace = %handle.id,
         canonical_added = canonical_count,
-        aliases = consolidation_result.aliases.len(),
-        flagged = consolidation_result.flagged_ids.len(),
-        llm_calls = consolidation_result.llm_calls,
-        cache_hits = consolidation_result.cache_hits,
+        aliases = result.aliases.len(),
+        flagged = result.flagged_ids.len(),
+        llm_calls = result.llm_calls,
+        cache_hits = result.cache_hits,
         "semantic consolidation phase complete"
     );
 
-    (
-        canonical_count,
-        consolidation_result.llm_calls,
-        consolidation_result.cache_hits,
-    )
+    (canonical_count, result.llm_calls, result.cache_hits)
+}
+
+/// On-demand, room-scoped semantic consolidation that compacts older history
+/// (spec-001 Phase 3, the `dream_consolidate_room` MCP tool).
+///
+/// Why: applications driving trusty-memory as a chat-session manager want to
+/// compact a single room's older turns on demand rather than waiting for the
+/// idle dream cycle, and — unlike the additive idle pass — they want the
+/// superseded originals evicted so history actually shrinks.
+/// What: selects non-Task drawers in `room` (or all rooms when `None`) whose
+/// `created_at` is older than `max_age_days`, runs the consolidator over them,
+/// applies the result (canonical drawers + KG provenance), then evicts every
+/// superseded original via `handle.forget`. Returns the created/evicted counts.
+/// `injected` lets tests supply a `MockInference`-backed consolidator; in
+/// production it is `None` and the consolidator is built from `config`.
+/// Test: `consolidate_scoped_filters_by_room`,
+/// `consolidate_scoped_skips_task_drawers`,
+/// `consolidate_scoped_no_inference_is_noop` in `dream::tests`.
+pub async fn consolidate_scoped(
+    handle: &Arc<PalaceHandle>,
+    config: &DreamConfig,
+    room: Option<RoomType>,
+    max_age_days: i64,
+    injected: Option<Arc<SemanticConsolidator>>,
+) -> Result<RoomConsolidationStats> {
+    let consolidator: Arc<SemanticConsolidator> = match injected {
+        Some(c) => c,
+        None => match build_consolidator_from_config(config) {
+            Some(c) => c,
+            None => {
+                tracing::debug!(
+                    palace = %handle.id,
+                    "dream_consolidate_room: inference unavailable; no-op"
+                );
+                return Ok(RoomConsolidationStats::default());
+            }
+        },
+    };
+
+    // Select candidates: room-scoped (list_drawers handles the room filter),
+    // older than the age cutoff, and never protected Task drawers.
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days.max(0));
+    let snapshot: Vec<Drawer> = handle
+        .list_drawers(room, None, usize::MAX)
+        .into_iter()
+        .filter(|d| !d.drawer_type.is_protected())
+        .filter(|d| d.created_at <= cutoff)
+        .collect();
+    if snapshot.is_empty() {
+        return Ok(RoomConsolidationStats::default());
+    }
+
+    let result = consolidator.consolidate(&snapshot).await;
+    let (summary_facts_created, superseded_ids) = apply_consolidation_result(handle, &result).await;
+
+    // Compaction step: evict the superseded originals so history shrinks.
+    // Task drawers were excluded from the snapshot, so they can never appear
+    // here. De-duplicate ids defensively in case two canonicals claim one.
+    let mut evicted = 0usize;
+    let mut seen: HashSet<Uuid> = HashSet::new();
+    for id in superseded_ids {
+        if !seen.insert(id) {
+            continue;
+        }
+        match handle.forget(id).await {
+            Ok(()) => evicted += 1,
+            Err(e) => tracing::warn!(?id, "dream_consolidate_room: evict failed: {e:#}"),
+        }
+    }
+
+    if let Err(e) = handle.flush() {
+        tracing::warn!(palace = %handle.id, "dream_consolidate_room flush failed: {e:#}");
+    }
+
+    Ok(RoomConsolidationStats {
+        summary_facts_created,
+        facts_evicted: evicted,
+    })
 }

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -523,11 +523,17 @@ pub(super) async fn semantic_consolidation_pass(
 /// `created_at` is older than `max_age_days`, runs the consolidator over them,
 /// applies the result (canonical drawers + KG provenance), then evicts every
 /// superseded original via `handle.forget`. Returns the created/evicted counts.
+/// `max_age_days <= 0` is treated as an explicit guard value (no-op, zero
+/// counts): the contract is "consolidate facts *older* than N days", and a
+/// non-positive window selects no history rather than the whole room — without
+/// the guard a cutoff of `now` would make every drawer (even ones created this
+/// instant) eligible and evict the entire room.
 /// `injected` lets tests supply a `MockInference`-backed consolidator; in
 /// production it is `None` and the consolidator is built from `config`.
 /// Test: `consolidate_scoped_filters_by_room`,
 /// `consolidate_scoped_skips_task_drawers`,
-/// `consolidate_scoped_no_inference_is_noop` in `dream::tests`.
+/// `consolidate_scoped_no_inference_is_noop`,
+/// `consolidate_scoped_non_positive_age_is_noop` in `dream::tests`.
 pub async fn consolidate_scoped(
     handle: &Arc<PalaceHandle>,
     config: &DreamConfig,
@@ -535,6 +541,18 @@ pub async fn consolidate_scoped(
     max_age_days: i64,
     injected: Option<Arc<SemanticConsolidator>>,
 ) -> Result<RoomConsolidationStats> {
+    // Guard value: a non-positive window means "consolidate nothing" rather than
+    // "consolidate everything". Return before building the consolidator so the
+    // call is a true no-op (no inference backend touched).
+    if max_age_days <= 0 {
+        tracing::debug!(
+            palace = %handle.id,
+            max_age_days,
+            "dream_consolidate_room: non-positive age window; no-op"
+        );
+        return Ok(RoomConsolidationStats::default());
+    }
+
     let consolidator: Arc<SemanticConsolidator> = match injected {
         Some(c) => c,
         None => match build_consolidator_from_config(config) {
@@ -551,7 +569,9 @@ pub async fn consolidate_scoped(
 
     // Select candidates: room-scoped (list_drawers handles the room filter),
     // older than the age cutoff, and never protected Task drawers.
-    let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days.max(0));
+    // `max_age_days` is guaranteed positive here (the `<= 0` guard above
+    // returned early), so the cutoff is strictly in the past.
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days);
     let snapshot: Vec<Drawer> = handle
         .list_drawers(room, None, usize::MAX)
         .into_iter()

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -50,6 +50,10 @@ pub(super) async fn content_prune_pass(
         if started.elapsed() >= budget {
             break;
         }
+        // spec-001: Task drawers are protected — never evicted by any pass.
+        if drawer.drawer_type.is_protected() {
+            continue;
+        }
         if is_low_quality_content(&drawer.content, min_words) {
             victims.push(drawer.id);
         }
@@ -190,6 +194,10 @@ pub(super) async fn dedup_pass(
         if already_removed.contains(&drawer.id) {
             continue;
         }
+        // spec-001: never merge away a protected Task drawer.
+        if drawer.drawer_type.is_protected() {
+            continue;
+        }
         // Top-3 keeps the dedup pass cheap; the first neighbor is `drawer`
         // itself (score ~1.0) so we look at index 1+. `vector_store.search`
         // returns pure cosine similarity — no importance weighting baked
@@ -208,6 +216,11 @@ pub(super) async fn dedup_pass(
             let Some(hit_drawer) = snapshot.iter().find(|d| d.id == hit.drawer_id) else {
                 continue;
             };
+            // spec-001: a protected Task drawer must never be merged away, even
+            // when it is the lower-importance side of a near-duplicate pair.
+            if hit_drawer.drawer_type.is_protected() {
+                continue;
+            }
 
             // Pick survivor (higher importance wins; ties keep `drawer`).
             let (survivor, loser) = if drawer.importance >= hit_drawer.importance {
@@ -241,6 +254,11 @@ pub(super) async fn prune_pass(
     for drawer in snapshot.iter() {
         if started.elapsed() >= budget {
             break;
+        }
+        // spec-001: Task drawers are never pruned, regardless of age or
+        // decayed importance.
+        if drawer.drawer_type.is_protected() {
+            continue;
         }
         let age = DecayConfig::age_days(drawer.created_at);
         let boost = drawer.accumulated_boost(&handle.decay_config);
@@ -339,7 +357,15 @@ pub(super) async fn semantic_consolidation_pass(
         Arc::new(SemanticConsolidator::new(backend, config.semantic.clone()))
     };
 
-    let snapshot: Vec<Drawer> = handle.drawers.read().clone();
+    // spec-001: exclude protected Task drawers from consolidation entirely so
+    // they are never folded into a canonical summary or superseded.
+    let snapshot: Vec<Drawer> = handle
+        .drawers
+        .read()
+        .iter()
+        .filter(|d| !d.drawer_type.is_protected())
+        .cloned()
+        .collect();
     if snapshot.is_empty() {
         return (0, 0, 0);
     }

--- a/crates/trusty-common/src/memory_core/dream/mod.rs
+++ b/crates/trusty-common/src/memory_core/dream/mod.rs
@@ -21,5 +21,6 @@ mod tests;
 // ── Public re-exports ────────────────────────────────────────────────────────
 
 pub use config::{DreamConfig, DreamStats, PersistedDreamStats};
+pub use cycle::{RoomConsolidationStats, consolidate_scoped};
 pub use dreamer::Dreamer;
 pub use helpers::extract_keywords;

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -623,6 +623,95 @@ async fn dream_cycle_semantic_consolidation_with_mock() {
     assert!(has_canonical, "canonical drawer must be present");
 }
 
+/// Why: spec-001 — `DrawerType::Task` drawers must never be fed to the
+/// semantic consolidator, so they can never be superseded by a canonical
+/// summary. This guards the snapshot filter in `semantic_consolidation_pass`.
+/// What: plants two Task drawers, injects a MockInference that WOULD merge any
+/// drawers it is handed, runs a dream cycle, and asserts the consolidator was
+/// never called (call_count == 0), no canonical drawer was created, and both
+/// Task drawers survive unchanged.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_cycle_semantic_consolidation_skips_task_drawers() {
+    use crate::memory_core::palace::DrawerType;
+    use crate::memory_core::retrieval::RememberOptions;
+    use crate::memory_core::semantic_consolidation::{
+        ConsolidationAction, MockInference, SemanticConsolidationConfig, SemanticConsolidator,
+    };
+
+    let handle = open_test_handle("dream-semantic-task-skip").await;
+
+    let task_opts = || RememberOptions {
+        force: true,
+        classify_as: Some(DrawerType::Task),
+        ..RememberOptions::default()
+    };
+    let id1 = handle
+        .remember_with_options(
+            "Goal: migrate the chat store to redb".into(),
+            RoomType::Planning,
+            vec![],
+            0.7,
+            task_opts(),
+        )
+        .await
+        .unwrap();
+    let id2 = handle
+        .remember_with_options(
+            "Milestone: ship the MCP chat-session tools".into(),
+            RoomType::Planning,
+            vec![],
+            0.6,
+            task_opts(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(handle.drawers.read().len(), 2);
+
+    // A mock that would merge anything it is handed — it must never be called.
+    let actions = vec![ConsolidationAction::Merge {
+        canonical_content: "tasks should NOT be merged".to_string(),
+        superseded_ids: vec![id1, id2],
+    }];
+    let mock = std::sync::Arc::new(MockInference::new(actions));
+    let call_count = mock.call_count.clone();
+    let cfg = SemanticConsolidationConfig {
+        enabled: true,
+        ..Default::default()
+    };
+    let consolidator = std::sync::Arc::new(SemanticConsolidator::new(mock, cfg));
+
+    let dreamer = Dreamer::with_consolidator(
+        DreamConfig {
+            dedup_threshold: 0.999,
+            semantic: SemanticConsolidationConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            ..DreamConfig::default()
+        },
+        consolidator,
+    );
+
+    let stats = dreamer.dream_cycle(&handle).await.unwrap();
+
+    assert_eq!(
+        stats.semantically_consolidated, 0,
+        "Task drawers must not be consolidated"
+    );
+    assert_eq!(
+        call_count.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "consolidator must never be called when only Task drawers exist"
+    );
+    let ids: Vec<Uuid> = handle.drawers.read().iter().map(|d| d.id).collect();
+    assert!(
+        ids.contains(&id1) && ids.contains(&id2),
+        "both tasks survive"
+    );
+    assert_eq!(handle.drawers.read().len(), 2, "no canonical drawer added");
+}
+
 /// Why: When no inference backend is configured, the semantic phase must
 /// silently skip without error and the dream cycle must complete normally
 /// with the same behavior as pre-#87.

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -1206,6 +1206,206 @@ async fn dream_cycle_recall_benchmark_disabled() {
     );
 }
 
+// ─── spec-001 Phase 3: on-demand room-scoped consolidation ───────────────────
+
+/// Why: `dream_consolidate_room` must scope to a single room — drawers in other
+/// rooms must not even reach the consolidator.
+/// What: seeds two aged Planning drawers, runs `consolidate_scoped` first for
+/// Backend (no aged drawers there) and asserts the consolidator is never called
+/// and nothing changes, then for Planning and asserts the two originals are
+/// consolidated into one summary and evicted.
+/// Test: this function.
+#[tokio::test]
+async fn consolidate_scoped_filters_by_room() {
+    use crate::memory_core::semantic_consolidation::{
+        ConsolidationAction, MockInference, SemanticConsolidationConfig, SemanticConsolidator,
+    };
+    use std::sync::atomic::Ordering;
+
+    let handle = open_test_handle("scoped-room-filter").await;
+    let p1 = handle
+        .remember(
+            "planning note one about the roadmap".into(),
+            RoomType::Planning,
+            vec![],
+            0.5,
+        )
+        .await
+        .unwrap();
+    let p2 = handle
+        .remember(
+            "planning note two about the roadmap".into(),
+            RoomType::Planning,
+            vec![],
+            0.5,
+        )
+        .await
+        .unwrap();
+    // Age both past the default 7-day window.
+    {
+        let mut drawers = handle.drawers.write();
+        for d in drawers.iter_mut() {
+            d.created_at = Utc::now() - ChronoDuration::days(30);
+        }
+    }
+
+    let mock = std::sync::Arc::new(MockInference::new(vec![ConsolidationAction::Merge {
+        canonical_content: "roadmap planning summary".to_string(),
+        superseded_ids: vec![p1, p2],
+    }]));
+    let call_count = mock.call_count.clone();
+    let consolidator = std::sync::Arc::new(SemanticConsolidator::new(
+        mock,
+        SemanticConsolidationConfig {
+            enabled: true,
+            ..Default::default()
+        },
+    ));
+    let cfg = DreamConfig::default();
+
+    // Backend has no aged drawers => consolidator never runs, nothing changes.
+    let backend = consolidate_scoped(
+        &handle,
+        &cfg,
+        Some(RoomType::Backend),
+        7,
+        Some(consolidator.clone()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(backend, RoomConsolidationStats::default());
+    assert_eq!(
+        call_count.load(Ordering::Relaxed),
+        0,
+        "wrong room must not consolidate"
+    );
+    assert_eq!(handle.drawers.read().len(), 2);
+
+    // Planning has the two aged drawers => one summary created, both evicted.
+    let planning = consolidate_scoped(
+        &handle,
+        &cfg,
+        Some(RoomType::Planning),
+        7,
+        Some(consolidator),
+    )
+    .await
+    .unwrap();
+    assert_eq!(planning.summary_facts_created, 1);
+    assert_eq!(planning.facts_evicted, 2);
+    assert_eq!(
+        call_count.load(Ordering::Relaxed),
+        1,
+        "consolidator ran once for Planning"
+    );
+    let ids: Vec<Uuid> = handle.drawers.read().iter().map(|d| d.id).collect();
+    assert!(
+        !ids.contains(&p1) && !ids.contains(&p2),
+        "superseded originals evicted"
+    );
+}
+
+/// Why: Task drawers must never be consolidated, even by the on-demand tool.
+/// What: seeds two aged Task drawers, runs `consolidate_scoped` with a mock that
+/// would merge them, and asserts the consolidator is never called and both
+/// tasks survive.
+/// Test: this function.
+#[tokio::test]
+async fn consolidate_scoped_skips_task_drawers() {
+    use crate::memory_core::palace::DrawerType;
+    use crate::memory_core::retrieval::RememberOptions;
+    use crate::memory_core::semantic_consolidation::{
+        ConsolidationAction, MockInference, SemanticConsolidationConfig, SemanticConsolidator,
+    };
+    use std::sync::atomic::Ordering;
+
+    let handle = open_test_handle("scoped-task-skip").await;
+    let task_opts = || RememberOptions {
+        force: true,
+        classify_as: Some(DrawerType::Task),
+        ..RememberOptions::default()
+    };
+    let t1 = handle
+        .remember_with_options(
+            "Goal: keep this forever".into(),
+            RoomType::Planning,
+            vec![],
+            0.5,
+            task_opts(),
+        )
+        .await
+        .unwrap();
+    let t2 = handle
+        .remember_with_options(
+            "Goal: and this one too".into(),
+            RoomType::Planning,
+            vec![],
+            0.5,
+            task_opts(),
+        )
+        .await
+        .unwrap();
+    {
+        let mut drawers = handle.drawers.write();
+        for d in drawers.iter_mut() {
+            d.created_at = Utc::now() - ChronoDuration::days(30);
+        }
+    }
+
+    let mock = std::sync::Arc::new(MockInference::new(vec![ConsolidationAction::Merge {
+        canonical_content: "tasks must NOT merge".to_string(),
+        superseded_ids: vec![t1, t2],
+    }]));
+    let call_count = mock.call_count.clone();
+    let consolidator = std::sync::Arc::new(SemanticConsolidator::new(
+        mock,
+        SemanticConsolidationConfig {
+            enabled: true,
+            ..Default::default()
+        },
+    ));
+
+    let stats = consolidate_scoped(
+        &handle,
+        &DreamConfig::default(),
+        None,
+        7,
+        Some(consolidator),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        stats,
+        RoomConsolidationStats::default(),
+        "task-only palace yields no work"
+    );
+    assert_eq!(
+        call_count.load(Ordering::Relaxed),
+        0,
+        "consolidator never sees Task drawers"
+    );
+    let ids: Vec<Uuid> = handle.drawers.read().iter().map(|d| d.id).collect();
+    assert!(ids.contains(&t1) && ids.contains(&t2), "both tasks survive");
+}
+
+/// Why: when no inference backend is configured the tool must no-op cleanly.
+/// What: with the OpenRouter env key removed, default config, and no injected
+/// consolidator, `consolidate_scoped` returns zero counts without error.
+/// Test: this function.
+#[tokio::test]
+async fn consolidate_scoped_no_inference_is_noop() {
+    let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
+    let handle = open_test_handle("scoped-no-inference").await;
+    handle
+        .remember("some aged fact".into(), RoomType::Backend, vec![], 0.5)
+        .await
+        .unwrap();
+    let stats = consolidate_scoped(&handle, &DreamConfig::default(), None, 7, None)
+        .await
+        .unwrap();
+    assert_eq!(stats, RoomConsolidationStats::default());
+}
+
 // ─── RAII env-var guard for tests ────────────────────────────────────────
 //
 // Safety: test-only; the tokio::test macro with default settings uses the

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -1406,6 +1406,84 @@ async fn consolidate_scoped_no_inference_is_noop() {
     assert_eq!(stats, RoomConsolidationStats::default());
 }
 
+/// Why: `max_age_days <= 0` is a guard value meaning "consolidate nothing".
+/// Regression for the off-by-zero bug where a cutoff of `now` made *every*
+/// drawer — including freshly created ones — eligible, evicting the whole room.
+/// What: seeds two recent (NOT aged) drawers plus a mock consolidator that would
+/// merge them, then calls `consolidate_scoped` with `max_age_days = 0` and a
+/// negative value; asserts zero counts, the consolidator never runs, and both
+/// recent drawers survive.
+/// Test: this function.
+#[tokio::test]
+async fn consolidate_scoped_non_positive_age_is_noop() {
+    use crate::memory_core::semantic_consolidation::{
+        ConsolidationAction, MockInference, SemanticConsolidationConfig, SemanticConsolidator,
+    };
+
+    let handle = open_test_handle("scoped-non-positive-age").await;
+    let r1 = handle
+        .remember(
+            "recent planning note one".into(),
+            RoomType::Planning,
+            vec![],
+            0.5,
+        )
+        .await
+        .unwrap();
+    let r2 = handle
+        .remember(
+            "recent planning note two".into(),
+            RoomType::Planning,
+            vec![],
+            0.5,
+        )
+        .await
+        .unwrap();
+    // Deliberately leave `created_at` at "now" — these drawers are NOT aged.
+
+    let mock = std::sync::Arc::new(MockInference::new(vec![ConsolidationAction::Merge {
+        canonical_content: "must NOT merge recent drawers".to_string(),
+        superseded_ids: vec![r1, r2],
+    }]));
+    let call_count = mock.call_count.clone();
+    let consolidator = std::sync::Arc::new(SemanticConsolidator::new(
+        mock,
+        SemanticConsolidationConfig {
+            enabled: true,
+            ..Default::default()
+        },
+    ));
+    let cfg = DreamConfig::default();
+
+    for age in [0_i64, -5] {
+        let stats = consolidate_scoped(
+            &handle,
+            &cfg,
+            Some(RoomType::Planning),
+            age,
+            Some(consolidator.clone()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            stats,
+            RoomConsolidationStats::default(),
+            "max_age_days={age} must consolidate/evict nothing"
+        );
+    }
+
+    assert_eq!(
+        call_count.load(Ordering::Relaxed),
+        0,
+        "consolidator must never run for a non-positive age window"
+    );
+    let ids: Vec<Uuid> = handle.drawers.read().iter().map(|d| d.id).collect();
+    assert!(
+        ids.contains(&r1) && ids.contains(&r2),
+        "recent drawers must survive a non-positive age window"
+    );
+}
+
 // ─── RAII env-var guard for tests ────────────────────────────────────────
 //
 // Safety: test-only; the tokio::test macro with default settings uses the

--- a/crates/trusty-common/src/memory_core/palace.rs
+++ b/crates/trusty-common/src/memory_core/palace.rs
@@ -121,6 +121,13 @@ pub enum DrawerType {
     AgentNote,
     /// Git commit message captured by a hook.
     Commit,
+    /// Task / goal / milestone (spec-001). Protected from the dream cycle:
+    /// never evicted (regardless of age or importance) and never consolidated.
+    /// Use for long-lived context an application must re-derive across
+    /// sessions. An optional [`Drawer::completed_at`] marks a task done; once
+    /// set, the drawer becomes eligible for *manual* cleanup but is still never
+    /// auto-evicted.
+    Task,
     /// Legacy / unclassified (the serde default for backward compat).
     #[default]
     Unknown,
@@ -139,8 +146,22 @@ impl DrawerType {
             DrawerType::SessionEvent => "SessionEvent",
             DrawerType::AgentNote => "AgentNote",
             DrawerType::Commit => "Commit",
+            DrawerType::Task => "Task",
             DrawerType::Unknown => "Unknown",
         }
+    }
+
+    /// Whether this drawer type is protected from the dream cycle.
+    ///
+    /// Why (spec-001): `Task` drawers hold goals/checkpoints an application
+    /// must survive history compaction; the dream cycle's eviction and
+    /// consolidation passes consult this so the protection lives in one place
+    /// rather than being re-derived at every call site.
+    /// What: returns `true` only for `DrawerType::Task`.
+    /// Test: `task_drawer_is_protected` in this module; behavioural coverage in
+    /// `tests/memory_palace.rs` and the dream cycle tests.
+    pub fn is_protected(&self) -> bool {
+        matches!(self, DrawerType::Task)
     }
 }
 
@@ -170,6 +191,13 @@ pub struct Drawer {
     /// events default to a 7-day TTL; user facts never expire.
     #[serde(default)]
     pub expires_at: Option<DateTime<Utc>>,
+    /// spec-001: completion timestamp for `DrawerType::Task` drawers. `None`
+    /// for an open task (and for every non-Task drawer). Setting it marks the
+    /// task done so the application can treat it as eligible for manual
+    /// cleanup; it never triggers automatic eviction. Legacy rows decode to
+    /// `None` via `#[serde(default)]`.
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
 }
 
 impl Drawer {
@@ -192,6 +220,7 @@ impl Drawer {
             access_count: 0,
             drawer_type: DrawerType::Unknown,
             expires_at: None,
+            completed_at: None,
         }
     }
 
@@ -263,7 +292,32 @@ mod tests {
         assert_eq!(DrawerType::SessionEvent.as_str(), "SessionEvent");
         assert_eq!(DrawerType::AgentNote.as_str(), "AgentNote");
         assert_eq!(DrawerType::Commit.as_str(), "Commit");
+        assert_eq!(DrawerType::Task.as_str(), "Task");
         assert_eq!(DrawerType::Unknown.as_str(), "Unknown");
+    }
+
+    #[test]
+    fn task_drawer_is_protected() {
+        assert!(DrawerType::Task.is_protected());
+        for t in [
+            DrawerType::UserFact,
+            DrawerType::SessionEvent,
+            DrawerType::AgentNote,
+            DrawerType::Commit,
+            DrawerType::Unknown,
+        ] {
+            assert!(!t.is_protected(), "{t:?} must not be protected");
+        }
+    }
+
+    #[test]
+    fn task_drawer_has_no_default_ttl() {
+        // Task drawers must never auto-expire — `with_type` only sets a TTL for
+        // SessionEvent, so Task falls through with `expires_at == None`.
+        let d = Drawer::new(Uuid::new_v4(), "ship v2").with_type(DrawerType::Task);
+        assert_eq!(d.drawer_type, DrawerType::Task);
+        assert!(d.expires_at.is_none(), "task drawers never expire");
+        assert!(d.completed_at.is_none(), "fresh task is not completed");
     }
 
     #[test]

--- a/crates/trusty-common/src/memory_core/retrieval/layers.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/layers.rs
@@ -100,6 +100,7 @@ pub fn retrieve_l0_l1(handle: &PalaceHandle) -> Vec<RecallResult> {
             access_count: 0,
             drawer_type: DrawerType::UserFact,
             expires_at: None,
+            completed_at: None,
         };
         out.push(RecallResult {
             drawer: identity_drawer,

--- a/crates/trusty-common/src/memory_core/retrieval/tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/tests.rs
@@ -1012,6 +1012,7 @@ fn rescore_l1_by_similarity_patches_scores() {
         access_count: 0,
         drawer_type: crate::memory_core::palace::DrawerType::UserFact,
         expires_at: None,
+        completed_at: None,
     };
 
     // L1 drawer that appears in the similarity map.

--- a/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 use super::super::kg::Triple;
 use super::store::KgStoreRedb;
-use super::types::{LegacyDrawerRecord, parse_drawer_type, triple_from_parts};
+use super::types::{LegacyDrawerRecord, PreTaskDrawerRecord, parse_drawer_type, triple_from_parts};
 
 impl KgStoreRedb {
     /// Return all currently active triples for `subject`.
@@ -250,16 +250,21 @@ impl KgStoreRedb {
             let record: DrawerRecord = match decode_value::<DrawerRecord>(v.value()) {
                 Ok(r) => r,
                 Err(_) => {
-                    // Issue #61: rows written before drawer_type /
-                    // expires_at_ms existed lack those trailing fields and
-                    // postcard refuses to decode them as the new struct.
-                    // Fall back to the legacy shape and lift it forward.
-                    match decode_value::<LegacyDrawerRecord>(v.value()) {
-                        Ok(legacy) => legacy.into(),
-                        Err(e) => {
-                            tracing::warn!(id = %id, "skip drawer with malformed value: {e}");
-                            continue;
-                        }
+                    // Postcard is positional, so older rows lack the current
+                    // shape's trailing fields and refuse to decode. Walk the
+                    // migration chain newest→oldest, lifting each forward:
+                    //   1. PreTaskDrawerRecord — #61-era (drawer_type +
+                    //      expires_at_ms, no spec-001 completed_at_ms).
+                    //   2. LegacyDrawerRecord — pre-#61 (none of those fields).
+                    match decode_value::<PreTaskDrawerRecord>(v.value()) {
+                        Ok(pre) => pre.into(),
+                        Err(_) => match decode_value::<LegacyDrawerRecord>(v.value()) {
+                            Ok(legacy) => legacy.into(),
+                            Err(e) => {
+                                tracing::warn!(id = %id, "skip drawer with malformed value: {e}");
+                                continue;
+                            }
+                        },
                     }
                 }
             };
@@ -281,6 +286,9 @@ impl KgStoreRedb {
             let expires_at = record
                 .expires_at_ms
                 .and_then(DateTime::from_timestamp_millis);
+            let completed_at = record
+                .completed_at_ms
+                .and_then(DateTime::from_timestamp_millis);
             out.push(Drawer {
                 id,
                 room_id,
@@ -293,6 +301,7 @@ impl KgStoreRedb {
                 access_count: 0,
                 drawer_type,
                 expires_at,
+                completed_at,
             });
         }
         Ok(out)

--- a/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
@@ -225,6 +225,66 @@ mod tests {
     }
 
     #[test]
+    fn pre_task_drawer_row_migrates_completed_at_to_none() {
+        // spec-001 migration regression: a drawer row written *before* the
+        // `completed_at_ms` field existed (the #61-era `PreTaskDrawerRecord`
+        // layout) must still decode. Postcard is positional, so decoding such
+        // bytes as the current `DrawerRecord` fails and the reader falls back
+        // through `PreTaskDrawerRecord` — see the fallback chain in
+        // `read_ops.rs::load_drawers`. The migrated row must keep its
+        // drawer_type / expires_at and default `completed_at` to `None`.
+        use crate::memory_core::palace::DrawerType;
+        use crate::memory_core::store::kg_store::{DRAWERS, encode_value};
+        use redb::Database;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("kg.redb");
+        let id = Uuid::new_v4();
+
+        // Write the legacy-shaped bytes directly, then drop the raw handle so
+        // `KgStoreRedb::open` can acquire its own (redb forbids two in-process
+        // handles to one file).
+        {
+            let old = super::super::types::PreTaskDrawerRecord {
+                room_id: Uuid::new_v4().to_string(),
+                content: "pre-spec-001 task row".to_string(),
+                importance: 0.6,
+                tags: vec!["legacy".to_string()],
+                source_file: None,
+                created_at_ms: 1_700_000_000_000,
+                drawer_type: Some("Task".to_string()),
+                expires_at_ms: None,
+            };
+            let bytes = encode_value(&old).expect("encode legacy record");
+            let db = Database::create(&path).expect("create redb");
+            let wtx = db.begin_write().expect("begin write");
+            {
+                let mut table = wtx.open_table(DRAWERS).expect("open drawers");
+                table
+                    .insert(id.as_bytes().as_slice(), bytes.as_slice())
+                    .expect("insert legacy drawer");
+            }
+            wtx.commit().expect("commit");
+        }
+
+        let kg = KgStoreRedb::open(&path).expect("reopen via KgStoreRedb");
+        let loaded = kg.load_drawers().expect("load drawers");
+        assert_eq!(loaded.len(), 1, "legacy row must decode, not be skipped");
+        assert_eq!(loaded[0].id, id);
+        assert_eq!(loaded[0].content, "pre-spec-001 task row");
+        assert_eq!(
+            loaded[0].drawer_type,
+            DrawerType::Task,
+            "drawer_type preserved through migration"
+        );
+        assert!(loaded[0].expires_at.is_none());
+        assert!(
+            loaded[0].completed_at.is_none(),
+            "missing completed_at_ms field must migrate to None"
+        );
+    }
+
+    #[test]
     fn load_drawer_ids_matches_load_drawers() {
         let (_d, kg) = open_kg();
         let room = Uuid::new_v4();

--- a/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
@@ -204,6 +204,27 @@ mod tests {
     }
 
     #[test]
+    fn drawer_completed_at_round_trips_through_redb() {
+        // spec-001: a Task drawer's type and optional completed_at timestamp
+        // must survive a write/read through the new on-disk field.
+        use crate::memory_core::palace::DrawerType;
+        let (_d, kg) = open_kg();
+        let mut drawer =
+            Drawer::new(Uuid::new_v4(), "ship v2 milestone").with_type(DrawerType::Task);
+        let done = chrono::Utc::now();
+        drawer.completed_at = Some(done);
+        kg.upsert_drawer(&drawer).unwrap();
+
+        let loaded = kg.load_drawers().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].drawer_type, DrawerType::Task);
+        assert!(loaded[0].expires_at.is_none(), "tasks never expire");
+        let got = loaded[0].completed_at.expect("completed_at persisted");
+        // redb stores millisecond precision; compare at that granularity.
+        assert_eq!(got.timestamp_millis(), done.timestamp_millis());
+    }
+
+    #[test]
     fn load_drawer_ids_matches_load_drawers() {
         let (_d, kg) = open_kg();
         let room = Uuid::new_v4();

--- a/crates/trusty-common/src/memory_core/store/kg_redb/types.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/types.rs
@@ -69,6 +69,50 @@ impl From<LegacyDrawerRecord> for DrawerRecord {
             created_at_ms: l.created_at_ms,
             drawer_type: None,
             expires_at_ms: None,
+            completed_at_ms: None,
+        }
+    }
+}
+
+/// #61-era on-disk shape of a drawer row (with `drawer_type` /
+/// `expires_at_ms` but without the spec-001 `completed_at_ms`).
+///
+/// Why: postcard is positional, so adding `completed_at_ms` to `DrawerRecord`
+/// means rows written in the #61 era no longer decode as the current shape —
+/// the reader would otherwise wrongly fall all the way back to
+/// `LegacyDrawerRecord` and silently drop each row's `drawer_type` /
+/// `expires_at`. This intermediate shape preserves those fields and only
+/// defaults the new `completed_at_ms`.
+/// What: mirrors the pre-spec-001 `DrawerRecord` field-for-field; `From` lifts
+/// it into the modern record with `completed_at_ms = None`.
+/// Test: `drawer_completed_at_round_trips_through_redb` and the existing
+/// `drawer_type_round_trips_through_redb`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(super) struct PreTaskDrawerRecord {
+    pub room_id: String,
+    pub content: String,
+    pub importance: f32,
+    pub tags: Vec<String>,
+    pub source_file: Option<String>,
+    pub created_at_ms: i64,
+    #[serde(default)]
+    pub drawer_type: Option<String>,
+    #[serde(default)]
+    pub expires_at_ms: Option<i64>,
+}
+
+impl From<PreTaskDrawerRecord> for DrawerRecord {
+    fn from(p: PreTaskDrawerRecord) -> Self {
+        DrawerRecord {
+            room_id: p.room_id,
+            content: p.content,
+            importance: p.importance,
+            tags: p.tags,
+            source_file: p.source_file,
+            created_at_ms: p.created_at_ms,
+            drawer_type: p.drawer_type,
+            expires_at_ms: p.expires_at_ms,
+            completed_at_ms: None,
         }
     }
 }
@@ -95,6 +139,7 @@ pub(super) fn drawer_to_record(drawer: &Drawer) -> DrawerRecord {
         created_at_ms: drawer.created_at.timestamp_millis(),
         drawer_type: Some(drawer.drawer_type.as_str().to_string()),
         expires_at_ms: drawer.expires_at.map(|d| d.timestamp_millis()),
+        completed_at_ms: drawer.completed_at.map(|d| d.timestamp_millis()),
     }
 }
 
@@ -113,6 +158,7 @@ pub(super) fn parse_drawer_type(tag: Option<&str>) -> crate::memory_core::palace
         Some("SessionEvent") => DrawerType::SessionEvent,
         Some("AgentNote") => DrawerType::AgentNote,
         Some("Commit") => DrawerType::Commit,
+        Some("Task") => DrawerType::Task,
         _ => DrawerType::Unknown,
     }
 }

--- a/crates/trusty-common/src/memory_core/store/kg_redb/types.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/types.rs
@@ -85,7 +85,9 @@ impl From<LegacyDrawerRecord> for DrawerRecord {
 /// defaults the new `completed_at_ms`.
 /// What: mirrors the pre-spec-001 `DrawerRecord` field-for-field; `From` lifts
 /// it into the modern record with `completed_at_ms = None`.
-/// Test: `drawer_completed_at_round_trips_through_redb` and the existing
+/// Test: `pre_task_drawer_row_migrates_completed_at_to_none` (decodes a
+/// legacy-shaped row through this fallback) plus the round-trip coverage in
+/// `drawer_completed_at_round_trips_through_redb` and
 /// `drawer_type_round_trips_through_redb`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(super) struct PreTaskDrawerRecord {

--- a/crates/trusty-common/src/memory_core/store/kg_store.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_store.rs
@@ -169,6 +169,14 @@ pub struct DrawerRecord {
     /// in the past.
     #[serde(default)]
     pub expires_at_ms: Option<i64>,
+    /// spec-001: optional `Task` completion timestamp (epoch ms). `None` for
+    /// open tasks and every non-Task drawer. Because postcard is positional,
+    /// rows written before this field existed fail to decode as the current
+    /// shape; the reader falls back through `PreTaskDrawerRecord` (the #61-era
+    /// shape) and then `LegacyDrawerRecord` to migrate them forward with this
+    /// field defaulted to `None`.
+    #[serde(default)]
+    pub completed_at_ms: Option<i64>,
 }
 
 // ── Key encoding helpers ─────────────────────────────────────────────────
@@ -434,6 +442,7 @@ mod tests {
             created_at_ms: 1_700_000_000_000,
             drawer_type: Some("UserFact".to_string()),
             expires_at_ms: Some(1_710_000_000_000),
+            completed_at_ms: Some(1_720_000_000_000),
         };
         let bytes = encode_value(&d).expect("encode");
         let decoded: DrawerRecord = decode_value(&bytes).expect("decode");
@@ -457,12 +466,14 @@ mod tests {
             created_at_ms: 1,
             drawer_type: None,
             expires_at_ms: None,
+            completed_at_ms: None,
         };
         let bytes = encode_value(&d).expect("encode");
         let decoded: DrawerRecord = decode_value(&bytes).expect("decode");
         assert_eq!(d, decoded);
         assert!(decoded.drawer_type.is_none());
         assert!(decoded.expires_at_ms.is_none());
+        assert!(decoded.completed_at_ms.is_none());
     }
 
     #[test]

--- a/crates/trusty-common/tests/memory_palace.rs
+++ b/crates/trusty-common/tests/memory_palace.rs
@@ -1,0 +1,171 @@
+//! Integration tests for `DrawerType::Task` protection (spec-001 Phase 4).
+//!
+//! Why: Task drawers hold goals/checkpoints an application must re-derive
+//! across sessions, so they must survive the dream cycle's eviction and
+//! consolidation passes. These tests exercise that contract end-to-end through
+//! the public palace + dream API, and confirm the optional `completed_at`
+//! timestamp round-trips through a palace reopen.
+//! What: builds a palace with the mock embedder (no model download), seeds Task
+//! and ordinary drawers, ages them past the prune floor, runs a full dream
+//! cycle, and asserts the Task drawers remain while the ordinary one is evicted.
+//! Test: this IS the test module.
+
+use chrono::{Duration as ChronoDuration, Utc};
+use std::sync::Arc;
+use tempfile::tempdir;
+use trusty_common::memory_core::dream::{DreamConfig, Dreamer};
+use trusty_common::memory_core::palace::{DrawerType, Palace, PalaceId, RoomType};
+use trusty_common::memory_core::retrieval::{
+    PalaceHandle, RememberOptions, seed_shared_embedder_with_mock,
+};
+
+/// Open a fresh palace backed by a leaked tempdir and the mock embedder.
+///
+/// Why: tests must not hit HuggingFace; the mock embedder is deterministic
+/// (identical content => identical vectors) which also lets the dedup pass
+/// fire on duplicate Task drawers.
+/// What: returns an open `PalaceHandle` and the data dir (so a second handle
+/// can reopen the same palace).
+/// Test: used by both tests below.
+fn open_palace(name: &str) -> (Arc<PalaceHandle>, std::path::PathBuf) {
+    seed_shared_embedder_with_mock();
+    let dir = tempdir().expect("tempdir");
+    let data_dir = dir.path().join(name);
+    std::fs::create_dir_all(&data_dir).expect("mkdir");
+    let palace = Palace {
+        id: PalaceId::new(name),
+        name: name.into(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir: data_dir.clone(),
+    };
+    let handle = PalaceHandle::open(&palace).expect("open palace");
+    std::mem::forget(dir); // keep the tempdir alive for the test's lifetime
+    (handle, data_dir)
+}
+
+/// Remember a drawer of an explicit `DrawerType`, bypassing the write filter.
+///
+/// Why: tests need to pin the classification (`Task` vs ordinary) and store
+/// otherwise-filterable short content deterministically.
+/// What: calls `remember_with_options` with `force=true` and the requested
+/// `classify_as`.
+/// Test: used by both tests below.
+async fn remember_typed(
+    handle: &Arc<PalaceHandle>,
+    content: &str,
+    importance: f32,
+    drawer_type: DrawerType,
+) -> uuid::Uuid {
+    handle
+        .remember_with_options(
+            content.to_string(),
+            RoomType::General,
+            vec![],
+            importance,
+            RememberOptions {
+                force: true,
+                classify_as: Some(drawer_type),
+                ..RememberOptions::default()
+            },
+        )
+        .await
+        .expect("remember")
+}
+
+/// Task drawers survive a full dream cycle (eviction + dedup); ordinary aged,
+/// low-importance drawers do not.
+///
+/// Why: spec-001 acceptance criterion 4 — Task drawers are never evicted or
+/// consolidated.
+/// What: seeds two identical Task drawers (which dedup would normally merge)
+/// plus one ordinary drawer, ages all three 60 days at importance 0.01 (well
+/// past the 30-day / 0.05 prune floor), runs a full dream cycle, and asserts
+/// both Task drawers remain while the ordinary one is pruned.
+/// Test: this function.
+#[tokio::test]
+async fn task_drawers_survive_full_dream_cycle() {
+    let (handle, _dir) = open_palace("task-survival");
+
+    let goal = "Goal: ship the trusty-memory chat session manager to production";
+    remember_typed(&handle, goal, 0.01, DrawerType::Task).await;
+    remember_typed(&handle, goal, 0.01, DrawerType::Task).await; // identical => dedup bait
+    let ordinary_id = remember_typed(
+        &handle,
+        "an ordinary stale note nobody reads",
+        0.01,
+        DrawerType::UserFact,
+    )
+    .await;
+
+    // Age every drawer well past the 30-day prune floor.
+    {
+        let mut drawers = handle.drawers.write();
+        for d in drawers.iter_mut() {
+            d.created_at = Utc::now() - ChronoDuration::days(60);
+        }
+    }
+    assert_eq!(handle.drawers.read().len(), 3, "three drawers seeded");
+
+    let dreamer = Dreamer::new(DreamConfig::default());
+    dreamer.dream_cycle(&handle).await.expect("dream cycle");
+
+    let drawers = handle.drawers.read();
+    let task_count = drawers
+        .iter()
+        .filter(|d| d.drawer_type == DrawerType::Task)
+        .count();
+    assert_eq!(
+        task_count, 2,
+        "both Task drawers must survive eviction + dedup; got {task_count}"
+    );
+    assert!(
+        !drawers.iter().any(|d| d.id == ordinary_id),
+        "ordinary aged low-importance drawer should have been pruned"
+    );
+}
+
+/// A Task drawer's `completed_at` timestamp survives a palace reopen.
+///
+/// Why: spec-001 — `completed_at` is tracked; it must persist so an
+/// application can distinguish open vs done tasks across restarts.
+/// What: stores a Task drawer, sets `completed_at`, flushes, drops the handle,
+/// reopens the palace from disk, and asserts the type + timestamp survived.
+/// Test: this function.
+#[tokio::test]
+async fn task_completed_at_round_trips_through_reopen() {
+    let (handle, data_dir) = open_palace("task-completed");
+    let id = remember_typed(&handle, "Goal: cut the v2 release", 0.5, DrawerType::Task).await;
+    let done = Utc::now();
+    // Mark the task complete in-memory, then persist through redb (the
+    // authoritative store consulted on reopen) so the change survives.
+    let updated = {
+        let mut drawers = handle.drawers.write();
+        let d = drawers.iter_mut().find(|d| d.id == id).expect("drawer");
+        d.completed_at = Some(done);
+        d.clone()
+    };
+    handle
+        .kg
+        .upsert_drawer_sync(&updated)
+        .expect("persist completed_at");
+    handle.flush().expect("flush");
+    drop(handle); // release the redb write lock before reopening
+
+    let palace = Palace {
+        id: PalaceId::new("task-completed"),
+        name: "task-completed".into(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir,
+    };
+    let reopened = PalaceHandle::open(&palace).expect("reopen palace");
+    let drawers = reopened.drawers.read();
+    let d = drawers
+        .iter()
+        .find(|d| d.id == id)
+        .expect("drawer survived");
+    assert_eq!(d.drawer_type, DrawerType::Task);
+    let got = d.completed_at.expect("completed_at persisted");
+    assert_eq!(got.timestamp_millis(), done.timestamp_millis());
+}

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -262,9 +262,22 @@ includes `memory_note`, `memory_recall_all`, `palace_delete`,
 
 | Tool | Arguments | Description |
 |---|---|---|
-| `palace_create` | `name, description?` | Create a new palace namespace. See [Palace as Project](#palace-as-project) for naming rules. |
+| `palace_create` | `name, description?, force?` | Create a new palace namespace. See [Palace as Project](#palace-as-project) for naming rules. Pass `force=true` to bypass project-slug validation and create a palace under an arbitrary app/tenant slug (chat-session-manager use case). |
 | `palace_list` | — | List all palaces and their IDs. |
 | `palace_info` | `palace` | Palace metadata and statistics. |
+
+### Chat session tools
+
+A redb-backed, per-palace chat store for applications using trusty-memory as a
+conversation session manager. Turns are stored verbatim and bypass the
+`memory_remember` signal/noise + dedup gates.
+
+| Tool | Arguments | Description |
+|---|---|---|
+| `chat_session_create` | `palace, session_id?, title?` | Create (or reference) a session. Returns `{ session_id, created_at, message_count }`. |
+| `chat_session_add_turn` | `palace, session_id, role, content` | Append a `user`/`assistant`/`system` turn (creates the session if missing). Returns `{ message_count, updated_at }`. |
+| `chat_session_get` | `palace, session_id` | Full session with all turns in order. |
+| `chat_session_list` | `palace, limit?=50, offset?=0` | Paginated session metadata. Returns `{ sessions, total_count }`. |
 
 ### Knowledge graph tools
 
@@ -278,7 +291,19 @@ includes `memory_note`, `memory_recall_all`, `palace_delete`,
 | Tool | Arguments | Description |
 |---|---|---|
 | `memory_dream` | `palace?` | Run a consolidation cycle (merge near-duplicates, prune, compact). |
+| `dream_consolidate_room` | `palace, room?, max_age_days?=7` | On-demand, synchronous LLM consolidation scoped to one room (omit `room` for all rooms). Summarises facts older than `max_age_days` into canonical drawers, then evicts the superseded originals. `Task` drawers are always skipped. No-op when no inference backend is configured. Returns `{ summary_facts_created, facts_evicted }`. |
 | `memory_status` | — | Global statistics (total drawers, vectors, KG triples). |
+
+### Task drawers (protected memory)
+
+`DrawerType::Task` is a drawer classification for goals, milestones, and
+checkpoints that an application must re-derive across sessions. Task drawers are
+**protected from the dream cycle**: they are never evicted (content-prune,
+dedup-merge, or age/importance prune) and never consolidated into summaries,
+regardless of age or importance. An optional `completed_at` timestamp marks a
+task done — this makes it eligible for *manual* cleanup but never triggers
+automatic eviction. Store a Task drawer by classifying a write as `Task`; it
+will survive every subsequent dream cycle until explicitly deleted.
 
 ## Dream Cycle: Semantic Consolidation (issue #87)
 
@@ -558,7 +583,7 @@ trusty-memory (this crate)          trusty-common `memory-core` feature
   axum HTTP/SSE server     ──────►  PalaceRegistry
   Unix domain socket       ──────►  usearch vector index (index.usearch)
   embedded Svelte UI               redb metadata + KG (kg.redb)
-  25 MCP tools                     fastembed (AllMiniLML6V2Q)
+  30 MCP tools                     fastembed (AllMiniLML6V2Q)
 
 trusty-memory-mcp-bridge (separate binary, PR #149)
   Claude Code stdio  ◄──pipe──►  trusty-memory UDS

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -92,8 +92,9 @@ async fn tools_list_returns_all_tools() {
     // Issue #99 added `memory_send_message`; issue #180 added
     // `palace_delete`; the #180 follow-up adds `palace_update` on top
     // of the 22-tool baseline; issue #537 adds `upgrade`;
-    // issue #1104 adds `console_metrics`.
-    assert_eq!(tools.len(), 25);
+    // issue #1104 adds `console_metrics`; spec-001 adds the four
+    // `chat_session_*` tools and `dream_consolidate_room`.
+    assert_eq!(tools.len(), 30);
 }
 
 #[tokio::test]

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -15,7 +15,7 @@
 //! functions guarantees the host-merged manifest and the standalone one
 //! stay byte-identical.
 //!
-//! Test: `tests` below assert the tool count (25), the name string, and
+//! Test: `tests` below assert the tool count (30), the name string, and
 //! that the read/write scope split matches what `scopes_for_tool` returns
 //! for representative tools (`memory_recall` → `memory.read`,
 //! `memory_remember` → `memory.write`).
@@ -25,7 +25,7 @@ use trusty_common::mcp::ServiceDescriptor;
 use crate::openrpc::scopes_for_tool;
 use crate::tools::tool_definitions_with;
 
-/// `ServiceDescriptor` impl that advertises this crate's 25 memory tools.
+/// `ServiceDescriptor` impl that advertises this crate's 30 memory tools.
 ///
 /// Why: Lets open-mpm link trusty-memory-mcp directly and include its
 /// tools in a unified `rpc.discover` document without bespoke glue code.
@@ -87,8 +87,8 @@ mod tests {
         let tools = svc.tools();
         assert_eq!(
             tools.len(),
-            25,
-            "expected 25 memory tools (including upgrade and console_metrics), got {}",
+            30,
+            "expected 30 memory tools (including chat-session + dream_consolidate_room), got {}",
             tools.len()
         );
     }
@@ -111,7 +111,7 @@ mod tests {
         //      so we must confirm dynamic dispatch resolves correctly here.
         let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
         assert_eq!(svc.name(), "trusty-memory");
-        assert_eq!(svc.tools().len(), 25);
+        assert_eq!(svc.tools().len(), 30);
         assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
         assert_eq!(svc.scopes_for("palace_delete"), vec!["memory.write"]);
         assert_eq!(svc.scopes_for("palace_update"), vec!["memory.write"]);

--- a/crates/trusty-memory/src/openrpc.rs
+++ b/crates/trusty-memory/src/openrpc.rs
@@ -55,7 +55,9 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         // Read-only / query
         "memory_recall" | "memory_recall_deep" | "memory_recall_all" | "memory_list"
         | "palace_list" | "palace_info" | "kg_query" | "kg_gaps" | "list_prompt_facts"
-        | "get_prompt_context" | "console_metrics" => &[MEMORY_READ],
+        | "get_prompt_context" | "console_metrics" | "chat_session_get" | "chat_session_list" => {
+            &[MEMORY_READ]
+        }
 
         // Mutating
         "memory_remember"
@@ -69,7 +71,10 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         | "add_alias"
         | "remove_prompt_fact"
         | "discover_aliases"
-        | "memory_send_message" => &[MEMORY_WRITE],
+        | "memory_send_message"
+        | "chat_session_create"
+        | "chat_session_add_turn"
+        | "dream_consolidate_room" => &[MEMORY_WRITE],
 
         // Bootstrap mutates the KG from external project files; it belongs
         // in the dedicated knowledge.write scope (issue #60).

--- a/crates/trusty-memory/src/service/core.rs
+++ b/crates/trusty-memory/src/service/core.rs
@@ -193,9 +193,13 @@ impl MemoryService {
         //      fallback (rarely meaningful when the daemon is launched from ~).
         // This keeps older clients that omit `cwd` working without a breaking
         // change, while letting pin-file-aware clients get accurate validation.
+        // spec-001: `force=true` lets an application bypass the project-slug
+        // gate so it can create palaces under arbitrary slugs (e.g. one per
+        // app/tenant for chat-session storage). The env-var bypass remains for
+        // test contexts; both short-circuit the same validation call.
         let skip_enforcement =
             std::env::var("TRUSTY_SKIP_PALACE_ENFORCEMENT").as_deref() == Ok("1");
-        if !skip_enforcement {
+        if !skip_enforcement && !body.force {
             let cwd = body
                 .cwd
                 .as_deref()

--- a/crates/trusty-memory/src/service/core.rs
+++ b/crates/trusty-memory/src/service/core.rs
@@ -197,6 +197,14 @@ impl MemoryService {
         // gate so it can create palaces under arbitrary slugs (e.g. one per
         // app/tenant for chat-session storage). The env-var bypass remains for
         // test contexts; both short-circuit the same validation call.
+        //
+        // KNOWN MVP LIMITATION (tracked follow-up): `force=true` bypasses slug
+        // validation with NO authorization check — any caller that can reach
+        // this endpoint can create a palace under an arbitrary slug, including
+        // one that collides with another tenant's namespace. This is intended
+        // for trusted / single-tenant callers only. Multi-tenant auth gating
+        // (verifying the caller owns the requested slug) is a tracked follow-up;
+        // do not expose `force` to untrusted clients until that lands.
         let skip_enforcement =
             std::env::var("TRUSTY_SKIP_PALACE_ENFORCEMENT").as_deref() == Ok("1");
         if !skip_enforcement && !body.force {

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -486,6 +486,7 @@ mod tests {
                 access_count: 0,
                 drawer_type: Default::default(),
                 expires_at: None,
+                completed_at: None,
             };
             handle.add_drawer(drawer);
         }

--- a/crates/trusty-memory/src/service/types.rs
+++ b/crates/trusty-memory/src/service/types.rs
@@ -82,9 +82,10 @@ impl From<PersistedDreamStats> for DreamStatusPayload {
 /// validation instead of the daemon's own cwd (which is `~` or `/` and
 /// rarely meaningful). When absent the existing daemon-cwd fallback applies
 /// so older clients continue to work.
-/// What: `name` is required; `description` and `cwd` are optional.
+/// What: `name` is required; `description`, `cwd`, and `force` are optional.
 /// Test: `create_palace_accepts_pinned_slug_via_cwd`,
-///       `create_palace_rejects_mismatch_when_cwd_given`.
+///       `create_palace_rejects_mismatch_when_cwd_given`,
+///       `create_palace_force_bypasses_validation`.
 #[derive(Deserialize, Clone, Debug)]
 pub struct CreatePalaceBody {
     pub name: String,
@@ -96,6 +97,12 @@ pub struct CreatePalaceBody {
     /// but the caller is inside a project tree.
     #[serde(default)]
     pub cwd: Option<String>,
+    /// When `true`, bypass project-slug validation so an application can
+    /// create a palace under an arbitrary slug (spec-001: trusty-memory as a
+    /// chat session manager). Defaults to `false`, preserving the issue #88
+    /// "palace name must match the project slug" gate for ordinary callers.
+    #[serde(default)]
+    pub force: bool,
 }
 
 /// `POST /api/v1/palaces/{id}/drawers` body — service-facing version.

--- a/crates/trusty-memory/src/tools/chat_ops.rs
+++ b/crates/trusty-memory/src/tools/chat_ops.rs
@@ -80,6 +80,13 @@ pub(crate) async fn handle_chat_session_create(state: &AppState, args: Value) ->
 /// to return the authoritative `message_count` and `updated_at`.
 /// Test: `chat_session_add_turn_appends`,
 /// `chat_session_add_turn_rejects_bad_role` in `tests/chat_mcp.rs`.
+///
+/// KNOWN MVP LIMITATION (tracked follow-up): the load→append→write sequence is
+/// NOT atomic. Two concurrent `add_turn` calls on the same `session_id` can both
+/// read the same history snapshot and the second write clobbers the first,
+/// dropping a message. The MVP assumes a single sequential caller per session; a
+/// follow-up issue covers making this a transactional read-modify-write (or a
+/// per-session append lock) before concurrent callers are supported.
 pub(crate) async fn handle_chat_session_add_turn(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "chat_session_add_turn")?;
     let session_id = args

--- a/crates/trusty-memory/src/tools/chat_ops.rs
+++ b/crates/trusty-memory/src/tools/chat_ops.rs
@@ -1,0 +1,166 @@
+//! Chat-session MCP tool handlers (spec-001 Phase 2).
+//!
+//! Why: trusty-memory already owns a redb-backed `ChatSessionStore` per palace
+//! (used by the HTTP chat UI), but it was unreachable over MCP. Applications
+//! driving trusty-memory as a dedicated chat-session manager need to create
+//! sessions, append prompt/response turns, and read history back over the same
+//! MCP surface they use for everything else. These handlers expose that store
+//! directly — deliberately NOT routing through `memory_remember`, whose
+//! signal/noise + 5-minute dedup gates are hostile to sequential conversational
+//! turns.
+//! What: four `pub(crate) async fn handle_chat_session_*` handlers wrapping the
+//! existing store methods (`create_session` / `upsert_session` / `get_session`
+//! / `list_sessions`). Visibility is `pub(crate)` so the dispatcher in
+//! `tools::mod` can route to them.
+//! Test: `crates/trusty-memory/tests/chat_mcp.rs`.
+
+use crate::AppState;
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+use trusty_common::memory_core::store::chat_sessions::ChatMessage;
+
+use super::helpers::resolve_palace;
+
+/// Roles accepted on a chat turn. Mirrors the OpenAI/Anthropic message-role
+/// vocabulary the spec's `chat_session_add_turn` schema enumerates.
+const VALID_ROLES: [&str; 3] = ["user", "assistant", "system"];
+
+/// Create (or reference) a chat session in a palace.
+///
+/// Why: applications open a session before streaming turns into it; returning
+/// the id (and current count) lets the caller thread it through subsequent
+/// `chat_session_add_turn` calls.
+/// What: when `session_id` is omitted, delegates to `ChatSessionStore::
+/// create_session(title)` which mints a fresh UUID and persists the title.
+/// When `session_id` is supplied, creates an empty session under that id via
+/// `upsert_session(id, &[])` if it does not already exist (idempotent); the
+/// optional `title` is only honoured on the generated-id path because the
+/// reused `upsert_session` API does not carry a title. Always reads the row
+/// back so the response reflects persisted state.
+/// Test: `chat_session_create_returns_id`,
+/// `chat_session_create_with_explicit_id` in `tests/chat_mcp.rs`.
+pub(crate) async fn handle_chat_session_create(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "chat_session_create")?;
+    let store = state.session_store(&palace)?;
+    let title = args
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let session_id = match args.get("session_id").and_then(|v| v.as_str()) {
+        Some(id) => {
+            // Idempotent: only seed an empty row when the id is new so we never
+            // clobber an existing session's history.
+            if store.get_session(id)?.is_none() {
+                store.upsert_session(id, &[])?;
+            }
+            id.to_string()
+        }
+        None => store.create_session(title)?,
+    };
+
+    let session = store
+        .get_session(&session_id)?
+        .ok_or_else(|| anyhow!("chat_session_create: session vanished after write"))?;
+    Ok(json!({
+        "session_id": session.id,
+        "created_at": session.created_at,
+        "message_count": session.history.len(),
+    }))
+}
+
+/// Append one message (prompt or response) to a session's history.
+///
+/// Why: each conversational turn must persist immediately and survive daemon
+/// restarts; appending here (rather than via `memory_remember`) keeps turns out
+/// of the noisy generic dedup path.
+/// What: validates `role` against [`VALID_ROLES`], loads the existing history
+/// (creating the session implicitly when missing, per spec), pushes the new
+/// `ChatMessage`, and writes it back via `upsert_session`. Reads the row back
+/// to return the authoritative `message_count` and `updated_at`.
+/// Test: `chat_session_add_turn_appends`,
+/// `chat_session_add_turn_rejects_bad_role` in `tests/chat_mcp.rs`.
+pub(crate) async fn handle_chat_session_add_turn(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "chat_session_add_turn")?;
+    let session_id = args
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("chat_session_add_turn: missing 'session_id'"))?;
+    let role = args
+        .get("role")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("chat_session_add_turn: missing 'role'"))?;
+    if !VALID_ROLES.contains(&role) {
+        return Err(anyhow!(
+            "chat_session_add_turn: invalid role '{role}' (expected one of {VALID_ROLES:?})"
+        ));
+    }
+    let content = args
+        .get("content")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("chat_session_add_turn: missing 'content'"))?;
+
+    let store = state.session_store(&palace)?;
+    // Load → append → write. Missing session => start from empty history so the
+    // turn implicitly creates the session (spec contract).
+    let mut history = store
+        .get_session(session_id)?
+        .map(|s| s.history)
+        .unwrap_or_default();
+    history.push(ChatMessage {
+        role: role.to_string(),
+        content: content.to_string(),
+    });
+    store.upsert_session(session_id, &history)?;
+
+    let session = store
+        .get_session(session_id)?
+        .ok_or_else(|| anyhow!("chat_session_add_turn: session vanished after write"))?;
+    Ok(json!({
+        "message_count": session.history.len(),
+        "updated_at": session.updated_at,
+    }))
+}
+
+/// Fetch a full session (metadata + every turn in order).
+///
+/// Why: resuming a conversation needs the entire message log in one call.
+/// What: reads the row via `get_session`; errors with a clear not-found message
+/// when the id is unknown. Serialises the `ChatSession` verbatim.
+/// Test: `chat_session_get_round_trips`,
+/// `chat_session_get_missing_errors` in `tests/chat_mcp.rs`.
+pub(crate) async fn handle_chat_session_get(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "chat_session_get")?;
+    let session_id = args
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("chat_session_get: missing 'session_id'"))?;
+    let store = state.session_store(&palace)?;
+    let session = store
+        .get_session(session_id)?
+        .ok_or_else(|| anyhow!("chat_session_get: session not found: {session_id}"))?;
+    Ok(serde_json::to_value(session)?)
+}
+
+/// List session metadata in a palace (paginated; no history bodies).
+///
+/// Why: a session sidebar / management view needs a recent-first list without
+/// paying to decode every history blob.
+/// What: calls `list_sessions` (already sorted `updated_at` DESC), records the
+/// unpaginated `total_count`, then applies `offset` + `limit` (defaults 0 / 50)
+/// to the slice it returns.
+/// Test: `chat_session_list_paginates` in `tests/chat_mcp.rs`.
+pub(crate) async fn handle_chat_session_list(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "chat_session_list")?;
+    let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
+    let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+
+    let store = state.session_store(&palace)?;
+    let metas = store.list_sessions()?;
+    let total_count = metas.len();
+    let page: Vec<_> = metas.into_iter().skip(offset).take(limit).collect();
+    Ok(json!({
+        "sessions": serde_json::to_value(page)?,
+        "total_count": total_count,
+    }))
+}

--- a/crates/trusty-memory/src/tools/definitions.rs
+++ b/crates/trusty-memory/src/tools/definitions.rs
@@ -96,6 +96,20 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
         vec!["palace", "short", "full"]
     };
     let discover_aliases_required: Vec<&str> = if has_default { vec![] } else { vec!["palace"] };
+    // spec-001 chat-session tools: `palace` is optional only when a server
+    // default is configured, matching the convention used by every other
+    // palace-scoped tool above.
+    let chat_session_palace_required: Vec<&str> = if has_default { vec![] } else { vec!["palace"] };
+    let chat_session_get_required: Vec<&str> = if has_default {
+        vec!["session_id"]
+    } else {
+        vec!["palace", "session_id"]
+    };
+    let chat_session_add_turn_required: Vec<&str> = if has_default {
+        vec!["session_id", "role", "content"]
+    } else {
+        vec!["palace", "session_id", "role", "content"]
+    };
 
     json!({
         "tools": [
@@ -388,6 +402,58 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                         "confirm": {"type": "boolean", "description": "Set to true to install the new version. NEVER set automatically — the operator must explicitly pass confirm=true.", "default": false}
                     },
                     "required": []
+                }
+            },
+            {
+                "name": "chat_session_create",
+                "description": "Create a new chat session in a palace (spec-001 chat-session manager). Returns the session id, its creation timestamp, and the message count (0 for a fresh session). Pass an optional session_id to use a caller-chosen id (idempotent — an existing session is returned unchanged); pass an optional title to name a server-generated session. Sessions are stored in the palace's dedicated redb chat store, NOT the generic memory drawer surface.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace":     {"type": "string", "description": "Palace slug (optional if server started with --palace)"},
+                        "session_id": {"type": "string", "description": "Optional caller-supplied session id; a UUID is generated when omitted."},
+                        "title":      {"type": "string", "description": "Optional session name (applied only when session_id is omitted)."}
+                    },
+                    "required": chat_session_palace_required,
+                }
+            },
+            {
+                "name": "chat_session_add_turn",
+                "description": "Append a message (prompt or response) to a chat session's history. Creates the session if it does not yet exist. Returns the new message_count and updated_at. Bypasses the memory_remember signal/noise + dedup gates so sequential conversational turns persist verbatim.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace":     {"type": "string"},
+                        "session_id": {"type": "string"},
+                        "role":       {"type": "string", "enum": ["user", "assistant", "system"]},
+                        "content":    {"type": "string"}
+                    },
+                    "required": chat_session_add_turn_required,
+                }
+            },
+            {
+                "name": "chat_session_get",
+                "description": "Retrieve a full chat session: metadata plus every turn in chronological order. Errors if the session id is unknown.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace":     {"type": "string"},
+                        "session_id": {"type": "string"}
+                    },
+                    "required": chat_session_get_required,
+                }
+            },
+            {
+                "name": "chat_session_list",
+                "description": "List chat sessions in a palace as paginated metadata (id, title, timestamps, message_count) ordered most-recently-updated first. Does not include message bodies. Returns { sessions, total_count }.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace": {"type": "string"},
+                        "limit":  {"type": "integer", "default": 50},
+                        "offset": {"type": "integer", "default": 0}
+                    },
+                    "required": chat_session_palace_required,
                 }
             },
             crate::console_metrics::descriptor()

--- a/crates/trusty-memory/src/tools/definitions.rs
+++ b/crates/trusty-memory/src/tools/definitions.rs
@@ -163,7 +163,8 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                     "properties": {
                         "name":        {"type": "string"},
                         "description": {"type": "string"},
-                        "cwd":         {"type": "string", "description": "Optional caller working directory used for palace-name enforcement. Pass the project root (or any path inside it) so the pin file at `.trusty-tools/trusty-memory.yaml` is honoured. When omitted, the daemon's own cwd is used (rarely meaningful for remote calls)."}
+                        "cwd":         {"type": "string", "description": "Optional caller working directory used for palace-name enforcement. Pass the project root (or any path inside it) so the pin file at `.trusty-tools/trusty-memory.yaml` is honoured. When omitted, the daemon's own cwd is used (rarely meaningful for remote calls)."},
+                        "force":       {"type": "boolean", "description": "Bypass project-slug validation so an application can create a palace under an arbitrary slug (spec-001: chat-session manager, one palace per app/tenant). Defaults to false.", "default": false}
                     },
                     "required": ["name"]
                 }

--- a/crates/trusty-memory/src/tools/definitions.rs
+++ b/crates/trusty-memory/src/tools/definitions.rs
@@ -110,6 +110,8 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
     } else {
         vec!["palace", "session_id", "role", "content"]
     };
+    let dream_consolidate_room_required: Vec<&str> =
+        if has_default { vec![] } else { vec!["palace"] };
 
     json!({
         "tools": [
@@ -454,6 +456,19 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                         "offset": {"type": "integer", "default": 0}
                     },
                     "required": chat_session_palace_required,
+                }
+            },
+            {
+                "name": "dream_consolidate_room",
+                "description": "Trigger LLM-driven semantic consolidation for one room (or all rooms) of a palace, on demand and synchronously (spec-001). Consolidates facts older than max_age_days into canonical summaries, then evicts the superseded originals so history shrinks. Task drawers are always skipped. No-op (zero counts) when no inference backend (OpenRouter key / local model) is configured. Returns { summary_facts_created, facts_evicted }.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace":       {"type": "string"},
+                        "room":         {"type": "string", "description": "Room to scope to (e.g. Backend, Planning, or a custom name). Omit or null to consolidate all rooms."},
+                        "max_age_days": {"type": "integer", "default": 7, "description": "Only consolidate facts older than this many days."}
+                    },
+                    "required": dream_consolidate_room_required,
                 }
             },
             crate::console_metrics::descriptor()

--- a/crates/trusty-memory/src/tools/dream_ops.rs
+++ b/crates/trusty-memory/src/tools/dream_ops.rs
@@ -1,0 +1,69 @@
+//! On-demand dream / consolidation MCP handlers (spec-001 Phase 3).
+//!
+//! Why: the idle dream cycle consolidates a whole palace on a ~300s timer. An
+//! application managing chat history wants to compact a single room's older
+//! turns on demand and have the superseded originals evicted so history
+//! actually shrinks. This handler exposes that scoped, synchronous pipeline.
+//! What: `handle_dream_consolidate_room` resolves the palace, parses the
+//! optional room + age window, builds a `DreamConfig` from the daemon's user
+//! config (OpenRouter key / local-model setting), and delegates to
+//! `dream::consolidate_scoped`. Task drawers are skipped inside that helper.
+//! Test: `crates/trusty-memory/tests/dream_room_mcp.rs` (wiring + no-op) and
+//! `dream::tests::consolidate_scoped_*` in trusty-common (behaviour).
+
+use crate::AppState;
+use anyhow::Result;
+use serde_json::{json, Value};
+use trusty_common::memory_core::dream::{consolidate_scoped, DreamConfig};
+
+use super::helpers::{open_palace_handle, parse_room, resolve_palace};
+
+/// Default age window: only consolidate facts older than this many days.
+const DEFAULT_MAX_AGE_DAYS: i64 = 7;
+
+/// Trigger LLM-driven consolidation for one room (or all rooms) of a palace.
+///
+/// Why: gives applications an explicit "compact this room's older history now"
+/// control instead of waiting for the idle dreamer; returns the work done so
+/// the caller can log progress.
+/// What: parses `room` (null/omitted = all rooms) and `max_age_days`
+/// (default 7), builds a `DreamConfig` seeded with the daemon's OpenRouter key
+/// and local-model flag, opens the palace, and runs `consolidate_scoped`. When
+/// no inference backend is configured the helper is a graceful no-op (zero
+/// counts). Returns `{ palace, room, summary_facts_created, facts_evicted }`.
+/// Test: `dream_consolidate_room_returns_shape` (no-op path) in
+/// `tests/dream_room_mcp.rs`.
+pub(crate) async fn handle_dream_consolidate_room(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "dream_consolidate_room")?;
+    // Absent / null / empty room => all rooms; otherwise scope to that room.
+    let room_arg = args
+        .get("room")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+    let room = room_arg.map(|s| parse_room(Some(s)));
+    let max_age_days = args
+        .get("max_age_days")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(DEFAULT_MAX_AGE_DAYS);
+
+    let handle = open_palace_handle(state, &palace)?;
+
+    // Seed the consolidation config from the daemon's user config so the
+    // inference backend (OpenRouter key / local model) matches the idle dream
+    // cycle. Everything else uses the dream defaults (semantic enabled).
+    let cfg = crate::web::load_user_config().unwrap_or_default();
+    let dream_cfg = DreamConfig {
+        openrouter_api_key: cfg.openrouter_api_key,
+        local_model_enabled: cfg.local_model.enabled,
+        ..DreamConfig::default()
+    };
+
+    let stats = consolidate_scoped(&handle, &dream_cfg, room, max_age_days, None).await?;
+
+    Ok(json!({
+        "palace": palace,
+        "room": room_arg,
+        "summary_facts_created": stats.summary_facts_created,
+        "facts_evicted": stats.facts_evicted,
+    }))
+}

--- a/crates/trusty-memory/src/tools/mod.rs
+++ b/crates/trusty-memory/src/tools/mod.rs
@@ -22,6 +22,7 @@
 pub mod bm25;
 pub mod chat_ops;
 pub mod definitions;
+pub mod dream_ops;
 pub mod helpers;
 pub mod kg_ops;
 pub mod memory_ops;
@@ -48,6 +49,7 @@ use chat_ops::{
     handle_chat_session_add_turn, handle_chat_session_create, handle_chat_session_get,
     handle_chat_session_list,
 };
+use dream_ops::handle_dream_consolidate_room;
 use kg_ops::{
     handle_add_alias, handle_discover_aliases, handle_get_prompt_context, handle_kg_assert,
     handle_kg_bootstrap, handle_kg_gaps, handle_kg_query, handle_list_prompt_facts,
@@ -105,6 +107,7 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
         "chat_session_add_turn" => handle_chat_session_add_turn(state, args).await,
         "chat_session_get" => handle_chat_session_get(state, args).await,
         "chat_session_list" => handle_chat_session_list(state, args).await,
+        "dream_consolidate_room" => handle_dream_consolidate_room(state, args).await,
         other => anyhow::bail!("unknown tool: {other}"),
     }
 }

--- a/crates/trusty-memory/src/tools/mod.rs
+++ b/crates/trusty-memory/src/tools/mod.rs
@@ -20,6 +20,7 @@
 //! - `kg_query(palace, subject)`                    -> Vec<Triple>
 
 pub mod bm25;
+pub mod chat_ops;
 pub mod definitions;
 pub mod helpers;
 pub mod kg_ops;
@@ -43,6 +44,10 @@ use crate::AppState;
 use anyhow::Result;
 use serde_json::Value;
 
+use chat_ops::{
+    handle_chat_session_add_turn, handle_chat_session_create, handle_chat_session_get,
+    handle_chat_session_list,
+};
 use kg_ops::{
     handle_add_alias, handle_discover_aliases, handle_get_prompt_context, handle_kg_assert,
     handle_kg_bootstrap, handle_kg_gaps, handle_kg_query, handle_list_prompt_facts,
@@ -96,6 +101,10 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
         "memory_send_message" => handle_memory_send_message(state, args).await,
         "upgrade" => handle_upgrade_tool(state, args).await,
         "console_metrics" => crate::console_metrics::handle_console_metrics(state, args).await,
+        "chat_session_create" => handle_chat_session_create(state, args).await,
+        "chat_session_add_turn" => handle_chat_session_add_turn(state, args).await,
+        "chat_session_get" => handle_chat_session_get(state, args).await,
+        "chat_session_list" => handle_chat_session_list(state, args).await,
         other => anyhow::bail!("unknown tool: {other}"),
     }
 }

--- a/crates/trusty-memory/src/tools/palace_ops.rs
+++ b/crates/trusty-memory/src/tools/palace_ops.rs
@@ -38,8 +38,13 @@ pub(crate) async fn handle_palace_create(state: &AppState, args: Value) -> Resul
     // names against tempdir roots that are not real projects). The bypass is
     // keyed on an env var (`TRUSTY_SKIP_PALACE_ENFORCEMENT=1`) that tests set
     // locally; production deployments never set it.
+    // spec-001 / Phase 1: `force=true` bypasses slug validation so an
+    // application can create a palace under an arbitrary slug (e.g. one palace
+    // per app/tenant for chat-session storage). The env-var bypass remains for
+    // test contexts; either short-circuits the same validation call.
+    let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
     let skip_enforcement = std::env::var("TRUSTY_SKIP_PALACE_ENFORCEMENT").as_deref() == Ok("1");
-    if !skip_enforcement {
+    if !skip_enforcement && !force {
         let cwd = args
             .get("cwd")
             .and_then(|v| v.as_str())

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -116,7 +116,7 @@ fn tool_definitions_lists_all_tools() {
         .get("tools")
         .and_then(|t| t.as_array())
         .expect("tools array");
-    assert_eq!(tools.len(), 25);
+    assert_eq!(tools.len(), 29);
     let names: Vec<&str> = tools
         .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
@@ -147,6 +147,10 @@ fn tool_definitions_lists_all_tools() {
         "memory_send_message",
         "upgrade",
         "console_metrics",
+        "chat_session_create",
+        "chat_session_add_turn",
+        "chat_session_get",
+        "chat_session_list",
     ] {
         assert!(names.contains(&expected), "missing tool: {expected}");
     }

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -116,7 +116,7 @@ fn tool_definitions_lists_all_tools() {
         .get("tools")
         .and_then(|t| t.as_array())
         .expect("tools array");
-    assert_eq!(tools.len(), 29);
+    assert_eq!(tools.len(), 30);
     let names: Vec<&str> = tools
         .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
@@ -151,6 +151,7 @@ fn tool_definitions_lists_all_tools() {
         "chat_session_add_turn",
         "chat_session_get",
         "chat_session_list",
+        "dream_consolidate_room",
     ] {
         assert!(names.contains(&expected), "missing tool: {expected}");
     }

--- a/crates/trusty-memory/tests/chat_mcp.rs
+++ b/crates/trusty-memory/tests/chat_mcp.rs
@@ -1,0 +1,250 @@
+//! Integration tests for the chat-session MCP tools (spec-001 Phase 2).
+//!
+//! Why: trusty-memory exposes a redb-backed per-palace chat store over MCP so
+//! applications can persist prompt/response turns. These tests assert the four
+//! tools round-trip correctly, that turns survive a store/daemon restart (a new
+//! `AppState` over the same data root), and that turns are queryable by session
+//! id — the core acceptance criteria for Phase 2.
+//! What: drives `dispatch_tool` against an `AppState` rooted at a tempdir. The
+//! chat store auto-creates the palace data dir on first use, so no
+//! `palace_create` (and no slug-enforcement bypass) is needed.
+//! Test: this IS the test module.
+
+use serde_json::json;
+use tempfile::TempDir;
+use trusty_memory::tools::dispatch_tool;
+use trusty_memory::AppState;
+
+const PALACE: &str = "chat-app";
+
+/// Build a ready `AppState` rooted at `root`.
+///
+/// Why: persistence tests need to construct a second `AppState` over the same
+/// root after the first is dropped, so the root is passed in explicitly.
+/// What: returns a ready state.
+/// Test: used by every test below.
+fn state_at(root: &TempDir) -> AppState {
+    let state = AppState::new(root.path().to_path_buf());
+    state.set_ready();
+    state
+}
+
+/// `chat_session_create` mints a session and reports a zero message count.
+#[tokio::test]
+async fn chat_session_create_returns_id() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = state_at(&tmp);
+    let created = dispatch_tool(
+        &state,
+        "chat_session_create",
+        json!({ "palace": PALACE, "title": "First chat" }),
+    )
+    .await
+    .expect("create");
+    let sid = created["session_id"].as_str().expect("session_id");
+    assert!(!sid.is_empty(), "session id is non-empty");
+    assert_eq!(created["message_count"], 0);
+    assert!(created["created_at"].is_string(), "created_at present");
+}
+
+/// A caller-supplied `session_id` is honoured and is idempotent.
+#[tokio::test]
+async fn chat_session_create_with_explicit_id() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = state_at(&tmp);
+    let first = dispatch_tool(
+        &state,
+        "chat_session_create",
+        json!({ "palace": PALACE, "session_id": "fixed-123" }),
+    )
+    .await
+    .expect("create");
+    assert_eq!(first["session_id"], "fixed-123");
+
+    // Add a turn, then re-create with the same id: history must be preserved.
+    dispatch_tool(
+        &state,
+        "chat_session_add_turn",
+        json!({ "palace": PALACE, "session_id": "fixed-123", "role": "user", "content": "hi" }),
+    )
+    .await
+    .expect("add turn");
+
+    let again = dispatch_tool(
+        &state,
+        "chat_session_create",
+        json!({ "palace": PALACE, "session_id": "fixed-123" }),
+    )
+    .await
+    .expect("re-create idempotent");
+    assert_eq!(again["session_id"], "fixed-123");
+    assert_eq!(again["message_count"], 1, "existing history preserved");
+}
+
+/// `chat_session_add_turn` appends turns and reports the running count.
+#[tokio::test]
+async fn chat_session_add_turn_appends() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = state_at(&tmp);
+    let sid = dispatch_tool(&state, "chat_session_create", json!({ "palace": PALACE }))
+        .await
+        .expect("create")["session_id"]
+        .as_str()
+        .expect("sid")
+        .to_string();
+
+    let r1 = dispatch_tool(
+        &state,
+        "chat_session_add_turn",
+        json!({ "palace": PALACE, "session_id": sid, "role": "user", "content": "What is redb?" }),
+    )
+    .await
+    .expect("turn 1");
+    assert_eq!(r1["message_count"], 1);
+
+    let r2 = dispatch_tool(
+        &state,
+        "chat_session_add_turn",
+        json!({ "palace": PALACE, "session_id": sid, "role": "assistant", "content": "An embedded KV store." }),
+    )
+    .await
+    .expect("turn 2");
+    assert_eq!(r2["message_count"], 2);
+    assert!(r2["updated_at"].is_string());
+}
+
+/// An unknown role is rejected before any write.
+#[tokio::test]
+async fn chat_session_add_turn_rejects_bad_role() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = state_at(&tmp);
+    let err = dispatch_tool(
+        &state,
+        "chat_session_add_turn",
+        json!({ "palace": PALACE, "session_id": "s1", "role": "robot", "content": "x" }),
+    )
+    .await
+    .expect_err("bad role rejected");
+    assert!(format!("{err:#}").contains("invalid role"));
+}
+
+/// `chat_session_get` returns the full ordered history; missing id errors.
+#[tokio::test]
+async fn chat_session_get_round_trips() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = state_at(&tmp);
+    let sid = dispatch_tool(&state, "chat_session_create", json!({ "palace": PALACE }))
+        .await
+        .expect("create")["session_id"]
+        .as_str()
+        .expect("sid")
+        .to_string();
+    for (role, content) in [("user", "a"), ("assistant", "b"), ("system", "c")] {
+        dispatch_tool(
+            &state,
+            "chat_session_add_turn",
+            json!({ "palace": PALACE, "session_id": sid, "role": role, "content": content }),
+        )
+        .await
+        .expect("turn");
+    }
+
+    let got = dispatch_tool(
+        &state,
+        "chat_session_get",
+        json!({ "palace": PALACE, "session_id": sid }),
+    )
+    .await
+    .expect("get");
+    let history = got["history"].as_array().expect("history");
+    assert_eq!(history.len(), 3);
+    assert_eq!(history[0]["role"], "user");
+    assert_eq!(history[0]["content"], "a");
+    assert_eq!(history[2]["role"], "system");
+
+    let missing = dispatch_tool(
+        &state,
+        "chat_session_get",
+        json!({ "palace": PALACE, "session_id": "does-not-exist" }),
+    )
+    .await;
+    assert!(missing.is_err(), "missing session must error");
+}
+
+/// `chat_session_list` reports total_count and applies offset + limit.
+#[tokio::test]
+async fn chat_session_list_paginates() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = state_at(&tmp);
+    for i in 0..3 {
+        dispatch_tool(
+            &state,
+            "chat_session_create",
+            json!({ "palace": PALACE, "session_id": format!("s{i}") }),
+        )
+        .await
+        .expect("create");
+    }
+
+    let all = dispatch_tool(&state, "chat_session_list", json!({ "palace": PALACE }))
+        .await
+        .expect("list");
+    assert_eq!(all["total_count"], 3);
+    assert_eq!(all["sessions"].as_array().expect("sessions").len(), 3);
+
+    let page = dispatch_tool(
+        &state,
+        "chat_session_list",
+        json!({ "palace": PALACE, "limit": 1, "offset": 1 }),
+    )
+    .await
+    .expect("list paged");
+    assert_eq!(page["total_count"], 3, "total ignores pagination");
+    assert_eq!(page["sessions"].as_array().expect("sessions").len(), 1);
+}
+
+/// Turns persist across a daemon/store restart and stay queryable by id.
+///
+/// Why: spec-001 acceptance criterion 2 — durability is the whole point of the
+/// redb backing. Dropping the first `AppState` (and its cached store handle)
+/// then opening a fresh one over the same data root simulates a restart.
+#[tokio::test]
+async fn turns_persist_across_restart() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let sid = {
+        let state = state_at(&tmp);
+        let sid = dispatch_tool(
+            &state,
+            "chat_session_create",
+            json!({ "palace": PALACE, "session_id": "durable" }),
+        )
+        .await
+        .expect("create")["session_id"]
+            .as_str()
+            .expect("sid")
+            .to_string();
+        dispatch_tool(
+            &state,
+            "chat_session_add_turn",
+            json!({ "palace": PALACE, "session_id": sid, "role": "user", "content": "remember me" }),
+        )
+        .await
+        .expect("turn");
+        sid
+        // `state` (and its session-store cache) dropped here.
+    };
+
+    // Fresh AppState over the same root — must re-open the on-disk redb store.
+    let state2 = state_at(&tmp);
+    let got = dispatch_tool(
+        &state2,
+        "chat_session_get",
+        json!({ "palace": PALACE, "session_id": sid }),
+    )
+    .await
+    .expect("get after restart");
+    let history = got["history"].as_array().expect("history");
+    assert_eq!(history.len(), 1, "turn survived restart");
+    assert_eq!(history[0]["content"], "remember me");
+}

--- a/crates/trusty-memory/tests/dream_room_mcp.rs
+++ b/crates/trusty-memory/tests/dream_room_mcp.rs
@@ -26,10 +26,11 @@ fn ready_state(tmp: &TempDir) -> AppState {
 /// for an empty palace (no inference call made).
 #[tokio::test]
 async fn dream_consolidate_room_returns_shape() {
-    // Force the inference gate to "unavailable" so the no-op path is taken even
-    // if no drawers existed. Safe: this dedicated test binary is single-process.
-    unsafe { std::env::remove_var("OPENROUTER_API_KEY") };
-
+    // No env mutation: the palace is created empty, so `consolidate_scoped`
+    // short-circuits on an empty drawer snapshot and never calls an inference
+    // backend — the result is zero counts regardless of any ambient
+    // OPENROUTER_API_KEY. Mutating `std::env` here would be a data race under
+    // the default multi-threaded `#[tokio::test]` runtime.
     let tmp = tempfile::tempdir().expect("tempdir");
     let state = ready_state(&tmp);
     let cwd = tmp.path().to_string_lossy().to_string();

--- a/crates/trusty-memory/tests/dream_room_mcp.rs
+++ b/crates/trusty-memory/tests/dream_room_mcp.rs
@@ -1,0 +1,69 @@
+//! Integration tests for the `dream_consolidate_room` MCP tool (spec-001 Phase 3).
+//!
+//! Why: confirms the on-demand consolidation tool is wired into the dispatcher,
+//! accepts the spec's arguments (palace / room / max_age_days), and returns the
+//! `{ summary_facts_created, facts_evicted }` shape synchronously.
+//! What: drives `dispatch_tool` against an `AppState` rooted at a tempdir. The
+//! palace is created empty, so the scoped consolidation short-circuits on an
+//! empty snapshot and never invokes any inference backend — keeping the test
+//! deterministic and offline regardless of ambient OpenRouter configuration.
+//! Behavioural coverage (room filtering, Task skip, eviction) lives in
+//! `trusty_common::memory_core::dream::tests::consolidate_scoped_*`.
+//! Test: this IS the test module.
+
+use serde_json::json;
+use tempfile::TempDir;
+use trusty_memory::tools::dispatch_tool;
+use trusty_memory::AppState;
+
+fn ready_state(tmp: &TempDir) -> AppState {
+    let state = AppState::new(tmp.path().to_path_buf());
+    state.set_ready();
+    state
+}
+
+/// The tool dispatches, accepts room + max_age_days, and returns zero counts
+/// for an empty palace (no inference call made).
+#[tokio::test]
+async fn dream_consolidate_room_returns_shape() {
+    // Force the inference gate to "unavailable" so the no-op path is taken even
+    // if no drawers existed. Safe: this dedicated test binary is single-process.
+    unsafe { std::env::remove_var("OPENROUTER_API_KEY") };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = ready_state(&tmp);
+    let cwd = tmp.path().to_string_lossy().to_string();
+
+    // Create a custom-slug palace via the Phase 1 force flag.
+    dispatch_tool(
+        &state,
+        "palace_create",
+        json!({ "name": "dreamapp", "force": true, "cwd": cwd }),
+    )
+    .await
+    .expect("create palace");
+
+    // All rooms (room omitted).
+    let all = dispatch_tool(
+        &state,
+        "dream_consolidate_room",
+        json!({ "palace": "dreamapp" }),
+    )
+    .await
+    .expect("consolidate all rooms");
+    assert_eq!(all["palace"], "dreamapp");
+    assert_eq!(all["summary_facts_created"], 0);
+    assert_eq!(all["facts_evicted"], 0);
+
+    // Scoped to a specific room with an explicit age window.
+    let scoped = dispatch_tool(
+        &state,
+        "dream_consolidate_room",
+        json!({ "palace": "dreamapp", "room": "Backend", "max_age_days": 3 }),
+    )
+    .await
+    .expect("consolidate Backend");
+    assert_eq!(scoped["room"], "Backend");
+    assert_eq!(scoped["summary_facts_created"], 0);
+    assert_eq!(scoped["facts_evicted"], 0);
+}

--- a/crates/trusty-memory/tests/palace_force.rs
+++ b/crates/trusty-memory/tests/palace_force.rs
@@ -1,0 +1,113 @@
+//! Integration tests for the `palace_create` `force` flag (spec-001 Phase 1).
+//!
+//! Why: ordinary `palace_create` calls are gated by issue #88 project-slug
+//! validation (the palace name must match the cwd-derived project slug or be
+//! `personal`). An application driving trusty-memory as a chat-session manager
+//! needs to create palaces under arbitrary app/tenant slugs, so a `force=true`
+//! escape hatch was added. This test lives in its own integration binary so it
+//! runs in a process where `TRUSTY_SKIP_PALACE_ENFORCEMENT` is never set —
+//! the lib's unit-test helpers set that var globally, which would otherwise
+//! mask the gate we are trying to exercise.
+//! What: drives `dispatch_tool` against an `AppState` rooted at a tempdir,
+//! passing an explicit `cwd` that has no project markers so validation has a
+//! deterministic outcome regardless of where `cargo test` runs.
+//! Test: this IS the test module.
+
+use serde_json::json;
+use tempfile::TempDir;
+use trusty_memory::tools::dispatch_tool;
+use trusty_memory::AppState;
+
+/// Build a ready `AppState` plus two tempdirs: the palace data root and a
+/// marker-free "project" dir used as the validation cwd.
+///
+/// Why: `force=false` must fail deterministically; pointing the validator at a
+/// directory with no `.git`/`Cargo.toml`/etc. guarantees the "no project root"
+/// rejection path rather than depending on the test runner's cwd.
+/// What: returns `(state, root_tmp, cwd_tmp)`; callers bind all three so drop
+/// cleans up after the test.
+/// Test: used by both tests below.
+fn fixture() -> (AppState, TempDir, TempDir) {
+    let root_tmp = tempfile::tempdir().expect("data root tempdir");
+    let cwd_tmp = tempfile::tempdir().expect("cwd tempdir");
+    let state = AppState::new(root_tmp.path().to_path_buf());
+    state.set_ready();
+    (state, root_tmp, cwd_tmp)
+}
+
+/// `force=true` bypasses slug validation and creates an arbitrary-slug palace.
+///
+/// Why: spec-001 acceptance criterion 1 — applications create custom palaces.
+/// What: creates two forced palaces under non-project slugs, confirms both
+/// appear in `palace_list`, and confirms each reports its own isolated
+/// `data_dir` (separate redb + HNSW root) via `palace_info`.
+/// Test: this function.
+#[tokio::test]
+async fn force_true_creates_custom_slug_palace_with_isolated_dirs() {
+    let (state, _root, cwd) = fixture();
+    let cwd_str = cwd.path().to_string_lossy().to_string();
+
+    for slug in ["acme-app", "tenant-42"] {
+        let created = dispatch_tool(
+            &state,
+            "palace_create",
+            json!({ "name": slug, "force": true, "cwd": cwd_str }),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("force create '{slug}' should succeed: {e:#}"));
+        assert_eq!(created["palace_id"], slug);
+        assert_eq!(created["status"], "created");
+    }
+
+    let listed = dispatch_tool(&state, "palace_list", json!({}))
+        .await
+        .expect("palace_list");
+    let palaces = listed["palaces"].as_array().expect("palaces array");
+    let names: Vec<&str> = palaces.iter().filter_map(|v| v.as_str()).collect();
+    assert!(names.contains(&"acme-app"), "acme-app present: {names:?}");
+    assert!(names.contains(&"tenant-42"), "tenant-42 present: {names:?}");
+
+    // Each palace must report its own data dir under the shared root — this is
+    // the on-disk isolation boundary (separate redb + HNSW per palace).
+    let info_a = dispatch_tool(&state, "palace_info", json!({ "palace": "acme-app" }))
+        .await
+        .expect("palace_info acme-app");
+    let info_b = dispatch_tool(&state, "palace_info", json!({ "palace": "tenant-42" }))
+        .await
+        .expect("palace_info tenant-42");
+    let dir_a = info_a["data_dir"].as_str().expect("acme data_dir");
+    let dir_b = info_b["data_dir"].as_str().expect("tenant data_dir");
+    assert_ne!(dir_a, dir_b, "palaces must have distinct data dirs");
+    assert!(dir_a.ends_with("acme-app"), "dir_a = {dir_a}");
+    assert!(dir_b.ends_with("tenant-42"), "dir_b = {dir_b}");
+    assert!(
+        std::path::Path::new(dir_a).is_dir(),
+        "acme-app data dir exists on disk"
+    );
+}
+
+/// `force=false` (the default) still enforces project-slug validation.
+///
+/// Why: spec-001 acceptance criterion 1 — the gate must remain intact for
+/// ordinary callers; `force` is opt-in only.
+/// What: attempts to create an arbitrary-slug palace from a marker-free cwd
+/// without `force`; expects an error mentioning the missing project root.
+/// Test: this function.
+#[tokio::test]
+async fn force_false_still_enforces_validation() {
+    let (state, _root, cwd) = fixture();
+    let cwd_str = cwd.path().to_string_lossy().to_string();
+
+    let err = dispatch_tool(
+        &state,
+        "palace_create",
+        json!({ "name": "acme-app", "cwd": cwd_str }),
+    )
+    .await
+    .expect_err("force=false must reject a non-project slug");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("no project root") || msg.contains("does not match"),
+        "expected a validation error, got: {msg}"
+    );
+}


### PR DESCRIPTION
Implements spec-001-chat-session-manager (docs/specs/trusty-memory-chat-session-manager.md). Part of epic #1683.

Closes #1700, #1701, #1702, #1703.
Tracking: #1699
Refs #1683, #1531, #1589

## Phases

| Phase | Feature | Issue |
|-------|---------|-------|
| P1 | `palace_create` `force` flag | #1700 |
| P2 | Four `chat_session_*` MCP tools over redb ChatSessionStore | #1701 |
| P3 | `dream_consolidate_room(palace, room?, max_age_days?=7)` scoped consolidation (skips Task drawers; returns {summary_facts_created, facts_evicted}) | #1702 |
| P4 | `DrawerType::Task` + `completed_at`, protected from eviction/consolidation | #1703 |

## Verification

Independent QA pass re-ran the suites:
- **trusty-common**: 409 lib + 23 integration passed / 0 failed (features: memory-core, embedder-test-support)
- **trusty-memory**: 398 lib + ~43 integration passed / 0 failed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

Proving tests:
- `palace_force.rs`
- `chat_mcp.rs` (incl. `turns_persist_across_restart`)
- `dream_room_mcp.rs` + `consolidate_scoped_*`
- `memory_palace.rs` (incl. `task_drawers_survive_full_dream_cycle`, `task_completed_at_round_trips`)

## Notes / follow-ups

1. Pre-existing non-hermetic test `semantic_consolidation::tests::inference_available_false_without_key` fails if `OPENROUTER_API_KEY` is in the ambient env (unrelated; run suites with it unset) — consider hardening separately.
2. `completed_at` has no MCP setter in the MVP (spec defers a `task_mark_complete` tool); field persists/round-trips via the store layer.
3. Spec file:line refs were stale — validation lives in `trusty-memory/src/project_root/validation.rs` + `service/core.rs`; MCP tools in `src/tools/`.

## Test commands

\`\`\`bash
env -u OPENROUTER_API_KEY cargo test -p trusty-common --features memory-core,embedder-test-support
env -u OPENROUTER_API_KEY cargo test -p trusty-memory
\`\`\`

🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)