### PR TITLE
chore(security): gitignore code-signing certificate artifacts (refs #873, #1726)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,12 @@ tga.db
 
 # Obsidian editor config (personal)
 .obsidian/
+
+# Code-signing certificate artifacts — never commit (see #873/#1726)
+docs/certificates/*.certSigningRequest
+docs/certificates/*.p12
+docs/certificates/*.cer
+docs/certificates/*.cert
+docs/certificates/*.pem
+docs/certificates/*.key
+docs/certificates/*.mobileprovision


### PR DESCRIPTION
## Summary

Adds `.gitignore` rules so code-signing certificate artifacts under `docs/certificates/` are never accidentally committed.

This supports the Developer ID signing work (#873, #1726). The directory currently holds `CertificateSigningRequest.certSigningRequest`, and during the signing flow it will also hold private keys and certificates (`.p12`, `.cer`, `.cert`, `.pem`, `.key`, `.mobileprovision`) which must **NEVER** be committed.

## Changes

Appended a clearly-commented block to the end of `.gitignore` ignoring certificate artifacts under `docs/certificates/`:

- `*.certSigningRequest` (CSRs)
- `*.p12` / `*.key` (private keys)
- `*.cer` / `*.cert` / `*.pem` (certificates)
- `*.mobileprovision` (provisioning profiles)

## Verification

`git check-ignore -v` confirms the patterns match:

```
.gitignore:72:docs/certificates/*.certSigningRequest	docs/certificates/CertificateSigningRequest.certSigningRequest
.gitignore:73:docs/certificates/*.p12	docs/certificates/DeveloperID.p12
```

Refs #873, #1726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)