### PR TITLE
chore: publish trusty-agents-common 0.1.3 + trusty-mpm 0.11.0 to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
-trusty-agents-common = { path = "crates/trusty-agents-common" }
+trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.1.3" }
 trusty-common = { path = "crates/trusty-common", version = "0.18.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "trusty-agents-common"
 version = "0.1.3"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "trusty-mpm: unified multi-agent orchestration platform (core, daemon, CLI, TUI, Telegram)"
-exclude = [".claude/", ".trusty-mpm/", "CLAUDE.md"]
+exclude = ["/.claude/", "/.trusty-mpm/", "/CLAUDE.md"]
 
 # ── Feature flags ─────────────────────────────────────────────────────────────
 #

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "trusty-mpm: unified multi-agent orchestration platform (core, daemon, CLI, TUI, Telegram)"
+exclude = [".claude/", ".trusty-mpm/", "CLAUDE.md"]
 
 # ── Feature flags ─────────────────────────────────────────────────────────────
 #


### PR DESCRIPTION
Records the manifest changes for publishing the trusty-mpm cascade to crates.io (both now LIVE):
- `trusty-agents-common`: removed `publish = false`; added `version = "0.1.3"` to the workspace dep entry (first-ever publish, 0.1.3).
- `trusty-mpm`: added a package `exclude` list (anchored to package root) for the runtime tool-artifact dirs (`/.claude/`, `/.trusty-mpm/`, `/CLAUDE.md`) so `cargo publish` isn't blocked by a dirty working dir. Published 0.11.0.

Tags pushed: `trusty-agents-common-v0.1.3`, `trusty-mpm-v0.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)