### PR TITLE
fix(trusty-mpm): redirect guided-default fallback to managed clone, never live checkout (#1724)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -41,10 +41,10 @@ struct SpawnManagedResponse {
 /// the daemon's in-project spawn path handles reconnect (Active session for the
 /// same `owner/repo` is returned immediately) and new-session creation
 /// (a per-session worktree is provisioned); (3) attaches to the resulting tmux
-/// session name. When the daemon is unreachable or the spawn fails, falls back
-/// to the `tm launch` path so the operator always gets a session.
-/// Test: `guided_default_falls_back_when_daemon_unreachable` in
-/// `tests_behavior_a.rs` (verifies no panic on a refused connection);
+/// session name. When the daemon is unreachable or the spawn fails, delegates
+/// to [`fallback_protected`] which preserves the live-checkout guarantee (#1724).
+/// Test: `guided_fallback_never_pollutes_github_git_checkout` in
+/// `tests_behavior_b_tests.rs` (verifies no framework files in live checkout);
 /// `guided_default_attaches_on_success` (mocked daemon response).
 pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> anyhow::Result<()> {
     // 1. Resolve the current directory.
@@ -82,23 +82,135 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
                 return Ok(());
             }
             Ok(_) => {
-                eprintln!("tm: daemon returned empty session name; falling back to launch");
+                eprintln!("tm: daemon returned empty session name; falling back");
             }
             Err(e) => {
-                eprintln!("tm: failed to parse daemon response ({e}); falling back to launch");
+                eprintln!("tm: failed to parse daemon response ({e}); falling back");
             }
         },
         Ok(r) => {
             eprintln!(
-                "tm: daemon returned {} for managed spawn; falling back to launch",
+                "tm: daemon returned {} for managed spawn; falling back",
                 r.status()
             );
         }
         Err(e) => {
-            eprintln!("tm: daemon unreachable ({e}); falling back to tm launch");
+            eprintln!("tm: daemon unreachable ({e}); falling back");
         }
     }
 
-    // 3. Fallback: run the classic `tm launch` path (framework deploy + attach).
+    // 3. Daemon unreachable or spawn failed — delegate to the protected fallback.
+    //    This NEVER deploys framework files into a GitHub-backed live checkout
+    //    (#1724): GitHub projects are redirected to their managed-clone workspace;
+    //    non-git directories retain the classic `tm launch` behaviour.
+    fallback_protected(client, url, &cwd).await
+}
+
+/// Daemon-unreachable fallback that protects live git checkouts (#1724).
+///
+/// Why: the guided default MUST NOT deploy framework files into a GitHub-backed
+/// git project's live checkout even when the daemon is down. The daemon's
+/// in-project spawn path (#1706) provides this guarantee when the daemon is
+/// running; this function preserves it when the daemon is unreachable.
+/// What: detects whether `cwd` is a GitHub-backed git project. If yes, delegates
+/// to [`redirect_to_managed_clone`] which sets up (or reuses) the protected base
+/// clone and creates a per-session worktree so `launch()` targets THAT workspace,
+/// never the live checkout. Non-GitHub git projects and non-git directories fall
+/// through to the classic `tm launch` path — consistent with the daemon's own
+/// local-path fast path for those cases.
+/// Test: `guided_fallback_never_pollutes_github_git_checkout` in
+/// `tests_behavior_b_tests.rs`.
+pub(crate) async fn fallback_protected(
+    client: &reqwest::Client,
+    url: &str,
+    cwd: &std::path::Path,
+) -> anyhow::Result<()> {
+    // Only GitHub-backed git projects need the managed-clone redirect.
+    // Non-GitHub git projects and non-git directories match the daemon's
+    // local-path fast path and may deploy locally — consistent behaviour.
+    if cwd.join(".git").exists()
+        && let Some(origin_url) = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(cwd)
+        && trusty_common::github_path::parse_github_path(&origin_url).is_some()
+    {
+        // GitHub project: redirect deploy to the protected managed clone.
+        return redirect_to_managed_clone(client, url, cwd, &origin_url).await;
+    }
+
+    // Non-GitHub git project or non-git directory: classic tm launch path.
     super::launch::launch(client, url, None, None).await
+}
+
+/// Redirect the guided-default fallback to the protected managed-clone workspace.
+///
+/// Why: when the daemon is unreachable and the current directory is a GitHub-backed
+/// git project, framework files must go into the managed-clone workspace
+/// (`~/trusty-tools/repos/<owner>/<repo>/worktrees/<session-id>/`), never
+/// into the operator's live checkout (#1724).
+/// What: (1) parses `owner/repo` from `origin_url`; (2) ensures the protected
+/// base clone exists (`ensure_base_clone` is idempotent — returns immediately when
+/// the clone already exists); (3) creates a per-session git worktree inside the
+/// base clone; (4) calls `launch()` with the worktree path as the target directory.
+/// If any step fails (unparseable URL, clone error, worktree error), the function
+/// returns `Err` with an actionable message — the live checkout is never touched.
+/// Test: `guided_fallback_never_pollutes_github_git_checkout`.
+async fn redirect_to_managed_clone(
+    client: &reqwest::Client,
+    url: &str,
+    cwd: &std::path::Path,
+    origin_url: &str,
+) -> anyhow::Result<()> {
+    use trusty_mpm::daemon::managed_routes::inproject;
+    use trusty_mpm::session_manager::ManagedSessionId;
+
+    // Parse owner/repo from the GitHub remote URL.
+    let Some(gh) = trusty_common::github_path::parse_github_path(origin_url) else {
+        eprintln!(
+            "tm: cannot determine GitHub project from remote URL '{origin_url}'.\n\
+             Start the daemon first with `tm start`, then run `tm` again."
+        );
+        anyhow::bail!(
+            "daemon unreachable: cannot parse GitHub remote URL as owner/repo — run `tm start` first"
+        );
+    };
+
+    // Ensure the protected base clone exists. Idempotent: returns Ok immediately
+    // when the clone is already present; clones once on first invocation.
+    let base = inproject::base_clone_path(&gh.owner, &gh.repo);
+    eprintln!(
+        "tm: daemon unreachable — redirecting to protected managed clone\n\
+         tm: base clone: {}",
+        base.display()
+    );
+    if let Err(e) = inproject::ensure_base_clone(origin_url, &base) {
+        eprintln!(
+            "tm: could not set up base clone for {}/{}: {e}\n\
+             Start the daemon first with `tm start`, then run `tm` again.",
+            gh.owner, gh.repo
+        );
+        anyhow::bail!("failed to set up managed base clone: {e}");
+    }
+
+    // Create a per-session worktree branched from the base clone.
+    let session_id = ManagedSessionId::new();
+    let worktree = match inproject::create_session_worktree(&base, &session_id) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "tm: could not create per-session worktree: {e}\n\
+                 Start the daemon first with `tm start`, then run `tm` again."
+            );
+            anyhow::bail!("failed to create session worktree: {e}");
+        }
+    };
+
+    eprintln!(
+        "tm: launching in protected workspace (live checkout at {} is untouched)\n\
+         tm: session worktree: {}",
+        cwd.display(),
+        worktree.display()
+    );
+
+    // Launch in the session worktree — not the live checkout.
+    let dir = worktree.to_string_lossy().to_string();
+    super::launch::launch(client, url, Some(dir), None).await
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -117,6 +117,10 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
 /// What: case-insensitive substring match for `"github.com"` in the raw URL —
 /// catches both HTTPS (`https://github.com/…`) and SSH (`git@github.com:…`)
 /// forms without adding a URL-parsing dependency.
