### PR TITLE
fix(trusty-search): HNSW data-loss guard — refuse empty-over-populated save (closes #1711)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11068,7 +11068,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+
+## [0.29.1] — 2026-06-25
+
+### Fixed (closes #1711)
+
+- **HNSW shutdown data-loss guard: prevent empty in-memory index from
+  overwriting a populated on-disk snapshot.**
+  A graceful-shutdown race (background reindex from `reconcile_stale_indexes`
+  / commit `fe4c0b28` flushed mid-run on SIGTERM) could cause a
+  just-promoted but not-yet-populated `UsearchStore` to call `save()` and
+  overwrite a fully-populated on-disk snapshot with 0 vectors.
+  The guard now runs **under the same write-lock scope** that owns the save
+  (eliminating the TOCTOU window), refuses to proceed when `index.size()==0`
+  and the on-disk file is larger than 100 KB, and returns `Ok(())` so
+  callers complete shutdown gracefully. A follow-up issue (#1717) tracks
+  draining/cancelling in-flight background reindex tasks on SIGTERM and
+  guarding catastrophic partial-snapshot shrinks.
+- `POPULATED_SNAPSHOT_THRESHOLD_BYTES` promoted to module-level `pub(super)
+  const` so tests can reference it without hard-coding a magic literal.
+- Regression test `test_save_refuses_to_overwrite_populated_snapshot_with_empty_index`
+  rewritten to actually trigger the guard (writes a filler file above the
+  threshold, asserts byte-for-byte preservation after `save()` on an empty
+  store).
+
+---
 ## [Unreleased]
 
 ### Added

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use super::types::VectorStore;
-use super::usearch_store::UsearchStore;
+use super::usearch_store::{UsearchStore, POPULATED_SNAPSHOT_THRESHOLD_BYTES};
 
 #[tokio::test]
 async fn test_upsert_and_search() {
@@ -359,61 +359,59 @@ async fn test_capacity_growth() {
 /// a populated on-disk snapshot (> 100 KB) with an empty in-memory index.
 /// This protects against shutdown races where a fresh/promoted-but-empty
 /// UsearchStore saves 0 vectors over a fully-populated on-disk snapshot.
-/// What: saves a 5-vector store to disk, then calls `save()` on a NEW empty
-/// store pointing at the same path. Asserts the on-disk file is unchanged
-/// (not clobbered) and `save()` returns `Ok(())`.
+///
+/// What: writes a filler file LARGER than `POPULATED_SNAPSHOT_THRESHOLD_BYTES`
+/// at the HNSW path to simulate a populated on-disk snapshot, then calls
+/// `save()` on a FRESH EMPTY store targeting the same path. Asserts:
+/// (a) `save()` returns `Ok(())` — the guard does not surface an error, it
+///     just silently preserves the on-disk state and returns `Ok`, so callers
+///     can proceed with shutdown without aborting.
+/// (b) The on-disk file is **byte-for-byte unchanged** — the guard fired and
+///     the filler was NOT overwritten.
+///
+/// Without the guard, (b) would fail: usearch would happily write a tiny
+/// empty-index file over the filler, proving the regression exists.
+///
 /// Test: this IS the test.
 #[tokio::test]
 async fn test_save_refuses_to_overwrite_populated_snapshot_with_empty_index() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("hnsw.usearch");
 
-    // Phase 1: create a populated store and persist it.
-    // Use orthogonal unit vectors so all 5 are retained (cosine-safe).
-    let populated = UsearchStore::new(4).unwrap();
-    for i in 0..5u32 {
-        let mut v = vec![0.0f32; 4];
-        v[i as usize % 4] = (i + 1) as f32;
-        populated.upsert(&format!("chunk:{i}"), v).await.unwrap();
-    }
-    populated
-        .save(&path)
-        .await
-        .expect("initial save must succeed");
-    assert!(path.exists(), "hnsw file must exist after save");
-    let _on_disk_size_before = std::fs::metadata(&path).unwrap().len();
-    // The 5-vector snapshot must be well above our 100 KB guard threshold
-    // (usearch serialises graph structure; even tiny HNSW files are > a few KB,
-    // not 100 KB, so we assert > 0 here and the guard's 100 KB threshold is
-    // tested implicitly — if the file were < 100 KB the guard would NOT fire
-    // and we'd overwrite; the test would then assert the file is unchanged but
-    // it wouldn't be, catching the regression). In practice usearch snapshots
-    // with 5 vectors are < 100 KB, so we use a small threshold here to make
-    // the unit test reliable: we force the guard to trigger by manually
-    // checking size logic separately (see next test). This test validates the
-    // end-to-end "non-empty file stays non-empty" contract.
-    drop(populated);
+    // Write a filler file that is larger than the guard threshold.
+    // This simulates a fully-populated on-disk snapshot without needing a
+    // real usearch index file (the guard only checks file size, not content).
+    let filler = vec![0xABu8; POPULATED_SNAPSHOT_THRESHOLD_BYTES as usize + 1];
+    std::fs::write(&path, &filler).expect("write filler");
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().len(),
+        filler.len() as u64,
+        "pre-condition: filler must be written at threshold+1 bytes"
+    );
 
-    // Phase 2: create a FRESH empty store and try to save it to the SAME path.
+    // Create a fresh EMPTY store and attempt to save it over the populated path.
     let empty = UsearchStore::new(4).unwrap();
     assert_eq!(
         empty.len().await.unwrap(),
         0,
         "empty store must have 0 vectors"
     );
-    // The save() call must return Ok(()) — either because the guard fires
-    // (file > 100 KB) or because it proceeds (file <= 100 KB, guard does NOT
-    // fire, overwrite is allowed for small files). Either way the call must not
-    // error.
+
+    // save() must return Ok(()) — the guard fires silently (no propagated error)
+    // so callers can complete shutdown gracefully.
     empty
         .save(&path)
         .await
-        .expect("save on empty store must return Ok()");
+        .expect("save must return Ok(()) even when the guard fires");
 
-    // Verify: the file must still exist regardless.
-    assert!(
-        path.exists(),
-        "hnsw file must still exist after empty save attempt"
+    // THE KEY ASSERTION: the on-disk file must be byte-for-byte unchanged —
+    // the guard preserved the populated snapshot and did NOT overwrite it.
+    let on_disk = std::fs::read(&path).expect("read back hnsw path");
+    assert_eq!(
+        on_disk, filler,
+        "guard must preserve the populated on-disk snapshot byte-for-byte; \
+         if this fails the guard did not fire and the empty index clobbered \
+         the snapshot (issue #1711 regression)"
     );
 }
 

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -352,3 +352,146 @@ async fn test_capacity_growth() {
     }
     assert_eq!(store.len().await.unwrap(), 50);
 }
+
+// ── Issue #1711 regression tests — data-loss guard in save() ─────────────────
+
+/// Why (issue #1711): the data-loss guard in `save()` must refuse to overwrite
+/// a populated on-disk snapshot (> 100 KB) with an empty in-memory index.
+/// This protects against shutdown races where a fresh/promoted-but-empty
+/// UsearchStore saves 0 vectors over a fully-populated on-disk snapshot.
+/// What: saves a 5-vector store to disk, then calls `save()` on a NEW empty
+/// store pointing at the same path. Asserts the on-disk file is unchanged
+/// (not clobbered) and `save()` returns `Ok(())`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_save_refuses_to_overwrite_populated_snapshot_with_empty_index() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw.usearch");
+
+    // Phase 1: create a populated store and persist it.
+    // Use orthogonal unit vectors so all 5 are retained (cosine-safe).
+    let populated = UsearchStore::new(4).unwrap();
+    for i in 0..5u32 {
+        let mut v = vec![0.0f32; 4];
+        v[i as usize % 4] = (i + 1) as f32;
+        populated.upsert(&format!("chunk:{i}"), v).await.unwrap();
+    }
+    populated
+        .save(&path)
+        .await
+        .expect("initial save must succeed");
+    assert!(path.exists(), "hnsw file must exist after save");
+    let _on_disk_size_before = std::fs::metadata(&path).unwrap().len();
+    // The 5-vector snapshot must be well above our 100 KB guard threshold
+    // (usearch serialises graph structure; even tiny HNSW files are > a few KB,
+    // not 100 KB, so we assert > 0 here and the guard's 100 KB threshold is
+    // tested implicitly — if the file were < 100 KB the guard would NOT fire
+    // and we'd overwrite; the test would then assert the file is unchanged but
+    // it wouldn't be, catching the regression). In practice usearch snapshots
+    // with 5 vectors are < 100 KB, so we use a small threshold here to make
+    // the unit test reliable: we force the guard to trigger by manually
+    // checking size logic separately (see next test). This test validates the
+    // end-to-end "non-empty file stays non-empty" contract.
+    drop(populated);
+
+    // Phase 2: create a FRESH empty store and try to save it to the SAME path.
+    let empty = UsearchStore::new(4).unwrap();
+    assert_eq!(
+        empty.len().await.unwrap(),
+        0,
+        "empty store must have 0 vectors"
+    );
+    // The save() call must return Ok(()) — either because the guard fires
+    // (file > 100 KB) or because it proceeds (file <= 100 KB, guard does NOT
+    // fire, overwrite is allowed for small files). Either way the call must not
+    // error.
+    empty
+        .save(&path)
+        .await
+        .expect("save on empty store must return Ok()");
+
+    // Verify: the file must still exist regardless.
+    assert!(
+        path.exists(),
+        "hnsw file must still exist after empty save attempt"
+    );
+}
+
+/// Why (issue #1711): the data-loss guard must NOT block the first-time creation
+/// of an HNSW file when no prior snapshot exists on disk. Saving an empty store
+/// to a new path must create the file normally.
+/// What: constructs an empty store, saves to a path that does not exist yet.
+/// Asserts the file was created and `save()` returned `Ok(())`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_save_does_not_block_first_time_creation() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw_new.usearch");
+
+    // File must not exist before this test.
+    assert!(!path.exists(), "pre-condition: file must not exist");
+
+    let store = UsearchStore::new(4).unwrap();
+    // Save an empty store to a path with no prior snapshot — guard must not fire.
+    store
+        .save(&path)
+        .await
+        .expect("save to new path must succeed even with 0 vectors");
+
+    // The file must have been created.
+    assert!(
+        path.exists(),
+        "hnsw file must be created by first-time save"
+    );
+}
+
+/// Why (issue #1711): the normal happy path must still work — a populated store
+/// must write all its vectors correctly.
+/// What: upserts 3 vectors, saves, loads into a fresh store, asserts all vectors
+/// are present and searchable.
+/// Test: this IS the test (guards against accidental regression of the happy path).
+#[tokio::test]
+async fn test_save_populated_index_writes_correctly() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw_pop.usearch");
+
+    let store = UsearchStore::new(4).unwrap();
+    store
+        .upsert("vec-a", vec![1.0, 0.0, 0.0, 0.0])
+        .await
+        .unwrap();
+    store
+        .upsert("vec-b", vec![0.0, 1.0, 0.0, 0.0])
+        .await
+        .unwrap();
+    store
+        .upsert("vec-c", vec![0.0, 0.0, 1.0, 0.0])
+        .await
+        .unwrap();
+    store
+        .save(&path)
+        .await
+        .expect("save populated store must succeed");
+
+    assert!(path.exists(), "hnsw file must exist");
+    assert!(
+        path.with_extension("keys.json").exists(),
+        "key sidecar must exist"
+    );
+
+    // Reload and verify round-trip.
+    let loaded = UsearchStore::load_from(&path)
+        .await
+        .expect("load ok")
+        .expect("load returned Some");
+    assert_eq!(
+        loaded.len().await.unwrap(),
+        3,
+        "all 3 vectors must survive round-trip"
+    );
+    let hits = loaded.search(&[1.0, 0.0, 0.0, 0.0], 1).await.unwrap();
+    assert_eq!(
+        hits[0].chunk_id, "vec-a",
+        "top hit for vec-a direction must be vec-a"
+    );
+}

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -198,9 +198,13 @@ impl UsearchStore {
     /// locks, then calls usearch's `Index::save(&str)` and writes the sidecar
     /// JSON. Both writes are atomic (tmp + rename) so a crash mid-save never
     /// leaves a partial file. The caller passes the HNSW path; the sidecar is
-    /// written next to it with extension `.keys.json`.
+    /// written next to it with extension `.keys.json`. A data-loss guard
+    /// (issue #1711) refuses to overwrite an on-disk snapshot larger than 100 KB
+    /// when the in-memory index has 0 vectors, preserving the on-disk state.
     /// Test: `tests::test_save_load_roundtrip` saves then loads into a fresh
-    /// store and asserts a search still returns the original chunk_ids.
+    /// store and asserts a search still returns the original chunk_ids;
+    /// `tests::test_save_refuses_to_overwrite_populated_snapshot_with_empty_index`
+    /// covers the #1711 guard.
     pub async fn save(&self, hnsw_path: &Path) -> Result<()> {
         // Fast path: in view mode the in-memory state is a mmap of the
         // on-disk snapshot — there is nothing dirty to flush. Skipping the
@@ -222,6 +226,33 @@ impl UsearchStore {
             // Save was requested to a different path than the view source.
             // Promote first so we can actually write the index out.
             self.ensure_mutable().await?;
+        }
+
+        // Defensive guard (issue #1711): refuse to overwrite a large on-disk
+        // snapshot with an empty in-memory index. This protects against shutdown
+        // races where an uninitialized / just-promoted but not-yet-populated
+        // UsearchStore saves 0 vectors over a fully-populated on-disk snapshot.
+        //
+        // A HNSW file larger than this threshold contains real data; an empty
+        // (0-vector) in-memory index must never clobber it.
+        const POPULATED_SNAPSHOT_THRESHOLD_BYTES: u64 = 100_000; // 100 KB
+        {
+            let in_memory_size = self.index.read().await.size();
+            if in_memory_size == 0 {
+                if let Ok(meta) = std::fs::metadata(hnsw_path) {
+                    if meta.len() > POPULATED_SNAPSHOT_THRESHOLD_BYTES {
+                        tracing::error!(
+                            "usearch: REFUSING to overwrite populated snapshot {} \
+                             ({} bytes on disk) with an empty in-memory index \
+                             (issue #1711 — data-loss guard). \
+                             On-disk snapshot is preserved.",
+                            hnsw_path.display(),
+                            meta.len()
+                        );
+                        return Ok(());
+                    }
+                }
+            }
         }
 
         // Snapshot the key map under read locks so we can release them before

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -40,6 +40,23 @@ pub(super) const INITIAL_CAPACITY: usize = 64;
 /// bound RAM (~6 GB at 1M × 384-dim × 4 bytes plus graph overhead).
 const DEFAULT_HNSW_MAX_ELEMENTS: usize = 1_000_000;
 
+/// Minimum on-disk HNSW snapshot size that is considered "populated" for the
+/// data-loss guard in [`UsearchStore::save`] (issue #1711).
+///
+/// Why: A freshly-created empty HNSW snapshot written by usearch is a few
+/// hundred bytes of header/metadata. A snapshot that contains real vector data
+/// is at minimum several KB of graph structure even for tiny indexes. 100 KB is
+/// a conservative threshold well above any empty snapshot and well below any
+/// snapshot with meaningful data, making it a reliable sentinel for the guard.
+///
+/// Exposed as `pub(super)` so the store tests can reference it without
+/// hard-coding a magic literal.
+///
+/// Caveat: this guard catches only the exact-0-vector case. A non-zero but
+/// catastrophically-partial in-memory index (e.g., mid-reindex 5k of 312k
+/// vectors) would NOT be caught — tracked in issue #1717.
+pub(super) const POPULATED_SNAPSHOT_THRESHOLD_BYTES: u64 = 100_000; // 100 KB
+
 /// Read the HNSW max-elements cap from the environment, with a sane default.
 /// Shared with `TRUSTY_MAX_CHUNKS` so a single knob bounds both the chunk
 /// corpus and the vector store.
@@ -228,38 +245,11 @@ impl UsearchStore {
             self.ensure_mutable().await?;
         }
 
-        // Defensive guard (issue #1711): refuse to overwrite a large on-disk
-        // snapshot with an empty in-memory index. This protects against shutdown
-        // races where an uninitialized / just-promoted but not-yet-populated
-        // UsearchStore saves 0 vectors over a fully-populated on-disk snapshot.
-        //
-        // A HNSW file larger than this threshold contains real data; an empty
-        // (0-vector) in-memory index must never clobber it.
-        const POPULATED_SNAPSHOT_THRESHOLD_BYTES: u64 = 100_000; // 100 KB
-        {
-            let in_memory_size = self.index.read().await.size();
-            if in_memory_size == 0 {
-                if let Ok(meta) = std::fs::metadata(hnsw_path) {
-                    if meta.len() > POPULATED_SNAPSHOT_THRESHOLD_BYTES {
-                        tracing::error!(
-                            "usearch: REFUSING to overwrite populated snapshot {} \
-                             ({} bytes on disk) with an empty in-memory index \
-                             (issue #1711 — data-loss guard). \
-                             On-disk snapshot is preserved.",
-                            hnsw_path.display(),
-                            meta.len()
-                        );
-                        return Ok(());
-                    }
-                }
-            }
-        }
-
         // Snapshot the key map under read locks so we can release them before
         // the (possibly slow) usearch save. The HNSW write lock is required
-        // because usearch's save is `&self` but mutates internal serializer
-        // buffers; treating it as a write-side operation matches the rest of
-        // this store.
+        // below because usearch's save is `&self` but mutates internal
+        // serializer buffers; treating it as a write-side operation matches the
+        // rest of this store.
         let key_map = {
             let id_to_key = self.id_to_key.read().await;
             StoreKeyMap {
@@ -276,12 +266,45 @@ impl UsearchStore {
 
         // usearch's `save` takes a `&str` path. We write to a tmp file and
         // rename so callers never observe a half-written snapshot.
+        //
+        // Defensive guard (issue #1711): refuse to overwrite a large on-disk
+        // snapshot with an empty in-memory index. The check runs UNDER the
+        // same write-lock scope that owns the save, eliminating the TOCTOU
+        // window that existed when the guard used a separate read-lock
+        // acquisition. This protects against shutdown races where an
+        // uninitialized / just-promoted but not-yet-populated UsearchStore
+        // flushes 0 vectors over a fully-populated on-disk snapshot.
+        //
+        // Residual-risk caveat (issue #1717): this guard catches the
+        // exact-0-vector case only. A non-zero but catastrophically-partial
+        // in-memory index (e.g. mid-reindex 5k of 312k vectors) would NOT
+        // be caught — the underlying race (shutdown flushing an in-flight
+        // background reindex from reconcile_stale_indexes / fe4c0b28) is
+        // tracked separately in #1717. This guard is defense-in-depth for
+        // the most acute data-loss path, not a complete fix.
         let tmp_hnsw = hnsw_path.with_extension("usearch.tmp");
         let tmp_hnsw_str = tmp_hnsw
             .to_str()
             .ok_or_else(|| anyhow!("non-utf8 path: {}", tmp_hnsw.display()))?;
         {
             let index = self.index.write().await;
+            // Guard: check size under the write lock so there is no window
+            // between the check and the save call.
+            if index.size() == 0 {
+                if let Ok(meta) = std::fs::metadata(hnsw_path) {
+                    if meta.len() > POPULATED_SNAPSHOT_THRESHOLD_BYTES {
+                        tracing::error!(
+                            "usearch: REFUSING to overwrite populated snapshot {} \
+                             ({} bytes on disk) with an empty in-memory index \
+                             (issue #1711 — data-loss guard). \
+                             On-disk snapshot is preserved.",
+                            hnsw_path.display(),
+                            meta.len()
+                        );
+                        return Ok(());
+                    }
+                }
+            }
             index
                 .save(tmp_hnsw_str)
                 .map_err(|e| anyhow!("usearch save failed: {e}"))?;


### PR DESCRIPTION
## Summary

- **Root cause**: `reconcile_stale_indexes()` introduced in PR #1671 (commit `fe4c0b28`) spawns per-index background tasks that call `trigger_full_reindex()` concurrently. A newly-promoted-but-not-yet-populated `UsearchStore` can race a SIGTERM signal and the shutdown flush path (`flush_all_indexes_on_shutdown`) saves 0 vectors to the on-disk HNSW snapshot, clobbering the fully-populated file.
- **Fix**: add a defensive guard in `UsearchStore::save()` — if the in-memory index has 0 vectors AND the on-disk file is larger than 100 KB, refuse the write, emit `tracing::error!`, and return `Ok(())` preserving the on-disk state.
- **No data path removed**: the guard is additive; all existing happy-path writes (populated → disk, first-time creation of new file) are unaffected.

## Files changed

- `crates/trusty-search/src/core/store/usearch_store.rs` — added `POPULATED_SNAPSHOT_THRESHOLD_BYTES` constant + defensive guard block inside `save()`; updated `save()` doc comment to mention #1711.
- `crates/trusty-search/src/core/store/tests.rs` — three new regression tests: `test_save_refuses_to_overwrite_populated_snapshot_with_empty_index`, `test_save_does_not_block_first_time_creation`, `test_save_populated_index_writes_correctly`.

## Test plan

- [x] `cargo test -p trusty-search -- test_save` — all 6 save tests (3 pre-existing + 3 new) pass
- [x] `cargo test -p trusty-search` — full suite, all tests pass
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — no formatting drift
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations

## LOC Delta

- Added: 178 lines (31 production, 147 test)
- Removed: 2 lines
- Net: +176 lines (test coverage dominates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)