### PR TITLE
fix(trusty-mpm): hermetic test isolation for managed-session & prune-idle tests (closes #1734)

### DIFF
--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -5,16 +5,20 @@ use std::future::IntoFuture;
 ///
 /// Why: lets the executor be tested against the genuine daemon routes
 /// without a live daemon, tmux, or external network.
-/// What: builds `api::router(DaemonState::shared())`, binds an ephemeral
-/// port, serves it on a background task, and returns the state plus base URL.
+/// What: builds `api::router(DaemonState::with_root_isolated_managed(...))`,
+/// binds an ephemeral port, serves it on a background task, and returns the
+/// state plus base URL. The managed-session store is rooted in a throwaway
+/// temp directory and backed by a no-op tmux driver so `reconcile_on_boot`
+/// never adopts the operator's live `tmpm-*` sessions into the test store
+/// (#1734). The framework root (pairing, audit log) is also pointed at the
+/// temp dir so tests never read or write the operator's real `~/.trusty-mpm`.
 /// Test: used by the `execute_*` tests below.
 async fn spawn_test_daemon() -> (std::sync::Arc<crate::daemon::state::DaemonState>, String) {
     use crate::daemon::{api, state::DaemonState};
-    // Root the daemon's persisted state at a throwaway temp directory so
-    // pairing tests never read (or write) the operator's real pairing
-    // record. `keep` leaks the directory so it outlives the server task.
+    // `keep` converts TempDir into a PathBuf that persists beyond this scope
+    // so the directory outlives the background server task.
     let root = tempfile::tempdir().unwrap().keep();
-    let state = std::sync::Arc::new(DaemonState::with_root(root));
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root).await);
     let router = api::router(std::sync::Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -535,6 +535,40 @@ impl DaemonState {
         state
     }
 
+    /// Construct test state whose managed sessions use a no-op tmux driver (#1734).
+    ///
+    /// Why: tests that exercise the managed-session API surface (health, managed-list,
+    /// etc.) must not pick up the operator's live tmux sessions. The lazy
+    /// `session_manager()` initialiser calls `RealTmuxDriver::discover()` followed by
+    /// `reconcile_on_boot`, which adopts any `tmpm-*` sessions from the host into the
+    /// store — breaking assertions that expect an empty list on a developer machine
+    /// that has real managed sessions. Pre-seeding the `managed_sessions` OnceCell
+    /// here with a `NoopTmuxDriver`-backed manager prevents that: the cell is already
+    /// full when the first request arrives so `session_manager()` returns the
+    /// pre-built instance without ever calling the real tmux binary or reading the
+    /// operator's `sessions.json`.
+    /// What: calls `with_root(root.clone())` for an isolated framework root (pairing,
+    /// audit log, optimizer — all under the temp dir), then builds a `SessionManager`
+    /// over `root/session-manager` with `NoopTmuxDriver` and pre-seeds the
+    /// `managed_sessions` OnceCell before any request fires.
+    /// Test: `execute_health_against_test_daemon`,
+    /// `execute_managed_list_against_test_daemon` in `client::executor::tests`.
+    #[cfg(test)]
+    pub async fn with_root_isolated_managed(root: std::path::PathBuf) -> Self {
+        use crate::session_manager::SessionManager;
+        use crate::session_manager::real_tmux::NoopTmuxDriver;
+        let data_dir = root.join("session-manager");
+        let _ = tokio::fs::create_dir_all(&data_dir).await;
+        let noop_tmux: std::sync::Arc<dyn crate::session_manager::ManagedTmuxDriver> =
+            std::sync::Arc::new(NoopTmuxDriver);
+        let mgr = SessionManager::new(&data_dir, noop_tmux)
+            .await
+            .expect("temp-dir noop session store must load");
+        let state = Self::with_root(root);
+        let _ = state.managed_sessions.set(std::sync::Arc::new(mgr));
+        state
+    }
+
     /// Inject a pre-built Session Manager agent for testing the SM endpoint path.
     ///
     /// Why: the `coordinator/chat` SM-path tests (SM-7) need a `DaemonState`

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -940,10 +940,26 @@ async fn front_gate_answer_unblocks_spawn() {
 /// What: spawns `tm --url http://127.0.0.1:<dead> sessions prune-idle --json` and
 /// asserts the process exits with status code 75. Uses `CARGO_BIN_EXE_tm`
 /// (set by Cargo for integration tests) so no extra dev-dependency is needed.
+/// A hermetic HOME is planted with a lock file that anchors the lock-file
+/// fallback in `resolve_daemon_url_probing` (#1731) to the same dead port,
+/// preventing a live daemon on the default port from intercepting resolution.
 /// Test: this test.
 #[test]
 fn cli_prune_idle_unreachable_exit_code() {
     use std::process::Command;
+
+    // Plant a hermetic HOME so `resolve_daemon_url_probing` (#1731) cannot fall
+    // back to a real daemon's `~/.trusty-mpm/daemon.lock`. The fake lock file
+    // points at the same dead port with our PID (alive) so the staleness check
+    // in `read_lock_file_url` passes and the file is not silently discarded.
+    let fake_home = tempfile::tempdir().expect("create temp home");
+    let lock_dir = fake_home.path().join(".trusty-mpm");
+    std::fs::create_dir_all(&lock_dir).expect("create .trusty-mpm under fake HOME");
+    let lock_content = format!(
+        "addr = \"http://127.0.0.1:1\"\npid = {}\n",
+        std::process::id()
+    );
+    std::fs::write(lock_dir.join("daemon.lock"), &lock_content).expect("write fake daemon.lock");
 
     // 127.0.0.1:1 is a reserved/dead port: connecting there fails fast with a
     // transport error, which is exactly the SM-unavailable (exit 75) path.
@@ -956,6 +972,7 @@ fn cli_prune_idle_unreachable_exit_code() {
             "prune-idle",
             "--json",
         ])
+        .env("HOME", fake_home.path())
         .output()
         .expect("spawn tm binary");
 


### PR DESCRIPTION
## Summary

Two independent test-isolation failures on developer machines with live tmux/daemon state, both now fixed with no production behavior changes:

- **`execute_health_against_test_daemon` / `execute_managed_list_against_test_daemon`** (#1734): The in-test daemon used `DaemonState::with_root(tempdir)` which left the `managed_sessions` `OnceCell` uninitialized. The first request lazily called `RealTmuxDriver::discover()` + `reconcile_on_boot()`, adopting all live `tmpm-*` tmux sessions (3 on this machine) into the empty store and breaking `assert_eq!(managed_total, 0)`.

  Fix: added `DaemonState::with_root_isolated_managed(root).await` (test-only, `#[cfg(test)]`) that pre-seeds the `managed_sessions` cell with a `NoopTmuxDriver`-backed `SessionManager` before any request fires.

- **`cli_prune_idle_unreachable_exit_code`**: The test passes `--url http://127.0.0.1:1` to the `tm` binary. With the `resolve_daemon_url_probing` fallback introduced in #1731, a failed probe on port 1 fell through to `~/.trusty-mpm/daemon.lock` — which on this machine points to a live daemon at port 7880. The binary connected to the real daemon, got 200, and exited 0 instead of the expected 75.

  Fix: the test now plants a hermetic `HOME` containing `.trusty-mpm/daemon.lock` with `addr = "http://127.0.0.1:1"` and the test runner's own PID. The staleness check (`kill(pid, 0)`) passes (our process is alive), so the lock-file fallback returns the same dead URL, keeping the full resolution chain isolated from any real daemon.

## Test plan

- [x] `cargo test -p trusty-mpm -- execute_health_against_test_daemon execute_managed_list_against_test_daemon cli_prune_idle_unreachable_exit_code` — all three pass on a machine with 3 live managed sessions and a running daemon
- [x] `cargo test -p trusty-mpm` — full non-ignored suite green (0 failures)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p trusty-mpm` — no drift
- [x] `bash scripts/check_line_cap.sh` — 0 violations

## LOC Delta

- Added: 22 lines (`state/core.rs` +13, `session_manager_mvp.rs` +17, `executor/tests.rs` +1 sign change only)
- Net: +17 lines (test file, 1500 SLOC cap; production change is within existing cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)