### PR TITLE
fix(trusty-mpm): source_id filter + stale-URL probe for guided-default (#1730 #1731)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -190,9 +190,13 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let client = reqwest::Client::new();
-    // Resolve the daemon URL once: explicit --url/TRUSTY_MPM_URL wins, then
-    // lock file (daemon may bind to an ephemeral port), then default.
-    let url = trusty_mpm::core::resolve_daemon_url(Some(&cli.url));
+    // Resolve the daemon URL once: explicit --url/TRUSTY_MPM_URL wins (but only
+    // when reachable), then lock file (daemon may bind to an ephemeral port),
+    // then default. Using the probing variant prevents a stale TRUSTY_MPM_URL
+    // (e.g. :7881 while the daemon is on :7880) from permanently breaking `tm`
+    // (#1731). Non-default explicit URLs that ARE reachable still win
+    // immediately so `--url http://…:9999` continues to work.
+    let url = trusty_mpm::core::resolve_daemon_url_probing(&client, Some(&cli.url)).await;
     // Why: handlers return `anyhow::Result`; we capture the dispatch result here
     // so the top-level boundary can translate the typed `PruneError::SmUnavailable`
     // (issue #1313) into the documented exit code 75. Doing the `process::exit`

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -370,5 +370,6 @@ fn make_session(
         last_activity_at: last_activity_at.map(str::to_owned),
         pending_decision: None,
         proposed_default: None,
+        source_id: None,
     }
 }

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -354,6 +354,7 @@ fn managed_session_summary_deserializes() {
         "last_activity_at": "2026-06-19T01:00:00Z",
         "pending_decision": "overwrite?",
         "proposed_default": "yes",
+        "source_id": "owner/repo",
     });
     let s: ManagedSessionSummary = serde_json::from_value(json).unwrap();
     assert_eq!(s.id, "00000000-0000-0000-0000-000000000001");