+/// Known limitation: a hostname such as `github.mycompany.com` does NOT match
+/// since `"github.mycompany.com".contains("github.com")` is false. URLs like
+/// `https://notgithub.com/a/b.git` also do not match. Both cases fall through
+/// to the non-GitHub refusal path — safe but not redirected.
 /// Test: `guided_fallback_blocks_non_github_git_checkout` verifies a Gitea URL
 /// is NOT treated as GitHub; `guided_fallback_never_pollutes_github_git_checkout`
 /// verifies a real GitHub URL is recognised.
@@ -124,38 +128,72 @@ fn is_github_remote(url: &str) -> bool {
     url.to_ascii_lowercase().contains("github.com")
 }
 
+/// Detect the git working-tree root at any depth by shelling to git.
+///
+/// Why: `cwd.join(".git").exists()` only fires when `cwd` IS the repo root.
+/// Operators commonly run `tm` from a nested subdirectory (e.g. `~/project/src/`);
+/// the shallow check would miss the repo, bypass the live-checkout guard, and
+/// allow `launch(None)` to write framework files into that subdir (#1724 gap).
+/// What: runs `git -C <cwd> rev-parse --show-toplevel`; returns the absolute
+/// repo root on success, `None` when cwd is not inside any git working tree
+/// (plain directory or bare repo). Bare repos (`--git-dir` succeeds but
+/// `--show-toplevel` does not) are treated as non-git — deploying into a bare
+/// repo has no live-checkout to protect.
+/// Test: `guided_fallback_blocks_github_git_from_subdirectory` calls
+/// `fallback_protected` from a nested subdir and asserts the protection fires.
+fn find_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let root = String::from_utf8_lossy(&out.stdout);
+    let root = root.trim();
+    if root.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(root))
+}
+
 /// Daemon-unreachable fallback that protects ALL live git checkouts (#1724).
 ///
 /// Why: the guided default MUST NOT deploy framework files into ANY git
 /// project's live checkout, even when the daemon is down. The invariant is:
-/// if `.git` is detected, the live working tree is never written to.
+/// if cwd is inside a git working tree (at ANY depth), it is never written to.
 /// What: three-way dispatch on cwd:
