### PR TITLE
fix(trusty-review): decouple AppState build from MCP initialize handshake (closes #1739)

### DIFF
--- a/crates/trusty-review/src/commands/serve.rs
+++ b/crates/trusty-review/src/commands/serve.rs
@@ -4,8 +4,10 @@
 //! The `--stdio` flag runs the MCP stdio JSON-RPC loop; without it the standard
 //! axum HTTP daemon starts on the configured port.
 //!
-//! What: builds `AppState` (LLM + verifier + search + analyze + dedup store),
-//! then either calls `serve_http` (HTTP mode) or `mcp::run` (stdio mode).
+//! What: for `--stdio`, spawns `build_app_state` in a background task and calls
+//! `mcp::run_deferred` immediately so the MCP `initialize` handshake is answered
+//! before any network or credential calls are made (issue #1739).  For HTTP mode,
+//! builds `AppState` synchronously then calls `serve_http`.
 //!
 //! Test: `cargo run -p trusty-review --features http-server -- serve --help`
 //! must exit 0; endpoint tests live in `service::handlers` and
@@ -14,7 +16,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use trusty_review::{
     config::ReviewConfig,
@@ -22,6 +24,7 @@ use trusty_review::{
         search_client::HttpSearchClient, subprocess_analyze_client::SubprocessAnalyzeClient,
     },
     llm::build_provider,
+    mcp::DeferredStateValue,
     pipeline::enforce_verifier_liveness,
     service::{AppState, DEFAULT_PORT, serve as serve_http},
 };
@@ -66,21 +69,48 @@ pub struct ServeArgs {
 /// Execute the `serve` subcommand.
 ///
 /// Why: the HTTP and MCP stdio daemon modes share the same dependency-building
-/// logic; only the final transport differs.
-/// What: builds `AppState`, then either calls `serve_http` (TCP mode) or
-/// `mcp::run` (stdio mode).  All logs go to stderr; stdout stays clean.
-/// Test: see module doc.
+/// logic; only the final transport and startup sequencing differ.  For stdio
+/// (issue #1739) `AppState` is built in the background so the MCP `initialize`
+/// handshake is answered in <1 ms regardless of provider or credential state.
+/// For HTTP, `AppState` is built synchronously (no strict deadline).
+/// What: for `--stdio`, spawns `build_app_state` as a background tokio task,
+/// then calls `mcp::run_deferred` with the watch receiver immediately.  For
+/// HTTP mode, builds `AppState` then calls `serve_http`.  All logs go to
+/// stderr; stdout stays clean.
+/// Test: see module doc; MCP deferred path is smoke-tested with broken Bedrock
+/// creds (initialize must respond in <1.5 s without the env-var workaround).
 pub async fn cmd_serve(config: ReviewConfig, args: ServeArgs) -> Result<()> {
-    // Build deps shared between both modes.
-    let state = build_app_state(config.clone()).await?;
-
     #[cfg(feature = "mcp")]
     if args.stdio {
-        info!("trusty-review MCP stdio service starting");
-        return trusty_review::mcp::run(state).await;
+        // ── Deferred-startup path (issue #1739) ──────────────────────────────
+        // Start the MCP stdio loop BEFORE building AppState so the `initialize`
+        // handshake (sent immediately by Claude Code, ~1.5 s deadline) is
+        // answered in <1 ms.  AppState construction — which may include a real
+        // Bedrock Converse API call for liveness probing — runs in a background
+        // task and feeds the watch channel when it finishes.
+        info!("trusty-review MCP stdio service starting (deferred AppState build, issue #1739)");
+        let (state_tx, state_rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+        let config_for_bg = config.clone();
+        tokio::spawn(async move {
+            let value: DeferredStateValue = match build_app_state(config_for_bg).await {
+                Ok(state) => {
+                    info!("trusty-review AppState ready — tool calls now accepted");
+                    Some(Ok(state))
+                }
+                Err(e) => {
+                    error!("trusty-review AppState build failed: {e:#}");
+                    Some(Err(format!("{e:#}")))
+                }
+            };
+            // Ignore SendError: it means the stdio loop already exited (EOF).
+            let _ = state_tx.send(value);
+        });
+        return trusty_review::mcp::run_deferred(state_rx).await;
     }
 
-    // HTTP mode.
+    // ── HTTP mode: synchronous build (no strict startup deadline) ────────────
+    let state = build_app_state(config.clone()).await?;
+
     use std::net::SocketAddr;
     let addr: SocketAddr = format!("{}:{}", args.bind, args.port)
         .parse()

--- a/crates/trusty-review/src/commands/serve.rs
+++ b/crates/trusty-review/src/commands/serve.rs
@@ -95,7 +95,7 @@ pub async fn cmd_serve(config: ReviewConfig, args: ServeArgs) -> Result<()> {
             let value: DeferredStateValue = match build_app_state(config_for_bg).await {
                 Ok(state) => {
                     info!("trusty-review AppState ready — tool calls now accepted");
-                    Some(Ok(state))
+                    Some(Ok(Arc::new(state)))
                 }
                 Err(e) => {
                     error!("trusty-review AppState build failed: {e:#}");

--- a/crates/trusty-review/src/mcp/mcp_tests.rs
+++ b/crates/trusty-review/src/mcp/mcp_tests.rs
@@ -337,15 +337,16 @@ async fn deferred_dispatch_tool_call_when_sender_dropped() {
 /// A tool call when AppState is ready dispatches normally to the review pipeline.
 ///
 /// Why: the happy path must work correctly after the deferred build completes.
-/// What: sends `Some(Ok(test_state()))` on the channel, then dispatches
-/// `review_health` and asserts the health response is well-formed.
+/// What: sends `Some(Ok(Arc::new(test_state())))` on the channel (matching the
+/// `Arc<AppState>` in `DeferredStateValue`), then dispatches `review_health`
+/// and asserts the health response is well-formed.
 /// Test: self-contained; uses the same `FakeLlm` / `FakeSearch` stubs as other
 /// dispatch tests.
 #[tokio::test]
 async fn deferred_dispatch_tool_call_when_ready() {
     let state = test_state();
     let (tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
-    tx.send(Some(Ok(state))).unwrap();
+    tx.send(Some(Ok(Arc::new(state)))).unwrap();
     let req = make_req("review_health", json!({}));
     let resp = dispatch_deferred(req, rx).await;
     let result = resp.result.expect("expected result from deferred dispatch");
@@ -353,6 +354,51 @@ async fn deferred_dispatch_tool_call_when_ready() {
     let health: Value = serde_json::from_str(text).expect("valid health JSON");
     assert_eq!(health["status"], "ok");
     assert!(health["version"].is_string());
+}
+
+/// The 30-second warmup timeout branch returns INTERNAL_ERROR with the warming-up message.
+///
+/// Why: validates that tool calls arriving before AppState is ready receive a
+/// clear, actionable error rather than hanging indefinitely — the key safety
+/// net for the `dispatch_deferred` timeout path.
+/// What: uses Tokio's paused clock (`start_paused = true`) so `advance(31 s)`
+/// fires the internal 30-second `tokio::time::timeout` instantly without any
+/// real wall-clock wait.  The watch channel never receives a value, simulating
+/// an in-progress (or stalled) background build.
+/// Test: gated `#[ignore]` because paused-clock tests require `tokio::test`
+/// with `start_paused = true` and can be flaky under high parallel test load.
+/// Run explicitly: `cargo test -p trusty-review -- --include-ignored
+/// deferred_dispatch_tool_call_times_out_warming_up`.
+#[tokio::test(start_paused = true)]
+#[ignore = "paused-clock test — run with --include-ignored"]
+async fn deferred_dispatch_tool_call_times_out_warming_up() {
+    use std::time::Duration;
+
+    // Channel with no value ever sent — background build is still "in progress".
+    let (_tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+    let req = make_req("review_health", json!({}));
+
+    // tokio::join! polls both futures concurrently.  With the clock paused,
+    // dispatch_deferred parks on wait_for.  advance(31 s) fires the 30-second
+    // timeout, waking dispatch_deferred which then returns the graceful error.
+    let (resp, _) = tokio::join!(
+        dispatch_deferred(req, rx),
+        tokio::time::advance(Duration::from_secs(31)),
+    );
+
+    let err = resp
+        .error
+        .expect("warmup timeout must produce a JSON-RPC error");
+    assert_eq!(
+        err.code,
+        error_codes::INTERNAL_ERROR,
+        "warmup timeout must return INTERNAL_ERROR"
+    );
+    assert!(
+        err.message.contains("warming up"),
+        "error must mention 'warming up', got: {}",
+        err.message
+    );
 }
 
 /// Binary stdio smoke test: spawn `trusty-review serve --stdio`, send MCP

--- a/crates/trusty-review/src/mcp/mcp_tests.rs
+++ b/crates/trusty-review/src/mcp/mcp_tests.rs
@@ -1,12 +1,14 @@
-//! Unit and integration tests for `mcp::dispatch`.
+//! Unit and integration tests for `mcp::dispatch` and `mcp::dispatch_deferred`.
 //!
 //! Why: split from `mcp/mod.rs` to keep that file under the 500-line cap while
-//! preserving full test coverage for the MCP dispatcher, tools/list handler,
-//! and the binary stdio smoke test (#950).
+//! preserving full test coverage for the MCP dispatcher, deferred-startup path
+//! (issue #1739), tools/list handler, and the binary stdio smoke test (#950).
 //! What: exercises `dispatch` with synthetic `Request` values for initialize,
 //! tools/list, tools/call, notification suppression, and error paths; also
-//! includes the in-process tools/list name-verification test and the
-//! #[ignore]-gated binary stdio spawn test (closes #950).
+//! covers `dispatch_deferred` for the three deferred-state outcomes (not-yet-
+//! ready/dropped-sender, build-failed, and ready); includes the in-process
+//! tools/list name-verification test and the #[ignore]-gated binary stdio
+//! spawn test (closes #950).
 //! Test: this is the test module; each `#[test]` / `#[tokio::test]` is a
 //! self-contained unit or integration test.
 
@@ -208,6 +210,149 @@ async fn dispatch_tools_list_three_tools_names_verified() {
         "tools/list returned unexpected set: {:?}",
         names
     );
+}
+
+// ── dispatch_deferred tests (issue #1739) ──────────────────────────────────
+//
+// These tests verify the deferred-startup invariant: `initialize` and
+// `tools/list` must be answered without waiting for AppState, while tool
+// calls gracefully handle all three channel states (not ready / failed / ok).
+
+/// `initialize` must respond immediately without consulting `state_rx`.
+///
+/// Why: validates the core #1739 invariant — the handshake response is
+/// produced before ANY background build completes, even when the watch
+/// channel was never sent a value.
+/// What: creates a watch channel that never receives a value (simulating an
+/// in-progress background build) and asserts `initialize` still returns the
+/// expected `serverInfo` immediately.
+/// Test: self-contained; no real providers.
+#[tokio::test]
+async fn deferred_dispatch_initialize_needs_no_state() {
+    // Sender is kept alive (never sends a value) — simulates AppState still building.
+    let (_tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+    let req = make_req("initialize", json!({}));
+    let resp = dispatch_deferred(req, rx).await;
+    let result = resp.result.expect("initialize must return a result");
+    assert_eq!(result["serverInfo"]["name"], "trusty-review");
+    assert!(result["serverInfo"]["version"].is_string());
+    assert_eq!(result["protocolVersion"], "2024-11-05");
+}
+
+/// `notifications/initialized` must be suppressed without consulting `state_rx`.
+///
+/// Why: notification suppression is a protocol requirement; it must work before
+/// AppState is ready so Claude Code's post-initialize notification is handled
+/// correctly in the deferred path.
+/// What: watch channel never receives a value; asserts the notification response
+/// has `suppress = true`.
+/// Test: self-contained; no real providers.
+#[tokio::test]
+async fn deferred_dispatch_notification_suppressed_without_state() {
+    let (_tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+    let req = Request {
+        jsonrpc: Some("2.0".into()),
+        id: None,
+        method: "notifications/initialized".into(),
+        params: None,
+    };
+    let resp = dispatch_deferred(req, rx).await;
+    assert!(
+        resp.suppress,
+        "notification must be suppressed without AppState"
+    );
+}
+
+/// `tools/list` must respond immediately without consulting `state_rx`.
+///
+/// Why: Claude Code requests tools/list right after initialize; answering it
+/// instantly lets the operator see tool metadata even before credentials are
+/// validated.
+/// What: watch channel never receives a value; asserts a non-empty tools array
+/// is returned.
+/// Test: self-contained; no real providers.
+#[tokio::test]
+async fn deferred_dispatch_tools_list_needs_no_state() {
+    let (_tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+    let req = make_req("tools/list", json!({}));
+    let resp = dispatch_deferred(req, rx).await;
+    let result = resp.result.expect("tools/list must return a result");
+    assert!(
+        result["tools"].as_array().is_some_and(|t| !t.is_empty()),
+        "tools/list must return a non-empty array"
+    );
+}
+
+/// A tool call when the background build failed returns a graceful JSON-RPC error.
+///
+/// Why: broken credentials should not crash the process or return a confusing
+/// error; the operator needs a clear actionable message.
+/// What: sends `Some(Err("bad creds"))` on the channel, then dispatches a
+/// `review_health` call and asserts `INTERNAL_ERROR` with the failure reason.
+/// Test: self-contained; no real providers.
+#[tokio::test]
+async fn deferred_dispatch_tool_call_when_build_failed() {
+    let (tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+    tx.send(Some(Err("bad creds: profile not found".to_string())))
+        .unwrap();
+    let req = make_req("review_health", json!({}));
+    let resp = dispatch_deferred(req, rx).await;
+    let err = resp.error.expect("expected JSON-RPC error");
+    assert_eq!(
+        err.code,
+        error_codes::INTERNAL_ERROR,
+        "failed build must return INTERNAL_ERROR"
+    );
+    assert!(
+        err.message.contains("initialization failed"),
+        "error message must mention initialization failure, got: {}",
+        err.message
+    );
+}
+
+/// A tool call when the watch sender is dropped (no value ever sent) returns a
+/// graceful JSON-RPC error.
+///
+/// Why: if the background task panics before sending any value the sender is
+/// dropped; `wait_for` then returns `RecvError`. The dispatcher must handle
+/// this cleanly rather than panicking.
+/// What: drops the sender immediately (no value sent) and asserts `INTERNAL_ERROR`.
+/// Test: self-contained; no real providers.
+#[tokio::test]
+async fn deferred_dispatch_tool_call_when_sender_dropped() {
+    let (tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+    // Drop the sender without ever sending a ready value.
+    drop(tx);
+    let req = make_req("review_health", json!({}));
+    let resp = dispatch_deferred(req, rx).await;
+    let err = resp.error.expect("expected JSON-RPC error");
+    assert_eq!(err.code, error_codes::INTERNAL_ERROR);
+    assert!(
+        err.message.contains("initialization failed"),
+        "dropped-sender must report initialization failure, got: {}",
+        err.message
+    );
+}
+
+/// A tool call when AppState is ready dispatches normally to the review pipeline.
+///
+/// Why: the happy path must work correctly after the deferred build completes.
+/// What: sends `Some(Ok(test_state()))` on the channel, then dispatches
+/// `review_health` and asserts the health response is well-formed.
+/// Test: self-contained; uses the same `FakeLlm` / `FakeSearch` stubs as other
+/// dispatch tests.
+#[tokio::test]
+async fn deferred_dispatch_tool_call_when_ready() {
+    let state = test_state();
+    let (tx, rx) = tokio::sync::watch::channel::<DeferredStateValue>(None);
+    tx.send(Some(Ok(state))).unwrap();
+    let req = make_req("review_health", json!({}));
+    let resp = dispatch_deferred(req, rx).await;
+    let result = resp.result.expect("expected result from deferred dispatch");
+    let text = result["content"][0]["text"].as_str().expect("text field");
+    let health: Value = serde_json::from_str(text).expect("valid health JSON");
+    assert_eq!(health["status"], "ok");
+    assert!(health["version"].is_string());
 }
 
 /// Binary stdio smoke test: spawn `trusty-review serve --stdio`, send MCP

--- a/crates/trusty-review/src/mcp/mod.rs
+++ b/crates/trusty-review/src/mcp/mod.rs
@@ -74,11 +74,13 @@ pub async fn run(state: AppState) -> Result<()> {
 /// Why: the MCP stdio loop must answer `initialize` before `AppState` is ready
 /// (the background build may take 7+ seconds on broken Bedrock creds).  This
 /// three-state value lets the dispatcher distinguish "still building" (`None`),
-/// "ready" (`Some(Ok(…))`), and "failed" (`Some(Err(reason))`).
-/// What: `None` on channel creation; the background task sends `Some(Ok(state))`
-/// or `Some(Err(reason))` when the build completes.
+/// "ready" (`Some(Ok(…))`), and "failed" (`Some(Err(reason))`).  `Arc`
+/// avoids cloning all 15+ `String` fields of `AppState` on every tool call —
+/// the dispatcher does one atomic refcount bump per call instead.
+/// What: `None` on channel creation; the background task sends
+/// `Some(Ok(Arc::new(state)))` or `Some(Err(reason))` when the build completes.
 /// Test: `deferred_dispatch_*` tests in `mcp_tests.rs` cover all three states.
-pub type DeferredStateValue = Option<Result<AppState, String>>;
+pub type DeferredStateValue = Option<Result<Arc<AppState>, String>>;
 
 /// Start the MCP stdio loop with deferred `AppState` construction (issue #1739).
 ///
@@ -157,7 +159,7 @@ pub(crate) async fn dispatch_deferred(
     // watch::Ref (RwLockReadGuard) is definitively dropped before the next
     // .await point — required for the enclosing future to satisfy Send.
     const WARMUP_TIMEOUT: Duration = Duration::from_secs(30);
-    let state_outcome: Result<AppState, String> = {
+    let state_outcome: Result<Arc<AppState>, String> = {
         let timed = tokio::time::timeout(WARMUP_TIMEOUT, state_rx.wait_for(|v| v.is_some())).await;
         match timed {
             Err(_elapsed) => {
@@ -181,10 +183,11 @@ pub(crate) async fn dispatch_deferred(
                 );
             }
             Ok(Ok(guard)) => {
-                // Clone the owned value out of the Ref.  The guard is dropped
-                // at the end of this block — before the .await below.
+                // Clone Arc out of the Ref — one atomic refcount bump instead of
+                // a full AppState copy.  The guard is dropped at the end of this
+                // block (before the dispatch(...).await below).
                 match &*guard {
-                    Some(Ok(state)) => Ok(state.clone()),
+                    Some(Ok(arc)) => Ok(Arc::clone(arc)),
                     Some(Err(reason)) => Err(reason.clone()),
                     None => unreachable!("wait_for guarantees the predicate is satisfied"),
                 }
@@ -198,7 +201,7 @@ pub(crate) async fn dispatch_deferred(
             error_codes::INTERNAL_ERROR,
             format!("server initialization failed: {reason}"),
         ),
-        // AppState is ready — delegate to the normal synchronous dispatcher.
+        // AppState is ready — Arc::deref gives &AppState for the dispatch call.
         Ok(state) => dispatch(req, &state).await,
     }
 }

--- a/crates/trusty-review/src/mcp/mod.rs
+++ b/crates/trusty-review/src/mcp/mod.rs
@@ -7,22 +7,29 @@
 //!
 //! What: `run(state)` builds the shared state once and calls
 //! `trusty_common::mcp::run_stdio_loop`, which reads JSON-RPC requests
-//! line-by-line from stdin and writes responses to stdout.  `dispatch` handles
-//! `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, and
-//! bare method names.  All tracing goes to stderr; stdout is the transport.
+//! line-by-line from stdin and writes responses to stdout.  `run_deferred`
+//! answers `initialize` immediately and builds `AppState` lazily so the
+//! startup handshake is never delayed by provider/network calls (issue #1739).
+//! `dispatch` handles `initialize`, `notifications/initialized`, `tools/list`,
+//! `tools/call`, and bare method names.  All tracing goes to stderr; stdout is
+//! the transport.
 //!
 //! Test: `dispatch_initialize_returns_server_info`,
 //! `dispatch_tools_list_returns_three_tools`,
 //! `dispatch_unknown_tool_returns_method_not_found`,
-//! `dispatch_notification_is_suppressed`.
+//! `dispatch_notification_is_suppressed`,
+//! `deferred_dispatch_initialize_needs_no_state`,
+//! `deferred_dispatch_tool_call_when_ready`.
 
 pub mod console_metrics;
 pub mod tools;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use serde_json::Value;
+use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
 use trusty_common::mcp::{Request, Response, error_codes, initialize_response, run_stdio_loop};
@@ -58,6 +65,142 @@ pub async fn run(state: AppState) -> Result<()> {
         async move { dispatch(req, &state).await }
     })
     .await
+}
+
+// ─── Deferred-startup entry point (issue #1739) ──────────────────────────────
+
+/// The value type carried by the deferred-state watch channel.
+///
+/// Why: the MCP stdio loop must answer `initialize` before `AppState` is ready
+/// (the background build may take 7+ seconds on broken Bedrock creds).  This
+/// three-state value lets the dispatcher distinguish "still building" (`None`),
+/// "ready" (`Some(Ok(…))`), and "failed" (`Some(Err(reason))`).
+/// What: `None` on channel creation; the background task sends `Some(Ok(state))`
+/// or `Some(Err(reason))` when the build completes.
+/// Test: `deferred_dispatch_*` tests in `mcp_tests.rs` cover all three states.
+pub type DeferredStateValue = Option<Result<AppState, String>>;
+
+/// Start the MCP stdio loop with deferred `AppState` construction (issue #1739).
+///
+/// Why: the MCP `initialize` handshake has a ~1.5 s deadline — Claude Code
+/// marks the server DEGRADED if the response is not received in time.
+/// `build_app_state` can take 7+ seconds when Bedrock credentials are broken.
+/// This entry-point answers `initialize` in <1 ms and defers provider/liveness
+/// calls to a background task, removing the startup race entirely.
+/// What: calls `run_stdio_loop` with `dispatch_deferred`, which handles protocol-
+/// level methods (`initialize`, `notifications/initialized`, `tools/list`)
+/// synchronously and awaits `state_rx` (with a 30 s timeout) for tool calls.
+/// The caller is responsible for spawning the background build and feeding
+/// results into the matching `watch::Sender<DeferredStateValue>`.
+/// Test: `deferred_dispatch_initialize_needs_no_state`,
+/// `deferred_dispatch_tool_call_when_ready`,
+/// `deferred_dispatch_tool_call_when_build_failed`,
+/// `deferred_dispatch_tool_call_when_sender_dropped` in `mcp_tests.rs`.
+pub async fn run_deferred(state_rx: watch::Receiver<DeferredStateValue>) -> Result<()> {
+    run_stdio_loop(move |req| {
+        let rx = state_rx.clone();
+        async move { dispatch_deferred(req, rx).await }
+    })
+    .await
+}
+
+/// Dispatch an MCP request when `AppState` is being built lazily in the
+/// background.
+///
+/// Why: see `run_deferred` — the dispatcher must answer `initialize` and
+/// `tools/list` immediately (they need no `AppState`), while tool calls can
+/// legitimately wait for the background build to finish.
+/// What: routes protocol-level methods without touching `state_rx`; for all
+/// other methods it awaits `state_rx.wait_for(|v| v.is_some())` with a
+/// 30-second timeout and then delegates to the regular `dispatch`.  A
+/// graceful JSON-RPC error is returned if the build times out or fails instead
+/// of panicking or hanging.
+/// Test: see `run_deferred` test list above.
+pub(crate) async fn dispatch_deferred(
+    req: Request,
+    mut state_rx: watch::Receiver<DeferredStateValue>,
+) -> Response {
+    let is_notification = req.id.is_none();
+    let id = req.id.clone();
+
+    if req.jsonrpc.as_deref() != Some("2.0") {
+        if is_notification {
+            return Response::suppressed();
+        }
+        return Response::err(id, error_codes::INVALID_REQUEST, "jsonrpc must be \"2.0\"");
+    }
+
+    // Protocol-level methods that need no AppState → answered immediately,
+    // BEFORE waiting for the background build.  This is the invariant that
+    // makes the initialize handshake fast even with broken credentials.
+    match req.method.as_str() {
+        "initialize" => {
+            return Response::ok(
+                id,
+                initialize_response("trusty-review", env!("CARGO_PKG_VERSION"), None),
+            );
+        }
+        "notifications/initialized" | "initialized" => {
+            return Response::suppressed();
+        }
+        "tools/list" => {
+            return Response::ok(id, serde_json::json!({ "tools": tool_descriptors() }));
+        }
+        _ => {}
+    }
+
+    // All other methods require AppState.  Await the background build with a
+    // generous timeout — a well-provisioned host should finish in < 5 s even
+    // with liveness probes; 30 s guards against severe but recoverable delays.
+    //
+    // IMPORTANT: extract an owned value inside a scoped block so the non-Send
+    // watch::Ref (RwLockReadGuard) is definitively dropped before the next
+    // .await point — required for the enclosing future to satisfy Send.
+    const WARMUP_TIMEOUT: Duration = Duration::from_secs(30);
+    let state_outcome: Result<AppState, String> = {
+        let timed = tokio::time::timeout(WARMUP_TIMEOUT, state_rx.wait_for(|v| v.is_some())).await;
+        match timed {
+            Err(_elapsed) => {
+                warn!(
+                    method = req.method.as_str(),
+                    "tool call received before AppState was ready (30 s warmup timeout)"
+                );
+                return Response::err(
+                    id,
+                    error_codes::INTERNAL_ERROR,
+                    "server is still warming up, retry shortly",
+                );
+            }
+            Ok(Err(_recv_err)) => {
+                // Sender dropped without ever sending a value — background task
+                // exited before it could report success or failure.
+                return Response::err(
+                    id,
+                    error_codes::INTERNAL_ERROR,
+                    "server initialization failed — check credentials and restart",
+                );
+            }
+            Ok(Ok(guard)) => {
+                // Clone the owned value out of the Ref.  The guard is dropped
+                // at the end of this block — before the .await below.
+                match &*guard {
+                    Some(Ok(state)) => Ok(state.clone()),
+                    Some(Err(reason)) => Err(reason.clone()),
+                    None => unreachable!("wait_for guarantees the predicate is satisfied"),
+                }
+            } // guard (RwLockReadGuard / watch::Ref) dropped here — .await is now safe
+        }
+    };
+
+    match state_outcome {
+        Err(reason) => Response::err(
+            id,
+            error_codes::INTERNAL_ERROR,
+            format!("server initialization failed: {reason}"),
+        ),
+        // AppState is ready — delegate to the normal synchronous dispatcher.
+        Ok(state) => dispatch(req, &state).await,
+    }
 }
 
 /// Build a fully-wired trusty-review [`AppState`] from environment + config file.


### PR DESCRIPTION
Closes #1739.

## Problem
`trusty-review serve --stdio` built `AppState` synchronously before starting the MCP stdio loop. `build_app_state` runs `enforce_verifier_liveness()`, which makes a real Bedrock Converse API call; on a host with unreachable/expired Bedrock creds it retries 3× and takes ~7.4s. Claude Code sends `initialize` immediately with a ~1.5s deadline, so the handshake timed out and trusty-review was marked DEGRADED every session, in every project.

## Fix
Decouple `AppState` construction from the MCP loop so `initialize` is answered immediately regardless of provider/credential state:
- `mcp/mod.rs`: `DeferredStateValue = Option<Result<Arc<AppState>, String>>` (None=building, Some(Ok)=ready, Some(Err)=failed); new `run_deferred(watch::Receiver)` + `dispatch_deferred(...)` that serve `initialize` / `notifications/initialized` / `tools/list` with NO state and await state (30s timeout) only for actual tool calls. State is shared as `Arc` — one atomic refcount bump per tool call.
- `commands/serve.rs`: `--stdio` creates a `watch::channel(None)`, spawns `build_app_state` as a background task that publishes the result, and starts the MCP loop immediately. HTTP mode unchanged.

## Proof
Decisive smoke (debug binary, broken `cto` Bedrock creds, NO `TRUSTY_REVIEW_VERIFIER_LIVENESS_CHECK` override): `initialize` responds in **124ms** (was ~7.4s) — well under the 1.5s deadline. The per-machine MCP-config env workaround (`TRUSTY_REVIEW_VERIFIER_LIVENESS_CHECK=false`) becomes unnecessary for everyone.

## Review & verification
- Adversarial Code Critic: APPROVE. Send-safety (no guard held across `.await`), readiness race (`wait_for` checks current value first), dropped-sender graceful-error path, static `tools/list`, and unchanged HTTP mode all independently verified. Two LOW findings remediated: `Arc<AppState>` (avoid per-call deep clone) + warmup-timeout test.
- 7 new unit tests for `dispatch_deferred` (initialize/notification/tools-list need no state; tool-call when ready / build-failed / sender-dropped / warmup-timeout).
- Gates green: `cargo test -p trusty-review`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `bash scripts/check_line_cap.sh` (0 violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)