@@ -361,6 +362,8 @@ fn managed_session_summary_deserializes() {
     assert_eq!(s.state, "running");
     assert_eq!(s.created_at.as_deref(), Some("2026-06-19T00:00:00Z"));
     assert_eq!(s.pending_decision.as_deref(), Some("overwrite?"));
+    // source_id round-trips (#1730).
+    assert_eq!(s.source_id.as_deref(), Some("owner/repo"));
 
     // Minimal body: only the always-present fields.
     let lean = serde_json::json!({"id": "x", "name": "n", "state": "stopped"});
@@ -370,6 +373,8 @@ fn managed_session_summary_deserializes() {
     // An absent `created_at` deserializes to `None`, not an empty string.
     assert!(s.created_at.is_none());
     assert!(s.pending_decision.is_none());
+    // An absent `source_id` defaults to None (legacy sessions without it).
+    assert!(s.source_id.is_none());
 }
 
 #[test]

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -394,6 +394,13 @@ pub struct ManagedSessionSummary {
     /// Proposed default answer to the pending decision.
     #[serde(default)]
     pub proposed_default: Option<String>,
+    /// Source project identity (`owner/repo`) for in-project sessions (#1730).
+    ///
+    /// Why: in-project sessions record which GitHub project they belong to so
+    /// callers can filter sessions by project via `?source_id=`. `None` for
+    /// sessions created outside the in-project spawn path.
+    #[serde(default)]
+    pub source_id: Option<String>,
 }
 
 /// Wrapper for `GET /api/v1/sessions/managed` (the list endpoint).

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -180,6 +180,7 @@ mod tests {
             last_activity_at: None,
             pending_decision: None,
             proposed_default: None,
+            source_id: None,
         };
         let items = vec![summary("m-1", "tmpm-red-owl"), summary("m-2", "api")];
         assert_eq!(

--- a/crates/trusty-mpm/src/core/discovery.rs
+++ b/crates/trusty-mpm/src/core/discovery.rs
@@ -155,14 +155,17 @@ pub async fn resolve_daemon_url_probing(
 /// Why: used by `resolve_daemon_url_probing` to validate stale explicit URLs
 /// before committing to them. A 500 ms timeout keeps the probe imperceptible
 /// to the user while still covering slow loopback responses.
-/// What: sends `GET <url>/health`; returns `true` if the response has any 2xx
-/// status, `false` on error (connection refused, timeout, etc.).
+/// What: sends `GET <url>/health` (trailing slash on `url` is stripped first
+/// to avoid the double-slash path `//health`); returns `true` if the response
+/// has any 2xx status, `false` on error (connection refused, timeout, etc.).
 /// Test: `probing_resolver_falls_back_when_explicit_unreachable`,
-/// `probing_resolver_wins_when_explicit_reachable`.
+/// `probing_resolver_wins_when_explicit_reachable`,
+/// `probe_url_trims_trailing_slash`.
 async fn probe_url(client: &reqwest::Client, url: &str) -> bool {
     use std::time::Duration;
+    let base = url.trim_end_matches('/');
     let probe = client
-        .get(format!("{url}/health"))
+        .get(format!("{base}/health"))
         .timeout(Duration::from_millis(500))
         .send()
         .await;
@@ -345,6 +348,52 @@ mod tests {
         assert_eq!(
             result, url,
             "reachable explicit URL must win over lock file / default"
+        );
+    }
+
+    /// Trailing slash on the base URL must not produce a double-slash path.
+    ///
+    /// Why: `probe_url("http://…:PORT/")` previously produced
+    /// `GET http://…:PORT//health` — the double slash could cause 404s on
+    /// strict HTTP servers, making a live daemon appear unreachable. The fix
+    /// trims the trailing slash before appending `/health`.
+    /// What: binds a TCP listener that echoes the request line in its 200
+    /// response body; asserts the captured path is `/health` not `//health`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn probe_url_trims_trailing_slash() {
+        use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("local_addr");
+
+        // Capture the request line so we can assert on the path.
+        let (path_tx, path_rx) = tokio::sync::oneshot::channel::<String>();
+        tokio::spawn(async move {
+            if let Ok((sock, _)) = listener.accept().await {
+                let (reader, mut writer) = sock.into_split();
+                let mut lines = BufReader::new(reader).lines();
+                // First line is the request line, e.g. "GET /health HTTP/1.1"
+                let req_line = lines.next_line().await.unwrap().unwrap_or_default();
+                let _ = path_tx.send(req_line);
+                let _ = writer
+                    .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+                    .await;
+            }
+        });
+
+        let client = reqwest::Client::new();
+        // URL with trailing slash — must probe `/health`, not `//health`.
+        let url_with_slash = format!("http://{addr}/");
+        probe_url(&client, &url_with_slash).await;
+
+        let req_line = path_rx.await.expect("request line captured");
+        // The path segment must be exactly "/health" with no double slash.
+        assert!(
+            req_line.starts_with("GET /health "),
+            "probe must request /health (no double slash); got: {req_line:?}"
         );
     }
 }

--- a/crates/trusty-mpm/src/core/discovery.rs
+++ b/crates/trusty-mpm/src/core/discovery.rs
@@ -102,6 +102,73 @@ pub fn resolve_daemon_url(explicit: Option<&str>) -> String {
         .to_string()
 }
 
+/// Resolve the daemon URL with reachability probing for explicit overrides.
+///
+/// Why: `resolve_daemon_url` treats an explicit non-default URL (e.g. a stale
+/// `TRUSTY_MPM_URL=http://127.0.0.1:7881`) as unconditionally winning, even
+/// when the daemon is no longer listening there. A stale env var therefore
+/// permanently breaks `tm` guided-default until the env is corrected, because
+/// the lock file (which records the daemon's actual bound address) is never
+/// consulted (#1731). This async variant probes the explicit URL before
+/// committing to it; on failure it falls through to the lock file and then
+/// the compiled-in default — exactly the fallback chain users expect.
+/// What: follows the same three-step priority order as `resolve_daemon_url`,
+/// but step 1 is gated on a 500 ms health probe.
+///
+/// 1. `explicit` (non-empty, non-default) — accepted only if reachable
+/// 2. Lock file `~/.trusty-mpm/daemon.lock` (if present and PID alive)
+/// 3. `DEFAULT_DAEMON_URL`
+///
+/// A reachable explicit URL wins immediately without consulting the lock file
+/// so a deliberately non-default daemon address (`--url http://…:9999`) still
+/// works.
+/// Test: `probing_resolver_falls_back_when_explicit_unreachable` and
+/// `probing_resolver_wins_when_explicit_reachable` below.
+pub async fn resolve_daemon_url_probing(
+    client: &reqwest::Client,
+    explicit: Option<&str>,
+) -> String {
+    // Step 1: if the caller supplied a real override (non-empty, non-default),
+    // probe it.  Only skip the probe when the "explicit" URL is actually the
+    // clap-injected default — identical behaviour to resolve_daemon_url so
+    // callers that pass DEFAULT_DAEMON_URL always see the lock file win.
+    if let Some(url) = explicit
+        && !url.is_empty()
+        && url != DEFAULT_DAEMON_URL
+    {
+        if probe_url(client, url).await {
+            return url.to_string();
+        }
+        // Probe failed: fall through to lock file, then hard default.
+        if let Some(lock_url) = read_lock_file_url() {
+            return lock_url;
+        }
+        return DEFAULT_DAEMON_URL.to_string();
+    }
+
+    // No real explicit override: delegate to the sync resolver.
+    resolve_daemon_url(explicit)
+}
+
+/// Probe a URL for reachability with a short timeout.
+///
+/// Why: used by `resolve_daemon_url_probing` to validate stale explicit URLs
+/// before committing to them. A 500 ms timeout keeps the probe imperceptible
+/// to the user while still covering slow loopback responses.
+/// What: sends `GET <url>/health`; returns `true` if the response has any 2xx
+/// status, `false` on error (connection refused, timeout, etc.).
+/// Test: `probing_resolver_falls_back_when_explicit_unreachable`,
+/// `probing_resolver_wins_when_explicit_reachable`.
+async fn probe_url(client: &reqwest::Client, url: &str) -> bool {
+    use std::time::Duration;
+    let probe = client
+        .get(format!("{url}/health"))
+        .timeout(Duration::from_millis(500))
+        .send()
+        .await;
+    probe.map(|r| r.status().is_success()).unwrap_or(false)
+}
+
 /// Read the daemon URL from the lock file if present and the PID is alive.
 fn read_lock_file_url() -> Option<String> {
     let path = lock_file_path();
@@ -209,6 +276,75 @@ mod tests {
         assert_eq!(
             path.parent().and_then(|p| p.file_name()),
             Some(std::ffi::OsStr::new(FRAMEWORK_DIR_NAME))
+        );
+    }
+
+    // ── resolve_daemon_url_probing tests (#1731) ─────────────────────────────
+
+    /// Stale explicit URL (unreachable) falls back to lock file or default (#1731).
+    ///
+    /// Why: `TRUSTY_MPM_URL=http://127.0.0.1:1` is never reachable (port 1 is
+    /// reserved and never listening). The probing resolver must skip it and
+    /// return either the lock-file URL (if the daemon is running and has written
+    /// one) or `DEFAULT_DAEMON_URL` — never the unreachable stale value.
+    /// What: calls `resolve_daemon_url_probing` with the reserved port; asserts
+    /// the result is a valid HTTP URL that is NOT the stale value.
+    /// Test: this test.
+    #[tokio::test]
+    async fn probing_resolver_falls_back_when_explicit_unreachable() {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(200))
+            .build()
+            .expect("build client");
+        let stale = "http://127.0.0.1:1"; // port 1 is reserved, always refused
+        let result = resolve_daemon_url_probing(&client, Some(stale)).await;
+        // Must return a valid HTTP URL.
+        assert!(
+            result.starts_with("http"),
+            "expected HTTP URL, got: {result}"
+        );
+        // Must NOT lock onto the unreachable stale URL.
+        assert_ne!(
+            result, stale,
+            "probing resolver must not return the unreachable stale URL"
+        );
+    }
+
+    /// Reachable explicit URL wins immediately, lock file is not consulted (#1731).
+    ///
+    /// Why: a deliberately non-default URL (`--url http://…:9999`) must still
+    /// win when the daemon is reachable at that address. The probe must not
+    /// cause a regression for the `tm --url <custom>` workflow.
+    /// What: binds a minimal TCP listener that responds with HTTP 200 on any
+    /// connection, calls `resolve_daemon_url_probing` with that address, and
+    /// asserts the result equals the listener's address.
+    /// Test: this test.
+    #[tokio::test]
+    async fn probing_resolver_wins_when_explicit_reachable() {
+        use tokio::io::AsyncWriteExt as _;
+
+        // Bind to an ephemeral port and respond HTTP 200 to the first connection.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("local_addr");
+        let url = format!("http://{addr}");
+
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                // A minimal HTTP/1.1 200 response is enough for reqwest to
+                // call `r.status().is_success()`.
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+                    .await;
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let result = resolve_daemon_url_probing(&client, Some(&url)).await;
+        assert_eq!(
+            result, url,
+            "reachable explicit URL must win over lock file / default"
         );
     }
 }

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -63,6 +63,6 @@ pub mod workspace_scan;
 pub use connect::{ResolveResult, SessionSummary, resolve_target};
 pub use discovery::{
     DEFAULT_DAEMON_ADDR, DEFAULT_DAEMON_URL, default_daemon_addr, lock_file_path,
-    resolve_daemon_url,
+    resolve_daemon_url, resolve_daemon_url_probing,
 };
 pub use error::{Error, Result};

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -1167,3 +1167,147 @@ async fn prune_route_rejects_bad_state() {
         "an unknown prune filter must yield 400"
     );
 }