-///   (1) GitHub-backed git project → delegate to [`redirect_to_managed_clone`]
-///       which provisions (or reuses) the protected base clone and per-session
-///       worktree, then calls `launch()` against THAT workspace, never the live
-///       checkout.
-///   (2) Non-GitHub git project (non-GitHub remote or no remote) → return an
-///       actionable `Err`; the live checkout is never touched.
-///   (3) Non-git directory (no `.git`) → classic `tm launch` path; there is no
-///       working tree to protect, consistent with the daemon's local-path fast
-///       path for plain directories.
-/// Test: `guided_fallback_never_pollutes_github_git_checkout` and
-/// `guided_fallback_blocks_non_github_git_checkout` in `tests_behavior_b_tests.rs`.
+///   (1) Inside a GitHub-backed git working tree → delegate to
+///       [`redirect_to_managed_clone`] which provisions (or reuses) the protected
+///       base clone and per-session worktree, then calls `launch()` against THAT
+///       workspace, never the live checkout. Uses the repo ROOT (not cwd) to
+///       read the origin remote — correct even from subdirectories.
+///   (2) Inside a non-GitHub git working tree (non-GitHub remote or no remote)
+///       → return an actionable `Err`; the live checkout is never touched.
+///   (3) Not inside any git working tree (plain directory or bare repo) →
+///       classic `tm launch` path; there is no live checkout to protect,
+///       consistent with the daemon's local-path fast path.
+/// Test: `guided_fallback_never_pollutes_github_git_checkout`,
+/// `guided_fallback_blocks_non_github_git_checkout`,
+/// `guided_fallback_blocks_github_git_from_subdirectory`, and
+/// `guided_fallback_redirect_success_worktree_not_live_checkout` in
+/// `tests_behavior_b_tests.rs`.
 pub(crate) async fn fallback_protected(
     client: &reqwest::Client,
     url: &str,
     cwd: &std::path::Path,
 ) -> anyhow::Result<()> {
-    if cwd.join(".git").exists() {
-        // Any git working tree is protected from in-place framework-file
-        // deployment (#1724). Dispatch on remote type:
-        //   • GitHub remote (github.com host) → redirect to managed clone.
-        //   • Non-GitHub remote or no remote   → actionable Err; never deploy.
+    if let Some(git_root) = find_git_root(cwd) {
+        // cwd is inside a git working tree (at any depth) — protect it.
+        // Read the origin remote from the REPO ROOT so subdirectory calls
+        // find the same remote as top-level calls would.
         //
         // NOTE: `parse_github_path` accepts *any* remote URL (not just GitHub);
-        // we therefore check for "github.com" in the URL explicitly rather than
-        // relying on a successful parse alone.
-        let origin_url = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(cwd);
+        // we therefore gate on `is_github_remote` (github.com substring) to
+        // distinguish GitHub from Gitea/GitLab/bare-SSH remotes.
+        let origin_url = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&git_root);
 
         if let Some(ref raw_url) = origin_url
             && is_github_remote(raw_url)
@@ -164,7 +202,7 @@ pub(crate) async fn fallback_protected(
             return redirect_to_managed_clone(client, url, cwd, raw_url).await;
         }
 
-        // Non-GitHub remote or no remote at all: refuse to write to the live tree.
+        // Non-GitHub remote or no remote: refuse to write to the live tree.
         let remote_desc = origin_url.as_deref().unwrap_or("(no remote configured)");
         eprintln!(
             "tm: daemon unreachable — refusing to deploy into live git checkout.\n\
@@ -176,11 +214,11 @@ pub(crate) async fn fallback_protected(
             "daemon unreachable: live git checkout at '{}' is protected — \
              auto-managed clones require a GitHub remote; \
              start the daemon with `tm start` first",
-            cwd.display()
+            git_root.display()
         );
     }
 
-    // Non-git directory: classic tm launch path (no working tree to protect).
+    // Not inside a git working tree: classic tm launch path.
     super::launch::launch(client, url, None, None).await
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -6,8 +6,10 @@
 //! in-project spawn path (#1706) is the right action: it either reconnects to
 //! an existing session for the same project (#1707) or creates a fresh
 //! per-session worktree, then attaches the terminal to it. Outside a git repo
-//! (or when no GitHub remote is found), falling back to `tm launch` (the full
+//! entirely (no `.git` directory), falling back to `tm launch` (the full
 //! framework-deploy path) preserves existing behaviour for non-git directories.
+//! Any git working tree — GitHub-backed or not — is protected from in-place
+//! framework-file deployment (#1724).
 //!
 //! What: [`run_guided_default`] detects the current directory, queries the
 //! managed spawn endpoint, and then attaches the terminal to the resulting
@@ -106,37 +108,79 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
     fallback_protected(client, url, &cwd).await
 }
 
-/// Daemon-unreachable fallback that protects live git checkouts (#1724).
+/// Return true when the remote URL targets github.com (any transport).
 ///
