### PR TITLE
chore(trusty-review): bump to v0.6.2 (#1739 Bedrock-handshake fix, published to crates.io)

### DIFF
--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.6.1"
+version     = "0.6.2"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
Records the version bump for trusty-review 0.6.2, published to crates.io (the #1739 fix that decouples AppState build from the MCP initialize handshake). Tag trusty-review-v0.6.2 pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)