+
+// ── #1730: list_managed_sessions ?source_id= filter + serialization ───────────
+//
+// These tests call `list_managed_sessions` directly (same axum-extractor pattern
+// as the prune route tests above) against a hermetic `DaemonState`.  Two sessions
+// are seeded: one with `source_id = "owner/repo"` (set via `set_source_id`) and
+// one plain session with no source_id.  The three filter branches are exercised:
+// known source_id → only matching session; unknown source_id → empty; no param →
+// all sessions.  A fourth assertion checks the JSON payload carries `source_id`.
+
+/// Managed-session list: `?source_id=` filter returns only matching sessions (#1730).
+///
+/// Why: the `GET /api/v1/sessions/managed?source_id=owner/repo` endpoint must
+/// return ONLY sessions bound to that project. Without correct serialization +
+/// server-side filter, `tm` guided-default shows sessions from other repos or
+/// returns none for a fabricated source_id.
+/// What: seeds one in-project session (source_id="owner/repo") and one plain
+/// session (no source_id), then asserts three filter variants: known source_id
+/// returns one matching session, unknown source_id returns zero, absent param
+/// returns at least both seeded sessions. A fourth check asserts the `source_id`
+/// field is present in the serialized JSON payload.
+/// NOTE: `DaemonState::with_root` calls `reconcile_on_boot` which may adopt live
+/// host `tmpm-*` sessions (source_id=None) into the temp store. Adopted external
+/// sessions have `source_id=None` so they cannot contaminate Cases 1 or 2 (which
+/// filter by a specific/non-existent source_id). Case 3 therefore asserts >= 2
+/// rather than == 2 to be host-environment-agnostic.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn list_managed_sessions_source_id_filter() {
+    use std::collections::HashMap;
+    use trusty_mpm::daemon::managed_routes::list_managed_sessions;
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root(root.path().to_path_buf()));
+    let mgr = state.session_manager().await;
+
+    // Session A: in-project session — source_id will be set to "owner/repo".
+    let id_a = ResumeSessionId::new();
+    let ws_a = root.path().join(format!("{id_a}-src-filter-a"));
+    let rec_a = mgr
+        .create_with_id(
+            id_a,
+            "source-id-filter-test-a".to_string(),
+            Some(ws_a.clone()),
+            None,
+            Some(ws_a),
+            Some("https://github.com/owner/repo".to_string()),
+            Some("main".to_string()),
+            ResumeRuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session A");
+    mgr.set_source_id(&id_a, "owner/repo")
+        .await
+        .expect("set source_id on session A");
+    let _reap_a = reap_on_drop(&state, &rec_a.tmux_name).await;
+
+    // Session B: plain session — no source_id set.
+    let id_b = ResumeSessionId::new();
+    let ws_b = root.path().join(format!("{id_b}-src-filter-b"));
+    let rec_b = mgr
+        .create_with_id(
+            id_b,
+            "source-id-filter-test-b".to_string(),
+            Some(ws_b.clone()),
+            None,
+            Some(ws_b),
+            Some("https://github.com/other/lib".to_string()),
+            Some("main".to_string()),
+            ResumeRuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session B");
+    let _reap_b = reap_on_drop(&state, &rec_b.tmux_name).await;
+
+    // ── Case 1: known source_id → only session A is returned ─────────────────
+    // External adopted sessions have source_id=None so they never match.
+    let q = HashMap::from([("source_id".to_string(), "owner/repo".to_string())]);
+    let (status, body) = decode_response(
+        list_managed_sessions(axum::extract::State(state.clone()), axum::extract::Query(q)).await,
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let sessions = body["sessions"].as_array().expect("sessions array");
+    assert_eq!(
+        sessions.len(),
+        1,
+        "known source_id must return exactly one session, got {body}"
+    );
+    assert_eq!(
+        sessions[0]["id"].as_str(),
+        Some(id_a.to_string().as_str()),
+        "the returned session must be session A"
+    );
+    // source_id must be present in the JSON payload (#1730).
+    assert_eq!(
+        sessions[0]["source_id"].as_str(),
+        Some("owner/repo"),
+        "source_id must be serialized in the session payload"
+    );
+
+    // ── Case 2: unknown source_id → empty list ────────────────────────────────
+    // External adopted sessions also have source_id=None so they don't contaminate.
+    let q = HashMap::from([("source_id".to_string(), "totally/random-xyz".to_string())]);
+    let (status, body) = decode_response(
+        list_managed_sessions(axum::extract::State(state.clone()), axum::extract::Query(q)).await,
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let sessions = body["sessions"].as_array().expect("sessions array");
+    assert_eq!(
+        sessions.len(),
+        0,
+        "unknown source_id must return an empty list, got {body}"
+    );
+
+    // ── Case 3: no ?source_id param → at least both seeded sessions returned ──
+    // May include external tmux sessions adopted by reconcile_on_boot on the host.
+    let q: HashMap<String, String> = HashMap::new();
+    let (status, body) = decode_response(
+        list_managed_sessions(axum::extract::State(state.clone()), axum::extract::Query(q)).await,
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let sessions = body["sessions"].as_array().expect("sessions array");
+    assert!(
+        sessions.len() >= 2,
+        "no source_id param must return at least the two seeded sessions, got {body}"
+    );
+    // Both seeded session IDs must appear in the unfiltered list.
+    let ids: Vec<&str> = sessions.iter().filter_map(|s| s["id"].as_str()).collect();
+    assert!(
+        ids.contains(&id_a.to_string().as_str()),
+        "session A must appear in unfiltered list; ids={ids:?}"
+    );
+    assert!(
+        ids.contains(&id_b.to_string().as_str()),
+        "session B must appear in unfiltered list; ids={ids:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Two daemon-side fixes found by the runtime smoke test of PR #1729 (guided-default session picker, epic #1590/#1705).

### Fix #1730 — managed-list endpoint ignores `?source_id=` filter

**Root cause:** The server-side filter and `SessionSummary.source_id` serialization were already correct. The missing piece was `ManagedSessionSummary` (the _client_ type in `client/http_client/types.rs`) — it lacked the `source_id` field, so the JSON value sent by the daemon was silently discarded. `tm` guided-default therefore always saw every session as having no project identity and could never filter by `?source_id=owner/repo`.

**Changes:**
- Add `source_id: Option<String>` with `#[serde(default)]` to `ManagedSessionSummary` (mirrors `daemon::managed_routes::SessionSummary` field-for-field).
- Fix two struct-literal initialisers that required the new field (`resolver.rs`, `tests_behavior_c_tests.rs`).
- Update `managed_session_summary_deserializes` to assert the field round-trips and defaults to `None` on legacy responses.
- Add `list_managed_sessions_source_id_filter` integration test (3 cases: known source_id → 1 result; unknown source_id → empty; no param → all sessions).

### Fix #1731 — stale `TRUSTY_MPM_URL` breaks `tm` permanently

**Root cause:** `resolve_daemon_url` treated any explicit non-default URL unconditionally (no reachability check). A stale `TRUSTY_MPM_URL=http://127.0.0.1:7881` in the environment bypassed the lock-file read entirely, pointing `tm` at a dead port. The daemon already writes `~/.trusty-mpm/daemon.lock` at startup with the actual bound URL; the bug was purely in the client-side resolution logic.

**Changes:**
- Add `resolve_daemon_url_probing(client, explicit) -> String` (async) in `core/discovery.rs` — same three-step precedence as the sync variant, but the explicit override is accepted only after a 500 ms `GET /health` probe; on failure it falls through to the lock file then `DEFAULT_DAEMON_URL`.
- Wire into `bin/tm/main.rs` primary URL resolution so all `tm` subcommands benefit.
- Add two unit tests: `probing_resolver_falls_back_when_explicit_unreachable` (port 1, always refused) and `probing_resolver_wins_when_explicit_reachable` (minimal tokio TCP listener responding HTTP 200).

## Test plan

- [ ] `cargo test -p trusty-mpm -- list_managed_sessions_source_id_filter` passes
- [ ] `cargo test -p trusty-mpm -- managed_session_summary_deserializes` passes
- [ ] `cargo test -p trusty-mpm -- probing_resolver_falls_back_when_explicit_unreachable probing_resolver_wins_when_explicit_reachable` passes
- [ ] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` zero warnings
- [ ] `cargo fmt --check -p trusty-mpm` no drift
- [ ] `bash scripts/check_line_cap.sh` passes (0 violations)
- [ ] Manual: set `TRUSTY_MPM_URL=http://127.0.0.1:7881` with daemon on :7880, run `tm` — should now show the session picker (not the protected fallback)
- [ ] Manual: `GET /api/v1/sessions/managed?source_id=owner/repo` returns only in-project sessions with `source_id` field in JSON payload

Closes #1730, closes #1731, refs #1705, refs #1590

🤖 Generated with [Claude Code](https://claude.com/claude-code)