-/// Why: the guided default MUST NOT deploy framework files into a GitHub-backed
-/// git project's live checkout even when the daemon is down. The daemon's
-/// in-project spawn path (#1706) provides this guarantee when the daemon is
-/// running; this function preserves it when the daemon is unreachable.
-/// What: detects whether `cwd` is a GitHub-backed git project. If yes, delegates
-/// to [`redirect_to_managed_clone`] which sets up (or reuses) the protected base
-/// clone and creates a per-session worktree so `launch()` targets THAT workspace,
-/// never the live checkout. Non-GitHub git projects and non-git directories fall
-/// through to the classic `tm launch` path — consistent with the daemon's own
-/// local-path fast path for those cases.
-/// Test: `guided_fallback_never_pollutes_github_git_checkout` in
-/// `tests_behavior_b_tests.rs`.
+/// Why: `parse_github_path` from `trusty-common` accepts *any* git remote URL,
+/// not just GitHub ones. We need a host-specific guard so that non-GitHub git
+/// projects (Gitea, GitLab, bare SSH, etc.) are refused rather than having a
+/// clone attempt made against an unrecognised host (#1724 residual gap).
+/// What: case-insensitive substring match for `"github.com"` in the raw URL —
+/// catches both HTTPS (`https://github.com/…`) and SSH (`git@github.com:…`)
+/// forms without adding a URL-parsing dependency.
+/// Test: `guided_fallback_blocks_non_github_git_checkout` verifies a Gitea URL
+/// is NOT treated as GitHub; `guided_fallback_never_pollutes_github_git_checkout`
+/// verifies a real GitHub URL is recognised.
+fn is_github_remote(url: &str) -> bool {
+    url.to_ascii_lowercase().contains("github.com")
+}
+
+/// Daemon-unreachable fallback that protects ALL live git checkouts (#1724).
+///
+/// Why: the guided default MUST NOT deploy framework files into ANY git
+/// project's live checkout, even when the daemon is down. The invariant is:
+/// if `.git` is detected, the live working tree is never written to.
+/// What: three-way dispatch on cwd:
+///   (1) GitHub-backed git project → delegate to [`redirect_to_managed_clone`]
+///       which provisions (or reuses) the protected base clone and per-session
+///       worktree, then calls `launch()` against THAT workspace, never the live
+///       checkout.
+///   (2) Non-GitHub git project (non-GitHub remote or no remote) → return an
+///       actionable `Err`; the live checkout is never touched.
+///   (3) Non-git directory (no `.git`) → classic `tm launch` path; there is no
+///       working tree to protect, consistent with the daemon's local-path fast
+///       path for plain directories.
+/// Test: `guided_fallback_never_pollutes_github_git_checkout` and
+/// `guided_fallback_blocks_non_github_git_checkout` in `tests_behavior_b_tests.rs`.
 pub(crate) async fn fallback_protected(
     client: &reqwest::Client,
     url: &str,
     cwd: &std::path::Path,
 ) -> anyhow::Result<()> {
-    // Only GitHub-backed git projects need the managed-clone redirect.
-    // Non-GitHub git projects and non-git directories match the daemon's
-    // local-path fast path and may deploy locally — consistent behaviour.
-    if cwd.join(".git").exists()
-        && let Some(origin_url) = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(cwd)
-        && trusty_common::github_path::parse_github_path(&origin_url).is_some()
-    {
-        // GitHub project: redirect deploy to the protected managed clone.
-        return redirect_to_managed_clone(client, url, cwd, &origin_url).await;
+    if cwd.join(".git").exists() {
+        // Any git working tree is protected from in-place framework-file
+        // deployment (#1724). Dispatch on remote type:
+        //   • GitHub remote (github.com host) → redirect to managed clone.
+        //   • Non-GitHub remote or no remote   → actionable Err; never deploy.
+        //
+        // NOTE: `parse_github_path` accepts *any* remote URL (not just GitHub);
+        // we therefore check for "github.com" in the URL explicitly rather than
+        // relying on a successful parse alone.
+        let origin_url = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(cwd);
+
+        if let Some(ref raw_url) = origin_url
+            && is_github_remote(raw_url)
+        {
+            // GitHub project: redirect deploy to the protected managed clone.
+            return redirect_to_managed_clone(client, url, cwd, raw_url).await;
+        }
+
+        // Non-GitHub remote or no remote at all: refuse to write to the live tree.
+        let remote_desc = origin_url.as_deref().unwrap_or("(no remote configured)");
+        eprintln!(
+            "tm: daemon unreachable — refusing to deploy into live git checkout.\n\
+             tm: Auto-protected managed clones require a GitHub remote \
+             (detected remote: {remote_desc}).\n\
+             tm: Start the daemon with `tm start`, then run `tm` again."
+        );
+        anyhow::bail!(
+            "daemon unreachable: live git checkout at '{}' is protected — \
+             auto-managed clones require a GitHub remote; \
+             start the daemon with `tm start` first",
+            cwd.display()
+        );
     }
 
-    // Non-GitHub git project or non-git directory: classic tm launch path.
+    // Non-git directory: classic tm launch path (no working tree to protect).
     super::launch::launch(client, url, None, None).await
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -796,3 +796,118 @@ fn cli_parses_sessctl_list_with_project_and_json() {
         other => panic!("expected sessctl list, got {other:?}"),
     }
 }
+
+// ── Regression tests for #1724 (guided-default fallback pollution guard) ──────
+
+/// Why (#1724): the guided-default fallback MUST NOT deploy framework files
+/// into a GitHub-backed git project's live checkout, even when the daemon is
+/// unreachable. This test locks in that guarantee.
+/// What: creates a temp directory, initialises a git repo inside it, sets a
+/// fake GitHub remote URL, pre-creates a stub base clone (so `ensure_base_clone`
+/// short-circuits without a network call), and calls `fallback_protected`
+/// directly with the daemon set to an unreachable address. Asserts that no
+/// framework files (`.trusty-mpm/`, `CLAUDE.md`, `.mcp.json`, `.claude/`) exist
+/// in the temp directory after the call.
+/// Test: this is the test.
+#[tokio::test]
+async fn guided_fallback_never_pollutes_github_git_checkout() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path();
+
+    // Build a minimal git repository at `project` with a fake GitHub remote.
+    // We use `git init` + `git remote add` so `get_origin_url` (which shells
+    // out to `git config --get remote.origin.url`) returns a parseable URL.
+    let git_init_ok = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(project)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !git_init_ok {
+        // git binary unavailable in this environment; skip gracefully.
+        eprintln!(
+            "guided_fallback_never_pollutes_github_git_checkout: git not available, skipping"
+        );
+        return;
+    }
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/trusty-ci-nonexistent/no-repo-1724.git",
+        ])
+        .current_dir(project)
+        .status();
+
+    // Pre-create a stub base clone so `ensure_base_clone` returns immediately
+    // (it checks `base/.git` and returns Ok when found), avoiding any real
+    // network call. `create_session_worktree` will fail because the stub is
+    // not a real git repository — the error path is the one we want to test.
+    //
+    // SAFETY: env-var mutation is accepted by the project convention (same
+    // pattern as crates/trusty-mpm/src/core/trusty_tools_config.rs tests).
+    // The test mutates TRUSTY_MPM_REPOS_ROOT to a unique tempdir so it does
+    // not conflict with concurrently-running tests on different paths.
+    let repos_root = tempfile::tempdir().unwrap();
+    let fake_base = repos_root
+        .path()
+        .join("trusty-ci-nonexistent")
+        .join("no-repo-1724");
+    std::fs::create_dir_all(fake_base.join(".git")).unwrap();
+
+    let prev = std::env::var(trusty_mpm::daemon::managed_routes::inproject::REPOS_ROOT_ENV).ok();
+    unsafe {
+        std::env::set_var(
+            trusty_mpm::daemon::managed_routes::inproject::REPOS_ROOT_ENV,
+            repos_root.path(),
+        );
+    }
+
+    // Call the protected fallback with an unreachable daemon URL and our fake
+    // git project as the working directory.
+    let client = reqwest::Client::new();
+    let result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", project).await;
+
+    // Restore the env var regardless of the outcome.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(
+                trusty_mpm::daemon::managed_routes::inproject::REPOS_ROOT_ENV,
+                v,
+            ),
+            None => {
+                std::env::remove_var(trusty_mpm::daemon::managed_routes::inproject::REPOS_ROOT_ENV)
+            }
+        }
+    }
+
+    // ── Acceptance criterion (#1724) ─────────────────────────────────────────
+    // None of the framework files that `prepare_session_with_style` writes must
+    // appear inside the live git checkout.
+    assert!(
+        !project.join("CLAUDE.md").exists(),
+        "#1724: CLAUDE.md must NOT be written to the live git checkout"
+    );
+    assert!(
+        !project.join(".mcp.json").exists(),
+        "#1724: .mcp.json must NOT be written to the live git checkout"
+    );
+    assert!(
+        !project.join(".trusty-mpm").exists(),
+        "#1724: .trusty-mpm dir must NOT be created in the live git checkout"
+    );
+    assert!(
+        !project.join(".claude").exists(),
+        "#1724: .claude dir must NOT be created in the live git checkout"
+    );
+
+    // The function must return Err (refused to deploy) rather than silently
+    // falling through to a live-checkout deploy.
+    assert!(
+        result.is_err(),
+        "#1724: fallback must Err rather than deploy to the live checkout; \
+         got Ok which means framework files may have been written"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -911,3 +911,129 @@ async fn guided_fallback_never_pollutes_github_git_checkout() {
          got Ok which means framework files may have been written"
     );
 }
