### PR TITLE
fix(trusty-mpm): include source_id in record_to_json to match record_to_summary (closes #1733)

### DIFF
--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -320,9 +320,13 @@ pub struct ActivityResponse {
 ///
 /// Why: the MCP tools return JSON values (not axum responses); reusing the same
 /// field set as [`SpawnResponse`]/[`SessionSummary`] keeps the MCP and HTTP
-/// payloads consistent for the driver skill.
-/// What: maps the record to a JSON object including the derived `attach_cmd`.
-/// Test: covered by `crate::daemon::mcp_session` tests that assert echoed fields.
+/// payloads consistent for the driver skill. `source_id` is included so MCP
+/// callers can filter or reconnect by project identity, matching what the HTTP
+/// `GET /api/v1/sessions/managed` path already exposes (#1733).
+/// What: maps the record to a JSON object including the derived `attach_cmd`
+/// and `source_id` (null when the session has no project identity).
+/// Test: `serializers_include_source_id` unit test in this module; also covered
+/// by `crate::daemon::mcp_session` tests that assert echoed fields.
 pub fn record_to_json(r: &SessionRecord) -> serde_json::Value {
     serde_json::json!({
         "id": r.id.to_string(),
@@ -337,6 +341,7 @@ pub fn record_to_json(r: &SessionRecord) -> serde_json::Value {
         "runtime": r.runtime.as_str(),
         "pending_decision": r.pending_decision,
         "proposed_default": r.proposed_default,
+        "source_id": r.source_id,
     })
 }
 
@@ -883,3 +888,6 @@ pub async fn get_session_activity(
     })
     .into_response()
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -1,0 +1,85 @@
+//! Unit tests for managed-routes serializers.
+//!
+//! Why: isolating these tests into a `tests.rs` sibling keeps the production
+//! file under the 500-SLOC cap while giving the test module the generous
+//! 1500-SLOC budget.
+//! What: focused assertions on `record_to_json` and `record_to_summary`.
+//! Test: this file.
+
+use std::path::PathBuf;
+
+use chrono::Utc;
+
+use super::{record_to_json, record_to_summary};
+use crate::session_manager::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// Build a minimal [`SessionRecord`] suitable for serialization tests.
+fn make_record(source_id: Option<&str>) -> SessionRecord {
+    SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: "tmpm-test-session".into(),
+        cwd: PathBuf::from("/tmp/test"),
+        task: "test task".into(),
+        state: ManagedSessionState::Active,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: None,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        workspace_owned: false,
+        source_id: source_id.map(String::from),
+    }
+}
+
+/// Why: both the MCP path (`record_to_json`) and the HTTP path
+/// (`record_to_summary`) must expose `source_id` so callers on either
+/// transport can filter or reconnect by project identity (#1733).
+/// What: asserts that a record with `source_id = Some("owner/repo")` is
+/// reflected by both serializers, and that a record with `source_id = None`
+/// serializes as JSON `null` from `record_to_json` and as `None` from
+/// `record_to_summary`.
+/// Test: this test.
+#[test]
+fn serializers_include_source_id() {
+    // ── Case 1: source_id is set ──────────────────────────────────────────
+    let r = make_record(Some("owner/repo"));
+
+    // record_to_json (MCP path) must include source_id as a string.
+    let json = record_to_json(&r);
+    assert_eq!(
+        json["source_id"].as_str(),
+        Some("owner/repo"),
+        "record_to_json must serialize source_id when present"
+    );
+
+    // record_to_summary (HTTP path) must include source_id.
+    let summary = record_to_summary(&r);
+    assert_eq!(
+        summary.source_id.as_deref(),
+        Some("owner/repo"),
+        "record_to_summary must include source_id when present"
+    );
+
+    // ── Case 2: source_id is None ─────────────────────────────────────────
+    let r_none = make_record(None);
+
+    // record_to_json must serialize source_id as JSON null, not omit it.
+    let json_none = record_to_json(&r_none);
+    assert!(
+        json_none["source_id"].is_null(),
+        "record_to_json must serialize source_id as null when absent, got {:?}",
+        json_none["source_id"]
+    );
+
+    // record_to_summary must carry None.
+    let summary_none = record_to_summary(&r_none);
+    assert_eq!(
+        summary_none.source_id, None,
+        "record_to_summary must carry None source_id when absent"
+    );
+}


### PR DESCRIPTION
## Summary

- `record_to_json` (the MCP serializer for `session_list`, `session_new`, `session_stop`, etc.) was missing `source_id` while the sibling HTTP serializer `record_to_summary` already included it — MCP callers listing managed sessions could not see a session's project identity, breaking the guided `tm` picker from #1730/#1705.
- Added `"source_id": r.source_id` to the `serde_json::json!` block in `record_to_json`; serializes as a JSON string when set, `null` when None — matching `record_to_summary` exactly.
- Added a unit test (`daemon::managed_routes::tests::serializers_include_source_id`) asserting both serializers include `source_id` when present and serialize `null` consistently when absent.

## Test plan

- [ ] `cargo test -p trusty-mpm -- serializers_include_source_id` → `ok` (new test)
- [ ] `cargo test -p trusty-mpm` → 2049 passed, 2 pre-existing local-env failures (`client::executor::tests`) unchanged, 0 new failures
- [ ] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → clean
- [ ] `cargo fmt --check` → clean
- [ ] `bash scripts/check_line_cap.sh` → `14 allowlisted, 0 violations — OK`

Refs: #1730, #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)