+
+/// Why (#1724 residual gap): the protected-checkout guarantee MUST hold for ANY
+/// git project, not only GitHub-backed ones. A git repo with a non-GitHub remote
+/// (e.g. a Gitea, GitLab, or bare SSH URL) or with NO remote configured must
+/// also be refused — the fallback must return `Err` and leave the live working
+/// tree untouched.
+/// What: inits a real git repo, adds a non-GitHub remote URL, then calls
+/// `fallback_protected` directly. Asserts that the four framework artifacts are
+/// absent and the call returns `Err`.
+/// Test: this is the test.
+#[tokio::test]
+async fn guided_fallback_blocks_non_github_git_checkout() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path();
+
+    // Build a minimal git repo with a non-GitHub (Gitea) remote.
+    let git_init_ok = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(project)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !git_init_ok {
+        eprintln!("guided_fallback_blocks_non_github_git_checkout: git not available, skipping");
+        return;
+    }
+    // Add a non-GitHub remote to confirm it is not parsed as a GitHub project.
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://gitea.example.com/org/repo.git",
+        ])
+        .current_dir(project)
+        .status();
+
+    // Call the protected fallback with an unreachable daemon URL.
+    let client = reqwest::Client::new();
+    let result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", project).await;
+
+    // ── Acceptance criterion (#1724 residual gap) ────────────────────────────
+    // None of the framework files must appear in the live git checkout.
+    assert!(
+        !project.join("CLAUDE.md").exists(),
+        "#1724: CLAUDE.md must NOT be written to a non-GitHub git checkout"
+    );
+    assert!(
+        !project.join(".mcp.json").exists(),
+        "#1724: .mcp.json must NOT be written to a non-GitHub git checkout"
+    );
+    assert!(
+        !project.join(".trusty-mpm").exists(),
+        "#1724: .trusty-mpm dir must NOT be created in a non-GitHub git checkout"
+    );
+    assert!(
+        !project.join(".claude").exists(),
+        "#1724: .claude dir must NOT be created in a non-GitHub git checkout"
+    );
+
+    // The fallback must refuse with Err, not silently deploy.
+    assert!(
+        result.is_err(),
+        "#1724: fallback must Err for non-GitHub git checkout; \
+         got Ok which means framework files may have been deployed"
+    );
+
+    // Verify it's the REFUSAL error, not a network-error from a clone attempt.
+    // If is_github_remote() incorrectly accepts non-GitHub URLs, it would try
+    // to clone from gitea.example.com and fail with a network error instead.
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("auto-managed clones require a GitHub remote")
+            || err_msg.contains("live git checkout"),
+        "#1724: error message must explain the protection; got: {err_msg}"
+    );
+}
+
+/// Why (#1724 non-git path): the protected-checkout guarantee applies only to git
+/// projects. A plain directory (no `.git`) should still reach the classic `tm launch`
+/// path — framework-file deployment into plain dirs is the intended behaviour and
+/// is not in scope of #1724. This test verifies the fallback does NOT blindly block
+/// all directories, only git working trees.
+/// What: creates a temp dir with NO `.git`, calls `fallback_protected`. The classic
+/// path calls `launch()` which will fail to connect to the unreachable daemon URL —
+/// but it must not panic, and must not pretend it's a git-protection refusal.
+/// Test: this is the test.
+#[tokio::test]
+async fn guided_fallback_non_git_dir_reaches_launch_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path();
+
+    // No git init — plain directory.
+    assert!(
+        !project.join(".git").exists(),
+        "test precondition: must NOT be a git repo"
+    );
+
+    // Call the protected fallback with an unreachable daemon URL.
+    let client = reqwest::Client::new();
+    let result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", project).await;
+
+    // The result must be Err (daemon is unreachable so launch() will fail),
+    // but it must NOT be the git-protection refusal error message.
+    assert!(
+        result.is_err(),
+        "non-git fallback must Err (daemon unreachable)"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        !err_msg.contains("live git checkout"),
+        "#1724: non-git dir must NOT hit the git-protection refusal path; got: {err_msg}"
+    );
+    assert!(
+        !err_msg.contains("auto-managed clones require"),
+        "#1724: non-git dir must NOT show GitHub-remote hint; got: {err_msg}"
+    );
+
+    // Framework files must not have been created (daemon was unreachable).
+    assert!(
+        !project.join("CLAUDE.md").exists(),
+        "CLAUDE.md must not exist when daemon is unreachable"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -808,8 +808,9 @@ fn cli_parses_sessctl_list_with_project_and_json() {
 /// directly with the daemon set to an unreachable address. Asserts that no
 /// framework files (`.trusty-mpm/`, `CLAUDE.md`, `.mcp.json`, `.claude/`) exist
 /// in the temp directory after the call.
-/// Test: this is the test.
+/// Test: this is the test. Annotated `serial` because it mutates `TRUSTY_MPM_REPOS_ROOT`.
 #[tokio::test]
+#[serial_test::serial]
 async fn guided_fallback_never_pollutes_github_git_checkout() {
     let dir = tempfile::tempdir().unwrap();
     let project = dir.path();
@@ -1035,5 +1036,209 @@ async fn guided_fallback_non_git_dir_reaches_launch_path() {
     assert!(
         !project.join("CLAUDE.md").exists(),
         "CLAUDE.md must not exist when daemon is unreachable"
+    );
+}
+
+/// Why (#1724 HIGH gap): `fallback_protected` previously used `cwd.join(".git").exists()`
+/// which only fires when `cwd` IS the repo root. Running `tm` from a subdirectory
+/// (e.g. `~/project/src/`) silently bypassed the guard and called `launch(None)`,
+/// resolving to `cwd` and deploying framework files into the live tree. This test
+/// covers that scenario for a GitHub-backed project: the guard must detect the git
+/// repo root at any depth and refuse to deploy.
+/// What: creates a real git repo, creates a nested `src/module/` subdir, and calls
+/// `fallback_protected` from within that subdir. Asserts no framework files appear
+/// anywhere in the repo tree and that the call returns `Err`.
+/// Test: this is the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn guided_fallback_blocks_github_git_from_subdirectory() {
+    let repo_dir = tempfile::tempdir().unwrap();
+    let git_init_ok = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(repo_dir.path())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !git_init_ok {
+        eprintln!("guided_fallback_blocks_github_git_from_subdirectory: git unavailable, skipping");
+        return;
+    }
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/trusty-ci-nonexistent/subdir-test-1724.git",
+        ])
+        .current_dir(repo_dir.path())
+        .status();
+
+    // Run from a NESTED subdirectory inside the repo.
+    let subdir = repo_dir.path().join("src").join("module");
+    std::fs::create_dir_all(&subdir).unwrap();
+
+    let client = reqwest::Client::new();
+    let result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", &subdir).await;
+
+    // ── Acceptance criterion (#1724 HIGH gap) ────────────────────────────────
+    // No framework files must exist anywhere in the repo tree.
+    assert!(
+        !repo_dir.path().join("CLAUDE.md").exists(),
+        "#1724: CLAUDE.md must NOT appear in repo root when called from subdir"
+    );
+    assert!(
+        !subdir.join("CLAUDE.md").exists(),
+        "#1724: CLAUDE.md must NOT appear in the subdir"
+    );
+    assert!(
+        !repo_dir.path().join(".mcp.json").exists(),
+        "#1724: .mcp.json must NOT appear in repo root"
+    );
+    assert!(
+        !subdir.join(".mcp.json").exists(),
+        "#1724: .mcp.json must NOT appear in the subdir"
+    );
+    // The call must return Err (refused or clone attempt failed — not deployed).
+    assert!(
+        result.is_err(),
+        "#1724: fallback from subdir must Err, not deploy to the live tree"
+    );
+}
+
+/// Why (#1724 success path): proves that when `redirect_to_managed_clone` succeeds
+/// (base clone exists as a real git repo so `create_session_worktree` can create a
+/// worktree), `launch()` is called with `Some(worktree)` — not `None` — so
+/// framework files go to the worktree, never to the live checkout.
+/// What: (1) creates a real git base clone (git init + empty commit); (2) sets
+/// `TRUSTY_MPM_REPOS_ROOT` to point at it; (3) creates a live checkout with a
+/// matching GitHub remote; (4) calls `fallback_protected`; (5) asserts live
+/// checkout is clean AND at least one per-session worktree was created under the
+/// base clone (proving `launch(Some(worktree))` was invoked, not `launch(None)`).
+/// Test: this is the test. Annotated `serial` because it mutates `TRUSTY_MPM_REPOS_ROOT`.
+#[tokio::test]
+#[serial_test::serial]
+async fn guided_fallback_redirect_success_worktree_not_live_checkout() {
+    // ── Set up a real git base clone (minimal: init + one empty commit) ──────
+    let repos_root = tempfile::tempdir().unwrap();
+    // Repo path must match parse_github_path("https://github.com/test-owner-1724/test-repo-1724.git")
+    let base = repos_root
+        .path()
+        .join("test-owner-1724")
+        .join("test-repo-1724");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let git_init_ok = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(&base)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !git_init_ok {
+        eprintln!(
+            "guided_fallback_redirect_success_worktree_not_live_checkout: git unavailable, skipping"
+        );
+        return;
+    }
+    // Configure minimal git identity so commit doesn't fail.
+    let _ = std::process::Command::new("git")
+        .args([
+            "-C",
+            base.to_str().unwrap(),
+            "config",
+            "user.email",
+            "ci@test.invalid",
+        ])
+        .status();
+    let _ = std::process::Command::new("git")
+        .args(["-C", base.to_str().unwrap(), "config", "user.name", "CI"])
+        .status();
+    // One empty commit gives us a HEAD branch so `git worktree add` succeeds.
+    let commit_ok = std::process::Command::new("git")
+        .args([
+            "-C",
+            base.to_str().unwrap(),
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !commit_ok {
+        eprintln!(
+            "guided_fallback_redirect_success_worktree_not_live_checkout: git commit failed, skipping"
+        );
+        return;
+    }
+
+    // ── Set up a live checkout with the matching GitHub remote ───────────────
+    let live_dir = tempfile::tempdir().unwrap();
+    let _ = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(live_dir.path())
+        .status();
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner-1724/test-repo-1724.git",
+        ])
+        .current_dir(live_dir.path())
+        .status();
+
+    // ── Point REPOS_ROOT at our temp dir (RAII: restore on scope exit) ───────
+    let repos_root_key = trusty_mpm::daemon::managed_routes::inproject::REPOS_ROOT_ENV;
+    let prev_repos_root = std::env::var(repos_root_key).ok();
+    unsafe { std::env::set_var(repos_root_key, repos_root.path()) };
+
+    let client = reqwest::Client::new();
+    let _result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", live_dir.path())
+            .await;
+
+    // Restore env var immediately (before assertions that might panic).
+    unsafe {
+        match prev_repos_root {
+            Some(ref v) => std::env::set_var(repos_root_key, v),
+            None => std::env::remove_var(repos_root_key),
+        }
+    }
+
+    // ── Acceptance criteria (#1724 success path) ─────────────────────────────
+    // Live checkout must be untouched.
+    assert!(
+        !live_dir.path().join("CLAUDE.md").exists(),
+        "#1724: CLAUDE.md must NOT appear in the live checkout after redirect"
+    );
+    assert!(
+        !live_dir.path().join(".mcp.json").exists(),
+        "#1724: .mcp.json must NOT appear in the live checkout after redirect"
+    );
+    assert!(
+        !live_dir.path().join(".trusty-mpm").exists(),
+        "#1724: .trusty-mpm must NOT be created in the live checkout"
+    );
+    assert!(
+        !live_dir.path().join(".claude").exists(),
+        "#1724: .claude must NOT be created in the live checkout"
+    );
+    // A per-session worktree must have been created inside the base clone,
+    // proving `launch(Some(worktree))` was called, not `launch(None)`.
+    let worktrees_dir = base.join("worktrees");
+    assert!(
+        worktrees_dir.exists(),
+        "#1724: worktrees/ dir must exist under base clone after successful redirect"
+    );
+    let sessions: Vec<_> = std::fs::read_dir(&worktrees_dir)
+        .expect("worktrees dir must be listable")
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(
+        !sessions.is_empty(),
+        "#1724: at least one per-session worktree must be present, proving \
+         launch(Some(worktree)) was invoked rather than launch(None)"
     );
 }


### PR DESCRIPTION
## Summary

- **Bug**: bare `tm` (and guided-default fallback) called `launch(client, url, None, None)` when the daemon was unreachable. `launch()` resolved `None` dir to `env::current_dir()` — the operator's live git checkout — and called `prepare_session_with_style()`, which wrote `.claude/`, `CLAUDE.md`, `.mcp.json`, and `.trusty-mpm/` directly into the live checkout. This violated the protected-clone guarantee from PR #1715.
- **Fix**: `fallback_protected()` (new `pub(crate)` function in `guided.rs`) inspects the current directory. GitHub-backed git projects are redirected to their managed-clone workspace (`~/trusty-tools/repos/<owner>/<repo>/worktrees/<session-id>/`) via the existing `inproject::ensure_base_clone` + `create_session_worktree` infrastructure. `launch()` is then called with the worktree path — never the live checkout. If any step fails, returns `Err` with an actionable message; the live checkout is never touched.
- **Scope preserved**: non-GitHub git projects and non-git directories fall through to the classic `tm launch` path, consistent with the daemon's own local-path fast path.

## Root-cause files and lines

| File | Old line | Problem |
|---|---|---|
| `crates/trusty-mpm/src/bin/tm/commands/guided.rs` | 103 | `super::launch::launch(client, url, None, None).await` — unconditional call with `None` dir resolved to live checkout |

## Changes

- `crates/trusty-mpm/src/bin/tm/commands/guided.rs`: rewrite fallback path to call `fallback_protected()` instead of `launch()` directly; add `fallback_protected` (pub(crate)) and private `redirect_to_managed_clone` helper; full Why/What/Test doc on all public items.
- `crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs`: add `guided_fallback_never_pollutes_github_git_checkout` regression test — `git init` + GitHub remote in tempdir, stub base clone via `TRUSTY_MPM_REPOS_ROOT`, asserts no framework files in live checkout and result is `Err`.

## Verification

```
cargo check -p trusty-mpm                              # passed
cargo clippy -p trusty-mpm --all-targets -- -D warnings # zero warnings
cargo test -p trusty-mpm -- guided_fallback             # 1 passed (new regression test)
cargo fmt --check                                       # no drift
bash scripts/check_line_cap.sh                         # 14 allowlisted, 0 violations — OK
```

## Test plan

- [ ] Run `cargo test -p trusty-mpm -- guided_fallback` — the new regression test must pass
- [ ] Run `cargo test -p trusty-mpm` — 2044+ tests pass; the 3 pre-existing env-dependent failures (`execute_*_against_test_daemon`, `test_mcp_config_review_no_home_write`) are unrelated to this change and fail identically on `main`
- [ ] Manual: `cd` into a GitHub-backed git project, kill the daemon, run `tm` — confirm no `.claude/`, `CLAUDE.md`, `.mcp.json`, or `.trusty-mpm/` appear in the live checkout; the command prints an actionable error
- [ ] Manual: in a non-git directory, same test — `tm launch` path still works as before

closes #1724

🤖 Generated with [Claude Code](https://claude.com/claude-code)